### PR TITLE
fix(gitops): pin mcp-service runAsUser 100 so runAsNonRoot admits the pod (#1922)

### DIFF
--- a/openbank-infra/gitops/components/mcp/mcp-service.yaml
+++ b/openbank-infra/gitops/components/mcp/mcp-service.yaml
@@ -30,6 +30,9 @@ spec:
     spec:
       securityContext:
         runAsNonRoot: true
+        runAsUser: 100
+        runAsGroup: 101
+        fsGroup: 101
         seccompProfile:
           type: RuntimeDefault
       containers:


### PR DESCRIPTION
Phase-1 deploy blocker: image `USER openbank` is non-numeric, so `runAsNonRoot: true` can't verify non-root and the container is refused. Pin `runAsUser 100 / runAsGroup 101 / fsGroup 101` (the image's actual ids, same as agent-service). No behaviour change. Refs #1922