### PR TITLE
fix(copilot): allow design_theme through the OPA gate (ADR-0191)

### DIFF
--- a/openbank-infra/gitops/components/copilot/copilot-opa-bundle.yaml
+++ b/openbank-infra/gitops/components/copilot/copilot-opa-bundle.yaml
@@ -9,7 +9,7 @@ metadata:
     app.kubernetes.io/name: copilot-service
     app.kubernetes.io/part-of: platform
   annotations:
-    openbank.tech/policy-checksum: "e873cef5348f5401"
+    openbank.tech/policy-checksum: "570754ed994f56fc"
 data:
   rest.rego: |
     # SPDX-License-Identifier: Apache-2.0
@@ -446,6 +446,9 @@ data:
     	"get_fx_rates",
     	"get_scheduled_payments",
     	"search_help",
+    	# design_theme (ADR-0191): no money, no server state — returns a ThemeSpec the app
+    	# persists via the edge and re-validates on-device; safe for any authenticated customer.
+    	"design_theme",
     }
 
     # Proposal tools (create ProposalToken, require SCA confirm).

--- a/openbank-infra/gitops/components/copilot/copilot-service.yaml
+++ b/openbank-infra/gitops/components/copilot/copilot-service.yaml
@@ -29,7 +29,7 @@ spec:
       annotations:
         # Rolls the pod when the OPA bundle changes — subPath mounts do NOT hot-reload.
         # Kept in sync by gen-copilot-opa-bundle.sh (do not hand-edit).
-        openbank.tech/policy-checksum: "e873cef5348f5401"
+        openbank.tech/policy-checksum: "570754ed994f56fc"
     spec:
       securityContext:
         runAsNonRoot: true

--- a/openbank-infra/opa/policies/copilot_tool.rego
+++ b/openbank-infra/opa/policies/copilot_tool.rego
@@ -62,6 +62,9 @@ read_only_tools := {
 	"get_fx_rates",
 	"get_scheduled_payments",
 	"search_help",
+	# design_theme (ADR-0191): no money, no server state — returns a ThemeSpec the app
+	# persists via the edge and re-validates on-device; safe for any authenticated customer.
+	"design_theme",
 }
 
 # Proposal tools (create ProposalToken, require SCA confirm).


### PR DESCRIPTION
`design_theme` shipped in #2076 but was never added to `read_only_tools` in the copilot OPA bundle. The `CopilotPolicyGate` is deny-by-default, so every call returned "unknown tool" — the tool registered in-process (verified: pod runs image `sandbox-91b9ac77`, the merge SHA) but the AI-designer path (P2) could never actually run. Same failure class as the sdd/interest OPA-enforce gaps.

Verified live before this fix: `read_only_tools` on the running copilot pod does **not** contain `design_theme`.

Fix: add `design_theme` to `read_only_tools` in `copilot_tool.rego` (source), regenerate `copilot-opa-bundle.yaml` + the checksum annotation so the OPA sidecar reloads. It moves no money and changes no server state — it returns a `ThemeSpec` the app persists via the edge preferences endpoint and re-validates on-device — so it's read-only, allowed for any authenticated customer, no SCA.

`opa check` passes locally.

🤖 Generated with [Claude Code](https://claude.com/claude-code)