### PR TITLE
chore(governance): close the VEX overlay coverage gap for CVE-2025-14969 / CVE-2026-45292

### DIFF
--- a/openbank-libs/governance/vex/ap2-service.openvex.json
+++ b/openbank-libs/governance/vex/ap2-service.openvex.json
@@ -1,0 +1,15 @@
+{
+  "@context": "https://openvex.dev/ns/v0.2.0",
+  "@id": "https://open-bank.tech/vex/ap2-service",
+  "author": "OpenBank Security",
+  "version": 1,
+  "statements": [
+    {
+      "vulnerability": {
+        "name": "CVE-2026-45292"
+      },
+      "status": "affected",
+      "action_statement": "Resolved io.opentelemetry:opentelemetry-api is 1.60.1 (bundled by the Quarkus platform BOM io.quarkus.platform:quarkus-bom:3.37.2). The unbounded W3C-baggage memory allocation is fixed in 1.62.0, which is binary-incompatible with the OpenTelemetry extension Quarkus 3.37.2 ships (a force to 1.62.0 fails every service at boot with NoClassDefFoundError: io/opentelemetry/common/impl/ApiUsageLogger, verified and reverted in PR #1367), so remediation requires the Quarkus platform bump tracked in issue #1446. Compensating control: the `baggage` propagator only parses the W3C `baggage` header on the in-mesh trace-context path (Istio STRICT mTLS between services); the customer-facing edge does not accept or forward an attacker-supplied baggage header, so the oversized-baggage parse path is not reachable from untrusted input. Residual risk: medium-severity DoS only, no data exposure."
+    }
+  ]
+}

--- a/openbank-libs/governance/vex/authz-policy-auditor.openvex.json
+++ b/openbank-libs/governance/vex/authz-policy-auditor.openvex.json
@@ -1,0 +1,22 @@
+{
+  "@context": "https://openvex.dev/ns/v0.2.0",
+  "@id": "https://open-bank.tech/vex/authz-policy-auditor",
+  "author": "OpenBank Security",
+  "version": 1,
+  "statements": [
+    {
+      "vulnerability": {
+        "name": "CVE-2025-14969"
+      },
+      "status": "affected",
+      "action_statement": "Resolved org.hibernate.reactive:hibernate-reactive-core is 3.4.1.Final (bundled by the Quarkus platform BOM io.quarkus.platform:quarkus-bom:3.37.2). The connection-leak DoS is fixed in 4.2.1.Final, a major-version jump that cannot be forced independently of the Quarkus platform (a bare force desyncs from the Quarkus-tested Vert.x/Hibernate-Reactive combination), so remediation is tracked as the Quarkus platform bump in issue #1446. Compensating controls in place: the reactive PostgreSQL pool is bounded with idle-connection eviction (shared openbank-libs default, PRs #1682/#1894), so a leaked-connection condition self-heals rather than permanently exhausting the pool, and every service is reachable only in-mesh (Istio STRICT mTLS) and via the authenticated BFF, not directly by an external client. Residual risk: medium-severity DoS only, no data exposure."
+    },
+    {
+      "vulnerability": {
+        "name": "CVE-2026-45292"
+      },
+      "status": "affected",
+      "action_statement": "Resolved io.opentelemetry:opentelemetry-api is 1.60.1 (bundled by the Quarkus platform BOM io.quarkus.platform:quarkus-bom:3.37.2). The unbounded W3C-baggage memory allocation is fixed in 1.62.0, which is binary-incompatible with the OpenTelemetry extension Quarkus 3.37.2 ships (a force to 1.62.0 fails every service at boot with NoClassDefFoundError: io/opentelemetry/common/impl/ApiUsageLogger, verified and reverted in PR #1367), so remediation requires the Quarkus platform bump tracked in issue #1446. Compensating control: the `baggage` propagator only parses the W3C `baggage` header on the in-mesh trace-context path (Istio STRICT mTLS between services); the customer-facing edge does not accept or forward an attacker-supplied baggage header, so the oversized-baggage parse path is not reachable from untrusted input. Residual risk: medium-severity DoS only, no data exposure."
+    }
+  ]
+}

--- a/openbank-libs/governance/vex/balance-service.openvex.json
+++ b/openbank-libs/governance/vex/balance-service.openvex.json
@@ -1,0 +1,22 @@
+{
+  "@context": "https://openvex.dev/ns/v0.2.0",
+  "@id": "https://open-bank.tech/vex/balance-service",
+  "author": "OpenBank Security",
+  "version": 1,
+  "statements": [
+    {
+      "vulnerability": {
+        "name": "CVE-2025-14969"
+      },
+      "status": "affected",
+      "action_statement": "Resolved org.hibernate.reactive:hibernate-reactive-core is 3.4.1.Final (bundled by the Quarkus platform BOM io.quarkus.platform:quarkus-bom:3.37.2). The connection-leak DoS is fixed in 4.2.1.Final, a major-version jump that cannot be forced independently of the Quarkus platform (a bare force desyncs from the Quarkus-tested Vert.x/Hibernate-Reactive combination), so remediation is tracked as the Quarkus platform bump in issue #1446. Compensating controls in place: the reactive PostgreSQL pool is bounded with idle-connection eviction (shared openbank-libs default, PRs #1682/#1894), so a leaked-connection condition self-heals rather than permanently exhausting the pool, and every service is reachable only in-mesh (Istio STRICT mTLS) and via the authenticated BFF, not directly by an external client. Residual risk: medium-severity DoS only, no data exposure."
+    },
+    {
+      "vulnerability": {
+        "name": "CVE-2026-45292"
+      },
+      "status": "affected",
+      "action_statement": "Resolved io.opentelemetry:opentelemetry-api is 1.60.1 (bundled by the Quarkus platform BOM io.quarkus.platform:quarkus-bom:3.37.2). The unbounded W3C-baggage memory allocation is fixed in 1.62.0, which is binary-incompatible with the OpenTelemetry extension Quarkus 3.37.2 ships (a force to 1.62.0 fails every service at boot with NoClassDefFoundError: io/opentelemetry/common/impl/ApiUsageLogger, verified and reverted in PR #1367), so remediation requires the Quarkus platform bump tracked in issue #1446. Compensating control: the `baggage` propagator only parses the W3C `baggage` header on the in-mesh trace-context path (Istio STRICT mTLS between services); the customer-facing edge does not accept or forward an attacker-supplied baggage header, so the oversized-baggage parse path is not reachable from untrusted input. Residual risk: medium-severity DoS only, no data exposure."
+    }
+  ]
+}

--- a/openbank-libs/governance/vex/control-liveness-sentinel.openvex.json
+++ b/openbank-libs/governance/vex/control-liveness-sentinel.openvex.json
@@ -1,0 +1,22 @@
+{
+  "@context": "https://openvex.dev/ns/v0.2.0",
+  "@id": "https://open-bank.tech/vex/control-liveness-sentinel",
+  "author": "OpenBank Security",
+  "version": 1,
+  "statements": [
+    {
+      "vulnerability": {
+        "name": "CVE-2025-14969"
+      },
+      "status": "affected",
+      "action_statement": "Resolved org.hibernate.reactive:hibernate-reactive-core is 3.4.1.Final (bundled by the Quarkus platform BOM io.quarkus.platform:quarkus-bom:3.37.2). The connection-leak DoS is fixed in 4.2.1.Final, a major-version jump that cannot be forced independently of the Quarkus platform (a bare force desyncs from the Quarkus-tested Vert.x/Hibernate-Reactive combination), so remediation is tracked as the Quarkus platform bump in issue #1446. Compensating controls in place: the reactive PostgreSQL pool is bounded with idle-connection eviction (shared openbank-libs default, PRs #1682/#1894), so a leaked-connection condition self-heals rather than permanently exhausting the pool, and every service is reachable only in-mesh (Istio STRICT mTLS) and via the authenticated BFF, not directly by an external client. Residual risk: medium-severity DoS only, no data exposure."
+    },
+    {
+      "vulnerability": {
+        "name": "CVE-2026-45292"
+      },
+      "status": "affected",
+      "action_statement": "Resolved io.opentelemetry:opentelemetry-api is 1.60.1 (bundled by the Quarkus platform BOM io.quarkus.platform:quarkus-bom:3.37.2). The unbounded W3C-baggage memory allocation is fixed in 1.62.0, which is binary-incompatible with the OpenTelemetry extension Quarkus 3.37.2 ships (a force to 1.62.0 fails every service at boot with NoClassDefFoundError: io/opentelemetry/common/impl/ApiUsageLogger, verified and reverted in PR #1367), so remediation requires the Quarkus platform bump tracked in issue #1446. Compensating control: the `baggage` propagator only parses the W3C `baggage` header on the in-mesh trace-context path (Istio STRICT mTLS between services); the customer-facing edge does not accept or forward an attacker-supplied baggage header, so the oversized-baggage parse path is not reachable from untrusted input. Residual risk: medium-severity DoS only, no data exposure."
+    }
+  ]
+}

--- a/openbank-libs/governance/vex/docs-truth-agent.openvex.json
+++ b/openbank-libs/governance/vex/docs-truth-agent.openvex.json
@@ -1,0 +1,22 @@
+{
+  "@context": "https://openvex.dev/ns/v0.2.0",
+  "@id": "https://open-bank.tech/vex/docs-truth-agent",
+  "author": "OpenBank Security",
+  "version": 1,
+  "statements": [
+    {
+      "vulnerability": {
+        "name": "CVE-2025-14969"
+      },
+      "status": "affected",
+      "action_statement": "Resolved org.hibernate.reactive:hibernate-reactive-core is 3.4.1.Final (bundled by the Quarkus platform BOM io.quarkus.platform:quarkus-bom:3.37.2). The connection-leak DoS is fixed in 4.2.1.Final, a major-version jump that cannot be forced independently of the Quarkus platform (a bare force desyncs from the Quarkus-tested Vert.x/Hibernate-Reactive combination), so remediation is tracked as the Quarkus platform bump in issue #1446. Compensating controls in place: the reactive PostgreSQL pool is bounded with idle-connection eviction (shared openbank-libs default, PRs #1682/#1894), so a leaked-connection condition self-heals rather than permanently exhausting the pool, and every service is reachable only in-mesh (Istio STRICT mTLS) and via the authenticated BFF, not directly by an external client. Residual risk: medium-severity DoS only, no data exposure."
+    },
+    {
+      "vulnerability": {
+        "name": "CVE-2026-45292"
+      },
+      "status": "affected",
+      "action_statement": "Resolved io.opentelemetry:opentelemetry-api is 1.60.1 (bundled by the Quarkus platform BOM io.quarkus.platform:quarkus-bom:3.37.2). The unbounded W3C-baggage memory allocation is fixed in 1.62.0, which is binary-incompatible with the OpenTelemetry extension Quarkus 3.37.2 ships (a force to 1.62.0 fails every service at boot with NoClassDefFoundError: io/opentelemetry/common/impl/ApiUsageLogger, verified and reverted in PR #1367), so remediation requires the Quarkus platform bump tracked in issue #1446. Compensating control: the `baggage` propagator only parses the W3C `baggage` header on the in-mesh trace-context path (Istio STRICT mTLS between services); the customer-facing edge does not accept or forward an attacker-supplied baggage header, so the oversized-baggage parse path is not reachable from untrusted input. Residual risk: medium-severity DoS only, no data exposure."
+    }
+  ]
+}

--- a/openbank-libs/governance/vex/document-service.openvex.json
+++ b/openbank-libs/governance/vex/document-service.openvex.json
@@ -1,0 +1,22 @@
+{
+  "@context": "https://openvex.dev/ns/v0.2.0",
+  "@id": "https://open-bank.tech/vex/document-service",
+  "author": "OpenBank Security",
+  "version": 1,
+  "statements": [
+    {
+      "vulnerability": {
+        "name": "CVE-2025-14969"
+      },
+      "status": "affected",
+      "action_statement": "Resolved org.hibernate.reactive:hibernate-reactive-core is 3.4.1.Final (bundled by the Quarkus platform BOM io.quarkus.platform:quarkus-bom:3.37.2). The connection-leak DoS is fixed in 4.2.1.Final, a major-version jump that cannot be forced independently of the Quarkus platform (a bare force desyncs from the Quarkus-tested Vert.x/Hibernate-Reactive combination), so remediation is tracked as the Quarkus platform bump in issue #1446. Compensating controls in place: the reactive PostgreSQL pool is bounded with idle-connection eviction (shared openbank-libs default, PRs #1682/#1894), so a leaked-connection condition self-heals rather than permanently exhausting the pool, and every service is reachable only in-mesh (Istio STRICT mTLS) and via the authenticated BFF, not directly by an external client. Residual risk: medium-severity DoS only, no data exposure."
+    },
+    {
+      "vulnerability": {
+        "name": "CVE-2026-45292"
+      },
+      "status": "affected",
+      "action_statement": "Resolved io.opentelemetry:opentelemetry-api is 1.60.1 (bundled by the Quarkus platform BOM io.quarkus.platform:quarkus-bom:3.37.2). The unbounded W3C-baggage memory allocation is fixed in 1.62.0, which is binary-incompatible with the OpenTelemetry extension Quarkus 3.37.2 ships (a force to 1.62.0 fails every service at boot with NoClassDefFoundError: io/opentelemetry/common/impl/ApiUsageLogger, verified and reverted in PR #1367), so remediation requires the Quarkus platform bump tracked in issue #1446. Compensating control: the `baggage` propagator only parses the W3C `baggage` header on the in-mesh trace-context path (Istio STRICT mTLS between services); the customer-facing edge does not accept or forward an attacker-supplied baggage header, so the oversized-baggage parse path is not reachable from untrusted input. Residual risk: medium-severity DoS only, no data exposure."
+    }
+  ]
+}

--- a/openbank-libs/governance/vex/finops-agent.openvex.json
+++ b/openbank-libs/governance/vex/finops-agent.openvex.json
@@ -2,7 +2,7 @@
   "@context": "https://openvex.dev/ns/v0.2.0",
   "@id": "https://open-bank.tech/vex/finops-agent",
   "author": "OpenBank Security",
-  "version": 3,
+  "version": 4,
   "statements": [
     {
       "vulnerability": {
@@ -162,6 +162,13 @@
       },
       "status": "affected",
       "action_statement": "Resolved io.opentelemetry:opentelemetry-api is 1.60.1 (bundled by the Quarkus platform BOM io.quarkus.platform:quarkus-bom:3.37.2). The unbounded W3C-baggage memory allocation is fixed in 1.62.0, which is binary-incompatible with the OpenTelemetry extension Quarkus 3.37.2 ships (a force to 1.62.0 fails every service at boot with NoClassDefFoundError: io/opentelemetry/common/impl/ApiUsageLogger, verified and reverted in PR #1367), so remediation requires the Quarkus platform bump tracked in issue #1446. Compensating control: the `baggage` propagator only parses the W3C `baggage` header on the in-mesh trace-context path (Istio STRICT mTLS between services); the customer-facing edge does not accept or forward an attacker-supplied baggage header, so the oversized-baggage parse path is not reachable from untrusted input. Residual risk: medium-severity DoS only, no data exposure."
+    },
+    {
+      "vulnerability": {
+        "name": "CVE-2025-14969"
+      },
+      "status": "affected",
+      "action_statement": "Resolved org.hibernate.reactive:hibernate-reactive-core is 3.4.1.Final (bundled by the Quarkus platform BOM io.quarkus.platform:quarkus-bom:3.37.2). The connection-leak DoS is fixed in 4.2.1.Final, a major-version jump that cannot be forced independently of the Quarkus platform (a bare force desyncs from the Quarkus-tested Vert.x/Hibernate-Reactive combination), so remediation is tracked as the Quarkus platform bump in issue #1446. Compensating controls in place: the reactive PostgreSQL pool is bounded with idle-connection eviction (shared openbank-libs default, PRs #1682/#1894), so a leaked-connection condition self-heals rather than permanently exhausting the pool, and every service is reachable only in-mesh (Istio STRICT mTLS) and via the authenticated BFF, not directly by an external client. Residual risk: medium-severity DoS only, no data exposure."
     }
   ]
 }

--- a/openbank-libs/governance/vex/flaky-test-hunter.openvex.json
+++ b/openbank-libs/governance/vex/flaky-test-hunter.openvex.json
@@ -1,0 +1,22 @@
+{
+  "@context": "https://openvex.dev/ns/v0.2.0",
+  "@id": "https://open-bank.tech/vex/flaky-test-hunter",
+  "author": "OpenBank Security",
+  "version": 1,
+  "statements": [
+    {
+      "vulnerability": {
+        "name": "CVE-2025-14969"
+      },
+      "status": "affected",
+      "action_statement": "Resolved org.hibernate.reactive:hibernate-reactive-core is 3.4.1.Final (bundled by the Quarkus platform BOM io.quarkus.platform:quarkus-bom:3.37.2). The connection-leak DoS is fixed in 4.2.1.Final, a major-version jump that cannot be forced independently of the Quarkus platform (a bare force desyncs from the Quarkus-tested Vert.x/Hibernate-Reactive combination), so remediation is tracked as the Quarkus platform bump in issue #1446. Compensating controls in place: the reactive PostgreSQL pool is bounded with idle-connection eviction (shared openbank-libs default, PRs #1682/#1894), so a leaked-connection condition self-heals rather than permanently exhausting the pool, and every service is reachable only in-mesh (Istio STRICT mTLS) and via the authenticated BFF, not directly by an external client. Residual risk: medium-severity DoS only, no data exposure."
+    },
+    {
+      "vulnerability": {
+        "name": "CVE-2026-45292"
+      },
+      "status": "affected",
+      "action_statement": "Resolved io.opentelemetry:opentelemetry-api is 1.60.1 (bundled by the Quarkus platform BOM io.quarkus.platform:quarkus-bom:3.37.2). The unbounded W3C-baggage memory allocation is fixed in 1.62.0, which is binary-incompatible with the OpenTelemetry extension Quarkus 3.37.2 ships (a force to 1.62.0 fails every service at boot with NoClassDefFoundError: io/opentelemetry/common/impl/ApiUsageLogger, verified and reverted in PR #1367), so remediation requires the Quarkus platform bump tracked in issue #1446. Compensating control: the `baggage` propagator only parses the W3C `baggage` header on the in-mesh trace-context path (Istio STRICT mTLS between services); the customer-facing edge does not accept or forward an attacker-supplied baggage header, so the oversized-baggage parse path is not reachable from untrusted input. Residual risk: medium-severity DoS only, no data exposure."
+    }
+  ]
+}

--- a/openbank-libs/governance/vex/governance-auditor.openvex.json
+++ b/openbank-libs/governance/vex/governance-auditor.openvex.json
@@ -1,0 +1,22 @@
+{
+  "@context": "https://openvex.dev/ns/v0.2.0",
+  "@id": "https://open-bank.tech/vex/governance-auditor",
+  "author": "OpenBank Security",
+  "version": 1,
+  "statements": [
+    {
+      "vulnerability": {
+        "name": "CVE-2025-14969"
+      },
+      "status": "affected",
+      "action_statement": "Resolved org.hibernate.reactive:hibernate-reactive-core is 3.4.1.Final (bundled by the Quarkus platform BOM io.quarkus.platform:quarkus-bom:3.37.2). The connection-leak DoS is fixed in 4.2.1.Final, a major-version jump that cannot be forced independently of the Quarkus platform (a bare force desyncs from the Quarkus-tested Vert.x/Hibernate-Reactive combination), so remediation is tracked as the Quarkus platform bump in issue #1446. Compensating controls in place: the reactive PostgreSQL pool is bounded with idle-connection eviction (shared openbank-libs default, PRs #1682/#1894), so a leaked-connection condition self-heals rather than permanently exhausting the pool, and every service is reachable only in-mesh (Istio STRICT mTLS) and via the authenticated BFF, not directly by an external client. Residual risk: medium-severity DoS only, no data exposure."
+    },
+    {
+      "vulnerability": {
+        "name": "CVE-2026-45292"
+      },
+      "status": "affected",
+      "action_statement": "Resolved io.opentelemetry:opentelemetry-api is 1.60.1 (bundled by the Quarkus platform BOM io.quarkus.platform:quarkus-bom:3.37.2). The unbounded W3C-baggage memory allocation is fixed in 1.62.0, which is binary-incompatible with the OpenTelemetry extension Quarkus 3.37.2 ships (a force to 1.62.0 fails every service at boot with NoClassDefFoundError: io/opentelemetry/common/impl/ApiUsageLogger, verified and reverted in PR #1367), so remediation requires the Quarkus platform bump tracked in issue #1446. Compensating control: the `baggage` propagator only parses the W3C `baggage` header on the in-mesh trace-context path (Istio STRICT mTLS between services); the customer-facing edge does not accept or forward an attacker-supplied baggage header, so the oversized-baggage parse path is not reachable from untrusted input. Residual risk: medium-severity DoS only, no data exposure."
+    }
+  ]
+}

--- a/openbank-libs/governance/vex/mcp-service.openvex.json
+++ b/openbank-libs/governance/vex/mcp-service.openvex.json
@@ -1,0 +1,15 @@
+{
+  "@context": "https://openvex.dev/ns/v0.2.0",
+  "@id": "https://open-bank.tech/vex/mcp-service",
+  "author": "OpenBank Security",
+  "version": 1,
+  "statements": [
+    {
+      "vulnerability": {
+        "name": "CVE-2026-45292"
+      },
+      "status": "affected",
+      "action_statement": "Resolved io.opentelemetry:opentelemetry-api is 1.60.1 (bundled by the Quarkus platform BOM io.quarkus.platform:quarkus-bom:3.37.2). The unbounded W3C-baggage memory allocation is fixed in 1.62.0, which is binary-incompatible with the OpenTelemetry extension Quarkus 3.37.2 ships (a force to 1.62.0 fails every service at boot with NoClassDefFoundError: io/opentelemetry/common/impl/ApiUsageLogger, verified and reverted in PR #1367), so remediation requires the Quarkus platform bump tracked in issue #1446. Compensating control: the `baggage` propagator only parses the W3C `baggage` header on the in-mesh trace-context path (Istio STRICT mTLS between services); the customer-facing edge does not accept or forward an attacker-supplied baggage header, so the oversized-baggage parse path is not reachable from untrusted input. Residual risk: medium-severity DoS only, no data exposure."
+    }
+  ]
+}

--- a/openbank-libs/governance/vex/party-service.openvex.json
+++ b/openbank-libs/governance/vex/party-service.openvex.json
@@ -1,0 +1,22 @@
+{
+  "@context": "https://openvex.dev/ns/v0.2.0",
+  "@id": "https://open-bank.tech/vex/party-service",
+  "author": "OpenBank Security",
+  "version": 1,
+  "statements": [
+    {
+      "vulnerability": {
+        "name": "CVE-2025-14969"
+      },
+      "status": "affected",
+      "action_statement": "Resolved org.hibernate.reactive:hibernate-reactive-core is 3.4.1.Final (bundled by the Quarkus platform BOM io.quarkus.platform:quarkus-bom:3.37.2). The connection-leak DoS is fixed in 4.2.1.Final, a major-version jump that cannot be forced independently of the Quarkus platform (a bare force desyncs from the Quarkus-tested Vert.x/Hibernate-Reactive combination), so remediation is tracked as the Quarkus platform bump in issue #1446. Compensating controls in place: the reactive PostgreSQL pool is bounded with idle-connection eviction (shared openbank-libs default, PRs #1682/#1894), so a leaked-connection condition self-heals rather than permanently exhausting the pool, and every service is reachable only in-mesh (Istio STRICT mTLS) and via the authenticated BFF, not directly by an external client. Residual risk: medium-severity DoS only, no data exposure."
+    },
+    {
+      "vulnerability": {
+        "name": "CVE-2026-45292"
+      },
+      "status": "affected",
+      "action_statement": "Resolved io.opentelemetry:opentelemetry-api is 1.60.1 (bundled by the Quarkus platform BOM io.quarkus.platform:quarkus-bom:3.37.2). The unbounded W3C-baggage memory allocation is fixed in 1.62.0, which is binary-incompatible with the OpenTelemetry extension Quarkus 3.37.2 ships (a force to 1.62.0 fails every service at boot with NoClassDefFoundError: io/opentelemetry/common/impl/ApiUsageLogger, verified and reverted in PR #1367), so remediation requires the Quarkus platform bump tracked in issue #1446. Compensating control: the `baggage` propagator only parses the W3C `baggage` header on the in-mesh trace-context path (Istio STRICT mTLS between services); the customer-facing edge does not accept or forward an attacker-supplied baggage header, so the oversized-baggage parse path is not reachable from untrusted input. Residual risk: medium-severity DoS only, no data exposure."
+    }
+  ]
+}

--- a/openbank-libs/governance/vex/psd2-service.openvex.json
+++ b/openbank-libs/governance/vex/psd2-service.openvex.json
@@ -1,0 +1,22 @@
+{
+  "@context": "https://openvex.dev/ns/v0.2.0",
+  "@id": "https://open-bank.tech/vex/psd2-service",
+  "author": "OpenBank Security",
+  "version": 1,
+  "statements": [
+    {
+      "vulnerability": {
+        "name": "CVE-2025-14969"
+      },
+      "status": "affected",
+      "action_statement": "Resolved org.hibernate.reactive:hibernate-reactive-core is 3.4.1.Final (bundled by the Quarkus platform BOM io.quarkus.platform:quarkus-bom:3.37.2). The connection-leak DoS is fixed in 4.2.1.Final, a major-version jump that cannot be forced independently of the Quarkus platform (a bare force desyncs from the Quarkus-tested Vert.x/Hibernate-Reactive combination), so remediation is tracked as the Quarkus platform bump in issue #1446. Compensating controls in place: the reactive PostgreSQL pool is bounded with idle-connection eviction (shared openbank-libs default, PRs #1682/#1894), so a leaked-connection condition self-heals rather than permanently exhausting the pool, and every service is reachable only in-mesh (Istio STRICT mTLS) and via the authenticated BFF, not directly by an external client. Residual risk: medium-severity DoS only, no data exposure."
+    },
+    {
+      "vulnerability": {
+        "name": "CVE-2026-45292"
+      },
+      "status": "affected",
+      "action_statement": "Resolved io.opentelemetry:opentelemetry-api is 1.60.1 (bundled by the Quarkus platform BOM io.quarkus.platform:quarkus-bom:3.37.2). The unbounded W3C-baggage memory allocation is fixed in 1.62.0, which is binary-incompatible with the OpenTelemetry extension Quarkus 3.37.2 ships (a force to 1.62.0 fails every service at boot with NoClassDefFoundError: io/opentelemetry/common/impl/ApiUsageLogger, verified and reverted in PR #1367), so remediation requires the Quarkus platform bump tracked in issue #1446. Compensating control: the `baggage` propagator only parses the W3C `baggage` header on the in-mesh trace-context path (Istio STRICT mTLS between services); the customer-facing edge does not accept or forward an attacker-supplied baggage header, so the oversized-baggage parse path is not reachable from untrusted input. Residual risk: medium-severity DoS only, no data exposure."
+    }
+  ]
+}

--- a/openbank-libs/governance/vex/release-steward.openvex.json
+++ b/openbank-libs/governance/vex/release-steward.openvex.json
@@ -1,0 +1,22 @@
+{
+  "@context": "https://openvex.dev/ns/v0.2.0",
+  "@id": "https://open-bank.tech/vex/release-steward",
+  "author": "OpenBank Security",
+  "version": 1,
+  "statements": [
+    {
+      "vulnerability": {
+        "name": "CVE-2025-14969"
+      },
+      "status": "affected",
+      "action_statement": "Resolved org.hibernate.reactive:hibernate-reactive-core is 3.4.1.Final (bundled by the Quarkus platform BOM io.quarkus.platform:quarkus-bom:3.37.2). The connection-leak DoS is fixed in 4.2.1.Final, a major-version jump that cannot be forced independently of the Quarkus platform (a bare force desyncs from the Quarkus-tested Vert.x/Hibernate-Reactive combination), so remediation is tracked as the Quarkus platform bump in issue #1446. Compensating controls in place: the reactive PostgreSQL pool is bounded with idle-connection eviction (shared openbank-libs default, PRs #1682/#1894), so a leaked-connection condition self-heals rather than permanently exhausting the pool, and every service is reachable only in-mesh (Istio STRICT mTLS) and via the authenticated BFF, not directly by an external client. Residual risk: medium-severity DoS only, no data exposure."
+    },
+    {
+      "vulnerability": {
+        "name": "CVE-2026-45292"
+      },
+      "status": "affected",
+      "action_statement": "Resolved io.opentelemetry:opentelemetry-api is 1.60.1 (bundled by the Quarkus platform BOM io.quarkus.platform:quarkus-bom:3.37.2). The unbounded W3C-baggage memory allocation is fixed in 1.62.0, which is binary-incompatible with the OpenTelemetry extension Quarkus 3.37.2 ships (a force to 1.62.0 fails every service at boot with NoClassDefFoundError: io/opentelemetry/common/impl/ApiUsageLogger, verified and reverted in PR #1367), so remediation requires the Quarkus platform bump tracked in issue #1446. Compensating control: the `baggage` propagator only parses the W3C `baggage` header on the in-mesh trace-context path (Istio STRICT mTLS between services); the customer-facing edge does not accept or forward an attacker-supplied baggage header, so the oversized-baggage parse path is not reachable from untrusted input. Residual risk: medium-severity DoS only, no data exposure."
+    }
+  ]
+}

--- a/openbank-libs/governance/vex/vop-service.openvex.json
+++ b/openbank-libs/governance/vex/vop-service.openvex.json
@@ -1,0 +1,22 @@
+{
+  "@context": "https://openvex.dev/ns/v0.2.0",
+  "@id": "https://open-bank.tech/vex/vop-service",
+  "author": "OpenBank Security",
+  "version": 1,
+  "statements": [
+    {
+      "vulnerability": {
+        "name": "CVE-2025-14969"
+      },
+      "status": "affected",
+      "action_statement": "Resolved org.hibernate.reactive:hibernate-reactive-core is 3.4.1.Final (bundled by the Quarkus platform BOM io.quarkus.platform:quarkus-bom:3.37.2). The connection-leak DoS is fixed in 4.2.1.Final, a major-version jump that cannot be forced independently of the Quarkus platform (a bare force desyncs from the Quarkus-tested Vert.x/Hibernate-Reactive combination), so remediation is tracked as the Quarkus platform bump in issue #1446. Compensating controls in place: the reactive PostgreSQL pool is bounded with idle-connection eviction (shared openbank-libs default, PRs #1682/#1894), so a leaked-connection condition self-heals rather than permanently exhausting the pool, and every service is reachable only in-mesh (Istio STRICT mTLS) and via the authenticated BFF, not directly by an external client. Residual risk: medium-severity DoS only, no data exposure."
+    },
+    {
+      "vulnerability": {
+        "name": "CVE-2026-45292"
+      },
+      "status": "affected",
+      "action_statement": "Resolved io.opentelemetry:opentelemetry-api is 1.60.1 (bundled by the Quarkus platform BOM io.quarkus.platform:quarkus-bom:3.37.2). The unbounded W3C-baggage memory allocation is fixed in 1.62.0, which is binary-incompatible with the OpenTelemetry extension Quarkus 3.37.2 ships (a force to 1.62.0 fails every service at boot with NoClassDefFoundError: io/opentelemetry/common/impl/ApiUsageLogger, verified and reverted in PR #1367), so remediation requires the Quarkus platform bump tracked in issue #1446. Compensating control: the `baggage` propagator only parses the W3C `baggage` header on the in-mesh trace-context path (Istio STRICT mTLS between services); the customer-facing edge does not accept or forward an attacker-supplied baggage header, so the oversized-baggage parse path is not reachable from untrusted input. Residual risk: medium-severity DoS only, no data exposure."
+    }
+  ]
+}


### PR DESCRIPTION
## Summary

Resolves the remaining **2 genuinely-open** `vex-triage` issues (#971, #975) by closing a **structural coverage gap** left by PR #1951.

### The gap

PR #1951 recorded the fleet `affected` verdict for both CVEs, but only across the **37 components that already had an OpenVEX overlay file**. The fleet has **53 components with a release evidence bundle** — 16 had no overlay at all.

`build-release-evidence.sh` merges `openbank-libs/governance/vex/<component>.openvex.json` over the trivy auto-inventory. With no overlay file, those components re-emit `under_investigation` on **every** future release, so `vex-inventory.py` would keep both CVEs in the triage queue forever and `vex-triage.py` could never auto-close #971/#975. Verified against the live inventory: CVE-2025-14969 was missing a verdict in **12** bundle-carrying components, CVE-2026-45292 in **13**.

This adds the same, already-reviewed verdicts to those components: **13 new overlays + finops-agent extended** (it was itself missing CVE-2025-14969).

### Grounding — verified, not rubber-stamped

- **Resolved versions read from a real release SBOM** (`party-service-v0.10.1.cdx.json`, one of the newly-covered components): `hibernate-reactive-core 3.4.1.Final`, `opentelemetry-api 1.60.1`, under `quarkus-bom 3.37.2` — matching the verdicts' stated versions exactly.
- **Reachability checked per component.** All 12 hibernate components genuinely use `quarkus-hibernate-reactive-panache-kotlin` against a reactive PostgreSQL datasource (incl. `psd2-service`, whose datasource comes from GitOps env rather than `application.yaml`, and which drives a Panache outbox). The connection-leak path *is* in the execute path, so `affected` + compensating controls is the honest verdict — `not_affected` would have been false.
- **Negative control holds:** `ap2-service` and `mcp-service` declare no Panache/Hibernate dependency, which is exactly why their bundles list only CVE-2026-45292. They get the OTel statement only.

Remediation for both remains the Quarkus platform bump tracked in **#1446**; no version bump is available today (4.2.1.Final is a major jump off the platform BOM; otel 1.62.0 is binary-incompatible with Quarkus 3.37.2's extension, proven and reverted in #1367).

## Note on #1818–#1836

Those 19 issues were **already resolved by PR #1951** and need no code here. Verified against the live `vex-inventory.py`: every one of those CVEs is now `not_affected` in **every** release bundle that carries it, and none is in the triage queue. They were opened by the 2026-07-20 weekly run (before #1951 merged on 2026-07-23) and simply have not met the next cron yet. Each is being commented with that evidence.

## Test plan

- [x] All 50 VEX overlays are valid JSON and structurally valid OpenVEX 0.2.0 (allowed status; `affected` ⇒ `action_statement`; `not_affected` ⇒ allowed `justification` + `impact_statement`; no duplicate CVE per component)
- [x] The validator was **proven against a known-positive** — injecting a bad status + dropped `action_statement` made it exit 1; restoring made it exit 0
- [x] Simulated the post-release queue: with these overlays, **CVE-2025-14969 and CVE-2026-45292 drain to zero** `under_investigation` components. Both currently have 32 and 35.
- [x] Overlay filenames match the `<component>` key `vex-inventory.py` derives from release tags

Closes #971
Closes #975

🤖 Generated with [Claude Code](https://claude.com/claude-code)