### PR TITLE
fix(sca): Kafka Write ACL on openbank.notification.requests (#4)

### DIFF
--- a/openbank-infra/gitops/components/sca/kafka-sca-mtls.yaml
+++ b/openbank-infra/gitops/components/sca/kafka-sca-mtls.yaml
@@ -37,6 +37,17 @@ spec:
           patternType: literal
         operations: [Write, Describe]
         host: "*"
+      # Decoupled/push SCA (#4): sca-service emits a "payment to approve" push request onto
+      # openbank.notification.requests (notification-requests-out channel). That topic IS
+      # ACL-locked (account-service writes it, notification-service reads it), so the
+      # allow.everyone.if.no.acl.found fallback does NOT apply here — an explicit Write grant is
+      # required or every emit fails with TOPIC_AUTHORIZATION_FAILED.
+      - resource:
+          type: topic
+          name: openbank.notification.requests
+          patternType: literal
+        operations: [Write, Describe]
+        host: "*"
 ---
 # Keystore projection: Strimzi User Operator writes the per-user keystore Secret
 # in `messaging`; ESO projects it into `sca` for pod volume mount.


### PR DESCRIPTION
The real SCA approval push (#2026) emits onto openbank.notification.requests, but sca-service's KafkaUser only had Write on openbank.sca.events → every emit failed with TOPIC_AUTHORIZATION_FAILED (that topic is ACL-locked, so the allow-everyone fallback doesn't apply). Add the explicit Write+Describe ACL. Strimzi reconciles without a restart. Caught by an E2E test (challenge created but no SCA_APPROVAL notification landed).