### PR TITLE
feat(feedback): rendering context and session id on screen feedback (ADR-0192)

### DIFF
--- a/openbank-analytics-sink/src/main/resources/clickhouse/V4__screen_feedback_context.sql
+++ b/openbank-analytics-sink/src/main/resources/clickhouse/V4__screen_feedback_context.sql
@@ -1,0 +1,57 @@
+-- SPDX-License-Identifier: Apache-2.0
+-- Copyright (c) OpenBank contributors. Licensed under the Apache License, Version 2.0.
+-- See LICENSE in the repository root or https://www.apache.org/licenses/LICENSE-2.0 for details.
+--
+-- Screen-feedback rendering context (ADR-0192 completion).
+--
+-- V3 shipped the feedback marts with platform + app_version only. The ADR's payload also names
+-- the OS version, locale, theme and the pseudonymous session id, and the app and edge now send
+-- them. This migration projects those four onto the gold layer.
+--
+-- CREATE OR REPLACE, not a V3 edit: V3's statements are all `CREATE VIEW IF NOT EXISTS`, so
+-- editing that file changes nothing on a database where the views already exist — it would look
+-- applied in git and silently do nothing in ClickHouse.
+--
+-- Backfill note: rows written before this ships have no such keys in `payload`, and
+-- JSONExtractString returns '' for a missing key. Historic rows therefore read as empty strings,
+-- not NULL — the same convention V3 already uses for an absent screenshot_key.
+--
+-- GDPR unchanged: session_id is client-generated and pseudonymous (never an account or device
+-- identifier), and party_id remains the key an erasure request uses to find rows and objects.
+
+CREATE OR REPLACE VIEW openbank_analytics.gold_screen_feedback AS
+SELECT
+    aggregate_id                                        AS reference,
+    occurred_at,
+    toDate(occurred_at)                                 AS day,
+    JSONExtractString(payload, 'partyId')               AS party_id,
+    JSONExtractString(payload, 'screenId')              AS screen_id,
+    JSONExtractString(payload, 'category')              AS category,
+    JSONExtractString(payload, 'comment')               AS comment,
+    JSONExtractString(payload, 'platform')              AS platform,
+    JSONExtractString(payload, 'appVersion')            AS app_version,
+    JSONExtractString(payload, 'osVersion')             AS os_version,
+    JSONExtractString(payload, 'locale')                AS locale,
+    JSONExtractString(payload, 'theme')                 AS theme,
+    JSONExtractString(payload, 'sessionId')             AS session_id,
+    JSONExtractString(payload, 'screenshotKey')         AS screenshot_key,
+    JSONExtractString(payload, 'screenshotStatus')      AS screenshot_status,
+    JSONExtractUInt(payload, 'screenshotBytes')         AS screenshot_bytes
+FROM openbank_analytics.bronze_events
+WHERE aggregate_type = 'SCREEN_FEEDBACK';
+
+-- WHERE IT BREAKS: the same screen can be fine on one OS/theme and broken on another, which is
+-- exactly what platform+app_version alone could not show. Ranks the combinations that generate
+-- bug reports, so a rendering fault gets attributed instead of being averaged away.
+CREATE OR REPLACE VIEW openbank_analytics.gold_screen_feedback_context AS
+SELECT
+    screen_id,
+    platform,
+    os_version,
+    theme,
+    locale,
+    countIf(category = 'BUG')   AS bugs,
+    count()                     AS submissions,
+    max(occurred_at)            AS last_seen
+FROM openbank_analytics.gold_screen_feedback
+GROUP BY screen_id, platform, os_version, theme, locale;

--- a/openbank-customer-edge/src/main/kotlin/com/openbank/customeredge/infrastructure/feedback/FeedbackPublisher.kt
+++ b/openbank-customer-edge/src/main/kotlin/com/openbank/customeredge/infrastructure/feedback/FeedbackPublisher.kt
@@ -36,6 +36,10 @@ data class FeedbackSubmission(
     val comment: String,
     val platform: String?,
     val appVersion: String?,
+    val osVersion: String?,
+    val locale: String?,
+    val theme: String?,
+    val sessionId: String?,
     val screenshotKey: String?,
     val screenshotBytes: Int,
     val screenshotStatus: String,
@@ -101,6 +105,12 @@ class FeedbackPublisher(
             payload.put("comment", submission.comment)
             submission.platform?.let { payload.put("platform", it) }
             submission.appVersion?.let { payload.put("appVersion", it) }
+            // Rendering context + session correlation (ADR-0192). Absent fields stay absent
+            // rather than becoming "", so the warehouse can tell "not reported" from "empty".
+            submission.osVersion?.let { payload.put("osVersion", it) }
+            submission.locale?.let { payload.put("locale", it) }
+            submission.theme?.let { payload.put("theme", it) }
+            submission.sessionId?.let { payload.put("sessionId", it) }
             submission.screenshotKey?.let { payload.put("screenshotKey", it) }
             payload.put("screenshotBytes", submission.screenshotBytes)
             payload.put("screenshotStatus", submission.screenshotStatus)

--- a/openbank-customer-edge/src/main/kotlin/com/openbank/customeredge/infrastructure/rest/FeedbackResource.kt
+++ b/openbank-customer-edge/src/main/kotlin/com/openbank/customeredge/infrastructure/rest/FeedbackResource.kt
@@ -109,6 +109,10 @@ class FeedbackResource(
                 comment = request.comment,
                 platform = request.platform,
                 appVersion = request.appVersion,
+                osVersion = request.context.osVersion,
+                locale = request.context.locale,
+                theme = request.context.theme,
+                sessionId = request.context.sessionId,
                 screenshotKey = stored.key,
                 screenshotBytes = request.screenshot?.size ?: 0,
                 screenshotStatus = stored.status,
@@ -126,7 +130,24 @@ class FeedbackResource(
         val comment: String,
         val platform: String?,
         val appVersion: String?,
+        val context: RenderContext,
         val screenshot: ByteArray?,
+    )
+
+    /**
+     * How the screen looked when the report was filed. The same screen renders differently per OS
+     * version, language and theme, so without these a "this looks wrong" report is not
+     * reproducible. [sessionId] is the app's pseudonymous client session (ADR-0192) and correlates
+     * the report with that session's RUM/trace data — it is never an account or device identifier.
+     *
+     * Grouped rather than inlined: as flat constructor arguments these four push [ValidRequest]
+     * past the parameter-count limit, and they genuinely travel as one unit.
+     */
+    private class RenderContext(
+        val osVersion: String?,
+        val locale: String?,
+        val theme: String?,
+        val sessionId: String?,
     )
 
     private sealed interface Parsed {
@@ -171,6 +192,12 @@ class FeedbackResource(
                 comment = comment,
                 platform = node.text("platform")?.take(MAX_SHORT_FIELD_LEN),
                 appVersion = node.text("appVersion")?.take(MAX_SHORT_FIELD_LEN),
+                context = RenderContext(
+                    osVersion = node.text("osVersion")?.take(MAX_SHORT_FIELD_LEN),
+                    locale = node.text("locale")?.take(MAX_SHORT_FIELD_LEN),
+                    theme = node.text("theme")?.take(MAX_SHORT_FIELD_LEN),
+                    sessionId = node.text("sessionId")?.take(MAX_SHORT_FIELD_LEN),
+                ),
                 screenshot = screenshot,
             ),
         )

--- a/openbank-customer-edge/src/main/resources/openapi.yaml
+++ b/openbank-customer-edge/src/main/resources/openapi.yaml
@@ -3,7 +3,7 @@
 openapi: 3.1.0
 info:
   title: Customer Edge API
-  version: 1.20.0
+  version: 1.21.0
   description: >-
     Customer-facing edge proxy (ADR-0065). Single internet-facing entry point for the
     retail customer app. Validates JWTs from the openbank-customers Keycloak realm,
@@ -1739,6 +1739,29 @@ components:
         appVersion:
           type: string
           maxLength: 32
+        osVersion:
+          type: string
+          maxLength: 32
+          description: Coarse OS release the report was filed on, e.g. `iOS 17.5`, `Android 14`.
+          example: iOS 17.5
+        locale:
+          type: string
+          maxLength: 32
+          description: UI language the screen was rendered in, e.g. `cs`, `en`.
+          example: cs
+        theme:
+          type: string
+          maxLength: 32
+          description: >-
+            Active app theme (ADR-0191), e.g. `green-dark`. The same screen renders differently
+            per theme, so a rendering complaint is not reproducible without it.
+          example: green-dark
+        sessionId:
+          type: string
+          maxLength: 32
+          description: >-
+            Client-generated pseudonymous session id (never PII) — correlates this report with
+            the session's RUM/trace data.
         screenshotPngBase64:
           type: string
           format: byte

--- a/openbank-customer-edge/src/test/kotlin/com/openbank/customeredge/FeedbackPublisherTest.kt
+++ b/openbank-customer-edge/src/test/kotlin/com/openbank/customeredge/FeedbackPublisherTest.kt
@@ -50,10 +50,46 @@ class FeedbackPublisherTest {
         comment = "Confirm button hides behind the keyboard",
         platform = "ios",
         appVersion = "0.4.0",
+        osVersion = "iOS 17.5",
+        locale = "cs",
+        theme = "green-dark",
+        sessionId = "7f3a1c20-9b44-4e51-8c2a-1d6e5f0a9b31",
         screenshotKey = screenshotKey,
         screenshotBytes = 40,
         screenshotStatus = status,
     )
+
+    @Test
+    fun `carries the rendering context and session id into the payload`() {
+        val record = slot<Record<String, String>>()
+        every { emitter.send(capture(record)) } returns CompletableFuture.completedFuture(null)
+
+        publisher().emit(submission())
+
+        val payload = mapper.readTree(record.captured.value())["payload"]
+        assertThat(payload["osVersion"].asText()).isEqualTo("iOS 17.5")
+        assertThat(payload["locale"].asText()).isEqualTo("cs")
+        assertThat(payload["theme"].asText()).isEqualTo("green-dark")
+        assertThat(payload["sessionId"].asText()).isEqualTo("7f3a1c20-9b44-4e51-8c2a-1d6e5f0a9b31")
+    }
+
+    @Test
+    fun `omits context keys entirely when the app did not report them`() {
+        // Absent must stay absent rather than becoming "": the warehouse has to be able to tell
+        // "this client never reported a theme" from "the theme was an empty string".
+        val record = slot<Record<String, String>>()
+        every { emitter.send(capture(record)) } returns CompletableFuture.completedFuture(null)
+
+        publisher().emit(
+            submission().copy(osVersion = null, locale = null, theme = null, sessionId = null),
+        )
+
+        val payload = mapper.readTree(record.captured.value())["payload"]
+        assertThat(payload.has("osVersion")).isFalse()
+        assertThat(payload.has("locale")).isFalse()
+        assertThat(payload.has("theme")).isFalse()
+        assertThat(payload.has("sessionId")).isFalse()
+    }
 
     @Test
     fun `emits the analytics envelope keyed on the reference, carrying the key and not the bytes`() {

--- a/openbank-customer-edge/src/test/kotlin/com/openbank/customeredge/FeedbackSubmissionTest.kt
+++ b/openbank-customer-edge/src/test/kotlin/com/openbank/customeredge/FeedbackSubmissionTest.kt
@@ -65,6 +65,45 @@ class FeedbackSubmissionTest {
     ) = """{"screenId":"$screenId","category":"$category","comment":"$comment"$extra}"""
 
     @Test
+    fun `rendering context is parsed, capped and passed through`() {
+        val extra = ""","osVersion":"iOS 17.5","locale":"cs","theme":"green-dark","sessionId":"sess-1""""
+        val resp = resource().submit(body(extra = extra))
+
+        assertThat(resp.status).isEqualTo(202)
+        val emitted = slot<FeedbackSubmission>()
+        verify(exactly = 1) { publisher.emit(capture(emitted)) }
+        assertThat(emitted.captured.osVersion).isEqualTo("iOS 17.5")
+        assertThat(emitted.captured.locale).isEqualTo("cs")
+        assertThat(emitted.captured.theme).isEqualTo("green-dark")
+        assertThat(emitted.captured.sessionId).isEqualTo("sess-1")
+    }
+
+    @Test
+    fun `oversized context values are truncated, not rejected`() {
+        // A client-side cap is a UX affordance; the server must bound the value itself before it
+        // reaches a 10-year warehouse. Truncating keeps the usable prefix instead of losing the
+        // whole report over a cosmetic field.
+        val extra = ""","theme":"${"t".repeat(200)}""""
+        val resp = resource().submit(body(extra = extra))
+
+        assertThat(resp.status).isEqualTo(202)
+        val emitted = slot<FeedbackSubmission>()
+        verify(exactly = 1) { publisher.emit(capture(emitted)) }
+        assertThat(emitted.captured.theme).hasSize(32)
+    }
+
+    @Test
+    fun `context fields are optional`() {
+        val resp = resource().submit(body())
+
+        assertThat(resp.status).isEqualTo(202)
+        val emitted = slot<FeedbackSubmission>()
+        verify(exactly = 1) { publisher.emit(capture(emitted)) }
+        assertThat(emitted.captured.osVersion).isNull()
+        assertThat(emitted.captured.theme).isNull()
+    }
+
+    @Test
     fun `well-formed text-only feedback is accepted with 202 and emitted once`() {
         val resp = resource().submit(body())
 


### PR DESCRIPTION
Edge half of the ADR-0192 payload gap. The first cut accepted `platform` + `appVersion`; the ADR also names OS version, locale, theme and the pseudonymous session id.

## Edge

`FeedbackResource` parses and caps the four new fields exactly like the existing short ones. `FeedbackPublisher` **omits** an absent field rather than emitting `""` — the warehouse must be able to tell "never reported" from "reported empty".

They travel as a grouped `RenderContext`: as flat constructor arguments they push `ValidRequest` past the parameter-count limit (detekt `LongParameterList`), and they genuinely move as one unit.

OpenAPI documents all four; `info.version` bumped to 1.21.0 (the api-contract check requires it).

## ClickHouse: why V4, not a V3 edit

V3's statements are all `CREATE VIEW IF NOT EXISTS`. Editing that file would look applied in git and **silently do nothing** on a database where the views already exist. V4 uses `CREATE OR REPLACE` and adds `gold_screen_feedback_context`, which ranks the OS/theme/locale combinations that generate bug reports — the thing `platform`+`app_version` alone could not show.

Rows written before this ships have no such keys, and `JSONExtractString` returns `''` for a missing key, so historic rows read as empty strings (V3's existing convention), not NULL.

⚠️ **Deploy step:** migrations here are applied by an operator, not on sink startup. **V4 has to be run manually** or the new columns never appear.

## Verification

`openbank-customer-edge` `Feedback*` suites: 30 tests, 5 new (field pass-through, truncation over the cap, optionality, payload presence, and that absent fields stay absent). ktlint + detekt clean.

Pairs with openbank-app#281.

🤖 Generated with [Claude Code](https://claude.com/claude-code)