### PR TITLE
ci(auto-deploy): fix can-i-deploy checkout + stop scheduled reconcile going red on ordinary blocks

### DIFF
--- a/.github/workflows/auto-deploy.yml
+++ b/.github/workflows/auto-deploy.yml
@@ -653,6 +653,15 @@ jobs:
       PACT_BROKER_PASSWORD: ${{ secrets.PACT_BROKER_PASSWORD }}
       PACT_STANDALONE_VERSION: "2.6.2"
     steps:
+      # This job had no checkout, so the #1420 money-path escalation below
+      # (`awk ... openbank-libs/governance/rules.yaml`) crashed with "cannot open" —
+      # latent until the scheduled reconcile started re-driving stranded (=often
+      # blocked) services every tick, which is the only path that reliably enters that
+      # block. Check out so rules.yaml is present and the money-path naming works.
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          fetch-depth: 0
+
       # The pact CLI runs natively on the ARC runner pod (which resolves the broker's
       # cluster DNS); the pact-cli docker image would run in dind and could not. The
       # standalone ships a linux arm64 build for the Graviton runner.
@@ -816,6 +825,19 @@ jobs:
               fi
             done
             [ "$mp_blocked" = "1" ] && echo "::error::can-i-deploy left one or more MONEY-PATH services behind this run — see the job summary (issue #1420)"
+          fi
+          # On a scheduled reconcile tick an ordinary (non money-path) service still blocked by
+          # the contract gate is EXPECTED — reconcile deliberately re-offers known strands and
+          # leaves the still-blocked ones for a later tick; the deployable subset already
+          # advanced via gitops-pr. Failing the job for that would make the every-3h schedule
+          # perpetually red — a red workflow addressed to nobody (see auto-deploy.yml scheduling
+          # note). So on `schedule` only fail the status when a MONEY-PATH service is the one
+          # left behind (mp_blocked=1), which must stay loud. push / workflow_dispatch keep the
+          # unconditional ADR-0092 behaviour below. Deploy behaviour is unchanged either way:
+          # gitops-pr deploys the `deployable` subset and never the blocked complement.
+          if [ "${{ github.event_name }}" = "schedule" ] && [ "$rc" -ne 0 ] && [ "${mp_blocked:-0}" != "1" ]; then
+            echo "::notice::reconcile tick: ${BLOCKED_N:-0} service(s) still gate-blocked (non money-path) — left for a later tick; the deployable subset deployed. Not failing the scheduled run."
+            exit 0
           fi
           # Enforce: non-zero rc still fails this job's own status for visibility (ADR-0092) —
           # it no longer blocks gitops-pr/record-deployment for the deployable subset above.


### PR DESCRIPTION
Follow-up to the scheduled reconcile (#2020, merged #2021). Cron **fires** and deploys **work** — the two scheduled ticks opened gitops PRs #2083 + #2084 (both merged), draining the strand backlog **23 → 12**. But the `can-i-deploy` job went **red every tick**, two causes, both fixed here:

## 1. `can-i-deploy` had no checkout → #1420 awk crash
The money-path-left-behind block runs `awk ... openbank-libs/governance/rules.yaml`, but the job never ran `actions/checkout` → `awk: cannot open` → exit 2. Latent since #1563: push runs rarely enter the blocked-services block; reconcile re-drives stranded (= often gate-blocked) services every tick and hits it reliably. So the #1420 money-path escalation never actually worked. **Fix:** add the checkout.

## 2. ADR-0092 red-on-block is wrong for a scheduled reconcile
`can-i-deploy` exits `rc=1` "for visibility" whenever any service is gate-blocked. For a per-push run that's rare and tied to a real change. For the every-3h reconcile it's the *normal steady state* — it deliberately re-offers known strands, some still blocked — so the schedule would be **perpetually red** (a red workflow addressed to nobody). **Fix:** on `schedule`, fail the status only when a **money-path** service is left behind (`mp_blocked=1`); ordinary blocks emit a `::notice::` and exit 0. `push` / `workflow_dispatch` keep the unconditional ADR-0092 behaviour.

**Deploy behaviour unchanged either way** — gitops-pr deploys the `deployable` subset and never the blocked complement; only the job *status* changes.

## Test
- actionlint finding set on `auto-deploy.yml` identical to `origin/main` (no new findings).
- `bash -n` of the edited `can-i-deploy` run block passes for both `event_name=schedule` and `=push`.
- Single-file change; no `rules.yaml` edit → no OPA-bundle restamp.

Refs #2020

🤖 Generated with [Claude Code](https://claude.com/claude-code)