### PR TITLE
fix(ap2): demo uses agent:ap2-anonymous so the OPA charter matches (#1923)

### DIFF
--- a/openbank-ap2-service/demo/ap2-mandate-demo.py
+++ b/openbank-ap2-service/demo/ap2-mandate-demo.py
@@ -62,7 +62,7 @@ def verify(si: str, sig: str, amount_minor: int) -> dict | None:
         "payment": {"payee": PAYEE, "amountMinor": amount_minor, "currency": CURRENCY, "at": "2026-06-01T00:00:00Z"},
     }
     req = urllib.request.Request(f"{AP2_URL}/ap2/verify", data=json.dumps(body).encode(),
-                                 headers={"Content-Type": "application/json", "X-Agent-Id": "agent:ap2-demo"})
+                                 headers={"Content-Type": "application/json", "X-Agent-Id": "agent:ap2-anonymous"})
     try:
         with urllib.request.urlopen(req, timeout=10) as r:
             v = json.load(r)


### PR DESCRIPTION
The demo sent `X-Agent-Id: agent:ap2-demo`, but the verifier's ADR-0034 charter is `ap2-anonymous` — so every `/ap2/verify` returned 403 "no matching allow rule". Use `agent:ap2-anonymous` (the endpoint's default identity). **Verified live**: valid=true in-bounds, valid=false over-cap/tampered. Refs #1923