### PR TITLE
fix(standing-order): run the daily execution sweep on a Vert.x context (#2148)

### DIFF
--- a/openbank-standing-order-service/src/main/kotlin/com/openbank/standingorder/infrastructure/scheduler/StandingOrderExecutionScheduler.kt
+++ b/openbank-standing-order-service/src/main/kotlin/com/openbank/standingorder/infrastructure/scheduler/StandingOrderExecutionScheduler.kt
@@ -12,7 +12,6 @@ import io.quarkus.scheduler.Scheduled
 import jakarta.enterprise.context.ApplicationScoped
 import jakarta.enterprise.event.Observes
 import jakarta.inject.Inject
-import kotlinx.coroutines.runBlocking
 import org.eclipse.microprofile.config.inject.ConfigProperty
 import org.jboss.logging.Logger
 import java.time.Clock
@@ -64,10 +63,16 @@ class StandingOrderExecutionScheduler {
         cron = "{openbank.scheduler.execution-cron}",
         concurrentExecution = Scheduled.ConcurrentExecution.SKIP,
     )
-    fun sweep(): Unit = runBlocking {
+    // MUST be a suspend fun, NOT `runBlocking { }`: Quarkus dispatches a suspend @Scheduled method
+    // on a Vert.x context, whereas runBlocking runs the coroutine on the bare scheduler
+    // executor-thread, which carries no Vert.x context — the first Hibernate-Reactive call
+    // (findDueForExecution) then throws HR000068 and the whole sweep aborts with zero outbox rows
+    // (issue #2148). The sibling StandingOrderOutboxDispatcher.dispatch() is already a suspend fun for
+    // exactly this reason. Covered by StandingOrderExecutionSweepIT against a real DB.
+    suspend fun sweep() {
         if (!enabled) {
             log.debug("[execution-scheduler] Disabled — skipping sweep")
-            return@runBlocking
+            return
         }
         val today = LocalDate.now(clock)
         log.infof("[execution-scheduler] Starting daily execution sweep for %s", today)

--- a/openbank-standing-order-service/src/test/kotlin/com/openbank/standingorder/integration/StandingOrderExecutionSweepIT.kt
+++ b/openbank-standing-order-service/src/test/kotlin/com/openbank/standingorder/integration/StandingOrderExecutionSweepIT.kt
@@ -1,0 +1,104 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright (c) OpenBank contributors. Licensed under the Apache License, Version 2.0.
+// See LICENSE in the repository root or https://www.apache.org/licenses/LICENSE-2.0 for details.
+package com.openbank.standingorder.integration
+
+import com.openbank.libs.domain.identifiers.Ids
+import com.openbank.standingorder.domain.model.Frequency
+import com.openbank.standingorder.domain.model.PaymentType
+import com.openbank.standingorder.domain.model.StandingOrder
+import com.openbank.standingorder.domain.model.StandingOrderStatus
+import com.openbank.standingorder.infrastructure.persistence.repository.StandingOrderOutboxRepositoryImpl
+import com.openbank.standingorder.infrastructure.persistence.repository.StandingOrderRepositoryImpl
+import com.openbank.standingorder.infrastructure.scheduler.StandingOrderExecutionScheduler
+import com.openbank.standingorder.it.PostgresRedisTestResource
+import io.quarkus.test.common.QuarkusTestResource
+import io.quarkus.test.junit.QuarkusTest
+import io.quarkus.vertx.VertxContextSupport
+import io.smallrye.mutiny.coroutines.uni
+import jakarta.inject.Inject
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.Dispatchers
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.Test
+import java.time.Instant
+import java.time.LocalDate
+import java.time.ZoneOffset
+import java.util.UUID
+
+/**
+ * Real-DB coverage for the daily execution sweep (issue #2148). The scheduler's `sweep()` used to be
+ * `fun sweep(): Unit = runBlocking { … }`, which runs the coroutine on the bare scheduler
+ * executor-thread — no Vert.x context — so the first Hibernate-Reactive call (`findDueForExecution`)
+ * threw `HR000068` and the whole sweep aborted with zero outbox rows. `sweep()` is now a `suspend fun`
+ * (Quarkus dispatches it on a Vert.x context, like the sibling `StandingOrderOutboxDispatcher`).
+ *
+ * The old `StandingOrderServiceTest` mocks the repository, so `executeOrders` never touched a real
+ * reactive session and the threading never ran — the same masking class as the pause/cancel 500
+ * (#2077) and the consent outbox 500 (#1521). This IT drives the sweep through a real Vert.x context
+ * and a real DB and asserts a due order produces a `standing_order_outbox` row — the coverage the
+ * mocked unit test lacked.
+ */
+@QuarkusTest
+@QuarkusTestResource(PostgresRedisTestResource::class)
+class StandingOrderExecutionSweepIT {
+
+    @Inject
+    lateinit var scheduler: StandingOrderExecutionScheduler
+
+    @Inject
+    lateinit var orderRepository: StandingOrderRepositoryImpl
+
+    @Inject
+    lateinit var outboxRepository: StandingOrderOutboxRepositoryImpl
+
+    private fun <T> onEventLoop(block: suspend () -> T): T =
+        VertxContextSupport.subscribeAndAwait { uni(CoroutineScope(Dispatchers.Unconfined)) { block() } }
+
+    private fun dueOrder(id: UUID, dueOn: LocalDate): StandingOrder {
+        val now = Instant.now()
+        return StandingOrder(
+            id = id,
+            idempotencyKey = "sweep-it-$id",
+            partyId = Ids.newId(),
+            debitAccountId = Ids.newId(),
+            debtorIban = "DE89370400440532013000",
+            debtorName = "Alice Debtor",
+            creditorIban = "DE75512108001245126199",
+            creditorName = "Bob Creditor",
+            creditorBic = null,
+            amountMinorUnits = 1_000,
+            currency = "EUR",
+            frequency = Frequency.MONTHLY,
+            paymentType = PaymentType.SEPA_CREDIT,
+            remittanceInfo = null,
+            startDate = dueOn,
+            endDate = null,
+            nextExecutionDate = dueOn,
+            lastExecutionDate = null,
+            executionCount = 0,
+            failureCount = 0,
+            status = StandingOrderStatus.ACTIVE,
+            createdAt = now,
+            updatedAt = now,
+        )
+    }
+
+    @Test
+    fun `sweep executes a due order and enqueues an outbox row (issue 2148)`() {
+        val id = Ids.newId()
+        // Clock is Clock.systemUTC() (ClockProducer), so the sweep's asOf is today; make the order due.
+        onEventLoop { orderRepository.save(dueOrder(id, LocalDate.now(ZoneOffset.UTC))) }
+
+        val before = onEventLoop { outboxRepository.countProcessable() }
+
+        // Pre-#2148 this threw HR000068 on the executor-thread and enqueued nothing; with the suspend
+        // fix it runs the reactive sweep to completion on a Vert.x context.
+        onEventLoop { scheduler.sweep() }
+
+        val after = onEventLoop { outboxRepository.countProcessable() }
+        assertThat(after)
+            .describedAs("the daily sweep must enqueue a standing-order.due outbox row for the due order")
+            .isGreaterThan(before)
+    }
+}


### PR DESCRIPTION
## Bug (money-path, severity:high)
`StandingOrderExecutionScheduler.sweep()` — the daily cron that turns due standing orders into payment-execution events — **threw `HR000068` on every run and enqueued nothing**. The standing-order execution pipeline was dead end-to-end; no due order ever executed (confirmed live in sandbox, #2148).

## Root cause
```kotlin
fun sweep(): Unit = runBlocking { … }   // runs on the bare scheduler executor-thread
```
`runBlocking` runs the coroutine on the scheduler's executor-thread, which carries **no Vert.x context**, so the first Hibernate-Reactive call (`findDueForExecution`) throws `HR000068: This method should exclusively be invoked from a Vert.x EventLoop thread`. It sits before the per-order try/catch, so the whole sweep aborts — 0 outbox rows. The documented repo footgun, here on the non-HTTP scheduler path.

## Fix
`suspend fun sweep()` — Quarkus dispatches a suspend `@Scheduled` method on a Vert.x context, exactly as the sibling `StandingOrderOutboxDispatcher.dispatch()` already does. Removed the unused `runBlocking` import. **3-line behavioural change.**

## Test (the coverage the mocked unit test lacked)
`StandingOrderExecutionSweepIT`: seeds a due ACTIVE order, drives `sweep()` through a **real Vert.x context + real DB**, asserts a `standing_order_outbox` row is enqueued. Ran green vs Testcontainers (`tests=1, failures=0`). The old `StandingOrderServiceTest` mocks the repo, so `executeOrders` never touched a real reactive session and the threading never ran — same masking class as #2077 / #1521. The issue's live sandbox E2E (HR000068 → 0 rows) is the fail-first evidence.

## Local gate
`detekt` + `ktlintCheck` + `compileTestKotlin` green; the IT green vs Testcontainers.

**money-path ⇒ 2 approvals + threat model. Held for review — not auto-merging.**

Refs #2148.

🤖 Generated with [Claude Code](https://claude.com/claude-code)