### PR TITLE
feat(libs): shared LLM gateway client — the single egress choke point (ADR-0174/0175)

### DIFF
--- a/openbank-libs-domain/src/main/kotlin/com/openbank/libs/llm/LlmGatewayPort.kt
+++ b/openbank-libs-domain/src/main/kotlin/com/openbank/libs/llm/LlmGatewayPort.kt
@@ -1,0 +1,30 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright (c) OpenBank contributors. Licensed under the Apache License, Version 2.0.
+// See LICENSE in the repository root or https://www.apache.org/licenses/LICENSE-2.0 for details.
+package com.openbank.libs.llm
+
+/**
+ * The single seam every agent/copilot uses to reach an LLM (ADR-0174 / ADR-0175).
+ *
+ * Today four services hand-roll their own `java.net.http.HttpClient` against an OpenAI-compatible
+ * `/chat/completions` endpoint (agent-service, copilot-service, devops-agent,
+ * control-liveness-sentinel), each with a slightly different provider URL — and the six stub agents
+ * point at a `litellm.ai-platform:4000` gateway that has never been deployed (ADR-0174 §2). That
+ * makes the US-provider egress un-enforced (ADR-0175 §4): there is no single choke point to route
+ * through an in-cluster gateway or to bound with an egress NetworkPolicy.
+ *
+ * This port is that choke point. A pure-domain interface (no framework imports): the caller builds
+ * its own prompt (including the ADR-0031 untrusted-input fencing) and gets back the completion text,
+ * or `null` when the backend is unreachable / unconfigured — so every caller degrades to a
+ * deterministic path exactly as the hand-rolled adapters do today. The runtime implementation
+ * (`OpenAiCompatibleLlmGatewayClient`) owns the HTTP/JSON and the base-URL config, so repointing the
+ * whole fleet from `api.deepinfra.com` to the in-cluster gateway is one config change, not N.
+ */
+interface LlmGatewayPort {
+    /**
+     * One chat round: a system prompt + a user prompt in, the assistant's text out.
+     * Returns `null` on any failure (unconfigured key, unreachable backend, non-2xx, empty choice) —
+     * the caller must treat `null` as "no model available" and fall back deterministically.
+     */
+    suspend fun chat(systemPrompt: String, userPrompt: String): String?
+}

--- a/openbank-libs-runtime/src/main/kotlin/com/openbank/libs/llm/OpenAiCompatibleLlmGatewayClient.kt
+++ b/openbank-libs-runtime/src/main/kotlin/com/openbank/libs/llm/OpenAiCompatibleLlmGatewayClient.kt
@@ -1,0 +1,120 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright (c) OpenBank contributors. Licensed under the Apache License, Version 2.0.
+// See LICENSE in the repository root or https://www.apache.org/licenses/LICENSE-2.0 for details.
+package com.openbank.libs.llm
+
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties
+import com.fasterxml.jackson.annotation.JsonInclude
+import com.fasterxml.jackson.annotation.JsonProperty
+import com.fasterxml.jackson.databind.ObjectMapper
+import com.fasterxml.jackson.module.kotlin.jacksonObjectMapper
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.withContext
+import org.jboss.logging.Logger
+import java.net.URI
+import java.net.http.HttpClient
+import java.net.http.HttpRequest
+import java.net.http.HttpResponse
+import java.time.Duration
+
+/**
+ * The shared OpenAI-compatible implementation of [LlmGatewayPort] (ADR-0174 / ADR-0175).
+ *
+ * Consolidates the four hand-rolled `/chat/completions` clients (agent-service, copilot-service,
+ * devops-agent, control-liveness-sentinel) into one. It is the single place the fleet's LLM egress
+ * flows through, so:
+ *  - repointing every agent from `api.deepinfra.com` to the in-cluster gateway
+ *    (`http://litellm.ai-platform.svc:4000`) is one [baseUrl] config change (ADR-0174);
+ *  - an egress NetworkPolicy that allows only the gateway to leave the cluster now has a single
+ *    choke point to sit in front of (ADR-0175 §4).
+ *
+ * Safety, matching the existing adapters:
+ *  - an empty [apiKey] degrades the call to `null` (deterministic fallback) rather than throwing —
+ *    the SmallRye SRCFG00040 CrashLoop footgun the adapters avoid with an optional key lookup;
+ *  - the key is never logged;
+ *  - the caller owns prompt construction and the ADR-0031 untrusted-input fencing — this client only
+ *    transports; it adds no instructions of its own.
+ *
+ * Framework-touching (HttpClient, Jackson, coroutine dispatch), so it lives in `openbank-libs-runtime`
+ * per the ADR-0122 domain/runtime split; the port stays pure in `openbank-libs-domain`. Constructor
+ * args are injectable so a unit test can point [baseUrl] at a local stub and swap [http].
+ */
+class OpenAiCompatibleLlmGatewayClient(
+    private val baseUrl: String,
+    private val model: String,
+    private val apiKey: String,
+    // jacksonObjectMapper(): the plain ObjectMapper() cannot instantiate the Kotlin data-class wire
+    // types (no default ctor) and silently fails deserialization to null — the Kotlin module is required.
+    private val mapper: ObjectMapper = jacksonObjectMapper(),
+    http: HttpClient? = null,
+    private val temperature: Double = 0.2,
+    private val maxTokens: Int = 700,
+) : LlmGatewayPort {
+
+    private val log = Logger.getLogger(OpenAiCompatibleLlmGatewayClient::class.java)
+
+    private val http: HttpClient = http ?: HttpClient.newBuilder()
+        .connectTimeout(Duration.ofSeconds(CONNECT_TIMEOUT_S))
+        .build()
+
+    @Suppress("TooGenericExceptionCaught") // IOException + parse errors have no common base worth splitting
+    override suspend fun chat(systemPrompt: String, userPrompt: String): String? {
+        if (apiKey.isBlank()) {
+            log.warn("LLM api-key not seeded — skipping call (degraded to deterministic fallback)")
+            return null
+        }
+        val url = "${baseUrl.trimEnd('/')}/chat/completions"
+        val body = ChatRequest(
+            model = model,
+            messages = listOf(ChatMessage("system", systemPrompt), ChatMessage("user", userPrompt)),
+            temperature = temperature,
+            maxTokens = maxTokens,
+        )
+        return try {
+            val request = HttpRequest.newBuilder(URI.create(url))
+                .timeout(Duration.ofSeconds(REQUEST_TIMEOUT_S))
+                .header("Authorization", "Bearer $apiKey")
+                .header("Content-Type", "application/json")
+                .POST(HttpRequest.BodyPublishers.ofString(mapper.writeValueAsString(body)))
+                .build()
+            // Blocking send off the event loop.
+            val resp = withContext(Dispatchers.IO) {
+                http.send(request, HttpResponse.BodyHandlers.ofString())
+            }
+            if (resp.statusCode() !in OK_RANGE) {
+                log.warnf("LLM backend %s returned HTTP %d", baseUrl, resp.statusCode())
+                return null
+            }
+            mapper.readValue(resp.body(), ChatResponse::class.java)
+                .choices.firstOrNull()?.message?.content?.takeIf { it.isNotBlank() }
+        } catch (ex: Exception) {
+            log.warnf("LLM call failed: %s", ex.message)
+            null
+        }
+    }
+
+    private companion object {
+        const val CONNECT_TIMEOUT_S = 10L
+        const val REQUEST_TIMEOUT_S = 60L
+        val OK_RANGE = 200..299
+    }
+}
+
+// --- OpenAI-compatible wire types (the schema DeepInfra, NVIDIA NIM, Groq, vLLM, LiteLLM speak) ---
+
+@JsonInclude(JsonInclude.Include.NON_NULL)
+internal data class ChatRequest(
+    val model: String,
+    val messages: List<ChatMessage>,
+    val temperature: Double = 0.2,
+    @JsonProperty("max_tokens") val maxTokens: Int = 700,
+    val stream: Boolean = false,
+)
+
+internal data class ChatMessage(val role: String, val content: String)
+
+@JsonIgnoreProperties(ignoreUnknown = true)
+internal data class ChatResponse(val choices: List<ChatChoice> = emptyList())
+
+@JsonIgnoreProperties(ignoreUnknown = true)
+internal data class ChatChoice(val message: ChatMessage = ChatMessage("assistant", ""))

--- a/openbank-libs-runtime/src/test/kotlin/com/openbank/libs/llm/OpenAiCompatibleLlmGatewayClientTest.kt
+++ b/openbank-libs-runtime/src/test/kotlin/com/openbank/libs/llm/OpenAiCompatibleLlmGatewayClientTest.kt
@@ -1,0 +1,91 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright (c) OpenBank contributors. Licensed under the Apache License, Version 2.0.
+// See LICENSE in the repository root or https://www.apache.org/licenses/LICENSE-2.0 for details.
+package com.openbank.libs.llm
+
+import com.sun.net.httpserver.HttpExchange
+import com.sun.net.httpserver.HttpServer
+import kotlinx.coroutines.runBlocking
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.AfterEach
+import org.junit.jupiter.api.Test
+import java.net.InetSocketAddress
+import java.nio.charset.StandardCharsets
+
+/**
+ * Round-trips the shared LLM gateway client against a real in-JVM HTTP stub (com.sun HttpServer),
+ * not a mock — so the actual OpenAI-compatible request/response wire format and the degradation
+ * paths are exercised end to end.
+ */
+class OpenAiCompatibleLlmGatewayClientTest {
+
+    private var server: HttpServer? = null
+    private var lastRequestBody: String? = null
+
+    @AfterEach
+    fun stop() {
+        server?.stop(0)
+    }
+
+    /** Start a stub that replies with [status] and [responseBody], capturing the request body. */
+    private fun startStub(status: Int, responseBody: String): String {
+        val srv = HttpServer.create(InetSocketAddress("127.0.0.1", 0), 0)
+        srv.createContext("/v1/chat/completions") { ex: HttpExchange ->
+            lastRequestBody = ex.requestBody.readBytes().toString(StandardCharsets.UTF_8)
+            val bytes = responseBody.toByteArray(StandardCharsets.UTF_8)
+            ex.sendResponseHeaders(status, bytes.size.toLong())
+            ex.responseBody.use { it.write(bytes) }
+        }
+        srv.start()
+        server = srv
+        return "http://127.0.0.1:${srv.address.port}/v1"
+    }
+
+    private fun client(baseUrl: String, apiKey: String = "test-key") =
+        OpenAiCompatibleLlmGatewayClient(baseUrl = baseUrl, model = "test-model", apiKey = apiKey)
+
+    @Test
+    fun `a successful completion returns the assistant content and sends the OpenAI wire shape`() {
+        val base = startStub(
+            200,
+            """{"choices":[{"message":{"role":"assistant","content":"root cause: chatty S3 sync"}}]}""",
+        )
+
+        val answer = runBlocking { client(base).chat("you are an SRE", "diagnose this") }
+
+        assertThat(answer).isEqualTo("root cause: chatty S3 sync")
+        // The request body must carry the model + both messages in the OpenAI schema.
+        assertThat(lastRequestBody).contains("\"model\":\"test-model\"")
+        assertThat(lastRequestBody).contains("\"role\":\"system\"")
+        assertThat(lastRequestBody).contains("\"role\":\"user\"")
+        assertThat(lastRequestBody).contains("\"max_tokens\"")
+    }
+
+    @Test
+    fun `a blank api key degrades to null without any HTTP call`() {
+        // No stub started — if the client tried to connect it would fail; a blank key must short out.
+        val answer = runBlocking { client("http://127.0.0.1:1/v1", apiKey = "").chat("s", "u") }
+        assertThat(answer).isNull()
+    }
+
+    @Test
+    fun `a non-2xx response degrades to null`() {
+        val base = startStub(500, "upstream boom")
+        val answer = runBlocking { client(base).chat("s", "u") }
+        assertThat(answer).isNull()
+    }
+
+    @Test
+    fun `an empty choices array degrades to null`() {
+        val base = startStub(200, """{"choices":[]}""")
+        val answer = runBlocking { client(base).chat("s", "u") }
+        assertThat(answer).isNull()
+    }
+
+    @Test
+    fun `a blank completion content degrades to null`() {
+        val base = startStub(200, """{"choices":[{"message":{"role":"assistant","content":"   "}}]}""")
+        val answer = runBlocking { client(base).chat("s", "u") }
+        assertThat(answer).isNull()
+    }
+}


### PR DESCRIPTION
## Why

Four services hand-roll their own OpenAI-compatible `/chat/completions` client (agent-service, copilot-service, devops-agent, control-liveness-sentinel), each pointing at `api.deepinfra.com` **directly**, and six stub agents point at a `litellm.ai-platform:4000` gateway that was never deployed. So the US-provider LLM egress has **no single choke point** — the core of ADR-0174 ("gateway not deployed at all") and ADR-0175 (egress un-enforced).

## What

The shared seam both ADRs need:
- **`LlmGatewayPort`** (openbank-libs-domain) — pure interface, `chat(system, user): String?`, `null` on any failure so callers keep their deterministic fallback.
- **`OpenAiCompatibleLlmGatewayClient`** (openbank-libs-runtime, per the ADR-0122 domain/runtime split) — the one HTTP/JSON implementation. Repointing the fleet from `api.deepinfra.com` to the in-cluster gateway becomes one `baseUrl` change, and an egress NetworkPolicy has a single choke point to sit in front of. Preserves the adapters' safety: blank api-key degrades to `null` (no SRCFG00040 CrashLoop), key never logged, caller owns the ADR-0031 prompt fencing.

## Verification

`OpenAiCompatibleLlmGatewayClientTest` — **5 tests green against a real in-JVM HTTP stub** (com.sun HttpServer, not a mock): success returns the assistant content and sends the OpenAI wire shape; blank key / non-2xx / empty choices / blank content all degrade to null. The round-trip test caught a real bug — the default `ObjectMapper` cannot deserialize the Kotlin wire types, `jacksonObjectMapper` is required.

Touches only `openbank-libs-domain`/`-runtime` (no version.txt → no release cut).

## Follow-up (issue #1919)

Repoint the two real adapters + copilot/agent providers onto this client, **deploy the in-cluster LiteLLM gateway**, and add the **egress NetworkPolicy** (ADR-0175 enforcement). Done as a separate PR because it repoints live agents and adds in-cluster infra that needs cluster validation.

## Linked issues

Refs #1919

🤖 Generated with [Claude Code](https://claude.com/claude-code)