### PR TITLE
fix(agent): route the assistant LLM call through the in-cluster gateway (ADR-0174/0175)

### DIFF
--- a/openbank-agent-service/CLAUDE.md
+++ b/openbank-agent-service/CLAUDE.md
@@ -47,7 +47,10 @@ JAVA_HOME=$(/usr/libexec/java_home -v 25) ./gradlew :openbank-agent-service:test
 
 ## Config gotchas
 
-- `GROQ_API_KEY` must be set for the `llama-3.3-70b-versatile` model; omit for mock-echo.
+- `AGENT_MODEL_API_KEY` (or the legacy `GROQ_API_KEY` fallback) must be set for the
+  `llama-3.3-70b-versatile` model; omit for mock-echo. Deployed, that key is the LiteLLM
+  *virtual* key and `AGENT_MODEL_ENDPOINT` points at the in-cluster gateway — the provider
+  key never lands in this pod (ADR-0174/0175).
 - `AGENT_POLICY_ENFORCEMENT=block` requires a running OPA sidecar — without it the gate
   degrades to advisory and logs a WARN (fail-open by design).
 - `AGENT_OVERSIGHT_ENABLED=true` enables the scheduled compliance-officer sweep (every 30 min).

--- a/openbank-agent-service/src/main/resources/application.yaml
+++ b/openbank-agent-service/src/main/resources/application.yaml
@@ -172,10 +172,18 @@ model-gateway:
       provider: mock
       sensitivity: hosted
     # Groq — free, fast, OpenAI-compatible. `id` is sent verbatim as the upstream model name.
-    # Served by the single `openai-compat` adapter; needs GROQ_API_KEY (see agent.model.openai).
+    # Served by the single `openai-compat` adapter; needs an API key (see agent.model.openai).
+    #
+    # ADR-0174/0175 (#1919): in a deployed environment the endpoint is repointed at the in-cluster
+    # LiteLLM gateway (`http://litellm.ai-platform.svc:4000/v1`) via AGENT_MODEL_ENDPOINT, so the
+    # gateway is the single pod allowed to leave the cluster to a US LLM provider and the provider
+    # key never lands in this pod. The model id is unchanged — litellm-config maps
+    # `llama-3.3-70b-versatile` to `groq/llama-3.3-70b-versatile` — so this is an endpoint + key
+    # change only. The direct-to-Groq URL stays the default for local dev / `./gradlew quarkusDev`,
+    # where there is no gateway to route through.
     - id: llama-3.3-70b-versatile
       provider: openai-compat
-      endpoint: https://api.groq.com/openai/v1
+      endpoint: ${AGENT_MODEL_ENDPOINT:https://api.groq.com/openai/v1}
       sensitivity: hosted
     # The SAME openai-compat adapter serves any OpenAI-shaped backend — just change endpoint+key:
     # - id: qwen2.5                       # self-hosted Ollama for the SELF_HOSTED (sensitive) tier
@@ -190,11 +198,15 @@ model-gateway:
 # case it degrades to advisory + logs a warn (so a dead OPA sidecar does not lock the assistant).
 # Set AGENT_POLICY_ENFORCEMENT=block in the k8s deployment env to enable enforcement in the sandbox.
 agent:
-  # API key for the openai-compat model backend (Groq by default). Empty in the committed config;
-  # supplied at runtime via GROQ_API_KEY (Vault/sealed-secret in a real deploy — never in git).
+  # API key for the openai-compat model backend. Empty in the committed config; supplied at runtime
+  # from OpenBao via ESO — never in git. In a deployed environment (ADR-0174/0175, #1919) this is the
+  # LiteLLM *virtual* key (AGENT_MODEL_API_KEY), not a provider key: the provider credential lives
+  # only in the ai-platform gateway pod. GROQ_API_KEY stays as the fallback so a local dev shell — and
+  # a deployed pod still running a pre-#1919 image — keeps working unchanged (nested-default
+  # expansion: AGENT_MODEL_API_KEY wins when set, GROQ_API_KEY otherwise, empty if neither).
   model:
     openai:
-      api-key: ${GROQ_API_KEY:}
+      api-key: ${AGENT_MODEL_API_KEY:${GROQ_API_KEY:}}
   policy:
     enforcement: ${AGENT_POLICY_ENFORCEMENT:advisory}
     opa:

--- a/openbank-agent-service/src/main/resources/docs/05-operations.cs.md
+++ b/openbank-agent-service/src/main/resources/docs/05-operations.cs.md
@@ -19,7 +19,9 @@
 | `QUARKUS_OIDC_AUTH_SERVER_URL` | `http://localhost:8080/realms/openbank` | issuer Keycloak realmu |
 | `OIDC_TLS_VERIFICATION` | `none` | nastavte na `required` v reálném HTTPS deployi |
 | `AGENT_DEFAULT_MODEL` | `mock-echo` | default model id gateway |
-| `GROQ_API_KEY` | *(prázdné)* | API klíč pro `openai-compat` backend (Vault/sealed-secret v reálném deployi — nikdy v gitu) |
+| `AGENT_MODEL_ENDPOINT` | `https://api.groq.com/openai/v1` | base URL `openai-compat` backendu. V nasazeném prostředí nastavte na `http://litellm.ai-platform.svc:4000/v1` — in-cluster LiteLLM gateway, jediný workload, který smí komunikovat s hostovaným LLM providerem (ADR-0174/0175) |
+| `AGENT_MODEL_API_KEY` | *(fallback na `GROQ_API_KEY`)* | klíč pro `openai-compat` backend. V nasazení jde o **virtuální** klíč LiteLLM, nikoli klíč providera (OpenBao/ESO — nikdy v gitu) |
+| `GROQ_API_KEY` | *(prázdné)* | legacy/local-dev fallback předchozího, při přímé komunikaci s Groq |
 | `AGENT_POLICY_ENFORCEMENT` | `advisory` | `advisory` (jen audit) nebo `block` (vynutit DENY) — ADR-0031 D9 |
 | `BUILD_TIME`, `GIT_COMMIT` | `unknown` | provenience pro `/api/v1/info` |
 

--- a/openbank-agent-service/src/main/resources/docs/05-operations.en.md
+++ b/openbank-agent-service/src/main/resources/docs/05-operations.en.md
@@ -19,7 +19,9 @@
 | `QUARKUS_OIDC_AUTH_SERVER_URL` | `http://localhost:8080/realms/openbank` | Keycloak realm issuer |
 | `OIDC_TLS_VERIFICATION` | `none` | set to `required` in a real HTTPS deploy |
 | `AGENT_DEFAULT_MODEL` | `mock-echo` | gateway default model id |
-| `GROQ_API_KEY` | *(empty)* | API key for the `openai-compat` backend (Vault/sealed-secret in a real deploy — never in git) |
+| `AGENT_MODEL_ENDPOINT` | `https://api.groq.com/openai/v1` | base URL of the `openai-compat` backend. In a deployed environment set to `http://litellm.ai-platform.svc:4000/v1` — the in-cluster LiteLLM gateway, the only workload permitted to egress to a hosted LLM provider (ADR-0174/0175) |
+| `AGENT_MODEL_API_KEY` | *(falls back to `GROQ_API_KEY`)* | key for the `openai-compat` backend. Deployed, this is the LiteLLM **virtual** key, not a provider key (OpenBao/ESO — never in git) |
+| `GROQ_API_KEY` | *(empty)* | legacy/local-dev fallback for the above when talking to Groq directly |
 | `AGENT_POLICY_ENFORCEMENT` | `advisory` | `advisory` (audit-only) or `block` (enforce DENY) — ADR-0031 D9 |
 | `BUILD_TIME`, `GIT_COMMIT` | `unknown` | provenance for `/api/v1/info` |
 

--- a/openbank-agent-service/src/test/kotlin/com/openbank/agent/infrastructure/model/ModelGatewayRoutingOverrideTest.kt
+++ b/openbank-agent-service/src/test/kotlin/com/openbank/agent/infrastructure/model/ModelGatewayRoutingOverrideTest.kt
@@ -1,0 +1,76 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+// Copyright (c) OpenBank contributors. Licensed under the GNU Affero General Public License v3.0 only.
+// A commercial licence is available from the maintainers as an alternative to the AGPL-3.0.
+// See LICENSES/AGPL-3.0-only.txt or https://www.gnu.org/licenses/agpl-3.0.html for details.
+
+package com.openbank.agent.infrastructure.model
+
+import com.openbank.agent.application.ModelGatewayConfig
+import io.quarkus.test.junit.QuarkusTest
+import io.quarkus.test.junit.QuarkusTestProfile
+import io.quarkus.test.junit.TestProfile
+import jakarta.inject.Inject
+import org.assertj.core.api.Assertions.assertThat
+import org.eclipse.microprofile.config.ConfigProvider
+import org.junit.jupiter.api.Test
+
+/**
+ * ADR-0174/0175 (#1919): the hosted model backend must be repointable at the in-cluster LiteLLM
+ * gateway by **environment alone** — no image rebuild, no code change — so the gateway can be the
+ * single pod allowed to egress to a US LLM provider.
+ *
+ * This guards the two config seams the GitOps manifest drives:
+ *  - `AGENT_MODEL_ENDPOINT` overrides the `llama-3.3-70b-versatile` entry's base URL (it is
+ *    `${AGENT_MODEL_ENDPOINT:https://api.groq.com/openai/v1}` in the committed config). Without the
+ *    placeholder the endpoint is baked into the image and repointing is impossible from GitOps.
+ *  - `AGENT_MODEL_API_KEY` overrides `agent.model.openai.api-key`, which is
+ *    `${AGENT_MODEL_API_KEY:${GROQ_API_KEY:}}` — a *nested* default, so a deploy still on a
+ *    pre-#1919 image (or a local dev shell) that only exports GROQ_API_KEY keeps working. If that
+ *    nesting ever stops expanding, the property resolves to the literal expression text and the
+ *    gateway would answer 401 — silently. The assertion below is against the resolved value, so a
+ *    non-expanding expression fails the test rather than shipping.
+ *
+ * Profile keeps boot infra-free (same rationale as [OpenAiCompatibleModelProviderBootTest]).
+ */
+@QuarkusTest
+@TestProfile(ModelGatewayRoutingOverrideTest.GatewayRoutedProfile::class)
+class ModelGatewayRoutingOverrideTest {
+
+    class GatewayRoutedProfile : QuarkusTestProfile {
+        override fun getConfigOverrides(): Map<String, String> = mapOf(
+            // Exactly what openbank-infra/gitops/components/agent/agent-service.yaml sets.
+            "AGENT_MODEL_ENDPOINT" to GATEWAY_URL,
+            "AGENT_MODEL_API_KEY" to VIRTUAL_KEY,
+            "quarkus.flyway.migrate-at-start" to "false",
+            "quarkus.oidc-client.early-tokens-acquisition" to "false",
+        )
+    }
+
+    @Inject
+    lateinit var modelGateway: ModelGatewayConfig
+
+    @Test
+    fun `AGENT_MODEL_ENDPOINT repoints the hosted model at the in-cluster gateway`() {
+        val hosted = modelGateway.models().single { it.id() == "llama-3.3-70b-versatile" }
+
+        assertThat(hosted.endpoint()).contains(GATEWAY_URL)
+        assertThat(hosted.provider()).isEqualTo("openai-compat")
+        // The id is sent verbatim upstream, so litellm-config must map this exact name.
+        assertThat(hosted.id()).isEqualTo("llama-3.3-70b-versatile")
+    }
+
+    @Test
+    fun `AGENT_MODEL_API_KEY resolves as the backend key and expands to a real value`() {
+        val key = ConfigProvider.getConfig()
+            .getOptionalValue("agent.model.openai.api-key", String::class.java).orElse("")
+
+        assertThat(key).isEqualTo(VIRTUAL_KEY)
+        // A non-expanding nested default would leave the raw `${...}` text here.
+        assertThat(key).doesNotContain("\${")
+    }
+
+    private companion object {
+        const val GATEWAY_URL = "http://litellm.ai-platform.svc:4000/v1"
+        const val VIRTUAL_KEY = "sk-test-virtual-key"
+    }
+}

--- a/openbank-infra/gitops/components/agent/agent-service.yaml
+++ b/openbank-infra/gitops/components/agent/agent-service.yaml
@@ -1,7 +1,9 @@
 # agent-service: the admin-UI AI assistant backend (ADR-0031 D6). A provider-agnostic
 # model gateway + MCP tool registry + policy gate. In the sandbox it runs the free
-# OpenAI-compatible Groq backend (llama-3.3-70b-versatile); the GROQ_API_KEY is synced
-# from Vault by ESO (es-agent-service). It is stateless (no DB, no Kafka): it only reads
+# OpenAI-compatible Groq backend (llama-3.3-70b-versatile) **through the in-cluster LiteLLM
+# gateway** (ADR-0174/0175, #1919): it presents a virtual key synced from OpenBao by ESO
+# (es-agent-service), and the provider key lives only in the ai-platform gateway pod, which is
+# the one workload allowed to leave the cluster. It is stateless (no DB, no Kafka): it only reads
 # the banking domain services over their in-cluster ClusterIPs via the MCP tools.
 # OIDC is disabled — the assistant endpoints carry no @RolesAllowed and the only caller
 # is the admin-ui BFF over the in-cluster network. The gate ENFORCES
@@ -78,14 +80,34 @@ spec:
             # output into the HITL queue; charter-rate-limited to 48 runs/day (every 30 min).
             - name: AGENT_OVERSIGHT_ENABLED
               value: "true"
-            # Free OpenAI-compatible backend (Groq).
+            # Free OpenAI-compatible backend (Groq), reached through the in-cluster LiteLLM gateway
+            # (ADR-0174/0175, #1919) — NOT api.groq.com directly. litellm-config maps this exact
+            # model id to `groq/llama-3.3-70b-versatile`, so the model name is unchanged and this is
+            # an endpoint + key change only. The provider key now lives solely in the ai-platform
+            # gateway pod, which is the one workload permitted to leave the cluster.
             - name: AGENT_DEFAULT_MODEL
               value: llama-3.3-70b-versatile
+            - name: AGENT_MODEL_ENDPOINT
+              value: http://litellm.ai-platform.svc:4000/v1
+            # LiteLLM virtual key (OpenBao litellm/LITELLM_MASTER_KEY via ESO), not a provider key.
+            # Optional so an un-seeded key degrades the chat call instead of CrashLooping the pod.
+            - name: AGENT_MODEL_API_KEY
+              valueFrom:
+                secretKeyRef:
+                  name: agent-service-secrets
+                  key: AGENT_MODEL_API_KEY
+                  optional: true
+            # ROLLOUT WINDOW ONLY — remove with the es-agent-service.yaml entry once the repointed
+            # image is live. The image deployed at merge time predates the AGENT_MODEL_* seam and
+            # still resolves `agent.model.openai.api-key` from GROQ_API_KEY against api.groq.com;
+            # dropping it here in the same commit would break the assistant until the deploy lands.
+            # Its removal is the precondition for the agent-pod egress lock (ADR-0175 §4).
             - name: GROQ_API_KEY
               valueFrom:
                 secretKeyRef:
                   name: agent-service-secrets
                   key: GROQ_API_KEY
+                  optional: true
             # MCP tool backends — in-cluster ClusterIPs. get_account hits account-service
             # (accounts ns, live); balance via balance-service (balances ns, live).
             - name: QUARKUS_REST_CLIENT_ACCOUNT_SERVICE_URL

--- a/openbank-infra/gitops/components/ai-platform/litellm-config.yaml
+++ b/openbank-infra/gitops/components/ai-platform/litellm-config.yaml
@@ -1,7 +1,8 @@
 # LiteLLM proxy config (ADR-0174). The single egress choke point: every agent/copilot LLM call
 # routes through here, and only this pod is allowed to leave the cluster to the provider (ADR-0175,
-# networkpolicy-litellm-egress.yaml). Model name is kept identical to what the agents already send
-# (deepseek-ai/DeepSeek-V3.2) so repointing them is an endpoint change only.
+# networkpolicy-litellm-egress.yaml). Model names are kept identical to what the callers already
+# send (deepseek-ai/DeepSeek-V3.2 for copilot + the ops agents, llama-3.3-70b-versatile for
+# agent-service) so repointing a caller is an endpoint + key change only, never a prompt change.
 apiVersion: v1
 kind: ConfigMap
 metadata:
@@ -14,6 +15,15 @@ data:
         litellm_params:
           model: deepinfra/deepseek-ai/DeepSeek-V3.2
           api_key: os.environ/DEEPINFRA_API_KEY
+      # agent-service's admin-UI assistant model (#1919). It sends `model-gateway.models[].id`
+      # verbatim, so the model_name MUST stay `llama-3.3-70b-versatile` — that is what repointing
+      # agent-service at this gateway costs: an endpoint + key change, nothing else. The Groq key
+      # is projected here from the SAME OpenBao path agent-service used to read it from, so the
+      # provider credential moves into this pod rather than being duplicated (ADR-0175).
+      - model_name: llama-3.3-70b-versatile
+        litellm_params:
+          model: groq/llama-3.3-70b-versatile
+          api_key: os.environ/GROQ_API_KEY
     general_settings:
       # Callers authenticate to LiteLLM with this virtual key (projected from OpenBao), NOT with the
       # upstream provider key — so the DeepInfra key lives only here, never in an agent pod (ADR-0175).

--- a/openbank-infra/gitops/components/ai-platform/litellm.yaml
+++ b/openbank-infra/gitops/components/ai-platform/litellm.yaml
@@ -46,6 +46,14 @@ spec:
                   name: litellm-secrets
                   key: DEEPINFRA_API_KEY
                   optional: true
+            # Second upstream provider key (Groq) — backs the llama-3.3-70b-versatile route used by
+            # agent-service (#1919). Same trade as above: it lives ONLY in this pod.
+            - name: GROQ_API_KEY
+              valueFrom:
+                secretKeyRef:
+                  name: litellm-secrets
+                  key: GROQ_API_KEY
+                  optional: true
             # Virtual key callers present to LiteLLM.
             - name: LITELLM_MASTER_KEY
               valueFrom:

--- a/openbank-infra/gitops/components/ai-platform/litellm.yaml
+++ b/openbank-infra/gitops/components/ai-platform/litellm.yaml
@@ -19,6 +19,14 @@ spec:
       labels:
         app.kubernetes.io/name: litellm
         app.kubernetes.io/part-of: ai-platform
+      annotations:
+        # LiteLLM parses --config ONCE at startup, and the ConfigMap is a plain volume mount, so a
+        # config edit reaches the filesystem and changes nothing: the proxy keeps serving the model
+        # list it booted with. Adding the llama-3.3-70b-versatile route without rolling the pod
+        # would leave agent-service's repointed call failing "model not found" with a green,
+        # in-sync ArgoCD — the same silent-degradation shape as an `optional: true` secret ref.
+        # BUMP THIS whenever litellm-config.yaml changes; that is what rolls the pod.
+        openbank.tech/litellm-config-revision: "2"
     spec:
       securityContext:
         runAsNonRoot: true

--- a/openbank-infra/gitops/components/ai-platform/model-externalsecret.yaml
+++ b/openbank-infra/gitops/components/ai-platform/model-externalsecret.yaml
@@ -33,3 +33,11 @@ spec:
       remoteRef:
         key: litellm
         property: LITELLM_MASTER_KEY
+    # Groq key for the llama-3.3-70b-versatile route (#1919). Read from the EXISTING
+    # `openbank/agent-service` KV path — no new seeding step — so the credential relocates into the
+    # gateway pod instead of being copied to a second place. Once agent-service is confirmed routed,
+    # `openbank/agent-service:GROQ_API_KEY` can be dropped from es-agent-service.yaml.
+    - secretKey: GROQ_API_KEY
+      remoteRef:
+        key: agent-service
+        property: GROQ_API_KEY

--- a/openbank-infra/gitops/components/external-secrets/es-agent-service.yaml
+++ b/openbank-infra/gitops/components/external-secrets/es-agent-service.yaml
@@ -1,6 +1,15 @@
 # agent-service secrets from OpenBao → agent-service-secrets Secret.
-# GROQ_API_KEY (external LLM API key) + OIDC_CLIENT_SECRET (openbank-services
-# realm client). Both projected from the openbank/agent-service KV path.
+#
+# AGENT_MODEL_API_KEY = the LiteLLM virtual key (ADR-0174/0175, #1919): agent-service authenticates
+# to the in-cluster gateway, NOT to the provider — the Groq key now lives only in ai-platform. Same
+# source and same shape as copilot's COPILOT_MODEL_API_KEY (es-copilot-service.yaml).
+#
+# GROQ_API_KEY is retained ONLY for the rollout window: the currently-deployed image predates the
+# AGENT_MODEL_* config seam and still reads GROQ_API_KEY against api.groq.com directly. Drop it (and
+# the matching env in agent-service.yaml) once the repointed image is live — that removal is the
+# precondition for turning on the agent-pod egress lock.
+#
+# OIDC_CLIENT_SECRET (openbank-services realm client) is unchanged.
 apiVersion: external-secrets.io/v1beta1
 kind: ExternalSecret
 metadata:
@@ -20,6 +29,10 @@ spec:
         annotations:
           argocd.argoproj.io/compare-options: IgnoreExtraneous
   data:
+    - secretKey: AGENT_MODEL_API_KEY
+      remoteRef:
+        key: litellm
+        property: LITELLM_MASTER_KEY
     - secretKey: GROQ_API_KEY
       remoteRef:
         key: agent-service


### PR DESCRIPTION
Closes nothing on its own — this is the **routing half** of #1919. The egress-lock half ships
separately (see *Why the egress lock is not in this PR*).

## What was actually true on `main`

- The gateway **is** deployed and healthy (`litellm-59b9b4c4cf-9j65p`, `1/1 Running`), and
  `copilot-service` **is** live-routed at it (`COPILOT_MODEL_ENDPOINT=http://litellm.ai-platform.svc:4000/v1`
  on the running Deployment), as are six ops agents. The issue comment claiming the real clients
  still call DeepInfra directly is stale.
- `openbank-agent-service` was the genuine remaining bypass: `model-gateway.models[].endpoint` was
  hard-coded to `https://api.groq.com/openai/v1` and the pod held the provider key. Not DeepInfra —
  **Groq** — which is why the "repoint at the existing DeepSeek route" shortcut does not apply.

## Changes

| File | Change |
|---|---|
| `openbank-agent-service/.../application.yaml` | `endpoint` → `${AGENT_MODEL_ENDPOINT:https://api.groq.com/openai/v1}`; `api-key` → `${AGENT_MODEL_API_KEY:${GROQ_API_KEY:}}` |
| `ai-platform/litellm-config.yaml` | new `llama-3.3-70b-versatile` → `groq/llama-3.3-70b-versatile` route |
| `ai-platform/litellm.yaml` + `model-externalsecret.yaml` | `GROQ_API_KEY` projected into the gateway pod from the **existing** `openbank/agent-service` KV path — no new seeding |
| `external-secrets/es-agent-service.yaml` | `AGENT_MODEL_API_KEY` ← `litellm/LITELLM_MASTER_KEY` (same pattern as copilot) |
| `agent/agent-service.yaml` | `AGENT_MODEL_ENDPOINT` + `AGENT_MODEL_API_KEY`; `GROQ_API_KEY` retained for the rollout window only |

The model id is unchanged (`llama-3.3-70b-versatile` is sent verbatim upstream by
`OpenAiCompatibleModelProvider`), so this is an endpoint + key change, never a prompt change.

`gen-network-policies.py` re-run: **no diff** — `platform` is already in litellm's generated ingress
allow-list via copilot.

## Verification

- `ModelGatewayRoutingOverrideTest` (new): asserts `AGENT_MODEL_ENDPOINT` repoints the hosted model
  entry and `AGENT_MODEL_API_KEY` resolves as the backend key. **Proven to fail** against the
  hard-coded endpoint before the change (both tests FAILED, restored, both PASS).
- The nested default `${AGENT_MODEL_API_KEY:${GROQ_API_KEY:}}` was verified against SmallRye Config
  3.17.2 directly (neither set → empty; `GROQ_API_KEY` only → groq value; both → gateway value),
  with the probe validated against a known-positive single-level expression first. The test also
  asserts the resolved value contains no literal `${`, because a non-expanding expression would
  reach the gateway as a bogus key and 401 **silently**.
- `:openbank-agent-service:ktlintCheck detekt test` — BUILD SUCCESSFUL.

## Why the egress lock is not in this PR

`agent-service`'s `policyTypes` is still `Ingress`-only, so nothing prevents the pod reaching a US
provider. That is real and it is #1919's other half — but it **cannot land in the same commit**:

The image the manifest pins today (`sandbox-237c397c`, running now) predates the `AGENT_MODEL_*`
seam. It resolves the backend key from `GROQ_API_KEY` and the endpoint from the baked-in
`https://api.groq.com/openai/v1`. An egress policy that denies internet `:443` would break the
assistant *immediately on merge* and stay broken until release-please cuts the release, the image
builds, and the deploy PR bumps the tag. That is not a guess about the policy — it is what the
running pod does.

So the lock ships as a follow-up whose precondition is checkable: the repointed image is live **and**
`GROQ_API_KEY` has been dropped from `agent-service.yaml` + `es-agent-service.yaml`.

### The outbound-destination list the lock will be built from

Enumerated from `agent-service.yaml` env, `application.yaml`, and the source — each entry is a
source→destination pair, not "the namespace":

| Destination | Port | Where it came from |
|---|---|---|
| `kube-system` CoreDNS | 53/UDP+TCP | every name resolution; proven to work through a `namespaceSelector` rule by the existing `litellm-egress` policy |
| `litellm.ai-platform.svc` | 4000 | **new**, this PR |
| `keycloak.iam.svc` | 8080 | `QUARKUS_OIDC_AUTH_SERVER_URL` — both the resource-server JWKS and the outbound client-credentials token |
| `agent-db-rw.platform.svc` (CNPG) | 5432 | `QUARKUS_DATASOURCE_JDBC_URL`; same namespace, so an egress `podSelector: {}` rule covers it |
| `openbank-cluster-kafka-bootstrap.messaging.svc` + broker pods | 9093 | `KAFKA_BOOTSTRAP_SERVERS` (mTLS listener); the allow must cover the `messaging` namespace, not just the bootstrap Service, because the client reconnects to per-broker advertised addresses |
| `account-service.accounts.svc` / `product-catalog.accounts.svc` | 8100 / 8104 | MCP tool rest-clients |
| `balance-service.balances.svc` | 8103 | MCP tool rest-client |
| `transaction-service` / `clearing-service` / `sepa-instant` (`payments`) | 8102 / 8124 / 8127 | MCP tool rest-clients |
| `ledger-service.ledger.svc` | 8101 | MCP tool rest-client |
| `aml-service.aml.svc` | 8117 | MCP tool rest-client |
| `sanctions-service.sanctions.svc` | 8123 | MCP tool rest-client |
| `fx-service.fx.svc` / `interest-service.interest.svc` / `dispute-service.dispute.svc` | 8119 / 8125 / 8135 | MCP tool rest-clients — registered but the services are not deployed; the edges must still be allowed or onboarding them later fails mysteriously |
| `kube-prometheus-stack-prometheus` / `loki` / `kube-prometheus-stack-alertmanager` / `tempo` (`observability`) | 9090 / 3100 / 9093 / 4317 | observability read tools + OTLP export |
| OPA sidecar | localhost:8181 | same pod — loopback, NetworkPolicy does not apply |

Checked and **not** needed: the Kubernetes API (no kubernetes-client on the classpath), OpenBao (the
SVID CA cert is a static base64 value verified in-process, no runtime call), S3/AWS endpoints.
Three rest-clients (`:8106`, `:8107`, `:8118`) have no manifest env and so resolve to `localhost` —
they are dead, not hidden cross-namespace edges.

The reverse direction (admin-ui → `:8109`, observability → `:8085`, security-scanner → `:8085`,
kubelet probes) is unaffected: NetworkPolicy is connection-tracked, so replies on an established
inbound connection need no egress rule.

Refs #1919
