### PR TITLE
fix(sdd): pin sdd-service min:1 (edge direct caller, #6 write path 502)

### DIFF
--- a/openbank-infra/gitops/components/sdd/sdd-service-http-scaledobject.yaml
+++ b/openbank-infra/gitops/components/sdd/sdd-service-http-scaledobject.yaml
@@ -60,7 +60,16 @@ spec:
     apiVersion: apps/v1
     port: 8129
   replicas:
-    min: 0
+    # min:1, NOT 0. The customer-edge calls sdd-service.sdd.svc:8129 DIRECTLY (see
+    # CustomerEdgeResource sddServiceUrl + this ns netpol), NOT through the KEDA HTTP
+    # interceptor — so at min:0 the interceptor never parks the request: the direct
+    # service simply has no endpoints and edge gets a ConnectException. The read path
+    # (GET /sdd/mandates) masked this with an empty-list fallback, but the new write
+    # path (POST /sdd/mandates, #6 mandate create) surfaced it as a 502 "upstream
+    # unavailable". Same class as card-issuance / interest-service; pin min:1 to keep a
+    # warm pod for the edge-facing SDD screen. The line-34 "interceptor parks the first
+    # request" premise is wrong for a direct (non-interceptor) caller.
+    min: 1
     max: 2
   scaledownPeriod: 300
   targetPendingRequests: 50


### PR DESCRIPTION
## Problem
`POST /customer/v1/sdd/mandates` (#6 SDD mandate create) returned **502 "upstream unavailable"**. Edge log: `java.net.ConnectException` on `createSddMandate`.

## Root cause
sdd-service is KEDA scale-to-zero (`HTTPScaledObject` min:0). But **customer-edge calls `sdd-service.sdd.svc:8129` DIRECTLY**, not through the KEDA HTTP interceptor — so at min:0 the interceptor never parks the request; the direct Service simply has no endpoints and edge gets a ConnectException. The read path (GET) masked it with an empty-list fallback; the new write path surfaced it as a 502. Same class as card-issuance / interest-service #1767.

## Fix
Pin `replicas.min: 1`. Keeps T1 label; warm pod for the edge-facing SDD screen.

🤖 Generated with [Claude Code](https://claude.com/claude-code)