### PR TITLE
fix(control-liveness-sentinel): query the workflow-liveness gauge name that is actually emitted (#2187)

### DIFF
--- a/docs/adr/0163-control-liveness-sentinel-ai-agent.md
+++ b/docs/adr/0163-control-liveness-sentinel-ai-agent.md
@@ -54,10 +54,18 @@ devops-agent:
   (`rules.yaml`'s advisory-gate `blocked_on` list for mechanisms 1/2, so it can distinguish a
   known, tracked exception from a new regression).
 - **Detects four ways**, one per ADR-0160 mechanism:
-  - **D1 — stale watchdog heartbeat.** Any `openbank_workflow_liveness_last_success_age_seconds`
+  - **D1 — stale watchdog heartbeat.** Any `openbank_workflow_last_success_age_seconds`
     gauge past 2× its declared expected interval — the same threshold ADR-0160 mechanism 3
     already defines as the paging line, so this agent's finding and Alertmanager's page always
     agree.
+    (Correction, #2187 follow-up: this line originally named the gauge
+    `openbank_workflow_liveness_last_success_age_seconds`, and the implementation queried that,
+    but ADR-0160's `DomainMetrics.registerWorkflowLiveness` emits it without the `liveness`
+    infix — so D1 collected an empty vector and could only report "no stale heartbeats". The
+    query and this line were aligned to the emitted name, which is the one actually in
+    Prometheus; both sides now read it from `WorkflowLivenessMetrics`. The "Alertmanager's page"
+    it claims to agree with does not exist yet either — no PrometheusRule implements mechanism
+    3's generic expression.)
   - **D2 — event-consumer regression.** A newly producer-only topic in
     `check-event-consumer-liveness.sh`'s report that is not in the `rules.yaml` allowlist.
   - **D3 — lineage-vs-code drift.** A `governance.yaml` lineage edge the code audit

--- a/docs/agents/control-liveness-sentinel.md
+++ b/docs/agents/control-liveness-sentinel.md
@@ -54,8 +54,19 @@ reconciliation did for 41 days (issue #855).
   Seeding those two secret values is the one remaining manual step before this agent can produce a
   real end-to-end proposal.
 - The Prometheus gauge names this agent queries
-  (`openbank_workflow_liveness_last_success_age_seconds`,
+  (`openbank_workflow_last_success_age_seconds` + `openbank_workflow_expected_interval_seconds`,
   `openbank_event_consumer_liveness_producer_only`, `openbank_lineage_audit_unverified_edge`,
   `openbank_reconciliation_consecutive_drift_runs`) are the contract this agent expects from
   ADR-0160's mechanisms 1–4; wiring each mechanism's CI script / watchdog primitive to actually
   emit them is tracked as part of ADR-0160's own rollout, not duplicated here.
+- **Mechanism 3 is the one with a live producer, and the name above is corrected.** This doc and
+  ADR-0163 D1 originally wrote `openbank_workflow_liveness_last_success_age_seconds`, but
+  `DomainMetrics.registerWorkflowLiveness` — shipped, with one adopter — emits
+  `openbank_workflow_last_success_age_seconds` (no `liveness` infix). The query was aligned to the
+  producer rather than the other way round: the emitted name is what is physically in Prometheus
+  today, and renaming a live series to match prose would break the existing adopter for nothing.
+  Both sides now take the name from `WorkflowLivenessMetrics` in `openbank-libs-domain`, so a
+  future disagreement is a compile error rather than an empty result vector. The other three names
+  have no producer yet **by design** (see the bullet above) — an empty vector there means "not
+  wired", which is different from mechanism 3's case, where a producer existed and was simply not
+  being asked for.

--- a/openbank-control-liveness-sentinel/src/main/kotlin/com/openbank/liveness/application/workflow/CollectSignalsActivityImpl.kt
+++ b/openbank-control-liveness-sentinel/src/main/kotlin/com/openbank/liveness/application/workflow/CollectSignalsActivityImpl.kt
@@ -5,6 +5,7 @@
 
 package com.openbank.liveness.application.workflow
 
+import com.openbank.libs.observability.WorkflowLivenessMetrics
 import com.openbank.liveness.application.port.out.PrometheusQueryPort
 import io.quarkus.vertx.VertxContextSupport
 import io.smallrye.mutiny.coroutines.asUni
@@ -27,8 +28,13 @@ open class CollectSignalsActivityImpl(private val prometheusQuery: PrometheusQue
     // matching interval gauge is dropped rather than guessed at.
     override fun collectWatchdogHeartbeats(): Map<String, Double> = runOnVertxContext {
         log.debug("Collecting WorkflowLivenessWatchdog heartbeat gauges")
-        val ages = prometheusQuery.queryVector("openbank_workflow_liveness_last_success_age_seconds")
-        val intervals = prometheusQuery.queryVector("openbank_workflow_liveness_expected_interval_seconds")
+        // Series names come from WorkflowLivenessMetrics — the same constants DomainMetrics
+        // registers the gauges under. They used to be literals here, and they were WRONG: this
+        // queried `openbank_workflow_liveness_*` while the producer emits `openbank_workflow_*`,
+        // so both queries returned an empty vector and mechanism 3 reported "no stale heartbeats"
+        // unconditionally — the exact vacuous-green shape the mechanism exists to catch.
+        val ages = prometheusQuery.queryVector(WorkflowLivenessMetrics.LAST_SUCCESS_AGE_SERIES)
+        val intervals = prometheusQuery.queryVector(WorkflowLivenessMetrics.EXPECTED_INTERVAL_SERIES)
         ages.mapNotNull { (job, age) ->
             val interval = intervals[job] ?: return@mapNotNull null
             "$job|$interval" to age

--- a/openbank-libs-domain/src/main/kotlin/com/openbank/libs/observability/WorkflowLivenessMetrics.kt
+++ b/openbank-libs-domain/src/main/kotlin/com/openbank/libs/observability/WorkflowLivenessMetrics.kt
@@ -1,0 +1,61 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright (c) OpenBank contributors. Licensed under the Apache License, Version 2.0.
+// See LICENSE in the repository root or https://www.apache.org/licenses/LICENSE-2.0 for details.
+
+package com.openbank.libs.observability
+
+/**
+ * The single place the ADR-0160 mechanism-3 workflow-liveness metric names are written down.
+ *
+ * **Why this object exists.** The names used to be string literals on both sides of the seam: the
+ * producer registered `openbank.workflow.last_success.age_seconds` in `DomainMetrics`, while the
+ * consumer — `openbank-control-liveness-sentinel` — queried
+ * `openbank_workflow_liveness_last_success_age_seconds`. Nothing emitted that second name, so every
+ * mechanism-3 collection returned an empty vector and the sentinel could only ever report "no stale
+ * heartbeats". Both sides had tests; both tests hardcoded their own side's literal, so neither could
+ * see the disagreement. That is the same failure shape as the dead schedulers the mechanism exists
+ * to catch (#2148, #2187): a control that is structurally incapable of reporting a problem still
+ * reads green.
+ *
+ * Anything that registers or queries these gauges must go through the constants here rather than
+ * spell the name again.
+ *
+ * Pure Kotlin on purpose: the producer lives in `openbank-libs-runtime` (Micrometer) and the
+ * consumer in a service's application layer, so the shared truth has to sit in the domain module
+ * that both can depend on (ADR-0122).
+ */
+object WorkflowLivenessMetrics {
+
+    /** Meter name (Micrometer, dotted) of the age-of-last-success gauge. */
+    const val LAST_SUCCESS_AGE_SECONDS: String = "openbank.workflow.last_success.age_seconds"
+
+    /** Meter name (Micrometer, dotted) of the companion expected-run-interval gauge. */
+    const val EXPECTED_INTERVAL_SECONDS: String = "openbank.workflow.expected_interval_seconds"
+
+    /** Tag carrying the workflow's stable low-cardinality name, e.g. `standing-order-execution`. */
+    const val WORKFLOW_TAG: String = "workflow"
+
+    /** PromQL series name of [LAST_SUCCESS_AGE_SECONDS] — what a Prometheus query must ask for. */
+    val LAST_SUCCESS_AGE_SERIES: String = promSeriesName(LAST_SUCCESS_AGE_SECONDS)
+
+    /** PromQL series name of [EXPECTED_INTERVAL_SECONDS]. */
+    val EXPECTED_INTERVAL_SERIES: String = promSeriesName(EXPECTED_INTERVAL_SECONDS)
+
+    /**
+     * Renders a Micrometer meter name as the Prometheus series name it is scraped under.
+     *
+     * Micrometer's `PrometheusNamingConvention` does more than this in general (it also sanitizes
+     * illegal characters and appends a base-unit suffix), so this is only exact for names that are
+     * already lower-snake plus dots and carry no base unit — which the two constants above are, and
+     * which [isRenderableName] pins.
+     */
+    fun promSeriesName(meterName: String): String = meterName.replace('.', '_')
+
+    /**
+     * True when a meter name is simple enough that [promSeriesName] renders it exactly as Micrometer
+     * would: lowercase letters, digits, `_` and `.` only, starting with a letter.
+     */
+    fun isRenderableName(meterName: String): Boolean = RENDERABLE.matches(meterName)
+
+    private val RENDERABLE = Regex("^[a-z][a-z0-9_.]*$")
+}

--- a/openbank-libs-runtime/build.gradle.kts
+++ b/openbank-libs-runtime/build.gradle.kts
@@ -70,6 +70,11 @@ dependencies {
     testImplementation("org.jboss.logging:jboss-logging:3.6.2.Final")
     testImplementation("jakarta.enterprise:jakarta.enterprise.cdi-api:4.1.0")
     testImplementation("io.micrometer:micrometer-core:1.14.5")
+    // Test-only: WorkflowLivenessMetricNamingTest checks the dotted meter name against Micrometer's
+    // REAL PrometheusNamingConvention rather than trusting the hand-rolled dot -> underscore
+    // rendering that the sentinel's PromQL depends on. The registry itself is never used at runtime
+    // here — each service brings quarkus-micrometer-registry-prometheus itself.
+    testImplementation("io.micrometer:micrometer-registry-prometheus:1.14.5")
     testRuntimeOnly("org.junit.platform:junit-platform-launcher")
 }
 

--- a/openbank-libs-runtime/src/main/kotlin/com/openbank/libs/observability/DomainMetrics.kt
+++ b/openbank-libs-runtime/src/main/kotlin/com/openbank/libs/observability/DomainMetrics.kt
@@ -367,12 +367,17 @@ class DomainMetrics {
     fun registerWorkflowLiveness(workflow: String, expectedInterval: Duration): WorkflowLivenessRecorder {
         val lastSuccessEpochMillis = java.util.concurrent.atomic.AtomicLong(java.time.Instant.EPOCH.toEpochMilli())
         reg()?.let { r ->
-            Gauge.builder("openbank.workflow.last_success.age_seconds") {
+            // Names come from WorkflowLivenessMetrics, never a literal: the consumer side
+            // (openbank-control-liveness-sentinel) queried a name nothing emitted for as long as
+            // both sides spelled it themselves, so mechanism 3 collected an empty vector and could
+            // only ever report "no stale heartbeats" (#2187 follow-up).
+            Gauge.builder(WorkflowLivenessMetrics.LAST_SUCCESS_AGE_SECONDS) {
                 Duration.between(java.time.Instant.ofEpochMilli(lastSuccessEpochMillis.get()), java.time.Instant.now())
                     .toSeconds().toDouble()
-            }.tag("workflow", workflow).strongReference(true).register(r)
-            Gauge.builder("openbank.workflow.expected_interval_seconds") { expectedInterval.toSeconds().toDouble() }
-                .tag("workflow", workflow).strongReference(true).register(r)
+            }.tag(WorkflowLivenessMetrics.WORKFLOW_TAG, workflow).strongReference(true).register(r)
+            Gauge.builder(WorkflowLivenessMetrics.EXPECTED_INTERVAL_SECONDS) {
+                expectedInterval.toSeconds().toDouble()
+            }.tag(WorkflowLivenessMetrics.WORKFLOW_TAG, workflow).strongReference(true).register(r)
         }
         return WorkflowLivenessRecorder(lastSuccessEpochMillis)
     }

--- a/openbank-libs-runtime/src/test/kotlin/com/openbank/libs/observability/WorkflowLivenessMetricNamingTest.kt
+++ b/openbank-libs-runtime/src/test/kotlin/com/openbank/libs/observability/WorkflowLivenessMetricNamingTest.kt
@@ -1,0 +1,94 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright (c) OpenBank contributors. Licensed under the Apache License, Version 2.0.
+// See LICENSE in the repository root or https://www.apache.org/licenses/LICENSE-2.0 for details.
+
+package com.openbank.libs.observability
+
+import io.micrometer.core.instrument.Meter
+import io.micrometer.core.instrument.MeterRegistry
+import io.micrometer.core.instrument.simple.SimpleMeterRegistry
+import io.micrometer.prometheusmetrics.PrometheusNamingConvention
+import io.mockk.every
+import io.mockk.mockk
+import jakarta.enterprise.inject.Instance
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.Test
+import java.time.Duration
+
+/**
+ * Guards the producer/consumer seam of ADR-0160 mechanism 3.
+ *
+ * `DomainMetrics.registerWorkflowLiveness` emits the gauges; `openbank-control-liveness-sentinel`
+ * reads them back over PromQL. For as long as each side spelled the name itself, they disagreed —
+ * the producer emitted `openbank_workflow_last_success_age_seconds`, the sentinel queried
+ * `openbank_workflow_liveness_last_success_age_seconds`. Every mechanism-3 collection therefore
+ * returned an empty vector, and the sentinel reported "no stale heartbeats" unconditionally. Both
+ * sides had unit tests; each hardcoded its own literal, so neither could see the disagreement.
+ *
+ * The tests below are deliberately about the *seam*, not about either side's spelling:
+ *
+ *  1. the meter names a real registration actually produces are the [WorkflowLivenessMetrics]
+ *     constants (so the shared constants describe reality, not intent), and
+ *  2. those meter names render, **under Micrometer's own `PrometheusNamingConvention`**, to exactly
+ *     the series names the sentinel queries. That is the step no amount of testing either side in
+ *     isolation could cover, and it is checked against the real convention rather than against this
+ *     repo's hand-rolled dot -> underscore helper — otherwise the helper would only be proving
+ *     itself.
+ */
+class WorkflowLivenessMetricNamingTest {
+
+    private fun withRegistry(reg: MeterRegistry): DomainMetrics {
+        val inst = mockk<Instance<MeterRegistry>>()
+        every { inst.isResolvable } returns true
+        every { inst.get() } returns reg
+        return DomainMetrics().apply { registryInstance = inst }
+    }
+
+    @Test
+    fun `a real registration emits exactly the meter names the shared constants declare`() {
+        val reg = SimpleMeterRegistry()
+
+        withRegistry(reg).registerWorkflowLiveness("standing-order-execution", Duration.ofDays(1))
+
+        assertThat(reg.meters.map { it.id.name })
+            .describedAs("the constants must describe what registerWorkflowLiveness really emits")
+            .contains(
+                WorkflowLivenessMetrics.LAST_SUCCESS_AGE_SECONDS,
+                WorkflowLivenessMetrics.EXPECTED_INTERVAL_SECONDS,
+            )
+        assertThat(reg.meters.mapNotNull { it.id.getTag(WorkflowLivenessMetrics.WORKFLOW_TAG) })
+            .describedAs("both gauges must carry the workflow tag the sentinel keys its map by")
+            .containsOnly("standing-order-execution", "standing-order-execution")
+    }
+
+    @Test
+    fun `the queried series names are what Micrometer's Prometheus convention renders`() {
+        val convention = PrometheusNamingConvention()
+
+        assertThat(convention.name(WorkflowLivenessMetrics.LAST_SUCCESS_AGE_SECONDS, Meter.Type.GAUGE))
+            .describedAs("the sentinel's PromQL must ask for the series Prometheus actually exposes")
+            .isEqualTo(WorkflowLivenessMetrics.LAST_SUCCESS_AGE_SERIES)
+        assertThat(convention.name(WorkflowLivenessMetrics.EXPECTED_INTERVAL_SECONDS, Meter.Type.GAUGE))
+            .isEqualTo(WorkflowLivenessMetrics.EXPECTED_INTERVAL_SERIES)
+    }
+
+    @Test
+    fun `the series names are pinned literally so a constant rename cannot silently move them`() {
+        // Dashboards, PromQL rules and the sentinel all address these by string. Renaming the Kotlin
+        // constant is free; renaming the SERIES is a breaking observability change and must be a
+        // deliberate edit here.
+        assertThat(WorkflowLivenessMetrics.LAST_SUCCESS_AGE_SERIES)
+            .isEqualTo("openbank_workflow_last_success_age_seconds")
+        assertThat(WorkflowLivenessMetrics.EXPECTED_INTERVAL_SERIES)
+            .isEqualTo("openbank_workflow_expected_interval_seconds")
+    }
+
+    @Test
+    fun `both meter names stay simple enough for the rendering helper to be exact`() {
+        // promSeriesName is only faithful for lower-snake-plus-dots names with no base unit; if
+        // someone adds an uppercase letter or a unit suffix, the helper silently stops matching what
+        // Prometheus exposes. Pin the precondition rather than discover it in production.
+        assertThat(WorkflowLivenessMetrics.isRenderableName(WorkflowLivenessMetrics.LAST_SUCCESS_AGE_SECONDS)).isTrue()
+        assertThat(WorkflowLivenessMetrics.isRenderableName(WorkflowLivenessMetrics.EXPECTED_INTERVAL_SECONDS)).isTrue()
+    }
+}


### PR DESCRIPTION
## The finding

#2187 fixed five `@Scheduled` jobs that had silently never run. The obvious follow-up question is *what would have told us* — and the answer is the ADR-0160 mechanism-3 workflow-liveness watchdog, consumed by `openbank-control-liveness-sentinel`. It could never have told us anything.

| side | name | file |
|---|---|---|
| producer | `openbank_workflow_last_success_age_seconds` | `DomainMetrics.registerWorkflowLiveness` |
| consumer | `openbank_workflow_`**`liveness_`**`last_success_age_seconds` | `CollectSignalsActivityImpl.collectWatchdogHeartbeats` |

Nothing in the repo emits the second name. Both `queryVector` calls returned an empty vector, so `detectStaleHeartbeats` iterated an empty map and mechanism 3 reported "no stale heartbeats" — unconditionally, for every job, forever. `PrometheusQueryAdapter` also catches and logs query failures returning an empty map, so "nothing found" and "nothing asked" look identical from the outside.

**Both sides had unit tests.** `DomainMetricsTest` asserts the dotted meter name; `DetectFindingsActivityImplTest` feeds the detector a pre-built map. Each hardcodes its own side's literal, so the bug lived exactly where neither looked. That is the same vacuous-green shape as the dead schedulers this control exists to catch: a control structurally incapable of reporting a problem still reads green.

## The fix

Both sides now take the name from `WorkflowLivenessMetrics` (`openbank-libs-domain`, pure Kotlin so the runtime module and a service application layer can both depend on it, ADR-0122). A future disagreement is a compile error, not an empty result vector.

**Which side moved, and why.** The query was aligned to the producer, not the reverse. The emitted name is what is physically in Prometheus today and has a live adopter (`StandingOrderExecutionScheduler`); renaming a working series to match prose would break it for nothing. ADR-0163 D1 and `docs/agents/control-liveness-sentinel.md` carried the wrong name and are corrected in place, with the correction marked as such rather than quietly rewritten.

## Test

`WorkflowLivenessMetricNamingTest` covers the **seam**, not either side:

1. a real `registerWorkflowLiveness` call must emit meters named by the constants (the constants describe reality, not intent);
2. those meter names must render to the queried series names **under Micrometer's own `PrometheusNamingConvention`** — not under this repo's dot-to-underscore helper, which would only be proving itself;
3. the series names are pinned as literals, so renaming a Kotlin constant cannot silently move a series that dashboards and PromQL address by string;
4. the meter names stay inside the character set for which the helper is exact.

Validated against a known-positive rather than trusting the green: drifting the constant back to the `liveness` infix fails (3) with

```
expected: "openbank_workflow_last_success_age_seconds"
 but was: "openbank_workflow_liveness_last_success_age_seconds"
```

## Scope, and what this PR deliberately does not do

- **Mechanisms 1, 2 and 4 also query names nothing emits** — `openbank_event_consumer_liveness_producer_only`, `openbank_lineage_audit_unverified_edge`, `openbank_reconciliation_consecutive_drift_runs`. That is documented and deliberate: `docs/agents/control-liveness-sentinel.md` says wiring those producers is tracked under ADR-0160's own rollout. Mechanism 3 is the one that *had* a producer and was simply not being asked for, so it is the only one treated as a defect here.
- **Four of the five repaired jobs still register no liveness gauge at all.** Only `standing-order-execution` calls `registerWorkflowLiveness`; ledger tie-out, ledger FX revaluation, fx ČNB ingestion and the billing cycle emit nothing. This PR makes the detector work; it does not give it anything new to look at. Filed separately — it touches three money-path services.
- **No PrometheusRule implements mechanism 3's generic expression**, despite `DomainMetrics`' KDoc and ADR-0163 D1 both describing it as the paging line. Also filed separately, because as specified it would page falsely: the age gauge seeds from `Instant.EPOCH`, so every fresh pod reads ~56 years stale until the job's first success — for a daily job that is up to a day of firing after every deploy. That needs a design decision (seed from persisted state, or gate on pod uptime), not a rule dropped in.

## Verification

```
./gradlew :openbank-libs-domain:build :openbank-libs-runtime:build \
          :openbank-control-liveness-sentinel:detekt \
          :openbank-control-liveness-sentinel:ktlintCheck \
          :openbank-control-liveness-sentinel:build
BUILD SUCCESSFUL
check-adr-registry: OK — 187 ADRs … derived artefacts fresh.
check-domain-purity: 11 violation(s) found, 0 new, baseline 11 entr(y/ies).
```

`docs/adr/gen-index.sh` produces no diff (no front-matter changed). Not money-path. No API change, no migration, no config key. New test-only dependency `micrometer-registry-prometheus` in `openbank-libs-runtime` — used solely to check the naming claim against the real convention.

Refs #2187, #2148.