### PR TITLE
fix(admin-ui): onboarding funnel board ClickHouse alias collision (sign_outcomes)

### DIFF
--- a/openbank-admin-ui/src/app/api/onboarding/funnel-analytics/route.ts
+++ b/openbank-admin-ui/src/app/api/onboarding/funnel-analytics/route.ts
@@ -124,7 +124,7 @@ export async function GET(req: NextRequest) {
         WHERE ${range}
         GROUP BY step`),
       chQuery(`
-        SELECT toString(day)   AS day,
+        SELECT day,
                sum(attempts)   AS attempts,
                sum(successes)  AS successes,
                sum(failures)   AS failures


### PR DESCRIPTION
The onboarding funnel board showed "Analytics-sink (ClickHouse) is not responding". Root cause: the sign-outcomes gold-mart query selected `toString(day) AS day` while grouping/ordering by `day`, so ClickHouse hit `NO_COMMON_TYPE: String, Date` (Code 386) and — because all five queries run in one `Promise.all` — the whole BFF fetch rejected. Fix selects the raw `day` Date (serialized as YYYY-MM-DD in JSON, so `String(r.day)` is unchanged). Verified against live ClickHouse. Closes part of #1982.

🤖 Generated with [Claude Code](https://claude.com/claude-code)