### PR TITLE
feat(gitops): route copilot-service LLM egress through the LiteLLM gateway (#1919)

### DIFF
--- a/openbank-infra/gitops/components/ai-platform/network-policies.yaml
+++ b/openbank-infra/gitops/components/ai-platform/network-policies.yaml
@@ -59,6 +59,9 @@ spec:
               kubernetes.io/metadata.name: governance-auditor
         - namespaceSelector:
             matchLabels:
+              kubernetes.io/metadata.name: platform
+        - namespaceSelector:
+            matchLabels:
               kubernetes.io/metadata.name: release-steward
         - namespaceSelector:
             matchLabels:

--- a/openbank-infra/gitops/components/copilot/copilot-service.yaml
+++ b/openbank-infra/gitops/components/copilot/copilot-service.yaml
@@ -64,16 +64,20 @@ spec:
             # Sandbox model: DeepInfra (OpenAI-compatible API), DeepSeek-V3.2 — fast, cheap (~$0.27/M),
             # no rate-limit issues on paid tier. Switch backends by updating COPILOT_MODEL_ENDPOINT +
             # model IDs only; no image rebuild.
-            # HOSTED (off-cluster) — sandbox/synthetic data only; production must pin to in-cluster/EU (D6).
+            # Routed through the in-cluster LiteLLM gateway (ADR-0174/0175), which now IS deployed
+            # (openbank-infra/gitops/components/ai-platform) and is the ONLY pod allowed to egress to
+            # the US provider (networkpolicy-litellm-egress.yaml). copilot presents the LiteLLM virtual
+            # key, not the DeepInfra key. Model id unchanged — litellm-config maps it to
+            # deepinfra/deepseek-ai/DeepSeek-V3.2, so this is an endpoint + key change only (#1919).
             - name: COPILOT_MODEL_ENDPOINT
-              value: https://api.deepinfra.com/v1/openai
+              value: http://litellm.ai-platform.svc:4000/v1
             - name: COPILOT_DEFAULT_MODEL
               value: deepseek-ai/DeepSeek-V3.2
             - name: COPILOT_MODEL_ID
               value: deepseek-ai/DeepSeek-V3.2
-            # DeepInfra API key, projected from OpenBao by ESO (copilot-service-secrets).
-            # Seed: bao kv patch openbank/copilot-service MODEL_API_KEY=<deepinfra-key>
-            # Optional so an un-seeded key doesn't CrashLoop the pod — until it's set model call degrades.
+            # LiteLLM virtual key, projected from OpenBao (litellm/LITELLM_MASTER_KEY) by ESO — the
+            # provider key now lives only in ai-platform (ADR-0175). Optional so an un-seeded key does
+            # not CrashLoop the pod — until it is set the model call degrades.
             - name: COPILOT_MODEL_API_KEY
               valueFrom:
                 secretKeyRef:

--- a/openbank-infra/gitops/components/external-secrets/es-copilot-service.yaml
+++ b/openbank-infra/gitops/components/external-secrets/es-copilot-service.yaml
@@ -1,6 +1,8 @@
 # copilot-service secret from OpenBao → copilot-service-secrets Secret.
-# COPILOT_MODEL_API_KEY = the NVIDIA NIM API key for the openai-compat model provider (ADR-0089).
-# Seed it once in OpenBao at KV path `openbank/copilot-service`, property `MODEL_API_KEY`.
+# COPILOT_MODEL_API_KEY = the LiteLLM virtual key (ADR-0174/0175): copilot authenticates to the
+# in-cluster gateway, NOT to the provider — the DeepInfra key now lives only in ai-platform (#1919).
+# Sourced from OpenBao KV path `openbank/litellm`, property `LITELLM_MASTER_KEY` (the same key the
+# gateway checks and the ops agents already present).
 # (No OIDC secret: copilot validates the customer JWT bearer-only via JWKS — no client secret.)
 apiVersion: external-secrets.io/v1beta1
 kind: ExternalSecret
@@ -23,5 +25,5 @@ spec:
   data:
     - secretKey: COPILOT_MODEL_API_KEY
       remoteRef:
-        key: copilot-service
-        property: MODEL_API_KEY
+        key: litellm
+        property: LITELLM_MASTER_KEY


### PR DESCRIPTION
## What
Repoints **copilot-service** (customer-facing assistant) LLM egress from `api.deepinfra.com` directly → the in-cluster **LiteLLM gateway** (`litellm.ai-platform.svc:4000`), the single egress choke point deployed by #2019.

## Why
#2019 deployed the gateway + repointed the 2 stub ops agents, but copilot still called DeepInfra directly — its prompt content bypassed the choke point (the open item in #1919 / ADR-0175 egress exposure).

## Changes (3 files, gitops only — no `agents.yaml`, no OPA-bundle restamp)
- `copilot-service.yaml`: `COPILOT_MODEL_ENDPOINT` → `http://litellm.ai-platform.svc:4000/v1`. Model id unchanged — litellm-config already fronts `deepseek-ai/DeepSeek-V3.2`, so **endpoint + key change only**.
- `es-copilot-service.yaml`: `COPILOT_MODEL_API_KEY` now sources the LiteLLM virtual key (`openbank/litellm:LITELLM_MASTER_KEY`), not the DeepInfra key. Still `optional` → **graceful degrade, no CrashLoop** if unseeded.
- `ai-platform/network-policies.yaml`: **regenerated** by `gen-network-policies.py` (ADR-0081) — the litellm ingress allow-list now admits the `platform` namespace (copilot runs there), so `copilot → litellm:4000` is not dropped. Derived from the new edge, not hand-edited.

## Verified (code-level)
- litellm-config fronts `deepseek-ai/DeepSeek-V3.2` (copilot's exact model id) ✓
- litellm ingress now admits `platform` ns ✓ (regenerated; drift gate clean)
- key degrades gracefully if the virtual key is unseeded ✓

## ⚠ Recommend a live-sandbox check before merge (customer-facing + network-path)
Can't be verified from code ([[validate-network-fix-from-real-source]]): confirm in sandbox that (a) `LITELLM_MASTER_KEY` is seeded at OpenBao `litellm`, (b) the litellm pod is reachable from the `platform` ns after this netpol applies, (c) copilot's completion round-trips. Failure mode is graceful degradation (copilot AI assist degrades), not an outage or money-path impact.

## Deliberately NOT in scope
- **agent-service** uses Groq (`llama-3.3-70b-versatile`) which litellm-config does not front — needs a litellm Groq route + key seeding (owner).
- **`agents.yaml: model_gateway_as_built`** left `gateway: none` until the fleet is fully routed + sandbox-verified (that refresh restamps ~29 OPA bundles — separate PR).

Refs #1919, ADR-0174, ADR-0175.

🤖 Generated with [Claude Code](https://claude.com/claude-code)