### PR TITLE
ci(admin-ui): run the ADR-0071 governance gate when a governance.yaml changes (#2236)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -20,13 +20,19 @@ jobs:
   # ---------------------------------------------------------------------------
 
   # ---------------------------------------------------------------------------
-  # Admin UI — path-scoped: only runs when openbank-admin-ui/** changes.
+  # Admin UI — path-scoped: runs when openbank-admin-ui/** changes, OR when a file
+  # the ADR-0071 governance gate READS changes. That gate lives in this job but
+  # validates every openbank-*/governance.yaml in the fleet, so scoping the job to
+  # admin-ui files alone let a backend PR add a service and never reach it: the job
+  # skipped, the always-run "Admin UI" gate job reads a skip as a pass, and the
+  # breakage landed on main where it blocked the next admin-ui PR (#2124 and #2104
+  # each shipped a governance.yaml with 0 admin-ui files touched — issue #2236).
   # On push to main (post-merge) always rebuilds to keep the sandbox image current.
   # A separate gate job ("Admin UI") always runs and fails only when the build
   # itself failed — so branch-protection never blocks a backend-only PR.
   # ---------------------------------------------------------------------------
   changes-ui:
-    name: Detect UI changes
+    name: Detect UI or governance changes
     runs-on: ubuntu-latest
     timeout-minutes: 5
     outputs:
@@ -46,9 +52,15 @@ jobs:
             # Force the remote-tracking ref to the true tip (persistent self-hosted
             # runners reuse the workdir, so the cached ref can be stale).
             git fetch origin "${{ github.base_ref }}:refs/remotes/origin/${{ github.base_ref }}" --no-tags
-            N=$(git diff --name-only "${BASE}...HEAD" -- openbank-admin-ui/ | wc -l | tr -d ' ')
+            # The extra pathspecs are the governance gate's INPUTS, not UI code:
+            # every per-service governance.yaml, plus the schema it validates them
+            # against. The generator itself lives under openbank-admin-ui/.
+            N=$(git diff --name-only "${BASE}...HEAD" -- \
+                  openbank-admin-ui/ \
+                  '*/governance.yaml' \
+                  openbank-libs/governance/governance.schema.json | wc -l | tr -d ' ')
             echo "changed=$( [ "$N" -gt 0 ] && echo 'true' || echo 'false' )" >> "$GITHUB_OUTPUT"
-            echo "Admin UI files changed: $N"
+            echo "Admin UI or governance files changed: $N"
           fi
 
   ui-build:


### PR DESCRIPTION
Closes #2236

## Problem

The ADR-0071 governance manifest gate validates **every** `openbank-*/governance.yaml` in the fleet — but it lives in the `ui-build` job, gated on a diff limited to `openbank-admin-ui/`. A backend PR that adds or edits a `governance.yaml` and touches no admin-ui file therefore never reaches the gate that governs it: `ui-build` skips, the always-run `Admin UI` gate job reads a skip as a pass, and the PR merges green. The breakage lands on `main`, where it blocks the *next* PR that does touch admin-ui.

`SKIPPED` is not `passed`, and nothing downstream could tell the difference.

## It shipped twice

| merge | admin-ui files | governance.yaml |
|---|---|---|
| `b0b827eb` (#2124, ap2) | 0 | `openbank-ap2-service/governance.yaml` |
| `c04790d2` (#2104, mcp) | 0 | `openbank-mcp-service/governance.yaml` |

Both merged green. `main` then failed with `Governance drift — 2 module(s) missing or with an invalid governance.yaml`, blocking unrelated admin-ui PRs until #2174 fixed it forward.

## Change

One hunk: widen the `changes-ui` path filter to the gate’s own **inputs** —

- `*/governance.yaml` (every per-service manifest)
- `openbank-libs/governance/governance.schema.json` (what they are validated against)

The generator already lives under `openbank-admin-ui/`, so it is covered.

No change to the required-check topology: `Admin UI` stays the single required check and the `main-protection` ruleset is untouched.

## Validation against known positives and negatives

A green run proves nothing here — the failure mode *is* a job that does not run. Ran the exact filter over five commits:

```
ap2-POS      new=1  old=0
mcp-POS      new=1  old=0
adminui-POS  new=9  old=6
ledger-NEG   new=0  old=0
release-NEG  new=0  old=0
```

Both incident commits flip 0 -> 1; backend-only commits stay at 0, so no PR starts paying for `ui-build` that was not already paying.

`actionlint` finding sets diffed branch-vs-`origin/main`: identical, only the line number shifts (241 -> 253) by the size of this hunk. No new findings.

## Cost

A governance-only PR now also pays the full `ui-build` (lint, type-check, tests, Playwright, build; ~20 min). This repo is public, so hosted `ubuntu-latest` minutes are **free** — the cost is latency on a rare PR (new service or a governance sweep, a handful a month), not spend. The cheaper-latency alternative — splitting the gate into its own lightweight job — adds a required-check name to the ruleset for a saving that is $0 either way, so it is not worth the branch-protection change.

## Note on #2199

[#2199](https://github.com/JiRaska/open-bank-oss/pull/2199) also edits `ci.yml`, but only adds a comment inside the `Governance manifest gate` step (~line 92). This PR touches `changes-ui` (~line 28). Different hunks, complementary: #2199 makes the gate check *more*, this makes it *run at all*.