### PR TITLE
fix(ledger): run both daily schedulers on a Vert.x context (#2187)

### DIFF
--- a/openbank-ledger-service/src/main/kotlin/com/openbank/ledger/infrastructure/schedule/FxRevaluationScheduler.kt
+++ b/openbank-ledger-service/src/main/kotlin/com/openbank/ledger/infrastructure/schedule/FxRevaluationScheduler.kt
@@ -9,7 +9,6 @@ import com.openbank.ledger.application.port.`in`.RevalueFxCommand
 import com.openbank.libs.persistence.lock.ClusterLock
 import io.quarkus.scheduler.Scheduled
 import jakarta.enterprise.context.ApplicationScoped
-import kotlinx.coroutines.runBlocking
 import org.jboss.logging.Logger
 import java.time.LocalDate
 import java.time.ZoneId
@@ -33,12 +32,24 @@ class FxRevaluationScheduler(private val useCase: FxRevaluationUseCase, private 
     private val log: Logger = Logger.getLogger(FxRevaluationScheduler::class.java)
     private val zone: ZoneId = ZoneId.of("Europe/Prague")
 
+    // `suspend`, never `runBlocking` (#2187, the fleet sweep of #2148). Quarkus invokes a plain
+    // @Scheduled method on a bare `executor-thread`, which carries no Vert.x context, so
+    // `runBlocking { clusterLock.tryRunExclusively(…) }` ran [PostgresClusterLock]'s
+    // `Panache.withTransaction` — the FIRST reactive call, and it sits *outside* the inner
+    // try/catch below — off the event loop and threw `HR000068: This method should exclusively be
+    // invoked from a Vert.x EventLoop thread`. Every tick aborted before `revalue` was ever
+    // reached, so no FX position was ever marked to the fixing. A suspending @Scheduled method is
+    // dispatched by Quarkus on a proper (duplicated) Vert.x context instead.
+    //
+    // The cron is a config expression (same default as before) purely so an IT can shrink it and
+    // drive the *real* scheduler dispatch — calling this method directly supplies a context the
+    // scheduler does not, and would pass against the broken code.
     @Scheduled(
-        cron = "0 0 15 * * ?",
+        cron = "{openbank.ledger.fx-revaluation.cron:0 0 15 * * ?}",
         timeZone = "Europe/Prague",
         concurrentExecution = Scheduled.ConcurrentExecution.SKIP,
     )
-    fun revalueDaily() = runBlocking {
+    suspend fun revalueDaily() {
         val ran = clusterLock.tryRunExclusively(JOB_NAME) {
             try {
                 val result = useCase.revalue(RevalueFxCommand(LocalDate.now(zone)))

--- a/openbank-ledger-service/src/main/kotlin/com/openbank/ledger/infrastructure/schedule/TieOutScheduler.kt
+++ b/openbank-ledger-service/src/main/kotlin/com/openbank/ledger/infrastructure/schedule/TieOutScheduler.kt
@@ -17,7 +17,6 @@ import io.micrometer.core.instrument.Counter
 import io.micrometer.core.instrument.MeterRegistry
 import io.quarkus.scheduler.Scheduled
 import jakarta.enterprise.context.ApplicationScoped
-import kotlinx.coroutines.runBlocking
 import org.eclipse.microprofile.config.inject.ConfigProperty
 import org.jboss.logging.Logger
 import java.time.Clock
@@ -77,12 +76,25 @@ class TieOutScheduler(
         .description("Number of sub-ledger tie-out breaks detected (ADR-0039 Phase B). Non-zero = incident.")
         .register(registry)
 
+    // `suspend`, never `runBlocking` (#2187, the fleet sweep of #2148). Quarkus invokes a plain
+    // @Scheduled method on a bare `executor-thread`, which carries no Vert.x context, so
+    // `runBlocking { clusterLock.tryRunExclusively(…) }` ran [PostgresClusterLock]'s
+    // `Panache.withTransaction` — the FIRST reactive call, and it sits *outside* every try/catch
+    // below — off the event loop and threw `HR000068: This method should exclusively be invoked
+    // from a Vert.x EventLoop thread`. Every daily tick aborted there, so the sub-ledger tie-out
+    // control (ADR-0039 Phase B) never checked a single account and never recorded a run. A
+    // suspending @Scheduled method is dispatched by Quarkus on a proper (duplicated) Vert.x
+    // context instead.
+    //
+    // The cron is a config expression (same default as before) purely so an IT can shrink it and
+    // drive the *real* scheduler dispatch — calling this method directly supplies a context the
+    // scheduler does not, and would pass against the broken code.
     @Scheduled(
-        cron = "0 0 6 * * ?",
+        cron = "{openbank.ledger.tieout.cron:0 0 6 * * ?}",
         timeZone = "Europe/Prague",
         concurrentExecution = Scheduled.ConcurrentExecution.SKIP,
     )
-    fun runTieOut(): Unit = runBlocking {
+    suspend fun runTieOut() {
         val ran = clusterLock.tryRunExclusively(JOB_NAME) {
             // clock.withZone(zone), NOT LocalDate.now(zone): the latter is `Clock.system(zone)` —
             // it silently ignores the injected `clock` and reads the JVM's real wall clock.

--- a/openbank-ledger-service/src/test/kotlin/com/openbank/ledger/infrastructure/schedule/TieOutSchedulerTest.kt
+++ b/openbank-ledger-service/src/test/kotlin/com/openbank/ledger/infrastructure/schedule/TieOutSchedulerTest.kt
@@ -19,6 +19,7 @@ import io.mockk.coEvery
 import io.mockk.coVerify
 import io.mockk.mockk
 import io.mockk.slot
+import kotlinx.coroutines.runBlocking
 import org.assertj.core.api.Assertions.assertThat
 import org.junit.jupiter.api.Test
 import java.math.BigDecimal
@@ -88,7 +89,7 @@ class TieOutSchedulerTest {
         val saved = slot<TieOutRunRecord>()
         coEvery { runs.save(capture(saved)) } answers { saved.captured }
 
-        scheduler.runTieOut()
+        runBlocking { scheduler.runTieOut() }
 
         assertThat(saved.captured.status).isEqualTo(TieOutRunStatus.OK)
         assertThat(saved.captured.accountsChecked).isEqualTo(1)
@@ -107,7 +108,7 @@ class TieOutSchedulerTest {
         val saved = slot<TieOutRunRecord>()
         coEvery { runs.save(capture(saved)) } answers { saved.captured }
 
-        scheduler.runTieOut()
+        runBlocking { scheduler.runTieOut() }
 
         assertThat(saved.captured.status).isEqualTo(TieOutRunStatus.BREAK)
         assertThat(saved.captured.breaks).isEqualTo(1)
@@ -124,7 +125,7 @@ class TieOutSchedulerTest {
         val saved = slot<TieOutRunRecord>()
         coEvery { runs.save(capture(saved)) } answers { saved.captured }
 
-        scheduler.runTieOut()
+        runBlocking { scheduler.runTieOut() }
 
         assertThat(saved.captured.status).isEqualTo(TieOutRunStatus.ERROR)
         assertThat(saved.captured.errors).isEqualTo(1)
@@ -146,7 +147,7 @@ class TieOutSchedulerTest {
         val saved = slot<TieOutRunRecord>()
         coEvery { runs.save(capture(saved)) } answers { saved.captured }
 
-        scheduler.runTieOut()
+        runBlocking { scheduler.runTieOut() }
 
         assertThat(saved.captured.status).isEqualTo(TieOutRunStatus.BREAK)
         assertThat(saved.captured.breaks).isEqualTo(1)
@@ -162,7 +163,7 @@ class TieOutSchedulerTest {
         coEvery { ledger.getControlAccountTieOut(any()) } returns listOf(tieOut(account.id, BigDecimal.ZERO))
         coEvery { runs.save(any()) } throws IllegalStateException("insert failed")
 
-        scheduler.runTieOut() // must not throw
+        runBlocking { scheduler.runTieOut() } // must not throw
 
         coVerify(exactly = 1) { runs.save(any()) }
     }
@@ -185,7 +186,7 @@ class TieOutSchedulerTest {
             record
         }
 
-        scheduler.runTieOut()
+        runBlocking { scheduler.runTieOut() }
 
         assertThat(savedDates).containsExactly(
             LocalDate.of(2026, 7, 13),
@@ -212,7 +213,7 @@ class TieOutSchedulerTest {
             record
         }
 
-        capped.runTieOut()
+        runBlocking { capped.runTieOut() }
 
         assertThat(savedDates).containsExactly(LocalDate.of(2026, 7, 11), LocalDate.of(2026, 7, 12))
     }
@@ -221,7 +222,7 @@ class TieOutSchedulerTest {
     fun `does nothing when already caught up through yesterday`() {
         coEvery { runs.findLatest() } returns runRecord(LocalDate.of(2026, 7, 15)) // == through
 
-        scheduler.runTieOut()
+        runBlocking { scheduler.runTieOut() }
 
         coVerify(exactly = 0) { runs.save(any()) }
         coVerify(exactly = 0) { glAccounts.findByCode(any()) }

--- a/openbank-ledger-service/src/test/kotlin/com/openbank/ledger/integration/LedgerSchedulerVertxContextIT.kt
+++ b/openbank-ledger-service/src/test/kotlin/com/openbank/ledger/integration/LedgerSchedulerVertxContextIT.kt
@@ -1,0 +1,137 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright (c) OpenBank contributors. Licensed under the Apache License, Version 2.0.
+// See LICENSE in the repository root or https://www.apache.org/licenses/LICENSE-2.0 for details.
+package com.openbank.ledger.integration
+
+import com.openbank.ledger.application.port.`in`.FxRevaluationResult
+import com.openbank.ledger.application.port.`in`.FxRevaluationUseCase
+import com.openbank.ledger.application.port.`in`.RevalueFxCommand
+import com.openbank.ledger.application.port.out.TieOutRunRepository
+import com.openbank.ledger.it.PostgresTestResource
+import io.quarkus.test.common.QuarkusTestResource
+import io.quarkus.test.junit.QuarkusTest
+import io.quarkus.test.junit.QuarkusTestProfile
+import io.quarkus.test.junit.TestProfile
+import io.quarkus.vertx.VertxContextSupport
+import io.smallrye.mutiny.coroutines.uni
+import jakarta.enterprise.context.ApplicationScoped
+import jakarta.enterprise.inject.Alternative
+import jakarta.inject.Inject
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.Dispatchers
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.Test
+import java.util.concurrent.atomic.AtomicInteger
+
+/**
+ * Regression coverage for #2187 (the fleet sweep of #2148) — both of ledger-service's daily
+ * `@Scheduled` jobs silently did nothing on every single tick.
+ *
+ * [com.openbank.ledger.infrastructure.schedule.TieOutScheduler.runTieOut] and
+ * [com.openbank.ledger.infrastructure.schedule.FxRevaluationScheduler.revalueDaily] were plain
+ * (non-`suspend`) methods whose bodies were `runBlocking { … }`. Quarkus invokes such a method on a
+ * bare `executor-thread`, which carries **no Vert.x context**, so the first reactive call — in both
+ * cases `PostgresClusterLock`'s `Panache.withTransaction`, which sits *outside* every try/catch in
+ * either scheduler — threw `HR000068: This method should exclusively be invoked from a Vert.x
+ * EventLoop thread` and aborted the whole tick. The sub-ledger tie-out control (ADR-0039 Phase B)
+ * had therefore never recorded a run, and no FX position had ever been marked to the ČNB fixing.
+ *
+ * **Why this test drives the cron and not the methods directly.** The defect is in *how the
+ * framework invokes the method*, not in the method body: calling `runTieOut()` from a test supplies
+ * a Vert.x context the real scheduler does not, so such a test passes against the broken code and
+ * proves nothing. The profile below shrinks both crons to every two seconds against a real Postgres
+ * and the test waits for a genuinely scheduler-dispatched run to leave its mark.
+ */
+@QuarkusTest
+@QuarkusTestResource(PostgresTestResource::class)
+@TestProfile(LedgerSchedulerVertxContextIT.FastSchedulerProfile::class)
+class LedgerSchedulerVertxContextIT {
+
+    /**
+     * Fires both daily jobs every two seconds instead of at 06:00 / 15:00, and keeps the outbox
+     * dispatcher off so a dispatched event cannot be re-consumed in this same JVM while the
+     * assertions run.
+     *
+     * [RecordingFxRevaluationUseCase] is enabled only for this profile: the real
+     * `FxRevaluationService` reaches out to fx-service for the ČNB fixing, which is not available
+     * here — and it would be the wrong thing to assert anyway. What is under test is whether the
+     * scheduler reaches its use case *at all*, which it did not.
+     */
+    class FastSchedulerProfile : QuarkusTestProfile {
+        override fun getConfigOverrides(): Map<String, String> = mapOf(
+            // `%test.quarkus.scheduler.enabled` is `false` for this whole service (application.yaml)
+            // — which is precisely why no ledger test could ever have caught #2187: with the
+            // scheduler off, the only thing any test exercises is a direct call, and a direct call
+            // supplies the Vert.x context the scheduler does not. This IT is the one place it is
+            // deliberately switched back on.
+            "quarkus.scheduler.enabled" to "true",
+            "openbank.ledger.tieout.cron" to "*/2 * * * * ?",
+            "openbank.ledger.fx-revaluation.cron" to "*/2 * * * * ?",
+            "openbank.outbox.dispatch-enabled" to "false",
+        )
+
+        override fun getEnabledAlternatives(): MutableSet<Class<*>> =
+            mutableSetOf(RecordingFxRevaluationUseCase::class.java)
+    }
+
+    /** Records that the scheduler actually got as far as calling the use case. */
+    @Alternative
+    @ApplicationScoped
+    class RecordingFxRevaluationUseCase : FxRevaluationUseCase {
+        override suspend fun revalue(command: RevalueFxCommand): FxRevaluationResult {
+            invocations.incrementAndGet()
+            return FxRevaluationResult(command.date, posted = false, journalId = null, movements = emptyMap())
+        }
+
+        companion object {
+            val invocations = AtomicInteger(0)
+        }
+    }
+
+    @Inject
+    lateinit var tieOutRuns: TieOutRunRepository
+
+    private fun <T> onEventLoop(block: suspend () -> T): T =
+        VertxContextSupport.subscribeAndAwait { uni(CoroutineScope(Dispatchers.Unconfined)) { block() } }
+
+    /** Polls [ready] until it holds, or the budget runs out. */
+    private fun await(ready: () -> Boolean): Boolean {
+        val deadline = System.nanoTime() + BUDGET_NANOS
+        while (System.nanoTime() < deadline) {
+            if (ready()) return true
+            Thread.sleep(POLL_INTERVAL_MILLIS)
+        }
+        return ready()
+    }
+
+    @Test
+    fun `the scheduled sub-ledger tie-out records a run`() {
+        val recorded = await { onEventLoop { tieOutRuns.findLatest() } != null }
+
+        assertThat(recorded)
+            .describedAs(
+                "a scheduler-dispatched tie-out must record a run — never recording one means the " +
+                    "sweep threw HR000068 off the Vert.x context before the first query (#2187)",
+            )
+            .isTrue()
+    }
+
+    @Test
+    fun `the scheduled FX revaluation reaches its use case`() {
+        val reached = await { RecordingFxRevaluationUseCase.invocations.get() > 0 }
+
+        assertThat(reached)
+            .describedAs(
+                "a scheduler-dispatched FX revaluation must reach the use case — the cluster lock " +
+                    "it acquires first is a reactive Panache transaction, and off the Vert.x " +
+                    "context it threw HR000068 before `revalue` was ever called (#2187)",
+            )
+            .isTrue()
+    }
+
+    private companion object {
+        /** Generous vs the 2 s cron so a slow CI runner cannot flake the wait. */
+        const val BUDGET_NANOS = 60_000_000_000L
+        const val POLL_INTERVAL_MILLIS = 250L
+    }
+}


### PR DESCRIPTION
## Summary

Neither of ledger-service's two daily `@Scheduled` jobs has ever done anything. `TieOutScheduler.runTieOut()` and `FxRevaluationScheduler.revalueDaily()` were plain (non-`suspend`) methods whose bodies were `runBlocking { … }`. Quarkus invokes such a method on a bare `executor-thread`, which carries **no Vert.x context**, so the first reactive call — in both cases `PostgresClusterLock`'s `Panache.withTransaction`, which sits *outside* every `try/catch` in either scheduler — threw `HR000068: This method should exclusively be invoked from a Vert.x EventLoop thread` and aborted the whole tick.

This is the exact defect class fixed for standing-order in #2180, swept fleet-wide in #2187.

**Consequence:** the ADR-0039 Phase B sub-ledger tie-out control never checked a single account and never recorded a `tie_out_run` row — so `TieOutFreshnessWatchdog` had nothing to escalate from either, and the control that the balance-reconciliation work (#856) leans on has been vacuously green. And no FX position was ever marked to the ČNB fixing.

## Type of change

- [x] fix (bug fix)

## Linked issues

Refs #2187, #2148

## Changes

- `TieOutScheduler.runTieOut()` and `FxRevaluationScheduler.revalueDaily()` are now **`suspend fun`**, `runBlocking` (and its import) removed. That is the unanimous fleet convention (#2180 documents why it beats `VertxContextSupport.subscribeAndAwait`), and the reason every outbox dispatcher in this same service has always worked.
- Both crons become config expressions with the **identical** defaults (`{openbank.ledger.tieout.cron:0 0 6 * * ?}`, `{openbank.ledger.fx-revaluation.cron:0 0 15 * * ?}`) — zero behaviour change, but an IT can now shrink them. Same `{prop:default}` form already used by `openbank.ledger.tieout.freshness-cron` next door.
- New `LedgerSchedulerVertxContextIT` — real-DB (Testcontainers Postgres) IT that drives the **actual cron**.
- `TieOutSchedulerTest`'s direct calls wrapped in `runBlocking` (the method is now suspending).

## Why the test drives the cron instead of calling the methods

The defect is in **how the framework invokes the method**, not in the method body: calling `runTieOut()` from a test supplies a Vert.x context the real scheduler does not, so such a test passes against the broken code and proves nothing.

The IT also has to set `quarkus.scheduler.enabled=true`, because `application.yaml` pins it to `false` under `%test` for this whole service. **That pin is exactly why no ledger test could ever have caught this** — with the scheduler off, the only thing any test ever exercises is a direct call.

`FxRevaluationUseCase` is stubbed by a profile-scoped `@Alternative` (the real one calls out to fx-service for the fixing, which is unavailable here — and is not what is under test). What is asserted is that the scheduler reaches its use case *at all*, which it did not.

## Revert-proof (both directions run locally)

- the two `suspend` keywords reverted to `fun … = runBlocking { … }` → IT **FAILS**: 0 tie-out runs recorded and 0 use-case invocations after the 60 s budget, with `HR000068 … executor-thread-N` in the log (734 occurrences).
- fix restored → IT **PASSES**: a `tie_out_run` row is written and the FX use case is invoked.

## Gate

`:openbank-ledger-service:detekt :ktlintCheck :koverVerify :build :quarkusBuild` all green locally.

money-path service ⇒ 2 approvals. No new threat surface (`docs/threat-models/openbank-ledger-service.md` untouched): this restores a control that was silently inert, it does not add one.