### PR TITLE
ci(admin-ui): let the ADR-0071 governance gate model stateless services, and fix its never-working gap reporter

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -96,7 +96,12 @@ jobs:
           GAPS=$(node -e "console.log(require('./governance.json').totals.withGaps)")
           if [ "$GAPS" -gt 0 ]; then
             echo "::error::Governance drift — $GAPS module(s) missing or with an invalid governance.yaml (ADR-0071 Phase 4). Add a governance.yaml to each flagged service."
-            node -e "const g=require('./governance.json'); g.modules.filter(m=>m.hasGap).forEach(m=>console.log('  gap: '+m.name))"
+            # Reads governance.json's real shape: a top-level `gaps` string array
+            # (issue #2165 — this used to read a `.modules` field that never existed,
+            # so it threw a TypeError on every failure and never named a module).
+            # No `?? []` fallback on purpose: a missing array is a generator bug and
+            # must be loud, not silently reported as "no gaps".
+            node -e "const g=require('./governance.json'); if(!Array.isArray(g.gaps)){console.error('::error::governance.json has no gaps array — generate-governance.mjs is broken');process.exit(2)} for(const x of g.gaps) console.log('  gap: '+x)"
             exit 1
           else
             echo "Governance manifest clean: $(node -e "console.log(require('./governance.json').totals.modules)") modules, 0 gaps."

--- a/openbank-admin-ui/scripts/generate-governance.mjs
+++ b/openbank-admin-ui/scripts/generate-governance.mjs
@@ -18,20 +18,17 @@
 
 import { readdirSync, statSync, readFileSync, writeFileSync, existsSync } from 'fs'
 import path from 'path'
-import { fileURLToPath } from 'url'
+import { fileURLToPath, pathToFileURL } from 'url'
 import { parse as parseYaml } from 'yaml'
 
 const __dirname = path.dirname(fileURLToPath(import.meta.url))
-const args = process.argv.slice(2)
-const getArg = (flag, dflt) => {
-  const i = args.indexOf(flag)
-  return i >= 0 && args[i + 1] ? args[i + 1] : dflt
-}
 
-const REPO = path.resolve(getArg('--repo', path.resolve(__dirname, '..', '..')))
-const OUT = path.resolve(getArg('--out', path.resolve(__dirname, '..', 'governance.json')))
+const REQUIRED = ['dataDomain', 'primaryDatastore', 'dataLineageRole', 'dataClassification', 'retentionPolicy']
 
-const REQUIRED = ['dataDomain', 'primaryDatastore', 'schemaName', 'dataLineageRole', 'dataClassification', 'retentionPolicy']
+// schemaName is NOT in REQUIRED because a stateless module legitimately owns none.
+// It is validated conditionally below: statelessness must be ASSERTED (`stateless: true`),
+// never inferred from an absent schemaName — otherwise a forgotten field and a service
+// that owns no schema are indistinguishable, and the gate silently stops meaning anything.
 
 // Enum constraints mirror governance.schema.json — an out-of-enum value is a gap,
 // so a future bad edit fails the CI drift gate instead of passing silently.
@@ -66,65 +63,104 @@ function flywayDeclaredVersion(dir) {
   return 'V' + versions.sort(cmp).at(-1)
 }
 
-// A module is a released component iff it has version.txt (admin-ui keeps it too).
-const modules = readdirSync(REPO)
-  .filter(n => n.startsWith('openbank-'))
-  .filter(n => { try { return statSync(path.join(REPO, n)).isDirectory() } catch { return false } })
-  .filter(n => existsSync(path.join(REPO, n, 'version.txt')))
-  .sort()
+// Exported (not just run as a CLI) so the gate's rules are unit-testable without
+// spawning a subprocess per case — see src/test/generate-governance.test.ts.
+export function buildManifest(REPO) {
+  // A module is a released component iff it has version.txt (admin-ui keeps it too).
+  const modules = readdirSync(REPO)
+    .filter(n => n.startsWith('openbank-'))
+    .filter(n => { try { return statSync(path.join(REPO, n)).isDirectory() } catch { return false } })
+    .filter(n => existsSync(path.join(REPO, n, 'version.txt')))
+    .sort()
 
-const services = []
-const gaps = []
-for (const name of modules) {
-  const dir = path.join(REPO, name)
-  const short = name.replace(/^openbank-/, '')
-  const raw = readText(path.join(dir, 'governance.yaml'))
-  if (raw == null) { gaps.push(`${name}: missing governance.yaml`); continue }
+  const services = []
+  const gaps = []
+  for (const name of modules) {
+    const dir = path.join(REPO, name)
+    const short = name.replace(/^openbank-/, '')
+    const raw = readText(path.join(dir, 'governance.yaml'))
+    if (raw == null) { gaps.push(`${name}: missing governance.yaml`); continue }
 
-  let decl
-  try { decl = parseYaml(raw) } catch (e) { gaps.push(`${name}: unparseable governance.yaml (${e.message})`); continue }
-  const missing = REQUIRED.filter(k => decl?.[k] == null || decl[k] === '')
-  if (missing.length) gaps.push(`${name}: governance.yaml missing ${missing.join(', ')}`)
-  for (const [k, allowed] of Object.entries(ENUMS)) {
-    if (decl?.[k] != null && !allowed.includes(decl[k])) {
-      gaps.push(`${name}: ${k}='${decl[k]}' not in [${allowed.join(', ')}]`)
+    let decl
+    try { decl = parseYaml(raw) } catch (e) { gaps.push(`${name}: unparseable governance.yaml (${e.message})`); continue }
+    const missing = REQUIRED.filter(k => decl?.[k] == null || decl[k] === '')
+    if (missing.length) gaps.push(`${name}: governance.yaml missing ${missing.join(', ')}`)
+
+    // Conditional schemaName rule (mirrors governance.schema.json's if/then/else).
+    const stateless = decl?.stateless === true
+    const hasSchemaName = decl?.schemaName != null && decl.schemaName !== ''
+    if (decl?.stateless != null && decl.stateless !== true) {
+      gaps.push(`${name}: stateless must be 'true' or omitted, got '${decl.stateless}'`)
     }
+    if (stateless && hasSchemaName) {
+      gaps.push(`${name}: declares stateless: true but also schemaName='${decl.schemaName}' — a stateless module owns no schema`)
+    }
+    if (!stateless && !hasSchemaName) {
+      gaps.push(`${name}: governance.yaml missing schemaName (add 'stateless: true' instead if the module owns no DB schema)`)
+    }
+
+    for (const [k, allowed] of Object.entries(ENUMS)) {
+      if (decl?.[k] != null && !allowed.includes(decl[k])) {
+        gaps.push(`${name}: ${k}='${decl[k]}' not in [${allowed.join(', ')}]`)
+      }
+    }
+
+    services.push({
+      serviceName: short,
+      dataDomain: decl.dataDomain ?? null,
+      primaryDatastore: decl.primaryDatastore ?? null,
+      schemaName: decl.schemaName ?? null,
+      stateless: stateless || undefined,
+      dataLineageRole: decl.dataLineageRole ?? null,
+      dataClassification: decl.dataClassification ?? 'unknown',
+      retentionPolicy: decl.retentionPolicy ?? 'unknown',
+      evidenceExported: typeof decl.evidenceExported === 'boolean' ? decl.evidenceExported : undefined,
+      flywayDeclaredVersion: flywayDeclaredVersion(dir),
+      lineage: decl.lineage ?? undefined,
+      schemaLineage: decl.schemaLineage ?? undefined,
+    })
   }
 
-  services.push({
-    serviceName: short,
-    dataDomain: decl.dataDomain ?? null,
-    primaryDatastore: decl.primaryDatastore ?? null,
-    schemaName: decl.schemaName ?? null,
-    dataLineageRole: decl.dataLineageRole ?? null,
-    dataClassification: decl.dataClassification ?? 'unknown',
-    retentionPolicy: decl.retentionPolicy ?? 'unknown',
-    evidenceExported: typeof decl.evidenceExported === 'boolean' ? decl.evidenceExported : undefined,
-    flywayDeclaredVersion: flywayDeclaredVersion(dir),
-    lineage: decl.lineage ?? undefined,
-    schemaLineage: decl.schemaLineage ?? undefined,
-  })
+  const totals = {
+    modules: services.length,
+    withLineage: services.filter(s => s.lineage).length,
+    evidenceExported: services.filter(s => s.evidenceExported).length,
+    withGaps: gaps.length,
+  }
+
+  return {
+    schema: 'openbank.governance/v1',
+    generator: 'generate-governance.mjs',
+    source: 'code-derived (governance.yaml + db/migration) — ADR-0071 / ADR-0029 D3',
+    collectedAt: null,
+    totals,
+    // The gap LIST, not just totals.withGaps — so the CI gate can name the offending
+    // modules from the artifact instead of guessing at a shape that never existed
+    // (issue #2165: the old reporter read `.modules`, which is not a field here, and
+    // therefore threw on every single failure without ever printing a gap).
+    gaps,
+    services,
+  }
 }
 
-const totals = {
-  modules: services.length,
-  withLineage: services.filter(s => s.lineage).length,
-  evidenceExported: services.filter(s => s.evidenceExported).length,
-  withGaps: gaps.length,
+function main() {
+  const args = process.argv.slice(2)
+  const getArg = (flag, dflt) => {
+    const i = args.indexOf(flag)
+    return i >= 0 && args[i + 1] ? args[i + 1] : dflt
+  }
+  const REPO = path.resolve(getArg('--repo', path.resolve(__dirname, '..', '..')))
+  const OUT = path.resolve(getArg('--out', path.resolve(__dirname, '..', 'governance.json')))
+
+  const manifest = buildManifest(REPO)
+  const { totals, gaps } = manifest
+  writeFileSync(OUT, JSON.stringify(manifest, null, 2) + '\n')
+  console.log(`[generate-governance] ${totals.modules} modules (${totals.withLineage} with lineage, ${totals.withGaps} gaps) → ${OUT}`)
+  if (gaps.length) {
+    console.log('[generate-governance] gaps:')
+    for (const g of gaps) console.log(`  - ${g}`)
+  }
 }
 
-const manifest = {
-  schema: 'openbank.governance/v1',
-  generator: 'generate-governance.mjs',
-  source: 'code-derived (governance.yaml + db/migration) — ADR-0071 / ADR-0029 D3',
-  collectedAt: null,
-  totals,
-  services,
-}
-
-writeFileSync(OUT, JSON.stringify(manifest, null, 2) + '\n')
-console.log(`[generate-governance] ${totals.modules} modules (${totals.withLineage} with lineage, ${totals.withGaps} gaps) → ${OUT}`)
-if (gaps.length) {
-  console.log('[generate-governance] gaps:')
-  for (const g of gaps) console.log(`  - ${g}`)
-}
+// CLI entrypoint only — importing this module (tests) must not write or log.
+if (process.argv[1] && import.meta.url === pathToFileURL(process.argv[1]).href) main()

--- a/openbank-admin-ui/src/app/docs/service-map/page.tsx
+++ b/openbank-admin-ui/src/app/docs/service-map/page.tsx
@@ -881,7 +881,7 @@ export default function ServiceMapPage() {
                       </div>
                       <div>
                         <div style={{ fontSize: '10px', color: 'var(--text-tertiary)' }}>{t('Schéma', 'Schema')}</div>
-                        <div style={{ fontWeight: 500, color: 'var(--text-secondary)' }}>{govEntry.schemaName}</div>
+                        <div style={{ fontWeight: 500, color: 'var(--text-secondary)' }}>{govEntry.schemaName ?? t('bez schématu (stateless)', 'no schema (stateless)')}</div>
                       </div>
                       <div>
                         <div style={{ fontSize: '10px', color: 'var(--text-tertiary)' }}>{t('Role v lineage', 'Lineage Role')}</div>

--- a/openbank-admin-ui/src/app/system/health/page.tsx
+++ b/openbank-admin-ui/src/app/system/health/page.tsx
@@ -250,7 +250,7 @@ function ServiceCard({ snapshot, resilience, governance, govTimestamp }: { snaps
           </div>
           <div style={{ display: 'flex', gap: '5px', flexWrap: 'wrap', alignItems: 'center' }}>
             <span className="tag" style={{ background: 'var(--surface-3)', border: 'none' }} title="Schema">
-              {governance.schemaName}
+              {governance.schemaName ?? 'no schema (stateless)'}
             </span>
             <span className="tag" style={{ background: 'var(--surface-3)', border: 'none' }} title="Current Version">
               {governance.flywayCurrentVersion || 'No version'}

--- a/openbank-admin-ui/src/lib/governance/governanceLoader.ts
+++ b/openbank-admin-ui/src/lib/governance/governanceLoader.ts
@@ -33,7 +33,8 @@ export function getGovernanceManifest(): GovernanceManifestEntry[] {
       serviceName: s.serviceName!,
       dataDomain: s.dataDomain!,
       primaryDatastore: s.primaryDatastore!,
-      schemaName: s.schemaName!,
+      schemaName: s.schemaName ?? null,   // null = declared stateless (ADR-0071)
+      stateless: s.stateless,
       dataLineageRole: s.dataLineageRole!,
       flywayDeclaredVersion: s.flywayDeclaredVersion ?? '',
       flywayCurrentVersion: null,        // runtime, no live-DB integration yet

--- a/openbank-admin-ui/src/lib/governance/manifest.ts
+++ b/openbank-admin-ui/src/lib/governance/manifest.ts
@@ -25,7 +25,10 @@ export interface GovernanceManifestEntry {
   serviceName: string
   dataDomain: DataDomain
   primaryDatastore: string
-  schemaName: string
+  /** Null iff the module declared `stateless: true` in its governance.yaml — it owns no DB schema (ADR-0071). */
+  schemaName: string | null
+  /** True iff the module asserted `stateless: true`; absent otherwise. */
+  stateless?: true
   dataLineageRole: DataLineageRole
   flywayDeclaredVersion: string
   flywayCurrentVersion: string | null

--- a/openbank-admin-ui/src/test/generate-governance.test.ts
+++ b/openbank-admin-ui/src/test/generate-governance.test.ts
@@ -1,0 +1,142 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright (c) OpenBank contributors. Licensed under the Apache License, Version 2.0.
+// See LICENSE in the repository root or https://www.apache.org/licenses/LICENSE-2.0 for details.
+
+import { beforeAll, describe, expect, it } from 'vitest'
+import { mkdtempSync, mkdirSync, rmSync, writeFileSync } from 'fs'
+import { tmpdir } from 'os'
+import path from 'path'
+// @ts-expect-error - plain .mjs build script, no type declarations by design
+import { buildManifest } from '../../scripts/generate-governance.mjs'
+
+// Regression guard for issue #2165 — the ADR-0071 governance gate had two defects,
+// both only observable on the gate's FAILURE path, which is why both survived:
+//
+//  1. schemaName was unconditionally required, so a genuinely stateless module
+//     (openbank-ap2-service, openbank-mcp-service) could never be clean. The fix is
+//     an EXPLICIT `stateless: true` assertion — statelessness must be declared, never
+//     inferred from an absent field, or a forgotten schemaName looks identical to a
+//     service that legitimately owns no schema.
+//  2. The CI reporter read governance.json's non-existent `.modules` field, so it
+//     threw a TypeError on every failure and had never once printed a gap. The
+//     manifest now carries a top-level `gaps` string array; the tests below lock in
+//     its presence, its length, and that it NAMES each offending module.
+//
+// The generator is imported, never spawned: `buildManifest` is the pure part and the
+// script's CLI half only runs under a `process.argv[1]` entrypoint guard. Spawning a
+// node subprocess per case measurably slowed the shared vitest pool and tipped
+// unrelated render-smoke tests over their 5 s timeout.
+
+interface Manifest {
+  totals: { modules: number; withGaps: number }
+  gaps: string[]
+  services: Array<{ serviceName: string; schemaName: string | null; stateless?: true }>
+}
+
+const STATEFUL = `dataDomain: core
+primaryDatastore: PostgreSQL
+schemaName: widgets_schema
+dataLineageRole: both
+dataClassification: confidential
+retentionPolicy: 10 years
+`
+
+const STATELESS = `dataDomain: payments
+primaryDatastore: none
+stateless: true
+dataLineageRole: consumer
+dataClassification: confidential
+retentionPolicy: not applicable
+`
+
+function buildRepo(modules: Record<string, string | null>): Manifest {
+  const repo = mkdtempSync(path.join(tmpdir(), 'gov-gate-'))
+  try {
+    for (const [name, yaml] of Object.entries(modules)) {
+      const dir = path.join(repo, name)
+      mkdirSync(dir, { recursive: true })
+      writeFileSync(path.join(dir, 'version.txt'), '1.0.0\n') // released-component marker
+      if (yaml != null) writeFileSync(path.join(dir, 'governance.yaml'), yaml)
+    }
+    return buildManifest(repo) as Manifest
+  } finally {
+    rmSync(repo, { recursive: true, force: true })
+  }
+}
+
+const gapFor = (m: Manifest, name: string) => m.gaps.filter(g => g.startsWith(`${name}:`))
+
+describe('generate-governance.mjs — the gap matrix (issue #2165)', () => {
+  let m: Manifest
+
+  beforeAll(() => {
+    m = buildRepo({
+      'openbank-ok-stateful': STATEFUL,
+      'openbank-ok-stateless': STATELESS,
+      'openbank-no-schemaname': STATEFUL.replace(/^schemaName:.*\n/m, ''),
+      'openbank-stateless-with-schema': STATELESS + 'schemaName: contradiction_schema\n',
+      'openbank-stateless-false': STATEFUL + 'stateless: false\n',
+      'openbank-no-yaml': null,
+    })
+  })
+
+  it('leaves a compliant stateful module and a compliant stateless module ungapped', () => {
+    expect(gapFor(m, 'openbank-ok-stateful')).toEqual([])
+    expect(gapFor(m, 'openbank-ok-stateless')).toEqual([])
+  })
+
+  it('flags a module that omits schemaName WITHOUT asserting statelessness', () => {
+    const [gap, ...rest] = gapFor(m, 'openbank-no-schemaname')
+    expect(rest).toEqual([])
+    expect(gap).toContain('missing schemaName')
+    expect(gap).toContain('stateless: true') // the remedy is spelled out in the message
+  })
+
+  it('flags the contradiction of `stateless: true` alongside a schemaName', () => {
+    const [gap, ...rest] = gapFor(m, 'openbank-stateless-with-schema')
+    expect(rest).toEqual([])
+    expect(gap).toContain('stateless')
+    expect(gap).toContain('contradiction_schema')
+  })
+
+  it('rejects `stateless: false` — the flag is an assertion, not a tri-state', () => {
+    expect(gapFor(m, 'openbank-stateless-false')).toEqual([
+      "openbank-stateless-false: stateless must be 'true' or omitted, got 'false'",
+    ])
+  })
+
+  it('still flags a module with no governance.yaml at all', () => {
+    expect(gapFor(m, 'openbank-no-yaml')).toEqual(['openbank-no-yaml: missing governance.yaml'])
+  })
+
+  it('records statelessness in the manifest so consumers can tell null-schema from unknown', () => {
+    const stateless = m.services.find(s => s.serviceName === 'ok-stateless')
+    expect(stateless).toMatchObject({ stateless: true, schemaName: null })
+    expect(m.services.find(s => s.serviceName === 'ok-stateful')).toMatchObject({
+      schemaName: 'widgets_schema',
+    })
+    expect(m.services.find(s => s.serviceName === 'ok-stateful')?.stateless).toBeUndefined()
+  })
+
+  // ── defect 2: the list the CI gate reads to name the offenders ──────────────
+  it('emits a top-level `gaps` ARRAY matching totals.withGaps and naming every module', () => {
+    expect(Array.isArray(m.gaps)).toBe(true)
+    expect(m.gaps).toHaveLength(m.totals.withGaps)
+    for (const name of [
+      'openbank-no-schemaname',
+      'openbank-stateless-with-schema',
+      'openbank-stateless-false',
+      'openbank-no-yaml',
+    ]) {
+      expect(m.gaps.join('\n')).toContain(name)
+    }
+  })
+})
+
+describe('generate-governance.mjs — a clean fleet (issue #2165)', () => {
+  it('emits `gaps: []` (present, not undefined) when nothing is wrong', () => {
+    const clean = buildRepo({ 'openbank-ok-stateful': STATEFUL, 'openbank-ok-stateless': STATELESS })
+    expect(clean.totals).toMatchObject({ modules: 2, withGaps: 0 })
+    expect(clean.gaps).toEqual([])
+  })
+})

--- a/openbank-ap2-service/governance.yaml
+++ b/openbank-ap2-service/governance.yaml
@@ -2,10 +2,13 @@
 # Per-service governance manifest (ADR-0071). Declarative, curatorial facts only.
 dataDomain: payments
 primaryDatastore: none
+# Owns no DB schema, asserted explicitly (ADR-0071): no schemaName key is correct here.
+stateless: true
 dataLineageRole: consumer
 dataClassification: confidential
 # Phase 1 (ADR-0193) holds no state: it verifies a presented mandate and returns a verdict. The
 # evidence record it produces is data-minimised (mandate hash, not the credential). When a phase-2
-# ADR persists evidence, set primaryDatastore/schemaName + payment-record retention (ADR-0118).
+# ADR persists evidence, drop `stateless`, set primaryDatastore/schemaName + payment-record
+# retention (ADR-0118).
 retentionPolicy: not applicable
 evidenceExported: false

--- a/openbank-libs/governance/governance.schema.json
+++ b/openbank-libs/governance/governance.schema.json
@@ -8,10 +8,20 @@
   "required": [
     "dataDomain",
     "primaryDatastore",
-    "schemaName",
     "dataLineageRole",
     "dataClassification",
     "retentionPolicy"
+  ],
+  "allOf": [
+    {
+      "$comment": "schemaName is required unless the module ASSERTS statelessness. 'Stateless' must be declared, never inferred from an absent field — otherwise a forgotten schemaName is indistinguishable from a service that owns no schema.",
+      "if": {
+        "properties": { "stateless": { "const": true } },
+        "required": ["stateless"]
+      },
+      "then": { "not": { "required": ["schemaName"] } },
+      "else": { "required": ["schemaName"] }
+    }
   ],
   "properties": {
     "dataDomain": {
@@ -23,8 +33,12 @@
       "type": "string",
       "minLength": 1
     },
+    "stateless": {
+      "description": "True iff this module owns no persistent DB schema. Explicit assertion, not an inference from a missing schemaName — a stateless module MUST set this and MUST NOT declare schemaName. When a later phase adds persistence, drop this flag and declare primaryDatastore + schemaName.",
+      "const": true
+    },
     "schemaName": {
-      "description": "Primary DB schema this service owns, e.g. 'accounts_schema'. Use 'n/a' if stateless.",
+      "description": "Primary DB schema this service owns, e.g. 'accounts_schema'. Omit it and set 'stateless: true' if the module owns no schema.",
       "type": "string",
       "minLength": 1
     },

--- a/openbank-mcp-service/governance.yaml
+++ b/openbank-mcp-service/governance.yaml
@@ -2,9 +2,12 @@
 # Per-service governance manifest (ADR-0071). Declarative, curatorial facts only.
 dataDomain: payments
 primaryDatastore: none
+# Owns no DB schema, asserted explicitly (ADR-0071): no schemaName key is correct here.
+stateless: true
 dataLineageRole: consumer
 dataClassification: confidential
 # Phase 1 holds no state (tools delegate to other services; proposals are a stub). When phase 2
-# adds a maker-checker proposal store, set primaryDatastore/schemaName + a 13-month retention.
+# adds a maker-checker proposal store, drop `stateless` and set
+# primaryDatastore/schemaName + a 13-month retention.
 retentionPolicy: not applicable
 evidenceExported: false


### PR DESCRIPTION
Closes #2165

`CI / Admin UI build` has been red on `main` since `openbank-ap2-service` and `openbank-mcp-service` landed. Two independent defects, both of which only manifest on the gate's **failure** path — which is exactly why both survived.

## 1. Stateless is now a modelled state, asserted rather than inferred

`generate-governance.mjs` required `schemaName` unconditionally. Both new services own no DB schema, so no value was correct.

Statelessness is now **asserted** (`stateless: true`), not inferred from an absent field. Making `schemaName` merely optional would have made a *forgotten* field indistinguishable from a service that legitimately owns none, and the gate would quietly stop meaning anything.

`openbank-libs/governance/governance.schema.json` gains a matching `if`/`then`/`else`: exactly one of `stateless: true` or a non-empty `schemaName` must be present. Declaring **both** is itself a gap, as is `stateless: false` (the flag is an assertion, not a tri-state).

## 2. The gap reporter had never worked

The failure branch ran `require('./governance.json').modules.filter(m => m.hasGap)`. There is no top-level `modules` field, so it threw `TypeError: Cannot read properties of undefined (reading 'filter')` on **every** failure and had never once printed a gap.

Reproduced on the exact artifact a failing run produces:

```
$ node -e "const g=require('./governance.json'); g.modules.filter(m=>m.hasGap).forEach(m=>console.log('  gap: '+m.name))"
TypeError: Cannot read properties of undefined (reading 'filter')
    at [eval]:1:49
```

The manifest now carries the gap **list** (top-level `gaps` string array) and the reporter reads that real shape. Deliberately **no** `?? []` fallback: a missing array is a generator bug and must be loud, not silently reported as "no gaps".

## Also

- The rule engine is exported as `buildManifest(repo)` behind a `process.argv[1]` CLI entrypoint guard, so the gate's rules are unit-testable without spawning a subprocess per case.
- `schemaName` is nullable through the admin-ui types (`manifest.ts`, `governanceLoader.ts`); both render sites label it `no schema (stateless)` instead of rendering blank.
- New `src/test/generate-governance.test.ts` (8 tests) pins the whole matrix, including that `gaps` is always an array and always names the offender.

## Known-positive validation (not just a green run)

Gate script extracted verbatim from `ci.yml` and run three times.

**Clean:**
```
[generate-governance] 53 modules (38 with lineage, 0 gaps) → .../governance.json
Governance manifest clean: 53 modules, 0 gaps.
GATE EXIT=0
```

**Deliberate gap — `openbank-ledger-service`'s `schemaName` stripped:**
```
[generate-governance] 53 modules (38 with lineage, 1 gaps) → .../governance.json
[generate-governance] gaps:
  - openbank-ledger-service: governance.yaml missing schemaName (add 'stateless: true' instead if the module owns no DB schema)
::error::Governance drift — 1 module(s) missing or with an invalid governance.yaml (ADR-0071 Phase 4). Add a governance.yaml to each flagged service.
  gap: openbank-ledger-service: governance.yaml missing schemaName (add 'stateless: true' instead if the module owns no DB schema)
GATE EXIT=1
```
The `gap:` line is the reporter — the line that used to be a stack trace.

**Restored:** back to `53 modules, 0 gaps`, `GATE EXIT=0`.

The new tests were also run against a generator regressed to each defect individually and fail in both cases (defect 1: 3 failures; defect 2: 7 failures).

## Other checks

- `actionlint` per file (proven to actually run by first pointing it at a deliberately broken workflow): **zero new findings** vs `origin/main` — finding sets diffed, not eyeballed.
- `npm run lint` 0 errors, `tsc --noEmit` clean, `check-manifest-types-only.sh` OK.
- Full vitest suite 39 files / 655 tests green, **3 consecutive runs** (an earlier subprocess-spawning version of the test destabilised unrelated render-smoke timeouts; that is why the generator was made importable).
- All 53 `governance.yaml` re-validated against the updated JSON Schema with ajv 8.

## Release scope

Deliberately typed `ci`, not `fix`. `openbank-ap2-service` and `openbank-mcp-service` change only `governance.yaml` with nothing under `src/main/**` — a releasing type would cut patch releases of both for a metadata line and trip `release_scope_mismatch`. The admin-ui source change is a nullable type plus a fallback label; not changelog-worthy on its own.

## Follow-up (not in this PR)

`governance.schema.json` is documentation-only — nothing machine-validates against it, and the ajv run above surfaced 4 pre-existing violations (`clearing`, `dispute`, `fx`, `sanctions` all have a bare `lineage:` key that parses to `null`). Untouched here; worth a separate issue.