### PR TITLE
fix(admin-ui): resync package-lock with react-is@17.0.2

### DIFF
--- a/openbank-admin-ui/package-lock.json
+++ b/openbank-admin-ui/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "openbank-admin-ui",
-  "version": "0.54.4",
+  "version": "0.55.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "openbank-admin-ui",
-      "version": "0.54.4",
+      "version": "0.55.1",
       "dependencies": {
         "@hookform/resolvers": "5.4.0",
         "@radix-ui/react-dialog": "1.1.20",
@@ -12257,6 +12257,14 @@
       "funding": {
         "url": "https://github.com/chalk/ansi-styles?sponsor=1"
       }
+    },
+    "node_modules/pretty-format/node_modules/react-is": {
+      "version": "17.0.2",
+      "resolved": "https://registry.npmjs.org/react-is/-/react-is-17.0.2.tgz",
+      "integrity": "sha512-w2GsyukL62IJnlaff/nRegPQR94C/XXamvMWmSHRJ4y7Ts/4ocGRmTHvOs8PSE6pB3dWOrD/nueuU5sduBsQ4w==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/prismjs": {
       "version": "1.30.0",


### PR DESCRIPTION
## Problem
The **Customer-app dossier** CI job fails on every PR (seen on #2037, #2028, #2023) with:

```
npm error `npm ci` can only install packages when your package.json and package-lock.json ... are in sync.
npm error Missing: react-is@17.0.2 from lock file
```

The lockfile drifted out of sync with `package.json` — missing `react-is@17.0.2` (transitive peer dep of `pretty-format`), and a stale top-level `version` field.

## Fix
Ran `npm install` in `openbank-admin-ui` to resync **only** `package-lock.json`:
- adds the missing `react-is@17.0.2` entry
- syncs the lockfile `version` (0.54.4 → 0.55.1) to match `package.json`

No source changes; lockfile only. This is an advisory (non-required) check, so it doesn't block merges — but it was red on every PR and masks real dossier failures.

Refs #2037