### PR TITLE
feat(sca): send a real approval push on challenge initiate

### DIFF
--- a/openbank-notification-service/src/main/kotlin/com/openbank/notification/application/NotificationConsumer.kt
+++ b/openbank-notification-service/src/main/kotlin/com/openbank/notification/application/NotificationConsumer.kt
@@ -415,6 +415,7 @@ class NotificationConsumer {
      * Every `vars[...]` key read here must be declared in that constant's [NotificationTemplate.variables];
      * anything else is rejected upstream and can never arrive.
      */
+    @Suppress("CyclomaticComplexMethod") // one branch per template — grows with the template catalogue
     private fun renderTemplate(template: NotificationTemplate, vars: Map<String, String>): Pair<String, String> =
         when (template) {
             NotificationTemplate.ACCOUNT_OPENED ->
@@ -469,6 +470,9 @@ class NotificationConsumer {
             NotificationTemplate.WELCOME ->
                 "Welcome to OpenBank" to
                     "<h2>Welcome!</h2><p>Thank you for joining OpenBank, ${vars.v("name")}.</p>"
+            NotificationTemplate.SCA_APPROVAL ->
+                "Approve your payment" to
+                    "<p>${vars.v("detail").ifBlank { "You have a payment waiting for your approval." }}</p>"
         }
 }
 

--- a/openbank-notification-service/src/main/kotlin/com/openbank/notification/domain/model/Notification.kt
+++ b/openbank-notification-service/src/main/kotlin/com/openbank/notification/domain/model/Notification.kt
@@ -41,6 +41,9 @@ enum class NotificationTemplate(val variables: Set<String>) {
     OTP_CODE(setOf("code")),
     PASSWORD_RESET(setOf("resetLink")),
     WELCOME(setOf("name")),
+
+    /** Decoupled/push SCA — "you have a payment to approve" (#4). [detail] = the human summary. */
+    SCA_APPROVAL(setOf("detail")),
     ;
 
     /** Keys in [vars] that this template does not accept. Empty = the request is well-formed. */
@@ -53,7 +56,7 @@ enum class NotificationTemplate(val variables: Set<String>) {
      */
     val category: NotificationCategory
         get() = when (this) {
-            OTP_CODE, PASSWORD_RESET, ACCOUNT_FROZEN,
+            OTP_CODE, PASSWORD_RESET, ACCOUNT_FROZEN, SCA_APPROVAL,
             KYC_APPROVED, KYC_REJECTED, KYC_DOCUMENT_REQUIRED,
             CONSENT_GRANTED, CONSENT_REVOKED,
             -> NotificationCategory.SECURITY

--- a/openbank-notification-service/src/test/kotlin/com/openbank/notification/domain/model/NotificationModelTest.kt
+++ b/openbank-notification-service/src/test/kotlin/com/openbank/notification/domain/model/NotificationModelTest.kt
@@ -33,12 +33,15 @@ class NotificationModelTest {
 
     @Test
     fun `NotificationTemplate has all expected templates`() {
-        assertThat(NotificationTemplate.values()).hasSize(13)
+        assertThat(NotificationTemplate.values()).hasSize(14)
         assertThat(NotificationTemplate.values()).contains(
             NotificationTemplate.ACCOUNT_OPENED,
             NotificationTemplate.OTP_CODE,
             NotificationTemplate.WELCOME,
+            NotificationTemplate.SCA_APPROVAL,
         )
+        // SCA_APPROVAL is SECURITY so the #2 push-preference gate never suppresses it.
+        assertThat(NotificationTemplate.SCA_APPROVAL.category).isEqualTo(NotificationCategory.SECURITY)
     }
 
     @Test

--- a/openbank-sca-service/src/main/kotlin/com/openbank/sca/infrastructure/ScaAdapters.kt
+++ b/openbank-sca-service/src/main/kotlin/com/openbank/sca/infrastructure/ScaAdapters.kt
@@ -4,6 +4,7 @@
 
 package com.openbank.sca.infrastructure
 
+import com.fasterxml.jackson.databind.ObjectMapper
 import com.openbank.sca.application.port.out.NotificationSender
 import com.openbank.sca.application.port.out.OtpGenerator
 import com.openbank.sca.application.port.out.OtpStore
@@ -11,7 +12,10 @@ import com.openbank.sca.application.port.out.ScaIdempotencyStore
 import io.quarkus.redis.datasource.ReactiveRedisDataSource
 import io.quarkus.redis.datasource.value.SetArgs
 import io.smallrye.mutiny.coroutines.awaitSuspending
+import io.smallrye.reactive.messaging.kafka.Record
 import jakarta.enterprise.context.ApplicationScoped
+import org.eclipse.microprofile.reactive.messaging.Channel
+import org.eclipse.microprofile.reactive.messaging.Emitter
 import java.security.SecureRandom
 import java.util.UUID
 
@@ -55,15 +59,29 @@ class RedisScaIdempotencyStore(private val redis: ReactiveRedisDataSource) : Sca
 }
 
 @ApplicationScoped
-class LoggingNotificationSender : NotificationSender {
+class LoggingNotificationSender(
+    private val objectMapper: ObjectMapper,
+    @Channel("notification-requests-out") private val notificationEmitter: Emitter<Record<String, String>>,
+) : NotificationSender {
     private val log = org.jboss.logging.Logger.getLogger(LoggingNotificationSender::class.java)
 
     // CodeQL java/log-injection: message is caller-supplied and flows straight into the log
     // line below. Strip CR/LF so an attacker can't forge additional log lines (CWE-117).
     private fun String?.sanitizeForLog(): String = (this ?: "-").replace('\n', '_').replace('\r', '_')
 
+    // Emit a real PUSH notification request (#4) so the party gets a "payment to approve" alert on
+    // their device. SCA_APPROVAL maps to the SECURITY category in notification-service, so it is
+    // always delivered regardless of the customer's push preferences.
     override suspend fun sendPushNotification(partyId: UUID, challengeId: UUID, message: String) {
         log.infof("PUSH → partyId=%s challengeId=%s message=%s", partyId, challengeId, message.sanitizeForLog())
+        val request = mapOf(
+            "partyId" to partyId.toString(),
+            "channel" to "PUSH",
+            "template" to "SCA_APPROVAL",
+            "recipient" to partyId.toString(),
+            "variables" to mapOf("detail" to message),
+        )
+        notificationEmitter.send(Record.of(partyId.toString(), objectMapper.writeValueAsString(request)))
     }
 
     override suspend fun sendSmsOtp(partyId: UUID, otp: String) {

--- a/openbank-sca-service/src/main/resources/application.yaml
+++ b/openbank-sca-service/src/main/resources/application.yaml
@@ -154,6 +154,14 @@ mp:
         topic: openbank.sca.events
         value.serializer: org.apache.kafka.common.serialization.StringSerializer
         key.serializer: org.apache.kafka.common.serialization.StringSerializer
+      # Decoupled/push SCA (#4): a "you have a payment to approve" push request drained by
+      # notification-service off openbank.notification.requests (same envelope as account-service).
+      notification-requests-out:
+        connector: smallrye-kafka
+        client.id: sca-service-notif-${quarkus.uuid}
+        topic: openbank.notification.requests
+        value.serializer: org.apache.kafka.common.serialization.StringSerializer
+        key.serializer: org.apache.kafka.common.serialization.StringSerializer
 
 # OPA sidecar (ADR-0034). Advisory mode by default.
 opa:


### PR DESCRIPTION
TOP-10 #4. sca-service's push sender was a stub — a PUSH_NOTIFICATION SCA challenge never actually alerted the customer. Now it emits a real notification request so the push is delivered, completing the decoupled-approval loop with #8's pending-approvals list.

## Adds
- sca-service: `sendPushNotification` emits to a new `notification-requests-out` Kafka channel (`openbank.notification.requests`, account-service envelope) with template=SCA_APPROVAL
- notification-service: `SCA_APPROVAL` template (**SECURITY** category → never gated by #2 push preferences) + renderTemplate case

## Notes
- The push data already carries the template name, so the app deep-links an SCA_APPROVAL tap to pending approvals (openbank-app PR).
- No new topic (openbank.notification.requests already exists); sca-service already has Kafka egress.

Closes #2025

🤖 Generated with [Claude Code](https://claude.com/claude-code)