### PR TITLE
feat(mcp): resolve acting agent + consent from the OAuth token (ADR-0195 step 1)

### DIFF
--- a/openbank-mcp-service/src/main/kotlin/com/openbank/mcp/infrastructure/mcp/CallerContextResolver.kt
+++ b/openbank-mcp-service/src/main/kotlin/com/openbank/mcp/infrastructure/mcp/CallerContextResolver.kt
@@ -1,0 +1,47 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+// Copyright (c) OpenBank contributors. Licensed under the GNU Affero General Public License v3.0 only.
+// A commercial licence is available from the maintainers as an alternative to the AGPL-3.0.
+// See LICENSES/AGPL-3.0-only.txt or https://www.gnu.org/licenses/agpl-3.0.html for details.
+package com.openbank.mcp.infrastructure.mcp
+
+import com.openbank.mcp.application.port.out.ConsentContext
+import jakarta.enterprise.context.ApplicationScoped
+import org.eclipse.microprofile.jwt.JsonWebToken
+
+/**
+ * Resolves the acting agent + presented PSD2 consent from the caller's validated OAuth 2.1 access
+ * token (ADR-0195). This is the caller-authentication half of MCP phase 2 (BLOCKER #2206): the OPA
+ * PDP must be asked about the *real* agent and the *real* consent, not the phase-1 placeholder.
+ *
+ * Returns `null` when no agent token is present — OIDC is still tenant-disabled, or the call is
+ * anonymous — so [McpEndpoint] can fall back to the phase-1 placeholder identity WITHOUT this class
+ * carrying that constant. That keeps the fallback (and the #2206 CI guard's `agent:mcp-anonymous`
+ * anchor) in one place, `McpEndpoint`.
+ *
+ * The token's `sub` (shape `agent:<id>`, which the shared `AuthorizeInterceptor` classifies as
+ * `AI_AGENT`) is the OPA principal id; the `consent_id` claim names the presented consent.
+ * `grantedAccounts` is left empty here on purpose: it is populated by the real read ports via
+ * consent-service `POST /consents/{id}/validate` (ADR-0195, the next step) — the only place the
+ * tool's required `ConsentScope` and the target account are known, and the only source that honours
+ * revoke/expire live. Account scope is never taken from the token.
+ */
+@ApplicationScoped
+class CallerContextResolver(private val jwt: JsonWebToken) {
+
+    /**
+     * @return the caller's [ConsentContext] when an `agent:` bearer token is present, else `null`.
+     * @throws IllegalStateException when an agent token is present but carries no `consent_id` — a
+     *   malformed token must fail closed, never silently degrade to an unscoped read.
+     */
+    fun resolveOrNull(): ConsentContext? {
+        val subject = jwt.subject?.takeIf { it.startsWith(AGENT_PREFIX) } ?: return null
+        val consentId = jwt.getClaim<String?>(CLAIM_CONSENT_ID)?.takeIf { it.isNotBlank() }
+            ?: error("agent token '$subject' carries no '$CLAIM_CONSENT_ID' claim")
+        return ConsentContext(agentId = subject, consentId = consentId, grantedAccounts = emptyList())
+    }
+
+    private companion object {
+        const val AGENT_PREFIX = "agent:"
+        const val CLAIM_CONSENT_ID = "consent_id"
+    }
+}

--- a/openbank-mcp-service/src/main/kotlin/com/openbank/mcp/infrastructure/mcp/McpEndpoint.kt
+++ b/openbank-mcp-service/src/main/kotlin/com/openbank/mcp/infrastructure/mcp/McpEndpoint.kt
@@ -45,9 +45,13 @@ import org.jboss.logging.Logger
  * against the bank is reconstructable. `tools/list`, `initialize` and `ping` do not: they touch no
  * customer data and expose only the static tool catalogue.
  *
- * Phase 1: the acting agent + consent are resolved from headers (X-Agent-Id / X-Consent-Id); the
- * real OAuth 2.1 → PSD2-consent binding (ADR-0126) is phase 2. The principal id is `agent:`-prefixed
- * so the shared AuthorizeInterceptor/rego classify it AI_AGENT and bridge to `agents.allow`.
+ * Caller identity (ADR-0195): the acting agent + presented consent come from the caller's validated
+ * OAuth 2.1 access token via [CallerContextResolver] — `sub` (`agent:<id>`, classified AI_AGENT by
+ * the shared AuthorizeInterceptor/rego and bridged to `agents.allow`) and the `consent_id` claim.
+ * While OIDC is still tenant-disabled no agent token is presented, so the resolver returns null and
+ * the endpoint falls back to the phase-1 placeholder identity (unchanged deployed behaviour). The
+ * consent's `grantedAccounts` are validated live at consent-service by the real read ports (the next
+ * ADR-0195 step); account scope is never taken from the token.
  */
 @Path("/mcp")
 @Consumes(MediaType.APPLICATION_JSON)
@@ -56,6 +60,7 @@ class McpEndpoint(
     private val registry: McpToolRegistry,
     private val pdp: PolicyDecisionPoint,
     private val auditor: McpCallAuditor,
+    private val callerResolver: CallerContextResolver,
     private val mapper: ObjectMapper,
     @ConfigProperty(name = "mcp.server.name", defaultValue = "openbank-mcp") private val serverName: String,
     @ConfigProperty(name = "mcp.server.version", defaultValue = "0.1.0") private val serverVersion: String,
@@ -91,10 +96,15 @@ class McpEndpoint(
     private fun handleToolCall(id: JsonNode, params: JsonNode): Response {
         val toolName = params.path("name").asText("")
         val arguments = params.path("arguments").let { if (it.isMissingNode) mapper.createObjectNode() else it }
-        val ctx = resolveContext()
         // Argument KEY names only — the values are customer data and must never enter the audit
         // trail (McpCallAuditor KDoc).
         val argumentKeys = arguments.fieldNames().asSequence().sorted().toList()
+
+        // Caller authentication (ADR-0195): the acting agent + presented consent come from the
+        // validated OAuth token. A malformed agent token (e.g. no consent_id) fails CLOSED — a
+        // money-adjacent surface never degrades to an unscoped identity.
+        val ctx = resolveCaller(toolName, argumentKeys)
+            ?: return toolError(id, "Authorization unavailable")
 
         fun audit(
             capability: String?,
@@ -163,11 +173,38 @@ class McpEndpoint(
         }
     }
 
-    // Phase 1 identity: headers. Phase 2: OAuth 2.1 token -> PSD2 consent (grantedAccounts).
-    private fun resolveContext(): ConsentContext {
-        // Placeholder resolution; the real binding lands with the OAuth resource-server config.
-        return ConsentContext(agentId = "agent:mcp-anonymous", consentId = "none", grantedAccounts = emptyList())
+    // Resolve the caller's identity + consent, or audit the failure and return null (the caller
+    // then denies with "Authorization unavailable"). Fails closed on any resolution error.
+    @Suppress("TooGenericExceptionCaught")
+    private fun resolveCaller(toolName: String, argumentKeys: List<String>): ConsentContext? = try {
+        resolveContext()
+    } catch (ex: Exception) {
+        log.warnf("caller context resolution failed for %s: %s — denying", toolName, ex.message)
+        runBlocking {
+            auditor.toolCallCompleted(
+                McpCallAuditor.ToolCall(
+                    agentId = "unknown",
+                    consentId = "none",
+                    tool = toolName,
+                    capability = null,
+                    decision = McpCallAuditor.Decision.UNAVAILABLE,
+                    result = AuditResult.DENIED,
+                    reason = "caller authentication failed",
+                    argumentKeys = argumentKeys,
+                ),
+            )
+        }
+        null
     }
+
+    // ADR-0195: the acting agent + consent come from the caller's validated OAuth token
+    // (CallerContextResolver). Until OIDC is enabled and a token is required, no agent token is
+    // presented and the resolver returns null, so we fall back to the phase-1 placeholder — the
+    // deployed stub surface keeps working unchanged. The `agent:mcp-anonymous` literal deliberately
+    // lives HERE: the #2206 CI guard keys on it, refusing to let a real read port land while this
+    // fallback is still reachable. It is removed when OIDC is enabled and a token becomes mandatory.
+    private fun resolveContext(): ConsentContext = callerResolver.resolveOrNull()
+        ?: ConsentContext(agentId = "agent:mcp-anonymous", consentId = "none", grantedAccounts = emptyList())
 
     private fun toolError(id: JsonNode, message: String): Response = Response.ok(
         McpResponse(id = id, result = ToolCallResult(listOf(ToolContent(text = message)), isError = true)),

--- a/openbank-mcp-service/src/test/kotlin/com/openbank/mcp/McpEndpointTest.kt
+++ b/openbank-mcp-service/src/test/kotlin/com/openbank/mcp/McpEndpointTest.kt
@@ -15,6 +15,7 @@ import com.openbank.mcp.application.McpToolRegistry
 import com.openbank.mcp.application.port.out.AccountReadPort
 import com.openbank.mcp.application.port.out.ConsentContext
 import com.openbank.mcp.application.port.out.ProposalPort
+import com.openbank.mcp.infrastructure.mcp.CallerContextResolver
 import com.openbank.mcp.infrastructure.mcp.McpEndpoint
 import org.assertj.core.api.Assertions.assertThat
 import org.junit.jupiter.api.Test
@@ -33,7 +34,10 @@ class McpEndpointTest {
     private fun endpoint(pdp: PolicyDecisionPoint): McpEndpoint {
         val stub = StubReads(mapper)
         val registry = McpToolRegistry(stub, stub, mapper)
-        return McpEndpoint(registry, pdp, McpCallAuditor(audit), mapper, "openbank-mcp", "0.1.0", "2025-06-18")
+        // Anonymous JWT (no `sub`) → the resolver returns null → the endpoint uses the phase-1
+        // placeholder identity, so these protocol/authorization assertions are unchanged (ADR-0195).
+        val caller = CallerContextResolver(TestJsonWebToken())
+        return McpEndpoint(registry, pdp, McpCallAuditor(audit), caller, mapper, "openbank-mcp", "0.1.0", "2025-06-18")
     }
 
     private fun rpc(method: String, params: Map<String, Any?> = emptyMap()): JsonNode =

--- a/openbank-mcp-service/src/test/kotlin/com/openbank/mcp/TestJsonWebToken.kt
+++ b/openbank-mcp-service/src/test/kotlin/com/openbank/mcp/TestJsonWebToken.kt
@@ -1,0 +1,19 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+// Copyright (c) OpenBank contributors. Licensed under the GNU Affero General Public License v3.0 only.
+package com.openbank.mcp
+
+import org.eclipse.microprofile.jwt.JsonWebToken
+
+/**
+ * Minimal POJO [JsonWebToken] for plain-unit tests (mcp tests carry no Quarkus context — see
+ * [McpEndpointTest]). Backed by a claim map; `getSubject()` resolves via `getClaim("sub")` per the
+ * MP-JWT default, so an empty map models an anonymous / OIDC-disabled call.
+ */
+class TestJsonWebToken(private val claims: Map<String, Any?> = emptyMap()) : JsonWebToken {
+    override fun getName(): String = claims["sub"]?.toString() ?: "anonymous"
+
+    override fun getClaimNames(): Set<String> = claims.keys
+
+    @Suppress("UNCHECKED_CAST")
+    override fun <T : Any?> getClaim(claimName: String): T? = claims[claimName] as? T
+}

--- a/openbank-mcp-service/src/test/kotlin/com/openbank/mcp/infrastructure/mcp/CallerContextResolverTest.kt
+++ b/openbank-mcp-service/src/test/kotlin/com/openbank/mcp/infrastructure/mcp/CallerContextResolverTest.kt
@@ -1,0 +1,60 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+// Copyright (c) OpenBank contributors. Licensed under the GNU Affero General Public License v3.0 only.
+package com.openbank.mcp.infrastructure.mcp
+
+import com.openbank.mcp.TestJsonWebToken
+import org.assertj.core.api.Assertions.assertThat
+import org.assertj.core.api.Assertions.assertThatThrownBy
+import org.junit.jupiter.api.Test
+
+/**
+ * Caller authentication (ADR-0195): the resolver turns a validated agent token into a
+ * [com.openbank.mcp.application.port.out.ConsentContext], or `null` when no agent token is present
+ * so the endpoint keeps its phase-1 placeholder. Plain-unit — no Quarkus, a POJO JWT.
+ */
+class CallerContextResolverTest {
+
+    @Test
+    fun `resolves agent id and consent from an agent token`() {
+        val ctx = CallerContextResolver(
+            TestJsonWebToken(mapOf("sub" to "agent:mcp-tpp-42", "consent_id" to "c-123")),
+        ).resolveOrNull()
+
+        assertThat(ctx).isNotNull
+        assertThat(ctx!!.agentId).isEqualTo("agent:mcp-tpp-42")
+        assertThat(ctx.consentId).isEqualTo("c-123")
+        // grantedAccounts is populated by the real read ports via consent-service /validate — the
+        // resolver never takes account scope from the token (ADR-0195).
+        assertThat(ctx.grantedAccounts).isEmpty()
+    }
+
+    @Test
+    fun `returns null when no token is present (anonymous, OIDC disabled)`() {
+        assertThat(CallerContextResolver(TestJsonWebToken()).resolveOrNull()).isNull()
+    }
+
+    @Test
+    fun `returns null when the subject is not an agent principal`() {
+        val ctx = CallerContextResolver(
+            TestJsonWebToken(mapOf("sub" to "service-account-openbank-services")),
+        ).resolveOrNull()
+        assertThat(ctx).isNull()
+    }
+
+    @Test
+    fun `fails closed when an agent token carries no consent_id`() {
+        assertThatThrownBy {
+            CallerContextResolver(TestJsonWebToken(mapOf("sub" to "agent:mcp-tpp-42"))).resolveOrNull()
+        }.isInstanceOf(IllegalStateException::class.java)
+            .hasMessageContaining("consent_id")
+    }
+
+    @Test
+    fun `fails closed when consent_id is blank`() {
+        assertThatThrownBy {
+            CallerContextResolver(
+                TestJsonWebToken(mapOf("sub" to "agent:mcp-tpp-42", "consent_id" to "  ")),
+            ).resolveOrNull()
+        }.isInstanceOf(IllegalStateException::class.java)
+    }
+}


### PR DESCRIPTION
## What

Step 1 of MCP phase-2 caller authentication (ADR-0195, resolves the code half of [#2206](https://github.com/JiRaska/open-bank-oss/issues/2206)). The OPA PDP must be asked about the **real** agent and consent, not the hardcoded `agent:mcp-anonymous` constant.

**Non-breaking by design:** OIDC stays tenant-disabled, so no agent token is presented and the resolver returns null → the endpoint keeps the phase-1 placeholder. The deployed stub surface is unchanged; this PR wires identity without turning on enforcement.

## Changes

- **`CallerContextResolver`** — reads the validated OAuth token: `sub` (`agent:<id>`, classified `AI_AGENT` by the shared interceptor) → OPA principal id; `consent_id` claim → the presented consent. A malformed agent token (no/blank `consent_id`) **fails closed**.
- **`McpEndpoint`** — `resolveContext()` delegates to the resolver, falling back to the placeholder when no token is present. The `agent:mcp-anonymous` literal stays here on purpose: the [#2230](https://github.com/JiRaska/open-bank-oss/pull/2230) guard keys on it, refusing a real read port while the fallback is reachable.

`grantedAccounts` stays empty here — it is populated by the real read ports via consent-service `POST /consents/{id}/validate` (the next step), the only place the tool's required `ConsentScope` + account are known and revoke/expire is honoured live. **Account scope is never taken from the token.**

## Verification

- Unit tests: agent token → context; anonymous / non-agent `sub` → null; missing / blank `consent_id` → fail closed.
- Local gate (JDK 25): `detekt` + `ktlintCheck` + `test` + `quarkusBuild` (CDI wiring for the `JsonWebToken` injection) — all green.
- `check-mcp-stub-ports-vs-caller-auth.sh` still passes (stub ports, placeholder present).

## Ordering (ADR-0195 / #2206)

Next steps, each its own PR: consent-service `/validate` client + real `@RegisterRestClient` read ports enforcing `grantedAccounts` (the #2230 guard gates this on the placeholder being removed) → `rest.rego` forward `attributes` so the PDP sees `consentId` → NetworkPolicy + OIDC enable + Keycloak agent-token issuer → threat-model update.

Money-path: needs 2 approvals.

Refs ADR-0195, #2206, #1922

🤖 Generated with [Claude Code](https://claude.com/claude-code)