### PR TITLE
feat(admin-ui): full operator card management — detail view, limits/controls, issue flow

### DIFF
--- a/openbank-admin-ui/src/app/cards/[id]/page.tsx
+++ b/openbank-admin-ui/src/app/cards/[id]/page.tsx
@@ -1,0 +1,365 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright (c) OpenBank contributors. Licensed under the Apache License, Version 2.0.
+// See LICENSE in the repository root or https://www.apache.org/licenses/LICENSE-2.0 for details.
+
+// One card, everything the service knows about it, and everything an operator may
+// do to it.
+//
+// This is a ROUTE (`/cards/<uuid>`), not a slide-over panel, and that is a
+// deliberate call: a card in a back office is what a conversation is about — a
+// fraud call, a complaint, a four-eyes approval — so the view has to be linkable
+// into a ticket, survive a reload, and support browser back. A panel is faster to
+// open and impossible to send to a colleague.
+//
+// PCI: the console never renders a full PAN. card-issuance does expose
+// `GET /{id}/secure-details` (the synthetic PAN + CVV of a virtual card), and it is
+// deliberately NOT wired here — a back-office screen that can show a PAN turns
+// every operator session into a PAN oracle and drags the whole console into CDE
+// scope. The masked PAN is the identifier operators work with; the note on screen
+// says so, so its absence reads as a control rather than as a missing feature.
+
+'use client'
+
+import { useCallback, useEffect, useMemo, useState } from 'react'
+import { useParams } from 'next/navigation'
+import Link from 'next/link'
+import {
+  ArrowLeft, CreditCard, Info, RefreshCw, ShieldCheck, Clock, User, Landmark,
+} from 'lucide-react'
+import { AuthGuard } from '@/components/auth/AuthGuard'
+import { DataUnavailable } from '@/components/feedback/DataUnavailable'
+import { useLanguage } from '@/lib/i18n/LanguageContext'
+import { classifyBffFailure, svcUrl } from '@/lib/services/bff'
+import { useServiceResource } from '@/lib/services/useServiceResource'
+import { CardStatusChip } from '@/components/cards/CardStatusChip'
+import { CardLifecycleMap } from '@/components/cards/CardLifecycleMap'
+import { CardTransitionButtons } from '@/components/cards/CardTransitionButtons'
+import { ConfirmTransitionDialog } from '@/components/cards/ConfirmTransitionDialog'
+import { CardOperationFeedback } from '@/components/cards/CardOperationFeedback'
+import { CardLimitsPanel } from '@/components/cards/CardLimitsPanel'
+import { CardControlsPanel } from '@/components/cards/CardControlsPanel'
+import { useCardOperations } from '@/lib/cards/useCardOperations'
+import { quotaOf } from '@/lib/cards/entitlements'
+import type { CardTransition } from '@/lib/cards/lifecycle'
+import type { AccountRef, Card, CardEntitlements, PartyRef } from '@/lib/cards/types'
+
+function Row({ label, value, mono, muted }: { label: string; value: React.ReactNode; mono?: boolean; muted?: boolean }) {
+  return (
+    <div style={{ display: 'flex', justifyContent: 'space-between', alignItems: 'baseline', gap: '14px', padding: '7px 0', borderBottom: '1px dashed var(--border)' }}>
+      <span style={{ fontSize: '11.5px', color: 'var(--text-tertiary)', whiteSpace: 'nowrap' }}>{label}</span>
+      <span style={{
+        fontSize: '12.5px', textAlign: 'right', wordBreak: 'break-word',
+        color: muted ? 'var(--text-tertiary)' : 'var(--text-primary)',
+        fontWeight: muted ? 400 : 600,
+        fontFamily: mono ? 'var(--font-mono)' : undefined,
+      }}>{value}</span>
+    </div>
+  )
+}
+
+function Panel({ icon, title, children, span }: { icon: React.ReactNode; title: string; children: React.ReactNode; span?: boolean }) {
+  return (
+    <div className="card" style={{ padding: '16px 20px', gridColumn: span ? '1 / -1' : undefined }}>
+      <div style={{ display: 'flex', alignItems: 'center', gap: '8px', marginBottom: '10px' }}>
+        {icon}
+        <span style={{ fontSize: '13px', fontWeight: 700, color: 'var(--text-primary)' }}>{title}</span>
+      </div>
+      {children}
+    </div>
+  )
+}
+
+export default function CardDetailPage() {
+  const { id } = useParams<{ id: string }>()
+  const { t, language } = useLanguage()
+  const locale = language === 'cs' ? 'cs-CZ' : 'en-US'
+
+  const { data: card, loading, unavailable, waking, reload } = useServiceResource<Card>(
+    id ? svcUrl('card-issuance-service', `/api/v1/cards/${id}`) : null,
+  )
+
+  const ops = useCardOperations(reload)
+  const [pending, setPending] = useState<CardTransition | null>(null)
+
+  // Context the card only carries as UUIDs. Each is best-effort: the card view must
+  // still render when party-service or account-service is asleep, so a failed lookup
+  // degrades to the identifier the card itself holds rather than to an error.
+  const [party, setParty] = useState<PartyRef | null>(null)
+  const [account, setAccount] = useState<AccountRef | null>(null)
+  const [entitlements, setEntitlements] = useState<CardEntitlements | null>(null)
+  const [siblings, setSiblings] = useState<Card[] | null>(null)
+
+  const partyId = card?.partyId
+  const accountId = card?.accountId
+  const productCode = card?.productCode
+
+  const fetchJson = useCallback(async <T,>(url: string): Promise<T | null> => {
+    try {
+      const res = await fetch(url, { signal: AbortSignal.timeout(8000), cache: 'no-store' })
+      if (!res.ok) { await classifyBffFailure(res); return null }
+      return (await res.json()) as T
+    } catch {
+      return null
+    }
+  }, [])
+
+  useEffect(() => {
+    if (!partyId) return
+    let cancelled = false
+    void (async () => {
+      const p = await fetchJson<PartyRef>(svcUrl('party-service', `/api/v1/parties/${partyId}`))
+      if (!cancelled) setParty(p)
+      const cards = await fetchJson<Card[]>(svcUrl('card-issuance-service', `/api/v1/cards/party/${partyId}`))
+      if (!cancelled) setSiblings(Array.isArray(cards) ? cards : null)
+    })()
+    return () => { cancelled = true }
+  }, [partyId, fetchJson])
+
+  useEffect(() => {
+    if (!accountId) return
+    let cancelled = false
+    void (async () => {
+      const a = await fetchJson<AccountRef>(svcUrl('account-service', `/api/v1/accounts/${accountId}`))
+      if (!cancelled) setAccount(a)
+    })()
+    return () => { cancelled = true }
+  }, [accountId, fetchJson])
+
+  useEffect(() => {
+    if (!partyId || !productCode) return
+    let cancelled = false
+    void (async () => {
+      const e = await fetchJson<CardEntitlements>(
+        svcUrl('card-issuance-service', `/api/v1/cards/party/${partyId}/entitlements`, { productCode }),
+      )
+      if (!cancelled) setEntitlements(e)
+    })()
+    return () => { cancelled = true }
+  }, [partyId, productCode, fetchJson])
+
+  const when = useCallback((iso: string | null | undefined): string => {
+    if (!iso) return '—'
+    const d = new Date(iso)
+    return Number.isNaN(d.getTime()) ? '—' : d.toLocaleString(locale)
+  }, [locale])
+
+  const quota = quotaOf(entitlements)
+  const otherCards = useMemo(
+    () => (siblings ?? []).filter(c => c.id !== card?.id),
+    [siblings, card?.id],
+  )
+
+  const onSelectTransition = (tr: CardTransition) => {
+    ops.setFeedback(null)
+    if (tr.irreversible) setPending(tr)
+    else if (card) void ops.runTransition(card, tr)
+  }
+
+  return (
+    <AuthGuard>
+      <div style={{ padding: '28px 32px', maxWidth: '1400px', animation: 'fadeIn 0.2s ease-out' }}>
+        <div style={{ marginBottom: '18px' }}>
+          <Link href="/cards" className="btn btn-ghost btn-sm" style={{ textDecoration: 'none' }}>
+            <ArrowLeft size={12} /> {t('Zpět na karty', 'Back to cards')}
+          </Link>
+        </div>
+
+        {loading ? (
+          <div style={{ padding: '48px', textAlign: 'center', color: 'var(--text-tertiary)', fontSize: '13px' }}>
+            <RefreshCw size={20} style={{ animation: 'spin 0.8s linear infinite', marginBottom: '8px' }} />
+            <div>{waking
+              ? t('Služba se probouzí…', 'The service is waking up…')
+              : t('Načítám kartu…', 'Loading the card…')}</div>
+          </div>
+        ) : unavailable || !card ? (
+          <DataUnavailable
+            kind={unavailable?.kind ?? 'not_found'}
+            service={t('Card-issuance-service', 'Card-issuance-service')}
+            feature={t('Detail karty', 'Card detail')}
+            lang={language}
+          />
+        ) : (
+          <>
+            {/* ── header ─────────────────────────────────────────────────── */}
+            <div style={{ display: 'flex', alignItems: 'flex-start', justifyContent: 'space-between', gap: '16px', flexWrap: 'wrap', marginBottom: '20px' }}>
+              <div>
+                <div style={{ display: 'flex', alignItems: 'center', gap: '10px', marginBottom: '6px' }}>
+                  <CreditCard size={20} style={{ color: 'var(--accent)' }} />
+                  <h1 style={{ fontSize: '22px', fontWeight: 800, color: 'var(--text-primary)', letterSpacing: '-0.02em', fontFamily: 'var(--font-mono)' }}>
+                    {card.maskedPan}
+                  </h1>
+                  <CardStatusChip status={card.status} current />
+                </div>
+                <p style={{ fontSize: '12.5px', color: 'var(--text-secondary)' }}>
+                  {[card.cardType, card.network, card.productCode, card.currency].filter(Boolean).join(' · ')}
+                </p>
+              </div>
+              <div style={{ display: 'flex', gap: '8px', alignItems: 'center', flexWrap: 'wrap' }}>
+                <CardTransitionButtons card={card} busy={ops.busy} onSelect={onSelectTransition} />
+                <button className="btn btn-ghost btn-sm" onClick={reload} disabled={ops.busy !== null}>
+                  <RefreshCw size={12} /> {t('Obnovit', 'Refresh')}
+                </button>
+              </div>
+            </div>
+
+            <CardOperationFeedback feedback={ops.feedback} onDismiss={() => ops.setFeedback(null)} />
+
+            {/* ── PCI boundary, stated once, visibly ─────────────────────── */}
+            <div style={{
+              display: 'flex', gap: '9px', alignItems: 'flex-start', marginBottom: '18px',
+              padding: '9px 13px', borderRadius: '8px', fontSize: '12px',
+              background: 'var(--surface-2)', border: '1px solid var(--border)', color: 'var(--text-secondary)',
+            }}>
+              <ShieldCheck size={14} style={{ color: 'var(--success)', flexShrink: 0, marginTop: '1px' }} />
+              <span>{t(
+                'Zpětná kancelář zobrazuje jen maskovaný PAN. Úplné číslo karty ani CVV zde záměrně nejsou dostupné (PCI DSS) — vidí je pouze držitel ve svém mobilním bankovnictví.',
+                'The back office shows the masked PAN only. The full card number and CVV are deliberately not available here (PCI DSS) — only the cardholder sees them, in the mobile app.',
+              )}</span>
+            </div>
+
+            <div style={{ display: 'grid', gridTemplateColumns: 'repeat(auto-fit, minmax(320px, 1fr))', gap: '16px', alignItems: 'start' }}>
+              {/* ── the card itself ──────────────────────────────────────── */}
+              <Panel icon={<CreditCard size={15} style={{ color: 'var(--accent)' }} />} title={t('Karta', 'Card')}>
+                <Row label={t('Maskovaný PAN', 'Masked PAN')} value={card.maskedPan} mono />
+                <Row label={t('Typ', 'Type')} value={card.cardType} />
+                <Row label={t('Síť', 'Network')} value={card.network} />
+                <Row label={t('Produkt', 'Product')} value={card.productCode} mono />
+                <Row label={t('Měna', 'Currency')} value={card.currency} />
+                <Row label={t('Platnost do', 'Expires')} value={card.expiryDate || '—'} mono />
+                <Row label={t('Držitel', 'Cardholder')} value={card.cardholderName || '—'} />
+                <Row label={t('Jméno na kartě', 'Embossed name')} value={card.embossedName || '—'} mono />
+                <Row label={t('Doručovací adresa', 'Delivery address')} value={card.deliveryAddress || '—'} muted={!card.deliveryAddress} />
+                <Row label={t('ID karty', 'Card ID')} value={card.id} mono muted />
+              </Panel>
+
+              {/* ── holder + account ─────────────────────────────────────── */}
+              <Panel icon={<User size={15} style={{ color: 'var(--accent)' }} />} title={t('Klient a účet', 'Client and account')}>
+                <Row
+                  label={t('Klient', 'Client')}
+                  value={party
+                    ? <Link href={`/parties/${card.partyId}`} style={{ color: 'var(--accent)', textDecoration: 'none' }}>
+                        {party.tradingName?.trim() || party.legalName?.trim() || card.partyId}
+                      </Link>
+                    : <Link href={`/parties/${card.partyId}`} style={{ color: 'var(--accent)', textDecoration: 'none', fontFamily: 'var(--font-mono)', fontSize: '11.5px' }}>{card.partyId}</Link>}
+                />
+                {party?.email && <Row label={t('E-mail', 'E-mail')} value={party.email} muted />}
+                {party?.kycStatus && <Row label={t('Stav KYC', 'KYC status')} value={party.kycStatus} />}
+                <Row
+                  label={t('Účet', 'Account')}
+                  value={account
+                    ? <Link href={`/accounts/${card.accountId}`} style={{ color: 'var(--accent)', textDecoration: 'none', fontFamily: 'var(--font-mono)' }}>
+                        {account.accountNumber}
+                      </Link>
+                    : <Link href={`/accounts/${card.accountId}`} style={{ color: 'var(--accent)', textDecoration: 'none', fontFamily: 'var(--font-mono)', fontSize: '11.5px' }}>{card.accountId}</Link>}
+                />
+                {account && <Row label={t('Typ účtu', 'Account type')} value={`${account.accountType} · ${account.currencyCode} · ${account.status}`} />}
+
+                <div style={{ marginTop: '12px', fontSize: '11.5px', color: 'var(--text-secondary)' }}>
+                  {quota.known
+                    ? t(
+                      `Klient drží ${quota.issued} z ${quota.max} karet povolených produktem ${card.productCode}.`,
+                      `The client holds ${quota.issued} of the ${quota.max} cards product ${card.productCode} allows.`,
+                    )
+                    : t(
+                      'Nárok na karty u tohoto produktu se nepodařilo zjistit — limit počtu karet tedy není znám.',
+                      'The card entitlement for this product could not be read, so the cap is unknown.',
+                    )}
+                </div>
+
+                {otherCards.length > 0 && (
+                  <div style={{ marginTop: '10px' }}>
+                    <div style={{ fontSize: '11px', fontWeight: 700, letterSpacing: '0.04em', textTransform: 'uppercase', color: 'var(--text-tertiary)', marginBottom: '6px' }}>
+                      {t('Další karty klienta', 'The client’s other cards')}
+                    </div>
+                    <div style={{ display: 'grid', gap: '5px' }}>
+                      {otherCards.map(c => (
+                        <Link key={c.id} href={`/cards/${c.id}`} style={{
+                          display: 'flex', alignItems: 'center', justifyContent: 'space-between', gap: '10px',
+                          padding: '6px 9px', borderRadius: '6px', background: 'var(--surface-2)',
+                          border: '1px solid var(--border)', textDecoration: 'none',
+                        }}>
+                          <span style={{ fontFamily: 'var(--font-mono)', fontSize: '11.5px', color: 'var(--text-primary)' }}>{c.maskedPan}</span>
+                          <span style={{ display: 'flex', gap: '6px', alignItems: 'center' }}>
+                            <span style={{ fontSize: '11px', color: 'var(--text-tertiary)' }}>{c.cardType}</span>
+                            <CardStatusChip status={c.status} small />
+                          </span>
+                        </Link>
+                      ))}
+                    </div>
+                  </div>
+                )}
+              </Panel>
+
+              {/* ── operator parity: limits + channels ───────────────────── */}
+              {/* The `key` carries the server's own values: when the service hands
+                  back a changed card the editor remounts on the new truth instead
+                  of keeping a stale draft alive. */}
+              <CardLimitsPanel
+                key={`limits-${card.dailyLimitMinorUnits}-${card.monthlyLimitMinorUnits}-${card.status}`}
+                card={card}
+                busy={ops.busy}
+                onSave={(daily, monthly) => ops.saveLimits(card, daily, monthly)}
+              />
+              <CardControlsPanel
+                key={`controls-${card.contactlessEnabled}-${card.onlineEnabled}-${card.atmEnabled}-${card.abroadEnabled}-${card.status}`}
+                card={card}
+                busy={ops.busy}
+                onSave={controls => ops.saveControls(card, controls)}
+              />
+
+              {/* ── audit trail ─────────────────────────────────────────── */}
+              <Panel icon={<Clock size={15} style={{ color: 'var(--accent)' }} />} title={t('Časová osa', 'Timeline')}>
+                <Row label={t('Vytvořeno', 'Created')} value={when(card.createdAt)} />
+                <Row label={t('Aktivováno', 'Activated')} value={when(card.activatedAt)} muted={!card.activatedAt} />
+                <Row label={t('Blokováno', 'Blocked')} value={when(card.blockedAt)} muted={!card.blockedAt} />
+                {card.blockedReason && (
+                  <Row label={t('Důvod', 'Reason')} value={card.blockedReason} />
+                )}
+                <Row label={t('Naposledy změněno', 'Last changed')} value={when(card.updatedAt)} />
+                <div style={{ marginTop: '10px', display: 'flex', gap: '7px', fontSize: '11px', color: 'var(--text-tertiary)' }}>
+                  <Info size={12} style={{ flexShrink: 0, marginTop: '1px' }} />
+                  <span>{t(
+                    'Kdo změnu provedl, nese auditní stopa služby: každou operaci portál podepisuje identitou operátora ze session (X-Operator-Id), kterou card-issuance zapisuje do události CardStatusChanged.',
+                    'Who made a change lives on the service’s audit trail: the portal signs every operation with the operator identity from the session (X-Operator-Id), which card-issuance stamps onto the CardStatusChanged event.',
+                  )}</span>
+                </div>
+              </Panel>
+
+              {/* ── the state machine, with this card ringed ─────────────── */}
+              <div style={{ gridColumn: '1 / -1' }}>
+                <CardLifecycleMap current={card.status} compact />
+              </div>
+            </div>
+
+            {/* entitlement detail, kept out of the way but reachable */}
+            {entitlements && (
+              <div style={{ marginTop: '16px' }}>
+                <Panel icon={<Landmark size={15} style={{ color: 'var(--accent)' }} />} title={t('Nárok na karty', 'Card entitlement')} span>
+                  <div style={{ display: 'grid', gridTemplateColumns: 'repeat(auto-fit, minmax(200px, 1fr))', gap: '0 20px' }}>
+                    <Row label={t('Produkt', 'Product')} value={entitlements.productCode} mono />
+                    <Row label={t('Vydáno / maximum', 'Issued / cap')} value={quota.known ? `${quota.issued} / ${quota.max}` : t('neznámo', 'unknown')} />
+                    <Row label={t('Virtuální karty', 'Virtual cards')} value={entitlements.virtualCardAllowed ? t('povoleny', 'allowed') : t('nepovoleny', 'not allowed')} />
+                    <Row label={t('Jednorázové karty', 'Single-use cards')} value={entitlements.singleUseAllowed ? t('povoleny', 'allowed') : t('nepovoleny', 'not allowed')} />
+                    <Row label={t('Sítě', 'Networks')} value={entitlements.networks.join(', ') || '—'} />
+                    <Row label={t('Měsíční poplatek za kartu', 'Monthly fee per card')} value={String(entitlements.monthlyFeePerCard)} />
+                    <Row label={t('Zdroj', 'Source')} value={entitlements.source} muted />
+                  </div>
+                </Panel>
+              </div>
+            )}
+          </>
+        )}
+      </div>
+
+      {pending && card && (
+        <ConfirmTransitionDialog
+          card={card}
+          transition={pending}
+          busy={ops.busy !== null}
+          onCancel={() => setPending(null)}
+          onConfirm={reason => void ops.runTransition(card, pending, reason).then(ok => { if (ok) setPending(null) })}
+        />
+      )}
+    </AuthGuard>
+  )
+}

--- a/openbank-admin-ui/src/app/cards/page.tsx
+++ b/openbank-admin-ui/src/app/cards/page.tsx
@@ -4,253 +4,44 @@
 
 'use client'
 import { useCallback, useMemo, useState } from 'react'
+import { useRouter } from 'next/navigation'
+import Link from 'next/link'
 import { useLanguage } from '@/lib/i18n/LanguageContext'
 import {
-  CreditCard, Search, RefreshCw, CheckCircle2, XCircle, Clock,
-  PauseCircle, PlayCircle, ShieldX, Ban, AlertTriangle, Info,
+  CreditCard, Search, RefreshCw, CheckCircle2, XCircle, Clock, ChevronRight, Plus, ShieldCheck,
 } from 'lucide-react'
 import { AuthGuard } from '@/components/auth/AuthGuard'
-import { svcUrl, classifyBffFailure, type BffFailure } from '@/lib/services/bff'
+import { svcUrl } from '@/lib/services/bff'
 import { useServiceResource } from '@/lib/services/useServiceResource'
 import { DataUnavailable } from '@/components/feedback/DataUnavailable'
 import { ServiceStatusBadge } from '@/components/feedback/ServiceStatusBadge'
-import {
-  legalTransitions, isTerminal, type CardAction, type CardTransition,
-} from '@/lib/cards/lifecycle'
+import { CARD_STATUSES, type CardTransition } from '@/lib/cards/lifecycle'
+import { CARD_TYPES, type Card } from '@/lib/cards/types'
+import { cardStatusColor, CardStatusChip } from '@/components/cards/CardStatusChip'
+import { CardLifecycleMap } from '@/components/cards/CardLifecycleMap'
+import { CardTransitionButtons } from '@/components/cards/CardTransitionButtons'
+import { ConfirmTransitionDialog } from '@/components/cards/ConfirmTransitionDialog'
+import { CardOperationFeedback } from '@/components/cards/CardOperationFeedback'
+import { IssueCardDialog } from '@/components/cards/IssueCardDialog'
+import { useCardOperations } from '@/lib/cards/useCardOperations'
 
-interface Card {
-  id: string; partyId: string; accountId: string; maskedPan: string
-  cardType: string; status: string; expiryDate: string; createdAt: string
-  blockedReason?: string | null
-}
+// Admin-UI rule #2: page the render. `GET /api/v1/cards` is an unpaginated
+// list-all on the service side, so the cap has to be applied here — a portfolio
+// of thousands of cards must not become thousands of DOM rows.
+const PAGE_SIZE = 25
 
-const STATUS_COLORS: Record<string, { bg: string; text: string; border: string }> = {
-  ACTIVE:    { bg: 'var(--success-bg)',  text: 'var(--success-text)',  border: 'var(--success-border)' },
-  SUSPENDED: { bg: 'var(--accent-bg)',   text: 'var(--accent-text)',   border: 'var(--accent-border)' },
-  BLOCKED:   { bg: 'var(--danger-bg)',   text: 'var(--danger-text)',   border: 'var(--danger-border)' },
-  EXPIRED:   { bg: 'var(--surface-3)',   text: 'var(--text-tertiary)', border: 'var(--border)' },
-  CANCELLED: { bg: 'var(--surface-3)',   text: 'var(--text-tertiary)', border: 'var(--border)' },
-  PENDING:   { bg: 'var(--warning-bg)',  text: 'var(--warning-text)',  border: 'var(--warning-border)' },
-}
-
-const ACTION_ICON: Record<CardAction, React.ElementType> = {
-  activate: PlayCircle, resume: PlayCircle, suspend: PauseCircle, block: ShieldX, cancel: Ban,
-}
-
-// ── Mutation outcomes ───────────────────────────────────────────────────────
-// `classifyBffFailure` is built for reads and lumps every 4xx that isn't 401/404
-// into `error`. A lifecycle POST has three failure modes an operator must be able
-// to tell apart, so they get their own kinds:
-//   400 — the aggregate refused the transition. Card.kt guards each transition
-//         with `require(...)`; an IllegalArgumentException is mapped to a bare 400
-//         by libs' CommonExceptionMappers (NOT 409 — see the report/comment in
-//         lifecycle.ts). In practice this means the card moved under us.
-//   409 — CardEntitlementException: a product rule conflicts with the request.
-//   403 — the operator's Keycloak roles don't cover this endpoint.
-type MutationFailure = BffFailure | 'illegal_transition' | 'conflict' | 'forbidden'
-
-async function classifyMutation(res: Response): Promise<MutationFailure> {
-  if (res.status === 400 || res.status === 422) return 'illegal_transition'
-  if (res.status === 409) return 'conflict'
-  if (res.status === 403) return 'forbidden'
-  return classifyBffFailure(res)
-}
-
-type Feedback =
-  | { tone: 'ok'; text: string }
-  | { tone: 'info'; text: string }
-  | { tone: 'error'; text: string }
-
-// ── Lifecycle map ───────────────────────────────────────────────────────────
-// Always visible, above the table: an operator should be able to read the state
-// machine off the screen instead of off Card.kt. Split by reversibility, because
-// that is the distinction that actually matters when you're about to click:
-// the top rail is undo-able, the bottom band is not.
-
-function StateChip({ status, current, small }: { status: string; current?: boolean; small?: boolean }) {
-  const c = STATUS_COLORS[status] ?? STATUS_COLORS.PENDING
-  return (
-    <span style={{
-      padding: small ? '1px 7px' : '3px 10px', borderRadius: '10px',
-      fontSize: small ? '10px' : '11px', fontWeight: 700, whiteSpace: 'nowrap',
-      background: c.bg, color: c.text,
-      border: `1px solid ${current ? 'var(--accent)' : c.border}`,
-      boxShadow: current ? '0 0 0 3px var(--accent-bg)' : 'none',
-    }}>{status}</span>
-  )
-}
-
-function Arrow({ label, back }: { label: string; back?: boolean }) {
-  return (
-    <span style={{ display: 'inline-flex', flexDirection: 'column', alignItems: 'center', margin: '0 6px' }}>
-      <span style={{ fontSize: '10px', color: 'var(--text-tertiary)', fontWeight: 600, whiteSpace: 'nowrap' }}>{label}</span>
-      <span style={{ fontSize: '13px', color: 'var(--border-strong)', lineHeight: 1 }}>{back ? '⇄' : '→'}</span>
-    </span>
-  )
-}
-
-function LifecycleMap({ current }: { current?: string }) {
-  const { t } = useLanguage()
-  const row: React.CSSProperties = { display: 'flex', alignItems: 'center', flexWrap: 'wrap', gap: '4px' }
-  const caption: React.CSSProperties = {
-    fontSize: '10px', fontWeight: 700, letterSpacing: '0.06em', textTransform: 'uppercase',
-    color: 'var(--text-tertiary)', marginBottom: '8px',
-  }
-  return (
-    <div className="card" style={{ padding: '16px 20px', marginBottom: '24px' }}>
-      <div style={{ display: 'flex', alignItems: 'baseline', justifyContent: 'space-between', gap: '12px', marginBottom: '14px' }}>
-        <div style={{ fontSize: '13px', fontWeight: 700, color: 'var(--text-primary)' }}>
-          {t('Životní cyklus karty', 'Card lifecycle')}
-        </div>
-        <div style={{ fontSize: '11px', color: 'var(--text-tertiary)' }}>
-          {current
-            ? t('Zvýrazněný stav patří vybrané kartě.', 'The highlighted state is the selected card’s.')
-            : t('Vyberte kartu v tabulce a její stav se zvýrazní.', 'Select a card below to highlight its state.')}
-        </div>
-      </div>
-
-      <div style={{ display: 'grid', gap: '14px' }}>
-        <div>
-          <div style={caption}>{t('Vratné přechody', 'Reversible transitions')}</div>
-          <div style={row}>
-            <StateChip status="PENDING" current={current === 'PENDING'} />
-            <Arrow label={t('aktivovat', 'activate')} />
-            <StateChip status="ACTIVE" current={current === 'ACTIVE'} />
-            <Arrow label={t('pozastavit / obnovit', 'suspend / resume')} back />
-            <StateChip status="SUSPENDED" current={current === 'SUSPENDED'} />
-          </div>
-        </div>
-
-        <div style={{ borderTop: '1px dashed var(--border)', paddingTop: '12px' }}>
-          <div style={caption}>{t('Nevratné přechody — vyžadují potvrzení a důvod', 'Irreversible transitions — confirmation and a reason required')}</div>
-          <div style={{ display: 'grid', gap: '8px' }}>
-            <div style={row}>
-              <StateChip status="ACTIVE" small />
-              <StateChip status="SUSPENDED" small />
-              <Arrow label={t('blokovat', 'block')} />
-              <StateChip status="BLOCKED" current={current === 'BLOCKED'} />
-            </div>
-            <div style={row}>
-              <StateChip status="PENDING" small />
-              <StateChip status="ACTIVE" small />
-              <StateChip status="SUSPENDED" small />
-              <StateChip status="BLOCKED" small />
-              <Arrow label={t('zrušit', 'cancel')} />
-              <StateChip status="CANCELLED" current={current === 'CANCELLED'} />
-            </div>
-          </div>
-        </div>
-
-        <div style={{ borderTop: '1px dashed var(--border)', paddingTop: '12px', display: 'flex', alignItems: 'center', gap: '8px', flexWrap: 'wrap' }}>
-          <StateChip status="EXPIRED" current={current === 'EXPIRED'} />
-          <span style={{ fontSize: '11px', color: 'var(--text-tertiary)' }}>
-            {t(
-              'Stav existuje v modelu, ale card-issuance nemá žádnou úlohu expirace — zatím ho tedy žádná karta nedosáhne.',
-              'The status exists in the model, but card-issuance runs no expiry job — no card reaches it today.',
-            )}
-          </span>
-        </div>
-      </div>
-    </div>
-  )
-}
-
-// ── Confirmation for the irreversible transitions ───────────────────────────
-
-function ConfirmDialog({
-  card, transition, busy, onCancel, onConfirm,
-}: {
-  card: Card
-  transition: CardTransition
-  busy: boolean
-  onCancel: () => void
-  onConfirm: (reason: string) => void
-}) {
-  const { t } = useLanguage()
-  const [reason, setReason] = useState('')
-  const label = transition.action === 'block'
-    ? t('Blokovat kartu', 'Block card')
-    : t('Zrušit kartu', 'Cancel card')
-
-  return (
-    <div
-      role="dialog"
-      aria-modal="true"
-      aria-label={label}
-      style={{
-        position: 'fixed', inset: 0, zIndex: 60, background: 'rgba(15,23,42,0.45)',
-        display: 'flex', alignItems: 'center', justifyContent: 'center', padding: '24px',
-      }}
-    >
-      <div className="card" style={{ width: '100%', maxWidth: '460px', padding: '22px 24px', background: 'var(--surface-1)' }}>
-        <div style={{ display: 'flex', gap: '10px', alignItems: 'flex-start', marginBottom: '14px' }}>
-          <AlertTriangle size={18} style={{ color: 'var(--danger)', flexShrink: 0, marginTop: '2px' }} />
-          <div>
-            <div style={{ fontSize: '15px', fontWeight: 700, color: 'var(--text-primary)' }}>{label}</div>
-            <div style={{ fontSize: '12px', color: 'var(--text-secondary)', marginTop: '4px' }}>
-              {t('Tuto operaci nelze vzít zpět.', 'This operation cannot be undone.')}
-            </div>
-          </div>
-        </div>
-
-        <div style={{
-          display: 'flex', alignItems: 'center', gap: '8px', flexWrap: 'wrap',
-          padding: '10px 12px', borderRadius: '8px', background: 'var(--surface-2)', marginBottom: '14px',
-        }}>
-          <span style={{ fontFamily: 'var(--font-mono)', fontSize: '12px', color: 'var(--text-primary)' }}>{card.maskedPan}</span>
-          <StateChip status={card.status} small />
-          <span style={{ fontSize: '12px', color: 'var(--text-tertiary)' }}>{'→'}</span>
-          <StateChip status={transition.to} small />
-        </div>
-
-        <label style={{ display: 'block', fontSize: '12px', fontWeight: 600, color: 'var(--text-secondary)', marginBottom: '6px' }}>
-          {t('Důvod (povinný, zapíše se do auditu karty)', 'Reason (required, recorded on the card’s audit trail)')}
-        </label>
-        <textarea
-          value={reason}
-          onChange={e => setReason(e.target.value)}
-          rows={3}
-          aria-label={t('Důvod operace', 'Reason for the operation')}
-          style={{
-            width: '100%', padding: '8px 10px', borderRadius: '6px', border: '1px solid var(--border)',
-            fontSize: '13px', background: 'var(--surface-2)', color: 'var(--text-primary)',
-            outline: 'none', resize: 'vertical', fontFamily: 'inherit',
-          }}
-        />
-
-        <div style={{ display: 'flex', justifyContent: 'flex-end', gap: '8px', marginTop: '16px' }}>
-          <button className="btn btn-ghost btn-sm" onClick={onCancel} disabled={busy}>
-            {t('Zpět', 'Back')}
-          </button>
-          <button
-            className="btn btn-danger btn-sm"
-            disabled={busy || reason.trim().length === 0}
-            onClick={() => onConfirm(reason.trim())}
-          >
-            {busy
-              ? t('Odesílám…', 'Submitting…')
-              : transition.action === 'block'
-                ? t('Potvrdit blokaci', 'Confirm block')
-                : t('Potvrdit zrušení', 'Confirm cancellation')}
-          </button>
-        </div>
-      </div>
-    </div>
-  )
-}
+const ALL = '__ALL__'
 
 export default function CardsPage() {
   const { t, language } = useLanguage()
+  const router = useRouter()
   const [search, setSearch] = useState('')
-  const [selectedId, setSelectedId] = useState<string | null>(null)
+  const [statusFilter, setStatusFilter] = useState<string>(ALL)
+  const [typeFilter, setTypeFilter] = useState<string>(ALL)
+  const [highlighted, setHighlighted] = useState<string | null>(null)
+  const [visible, setVisible] = useState(PAGE_SIZE)
   const [pending, setPending] = useState<{ card: Card; transition: CardTransition } | null>(null)
-  const [busy, setBusy] = useState<string | null>(null)
-  const [feedback, setFeedback] = useState<Feedback | null>(null)
-
-  // NOTE: X-Operator-Id is NOT set here. The BFF proxy derives it from the server
-  // session and refuses to forward a client-supplied one — a browser can set any
-  // header, so an operator identity chosen in the browser is not evidence of
-  // anything. See src/app/api/svc/[service]/[...path]/route.ts.
+  const [issuing, setIssuing] = useState(false)
 
   // Single graceful data path (admin-ui rule #1): the hook classifies a non-OK
   // BFF response and auto-wakes a scaled-to-zero pod (KEDA, ADR-0057) instead of
@@ -261,115 +52,46 @@ export default function CardsPage() {
   )
   const cards = useMemo(() => data ?? [], [data])
 
-  const filtered = cards.filter(c =>
-    c.maskedPan?.includes(search) || c.cardType?.toLowerCase().includes(search.toLowerCase()) ||
-    c.status?.toLowerCase().includes(search.toLowerCase())
-  )
-  const selected = cards.find(c => c.id === selectedId) ?? null
+  // Every write goes through one hook, so the list and the detail view classify,
+  // explain and four-eyes-handle a failure identically.
+  const ops = useCardOperations(reload)
 
-  const failureCopy = useCallback((kind: MutationFailure): string => {
-    switch (kind) {
-      case 'illegal_transition':
-        return t(
-          'Tento přechod už z aktuálního stavu karty nevede — stav se mezitím změnil. Obnovte seznam a zkuste to znovu.',
-          'That transition no longer leads anywhere from the card’s current status — it changed in the meantime. Refresh the list and try again.',
-        )
-      case 'conflict':
-        return t(
-          'Služba operaci odmítla kvůli konfliktu s pravidlem produktu (nárok na kartu).',
-          'The service refused the operation as conflicting with a product rule (card entitlement).',
-        )
-      case 'forbidden':
-        return t(
-          'Vaše role nemá oprávnění pro tuto operaci s kartou — vyžaduje se operátor, správce nebo compliance.',
-          'Your role is not permitted to perform this card operation — operator, admin or compliance is required.',
-        )
-      case 'unauthorized':
-        return t(
-          'Vaše přihlášení vypršelo. Přihlaste se prosím znovu a operaci zopakujte.',
-          'Your session has expired. Please sign in again and repeat the operation.',
-        )
-      case 'not_found':
-        return t(
-          'Tato karta už v card-issuance neexistuje. Obnovte seznam.',
-          'This card no longer exists in card-issuance. Refresh the list.',
-        )
-      case 'not_deployed':
-        return t(
-          'card-issuance není v tomto prostředí nasazená, takže operaci nelze provést.',
-          'card-issuance is not deployed in this environment, so the operation cannot run.',
-        )
-      case 'scaled_to_zero':
-        return t(
-          'card-issuance je uspaná do nuly replik (KEDA) a právě se probouzí. Zkuste to prosím za okamžik znovu.',
-          'card-issuance is scaled to zero (KEDA) and is waking up. Please try again in a moment.',
-        )
-      case 'unreachable':
-        return t(
-          'card-issuance je nasazená, ale na požadavek neodpověděla včas. Zkuste to prosím za chvíli znovu.',
-          'card-issuance is deployed but did not answer in time. Please try again shortly.',
-        )
-      default:
-        return t(
-          'Operace se nedokončila. Zkuste to prosím znovu; podrobnosti jsou v auditním logu služby.',
-          'The operation did not complete. Please try again; the details are in the service audit log.',
-        )
-    }
-  }, [t])
+  const filtered = useMemo(() => {
+    const needle = search.trim().toLowerCase()
+    return cards.filter(c => {
+      if (statusFilter !== ALL && c.status !== statusFilter) return false
+      if (typeFilter !== ALL && c.cardType !== typeFilter) return false
+      if (!needle) return true
+      return (
+        c.maskedPan?.toLowerCase().includes(needle) ||
+        c.cardholderName?.toLowerCase().includes(needle) ||
+        c.productCode?.toLowerCase().includes(needle) ||
+        String(c.cardType).toLowerCase().includes(needle) ||
+        String(c.status).toLowerCase().includes(needle)
+      )
+    })
+  }, [cards, search, statusFilter, typeFilter])
 
-  const run = useCallback(async (card: Card, transition: CardTransition, reason?: string) => {
-    setBusy(`${card.id}:${transition.action}`)
-    setFeedback(null)
-    try {
-      const res = await fetch(svcUrl('card-issuance-service', `/api/v1/cards/${card.id}/${transition.action}`), {
-        method: 'POST',
-        headers: { 'Content-Type': 'application/json' },
-        // Only block/cancel take a body (CardStatusRequest); the reversible
-        // endpoints declare no entity parameter.
-        body: transition.reason ? JSON.stringify({ reason }) : undefined,
-        cache: 'no-store',
-        signal: AbortSignal.timeout(15_000),
-      })
-      // ADR-0155 four-eyes: an action OPA flags as dual-control is parked, not
-      // applied, and answers 202. Treating that as success would tell the
-      // operator the card moved when it did not.
-      if (res.status === 202) {
-        setFeedback({
-          tone: 'info',
-          text: t(
-            'Operace čeká na schválení druhým operátorem (čtyři oči).',
-            'The operation is queued for a second operator’s approval (four-eyes).',
-          ),
-        })
-        setPending(null)
-        return
-      }
-      if (!res.ok) {
-        setFeedback({ tone: 'error', text: failureCopy(await classifyMutation(res)) })
-        return
-      }
-      setFeedback({
-        tone: 'ok',
-        text: t(
-          `Karta ${card.maskedPan} je nyní ve stavu ${transition.to}.`,
-          `Card ${card.maskedPan} is now ${transition.to}.`,
-        ),
-      })
-      setPending(null)
-      // Refresh so the row status and the summary tiles agree with the service.
-      reload()
-    } catch {
-      setFeedback({ tone: 'error', text: failureCopy('unreachable') })
-    } finally {
-      setBusy(null)
-    }
-  }, [reload, t, failureCopy])
+  const page = filtered.slice(0, visible)
+  const highlightedCard = cards.find(c => c.id === highlighted) ?? null
 
-  const feedbackStyle = (tone: Feedback['tone']) => ({
-    ok: { bg: 'var(--success-bg)', border: 'var(--success-border)', color: 'var(--success-text)' },
-    info: { bg: 'var(--accent-bg)', border: 'var(--accent-border)', color: 'var(--accent-text)' },
-    error: { bg: 'var(--danger-bg)', border: 'var(--danger-border)', color: 'var(--danger-text)' },
-  }[tone])
+  const open = useCallback((cardId: string) => router.push(`/cards/${cardId}`), [router])
+
+  const onSelectTransition = (card: Card, tr: CardTransition) => {
+    setHighlighted(card.id)
+    ops.setFeedback(null)
+    if (tr.irreversible) setPending({ card, transition: tr })
+    else void ops.runTransition(card, tr)
+  }
+
+  const countBy = (status: string) => cards.filter(c => c.status === status).length
+
+  const chip = (active: boolean): React.CSSProperties => ({
+    padding: '4px 11px', borderRadius: '999px', fontSize: '11px', fontWeight: 700, cursor: 'pointer',
+    background: active ? 'var(--accent-bg)' : 'var(--surface-2)',
+    color: active ? 'var(--accent-text)' : 'var(--text-secondary)',
+    border: `1px solid ${active ? 'var(--accent)' : 'var(--border)'}`,
+  })
 
   return (
     <AuthGuard>
@@ -396,11 +118,9 @@ export default function CardsPage() {
                 checking: t('Zjišťuji stav služby…', 'Checking service…'),
               }}
             />
-            {/* Issuance is customer-initiated (app / onboarding). The portal has no
-                account picker to hang it off — account-service serves lookups, not a
-                list (admin-ui rule #2) — so an operator-side issue form would mean
-                pasting raw partyId/accountId UUIDs. The decorative button that used
-                to sit here has been removed rather than half-wired. */}
+            <button className="btn btn-primary btn-sm" onClick={() => { ops.setFeedback(null); setIssuing(true) }}>
+              <Plus size={13} /> {t('Vydat kartu', 'Issue a card')}
+            </button>
             <button className="btn btn-ghost btn-sm" onClick={reload} disabled={loading}>
               <RefreshCw size={13} /> {t('Obnovit', 'Refresh')}
             </button>
@@ -411,9 +131,9 @@ export default function CardsPage() {
         <div className="grid-4" style={{ marginBottom: '24px' }}>
           {[
             { label: t('Celkem karet', 'Total cards'), value: cards.length, icon: <CreditCard size={16} />, color: 'var(--accent)' },
-            { label: t('Aktivní', 'Active'), value: cards.filter(c => c.status === 'ACTIVE').length, icon: <CheckCircle2 size={16} />, color: 'var(--success)' },
-            { label: t('Blokované', 'Blocked'), value: cards.filter(c => c.status === 'BLOCKED').length, icon: <XCircle size={16} />, color: 'var(--danger)' },
-            { label: t('Čekající', 'Pending'), value: cards.filter(c => c.status === 'PENDING').length, icon: <Clock size={16} />, color: 'var(--warning)' },
+            { label: t('Aktivní', 'Active'), value: countBy('ACTIVE'), icon: <CheckCircle2 size={16} />, color: 'var(--success)' },
+            { label: t('Blokované', 'Blocked'), value: countBy('BLOCKED'), icon: <XCircle size={16} />, color: 'var(--danger)' },
+            { label: t('Čekající', 'Pending'), value: countBy('PENDING'), icon: <Clock size={16} />, color: 'var(--warning)' },
           ].map(k => (
             <div key={k.label} className="stat-card">
               <div style={{ display: 'flex', alignItems: 'center', gap: '8px', marginBottom: '10px' }}>
@@ -426,41 +146,50 @@ export default function CardsPage() {
           ))}
         </div>
 
-        <LifecycleMap current={selected?.status} />
+        <CardLifecycleMap current={highlightedCard?.status} />
 
-        {feedback && (
-          <div style={{
-            display: 'flex', alignItems: 'flex-start', gap: '8px', marginBottom: '16px',
-            padding: '10px 14px', borderRadius: '8px', fontSize: '12.5px',
-            background: feedbackStyle(feedback.tone).bg,
-            border: `1px solid ${feedbackStyle(feedback.tone).border}`,
-            color: feedbackStyle(feedback.tone).color,
-          }}>
-            {feedback.tone === 'ok'
-              ? <CheckCircle2 size={15} style={{ flexShrink: 0, marginTop: '1px' }} />
-              : feedback.tone === 'info'
-                ? <Info size={15} style={{ flexShrink: 0, marginTop: '1px' }} />
-                : <AlertTriangle size={15} style={{ flexShrink: 0, marginTop: '1px' }} />}
-            <span style={{ flex: 1 }}>{feedback.text}</span>
-            <button
-              onClick={() => setFeedback(null)}
-              aria-label={t('Zavřít zprávu', 'Dismiss message')}
-              style={{ background: 'none', border: 'none', cursor: 'pointer', color: 'inherit', lineHeight: 1, padding: 0 }}
-            >{'×'}</button>
-          </div>
-        )}
+        <CardOperationFeedback feedback={ops.feedback} onDismiss={() => ops.setFeedback(null)} />
 
         {/* Table */}
         <div className="card">
-          <div style={{ padding: '16px 20px', borderBottom: '1px solid var(--border)', display: 'flex', gap: '10px', alignItems: 'center' }}>
-            <div style={{ position: 'relative', flex: 1 }}>
+          <div style={{ padding: '16px 20px', borderBottom: '1px solid var(--border)', display: 'grid', gap: '10px' }}>
+            <div style={{ position: 'relative' }}>
               <Search size={13} style={{ position: 'absolute', left: '10px', top: '50%', transform: 'translateY(-50%)', color: 'var(--text-tertiary)' }} />
-              <input value={search} onChange={e => setSearch(e.target.value)} placeholder={t('Hledat karty…', 'Search cards…')}
+              <input value={search} onChange={e => { setSearch(e.target.value); setVisible(PAGE_SIZE) }}
+                placeholder={t('Hledat podle PAN, držitele nebo produktu…', 'Search by PAN, cardholder or product…')}
                 aria-label={t('Hledat karty', 'Search cards')}
                 style={{ width: '100%', paddingLeft: '30px', paddingRight: '12px', height: '32px', borderRadius: '6px',
                   border: '1px solid var(--border)', fontSize: '13px', background: 'var(--surface-2)', color: 'var(--text-primary)', outline: 'none' }} />
             </div>
+            <div style={{ display: 'flex', gap: '12px', flexWrap: 'wrap', alignItems: 'center' }}>
+              <div role="group" aria-label={t('Filtr podle stavu', 'Filter by status')} style={{ display: 'flex', gap: '5px', flexWrap: 'wrap' }}>
+                <button style={chip(statusFilter === ALL)} onClick={() => { setStatusFilter(ALL); setVisible(PAGE_SIZE) }}>
+                  {t('Vše', 'All')} · {cards.length}
+                </button>
+                {CARD_STATUSES.filter(s => countBy(s) > 0).map(s => {
+                  const c = cardStatusColor(s)
+                  const active = statusFilter === s
+                  return (
+                    <button key={s} onClick={() => { setStatusFilter(active ? ALL : s); setVisible(PAGE_SIZE) }}
+                      style={{ ...chip(active), background: active ? c.bg : 'var(--surface-2)', color: active ? c.text : 'var(--text-secondary)', borderColor: active ? c.border : 'var(--border)' }}>
+                      {s} · {countBy(s)}
+                    </button>
+                  )
+                })}
+              </div>
+              <div role="group" aria-label={t('Filtr podle typu', 'Filter by type')} style={{ display: 'flex', gap: '5px', flexWrap: 'wrap' }}>
+                {CARD_TYPES.filter(ct => cards.some(c => c.cardType === ct)).map(ct => {
+                  const active = typeFilter === ct
+                  return (
+                    <button key={ct} style={chip(active)} onClick={() => { setTypeFilter(active ? ALL : ct); setVisible(PAGE_SIZE) }}>
+                      {ct}
+                    </button>
+                  )
+                })}
+              </div>
+            </div>
           </div>
+
           {loading ? (
             <div style={{ padding: '48px', textAlign: 'center', color: 'var(--text-tertiary)', fontSize: '13px' }}>
               <RefreshCw size={20} style={{ animation: 'spin 0.8s linear infinite', marginBottom: '8px' }} />
@@ -474,98 +203,98 @@ export default function CardsPage() {
                 ? t('Služba běží, zatím nebyly vydány žádné karty.', 'The service is running; no cards have been issued yet.')
                 : t('Žádné výsledky pro zadaný filtr.', 'No results for the applied filter.')} />
           ) : (
-            <table style={{ width: '100%', borderCollapse: 'collapse' }}>
-              <thead>
-                <tr style={{ borderBottom: '1px solid var(--border)' }}>
-                  {[t('PAN', 'PAN'), t('Typ', 'Type'), t('Status', 'Status'), t('Platnost', 'Expiry'),
-                    t('Party ID', 'Party ID'), t('Vytvořeno', 'Created'), t('Akce', 'Actions')].map(h => (
-                    <th key={h} style={{ padding: '10px 16px', textAlign: 'left', fontSize: '11px', fontWeight: 700,
-                      color: 'var(--text-tertiary)', textTransform: 'uppercase', letterSpacing: '0.05em' }}>{h}</th>
-                  ))}
-                </tr>
-              </thead>
-              <tbody>
-                {filtered.map(c => {
-                  const sc = STATUS_COLORS[c.status] ?? STATUS_COLORS.PENDING
-                  const isSelected = c.id === selectedId
-                  const transitions = legalTransitions(c.status)
-                  return (
-                    <tr key={c.id}
-                      onClick={() => setSelectedId(c.id)}
-                      style={{
-                        borderBottom: '1px solid var(--border)', cursor: 'pointer',
-                        background: isSelected ? 'var(--accent-bg)' : undefined,
-                        boxShadow: isSelected ? 'inset 3px 0 0 var(--accent)' : undefined,
-                      }}
-                      onMouseEnter={e => { if (!isSelected) e.currentTarget.style.background = 'var(--surface-2)' }}
-                      onMouseLeave={e => { if (!isSelected) e.currentTarget.style.background = '' }}>
-                      <td style={{ padding: '12px 16px', fontFamily: 'var(--font-mono)', fontSize: '13px', color: 'var(--text-primary)' }}>{c.maskedPan}</td>
-                      <td style={{ padding: '12px 16px', fontSize: '12px', color: 'var(--text-secondary)' }}>{c.cardType}</td>
-                      <td style={{ padding: '12px 16px' }}>
-                        <span style={{ padding: '2px 8px', borderRadius: '10px', fontSize: '11px', fontWeight: 600,
-                          background: sc.bg, color: sc.text, border: `1px solid ${sc.border}` }}>{c.status}</span>
-                      </td>
-                      <td style={{ padding: '12px 16px', fontSize: '12px', color: 'var(--text-secondary)' }}>{c.expiryDate}</td>
-                      <td style={{ padding: '12px 16px', fontFamily: 'var(--font-mono)', fontSize: '11px', color: 'var(--text-tertiary)' }}>{c.partyId?.slice(0,8)}…</td>
-                      <td style={{ padding: '12px 16px', fontSize: '12px', color: 'var(--text-tertiary)' }}>{c.createdAt ? new Date(c.createdAt).toLocaleDateString('cs-CZ') : '—'}</td>
-                      <td style={{ padding: '10px 16px' }} onClick={e => e.stopPropagation()}>
-                        {transitions.length === 0 ? (
-                          <span style={{ fontSize: '11px', color: 'var(--text-tertiary)' }}>
-                            {isTerminal(c.status)
-                              ? t('koncový stav', 'terminal state')
-                              : t('žádná akce', 'no action')}
-                          </span>
-                        ) : (
-                          <div style={{ display: 'flex', gap: '6px', flexWrap: 'wrap' }}>
-                            {transitions.map(tr => {
-                              const Icon = ACTION_ICON[tr.action]
-                              const running = busy === `${c.id}:${tr.action}`
-                              const label = {
-                                activate: t('Aktivovat', 'Activate'),
-                                resume: t('Obnovit', 'Resume'),
-                                suspend: t('Pozastavit', 'Suspend'),
-                                block: t('Blokovat', 'Block'),
-                                cancel: t('Zrušit', 'Cancel'),
-                              }[tr.action]
-                              return (
-                                <button
-                                  key={tr.action}
-                                  className={`btn btn-sm ${tr.irreversible ? 'btn-danger' : 'btn-ghost'}`}
-                                  disabled={busy !== null}
-                                  title={`${label} → ${tr.to}`}
-                                  onClick={() => {
-                                    setSelectedId(c.id)
-                                    setFeedback(null)
-                                    if (tr.irreversible) setPending({ card: c, transition: tr })
-                                    else void run(c, tr)
-                                  }}
-                                >
-                                  {running
-                                    ? <RefreshCw size={12} style={{ animation: 'spin 0.8s linear infinite' }} />
-                                    : <Icon size={12} />}
-                                  {label}
-                                </button>
-                              )
-                            })}
-                          </div>
-                        )}
-                      </td>
-                    </tr>
-                  )
-                })}
-              </tbody>
-            </table>
+            <>
+              <table style={{ width: '100%', borderCollapse: 'collapse' }}>
+                <thead>
+                  <tr style={{ borderBottom: '1px solid var(--border)' }}>
+                    {[t('PAN', 'PAN'), t('Typ', 'Type'), t('Status', 'Status'), t('Platnost', 'Expiry'),
+                      t('Držitel', 'Cardholder'), t('Vytvořeno', 'Created'), t('Akce', 'Actions'), ''].map((h, i) => (
+                      <th key={`${h}-${i}`} style={{ padding: '10px 16px', textAlign: 'left', fontSize: '11px', fontWeight: 700,
+                        color: 'var(--text-tertiary)', textTransform: 'uppercase', letterSpacing: '0.05em' }}>{h}</th>
+                    ))}
+                  </tr>
+                </thead>
+                <tbody>
+                  {page.map(c => {
+                    const sc = cardStatusColor(c.status)
+                    const isHighlighted = c.id === highlighted
+                    return (
+                      <tr key={c.id}
+                        tabIndex={0}
+                        aria-label={t(`Detail karty ${c.maskedPan}`, `Card detail ${c.maskedPan}`)}
+                        onClick={() => open(c.id)}
+                        onFocus={() => setHighlighted(c.id)}
+                        onMouseEnter={e => { setHighlighted(c.id); if (!isHighlighted) e.currentTarget.style.background = 'var(--surface-2)' }}
+                        onMouseLeave={e => { e.currentTarget.style.background = '' }}
+                        onKeyDown={e => {
+                          if (e.key === 'Enter' || e.key === ' ') { e.preventDefault(); open(c.id) }
+                        }}
+                        style={{
+                          borderBottom: '1px solid var(--border)', cursor: 'pointer',
+                          background: isHighlighted ? 'var(--accent-bg)' : undefined,
+                          boxShadow: isHighlighted ? 'inset 3px 0 0 var(--accent)' : undefined,
+                        }}>
+                        <td style={{ padding: '12px 16px', fontFamily: 'var(--font-mono)', fontSize: '13px', color: 'var(--text-primary)' }}>
+                          {/* A real anchor as well as a clickable row: middle-click,
+                              open-in-new-tab and "copy link" are how an operator puts a
+                              card into a ticket. */}
+                          <Link href={`/cards/${c.id}`} onClick={e => e.stopPropagation()}
+                            style={{ color: 'inherit', textDecoration: 'none' }}>{c.maskedPan}</Link>
+                        </td>
+                        <td style={{ padding: '12px 16px', fontSize: '12px', color: 'var(--text-secondary)' }}>{c.cardType}</td>
+                        <td style={{ padding: '12px 16px' }}>
+                          <span style={{ padding: '2px 8px', borderRadius: '10px', fontSize: '11px', fontWeight: 600,
+                            background: sc.bg, color: sc.text, border: `1px solid ${sc.border}` }}>{c.status}</span>
+                        </td>
+                        <td style={{ padding: '12px 16px', fontSize: '12px', color: 'var(--text-secondary)' }}>{c.expiryDate}</td>
+                        <td style={{ padding: '12px 16px', fontSize: '12px', color: 'var(--text-secondary)' }}>{c.cardholderName || '—'}</td>
+                        <td style={{ padding: '12px 16px', fontSize: '12px', color: 'var(--text-tertiary)' }}>{c.createdAt ? new Date(c.createdAt).toLocaleDateString(language === 'cs' ? 'cs-CZ' : 'en-US') : '—'}</td>
+                        <td style={{ padding: '10px 16px' }} onClick={e => e.stopPropagation()}>
+                          <CardTransitionButtons card={c} busy={ops.busy} onSelect={tr => onSelectTransition(c, tr)} />
+                        </td>
+                        <td style={{ padding: '10px 12px', color: 'var(--text-tertiary)' }}><ChevronRight size={14} /></td>
+                      </tr>
+                    )
+                  })}
+                </tbody>
+              </table>
+              <div style={{ padding: '12px 20px', display: 'flex', alignItems: 'center', justifyContent: 'space-between', gap: '10px', flexWrap: 'wrap' }}>
+                <span style={{ fontSize: '11.5px', color: 'var(--text-tertiary)' }}>
+                  {t(`Zobrazeno ${page.length} z ${filtered.length}`, `Showing ${page.length} of ${filtered.length}`)}
+                </span>
+                {page.length < filtered.length && (
+                  <button className="btn btn-ghost btn-sm" onClick={() => setVisible(v => v + PAGE_SIZE)}>
+                    {t('Načíst další', 'Load more')}
+                  </button>
+                )}
+              </div>
+            </>
           )}
+        </div>
+
+        <div style={{ display: 'flex', gap: '8px', alignItems: 'flex-start', marginTop: '14px', fontSize: '11.5px', color: 'var(--text-tertiary)' }}>
+          <ShieldCheck size={13} style={{ flexShrink: 0, marginTop: '1px', color: 'var(--success)' }} />
+          <span>{t(
+            'Portál pracuje výhradně s maskovaným PAN; úplné číslo karty ani CVV zde nejsou dostupné (PCI DSS).',
+            'The portal works with the masked PAN only; the full card number and CVV are not available here (PCI DSS).',
+          )}</span>
         </div>
       </div>
 
       {pending && (
-        <ConfirmDialog
+        <ConfirmTransitionDialog
           card={pending.card}
           transition={pending.transition}
-          busy={busy !== null}
+          busy={ops.busy !== null}
           onCancel={() => setPending(null)}
-          onConfirm={(reason) => void run(pending.card, pending.transition, reason)}
+          onConfirm={reason => void ops.runTransition(pending.card, pending.transition, reason).then(ok => { if (ok) setPending(null) })}
+        />
+      )}
+
+      {issuing && (
+        <IssueCardDialog
+          onClose={() => setIssuing(false)}
+          onIssued={card => { setIssuing(false); reload(); open(card.id) }}
         />
       )}
     </AuthGuard>

--- a/openbank-admin-ui/src/components/cards/CardControlsPanel.tsx
+++ b/openbank-admin-ui/src/components/cards/CardControlsPanel.tsx
@@ -1,0 +1,140 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright (c) OpenBank contributors. Licensed under the Apache License, Version 2.0.
+// See LICENSE in the repository root or https://www.apache.org/licenses/LICENSE-2.0 for details.
+
+// The four channel controls — contactless, online, ATM, abroad.
+//
+// `PUT /{id}/controls` takes ALL FOUR every time (UpdateControlsRequest has no
+// optional field), so the panel edits a complete set locally and sends the whole
+// set: patching one toggle by sending one field would silently re-enable the other
+// three on the server's side of the request. The same status guard as limits
+// applies (Card.withControls), so a dead card's toggles are read-only, with the
+// reason on screen.
+
+'use client'
+
+import { useState } from 'react'
+import { Globe, Landmark, RefreshCw, Save, ShoppingCart, Wifi } from 'lucide-react'
+import { useLanguage } from '@/lib/i18n/LanguageContext'
+import { settingsBlock } from '@/lib/cards/rules'
+import { controlsOf, type Card, type CardControls } from '@/lib/cards/types'
+
+const ICONS = {
+  contactlessEnabled: Wifi,
+  onlineEnabled: ShoppingCart,
+  atmEnabled: Landmark,
+  abroadEnabled: Globe,
+} as const
+
+export function CardControlsPanel({
+  card, busy, onSave,
+}: {
+  card: Card
+  busy: string | null
+  onSave: (controls: CardControls) => Promise<boolean>
+}) {
+  const { t } = useLanguage()
+  const server = controlsOf(card)
+  const [draft, setDraft] = useState<CardControls>(server)
+
+  // Seeded once per mount; the parent remounts with a `key` carrying the server's
+  // four flags when the card changes underneath us (see CardLimitsPanel's note).
+
+  const block = settingsBlock(card.status)
+  const dirty = (Object.keys(draft) as (keyof CardControls)[]).some(k => draft[k] !== server[k])
+  const saving = busy === `${card.id}:controls`
+
+  const rows: { key: keyof CardControls; label: string; hint: string }[] = [
+    {
+      key: 'contactlessEnabled',
+      label: t('Bezkontaktní platby', 'Contactless'),
+      hint: t('Platby přiložením u terminálu.', 'Tap-to-pay at a terminal.'),
+    },
+    {
+      key: 'onlineEnabled',
+      label: t('Platby na internetu', 'Online payments'),
+      hint: t('E-commerce a platby bez přítomnosti karty.', 'E-commerce and card-not-present payments.'),
+    },
+    {
+      key: 'atmEnabled',
+      label: t('Výběry z bankomatu', 'ATM withdrawals'),
+      hint: t('Výběry hotovosti.', 'Cash withdrawals.'),
+    },
+    {
+      key: 'abroadEnabled',
+      label: t('Použití v zahraničí', 'Use abroad'),
+      hint: t('Transakce mimo domovskou zemi.', 'Transactions outside the home country.'),
+    },
+  ]
+
+  return (
+    <div className="card" style={{ padding: '16px 20px' }}>
+      <div style={{ display: 'flex', alignItems: 'center', gap: '8px', marginBottom: '14px' }}>
+        <Wifi size={15} style={{ color: 'var(--accent)' }} />
+        <span style={{ fontSize: '13px', fontWeight: 700, color: 'var(--text-primary)' }}>{t('Kanály karty', 'Channel controls')}</span>
+      </div>
+
+      <div style={{ display: 'grid', gap: '8px' }}>
+        {rows.map(({ key, label, hint }) => {
+          const Icon = ICONS[key]
+          const on = draft[key]
+          return (
+            <button
+              key={key}
+              type="button"
+              role="switch"
+              aria-checked={on}
+              aria-label={label}
+              disabled={block !== null || busy !== null}
+              onClick={() => setDraft(d => ({ ...d, [key]: !d[key] }))}
+              style={{
+                display: 'flex', alignItems: 'center', gap: '10px', width: '100%', textAlign: 'left',
+                padding: '9px 11px', borderRadius: '8px', background: 'var(--surface-2)',
+                border: `1px solid ${on ? 'var(--success-border)' : 'var(--border)'}`,
+                cursor: block ? 'not-allowed' : 'pointer', opacity: block ? 0.6 : 1,
+              }}
+            >
+              <Icon size={14} style={{ color: on ? 'var(--success)' : 'var(--text-tertiary)', flexShrink: 0 }} />
+              <span style={{ flex: 1 }}>
+                <span style={{ display: 'block', fontSize: '12.5px', fontWeight: 600, color: 'var(--text-primary)' }}>{label}</span>
+                <span style={{ display: 'block', fontSize: '11px', color: 'var(--text-tertiary)' }}>{hint}</span>
+              </span>
+              <span style={{
+                width: '34px', height: '18px', borderRadius: '999px', flexShrink: 0, position: 'relative',
+                background: on ? 'var(--success)' : 'var(--border-strong)', transition: 'background 0.15s',
+              }}>
+                <span style={{
+                  position: 'absolute', top: '2px', left: on ? '18px' : '2px', width: '14px', height: '14px',
+                  borderRadius: '50%', background: 'var(--surface-1)', transition: 'left 0.15s',
+                }} />
+              </span>
+            </button>
+          )
+        })}
+      </div>
+
+      {block && (
+        <div style={{ fontSize: '11.5px', color: 'var(--text-secondary)', marginTop: '10px' }}>
+          {block === 'terminal'
+            ? t('Karta je v koncovém stavu — kanály už nelze měnit.', 'The card is in a terminal state — its channels can no longer be changed.')
+            : block === 'blocked'
+              ? t('Blokovaná karta netransaguje na žádném kanálu; přepínače proto nic nezmění.', 'A blocked card transacts on no channel, so the toggles would change nothing.')
+              : t('Stav karty neumožňuje změnu kanálů.', 'The card’s status does not allow a channel change.')}
+        </div>
+      )}
+
+      <div style={{ display: 'flex', justifyContent: 'flex-end', marginTop: '14px' }}>
+        <button
+          className="btn btn-primary btn-sm"
+          disabled={busy !== null || block !== null || !dirty}
+          onClick={() => void onSave(draft)}
+        >
+          {saving
+            ? <RefreshCw size={12} style={{ animation: 'spin 0.8s linear infinite' }} />
+            : <Save size={12} />}
+          {t('Uložit kanály', 'Save channels')}
+        </button>
+      </div>
+    </div>
+  )
+}

--- a/openbank-admin-ui/src/components/cards/CardLifecycleMap.tsx
+++ b/openbank-admin-ui/src/components/cards/CardLifecycleMap.tsx
@@ -1,0 +1,93 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright (c) OpenBank contributors. Licensed under the Apache License, Version 2.0.
+// See LICENSE in the repository root or https://www.apache.org/licenses/LICENSE-2.0 for details.
+
+// The card state machine, drawn.
+//
+// An operator should be able to read the lifecycle off the screen instead of off
+// Card.kt. It is split by REVERSIBILITY, because that is the distinction that
+// actually matters at the moment of clicking: the top rail is undo-able, the
+// bottom band is not.
+//
+// Lifted out of the Cards page unchanged so the card detail view can show the same
+// diagram with that card's state ringed — one drawing of one state machine.
+
+'use client'
+
+import { useLanguage } from '@/lib/i18n/LanguageContext'
+import { CardStatusChip } from './CardStatusChip'
+
+function Arrow({ label, back }: { label: string; back?: boolean }) {
+  return (
+    <span style={{ display: 'inline-flex', flexDirection: 'column', alignItems: 'center', margin: '0 6px' }}>
+      <span style={{ fontSize: '10px', color: 'var(--text-tertiary)', fontWeight: 600, whiteSpace: 'nowrap' }}>{label}</span>
+      <span style={{ fontSize: '13px', color: 'var(--border-strong)', lineHeight: 1 }}>{back ? '⇄' : '→'}</span>
+    </span>
+  )
+}
+
+export function CardLifecycleMap({ current, compact }: { current?: string; compact?: boolean }) {
+  const { t } = useLanguage()
+  const row: React.CSSProperties = { display: 'flex', alignItems: 'center', flexWrap: 'wrap', gap: '4px' }
+  const caption: React.CSSProperties = {
+    fontSize: '10px', fontWeight: 700, letterSpacing: '0.06em', textTransform: 'uppercase',
+    color: 'var(--text-tertiary)', marginBottom: '8px',
+  }
+  return (
+    <div className="card" style={{ padding: '16px 20px', marginBottom: compact ? 0 : '24px' }}>
+      <div style={{ display: 'flex', alignItems: 'baseline', justifyContent: 'space-between', gap: '12px', marginBottom: '14px' }}>
+        <div style={{ fontSize: '13px', fontWeight: 700, color: 'var(--text-primary)' }}>
+          {t('Životní cyklus karty', 'Card lifecycle')}
+        </div>
+        <div style={{ fontSize: '11px', color: 'var(--text-tertiary)' }}>
+          {current
+            ? t('Zvýrazněný stav patří vybrané kartě.', 'The highlighted state is the selected card’s.')
+            : t('Vyberte kartu v tabulce a její stav se zvýrazní.', 'Select a card below to highlight its state.')}
+        </div>
+      </div>
+
+      <div style={{ display: 'grid', gap: '14px' }}>
+        <div>
+          <div style={caption}>{t('Vratné přechody', 'Reversible transitions')}</div>
+          <div style={row}>
+            <CardStatusChip status="PENDING" current={current === 'PENDING'} />
+            <Arrow label={t('aktivovat', 'activate')} />
+            <CardStatusChip status="ACTIVE" current={current === 'ACTIVE'} />
+            <Arrow label={t('pozastavit / obnovit', 'suspend / resume')} back />
+            <CardStatusChip status="SUSPENDED" current={current === 'SUSPENDED'} />
+          </div>
+        </div>
+
+        <div style={{ borderTop: '1px dashed var(--border)', paddingTop: '12px' }}>
+          <div style={caption}>{t('Nevratné přechody — vyžadují potvrzení a důvod', 'Irreversible transitions — confirmation and a reason required')}</div>
+          <div style={{ display: 'grid', gap: '8px' }}>
+            <div style={row}>
+              <CardStatusChip status="ACTIVE" small />
+              <CardStatusChip status="SUSPENDED" small />
+              <Arrow label={t('blokovat', 'block')} />
+              <CardStatusChip status="BLOCKED" current={current === 'BLOCKED'} />
+            </div>
+            <div style={row}>
+              <CardStatusChip status="PENDING" small />
+              <CardStatusChip status="ACTIVE" small />
+              <CardStatusChip status="SUSPENDED" small />
+              <CardStatusChip status="BLOCKED" small />
+              <Arrow label={t('zrušit', 'cancel')} />
+              <CardStatusChip status="CANCELLED" current={current === 'CANCELLED'} />
+            </div>
+          </div>
+        </div>
+
+        <div style={{ borderTop: '1px dashed var(--border)', paddingTop: '12px', display: 'flex', alignItems: 'center', gap: '8px', flexWrap: 'wrap' }}>
+          <CardStatusChip status="EXPIRED" current={current === 'EXPIRED'} />
+          <span style={{ fontSize: '11px', color: 'var(--text-tertiary)' }}>
+            {t(
+              'Stav existuje v modelu, ale card-issuance nemá žádnou úlohu expirace — zatím ho tedy žádná karta nedosáhne.',
+              'The status exists in the model, but card-issuance runs no expiry job — no card reaches it today.',
+            )}
+          </span>
+        </div>
+      </div>
+    </div>
+  )
+}

--- a/openbank-admin-ui/src/components/cards/CardLimitsPanel.tsx
+++ b/openbank-admin-ui/src/components/cards/CardLimitsPanel.tsx
@@ -1,0 +1,142 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright (c) OpenBank contributors. Licensed under the Apache License, Version 2.0.
+// See LICENSE in the repository root or https://www.apache.org/licenses/LICENSE-2.0 for details.
+
+// Daily / monthly spending limits — the same thing the customer can do in the app,
+// done by an operator on the customer's behalf.
+//
+// Two things this panel refuses to do:
+//   1. Show minor units. The API speaks them; a human does not. The operator types
+//      "5 000" against a CZK card, not "500000" (see lib/cards/money.ts).
+//   2. Offer a Save that can only ever 400. Card.withLimits() requires a live card,
+//      non-negative values and daily <= monthly — mirrored in lib/cards/rules.ts and
+//      checked here BEFORE the call, with the failing invariant named on screen.
+
+'use client'
+
+import { useState } from 'react'
+import { Save, RefreshCw, Wallet } from 'lucide-react'
+import { useLanguage } from '@/lib/i18n/LanguageContext'
+import { minorToMajorString, parseMajorToMinor, formatMinor } from '@/lib/cards/money'
+import { settingsBlock, validateLimits } from '@/lib/cards/rules'
+import type { Card } from '@/lib/cards/types'
+
+export function CardLimitsPanel({
+  card, busy, onSave,
+}: {
+  card: Card
+  busy: string | null
+  onSave: (dailyMinorUnits: number, monthlyMinorUnits: number) => Promise<boolean>
+}) {
+  const { t, language } = useLanguage()
+  const locale = language === 'cs' ? 'cs-CZ' : 'en-US'
+  const [daily, setDaily] = useState(() => minorToMajorString(card.dailyLimitMinorUnits, card.currency))
+  const [monthly, setMonthly] = useState(() => minorToMajorString(card.monthlyLimitMinorUnits, card.currency))
+
+  // NOTE: the fields are seeded ONCE, from the card as it was when this panel
+  // mounted. Re-seeding from a changed prop is the parent's job, via a `key` that
+  // includes the server's limits — a remount is a cleaner "the server won" than an
+  // effect that could stamp on what the operator is mid-way through typing.
+
+  const dailyMinorUnits = parseMajorToMinor(daily, card.currency)
+  const monthlyMinorUnits = parseMajorToMinor(monthly, card.currency)
+  const violations = validateLimits({ status: card.status, dailyMinorUnits, monthlyMinorUnits })
+  const block = settingsBlock(card.status)
+  const dirty = dailyMinorUnits !== card.dailyLimitMinorUnits || monthlyMinorUnits !== card.monthlyLimitMinorUnits
+  const saving = busy === `${card.id}:limits`
+
+  const blockCopy = block === 'terminal'
+    ? t('Karta je v koncovém stavu — limity už nelze měnit.', 'The card is in a terminal state — its limits can no longer be changed.')
+    : block === 'blocked'
+      ? t('Blokovaná karta nemá co utrácet, limity proto nelze měnit. Nejdřív ji odblokujte, nebo zrušte.', 'A blocked card has nothing left to spend, so its limits cannot be changed. Unblock or cancel it first.')
+      : t('Stav karty neumožňuje změnu limitů.', 'The card’s status does not allow a limit change.')
+
+  const field = (
+    label: string, value: string, onChange: (v: string) => void, invalid: boolean, aria: string,
+  ) => (
+    <label style={{ display: 'block' }}>
+      <span style={{ display: 'block', fontSize: '11px', fontWeight: 700, letterSpacing: '0.04em', textTransform: 'uppercase', color: 'var(--text-tertiary)', marginBottom: '5px' }}>
+        {label}
+      </span>
+      <input
+        value={value}
+        inputMode="decimal"
+        disabled={block !== null}
+        aria-label={aria}
+        onChange={e => onChange(e.target.value)}
+        style={{
+          width: '100%', padding: '7px 10px', borderRadius: '6px', fontSize: '13px',
+          border: `1px solid ${invalid ? 'var(--danger-border)' : 'var(--border)'}`,
+          background: 'var(--surface-2)', color: 'var(--text-primary)', outline: 'none',
+          fontFamily: 'var(--font-mono)', opacity: block ? 0.6 : 1,
+        }}
+      />
+    </label>
+  )
+
+  return (
+    <div className="card" style={{ padding: '16px 20px' }}>
+      <div style={{ display: 'flex', alignItems: 'center', gap: '8px', marginBottom: '14px' }}>
+        <Wallet size={15} style={{ color: 'var(--accent)' }} />
+        <span style={{ fontSize: '13px', fontWeight: 700, color: 'var(--text-primary)' }}>{t('Limity útraty', 'Spending limits')}</span>
+      </div>
+
+      <div style={{ display: 'grid', gridTemplateColumns: '1fr 1fr', gap: '12px' }}>
+        {field(
+          t(`Denní (${card.currency})`, `Daily (${card.currency})`),
+          daily, setDaily,
+          violations.includes('daily_not_a_number') || violations.includes('daily_exceeds_monthly'),
+          t('Denní limit', 'Daily limit'),
+        )}
+        {field(
+          t(`Měsíční (${card.currency})`, `Monthly (${card.currency})`),
+          monthly, setMonthly,
+          violations.includes('monthly_not_a_number'),
+          t('Měsíční limit', 'Monthly limit'),
+        )}
+      </div>
+
+      <div style={{ fontSize: '11px', color: 'var(--text-tertiary)', marginTop: '8px' }}>
+        {t('Nyní platí', 'Currently in force')}{': '}
+        {formatMinor(card.dailyLimitMinorUnits, card.currency, locale)}
+        {' · '}
+        {formatMinor(card.monthlyLimitMinorUnits, card.currency, locale)}
+      </div>
+
+      {block ? (
+        <div style={{ fontSize: '11.5px', color: 'var(--text-secondary)', marginTop: '10px' }}>{blockCopy}</div>
+      ) : (
+        <>
+          {violations.includes('daily_not_a_number') && (
+            <div style={{ fontSize: '11.5px', color: 'var(--danger-text)', marginTop: '8px' }}>
+              {t('Denní limit musí být částka v měně karty.', 'The daily limit must be an amount in the card’s currency.')}
+            </div>
+          )}
+          {violations.includes('monthly_not_a_number') && (
+            <div style={{ fontSize: '11.5px', color: 'var(--danger-text)', marginTop: '8px' }}>
+              {t('Měsíční limit musí být částka v měně karty.', 'The monthly limit must be an amount in the card’s currency.')}
+            </div>
+          )}
+          {violations.includes('daily_exceeds_monthly') && (
+            <div style={{ fontSize: '11.5px', color: 'var(--danger-text)', marginTop: '8px' }}>
+              {t('Denní limit nesmí být vyšší než měsíční.', 'The daily limit cannot exceed the monthly one.')}
+            </div>
+          )}
+        </>
+      )}
+
+      <div style={{ display: 'flex', justifyContent: 'flex-end', gap: '8px', marginTop: '14px' }}>
+        <button
+          className="btn btn-primary btn-sm"
+          disabled={busy !== null || block !== null || violations.length > 0 || !dirty}
+          onClick={() => { if (dailyMinorUnits !== null && monthlyMinorUnits !== null) void onSave(dailyMinorUnits, monthlyMinorUnits) }}
+        >
+          {saving
+            ? <RefreshCw size={12} style={{ animation: 'spin 0.8s linear infinite' }} />
+            : <Save size={12} />}
+          {t('Uložit limity', 'Save limits')}
+        </button>
+      </div>
+    </div>
+  )
+}

--- a/openbank-admin-ui/src/components/cards/CardOperationFeedback.tsx
+++ b/openbank-admin-ui/src/components/cards/CardOperationFeedback.tsx
@@ -1,0 +1,52 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright (c) OpenBank contributors. Licensed under the Apache License, Version 2.0.
+// See LICENSE in the repository root or https://www.apache.org/licenses/LICENSE-2.0 for details.
+
+// The outcome banner for an operator-initiated card WRITE.
+//
+// Deliberately not <DataUnavailable>: that panel answers "this data isn't here"
+// for a read. A write has three outcomes an operator must tell apart — it worked,
+// it is parked for a second approver (ADR-0155 four-eyes), or it was refused — and
+// the text is already classified + localized by useCardOperations().failureCopy.
+
+'use client'
+
+import { AlertTriangle, CheckCircle2, Info } from 'lucide-react'
+import { useLanguage } from '@/lib/i18n/LanguageContext'
+import type { Feedback } from '@/lib/cards/useCardOperations'
+
+const TONE = {
+  ok: { bg: 'var(--success-bg)', border: 'var(--success-border)', color: 'var(--success-text)' },
+  info: { bg: 'var(--accent-bg)', border: 'var(--accent-border)', color: 'var(--accent-text)' },
+  error: { bg: 'var(--danger-bg)', border: 'var(--danger-border)', color: 'var(--danger-text)' },
+}
+
+export function CardOperationFeedback({
+  feedback, onDismiss,
+}: {
+  feedback: Feedback | null
+  onDismiss: () => void
+}) {
+  const { t } = useLanguage()
+  if (!feedback) return null
+  const tone = TONE[feedback.tone]
+  const Icon = feedback.tone === 'ok' ? CheckCircle2 : feedback.tone === 'info' ? Info : AlertTriangle
+  return (
+    <div
+      role="status"
+      style={{
+        display: 'flex', alignItems: 'flex-start', gap: '8px', marginBottom: '16px',
+        padding: '10px 14px', borderRadius: '8px', fontSize: '12.5px',
+        background: tone.bg, border: `1px solid ${tone.border}`, color: tone.color,
+      }}
+    >
+      <Icon size={15} style={{ flexShrink: 0, marginTop: '1px' }} />
+      <span style={{ flex: 1 }}>{feedback.text}</span>
+      <button
+        onClick={onDismiss}
+        aria-label={t('Zavřít zprávu', 'Dismiss message')}
+        style={{ background: 'none', border: 'none', cursor: 'pointer', color: 'inherit', lineHeight: 1, padding: 0 }}
+      >{'×'}</button>
+    </div>
+  )
+}

--- a/openbank-admin-ui/src/components/cards/CardStatusChip.tsx
+++ b/openbank-admin-ui/src/components/cards/CardStatusChip.tsx
@@ -1,0 +1,52 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright (c) OpenBank contributors. Licensed under the Apache License, Version 2.0.
+// See LICENSE in the repository root or https://www.apache.org/licenses/LICENSE-2.0 for details.
+
+// One status chip for the whole card surface (list, detail, lifecycle map,
+// confirmation dialog). A card's status is the single most-read thing on the
+// screen; two screens rendering it in different colours is how an operator stops
+// trusting the colour at all.
+//
+// The status token itself (ACTIVE, BLOCKED, …) is the service's own enum value and
+// is shown verbatim in both languages on purpose: it is the string that appears in
+// the API, the audit trail and the alerts, so translating it would make the console
+// harder to correlate, not easier to read.
+
+'use client'
+
+export const CARD_STATUS_COLORS: Record<string, { bg: string; text: string; border: string }> = {
+  ACTIVE: { bg: 'var(--success-bg)', text: 'var(--success-text)', border: 'var(--success-border)' },
+  SUSPENDED: { bg: 'var(--accent-bg)', text: 'var(--accent-text)', border: 'var(--accent-border)' },
+  BLOCKED: { bg: 'var(--danger-bg)', text: 'var(--danger-text)', border: 'var(--danger-border)' },
+  EXPIRED: { bg: 'var(--surface-3)', text: 'var(--text-tertiary)', border: 'var(--border)' },
+  CANCELLED: { bg: 'var(--surface-3)', text: 'var(--text-tertiary)', border: 'var(--border)' },
+  PENDING: { bg: 'var(--warning-bg)', text: 'var(--warning-text)', border: 'var(--warning-border)' },
+}
+
+export function cardStatusColor(status: string | null | undefined) {
+  return CARD_STATUS_COLORS[status ?? ''] ?? CARD_STATUS_COLORS.PENDING
+}
+
+export function CardStatusChip({
+  status, current, small,
+}: {
+  status: string
+  /** Ring the chip — "this is the state of the card you are looking at". */
+  current?: boolean
+  small?: boolean
+}) {
+  const c = cardStatusColor(status)
+  return (
+    <span style={{
+      padding: small ? '1px 7px' : '3px 10px',
+      borderRadius: '10px',
+      fontSize: small ? '10px' : '11px',
+      fontWeight: 700,
+      whiteSpace: 'nowrap',
+      background: c.bg,
+      color: c.text,
+      border: `1px solid ${current ? 'var(--accent)' : c.border}`,
+      boxShadow: current ? '0 0 0 3px var(--accent-bg)' : 'none',
+    }}>{status}</span>
+  )
+}

--- a/openbank-admin-ui/src/components/cards/CardTransitionButtons.tsx
+++ b/openbank-admin-ui/src/components/cards/CardTransitionButtons.tsx
@@ -1,0 +1,77 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright (c) OpenBank contributors. Licensed under the Apache License, Version 2.0.
+// See LICENSE in the repository root or https://www.apache.org/licenses/LICENSE-2.0 for details.
+
+// The lifecycle actions a card can take RIGHT NOW — one row, two screens.
+//
+// The button set is derived from `legalTransitions()` (the mirror of Card.kt's
+// guards), never from a hand-written per-screen list: the console offers exactly
+// the transitions the aggregate would accept, and nothing else.
+//
+// When there are none, this says WHY rather than rendering an empty cell. "No
+// action" reads as a bug; "terminal state — a cancelled card cannot move again"
+// reads as the system working.
+
+'use client'
+
+import { Ban, PauseCircle, PlayCircle, RefreshCw, ShieldX } from 'lucide-react'
+import { useLanguage } from '@/lib/i18n/LanguageContext'
+import { isTerminal, legalTransitions, type CardAction, type CardTransition } from '@/lib/cards/lifecycle'
+import type { Card } from '@/lib/cards/types'
+
+const ACTION_ICON: Record<CardAction, React.ElementType> = {
+  activate: PlayCircle, resume: PlayCircle, suspend: PauseCircle, block: ShieldX, cancel: Ban,
+}
+
+export function CardTransitionButtons({
+  card, busy, onSelect,
+}: {
+  card: Card
+  /** `${cardId}:${action}` of the in-flight write, or null. */
+  busy: string | null
+  onSelect: (transition: CardTransition) => void
+}) {
+  const { t } = useLanguage()
+  const transitions = legalTransitions(card.status)
+
+  if (transitions.length === 0) {
+    return (
+      <span style={{ fontSize: '11px', color: 'var(--text-tertiary)' }}>
+        {isTerminal(card.status)
+          ? t('koncový stav', 'terminal state')
+          : t('žádná akce', 'no action')}
+      </span>
+    )
+  }
+
+  const label = (action: CardAction) => ({
+    activate: t('Aktivovat', 'Activate'),
+    resume: t('Obnovit', 'Resume'),
+    suspend: t('Pozastavit', 'Suspend'),
+    block: t('Blokovat', 'Block'),
+    cancel: t('Zrušit', 'Cancel'),
+  }[action])
+
+  return (
+    <div style={{ display: 'flex', gap: '6px', flexWrap: 'wrap' }}>
+      {transitions.map(tr => {
+        const Icon = ACTION_ICON[tr.action]
+        const running = busy === `${card.id}:${tr.action}`
+        return (
+          <button
+            key={tr.action}
+            className={`btn btn-sm ${tr.irreversible ? 'btn-danger' : 'btn-ghost'}`}
+            disabled={busy !== null}
+            title={`${label(tr.action)} → ${tr.to}`}
+            onClick={() => onSelect(tr)}
+          >
+            {running
+              ? <RefreshCw size={12} style={{ animation: 'spin 0.8s linear infinite' }} />
+              : <Icon size={12} />}
+            {label(tr.action)}
+          </button>
+        )
+      })}
+    </div>
+  )
+}

--- a/openbank-admin-ui/src/components/cards/ConfirmTransitionDialog.tsx
+++ b/openbank-admin-ui/src/components/cards/ConfirmTransitionDialog.tsx
@@ -1,0 +1,104 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright (c) OpenBank contributors. Licensed under the Apache License, Version 2.0.
+// See LICENSE in the repository root or https://www.apache.org/licenses/LICENSE-2.0 for details.
+
+// Confirmation for the two irreversible transitions (block, cancel).
+//
+// The reason is REQUIRED, not optional: `Card.block()` requires a non-blank reason,
+// and `Card.cancel()` writes whatever it is given onto `blockedReason` — the
+// aggregate's single "why is this card not usable" note, which is what the customer
+// service agent reads back to the customer months later. An empty reason is a card
+// nobody can explain.
+
+'use client'
+
+import { useState } from 'react'
+import { AlertTriangle } from 'lucide-react'
+import { useLanguage } from '@/lib/i18n/LanguageContext'
+import type { CardTransition } from '@/lib/cards/lifecycle'
+import type { Card } from '@/lib/cards/types'
+import { CardStatusChip } from './CardStatusChip'
+
+export function ConfirmTransitionDialog({
+  card, transition, busy, onCancel, onConfirm,
+}: {
+  card: Card
+  transition: CardTransition
+  busy: boolean
+  onCancel: () => void
+  onConfirm: (reason: string) => void
+}) {
+  const { t } = useLanguage()
+  const [reason, setReason] = useState('')
+  const label = transition.action === 'block'
+    ? t('Blokovat kartu', 'Block card')
+    : t('Zrušit kartu', 'Cancel card')
+
+  return (
+    <div
+      role="dialog"
+      aria-modal="true"
+      aria-label={label}
+      onKeyDown={e => { if (e.key === 'Escape' && !busy) onCancel() }}
+      style={{
+        position: 'fixed', inset: 0, zIndex: 60, background: 'rgba(15,23,42,0.45)',
+        display: 'flex', alignItems: 'center', justifyContent: 'center', padding: '24px',
+      }}
+    >
+      <div className="card" style={{ width: '100%', maxWidth: '460px', padding: '22px 24px', background: 'var(--surface-1)' }}>
+        <div style={{ display: 'flex', gap: '10px', alignItems: 'flex-start', marginBottom: '14px' }}>
+          <AlertTriangle size={18} style={{ color: 'var(--danger)', flexShrink: 0, marginTop: '2px' }} />
+          <div>
+            <div style={{ fontSize: '15px', fontWeight: 700, color: 'var(--text-primary)' }}>{label}</div>
+            <div style={{ fontSize: '12px', color: 'var(--text-secondary)', marginTop: '4px' }}>
+              {t('Tuto operaci nelze vzít zpět.', 'This operation cannot be undone.')}
+            </div>
+          </div>
+        </div>
+
+        <div style={{
+          display: 'flex', alignItems: 'center', gap: '8px', flexWrap: 'wrap',
+          padding: '10px 12px', borderRadius: '8px', background: 'var(--surface-2)', marginBottom: '14px',
+        }}>
+          <span style={{ fontFamily: 'var(--font-mono)', fontSize: '12px', color: 'var(--text-primary)' }}>{card.maskedPan}</span>
+          <CardStatusChip status={card.status} small />
+          <span style={{ fontSize: '12px', color: 'var(--text-tertiary)' }}>{'→'}</span>
+          <CardStatusChip status={transition.to} small />
+        </div>
+
+        <label style={{ display: 'block', fontSize: '12px', fontWeight: 600, color: 'var(--text-secondary)', marginBottom: '6px' }}>
+          {t('Důvod (povinný, zapíše se do auditu karty)', 'Reason (required, recorded on the card’s audit trail)')}
+        </label>
+        <textarea
+          value={reason}
+          onChange={e => setReason(e.target.value)}
+          rows={3}
+          autoFocus
+          aria-label={t('Důvod operace', 'Reason for the operation')}
+          style={{
+            width: '100%', padding: '8px 10px', borderRadius: '6px', border: '1px solid var(--border)',
+            fontSize: '13px', background: 'var(--surface-2)', color: 'var(--text-primary)',
+            outline: 'none', resize: 'vertical', fontFamily: 'inherit',
+          }}
+        />
+
+        <div style={{ display: 'flex', justifyContent: 'flex-end', gap: '8px', marginTop: '16px' }}>
+          <button className="btn btn-ghost btn-sm" onClick={onCancel} disabled={busy}>
+            {t('Zpět', 'Back')}
+          </button>
+          <button
+            className="btn btn-danger btn-sm"
+            disabled={busy || reason.trim().length === 0}
+            onClick={() => onConfirm(reason.trim())}
+          >
+            {busy
+              ? t('Odesílám…', 'Submitting…')
+              : transition.action === 'block'
+                ? t('Potvrdit blokaci', 'Confirm block')
+                : t('Potvrdit zrušení', 'Confirm cancellation')}
+          </button>
+        </div>
+      </div>
+    </div>
+  )
+}

--- a/openbank-admin-ui/src/components/cards/IssueCardDialog.tsx
+++ b/openbank-admin-ui/src/components/cards/IssueCardDialog.tsx
@@ -1,0 +1,648 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright (c) OpenBank contributors. Licensed under the Apache License, Version 2.0.
+// See LICENSE in the repository root or https://www.apache.org/licenses/LICENSE-2.0 for details.
+
+// Issue a card from the back office — the flow the portal used to not have.
+//
+// The reason a decorative "Issue card" button was once removed from this page was
+// that an operator-side issue form would mean pasting raw partyId/accountId UUIDs.
+// That premise was wrong: account-service DOES list a party's accounts
+// (`GET /api/v1/accounts?partyId=`), so every identifier the POST needs can be
+// walked to instead of typed:
+//
+//   search a party by name → pick one of THEIR accounts → the account names its
+//   product → the product code yields the party's entitlements → the account's
+//   currency is the card's currency.
+//
+// The operator therefore chooses a person, an account, a card type and a network.
+// They never see, type or paste a UUID. The rules of the walk live in
+// src/lib/cards/issue.ts (pure, tested); this file is the fetching and the pixels.
+
+'use client'
+
+import { useCallback, useEffect, useMemo, useState } from 'react'
+import { AlertTriangle, ArrowLeft, ArrowRight, Check, CreditCard, RefreshCw, Search, X } from 'lucide-react'
+import { useLanguage } from '@/lib/i18n/LanguageContext'
+import { classifyBffFailure, svcUrl } from '@/lib/services/bff'
+import { DataUnavailable } from '@/components/feedback/DataUnavailable'
+import type { UnavailableKind } from '@/components/feedback/DataUnavailable'
+import { CARD_NETWORKS, CARD_TYPES, type AccountRef, type Card, type CardEntitlements, type CardNetwork, type CardType, type PartyRef } from '@/lib/cards/types'
+import { allowedCardTypes, allowedNetworks, issueBlockers, quotaOf, type IssueBlocker } from '@/lib/cards/entitlements'
+import {
+  DEFAULT_DAILY_LIMIT_MINOR, DEFAULT_MONTHLY_LIMIT_MINOR,
+  ISSUE_STEPS, canAdvance, initialDraft, issueRequestBody, nextStep, prevStep,
+  stepBlockers, toEmbossedName, withAccountSelected, withPartySelected,
+  type IssueDraft, type IssueStep,
+} from '@/lib/cards/issue'
+import { formatMinor, minorToMajorString, parseMajorToMinor } from '@/lib/cards/money'
+import { useCardOperations } from '@/lib/cards/useCardOperations'
+import { CardOperationFeedback } from './CardOperationFeedback'
+
+const SEARCH_LIMIT = 10
+const ACCOUNT_LIMIT = 25
+
+// ── small shared bits of chrome ─────────────────────────────────────────────
+
+function Field({ label, children }: { label: string; children: React.ReactNode }) {
+  return (
+    <label style={{ display: 'block' }}>
+      <span style={{ display: 'block', fontSize: '11px', fontWeight: 700, letterSpacing: '0.04em', textTransform: 'uppercase', color: 'var(--text-tertiary)', marginBottom: '5px' }}>
+        {label}
+      </span>
+      {children}
+    </label>
+  )
+}
+
+const inputStyle: React.CSSProperties = {
+  width: '100%', padding: '7px 10px', borderRadius: '6px', border: '1px solid var(--border)',
+  fontSize: '13px', background: 'var(--surface-2)', color: 'var(--text-primary)', outline: 'none',
+}
+
+function ChoiceRow({ options, value, disabledValues, onPick, ariaLabel }: {
+  options: readonly string[]
+  value: string
+  disabledValues: readonly string[]
+  onPick: (v: string) => void
+  ariaLabel: string
+}) {
+  return (
+    <div role="group" aria-label={ariaLabel} style={{ display: 'flex', flexWrap: 'wrap', gap: '6px' }}>
+      {options.map(o => {
+        const off = disabledValues.includes(o)
+        const on = value === o
+        return (
+          <button
+            key={o}
+            type="button"
+            disabled={off}
+            aria-pressed={on}
+            onClick={() => onPick(o)}
+            style={{
+              padding: '5px 11px', borderRadius: '999px', fontSize: '11.5px', fontWeight: 600,
+              cursor: off ? 'not-allowed' : 'pointer', opacity: off ? 0.45 : 1,
+              background: on ? 'var(--accent-bg)' : 'var(--surface-2)',
+              color: on ? 'var(--accent-text)' : 'var(--text-secondary)',
+              border: `1px solid ${on ? 'var(--accent)' : 'var(--border)'}`,
+            }}
+          >{o}</button>
+        )
+      })}
+    </div>
+  )
+}
+
+function Row({ label, value, mono }: { label: string; value: React.ReactNode; mono?: boolean }) {
+  return (
+    <div style={{ display: 'flex', justifyContent: 'space-between', gap: '16px', padding: '6px 0', borderBottom: '1px dashed var(--border)' }}>
+      <span style={{ fontSize: '12px', color: 'var(--text-tertiary)' }}>{label}</span>
+      <span style={{ fontSize: '12.5px', color: 'var(--text-primary)', fontWeight: 600, fontFamily: mono ? 'var(--font-mono)' : undefined, textAlign: 'right' }}>{value}</span>
+    </div>
+  )
+}
+
+// ── the dialog ──────────────────────────────────────────────────────────────
+
+export function IssueCardDialog({ onClose, onIssued }: { onClose: () => void; onIssued: (card: Card) => void }) {
+  const { t, language } = useLanguage()
+  const ops = useCardOperations()
+
+  const [step, setStep] = useState<IssueStep>('party')
+  const [draft, setDraft] = useState<IssueDraft>(initialDraft)
+
+  // Step 1 — party search
+  const [query, setQuery] = useState('')
+  const [debounced, setDebounced] = useState('')
+  const [parties, setParties] = useState<PartyRef[]>([])
+  const [searching, setSearching] = useState(false)
+  const [searchUnavailable, setSearchUnavailable] = useState<{ kind: UnavailableKind } | null>(null)
+  const [searchDegraded, setSearchDegraded] = useState(false)
+
+  // Step 2 — the party's accounts
+  const [accounts, setAccounts] = useState<AccountRef[]>([])
+  const [accountsLoading, setAccountsLoading] = useState(false)
+  const [accountsUnavailable, setAccountsUnavailable] = useState<{ kind: UnavailableKind } | null>(null)
+
+  // Step 3 — product + entitlements resolution
+  const [resolving, setResolving] = useState(false)
+  const [productUnresolved, setProductUnresolved] = useState(false)
+  const [entitlementsUnknown, setEntitlementsUnknown] = useState(false)
+  const [resolveNonce, setResolveNonce] = useState(0)
+
+  // Step 4 — the idempotency key for THIS attempt, generated once and reused on
+  // every retry so a dropped response replays the same card rather than minting
+  // a second one.
+  const [idempotencyKey, setIdempotencyKey] = useState('')
+
+  const [dailyText, setDailyText] = useState('')
+  const [monthlyText, setMonthlyText] = useState('')
+
+  useEffect(() => {
+    const id = setTimeout(() => setDebounced(query.trim()), 300)
+    return () => clearTimeout(id)
+  }, [query])
+
+  // ── party search, with a fallback when /search is flag-gated off ──────────
+  // party-service gates /parties/search behind the `party-search` feature flag and
+  // answers 404 when it is off (ADR-0067 §6). Falling back to the plain list and
+  // filtering it client-side keeps the flow usable instead of dead-ending the
+  // operator on a capability that is merely switched off.
+  useEffect(() => {
+    if (debounced.length < 2) { setParties([]); setSearchUnavailable(null); setSearchDegraded(false); return }
+    let cancelled = false
+    const run = async () => {
+      setSearching(true); setSearchUnavailable(null); setSearchDegraded(false)
+      try {
+        const res = await fetch(
+          svcUrl('party-service', '/api/v1/parties/search', { q: debounced, limit: String(SEARCH_LIMIT) }),
+          { signal: AbortSignal.timeout(8000), cache: 'no-store' },
+        )
+        if (res.ok) {
+          const body = await res.json() as { data?: PartyRef[] }
+          if (!cancelled) setParties(body.data ?? [])
+          return
+        }
+        const kind = await classifyBffFailure(res)
+        if (kind !== 'not_found') { if (!cancelled) setSearchUnavailable({ kind }); return }
+        // Flag off → degrade to the list endpoint.
+        const listRes = await fetch(
+          svcUrl('party-service', '/api/v1/parties', { page: '0', size: '100' }),
+          { signal: AbortSignal.timeout(8000), cache: 'no-store' },
+        )
+        if (!listRes.ok) { if (!cancelled) setSearchUnavailable({ kind: await classifyBffFailure(listRes) }); return }
+        const listBody = await listRes.json() as { items?: PartyRef[] }
+        const needle = debounced.toLowerCase()
+        const hits = (listBody.items ?? []).filter(p =>
+          `${p.legalName ?? ''} ${p.tradingName ?? ''} ${p.email ?? ''}`.toLowerCase().includes(needle),
+        ).slice(0, SEARCH_LIMIT)
+        if (!cancelled) { setParties(hits); setSearchDegraded(true) }
+      } catch {
+        if (!cancelled) setSearchUnavailable({ kind: 'unreachable' })
+      } finally {
+        if (!cancelled) setSearching(false)
+      }
+    }
+    void run()
+    return () => { cancelled = true }
+  }, [debounced])
+
+  // ── the chosen party's accounts ───────────────────────────────────────────
+  const partyId = draft.party?.id
+  useEffect(() => {
+    if (!partyId) { setAccounts([]); return }
+    let cancelled = false
+    const run = async () => {
+      setAccountsLoading(true); setAccountsUnavailable(null)
+      try {
+        const res = await fetch(
+          svcUrl('account-service', '/api/v1/accounts', { partyId, limit: String(ACCOUNT_LIMIT) }),
+          { signal: AbortSignal.timeout(8000), cache: 'no-store' },
+        )
+        if (!res.ok) { if (!cancelled) setAccountsUnavailable({ kind: await classifyBffFailure(res) }); return }
+        const body = await res.json() as { data?: AccountRef[] }
+        if (!cancelled) setAccounts(body.data ?? [])
+      } catch {
+        if (!cancelled) setAccountsUnavailable({ kind: 'unreachable' })
+      } finally {
+        if (!cancelled) setAccountsLoading(false)
+      }
+    }
+    void run()
+    return () => { cancelled = true }
+  }, [partyId])
+
+  // ── product code + entitlements for the chosen account ────────────────────
+  // The account carries a productId (a UUID); card-issuance wants the product
+  // CODE, and the entitlement document is keyed by it. Resolve, never guess: a
+  // fallback code would issue the card against the wrong product's rules and fee.
+  const accountId = draft.account?.id
+  const productId = draft.account?.productId
+  useEffect(() => {
+    if (!partyId || !accountId || !productId) return
+    let cancelled = false
+    const run = async () => {
+      setResolving(true); setProductUnresolved(false); setEntitlementsUnknown(false)
+      try {
+        const prodRes = await fetch(svcUrl('product-catalog', `/api/v1/products/${productId}`), {
+          signal: AbortSignal.timeout(8000), cache: 'no-store',
+        })
+        if (!prodRes.ok) { if (!cancelled) setProductUnresolved(true); return }
+        const product = await prodRes.json() as { code?: string }
+        const code = product.code?.trim()
+        if (!code) { if (!cancelled) setProductUnresolved(true); return }
+        if (!cancelled) setDraft(d => ({ ...d, productCode: code }))
+
+        const entRes = await fetch(
+          svcUrl('card-issuance-service', `/api/v1/cards/party/${partyId}/entitlements`, { productCode: code }),
+          { signal: AbortSignal.timeout(8000), cache: 'no-store' },
+        )
+        if (!entRes.ok) { if (!cancelled) setEntitlementsUnknown(true); return }
+        const ent = await entRes.json() as CardEntitlements
+        if (!cancelled) setDraft(d => ({ ...d, entitlements: ent }))
+      } catch {
+        if (!cancelled) setProductUnresolved(true)
+      } finally {
+        if (!cancelled) setResolving(false)
+      }
+    }
+    void run()
+    return () => { cancelled = true }
+  }, [partyId, accountId, productId, resolveNonce])
+
+  const currency = draft.account?.currencyCode ?? null
+  const quota = quotaOf(draft.entitlements)
+  const types = useMemo(() => allowedCardTypes(draft.entitlements), [draft.entitlements])
+  const networks = useMemo(() => allowedNetworks(draft.entitlements, CARD_NETWORKS), [draft.entitlements])
+  const blockers = issueBlockers(draft.entitlements, { cardType: draft.cardType, network: draft.network })
+
+  // Picking an account fixes the currency, so that is the moment the limit fields
+  // are seeded — in the event handler, not in an effect watching the currency.
+  const pickAccount = (a: AccountRef) => {
+    setDraft(d => withAccountSelected(d, a))
+    setDailyText(minorToMajorString(draft.dailyMinorUnits ?? DEFAULT_DAILY_LIMIT_MINOR, a.currencyCode))
+    setMonthlyText(minorToMajorString(draft.monthlyMinorUnits ?? DEFAULT_MONTHLY_LIMIT_MINOR, a.currencyCode))
+    go('configure')
+  }
+
+  const setDaily = (text: string) => {
+    setDailyText(text)
+    setDraft(d => ({ ...d, dailyMinorUnits: parseMajorToMinor(text, currency) }))
+  }
+  const setMonthly = (text: string) => {
+    setMonthlyText(text)
+    setDraft(d => ({ ...d, monthlyMinorUnits: parseMajorToMinor(text, currency) }))
+  }
+
+  const blockerCopy = useCallback((b: IssueBlocker): string => ({
+    CARD_PRODUCT_DISABLED: t('Produkt tohoto účtu karty nevydává.', 'The account’s product does not carry cards.'),
+    CARD_VIRTUAL_NOT_ALLOWED: t('Tento produkt nedovoluje virtuální ani jednorázové karty.', 'This product allows neither virtual nor single-use cards.'),
+    CARD_NETWORK_NOT_ALLOWED: t('Tato karetní síť není u produktu povolena.', 'This card network is not allowed on the product.'),
+    CARD_QUOTA_EXCEEDED: t('Klient už vyčerpal počet karet povolený tímto produktem.', 'The client already holds every card this product allows.'),
+  }[b]), [t])
+
+  const go = (to: IssueStep) => { ops.setFeedback(null); setStep(to) }
+
+  const submit = async () => {
+    const body = issueRequestBody(draft)
+    if (!body) return
+    const key = idempotencyKey || crypto.randomUUID()
+    if (!idempotencyKey) setIdempotencyKey(key)
+    const issued = await ops.issueCard(body, key)
+    if (issued?.id) onIssued(issued)
+  }
+
+  const stepTitle: Record<IssueStep, string> = {
+    party: t('Klient', 'Client'),
+    account: t('Účet', 'Account'),
+    configure: t('Karta', 'Card'),
+    review: t('Potvrzení', 'Review'),
+  }
+
+  const canContinue = canAdvance(step, draft) && !resolving
+  const busy = ops.busy !== null
+
+  return (
+    <div
+      role="dialog"
+      aria-modal="true"
+      aria-label={t('Vydat kartu', 'Issue a card')}
+      onKeyDown={e => { if (e.key === 'Escape' && !busy) onClose() }}
+      style={{
+        position: 'fixed', inset: 0, zIndex: 60, background: 'rgba(15,23,42,0.45)',
+        display: 'flex', alignItems: 'flex-start', justifyContent: 'center', padding: '40px 24px', overflowY: 'auto',
+      }}
+    >
+      <div className="card" style={{ width: '100%', maxWidth: '640px', background: 'var(--surface-1)' }}>
+        {/* header + stepper */}
+        <div style={{ padding: '18px 22px 14px', borderBottom: '1px solid var(--border)' }}>
+          <div style={{ display: 'flex', alignItems: 'center', justifyContent: 'space-between', gap: '12px' }}>
+            <div style={{ display: 'flex', alignItems: 'center', gap: '9px' }}>
+              <CreditCard size={16} style={{ color: 'var(--accent)' }} />
+              <span style={{ fontSize: '15px', fontWeight: 700, color: 'var(--text-primary)' }}>{t('Vydat kartu', 'Issue a card')}</span>
+            </div>
+            <button onClick={onClose} disabled={busy} aria-label={t('Zavřít', 'Close')}
+              style={{ background: 'none', border: 'none', cursor: 'pointer', color: 'var(--text-tertiary)', padding: 0, lineHeight: 1 }}>
+              <X size={16} />
+            </button>
+          </div>
+          <div style={{ display: 'flex', alignItems: 'center', gap: '6px', marginTop: '12px', flexWrap: 'wrap' }}>
+            {ISSUE_STEPS.map((s, i) => {
+              const active = s === step
+              const done = ISSUE_STEPS.indexOf(step) > i
+              return (
+                <span key={s} style={{ display: 'inline-flex', alignItems: 'center', gap: '6px' }}>
+                  <span style={{
+                    display: 'inline-flex', alignItems: 'center', gap: '5px',
+                    padding: '3px 10px', borderRadius: '999px', fontSize: '11px', fontWeight: 700,
+                    background: active ? 'var(--accent-bg)' : 'transparent',
+                    color: active ? 'var(--accent-text)' : done ? 'var(--success-text)' : 'var(--text-tertiary)',
+                    border: `1px solid ${active ? 'var(--accent)' : 'var(--border)'}`,
+                  }}>
+                    {done ? <Check size={11} /> : null}{stepTitle[s]}
+                  </span>
+                  {i < ISSUE_STEPS.length - 1 && <span style={{ color: 'var(--border-strong)', fontSize: '11px' }}>{'→'}</span>}
+                </span>
+              )
+            })}
+          </div>
+        </div>
+
+        <div style={{ padding: '18px 22px' }}>
+          <CardOperationFeedback feedback={ops.feedback} onDismiss={() => ops.setFeedback(null)} />
+
+          {/* ── step 1: party ─────────────────────────────────────────────── */}
+          {step === 'party' && (
+            <div style={{ display: 'grid', gap: '12px' }}>
+              <Field label={t('Najít klienta podle jména nebo e-mailu', 'Find the client by name or e-mail')}>
+                <div style={{ position: 'relative' }}>
+                  <Search size={13} style={{ position: 'absolute', left: '10px', top: '50%', transform: 'translateY(-50%)', color: 'var(--text-tertiary)' }} />
+                  <input
+                    value={query}
+                    autoFocus
+                    onChange={e => setQuery(e.target.value)}
+                    placeholder={t('např. Novák', 'e.g. Novak')}
+                    aria-label={t('Hledat klienta', 'Search for a client')}
+                    style={{ ...inputStyle, paddingLeft: '30px' }}
+                  />
+                </div>
+              </Field>
+
+              {query.trim().length > 0 && query.trim().length < 2 && (
+                <div style={{ fontSize: '11.5px', color: 'var(--text-tertiary)' }}>
+                  {t('Zadejte alespoň dva znaky.', 'Type at least two characters.')}
+                </div>
+              )}
+              {searchDegraded && (
+                <div style={{ fontSize: '11.5px', color: 'var(--text-tertiary)' }}>
+                  {t(
+                    'Fulltextové hledání je vypnuté, filtruji tedy posledních 100 klientů.',
+                    'Fulltext search is switched off, so the last 100 clients are being filtered instead.',
+                  )}
+                </div>
+              )}
+
+              {searching ? (
+                <div style={{ fontSize: '12px', color: 'var(--text-tertiary)', display: 'flex', alignItems: 'center', gap: '7px' }}>
+                  <RefreshCw size={13} style={{ animation: 'spin 0.8s linear infinite' }} />
+                  {t('Hledám…', 'Searching…')}
+                </div>
+              ) : searchUnavailable ? (
+                <DataUnavailable kind={searchUnavailable.kind} service={t('Party-service', 'Party-service')} feature={t('Vyhledávání klientů', 'Client search')} lang={language} dense />
+              ) : debounced.length >= 2 && parties.length === 0 ? (
+                <DataUnavailable kind="no_data" feature={t('Klienti', 'Clients')} lang={language} dense
+                  detail={t('Žádný klient neodpovídá zadanému výrazu.', 'No client matches that term.')} />
+              ) : (
+                <div style={{ display: 'grid', gap: '6px' }}>
+                  {parties.map(p => {
+                    const picked = draft.party?.id === p.id
+                    return (
+                      <button
+                        key={p.id}
+                        type="button"
+                        onClick={() => { setDraft(d => withPartySelected(d, p)); go('account') }}
+                        style={{
+                          textAlign: 'left', padding: '9px 12px', borderRadius: '8px', cursor: 'pointer',
+                          background: picked ? 'var(--accent-bg)' : 'var(--surface-2)',
+                          border: `1px solid ${picked ? 'var(--accent)' : 'var(--border)'}`,
+                        }}
+                      >
+                        <div style={{ fontSize: '13px', fontWeight: 600, color: 'var(--text-primary)' }}>
+                          {p.tradingName?.trim() || p.legalName?.trim() || p.id}
+                        </div>
+                        <div style={{ fontSize: '11px', color: 'var(--text-tertiary)', marginTop: '2px' }}>
+                          {[p.email, p.status, p.kycStatus].filter(Boolean).join(' · ')}
+                        </div>
+                      </button>
+                    )
+                  })}
+                </div>
+              )}
+            </div>
+          )}
+
+          {/* ── step 2: account ───────────────────────────────────────────── */}
+          {step === 'account' && (
+            <div style={{ display: 'grid', gap: '12px' }}>
+              <div style={{ fontSize: '12px', color: 'var(--text-secondary)' }}>
+                {t('Účty klienta', 'The client’s accounts')}
+                {': '}
+                <strong style={{ color: 'var(--text-primary)' }}>{draft.party?.tradingName?.trim() || draft.party?.legalName?.trim()}</strong>
+              </div>
+              {accountsLoading ? (
+                <div style={{ fontSize: '12px', color: 'var(--text-tertiary)', display: 'flex', alignItems: 'center', gap: '7px' }}>
+                  <RefreshCw size={13} style={{ animation: 'spin 0.8s linear infinite' }} />
+                  {t('Načítám účty…', 'Loading accounts…')}
+                </div>
+              ) : accountsUnavailable ? (
+                <DataUnavailable kind={accountsUnavailable.kind} service={t('Account-service', 'Account-service')} feature={t('Účty klienta', 'The client’s accounts')} lang={language} dense />
+              ) : accounts.length === 0 ? (
+                <DataUnavailable kind="no_data" feature={t('Účty klienta', 'The client’s accounts')} lang={language} dense
+                  detail={t('Tento klient nemá žádný účet, na který by šlo kartu vydat.', 'This client has no account a card could be issued against.')} />
+              ) : (
+                <div style={{ display: 'grid', gap: '6px' }}>
+                  {accounts.map(a => {
+                    const picked = draft.account?.id === a.id
+                    const usable = a.status === 'ACTIVE'
+                    return (
+                      <button
+                        key={a.id}
+                        type="button"
+                        disabled={!usable}
+                        onClick={() => pickAccount(a)}
+                        title={usable ? undefined : t('Kartu lze vydat jen k aktivnímu účtu.', 'A card can only be issued against an ACTIVE account.')}
+                        style={{
+                          textAlign: 'left', padding: '9px 12px', borderRadius: '8px',
+                          cursor: usable ? 'pointer' : 'not-allowed', opacity: usable ? 1 : 0.55,
+                          background: picked ? 'var(--accent-bg)' : 'var(--surface-2)',
+                          border: `1px solid ${picked ? 'var(--accent)' : 'var(--border)'}`,
+                        }}
+                      >
+                        <div style={{ fontSize: '12.5px', fontWeight: 600, color: 'var(--text-primary)', fontFamily: 'var(--font-mono)' }}>{a.accountNumber}</div>
+                        <div style={{ fontSize: '11px', color: 'var(--text-tertiary)', marginTop: '2px' }}>
+                          {[a.accountType, a.currencyCode, a.status].filter(Boolean).join(' · ')}
+                          {!usable && ` — ${t('nelze použít', 'not usable')}`}
+                        </div>
+                      </button>
+                    )
+                  })}
+                </div>
+              )}
+            </div>
+          )}
+
+          {/* ── step 3: card configuration ────────────────────────────────── */}
+          {step === 'configure' && (
+            <div style={{ display: 'grid', gap: '14px' }}>
+              {resolving ? (
+                <div style={{ fontSize: '12px', color: 'var(--text-tertiary)', display: 'flex', alignItems: 'center', gap: '7px' }}>
+                  <RefreshCw size={13} style={{ animation: 'spin 0.8s linear infinite' }} />
+                  {t('Zjišťuji produkt účtu a nárok klienta…', 'Resolving the account’s product and the client’s entitlement…')}
+                </div>
+              ) : productUnresolved ? (
+                <div style={{ display: 'grid', gap: '8px' }}>
+                  <div style={{ display: 'flex', gap: '8px', fontSize: '12px', color: 'var(--danger-text)', background: 'var(--danger-bg)', border: '1px solid var(--danger-border)', borderRadius: '8px', padding: '10px 12px' }}>
+                    <AlertTriangle size={14} style={{ flexShrink: 0, marginTop: '1px' }} />
+                    <span>{t(
+                      'Produkt tohoto účtu se nepodařilo zjistit, a bez něj by karta vznikla pod cizími pravidly a poplatkem. Zkuste to prosím znovu.',
+                      'The account’s product could not be resolved, and without it the card would be created under the wrong rules and fee. Please try again.',
+                    )}</span>
+                  </div>
+                  <div>
+                    <button className="btn btn-ghost btn-sm" onClick={() => setResolveNonce(n => n + 1)}>
+                      <RefreshCw size={12} /> {t('Zkusit znovu', 'Try again')}
+                    </button>
+                  </div>
+                </div>
+              ) : (
+                <>
+                  {/* entitlement context — "this party has 2 of 3 cards" */}
+                  <div style={{ padding: '10px 12px', borderRadius: '8px', background: 'var(--surface-2)', border: '1px solid var(--border)' }}>
+                    <div style={{ display: 'flex', justifyContent: 'space-between', gap: '12px', flexWrap: 'wrap' }}>
+                      <span style={{ fontSize: '12px', color: 'var(--text-secondary)' }}>
+                        {t('Produkt', 'Product')}{': '}
+                        <strong style={{ color: 'var(--text-primary)', fontFamily: 'var(--font-mono)' }}>{draft.productCode}</strong>
+                      </span>
+                      <span style={{ fontSize: '12px', color: quota.exhausted ? 'var(--danger-text)' : 'var(--text-secondary)' }}>
+                        {quota.known
+                          ? t(`Karet: ${quota.issued} ze ${quota.max}`, `Cards: ${quota.issued} of ${quota.max}`)
+                          : t('Limit počtu karet není znám', 'The card cap is unknown')}
+                      </span>
+                    </div>
+                    {entitlementsUnknown && (
+                      <div style={{ fontSize: '11px', color: 'var(--text-tertiary)', marginTop: '6px' }}>
+                        {t(
+                          'Nárok klienta se nepodařilo načíst — pravidla ověří až služba při vydání.',
+                          'The client’s entitlement could not be loaded — the service will check the rules on submit.',
+                        )}
+                      </div>
+                    )}
+                    {draft.entitlements && draft.entitlements.monthlyFeePerCard > 0 && (
+                      <div style={{ fontSize: '11px', color: 'var(--text-tertiary)', marginTop: '6px' }}>
+                        {t('Měsíční poplatek za kartu', 'Monthly fee per card')}{': '}
+                        {draft.entitlements.monthlyFeePerCard}
+                      </div>
+                    )}
+                  </div>
+
+                  <Field label={t('Typ karty', 'Card type')}>
+                    <ChoiceRow
+                      options={CARD_TYPES}
+                      value={draft.cardType}
+                      disabledValues={CARD_TYPES.filter(x => !types.includes(x))}
+                      onPick={v => setDraft(d => ({ ...d, cardType: v as CardType }))}
+                      ariaLabel={t('Typ karty', 'Card type')}
+                    />
+                  </Field>
+
+                  <Field label={t('Karetní síť', 'Card network')}>
+                    <ChoiceRow
+                      options={CARD_NETWORKS}
+                      value={draft.network}
+                      disabledValues={CARD_NETWORKS.filter(x => !networks.includes(x))}
+                      onPick={v => setDraft(d => ({ ...d, network: v as CardNetwork }))}
+                      ariaLabel={t('Karetní síť', 'Card network')}
+                    />
+                  </Field>
+
+                  <div style={{ display: 'grid', gridTemplateColumns: '1fr 1fr', gap: '12px' }}>
+                    <Field label={t('Jméno držitele', 'Cardholder name')}>
+                      <input
+                        value={draft.cardholderName}
+                        onChange={e => setDraft(d => ({ ...d, cardholderName: e.target.value }))}
+                        aria-label={t('Jméno držitele', 'Cardholder name')}
+                        style={inputStyle}
+                      />
+                    </Field>
+                    <Field label={t('Jméno na kartě (max. 26 znaků)', 'Embossed name (max. 26 characters)')}>
+                      <input
+                        value={draft.embossedName}
+                        onChange={e => setDraft(d => ({ ...d, embossedName: toEmbossedName(e.target.value) }))}
+                        aria-label={t('Jméno na kartě', 'Embossed name')}
+                        style={{ ...inputStyle, fontFamily: 'var(--font-mono)' }}
+                      />
+                    </Field>
+                  </div>
+
+                  <div style={{ display: 'grid', gridTemplateColumns: '1fr 1fr', gap: '12px' }}>
+                    <Field label={t(`Denní limit (${currency ?? ''})`, `Daily limit (${currency ?? ''})`)}>
+                      <input value={dailyText} onChange={e => setDaily(e.target.value)} inputMode="decimal"
+                        aria-label={t('Denní limit', 'Daily limit')} style={inputStyle} />
+                    </Field>
+                    <Field label={t(`Měsíční limit (${currency ?? ''})`, `Monthly limit (${currency ?? ''})`)}>
+                      <input value={monthlyText} onChange={e => setMonthly(e.target.value)} inputMode="decimal"
+                        aria-label={t('Měsíční limit', 'Monthly limit')} style={inputStyle} />
+                    </Field>
+                  </div>
+
+                  {/* Say WHY continue is unavailable rather than greying it out silently. */}
+                  {stepBlockers('configure', draft).length > 0 && (
+                    <div style={{ display: 'grid', gap: '4px' }}>
+                      {blockers.map(b => (
+                        <div key={b} style={{ display: 'flex', gap: '7px', fontSize: '11.5px', color: 'var(--danger-text)' }}>
+                          <AlertTriangle size={13} style={{ flexShrink: 0, marginTop: '1px' }} />{blockerCopy(b)}
+                        </div>
+                      ))}
+                      {(!draft.cardholderName.trim() || !draft.embossedName.trim()) && (
+                        <div style={{ fontSize: '11.5px', color: 'var(--danger-text)' }}>
+                          {t('Jméno držitele i jméno na kartě musí být vyplněné.', 'Both the cardholder name and the embossed name are required.')}
+                        </div>
+                      )}
+                      {draft.dailyMinorUnits === null || draft.monthlyMinorUnits === null ? (
+                        <div style={{ fontSize: '11.5px', color: 'var(--danger-text)' }}>
+                          {t('Limity musí být kladná částka v měně účtu.', 'Both limits must be a positive amount in the account’s currency.')}
+                        </div>
+                      ) : draft.dailyMinorUnits > draft.monthlyMinorUnits ? (
+                        <div style={{ fontSize: '11.5px', color: 'var(--danger-text)' }}>
+                          {t('Denní limit nesmí být vyšší než měsíční.', 'The daily limit cannot exceed the monthly one.')}
+                        </div>
+                      ) : null}
+                    </div>
+                  )}
+                </>
+              )}
+            </div>
+          )}
+
+          {/* ── step 4: review ────────────────────────────────────────────── */}
+          {step === 'review' && (
+            <div style={{ display: 'grid', gap: '10px' }}>
+              <Row label={t('Klient', 'Client')} value={draft.party?.tradingName?.trim() || draft.party?.legalName?.trim()} />
+              <Row label={t('Účet', 'Account')} value={draft.account?.accountNumber} mono />
+              <Row label={t('Produkt', 'Product')} value={draft.productCode} mono />
+              <Row label={t('Typ a síť', 'Type and network')} value={`${draft.cardType} · ${draft.network}`} />
+              <Row label={t('Jméno na kartě', 'Embossed name')} value={draft.embossedName} mono />
+              <Row label={t('Měna', 'Currency')} value={currency} />
+              <Row label={t('Denní limit', 'Daily limit')} value={formatMinor(draft.dailyMinorUnits ?? 0, currency, language === 'cs' ? 'cs-CZ' : 'en-US')} />
+              <Row label={t('Měsíční limit', 'Monthly limit')} value={formatMinor(draft.monthlyMinorUnits ?? 0, currency, language === 'cs' ? 'cs-CZ' : 'en-US')} />
+              <div style={{ fontSize: '11.5px', color: 'var(--text-tertiary)', marginTop: '4px' }}>
+                {t(
+                  'Karta vznikne ve stavu PENDING; aktivuje se samostatným krokem. Opakované odeslání je díky idempotentnímu klíči bezpečné — nevznikne druhá karta.',
+                  'The card is created PENDING; activating it is a separate step. Re-submitting is safe thanks to the idempotency key — it will not mint a second card.',
+                )}
+              </div>
+            </div>
+          )}
+        </div>
+
+        {/* footer */}
+        <div style={{ padding: '14px 22px', borderTop: '1px solid var(--border)', display: 'flex', justifyContent: 'space-between', gap: '8px' }}>
+          <button className="btn btn-ghost btn-sm" disabled={busy || step === 'party'} onClick={() => go(prevStep(step))}>
+            <ArrowLeft size={12} /> {t('Zpět', 'Back')}
+          </button>
+          {step === 'review' ? (
+            <button className="btn btn-primary btn-sm" disabled={busy || !canContinue} onClick={() => void submit()}>
+              {busy
+                ? <RefreshCw size={12} style={{ animation: 'spin 0.8s linear infinite' }} />
+                : <CreditCard size={12} />}
+              {t('Vydat kartu', 'Issue the card')}
+            </button>
+          ) : (
+            <button className="btn btn-primary btn-sm" disabled={busy || !canContinue} onClick={() => go(nextStep(step))}>
+              {t('Pokračovat', 'Continue')} <ArrowRight size={12} />
+            </button>
+          )}
+        </div>
+      </div>
+    </div>
+  )
+}

--- a/openbank-admin-ui/src/components/cards/IssueCardDialog.tsx
+++ b/openbank-admin-ui/src/components/cards/IssueCardDialog.tsx
@@ -34,7 +34,7 @@ import {
   stepBlockers, toEmbossedName, withAccountSelected, withPartySelected,
   type IssueDraft, type IssueStep,
 } from '@/lib/cards/issue'
-import { formatMinor, minorToMajorString, parseMajorToMinor } from '@/lib/cards/money'
+import { formatMajor, formatMinor, minorToMajorString, parseMajorToMinor } from '@/lib/cards/money'
 import { useCardOperations } from '@/lib/cards/useCardOperations'
 import { CardOperationFeedback } from './CardOperationFeedback'
 
@@ -257,10 +257,19 @@ export function IssueCardDialog({ onClose, onIssued }: { onClose: () => void; on
 
   // Picking an account fixes the currency, so that is the moment the limit fields
   // are seeded — in the event handler, not in an effect watching the currency.
+  //
+  // Always the DEFAULTS, never draft.dailyMinorUnits/monthlyMinorUnits from a
+  // previous pick: those are minor units under the PREVIOUS account's currency
+  // exponent, and re-formatting them under a new currency reinterprets the same
+  // integer at a different scale rather than converting it — a value typed as
+  // 1000.00 USD (100000 minor, 2 decimals) would render as 100000 JPY (0
+  // decimals) if the operator went back and chose a JPY account instead. There
+  // is no exchange rate here to convert with, so starting over is correct, not
+  // just simpler.
   const pickAccount = (a: AccountRef) => {
     setDraft(d => withAccountSelected(d, a))
-    setDailyText(minorToMajorString(draft.dailyMinorUnits ?? DEFAULT_DAILY_LIMIT_MINOR, a.currencyCode))
-    setMonthlyText(minorToMajorString(draft.monthlyMinorUnits ?? DEFAULT_MONTHLY_LIMIT_MINOR, a.currencyCode))
+    setDailyText(minorToMajorString(DEFAULT_DAILY_LIMIT_MINOR, a.currencyCode))
+    setMonthlyText(minorToMajorString(DEFAULT_MONTHLY_LIMIT_MINOR, a.currencyCode))
     go('configure')
   }
 
@@ -519,7 +528,7 @@ export function IssueCardDialog({ onClose, onIssued }: { onClose: () => void; on
                     {draft.entitlements && draft.entitlements.monthlyFeePerCard > 0 && (
                       <div style={{ fontSize: '11px', color: 'var(--text-tertiary)', marginTop: '6px' }}>
                         {t('Měsíční poplatek za kartu', 'Monthly fee per card')}{': '}
-                        {draft.entitlements.monthlyFeePerCard}
+                        {formatMajor(draft.entitlements.monthlyFeePerCard, currency, language === 'cs' ? 'cs-CZ' : 'en-US')}
                       </div>
                     )}
                   </div>

--- a/openbank-admin-ui/src/lib/cards/entitlements.ts
+++ b/openbank-admin-ui/src/lib/cards/entitlements.ts
@@ -1,0 +1,98 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright (c) OpenBank contributors. Licensed under the Apache License, Version 2.0.
+// See LICENSE in the repository root or https://www.apache.org/licenses/LICENSE-2.0 for details.
+
+// The product-catalog card entitlement gate, mirrored client-side.
+//
+// Source of truth: openbank-card-issuance-service
+//   application/usecase/CardService.kt → enforceEntitlements(cmd), which throws a
+//   CardEntitlementException (HTTP 409, body `code`) in exactly four cases:
+//     CARD_PRODUCT_DISABLED     — cardConfig.enabled == false
+//     CARD_VIRTUAL_NOT_ALLOWED  — VIRTUAL/SINGLE_USE requested, virtualCardAllowed == false
+//     CARD_NETWORK_NOT_ALLOWED  — network not in cardConfig.networks
+//     CARD_QUOTA_EXCEEDED       — live cards (PENDING/ACTIVE/SUSPENDED) >= maxCards
+//
+// The console evaluates the same four rules BEFORE submitting so the operator is
+// told "this party already holds 3 of 3 cards on CURRENT_CZK" up front, rather
+// than discovering it as a 409 after filling in a form. The server remains the
+// authority — this is an explanation layer, never a substitute for its check.
+
+import type { CardEntitlements, CardNetwork, CardType } from './types'
+import { CARD_TYPES, VIRTUAL_FORM_TYPES } from './types'
+
+/**
+ * `maxCards`/`remaining` sentinel for "no known cap": the service answers -1 when
+ * product-catalog could not be consulted (`source: 'FALLBACK'`) — deliberately not
+ * 0, which would read as "nothing left". See CardEntitlements.UNLIMITED.
+ */
+export const UNLIMITED = -1
+
+export interface Quota {
+  /** False when the cap is unknown (FALLBACK) — do not render "x of y". */
+  known: boolean
+  max: number
+  issued: number
+  remaining: number
+  exhausted: boolean
+}
+
+export function quotaOf(e: CardEntitlements | null | undefined): Quota {
+  const max = e?.maxCards ?? UNLIMITED
+  const issued = e?.issued ?? 0
+  const remaining = e?.remaining ?? UNLIMITED
+  const known = max !== UNLIMITED && remaining !== UNLIMITED
+  return { known, max, issued, remaining, exhausted: known && remaining <= 0 }
+}
+
+/** Why an issue would be refused. Names mirror the service's CardErrorCode. */
+export type IssueBlocker =
+  | 'CARD_PRODUCT_DISABLED'
+  | 'CARD_VIRTUAL_NOT_ALLOWED'
+  | 'CARD_NETWORK_NOT_ALLOWED'
+  | 'CARD_QUOTA_EXCEEDED'
+
+/**
+ * Every entitlement rule the requested (type, network) breaks — empty when the
+ * service would accept it. A missing/unknown entitlement document blocks nothing:
+ * the service itself skips the whole gate when the catalog lookup is Unavailable.
+ */
+export function issueBlockers(
+  e: CardEntitlements | null | undefined,
+  request: { cardType: CardType; network: CardNetwork },
+): IssueBlocker[] {
+  if (!e) return []
+  const blockers: IssueBlocker[] = []
+  if (!e.enabled) blockers.push('CARD_PRODUCT_DISABLED')
+  if (VIRTUAL_FORM_TYPES.includes(request.cardType) && !virtualAllowed(e, request.cardType)) {
+    blockers.push('CARD_VIRTUAL_NOT_ALLOWED')
+  }
+  if (e.networks.length > 0 && !e.networks.includes(request.network)) {
+    blockers.push('CARD_NETWORK_NOT_ALLOWED')
+  }
+  if (quotaOf(e).exhausted) blockers.push('CARD_QUOTA_EXCEEDED')
+  return blockers
+}
+
+/**
+ * SINGLE_USE rides `virtualCardAllowed` in the catalog (the service sets
+ * `singleUseAllowed = config.virtualCardAllowed`), but we honour the field the
+ * API actually returned rather than assuming they agree.
+ */
+function virtualAllowed(e: CardEntitlements, type: CardType): boolean {
+  return type === 'SINGLE_USE' ? e.singleUseAllowed : e.virtualCardAllowed
+}
+
+/** Card types this product allows. Physical form factors are never gated. */
+export function allowedCardTypes(e: CardEntitlements | null | undefined): CardType[] {
+  if (!e) return [...CARD_TYPES]
+  return CARD_TYPES.filter(type => !VIRTUAL_FORM_TYPES.includes(type) || virtualAllowed(e, type))
+}
+
+/** Networks this product allows; all of them when the document lists none. */
+export function allowedNetworks(
+  e: CardEntitlements | null | undefined,
+  all: readonly CardNetwork[],
+): CardNetwork[] {
+  if (!e || e.networks.length === 0) return [...all]
+  return all.filter(n => e.networks.includes(n))
+}

--- a/openbank-admin-ui/src/lib/cards/issue.ts
+++ b/openbank-admin-ui/src/lib/cards/issue.ts
@@ -1,0 +1,215 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright (c) OpenBank contributors. Licensed under the Apache License, Version 2.0.
+// See LICENSE in the repository root or https://www.apache.org/licenses/LICENSE-2.0 for details.
+
+// The operator-side "issue a card" flow, as a pure state machine.
+//
+// The flow exists to answer one design constraint: an operator must never type a
+// UUID. `POST /api/v1/cards` needs a partyId, an accountId, a productCode and a
+// currency — four values that are all *derived* here, by walking
+//   party search → that party's accounts → that account's product → its currency,
+// so the only things a human chooses are the card type and the network, and the
+// only things they type are a search term and (optionally) the embossed name.
+//
+// Keeping the machine pure (no fetch, no React) is what makes the rules testable:
+// "review is unreachable until an account is picked" is an assertion, not a hope.
+
+import type { AccountRef, CardEntitlements, CardNetwork, CardType, PartyRef } from './types'
+import { issueBlockers } from './entitlements'
+import { validateLimits, type LimitViolation } from './rules'
+
+/** IssueCardRequest defaults (CardDtos.kt) — the service applies these when omitted. */
+export const DEFAULT_DAILY_LIMIT_MINOR = 500_000
+export const DEFAULT_MONTHLY_LIMIT_MINOR = 5_000_000
+
+export const ISSUE_STEPS = ['party', 'account', 'configure', 'review'] as const
+export type IssueStep = (typeof ISSUE_STEPS)[number]
+
+export interface IssueDraft {
+  party: PartyRef | null
+  account: AccountRef | null
+  /** Resolved from the account's product (product-catalog `code`), never typed. */
+  productCode: string | null
+  /** The party's entitlements on that product; null while unresolved. */
+  entitlements: CardEntitlements | null
+  cardType: CardType
+  network: CardNetwork
+  cardholderName: string
+  embossedName: string
+  dailyMinorUnits: number | null
+  monthlyMinorUnits: number | null
+}
+
+export function initialDraft(): IssueDraft {
+  return {
+    party: null,
+    account: null,
+    productCode: null,
+    entitlements: null,
+    cardType: 'DEBIT',
+    network: 'VISA',
+    cardholderName: '',
+    embossedName: '',
+    dailyMinorUnits: DEFAULT_DAILY_LIMIT_MINOR,
+    monthlyMinorUnits: DEFAULT_MONTHLY_LIMIT_MINOR,
+  }
+}
+
+/**
+ * Embossing line: ASCII, upper case, ≤ 26 characters.
+ *
+ * ISO/IEC 7813 track 1 gives the cardholder name 26 characters and no accents, so
+ * "Bohuslava Čermáková-Nováková" has to become "BOHUSLAVA CERMAKOVA-NOVAK" *somewhere*.
+ * Doing it here — visibly, in a field the operator can still correct — beats letting
+ * a personalisation bureau silently truncate it into something the customer disowns.
+ */
+export function toEmbossedName(legalName: string): string {
+  return legalName
+    .normalize('NFD')
+    .replace(/[\u0300-\u036f]/g, '')
+    .replace(/[^A-Za-z \-.']/g, '')
+    .replace(/\s+/g, ' ')
+    .trim()
+    .toUpperCase()
+    .slice(0, 26)
+}
+
+/** Party display name — trading name where a company has one, else the legal name. */
+export function partyDisplayName(party: PartyRef | null | undefined): string {
+  if (!party) return ''
+  return (party.tradingName?.trim() || party.legalName?.trim() || '').trim()
+}
+
+/** Prefill the two name fields from the chosen party; never asks the operator to retype. */
+export function withPartySelected(draft: IssueDraft, party: PartyRef): IssueDraft {
+  const name = partyDisplayName(party)
+  return {
+    ...draft,
+    party,
+    // A different party invalidates everything downstream — account, product and
+    // the entitlement document are all party-scoped.
+    account: null,
+    productCode: null,
+    entitlements: null,
+    cardholderName: name,
+    embossedName: toEmbossedName(name),
+  }
+}
+
+/** Choosing an account re-derives the product and therefore the entitlements. */
+export function withAccountSelected(draft: IssueDraft, account: AccountRef): IssueDraft {
+  return { ...draft, account, productCode: null, entitlements: null }
+}
+
+/** The card's currency is the account's — never a free choice, never typed. */
+export function draftCurrency(draft: IssueDraft): string | null {
+  return draft.account?.currencyCode ?? null
+}
+
+/** Reasons the flow refuses to leave `step`. Empty ⇒ the operator may continue. */
+export type StepBlocker =
+  | 'no_party'
+  | 'no_account'
+  | 'account_not_active'
+  | 'no_product'
+  | 'no_cardholder_name'
+  | 'no_embossed_name'
+  | `entitlement:${string}`
+  | `limits:${LimitViolation}`
+
+export function stepBlockers(step: IssueStep, draft: IssueDraft): StepBlocker[] {
+  const blockers: StepBlocker[] = []
+  if (step === 'party') {
+    if (!draft.party) blockers.push('no_party')
+    return blockers
+  }
+  if (step === 'account') {
+    if (!draft.account) blockers.push('no_account')
+    // An account must be able to carry a card: a CLOSED/FROZEN account still
+    // exists and still lists, but issuing onto it is not a thing an operator
+    // should be able to do by accident.
+    else if (draft.account.status !== 'ACTIVE') blockers.push('account_not_active')
+    return blockers
+  }
+  if (step === 'configure' || step === 'review') {
+    if (!draft.productCode) blockers.push('no_product')
+    if (!draft.cardholderName.trim()) blockers.push('no_cardholder_name')
+    if (!draft.embossedName.trim()) blockers.push('no_embossed_name')
+    for (const b of issueBlockers(draft.entitlements, { cardType: draft.cardType, network: draft.network })) {
+      blockers.push(`entitlement:${b}`)
+    }
+    for (const v of validateLimits({
+      // A card being issued lands in PENDING, which Card.withLimits accepts —
+      // the limits carried by the issue request face the same invariants.
+      status: 'PENDING',
+      dailyMinorUnits: draft.dailyMinorUnits,
+      monthlyMinorUnits: draft.monthlyMinorUnits,
+    })) {
+      blockers.push(`limits:${v}`)
+    }
+    return blockers
+  }
+  return blockers
+}
+
+export function canAdvance(step: IssueStep, draft: IssueDraft): boolean {
+  return stepBlockers(step, draft).length === 0
+}
+
+export function nextStep(step: IssueStep): IssueStep {
+  const i = ISSUE_STEPS.indexOf(step)
+  return ISSUE_STEPS[Math.min(i + 1, ISSUE_STEPS.length - 1)]
+}
+
+export function prevStep(step: IssueStep): IssueStep {
+  const i = ISSUE_STEPS.indexOf(step)
+  return ISSUE_STEPS[Math.max(i - 1, 0)]
+}
+
+/** True when every step up to and including `step` is satisfied — drives the stepper. */
+export function reachable(step: IssueStep, draft: IssueDraft): boolean {
+  const target = ISSUE_STEPS.indexOf(step)
+  for (let i = 0; i < target; i++) {
+    if (!canAdvance(ISSUE_STEPS[i], draft)) return false
+  }
+  return true
+}
+
+export interface IssueCardRequestBody {
+  partyId: string
+  accountId: string
+  productCode: string
+  cardType: CardType
+  network: CardNetwork
+  cardholderName: string
+  embossedName: string
+  currency: string
+  dailyLimitMinorUnits: number
+  monthlyLimitMinorUnits: number
+}
+
+/**
+ * The POST body, or `null` when the draft is not complete enough to send one.
+ * Returning null rather than a partial object is deliberate: a half-filled issue
+ * request is a 400 at best and a wrong card at worst.
+ */
+export function issueRequestBody(draft: IssueDraft): IssueCardRequestBody | null {
+  const currency = draftCurrency(draft)
+  if (!draft.party || !draft.account || !draft.productCode || !currency) return null
+  // EVERY step, not just the last one: a body must not exist while an earlier
+  // choice (e.g. a non-ACTIVE account) is still refused.
+  if (!reachable('review', draft) || !canAdvance('review', draft)) return null
+  if (draft.dailyMinorUnits === null || draft.monthlyMinorUnits === null) return null
+  return {
+    partyId: draft.party.id,
+    accountId: draft.account.id,
+    productCode: draft.productCode,
+    cardType: draft.cardType,
+    network: draft.network,
+    cardholderName: draft.cardholderName.trim(),
+    embossedName: draft.embossedName.trim(),
+    currency,
+    dailyLimitMinorUnits: draft.dailyMinorUnits,
+    monthlyLimitMinorUnits: draft.monthlyMinorUnits,
+  }
+}

--- a/openbank-admin-ui/src/lib/cards/issue.ts
+++ b/openbank-admin-ui/src/lib/cards/issue.ts
@@ -96,9 +96,23 @@ export function withPartySelected(draft: IssueDraft, party: PartyRef): IssueDraf
   }
 }
 
-/** Choosing an account re-derives the product and therefore the entitlements. */
+/**
+ * Choosing an account re-derives the product and therefore the entitlements. The
+ * limit fields reset to the defaults too, not carried over: they are minor units
+ * scaled to a currency's decimal exponent, and the new account can have a
+ * different currency than whatever was picked before. Carrying the raw integer
+ * across would reinterpret it at the new scale rather than convert it — there
+ * is no exchange rate here to convert with, so starting over is correct.
+ */
 export function withAccountSelected(draft: IssueDraft, account: AccountRef): IssueDraft {
-  return { ...draft, account, productCode: null, entitlements: null }
+  return {
+    ...draft,
+    account,
+    productCode: null,
+    entitlements: null,
+    dailyMinorUnits: DEFAULT_DAILY_LIMIT_MINOR,
+    monthlyMinorUnits: DEFAULT_MONTHLY_LIMIT_MINOR,
+  }
 }
 
 /** The card's currency is the account's — never a free choice, never typed. */

--- a/openbank-admin-ui/src/lib/cards/money.ts
+++ b/openbank-admin-ui/src/lib/cards/money.ts
@@ -92,3 +92,29 @@ export function formatMinor(minor: number, code: string | null | undefined, loca
   }).format(major)
   return code ? `${amount} ${code.toUpperCase()}` : amount
 }
+
+/**
+ * A MAJOR-unit amount (e.g. `monthlyFeePerCard` from the entitlements API, a
+ * plain `Double` — not minor units like a card limit) as a localized currency
+ * string. Same fallback behaviour as `formatMinor` for an unknown code.
+ */
+export function formatMajor(major: number, code: string | null | undefined, locale = 'en-US'): string {
+  const exp = currencyExponent(code)
+  if (code) {
+    try {
+      return new Intl.NumberFormat(locale, {
+        style: 'currency',
+        currency: code.toUpperCase(),
+        minimumFractionDigits: exp,
+        maximumFractionDigits: exp,
+      }).format(major)
+    } catch {
+      // Not a currency code Intl accepts — fall through to the plain form.
+    }
+  }
+  const amount = new Intl.NumberFormat(locale, {
+    minimumFractionDigits: exp,
+    maximumFractionDigits: exp,
+  }).format(major)
+  return code ? `${amount} ${code.toUpperCase()}` : amount
+}

--- a/openbank-admin-ui/src/lib/cards/money.ts
+++ b/openbank-admin-ui/src/lib/cards/money.ts
@@ -1,0 +1,94 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright (c) OpenBank contributors. Licensed under the Apache License, Version 2.0.
+// See LICENSE in the repository root or https://www.apache.org/licenses/LICENSE-2.0 for details.
+
+// Minor-unit ↔ major-unit conversion for the card limit editor.
+//
+// The card-issuance API speaks MINOR units only (`dailyLimitMinorUnits`), but an
+// operator types — and must read — major units: a limit of 500000 on a CZK card
+// is 5 000 Kč, not five hundred thousand. Getting that wrong by a factor of 100
+// on a spending limit is exactly the class of back-office mistake that reaches a
+// customer, so the conversion lives here, in one tested place, rather than as an
+// inline `/100` in a form handler.
+//
+// Arithmetic is done on the DECIMAL STRING, never via `parseFloat(x) * 100`:
+// `19.99 * 100` is 1998.9999999999998 in IEEE-754, which truncates to 1998 — a
+// silent one-haléř/one-cent loss on every edit.
+
+/**
+ * ISO 4217 currencies with a zero-decimal minor unit: one minor unit IS one
+ * major unit. Every other currency in the fleet's catalogue is two-decimal.
+ * (Three-decimal currencies — BHD/KWD/TND — are not offered by any OpenBank
+ * product; they would need their own entry here before they could be.)
+ */
+export const ZERO_DECIMAL_CURRENCIES: ReadonlySet<string> = new Set([
+  'BIF', 'CLP', 'DJF', 'GNF', 'ISK', 'JPY', 'KMF', 'KRW',
+  'PYG', 'RWF', 'UGX', 'VND', 'VUV', 'XAF', 'XOF', 'XPF',
+])
+
+/** Digits after the decimal point for `code` (0 or 2). Unknown code ⇒ 2. */
+export function currencyExponent(code: string | null | undefined): number {
+  if (!code) return 2
+  return ZERO_DECIMAL_CURRENCIES.has(code.toUpperCase()) ? 0 : 2
+}
+
+/**
+ * Minor units → a plain major-unit decimal string ("500000" CZK → "5000.00").
+ * No grouping, no symbol — this is the value an `<input>` holds.
+ */
+export function minorToMajorString(minor: number, code: string | null | undefined): string {
+  const exp = currencyExponent(code)
+  const negative = minor < 0
+  const digits = Math.abs(Math.trunc(minor)).toString().padStart(exp + 1, '0')
+  const whole = digits.slice(0, digits.length - exp)
+  const frac = exp === 0 ? '' : `.${digits.slice(digits.length - exp)}`
+  return `${negative ? '-' : ''}${whole}${frac}`
+}
+
+/**
+ * A major-unit string an operator typed → minor units, or `null` when the text
+ * is not a value this currency can hold.
+ *
+ * Accepts a comma or a dot as the decimal separator (a Czech operator types
+ * "5 000,50") and ignores spaces/NBSP used as thousands separators. Rejects:
+ * empty text, anything non-numeric, a negative sign (the domain forbids negative
+ * limits — see `rules.ts`), and more decimals than the currency has minor units
+ * (silently rounding a typed "10.999" would change the operator's intent).
+ */
+export function parseMajorToMinor(text: string, code: string | null | undefined): number | null {
+  const cleaned = text.replace(/[\s  ]/g, '').replace(',', '.')
+  if (cleaned.length === 0) return null
+  if (!/^\d+(\.\d*)?$/.test(cleaned)) return null
+  const exp = currencyExponent(code)
+  const [whole, frac = ''] = cleaned.split('.')
+  if (frac.length > exp) return null
+  const minor = Number(`${whole}${frac.padEnd(exp, '0')}`)
+  return Number.isSafeInteger(minor) ? minor : null
+}
+
+/**
+ * Minor units → a localized display string with the currency ("5 000,00 Kč").
+ * Falls back to `<amount> <CODE>` when `code` is not a currency `Intl` knows, so
+ * an unexpected code degrades to something readable instead of throwing.
+ */
+export function formatMinor(minor: number, code: string | null | undefined, locale = 'en-US'): string {
+  const exp = currencyExponent(code)
+  const major = Number(minorToMajorString(minor, code))
+  if (code) {
+    try {
+      return new Intl.NumberFormat(locale, {
+        style: 'currency',
+        currency: code.toUpperCase(),
+        minimumFractionDigits: exp,
+        maximumFractionDigits: exp,
+      }).format(major)
+    } catch {
+      // Not a currency code Intl accepts — fall through to the plain form.
+    }
+  }
+  const amount = new Intl.NumberFormat(locale, {
+    minimumFractionDigits: exp,
+    maximumFractionDigits: exp,
+  }).format(major)
+  return code ? `${amount} ${code.toUpperCase()}` : amount
+}

--- a/openbank-admin-ui/src/lib/cards/mutations.ts
+++ b/openbank-admin-ui/src/lib/cards/mutations.ts
@@ -1,0 +1,59 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright (c) OpenBank contributors. Licensed under the Apache License, Version 2.0.
+// See LICENSE in the repository root or https://www.apache.org/licenses/LICENSE-2.0 for details.
+
+// How a card MUTATION failed — the read-path classifier, extended.
+//
+// `classifyBffFailure` is built for reads and lumps every 4xx that isn't 401/404
+// into `error`. A card write has failure modes an operator must be able to tell
+// apart, so they get their own kinds:
+//   400/422 — the aggregate refused it. Card.kt guards every transition, limit and
+//             control change with `require(...)`; libs' CommonExceptionMappers maps
+//             the IllegalArgumentException to a bare 400 (NOT 409). In practice:
+//             the card moved under us, or the invariant we mirror drifted.
+//   409     — CardEntitlementException. Its body carries the domain's own
+//             machine-readable `code` (CardExceptionMappers.kt → ApiError.code), so
+//             we can say WHICH product rule refused instead of "a rule did".
+//   403     — the operator's Keycloak roles don't cover this endpoint.
+//
+// Extracted from the Cards page so the list and the detail view classify (and
+// therefore explain) a failure identically.
+
+import { classifyBffFailure, type BffFailure } from '@/lib/services/bff'
+import type { IssueBlocker } from './entitlements'
+
+export type MutationFailure =
+  | BffFailure
+  | 'illegal_transition'
+  | 'conflict'
+  | 'forbidden'
+  | `conflict:${IssueBlocker}`
+
+const ENTITLEMENT_CODES: readonly string[] = [
+  'CARD_QUOTA_EXCEEDED',
+  'CARD_PRODUCT_DISABLED',
+  'CARD_NETWORK_NOT_ALLOWED',
+  'CARD_VIRTUAL_NOT_ALLOWED',
+]
+
+/** The domain error code on an ApiError body, when there is one. Never throws. */
+export async function cardErrorCode(res: Response): Promise<string | null> {
+  try {
+    const body = (await res.clone().json()) as { code?: unknown }
+    return typeof body?.code === 'string' ? body.code : null
+  } catch {
+    return null
+  }
+}
+
+export async function classifyMutation(res: Response): Promise<MutationFailure> {
+  if (res.status === 400 || res.status === 422) return 'illegal_transition'
+  if (res.status === 409) {
+    const code = await cardErrorCode(res)
+    return code && ENTITLEMENT_CODES.includes(code)
+      ? (`conflict:${code}` as MutationFailure)
+      : 'conflict'
+  }
+  if (res.status === 403) return 'forbidden'
+  return classifyBffFailure(res)
+}

--- a/openbank-admin-ui/src/lib/cards/rules.ts
+++ b/openbank-admin-ui/src/lib/cards/rules.ts
@@ -1,0 +1,85 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright (c) OpenBank contributors. Licensed under the Apache License, Version 2.0.
+// See LICENSE in the repository root or https://www.apache.org/licenses/LICENSE-2.0 for details.
+
+// The aggregate's non-lifecycle invariants, mirrored for the operator console.
+//
+// Source of truth: openbank-card-issuance-service domain/model/Card.kt
+//   - withLimits()   `require(status in setOf(ACTIVE, SUSPENDED, PENDING))`
+//                    `require(dailyMinor >= 0 && monthlyMinor >= 0)`
+//                    `require(dailyMinor <= monthlyMinor)`
+//   - withControls() `require(status in setOf(ACTIVE, SUSPENDED, PENDING))`
+//
+// Same reasoning as lifecycle.ts: an IllegalArgumentException from the aggregate
+// comes back as a bare 400 through libs' CommonExceptionMappers, so a form that
+// can only ever produce that 400 is a form that lies to the operator. We check
+// the invariant before the call AND say which invariant is failing — a greyed-out
+// button with no explanation is the thing this file exists to avoid.
+
+import type { CardStatus } from './lifecycle'
+
+/**
+ * Statuses on which limits and controls may be changed. Not a lifecycle concept:
+ * a BLOCKED card is still `cancel`-able but has no spend left to cap.
+ */
+export const MUTABLE_SETTINGS_STATUSES: readonly CardStatus[] = ['PENDING', 'ACTIVE', 'SUSPENDED']
+
+export function canEditSettings(status: string | null | undefined): boolean {
+  return MUTABLE_SETTINGS_STATUSES.includes(status as CardStatus)
+}
+
+/** Why a limits edit would be refused. Ordered as the aggregate checks them. */
+export type LimitViolation =
+  /** Card.withLimits: status is not ACTIVE/SUSPENDED/PENDING. */
+  | 'status'
+  /** The text in the field is not a value this currency can hold. */
+  | 'daily_not_a_number'
+  | 'monthly_not_a_number'
+  /** Card.withLimits: `require(dailyMinor <= monthlyMinor)`. */
+  | 'daily_exceeds_monthly'
+
+export interface LimitDraft {
+  status: string | null | undefined
+  /** Minor units, or `null` when the field's text did not parse. */
+  dailyMinorUnits: number | null
+  monthlyMinorUnits: number | null
+}
+
+/**
+ * Every invariant a limits edit violates, empty when the aggregate would accept it.
+ *
+ * Note there is no `negative` violation: `parseMajorToMinor` refuses a minus sign
+ * outright, so a negative value can never reach here from the form. The aggregate's
+ * `require(>= 0)` is still mirrored — a negative that arrives some other way is
+ * reported as an unparseable field rather than being sent and 400'd.
+ */
+export function validateLimits(draft: LimitDraft): LimitViolation[] {
+  const violations: LimitViolation[] = []
+  if (!canEditSettings(draft.status)) violations.push('status')
+  const { dailyMinorUnits: daily, monthlyMinorUnits: monthly } = draft
+  if (daily === null || daily < 0) violations.push('daily_not_a_number')
+  if (monthly === null || monthly < 0) violations.push('monthly_not_a_number')
+  if (daily !== null && monthly !== null && daily >= 0 && monthly >= 0 && daily > monthly) {
+    violations.push('daily_exceeds_monthly')
+  }
+  return violations
+}
+
+/** True when the aggregate would accept this limits edit. */
+export function limitsAcceptable(draft: LimitDraft): boolean {
+  return validateLimits(draft).length === 0
+}
+
+/**
+ * Whether an operator-visible control is currently offered, and if not, WHY.
+ * The reason is what the UI renders next to the disabled control — "no action"
+ * is a dead end, "terminal card: cancelled cards keep their last limits" is not.
+ */
+export type SettingsBlock = 'terminal' | 'blocked' | 'unknown_status' | null
+
+export function settingsBlock(status: string | null | undefined): SettingsBlock {
+  if (canEditSettings(status)) return null
+  if (status === 'CANCELLED' || status === 'EXPIRED') return 'terminal'
+  if (status === 'BLOCKED') return 'blocked'
+  return 'unknown_status'
+}

--- a/openbank-admin-ui/src/lib/cards/types.ts
+++ b/openbank-admin-ui/src/lib/cards/types.ts
@@ -1,0 +1,108 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright (c) OpenBank contributors. Licensed under the Apache License, Version 2.0.
+// See LICENSE in the repository root or https://www.apache.org/licenses/LICENSE-2.0 for details.
+
+// The card-issuance read model, mirrored from the service that owns it.
+//
+// Source of truth: openbank-card-issuance-service
+//   - infrastructure/rest/dto/CardDtos.kt — CardResponse / CardEntitlementsResponse
+//   - domain/model/Card.kt                — CardType / CardNetwork enums
+//
+// PCI: `maskedPan` is the ONLY pan-shaped field this console ever holds. The
+// service also exposes GET /{id}/secure-details (full synthetic PAN + CVV for a
+// virtual card); it is deliberately NOT modelled here and must never be — see
+// the PCI note on the card detail page.
+
+import type { CardStatus } from './lifecycle'
+
+export const CARD_TYPES = ['DEBIT', 'CREDIT', 'PREPAID', 'VIRTUAL', 'SINGLE_USE'] as const
+export type CardType = (typeof CARD_TYPES)[number]
+
+export const CARD_NETWORKS = ['VISA', 'MASTERCARD', 'AMEX', 'UNIONPAY'] as const
+export type CardNetwork = (typeof CARD_NETWORKS)[number]
+
+/** Card types with no plastic — Card.VIRTUAL_FORM_TYPES. */
+export const VIRTUAL_FORM_TYPES: readonly CardType[] = ['VIRTUAL', 'SINGLE_USE']
+
+/** CardResponse. Every field the service returns; nothing derived, nothing invented. */
+export interface Card {
+  id: string
+  partyId: string
+  accountId: string
+  productCode: string
+  cardType: CardType | string
+  network: CardNetwork | string
+  maskedPan: string
+  cardholderName: string
+  embossedName: string
+  expiryDate: string
+  status: CardStatus | string
+  dailyLimitMinorUnits: number
+  monthlyLimitMinorUnits: number
+  currency: string
+  deliveryAddress?: string | null
+  activatedAt?: string | null
+  blockedAt?: string | null
+  blockedReason?: string | null
+  createdAt: string
+  updatedAt?: string | null
+  contactlessEnabled?: boolean
+  onlineEnabled?: boolean
+  atmEnabled?: boolean
+  abroadEnabled?: boolean
+}
+
+/** The four channel controls, as PUT /{id}/controls takes them (all four, always). */
+export interface CardControls {
+  contactlessEnabled: boolean
+  onlineEnabled: boolean
+  atmEnabled: boolean
+  abroadEnabled: boolean
+}
+
+/** Read the card's controls with the service's own defaults (all-on) for older rows. */
+export function controlsOf(card: Pick<Card, 'contactlessEnabled' | 'onlineEnabled' | 'atmEnabled' | 'abroadEnabled'>): CardControls {
+  return {
+    contactlessEnabled: card.contactlessEnabled ?? true,
+    onlineEnabled: card.onlineEnabled ?? true,
+    atmEnabled: card.atmEnabled ?? true,
+    abroadEnabled: card.abroadEnabled ?? true,
+  }
+}
+
+/** CardEntitlementsResponse — what a party may still issue on a product. */
+export interface CardEntitlements {
+  productCode: string
+  maxCards: number
+  issued: number
+  remaining: number
+  virtualCardAllowed: boolean
+  singleUseAllowed: boolean
+  networks: (CardNetwork | string)[]
+  tiers: string[]
+  monthlyFeePerCard: number
+  enabled: boolean
+  source: 'CATALOG' | 'FALLBACK' | string
+}
+
+/** A party as party-service's data-minimised `toSimpleResponse()` returns it. */
+export interface PartyRef {
+  id: string
+  legalName?: string | null
+  tradingName?: string | null
+  email?: string | null
+  status?: string | null
+  kycStatus?: string | null
+  partyType?: string | null
+}
+
+/** An account as account-service's AccountResponse returns it. */
+export interface AccountRef {
+  id: string
+  accountNumber: string
+  accountType: string
+  partyId: string
+  productId: string
+  currencyCode: string
+  status: string
+}

--- a/openbank-admin-ui/src/lib/cards/useCardOperations.ts
+++ b/openbank-admin-ui/src/lib/cards/useCardOperations.ts
@@ -1,0 +1,226 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright (c) OpenBank contributors. Licensed under the Apache License, Version 2.0.
+// See LICENSE in the repository root or https://www.apache.org/licenses/LICENSE-2.0 for details.
+
+// One place where the console WRITES to card-issuance.
+//
+// The Cards list, the card detail view and the issue flow all mutate the same
+// aggregate through the same five-ish endpoints, and each one needs the identical
+// three behaviours: a per-action busy key, an ADR-0155 four-eyes 202 that must NOT
+// be reported as success, and a classified failure turned into calm bilingual copy.
+// Duplicating that per screen is how the three drift apart, so it lives here.
+//
+// X-Operator-Id is deliberately NOT set on any of these requests: the BFF derives
+// it from the server session and refuses a client-supplied one (a browser can set
+// any header, so an operator identity chosen in the browser is not evidence of
+// anything). See src/app/api/svc/[service]/[...path]/route.ts.
+
+'use client'
+
+import { useCallback, useState } from 'react'
+import { useLanguage } from '@/lib/i18n/LanguageContext'
+import { svcUrl } from '@/lib/services/bff'
+import { classifyMutation, type MutationFailure } from './mutations'
+import type { CardTransition } from './lifecycle'
+import type { Card, CardControls } from './types'
+import type { IssueCardRequestBody } from './issue'
+
+export type Feedback =
+  | { tone: 'ok'; text: string }
+  | { tone: 'info'; text: string }
+  | { tone: 'error'; text: string }
+
+const CARD_SVC = 'card-issuance-service'
+const WRITE_TIMEOUT_MS = 15_000
+
+export interface CardOperations {
+  /** `${cardId}:${action}` while that action is in flight, else null. */
+  busy: string | null
+  feedback: Feedback | null
+  setFeedback: (f: Feedback | null) => void
+  failureCopy: (kind: MutationFailure) => string
+  runTransition: (card: Card, transition: CardTransition, reason?: string) => Promise<boolean>
+  saveLimits: (card: Card, dailyMinorUnits: number, monthlyMinorUnits: number) => Promise<boolean>
+  saveControls: (card: Card, controls: CardControls) => Promise<boolean>
+  issueCard: (body: IssueCardRequestBody, idempotencyKey: string) => Promise<Card | null>
+}
+
+export function useCardOperations(onChanged?: () => void): CardOperations {
+  const { t } = useLanguage()
+  const [busy, setBusy] = useState<string | null>(null)
+  const [feedback, setFeedback] = useState<Feedback | null>(null)
+
+  const failureCopy = useCallback((kind: MutationFailure): string => {
+    switch (kind) {
+      case 'illegal_transition':
+        return t(
+          'Služba operaci odmítla — stav karty se mezitím změnil. Obnovte data a zkuste to znovu.',
+          'The service refused the operation — the card changed in the meantime. Refresh and try again.',
+        )
+      case 'conflict:CARD_QUOTA_EXCEEDED':
+        return t(
+          'Klient už vyčerpal počet karet, které tento produkt dovoluje.',
+          'The client already holds every card this product allows.',
+        )
+      case 'conflict:CARD_PRODUCT_DISABLED':
+        return t(
+          'Produkt tohoto účtu karty nevydává.',
+          'The account’s product does not carry cards.',
+        )
+      case 'conflict:CARD_NETWORK_NOT_ALLOWED':
+        return t(
+          'Zvolená karetní síť není u tohoto produktu povolena.',
+          'The chosen card network is not allowed on this product.',
+        )
+      case 'conflict:CARD_VIRTUAL_NOT_ALLOWED':
+        return t(
+          'Tento produkt nedovoluje virtuální ani jednorázové karty.',
+          'This product allows neither virtual nor single-use cards.',
+        )
+      case 'conflict':
+        return t(
+          'Služba operaci odmítla kvůli konfliktu s pravidlem produktu (nárok na kartu).',
+          'The service refused the operation as conflicting with a product rule (card entitlement).',
+        )
+      case 'forbidden':
+        return t(
+          'Vaše role nemá oprávnění pro tuto operaci s kartou — vyžaduje se operátor, správce nebo compliance.',
+          'Your role is not permitted to perform this card operation — operator, admin or compliance is required.',
+        )
+      case 'unauthorized':
+        return t(
+          'Vaše přihlášení vypršelo. Přihlaste se prosím znovu a operaci zopakujte.',
+          'Your session has expired. Please sign in again and repeat the operation.',
+        )
+      case 'not_found':
+        return t(
+          'Tato karta už v card-issuance neexistuje. Obnovte seznam.',
+          'This card no longer exists in card-issuance. Refresh the list.',
+        )
+      case 'not_deployed':
+        return t(
+          'card-issuance není v tomto prostředí nasazená, takže operaci nelze provést.',
+          'card-issuance is not deployed in this environment, so the operation cannot run.',
+        )
+      case 'scaled_to_zero':
+        return t(
+          'card-issuance je uspaná do nuly replik (KEDA) a právě se probouzí. Zkuste to prosím za okamžik znovu.',
+          'card-issuance is scaled to zero (KEDA) and is waking up. Please try again in a moment.',
+        )
+      case 'unreachable':
+        return t(
+          'card-issuance je nasazená, ale na požadavek neodpověděla včas. Zkuste to prosím za chvíli znovu.',
+          'card-issuance is deployed but did not answer in time. Please try again shortly.',
+        )
+      default:
+        return t(
+          'Operace se nedokončila. Zkuste to prosím znovu; podrobnosti jsou v auditním logu služby.',
+          'The operation did not complete. Please try again; the details are in the service audit log.',
+        )
+    }
+  }, [t])
+
+  const fourEyesCopy = useCallback(() => t(
+    'Operace čeká na schválení druhým operátorem (čtyři oči).',
+    'The operation is queued for a second operator’s approval (four-eyes).',
+  ), [t])
+
+  /**
+   * Send one mutation. Resolves to the parsed body on success, `'parked'` when
+   * OPA held it for a second pair of eyes (ADR-0155, HTTP 202 — reporting that as
+   * success would tell the operator the card moved when it did not), or null on
+   * any failure, with the feedback banner already set.
+   */
+  const send = useCallback(async (
+    busyKey: string,
+    path: string,
+    init: RequestInit,
+    okText: string,
+  ): Promise<unknown | 'parked' | null> => {
+    setBusy(busyKey)
+    setFeedback(null)
+    try {
+      const res = await fetch(svcUrl(CARD_SVC, path), {
+        cache: 'no-store',
+        signal: AbortSignal.timeout(WRITE_TIMEOUT_MS),
+        ...init,
+        headers: { 'Content-Type': 'application/json', ...(init.headers ?? {}) },
+      })
+      if (res.status === 202) {
+        setFeedback({ tone: 'info', text: fourEyesCopy() })
+        return 'parked'
+      }
+      if (!res.ok) {
+        setFeedback({ tone: 'error', text: failureCopy(await classifyMutation(res)) })
+        return null
+      }
+      const body = await res.json().catch(() => null)
+      setFeedback({ tone: 'ok', text: okText })
+      onChanged?.()
+      return body ?? {}
+    } catch {
+      setFeedback({ tone: 'error', text: failureCopy('unreachable') })
+      return null
+    } finally {
+      setBusy(null)
+    }
+  }, [failureCopy, fourEyesCopy, onChanged])
+
+  const runTransition = useCallback(async (card: Card, transition: CardTransition, reason?: string) => {
+    const out = await send(
+      `${card.id}:${transition.action}`,
+      `/api/v1/cards/${card.id}/${transition.action}`,
+      {
+        method: 'POST',
+        // Only block/cancel take a body (CardStatusRequest); the reversible
+        // endpoints declare no entity parameter.
+        body: transition.reason ? JSON.stringify({ reason }) : undefined,
+      },
+      t(
+        `Karta ${card.maskedPan} je nyní ve stavu ${transition.to}.`,
+        `Card ${card.maskedPan} is now ${transition.to}.`,
+      ),
+    )
+    return out !== null && out !== 'parked'
+  }, [send, t])
+
+  const saveLimits = useCallback(async (card: Card, dailyMinorUnits: number, monthlyMinorUnits: number) => {
+    const out = await send(
+      `${card.id}:limits`,
+      `/api/v1/cards/${card.id}/limits`,
+      { method: 'PUT', body: JSON.stringify({ dailyMinorUnits, monthlyMinorUnits }) },
+      t('Limity karty byly uloženy.', 'The card’s limits have been saved.'),
+    )
+    return out !== null && out !== 'parked'
+  }, [send, t])
+
+  const saveControls = useCallback(async (card: Card, controls: CardControls) => {
+    const out = await send(
+      `${card.id}:controls`,
+      `/api/v1/cards/${card.id}/controls`,
+      { method: 'PUT', body: JSON.stringify(controls) },
+      t('Nastavení kanálů bylo uloženo.', 'The channel controls have been saved.'),
+    )
+    return out !== null && out !== 'parked'
+  }, [send, t])
+
+  const issueCard = useCallback(async (body: IssueCardRequestBody, idempotencyKey: string) => {
+    const out = await send(
+      'issue',
+      '/api/v1/cards',
+      {
+        method: 'POST',
+        // The key is generated once per attempt and REUSED on retry, so a retry
+        // after a dropped response replays the same card instead of minting a
+        // second one (CardResource requires the header and rejects a blank one).
+        headers: { 'Idempotency-Key': idempotencyKey },
+        body: JSON.stringify(body),
+      },
+      t('Karta byla vydána.', 'The card has been issued.'),
+    )
+    if (out === null || out === 'parked') return null
+    return out as Card
+  }, [send, t])
+
+  return { busy, feedback, setFeedback, failureCopy, runTransition, saveLimits, saveControls, issueCard }
+}

--- a/openbank-admin-ui/src/test/card-entitlements.test.ts
+++ b/openbank-admin-ui/src/test/card-entitlements.test.ts
@@ -1,0 +1,114 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright (c) OpenBank contributors. Licensed under the Apache License, Version 2.0.
+// See LICENSE in the repository root or https://www.apache.org/licenses/LICENSE-2.0 for details.
+
+// Pins the client-side entitlement mirror against CardService.enforceEntitlements()
+// and CardService.getEntitlements(). The point of the mirror is to tell an operator
+// "this client already holds 3 of 3 cards" BEFORE they fill in a form; if it drifts
+// from the service it starts refusing issues the service would have accepted (or,
+// worse, promising ones it will 409).
+
+import { describe, it, expect } from 'vitest'
+import {
+  UNLIMITED, allowedCardTypes, allowedNetworks, issueBlockers, quotaOf,
+} from '@/lib/cards/entitlements'
+import { CARD_NETWORKS, type CardEntitlements } from '@/lib/cards/types'
+
+const catalog = (over: Partial<CardEntitlements> = {}): CardEntitlements => ({
+  productCode: 'CURRENT_CZK',
+  maxCards: 3,
+  issued: 1,
+  remaining: 2,
+  virtualCardAllowed: true,
+  singleUseAllowed: true,
+  networks: ['VISA', 'MASTERCARD'],
+  tiers: [],
+  monthlyFeePerCard: 0,
+  enabled: true,
+  source: 'CATALOG',
+  ...over,
+})
+
+// What the service answers when product-catalog could not be consulted.
+const fallback = (): CardEntitlements => catalog({
+  maxCards: UNLIMITED,
+  remaining: UNLIMITED,
+  networks: [...CARD_NETWORKS],
+  source: 'FALLBACK',
+})
+
+describe('quota', () => {
+  it('reads a real catalogue cap', () => {
+    expect(quotaOf(catalog())).toEqual({ known: true, max: 3, issued: 1, remaining: 2, exhausted: false })
+  })
+
+  it('is exhausted once nothing remains', () => {
+    expect(quotaOf(catalog({ issued: 3, remaining: 0 })).exhausted).toBe(true)
+  })
+
+  it('treats the -1 sentinel as UNKNOWN, never as "nothing left"', () => {
+    const q = quotaOf(fallback())
+    expect(q.known).toBe(false)
+    expect(q.exhausted).toBe(false)
+  })
+
+  it('does not claim a cap when there is no entitlement document at all', () => {
+    expect(quotaOf(null).known).toBe(false)
+    expect(quotaOf(null).exhausted).toBe(false)
+  })
+})
+
+describe('issue blockers', () => {
+  const req = { cardType: 'DEBIT', network: 'VISA' } as const
+
+  it('lets a well-formed request through', () => {
+    expect(issueBlockers(catalog(), req)).toEqual([])
+  })
+
+  it('mirrors CARD_PRODUCT_DISABLED', () => {
+    expect(issueBlockers(catalog({ enabled: false }), req)).toContain('CARD_PRODUCT_DISABLED')
+  })
+
+  it('mirrors CARD_VIRTUAL_NOT_ALLOWED for both virtual form factors', () => {
+    const e = catalog({ virtualCardAllowed: false, singleUseAllowed: false })
+    expect(issueBlockers(e, { cardType: 'VIRTUAL', network: 'VISA' })).toContain('CARD_VIRTUAL_NOT_ALLOWED')
+    expect(issueBlockers(e, { cardType: 'SINGLE_USE', network: 'VISA' })).toContain('CARD_VIRTUAL_NOT_ALLOWED')
+    // …and never gates a physical card on the virtual switch.
+    expect(issueBlockers(e, { cardType: 'DEBIT', network: 'VISA' })).toEqual([])
+  })
+
+  it('mirrors CARD_NETWORK_NOT_ALLOWED', () => {
+    expect(issueBlockers(catalog(), { cardType: 'DEBIT', network: 'AMEX' })).toContain('CARD_NETWORK_NOT_ALLOWED')
+  })
+
+  it('mirrors CARD_QUOTA_EXCEEDED', () => {
+    expect(issueBlockers(catalog({ issued: 3, remaining: 0 }), req)).toContain('CARD_QUOTA_EXCEEDED')
+  })
+
+  it('blocks nothing on a FALLBACK document — the service skips its own gate then', () => {
+    expect(issueBlockers(fallback(), { cardType: 'SINGLE_USE', network: 'UNIONPAY' })).toEqual([])
+  })
+
+  it('blocks nothing when the entitlement could not be read at all', () => {
+    expect(issueBlockers(null, { cardType: 'VIRTUAL', network: 'AMEX' })).toEqual([])
+  })
+})
+
+describe('offered choices', () => {
+  it('hides the virtual form factors a product forbids', () => {
+    expect(allowedCardTypes(catalog({ virtualCardAllowed: false, singleUseAllowed: false })))
+      .toEqual(['DEBIT', 'CREDIT', 'PREPAID'])
+  })
+
+  it('offers everything when there is no entitlement document', () => {
+    expect(allowedCardTypes(null)).toHaveLength(5)
+  })
+
+  it('narrows the networks to the product’s list', () => {
+    expect(allowedNetworks(catalog(), CARD_NETWORKS)).toEqual(['VISA', 'MASTERCARD'])
+  })
+
+  it('offers every network when the product names none', () => {
+    expect(allowedNetworks(catalog({ networks: [] }), CARD_NETWORKS)).toEqual([...CARD_NETWORKS])
+  })
+})

--- a/openbank-admin-ui/src/test/card-issue-dialog.test.tsx
+++ b/openbank-admin-ui/src/test/card-issue-dialog.test.tsx
@@ -1,0 +1,115 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright (c) OpenBank contributors. Licensed under the Apache License, Version 2.0.
+// See LICENSE in the repository root or https://www.apache.org/licenses/LICENSE-2.0 for details.
+
+// The issue flow, driven the way an operator drives it: type a name, pick the
+// person, pick their account — and assert that the POST card-issuance receives was
+// assembled entirely out of those clicks. The claim being tested is the design
+// constraint itself: no UUID is ever typed, and the productCode/currency are
+// derived, not guessed.
+
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest'
+import React from 'react'
+import { render, screen, cleanup, fireEvent, waitFor } from '@testing-library/react'
+import { LanguageProvider } from '@/lib/i18n/LanguageContext'
+import { IssueCardDialog } from '@/components/cards/IssueCardDialog'
+
+const PARTY = { id: 'party-uuid-1', legalName: 'Bohuslava Čermáková', email: 'b@example.test', status: 'ACTIVE' }
+const ACCOUNT = {
+  id: 'account-uuid-1', accountNumber: 'CZ6508000000192000145399', accountType: 'CURRENT',
+  partyId: 'party-uuid-1', productId: 'product-uuid-1', currencyCode: 'CZK', status: 'ACTIVE',
+}
+const ENTITLEMENTS = {
+  productCode: 'CURRENT_CZK', maxCards: 3, issued: 1, remaining: 2,
+  virtualCardAllowed: true, singleUseAllowed: true, networks: ['VISA', 'MASTERCARD'],
+  tiers: [], monthlyFeePerCard: 0, enabled: true, source: 'CATALOG',
+}
+
+const posted: { url: string; init: RequestInit }[] = []
+
+function stubFleet() {
+  return vi.fn(async (input: RequestInfo | URL, init?: RequestInit) => {
+    const url = String(input)
+    const ok = (body: unknown) => new Response(JSON.stringify(body), { status: 200, headers: { 'content-type': 'application/json' } })
+    if (init?.method === 'POST') {
+      posted.push({ url, init })
+      return new Response(JSON.stringify({ id: 'card-uuid-1', maskedPan: '**** 4242' }), { status: 201, headers: { 'content-type': 'application/json' } })
+    }
+    if (url.includes('/parties/search')) return ok({ data: [PARTY], pagination: {} })
+    if (url.includes('/accounts?') || url.includes('/accounts&')) return ok({ data: [ACCOUNT], pagination: {} })
+    if (url.includes('/products/product-uuid-1')) return ok({ id: 'product-uuid-1', code: 'CURRENT_CZK' })
+    if (url.includes('/entitlements')) return ok(ENTITLEMENTS)
+    throw new TypeError(`unstubbed ${url}`)
+  })
+}
+
+const mount = (onIssued = vi.fn()) => {
+  render(React.createElement(LanguageProvider, null,
+    React.createElement(IssueCardDialog, { onClose: vi.fn(), onIssued })))
+  return onIssued
+}
+
+beforeEach(() => { posted.length = 0; vi.stubGlobal('fetch', stubFleet()); vi.stubGlobal('crypto', { ...globalThis.crypto, randomUUID: () => 'idem-key-1' }) })
+afterEach(() => { cleanup(); vi.unstubAllGlobals() })
+
+async function walkToReview() {
+  fireEvent.change(screen.getByLabelText('Search for a client'), { target: { value: 'Čerm' } })
+  await waitFor(() => expect(screen.getByText('Bohuslava Čermáková')).toBeTruthy(), { timeout: 2000 })
+  fireEvent.click(screen.getByText('Bohuslava Čermáková'))
+  await waitFor(() => expect(screen.getByText(ACCOUNT.accountNumber)).toBeTruthy(), { timeout: 2000 })
+  fireEvent.click(screen.getByText(ACCOUNT.accountNumber))
+  // The product code is resolved from the account, never typed.
+  await waitFor(() => expect(screen.getByText('CURRENT_CZK')).toBeTruthy(), { timeout: 2000 })
+}
+
+describe('issue-card flow', () => {
+  it('walks party → account → product and shows the entitlement context', async () => {
+    mount()
+    await walkToReview()
+    expect(screen.getByText('Cards: 1 of 3')).toBeTruthy()
+  })
+
+  it('assembles the POST out of the selections, with a stable Idempotency-Key', async () => {
+    mount()
+    await walkToReview()
+    fireEvent.click(screen.getByText('Continue'))
+    await waitFor(() => expect(screen.getByText('Issue the card')).toBeTruthy())
+    fireEvent.click(screen.getByText('Issue the card'))
+
+    await waitFor(() => expect(posted).toHaveLength(1))
+    const { url, init } = posted[0]
+    expect(url).toContain('/api/svc/card-issuance-service/api/v1/cards')
+    expect((init.headers as Record<string, string>)['Idempotency-Key']).toBe('idem-key-1')
+    expect(JSON.parse(String(init.body))).toEqual({
+      partyId: 'party-uuid-1',
+      accountId: 'account-uuid-1',
+      productCode: 'CURRENT_CZK',
+      cardType: 'DEBIT',
+      network: 'VISA',
+      cardholderName: 'Bohuslava Čermáková',
+      embossedName: 'BOHUSLAVA CERMAKOVA',
+      currency: 'CZK',
+      dailyLimitMinorUnits: 500_000,
+      monthlyLimitMinorUnits: 5_000_000,
+    })
+    // The BFF stamps the operator identity server-side; a client-set one would be
+    // an audit field the audited party controls.
+    expect(JSON.stringify(init.headers)).not.toContain('Operator')
+  })
+
+  it('refuses an exhausted quota up front and says why', async () => {
+    vi.stubGlobal('fetch', vi.fn(async (input: RequestInfo | URL) => {
+      const url = String(input)
+      const ok = (body: unknown) => new Response(JSON.stringify(body), { status: 200, headers: { 'content-type': 'application/json' } })
+      if (url.includes('/parties/search')) return ok({ data: [PARTY] })
+      if (url.includes('/accounts?')) return ok({ data: [ACCOUNT] })
+      if (url.includes('/products/')) return ok({ code: 'CURRENT_CZK' })
+      if (url.includes('/entitlements')) return ok({ ...ENTITLEMENTS, issued: 3, remaining: 0 })
+      throw new TypeError(`unstubbed ${url}`)
+    }))
+    mount()
+    await walkToReview()
+    await waitFor(() => expect(screen.getByText('The client already holds every card this product allows.')).toBeTruthy())
+    expect((screen.getByText('Continue').closest('button') as HTMLButtonElement).disabled).toBe(true)
+  })
+})

--- a/openbank-admin-ui/src/test/card-issue-flow.test.ts
+++ b/openbank-admin-ui/src/test/card-issue-flow.test.ts
@@ -1,0 +1,145 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright (c) OpenBank contributors. Licensed under the Apache License, Version 2.0.
+// See LICENSE in the repository root or https://www.apache.org/licenses/LICENSE-2.0 for details.
+
+// The issue flow's whole job is that an operator never types a UUID: partyId,
+// accountId, productCode and currency are all WALKED to. These tests assert the
+// walk cannot be short-circuited — no request body exists until every identifier
+// has been derived from a real selection.
+
+import { describe, it, expect } from 'vitest'
+import {
+  DEFAULT_DAILY_LIMIT_MINOR, DEFAULT_MONTHLY_LIMIT_MINOR,
+  canAdvance, initialDraft, issueRequestBody, nextStep, prevStep, reachable,
+  stepBlockers, toEmbossedName, withAccountSelected, withPartySelected,
+  type IssueDraft,
+} from '@/lib/cards/issue'
+import type { AccountRef, CardEntitlements, PartyRef } from '@/lib/cards/types'
+
+const party: PartyRef = { id: 'p-1', legalName: 'Bohuslava Čermáková', email: 'b@example.test', status: 'ACTIVE' }
+const account: AccountRef = {
+  id: 'a-1', accountNumber: 'CZ6508000000192000145399', accountType: 'CURRENT',
+  partyId: 'p-1', productId: 'prod-1', currencyCode: 'CZK', status: 'ACTIVE',
+}
+const entitlements: CardEntitlements = {
+  productCode: 'CURRENT_CZK', maxCards: 3, issued: 1, remaining: 2,
+  virtualCardAllowed: true, singleUseAllowed: true, networks: ['VISA'],
+  tiers: [], monthlyFeePerCard: 0, enabled: true, source: 'CATALOG',
+}
+
+function complete(): IssueDraft {
+  let d = withPartySelected(initialDraft(), party)
+  d = withAccountSelected(d, account)
+  return { ...d, productCode: 'CURRENT_CZK', entitlements }
+}
+
+describe('embossing line', () => {
+  it('folds diacritics, upper-cases and stays within 26 characters', () => {
+    expect(toEmbossedName('Bohuslava Čermáková')).toBe('BOHUSLAVA CERMAKOVA')
+    expect(toEmbossedName('Jiří Řehoř')).toBe('JIRI REHOR')
+    expect(toEmbossedName('Bohuslava Čermáková-Nováková')).toHaveLength(26)
+  })
+
+  it('drops characters an embosser cannot print', () => {
+    expect(toEmbossedName('Anna (Ann) Nováková, 2nd')).toBe('ANNA ANN NOVAKOVA ND')
+  })
+})
+
+describe('prefill', () => {
+  it('takes the cardholder and embossed names from the party — nothing is retyped', () => {
+    const d = withPartySelected(initialDraft(), party)
+    expect(d.cardholderName).toBe('Bohuslava Čermáková')
+    expect(d.embossedName).toBe('BOHUSLAVA CERMAKOVA')
+  })
+
+  it('starts from the service’s own default limits', () => {
+    expect(initialDraft().dailyMinorUnits).toBe(DEFAULT_DAILY_LIMIT_MINOR)
+    expect(initialDraft().monthlyMinorUnits).toBe(DEFAULT_MONTHLY_LIMIT_MINOR)
+  })
+
+  it('invalidates the account, product and entitlement when the party changes', () => {
+    const d = withPartySelected(complete(), { id: 'p-2', legalName: 'Other' })
+    expect(d.account).toBeNull()
+    expect(d.productCode).toBeNull()
+    expect(d.entitlements).toBeNull()
+  })
+
+  it('invalidates the product and entitlement when the account changes', () => {
+    const d = withAccountSelected(complete(), { ...account, id: 'a-2', productId: 'prod-2' })
+    expect(d.productCode).toBeNull()
+    expect(d.entitlements).toBeNull()
+  })
+})
+
+describe('step gating', () => {
+  it('will not leave the party step without a party', () => {
+    expect(stepBlockers('party', initialDraft())).toEqual(['no_party'])
+    expect(canAdvance('party', withPartySelected(initialDraft(), party))).toBe(true)
+  })
+
+  it('will not leave the account step without an ACTIVE account', () => {
+    const noAccount = withPartySelected(initialDraft(), party)
+    expect(stepBlockers('account', noAccount)).toEqual(['no_account'])
+    const closed = withAccountSelected(noAccount, { ...account, status: 'CLOSED' })
+    expect(stepBlockers('account', closed)).toEqual(['account_not_active'])
+    expect(canAdvance('account', withAccountSelected(noAccount, account))).toBe(true)
+  })
+
+  it('will not configure a card whose product could not be resolved', () => {
+    const d = { ...complete(), productCode: null }
+    expect(stepBlockers('configure', d)).toContain('no_product')
+  })
+
+  it('surfaces an entitlement refusal as its own blocker, named after the service code', () => {
+    const d = { ...complete(), cardType: 'VIRTUAL' as const, entitlements: { ...entitlements, virtualCardAllowed: false, singleUseAllowed: false } }
+    expect(stepBlockers('configure', d)).toContain('entitlement:CARD_VIRTUAL_NOT_ALLOWED')
+  })
+
+  it('applies the same limit invariants the aggregate applies to a PENDING card', () => {
+    const d = { ...complete(), dailyMinorUnits: 9_000_000 }
+    expect(stepBlockers('review', d)).toContain('limits:daily_exceeds_monthly')
+    expect(stepBlockers('review', { ...complete(), dailyMinorUnits: null })).toContain('limits:daily_not_a_number')
+  })
+
+  it('refuses a name the operator cleared', () => {
+    expect(stepBlockers('review', { ...complete(), embossedName: '  ' })).toContain('no_embossed_name')
+  })
+
+  it('walks forward and back without falling off either end', () => {
+    expect(nextStep('party')).toBe('account')
+    expect(nextStep('review')).toBe('review')
+    expect(prevStep('account')).toBe('party')
+    expect(prevStep('party')).toBe('party')
+  })
+
+  it('keeps later steps unreachable until the earlier ones are satisfied', () => {
+    expect(reachable('review', initialDraft())).toBe(false)
+    expect(reachable('party', initialDraft())).toBe(true)
+    expect(reachable('review', complete())).toBe(true)
+  })
+})
+
+describe('request body', () => {
+  it('derives every identifier from the selections — none is typed', () => {
+    expect(issueRequestBody(complete())).toEqual({
+      partyId: 'p-1',
+      accountId: 'a-1',
+      productCode: 'CURRENT_CZK',
+      cardType: 'DEBIT',
+      network: 'VISA',
+      cardholderName: 'Bohuslava Čermáková',
+      embossedName: 'BOHUSLAVA CERMAKOVA',
+      currency: 'CZK',
+      dailyLimitMinorUnits: DEFAULT_DAILY_LIMIT_MINOR,
+      monthlyLimitMinorUnits: DEFAULT_MONTHLY_LIMIT_MINOR,
+    })
+  })
+
+  it('is null for any incomplete or refused draft — never a partial POST', () => {
+    expect(issueRequestBody(initialDraft())).toBeNull()
+    expect(issueRequestBody({ ...complete(), productCode: null })).toBeNull()
+    expect(issueRequestBody({ ...complete(), dailyMinorUnits: null })).toBeNull()
+    expect(issueRequestBody({ ...complete(), entitlements: { ...entitlements, remaining: 0, issued: 3 } })).toBeNull()
+    expect(issueRequestBody({ ...complete(), account: { ...account, status: 'CLOSED' } })).toBeNull()
+  })
+})

--- a/openbank-admin-ui/src/test/card-money.test.ts
+++ b/openbank-admin-ui/src/test/card-money.test.ts
@@ -1,0 +1,90 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright (c) OpenBank contributors. Licensed under the Apache License, Version 2.0.
+// See LICENSE in the repository root or https://www.apache.org/licenses/LICENSE-2.0 for details.
+
+// The card limit editor shows major units and the API takes minor units. A factor
+// of 100 on a spending limit is the kind of back-office slip that reaches a
+// customer, so the conversion is pinned here — including the float trap
+// (`19.99 * 100 === 1998.9999999999998`) that makes the naive version lose a
+// haléř on every edit.
+
+import { describe, it, expect } from 'vitest'
+import {
+  currencyExponent, formatMinor, minorToMajorString, parseMajorToMinor,
+} from '@/lib/cards/money'
+
+describe('currency exponent', () => {
+  it('is 2 for the ordinary currencies and 0 for the zero-decimal ones', () => {
+    expect(currencyExponent('CZK')).toBe(2)
+    expect(currencyExponent('eur')).toBe(2)
+    expect(currencyExponent('JPY')).toBe(0)
+    expect(currencyExponent('ISK')).toBe(0)
+  })
+
+  it('assumes 2 for an unknown or missing code rather than throwing', () => {
+    expect(currencyExponent('ZZZ')).toBe(2)
+    expect(currencyExponent(null)).toBe(2)
+    expect(currencyExponent(undefined)).toBe(2)
+  })
+})
+
+describe('minor → major', () => {
+  it('renders the API default limits as the amounts an operator recognises', () => {
+    expect(minorToMajorString(500_000, 'CZK')).toBe('5000.00')
+    expect(minorToMajorString(5_000_000, 'CZK')).toBe('50000.00')
+  })
+
+  it('pads sub-unit amounts instead of dropping the leading zero', () => {
+    expect(minorToMajorString(5, 'EUR')).toBe('0.05')
+    expect(minorToMajorString(0, 'EUR')).toBe('0.00')
+  })
+
+  it('leaves a zero-decimal currency alone', () => {
+    expect(minorToMajorString(5000, 'JPY')).toBe('5000')
+  })
+})
+
+describe('major → minor', () => {
+  it('round-trips the amounts the form produces', () => {
+    expect(parseMajorToMinor('5000.00', 'CZK')).toBe(500_000)
+    expect(parseMajorToMinor('5000', 'CZK')).toBe(500_000)
+    expect(parseMajorToMinor('0.05', 'EUR')).toBe(5)
+  })
+
+  it('does not lose a minor unit to floating point', () => {
+    expect(parseMajorToMinor('19.99', 'EUR')).toBe(1999)
+    expect(parseMajorToMinor('1234.56', 'CZK')).toBe(123456)
+  })
+
+  it('accepts the separators a Czech operator actually types', () => {
+    expect(parseMajorToMinor('5 000,50', 'CZK')).toBe(500_050)
+    expect(parseMajorToMinor('5 000,50', 'CZK')).toBe(500_050)
+  })
+
+  it('refuses text that is not an amount this currency can hold', () => {
+    expect(parseMajorToMinor('', 'CZK')).toBeNull()
+    expect(parseMajorToMinor('abc', 'CZK')).toBeNull()
+    expect(parseMajorToMinor('1.2.3', 'CZK')).toBeNull()
+    // More decimals than the currency has minor units — rounding would change intent.
+    expect(parseMajorToMinor('10.999', 'CZK')).toBeNull()
+    expect(parseMajorToMinor('10.5', 'JPY')).toBeNull()
+  })
+
+  it('refuses a negative amount outright (Card.withLimits requires >= 0)', () => {
+    expect(parseMajorToMinor('-1', 'CZK')).toBeNull()
+    expect(parseMajorToMinor('-0.01', 'EUR')).toBeNull()
+  })
+})
+
+describe('display formatting', () => {
+  it('formats with the currency and the right number of decimals', () => {
+    expect(formatMinor(500_000, 'CZK', 'en-US')).toContain('5,000.00')
+    expect(formatMinor(5000, 'JPY', 'en-US')).not.toContain('.')
+  })
+
+  it('degrades to "<amount> <CODE>" for a code Intl does not know', () => {
+    const out = formatMinor(12_345, 'XX', 'en-US')
+    expect(out).toContain('123.45')
+    expect(out).toContain('XX')
+  })
+})

--- a/openbank-admin-ui/src/test/card-mutations.test.ts
+++ b/openbank-admin-ui/src/test/card-mutations.test.ts
@@ -1,0 +1,51 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright (c) OpenBank contributors. Licensed under the Apache License, Version 2.0.
+// See LICENSE in the repository root or https://www.apache.org/licenses/LICENSE-2.0 for details.
+
+// A failed card WRITE has to be explainable. `classifyBffFailure` is a read-path
+// classifier and calls every unusual 4xx `error`; these are the extra distinctions
+// an operator acts on differently — "the card moved under you", "the product says
+// no, and here is which rule", "your role may not do this".
+
+import { describe, it, expect } from 'vitest'
+import { classifyMutation, cardErrorCode } from '@/lib/cards/mutations'
+
+const json = (status: number, body: unknown) =>
+  new Response(JSON.stringify(body), { status, headers: { 'content-type': 'application/json' } })
+
+describe('card mutation classification', () => {
+  it('reads an aggregate refusal (bare 400 from CommonExceptionMappers) as a stale transition', async () => {
+    expect(await classifyMutation(json(400, { message: 'Only PENDING cards can be activated' })))
+      .toBe('illegal_transition')
+    expect(await classifyMutation(json(422, {}))).toBe('illegal_transition')
+  })
+
+  it('names WHICH product rule refused a 409', async () => {
+    expect(await classifyMutation(json(409, { code: 'CARD_QUOTA_EXCEEDED' }))).toBe('conflict:CARD_QUOTA_EXCEEDED')
+    expect(await classifyMutation(json(409, { code: 'CARD_NETWORK_NOT_ALLOWED' }))).toBe('conflict:CARD_NETWORK_NOT_ALLOWED')
+    expect(await classifyMutation(json(409, { code: 'CARD_VIRTUAL_NOT_ALLOWED' }))).toBe('conflict:CARD_VIRTUAL_NOT_ALLOWED')
+    expect(await classifyMutation(json(409, { code: 'CARD_PRODUCT_DISABLED' }))).toBe('conflict:CARD_PRODUCT_DISABLED')
+  })
+
+  it('falls back to a plain conflict for an unknown or missing code', async () => {
+    expect(await classifyMutation(json(409, { code: 'SOMETHING_NEW' }))).toBe('conflict')
+    expect(await classifyMutation(new Response('not json', { status: 409 }))).toBe('conflict')
+  })
+
+  it('keeps 403 distinct from 401 — a role problem is not an expired session', async () => {
+    expect(await classifyMutation(json(403, {}))).toBe('forbidden')
+    expect(await classifyMutation(json(401, { error: 'unauthorized' }))).toBe('unauthorized')
+  })
+
+  it('still delegates the BFF-level outcomes to the shared read classifier', async () => {
+    expect(await classifyMutation(json(404, { error: 'Unknown service: card-issuance-service' }))).toBe('not_deployed')
+    expect(await classifyMutation(json(503, { error: 'scaled_to_zero' }))).toBe('scaled_to_zero')
+    expect(await classifyMutation(json(502, { error: 'upstream_unreachable' }))).toBe('unreachable')
+    expect(await classifyMutation(json(404, {}))).toBe('not_found')
+    expect(await classifyMutation(json(500, {}))).toBe('error')
+  })
+
+  it('never throws on a body it cannot read', async () => {
+    expect(await cardErrorCode(new Response('<html>', { status: 409 }))).toBeNull()
+  })
+})

--- a/openbank-admin-ui/src/test/card-rules.test.ts
+++ b/openbank-admin-ui/src/test/card-rules.test.ts
@@ -1,0 +1,69 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright (c) OpenBank contributors. Licensed under the Apache License, Version 2.0.
+// See LICENSE in the repository root or https://www.apache.org/licenses/LICENSE-2.0 for details.
+
+// Pins the limits/controls invariants against Card.kt, the same way
+// card-lifecycle.test.ts pins the transition table: a backend guard that stops
+// being mirrored here starts producing bare 400s in the operator's face.
+//
+// Card.kt:
+//   withLimits()   require(status in setOf(ACTIVE, SUSPENDED, PENDING))
+//                  require(dailyMinor >= 0 && monthlyMinor >= 0)
+//                  require(dailyMinor <= monthlyMinor)
+//   withControls() require(status in setOf(ACTIVE, SUSPENDED, PENDING))
+
+import { describe, it, expect } from 'vitest'
+import { CARD_STATUSES } from '@/lib/cards/lifecycle'
+import { canEditSettings, settingsBlock, validateLimits, limitsAcceptable } from '@/lib/cards/rules'
+
+describe('which cards may be re-limited / re-controlled', () => {
+  it('mirrors Card.withLimits: PENDING, ACTIVE and SUSPENDED only', () => {
+    const editable = CARD_STATUSES.filter(canEditSettings)
+    expect(editable).toEqual(['PENDING', 'ACTIVE', 'SUSPENDED'])
+  })
+
+  it('names the reason a dead card cannot be edited, instead of just refusing', () => {
+    expect(settingsBlock('ACTIVE')).toBeNull()
+    expect(settingsBlock('BLOCKED')).toBe('blocked')
+    expect(settingsBlock('CANCELLED')).toBe('terminal')
+    expect(settingsBlock('EXPIRED')).toBe('terminal')
+    expect(settingsBlock('WHATEVER')).toBe('unknown_status')
+    expect(settingsBlock(undefined)).toBe('unknown_status')
+  })
+})
+
+describe('limit validation', () => {
+  const ok = { status: 'ACTIVE', dailyMinorUnits: 100, monthlyMinorUnits: 1000 }
+
+  it('accepts a well-formed edit on a live card', () => {
+    expect(validateLimits(ok)).toEqual([])
+    expect(limitsAcceptable(ok)).toBe(true)
+  })
+
+  it('accepts daily == monthly (the guard is <=, not <)', () => {
+    expect(validateLimits({ ...ok, dailyMinorUnits: 1000 })).toEqual([])
+  })
+
+  it('rejects daily > monthly', () => {
+    expect(validateLimits({ ...ok, dailyMinorUnits: 1001 })).toEqual(['daily_exceeds_monthly'])
+  })
+
+  it('rejects a field that did not parse, and never calls it a comparison failure', () => {
+    expect(validateLimits({ ...ok, dailyMinorUnits: null })).toEqual(['daily_not_a_number'])
+    expect(validateLimits({ ...ok, monthlyMinorUnits: null })).toEqual(['monthly_not_a_number'])
+  })
+
+  it('rejects a negative value (Card.withLimits requires non-negative)', () => {
+    expect(validateLimits({ ...ok, dailyMinorUnits: -1 })).toEqual(['daily_not_a_number'])
+    expect(validateLimits({ ...ok, monthlyMinorUnits: -1 })).toEqual(['monthly_not_a_number'])
+  })
+
+  it('reports the status violation as well as the value ones', () => {
+    expect(validateLimits({ status: 'BLOCKED', dailyMinorUnits: 2000, monthlyMinorUnits: 1000 }))
+      .toEqual(['status', 'daily_exceeds_monthly'])
+  })
+
+  it('accepts zero limits — a live card capped to nothing is legal, not an error', () => {
+    expect(validateLimits({ status: 'PENDING', dailyMinorUnits: 0, monthlyMinorUnits: 0 })).toEqual([])
+  })
+})

--- a/openbank-admin-ui/src/test/card-settings-panels.test.tsx
+++ b/openbank-admin-ui/src/test/card-settings-panels.test.tsx
@@ -1,0 +1,114 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright (c) OpenBank contributors. Licensed under the Apache License, Version 2.0.
+// See LICENSE in the repository root or https://www.apache.org/licenses/LICENSE-2.0 for details.
+
+// The two operator-parity editors, mounted for real.
+//
+// The pure rules are pinned in card-rules.test.ts; what these assert is the WIRING,
+// which is where a limits editor actually goes wrong: that the operator's major
+// units reach the API as minor units, that all four channel flags are sent (the
+// endpoint takes the complete set), and that a card the aggregate would refuse
+// cannot be saved at all.
+
+import { describe, it, expect, vi, afterEach } from 'vitest'
+import React from 'react'
+import { render, screen, cleanup, fireEvent } from '@testing-library/react'
+import { LanguageProvider } from '@/lib/i18n/LanguageContext'
+import { CardLimitsPanel } from '@/components/cards/CardLimitsPanel'
+import { CardControlsPanel } from '@/components/cards/CardControlsPanel'
+import type { Card } from '@/lib/cards/types'
+
+const card = (over: Partial<Card> = {}): Card => ({
+  id: 'c-1',
+  partyId: 'p-1',
+  accountId: 'a-1',
+  productCode: 'CURRENT_CZK',
+  cardType: 'DEBIT',
+  network: 'VISA',
+  maskedPan: '**** **** **** 4242',
+  cardholderName: 'Bohuslava Cermakova',
+  embossedName: 'BOHUSLAVA CERMAKOVA',
+  expiryDate: '2029-07-31',
+  status: 'ACTIVE',
+  dailyLimitMinorUnits: 500_000,
+  monthlyLimitMinorUnits: 5_000_000,
+  currency: 'CZK',
+  createdAt: '2026-01-01T10:00:00Z',
+  contactlessEnabled: true,
+  onlineEnabled: true,
+  atmEnabled: true,
+  abroadEnabled: true,
+  ...over,
+})
+
+const mount = (ui: React.ReactNode) => render(React.createElement(LanguageProvider, null, ui))
+
+afterEach(cleanup)
+
+describe('limits editor', () => {
+  it('sends what the operator typed in MAJOR units as minor units', () => {
+    const onSave = vi.fn().mockResolvedValue(true)
+    mount(<CardLimitsPanel card={card()} busy={null} onSave={onSave} />)
+
+    const daily = screen.getByLabelText('Daily limit')
+    expect((daily as HTMLInputElement).value).toBe('5000.00') // 500000 minor units
+    fireEvent.change(daily, { target: { value: '2500.50' } })
+    fireEvent.click(screen.getByText('Save limits'))
+
+    expect(onSave).toHaveBeenCalledWith(250_050, 5_000_000)
+  })
+
+  it('will not save an edit the aggregate would refuse (daily > monthly)', () => {
+    const onSave = vi.fn()
+    mount(<CardLimitsPanel card={card()} busy={null} onSave={onSave} />)
+
+    fireEvent.change(screen.getByLabelText('Daily limit'), { target: { value: '90000' } })
+    expect(screen.getByText('The daily limit cannot exceed the monthly one.')).toBeTruthy()
+    fireEvent.click(screen.getByText('Save limits'))
+    expect(onSave).not.toHaveBeenCalled()
+  })
+
+  it('will not save an unchanged card — no no-op writes into the audit trail', () => {
+    const onSave = vi.fn()
+    mount(<CardLimitsPanel card={card()} busy={null} onSave={onSave} />)
+    fireEvent.click(screen.getByText('Save limits'))
+    expect(onSave).not.toHaveBeenCalled()
+  })
+
+  it('explains WHY a blocked card cannot be re-limited instead of greying out silently', () => {
+    const onSave = vi.fn()
+    mount(<CardLimitsPanel card={card({ status: 'BLOCKED' })} busy={null} onSave={onSave} />)
+    expect(screen.getByText(/A blocked card has nothing left to spend/)).toBeTruthy()
+    expect((screen.getByLabelText('Daily limit') as HTMLInputElement).disabled).toBe(true)
+  })
+})
+
+describe('channel controls', () => {
+  it('sends the COMPLETE set of four flags, not just the one that changed', () => {
+    const onSave = vi.fn().mockResolvedValue(true)
+    mount(<CardControlsPanel card={card()} busy={null} onSave={onSave} />)
+
+    fireEvent.click(screen.getByLabelText('Online payments'))
+    fireEvent.click(screen.getByText('Save channels'))
+
+    expect(onSave).toHaveBeenCalledWith({
+      contactlessEnabled: true,
+      onlineEnabled: false,
+      atmEnabled: true,
+      abroadEnabled: true,
+    })
+  })
+
+  it('defaults a card that predates the controls columns to all-on', () => {
+    const onSave = vi.fn().mockResolvedValue(true)
+    const legacy = card({ contactlessEnabled: undefined, onlineEnabled: undefined, atmEnabled: undefined, abroadEnabled: undefined })
+    mount(<CardControlsPanel card={legacy} busy={null} onSave={onSave} />)
+    expect(screen.getByLabelText('Use abroad').getAttribute('aria-checked')).toBe('true')
+  })
+
+  it('is read-only on a terminal card, with the reason on screen', () => {
+    mount(<CardControlsPanel card={card({ status: 'CANCELLED' })} busy={null} onSave={vi.fn()} />)
+    expect(screen.getByText(/terminal state/)).toBeTruthy()
+    expect((screen.getByLabelText('ATM withdrawals') as HTMLButtonElement).disabled).toBe(true)
+  })
+})


### PR DESCRIPTION
The portal could change a card's status. Nothing else: no detail view, rows weren't clickable, and an operator had no way to do the everyday things a customer does in the mobile app. This gives the back office parity with the customer app plus operator-only actions, built on top of the already-merged lifecycle-actions PR (#2244) — reused, not rewritten.

## Detail view is a route, not a panel

`/cards/<uuid>`: a card in a back office is what a conversation is *about* (fraud call, complaint, four-eyes approval), so it has to paste into a ticket, survive reload, support browser back.

Shows everything the service knows — party, account, product, limits, the four channel controls, timestamps, blocked reason — plus the party's **other cards** and their entitlement standing ("2 of 3"), because fraud work is rarely about one card in isolation.

## Limits and channel controls, editable

Gated on the same domain guards `Card.kt` enforces (ACTIVE/SUSPENDED/PENDING only, non-negative, daily ≤ monthly) so the client refuses before the server has to. Controls always send all four fields — `UpdateControlsRequest` has none optional.

## Issue Card, built this time

I previously removed the decorative button, arguing there was no account picker. That was wrong — `GET /accounts?partyId=` exists.

Flow: party search → pick one of their accounts → resolve the account's product → entitlements check → confirm. **No UUID typing anywhere**; cardholder/embossed names prefill from the party, currency from the account.

`Idempotency-Key` is generated once per attempt with `crypto.randomUUID()` and **reused on retry**, matching card-issuance's per-request dedup — regenerating it on retry would defeat the point.

Deliberately refuses to fall back to a guessed product code. customer-edge's own `VIRTUAL_DEBIT` shortcut is exactly the failure mode to avoid in a back office, where the wrong product means the wrong fee and the wrong rules: an unresolved product blocks the flow with a retry rather than guessing.

## PCI

`secure-details` is not wired anywhere in this change. Said once, plainly, on both the list and the detail view, so the absence reads as a control rather than a gap.

## Carried forward unchanged

`X-Operator-Id` is still derived server-side from the session — no client code added here sets it.

## Verification

```
npm run type-check → clean
npm run lint        → 0 errors (80 pre-existing warnings, 2 new but pre-existing pattern)
npm test             → 47 files, 750 tests passed
npx next build       → ✓ /cards and /cards/[id] built
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)