### PR TITLE
docs(gitops): drop the stale 'pending first CI build' note on control-liveness-sentinel

### DIFF
--- a/openbank-infra/gitops/components/control-liveness-sentinel/control-liveness-sentinel.yaml
+++ b/openbank-infra/gitops/components/control-liveness-sentinel/control-liveness-sentinel.yaml
@@ -26,8 +26,6 @@ spec:
           type: RuntimeDefault
       containers:
         - name: control-liveness-sentinel
-          # Pending first CI build (ADR-0163 initial PR) — build-push-service.sh publishes the
-          # real sandbox-<sha> tag on merge; ArgoCD will not sync a healthy pod until then.
           image: 265175468565.dkr.ecr.eu-north-1.amazonaws.com/openbank-control-liveness-sentinel:sandbox-f4bd8b81
           imagePullPolicy: IfNotPresent
           ports:


### PR DESCRIPTION
The comment on the control-liveness-sentinel container claimed the service was awaiting its first CI build and that ArgoCD would not sync a healthy pod until then. It has long been built and running (verified live during the #2019 LiteLLM work: pod Running/Healthy). The note no longer holds and misleads the next reader — remove it. The image line is unchanged.

## Linked issues

N/A — stale-comment cleanup, no behaviour change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)