### PR TITLE
chore(gitops): deploy sca + notification sandbox-f53c5273 (#4)

### DIFF
--- a/openbank-infra/gitops/components/notifications/notification-service.yaml
+++ b/openbank-infra/gitops/components/notifications/notification-service.yaml
@@ -57,7 +57,7 @@ spec:
           type: RuntimeDefault
       containers:
         - name: notification-service
-          image: 265175468565.dkr.ecr.eu-north-1.amazonaws.com/openbank-notification-service:sandbox-6de0d5e9
+          image: 265175468565.dkr.ecr.eu-north-1.amazonaws.com/openbank-notification-service:sandbox-f53c5273
           imagePullPolicy: IfNotPresent
           ports:
             - name: http

--- a/openbank-infra/gitops/components/sca/sca-service.yaml
+++ b/openbank-infra/gitops/components/sca/sca-service.yaml
@@ -39,7 +39,7 @@ spec:
           type: RuntimeDefault
       containers:
         - name: sca-service
-          image: 265175468565.dkr.ecr.eu-north-1.amazonaws.com/openbank-sca-service:sandbox-5684d761
+          image: 265175468565.dkr.ecr.eu-north-1.amazonaws.com/openbank-sca-service:sandbox-f53c5273
           imagePullPolicy: IfNotPresent
           ports:
             - name: http


### PR DESCRIPTION
Auto-deploy for #2026 built+pushed both images but DEPLOYABLE_SERVICES omitted notification-service and the run failed at can-i-deploy before bumping gitops. Both images are built + cosign-signed. Hand-bumping so ArgoCD rolls the real SCA push (#4).