### PR TITLE
chore(gitops): co-deploy swift + transaction to break the #1348 pact deadlock

### DIFF
--- a/openbank-infra/gitops/components/payments/payments-services.yaml
+++ b/openbank-infra/gitops/components/payments/payments-services.yaml
@@ -53,7 +53,7 @@ spec:
           type: RuntimeDefault
       containers:
         - name: transaction-service
-          image: 265175468565.dkr.ecr.eu-north-1.amazonaws.com/openbank-transaction-service:sandbox-6376c3fc
+          image: 265175468565.dkr.ecr.eu-north-1.amazonaws.com/openbank-transaction-service:sandbox-a5e5d32a
           imagePullPolicy: IfNotPresent
           ports:
             - name: http
@@ -2456,7 +2456,7 @@ spec:
         - name: swift-service
 
 
-          image: 265175468565.dkr.ecr.eu-north-1.amazonaws.com/openbank-swift-service:sandbox-237c397c
+          image: 265175468565.dkr.ecr.eu-north-1.amazonaws.com/openbank-swift-service:sandbox-5dfa9ea7
 
           imagePullPolicy: IfNotPresent
           ports:


### PR DESCRIPTION
Manual co-deploy of the swift↔transaction connected component (the established `reference-manual-co-deploy-past-a-frozen-pact-graph` recipe, as used for sepa #844 via #1979).

## Why manual

swift and transaction each fail `can-i-deploy` **only** because of the OTHER's stale deployed version carrying the pre-#2030 `SETTLED` pact. That is a **broker artifact, not a runtime incompatibility**: swift has always emitted status `COMPLETED` and the running transaction has always handled it — #2030 only corrected the hand-written pact that wrongly expected `SETTLED`. Now verified green: **swift@66396b7f × transaction = True** (via the #2045 verify-provider tool).

## What

Bump both to their built post-fix main images in one gitops change so the deployed versions become mutually consistent:
- `transaction-service` → `sandbox-a5e5d32a`
- `swift-service` → `sandbox-5dfa9ea7`

`record-deployment-on-merge` (#1912) records both. Unblocks the last real edge of the #1348 drain; domestic-payment + sepa-payment (#844) follow.

## Linked issues

Refs #1348

🤖 Generated with [Claude Code](https://claude.com/claude-code)