### PR TITLE
perf(ci): scope main-push builds to changed services + pact neighbors, not full-fleet (#1208)

### DIFF
--- a/.github/workflows/services-ci.yml
+++ b/.github/workflows/services-ci.yml
@@ -106,8 +106,67 @@ jobs:
               echo "Decision: push changed only inert paths (release/docs/admin-ui/infra) -> build nothing."
               CHANGED=""
             else
-              echo "Decision: push changed $RELEVANT_COUNT build-relevant path(s) -> full-fleet (Pact completeness)."
-              CHANGED="$ALL"
+              # Scope the main-push build instead of always full-fleeting (#1208/#2039). Full-fleet
+              # on ANY build-relevant change is ~30 jobs and, on the 6-runner pool, wedges the queue
+              # for hours (a merged contract fix sits unverified behind it — the #1348 drain, #945).
+              # The safe direction is still over-build: the moment a changed path is NOT cleanly
+              # attributable to a module or a pact pair, fall back to full-fleet. Never under-build
+              # the Pact graph.
+              #   - code-global input (openbank-libs*, gradle, build-logic) -> full-fleet (any
+              #     service's compile/test inputs may change).
+              #   - pacts/<consumer>-<provider>.json changed -> build BOTH: the consumer republishes
+              #     the pact, the provider re-verifies against it (the exact completeness reason
+              #     main-push used to full-fleet for). Delimiter is the single '-openbank-'.
+              #   - <module>/... changed -> that module.
+              #   - openbank-libs/governance/ -> data for CI checks/admin-ui, not a compile input.
+              #   - the CI recipe itself -> canary below.
+              #   - anything else -> unattributable -> full-fleet (safety).
+              FILES_CODE=$(grep -vE '^openbank-libs/governance/' <<< "$RELEVANT" || true)
+              if grep -qE '^(openbank-libs/|openbank-libs-domain/|openbank-libs-runtime/|openbank-libs-testing/|gradle/|settings\.gradle\.kts|build\.gradle\.kts|gradle\.properties|build-logic/)' <<< "$FILES_CODE"; then
+                echo "Decision: code-global change -> full-fleet."
+                CHANGED="$ALL"
+              else
+                CHANGED=""
+                SCOPE_OK=1
+                while IFS= read -r f; do
+                  [ -z "$f" ] && continue
+                  case "$f" in
+                    pacts/*.json)
+                      base=$(basename "$f" .json)
+                      prov="openbank-${base##*-openbank-}"
+                      cons="${base%-openbank-*}"
+                      for p in "$cons" "$prov"; do
+                        if grep -qE "(^| )${p}( |$)" <<< " $ALL "; then CHANGED="$CHANGED $p"; else SCOPE_OK=0; fi
+                      done ;;
+                    openbank-libs/governance/*) : ;;
+                    .github/workflows/services-ci.yml|.github/workflows/_service-ci.yml) : ;;
+                    openbank-*/*)
+                      m="${f%%/*}"
+                      if grep -qE "(^| )${m}( |$)" <<< " $ALL "; then CHANGED="$CHANGED $m"; else SCOPE_OK=0; fi ;;
+                    *) SCOPE_OK=0 ;;
+                  esac
+                done <<< "$RELEVANT"
+                if [ "$SCOPE_OK" -eq 0 ]; then
+                  echo "Decision: a changed path is not cleanly attributable -> full-fleet (safety)."
+                  CHANGED="$ALL"
+                else
+                  # (No dedup here: the matrix JSON below is built with `sort -u`, so a service
+                  # named by both its src and a pact edge collapses to one job downstream.)
+                  # DST-harness edge (ADR-0115/#267) — same as the PR path.
+                  if { grep -qE '(^| )openbank-(ledger|balance|transaction)-service( |$)' <<< " $CHANGED " \
+                       || grep -qE '(^| )openbank-sepa-payment( |$)' <<< " $CHANGED " \
+                       || grep -qE '(^| )openbank-settlement-service( |$)' <<< " $CHANGED "; } \
+                     && ! grep -qE '(^| )openbank-simulation( |$)' <<< " $CHANGED "; then
+                    CHANGED="$CHANGED openbank-simulation"
+                  fi
+                  # Recipe-only change -> one canary (same as the PR path).
+                  if [ -z "${CHANGED// /}" ] \
+                     && grep -qE '^\.github/workflows/(services-ci|_service-ci)\.yml' <<< "$FILES"; then
+                    CHANGED="openbank-libs"
+                  fi
+                  echo "Decision: scoped main-push build -> ${CHANGED:-<none>}"
+                fi
+              fi
             fi
           else
             BASE="origin/${{ github.base_ref }}"


### PR DESCRIPTION
## Why (the conceptual + $0 fix — no more runners)

Main-push builds the **full fleet (~30 jobs) on ANY build-relevant change** for Pact completeness. On the 6-runner ARC pool that saturates the queue and wedges it for hours — a merged contract fix then sits unverified behind the backlog (tonight's #1348 drain; #945 before it). **Adding runners is the wrong lever (FinOps).** The waste and the wedge share one root: too many jobs per run.

## What

Scope the main-push build the same way the **PR path already does** (per-module fan-out + DST-harness edge + recipe canary), **plus** the piece that was the whole reason main-push full-fleeted:

- a changed **`pacts/<consumer>-<provider>.json`** now builds **both** — the consumer republishes the pact, the provider re-verifies against it.

**Safety invariant unchanged — never under-build the Pact graph:** the moment a changed path is not cleanly attributable to a module or a pact pair (or it touches `openbank-libs*`/`gradle`/`build-logic`), it falls back to **full-fleet**.

## Cost is NEGATIVE

Most commits touch 1-2 services → a run drops from ~30 jobs to a handful. The queue stops saturating and CI compute falls. Example — **#2030** (`pacts/transaction-swift.json` + swift test) scopes to **{swift, transaction, simulation} = 3 jobs instead of 56.**

## Testing

The detect logic was extracted and run in **bash (CI's shell, not the local zsh — the word-splitting differs)** against 7 scenarios:

| change | result |
|---|---|
| pact + provider test (#2030) | swift + transaction + simulation (3) |
| `openbank-libs-runtime/` | full-fleet (56) |
| `openbank-libs/governance/` | nothing |
| single service src | that service + simulation edge |
| unrecognized root path | full-fleet (safety) |
| inert (docs/infra) | nothing |
| recipe (services-ci.yml) | canary openbank-libs |

`actionlint`: no new findings vs `origin/main`.

## Note

This is the **money-path build-selection gate** — worth a careful read on the pact-neighbor derivation and the full-fleet fallbacks, even though it's thoroughly tested. It is the durable fix for the class #2039/#2045 only work around.

## Linked issues

Refs #1208, Refs #2039, Refs #1348

🤖 Generated with [Claude Code](https://claude.com/claude-code)