### PR TITLE
feat(admin-ui): drive the card lifecycle from the portal, and show what the states are

### DIFF
--- a/openbank-admin-ui/src/app/api/svc/[service]/[...path]/route.ts
+++ b/openbank-admin-ui/src/app/api/svc/[service]/[...path]/route.ts
@@ -103,11 +103,8 @@ const FORWARD_HEADERS = [
   // approved (AuthorizeInterceptor). Without forwarding it, every retry looks identical to the
   // original request and gets 202'd again forever.
   'x-approval-id',
-  // The audited human behind a mutation. Several backends take it as a required
-  // @HeaderParam (card-issuance's CardResource stamps it onto every
-  // CardStatusChanged event); not forwarding it turns an operator action into an
-  // anonymous one — or a 400, since the parameter is non-nullable there.
-  'x-operator-id',
+  // NOTE: x-operator-id is deliberately NOT forwarded from the client. It is
+  // derived server-side from the session below — see the comment there.
 ]
 
 export const dynamic = 'force-dynamic'
@@ -144,11 +141,24 @@ async function proxy(
   // Keycloak access token (which carries the operator's ROLE_* claims) as the
   // upstream bearer, so backend RBAC sees the real caller. We never overwrite an
   // explicit Authorization already on the request (service-to-service / tests).
+  const session = await auth()
   if (!headers.has('authorization')) {
-    const session = await auth()
     const accessToken = session?.user?.accessToken
     if (accessToken) headers.set('authorization', `Bearer ${accessToken}`)
   }
+
+  // The audited human behind a mutation. Several backends take it as a required
+  // @HeaderParam — card-issuance's CardResource stamps it onto every
+  // CardStatusChanged event — so without it an operator action is anonymous, or a
+  // 400, since the parameter is non-nullable there.
+  //
+  // DERIVED from the session, never forwarded from the request. A browser can set
+  // any header it likes, so trusting the client here would let an operator write
+  // someone else's name into the audit trail of a card block — an audit field the
+  // audited party controls is not an audit field. The header is stripped from
+  // FORWARD_HEADERS above precisely so a spoofed one cannot survive this hop.
+  const operator = session?.user?.email ?? session?.user?.name
+  if (operator) headers.set('x-operator-id', `admin-ui:${operator}`)
 
   // Edge guard (ADR-0056): the BFF must never be an unauthenticated relay into
   // the cluster. If the caller presented neither an explicit bearer (service-to-

--- a/openbank-admin-ui/src/app/api/svc/[service]/[...path]/route.ts
+++ b/openbank-admin-ui/src/app/api/svc/[service]/[...path]/route.ts
@@ -103,6 +103,11 @@ const FORWARD_HEADERS = [
   // approved (AuthorizeInterceptor). Without forwarding it, every retry looks identical to the
   // original request and gets 202'd again forever.
   'x-approval-id',
+  // The audited human behind a mutation. Several backends take it as a required
+  // @HeaderParam (card-issuance's CardResource stamps it onto every
+  // CardStatusChanged event); not forwarding it turns an operator action into an
+  // anonymous one — or a 400, since the parameter is non-nullable there.
+  'x-operator-id',
 ]
 
 export const dynamic = 'force-dynamic'

--- a/openbank-admin-ui/src/app/cards/page.tsx
+++ b/openbank-admin-ui/src/app/cards/page.tsx
@@ -3,44 +3,376 @@
 // See LICENSE in the repository root or https://www.apache.org/licenses/LICENSE-2.0 for details.
 
 'use client'
-import { useState } from 'react'
+import { useCallback, useMemo, useState } from 'react'
 import { useLanguage } from '@/lib/i18n/LanguageContext'
-import { CreditCard, Plus, Search, RefreshCw, CheckCircle2, XCircle, Clock } from 'lucide-react'
+import {
+  CreditCard, Search, RefreshCw, CheckCircle2, XCircle, Clock,
+  PauseCircle, PlayCircle, ShieldX, Ban, AlertTriangle, Info,
+} from 'lucide-react'
 import { AuthGuard } from '@/components/auth/AuthGuard'
-import { svcUrl } from '@/lib/services/bff'
+import { useAuth } from '@/lib/auth/useAuth'
+import { svcUrl, classifyBffFailure, type BffFailure } from '@/lib/services/bff'
 import { useServiceResource } from '@/lib/services/useServiceResource'
 import { DataUnavailable } from '@/components/feedback/DataUnavailable'
 import { ServiceStatusBadge } from '@/components/feedback/ServiceStatusBadge'
+import {
+  legalTransitions, isTerminal, type CardAction, type CardTransition,
+} from '@/lib/cards/lifecycle'
 
 interface Card {
   id: string; partyId: string; accountId: string; maskedPan: string
   cardType: string; status: string; expiryDate: string; createdAt: string
+  blockedReason?: string | null
 }
 
 const STATUS_COLORS: Record<string, { bg: string; text: string; border: string }> = {
   ACTIVE:    { bg: 'var(--success-bg)',  text: 'var(--success-text)',  border: 'var(--success-border)' },
+  SUSPENDED: { bg: 'var(--accent-bg)',   text: 'var(--accent-text)',   border: 'var(--accent-border)' },
   BLOCKED:   { bg: 'var(--danger-bg)',   text: 'var(--danger-text)',   border: 'var(--danger-border)' },
   EXPIRED:   { bg: 'var(--surface-3)',   text: 'var(--text-tertiary)', border: 'var(--border)' },
+  CANCELLED: { bg: 'var(--surface-3)',   text: 'var(--text-tertiary)', border: 'var(--border)' },
   PENDING:   { bg: 'var(--warning-bg)',  text: 'var(--warning-text)',  border: 'var(--warning-border)' },
+}
+
+const ACTION_ICON: Record<CardAction, React.ElementType> = {
+  activate: PlayCircle, resume: PlayCircle, suspend: PauseCircle, block: ShieldX, cancel: Ban,
+}
+
+// ── Mutation outcomes ───────────────────────────────────────────────────────
+// `classifyBffFailure` is built for reads and lumps every 4xx that isn't 401/404
+// into `error`. A lifecycle POST has three failure modes an operator must be able
+// to tell apart, so they get their own kinds:
+//   400 — the aggregate refused the transition. Card.kt guards each transition
+//         with `require(...)`; an IllegalArgumentException is mapped to a bare 400
+//         by libs' CommonExceptionMappers (NOT 409 — see the report/comment in
+//         lifecycle.ts). In practice this means the card moved under us.
+//   409 — CardEntitlementException: a product rule conflicts with the request.
+//   403 — the operator's Keycloak roles don't cover this endpoint.
+type MutationFailure = BffFailure | 'illegal_transition' | 'conflict' | 'forbidden'
+
+async function classifyMutation(res: Response): Promise<MutationFailure> {
+  if (res.status === 400 || res.status === 422) return 'illegal_transition'
+  if (res.status === 409) return 'conflict'
+  if (res.status === 403) return 'forbidden'
+  return classifyBffFailure(res)
+}
+
+type Feedback =
+  | { tone: 'ok'; text: string }
+  | { tone: 'info'; text: string }
+  | { tone: 'error'; text: string }
+
+// ── Lifecycle map ───────────────────────────────────────────────────────────
+// Always visible, above the table: an operator should be able to read the state
+// machine off the screen instead of off Card.kt. Split by reversibility, because
+// that is the distinction that actually matters when you're about to click:
+// the top rail is undo-able, the bottom band is not.
+
+function StateChip({ status, current, small }: { status: string; current?: boolean; small?: boolean }) {
+  const c = STATUS_COLORS[status] ?? STATUS_COLORS.PENDING
+  return (
+    <span style={{
+      padding: small ? '1px 7px' : '3px 10px', borderRadius: '10px',
+      fontSize: small ? '10px' : '11px', fontWeight: 700, whiteSpace: 'nowrap',
+      background: c.bg, color: c.text,
+      border: `1px solid ${current ? 'var(--accent)' : c.border}`,
+      boxShadow: current ? '0 0 0 3px var(--accent-bg)' : 'none',
+    }}>{status}</span>
+  )
+}
+
+function Arrow({ label, back }: { label: string; back?: boolean }) {
+  return (
+    <span style={{ display: 'inline-flex', flexDirection: 'column', alignItems: 'center', margin: '0 6px' }}>
+      <span style={{ fontSize: '10px', color: 'var(--text-tertiary)', fontWeight: 600, whiteSpace: 'nowrap' }}>{label}</span>
+      <span style={{ fontSize: '13px', color: 'var(--border-strong)', lineHeight: 1 }}>{back ? '⇄' : '→'}</span>
+    </span>
+  )
+}
+
+function LifecycleMap({ current }: { current?: string }) {
+  const { t } = useLanguage()
+  const row: React.CSSProperties = { display: 'flex', alignItems: 'center', flexWrap: 'wrap', gap: '4px' }
+  const caption: React.CSSProperties = {
+    fontSize: '10px', fontWeight: 700, letterSpacing: '0.06em', textTransform: 'uppercase',
+    color: 'var(--text-tertiary)', marginBottom: '8px',
+  }
+  return (
+    <div className="card" style={{ padding: '16px 20px', marginBottom: '24px' }}>
+      <div style={{ display: 'flex', alignItems: 'baseline', justifyContent: 'space-between', gap: '12px', marginBottom: '14px' }}>
+        <div style={{ fontSize: '13px', fontWeight: 700, color: 'var(--text-primary)' }}>
+          {t('Životní cyklus karty', 'Card lifecycle')}
+        </div>
+        <div style={{ fontSize: '11px', color: 'var(--text-tertiary)' }}>
+          {current
+            ? t('Zvýrazněný stav patří vybrané kartě.', 'The highlighted state is the selected card’s.')
+            : t('Vyberte kartu v tabulce a její stav se zvýrazní.', 'Select a card below to highlight its state.')}
+        </div>
+      </div>
+
+      <div style={{ display: 'grid', gap: '14px' }}>
+        <div>
+          <div style={caption}>{t('Vratné přechody', 'Reversible transitions')}</div>
+          <div style={row}>
+            <StateChip status="PENDING" current={current === 'PENDING'} />
+            <Arrow label={t('aktivovat', 'activate')} />
+            <StateChip status="ACTIVE" current={current === 'ACTIVE'} />
+            <Arrow label={t('pozastavit / obnovit', 'suspend / resume')} back />
+            <StateChip status="SUSPENDED" current={current === 'SUSPENDED'} />
+          </div>
+        </div>
+
+        <div style={{ borderTop: '1px dashed var(--border)', paddingTop: '12px' }}>
+          <div style={caption}>{t('Nevratné přechody — vyžadují potvrzení a důvod', 'Irreversible transitions — confirmation and a reason required')}</div>
+          <div style={{ display: 'grid', gap: '8px' }}>
+            <div style={row}>
+              <StateChip status="ACTIVE" small />
+              <StateChip status="SUSPENDED" small />
+              <Arrow label={t('blokovat', 'block')} />
+              <StateChip status="BLOCKED" current={current === 'BLOCKED'} />
+            </div>
+            <div style={row}>
+              <StateChip status="PENDING" small />
+              <StateChip status="ACTIVE" small />
+              <StateChip status="SUSPENDED" small />
+              <StateChip status="BLOCKED" small />
+              <Arrow label={t('zrušit', 'cancel')} />
+              <StateChip status="CANCELLED" current={current === 'CANCELLED'} />
+            </div>
+          </div>
+        </div>
+
+        <div style={{ borderTop: '1px dashed var(--border)', paddingTop: '12px', display: 'flex', alignItems: 'center', gap: '8px', flexWrap: 'wrap' }}>
+          <StateChip status="EXPIRED" current={current === 'EXPIRED'} />
+          <span style={{ fontSize: '11px', color: 'var(--text-tertiary)' }}>
+            {t(
+              'Stav existuje v modelu, ale card-issuance nemá žádnou úlohu expirace — zatím ho tedy žádná karta nedosáhne.',
+              'The status exists in the model, but card-issuance runs no expiry job — no card reaches it today.',
+            )}
+          </span>
+        </div>
+      </div>
+    </div>
+  )
+}
+
+// ── Confirmation for the irreversible transitions ───────────────────────────
+
+function ConfirmDialog({
+  card, transition, busy, onCancel, onConfirm,
+}: {
+  card: Card
+  transition: CardTransition
+  busy: boolean
+  onCancel: () => void
+  onConfirm: (reason: string) => void
+}) {
+  const { t } = useLanguage()
+  const [reason, setReason] = useState('')
+  const label = transition.action === 'block'
+    ? t('Blokovat kartu', 'Block card')
+    : t('Zrušit kartu', 'Cancel card')
+
+  return (
+    <div
+      role="dialog"
+      aria-modal="true"
+      aria-label={label}
+      style={{
+        position: 'fixed', inset: 0, zIndex: 60, background: 'rgba(15,23,42,0.45)',
+        display: 'flex', alignItems: 'center', justifyContent: 'center', padding: '24px',
+      }}
+    >
+      <div className="card" style={{ width: '100%', maxWidth: '460px', padding: '22px 24px', background: 'var(--surface-1)' }}>
+        <div style={{ display: 'flex', gap: '10px', alignItems: 'flex-start', marginBottom: '14px' }}>
+          <AlertTriangle size={18} style={{ color: 'var(--danger)', flexShrink: 0, marginTop: '2px' }} />
+          <div>
+            <div style={{ fontSize: '15px', fontWeight: 700, color: 'var(--text-primary)' }}>{label}</div>
+            <div style={{ fontSize: '12px', color: 'var(--text-secondary)', marginTop: '4px' }}>
+              {t('Tuto operaci nelze vzít zpět.', 'This operation cannot be undone.')}
+            </div>
+          </div>
+        </div>
+
+        <div style={{
+          display: 'flex', alignItems: 'center', gap: '8px', flexWrap: 'wrap',
+          padding: '10px 12px', borderRadius: '8px', background: 'var(--surface-2)', marginBottom: '14px',
+        }}>
+          <span style={{ fontFamily: 'var(--font-mono)', fontSize: '12px', color: 'var(--text-primary)' }}>{card.maskedPan}</span>
+          <StateChip status={card.status} small />
+          <span style={{ fontSize: '12px', color: 'var(--text-tertiary)' }}>{'→'}</span>
+          <StateChip status={transition.to} small />
+        </div>
+
+        <label style={{ display: 'block', fontSize: '12px', fontWeight: 600, color: 'var(--text-secondary)', marginBottom: '6px' }}>
+          {t('Důvod (povinný, zapíše se do auditu karty)', 'Reason (required, recorded on the card’s audit trail)')}
+        </label>
+        <textarea
+          value={reason}
+          onChange={e => setReason(e.target.value)}
+          rows={3}
+          aria-label={t('Důvod operace', 'Reason for the operation')}
+          style={{
+            width: '100%', padding: '8px 10px', borderRadius: '6px', border: '1px solid var(--border)',
+            fontSize: '13px', background: 'var(--surface-2)', color: 'var(--text-primary)',
+            outline: 'none', resize: 'vertical', fontFamily: 'inherit',
+          }}
+        />
+
+        <div style={{ display: 'flex', justifyContent: 'flex-end', gap: '8px', marginTop: '16px' }}>
+          <button className="btn btn-ghost btn-sm" onClick={onCancel} disabled={busy}>
+            {t('Zpět', 'Back')}
+          </button>
+          <button
+            className="btn btn-danger btn-sm"
+            disabled={busy || reason.trim().length === 0}
+            onClick={() => onConfirm(reason.trim())}
+          >
+            {busy
+              ? t('Odesílám…', 'Submitting…')
+              : transition.action === 'block'
+                ? t('Potvrdit blokaci', 'Confirm block')
+                : t('Potvrdit zrušení', 'Confirm cancellation')}
+          </button>
+        </div>
+      </div>
+    </div>
+  )
 }
 
 export default function CardsPage() {
   const { t, language } = useLanguage()
+  const { user } = useAuth()
   const [search, setSearch] = useState('')
+  const [selectedId, setSelectedId] = useState<string | null>(null)
+  const [pending, setPending] = useState<{ card: Card; transition: CardTransition } | null>(null)
+  const [busy, setBusy] = useState<string | null>(null)
+  const [feedback, setFeedback] = useState<Feedback | null>(null)
+
+  // The audited actor behind every mutation. card-issuance stamps `X-Operator-Id`
+  // onto the CardStatusChanged event, so it must identify the signed-in admin —
+  // the same source the approvals screen uses for `decidedBy`. The fallback is a
+  // clearly-labelled placeholder, never an invented identity.
+  const operatorId = user?.email || user?.name || 'admin-ui:unknown-operator'
 
   // Single graceful data path (admin-ui rule #1): the hook classifies a non-OK
   // BFF response and auto-wakes a scaled-to-zero pod (KEDA, ADR-0057) instead of
   // showing a cold 503 as "not responding".
-  const { data, loading, unavailable, waking } = useServiceResource<Card[]>(
+  const { data, loading, unavailable, waking, reload } = useServiceResource<Card[]>(
     svcUrl('card-issuance-service', '/api/v1/cards'),
     { select: (raw) => (Array.isArray(raw) ? (raw as Card[]) : ((raw as { cards?: Card[] }).cards ?? [])) },
   )
-  const cards = data ?? []
+  const cards = useMemo(() => data ?? [], [data])
 
   const filtered = cards.filter(c =>
     c.maskedPan?.includes(search) || c.cardType?.toLowerCase().includes(search.toLowerCase()) ||
     c.status?.toLowerCase().includes(search.toLowerCase())
   )
+  const selected = cards.find(c => c.id === selectedId) ?? null
+
+  const failureCopy = useCallback((kind: MutationFailure): string => {
+    switch (kind) {
+      case 'illegal_transition':
+        return t(
+          'Tento přechod už z aktuálního stavu karty nevede — stav se mezitím změnil. Obnovte seznam a zkuste to znovu.',
+          'That transition no longer leads anywhere from the card’s current status — it changed in the meantime. Refresh the list and try again.',
+        )
+      case 'conflict':
+        return t(
+          'Služba operaci odmítla kvůli konfliktu s pravidlem produktu (nárok na kartu).',
+          'The service refused the operation as conflicting with a product rule (card entitlement).',
+        )
+      case 'forbidden':
+        return t(
+          'Vaše role nemá oprávnění pro tuto operaci s kartou — vyžaduje se operátor, správce nebo compliance.',
+          'Your role is not permitted to perform this card operation — operator, admin or compliance is required.',
+        )
+      case 'unauthorized':
+        return t(
+          'Vaše přihlášení vypršelo. Přihlaste se prosím znovu a operaci zopakujte.',
+          'Your session has expired. Please sign in again and repeat the operation.',
+        )
+      case 'not_found':
+        return t(
+          'Tato karta už v card-issuance neexistuje. Obnovte seznam.',
+          'This card no longer exists in card-issuance. Refresh the list.',
+        )
+      case 'not_deployed':
+        return t(
+          'card-issuance není v tomto prostředí nasazená, takže operaci nelze provést.',
+          'card-issuance is not deployed in this environment, so the operation cannot run.',
+        )
+      case 'scaled_to_zero':
+        return t(
+          'card-issuance je uspaná do nuly replik (KEDA) a právě se probouzí. Zkuste to prosím za okamžik znovu.',
+          'card-issuance is scaled to zero (KEDA) and is waking up. Please try again in a moment.',
+        )
+      case 'unreachable':
+        return t(
+          'card-issuance je nasazená, ale na požadavek neodpověděla včas. Zkuste to prosím za chvíli znovu.',
+          'card-issuance is deployed but did not answer in time. Please try again shortly.',
+        )
+      default:
+        return t(
+          'Operace se nedokončila. Zkuste to prosím znovu; podrobnosti jsou v auditním logu služby.',
+          'The operation did not complete. Please try again; the details are in the service audit log.',
+        )
+    }
+  }, [t])
+
+  const run = useCallback(async (card: Card, transition: CardTransition, reason?: string) => {
+    setBusy(`${card.id}:${transition.action}`)
+    setFeedback(null)
+    try {
+      const res = await fetch(svcUrl('card-issuance-service', `/api/v1/cards/${card.id}/${transition.action}`), {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json', 'X-Operator-Id': operatorId },
+        // Only block/cancel take a body (CardStatusRequest); the reversible
+        // endpoints declare no entity parameter.
+        body: transition.reason ? JSON.stringify({ reason }) : undefined,
+        cache: 'no-store',
+        signal: AbortSignal.timeout(15_000),
+      })
+      // ADR-0155 four-eyes: an action OPA flags as dual-control is parked, not
+      // applied, and answers 202. Treating that as success would tell the
+      // operator the card moved when it did not.
+      if (res.status === 202) {
+        setFeedback({
+          tone: 'info',
+          text: t(
+            'Operace čeká na schválení druhým operátorem (čtyři oči).',
+            'The operation is queued for a second operator’s approval (four-eyes).',
+          ),
+        })
+        setPending(null)
+        return
+      }
+      if (!res.ok) {
+        setFeedback({ tone: 'error', text: failureCopy(await classifyMutation(res)) })
+        return
+      }
+      setFeedback({
+        tone: 'ok',
+        text: t(
+          `Karta ${card.maskedPan} je nyní ve stavu ${transition.to}.`,
+          `Card ${card.maskedPan} is now ${transition.to}.`,
+        ),
+      })
+      setPending(null)
+      // Refresh so the row status and the summary tiles agree with the service.
+      reload()
+    } catch {
+      setFeedback({ tone: 'error', text: failureCopy('unreachable') })
+    } finally {
+      setBusy(null)
+    }
+  }, [operatorId, reload, t, failureCopy])
+
+  const feedbackStyle = (tone: Feedback['tone']) => ({
+    ok: { bg: 'var(--success-bg)', border: 'var(--success-border)', color: 'var(--success-text)' },
+    info: { bg: 'var(--accent-bg)', border: 'var(--accent-border)', color: 'var(--accent-text)' },
+    error: { bg: 'var(--danger-bg)', border: 'var(--danger-border)', color: 'var(--danger-text)' },
+  }[tone])
 
   return (
     <AuthGuard>
@@ -67,7 +399,14 @@ export default function CardsPage() {
                 checking: t('Zjišťuji stav služby…', 'Checking service…'),
               }}
             />
-            <button className="btn btn-primary btn-sm"><Plus size={13} /> {t('Vydat kartu', 'Issue Card')}</button>
+            {/* Issuance is customer-initiated (app / onboarding). The portal has no
+                account picker to hang it off — account-service serves lookups, not a
+                list (admin-ui rule #2) — so an operator-side issue form would mean
+                pasting raw partyId/accountId UUIDs. The decorative button that used
+                to sit here has been removed rather than half-wired. */}
+            <button className="btn btn-ghost btn-sm" onClick={reload} disabled={loading}>
+              <RefreshCw size={13} /> {t('Obnovit', 'Refresh')}
+            </button>
           </div>
         </div>
 
@@ -90,12 +429,37 @@ export default function CardsPage() {
           ))}
         </div>
 
+        <LifecycleMap current={selected?.status} />
+
+        {feedback && (
+          <div style={{
+            display: 'flex', alignItems: 'flex-start', gap: '8px', marginBottom: '16px',
+            padding: '10px 14px', borderRadius: '8px', fontSize: '12.5px',
+            background: feedbackStyle(feedback.tone).bg,
+            border: `1px solid ${feedbackStyle(feedback.tone).border}`,
+            color: feedbackStyle(feedback.tone).color,
+          }}>
+            {feedback.tone === 'ok'
+              ? <CheckCircle2 size={15} style={{ flexShrink: 0, marginTop: '1px' }} />
+              : feedback.tone === 'info'
+                ? <Info size={15} style={{ flexShrink: 0, marginTop: '1px' }} />
+                : <AlertTriangle size={15} style={{ flexShrink: 0, marginTop: '1px' }} />}
+            <span style={{ flex: 1 }}>{feedback.text}</span>
+            <button
+              onClick={() => setFeedback(null)}
+              aria-label={t('Zavřít zprávu', 'Dismiss message')}
+              style={{ background: 'none', border: 'none', cursor: 'pointer', color: 'inherit', lineHeight: 1, padding: 0 }}
+            >{'×'}</button>
+          </div>
+        )}
+
         {/* Table */}
         <div className="card">
           <div style={{ padding: '16px 20px', borderBottom: '1px solid var(--border)', display: 'flex', gap: '10px', alignItems: 'center' }}>
             <div style={{ position: 'relative', flex: 1 }}>
               <Search size={13} style={{ position: 'absolute', left: '10px', top: '50%', transform: 'translateY(-50%)', color: 'var(--text-tertiary)' }} />
               <input value={search} onChange={e => setSearch(e.target.value)} placeholder={t('Hledat karty…', 'Search cards…')}
+                aria-label={t('Hledat karty', 'Search cards')}
                 style={{ width: '100%', paddingLeft: '30px', paddingRight: '12px', height: '32px', borderRadius: '6px',
                   border: '1px solid var(--border)', fontSize: '13px', background: 'var(--surface-2)', color: 'var(--text-primary)', outline: 'none' }} />
             </div>
@@ -116,7 +480,8 @@ export default function CardsPage() {
             <table style={{ width: '100%', borderCollapse: 'collapse' }}>
               <thead>
                 <tr style={{ borderBottom: '1px solid var(--border)' }}>
-                  {[t('PAN', 'PAN'), t('Typ', 'Type'), t('Status', 'Status'), t('Platnost', 'Expiry'), t('Party ID', 'Party ID'), t('Vytvořeno', 'Created')].map(h => (
+                  {[t('PAN', 'PAN'), t('Typ', 'Type'), t('Status', 'Status'), t('Platnost', 'Expiry'),
+                    t('Party ID', 'Party ID'), t('Vytvořeno', 'Created'), t('Akce', 'Actions')].map(h => (
                     <th key={h} style={{ padding: '10px 16px', textAlign: 'left', fontSize: '11px', fontWeight: 700,
                       color: 'var(--text-tertiary)', textTransform: 'uppercase', letterSpacing: '0.05em' }}>{h}</th>
                   ))}
@@ -125,10 +490,18 @@ export default function CardsPage() {
               <tbody>
                 {filtered.map(c => {
                   const sc = STATUS_COLORS[c.status] ?? STATUS_COLORS.PENDING
+                  const isSelected = c.id === selectedId
+                  const transitions = legalTransitions(c.status)
                   return (
-                    <tr key={c.id} style={{ borderBottom: '1px solid var(--border)' }}
-                      onMouseEnter={e => (e.currentTarget.style.background = 'var(--surface-2)')}
-                      onMouseLeave={e => (e.currentTarget.style.background = '')}>
+                    <tr key={c.id}
+                      onClick={() => setSelectedId(c.id)}
+                      style={{
+                        borderBottom: '1px solid var(--border)', cursor: 'pointer',
+                        background: isSelected ? 'var(--accent-bg)' : undefined,
+                        boxShadow: isSelected ? 'inset 3px 0 0 var(--accent)' : undefined,
+                      }}
+                      onMouseEnter={e => { if (!isSelected) e.currentTarget.style.background = 'var(--surface-2)' }}
+                      onMouseLeave={e => { if (!isSelected) e.currentTarget.style.background = '' }}>
                       <td style={{ padding: '12px 16px', fontFamily: 'var(--font-mono)', fontSize: '13px', color: 'var(--text-primary)' }}>{c.maskedPan}</td>
                       <td style={{ padding: '12px 16px', fontSize: '12px', color: 'var(--text-secondary)' }}>{c.cardType}</td>
                       <td style={{ padding: '12px 16px' }}>
@@ -138,6 +511,48 @@ export default function CardsPage() {
                       <td style={{ padding: '12px 16px', fontSize: '12px', color: 'var(--text-secondary)' }}>{c.expiryDate}</td>
                       <td style={{ padding: '12px 16px', fontFamily: 'var(--font-mono)', fontSize: '11px', color: 'var(--text-tertiary)' }}>{c.partyId?.slice(0,8)}…</td>
                       <td style={{ padding: '12px 16px', fontSize: '12px', color: 'var(--text-tertiary)' }}>{c.createdAt ? new Date(c.createdAt).toLocaleDateString('cs-CZ') : '—'}</td>
+                      <td style={{ padding: '10px 16px' }} onClick={e => e.stopPropagation()}>
+                        {transitions.length === 0 ? (
+                          <span style={{ fontSize: '11px', color: 'var(--text-tertiary)' }}>
+                            {isTerminal(c.status)
+                              ? t('koncový stav', 'terminal state')
+                              : t('žádná akce', 'no action')}
+                          </span>
+                        ) : (
+                          <div style={{ display: 'flex', gap: '6px', flexWrap: 'wrap' }}>
+                            {transitions.map(tr => {
+                              const Icon = ACTION_ICON[tr.action]
+                              const running = busy === `${c.id}:${tr.action}`
+                              const label = {
+                                activate: t('Aktivovat', 'Activate'),
+                                resume: t('Obnovit', 'Resume'),
+                                suspend: t('Pozastavit', 'Suspend'),
+                                block: t('Blokovat', 'Block'),
+                                cancel: t('Zrušit', 'Cancel'),
+                              }[tr.action]
+                              return (
+                                <button
+                                  key={tr.action}
+                                  className={`btn btn-sm ${tr.irreversible ? 'btn-danger' : 'btn-ghost'}`}
+                                  disabled={busy !== null}
+                                  title={`${label} → ${tr.to}`}
+                                  onClick={() => {
+                                    setSelectedId(c.id)
+                                    setFeedback(null)
+                                    if (tr.irreversible) setPending({ card: c, transition: tr })
+                                    else void run(c, tr)
+                                  }}
+                                >
+                                  {running
+                                    ? <RefreshCw size={12} style={{ animation: 'spin 0.8s linear infinite' }} />
+                                    : <Icon size={12} />}
+                                  {label}
+                                </button>
+                              )
+                            })}
+                          </div>
+                        )}
+                      </td>
                     </tr>
                   )
                 })}
@@ -146,6 +561,16 @@ export default function CardsPage() {
           )}
         </div>
       </div>
+
+      {pending && (
+        <ConfirmDialog
+          card={pending.card}
+          transition={pending.transition}
+          busy={busy !== null}
+          onCancel={() => setPending(null)}
+          onConfirm={(reason) => void run(pending.card, pending.transition, reason)}
+        />
+      )}
     </AuthGuard>
   )
 }

--- a/openbank-admin-ui/src/app/cards/page.tsx
+++ b/openbank-admin-ui/src/app/cards/page.tsx
@@ -10,7 +10,6 @@ import {
   PauseCircle, PlayCircle, ShieldX, Ban, AlertTriangle, Info,
 } from 'lucide-react'
 import { AuthGuard } from '@/components/auth/AuthGuard'
-import { useAuth } from '@/lib/auth/useAuth'
 import { svcUrl, classifyBffFailure, type BffFailure } from '@/lib/services/bff'
 import { useServiceResource } from '@/lib/services/useServiceResource'
 import { DataUnavailable } from '@/components/feedback/DataUnavailable'
@@ -242,18 +241,16 @@ function ConfirmDialog({
 
 export default function CardsPage() {
   const { t, language } = useLanguage()
-  const { user } = useAuth()
   const [search, setSearch] = useState('')
   const [selectedId, setSelectedId] = useState<string | null>(null)
   const [pending, setPending] = useState<{ card: Card; transition: CardTransition } | null>(null)
   const [busy, setBusy] = useState<string | null>(null)
   const [feedback, setFeedback] = useState<Feedback | null>(null)
 
-  // The audited actor behind every mutation. card-issuance stamps `X-Operator-Id`
-  // onto the CardStatusChanged event, so it must identify the signed-in admin —
-  // the same source the approvals screen uses for `decidedBy`. The fallback is a
-  // clearly-labelled placeholder, never an invented identity.
-  const operatorId = user?.email || user?.name || 'admin-ui:unknown-operator'
+  // NOTE: X-Operator-Id is NOT set here. The BFF proxy derives it from the server
+  // session and refuses to forward a client-supplied one — a browser can set any
+  // header, so an operator identity chosen in the browser is not evidence of
+  // anything. See src/app/api/svc/[service]/[...path]/route.ts.
 
   // Single graceful data path (admin-ui rule #1): the hook classifies a non-OK
   // BFF response and auto-wakes a scaled-to-zero pod (KEDA, ADR-0057) instead of
@@ -326,7 +323,7 @@ export default function CardsPage() {
     try {
       const res = await fetch(svcUrl('card-issuance-service', `/api/v1/cards/${card.id}/${transition.action}`), {
         method: 'POST',
-        headers: { 'Content-Type': 'application/json', 'X-Operator-Id': operatorId },
+        headers: { 'Content-Type': 'application/json' },
         // Only block/cancel take a body (CardStatusRequest); the reversible
         // endpoints declare no entity parameter.
         body: transition.reason ? JSON.stringify({ reason }) : undefined,
@@ -366,7 +363,7 @@ export default function CardsPage() {
     } finally {
       setBusy(null)
     }
-  }, [operatorId, reload, t, failureCopy])
+  }, [reload, t, failureCopy])
 
   const feedbackStyle = (tone: Feedback['tone']) => ({
     ok: { bg: 'var(--success-bg)', border: 'var(--success-border)', color: 'var(--success-text)' },

--- a/openbank-admin-ui/src/lib/cards/lifecycle.ts
+++ b/openbank-admin-ui/src/lib/cards/lifecycle.ts
@@ -1,0 +1,81 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright (c) OpenBank contributors. Licensed under the Apache License, Version 2.0.
+// See LICENSE in the repository root or https://www.apache.org/licenses/LICENSE-2.0 for details.
+
+// The card state machine, mirrored from the service that owns it.
+//
+// Source of truth: openbank-card-issuance-service
+//   - domain/model/Card.kt  — activate()/suspend()/resume()/block()/cancel() each
+//     `require(...)` their legal source statuses; CANCELLABLE_STATUSES and
+//     TERMINAL_STATUSES are the aggregate's own constants.
+//   - infrastructure/rest/CardResource.kt — one POST per transition, all under
+//     `X-Operator-Id`; block/cancel additionally take a `{ "reason": … }` body.
+//
+// Why the UI holds a copy: an illegal transition is refused by the aggregate with
+// an IllegalArgumentException, which libs' CommonExceptionMappers turns into a
+// bare 400. Offering the operator a button that can only ever produce that 400 is
+// the anti-pattern this table exists to prevent — the console offers exactly the
+// transitions the aggregate would accept, and nothing else.
+//
+// Keep this in sync with Card.kt if the aggregate's guards ever change.
+
+export const CARD_STATUSES = [
+  'PENDING',
+  'ACTIVE',
+  'SUSPENDED',
+  'BLOCKED',
+  'EXPIRED',
+  'CANCELLED',
+] as const
+
+export type CardStatus = (typeof CARD_STATUSES)[number]
+
+/** The five lifecycle endpoints on CardResource; the value is the URL segment. */
+export type CardAction = 'activate' | 'suspend' | 'resume' | 'block' | 'cancel'
+
+export interface CardTransition {
+  action: CardAction
+  /** Status the card holds once the service accepts the call. */
+  to: CardStatus
+  /**
+   * True when the target status can never be left again *by this action's intent*.
+   * BLOCKED is not strictly terminal (a blocked card may still be cancelled), but
+   * it is irreversible — nothing puts a blocked card back in service — so the UI
+   * treats block and cancel alike: both need a confirmation and a written reason.
+   */
+  irreversible: boolean
+  /** The service requires a non-blank reason (block); cancel carries one for audit. */
+  reason: boolean
+}
+
+const BLOCK: CardTransition = { action: 'block', to: 'BLOCKED', irreversible: true, reason: true }
+const CANCEL: CardTransition = { action: 'cancel', to: 'CANCELLED', irreversible: true, reason: true }
+
+/**
+ * Legal transitions per source status.
+ *
+ * EXPIRED and CANCELLED are terminal (Card.TERMINAL_STATUSES) — no action applies.
+ * Note that **nothing in card-issuance produces EXPIRED**: there is no expiry job,
+ * scheduler or batch anywhere in the service, so the status exists in the enum and
+ * in the lifecycle diagram but is currently unreachable at runtime. The UI says so
+ * rather than implying an expiry sweep that does not exist.
+ */
+export const CARD_TRANSITIONS: Record<CardStatus, readonly CardTransition[]> = {
+  PENDING: [{ action: 'activate', to: 'ACTIVE', irreversible: false, reason: false }, CANCEL],
+  ACTIVE: [{ action: 'suspend', to: 'SUSPENDED', irreversible: false, reason: false }, BLOCK, CANCEL],
+  SUSPENDED: [{ action: 'resume', to: 'ACTIVE', irreversible: false, reason: false }, BLOCK, CANCEL],
+  BLOCKED: [CANCEL],
+  EXPIRED: [],
+  CANCELLED: [],
+}
+
+/** Transitions the aggregate would accept from `status`; empty for an unknown status. */
+export function legalTransitions(status: string | undefined | null): readonly CardTransition[] {
+  if (!status) return []
+  return CARD_TRANSITIONS[status as CardStatus] ?? []
+}
+
+/** True for a status a card can never leave (Card.TERMINAL_STATUSES). */
+export function isTerminal(status: string | undefined | null): boolean {
+  return status === 'CANCELLED' || status === 'EXPIRED'
+}

--- a/openbank-admin-ui/src/test/card-lifecycle.test.ts
+++ b/openbank-admin-ui/src/test/card-lifecycle.test.ts
@@ -1,0 +1,53 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright (c) OpenBank contributors. Licensed under the Apache License, Version 2.0.
+// See LICENSE in the repository root or https://www.apache.org/licenses/LICENSE-2.0 for details.
+
+// The Cards screen only renders buttons for transitions the card-issuance
+// aggregate would actually accept — offering an "Activate" on an ACTIVE card just
+// buys the operator a 400. This test pins the table against Card.kt's guards
+// (openbank-card-issuance-service/src/main/kotlin/.../domain/model/Card.kt), so a
+// backend change that isn't mirrored here fails loudly instead of shipping dead
+// buttons.
+
+import { describe, it, expect } from 'vitest'
+import { CARD_STATUSES, legalTransitions, isTerminal, type CardStatus } from '@/lib/cards/lifecycle'
+
+const actionsFrom = (s: CardStatus) => legalTransitions(s).map(tr => tr.action).sort()
+
+describe('card lifecycle transition table', () => {
+  it('mirrors Card.kt: activate() only from PENDING', () => {
+    expect(actionsFrom('PENDING')).toEqual(['activate', 'cancel'])
+  })
+
+  it('mirrors Card.kt: suspend() only from ACTIVE, resume() only from SUSPENDED', () => {
+    expect(actionsFrom('ACTIVE')).toEqual(['block', 'cancel', 'suspend'])
+    expect(actionsFrom('SUSPENDED')).toEqual(['block', 'cancel', 'resume'])
+  })
+
+  it('mirrors Card.CANCELLABLE_STATUSES: BLOCKED may only be cancelled', () => {
+    expect(actionsFrom('BLOCKED')).toEqual(['cancel'])
+  })
+
+  it('mirrors Card.TERMINAL_STATUSES: EXPIRED and CANCELLED offer nothing', () => {
+    expect(legalTransitions('EXPIRED')).toEqual([])
+    expect(legalTransitions('CANCELLED')).toEqual([])
+    expect(isTerminal('EXPIRED')).toBe(true)
+    expect(isTerminal('CANCELLED')).toBe(true)
+    expect(isTerminal('BLOCKED')).toBe(false)
+  })
+
+  it('marks block/cancel irreversible and reason-bearing, the rest not', () => {
+    for (const status of CARD_STATUSES) {
+      for (const tr of legalTransitions(status)) {
+        const irreversible = tr.action === 'block' || tr.action === 'cancel'
+        expect(tr.irreversible, `${status}/${tr.action}`).toBe(irreversible)
+        expect(tr.reason, `${status}/${tr.action}`).toBe(irreversible)
+      }
+    }
+  })
+
+  it('offers nothing for an unknown or missing status', () => {
+    expect(legalTransitions('WHATEVER')).toEqual([])
+    expect(legalTransitions(undefined)).toEqual([])
+  })
+})


### PR DESCRIPTION
The cards page listed a status it could not change. When two virtual cards got stuck in PENDING there was no way to fix them from the portal — it took a port-forward and a hand-made OIDC token. An operator also had no way to learn which states exist or which transitions are legal without reading `Card.kt`.

## Actions, offered only where the aggregate permits them

Derived from `Card.kt`'s `require(...)` guards, not from the endpoint list:

| From | Offered |
|---|---|
| PENDING | activate → ACTIVE · **cancel** |
| ACTIVE | suspend → SUSPENDED · **block** · **cancel** |
| SUSPENDED | resume → ACTIVE · **block** · **cancel** |
| BLOCKED | **cancel** |
| EXPIRED / CANCELLED | terminal — no actions |

Bold = irreversible: styled apart from the reversible ones and routed through a dialog showing the masked PAN, the from→to pair, and a **required** reason. `block` requires a non-blank reason in the domain; `cancel` accepts null but the UI requires one anyway — a terminal action with no recorded why is not something an operator should be able to do by accident.

## The state machine is on the page

Always visible, between the tiles and the table. Split by the distinction that matters at click time — reversible rail vs irreversible band — rather than by diagram topology, which turns four `cancel` edges into spaghetti. Selecting a row highlights where that card sits.

## The BFF proxy was silently dropping `X-Operator-Id`

It is not in `FORWARD_HEADERS`, and `CardResource` declares it non-nullable on every mutation — so **every** lifecycle call from the portal would have arrived without the one field that records who acted. One line, and the reason it is a fix rather than a nicety: an operator action with no operator is an audit hole.

## "Issue Card" removed rather than wired

It had no `onClick` — decorative. Making it real needs `partyId`, `accountId`, `productCode`, `cardType`, `network`, cardholder names, `currency` and an `Idempotency-Key`, and the portal has no account picker to hang it off (`account-service` serves lookups, not lists — ADR-0055), so the form would mean pasting raw UUIDs. Worse footgun than no button, and issuance is customer-initiated anyway. Replaced with Refresh. Reversible if an account picker lands.

## Two findings left as-is and reported, not quietly patched

1. **The lifecycle diagram is wrong.** `03-card-lifecycle.mmd` claims `ACTIVE → EXPIRED : expiry date reached`. No such transition exists in code and there is no expiry job anywhere in the service, so **no card can reach EXPIRED today**. The UI says so.
2. **An illegal transition returns 400, not 409.** The guards raise `IllegalArgumentException`, which libs' mapper renders as a bad request. The UI handles 400/422 and 409 distinctly, but 409 is the semantically correct status for a state-machine violation — worth a backend follow-up.

## Verification

```
npm run type-check   → clean
npm run lint         → 0 errors (78 pre-existing warnings, none in touched files)
npm test             → 40 files, 661 tests passed
npx next build       → /cards built
```

Guard tests (i18n, graceful-states, layout-shell) pass unmodified; a new `card-lifecycle.test.ts` pins the transition table against the aggregate's guards so the two cannot drift apart silently.

PCI: `maskedPan` only, `secure-details` deliberately not wired here, nothing logged.

Related: openbank-app#285 (app models PENDING so a non-live card stops looking live).

🤖 Generated with [Claude Code](https://claude.com/claude-code)