### PR TITLE
chore(gitops): bump admin-ui to sandbox-98e53399 (funnel board fix)

### DIFF
--- a/openbank-infra/gitops/components/admin-ui/admin-ui.yaml
+++ b/openbank-infra/gitops/components/admin-ui/admin-ui.yaml
@@ -38,7 +38,7 @@ spec:
           type: RuntimeDefault
       containers:
         - name: admin-ui
-          image: 265175468565.dkr.ecr.eu-north-1.amazonaws.com/openbank-admin-ui:sandbox-81f981ad
+          image: 265175468565.dkr.ecr.eu-north-1.amazonaws.com/openbank-admin-ui:sandbox-98e53399
           ports:
             - name: http
               containerPort: 3000


### PR DESCRIPTION
gitops admin-ui image was stuck at sandbox-81f981ad (pre-fix) so the live board still 500'd on sign_outcomes. Bumps to sandbox-98e53399 — newest signed build, includes #2115's fix. Closes part of #1982.

🤖 Generated with [Claude Code](https://claude.com/claude-code)