### PR TITLE
fix(gitops): rest.rego agent bridge tolerates a null resource (unblocks MCP tools/call)

### DIFF
--- a/openbank-infra/gitops/components/accounts/account-opa-bundle.yaml
+++ b/openbank-infra/gitops/components/accounts/account-opa-bundle.yaml
@@ -9,7 +9,7 @@ metadata:
     app.kubernetes.io/name: account-service
     app.kubernetes.io/part-of: accounts
   annotations:
-    openbank.tech/policy-checksum: "ebb61bfb90ea1933"
+    openbank.tech/policy-checksum: "549e30dfb2e05686"
 data:
   rest.rego: |
     # SPDX-License-Identifier: Apache-2.0
@@ -121,10 +121,16 @@ data:
     	# skill_ok, none of which charter_allowed alone consults. Calling charter_allowed
     	# directly would let a fleet-wide hard-denied tool tier, or an agent's own
     	# tools.deny glob, silently reach a REST action anyway.
+    	# object.get (not input.resource): the PDP omits `resource` from the query entirely when
+    	# it is null (OpaSidecarPolicyDecisionPoint.toInput only puts it when non-null), and a bare
+    	# `input.resource` reference is then UNDEFINED, which makes this whole object — and the
+    	# agents.allow call — undefined, silently denying every resource-less AI_AGENT REST call.
+    	# The MCP server (openbank-mcp-service) is the first caller to route AI_AGENT through
+    	# rest.allow with no resource; agent-service queries agents.allow directly and never hit this.
     	data.openbank.agents.allow with input as {
     		"agent": input.principal.id,
     		"tool": input.action,
-    		"resource": input.resource,
+    		"resource": object.get(input, "resource", null),
     	}
     }
 

--- a/openbank-infra/gitops/components/accounts/account-service.yaml
+++ b/openbank-infra/gitops/components/accounts/account-service.yaml
@@ -37,7 +37,7 @@ spec:
       annotations:
         # Rolls the pod when the OPA bundle changes — subPath mounts do NOT hot-reload.
         # Kept in sync by gen-account-opa-bundle.sh (do not hand-edit).
-        openbank.tech/policy-checksum: "ebb61bfb90ea1933"
+        openbank.tech/policy-checksum: "549e30dfb2e05686"
     spec:
       securityContext:
         runAsNonRoot: true

--- a/openbank-infra/gitops/components/anacredit/anacredit-opa-bundle.yaml
+++ b/openbank-infra/gitops/components/anacredit/anacredit-opa-bundle.yaml
@@ -9,7 +9,7 @@ metadata:
     app.kubernetes.io/name: anacredit-service
     app.kubernetes.io/part-of: anacredit
   annotations:
-    openbank.tech/policy-checksum: "7becc8181e27cd7d"
+    openbank.tech/policy-checksum: "4e1f31892fe706a3"
 data:
   rest.rego: |
     # SPDX-License-Identifier: Apache-2.0
@@ -121,10 +121,16 @@ data:
     	# skill_ok, none of which charter_allowed alone consults. Calling charter_allowed
     	# directly would let a fleet-wide hard-denied tool tier, or an agent's own
     	# tools.deny glob, silently reach a REST action anyway.
+    	# object.get (not input.resource): the PDP omits `resource` from the query entirely when
+    	# it is null (OpaSidecarPolicyDecisionPoint.toInput only puts it when non-null), and a bare
+    	# `input.resource` reference is then UNDEFINED, which makes this whole object — and the
+    	# agents.allow call — undefined, silently denying every resource-less AI_AGENT REST call.
+    	# The MCP server (openbank-mcp-service) is the first caller to route AI_AGENT through
+    	# rest.allow with no resource; agent-service queries agents.allow directly and never hit this.
     	data.openbank.agents.allow with input as {
     		"agent": input.principal.id,
     		"tool": input.action,
-    		"resource": input.resource,
+    		"resource": object.get(input, "resource", null),
     	}
     }
 

--- a/openbank-infra/gitops/components/anacredit/anacredit-service.yaml
+++ b/openbank-infra/gitops/components/anacredit/anacredit-service.yaml
@@ -32,7 +32,7 @@ spec:
       annotations:
         # Rolls the pods when the OPA bundle changes — subPath mounts do NOT hot-reload.
         # Kept in sync by gen-anacredit-opa-bundle.sh (do not hand-edit).
-        openbank.tech/policy-checksum: "7becc8181e27cd7d"
+        openbank.tech/policy-checksum: "4e1f31892fe706a3"
     spec:
       securityContext:
         runAsNonRoot: true

--- a/openbank-infra/gitops/components/balances/balance-opa-bundle.yaml
+++ b/openbank-infra/gitops/components/balances/balance-opa-bundle.yaml
@@ -9,7 +9,7 @@ metadata:
     app.kubernetes.io/name: balance-service
     app.kubernetes.io/part-of: balances
   annotations:
-    openbank.tech/policy-checksum: "94c7e43cae2f6dd2"
+    openbank.tech/policy-checksum: "2280f6e0ad7d4853"
 data:
   rest.rego: |
     # SPDX-License-Identifier: Apache-2.0
@@ -121,10 +121,16 @@ data:
     	# skill_ok, none of which charter_allowed alone consults. Calling charter_allowed
     	# directly would let a fleet-wide hard-denied tool tier, or an agent's own
     	# tools.deny glob, silently reach a REST action anyway.
+    	# object.get (not input.resource): the PDP omits `resource` from the query entirely when
+    	# it is null (OpaSidecarPolicyDecisionPoint.toInput only puts it when non-null), and a bare
+    	# `input.resource` reference is then UNDEFINED, which makes this whole object — and the
+    	# agents.allow call — undefined, silently denying every resource-less AI_AGENT REST call.
+    	# The MCP server (openbank-mcp-service) is the first caller to route AI_AGENT through
+    	# rest.allow with no resource; agent-service queries agents.allow directly and never hit this.
     	data.openbank.agents.allow with input as {
     		"agent": input.principal.id,
     		"tool": input.action,
-    		"resource": input.resource,
+    		"resource": object.get(input, "resource", null),
     	}
     }
 

--- a/openbank-infra/gitops/components/balances/balance-service.yaml
+++ b/openbank-infra/gitops/components/balances/balance-service.yaml
@@ -34,7 +34,7 @@ spec:
       annotations:
         # Rolls the pods when the OPA bundle changes — subPath mounts do NOT hot-reload.
         # Kept in sync by gen-balance-opa-bundle.sh (do not hand-edit).
-        openbank.tech/policy-checksum: "94c7e43cae2f6dd2"
+        openbank.tech/policy-checksum: "2280f6e0ad7d4853"
     spec:
       securityContext:
         runAsNonRoot: true

--- a/openbank-infra/gitops/components/billing/billing-opa-bundle.yaml
+++ b/openbank-infra/gitops/components/billing/billing-opa-bundle.yaml
@@ -9,7 +9,7 @@ metadata:
     app.kubernetes.io/name: billing-service
     app.kubernetes.io/part-of: billing
   annotations:
-    openbank.tech/policy-checksum: "a25fe07bf25bd265"
+    openbank.tech/policy-checksum: "d49358631b8bef71"
 data:
   rest.rego: |
     # SPDX-License-Identifier: Apache-2.0
@@ -121,10 +121,16 @@ data:
     	# skill_ok, none of which charter_allowed alone consults. Calling charter_allowed
     	# directly would let a fleet-wide hard-denied tool tier, or an agent's own
     	# tools.deny glob, silently reach a REST action anyway.
+    	# object.get (not input.resource): the PDP omits `resource` from the query entirely when
+    	# it is null (OpaSidecarPolicyDecisionPoint.toInput only puts it when non-null), and a bare
+    	# `input.resource` reference is then UNDEFINED, which makes this whole object — and the
+    	# agents.allow call — undefined, silently denying every resource-less AI_AGENT REST call.
+    	# The MCP server (openbank-mcp-service) is the first caller to route AI_AGENT through
+    	# rest.allow with no resource; agent-service queries agents.allow directly and never hit this.
     	data.openbank.agents.allow with input as {
     		"agent": input.principal.id,
     		"tool": input.action,
-    		"resource": input.resource,
+    		"resource": object.get(input, "resource", null),
     	}
     }
 

--- a/openbank-infra/gitops/components/billing/billing-service.yaml
+++ b/openbank-infra/gitops/components/billing/billing-service.yaml
@@ -27,7 +27,7 @@ spec:
       annotations:
         # Rolls the pods when the OPA bundle changes — subPath mounts do NOT hot-reload.
         # Kept in sync by gen-billing-opa-bundle.sh (do not hand-edit).
-        openbank.tech/policy-checksum: "a25fe07bf25bd265"
+        openbank.tech/policy-checksum: "d49358631b8bef71"
     spec:
       securityContext:
         runAsNonRoot: true

--- a/openbank-infra/gitops/components/consent/consent-opa-bundle.yaml
+++ b/openbank-infra/gitops/components/consent/consent-opa-bundle.yaml
@@ -9,7 +9,7 @@ metadata:
     app.kubernetes.io/name: consent-service
     app.kubernetes.io/part-of: consent
   annotations:
-    openbank.tech/policy-checksum: "f9c044833ee78739"
+    openbank.tech/policy-checksum: "6befb0e8bcdd2309"
 data:
   rest.rego: |
     # SPDX-License-Identifier: Apache-2.0
@@ -121,10 +121,16 @@ data:
     	# skill_ok, none of which charter_allowed alone consults. Calling charter_allowed
     	# directly would let a fleet-wide hard-denied tool tier, or an agent's own
     	# tools.deny glob, silently reach a REST action anyway.
+    	# object.get (not input.resource): the PDP omits `resource` from the query entirely when
+    	# it is null (OpaSidecarPolicyDecisionPoint.toInput only puts it when non-null), and a bare
+    	# `input.resource` reference is then UNDEFINED, which makes this whole object — and the
+    	# agents.allow call — undefined, silently denying every resource-less AI_AGENT REST call.
+    	# The MCP server (openbank-mcp-service) is the first caller to route AI_AGENT through
+    	# rest.allow with no resource; agent-service queries agents.allow directly and never hit this.
     	data.openbank.agents.allow with input as {
     		"agent": input.principal.id,
     		"tool": input.action,
-    		"resource": input.resource,
+    		"resource": object.get(input, "resource", null),
     	}
     }
 

--- a/openbank-infra/gitops/components/consent/consent-service.yaml
+++ b/openbank-infra/gitops/components/consent/consent-service.yaml
@@ -28,7 +28,7 @@ spec:
       annotations:
         # Rolls the pods when the OPA bundle changes — subPath mounts do NOT hot-reload.
         # Kept in sync by gen-consent-opa-bundle.sh (do not hand-edit).
-        openbank.tech/policy-checksum: "f9c044833ee78739"
+        openbank.tech/policy-checksum: "6befb0e8bcdd2309"
     spec:
       securityContext:
         runAsNonRoot: true

--- a/openbank-infra/gitops/components/copilot/copilot-opa-bundle.yaml
+++ b/openbank-infra/gitops/components/copilot/copilot-opa-bundle.yaml
@@ -9,7 +9,7 @@ metadata:
     app.kubernetes.io/name: copilot-service
     app.kubernetes.io/part-of: platform
   annotations:
-    openbank.tech/policy-checksum: "b2043da78e28000f"
+    openbank.tech/policy-checksum: "fa28e6a92fe82f03"
 data:
   rest.rego: |
     # SPDX-License-Identifier: Apache-2.0
@@ -121,10 +121,16 @@ data:
     	# skill_ok, none of which charter_allowed alone consults. Calling charter_allowed
     	# directly would let a fleet-wide hard-denied tool tier, or an agent's own
     	# tools.deny glob, silently reach a REST action anyway.
+    	# object.get (not input.resource): the PDP omits `resource` from the query entirely when
+    	# it is null (OpaSidecarPolicyDecisionPoint.toInput only puts it when non-null), and a bare
+    	# `input.resource` reference is then UNDEFINED, which makes this whole object — and the
+    	# agents.allow call — undefined, silently denying every resource-less AI_AGENT REST call.
+    	# The MCP server (openbank-mcp-service) is the first caller to route AI_AGENT through
+    	# rest.allow with no resource; agent-service queries agents.allow directly and never hit this.
     	data.openbank.agents.allow with input as {
     		"agent": input.principal.id,
     		"tool": input.action,
-    		"resource": input.resource,
+    		"resource": object.get(input, "resource", null),
     	}
     }
 

--- a/openbank-infra/gitops/components/copilot/copilot-service.yaml
+++ b/openbank-infra/gitops/components/copilot/copilot-service.yaml
@@ -29,7 +29,7 @@ spec:
       annotations:
         # Rolls the pod when the OPA bundle changes — subPath mounts do NOT hot-reload.
         # Kept in sync by gen-copilot-opa-bundle.sh (do not hand-edit).
-        openbank.tech/policy-checksum: "b2043da78e28000f"
+        openbank.tech/policy-checksum: "fa28e6a92fe82f03"
     spec:
       securityContext:
         runAsNonRoot: true

--- a/openbank-infra/gitops/components/customer-edge/customer-edge-opa-bundle.yaml
+++ b/openbank-infra/gitops/components/customer-edge/customer-edge-opa-bundle.yaml
@@ -10,7 +10,7 @@ metadata:
     app.kubernetes.io/name: customer-edge
     app.kubernetes.io/part-of: customer-edge
   annotations:
-    openbank.tech/policy-checksum: "1e9aeebd53e8aa3d"
+    openbank.tech/policy-checksum: "fafb98c3d419eced"
 data:
   rest.rego: |
     # SPDX-License-Identifier: Apache-2.0
@@ -122,10 +122,16 @@ data:
     	# skill_ok, none of which charter_allowed alone consults. Calling charter_allowed
     	# directly would let a fleet-wide hard-denied tool tier, or an agent's own
     	# tools.deny glob, silently reach a REST action anyway.
+    	# object.get (not input.resource): the PDP omits `resource` from the query entirely when
+    	# it is null (OpaSidecarPolicyDecisionPoint.toInput only puts it when non-null), and a bare
+    	# `input.resource` reference is then UNDEFINED, which makes this whole object — and the
+    	# agents.allow call — undefined, silently denying every resource-less AI_AGENT REST call.
+    	# The MCP server (openbank-mcp-service) is the first caller to route AI_AGENT through
+    	# rest.allow with no resource; agent-service queries agents.allow directly and never hit this.
     	data.openbank.agents.allow with input as {
     		"agent": input.principal.id,
     		"tool": input.action,
-    		"resource": input.resource,
+    		"resource": object.get(input, "resource", null),
     	}
     }
 

--- a/openbank-infra/gitops/components/customer-edge/customer-edge.yaml
+++ b/openbank-infra/gitops/components/customer-edge/customer-edge.yaml
@@ -65,7 +65,7 @@ spec:
       annotations:
         # Rolls the pod when the OPA bundle changes — subPath mounts do NOT hot-reload.
         # Kept in sync by gen-customer-edge-opa-bundle.sh (do not hand-edit).
-        openbank.tech/policy-checksum: "1e9aeebd53e8aa3d"
+        openbank.tech/policy-checksum: "fafb98c3d419eced"
     spec:
       # Dedicated SA so EKS Pod Identity can hand the edge (and ONLY the edge) the
       # feedback-screenshots S3 role — ADR-0192, openbank-infra/aws/envs/sandbox-platform/

--- a/openbank-infra/gitops/components/document-service/document-service-opa-bundle.yaml
+++ b/openbank-infra/gitops/components/document-service/document-service-opa-bundle.yaml
@@ -10,7 +10,7 @@ metadata:
     app.kubernetes.io/name: document-service
     app.kubernetes.io/part-of: documents
   annotations:
-    openbank.tech/policy-checksum: "1e9aeebd53e8aa3d"
+    openbank.tech/policy-checksum: "fafb98c3d419eced"
 data:
   rest.rego: |
     # SPDX-License-Identifier: Apache-2.0
@@ -122,10 +122,16 @@ data:
     	# skill_ok, none of which charter_allowed alone consults. Calling charter_allowed
     	# directly would let a fleet-wide hard-denied tool tier, or an agent's own
     	# tools.deny glob, silently reach a REST action anyway.
+    	# object.get (not input.resource): the PDP omits `resource` from the query entirely when
+    	# it is null (OpaSidecarPolicyDecisionPoint.toInput only puts it when non-null), and a bare
+    	# `input.resource` reference is then UNDEFINED, which makes this whole object — and the
+    	# agents.allow call — undefined, silently denying every resource-less AI_AGENT REST call.
+    	# The MCP server (openbank-mcp-service) is the first caller to route AI_AGENT through
+    	# rest.allow with no resource; agent-service queries agents.allow directly and never hit this.
     	data.openbank.agents.allow with input as {
     		"agent": input.principal.id,
     		"tool": input.action,
-    		"resource": input.resource,
+    		"resource": object.get(input, "resource", null),
     	}
     }
 

--- a/openbank-infra/gitops/components/document-service/document-service-service.yaml
+++ b/openbank-infra/gitops/components/document-service/document-service-service.yaml
@@ -43,7 +43,7 @@ spec:
       annotations:
         # Rolls the pods when the OPA bundle changes — subPath mounts do NOT hot-reload.
         # Kept in sync by gen-document-service-opa-bundle.sh (do not hand-edit).
-        openbank.tech/policy-checksum: "1e9aeebd53e8aa3d"
+        openbank.tech/policy-checksum: "fafb98c3d419eced"
     spec:
       # ADR-0162 D4 (continued): a dedicated SA (not `default`) is what OpenBao's Kubernetes-auth
       # role `document-service-signing` is bound to — least-privilege, one identity per consumer.

--- a/openbank-infra/gitops/components/fraud-service/fraud-opa-bundle.yaml
+++ b/openbank-infra/gitops/components/fraud-service/fraud-opa-bundle.yaml
@@ -9,7 +9,7 @@ metadata:
     app.kubernetes.io/name: fraud-service
     app.kubernetes.io/part-of: fraud
   annotations:
-    openbank.tech/policy-checksum: "202d5d0c3349f472"
+    openbank.tech/policy-checksum: "881d1e4b1f2f21c4"
 data:
   rest.rego: |
     # SPDX-License-Identifier: Apache-2.0
@@ -121,10 +121,16 @@ data:
     	# skill_ok, none of which charter_allowed alone consults. Calling charter_allowed
     	# directly would let a fleet-wide hard-denied tool tier, or an agent's own
     	# tools.deny glob, silently reach a REST action anyway.
+    	# object.get (not input.resource): the PDP omits `resource` from the query entirely when
+    	# it is null (OpaSidecarPolicyDecisionPoint.toInput only puts it when non-null), and a bare
+    	# `input.resource` reference is then UNDEFINED, which makes this whole object — and the
+    	# agents.allow call — undefined, silently denying every resource-less AI_AGENT REST call.
+    	# The MCP server (openbank-mcp-service) is the first caller to route AI_AGENT through
+    	# rest.allow with no resource; agent-service queries agents.allow directly and never hit this.
     	data.openbank.agents.allow with input as {
     		"agent": input.principal.id,
     		"tool": input.action,
-    		"resource": input.resource,
+    		"resource": object.get(input, "resource", null),
     	}
     }
 

--- a/openbank-infra/gitops/components/fraud-service/fraud-service.yaml
+++ b/openbank-infra/gitops/components/fraud-service/fraud-service.yaml
@@ -23,7 +23,7 @@ spec:
       annotations:
         # Rolls the pods when the OPA bundle changes — subPath mounts do NOT hot-reload.
         # Kept in sync by gen-fraud-opa-bundle.sh (do not hand-edit).
-        openbank.tech/policy-checksum: "202d5d0c3349f472"
+        openbank.tech/policy-checksum: "881d1e4b1f2f21c4"
     spec:
       securityContext:
         runAsNonRoot: true

--- a/openbank-infra/gitops/components/fx-service/fx-opa-bundle.yaml
+++ b/openbank-infra/gitops/components/fx-service/fx-opa-bundle.yaml
@@ -9,7 +9,7 @@ metadata:
     app.kubernetes.io/name: fx-service
     app.kubernetes.io/part-of: fx
   annotations:
-    openbank.tech/policy-checksum: "9827208042ced43c"
+    openbank.tech/policy-checksum: "ed370dc64d3f3e0f"
 data:
   rest.rego: |
     # SPDX-License-Identifier: Apache-2.0
@@ -121,10 +121,16 @@ data:
     	# skill_ok, none of which charter_allowed alone consults. Calling charter_allowed
     	# directly would let a fleet-wide hard-denied tool tier, or an agent's own
     	# tools.deny glob, silently reach a REST action anyway.
+    	# object.get (not input.resource): the PDP omits `resource` from the query entirely when
+    	# it is null (OpaSidecarPolicyDecisionPoint.toInput only puts it when non-null), and a bare
+    	# `input.resource` reference is then UNDEFINED, which makes this whole object — and the
+    	# agents.allow call — undefined, silently denying every resource-less AI_AGENT REST call.
+    	# The MCP server (openbank-mcp-service) is the first caller to route AI_AGENT through
+    	# rest.allow with no resource; agent-service queries agents.allow directly and never hit this.
     	data.openbank.agents.allow with input as {
     		"agent": input.principal.id,
     		"tool": input.action,
-    		"resource": input.resource,
+    		"resource": object.get(input, "resource", null),
     	}
     }
 

--- a/openbank-infra/gitops/components/fx-service/fx-service.yaml
+++ b/openbank-infra/gitops/components/fx-service/fx-service.yaml
@@ -22,7 +22,7 @@ spec:
       annotations:
         # Rolls the pods when the OPA bundle changes — subPath mounts do NOT hot-reload.
         # Kept in sync by gen-fx-opa-bundle.sh (do not hand-edit).
-        openbank.tech/policy-checksum: "9827208042ced43c"
+        openbank.tech/policy-checksum: "ed370dc64d3f3e0f"
     spec:
       securityContext:
         runAsNonRoot: true

--- a/openbank-infra/gitops/components/interest-service/interest-opa-bundle.yaml
+++ b/openbank-infra/gitops/components/interest-service/interest-opa-bundle.yaml
@@ -9,7 +9,7 @@ metadata:
     app.kubernetes.io/name: interest-service
     app.kubernetes.io/part-of: interest
   annotations:
-    openbank.tech/policy-checksum: "02669ed0d220482d"
+    openbank.tech/policy-checksum: "0f357f8144d0a445"
 data:
   rest.rego: |
     # SPDX-License-Identifier: Apache-2.0
@@ -121,10 +121,16 @@ data:
     	# skill_ok, none of which charter_allowed alone consults. Calling charter_allowed
     	# directly would let a fleet-wide hard-denied tool tier, or an agent's own
     	# tools.deny glob, silently reach a REST action anyway.
+    	# object.get (not input.resource): the PDP omits `resource` from the query entirely when
+    	# it is null (OpaSidecarPolicyDecisionPoint.toInput only puts it when non-null), and a bare
+    	# `input.resource` reference is then UNDEFINED, which makes this whole object — and the
+    	# agents.allow call — undefined, silently denying every resource-less AI_AGENT REST call.
+    	# The MCP server (openbank-mcp-service) is the first caller to route AI_AGENT through
+    	# rest.allow with no resource; agent-service queries agents.allow directly and never hit this.
     	data.openbank.agents.allow with input as {
     		"agent": input.principal.id,
     		"tool": input.action,
-    		"resource": input.resource,
+    		"resource": object.get(input, "resource", null),
     	}
     }
 

--- a/openbank-infra/gitops/components/interest-service/interest-service.yaml
+++ b/openbank-infra/gitops/components/interest-service/interest-service.yaml
@@ -16,7 +16,7 @@ spec:
       annotations:
         # Rolls the pods when the OPA bundle changes — subPath mounts do NOT hot-reload.
         # Kept in sync by gen-interest-opa-bundle.sh (do not hand-edit).
-        openbank.tech/policy-checksum: "02669ed0d220482d"
+        openbank.tech/policy-checksum: "0f357f8144d0a445"
     spec:
       securityContext:
         runAsNonRoot: true

--- a/openbank-infra/gitops/components/ledger/ledger-opa-bundle.yaml
+++ b/openbank-infra/gitops/components/ledger/ledger-opa-bundle.yaml
@@ -9,7 +9,7 @@ metadata:
     app.kubernetes.io/name: ledger-service
     app.kubernetes.io/part-of: ledger
   annotations:
-    openbank.tech/policy-checksum: "8c6defaaddcb9a3c"
+    openbank.tech/policy-checksum: "3fdf4c343e9e40ed"
 data:
   rest.rego: |
     # SPDX-License-Identifier: Apache-2.0
@@ -121,10 +121,16 @@ data:
     	# skill_ok, none of which charter_allowed alone consults. Calling charter_allowed
     	# directly would let a fleet-wide hard-denied tool tier, or an agent's own
     	# tools.deny glob, silently reach a REST action anyway.
+    	# object.get (not input.resource): the PDP omits `resource` from the query entirely when
+    	# it is null (OpaSidecarPolicyDecisionPoint.toInput only puts it when non-null), and a bare
+    	# `input.resource` reference is then UNDEFINED, which makes this whole object — and the
+    	# agents.allow call — undefined, silently denying every resource-less AI_AGENT REST call.
+    	# The MCP server (openbank-mcp-service) is the first caller to route AI_AGENT through
+    	# rest.allow with no resource; agent-service queries agents.allow directly and never hit this.
     	data.openbank.agents.allow with input as {
     		"agent": input.principal.id,
     		"tool": input.action,
-    		"resource": input.resource,
+    		"resource": object.get(input, "resource", null),
     	}
     }
 

--- a/openbank-infra/gitops/components/ledger/ledger-service.yaml
+++ b/openbank-infra/gitops/components/ledger/ledger-service.yaml
@@ -38,7 +38,7 @@ spec:
       annotations:
         # Rolls the pods when the OPA bundle changes — subPath mounts do NOT hot-reload.
         # Kept in sync by gen-ledger-opa-bundle.sh (do not hand-edit).
-        openbank.tech/policy-checksum: "8c6defaaddcb9a3c"
+        openbank.tech/policy-checksum: "3fdf4c343e9e40ed"
     spec:
       securityContext:
         runAsNonRoot: true

--- a/openbank-infra/gitops/components/lending/lending-opa-bundle.yaml
+++ b/openbank-infra/gitops/components/lending/lending-opa-bundle.yaml
@@ -9,7 +9,7 @@ metadata:
     app.kubernetes.io/name: lending-service
     app.kubernetes.io/part-of: lending
   annotations:
-    openbank.tech/policy-checksum: "1d389fd799428d61"
+    openbank.tech/policy-checksum: "634ff0ff70659504"
 data:
   rest.rego: |
     # SPDX-License-Identifier: Apache-2.0
@@ -121,10 +121,16 @@ data:
     	# skill_ok, none of which charter_allowed alone consults. Calling charter_allowed
     	# directly would let a fleet-wide hard-denied tool tier, or an agent's own
     	# tools.deny glob, silently reach a REST action anyway.
+    	# object.get (not input.resource): the PDP omits `resource` from the query entirely when
+    	# it is null (OpaSidecarPolicyDecisionPoint.toInput only puts it when non-null), and a bare
+    	# `input.resource` reference is then UNDEFINED, which makes this whole object — and the
+    	# agents.allow call — undefined, silently denying every resource-less AI_AGENT REST call.
+    	# The MCP server (openbank-mcp-service) is the first caller to route AI_AGENT through
+    	# rest.allow with no resource; agent-service queries agents.allow directly and never hit this.
     	data.openbank.agents.allow with input as {
     		"agent": input.principal.id,
     		"tool": input.action,
-    		"resource": input.resource,
+    		"resource": object.get(input, "resource", null),
     	}
     }
 

--- a/openbank-infra/gitops/components/lending/lending-service.yaml
+++ b/openbank-infra/gitops/components/lending/lending-service.yaml
@@ -34,7 +34,7 @@ spec:
       annotations:
         # Rolls the pods when the OPA bundle changes — subPath mounts do NOT hot-reload.
         # Kept in sync by gen-lending-opa-bundle.sh (do not hand-edit).
-        openbank.tech/policy-checksum: "1d389fd799428d61"
+        openbank.tech/policy-checksum: "634ff0ff70659504"
     spec:
       securityContext:
         runAsNonRoot: true

--- a/openbank-infra/gitops/components/mcp/mcp-opa-bundle.yaml
+++ b/openbank-infra/gitops/components/mcp/mcp-opa-bundle.yaml
@@ -9,7 +9,7 @@ metadata:
     app.kubernetes.io/name: mcp-service
     app.kubernetes.io/part-of: platform
   annotations:
-    openbank.tech/policy-checksum: "8247b3f401bef1b1"
+    openbank.tech/policy-checksum: "921b93672df2d82b"
 data:
   rest.rego: |
     # SPDX-License-Identifier: Apache-2.0
@@ -121,10 +121,16 @@ data:
     	# skill_ok, none of which charter_allowed alone consults. Calling charter_allowed
     	# directly would let a fleet-wide hard-denied tool tier, or an agent's own
     	# tools.deny glob, silently reach a REST action anyway.
+    	# object.get (not input.resource): the PDP omits `resource` from the query entirely when
+    	# it is null (OpaSidecarPolicyDecisionPoint.toInput only puts it when non-null), and a bare
+    	# `input.resource` reference is then UNDEFINED, which makes this whole object — and the
+    	# agents.allow call — undefined, silently denying every resource-less AI_AGENT REST call.
+    	# The MCP server (openbank-mcp-service) is the first caller to route AI_AGENT through
+    	# rest.allow with no resource; agent-service queries agents.allow directly and never hit this.
     	data.openbank.agents.allow with input as {
     		"agent": input.principal.id,
     		"tool": input.action,
-    		"resource": input.resource,
+    		"resource": object.get(input, "resource", null),
     	}
     }
 

--- a/openbank-infra/gitops/components/mcp/mcp-service.yaml
+++ b/openbank-infra/gitops/components/mcp/mcp-service.yaml
@@ -29,7 +29,7 @@ spec:
       annotations:
         # Rolls the pod when the OPA bundle changes — subPath mounts do NOT hot-reload.
         # Kept in sync by gen-mcp-opa-bundle.sh (do not hand-edit).
-        openbank.tech/policy-checksum: "8247b3f401bef1b1"
+        openbank.tech/policy-checksum: "921b93672df2d82b"
     spec:
       securityContext:
         runAsNonRoot: true

--- a/openbank-infra/gitops/components/notifications/notification-service-opa-bundle.yaml
+++ b/openbank-infra/gitops/components/notifications/notification-service-opa-bundle.yaml
@@ -10,7 +10,7 @@ metadata:
     app.kubernetes.io/name: notification-service
     app.kubernetes.io/part-of: notifications
   annotations:
-    openbank.tech/policy-checksum: "1e9aeebd53e8aa3d"
+    openbank.tech/policy-checksum: "fafb98c3d419eced"
 data:
   rest.rego: |
     # SPDX-License-Identifier: Apache-2.0
@@ -122,10 +122,16 @@ data:
     	# skill_ok, none of which charter_allowed alone consults. Calling charter_allowed
     	# directly would let a fleet-wide hard-denied tool tier, or an agent's own
     	# tools.deny glob, silently reach a REST action anyway.
+    	# object.get (not input.resource): the PDP omits `resource` from the query entirely when
+    	# it is null (OpaSidecarPolicyDecisionPoint.toInput only puts it when non-null), and a bare
+    	# `input.resource` reference is then UNDEFINED, which makes this whole object — and the
+    	# agents.allow call — undefined, silently denying every resource-less AI_AGENT REST call.
+    	# The MCP server (openbank-mcp-service) is the first caller to route AI_AGENT through
+    	# rest.allow with no resource; agent-service queries agents.allow directly and never hit this.
     	data.openbank.agents.allow with input as {
     		"agent": input.principal.id,
     		"tool": input.action,
-    		"resource": input.resource,
+    		"resource": object.get(input, "resource", null),
     	}
     }
 

--- a/openbank-infra/gitops/components/notifications/notification-service.yaml
+++ b/openbank-infra/gitops/components/notifications/notification-service.yaml
@@ -39,7 +39,7 @@ spec:
       annotations:
         # Rolls the Deployment when the OPA policy bundle changes (subPath mounts don't
         # hot-reload). Kept in sync by gen-notification-opa-bundle.sh.
-        openbank.tech/policy-checksum: "1e9aeebd53e8aa3d"
+        openbank.tech/policy-checksum: "fafb98c3d419eced"
       labels:
         app.kubernetes.io/name: notification-service
         app.kubernetes.io/part-of: notifications

--- a/openbank-infra/gitops/components/party/party-opa-bundle.yaml
+++ b/openbank-infra/gitops/components/party/party-opa-bundle.yaml
@@ -9,7 +9,7 @@ metadata:
     app.kubernetes.io/name: party-service
     app.kubernetes.io/part-of: party
   annotations:
-    openbank.tech/policy-checksum: "fce9ad005edc9253"
+    openbank.tech/policy-checksum: "3077beea8938ba90"
 data:
   rest.rego: |
     # SPDX-License-Identifier: Apache-2.0
@@ -121,10 +121,16 @@ data:
     	# skill_ok, none of which charter_allowed alone consults. Calling charter_allowed
     	# directly would let a fleet-wide hard-denied tool tier, or an agent's own
     	# tools.deny glob, silently reach a REST action anyway.
+    	# object.get (not input.resource): the PDP omits `resource` from the query entirely when
+    	# it is null (OpaSidecarPolicyDecisionPoint.toInput only puts it when non-null), and a bare
+    	# `input.resource` reference is then UNDEFINED, which makes this whole object — and the
+    	# agents.allow call — undefined, silently denying every resource-less AI_AGENT REST call.
+    	# The MCP server (openbank-mcp-service) is the first caller to route AI_AGENT through
+    	# rest.allow with no resource; agent-service queries agents.allow directly and never hit this.
     	data.openbank.agents.allow with input as {
     		"agent": input.principal.id,
     		"tool": input.action,
-    		"resource": input.resource,
+    		"resource": object.get(input, "resource", null),
     	}
     }
 

--- a/openbank-infra/gitops/components/party/party-service.yaml
+++ b/openbank-infra/gitops/components/party/party-service.yaml
@@ -22,7 +22,7 @@ spec:
       annotations:
         # Rolls the pod when the OPA bundle changes — subPath mounts do NOT hot-reload.
         # Kept in sync by gen-party-opa-bundle.sh (do not hand-edit).
-        openbank.tech/policy-checksum: "fce9ad005edc9253"
+        openbank.tech/policy-checksum: "3077beea8938ba90"
       labels:
         app.kubernetes.io/name: party-service
         app.kubernetes.io/part-of: party

--- a/openbank-infra/gitops/components/payments/card-issuance-opa-bundle.yaml
+++ b/openbank-infra/gitops/components/payments/card-issuance-opa-bundle.yaml
@@ -9,7 +9,7 @@ metadata:
     app.kubernetes.io/name: card-issuance-service
     app.kubernetes.io/part-of: payments
   annotations:
-    openbank.tech/policy-checksum: "a6ddb4ffccbbbe71"
+    openbank.tech/policy-checksum: "a45b80b51f602655"
 data:
   rest.rego: |
     # SPDX-License-Identifier: Apache-2.0
@@ -121,10 +121,16 @@ data:
     	# skill_ok, none of which charter_allowed alone consults. Calling charter_allowed
     	# directly would let a fleet-wide hard-denied tool tier, or an agent's own
     	# tools.deny glob, silently reach a REST action anyway.
+    	# object.get (not input.resource): the PDP omits `resource` from the query entirely when
+    	# it is null (OpaSidecarPolicyDecisionPoint.toInput only puts it when non-null), and a bare
+    	# `input.resource` reference is then UNDEFINED, which makes this whole object — and the
+    	# agents.allow call — undefined, silently denying every resource-less AI_AGENT REST call.
+    	# The MCP server (openbank-mcp-service) is the first caller to route AI_AGENT through
+    	# rest.allow with no resource; agent-service queries agents.allow directly and never hit this.
     	data.openbank.agents.allow with input as {
     		"agent": input.principal.id,
     		"tool": input.action,
-    		"resource": input.resource,
+    		"resource": object.get(input, "resource", null),
     	}
     }
 

--- a/openbank-infra/gitops/components/payments/clearing-opa-bundle.yaml
+++ b/openbank-infra/gitops/components/payments/clearing-opa-bundle.yaml
@@ -9,7 +9,7 @@ metadata:
     app.kubernetes.io/name: clearing-service
     app.kubernetes.io/part-of: payments
   annotations:
-    openbank.tech/policy-checksum: "f4473e6c4382cd3e"
+    openbank.tech/policy-checksum: "86a4f28479570b21"
 data:
   rest.rego: |
     # SPDX-License-Identifier: Apache-2.0
@@ -121,10 +121,16 @@ data:
     	# skill_ok, none of which charter_allowed alone consults. Calling charter_allowed
     	# directly would let a fleet-wide hard-denied tool tier, or an agent's own
     	# tools.deny glob, silently reach a REST action anyway.
+    	# object.get (not input.resource): the PDP omits `resource` from the query entirely when
+    	# it is null (OpaSidecarPolicyDecisionPoint.toInput only puts it when non-null), and a bare
+    	# `input.resource` reference is then UNDEFINED, which makes this whole object — and the
+    	# agents.allow call — undefined, silently denying every resource-less AI_AGENT REST call.
+    	# The MCP server (openbank-mcp-service) is the first caller to route AI_AGENT through
+    	# rest.allow with no resource; agent-service queries agents.allow directly and never hit this.
     	data.openbank.agents.allow with input as {
     		"agent": input.principal.id,
     		"tool": input.action,
-    		"resource": input.resource,
+    		"resource": object.get(input, "resource", null),
     	}
     }
 

--- a/openbank-infra/gitops/components/payments/domestic-payment-opa-bundle.yaml
+++ b/openbank-infra/gitops/components/payments/domestic-payment-opa-bundle.yaml
@@ -9,7 +9,7 @@ metadata:
     app.kubernetes.io/name: domestic-payment
     app.kubernetes.io/part-of: payments
   annotations:
-    openbank.tech/policy-checksum: "9d88f433cccff27b"
+    openbank.tech/policy-checksum: "ccc815f1c00c3593"
 data:
   rest.rego: |
     # SPDX-License-Identifier: Apache-2.0
@@ -121,10 +121,16 @@ data:
     	# skill_ok, none of which charter_allowed alone consults. Calling charter_allowed
     	# directly would let a fleet-wide hard-denied tool tier, or an agent's own
     	# tools.deny glob, silently reach a REST action anyway.
+    	# object.get (not input.resource): the PDP omits `resource` from the query entirely when
+    	# it is null (OpaSidecarPolicyDecisionPoint.toInput only puts it when non-null), and a bare
+    	# `input.resource` reference is then UNDEFINED, which makes this whole object — and the
+    	# agents.allow call — undefined, silently denying every resource-less AI_AGENT REST call.
+    	# The MCP server (openbank-mcp-service) is the first caller to route AI_AGENT through
+    	# rest.allow with no resource; agent-service queries agents.allow directly and never hit this.
     	data.openbank.agents.allow with input as {
     		"agent": input.principal.id,
     		"tool": input.action,
-    		"resource": input.resource,
+    		"resource": object.get(input, "resource", null),
     	}
     }
 

--- a/openbank-infra/gitops/components/payments/payments-services.yaml
+++ b/openbank-infra/gitops/components/payments/payments-services.yaml
@@ -42,7 +42,7 @@ spec:
         # Rolls the pods when the OPA bundle changes — subPath mounts do NOT hot-reload.
         # Kept in sync by gen-transaction-opa-bundle.sh via the trailing marker comment
         # (do not hand-edit, do not drop the marker).
-        openbank.tech/policy-checksum: "ef07c90a32659b20" # transaction-opa-bundle
+        openbank.tech/policy-checksum: "9ce5515ea6885e4c" # transaction-opa-bundle
     spec:
       securityContext:
         runAsNonRoot: true
@@ -375,7 +375,7 @@ spec:
       annotations:
         # Rolls the pods when the OPA bundle changes — subPath mounts do NOT hot-reload.
         # Kept in sync by gen-sepa-payment-opa-bundle.sh (do not hand-edit).
-        openbank.tech/policy-checksum: "01e0013e3fe93cf4"
+        openbank.tech/policy-checksum: "e6c1f19908500390"
     spec:
       securityContext:
         runAsNonRoot: true
@@ -729,7 +729,7 @@ spec:
         # Rolls the pods when the OPA bundle changes — subPath mounts do NOT hot-reload.
         # Kept in sync by gen-domestic-payment-opa-bundle.sh via the trailing marker
         # comment (do not hand-edit, do not drop the marker).
-        openbank.tech/policy-checksum: "9d88f433cccff27b" # domestic-payment-opa-bundle
+        openbank.tech/policy-checksum: "ccc815f1c00c3593" # domestic-payment-opa-bundle
     spec:
       securityContext:
         runAsNonRoot: true
@@ -1053,7 +1053,7 @@ spec:
       annotations:
         # Rolls the pods when the OPA bundle changes — subPath mounts do NOT hot-reload.
         # Kept in sync by gen-sepa-instant-opa-bundle.sh (do not hand-edit).
-        openbank.tech/policy-checksum: "21ea9ca804287a85"
+        openbank.tech/policy-checksum: "65d17f7408f20b8e"
     spec:
       securityContext:
         runAsNonRoot: true
@@ -1369,7 +1369,7 @@ spec:
         # Rolls the pods when the OPA bundle changes — subPath mounts do NOT hot-reload.
         # Kept in sync by gen-clearing-opa-bundle.sh via the trailing marker comment
         # (do not hand-edit, do not drop the marker).
-        openbank.tech/policy-checksum: "f4473e6c4382cd3e" # clearing-opa-bundle
+        openbank.tech/policy-checksum: "86a4f28479570b21" # clearing-opa-bundle
     spec:
       securityContext:
         runAsNonRoot: true
@@ -1658,7 +1658,7 @@ spec:
       annotations:
         # Rolls the pod when the OPA bundle changes (ADR-0034). Value is stamped by
         # gen-standing-order-opa-bundle.sh — do not hand-edit.
-        openbank.tech/policy-checksum: "42245ee4c8df9bf2" # standing-order-opa-bundle
+        openbank.tech/policy-checksum: "f1abad11b19931a5" # standing-order-opa-bundle
     spec:
       securityContext:
         runAsNonRoot: true
@@ -1911,7 +1911,7 @@ spec:
       annotations:
         # Rolls the pods when the OPA bundle changes — subPath mounts do NOT hot-reload.
         # Kept in sync by gen-card-issuance-opa-bundle.sh (do not hand-edit).
-        openbank.tech/policy-checksum: "a6ddb4ffccbbbe71"
+        openbank.tech/policy-checksum: "a45b80b51f602655"
     spec:
       securityContext:
         runAsNonRoot: true
@@ -2178,7 +2178,7 @@ spec:
         # Rolls the pods when the OPA bundle changes — subPath mounts do NOT hot-reload.
         # Kept in sync by gen-settlement-opa-bundle.sh via the trailing marker comment
         # (do not hand-edit, do not drop the marker).
-        openbank.tech/policy-checksum: "151e6696cefa47a3" # settlement-opa-bundle
+        openbank.tech/policy-checksum: "8a8cca1f49b789af" # settlement-opa-bundle
     spec:
       securityContext:
         runAsNonRoot: true
@@ -2579,7 +2579,7 @@ spec:
       annotations:
         # Rolls the pods when the OPA bundle changes — subPath mounts do NOT hot-reload.
         # Kept in sync by gen-swift-opa-bundle.sh (do not hand-edit).
-        openbank.tech/policy-checksum: "322e699170ce79f8"
+        openbank.tech/policy-checksum: "db6aa003bb3319fe"
     spec:
       securityContext:
         runAsNonRoot: true
@@ -2893,7 +2893,7 @@ spec:
       annotations:
         # Rolls the pods when the OPA bundle changes — subPath mounts do NOT hot-reload.
         # Kept in sync by gen-vop-opa-bundle.sh (do not hand-edit).
-        openbank.tech/policy-checksum: "7bb427539fa5190b"
+        openbank.tech/policy-checksum: "bb0176d4cca4827e"
     spec:
       securityContext:
         runAsNonRoot: true

--- a/openbank-infra/gitops/components/payments/sepa-instant-opa-bundle.yaml
+++ b/openbank-infra/gitops/components/payments/sepa-instant-opa-bundle.yaml
@@ -9,7 +9,7 @@ metadata:
     app.kubernetes.io/name: sepa-instant
     app.kubernetes.io/part-of: payments
   annotations:
-    openbank.tech/policy-checksum: "21ea9ca804287a85"
+    openbank.tech/policy-checksum: "65d17f7408f20b8e"
 data:
   rest.rego: |
     # SPDX-License-Identifier: Apache-2.0
@@ -121,10 +121,16 @@ data:
     	# skill_ok, none of which charter_allowed alone consults. Calling charter_allowed
     	# directly would let a fleet-wide hard-denied tool tier, or an agent's own
     	# tools.deny glob, silently reach a REST action anyway.
+    	# object.get (not input.resource): the PDP omits `resource` from the query entirely when
+    	# it is null (OpaSidecarPolicyDecisionPoint.toInput only puts it when non-null), and a bare
+    	# `input.resource` reference is then UNDEFINED, which makes this whole object — and the
+    	# agents.allow call — undefined, silently denying every resource-less AI_AGENT REST call.
+    	# The MCP server (openbank-mcp-service) is the first caller to route AI_AGENT through
+    	# rest.allow with no resource; agent-service queries agents.allow directly and never hit this.
     	data.openbank.agents.allow with input as {
     		"agent": input.principal.id,
     		"tool": input.action,
-    		"resource": input.resource,
+    		"resource": object.get(input, "resource", null),
     	}
     }
 

--- a/openbank-infra/gitops/components/payments/sepa-payment-opa-bundle.yaml
+++ b/openbank-infra/gitops/components/payments/sepa-payment-opa-bundle.yaml
@@ -9,7 +9,7 @@ metadata:
     app.kubernetes.io/name: sepa-payment
     app.kubernetes.io/part-of: payments
   annotations:
-    openbank.tech/policy-checksum: "01e0013e3fe93cf4"
+    openbank.tech/policy-checksum: "e6c1f19908500390"
 data:
   rest.rego: |
     # SPDX-License-Identifier: Apache-2.0
@@ -121,10 +121,16 @@ data:
     	# skill_ok, none of which charter_allowed alone consults. Calling charter_allowed
     	# directly would let a fleet-wide hard-denied tool tier, or an agent's own
     	# tools.deny glob, silently reach a REST action anyway.
+    	# object.get (not input.resource): the PDP omits `resource` from the query entirely when
+    	# it is null (OpaSidecarPolicyDecisionPoint.toInput only puts it when non-null), and a bare
+    	# `input.resource` reference is then UNDEFINED, which makes this whole object — and the
+    	# agents.allow call — undefined, silently denying every resource-less AI_AGENT REST call.
+    	# The MCP server (openbank-mcp-service) is the first caller to route AI_AGENT through
+    	# rest.allow with no resource; agent-service queries agents.allow directly and never hit this.
     	data.openbank.agents.allow with input as {
     		"agent": input.principal.id,
     		"tool": input.action,
-    		"resource": input.resource,
+    		"resource": object.get(input, "resource", null),
     	}
     }
 

--- a/openbank-infra/gitops/components/payments/settlement-opa-bundle.yaml
+++ b/openbank-infra/gitops/components/payments/settlement-opa-bundle.yaml
@@ -9,7 +9,7 @@ metadata:
     app.kubernetes.io/name: settlement-service
     app.kubernetes.io/part-of: payments
   annotations:
-    openbank.tech/policy-checksum: "151e6696cefa47a3"
+    openbank.tech/policy-checksum: "8a8cca1f49b789af"
 data:
   rest.rego: |
     # SPDX-License-Identifier: Apache-2.0
@@ -121,10 +121,16 @@ data:
     	# skill_ok, none of which charter_allowed alone consults. Calling charter_allowed
     	# directly would let a fleet-wide hard-denied tool tier, or an agent's own
     	# tools.deny glob, silently reach a REST action anyway.
+    	# object.get (not input.resource): the PDP omits `resource` from the query entirely when
+    	# it is null (OpaSidecarPolicyDecisionPoint.toInput only puts it when non-null), and a bare
+    	# `input.resource` reference is then UNDEFINED, which makes this whole object — and the
+    	# agents.allow call — undefined, silently denying every resource-less AI_AGENT REST call.
+    	# The MCP server (openbank-mcp-service) is the first caller to route AI_AGENT through
+    	# rest.allow with no resource; agent-service queries agents.allow directly and never hit this.
     	data.openbank.agents.allow with input as {
     		"agent": input.principal.id,
     		"tool": input.action,
-    		"resource": input.resource,
+    		"resource": object.get(input, "resource", null),
     	}
     }
 

--- a/openbank-infra/gitops/components/payments/standing-order-opa-bundle.yaml
+++ b/openbank-infra/gitops/components/payments/standing-order-opa-bundle.yaml
@@ -9,7 +9,7 @@ metadata:
     app.kubernetes.io/name: standing-order-service
     app.kubernetes.io/part-of: payments
   annotations:
-    openbank.tech/policy-checksum: "42245ee4c8df9bf2"
+    openbank.tech/policy-checksum: "f1abad11b19931a5"
 data:
   rest.rego: |
     # SPDX-License-Identifier: Apache-2.0
@@ -121,10 +121,16 @@ data:
     	# skill_ok, none of which charter_allowed alone consults. Calling charter_allowed
     	# directly would let a fleet-wide hard-denied tool tier, or an agent's own
     	# tools.deny glob, silently reach a REST action anyway.
+    	# object.get (not input.resource): the PDP omits `resource` from the query entirely when
+    	# it is null (OpaSidecarPolicyDecisionPoint.toInput only puts it when non-null), and a bare
+    	# `input.resource` reference is then UNDEFINED, which makes this whole object — and the
+    	# agents.allow call — undefined, silently denying every resource-less AI_AGENT REST call.
+    	# The MCP server (openbank-mcp-service) is the first caller to route AI_AGENT through
+    	# rest.allow with no resource; agent-service queries agents.allow directly and never hit this.
     	data.openbank.agents.allow with input as {
     		"agent": input.principal.id,
     		"tool": input.action,
-    		"resource": input.resource,
+    		"resource": object.get(input, "resource", null),
     	}
     }
 

--- a/openbank-infra/gitops/components/payments/swift-opa-bundle.yaml
+++ b/openbank-infra/gitops/components/payments/swift-opa-bundle.yaml
@@ -9,7 +9,7 @@ metadata:
     app.kubernetes.io/name: swift-service
     app.kubernetes.io/part-of: payments
   annotations:
-    openbank.tech/policy-checksum: "322e699170ce79f8"
+    openbank.tech/policy-checksum: "db6aa003bb3319fe"
 data:
   rest.rego: |
     # SPDX-License-Identifier: Apache-2.0
@@ -121,10 +121,16 @@ data:
     	# skill_ok, none of which charter_allowed alone consults. Calling charter_allowed
     	# directly would let a fleet-wide hard-denied tool tier, or an agent's own
     	# tools.deny glob, silently reach a REST action anyway.
+    	# object.get (not input.resource): the PDP omits `resource` from the query entirely when
+    	# it is null (OpaSidecarPolicyDecisionPoint.toInput only puts it when non-null), and a bare
+    	# `input.resource` reference is then UNDEFINED, which makes this whole object — and the
+    	# agents.allow call — undefined, silently denying every resource-less AI_AGENT REST call.
+    	# The MCP server (openbank-mcp-service) is the first caller to route AI_AGENT through
+    	# rest.allow with no resource; agent-service queries agents.allow directly and never hit this.
     	data.openbank.agents.allow with input as {
     		"agent": input.principal.id,
     		"tool": input.action,
-    		"resource": input.resource,
+    		"resource": object.get(input, "resource", null),
     	}
     }
 

--- a/openbank-infra/gitops/components/payments/transaction-opa-bundle.yaml
+++ b/openbank-infra/gitops/components/payments/transaction-opa-bundle.yaml
@@ -9,7 +9,7 @@ metadata:
     app.kubernetes.io/name: transaction-service
     app.kubernetes.io/part-of: payments
   annotations:
-    openbank.tech/policy-checksum: "ef07c90a32659b20"
+    openbank.tech/policy-checksum: "9ce5515ea6885e4c"
 data:
   rest.rego: |
     # SPDX-License-Identifier: Apache-2.0
@@ -121,10 +121,16 @@ data:
     	# skill_ok, none of which charter_allowed alone consults. Calling charter_allowed
     	# directly would let a fleet-wide hard-denied tool tier, or an agent's own
     	# tools.deny glob, silently reach a REST action anyway.
+    	# object.get (not input.resource): the PDP omits `resource` from the query entirely when
+    	# it is null (OpaSidecarPolicyDecisionPoint.toInput only puts it when non-null), and a bare
+    	# `input.resource` reference is then UNDEFINED, which makes this whole object — and the
+    	# agents.allow call — undefined, silently denying every resource-less AI_AGENT REST call.
+    	# The MCP server (openbank-mcp-service) is the first caller to route AI_AGENT through
+    	# rest.allow with no resource; agent-service queries agents.allow directly and never hit this.
     	data.openbank.agents.allow with input as {
     		"agent": input.principal.id,
     		"tool": input.action,
-    		"resource": input.resource,
+    		"resource": object.get(input, "resource", null),
     	}
     }
 

--- a/openbank-infra/gitops/components/payments/vop-opa-bundle.yaml
+++ b/openbank-infra/gitops/components/payments/vop-opa-bundle.yaml
@@ -9,7 +9,7 @@ metadata:
     app.kubernetes.io/name: vop-service
     app.kubernetes.io/part-of: payments
   annotations:
-    openbank.tech/policy-checksum: "7bb427539fa5190b"
+    openbank.tech/policy-checksum: "bb0176d4cca4827e"
 data:
   rest.rego: |
     # SPDX-License-Identifier: Apache-2.0
@@ -121,10 +121,16 @@ data:
     	# skill_ok, none of which charter_allowed alone consults. Calling charter_allowed
     	# directly would let a fleet-wide hard-denied tool tier, or an agent's own
     	# tools.deny glob, silently reach a REST action anyway.
+    	# object.get (not input.resource): the PDP omits `resource` from the query entirely when
+    	# it is null (OpaSidecarPolicyDecisionPoint.toInput only puts it when non-null), and a bare
+    	# `input.resource` reference is then UNDEFINED, which makes this whole object — and the
+    	# agents.allow call — undefined, silently denying every resource-less AI_AGENT REST call.
+    	# The MCP server (openbank-mcp-service) is the first caller to route AI_AGENT through
+    	# rest.allow with no resource; agent-service queries agents.allow directly and never hit this.
     	data.openbank.agents.allow with input as {
     		"agent": input.principal.id,
     		"tool": input.action,
-    		"resource": input.resource,
+    		"resource": object.get(input, "resource", null),
     	}
     }
 

--- a/openbank-infra/gitops/components/pid/pid-opa-bundle.yaml
+++ b/openbank-infra/gitops/components/pid/pid-opa-bundle.yaml
@@ -9,7 +9,7 @@ metadata:
     app.kubernetes.io/name: pid-service
     app.kubernetes.io/part-of: pid
   annotations:
-    openbank.tech/policy-checksum: "5b665140059aa543"
+    openbank.tech/policy-checksum: "77c9e04262c27e0b"
 data:
   rest.rego: |
     # SPDX-License-Identifier: Apache-2.0
@@ -121,10 +121,16 @@ data:
     	# skill_ok, none of which charter_allowed alone consults. Calling charter_allowed
     	# directly would let a fleet-wide hard-denied tool tier, or an agent's own
     	# tools.deny glob, silently reach a REST action anyway.
+    	# object.get (not input.resource): the PDP omits `resource` from the query entirely when
+    	# it is null (OpaSidecarPolicyDecisionPoint.toInput only puts it when non-null), and a bare
+    	# `input.resource` reference is then UNDEFINED, which makes this whole object — and the
+    	# agents.allow call — undefined, silently denying every resource-less AI_AGENT REST call.
+    	# The MCP server (openbank-mcp-service) is the first caller to route AI_AGENT through
+    	# rest.allow with no resource; agent-service queries agents.allow directly and never hit this.
     	data.openbank.agents.allow with input as {
     		"agent": input.principal.id,
     		"tool": input.action,
-    		"resource": input.resource,
+    		"resource": object.get(input, "resource", null),
     	}
     }
 

--- a/openbank-infra/gitops/components/pid/pid-service.yaml
+++ b/openbank-infra/gitops/components/pid/pid-service.yaml
@@ -22,7 +22,7 @@ spec:
       annotations:
         # Rolls the pod when the OPA bundle changes — subPath mounts do NOT hot-reload.
         # Kept in sync by gen-pid-opa-bundle.sh (do not hand-edit).
-        openbank.tech/policy-checksum: "5b665140059aa543"
+        openbank.tech/policy-checksum: "77c9e04262c27e0b"
     spec:
       securityContext:
         runAsNonRoot: true

--- a/openbank-infra/gitops/components/sanctions-service/sanctions-opa-bundle.yaml
+++ b/openbank-infra/gitops/components/sanctions-service/sanctions-opa-bundle.yaml
@@ -9,7 +9,7 @@ metadata:
     app.kubernetes.io/name: sanctions-service
     app.kubernetes.io/part-of: sanctions
   annotations:
-    openbank.tech/policy-checksum: "3e682645e75c9491"
+    openbank.tech/policy-checksum: "513822c79af6de6d"
 data:
   rest.rego: |
     # SPDX-License-Identifier: Apache-2.0
@@ -121,10 +121,16 @@ data:
     	# skill_ok, none of which charter_allowed alone consults. Calling charter_allowed
     	# directly would let a fleet-wide hard-denied tool tier, or an agent's own
     	# tools.deny glob, silently reach a REST action anyway.
+    	# object.get (not input.resource): the PDP omits `resource` from the query entirely when
+    	# it is null (OpaSidecarPolicyDecisionPoint.toInput only puts it when non-null), and a bare
+    	# `input.resource` reference is then UNDEFINED, which makes this whole object — and the
+    	# agents.allow call — undefined, silently denying every resource-less AI_AGENT REST call.
+    	# The MCP server (openbank-mcp-service) is the first caller to route AI_AGENT through
+    	# rest.allow with no resource; agent-service queries agents.allow directly and never hit this.
     	data.openbank.agents.allow with input as {
     		"agent": input.principal.id,
     		"tool": input.action,
-    		"resource": input.resource,
+    		"resource": object.get(input, "resource", null),
     	}
     }
 

--- a/openbank-infra/gitops/components/sanctions-service/sanctions-service.yaml
+++ b/openbank-infra/gitops/components/sanctions-service/sanctions-service.yaml
@@ -49,7 +49,7 @@ spec:
       annotations:
         # Rolls the pods when the OPA bundle changes — subPath mounts do NOT hot-reload.
         # Kept in sync by gen-sanctions-opa-bundle.sh (do not hand-edit).
-        openbank.tech/policy-checksum: "3e682645e75c9491"
+        openbank.tech/policy-checksum: "513822c79af6de6d"
     spec:
       securityContext:
         runAsNonRoot: true

--- a/openbank-infra/gitops/components/sca/sca-opa-bundle.yaml
+++ b/openbank-infra/gitops/components/sca/sca-opa-bundle.yaml
@@ -9,7 +9,7 @@ metadata:
     app.kubernetes.io/name: sca-service
     app.kubernetes.io/part-of: sca
   annotations:
-    openbank.tech/policy-checksum: "0f02108ec1b94901"
+    openbank.tech/policy-checksum: "b8b4babcd6723353"
 data:
   rest.rego: |
     # SPDX-License-Identifier: Apache-2.0
@@ -121,10 +121,16 @@ data:
     	# skill_ok, none of which charter_allowed alone consults. Calling charter_allowed
     	# directly would let a fleet-wide hard-denied tool tier, or an agent's own
     	# tools.deny glob, silently reach a REST action anyway.
+    	# object.get (not input.resource): the PDP omits `resource` from the query entirely when
+    	# it is null (OpaSidecarPolicyDecisionPoint.toInput only puts it when non-null), and a bare
+    	# `input.resource` reference is then UNDEFINED, which makes this whole object — and the
+    	# agents.allow call — undefined, silently denying every resource-less AI_AGENT REST call.
+    	# The MCP server (openbank-mcp-service) is the first caller to route AI_AGENT through
+    	# rest.allow with no resource; agent-service queries agents.allow directly and never hit this.
     	data.openbank.agents.allow with input as {
     		"agent": input.principal.id,
     		"tool": input.action,
-    		"resource": input.resource,
+    		"resource": object.get(input, "resource", null),
     	}
     }
 

--- a/openbank-infra/gitops/components/sca/sca-service.yaml
+++ b/openbank-infra/gitops/components/sca/sca-service.yaml
@@ -28,7 +28,7 @@ spec:
       annotations:
         # Rolls the pods when the OPA bundle changes — subPath mounts do NOT hot-reload.
         # Kept in sync by gen-sca-opa-bundle.sh (do not hand-edit).
-        openbank.tech/policy-checksum: "0f02108ec1b94901"
+        openbank.tech/policy-checksum: "b8b4babcd6723353"
     spec:
       securityContext:
         runAsNonRoot: true

--- a/openbank-infra/gitops/components/statements/statement-opa-bundle.yaml
+++ b/openbank-infra/gitops/components/statements/statement-opa-bundle.yaml
@@ -9,7 +9,7 @@ metadata:
     app.kubernetes.io/name: statement-service
     app.kubernetes.io/part-of: statements
   annotations:
-    openbank.tech/policy-checksum: "27edd2fcacdc87f9"
+    openbank.tech/policy-checksum: "62031b9fcde120dd"
 data:
   rest.rego: |
     # SPDX-License-Identifier: Apache-2.0
@@ -121,10 +121,16 @@ data:
     	# skill_ok, none of which charter_allowed alone consults. Calling charter_allowed
     	# directly would let a fleet-wide hard-denied tool tier, or an agent's own
     	# tools.deny glob, silently reach a REST action anyway.
+    	# object.get (not input.resource): the PDP omits `resource` from the query entirely when
+    	# it is null (OpaSidecarPolicyDecisionPoint.toInput only puts it when non-null), and a bare
+    	# `input.resource` reference is then UNDEFINED, which makes this whole object — and the
+    	# agents.allow call — undefined, silently denying every resource-less AI_AGENT REST call.
+    	# The MCP server (openbank-mcp-service) is the first caller to route AI_AGENT through
+    	# rest.allow with no resource; agent-service queries agents.allow directly and never hit this.
     	data.openbank.agents.allow with input as {
     		"agent": input.principal.id,
     		"tool": input.action,
-    		"resource": input.resource,
+    		"resource": object.get(input, "resource", null),
     	}
     }
 

--- a/openbank-infra/gitops/components/statements/statement-service.yaml
+++ b/openbank-infra/gitops/components/statements/statement-service.yaml
@@ -26,7 +26,7 @@ spec:
       annotations:
         # Rolls the pod when the OPA bundle changes — subPath mounts do NOT hot-reload.
         # Kept in sync by gen-statement-opa-bundle.sh (do not hand-edit).
-        openbank.tech/policy-checksum: "27edd2fcacdc87f9"
+        openbank.tech/policy-checksum: "62031b9fcde120dd"
       labels:
         app.kubernetes.io/name: statement-service
         app.kubernetes.io/part-of: statements

--- a/openbank-libs/governance/policies/rest.rego
+++ b/openbank-libs/governance/policies/rest.rego
@@ -107,10 +107,16 @@ allowed_reasons contains "agent-charter-allows" if {
 	# skill_ok, none of which charter_allowed alone consults. Calling charter_allowed
 	# directly would let a fleet-wide hard-denied tool tier, or an agent's own
 	# tools.deny glob, silently reach a REST action anyway.
+	# object.get (not input.resource): the PDP omits `resource` from the query entirely when
+	# it is null (OpaSidecarPolicyDecisionPoint.toInput only puts it when non-null), and a bare
+	# `input.resource` reference is then UNDEFINED, which makes this whole object — and the
+	# agents.allow call — undefined, silently denying every resource-less AI_AGENT REST call.
+	# The MCP server (openbank-mcp-service) is the first caller to route AI_AGENT through
+	# rest.allow with no resource; agent-service queries agents.allow directly and never hit this.
 	data.openbank.agents.allow with input as {
 		"agent": input.principal.id,
 		"tool": input.action,
-		"resource": input.resource,
+		"resource": object.get(input, "resource", null),
 	}
 }
 

--- a/openbank-libs/governance/policies/rest_test.rego
+++ b/openbank-libs/governance/policies/rest_test.rego
@@ -718,6 +718,23 @@ test_allow_ai_agent_ledger_list_via_charter_bridge if {
 	decision.reason == "agent-charter-allows"
 }
 
+# REGRESSION (openbank-mcp-service, ADR-0181): the PDP OMITS `resource` from the query when it
+# is null (OpaSidecarPolicyDecisionPoint.toInput), so the bridge input has NO resource key at
+# all — the real production shape for the MCP server, which is the first AI_AGENT caller routed
+# through rest.allow. A bare `input.resource` in the bridge was undefined here, denying the call;
+# every other agent test sends an explicit `"resource": null` and so never covered this path.
+test_allow_ai_agent_via_charter_bridge_without_resource_key if {
+	decision := rest.allow with input as {
+		"principal": {"id": "agent:ui-assistant", "type": "AI_AGENT", "roles": []},
+		"action": "ledger.list",
+	}
+		with data.openbank.bundle as bundle
+		with data.agents as agent_charters_for_rest_bridge
+
+	decision.allow == true
+	decision.reason == "agent-charter-allows"
+}
+
 # The bridge is read-only -- an AI_AGENT can never reach a write action through it.
 test_deny_ai_agent_ledger_create_via_charter_bridge if {
 	not rest.allow with input as {


### PR DESCRIPTION
## What

Follow-up to #2142 (ADR-0181 phase-2 MCP OPA wiring). After that merged, the sidecar deployed and the PDP became reachable — but `tools/call list_accounts` still returned **"Denied by policy: no matching allow rule"** despite the `mcp-anonymous` charter being present and the bundle checksum matching.

## Root cause

The AI_AGENT bridge in `rest.rego` builds its `agents.allow` input with a bare `input.resource`:

```rego
data.openbank.agents.allow with input as {
    "agent": input.principal.id, "tool": input.action, "resource": input.resource,
}
```

`OpaSidecarPolicyDecisionPoint.toInput` **omits** `resource` from the query when it is null, so `input.resource` is **undefined** → the whole object (and the delegated `agents.allow` call) is undefined → silent deny.

`openbank-mcp-service` is the **first** caller to route an AI_AGENT through `data.openbank.rest.allow`; `agent-service` queries `data.openbank.agents.allow` directly and never hit this. Latent since the bridge was written.

**Live proof on the deployed sidecar:** `agents.allow` → `true` for `query.account.readonly`, but `rest.allow` → `false`. With `resource: null` sent explicitly → `true`; with the key omitted (the real PDP shape) → `false`.

## Fix

`object.get(input, "resource", null)` — an absent resource passes through as null (a shape `agents.allow` already handles). Add a regression test that **omits** the key; every existing agent-bridge test sent an explicit `"resource": null`, which is exactly why the gap was invisible.

Fleet OPA bundles + pod-roll annotations regenerated (rest.rego restamps all). `opa test` 144/144.

## After merge
ArgoCD rolls the new bundle; re-run `tools/call list_accounts` → expect a stub-data result (not a deny).

Refs ADR-0181, ADR-0034

🤖 Generated with [Claude Code](https://claude.com/claude-code)