### PR TITLE
ci: gate on runBlocking inside a @Scheduled method body (#2187)

### DIFF
--- a/.github/scripts/check-no-runblocking-in-scheduled.py
+++ b/.github/scripts/check-no-runblocking-in-scheduled.py
@@ -1,0 +1,213 @@
+#!/usr/bin/env python3
+"""Guard: no `runBlocking` in the body of a `@Scheduled` method (rules.yaml: scheduled_methods).
+
+WHY THIS EXISTS: Quarkus invokes a plain (non-`suspend`) `@Scheduled` method on a bare
+`executor-thread`, which carries **no Vert.x context**. So a body of `runBlocking { … }` runs
+the coroutine on that thread, and the first reactive Hibernate-Reactive / Panache call inside
+throws:
+
+    HR000068: This method should exclusively be invoked from a Vert.x EventLoop thread;
+    currently running on thread 'executor-thread-1'
+
+The job then aborts having done nothing — and every one of these failed *silently*, because the
+throw happens before whatever per-item try/catch the job has (or is swallowed by the job's own
+outer catch into a single ERROR line nobody reads).
+
+This is not hypothetical. #2148 found `StandingOrderExecutionScheduler.sweep()` in this shape:
+no due standing order had **ever** executed. The #2187 fleet sweep then found the same shape in
+four more schedulers, three of them money-path — the daily sub-ledger tie-out control and the
+daily FX revaluation (both ledger-service, #2190), the statutory ČNB fixing ingestion
+(fx-service, #2191) and the monthly billing cycle (#2194). None had ever run.
+
+Every one of them had tests. None could see it: a test that calls the method *directly* supplies
+a Vert.x context the scheduler does not, so it passes against the broken code. That is what makes
+this a guard rather than a lesson in a doc — the natural test does not fail.
+
+THE FIX is always the same: make the method a `suspend fun`. Quarkus dispatches a suspending
+`@Scheduled` method on a proper (duplicated) Vert.x context. That is the unanimous fleet
+convention — every other reactive `@Scheduled` method in the monorepo is either `suspend` or
+returns `Uni`. Prefer it over `VertxContextSupport.subscribeAndAwait`, which merely swaps one
+blocking bridge for another, pins the scheduler worker for the whole run, and *throws* if ever
+called from an event-loop thread (so it breaks the day the method gains `@NonBlocking` or a
+virtual thread).
+
+WHAT IT CHECKS: every `openbank-*/src/main/kotlin/**.kt`. For each `@Scheduled` annotation it
+locates the annotated method, brace-matches its body, and flags `runBlocking` inside it — in
+code, never in comments. A genuine exception (a service with no reactive persistence on its
+classpath at all, where `runBlocking` is a deliberate bridge for *blocking* clients) must be
+listed in `rules.yaml: scheduled_methods.runblocking_allowlist` with a one-line reason, the same
+individually-justified-exception idiom as the ktlint/detekt baselines and
+`event_consumer_liveness.allowlist`.
+
+ENFORCED: findings are ::error:: annotations and exit 1.
+
+stdlib + PyYAML (already installed earlier in the same CI job, matching
+check-event-consumer-liveness.py).
+Usage: check-no-runblocking-in-scheduled.py [--root .] [--rules openbank-libs/governance/rules.yaml]
+"""
+from __future__ import annotations
+
+import argparse
+import pathlib
+import re
+import sys
+
+import yaml
+
+SCHEDULED_RE = re.compile(r"^\s*@Scheduled\b")
+FUN_RE = re.compile(r"\bfun\s+`?(\w+)`?\s*\(")
+RUNBLOCKING_RE = re.compile(r"\brunBlocking\b")
+
+
+def strip_comments(lines: list[str]) -> list[str]:
+    """Blanks out `//` line comments and `/* … */` blocks, keeping line numbering intact.
+
+    Needed in both directions: a fix comment explaining *why* the method must never use
+    `runBlocking` (every one of the #2187 fixes carries one) must not itself trip the guard, and
+    a real violation must not be hideable by trailing a comment marker.
+    """
+    out: list[str] = []
+    in_block = False
+    for line in lines:
+        buf = []
+        i = 0
+        while i < len(line):
+            two = line[i:i + 2]
+            if in_block:
+                if two == "*/":
+                    in_block = False
+                    i += 2
+                    continue
+                i += 1
+                continue
+            if two == "/*":
+                in_block = True
+                i += 2
+                continue
+            if two == "//":
+                break
+            buf.append(line[i])
+            i += 1
+        out.append("".join(buf))
+    return out
+
+
+def scheduled_method_bodies(lines: list[str]) -> list[tuple[str, int, int, int]]:
+    """Every `@Scheduled` method in a file as (name, decl_line, body_start, body_end), 0-based.
+
+    Walks from each `@Scheduled` to the `fun` that follows it (past any further annotations or a
+    wrapped argument list), then brace-matches the body. An expression body (`= runBlocking { … }`)
+    is matched the same way — the guard only cares which lines belong to the method.
+    """
+    found: list[tuple[str, int, int, int]] = []
+    for idx, line in enumerate(lines):
+        if not SCHEDULED_RE.match(line):
+            continue
+        decl = next(
+            (j for j in range(idx, min(idx + 40, len(lines))) if FUN_RE.search(lines[j])),
+            None,
+        )
+        if decl is None:
+            continue
+        name = FUN_RE.search(lines[decl]).group(1)
+
+        # The body opens at the first `{` after the parameter list closes. Tracking paren depth
+        # keeps a default-argument lambda or a wrapped signature from being mistaken for it.
+        depth_paren = 0
+        start = None
+        for j in range(decl, len(lines)):
+            for ch in lines[j]:
+                if ch == "(":
+                    depth_paren += 1
+                elif ch == ")":
+                    depth_paren -= 1
+                elif ch == "{" and depth_paren <= 0:
+                    start = j
+                    break
+            if start is not None:
+                break
+        if start is None:
+            continue
+
+        depth = 0
+        end = None
+        for j in range(start, len(lines)):
+            depth += lines[j].count("{") - lines[j].count("}")
+            if depth <= 0:
+                end = j
+                break
+        found.append((name, decl, start, end if end is not None else len(lines) - 1))
+    return found
+
+
+def load_allowlist(rules_path: pathlib.Path) -> dict[str, str]:
+    """`rules.yaml: scheduled_methods.runblocking_allowlist` as {"<path>#<method>": reason}."""
+    data = yaml.safe_load(rules_path.read_text(encoding="utf-8")) or {}
+    entries = (data.get("scheduled_methods") or {}).get("runblocking_allowlist") or []
+    allow: dict[str, str] = {}
+    for entry in entries:
+        if isinstance(entry, dict) and "method" in entry:
+            allow[str(entry["method"])] = str(entry.get("reason", ""))
+    return allow
+
+
+def main() -> int:
+    ap = argparse.ArgumentParser()
+    ap.add_argument("--root", default=".")
+    ap.add_argument("--rules", default="openbank-libs/governance/rules.yaml")
+    args = ap.parse_args()
+
+    root = pathlib.Path(args.root)
+    allow = load_allowlist(root / args.rules)
+    used_allow: set[str] = set()
+
+    sources = sorted(
+        p for p in root.glob("openbank-*/src/main/kotlin/**/*.kt") if "/build/" not in str(p)
+    )
+
+    scheduled = 0
+    fail = 0
+    for path in sources:
+        raw = path.read_text(encoding="utf-8").splitlines()
+        if not any(SCHEDULED_RE.match(line) for line in raw):
+            continue
+        code = strip_comments(raw)
+        rel = path.relative_to(root).as_posix()
+        for name, _decl, start, end in scheduled_method_bodies(code):
+            scheduled += 1
+            hits = [j for j in range(start, end + 1) if RUNBLOCKING_RE.search(code[j])]
+            if not hits:
+                continue
+            key = f"{rel}#{name}"
+            if key in allow:
+                used_allow.add(key)
+                print(f"::notice file={rel},line={hits[0] + 1}::allowlisted: {allow[key]}")
+                continue
+            fail = 1
+            for j in hits:
+                print(
+                    f"::error file={rel},line={j + 1}::runBlocking inside the @Scheduled method "
+                    f"`{name}` — Quarkus invokes a non-suspend @Scheduled method on a bare "
+                    f"executor-thread with no Vert.x context, so the first reactive Panache call "
+                    f"throws HR000068 and the job silently does nothing (#2148, #2187). Make it a "
+                    f"`suspend fun` (rules.yaml: scheduled_methods)."
+                )
+
+    for key in sorted(set(allow) - used_allow):
+        fail = 1
+        print(
+            f"::error file={args.rules}::stale allowlist entry "
+            f"`scheduled_methods.runblocking_allowlist: {key}` — that method no longer has "
+            f"runBlocking in a @Scheduled body (or no longer exists). Remove it."
+        )
+
+    verdict = "clean." if fail == 0 else "VIOLATIONS above."
+    print(
+        f"check-no-runblocking-in-scheduled: {scheduled} @Scheduled method(s) checked across "
+        f"{len(sources)} main-source file(s), {len(allow)} allowlisted — {verdict}"
+    )
+    return fail
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -386,6 +386,16 @@ jobs:
       - name: "event-consumer liveness (ADR-0160, enforced)"
         run: python3 .github/scripts/check-event-consumer-liveness.py --enforce
 
+      # rules.yaml: scheduled_methods.no_runblocking_in_scheduled_body. Fleet-wide scan (not
+      # diff-scoped): `runBlocking` in the body of a @Scheduled method runs the coroutine on a
+      # bare executor-thread with no Vert.x context, so the first reactive Panache call throws
+      # HR000068 and the job silently does nothing. Found live five times (#2148 standing-order;
+      # #2187 ledger tie-out + FX revaluation, fx ČNB ingestion, billing cycle) — none had ever
+      # run. It is a gate rather than a doc because the natural test cannot fail: calling the
+      # method directly supplies the context the scheduler does not. ENFORCED.
+      - name: "no runBlocking in a @Scheduled body (rules.yaml: scheduled_methods, enforced)"
+        run: python3 .github/scripts/check-no-runblocking-in-scheduled.py
+
       # ADR-0160 mechanism 2 / rules.yaml: change_requirements.lineage_code_audit. Fleet-wide scan
       # (not diff-scoped): every governance.yaml lineage.downstream edge must be backed by
       # grep-verifiable code, or a one-line-reasoned allowlist entry. Reuses mechanism 1's topic

--- a/openbank-infra/gitops/components/accounts/account-opa-bundle.yaml
+++ b/openbank-infra/gitops/components/accounts/account-opa-bundle.yaml
@@ -9,7 +9,7 @@ metadata:
     app.kubernetes.io/name: account-service
     app.kubernetes.io/part-of: accounts
   annotations:
-    openbank.tech/policy-checksum: "5bdeb7d5617a0e26"
+    openbank.tech/policy-checksum: "434931963099332d"
 data:
   rest.rego: |
     # SPDX-License-Identifier: Apache-2.0
@@ -2368,6 +2368,57 @@ data:
       # edge-service-notification rule and rest_test.rego's
       # test_deny_operator_read_any_does_not_cover_write).
       ci_producer: ".github/scripts/check-no-service-principal-type.sh"
+
+    # ---------------------------------------------------------------------------------------
+    # Scheduled-method invariants (issue #2148, fleet sweep #2187).
+    # ---------------------------------------------------------------------------------------
+    scheduled_methods:
+      no_runblocking_in_scheduled_body: true
+      # Quarkus invokes a plain (non-`suspend`) @Scheduled method on a bare `executor-thread`,
+      # which carries NO Vert.x context. A body of `runBlocking { … }` therefore runs the
+      # coroutine on that thread, and the first reactive Hibernate-Reactive/Panache call inside
+      # throws `HR000068: This method should exclusively be invoked from a Vert.x EventLoop
+      # thread`. The job aborts having done nothing, and does so silently — the throw lands
+      # before whatever per-item try/catch the job has, or is swallowed by its own outer catch
+      # into one ERROR line.
+      #
+      # Found live five times. #2148: StandingOrderExecutionScheduler.sweep() — no due standing
+      # order had EVER executed (PR #2180). The #2187 sweep then found the same shape in the
+      # daily sub-ledger tie-out control and the daily FX revaluation (ledger, PR #2190), the
+      # statutory ČNB fixing ingestion (fx, PR #2191) and the monthly billing cycle (PR #2194).
+      # None had ever run.
+      #
+      # This is a GATE and not a documented lesson because the natural test does not fail: a test
+      # that calls the method directly supplies a Vert.x context the scheduler does not, so it
+      # passes against the broken code — which is exactly how all five hid behind green suites.
+      # Regression coverage must drive the REAL cron via a @TestProfile that shrinks the cron
+      # expression (pattern: StandingOrderExecutionSweepIT, LedgerSchedulerVertxContextIT).
+      #
+      # FIX: make the method a `suspend fun` — Quarkus dispatches a suspending @Scheduled method
+      # on a proper (duplicated) Vert.x context. Unanimous fleet convention: every other reactive
+      # @Scheduled method here is `suspend` or returns `Uni`. Preferred over
+      # `VertxContextSupport.subscribeAndAwait`, which swaps one blocking bridge for another,
+      # pins the scheduler worker for the whole run, and throws if ever called FROM an event-loop
+      # thread (so it breaks the day the method gains @NonBlocking or a virtual thread).
+      #
+      # An entry below is a genuine exception, not a deferral: a service with no reactive
+      # persistence on its classpath at all, where `runBlocking` bridges deliberately BLOCKING
+      # clients and `suspend` would be the wrong change. Same individually-justified-exception
+      # idiom as the ktlint/detekt baselines and event_consumer_liveness.allowlist. A stale entry
+      # is itself a violation.
+      runblocking_allowlist:
+        - method: "openbank-agent-service/src/main/kotlin/com/openbank/agent/application/OversightService.kt#scheduledSweep"
+          reason: >-
+            agent-service has NO Hibernate Reactive on its classpath (build.gradle.kts: the
+            proposals store is plain Agroal JDBC, deliberately not the reactive stack). The sweep
+            drives blocking OPA/MCP/LLM clients and needs to stay on a worker thread — the same
+            bridge ChatEndpoint uses. `suspend` here would move blocking I/O onto an event loop.
+        - method: "openbank-analytics-sink/src/main/kotlin/com/openbank/analytics/infrastructure/reconcile/ReconciliationJob.kt#scheduled"
+          reason: >-
+            analytics-sink deliberately DROPS hibernate-reactive-panache, reactive-pg-client and
+            jdbc-postgresql (build.gradle.kts) — it has no OLTP datasource to reach. The
+            reconciliation reads the warehouse and the WORM archive over blocking clients.
+      ci_producer: ".github/scripts/check-no-runblocking-in-scheduled.py"
 
     # ---------------------------------------------------------------------------------------
     # Vulnerability-management lifecycle SLAs (ADR-0030 D1). Detection -> closure, in days.

--- a/openbank-infra/gitops/components/accounts/account-service.yaml
+++ b/openbank-infra/gitops/components/accounts/account-service.yaml
@@ -37,7 +37,7 @@ spec:
       annotations:
         # Rolls the pod when the OPA bundle changes — subPath mounts do NOT hot-reload.
         # Kept in sync by gen-account-opa-bundle.sh (do not hand-edit).
-        openbank.tech/policy-checksum: "5bdeb7d5617a0e26"
+        openbank.tech/policy-checksum: "434931963099332d"
     spec:
       securityContext:
         runAsNonRoot: true

--- a/openbank-infra/gitops/components/anacredit/anacredit-opa-bundle.yaml
+++ b/openbank-infra/gitops/components/anacredit/anacredit-opa-bundle.yaml
@@ -9,7 +9,7 @@ metadata:
     app.kubernetes.io/name: anacredit-service
     app.kubernetes.io/part-of: anacredit
   annotations:
-    openbank.tech/policy-checksum: "8cbb7cc0696aee49"
+    openbank.tech/policy-checksum: "0440944afa019375"
 data:
   rest.rego: |
     # SPDX-License-Identifier: Apache-2.0
@@ -2311,6 +2311,57 @@ data:
       # edge-service-notification rule and rest_test.rego's
       # test_deny_operator_read_any_does_not_cover_write).
       ci_producer: ".github/scripts/check-no-service-principal-type.sh"
+
+    # ---------------------------------------------------------------------------------------
+    # Scheduled-method invariants (issue #2148, fleet sweep #2187).
+    # ---------------------------------------------------------------------------------------
+    scheduled_methods:
+      no_runblocking_in_scheduled_body: true
+      # Quarkus invokes a plain (non-`suspend`) @Scheduled method on a bare `executor-thread`,
+      # which carries NO Vert.x context. A body of `runBlocking { … }` therefore runs the
+      # coroutine on that thread, and the first reactive Hibernate-Reactive/Panache call inside
+      # throws `HR000068: This method should exclusively be invoked from a Vert.x EventLoop
+      # thread`. The job aborts having done nothing, and does so silently — the throw lands
+      # before whatever per-item try/catch the job has, or is swallowed by its own outer catch
+      # into one ERROR line.
+      #
+      # Found live five times. #2148: StandingOrderExecutionScheduler.sweep() — no due standing
+      # order had EVER executed (PR #2180). The #2187 sweep then found the same shape in the
+      # daily sub-ledger tie-out control and the daily FX revaluation (ledger, PR #2190), the
+      # statutory ČNB fixing ingestion (fx, PR #2191) and the monthly billing cycle (PR #2194).
+      # None had ever run.
+      #
+      # This is a GATE and not a documented lesson because the natural test does not fail: a test
+      # that calls the method directly supplies a Vert.x context the scheduler does not, so it
+      # passes against the broken code — which is exactly how all five hid behind green suites.
+      # Regression coverage must drive the REAL cron via a @TestProfile that shrinks the cron
+      # expression (pattern: StandingOrderExecutionSweepIT, LedgerSchedulerVertxContextIT).
+      #
+      # FIX: make the method a `suspend fun` — Quarkus dispatches a suspending @Scheduled method
+      # on a proper (duplicated) Vert.x context. Unanimous fleet convention: every other reactive
+      # @Scheduled method here is `suspend` or returns `Uni`. Preferred over
+      # `VertxContextSupport.subscribeAndAwait`, which swaps one blocking bridge for another,
+      # pins the scheduler worker for the whole run, and throws if ever called FROM an event-loop
+      # thread (so it breaks the day the method gains @NonBlocking or a virtual thread).
+      #
+      # An entry below is a genuine exception, not a deferral: a service with no reactive
+      # persistence on its classpath at all, where `runBlocking` bridges deliberately BLOCKING
+      # clients and `suspend` would be the wrong change. Same individually-justified-exception
+      # idiom as the ktlint/detekt baselines and event_consumer_liveness.allowlist. A stale entry
+      # is itself a violation.
+      runblocking_allowlist:
+        - method: "openbank-agent-service/src/main/kotlin/com/openbank/agent/application/OversightService.kt#scheduledSweep"
+          reason: >-
+            agent-service has NO Hibernate Reactive on its classpath (build.gradle.kts: the
+            proposals store is plain Agroal JDBC, deliberately not the reactive stack). The sweep
+            drives blocking OPA/MCP/LLM clients and needs to stay on a worker thread — the same
+            bridge ChatEndpoint uses. `suspend` here would move blocking I/O onto an event loop.
+        - method: "openbank-analytics-sink/src/main/kotlin/com/openbank/analytics/infrastructure/reconcile/ReconciliationJob.kt#scheduled"
+          reason: >-
+            analytics-sink deliberately DROPS hibernate-reactive-panache, reactive-pg-client and
+            jdbc-postgresql (build.gradle.kts) — it has no OLTP datasource to reach. The
+            reconciliation reads the warehouse and the WORM archive over blocking clients.
+      ci_producer: ".github/scripts/check-no-runblocking-in-scheduled.py"
 
     # ---------------------------------------------------------------------------------------
     # Vulnerability-management lifecycle SLAs (ADR-0030 D1). Detection -> closure, in days.

--- a/openbank-infra/gitops/components/anacredit/anacredit-service.yaml
+++ b/openbank-infra/gitops/components/anacredit/anacredit-service.yaml
@@ -32,7 +32,7 @@ spec:
       annotations:
         # Rolls the pods when the OPA bundle changes — subPath mounts do NOT hot-reload.
         # Kept in sync by gen-anacredit-opa-bundle.sh (do not hand-edit).
-        openbank.tech/policy-checksum: "8cbb7cc0696aee49"
+        openbank.tech/policy-checksum: "0440944afa019375"
     spec:
       securityContext:
         runAsNonRoot: true

--- a/openbank-infra/gitops/components/ap2/ap2-opa-bundle.yaml
+++ b/openbank-infra/gitops/components/ap2/ap2-opa-bundle.yaml
@@ -9,7 +9,7 @@ metadata:
     app.kubernetes.io/name: mcp-service
     app.kubernetes.io/part-of: platform
   annotations:
-    openbank.tech/policy-checksum: "f914896e8577af47"
+    openbank.tech/policy-checksum: "e57e6df81c829864"
 data:
   rest.rego: |
     # SPDX-License-Identifier: Apache-2.0
@@ -2279,6 +2279,57 @@ data:
       # edge-service-notification rule and rest_test.rego's
       # test_deny_operator_read_any_does_not_cover_write).
       ci_producer: ".github/scripts/check-no-service-principal-type.sh"
+
+    # ---------------------------------------------------------------------------------------
+    # Scheduled-method invariants (issue #2148, fleet sweep #2187).
+    # ---------------------------------------------------------------------------------------
+    scheduled_methods:
+      no_runblocking_in_scheduled_body: true
+      # Quarkus invokes a plain (non-`suspend`) @Scheduled method on a bare `executor-thread`,
+      # which carries NO Vert.x context. A body of `runBlocking { … }` therefore runs the
+      # coroutine on that thread, and the first reactive Hibernate-Reactive/Panache call inside
+      # throws `HR000068: This method should exclusively be invoked from a Vert.x EventLoop
+      # thread`. The job aborts having done nothing, and does so silently — the throw lands
+      # before whatever per-item try/catch the job has, or is swallowed by its own outer catch
+      # into one ERROR line.
+      #
+      # Found live five times. #2148: StandingOrderExecutionScheduler.sweep() — no due standing
+      # order had EVER executed (PR #2180). The #2187 sweep then found the same shape in the
+      # daily sub-ledger tie-out control and the daily FX revaluation (ledger, PR #2190), the
+      # statutory ČNB fixing ingestion (fx, PR #2191) and the monthly billing cycle (PR #2194).
+      # None had ever run.
+      #
+      # This is a GATE and not a documented lesson because the natural test does not fail: a test
+      # that calls the method directly supplies a Vert.x context the scheduler does not, so it
+      # passes against the broken code — which is exactly how all five hid behind green suites.
+      # Regression coverage must drive the REAL cron via a @TestProfile that shrinks the cron
+      # expression (pattern: StandingOrderExecutionSweepIT, LedgerSchedulerVertxContextIT).
+      #
+      # FIX: make the method a `suspend fun` — Quarkus dispatches a suspending @Scheduled method
+      # on a proper (duplicated) Vert.x context. Unanimous fleet convention: every other reactive
+      # @Scheduled method here is `suspend` or returns `Uni`. Preferred over
+      # `VertxContextSupport.subscribeAndAwait`, which swaps one blocking bridge for another,
+      # pins the scheduler worker for the whole run, and throws if ever called FROM an event-loop
+      # thread (so it breaks the day the method gains @NonBlocking or a virtual thread).
+      #
+      # An entry below is a genuine exception, not a deferral: a service with no reactive
+      # persistence on its classpath at all, where `runBlocking` bridges deliberately BLOCKING
+      # clients and `suspend` would be the wrong change. Same individually-justified-exception
+      # idiom as the ktlint/detekt baselines and event_consumer_liveness.allowlist. A stale entry
+      # is itself a violation.
+      runblocking_allowlist:
+        - method: "openbank-agent-service/src/main/kotlin/com/openbank/agent/application/OversightService.kt#scheduledSweep"
+          reason: >-
+            agent-service has NO Hibernate Reactive on its classpath (build.gradle.kts: the
+            proposals store is plain Agroal JDBC, deliberately not the reactive stack). The sweep
+            drives blocking OPA/MCP/LLM clients and needs to stay on a worker thread — the same
+            bridge ChatEndpoint uses. `suspend` here would move blocking I/O onto an event loop.
+        - method: "openbank-analytics-sink/src/main/kotlin/com/openbank/analytics/infrastructure/reconcile/ReconciliationJob.kt#scheduled"
+          reason: >-
+            analytics-sink deliberately DROPS hibernate-reactive-panache, reactive-pg-client and
+            jdbc-postgresql (build.gradle.kts) — it has no OLTP datasource to reach. The
+            reconciliation reads the warehouse and the WORM archive over blocking clients.
+      ci_producer: ".github/scripts/check-no-runblocking-in-scheduled.py"
 
     # ---------------------------------------------------------------------------------------
     # Vulnerability-management lifecycle SLAs (ADR-0030 D1). Detection -> closure, in days.

--- a/openbank-infra/gitops/components/ap2/ap2-service.yaml
+++ b/openbank-infra/gitops/components/ap2/ap2-service.yaml
@@ -30,7 +30,7 @@ spec:
       annotations:
         # Roll the pod when the OPA policy bundle changes (subPath mounts don't hot-reload).
         # Kept in sync by gen-ap2-opa-bundle.sh (do not hand-edit).
-        openbank.tech/policy-checksum: "f914896e8577af47"
+        openbank.tech/policy-checksum: "e57e6df81c829864"
     spec:
       securityContext:
         runAsNonRoot: true

--- a/openbank-infra/gitops/components/balances/balance-opa-bundle.yaml
+++ b/openbank-infra/gitops/components/balances/balance-opa-bundle.yaml
@@ -9,7 +9,7 @@ metadata:
     app.kubernetes.io/name: balance-service
     app.kubernetes.io/part-of: balances
   annotations:
-    openbank.tech/policy-checksum: "b8e26855e3b0f754"
+    openbank.tech/policy-checksum: "15d3070e2ef162ae"
 data:
   rest.rego: |
     # SPDX-License-Identifier: Apache-2.0
@@ -2412,6 +2412,57 @@ data:
       # edge-service-notification rule and rest_test.rego's
       # test_deny_operator_read_any_does_not_cover_write).
       ci_producer: ".github/scripts/check-no-service-principal-type.sh"
+
+    # ---------------------------------------------------------------------------------------
+    # Scheduled-method invariants (issue #2148, fleet sweep #2187).
+    # ---------------------------------------------------------------------------------------
+    scheduled_methods:
+      no_runblocking_in_scheduled_body: true
+      # Quarkus invokes a plain (non-`suspend`) @Scheduled method on a bare `executor-thread`,
+      # which carries NO Vert.x context. A body of `runBlocking { … }` therefore runs the
+      # coroutine on that thread, and the first reactive Hibernate-Reactive/Panache call inside
+      # throws `HR000068: This method should exclusively be invoked from a Vert.x EventLoop
+      # thread`. The job aborts having done nothing, and does so silently — the throw lands
+      # before whatever per-item try/catch the job has, or is swallowed by its own outer catch
+      # into one ERROR line.
+      #
+      # Found live five times. #2148: StandingOrderExecutionScheduler.sweep() — no due standing
+      # order had EVER executed (PR #2180). The #2187 sweep then found the same shape in the
+      # daily sub-ledger tie-out control and the daily FX revaluation (ledger, PR #2190), the
+      # statutory ČNB fixing ingestion (fx, PR #2191) and the monthly billing cycle (PR #2194).
+      # None had ever run.
+      #
+      # This is a GATE and not a documented lesson because the natural test does not fail: a test
+      # that calls the method directly supplies a Vert.x context the scheduler does not, so it
+      # passes against the broken code — which is exactly how all five hid behind green suites.
+      # Regression coverage must drive the REAL cron via a @TestProfile that shrinks the cron
+      # expression (pattern: StandingOrderExecutionSweepIT, LedgerSchedulerVertxContextIT).
+      #
+      # FIX: make the method a `suspend fun` — Quarkus dispatches a suspending @Scheduled method
+      # on a proper (duplicated) Vert.x context. Unanimous fleet convention: every other reactive
+      # @Scheduled method here is `suspend` or returns `Uni`. Preferred over
+      # `VertxContextSupport.subscribeAndAwait`, which swaps one blocking bridge for another,
+      # pins the scheduler worker for the whole run, and throws if ever called FROM an event-loop
+      # thread (so it breaks the day the method gains @NonBlocking or a virtual thread).
+      #
+      # An entry below is a genuine exception, not a deferral: a service with no reactive
+      # persistence on its classpath at all, where `runBlocking` bridges deliberately BLOCKING
+      # clients and `suspend` would be the wrong change. Same individually-justified-exception
+      # idiom as the ktlint/detekt baselines and event_consumer_liveness.allowlist. A stale entry
+      # is itself a violation.
+      runblocking_allowlist:
+        - method: "openbank-agent-service/src/main/kotlin/com/openbank/agent/application/OversightService.kt#scheduledSweep"
+          reason: >-
+            agent-service has NO Hibernate Reactive on its classpath (build.gradle.kts: the
+            proposals store is plain Agroal JDBC, deliberately not the reactive stack). The sweep
+            drives blocking OPA/MCP/LLM clients and needs to stay on a worker thread — the same
+            bridge ChatEndpoint uses. `suspend` here would move blocking I/O onto an event loop.
+        - method: "openbank-analytics-sink/src/main/kotlin/com/openbank/analytics/infrastructure/reconcile/ReconciliationJob.kt#scheduled"
+          reason: >-
+            analytics-sink deliberately DROPS hibernate-reactive-panache, reactive-pg-client and
+            jdbc-postgresql (build.gradle.kts) — it has no OLTP datasource to reach. The
+            reconciliation reads the warehouse and the WORM archive over blocking clients.
+      ci_producer: ".github/scripts/check-no-runblocking-in-scheduled.py"
 
     # ---------------------------------------------------------------------------------------
     # Vulnerability-management lifecycle SLAs (ADR-0030 D1). Detection -> closure, in days.

--- a/openbank-infra/gitops/components/balances/balance-service.yaml
+++ b/openbank-infra/gitops/components/balances/balance-service.yaml
@@ -34,7 +34,7 @@ spec:
       annotations:
         # Rolls the pods when the OPA bundle changes — subPath mounts do NOT hot-reload.
         # Kept in sync by gen-balance-opa-bundle.sh (do not hand-edit).
-        openbank.tech/policy-checksum: "b8e26855e3b0f754"
+        openbank.tech/policy-checksum: "15d3070e2ef162ae"
     spec:
       securityContext:
         runAsNonRoot: true

--- a/openbank-infra/gitops/components/billing/billing-opa-bundle.yaml
+++ b/openbank-infra/gitops/components/billing/billing-opa-bundle.yaml
@@ -9,7 +9,7 @@ metadata:
     app.kubernetes.io/name: billing-service
     app.kubernetes.io/part-of: billing
   annotations:
-    openbank.tech/policy-checksum: "d42ace2772888f59"
+    openbank.tech/policy-checksum: "cce280d17c1ee65a"
 data:
   rest.rego: |
     # SPDX-License-Identifier: Apache-2.0
@@ -2317,6 +2317,57 @@ data:
       # edge-service-notification rule and rest_test.rego's
       # test_deny_operator_read_any_does_not_cover_write).
       ci_producer: ".github/scripts/check-no-service-principal-type.sh"
+
+    # ---------------------------------------------------------------------------------------
+    # Scheduled-method invariants (issue #2148, fleet sweep #2187).
+    # ---------------------------------------------------------------------------------------
+    scheduled_methods:
+      no_runblocking_in_scheduled_body: true
+      # Quarkus invokes a plain (non-`suspend`) @Scheduled method on a bare `executor-thread`,
+      # which carries NO Vert.x context. A body of `runBlocking { … }` therefore runs the
+      # coroutine on that thread, and the first reactive Hibernate-Reactive/Panache call inside
+      # throws `HR000068: This method should exclusively be invoked from a Vert.x EventLoop
+      # thread`. The job aborts having done nothing, and does so silently — the throw lands
+      # before whatever per-item try/catch the job has, or is swallowed by its own outer catch
+      # into one ERROR line.
+      #
+      # Found live five times. #2148: StandingOrderExecutionScheduler.sweep() — no due standing
+      # order had EVER executed (PR #2180). The #2187 sweep then found the same shape in the
+      # daily sub-ledger tie-out control and the daily FX revaluation (ledger, PR #2190), the
+      # statutory ČNB fixing ingestion (fx, PR #2191) and the monthly billing cycle (PR #2194).
+      # None had ever run.
+      #
+      # This is a GATE and not a documented lesson because the natural test does not fail: a test
+      # that calls the method directly supplies a Vert.x context the scheduler does not, so it
+      # passes against the broken code — which is exactly how all five hid behind green suites.
+      # Regression coverage must drive the REAL cron via a @TestProfile that shrinks the cron
+      # expression (pattern: StandingOrderExecutionSweepIT, LedgerSchedulerVertxContextIT).
+      #
+      # FIX: make the method a `suspend fun` — Quarkus dispatches a suspending @Scheduled method
+      # on a proper (duplicated) Vert.x context. Unanimous fleet convention: every other reactive
+      # @Scheduled method here is `suspend` or returns `Uni`. Preferred over
+      # `VertxContextSupport.subscribeAndAwait`, which swaps one blocking bridge for another,
+      # pins the scheduler worker for the whole run, and throws if ever called FROM an event-loop
+      # thread (so it breaks the day the method gains @NonBlocking or a virtual thread).
+      #
+      # An entry below is a genuine exception, not a deferral: a service with no reactive
+      # persistence on its classpath at all, where `runBlocking` bridges deliberately BLOCKING
+      # clients and `suspend` would be the wrong change. Same individually-justified-exception
+      # idiom as the ktlint/detekt baselines and event_consumer_liveness.allowlist. A stale entry
+      # is itself a violation.
+      runblocking_allowlist:
+        - method: "openbank-agent-service/src/main/kotlin/com/openbank/agent/application/OversightService.kt#scheduledSweep"
+          reason: >-
+            agent-service has NO Hibernate Reactive on its classpath (build.gradle.kts: the
+            proposals store is plain Agroal JDBC, deliberately not the reactive stack). The sweep
+            drives blocking OPA/MCP/LLM clients and needs to stay on a worker thread — the same
+            bridge ChatEndpoint uses. `suspend` here would move blocking I/O onto an event loop.
+        - method: "openbank-analytics-sink/src/main/kotlin/com/openbank/analytics/infrastructure/reconcile/ReconciliationJob.kt#scheduled"
+          reason: >-
+            analytics-sink deliberately DROPS hibernate-reactive-panache, reactive-pg-client and
+            jdbc-postgresql (build.gradle.kts) — it has no OLTP datasource to reach. The
+            reconciliation reads the warehouse and the WORM archive over blocking clients.
+      ci_producer: ".github/scripts/check-no-runblocking-in-scheduled.py"
 
     # ---------------------------------------------------------------------------------------
     # Vulnerability-management lifecycle SLAs (ADR-0030 D1). Detection -> closure, in days.

--- a/openbank-infra/gitops/components/billing/billing-service.yaml
+++ b/openbank-infra/gitops/components/billing/billing-service.yaml
@@ -27,7 +27,7 @@ spec:
       annotations:
         # Rolls the pods when the OPA bundle changes — subPath mounts do NOT hot-reload.
         # Kept in sync by gen-billing-opa-bundle.sh (do not hand-edit).
-        openbank.tech/policy-checksum: "d42ace2772888f59"
+        openbank.tech/policy-checksum: "cce280d17c1ee65a"
     spec:
       securityContext:
         runAsNonRoot: true

--- a/openbank-infra/gitops/components/consent/consent-opa-bundle.yaml
+++ b/openbank-infra/gitops/components/consent/consent-opa-bundle.yaml
@@ -9,7 +9,7 @@ metadata:
     app.kubernetes.io/name: consent-service
     app.kubernetes.io/part-of: consent
   annotations:
-    openbank.tech/policy-checksum: "f9f15d2bbe56c2bd"
+    openbank.tech/policy-checksum: "8082e5d9121ed283"
 data:
   rest.rego: |
     # SPDX-License-Identifier: Apache-2.0
@@ -2349,6 +2349,57 @@ data:
       # edge-service-notification rule and rest_test.rego's
       # test_deny_operator_read_any_does_not_cover_write).
       ci_producer: ".github/scripts/check-no-service-principal-type.sh"
+
+    # ---------------------------------------------------------------------------------------
+    # Scheduled-method invariants (issue #2148, fleet sweep #2187).
+    # ---------------------------------------------------------------------------------------
+    scheduled_methods:
+      no_runblocking_in_scheduled_body: true
+      # Quarkus invokes a plain (non-`suspend`) @Scheduled method on a bare `executor-thread`,
+      # which carries NO Vert.x context. A body of `runBlocking { … }` therefore runs the
+      # coroutine on that thread, and the first reactive Hibernate-Reactive/Panache call inside
+      # throws `HR000068: This method should exclusively be invoked from a Vert.x EventLoop
+      # thread`. The job aborts having done nothing, and does so silently — the throw lands
+      # before whatever per-item try/catch the job has, or is swallowed by its own outer catch
+      # into one ERROR line.
+      #
+      # Found live five times. #2148: StandingOrderExecutionScheduler.sweep() — no due standing
+      # order had EVER executed (PR #2180). The #2187 sweep then found the same shape in the
+      # daily sub-ledger tie-out control and the daily FX revaluation (ledger, PR #2190), the
+      # statutory ČNB fixing ingestion (fx, PR #2191) and the monthly billing cycle (PR #2194).
+      # None had ever run.
+      #
+      # This is a GATE and not a documented lesson because the natural test does not fail: a test
+      # that calls the method directly supplies a Vert.x context the scheduler does not, so it
+      # passes against the broken code — which is exactly how all five hid behind green suites.
+      # Regression coverage must drive the REAL cron via a @TestProfile that shrinks the cron
+      # expression (pattern: StandingOrderExecutionSweepIT, LedgerSchedulerVertxContextIT).
+      #
+      # FIX: make the method a `suspend fun` — Quarkus dispatches a suspending @Scheduled method
+      # on a proper (duplicated) Vert.x context. Unanimous fleet convention: every other reactive
+      # @Scheduled method here is `suspend` or returns `Uni`. Preferred over
+      # `VertxContextSupport.subscribeAndAwait`, which swaps one blocking bridge for another,
+      # pins the scheduler worker for the whole run, and throws if ever called FROM an event-loop
+      # thread (so it breaks the day the method gains @NonBlocking or a virtual thread).
+      #
+      # An entry below is a genuine exception, not a deferral: a service with no reactive
+      # persistence on its classpath at all, where `runBlocking` bridges deliberately BLOCKING
+      # clients and `suspend` would be the wrong change. Same individually-justified-exception
+      # idiom as the ktlint/detekt baselines and event_consumer_liveness.allowlist. A stale entry
+      # is itself a violation.
+      runblocking_allowlist:
+        - method: "openbank-agent-service/src/main/kotlin/com/openbank/agent/application/OversightService.kt#scheduledSweep"
+          reason: >-
+            agent-service has NO Hibernate Reactive on its classpath (build.gradle.kts: the
+            proposals store is plain Agroal JDBC, deliberately not the reactive stack). The sweep
+            drives blocking OPA/MCP/LLM clients and needs to stay on a worker thread — the same
+            bridge ChatEndpoint uses. `suspend` here would move blocking I/O onto an event loop.
+        - method: "openbank-analytics-sink/src/main/kotlin/com/openbank/analytics/infrastructure/reconcile/ReconciliationJob.kt#scheduled"
+          reason: >-
+            analytics-sink deliberately DROPS hibernate-reactive-panache, reactive-pg-client and
+            jdbc-postgresql (build.gradle.kts) — it has no OLTP datasource to reach. The
+            reconciliation reads the warehouse and the WORM archive over blocking clients.
+      ci_producer: ".github/scripts/check-no-runblocking-in-scheduled.py"
 
     # ---------------------------------------------------------------------------------------
     # Vulnerability-management lifecycle SLAs (ADR-0030 D1). Detection -> closure, in days.

--- a/openbank-infra/gitops/components/consent/consent-service.yaml
+++ b/openbank-infra/gitops/components/consent/consent-service.yaml
@@ -28,7 +28,7 @@ spec:
       annotations:
         # Rolls the pods when the OPA bundle changes — subPath mounts do NOT hot-reload.
         # Kept in sync by gen-consent-opa-bundle.sh (do not hand-edit).
-        openbank.tech/policy-checksum: "f9f15d2bbe56c2bd"
+        openbank.tech/policy-checksum: "8082e5d9121ed283"
     spec:
       securityContext:
         runAsNonRoot: true

--- a/openbank-infra/gitops/components/copilot/copilot-opa-bundle.yaml
+++ b/openbank-infra/gitops/components/copilot/copilot-opa-bundle.yaml
@@ -9,7 +9,7 @@ metadata:
     app.kubernetes.io/name: copilot-service
     app.kubernetes.io/part-of: platform
   annotations:
-    openbank.tech/policy-checksum: "c217dc053019d025"
+    openbank.tech/policy-checksum: "6caeaaadfada627c"
 data:
   rest.rego: |
     # SPDX-License-Identifier: Apache-2.0
@@ -2403,6 +2403,57 @@ data:
       # edge-service-notification rule and rest_test.rego's
       # test_deny_operator_read_any_does_not_cover_write).
       ci_producer: ".github/scripts/check-no-service-principal-type.sh"
+
+    # ---------------------------------------------------------------------------------------
+    # Scheduled-method invariants (issue #2148, fleet sweep #2187).
+    # ---------------------------------------------------------------------------------------
+    scheduled_methods:
+      no_runblocking_in_scheduled_body: true
+      # Quarkus invokes a plain (non-`suspend`) @Scheduled method on a bare `executor-thread`,
+      # which carries NO Vert.x context. A body of `runBlocking { … }` therefore runs the
+      # coroutine on that thread, and the first reactive Hibernate-Reactive/Panache call inside
+      # throws `HR000068: This method should exclusively be invoked from a Vert.x EventLoop
+      # thread`. The job aborts having done nothing, and does so silently — the throw lands
+      # before whatever per-item try/catch the job has, or is swallowed by its own outer catch
+      # into one ERROR line.
+      #
+      # Found live five times. #2148: StandingOrderExecutionScheduler.sweep() — no due standing
+      # order had EVER executed (PR #2180). The #2187 sweep then found the same shape in the
+      # daily sub-ledger tie-out control and the daily FX revaluation (ledger, PR #2190), the
+      # statutory ČNB fixing ingestion (fx, PR #2191) and the monthly billing cycle (PR #2194).
+      # None had ever run.
+      #
+      # This is a GATE and not a documented lesson because the natural test does not fail: a test
+      # that calls the method directly supplies a Vert.x context the scheduler does not, so it
+      # passes against the broken code — which is exactly how all five hid behind green suites.
+      # Regression coverage must drive the REAL cron via a @TestProfile that shrinks the cron
+      # expression (pattern: StandingOrderExecutionSweepIT, LedgerSchedulerVertxContextIT).
+      #
+      # FIX: make the method a `suspend fun` — Quarkus dispatches a suspending @Scheduled method
+      # on a proper (duplicated) Vert.x context. Unanimous fleet convention: every other reactive
+      # @Scheduled method here is `suspend` or returns `Uni`. Preferred over
+      # `VertxContextSupport.subscribeAndAwait`, which swaps one blocking bridge for another,
+      # pins the scheduler worker for the whole run, and throws if ever called FROM an event-loop
+      # thread (so it breaks the day the method gains @NonBlocking or a virtual thread).
+      #
+      # An entry below is a genuine exception, not a deferral: a service with no reactive
+      # persistence on its classpath at all, where `runBlocking` bridges deliberately BLOCKING
+      # clients and `suspend` would be the wrong change. Same individually-justified-exception
+      # idiom as the ktlint/detekt baselines and event_consumer_liveness.allowlist. A stale entry
+      # is itself a violation.
+      runblocking_allowlist:
+        - method: "openbank-agent-service/src/main/kotlin/com/openbank/agent/application/OversightService.kt#scheduledSweep"
+          reason: >-
+            agent-service has NO Hibernate Reactive on its classpath (build.gradle.kts: the
+            proposals store is plain Agroal JDBC, deliberately not the reactive stack). The sweep
+            drives blocking OPA/MCP/LLM clients and needs to stay on a worker thread — the same
+            bridge ChatEndpoint uses. `suspend` here would move blocking I/O onto an event loop.
+        - method: "openbank-analytics-sink/src/main/kotlin/com/openbank/analytics/infrastructure/reconcile/ReconciliationJob.kt#scheduled"
+          reason: >-
+            analytics-sink deliberately DROPS hibernate-reactive-panache, reactive-pg-client and
+            jdbc-postgresql (build.gradle.kts) — it has no OLTP datasource to reach. The
+            reconciliation reads the warehouse and the WORM archive over blocking clients.
+      ci_producer: ".github/scripts/check-no-runblocking-in-scheduled.py"
 
     # ---------------------------------------------------------------------------------------
     # Vulnerability-management lifecycle SLAs (ADR-0030 D1). Detection -> closure, in days.

--- a/openbank-infra/gitops/components/copilot/copilot-service.yaml
+++ b/openbank-infra/gitops/components/copilot/copilot-service.yaml
@@ -29,7 +29,7 @@ spec:
       annotations:
         # Rolls the pod when the OPA bundle changes — subPath mounts do NOT hot-reload.
         # Kept in sync by gen-copilot-opa-bundle.sh (do not hand-edit).
-        openbank.tech/policy-checksum: "c217dc053019d025"
+        openbank.tech/policy-checksum: "6caeaaadfada627c"
     spec:
       securityContext:
         runAsNonRoot: true

--- a/openbank-infra/gitops/components/customer-edge/customer-edge-opa-bundle.yaml
+++ b/openbank-infra/gitops/components/customer-edge/customer-edge-opa-bundle.yaml
@@ -10,7 +10,7 @@ metadata:
     app.kubernetes.io/name: customer-edge
     app.kubernetes.io/part-of: customer-edge
   annotations:
-    openbank.tech/policy-checksum: "b98b878286dda238"
+    openbank.tech/policy-checksum: "e686dc210d1bc4a8"
 data:
   rest.rego: |
     # SPDX-License-Identifier: Apache-2.0
@@ -1531,6 +1531,57 @@ data:
       # edge-service-notification rule and rest_test.rego's
       # test_deny_operator_read_any_does_not_cover_write).
       ci_producer: ".github/scripts/check-no-service-principal-type.sh"
+
+    # ---------------------------------------------------------------------------------------
+    # Scheduled-method invariants (issue #2148, fleet sweep #2187).
+    # ---------------------------------------------------------------------------------------
+    scheduled_methods:
+      no_runblocking_in_scheduled_body: true
+      # Quarkus invokes a plain (non-`suspend`) @Scheduled method on a bare `executor-thread`,
+      # which carries NO Vert.x context. A body of `runBlocking { … }` therefore runs the
+      # coroutine on that thread, and the first reactive Hibernate-Reactive/Panache call inside
+      # throws `HR000068: This method should exclusively be invoked from a Vert.x EventLoop
+      # thread`. The job aborts having done nothing, and does so silently — the throw lands
+      # before whatever per-item try/catch the job has, or is swallowed by its own outer catch
+      # into one ERROR line.
+      #
+      # Found live five times. #2148: StandingOrderExecutionScheduler.sweep() — no due standing
+      # order had EVER executed (PR #2180). The #2187 sweep then found the same shape in the
+      # daily sub-ledger tie-out control and the daily FX revaluation (ledger, PR #2190), the
+      # statutory ČNB fixing ingestion (fx, PR #2191) and the monthly billing cycle (PR #2194).
+      # None had ever run.
+      #
+      # This is a GATE and not a documented lesson because the natural test does not fail: a test
+      # that calls the method directly supplies a Vert.x context the scheduler does not, so it
+      # passes against the broken code — which is exactly how all five hid behind green suites.
+      # Regression coverage must drive the REAL cron via a @TestProfile that shrinks the cron
+      # expression (pattern: StandingOrderExecutionSweepIT, LedgerSchedulerVertxContextIT).
+      #
+      # FIX: make the method a `suspend fun` — Quarkus dispatches a suspending @Scheduled method
+      # on a proper (duplicated) Vert.x context. Unanimous fleet convention: every other reactive
+      # @Scheduled method here is `suspend` or returns `Uni`. Preferred over
+      # `VertxContextSupport.subscribeAndAwait`, which swaps one blocking bridge for another,
+      # pins the scheduler worker for the whole run, and throws if ever called FROM an event-loop
+      # thread (so it breaks the day the method gains @NonBlocking or a virtual thread).
+      #
+      # An entry below is a genuine exception, not a deferral: a service with no reactive
+      # persistence on its classpath at all, where `runBlocking` bridges deliberately BLOCKING
+      # clients and `suspend` would be the wrong change. Same individually-justified-exception
+      # idiom as the ktlint/detekt baselines and event_consumer_liveness.allowlist. A stale entry
+      # is itself a violation.
+      runblocking_allowlist:
+        - method: "openbank-agent-service/src/main/kotlin/com/openbank/agent/application/OversightService.kt#scheduledSweep"
+          reason: >-
+            agent-service has NO Hibernate Reactive on its classpath (build.gradle.kts: the
+            proposals store is plain Agroal JDBC, deliberately not the reactive stack). The sweep
+            drives blocking OPA/MCP/LLM clients and needs to stay on a worker thread — the same
+            bridge ChatEndpoint uses. `suspend` here would move blocking I/O onto an event loop.
+        - method: "openbank-analytics-sink/src/main/kotlin/com/openbank/analytics/infrastructure/reconcile/ReconciliationJob.kt#scheduled"
+          reason: >-
+            analytics-sink deliberately DROPS hibernate-reactive-panache, reactive-pg-client and
+            jdbc-postgresql (build.gradle.kts) — it has no OLTP datasource to reach. The
+            reconciliation reads the warehouse and the WORM archive over blocking clients.
+      ci_producer: ".github/scripts/check-no-runblocking-in-scheduled.py"
 
     # ---------------------------------------------------------------------------------------
     # Vulnerability-management lifecycle SLAs (ADR-0030 D1). Detection -> closure, in days.

--- a/openbank-infra/gitops/components/customer-edge/customer-edge.yaml
+++ b/openbank-infra/gitops/components/customer-edge/customer-edge.yaml
@@ -65,7 +65,7 @@ spec:
       annotations:
         # Rolls the pod when the OPA bundle changes — subPath mounts do NOT hot-reload.
         # Kept in sync by gen-customer-edge-opa-bundle.sh (do not hand-edit).
-        openbank.tech/policy-checksum: "b98b878286dda238"
+        openbank.tech/policy-checksum: "e686dc210d1bc4a8"
     spec:
       # Dedicated SA so EKS Pod Identity can hand the edge (and ONLY the edge) the
       # feedback-screenshots S3 role — ADR-0192, openbank-infra/aws/envs/sandbox-platform/

--- a/openbank-infra/gitops/components/document-service/document-service-opa-bundle.yaml
+++ b/openbank-infra/gitops/components/document-service/document-service-opa-bundle.yaml
@@ -10,7 +10,7 @@ metadata:
     app.kubernetes.io/name: document-service
     app.kubernetes.io/part-of: documents
   annotations:
-    openbank.tech/policy-checksum: "b98b878286dda238"
+    openbank.tech/policy-checksum: "e686dc210d1bc4a8"
 data:
   rest.rego: |
     # SPDX-License-Identifier: Apache-2.0
@@ -1531,6 +1531,57 @@ data:
       # edge-service-notification rule and rest_test.rego's
       # test_deny_operator_read_any_does_not_cover_write).
       ci_producer: ".github/scripts/check-no-service-principal-type.sh"
+
+    # ---------------------------------------------------------------------------------------
+    # Scheduled-method invariants (issue #2148, fleet sweep #2187).
+    # ---------------------------------------------------------------------------------------
+    scheduled_methods:
+      no_runblocking_in_scheduled_body: true
+      # Quarkus invokes a plain (non-`suspend`) @Scheduled method on a bare `executor-thread`,
+      # which carries NO Vert.x context. A body of `runBlocking { … }` therefore runs the
+      # coroutine on that thread, and the first reactive Hibernate-Reactive/Panache call inside
+      # throws `HR000068: This method should exclusively be invoked from a Vert.x EventLoop
+      # thread`. The job aborts having done nothing, and does so silently — the throw lands
+      # before whatever per-item try/catch the job has, or is swallowed by its own outer catch
+      # into one ERROR line.
+      #
+      # Found live five times. #2148: StandingOrderExecutionScheduler.sweep() — no due standing
+      # order had EVER executed (PR #2180). The #2187 sweep then found the same shape in the
+      # daily sub-ledger tie-out control and the daily FX revaluation (ledger, PR #2190), the
+      # statutory ČNB fixing ingestion (fx, PR #2191) and the monthly billing cycle (PR #2194).
+      # None had ever run.
+      #
+      # This is a GATE and not a documented lesson because the natural test does not fail: a test
+      # that calls the method directly supplies a Vert.x context the scheduler does not, so it
+      # passes against the broken code — which is exactly how all five hid behind green suites.
+      # Regression coverage must drive the REAL cron via a @TestProfile that shrinks the cron
+      # expression (pattern: StandingOrderExecutionSweepIT, LedgerSchedulerVertxContextIT).
+      #
+      # FIX: make the method a `suspend fun` — Quarkus dispatches a suspending @Scheduled method
+      # on a proper (duplicated) Vert.x context. Unanimous fleet convention: every other reactive
+      # @Scheduled method here is `suspend` or returns `Uni`. Preferred over
+      # `VertxContextSupport.subscribeAndAwait`, which swaps one blocking bridge for another,
+      # pins the scheduler worker for the whole run, and throws if ever called FROM an event-loop
+      # thread (so it breaks the day the method gains @NonBlocking or a virtual thread).
+      #
+      # An entry below is a genuine exception, not a deferral: a service with no reactive
+      # persistence on its classpath at all, where `runBlocking` bridges deliberately BLOCKING
+      # clients and `suspend` would be the wrong change. Same individually-justified-exception
+      # idiom as the ktlint/detekt baselines and event_consumer_liveness.allowlist. A stale entry
+      # is itself a violation.
+      runblocking_allowlist:
+        - method: "openbank-agent-service/src/main/kotlin/com/openbank/agent/application/OversightService.kt#scheduledSweep"
+          reason: >-
+            agent-service has NO Hibernate Reactive on its classpath (build.gradle.kts: the
+            proposals store is plain Agroal JDBC, deliberately not the reactive stack). The sweep
+            drives blocking OPA/MCP/LLM clients and needs to stay on a worker thread — the same
+            bridge ChatEndpoint uses. `suspend` here would move blocking I/O onto an event loop.
+        - method: "openbank-analytics-sink/src/main/kotlin/com/openbank/analytics/infrastructure/reconcile/ReconciliationJob.kt#scheduled"
+          reason: >-
+            analytics-sink deliberately DROPS hibernate-reactive-panache, reactive-pg-client and
+            jdbc-postgresql (build.gradle.kts) — it has no OLTP datasource to reach. The
+            reconciliation reads the warehouse and the WORM archive over blocking clients.
+      ci_producer: ".github/scripts/check-no-runblocking-in-scheduled.py"
 
     # ---------------------------------------------------------------------------------------
     # Vulnerability-management lifecycle SLAs (ADR-0030 D1). Detection -> closure, in days.

--- a/openbank-infra/gitops/components/document-service/document-service-service.yaml
+++ b/openbank-infra/gitops/components/document-service/document-service-service.yaml
@@ -43,7 +43,7 @@ spec:
       annotations:
         # Rolls the pods when the OPA bundle changes — subPath mounts do NOT hot-reload.
         # Kept in sync by gen-document-service-opa-bundle.sh (do not hand-edit).
-        openbank.tech/policy-checksum: "b98b878286dda238"
+        openbank.tech/policy-checksum: "e686dc210d1bc4a8"
     spec:
       # ADR-0162 D4 (continued): a dedicated SA (not `default`) is what OpenBao's Kubernetes-auth
       # role `document-service-signing` is bound to — least-privilege, one identity per consumer.

--- a/openbank-infra/gitops/components/fraud-service/fraud-opa-bundle.yaml
+++ b/openbank-infra/gitops/components/fraud-service/fraud-opa-bundle.yaml
@@ -9,7 +9,7 @@ metadata:
     app.kubernetes.io/name: fraud-service
     app.kubernetes.io/part-of: fraud
   annotations:
-    openbank.tech/policy-checksum: "215adca5371ef047"
+    openbank.tech/policy-checksum: "ba23359b2845465f"
 data:
   rest.rego: |
     # SPDX-License-Identifier: Apache-2.0
@@ -2328,6 +2328,57 @@ data:
       # edge-service-notification rule and rest_test.rego's
       # test_deny_operator_read_any_does_not_cover_write).
       ci_producer: ".github/scripts/check-no-service-principal-type.sh"
+
+    # ---------------------------------------------------------------------------------------
+    # Scheduled-method invariants (issue #2148, fleet sweep #2187).
+    # ---------------------------------------------------------------------------------------
+    scheduled_methods:
+      no_runblocking_in_scheduled_body: true
+      # Quarkus invokes a plain (non-`suspend`) @Scheduled method on a bare `executor-thread`,
+      # which carries NO Vert.x context. A body of `runBlocking { … }` therefore runs the
+      # coroutine on that thread, and the first reactive Hibernate-Reactive/Panache call inside
+      # throws `HR000068: This method should exclusively be invoked from a Vert.x EventLoop
+      # thread`. The job aborts having done nothing, and does so silently — the throw lands
+      # before whatever per-item try/catch the job has, or is swallowed by its own outer catch
+      # into one ERROR line.
+      #
+      # Found live five times. #2148: StandingOrderExecutionScheduler.sweep() — no due standing
+      # order had EVER executed (PR #2180). The #2187 sweep then found the same shape in the
+      # daily sub-ledger tie-out control and the daily FX revaluation (ledger, PR #2190), the
+      # statutory ČNB fixing ingestion (fx, PR #2191) and the monthly billing cycle (PR #2194).
+      # None had ever run.
+      #
+      # This is a GATE and not a documented lesson because the natural test does not fail: a test
+      # that calls the method directly supplies a Vert.x context the scheduler does not, so it
+      # passes against the broken code — which is exactly how all five hid behind green suites.
+      # Regression coverage must drive the REAL cron via a @TestProfile that shrinks the cron
+      # expression (pattern: StandingOrderExecutionSweepIT, LedgerSchedulerVertxContextIT).
+      #
+      # FIX: make the method a `suspend fun` — Quarkus dispatches a suspending @Scheduled method
+      # on a proper (duplicated) Vert.x context. Unanimous fleet convention: every other reactive
+      # @Scheduled method here is `suspend` or returns `Uni`. Preferred over
+      # `VertxContextSupport.subscribeAndAwait`, which swaps one blocking bridge for another,
+      # pins the scheduler worker for the whole run, and throws if ever called FROM an event-loop
+      # thread (so it breaks the day the method gains @NonBlocking or a virtual thread).
+      #
+      # An entry below is a genuine exception, not a deferral: a service with no reactive
+      # persistence on its classpath at all, where `runBlocking` bridges deliberately BLOCKING
+      # clients and `suspend` would be the wrong change. Same individually-justified-exception
+      # idiom as the ktlint/detekt baselines and event_consumer_liveness.allowlist. A stale entry
+      # is itself a violation.
+      runblocking_allowlist:
+        - method: "openbank-agent-service/src/main/kotlin/com/openbank/agent/application/OversightService.kt#scheduledSweep"
+          reason: >-
+            agent-service has NO Hibernate Reactive on its classpath (build.gradle.kts: the
+            proposals store is plain Agroal JDBC, deliberately not the reactive stack). The sweep
+            drives blocking OPA/MCP/LLM clients and needs to stay on a worker thread — the same
+            bridge ChatEndpoint uses. `suspend` here would move blocking I/O onto an event loop.
+        - method: "openbank-analytics-sink/src/main/kotlin/com/openbank/analytics/infrastructure/reconcile/ReconciliationJob.kt#scheduled"
+          reason: >-
+            analytics-sink deliberately DROPS hibernate-reactive-panache, reactive-pg-client and
+            jdbc-postgresql (build.gradle.kts) — it has no OLTP datasource to reach. The
+            reconciliation reads the warehouse and the WORM archive over blocking clients.
+      ci_producer: ".github/scripts/check-no-runblocking-in-scheduled.py"
 
     # ---------------------------------------------------------------------------------------
     # Vulnerability-management lifecycle SLAs (ADR-0030 D1). Detection -> closure, in days.

--- a/openbank-infra/gitops/components/fraud-service/fraud-service.yaml
+++ b/openbank-infra/gitops/components/fraud-service/fraud-service.yaml
@@ -23,7 +23,7 @@ spec:
       annotations:
         # Rolls the pods when the OPA bundle changes — subPath mounts do NOT hot-reload.
         # Kept in sync by gen-fraud-opa-bundle.sh (do not hand-edit).
-        openbank.tech/policy-checksum: "215adca5371ef047"
+        openbank.tech/policy-checksum: "ba23359b2845465f"
     spec:
       securityContext:
         runAsNonRoot: true

--- a/openbank-infra/gitops/components/fx-service/fx-opa-bundle.yaml
+++ b/openbank-infra/gitops/components/fx-service/fx-opa-bundle.yaml
@@ -9,7 +9,7 @@ metadata:
     app.kubernetes.io/name: fx-service
     app.kubernetes.io/part-of: fx
   annotations:
-    openbank.tech/policy-checksum: "99a6bf0cabab12e8"
+    openbank.tech/policy-checksum: "6f0be59e4e5ac0c7"
 data:
   rest.rego: |
     # SPDX-License-Identifier: Apache-2.0
@@ -2379,6 +2379,57 @@ data:
       # edge-service-notification rule and rest_test.rego's
       # test_deny_operator_read_any_does_not_cover_write).
       ci_producer: ".github/scripts/check-no-service-principal-type.sh"
+
+    # ---------------------------------------------------------------------------------------
+    # Scheduled-method invariants (issue #2148, fleet sweep #2187).
+    # ---------------------------------------------------------------------------------------
+    scheduled_methods:
+      no_runblocking_in_scheduled_body: true
+      # Quarkus invokes a plain (non-`suspend`) @Scheduled method on a bare `executor-thread`,
+      # which carries NO Vert.x context. A body of `runBlocking { … }` therefore runs the
+      # coroutine on that thread, and the first reactive Hibernate-Reactive/Panache call inside
+      # throws `HR000068: This method should exclusively be invoked from a Vert.x EventLoop
+      # thread`. The job aborts having done nothing, and does so silently — the throw lands
+      # before whatever per-item try/catch the job has, or is swallowed by its own outer catch
+      # into one ERROR line.
+      #
+      # Found live five times. #2148: StandingOrderExecutionScheduler.sweep() — no due standing
+      # order had EVER executed (PR #2180). The #2187 sweep then found the same shape in the
+      # daily sub-ledger tie-out control and the daily FX revaluation (ledger, PR #2190), the
+      # statutory ČNB fixing ingestion (fx, PR #2191) and the monthly billing cycle (PR #2194).
+      # None had ever run.
+      #
+      # This is a GATE and not a documented lesson because the natural test does not fail: a test
+      # that calls the method directly supplies a Vert.x context the scheduler does not, so it
+      # passes against the broken code — which is exactly how all five hid behind green suites.
+      # Regression coverage must drive the REAL cron via a @TestProfile that shrinks the cron
+      # expression (pattern: StandingOrderExecutionSweepIT, LedgerSchedulerVertxContextIT).
+      #
+      # FIX: make the method a `suspend fun` — Quarkus dispatches a suspending @Scheduled method
+      # on a proper (duplicated) Vert.x context. Unanimous fleet convention: every other reactive
+      # @Scheduled method here is `suspend` or returns `Uni`. Preferred over
+      # `VertxContextSupport.subscribeAndAwait`, which swaps one blocking bridge for another,
+      # pins the scheduler worker for the whole run, and throws if ever called FROM an event-loop
+      # thread (so it breaks the day the method gains @NonBlocking or a virtual thread).
+      #
+      # An entry below is a genuine exception, not a deferral: a service with no reactive
+      # persistence on its classpath at all, where `runBlocking` bridges deliberately BLOCKING
+      # clients and `suspend` would be the wrong change. Same individually-justified-exception
+      # idiom as the ktlint/detekt baselines and event_consumer_liveness.allowlist. A stale entry
+      # is itself a violation.
+      runblocking_allowlist:
+        - method: "openbank-agent-service/src/main/kotlin/com/openbank/agent/application/OversightService.kt#scheduledSweep"
+          reason: >-
+            agent-service has NO Hibernate Reactive on its classpath (build.gradle.kts: the
+            proposals store is plain Agroal JDBC, deliberately not the reactive stack). The sweep
+            drives blocking OPA/MCP/LLM clients and needs to stay on a worker thread — the same
+            bridge ChatEndpoint uses. `suspend` here would move blocking I/O onto an event loop.
+        - method: "openbank-analytics-sink/src/main/kotlin/com/openbank/analytics/infrastructure/reconcile/ReconciliationJob.kt#scheduled"
+          reason: >-
+            analytics-sink deliberately DROPS hibernate-reactive-panache, reactive-pg-client and
+            jdbc-postgresql (build.gradle.kts) — it has no OLTP datasource to reach. The
+            reconciliation reads the warehouse and the WORM archive over blocking clients.
+      ci_producer: ".github/scripts/check-no-runblocking-in-scheduled.py"
 
     # ---------------------------------------------------------------------------------------
     # Vulnerability-management lifecycle SLAs (ADR-0030 D1). Detection -> closure, in days.

--- a/openbank-infra/gitops/components/fx-service/fx-service.yaml
+++ b/openbank-infra/gitops/components/fx-service/fx-service.yaml
@@ -22,7 +22,7 @@ spec:
       annotations:
         # Rolls the pods when the OPA bundle changes — subPath mounts do NOT hot-reload.
         # Kept in sync by gen-fx-opa-bundle.sh (do not hand-edit).
-        openbank.tech/policy-checksum: "99a6bf0cabab12e8"
+        openbank.tech/policy-checksum: "6f0be59e4e5ac0c7"
     spec:
       securityContext:
         runAsNonRoot: true

--- a/openbank-infra/gitops/components/interest-service/interest-opa-bundle.yaml
+++ b/openbank-infra/gitops/components/interest-service/interest-opa-bundle.yaml
@@ -9,7 +9,7 @@ metadata:
     app.kubernetes.io/name: interest-service
     app.kubernetes.io/part-of: interest
   annotations:
-    openbank.tech/policy-checksum: "9aab218d292240fa"
+    openbank.tech/policy-checksum: "997bcf09bf094366"
 data:
   rest.rego: |
     # SPDX-License-Identifier: Apache-2.0
@@ -2313,6 +2313,57 @@ data:
       # edge-service-notification rule and rest_test.rego's
       # test_deny_operator_read_any_does_not_cover_write).
       ci_producer: ".github/scripts/check-no-service-principal-type.sh"
+
+    # ---------------------------------------------------------------------------------------
+    # Scheduled-method invariants (issue #2148, fleet sweep #2187).
+    # ---------------------------------------------------------------------------------------
+    scheduled_methods:
+      no_runblocking_in_scheduled_body: true
+      # Quarkus invokes a plain (non-`suspend`) @Scheduled method on a bare `executor-thread`,
+      # which carries NO Vert.x context. A body of `runBlocking { … }` therefore runs the
+      # coroutine on that thread, and the first reactive Hibernate-Reactive/Panache call inside
+      # throws `HR000068: This method should exclusively be invoked from a Vert.x EventLoop
+      # thread`. The job aborts having done nothing, and does so silently — the throw lands
+      # before whatever per-item try/catch the job has, or is swallowed by its own outer catch
+      # into one ERROR line.
+      #
+      # Found live five times. #2148: StandingOrderExecutionScheduler.sweep() — no due standing
+      # order had EVER executed (PR #2180). The #2187 sweep then found the same shape in the
+      # daily sub-ledger tie-out control and the daily FX revaluation (ledger, PR #2190), the
+      # statutory ČNB fixing ingestion (fx, PR #2191) and the monthly billing cycle (PR #2194).
+      # None had ever run.
+      #
+      # This is a GATE and not a documented lesson because the natural test does not fail: a test
+      # that calls the method directly supplies a Vert.x context the scheduler does not, so it
+      # passes against the broken code — which is exactly how all five hid behind green suites.
+      # Regression coverage must drive the REAL cron via a @TestProfile that shrinks the cron
+      # expression (pattern: StandingOrderExecutionSweepIT, LedgerSchedulerVertxContextIT).
+      #
+      # FIX: make the method a `suspend fun` — Quarkus dispatches a suspending @Scheduled method
+      # on a proper (duplicated) Vert.x context. Unanimous fleet convention: every other reactive
+      # @Scheduled method here is `suspend` or returns `Uni`. Preferred over
+      # `VertxContextSupport.subscribeAndAwait`, which swaps one blocking bridge for another,
+      # pins the scheduler worker for the whole run, and throws if ever called FROM an event-loop
+      # thread (so it breaks the day the method gains @NonBlocking or a virtual thread).
+      #
+      # An entry below is a genuine exception, not a deferral: a service with no reactive
+      # persistence on its classpath at all, where `runBlocking` bridges deliberately BLOCKING
+      # clients and `suspend` would be the wrong change. Same individually-justified-exception
+      # idiom as the ktlint/detekt baselines and event_consumer_liveness.allowlist. A stale entry
+      # is itself a violation.
+      runblocking_allowlist:
+        - method: "openbank-agent-service/src/main/kotlin/com/openbank/agent/application/OversightService.kt#scheduledSweep"
+          reason: >-
+            agent-service has NO Hibernate Reactive on its classpath (build.gradle.kts: the
+            proposals store is plain Agroal JDBC, deliberately not the reactive stack). The sweep
+            drives blocking OPA/MCP/LLM clients and needs to stay on a worker thread — the same
+            bridge ChatEndpoint uses. `suspend` here would move blocking I/O onto an event loop.
+        - method: "openbank-analytics-sink/src/main/kotlin/com/openbank/analytics/infrastructure/reconcile/ReconciliationJob.kt#scheduled"
+          reason: >-
+            analytics-sink deliberately DROPS hibernate-reactive-panache, reactive-pg-client and
+            jdbc-postgresql (build.gradle.kts) — it has no OLTP datasource to reach. The
+            reconciliation reads the warehouse and the WORM archive over blocking clients.
+      ci_producer: ".github/scripts/check-no-runblocking-in-scheduled.py"
 
     # ---------------------------------------------------------------------------------------
     # Vulnerability-management lifecycle SLAs (ADR-0030 D1). Detection -> closure, in days.

--- a/openbank-infra/gitops/components/interest-service/interest-service.yaml
+++ b/openbank-infra/gitops/components/interest-service/interest-service.yaml
@@ -16,7 +16,7 @@ spec:
       annotations:
         # Rolls the pods when the OPA bundle changes — subPath mounts do NOT hot-reload.
         # Kept in sync by gen-interest-opa-bundle.sh (do not hand-edit).
-        openbank.tech/policy-checksum: "9aab218d292240fa"
+        openbank.tech/policy-checksum: "997bcf09bf094366"
     spec:
       securityContext:
         runAsNonRoot: true

--- a/openbank-infra/gitops/components/ledger/ledger-opa-bundle.yaml
+++ b/openbank-infra/gitops/components/ledger/ledger-opa-bundle.yaml
@@ -9,7 +9,7 @@ metadata:
     app.kubernetes.io/name: ledger-service
     app.kubernetes.io/part-of: ledger
   annotations:
-    openbank.tech/policy-checksum: "12a6e3bd17a9ab85"
+    openbank.tech/policy-checksum: "bb82a10437468998"
 data:
   rest.rego: |
     # SPDX-License-Identifier: Apache-2.0
@@ -2426,6 +2426,57 @@ data:
       # edge-service-notification rule and rest_test.rego's
       # test_deny_operator_read_any_does_not_cover_write).
       ci_producer: ".github/scripts/check-no-service-principal-type.sh"
+
+    # ---------------------------------------------------------------------------------------
+    # Scheduled-method invariants (issue #2148, fleet sweep #2187).
+    # ---------------------------------------------------------------------------------------
+    scheduled_methods:
+      no_runblocking_in_scheduled_body: true
+      # Quarkus invokes a plain (non-`suspend`) @Scheduled method on a bare `executor-thread`,
+      # which carries NO Vert.x context. A body of `runBlocking { … }` therefore runs the
+      # coroutine on that thread, and the first reactive Hibernate-Reactive/Panache call inside
+      # throws `HR000068: This method should exclusively be invoked from a Vert.x EventLoop
+      # thread`. The job aborts having done nothing, and does so silently — the throw lands
+      # before whatever per-item try/catch the job has, or is swallowed by its own outer catch
+      # into one ERROR line.
+      #
+      # Found live five times. #2148: StandingOrderExecutionScheduler.sweep() — no due standing
+      # order had EVER executed (PR #2180). The #2187 sweep then found the same shape in the
+      # daily sub-ledger tie-out control and the daily FX revaluation (ledger, PR #2190), the
+      # statutory ČNB fixing ingestion (fx, PR #2191) and the monthly billing cycle (PR #2194).
+      # None had ever run.
+      #
+      # This is a GATE and not a documented lesson because the natural test does not fail: a test
+      # that calls the method directly supplies a Vert.x context the scheduler does not, so it
+      # passes against the broken code — which is exactly how all five hid behind green suites.
+      # Regression coverage must drive the REAL cron via a @TestProfile that shrinks the cron
+      # expression (pattern: StandingOrderExecutionSweepIT, LedgerSchedulerVertxContextIT).
+      #
+      # FIX: make the method a `suspend fun` — Quarkus dispatches a suspending @Scheduled method
+      # on a proper (duplicated) Vert.x context. Unanimous fleet convention: every other reactive
+      # @Scheduled method here is `suspend` or returns `Uni`. Preferred over
+      # `VertxContextSupport.subscribeAndAwait`, which swaps one blocking bridge for another,
+      # pins the scheduler worker for the whole run, and throws if ever called FROM an event-loop
+      # thread (so it breaks the day the method gains @NonBlocking or a virtual thread).
+      #
+      # An entry below is a genuine exception, not a deferral: a service with no reactive
+      # persistence on its classpath at all, where `runBlocking` bridges deliberately BLOCKING
+      # clients and `suspend` would be the wrong change. Same individually-justified-exception
+      # idiom as the ktlint/detekt baselines and event_consumer_liveness.allowlist. A stale entry
+      # is itself a violation.
+      runblocking_allowlist:
+        - method: "openbank-agent-service/src/main/kotlin/com/openbank/agent/application/OversightService.kt#scheduledSweep"
+          reason: >-
+            agent-service has NO Hibernate Reactive on its classpath (build.gradle.kts: the
+            proposals store is plain Agroal JDBC, deliberately not the reactive stack). The sweep
+            drives blocking OPA/MCP/LLM clients and needs to stay on a worker thread — the same
+            bridge ChatEndpoint uses. `suspend` here would move blocking I/O onto an event loop.
+        - method: "openbank-analytics-sink/src/main/kotlin/com/openbank/analytics/infrastructure/reconcile/ReconciliationJob.kt#scheduled"
+          reason: >-
+            analytics-sink deliberately DROPS hibernate-reactive-panache, reactive-pg-client and
+            jdbc-postgresql (build.gradle.kts) — it has no OLTP datasource to reach. The
+            reconciliation reads the warehouse and the WORM archive over blocking clients.
+      ci_producer: ".github/scripts/check-no-runblocking-in-scheduled.py"
 
     # ---------------------------------------------------------------------------------------
     # Vulnerability-management lifecycle SLAs (ADR-0030 D1). Detection -> closure, in days.

--- a/openbank-infra/gitops/components/ledger/ledger-service.yaml
+++ b/openbank-infra/gitops/components/ledger/ledger-service.yaml
@@ -38,7 +38,7 @@ spec:
       annotations:
         # Rolls the pods when the OPA bundle changes — subPath mounts do NOT hot-reload.
         # Kept in sync by gen-ledger-opa-bundle.sh (do not hand-edit).
-        openbank.tech/policy-checksum: "12a6e3bd17a9ab85"
+        openbank.tech/policy-checksum: "bb82a10437468998"
     spec:
       securityContext:
         runAsNonRoot: true

--- a/openbank-infra/gitops/components/lending/lending-opa-bundle.yaml
+++ b/openbank-infra/gitops/components/lending/lending-opa-bundle.yaml
@@ -9,7 +9,7 @@ metadata:
     app.kubernetes.io/name: lending-service
     app.kubernetes.io/part-of: lending
   annotations:
-    openbank.tech/policy-checksum: "41d7e8977189b60a"
+    openbank.tech/policy-checksum: "b2107ed031e9fcf6"
 data:
   rest.rego: |
     # SPDX-License-Identifier: Apache-2.0
@@ -2381,6 +2381,57 @@ data:
       # edge-service-notification rule and rest_test.rego's
       # test_deny_operator_read_any_does_not_cover_write).
       ci_producer: ".github/scripts/check-no-service-principal-type.sh"
+
+    # ---------------------------------------------------------------------------------------
+    # Scheduled-method invariants (issue #2148, fleet sweep #2187).
+    # ---------------------------------------------------------------------------------------
+    scheduled_methods:
+      no_runblocking_in_scheduled_body: true
+      # Quarkus invokes a plain (non-`suspend`) @Scheduled method on a bare `executor-thread`,
+      # which carries NO Vert.x context. A body of `runBlocking { … }` therefore runs the
+      # coroutine on that thread, and the first reactive Hibernate-Reactive/Panache call inside
+      # throws `HR000068: This method should exclusively be invoked from a Vert.x EventLoop
+      # thread`. The job aborts having done nothing, and does so silently — the throw lands
+      # before whatever per-item try/catch the job has, or is swallowed by its own outer catch
+      # into one ERROR line.
+      #
+      # Found live five times. #2148: StandingOrderExecutionScheduler.sweep() — no due standing
+      # order had EVER executed (PR #2180). The #2187 sweep then found the same shape in the
+      # daily sub-ledger tie-out control and the daily FX revaluation (ledger, PR #2190), the
+      # statutory ČNB fixing ingestion (fx, PR #2191) and the monthly billing cycle (PR #2194).
+      # None had ever run.
+      #
+      # This is a GATE and not a documented lesson because the natural test does not fail: a test
+      # that calls the method directly supplies a Vert.x context the scheduler does not, so it
+      # passes against the broken code — which is exactly how all five hid behind green suites.
+      # Regression coverage must drive the REAL cron via a @TestProfile that shrinks the cron
+      # expression (pattern: StandingOrderExecutionSweepIT, LedgerSchedulerVertxContextIT).
+      #
+      # FIX: make the method a `suspend fun` — Quarkus dispatches a suspending @Scheduled method
+      # on a proper (duplicated) Vert.x context. Unanimous fleet convention: every other reactive
+      # @Scheduled method here is `suspend` or returns `Uni`. Preferred over
+      # `VertxContextSupport.subscribeAndAwait`, which swaps one blocking bridge for another,
+      # pins the scheduler worker for the whole run, and throws if ever called FROM an event-loop
+      # thread (so it breaks the day the method gains @NonBlocking or a virtual thread).
+      #
+      # An entry below is a genuine exception, not a deferral: a service with no reactive
+      # persistence on its classpath at all, where `runBlocking` bridges deliberately BLOCKING
+      # clients and `suspend` would be the wrong change. Same individually-justified-exception
+      # idiom as the ktlint/detekt baselines and event_consumer_liveness.allowlist. A stale entry
+      # is itself a violation.
+      runblocking_allowlist:
+        - method: "openbank-agent-service/src/main/kotlin/com/openbank/agent/application/OversightService.kt#scheduledSweep"
+          reason: >-
+            agent-service has NO Hibernate Reactive on its classpath (build.gradle.kts: the
+            proposals store is plain Agroal JDBC, deliberately not the reactive stack). The sweep
+            drives blocking OPA/MCP/LLM clients and needs to stay on a worker thread — the same
+            bridge ChatEndpoint uses. `suspend` here would move blocking I/O onto an event loop.
+        - method: "openbank-analytics-sink/src/main/kotlin/com/openbank/analytics/infrastructure/reconcile/ReconciliationJob.kt#scheduled"
+          reason: >-
+            analytics-sink deliberately DROPS hibernate-reactive-panache, reactive-pg-client and
+            jdbc-postgresql (build.gradle.kts) — it has no OLTP datasource to reach. The
+            reconciliation reads the warehouse and the WORM archive over blocking clients.
+      ci_producer: ".github/scripts/check-no-runblocking-in-scheduled.py"
 
     # ---------------------------------------------------------------------------------------
     # Vulnerability-management lifecycle SLAs (ADR-0030 D1). Detection -> closure, in days.

--- a/openbank-infra/gitops/components/lending/lending-service.yaml
+++ b/openbank-infra/gitops/components/lending/lending-service.yaml
@@ -34,7 +34,7 @@ spec:
       annotations:
         # Rolls the pods when the OPA bundle changes — subPath mounts do NOT hot-reload.
         # Kept in sync by gen-lending-opa-bundle.sh (do not hand-edit).
-        openbank.tech/policy-checksum: "41d7e8977189b60a"
+        openbank.tech/policy-checksum: "b2107ed031e9fcf6"
     spec:
       securityContext:
         runAsNonRoot: true

--- a/openbank-infra/gitops/components/mcp/mcp-opa-bundle.yaml
+++ b/openbank-infra/gitops/components/mcp/mcp-opa-bundle.yaml
@@ -9,7 +9,7 @@ metadata:
     app.kubernetes.io/name: mcp-service
     app.kubernetes.io/part-of: platform
   annotations:
-    openbank.tech/policy-checksum: "f914896e8577af47"
+    openbank.tech/policy-checksum: "e57e6df81c829864"
 data:
   rest.rego: |
     # SPDX-License-Identifier: Apache-2.0
@@ -2279,6 +2279,57 @@ data:
       # edge-service-notification rule and rest_test.rego's
       # test_deny_operator_read_any_does_not_cover_write).
       ci_producer: ".github/scripts/check-no-service-principal-type.sh"
+
+    # ---------------------------------------------------------------------------------------
+    # Scheduled-method invariants (issue #2148, fleet sweep #2187).
+    # ---------------------------------------------------------------------------------------
+    scheduled_methods:
+      no_runblocking_in_scheduled_body: true
+      # Quarkus invokes a plain (non-`suspend`) @Scheduled method on a bare `executor-thread`,
+      # which carries NO Vert.x context. A body of `runBlocking { … }` therefore runs the
+      # coroutine on that thread, and the first reactive Hibernate-Reactive/Panache call inside
+      # throws `HR000068: This method should exclusively be invoked from a Vert.x EventLoop
+      # thread`. The job aborts having done nothing, and does so silently — the throw lands
+      # before whatever per-item try/catch the job has, or is swallowed by its own outer catch
+      # into one ERROR line.
+      #
+      # Found live five times. #2148: StandingOrderExecutionScheduler.sweep() — no due standing
+      # order had EVER executed (PR #2180). The #2187 sweep then found the same shape in the
+      # daily sub-ledger tie-out control and the daily FX revaluation (ledger, PR #2190), the
+      # statutory ČNB fixing ingestion (fx, PR #2191) and the monthly billing cycle (PR #2194).
+      # None had ever run.
+      #
+      # This is a GATE and not a documented lesson because the natural test does not fail: a test
+      # that calls the method directly supplies a Vert.x context the scheduler does not, so it
+      # passes against the broken code — which is exactly how all five hid behind green suites.
+      # Regression coverage must drive the REAL cron via a @TestProfile that shrinks the cron
+      # expression (pattern: StandingOrderExecutionSweepIT, LedgerSchedulerVertxContextIT).
+      #
+      # FIX: make the method a `suspend fun` — Quarkus dispatches a suspending @Scheduled method
+      # on a proper (duplicated) Vert.x context. Unanimous fleet convention: every other reactive
+      # @Scheduled method here is `suspend` or returns `Uni`. Preferred over
+      # `VertxContextSupport.subscribeAndAwait`, which swaps one blocking bridge for another,
+      # pins the scheduler worker for the whole run, and throws if ever called FROM an event-loop
+      # thread (so it breaks the day the method gains @NonBlocking or a virtual thread).
+      #
+      # An entry below is a genuine exception, not a deferral: a service with no reactive
+      # persistence on its classpath at all, where `runBlocking` bridges deliberately BLOCKING
+      # clients and `suspend` would be the wrong change. Same individually-justified-exception
+      # idiom as the ktlint/detekt baselines and event_consumer_liveness.allowlist. A stale entry
+      # is itself a violation.
+      runblocking_allowlist:
+        - method: "openbank-agent-service/src/main/kotlin/com/openbank/agent/application/OversightService.kt#scheduledSweep"
+          reason: >-
+            agent-service has NO Hibernate Reactive on its classpath (build.gradle.kts: the
+            proposals store is plain Agroal JDBC, deliberately not the reactive stack). The sweep
+            drives blocking OPA/MCP/LLM clients and needs to stay on a worker thread — the same
+            bridge ChatEndpoint uses. `suspend` here would move blocking I/O onto an event loop.
+        - method: "openbank-analytics-sink/src/main/kotlin/com/openbank/analytics/infrastructure/reconcile/ReconciliationJob.kt#scheduled"
+          reason: >-
+            analytics-sink deliberately DROPS hibernate-reactive-panache, reactive-pg-client and
+            jdbc-postgresql (build.gradle.kts) — it has no OLTP datasource to reach. The
+            reconciliation reads the warehouse and the WORM archive over blocking clients.
+      ci_producer: ".github/scripts/check-no-runblocking-in-scheduled.py"
 
     # ---------------------------------------------------------------------------------------
     # Vulnerability-management lifecycle SLAs (ADR-0030 D1). Detection -> closure, in days.

--- a/openbank-infra/gitops/components/mcp/mcp-service.yaml
+++ b/openbank-infra/gitops/components/mcp/mcp-service.yaml
@@ -29,7 +29,7 @@ spec:
       annotations:
         # Rolls the pod when the OPA bundle changes — subPath mounts do NOT hot-reload.
         # Kept in sync by gen-mcp-opa-bundle.sh (do not hand-edit).
-        openbank.tech/policy-checksum: "f914896e8577af47"
+        openbank.tech/policy-checksum: "e57e6df81c829864"
     spec:
       securityContext:
         runAsNonRoot: true

--- a/openbank-infra/gitops/components/notifications/notification-service-opa-bundle.yaml
+++ b/openbank-infra/gitops/components/notifications/notification-service-opa-bundle.yaml
@@ -10,7 +10,7 @@ metadata:
     app.kubernetes.io/name: notification-service
     app.kubernetes.io/part-of: notifications
   annotations:
-    openbank.tech/policy-checksum: "b98b878286dda238"
+    openbank.tech/policy-checksum: "e686dc210d1bc4a8"
 data:
   rest.rego: |
     # SPDX-License-Identifier: Apache-2.0
@@ -1531,6 +1531,57 @@ data:
       # edge-service-notification rule and rest_test.rego's
       # test_deny_operator_read_any_does_not_cover_write).
       ci_producer: ".github/scripts/check-no-service-principal-type.sh"
+
+    # ---------------------------------------------------------------------------------------
+    # Scheduled-method invariants (issue #2148, fleet sweep #2187).
+    # ---------------------------------------------------------------------------------------
+    scheduled_methods:
+      no_runblocking_in_scheduled_body: true
+      # Quarkus invokes a plain (non-`suspend`) @Scheduled method on a bare `executor-thread`,
+      # which carries NO Vert.x context. A body of `runBlocking { … }` therefore runs the
+      # coroutine on that thread, and the first reactive Hibernate-Reactive/Panache call inside
+      # throws `HR000068: This method should exclusively be invoked from a Vert.x EventLoop
+      # thread`. The job aborts having done nothing, and does so silently — the throw lands
+      # before whatever per-item try/catch the job has, or is swallowed by its own outer catch
+      # into one ERROR line.
+      #
+      # Found live five times. #2148: StandingOrderExecutionScheduler.sweep() — no due standing
+      # order had EVER executed (PR #2180). The #2187 sweep then found the same shape in the
+      # daily sub-ledger tie-out control and the daily FX revaluation (ledger, PR #2190), the
+      # statutory ČNB fixing ingestion (fx, PR #2191) and the monthly billing cycle (PR #2194).
+      # None had ever run.
+      #
+      # This is a GATE and not a documented lesson because the natural test does not fail: a test
+      # that calls the method directly supplies a Vert.x context the scheduler does not, so it
+      # passes against the broken code — which is exactly how all five hid behind green suites.
+      # Regression coverage must drive the REAL cron via a @TestProfile that shrinks the cron
+      # expression (pattern: StandingOrderExecutionSweepIT, LedgerSchedulerVertxContextIT).
+      #
+      # FIX: make the method a `suspend fun` — Quarkus dispatches a suspending @Scheduled method
+      # on a proper (duplicated) Vert.x context. Unanimous fleet convention: every other reactive
+      # @Scheduled method here is `suspend` or returns `Uni`. Preferred over
+      # `VertxContextSupport.subscribeAndAwait`, which swaps one blocking bridge for another,
+      # pins the scheduler worker for the whole run, and throws if ever called FROM an event-loop
+      # thread (so it breaks the day the method gains @NonBlocking or a virtual thread).
+      #
+      # An entry below is a genuine exception, not a deferral: a service with no reactive
+      # persistence on its classpath at all, where `runBlocking` bridges deliberately BLOCKING
+      # clients and `suspend` would be the wrong change. Same individually-justified-exception
+      # idiom as the ktlint/detekt baselines and event_consumer_liveness.allowlist. A stale entry
+      # is itself a violation.
+      runblocking_allowlist:
+        - method: "openbank-agent-service/src/main/kotlin/com/openbank/agent/application/OversightService.kt#scheduledSweep"
+          reason: >-
+            agent-service has NO Hibernate Reactive on its classpath (build.gradle.kts: the
+            proposals store is plain Agroal JDBC, deliberately not the reactive stack). The sweep
+            drives blocking OPA/MCP/LLM clients and needs to stay on a worker thread — the same
+            bridge ChatEndpoint uses. `suspend` here would move blocking I/O onto an event loop.
+        - method: "openbank-analytics-sink/src/main/kotlin/com/openbank/analytics/infrastructure/reconcile/ReconciliationJob.kt#scheduled"
+          reason: >-
+            analytics-sink deliberately DROPS hibernate-reactive-panache, reactive-pg-client and
+            jdbc-postgresql (build.gradle.kts) — it has no OLTP datasource to reach. The
+            reconciliation reads the warehouse and the WORM archive over blocking clients.
+      ci_producer: ".github/scripts/check-no-runblocking-in-scheduled.py"
 
     # ---------------------------------------------------------------------------------------
     # Vulnerability-management lifecycle SLAs (ADR-0030 D1). Detection -> closure, in days.

--- a/openbank-infra/gitops/components/notifications/notification-service.yaml
+++ b/openbank-infra/gitops/components/notifications/notification-service.yaml
@@ -39,7 +39,7 @@ spec:
       annotations:
         # Rolls the Deployment when the OPA policy bundle changes (subPath mounts don't
         # hot-reload). Kept in sync by gen-notification-opa-bundle.sh.
-        openbank.tech/policy-checksum: "b98b878286dda238"
+        openbank.tech/policy-checksum: "e686dc210d1bc4a8"
       labels:
         app.kubernetes.io/name: notification-service
         app.kubernetes.io/part-of: notifications

--- a/openbank-infra/gitops/components/party/party-opa-bundle.yaml
+++ b/openbank-infra/gitops/components/party/party-opa-bundle.yaml
@@ -9,7 +9,7 @@ metadata:
     app.kubernetes.io/name: party-service
     app.kubernetes.io/part-of: party
   annotations:
-    openbank.tech/policy-checksum: "766f973c1e111629"
+    openbank.tech/policy-checksum: "b2041240ec63e511"
 data:
   rest.rego: |
     # SPDX-License-Identifier: Apache-2.0
@@ -2350,6 +2350,57 @@ data:
       # edge-service-notification rule and rest_test.rego's
       # test_deny_operator_read_any_does_not_cover_write).
       ci_producer: ".github/scripts/check-no-service-principal-type.sh"
+
+    # ---------------------------------------------------------------------------------------
+    # Scheduled-method invariants (issue #2148, fleet sweep #2187).
+    # ---------------------------------------------------------------------------------------
+    scheduled_methods:
+      no_runblocking_in_scheduled_body: true
+      # Quarkus invokes a plain (non-`suspend`) @Scheduled method on a bare `executor-thread`,
+      # which carries NO Vert.x context. A body of `runBlocking { … }` therefore runs the
+      # coroutine on that thread, and the first reactive Hibernate-Reactive/Panache call inside
+      # throws `HR000068: This method should exclusively be invoked from a Vert.x EventLoop
+      # thread`. The job aborts having done nothing, and does so silently — the throw lands
+      # before whatever per-item try/catch the job has, or is swallowed by its own outer catch
+      # into one ERROR line.
+      #
+      # Found live five times. #2148: StandingOrderExecutionScheduler.sweep() — no due standing
+      # order had EVER executed (PR #2180). The #2187 sweep then found the same shape in the
+      # daily sub-ledger tie-out control and the daily FX revaluation (ledger, PR #2190), the
+      # statutory ČNB fixing ingestion (fx, PR #2191) and the monthly billing cycle (PR #2194).
+      # None had ever run.
+      #
+      # This is a GATE and not a documented lesson because the natural test does not fail: a test
+      # that calls the method directly supplies a Vert.x context the scheduler does not, so it
+      # passes against the broken code — which is exactly how all five hid behind green suites.
+      # Regression coverage must drive the REAL cron via a @TestProfile that shrinks the cron
+      # expression (pattern: StandingOrderExecutionSweepIT, LedgerSchedulerVertxContextIT).
+      #
+      # FIX: make the method a `suspend fun` — Quarkus dispatches a suspending @Scheduled method
+      # on a proper (duplicated) Vert.x context. Unanimous fleet convention: every other reactive
+      # @Scheduled method here is `suspend` or returns `Uni`. Preferred over
+      # `VertxContextSupport.subscribeAndAwait`, which swaps one blocking bridge for another,
+      # pins the scheduler worker for the whole run, and throws if ever called FROM an event-loop
+      # thread (so it breaks the day the method gains @NonBlocking or a virtual thread).
+      #
+      # An entry below is a genuine exception, not a deferral: a service with no reactive
+      # persistence on its classpath at all, where `runBlocking` bridges deliberately BLOCKING
+      # clients and `suspend` would be the wrong change. Same individually-justified-exception
+      # idiom as the ktlint/detekt baselines and event_consumer_liveness.allowlist. A stale entry
+      # is itself a violation.
+      runblocking_allowlist:
+        - method: "openbank-agent-service/src/main/kotlin/com/openbank/agent/application/OversightService.kt#scheduledSweep"
+          reason: >-
+            agent-service has NO Hibernate Reactive on its classpath (build.gradle.kts: the
+            proposals store is plain Agroal JDBC, deliberately not the reactive stack). The sweep
+            drives blocking OPA/MCP/LLM clients and needs to stay on a worker thread — the same
+            bridge ChatEndpoint uses. `suspend` here would move blocking I/O onto an event loop.
+        - method: "openbank-analytics-sink/src/main/kotlin/com/openbank/analytics/infrastructure/reconcile/ReconciliationJob.kt#scheduled"
+          reason: >-
+            analytics-sink deliberately DROPS hibernate-reactive-panache, reactive-pg-client and
+            jdbc-postgresql (build.gradle.kts) — it has no OLTP datasource to reach. The
+            reconciliation reads the warehouse and the WORM archive over blocking clients.
+      ci_producer: ".github/scripts/check-no-runblocking-in-scheduled.py"
 
     # ---------------------------------------------------------------------------------------
     # Vulnerability-management lifecycle SLAs (ADR-0030 D1). Detection -> closure, in days.

--- a/openbank-infra/gitops/components/party/party-service.yaml
+++ b/openbank-infra/gitops/components/party/party-service.yaml
@@ -22,7 +22,7 @@ spec:
       annotations:
         # Rolls the pod when the OPA bundle changes — subPath mounts do NOT hot-reload.
         # Kept in sync by gen-party-opa-bundle.sh (do not hand-edit).
-        openbank.tech/policy-checksum: "766f973c1e111629"
+        openbank.tech/policy-checksum: "b2041240ec63e511"
       labels:
         app.kubernetes.io/name: party-service
         app.kubernetes.io/part-of: party

--- a/openbank-infra/gitops/components/payments/card-issuance-opa-bundle.yaml
+++ b/openbank-infra/gitops/components/payments/card-issuance-opa-bundle.yaml
@@ -9,7 +9,7 @@ metadata:
     app.kubernetes.io/name: card-issuance-service
     app.kubernetes.io/part-of: payments
   annotations:
-    openbank.tech/policy-checksum: "b7dceb20eedf8ae4"
+    openbank.tech/policy-checksum: "9b725eb23441aee5"
 data:
   rest.rego: |
     # SPDX-License-Identifier: Apache-2.0
@@ -2334,6 +2334,57 @@ data:
       # edge-service-notification rule and rest_test.rego's
       # test_deny_operator_read_any_does_not_cover_write).
       ci_producer: ".github/scripts/check-no-service-principal-type.sh"
+
+    # ---------------------------------------------------------------------------------------
+    # Scheduled-method invariants (issue #2148, fleet sweep #2187).
+    # ---------------------------------------------------------------------------------------
+    scheduled_methods:
+      no_runblocking_in_scheduled_body: true
+      # Quarkus invokes a plain (non-`suspend`) @Scheduled method on a bare `executor-thread`,
+      # which carries NO Vert.x context. A body of `runBlocking { … }` therefore runs the
+      # coroutine on that thread, and the first reactive Hibernate-Reactive/Panache call inside
+      # throws `HR000068: This method should exclusively be invoked from a Vert.x EventLoop
+      # thread`. The job aborts having done nothing, and does so silently — the throw lands
+      # before whatever per-item try/catch the job has, or is swallowed by its own outer catch
+      # into one ERROR line.
+      #
+      # Found live five times. #2148: StandingOrderExecutionScheduler.sweep() — no due standing
+      # order had EVER executed (PR #2180). The #2187 sweep then found the same shape in the
+      # daily sub-ledger tie-out control and the daily FX revaluation (ledger, PR #2190), the
+      # statutory ČNB fixing ingestion (fx, PR #2191) and the monthly billing cycle (PR #2194).
+      # None had ever run.
+      #
+      # This is a GATE and not a documented lesson because the natural test does not fail: a test
+      # that calls the method directly supplies a Vert.x context the scheduler does not, so it
+      # passes against the broken code — which is exactly how all five hid behind green suites.
+      # Regression coverage must drive the REAL cron via a @TestProfile that shrinks the cron
+      # expression (pattern: StandingOrderExecutionSweepIT, LedgerSchedulerVertxContextIT).
+      #
+      # FIX: make the method a `suspend fun` — Quarkus dispatches a suspending @Scheduled method
+      # on a proper (duplicated) Vert.x context. Unanimous fleet convention: every other reactive
+      # @Scheduled method here is `suspend` or returns `Uni`. Preferred over
+      # `VertxContextSupport.subscribeAndAwait`, which swaps one blocking bridge for another,
+      # pins the scheduler worker for the whole run, and throws if ever called FROM an event-loop
+      # thread (so it breaks the day the method gains @NonBlocking or a virtual thread).
+      #
+      # An entry below is a genuine exception, not a deferral: a service with no reactive
+      # persistence on its classpath at all, where `runBlocking` bridges deliberately BLOCKING
+      # clients and `suspend` would be the wrong change. Same individually-justified-exception
+      # idiom as the ktlint/detekt baselines and event_consumer_liveness.allowlist. A stale entry
+      # is itself a violation.
+      runblocking_allowlist:
+        - method: "openbank-agent-service/src/main/kotlin/com/openbank/agent/application/OversightService.kt#scheduledSweep"
+          reason: >-
+            agent-service has NO Hibernate Reactive on its classpath (build.gradle.kts: the
+            proposals store is plain Agroal JDBC, deliberately not the reactive stack). The sweep
+            drives blocking OPA/MCP/LLM clients and needs to stay on a worker thread — the same
+            bridge ChatEndpoint uses. `suspend` here would move blocking I/O onto an event loop.
+        - method: "openbank-analytics-sink/src/main/kotlin/com/openbank/analytics/infrastructure/reconcile/ReconciliationJob.kt#scheduled"
+          reason: >-
+            analytics-sink deliberately DROPS hibernate-reactive-panache, reactive-pg-client and
+            jdbc-postgresql (build.gradle.kts) — it has no OLTP datasource to reach. The
+            reconciliation reads the warehouse and the WORM archive over blocking clients.
+      ci_producer: ".github/scripts/check-no-runblocking-in-scheduled.py"
 
     # ---------------------------------------------------------------------------------------
     # Vulnerability-management lifecycle SLAs (ADR-0030 D1). Detection -> closure, in days.

--- a/openbank-infra/gitops/components/payments/clearing-opa-bundle.yaml
+++ b/openbank-infra/gitops/components/payments/clearing-opa-bundle.yaml
@@ -9,7 +9,7 @@ metadata:
     app.kubernetes.io/name: clearing-service
     app.kubernetes.io/part-of: payments
   annotations:
-    openbank.tech/policy-checksum: "997c3cb4e4aa33e8"
+    openbank.tech/policy-checksum: "671aac9749347129"
 data:
   rest.rego: |
     # SPDX-License-Identifier: Apache-2.0
@@ -2371,6 +2371,57 @@ data:
       # edge-service-notification rule and rest_test.rego's
       # test_deny_operator_read_any_does_not_cover_write).
       ci_producer: ".github/scripts/check-no-service-principal-type.sh"
+
+    # ---------------------------------------------------------------------------------------
+    # Scheduled-method invariants (issue #2148, fleet sweep #2187).
+    # ---------------------------------------------------------------------------------------
+    scheduled_methods:
+      no_runblocking_in_scheduled_body: true
+      # Quarkus invokes a plain (non-`suspend`) @Scheduled method on a bare `executor-thread`,
+      # which carries NO Vert.x context. A body of `runBlocking { … }` therefore runs the
+      # coroutine on that thread, and the first reactive Hibernate-Reactive/Panache call inside
+      # throws `HR000068: This method should exclusively be invoked from a Vert.x EventLoop
+      # thread`. The job aborts having done nothing, and does so silently — the throw lands
+      # before whatever per-item try/catch the job has, or is swallowed by its own outer catch
+      # into one ERROR line.
+      #
+      # Found live five times. #2148: StandingOrderExecutionScheduler.sweep() — no due standing
+      # order had EVER executed (PR #2180). The #2187 sweep then found the same shape in the
+      # daily sub-ledger tie-out control and the daily FX revaluation (ledger, PR #2190), the
+      # statutory ČNB fixing ingestion (fx, PR #2191) and the monthly billing cycle (PR #2194).
+      # None had ever run.
+      #
+      # This is a GATE and not a documented lesson because the natural test does not fail: a test
+      # that calls the method directly supplies a Vert.x context the scheduler does not, so it
+      # passes against the broken code — which is exactly how all five hid behind green suites.
+      # Regression coverage must drive the REAL cron via a @TestProfile that shrinks the cron
+      # expression (pattern: StandingOrderExecutionSweepIT, LedgerSchedulerVertxContextIT).
+      #
+      # FIX: make the method a `suspend fun` — Quarkus dispatches a suspending @Scheduled method
+      # on a proper (duplicated) Vert.x context. Unanimous fleet convention: every other reactive
+      # @Scheduled method here is `suspend` or returns `Uni`. Preferred over
+      # `VertxContextSupport.subscribeAndAwait`, which swaps one blocking bridge for another,
+      # pins the scheduler worker for the whole run, and throws if ever called FROM an event-loop
+      # thread (so it breaks the day the method gains @NonBlocking or a virtual thread).
+      #
+      # An entry below is a genuine exception, not a deferral: a service with no reactive
+      # persistence on its classpath at all, where `runBlocking` bridges deliberately BLOCKING
+      # clients and `suspend` would be the wrong change. Same individually-justified-exception
+      # idiom as the ktlint/detekt baselines and event_consumer_liveness.allowlist. A stale entry
+      # is itself a violation.
+      runblocking_allowlist:
+        - method: "openbank-agent-service/src/main/kotlin/com/openbank/agent/application/OversightService.kt#scheduledSweep"
+          reason: >-
+            agent-service has NO Hibernate Reactive on its classpath (build.gradle.kts: the
+            proposals store is plain Agroal JDBC, deliberately not the reactive stack). The sweep
+            drives blocking OPA/MCP/LLM clients and needs to stay on a worker thread — the same
+            bridge ChatEndpoint uses. `suspend` here would move blocking I/O onto an event loop.
+        - method: "openbank-analytics-sink/src/main/kotlin/com/openbank/analytics/infrastructure/reconcile/ReconciliationJob.kt#scheduled"
+          reason: >-
+            analytics-sink deliberately DROPS hibernate-reactive-panache, reactive-pg-client and
+            jdbc-postgresql (build.gradle.kts) — it has no OLTP datasource to reach. The
+            reconciliation reads the warehouse and the WORM archive over blocking clients.
+      ci_producer: ".github/scripts/check-no-runblocking-in-scheduled.py"
 
     # ---------------------------------------------------------------------------------------
     # Vulnerability-management lifecycle SLAs (ADR-0030 D1). Detection -> closure, in days.

--- a/openbank-infra/gitops/components/payments/domestic-payment-opa-bundle.yaml
+++ b/openbank-infra/gitops/components/payments/domestic-payment-opa-bundle.yaml
@@ -9,7 +9,7 @@ metadata:
     app.kubernetes.io/name: domestic-payment
     app.kubernetes.io/part-of: payments
   annotations:
-    openbank.tech/policy-checksum: "d66f7755e7696b5a"
+    openbank.tech/policy-checksum: "8412bbd9aa1eb939"
 data:
   rest.rego: |
     # SPDX-License-Identifier: Apache-2.0
@@ -2356,6 +2356,57 @@ data:
       # edge-service-notification rule and rest_test.rego's
       # test_deny_operator_read_any_does_not_cover_write).
       ci_producer: ".github/scripts/check-no-service-principal-type.sh"
+
+    # ---------------------------------------------------------------------------------------
+    # Scheduled-method invariants (issue #2148, fleet sweep #2187).
+    # ---------------------------------------------------------------------------------------
+    scheduled_methods:
+      no_runblocking_in_scheduled_body: true
+      # Quarkus invokes a plain (non-`suspend`) @Scheduled method on a bare `executor-thread`,
+      # which carries NO Vert.x context. A body of `runBlocking { … }` therefore runs the
+      # coroutine on that thread, and the first reactive Hibernate-Reactive/Panache call inside
+      # throws `HR000068: This method should exclusively be invoked from a Vert.x EventLoop
+      # thread`. The job aborts having done nothing, and does so silently — the throw lands
+      # before whatever per-item try/catch the job has, or is swallowed by its own outer catch
+      # into one ERROR line.
+      #
+      # Found live five times. #2148: StandingOrderExecutionScheduler.sweep() — no due standing
+      # order had EVER executed (PR #2180). The #2187 sweep then found the same shape in the
+      # daily sub-ledger tie-out control and the daily FX revaluation (ledger, PR #2190), the
+      # statutory ČNB fixing ingestion (fx, PR #2191) and the monthly billing cycle (PR #2194).
+      # None had ever run.
+      #
+      # This is a GATE and not a documented lesson because the natural test does not fail: a test
+      # that calls the method directly supplies a Vert.x context the scheduler does not, so it
+      # passes against the broken code — which is exactly how all five hid behind green suites.
+      # Regression coverage must drive the REAL cron via a @TestProfile that shrinks the cron
+      # expression (pattern: StandingOrderExecutionSweepIT, LedgerSchedulerVertxContextIT).
+      #
+      # FIX: make the method a `suspend fun` — Quarkus dispatches a suspending @Scheduled method
+      # on a proper (duplicated) Vert.x context. Unanimous fleet convention: every other reactive
+      # @Scheduled method here is `suspend` or returns `Uni`. Preferred over
+      # `VertxContextSupport.subscribeAndAwait`, which swaps one blocking bridge for another,
+      # pins the scheduler worker for the whole run, and throws if ever called FROM an event-loop
+      # thread (so it breaks the day the method gains @NonBlocking or a virtual thread).
+      #
+      # An entry below is a genuine exception, not a deferral: a service with no reactive
+      # persistence on its classpath at all, where `runBlocking` bridges deliberately BLOCKING
+      # clients and `suspend` would be the wrong change. Same individually-justified-exception
+      # idiom as the ktlint/detekt baselines and event_consumer_liveness.allowlist. A stale entry
+      # is itself a violation.
+      runblocking_allowlist:
+        - method: "openbank-agent-service/src/main/kotlin/com/openbank/agent/application/OversightService.kt#scheduledSweep"
+          reason: >-
+            agent-service has NO Hibernate Reactive on its classpath (build.gradle.kts: the
+            proposals store is plain Agroal JDBC, deliberately not the reactive stack). The sweep
+            drives blocking OPA/MCP/LLM clients and needs to stay on a worker thread — the same
+            bridge ChatEndpoint uses. `suspend` here would move blocking I/O onto an event loop.
+        - method: "openbank-analytics-sink/src/main/kotlin/com/openbank/analytics/infrastructure/reconcile/ReconciliationJob.kt#scheduled"
+          reason: >-
+            analytics-sink deliberately DROPS hibernate-reactive-panache, reactive-pg-client and
+            jdbc-postgresql (build.gradle.kts) — it has no OLTP datasource to reach. The
+            reconciliation reads the warehouse and the WORM archive over blocking clients.
+      ci_producer: ".github/scripts/check-no-runblocking-in-scheduled.py"
 
     # ---------------------------------------------------------------------------------------
     # Vulnerability-management lifecycle SLAs (ADR-0030 D1). Detection -> closure, in days.

--- a/openbank-infra/gitops/components/payments/payments-services.yaml
+++ b/openbank-infra/gitops/components/payments/payments-services.yaml
@@ -42,7 +42,7 @@ spec:
         # Rolls the pods when the OPA bundle changes — subPath mounts do NOT hot-reload.
         # Kept in sync by gen-transaction-opa-bundle.sh via the trailing marker comment
         # (do not hand-edit, do not drop the marker).
-        openbank.tech/policy-checksum: "b10c6e84a09222ce" # transaction-opa-bundle
+        openbank.tech/policy-checksum: "a2b81c0c94acf704" # transaction-opa-bundle
     spec:
       securityContext:
         runAsNonRoot: true
@@ -375,7 +375,7 @@ spec:
       annotations:
         # Rolls the pods when the OPA bundle changes — subPath mounts do NOT hot-reload.
         # Kept in sync by gen-sepa-payment-opa-bundle.sh (do not hand-edit).
-        openbank.tech/policy-checksum: "ca9602df7e8e70c4"
+        openbank.tech/policy-checksum: "93a38a129627102a"
     spec:
       securityContext:
         runAsNonRoot: true
@@ -729,7 +729,7 @@ spec:
         # Rolls the pods when the OPA bundle changes — subPath mounts do NOT hot-reload.
         # Kept in sync by gen-domestic-payment-opa-bundle.sh via the trailing marker
         # comment (do not hand-edit, do not drop the marker).
-        openbank.tech/policy-checksum: "d66f7755e7696b5a" # domestic-payment-opa-bundle
+        openbank.tech/policy-checksum: "8412bbd9aa1eb939" # domestic-payment-opa-bundle
     spec:
       securityContext:
         runAsNonRoot: true
@@ -1053,7 +1053,7 @@ spec:
       annotations:
         # Rolls the pods when the OPA bundle changes — subPath mounts do NOT hot-reload.
         # Kept in sync by gen-sepa-instant-opa-bundle.sh (do not hand-edit).
-        openbank.tech/policy-checksum: "aa00a1af01f6b979"
+        openbank.tech/policy-checksum: "53e6bea21393b691"
     spec:
       securityContext:
         runAsNonRoot: true
@@ -1369,7 +1369,7 @@ spec:
         # Rolls the pods when the OPA bundle changes — subPath mounts do NOT hot-reload.
         # Kept in sync by gen-clearing-opa-bundle.sh via the trailing marker comment
         # (do not hand-edit, do not drop the marker).
-        openbank.tech/policy-checksum: "997c3cb4e4aa33e8" # clearing-opa-bundle
+        openbank.tech/policy-checksum: "671aac9749347129" # clearing-opa-bundle
     spec:
       securityContext:
         runAsNonRoot: true
@@ -1658,7 +1658,7 @@ spec:
       annotations:
         # Rolls the pod when the OPA bundle changes (ADR-0034). Value is stamped by
         # gen-standing-order-opa-bundle.sh — do not hand-edit.
-        openbank.tech/policy-checksum: "8b08524e5c3e0c34" # standing-order-opa-bundle
+        openbank.tech/policy-checksum: "e7dd65691439f4f9" # standing-order-opa-bundle
     spec:
       securityContext:
         runAsNonRoot: true
@@ -1911,7 +1911,7 @@ spec:
       annotations:
         # Rolls the pods when the OPA bundle changes — subPath mounts do NOT hot-reload.
         # Kept in sync by gen-card-issuance-opa-bundle.sh (do not hand-edit).
-        openbank.tech/policy-checksum: "b7dceb20eedf8ae4"
+        openbank.tech/policy-checksum: "9b725eb23441aee5"
     spec:
       securityContext:
         runAsNonRoot: true
@@ -2178,7 +2178,7 @@ spec:
         # Rolls the pods when the OPA bundle changes — subPath mounts do NOT hot-reload.
         # Kept in sync by gen-settlement-opa-bundle.sh via the trailing marker comment
         # (do not hand-edit, do not drop the marker).
-        openbank.tech/policy-checksum: "107a2aea38cf73fa" # settlement-opa-bundle
+        openbank.tech/policy-checksum: "fd5739c501ce3367" # settlement-opa-bundle
     spec:
       securityContext:
         runAsNonRoot: true
@@ -2579,7 +2579,7 @@ spec:
       annotations:
         # Rolls the pods when the OPA bundle changes — subPath mounts do NOT hot-reload.
         # Kept in sync by gen-swift-opa-bundle.sh (do not hand-edit).
-        openbank.tech/policy-checksum: "5d17b49e88d77cf9"
+        openbank.tech/policy-checksum: "c0fa6b217921ac34"
     spec:
       securityContext:
         runAsNonRoot: true
@@ -2893,7 +2893,7 @@ spec:
       annotations:
         # Rolls the pods when the OPA bundle changes — subPath mounts do NOT hot-reload.
         # Kept in sync by gen-vop-opa-bundle.sh (do not hand-edit).
-        openbank.tech/policy-checksum: "258b7c248622276d"
+        openbank.tech/policy-checksum: "393e0ffa2b150b23"
     spec:
       securityContext:
         runAsNonRoot: true

--- a/openbank-infra/gitops/components/payments/sepa-instant-opa-bundle.yaml
+++ b/openbank-infra/gitops/components/payments/sepa-instant-opa-bundle.yaml
@@ -9,7 +9,7 @@ metadata:
     app.kubernetes.io/name: sepa-instant
     app.kubernetes.io/part-of: payments
   annotations:
-    openbank.tech/policy-checksum: "aa00a1af01f6b979"
+    openbank.tech/policy-checksum: "53e6bea21393b691"
 data:
   rest.rego: |
     # SPDX-License-Identifier: Apache-2.0
@@ -2329,6 +2329,57 @@ data:
       # edge-service-notification rule and rest_test.rego's
       # test_deny_operator_read_any_does_not_cover_write).
       ci_producer: ".github/scripts/check-no-service-principal-type.sh"
+
+    # ---------------------------------------------------------------------------------------
+    # Scheduled-method invariants (issue #2148, fleet sweep #2187).
+    # ---------------------------------------------------------------------------------------
+    scheduled_methods:
+      no_runblocking_in_scheduled_body: true
+      # Quarkus invokes a plain (non-`suspend`) @Scheduled method on a bare `executor-thread`,
+      # which carries NO Vert.x context. A body of `runBlocking { … }` therefore runs the
+      # coroutine on that thread, and the first reactive Hibernate-Reactive/Panache call inside
+      # throws `HR000068: This method should exclusively be invoked from a Vert.x EventLoop
+      # thread`. The job aborts having done nothing, and does so silently — the throw lands
+      # before whatever per-item try/catch the job has, or is swallowed by its own outer catch
+      # into one ERROR line.
+      #
+      # Found live five times. #2148: StandingOrderExecutionScheduler.sweep() — no due standing
+      # order had EVER executed (PR #2180). The #2187 sweep then found the same shape in the
+      # daily sub-ledger tie-out control and the daily FX revaluation (ledger, PR #2190), the
+      # statutory ČNB fixing ingestion (fx, PR #2191) and the monthly billing cycle (PR #2194).
+      # None had ever run.
+      #
+      # This is a GATE and not a documented lesson because the natural test does not fail: a test
+      # that calls the method directly supplies a Vert.x context the scheduler does not, so it
+      # passes against the broken code — which is exactly how all five hid behind green suites.
+      # Regression coverage must drive the REAL cron via a @TestProfile that shrinks the cron
+      # expression (pattern: StandingOrderExecutionSweepIT, LedgerSchedulerVertxContextIT).
+      #
+      # FIX: make the method a `suspend fun` — Quarkus dispatches a suspending @Scheduled method
+      # on a proper (duplicated) Vert.x context. Unanimous fleet convention: every other reactive
+      # @Scheduled method here is `suspend` or returns `Uni`. Preferred over
+      # `VertxContextSupport.subscribeAndAwait`, which swaps one blocking bridge for another,
+      # pins the scheduler worker for the whole run, and throws if ever called FROM an event-loop
+      # thread (so it breaks the day the method gains @NonBlocking or a virtual thread).
+      #
+      # An entry below is a genuine exception, not a deferral: a service with no reactive
+      # persistence on its classpath at all, where `runBlocking` bridges deliberately BLOCKING
+      # clients and `suspend` would be the wrong change. Same individually-justified-exception
+      # idiom as the ktlint/detekt baselines and event_consumer_liveness.allowlist. A stale entry
+      # is itself a violation.
+      runblocking_allowlist:
+        - method: "openbank-agent-service/src/main/kotlin/com/openbank/agent/application/OversightService.kt#scheduledSweep"
+          reason: >-
+            agent-service has NO Hibernate Reactive on its classpath (build.gradle.kts: the
+            proposals store is plain Agroal JDBC, deliberately not the reactive stack). The sweep
+            drives blocking OPA/MCP/LLM clients and needs to stay on a worker thread — the same
+            bridge ChatEndpoint uses. `suspend` here would move blocking I/O onto an event loop.
+        - method: "openbank-analytics-sink/src/main/kotlin/com/openbank/analytics/infrastructure/reconcile/ReconciliationJob.kt#scheduled"
+          reason: >-
+            analytics-sink deliberately DROPS hibernate-reactive-panache, reactive-pg-client and
+            jdbc-postgresql (build.gradle.kts) — it has no OLTP datasource to reach. The
+            reconciliation reads the warehouse and the WORM archive over blocking clients.
+      ci_producer: ".github/scripts/check-no-runblocking-in-scheduled.py"
 
     # ---------------------------------------------------------------------------------------
     # Vulnerability-management lifecycle SLAs (ADR-0030 D1). Detection -> closure, in days.

--- a/openbank-infra/gitops/components/payments/sepa-payment-opa-bundle.yaml
+++ b/openbank-infra/gitops/components/payments/sepa-payment-opa-bundle.yaml
@@ -9,7 +9,7 @@ metadata:
     app.kubernetes.io/name: sepa-payment
     app.kubernetes.io/part-of: payments
   annotations:
-    openbank.tech/policy-checksum: "ca9602df7e8e70c4"
+    openbank.tech/policy-checksum: "93a38a129627102a"
 data:
   rest.rego: |
     # SPDX-License-Identifier: Apache-2.0
@@ -2350,6 +2350,57 @@ data:
       # edge-service-notification rule and rest_test.rego's
       # test_deny_operator_read_any_does_not_cover_write).
       ci_producer: ".github/scripts/check-no-service-principal-type.sh"
+
+    # ---------------------------------------------------------------------------------------
+    # Scheduled-method invariants (issue #2148, fleet sweep #2187).
+    # ---------------------------------------------------------------------------------------
+    scheduled_methods:
+      no_runblocking_in_scheduled_body: true
+      # Quarkus invokes a plain (non-`suspend`) @Scheduled method on a bare `executor-thread`,
+      # which carries NO Vert.x context. A body of `runBlocking { … }` therefore runs the
+      # coroutine on that thread, and the first reactive Hibernate-Reactive/Panache call inside
+      # throws `HR000068: This method should exclusively be invoked from a Vert.x EventLoop
+      # thread`. The job aborts having done nothing, and does so silently — the throw lands
+      # before whatever per-item try/catch the job has, or is swallowed by its own outer catch
+      # into one ERROR line.
+      #
+      # Found live five times. #2148: StandingOrderExecutionScheduler.sweep() — no due standing
+      # order had EVER executed (PR #2180). The #2187 sweep then found the same shape in the
+      # daily sub-ledger tie-out control and the daily FX revaluation (ledger, PR #2190), the
+      # statutory ČNB fixing ingestion (fx, PR #2191) and the monthly billing cycle (PR #2194).
+      # None had ever run.
+      #
+      # This is a GATE and not a documented lesson because the natural test does not fail: a test
+      # that calls the method directly supplies a Vert.x context the scheduler does not, so it
+      # passes against the broken code — which is exactly how all five hid behind green suites.
+      # Regression coverage must drive the REAL cron via a @TestProfile that shrinks the cron
+      # expression (pattern: StandingOrderExecutionSweepIT, LedgerSchedulerVertxContextIT).
+      #
+      # FIX: make the method a `suspend fun` — Quarkus dispatches a suspending @Scheduled method
+      # on a proper (duplicated) Vert.x context. Unanimous fleet convention: every other reactive
+      # @Scheduled method here is `suspend` or returns `Uni`. Preferred over
+      # `VertxContextSupport.subscribeAndAwait`, which swaps one blocking bridge for another,
+      # pins the scheduler worker for the whole run, and throws if ever called FROM an event-loop
+      # thread (so it breaks the day the method gains @NonBlocking or a virtual thread).
+      #
+      # An entry below is a genuine exception, not a deferral: a service with no reactive
+      # persistence on its classpath at all, where `runBlocking` bridges deliberately BLOCKING
+      # clients and `suspend` would be the wrong change. Same individually-justified-exception
+      # idiom as the ktlint/detekt baselines and event_consumer_liveness.allowlist. A stale entry
+      # is itself a violation.
+      runblocking_allowlist:
+        - method: "openbank-agent-service/src/main/kotlin/com/openbank/agent/application/OversightService.kt#scheduledSweep"
+          reason: >-
+            agent-service has NO Hibernate Reactive on its classpath (build.gradle.kts: the
+            proposals store is plain Agroal JDBC, deliberately not the reactive stack). The sweep
+            drives blocking OPA/MCP/LLM clients and needs to stay on a worker thread — the same
+            bridge ChatEndpoint uses. `suspend` here would move blocking I/O onto an event loop.
+        - method: "openbank-analytics-sink/src/main/kotlin/com/openbank/analytics/infrastructure/reconcile/ReconciliationJob.kt#scheduled"
+          reason: >-
+            analytics-sink deliberately DROPS hibernate-reactive-panache, reactive-pg-client and
+            jdbc-postgresql (build.gradle.kts) — it has no OLTP datasource to reach. The
+            reconciliation reads the warehouse and the WORM archive over blocking clients.
+      ci_producer: ".github/scripts/check-no-runblocking-in-scheduled.py"
 
     # ---------------------------------------------------------------------------------------
     # Vulnerability-management lifecycle SLAs (ADR-0030 D1). Detection -> closure, in days.

--- a/openbank-infra/gitops/components/payments/settlement-opa-bundle.yaml
+++ b/openbank-infra/gitops/components/payments/settlement-opa-bundle.yaml
@@ -9,7 +9,7 @@ metadata:
     app.kubernetes.io/name: settlement-service
     app.kubernetes.io/part-of: payments
   annotations:
-    openbank.tech/policy-checksum: "107a2aea38cf73fa"
+    openbank.tech/policy-checksum: "fd5739c501ce3367"
 data:
   rest.rego: |
     # SPDX-License-Identifier: Apache-2.0
@@ -2330,6 +2330,57 @@ data:
       # edge-service-notification rule and rest_test.rego's
       # test_deny_operator_read_any_does_not_cover_write).
       ci_producer: ".github/scripts/check-no-service-principal-type.sh"
+
+    # ---------------------------------------------------------------------------------------
+    # Scheduled-method invariants (issue #2148, fleet sweep #2187).
+    # ---------------------------------------------------------------------------------------
+    scheduled_methods:
+      no_runblocking_in_scheduled_body: true
+      # Quarkus invokes a plain (non-`suspend`) @Scheduled method on a bare `executor-thread`,
+      # which carries NO Vert.x context. A body of `runBlocking { … }` therefore runs the
+      # coroutine on that thread, and the first reactive Hibernate-Reactive/Panache call inside
+      # throws `HR000068: This method should exclusively be invoked from a Vert.x EventLoop
+      # thread`. The job aborts having done nothing, and does so silently — the throw lands
+      # before whatever per-item try/catch the job has, or is swallowed by its own outer catch
+      # into one ERROR line.
+      #
+      # Found live five times. #2148: StandingOrderExecutionScheduler.sweep() — no due standing
+      # order had EVER executed (PR #2180). The #2187 sweep then found the same shape in the
+      # daily sub-ledger tie-out control and the daily FX revaluation (ledger, PR #2190), the
+      # statutory ČNB fixing ingestion (fx, PR #2191) and the monthly billing cycle (PR #2194).
+      # None had ever run.
+      #
+      # This is a GATE and not a documented lesson because the natural test does not fail: a test
+      # that calls the method directly supplies a Vert.x context the scheduler does not, so it
+      # passes against the broken code — which is exactly how all five hid behind green suites.
+      # Regression coverage must drive the REAL cron via a @TestProfile that shrinks the cron
+      # expression (pattern: StandingOrderExecutionSweepIT, LedgerSchedulerVertxContextIT).
+      #
+      # FIX: make the method a `suspend fun` — Quarkus dispatches a suspending @Scheduled method
+      # on a proper (duplicated) Vert.x context. Unanimous fleet convention: every other reactive
+      # @Scheduled method here is `suspend` or returns `Uni`. Preferred over
+      # `VertxContextSupport.subscribeAndAwait`, which swaps one blocking bridge for another,
+      # pins the scheduler worker for the whole run, and throws if ever called FROM an event-loop
+      # thread (so it breaks the day the method gains @NonBlocking or a virtual thread).
+      #
+      # An entry below is a genuine exception, not a deferral: a service with no reactive
+      # persistence on its classpath at all, where `runBlocking` bridges deliberately BLOCKING
+      # clients and `suspend` would be the wrong change. Same individually-justified-exception
+      # idiom as the ktlint/detekt baselines and event_consumer_liveness.allowlist. A stale entry
+      # is itself a violation.
+      runblocking_allowlist:
+        - method: "openbank-agent-service/src/main/kotlin/com/openbank/agent/application/OversightService.kt#scheduledSweep"
+          reason: >-
+            agent-service has NO Hibernate Reactive on its classpath (build.gradle.kts: the
+            proposals store is plain Agroal JDBC, deliberately not the reactive stack). The sweep
+            drives blocking OPA/MCP/LLM clients and needs to stay on a worker thread — the same
+            bridge ChatEndpoint uses. `suspend` here would move blocking I/O onto an event loop.
+        - method: "openbank-analytics-sink/src/main/kotlin/com/openbank/analytics/infrastructure/reconcile/ReconciliationJob.kt#scheduled"
+          reason: >-
+            analytics-sink deliberately DROPS hibernate-reactive-panache, reactive-pg-client and
+            jdbc-postgresql (build.gradle.kts) — it has no OLTP datasource to reach. The
+            reconciliation reads the warehouse and the WORM archive over blocking clients.
+      ci_producer: ".github/scripts/check-no-runblocking-in-scheduled.py"
 
     # ---------------------------------------------------------------------------------------
     # Vulnerability-management lifecycle SLAs (ADR-0030 D1). Detection -> closure, in days.

--- a/openbank-infra/gitops/components/payments/standing-order-opa-bundle.yaml
+++ b/openbank-infra/gitops/components/payments/standing-order-opa-bundle.yaml
@@ -9,7 +9,7 @@ metadata:
     app.kubernetes.io/name: standing-order-service
     app.kubernetes.io/part-of: payments
   annotations:
-    openbank.tech/policy-checksum: "8b08524e5c3e0c34"
+    openbank.tech/policy-checksum: "e7dd65691439f4f9"
 data:
   rest.rego: |
     # SPDX-License-Identifier: Apache-2.0
@@ -2315,6 +2315,57 @@ data:
       # edge-service-notification rule and rest_test.rego's
       # test_deny_operator_read_any_does_not_cover_write).
       ci_producer: ".github/scripts/check-no-service-principal-type.sh"
+
+    # ---------------------------------------------------------------------------------------
+    # Scheduled-method invariants (issue #2148, fleet sweep #2187).
+    # ---------------------------------------------------------------------------------------
+    scheduled_methods:
+      no_runblocking_in_scheduled_body: true
+      # Quarkus invokes a plain (non-`suspend`) @Scheduled method on a bare `executor-thread`,
+      # which carries NO Vert.x context. A body of `runBlocking { … }` therefore runs the
+      # coroutine on that thread, and the first reactive Hibernate-Reactive/Panache call inside
+      # throws `HR000068: This method should exclusively be invoked from a Vert.x EventLoop
+      # thread`. The job aborts having done nothing, and does so silently — the throw lands
+      # before whatever per-item try/catch the job has, or is swallowed by its own outer catch
+      # into one ERROR line.
+      #
+      # Found live five times. #2148: StandingOrderExecutionScheduler.sweep() — no due standing
+      # order had EVER executed (PR #2180). The #2187 sweep then found the same shape in the
+      # daily sub-ledger tie-out control and the daily FX revaluation (ledger, PR #2190), the
+      # statutory ČNB fixing ingestion (fx, PR #2191) and the monthly billing cycle (PR #2194).
+      # None had ever run.
+      #
+      # This is a GATE and not a documented lesson because the natural test does not fail: a test
+      # that calls the method directly supplies a Vert.x context the scheduler does not, so it
+      # passes against the broken code — which is exactly how all five hid behind green suites.
+      # Regression coverage must drive the REAL cron via a @TestProfile that shrinks the cron
+      # expression (pattern: StandingOrderExecutionSweepIT, LedgerSchedulerVertxContextIT).
+      #
+      # FIX: make the method a `suspend fun` — Quarkus dispatches a suspending @Scheduled method
+      # on a proper (duplicated) Vert.x context. Unanimous fleet convention: every other reactive
+      # @Scheduled method here is `suspend` or returns `Uni`. Preferred over
+      # `VertxContextSupport.subscribeAndAwait`, which swaps one blocking bridge for another,
+      # pins the scheduler worker for the whole run, and throws if ever called FROM an event-loop
+      # thread (so it breaks the day the method gains @NonBlocking or a virtual thread).
+      #
+      # An entry below is a genuine exception, not a deferral: a service with no reactive
+      # persistence on its classpath at all, where `runBlocking` bridges deliberately BLOCKING
+      # clients and `suspend` would be the wrong change. Same individually-justified-exception
+      # idiom as the ktlint/detekt baselines and event_consumer_liveness.allowlist. A stale entry
+      # is itself a violation.
+      runblocking_allowlist:
+        - method: "openbank-agent-service/src/main/kotlin/com/openbank/agent/application/OversightService.kt#scheduledSweep"
+          reason: >-
+            agent-service has NO Hibernate Reactive on its classpath (build.gradle.kts: the
+            proposals store is plain Agroal JDBC, deliberately not the reactive stack). The sweep
+            drives blocking OPA/MCP/LLM clients and needs to stay on a worker thread — the same
+            bridge ChatEndpoint uses. `suspend` here would move blocking I/O onto an event loop.
+        - method: "openbank-analytics-sink/src/main/kotlin/com/openbank/analytics/infrastructure/reconcile/ReconciliationJob.kt#scheduled"
+          reason: >-
+            analytics-sink deliberately DROPS hibernate-reactive-panache, reactive-pg-client and
+            jdbc-postgresql (build.gradle.kts) — it has no OLTP datasource to reach. The
+            reconciliation reads the warehouse and the WORM archive over blocking clients.
+      ci_producer: ".github/scripts/check-no-runblocking-in-scheduled.py"
 
     # ---------------------------------------------------------------------------------------
     # Vulnerability-management lifecycle SLAs (ADR-0030 D1). Detection -> closure, in days.

--- a/openbank-infra/gitops/components/payments/swift-opa-bundle.yaml
+++ b/openbank-infra/gitops/components/payments/swift-opa-bundle.yaml
@@ -9,7 +9,7 @@ metadata:
     app.kubernetes.io/name: swift-service
     app.kubernetes.io/part-of: payments
   annotations:
-    openbank.tech/policy-checksum: "5d17b49e88d77cf9"
+    openbank.tech/policy-checksum: "c0fa6b217921ac34"
 data:
   rest.rego: |
     # SPDX-License-Identifier: Apache-2.0
@@ -2333,6 +2333,57 @@ data:
       # edge-service-notification rule and rest_test.rego's
       # test_deny_operator_read_any_does_not_cover_write).
       ci_producer: ".github/scripts/check-no-service-principal-type.sh"
+
+    # ---------------------------------------------------------------------------------------
+    # Scheduled-method invariants (issue #2148, fleet sweep #2187).
+    # ---------------------------------------------------------------------------------------
+    scheduled_methods:
+      no_runblocking_in_scheduled_body: true
+      # Quarkus invokes a plain (non-`suspend`) @Scheduled method on a bare `executor-thread`,
+      # which carries NO Vert.x context. A body of `runBlocking { … }` therefore runs the
+      # coroutine on that thread, and the first reactive Hibernate-Reactive/Panache call inside
+      # throws `HR000068: This method should exclusively be invoked from a Vert.x EventLoop
+      # thread`. The job aborts having done nothing, and does so silently — the throw lands
+      # before whatever per-item try/catch the job has, or is swallowed by its own outer catch
+      # into one ERROR line.
+      #
+      # Found live five times. #2148: StandingOrderExecutionScheduler.sweep() — no due standing
+      # order had EVER executed (PR #2180). The #2187 sweep then found the same shape in the
+      # daily sub-ledger tie-out control and the daily FX revaluation (ledger, PR #2190), the
+      # statutory ČNB fixing ingestion (fx, PR #2191) and the monthly billing cycle (PR #2194).
+      # None had ever run.
+      #
+      # This is a GATE and not a documented lesson because the natural test does not fail: a test
+      # that calls the method directly supplies a Vert.x context the scheduler does not, so it
+      # passes against the broken code — which is exactly how all five hid behind green suites.
+      # Regression coverage must drive the REAL cron via a @TestProfile that shrinks the cron
+      # expression (pattern: StandingOrderExecutionSweepIT, LedgerSchedulerVertxContextIT).
+      #
+      # FIX: make the method a `suspend fun` — Quarkus dispatches a suspending @Scheduled method
+      # on a proper (duplicated) Vert.x context. Unanimous fleet convention: every other reactive
+      # @Scheduled method here is `suspend` or returns `Uni`. Preferred over
+      # `VertxContextSupport.subscribeAndAwait`, which swaps one blocking bridge for another,
+      # pins the scheduler worker for the whole run, and throws if ever called FROM an event-loop
+      # thread (so it breaks the day the method gains @NonBlocking or a virtual thread).
+      #
+      # An entry below is a genuine exception, not a deferral: a service with no reactive
+      # persistence on its classpath at all, where `runBlocking` bridges deliberately BLOCKING
+      # clients and `suspend` would be the wrong change. Same individually-justified-exception
+      # idiom as the ktlint/detekt baselines and event_consumer_liveness.allowlist. A stale entry
+      # is itself a violation.
+      runblocking_allowlist:
+        - method: "openbank-agent-service/src/main/kotlin/com/openbank/agent/application/OversightService.kt#scheduledSweep"
+          reason: >-
+            agent-service has NO Hibernate Reactive on its classpath (build.gradle.kts: the
+            proposals store is plain Agroal JDBC, deliberately not the reactive stack). The sweep
+            drives blocking OPA/MCP/LLM clients and needs to stay on a worker thread — the same
+            bridge ChatEndpoint uses. `suspend` here would move blocking I/O onto an event loop.
+        - method: "openbank-analytics-sink/src/main/kotlin/com/openbank/analytics/infrastructure/reconcile/ReconciliationJob.kt#scheduled"
+          reason: >-
+            analytics-sink deliberately DROPS hibernate-reactive-panache, reactive-pg-client and
+            jdbc-postgresql (build.gradle.kts) — it has no OLTP datasource to reach. The
+            reconciliation reads the warehouse and the WORM archive over blocking clients.
+      ci_producer: ".github/scripts/check-no-runblocking-in-scheduled.py"
 
     # ---------------------------------------------------------------------------------------
     # Vulnerability-management lifecycle SLAs (ADR-0030 D1). Detection -> closure, in days.

--- a/openbank-infra/gitops/components/payments/transaction-opa-bundle.yaml
+++ b/openbank-infra/gitops/components/payments/transaction-opa-bundle.yaml
@@ -9,7 +9,7 @@ metadata:
     app.kubernetes.io/name: transaction-service
     app.kubernetes.io/part-of: payments
   annotations:
-    openbank.tech/policy-checksum: "b10c6e84a09222ce"
+    openbank.tech/policy-checksum: "a2b81c0c94acf704"
 data:
   rest.rego: |
     # SPDX-License-Identifier: Apache-2.0
@@ -2386,6 +2386,57 @@ data:
       # edge-service-notification rule and rest_test.rego's
       # test_deny_operator_read_any_does_not_cover_write).
       ci_producer: ".github/scripts/check-no-service-principal-type.sh"
+
+    # ---------------------------------------------------------------------------------------
+    # Scheduled-method invariants (issue #2148, fleet sweep #2187).
+    # ---------------------------------------------------------------------------------------
+    scheduled_methods:
+      no_runblocking_in_scheduled_body: true
+      # Quarkus invokes a plain (non-`suspend`) @Scheduled method on a bare `executor-thread`,
+      # which carries NO Vert.x context. A body of `runBlocking { … }` therefore runs the
+      # coroutine on that thread, and the first reactive Hibernate-Reactive/Panache call inside
+      # throws `HR000068: This method should exclusively be invoked from a Vert.x EventLoop
+      # thread`. The job aborts having done nothing, and does so silently — the throw lands
+      # before whatever per-item try/catch the job has, or is swallowed by its own outer catch
+      # into one ERROR line.
+      #
+      # Found live five times. #2148: StandingOrderExecutionScheduler.sweep() — no due standing
+      # order had EVER executed (PR #2180). The #2187 sweep then found the same shape in the
+      # daily sub-ledger tie-out control and the daily FX revaluation (ledger, PR #2190), the
+      # statutory ČNB fixing ingestion (fx, PR #2191) and the monthly billing cycle (PR #2194).
+      # None had ever run.
+      #
+      # This is a GATE and not a documented lesson because the natural test does not fail: a test
+      # that calls the method directly supplies a Vert.x context the scheduler does not, so it
+      # passes against the broken code — which is exactly how all five hid behind green suites.
+      # Regression coverage must drive the REAL cron via a @TestProfile that shrinks the cron
+      # expression (pattern: StandingOrderExecutionSweepIT, LedgerSchedulerVertxContextIT).
+      #
+      # FIX: make the method a `suspend fun` — Quarkus dispatches a suspending @Scheduled method
+      # on a proper (duplicated) Vert.x context. Unanimous fleet convention: every other reactive
+      # @Scheduled method here is `suspend` or returns `Uni`. Preferred over
+      # `VertxContextSupport.subscribeAndAwait`, which swaps one blocking bridge for another,
+      # pins the scheduler worker for the whole run, and throws if ever called FROM an event-loop
+      # thread (so it breaks the day the method gains @NonBlocking or a virtual thread).
+      #
+      # An entry below is a genuine exception, not a deferral: a service with no reactive
+      # persistence on its classpath at all, where `runBlocking` bridges deliberately BLOCKING
+      # clients and `suspend` would be the wrong change. Same individually-justified-exception
+      # idiom as the ktlint/detekt baselines and event_consumer_liveness.allowlist. A stale entry
+      # is itself a violation.
+      runblocking_allowlist:
+        - method: "openbank-agent-service/src/main/kotlin/com/openbank/agent/application/OversightService.kt#scheduledSweep"
+          reason: >-
+            agent-service has NO Hibernate Reactive on its classpath (build.gradle.kts: the
+            proposals store is plain Agroal JDBC, deliberately not the reactive stack). The sweep
+            drives blocking OPA/MCP/LLM clients and needs to stay on a worker thread — the same
+            bridge ChatEndpoint uses. `suspend` here would move blocking I/O onto an event loop.
+        - method: "openbank-analytics-sink/src/main/kotlin/com/openbank/analytics/infrastructure/reconcile/ReconciliationJob.kt#scheduled"
+          reason: >-
+            analytics-sink deliberately DROPS hibernate-reactive-panache, reactive-pg-client and
+            jdbc-postgresql (build.gradle.kts) — it has no OLTP datasource to reach. The
+            reconciliation reads the warehouse and the WORM archive over blocking clients.
+      ci_producer: ".github/scripts/check-no-runblocking-in-scheduled.py"
 
     # ---------------------------------------------------------------------------------------
     # Vulnerability-management lifecycle SLAs (ADR-0030 D1). Detection -> closure, in days.

--- a/openbank-infra/gitops/components/payments/vop-opa-bundle.yaml
+++ b/openbank-infra/gitops/components/payments/vop-opa-bundle.yaml
@@ -9,7 +9,7 @@ metadata:
     app.kubernetes.io/name: vop-service
     app.kubernetes.io/part-of: payments
   annotations:
-    openbank.tech/policy-checksum: "258b7c248622276d"
+    openbank.tech/policy-checksum: "393e0ffa2b150b23"
 data:
   rest.rego: |
     # SPDX-License-Identifier: Apache-2.0
@@ -2337,6 +2337,57 @@ data:
       # edge-service-notification rule and rest_test.rego's
       # test_deny_operator_read_any_does_not_cover_write).
       ci_producer: ".github/scripts/check-no-service-principal-type.sh"
+
+    # ---------------------------------------------------------------------------------------
+    # Scheduled-method invariants (issue #2148, fleet sweep #2187).
+    # ---------------------------------------------------------------------------------------
+    scheduled_methods:
+      no_runblocking_in_scheduled_body: true
+      # Quarkus invokes a plain (non-`suspend`) @Scheduled method on a bare `executor-thread`,
+      # which carries NO Vert.x context. A body of `runBlocking { … }` therefore runs the
+      # coroutine on that thread, and the first reactive Hibernate-Reactive/Panache call inside
+      # throws `HR000068: This method should exclusively be invoked from a Vert.x EventLoop
+      # thread`. The job aborts having done nothing, and does so silently — the throw lands
+      # before whatever per-item try/catch the job has, or is swallowed by its own outer catch
+      # into one ERROR line.
+      #
+      # Found live five times. #2148: StandingOrderExecutionScheduler.sweep() — no due standing
+      # order had EVER executed (PR #2180). The #2187 sweep then found the same shape in the
+      # daily sub-ledger tie-out control and the daily FX revaluation (ledger, PR #2190), the
+      # statutory ČNB fixing ingestion (fx, PR #2191) and the monthly billing cycle (PR #2194).
+      # None had ever run.
+      #
+      # This is a GATE and not a documented lesson because the natural test does not fail: a test
+      # that calls the method directly supplies a Vert.x context the scheduler does not, so it
+      # passes against the broken code — which is exactly how all five hid behind green suites.
+      # Regression coverage must drive the REAL cron via a @TestProfile that shrinks the cron
+      # expression (pattern: StandingOrderExecutionSweepIT, LedgerSchedulerVertxContextIT).
+      #
+      # FIX: make the method a `suspend fun` — Quarkus dispatches a suspending @Scheduled method
+      # on a proper (duplicated) Vert.x context. Unanimous fleet convention: every other reactive
+      # @Scheduled method here is `suspend` or returns `Uni`. Preferred over
+      # `VertxContextSupport.subscribeAndAwait`, which swaps one blocking bridge for another,
+      # pins the scheduler worker for the whole run, and throws if ever called FROM an event-loop
+      # thread (so it breaks the day the method gains @NonBlocking or a virtual thread).
+      #
+      # An entry below is a genuine exception, not a deferral: a service with no reactive
+      # persistence on its classpath at all, where `runBlocking` bridges deliberately BLOCKING
+      # clients and `suspend` would be the wrong change. Same individually-justified-exception
+      # idiom as the ktlint/detekt baselines and event_consumer_liveness.allowlist. A stale entry
+      # is itself a violation.
+      runblocking_allowlist:
+        - method: "openbank-agent-service/src/main/kotlin/com/openbank/agent/application/OversightService.kt#scheduledSweep"
+          reason: >-
+            agent-service has NO Hibernate Reactive on its classpath (build.gradle.kts: the
+            proposals store is plain Agroal JDBC, deliberately not the reactive stack). The sweep
+            drives blocking OPA/MCP/LLM clients and needs to stay on a worker thread — the same
+            bridge ChatEndpoint uses. `suspend` here would move blocking I/O onto an event loop.
+        - method: "openbank-analytics-sink/src/main/kotlin/com/openbank/analytics/infrastructure/reconcile/ReconciliationJob.kt#scheduled"
+          reason: >-
+            analytics-sink deliberately DROPS hibernate-reactive-panache, reactive-pg-client and
+            jdbc-postgresql (build.gradle.kts) — it has no OLTP datasource to reach. The
+            reconciliation reads the warehouse and the WORM archive over blocking clients.
+      ci_producer: ".github/scripts/check-no-runblocking-in-scheduled.py"
 
     # ---------------------------------------------------------------------------------------
     # Vulnerability-management lifecycle SLAs (ADR-0030 D1). Detection -> closure, in days.

--- a/openbank-infra/gitops/components/pid/pid-opa-bundle.yaml
+++ b/openbank-infra/gitops/components/pid/pid-opa-bundle.yaml
@@ -9,7 +9,7 @@ metadata:
     app.kubernetes.io/name: pid-service
     app.kubernetes.io/part-of: pid
   annotations:
-    openbank.tech/policy-checksum: "ba480eabebd364ed"
+    openbank.tech/policy-checksum: "5f1953ae78d7c642"
 data:
   rest.rego: |
     # SPDX-License-Identifier: Apache-2.0
@@ -2339,6 +2339,57 @@ data:
       # edge-service-notification rule and rest_test.rego's
       # test_deny_operator_read_any_does_not_cover_write).
       ci_producer: ".github/scripts/check-no-service-principal-type.sh"
+
+    # ---------------------------------------------------------------------------------------
+    # Scheduled-method invariants (issue #2148, fleet sweep #2187).
+    # ---------------------------------------------------------------------------------------
+    scheduled_methods:
+      no_runblocking_in_scheduled_body: true
+      # Quarkus invokes a plain (non-`suspend`) @Scheduled method on a bare `executor-thread`,
+      # which carries NO Vert.x context. A body of `runBlocking { … }` therefore runs the
+      # coroutine on that thread, and the first reactive Hibernate-Reactive/Panache call inside
+      # throws `HR000068: This method should exclusively be invoked from a Vert.x EventLoop
+      # thread`. The job aborts having done nothing, and does so silently — the throw lands
+      # before whatever per-item try/catch the job has, or is swallowed by its own outer catch
+      # into one ERROR line.
+      #
+      # Found live five times. #2148: StandingOrderExecutionScheduler.sweep() — no due standing
+      # order had EVER executed (PR #2180). The #2187 sweep then found the same shape in the
+      # daily sub-ledger tie-out control and the daily FX revaluation (ledger, PR #2190), the
+      # statutory ČNB fixing ingestion (fx, PR #2191) and the monthly billing cycle (PR #2194).
+      # None had ever run.
+      #
+      # This is a GATE and not a documented lesson because the natural test does not fail: a test
+      # that calls the method directly supplies a Vert.x context the scheduler does not, so it
+      # passes against the broken code — which is exactly how all five hid behind green suites.
+      # Regression coverage must drive the REAL cron via a @TestProfile that shrinks the cron
+      # expression (pattern: StandingOrderExecutionSweepIT, LedgerSchedulerVertxContextIT).
+      #
+      # FIX: make the method a `suspend fun` — Quarkus dispatches a suspending @Scheduled method
+      # on a proper (duplicated) Vert.x context. Unanimous fleet convention: every other reactive
+      # @Scheduled method here is `suspend` or returns `Uni`. Preferred over
+      # `VertxContextSupport.subscribeAndAwait`, which swaps one blocking bridge for another,
+      # pins the scheduler worker for the whole run, and throws if ever called FROM an event-loop
+      # thread (so it breaks the day the method gains @NonBlocking or a virtual thread).
+      #
+      # An entry below is a genuine exception, not a deferral: a service with no reactive
+      # persistence on its classpath at all, where `runBlocking` bridges deliberately BLOCKING
+      # clients and `suspend` would be the wrong change. Same individually-justified-exception
+      # idiom as the ktlint/detekt baselines and event_consumer_liveness.allowlist. A stale entry
+      # is itself a violation.
+      runblocking_allowlist:
+        - method: "openbank-agent-service/src/main/kotlin/com/openbank/agent/application/OversightService.kt#scheduledSweep"
+          reason: >-
+            agent-service has NO Hibernate Reactive on its classpath (build.gradle.kts: the
+            proposals store is plain Agroal JDBC, deliberately not the reactive stack). The sweep
+            drives blocking OPA/MCP/LLM clients and needs to stay on a worker thread — the same
+            bridge ChatEndpoint uses. `suspend` here would move blocking I/O onto an event loop.
+        - method: "openbank-analytics-sink/src/main/kotlin/com/openbank/analytics/infrastructure/reconcile/ReconciliationJob.kt#scheduled"
+          reason: >-
+            analytics-sink deliberately DROPS hibernate-reactive-panache, reactive-pg-client and
+            jdbc-postgresql (build.gradle.kts) — it has no OLTP datasource to reach. The
+            reconciliation reads the warehouse and the WORM archive over blocking clients.
+      ci_producer: ".github/scripts/check-no-runblocking-in-scheduled.py"
 
     # ---------------------------------------------------------------------------------------
     # Vulnerability-management lifecycle SLAs (ADR-0030 D1). Detection -> closure, in days.

--- a/openbank-infra/gitops/components/pid/pid-service.yaml
+++ b/openbank-infra/gitops/components/pid/pid-service.yaml
@@ -22,7 +22,7 @@ spec:
       annotations:
         # Rolls the pod when the OPA bundle changes — subPath mounts do NOT hot-reload.
         # Kept in sync by gen-pid-opa-bundle.sh (do not hand-edit).
-        openbank.tech/policy-checksum: "ba480eabebd364ed"
+        openbank.tech/policy-checksum: "5f1953ae78d7c642"
     spec:
       securityContext:
         runAsNonRoot: true

--- a/openbank-infra/gitops/components/psd2-service/psd2-opa-bundle.yaml
+++ b/openbank-infra/gitops/components/psd2-service/psd2-opa-bundle.yaml
@@ -9,7 +9,7 @@ metadata:
     app.kubernetes.io/name: psd2-service
     app.kubernetes.io/part-of: psd2
   annotations:
-    openbank.tech/policy-checksum: "ced44d03f5956f8c"
+    openbank.tech/policy-checksum: "06d7408b01ab6f9d"
 data:
   rest.rego: |
     # SPDX-License-Identifier: Apache-2.0
@@ -2412,6 +2412,57 @@ data:
       # edge-service-notification rule and rest_test.rego's
       # test_deny_operator_read_any_does_not_cover_write).
       ci_producer: ".github/scripts/check-no-service-principal-type.sh"
+
+    # ---------------------------------------------------------------------------------------
+    # Scheduled-method invariants (issue #2148, fleet sweep #2187).
+    # ---------------------------------------------------------------------------------------
+    scheduled_methods:
+      no_runblocking_in_scheduled_body: true
+      # Quarkus invokes a plain (non-`suspend`) @Scheduled method on a bare `executor-thread`,
+      # which carries NO Vert.x context. A body of `runBlocking { … }` therefore runs the
+      # coroutine on that thread, and the first reactive Hibernate-Reactive/Panache call inside
+      # throws `HR000068: This method should exclusively be invoked from a Vert.x EventLoop
+      # thread`. The job aborts having done nothing, and does so silently — the throw lands
+      # before whatever per-item try/catch the job has, or is swallowed by its own outer catch
+      # into one ERROR line.
+      #
+      # Found live five times. #2148: StandingOrderExecutionScheduler.sweep() — no due standing
+      # order had EVER executed (PR #2180). The #2187 sweep then found the same shape in the
+      # daily sub-ledger tie-out control and the daily FX revaluation (ledger, PR #2190), the
+      # statutory ČNB fixing ingestion (fx, PR #2191) and the monthly billing cycle (PR #2194).
+      # None had ever run.
+      #
+      # This is a GATE and not a documented lesson because the natural test does not fail: a test
+      # that calls the method directly supplies a Vert.x context the scheduler does not, so it
+      # passes against the broken code — which is exactly how all five hid behind green suites.
+      # Regression coverage must drive the REAL cron via a @TestProfile that shrinks the cron
+      # expression (pattern: StandingOrderExecutionSweepIT, LedgerSchedulerVertxContextIT).
+      #
+      # FIX: make the method a `suspend fun` — Quarkus dispatches a suspending @Scheduled method
+      # on a proper (duplicated) Vert.x context. Unanimous fleet convention: every other reactive
+      # @Scheduled method here is `suspend` or returns `Uni`. Preferred over
+      # `VertxContextSupport.subscribeAndAwait`, which swaps one blocking bridge for another,
+      # pins the scheduler worker for the whole run, and throws if ever called FROM an event-loop
+      # thread (so it breaks the day the method gains @NonBlocking or a virtual thread).
+      #
+      # An entry below is a genuine exception, not a deferral: a service with no reactive
+      # persistence on its classpath at all, where `runBlocking` bridges deliberately BLOCKING
+      # clients and `suspend` would be the wrong change. Same individually-justified-exception
+      # idiom as the ktlint/detekt baselines and event_consumer_liveness.allowlist. A stale entry
+      # is itself a violation.
+      runblocking_allowlist:
+        - method: "openbank-agent-service/src/main/kotlin/com/openbank/agent/application/OversightService.kt#scheduledSweep"
+          reason: >-
+            agent-service has NO Hibernate Reactive on its classpath (build.gradle.kts: the
+            proposals store is plain Agroal JDBC, deliberately not the reactive stack). The sweep
+            drives blocking OPA/MCP/LLM clients and needs to stay on a worker thread — the same
+            bridge ChatEndpoint uses. `suspend` here would move blocking I/O onto an event loop.
+        - method: "openbank-analytics-sink/src/main/kotlin/com/openbank/analytics/infrastructure/reconcile/ReconciliationJob.kt#scheduled"
+          reason: >-
+            analytics-sink deliberately DROPS hibernate-reactive-panache, reactive-pg-client and
+            jdbc-postgresql (build.gradle.kts) — it has no OLTP datasource to reach. The
+            reconciliation reads the warehouse and the WORM archive over blocking clients.
+      ci_producer: ".github/scripts/check-no-runblocking-in-scheduled.py"
 
     # ---------------------------------------------------------------------------------------
     # Vulnerability-management lifecycle SLAs (ADR-0030 D1). Detection -> closure, in days.

--- a/openbank-infra/gitops/components/psd2-service/psd2-service.yaml
+++ b/openbank-infra/gitops/components/psd2-service/psd2-service.yaml
@@ -18,7 +18,7 @@ spec:
       annotations:
         # Rolls the pod when the OPA bundle changes — subPath mounts do NOT hot-reload.
         # Kept in sync by gen-psd2-opa-bundle.sh (do not hand-edit).
-        openbank.tech/policy-checksum: "ced44d03f5956f8c"
+        openbank.tech/policy-checksum: "06d7408b01ab6f9d"
       labels: {app.kubernetes.io/name: psd2-service, app.kubernetes.io/part-of: psd2}
     spec:
       securityContext:

--- a/openbank-infra/gitops/components/sanctions-service/sanctions-opa-bundle.yaml
+++ b/openbank-infra/gitops/components/sanctions-service/sanctions-opa-bundle.yaml
@@ -9,7 +9,7 @@ metadata:
     app.kubernetes.io/name: sanctions-service
     app.kubernetes.io/part-of: sanctions
   annotations:
-    openbank.tech/policy-checksum: "f3382016e5ce89e5"
+    openbank.tech/policy-checksum: "cd78df11e153f5d3"
 data:
   rest.rego: |
     # SPDX-License-Identifier: Apache-2.0
@@ -2317,6 +2317,57 @@ data:
       # edge-service-notification rule and rest_test.rego's
       # test_deny_operator_read_any_does_not_cover_write).
       ci_producer: ".github/scripts/check-no-service-principal-type.sh"
+
+    # ---------------------------------------------------------------------------------------
+    # Scheduled-method invariants (issue #2148, fleet sweep #2187).
+    # ---------------------------------------------------------------------------------------
+    scheduled_methods:
+      no_runblocking_in_scheduled_body: true
+      # Quarkus invokes a plain (non-`suspend`) @Scheduled method on a bare `executor-thread`,
+      # which carries NO Vert.x context. A body of `runBlocking { … }` therefore runs the
+      # coroutine on that thread, and the first reactive Hibernate-Reactive/Panache call inside
+      # throws `HR000068: This method should exclusively be invoked from a Vert.x EventLoop
+      # thread`. The job aborts having done nothing, and does so silently — the throw lands
+      # before whatever per-item try/catch the job has, or is swallowed by its own outer catch
+      # into one ERROR line.
+      #
+      # Found live five times. #2148: StandingOrderExecutionScheduler.sweep() — no due standing
+      # order had EVER executed (PR #2180). The #2187 sweep then found the same shape in the
+      # daily sub-ledger tie-out control and the daily FX revaluation (ledger, PR #2190), the
+      # statutory ČNB fixing ingestion (fx, PR #2191) and the monthly billing cycle (PR #2194).
+      # None had ever run.
+      #
+      # This is a GATE and not a documented lesson because the natural test does not fail: a test
+      # that calls the method directly supplies a Vert.x context the scheduler does not, so it
+      # passes against the broken code — which is exactly how all five hid behind green suites.
+      # Regression coverage must drive the REAL cron via a @TestProfile that shrinks the cron
+      # expression (pattern: StandingOrderExecutionSweepIT, LedgerSchedulerVertxContextIT).
+      #
+      # FIX: make the method a `suspend fun` — Quarkus dispatches a suspending @Scheduled method
+      # on a proper (duplicated) Vert.x context. Unanimous fleet convention: every other reactive
+      # @Scheduled method here is `suspend` or returns `Uni`. Preferred over
+      # `VertxContextSupport.subscribeAndAwait`, which swaps one blocking bridge for another,
+      # pins the scheduler worker for the whole run, and throws if ever called FROM an event-loop
+      # thread (so it breaks the day the method gains @NonBlocking or a virtual thread).
+      #
+      # An entry below is a genuine exception, not a deferral: a service with no reactive
+      # persistence on its classpath at all, where `runBlocking` bridges deliberately BLOCKING
+      # clients and `suspend` would be the wrong change. Same individually-justified-exception
+      # idiom as the ktlint/detekt baselines and event_consumer_liveness.allowlist. A stale entry
+      # is itself a violation.
+      runblocking_allowlist:
+        - method: "openbank-agent-service/src/main/kotlin/com/openbank/agent/application/OversightService.kt#scheduledSweep"
+          reason: >-
+            agent-service has NO Hibernate Reactive on its classpath (build.gradle.kts: the
+            proposals store is plain Agroal JDBC, deliberately not the reactive stack). The sweep
+            drives blocking OPA/MCP/LLM clients and needs to stay on a worker thread — the same
+            bridge ChatEndpoint uses. `suspend` here would move blocking I/O onto an event loop.
+        - method: "openbank-analytics-sink/src/main/kotlin/com/openbank/analytics/infrastructure/reconcile/ReconciliationJob.kt#scheduled"
+          reason: >-
+            analytics-sink deliberately DROPS hibernate-reactive-panache, reactive-pg-client and
+            jdbc-postgresql (build.gradle.kts) — it has no OLTP datasource to reach. The
+            reconciliation reads the warehouse and the WORM archive over blocking clients.
+      ci_producer: ".github/scripts/check-no-runblocking-in-scheduled.py"
 
     # ---------------------------------------------------------------------------------------
     # Vulnerability-management lifecycle SLAs (ADR-0030 D1). Detection -> closure, in days.

--- a/openbank-infra/gitops/components/sanctions-service/sanctions-service.yaml
+++ b/openbank-infra/gitops/components/sanctions-service/sanctions-service.yaml
@@ -49,7 +49,7 @@ spec:
       annotations:
         # Rolls the pods when the OPA bundle changes — subPath mounts do NOT hot-reload.
         # Kept in sync by gen-sanctions-opa-bundle.sh (do not hand-edit).
-        openbank.tech/policy-checksum: "f3382016e5ce89e5"
+        openbank.tech/policy-checksum: "cd78df11e153f5d3"
     spec:
       securityContext:
         runAsNonRoot: true

--- a/openbank-infra/gitops/components/sca/sca-opa-bundle.yaml
+++ b/openbank-infra/gitops/components/sca/sca-opa-bundle.yaml
@@ -9,7 +9,7 @@ metadata:
     app.kubernetes.io/name: sca-service
     app.kubernetes.io/part-of: sca
   annotations:
-    openbank.tech/policy-checksum: "1b7b2813081244f5"
+    openbank.tech/policy-checksum: "5e039f5a6c9e86ad"
 data:
   rest.rego: |
     # SPDX-License-Identifier: Apache-2.0
@@ -2353,6 +2353,57 @@ data:
       # edge-service-notification rule and rest_test.rego's
       # test_deny_operator_read_any_does_not_cover_write).
       ci_producer: ".github/scripts/check-no-service-principal-type.sh"
+
+    # ---------------------------------------------------------------------------------------
+    # Scheduled-method invariants (issue #2148, fleet sweep #2187).
+    # ---------------------------------------------------------------------------------------
+    scheduled_methods:
+      no_runblocking_in_scheduled_body: true
+      # Quarkus invokes a plain (non-`suspend`) @Scheduled method on a bare `executor-thread`,
+      # which carries NO Vert.x context. A body of `runBlocking { … }` therefore runs the
+      # coroutine on that thread, and the first reactive Hibernate-Reactive/Panache call inside
+      # throws `HR000068: This method should exclusively be invoked from a Vert.x EventLoop
+      # thread`. The job aborts having done nothing, and does so silently — the throw lands
+      # before whatever per-item try/catch the job has, or is swallowed by its own outer catch
+      # into one ERROR line.
+      #
+      # Found live five times. #2148: StandingOrderExecutionScheduler.sweep() — no due standing
+      # order had EVER executed (PR #2180). The #2187 sweep then found the same shape in the
+      # daily sub-ledger tie-out control and the daily FX revaluation (ledger, PR #2190), the
+      # statutory ČNB fixing ingestion (fx, PR #2191) and the monthly billing cycle (PR #2194).
+      # None had ever run.
+      #
+      # This is a GATE and not a documented lesson because the natural test does not fail: a test
+      # that calls the method directly supplies a Vert.x context the scheduler does not, so it
+      # passes against the broken code — which is exactly how all five hid behind green suites.
+      # Regression coverage must drive the REAL cron via a @TestProfile that shrinks the cron
+      # expression (pattern: StandingOrderExecutionSweepIT, LedgerSchedulerVertxContextIT).
+      #
+      # FIX: make the method a `suspend fun` — Quarkus dispatches a suspending @Scheduled method
+      # on a proper (duplicated) Vert.x context. Unanimous fleet convention: every other reactive
+      # @Scheduled method here is `suspend` or returns `Uni`. Preferred over
+      # `VertxContextSupport.subscribeAndAwait`, which swaps one blocking bridge for another,
+      # pins the scheduler worker for the whole run, and throws if ever called FROM an event-loop
+      # thread (so it breaks the day the method gains @NonBlocking or a virtual thread).
+      #
+      # An entry below is a genuine exception, not a deferral: a service with no reactive
+      # persistence on its classpath at all, where `runBlocking` bridges deliberately BLOCKING
+      # clients and `suspend` would be the wrong change. Same individually-justified-exception
+      # idiom as the ktlint/detekt baselines and event_consumer_liveness.allowlist. A stale entry
+      # is itself a violation.
+      runblocking_allowlist:
+        - method: "openbank-agent-service/src/main/kotlin/com/openbank/agent/application/OversightService.kt#scheduledSweep"
+          reason: >-
+            agent-service has NO Hibernate Reactive on its classpath (build.gradle.kts: the
+            proposals store is plain Agroal JDBC, deliberately not the reactive stack). The sweep
+            drives blocking OPA/MCP/LLM clients and needs to stay on a worker thread — the same
+            bridge ChatEndpoint uses. `suspend` here would move blocking I/O onto an event loop.
+        - method: "openbank-analytics-sink/src/main/kotlin/com/openbank/analytics/infrastructure/reconcile/ReconciliationJob.kt#scheduled"
+          reason: >-
+            analytics-sink deliberately DROPS hibernate-reactive-panache, reactive-pg-client and
+            jdbc-postgresql (build.gradle.kts) — it has no OLTP datasource to reach. The
+            reconciliation reads the warehouse and the WORM archive over blocking clients.
+      ci_producer: ".github/scripts/check-no-runblocking-in-scheduled.py"
 
     # ---------------------------------------------------------------------------------------
     # Vulnerability-management lifecycle SLAs (ADR-0030 D1). Detection -> closure, in days.

--- a/openbank-infra/gitops/components/sca/sca-service.yaml
+++ b/openbank-infra/gitops/components/sca/sca-service.yaml
@@ -28,7 +28,7 @@ spec:
       annotations:
         # Rolls the pods when the OPA bundle changes — subPath mounts do NOT hot-reload.
         # Kept in sync by gen-sca-opa-bundle.sh (do not hand-edit).
-        openbank.tech/policy-checksum: "1b7b2813081244f5"
+        openbank.tech/policy-checksum: "5e039f5a6c9e86ad"
     spec:
       securityContext:
         runAsNonRoot: true

--- a/openbank-infra/gitops/components/statements/statement-opa-bundle.yaml
+++ b/openbank-infra/gitops/components/statements/statement-opa-bundle.yaml
@@ -9,7 +9,7 @@ metadata:
     app.kubernetes.io/name: statement-service
     app.kubernetes.io/part-of: statements
   annotations:
-    openbank.tech/policy-checksum: "360a3a6199cd4e9a"
+    openbank.tech/policy-checksum: "46b29807cf55bd08"
 data:
   rest.rego: |
     # SPDX-License-Identifier: Apache-2.0
@@ -2383,6 +2383,57 @@ data:
       # edge-service-notification rule and rest_test.rego's
       # test_deny_operator_read_any_does_not_cover_write).
       ci_producer: ".github/scripts/check-no-service-principal-type.sh"
+
+    # ---------------------------------------------------------------------------------------
+    # Scheduled-method invariants (issue #2148, fleet sweep #2187).
+    # ---------------------------------------------------------------------------------------
+    scheduled_methods:
+      no_runblocking_in_scheduled_body: true
+      # Quarkus invokes a plain (non-`suspend`) @Scheduled method on a bare `executor-thread`,
+      # which carries NO Vert.x context. A body of `runBlocking { … }` therefore runs the
+      # coroutine on that thread, and the first reactive Hibernate-Reactive/Panache call inside
+      # throws `HR000068: This method should exclusively be invoked from a Vert.x EventLoop
+      # thread`. The job aborts having done nothing, and does so silently — the throw lands
+      # before whatever per-item try/catch the job has, or is swallowed by its own outer catch
+      # into one ERROR line.
+      #
+      # Found live five times. #2148: StandingOrderExecutionScheduler.sweep() — no due standing
+      # order had EVER executed (PR #2180). The #2187 sweep then found the same shape in the
+      # daily sub-ledger tie-out control and the daily FX revaluation (ledger, PR #2190), the
+      # statutory ČNB fixing ingestion (fx, PR #2191) and the monthly billing cycle (PR #2194).
+      # None had ever run.
+      #
+      # This is a GATE and not a documented lesson because the natural test does not fail: a test
+      # that calls the method directly supplies a Vert.x context the scheduler does not, so it
+      # passes against the broken code — which is exactly how all five hid behind green suites.
+      # Regression coverage must drive the REAL cron via a @TestProfile that shrinks the cron
+      # expression (pattern: StandingOrderExecutionSweepIT, LedgerSchedulerVertxContextIT).
+      #
+      # FIX: make the method a `suspend fun` — Quarkus dispatches a suspending @Scheduled method
+      # on a proper (duplicated) Vert.x context. Unanimous fleet convention: every other reactive
+      # @Scheduled method here is `suspend` or returns `Uni`. Preferred over
+      # `VertxContextSupport.subscribeAndAwait`, which swaps one blocking bridge for another,
+      # pins the scheduler worker for the whole run, and throws if ever called FROM an event-loop
+      # thread (so it breaks the day the method gains @NonBlocking or a virtual thread).
+      #
+      # An entry below is a genuine exception, not a deferral: a service with no reactive
+      # persistence on its classpath at all, where `runBlocking` bridges deliberately BLOCKING
+      # clients and `suspend` would be the wrong change. Same individually-justified-exception
+      # idiom as the ktlint/detekt baselines and event_consumer_liveness.allowlist. A stale entry
+      # is itself a violation.
+      runblocking_allowlist:
+        - method: "openbank-agent-service/src/main/kotlin/com/openbank/agent/application/OversightService.kt#scheduledSweep"
+          reason: >-
+            agent-service has NO Hibernate Reactive on its classpath (build.gradle.kts: the
+            proposals store is plain Agroal JDBC, deliberately not the reactive stack). The sweep
+            drives blocking OPA/MCP/LLM clients and needs to stay on a worker thread — the same
+            bridge ChatEndpoint uses. `suspend` here would move blocking I/O onto an event loop.
+        - method: "openbank-analytics-sink/src/main/kotlin/com/openbank/analytics/infrastructure/reconcile/ReconciliationJob.kt#scheduled"
+          reason: >-
+            analytics-sink deliberately DROPS hibernate-reactive-panache, reactive-pg-client and
+            jdbc-postgresql (build.gradle.kts) — it has no OLTP datasource to reach. The
+            reconciliation reads the warehouse and the WORM archive over blocking clients.
+      ci_producer: ".github/scripts/check-no-runblocking-in-scheduled.py"
 
     # ---------------------------------------------------------------------------------------
     # Vulnerability-management lifecycle SLAs (ADR-0030 D1). Detection -> closure, in days.

--- a/openbank-infra/gitops/components/statements/statement-service.yaml
+++ b/openbank-infra/gitops/components/statements/statement-service.yaml
@@ -26,7 +26,7 @@ spec:
       annotations:
         # Rolls the pod when the OPA bundle changes — subPath mounts do NOT hot-reload.
         # Kept in sync by gen-statement-opa-bundle.sh (do not hand-edit).
-        openbank.tech/policy-checksum: "360a3a6199cd4e9a"
+        openbank.tech/policy-checksum: "46b29807cf55bd08"
       labels:
         app.kubernetes.io/name: statement-service
         app.kubernetes.io/part-of: statements

--- a/openbank-libs/governance/rules.yaml
+++ b/openbank-libs/governance/rules.yaml
@@ -982,6 +982,57 @@ authz_policy:
   ci_producer: ".github/scripts/check-no-service-principal-type.sh"
 
 # ---------------------------------------------------------------------------------------
+# Scheduled-method invariants (issue #2148, fleet sweep #2187).
+# ---------------------------------------------------------------------------------------
+scheduled_methods:
+  no_runblocking_in_scheduled_body: true
+  # Quarkus invokes a plain (non-`suspend`) @Scheduled method on a bare `executor-thread`,
+  # which carries NO Vert.x context. A body of `runBlocking { … }` therefore runs the
+  # coroutine on that thread, and the first reactive Hibernate-Reactive/Panache call inside
+  # throws `HR000068: This method should exclusively be invoked from a Vert.x EventLoop
+  # thread`. The job aborts having done nothing, and does so silently — the throw lands
+  # before whatever per-item try/catch the job has, or is swallowed by its own outer catch
+  # into one ERROR line.
+  #
+  # Found live five times. #2148: StandingOrderExecutionScheduler.sweep() — no due standing
+  # order had EVER executed (PR #2180). The #2187 sweep then found the same shape in the
+  # daily sub-ledger tie-out control and the daily FX revaluation (ledger, PR #2190), the
+  # statutory ČNB fixing ingestion (fx, PR #2191) and the monthly billing cycle (PR #2194).
+  # None had ever run.
+  #
+  # This is a GATE and not a documented lesson because the natural test does not fail: a test
+  # that calls the method directly supplies a Vert.x context the scheduler does not, so it
+  # passes against the broken code — which is exactly how all five hid behind green suites.
+  # Regression coverage must drive the REAL cron via a @TestProfile that shrinks the cron
+  # expression (pattern: StandingOrderExecutionSweepIT, LedgerSchedulerVertxContextIT).
+  #
+  # FIX: make the method a `suspend fun` — Quarkus dispatches a suspending @Scheduled method
+  # on a proper (duplicated) Vert.x context. Unanimous fleet convention: every other reactive
+  # @Scheduled method here is `suspend` or returns `Uni`. Preferred over
+  # `VertxContextSupport.subscribeAndAwait`, which swaps one blocking bridge for another,
+  # pins the scheduler worker for the whole run, and throws if ever called FROM an event-loop
+  # thread (so it breaks the day the method gains @NonBlocking or a virtual thread).
+  #
+  # An entry below is a genuine exception, not a deferral: a service with no reactive
+  # persistence on its classpath at all, where `runBlocking` bridges deliberately BLOCKING
+  # clients and `suspend` would be the wrong change. Same individually-justified-exception
+  # idiom as the ktlint/detekt baselines and event_consumer_liveness.allowlist. A stale entry
+  # is itself a violation.
+  runblocking_allowlist:
+    - method: "openbank-agent-service/src/main/kotlin/com/openbank/agent/application/OversightService.kt#scheduledSweep"
+      reason: >-
+        agent-service has NO Hibernate Reactive on its classpath (build.gradle.kts: the
+        proposals store is plain Agroal JDBC, deliberately not the reactive stack). The sweep
+        drives blocking OPA/MCP/LLM clients and needs to stay on a worker thread — the same
+        bridge ChatEndpoint uses. `suspend` here would move blocking I/O onto an event loop.
+    - method: "openbank-analytics-sink/src/main/kotlin/com/openbank/analytics/infrastructure/reconcile/ReconciliationJob.kt#scheduled"
+      reason: >-
+        analytics-sink deliberately DROPS hibernate-reactive-panache, reactive-pg-client and
+        jdbc-postgresql (build.gradle.kts) — it has no OLTP datasource to reach. The
+        reconciliation reads the warehouse and the WORM archive over blocking clients.
+  ci_producer: ".github/scripts/check-no-runblocking-in-scheduled.py"
+
+# ---------------------------------------------------------------------------------------
 # Vulnerability-management lifecycle SLAs (ADR-0030 D1). Detection -> closure, in days.
 # ---------------------------------------------------------------------------------------
 vuln_management:


### PR DESCRIPTION
## Summary

`runBlocking` in the body of a `@Scheduled` method is never correct in this codebase. Quarkus invokes a plain (non-`suspend`) `@Scheduled` method on a bare `executor-thread`, which carries **no Vert.x context**, so the first reactive Hibernate-Reactive/Panache call inside throws `HR000068` and the job aborts having done nothing — *silently*, because the throw lands before whatever per-item `try/catch` the job has, or is swallowed by its own outer catch into one ERROR line nobody reads.

Found live **five times**: #2148 (`StandingOrderExecutionScheduler.sweep()` — no due standing order had ever executed, PR #2180), then the #2187 sweep found the daily sub-ledger tie-out control and the daily FX revaluation (PR #2190), the statutory ČNB fixing ingestion (PR #2191) and the monthly billing cycle (PR #2194). None had ever run.

This is a **gate** rather than a bullet in `CLAUDE.md` because the natural test cannot fail: a test that calls the method directly supplies a Vert.x context the scheduler does not, so it passes against the broken code. All five hid behind green suites exactly that way. Documentation does not stop that; a check does.

## Type of change

- [x] ci / governance

## Linked issues

Closes #2187. Refs #2148.

## Changes

- **`.github/scripts/check-no-runblocking-in-scheduled.py`** — brace-matches every `@Scheduled` method body under `openbank-*/src/main/kotlin` and flags `runBlocking` **in code**. Comments are stripped in both directions: a fix comment saying "`suspend`, never `runBlocking`" (every #2187 fix carries one) must not trip it, and a trailing `//` must not be able to hide a real one.
- **`rules.yaml: scheduled_methods`** — the authoritative rule, the why, the fix (`suspend fun`, and why it beats `VertxContextSupport.subscribeAndAwait`), the requirement that regression coverage drives the real cron, and the allowlist.
- **Allowlisted (2), each with a one-line reason:** agent-service `OversightService.scheduledSweep` and analytics-sink `ReconciliationJob.scheduled`. These were on the #2187 candidate list and triaged **NOT-AFFECTED**: neither service has Hibernate Reactive on its classpath at all — both `build.gradle.kts` say so explicitly (agent-service uses plain Agroal JDBC for proposals; analytics-sink deliberately drops `hibernate-reactive-panache`/`reactive-pg-client`/`jdbc-postgresql`). Their `runBlocking` bridges deliberately **blocking** clients, and `suspend` there would move blocking I/O onto an event loop. A stale allowlist entry is itself a violation.
- Wired into `ci.yml` beside the other `rules.yaml` gates, **ENFORCED**.

## Guard validation — three directions, before trusting it

A guard you have never seen fail proves nothing.

1. **Known-positive:** run against the pre-#2180 `StandingOrderExecutionScheduler.kt` content → **FLAGS** it (2 errors, lines 67 and 70).
2. **Known-negative:** run against current `main` with all three #2187 fixes merged → **clean**, exit 0, 62 `@Scheduled` methods checked across 1604 files, 2 allowlisted.
3. **Comment handling:** synthetic probe with one `suspend` method whose body mentions `runBlocking` in a `//` comment *and* a `/* … */` block, plus one genuinely broken method → flags only the broken one. Stale-allowlist detection exercised separately (2 errors when the allowlisted paths are absent).

## OPA bundle churn

Editing `rules.yaml` restamps every service's OPA bundle and pod-roll annotation — the 33 `gen-*opa-bundle*.sh` generators embed and hash `rules.yaml` verbatim. All were re-run (`find … -name 'gen-*opa-bundle*.sh' | sort | xargs -n1 bash`) and committed; **none hand-edited**. That is the 56 generated files in this diff. Short shelf life against a competing governance PR — merging with `--auto`.

`actionlint` on the modified `ci.yml` reports the same finding set as unmodified `main` (one pre-existing SC2086 at line 241, untouched by this PR).