### PR TITLE
chore(gitops): deploy notification-service sandbox-6de0d5e9 (#2 prefs)

### DIFF
--- a/openbank-infra/gitops/components/notifications/notification-service.yaml
+++ b/openbank-infra/gitops/components/notifications/notification-service.yaml
@@ -57,7 +57,7 @@ spec:
           type: RuntimeDefault
       containers:
         - name: notification-service
-          image: 265175468565.dkr.ecr.eu-north-1.amazonaws.com/openbank-notification-service:sandbox-bd2fed23
+          image: 265175468565.dkr.ecr.eu-north-1.amazonaws.com/openbank-notification-service:sandbox-6de0d5e9
           imagePullPolicy: IfNotPresent
           ports:
             - name: http


### PR DESCRIPTION
Auto-deploy for #1990 built+pushed `notification-service:sandbox-6de0d5e9` but only listed customer-edge in DEPLOYABLE_SERVICES, so gitops was never bumped — notification-service still runs the pre-#1990 image (no V11 `notification_preferences` table, the new endpoint 404s). Image is built + cosign-signed. Hand-bumping the tag.

Changed-service detection missing notification-service here is a pipeline bug tracked separately.