### PR TITLE
fix(standing-order): wire Kafka mTLS so the execution-trigger consumer can join its group

### DIFF
--- a/openbank-infra/gitops/components/payments/kafka-mtls-externalsecrets.yaml
+++ b/openbank-infra/gitops/components/payments/kafka-mtls-externalsecrets.yaml
@@ -169,6 +169,29 @@ spec:
     - extract:
         key: card-issuance-service
 ---
+# standing-order-service keystore (#889 / ONCE — late mTLS wiring, same gap as
+# card-issuance above). eso-kafka-cert-reader already lists standing-order-service
+# in its resourceNames (kafka-scheme-accepted-acl.yaml), so no RBAC change needed.
+apiVersion: external-secrets.io/v1beta1
+kind: ExternalSecret
+metadata:
+  annotations:
+    argocd.argoproj.io/sync-wave: "-1"
+  name: standing-order-service-kafka-keystore
+  namespace: payments
+spec:
+  refreshInterval: 1h
+  secretStoreRef:
+    kind: ClusterSecretStore
+    name: kafka-messaging-certs
+  target:
+    name: standing-order-service-kafka-keystore
+    creationPolicy: Owner
+    deletionPolicy: Retain
+  dataFrom:
+    - extract:
+        key: standing-order-service
+---
 # Shared cluster-CA truststore — same for every client; one projection, mounted
 # read-only by all Rollouts in payments.
 apiVersion: external-secrets.io/v1beta1

--- a/openbank-infra/gitops/components/payments/kafka-scheme-accepted-acl.yaml
+++ b/openbank-infra/gitops/components/payments/kafka-scheme-accepted-acl.yaml
@@ -257,6 +257,53 @@ spec:
         operations: [Read]
         host: "*"
 ---
+# ── standing-order-service (#889 / ONCE feature) ────────────────────────────
+# Late mTLS wiring — same gap as card-issuance-service above. standing-order was
+# listed as "non-deployed, RBAC pre-registered" in the ADR-0137 fleet sweep
+# (kafka.yaml), then deployed anyway (recurring-order engine, #889; ONCE one-off
+# payments) WITHOUT its mTLS manifests. On the plaintext listener it authenticates
+# as User:ANONYMOUS, which allow.everyone.if.no.acl.found=false denies on every
+# resource — so its execution-trigger consumer got GroupAuthorizationException on
+# group `openbank-standing-order-service` and never joined, killing the whole
+# standing-order execution pipeline in sandbox.
+#
+# Self-consume model (#889): the outbox dispatches due events to
+# openbank.standing-orders.order.event (channel standing-order-events-out) and
+# StandingOrderDueConsumer reads the SAME topic (channel standing-order-due-in) to
+# initiate the real SEPA payment — so this one KafkaUser needs BOTH Write and Read
+# on that topic, plus Read on its service-scoped consumer group (group.id falls
+# back to quarkus.application.name = openbank-standing-order-service).
+apiVersion: kafka.strimzi.io/v1
+kind: KafkaUser
+metadata:
+  annotations:
+    # ADR-0137: certs (KafkaUsers→Strimzi secrets→ESO projection) must land
+    # before the payments Deployment rolls the pod onto mTLS; lower waves sync
+    # first and ArgoCD blocks on the ExternalSecrets reaching SecretSynced.
+    argocd.argoproj.io/sync-wave: "-2"
+  name: standing-order-service
+  namespace: messaging
+  labels:
+    strimzi.io/cluster: openbank-cluster
+spec:
+  authentication:
+    type: tls
+  authorization:
+    type: simple
+    acls:
+      - resource:
+          type: topic
+          name: openbank.standing-orders.order.event
+          patternType: literal
+        operations: [Read, Write, Describe]
+        host: "*"
+      - resource:
+          type: group
+          name: openbank-standing-order-service
+          patternType: literal
+        operations: [Read]
+        host: "*"
+---
 # ── External Secrets reader (ADR-0137) ──────────────────────────────────────
 # The Strimzi User Operator writes the KafkaUser keystores (and the cluster CA
 # truststore) as Secrets in THIS namespace (messaging), but the services run in

--- a/openbank-infra/gitops/components/payments/payments-services.yaml
+++ b/openbank-infra/gitops/components/payments/payments-services.yaml
@@ -1683,7 +1683,34 @@ spec:
                   name: standing-order-db-app
                   key: password
             - name: KAFKA_BOOTSTRAP_SERVERS
-              value: openbank-cluster-kafka-bootstrap.messaging.svc:9092
+              value: openbank-cluster-kafka-bootstrap.messaging.svc:9093
+            - name: QUARKUS_SMALLRYE_REACTIVE_MESSAGING_KAFKA_BOOTSTRAP_SERVERS
+              value: openbank-cluster-kafka-bootstrap.messaging.svc:9093
+            # mTLS to Strimzi (ADR-0137, #889). See application.yaml's
+            # mp.messaging.connector.smallrye-kafka.* for how these map to the
+            # SmallRye Kafka connector's SSL config. Without these the pod
+            # authenticated as User:ANONYMOUS and deny-by-default blocked its
+            # execution-trigger consumer group (GroupAuthorizationException).
+            - name: KAFKA_SECURITY_PROTOCOL
+              value: SSL
+            - name: KAFKA_SSL_KEYSTORE_LOCATION
+              value: /mnt/kafka/keystore/user.p12
+            - name: KAFKA_SSL_KEYSTORE_TYPE
+              value: PKCS12
+            - name: KAFKA_SSL_KEYSTORE_PASSWORD
+              valueFrom:
+                secretKeyRef:
+                  name: standing-order-service-kafka-keystore
+                  key: user.password
+            - name: KAFKA_SSL_TRUSTSTORE_LOCATION
+              value: /mnt/kafka/truststore/ca.p12
+            - name: KAFKA_SSL_TRUSTSTORE_TYPE
+              value: PKCS12
+            - name: KAFKA_SSL_TRUSTSTORE_PASSWORD
+              valueFrom:
+                secretKeyRef:
+                  name: kafka-cluster-ca-truststore
+                  key: ca.password
             - name: QUARKUS_OIDC_AUTH_SERVER_URL
               value: http://keycloak.iam.svc:8080/realms/openbank
             - name: OIDC_CLIENT_SECRET
@@ -1726,6 +1753,12 @@ spec:
           volumeMounts:
             - name: tmp
               mountPath: /tmp
+            - name: kafka-keystore
+              mountPath: /mnt/kafka/keystore
+              readOnly: true
+            - name: kafka-truststore
+              mountPath: /mnt/kafka/truststore
+              readOnly: true
           resources:
             requests:
               cpu: 150m
@@ -1736,6 +1769,12 @@ spec:
       volumes:
         - name: tmp
           emptyDir: {}
+        - name: kafka-keystore
+          secret:
+            secretName: standing-order-service-kafka-keystore
+        - name: kafka-truststore
+          secret:
+            secretName: kafka-cluster-ca-truststore
 ---
 apiVersion: v1
 kind: Service


### PR DESCRIPTION
## Problem

standing-order-service could not consume its execution-trigger topic in sandbox. Pod log (payments ns) repeatedly warned:

```
SRMSG18285: Failed to poll consumer client kafka-consumer-standing-order-due-in ...
GroupAuthorizationException: Not authorized to access group: openbank-standing-order-service
```

The standing-order execution pipeline (including the new **ONCE** one-off payments, #889) was effectively dead: the daily scheduler publishes due events but the consumer can't join its group, so orders never fire. Discovered while E2E-testing ONCE.

## Root cause

standing-order was one of the four services the ADR-0137 mTLS fleet sweep listed as *"non-deployed, RBAC pre-registered"* (`kafka.yaml`) — then it got **deployed anyway** without its mTLS manifests. It ran on the plaintext `:9092` listener, so it authenticated as `User:ANONYMOUS`. With `allow.everyone.if.no.acl.found: "false"` (deny-by-default), ANONYMOUS is denied on **both** the group and the self-consumed topic `openbank.standing-orders.order.event`. The group is checked first on join, so `GroupAuthorizationException` surfaced first; the producer write was denied too (masked by outbox retry).

A lone Group ACL cannot fix this — there was no KafkaUser principal to attach it to, and it would not affect a plaintext ANONYMOUS connection. Same class of gap as card-issuance-service's late mTLS wiring.

## Fix (mirrors card-issuance-service)

1. **KafkaUser** `standing-order-service` (messaging ns) — `Read,Write,Describe` on `openbank.standing-orders.order.event` (producer and consumer share the topic, #889 self-consume) + `Read` on group `openbank-standing-order-service` (SmallRye group.id falls back to the app name).
2. **ExternalSecret** `standing-order-service-kafka-keystore` (payments ns) — projects the cert. `eso-kafka-cert-reader` already pre-lists the service, so no RBAC change.
3. **Deployment** onto `tls:9093` with `KAFKA_SECURITY_PROTOCOL=SSL`, keystore/truststore env + volume mounts.

## Notes

- **Requires a pod restart** (deployment env change) — not the no-restart ACL reconcile the issue assumed, because the service was never on mTLS.
- Egress unchanged: payments has ingress-only NetworkPolicies (plaintext already reached messaging), so `:9093` is reachable.
- No `rules.yaml`/`.rego` touched ⇒ no OPA-bundle regeneration.

## Verification after merge/sync

- ExternalSecret `standing-order-service-kafka-keystore` reaches `SecretSynced`.
- Pod rolls onto 9093; `GroupAuthorizationException` stops.
- `kafka_consumergroup_lag{group="openbank-standing-order-service"}` starts reporting (group joined); a due standing order fires an actual SEPA payment.