### PR TITLE
feat(mcp): emit an AI-attributed audit event for every tools/call (ADR-0031 D5)

### DIFF
--- a/docs/threat-models/openbank-mcp-service.md
+++ b/docs/threat-models/openbank-mcp-service.md
@@ -38,7 +38,7 @@ What is actually running (`openbank-infra/gitops/components/mcp/mcp-service.yaml
 | Caller authentication on `/mcp` | **NONE.** `quarkus.oidc.tenant-enabled: false` (`src/main/resources/application.yaml`); no `@RolesAllowed`, no `@Authorize`, no mTLS, no API key |
 | Caller identity | **NONE.** `McpEndpoint.resolveContext()` returns a hardcoded `ConsentContext("agent:mcp-anonymous", "none", emptyList())` — the `X-Agent-Id` / `X-Consent-Id` headers its own KDoc describes are **not read** |
 | Consent scoping | **[INTENT]** — `ReadPorts.kt` KDoc assigns the granted-account intersection to "the port implementation"; the only implementation is the stub, which enforces nothing |
-| Audit trail of tool calls / policy decisions | **NONE.** No `AuditEventPublisher`, no `AuditEvent`, no Kafka producer in the module |
+| Audit trail of tool calls / policy decisions | **LIVE** (`application/McpCallAuditor.kt`) — one canonical `AuditEvent` per `tools/call`, `actorType = AI_AGENT`, carrying tool, capability, charter, `policy_decision` and outcome. Emitted on ALL four outcomes (allow, policy deny, unmapped tool, PDP outage). Delivery is the shared `LoggingAuditEventPublisher` (log pipeline), as everywhere else in the fleet — no Kafka producer in the module |
 | Rate limiting / budgets / idempotency | **NONE** in this service |
 | NetworkPolicy | **LIVE.** `mcp-service-ingress-allow-list` (ADR-0081, derived) admits same-namespace + admin-ui:8150/8181 + observability/security-scanner:8085 and drops every other cross-namespace source. Ingress only — egress is unrestricted |
 | Internet exposure | **NO** ingress, no `HTTPRoute`, `Service` is `ClusterIP` — in-cluster only |
@@ -181,15 +181,23 @@ invariant that nothing enforces. Phase 2 must land the OAuth 2.1 → PSD2-consen
 
 ### Repudiation
 
-- **T-R1 — no audit trail whatsoever. [LIVE gap — the most serious documented-but-unenforced
-  control in this service]** `agents.rego`'s `decision` object exists precisely so "a DENY is
-  auditable, not silent", and its own comment says the MCP endpoint records it into
-  `AuditEvent.payload.policy_decision` (ADR-0031 D5). **`openbank-mcp-service` emits no audit event
-  of any kind** — there is no `AuditEventPublisher`, no audit dependency, and no Kafka producer in
-  the module. A tool call, an allow, a deny, and a payment proposal are all invisible to the
-  ADR-0086 hash chain. A DENY is logged at WARN in the pod log and nowhere else. For an
-  AI-initiated action in a bank this is the attribution requirement, not a nice-to-have; it must
-  land with phase 2, and arguably before it.
+- **T-R1 — tool-call attribution. [LIVE — closed by issue #2207]** `agents.rego`'s `decision`
+  object exists precisely so "a DENY is auditable, not silent", and its own comment says the MCP
+  endpoint records it into `AuditEvent.payload.policy_decision` (ADR-0031 D5). `McpCallAuditor` now
+  does exactly that: every `tools/call` emits one canonical `AuditEvent` with
+  `actorType = AI_AGENT`, `operation = mcp.tool.call`, `resourceId = <tool>`, and a payload of
+  tool / capability / charter / consent id / `policy_decision` / reason. All four outcomes are on
+  the record — an unmapped tool and a PDP outage included, because a trail that shows only
+  successes hides the interesting half. `tools/list`, `initialize` and `ping` are deliberately not
+  audited (static catalogue, no customer data).
+  **Residual:** (a) attribution is only as good as the identity, and the actor is the constant
+  `agent:mcp-anonymous` until T-S1 lands — the trail answers "what was done" but not yet "by whom";
+  (b) delivery is the shared `LoggingAuditEventPublisher`, so entries reach the ADR-0086 hash chain
+  via the log pipeline rather than a durable Kafka producer — the fleet-wide posture, not specific
+  to this service; (c) the payload deliberately carries **no** tool arguments and **no** tool
+  output, only argument key names, so the trail cannot be used to reconstruct the customer data an
+  agent saw (GDPR data minimisation). That last one is a trade: it bounds the blast radius of the
+  audit store at the cost of not recording *which* account was queried.
 
 ### Information disclosure
 
@@ -296,13 +304,13 @@ reader skimming `agents.yaml` would reasonably assume all of them work:
 | `pii: masked` on the agent's data scope | `agents.yaml: mcp-anonymous.data_scope` | **nothing** in this service |
 | `requires_human: {every: proposal, sca: dynamic_linking, scope: consent_granted}` | `agents.yaml` | **nothing** — stated explicitly in `agents.rego` |
 | `limits: {tokens_per_run, runs_per_day}` | `agents.yaml` | **nothing** in this service (agent-service has a `CharterRateLimiter`; this one does not) |
-| Policy decision recorded to the audit chain | `agents.rego` `decision` comment, ADR-0031 D5 | **nothing** — no audit publisher in the module |
+| ~~Policy decision recorded to the audit chain~~ | `agents.rego` `decision` comment, ADR-0031 D5 | **now enforced** — `McpCallAuditor` (#2207); see T-R1 |
 | Declared tool `inputSchema` | `McpToolRegistry.tools` | **nothing** server-side beyond presence + JSON type |
 | 2 approvals on money-path changes | `CLAUDE.md`, `rules.yaml` | **nothing** — `main-protection` has `required_approving_review_count: 0` (issue #2183). Relevant here because §7 argues for the money-path listing |
 
 Genuinely enforced today: the deny-by-default capability map, the charter allow/deny evaluation via
-the shared PDP, fail-closed on PDP error, the read-only signed OPA bundle with a pod-rolling
-checksum, and the container hardening.
+the shared PDP, fail-closed on PDP error, the AI-attributed audit event on every tool call, the
+read-only signed OPA bundle with a pod-rolling checksum, and the container hardening.
 
 ## 6. Residual risks & assumptions
 
@@ -340,7 +348,7 @@ checksum, and the container hardening.
   it is not implemented — `main-protection` requires zero approvals (issue #2183). That is an
   argument for fixing #2183, not for skipping the listing.
 
-Recommended follow-up issues (not opened by this PR): audit events for every tool call and policy decision (T-R1); OAuth 2.1 → consent binding before the
+Recommended follow-up issues (not opened by this PR): OAuth 2.1 → consent binding before the
 read ports are bound (T-S1/T-E2); server-side `inputSchema` validation + idempotency on
 `propose_payment` (T-T2/T-D2).
 
@@ -358,3 +366,7 @@ read ports are bound (T-S1/T-E2); server-side `inputSchema` validation + idempot
   `components/agent/` (one file per *namespace*, first directory alphabetically). Restated as the
   narrower, true risk: the unconditional same-namespace rule leaves the whole `platform` namespace
   able to reach an unauthenticated `:8150`.
+- **2026-07-25 (issue #2207)** — T-R1 closed: `McpCallAuditor` emits an AI-attributed `AuditEvent`
+  for every `tools/call` outcome, so the ADR-0031 D5 `policy_decision` the rego was written to
+  expose is now on the record. Residuals restated (constant actor id until T-S1, log-pipeline
+  delivery, deliberately no arguments/results in the payload).

--- a/openbank-mcp-service/build.gradle.kts
+++ b/openbank-mcp-service/build.gradle.kts
@@ -38,9 +38,10 @@ kover {
         verify {
             rule {
                 bound {
-                    // Ratchet floor (ADR-0020). Set from the measured value at introduction with
-                    // ~5pt headroom; raise-only from here.
-                    minValue = 55
+                    // Ratchet floor (ADR-0020). Raise-only. 55 at introduction; the audit-event
+                    // tests (#2207) took the measured value to 82.1% LINE, so the floor moves to 75
+                    // (~7pt headroom) rather than leaving a 27pt gap the ratchet cannot see through.
+                    minValue = 75
                     coverageUnits = kotlinx.kover.gradle.plugin.dsl.CoverageUnit.LINE
                 }
             }

--- a/openbank-mcp-service/src/main/kotlin/com/openbank/mcp/application/McpCallAuditor.kt
+++ b/openbank-mcp-service/src/main/kotlin/com/openbank/mcp/application/McpCallAuditor.kt
@@ -1,0 +1,85 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+// Copyright (c) OpenBank contributors. Licensed under the GNU Affero General Public License v3.0 only.
+// A commercial licence is available from the maintainers as an alternative to the AGPL-3.0.
+// See LICENSES/AGPL-3.0-only.txt or https://www.gnu.org/licenses/agpl-3.0.html for details.
+package com.openbank.mcp.application
+
+import com.openbank.libs.audit.AuditEvent
+import com.openbank.libs.audit.AuditEventPublisher
+import com.openbank.libs.audit.AuditResult
+import jakarta.enterprise.context.ApplicationScoped
+import java.time.Instant
+
+/**
+ * Emits the AI-attributed audit event for every `tools/call` (ADR-0031 D5, ADR-0086 audit chain).
+ *
+ * Without this, an AI-initiated action against the bank left no record at all: the first question
+ * after any incident is "what did the agent do", and `agents.rego`'s `decision` object exists
+ * precisely so the MCP endpoint can answer it. The envelope is the canonical
+ * [com.openbank.libs.audit.AuditEvent] — same shape agent-service publishes from its own
+ * `AgentPolicyGate` (`actorType = AI_AGENT`, `policy_decision` in the payload), so both AI planes
+ * land in one queryable trail rather than two dialects.
+ *
+ * **Every** outcome is recorded, not only the happy path — an unmapped tool and a PDP outage are
+ * exactly the events an investigation looks for, and a trail that only shows successes is a trail
+ * that hides the interesting half.
+ *
+ * PII: the envelope says **what happened**, never what came back. Tool arguments and tool results
+ * are the customer's account data; only the argument *key names* are recorded, so a reviewer can
+ * see the call was e.g. account-scoped without the trail becoming a second copy of the data
+ * (GDPR data minimisation; `AuditEvent.payload` is documented as "NEVER raw PII").
+ */
+@ApplicationScoped
+class McpCallAuditor(private val publisher: AuditEventPublisher) {
+
+    /** One `tools/call` attempt and how it ended. */
+    data class ToolCall(
+        val agentId: String,
+        val consentId: String,
+        val tool: String,
+        /** The ADR-0034 capability the tool maps to; `null` when the tool has no mapping at all. */
+        val capability: String?,
+        val decision: Decision,
+        val result: AuditResult,
+        val reason: String? = null,
+        /** Argument KEY names only — never the values (see the class KDoc). */
+        val argumentKeys: List<String> = emptyList(),
+    )
+
+    /** The PDP outcome as recorded in the payload — `UNAVAILABLE` is a deny, but a distinct one. */
+    enum class Decision { ALLOW, DENY, UNAVAILABLE }
+
+    suspend fun toolCallCompleted(call: ToolCall) {
+        publisher.publish(
+            AuditEvent(
+                actorId = call.agentId,
+                actorType = ACTOR_TYPE,
+                operation = OPERATION,
+                resourceType = RESOURCE_TYPE,
+                resourceId = call.tool,
+                timestamp = Instant.now(),
+                result = call.result,
+                payload = buildMap {
+                    put("tool", call.tool)
+                    put("capability", call.capability)
+                    put("charter", call.agentId.removePrefix(AGENT_ID_PREFIX))
+                    put("consent_id", call.consentId)
+                    put("policy_decision", call.decision.name)
+                    put("argument_keys", call.argumentKeys)
+                    call.reason?.let { put("reason", it) }
+                },
+            ),
+        )
+    }
+
+    private companion object {
+        const val ACTOR_TYPE = "AI_AGENT"
+
+        /** `<service>.<aggregate>.<verb>` (AuditEvent KDoc); agent-service's twin is `agent.mcp.tool_call`. */
+        const val OPERATION = "mcp.tool.call"
+        const val RESOURCE_TYPE = "mcp.tool"
+
+        /** The `agent:` prefix the shared rego strips to match a charter id in `agents.yaml`. */
+        const val AGENT_ID_PREFIX = "agent:"
+    }
+}

--- a/openbank-mcp-service/src/main/kotlin/com/openbank/mcp/infrastructure/mcp/McpEndpoint.kt
+++ b/openbank-mcp-service/src/main/kotlin/com/openbank/mcp/infrastructure/mcp/McpEndpoint.kt
@@ -7,9 +7,11 @@ package com.openbank.mcp.infrastructure.mcp
 import com.fasterxml.jackson.databind.JsonNode
 import com.fasterxml.jackson.databind.ObjectMapper
 import com.fasterxml.jackson.databind.node.NullNode
+import com.openbank.libs.audit.AuditResult
 import com.openbank.libs.authz.AuthzQuery
 import com.openbank.libs.authz.PolicyDecisionPoint
 import com.openbank.libs.authz.Principal
+import com.openbank.mcp.application.McpCallAuditor
 import com.openbank.mcp.application.McpToolRegistry
 import com.openbank.mcp.application.port.out.ConsentContext
 import com.openbank.mcp.application.protocol.InitializeResult
@@ -38,6 +40,11 @@ import org.jboss.logging.Logger
  * in-service PDP), so an MCP tool-call is gated by exactly the same policy plane as a human REST
  * call. Deny-by-default: a tool with no capability entry, or an OPA `deny`, is refused.
  *
+ * Every `tools/call` — allowed, denied, unmapped, or denied by a PDP outage — emits one
+ * AI-attributed [McpCallAuditor] audit event (ADR-0031 D5 / ADR-0086), so an AI-initiated action
+ * against the bank is reconstructable. `tools/list`, `initialize` and `ping` do not: they touch no
+ * customer data and expose only the static tool catalogue.
+ *
  * Phase 1: the acting agent + consent are resolved from headers (X-Agent-Id / X-Consent-Id); the
  * real OAuth 2.1 → PSD2-consent binding (ADR-0126) is phase 2. The principal id is `agent:`-prefixed
  * so the shared AuthorizeInterceptor/rego classify it AI_AGENT and bridge to `agents.allow`.
@@ -48,6 +55,7 @@ import org.jboss.logging.Logger
 class McpEndpoint(
     private val registry: McpToolRegistry,
     private val pdp: PolicyDecisionPoint,
+    private val auditor: McpCallAuditor,
     private val mapper: ObjectMapper,
     @ConfigProperty(name = "mcp.server.name", defaultValue = "openbank-mcp") private val serverName: String,
     @ConfigProperty(name = "mcp.server.version", defaultValue = "0.1.0") private val serverVersion: String,
@@ -84,10 +92,36 @@ class McpEndpoint(
         val toolName = params.path("name").asText("")
         val arguments = params.path("arguments").let { if (it.isMissingNode) mapper.createObjectNode() else it }
         val ctx = resolveContext()
+        // Argument KEY names only — the values are customer data and must never enter the audit
+        // trail (McpCallAuditor KDoc).
+        val argumentKeys = arguments.fieldNames().asSequence().sorted().toList()
+
+        fun audit(
+            capability: String?,
+            decision: McpCallAuditor.Decision,
+            result: AuditResult,
+            reason: String? = null,
+        ) = runBlocking {
+            auditor.toolCallCompleted(
+                McpCallAuditor.ToolCall(
+                    agentId = ctx.agentId,
+                    consentId = ctx.consentId,
+                    tool = toolName,
+                    capability = capability,
+                    decision = decision,
+                    result = result,
+                    reason = reason,
+                    argumentKeys = argumentKeys,
+                ),
+            )
+        }
 
         // Deny-by-default: no capability mapping ⇒ no OPA action ⇒ refuse.
         val capability = registry.capabilities[toolName]
-            ?: return toolError(id, "Tool not permitted: $toolName")
+        if (capability == null) {
+            audit(null, McpCallAuditor.Decision.DENY, AuditResult.DENIED, "no capability mapping")
+            return toolError(id, "Tool not permitted: $toolName")
+        }
 
         // Gate on the SHARED ADR-0034 PDP as an AI_AGENT principal (input.action = the capability).
         val decision = try {
@@ -104,18 +138,25 @@ class McpEndpoint(
         } catch (ex: Exception) {
             // Fail closed: a PDP outage denies (never fail-open on a money-adjacent surface).
             log.warnf("PDP error authorizing %s: %s — denying", toolName, ex.message)
+            audit(capability, McpCallAuditor.Decision.UNAVAILABLE, AuditResult.DENIED, "pdp unavailable")
             return toolError(id, "Authorization unavailable")
         }
         if (!decision.allow) {
-            return toolError(id, "Denied by policy: ${decision.reason ?: "no matching allow rule"}")
+            val reason = decision.reason ?: "no matching allow rule"
+            audit(capability, McpCallAuditor.Decision.DENY, AuditResult.DENIED, reason)
+            return toolError(id, "Denied by policy: $reason")
         }
 
         return try {
-            Response.ok(McpResponse(id = id, result = registry.call(toolName, arguments, ctx))).build()
+            val result = registry.call(toolName, arguments, ctx)
+            audit(capability, McpCallAuditor.Decision.ALLOW, AuditResult.SUCCESS)
+            Response.ok(McpResponse(id = id, result = result)).build()
         } catch (ex: IllegalArgumentException) {
+            audit(capability, McpCallAuditor.Decision.ALLOW, AuditResult.FAILURE, "invalid params")
             error(id, McpErrorCode.INVALID_PARAMS, ex.message ?: "invalid params")
         } catch (ex: Exception) {
             log.warnf("tool %s failed: %s", toolName, ex.message)
+            audit(capability, McpCallAuditor.Decision.ALLOW, AuditResult.FAILURE, "tool error")
             Response.ok(
                 McpResponse(id = id, result = ToolCallResult(listOf(ToolContent(text = "tool error")), isError = true)),
             ).build()

--- a/openbank-mcp-service/src/test/kotlin/com/openbank/mcp/McpAuditEventIT.kt
+++ b/openbank-mcp-service/src/test/kotlin/com/openbank/mcp/McpAuditEventIT.kt
@@ -1,0 +1,99 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+// Copyright (c) OpenBank contributors. Licensed under the GNU Affero General Public License v3.0 only.
+package com.openbank.mcp
+
+import com.openbank.libs.audit.AuditEvent
+import com.openbank.libs.audit.AuditResult
+import io.quarkus.test.junit.QuarkusTest
+import io.restassured.RestAssured.given
+import io.restassured.http.ContentType
+import jakarta.inject.Inject
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Test
+
+/**
+ * Drives `tools/call` over the REAL HTTP stack and the REAL CDI graph and asserts the ADR-0031 D5
+ * audit event actually leaves the endpoint — for an ALLOWED call and for a DENIED one.
+ *
+ * The plain-unit tests in `McpEndpointTest` build the endpoint themselves, so they can only prove
+ * that the code path calls the auditor it was handed. What they cannot prove — and what this test
+ * exists for — is that the container resolves `McpCallAuditor` and its `AuditEventPublisher` at
+ * all, which is the way an audit trail actually goes missing in production: silently, with every
+ * unit test green.
+ */
+@QuarkusTest
+class McpAuditEventIT {
+
+    @Inject
+    lateinit var recorder: RecordingAuditEventPublisher
+
+    @BeforeEach
+    fun reset() = recorder.clear()
+
+    private fun toolsCall(tool: String, arguments: String = "{}") {
+        given()
+            .contentType(ContentType.JSON)
+            .body("""{"jsonrpc":"2.0","id":1,"method":"tools/call","params":{"name":"$tool","arguments":$arguments}}""")
+            .post("/mcp")
+            .then()
+            .statusCode(200)
+    }
+
+    private fun singleEvent(): AuditEvent {
+        assertThat(recorder.events).hasSize(1)
+        return recorder.events.single()
+    }
+
+    @Test
+    fun `an allowed tool call emits an AI-attributed audit event`() {
+        toolsCall(TestPolicyDecisionPoint.ALLOWED_TOOL)
+
+        val event = singleEvent()
+        assertThat(event.actorType).isEqualTo("AI_AGENT")
+        assertThat(event.actorId).isEqualTo("agent:mcp-anonymous")
+        assertThat(event.operation).isEqualTo("mcp.tool.call")
+        assertThat(event.resourceType).isEqualTo("mcp.tool")
+        assertThat(event.resourceId).isEqualTo(TestPolicyDecisionPoint.ALLOWED_TOOL)
+        assertThat(event.result).isEqualTo(AuditResult.SUCCESS)
+        assertThat(event.payload)
+            .containsEntry("policy_decision", "ALLOW")
+            .containsEntry("charter", "mcp-anonymous")
+            .containsEntry("capability", "query.account.readonly")
+    }
+
+    @Test
+    fun `a denied tool call emits a DENIED audit event carrying the policy reason`() {
+        toolsCall(TestPolicyDecisionPoint.DENIED_TOOL)
+
+        val event = singleEvent()
+        assertThat(event.actorType).isEqualTo("AI_AGENT")
+        assertThat(event.resourceId).isEqualTo(TestPolicyDecisionPoint.DENIED_TOOL)
+        assertThat(event.result).isEqualTo(AuditResult.DENIED)
+        assertThat(event.payload)
+            .containsEntry("policy_decision", "DENY")
+            .containsEntry("reason", "no matching allow rule")
+    }
+
+    @Test
+    fun `the audit event records argument key names but never their values`() {
+        toolsCall(TestPolicyDecisionPoint.DENIED_TOOL, """{"accountId":"CZ6508000000192000145399"}""")
+
+        val event = singleEvent()
+        assertThat(event.payload["argument_keys"]).isEqualTo(listOf("accountId"))
+        assertThat(event.payload.values.map { it.toString() })
+            .noneMatch { it.contains("CZ6508000000192000145399") }
+    }
+
+    @Test
+    fun `tools list is not audited - no customer data is touched`() {
+        given()
+            .contentType(ContentType.JSON)
+            .body("""{"jsonrpc":"2.0","id":1,"method":"tools/list","params":{}}""")
+            .post("/mcp")
+            .then()
+            .statusCode(200)
+
+        assertThat(recorder.events).isEmpty()
+    }
+}

--- a/openbank-mcp-service/src/test/kotlin/com/openbank/mcp/McpEndpointTest.kt
+++ b/openbank-mcp-service/src/test/kotlin/com/openbank/mcp/McpEndpointTest.kt
@@ -4,9 +4,13 @@ package com.openbank.mcp
 
 import com.fasterxml.jackson.databind.JsonNode
 import com.fasterxml.jackson.module.kotlin.jacksonObjectMapper
+import com.openbank.libs.audit.AuditEvent
+import com.openbank.libs.audit.AuditEventPublisher
+import com.openbank.libs.audit.AuditResult
 import com.openbank.libs.authz.AuthzDecision
 import com.openbank.libs.authz.AuthzQuery
 import com.openbank.libs.authz.PolicyDecisionPoint
+import com.openbank.mcp.application.McpCallAuditor
 import com.openbank.mcp.application.McpToolRegistry
 import com.openbank.mcp.application.port.out.AccountReadPort
 import com.openbank.mcp.application.port.out.ConsentContext
@@ -24,10 +28,12 @@ class McpEndpointTest {
 
     private val mapper = jacksonObjectMapper()
 
+    private val audit = Recorder()
+
     private fun endpoint(pdp: PolicyDecisionPoint): McpEndpoint {
         val stub = StubReads(mapper)
         val registry = McpToolRegistry(stub, stub, mapper)
-        return McpEndpoint(registry, pdp, mapper, "openbank-mcp", "0.1.0", "2025-06-18")
+        return McpEndpoint(registry, pdp, McpCallAuditor(audit), mapper, "openbank-mcp", "0.1.0", "2025-06-18")
     }
 
     private fun rpc(method: String, params: Map<String, Any?> = emptyMap()): JsonNode =
@@ -97,6 +103,75 @@ class McpEndpointTest {
         ).contains("Authorization unavailable")
     }
 
+    // ── ADR-0031 D5: every tools/call outcome is on the record ──────────────────────────────
+
+    @Test
+    fun `an allowed tool call is audited as ALLOW + SUCCESS`() {
+        endpoint(allowAll()).handle(
+            rpc("tools/call", mapOf("name" to "list_accounts", "arguments" to mapOf("unused" to "x"))),
+        )
+        val event = audit.events.single()
+        assertThat(event.actorType).isEqualTo("AI_AGENT")
+        assertThat(event.operation).isEqualTo("mcp.tool.call")
+        assertThat(event.result).isEqualTo(AuditResult.SUCCESS)
+        assertThat(event.payload)
+            .containsEntry("policy_decision", "ALLOW")
+            .containsEntry("capability", "query.account.readonly")
+            .containsEntry("charter", "mcp-anonymous")
+            .containsEntry("argument_keys", listOf("unused"))
+    }
+
+    @Test
+    fun `a policy-denied tool call is audited as DENY + DENIED with the reason`() {
+        endpoint(denyAll()).handle(
+            rpc("tools/call", mapOf("name" to "list_accounts", "arguments" to emptyMap<String, Any>())),
+        )
+        val event = audit.events.single()
+        assertThat(event.result).isEqualTo(AuditResult.DENIED)
+        assertThat(event.payload)
+            .containsEntry("policy_decision", "DENY")
+            .containsEntry("reason", "no matching allow rule")
+    }
+
+    @Test
+    fun `an unmapped tool is audited even though the PDP is never consulted`() {
+        endpoint(exploding()).handle(
+            rpc("tools/call", mapOf("name" to "delete_everything", "arguments" to emptyMap<String, Any>())),
+        )
+        val event = audit.events.single()
+        assertThat(event.result).isEqualTo(AuditResult.DENIED)
+        assertThat(event.resourceId).isEqualTo("delete_everything")
+        assertThat(event.payload)
+            .containsEntry("capability", null)
+            .containsEntry("reason", "no capability mapping")
+    }
+
+    @Test
+    fun `a PDP outage is audited as UNAVAILABLE, distinct from a policy DENY`() {
+        endpoint(exploding()).handle(
+            rpc("tools/call", mapOf("name" to "list_accounts", "arguments" to emptyMap<String, Any>())),
+        )
+        val event = audit.events.single()
+        assertThat(event.result).isEqualTo(AuditResult.DENIED)
+        assertThat(event.payload).containsEntry("policy_decision", "UNAVAILABLE")
+    }
+
+    @Test
+    fun `the audit payload never carries tool arguments or tool output`() {
+        endpoint(allowAll()).handle(
+            rpc("tools/call", mapOf("name" to "get_balance", "arguments" to mapOf("accountId" to SECRET))),
+        )
+        val rendered = audit.events.single().payload.toString()
+        assertThat(rendered).contains("accountId").doesNotContain(SECRET)
+    }
+
+    private class Recorder : AuditEventPublisher {
+        val events = mutableListOf<AuditEvent>()
+        override suspend fun publish(event: AuditEvent) {
+            events.add(event)
+        }
+    }
+
     private fun allowAll() = object : PolicyDecisionPoint {
         override suspend fun allow(query: AuthzQuery) = AuthzDecision(allow = true)
     }
@@ -107,6 +182,10 @@ class McpEndpointTest {
 
     private fun exploding() = object : PolicyDecisionPoint {
         override suspend fun allow(query: AuthzQuery): AuthzDecision = error("PDP down")
+    }
+
+    private companion object {
+        const val SECRET = "CZ6508000000192000145399"
     }
 
     private class StubReads(private val m: com.fasterxml.jackson.databind.ObjectMapper) :

--- a/openbank-mcp-service/src/test/kotlin/com/openbank/mcp/RecordingAuditEventPublisher.kt
+++ b/openbank-mcp-service/src/test/kotlin/com/openbank/mcp/RecordingAuditEventPublisher.kt
@@ -1,0 +1,33 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+// Copyright (c) OpenBank contributors. Licensed under the GNU Affero General Public License v3.0 only.
+package com.openbank.mcp
+
+import com.openbank.libs.audit.AuditEvent
+import com.openbank.libs.audit.AuditEventPublisher
+import jakarta.annotation.Priority
+import jakarta.enterprise.context.ApplicationScoped
+import jakarta.enterprise.inject.Alternative
+import java.util.concurrent.CopyOnWriteArrayList
+
+/**
+ * A REAL CDI bean that replaces [com.openbank.libs.audit.LoggingAuditEventPublisher] for the
+ * `@QuarkusTest`s, rather than a mock handed to a constructor.
+ *
+ * The failure this guards against is a wiring failure — the endpoint not being given a publisher,
+ * or the `McpCallAuditor` never being resolved — and a constructor-injected mock cannot see that,
+ * because the test builds the graph itself. Here the container builds it, so an event landing in
+ * [events] proves the deployed wiring emits.
+ */
+@ApplicationScoped
+@Alternative
+@Priority(1)
+class RecordingAuditEventPublisher : AuditEventPublisher {
+
+    val events: MutableList<AuditEvent> = CopyOnWriteArrayList()
+
+    override suspend fun publish(event: AuditEvent) {
+        events.add(event)
+    }
+
+    fun clear() = events.clear()
+}

--- a/openbank-mcp-service/src/test/kotlin/com/openbank/mcp/TestPolicyDecisionPoint.kt
+++ b/openbank-mcp-service/src/test/kotlin/com/openbank/mcp/TestPolicyDecisionPoint.kt
@@ -1,0 +1,35 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+// Copyright (c) OpenBank contributors. Licensed under the GNU Affero General Public License v3.0 only.
+package com.openbank.mcp
+
+import com.openbank.libs.authz.AuthzDecision
+import com.openbank.libs.authz.AuthzQuery
+import com.openbank.libs.authz.PolicyDecisionPoint
+import jakarta.annotation.Priority
+import jakarta.enterprise.context.ApplicationScoped
+import jakarta.enterprise.inject.Alternative
+
+/**
+ * Stands in for the OPA sidecar, which does not exist in a test JVM (`AuthzProducer` would produce
+ * a client against `localhost:8181` and every call would fail closed — a real posture, but it makes
+ * the ALLOW branch unreachable).
+ *
+ * Deliberately deterministic rather than a mock: `list_accounts` is allowed, everything else is
+ * denied, so one running container serves both the allow and the deny assertion without
+ * per-test stubbing.
+ */
+@ApplicationScoped
+@Alternative
+@Priority(1)
+class TestPolicyDecisionPoint : PolicyDecisionPoint {
+    override suspend fun allow(query: AuthzQuery): AuthzDecision = if (query.attributes["tool"] == ALLOWED_TOOL) {
+        AuthzDecision(allow = true)
+    } else {
+        AuthzDecision(allow = false, reason = "no matching allow rule")
+    }
+
+    companion object {
+        const val ALLOWED_TOOL = "list_accounts"
+        const val DENIED_TOOL = "list_consents"
+    }
+}


### PR DESCRIPTION
Second half of #2207. The first half (#2213) is the NetworkPolicy finding and is independent —
this does not wait on it.

## The gap

`agents.rego` builds a `decision` object specifically so a DENY is "auditable, not silent", and its
own comment says the MCP endpoint records it into `AuditEvent.payload.policy_decision` (ADR-0031 D5).
`openbank-mcp-service` had **no `AuditEventPublisher`, no audit dependency, no producer of any kind**.
Every AI-initiated tool call was invisible to the ADR-0086 audit chain — after an incident there was
no answer to "what did the agent do", only a WARN line in a pod log, and only for the denials.

For a service whose entire purpose is exposing bank capability to AI agents, that is the attribution
requirement, not a nice-to-have.

## The event

No new event shape was invented. `McpCallAuditor` publishes the canonical
`com.openbank.libs.audit.AuditEvent` through the shared `AuditEventPublisher`, using the same
`actorType = AI_AGENT` + `policy_decision` payload convention agent-service's `AgentPolicyGate`
already uses — so both AI planes land in one queryable trail rather than two dialects. Both libs were
already on the classpath; no dependency added.

| field | value |
|---|---|
| `actorId` | the acting agent (`agent:mcp-anonymous` in phase 1) |
| `actorType` | `AI_AGENT` |
| `operation` | `mcp.tool.call` (agent-service's twin is `agent.mcp.tool_call`) |
| `resourceType` / `resourceId` | `mcp.tool` / the tool name |
| `result` | `SUCCESS` / `DENIED` / `FAILURE` |
| `payload` | `tool`, `capability`, `charter`, `consent_id`, `policy_decision`, `reason`, `argument_keys` |

**All four outcomes are recorded**, not just the happy path:

| outcome | `result` | `policy_decision` |
|---|---|---|
| PDP allowed, tool ran | `SUCCESS` | `ALLOW` |
| PDP denied | `DENIED` | `DENY` (+ the rego's reason) |
| tool has no capability mapping — refused before the PDP is consulted | `DENIED` | `DENY` |
| PDP unreachable — fail-closed | `DENIED` | **`UNAVAILABLE`** |

`UNAVAILABLE` is deliberately distinct from `DENY`: an investigation needs to tell "policy said no"
from "policy could not be asked". A trail that shows only successes hides the interesting half.

`tools/list`, `initialize` and `ping` emit nothing — static catalogue, no customer data.

## What is deliberately NOT in the event

The payload carries **no tool arguments and no tool output** — only the argument *key names*. A
reviewer can see a call was account-scoped without the audit store becoming a second copy of the
customer's account data (`AuditEvent.payload` is documented as "NEVER raw PII"; GDPR data
minimisation). `McpEndpointTest` asserts an IBAN passed as an argument value does not appear anywhere
in the emitted payload while the key `accountId` does.

That is a trade, and it is written into the threat model rather than left implicit: it bounds the
blast radius of the audit store at the cost of not recording *which* account was queried.

## Tests, and why there are two levels

- `McpEndpointTest` (+5 cases) — all four outcome branches plus the no-PII assertion.
- `McpAuditEventIT` (`@QuarkusTest`, new) — drives a real `POST /mcp` over the HTTP stack through
  the real CDI graph, with an `@Alternative @Priority(1)` `RecordingAuditEventPublisher` replacing
  `LoggingAuditEventPublisher`.

The second exists because a constructor-injected mock can only prove the code calls what the test
handed it; it cannot prove the container resolves `McpCallAuditor` and its publisher at all — which
is exactly how an audit trail goes missing in production: silently, with every unit test green. The
PDP is stubbed (there is no OPA sidecar in a test JVM, so every call would otherwise fail closed and
the ALLOW branch would be unreachable), but the publisher is a real bean in the real graph.

There is no Kafka or outbox path here: no service in this repo ships a Kafka `AuditEventPublisher` —
the fleet-wide posture is `LoggingAuditEventPublisher` into the log pipeline. So the atomicity
concern that forces a real-DB IT elsewhere does not apply; the wiring is the risk, and the IT covers it.

### Revert-proof (a test that has never failed proves nothing)

With the production emission reverted in `McpEndpoint.handleToolCall` (the local `audit(...)` helper
short-circuited to `Unit`) and the tests untouched:

```
McpAuditEventIT > an allowed tool call emits an AI-attributed audit event()                FAILED
McpAuditEventIT > a denied tool call emits a DENIED audit event carrying the policy reason() FAILED
McpAuditEventIT > the audit event records argument key names but never their values()      FAILED
McpEndpointTest > an allowed tool call is audited as ALLOW + SUCCESS()                     FAILED
McpEndpointTest > a policy-denied tool call is audited as DENY + DENIED with the reason()  FAILED
McpEndpointTest > an unmapped tool is audited even though the PDP is never consulted()     FAILED
McpEndpointTest > a PDP outage is audited as UNAVAILABLE, distinct from a policy DENY()    FAILED
McpEndpointTest > the audit payload never carries tool arguments or tool output()          FAILED
BUILD FAILED
```

8 failures, and every pre-existing test stayed green. `tools list is not audited` correctly passes in
both states — it is a negative assertion. Production code restored and re-verified after.

## Gate

```
./gradlew :openbank-mcp-service:detekt :openbank-mcp-service:ktlintCheck \
          :openbank-mcp-service:koverVerify :openbank-mcp-service:build \
          :openbank-mcp-service:quarkusBuild
BUILD SUCCESSFUL
```

`quarkusBuild` included deliberately — CDI/ArC wiring failures surface only there.

Kover floor **55 → 75** (measured 82.1% LINE after this change). Ratchet-only; 55 was the
introduction value and left a 27pt gap the ratchet could not see through.

Hexagonal purity respected: `McpCallAuditor` is in `application`, and no Jackson type moved into a
domain package.

## Not changed

- `openapi.yaml` / `info.version` — no API-contract change. Same `/mcp` endpoint, same JSON-RPC
  request and response shapes; the audit event is a side effect, not part of the contract.
- `version.txt` — release-please cuts this (`feat` + a path under `openbank-mcp-service/src/main`).
- `governance.yaml` — the service remains stateless; the audit event is emitted, not stored.

## Threat model

`docs/threat-models/openbank-mcp-service.md` T-R1 ("no audit trail whatsoever", flagged there as the
most serious documented-but-unenforced control) moves to LIVE, with the three residuals stated
explicitly rather than dropped: the actor id is still the constant `agent:mcp-anonymous` until the
identity work in #2206 lands — the trail answers *what* was done but not yet *by whom*; delivery is
the log pipeline, not a durable Kafka producer; and the payload omits arguments and results by design.

Closes #2207
