### PR TITLE
security(agent): deny direct provider egress from the agent pod (ADR-0175 §4)

### DIFF
--- a/openbank-infra/gitops/components/agent/networkpolicy-agent-egress.yaml
+++ b/openbank-infra/gitops/components/agent/networkpolicy-agent-egress.yaml
@@ -1,0 +1,186 @@
+# Egress lockdown for agent-service (ADR-0175 §4, issue #1919).
+#
+# ADR-0175 states that the in-cluster LiteLLM gateway is the ONE workload permitted to leave the
+# cluster to a hosted (US) LLM provider. Until this file existed that was an aspiration: the agent
+# component declared `policyTypes: [Ingress]` only, so nothing stopped this pod — the one with MCP
+# read access to accounts, balances, ledger, AML and sanctions — opening a TLS session to any
+# endpoint on the internet. This policy makes the claim true for agent-service.
+#
+# Hand-written and DELIBERATELY named networkpolicy-*.yaml (not network-policies.yaml) so
+# gen-network-policies.py — which owns/overwrites network-policies.yaml and emits INGRESS only —
+# never clobbers it (ADR-0081). Same convention as ai-platform/networkpolicy-litellm-egress.yaml.
+# Ingress for this pod stays generator-owned; this file is egress-only. NetworkPolicies are additive,
+# so adding `Egress` here does not weaken the generated ingress allow-list.
+#
+# PRECONDITION — do not merge before both hold:
+#   1. The agent-service image running in the sandbox honours AGENT_MODEL_ENDPOINT (i.e. the #1919
+#      routing change is deployed, not merely merged). An older image resolves the backend endpoint
+#      from the baked-in https://api.groq.com/openai/v1, which this policy denies.
+#   2. `GROQ_API_KEY` has been dropped from agent-service.yaml and es-agent-service.yaml — its
+#      presence is the marker that the direct-to-provider path is still in use.
+#
+# THE ALLOW-LIST IS EXHAUSTIVE — every rule below is a destination agent-service actually has,
+# derived from its Deployment env, its application.yaml rest-clients, and its source. A destination
+# that is missing here is DROPPED by the VPC CNI network-policy agent (standard mode, ADR-0060) with
+# no manifest error and no policy diff — just a hung call. If a tool starts failing after this lands,
+# suspect an unlisted destination first. Rollback is a single `kubectl -n platform delete
+# networkpolicy agent-service-egress-allow-list`.
+#
+# Not listed, on purpose:
+#   - the OPA sidecar (localhost:8181) — same pod, loopback, NetworkPolicy does not apply;
+#   - the Kubernetes API — no kubernetes-client on the service's classpath;
+#   - OpenBao — AGENT_IDENTITY_SVID_CA_CERT is a static value verified in-process, no runtime call;
+#   - inbound replies (admin-ui :8109, Prometheus/security-scanner :8085, kubelet probes) — policy
+#     enforcement is connection-tracked, so an established inbound connection needs no egress rule.
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: agent-service-egress-allow-list
+  namespace: platform
+  labels:
+    app.kubernetes.io/name: agent-service
+    app.kubernetes.io/part-of: platform
+spec:
+  podSelector:
+    matchLabels:
+      app.kubernetes.io/name: agent-service
+  policyTypes:
+    - Egress
+  egress:
+    # DNS. Every other rule depends on this one resolving first.
+    - to:
+        - namespaceSelector:
+            matchLabels:
+              kubernetes.io/metadata.name: kube-system
+      ports:
+        - protocol: UDP
+          port: 53
+        - protocol: TCP
+          port: 53
+    # THE MODEL CALL — the whole point of #1919. The gateway holds the provider key and is the only
+    # workload with an internet hole; this pod reaches a hosted model exclusively through it.
+    - to:
+        - namespaceSelector:
+            matchLabels:
+              kubernetes.io/metadata.name: ai-platform
+      ports:
+        - protocol: TCP
+          port: 4000
+    # Same namespace: the single-owner CNPG proposals store (agent-db-rw:5432). CNPG pods are
+    # operator-managed and carry no app.kubernetes.io/name we control, so select the namespace's
+    # pods wholesale rather than guessing an operator label.
+    - to:
+        - podSelector: {}
+    # Keycloak: resource-server JWKS *and* the outbound client-credentials token the MCP tool
+    # clients present to the banking services (QUARKUS_OIDC_AUTH_SERVER_URL).
+    - to:
+        - namespaceSelector:
+            matchLabels:
+              kubernetes.io/metadata.name: iam
+      ports:
+        - protocol: TCP
+          port: 8080
+    # Kafka oversight-events consumer, mTLS listener (ADR-0137). The namespace — not just the
+    # bootstrap Service — because after bootstrap the client reconnects to each broker's advertised
+    # per-pod address; allowing only the bootstrap endpoint yields a consumer that connects once and
+    # then silently never fetches.
+    - to:
+        - namespaceSelector:
+            matchLabels:
+              kubernetes.io/metadata.name: messaging
+      ports:
+        - protocol: TCP
+          port: 9093
+    # MCP read tools — one rule per callee namespace, ports as declared in the Deployment env.
+    # accounts: account-service :8100, product-catalog :8104
+    - to:
+        - namespaceSelector:
+            matchLabels:
+              kubernetes.io/metadata.name: accounts
+      ports:
+        - protocol: TCP
+          port: 8100
+        - protocol: TCP
+          port: 8104
+    # balances: balance-service :8103
+    - to:
+        - namespaceSelector:
+            matchLabels:
+              kubernetes.io/metadata.name: balances
+      ports:
+        - protocol: TCP
+          port: 8103
+    # payments: transaction :8102, clearing :8124, sepa-instant :8127
+    - to:
+        - namespaceSelector:
+            matchLabels:
+              kubernetes.io/metadata.name: payments
+      ports:
+        - protocol: TCP
+          port: 8102
+        - protocol: TCP
+          port: 8124
+        - protocol: TCP
+          port: 8127
+    # ledger: ledger-service :8101
+    - to:
+        - namespaceSelector:
+            matchLabels:
+              kubernetes.io/metadata.name: ledger
+      ports:
+        - protocol: TCP
+          port: 8101
+    # aml: aml-service :8117
+    - to:
+        - namespaceSelector:
+            matchLabels:
+              kubernetes.io/metadata.name: aml
+      ports:
+        - protocol: TCP
+          port: 8117
+    # sanctions: sanctions-service :8123
+    - to:
+        - namespaceSelector:
+            matchLabels:
+              kubernetes.io/metadata.name: sanctions
+      ports:
+        - protocol: TCP
+          port: 8123
+    # fx / interest / dispute: the tools are registered but the services are not deployed yet. The
+    # edges are allowed now so onboarding one later does not fail as a mysterious hang.
+    - to:
+        - namespaceSelector:
+            matchLabels:
+              kubernetes.io/metadata.name: fx
+      ports:
+        - protocol: TCP
+          port: 8119
+    - to:
+        - namespaceSelector:
+            matchLabels:
+              kubernetes.io/metadata.name: interest
+      ports:
+        - protocol: TCP
+          port: 8125
+    - to:
+        - namespaceSelector:
+            matchLabels:
+              kubernetes.io/metadata.name: dispute
+      ports:
+        - protocol: TCP
+          port: 8135
+    # Observability: the query.observability.readonly tools (Prometheus :9090, Loki :3100,
+    # Alertmanager :9093) plus the OTLP trace export to Tempo :4317.
+    - to:
+        - namespaceSelector:
+            matchLabels:
+              kubernetes.io/metadata.name: observability
+      ports:
+        - protocol: TCP
+          port: 9090
+        - protocol: TCP
+          port: 3100
+        - protocol: TCP
+          port: 9093
+        - protocol: TCP
+          port: 4317


### PR DESCRIPTION
**DRAFT ON PURPOSE — this must not merge until #2209 is deployed.** See *Merge precondition*.

The egress half of #1919. #2209 is the routing half.

## The gap

`openbank-infra/gitops/components/agent/network-policies.yaml` declares `policyTypes: [Ingress]`
only. ADR-0175 §4 says the LiteLLM gateway is the one workload permitted to leave the cluster to a
hosted LLM provider — but nothing enforced that for `agent-service`, the pod with MCP read access to
accounts, balances, ledger, AML and sanctions. It could open a TLS session to any internet endpoint.

## The allow-list, and where each destination came from

Enumerated from the Deployment env, `application.yaml`, and the source — source→destination pairs,
not "the namespace":

| Destination | Port | Source of truth |
|---|---|---|
| `kube-system` CoreDNS | 53 UDP+TCP | every resolution. The existing `litellm-egress` policy proves a `namespaceSelector` DNS rule works here (litellm resolved and reached DeepInfra: one `POST /v1/chat/completions → 200` in its log) |
| `ai-platform` → litellm | 4000 | `AGENT_MODEL_ENDPOINT` (#2209) |
| same-namespace pods | all | `agent-db-rw.platform.svc:5432`, the CNPG proposals store. Selected as `podSelector: {}` because CNPG pods are operator-managed and carry no app label we control |
| `iam` → keycloak | 8080 | `QUARKUS_OIDC_AUTH_SERVER_URL` — resource-server JWKS *and* the outbound client-credentials token |
| `messaging` → Kafka | 9093 | `KAFKA_BOOTSTRAP_SERVERS`, mTLS listener (ADR-0137). Scoped to the namespace rather than the bootstrap Service, because after bootstrap the client reconnects to per-broker advertised addresses — a bootstrap-only rule yields a consumer that connects once and then silently never fetches |
| `accounts` | 8100, 8104 | `QUARKUS_REST_CLIENT_ACCOUNT_SERVICE_URL`, `..._PRODUCT_CATALOG_URL` |
| `balances` | 8103 | `..._BALANCE_SERVICE_URL` |
| `payments` | 8102, 8124, 8127 | `..._TRANSACTION_SERVICE_URL`, `..._CLEARING_SERVICE_URL`, `..._SEPA_INSTANT_SERVICE_URL` |
| `ledger` | 8101 | `..._LEDGER_SERVICE_URL` |
| `aml` | 8117 | `..._AML_SERVICE_URL` |
| `sanctions` | 8123 | `..._SANCTIONS_SERVICE_URL` |
| `fx` / `interest` / `dispute` | 8119 / 8125 / 8135 | `..._FX_/INTEREST_/DISPUTE_SERVICE_URL` — tools registered, services not yet deployed. Allowed now so onboarding one later does not present as a mysterious hang |
| `observability` | 9090, 3100, 9093, 4317 | Prometheus / Loki / Alertmanager read tools + `QUARKUS_OTEL_EXPORTER_OTLP_ENDPOINT` |

Deliberately **absent**, each checked rather than assumed:

- **OPA sidecar** — `QUARKUS_REST_CLIENT_OPA_URL=http://localhost:8181`, same pod. Loopback;
  NetworkPolicy does not apply. A rule for it would be cargo cult.
- **Kubernetes API** — no kubernetes-client on `openbank-agent-service`'s classpath.
- **OpenBao** — `AGENT_IDENTITY_SVID_CA_CERT` is a static base64 PEM verified in-process by
  `AgentSvidVerifier`; issuance happens elsewhere. No runtime call.
- **`:8106`, `:8107`, `:8118` rest-clients** — declared in `application.yaml` but given no manifest
  env, so they resolve to `localhost` and are dead. Not hidden cross-namespace edges — this is
  exactly the `gen-network-policies.py` blind spot from #1784, checked in the other direction.

### Reverse direction

`admin-ui → :8109`, `observability → :8085`, `security-scanner → :8085`, `admin-ui → :8181`, and
kubelet probes are all **ingress** and unaffected: enforcement is connection-tracked, so replies on
an established inbound connection need no egress rule. The generated ingress allow-list stays
generator-owned; NetworkPolicies are additive, so adding `Egress` does not weaken it.

## Merge precondition

Both must hold, and both are checkable — this is not caution-in-general:

1. **#2209 is deployed, not merely merged.** The image pinned today (`sandbox-237c397c`, running
   now) predates the `AGENT_MODEL_ENDPOINT` seam and resolves its backend from the baked-in
   `https://api.groq.com/openai/v1`. This policy denies that. Merging early takes the assistant
   offline until release-please → build → deploy-PR completes.
2. **`GROQ_API_KEY` is gone** from `agent-service.yaml` and `es-agent-service.yaml`. Its presence is
   the marker that the direct-to-provider path is still live. Fold that removal into this PR when
   rebasing it for merge.

Verify (1) with:
```
kubectl -n platform get deploy agent-service \
  -o jsonpath='{.spec.template.spec.containers[0].env[?(@.name=="AGENT_MODEL_ENDPOINT")].value}'
kubectl -n platform get pod -l app.kubernetes.io/name=agent-service \
  -o jsonpath='{.items[0].spec.containers[0].image}'
```
and confirm the running image is a post-#2209 tag.

## Not validated in a live cluster, by design

The task ran read-only: no `kubectl apply`, no hand-applied policy. This repo has been burned by a
policy validated from the wrong vantage point (#1640: a cross-namespace probe run from *inside* the
target namespace passed, then the policy blocked the real source in production), so the enumeration
above is derived from declarations rather than from a probe that could pass for the wrong reason.
Rollback is one command: `kubectl -n platform delete networkpolicy agent-service-egress-allow-list`.

Refs #1919
