### PR TITLE
chore(governance): refresh model_gateway_as_built against the running fleet (#1919)

### DIFF
--- a/.github/scripts/gen-eu-ai-act.py
+++ b/.github/scripts/gen-eu-ai-act.py
@@ -211,10 +211,36 @@ def main():
         w("goes today — distinct from `model_gateway_target`, the ADR-0031 D6 decision that is")
         w("not deployed.")
         w("")
+        gateway = mg.get("gateway", "none")
+        egress = mg.get("egress_enforced", "none")
+        routed = mg.get("routed") or []
+        not_routed = mg.get("not_routed") or []
+        # The bearing column states what the value MEANS for the obligation, so it must track the
+        # value. Hard-coding the gateway-absent prose survived the gateway being deployed once
+        # already; a generated compliance doc that contradicts its own inventory row is the exact
+        # failure this file exists to prevent.
+        gateway_bearing = (
+            "No single point to enforce residency, redaction, or an egress NetworkPolicy."
+            if gateway == "none" else
+            "A single in-cluster choke point exists — the place where residency, redaction and an "
+            "egress NetworkPolicy CAN be enforced. Whether every caller is actually forced through "
+            "it is the `Egress enforced` row, not this one."
+        )
+        egress_bearing = {
+            "full": "Every LLM caller is network-forced through the gateway; the provider is "
+                    "unreachable directly.",
+            "partial": "The gateway is enforced for its own egress, but at least one caller's pod "
+                       "can still reach a provider directly — the choke point is bypassable.",
+        }.get(egress, "No egress policy forces callers through the gateway.")
         w("| Property | As-built value | AI Act / GDPR bearing |")
         w("|---|---|---|")
-        w(f"| Gateway / egress choke point | `{mg.get('gateway', 'none')}` | "
-          "No single point to enforce residency, redaction, or an egress NetworkPolicy. |")
+        w(f"| Gateway / egress choke point | `{gateway}` | {gateway_bearing} |")
+        w(f"| Egress enforced | `{egress}` | {egress_bearing} |")
+        if routed or not_routed:
+            w(f"| Callers routed through the gateway | {', '.join('`'+r+'`' for r in routed) or 'none'} | "
+              "Prompt content from these systems has a single auditable egress path. |")
+            w(f"| Callers NOT routed | {', '.join('`'+r+'`' for r in not_routed) or 'none'} | "
+              "Prompt content from these systems reaches a provider directly. |")
         w(f"| Hosted (external) provider(s) | {', '.join('`'+h+'`' for h in hosted) or 'none'} | "
           "Prompt content leaves the platform trust boundary — Art. 10 data governance applies. |")
         w(f"| Sensitive-data routing | `{mg.get('routing', 'none')}` | "
@@ -224,7 +250,16 @@ def main():
         w(f"| Fallback | `{mg.get('fallback', 'none')}` | "
           "Single provider; on failure the agent degrades to a deterministic path. |")
         w("")
-        if hosted and mg.get("gateway", "none") == "none":
+        if hosted and gateway != "none" and egress != "full":
+            w("> ⚠ **Partially closed gap (Art. 10 / GDPR).** A hosted external provider is in use")
+            w("> behind an in-cluster gateway, so the provider credential and the egress path are")
+            w("> centralised and auditable — but the gateway is not yet the *only* way out. Until")
+            w("> `egress_enforced` reads `full`, a caller pod can still reach the provider directly")
+            w("> and the choke point is a convention, not a control. Sensitive-data routing remains")
+            w("> absent either way. Residency, DPA and the synthetic-data licence position are")
+            w("> recorded in **ADR-0175**.")
+            w("")
+        if hosted and gateway == "none":
             w("> ⚠ **Open gap (Art. 10 / GDPR).** A hosted external provider is in use with no")
             w("> gateway and no sensitive-data routing, so prompt content egresses with no enforced")
             w("> residency or redaction control. This is the platform's most material AI-egress")

--- a/docs/compliance/eu-ai-act.md
+++ b/docs/compliance/eu-ai-act.md
@@ -88,23 +88,26 @@ not deployed.
 
 | Property | As-built value | AI Act / GDPR bearing |
 |---|---|---|
-| Gateway / egress choke point | `none` | No single point to enforce residency, redaction, or an egress NetworkPolicy. |
-| Hosted (external) provider(s) | `deepinfra` | Prompt content leaves the platform trust boundary — Art. 10 data governance applies. |
+| Gateway / egress choke point | `litellm` | A single in-cluster choke point exists — the place where residency, redaction and an egress NetworkPolicy CAN be enforced. Whether every caller is actually forced through it is the `Egress enforced` row, not this one. |
+| Egress enforced | `partial` | The gateway is enforced for its own egress, but at least one caller's pod can still reach a provider directly — the choke point is bypassable. |
+| Callers routed through the gateway | `copilot-service`, `control-liveness-sentinel`, `devops-agent`, `docs-truth-agent`, `finops-agent`, `flaky-test-hunter`, `governance-auditor`, `release-steward`, `authz-policy-auditor` | Prompt content from these systems has a single auditable egress path. |
+| Callers NOT routed | `agent-service` | Prompt content from these systems reaches a provider directly. |
+| Hosted (external) provider(s) | `deepinfra`, `groq` | Prompt content leaves the platform trust boundary — Art. 10 data governance applies. |
 | Sensitive-data routing | `none` | No routing separates sensitive from non-sensitive prompt data. |
 | Budgets enforced at | `charter` | Cost control only — not a data-governance control. |
 | Fallback | `none` | Single provider; on failure the agent degrades to a deterministic path. |
 
-> ⚠ **Open gap (Art. 10 / GDPR).** A hosted external provider is in use with no
-> gateway and no sensitive-data routing, so prompt content egresses with no enforced
-> residency or redaction control. This is the platform's most material AI-egress
-> exposure and would block any high-risk (Annex III) deployment. Residency, DPA, and
-> the synthetic-data licence position are recorded in **ADR-0175**; the shared egress
-> seam that gives this path a single choke point landed in #2018, with the fleet
-> repoint tracked as its follow-up. Until that lands, treat LLM egress as un-enforced.
+> ⚠ **Partially closed gap (Art. 10 / GDPR).** A hosted external provider is in use
+> behind an in-cluster gateway, so the provider credential and the egress path are
+> centralised and auditable — but the gateway is not yet the *only* way out. Until
+> `egress_enforced` reads `full`, a caller pod can still reach the provider directly
+> and the choke point is a convention, not a control. Sensitive-data routing remains
+> absent either way. Residency, DPA and the synthetic-data licence position are
+> recorded in **ADR-0175**.
 
 ## Provenance
 
-- Source: `openbank-libs/governance/agents.yaml` (sha256 `ebac2c2fb74b933a…`, 15 charters)
+- Source: `openbank-libs/governance/agents.yaml` (sha256 `39267a3241371cc2…`, 15 charters)
 - Source: `openbank-libs/governance/ml-systems.yaml` (sha256 `9cd5cb5b20918520…`, 4 non-agent systems)
 - Related: ADR-0031 (agent governance), ADR-0084 (fraud scoring plane), ADR-0139/0140
   (ML decisioning platform), ADR-0141 (model registry), ADR-0142 (credit decisioning),

--- a/openbank-infra/gitops/components/accounts/account-opa-bundle.yaml
+++ b/openbank-infra/gitops/components/accounts/account-opa-bundle.yaml
@@ -9,7 +9,7 @@ metadata:
     app.kubernetes.io/name: account-service
     app.kubernetes.io/part-of: accounts
   annotations:
-    openbank.tech/policy-checksum: "434931963099332d"
+    openbank.tech/policy-checksum: "915e917edf55373b"
 data:
   rest.rego: |
     # SPDX-License-Identifier: Apache-2.0
@@ -724,19 +724,48 @@ data:
     # an absent control gets found, an asserted one gets relied on. Any consumer reading the bundles
     # must now hit `_target` / `_as_built` and cannot mistake the intent for the state.
     # ---------------------------------------------------------------------------------------
-    model_gateway_as_built:            # verified 2026-07-16 against gitops + the live sandbox
-      gateway: none                    # no gateway. Agents call the provider endpoint directly.
-                                       # LLM_GATEWAY_URL=http://litellm.ai-platform.svc:4000 is set on 5
-                                       # agents and points at a Service that has never existed (#1280).
-      budgets_enforced_at: charter     # CharterRateLimiter in openbank-agent-service — NOT a gateway.
-      providers:
+    model_gateway_as_built:            # verified 2026-07-25 against gitops AND the running Deployments
+      gateway: litellm                 # in-cluster LiteLLM proxy, ai-platform ns, :4000 (ADR-0174/0175,
+                                       # #2019). Deployed and serving. It is the only workload holding a
+                                       # provider key and the only one with an internet egress hole
+                                       # (ai-platform/networkpolicy-litellm-egress.yaml), so it is a real
+                                       # choke point — but see `egress_enforced` before treating it as a
+                                       # *complete* one.
+      routed:                          # read off the RUNNING Deployments' env, not off the manifests
+        - copilot-service              # COPILOT_MODEL_ENDPOINT (#2062) — the customer-facing assistant
+        - control-liveness-sentinel    # LIVENESS_MODEL_ENDPOINT
+        - devops-agent                 # DEVOPS_MODEL_ENDPOINT
+        - docs-truth-agent             # LLM_GATEWAY_URL
+        - finops-agent                 # LLM_GATEWAY_URL
+        - flaky-test-hunter            # LLM_GATEWAY_URL
+        - governance-auditor           # LLM_GATEWAY_URL
+        - release-steward              # LLM_GATEWAY_URL
+        - authz-policy-auditor         # LLM_GATEWAY_URL
+      not_routed:
+        - agent-service                # AGENT_MODEL_ENDPOINT repoint merged (#2209), but the deployed
+                                       # image resolves the baked-in api.groq.com URL until the rebuilt
+                                       # image rolls out. Promote it to `routed` only after re-reading
+                                       # the live Deployment — merged is not deployed.
+      egress_enforced: partial         # ai-platform is egress-locked; `platform` is NOT. agent-service's
+                                       # component still declares policyTypes: [Ingress] only, so the
+                                       # gateway is bypassable from that pod. #2210 adds the Egress half,
+                                       # gated on the agent-service repoint actually being deployed.
+      budgets_enforced_at: charter     # CharterRateLimiter in openbank-agent-service — NOT the gateway.
+      providers:                       # both terminate INSIDE the gateway pod; no agent holds either key
         deepinfra:                     # api.deepinfra.com, deepseek-ai/DeepSeek-V3.2. US-hosted, no region
-                                       # pinning, no DPA. The single de-facto provider; chosen on cost.
+                                       # pinning, no DPA. Serves copilot + the ops agents.
           hosted: true                 # prompt data LEAVES THE EU. Licensed for synthetic data only —
-                                       # see ADR-0175 §4/§5. There is NO technical control enforcing that.
-      routing: none                    # no sensitive_data routing exists. See ADR-0175 D3.
-      fallback: none                   # single provider. On failure LlmDiagnosisAdapter returns null and
-                                       # the agent degrades to a deterministic path (ADR-0174 §4).
+                                       # see ADR-0175 §4/§5. Routing it through the gateway centralises
+                                       # the exposure; it does not remove it.
+        groq:                          # api.groq.com, llama-3.3-70b-versatile. US-hosted, same posture.
+                                       # Serves agent-service's admin-UI assistant (#2209).
+          hosted: true                 # prompt data LEAVES THE EU. Same licence and same caveat.
+      routing: none                    # still no sensitive_data routing: the gateway serves two hosted
+                                       # models and no self-hosted tier exists. ADR-0175 D3 stays open —
+                                       # a choke point is where routing COULD be enforced, not routing.
+      fallback: none                   # no cross-provider failover is configured. On failure
+                                       # LlmDiagnosisAdapter returns null and the agent degrades to a
+                                       # deterministic path (ADR-0174 §4).
 
     model_gateway_target:              # ADR-0031 D6 — the decision. NOT the state. Nothing here is deployed.
       tool: litellm                       # or equivalent open gateway in front of all models

--- a/openbank-infra/gitops/components/accounts/account-service.yaml
+++ b/openbank-infra/gitops/components/accounts/account-service.yaml
@@ -37,7 +37,7 @@ spec:
       annotations:
         # Rolls the pod when the OPA bundle changes — subPath mounts do NOT hot-reload.
         # Kept in sync by gen-account-opa-bundle.sh (do not hand-edit).
-        openbank.tech/policy-checksum: "434931963099332d"
+        openbank.tech/policy-checksum: "915e917edf55373b"
     spec:
       securityContext:
         runAsNonRoot: true

--- a/openbank-infra/gitops/components/agent/agent-opa-bundle.yaml
+++ b/openbank-infra/gitops/components/agent/agent-opa-bundle.yaml
@@ -9,7 +9,7 @@ metadata:
     app.kubernetes.io/name: agent-service
     app.kubernetes.io/part-of: platform
   annotations:
-    openbank.tech/policy-checksum: "727b8c8d41e521f9"
+    openbank.tech/policy-checksum: "1cf8773379881a4c"
 data:
   agents.rego: |
     # SPDX-License-Identifier: Apache-2.0
@@ -278,19 +278,48 @@ data:
     # an absent control gets found, an asserted one gets relied on. Any consumer reading the bundles
     # must now hit `_target` / `_as_built` and cannot mistake the intent for the state.
     # ---------------------------------------------------------------------------------------
-    model_gateway_as_built:            # verified 2026-07-16 against gitops + the live sandbox
-      gateway: none                    # no gateway. Agents call the provider endpoint directly.
-                                       # LLM_GATEWAY_URL=http://litellm.ai-platform.svc:4000 is set on 5
-                                       # agents and points at a Service that has never existed (#1280).
-      budgets_enforced_at: charter     # CharterRateLimiter in openbank-agent-service — NOT a gateway.
-      providers:
+    model_gateway_as_built:            # verified 2026-07-25 against gitops AND the running Deployments
+      gateway: litellm                 # in-cluster LiteLLM proxy, ai-platform ns, :4000 (ADR-0174/0175,
+                                       # #2019). Deployed and serving. It is the only workload holding a
+                                       # provider key and the only one with an internet egress hole
+                                       # (ai-platform/networkpolicy-litellm-egress.yaml), so it is a real
+                                       # choke point — but see `egress_enforced` before treating it as a
+                                       # *complete* one.
+      routed:                          # read off the RUNNING Deployments' env, not off the manifests
+        - copilot-service              # COPILOT_MODEL_ENDPOINT (#2062) — the customer-facing assistant
+        - control-liveness-sentinel    # LIVENESS_MODEL_ENDPOINT
+        - devops-agent                 # DEVOPS_MODEL_ENDPOINT
+        - docs-truth-agent             # LLM_GATEWAY_URL
+        - finops-agent                 # LLM_GATEWAY_URL
+        - flaky-test-hunter            # LLM_GATEWAY_URL
+        - governance-auditor           # LLM_GATEWAY_URL
+        - release-steward              # LLM_GATEWAY_URL
+        - authz-policy-auditor         # LLM_GATEWAY_URL
+      not_routed:
+        - agent-service                # AGENT_MODEL_ENDPOINT repoint merged (#2209), but the deployed
+                                       # image resolves the baked-in api.groq.com URL until the rebuilt
+                                       # image rolls out. Promote it to `routed` only after re-reading
+                                       # the live Deployment — merged is not deployed.
+      egress_enforced: partial         # ai-platform is egress-locked; `platform` is NOT. agent-service's
+                                       # component still declares policyTypes: [Ingress] only, so the
+                                       # gateway is bypassable from that pod. #2210 adds the Egress half,
+                                       # gated on the agent-service repoint actually being deployed.
+      budgets_enforced_at: charter     # CharterRateLimiter in openbank-agent-service — NOT the gateway.
+      providers:                       # both terminate INSIDE the gateway pod; no agent holds either key
         deepinfra:                     # api.deepinfra.com, deepseek-ai/DeepSeek-V3.2. US-hosted, no region
-                                       # pinning, no DPA. The single de-facto provider; chosen on cost.
+                                       # pinning, no DPA. Serves copilot + the ops agents.
           hosted: true                 # prompt data LEAVES THE EU. Licensed for synthetic data only —
-                                       # see ADR-0175 §4/§5. There is NO technical control enforcing that.
-      routing: none                    # no sensitive_data routing exists. See ADR-0175 D3.
-      fallback: none                   # single provider. On failure LlmDiagnosisAdapter returns null and
-                                       # the agent degrades to a deterministic path (ADR-0174 §4).
+                                       # see ADR-0175 §4/§5. Routing it through the gateway centralises
+                                       # the exposure; it does not remove it.
+        groq:                          # api.groq.com, llama-3.3-70b-versatile. US-hosted, same posture.
+                                       # Serves agent-service's admin-UI assistant (#2209).
+          hosted: true                 # prompt data LEAVES THE EU. Same licence and same caveat.
+      routing: none                    # still no sensitive_data routing: the gateway serves two hosted
+                                       # models and no self-hosted tier exists. ADR-0175 D3 stays open —
+                                       # a choke point is where routing COULD be enforced, not routing.
+      fallback: none                   # no cross-provider failover is configured. On failure
+                                       # LlmDiagnosisAdapter returns null and the agent degrades to a
+                                       # deterministic path (ADR-0174 §4).
 
     model_gateway_target:              # ADR-0031 D6 — the decision. NOT the state. Nothing here is deployed.
       tool: litellm                       # or equivalent open gateway in front of all models

--- a/openbank-infra/gitops/components/agent/agent-service.yaml
+++ b/openbank-infra/gitops/components/agent/agent-service.yaml
@@ -31,7 +31,7 @@ spec:
       annotations:
         # Roll the pod when the OPA policy bundle changes (subPath mounts don't hot-reload).
         # Must match agent-opa-bundle's openbank.tech/policy-checksum (CI verifies, no drift).
-        openbank.tech/policy-checksum: "727b8c8d41e521f9"
+        openbank.tech/policy-checksum: "1cf8773379881a4c"
     spec:
       securityContext:
         runAsNonRoot: true

--- a/openbank-infra/gitops/components/anacredit/anacredit-opa-bundle.yaml
+++ b/openbank-infra/gitops/components/anacredit/anacredit-opa-bundle.yaml
@@ -9,7 +9,7 @@ metadata:
     app.kubernetes.io/name: anacredit-service
     app.kubernetes.io/part-of: anacredit
   annotations:
-    openbank.tech/policy-checksum: "0440944afa019375"
+    openbank.tech/policy-checksum: "4fa2d946aeee1688"
 data:
   rest.rego: |
     # SPDX-License-Identifier: Apache-2.0
@@ -667,19 +667,48 @@ data:
     # an absent control gets found, an asserted one gets relied on. Any consumer reading the bundles
     # must now hit `_target` / `_as_built` and cannot mistake the intent for the state.
     # ---------------------------------------------------------------------------------------
-    model_gateway_as_built:            # verified 2026-07-16 against gitops + the live sandbox
-      gateway: none                    # no gateway. Agents call the provider endpoint directly.
-                                       # LLM_GATEWAY_URL=http://litellm.ai-platform.svc:4000 is set on 5
-                                       # agents and points at a Service that has never existed (#1280).
-      budgets_enforced_at: charter     # CharterRateLimiter in openbank-agent-service — NOT a gateway.
-      providers:
+    model_gateway_as_built:            # verified 2026-07-25 against gitops AND the running Deployments
+      gateway: litellm                 # in-cluster LiteLLM proxy, ai-platform ns, :4000 (ADR-0174/0175,
+                                       # #2019). Deployed and serving. It is the only workload holding a
+                                       # provider key and the only one with an internet egress hole
+                                       # (ai-platform/networkpolicy-litellm-egress.yaml), so it is a real
+                                       # choke point — but see `egress_enforced` before treating it as a
+                                       # *complete* one.
+      routed:                          # read off the RUNNING Deployments' env, not off the manifests
+        - copilot-service              # COPILOT_MODEL_ENDPOINT (#2062) — the customer-facing assistant
+        - control-liveness-sentinel    # LIVENESS_MODEL_ENDPOINT
+        - devops-agent                 # DEVOPS_MODEL_ENDPOINT
+        - docs-truth-agent             # LLM_GATEWAY_URL
+        - finops-agent                 # LLM_GATEWAY_URL
+        - flaky-test-hunter            # LLM_GATEWAY_URL
+        - governance-auditor           # LLM_GATEWAY_URL
+        - release-steward              # LLM_GATEWAY_URL
+        - authz-policy-auditor         # LLM_GATEWAY_URL
+      not_routed:
+        - agent-service                # AGENT_MODEL_ENDPOINT repoint merged (#2209), but the deployed
+                                       # image resolves the baked-in api.groq.com URL until the rebuilt
+                                       # image rolls out. Promote it to `routed` only after re-reading
+                                       # the live Deployment — merged is not deployed.
+      egress_enforced: partial         # ai-platform is egress-locked; `platform` is NOT. agent-service's
+                                       # component still declares policyTypes: [Ingress] only, so the
+                                       # gateway is bypassable from that pod. #2210 adds the Egress half,
+                                       # gated on the agent-service repoint actually being deployed.
+      budgets_enforced_at: charter     # CharterRateLimiter in openbank-agent-service — NOT the gateway.
+      providers:                       # both terminate INSIDE the gateway pod; no agent holds either key
         deepinfra:                     # api.deepinfra.com, deepseek-ai/DeepSeek-V3.2. US-hosted, no region
-                                       # pinning, no DPA. The single de-facto provider; chosen on cost.
+                                       # pinning, no DPA. Serves copilot + the ops agents.
           hosted: true                 # prompt data LEAVES THE EU. Licensed for synthetic data only —
-                                       # see ADR-0175 §4/§5. There is NO technical control enforcing that.
-      routing: none                    # no sensitive_data routing exists. See ADR-0175 D3.
-      fallback: none                   # single provider. On failure LlmDiagnosisAdapter returns null and
-                                       # the agent degrades to a deterministic path (ADR-0174 §4).
+                                       # see ADR-0175 §4/§5. Routing it through the gateway centralises
+                                       # the exposure; it does not remove it.
+        groq:                          # api.groq.com, llama-3.3-70b-versatile. US-hosted, same posture.
+                                       # Serves agent-service's admin-UI assistant (#2209).
+          hosted: true                 # prompt data LEAVES THE EU. Same licence and same caveat.
+      routing: none                    # still no sensitive_data routing: the gateway serves two hosted
+                                       # models and no self-hosted tier exists. ADR-0175 D3 stays open —
+                                       # a choke point is where routing COULD be enforced, not routing.
+      fallback: none                   # no cross-provider failover is configured. On failure
+                                       # LlmDiagnosisAdapter returns null and the agent degrades to a
+                                       # deterministic path (ADR-0174 §4).
 
     model_gateway_target:              # ADR-0031 D6 — the decision. NOT the state. Nothing here is deployed.
       tool: litellm                       # or equivalent open gateway in front of all models

--- a/openbank-infra/gitops/components/anacredit/anacredit-service.yaml
+++ b/openbank-infra/gitops/components/anacredit/anacredit-service.yaml
@@ -32,7 +32,7 @@ spec:
       annotations:
         # Rolls the pods when the OPA bundle changes — subPath mounts do NOT hot-reload.
         # Kept in sync by gen-anacredit-opa-bundle.sh (do not hand-edit).
-        openbank.tech/policy-checksum: "0440944afa019375"
+        openbank.tech/policy-checksum: "4fa2d946aeee1688"
     spec:
       securityContext:
         runAsNonRoot: true

--- a/openbank-infra/gitops/components/ap2/ap2-opa-bundle.yaml
+++ b/openbank-infra/gitops/components/ap2/ap2-opa-bundle.yaml
@@ -9,7 +9,7 @@ metadata:
     app.kubernetes.io/name: mcp-service
     app.kubernetes.io/part-of: platform
   annotations:
-    openbank.tech/policy-checksum: "e57e6df81c829864"
+    openbank.tech/policy-checksum: "39551e1032eb36b2"
 data:
   rest.rego: |
     # SPDX-License-Identifier: Apache-2.0
@@ -635,19 +635,48 @@ data:
     # an absent control gets found, an asserted one gets relied on. Any consumer reading the bundles
     # must now hit `_target` / `_as_built` and cannot mistake the intent for the state.
     # ---------------------------------------------------------------------------------------
-    model_gateway_as_built:            # verified 2026-07-16 against gitops + the live sandbox
-      gateway: none                    # no gateway. Agents call the provider endpoint directly.
-                                       # LLM_GATEWAY_URL=http://litellm.ai-platform.svc:4000 is set on 5
-                                       # agents and points at a Service that has never existed (#1280).
-      budgets_enforced_at: charter     # CharterRateLimiter in openbank-agent-service — NOT a gateway.
-      providers:
+    model_gateway_as_built:            # verified 2026-07-25 against gitops AND the running Deployments
+      gateway: litellm                 # in-cluster LiteLLM proxy, ai-platform ns, :4000 (ADR-0174/0175,
+                                       # #2019). Deployed and serving. It is the only workload holding a
+                                       # provider key and the only one with an internet egress hole
+                                       # (ai-platform/networkpolicy-litellm-egress.yaml), so it is a real
+                                       # choke point — but see `egress_enforced` before treating it as a
+                                       # *complete* one.
+      routed:                          # read off the RUNNING Deployments' env, not off the manifests
+        - copilot-service              # COPILOT_MODEL_ENDPOINT (#2062) — the customer-facing assistant
+        - control-liveness-sentinel    # LIVENESS_MODEL_ENDPOINT
+        - devops-agent                 # DEVOPS_MODEL_ENDPOINT
+        - docs-truth-agent             # LLM_GATEWAY_URL
+        - finops-agent                 # LLM_GATEWAY_URL
+        - flaky-test-hunter            # LLM_GATEWAY_URL
+        - governance-auditor           # LLM_GATEWAY_URL
+        - release-steward              # LLM_GATEWAY_URL
+        - authz-policy-auditor         # LLM_GATEWAY_URL
+      not_routed:
+        - agent-service                # AGENT_MODEL_ENDPOINT repoint merged (#2209), but the deployed
+                                       # image resolves the baked-in api.groq.com URL until the rebuilt
+                                       # image rolls out. Promote it to `routed` only after re-reading
+                                       # the live Deployment — merged is not deployed.
+      egress_enforced: partial         # ai-platform is egress-locked; `platform` is NOT. agent-service's
+                                       # component still declares policyTypes: [Ingress] only, so the
+                                       # gateway is bypassable from that pod. #2210 adds the Egress half,
+                                       # gated on the agent-service repoint actually being deployed.
+      budgets_enforced_at: charter     # CharterRateLimiter in openbank-agent-service — NOT the gateway.
+      providers:                       # both terminate INSIDE the gateway pod; no agent holds either key
         deepinfra:                     # api.deepinfra.com, deepseek-ai/DeepSeek-V3.2. US-hosted, no region
-                                       # pinning, no DPA. The single de-facto provider; chosen on cost.
+                                       # pinning, no DPA. Serves copilot + the ops agents.
           hosted: true                 # prompt data LEAVES THE EU. Licensed for synthetic data only —
-                                       # see ADR-0175 §4/§5. There is NO technical control enforcing that.
-      routing: none                    # no sensitive_data routing exists. See ADR-0175 D3.
-      fallback: none                   # single provider. On failure LlmDiagnosisAdapter returns null and
-                                       # the agent degrades to a deterministic path (ADR-0174 §4).
+                                       # see ADR-0175 §4/§5. Routing it through the gateway centralises
+                                       # the exposure; it does not remove it.
+        groq:                          # api.groq.com, llama-3.3-70b-versatile. US-hosted, same posture.
+                                       # Serves agent-service's admin-UI assistant (#2209).
+          hosted: true                 # prompt data LEAVES THE EU. Same licence and same caveat.
+      routing: none                    # still no sensitive_data routing: the gateway serves two hosted
+                                       # models and no self-hosted tier exists. ADR-0175 D3 stays open —
+                                       # a choke point is where routing COULD be enforced, not routing.
+      fallback: none                   # no cross-provider failover is configured. On failure
+                                       # LlmDiagnosisAdapter returns null and the agent degrades to a
+                                       # deterministic path (ADR-0174 §4).
 
     model_gateway_target:              # ADR-0031 D6 — the decision. NOT the state. Nothing here is deployed.
       tool: litellm                       # or equivalent open gateway in front of all models

--- a/openbank-infra/gitops/components/ap2/ap2-service.yaml
+++ b/openbank-infra/gitops/components/ap2/ap2-service.yaml
@@ -30,7 +30,7 @@ spec:
       annotations:
         # Roll the pod when the OPA policy bundle changes (subPath mounts don't hot-reload).
         # Kept in sync by gen-ap2-opa-bundle.sh (do not hand-edit).
-        openbank.tech/policy-checksum: "e57e6df81c829864"
+        openbank.tech/policy-checksum: "39551e1032eb36b2"
     spec:
       securityContext:
         runAsNonRoot: true

--- a/openbank-infra/gitops/components/balances/balance-opa-bundle.yaml
+++ b/openbank-infra/gitops/components/balances/balance-opa-bundle.yaml
@@ -9,7 +9,7 @@ metadata:
     app.kubernetes.io/name: balance-service
     app.kubernetes.io/part-of: balances
   annotations:
-    openbank.tech/policy-checksum: "15d3070e2ef162ae"
+    openbank.tech/policy-checksum: "708c35bdca22512d"
 data:
   rest.rego: |
     # SPDX-License-Identifier: Apache-2.0
@@ -768,19 +768,48 @@ data:
     # an absent control gets found, an asserted one gets relied on. Any consumer reading the bundles
     # must now hit `_target` / `_as_built` and cannot mistake the intent for the state.
     # ---------------------------------------------------------------------------------------
-    model_gateway_as_built:            # verified 2026-07-16 against gitops + the live sandbox
-      gateway: none                    # no gateway. Agents call the provider endpoint directly.
-                                       # LLM_GATEWAY_URL=http://litellm.ai-platform.svc:4000 is set on 5
-                                       # agents and points at a Service that has never existed (#1280).
-      budgets_enforced_at: charter     # CharterRateLimiter in openbank-agent-service — NOT a gateway.
-      providers:
+    model_gateway_as_built:            # verified 2026-07-25 against gitops AND the running Deployments
+      gateway: litellm                 # in-cluster LiteLLM proxy, ai-platform ns, :4000 (ADR-0174/0175,
+                                       # #2019). Deployed and serving. It is the only workload holding a
+                                       # provider key and the only one with an internet egress hole
+                                       # (ai-platform/networkpolicy-litellm-egress.yaml), so it is a real
+                                       # choke point — but see `egress_enforced` before treating it as a
+                                       # *complete* one.
+      routed:                          # read off the RUNNING Deployments' env, not off the manifests
+        - copilot-service              # COPILOT_MODEL_ENDPOINT (#2062) — the customer-facing assistant
+        - control-liveness-sentinel    # LIVENESS_MODEL_ENDPOINT
+        - devops-agent                 # DEVOPS_MODEL_ENDPOINT
+        - docs-truth-agent             # LLM_GATEWAY_URL
+        - finops-agent                 # LLM_GATEWAY_URL
+        - flaky-test-hunter            # LLM_GATEWAY_URL
+        - governance-auditor           # LLM_GATEWAY_URL
+        - release-steward              # LLM_GATEWAY_URL
+        - authz-policy-auditor         # LLM_GATEWAY_URL
+      not_routed:
+        - agent-service                # AGENT_MODEL_ENDPOINT repoint merged (#2209), but the deployed
+                                       # image resolves the baked-in api.groq.com URL until the rebuilt
+                                       # image rolls out. Promote it to `routed` only after re-reading
+                                       # the live Deployment — merged is not deployed.
+      egress_enforced: partial         # ai-platform is egress-locked; `platform` is NOT. agent-service's
+                                       # component still declares policyTypes: [Ingress] only, so the
+                                       # gateway is bypassable from that pod. #2210 adds the Egress half,
+                                       # gated on the agent-service repoint actually being deployed.
+      budgets_enforced_at: charter     # CharterRateLimiter in openbank-agent-service — NOT the gateway.
+      providers:                       # both terminate INSIDE the gateway pod; no agent holds either key
         deepinfra:                     # api.deepinfra.com, deepseek-ai/DeepSeek-V3.2. US-hosted, no region
-                                       # pinning, no DPA. The single de-facto provider; chosen on cost.
+                                       # pinning, no DPA. Serves copilot + the ops agents.
           hosted: true                 # prompt data LEAVES THE EU. Licensed for synthetic data only —
-                                       # see ADR-0175 §4/§5. There is NO technical control enforcing that.
-      routing: none                    # no sensitive_data routing exists. See ADR-0175 D3.
-      fallback: none                   # single provider. On failure LlmDiagnosisAdapter returns null and
-                                       # the agent degrades to a deterministic path (ADR-0174 §4).
+                                       # see ADR-0175 §4/§5. Routing it through the gateway centralises
+                                       # the exposure; it does not remove it.
+        groq:                          # api.groq.com, llama-3.3-70b-versatile. US-hosted, same posture.
+                                       # Serves agent-service's admin-UI assistant (#2209).
+          hosted: true                 # prompt data LEAVES THE EU. Same licence and same caveat.
+      routing: none                    # still no sensitive_data routing: the gateway serves two hosted
+                                       # models and no self-hosted tier exists. ADR-0175 D3 stays open —
+                                       # a choke point is where routing COULD be enforced, not routing.
+      fallback: none                   # no cross-provider failover is configured. On failure
+                                       # LlmDiagnosisAdapter returns null and the agent degrades to a
+                                       # deterministic path (ADR-0174 §4).
 
     model_gateway_target:              # ADR-0031 D6 — the decision. NOT the state. Nothing here is deployed.
       tool: litellm                       # or equivalent open gateway in front of all models

--- a/openbank-infra/gitops/components/balances/balance-service.yaml
+++ b/openbank-infra/gitops/components/balances/balance-service.yaml
@@ -34,7 +34,7 @@ spec:
       annotations:
         # Rolls the pods when the OPA bundle changes — subPath mounts do NOT hot-reload.
         # Kept in sync by gen-balance-opa-bundle.sh (do not hand-edit).
-        openbank.tech/policy-checksum: "15d3070e2ef162ae"
+        openbank.tech/policy-checksum: "708c35bdca22512d"
     spec:
       securityContext:
         runAsNonRoot: true

--- a/openbank-infra/gitops/components/billing/billing-opa-bundle.yaml
+++ b/openbank-infra/gitops/components/billing/billing-opa-bundle.yaml
@@ -9,7 +9,7 @@ metadata:
     app.kubernetes.io/name: billing-service
     app.kubernetes.io/part-of: billing
   annotations:
-    openbank.tech/policy-checksum: "cce280d17c1ee65a"
+    openbank.tech/policy-checksum: "02421ff1a852528c"
 data:
   rest.rego: |
     # SPDX-License-Identifier: Apache-2.0
@@ -673,19 +673,48 @@ data:
     # an absent control gets found, an asserted one gets relied on. Any consumer reading the bundles
     # must now hit `_target` / `_as_built` and cannot mistake the intent for the state.
     # ---------------------------------------------------------------------------------------
-    model_gateway_as_built:            # verified 2026-07-16 against gitops + the live sandbox
-      gateway: none                    # no gateway. Agents call the provider endpoint directly.
-                                       # LLM_GATEWAY_URL=http://litellm.ai-platform.svc:4000 is set on 5
-                                       # agents and points at a Service that has never existed (#1280).
-      budgets_enforced_at: charter     # CharterRateLimiter in openbank-agent-service — NOT a gateway.
-      providers:
+    model_gateway_as_built:            # verified 2026-07-25 against gitops AND the running Deployments
+      gateway: litellm                 # in-cluster LiteLLM proxy, ai-platform ns, :4000 (ADR-0174/0175,
+                                       # #2019). Deployed and serving. It is the only workload holding a
+                                       # provider key and the only one with an internet egress hole
+                                       # (ai-platform/networkpolicy-litellm-egress.yaml), so it is a real
+                                       # choke point — but see `egress_enforced` before treating it as a
+                                       # *complete* one.
+      routed:                          # read off the RUNNING Deployments' env, not off the manifests
+        - copilot-service              # COPILOT_MODEL_ENDPOINT (#2062) — the customer-facing assistant
+        - control-liveness-sentinel    # LIVENESS_MODEL_ENDPOINT
+        - devops-agent                 # DEVOPS_MODEL_ENDPOINT
+        - docs-truth-agent             # LLM_GATEWAY_URL
+        - finops-agent                 # LLM_GATEWAY_URL
+        - flaky-test-hunter            # LLM_GATEWAY_URL
+        - governance-auditor           # LLM_GATEWAY_URL
+        - release-steward              # LLM_GATEWAY_URL
+        - authz-policy-auditor         # LLM_GATEWAY_URL
+      not_routed:
+        - agent-service                # AGENT_MODEL_ENDPOINT repoint merged (#2209), but the deployed
+                                       # image resolves the baked-in api.groq.com URL until the rebuilt
+                                       # image rolls out. Promote it to `routed` only after re-reading
+                                       # the live Deployment — merged is not deployed.
+      egress_enforced: partial         # ai-platform is egress-locked; `platform` is NOT. agent-service's
+                                       # component still declares policyTypes: [Ingress] only, so the
+                                       # gateway is bypassable from that pod. #2210 adds the Egress half,
+                                       # gated on the agent-service repoint actually being deployed.
+      budgets_enforced_at: charter     # CharterRateLimiter in openbank-agent-service — NOT the gateway.
+      providers:                       # both terminate INSIDE the gateway pod; no agent holds either key
         deepinfra:                     # api.deepinfra.com, deepseek-ai/DeepSeek-V3.2. US-hosted, no region
-                                       # pinning, no DPA. The single de-facto provider; chosen on cost.
+                                       # pinning, no DPA. Serves copilot + the ops agents.
           hosted: true                 # prompt data LEAVES THE EU. Licensed for synthetic data only —
-                                       # see ADR-0175 §4/§5. There is NO technical control enforcing that.
-      routing: none                    # no sensitive_data routing exists. See ADR-0175 D3.
-      fallback: none                   # single provider. On failure LlmDiagnosisAdapter returns null and
-                                       # the agent degrades to a deterministic path (ADR-0174 §4).
+                                       # see ADR-0175 §4/§5. Routing it through the gateway centralises
+                                       # the exposure; it does not remove it.
+        groq:                          # api.groq.com, llama-3.3-70b-versatile. US-hosted, same posture.
+                                       # Serves agent-service's admin-UI assistant (#2209).
+          hosted: true                 # prompt data LEAVES THE EU. Same licence and same caveat.
+      routing: none                    # still no sensitive_data routing: the gateway serves two hosted
+                                       # models and no self-hosted tier exists. ADR-0175 D3 stays open —
+                                       # a choke point is where routing COULD be enforced, not routing.
+      fallback: none                   # no cross-provider failover is configured. On failure
+                                       # LlmDiagnosisAdapter returns null and the agent degrades to a
+                                       # deterministic path (ADR-0174 §4).
 
     model_gateway_target:              # ADR-0031 D6 — the decision. NOT the state. Nothing here is deployed.
       tool: litellm                       # or equivalent open gateway in front of all models

--- a/openbank-infra/gitops/components/billing/billing-service.yaml
+++ b/openbank-infra/gitops/components/billing/billing-service.yaml
@@ -27,7 +27,7 @@ spec:
       annotations:
         # Rolls the pods when the OPA bundle changes — subPath mounts do NOT hot-reload.
         # Kept in sync by gen-billing-opa-bundle.sh (do not hand-edit).
-        openbank.tech/policy-checksum: "cce280d17c1ee65a"
+        openbank.tech/policy-checksum: "02421ff1a852528c"
     spec:
       securityContext:
         runAsNonRoot: true

--- a/openbank-infra/gitops/components/consent/consent-opa-bundle.yaml
+++ b/openbank-infra/gitops/components/consent/consent-opa-bundle.yaml
@@ -9,7 +9,7 @@ metadata:
     app.kubernetes.io/name: consent-service
     app.kubernetes.io/part-of: consent
   annotations:
-    openbank.tech/policy-checksum: "8082e5d9121ed283"
+    openbank.tech/policy-checksum: "19f4216b9a81aeab"
 data:
   rest.rego: |
     # SPDX-License-Identifier: Apache-2.0
@@ -705,19 +705,48 @@ data:
     # an absent control gets found, an asserted one gets relied on. Any consumer reading the bundles
     # must now hit `_target` / `_as_built` and cannot mistake the intent for the state.
     # ---------------------------------------------------------------------------------------
-    model_gateway_as_built:            # verified 2026-07-16 against gitops + the live sandbox
-      gateway: none                    # no gateway. Agents call the provider endpoint directly.
-                                       # LLM_GATEWAY_URL=http://litellm.ai-platform.svc:4000 is set on 5
-                                       # agents and points at a Service that has never existed (#1280).
-      budgets_enforced_at: charter     # CharterRateLimiter in openbank-agent-service — NOT a gateway.
-      providers:
+    model_gateway_as_built:            # verified 2026-07-25 against gitops AND the running Deployments
+      gateway: litellm                 # in-cluster LiteLLM proxy, ai-platform ns, :4000 (ADR-0174/0175,
+                                       # #2019). Deployed and serving. It is the only workload holding a
+                                       # provider key and the only one with an internet egress hole
+                                       # (ai-platform/networkpolicy-litellm-egress.yaml), so it is a real
+                                       # choke point — but see `egress_enforced` before treating it as a
+                                       # *complete* one.
+      routed:                          # read off the RUNNING Deployments' env, not off the manifests
+        - copilot-service              # COPILOT_MODEL_ENDPOINT (#2062) — the customer-facing assistant
+        - control-liveness-sentinel    # LIVENESS_MODEL_ENDPOINT
+        - devops-agent                 # DEVOPS_MODEL_ENDPOINT
+        - docs-truth-agent             # LLM_GATEWAY_URL
+        - finops-agent                 # LLM_GATEWAY_URL
+        - flaky-test-hunter            # LLM_GATEWAY_URL
+        - governance-auditor           # LLM_GATEWAY_URL
+        - release-steward              # LLM_GATEWAY_URL
+        - authz-policy-auditor         # LLM_GATEWAY_URL
+      not_routed:
+        - agent-service                # AGENT_MODEL_ENDPOINT repoint merged (#2209), but the deployed
+                                       # image resolves the baked-in api.groq.com URL until the rebuilt
+                                       # image rolls out. Promote it to `routed` only after re-reading
+                                       # the live Deployment — merged is not deployed.
+      egress_enforced: partial         # ai-platform is egress-locked; `platform` is NOT. agent-service's
+                                       # component still declares policyTypes: [Ingress] only, so the
+                                       # gateway is bypassable from that pod. #2210 adds the Egress half,
+                                       # gated on the agent-service repoint actually being deployed.
+      budgets_enforced_at: charter     # CharterRateLimiter in openbank-agent-service — NOT the gateway.
+      providers:                       # both terminate INSIDE the gateway pod; no agent holds either key
         deepinfra:                     # api.deepinfra.com, deepseek-ai/DeepSeek-V3.2. US-hosted, no region
-                                       # pinning, no DPA. The single de-facto provider; chosen on cost.
+                                       # pinning, no DPA. Serves copilot + the ops agents.
           hosted: true                 # prompt data LEAVES THE EU. Licensed for synthetic data only —
-                                       # see ADR-0175 §4/§5. There is NO technical control enforcing that.
-      routing: none                    # no sensitive_data routing exists. See ADR-0175 D3.
-      fallback: none                   # single provider. On failure LlmDiagnosisAdapter returns null and
-                                       # the agent degrades to a deterministic path (ADR-0174 §4).
+                                       # see ADR-0175 §4/§5. Routing it through the gateway centralises
+                                       # the exposure; it does not remove it.
+        groq:                          # api.groq.com, llama-3.3-70b-versatile. US-hosted, same posture.
+                                       # Serves agent-service's admin-UI assistant (#2209).
+          hosted: true                 # prompt data LEAVES THE EU. Same licence and same caveat.
+      routing: none                    # still no sensitive_data routing: the gateway serves two hosted
+                                       # models and no self-hosted tier exists. ADR-0175 D3 stays open —
+                                       # a choke point is where routing COULD be enforced, not routing.
+      fallback: none                   # no cross-provider failover is configured. On failure
+                                       # LlmDiagnosisAdapter returns null and the agent degrades to a
+                                       # deterministic path (ADR-0174 §4).
 
     model_gateway_target:              # ADR-0031 D6 — the decision. NOT the state. Nothing here is deployed.
       tool: litellm                       # or equivalent open gateway in front of all models

--- a/openbank-infra/gitops/components/consent/consent-service.yaml
+++ b/openbank-infra/gitops/components/consent/consent-service.yaml
@@ -28,7 +28,7 @@ spec:
       annotations:
         # Rolls the pods when the OPA bundle changes — subPath mounts do NOT hot-reload.
         # Kept in sync by gen-consent-opa-bundle.sh (do not hand-edit).
-        openbank.tech/policy-checksum: "8082e5d9121ed283"
+        openbank.tech/policy-checksum: "19f4216b9a81aeab"
     spec:
       securityContext:
         runAsNonRoot: true

--- a/openbank-infra/gitops/components/copilot/copilot-opa-bundle.yaml
+++ b/openbank-infra/gitops/components/copilot/copilot-opa-bundle.yaml
@@ -9,7 +9,7 @@ metadata:
     app.kubernetes.io/name: copilot-service
     app.kubernetes.io/part-of: platform
   annotations:
-    openbank.tech/policy-checksum: "6caeaaadfada627c"
+    openbank.tech/policy-checksum: "cb371a6499189e24"
 data:
   rest.rego: |
     # SPDX-License-Identifier: Apache-2.0
@@ -759,19 +759,48 @@ data:
     # an absent control gets found, an asserted one gets relied on. Any consumer reading the bundles
     # must now hit `_target` / `_as_built` and cannot mistake the intent for the state.
     # ---------------------------------------------------------------------------------------
-    model_gateway_as_built:            # verified 2026-07-16 against gitops + the live sandbox
-      gateway: none                    # no gateway. Agents call the provider endpoint directly.
-                                       # LLM_GATEWAY_URL=http://litellm.ai-platform.svc:4000 is set on 5
-                                       # agents and points at a Service that has never existed (#1280).
-      budgets_enforced_at: charter     # CharterRateLimiter in openbank-agent-service — NOT a gateway.
-      providers:
+    model_gateway_as_built:            # verified 2026-07-25 against gitops AND the running Deployments
+      gateway: litellm                 # in-cluster LiteLLM proxy, ai-platform ns, :4000 (ADR-0174/0175,
+                                       # #2019). Deployed and serving. It is the only workload holding a
+                                       # provider key and the only one with an internet egress hole
+                                       # (ai-platform/networkpolicy-litellm-egress.yaml), so it is a real
+                                       # choke point — but see `egress_enforced` before treating it as a
+                                       # *complete* one.
+      routed:                          # read off the RUNNING Deployments' env, not off the manifests
+        - copilot-service              # COPILOT_MODEL_ENDPOINT (#2062) — the customer-facing assistant
+        - control-liveness-sentinel    # LIVENESS_MODEL_ENDPOINT
+        - devops-agent                 # DEVOPS_MODEL_ENDPOINT
+        - docs-truth-agent             # LLM_GATEWAY_URL
+        - finops-agent                 # LLM_GATEWAY_URL
+        - flaky-test-hunter            # LLM_GATEWAY_URL
+        - governance-auditor           # LLM_GATEWAY_URL
+        - release-steward              # LLM_GATEWAY_URL
+        - authz-policy-auditor         # LLM_GATEWAY_URL
+      not_routed:
+        - agent-service                # AGENT_MODEL_ENDPOINT repoint merged (#2209), but the deployed
+                                       # image resolves the baked-in api.groq.com URL until the rebuilt
+                                       # image rolls out. Promote it to `routed` only after re-reading
+                                       # the live Deployment — merged is not deployed.
+      egress_enforced: partial         # ai-platform is egress-locked; `platform` is NOT. agent-service's
+                                       # component still declares policyTypes: [Ingress] only, so the
+                                       # gateway is bypassable from that pod. #2210 adds the Egress half,
+                                       # gated on the agent-service repoint actually being deployed.
+      budgets_enforced_at: charter     # CharterRateLimiter in openbank-agent-service — NOT the gateway.
+      providers:                       # both terminate INSIDE the gateway pod; no agent holds either key
         deepinfra:                     # api.deepinfra.com, deepseek-ai/DeepSeek-V3.2. US-hosted, no region
-                                       # pinning, no DPA. The single de-facto provider; chosen on cost.
+                                       # pinning, no DPA. Serves copilot + the ops agents.
           hosted: true                 # prompt data LEAVES THE EU. Licensed for synthetic data only —
-                                       # see ADR-0175 §4/§5. There is NO technical control enforcing that.
-      routing: none                    # no sensitive_data routing exists. See ADR-0175 D3.
-      fallback: none                   # single provider. On failure LlmDiagnosisAdapter returns null and
-                                       # the agent degrades to a deterministic path (ADR-0174 §4).
+                                       # see ADR-0175 §4/§5. Routing it through the gateway centralises
+                                       # the exposure; it does not remove it.
+        groq:                          # api.groq.com, llama-3.3-70b-versatile. US-hosted, same posture.
+                                       # Serves agent-service's admin-UI assistant (#2209).
+          hosted: true                 # prompt data LEAVES THE EU. Same licence and same caveat.
+      routing: none                    # still no sensitive_data routing: the gateway serves two hosted
+                                       # models and no self-hosted tier exists. ADR-0175 D3 stays open —
+                                       # a choke point is where routing COULD be enforced, not routing.
+      fallback: none                   # no cross-provider failover is configured. On failure
+                                       # LlmDiagnosisAdapter returns null and the agent degrades to a
+                                       # deterministic path (ADR-0174 §4).
 
     model_gateway_target:              # ADR-0031 D6 — the decision. NOT the state. Nothing here is deployed.
       tool: litellm                       # or equivalent open gateway in front of all models

--- a/openbank-infra/gitops/components/copilot/copilot-service.yaml
+++ b/openbank-infra/gitops/components/copilot/copilot-service.yaml
@@ -29,7 +29,7 @@ spec:
       annotations:
         # Rolls the pod when the OPA bundle changes — subPath mounts do NOT hot-reload.
         # Kept in sync by gen-copilot-opa-bundle.sh (do not hand-edit).
-        openbank.tech/policy-checksum: "6caeaaadfada627c"
+        openbank.tech/policy-checksum: "cb371a6499189e24"
     spec:
       securityContext:
         runAsNonRoot: true

--- a/openbank-infra/gitops/components/customer-edge/customer-edge-opa-bundle.yaml
+++ b/openbank-infra/gitops/components/customer-edge/customer-edge-opa-bundle.yaml
@@ -10,7 +10,7 @@ metadata:
     app.kubernetes.io/name: customer-edge
     app.kubernetes.io/part-of: customer-edge
   annotations:
-    openbank.tech/policy-checksum: "e686dc210d1bc4a8"
+    openbank.tech/policy-checksum: "f86f4fd928041707"
 data:
   rest.rego: |
     # SPDX-License-Identifier: Apache-2.0
@@ -2218,19 +2218,48 @@ data:
     # an absent control gets found, an asserted one gets relied on. Any consumer reading the bundles
     # must now hit `_target` / `_as_built` and cannot mistake the intent for the state.
     # ---------------------------------------------------------------------------------------
-    model_gateway_as_built:            # verified 2026-07-16 against gitops + the live sandbox
-      gateway: none                    # no gateway. Agents call the provider endpoint directly.
-                                       # LLM_GATEWAY_URL=http://litellm.ai-platform.svc:4000 is set on 5
-                                       # agents and points at a Service that has never existed (#1280).
-      budgets_enforced_at: charter     # CharterRateLimiter in openbank-agent-service — NOT a gateway.
-      providers:
+    model_gateway_as_built:            # verified 2026-07-25 against gitops AND the running Deployments
+      gateway: litellm                 # in-cluster LiteLLM proxy, ai-platform ns, :4000 (ADR-0174/0175,
+                                       # #2019). Deployed and serving. It is the only workload holding a
+                                       # provider key and the only one with an internet egress hole
+                                       # (ai-platform/networkpolicy-litellm-egress.yaml), so it is a real
+                                       # choke point — but see `egress_enforced` before treating it as a
+                                       # *complete* one.
+      routed:                          # read off the RUNNING Deployments' env, not off the manifests
+        - copilot-service              # COPILOT_MODEL_ENDPOINT (#2062) — the customer-facing assistant
+        - control-liveness-sentinel    # LIVENESS_MODEL_ENDPOINT
+        - devops-agent                 # DEVOPS_MODEL_ENDPOINT
+        - docs-truth-agent             # LLM_GATEWAY_URL
+        - finops-agent                 # LLM_GATEWAY_URL
+        - flaky-test-hunter            # LLM_GATEWAY_URL
+        - governance-auditor           # LLM_GATEWAY_URL
+        - release-steward              # LLM_GATEWAY_URL
+        - authz-policy-auditor         # LLM_GATEWAY_URL
+      not_routed:
+        - agent-service                # AGENT_MODEL_ENDPOINT repoint merged (#2209), but the deployed
+                                       # image resolves the baked-in api.groq.com URL until the rebuilt
+                                       # image rolls out. Promote it to `routed` only after re-reading
+                                       # the live Deployment — merged is not deployed.
+      egress_enforced: partial         # ai-platform is egress-locked; `platform` is NOT. agent-service's
+                                       # component still declares policyTypes: [Ingress] only, so the
+                                       # gateway is bypassable from that pod. #2210 adds the Egress half,
+                                       # gated on the agent-service repoint actually being deployed.
+      budgets_enforced_at: charter     # CharterRateLimiter in openbank-agent-service — NOT the gateway.
+      providers:                       # both terminate INSIDE the gateway pod; no agent holds either key
         deepinfra:                     # api.deepinfra.com, deepseek-ai/DeepSeek-V3.2. US-hosted, no region
-                                       # pinning, no DPA. The single de-facto provider; chosen on cost.
+                                       # pinning, no DPA. Serves copilot + the ops agents.
           hosted: true                 # prompt data LEAVES THE EU. Licensed for synthetic data only —
-                                       # see ADR-0175 §4/§5. There is NO technical control enforcing that.
-      routing: none                    # no sensitive_data routing exists. See ADR-0175 D3.
-      fallback: none                   # single provider. On failure LlmDiagnosisAdapter returns null and
-                                       # the agent degrades to a deterministic path (ADR-0174 §4).
+                                       # see ADR-0175 §4/§5. Routing it through the gateway centralises
+                                       # the exposure; it does not remove it.
+        groq:                          # api.groq.com, llama-3.3-70b-versatile. US-hosted, same posture.
+                                       # Serves agent-service's admin-UI assistant (#2209).
+          hosted: true                 # prompt data LEAVES THE EU. Same licence and same caveat.
+      routing: none                    # still no sensitive_data routing: the gateway serves two hosted
+                                       # models and no self-hosted tier exists. ADR-0175 D3 stays open —
+                                       # a choke point is where routing COULD be enforced, not routing.
+      fallback: none                   # no cross-provider failover is configured. On failure
+                                       # LlmDiagnosisAdapter returns null and the agent degrades to a
+                                       # deterministic path (ADR-0174 §4).
 
     model_gateway_target:              # ADR-0031 D6 — the decision. NOT the state. Nothing here is deployed.
       tool: litellm                       # or equivalent open gateway in front of all models

--- a/openbank-infra/gitops/components/customer-edge/customer-edge.yaml
+++ b/openbank-infra/gitops/components/customer-edge/customer-edge.yaml
@@ -65,7 +65,7 @@ spec:
       annotations:
         # Rolls the pod when the OPA bundle changes — subPath mounts do NOT hot-reload.
         # Kept in sync by gen-customer-edge-opa-bundle.sh (do not hand-edit).
-        openbank.tech/policy-checksum: "e686dc210d1bc4a8"
+        openbank.tech/policy-checksum: "f86f4fd928041707"
     spec:
       # Dedicated SA so EKS Pod Identity can hand the edge (and ONLY the edge) the
       # feedback-screenshots S3 role — ADR-0192, openbank-infra/aws/envs/sandbox-platform/

--- a/openbank-infra/gitops/components/document-service/document-service-opa-bundle.yaml
+++ b/openbank-infra/gitops/components/document-service/document-service-opa-bundle.yaml
@@ -10,7 +10,7 @@ metadata:
     app.kubernetes.io/name: document-service
     app.kubernetes.io/part-of: documents
   annotations:
-    openbank.tech/policy-checksum: "e686dc210d1bc4a8"
+    openbank.tech/policy-checksum: "f86f4fd928041707"
 data:
   rest.rego: |
     # SPDX-License-Identifier: Apache-2.0
@@ -2218,19 +2218,48 @@ data:
     # an absent control gets found, an asserted one gets relied on. Any consumer reading the bundles
     # must now hit `_target` / `_as_built` and cannot mistake the intent for the state.
     # ---------------------------------------------------------------------------------------
-    model_gateway_as_built:            # verified 2026-07-16 against gitops + the live sandbox
-      gateway: none                    # no gateway. Agents call the provider endpoint directly.
-                                       # LLM_GATEWAY_URL=http://litellm.ai-platform.svc:4000 is set on 5
-                                       # agents and points at a Service that has never existed (#1280).
-      budgets_enforced_at: charter     # CharterRateLimiter in openbank-agent-service — NOT a gateway.
-      providers:
+    model_gateway_as_built:            # verified 2026-07-25 against gitops AND the running Deployments
+      gateway: litellm                 # in-cluster LiteLLM proxy, ai-platform ns, :4000 (ADR-0174/0175,
+                                       # #2019). Deployed and serving. It is the only workload holding a
+                                       # provider key and the only one with an internet egress hole
+                                       # (ai-platform/networkpolicy-litellm-egress.yaml), so it is a real
+                                       # choke point — but see `egress_enforced` before treating it as a
+                                       # *complete* one.
+      routed:                          # read off the RUNNING Deployments' env, not off the manifests
+        - copilot-service              # COPILOT_MODEL_ENDPOINT (#2062) — the customer-facing assistant
+        - control-liveness-sentinel    # LIVENESS_MODEL_ENDPOINT
+        - devops-agent                 # DEVOPS_MODEL_ENDPOINT
+        - docs-truth-agent             # LLM_GATEWAY_URL
+        - finops-agent                 # LLM_GATEWAY_URL
+        - flaky-test-hunter            # LLM_GATEWAY_URL
+        - governance-auditor           # LLM_GATEWAY_URL
+        - release-steward              # LLM_GATEWAY_URL
+        - authz-policy-auditor         # LLM_GATEWAY_URL
+      not_routed:
+        - agent-service                # AGENT_MODEL_ENDPOINT repoint merged (#2209), but the deployed
+                                       # image resolves the baked-in api.groq.com URL until the rebuilt
+                                       # image rolls out. Promote it to `routed` only after re-reading
+                                       # the live Deployment — merged is not deployed.
+      egress_enforced: partial         # ai-platform is egress-locked; `platform` is NOT. agent-service's
+                                       # component still declares policyTypes: [Ingress] only, so the
+                                       # gateway is bypassable from that pod. #2210 adds the Egress half,
+                                       # gated on the agent-service repoint actually being deployed.
+      budgets_enforced_at: charter     # CharterRateLimiter in openbank-agent-service — NOT the gateway.
+      providers:                       # both terminate INSIDE the gateway pod; no agent holds either key
         deepinfra:                     # api.deepinfra.com, deepseek-ai/DeepSeek-V3.2. US-hosted, no region
-                                       # pinning, no DPA. The single de-facto provider; chosen on cost.
+                                       # pinning, no DPA. Serves copilot + the ops agents.
           hosted: true                 # prompt data LEAVES THE EU. Licensed for synthetic data only —
-                                       # see ADR-0175 §4/§5. There is NO technical control enforcing that.
-      routing: none                    # no sensitive_data routing exists. See ADR-0175 D3.
-      fallback: none                   # single provider. On failure LlmDiagnosisAdapter returns null and
-                                       # the agent degrades to a deterministic path (ADR-0174 §4).
+                                       # see ADR-0175 §4/§5. Routing it through the gateway centralises
+                                       # the exposure; it does not remove it.
+        groq:                          # api.groq.com, llama-3.3-70b-versatile. US-hosted, same posture.
+                                       # Serves agent-service's admin-UI assistant (#2209).
+          hosted: true                 # prompt data LEAVES THE EU. Same licence and same caveat.
+      routing: none                    # still no sensitive_data routing: the gateway serves two hosted
+                                       # models and no self-hosted tier exists. ADR-0175 D3 stays open —
+                                       # a choke point is where routing COULD be enforced, not routing.
+      fallback: none                   # no cross-provider failover is configured. On failure
+                                       # LlmDiagnosisAdapter returns null and the agent degrades to a
+                                       # deterministic path (ADR-0174 §4).
 
     model_gateway_target:              # ADR-0031 D6 — the decision. NOT the state. Nothing here is deployed.
       tool: litellm                       # or equivalent open gateway in front of all models

--- a/openbank-infra/gitops/components/document-service/document-service-service.yaml
+++ b/openbank-infra/gitops/components/document-service/document-service-service.yaml
@@ -43,7 +43,7 @@ spec:
       annotations:
         # Rolls the pods when the OPA bundle changes — subPath mounts do NOT hot-reload.
         # Kept in sync by gen-document-service-opa-bundle.sh (do not hand-edit).
-        openbank.tech/policy-checksum: "e686dc210d1bc4a8"
+        openbank.tech/policy-checksum: "f86f4fd928041707"
     spec:
       # ADR-0162 D4 (continued): a dedicated SA (not `default`) is what OpenBao's Kubernetes-auth
       # role `document-service-signing` is bound to — least-privilege, one identity per consumer.

--- a/openbank-infra/gitops/components/fraud-service/fraud-opa-bundle.yaml
+++ b/openbank-infra/gitops/components/fraud-service/fraud-opa-bundle.yaml
@@ -9,7 +9,7 @@ metadata:
     app.kubernetes.io/name: fraud-service
     app.kubernetes.io/part-of: fraud
   annotations:
-    openbank.tech/policy-checksum: "ba23359b2845465f"
+    openbank.tech/policy-checksum: "5a6ea4eeeab0fcf6"
 data:
   rest.rego: |
     # SPDX-License-Identifier: Apache-2.0
@@ -684,19 +684,48 @@ data:
     # an absent control gets found, an asserted one gets relied on. Any consumer reading the bundles
     # must now hit `_target` / `_as_built` and cannot mistake the intent for the state.
     # ---------------------------------------------------------------------------------------
-    model_gateway_as_built:            # verified 2026-07-16 against gitops + the live sandbox
-      gateway: none                    # no gateway. Agents call the provider endpoint directly.
-                                       # LLM_GATEWAY_URL=http://litellm.ai-platform.svc:4000 is set on 5
-                                       # agents and points at a Service that has never existed (#1280).
-      budgets_enforced_at: charter     # CharterRateLimiter in openbank-agent-service — NOT a gateway.
-      providers:
+    model_gateway_as_built:            # verified 2026-07-25 against gitops AND the running Deployments
+      gateway: litellm                 # in-cluster LiteLLM proxy, ai-platform ns, :4000 (ADR-0174/0175,
+                                       # #2019). Deployed and serving. It is the only workload holding a
+                                       # provider key and the only one with an internet egress hole
+                                       # (ai-platform/networkpolicy-litellm-egress.yaml), so it is a real
+                                       # choke point — but see `egress_enforced` before treating it as a
+                                       # *complete* one.
+      routed:                          # read off the RUNNING Deployments' env, not off the manifests
+        - copilot-service              # COPILOT_MODEL_ENDPOINT (#2062) — the customer-facing assistant
+        - control-liveness-sentinel    # LIVENESS_MODEL_ENDPOINT
+        - devops-agent                 # DEVOPS_MODEL_ENDPOINT
+        - docs-truth-agent             # LLM_GATEWAY_URL
+        - finops-agent                 # LLM_GATEWAY_URL
+        - flaky-test-hunter            # LLM_GATEWAY_URL
+        - governance-auditor           # LLM_GATEWAY_URL
+        - release-steward              # LLM_GATEWAY_URL
+        - authz-policy-auditor         # LLM_GATEWAY_URL
+      not_routed:
+        - agent-service                # AGENT_MODEL_ENDPOINT repoint merged (#2209), but the deployed
+                                       # image resolves the baked-in api.groq.com URL until the rebuilt
+                                       # image rolls out. Promote it to `routed` only after re-reading
+                                       # the live Deployment — merged is not deployed.
+      egress_enforced: partial         # ai-platform is egress-locked; `platform` is NOT. agent-service's
+                                       # component still declares policyTypes: [Ingress] only, so the
+                                       # gateway is bypassable from that pod. #2210 adds the Egress half,
+                                       # gated on the agent-service repoint actually being deployed.
+      budgets_enforced_at: charter     # CharterRateLimiter in openbank-agent-service — NOT the gateway.
+      providers:                       # both terminate INSIDE the gateway pod; no agent holds either key
         deepinfra:                     # api.deepinfra.com, deepseek-ai/DeepSeek-V3.2. US-hosted, no region
-                                       # pinning, no DPA. The single de-facto provider; chosen on cost.
+                                       # pinning, no DPA. Serves copilot + the ops agents.
           hosted: true                 # prompt data LEAVES THE EU. Licensed for synthetic data only —
-                                       # see ADR-0175 §4/§5. There is NO technical control enforcing that.
-      routing: none                    # no sensitive_data routing exists. See ADR-0175 D3.
-      fallback: none                   # single provider. On failure LlmDiagnosisAdapter returns null and
-                                       # the agent degrades to a deterministic path (ADR-0174 §4).
+                                       # see ADR-0175 §4/§5. Routing it through the gateway centralises
+                                       # the exposure; it does not remove it.
+        groq:                          # api.groq.com, llama-3.3-70b-versatile. US-hosted, same posture.
+                                       # Serves agent-service's admin-UI assistant (#2209).
+          hosted: true                 # prompt data LEAVES THE EU. Same licence and same caveat.
+      routing: none                    # still no sensitive_data routing: the gateway serves two hosted
+                                       # models and no self-hosted tier exists. ADR-0175 D3 stays open —
+                                       # a choke point is where routing COULD be enforced, not routing.
+      fallback: none                   # no cross-provider failover is configured. On failure
+                                       # LlmDiagnosisAdapter returns null and the agent degrades to a
+                                       # deterministic path (ADR-0174 §4).
 
     model_gateway_target:              # ADR-0031 D6 — the decision. NOT the state. Nothing here is deployed.
       tool: litellm                       # or equivalent open gateway in front of all models

--- a/openbank-infra/gitops/components/fraud-service/fraud-service.yaml
+++ b/openbank-infra/gitops/components/fraud-service/fraud-service.yaml
@@ -23,7 +23,7 @@ spec:
       annotations:
         # Rolls the pods when the OPA bundle changes — subPath mounts do NOT hot-reload.
         # Kept in sync by gen-fraud-opa-bundle.sh (do not hand-edit).
-        openbank.tech/policy-checksum: "ba23359b2845465f"
+        openbank.tech/policy-checksum: "5a6ea4eeeab0fcf6"
     spec:
       securityContext:
         runAsNonRoot: true

--- a/openbank-infra/gitops/components/fx-service/fx-opa-bundle.yaml
+++ b/openbank-infra/gitops/components/fx-service/fx-opa-bundle.yaml
@@ -9,7 +9,7 @@ metadata:
     app.kubernetes.io/name: fx-service
     app.kubernetes.io/part-of: fx
   annotations:
-    openbank.tech/policy-checksum: "6f0be59e4e5ac0c7"
+    openbank.tech/policy-checksum: "bdf8a13c435719ec"
 data:
   rest.rego: |
     # SPDX-License-Identifier: Apache-2.0
@@ -735,19 +735,48 @@ data:
     # an absent control gets found, an asserted one gets relied on. Any consumer reading the bundles
     # must now hit `_target` / `_as_built` and cannot mistake the intent for the state.
     # ---------------------------------------------------------------------------------------
-    model_gateway_as_built:            # verified 2026-07-16 against gitops + the live sandbox
-      gateway: none                    # no gateway. Agents call the provider endpoint directly.
-                                       # LLM_GATEWAY_URL=http://litellm.ai-platform.svc:4000 is set on 5
-                                       # agents and points at a Service that has never existed (#1280).
-      budgets_enforced_at: charter     # CharterRateLimiter in openbank-agent-service — NOT a gateway.
-      providers:
+    model_gateway_as_built:            # verified 2026-07-25 against gitops AND the running Deployments
+      gateway: litellm                 # in-cluster LiteLLM proxy, ai-platform ns, :4000 (ADR-0174/0175,
+                                       # #2019). Deployed and serving. It is the only workload holding a
+                                       # provider key and the only one with an internet egress hole
+                                       # (ai-platform/networkpolicy-litellm-egress.yaml), so it is a real
+                                       # choke point — but see `egress_enforced` before treating it as a
+                                       # *complete* one.
+      routed:                          # read off the RUNNING Deployments' env, not off the manifests
+        - copilot-service              # COPILOT_MODEL_ENDPOINT (#2062) — the customer-facing assistant
+        - control-liveness-sentinel    # LIVENESS_MODEL_ENDPOINT
+        - devops-agent                 # DEVOPS_MODEL_ENDPOINT
+        - docs-truth-agent             # LLM_GATEWAY_URL
+        - finops-agent                 # LLM_GATEWAY_URL
+        - flaky-test-hunter            # LLM_GATEWAY_URL
+        - governance-auditor           # LLM_GATEWAY_URL
+        - release-steward              # LLM_GATEWAY_URL
+        - authz-policy-auditor         # LLM_GATEWAY_URL
+      not_routed:
+        - agent-service                # AGENT_MODEL_ENDPOINT repoint merged (#2209), but the deployed
+                                       # image resolves the baked-in api.groq.com URL until the rebuilt
+                                       # image rolls out. Promote it to `routed` only after re-reading
+                                       # the live Deployment — merged is not deployed.
+      egress_enforced: partial         # ai-platform is egress-locked; `platform` is NOT. agent-service's
+                                       # component still declares policyTypes: [Ingress] only, so the
+                                       # gateway is bypassable from that pod. #2210 adds the Egress half,
+                                       # gated on the agent-service repoint actually being deployed.
+      budgets_enforced_at: charter     # CharterRateLimiter in openbank-agent-service — NOT the gateway.
+      providers:                       # both terminate INSIDE the gateway pod; no agent holds either key
         deepinfra:                     # api.deepinfra.com, deepseek-ai/DeepSeek-V3.2. US-hosted, no region
-                                       # pinning, no DPA. The single de-facto provider; chosen on cost.
+                                       # pinning, no DPA. Serves copilot + the ops agents.
           hosted: true                 # prompt data LEAVES THE EU. Licensed for synthetic data only —
-                                       # see ADR-0175 §4/§5. There is NO technical control enforcing that.
-      routing: none                    # no sensitive_data routing exists. See ADR-0175 D3.
-      fallback: none                   # single provider. On failure LlmDiagnosisAdapter returns null and
-                                       # the agent degrades to a deterministic path (ADR-0174 §4).
+                                       # see ADR-0175 §4/§5. Routing it through the gateway centralises
+                                       # the exposure; it does not remove it.
+        groq:                          # api.groq.com, llama-3.3-70b-versatile. US-hosted, same posture.
+                                       # Serves agent-service's admin-UI assistant (#2209).
+          hosted: true                 # prompt data LEAVES THE EU. Same licence and same caveat.
+      routing: none                    # still no sensitive_data routing: the gateway serves two hosted
+                                       # models and no self-hosted tier exists. ADR-0175 D3 stays open —
+                                       # a choke point is where routing COULD be enforced, not routing.
+      fallback: none                   # no cross-provider failover is configured. On failure
+                                       # LlmDiagnosisAdapter returns null and the agent degrades to a
+                                       # deterministic path (ADR-0174 §4).
 
     model_gateway_target:              # ADR-0031 D6 — the decision. NOT the state. Nothing here is deployed.
       tool: litellm                       # or equivalent open gateway in front of all models

--- a/openbank-infra/gitops/components/fx-service/fx-service.yaml
+++ b/openbank-infra/gitops/components/fx-service/fx-service.yaml
@@ -22,7 +22,7 @@ spec:
       annotations:
         # Rolls the pods when the OPA bundle changes — subPath mounts do NOT hot-reload.
         # Kept in sync by gen-fx-opa-bundle.sh (do not hand-edit).
-        openbank.tech/policy-checksum: "6f0be59e4e5ac0c7"
+        openbank.tech/policy-checksum: "bdf8a13c435719ec"
     spec:
       securityContext:
         runAsNonRoot: true

--- a/openbank-infra/gitops/components/interest-service/interest-opa-bundle.yaml
+++ b/openbank-infra/gitops/components/interest-service/interest-opa-bundle.yaml
@@ -9,7 +9,7 @@ metadata:
     app.kubernetes.io/name: interest-service
     app.kubernetes.io/part-of: interest
   annotations:
-    openbank.tech/policy-checksum: "997bcf09bf094366"
+    openbank.tech/policy-checksum: "2c7f3a3883ca331b"
 data:
   rest.rego: |
     # SPDX-License-Identifier: Apache-2.0
@@ -669,19 +669,48 @@ data:
     # an absent control gets found, an asserted one gets relied on. Any consumer reading the bundles
     # must now hit `_target` / `_as_built` and cannot mistake the intent for the state.
     # ---------------------------------------------------------------------------------------
-    model_gateway_as_built:            # verified 2026-07-16 against gitops + the live sandbox
-      gateway: none                    # no gateway. Agents call the provider endpoint directly.
-                                       # LLM_GATEWAY_URL=http://litellm.ai-platform.svc:4000 is set on 5
-                                       # agents and points at a Service that has never existed (#1280).
-      budgets_enforced_at: charter     # CharterRateLimiter in openbank-agent-service — NOT a gateway.
-      providers:
+    model_gateway_as_built:            # verified 2026-07-25 against gitops AND the running Deployments
+      gateway: litellm                 # in-cluster LiteLLM proxy, ai-platform ns, :4000 (ADR-0174/0175,
+                                       # #2019). Deployed and serving. It is the only workload holding a
+                                       # provider key and the only one with an internet egress hole
+                                       # (ai-platform/networkpolicy-litellm-egress.yaml), so it is a real
+                                       # choke point — but see `egress_enforced` before treating it as a
+                                       # *complete* one.
+      routed:                          # read off the RUNNING Deployments' env, not off the manifests
+        - copilot-service              # COPILOT_MODEL_ENDPOINT (#2062) — the customer-facing assistant
+        - control-liveness-sentinel    # LIVENESS_MODEL_ENDPOINT
+        - devops-agent                 # DEVOPS_MODEL_ENDPOINT
+        - docs-truth-agent             # LLM_GATEWAY_URL
+        - finops-agent                 # LLM_GATEWAY_URL
+        - flaky-test-hunter            # LLM_GATEWAY_URL
+        - governance-auditor           # LLM_GATEWAY_URL
+        - release-steward              # LLM_GATEWAY_URL
+        - authz-policy-auditor         # LLM_GATEWAY_URL
+      not_routed:
+        - agent-service                # AGENT_MODEL_ENDPOINT repoint merged (#2209), but the deployed
+                                       # image resolves the baked-in api.groq.com URL until the rebuilt
+                                       # image rolls out. Promote it to `routed` only after re-reading
+                                       # the live Deployment — merged is not deployed.
+      egress_enforced: partial         # ai-platform is egress-locked; `platform` is NOT. agent-service's
+                                       # component still declares policyTypes: [Ingress] only, so the
+                                       # gateway is bypassable from that pod. #2210 adds the Egress half,
+                                       # gated on the agent-service repoint actually being deployed.
+      budgets_enforced_at: charter     # CharterRateLimiter in openbank-agent-service — NOT the gateway.
+      providers:                       # both terminate INSIDE the gateway pod; no agent holds either key
         deepinfra:                     # api.deepinfra.com, deepseek-ai/DeepSeek-V3.2. US-hosted, no region
-                                       # pinning, no DPA. The single de-facto provider; chosen on cost.
+                                       # pinning, no DPA. Serves copilot + the ops agents.
           hosted: true                 # prompt data LEAVES THE EU. Licensed for synthetic data only —
-                                       # see ADR-0175 §4/§5. There is NO technical control enforcing that.
-      routing: none                    # no sensitive_data routing exists. See ADR-0175 D3.
-      fallback: none                   # single provider. On failure LlmDiagnosisAdapter returns null and
-                                       # the agent degrades to a deterministic path (ADR-0174 §4).
+                                       # see ADR-0175 §4/§5. Routing it through the gateway centralises
+                                       # the exposure; it does not remove it.
+        groq:                          # api.groq.com, llama-3.3-70b-versatile. US-hosted, same posture.
+                                       # Serves agent-service's admin-UI assistant (#2209).
+          hosted: true                 # prompt data LEAVES THE EU. Same licence and same caveat.
+      routing: none                    # still no sensitive_data routing: the gateway serves two hosted
+                                       # models and no self-hosted tier exists. ADR-0175 D3 stays open —
+                                       # a choke point is where routing COULD be enforced, not routing.
+      fallback: none                   # no cross-provider failover is configured. On failure
+                                       # LlmDiagnosisAdapter returns null and the agent degrades to a
+                                       # deterministic path (ADR-0174 §4).
 
     model_gateway_target:              # ADR-0031 D6 — the decision. NOT the state. Nothing here is deployed.
       tool: litellm                       # or equivalent open gateway in front of all models

--- a/openbank-infra/gitops/components/interest-service/interest-service.yaml
+++ b/openbank-infra/gitops/components/interest-service/interest-service.yaml
@@ -16,7 +16,7 @@ spec:
       annotations:
         # Rolls the pods when the OPA bundle changes — subPath mounts do NOT hot-reload.
         # Kept in sync by gen-interest-opa-bundle.sh (do not hand-edit).
-        openbank.tech/policy-checksum: "997bcf09bf094366"
+        openbank.tech/policy-checksum: "2c7f3a3883ca331b"
     spec:
       securityContext:
         runAsNonRoot: true

--- a/openbank-infra/gitops/components/ledger/ledger-opa-bundle.yaml
+++ b/openbank-infra/gitops/components/ledger/ledger-opa-bundle.yaml
@@ -9,7 +9,7 @@ metadata:
     app.kubernetes.io/name: ledger-service
     app.kubernetes.io/part-of: ledger
   annotations:
-    openbank.tech/policy-checksum: "bb82a10437468998"
+    openbank.tech/policy-checksum: "b27fef0b0d139a8a"
 data:
   rest.rego: |
     # SPDX-License-Identifier: Apache-2.0
@@ -782,19 +782,48 @@ data:
     # an absent control gets found, an asserted one gets relied on. Any consumer reading the bundles
     # must now hit `_target` / `_as_built` and cannot mistake the intent for the state.
     # ---------------------------------------------------------------------------------------
-    model_gateway_as_built:            # verified 2026-07-16 against gitops + the live sandbox
-      gateway: none                    # no gateway. Agents call the provider endpoint directly.
-                                       # LLM_GATEWAY_URL=http://litellm.ai-platform.svc:4000 is set on 5
-                                       # agents and points at a Service that has never existed (#1280).
-      budgets_enforced_at: charter     # CharterRateLimiter in openbank-agent-service — NOT a gateway.
-      providers:
+    model_gateway_as_built:            # verified 2026-07-25 against gitops AND the running Deployments
+      gateway: litellm                 # in-cluster LiteLLM proxy, ai-platform ns, :4000 (ADR-0174/0175,
+                                       # #2019). Deployed and serving. It is the only workload holding a
+                                       # provider key and the only one with an internet egress hole
+                                       # (ai-platform/networkpolicy-litellm-egress.yaml), so it is a real
+                                       # choke point — but see `egress_enforced` before treating it as a
+                                       # *complete* one.
+      routed:                          # read off the RUNNING Deployments' env, not off the manifests
+        - copilot-service              # COPILOT_MODEL_ENDPOINT (#2062) — the customer-facing assistant
+        - control-liveness-sentinel    # LIVENESS_MODEL_ENDPOINT
+        - devops-agent                 # DEVOPS_MODEL_ENDPOINT
+        - docs-truth-agent             # LLM_GATEWAY_URL
+        - finops-agent                 # LLM_GATEWAY_URL
+        - flaky-test-hunter            # LLM_GATEWAY_URL
+        - governance-auditor           # LLM_GATEWAY_URL
+        - release-steward              # LLM_GATEWAY_URL
+        - authz-policy-auditor         # LLM_GATEWAY_URL
+      not_routed:
+        - agent-service                # AGENT_MODEL_ENDPOINT repoint merged (#2209), but the deployed
+                                       # image resolves the baked-in api.groq.com URL until the rebuilt
+                                       # image rolls out. Promote it to `routed` only after re-reading
+                                       # the live Deployment — merged is not deployed.
+      egress_enforced: partial         # ai-platform is egress-locked; `platform` is NOT. agent-service's
+                                       # component still declares policyTypes: [Ingress] only, so the
+                                       # gateway is bypassable from that pod. #2210 adds the Egress half,
+                                       # gated on the agent-service repoint actually being deployed.
+      budgets_enforced_at: charter     # CharterRateLimiter in openbank-agent-service — NOT the gateway.
+      providers:                       # both terminate INSIDE the gateway pod; no agent holds either key
         deepinfra:                     # api.deepinfra.com, deepseek-ai/DeepSeek-V3.2. US-hosted, no region
-                                       # pinning, no DPA. The single de-facto provider; chosen on cost.
+                                       # pinning, no DPA. Serves copilot + the ops agents.
           hosted: true                 # prompt data LEAVES THE EU. Licensed for synthetic data only —
-                                       # see ADR-0175 §4/§5. There is NO technical control enforcing that.
-      routing: none                    # no sensitive_data routing exists. See ADR-0175 D3.
-      fallback: none                   # single provider. On failure LlmDiagnosisAdapter returns null and
-                                       # the agent degrades to a deterministic path (ADR-0174 §4).
+                                       # see ADR-0175 §4/§5. Routing it through the gateway centralises
+                                       # the exposure; it does not remove it.
+        groq:                          # api.groq.com, llama-3.3-70b-versatile. US-hosted, same posture.
+                                       # Serves agent-service's admin-UI assistant (#2209).
+          hosted: true                 # prompt data LEAVES THE EU. Same licence and same caveat.
+      routing: none                    # still no sensitive_data routing: the gateway serves two hosted
+                                       # models and no self-hosted tier exists. ADR-0175 D3 stays open —
+                                       # a choke point is where routing COULD be enforced, not routing.
+      fallback: none                   # no cross-provider failover is configured. On failure
+                                       # LlmDiagnosisAdapter returns null and the agent degrades to a
+                                       # deterministic path (ADR-0174 §4).
 
     model_gateway_target:              # ADR-0031 D6 — the decision. NOT the state. Nothing here is deployed.
       tool: litellm                       # or equivalent open gateway in front of all models

--- a/openbank-infra/gitops/components/ledger/ledger-service.yaml
+++ b/openbank-infra/gitops/components/ledger/ledger-service.yaml
@@ -38,7 +38,7 @@ spec:
       annotations:
         # Rolls the pods when the OPA bundle changes — subPath mounts do NOT hot-reload.
         # Kept in sync by gen-ledger-opa-bundle.sh (do not hand-edit).
-        openbank.tech/policy-checksum: "bb82a10437468998"
+        openbank.tech/policy-checksum: "b27fef0b0d139a8a"
     spec:
       securityContext:
         runAsNonRoot: true

--- a/openbank-infra/gitops/components/lending/lending-opa-bundle.yaml
+++ b/openbank-infra/gitops/components/lending/lending-opa-bundle.yaml
@@ -9,7 +9,7 @@ metadata:
     app.kubernetes.io/name: lending-service
     app.kubernetes.io/part-of: lending
   annotations:
-    openbank.tech/policy-checksum: "b2107ed031e9fcf6"
+    openbank.tech/policy-checksum: "2ede447a33813aae"
 data:
   rest.rego: |
     # SPDX-License-Identifier: Apache-2.0
@@ -737,19 +737,48 @@ data:
     # an absent control gets found, an asserted one gets relied on. Any consumer reading the bundles
     # must now hit `_target` / `_as_built` and cannot mistake the intent for the state.
     # ---------------------------------------------------------------------------------------
-    model_gateway_as_built:            # verified 2026-07-16 against gitops + the live sandbox
-      gateway: none                    # no gateway. Agents call the provider endpoint directly.
-                                       # LLM_GATEWAY_URL=http://litellm.ai-platform.svc:4000 is set on 5
-                                       # agents and points at a Service that has never existed (#1280).
-      budgets_enforced_at: charter     # CharterRateLimiter in openbank-agent-service — NOT a gateway.
-      providers:
+    model_gateway_as_built:            # verified 2026-07-25 against gitops AND the running Deployments
+      gateway: litellm                 # in-cluster LiteLLM proxy, ai-platform ns, :4000 (ADR-0174/0175,
+                                       # #2019). Deployed and serving. It is the only workload holding a
+                                       # provider key and the only one with an internet egress hole
+                                       # (ai-platform/networkpolicy-litellm-egress.yaml), so it is a real
+                                       # choke point — but see `egress_enforced` before treating it as a
+                                       # *complete* one.
+      routed:                          # read off the RUNNING Deployments' env, not off the manifests
+        - copilot-service              # COPILOT_MODEL_ENDPOINT (#2062) — the customer-facing assistant
+        - control-liveness-sentinel    # LIVENESS_MODEL_ENDPOINT
+        - devops-agent                 # DEVOPS_MODEL_ENDPOINT
+        - docs-truth-agent             # LLM_GATEWAY_URL
+        - finops-agent                 # LLM_GATEWAY_URL
+        - flaky-test-hunter            # LLM_GATEWAY_URL
+        - governance-auditor           # LLM_GATEWAY_URL
+        - release-steward              # LLM_GATEWAY_URL
+        - authz-policy-auditor         # LLM_GATEWAY_URL
+      not_routed:
+        - agent-service                # AGENT_MODEL_ENDPOINT repoint merged (#2209), but the deployed
+                                       # image resolves the baked-in api.groq.com URL until the rebuilt
+                                       # image rolls out. Promote it to `routed` only after re-reading
+                                       # the live Deployment — merged is not deployed.
+      egress_enforced: partial         # ai-platform is egress-locked; `platform` is NOT. agent-service's
+                                       # component still declares policyTypes: [Ingress] only, so the
+                                       # gateway is bypassable from that pod. #2210 adds the Egress half,
+                                       # gated on the agent-service repoint actually being deployed.
+      budgets_enforced_at: charter     # CharterRateLimiter in openbank-agent-service — NOT the gateway.
+      providers:                       # both terminate INSIDE the gateway pod; no agent holds either key
         deepinfra:                     # api.deepinfra.com, deepseek-ai/DeepSeek-V3.2. US-hosted, no region
-                                       # pinning, no DPA. The single de-facto provider; chosen on cost.
+                                       # pinning, no DPA. Serves copilot + the ops agents.
           hosted: true                 # prompt data LEAVES THE EU. Licensed for synthetic data only —
-                                       # see ADR-0175 §4/§5. There is NO technical control enforcing that.
-      routing: none                    # no sensitive_data routing exists. See ADR-0175 D3.
-      fallback: none                   # single provider. On failure LlmDiagnosisAdapter returns null and
-                                       # the agent degrades to a deterministic path (ADR-0174 §4).
+                                       # see ADR-0175 §4/§5. Routing it through the gateway centralises
+                                       # the exposure; it does not remove it.
+        groq:                          # api.groq.com, llama-3.3-70b-versatile. US-hosted, same posture.
+                                       # Serves agent-service's admin-UI assistant (#2209).
+          hosted: true                 # prompt data LEAVES THE EU. Same licence and same caveat.
+      routing: none                    # still no sensitive_data routing: the gateway serves two hosted
+                                       # models and no self-hosted tier exists. ADR-0175 D3 stays open —
+                                       # a choke point is where routing COULD be enforced, not routing.
+      fallback: none                   # no cross-provider failover is configured. On failure
+                                       # LlmDiagnosisAdapter returns null and the agent degrades to a
+                                       # deterministic path (ADR-0174 §4).
 
     model_gateway_target:              # ADR-0031 D6 — the decision. NOT the state. Nothing here is deployed.
       tool: litellm                       # or equivalent open gateway in front of all models

--- a/openbank-infra/gitops/components/lending/lending-service.yaml
+++ b/openbank-infra/gitops/components/lending/lending-service.yaml
@@ -34,7 +34,7 @@ spec:
       annotations:
         # Rolls the pods when the OPA bundle changes — subPath mounts do NOT hot-reload.
         # Kept in sync by gen-lending-opa-bundle.sh (do not hand-edit).
-        openbank.tech/policy-checksum: "b2107ed031e9fcf6"
+        openbank.tech/policy-checksum: "2ede447a33813aae"
     spec:
       securityContext:
         runAsNonRoot: true

--- a/openbank-infra/gitops/components/mcp/mcp-opa-bundle.yaml
+++ b/openbank-infra/gitops/components/mcp/mcp-opa-bundle.yaml
@@ -9,7 +9,7 @@ metadata:
     app.kubernetes.io/name: mcp-service
     app.kubernetes.io/part-of: platform
   annotations:
-    openbank.tech/policy-checksum: "e57e6df81c829864"
+    openbank.tech/policy-checksum: "39551e1032eb36b2"
 data:
   rest.rego: |
     # SPDX-License-Identifier: Apache-2.0
@@ -635,19 +635,48 @@ data:
     # an absent control gets found, an asserted one gets relied on. Any consumer reading the bundles
     # must now hit `_target` / `_as_built` and cannot mistake the intent for the state.
     # ---------------------------------------------------------------------------------------
-    model_gateway_as_built:            # verified 2026-07-16 against gitops + the live sandbox
-      gateway: none                    # no gateway. Agents call the provider endpoint directly.
-                                       # LLM_GATEWAY_URL=http://litellm.ai-platform.svc:4000 is set on 5
-                                       # agents and points at a Service that has never existed (#1280).
-      budgets_enforced_at: charter     # CharterRateLimiter in openbank-agent-service — NOT a gateway.
-      providers:
+    model_gateway_as_built:            # verified 2026-07-25 against gitops AND the running Deployments
+      gateway: litellm                 # in-cluster LiteLLM proxy, ai-platform ns, :4000 (ADR-0174/0175,
+                                       # #2019). Deployed and serving. It is the only workload holding a
+                                       # provider key and the only one with an internet egress hole
+                                       # (ai-platform/networkpolicy-litellm-egress.yaml), so it is a real
+                                       # choke point — but see `egress_enforced` before treating it as a
+                                       # *complete* one.
+      routed:                          # read off the RUNNING Deployments' env, not off the manifests
+        - copilot-service              # COPILOT_MODEL_ENDPOINT (#2062) — the customer-facing assistant
+        - control-liveness-sentinel    # LIVENESS_MODEL_ENDPOINT
+        - devops-agent                 # DEVOPS_MODEL_ENDPOINT
+        - docs-truth-agent             # LLM_GATEWAY_URL
+        - finops-agent                 # LLM_GATEWAY_URL
+        - flaky-test-hunter            # LLM_GATEWAY_URL
+        - governance-auditor           # LLM_GATEWAY_URL
+        - release-steward              # LLM_GATEWAY_URL
+        - authz-policy-auditor         # LLM_GATEWAY_URL
+      not_routed:
+        - agent-service                # AGENT_MODEL_ENDPOINT repoint merged (#2209), but the deployed
+                                       # image resolves the baked-in api.groq.com URL until the rebuilt
+                                       # image rolls out. Promote it to `routed` only after re-reading
+                                       # the live Deployment — merged is not deployed.
+      egress_enforced: partial         # ai-platform is egress-locked; `platform` is NOT. agent-service's
+                                       # component still declares policyTypes: [Ingress] only, so the
+                                       # gateway is bypassable from that pod. #2210 adds the Egress half,
+                                       # gated on the agent-service repoint actually being deployed.
+      budgets_enforced_at: charter     # CharterRateLimiter in openbank-agent-service — NOT the gateway.
+      providers:                       # both terminate INSIDE the gateway pod; no agent holds either key
         deepinfra:                     # api.deepinfra.com, deepseek-ai/DeepSeek-V3.2. US-hosted, no region
-                                       # pinning, no DPA. The single de-facto provider; chosen on cost.
+                                       # pinning, no DPA. Serves copilot + the ops agents.
           hosted: true                 # prompt data LEAVES THE EU. Licensed for synthetic data only —
-                                       # see ADR-0175 §4/§5. There is NO technical control enforcing that.
-      routing: none                    # no sensitive_data routing exists. See ADR-0175 D3.
-      fallback: none                   # single provider. On failure LlmDiagnosisAdapter returns null and
-                                       # the agent degrades to a deterministic path (ADR-0174 §4).
+                                       # see ADR-0175 §4/§5. Routing it through the gateway centralises
+                                       # the exposure; it does not remove it.
+        groq:                          # api.groq.com, llama-3.3-70b-versatile. US-hosted, same posture.
+                                       # Serves agent-service's admin-UI assistant (#2209).
+          hosted: true                 # prompt data LEAVES THE EU. Same licence and same caveat.
+      routing: none                    # still no sensitive_data routing: the gateway serves two hosted
+                                       # models and no self-hosted tier exists. ADR-0175 D3 stays open —
+                                       # a choke point is where routing COULD be enforced, not routing.
+      fallback: none                   # no cross-provider failover is configured. On failure
+                                       # LlmDiagnosisAdapter returns null and the agent degrades to a
+                                       # deterministic path (ADR-0174 §4).
 
     model_gateway_target:              # ADR-0031 D6 — the decision. NOT the state. Nothing here is deployed.
       tool: litellm                       # or equivalent open gateway in front of all models

--- a/openbank-infra/gitops/components/mcp/mcp-service.yaml
+++ b/openbank-infra/gitops/components/mcp/mcp-service.yaml
@@ -29,7 +29,7 @@ spec:
       annotations:
         # Rolls the pod when the OPA bundle changes — subPath mounts do NOT hot-reload.
         # Kept in sync by gen-mcp-opa-bundle.sh (do not hand-edit).
-        openbank.tech/policy-checksum: "e57e6df81c829864"
+        openbank.tech/policy-checksum: "39551e1032eb36b2"
     spec:
       securityContext:
         runAsNonRoot: true

--- a/openbank-infra/gitops/components/notifications/notification-service-opa-bundle.yaml
+++ b/openbank-infra/gitops/components/notifications/notification-service-opa-bundle.yaml
@@ -10,7 +10,7 @@ metadata:
     app.kubernetes.io/name: notification-service
     app.kubernetes.io/part-of: notifications
   annotations:
-    openbank.tech/policy-checksum: "e686dc210d1bc4a8"
+    openbank.tech/policy-checksum: "f86f4fd928041707"
 data:
   rest.rego: |
     # SPDX-License-Identifier: Apache-2.0
@@ -2218,19 +2218,48 @@ data:
     # an absent control gets found, an asserted one gets relied on. Any consumer reading the bundles
     # must now hit `_target` / `_as_built` and cannot mistake the intent for the state.
     # ---------------------------------------------------------------------------------------
-    model_gateway_as_built:            # verified 2026-07-16 against gitops + the live sandbox
-      gateway: none                    # no gateway. Agents call the provider endpoint directly.
-                                       # LLM_GATEWAY_URL=http://litellm.ai-platform.svc:4000 is set on 5
-                                       # agents and points at a Service that has never existed (#1280).
-      budgets_enforced_at: charter     # CharterRateLimiter in openbank-agent-service — NOT a gateway.
-      providers:
+    model_gateway_as_built:            # verified 2026-07-25 against gitops AND the running Deployments
+      gateway: litellm                 # in-cluster LiteLLM proxy, ai-platform ns, :4000 (ADR-0174/0175,
+                                       # #2019). Deployed and serving. It is the only workload holding a
+                                       # provider key and the only one with an internet egress hole
+                                       # (ai-platform/networkpolicy-litellm-egress.yaml), so it is a real
+                                       # choke point — but see `egress_enforced` before treating it as a
+                                       # *complete* one.
+      routed:                          # read off the RUNNING Deployments' env, not off the manifests
+        - copilot-service              # COPILOT_MODEL_ENDPOINT (#2062) — the customer-facing assistant
+        - control-liveness-sentinel    # LIVENESS_MODEL_ENDPOINT
+        - devops-agent                 # DEVOPS_MODEL_ENDPOINT
+        - docs-truth-agent             # LLM_GATEWAY_URL
+        - finops-agent                 # LLM_GATEWAY_URL
+        - flaky-test-hunter            # LLM_GATEWAY_URL
+        - governance-auditor           # LLM_GATEWAY_URL
+        - release-steward              # LLM_GATEWAY_URL
+        - authz-policy-auditor         # LLM_GATEWAY_URL
+      not_routed:
+        - agent-service                # AGENT_MODEL_ENDPOINT repoint merged (#2209), but the deployed
+                                       # image resolves the baked-in api.groq.com URL until the rebuilt
+                                       # image rolls out. Promote it to `routed` only after re-reading
+                                       # the live Deployment — merged is not deployed.
+      egress_enforced: partial         # ai-platform is egress-locked; `platform` is NOT. agent-service's
+                                       # component still declares policyTypes: [Ingress] only, so the
+                                       # gateway is bypassable from that pod. #2210 adds the Egress half,
+                                       # gated on the agent-service repoint actually being deployed.
+      budgets_enforced_at: charter     # CharterRateLimiter in openbank-agent-service — NOT the gateway.
+      providers:                       # both terminate INSIDE the gateway pod; no agent holds either key
         deepinfra:                     # api.deepinfra.com, deepseek-ai/DeepSeek-V3.2. US-hosted, no region
-                                       # pinning, no DPA. The single de-facto provider; chosen on cost.
+                                       # pinning, no DPA. Serves copilot + the ops agents.
           hosted: true                 # prompt data LEAVES THE EU. Licensed for synthetic data only —
-                                       # see ADR-0175 §4/§5. There is NO technical control enforcing that.
-      routing: none                    # no sensitive_data routing exists. See ADR-0175 D3.
-      fallback: none                   # single provider. On failure LlmDiagnosisAdapter returns null and
-                                       # the agent degrades to a deterministic path (ADR-0174 §4).
+                                       # see ADR-0175 §4/§5. Routing it through the gateway centralises
+                                       # the exposure; it does not remove it.
+        groq:                          # api.groq.com, llama-3.3-70b-versatile. US-hosted, same posture.
+                                       # Serves agent-service's admin-UI assistant (#2209).
+          hosted: true                 # prompt data LEAVES THE EU. Same licence and same caveat.
+      routing: none                    # still no sensitive_data routing: the gateway serves two hosted
+                                       # models and no self-hosted tier exists. ADR-0175 D3 stays open —
+                                       # a choke point is where routing COULD be enforced, not routing.
+      fallback: none                   # no cross-provider failover is configured. On failure
+                                       # LlmDiagnosisAdapter returns null and the agent degrades to a
+                                       # deterministic path (ADR-0174 §4).
 
     model_gateway_target:              # ADR-0031 D6 — the decision. NOT the state. Nothing here is deployed.
       tool: litellm                       # or equivalent open gateway in front of all models

--- a/openbank-infra/gitops/components/notifications/notification-service.yaml
+++ b/openbank-infra/gitops/components/notifications/notification-service.yaml
@@ -39,7 +39,7 @@ spec:
       annotations:
         # Rolls the Deployment when the OPA policy bundle changes (subPath mounts don't
         # hot-reload). Kept in sync by gen-notification-opa-bundle.sh.
-        openbank.tech/policy-checksum: "e686dc210d1bc4a8"
+        openbank.tech/policy-checksum: "f86f4fd928041707"
       labels:
         app.kubernetes.io/name: notification-service
         app.kubernetes.io/part-of: notifications

--- a/openbank-infra/gitops/components/party/party-opa-bundle.yaml
+++ b/openbank-infra/gitops/components/party/party-opa-bundle.yaml
@@ -9,7 +9,7 @@ metadata:
     app.kubernetes.io/name: party-service
     app.kubernetes.io/part-of: party
   annotations:
-    openbank.tech/policy-checksum: "b2041240ec63e511"
+    openbank.tech/policy-checksum: "e438f37d8d705163"
 data:
   rest.rego: |
     # SPDX-License-Identifier: Apache-2.0
@@ -706,19 +706,48 @@ data:
     # an absent control gets found, an asserted one gets relied on. Any consumer reading the bundles
     # must now hit `_target` / `_as_built` and cannot mistake the intent for the state.
     # ---------------------------------------------------------------------------------------
-    model_gateway_as_built:            # verified 2026-07-16 against gitops + the live sandbox
-      gateway: none                    # no gateway. Agents call the provider endpoint directly.
-                                       # LLM_GATEWAY_URL=http://litellm.ai-platform.svc:4000 is set on 5
-                                       # agents and points at a Service that has never existed (#1280).
-      budgets_enforced_at: charter     # CharterRateLimiter in openbank-agent-service — NOT a gateway.
-      providers:
+    model_gateway_as_built:            # verified 2026-07-25 against gitops AND the running Deployments
+      gateway: litellm                 # in-cluster LiteLLM proxy, ai-platform ns, :4000 (ADR-0174/0175,
+                                       # #2019). Deployed and serving. It is the only workload holding a
+                                       # provider key and the only one with an internet egress hole
+                                       # (ai-platform/networkpolicy-litellm-egress.yaml), so it is a real
+                                       # choke point — but see `egress_enforced` before treating it as a
+                                       # *complete* one.
+      routed:                          # read off the RUNNING Deployments' env, not off the manifests
+        - copilot-service              # COPILOT_MODEL_ENDPOINT (#2062) — the customer-facing assistant
+        - control-liveness-sentinel    # LIVENESS_MODEL_ENDPOINT
+        - devops-agent                 # DEVOPS_MODEL_ENDPOINT
+        - docs-truth-agent             # LLM_GATEWAY_URL
+        - finops-agent                 # LLM_GATEWAY_URL
+        - flaky-test-hunter            # LLM_GATEWAY_URL
+        - governance-auditor           # LLM_GATEWAY_URL
+        - release-steward              # LLM_GATEWAY_URL
+        - authz-policy-auditor         # LLM_GATEWAY_URL
+      not_routed:
+        - agent-service                # AGENT_MODEL_ENDPOINT repoint merged (#2209), but the deployed
+                                       # image resolves the baked-in api.groq.com URL until the rebuilt
+                                       # image rolls out. Promote it to `routed` only after re-reading
+                                       # the live Deployment — merged is not deployed.
+      egress_enforced: partial         # ai-platform is egress-locked; `platform` is NOT. agent-service's
+                                       # component still declares policyTypes: [Ingress] only, so the
+                                       # gateway is bypassable from that pod. #2210 adds the Egress half,
+                                       # gated on the agent-service repoint actually being deployed.
+      budgets_enforced_at: charter     # CharterRateLimiter in openbank-agent-service — NOT the gateway.
+      providers:                       # both terminate INSIDE the gateway pod; no agent holds either key
         deepinfra:                     # api.deepinfra.com, deepseek-ai/DeepSeek-V3.2. US-hosted, no region
-                                       # pinning, no DPA. The single de-facto provider; chosen on cost.
+                                       # pinning, no DPA. Serves copilot + the ops agents.
           hosted: true                 # prompt data LEAVES THE EU. Licensed for synthetic data only —
-                                       # see ADR-0175 §4/§5. There is NO technical control enforcing that.
-      routing: none                    # no sensitive_data routing exists. See ADR-0175 D3.
-      fallback: none                   # single provider. On failure LlmDiagnosisAdapter returns null and
-                                       # the agent degrades to a deterministic path (ADR-0174 §4).
+                                       # see ADR-0175 §4/§5. Routing it through the gateway centralises
+                                       # the exposure; it does not remove it.
+        groq:                          # api.groq.com, llama-3.3-70b-versatile. US-hosted, same posture.
+                                       # Serves agent-service's admin-UI assistant (#2209).
+          hosted: true                 # prompt data LEAVES THE EU. Same licence and same caveat.
+      routing: none                    # still no sensitive_data routing: the gateway serves two hosted
+                                       # models and no self-hosted tier exists. ADR-0175 D3 stays open —
+                                       # a choke point is where routing COULD be enforced, not routing.
+      fallback: none                   # no cross-provider failover is configured. On failure
+                                       # LlmDiagnosisAdapter returns null and the agent degrades to a
+                                       # deterministic path (ADR-0174 §4).
 
     model_gateway_target:              # ADR-0031 D6 — the decision. NOT the state. Nothing here is deployed.
       tool: litellm                       # or equivalent open gateway in front of all models

--- a/openbank-infra/gitops/components/party/party-service.yaml
+++ b/openbank-infra/gitops/components/party/party-service.yaml
@@ -22,7 +22,7 @@ spec:
       annotations:
         # Rolls the pod when the OPA bundle changes — subPath mounts do NOT hot-reload.
         # Kept in sync by gen-party-opa-bundle.sh (do not hand-edit).
-        openbank.tech/policy-checksum: "b2041240ec63e511"
+        openbank.tech/policy-checksum: "e438f37d8d705163"
       labels:
         app.kubernetes.io/name: party-service
         app.kubernetes.io/part-of: party

--- a/openbank-infra/gitops/components/payments/card-issuance-opa-bundle.yaml
+++ b/openbank-infra/gitops/components/payments/card-issuance-opa-bundle.yaml
@@ -9,7 +9,7 @@ metadata:
     app.kubernetes.io/name: card-issuance-service
     app.kubernetes.io/part-of: payments
   annotations:
-    openbank.tech/policy-checksum: "9b725eb23441aee5"
+    openbank.tech/policy-checksum: "df81c4ecd69a86e2"
 data:
   rest.rego: |
     # SPDX-License-Identifier: Apache-2.0
@@ -690,19 +690,48 @@ data:
     # an absent control gets found, an asserted one gets relied on. Any consumer reading the bundles
     # must now hit `_target` / `_as_built` and cannot mistake the intent for the state.
     # ---------------------------------------------------------------------------------------
-    model_gateway_as_built:            # verified 2026-07-16 against gitops + the live sandbox
-      gateway: none                    # no gateway. Agents call the provider endpoint directly.
-                                       # LLM_GATEWAY_URL=http://litellm.ai-platform.svc:4000 is set on 5
-                                       # agents and points at a Service that has never existed (#1280).
-      budgets_enforced_at: charter     # CharterRateLimiter in openbank-agent-service — NOT a gateway.
-      providers:
+    model_gateway_as_built:            # verified 2026-07-25 against gitops AND the running Deployments
+      gateway: litellm                 # in-cluster LiteLLM proxy, ai-platform ns, :4000 (ADR-0174/0175,
+                                       # #2019). Deployed and serving. It is the only workload holding a
+                                       # provider key and the only one with an internet egress hole
+                                       # (ai-platform/networkpolicy-litellm-egress.yaml), so it is a real
+                                       # choke point — but see `egress_enforced` before treating it as a
+                                       # *complete* one.
+      routed:                          # read off the RUNNING Deployments' env, not off the manifests
+        - copilot-service              # COPILOT_MODEL_ENDPOINT (#2062) — the customer-facing assistant
+        - control-liveness-sentinel    # LIVENESS_MODEL_ENDPOINT
+        - devops-agent                 # DEVOPS_MODEL_ENDPOINT
+        - docs-truth-agent             # LLM_GATEWAY_URL
+        - finops-agent                 # LLM_GATEWAY_URL
+        - flaky-test-hunter            # LLM_GATEWAY_URL
+        - governance-auditor           # LLM_GATEWAY_URL
+        - release-steward              # LLM_GATEWAY_URL
+        - authz-policy-auditor         # LLM_GATEWAY_URL
+      not_routed:
+        - agent-service                # AGENT_MODEL_ENDPOINT repoint merged (#2209), but the deployed
+                                       # image resolves the baked-in api.groq.com URL until the rebuilt
+                                       # image rolls out. Promote it to `routed` only after re-reading
+                                       # the live Deployment — merged is not deployed.
+      egress_enforced: partial         # ai-platform is egress-locked; `platform` is NOT. agent-service's
+                                       # component still declares policyTypes: [Ingress] only, so the
+                                       # gateway is bypassable from that pod. #2210 adds the Egress half,
+                                       # gated on the agent-service repoint actually being deployed.
+      budgets_enforced_at: charter     # CharterRateLimiter in openbank-agent-service — NOT the gateway.
+      providers:                       # both terminate INSIDE the gateway pod; no agent holds either key
         deepinfra:                     # api.deepinfra.com, deepseek-ai/DeepSeek-V3.2. US-hosted, no region
-                                       # pinning, no DPA. The single de-facto provider; chosen on cost.
+                                       # pinning, no DPA. Serves copilot + the ops agents.
           hosted: true                 # prompt data LEAVES THE EU. Licensed for synthetic data only —
-                                       # see ADR-0175 §4/§5. There is NO technical control enforcing that.
-      routing: none                    # no sensitive_data routing exists. See ADR-0175 D3.
-      fallback: none                   # single provider. On failure LlmDiagnosisAdapter returns null and
-                                       # the agent degrades to a deterministic path (ADR-0174 §4).
+                                       # see ADR-0175 §4/§5. Routing it through the gateway centralises
+                                       # the exposure; it does not remove it.
+        groq:                          # api.groq.com, llama-3.3-70b-versatile. US-hosted, same posture.
+                                       # Serves agent-service's admin-UI assistant (#2209).
+          hosted: true                 # prompt data LEAVES THE EU. Same licence and same caveat.
+      routing: none                    # still no sensitive_data routing: the gateway serves two hosted
+                                       # models and no self-hosted tier exists. ADR-0175 D3 stays open —
+                                       # a choke point is where routing COULD be enforced, not routing.
+      fallback: none                   # no cross-provider failover is configured. On failure
+                                       # LlmDiagnosisAdapter returns null and the agent degrades to a
+                                       # deterministic path (ADR-0174 §4).
 
     model_gateway_target:              # ADR-0031 D6 — the decision. NOT the state. Nothing here is deployed.
       tool: litellm                       # or equivalent open gateway in front of all models

--- a/openbank-infra/gitops/components/payments/clearing-opa-bundle.yaml
+++ b/openbank-infra/gitops/components/payments/clearing-opa-bundle.yaml
@@ -9,7 +9,7 @@ metadata:
     app.kubernetes.io/name: clearing-service
     app.kubernetes.io/part-of: payments
   annotations:
-    openbank.tech/policy-checksum: "671aac9749347129"
+    openbank.tech/policy-checksum: "0315d8d7d8fc567f"
 data:
   rest.rego: |
     # SPDX-License-Identifier: Apache-2.0
@@ -727,19 +727,48 @@ data:
     # an absent control gets found, an asserted one gets relied on. Any consumer reading the bundles
     # must now hit `_target` / `_as_built` and cannot mistake the intent for the state.
     # ---------------------------------------------------------------------------------------
-    model_gateway_as_built:            # verified 2026-07-16 against gitops + the live sandbox
-      gateway: none                    # no gateway. Agents call the provider endpoint directly.
-                                       # LLM_GATEWAY_URL=http://litellm.ai-platform.svc:4000 is set on 5
-                                       # agents and points at a Service that has never existed (#1280).
-      budgets_enforced_at: charter     # CharterRateLimiter in openbank-agent-service — NOT a gateway.
-      providers:
+    model_gateway_as_built:            # verified 2026-07-25 against gitops AND the running Deployments
+      gateway: litellm                 # in-cluster LiteLLM proxy, ai-platform ns, :4000 (ADR-0174/0175,
+                                       # #2019). Deployed and serving. It is the only workload holding a
+                                       # provider key and the only one with an internet egress hole
+                                       # (ai-platform/networkpolicy-litellm-egress.yaml), so it is a real
+                                       # choke point — but see `egress_enforced` before treating it as a
+                                       # *complete* one.
+      routed:                          # read off the RUNNING Deployments' env, not off the manifests
+        - copilot-service              # COPILOT_MODEL_ENDPOINT (#2062) — the customer-facing assistant
+        - control-liveness-sentinel    # LIVENESS_MODEL_ENDPOINT
+        - devops-agent                 # DEVOPS_MODEL_ENDPOINT
+        - docs-truth-agent             # LLM_GATEWAY_URL
+        - finops-agent                 # LLM_GATEWAY_URL
+        - flaky-test-hunter            # LLM_GATEWAY_URL
+        - governance-auditor           # LLM_GATEWAY_URL
+        - release-steward              # LLM_GATEWAY_URL
+        - authz-policy-auditor         # LLM_GATEWAY_URL
+      not_routed:
+        - agent-service                # AGENT_MODEL_ENDPOINT repoint merged (#2209), but the deployed
+                                       # image resolves the baked-in api.groq.com URL until the rebuilt
+                                       # image rolls out. Promote it to `routed` only after re-reading
+                                       # the live Deployment — merged is not deployed.
+      egress_enforced: partial         # ai-platform is egress-locked; `platform` is NOT. agent-service's
+                                       # component still declares policyTypes: [Ingress] only, so the
+                                       # gateway is bypassable from that pod. #2210 adds the Egress half,
+                                       # gated on the agent-service repoint actually being deployed.
+      budgets_enforced_at: charter     # CharterRateLimiter in openbank-agent-service — NOT the gateway.
+      providers:                       # both terminate INSIDE the gateway pod; no agent holds either key
         deepinfra:                     # api.deepinfra.com, deepseek-ai/DeepSeek-V3.2. US-hosted, no region
-                                       # pinning, no DPA. The single de-facto provider; chosen on cost.
+                                       # pinning, no DPA. Serves copilot + the ops agents.
           hosted: true                 # prompt data LEAVES THE EU. Licensed for synthetic data only —
-                                       # see ADR-0175 §4/§5. There is NO technical control enforcing that.
-      routing: none                    # no sensitive_data routing exists. See ADR-0175 D3.
-      fallback: none                   # single provider. On failure LlmDiagnosisAdapter returns null and
-                                       # the agent degrades to a deterministic path (ADR-0174 §4).
+                                       # see ADR-0175 §4/§5. Routing it through the gateway centralises
+                                       # the exposure; it does not remove it.
+        groq:                          # api.groq.com, llama-3.3-70b-versatile. US-hosted, same posture.
+                                       # Serves agent-service's admin-UI assistant (#2209).
+          hosted: true                 # prompt data LEAVES THE EU. Same licence and same caveat.
+      routing: none                    # still no sensitive_data routing: the gateway serves two hosted
+                                       # models and no self-hosted tier exists. ADR-0175 D3 stays open —
+                                       # a choke point is where routing COULD be enforced, not routing.
+      fallback: none                   # no cross-provider failover is configured. On failure
+                                       # LlmDiagnosisAdapter returns null and the agent degrades to a
+                                       # deterministic path (ADR-0174 §4).
 
     model_gateway_target:              # ADR-0031 D6 — the decision. NOT the state. Nothing here is deployed.
       tool: litellm                       # or equivalent open gateway in front of all models

--- a/openbank-infra/gitops/components/payments/domestic-payment-opa-bundle.yaml
+++ b/openbank-infra/gitops/components/payments/domestic-payment-opa-bundle.yaml
@@ -9,7 +9,7 @@ metadata:
     app.kubernetes.io/name: domestic-payment
     app.kubernetes.io/part-of: payments
   annotations:
-    openbank.tech/policy-checksum: "8412bbd9aa1eb939"
+    openbank.tech/policy-checksum: "5df1031a168b5539"
 data:
   rest.rego: |
     # SPDX-License-Identifier: Apache-2.0
@@ -712,19 +712,48 @@ data:
     # an absent control gets found, an asserted one gets relied on. Any consumer reading the bundles
     # must now hit `_target` / `_as_built` and cannot mistake the intent for the state.
     # ---------------------------------------------------------------------------------------
-    model_gateway_as_built:            # verified 2026-07-16 against gitops + the live sandbox
-      gateway: none                    # no gateway. Agents call the provider endpoint directly.
-                                       # LLM_GATEWAY_URL=http://litellm.ai-platform.svc:4000 is set on 5
-                                       # agents and points at a Service that has never existed (#1280).
-      budgets_enforced_at: charter     # CharterRateLimiter in openbank-agent-service — NOT a gateway.
-      providers:
+    model_gateway_as_built:            # verified 2026-07-25 against gitops AND the running Deployments
+      gateway: litellm                 # in-cluster LiteLLM proxy, ai-platform ns, :4000 (ADR-0174/0175,
+                                       # #2019). Deployed and serving. It is the only workload holding a
+                                       # provider key and the only one with an internet egress hole
+                                       # (ai-platform/networkpolicy-litellm-egress.yaml), so it is a real
+                                       # choke point — but see `egress_enforced` before treating it as a
+                                       # *complete* one.
+      routed:                          # read off the RUNNING Deployments' env, not off the manifests
+        - copilot-service              # COPILOT_MODEL_ENDPOINT (#2062) — the customer-facing assistant
+        - control-liveness-sentinel    # LIVENESS_MODEL_ENDPOINT
+        - devops-agent                 # DEVOPS_MODEL_ENDPOINT
+        - docs-truth-agent             # LLM_GATEWAY_URL
+        - finops-agent                 # LLM_GATEWAY_URL
+        - flaky-test-hunter            # LLM_GATEWAY_URL
+        - governance-auditor           # LLM_GATEWAY_URL
+        - release-steward              # LLM_GATEWAY_URL
+        - authz-policy-auditor         # LLM_GATEWAY_URL
+      not_routed:
+        - agent-service                # AGENT_MODEL_ENDPOINT repoint merged (#2209), but the deployed
+                                       # image resolves the baked-in api.groq.com URL until the rebuilt
+                                       # image rolls out. Promote it to `routed` only after re-reading
+                                       # the live Deployment — merged is not deployed.
+      egress_enforced: partial         # ai-platform is egress-locked; `platform` is NOT. agent-service's
+                                       # component still declares policyTypes: [Ingress] only, so the
+                                       # gateway is bypassable from that pod. #2210 adds the Egress half,
+                                       # gated on the agent-service repoint actually being deployed.
+      budgets_enforced_at: charter     # CharterRateLimiter in openbank-agent-service — NOT the gateway.
+      providers:                       # both terminate INSIDE the gateway pod; no agent holds either key
         deepinfra:                     # api.deepinfra.com, deepseek-ai/DeepSeek-V3.2. US-hosted, no region
-                                       # pinning, no DPA. The single de-facto provider; chosen on cost.
+                                       # pinning, no DPA. Serves copilot + the ops agents.
           hosted: true                 # prompt data LEAVES THE EU. Licensed for synthetic data only —
-                                       # see ADR-0175 §4/§5. There is NO technical control enforcing that.
-      routing: none                    # no sensitive_data routing exists. See ADR-0175 D3.
-      fallback: none                   # single provider. On failure LlmDiagnosisAdapter returns null and
-                                       # the agent degrades to a deterministic path (ADR-0174 §4).
+                                       # see ADR-0175 §4/§5. Routing it through the gateway centralises
+                                       # the exposure; it does not remove it.
+        groq:                          # api.groq.com, llama-3.3-70b-versatile. US-hosted, same posture.
+                                       # Serves agent-service's admin-UI assistant (#2209).
+          hosted: true                 # prompt data LEAVES THE EU. Same licence and same caveat.
+      routing: none                    # still no sensitive_data routing: the gateway serves two hosted
+                                       # models and no self-hosted tier exists. ADR-0175 D3 stays open —
+                                       # a choke point is where routing COULD be enforced, not routing.
+      fallback: none                   # no cross-provider failover is configured. On failure
+                                       # LlmDiagnosisAdapter returns null and the agent degrades to a
+                                       # deterministic path (ADR-0174 §4).
 
     model_gateway_target:              # ADR-0031 D6 — the decision. NOT the state. Nothing here is deployed.
       tool: litellm                       # or equivalent open gateway in front of all models

--- a/openbank-infra/gitops/components/payments/payments-services.yaml
+++ b/openbank-infra/gitops/components/payments/payments-services.yaml
@@ -42,7 +42,7 @@ spec:
         # Rolls the pods when the OPA bundle changes — subPath mounts do NOT hot-reload.
         # Kept in sync by gen-transaction-opa-bundle.sh via the trailing marker comment
         # (do not hand-edit, do not drop the marker).
-        openbank.tech/policy-checksum: "a2b81c0c94acf704" # transaction-opa-bundle
+        openbank.tech/policy-checksum: "6cb1baed6742783f" # transaction-opa-bundle
     spec:
       securityContext:
         runAsNonRoot: true
@@ -375,7 +375,7 @@ spec:
       annotations:
         # Rolls the pods when the OPA bundle changes — subPath mounts do NOT hot-reload.
         # Kept in sync by gen-sepa-payment-opa-bundle.sh (do not hand-edit).
-        openbank.tech/policy-checksum: "93a38a129627102a"
+        openbank.tech/policy-checksum: "5bf847199fb4acb1"
     spec:
       securityContext:
         runAsNonRoot: true
@@ -729,7 +729,7 @@ spec:
         # Rolls the pods when the OPA bundle changes — subPath mounts do NOT hot-reload.
         # Kept in sync by gen-domestic-payment-opa-bundle.sh via the trailing marker
         # comment (do not hand-edit, do not drop the marker).
-        openbank.tech/policy-checksum: "8412bbd9aa1eb939" # domestic-payment-opa-bundle
+        openbank.tech/policy-checksum: "5df1031a168b5539" # domestic-payment-opa-bundle
     spec:
       securityContext:
         runAsNonRoot: true
@@ -1053,7 +1053,7 @@ spec:
       annotations:
         # Rolls the pods when the OPA bundle changes — subPath mounts do NOT hot-reload.
         # Kept in sync by gen-sepa-instant-opa-bundle.sh (do not hand-edit).
-        openbank.tech/policy-checksum: "53e6bea21393b691"
+        openbank.tech/policy-checksum: "b621ca294c0d80f6"
     spec:
       securityContext:
         runAsNonRoot: true
@@ -1369,7 +1369,7 @@ spec:
         # Rolls the pods when the OPA bundle changes — subPath mounts do NOT hot-reload.
         # Kept in sync by gen-clearing-opa-bundle.sh via the trailing marker comment
         # (do not hand-edit, do not drop the marker).
-        openbank.tech/policy-checksum: "671aac9749347129" # clearing-opa-bundle
+        openbank.tech/policy-checksum: "0315d8d7d8fc567f" # clearing-opa-bundle
     spec:
       securityContext:
         runAsNonRoot: true
@@ -1658,7 +1658,7 @@ spec:
       annotations:
         # Rolls the pod when the OPA bundle changes (ADR-0034). Value is stamped by
         # gen-standing-order-opa-bundle.sh — do not hand-edit.
-        openbank.tech/policy-checksum: "e7dd65691439f4f9" # standing-order-opa-bundle
+        openbank.tech/policy-checksum: "d9afa135beb74727" # standing-order-opa-bundle
     spec:
       securityContext:
         runAsNonRoot: true
@@ -1911,7 +1911,7 @@ spec:
       annotations:
         # Rolls the pods when the OPA bundle changes — subPath mounts do NOT hot-reload.
         # Kept in sync by gen-card-issuance-opa-bundle.sh (do not hand-edit).
-        openbank.tech/policy-checksum: "9b725eb23441aee5"
+        openbank.tech/policy-checksum: "df81c4ecd69a86e2"
     spec:
       securityContext:
         runAsNonRoot: true
@@ -2178,7 +2178,7 @@ spec:
         # Rolls the pods when the OPA bundle changes — subPath mounts do NOT hot-reload.
         # Kept in sync by gen-settlement-opa-bundle.sh via the trailing marker comment
         # (do not hand-edit, do not drop the marker).
-        openbank.tech/policy-checksum: "fd5739c501ce3367" # settlement-opa-bundle
+        openbank.tech/policy-checksum: "645336d77720a24e" # settlement-opa-bundle
     spec:
       securityContext:
         runAsNonRoot: true
@@ -2579,7 +2579,7 @@ spec:
       annotations:
         # Rolls the pods when the OPA bundle changes — subPath mounts do NOT hot-reload.
         # Kept in sync by gen-swift-opa-bundle.sh (do not hand-edit).
-        openbank.tech/policy-checksum: "c0fa6b217921ac34"
+        openbank.tech/policy-checksum: "12dcf4bca2e2366b"
     spec:
       securityContext:
         runAsNonRoot: true
@@ -2893,7 +2893,7 @@ spec:
       annotations:
         # Rolls the pods when the OPA bundle changes — subPath mounts do NOT hot-reload.
         # Kept in sync by gen-vop-opa-bundle.sh (do not hand-edit).
-        openbank.tech/policy-checksum: "393e0ffa2b150b23"
+        openbank.tech/policy-checksum: "226b220834fe5b7f"
     spec:
       securityContext:
         runAsNonRoot: true

--- a/openbank-infra/gitops/components/payments/sepa-instant-opa-bundle.yaml
+++ b/openbank-infra/gitops/components/payments/sepa-instant-opa-bundle.yaml
@@ -9,7 +9,7 @@ metadata:
     app.kubernetes.io/name: sepa-instant
     app.kubernetes.io/part-of: payments
   annotations:
-    openbank.tech/policy-checksum: "53e6bea21393b691"
+    openbank.tech/policy-checksum: "b621ca294c0d80f6"
 data:
   rest.rego: |
     # SPDX-License-Identifier: Apache-2.0
@@ -685,19 +685,48 @@ data:
     # an absent control gets found, an asserted one gets relied on. Any consumer reading the bundles
     # must now hit `_target` / `_as_built` and cannot mistake the intent for the state.
     # ---------------------------------------------------------------------------------------
-    model_gateway_as_built:            # verified 2026-07-16 against gitops + the live sandbox
-      gateway: none                    # no gateway. Agents call the provider endpoint directly.
-                                       # LLM_GATEWAY_URL=http://litellm.ai-platform.svc:4000 is set on 5
-                                       # agents and points at a Service that has never existed (#1280).
-      budgets_enforced_at: charter     # CharterRateLimiter in openbank-agent-service — NOT a gateway.
-      providers:
+    model_gateway_as_built:            # verified 2026-07-25 against gitops AND the running Deployments
+      gateway: litellm                 # in-cluster LiteLLM proxy, ai-platform ns, :4000 (ADR-0174/0175,
+                                       # #2019). Deployed and serving. It is the only workload holding a
+                                       # provider key and the only one with an internet egress hole
+                                       # (ai-platform/networkpolicy-litellm-egress.yaml), so it is a real
+                                       # choke point — but see `egress_enforced` before treating it as a
+                                       # *complete* one.
+      routed:                          # read off the RUNNING Deployments' env, not off the manifests
+        - copilot-service              # COPILOT_MODEL_ENDPOINT (#2062) — the customer-facing assistant
+        - control-liveness-sentinel    # LIVENESS_MODEL_ENDPOINT
+        - devops-agent                 # DEVOPS_MODEL_ENDPOINT
+        - docs-truth-agent             # LLM_GATEWAY_URL
+        - finops-agent                 # LLM_GATEWAY_URL
+        - flaky-test-hunter            # LLM_GATEWAY_URL
+        - governance-auditor           # LLM_GATEWAY_URL
+        - release-steward              # LLM_GATEWAY_URL
+        - authz-policy-auditor         # LLM_GATEWAY_URL
+      not_routed:
+        - agent-service                # AGENT_MODEL_ENDPOINT repoint merged (#2209), but the deployed
+                                       # image resolves the baked-in api.groq.com URL until the rebuilt
+                                       # image rolls out. Promote it to `routed` only after re-reading
+                                       # the live Deployment — merged is not deployed.
+      egress_enforced: partial         # ai-platform is egress-locked; `platform` is NOT. agent-service's
+                                       # component still declares policyTypes: [Ingress] only, so the
+                                       # gateway is bypassable from that pod. #2210 adds the Egress half,
+                                       # gated on the agent-service repoint actually being deployed.
+      budgets_enforced_at: charter     # CharterRateLimiter in openbank-agent-service — NOT the gateway.
+      providers:                       # both terminate INSIDE the gateway pod; no agent holds either key
         deepinfra:                     # api.deepinfra.com, deepseek-ai/DeepSeek-V3.2. US-hosted, no region
-                                       # pinning, no DPA. The single de-facto provider; chosen on cost.
+                                       # pinning, no DPA. Serves copilot + the ops agents.
           hosted: true                 # prompt data LEAVES THE EU. Licensed for synthetic data only —
-                                       # see ADR-0175 §4/§5. There is NO technical control enforcing that.
-      routing: none                    # no sensitive_data routing exists. See ADR-0175 D3.
-      fallback: none                   # single provider. On failure LlmDiagnosisAdapter returns null and
-                                       # the agent degrades to a deterministic path (ADR-0174 §4).
+                                       # see ADR-0175 §4/§5. Routing it through the gateway centralises
+                                       # the exposure; it does not remove it.
+        groq:                          # api.groq.com, llama-3.3-70b-versatile. US-hosted, same posture.
+                                       # Serves agent-service's admin-UI assistant (#2209).
+          hosted: true                 # prompt data LEAVES THE EU. Same licence and same caveat.
+      routing: none                    # still no sensitive_data routing: the gateway serves two hosted
+                                       # models and no self-hosted tier exists. ADR-0175 D3 stays open —
+                                       # a choke point is where routing COULD be enforced, not routing.
+      fallback: none                   # no cross-provider failover is configured. On failure
+                                       # LlmDiagnosisAdapter returns null and the agent degrades to a
+                                       # deterministic path (ADR-0174 §4).
 
     model_gateway_target:              # ADR-0031 D6 — the decision. NOT the state. Nothing here is deployed.
       tool: litellm                       # or equivalent open gateway in front of all models

--- a/openbank-infra/gitops/components/payments/sepa-payment-opa-bundle.yaml
+++ b/openbank-infra/gitops/components/payments/sepa-payment-opa-bundle.yaml
@@ -9,7 +9,7 @@ metadata:
     app.kubernetes.io/name: sepa-payment
     app.kubernetes.io/part-of: payments
   annotations:
-    openbank.tech/policy-checksum: "93a38a129627102a"
+    openbank.tech/policy-checksum: "5bf847199fb4acb1"
 data:
   rest.rego: |
     # SPDX-License-Identifier: Apache-2.0
@@ -706,19 +706,48 @@ data:
     # an absent control gets found, an asserted one gets relied on. Any consumer reading the bundles
     # must now hit `_target` / `_as_built` and cannot mistake the intent for the state.
     # ---------------------------------------------------------------------------------------
-    model_gateway_as_built:            # verified 2026-07-16 against gitops + the live sandbox
-      gateway: none                    # no gateway. Agents call the provider endpoint directly.
-                                       # LLM_GATEWAY_URL=http://litellm.ai-platform.svc:4000 is set on 5
-                                       # agents and points at a Service that has never existed (#1280).
-      budgets_enforced_at: charter     # CharterRateLimiter in openbank-agent-service — NOT a gateway.
-      providers:
+    model_gateway_as_built:            # verified 2026-07-25 against gitops AND the running Deployments
+      gateway: litellm                 # in-cluster LiteLLM proxy, ai-platform ns, :4000 (ADR-0174/0175,
+                                       # #2019). Deployed and serving. It is the only workload holding a
+                                       # provider key and the only one with an internet egress hole
+                                       # (ai-platform/networkpolicy-litellm-egress.yaml), so it is a real
+                                       # choke point — but see `egress_enforced` before treating it as a
+                                       # *complete* one.
+      routed:                          # read off the RUNNING Deployments' env, not off the manifests
+        - copilot-service              # COPILOT_MODEL_ENDPOINT (#2062) — the customer-facing assistant
+        - control-liveness-sentinel    # LIVENESS_MODEL_ENDPOINT
+        - devops-agent                 # DEVOPS_MODEL_ENDPOINT
+        - docs-truth-agent             # LLM_GATEWAY_URL
+        - finops-agent                 # LLM_GATEWAY_URL
+        - flaky-test-hunter            # LLM_GATEWAY_URL
+        - governance-auditor           # LLM_GATEWAY_URL
+        - release-steward              # LLM_GATEWAY_URL
+        - authz-policy-auditor         # LLM_GATEWAY_URL
+      not_routed:
+        - agent-service                # AGENT_MODEL_ENDPOINT repoint merged (#2209), but the deployed
+                                       # image resolves the baked-in api.groq.com URL until the rebuilt
+                                       # image rolls out. Promote it to `routed` only after re-reading
+                                       # the live Deployment — merged is not deployed.
+      egress_enforced: partial         # ai-platform is egress-locked; `platform` is NOT. agent-service's
+                                       # component still declares policyTypes: [Ingress] only, so the
+                                       # gateway is bypassable from that pod. #2210 adds the Egress half,
+                                       # gated on the agent-service repoint actually being deployed.
+      budgets_enforced_at: charter     # CharterRateLimiter in openbank-agent-service — NOT the gateway.
+      providers:                       # both terminate INSIDE the gateway pod; no agent holds either key
         deepinfra:                     # api.deepinfra.com, deepseek-ai/DeepSeek-V3.2. US-hosted, no region
-                                       # pinning, no DPA. The single de-facto provider; chosen on cost.
+                                       # pinning, no DPA. Serves copilot + the ops agents.
           hosted: true                 # prompt data LEAVES THE EU. Licensed for synthetic data only —
-                                       # see ADR-0175 §4/§5. There is NO technical control enforcing that.
-      routing: none                    # no sensitive_data routing exists. See ADR-0175 D3.
-      fallback: none                   # single provider. On failure LlmDiagnosisAdapter returns null and
-                                       # the agent degrades to a deterministic path (ADR-0174 §4).
+                                       # see ADR-0175 §4/§5. Routing it through the gateway centralises
+                                       # the exposure; it does not remove it.
+        groq:                          # api.groq.com, llama-3.3-70b-versatile. US-hosted, same posture.
+                                       # Serves agent-service's admin-UI assistant (#2209).
+          hosted: true                 # prompt data LEAVES THE EU. Same licence and same caveat.
+      routing: none                    # still no sensitive_data routing: the gateway serves two hosted
+                                       # models and no self-hosted tier exists. ADR-0175 D3 stays open —
+                                       # a choke point is where routing COULD be enforced, not routing.
+      fallback: none                   # no cross-provider failover is configured. On failure
+                                       # LlmDiagnosisAdapter returns null and the agent degrades to a
+                                       # deterministic path (ADR-0174 §4).
 
     model_gateway_target:              # ADR-0031 D6 — the decision. NOT the state. Nothing here is deployed.
       tool: litellm                       # or equivalent open gateway in front of all models

--- a/openbank-infra/gitops/components/payments/settlement-opa-bundle.yaml
+++ b/openbank-infra/gitops/components/payments/settlement-opa-bundle.yaml
@@ -9,7 +9,7 @@ metadata:
     app.kubernetes.io/name: settlement-service
     app.kubernetes.io/part-of: payments
   annotations:
-    openbank.tech/policy-checksum: "fd5739c501ce3367"
+    openbank.tech/policy-checksum: "645336d77720a24e"
 data:
   rest.rego: |
     # SPDX-License-Identifier: Apache-2.0
@@ -686,19 +686,48 @@ data:
     # an absent control gets found, an asserted one gets relied on. Any consumer reading the bundles
     # must now hit `_target` / `_as_built` and cannot mistake the intent for the state.
     # ---------------------------------------------------------------------------------------
-    model_gateway_as_built:            # verified 2026-07-16 against gitops + the live sandbox
-      gateway: none                    # no gateway. Agents call the provider endpoint directly.
-                                       # LLM_GATEWAY_URL=http://litellm.ai-platform.svc:4000 is set on 5
-                                       # agents and points at a Service that has never existed (#1280).
-      budgets_enforced_at: charter     # CharterRateLimiter in openbank-agent-service — NOT a gateway.
-      providers:
+    model_gateway_as_built:            # verified 2026-07-25 against gitops AND the running Deployments
+      gateway: litellm                 # in-cluster LiteLLM proxy, ai-platform ns, :4000 (ADR-0174/0175,
+                                       # #2019). Deployed and serving. It is the only workload holding a
+                                       # provider key and the only one with an internet egress hole
+                                       # (ai-platform/networkpolicy-litellm-egress.yaml), so it is a real
+                                       # choke point — but see `egress_enforced` before treating it as a
+                                       # *complete* one.
+      routed:                          # read off the RUNNING Deployments' env, not off the manifests
+        - copilot-service              # COPILOT_MODEL_ENDPOINT (#2062) — the customer-facing assistant
+        - control-liveness-sentinel    # LIVENESS_MODEL_ENDPOINT
+        - devops-agent                 # DEVOPS_MODEL_ENDPOINT
+        - docs-truth-agent             # LLM_GATEWAY_URL
+        - finops-agent                 # LLM_GATEWAY_URL
+        - flaky-test-hunter            # LLM_GATEWAY_URL
+        - governance-auditor           # LLM_GATEWAY_URL
+        - release-steward              # LLM_GATEWAY_URL
+        - authz-policy-auditor         # LLM_GATEWAY_URL
+      not_routed:
+        - agent-service                # AGENT_MODEL_ENDPOINT repoint merged (#2209), but the deployed
+                                       # image resolves the baked-in api.groq.com URL until the rebuilt
+                                       # image rolls out. Promote it to `routed` only after re-reading
+                                       # the live Deployment — merged is not deployed.
+      egress_enforced: partial         # ai-platform is egress-locked; `platform` is NOT. agent-service's
+                                       # component still declares policyTypes: [Ingress] only, so the
+                                       # gateway is bypassable from that pod. #2210 adds the Egress half,
+                                       # gated on the agent-service repoint actually being deployed.
+      budgets_enforced_at: charter     # CharterRateLimiter in openbank-agent-service — NOT the gateway.
+      providers:                       # both terminate INSIDE the gateway pod; no agent holds either key
         deepinfra:                     # api.deepinfra.com, deepseek-ai/DeepSeek-V3.2. US-hosted, no region
-                                       # pinning, no DPA. The single de-facto provider; chosen on cost.
+                                       # pinning, no DPA. Serves copilot + the ops agents.
           hosted: true                 # prompt data LEAVES THE EU. Licensed for synthetic data only —
-                                       # see ADR-0175 §4/§5. There is NO technical control enforcing that.
-      routing: none                    # no sensitive_data routing exists. See ADR-0175 D3.
-      fallback: none                   # single provider. On failure LlmDiagnosisAdapter returns null and
-                                       # the agent degrades to a deterministic path (ADR-0174 §4).
+                                       # see ADR-0175 §4/§5. Routing it through the gateway centralises
+                                       # the exposure; it does not remove it.
+        groq:                          # api.groq.com, llama-3.3-70b-versatile. US-hosted, same posture.
+                                       # Serves agent-service's admin-UI assistant (#2209).
+          hosted: true                 # prompt data LEAVES THE EU. Same licence and same caveat.
+      routing: none                    # still no sensitive_data routing: the gateway serves two hosted
+                                       # models and no self-hosted tier exists. ADR-0175 D3 stays open —
+                                       # a choke point is where routing COULD be enforced, not routing.
+      fallback: none                   # no cross-provider failover is configured. On failure
+                                       # LlmDiagnosisAdapter returns null and the agent degrades to a
+                                       # deterministic path (ADR-0174 §4).
 
     model_gateway_target:              # ADR-0031 D6 — the decision. NOT the state. Nothing here is deployed.
       tool: litellm                       # or equivalent open gateway in front of all models

--- a/openbank-infra/gitops/components/payments/standing-order-opa-bundle.yaml
+++ b/openbank-infra/gitops/components/payments/standing-order-opa-bundle.yaml
@@ -9,7 +9,7 @@ metadata:
     app.kubernetes.io/name: standing-order-service
     app.kubernetes.io/part-of: payments
   annotations:
-    openbank.tech/policy-checksum: "e7dd65691439f4f9"
+    openbank.tech/policy-checksum: "d9afa135beb74727"
 data:
   rest.rego: |
     # SPDX-License-Identifier: Apache-2.0
@@ -671,19 +671,48 @@ data:
     # an absent control gets found, an asserted one gets relied on. Any consumer reading the bundles
     # must now hit `_target` / `_as_built` and cannot mistake the intent for the state.
     # ---------------------------------------------------------------------------------------
-    model_gateway_as_built:            # verified 2026-07-16 against gitops + the live sandbox
-      gateway: none                    # no gateway. Agents call the provider endpoint directly.
-                                       # LLM_GATEWAY_URL=http://litellm.ai-platform.svc:4000 is set on 5
-                                       # agents and points at a Service that has never existed (#1280).
-      budgets_enforced_at: charter     # CharterRateLimiter in openbank-agent-service — NOT a gateway.
-      providers:
+    model_gateway_as_built:            # verified 2026-07-25 against gitops AND the running Deployments
+      gateway: litellm                 # in-cluster LiteLLM proxy, ai-platform ns, :4000 (ADR-0174/0175,
+                                       # #2019). Deployed and serving. It is the only workload holding a
+                                       # provider key and the only one with an internet egress hole
+                                       # (ai-platform/networkpolicy-litellm-egress.yaml), so it is a real
+                                       # choke point — but see `egress_enforced` before treating it as a
+                                       # *complete* one.
+      routed:                          # read off the RUNNING Deployments' env, not off the manifests
+        - copilot-service              # COPILOT_MODEL_ENDPOINT (#2062) — the customer-facing assistant
+        - control-liveness-sentinel    # LIVENESS_MODEL_ENDPOINT
+        - devops-agent                 # DEVOPS_MODEL_ENDPOINT
+        - docs-truth-agent             # LLM_GATEWAY_URL
+        - finops-agent                 # LLM_GATEWAY_URL
+        - flaky-test-hunter            # LLM_GATEWAY_URL
+        - governance-auditor           # LLM_GATEWAY_URL
+        - release-steward              # LLM_GATEWAY_URL
+        - authz-policy-auditor         # LLM_GATEWAY_URL
+      not_routed:
+        - agent-service                # AGENT_MODEL_ENDPOINT repoint merged (#2209), but the deployed
+                                       # image resolves the baked-in api.groq.com URL until the rebuilt
+                                       # image rolls out. Promote it to `routed` only after re-reading
+                                       # the live Deployment — merged is not deployed.
+      egress_enforced: partial         # ai-platform is egress-locked; `platform` is NOT. agent-service's
+                                       # component still declares policyTypes: [Ingress] only, so the
+                                       # gateway is bypassable from that pod. #2210 adds the Egress half,
+                                       # gated on the agent-service repoint actually being deployed.
+      budgets_enforced_at: charter     # CharterRateLimiter in openbank-agent-service — NOT the gateway.
+      providers:                       # both terminate INSIDE the gateway pod; no agent holds either key
         deepinfra:                     # api.deepinfra.com, deepseek-ai/DeepSeek-V3.2. US-hosted, no region
-                                       # pinning, no DPA. The single de-facto provider; chosen on cost.
+                                       # pinning, no DPA. Serves copilot + the ops agents.
           hosted: true                 # prompt data LEAVES THE EU. Licensed for synthetic data only —
-                                       # see ADR-0175 §4/§5. There is NO technical control enforcing that.
-      routing: none                    # no sensitive_data routing exists. See ADR-0175 D3.
-      fallback: none                   # single provider. On failure LlmDiagnosisAdapter returns null and
-                                       # the agent degrades to a deterministic path (ADR-0174 §4).
+                                       # see ADR-0175 §4/§5. Routing it through the gateway centralises
+                                       # the exposure; it does not remove it.
+        groq:                          # api.groq.com, llama-3.3-70b-versatile. US-hosted, same posture.
+                                       # Serves agent-service's admin-UI assistant (#2209).
+          hosted: true                 # prompt data LEAVES THE EU. Same licence and same caveat.
+      routing: none                    # still no sensitive_data routing: the gateway serves two hosted
+                                       # models and no self-hosted tier exists. ADR-0175 D3 stays open —
+                                       # a choke point is where routing COULD be enforced, not routing.
+      fallback: none                   # no cross-provider failover is configured. On failure
+                                       # LlmDiagnosisAdapter returns null and the agent degrades to a
+                                       # deterministic path (ADR-0174 §4).
 
     model_gateway_target:              # ADR-0031 D6 — the decision. NOT the state. Nothing here is deployed.
       tool: litellm                       # or equivalent open gateway in front of all models

--- a/openbank-infra/gitops/components/payments/swift-opa-bundle.yaml
+++ b/openbank-infra/gitops/components/payments/swift-opa-bundle.yaml
@@ -9,7 +9,7 @@ metadata:
     app.kubernetes.io/name: swift-service
     app.kubernetes.io/part-of: payments
   annotations:
-    openbank.tech/policy-checksum: "c0fa6b217921ac34"
+    openbank.tech/policy-checksum: "12dcf4bca2e2366b"
 data:
   rest.rego: |
     # SPDX-License-Identifier: Apache-2.0
@@ -689,19 +689,48 @@ data:
     # an absent control gets found, an asserted one gets relied on. Any consumer reading the bundles
     # must now hit `_target` / `_as_built` and cannot mistake the intent for the state.
     # ---------------------------------------------------------------------------------------
-    model_gateway_as_built:            # verified 2026-07-16 against gitops + the live sandbox
-      gateway: none                    # no gateway. Agents call the provider endpoint directly.
-                                       # LLM_GATEWAY_URL=http://litellm.ai-platform.svc:4000 is set on 5
-                                       # agents and points at a Service that has never existed (#1280).
-      budgets_enforced_at: charter     # CharterRateLimiter in openbank-agent-service — NOT a gateway.
-      providers:
+    model_gateway_as_built:            # verified 2026-07-25 against gitops AND the running Deployments
+      gateway: litellm                 # in-cluster LiteLLM proxy, ai-platform ns, :4000 (ADR-0174/0175,
+                                       # #2019). Deployed and serving. It is the only workload holding a
+                                       # provider key and the only one with an internet egress hole
+                                       # (ai-platform/networkpolicy-litellm-egress.yaml), so it is a real
+                                       # choke point — but see `egress_enforced` before treating it as a
+                                       # *complete* one.
+      routed:                          # read off the RUNNING Deployments' env, not off the manifests
+        - copilot-service              # COPILOT_MODEL_ENDPOINT (#2062) — the customer-facing assistant
+        - control-liveness-sentinel    # LIVENESS_MODEL_ENDPOINT
+        - devops-agent                 # DEVOPS_MODEL_ENDPOINT
+        - docs-truth-agent             # LLM_GATEWAY_URL
+        - finops-agent                 # LLM_GATEWAY_URL
+        - flaky-test-hunter            # LLM_GATEWAY_URL
+        - governance-auditor           # LLM_GATEWAY_URL
+        - release-steward              # LLM_GATEWAY_URL
+        - authz-policy-auditor         # LLM_GATEWAY_URL
+      not_routed:
+        - agent-service                # AGENT_MODEL_ENDPOINT repoint merged (#2209), but the deployed
+                                       # image resolves the baked-in api.groq.com URL until the rebuilt
+                                       # image rolls out. Promote it to `routed` only after re-reading
+                                       # the live Deployment — merged is not deployed.
+      egress_enforced: partial         # ai-platform is egress-locked; `platform` is NOT. agent-service's
+                                       # component still declares policyTypes: [Ingress] only, so the
+                                       # gateway is bypassable from that pod. #2210 adds the Egress half,
+                                       # gated on the agent-service repoint actually being deployed.
+      budgets_enforced_at: charter     # CharterRateLimiter in openbank-agent-service — NOT the gateway.
+      providers:                       # both terminate INSIDE the gateway pod; no agent holds either key
         deepinfra:                     # api.deepinfra.com, deepseek-ai/DeepSeek-V3.2. US-hosted, no region
-                                       # pinning, no DPA. The single de-facto provider; chosen on cost.
+                                       # pinning, no DPA. Serves copilot + the ops agents.
           hosted: true                 # prompt data LEAVES THE EU. Licensed for synthetic data only —
-                                       # see ADR-0175 §4/§5. There is NO technical control enforcing that.
-      routing: none                    # no sensitive_data routing exists. See ADR-0175 D3.
-      fallback: none                   # single provider. On failure LlmDiagnosisAdapter returns null and
-                                       # the agent degrades to a deterministic path (ADR-0174 §4).
+                                       # see ADR-0175 §4/§5. Routing it through the gateway centralises
+                                       # the exposure; it does not remove it.
+        groq:                          # api.groq.com, llama-3.3-70b-versatile. US-hosted, same posture.
+                                       # Serves agent-service's admin-UI assistant (#2209).
+          hosted: true                 # prompt data LEAVES THE EU. Same licence and same caveat.
+      routing: none                    # still no sensitive_data routing: the gateway serves two hosted
+                                       # models and no self-hosted tier exists. ADR-0175 D3 stays open —
+                                       # a choke point is where routing COULD be enforced, not routing.
+      fallback: none                   # no cross-provider failover is configured. On failure
+                                       # LlmDiagnosisAdapter returns null and the agent degrades to a
+                                       # deterministic path (ADR-0174 §4).
 
     model_gateway_target:              # ADR-0031 D6 — the decision. NOT the state. Nothing here is deployed.
       tool: litellm                       # or equivalent open gateway in front of all models

--- a/openbank-infra/gitops/components/payments/transaction-opa-bundle.yaml
+++ b/openbank-infra/gitops/components/payments/transaction-opa-bundle.yaml
@@ -9,7 +9,7 @@ metadata:
     app.kubernetes.io/name: transaction-service
     app.kubernetes.io/part-of: payments
   annotations:
-    openbank.tech/policy-checksum: "a2b81c0c94acf704"
+    openbank.tech/policy-checksum: "6cb1baed6742783f"
 data:
   rest.rego: |
     # SPDX-License-Identifier: Apache-2.0
@@ -742,19 +742,48 @@ data:
     # an absent control gets found, an asserted one gets relied on. Any consumer reading the bundles
     # must now hit `_target` / `_as_built` and cannot mistake the intent for the state.
     # ---------------------------------------------------------------------------------------
-    model_gateway_as_built:            # verified 2026-07-16 against gitops + the live sandbox
-      gateway: none                    # no gateway. Agents call the provider endpoint directly.
-                                       # LLM_GATEWAY_URL=http://litellm.ai-platform.svc:4000 is set on 5
-                                       # agents and points at a Service that has never existed (#1280).
-      budgets_enforced_at: charter     # CharterRateLimiter in openbank-agent-service — NOT a gateway.
-      providers:
+    model_gateway_as_built:            # verified 2026-07-25 against gitops AND the running Deployments
+      gateway: litellm                 # in-cluster LiteLLM proxy, ai-platform ns, :4000 (ADR-0174/0175,
+                                       # #2019). Deployed and serving. It is the only workload holding a
+                                       # provider key and the only one with an internet egress hole
+                                       # (ai-platform/networkpolicy-litellm-egress.yaml), so it is a real
+                                       # choke point — but see `egress_enforced` before treating it as a
+                                       # *complete* one.
+      routed:                          # read off the RUNNING Deployments' env, not off the manifests
+        - copilot-service              # COPILOT_MODEL_ENDPOINT (#2062) — the customer-facing assistant
+        - control-liveness-sentinel    # LIVENESS_MODEL_ENDPOINT
+        - devops-agent                 # DEVOPS_MODEL_ENDPOINT
+        - docs-truth-agent             # LLM_GATEWAY_URL
+        - finops-agent                 # LLM_GATEWAY_URL
+        - flaky-test-hunter            # LLM_GATEWAY_URL
+        - governance-auditor           # LLM_GATEWAY_URL
+        - release-steward              # LLM_GATEWAY_URL
+        - authz-policy-auditor         # LLM_GATEWAY_URL
+      not_routed:
+        - agent-service                # AGENT_MODEL_ENDPOINT repoint merged (#2209), but the deployed
+                                       # image resolves the baked-in api.groq.com URL until the rebuilt
+                                       # image rolls out. Promote it to `routed` only after re-reading
+                                       # the live Deployment — merged is not deployed.
+      egress_enforced: partial         # ai-platform is egress-locked; `platform` is NOT. agent-service's
+                                       # component still declares policyTypes: [Ingress] only, so the
+                                       # gateway is bypassable from that pod. #2210 adds the Egress half,
+                                       # gated on the agent-service repoint actually being deployed.
+      budgets_enforced_at: charter     # CharterRateLimiter in openbank-agent-service — NOT the gateway.
+      providers:                       # both terminate INSIDE the gateway pod; no agent holds either key
         deepinfra:                     # api.deepinfra.com, deepseek-ai/DeepSeek-V3.2. US-hosted, no region
-                                       # pinning, no DPA. The single de-facto provider; chosen on cost.
+                                       # pinning, no DPA. Serves copilot + the ops agents.
           hosted: true                 # prompt data LEAVES THE EU. Licensed for synthetic data only —
-                                       # see ADR-0175 §4/§5. There is NO technical control enforcing that.
-      routing: none                    # no sensitive_data routing exists. See ADR-0175 D3.
-      fallback: none                   # single provider. On failure LlmDiagnosisAdapter returns null and
-                                       # the agent degrades to a deterministic path (ADR-0174 §4).
+                                       # see ADR-0175 §4/§5. Routing it through the gateway centralises
+                                       # the exposure; it does not remove it.
+        groq:                          # api.groq.com, llama-3.3-70b-versatile. US-hosted, same posture.
+                                       # Serves agent-service's admin-UI assistant (#2209).
+          hosted: true                 # prompt data LEAVES THE EU. Same licence and same caveat.
+      routing: none                    # still no sensitive_data routing: the gateway serves two hosted
+                                       # models and no self-hosted tier exists. ADR-0175 D3 stays open —
+                                       # a choke point is where routing COULD be enforced, not routing.
+      fallback: none                   # no cross-provider failover is configured. On failure
+                                       # LlmDiagnosisAdapter returns null and the agent degrades to a
+                                       # deterministic path (ADR-0174 §4).
 
     model_gateway_target:              # ADR-0031 D6 — the decision. NOT the state. Nothing here is deployed.
       tool: litellm                       # or equivalent open gateway in front of all models

--- a/openbank-infra/gitops/components/payments/vop-opa-bundle.yaml
+++ b/openbank-infra/gitops/components/payments/vop-opa-bundle.yaml
@@ -9,7 +9,7 @@ metadata:
     app.kubernetes.io/name: vop-service
     app.kubernetes.io/part-of: payments
   annotations:
-    openbank.tech/policy-checksum: "393e0ffa2b150b23"
+    openbank.tech/policy-checksum: "226b220834fe5b7f"
 data:
   rest.rego: |
     # SPDX-License-Identifier: Apache-2.0
@@ -693,19 +693,48 @@ data:
     # an absent control gets found, an asserted one gets relied on. Any consumer reading the bundles
     # must now hit `_target` / `_as_built` and cannot mistake the intent for the state.
     # ---------------------------------------------------------------------------------------
-    model_gateway_as_built:            # verified 2026-07-16 against gitops + the live sandbox
-      gateway: none                    # no gateway. Agents call the provider endpoint directly.
-                                       # LLM_GATEWAY_URL=http://litellm.ai-platform.svc:4000 is set on 5
-                                       # agents and points at a Service that has never existed (#1280).
-      budgets_enforced_at: charter     # CharterRateLimiter in openbank-agent-service — NOT a gateway.
-      providers:
+    model_gateway_as_built:            # verified 2026-07-25 against gitops AND the running Deployments
+      gateway: litellm                 # in-cluster LiteLLM proxy, ai-platform ns, :4000 (ADR-0174/0175,
+                                       # #2019). Deployed and serving. It is the only workload holding a
+                                       # provider key and the only one with an internet egress hole
+                                       # (ai-platform/networkpolicy-litellm-egress.yaml), so it is a real
+                                       # choke point — but see `egress_enforced` before treating it as a
+                                       # *complete* one.
+      routed:                          # read off the RUNNING Deployments' env, not off the manifests
+        - copilot-service              # COPILOT_MODEL_ENDPOINT (#2062) — the customer-facing assistant
+        - control-liveness-sentinel    # LIVENESS_MODEL_ENDPOINT
+        - devops-agent                 # DEVOPS_MODEL_ENDPOINT
+        - docs-truth-agent             # LLM_GATEWAY_URL
+        - finops-agent                 # LLM_GATEWAY_URL
+        - flaky-test-hunter            # LLM_GATEWAY_URL
+        - governance-auditor           # LLM_GATEWAY_URL
+        - release-steward              # LLM_GATEWAY_URL
+        - authz-policy-auditor         # LLM_GATEWAY_URL
+      not_routed:
+        - agent-service                # AGENT_MODEL_ENDPOINT repoint merged (#2209), but the deployed
+                                       # image resolves the baked-in api.groq.com URL until the rebuilt
+                                       # image rolls out. Promote it to `routed` only after re-reading
+                                       # the live Deployment — merged is not deployed.
+      egress_enforced: partial         # ai-platform is egress-locked; `platform` is NOT. agent-service's
+                                       # component still declares policyTypes: [Ingress] only, so the
+                                       # gateway is bypassable from that pod. #2210 adds the Egress half,
+                                       # gated on the agent-service repoint actually being deployed.
+      budgets_enforced_at: charter     # CharterRateLimiter in openbank-agent-service — NOT the gateway.
+      providers:                       # both terminate INSIDE the gateway pod; no agent holds either key
         deepinfra:                     # api.deepinfra.com, deepseek-ai/DeepSeek-V3.2. US-hosted, no region
-                                       # pinning, no DPA. The single de-facto provider; chosen on cost.
+                                       # pinning, no DPA. Serves copilot + the ops agents.
           hosted: true                 # prompt data LEAVES THE EU. Licensed for synthetic data only —
-                                       # see ADR-0175 §4/§5. There is NO technical control enforcing that.
-      routing: none                    # no sensitive_data routing exists. See ADR-0175 D3.
-      fallback: none                   # single provider. On failure LlmDiagnosisAdapter returns null and
-                                       # the agent degrades to a deterministic path (ADR-0174 §4).
+                                       # see ADR-0175 §4/§5. Routing it through the gateway centralises
+                                       # the exposure; it does not remove it.
+        groq:                          # api.groq.com, llama-3.3-70b-versatile. US-hosted, same posture.
+                                       # Serves agent-service's admin-UI assistant (#2209).
+          hosted: true                 # prompt data LEAVES THE EU. Same licence and same caveat.
+      routing: none                    # still no sensitive_data routing: the gateway serves two hosted
+                                       # models and no self-hosted tier exists. ADR-0175 D3 stays open —
+                                       # a choke point is where routing COULD be enforced, not routing.
+      fallback: none                   # no cross-provider failover is configured. On failure
+                                       # LlmDiagnosisAdapter returns null and the agent degrades to a
+                                       # deterministic path (ADR-0174 §4).
 
     model_gateway_target:              # ADR-0031 D6 — the decision. NOT the state. Nothing here is deployed.
       tool: litellm                       # or equivalent open gateway in front of all models

--- a/openbank-infra/gitops/components/pid/pid-opa-bundle.yaml
+++ b/openbank-infra/gitops/components/pid/pid-opa-bundle.yaml
@@ -9,7 +9,7 @@ metadata:
     app.kubernetes.io/name: pid-service
     app.kubernetes.io/part-of: pid
   annotations:
-    openbank.tech/policy-checksum: "5f1953ae78d7c642"
+    openbank.tech/policy-checksum: "7e7619eba7637de1"
 data:
   rest.rego: |
     # SPDX-License-Identifier: Apache-2.0
@@ -695,19 +695,48 @@ data:
     # an absent control gets found, an asserted one gets relied on. Any consumer reading the bundles
     # must now hit `_target` / `_as_built` and cannot mistake the intent for the state.
     # ---------------------------------------------------------------------------------------
-    model_gateway_as_built:            # verified 2026-07-16 against gitops + the live sandbox
-      gateway: none                    # no gateway. Agents call the provider endpoint directly.
-                                       # LLM_GATEWAY_URL=http://litellm.ai-platform.svc:4000 is set on 5
-                                       # agents and points at a Service that has never existed (#1280).
-      budgets_enforced_at: charter     # CharterRateLimiter in openbank-agent-service — NOT a gateway.
-      providers:
+    model_gateway_as_built:            # verified 2026-07-25 against gitops AND the running Deployments
+      gateway: litellm                 # in-cluster LiteLLM proxy, ai-platform ns, :4000 (ADR-0174/0175,
+                                       # #2019). Deployed and serving. It is the only workload holding a
+                                       # provider key and the only one with an internet egress hole
+                                       # (ai-platform/networkpolicy-litellm-egress.yaml), so it is a real
+                                       # choke point — but see `egress_enforced` before treating it as a
+                                       # *complete* one.
+      routed:                          # read off the RUNNING Deployments' env, not off the manifests
+        - copilot-service              # COPILOT_MODEL_ENDPOINT (#2062) — the customer-facing assistant
+        - control-liveness-sentinel    # LIVENESS_MODEL_ENDPOINT
+        - devops-agent                 # DEVOPS_MODEL_ENDPOINT
+        - docs-truth-agent             # LLM_GATEWAY_URL
+        - finops-agent                 # LLM_GATEWAY_URL
+        - flaky-test-hunter            # LLM_GATEWAY_URL
+        - governance-auditor           # LLM_GATEWAY_URL
+        - release-steward              # LLM_GATEWAY_URL
+        - authz-policy-auditor         # LLM_GATEWAY_URL
+      not_routed:
+        - agent-service                # AGENT_MODEL_ENDPOINT repoint merged (#2209), but the deployed
+                                       # image resolves the baked-in api.groq.com URL until the rebuilt
+                                       # image rolls out. Promote it to `routed` only after re-reading
+                                       # the live Deployment — merged is not deployed.
+      egress_enforced: partial         # ai-platform is egress-locked; `platform` is NOT. agent-service's
+                                       # component still declares policyTypes: [Ingress] only, so the
+                                       # gateway is bypassable from that pod. #2210 adds the Egress half,
+                                       # gated on the agent-service repoint actually being deployed.
+      budgets_enforced_at: charter     # CharterRateLimiter in openbank-agent-service — NOT the gateway.
+      providers:                       # both terminate INSIDE the gateway pod; no agent holds either key
         deepinfra:                     # api.deepinfra.com, deepseek-ai/DeepSeek-V3.2. US-hosted, no region
-                                       # pinning, no DPA. The single de-facto provider; chosen on cost.
+                                       # pinning, no DPA. Serves copilot + the ops agents.
           hosted: true                 # prompt data LEAVES THE EU. Licensed for synthetic data only —
-                                       # see ADR-0175 §4/§5. There is NO technical control enforcing that.
-      routing: none                    # no sensitive_data routing exists. See ADR-0175 D3.
-      fallback: none                   # single provider. On failure LlmDiagnosisAdapter returns null and
-                                       # the agent degrades to a deterministic path (ADR-0174 §4).
+                                       # see ADR-0175 §4/§5. Routing it through the gateway centralises
+                                       # the exposure; it does not remove it.
+        groq:                          # api.groq.com, llama-3.3-70b-versatile. US-hosted, same posture.
+                                       # Serves agent-service's admin-UI assistant (#2209).
+          hosted: true                 # prompt data LEAVES THE EU. Same licence and same caveat.
+      routing: none                    # still no sensitive_data routing: the gateway serves two hosted
+                                       # models and no self-hosted tier exists. ADR-0175 D3 stays open —
+                                       # a choke point is where routing COULD be enforced, not routing.
+      fallback: none                   # no cross-provider failover is configured. On failure
+                                       # LlmDiagnosisAdapter returns null and the agent degrades to a
+                                       # deterministic path (ADR-0174 §4).
 
     model_gateway_target:              # ADR-0031 D6 — the decision. NOT the state. Nothing here is deployed.
       tool: litellm                       # or equivalent open gateway in front of all models

--- a/openbank-infra/gitops/components/pid/pid-service.yaml
+++ b/openbank-infra/gitops/components/pid/pid-service.yaml
@@ -22,7 +22,7 @@ spec:
       annotations:
         # Rolls the pod when the OPA bundle changes — subPath mounts do NOT hot-reload.
         # Kept in sync by gen-pid-opa-bundle.sh (do not hand-edit).
-        openbank.tech/policy-checksum: "5f1953ae78d7c642"
+        openbank.tech/policy-checksum: "7e7619eba7637de1"
     spec:
       securityContext:
         runAsNonRoot: true

--- a/openbank-infra/gitops/components/psd2-service/psd2-opa-bundle.yaml
+++ b/openbank-infra/gitops/components/psd2-service/psd2-opa-bundle.yaml
@@ -9,7 +9,7 @@ metadata:
     app.kubernetes.io/name: psd2-service
     app.kubernetes.io/part-of: psd2
   annotations:
-    openbank.tech/policy-checksum: "06d7408b01ab6f9d"
+    openbank.tech/policy-checksum: "960d13b2074ebc61"
 data:
   rest.rego: |
     # SPDX-License-Identifier: Apache-2.0
@@ -768,19 +768,48 @@ data:
     # an absent control gets found, an asserted one gets relied on. Any consumer reading the bundles
     # must now hit `_target` / `_as_built` and cannot mistake the intent for the state.
     # ---------------------------------------------------------------------------------------
-    model_gateway_as_built:            # verified 2026-07-16 against gitops + the live sandbox
-      gateway: none                    # no gateway. Agents call the provider endpoint directly.
-                                       # LLM_GATEWAY_URL=http://litellm.ai-platform.svc:4000 is set on 5
-                                       # agents and points at a Service that has never existed (#1280).
-      budgets_enforced_at: charter     # CharterRateLimiter in openbank-agent-service — NOT a gateway.
-      providers:
+    model_gateway_as_built:            # verified 2026-07-25 against gitops AND the running Deployments
+      gateway: litellm                 # in-cluster LiteLLM proxy, ai-platform ns, :4000 (ADR-0174/0175,
+                                       # #2019). Deployed and serving. It is the only workload holding a
+                                       # provider key and the only one with an internet egress hole
+                                       # (ai-platform/networkpolicy-litellm-egress.yaml), so it is a real
+                                       # choke point — but see `egress_enforced` before treating it as a
+                                       # *complete* one.
+      routed:                          # read off the RUNNING Deployments' env, not off the manifests
+        - copilot-service              # COPILOT_MODEL_ENDPOINT (#2062) — the customer-facing assistant
+        - control-liveness-sentinel    # LIVENESS_MODEL_ENDPOINT
+        - devops-agent                 # DEVOPS_MODEL_ENDPOINT
+        - docs-truth-agent             # LLM_GATEWAY_URL
+        - finops-agent                 # LLM_GATEWAY_URL
+        - flaky-test-hunter            # LLM_GATEWAY_URL
+        - governance-auditor           # LLM_GATEWAY_URL
+        - release-steward              # LLM_GATEWAY_URL
+        - authz-policy-auditor         # LLM_GATEWAY_URL
+      not_routed:
+        - agent-service                # AGENT_MODEL_ENDPOINT repoint merged (#2209), but the deployed
+                                       # image resolves the baked-in api.groq.com URL until the rebuilt
+                                       # image rolls out. Promote it to `routed` only after re-reading
+                                       # the live Deployment — merged is not deployed.
+      egress_enforced: partial         # ai-platform is egress-locked; `platform` is NOT. agent-service's
+                                       # component still declares policyTypes: [Ingress] only, so the
+                                       # gateway is bypassable from that pod. #2210 adds the Egress half,
+                                       # gated on the agent-service repoint actually being deployed.
+      budgets_enforced_at: charter     # CharterRateLimiter in openbank-agent-service — NOT the gateway.
+      providers:                       # both terminate INSIDE the gateway pod; no agent holds either key
         deepinfra:                     # api.deepinfra.com, deepseek-ai/DeepSeek-V3.2. US-hosted, no region
-                                       # pinning, no DPA. The single de-facto provider; chosen on cost.
+                                       # pinning, no DPA. Serves copilot + the ops agents.
           hosted: true                 # prompt data LEAVES THE EU. Licensed for synthetic data only —
-                                       # see ADR-0175 §4/§5. There is NO technical control enforcing that.
-      routing: none                    # no sensitive_data routing exists. See ADR-0175 D3.
-      fallback: none                   # single provider. On failure LlmDiagnosisAdapter returns null and
-                                       # the agent degrades to a deterministic path (ADR-0174 §4).
+                                       # see ADR-0175 §4/§5. Routing it through the gateway centralises
+                                       # the exposure; it does not remove it.
+        groq:                          # api.groq.com, llama-3.3-70b-versatile. US-hosted, same posture.
+                                       # Serves agent-service's admin-UI assistant (#2209).
+          hosted: true                 # prompt data LEAVES THE EU. Same licence and same caveat.
+      routing: none                    # still no sensitive_data routing: the gateway serves two hosted
+                                       # models and no self-hosted tier exists. ADR-0175 D3 stays open —
+                                       # a choke point is where routing COULD be enforced, not routing.
+      fallback: none                   # no cross-provider failover is configured. On failure
+                                       # LlmDiagnosisAdapter returns null and the agent degrades to a
+                                       # deterministic path (ADR-0174 §4).
 
     model_gateway_target:              # ADR-0031 D6 — the decision. NOT the state. Nothing here is deployed.
       tool: litellm                       # or equivalent open gateway in front of all models

--- a/openbank-infra/gitops/components/psd2-service/psd2-service.yaml
+++ b/openbank-infra/gitops/components/psd2-service/psd2-service.yaml
@@ -18,7 +18,7 @@ spec:
       annotations:
         # Rolls the pod when the OPA bundle changes — subPath mounts do NOT hot-reload.
         # Kept in sync by gen-psd2-opa-bundle.sh (do not hand-edit).
-        openbank.tech/policy-checksum: "06d7408b01ab6f9d"
+        openbank.tech/policy-checksum: "960d13b2074ebc61"
       labels: {app.kubernetes.io/name: psd2-service, app.kubernetes.io/part-of: psd2}
     spec:
       securityContext:

--- a/openbank-infra/gitops/components/sanctions-service/sanctions-opa-bundle.yaml
+++ b/openbank-infra/gitops/components/sanctions-service/sanctions-opa-bundle.yaml
@@ -9,7 +9,7 @@ metadata:
     app.kubernetes.io/name: sanctions-service
     app.kubernetes.io/part-of: sanctions
   annotations:
-    openbank.tech/policy-checksum: "cd78df11e153f5d3"
+    openbank.tech/policy-checksum: "d4c654f78a2c3e2d"
 data:
   rest.rego: |
     # SPDX-License-Identifier: Apache-2.0
@@ -673,19 +673,48 @@ data:
     # an absent control gets found, an asserted one gets relied on. Any consumer reading the bundles
     # must now hit `_target` / `_as_built` and cannot mistake the intent for the state.
     # ---------------------------------------------------------------------------------------
-    model_gateway_as_built:            # verified 2026-07-16 against gitops + the live sandbox
-      gateway: none                    # no gateway. Agents call the provider endpoint directly.
-                                       # LLM_GATEWAY_URL=http://litellm.ai-platform.svc:4000 is set on 5
-                                       # agents and points at a Service that has never existed (#1280).
-      budgets_enforced_at: charter     # CharterRateLimiter in openbank-agent-service — NOT a gateway.
-      providers:
+    model_gateway_as_built:            # verified 2026-07-25 against gitops AND the running Deployments
+      gateway: litellm                 # in-cluster LiteLLM proxy, ai-platform ns, :4000 (ADR-0174/0175,
+                                       # #2019). Deployed and serving. It is the only workload holding a
+                                       # provider key and the only one with an internet egress hole
+                                       # (ai-platform/networkpolicy-litellm-egress.yaml), so it is a real
+                                       # choke point — but see `egress_enforced` before treating it as a
+                                       # *complete* one.
+      routed:                          # read off the RUNNING Deployments' env, not off the manifests
+        - copilot-service              # COPILOT_MODEL_ENDPOINT (#2062) — the customer-facing assistant
+        - control-liveness-sentinel    # LIVENESS_MODEL_ENDPOINT
+        - devops-agent                 # DEVOPS_MODEL_ENDPOINT
+        - docs-truth-agent             # LLM_GATEWAY_URL
+        - finops-agent                 # LLM_GATEWAY_URL
+        - flaky-test-hunter            # LLM_GATEWAY_URL
+        - governance-auditor           # LLM_GATEWAY_URL
+        - release-steward              # LLM_GATEWAY_URL
+        - authz-policy-auditor         # LLM_GATEWAY_URL
+      not_routed:
+        - agent-service                # AGENT_MODEL_ENDPOINT repoint merged (#2209), but the deployed
+                                       # image resolves the baked-in api.groq.com URL until the rebuilt
+                                       # image rolls out. Promote it to `routed` only after re-reading
+                                       # the live Deployment — merged is not deployed.
+      egress_enforced: partial         # ai-platform is egress-locked; `platform` is NOT. agent-service's
+                                       # component still declares policyTypes: [Ingress] only, so the
+                                       # gateway is bypassable from that pod. #2210 adds the Egress half,
+                                       # gated on the agent-service repoint actually being deployed.
+      budgets_enforced_at: charter     # CharterRateLimiter in openbank-agent-service — NOT the gateway.
+      providers:                       # both terminate INSIDE the gateway pod; no agent holds either key
         deepinfra:                     # api.deepinfra.com, deepseek-ai/DeepSeek-V3.2. US-hosted, no region
-                                       # pinning, no DPA. The single de-facto provider; chosen on cost.
+                                       # pinning, no DPA. Serves copilot + the ops agents.
           hosted: true                 # prompt data LEAVES THE EU. Licensed for synthetic data only —
-                                       # see ADR-0175 §4/§5. There is NO technical control enforcing that.
-      routing: none                    # no sensitive_data routing exists. See ADR-0175 D3.
-      fallback: none                   # single provider. On failure LlmDiagnosisAdapter returns null and
-                                       # the agent degrades to a deterministic path (ADR-0174 §4).
+                                       # see ADR-0175 §4/§5. Routing it through the gateway centralises
+                                       # the exposure; it does not remove it.
+        groq:                          # api.groq.com, llama-3.3-70b-versatile. US-hosted, same posture.
+                                       # Serves agent-service's admin-UI assistant (#2209).
+          hosted: true                 # prompt data LEAVES THE EU. Same licence and same caveat.
+      routing: none                    # still no sensitive_data routing: the gateway serves two hosted
+                                       # models and no self-hosted tier exists. ADR-0175 D3 stays open —
+                                       # a choke point is where routing COULD be enforced, not routing.
+      fallback: none                   # no cross-provider failover is configured. On failure
+                                       # LlmDiagnosisAdapter returns null and the agent degrades to a
+                                       # deterministic path (ADR-0174 §4).
 
     model_gateway_target:              # ADR-0031 D6 — the decision. NOT the state. Nothing here is deployed.
       tool: litellm                       # or equivalent open gateway in front of all models

--- a/openbank-infra/gitops/components/sanctions-service/sanctions-service.yaml
+++ b/openbank-infra/gitops/components/sanctions-service/sanctions-service.yaml
@@ -49,7 +49,7 @@ spec:
       annotations:
         # Rolls the pods when the OPA bundle changes — subPath mounts do NOT hot-reload.
         # Kept in sync by gen-sanctions-opa-bundle.sh (do not hand-edit).
-        openbank.tech/policy-checksum: "cd78df11e153f5d3"
+        openbank.tech/policy-checksum: "d4c654f78a2c3e2d"
     spec:
       securityContext:
         runAsNonRoot: true

--- a/openbank-infra/gitops/components/sca/sca-opa-bundle.yaml
+++ b/openbank-infra/gitops/components/sca/sca-opa-bundle.yaml
@@ -9,7 +9,7 @@ metadata:
     app.kubernetes.io/name: sca-service
     app.kubernetes.io/part-of: sca
   annotations:
-    openbank.tech/policy-checksum: "5e039f5a6c9e86ad"
+    openbank.tech/policy-checksum: "d40355816e8a75d6"
 data:
   rest.rego: |
     # SPDX-License-Identifier: Apache-2.0
@@ -709,19 +709,48 @@ data:
     # an absent control gets found, an asserted one gets relied on. Any consumer reading the bundles
     # must now hit `_target` / `_as_built` and cannot mistake the intent for the state.
     # ---------------------------------------------------------------------------------------
-    model_gateway_as_built:            # verified 2026-07-16 against gitops + the live sandbox
-      gateway: none                    # no gateway. Agents call the provider endpoint directly.
-                                       # LLM_GATEWAY_URL=http://litellm.ai-platform.svc:4000 is set on 5
-                                       # agents and points at a Service that has never existed (#1280).
-      budgets_enforced_at: charter     # CharterRateLimiter in openbank-agent-service — NOT a gateway.
-      providers:
+    model_gateway_as_built:            # verified 2026-07-25 against gitops AND the running Deployments
+      gateway: litellm                 # in-cluster LiteLLM proxy, ai-platform ns, :4000 (ADR-0174/0175,
+                                       # #2019). Deployed and serving. It is the only workload holding a
+                                       # provider key and the only one with an internet egress hole
+                                       # (ai-platform/networkpolicy-litellm-egress.yaml), so it is a real
+                                       # choke point — but see `egress_enforced` before treating it as a
+                                       # *complete* one.
+      routed:                          # read off the RUNNING Deployments' env, not off the manifests
+        - copilot-service              # COPILOT_MODEL_ENDPOINT (#2062) — the customer-facing assistant
+        - control-liveness-sentinel    # LIVENESS_MODEL_ENDPOINT
+        - devops-agent                 # DEVOPS_MODEL_ENDPOINT
+        - docs-truth-agent             # LLM_GATEWAY_URL
+        - finops-agent                 # LLM_GATEWAY_URL
+        - flaky-test-hunter            # LLM_GATEWAY_URL
+        - governance-auditor           # LLM_GATEWAY_URL
+        - release-steward              # LLM_GATEWAY_URL
+        - authz-policy-auditor         # LLM_GATEWAY_URL
+      not_routed:
+        - agent-service                # AGENT_MODEL_ENDPOINT repoint merged (#2209), but the deployed
+                                       # image resolves the baked-in api.groq.com URL until the rebuilt
+                                       # image rolls out. Promote it to `routed` only after re-reading
+                                       # the live Deployment — merged is not deployed.
+      egress_enforced: partial         # ai-platform is egress-locked; `platform` is NOT. agent-service's
+                                       # component still declares policyTypes: [Ingress] only, so the
+                                       # gateway is bypassable from that pod. #2210 adds the Egress half,
+                                       # gated on the agent-service repoint actually being deployed.
+      budgets_enforced_at: charter     # CharterRateLimiter in openbank-agent-service — NOT the gateway.
+      providers:                       # both terminate INSIDE the gateway pod; no agent holds either key
         deepinfra:                     # api.deepinfra.com, deepseek-ai/DeepSeek-V3.2. US-hosted, no region
-                                       # pinning, no DPA. The single de-facto provider; chosen on cost.
+                                       # pinning, no DPA. Serves copilot + the ops agents.
           hosted: true                 # prompt data LEAVES THE EU. Licensed for synthetic data only —
-                                       # see ADR-0175 §4/§5. There is NO technical control enforcing that.
-      routing: none                    # no sensitive_data routing exists. See ADR-0175 D3.
-      fallback: none                   # single provider. On failure LlmDiagnosisAdapter returns null and
-                                       # the agent degrades to a deterministic path (ADR-0174 §4).
+                                       # see ADR-0175 §4/§5. Routing it through the gateway centralises
+                                       # the exposure; it does not remove it.
+        groq:                          # api.groq.com, llama-3.3-70b-versatile. US-hosted, same posture.
+                                       # Serves agent-service's admin-UI assistant (#2209).
+          hosted: true                 # prompt data LEAVES THE EU. Same licence and same caveat.
+      routing: none                    # still no sensitive_data routing: the gateway serves two hosted
+                                       # models and no self-hosted tier exists. ADR-0175 D3 stays open —
+                                       # a choke point is where routing COULD be enforced, not routing.
+      fallback: none                   # no cross-provider failover is configured. On failure
+                                       # LlmDiagnosisAdapter returns null and the agent degrades to a
+                                       # deterministic path (ADR-0174 §4).
 
     model_gateway_target:              # ADR-0031 D6 — the decision. NOT the state. Nothing here is deployed.
       tool: litellm                       # or equivalent open gateway in front of all models

--- a/openbank-infra/gitops/components/sca/sca-service.yaml
+++ b/openbank-infra/gitops/components/sca/sca-service.yaml
@@ -28,7 +28,7 @@ spec:
       annotations:
         # Rolls the pods when the OPA bundle changes — subPath mounts do NOT hot-reload.
         # Kept in sync by gen-sca-opa-bundle.sh (do not hand-edit).
-        openbank.tech/policy-checksum: "5e039f5a6c9e86ad"
+        openbank.tech/policy-checksum: "d40355816e8a75d6"
     spec:
       securityContext:
         runAsNonRoot: true

--- a/openbank-infra/gitops/components/statements/statement-opa-bundle.yaml
+++ b/openbank-infra/gitops/components/statements/statement-opa-bundle.yaml
@@ -9,7 +9,7 @@ metadata:
     app.kubernetes.io/name: statement-service
     app.kubernetes.io/part-of: statements
   annotations:
-    openbank.tech/policy-checksum: "46b29807cf55bd08"
+    openbank.tech/policy-checksum: "a2927c75d3d7b76d"
 data:
   rest.rego: |
     # SPDX-License-Identifier: Apache-2.0
@@ -739,19 +739,48 @@ data:
     # an absent control gets found, an asserted one gets relied on. Any consumer reading the bundles
     # must now hit `_target` / `_as_built` and cannot mistake the intent for the state.
     # ---------------------------------------------------------------------------------------
-    model_gateway_as_built:            # verified 2026-07-16 against gitops + the live sandbox
-      gateway: none                    # no gateway. Agents call the provider endpoint directly.
-                                       # LLM_GATEWAY_URL=http://litellm.ai-platform.svc:4000 is set on 5
-                                       # agents and points at a Service that has never existed (#1280).
-      budgets_enforced_at: charter     # CharterRateLimiter in openbank-agent-service — NOT a gateway.
-      providers:
+    model_gateway_as_built:            # verified 2026-07-25 against gitops AND the running Deployments
+      gateway: litellm                 # in-cluster LiteLLM proxy, ai-platform ns, :4000 (ADR-0174/0175,
+                                       # #2019). Deployed and serving. It is the only workload holding a
+                                       # provider key and the only one with an internet egress hole
+                                       # (ai-platform/networkpolicy-litellm-egress.yaml), so it is a real
+                                       # choke point — but see `egress_enforced` before treating it as a
+                                       # *complete* one.
+      routed:                          # read off the RUNNING Deployments' env, not off the manifests
+        - copilot-service              # COPILOT_MODEL_ENDPOINT (#2062) — the customer-facing assistant
+        - control-liveness-sentinel    # LIVENESS_MODEL_ENDPOINT
+        - devops-agent                 # DEVOPS_MODEL_ENDPOINT
+        - docs-truth-agent             # LLM_GATEWAY_URL
+        - finops-agent                 # LLM_GATEWAY_URL
+        - flaky-test-hunter            # LLM_GATEWAY_URL
+        - governance-auditor           # LLM_GATEWAY_URL
+        - release-steward              # LLM_GATEWAY_URL
+        - authz-policy-auditor         # LLM_GATEWAY_URL
+      not_routed:
+        - agent-service                # AGENT_MODEL_ENDPOINT repoint merged (#2209), but the deployed
+                                       # image resolves the baked-in api.groq.com URL until the rebuilt
+                                       # image rolls out. Promote it to `routed` only after re-reading
+                                       # the live Deployment — merged is not deployed.
+      egress_enforced: partial         # ai-platform is egress-locked; `platform` is NOT. agent-service's
+                                       # component still declares policyTypes: [Ingress] only, so the
+                                       # gateway is bypassable from that pod. #2210 adds the Egress half,
+                                       # gated on the agent-service repoint actually being deployed.
+      budgets_enforced_at: charter     # CharterRateLimiter in openbank-agent-service — NOT the gateway.
+      providers:                       # both terminate INSIDE the gateway pod; no agent holds either key
         deepinfra:                     # api.deepinfra.com, deepseek-ai/DeepSeek-V3.2. US-hosted, no region
-                                       # pinning, no DPA. The single de-facto provider; chosen on cost.
+                                       # pinning, no DPA. Serves copilot + the ops agents.
           hosted: true                 # prompt data LEAVES THE EU. Licensed for synthetic data only —
-                                       # see ADR-0175 §4/§5. There is NO technical control enforcing that.
-      routing: none                    # no sensitive_data routing exists. See ADR-0175 D3.
-      fallback: none                   # single provider. On failure LlmDiagnosisAdapter returns null and
-                                       # the agent degrades to a deterministic path (ADR-0174 §4).
+                                       # see ADR-0175 §4/§5. Routing it through the gateway centralises
+                                       # the exposure; it does not remove it.
+        groq:                          # api.groq.com, llama-3.3-70b-versatile. US-hosted, same posture.
+                                       # Serves agent-service's admin-UI assistant (#2209).
+          hosted: true                 # prompt data LEAVES THE EU. Same licence and same caveat.
+      routing: none                    # still no sensitive_data routing: the gateway serves two hosted
+                                       # models and no self-hosted tier exists. ADR-0175 D3 stays open —
+                                       # a choke point is where routing COULD be enforced, not routing.
+      fallback: none                   # no cross-provider failover is configured. On failure
+                                       # LlmDiagnosisAdapter returns null and the agent degrades to a
+                                       # deterministic path (ADR-0174 §4).
 
     model_gateway_target:              # ADR-0031 D6 — the decision. NOT the state. Nothing here is deployed.
       tool: litellm                       # or equivalent open gateway in front of all models

--- a/openbank-infra/gitops/components/statements/statement-service.yaml
+++ b/openbank-infra/gitops/components/statements/statement-service.yaml
@@ -26,7 +26,7 @@ spec:
       annotations:
         # Rolls the pod when the OPA bundle changes — subPath mounts do NOT hot-reload.
         # Kept in sync by gen-statement-opa-bundle.sh (do not hand-edit).
-        openbank.tech/policy-checksum: "46b29807cf55bd08"
+        openbank.tech/policy-checksum: "a2927c75d3d7b76d"
       labels:
         app.kubernetes.io/name: statement-service
         app.kubernetes.io/part-of: statements

--- a/openbank-libs/governance/agents.yaml
+++ b/openbank-libs/governance/agents.yaml
@@ -85,19 +85,48 @@ runtime:
 # an absent control gets found, an asserted one gets relied on. Any consumer reading the bundles
 # must now hit `_target` / `_as_built` and cannot mistake the intent for the state.
 # ---------------------------------------------------------------------------------------
-model_gateway_as_built:            # verified 2026-07-16 against gitops + the live sandbox
-  gateway: none                    # no gateway. Agents call the provider endpoint directly.
-                                   # LLM_GATEWAY_URL=http://litellm.ai-platform.svc:4000 is set on 5
-                                   # agents and points at a Service that has never existed (#1280).
-  budgets_enforced_at: charter     # CharterRateLimiter in openbank-agent-service — NOT a gateway.
-  providers:
+model_gateway_as_built:            # verified 2026-07-25 against gitops AND the running Deployments
+  gateway: litellm                 # in-cluster LiteLLM proxy, ai-platform ns, :4000 (ADR-0174/0175,
+                                   # #2019). Deployed and serving. It is the only workload holding a
+                                   # provider key and the only one with an internet egress hole
+                                   # (ai-platform/networkpolicy-litellm-egress.yaml), so it is a real
+                                   # choke point — but see `egress_enforced` before treating it as a
+                                   # *complete* one.
+  routed:                          # read off the RUNNING Deployments' env, not off the manifests
+    - copilot-service              # COPILOT_MODEL_ENDPOINT (#2062) — the customer-facing assistant
+    - control-liveness-sentinel    # LIVENESS_MODEL_ENDPOINT
+    - devops-agent                 # DEVOPS_MODEL_ENDPOINT
+    - docs-truth-agent             # LLM_GATEWAY_URL
+    - finops-agent                 # LLM_GATEWAY_URL
+    - flaky-test-hunter            # LLM_GATEWAY_URL
+    - governance-auditor           # LLM_GATEWAY_URL
+    - release-steward              # LLM_GATEWAY_URL
+    - authz-policy-auditor         # LLM_GATEWAY_URL
+  not_routed:
+    - agent-service                # AGENT_MODEL_ENDPOINT repoint merged (#2209), but the deployed
+                                   # image resolves the baked-in api.groq.com URL until the rebuilt
+                                   # image rolls out. Promote it to `routed` only after re-reading
+                                   # the live Deployment — merged is not deployed.
+  egress_enforced: partial         # ai-platform is egress-locked; `platform` is NOT. agent-service's
+                                   # component still declares policyTypes: [Ingress] only, so the
+                                   # gateway is bypassable from that pod. #2210 adds the Egress half,
+                                   # gated on the agent-service repoint actually being deployed.
+  budgets_enforced_at: charter     # CharterRateLimiter in openbank-agent-service — NOT the gateway.
+  providers:                       # both terminate INSIDE the gateway pod; no agent holds either key
     deepinfra:                     # api.deepinfra.com, deepseek-ai/DeepSeek-V3.2. US-hosted, no region
-                                   # pinning, no DPA. The single de-facto provider; chosen on cost.
+                                   # pinning, no DPA. Serves copilot + the ops agents.
       hosted: true                 # prompt data LEAVES THE EU. Licensed for synthetic data only —
-                                   # see ADR-0175 §4/§5. There is NO technical control enforcing that.
-  routing: none                    # no sensitive_data routing exists. See ADR-0175 D3.
-  fallback: none                   # single provider. On failure LlmDiagnosisAdapter returns null and
-                                   # the agent degrades to a deterministic path (ADR-0174 §4).
+                                   # see ADR-0175 §4/§5. Routing it through the gateway centralises
+                                   # the exposure; it does not remove it.
+    groq:                          # api.groq.com, llama-3.3-70b-versatile. US-hosted, same posture.
+                                   # Serves agent-service's admin-UI assistant (#2209).
+      hosted: true                 # prompt data LEAVES THE EU. Same licence and same caveat.
+  routing: none                    # still no sensitive_data routing: the gateway serves two hosted
+                                   # models and no self-hosted tier exists. ADR-0175 D3 stays open —
+                                   # a choke point is where routing COULD be enforced, not routing.
+  fallback: none                   # no cross-provider failover is configured. On failure
+                                   # LlmDiagnosisAdapter returns null and the agent degrades to a
+                                   # deterministic path (ADR-0174 §4).
 
 model_gateway_target:              # ADR-0031 D6 — the decision. NOT the state. Nothing here is deployed.
   tool: litellm                       # or equivalent open gateway in front of all models


### PR DESCRIPTION
The governance half of #1919. Short shelf life — `agents.yaml` is embedded verbatim in 29 OPA
bundles, so any competing governance PR conflicts this one. Auto-merge is armed.

## What was stale

`agents.yaml: model_gateway_as_built` read `gateway: none` — *"no gateway. Agents call the provider
endpoint directly. `LLM_GATEWAY_URL` … points at a Service that has never existed (#1280)."*

That was accurate on 2026-07-16. It is not accurate now. Verified against the **running**
Deployments' env (not the manifests, and not the issue's comments, which are stale in the other
direction):

| Caller | Env var | Value |
|---|---|---|
| `copilot-service` | `COPILOT_MODEL_ENDPOINT` | `http://litellm.ai-platform.svc:4000/v1` |
| `control-liveness-sentinel` | `LIVENESS_MODEL_ENDPOINT` | `http://litellm.ai-platform.svc:4000/v1` |
| `devops-agent` | `DEVOPS_MODEL_ENDPOINT` | `http://litellm.ai-platform.svc:4000/v1` |
| `docs-truth-agent`, `finops-agent`, `flaky-test-hunter`, `governance-auditor`, `release-steward`, `authz-policy-auditor` | `LLM_GATEWAY_URL` | `http://litellm.ai-platform.svc:4000` |

`litellm-59b9b4c4cf-9j65p` is `1/1 Running` in `ai-platform` and has served a `POST
/v1/chat/completions → 200`.

## What the refresh does *not* do

It does not swap one blanket claim for another. Three deliberate restraints:

- **`routed` / `not_routed` name callers individually.** `agent-service` is in `not_routed`: the
  repoint is merged (#2209) but the deployed image still resolves the baked-in `api.groq.com` URL.
  Merged is not deployed — promote it only after re-reading the live Deployment.
- **`egress_enforced: partial`.** `ai-platform` is egress-locked; `platform` is not. Until #2210
  lands, the agent pod can still reach a provider directly, so the choke point is a convention, not
  a control. Claiming `full` here is exactly the false-control-claim failure the `_as_built` /
  `_target` split (#1280) was created to prevent.
- **`routing: none` is unchanged.** A choke point is *where* sensitive-data routing could be
  enforced, not routing. ADR-0175 D3 stays open.

`providers` gains `groq` alongside `deepinfra`; both keys now terminate inside the gateway pod.

## Generator fix (not cosmetic)

`gen-eu-ai-act.py` hard-coded the gateway-*absent* prose into the inventory table's "AI Act / GDPR
bearing" column:

```
| Gateway / egress choke point | `{gateway}` | No single point to enforce residency, redaction, or an egress NetworkPolicy. |
```

With `gateway: litellm` that row would have read `litellm` **and** "No single point to enforce…" —
a generated compliance document contradicting its own value column. The bearing text and the warning
banner are now derived from the values, and the table gains `Egress enforced` plus the routed /
not-routed caller lists. The ⚠ banner degrades from *Open gap* to *Partially closed gap* and only
disappears when `egress_enforced` reads `full`.

Regenerating also picks up the `ap2-anonymous` charter, which had drifted out of the committed doc
independently of this change.

## Blast radius

60 files: `agents.yaml`, the generator, `docs/compliance/eu-ai-act.md`, and 29 OPA bundles + their
pod-roll annotations — regenerated with

```
find openbank-infra/gitops/components -name 'gen-*opa-bundle*.sh' | sort | xargs -n1 bash
```

Nothing hand-edited. Expect every service whose `openbank.tech/policy-checksum` moved to roll its
pods; that is the mechanism working, since subPath mounts do not hot-reload. No `.rego` changed, and
no rule reads `model_gateway_as_built` — it is inventory data, consumed by the AI Act generator.

Refs #1919
