### PR TITLE
chore(admin-ui): publish customer-app dossier — tls-pinning live

### DIFF
--- a/openbank-admin-ui/app-status.json
+++ b/openbank-admin-ui/app-status.json
@@ -188,13 +188,13 @@
       "lens": [
         "security"
       ],
-      "status": "partial",
+      "status": "live",
       "adr": [
         "ADR-0066"
       ],
       "gap": {
-        "cs": "SPKI pinning je implementován, ale produkční hashe nejsou nastaveny (PINNED_SPKI_HASHES je prázdné), takže pinning je v sandboxu vypnutý (ADR-0066-S3).",
-        "en": "SPKI pinning is implemented but production hashes are not set (PINNED_SPKI_HASHES is empty), so pinning is disabled in sandbox (ADR-0066-S3)."
+        "cs": "SPKI pinning je aktivní: PINNED_SPKI_HASHES obsahuje produkční piny pro všechny hosty (customer.open-bank.tech, kc.open-bank.tech, rum.open-bank.tech) a useFakeData=false, takže CERT_PINNING_ENABLED=true. Zbytkový provozní úkol: piny jsou hardcoded, takže je nutné je aktualizovat při rotaci certifikátů (zmírněno cert-manager private-key-rotation-policy: Never na ingressu; cross-host backup pin dle RFC 7469 §2.1.3).",
+        "en": "SPKI pinning is active: PINNED_SPKI_HASHES holds production pins for all hosts (customer.open-bank.tech, kc.open-bank.tech, rum.open-bank.tech) and useFakeData=false, so CERT_PINNING_ENABLED=true. Residual operational task: pins are hardcoded and must be updated on cert rotation (mitigated by cert-manager private-key-rotation-policy: Never on the ingress; cross-host backup pin per RFC 7469 §2.1.3)."
       },
       "derivedStatus": "live"
     },
@@ -278,8 +278,8 @@
   "summary": {
     "total": 13,
     "byStatus": {
-      "live": 9,
-      "partial": 3,
+      "live": 10,
+      "partial": 2,
       "planned": 1
     },
     "decisionMissing": []


### PR DESCRIPTION
Republishes the derived `openbank-admin-ui/app-status.json` after the openbank-app curatorial fix [openbank-app#276](https://github.com/JiRaska/openbank-app/pull/276) (merged): `tls-pinning` `status: partial` → `live`, gap narrative corrected (production pins are populated + active, not empty).

Clears the advisory `derivedStatus` drift the dossier generator flagged (code signal `live` vs stale yaml `partial`, ADR-0074 / issue #26).

## Why manual
openbank-app's `app-status` workflow is meant to auto-open this publish PR, but its `PLATFORM_RW_TOKEN` secret is not configured — the publish job runs only its "no platform write token" skip notice. Regenerated here via `generate-app-status.mjs` per the documented local fallback (the drift-comment recipe).

## Diff
- `tls-pinning`: `status` `partial`→`live`, gap rewritten
- `summary.byStatus`: `live 9→10, partial 3→2`
- derived block unchanged (already matched main)

Derived data — generated, not hand-edited (ADR-0029 #7). Refs ADR-0074 (dossier invariant 3).

🤖 Generated with [Claude Code](https://claude.com/claude-code)