### PR TITLE
fix(analytics): count SIGN_SUCCESS as the SIGN step's funnel completion

### DIFF
--- a/openbank-analytics-sink/src/main/resources/clickhouse/V2__onboarding_funnel.sql
+++ b/openbank-analytics-sink/src/main/resources/clickhouse/V2__onboarding_funnel.sql
@@ -59,7 +59,10 @@ SELECT
         step = 'SIGN',      6,
         99)                                                     AS step_ordinal,
     uniqExactIf(session_id, action = 'STEP_VIEWED')             AS sessions_viewed,
-    uniqExactIf(session_id, action = 'STEP_COMPLETED')          AS sessions_completed,
+    -- The SIGN step never emits STEP_COMPLETED — its terminal success signal is SIGN_SUCCESS
+    -- (a signature can fail, unlike the earlier steps' unconditional completion). Count that as the
+    -- SIGN step's completion so a signed agreement shows as "completed" in the funnel / conversion.
+    uniqExactIf(session_id, action = 'STEP_COMPLETED' OR (step = 'SIGN' AND action = 'SIGN_SUCCESS')) AS sessions_completed,
     uniqExactIf(session_id, action = 'HOLD_ABANDONED')          AS hold_abandons
 FROM openbank_analytics.gold_onboarding_funnel_events
 GROUP BY day, step;

--- a/openbank-infra/gitops/components/analytics/clickhouse-init-configmap.yaml
+++ b/openbank-infra/gitops/components/analytics/clickhouse-init-configmap.yaml
@@ -316,7 +316,10 @@ data:
             step = 'SIGN',      6,
             99)                                                     AS step_ordinal,
         uniqExactIf(session_id, action = 'STEP_VIEWED')             AS sessions_viewed,
-        uniqExactIf(session_id, action = 'STEP_COMPLETED')          AS sessions_completed,
+        -- The SIGN step never emits STEP_COMPLETED — its terminal success signal is SIGN_SUCCESS
+        -- (a signature can fail, unlike the earlier steps' unconditional completion). Count that as the
+        -- SIGN step's completion so a signed agreement shows as "completed" in the funnel / conversion.
+        uniqExactIf(session_id, action = 'STEP_COMPLETED' OR (step = 'SIGN' AND action = 'SIGN_SUCCESS')) AS sessions_completed,
         uniqExactIf(session_id, action = 'HOLD_ABANDONED')          AS hold_abandons
     FROM openbank_analytics.gold_onboarding_funnel_events
     GROUP BY day, step;


### PR DESCRIPTION
Board showed COMPLETED SIGNATURE=0 / 0% conversion but SIGNATURE SUCCESS=100% — the SIGN step never emits STEP_COMPLETED (its terminal is SIGN_SUCCESS, since a signature can fail). gold_onboarding_funnel_daily now counts `STEP_COMPLETED OR (step='SIGN' AND action='SIGN_SUCCESS')`. Applied live via CREATE OR REPLACE VIEW; this persists it in V2 + the init ConfigMap. Closes part of #1982.

🤖 Generated with [Claude Code](https://claude.com/claude-code)