### PR TITLE
docs(compliance): OpenSSF Gold gap + FAPI 2.0 self-assessment runbook (#1925/#1911)

### DIFF
--- a/docs/compliance/fapi2-self-assessment.md
+++ b/docs/compliance/fapi2-self-assessment.md
@@ -1,0 +1,54 @@
+# FAPI 2.0 conformance — self-assessment checklist
+
+> A runbook for a FAPI 2.0 Security Profile self-assessment of the sandbox authorization server
+> (Keycloak) and resource server (`openbank-psd2-service`) using the free
+> [OpenID Foundation conformance suite](https://openid.net/certification/conformance/). No OSS
+> banking platform holds a FAPI 2.0 certification; even a **published self-assessment run** is a
+> credibility artifact none of the category has. Formal certification is a per-deployment fee to the
+> OpenID Foundation, decided only after the suite passes green.
+>
+> **Positioning, not a certification.** This lists what to run and the config to check first; it is
+> not a claim of conformance.
+
+## What is in scope here
+
+The PSD2/XS2A surface is the FAPI-relevant one: `openbank-psd2-service` (RS), `openbank-sca-service`
+(SCA), `openbank-consent-service`, `openbank-tpp-registry-service`, and Keycloak as the AS
+(`iam` namespace). FAPI 2.0 Security Profile (final 2025-02) is the target; Message Signing (final
+2025-08) is a separate, later profile.
+
+## Pre-run config checklist (the usual FAPI 2.0 fail points)
+
+Check these in the Keycloak realm/client config and `openbank-psd2-service` before wasting a suite
+run — each is a common hard fail:
+
+- [ ] **PAR (Pushed Authorization Requests) required** — the client must not accept a plain
+      front-channel `authorization_request`; `require_pushed_authorization_requests = true`.
+- [ ] **Sender-constrained tokens** — **DPoP** or **mTLS** client-certificate-bound access tokens.
+      A plain bearer token fails FAPI 2.0. Decide which (mTLS fits the existing mesh; DPoP fits
+      public clients).
+- [ ] **PKCE with S256** enforced (no `plain`).
+- [ ] **Strict `iss` / `aud`** validation on every token and the authorization response.
+- [ ] **JARM** (JWT-secured authorization response) if response signing is used — else confirm the
+      redirect response mode is FAPI-acceptable.
+- [ ] **No unencrypted redirect URIs**; HTTPS only; exact redirect-URI matching.
+- [ ] Token lifetimes and refresh-token rotation within the profile's bounds.
+
+## Run
+
+1. Deploy the OpenID conformance suite (self-hosted image, or the hosted instance) with **network
+   reachability to the sandbox AS** — this needs the sandbox Keycloak reachable from the runner,
+   which is the one thing an in-repo assessment cannot do headless.
+2. Configure a test plan: **FAPI 2.0 Security Profile**, AS = the openbank realm, RS =
+   `openbank-psd2-service` an XS2A endpoint.
+3. Run the plan; fix the config gaps it flags (they will mostly be from the checklist above); re-run
+   until green.
+4. **Publish the results** in-repo (`docs/compliance/fapi2-results/`) — the artifact is the point,
+   whether or not formal certification follows.
+
+## What is preparable vs not
+
+- **Preparable in-repo now:** the config-diff (the checklist above turned into concrete Keycloak
+  client settings + `psd2-service` config keys), and the conformance-suite test-plan JSON.
+- **Needs a live run (not headless):** the suite must reach the sandbox AS over the network. That is
+  the maintainer's run (or grant the assessor cluster access) — it is the only blocking step.

--- a/docs/compliance/openssf-gold-gap.md
+++ b/docs/compliance/openssf-gold-gap.md
@@ -1,0 +1,65 @@
+# OpenSSF Best Practices — Silver → Gold gap analysis
+
+> Assessment of this repository against the [OpenSSF Best Practices Gold criteria](https://www.bestpractices.dev/en/criteria/2),
+> to make the path to Gold concrete. **Positioning, not a submission** — the badge is submitted from
+> the maintainer's BadgeApp account; several criteria are attestations only the maintainer can make.
+> Verified against `origin/main` (SPDX coverage sampled, contributor list from `git log`, coverage
+> floor from the kover config).
+
+## Headline
+
+The platform **already meets almost every security and quality-infrastructure Gold criterion** — it
+is a security-heavy codebase (Falco, mesh mTLS, OPA, signed SLSA evidence, an external pentest,
+ZAP + ClusterFuzzLite dynamic analysis). Gold is blocked on **three things that share one root**
+plus a coverage push:
+
+1. **bus factor ≥ 2**, 2. **two-person review (≥50% of changes reviewed by a non-author)**,
+3. **two unassociated significant contributors** — all three fail for the same reason: a **single
+maintainer** (`CODEOWNERS` is `@JiRaska` on every path; the git log is JiRaska + bots). Plus
+4. **90% statement / 80% branch coverage** (the current ratchet floor is far lower).
+
+**The first three are not solvable in code.** One added external reviewer/maintainer unlocks all
+three at once — it is the single highest-leverage, non-purchasable action for the whole
+credibility roadmap.
+
+## Criterion-by-criterion
+
+### Prerequisites
+| Criterion | State | Action |
+|---|---|---|
+| `achieve_silver` | ⚠️ ~84% | Close the remaining Silver criteria (owner, BadgeApp) |
+| `bus_factor` (≥2) | ❌ | **Add a second maintainer / external review pool** (owner) |
+| `contributors_unassociated` (2+ significant) | ❌ | Same root — grow unassociated contribution |
+
+### Basics
+| `copyright_per_file` / `license_per_file` (SPDX) | ✅ | Sampled 52/52 in ledger; confirm fleet-wide, then attest |
+
+### Change control
+| `repo_distributed` (git) | ✅ | Attest |
+| `small_tasks` | ✅ | `good first issue` label exists |
+| `require_2FA` / `secure_2FA` | ✅ (assumed) | Owner attests GitHub 2FA is enforced (cryptographic, not SMS) |
+
+### Quality
+| `code_review_standards` | ⚠️ | CONTRIBUTING.md + GOVERNANCE.md document the flow; point the criterion at them |
+| `two_person_review` (≥50%) | ❌ | **Bus-factor root** — needs a second human reviewer |
+| `build_reproducible` | ⚠️ | `verification-metadata.xml` byte-pins + fast-jar help; either finish reproducibility or claim N/A with justification |
+| `test_invocation` (`./gradlew test`) | ✅ | Attest |
+| `test_continuous_integration` | ✅ | Extensive CI — attest |
+| `test_statement_coverage90` | ❌ | Ratchet floor ~55%; raise over time (money-path first) |
+| `test_branch_coverage80` | ❌ | Same |
+
+### Security
+| `crypto_used_network` / `crypto_tls12` | ✅ | TLS + Istio mTLS |
+| `hardened_site` | ⚠️ | Confirm security headers on open-bank.tech (CSP/HSTS) |
+| `security_review` (≤5y) | ✅ | External pentest, ADR-0080 |
+| `hardening` | ✅ | Falco, NetworkPolicies, OPA, seccomp, PSS-restricted |
+| `dynamic_analysis` | ✅ | ZAP baseline + schemathesis + ClusterFuzzLite |
+
+## Recommended order
+
+1. **Add a second reviewer/maintainer** — unlocks `bus_factor`, `two_person_review`,
+   `contributors_unassociated` (3 criteria, 1 action) and is a prerequisite for the whole Gold push
+   *and* the OSTIF-style external audit.
+2. **Close Silver to 100%** — small, owner-driven BadgeApp work.
+3. **Attest the already-met security/infra criteria** — most of Gold is a form-fill once (1).
+4. **Coverage ratchet toward 90/80** — the one real engineering effort; sequence money-path first.


### PR DESCRIPTION
Two owner-action roadmaps for the cheap-but-high-credibility levers (strategy audit):

- **`openssf-gold-gap.md`** — criterion-by-criterion vs the [Gold badge](https://www.bestpractices.dev/en/criteria/2). The platform already meets almost every security/quality-infra criterion; Gold is blocked on **three criteria sharing one root — a single maintainer** (`bus_factor`, `two_person_review`, `contributors_unassociated`) — plus 90/80 coverage. **One added external reviewer unlocks three criteria at once** — the highest-leverage non-purchasable action.
- **`fapi2-self-assessment.md`** — a runbook for a FAPI 2.0 Security Profile self-assessment (Keycloak AS + `psd2-service` RS) with the pre-run config checklist (PAR required, DPoP/mTLS sender-constraining, PKCE S256, iss/aud strictness). No OSS bank holds a FAPI 2.0 cert; even a published self-assessment run is a category first.

Both honest about what needs the maintainer (BadgeApp submit, a live conformance run) vs what is preparable in-repo.

## Linked issues

Refs #1925, Refs #1911, Refs #1929

🤖 Generated with [Claude Code](https://claude.com/claude-code)