### PR TITLE
fix(domestic): make Temporal the sole orchestrator, retire the legacy in-service flow (ADR-0120 Phase 6, #1917 — 3/3)

### DIFF
--- a/docs/threat-models/openbank-domestic-payment.md
+++ b/docs/threat-models/openbank-domestic-payment.md
@@ -85,6 +85,24 @@ not change any existing request's outcome until explicitly flipped.
 
 ## 6. Change log
 
+- **2026-07-24** — Retire the legacy in-service orchestration; Temporal is the sole orchestrator
+  (ADR-0120 Phase 6, issue #1917). `createPayment` no longer branches on `openbank.temporal.enabled`
+  (removed) — it always dispatches `DomesticPaymentWorkflow` (screening → shadow fraud scoring → scheme
+  submission → settle). The in-service `applyScreening`/`applyFraudGate`/`submitToScheme`/
+  `attemptSettlement` flow and its now-unused ports (screening/aml/fraud/scheme/settlement + the
+  `schemeSubmissionEnabled`/`fraudEnforcementEnabled` service flags) are deleted; `persistTransition`,
+  `buildReceivedPayment`, the server-side transferScope derivation, and the query/transition endpoints
+  are unchanged. Worker registration is gated separately by `openbank.domestic.worker.enabled` (default
+  true; `%test` false) so @QuarkusTest boot does not connect to an absent Temporal frontend; a test
+  `WorkflowClientTestProducer` backs the CDI `WorkflowClient` with an in-process `TestWorkflowEnvironment`.
+  **No new trust boundary or external caller** — the same screening/fraud/scheme/settlement steps now run
+  inside Temporal activities (each already OIDC/mTLS-bounded), with the workflow adding durable retries +
+  reverse compensation. The prerequisite that the Temporal path was missing shadow fraud scoring was
+  fixed in the same change (the `shadowFraudScore` activity is now invoked between validation and scheme
+  submission, matching the retired flow). Rollback: revert the commit (the flag + in-service flow return).
+  Risk class = **availability/correctness** (durable orchestration replaces a best-effort in-process
+  sequence); verified by a sandbox canary (worker registers + polls `openbank-domestic-payments`, real
+  payments complete via Temporal end-to-end).
 - **2026-07-08** — ADR-0155 rollout (issue #413): wired the four-eyes maker-checker mechanism
   piloted on sepa-payment. New `ApprovalConfig` (`ApprovalStore` via `RedisApprovalStore`) and
   new checker-facing endpoint `PATCH /api/v1/domestic-payments/approvals/{id}`

--- a/openbank-domestic-payment/build.gradle.kts
+++ b/openbank-domestic-payment/build.gradle.kts
@@ -39,6 +39,9 @@ dependencies {
     implementation(project(":openbank-libs-domain"))
     implementation(project(":openbank-libs-runtime"))
     testImplementation(libs.quarkus.junit5)
+    // In-process Temporal test server for the sole-orchestrator dispatch/workflow tests (ADR-0120 Phase 6, #1917).
+    testImplementation("io.temporal:temporal-testing:1.25.1")
+    testImplementation("io.grpc:grpc-inprocess:1.68.1")
     // @TestSecurity for the ADR-0034 Phase 5 advisory-mode authz regression test.
     testImplementation(libs.quarkus.test.security)
     testImplementation(libs.assertj)

--- a/openbank-domestic-payment/src/main/kotlin/com/openbank/domestic/application/usecase/DomesticPaymentService.kt
+++ b/openbank-domestic-payment/src/main/kotlin/com/openbank/domestic/application/usecase/DomesticPaymentService.kt
@@ -9,31 +9,13 @@ import com.openbank.domestic.application.port.`in`.DomesticPaymentUseCase
 import com.openbank.domestic.application.port.`in`.ListDomesticPaymentsQuery
 import com.openbank.domestic.application.port.`in`.TransitionDomesticPaymentStatusCommand
 import com.openbank.domestic.application.port.out.AccountLookupPort
-import com.openbank.domestic.application.port.out.AmlCasePort
-import com.openbank.domestic.application.port.out.AmlCaseRiskLevel
 import com.openbank.domestic.application.port.out.DomesticPaymentEventPublisher
 import com.openbank.domestic.application.port.out.DomesticPaymentRepository
-import com.openbank.domestic.application.port.out.FraudScoreCommand
-import com.openbank.domestic.application.port.out.FraudScoringPort
-import com.openbank.domestic.application.port.out.FraudVerdict
-import com.openbank.domestic.application.port.out.OpenAmlCaseCommand
-import com.openbank.domestic.application.port.out.SanctionsScreeningPort
-import com.openbank.domestic.application.port.out.SchemeGatewayPort
-import com.openbank.domestic.application.port.out.SchemeGatewayUnavailableException
-import com.openbank.domestic.application.port.out.ScreeningUnavailableException
-import com.openbank.domestic.application.port.out.SettlementPort
-import com.openbank.domestic.application.port.out.SettlementUnavailableException
 import com.openbank.domestic.application.workflow.DomesticPaymentWorkflow
 import com.openbank.domestic.domain.model.DomesticPayment
 import com.openbank.domestic.domain.model.DomesticPaymentPriority
 import com.openbank.domestic.domain.model.DomesticPaymentStatus
-import com.openbank.domestic.domain.model.DomesticRejectReason
 import com.openbank.domestic.domain.model.DomesticTransferScope
-import com.openbank.domestic.domain.screening.ScreeningDecision
-import com.openbank.domestic.domain.screening.ScreeningMatchStatus
-import com.openbank.domestic.domain.screening.ScreeningPolicy
-import com.openbank.domestic.domain.screening.ScreeningResult
-import com.openbank.domestic.domain.screening.ScreeningRole
 import com.openbank.libs.observability.DomainMetrics
 import com.openbank.libs.persistence.outbox.OutboxMessage
 import io.temporal.client.WorkflowClient
@@ -41,9 +23,7 @@ import io.temporal.client.WorkflowOptions
 import jakarta.enterprise.context.ApplicationScoped
 import jakarta.inject.Inject
 import org.eclipse.microprofile.config.inject.ConfigProperty
-import org.jboss.logging.Logger
 import java.time.Clock
-import java.time.Duration
 import java.time.Instant
 import java.util.Locale
 import java.util.UUID
@@ -56,21 +36,10 @@ class InvalidDomesticPaymentStateTransitionException(message: String) : RuntimeE
 class DomesticPaymentService(
     private val paymentRepository: DomesticPaymentRepository,
     private val eventPublisher: DomesticPaymentEventPublisher,
-    private val screeningPort: SanctionsScreeningPort,
-    private val amlCasePort: AmlCasePort,
-    private val fraudScoringPort: FraudScoringPort,
-    private val schemeGatewayPort: SchemeGatewayPort,
-    private val settlementPort: SettlementPort,
     private val accountLookupPort: AccountLookupPort,
     private val metrics: DomainMetrics,
-    @ConfigProperty(name = "openbank.temporal.enabled", defaultValue = "false")
-    private val temporalEnabled: Boolean,
     @ConfigProperty(name = "openbank.temporal.task-queue", defaultValue = "openbank-domestic-payments")
     private val temporalTaskQueue: String,
-    @ConfigProperty(name = "openbank.domestic.scheme-submission.enabled", defaultValue = "false")
-    private val schemeSubmissionEnabled: Boolean,
-    @ConfigProperty(name = "openbank.domestic.fraud.enforcement-enabled", defaultValue = "false")
-    private val fraudEnforcementEnabled: Boolean,
     private val workflowClient: WorkflowClient,
     private val clock: Clock,
 ) : DomesticPaymentUseCase {
@@ -79,38 +48,24 @@ class DomesticPaymentService(
     constructor(
         paymentRepository: DomesticPaymentRepository,
         eventPublisher: DomesticPaymentEventPublisher,
-        screeningPort: SanctionsScreeningPort,
-        amlCasePort: AmlCasePort,
-        fraudScoringPort: FraudScoringPort,
-        schemeGatewayPort: SchemeGatewayPort,
-        settlementPort: SettlementPort,
         accountLookupPort: AccountLookupPort,
         metrics: DomainMetrics,
-        @ConfigProperty(name = "openbank.temporal.enabled", defaultValue = "false")
-        temporalEnabled: Boolean,
         @ConfigProperty(name = "openbank.temporal.task-queue", defaultValue = "openbank-domestic-payments")
         temporalTaskQueue: String,
-        @ConfigProperty(name = "openbank.domestic.scheme-submission.enabled", defaultValue = "false")
-        schemeSubmissionEnabled: Boolean,
-        @ConfigProperty(name = "openbank.domestic.fraud.enforcement-enabled", defaultValue = "false")
-        fraudEnforcementEnabled: Boolean,
         workflowClient: WorkflowClient,
     ) : this(
-        paymentRepository, eventPublisher, screeningPort, amlCasePort, fraudScoringPort,
-        schemeGatewayPort, settlementPort, accountLookupPort, metrics, temporalEnabled, temporalTaskQueue,
-        schemeSubmissionEnabled, fraudEnforcementEnabled, workflowClient, Clock.systemUTC(),
+        paymentRepository,
+        eventPublisher,
+        accountLookupPort,
+        metrics,
+        temporalTaskQueue,
+        workflowClient,
+        Clock.systemUTC(),
     )
-
-    private val log = Logger.getLogger(DomesticPaymentService::class.java)
 
     companion object {
         private const val PAYMENT_CREATED_EVENT = "domestic.payment.created"
         private const val PAYMENT_STATUS_CHANGED_EVENT = "domestic.payment.status-changed"
-
-        private const val ALERT_SANCTIONS_HIT = "SANCTIONS_HIT"
-        private const val ALERT_AML_HOLD = "AML_HOLD"
-        private const val ALERT_SCREENING_UNAVAILABLE = "SCREENING_UNAVAILABLE"
-        private const val ALERT_FRAUD_REVIEW = "FRAUD_REVIEW"
 
         private const val OWN_BANK_CODE = "0000"
     }
@@ -156,93 +111,19 @@ class DomesticPaymentService(
 
         metrics.paymentSubmitted("domestic", payment.currency)
 
-        if (temporalEnabled) {
-            // ADR-0101 P2: delegate durable orchestration to Temporal — fire-and-forget start.
-            val stub = workflowClient.newWorkflowStub(
-                DomesticPaymentWorkflow::class.java,
-                WorkflowOptions.newBuilder()
-                    .setTaskQueue(temporalTaskQueue)
-                    .setWorkflowId("domestic-payment-${received.id}")
-                    .build(),
-            )
-            WorkflowClient.start(stub::process, received.id)
-            return received
-        }
-
-        // ADR-0032: screening is the first processing step, run synchronously after the RECEIVED row
-        // is durably persisted (so the payment is never lost if screening then fails). Fraud scoring
-        // (ADR-0084 §4.2) is the second gate, consulted only for a payment screening has cleared —
-        // see applyScreening's CLEAR branch.
-        val screened = applyScreening(received)
-
-        return submitToScheme(screened)
-    }
-
-    /**
-     * ADR-0104 D4: once the payment is VALIDATED, build a real `pacs.008` and submit it to the
-     * scheme gateway (Czech CERTIS / the clearing simulator today). `ACSC` → SENT_TO_CLEARING;
-     * `RJCT` → REJECTED. Fails closed: if the gateway is unreachable the payment stays VALIDATED
-     * (the operator retries or a manual transition handles it). No-op unless the pilot flag is on.
-     */
-    @Suppress("TooGenericExceptionCaught")
-    private suspend fun submitToScheme(payment: DomesticPayment): DomesticPayment {
-        if (!schemeSubmissionEnabled || payment.status != DomesticPaymentStatus.VALIDATED) return payment
-
-        return try {
-            val outcome = schemeGatewayPort.submit(payment)
-            if (outcome.accepted) {
-                val sentToClearing =
-                    persistTransition(payment, DomesticPaymentStatus.SENT_TO_CLEARING, null, null)
-                attemptSettlement(sentToClearing)
-            } else {
-                val reason = mapSchemeReason(outcome.reasonCode)
-                persistTransition(
-                    payment,
-                    DomesticPaymentStatus.REJECTED,
-                    reason,
-                    "scheme reject (pacs.002): ${outcome.reasonCode ?: "unspecified"}",
-                )
-            }
-        } catch (ex: SchemeGatewayUnavailableException) {
-            log.warnf(ex, "Scheme gateway unavailable for payment %s; holding in VALIDATED", payment.id)
-            payment
-        } catch (ex: Exception) {
-            log.warnf(ex, "Unexpected error during scheme submission for payment %s; holding in VALIDATED", payment.id)
-            payment
-        }
-    }
-
-    /**
-     * ADR-0108: book the funds in transaction-service after the scheme confirms ACSC.
-     * On success → SETTLED. On [SettlementUnavailableException] → warn and stay in
-     * SENT_TO_CLEARING; a Temporal retry or operator intervention will complete it.
-     */
-    @Suppress("TooGenericExceptionCaught")
-    private suspend fun attemptSettlement(payment: DomesticPayment): DomesticPayment = try {
-        settlementPort.settle(payment)
-        persistTransition(payment, DomesticPaymentStatus.SETTLED, null, null)
-    } catch (ex: SettlementUnavailableException) {
-        log.warnf(
-            ex,
-            "Settlement unavailable for payment %s; holding in SENT_TO_CLEARING",
-            payment.id,
+        // ADR-0120 Phase 6 (issue #1917): Temporal is the sole orchestrator. DomesticPaymentWorkflow runs
+        // screening → shadow fraud scoring → scheme submission → settle; the legacy in-service flow
+        // (applyScreening/applyFraudGate/submitToScheme/attemptSettlement) is retired. Fire-and-forget
+        // start; the payment is returned RECEIVED and the workflow drives it to its terminal state.
+        val stub = workflowClient.newWorkflowStub(
+            DomesticPaymentWorkflow::class.java,
+            WorkflowOptions.newBuilder()
+                .setTaskQueue(temporalTaskQueue)
+                .setWorkflowId("domestic-payment-${received.id}")
+                .build(),
         )
-        payment
-    } catch (ex: Exception) {
-        log.warnf(
-            ex,
-            "Unexpected error during settlement for payment %s; holding in SENT_TO_CLEARING",
-            payment.id,
-        )
-        payment
-    }
-
-    private fun mapSchemeReason(code: String?): DomesticRejectReason = when (code) {
-        "AC04" -> DomesticRejectReason.BENEFICIARY_ACCOUNT_CLOSED
-        "AC06" -> DomesticRejectReason.BENEFICIARY_ACCOUNT_CLOSED
-        "RC01" -> DomesticRejectReason.INVALID_BANK_CODE
-        "AM05" -> DomesticRejectReason.INSUFFICIENT_FUNDS
-        else -> DomesticRejectReason.TECHNICAL_ERROR
+        WorkflowClient.start(stub::process, received.id)
+        return received
     }
 
     /** Assemble the initial RECEIVED payment from the validated command. */
@@ -282,179 +163,6 @@ class DomesticPaymentService(
             updatedAt = now,
         )
     }
-
-    /**
-     * The fraud gate for a payment screening has cleared (ADR-0084 §4.2). Always scores — the
-     * verdict is metered + audited by fraud-service regardless of enforcement — but only ACTS on
-     * it when `openbank.domestic.fraud.enforcement-enabled` is true (default false, a
-     * runbook-gated rollout flip, same convention as the four-eyes `enforce` toggle). With
-     * enforcement off, or verdict ALLOW, this persists VALIDATED exactly like the pre-Phase-2
-     * shadow path. REVIEW/CHALLENGE hold the payment in RECEIVED (same shape as an AML REVIEW
-     * hold: a case is opened, no further transition, a human releases it) rather than persisting
-     * anything — mirrors [applyScreening]'s own hold-vs-persist split. DECLINE rejects outright.
-     * The adapter is fail-open (`FraudScoringAdapter`), so an unreachable fraud-service always
-     * scores ALLOW here — this gate can only ever add friction, never remove availability.
-     */
-    private suspend fun applyFraudGate(payment: DomesticPayment): DomesticPayment {
-        val outcome = fraudScoringPort.score(
-            FraudScoreCommand(
-                amount = payment.amount,
-                currency = payment.currency,
-                rail = "DOMESTIC",
-                accountId = payment.debtorAccountId,
-                counterpartyId = null,
-            ),
-        )
-        if (outcome.verdict == FraudVerdict.ALLOW) {
-            return persistTransition(payment, DomesticPaymentStatus.VALIDATED, null, null)
-        }
-
-        val mode = if (fraudEnforcementEnabled) "ENFORCED" else "SHADOW"
-        log.infof(
-            "Fraud %s verdict %s (score=%d, rules=%s, reasons=%s) for payment %s",
-            mode,
-            outcome.verdict,
-            outcome.score,
-            outcome.ruleVersion,
-            outcome.reasons,
-            payment.id,
-        )
-        if (!fraudEnforcementEnabled) {
-            return persistTransition(payment, DomesticPaymentStatus.VALIDATED, null, null)
-        }
-
-        val detail = "verdict=${outcome.verdict} score=${outcome.score} rules=${outcome.ruleVersion} " +
-            "reasons=${outcome.reasons.joinToString()}"
-        return when (outcome.verdict) {
-            FraudVerdict.DECLINE -> {
-                openCaseQuietly(payment, AmlCaseRiskLevel.CRITICAL, ALERT_FRAUD_REVIEW, detail, null)
-                persistTransition(payment, DomesticPaymentStatus.REJECTED, DomesticRejectReason.FRAUD_SUSPECTED, detail)
-            }
-            FraudVerdict.REVIEW, FraudVerdict.CHALLENGE -> {
-                openCaseQuietly(payment, AmlCaseRiskLevel.HIGH, ALERT_FRAUD_REVIEW, detail, null)
-                payment
-            }
-            FraudVerdict.ALLOW -> persistTransition(payment, DomesticPaymentStatus.VALIDATED, null, null)
-        }
-    }
-
-    /**
-     * Screens both names and applies the [ScreeningPolicy] verdict (ADR-0032 §B). Fails closed
-     * (§C): if the sanctions service is unreachable the payment is held in RECEIVED, never released.
-     */
-    private suspend fun applyScreening(payment: DomesticPayment): DomesticPayment {
-        if (payment.transferScope == DomesticTransferScope.OWN_ACCOUNTS ||
-            payment.transferScope == DomesticTransferScope.TECHNICAL_ACCOUNT
-        ) {
-            log.infof("%s payment %s — screening skipped (SDD)", payment.transferScope, payment.id)
-            return persistTransition(payment, DomesticPaymentStatus.VALIDATED, null, null)
-        }
-
-        val results = try {
-            listOf(
-                screeningPort.screen(payment.debtorName, ScreeningRole.DEBTOR, "${payment.id}:debtor"),
-                screeningPort.screen(payment.creditorName, ScreeningRole.CREDITOR, "${payment.id}:creditor"),
-            )
-        } catch (ex: ScreeningUnavailableException) {
-            log.warnf(ex, "Sanctions screening unavailable for payment %s; holding in RECEIVED", payment.id)
-            openCaseQuietly(payment, AmlCaseRiskLevel.MEDIUM, ALERT_SCREENING_UNAVAILABLE, ex.message, null)
-            return payment
-        }
-
-        results.forEach { result ->
-            metrics.sanctionsScreening(result.role.name.lowercase())
-        }
-
-        return when (ScreeningPolicy.decide(results)) {
-            ScreeningDecision.CLEAR -> applyFraudGate(payment)
-
-            ScreeningDecision.REVIEW -> {
-                results.filter {
-                    it.status != ScreeningMatchStatus.CLEAR && it.status != ScreeningMatchStatus.WHITELISTED
-                }.forEach { metrics.sanctionsHit(it.role.name.lowercase(), "review") }
-                openCaseQuietly(payment, AmlCaseRiskLevel.HIGH, ALERT_AML_HOLD, detail(results), matchedEntity(results))
-                payment
-            }
-
-            ScreeningDecision.BLOCK -> {
-                results.filter {
-                    it.status != ScreeningMatchStatus.CLEAR && it.status != ScreeningMatchStatus.WHITELISTED
-                }.forEach { metrics.sanctionsHit(it.role.name.lowercase(), "block") }
-                val detail = detail(results)
-                openCaseQuietly(payment, AmlCaseRiskLevel.CRITICAL, ALERT_SANCTIONS_HIT, detail, matchedEntity(results))
-                persistTransition(payment, DomesticPaymentStatus.REJECTED, DomesticRejectReason.SANCTIONS_HIT, detail)
-            }
-        }
-    }
-
-    private suspend fun persistTransition(
-        payment: DomesticPayment,
-        target: DomesticPaymentStatus,
-        reason: DomesticRejectReason?,
-        detail: String?,
-    ): DomesticPayment {
-        val now = Instant.now(clock)
-        val updated = payment.transitionTo(target, reason, detail, clock)
-        val saved = paymentRepository.update(
-            payment = updated,
-            outboxMessage = OutboxMessage(
-                aggregateId = updated.id,
-                eventType = PAYMENT_STATUS_CHANGED_EVENT,
-                payload = eventPublisher.statusChangedPayload(payment, updated),
-            ),
-        )
-        val terminalOutcomes = setOf(
-            DomesticPaymentStatus.SETTLED,
-            DomesticPaymentStatus.REJECTED,
-            DomesticPaymentStatus.RETURNED,
-            DomesticPaymentStatus.CANCELLED,
-        )
-        if (target in terminalOutcomes) {
-            val outcome = target.name.lowercase()
-            metrics.paymentCompleted("domestic", payment.currency, outcome)
-            metrics.paymentProcessingDuration(
-                "domestic",
-                outcome,
-                Duration.between(payment.createdAt, now),
-            )
-        }
-        return saved
-    }
-
-    /** Opening the AML case is best-effort: a case-store outage must not flip the screening verdict. */
-    private suspend fun openCaseQuietly(
-        payment: DomesticPayment,
-        riskLevel: AmlCaseRiskLevel,
-        alertCode: String,
-        detail: String?,
-        matchedEntity: String?,
-    ) {
-        try {
-            amlCasePort.openCase(
-                OpenAmlCaseCommand(
-                    idempotencyKey = "aml-${payment.id}-$alertCode",
-                    paymentId = payment.id,
-                    debtorAccountId = payment.debtorAccountId,
-                    customerReference =
-                    "${payment.debtorName} / ${payment.debtorAccountNumber}/${payment.debtorBankCode}",
-                    riskLevel = riskLevel,
-                    alertCode = alertCode,
-                    alertDetail = detail,
-                    matchedEntity = matchedEntity,
-                ),
-            )
-        } catch (ex: Exception) {
-            log.errorf(ex, "Failed to open AML case (%s) for payment %s", alertCode, payment.id)
-        }
-    }
-
-    private fun detail(results: List<ScreeningResult>): String =
-        results.filter { it.status != ScreeningMatchStatus.CLEAR && it.status != ScreeningMatchStatus.WHITELISTED }
-            .joinToString("; ") { "${it.role} '${it.subject}' ${it.status} score=${it.score}" }
-            .ifBlank { "no actionable matches" }
-
-    private fun matchedEntity(results: List<ScreeningResult>): String? =
-        results.firstNotNullOfOrNull { it.matchedEntity }
 
     override suspend fun getPayment(paymentId: UUID): DomesticPayment =
         paymentRepository.findById(paymentId) ?: throw DomesticPaymentNotFoundException(paymentId)

--- a/openbank-domestic-payment/src/main/kotlin/com/openbank/domestic/application/workflow/DomesticPaymentWorkerRegistrar.kt
+++ b/openbank-domestic-payment/src/main/kotlin/com/openbank/domestic/application/workflow/DomesticPaymentWorkerRegistrar.kt
@@ -14,8 +14,8 @@ import org.jboss.logging.Logger
 
 @ApplicationScoped
 class DomesticPaymentWorkerRegistrar(
-    @ConfigProperty(name = "openbank.temporal.enabled", defaultValue = "false")
-    private val enabled: Boolean,
+    @ConfigProperty(name = "openbank.domestic.worker.enabled", defaultValue = "true")
+    private val workerEnabled: Boolean,
     @ConfigProperty(name = "openbank.temporal.task-queue", defaultValue = "openbank-domestic-payments")
     private val taskQueue: String,
     private val workflowClient: WorkflowClient,
@@ -26,8 +26,13 @@ class DomesticPaymentWorkerRegistrar(
 
     @Suppress("UnusedParameter")
     fun onStart(@Observes event: StartupEvent) {
-        if (!enabled) {
-            log.info("Temporal worker disabled (openbank.temporal.enabled=false); skipping registration")
+        // ADR-0120 Phase 6 (issue #1917): Temporal is the sole orchestrator, so the worker registers by
+        // default in production. Worker registration is gated separately from dispatch by
+        // openbank.domestic.worker.enabled (default true) so @QuarkusTest runs — which have no real
+        // Temporal frontend and drive their own in-process TestWorkflowEnvironment — set it false and
+        // don't fail boot on UNAVAILABLE (mirrors settlement / sepa-payment / transaction-service).
+        if (!workerEnabled) {
+            log.info("Temporal domestic worker registration disabled (openbank.domestic.worker.enabled=false)")
             return
         }
         log.infof("Registering Temporal worker on task queue '%s'", taskQueue)

--- a/openbank-domestic-payment/src/main/kotlin/com/openbank/domestic/application/workflow/DomesticPaymentWorkflowImpl.kt
+++ b/openbank-domestic-payment/src/main/kotlin/com/openbank/domestic/application/workflow/DomesticPaymentWorkflowImpl.kt
@@ -46,6 +46,12 @@ class DomesticPaymentWorkflowImpl : DomesticPaymentWorkflow {
             }
             ScreeningDecision.CLEAR -> {
                 activities.validatePayment(paymentId)
+                // ADR-0084 §4.2 (SHADOW): score fraud on the payment that cleared screening and is
+                // proceeding — observed, never enforced, fail-open via the adapter. Issue #1917: the
+                // legacy DomesticPaymentService flow ran this after screening cleared; the workflow
+                // defined the activity but never invoked it, so making Temporal the sole orchestrator
+                // would have silently dropped shadow fraud scoring. Restored here.
+                activities.shadowFraudScore(paymentId)
                 val schemeStatus = activities.submitScheme(paymentId)
                 // ADR-0108: if scheme accepted (SENT_TO_CLEARING), book the funds.
                 if (schemeStatus == DomesticPaymentStatus.SENT_TO_CLEARING) {

--- a/openbank-domestic-payment/src/main/kotlin/com/openbank/domestic/infrastructure/temporal/TemporalClientProducer.kt
+++ b/openbank-domestic-payment/src/main/kotlin/com/openbank/domestic/infrastructure/temporal/TemporalClientProducer.kt
@@ -25,7 +25,8 @@ class TemporalClientProducer(
     private val meterRegistry: MeterRegistry,
 ) {
 
-    // Lazy so no TCP connection attempt happens when temporal.enabled=false.
+    // Lazy so no TCP connection attempt happens until the client is first used (e.g. tests that set
+    // openbank.domestic.worker.enabled=false and never dispatch a workflow never open a connection).
     private val client: WorkflowClient by lazy {
         val scope = RootScopeBuilder()
             .reporter(MicrometerClientStatsReporter(meterRegistry))

--- a/openbank-domestic-payment/src/main/resources/application.yaml
+++ b/openbank-domestic-payment/src/main/resources/application.yaml
@@ -145,6 +145,12 @@ mp:
       enabled: false
     devservices:
       enabled: false
+  openbank:
+    domestic:
+      # No real Temporal frontend in @QuarkusTest: don't register the worker (it would fail boot on
+      # UNAVAILABLE). Tests that need the workflow drive their own in-process TestWorkflowEnvironment.
+      worker:
+        enabled: false
 openbank:
   bank:
     bic: ${OPENBANK_BIC:OPBKCZ22}

--- a/openbank-domestic-payment/src/test/kotlin/com/openbank/domestic/application/usecase/DomesticPaymentServiceTemporalTest.kt
+++ b/openbank-domestic-payment/src/test/kotlin/com/openbank/domestic/application/usecase/DomesticPaymentServiceTemporalTest.kt
@@ -1,0 +1,147 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright (c) OpenBank contributors. Licensed under the Apache License, Version 2.0.
+// See LICENSE in the repository root or https://www.apache.org/licenses/LICENSE-2.0 for details.
+
+package com.openbank.domestic.application.usecase
+
+import com.openbank.domestic.application.port.`in`.CreateDomesticPaymentCommand
+import com.openbank.domestic.application.port.out.AccountLookupPort
+import com.openbank.domestic.application.port.out.DomesticPaymentEventPublisher
+import com.openbank.domestic.application.port.out.DomesticPaymentRepository
+import com.openbank.domestic.application.workflow.DomesticPaymentWorkflow
+import com.openbank.domestic.domain.model.DomesticPaymentPriority
+import com.openbank.domestic.domain.model.DomesticPaymentStatus
+import com.openbank.domestic.domain.model.DomesticTransferScope
+import com.openbank.libs.observability.DomainMetrics
+import io.mockk.coEvery
+import io.mockk.every
+import io.mockk.mockk
+import io.temporal.testing.TestWorkflowEnvironment
+import io.temporal.worker.Worker
+import kotlinx.coroutines.runBlocking
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.AfterEach
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Test
+import java.math.BigDecimal
+import java.util.UUID
+
+/**
+ * Coverage for [DomesticPaymentService.createPayment]'s Temporal dispatch — the sole orchestration path
+ * since ADR-0120 Phase 6 (issue #1917) retired the legacy in-service flow — driven against a real
+ * in-memory [TestWorkflowEnvironment] rather than mocking Temporal's static `WorkflowClient.start`.
+ * A fresh payment is persisted RECEIVED with its server-derived transferScope and its workflow started
+ * fire-and-forget; the workflow's screening/fraud/scheme routing is covered by DomesticPaymentWorkflowImplTest.
+ */
+class DomesticPaymentServiceTemporalTest {
+
+    private val repo: DomesticPaymentRepository = mockk()
+    private val eventPublisher: DomesticPaymentEventPublisher = mockk()
+    private val accountLookupPort: AccountLookupPort = mockk()
+    private val metrics: DomainMetrics = mockk(relaxed = true)
+
+    private lateinit var env: TestWorkflowEnvironment
+    private lateinit var worker: Worker
+    private lateinit var service: DomesticPaymentService
+
+    private companion object {
+        const val TASK_QUEUE = "openbank-domestic-payments"
+    }
+
+    @BeforeEach
+    fun setUp() {
+        env = TestWorkflowEnvironment.newInstance()
+        worker = env.newWorker(TASK_QUEUE)
+        worker.registerWorkflowImplementationTypes(NoOpDomesticPaymentWorkflow::class.java)
+        env.start()
+        service = DomesticPaymentService(
+            repo,
+            eventPublisher,
+            accountLookupPort,
+            metrics,
+            TASK_QUEUE,
+            env.workflowClient,
+        )
+
+        coEvery { repo.save(any(), any()) } answers { firstArg() }
+        coEvery { accountLookupPort.findPartyByIban(any()) } returns null
+        every { eventPublisher.paymentCreatedPayload(any()) } returns "{\"event\":\"created\"}"
+    }
+
+    @AfterEach
+    fun tearDown() {
+        env.close()
+    }
+
+    @Test
+    fun `createPayment persists RECEIVED and dispatches the Temporal workflow`() {
+        coEvery { repo.findByIdempotencyKey("dom-idem-new") } returns null
+
+        val result = runBlocking { service.createPayment(command()) }
+
+        // createPayment returns the freshly-persisted RECEIVED row; the workflow drives it onward
+        // asynchronously (routing verified in DomesticPaymentWorkflowImplTest).
+        assertThat(result.status).isEqualTo(DomesticPaymentStatus.RECEIVED)
+        assertThat(result.currency).isEqualTo("CZK")
+    }
+
+    @Test
+    fun `createPayment derives EXTERNAL scope for a non-own-bank creditor`() {
+        coEvery { repo.findByIdempotencyKey(any()) } returns null
+
+        val result = runBlocking { service.createPayment(command(creditorBankCode = " 0100 ")) }
+
+        assertThat(result.transferScope).isEqualTo(DomesticTransferScope.EXTERNAL)
+    }
+
+    @Test
+    fun `createPayment derives INTERNAL_CLIENT scope for an own-bank creditor with unknown party`() {
+        coEvery { repo.findByIdempotencyKey(any()) } returns null
+
+        val result = runBlocking { service.createPayment(command(creditorBankCode = "0000")) }
+
+        assertThat(result.transferScope).isEqualTo(DomesticTransferScope.INTERNAL_CLIENT)
+    }
+
+    @Test
+    fun `createPayment derives OWN_ACCOUNTS scope when the own-bank creditor party matches the actor`() {
+        val actorId = UUID.randomUUID()
+        coEvery { repo.findByIdempotencyKey(any()) } returns null
+        coEvery { accountLookupPort.findPartyByIban(any()) } returns actorId
+
+        val result = runBlocking { service.createPayment(command(creditorBankCode = "0000", actorId = actorId)) }
+
+        assertThat(result.transferScope).isEqualTo(DomesticTransferScope.OWN_ACCOUNTS)
+    }
+
+    private fun command(
+        idempotencyKey: String = "dom-idem-new",
+        creditorBankCode: String = " 0100 ",
+        actorId: UUID? = null,
+    ) = CreateDomesticPaymentCommand(
+        idempotencyKey = idempotencyKey,
+        debtorAccountId = UUID.randomUUID(),
+        debtorAccountNumber = " 1234567890 ",
+        debtorBankCode = " 0800 ",
+        debtorName = "  Alice Example ",
+        creditorAccountNumber = " 9876543210 ",
+        creditorBankCode = creditorBankCode,
+        creditorName = "  Brno Utility ",
+        amount = BigDecimal("1500.00"),
+        currency = " czk ",
+        variableSymbol = " 2026001 ",
+        specificSymbol = null,
+        constantSymbol = " 0308 ",
+        messageForPayee = "  Utility bill ",
+        priority = DomesticPaymentPriority.URGENT,
+        technicalAccountCode = null,
+        statementLabel = "  Monthly settlement  ",
+        endToEndId = "   ",
+        actorId = actorId,
+    )
+
+    /** No-op workflow so the dispatch has a registered type on the queue; behaviour is tested elsewhere. */
+    class NoOpDomesticPaymentWorkflow : DomesticPaymentWorkflow {
+        override fun process(paymentId: UUID): DomesticPaymentStatus = DomesticPaymentStatus.RECEIVED
+    }
+}

--- a/openbank-domestic-payment/src/test/kotlin/com/openbank/domestic/application/usecase/DomesticPaymentServiceTest.kt
+++ b/openbank-domestic-payment/src/test/kotlin/com/openbank/domestic/application/usecase/DomesticPaymentServiceTest.kt
@@ -1,35 +1,20 @@
-// SPDX-License-Identifier: Apache-2.0\n// Copyright (c) OpenBank contributors. Licensed under the Apache License, Version 2.0.\n// See LICENSE in the repository root or https://www.apache.org/licenses/LICENSE-2.0 for details.\n
+// SPDX-License-Identifier: Apache-2.0
+// Copyright (c) OpenBank contributors. Licensed under the Apache License, Version 2.0.
+// See LICENSE in the repository root or https://www.apache.org/licenses/LICENSE-2.0 for details.
+
 package com.openbank.domestic.application.usecase
 
 import com.openbank.domestic.application.port.`in`.CreateDomesticPaymentCommand
 import com.openbank.domestic.application.port.`in`.TransitionDomesticPaymentStatusCommand
 import com.openbank.domestic.application.port.out.AccountLookupPort
-import com.openbank.domestic.application.port.out.AmlCasePort
-import com.openbank.domestic.application.port.out.AmlCaseRiskLevel
 import com.openbank.domestic.application.port.out.DomesticPaymentEventPublisher
 import com.openbank.domestic.application.port.out.DomesticPaymentRepository
-import com.openbank.domestic.application.port.out.FraudScoreOutcome
-import com.openbank.domestic.application.port.out.FraudScoringPort
-import com.openbank.domestic.application.port.out.FraudVerdict
-import com.openbank.domestic.application.port.out.SanctionsScreeningPort
-import com.openbank.domestic.application.port.out.SchemeGatewayPort
-import com.openbank.domestic.application.port.out.SchemeSubmissionOutcome
-import com.openbank.domestic.application.port.out.ScreeningUnavailableException
-import com.openbank.domestic.application.port.out.SettlementOutcome
-import com.openbank.domestic.application.port.out.SettlementPort
-import com.openbank.domestic.application.port.out.SettlementUnavailableException
 import com.openbank.domestic.domain.model.DomesticPayment
 import com.openbank.domestic.domain.model.DomesticPaymentPriority
 import com.openbank.domestic.domain.model.DomesticPaymentStatus
-import com.openbank.domestic.domain.model.DomesticRejectReason
 import com.openbank.domestic.domain.model.DomesticTransferScope
-import com.openbank.domestic.domain.screening.ScreeningMatchStatus
-import com.openbank.domestic.domain.screening.ScreeningResult
-import com.openbank.domestic.domain.screening.ScreeningRole
 import com.openbank.libs.observability.DomainMetrics
-import com.openbank.libs.persistence.outbox.OutboxMessage
 import io.mockk.coEvery
-import io.mockk.coJustRun
 import io.mockk.coVerify
 import io.mockk.every
 import io.mockk.mockk
@@ -43,14 +28,18 @@ import java.math.BigDecimal
 import java.time.Instant
 import java.util.UUID
 
+/**
+ * Coverage for [DomesticPaymentService]'s non-orchestration paths: idempotent replay and status
+ * transitions. Since ADR-0120 Phase 6 (issue #1917) retired the legacy in-service flow, `createPayment`
+ * for a NEW payment dispatches the Temporal [com.openbank.domestic.application.workflow.DomesticPaymentWorkflow]
+ * (screening → shadow fraud → scheme → settle) — that dispatch and its scope derivation are covered by
+ * DomesticPaymentServiceTemporalTest, and the workflow routing by DomesticPaymentWorkflowImplTest, both
+ * against a real in-memory TestWorkflowEnvironment. The replay path here returns before any dispatch, so
+ * a relaxed WorkflowClient mock suffices.
+ */
 class DomesticPaymentServiceTest {
     private lateinit var paymentRepository: DomesticPaymentRepository
     private lateinit var eventPublisher: DomesticPaymentEventPublisher
-    private lateinit var screeningPort: SanctionsScreeningPort
-    private lateinit var amlCasePort: AmlCasePort
-    private lateinit var fraudScoringPort: FraudScoringPort
-    private lateinit var schemeGatewayPort: SchemeGatewayPort
-    private lateinit var settlementPort: SettlementPort
     private lateinit var accountLookupPort: AccountLookupPort
     private lateinit var metrics: DomainMetrics
     private lateinit var workflowClient: WorkflowClient
@@ -61,386 +50,35 @@ class DomesticPaymentServiceTest {
     fun setUp() {
         paymentRepository = mockk()
         eventPublisher = mockk()
-        screeningPort = mockk()
-        amlCasePort = mockk()
-        fraudScoringPort = mockk()
-        schemeGatewayPort = mockk()
-        settlementPort = mockk()
         accountLookupPort = mockk()
         metrics = mockk(relaxed = true)
-        workflowClient = mockk()
-        // temporalEnabled = false: these tests cover the synchronous screening/fraud path
-        // (ADR-0101 P2 delegates to Temporal only when enabled), so workflowClient is unused.
-        // fraudEnforcementEnabled = false here — the shadow-mode default; enforcement-specific
-        // tests rebuild the service with it on.
-        service = buildService(fraudEnforcementEnabled = false)
+        workflowClient = mockk(relaxed = true)
+        service = DomesticPaymentService(
+            paymentRepository,
+            eventPublisher,
+            accountLookupPort,
+            metrics,
+            "openbank-domestic-payments",
+            workflowClient,
+        )
 
-        // Account lookup for server-side transferScope derivation: default to null (INTERNAL_CLIENT).
-        coEvery { accountLookupPort.findPartyByIban(any()) } returns null
-
-        // Fraud scoring is SHADOW (ADR-0084): default to ALLOW; never affects the payment outcome.
-        coEvery { fraudScoringPort.score(any()) } returns FraudScoreOutcome(FraudVerdict.ALLOW, 0, "v0", emptyList())
-
-        // Defaults reused by most tests: repo echoes the aggregate, publisher returns opaque payloads.
         coEvery { paymentRepository.save(any(), any()) } answers { firstArg() }
         coEvery { paymentRepository.update(any(), any()) } answers { firstArg() }
         every { eventPublisher.paymentCreatedPayload(any()) } returns "{\"event\":\"created\"}"
         every { eventPublisher.statusChangedPayload(any(), any()) } returns "{\"event\":\"status-changed\"}"
-        coJustRun { amlCasePort.openCase(any()) }
     }
 
-    private fun buildService(fraudEnforcementEnabled: Boolean): DomesticPaymentService = DomesticPaymentService(
-        paymentRepository,
-        eventPublisher,
-        screeningPort,
-        amlCasePort,
-        fraudScoringPort,
-        schemeGatewayPort,
-        settlementPort,
-        accountLookupPort,
-        metrics,
-        temporalEnabled = false,
-        temporalTaskQueue = "openbank-domestic-payments",
-        schemeSubmissionEnabled = false,
-        fraudEnforcementEnabled = fraudEnforcementEnabled,
-        workflowClient = workflowClient,
-    )
-
-    private fun buildServiceWithScheme(): DomesticPaymentService = DomesticPaymentService(
-        paymentRepository,
-        eventPublisher,
-        screeningPort,
-        amlCasePort,
-        fraudScoringPort,
-        schemeGatewayPort,
-        settlementPort,
-        accountLookupPort,
-        metrics,
-        temporalEnabled = false,
-        temporalTaskQueue = "openbank-domestic-payments",
-        schemeSubmissionEnabled = true,
-        fraudEnforcementEnabled = false,
-        workflowClient = workflowClient,
-    )
-
-    private fun clear(role: ScreeningRole) = ScreeningResult("name", role, ScreeningMatchStatus.CLEAR, 0.0, null)
-
     @Test
-    fun `create payment normalizes domestic fields and persists outbox event`(): Unit = runBlocking {
-        val command = createCommand()
+    fun `create payment replays existing domestic payment on idempotency key without dispatching`(): Unit =
+        runBlocking {
+            val existing = payment()
+            coEvery { paymentRepository.findByIdempotencyKey(existing.idempotencyKey) } returns existing
 
-        coEvery { paymentRepository.findByIdempotencyKey(command.idempotencyKey) } returns null
-        coEvery { screeningPort.screen(any(), ScreeningRole.DEBTOR, any()) } returns clear(ScreeningRole.DEBTOR)
-        coEvery { screeningPort.screen(any(), ScreeningRole.CREDITOR, any()) } returns clear(ScreeningRole.CREDITOR)
+            val result = service.createPayment(createCommand(idempotencyKey = existing.idempotencyKey))
 
-        val result = service.createPayment(command)
-
-        assertThat(result.status).isEqualTo(DomesticPaymentStatus.VALIDATED)
-        assertThat(result.currency).isEqualTo("CZK")
-        assertThat(result.priority).isEqualTo(DomesticPaymentPriority.URGENT)
-        assertThat(result.transferScope).isEqualTo(DomesticTransferScope.EXTERNAL) // creditorBankCode="0100" → EXTERNAL
-        assertThat(result.variableSymbol).isEqualTo("2026001")
-        assertThat(result.messageForPayee).isEqualTo("Utility bill")
-        assertThat(result.endToEndId).startsWith("DOMU")
-
-        coVerify {
-            paymentRepository.save(
-                match {
-                    it.creditorName == "Brno Utility" &&
-                        it.statementLabel == "Monthly settlement" &&
-                        it.currency == "CZK"
-                },
-                match<OutboxMessage> {
-                    it.aggregateId == result.id &&
-                        it.eventType == "domestic.payment.created" &&
-                        it.payload.contains("created")
-                },
-            )
+            assertThat(result).isEqualTo(existing)
+            coVerify(exactly = 0) { paymentRepository.save(any(), any()) }
         }
-        // SHADOW: the scorer is consulted on every created payment (ADR-0084 §4.1).
-        coVerify(exactly = 1) { fraudScoringPort.score(any()) }
-    }
-
-    @Test
-    fun `fraud shadow verdict is observed but never enforced`(): Unit = runBlocking {
-        val command = createCommand()
-        coEvery { paymentRepository.findByIdempotencyKey(command.idempotencyKey) } returns null
-        coEvery { screeningPort.screen(any(), ScreeningRole.DEBTOR, any()) } returns clear(ScreeningRole.DEBTOR)
-        coEvery { screeningPort.screen(any(), ScreeningRole.CREDITOR, any()) } returns clear(ScreeningRole.CREDITOR)
-        coEvery { fraudScoringPort.score(any()) } returns
-            FraudScoreOutcome(FraudVerdict.DECLINE, 99, "v0", listOf("velocity-cap"))
-
-        val result = service.createPayment(command)
-
-        assertThat(result.status).isEqualTo(DomesticPaymentStatus.VALIDATED)
-        coVerify(exactly = 1) { fraudScoringPort.score(any()) }
-    }
-
-    @Test
-    fun `enforced DECLINE verdict rejects the payment and opens a CRITICAL fraud case`(): Unit = runBlocking {
-        val enforced = buildService(fraudEnforcementEnabled = true)
-        val command = createCommand()
-        coEvery { paymentRepository.findByIdempotencyKey(command.idempotencyKey) } returns null
-        coEvery { screeningPort.screen(any(), any(), any()) } returns clear(ScreeningRole.DEBTOR)
-        coEvery { fraudScoringPort.score(any()) } returns
-            FraudScoreOutcome(FraudVerdict.DECLINE, 99, "v4", listOf("velocity-cap"))
-
-        val result = enforced.createPayment(command)
-
-        assertThat(result.status).isEqualTo(DomesticPaymentStatus.REJECTED)
-        assertThat(result.rejectReason).isEqualTo(DomesticRejectReason.FRAUD_SUSPECTED)
-        coVerify {
-            amlCasePort.openCase(
-                match { it.riskLevel == AmlCaseRiskLevel.CRITICAL && it.alertCode == "FRAUD_REVIEW" },
-            )
-        }
-    }
-
-    @Test
-    fun `enforced REVIEW verdict holds the payment in RECEIVED and opens a HIGH fraud case`(): Unit = runBlocking {
-        val enforced = buildService(fraudEnforcementEnabled = true)
-        val command = createCommand()
-        coEvery { paymentRepository.findByIdempotencyKey(command.idempotencyKey) } returns null
-        coEvery { screeningPort.screen(any(), any(), any()) } returns clear(ScreeningRole.DEBTOR)
-        coEvery { fraudScoringPort.score(any()) } returns
-            FraudScoreOutcome(FraudVerdict.REVIEW, 60, "v4", listOf("new-payee-high-amount"))
-
-        val result = enforced.createPayment(command)
-
-        assertThat(result.status).isEqualTo(DomesticPaymentStatus.RECEIVED)
-        coVerify {
-            amlCasePort.openCase(
-                match { it.riskLevel == AmlCaseRiskLevel.HIGH && it.alertCode == "FRAUD_REVIEW" },
-            )
-        }
-        coVerify(exactly = 0) { paymentRepository.update(any(), any()) }
-    }
-
-    @Test
-    fun `enforced CHALLENGE verdict also holds the payment for manual release`(): Unit = runBlocking {
-        val enforced = buildService(fraudEnforcementEnabled = true)
-        val command = createCommand()
-        coEvery { paymentRepository.findByIdempotencyKey(command.idempotencyKey) } returns null
-        coEvery { screeningPort.screen(any(), any(), any()) } returns clear(ScreeningRole.DEBTOR)
-        coEvery { fraudScoringPort.score(any()) } returns
-            FraudScoreOutcome(FraudVerdict.CHALLENGE, 40, "v4", listOf("velocity-h1"))
-
-        val result = enforced.createPayment(command)
-
-        assertThat(result.status).isEqualTo(DomesticPaymentStatus.RECEIVED)
-        coVerify(exactly = 0) { paymentRepository.update(any(), any()) }
-    }
-
-    @Test
-    fun `enforced ALLOW verdict validates the payment exactly like shadow mode`(): Unit = runBlocking {
-        val enforced = buildService(fraudEnforcementEnabled = true)
-        val command = createCommand()
-        coEvery { paymentRepository.findByIdempotencyKey(command.idempotencyKey) } returns null
-        coEvery { screeningPort.screen(any(), any(), any()) } returns clear(ScreeningRole.DEBTOR)
-        coEvery { fraudScoringPort.score(any()) } returns FraudScoreOutcome(FraudVerdict.ALLOW, 0, "v4", emptyList())
-
-        val result = enforced.createPayment(command)
-
-        assertThat(result.status).isEqualTo(DomesticPaymentStatus.VALIDATED)
-        coVerify(exactly = 0) { amlCasePort.openCase(any()) }
-    }
-
-    @Test
-    fun `create payment replays existing domestic payment on idempotency key`(): Unit = runBlocking {
-        val existing = payment()
-        coEvery { paymentRepository.findByIdempotencyKey(existing.idempotencyKey) } returns existing
-
-        val result = service.createPayment(createCommand(idempotencyKey = existing.idempotencyKey))
-
-        assertThat(result).isEqualTo(existing)
-        coVerify(exactly = 0) { paymentRepository.save(any(), any()) }
-    }
-
-    @Test
-    fun `create payment derives EXTERNAL scope for non-own-bank creditor`() = runBlocking<Unit> {
-        val command = createCommand() // creditorBankCode = "0100" → EXTERNAL
-
-        coEvery { paymentRepository.findByIdempotencyKey(command.idempotencyKey) } returns null
-        coEvery { screeningPort.screen(any(), ScreeningRole.DEBTOR, any()) } returns clear(ScreeningRole.DEBTOR)
-        coEvery { screeningPort.screen(any(), ScreeningRole.CREDITOR, any()) } returns clear(ScreeningRole.CREDITOR)
-
-        val result = service.createPayment(command)
-
-        assertThat(result.transferScope).isEqualTo(DomesticTransferScope.EXTERNAL)
-    }
-
-    @Test
-    fun `create payment derives INTERNAL_CLIENT scope for own-bank creditor unknown party`() = runBlocking<Unit> {
-        val command = createCommand(creditorBankCode = "0000")
-
-        coEvery { paymentRepository.findByIdempotencyKey(command.idempotencyKey) } returns null
-        coEvery { screeningPort.screen(any(), ScreeningRole.DEBTOR, any()) } returns clear(ScreeningRole.DEBTOR)
-        coEvery { screeningPort.screen(any(), ScreeningRole.CREDITOR, any()) } returns clear(ScreeningRole.CREDITOR)
-
-        val result = service.createPayment(command)
-
-        assertThat(result.transferScope).isEqualTo(DomesticTransferScope.INTERNAL_CLIENT)
-    }
-
-    @Test
-    fun `own accounts path persists correctly`(): Unit = runBlocking {
-        val actorId = UUID.randomUUID()
-        // own-bank creditor whose partyId matches the actor → OWN_ACCOUNTS
-        coEvery { accountLookupPort.findPartyByIban(any()) } returns actorId
-        val command = createCommand(
-            creditorBankCode = "0000",
-            actorId = actorId,
-            technicalAccountCode = null,
-        )
-
-        coEvery { paymentRepository.findByIdempotencyKey(command.idempotencyKey) } returns null
-        coEvery { settlementPort.settle(any()) } returns SettlementOutcome(settled = true, transactionId = null)
-
-        val result = service.createPayment(command)
-
-        assertThat(result.transferScope).isEqualTo(DomesticTransferScope.OWN_ACCOUNTS)
-        coVerify {
-            paymentRepository.save(
-                match {
-                    it.transferScope == DomesticTransferScope.OWN_ACCOUNTS &&
-                        it.technicalAccountCode == null
-                },
-                any(),
-            )
-        }
-    }
-
-    @Test
-    fun `clean screening validates the payment and persists both outbox messages`(): Unit = runBlocking {
-        val command = createCommand()
-        coEvery { paymentRepository.findByIdempotencyKey(command.idempotencyKey) } returns null
-        coEvery { screeningPort.screen(any(), ScreeningRole.DEBTOR, any()) } returns clear(ScreeningRole.DEBTOR)
-        coEvery { screeningPort.screen(any(), ScreeningRole.CREDITOR, any()) } returns clear(ScreeningRole.CREDITOR)
-
-        val result = service.createPayment(command)
-
-        assertThat(result.status).isEqualTo(DomesticPaymentStatus.VALIDATED)
-        coVerify {
-            paymentRepository.save(
-                match { it.status == DomesticPaymentStatus.RECEIVED && it.idempotencyKey == command.idempotencyKey },
-                match<OutboxMessage> { it.eventType == "domestic.payment.created" },
-            )
-        }
-        coVerify {
-            paymentRepository.update(
-                match { it.status == DomesticPaymentStatus.VALIDATED },
-                match<OutboxMessage> { it.eventType == "domestic.payment.status-changed" },
-            )
-        }
-        coVerify(exactly = 0) { amlCasePort.openCase(any()) }
-    }
-
-    @Test
-    fun `sanctioned creditor rejects the payment and opens a CRITICAL aml case`(): Unit = runBlocking {
-        val command = createCommand()
-        coEvery { paymentRepository.findByIdempotencyKey(command.idempotencyKey) } returns null
-        coEvery { screeningPort.screen(any(), ScreeningRole.DEBTOR, any()) } returns clear(ScreeningRole.DEBTOR)
-        coEvery { screeningPort.screen(any(), ScreeningRole.CREDITOR, any()) } returns
-            ScreeningResult(
-                "Brno Utility",
-                ScreeningRole.CREDITOR,
-                ScreeningMatchStatus.HIT,
-                0.97,
-                "BRNO UTILITY / OFAC",
-            )
-
-        val result = service.createPayment(command)
-
-        assertThat(result.status).isEqualTo(DomesticPaymentStatus.REJECTED)
-        assertThat(result.rejectReason).isEqualTo(DomesticRejectReason.SANCTIONS_HIT)
-        coVerify {
-            amlCasePort.openCase(
-                match {
-                    it.riskLevel == AmlCaseRiskLevel.CRITICAL &&
-                        it.alertCode == "SANCTIONS_HIT" &&
-                        it.paymentId == result.id &&
-                        it.matchedEntity == "BRNO UTILITY / OFAC"
-                },
-            )
-        }
-        coVerify { paymentRepository.update(match { it.status == DomesticPaymentStatus.REJECTED }, any()) }
-    }
-
-    @Test
-    fun `sub-threshold potential hit holds the payment in RECEIVED and opens a HIGH aml case`(): Unit = runBlocking {
-        val command = createCommand()
-        coEvery { paymentRepository.findByIdempotencyKey(command.idempotencyKey) } returns null
-        coEvery { screeningPort.screen(any(), ScreeningRole.DEBTOR, any()) } returns clear(ScreeningRole.DEBTOR)
-        coEvery { screeningPort.screen(any(), ScreeningRole.CREDITOR, any()) } returns
-            ScreeningResult(
-                "Brno Utility",
-                ScreeningRole.CREDITOR,
-                ScreeningMatchStatus.POTENTIAL_HIT,
-                0.50,
-                "B. UTILITY",
-            )
-
-        val result = service.createPayment(command)
-
-        assertThat(result.status).isEqualTo(DomesticPaymentStatus.RECEIVED)
-        coVerify {
-            amlCasePort.openCase(
-                match { it.riskLevel == AmlCaseRiskLevel.HIGH && it.alertCode == "AML_HOLD" },
-            )
-        }
-        coVerify(exactly = 0) { paymentRepository.update(any(), any()) }
-    }
-
-    @Test
-    fun `screening unavailable holds the payment in RECEIVED and opens a MEDIUM aml case`(): Unit = runBlocking {
-        val command = createCommand()
-        coEvery { paymentRepository.findByIdempotencyKey(command.idempotencyKey) } returns null
-        coEvery {
-            screeningPort.screen(any(), any(), any())
-        } throws ScreeningUnavailableException(RuntimeException("down"))
-
-        val result = service.createPayment(command)
-
-        assertThat(result.status).isEqualTo(DomesticPaymentStatus.RECEIVED)
-        coVerify {
-            amlCasePort.openCase(
-                match { it.riskLevel == AmlCaseRiskLevel.MEDIUM && it.alertCode == "SCREENING_UNAVAILABLE" },
-            )
-        }
-        coVerify(exactly = 0) { paymentRepository.update(any(), any()) }
-    }
-
-    @Test
-    fun `scheme ACSC followed by successful settlement transitions payment to SETTLED`(): Unit = runBlocking {
-        val serviceWithScheme = buildServiceWithScheme()
-        val command = createCommand()
-        coEvery { paymentRepository.findByIdempotencyKey(command.idempotencyKey) } returns null
-        coEvery {
-            screeningPort.screen(any(), any(), any())
-        } returns clear(ScreeningRole.DEBTOR)
-        coEvery { schemeGatewayPort.submit(any()) } returns SchemeSubmissionOutcome(accepted = true, reasonCode = null)
-        coEvery { settlementPort.settle(any()) } returns SettlementOutcome(settled = true, transactionId = null)
-
-        val result = serviceWithScheme.createPayment(command)
-
-        assertThat(result.status).isEqualTo(DomesticPaymentStatus.SETTLED)
-    }
-
-    @Test
-    fun `settlement unavailable holds payment in SENT_TO_CLEARING`(): Unit = runBlocking {
-        val serviceWithScheme = buildServiceWithScheme()
-        val command = createCommand()
-        coEvery { paymentRepository.findByIdempotencyKey(command.idempotencyKey) } returns null
-        coEvery {
-            screeningPort.screen(any(), any(), any())
-        } returns clear(ScreeningRole.DEBTOR)
-        coEvery { schemeGatewayPort.submit(any()) } returns SchemeSubmissionOutcome(accepted = true, reasonCode = null)
-        coEvery { settlementPort.settle(any()) } throws SettlementUnavailableException("tx-service down")
-
-        val result = serviceWithScheme.createPayment(command)
-
-        assertThat(result.status).isEqualTo(DomesticPaymentStatus.SENT_TO_CLEARING)
-    }
 
     @Test
     fun `transition to rejected requires reject reason`() {

--- a/openbank-domestic-payment/src/test/kotlin/com/openbank/domestic/application/workflow/DomesticPaymentWorkflowImplTest.kt
+++ b/openbank-domestic-payment/src/test/kotlin/com/openbank/domestic/application/workflow/DomesticPaymentWorkflowImplTest.kt
@@ -1,0 +1,96 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright (c) OpenBank contributors. Licensed under the Apache License, Version 2.0.
+// See LICENSE in the repository root or https://www.apache.org/licenses/LICENSE-2.0 for details.
+
+package com.openbank.domestic.application.workflow
+
+import com.openbank.domestic.domain.model.DomesticPaymentStatus
+import com.openbank.domestic.domain.screening.ScreeningDecision
+import io.mockk.every
+import io.mockk.mockk
+import io.mockk.verify
+import io.mockk.verifyOrder
+import io.temporal.client.WorkflowOptions
+import io.temporal.testing.TestWorkflowEnvironment
+import io.temporal.worker.Worker
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.AfterEach
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Test
+import java.util.UUID
+
+class DomesticPaymentWorkflowImplTest {
+
+    private lateinit var env: TestWorkflowEnvironment
+    private lateinit var worker: Worker
+    private lateinit var activities: DomesticPaymentActivities
+
+    companion object {
+        private const val TASK_QUEUE = "test-domestic-payments"
+    }
+
+    @BeforeEach
+    fun setUp() {
+        env = TestWorkflowEnvironment.newInstance()
+        worker = env.newWorker(TASK_QUEUE)
+        worker.registerWorkflowImplementationTypes(DomesticPaymentWorkflowImpl::class.java)
+        activities = mockk(relaxed = true)
+        worker.registerActivitiesImplementations(activities)
+        env.start()
+    }
+
+    @AfterEach
+    fun tearDown() {
+        env.close()
+    }
+
+    private fun workflowStub(): DomesticPaymentWorkflow = env.workflowClient.newWorkflowStub(
+        DomesticPaymentWorkflow::class.java,
+        WorkflowOptions.newBuilder().setTaskQueue(TASK_QUEUE).build(),
+    )
+
+    @Test
+    fun `CLEAR decision validates, shadow-scores fraud, submits to scheme and settles (issue #1917)`() {
+        val paymentId = UUID.randomUUID()
+        every { activities.screenPayment(paymentId) } returns ScreeningDecision.CLEAR
+        every { activities.validatePayment(paymentId) } returns Unit
+        every { activities.submitScheme(paymentId) } returns DomesticPaymentStatus.SENT_TO_CLEARING
+        every { activities.settlePayment(paymentId) } returns DomesticPaymentStatus.SETTLED
+
+        val result = workflowStub().process(paymentId)
+
+        assertThat(result).isEqualTo(DomesticPaymentStatus.SETTLED)
+        // #1917: the workflow defined shadowFraudScore but never called it, so making Temporal the sole
+        // orchestrator would have silently dropped ADR-0084 shadow fraud scoring. It now runs between
+        // validation and scheme submission, matching the retired legacy DomesticPaymentService flow.
+        verifyOrder {
+            activities.validatePayment(paymentId)
+            activities.shadowFraudScore(paymentId)
+            activities.submitScheme(paymentId)
+        }
+    }
+
+    @Test
+    fun `BLOCK decision rejects payment and returns REJECTED`() {
+        val paymentId = UUID.randomUUID()
+        every { activities.screenPayment(paymentId) } returns ScreeningDecision.BLOCK
+        every { activities.rejectPayment(paymentId) } returns Unit
+
+        val result = workflowStub().process(paymentId)
+
+        assertThat(result).isEqualTo(DomesticPaymentStatus.REJECTED)
+        verify { activities.rejectPayment(paymentId) }
+    }
+
+    @Test
+    fun `REVIEW decision returns RECEIVED without validation or fraud scoring`() {
+        val paymentId = UUID.randomUUID()
+        every { activities.screenPayment(paymentId) } returns ScreeningDecision.REVIEW
+
+        val result = workflowStub().process(paymentId)
+
+        assertThat(result).isEqualTo(DomesticPaymentStatus.RECEIVED)
+        verify(exactly = 0) { activities.validatePayment(any()) }
+        verify(exactly = 0) { activities.shadowFraudScore(any()) }
+    }
+}

--- a/openbank-domestic-payment/src/test/kotlin/com/openbank/domestic/infrastructure/temporal/WorkflowClientTestProducer.kt
+++ b/openbank-domestic-payment/src/test/kotlin/com/openbank/domestic/infrastructure/temporal/WorkflowClientTestProducer.kt
@@ -1,0 +1,54 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright (c) OpenBank contributors. Licensed under the Apache License, Version 2.0.
+// See LICENSE in the repository root or https://www.apache.org/licenses/LICENSE-2.0 for details.
+
+package com.openbank.domestic.infrastructure.temporal
+
+import com.openbank.domestic.application.workflow.DomesticPaymentWorkflow
+import com.openbank.domestic.domain.model.DomesticPaymentStatus
+import io.temporal.client.WorkflowClient
+import io.temporal.testing.TestWorkflowEnvironment
+import jakarta.annotation.PostConstruct
+import jakarta.annotation.PreDestroy
+import jakarta.annotation.Priority
+import jakarta.enterprise.context.ApplicationScoped
+import jakarta.enterprise.inject.Alternative
+import jakarta.enterprise.inject.Produces
+import java.util.UUID
+
+/**
+ * Replaces the real Temporal [WorkflowClient] in @QuarkusTest with an in-process
+ * [TestWorkflowEnvironment], so a REST call that creates a payment (→ `DomesticPaymentService.createPayment`,
+ * which is Temporal-only since ADR-0120 Phase 6 / issue #1917 retired the legacy in-service flow)
+ * dispatches to a deterministic no-op workflow instead of connecting to a real frontend (which does not
+ * exist in the test JVM). Mirrors settlement-service / sepa-payment / transaction-service. The worker
+ * itself stays off in tests (`openbank.domestic.worker.enabled=false`); this env registers its own no-op worker.
+ */
+@ApplicationScoped
+@Alternative
+@Priority(1)
+class WorkflowClientTestProducer {
+
+    private lateinit var testEnv: TestWorkflowEnvironment
+
+    @PostConstruct
+    fun start() {
+        testEnv = TestWorkflowEnvironment.newInstance()
+        testEnv.newWorker("openbank-domestic-payments")
+            .registerWorkflowImplementationTypes(NoOpDomesticPaymentWorkflow::class.java)
+        testEnv.start()
+    }
+
+    @Produces
+    @ApplicationScoped
+    fun workflowClient(): WorkflowClient = testEnv.workflowClient
+
+    @PreDestroy
+    fun stop() {
+        if (::testEnv.isInitialized) testEnv.close()
+    }
+
+    class NoOpDomesticPaymentWorkflow : DomesticPaymentWorkflow {
+        override fun process(paymentId: UUID): DomesticPaymentStatus = DomesticPaymentStatus.RECEIVED
+    }
+}


### PR DESCRIPTION
Completes **#1917** (ADR-0120 Phase 6). domestic-payment is the **last** of the three dual-saga services — after settlement (#2066) and sepa (#2110) — to retire its hand-rolled in-service orchestration.

## What changes
- `createPayment` no longer branches on `openbank.temporal.enabled` (removed) — it always dispatches `DomesticPaymentWorkflow` (screening → shadow fraud → scheme submission → settle).
- The in-service legacy flow (`applyScreening`/`applyFraudGate`/`submitToScheme`/`attemptSettlement` + `mapSchemeReason`/`openCaseQuietly`/`detail`/`matchedEntity`) and its now-unused ports (`SanctionsScreeningPort`/`AmlCasePort`/`FraudScoringPort`/`SchemeGatewayPort`/`SettlementPort` + the `schemeSubmissionEnabled`/`fraudEnforcementEnabled` service flags) are **deleted**.
- `buildReceivedPayment`, server-side `transferScope` derivation, `persistTransition`, `generateEndToEndId`, and the query/transition endpoints are **unchanged**. The Temporal activities keep their own copies of those ports — no behaviour is lost; the same steps now run durably with retries + reverse compensation.

## Behaviour-equivalence prerequisite (folded in)
The workflow defined the `shadowFraudScore` activity but **never invoked it** — making Temporal the sole orchestrator would have silently dropped ADR-0084 shadow fraud scoring. It now runs between validation and scheme submission, matching the retired flow (asserted by `DomesticPaymentWorkflowImplTest`).

## Tests
- Worker registration gated by `openbank.domestic.worker.enabled` (default true; `%test` false); test `WorkflowClientTestProducer` backs the CDI `WorkflowClient` with an in-process `TestWorkflowEnvironment` (mirrors settlement/sepa/transaction).
- `DomesticPaymentServiceTest` trimmed to the non-orchestration paths (replay, transition); new `DomesticPaymentServiceTemporalTest` drives dispatch + scope derivation against a real `TestWorkflowEnvironment`; new `DomesticPaymentWorkflowImplTest` covers workflow routing.

## Money-path
Threat-model change-log updated (ADR-0030). Sandbox canary this session already confirmed the domestic worker registers + polls `openbank-domestic-payments` and Temporal completes payments end-to-end.

Refs #1917