### PR TITLE
fix(standing-order): merge instead of persist so cancel/pause don't 500

### DIFF
--- a/openbank-standing-order-service/src/main/kotlin/com/openbank/standingorder/infrastructure/persistence/repository/StandingOrderRepositoryImpl.kt
+++ b/openbank-standing-order-service/src/main/kotlin/com/openbank/standingorder/infrastructure/persistence/repository/StandingOrderRepositoryImpl.kt
@@ -28,7 +28,9 @@ class StandingOrderRepositoryImpl :
 
     override suspend fun save(order: StandingOrder): StandingOrder {
         val e = order.toEntity()
-        Panache.withTransaction { persist(e) }.awaitSuspending()
+        // Application-assigned @Id: persist() is INSERT-only and duplicate-keys on any update
+        // (pause/resume/cancel load an existing row). merge() upserts. See ADR-0126 D3 / #1521.
+        Panache.withTransaction { Panache.getSession().flatMap { it.merge(e) } }.awaitSuspending()
         return e.toDomain()
     }
     override suspend fun findById(id: UUID) =

--- a/openbank-standing-order-service/src/test/kotlin/com/openbank/standingorder/integration/StandingOrderSaveUpsertIT.kt
+++ b/openbank-standing-order-service/src/test/kotlin/com/openbank/standingorder/integration/StandingOrderSaveUpsertIT.kt
@@ -1,0 +1,102 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright (c) OpenBank contributors. Licensed under the Apache License, Version 2.0.
+// See LICENSE in the repository root or https://www.apache.org/licenses/LICENSE-2.0 for details.
+package com.openbank.standingorder.integration
+
+import com.openbank.libs.domain.identifiers.Ids
+import com.openbank.standingorder.domain.model.Frequency
+import com.openbank.standingorder.domain.model.PaymentType
+import com.openbank.standingorder.domain.model.StandingOrder
+import com.openbank.standingorder.domain.model.StandingOrderStatus
+import com.openbank.standingorder.infrastructure.persistence.repository.StandingOrderRepositoryImpl
+import com.openbank.standingorder.it.PostgresRedisTestResource
+import io.quarkus.test.common.QuarkusTestResource
+import io.quarkus.test.junit.QuarkusTest
+import io.quarkus.vertx.VertxContextSupport
+import io.smallrye.mutiny.coroutines.uni
+import jakarta.inject.Inject
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.Dispatchers
+import org.assertj.core.api.Assertions.assertThat
+import org.assertj.core.api.Assertions.assertThatCode
+import org.junit.jupiter.api.Test
+import java.time.Instant
+import java.time.LocalDate
+import java.util.UUID
+
+/**
+ * Regression coverage for the pause/cancel/resume HTTP 500 (#2077): the aggregate has an
+ * application-assigned `@Id`, so [StandingOrderRepositoryImpl.save] must `merge` (upsert) — a
+ * `persist` schedules an INSERT and duplicate-keys on `standing_orders_pkey` the moment `save`
+ * is called for an *existing* row, which is exactly what pause/resume/cancel/confirm do.
+ *
+ * This drives the repository through a real Vert.x context (a mocked repo cannot see the flush),
+ * seeding via `save` then re-saving a state transition on the same id — the second `save` threw
+ * `duplicate key value violates unique constraint "standing_orders_pkey"` before the fix.
+ */
+@QuarkusTest
+@QuarkusTestResource(PostgresRedisTestResource::class)
+class StandingOrderSaveUpsertIT {
+
+    @Inject
+    lateinit var repository: StandingOrderRepositoryImpl
+
+    private fun <T> onEventLoop(block: suspend () -> T): T =
+        VertxContextSupport.subscribeAndAwait { uni(CoroutineScope(Dispatchers.Unconfined)) { block() } }
+
+    private fun newOrder(id: UUID): StandingOrder {
+        val now = Instant.now()
+        return StandingOrder(
+            id = id,
+            idempotencyKey = "upsert-it-$id",
+            partyId = Ids.newId(),
+            debitAccountId = Ids.newId(),
+            debtorIban = "DE89370400440532013000",
+            debtorName = "Alice Debtor",
+            creditorIban = "DE75512108001245126199",
+            creditorName = "Bob Creditor",
+            creditorBic = null,
+            amountMinorUnits = 1_000,
+            currency = "EUR",
+            frequency = Frequency.MONTHLY,
+            paymentType = PaymentType.SEPA_CREDIT,
+            remittanceInfo = null,
+            startDate = LocalDate.of(2026, 1, 1),
+            endDate = null,
+            nextExecutionDate = LocalDate.of(2026, 1, 1),
+            lastExecutionDate = null,
+            executionCount = 0,
+            failureCount = 0,
+            status = StandingOrderStatus.ACTIVE,
+            createdAt = now,
+            updatedAt = now,
+        )
+    }
+
+    @Test
+    fun `cancel re-saves an existing order without a duplicate-key error`() {
+        val id = Ids.newId()
+        onEventLoop { repository.save(newOrder(id)) }
+
+        assertThatCode {
+            onEventLoop { repository.save(newOrder(id).cancel(Instant.now())) }
+        }.describedAs("re-saving an existing order must upsert, not INSERT").doesNotThrowAnyException()
+
+        val reloaded = onEventLoop { repository.findById(id) }
+        assertThat(reloaded).isNotNull
+        assertThat(reloaded!!.status).isEqualTo(StandingOrderStatus.CANCELLED)
+    }
+
+    @Test
+    fun `pause re-saves an existing order without a duplicate-key error`() {
+        val id = Ids.newId()
+        onEventLoop { repository.save(newOrder(id)) }
+
+        assertThatCode {
+            onEventLoop { repository.save(newOrder(id).pause(Instant.now())) }
+        }.describedAs("re-saving an existing order must upsert, not INSERT").doesNotThrowAnyException()
+
+        val reloaded = onEventLoop { repository.findById(id) }
+        assertThat(reloaded!!.status).isEqualTo(StandingOrderStatus.PAUSED)
+    }
+}


### PR DESCRIPTION
## What & why
Cancelling (`DELETE /customer/v1/standing-orders/{id}`) or pausing a standing order returned **HTTP 500**. Pod log (payments ns, `standing-order-service:sandbox-eb0bcf30`, confirmed live 2026-07-24):

```
ERROR: duplicate key value violates unique constraint "standing_orders_pkey" (23505)
```

`StandingOrderEntity` has an application-assigned `@Id` (no `@GeneratedValue`), so `StandingOrderRepositoryImpl.save()` calling Panache `persist()` is **INSERT-only**. Create is fine, but `pause`/`resume`/`cancel`/`confirmExecution` load an existing row and re-`save()` it → Hibernate schedules an INSERT for an existing PK → `23505` → 500. Same class as the ADR-0126 D3 assigned-`@Id` upsert rule (#1521); `saveWithExecution` already did the find-or-persist dance correctly.

The customer app's standing-order cancel (trash icon in `StandingOrderScreen`) and pause toggle were broken — every cancel/pause 500'd. Pre-existing, unrelated to the recent ONCE change.

## Change
- `save()` now uses `Panache.getSession().merge(e)` (upsert) inside the transaction — correct for both create and update.
- New `StandingOrderSaveUpsertIT`: a real-DB IT (Vert.x context via `VertxContextSupport`) that `save()`s then re-`save()`s a cancel/pause transition on the same id. It **reproduced the exact `standing_orders_pkey` duplicate-key error** on the pre-fix `persist()` code and passes on the fix. A mocked-repo unit test cannot see the flush, which is why this shipped.

## Testing
- Fail-first verified: reverted to `persist()` → both IT cases fail with `duplicate key value violates unique constraint "standing_orders_pkey" (23505)`.
- With the fix: `detekt` + `ktlintCheck` + `compileTestKotlin` green; `StandingOrderSaveUpsertIT` green.

Closes #2077

🤖 Generated with [Claude Code](https://claude.com/claude-code)