### PR TITLE
ci: verify-provider dispatch — re-verify one provider without a full-fleet run (#2039)

### DIFF
--- a/.github/workflows/_service-ci.yml
+++ b/.github/workflows/_service-ci.yml
@@ -52,7 +52,9 @@ jobs:
     # KEEP THIS EXPRESSION IN LOCKSTEP with the PACT_BROKER_URL env below — a hosted
     # runner with a set (unreachable) broker URL fails the provider tests instead
     # of skipping them.
-    runs-on: ${{ github.event_name == 'push' && github.ref == 'refs/heads/main' && 'openbank-build' || 'ubuntu-latest' }}
+    # workflow_dispatch (verify-provider.yml, #2039) also runs on the ARC pool so a single
+    # provider can re-verify + re-publish without a full-fleet run. KEEP IN LOCKSTEP with PACT_BROKER_URL.
+    runs-on: ${{ (github.event_name == 'push' || github.event_name == 'workflow_dispatch') && github.ref == 'refs/heads/main' && 'openbank-build' || 'ubuntu-latest' }}
     timeout-minutes: 45
     env:
       # Pact Broker (ADR-0092). The broker has no public ingress (ADR-0056); the
@@ -67,7 +69,7 @@ jobs:
       # cluster-DNS broker; a set-but-unreachable URL would fail the provider tests
       # instead of skipping them). Main-push behaviour is unchanged: verify + publish.
       # KEEP IN LOCKSTEP with the runs-on expression above.
-      PACT_BROKER_URL: ${{ github.event_name == 'push' && github.ref == 'refs/heads/main' && vars.PACT_BROKER_URL || '' }}
+      PACT_BROKER_URL: ${{ (github.event_name == 'push' || github.event_name == 'workflow_dispatch') && github.ref == 'refs/heads/main' && vars.PACT_BROKER_URL || '' }}
       PACT_BROKER_USERNAME: ${{ vars.PACT_BROKER_USERNAME }}
       PACT_BROKER_PASSWORD: ${{ secrets.PACT_BROKER_PASSWORD }}
       # Testcontainers pulls postgres:16.3-alpine and redpandadata/redpanda through

--- a/.github/workflows/verify-provider.yml
+++ b/.github/workflows/verify-provider.yml
@@ -1,0 +1,30 @@
+# Re-verify + re-publish ONE provider's pact verification on demand (ADR-0092, #2039).
+#
+# WHY: a main-push provider verification only republishes as part of the full-fleet run, which
+# saturates the 6-runner ARC pool and can wedge for hours (#1208/#2039) — so a merged pact/contract
+# fix (e.g. #2030's swift status vocab) may sit unverified behind the queue. This dispatches a SINGLE
+# provider's build+verify on the ARC pool (broker access), turning a ~30-job wedge into one ~5-min
+# job. Same reusable workflow, same publish path (github.ref==main ⇒ PUBLISH_RESULTS=true).
+#
+# Maintainer-triggered only (workflow_dispatch). Runs on main. No new runners, no full-fleet.
+name: Verify one provider
+
+on:
+  workflow_dispatch:
+    inputs:
+      service:
+        description: "Provider service dir, e.g. openbank-swift-service"
+        required: true
+        type: string
+
+permissions:
+  contents: read
+  id-token: write
+
+jobs:
+  verify:
+    uses: ./.github/workflows/_service-ci.yml
+    with:
+      service: ${{ inputs.service }}
+    secrets:
+      PACT_BROKER_PASSWORD: ${{ secrets.PACT_BROKER_PASSWORD }}


### PR DESCRIPTION
## Why

A main-push provider verification only republishes **inside the full-fleet run**, which saturates the 6-runner ARC pool and can wedge for hours (#1208/#2039). A merged contract fix (e.g. #2030's swift status-vocab fix) then sits unverified behind the queue with **no way to nudge just the one provider** — the exact wall the #1348 drain hit tonight.

## What

`verify-provider.yml`: a maintainer-triggered `workflow_dispatch(service)` that calls the existing `_service-ci` reusable workflow for a **single** service. Two **additive** expression edits in `_service-ci` let a `workflow_dispatch`-on-main run land on the ARC pool (broker access) exactly like a main push; the publish path is already ref-only (`PUBLISH_RESULTS = github.ref==main`), so it republishes the verification.

**Push/PR behaviour is unchanged** — the guards only *add* the `workflow_dispatch` event. Turns a ~30-job wedge into one ~5-min job. No new runners, no full-fleet (the FinOps-friendly lever).

## Verification

Both workflow files parse; `actionlint` clean. First real use: dispatch it for `openbank-swift-service` to republish the #2030-corrected verification and unblock the drain.

## Linked issues

Refs #2039, Refs #1208, Refs #1348

🤖 Generated with [Claude Code](https://claude.com/claude-code)