### PR TITLE
fix(mcp): pin USER to numeric uid 100 so runAsNonRoot admits the pod

### DIFF
--- a/openbank-mcp-service/Dockerfile
+++ b/openbank-mcp-service/Dockerfile
@@ -16,7 +16,10 @@ FROM eclipse-temurin:25-jre-alpine@sha256:28db6fdf60e38945e43d840c0333aeaec66c15
 WORKDIR /app
 
 RUN addgroup -S openbank && adduser -S openbank -G openbank
-USER openbank
+# Numeric UID (alpine `adduser -S` assigns uid 100) so Kubernetes `runAsNonRoot: true`
+# can verify the user is non-root. A named USER makes admission fail with
+# "image has non-numeric user (openbank), cannot verify user is non-root".
+USER 100
 
 COPY --from=build /build/openbank-mcp-service/build/quarkus-app/lib/ /app/lib/
 COPY --from=build /build/openbank-mcp-service/build/quarkus-app/*.jar /app/


### PR DESCRIPTION
## What

Change the final `USER openbank` to `USER 100` (numeric) in `openbank-mcp-service/Dockerfile`.

## Why

The alpine `adduser -S openbank` assigns uid 100/gid 101, but a non-numeric `USER` name means Kubernetes `runAsNonRoot: true` cannot verify the user is non-root:

> image has non-numeric user (openbank), cannot verify user is non-root

and the pod is refused. The sandbox deploy worked around it by pinning `runAsUser: 100` in the gitops manifest (`openbank-infra/gitops/components/mcp/mcp-service.yaml`, #2136), but a future image rebuild would reintroduce the block while the Dockerfile still used the name. Making `USER` numeric makes the image self-consistent.

## Scope

Service-code change under `openbank-mcp-service/` — rebuilds and releases `openbank-mcp-service`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)