### PR TITLE
fix(notification): stop push payloads leaking amount/PII, add party-scoped read (#1182)

### DIFF
--- a/openbank-notification-service/src/main/kotlin/com/openbank/notification/application/NotificationConsumer.kt
+++ b/openbank-notification-service/src/main/kotlin/com/openbank/notification/application/NotificationConsumer.kt
@@ -43,6 +43,17 @@ import java.util.concurrent.Executor
 @Suppress("TooManyFunctions") // one delivery path per channel + shared helpers; grows with channels
 class NotificationConsumer {
 
+    companion object {
+        /**
+         * Generic, PII-free push body (ADR-0135 §3, issue #1182). Lock-screen-visible push
+         * payloads must never carry the transaction amount, account number, or any PII — the
+         * subject alone (already PII-free, e.g. "Transaction completed") is the title and this
+         * fixed string is the body. Full detail is fetched on tap via the authenticated,
+         * party-scoped GET /api/v1/notifications/{id}/self.
+         */
+        const val GENERIC_PUSH_BODY = "Open the OpenBank app to view details."
+    }
+
     @Inject lateinit var mailer: ReactiveMailer
 
     @Inject lateinit var objectMapper: ObjectMapper
@@ -156,7 +167,7 @@ class NotificationConsumer {
                         log.infof("SMS stub: to=%s template=%s", req.recipient, req.template)
                         Uni.createFrom().voidItem()
                     }
-                    NotificationChannel.PUSH -> maybeSendPush(req, subject, body, entity)
+                    NotificationChannel.PUSH -> maybeSendPush(req, subject, entity)
                     NotificationChannel.IN_APP -> {
                         log.infof("IN_APP stub: to=%s template=%s", req.recipient, req.template)
                         Uni.createFrom().voidItem()
@@ -296,14 +307,9 @@ class NotificationConsumer {
      * account freeze) always send. For a togglable category, a missing preference row means "on";
      * a muted category records the notification as SUPPRESSED and skips egress.
      */
-    private fun maybeSendPush(
-        req: NotificationRequest,
-        subject: String,
-        body: String,
-        entity: NotificationEntity,
-    ): Uni<Void> {
+    private fun maybeSendPush(req: NotificationRequest, subject: String, entity: NotificationEntity): Uni<Void> {
         val category = req.template.category
-        if (category == NotificationCategory.SECURITY) return sendPush(req, subject, body, entity)
+        if (category == NotificationCategory.SECURITY) return sendPush(req, subject, entity)
         return Panache.withTransaction { preferenceRepo.findByParty(req.partyId) }.chain { pref ->
             val enabled = when (category) {
                 NotificationCategory.PAYMENTS -> pref?.paymentsPush ?: true
@@ -312,7 +318,7 @@ class NotificationConsumer {
                 NotificationCategory.SECURITY -> true
             }
             if (enabled) {
-                sendPush(req, subject, body, entity)
+                sendPush(req, subject, entity)
             } else {
                 log.infof("PUSH suppressed by preference: party=%s category=%s", req.partyId, category)
                 markStatus(entity, "SUPPRESSED")
@@ -330,13 +336,15 @@ class NotificationConsumer {
      * Adapters are off by default; a disabled adapter returns a *skipped* (successful) result,
      * so in the sandbox a push is recorded SENT without any egress (mirrors the EMAIL stub).
      */
-    private fun sendPush(
-        req: NotificationRequest,
-        subject: String,
-        body: String,
-        entity: NotificationEntity,
-    ): Uni<Void> {
-        val pushText = htmlToPlain(body)
+    private fun sendPush(req: NotificationRequest, subject: String, entity: NotificationEntity): Uni<Void> {
+        // ADR-0135 §3 + issue #1182: push payloads must carry NO amount / account number / PII.
+        // The rendered body (e.g. "Transaction of 1 234,00 EUR completed") used to be flattened
+        // with htmlToPlain(body) and shipped as the PushMessage body, landing verbatim in the
+        // lock-screen-visible aps.alert.body (ApnsPushSender) / FCM notification — a direct §3
+        // violation. We now send only the already-PII-free subject as the title plus a fixed
+        // generic wake body. The customer's device fetches the full detail on tap via the
+        // authenticated, party-scoped GET /api/v1/notifications/{id}/self.
+        val pushText = GENERIC_PUSH_BODY
         // Capture the Vert.x (duplicated) context now, while we are demonstrably on it — the
         // opening findActiveByParty transaction below only works because we are. The push adapter's
         // send completes on the JDK HttpClient's own thread pool, off the event loop
@@ -396,10 +404,6 @@ class NotificationConsumer {
         notificationRepo.find("notificationId", entity.notificationId).firstResult()
             .map { e -> e?.also { it.status = status } }
     }.replaceWithVoid()
-
-    /** Strip HTML so the rich email body renders as a plain push alert. */
-    private fun htmlToPlain(html: String): String =
-        html.replace(Regex("<[^>]+>"), " ").replace(Regex("\\s+"), " ").trim()
 
     /**
      * Renders [template] into a (subject, body) pair.

--- a/openbank-notification-service/src/main/kotlin/com/openbank/notification/infrastructure/persistence/repository/NotificationRepository.kt
+++ b/openbank-notification-service/src/main/kotlin/com/openbank/notification/infrastructure/persistence/repository/NotificationRepository.kt
@@ -14,6 +14,7 @@ import java.time.Instant
 import java.util.UUID
 
 @ApplicationScoped
+@Suppress("TooManyFunctions") // query methods per read/write path; grows with notification features
 class NotificationRepository : PanacheRepository<NotificationEntity> {
 
     suspend fun listAll(page: Int, size: Int): List<NotificationEntity> =
@@ -40,6 +41,16 @@ class NotificationRepository : PanacheRepository<NotificationEntity> {
 
     suspend fun findById(id: UUID): NotificationEntity? =
         Panache.withSession { find("notificationId", id).firstResult() }.awaitSuspending()
+
+    /**
+     * Party-scoped single read (customer fetch-on-tap, ADR-0135 §3 / issue #1182). The SELECT is
+     * scoped by partyId so a customer can only ever read their OWN notification — the same
+     * IDOR guard [markRead] applies to the UPDATE. Returns null when the id does not exist OR
+     * belongs to a different party (the caller cannot distinguish the two → no existence oracle).
+     */
+    suspend fun findByIdAndParty(id: UUID, partyId: UUID): NotificationEntity? = Panache.withSession {
+        find("notificationId = ?1 and partyId = ?2", id, partyId).firstResult()
+    }.awaitSuspending()
 
     suspend fun deleteByPartyId(partyId: UUID): Long =
         Panache.withTransaction { delete("partyId", partyId) }.awaitSuspending()

--- a/openbank-notification-service/src/main/kotlin/com/openbank/notification/infrastructure/rest/NotificationResource.kt
+++ b/openbank-notification-service/src/main/kotlin/com/openbank/notification/infrastructure/rest/NotificationResource.kt
@@ -9,6 +9,7 @@ import com.openbank.notification.domain.model.NotificationTemplate
 import com.openbank.notification.domain.model.OperatorMessageTemplate
 import com.openbank.notification.domain.model.OperatorMessageTemplateSensitivity
 import com.openbank.notification.domain.model.TemplateSensitivity
+import com.openbank.notification.infrastructure.persistence.entity.NotificationEntity
 import com.openbank.notification.infrastructure.persistence.repository.NotificationRepository
 import jakarta.annotation.security.RolesAllowed
 import jakarta.inject.Inject
@@ -78,22 +79,44 @@ class NotificationResource {
     @Operation(summary = "Get notification by ID")
     suspend fun getNotification(@PathParam("id") id: UUID): Response {
         val n = repo.findById(id) ?: return Response.status(404).build()
-        return Response.ok(
-            mapOf(
-                "id" to n.notificationId,
-                "partyId" to n.partyId,
-                "channel" to n.channel,
-                "template" to n.template,
-                "recipient" to n.recipient,
-                "subject" to n.subject,
-                "body" to bodyForRead(n.template, n.body),
-                "status" to n.status,
-                "sentAt" to n.sentAt,
-                "readAt" to n.readAt,
-                "createdAt" to n.createdAt,
-            ),
-        ).build()
+        return Response.ok(notificationView(n)).build()
     }
+
+    /**
+     * Party-scoped single read for the customer app's fetch-on-tap (ADR-0135 §3, issue #1182).
+     * The push payload now carries no amount/PII (see NotificationConsumer.sendPush); on tap the
+     * app calls this to load the full detail. partyId is the edge-injected authoritative identity
+     * (customer-edge translates the mobile JWT to ROLE_SERVICE and injects it) — the repository
+     * SELECT is scoped by it, so a caller can never read another party's notification (IDOR guard,
+     * same shape as [markRead]). A missing/other-party id is a 404 with no existence oracle.
+     */
+    @GET
+    @Path("/{id}/self")
+    @RolesAllowed("ROLE_OPERATOR", "ROLE_SERVICE", "ROLE_ADMIN")
+    @Authorize(action = "notification.read.self", resource = "#id")
+    @Operation(summary = "Get one of the caller's own notifications (party-scoped)")
+    suspend fun getOwnNotification(@PathParam("id") id: UUID, @QueryParam("partyId") partyId: UUID?): Response {
+        partyId ?: return Response.status(Response.Status.BAD_REQUEST)
+            .entity(mapOf("code" to "BAD_REQUEST", "message" to "partyId query parameter is required")).build()
+        val n = repo.findByIdAndParty(id, partyId)
+            ?: return Response.status(Response.Status.NOT_FOUND)
+                .entity(mapOf("code" to "NOT_FOUND", "message" to "Notification not found")).build()
+        return Response.ok(notificationView(n)).build()
+    }
+
+    private fun notificationView(n: NotificationEntity) = mapOf(
+        "id" to n.notificationId,
+        "partyId" to n.partyId,
+        "channel" to n.channel,
+        "template" to n.template,
+        "recipient" to n.recipient,
+        "subject" to n.subject,
+        "body" to bodyForRead(n.template, n.body),
+        "status" to n.status,
+        "sentAt" to n.sentAt,
+        "readAt" to n.readAt,
+        "createdAt" to n.createdAt,
+    )
 
     /**
      * Mark one notification read (customer notification center). partyId is the edge-injected

--- a/openbank-notification-service/src/main/resources/openapi.yaml
+++ b/openbank-notification-service/src/main/resources/openapi.yaml
@@ -3,7 +3,7 @@
 openapi: 3.1.0
 info:
   title: Notification Service API
-  version: 1.6.0
+  version: 1.7.0
   description: Notification delivery management — query sent/pending notifications, manage push device tokens.
   license:
     name: Apache-2.0
@@ -149,6 +149,41 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/NotificationResponse'
+        '404':
+          $ref: '#/components/responses/NotFound'
+
+  /api/v1/notifications/{id}/self:
+    get:
+      tags: [Notifications]
+      summary: Get one of the caller's own notifications (party-scoped, fetch-on-tap)
+      description: >-
+        Party-scoped single read for the customer app's fetch-on-tap (ADR-0135 §3, issue #1182).
+        Push payloads carry no amount/PII; on tap the app loads the full notification detail here.
+        The SELECT is scoped by the edge-injected partyId, so a caller can only read their own
+        notification (IDOR guard). A missing or other-party id returns 404 with no existence oracle.
+      operationId: getOwnNotification
+      parameters:
+        - name: id
+          in: path
+          required: true
+          schema:
+            type: string
+            format: uuid
+        - name: partyId
+          in: query
+          required: true
+          schema:
+            type: string
+            format: uuid
+      responses:
+        '200':
+          description: Notification detail
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/NotificationResponse'
+        '400':
+          description: Missing partyId
         '404':
           $ref: '#/components/responses/NotFound'
 

--- a/openbank-notification-service/src/test/kotlin/com/openbank/notification/infrastructure/rest/NotificationResourceReadTest.kt
+++ b/openbank-notification-service/src/test/kotlin/com/openbank/notification/infrastructure/rest/NotificationResourceReadTest.kt
@@ -1,0 +1,76 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright (c) OpenBank contributors. Licensed under the Apache License, Version 2.0.
+// See LICENSE in the repository root or https://www.apache.org/licenses/LICENSE-2.0 for details.
+
+package com.openbank.notification.infrastructure.rest
+
+import com.openbank.notification.infrastructure.persistence.entity.NotificationEntity
+import com.openbank.notification.infrastructure.persistence.repository.NotificationRepository
+import io.mockk.coEvery
+import io.mockk.coVerify
+import io.mockk.mockk
+import jakarta.ws.rs.core.Response
+import kotlinx.coroutines.runBlocking
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Test
+import java.time.Instant
+import java.util.UUID
+
+/**
+ * Party-scoped fetch-on-tap read (ADR-0135 §3, issue #1182). Mirrors the IDOR-safe pattern of
+ * [DeviceResourceDeactivateTest]: the repository SELECT is scoped by partyId, so a caller can only
+ * read their OWN notification — an id owned by another party (or absent) is a 404 with no oracle.
+ */
+class NotificationResourceReadTest {
+
+    private val repo = mockk<NotificationRepository>()
+    private val resource = NotificationResource().also { it.repo = repo }
+
+    private fun entity(id: UUID, partyId: UUID) = NotificationEntity().also {
+        it.notificationId = id
+        it.partyId = partyId
+        it.channel = "PUSH"
+        it.template = "TRANSACTION_COMPLETED"
+        it.recipient = "customer@example.com"
+        it.subject = "Transaction completed"
+        it.body = "<p>Transaction of <b>10.00 EUR</b> completed successfully.</p>"
+        it.status = "SENT"
+        it.createdAt = Instant.now()
+    }
+
+    @Test
+    fun `own notification - owner reads their row - returns 200`(): Unit = runBlocking {
+        val id = UUID.randomUUID()
+        val partyId = UUID.randomUUID()
+        coEvery { repo.findByIdAndParty(id, partyId) } returns entity(id, partyId)
+
+        val response = resource.getOwnNotification(id, partyId)
+
+        assertEquals(Response.Status.OK.statusCode, response.status)
+        @Suppress("UNCHECKED_CAST")
+        val body = response.entity as Map<String, Any?>
+        assertEquals(id, body["id"])
+        assertEquals(partyId, body["partyId"])
+        coVerify(exactly = 1) { repo.findByIdAndParty(id, partyId) }
+    }
+
+    @Test
+    fun `own notification - not the caller's party - returns 404 (IDOR guard)`(): Unit = runBlocking {
+        val id = UUID.randomUUID()
+        val otherParty = UUID.randomUUID()
+        // Repo returns null when the row is not owned by this party — the resource must 404.
+        coEvery { repo.findByIdAndParty(id, otherParty) } returns null
+
+        val response = resource.getOwnNotification(id, otherParty)
+
+        assertEquals(Response.Status.NOT_FOUND.statusCode, response.status)
+        coVerify(exactly = 1) { repo.findByIdAndParty(id, otherParty) }
+    }
+
+    @Test
+    fun `own notification - missing partyId - returns 400`(): Unit = runBlocking {
+        val response = resource.getOwnNotification(UUID.randomUUID(), partyId = null)
+
+        assertEquals(Response.Status.BAD_REQUEST.statusCode, response.status)
+    }
+}

--- a/openbank-notification-service/src/test/kotlin/com/openbank/notification/integration/NotificationConsumerIT.kt
+++ b/openbank-notification-service/src/test/kotlin/com/openbank/notification/integration/NotificationConsumerIT.kt
@@ -4,6 +4,7 @@
 package com.openbank.notification.integration
 
 import com.fasterxml.jackson.databind.ObjectMapper
+import com.openbank.notification.application.NotificationConsumer.Companion.GENERIC_PUSH_BODY
 import com.openbank.notification.application.port.out.PushMessage
 import com.openbank.notification.application.port.out.PushSender
 import com.openbank.notification.domain.model.NotificationChannel
@@ -320,6 +321,47 @@ class NotificationConsumerIT {
         assertThat(deviceStatusFor(OffContextPushSender.BAD_TOKEN)).isEqualTo("INVALID")
         assertThat(deviceStatusFor(OffContextPushSender.GOOD_TOKEN)).isEqualTo("ACTIVE")
     }
+
+    /**
+     * ADR-0135 §3 + issue #1182: the push payload that leaves the service must carry NO transaction
+     * amount, account number, or other PII. Pre-fix `sendPush` shipped `htmlToPlain(body)` — the
+     * fully-rendered "Transaction of 12345.67 EUR completed" — as the PushMessage body, landing on
+     * the lock screen. This asserts the delivered payload's title is the PII-free subject and the
+     * body is the fixed generic wake string, with the amount present in NEITHER. Fails against the
+     * old behavior (which put the amount in the body).
+     */
+    @Test
+    fun `PUSH payload carries no amount or PII (ADR-0135 section 3, issue 1182)`() {
+        val partyId = UUID.randomUUID()
+        val amount = "12345.67"
+        val account = "CZ6508000000192000145399"
+        // A token unique to this test — the (platform, token) unique constraint is shared across the
+        // IT DB, so reusing GOOD_TOKEN would collide with the fan-out test's seed. Delivery success
+        // is irrelevant here: send() captures the outbound PushMessage regardless of accept/reject.
+        val piiToken = "apns-pii-payload-token-it"
+        OffContextPushSender.SENT.clear()
+        seedActiveDevice(partyId, piiToken)
+
+        consumeAndAwait(
+            NotificationRequest(
+                partyId = partyId,
+                channel = NotificationChannel.PUSH,
+                template = NotificationTemplate.TRANSACTION_COMPLETED,
+                recipient = "push-tx@example.com",
+                variables = mapOf("amount" to amount, "currency" to "EUR"),
+            ),
+        )
+
+        val delivered = OffContextPushSender.SENT.filter { it.token == piiToken }
+        assertThat(delivered).hasSize(1)
+        val msg = delivered.first()
+        // Title is the already-PII-free subject; body is the fixed generic wake string.
+        assertThat(msg.title).isEqualTo("Transaction completed")
+        assertThat(msg.body).isEqualTo(GENERIC_PUSH_BODY)
+        // The amount and account never appear anywhere in the transported payload.
+        assertThat(msg.title).doesNotContain(amount).doesNotContain(account)
+        assertThat(msg.body).doesNotContain(amount).doesNotContain(account)
+    }
 }
 
 /**
@@ -333,6 +375,9 @@ class NotificationConsumerIT {
 @ApplicationScoped
 class OffContextPushSender : PushSender {
     override fun send(message: PushMessage): Uni<PushResult> {
+        // Record what actually crosses the transport boundary so a test can assert the payload
+        // is PII-free (ADR-0135 §3, issue #1182).
+        SENT.add(message)
         val result = if (message.token == GOOD_TOKEN) {
             PushResult.ok("apns-id-it")
         } else {
@@ -345,5 +390,8 @@ class OffContextPushSender : PushSender {
         const val GOOD_TOKEN = "apns-good-token-it"
         const val BAD_TOKEN = "apns-bad-token-it"
         private val EXECUTOR = Executors.newSingleThreadExecutor()
+
+        /** Messages the adapter was asked to deliver, in order — inspected by the PII assertion. */
+        val SENT: MutableList<PushMessage> = java.util.concurrent.CopyOnWriteArrayList()
     }
 }


### PR DESCRIPTION
## Summary
ADR-0135 §3 mandates **PII-free push payloads**. `NotificationConsumer.sendPush` built the push body from `htmlToPlain(body)` — the fully-rendered template **including the transaction amount** — which `ApnsPushSender`/FCM place in the lock-screen-visible `aps.alert.body`. That is a direct §3 violation (GDPR / PSD2-SCA notification-content exposure). Fixes it in two pieces (one PR).

### Piece A — stop the leak (app-independent, compliance-mandated)
`sendPush` now sends only the already-PII-free **subject** as the push title plus a fixed **generic wake body** (`GENERIC_PUSH_BODY`), never the rendered body. The rendered subjects are already PII-free ("Transaction completed", "Account Frozen", …). Removed the now-unused `htmlToPlain` helper. Comment cites ADR-0135 §3 + #1182.

### Piece B — party-scoped fetch-on-tap read
The KMP app fetches the full detail on tap. Added `GET /api/v1/notifications/{id}/self` (`@Authorize(action = "notification.read.self")`), scoped by the edge-injected `partyId` via a new `NotificationRepository.findByIdAndParty` — the **same IDOR-safe pattern as `markRead`**. Returns 404 (no existence oracle) for a missing or other-party id, 400 without `partyId`. The staff-only `getNotification` is unchanged. `openapi.yaml` `info.version` 1.6.0 → **1.7.0** (additive, ADR-0048).

The rego `edge-service-notification` rule already grants the `notification.*` prefix to the edge M2M identity, so `notification.read.self` needs no policy change.

## UX note
The customer's push now shows a **generic title/body** until the KMP `openbank-app` adopts fetch-on-tap (cross-repo, tracked in #1182). This is **compliance-required** and correct as an interim state — the lock screen no longer reveals the amount.

## Test evidence
Local gate green: `detekt` + `ktlintCheck` + `test` all pass.
- `NotificationConsumerIT` new test asserts the delivered `PushMessage` **title** is the PII-free subject and **body** is `GENERIC_PUSH_BODY`, with the amount/account present in **neither** (fails against the old `htmlToPlain` behavior).
- `NotificationResourceReadTest` covers owner→200, other-party→404 (IDOR guard), missing-partyId→400.

## Notes
- ADR-0135 delivery note already carries the 2026-07-23 payload-minimisation correction — no ADR edit needed.
- notification-service is **not** money-path.

## Linked issues
Closes #1182

🤖 Generated with [Claude Code](https://claude.com/claude-code)