### PR TITLE
ci(governance): enforce the EU AI Act + agent-charter drift gates in the required job

### DIFF
--- a/.github/workflows/agent-charter-registry.yml
+++ b/.github/workflows/agent-charter-registry.yml
@@ -7,6 +7,15 @@
 # (docs/agents/*.md). Enforces full id parity between the two — see the script's
 # header for the drift class this prevents. Mirrors adr-registry.yml: small,
 # named, own workflow rather than a step buried in the services-ci matrix.
+#
+# WHERE THE TEETH ACTUALLY ARE (2026-07-25): like adr-registry.yml and
+# eu-ai-act-registry.yml, this workflow is NOT in the main-protection ruleset's
+# required-status-checks list, and cannot be — it is path-filtered, and GitHub holds
+# a required context that never runs as permanently "Expected", which would block
+# every PR touching none of the paths below. The binding gate is the
+# `agent charter registry parity` step inside the REQUIRED `Validate manifests` job
+# in ci.yml, which runs this same script unconditionally. This workflow is the fast,
+# path-filtered echo. Do not delete either without moving the other.
 # -----------------------------------------------------------------------------
 name: Agent charter registry
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1049,6 +1049,39 @@ jobs:
       - name: ADR registry integrity check
         run: bash .github/scripts/check-adr-registry.sh
 
+      # Agent charter parity (ADR-0031 / ADR-0156): every openbank-libs/governance/agents.yaml
+      # id has a docs/agents/<id>.md and vice versa.
+      #
+      # Runs here as well as in the `agent-charter-registry` workflow for the same reason the
+      # ADR gate above does — and, unlike that one, for a reason that has already bitten. That
+      # workflow is path-filtered, and a path-filtered workflow CANNOT be a required status
+      # check: GitHub reports a required context that never runs as permanently "Expected", so
+      # requiring it would block every unrelated PR. So a red run on it is advisory in practice,
+      # and PR #2156 merged over exactly that (see the eu-ai-act step below). This job is
+      # unconditional (`on: pull_request`, no paths filter) and IS required as
+      # `Validate manifests`, so putting the binding copy here is what actually gates the merge.
+      # ENFORCED. Pure bash, ~1 s — no measurable runner cost on a job that already runs.
+      - name: "agent charter registry parity (ADR-0031/0156, enforced)"
+        run: bash .github/scripts/check-agent-charter-registry.sh
+
+      # EU AI Act inventory drift (ADR-0148 rule #7, issue #1918).
+      #
+      # docs/compliance/eu-ai-act.md is DERIVED from openbank-libs/governance/agents.yaml +
+      # ml-systems.yaml by gen-eu-ai-act.py. A stale inventory is worse than none: auditors read
+      # it as a live claim, and Annex III applies from 2026-08-02.
+      #
+      # WHY IT MOVED HERE (2026-07-25). The guard existed and the `eu-ai-act-registry` workflow
+      # ran it, but that workflow is path-filtered and therefore un-requireable (above), so its
+      # verdict was advisory. PR #2156 added the `ap2-anonymous` charter without regenerating the
+      # doc, went red on `eu-ai-act-registry` TWICE, and merged anyway — main then carried an AI
+      # system inventory missing an AI system until #2211 regenerated it. An advisory check over
+      # a GENERATED artifact is a contradiction: red does not mean "someone should look", it means
+      # "the committed document does not match reality", and there is no judgement left to
+      # exercise. ENFORCED, and the pyyaml the generator needs is installed by the
+      # gen-network-policies step above.
+      - name: "EU AI Act inventory drift (ADR-0148 rule #7, enforced)"
+        run: bash .github/scripts/check-eu-ai-act.sh
+
   # ---------------------------------------------------------------------------
   # Customer-app dossier content check (ADR-0074 invariant 5).
   #

--- a/.github/workflows/eu-ai-act-registry.yml
+++ b/.github/workflows/eu-ai-act-registry.yml
@@ -1,8 +1,8 @@
 # -----------------------------------------------------------------------------
 # EU AI Act inventory drift gate (ADR-0148 rule #7; issue #1918).
 #
-# Runs `.github/scripts/check-eu-ai-act.sh` on every PR that touches the source
-# (openbank-libs/governance/agents.yaml), the DERIVED compliance doc
+# Runs `.github/scripts/check-eu-ai-act.sh` on every PR that touches either source
+# (openbank-libs/governance/agents.yaml, ml-systems.yaml), the DERIVED compliance doc
 # (docs/compliance/eu-ai-act.md), or the generator/guard themselves. The doc is
 # generated from agents.yaml and must never be hand-edited or drift from a fresh
 # generator run — a stale AI Act inventory is worse than none, because auditors
@@ -11,6 +11,19 @@
 # The guard existed but nothing ran it, so the compliance doc could silently
 # drift from agents.yaml. Mirrors adr-registry.yml / agent-charter-registry.yml:
 # small, named, its own workflow rather than a step buried in the services-ci matrix.
+#
+# WHERE THE TEETH ACTUALLY ARE (2026-07-25): this workflow is NOT — and cannot be —
+# in the main-protection ruleset's required-status-checks list. It is path-filtered,
+# and GitHub reports a required context that never runs as permanently "Expected",
+# which would block every PR that touches none of the paths below. So a red run here
+# is advisory in practice: PR #2156 added the `ap2-anonymous` charter without
+# regenerating the doc, reddened this workflow TWICE, and merged anyway, leaving the
+# AI Act inventory on main missing an AI system (regenerated later in #2211).
+# The binding gate is now the `EU AI Act inventory drift` step inside the REQUIRED
+# `Validate manifests` job in ci.yml, which runs this same script unconditionally —
+# the pattern adr-registry.yml already documents. This workflow stays as the fast,
+# path-filtered echo (seconds on a governance-only PR). Do not delete either without
+# moving the other into `Validate manifests`.
 # -----------------------------------------------------------------------------
 name: EU AI Act registry
 
@@ -19,6 +32,9 @@ on:
     types: [opened, synchronize, reopened]
     paths:
       - 'openbank-libs/governance/agents.yaml'
+      # gen-eu-ai-act.py reads BOTH registries; ml-systems.yaml was missing here, so a
+      # PR editing only the non-agent ML inventory did not even trigger this echo.
+      - 'openbank-libs/governance/ml-systems.yaml'
       - 'docs/compliance/eu-ai-act.md'
       - '.github/scripts/gen-eu-ai-act.py'
       - '.github/scripts/check-eu-ai-act.sh'
@@ -27,6 +43,9 @@ on:
     branches: [main]
     paths:
       - 'openbank-libs/governance/agents.yaml'
+      # gen-eu-ai-act.py reads BOTH registries; ml-systems.yaml was missing here, so a
+      # PR editing only the non-agent ML inventory did not even trigger this echo.
+      - 'openbank-libs/governance/ml-systems.yaml'
       - 'docs/compliance/eu-ai-act.md'
       - '.github/scripts/gen-eu-ai-act.py'
       - '.github/scripts/check-eu-ai-act.sh'

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -267,7 +267,7 @@ fire from *outside* it, so they stay here:
   red advisory check means "someone should look"; on a generated one it means "the committed document
   does not match reality" — there is no judgement left to exercise, so advisory just makes the drift
   mergeable. `eu-ai-act-registry` went red twice on #2156 and the PR merged anyway, leaving the EU AI
-  Act inventory omitting an AI system until it was regenerated. Tracked as #2216.
+  Act inventory omitting an AI system until it was regenerated (#2216).
 - **The gate that never existed beats the unfalsified one: check whether anything reads the artifact
   at all before assuming a green covers it.** This repo is a MULTI-LICENSE tree — Apache-2.0 at the
   root, an AGPL-3.0-only open-core subset (ADR-0136 + ADR-0181/0193) — and *nothing* compared the
@@ -310,6 +310,16 @@ fire from *outside* it, so they stay here:
   duplicate key there is silently resolved by SnakeYAML keeping the LAST occurrence, so a new value
   added above an existing one is dropped with no error anywhere. Diff yamllint finding *sets*
   against `origin/main` when editing it (that is the only thing that caught it on #2457).
+- **A `paths:`-filtered workflow can never be a required status check — so its red is advisory no
+  matter how the job is written.** GitHub holds a required context that does not report as
+  permanently "Expected — waiting for status", so requiring a path-filtered workflow blocks every PR
+  that touches none of its paths. That is why all five required contexts (`all-green`,
+  `Validate manifests`, `Gitleaks`, `issue-hygiene`, `OPA policy gate`) run unconditionally. The
+  established fix is not to require the small workflow but to put the **binding copy of the script**
+  in the unconditional `Validate manifests` job in `ci.yml` and keep the path-filtered workflow as a
+  fast echo — what `adr-registry` already did, and what `agent-charter-registry` and `eu-ai-act` now
+  do too. Corollary: reaching for the ruleset is usually the wrong instinct here, since the in-repo
+  fix ships in the same PR as the gate and needs no GitHub-side config change.
 
 ### CI / bot commit signing
 - **What signs a bot commit is the *endpoint*, not the token — and `main-protection` enforces


### PR DESCRIPTION
## Summary

`eu-ai-act-registry` and `agent-charter-registry` guard **derived** artifacts, but neither could block a merge. Both workflows are `paths:`-filtered, and a path-filtered workflow **cannot be a required status check** — so their red was advisory in practice, which is how PR #2156 merged with a stale EU AI Act inventory. This moves the binding copy of each guard into the already-required `Validate manifests` job, the pattern `adr-registry` established. No gate is weakened; no existing check changes behaviour.

## Type of change

- [x] chore (build / tooling)

## Linked issues

Closes #2216
Refs #1918, #2156, #2211

## The evaluation the issue asked for

**Should `eu-ai-act-registry` / `adr-registry` / `agent-charter-registry` go into `main-protection`'s `required_status_checks`? No — and it is not a judgement call, it is structurally impossible.**

All three are `paths:`-filtered. GitHub reports a required context that never runs as permanently *"Expected — waiting for status"*, so requiring any of them would block every PR touching none of their paths. That is not a hypothetical the repo has to reason about from first principles — it already solves exactly this, twice, in code:

1. **`ci.yml` says so about the admin UI**, in the header of the path-scoped `ui-build` job:
   > *"A separate gate job (`Admin UI`) always runs and fails only when the build itself failed — so branch-protection never blocks a backend-only PR."*
2. **`adr-registry.yml`'s own header says so about this exact family** (verified 2026-07-20):
   > *"`adr-registry` is NOT in the main-protection ruleset's required-status-checks list … The binding gate is the `ADR registry integrity check` step inside the REQUIRED `Validate manifests` job in ci.yml, which runs this same script."*

And the ruleset confirms the invariant: every one of the five required contexts runs unconditionally.

| required context | trigger |
|---|---|
| `all-green` | `services-ci.yml`, `if: always()`, green on an empty matrix |
| `Validate manifests` | `ci.yml` `on: pull_request`, **no** paths filter |
| `Gitleaks`, `issue-hygiene`, `OPA policy gate` | unfiltered `pull_request` |

So `adr-registry` was never the anomaly — it was the **worked example**. `agent-charter-registry` and `eu-ai-act-registry` were written as its siblings (both headers literally say "Mirrors adr-registry.yml") but copied only the *echo* half and never the *teeth* half. This PR finishes the copy.

A secondary reason to prefer this over a ruleset edit: the ruleset is GitHub-side config that no PR can carry. Fixing it in-repo means the gate and its enforcement land in the same reviewable commit and take effect on merge, with nothing to remember to do afterwards.

## Changes

- **`ci.yml`** — two steps appended to the `validate` job (`Validate manifests`), after the existing `ADR registry integrity check`:
  - `agent charter registry parity (ADR-0031/0156, enforced)` → `check-agent-charter-registry.sh`
  - `EU AI Act inventory drift (ADR-0148 rule #7, enforced)` → `check-eu-ai-act.sh`

  Placed last on purpose: `Validate manifests` stops at the first failing gate and reports every later step as `skipped`, so adding steps at the tail cannot mask an existing gate. `check-eu-ai-act.sh` needs PyYAML, which the `gen-network-policies` step earlier in the same job already installs (hash-pinned, with a hard error if unavailable).

- **`eu-ai-act-registry.yml`** — **trigger gap fixed**: `gen-eu-ai-act.py` reads **both** `openbank-libs/governance/agents.yaml` *and* `ml-systems.yaml`, but only the former was in `paths:`. A PR editing only the non-agent ML inventory did not trigger the workflow at all. Added to both the `pull_request` and `push` lists.

- **`eu-ai-act-registry.yml` / `agent-charter-registry.yml`** — a "where the teeth actually are" header on each, mirroring the one `adr-registry.yml` carries, so the next person does not re-derive this or delete one half.

- **`CLAUDE.md`** — the general rule under *CI gates*, since this is the third instance of the same shape.

### Sweep for the same shape

Every path-filtered workflow that runs a `.github/scripts/` guard, and whether a binding copy exists in `Validate manifests`:

| workflow | binding copy in `Validate manifests` |
|---|---|
| `adr-registry.yml` | ✅ already (`ADR registry integrity check`) |
| `agent-charter-registry.yml` | ✅ **added here** |
| `eu-ai-act-registry.yml` | ✅ **added here** |

That is the complete set — no fourth instance.

Out of scope, flagged for a separate call: `public-readiness.yml` runs unfiltered on every PR, so unlike these three it *is* eligible for the required list. Whether it should be added is a ruleset decision, not an in-repo one, and its audit is partly judgement-based rather than a pure derived-artifact diff — so it does not belong in this PR. #2216 raised it; leaving it on that issue's tail.

## Verification — both guards were failed on purpose before being wired in

Per this repo's own rule that *a gate that has only ever passed is unfalsified*, each was fed an input it MUST flag:

- **`check-eu-ai-act.sh`** — appended a synthetic `known-positive-probe` entry to `ml-systems.yaml`. Guard exited **1** with the drift diff, including the provenance line moving `4 non-agent systems` → `5`. This doubles as the proof that `ml-systems.yaml` is a real generator input, which is what surfaced the `paths:` gap above.
- **`check-agent-charter-registry.sh`** — moved `docs/agents/customer-copilot.md` aside. Guard exited **1**: `agents.yaml declares agent 'customer-copilot' with no matching 'docs/agents/customer-copilot.md'`.

Both restored, both green on a clean tree (`15 agent(s), full parity`; `eu-ai-act.md is in sync`).

Also checked locally:
- Step ordering simulated in sequence (`gen-network-policies.py` + its `--intent-to-add`, then both new guards) — no interference; only the four intended files are modified afterwards.
- `yamllint` with the job's own config: no new findings (the 5 pre-existing `warning`s are unchanged, and CI does not run `--strict`).
- `actionlint` per file: finding set on `ci.yml` is **identical** to `origin/main`'s (one pre-existing `SC2086` at line 241, in the unrelated `shellcheck` step); zero findings on the other two.

## Cost

**$0 delta.** No new job, no new runner, no new checkout — two `bash` steps appended to a job that already runs on every PR. Measured locally at **~1.2 s combined** against a `Validate manifests` job budgeted at 10 minutes, on `ubuntu-latest` (hosted, not the self-hosted `openbank-build` pool), so no queue-time exposure either. The `ml-systems.yaml` paths addition can only *add* triggers of a ~30 s hosted workflow, on the handful of PRs per quarter that touch that file.

## Definition of Done

- [x] Hexagonal layering preserved (no application code touched).
- [ ] Unit tests added/updated. — n/a, CI configuration; both guards have their failure path exercised above, which is the applicable check for a gate.
- [ ] Integration tests / contract tests / OpenAPI / Flyway / Avro — n/a, no service boundary, API, DB, or event touched.
- [x] `./gradlew detekt ktlintCheck koverVerify build` — n/a, no Gradle module changed (path-scoped CI builds nothing here).
- [x] No new lint warnings (yamllint + actionlint finding sets diffed against `origin/main`).
- [x] Docs updated (`CLAUDE.md`; both workflow headers).

## Security checklist

- [x] No secrets, tokens, passwords, or PII in code, config, tests, logs.
- [x] No new `@Suppress`/`as Any`.
- [x] No new third-party dependency.
- [x] No auth / crypto / payment code changed.
- [x] No PII or cardholder-data path changed.

Both new steps are static `run: bash .github/scripts/...` with no `${{ }}` interpolation of any event field, so there is no workflow-injection surface.

## Compliance impact

- [x] DORA — a governance gate over a derived artifact becomes binding rather than advisory.
- [x] EU AI Act — this is the enforcement half of the Annex IV standing inventory. Annex III applies **2026-08-02**; after this merges, a charter or ML-system addition that does not regenerate `docs/compliance/eu-ai-act.md` cannot land.
