### PR TITLE
fix(cards): issue virtual cards ACTIVE and backfill the vault for pre-ADR-0194 cards

### DIFF
--- a/openbank-card-issuance-service/src/main/kotlin/com/openbank/cardissuance/application/port/out/CardPorts.kt
+++ b/openbank-card-issuance-service/src/main/kotlin/com/openbank/cardissuance/application/port/out/CardPorts.kt
@@ -35,4 +35,19 @@ interface CardRepository {
 
     /** Anonymises PII (cardholderName, embossedName) for cards whose expiry_date is before [cutoff]. Returns the count updated. */
     suspend fun anonymizeExpiredCardPii(cutoff: LocalDate): Int
+
+    /**
+     * Cards with **no stored PAN credential** that are still worth one — i.e. `pan_encrypted IS NULL`
+     * and the card is not in a terminal status. Feeds the vault backfill (ADR-0194 follow-up); a
+     * CANCELLED or EXPIRED card is dead and needs no credential minted for it.
+     */
+    suspend fun findWithoutPanCredential(): List<Card>
+
+    /**
+     * Writes the encrypted PAN/CVV onto a card **only if it has none** (`pan_encrypted IS NULL`).
+     * Returns true when the row was written. The NULL guard is what makes the backfill idempotent
+     * and safe to race: a second boot, or a concurrent replica, updates nothing and cannot renumber
+     * a card that already has a credential.
+     */
+    suspend fun storePanCredentialIfAbsent(cardId: UUID, panEncrypted: String, cvvEncrypted: String): Boolean
 }

--- a/openbank-card-issuance-service/src/main/kotlin/com/openbank/cardissuance/application/usecase/CardPanVaultBackfill.kt
+++ b/openbank-card-issuance-service/src/main/kotlin/com/openbank/cardissuance/application/usecase/CardPanVaultBackfill.kt
@@ -1,0 +1,85 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright (c) OpenBank contributors. Licensed under the Apache License, Version 2.0.
+// See LICENSE in the repository root or https://www.apache.org/licenses/LICENSE-2.0 for details.
+
+package com.openbank.cardissuance.application.usecase
+
+import com.openbank.cardissuance.application.port.out.CardRepository
+import com.openbank.cardissuance.application.port.out.CardSecretCipher
+import com.openbank.cardissuance.domain.model.Card
+import com.openbank.cardissuance.domain.model.SyntheticPanGenerator
+import jakarta.enterprise.context.ApplicationScoped
+import org.jboss.logging.Logger
+
+/** Outcome of one backfill pass. Counts only — never a card number. */
+data class CardPanBackfillResult(val backfilled: Int, val skipped: Int) {
+    val isEmpty: Boolean get() = backfilled == 0 && skipped == 0
+}
+
+/**
+ * Fills the synthetic-PAN vault for cards issued **before** it existed (ADR-0194 follow-up).
+ *
+ * Those cards have `pan_encrypted IS NULL`, so `readSecureDetails` refuses them with
+ * `CARD_SECURE_DETAILS_NOT_STORED` — correctly, but permanently: in the app the customer taps
+ * "Detaily", authenticates, and gets an error with no way out, forever. Nothing else in the system
+ * can ever repair those rows, because a credential is only minted at issue time.
+ *
+ * **The generated PAN keeps the card's existing last 4 digits.** `maskedPan` is already displayed
+ * (`**** **** **** 3901`) and the customer has read it off the screen; minting an unrelated number
+ * would silently change the card's identity under them, which is worse than the broken button. Only
+ * the hidden middle digits are new. When no Luhn-valid PAN can be built for a given last-4 (a mask
+ * that is not four digits — the pre-vault masks were random, so this is possible), the card is
+ * **skipped**: an unreadable "Detaily" is recoverable, a renumbered card is not.
+ *
+ * Idempotent by construction: it only ever considers rows where the column is NULL, and the write
+ * itself re-checks that predicate ([CardRepository.storePanCredentialIfAbsent]). A second pass — a
+ * restart, a second replica — finds nothing and does nothing.
+ */
+@ApplicationScoped
+class CardPanVaultBackfill(private val repo: CardRepository, private val cipher: CardSecretCipher) {
+
+    /**
+     * Mint and store a credential for every non-terminal card missing one. Returns the counts;
+     * logs one summary line. **No PAN or CVV is ever logged**, here or in the failure path.
+     */
+    suspend fun run(): CardPanBackfillResult {
+        val candidates = repo.findWithoutPanCredential()
+        if (candidates.isEmpty()) return CardPanBackfillResult(backfilled = 0, skipped = 0)
+
+        var backfilled = 0
+        var skipped = 0
+        for (card in candidates) {
+            val credential = SyntheticPanGenerator.generate(card.network, last4Of(card))
+            if (credential == null) {
+                log.warnf(
+                    "[pan-vault-backfill] skipped card %s: its masked PAN carries no usable last 4 " +
+                        "digits, and renumbering a card the customer has already seen is not an option",
+                    card.id,
+                )
+                skipped++
+                continue
+            }
+            val written = repo.storePanCredentialIfAbsent(
+                card.id,
+                cipher.encrypt(credential.pan),
+                cipher.encrypt(credential.cvv),
+            )
+            if (written) backfilled++ else skipped++
+        }
+        log.infof(
+            "[pan-vault-backfill] %d card(s) had no stored credential: %d backfilled, %d skipped",
+            candidates.size,
+            backfilled,
+            skipped,
+        )
+        return CardPanBackfillResult(backfilled = backfilled, skipped = skipped)
+    }
+
+    /** The four digits the customer already sees. Anything else (a shorter or non-numeric tail) is refused upstream. */
+    private fun last4Of(card: Card): String = card.maskedPan.takeLast(LAST4_LENGTH)
+
+    private companion object {
+        val log: Logger = Logger.getLogger(CardPanVaultBackfill::class.java)
+        const val LAST4_LENGTH = 4
+    }
+}

--- a/openbank-card-issuance-service/src/main/kotlin/com/openbank/cardissuance/application/usecase/CardService.kt
+++ b/openbank-card-issuance-service/src/main/kotlin/com/openbank/cardissuance/application/usecase/CardService.kt
@@ -34,6 +34,19 @@ class CardService(
         // Synthetic, Luhn-valid test PAN — see SyntheticPanGenerator. maskedPan is DERIVED from it,
         // so the displayed last-4 finally matches a number that exists (it used to be random).
         val credential = SyntheticPanGenerator.generate(cmd.network)
+        // PENDING exists for ONE reason: somebody still has to physically receive the plastic and
+        // activate it. A card with no plastic has nothing to receive, and the only PENDING → ACTIVE
+        // route (POST /cards/{id}/activate) is OPERATOR/ADMIN-only with no customer path through
+        // customer-edge — so a self-issued virtual card left PENDING can never transact and never
+        // be rescued. Issue those ACTIVE instead.
+        //
+        // The discriminator is the FORM FACTOR, not deliveryAddress, even though the delivery step
+        // is the real distinction: deliveryAddress is optional on IssueCardCommand, so a caller who
+        // simply omits it for a DEBIT card would get an ACTIVE card whose plastic is still in the
+        // post — the dangerous direction to be wrong in. Card.VIRTUAL_FORM_TYPES is already the
+        // module's single definition of "this card has no plastic" (it also governs secure-details),
+        // so reusing it keeps one answer to that question rather than two.
+        val activatedOnIssue = cmd.cardType in Card.VIRTUAL_FORM_TYPES
         val card = Card(
             id = UUID.randomUUID(), idempotencyKey = cmd.idempotencyKey,
             partyId = cmd.partyId, accountId = cmd.accountId,
@@ -41,11 +54,11 @@ class CardService(
             maskedPan = credential.maskedPan,
             cardholderName = cmd.cardholderName, embossedName = cmd.embossedName,
             expiryDate = LocalDate.now(clock).plusYears(EXPIRY_YEARS),
-            status = CardStatus.PENDING,
+            status = if (activatedOnIssue) CardStatus.ACTIVE else CardStatus.PENDING,
             dailyLimitMinorUnits = cmd.dailyLimitMinorUnits,
             monthlyLimitMinorUnits = cmd.monthlyLimitMinorUnits,
             currency = cmd.currency, deliveryAddress = cmd.deliveryAddress,
-            activatedAt = null, blockedAt = null, blockedReason = null,
+            activatedAt = if (activatedOnIssue) now else null, blockedAt = null, blockedReason = null,
             createdAt = now, updatedAt = now,
             panEncrypted = cipher.encrypt(credential.pan),
             cvvEncrypted = cipher.encrypt(credential.cvv),

--- a/openbank-card-issuance-service/src/main/kotlin/com/openbank/cardissuance/domain/model/Card.kt
+++ b/openbank-card-issuance-service/src/main/kotlin/com/openbank/cardissuance/domain/model/Card.kt
@@ -144,5 +144,12 @@ data class Card(
 
         /** Card types with no plastic, i.e. the only ones whose PAN may be re-served digitally. */
         val VIRTUAL_FORM_TYPES = setOf(CardType.VIRTUAL, CardType.SINGLE_USE)
+
+        /**
+         * Statuses a card can never leave — the complement of [CANCELLABLE_STATUSES]. A card here
+         * is dead: no transition applies, and nothing should be provisioned for it (the PAN-vault
+         * backfill skips them for exactly that reason).
+         */
+        val TERMINAL_STATUSES = setOf(CardStatus.CANCELLED, CardStatus.EXPIRED)
     }
 }

--- a/openbank-card-issuance-service/src/main/kotlin/com/openbank/cardissuance/domain/model/SyntheticPan.kt
+++ b/openbank-card-issuance-service/src/main/kotlin/com/openbank/cardissuance/domain/model/SyntheticPan.kt
@@ -53,20 +53,65 @@ object SyntheticPanGenerator {
 
     fun generate(network: CardNetwork): SyntheticCardCredential {
         val prefix = TEST_BIN_PREFIXES.getValue(network)
-        val panLength = if (network == CardNetwork.AMEX) PAN_LENGTH_AMEX else PAN_LENGTH_DEFAULT
-        val cvvLength = if (network == CardNetwork.AMEX) CVV_LENGTH_AMEX else CVV_LENGTH_DEFAULT
-
         val body = buildString {
             append(prefix)
-            repeat(panLength - prefix.length - 1) { append(random.nextInt(DECIMAL_RADIX)) }
+            repeat(panLength(network) - prefix.length - 1) { append(random.nextInt(DECIMAL_RADIX)) }
         }
-        val pan = body + luhnCheckDigit(body)
-        val cvv = (1..cvvLength).joinToString("") { random.nextInt(DECIMAL_RADIX).toString() }
-        return SyntheticCardCredential(pan = pan, cvv = cvv, maskedPan = mask(pan))
+        return credential(network, body + luhnCheckDigit(body))
+    }
+
+    /**
+     * Same as [generate], but the PAN is forced to END in [requiredLast4].
+     *
+     * This exists for the vault backfill: a card issued before the vault has a `maskedPan` the
+     * customer has already seen (`**** **** **** 3901`). Minting a fresh PAN for it must not
+     * silently change the card's identity under them, so the generated number keeps those four
+     * digits and only the hidden middle is new.
+     *
+     * The subtlety is that **the Luhn check digit IS the last digit** — it cannot be appended once
+     * the last 4 are pinned. Instead we pick the free middle digits, then solve for the one
+     * immediately preceding the fixed tail: at any single position, varying that digit 0..9 walks
+     * the Luhn sum through all ten residues mod 10 (undoubled trivially; doubled-with-rollover maps
+     * 0..9 → 0,2,4,6,8,1,3,5,7,9, also a bijection), so exactly one value makes the required final
+     * digit the correct check digit. The search is written as a bounded loop over 0..9 rather than
+     * arithmetic anyway, so an unrepresentable input returns `null` instead of a wrong number.
+     *
+     * Returns `null` when [requiredLast4] is not exactly four digits — the caller must then leave
+     * the card alone rather than renumber it.
+     */
+    fun generate(network: CardNetwork, requiredLast4: String?): SyntheticCardCredential? {
+        if (requiredLast4 == null) return null
+        if (requiredLast4.length != MASK_VISIBLE_DIGITS) return null
+        if (!requiredLast4.all { it.isDigit() }) return null
+
+        val prefix = TEST_BIN_PREFIXES.getValue(network)
+        val freeDigits = panLength(network) - prefix.length - MASK_VISIBLE_DIGITS
+        if (freeDigits < 1) return null
+
+        // One free digit is reserved as the solved "pivot"; the rest is random filler.
+        val filler = (1 until freeDigits).joinToString("") { random.nextInt(DECIMAL_RADIX).toString() }
+        val head = prefix + filler
+        val tail = requiredLast4.dropLast(1)
+        val checkDigit = requiredLast4.last().digitToInt()
+
+        val pivot = (0 until DECIMAL_RADIX).firstOrNull { candidate ->
+            luhnCheckDigit("$head$candidate$tail") == checkDigit
+        } ?: return null
+
+        return credential(network, "$head$pivot$tail${requiredLast4.last()}")
     }
 
     /** `**** **** **** 1234` — the last [MASK_VISIBLE_DIGITS] of the real PAN, everything else hidden. */
     fun mask(pan: String): String = "**** **** **** ${pan.takeLast(MASK_VISIBLE_DIGITS)}"
+
+    private fun panLength(network: CardNetwork) =
+        if (network == CardNetwork.AMEX) PAN_LENGTH_AMEX else PAN_LENGTH_DEFAULT
+
+    private fun credential(network: CardNetwork, pan: String): SyntheticCardCredential {
+        val cvvLength = if (network == CardNetwork.AMEX) CVV_LENGTH_AMEX else CVV_LENGTH_DEFAULT
+        val cvv = (1..cvvLength).joinToString("") { random.nextInt(DECIMAL_RADIX).toString() }
+        return SyntheticCardCredential(pan = pan, cvv = cvv, maskedPan = mask(pan))
+    }
 
     /** True when [pan] satisfies the Luhn (mod-10) checksum. */
     fun isLuhnValid(pan: String): Boolean {

--- a/openbank-card-issuance-service/src/main/kotlin/com/openbank/cardissuance/infrastructure/persistence/repository/CardRepositoryImpl.kt
+++ b/openbank-card-issuance-service/src/main/kotlin/com/openbank/cardissuance/infrastructure/persistence/repository/CardRepositoryImpl.kt
@@ -18,6 +18,7 @@ import java.time.LocalDate
 import java.util.UUID
 
 @ApplicationScoped
+@Suppress("TooManyFunctions") // one adapter method per CardRepository port method (hexagonal)
 class CardRepositoryImpl(private val outboxRepository: CardOutboxRepositoryImpl) :
     CardRepository,
     PanacheRepository<CardEntity> {
@@ -74,6 +75,28 @@ class CardRepositoryImpl(private val outboxRepository: CardOutboxRepositoryImpl)
         )
     }.awaitSuspending()
 
+    override suspend fun findWithoutPanCredential(): List<Card> = Panache.withSession {
+        find("panEncrypted IS NULL AND status NOT IN ?1", TERMINAL_STATUS_NAMES).list()
+    }.awaitSuspending().map { it.toDomain() }
+
+    /**
+     * Bulk UPDATE rather than a load-mutate-flush: the `panEncrypted IS NULL` predicate has to be
+     * part of the *write*, not a check the caller made earlier, or two replicas booting together
+     * could both decide a card needs a credential and the second would overwrite the first's.
+     */
+    override suspend fun storePanCredentialIfAbsent(
+        cardId: UUID,
+        panEncrypted: String,
+        cvvEncrypted: String,
+    ): Boolean = Panache.withTransaction {
+        update(
+            "panEncrypted = ?1, cvvEncrypted = ?2 WHERE id = ?3 AND panEncrypted IS NULL",
+            panEncrypted,
+            cvvEncrypted,
+            cardId,
+        )
+    }.awaitSuspending() == 1
+
     /** Copy the mutable (lifecycle) fields of [card] onto a managed entity for an in-place update. */
     private fun CardEntity.applyFrom(card: Card) {
         status = card.status.name
@@ -93,5 +116,10 @@ class CardRepositoryImpl(private val outboxRepository: CardOutboxRepositoryImpl)
         blockedAt = card.blockedAt
         blockedReason = card.blockedReason
         updatedAt = card.updatedAt
+    }
+
+    private companion object {
+        /** `status` is persisted as its enum NAME (see CardMapper), so the query compares strings. */
+        val TERMINAL_STATUS_NAMES = Card.TERMINAL_STATUSES.map { it.name }
     }
 }

--- a/openbank-card-issuance-service/src/main/kotlin/com/openbank/cardissuance/infrastructure/startup/CardPanVaultBackfillStarter.kt
+++ b/openbank-card-issuance-service/src/main/kotlin/com/openbank/cardissuance/infrastructure/startup/CardPanVaultBackfillStarter.kt
@@ -1,0 +1,79 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright (c) OpenBank contributors. Licensed under the Apache License, Version 2.0.
+// See LICENSE in the repository root or https://www.apache.org/licenses/LICENSE-2.0 for details.
+
+package com.openbank.cardissuance.infrastructure.startup
+
+import com.openbank.cardissuance.application.usecase.CardPanVaultBackfill
+import io.quarkus.runtime.Startup
+import io.quarkus.vertx.VertxContextSupport
+import io.smallrye.mutiny.coroutines.uni
+import jakarta.annotation.PostConstruct
+import jakarta.enterprise.context.ApplicationScoped
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.Dispatchers
+import org.eclipse.microprofile.config.inject.ConfigProperty
+import org.jboss.logging.Logger
+
+/**
+ * Runs [CardPanVaultBackfill] once per boot.
+ *
+ * [Startup] because an `@ApplicationScoped` bean is lazy — without it this would first run on some
+ * unrelated request, or never (see the repo CLAUDE.md; the same reason `AesGcmCardSecretCipher`
+ * carries it).
+ *
+ * **Two deliberate properties.**
+ *
+ * *It runs on a Vert.x duplicated context.* The repository is Hibernate Reactive Panache, and
+ * `Panache.withSession`/`withTransaction` throw `No current Vertx context found` off one — a
+ * `@PostConstruct` body executes on the plain startup thread, so it cannot call the repository
+ * directly. [VertxContextSupport] establishes that context for us.
+ *
+ * *It never blocks and never fails the boot.* We subscribe (fire-and-forget) rather than
+ * `subscribeAndAwait`, so a slow or unreachable database delays no readiness probe, and every
+ * failure is caught and logged loudly instead of propagating. The service coming up matters more
+ * than the backfill completing: an un-backfilled card shows the same "Detaily" error it shows
+ * today, whereas a card-issuance that will not start takes down issuing, blocking and cancelling
+ * for everyone. The next boot retries — the pass is idempotent.
+ */
+@Startup
+@ApplicationScoped
+class CardPanVaultBackfillStarter(
+    private val backfill: CardPanVaultBackfill,
+    @ConfigProperty(name = "openbank.card.pan-vault-backfill.enabled", defaultValue = "true")
+    private val enabled: Boolean,
+) {
+
+    // TooGenericExceptionCaught: this IS the loud-log-and-carry-on boundary the KDoc describes.
+    // Anything the backfill can throw — a driver error, a cipher misconfiguration — must not reach
+    // the boot, so the catch is deliberately as wide as the language allows.
+    @PostConstruct
+    @Suppress("TooGenericExceptionCaught")
+    fun onStartup() {
+        if (!enabled) {
+            log.info("[pan-vault-backfill] disabled by configuration; pre-vault cards keep an empty vault")
+            return
+        }
+        try {
+            VertxContextSupport.subscribe(
+                { uni(CoroutineScope(Dispatchers.Unconfined)) { backfill.run() }.toMulti() },
+                { subscription -> subscription.with({ }, { failure -> logFailure(failure) }) },
+            )
+        } catch (e: Throwable) {
+            logFailure(e)
+        }
+    }
+
+    private fun logFailure(failure: Throwable) {
+        log.error(
+            "[pan-vault-backfill] failed; the service is starting anyway. Cards issued before the " +
+                "synthetic-PAN vault keep returning CARD_SECURE_DETAILS_NOT_STORED until a later " +
+                "boot succeeds.",
+            failure,
+        )
+    }
+
+    private companion object {
+        val log: Logger = Logger.getLogger(CardPanVaultBackfillStarter::class.java)
+    }
+}

--- a/openbank-card-issuance-service/src/main/resources/diagrams/03-card-lifecycle.mmd
+++ b/openbank-card-issuance-service/src/main/resources/diagrams/03-card-lifecycle.mmd
@@ -1,6 +1,9 @@
 %% title: Card Lifecycle
 stateDiagram-v2
-    [*] --> PENDING : issueCard()
+    %% PENDING means "waiting for the plastic to be received"; a card with no plastic
+    %% (VIRTUAL / SINGLE_USE) has nothing to wait for and is issued ACTIVE directly.
+    [*] --> PENDING : issueCard() — card with plastic
+    [*] --> ACTIVE : issueCard() — VIRTUAL / SINGLE_USE
     PENDING --> ACTIVE : activate()
     ACTIVE --> SUSPENDED : suspend()
     SUSPENDED --> ACTIVE : resume()

--- a/openbank-card-issuance-service/src/main/resources/docs/01-overview.cs.md
+++ b/openbank-card-issuance-service/src/main/resources/docs/01-overview.cs.md
@@ -5,7 +5,7 @@
 `openbank-card-issuance-service` je **systém záznamu pro karty** v platformě OpenBank. Drží:
 
 - **Agregát Card** — `id` karty, vlastnící `partyId` a `accountId`, `productCode`, `cardType` (DEBIT / CREDIT / PREPAID / VIRTUAL), `network` (VISA / MASTERCARD / AMEX / UNIONPAY), **maskovaný PAN** (pouze poslední 4 číslice), jméno držitele a embosované jméno, datum expirace, stav, per-kartové limity útraty (denní / měsíční v minor units), měnu a volitelnou doručovací adresu.
-- **Stavový automat životního cyklu** — `PENDING → ACTIVE` (activate), `ACTIVE → SUSPENDED` (suspend) / `SUSPENDED → ACTIVE` (resume), `{ACTIVE, SUSPENDED} → BLOCKED` (trvalá blokace, vyžaduje důvod). `EXPIRED` a `CANCELLED` jsou v modelu terminální stavy.
+- **Stavový automat životního cyklu** — karta s plastem se vydává ve stavu `PENDING` a aktivuje se, až ji klient obdrží; karta `VIRTUAL` / `SINGLE_USE` nemá co obdržet a vydává se rovnou jako `ACTIVE`. Dále `PENDING → ACTIVE` (activate), `ACTIVE → SUSPENDED` (suspend) / `SUSPENDED → ACTIVE` (resume), `{ACTIVE, SUSPENDED} → BLOCKED` (trvalá blokace, vyžaduje důvod). `EXPIRED` a `CANCELLED` jsou v modelu terminální stavy.
 - **Doménové události** — `CardIssued` a `CardStatusChanged`, emitované při každé změně stavu a publikované přes transakční outbox.
 
 ## Co služba **NEDĚLÁ**

--- a/openbank-card-issuance-service/src/main/resources/docs/01-overview.en.md
+++ b/openbank-card-issuance-service/src/main/resources/docs/01-overview.en.md
@@ -5,7 +5,7 @@
 `openbank-card-issuance-service` is the **system of record for cards** in the OpenBank platform. It holds:
 
 - **Card aggregate** — the card's `id`, the owning `partyId` and `accountId`, `productCode`, `cardType` (DEBIT / CREDIT / PREPAID / VIRTUAL), `network` (VISA / MASTERCARD / AMEX / UNIONPAY), a **masked PAN** (last 4 digits only), cardholder and embossed name, expiry date, status, per-card spend limits (daily / monthly, in minor units), currency and optional delivery address.
-- **Lifecycle state machine** — `PENDING → ACTIVE` (activate), `ACTIVE → SUSPENDED` (suspend) / `SUSPENDED → ACTIVE` (resume), `{ACTIVE, SUSPENDED} → BLOCKED` (permanent block, requires a reason). `EXPIRED` and `CANCELLED` are terminal states in the model.
+- **Lifecycle state machine** — a card with plastic is issued `PENDING` and activated when the customer receives it; a `VIRTUAL` / `SINGLE_USE` card has nothing to receive and is issued `ACTIVE` directly. Then `PENDING → ACTIVE` (activate), `ACTIVE → SUSPENDED` (suspend) / `SUSPENDED → ACTIVE` (resume), `{ACTIVE, SUSPENDED} → BLOCKED` (permanent block, requires a reason). `EXPIRED` and `CANCELLED` are terminal states in the model.
 - **Domain events** — `CardIssued` and `CardStatusChanged`, emitted on every state change and published via the transactional outbox.
 
 ## What the service **does NOT** do

--- a/openbank-card-issuance-service/src/main/resources/docs/02-architecture.cs.md
+++ b/openbank-card-issuance-service/src/main/resources/docs/02-architecture.cs.md
@@ -91,7 +91,7 @@ sequenceDiagram
   R->>S: issueCard(cmd)
   S->>DB: findByIdempotencyKey (kontrola opakování)
   S->>DB: BEGIN TX
-  S->>DB: INSERT INTO cards (status=PENDING)
+  S->>DB: INSERT INTO cards<br/>(status=PENDING pro plastovou kartu,<br/>ACTIVE pro VIRTUAL / SINGLE_USE)
   S->>DB: INSERT INTO card_outbox<br/>(event=card.issued.v1, status=PENDING)
   S->>DB: COMMIT
   R-->>C: 201 Created

--- a/openbank-card-issuance-service/src/main/resources/docs/02-architecture.en.md
+++ b/openbank-card-issuance-service/src/main/resources/docs/02-architecture.en.md
@@ -91,7 +91,7 @@ sequenceDiagram
   R->>S: issueCard(cmd)
   S->>DB: findByIdempotencyKey (replay check)
   S->>DB: BEGIN TX
-  S->>DB: INSERT INTO cards (status=PENDING)
+  S->>DB: INSERT INTO cards<br/>(status=PENDING with plastic,<br/>ACTIVE for VIRTUAL / SINGLE_USE)
   S->>DB: INSERT INTO card_outbox<br/>(event=card.issued.v1, status=PENDING)
   S->>DB: COMMIT
   R-->>C: 201 Created

--- a/openbank-card-issuance-service/src/main/resources/docs/05-operations.cs.md
+++ b/openbank-card-issuance-service/src/main/resources/docs/05-operations.cs.md
@@ -40,6 +40,7 @@ Služba používá sdílenou Gradle konvenci `openbank.quarkus-service`; Dockerf
 | Redis hosts | `redis://localhost:6379` | Valkey/Redis |
 | OTel OTLP endpoint | `http://localhost:4317` | tracing |
 | `openbank.rate-limit.max-concurrent-requests` | `200` | strop souběžnosti |
+| `openbank.card.pan-vault-backfill.enabled` | `true` | při startu vygeneruje syntetický PAN pro neterminální karty vydané před trezorem (`pan_encrypted IS NULL`) a zachová jim zobrazené poslední 4 číslice. Idempotentní, neblokující a nikdy neshodí start; při každém startu zaloguje jednu souhrnnou řádku `[pan-vault-backfill]` |
 
 Bezpečnostní hlavičky (`X-Content-Type-Options`, `X-Frame-Options: DENY`, CSP `default-src 'self'`, HSTS atd.) jsou globálně nastaveny v `application.yaml`. Logy jsou JSON v ne-dev profilech.
 

--- a/openbank-card-issuance-service/src/main/resources/docs/05-operations.en.md
+++ b/openbank-card-issuance-service/src/main/resources/docs/05-operations.en.md
@@ -40,6 +40,7 @@ The **management interface is enabled on a separate port 8085** (`quarkus.manage
 | Redis hosts | `redis://localhost:6379` | Valkey/Redis |
 | OTel OTLP endpoint | `http://localhost:4317` | tracing |
 | `openbank.rate-limit.max-concurrent-requests` | `200` | concurrency cap |
+| `openbank.card.pan-vault-backfill.enabled` | `true` | mint a synthetic PAN at boot for non-terminal cards issued before the vault (`pan_encrypted IS NULL`), preserving each card's displayed last 4. Idempotent, non-blocking, and never fails the boot; it logs one `[pan-vault-backfill]` summary line per start |
 
 Security headers (`X-Content-Type-Options`, `X-Frame-Options: DENY`, CSP `default-src 'self'`, HSTS, etc.) are set globally in `application.yaml`. Logs are JSON in non-dev profiles.
 

--- a/openbank-card-issuance-service/src/test/kotlin/com/openbank/cardissuance/application/usecase/CardPanVaultBackfillTest.kt
+++ b/openbank-card-issuance-service/src/test/kotlin/com/openbank/cardissuance/application/usecase/CardPanVaultBackfillTest.kt
@@ -1,0 +1,169 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright (c) OpenBank contributors. Licensed under the Apache License, Version 2.0.
+// See LICENSE in the repository root or https://www.apache.org/licenses/LICENSE-2.0 for details.
+
+package com.openbank.cardissuance.application.usecase
+
+import com.openbank.cardissuance.application.port.out.CardRepository
+import com.openbank.cardissuance.domain.model.Card
+import com.openbank.cardissuance.domain.model.CardNetwork
+import com.openbank.cardissuance.domain.model.CardStatus
+import com.openbank.cardissuance.domain.model.CardType
+import com.openbank.cardissuance.domain.model.SyntheticPanGenerator
+import com.openbank.cardissuance.infrastructure.crypto.AesGcmCardSecretCipher
+import io.mockk.coEvery
+import io.mockk.coVerify
+import io.mockk.mockk
+import io.mockk.slot
+import kotlinx.coroutines.runBlocking
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Test
+import java.time.Instant
+import java.time.LocalDate
+import java.util.Base64
+import java.util.Optional
+import java.util.UUID
+
+/**
+ * The vault backfill (ADR-0194 follow-up): cards issued before `pan_encrypted` existed can never
+ * serve "Detaily" — and nothing else in the system repairs them.
+ */
+class CardPanVaultBackfillTest {
+
+    private lateinit var repo: CardRepository
+    private lateinit var backfill: CardPanVaultBackfill
+
+    // A real cipher, as in CardServiceTest: the round-trip is part of the behaviour under test.
+    // TEST ONLY key, built in code rather than pasted as a base64 literal (the repo's secret scan
+    // cannot tell a "only a test key" blob from a real one, and should not have to).
+    private val cipher = AesGcmCardSecretCipher(
+        Optional.of(Base64.getEncoder().encodeToString(ByteArray(32) { it.toByte() })),
+        false,
+    )
+
+    @BeforeEach
+    fun setUp() {
+        repo = mockk()
+        backfill = CardPanVaultBackfill(repo, cipher)
+    }
+
+    @Test fun `fills the vault for a card that has none, keeping its displayed last 4`(): Unit = runBlocking {
+        val legacy = card(maskedPan = "**** **** **** 3901")
+        coEvery { repo.findWithoutPanCredential() } returns listOf(legacy)
+        val pan = slot<String>()
+        val cvv = slot<String>()
+        coEvery { repo.storePanCredentialIfAbsent(legacy.id, capture(pan), capture(cvv)) } returns true
+
+        val result = backfill.run()
+
+        assertThat(result).isEqualTo(CardPanBackfillResult(backfilled = 1, skipped = 0))
+        val stored = cipher.decrypt(pan.captured)
+        // The customer has already read "3901" off the screen — the minted PAN must not renumber
+        // the card under them.
+        assertThat(stored).endsWith("3901")
+        assertThat(stored).startsWith("411111")
+        assertThat(SyntheticPanGenerator.isLuhnValid(stored)).isTrue()
+        assertThat(cipher.decrypt(cvv.captured)).hasSize(3).containsOnlyDigits()
+        // Ciphertext, not the clear value.
+        assertThat(pan.captured).isNotEqualTo(stored)
+    }
+
+    @Test fun `the card's maskedPan still matches the PAN that was minted for it`(): Unit = runBlocking {
+        val legacy = card(maskedPan = "**** **** **** 0007", network = CardNetwork.AMEX)
+        coEvery { repo.findWithoutPanCredential() } returns listOf(legacy)
+        val pan = slot<String>()
+        coEvery { repo.storePanCredentialIfAbsent(legacy.id, capture(pan), any()) } returns true
+
+        backfill.run()
+
+        assertThat(SyntheticPanGenerator.mask(cipher.decrypt(pan.captured))).isEqualTo(legacy.maskedPan)
+    }
+
+    // Terminal cards are excluded by the query itself (CardRepository.findWithoutPanCredential),
+    // so the backfill must not need to re-filter them — and must not touch one if it sees it.
+    @Test fun `a terminal card is never a candidate`(): Unit = runBlocking {
+        coEvery { repo.findWithoutPanCredential() } returns emptyList()
+
+        val result = backfill.run()
+
+        assertThat(result.isEmpty).isTrue()
+        coVerify(exactly = 0) { repo.storePanCredentialIfAbsent(any(), any(), any()) }
+        assertThat(Card.TERMINAL_STATUSES).containsExactlyInAnyOrder(CardStatus.CANCELLED, CardStatus.EXPIRED)
+    }
+
+    // Idempotence has two layers: the query only returns NULL rows, and the write re-checks the
+    // predicate. This is the second layer — a row that gained a credential in between is skipped,
+    // never overwritten.
+    @Test fun `a card that gained a credential concurrently is skipped, not renumbered`(): Unit = runBlocking {
+        val legacy = card(maskedPan = "**** **** **** 3901")
+        coEvery { repo.findWithoutPanCredential() } returns listOf(legacy)
+        coEvery { repo.storePanCredentialIfAbsent(legacy.id, any(), any()) } returns false
+
+        val result = backfill.run()
+
+        assertThat(result).isEqualTo(CardPanBackfillResult(backfilled = 0, skipped = 1))
+    }
+
+    @Test fun `a second run is a no-op once every card has a credential`(): Unit = runBlocking {
+        val legacy = card(maskedPan = "**** **** **** 3901")
+        coEvery { repo.findWithoutPanCredential() } returnsMany listOf(listOf(legacy), emptyList())
+        coEvery { repo.storePanCredentialIfAbsent(legacy.id, any(), any()) } returns true
+
+        assertThat(backfill.run().backfilled).isEqualTo(1)
+        assertThat(backfill.run()).isEqualTo(CardPanBackfillResult(backfilled = 0, skipped = 0))
+
+        coVerify(exactly = 1) { repo.storePanCredentialIfAbsent(legacy.id, any(), any()) }
+    }
+
+    // The pre-vault masks were random, and some are not four digits. Refusing beats renumbering.
+    @Test fun `a card whose mask carries no usable last 4 is skipped, not renumbered`(): Unit = runBlocking {
+        val unusable = card(maskedPan = "**** **** **** ****")
+        coEvery { repo.findWithoutPanCredential() } returns listOf(unusable)
+
+        val result = backfill.run()
+
+        assertThat(result).isEqualTo(CardPanBackfillResult(backfilled = 0, skipped = 1))
+        coVerify(exactly = 0) { repo.storePanCredentialIfAbsent(any(), any(), any()) }
+    }
+
+    @Test fun `a mixed batch reports both counts`(): Unit = runBlocking {
+        val good = card(maskedPan = "**** **** **** 1234")
+        val unusable = card(
+            maskedPan = "**** **** **** ab12",
+            id = UUID.fromString("44444444-4444-4444-4444-444444444444"),
+        )
+        coEvery { repo.findWithoutPanCredential() } returns listOf(good, unusable)
+        coEvery { repo.storePanCredentialIfAbsent(good.id, any(), any()) } returns true
+
+        assertThat(backfill.run()).isEqualTo(CardPanBackfillResult(backfilled = 1, skipped = 1))
+    }
+
+    private fun card(
+        maskedPan: String,
+        network: CardNetwork = CardNetwork.VISA,
+        id: UUID = UUID.fromString("11111111-1111-1111-1111-111111111111"),
+    ) = Card(
+        id = id,
+        idempotencyKey = "idem-$id-$maskedPan",
+        partyId = UUID.fromString("22222222-2222-2222-2222-222222222222"),
+        accountId = UUID.fromString("33333333-3333-3333-3333-333333333333"),
+        productCode = "CARD-001",
+        cardType = CardType.VIRTUAL,
+        network = network,
+        maskedPan = maskedPan,
+        cardholderName = "Jane Doe",
+        embossedName = "JANE DOE",
+        expiryDate = LocalDate.of(2030, 12, 31),
+        status = CardStatus.ACTIVE,
+        dailyLimitMinorUnits = 100_00,
+        monthlyLimitMinorUnits = 1_000_00,
+        currency = "EUR",
+        deliveryAddress = null,
+        activatedAt = null,
+        blockedAt = null,
+        blockedReason = null,
+        createdAt = Instant.parse("2026-01-01T00:00:00Z"),
+        updatedAt = Instant.parse("2026-01-01T00:00:00Z"),
+    )
+}

--- a/openbank-card-issuance-service/src/test/kotlin/com/openbank/cardissuance/application/usecase/CardServiceTest.kt
+++ b/openbank-card-issuance-service/src/test/kotlin/com/openbank/cardissuance/application/usecase/CardServiceTest.kt
@@ -225,6 +225,51 @@ class CardServiceTest {
         coVerify(exactly = 0) { repo.save(any(), any()) }
     }
 
+    // ── issued status by card type ─────────────────────────────────────────────────────
+    // PENDING means "waiting for someone to receive the plastic". A card with no plastic has
+    // nothing to wait for and no customer-facing activate route, so PENDING there is a dead end.
+
+    @Test fun `a card with plastic is issued PENDING and not activated`(): Unit = runBlocking {
+        listOf(CardType.DEBIT, CardType.CREDIT, CardType.PREPAID).forEach { type ->
+            val command = issueCmd("idem-$type").copy(cardType = type)
+            coEvery { repo.findByIdempotencyKey(command.idempotencyKey) } returns null
+            coEvery { repo.save(any(), any()) } answers { firstArg() }
+
+            val issued = service.issueCard(command)
+
+            assertThat(issued.status).describedAs("%s", type).isEqualTo(CardStatus.PENDING)
+            assertThat(issued.activatedAt).describedAs("%s", type).isNull()
+        }
+    }
+
+    @Test fun `a card with no plastic is issued ACTIVE and stamped as activated`(): Unit = runBlocking {
+        listOf(CardType.VIRTUAL, CardType.SINGLE_USE).forEach { type ->
+            val command = issueCmd("idem-$type").copy(cardType = type)
+            coEvery { repo.findByIdempotencyKey(command.idempotencyKey) } returns null
+            coEvery { repo.save(any(), any()) } answers { firstArg() }
+
+            val issued = service.issueCard(command)
+
+            assertThat(issued.status).describedAs("%s", type).isEqualTo(CardStatus.ACTIVE)
+            assertThat(issued.activatedAt).describedAs("%s", type).isEqualTo(Instant.now(clock))
+        }
+    }
+
+    // The physical path must keep working: an ACTIVE-on-issue virtual card is NOT allowed to make
+    // activate() unreachable for the plastic it exists for.
+    @Test fun `a physical card issued PENDING can still be activated afterwards`(): Unit = runBlocking {
+        val command = issueCmd("idem-physical-activate")
+        coEvery { repo.findByIdempotencyKey(command.idempotencyKey) } returns null
+        coEvery { repo.save(any(), any()) } answers { firstArg() }
+        val issued = service.issueCard(command)
+        coEvery { repo.findById(issued.id) } returns issued
+
+        val activated = service.activateCard(CardStatusCommand(issued.id, "Plastic received", "ops-user"))
+
+        assertThat(activated.status).isEqualTo(CardStatus.ACTIVE)
+        assertThat(activated.activatedAt).isEqualTo(Instant.now(clock))
+    }
+
     // ── synthetic PAN vault (#3) ───────────────────────────────────────────────────────
 
     @Test fun `issue stores an encrypted Luhn-valid PAN and derives the mask from it`(): Unit = runBlocking {

--- a/openbank-card-issuance-service/src/test/kotlin/com/openbank/cardissuance/domain/model/SyntheticPanGeneratorTest.kt
+++ b/openbank-card-issuance-service/src/test/kotlin/com/openbank/cardissuance/domain/model/SyntheticPanGeneratorTest.kt
@@ -63,7 +63,64 @@ class SyntheticPanGeneratorTest {
         assertThat(SyntheticPanGenerator.isLuhnValid("")).isFalse()
     }
 
+    // ── generate(network, requiredLast4) — the vault backfill's entry point ────────────
+    // The check digit IS the last digit, so pinning the last 4 means SOLVING for a body whose
+    // Luhn check digit lands on the requested final digit — not appending one.
+
+    @Test fun `a PAN generated for a required last 4 ends in those digits and stays Luhn valid`() {
+        CardNetwork.entries.forEach { network ->
+            LAST4_CASES.forEach { last4 ->
+                val credential = SyntheticPanGenerator.generate(network, last4)
+                assertThat(credential)
+                    .describedAs("%s must produce a PAN ending in %s", network, last4)
+                    .isNotNull()
+                assertThat(credential!!.pan).endsWith(last4)
+                assertThat(SyntheticPanGenerator.isLuhnValid(credential.pan))
+                    .describedAs("%s PAN ending %s must satisfy Luhn", network, last4)
+                    .isTrue()
+            }
+        }
+    }
+
+    @Test fun `a PAN generated for a required last 4 keeps the network BIN, length and mask`() {
+        val credential = SyntheticPanGenerator.generate(CardNetwork.MASTERCARD, "3901")!!
+        assertThat(credential.pan).startsWith("555555").hasSize(16)
+        assertThat(credential.maskedPan).isEqualTo("**** **** **** 3901")
+
+        val amex = SyntheticPanGenerator.generate(CardNetwork.AMEX, "0007")!!
+        assertThat(amex.pan).startsWith("378282").hasSize(15).endsWith("0007")
+        assertThat(amex.cvv).hasSize(4)
+    }
+
+    @Test fun `every required check digit 0-9 is reachable`() {
+        (0..9).forEach { checkDigit ->
+            val last4 = "129$checkDigit"
+            val credential = SyntheticPanGenerator.generate(CardNetwork.VISA, last4)
+            assertThat(credential).describedAs("last4 %s", last4).isNotNull()
+            assertThat(SyntheticPanGenerator.isLuhnValid(credential!!.pan)).isTrue()
+        }
+    }
+
+    @Test fun `only the hidden middle changes between two PANs built for the same last 4`() {
+        val pans = (1..REPEATS).map { SyntheticPanGenerator.generate(CardNetwork.VISA, "3901")!!.pan }
+        assertThat(pans).allMatch { it.endsWith("3901") }
+        // Not a fixed number: the free middle is random, so repeated calls must not collide.
+        assertThat(pans.toSet().size).isGreaterThan(1)
+    }
+
+    // A pre-vault maskedPan was a random string; anything that is not four digits must be REFUSED,
+    // because the alternative is renumbering a card the customer has already read off the screen.
+    @Test fun `an unusable required last 4 yields null rather than a different number`() {
+        assertThat(SyntheticPanGenerator.generate(CardNetwork.VISA, null)).isNull()
+        assertThat(SyntheticPanGenerator.generate(CardNetwork.VISA, "")).isNull()
+        assertThat(SyntheticPanGenerator.generate(CardNetwork.VISA, "390")).isNull()
+        assertThat(SyntheticPanGenerator.generate(CardNetwork.VISA, "39012")).isNull()
+        assertThat(SyntheticPanGenerator.generate(CardNetwork.VISA, "39*1")).isNull()
+        assertThat(SyntheticPanGenerator.generate(CardNetwork.VISA, "****")).isNull()
+    }
+
     private companion object {
         const val REPEATS = 50
+        val LAST4_CASES = listOf("0000", "3901", "1234", "9999", "0007", "5005")
     }
 }


### PR DESCRIPTION
Two defects found by running the new card screen against sandbox for real, both reported from TestFlight build 70.

## 1. Virtual cards were issued PENDING and nothing could ever activate them

`issueCard()` hardcoded `status = PENDING` for every card. `PENDING → ACTIVE` happens only via `POST /cards/{id}/activate` — an OPERATOR/ADMIN route with no customer-facing path through the edge. So a customer who self-issued a virtual card got one that **could never transact**.

Verified live: both cards in the sandbox DB were `VIRTUAL` / `PENDING`.

`VIRTUAL` and `SINGLE_USE` now issue `ACTIVE` with `activatedAt` set; everything else keeps `PENDING`.

The discriminator is card **type**, not `deliveryAddress` — which reads like the truer test (the delivery step is the real distinction) but is optional on the command, so a caller who simply omits it for a `DEBIT` card would get an ACTIVE card whose plastic is still in the post. That is the dangerous direction to be wrong in. `VIRTUAL_FORM_TYPES` is already this module's single definition of "no plastic" (it governs `secure-details` too).

Checked downstream: `CardIssued` carries no status field and a repo-wide grep found zero consumers of `card.issued` outside this service.

## 2. Cards issued before the vault had no PAN, so "show details" was permanently broken

`pan_encrypted IS NULL` makes `secure-details` refuse with `CARD_SECURE_DETAILS_NOT_STORED` — which in the app is a customer authenticating with Face ID and then being told it did not work. Every time, with no way out. That is the exact bug being reported.

A startup backfill mints and encrypts a credential for any non-terminal card missing one:

- **Preserves the existing masked last 4**, so a number the customer has already seen does not change under them. A mask that cannot be honoured (pre-vault masks were random digits, not a real PAN's tail) is **skipped, never renumbered**.
- The write carries `AND panEncrypted IS NULL` in the UPDATE statement itself, so it stays idempotent even with two replicas booting together.
- Every failure path lets the service come up — booting matters more than backfilling.
- One summary log line. No PAN or CVV is ever a log argument.
- Gated by `openbank.card.pan-vault-backfill.enabled` (default true).

Runs on a Vert.x duplicated context: Hibernate Reactive Panache throws `No current Vertx context found` on the plain startup thread.

### `SyntheticPanGenerator.generate(network, requiredLast4)`

The Luhn check digit **is** the last digit, so a required tail cannot be appended. The overload fixes the BIN prefix and the tail, randomises the free middle, and solves the digit immediately before the tail — that position walks all ten residues mod 10 whether doubled or not, so a solution always exists. Returns null for a tail that isn't exactly four digits.

## Verification

`ktlintCheck`, `detekt`, `test`, `koverVerify`, `quarkusBuild` (the last to validate CDI wiring of the new `@Startup` bean) — all green. 90 tests.

New tests cover the issued-status matrix by card type (including that a physical card is still activatable), the required-last-4 generator across all networks and all ten check digits, and the backfill: fills NULL rows preserving `maskedPan`, AMEX mask round-trip, terminal cards excluded, concurrent-write skip, second run a no-op, unusable mask skipped.

One flaky-IT note: `CardOutboxClaimIT` failed once with `Port already bound: 8081` — another Quarkus test on this shared machine, not this change. Green on re-run and on two subsequent full runs.

App companion: JiRaska/openbank-app#282 (merged).

🤖 Generated with [Claude Code](https://claude.com/claude-code)