### PR TITLE
feat(infra): feedback screenshot bucket, 90-day lifecycle and Pod Identity (ADR-0192)

### DIFF
--- a/openbank-infra/aws/envs/sandbox-platform/feedback-screenshots.tf
+++ b/openbank-infra/aws/envs/sandbox-platform/feedback-screenshots.tf
@@ -1,0 +1,139 @@
+# ---------------------------------------------------------------------------
+# In-app screen-feedback screenshots — S3 + Pod Identity for customer-edge (ADR-0192).
+#
+# The app's feedback rail captures a screenshot the user explicitly previews and
+# confirms; customer-edge writes it here and puts only the object KEY on
+# `openbank.feedback.events`, so the image never enters Kafka or the ClickHouse
+# bronze layer (which is retained ≥10 years). One lifecycle-managed bucket is the
+# whole footprint of that decision.
+#
+# Retention is 90 days and it is a BUCKET property on purpose: ADR-0192 commits to
+# storage limitation for personal data, and application code must not be the thing
+# that decides when a screenshot disappears. Erasure-by-party stays possible for the
+# window: the ClickHouse `gold_screen_feedback` view maps party_id -> screenshot_key.
+#
+# Mechanism: EKS Pod Identity (like cost-collector / db-backups — no IRSA
+# annotations); the edge runs as the dedicated `customer-edge` ServiceAccount and
+# the AWS SDK default credentials chain picks it up. Deliberately NOT the namespace's
+# `default` SA: Redis and the OPA sidecar share that namespace and have no business
+# holding S3 credentials.
+#
+# Grant is write-only (no s3:GetObject, no s3:DeleteObject). The edge only ever puts;
+# reading a customer's screenshot is a support/analytics act that must go through a
+# separate, audited identity rather than ride on the internet-facing service's role.
+# ---------------------------------------------------------------------------
+
+resource "aws_s3_bucket" "feedback_screenshots" {
+  bucket        = "${local.cluster_name}-feedback"
+  force_destroy = true # sandbox only — prod must never set this
+  tags          = { Project = "openbank", ManagedBy = "opentofu", Adr = "0192" }
+}
+
+resource "aws_s3_bucket_public_access_block" "feedback_screenshots" {
+  bucket                  = aws_s3_bucket.feedback_screenshots.id
+  block_public_acls       = true
+  block_public_policy     = true
+  ignore_public_acls      = true
+  restrict_public_buckets = true
+}
+
+resource "aws_s3_bucket_server_side_encryption_configuration" "feedback_screenshots" {
+  bucket = aws_s3_bucket.feedback_screenshots.id
+  rule {
+    apply_server_side_encryption_by_default {
+      sse_algorithm = "AES256"
+    }
+  }
+}
+
+data "aws_iam_policy_document" "feedback_screenshots_policy" {
+  statement {
+    sid     = "DenyInsecureTransport"
+    effect  = "Deny"
+    actions = ["s3:*"]
+    resources = [
+      aws_s3_bucket.feedback_screenshots.arn,
+      "${aws_s3_bucket.feedback_screenshots.arn}/*",
+    ]
+    principals {
+      type        = "*"
+      identifiers = ["*"]
+    }
+    condition {
+      test     = "Bool"
+      variable = "aws:SecureTransport"
+      values   = ["false"]
+    }
+  }
+}
+
+resource "aws_s3_bucket_policy" "feedback_screenshots" {
+  bucket     = aws_s3_bucket.feedback_screenshots.id
+  policy     = data.aws_iam_policy_document.feedback_screenshots_policy.json
+  depends_on = [aws_s3_bucket_public_access_block.feedback_screenshots]
+}
+
+resource "aws_s3_bucket_lifecycle_configuration" "feedback_screenshots" {
+  bucket = aws_s3_bucket.feedback_screenshots.id
+  rule {
+    id     = "adr-0192-90-day-retention"
+    status = "Enabled"
+    filter {}
+    # THE storage-limitation control of ADR-0192. Not a cost tweak — do not extend
+    # it without revisiting the GDPR terms the app shows the user.
+    expiration {
+      days = 90
+    }
+    abort_incomplete_multipart_upload {
+      days_after_initiation = 3
+    }
+  }
+}
+
+data "aws_iam_policy_document" "feedback_screenshots_assume" {
+  statement {
+    actions = ["sts:AssumeRole", "sts:TagSession"]
+    principals {
+      type        = "Service"
+      identifiers = ["pods.eks.amazonaws.com"]
+    }
+  }
+}
+
+resource "aws_iam_role" "feedback_screenshots" {
+  name               = "${local.cluster_name}-feedback-screenshots"
+  assume_role_policy = data.aws_iam_policy_document.feedback_screenshots_assume.json
+  tags               = { Project = "openbank", ManagedBy = "opentofu", Adr = "0192" }
+}
+
+data "aws_iam_policy_document" "feedback_screenshots" {
+  statement {
+    sid = "PutScreenshotsOnly"
+    # Write-only, and scoped to the key prefix FeedbackScreenshotStore actually mints.
+    # No ListBucket either: the edge addresses objects by a key it just generated, so
+    # enumerating other customers' screenshots is not a capability it needs.
+    actions   = ["s3:PutObject"]
+    resources = ["${aws_s3_bucket.feedback_screenshots.arn}/customer-edge/feedback/*"]
+  }
+}
+
+resource "aws_iam_role_policy" "feedback_screenshots" {
+  name   = "s3-feedback-write"
+  role   = aws_iam_role.feedback_screenshots.id
+  policy = data.aws_iam_policy_document.feedback_screenshots.json
+}
+
+# The edge's own ServiceAccount (openbank-infra/gitops/components/customer-edge/customer-edge.yaml).
+# The Rollout must set serviceAccountName: customer-edge or the pods keep running as
+# `default` and the association silently never applies — the failure mode is a
+# STORE_FAILED on every submission, not a crash.
+resource "aws_eks_pod_identity_association" "feedback_screenshots" {
+  cluster_name    = local.cluster_name
+  namespace       = "customer-edge"
+  service_account = "customer-edge"
+  role_arn        = aws_iam_role.feedback_screenshots.arn
+}
+
+output "feedback_screenshots_bucket" {
+  value = aws_s3_bucket.feedback_screenshots.bucket
+}

--- a/openbank-infra/gitops/components/customer-edge/customer-edge.yaml
+++ b/openbank-infra/gitops/components/customer-edge/customer-edge.yaml
@@ -3,6 +3,20 @@
 # ownership, proxies an allow-listed route set. Deny-by-default.
 # Progressive delivery via Argo Rollout (ADR-0098 Phase 4): canary 10 %→30 % with
 # Prometheus error-rate / p95-latency analysis before full promotion.
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: customer-edge
+  namespace: customer-edge
+  labels:
+    app.kubernetes.io/name: customer-edge
+    app.kubernetes.io/part-of: customer-edge
+  annotations:
+    # Sync-wave -1: the SA must exist before the Rollout that references it, otherwise
+    # the first sync creates pods that fall back to `default` and never pick up the
+    # EKS Pod Identity credentials.
+    argocd.argoproj.io/sync-wave: "-1"
+---
 apiVersion: argoproj.io/v1alpha1
 kind: Rollout
 metadata:
@@ -53,6 +67,11 @@ spec:
         # Kept in sync by gen-customer-edge-opa-bundle.sh (do not hand-edit).
         openbank.tech/policy-checksum: "3f4eee07f47dc3ba"
     spec:
+      # Dedicated SA so EKS Pod Identity can hand the edge (and ONLY the edge) the
+      # feedback-screenshots S3 role — ADR-0192, openbank-infra/aws/envs/sandbox-platform/
+      # feedback-screenshots.tf. Running as `default` would either lose the credentials
+      # entirely or, if associated, hand them to Redis and the OPA sidecar too.
+      serviceAccountName: customer-edge
       securityContext:
         runAsNonRoot: true
         runAsUser: 100
@@ -213,13 +232,14 @@ spec:
             - name: AUTHZ_ENFORCE
               value: "true"
             # ADR-0192 screen feedback: bucket the confirmed screenshots are written to via the
-            # shared ObjectStorePort. The 90-day expiry lifecycle rule, SSE settings and the EKS
-            # Pod Identity association that gives this pod s3:PutObject are TERRAFORM concerns
-            # (sandbox-platform), not manifest ones. Until they exist the put fails and the
-            # submission is still recorded with screenshotStatus=STORE_FAILED — visible on
-            # gold_screen_feedback_screenshot_health and the FeedbackScreenshotStoreFailing alert.
+            # shared ObjectStorePort. The bucket itself, its 90-day expiry lifecycle rule, the SSE
+            # settings and the EKS Pod Identity association granting s3:PutObject are Terraform,
+            # not manifest: openbank-infra/aws/envs/sandbox-platform/feedback-screenshots.tf.
+            # The name below MUST match "${local.cluster_name}-feedback" there. If it drifts, the
+            # put fails and the submission is still recorded with screenshotStatus=STORE_FAILED —
+            # visible on gold_screen_feedback_screenshot_health and FeedbackScreenshotStoreFailing.
             - name: OBJECTSTORE_S3_BUCKET
-              value: openbank-feedback-sandbox
+              value: openbank-sandbox-feedback
             - name: OBJECTSTORE_S3_REGION
               value: eu-north-1
             # Redis: nearby-pay payment sessions (ADR-0087) + WebAuthn RP challenge/


### PR DESCRIPTION
## Summary

Completes the ADR-0192 delivery. #2108 shipped the endpoint, the Kafka stream and the ClickHouse marts, but the edge had nowhere to write a screenshot and no credentials to write with — so every submission was recording `screenshotStatus=STORE_FAILED`. This adds the bucket, its retention rule and the identity that can put to it.

## Type of change

- [x] feat (new functionality)

## Linked issues

Refs #2108 — ADR-0192 (`docs/adr/0192-screen-feedback.md`), whose `delivery-status` moves from `partial` to shipped once this is applied.

## Changes

**Terraform — `openbank-infra/aws/envs/sandbox-platform/feedback-screenshots.tf`**
- `s3://openbank-sandbox-feedback` — SSE `AES256`, public access blocked, TLS-only bucket policy, `force_destroy` (sandbox only).
- **90-day expiry lifecycle rule.** This is the storage-limitation control ADR-0192 commits to, deliberately a bucket property rather than something application code decides.
- IAM role with **`s3:PutObject` only**, scoped to the `customer-edge/feedback/*` prefix. No `GetObject`, no `DeleteObject`, no `ListBucket` — the edge only ever puts, and reading a customer's screenshot should be an audited support/analytics act under a separate identity, not a capability of the internet-facing service.
- `aws_eks_pod_identity_association` (same mechanism as cost-collector / db-backups — no IRSA annotations).

**GitOps — `components/customer-edge/customer-edge.yaml`**
- Dedicated `customer-edge` ServiceAccount (sync-wave `-1`) + `serviceAccountName` on the Rollout. Associating the namespace's `default` SA would have handed the same S3 credentials to Redis and the OPA sidecar.
- `OBJECTSTORE_S3_BUCKET` corrected to `openbank-sandbox-feedback` to match `"${local.cluster_name}-feedback"`.

## Plan preview (read before dispatching the apply)

Ran locally with `AWS_PROFILE=openbank` (read-only): **9 to add, 0 to change, 0 to destroy**.

Eight are this change. **The ninth is a passenger, not mine:**

```
# aws_eks_pod_identity_association.db_backups_fleet["finops"] will be created
```

That association is already committed in `db-backups.tf` but has never been applied — meaning `finops-db` currently has no S3 credentials and its WAL archiving is failing. Applying it is almost certainly the right thing, but it is a separate decision from this PR and whoever dispatches `platform-tofu.yml` should know they are enacting it. The apply is not targeted (ADR-0060, no workflow inputs), so it cannot be excluded.

Note: the local plan could not evaluate the `github` provider (`governance_gh_pat` is only available as a CI secret — a dummy value 401s), so any `github_*` drift is not visible above. The PR's own plan job will show it.

## Verification

`tofu validate` clean (only pre-existing deprecation warnings); `tofu fmt -check` clean. Nothing is applied by merging — the apply is a deliberate `gh workflow run platform-tofu.yml --ref main` after reading the plan.

Once applied: submissions should flip from `screenshotStatus=STORE_FAILED` to `STORED` (watch `gold_screen_feedback_screenshot_health`, and the `FeedbackScreenshotStoreFailing` alert should clear).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
