### PR TITLE
fix(swift): align the transaction→swift pact to swift's real status vocabulary (#1348)

### DIFF
--- a/openbank-swift-service/src/test/kotlin/com/openbank/swift/contract/SwiftMessagePactProviderVerificationTest.kt
+++ b/openbank-swift-service/src/test/kotlin/com/openbank/swift/contract/SwiftMessagePactProviderVerificationTest.kt
@@ -68,7 +68,7 @@ class SwiftMessagePactProviderVerificationTest {
         // No state setup needed: message producer methods return deterministic payloads.
     }
 
-    @PactVerifyProvider("a swift.message.status-changed event with status SETTLED")
+    @PactVerifyProvider("a swift.message.status-changed event with status COMPLETED")
     fun produceSwiftStatusChanged(): String {
         val message = SwiftMessage(
             id = UUID.fromString("aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa"),

--- a/pacts/openbank-transaction-service-openbank-swift-service.json
+++ b/pacts/openbank-transaction-service-openbank-swift-service.json
@@ -10,10 +10,10 @@
         "messageType": "MT103",
         "occurredAt": "2000-01-31T14:00:00Z",
         "paymentSagaRef": "string",
-        "status": "SETTLED",
+        "status": "COMPLETED",
         "swiftMessageId": "e2490de5-5bd3-43d5-b7c4-526e33f71304"
       },
-      "description": "a swift.message.status-changed event with status SETTLED",
+      "description": "a swift.message.status-changed event with status COMPLETED",
       "generators": {
         "body": {
           "$.occurredAt": {
@@ -79,7 +79,7 @@
             "matchers": [
               {
                 "match": "regex",
-                "regex": "VALIDATED|SENT|SETTLED|REJECTED"
+                "regex": "VALIDATED|SENT|COMPLETED|REJECTED"
               }
             ]
           },


### PR DESCRIPTION
## The real root cause

This is what #1948's ClassGraph-scan fix **uncovered** by letting the verification actually run. The hand-written `pacts/openbank-transaction-service-openbank-swift-service.json` expects `status: SETTLED` (regex `VALIDATED|SENT|SETTLED|REJECTED`) — but swift's `SwiftStatus` enum has **no SETTLED**. Its terminal settled state is `COMPLETED` (`SwiftService.settle` emits `status COMPLETED`), so the provider produces `COMPLETED` and the broker verification fails:

> `Expected 'COMPLETED' to match 'VALIDATED|SENT|SETTLED|REJECTED'` (`$.status`) — swift@a438d8dd, 2026-07-23T23:50

The whole ARC-queue investigation was a red herring: swift **did** rebuild + re-verify (a438d8dd has the ClassGraph fix); the verification simply revealed this genuine contract mismatch underneath.

## Fix

The provider owns its event vocabulary; the consumer pact was wrong. Align the hand-written pact to swift's real value — `status COMPLETED`, regex `VALIDATED|SENT|COMPLETED|REJECTED`, interaction renamed to "…with status COMPLETED", and the swift `@PactVerifyProvider` description to match. swift's producer already emits `COMPLETED`, so **no production behaviour changes**.

## Effect

Unblocks the last real edge in the #1348 drain (balance #1935 / domestic-payment #1936 already fixed). Once transaction republishes the corrected pact and swift re-verifies green on main-push, transaction can deploy and the 12-day-stuck sepa-payment #844 fix follows.

## Verification

`compileTestKotlin` + `ktlintCheck` green; pact JSON valid. The provider verification itself is broker-gated (main-push lane) — the alignment is deterministic: pact now expects COMPLETED, swift emits COMPLETED, provider test named COMPLETED.

## Linked issues

Refs #1348. Follow-up: this pact is hand-written (#1347 class) — a real transaction consumer test would stop the two vocabularies drifting again.

🤖 Generated with [Claude Code](https://claude.com/claude-code)