### PR TITLE
docs(governance): inventory non-agent ML systems in the EU AI Act mapping (#1918)

### DIFF
--- a/.github/scripts/gen-eu-ai-act.py
+++ b/.github/scripts/gen-eu-ai-act.py
@@ -36,6 +36,10 @@ except ImportError:
 
 ROOT = pathlib.Path(__file__).resolve().parents[2]
 AGENTS = ROOT / "openbank-libs" / "governance" / "agents.yaml"
+# Non-agent AI/ML systems (fraud scoring plane, ML decisioning substrate) — the AI systems that
+# are NOT LLM agent charters. Kept out of agents.yaml on purpose (that file is hashed verbatim
+# into ~29 OPA bundles); consumed only here to complete the EU AI Act inventory. See its header.
+ML_SYSTEMS = ROOT / "openbank-libs" / "governance" / "ml-systems.yaml"
 OUT = ROOT / "docs" / "compliance" / "eu-ai-act.md"
 
 # --- classification ruleset (encoded, reviewed here — not free text in the doc) -------------
@@ -89,6 +93,15 @@ def classify(agent):
 def main():
     data = yaml.safe_load(AGENTS.read_text())
     agents = data.get("agents", []) or []
+    ml_data = yaml.safe_load(ML_SYSTEMS.read_text()) if ML_SYSTEMS.exists() else {}
+    ml_systems = (ml_data or {}).get("ml_systems", []) or []
+    # A non-agent ML system flips the obligations to "APPLIES NOW" only if it is both HIGH-RISK
+    # and actually deployed-and-acting (deployed: true). A planned or shadow-only high-risk system
+    # is inventoried but does not yet trigger the article-by-article obligations.
+    ml_high_risk_live = [
+        m.get("id") for m in ml_systems
+        if m.get("risk_class") == "HIGH-RISK" and m.get("deployed") is True
+    ]
 
     L = []
     w = L.append
@@ -109,9 +122,12 @@ def main():
     w("performs credit scoring or credit decisioning; ADR-0142 (credit decisioning) is")
     w("*Proposed* and unbuilt. The customer- and operator-facing agents are")
     w("proposal-only — a human dispositions every effect — which keeps them out of the")
-    w("autonomous-decision-making category. This document is (a) the standing AI-system")
-    w("inventory a deployer must keep, and (b) the precondition ADR-0142 must satisfy")
-    w("article-by-article before it can move past *Proposed*.")
+    w("autonomous-decision-making category. The one ML system near the money path, the fraud")
+    w("scoring plane (ADR-0084), runs its model in **shadow mode** — the verdict is logged, never")
+    w("enforced — and fraud detection is not Annex III creditworthiness. This document is (a) the")
+    w("standing AI-system inventory a deployer must keep — LLM agents *and* the non-agent ML")
+    w("systems below — and (b) the precondition ADR-0142 must satisfy article-by-article before")
+    w("it can move past *Proposed*.")
     w("")
     w("## System inventory")
     w("")
@@ -124,6 +140,35 @@ def main():
             high_risk.append(a.get("id"))
         w(f"| `{a.get('id')}` | {a.get('plane', '—')} | {cls} | {point} | {why} |")
     w("")
+
+    # --- Non-agent ML / statistical systems (ADR-0084 fraud plane, ADR-0139/0140/0141/0142) -----
+    # The inventory the AI Act requires covers EVERY AI system, not only the LLM agent charters.
+    # The fraud scoring plane and the ML decisioning substrate are AI systems that are not charters;
+    # they are inventoried here from ml-systems.yaml so the document names them explicitly rather
+    # than leaving them out (an inventory that omits a running system reads as a false all-clear).
+    if ml_systems:
+        w("### Non-agent ML and statistical systems")
+        w("")
+        w("AI systems that are not LLM agent charters — the fraud scoring plane and the ML")
+        w("decisioning substrate (source: `openbank-libs/governance/ml-systems.yaml`). Credit")
+        w("decisioning is the only entry that becomes high-risk, and it is unbuilt.")
+        w("")
+        w("| System | ADR | Status | Plane | Risk class | Annex III | Basis |")
+        w("|---|---|---|---|---|---|---|")
+        for m in ml_systems:
+            basis = " ".join(str(m.get("basis", "—")).split())
+            w(f"| `{m.get('id')}` | {m.get('adr', '—')} | {m.get('status', '—')} | "
+              f"{m.get('plane', '—')} | {m.get('risk_class', '—')} | {m.get('annex', '—')} | {basis} |")
+        w("")
+        planned = [m.get("id") for m in ml_systems
+                   if m.get("risk_class") == "Planned high-risk (not deployed)"]
+        if planned:
+            w("> **Planned high-risk (not deployed):** "
+              f"{', '.join('`'+p+'`' for p in planned)}. Inventoried in advance; the Art. 9–15")
+            w("> obligations below apply the day it ships, which is why this document is ADR-0142's")
+            w("> named precondition. No such system runs today.")
+            w("")
+
     w("## Obligation coverage (Art. 9–15) for a high-risk system")
     w("")
     w("The controls below already exist and satisfy each obligation *in substance* for the day")
@@ -132,13 +177,14 @@ def main():
     w("")
     w("| Obligation | Existing control | Status |")
     w("|---|---|---|")
+    live_high_risk = high_risk or ml_high_risk_live
     for art, control in OBLIGATIONS:
-        status = "control exists; evidence pack open" if not high_risk else "APPLIES NOW — verify per system"
+        status = "control exists; evidence pack open" if not live_high_risk else "APPLIES NOW — verify per system"
         w(f"| {art} | {control} | {status} |")
     w("")
-    if high_risk:
-        w("> ⚠ **A high-risk system is now declared in the charters** "
-          f"({', '.join('`'+h+'`' for h in high_risk)}). "
+    if live_high_risk:
+        w("> ⚠ **A high-risk system is now declared and deployed** "
+          f"({', '.join('`'+h+'`' for h in live_high_risk)}). "
           "Every obligation above APPLIES from 2026-08-02; this table must be reviewed per system, "
           "and ADR-0142's preconditions confirmed, before deploy.")
     else:
@@ -193,8 +239,13 @@ def main():
     src = AGENTS.read_bytes()
     w(f"- Source: `openbank-libs/governance/agents.yaml` "
       f"(sha256 `{hashlib.sha256(src).hexdigest()[:16]}…`, {len(agents)} charters)")
-    w("- Related: ADR-0031 (agent governance), ADR-0141 (model registry), ADR-0142 (credit")
-    w("  decisioning), ADR-0148 (this assurance layer).")
+    if ml_systems:
+        ml_src = ML_SYSTEMS.read_bytes()
+        w(f"- Source: `openbank-libs/governance/ml-systems.yaml` "
+          f"(sha256 `{hashlib.sha256(ml_src).hexdigest()[:16]}…`, {len(ml_systems)} non-agent systems)")
+    w("- Related: ADR-0031 (agent governance), ADR-0084 (fraud scoring plane), ADR-0139/0140")
+    w("  (ML decisioning platform), ADR-0141 (model registry), ADR-0142 (credit decisioning),")
+    w("  ADR-0148 (this assurance layer).")
     w("")
 
     OUT.parent.mkdir(parents=True, exist_ok=True)

--- a/docs/adr/0148-ai-assurance-prompt-registry-evals-gate-and-eu-ai-act-mapping.md
+++ b/docs/adr/0148-ai-assurance-prompt-registry-evals-gate-and-eu-ai-act-mapping.md
@@ -21,6 +21,16 @@ summary: "Add an AI assurance layer: an in-repo versioned prompt registry that e
 > first real ops-agent prompts extracted. Still open: wiring each service to *load* its
 > system prompt from the registry (so `prompt_hash` resolves), the `check-prompt-registry`
 > guard, and the per-charter **evals gate** — tracked as the ADR-0148 code follow-up.
+>
+> **Update (2026-07-25, issue #1918).** The mapping's system inventory now covers the AI
+> systems that are **not** LLM agent charters — the fraud scoring plane (ADR-0084) and the ML
+> decisioning substrate (ADR-0139/0140/0141/0142) — from a new
+> `openbank-libs/governance/ml-systems.yaml`, kept separate from `agents.yaml` (which is hashed
+> verbatim into ~29 OPA bundles) and consumed only by `gen-eu-ai-act.py`. This closes the
+> deadline-critical (2026-08-02) inventory gap: the document now names every AI system, records
+> that the only high-risk one (credit decisioning, ADR-0142) is *planned and unbuilt*, and that
+> the nearest-to-money ML system (fraud) runs **shadow-only**. The evals-gate registry + guard
+> landed in #2070; the prompt-loading wiring remains the deferred code follow-up.
 
 ## Context
 

--- a/docs/compliance/eu-ai-act.md
+++ b/docs/compliance/eu-ai-act.md
@@ -15,9 +15,12 @@ Creditworthiness assessment of natural persons is high-risk under **Annex III(5)
 performs credit scoring or credit decisioning; ADR-0142 (credit decisioning) is
 *Proposed* and unbuilt. The customer- and operator-facing agents are
 proposal-only — a human dispositions every effect — which keeps them out of the
-autonomous-decision-making category. This document is (a) the standing AI-system
-inventory a deployer must keep, and (b) the precondition ADR-0142 must satisfy
-article-by-article before it can move past *Proposed*.
+autonomous-decision-making category. The one ML system near the money path, the fraud
+scoring plane (ADR-0084), runs its model in **shadow mode** — the verdict is logged, never
+enforced — and fraud detection is not Annex III creditworthiness. This document is (a) the
+standing AI-system inventory a deployer must keep — LLM agents *and* the non-agent ML
+systems below — and (b) the precondition ADR-0142 must satisfy article-by-article before
+it can move past *Proposed*.
 
 ## System inventory
 
@@ -37,6 +40,23 @@ article-by-article before it can move past *Proposed*.
 | `docs-truth-agent` | control | Limited / minimal risk | — | produces proposals only; a human dispositions every effect (not autonomous decision-making on a natural person). |
 | `authz-policy-auditor` | control | Limited / minimal risk | — | produces proposals only; a human dispositions every effect (not autonomous decision-making on a natural person). |
 | `flaky-test-hunter` | development | Limited / minimal risk | — | produces proposals only; a human dispositions every effect (not autonomous decision-making on a natural person). |
+
+### Non-agent ML and statistical systems
+
+AI systems that are not LLM agent charters — the fraud scoring plane and the ML
+decisioning substrate (source: `openbank-libs/governance/ml-systems.yaml`). Credit
+decisioning is the only entry that becomes high-risk, and it is unbuilt.
+
+| System | ADR | Status | Plane | Risk class | Annex III | Basis |
+|---|---|---|---|---|---|---|
+| `fraud-real-time-scoring` | ADR-0084 | shipped | openbank-fraud-service | Limited / minimal risk | — | Real-time transaction fraud scoring (ALLOW/CHALLENGE/REVIEW/DECLINE). Fraud prevention is not Annex III creditworthiness; the deterministic rule layer is the permanent decision floor (ADR-0139) and the service fails open behind a flag — it can add friction, never autonomously deny a natural person a service. |
+| `ml-decisioning-platform` | ADR-0139, ADR-0140 | partial | openbank-libs (feature store + in-process ONNX serving) | Limited / minimal risk | — | Event-fed feature store + in-process ONNX serving (a real baseline model, openbank-fraud-service `ml/baseline-fraud-v1.onnx` via `MlModelPort.scoreShadow`), shadow-to-champion governance. Runs in production in SHADOW mode only — scores are logged, never honoured; the caller degrades to the deterministic rule floor — and its sole consumer is fraud scoring, so it makes no decision on a natural person. Point-in-time correctness (ADR-0140) removes train/serve skew by construction. `deployed: false` here means "acts on its output" — the model runs but its verdict is never enforced. |
+| `model-registry-provenance` | ADR-0141 | proposed | openbank-libs (governance substrate) | — | — | Model card + signed content-addressed ONNX artifact + in-toto attestation. Not itself an AI system that acts — it is the Art. 11 technical-documentation / provenance substrate a high-risk model would be governed by. Proposed, unbuilt. |
+| `credit-decisioning-engine` | ADR-0142 | proposed | (planned) openbank-libs ML platform | Planned high-risk (not deployed) | III.5(b) | Creditworthiness assessment of natural persons — Annex III(5)(b) high-risk. PROPOSED and unbuilt; when it ships it is the platform's first high-risk system and every Art. 9-15 obligation applies. Stricter than fraud by design: no decision without machine-readable adverse-action reasons, deterministic affordability rules supreme, declines route to mandatory four-eyes. This inventory is the precondition ADR-0142 must satisfy first. |
+
+> **Planned high-risk (not deployed):** `credit-decisioning-engine`. Inventoried in advance; the Art. 9–15
+> obligations below apply the day it ships, which is why this document is ADR-0142's
+> named precondition. No such system runs today.
 
 ## Obligation coverage (Art. 9–15) for a high-risk system
 
@@ -84,5 +104,7 @@ not deployed.
 ## Provenance
 
 - Source: `openbank-libs/governance/agents.yaml` (sha256 `db00ef54f93055dd…`, 14 charters)
-- Related: ADR-0031 (agent governance), ADR-0141 (model registry), ADR-0142 (credit
-  decisioning), ADR-0148 (this assurance layer).
+- Source: `openbank-libs/governance/ml-systems.yaml` (sha256 `9cd5cb5b20918520…`, 4 non-agent systems)
+- Related: ADR-0031 (agent governance), ADR-0084 (fraud scoring plane), ADR-0139/0140
+  (ML decisioning platform), ADR-0141 (model registry), ADR-0142 (credit decisioning),
+  ADR-0148 (this assurance layer).

--- a/openbank-libs/governance/ml-systems.yaml
+++ b/openbank-libs/governance/ml-systems.yaml
@@ -1,0 +1,79 @@
+# SPDX-License-Identifier: Apache-2.0
+# Copyright (c) OpenBank contributors. Licensed under the Apache License, Version 2.0.
+#
+# Non-agent AI/ML system inventory (ADR-0148, EU AI Act Annex IV standing inventory).
+#
+# WHY A SEPARATE FILE (not agents.yaml):
+#   agents.yaml is embedded verbatim + hashed by every gen-*-opa-bundle.sh, so a doc-only
+#   edit there would restamp ~29 OPA bundles (the same reason ADR-0148's evals fixtures live
+#   in a separate registry). These entries have zero policy relevance, so they live here and
+#   are consumed only by gen-eu-ai-act.py to complete the EU AI Act system inventory with the
+#   AI systems that are NOT LLM agent charters — the fraud scoring plane and the ML decisioning
+#   substrate. Edit here and regenerate: python3 .github/scripts/gen-eu-ai-act.py
+#
+# Fields per system:
+#   id         short stable identifier
+#   adr        deciding ADR(s)
+#   status     shipped | partial | proposed  (mirrors the ADR delivery-status)
+#   deployed   true only if it runs in production AND acts on its output (drives the obligation
+#              flip: a planned or shadow-only high-risk system does NOT make Art. 9-15 apply yet)
+#   plane      where it runs
+#   risk_class "Limited / minimal risk" | "Planned high-risk (not deployed)" | "HIGH-RISK"
+#   annex      Annex III point, or "—"
+#   basis      one-line justification for the risk class
+
+ml_systems:
+  - id: fraud-real-time-scoring
+    adr: "ADR-0084"
+    status: shipped
+    deployed: true
+    plane: openbank-fraud-service
+    risk_class: "Limited / minimal risk"
+    annex: "—"
+    basis: >-
+      Real-time transaction fraud scoring (ALLOW/CHALLENGE/REVIEW/DECLINE). Fraud prevention
+      is not Annex III creditworthiness; the deterministic rule layer is the permanent decision
+      floor (ADR-0139) and the service fails open behind a flag — it can add friction, never
+      autonomously deny a natural person a service.
+
+  - id: ml-decisioning-platform
+    adr: "ADR-0139, ADR-0140"
+    status: partial
+    deployed: false
+    plane: openbank-libs (feature store + in-process ONNX serving)
+    risk_class: "Limited / minimal risk"
+    annex: "—"
+    basis: >-
+      Event-fed feature store + in-process ONNX serving (a real baseline model,
+      openbank-fraud-service `ml/baseline-fraud-v1.onnx` via `MlModelPort.scoreShadow`),
+      shadow-to-champion governance. Runs in production in SHADOW mode only — scores are logged,
+      never honoured; the caller degrades to the deterministic rule floor — and its sole consumer
+      is fraud scoring, so it makes no decision on a natural person. Point-in-time correctness
+      (ADR-0140) removes train/serve skew by construction. `deployed: false` here means "acts on
+      its output" — the model runs but its verdict is never enforced.
+
+  - id: model-registry-provenance
+    adr: "ADR-0141"
+    status: proposed
+    deployed: false
+    plane: openbank-libs (governance substrate)
+    risk_class: "—"
+    annex: "—"
+    basis: >-
+      Model card + signed content-addressed ONNX artifact + in-toto attestation. Not itself an
+      AI system that acts — it is the Art. 11 technical-documentation / provenance substrate a
+      high-risk model would be governed by. Proposed, unbuilt.
+
+  - id: credit-decisioning-engine
+    adr: "ADR-0142"
+    status: proposed
+    deployed: false
+    plane: "(planned) openbank-libs ML platform"
+    risk_class: "Planned high-risk (not deployed)"
+    annex: "III.5(b)"
+    basis: >-
+      Creditworthiness assessment of natural persons — Annex III(5)(b) high-risk. PROPOSED and
+      unbuilt; when it ships it is the platform's first high-risk system and every Art. 9-15
+      obligation applies. Stricter than fraud by design: no decision without machine-readable
+      adverse-action reasons, deterministic affordability rules supreme, declines route to
+      mandatory four-eyes. This inventory is the precondition ADR-0142 must satisfy first.


### PR DESCRIPTION
Closes the deadline-critical (**2026-08-02**) inventory gap in #1918.

## Problem
`docs/compliance/eu-ai-act.md` (ADR-0148) is the platform's standing EU AI Act system inventory, but it was generated **only** from the LLM agent charters in `agents.yaml`. The AI Act requires the inventory to name *every* AI system — and two were absent: the **fraud scoring plane** (ADR-0084, shipped) and the **ML decisioning substrate** (ADR-0139/0140/0141/0142). An inventory that omits a running system reads as a false all-clear to an auditor.

> Note: #1918's body ("`governance/prompts/` and `docs/compliance/eu-ai-act.md` do not exist") is **stale** — both landed in the ADR-0148 first increment (2026-07-23) and the evals-gate registry landed in #2070. Verified against live `origin/main`. The one genuine remaining gap in the *compliance-critical* mapping was the non-agent ML inventory, which this PR fills.

## Change
- **New** `openbank-libs/governance/ml-systems.yaml` — the non-agent AI/ML inventory. Kept **separate** from `agents.yaml` on purpose: that file is hashed verbatim into ~29 OPA bundles, so a doc-only entry there would restamp all of them (same rationale as ADR-0148's evals registry). Consumed only by the generator.
- `gen-eu-ai-act.py` emits a **"Non-agent ML and statistical systems"** table and factors a *deployed-and-acting* high-risk ML system into the Art. 9–15 obligation flip. A **planned** (credit, ADR-0142) or **shadow-only** (fraud ML) high-risk system is inventoried but does not trigger the obligations yet.
- Regenerated `eu-ai-act.md` + ADR-0148 delivery-note update.

## Result — the mapping now records, before the deadline
| System | ADR | Risk | Note |
|---|---|---|---|
| fraud real-time scoring | 0084 | Limited/minimal | fraud ≠ Annex III creditworthiness; rule floor supreme; fails open |
| ML decisioning platform | 0139/0140 | Limited/minimal | real baseline ONNX, **shadow-only** — verdict never enforced |
| model registry/provenance | 0141 | — | proposed governance substrate |
| credit decisioning | 0142 | **Planned high-risk** | Annex III(5)(b), **unbuilt** — this doc is its named precondition |

## Guardrail
Drift-guarded by the existing `check-eu-ai-act.sh` (regenerates + diffs, so `ml-systems.yaml` is covered automatically). No new CI wiring needed.

Deferred past the deadline (per the issue): wiring services to *load* prompts from the registry so `prompt_hash` resolves, and evals depth.

Refs #1918