### PR TITLE
chore(deploy): bump standing-order-service to sandbox-eb0bcf30 (ONCE)

### DIFF
--- a/openbank-infra/gitops/components/payments/payments-services.yaml
+++ b/openbank-infra/gitops/components/payments/payments-services.yaml
@@ -1665,7 +1665,7 @@ spec:
           type: RuntimeDefault
       containers:
         - name: standing-order-service
-          image: 265175468565.dkr.ecr.eu-north-1.amazonaws.com/openbank-standing-order-service:sandbox-237c397c
+          image: 265175468565.dkr.ecr.eu-north-1.amazonaws.com/openbank-standing-order-service:sandbox-eb0bcf30
           imagePullPolicy: IfNotPresent
           ports:
             - name: http


### PR DESCRIPTION
Auto-deploy built+signed `standing-order-service:sandbox-eb0bcf30` (#2072 ONCE) but DEPLOYABLE_SERVICES omitted the gitops bump. Hand-bump; image already signed/attested.

🤖 Generated with [Claude Code](https://claude.com/claude-code)