### PR TITLE
feat(control-liveness-sentinel): load prompt from the registry + route via the LlmGatewayPort seam (#1918)

### DIFF
--- a/openbank-control-liveness-sentinel/build.gradle.kts
+++ b/openbank-control-liveness-sentinel/build.gradle.kts
@@ -45,6 +45,17 @@ dependencies {
     testImplementation(libs.rest.assured.kotlin)
 }
 
+// Package the ADR-0148 prompt registry onto the classpath so LlmDiagnosisAdapter loads its system
+// prompt from the registered file (byte-for-byte, so the prompt_hash resolves) instead of an inline
+// constant. The registry is the single source of truth (openbank-libs/governance/prompts/); this copy
+// is derived — never hand-edit the packaged copy.
+tasks.named<Copy>("processResources") {
+    from(rootProject.file("openbank-libs/governance/prompts/control-liveness-sentinel")) {
+        include("*.md")
+        into("governance-prompts/control-liveness-sentinel")
+    }
+}
+
 kover {
     reports {
         filters {

--- a/openbank-control-liveness-sentinel/src/main/kotlin/com/openbank/liveness/infrastructure/adapter/LlmDiagnosisAdapter.kt
+++ b/openbank-control-liveness-sentinel/src/main/kotlin/com/openbank/liveness/infrastructure/adapter/LlmDiagnosisAdapter.kt
@@ -5,113 +5,39 @@
 
 package com.openbank.liveness.infrastructure.adapter
 
-import com.fasterxml.jackson.databind.ObjectMapper
+import com.openbank.libs.llm.LlmGatewayPort
 import com.openbank.liveness.application.port.out.LlmDiagnosisPort
 import com.openbank.liveness.domain.model.LivenessFinding
-import com.openbank.liveness.infrastructure.config.LivenessSentinelConfig
 import jakarta.enterprise.context.ApplicationScoped
 import jakarta.inject.Inject
-import kotlinx.coroutines.Dispatchers
-import kotlinx.coroutines.withContext
-import org.eclipse.microprofile.config.ConfigProvider
-import org.jboss.logging.Logger
-import java.net.URI
-import java.net.http.HttpClient
-import java.net.http.HttpRequest
-import java.net.http.HttpResponse
-import java.time.Duration
 
 /**
- * Real OpenAI-compatible `/chat/completions` client (ADR-0163), same wire shape and provider as
- * devops-agent's `DevOpsConfig`/adapter (ADR-0119) and the customer copilot (ADR-0089) — NOT the
- * "litellm.ai-platform" gateway every sibling agent's original charter/stub named, which is not
- * actually deployed anywhere in this repo (verified: no LiteLLM Deployment/Service manifest
- * exists). The API key is an OPTIONAL lookup so an un-seeded key degrades diagnosis to a
- * placeholder instead of CrashLooping the pod at boot (SmallRye SRCFG00040 on an empty bind).
+ * Live LLM diagnosis (ADR-0163), migrated onto the two ADR-0148 / ADR-0174 seams — the same
+ * pattern devops-agent adopted first (#2240):
+ *  - The model call goes through the shared [LlmGatewayPort] (ADR-0174) instead of a per-adapter
+ *    `java.net.http.HttpClient`. Returns `null` on any failure, so the agent still degrades to a
+ *    deterministic placeholder exactly as before; the adapter is now injectable, so an eval can
+ *    drive it with a stub gateway.
+ *  - The system prompt is loaded from the ADR-0148 prompt registry (the
+ *    control-liveness-sentinel `system.v1.md` file), packaged at build time (see
+ *    build.gradle.kts) and read verbatim, so the runtime prompt equals the registered content
+ *    byte-for-byte — the `prompt_hash` in an AI-attributed AuditEvent now resolves.
  *
- * `proposeFixDiff` deliberately stays unimplemented (always null): generating a code/IaC diff
- * for an unreviewed auto-apply is a materially bigger, riskier lift than a text diagnosis, and
- * ADR-0163's own design already treats "propose a tracking ticket" as the expected fallback when
- * no diff is available — this is that fallback, not a stub standing in for a real feature.
+ * `proposeFixDiff` stays unimplemented (always null): generating a code/IaC diff for an unreviewed
+ * auto-apply is a materially bigger, riskier lift than a text diagnosis, and ADR-0163's own design
+ * already treats "propose a tracking ticket" as the expected fallback when no diff is available —
+ * this is that fallback, not a stub standing in for a real feature. Unchanged by this migration.
  */
 @ApplicationScoped
-class LlmDiagnosisAdapter(private val config: LivenessSentinelConfig) : LlmDiagnosisPort {
+class LlmDiagnosisAdapter : LlmDiagnosisPort {
 
     @Inject
-    lateinit var objectMapper: ObjectMapper
+    lateinit var gateway: LlmGatewayPort
 
-    private val log = Logger.getLogger(LlmDiagnosisAdapter::class.java)
-
-    // OPTIONAL (not @ConfigProperty-injected): an un-seeded key must not fail config load at boot.
-    // Deliberately OUTSIDE the openbank.liveness-sentinel prefix LivenessSentinelConfig's strict
-    // @ConfigMapping owns — a key nested under that prefix with no matching interface property
-    // fails boot with SRCFG00050 ("does not map to any root"), which crash-looped this pod on
-    // first real deploy. "liveness.model.api-key" resolves via SmallRye's env-var relaxed matching
-    // straight from LIVENESS_MODEL_API_KEY, no application.yaml entry needed — mirrors
-    // DevOpsConfig / OpenAiCompatibleModelProvider's short, unmapped lookup key exactly.
-    private val apiKey: String
-        get() = ConfigProvider.getConfig()
-            .getOptionalValue("liveness.model.api-key", String::class.java).orElse("")
-
-    private val http: HttpClient by lazy {
-        HttpClient.newBuilder().connectTimeout(Duration.ofSeconds(CONNECT_TIMEOUT_S)).build()
-    }
-
-    @Suppress("TooGenericExceptionCaught")
     override suspend fun diagnose(finding: LivenessFinding, contextMetrics: Map<String, Double>): String {
-        if (apiKey.isBlank()) {
-            log.warn(
-                "liveness.model.api-key not seeded — returning placeholder diagnosis (degraded)",
-            )
-            return "Automated diagnosis unavailable (model API key not seeded). Finding: ${finding.title}. " +
-                "Affected control: ${finding.affectedControl}."
-        }
-        return try {
-            withContext(Dispatchers.IO) { callModel(finding, contextMetrics) }
-        } catch (ex: Exception) {
-            log.warnf("LLM diagnosis call failed for finding %s: %s", finding.id, ex.message)
-            "Automated diagnosis failed (${ex.message}). Finding: ${finding.title}. " +
-                "Affected control: ${finding.affectedControl}."
-        }
-    }
-
-    @Suppress("TooGenericExceptionCaught")
-    private fun callModel(finding: LivenessFinding, contextMetrics: Map<String, Double>): String {
-        val url = "${config.modelEndpoint().trimEnd('/')}/chat/completions"
-        val payload = objectMapper.writeValueAsString(buildRequestBody(finding, contextMetrics))
-        val request = HttpRequest.newBuilder(URI.create(url))
-            .timeout(Duration.ofSeconds(REQUEST_TIMEOUT_S))
-            .header("Authorization", "Bearer $apiKey")
-            .header("Content-Type", "application/json")
-            .POST(HttpRequest.BodyPublishers.ofString(payload))
-            .build()
-        val resp = http.send(request, HttpResponse.BodyHandlers.ofString())
-        if (resp.statusCode() !in OK_RANGE) {
-            log.warnf(
-                "model backend %s returned HTTP %d for finding %s",
-                config.modelEndpoint(),
-                resp.statusCode(),
-                finding.id,
-            )
-            error("model backend HTTP ${resp.statusCode()}")
-        }
-        return parseContent(resp.body())
-    }
-
-    private fun buildRequestBody(finding: LivenessFinding, contextMetrics: Map<String, Double>) = mapOf(
-        "model" to config.modelId(),
-        "max_tokens" to MAX_TOKENS,
-        "temperature" to TEMPERATURE,
-        "messages" to listOf(
-            mapOf("role" to "system", "content" to SYSTEM_PROMPT),
-            mapOf("role" to "user", "content" to userPrompt(finding, contextMetrics)),
-        ),
-    )
-
-    private fun userPrompt(finding: LivenessFinding, contextMetrics: Map<String, Double>): String {
         val metrics =
             if (contextMetrics.isEmpty()) "(none)" else contextMetrics.entries.joinToString { (k, v) -> "$k=$v" }
-        return """
+        val user = """
             A control-liveness finding was detected. Write a concise (2-4 sentence) root-cause
             hypothesis a human on-call engineer can act on immediately. Do not invent facts not
             present below; say so plainly if the cause is not determinable from this data alone.
@@ -124,34 +50,34 @@ class LlmDiagnosisAdapter(private val config: LivenessSentinelConfig) : LlmDiagn
             Threshold: ${finding.threshold}
             Context metrics: $metrics
         """.trimIndent()
+
+        return gateway.chat(SYSTEM_PROMPT, user)
+            ?: (
+                "Automated diagnosis unavailable (model backend not reachable or API key not seeded). " +
+                    "Finding: ${finding.title}. Affected control: ${finding.affectedControl}."
+                )
     }
 
-    private fun parseContent(json: String): String {
-        val root = objectMapper.readTree(json)
-        val choice = root.path("choices").firstOrNull() ?: error("model backend returned no choices")
-        val content = choice.path("message").path("content")
-        return if (content.isNull || content.isMissingNode) "" else content.asText().trim()
-    }
-
-    override suspend fun proposeFixDiff(finding: LivenessFinding, diagnosis: String): String? {
-        log.infof(
-            "LLM fix-diff proposal requested for finding %s mechanism=%s — deliberately unimplemented " +
-                "(ADR-0163: falls back to a tracking ticket)",
-            finding.id,
-            finding.mechanism,
-        )
-        return null
-    }
+    override suspend fun proposeFixDiff(finding: LivenessFinding, diagnosis: String): String? = null
 
     private companion object {
-        const val CONNECT_TIMEOUT_S = 10L
-        const val REQUEST_TIMEOUT_S = 60L
-        const val MAX_TOKENS = 400
-        const val TEMPERATURE = 0.2
-        val OK_RANGE = 200..299
-        const val SYSTEM_PROMPT =
-            "You are a root-cause diagnosis assistant for a banking platform's control-liveness " +
-                "monitoring. You propose, you never act — your output is a diagnosis note for a human " +
-                "on-call engineer, not an instruction to any system."
+        val SYSTEM_PROMPT = loadRegisteredPrompt()
+
+        /**
+         * Load the system prompt from the ADR-0148 registry, packaged onto the classpath at build
+         * time from the control-liveness-sentinel `system.v1.md` registry file. Read verbatim so
+         * the runtime prompt equals the registry file byte-for-byte (the `prompt_hash`
+         * resolvability contract). A missing resource is a build misconfiguration and fails fast
+         * rather than shipping a silent empty prompt.
+         */
+        private fun loadRegisteredPrompt(): String {
+            val path = "/governance-prompts/control-liveness-sentinel/system.v1.md"
+            return LlmDiagnosisAdapter::class.java.getResourceAsStream(path)
+                ?.bufferedReader()?.use { it.readText() }
+                ?: error(
+                    "prompt registry resource missing: $path — packaged by build.gradle.kts from " +
+                        "the control-liveness-sentinel registry prompt (ADR-0148)",
+                )
+        }
     }
 }

--- a/openbank-control-liveness-sentinel/src/main/kotlin/com/openbank/liveness/infrastructure/config/LlmGatewayProducer.kt
+++ b/openbank-control-liveness-sentinel/src/main/kotlin/com/openbank/liveness/infrastructure/config/LlmGatewayProducer.kt
@@ -1,0 +1,40 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+// Copyright (c) OpenBank contributors. Licensed under the GNU Affero General Public License v3.0 only.
+// A commercial licence is available from the maintainers as an alternative to the AGPL-3.0.
+// See LICENSES/AGPL-3.0-only.txt or https://www.gnu.org/licenses/agpl-3.0.html for details.
+
+package com.openbank.liveness.infrastructure.config
+
+import com.openbank.libs.llm.LlmGatewayPort
+import com.openbank.libs.llm.OpenAiCompatibleLlmGatewayClient
+import jakarta.enterprise.context.ApplicationScoped
+import jakarta.enterprise.inject.Produces
+import org.eclipse.microprofile.config.ConfigProvider
+
+/**
+ * Produces the shared [LlmGatewayPort] (ADR-0174) for control-liveness-sentinel, wired to the same
+ * endpoint + model the gitops config points at (litellm gateway since #2019).
+ *
+ * The API key is read via an OPTIONAL lookup (not @ConfigProperty), so an un-seeded key degrades
+ * the gateway to a deterministic `null` rather than CrashLooping the pod (SmallRye SRCFG00040) —
+ * the same safety the previous hand-rolled adapter had. Deliberately OUTSIDE the
+ * `openbank.liveness-sentinel` prefix `LivenessSentinelConfig`'s strict `@ConfigMapping` owns (a key
+ * nested under that prefix with no matching interface property fails boot with SRCFG00050 — the
+ * bug the original adapter's comment documents). The key is never logged.
+ */
+@ApplicationScoped
+class LlmGatewayProducer {
+
+    @Produces
+    @ApplicationScoped
+    fun llmGateway(config: LivenessSentinelConfig): LlmGatewayPort {
+        val apiKey = ConfigProvider.getConfig()
+            .getOptionalValue("liveness.model.api-key", String::class.java)
+            .orElse("")
+        return OpenAiCompatibleLlmGatewayClient(
+            baseUrl = config.modelEndpoint(),
+            model = config.modelId(),
+            apiKey = apiKey,
+        )
+    }
+}

--- a/openbank-control-liveness-sentinel/src/test/kotlin/com/openbank/liveness/infrastructure/adapter/LlmDiagnosisAdapterTest.kt
+++ b/openbank-control-liveness-sentinel/src/test/kotlin/com/openbank/liveness/infrastructure/adapter/LlmDiagnosisAdapterTest.kt
@@ -1,0 +1,79 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+// Copyright (c) OpenBank contributors. Licensed under the GNU Affero General Public License v3.0 only.
+// A commercial licence is available from the maintainers as an alternative to the AGPL-3.0.
+// See LICENSES/AGPL-3.0-only.txt or https://www.gnu.org/licenses/agpl-3.0.html for details.
+
+package com.openbank.liveness.infrastructure.adapter
+
+import com.openbank.libs.llm.LlmGatewayPort
+import com.openbank.liveness.domain.model.ControlMechanism
+import com.openbank.liveness.domain.model.FindingSeverity
+import com.openbank.liveness.domain.model.LivenessFinding
+import kotlinx.coroutines.runBlocking
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.Test
+import java.math.BigDecimal
+import java.time.Instant
+
+/**
+ * Unit coverage for the ADR-0148 / ADR-0174 seams (issue #1918), mirroring
+ * devops-agent's LlmDiagnosisAdapterTest (#2240). Drives the adapter with a stub [LlmGatewayPort]
+ * and asserts: (1) the system prompt sent IS the registered registry file byte-for-byte (the
+ * prompt_hash resolvability contract), and (2) a null gateway degrades to the deterministic
+ * placeholder exactly as the old hand-rolled adapter did.
+ */
+class LlmDiagnosisAdapterTest {
+
+    private class StubGateway(var response: String?) : LlmGatewayPort {
+        val systemPrompts = mutableListOf<String>()
+        override suspend fun chat(systemPrompt: String, userPrompt: String): String? {
+            systemPrompts += systemPrompt
+            return response
+        }
+    }
+
+    private fun finding() = LivenessFinding(
+        id = "finding-1",
+        mechanism = ControlMechanism.entries.first(),
+        severity = FindingSeverity.entries.first(),
+        detectedAt = Instant.parse("2026-07-25T03:00:00Z"),
+        title = "cnpg-wal-archiving stalled",
+        affectedControl = "cnpg-wal-archiving",
+        rawMetricValue = BigDecimal("920"),
+        threshold = BigDecimal("900"),
+    )
+
+    private fun registeredPrompt(): String =
+        javaClass.getResourceAsStream("/governance-prompts/control-liveness-sentinel/system.v1.md")!!
+            .bufferedReader().use { it.readText() }
+
+    @Test
+    fun `diagnose sends the registered system prompt and returns the model text`(): Unit = runBlocking {
+        val stub = StubGateway("Root cause: WAL archiving is blocked by a full disk on the replica.")
+        val adapter = LlmDiagnosisAdapter().also { it.gateway = stub }
+
+        val out = adapter.diagnose(finding(), mapOf("wal_age_minutes" to 15.3))
+
+        assertThat(out).isEqualTo("Root cause: WAL archiving is blocked by a full disk on the replica.")
+        assertThat(stub.systemPrompts.single()).isEqualTo(registeredPrompt())
+    }
+
+    @Test
+    fun `diagnose degrades to a deterministic placeholder when the gateway is unavailable`(): Unit = runBlocking {
+        val adapter = LlmDiagnosisAdapter().also { it.gateway = StubGateway(null) }
+
+        val out = adapter.diagnose(finding(), emptyMap())
+
+        assertThat(out).contains("Automated diagnosis unavailable")
+        assertThat(out).contains("cnpg-wal-archiving")
+    }
+
+    @Test
+    fun `proposeFixDiff stays unimplemented`(): Unit = runBlocking {
+        val adapter = LlmDiagnosisAdapter().also { it.gateway = StubGateway("some diff") }
+
+        val out = adapter.proposeFixDiff(finding(), diagnosis = "disk full")
+
+        assertThat(out).isNull()
+    }
+}


### PR DESCRIPTION
## What
Second agent onto the ADR-0148 / ADR-0174 seams, following the devops-agent pattern (#2240).

## Changes
- `LlmGatewayPort` seam instead of the hand-rolled `HttpClient`; `LlmGatewayProducer` wires `OpenAiCompatibleLlmGatewayClient` from `LivenessSentinelConfig` (optional key → graceful degrade). Adapter is now stub-injectable.
- System prompt loaded from the registry (`prompts/control-liveness-sentinel/system.v1.md`), packaged via `processResources`, read byte-for-byte.
- `proposeFixDiff` unchanged (stays unimplemented per ADR-0163 design).

## Test + gate
`LlmDiagnosisAdapterTest` (mirrors devops-agent's): stub gateway, asserts byte-parity system prompt + graceful degrade + `proposeFixDiff` null. Local gate green: detekt, ktlint, test (3/3), quarkusBuild (CDI/ArC validated).

Non-money-path (control plane). Unblocks a second evals recording for #1918.

Refs #1918, ADR-0148, ADR-0174.

🤖 Generated with [Claude Code](https://claude.com/claude-code)