### PR TITLE
security(infra): stop publishing the loopback-only OPA sidecar port to callers

### DIFF
--- a/openbank-infra/CLAUDE.md
+++ b/openbank-infra/CLAUDE.md
@@ -98,6 +98,21 @@ out of it (they are path-scoped, not less important — several are live-inciden
   workloads), but the reflex stands: verify with
   `kubectl get netpol -n <ns>` / `grep -rl '<workload>-ingress-allow-list' gitops/components/`,
   never with `ls components/<svc>/`.
+- **The generator derives ingress ports from EVERY container's `containerPorts` — a sidecar port
+  that only ever serves loopback must be named into `SIDECAR_LOCAL_ONLY_PORT_NAMES`, or it is
+  published to the app's whole caller set.** The OPA PDP sidecar is the case that forced the rule:
+  the app reaches it at `http://localhost:8181` (`OpaSidecarPolicyDecisionPoint.DEFAULT_BASE_URL`,
+  no `OPA_URL` env in most components), so it needs no cross-namespace ingress at all — yet 8181
+  landed in the SAME derived rule as the app's HTTP port on 29 components, admitting every declared
+  caller namespace (for kyc: customer-edge, party, admin-ui, security-scanner) to an `opa run
+  --server` with no `--authentication` and no `--authorization`. That is a policy ORACLE
+  (`POST /v1/data/openbank/rest/allow` with arbitrary input), full disclosure of the rego plus
+  `data.agents` / `data.rules` (`GET /v1/policies`, `GET /v1/data`), arbitrary rego evaluation
+  (`POST /v1/query`, a CPU-burn DoS on a money-path pod) and writes to any data root the bundle's
+  `.manifest` does not own. Decision *integrity* held — a bundle root is write-protected, so
+  `openbank/rest/allow` itself cannot be overwritten. Fix is in the generator only; never hand-edit
+  a derived `network-policies.yaml`. Residual, accepted: the unconditional same-namespace rule still
+  reaches 8181 from co-tenant pods — NetworkPolicy cannot express "loopback only".
 - **The generator's `URL_RE` requires a literal `.svc` — `http://kyc-service.kyc:8114` does NOT
   match, `http://kyc-service.kyc.svc:8114` does.** Write the short form and the generator exits 0
   and changes nothing: a silent no-op indistinguishable from "already in sync". Always diff the

--- a/openbank-infra/gitops/components/accounts/network-policies.yaml
+++ b/openbank-infra/gitops/components/accounts/network-policies.yaml
@@ -78,8 +78,6 @@ spec:
       ports:
         - protocol: TCP
           port: 8100
-        - protocol: TCP
-          port: 8181
     - from:
         - namespaceSelector:
             matchLabels:

--- a/openbank-infra/gitops/components/agent/network-policies.yaml
+++ b/openbank-infra/gitops/components/agent/network-policies.yaml
@@ -51,8 +51,6 @@ spec:
       ports:
         - protocol: TCP
           port: 8109
-        - protocol: TCP
-          port: 8181
     - from:
         - namespaceSelector:
             matchLabels:

--- a/openbank-infra/gitops/components/aml/network-policies.yaml
+++ b/openbank-infra/gitops/components/aml/network-policies.yaml
@@ -60,8 +60,6 @@ spec:
       ports:
         - protocol: TCP
           port: 8117
-        - protocol: TCP
-          port: 8181
     - from:
         - namespaceSelector:
             matchLabels:

--- a/openbank-infra/gitops/components/anacredit/network-policies.yaml
+++ b/openbank-infra/gitops/components/anacredit/network-policies.yaml
@@ -48,8 +48,6 @@ spec:
       ports:
         - protocol: TCP
           port: 8137
-        - protocol: TCP
-          port: 8181
     - from:
         - namespaceSelector:
             matchLabels:

--- a/openbank-infra/gitops/components/ap2/network-policies.yaml
+++ b/openbank-infra/gitops/components/ap2/network-policies.yaml
@@ -48,8 +48,6 @@ spec:
       ports:
         - protocol: TCP
           port: 8151
-        - protocol: TCP
-          port: 8181
     - from:
         - namespaceSelector:
             matchLabels:

--- a/openbank-infra/gitops/components/audit/network-policies.yaml
+++ b/openbank-infra/gitops/components/audit/network-policies.yaml
@@ -51,8 +51,6 @@ spec:
       ports:
         - protocol: TCP
           port: 8113
-        - protocol: TCP
-          port: 8181
     - from:
         - namespaceSelector:
             matchLabels:

--- a/openbank-infra/gitops/components/balances/network-policies.yaml
+++ b/openbank-infra/gitops/components/balances/network-policies.yaml
@@ -69,8 +69,6 @@ spec:
       ports:
         - protocol: TCP
           port: 8103
-        - protocol: TCP
-          port: 8181
     - from:
         - namespaceSelector:
             matchLabels:

--- a/openbank-infra/gitops/components/billing/network-policies.yaml
+++ b/openbank-infra/gitops/components/billing/network-policies.yaml
@@ -48,8 +48,6 @@ spec:
       ports:
         - protocol: TCP
           port: 8132
-        - protocol: TCP
-          port: 8181
     - from:
         - namespaceSelector:
             matchLabels:

--- a/openbank-infra/gitops/components/consent/network-policies.yaml
+++ b/openbank-infra/gitops/components/consent/network-policies.yaml
@@ -57,8 +57,6 @@ spec:
       ports:
         - protocol: TCP
           port: 8106
-        - protocol: TCP
-          port: 8181
     - from:
         - namespaceSelector:
             matchLabels:

--- a/openbank-infra/gitops/components/copilot/network-policies.yaml
+++ b/openbank-infra/gitops/components/copilot/network-policies.yaml
@@ -80,8 +80,6 @@ spec:
       ports:
         - protocol: TCP
           port: 8131
-        - protocol: TCP
-          port: 8181
     - from:
         - namespaceSelector:
             matchLabels:

--- a/openbank-infra/gitops/components/customer-edge/network-policies.yaml
+++ b/openbank-infra/gitops/components/customer-edge/network-policies.yaml
@@ -51,8 +51,6 @@ spec:
       ports:
         - protocol: TCP
           port: 8128
-        - protocol: TCP
-          port: 8181
     - from:
         - namespaceSelector:
             matchLabels:

--- a/openbank-infra/gitops/components/dispute-service/network-policies.yaml
+++ b/openbank-infra/gitops/components/dispute-service/network-policies.yaml
@@ -57,8 +57,6 @@ spec:
       ports:
         - protocol: TCP
           port: 8135
-        - protocol: TCP
-          port: 8181
     - from:
         - namespaceSelector:
             matchLabels:

--- a/openbank-infra/gitops/components/document-service/network-policies.yaml
+++ b/openbank-infra/gitops/components/document-service/network-policies.yaml
@@ -51,8 +51,6 @@ spec:
       ports:
         - protocol: TCP
           port: 8143
-        - protocol: TCP
-          port: 8181
     - from:
         - namespaceSelector:
             matchLabels:

--- a/openbank-infra/gitops/components/fraud-service/network-policies.yaml
+++ b/openbank-infra/gitops/components/fraud-service/network-policies.yaml
@@ -48,8 +48,6 @@ spec:
       ports:
         - protocol: TCP
           port: 8133
-        - protocol: TCP
-          port: 8181
     - from:
         - namespaceSelector:
             matchLabels:

--- a/openbank-infra/gitops/components/fx-service/network-policies.yaml
+++ b/openbank-infra/gitops/components/fx-service/network-policies.yaml
@@ -60,8 +60,6 @@ spec:
       ports:
         - protocol: TCP
           port: 8119
-        - protocol: TCP
-          port: 8181
     - from:
         - namespaceSelector:
             matchLabels:

--- a/openbank-infra/gitops/components/interest-service/network-policies.yaml
+++ b/openbank-infra/gitops/components/interest-service/network-policies.yaml
@@ -60,8 +60,6 @@ spec:
       ports:
         - protocol: TCP
           port: 8125
-        - protocol: TCP
-          port: 8181
     - from:
         - namespaceSelector:
             matchLabels:

--- a/openbank-infra/gitops/components/kyc/network-policies.yaml
+++ b/openbank-infra/gitops/components/kyc/network-policies.yaml
@@ -57,8 +57,6 @@ spec:
       ports:
         - protocol: TCP
           port: 8114
-        - protocol: TCP
-          port: 8181
     - from:
         - namespaceSelector:
             matchLabels:

--- a/openbank-infra/gitops/components/ledger/network-policies.yaml
+++ b/openbank-infra/gitops/components/ledger/network-policies.yaml
@@ -69,8 +69,6 @@ spec:
       ports:
         - protocol: TCP
           port: 8101
-        - protocol: TCP
-          port: 8181
     - from:
         - namespaceSelector:
             matchLabels:

--- a/openbank-infra/gitops/components/lending/network-policies.yaml
+++ b/openbank-infra/gitops/components/lending/network-policies.yaml
@@ -51,8 +51,6 @@ spec:
       ports:
         - protocol: TCP
           port: 8126
-        - protocol: TCP
-          port: 8181
     - from:
         - namespaceSelector:
             matchLabels:

--- a/openbank-infra/gitops/components/mcp/network-policies.yaml
+++ b/openbank-infra/gitops/components/mcp/network-policies.yaml
@@ -48,8 +48,6 @@ spec:
       ports:
         - protocol: TCP
           port: 8150
-        - protocol: TCP
-          port: 8181
     - from:
         - namespaceSelector:
             matchLabels:

--- a/openbank-infra/gitops/components/notifications/network-policies.yaml
+++ b/openbank-infra/gitops/components/notifications/network-policies.yaml
@@ -54,8 +54,6 @@ spec:
       ports:
         - protocol: TCP
           port: 8112
-        - protocol: TCP
-          port: 8181
     - from:
         - namespaceSelector:
             matchLabels:

--- a/openbank-infra/gitops/components/party/network-policies.yaml
+++ b/openbank-infra/gitops/components/party/network-policies.yaml
@@ -64,8 +64,6 @@ spec:
           port: 8016
         - protocol: TCP
           port: 8111
-        - protocol: TCP
-          port: 8181
     - from:
         - namespaceSelector:
             matchLabels:

--- a/openbank-infra/gitops/components/payments/network-policies.yaml
+++ b/openbank-infra/gitops/components/payments/network-policies.yaml
@@ -60,8 +60,6 @@ spec:
       ports:
         - protocol: TCP
           port: 8118
-        - protocol: TCP
-          port: 8181
     - from:
         - namespaceSelector:
             matchLabels:
@@ -107,8 +105,6 @@ spec:
       ports:
         - protocol: TCP
           port: 8124
-        - protocol: TCP
-          port: 8181
     - from:
         - namespaceSelector:
             matchLabels:
@@ -193,8 +189,6 @@ spec:
       ports:
         - protocol: TCP
           port: 8116
-        - protocol: TCP
-          port: 8181
     - from:
         - namespaceSelector:
             matchLabels:
@@ -282,8 +276,6 @@ spec:
       ports:
         - protocol: TCP
           port: 8127
-        - protocol: TCP
-          port: 8181
     - from:
         - namespaceSelector:
             matchLabels:
@@ -336,8 +328,6 @@ spec:
       ports:
         - protocol: TCP
           port: 8115
-        - protocol: TCP
-          port: 8181
     - from:
         - namespaceSelector:
             matchLabels:
@@ -384,8 +374,6 @@ spec:
       ports:
         - protocol: TCP
           port: 8138
-        - protocol: TCP
-          port: 8181
     - from:
         - namespaceSelector:
             matchLabels:
@@ -431,8 +419,6 @@ spec:
       ports:
         - protocol: TCP
           port: 8121
-        - protocol: TCP
-          port: 8181
     - from:
         - namespaceSelector:
             matchLabels:
@@ -478,8 +464,6 @@ spec:
       ports:
         - protocol: TCP
           port: 8122
-        - protocol: TCP
-          port: 8181
     - from:
         - namespaceSelector:
             matchLabels:
@@ -537,8 +521,6 @@ spec:
       ports:
         - protocol: TCP
           port: 8102
-        - protocol: TCP
-          port: 8181
     - from:
         - namespaceSelector:
             matchLabels:
@@ -588,8 +570,6 @@ spec:
       ports:
         - protocol: TCP
           port: 8149
-        - protocol: TCP
-          port: 8181
     - from:
         - namespaceSelector:
             matchLabels:

--- a/openbank-infra/gitops/components/pid/network-policies.yaml
+++ b/openbank-infra/gitops/components/pid/network-policies.yaml
@@ -54,8 +54,6 @@ spec:
       ports:
         - protocol: TCP
           port: 8105
-        - protocol: TCP
-          port: 8181
     - from:
         - namespaceSelector:
             matchLabels:

--- a/openbank-infra/gitops/components/psd2-service/network-policies.yaml
+++ b/openbank-infra/gitops/components/psd2-service/network-policies.yaml
@@ -51,8 +51,6 @@ spec:
       ports:
         - protocol: TCP
           port: 8107
-        - protocol: TCP
-          port: 8181
     - from:
         - namespaceSelector:
             matchLabels:

--- a/openbank-infra/gitops/components/sanctions-service/network-policies.yaml
+++ b/openbank-infra/gitops/components/sanctions-service/network-policies.yaml
@@ -84,8 +84,6 @@ spec:
       ports:
         - protocol: TCP
           port: 8123
-        - protocol: TCP
-          port: 8181
     - from:
         - namespaceSelector:
             matchLabels:

--- a/openbank-infra/gitops/components/sca/network-policies.yaml
+++ b/openbank-infra/gitops/components/sca/network-policies.yaml
@@ -78,8 +78,6 @@ spec:
       ports:
         - protocol: TCP
           port: 8110
-        - protocol: TCP
-          port: 8181
     - from:
         - namespaceSelector:
             matchLabels:

--- a/openbank-infra/gitops/components/statements/network-policies.yaml
+++ b/openbank-infra/gitops/components/statements/network-policies.yaml
@@ -51,8 +51,6 @@ spec:
       ports:
         - protocol: TCP
           port: 8136
-        - protocol: TCP
-          port: 8181
     - from:
         - namespaceSelector:
             matchLabels:

--- a/openbank-infra/gitops/components/tpp-registry/network-policies.yaml
+++ b/openbank-infra/gitops/components/tpp-registry/network-policies.yaml
@@ -66,8 +66,6 @@ spec:
       ports:
         - protocol: TCP
           port: 8108
-        - protocol: TCP
-          port: 8181
     - from:
         - namespaceSelector:
             matchLabels:

--- a/openbank-infra/scripts/gen-network-policies.py
+++ b/openbank-infra/scripts/gen-network-policies.py
@@ -88,6 +88,33 @@ KEDA_NS = "keda"
 # unconditionally treated as an admin-ui-reachable HTTP port.
 INTERNAL_ONLY_PORT_NAMES = {"redis", "postgres", "postgresql"}
 
+# Container ports belonging to a SIDECAR the app container reaches over the pod's
+# own loopback — never a cross-namespace edge. Keyed by `ports[].name`, same
+# convention as INTERNAL_ONLY_PORT_NAMES above.
+#
+# The OPA PDP sidecar (ADR-0034 Phase 5 / issue #1797) is the case that forced
+# this: `OpaSidecarPolicyDecisionPoint.DEFAULT_BASE_URL` is
+# `http://localhost:8181`, so the only client of :8181 is the app container
+# sharing the pod's network namespace — which NetworkPolicy does not police at
+# all. But the generator derives ingress ports mechanically from every container's
+# containerPorts, so 8181 landed in the SAME rule as the app's HTTP port: on
+# kyc-service that admitted customer-edge, party, admin-ui and security-scanner
+# straight to a PDP that runs `opa run --server` with no `--authentication` and no
+# `--authorization`. Any pod in those namespaces could POST /v1/data/openbank/rest/allow
+# to probe the policy as an oracle, GET /v1/policies to read the whole rego +
+# `data.agents` / `data.rules` governance data, POST /v1/query to evaluate arbitrary
+# rego (a CPU-burn DoS against a money-path pod), and PUT /v1/data under any root the
+# mounted bundle's .manifest does not own. Decision INTEGRITY held (a bundle root is
+# write-protected, so `openbank/rest/allow` itself could not be overwritten) — the
+# exposure is disclosure, oracle and DoS, on ~29 components fleet-wide.
+#
+# A port whose name lands here is excluded from http_ports, so it gets neither the
+# derived-caller rule nor the admin-ui / ingress-nginx / KEDA rules. It stays
+# reachable via the unconditional same-namespace rule (co-tenant pods of the same
+# namespace) — NetworkPolicy cannot express "loopback only", and tightening the
+# same-namespace rule to a port list is a separate, larger change.
+SIDECAR_LOCAL_ONLY_PORT_NAMES = {"opa"}
+
 HEADER = """\
 # SPDX-License-Identifier: Apache-2.0
 # Copyright (c) OpenBank contributors. Licensed under the Apache License, Version 2.0.
@@ -309,7 +336,8 @@ def main():
         if mgmt_port is None and MGMT_PORT in wl["ports"].values():
             mgmt_port = MGMT_PORT
         internal_only_ports = {
-            p for n, p in wl["ports"].items() if n in INTERNAL_ONLY_PORT_NAMES
+            p for n, p in wl["ports"].items()
+            if n in INTERNAL_ONLY_PORT_NAMES or n in SIDECAR_LOCAL_ONLY_PORT_NAMES
         }
         http_ports = sorted(
             p for n, p in wl["ports"].items()


### PR DESCRIPTION
## What

`openbank-infra/scripts/gen-network-policies.py` derives ingress ports mechanically from **every** container's `containerPorts`. The OPA PDP sidecar (ADR-0034 Phase 5, #1797) declares `containerPort: 8181`, so 8181 landed in the **same** derived ingress rule as the app's HTTP port on **29 components** — publishing the PDP to every namespace allowed to call the app.

For `kyc-service` that was `customer-edge`, `party`, `admin-ui`, `security-scanner`.

## Why it matters

1. **The app reaches the sidecar over loopback.** `OpaSidecarPolicyDecisionPoint.DEFAULT_BASE_URL` is `http://localhost:8181` and most components set no `OPA_URL` at all. Same-pod traffic is not policed by NetworkPolicy, so **8181 needs no cross-namespace ingress whatsoever**.
2. **The sidecar is unauthenticated.** `opa run --server --addr=0.0.0.0:8181 --bundle /bundle` — no `--authentication`, no `--authorization`. From an allowed namespace a pod could:
   - `POST /v1/data/openbank/rest/allow` with arbitrary input — a **policy oracle**;
   - `GET /v1/policies` / `GET /v1/data` — read the whole rego plus the `data.agents` / `data.rules` governance data;
   - `POST /v1/query`, `/v1/compile` — evaluate arbitrary rego, a **CPU-burn DoS** against a money-path pod;
   - `PUT /v1/data/<path>` for any root the mounted bundle's `.manifest` does not own.

   Decision **integrity held**: the bundle roots (`openbank/rest`, `openbank/agents`, `openbank/copilot`, `agents`, `rules`) are write-protected, so `openbank/rest/allow` itself could not be overwritten. The exposure is disclosure, oracle and DoS.

Pre-existing fleet-wide pattern already on `main`, **not** a regression from any single PR.

## Fix — in the generator, never a hand-edit

New `SIDECAR_LOCAL_ONLY_PORT_NAMES = {"opa"}`, applied alongside `INTERNAL_ONLY_PORT_NAMES`: such a port is kept out of `http_ports`, so it gets neither the derived-caller rule nor the admin-ui / ingress-nginx / KEDA rules.

All **38** sidecar port declarations across the fleet are named `opa`, and no Pod/ServiceMonitor scrapes it — so nothing else moves. The regenerated diff is exactly **76 deleted lines (38 × 2)** and nothing else.

## Residual, accepted

The unconditional same-namespace rule (`from: [{podSelector: {}}]`) still reaches 8181 from co-tenant pods. NetworkPolicy cannot express "loopback only", and narrowing that rule to a port list is a separate, larger change. Documented in `openbank-infra/CLAUDE.md`.

Binding OPA to `127.0.0.1` would close it fully but breaks the kubelet `httpGet` readiness/liveness probes (they hit the pod IP, and the distroless OPA image has no shell for an `exec` probe).

## Verification

Ran the generator with the exclusion **disabled** → 29 files regain `port: 8181`; **enabled** → 0. The gate was exercised against a known-positive rather than trusted on a clean pass. Regen is idempotent (second run produces no further drift).

Refs #1797