### PR TITLE
ci(fleet-lint): raise the fleet-lint Gradle daemon heap 4g→6g so the gate stops OOM-ing

### DIFF
--- a/.github/workflows/fleet-lint.yml
+++ b/.github/workflows/fleet-lint.yml
@@ -75,7 +75,18 @@ jobs:
       # on a persistent runner isn't reused. file.encoding=UTF-8 alone does NOT fix filename decoding.
       LANG: C.UTF-8
       LC_ALL: C.UTF-8
-      GRADLE_OPTS: "-Dorg.gradle.jvmargs=-Xmx4g -Dfile.encoding=UTF-8 -Dsun.jnu.encoding=UTF-8"
+      # Heap is a RATCHET, and nothing measures it — expect to raise it again as the fleet grows.
+      # This is the only workflow that configures AND executes every module in ONE invocation, so
+      # its peak heap scales with the whole task graph (455 actionable tasks and climbing), not with
+      # one service. At -Xmx4g it started dying with `java.lang.OutOfMemoryError: Java heap space`
+      # in Gradle's MissingTaskDependencyDetector / ExecutionNodeAccessHierarchy — the execution-time
+      # VFS hierarchy that records every task's input/output locations, which grows with the graph.
+      # An OOM here is worse than a slow run: it aborts PART-WAY (235 of 455 tasks executed), so the
+      # modules after the abort are never linted at all, and the red check reads as "the fleet is
+      # broken" when nothing is. dependency-submission.yml already ratcheted 4g→6g for this same
+      # OOM class, and security.yml runs at 6g; ubuntu-latest has 16 GB, so 6g leaves ample room for
+      # the separate Kotlin compile daemon and the worker processes.
+      GRADLE_OPTS: "-Dorg.gradle.jvmargs=-Xmx6g -Dfile.encoding=UTF-8 -Dsun.jnu.encoding=UTF-8"
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
 


### PR DESCRIPTION
## What

Raise the `fleet-lint` job's Gradle daemon heap from `-Xmx4g` to `-Xmx6g`.

## Why

The full-fleet lint gate went red again — and this time nothing in the fleet is broken. Run [30142905147](https://github.com/JiRaska/open-bank-oss/actions/runs/30142905147) died with:

```
FAILURE: Build failed with an exception.
* What went wrong:
Java heap space
java.lang.OutOfMemoryError: Java heap space
  at org.gradle.execution.plan.ExecutionNodeAccessHierarchy.recordNodeAccessingLocation
  at org.gradle.api.internal.tasks.execution.MissingTaskDependencyDetector...
455 actionable tasks: 235 executed, 220 from cache
BUILD FAILED in 7m 47s
```

That log has **zero** `> Task ... FAILED` lines and **zero** `<file>.kt:<line>:<col>` violations (probe validated against the earlier genuinely-failing run 30120384920, which has 17). The daemon ran out of heap building Gradle's execution-time VFS hierarchy — it did not find a lint or compile defect.

`fleet-lint` is the only workflow that configures **and** executes every module in one Gradle invocation, so its peak heap scales with the whole task graph rather than with a single service — and the graph has grown fast (mcp-service, ap2-service, card-issuance-service and feedback all landed in the last day). `dependency-submission.yml` already ratcheted 4g→6g for this exact OOM class and `security.yml` runs at 6g; `ubuntu-latest` has 16 GB, so 6g leaves ample headroom for the separate Kotlin compile daemon and the workers.

**Why fix it rather than just re-run:** an OOM aborts the run *part-way* (235 of 455 tasks), so every module after the abort is never linted at all, while the red check reads as "the fleet is broken". That is a vacuous-red that trains people to dismiss the one gate whose entire purpose is to be a clean, un-dismissable signal — and it would dismiss a real break just as convincingly. The comment added above `GRADLE_OPTS` records that this heap is a ratchet with nothing measuring it.

## The original #2107 failure was real, and is already fixed

#2107 was opened by run 30120384920, a genuine break: #2037 made `InterestRateConfig.currency` required, but path-scoped CI never rebuilt `openbank-simulation`, so `InterestAccrualScenario.kt:110` landed on main calling the constructor without it — exactly the drift class this gate exists to catch.

Commit `0a9cff79` passed `world.currency` and the gate recovered. Runs 30121211233, 30121454402, 30123006641, 30126227036, 30127202388, 30128900795, 30132691198, 30133247088 and 30135459561 all reached `BUILD SUCCESSFUL`; the newest of them compiled **and** linted `openbank-simulation` across 58 modules. #2107 also has **0 comments**, and the alert step comments on the open issue on *every* subsequent failure — independent confirmation of the green streak.

No Kotlin or Gradle source has changed on main since that last fully-green run (the 11 commits since touch only gitops, admin-ui, docs, governance and CI), so the heap is the only thing left to fix.

## Verification

- `actionlint` clean on the changed file; finding set identical to `origin/main` (both empty), and the probe was validated against a deliberately broken copy (exit 1).
- YAML parses.
- The real proof is the gate itself going green on the next push to main.

Closes #2107

🤖 Generated with [Claude Code](https://claude.com/claude-code)