### PR TITLE
feat(balance): surface the future-value-dated pipeline on the reconciliation report (ADR-0178 Phase 3)

### DIFF
--- a/docs/threat-models/openbank-balance-service.md
+++ b/docs/threat-models/openbank-balance-service.md
@@ -8,11 +8,13 @@ STRIDE/DFD threat model for the balance bounded context, per ADR-0030 D2.
 Money-path service. Reviewed in PR; referenced from ADR-0039.
 
 - **Status:** Draft (lightweight, ADR-0039-aware)
-- **Last reviewed:** 2026-06-08
+- **Last reviewed:** 2026-07-25 (ADR-0178 Phase 3 — reconciliation publishes the future-value-dated
+  pipeline; read-only reporting, no write path and no change to the drift arithmetic)
 - **Owner:** balance CODEOWNERS
 - **Related ADRs:** ADR-0002 (hexagonal), ADR-0017 (Vault), ADR-0018 (OPA authz),
   ADR-0024/0025 (single IBAN + currency pockets), ADR-0034 (OPA unified authz),
-  ADR-0039 (balance as projection of ledger)
+  ADR-0039 (balance as projection of ledger), ADR-0160 (sustained-drift alerting),
+  ADR-0178 (value-date-correct reconciliation)
 
 ## 1. Scope & assets
 
@@ -140,6 +142,18 @@ also be deleted (nothing else in balance-service depends on it).
   dampener does not contain it). Anchoring on the materialized `balances` (not on the audit sum) keeps
   the tie-out able to catch a `balances`⇄projection-audit desync — it is not blind to a broken write
   path (T2).
+- **The future-value-dated pipeline is published, never subtracted** (ADR-0178 Phase 3). The
+  reconciliation reports `futureValueDatedPipeline` per currency — the same `Σ delta with
+  entry_date > asOf` tail the value-date basis already excludes — so an operator sees the expected
+  upcoming movement instead of an unexplained gap between the tie-out figure and the raw materialized
+  total. It must stay **read-only and out of the drift arithmetic**: both sides of the tie-out already
+  exclude that tail, so folding it into `difference` would double-count and re-create the false drift
+  Phase 1 removed, while *subtracting* it from a genuine mismatch would let a real divergence hide
+  behind an outstanding pipeline. The remaining `difference` is therefore UNEXPLAINED drift by
+  construction — that, plus the ADR-0160 sustained-duration `for:` clause, is the alerting signal.
+  Locked by `BalanceReconciliationServiceTest` (a purely future-value-dated batch raises zero drift; a
+  genuine shortfall still drifts while a pipeline is outstanding) and by `BalanceReconciliationAsOfIT`
+  against a real database.
 
 ## 6. Open items / follow-ups
 

--- a/openbank-admin-ui/src/app/day-end/page.tsx
+++ b/openbank-admin-ui/src/app/day-end/page.tsx
@@ -119,6 +119,9 @@ interface CurrencyReconciliation {
   subLedgerBookedSum: number | string
   difference: number | string
   withinTolerance: boolean
+  // ADR-0178 Phase 3 — future-value-dated pipeline (posted, not yet effective). Optional: reports
+  // recorded before the field existed omit it, so render 0 rather than NaN.
+  futureValueDatedPipeline?: number | string
 }
 
 interface ReconciliationReport {
@@ -319,18 +322,21 @@ function EodPanel() {
                     <th style={{ textAlign: 'left', padding: '8px 16px', fontWeight: 600 }}>{t('Měna', 'Currency')}</th>
                     <th style={{ padding: '8px 16px', fontWeight: 600 }}>{t('Kontrolní účet HK', 'Ledger control')}</th>
                     <th style={{ padding: '8px 16px', fontWeight: 600 }}>{t('Součet sub-ledgeru', 'Sub-ledger sum')}</th>
-                    <th style={{ padding: '8px 16px', fontWeight: 600 }}>{t('Rozdíl', 'Difference')}</th>
+                    <th style={{ padding: '8px 16px', fontWeight: 600 }} title={t('Zaúčtované pohyby s pozdějším datem valuty — ještě nejsou v žádné straně vyrovnání, proto nejde o rozdíl.', 'Posted movements value-dated after asOf — counted by neither side of the tie-out, so not drift.')}>{t('Očekávané pohyby (valuta)', 'Value-date pipeline')}</th>
+                    <th style={{ padding: '8px 16px', fontWeight: 600 }}>{t('Nevysvětlený rozdíl', 'Unexplained difference')}</th>
                     <th style={{ textAlign: 'center', padding: '8px 16px', fontWeight: 600 }}>{t('Stav', 'Status')}</th>
                   </tr>
                 </thead>
                 <tbody>
                   {report.currencies.map(row => {
                     const diff = num(row.difference)
+                    const pipeline = num(row.futureValueDatedPipeline ?? 0)
                     return (
                       <tr key={row.currency} style={{ borderTop: '1px solid var(--border)' }}>
                         <td style={{ padding: '10px 16px', fontWeight: 600, color: 'var(--text-primary)' }}>{row.currency}</td>
                         <td style={{ padding: '10px 16px', textAlign: 'right', fontFamily: 'JetBrains Mono, monospace', color: 'var(--text-secondary)' }}>{fmtAmount(row.ledgerControlBalance)}</td>
                         <td style={{ padding: '10px 16px', textAlign: 'right', fontFamily: 'JetBrains Mono, monospace', color: 'var(--text-secondary)' }}>{fmtAmount(row.subLedgerBookedSum)}</td>
+                        <td style={{ padding: '10px 16px', textAlign: 'right', fontFamily: 'JetBrains Mono, monospace', color: pipeline === 0 ? 'var(--text-tertiary)' : 'var(--text-secondary)' }}>{fmtAmount(row.futureValueDatedPipeline ?? 0)}</td>
                         <td style={{ padding: '10px 16px', textAlign: 'right', fontFamily: 'JetBrains Mono, monospace', fontWeight: 600, color: diff === 0 ? 'var(--text-secondary)' : 'var(--danger)' }}>{fmtAmount(row.difference)}</td>
                         <td style={{ padding: '10px 16px', textAlign: 'center' }}>
                           <span className={row.withinTolerance ? 'pill pill-success' : 'pill pill-danger'}>

--- a/openbank-balance-service/src/main/kotlin/com/openbank/balance/application/port/out/BalancePorts.kt
+++ b/openbank-balance-service/src/main/kotlin/com/openbank/balance/application/port/out/BalancePorts.kt
@@ -38,6 +38,19 @@ interface BalanceRepository {
     suspend fun sumBookedByCurrencyAsOf(asOf: java.time.LocalDate): Map<String, BigDecimal>
 
     /**
+     * The future-value-dated **pipeline** per currency: Σ of projected booked deltas whose value date
+     * is strictly after [asOf], read from the dated projection audit (`ledger_projection_event`).
+     *
+     * This is exactly the tail [sumBookedByCurrencyAsOf] subtracts, published in its own right for
+     * ADR-0178 Phase 3 control quality: it is the expected upcoming movement, so an operator reading
+     * the tie-out can see *why* the value-date sub-ledger sum differs from the raw materialized booked
+     * total rather than facing an unexplained control-account gap. Read-only reporting — it moves no
+     * money and does not feed the drift calculation (both tie-out sides already exclude this tail, so
+     * subtracting it again would double-count). Empty when nothing is value-dated after [asOf].
+     */
+    suspend fun sumFutureValueDatedByCurrency(asOf: java.time.LocalDate): Map<String, BigDecimal>
+
+    /**
      * Sum of booked deltas applied to ([accountId], [currency]) with a booking date *strictly after*
      * [asOf], read from the dated ledger-projection audit (`ledger_projection_event`). Used to rewind
      * the current booked balance to a point in time: `bookedAsOf = current − sumBookedDeltaAfter(asOf)`.

--- a/openbank-balance-service/src/main/kotlin/com/openbank/balance/application/usecase/BalanceReconciliationService.kt
+++ b/openbank-balance-service/src/main/kotlin/com/openbank/balance/application/usecase/BalanceReconciliationService.kt
@@ -47,12 +47,19 @@ class BalanceReconciliationService(
         // a future-value-dated journal is POSTED but not yet in the ledger control, so counting it in
         // the sub-ledger sum would surface a self-resolving false drift for the whole pre-value window.
         val bookedByCcy = balanceRepo.sumBookedByCurrencyAsOf(asOf)
+        // ADR-0178 Phase 3 — explainability. The tail the line above subtracts, reported in its own
+        // right: POSTED movements whose value date is still ahead, which neither side of the tie-out
+        // counts yet. Attached to the report, never to `difference` — both sides already exclude it,
+        // so folding it into the drift would double-count and re-introduce the very false positive
+        // Phase 1 removed. Drift therefore stays UNEXPLAINED drift; this column is the explained part.
+        val futureValueDatedByCcy = balanceRepo.sumFutureValueDatedByCurrency(asOf)
 
         val report = ReconciliationPolicy.reconcile(
             ledgerControlByCurrency = ledgerByCcy,
             subLedgerBookedByCurrency = bookedByCcy,
             asOf = asOf,
             generatedAt = OffsetDateTime.now(clock),
+            futureValueDatedByCurrency = futureValueDatedByCcy,
         )
 
         val persisted = recordRepo.save(report)

--- a/openbank-balance-service/src/main/kotlin/com/openbank/balance/domain/reconciliation/ControlReconciliation.kt
+++ b/openbank-balance-service/src/main/kotlin/com/openbank/balance/domain/reconciliation/ControlReconciliation.kt
@@ -30,6 +30,16 @@ data class CurrencyReconciliation(
     /** subLedgerBookedSum − ledgerControlBalance. Zero (within tolerance) means the two agree. */
     val difference: BigDecimal,
     val withinTolerance: Boolean,
+    /**
+     * ADR-0178 Phase 3 — the future-value-dated **pipeline**: Σ of projected booked deltas whose value
+     * date is strictly after [ReconciliationReport.asOf]. These are POSTED movements that neither side
+     * of the tie-out counts yet, so they never contribute to [difference]; the figure is published
+     * purely so an operator can see the expected upcoming movement instead of an unexplained gap
+     * between this run's [subLedgerBookedSum] and the raw materialized booked total.
+     *
+     * Defaulted to ZERO so a reconciliation row persisted before this field existed still deserializes.
+     */
+    val futureValueDatedPipeline: BigDecimal = BigDecimal.ZERO,
 )
 
 /** A single reconciliation run across every currency seen on either side. */
@@ -39,7 +49,15 @@ data class ReconciliationReport(
     val tolerance: BigDecimal,
     val currencies: List<CurrencyReconciliation>,
 ) {
-    /** True when any currency drifted beyond tolerance — the alerting signal. */
+    /**
+     * True when any currency drifted beyond tolerance — the alerting signal.
+     *
+     * ADR-0178 Phase 3: this is already **unexplained** drift by construction. Both sides are compared
+     * on the ledger's value-date basis (Phase 1), so a future-value-dated posting is excluded from
+     * both and cannot move [CurrencyReconciliation.difference]; whatever remains is a genuine
+     * divergence, not value-date timing. [CurrencyReconciliation.futureValueDatedPipeline] reports the
+     * excluded timing figure separately so the operator can see it without it polluting the signal.
+     */
     val hasDrift: Boolean get() = currencies.any { !it.withinTolerance }
 
     val driftedCurrencies: List<String> get() = currencies.filter { !it.withinTolerance }.map { it.currency }
@@ -59,15 +77,26 @@ object ReconciliationPolicy {
      * Currencies are the union of both maps; a currency present on only one side is reconciled against
      * an implicit zero on the other (so a stray balance with no ledger backing, or vice versa, surfaces
      * as drift rather than silently dropping out).
+     *
+     * [futureValueDatedByCurrency] (ADR-0178 Phase 3) carries the future-value-dated pipeline per
+     * currency. It is reported, never subtracted: both sides are already on the value-date basis, so
+     * folding it into [CurrencyReconciliation.difference] would double-count. A currency that appears
+     * ONLY in the pipeline map still yields a row — an entirely future-dated currency is worth showing
+     * (both tie-out sides are legitimately zero for it), and its difference is zero, so it raises no
+     * drift.
      */
+    @Suppress("LongParameterList")
     fun reconcile(
         ledgerControlByCurrency: Map<String, BigDecimal>,
         subLedgerBookedByCurrency: Map<String, BigDecimal>,
         asOf: LocalDate,
         generatedAt: OffsetDateTime,
         tolerance: BigDecimal = DEFAULT_TOLERANCE,
+        futureValueDatedByCurrency: Map<String, BigDecimal> = emptyMap(),
     ): ReconciliationReport {
-        val currencies = (ledgerControlByCurrency.keys + subLedgerBookedByCurrency.keys)
+        val currencies = (
+            ledgerControlByCurrency.keys + subLedgerBookedByCurrency.keys + futureValueDatedByCurrency.keys
+            )
             .toSortedSet()
             .map { ccy ->
                 val ledger = ledgerControlByCurrency[ccy] ?: BigDecimal.ZERO
@@ -79,6 +108,7 @@ object ReconciliationPolicy {
                     subLedgerBookedSum = subLedger,
                     difference = difference,
                     withinTolerance = difference.abs().compareTo(tolerance) <= 0,
+                    futureValueDatedPipeline = futureValueDatedByCurrency[ccy] ?: BigDecimal.ZERO,
                 )
             }
         return ReconciliationReport(

--- a/openbank-balance-service/src/main/kotlin/com/openbank/balance/infrastructure/persistence/repository/BalanceRepositoryImpl.kt
+++ b/openbank-balance-service/src/main/kotlin/com/openbank/balance/infrastructure/persistence/repository/BalanceRepositoryImpl.kt
@@ -96,14 +96,14 @@ class BalanceRepositoryImpl(private val repo: BalancePanacheRepo) : BalanceRepos
         // audit, so a write-path bug that desynchronized `balances` from `ledger_projection_event` still
         // surfaces as drift instead of being hidden by summing the audit alone.
         val current = sumBookedByCurrency()
-        val futureDated = sumBookedDeltaAfterByCurrency(asOf)
+        val futureDated = sumFutureValueDatedByCurrency(asOf)
         return (current.keys + futureDated.keys).associateWith { ccy ->
             (current[ccy] ?: BigDecimal.ZERO).subtract(futureDated[ccy] ?: BigDecimal.ZERO)
         }
     }
 
     /** Σ of projected booked deltas whose value date is strictly after [asOf], grouped by currency. */
-    private suspend fun sumBookedDeltaAfterByCurrency(asOf: java.time.LocalDate): Map<String, BigDecimal> =
+    override suspend fun sumFutureValueDatedByCurrency(asOf: java.time.LocalDate): Map<String, BigDecimal> =
         Panache.withSession {
             Panache.getSession().flatMap { session ->
                 session.createQuery(

--- a/openbank-balance-service/src/main/resources/openapi.yaml
+++ b/openbank-balance-service/src/main/resources/openapi.yaml
@@ -3,7 +3,7 @@
 openapi: 3.1.0
 info:
   title: Balance Service API
-  version: 1.4.1
+  version: 1.5.0
   description: >-
     Account balance management — holds, credits, debits, multi-currency. Per ADR-0039 (Phase A) a
     read-only reconciliation ties out, per currency, the ledger deposit-control balance against the
@@ -382,9 +382,22 @@ components:
           description: Sum of balance-service booked amounts across all accounts in the currency.
         difference:
           type: number
-          description: subLedgerBookedSum − ledgerControlBalance; zero (within tolerance) means agreement.
+          description: >-
+            subLedgerBookedSum − ledgerControlBalance; zero (within tolerance) means agreement. Both
+            sides are on the ledger's value-date basis (ADR-0178 Phase 1), so this is UNEXPLAINED
+            drift — value-date timing cannot contribute to it.
         withinTolerance:
           type: boolean
+        futureValueDatedPipeline:
+          type: number
+          default: 0
+          description: >-
+            ADR-0178 Phase 3 — the future-value-dated pipeline: sum of projected booked deltas whose
+            value date is strictly after asOf. These movements are POSTED but not yet effective, so
+            neither side of the tie-out counts them and they never contribute to `difference`.
+            Reported so an operator can see the expected upcoming movement rather than an unexplained
+            gap between subLedgerBookedSum and the raw materialized booked total. Absent on runs
+            recorded before this field existed; treat as 0.
 
     ApiError:
       type: object

--- a/openbank-balance-service/src/test/kotlin/com/openbank/balance/application/usecase/BalanceReconciliationServiceTest.kt
+++ b/openbank-balance-service/src/test/kotlin/com/openbank/balance/application/usecase/BalanceReconciliationServiceTest.kt
@@ -65,6 +65,62 @@ class BalanceReconciliationServiceTest {
     }
 
     @Test
+    fun `reconcile reports the future-value-dated pipeline without turning it into drift`(): Unit = runBlocking {
+        // ADR-0178 Phase 3. Same scenario as the value-date test above: 1500 booked, of which 500 is
+        // value-dated forward, so the value-date-correct sum (1000) ties out to the control (1000).
+        // The 500 must be REPORTED as the pipeline and must NOT move `difference` — the tie-out sides
+        // already exclude it, so subtracting it again would re-create the false drift Phase 1 removed.
+        val ledger = FakeLedgerControl(mapOf("CZK" to BigDecimal("1000.00")))
+        val balanceRepo = FakeSumRepository(
+            sums = mapOf("CZK" to BigDecimal("1500.00")),
+            valueDatedSums = mapOf("CZK" to BigDecimal("1000.00")),
+            futureValueDated = mapOf("CZK" to BigDecimal("500.00")),
+        )
+        val records = FakeRecordRepository()
+        val service = BalanceReconciliationService(
+            balanceRepo,
+            ledger,
+            records,
+            java.time.Clock.systemUTC(),
+            mockk<DomainMetrics>(relaxed = true),
+        )
+
+        val report = service.reconcile(asOf)
+
+        val czk = report.currencies.single()
+        assertEquals(0, czk.futureValueDatedPipeline.compareTo(BigDecimal("500.00")), "pipeline must be surfaced")
+        assertEquals(0, czk.difference.compareTo(BigDecimal.ZERO), "pipeline must not leak into drift")
+        assertFalse(report.hasDrift, "a purely future-value-dated batch must raise ZERO alerts")
+        assertEquals(asOf, balanceRepo.askedPipelineAsOf, "pipeline must be read as of the tie-out date")
+    }
+
+    @Test
+    fun `a genuine divergence still drifts even while a pipeline is outstanding`(): Unit = runBlocking {
+        // The pipeline is explanatory only: a real 10.00 shortfall on the value-date basis must still
+        // alert, and must not be masked by an unrelated future-value-dated batch sitting in the tail.
+        val ledger = FakeLedgerControl(mapOf("CZK" to BigDecimal("1000.00")))
+        val balanceRepo = FakeSumRepository(
+            sums = mapOf("CZK" to BigDecimal("1490.00")),
+            valueDatedSums = mapOf("CZK" to BigDecimal("990.00")),
+            futureValueDated = mapOf("CZK" to BigDecimal("500.00")),
+        )
+        val service = BalanceReconciliationService(
+            balanceRepo,
+            ledger,
+            FakeRecordRepository(),
+            java.time.Clock.systemUTC(),
+            mockk<DomainMetrics>(relaxed = true),
+        )
+
+        val report = service.reconcile(asOf)
+
+        assertTrue(report.hasDrift, "unexplained drift must still alert while a pipeline is outstanding")
+        val czk = report.currencies.single()
+        assertEquals(0, czk.difference.compareTo(BigDecimal("-10.00")), "drift is the value-date-basis gap only")
+        assertEquals(0, czk.futureValueDatedPipeline.compareTo(BigDecimal("500.00")))
+    }
+
+    @Test
     fun `reconcile flags drift when ledger and booked disagree`(): Unit = runBlocking {
         val ledger = FakeLedgerControl(mapOf("CZK" to BigDecimal("1000.00")))
         val balanceRepo = FakeSumRepository(mapOf("CZK" to BigDecimal("990.00")))
@@ -145,8 +201,10 @@ class BalanceReconciliationServiceTest {
     private class FakeSumRepository(
         private val sums: Map<String, BigDecimal>,
         private val valueDatedSums: Map<String, BigDecimal> = sums,
+        private val futureValueDated: Map<String, BigDecimal> = emptyMap(),
     ) : com.openbank.balance.application.port.out.BalanceRepository {
         var askedAsOf: LocalDate? = null
+        var askedPipelineAsOf: LocalDate? = null
         override suspend fun findByAccountIdAndCurrency(accountId: UUID, currency: String) = null
         override suspend fun findAllByAccountId(accountId: UUID) =
             emptyList<com.openbank.balance.domain.model.Balance>()
@@ -162,6 +220,10 @@ class BalanceReconciliationServiceTest {
             currency: String,
             asOf: java.time.LocalDate,
         ): BigDecimal = BigDecimal.ZERO
+        override suspend fun sumFutureValueDatedByCurrency(asOf: LocalDate): Map<String, BigDecimal> {
+            askedPipelineAsOf = asOf
+            return futureValueDated
+        }
     }
 
     private class FakeRecordRepository : ReconciliationRecordRepository {

--- a/openbank-balance-service/src/test/kotlin/com/openbank/balance/application/usecase/BalanceServiceTest.kt
+++ b/openbank-balance-service/src/test/kotlin/com/openbank/balance/application/usecase/BalanceServiceTest.kt
@@ -284,6 +284,9 @@ class BalanceServiceTest {
             currency: String,
             asOf: java.time.LocalDate,
         ): BigDecimal = futureDelta
+
+        override suspend fun sumFutureValueDatedByCurrency(asOf: java.time.LocalDate): Map<String, BigDecimal> =
+            mapOf(seed.currency to futureDelta)
     }
 
     /**

--- a/openbank-balance-service/src/test/kotlin/com/openbank/balance/contract/ReconciliationContractTest.kt
+++ b/openbank-balance-service/src/test/kotlin/com/openbank/balance/contract/ReconciliationContractTest.kt
@@ -5,6 +5,7 @@
 package com.openbank.balance.contract
 
 import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Assertions.assertFalse
 import org.junit.jupiter.api.Assertions.assertTrue
 import org.junit.jupiter.api.Test
 import java.io.File
@@ -22,9 +23,32 @@ class ReconciliationContractTest {
     @Test
     fun `contract version is bumped for the reconciliation change`() {
         val version = Regex("""(?m)^\s+version:\s*"?([^"\s]+)"?\s*$""").find(openapi)?.groupValues?.get(1)
-        // 1.4.1: editorial bump for the 403 Forbidden documentation added across every operation
-        // (ADR-0034 Phase 5, issue #266 — OPA enforcement). No schema/behavior change.
-        assertEquals("1.4.1", version)
+        // 1.5.0: MINOR — ADR-0178 Phase 3 adds the optional, additive `futureValueDatedPipeline`
+        // property to CurrencyReconciliation (issue #1746). Backward compatible: no property removed,
+        // none made required, no behavior change. Previous 1.4.1 was an editorial bump for the 403
+        // Forbidden documentation added across every operation (ADR-0034 Phase 5, issue #266).
+        assertEquals("1.5.0", version)
+    }
+
+    /**
+     * ADR-0048: an API change ships with a contract test. Locks the Phase 3 field to the *response*
+     * schema and pins its additive shape — it must stay optional, so an older consumer that never
+     * reads it keeps parsing the report unchanged.
+     */
+    @Test
+    fun `the per-currency tie-out documents the future-value-dated pipeline as an optional field`() {
+        val currencySchema = openapi
+            .substringAfter("    CurrencyReconciliation:")
+            .substringBefore("\n    ApiError:")
+
+        assertTrue(
+            currencySchema.contains("futureValueDatedPipeline:"),
+            "CurrencyReconciliation must expose futureValueDatedPipeline (ADR-0178 Phase 3)",
+        )
+        assertFalse(
+            currencySchema.contains("required:"),
+            "futureValueDatedPipeline must stay OPTIONAL — making it required is a breaking MAJOR change",
+        )
     }
 
     @Test

--- a/openbank-balance-service/src/test/kotlin/com/openbank/balance/integration/BalanceReconciliationAsOfIT.kt
+++ b/openbank-balance-service/src/test/kotlin/com/openbank/balance/integration/BalanceReconciliationAsOfIT.kt
@@ -105,4 +105,72 @@ class BalanceReconciliationAsOfIT {
         assertThat(asOfSum["CZK"]).isEqualByComparingTo("1000.00")
         assertThat(asOfSum["EUR"]).isEqualByComparingTo("200.00")
     }
+
+    /**
+     * ADR-0178 Phase 3 — the pipeline the tie-out subtracts must also be readable on its own, against
+     * a REAL database. A mocked repository cannot prove the `entry_date > :asOf` grouping or the
+     * `sumBookedByCurrencyAsOf = sumBookedByCurrency − pipeline` identity that the operator-facing
+     * explanation rests on; it would happily return whatever the fake was told to.
+     */
+    @Test
+    fun `sumFutureValueDatedByCurrency reports the tail that the as-of sum subtracts`() {
+        val asOf = LocalDate.of(2026, 7, 18)
+        val acctCzk = UUID.randomUUID()
+        val acctEur = UUID.randomUUID()
+        clean()
+
+        onEventLoop {
+            // CZK: 1000 effective + two future-value-dated credits (500 + 250) = 750 pipeline.
+            projection.applyBookedDelta(
+                journalEntryId = UUID.randomUUID(),
+                accountId = acctCzk,
+                currency = "CZK",
+                delta = BigDecimal("1000.00"),
+                transactionId = UUID.randomUUID(),
+                entryDate = asOf.minusDays(1),
+            )
+            projection.applyBookedDelta(
+                journalEntryId = UUID.randomUUID(),
+                accountId = acctCzk,
+                currency = "CZK",
+                delta = BigDecimal("500.00"),
+                transactionId = UUID.randomUUID(),
+                entryDate = asOf.plusDays(2),
+            )
+            projection.applyBookedDelta(
+                journalEntryId = UUID.randomUUID(),
+                accountId = acctCzk,
+                currency = "CZK",
+                delta = BigDecimal("250.00"),
+                transactionId = UUID.randomUUID(),
+                entryDate = asOf.plusDays(5),
+            )
+            // EUR: entirely effective — must NOT appear in the pipeline at all.
+            projection.applyBookedDelta(
+                journalEntryId = UUID.randomUUID(),
+                accountId = acctEur,
+                currency = "EUR",
+                delta = BigDecimal("200.00"),
+                transactionId = UUID.randomUUID(),
+                entryDate = asOf.minusDays(1),
+            )
+        }
+
+        val pipeline = onEventLoop { balanceRepo.sumFutureValueDatedByCurrency(asOf) }
+        val current = onEventLoop { balanceRepo.sumBookedByCurrency() }
+        val asOfSum = onEventLoop { balanceRepo.sumBookedByCurrencyAsOf(asOf) }
+
+        assertThat(pipeline["CZK"]).isEqualByComparingTo("750.00")
+        // A currency with no future-value-dated movement must be absent, not a spurious zero row.
+        assertThat(pipeline).doesNotContainKey("EUR")
+
+        // The identity the operator-facing explanation rests on: the pipeline is exactly the gap
+        // between the raw materialized total and the value-date-correct tie-out figure.
+        assertThat(current.getValue("CZK").subtract(asOfSum.getValue("CZK"))).isEqualByComparingTo("750.00")
+        assertThat(current.getValue("EUR").subtract(asOfSum.getValue("EUR"))).isEqualByComparingTo("0.00")
+
+        // An asOf beyond every value date leaves nothing in the pipeline — it drains, never accumulates.
+        val drained = onEventLoop { balanceRepo.sumFutureValueDatedByCurrency(asOf.plusDays(10)) }
+        assertThat(drained).isEmpty()
+    }
 }


### PR DESCRIPTION
Closes #1746

## What

ADR-0178 **Phase 3 — control quality**. Phase 1 moved the EoD tie-out onto the ledger's value-date basis, so a future-value-dated journal no longer raises false drift. But the figure it subtracts stayed invisible: the operator saw the corrected sum with no way to tell *why* it differs from the raw materialized booked total.

The reconciliation now publishes that tail per currency, so the report separates **EXPLAINED** movement (posted, value-dated ahead, counted by neither side of the tie-out) from **UNEXPLAINED** drift.

## The slice (mostly plumbing)

1. `BalanceRepository.sumFutureValueDatedByCurrency(asOf)` — the existing per-currency `entry_date > :asOf` query, previously private inside `BalanceRepositoryImpl`, promoted onto the port. `sumBookedByCurrencyAsOf` now calls it through the port method, so there is exactly one implementation of the tail.
2. `CurrencyReconciliation.futureValueDatedPipeline` — attached by `BalanceReconciliationService` and assembled by the pure `ReconciliationPolicy`.
3. `openapi.yaml` `info.version` **1.4.1 → 1.5.0** + contract test.
4. Admin-UI day-end view renders it.

## Published, never subtracted

This is the load-bearing decision, and it is asserted by tests both ways:

- Folding the pipeline into `difference` would **double-count** — both tie-out sides already exclude that tail — and re-create the exact false drift Phase 1 removed.
- *Subtracting* it from a genuine mismatch would let a **real divergence hide** behind an outstanding pipeline.

So `difference` remains unexplained drift *by construction*; that, plus the ADR-0160 sustained-duration `for:` clause, stays the alerting signal. No alerting rule changed — Phase 1 already made the basis correct, and this PR asserts that property rather than adding a new suppression.

## Scope discipline

Read-only reporting. **No money moves, no booking behaviour changes.** `LedgerProjectionService.apply` is untouched and no `effective_booked` column is introduced — that is Phase 2 (#1745), still blocked on the undecided product-semantics call.

No DB migration: the per-currency rows are persisted as JSON, and the new field defaults to `BigDecimal.ZERO`, so runs recorded before it deserialize unchanged. The UI treats it as optional for the same reason.

## Tests

- **Unit** (`BalanceReconciliationServiceTest`) — a purely future-value-dated batch yields **zero** drift while the pipeline is reported; a genuine 10.00 shortfall **still drifts** while a 500.00 pipeline is outstanding. These are the issue's two acceptance criteria.
- **Real-database IT** (`BalanceReconciliationAsOfIT`) — the `entry_date > :asOf` grouping, absence of a spurious zero row for a currency with no future tail, the `sumBookedByCurrencyAsOf = sumBookedByCurrency − pipeline` identity, and that the pipeline **drains** rather than accumulates. A mocked repository cannot prove any of these; it returns whatever it was told.
- **Contract** (`ReconciliationContractTest`) — pins 1.5.0 and pins the field as *optional* (making it required would be a breaking MAJOR).

## API version (ADR-0048)

Additive, optional response property; nothing removed or made required → **MINOR**. Re-checked `info.version` against live `origin/main` immediately before finalizing: **1.4.1**, with no competing open PR touching the balance spec. Took **1.5.0**.

## Gate

`detekt` · `ktlintCheck` · `build` · `koverVerify` · `quarkusBuild` — all green from the worktree root. Coverage floors untouched (ratchet-only). Admin-UI: `tsc --noEmit` clean, `eslint` 0 errors (3 pre-existing warnings on untouched lines).

## Money-path notice

`openbank-balance-service` is in `rules.yaml: money_path_services`, so this PR requires **2 approvals** and carries the ADR-0030 D2 threat-model refresh (`docs/threat-models/openbank-balance-service.md`, with the published-never-subtracted invariant recorded). It is **not self-mergeable** — that is expected and correct, not something to work around.

Refs ADR-0178, ADR-0160, ADR-0048