### PR TITLE
ci(mcp): guard a real MCP read port cannot land before caller auth (BLOCKER #2206)

### DIFF
--- a/.github/scripts/check-mcp-stub-ports-vs-caller-auth.sh
+++ b/.github/scripts/check-mcp-stub-ports-vs-caller-auth.sh
@@ -1,0 +1,78 @@
+#!/usr/bin/env bash
+# -----------------------------------------------------------------------------
+# Guard: openbank-mcp-service must not bind a REAL read/proposal port while its
+# caller identity is still the hardcoded phase-1 placeholder (BLOCKER #2206).
+#
+# WHY THIS EXISTS
+#   The MCP threat model (PR #2200, docs/threat-models/openbank-mcp-service.md)
+#   established that this service authenticates NOBODY today:
+#     - McpEndpoint.resolveContext() hardcodes
+#       ConsentContext("agent:mcp-anonymous", "none", emptyList()) — it does NOT
+#       read the X-Agent-Id / X-Consent-Id headers its own KDoc claims, there is
+#       no OIDC (tenant-enabled: false), no @RolesAllowed, no mTLS.
+#     - The OPA PDP therefore authorizes a CONSTANT. It works; it is asked the
+#       wrong question.
+#     - Consent-scoped account filtering is delegated to "the port implementation",
+#       and the only implementation is StubReadPorts, which enforces nothing.
+#   So the STUB BOUNDARY is the load-bearing security control, and nothing else
+#   guards it. Phase 2's plan — swap StubReadPorts for real @RegisterRestClient
+#   adapters — needs NO endpoint and NO policy edit, which is exactly what makes
+#   it dangerous: the moment a real port lands, get_balance(accountId) becomes an
+#   UNAUTHENTICATED read of any guessable account id, and every other CI gate
+#   stays green because nothing in CI knows the stub was the control.
+#
+# THE INVARIANT
+#   A real (non-Stub) AccountReadPort / ProposalPort implementation may be wired
+#   ONLY once resolveContext() no longer returns the hardcoded placeholder
+#   identity. Caller authentication + consent binding must land BEFORE, or
+#   atomically WITH, the real read ports — never as a follow-up (#2206).
+#
+#   This guard fails if a non-Stub port implementation exists in the service while
+#   McpEndpoint still carries the `agent:mcp-anonymous` placeholder constant. It
+#   is a REGRESSION guard: 0 violations today (only StubReadPorts is wired).
+#
+# stdlib-only (grep/awk); no Kotlin parser. ENFORCED.
+# Usage: check-mcp-stub-ports-vs-caller-auth.sh [root]   (default root: .)
+# Exit: 0 = clean, 1 = violation.
+# -----------------------------------------------------------------------------
+set -euo pipefail
+
+ROOT="${1:-.}"
+cd "$ROOT"
+SVC="openbank-mcp-service/src/main/kotlin"
+ENDPOINT="$SVC/com/openbank/mcp/infrastructure/mcp/McpEndpoint.kt"
+
+# If the service tree isn't present (path-scoped checkout), nothing to check.
+if [[ ! -d "$SVC" ]]; then
+  echo "check-mcp-stub-ports-vs-caller-auth: openbank-mcp-service not present — skipping."
+  exit 0
+fi
+if [[ ! -f "$ENDPOINT" ]]; then
+  echo "::error title=MCP caller-auth guard::McpEndpoint.kt not found at $ENDPOINT — the guard cannot verify the placeholder identity; wiring may have moved. Update this guard." >&2
+  exit 1
+fi
+
+# 1. Is resolveContext still the phase-1 placeholder? The load-bearing signal is
+#    the literal placeholder principal id; a real OAuth/consent resolution removes it.
+placeholder_present=0
+if grep -qE 'agent:mcp-anonymous' "$ENDPOINT"; then
+  placeholder_present=1
+fi
+
+# 2. Is a NON-Stub AccountReadPort / ProposalPort implementation wired anywhere in
+#    the service? (The interface declarations in port/out/ReadPorts.kt are
+#    `interface AccountReadPort` — only `class X ... : AccountReadPort` matches here.)
+impl_classes=$(grep -rhoE 'class[[:space:]]+[A-Za-z0-9_]+[^{]*:[^{]*\b(AccountReadPort|ProposalPort)\b' "$SVC" 2>/dev/null \
+  | grep -oE 'class[[:space:]]+[A-Za-z0-9_]+' | awk '{print $2}' | sort -u || true)
+non_stub=$(printf '%s\n' "$impl_classes" | grep -vE '^Stub' | grep -v '^$' || true)
+
+if [[ "$placeholder_present" -eq 1 && -n "$non_stub" ]]; then
+  echo "::error title=MCP caller-auth guard (BLOCKER #2206)::A non-stub read/proposal port is wired while McpEndpoint.resolveContext() still returns the hardcoded 'agent:mcp-anonymous' placeholder. This turns get_balance/list_accounts into an UNAUTHENTICATED read of any account. Land real caller identity + PSD2 consent binding (resolveContext) BEFORE or ATOMICALLY WITH the real port. Offending non-stub impl(s): $(echo "$non_stub" | tr '\n' ' ')" >&2
+  exit 1
+fi
+
+if [[ "$placeholder_present" -eq 1 ]]; then
+  echo "check-mcp-stub-ports-vs-caller-auth: OK — placeholder identity still in place, only stub ports wired (phase 1)."
+else
+  echo "check-mcp-stub-ports-vs-caller-auth: OK — placeholder identity removed; real caller auth landed, real ports permitted."
+fi

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -632,6 +632,20 @@ jobs:
       - name: "no dead-code SERVICE-principal rego rule (enforced)"
         run: bash .github/scripts/check-no-service-principal-type.sh .
 
+      # openbank-mcp-service caller-auth ordering guard (BLOCKER #2206). The MCP
+      # threat model (#2200) established the service authenticates nobody today —
+      # resolveContext() hardcodes the "agent:mcp-anonymous" placeholder and the OPA
+      # PDP authorizes a constant; consent-scoped filtering is delegated to a port
+      # impl that is only StubReadPorts. The stub boundary IS the security control.
+      # Phase-2's "swap the stub for a real @RegisterRestClient adapter" needs no
+      # endpoint and no policy edit, so a real port silently turns get_balance into
+      # an unauthenticated read of any account with every other gate green. This
+      # guard fails if a non-Stub read/proposal port is wired while the placeholder
+      # identity remains — forcing real caller auth to land before/with the port.
+      # 0 violations on origin/main at introduction — a regression guard. ENFORCED.
+      - name: "MCP real-port requires caller auth first (BLOCKER #2206, enforced)"
+        run: bash .github/scripts/check-mcp-stub-ports-vs-caller-auth.sh .
+
       # No service may register its own ExceptionMapper for a JDK type
       # openbank-libs-runtime already maps (IllegalArgumentException,
       # IllegalStateException, NoSuchElementException, Exception,


### PR DESCRIPTION
## What

A regression guard that makes the [#2206](https://github.com/JiRaska/open-bank-oss/issues/2206) ordering constraint **structurally enforced**, so MCP phase-2 (real data) can be built incrementally without ever reintroducing the vulnerability it warns about.

## Why

The MCP threat model (PR #2200) established that `openbank-mcp-service` authenticates **nobody** today:
- `McpEndpoint.resolveContext()` hardcodes `ConsentContext("agent:mcp-anonymous", "none", emptyList())` — it does not read the headers its KDoc claims; OIDC is `tenant-enabled: false`; no `@RolesAllowed`, no mTLS.
- The OPA PDP authorizes a **constant** (it works — it's asked the wrong question).
- Consent-scoped account filtering is delegated to a port impl that is only `StubReadPorts`, which enforces nothing.

**The stub boundary is the load-bearing security control, and nothing guarded it.** Phase-2's plan — swap `StubReadPorts` for real `@RegisterRestClient` adapters — needs **no endpoint and no policy edit**, so a real port silently turns `get_balance(accountId)` into an **unauthenticated read of any account** with every other CI gate green (#2206 item 4).

## The guard

`check-mcp-stub-ports-vs-caller-auth.sh` (stdlib grep, ENFORCED in `ci.yml` governance-checks) **fails if** a non-`Stub` `AccountReadPort`/`ProposalPort` implementation is wired **while** `McpEndpoint` still carries the `agent:mcp-anonymous` placeholder — forcing real caller auth + PSD2 consent binding to land **before, or atomically with**, the real read ports.

Verified three ways: clean on `origin/main` (exit 0), **fails** on a simulated real port + placeholder (exit 1), **passes** once the placeholder is removed (auth landed → real ports permitted).

## Scope note

This is the safe prerequisite that de-risks phase-2. The phase-2 feature itself (real OAuth 2.1 → PSD2-consent binding per ADR-0126, real REST adapters, the `rest.rego` `attributes`-drop fix so the PDP sees `consentId`, cross-ns NetworkPolicy edges) is a money-path epic requiring a design decision + 2 approvals + threat-model update — tracked by #2206, not in this PR.

Refs #2206, #1922, PR #2200

🤖 Generated with [Claude Code](https://claude.com/claude-code)