### PR TITLE
ci(agent-review): exclude generated artifacts and budget the reviewer payload to the 8000-token cap

### DIFF
--- a/.github/workflows/agent-review.yml
+++ b/.github/workflows/agent-review.yml
@@ -35,6 +35,10 @@
 #   * FALLBACK. If GitHub Models errors or is rate-limited, fall back to Claude via
 #     claude-code-action (auth = CLAUDE_CODE_OAUTH_TOKEN from `claude setup-token`,
 #     which runs on a Pro/Max subscription — no paid API key required).
+#     KNOWN BROKEN (#2161): the OAuth token is currently rejected at the gateway on
+#     the first model call (`is_error:true` at `num_turns:1`, ~2s), so this standby
+#     path does not actually review anything. Re-minting the token needs the owner's
+#     Claude session, so it is tracked separately — do not assume a fallback exists.
 #
 # Prerequisites (one-time, outside this file):
 #   1. Settings → Actions → General → "Allow GitHub Actions to approve pull
@@ -182,13 +186,78 @@ jobs:
             echo "skip=false" >> "$GITHUB_OUTPUT"
           fi
 
-          # Stash a size-capped diff for the reviewer prompt. Write to a file
-          # first, then truncate — piping straight into `head -c` lets `head`
-          # close stdin early on a large diff, sending `git diff` a SIGPIPE
-          # that fails the step under `pipefail` even though the truncated
-          # diff was written successfully.
-          git diff "origin/${BASE_REF}...HEAD" > /tmp/pr.full.diff
-          head -c 30000 /tmp/pr.full.diff > /tmp/pr.diff
+          # --- Reviewer payload: derived files out, hard token budget in -------
+          #
+          # Two independent defects fixed here (#2088), both observed on PR #2082:
+          #
+          #  1. GENERATED FILES DOMINATED THE PAYLOAD. Editing rules.yaml or any
+          #     .rego restamps EVERY service's OPA bundle ConfigMap (each embeds
+          #     rules.yaml + agents.yaml + rest.rego verbatim, ~2.8k lines), so a
+          #     one-line governance edit ships ~44 changed generated YAMLs. On
+          #     #2082 the raw 3-dot diff was 211,616 bytes, of which 196,973 were
+          #     a single `standing-order-opa-bundle.yaml` — 93% of the payload was
+          #     a file marked "GENERATED … do not hand-edit" that no reviewer
+          #     should read. The same class of noise already produced three
+          #     repeat false positives on the derived admin-ui catalogs (see the
+          #     admin-ui-deploy note in the job `if:` above). EXCLUDES below are
+          #     CI-generated artifacts only — never hand-written code.
+          #
+          #  2. THE BUDGET DID NOT MATCH THE MODEL'S CAP. `head -c 30000` is
+          #     ~8-10k tokens of diff alone, on top of a 4000-char PR body and the
+          #     instructions — well past GitHub Models' hard 8000-token REQUEST
+          #     cap, so those PRs 413'd deterministically ("Request body too
+          #     large for gpt-4o model. Max size: 8000 tokens"). Budget, measured
+          #     with tiktoken's o200k_base on real diffs from this repo (3.7-4.2
+          #     chars/token; 3.0 used as a pessimistic floor):
+          #       diff  16000 chars / 3.0 = 5333 tok  (measured ~4300)
+          #       body   4000 chars       ≈ 1100 tok  (prose, ~3.6 ch/tok)
+          #       scaffold + instructions ≈  250 tok
+          #       -------------------------------------------------
+          #       worst case              ≈ 6700 tok → ~15% headroom under 8000.
+          #     20000 (the value #2088 floated) leaves only ~5% and loses the
+          #     margin to a denser-than-3.0 diff, so it is deliberately lower.
+          #
+          # SCOPE NOTE — the excludes apply to the REVIEWER PAYLOAD ONLY, never
+          # to the sensitivity classification above. A generated bundle is still
+          # a real change; it just isn't something an LLM reviews line by line.
+          # Moving these excludes up into the classifier would silently narrow
+          # the money-path / governance gate, which this workflow must never do.
+          GENERATED_EXCLUDES=(
+            ':!**/*-opa-bundle*.yaml'              # ADR-0034 OPA bundle ConfigMaps (gen-*-opa-bundle.sh)
+            ':!openbank-admin-ui/app-status.json'  # derived catalogs, ADR-0071/0079/0081
+            ':!openbank-admin-ui/cluster-topology.json'
+            ':!openbank-admin-ui/infra-lifecycle.json'
+            ':!openbank-admin-ui/infra-vulns.json'
+            ':!openbank-admin-ui/package-lock.json' # npm-generated lockfile
+            ':!gradle/verification-metadata.xml'    # Gradle-generated dependency checksums
+            ':!**/CHANGELOG.md'                     # release-please-generated
+          )
+          # Write to a file first, THEN truncate — piping straight into `head -c`
+          # lets `head` close stdin early on a large diff, sending `git diff` a
+          # SIGPIPE that fails the step under `pipefail` even though the
+          # truncated diff was written successfully (#359).
+          git diff "origin/${BASE_REF}...HEAD" -- . "${GENERATED_EXCLUDES[@]}" > /tmp/pr.full.diff
+          git diff --name-only "origin/${BASE_REF}...HEAD" > /tmp/pr.files.all
+          git diff --name-only "origin/${BASE_REF}...HEAD" -- . "${GENERATED_EXCLUDES[@]}" > /tmp/pr.files.kept
+          DIFF_BUDGET=16000
+          head -c "$DIFF_BUDGET" /tmp/pr.full.diff > /tmp/pr.diff
+
+          FULL_BYTES="$(wc -c < /tmp/pr.full.diff | tr -d ' ')"
+          KEPT_BYTES="$(wc -c < /tmp/pr.diff | tr -d ' ')"
+          EXCLUDED_FILES="$(( $(wc -l < /tmp/pr.files.all) - $(wc -l < /tmp/pr.files.kept) ))"
+          echo "review payload: ${KEPT_BYTES}/${FULL_BYTES} bytes after dropping ${EXCLUDED_FILES} generated file(s)"
+          {
+            echo "diff_full_bytes=${FULL_BYTES}"
+            echo "diff_kept_bytes=${KEPT_BYTES}"
+            echo "generated_excluded=${EXCLUDED_FILES}"
+          } >> "$GITHUB_OUTPUT"
+          # Truncation must never be silent: an APPROVE derived from a fragment
+          # of the diff is a vacuous green, which is worse than no review.
+          if [ "$KEPT_BYTES" -lt "$FULL_BYTES" ]; then
+            echo "diff_truncated=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "diff_truncated=false" >> "$GITHUB_OUTPUT"
+          fi
 
       # --- Sensitive: defer to a human, do not approve ------------------------
       - name: Defer to human review
@@ -208,6 +277,10 @@ jobs:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           PR: ${{ github.event.pull_request.number }}
           TITLE: ${{ github.event.pull_request.title }}
+          DIFF_TRUNCATED: ${{ steps.scope.outputs.diff_truncated }}
+          DIFF_FULL_BYTES: ${{ steps.scope.outputs.diff_full_bytes }}
+          DIFF_KEPT_BYTES: ${{ steps.scope.outputs.diff_kept_bytes }}
+          GENERATED_EXCLUDED: ${{ steps.scope.outputs.generated_excluded }}
         run: |
           set -euo pipefail
           # Fetch the PR body FRESH via the API, not from the event payload — the
@@ -219,6 +292,10 @@ jobs:
           # guard as the diff above.
           gh pr view "$PR" --json body --jq '.body // ""' > /tmp/pr.body.full
           head -c 4000 /tmp/pr.body.full > /tmp/pr.body
+          DIFF_TRUNCATED_LABEL=""
+          if [ "$DIFF_TRUNCATED" = "true" ]; then
+            DIFF_TRUNCATED_LABEL=" (TRUNCATED — ${DIFF_KEPT_BYTES} of ${DIFF_FULL_BYTES} bytes)"
+          fi
           {
             echo "You are an INDEPENDENT, adversarial code reviewer for a banking-grade"
             echo "Quarkus/Kotlin monorepo. Your default posture is skepticism: actively"
@@ -233,7 +310,22 @@ jobs:
             cat /tmp/pr.body
             echo '```'
             echo
-            echo "Unified diff (may be truncated):"
+            if [ "${GENERATED_EXCLUDED:-0}" -gt 0 ]; then
+              echo "NOTE: ${GENERATED_EXCLUDED} CI-generated file(s) (OPA bundle ConfigMaps,"
+              echo "derived catalogs, lockfiles, CHANGELOGs) were removed from the diff below."
+              echo "They are regenerated by scripts and are never hand-edited — do not comment"
+              echo "on their absence, and do not treat it as an incomplete change."
+              echo
+            fi
+            if [ "$DIFF_TRUNCATED" = "true" ]; then
+              echo "WARNING: THE DIFF BELOW IS TRUNCATED. Only ${DIFF_KEPT_BYTES} of"
+              echo "${DIFF_FULL_BYTES} bytes are shown; the rest of the change is NOT visible"
+              echo "to you. You have therefore not seen the whole change and MUST NOT answer"
+              echo "APPROVE — answer REQUEST_CHANGES and say in the summary that the diff was"
+              echo "too large to review in full."
+              echo
+            fi
+            echo "Unified diff${DIFF_TRUNCATED_LABEL}:"
             echo '```diff'
             cat /tmp/pr.diff
             echo '```'
@@ -260,6 +352,10 @@ jobs:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           PR: ${{ github.event.pull_request.number }}
           RESPONSE: ${{ steps.ghmodels.outputs.response }}
+          DIFF_TRUNCATED: ${{ steps.scope.outputs.diff_truncated }}
+          DIFF_FULL_BYTES: ${{ steps.scope.outputs.diff_full_bytes }}
+          DIFF_KEPT_BYTES: ${{ steps.scope.outputs.diff_kept_bytes }}
+          GENERATED_EXCLUDED: ${{ steps.scope.outputs.generated_excluded }}
         run: |
           set -euo pipefail
           # Extract the first {...} JSON object; tolerate stray prose. Same fix as the
@@ -273,9 +369,31 @@ jobs:
           JSON="$(grep -oE '\{.*\}' -m1 /tmp/response.txt || true)"
           DECISION="$(printf '%s' "$JSON" | jq -r '.decision // "REQUEST_CHANGES"')"
           SUMMARY="$(printf '%s' "$JSON" | jq -r '.summary // "no summary"')"
+
+          # Coverage footer — the reader must be able to tell what the verdict
+          # was actually based on. A green tick on a fragment of the diff reads
+          # exactly like a green tick on the whole thing, which is the failure
+          # class this repo works hardest to avoid (#2088).
+          FOOTER=""
+          if [ "${GENERATED_EXCLUDED:-0}" -gt 0 ]; then
+            FOOTER="${FOOTER}
+          _Excluded ${GENERATED_EXCLUDED} CI-generated file(s) (OPA bundles, derived catalogs, lockfiles, CHANGELOGs) from the reviewed diff — they are regenerated, not hand-written._"
+          fi
+          if [ "$DIFF_TRUNCATED" = "true" ]; then
+            FOOTER="${FOOTER}
+          ⚠️ **Partial review — the diff was truncated.** Only ${DIFF_KEPT_BYTES} of ${DIFF_FULL_BYTES} diff bytes fit the model's request budget, so this verdict covers PART of the change only. Do not read it as a clean pass; a human should review the rest."
+            # Belt and braces: even if the model ignored the in-prompt
+            # instruction and answered APPROVE, an approval based on a fragment
+            # must not be posted as an approving review.
+            if [ "$DECISION" = "APPROVE" ]; then
+              echo "::warning::model returned APPROVE on a truncated diff — downgrading to a comment review"
+              DECISION="REQUEST_CHANGES"
+            fi
+          fi
           BODY="🤖 **Agent review (GitHub Models · gpt-4o)**
 
           ${SUMMARY}
+          ${FOOTER}
 
           _Automated independent review. Sensitive changes are always deferred to a human._"
           if [ "$DECISION" = "APPROVE" ]; then


### PR DESCRIPTION
Closes #2088 (the 413 only). Refs #2161 (the fallback credential — owner-only, deliberately NOT closed here).

## Problem

`agent-review` went **red deterministically** on any PR whose diff is dominated by a generated file, and it has done so for a whole class of PRs. Two independent defects, both confirmed against the run logs on PR #2082, not inferred:

1. **Generated files dominated the payload.** Editing `rules.yaml` or any `.rego` restamps *every* service's OPA bundle ConfigMap (each embeds `rules.yaml` + `agents.yaml` + `rest.rego` verbatim, ~2.8k lines), so a one-line governance edit ships ~44 changed generated YAMLs. On #2082 the raw 3-dot diff was **211,616 bytes, of which 196,973 were a single `standing-order-opa-bundle.yaml`** — 93% of what the reviewer read was a file marked `GENERATED … do not hand-edit`.
2. **The budget did not match the model's cap.** `head -c 30000` is ~8-10k tokens of diff alone, on top of a 4000-char PR body and the instructions — past GitHub Models' hard **8000-token request** cap. Hence `413 Request body too large for gpt-4o model. Max size: 8000 tokens`.

The check is advisory (not a required status check), so it never blocked a merge. That is exactly what makes it worth fixing: a permanently-red advisory check trains everyone to ignore it, which is the failure class this repo works hardest to avoid.

## Changes — all confined to the reviewer payload

**Exclude CI-generated artifacts from the review diff.** Pathspec excludes for the OPA bundle ConfigMaps, the derived admin-ui catalogs (`app-status` / `cluster-topology` / `infra-lifecycle` / `infra-vulns`.json, ADR-0071/0079/0081), `package-lock.json`, `gradle/verification-metadata.xml`, and `CHANGELOG.md`. Every one is script-regenerated and never hand-edited; **no hand-written code is excluded**. Reviewing the derived admin-ui catalogs had already produced three repeat false positives on deploy PRs (#596/#608/#609), documented in this workflow's own header.

> **The excludes apply to the reviewer payload ONLY, never to the sensitivity classification above them.** Moving them up into the classifier would silently narrow the money-path / governance gate. A generated bundle is still a real change — it just isn't something an LLM reviews line by line.

**Budget cut 30000 → 16000 chars.** Arithmetic sanity-checked rather than taken on faith. Measured with tiktoken's `o200k_base` on real diffs from this repo: **3.7–4.2 chars/token**; 3.0 used as a pessimistic floor.

| component | chars | tokens @3.0 floor |
|---|---|---|
| diff | 16000 | 5333 |
| PR body | 4000 | ~1100 (prose, ~3.6 ch/tok) |
| scaffold + instructions | — | ~250 |
| **worst case** | | **~6700 of 8000 (~15% headroom)** |

The 20000 that #2088 floated leaves only ~5% headroom and loses the margin to a denser-than-3.0 diff, so this goes a notch lower.

**Truncation is no longer silent.** If the diff *still* doesn't fit:
- the prompt states the byte counts and forbids `APPROVE` ("you have not seen the whole change");
- the posted review carries an explicit `⚠️ Partial review — the diff was truncated` banner with `kept/full` bytes;
- an `APPROVE` returned anyway is **downgraded to a comment review**, so a verdict based on a fragment can never be posted as an approving review.

A green tick on part of a diff reads exactly like a green tick on the whole thing. That's a vacuous green, and it's now impossible to produce one here.

The reviewer is also told *which* generated files were dropped and why, so it doesn't flag their absence as an incomplete change.

## Verification — measured, not asserted

Ran the exact new diff command over the real range of PR #2082 (`a3c85dfb...1457610c`), the PR that produced the 413:

| | before | after |
|---|---|---|
| reviewer payload | **211,616 bytes** | **14,643 bytes** (−93%) |
| files in payload | 6 | 5 (1 generated dropped) |
| assembled prompt (tiktoken, gpt-4o) | ~50k tokens of diff alone | **4,958 tokens of 8,000** |
| truncated? | yes, silently | **no — fits whole** |

Also exercised the truncation branch against a known-positive (same range, budget forced to 5000) and confirmed it reports `diff_truncated=true` with `5000/14643` — the flag is not a path that only ever reports "clean".

Fleet-restamp commits measured for scale too: `35cc28b0` (28 bundles) 136,061 → 36,783 bytes; `91460fcc` (27 bundles) 552,104 → 323,952 bytes. Both would still truncate — and now say so out loud — but both also touch `rules.yaml`, so the scope gate defers them to a human before a prompt is ever built.

**Lint:** `actionlint` (with shellcheck integration active) run per file — clean. Both the linter *and* the shellcheck integration were first validated against deliberately-broken control files, so "clean" means the checks ran, not that they were silently filtered.

## NOT fixed here — owner-only, tracked in #2161

Item 3 of #2088 — the Claude fallback that should have absorbed the 413 is **itself dead**: its first model call is rejected at the gateway (`is_error:true` at `num_turns:1`, `total_cost_usd:0`, ~2s), reproduced on 3 reruns over ~8h. Fixing it means re-minting `CLAUDE_CODE_OAUTH_TOKEN` via `claude setup-token`, which requires the owner's Claude Pro/Max session — no agent and no CI job can produce that credential, so no attempt was made.

Tracked in **#2161**, and flagged in this workflow's header as `KNOWN BROKEN` so nobody assumes a standby reviewer exists. Note this fix makes the fallback *less* likely to be exercised (the primary now succeeds on exactly the PRs that used to 413), which is precisely why it needed its own issue rather than an implicit close.

## Risk

Low. Single workflow file; the job is advisory and not a required check. The sensitivity classifier — the part that defers money-path / governance / CI / migration / ADR changes to a human — is **byte-for-byte unchanged**. The failure mode of a mistake here is "the reviewer sees less diff", never "a sensitive PR gets auto-approved".

Self-referentially, this PR touches `.github/**`, so `agent-review` will classify it as a CI/automation change and defer to a human — as designed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
