### PR TITLE
feat(standing-order): ONCE frequency (one-off future-dated payment) — #7

### DIFF
--- a/openbank-standing-order-service/src/main/kotlin/com/openbank/standingorder/domain/model/StandingOrder.kt
+++ b/openbank-standing-order-service/src/main/kotlin/com/openbank/standingorder/domain/model/StandingOrder.kt
@@ -9,7 +9,10 @@ import java.time.LocalDate
 import java.util.UUID
 
 enum class StandingOrderStatus { ACTIVE, PAUSED, CANCELLED, COMPLETED, FAILED }
-enum class Frequency { DAILY, WEEKLY, BIWEEKLY, MONTHLY, QUARTERLY, ANNUALLY }
+// ONCE = a one-off future-dated payment: it fires exactly once on its startDate and then
+// COMPLETES (never recurs). Modelled as a frequency so it reuses the whole scheduler engine
+// (due-query + execute + record) rather than a separate scheduled-payment service.
+enum class Frequency { ONCE, DAILY, WEEKLY, BIWEEKLY, MONTHLY, QUARTERLY, ANNUALLY }
 enum class PaymentType { SEPA_CREDIT, DOMESTIC, INTERNAL }
 
 data class StandingOrder(
@@ -60,10 +63,19 @@ data class StandingOrder(
         nextExecutionDate = nextDate,
         executionCount = executionCount + 1,
         updatedAt = now,
-        status = if (endDate != null && nextDate.isAfter(endDate)) StandingOrderStatus.COMPLETED else status,
+        // A ONCE order is spent after its single execution; a recurring order completes only once
+        // it runs past its (optional) endDate.
+        status = if (frequency == Frequency.ONCE || (endDate != null && nextDate.isAfter(endDate))) {
+            StandingOrderStatus.COMPLETED
+        } else {
+            status
+        },
     )
 
     fun calculateNextDate(from: LocalDate): LocalDate = when (frequency) {
+        // ONCE never recurs (recordExecution completes it); the returned date is unused, so keep it
+        // unchanged rather than inventing a future occurrence.
+        Frequency.ONCE -> from
         Frequency.DAILY -> from.plusDays(1)
         Frequency.WEEKLY -> from.plusWeeks(1)
         Frequency.BIWEEKLY -> from.plusWeeks(2)

--- a/openbank-standing-order-service/src/main/kotlin/com/openbank/standingorder/domain/model/StandingOrder.kt
+++ b/openbank-standing-order-service/src/main/kotlin/com/openbank/standingorder/domain/model/StandingOrder.kt
@@ -9,6 +9,7 @@ import java.time.LocalDate
 import java.util.UUID
 
 enum class StandingOrderStatus { ACTIVE, PAUSED, CANCELLED, COMPLETED, FAILED }
+
 // ONCE = a one-off future-dated payment: it fires exactly once on its startDate and then
 // COMPLETES (never recurs). Modelled as a frequency so it reuses the whole scheduler engine
 // (due-query + execute + record) rather than a separate scheduled-payment service.

--- a/openbank-standing-order-service/src/main/resources/openapi.yaml
+++ b/openbank-standing-order-service/src/main/resources/openapi.yaml
@@ -163,7 +163,7 @@ components:
           type: string
         frequency:
           type: string
-          enum: [DAILY, WEEKLY, BIWEEKLY, MONTHLY, QUARTERLY, ANNUALLY]
+          enum: [ONCE, DAILY, WEEKLY, BIWEEKLY, MONTHLY, QUARTERLY, ANNUALLY]
         startDate:
           type: string
           format: date

--- a/openbank-standing-order-service/src/main/resources/openapi.yaml
+++ b/openbank-standing-order-service/src/main/resources/openapi.yaml
@@ -3,7 +3,7 @@
 openapi: 3.1.0
 info:
   title: Standing Order Service API
-  version: 1.2.0
+  version: 1.3.0
   description: Recurring payment orders — create, pause, resume, cancel.
   license:
     name: Apache-2.0

--- a/openbank-standing-order-service/src/test/kotlin/com/openbank/standingorder/domain/model/StandingOrderTest.kt
+++ b/openbank-standing-order-service/src/test/kotlin/com/openbank/standingorder/domain/model/StandingOrderTest.kt
@@ -120,6 +120,22 @@ class StandingOrderTest {
         assertThat(updated.status).isEqualTo(StandingOrderStatus.ACTIVE)
     }
 
+    @Test
+    fun `recordExecution completes a ONCE order after its single execution`() {
+        val order = standingOrder(
+            frequency = Frequency.ONCE,
+            startDate = LocalDate.of(2026, 6, 1),
+            endDate = null,
+            nextExecutionDate = LocalDate.of(2026, 6, 1),
+            status = StandingOrderStatus.ACTIVE,
+        )
+
+        val executed = order.recordExecution(order.calculateNextDate(order.nextExecutionDate), FIXED_NOW)
+
+        assertThat(executed.status).isEqualTo(StandingOrderStatus.COMPLETED)
+        assertThat(executed.executionCount).isEqualTo(order.executionCount + 1)
+    }
+
     private fun standingOrder(
         id: UUID = UUID.fromString("00000000-0000-0000-0000-000000000001"),
         idempotencyKey: String = "idempotency-key",
@@ -187,6 +203,8 @@ class StandingOrderTest {
 
         @JvmStatic
         fun frequencyNextDateCases(): Stream<Arguments> = Stream.of(
+            // ONCE never advances — the returned date is unused (recordExecution completes it).
+            Arguments.of(Frequency.ONCE, LocalDate.of(2026, 1, 1), LocalDate.of(2026, 1, 1)),
             Arguments.of(Frequency.DAILY, LocalDate.of(2026, 1, 1), LocalDate.of(2026, 1, 2)),
             Arguments.of(Frequency.WEEKLY, LocalDate.of(2026, 1, 1), LocalDate.of(2026, 1, 8)),
             Arguments.of(Frequency.BIWEEKLY, LocalDate.of(2026, 1, 1), LocalDate.of(2026, 1, 15)),


### PR DESCRIPTION
## What
Adds a **ONCE** frequency to standing orders: a one-time payment that fires exactly once on its `startDate`, then **COMPLETES** (never recurs).

This is the #7 "future-dated one-off payment" reframe — instead of a new scheduled-payment service, a one-off is just a standing order with a ONCE frequency, reusing the existing scheduler engine (due-query → execute → record).

## Changes
- `Frequency.ONCE` enum value
- `calculateNextDate`: ONCE returns the date unchanged (unused — the order completes)
- `recordExecution`: a ONCE order transitions to COMPLETED after its single execution; recurring orders still complete only past their optional `endDate`
- `openapi.yaml` frequency enum + `StandingOrderTest` (next-date no-op + completion assertion)

No DDL: `frequency` is a VARCHAR with no CHECK constraint; the create DTO and customer-edge bind the enum by name and accept any value. Customer-edge needs no change (it already forwards `frequency` + `startDate` untouched, defaulting startDate to today only when absent).

## Test
`:openbank-standing-order-service:test --tests '*StandingOrderTest'` green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)