### PR TITLE
fix(fx): run the daily ČNB fixing ingestion on a Vert.x context (#2187)

### DIFF
--- a/openbank-fx-service/src/main/kotlin/com/openbank/fx/infrastructure/schedule/CnbRateIngestionScheduler.kt
+++ b/openbank-fx-service/src/main/kotlin/com/openbank/fx/infrastructure/schedule/CnbRateIngestionScheduler.kt
@@ -9,7 +9,6 @@ import com.openbank.fx.application.port.`in`.IngestCnbFixingCommand
 import io.quarkus.scheduler.Scheduled
 import jakarta.enterprise.context.ApplicationScoped
 import org.jboss.logging.Logger
-import kotlinx.coroutines.runBlocking
 
 /**
  * Daily job that ingests the ČNB central-bank fixing shortly after its ~14:30 Europe/Prague
@@ -18,22 +17,36 @@ import kotlinx.coroutines.runBlocking
  * manual `POST /api/v1/fx/cnb/ingest` endpoint covers backfill.
  */
 @ApplicationScoped
-class CnbRateIngestionScheduler(
-    private val useCase: CnbRateIngestionUseCase
-) {
+class CnbRateIngestionScheduler(private val useCase: CnbRateIngestionUseCase) {
     private val log = Logger.getLogger(CnbRateIngestionScheduler::class.java)
 
+    // `suspend`, never `runBlocking` (#2187, the fleet sweep of #2148). Quarkus invokes a plain
+    // @Scheduled method on a bare `executor-thread`, which carries no Vert.x context, so
+    // `runBlocking { useCase.ingest(…) }` ran the first reactive Panache query inside
+    // (`FxRateRepository.findBySourceAndValidFrom`, via `sf.withSession`) off the event loop and
+    // threw `HR000068: This method should exclusively be invoked from a Vert.x EventLoop thread`.
+    // The catch below then swallowed it into a single ERROR line, so the daily ČNB fixing was
+    // never once ingested and nothing else showed it. A suspending @Scheduled method is dispatched
+    // by Quarkus on a proper (duplicated) Vert.x context instead.
+    //
+    // The cron is a config expression (same default as before) purely so an IT can shrink it and
+    // drive the *real* scheduler dispatch — calling this method directly supplies a context the
+    // scheduler does not, and would pass against the broken code.
     @Scheduled(
-        cron = "0 40 14 * * ?",
+        cron = "{openbank.cnb.ingestion-cron:0 40 14 * * ?}",
         timeZone = "Europe/Prague",
-        concurrentExecution = Scheduled.ConcurrentExecution.SKIP
+        concurrentExecution = Scheduled.ConcurrentExecution.SKIP,
     )
-    fun ingestDailyFixing() = runBlocking {
+    suspend fun ingestDailyFixing() {
         try {
             val result = useCase.ingest(IngestCnbFixingCommand(date = null))
             log.infof(
                 "ČNB fixing ingested for %s (#%s): %d new, %d unchanged %s",
-                result.date, result.sequence, result.ingested, result.skipped, result.currencies
+                result.date,
+                result.sequence,
+                result.ingested,
+                result.skipped,
+                result.currencies,
             )
         } catch (ex: Exception) {
             log.errorf(ex, "ČNB fixing ingestion failed: %s", ex.message)

--- a/openbank-fx-service/src/test/kotlin/com/openbank/fx/infrastructure/schedule/CnbRateIngestionSchedulerTest.kt
+++ b/openbank-fx-service/src/test/kotlin/com/openbank/fx/infrastructure/schedule/CnbRateIngestionSchedulerTest.kt
@@ -10,6 +10,7 @@ import com.openbank.fx.application.port.`in`.IngestCnbFixingCommand
 import io.mockk.coEvery
 import io.mockk.coVerify
 import io.mockk.mockk
+import kotlinx.coroutines.runBlocking
 import org.junit.jupiter.api.Test
 import java.time.LocalDate
 
@@ -23,7 +24,7 @@ class CnbRateIngestionSchedulerTest {
         coEvery { useCase.ingest(IngestCnbFixingCommand(date = null)) } returns
             CnbIngestionResult(LocalDate.of(2026, 5, 30), 104, 3, 0, listOf("EUR", "USD", "GBP"))
 
-        scheduler.ingestDailyFixing()
+        runBlocking { scheduler.ingestDailyFixing() }
 
         coVerify(exactly = 1) { useCase.ingest(IngestCnbFixingCommand(date = null)) }
     }
@@ -33,7 +34,7 @@ class CnbRateIngestionSchedulerTest {
         coEvery { useCase.ingest(any()) } throws RuntimeException("ČNB feed unreachable")
 
         // Must not throw — the scheduler must never crash the Quarkus scheduler thread.
-        scheduler.ingestDailyFixing()
+        runBlocking { scheduler.ingestDailyFixing() }
 
         coVerify(exactly = 1) { useCase.ingest(any()) }
     }

--- a/openbank-fx-service/src/test/kotlin/com/openbank/fx/integration/CnbIngestionSchedulerVertxContextIT.kt
+++ b/openbank-fx-service/src/test/kotlin/com/openbank/fx/integration/CnbIngestionSchedulerVertxContextIT.kt
@@ -1,0 +1,134 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright (c) OpenBank contributors. Licensed under the Apache License, Version 2.0.
+// See LICENSE in the repository root or https://www.apache.org/licenses/LICENSE-2.0 for details.
+package com.openbank.fx.integration
+
+import com.openbank.fx.application.port.out.CnbRateProvider
+import com.openbank.fx.application.port.out.FxRateRepository
+import com.openbank.fx.domain.model.RateSource
+import com.openbank.fx.it.PostgresRedisTestResource
+import io.quarkus.test.common.QuarkusTestResource
+import io.quarkus.test.junit.QuarkusTest
+import io.quarkus.test.junit.QuarkusTestProfile
+import io.quarkus.test.junit.TestProfile
+import io.quarkus.vertx.VertxContextSupport
+import io.smallrye.mutiny.coroutines.uni
+import jakarta.enterprise.context.ApplicationScoped
+import jakarta.enterprise.inject.Alternative
+import jakarta.inject.Inject
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.Dispatchers
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.Test
+import java.math.BigDecimal
+import java.time.Instant
+import java.time.LocalDate
+import java.time.ZoneId
+
+/**
+ * Regression coverage for #2187 (the fleet sweep of #2148) — the daily ČNB fixing ingestion had
+ * never ingested a single rate.
+ *
+ * [com.openbank.fx.infrastructure.schedule.CnbRateIngestionScheduler.ingestDailyFixing] was a plain
+ * (non-`suspend`) method whose body was `runBlocking { … }`. Quarkus invokes such a method on a bare
+ * `executor-thread`, which carries **no Vert.x context**, so the first reactive Panache query inside
+ * (`FxRateRepository.findBySourceAndValidFrom`, via `sf.withSession`) threw
+ * `HR000068: This method should exclusively be invoked from a Vert.x EventLoop thread`. The
+ * scheduler's own `catch` then swallowed it into one ERROR line, so the statutory ADR-0046 fixing
+ * was silently never ingested — and the ledger FX revaluation that consumes it (fixed in the same
+ * sweep) had nothing to read even once its own scheduler worked.
+ *
+ * **Why this test drives the cron and not `ingestDailyFixing()`.** The defect is in *how the
+ * framework invokes the method*, not in the method body: calling it directly from a test supplies a
+ * Vert.x context the real scheduler does not, so `CnbRateIngestionSchedulerTest` (mocked use case,
+ * direct call) passed against the broken code the whole time. The profile below shrinks the cron to
+ * every two seconds and stubs only the external ČNB feed, so everything from the scheduler
+ * dispatch through to the real Postgres write is exercised for real.
+ */
+@QuarkusTest
+@QuarkusTestResource(PostgresRedisTestResource::class)
+@TestProfile(CnbIngestionSchedulerVertxContextIT.FastIngestionProfile::class)
+class CnbIngestionSchedulerVertxContextIT {
+
+    /**
+     * Fires the ingestion every two seconds instead of at 14:40 Prague, narrows the ingested set to
+     * one currency, and swaps the external ČNB HTTP feed for [StubCnbRateProvider] — the feed is
+     * the one thing that genuinely cannot run here, and it is not what is under test. The outbox
+     * dispatcher is pinned off so its own tick cannot interfere with the assertions.
+     */
+    class FastIngestionProfile : QuarkusTestProfile {
+        override fun getConfigOverrides(): Map<String, String> = mapOf(
+            "quarkus.scheduler.enabled" to "true",
+            "openbank.cnb.ingestion-cron" to "*/2 * * * * ?",
+            "openbank.cnb.currencies" to CURRENCY,
+            "openbank.outbox.dispatch-enabled" to "false",
+        )
+
+        override fun getEnabledAlternatives(): MutableSet<Class<*>> = mutableSetOf(StubCnbRateProvider::class.java)
+    }
+
+    /** Serves one deterministic fixing instead of calling cnb.cz. */
+    @Alternative
+    @ApplicationScoped
+    class StubCnbRateProvider : CnbRateProvider {
+        override suspend fun fetchFixing(date: LocalDate?): String =
+            """
+            30.05.2026 #104
+            země|měna|množství|kód|kurz
+            EMU|euro|1|$CURRENCY|$RATE_TEXT
+            """.trimIndent()
+    }
+
+    @Inject
+    lateinit var rates: FxRateRepository
+
+    private fun <T> onEventLoop(block: suspend () -> T): T =
+        VertxContextSupport.subscribeAndAwait { uni(CoroutineScope(Dispatchers.Unconfined)) { block() } }
+
+    /**
+     * Looked up by its exact `validFrom` rather than via `findLatestBySource`, whose `validTo > now`
+     * filter would hide this deliberately fixed (and by now expired) fixing date — and by the same
+     * token this cannot match a row any other IT left behind.
+     */
+    private fun ingestedFixing() =
+        onEventLoop { rates.findBySourceAndValidFrom(CURRENCY, QUOTE, RateSource.CNB, VALID_FROM) }
+
+    @Test
+    fun `the scheduled CNB ingestion persists the fixing`() {
+        val deadline = System.nanoTime() + BUDGET_NANOS
+        var ingested = ingestedFixing()
+        while (ingested == null && System.nanoTime() < deadline) {
+            Thread.sleep(POLL_INTERVAL_MILLIS)
+            ingested = ingestedFixing()
+        }
+
+        assertThat(ingested)
+            .describedAs(
+                "a scheduler-dispatched ingestion must persist the fixing — nothing persisted means " +
+                    "the run threw HR000068 off the Vert.x context on its first query and the " +
+                    "scheduler's catch swallowed it (#2187)",
+            )
+            .isNotNull
+        // A mid rate carries no bank spread (ADR-0046), so bid == ask == the published rate.
+        assertThat(ingested!!.bidRate).isEqualByComparingTo(BigDecimal(RATE))
+        assertThat(ingested.askRate).isEqualByComparingTo(BigDecimal(RATE))
+    }
+
+    private companion object {
+        const val CURRENCY = "EUR"
+        const val QUOTE = "CZK"
+
+        /** The feed writes rates with a decimal comma; the parser is what turns it into [RATE]. */
+        const val RATE_TEXT = "25,145"
+        const val RATE = "25.145"
+
+        /** Matches the header of the stub feed above; the fixing is valid from its own Prague day. */
+        val VALID_FROM: Instant = LocalDate.of(2026, 5, 30)
+            .atStartOfDay(ZoneId.of("Europe/Prague"))
+            .toInstant()
+
+        /** Generous vs the 2 s cron so a slow CI runner cannot flake the wait. */
+        const val BUDGET_NANOS = 60_000_000_000L
+        const val POLL_INTERVAL_MILLIS = 250L
+    }
+}


### PR DESCRIPTION
## Summary

`CnbRateIngestionScheduler.ingestDailyFixing()` was a plain (non-`suspend`) `@Scheduled` method whose body was `runBlocking { … }`. Quarkus invokes such a method on a bare `executor-thread`, which carries **no Vert.x context**, so the first reactive Panache query inside (`FxRateRepository.findBySourceAndValidFrom`, via `sf.withSession`) threw `HR000068: This method should exclusively be invoked from a Vert.x EventLoop thread`.

The scheduler's own `catch` then swallowed it into a single ERROR line, so the statutory ADR-0046 ČNB fixing was **never once ingested** and nothing else surfaced it. Same defect class as #2148/#2180, swept fleet-wide in #2187 — and it compounds with the ledger half of that sweep (#2190): the ledger FX revaluation reads exactly the rates this job was never writing.

## Type of change

- [x] fix (bug fix)

## Linked issues

Refs #2187, #2148

## Changes

- `ingestDailyFixing()` is now a **`suspend fun`**, `runBlocking` (and its import) removed. That is the unanimous fleet convention; #2180 documents why it beats `VertxContextSupport.subscribeAndAwait`.
- The cron becomes a config expression with the **identical** default (`{openbank.cnb.ingestion-cron:0 40 14 * * ?}`) — zero behaviour change, but an IT can now shrink it.
- New `CnbIngestionSchedulerVertxContextIT`, a real-DB (Testcontainers Postgres) IT that drives the **actual cron**.
- `CnbRateIngestionSchedulerTest`'s direct calls wrapped in `runBlocking` (the method is now suspending).
- `ktlintFormat` on the one touched main file collapses its (pre-existing) class-signature / trailing-comma / argument-wrapping violations, which path-scoped CI only surfaces once the file is touched. No other file reformatted.

## Why the test drives the cron instead of calling the method

The defect is in **how the framework invokes the method**, not in the method body: a direct call supplies the Vert.x context the real scheduler does not. That is precisely why the existing `CnbRateIngestionSchedulerTest` — mocked use case, direct call — passed against the broken code the whole time.

The IT stubs only `CnbRateProvider` (the external cnb.cz HTTP feed, the one thing that genuinely cannot run in a test, and not what is under test) via a profile-scoped `@Alternative`. Everything from the scheduler dispatch through the parser to the real Postgres write runs for real. It asserts on the row by its exact `validFrom` rather than `findLatestBySource`, whose `validTo > now` filter would hide a deliberately fixed fixing date — and which by the same token makes the assertion immune to rows any other IT leaves behind.

## Revert-proof (both directions run locally)

- `suspend` reverted to `fun ingestDailyFixing() = runBlocking { … }` → IT **FAILS**: nothing persisted after the 60 s budget, 121 × `HR000068 … executor-thread-N` in the log.
- fix restored → IT **PASSES**: the fixing row is persisted with `bid == ask == 25.145`.

## Gate

`:openbank-fx-service:detekt :ktlintCheck :koverVerify :build :quarkusBuild` all green locally.

money-path service ⇒ 2 approvals. No new threat surface (`docs/threat-models/openbank-fx-service.md` untouched): this restores an ingestion that was silently inert, it does not add one.