### PR TITLE
docs: capture the @Scheduled Vert.x-context and gate-hygiene lessons

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -113,6 +113,24 @@ These are real, repeatable gotchas — worth knowing before they cost you a debu
   `require-trusted-issuer` — documented as "refuses to **start**" — would have thrown on a *request*,
   long after the deploy went green. Add `@Startup` (`io.quarkus.runtime.Startup`) to any bean whose
   `init` is a boot-time gate or a config-sanity warning.
+- **A plain (non-`suspend`) `@Scheduled` method carries NO Vert.x context** — Quarkus invokes it on a
+  bare `executor-thread`, so a body of `runBlocking { … }` around a reactive Panache call throws
+  `HR000068` and the job aborts having done nothing, silently (the throw lands before the per-item
+  try/catch). Make it a `suspend fun` — the unanimous fleet convention.
+  `VertxContextSupport.subscribeAndAwait` is not the fix: it swaps one blocking bridge for another
+  and *throws* if ever called from an event loop, so it breaks the day the method gains
+  `@NonBlocking` or a virtual thread. Five schedulers, three of them money-path, had **never** run
+  (#2148, #2187). Now a hard rule:
+  `rules.yaml: scheduled_methods` + `.github/scripts/check-no-runblocking-in-scheduled.py`.
+- **A test that calls a `@Scheduled` method directly cannot see that bug** — the direct call supplies
+  the very Vert.x context the scheduler does not, so it passes against broken code (and where
+  `%test.quarkus.scheduler.enabled` is `false`, as in ledger and billing, the scheduler class is
+  structurally invisible to every test). Drive the REAL cron from a `@TestProfile` that re-enables
+  the scheduler and shrinks the cron expression: `StandingOrderExecutionSweepIT`,
+  `LedgerSchedulerVertxContextIT`, `CnbIngestionSchedulerVertxContextIT`. Footgun inside that
+  profile: a `QuarkusTestProfile` loads in a **different classloader** from the test class, so a
+  companion object initializes twice — a randomized id in `getConfigOverrides()` hands the scheduler
+  one value and the assertion another. Use literals.
 
 ### ktlint
 - Path-scoped CI only lints changed files, so a pre-existing wildcard import or a latent
@@ -156,6 +174,20 @@ fire from *outside* it, so they stay here:
   amd64 and silently miss an arm64-only image) and checks the SBOM *before* attesting; `cosign
   attest` is additive, so a green `verify-attestation` can be about an earlier build's envelope.
 
+### CI gates — exercise the failure path before trusting the green
+- **A gate that has only ever passed is unfalsified.** Its failure path is code nobody has run, and
+  it fails in ways a green/red signal cannot express. Three independent instances in one week: the
+  ADR-0071 governance reporter crashed with a `TypeError` on *every* failure, so it had never once
+  printed a gap (#2165); a `Trivy fs scan` step exited 1 while printing no finding, so the actual CVE
+  had to be read out of the code-scanning API instead (PR #2154); an OOM'd `fleet-lint` reported a
+  plain red while having silently left half the fleet unlinted — 455 actionable findings against a
+  true 920 (#2177). Feed every new gate an input it MUST flag, and read what it *prints*, not just
+  its exit code.
+- **An advisory check over a *generated* artifact is a contradiction.** On a hand-written artifact a
+  red advisory check means "someone should look"; on a generated one it means "the committed document
+  does not match reality" — there is no judgement left to exercise, so advisory just makes the drift
+  mergeable. `eu-ai-act-registry` went red twice on #2156 and the PR merged anyway, leaving the EU AI
+  Act inventory omitting an AI system until it was regenerated. Tracked as #2216.
 
 ### CI / bot commit signing
 - **What signs a bot commit is the *endpoint*, not the token — and `main-protection` enforces


### PR DESCRIPTION
## What

Routes the durable lessons from this week's scheduler + gate-hygiene work into the repo per
`rules.yaml: knowledge_capture`. Docs only — one file, `CLAUDE.md`, +32 lines. `docs` is a hidden
commit type, so this deliberately cuts no release.

The main work here was **not** writing bullets, it was checking `origin/main` for each candidate so
nothing is duplicated. Verdict per candidate:

| # | Lesson | Verdict |
|---|---|---|
| 1 | `runBlocking` in a `@Scheduled` body throws `HR000068` | **ADDED** (root `CLAUDE.md` → Kotlin/Quarkus) |
| 2 | A test calling a `@Scheduled` method directly cannot see it | **ADDED** (same section, one bullet with 3) |
| 3 | `QuarkusTestProfile` loads in its own classloader | **ADDED** (folded into 2) |
| 4 | Derived NetworkPolicies keyed by namespace, not directory | **ALREADY COVERED** |
| 5 | A gate's failure path must be exercised before it is trusted | **ADDED** (new `### CI gates` subsection) |
| 6 | An advisory check over a *generated* artifact is a contradiction | **ADDED** (same subsection) |

### 1 — ADDED (summary only; the hard rule was already there)

`rules.yaml: scheduled_methods` and `.github/scripts/check-no-runblocking-in-scheduled.py` both
landed in #2197, with an allow-list and a thorough rationale comment. That half is done and is not
touched. What was missing is the half `rules.yaml: knowledge_capture` asks for explicitly —
*"add a CI guard where feasible; **summarize in CLAUDE.md**"*. Nothing in any `CLAUDE.md` explained
why a plain `@Scheduled` method has no Vert.x context, so the bullet is a summary that points at the
authoritative rule rather than restating it.

### 2 + 3 — ADDED as one bullet

Deliberately one bullet, not three: they are the same trap seen from three angles, and a reader who
hits one needs all of it. It sits next to the existing *"a `Panache.withTransaction` repo can't be
called from a bare `@QuarkusTest` thread"* and *"invisible to unit tests that mock the repository"*
bullets, which is the same family.

The `%test.quarkus.scheduler.enabled: false` detail is verified against `origin/main` (ledger
`application.yaml:161`, billing `:197`) — with the scheduler off, no test in either service could
ever have caught #2187. That is currently documented only in a code comment inside
`LedgerSchedulerVertxContextIT`, which is exactly where someone about to make the mistake will not
look.

The classloader clause is not documented anywhere in the repo.

### 4 — ALREADY COVERED, nothing added

`openbank-infra/CLAUDE.md` already carries *"check the namespace, not the directory"* from #2213.
It fires only inside `openbank-infra/`, and root keeps only what fires fleet-wide or from outside
the scoped tree — so repeating it in root would be exactly the bloat the routing rule forbids.

### 5 — ADDED, as a new subsection

Judged **not** covered by what exists. The nearest neighbours are narrower: *"a red push-triggered
workflow on `main` is addressed to nobody"* is about a gate whose red is **ignored**; this is about
a gate whose red is **uninformative or absent**, which is a different failure. `rules.yaml` has
`vacuous` only in two rule-specific comments. Three independent instances in one week (#2165, PR
#2154, #2177) is enough to state the general form once.

Kept as prose, not a `rules.yaml` rule: "did anyone exercise this gate's failure path" is not
mechanically checkable, and a rule with no possible producer is the shape ADR-0029 D7 exists to
avoid.

### 6 — ADDED, next to 5

Same family, but the distinction earns its own bullet: for a *generated* artifact, red does not mean
"someone should look", it means the committed document does not match reality. Also kept as prose —
the actionable follow-up (making `eu-ai-act-registry` required, plus a sweep of the other
generated-artifact gates) is already tracked as #2216, and encoding a rule for a state that is not
yet true would just be drift in the other direction.

## Verification

- Every candidate grepped against `origin/main` (`git show origin/main:<path>`), not the local
  checkout.
- No `rules.yaml`, `.rego` or bundle touched, so no OPA-bundle restamp.
- No secrets, hostnames, account specifics or personal data; PR/issue numbers only, house style.

Refs #2148, #2187, #2165, #2177, #2216

🤖 Generated with [Claude Code](https://claude.com/claude-code)
