### PR TITLE
fix(infra): stop the generated runbooks naming namespaces that do not exist

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -366,6 +366,23 @@ jobs:
       - name: "PodMonitor namespace coverage (issue #2255, enforced)"
         run: python3 .github/scripts/check-podmonitor-namespace-coverage.py
 
+
+      # issue #2255. docs/runbooks/svc-*.md are GENERATED from governance.yaml + the gitops
+      # manifests, and nothing checked them, so 25 of 30 had silently gone stale: they told
+      # an on-call engineer "DR is not achievable today — no backup configured" for services
+      # whose CNPG backups had since been enabled. A generated artifact with no drift gate is
+      # not documentation, it is a claim nobody is accountable for. Same shape as the
+      # NetworkPolicy gate above, including --intent-to-add so a NEW service with no
+      # committed runbook fails as an addition rather than being invisible to `git diff`.
+      - name: "service runbook drift (issue #2255, enforced)"
+        run: |
+          python3 openbank-infra/scripts/generate-service-runbooks.py --force
+          git add -A --intent-to-add docs/runbooks/
+          if ! git diff --exit-code docs/runbooks/; then
+            echo "::error::Service runbook drift — run 'python3 openbank-infra/scripts/generate-service-runbooks.py --force' and commit the result (a new file listed above means a service has no committed runbook). Never hand-edit a generated runbook."
+            exit 1
+          fi
+
       # The governance gates in this job (threat-model coverage + diff, network-policy
       # generation, authz-coverage) are stdlib Python with committed *_test.py suites that,
       # until now, no workflow ran — a gate whose own logic is untested silently rots. Run

--- a/docs/runbooks/svc-account.md
+++ b/docs/runbooks/svc-account.md
@@ -23,7 +23,7 @@ exercised DR drill, tracked as TTL'd attestations, never faked here. -->
 ## Dependencies
 
 - **Upstream (this service consumes):** `transaction-service`, `interest-service`, `card-issuance-service`, `consent-service`, `agent-service`
-- **Downstream (depends on this service):** `balance-service`, `party-service`, `audit-service`
+- **Downstream (depends on this service):** `balance-service`, `audit-service`
 
 A failure here propagates to the downstream services above — check them when
 triaging an incident that starts on `account`.
@@ -31,14 +31,14 @@ triaging an incident that starts on `account`.
 ## Health & probes
 
 - Readiness: `GET :8100/q/health/ready` · Liveness: `GET :8100/q/health/live`
-- Metrics: scraped by the fleet PodMonitor (namespace `account`); dashboards in Grafana.
-- Logs: `kubectl logs -n account deploy/account-service -f`, or Loki
-  `{namespace="account"}`.
+- Metrics: scraped by the fleet PodMonitor (namespace `accounts`); dashboards in Grafana.
+- Logs: `kubectl logs -n accounts deploy/account-service -f`, or Loki
+  `{namespace="accounts"}`.
 
 ## Routine operations
 
-- **Restart:** `kubectl rollout restart deploy/account-service -n account` (rolling, zero-downtime at >1 replica).
-- **Scale:** `kubectl scale deploy/account-service -n account --replicas=<n>` (or edit the GitOps Deployment — GitOps is source of truth, a manual scale is reverted by ArgoCD).
+- **Restart:** `kubectl rollout restart deploy/account-service -n accounts` (rolling, zero-downtime at >1 replica).
+- **Scale:** `kubectl scale deploy/account-service -n accounts --replicas=<n>` (or edit the GitOps Deployment — GitOps is source of truth, a manual scale is reverted by ArgoCD).
 - **Config/secret change:** edit the GitOps manifest; ArgoCD syncs. Never `kubectl edit` in place.
 
 ## Common failure modes
@@ -53,9 +53,8 @@ triaging an incident that starts on `account`.
 
 ## Disaster recovery
 
-- **RPO/RTO: undefined** — no backup is configured yet (see the prerequisite below), so no recovery-point/time guarantee can be made today.
-- **⚠ Prerequisite NOT met:** this PostgreSQL cluster has **no backup configured** (`barmanObjectStore` absent — prod-readiness C5=1). **DR is not achievable today** and the RPO/RTO targets above do NOT yet apply. Enabling the CNPG backup is the blocking prerequisite (see the backup sweep). Once enabled, the procedure is:
-- **Mechanism (after enablement):** CNPG continuous WAL + base backups → PITR.
+- **RPO target:** ≤ 5 min (continuous archiving). **RTO target:** ≤ 30 min (restore + warm-up).
+- **Mechanism:** CloudNativePG continuous WAL archiving + base backups to S3 (`barmanObjectStore`). Point-in-time recovery (PITR).
 - **Restore:** create a `Cluster` with `bootstrap.recovery` pointing at the backup object store; CNPG replays WAL to the target time. See runbook 0003 (PG major upgrade) for the cluster-recreate mechanics.
 - **Verify:** `kubectl cnpg status <db>-rw -n <ns>` shows the recovered cluster Healthy and the `*-app` secret regenerated.
 

--- a/docs/runbooks/svc-agent.md
+++ b/docs/runbooks/svc-agent.md
@@ -31,14 +31,14 @@ triaging an incident that starts on `agent`.
 ## Health & probes
 
 - Readiness: `GET :8109/q/health/ready` · Liveness: `GET :8109/q/health/live`
-- Metrics: scraped by the fleet PodMonitor (namespace `agent`); dashboards in Grafana.
-- Logs: `kubectl logs -n agent deploy/agent-service -f`, or Loki
-  `{namespace="agent"}`.
+- Metrics: scraped by the fleet PodMonitor (namespace `platform`); dashboards in Grafana.
+- Logs: `kubectl logs -n platform deploy/agent-service -f`, or Loki
+  `{namespace="platform"}`.
 
 ## Routine operations
 
-- **Restart:** `kubectl rollout restart deploy/agent-service -n agent` (rolling, zero-downtime at >1 replica).
-- **Scale:** `kubectl scale deploy/agent-service -n agent --replicas=<n>` (or edit the GitOps Deployment — GitOps is source of truth, a manual scale is reverted by ArgoCD).
+- **Restart:** `kubectl rollout restart deploy/agent-service -n platform` (rolling, zero-downtime at >1 replica).
+- **Scale:** `kubectl scale deploy/agent-service -n platform --replicas=<n>` (or edit the GitOps Deployment — GitOps is source of truth, a manual scale is reverted by ArgoCD).
 - **Config/secret change:** edit the GitOps manifest; ArgoCD syncs. Never `kubectl edit` in place.
 
 ## Common failure modes
@@ -53,7 +53,7 @@ triaging an incident that starts on `agent`.
 
 ## Disaster recovery
 
-- **RPO/RTO: undefined** — no backup is configured yet (see the prerequisite below), so no recovery-point/time guarantee can be made today.
+- **RPO target:** ≤ 5 min (continuous archiving). **RTO target:** ≤ 30 min (restore + warm-up).
 - **Mechanism:** restore from the datastore's managed backup to a fresh instance (confirm a backup is actually configured for this datastore first).
 - **Restore:** provision a new datastore from the latest backup, replay any incremental logs, re-point the service.
 - **Verify:** health endpoint green + a domain spot check against last known-good.

--- a/docs/runbooks/svc-anacredit.md
+++ b/docs/runbooks/svc-anacredit.md
@@ -53,9 +53,8 @@ triaging an incident that starts on `anacredit`.
 
 ## Disaster recovery
 
-- **RPO/RTO: undefined** — no backup is configured yet (see the prerequisite below), so no recovery-point/time guarantee can be made today.
-- **⚠ Prerequisite NOT met:** this PostgreSQL cluster has **no backup configured** (`barmanObjectStore` absent — prod-readiness C5=1). **DR is not achievable today** and the RPO/RTO targets above do NOT yet apply. Enabling the CNPG backup is the blocking prerequisite (see the backup sweep). Once enabled, the procedure is:
-- **Mechanism (after enablement):** CNPG continuous WAL + base backups → PITR.
+- **RPO target:** ≤ 5 min (continuous archiving). **RTO target:** ≤ 30 min (restore + warm-up).
+- **Mechanism:** CloudNativePG continuous WAL archiving + base backups to S3 (`barmanObjectStore`). Point-in-time recovery (PITR).
 - **Restore:** create a `Cluster` with `bootstrap.recovery` pointing at the backup object store; CNPG replays WAL to the target time. See runbook 0003 (PG major upgrade) for the cluster-recreate mechanics.
 - **Verify:** `kubectl cnpg status <db>-rw -n <ns>` shows the recovered cluster Healthy and the `*-app` secret regenerated.
 

--- a/docs/runbooks/svc-ap2.md
+++ b/docs/runbooks/svc-ap2.md
@@ -1,0 +1,71 @@
+<!-- Generated starter runbook (generate-service-runbooks.py) from declared
+service facts. Real scaffolding — EXTEND with operational specifics; do not delete.
+Bank-grade ops (prod-readiness C9=3 / C6=3) still needs a real on-call rotation and an
+exercised DR drill, tracked as TTL'd attestations, never faked here. -->
+
+# Runbook — openbank-ap2-service
+
+> Operational runbook for the `ap2` service. Data domain **payments**,
+> classification **confidential**, datastore **none**.
+
+## Service identity
+
+| Field | Value |
+|---|---|
+| Service | `openbank-ap2-service` |
+| HTTP port | `8151` |
+| Data domain | payments |
+| Datastore | none (schema `—`) |
+| Classification | confidential |
+| Retention | not applicable |
+| Lineage role | consumer |
+
+## Dependencies
+
+- **Upstream (this service consumes):** _none declared_
+- **Downstream (depends on this service):** _none declared_
+
+A failure here propagates to the downstream services above — check them when
+triaging an incident that starts on `ap2`.
+
+## Health & probes
+
+- Readiness: `GET :8151/q/health/ready` · Liveness: `GET :8151/q/health/live`
+- Metrics: scraped by the fleet PodMonitor (namespace `platform`); dashboards in Grafana.
+- Logs: `kubectl logs -n platform deploy/ap2-service -f`, or Loki
+  `{namespace="platform"}`.
+
+## Routine operations
+
+- **Restart:** `kubectl rollout restart deploy/ap2-service -n platform` (rolling, zero-downtime at >1 replica).
+- **Scale:** `kubectl scale deploy/ap2-service -n platform --replicas=<n>` (or edit the GitOps Deployment — GitOps is source of truth, a manual scale is reverted by ArgoCD).
+- **Config/secret change:** edit the GitOps manifest; ArgoCD syncs. Never `kubectl edit` in place.
+
+## Common failure modes
+
+- **Pod CrashLoopBackOff at boot:** usually a missing/invalid config or secret
+  (`ExternalSecret` not synced). Check `kubectl describe pod` events and the
+  first 50 log lines.
+- **Readiness flapping:** this service holds no datastore, so look outward — an
+  upstream dependency below, or the OPA sidecar if `AUTHZ_ENFORCE` is on (with no
+  reachable PDP, `@Authorize` fails closed).
+- **Downstream errors:** verify the upstream dependencies above are healthy before
+  assuming the fault is local.
+
+## Disaster recovery
+
+- **RPO: n/a** — no persistent state. **RTO target:** ≤ 10 min (image pull + rollout).
+- **Mechanism:** none needed — this service declares no primary datastore, so it holds no state to lose. Recovery is a redeploy from the GitOps manifests, which are the source of truth.
+- **Restore:** re-sync the ArgoCD Application (or `kubectl rollout restart` the Deployment). Any state this service reads lives in its upstream services above — recover those first, using their own runbooks.
+- **Verify:** health endpoint green, then re-drive one request end to end against an upstream that is already known-good.
+
+> RPO/RTO above are documented targets. They become **Bank-grade** (prod-readiness
+> C6=3) only once a restore/failover drill has actually been rehearsed and attested
+> (`openbank-libs/governance/attestations.yaml: ap2.dr_drill`).
+
+## Escalation & break-glass
+
+- First responder: the owning squad's on-call (rotation tracked as the
+  `ap2.oncall` attestation — until that is live, escalate via the team channel).
+- Break-glass cluster access is audited; use it only for a declared incident and
+  record the justification.

--- a/docs/runbooks/svc-balance.md
+++ b/docs/runbooks/svc-balance.md
@@ -31,14 +31,14 @@ triaging an incident that starts on `balance`.
 ## Health & probes
 
 - Readiness: `GET :8103/q/health/ready` · Liveness: `GET :8103/q/health/live`
-- Metrics: scraped by the fleet PodMonitor (namespace `balance`); dashboards in Grafana.
-- Logs: `kubectl logs -n balance deploy/balance-service -f`, or Loki
-  `{namespace="balance"}`.
+- Metrics: scraped by the fleet PodMonitor (namespace `balances`); dashboards in Grafana.
+- Logs: `kubectl logs -n balances deploy/balance-service -f`, or Loki
+  `{namespace="balances"}`.
 
 ## Routine operations
 
-- **Restart:** `kubectl rollout restart deploy/balance-service -n balance` (rolling, zero-downtime at >1 replica).
-- **Scale:** `kubectl scale deploy/balance-service -n balance --replicas=<n>` (or edit the GitOps Deployment — GitOps is source of truth, a manual scale is reverted by ArgoCD).
+- **Restart:** `kubectl rollout restart deploy/balance-service -n balances` (rolling, zero-downtime at >1 replica).
+- **Scale:** `kubectl scale deploy/balance-service -n balances --replicas=<n>` (or edit the GitOps Deployment — GitOps is source of truth, a manual scale is reverted by ArgoCD).
 - **Config/secret change:** edit the GitOps manifest; ArgoCD syncs. Never `kubectl edit` in place.
 
 ## Common failure modes
@@ -53,7 +53,7 @@ triaging an incident that starts on `balance`.
 
 ## Disaster recovery
 
-- **RPO/RTO: undefined** — no backup is configured yet (see the prerequisite below), so no recovery-point/time guarantee can be made today.
+- **RPO target:** ≤ 5 min (continuous archiving). **RTO target:** ≤ 30 min (restore + warm-up).
 - **Mechanism:** restore from the datastore's managed backup to a fresh instance (confirm a backup is actually configured for this datastore first).
 - **Restore:** provision a new datastore from the latest backup, replay any incremental logs, re-point the service.
 - **Verify:** health endpoint green + a domain spot check against last known-good.

--- a/docs/runbooks/svc-billing.md
+++ b/docs/runbooks/svc-billing.md
@@ -3,42 +3,42 @@ service facts. Real scaffolding — EXTEND with operational specifics; do not de
 Bank-grade ops (prod-readiness C9=3 / C6=3) still needs a real on-call rotation and an
 exercised DR drill, tracked as TTL'd attestations, never faked here. -->
 
-# Runbook — openbank-interest-service
+# Runbook — openbank-billing-service
 
-> Operational runbook for the `interest` service. Data domain **payments**,
+> Operational runbook for the `billing` service. Data domain **payments**,
 > classification **internal**, datastore **PostgreSQL**.
 
 ## Service identity
 
 | Field | Value |
 |---|---|
-| Service | `openbank-interest-service` |
-| HTTP port | `8125` |
+| Service | `openbank-billing-service` |
+| HTTP port | `8132` |
 | Data domain | payments |
-| Datastore | PostgreSQL (schema `interest_schema`) |
+| Datastore | PostgreSQL (schema `billing_schema`) |
 | Classification | internal |
-| Retention | 5 years |
+| Retention | 7 years |
 | Lineage role | both |
 
 ## Dependencies
 
 - **Upstream (this service consumes):** _none declared_
-- **Downstream (depends on this service):** `account-service`
+- **Downstream (depends on this service):** _none declared_
 
 A failure here propagates to the downstream services above — check them when
-triaging an incident that starts on `interest`.
+triaging an incident that starts on `billing`.
 
 ## Health & probes
 
-- Readiness: `GET :8125/q/health/ready` · Liveness: `GET :8125/q/health/live`
-- Metrics: scraped by the fleet PodMonitor (namespace `interest`); dashboards in Grafana.
-- Logs: `kubectl logs -n interest deploy/interest-service -f`, or Loki
-  `{namespace="interest"}`.
+- Readiness: `GET :8132/q/health/ready` · Liveness: `GET :8132/q/health/live`
+- Metrics: scraped by the fleet PodMonitor (namespace `billing`); dashboards in Grafana.
+- Logs: `kubectl logs -n billing deploy/billing-service -f`, or Loki
+  `{namespace="billing"}`.
 
 ## Routine operations
 
-- **Restart:** `kubectl rollout restart deploy/interest-service -n interest` (rolling, zero-downtime at >1 replica).
-- **Scale:** `kubectl scale deploy/interest-service -n interest --replicas=<n>` (or edit the GitOps Deployment — GitOps is source of truth, a manual scale is reverted by ArgoCD).
+- **Restart:** `kubectl rollout restart deploy/billing-service -n billing` (rolling, zero-downtime at >1 replica).
+- **Scale:** `kubectl scale deploy/billing-service -n billing --replicas=<n>` (or edit the GitOps Deployment — GitOps is source of truth, a manual scale is reverted by ArgoCD).
 - **Config/secret change:** edit the GitOps manifest; ArgoCD syncs. Never `kubectl edit` in place.
 
 ## Common failure modes
@@ -60,11 +60,11 @@ triaging an incident that starts on `interest`.
 
 > RPO/RTO above are documented targets. They become **Bank-grade** (prod-readiness
 > C6=3) only once a restore/failover drill has actually been rehearsed and attested
-> (`openbank-libs/governance/attestations.yaml: interest.dr_drill`).
+> (`openbank-libs/governance/attestations.yaml: billing.dr_drill`).
 
 ## Escalation & break-glass
 
 - First responder: the owning squad's on-call (rotation tracked as the
-  `interest.oncall` attestation — until that is live, escalate via the team channel).
+  `billing.oncall` attestation — until that is live, escalate via the team channel).
 - Break-glass cluster access is audited; use it only for a declared incident and
   record the justification.

--- a/docs/runbooks/svc-card-issuance.md
+++ b/docs/runbooks/svc-card-issuance.md
@@ -23,7 +23,7 @@ exercised DR drill, tracked as TTL'd attestations, never faked here. -->
 ## Dependencies
 
 - **Upstream (this service consumes):** `dispute-service`
-- **Downstream (depends on this service):** `account-service`
+- **Downstream (depends on this service):** _none declared_
 
 A failure here propagates to the downstream services above — check them when
 triaging an incident that starts on `card-issuance`.
@@ -31,14 +31,14 @@ triaging an incident that starts on `card-issuance`.
 ## Health & probes
 
 - Readiness: `GET :8118/q/health/ready` · Liveness: `GET :8118/q/health/live`
-- Metrics: scraped by the fleet PodMonitor (namespace `card-issuance`); dashboards in Grafana.
-- Logs: `kubectl logs -n card-issuance deploy/card-issuance-service -f`, or Loki
-  `{namespace="card-issuance"}`.
+- Metrics: scraped by the fleet PodMonitor (namespace `payments`); dashboards in Grafana.
+- Logs: `kubectl logs -n payments deploy/card-issuance-service -f`, or Loki
+  `{namespace="payments"}`.
 
 ## Routine operations
 
-- **Restart:** `kubectl rollout restart deploy/card-issuance-service -n card-issuance` (rolling, zero-downtime at >1 replica).
-- **Scale:** `kubectl scale deploy/card-issuance-service -n card-issuance --replicas=<n>` (or edit the GitOps Deployment — GitOps is source of truth, a manual scale is reverted by ArgoCD).
+- **Restart:** `kubectl rollout restart deploy/card-issuance-service -n payments` (rolling, zero-downtime at >1 replica).
+- **Scale:** `kubectl scale deploy/card-issuance-service -n payments --replicas=<n>` (or edit the GitOps Deployment — GitOps is source of truth, a manual scale is reverted by ArgoCD).
 - **Config/secret change:** edit the GitOps manifest; ArgoCD syncs. Never `kubectl edit` in place.
 
 ## Common failure modes
@@ -53,9 +53,8 @@ triaging an incident that starts on `card-issuance`.
 
 ## Disaster recovery
 
-- **RPO/RTO: undefined** — no backup is configured yet (see the prerequisite below), so no recovery-point/time guarantee can be made today.
-- **⚠ Prerequisite NOT met:** this PostgreSQL cluster has **no backup configured** (`barmanObjectStore` absent — prod-readiness C5=1). **DR is not achievable today** and the RPO/RTO targets above do NOT yet apply. Enabling the CNPG backup is the blocking prerequisite (see the backup sweep). Once enabled, the procedure is:
-- **Mechanism (after enablement):** CNPG continuous WAL + base backups → PITR.
+- **RPO target:** ≤ 5 min (continuous archiving). **RTO target:** ≤ 30 min (restore + warm-up).
+- **Mechanism:** CloudNativePG continuous WAL archiving + base backups to S3 (`barmanObjectStore`). Point-in-time recovery (PITR).
 - **Restore:** create a `Cluster` with `bootstrap.recovery` pointing at the backup object store; CNPG replays WAL to the target time. See runbook 0003 (PG major upgrade) for the cluster-recreate mechanics.
 - **Verify:** `kubectl cnpg status <db>-rw -n <ns>` shows the recovered cluster Healthy and the `*-app` secret regenerated.
 

--- a/docs/runbooks/svc-clearing.md
+++ b/docs/runbooks/svc-clearing.md
@@ -23,7 +23,7 @@ exercised DR drill, tracked as TTL'd attestations, never faked here. -->
 ## Dependencies
 
 - **Upstream (this service consumes):** _none declared_
-- **Downstream (depends on this service):** `transaction-service`
+- **Downstream (depends on this service):** _none declared_
 
 A failure here propagates to the downstream services above — check them when
 triaging an incident that starts on `clearing`.
@@ -31,14 +31,14 @@ triaging an incident that starts on `clearing`.
 ## Health & probes
 
 - Readiness: `GET :8124/q/health/ready` · Liveness: `GET :8124/q/health/live`
-- Metrics: scraped by the fleet PodMonitor (namespace `clearing`); dashboards in Grafana.
-- Logs: `kubectl logs -n clearing deploy/clearing-service -f`, or Loki
-  `{namespace="clearing"}`.
+- Metrics: scraped by the fleet PodMonitor (namespace `payments`); dashboards in Grafana.
+- Logs: `kubectl logs -n payments deploy/clearing-service -f`, or Loki
+  `{namespace="payments"}`.
 
 ## Routine operations
 
-- **Restart:** `kubectl rollout restart deploy/clearing-service -n clearing` (rolling, zero-downtime at >1 replica).
-- **Scale:** `kubectl scale deploy/clearing-service -n clearing --replicas=<n>` (or edit the GitOps Deployment — GitOps is source of truth, a manual scale is reverted by ArgoCD).
+- **Restart:** `kubectl rollout restart deploy/clearing-service -n payments` (rolling, zero-downtime at >1 replica).
+- **Scale:** `kubectl scale deploy/clearing-service -n payments --replicas=<n>` (or edit the GitOps Deployment — GitOps is source of truth, a manual scale is reverted by ArgoCD).
 - **Config/secret change:** edit the GitOps manifest; ArgoCD syncs. Never `kubectl edit` in place.
 
 ## Common failure modes
@@ -53,9 +53,8 @@ triaging an incident that starts on `clearing`.
 
 ## Disaster recovery
 
-- **RPO/RTO: undefined** — no backup is configured yet (see the prerequisite below), so no recovery-point/time guarantee can be made today.
-- **⚠ Prerequisite NOT met:** this PostgreSQL cluster has **no backup configured** (`barmanObjectStore` absent — prod-readiness C5=1). **DR is not achievable today** and the RPO/RTO targets above do NOT yet apply. Enabling the CNPG backup is the blocking prerequisite (see the backup sweep). Once enabled, the procedure is:
-- **Mechanism (after enablement):** CNPG continuous WAL + base backups → PITR.
+- **RPO target:** ≤ 5 min (continuous archiving). **RTO target:** ≤ 30 min (restore + warm-up).
+- **Mechanism:** CloudNativePG continuous WAL archiving + base backups to S3 (`barmanObjectStore`). Point-in-time recovery (PITR).
 - **Restore:** create a `Cluster` with `bootstrap.recovery` pointing at the backup object store; CNPG replays WAL to the target time. See runbook 0003 (PG major upgrade) for the cluster-recreate mechanics.
 - **Verify:** `kubectl cnpg status <db>-rw -n <ns>` shows the recovered cluster Healthy and the `*-app` secret regenerated.
 

--- a/docs/runbooks/svc-consent.md
+++ b/docs/runbooks/svc-consent.md
@@ -23,7 +23,7 @@ exercised DR drill, tracked as TTL'd attestations, never faked here. -->
 ## Dependencies
 
 - **Upstream (this service consumes):** `psd2-service`
-- **Downstream (depends on this service):** `account-service`
+- **Downstream (depends on this service):** _none declared_
 
 A failure here propagates to the downstream services above — check them when
 triaging an incident that starts on `consent`.
@@ -53,9 +53,8 @@ triaging an incident that starts on `consent`.
 
 ## Disaster recovery
 
-- **RPO/RTO: undefined** — no backup is configured yet (see the prerequisite below), so no recovery-point/time guarantee can be made today.
-- **⚠ Prerequisite NOT met:** this PostgreSQL cluster has **no backup configured** (`barmanObjectStore` absent — prod-readiness C5=1). **DR is not achievable today** and the RPO/RTO targets above do NOT yet apply. Enabling the CNPG backup is the blocking prerequisite (see the backup sweep). Once enabled, the procedure is:
-- **Mechanism (after enablement):** CNPG continuous WAL + base backups → PITR.
+- **RPO target:** ≤ 5 min (continuous archiving). **RTO target:** ≤ 30 min (restore + warm-up).
+- **Mechanism:** CloudNativePG continuous WAL archiving + base backups to S3 (`barmanObjectStore`). Point-in-time recovery (PITR).
 - **Restore:** create a `Cluster` with `bootstrap.recovery` pointing at the backup object store; CNPG replays WAL to the target time. See runbook 0003 (PG major upgrade) for the cluster-recreate mechanics.
 - **Verify:** `kubectl cnpg status <db>-rw -n <ns>` shows the recovered cluster Healthy and the `*-app` secret regenerated.
 

--- a/docs/runbooks/svc-copilot.md
+++ b/docs/runbooks/svc-copilot.md
@@ -5,7 +5,7 @@ exercised DR drill, tracked as TTL'd attestations, never faked here. -->
 
 # Runbook — openbank-copilot-service
 
-> Operational runbook for the `copilot` service. Data domain **customer**,
+> Operational runbook for the `copilot` service. Data domain **platform**,
 > classification **confidential**, datastore **PostgreSQL**.
 
 ## Service identity
@@ -14,7 +14,7 @@ exercised DR drill, tracked as TTL'd attestations, never faked here. -->
 |---|---|
 | Service | `openbank-copilot-service` |
 | HTTP port | `8131` |
-| Data domain | customer |
+| Data domain | platform |
 | Datastore | PostgreSQL (schema `copilot_schema`) |
 | Classification | confidential |
 | Retention | 1 year |
@@ -23,7 +23,7 @@ exercised DR drill, tracked as TTL'd attestations, never faked here. -->
 ## Dependencies
 
 - **Upstream (this service consumes):** _none declared_
-- **Downstream (depends on this service):** `balance-service`, `transaction-service`, `ledger-service`, `fx-service`, `domestic-payment`, `card-issuance-service`, `dispute-service`
+- **Downstream (depends on this service):** `balance-service`, `transaction-service`, `ledger-service`, `fx-service`
 
 A failure here propagates to the downstream services above — check them when
 triaging an incident that starts on `copilot`.
@@ -31,14 +31,14 @@ triaging an incident that starts on `copilot`.
 ## Health & probes
 
 - Readiness: `GET :8131/q/health/ready` · Liveness: `GET :8131/q/health/live`
-- Metrics: scraped by the fleet PodMonitor (namespace `copilot`); dashboards in Grafana.
-- Logs: `kubectl logs -n copilot deploy/copilot-service -f`, or Loki
-  `{namespace="copilot"}`.
+- Metrics: scraped by the fleet PodMonitor (namespace `platform`); dashboards in Grafana.
+- Logs: `kubectl logs -n platform deploy/copilot-service -f`, or Loki
+  `{namespace="platform"}`.
 
 ## Routine operations
 
-- **Restart:** `kubectl rollout restart deploy/copilot-service -n copilot` (rolling, zero-downtime at >1 replica).
-- **Scale:** `kubectl scale deploy/copilot-service -n copilot --replicas=<n>` (or edit the GitOps Deployment — GitOps is source of truth, a manual scale is reverted by ArgoCD).
+- **Restart:** `kubectl rollout restart deploy/copilot-service -n platform` (rolling, zero-downtime at >1 replica).
+- **Scale:** `kubectl scale deploy/copilot-service -n platform --replicas=<n>` (or edit the GitOps Deployment — GitOps is source of truth, a manual scale is reverted by ArgoCD).
 - **Config/secret change:** edit the GitOps manifest; ArgoCD syncs. Never `kubectl edit` in place.
 
 ## Common failure modes
@@ -53,9 +53,8 @@ triaging an incident that starts on `copilot`.
 
 ## Disaster recovery
 
-- **RPO/RTO: undefined** — no backup is configured yet (see the prerequisite below), so no recovery-point/time guarantee can be made today.
-- **⚠ Prerequisite NOT met:** this PostgreSQL cluster has **no backup configured** (`barmanObjectStore` absent — prod-readiness C5=1). **DR is not achievable today** and the RPO/RTO targets above do NOT yet apply. Enabling the CNPG backup is the blocking prerequisite (see the backup sweep). Once enabled, the procedure is:
-- **Mechanism (after enablement):** CNPG continuous WAL + base backups → PITR.
+- **RPO target:** ≤ 5 min (continuous archiving). **RTO target:** ≤ 30 min (restore + warm-up).
+- **Mechanism:** CloudNativePG continuous WAL archiving + base backups to S3 (`barmanObjectStore`). Point-in-time recovery (PITR).
 - **Restore:** create a `Cluster` with `bootstrap.recovery` pointing at the backup object store; CNPG replays WAL to the target time. See runbook 0003 (PG major upgrade) for the cluster-recreate mechanics.
 - **Verify:** `kubectl cnpg status <db>-rw -n <ns>` shows the recovered cluster Healthy and the `*-app` secret regenerated.
 

--- a/docs/runbooks/svc-dispute.md
+++ b/docs/runbooks/svc-dispute.md
@@ -23,7 +23,7 @@ exercised DR drill, tracked as TTL'd attestations, never faked here. -->
 ## Dependencies
 
 - **Upstream (this service consumes):** _none declared_
-- **Downstream (depends on this service):** `card-issuance-service`
+- **Downstream (depends on this service):** _none declared_
 
 A failure here propagates to the downstream services above — check them when
 triaging an incident that starts on `dispute`.
@@ -53,9 +53,8 @@ triaging an incident that starts on `dispute`.
 
 ## Disaster recovery
 
-- **RPO/RTO: undefined** — no backup is configured yet (see the prerequisite below), so no recovery-point/time guarantee can be made today.
-- **⚠ Prerequisite NOT met:** this PostgreSQL cluster has **no backup configured** (`barmanObjectStore` absent — prod-readiness C5=1). **DR is not achievable today** and the RPO/RTO targets above do NOT yet apply. Enabling the CNPG backup is the blocking prerequisite (see the backup sweep). Once enabled, the procedure is:
-- **Mechanism (after enablement):** CNPG continuous WAL + base backups → PITR.
+- **RPO target:** ≤ 5 min (continuous archiving). **RTO target:** ≤ 30 min (restore + warm-up).
+- **Mechanism:** CloudNativePG continuous WAL archiving + base backups to S3 (`barmanObjectStore`). Point-in-time recovery (PITR).
 - **Restore:** create a `Cluster` with `bootstrap.recovery` pointing at the backup object store; CNPG replays WAL to the target time. See runbook 0003 (PG major upgrade) for the cluster-recreate mechanics.
 - **Verify:** `kubectl cnpg status <db>-rw -n <ns>` shows the recovered cluster Healthy and the `*-app` secret regenerated.
 

--- a/docs/runbooks/svc-document.md
+++ b/docs/runbooks/svc-document.md
@@ -3,42 +3,42 @@ service facts. Real scaffolding — EXTEND with operational specifics; do not de
 Bank-grade ops (prod-readiness C9=3 / C6=3) still needs a real on-call rotation and an
 exercised DR drill, tracked as TTL'd attestations, never faked here. -->
 
-# Runbook — openbank-interest-service
+# Runbook — openbank-document-service
 
-> Operational runbook for the `interest` service. Data domain **payments**,
-> classification **internal**, datastore **PostgreSQL**.
+> Operational runbook for the `document` service. Data domain **platform**,
+> classification **restricted**, datastore **PostgreSQL**.
 
 ## Service identity
 
 | Field | Value |
 |---|---|
-| Service | `openbank-interest-service` |
-| HTTP port | `8125` |
-| Data domain | payments |
-| Datastore | PostgreSQL (schema `interest_schema`) |
-| Classification | internal |
-| Retention | 5 years |
+| Service | `openbank-document-service` |
+| HTTP port | `8143` |
+| Data domain | platform |
+| Datastore | PostgreSQL (schema `documents_schema`) |
+| Classification | restricted |
+| Retention | 10 years |
 | Lineage role | both |
 
 ## Dependencies
 
-- **Upstream (this service consumes):** _none declared_
-- **Downstream (depends on this service):** `account-service`
+- **Upstream (this service consumes):** `sca-service`, `product-catalog`, `account-service`
+- **Downstream (depends on this service):** _none declared_
 
 A failure here propagates to the downstream services above — check them when
-triaging an incident that starts on `interest`.
+triaging an incident that starts on `document`.
 
 ## Health & probes
 
-- Readiness: `GET :8125/q/health/ready` · Liveness: `GET :8125/q/health/live`
-- Metrics: scraped by the fleet PodMonitor (namespace `interest`); dashboards in Grafana.
-- Logs: `kubectl logs -n interest deploy/interest-service -f`, or Loki
-  `{namespace="interest"}`.
+- Readiness: `GET :8143/q/health/ready` · Liveness: `GET :8143/q/health/live`
+- Metrics: scraped by the fleet PodMonitor (namespace `documents`); dashboards in Grafana.
+- Logs: `kubectl logs -n documents deploy/document-service -f`, or Loki
+  `{namespace="documents"}`.
 
 ## Routine operations
 
-- **Restart:** `kubectl rollout restart deploy/interest-service -n interest` (rolling, zero-downtime at >1 replica).
-- **Scale:** `kubectl scale deploy/interest-service -n interest --replicas=<n>` (or edit the GitOps Deployment — GitOps is source of truth, a manual scale is reverted by ArgoCD).
+- **Restart:** `kubectl rollout restart deploy/document-service -n documents` (rolling, zero-downtime at >1 replica).
+- **Scale:** `kubectl scale deploy/document-service -n documents --replicas=<n>` (or edit the GitOps Deployment — GitOps is source of truth, a manual scale is reverted by ArgoCD).
 - **Config/secret change:** edit the GitOps manifest; ArgoCD syncs. Never `kubectl edit` in place.
 
 ## Common failure modes
@@ -60,11 +60,11 @@ triaging an incident that starts on `interest`.
 
 > RPO/RTO above are documented targets. They become **Bank-grade** (prod-readiness
 > C6=3) only once a restore/failover drill has actually been rehearsed and attested
-> (`openbank-libs/governance/attestations.yaml: interest.dr_drill`).
+> (`openbank-libs/governance/attestations.yaml: document.dr_drill`).
 
 ## Escalation & break-glass
 
 - First responder: the owning squad's on-call (rotation tracked as the
-  `interest.oncall` attestation — until that is live, escalate via the team channel).
+  `document.oncall` attestation — until that is live, escalate via the team channel).
 - Break-glass cluster access is audited; use it only for a declared incident and
   record the justification.

--- a/docs/runbooks/svc-finrep.md
+++ b/docs/runbooks/svc-finrep.md
@@ -1,0 +1,71 @@
+<!-- Generated starter runbook (generate-service-runbooks.py) from declared
+service facts. Real scaffolding — EXTEND with operational specifics; do not delete.
+Bank-grade ops (prod-readiness C9=3 / C6=3) still needs a real on-call rotation and an
+exercised DR drill, tracked as TTL'd attestations, never faked here. -->
+
+# Runbook — openbank-finrep-service
+
+> Operational runbook for the `finrep` service. Data domain **compliance**,
+> classification **confidential**, datastore **none**.
+
+## Service identity
+
+| Field | Value |
+|---|---|
+| Service | `openbank-finrep-service` |
+| HTTP port | `8140` |
+| Data domain | compliance |
+| Datastore | none (schema `n/a`) |
+| Classification | confidential |
+| Retention | 10 years |
+| Lineage role | consumer |
+
+## Dependencies
+
+- **Upstream (this service consumes):** `ledger-service`, `statement-service`
+- **Downstream (depends on this service):** _none declared_
+
+A failure here propagates to the downstream services above — check them when
+triaging an incident that starts on `finrep`.
+
+## Health & probes
+
+- Readiness: `GET :8140/q/health/ready` · Liveness: `GET :8140/q/health/live`
+- Metrics: scraped by the fleet PodMonitor (namespace `finrep`); dashboards in Grafana.
+- Logs: `kubectl logs -n finrep deploy/finrep-service -f`, or Loki
+  `{namespace="finrep"}`.
+
+## Routine operations
+
+- **Restart:** `kubectl rollout restart deploy/finrep-service -n finrep` (rolling, zero-downtime at >1 replica).
+- **Scale:** `kubectl scale deploy/finrep-service -n finrep --replicas=<n>` (or edit the GitOps Deployment — GitOps is source of truth, a manual scale is reverted by ArgoCD).
+- **Config/secret change:** edit the GitOps manifest; ArgoCD syncs. Never `kubectl edit` in place.
+
+## Common failure modes
+
+- **Pod CrashLoopBackOff at boot:** usually a missing/invalid config or secret
+  (`ExternalSecret` not synced). Check `kubectl describe pod` events and the
+  first 50 log lines.
+- **Readiness flapping:** this service holds no datastore, so look outward — an
+  upstream dependency below, or the OPA sidecar if `AUTHZ_ENFORCE` is on (with no
+  reachable PDP, `@Authorize` fails closed).
+- **Downstream errors:** verify the upstream dependencies above are healthy before
+  assuming the fault is local.
+
+## Disaster recovery
+
+- **RPO: n/a** — no persistent state. **RTO target:** ≤ 10 min (image pull + rollout).
+- **Mechanism:** none needed — this service declares no primary datastore, so it holds no state to lose. Recovery is a redeploy from the GitOps manifests, which are the source of truth.
+- **Restore:** re-sync the ArgoCD Application (or `kubectl rollout restart` the Deployment). Any state this service reads lives in its upstream services above — recover those first, using their own runbooks.
+- **Verify:** health endpoint green, then re-drive one request end to end against an upstream that is already known-good.
+
+> RPO/RTO above are documented targets. They become **Bank-grade** (prod-readiness
+> C6=3) only once a restore/failover drill has actually been rehearsed and attested
+> (`openbank-libs/governance/attestations.yaml: finrep.dr_drill`).
+
+## Escalation & break-glass
+
+- First responder: the owning squad's on-call (rotation tracked as the
+  `finrep.oncall` attestation — until that is live, escalate via the team channel).
+- Break-glass cluster access is audited; use it only for a declared incident and
+  record the justification.

--- a/docs/runbooks/svc-fraud.md
+++ b/docs/runbooks/svc-fraud.md
@@ -53,9 +53,8 @@ triaging an incident that starts on `fraud`.
 
 ## Disaster recovery
 
-- **RPO/RTO: undefined** — no backup is configured yet (see the prerequisite below), so no recovery-point/time guarantee can be made today.
-- **⚠ Prerequisite NOT met:** this PostgreSQL cluster has **no backup configured** (`barmanObjectStore` absent — prod-readiness C5=1). **DR is not achievable today** and the RPO/RTO targets above do NOT yet apply. Enabling the CNPG backup is the blocking prerequisite (see the backup sweep). Once enabled, the procedure is:
-- **Mechanism (after enablement):** CNPG continuous WAL + base backups → PITR.
+- **RPO target:** ≤ 5 min (continuous archiving). **RTO target:** ≤ 30 min (restore + warm-up).
+- **Mechanism:** CloudNativePG continuous WAL archiving + base backups to S3 (`barmanObjectStore`). Point-in-time recovery (PITR).
 - **Restore:** create a `Cluster` with `bootstrap.recovery` pointing at the backup object store; CNPG replays WAL to the target time. See runbook 0003 (PG major upgrade) for the cluster-recreate mechanics.
 - **Verify:** `kubectl cnpg status <db>-rw -n <ns>` shows the recovered cluster Healthy and the `*-app` secret regenerated.
 

--- a/docs/runbooks/svc-fx.md
+++ b/docs/runbooks/svc-fx.md
@@ -23,7 +23,7 @@ exercised DR drill, tracked as TTL'd attestations, never faked here. -->
 ## Dependencies
 
 - **Upstream (this service consumes):** _none declared_
-- **Downstream (depends on this service):** `transaction-service`
+- **Downstream (depends on this service):** _none declared_
 
 A failure here propagates to the downstream services above — check them when
 triaging an incident that starts on `fx`.
@@ -53,7 +53,7 @@ triaging an incident that starts on `fx`.
 
 ## Disaster recovery
 
-- **RPO/RTO: undefined** — no backup is configured yet (see the prerequisite below), so no recovery-point/time guarantee can be made today.
+- **RPO target:** ≤ 5 min (continuous archiving). **RTO target:** ≤ 30 min (restore + warm-up).
 - **Mechanism:** restore from the datastore's managed backup to a fresh instance (confirm a backup is actually configured for this datastore first).
 - **Restore:** provision a new datastore from the latest backup, replay any incremental logs, re-point the service.
 - **Verify:** health endpoint green + a domain spot check against last known-good.

--- a/docs/runbooks/svc-kyc.md
+++ b/docs/runbooks/svc-kyc.md
@@ -23,7 +23,7 @@ exercised DR drill, tracked as TTL'd attestations, never faked here. -->
 ## Dependencies
 
 - **Upstream (this service consumes):** _none declared_
-- **Downstream (depends on this service):** `party-service`, `aml-service`, `notification-service`
+- **Downstream (depends on this service):** `party-service`
 
 A failure here propagates to the downstream services above — check them when
 triaging an incident that starts on `kyc`.
@@ -53,9 +53,8 @@ triaging an incident that starts on `kyc`.
 
 ## Disaster recovery
 
-- **RPO/RTO: undefined** — no backup is configured yet (see the prerequisite below), so no recovery-point/time guarantee can be made today.
-- **⚠ Prerequisite NOT met:** this PostgreSQL cluster has **no backup configured** (`barmanObjectStore` absent — prod-readiness C5=1). **DR is not achievable today** and the RPO/RTO targets above do NOT yet apply. Enabling the CNPG backup is the blocking prerequisite (see the backup sweep). Once enabled, the procedure is:
-- **Mechanism (after enablement):** CNPG continuous WAL + base backups → PITR.
+- **RPO target:** ≤ 5 min (continuous archiving). **RTO target:** ≤ 30 min (restore + warm-up).
+- **Mechanism:** CloudNativePG continuous WAL archiving + base backups to S3 (`barmanObjectStore`). Point-in-time recovery (PITR).
 - **Restore:** create a `Cluster` with `bootstrap.recovery` pointing at the backup object store; CNPG replays WAL to the target time. See runbook 0003 (PG major upgrade) for the cluster-recreate mechanics.
 - **Verify:** `kubectl cnpg status <db>-rw -n <ns>` shows the recovered cluster Healthy and the `*-app` secret regenerated.
 

--- a/docs/runbooks/svc-ledger.md
+++ b/docs/runbooks/svc-ledger.md
@@ -53,9 +53,8 @@ triaging an incident that starts on `ledger`.
 
 ## Disaster recovery
 
-- **RPO/RTO: undefined** — no backup is configured yet (see the prerequisite below), so no recovery-point/time guarantee can be made today.
-- **⚠ Prerequisite NOT met:** this PostgreSQL cluster has **no backup configured** (`barmanObjectStore` absent — prod-readiness C5=1). **DR is not achievable today** and the RPO/RTO targets above do NOT yet apply. Enabling the CNPG backup is the blocking prerequisite (see the backup sweep). Once enabled, the procedure is:
-- **Mechanism (after enablement):** CNPG continuous WAL + base backups → PITR.
+- **RPO target:** ≤ 5 min (continuous archiving). **RTO target:** ≤ 30 min (restore + warm-up).
+- **Mechanism:** CloudNativePG continuous WAL archiving + base backups to S3 (`barmanObjectStore`). Point-in-time recovery (PITR).
 - **Restore:** create a `Cluster` with `bootstrap.recovery` pointing at the backup object store; CNPG replays WAL to the target time. See runbook 0003 (PG major upgrade) for the cluster-recreate mechanics.
 - **Verify:** `kubectl cnpg status <db>-rw -n <ns>` shows the recovered cluster Healthy and the `*-app` secret regenerated.
 

--- a/docs/runbooks/svc-lending.md
+++ b/docs/runbooks/svc-lending.md
@@ -53,9 +53,8 @@ triaging an incident that starts on `lending`.
 
 ## Disaster recovery
 
-- **RPO/RTO: undefined** — no backup is configured yet (see the prerequisite below), so no recovery-point/time guarantee can be made today.
-- **⚠ Prerequisite NOT met:** this PostgreSQL cluster has **no backup configured** (`barmanObjectStore` absent — prod-readiness C5=1). **DR is not achievable today** and the RPO/RTO targets above do NOT yet apply. Enabling the CNPG backup is the blocking prerequisite (see the backup sweep). Once enabled, the procedure is:
-- **Mechanism (after enablement):** CNPG continuous WAL + base backups → PITR.
+- **RPO target:** ≤ 5 min (continuous archiving). **RTO target:** ≤ 30 min (restore + warm-up).
+- **Mechanism:** CloudNativePG continuous WAL archiving + base backups to S3 (`barmanObjectStore`). Point-in-time recovery (PITR).
 - **Restore:** create a `Cluster` with `bootstrap.recovery` pointing at the backup object store; CNPG replays WAL to the target time. See runbook 0003 (PG major upgrade) for the cluster-recreate mechanics.
 - **Verify:** `kubectl cnpg status <db>-rw -n <ns>` shows the recovered cluster Healthy and the `*-app` secret regenerated.
 

--- a/docs/runbooks/svc-mcp.md
+++ b/docs/runbooks/svc-mcp.md
@@ -1,0 +1,71 @@
+<!-- Generated starter runbook (generate-service-runbooks.py) from declared
+service facts. Real scaffolding — EXTEND with operational specifics; do not delete.
+Bank-grade ops (prod-readiness C9=3 / C6=3) still needs a real on-call rotation and an
+exercised DR drill, tracked as TTL'd attestations, never faked here. -->
+
+# Runbook — openbank-mcp-service
+
+> Operational runbook for the `mcp` service. Data domain **payments**,
+> classification **confidential**, datastore **none**.
+
+## Service identity
+
+| Field | Value |
+|---|---|
+| Service | `openbank-mcp-service` |
+| HTTP port | `8150` |
+| Data domain | payments |
+| Datastore | none (schema `—`) |
+| Classification | confidential |
+| Retention | not applicable |
+| Lineage role | consumer |
+
+## Dependencies
+
+- **Upstream (this service consumes):** _none declared_
+- **Downstream (depends on this service):** _none declared_
+
+A failure here propagates to the downstream services above — check them when
+triaging an incident that starts on `mcp`.
+
+## Health & probes
+
+- Readiness: `GET :8150/q/health/ready` · Liveness: `GET :8150/q/health/live`
+- Metrics: scraped by the fleet PodMonitor (namespace `platform`); dashboards in Grafana.
+- Logs: `kubectl logs -n platform deploy/mcp-service -f`, or Loki
+  `{namespace="platform"}`.
+
+## Routine operations
+
+- **Restart:** `kubectl rollout restart deploy/mcp-service -n platform` (rolling, zero-downtime at >1 replica).
+- **Scale:** `kubectl scale deploy/mcp-service -n platform --replicas=<n>` (or edit the GitOps Deployment — GitOps is source of truth, a manual scale is reverted by ArgoCD).
+- **Config/secret change:** edit the GitOps manifest; ArgoCD syncs. Never `kubectl edit` in place.
+
+## Common failure modes
+
+- **Pod CrashLoopBackOff at boot:** usually a missing/invalid config or secret
+  (`ExternalSecret` not synced). Check `kubectl describe pod` events and the
+  first 50 log lines.
+- **Readiness flapping:** this service holds no datastore, so look outward — an
+  upstream dependency below, or the OPA sidecar if `AUTHZ_ENFORCE` is on (with no
+  reachable PDP, `@Authorize` fails closed).
+- **Downstream errors:** verify the upstream dependencies above are healthy before
+  assuming the fault is local.
+
+## Disaster recovery
+
+- **RPO: n/a** — no persistent state. **RTO target:** ≤ 10 min (image pull + rollout).
+- **Mechanism:** none needed — this service declares no primary datastore, so it holds no state to lose. Recovery is a redeploy from the GitOps manifests, which are the source of truth.
+- **Restore:** re-sync the ArgoCD Application (or `kubectl rollout restart` the Deployment). Any state this service reads lives in its upstream services above — recover those first, using their own runbooks.
+- **Verify:** health endpoint green, then re-drive one request end to end against an upstream that is already known-good.
+
+> RPO/RTO above are documented targets. They become **Bank-grade** (prod-readiness
+> C6=3) only once a restore/failover drill has actually been rehearsed and attested
+> (`openbank-libs/governance/attestations.yaml: mcp.dr_drill`).
+
+## Escalation & break-glass
+
+- First responder: the owning squad's on-call (rotation tracked as the
+  `mcp.oncall` attestation — until that is live, escalate via the team channel).
+- Break-glass cluster access is audited; use it only for a declared incident and
+  record the justification.

--- a/docs/runbooks/svc-notification.md
+++ b/docs/runbooks/svc-notification.md
@@ -31,14 +31,14 @@ triaging an incident that starts on `notification`.
 ## Health & probes
 
 - Readiness: `GET :8112/q/health/ready` · Liveness: `GET :8112/q/health/live`
-- Metrics: scraped by the fleet PodMonitor (namespace `notification`); dashboards in Grafana.
-- Logs: `kubectl logs -n notification deploy/notification-service -f`, or Loki
-  `{namespace="notification"}`.
+- Metrics: scraped by the fleet PodMonitor (namespace `notifications`); dashboards in Grafana.
+- Logs: `kubectl logs -n notifications deploy/notification-service -f`, or Loki
+  `{namespace="notifications"}`.
 
 ## Routine operations
 
-- **Restart:** `kubectl rollout restart deploy/notification-service -n notification` (rolling, zero-downtime at >1 replica).
-- **Scale:** `kubectl scale deploy/notification-service -n notification --replicas=<n>` (or edit the GitOps Deployment — GitOps is source of truth, a manual scale is reverted by ArgoCD).
+- **Restart:** `kubectl rollout restart deploy/notification-service -n notifications` (rolling, zero-downtime at >1 replica).
+- **Scale:** `kubectl scale deploy/notification-service -n notifications --replicas=<n>` (or edit the GitOps Deployment — GitOps is source of truth, a manual scale is reverted by ArgoCD).
 - **Config/secret change:** edit the GitOps manifest; ArgoCD syncs. Never `kubectl edit` in place.
 
 ## Common failure modes

--- a/docs/runbooks/svc-onboarding.md
+++ b/docs/runbooks/svc-onboarding.md
@@ -23,7 +23,7 @@ exercised DR drill, tracked as TTL'd attestations, never faked here. -->
 ## Dependencies
 
 - **Upstream (this service consumes):** `party-service`, `kyc-service`
-- **Downstream (depends on this service):** `account-service`
+- **Downstream (depends on this service):** _none declared_
 
 A failure here propagates to the downstream services above — check them when
 triaging an incident that starts on `onboarding`.
@@ -53,9 +53,8 @@ triaging an incident that starts on `onboarding`.
 
 ## Disaster recovery
 
-- **RPO/RTO: undefined** — no backup is configured yet (see the prerequisite below), so no recovery-point/time guarantee can be made today.
-- **⚠ Prerequisite NOT met:** this PostgreSQL cluster has **no backup configured** (`barmanObjectStore` absent — prod-readiness C5=1). **DR is not achievable today** and the RPO/RTO targets above do NOT yet apply. Enabling the CNPG backup is the blocking prerequisite (see the backup sweep). Once enabled, the procedure is:
-- **Mechanism (after enablement):** CNPG continuous WAL + base backups → PITR.
+- **RPO target:** ≤ 5 min (continuous archiving). **RTO target:** ≤ 30 min (restore + warm-up).
+- **Mechanism:** CloudNativePG continuous WAL archiving + base backups to S3 (`barmanObjectStore`). Point-in-time recovery (PITR).
 - **Restore:** create a `Cluster` with `bootstrap.recovery` pointing at the backup object store; CNPG replays WAL to the target time. See runbook 0003 (PG major upgrade) for the cluster-recreate mechanics.
 - **Verify:** `kubectl cnpg status <db>-rw -n <ns>` shows the recovered cluster Healthy and the `*-app` secret regenerated.
 

--- a/docs/runbooks/svc-party.md
+++ b/docs/runbooks/svc-party.md
@@ -23,7 +23,7 @@ exercised DR drill, tracked as TTL'd attestations, never faked here. -->
 ## Dependencies
 
 - **Upstream (this service consumes):** `account-service`, `kyc-service`
-- **Downstream (depends on this service):** `pid-service`, `audit-service`
+- **Downstream (depends on this service):** `audit-service`, `account-service`
 
 A failure here propagates to the downstream services above — check them when
 triaging an incident that starts on `party`.

--- a/docs/runbooks/svc-pid.md
+++ b/docs/runbooks/svc-pid.md
@@ -53,9 +53,8 @@ triaging an incident that starts on `pid`.
 
 ## Disaster recovery
 
-- **RPO/RTO: undefined** — no backup is configured yet (see the prerequisite below), so no recovery-point/time guarantee can be made today.
-- **⚠ Prerequisite NOT met:** this PostgreSQL cluster has **no backup configured** (`barmanObjectStore` absent — prod-readiness C5=1). **DR is not achievable today** and the RPO/RTO targets above do NOT yet apply. Enabling the CNPG backup is the blocking prerequisite (see the backup sweep). Once enabled, the procedure is:
-- **Mechanism (after enablement):** CNPG continuous WAL + base backups → PITR.
+- **RPO target:** ≤ 5 min (continuous archiving). **RTO target:** ≤ 30 min (restore + warm-up).
+- **Mechanism:** CloudNativePG continuous WAL archiving + base backups to S3 (`barmanObjectStore`). Point-in-time recovery (PITR).
 - **Restore:** create a `Cluster` with `bootstrap.recovery` pointing at the backup object store; CNPG replays WAL to the target time. See runbook 0003 (PG major upgrade) for the cluster-recreate mechanics.
 - **Verify:** `kubectl cnpg status <db>-rw -n <ns>` shows the recovered cluster Healthy and the `*-app` secret regenerated.
 

--- a/docs/runbooks/svc-psd2.md
+++ b/docs/runbooks/svc-psd2.md
@@ -53,7 +53,7 @@ triaging an incident that starts on `psd2`.
 
 ## Disaster recovery
 
-- **RPO/RTO: undefined** — no backup is configured yet (see the prerequisite below), so no recovery-point/time guarantee can be made today.
+- **RPO target:** ≤ 5 min (continuous archiving). **RTO target:** ≤ 30 min (restore + warm-up).
 - **Mechanism:** restore from the datastore's managed backup to a fresh instance (confirm a backup is actually configured for this datastore first).
 - **Restore:** provision a new datastore from the latest backup, replay any incremental logs, re-point the service.
 - **Verify:** health endpoint green + a domain spot check against last known-good.

--- a/docs/runbooks/svc-sanctions.md
+++ b/docs/runbooks/svc-sanctions.md
@@ -23,7 +23,7 @@ exercised DR drill, tracked as TTL'd attestations, never faked here. -->
 ## Dependencies
 
 - **Upstream (this service consumes):** _none declared_
-- **Downstream (depends on this service):** `aml-service`
+- **Downstream (depends on this service):** _none declared_
 
 A failure here propagates to the downstream services above — check them when
 triaging an incident that starts on `sanctions`.
@@ -53,9 +53,8 @@ triaging an incident that starts on `sanctions`.
 
 ## Disaster recovery
 
-- **RPO/RTO: undefined** — no backup is configured yet (see the prerequisite below), so no recovery-point/time guarantee can be made today.
-- **⚠ Prerequisite NOT met:** this PostgreSQL cluster has **no backup configured** (`barmanObjectStore` absent — prod-readiness C5=1). **DR is not achievable today** and the RPO/RTO targets above do NOT yet apply. Enabling the CNPG backup is the blocking prerequisite (see the backup sweep). Once enabled, the procedure is:
-- **Mechanism (after enablement):** CNPG continuous WAL + base backups → PITR.
+- **RPO target:** ≤ 5 min (continuous archiving). **RTO target:** ≤ 30 min (restore + warm-up).
+- **Mechanism:** CloudNativePG continuous WAL archiving + base backups to S3 (`barmanObjectStore`). Point-in-time recovery (PITR).
 - **Restore:** create a `Cluster` with `bootstrap.recovery` pointing at the backup object store; CNPG replays WAL to the target time. See runbook 0003 (PG major upgrade) for the cluster-recreate mechanics.
 - **Verify:** `kubectl cnpg status <db>-rw -n <ns>` shows the recovered cluster Healthy and the `*-app` secret regenerated.
 

--- a/docs/runbooks/svc-sdd.md
+++ b/docs/runbooks/svc-sdd.md
@@ -53,9 +53,8 @@ triaging an incident that starts on `sdd`.
 
 ## Disaster recovery
 
-- **RPO/RTO: undefined** — no backup is configured yet (see the prerequisite below), so no recovery-point/time guarantee can be made today.
-- **⚠ Prerequisite NOT met:** this PostgreSQL cluster has **no backup configured** (`barmanObjectStore` absent — prod-readiness C5=1). **DR is not achievable today** and the RPO/RTO targets above do NOT yet apply. Enabling the CNPG backup is the blocking prerequisite (see the backup sweep). Once enabled, the procedure is:
-- **Mechanism (after enablement):** CNPG continuous WAL + base backups → PITR.
+- **RPO target:** ≤ 5 min (continuous archiving). **RTO target:** ≤ 30 min (restore + warm-up).
+- **Mechanism:** CloudNativePG continuous WAL archiving + base backups to S3 (`barmanObjectStore`). Point-in-time recovery (PITR).
 - **Restore:** create a `Cluster` with `bootstrap.recovery` pointing at the backup object store; CNPG replays WAL to the target time. See runbook 0003 (PG major upgrade) for the cluster-recreate mechanics.
 - **Verify:** `kubectl cnpg status <db>-rw -n <ns>` shows the recovered cluster Healthy and the `*-app` secret regenerated.
 

--- a/docs/runbooks/svc-settlement.md
+++ b/docs/runbooks/svc-settlement.md
@@ -3,42 +3,42 @@ service facts. Real scaffolding — EXTEND with operational specifics; do not de
 Bank-grade ops (prod-readiness C9=3 / C6=3) still needs a real on-call rotation and an
 exercised DR drill, tracked as TTL'd attestations, never faked here. -->
 
-# Runbook — openbank-interest-service
+# Runbook — openbank-settlement-service
 
-> Operational runbook for the `interest` service. Data domain **payments**,
-> classification **internal**, datastore **PostgreSQL**.
+> Operational runbook for the `settlement` service. Data domain **payments**,
+> classification **confidential**, datastore **PostgreSQL**.
 
 ## Service identity
 
 | Field | Value |
 |---|---|
-| Service | `openbank-interest-service` |
-| HTTP port | `8125` |
+| Service | `openbank-settlement-service` |
+| HTTP port | `8138` |
 | Data domain | payments |
-| Datastore | PostgreSQL (schema `interest_schema`) |
-| Classification | internal |
-| Retention | 5 years |
+| Datastore | PostgreSQL (schema `settlement_schema`) |
+| Classification | confidential |
+| Retention | 7 years |
 | Lineage role | both |
 
 ## Dependencies
 
-- **Upstream (this service consumes):** _none declared_
-- **Downstream (depends on this service):** `account-service`
+- **Upstream (this service consumes):** `ledger-service`, `sepa-payment`
+- **Downstream (depends on this service):** `audit-service`
 
 A failure here propagates to the downstream services above — check them when
-triaging an incident that starts on `interest`.
+triaging an incident that starts on `settlement`.
 
 ## Health & probes
 
-- Readiness: `GET :8125/q/health/ready` · Liveness: `GET :8125/q/health/live`
-- Metrics: scraped by the fleet PodMonitor (namespace `interest`); dashboards in Grafana.
-- Logs: `kubectl logs -n interest deploy/interest-service -f`, or Loki
-  `{namespace="interest"}`.
+- Readiness: `GET :8138/q/health/ready` · Liveness: `GET :8138/q/health/live`
+- Metrics: scraped by the fleet PodMonitor (namespace `payments`); dashboards in Grafana.
+- Logs: `kubectl logs -n payments deploy/settlement-service -f`, or Loki
+  `{namespace="payments"}`.
 
 ## Routine operations
 
-- **Restart:** `kubectl rollout restart deploy/interest-service -n interest` (rolling, zero-downtime at >1 replica).
-- **Scale:** `kubectl scale deploy/interest-service -n interest --replicas=<n>` (or edit the GitOps Deployment — GitOps is source of truth, a manual scale is reverted by ArgoCD).
+- **Restart:** `kubectl rollout restart deploy/settlement-service -n payments` (rolling, zero-downtime at >1 replica).
+- **Scale:** `kubectl scale deploy/settlement-service -n payments --replicas=<n>` (or edit the GitOps Deployment — GitOps is source of truth, a manual scale is reverted by ArgoCD).
 - **Config/secret change:** edit the GitOps manifest; ArgoCD syncs. Never `kubectl edit` in place.
 
 ## Common failure modes
@@ -60,11 +60,11 @@ triaging an incident that starts on `interest`.
 
 > RPO/RTO above are documented targets. They become **Bank-grade** (prod-readiness
 > C6=3) only once a restore/failover drill has actually been rehearsed and attested
-> (`openbank-libs/governance/attestations.yaml: interest.dr_drill`).
+> (`openbank-libs/governance/attestations.yaml: settlement.dr_drill`).
 
 ## Escalation & break-glass
 
 - First responder: the owning squad's on-call (rotation tracked as the
-  `interest.oncall` attestation — until that is live, escalate via the team channel).
+  `settlement.oncall` attestation — until that is live, escalate via the team channel).
 - Break-glass cluster access is audited; use it only for a declared incident and
   record the justification.

--- a/docs/runbooks/svc-standing-order.md
+++ b/docs/runbooks/svc-standing-order.md
@@ -23,7 +23,7 @@ exercised DR drill, tracked as TTL'd attestations, never faked here. -->
 ## Dependencies
 
 - **Upstream (this service consumes):** _none declared_
-- **Downstream (depends on this service):** `transaction-service`
+- **Downstream (depends on this service):** `sepa-payment`
 
 A failure here propagates to the downstream services above — check them when
 triaging an incident that starts on `standing-order`.
@@ -31,14 +31,14 @@ triaging an incident that starts on `standing-order`.
 ## Health & probes
 
 - Readiness: `GET :8121/q/health/ready` · Liveness: `GET :8121/q/health/live`
-- Metrics: scraped by the fleet PodMonitor (namespace `standing-order`); dashboards in Grafana.
-- Logs: `kubectl logs -n standing-order deploy/standing-order-service -f`, or Loki
-  `{namespace="standing-order"}`.
+- Metrics: scraped by the fleet PodMonitor (namespace `payments`); dashboards in Grafana.
+- Logs: `kubectl logs -n payments deploy/standing-order-service -f`, or Loki
+  `{namespace="payments"}`.
 
 ## Routine operations
 
-- **Restart:** `kubectl rollout restart deploy/standing-order-service -n standing-order` (rolling, zero-downtime at >1 replica).
-- **Scale:** `kubectl scale deploy/standing-order-service -n standing-order --replicas=<n>` (or edit the GitOps Deployment — GitOps is source of truth, a manual scale is reverted by ArgoCD).
+- **Restart:** `kubectl rollout restart deploy/standing-order-service -n payments` (rolling, zero-downtime at >1 replica).
+- **Scale:** `kubectl scale deploy/standing-order-service -n payments --replicas=<n>` (or edit the GitOps Deployment — GitOps is source of truth, a manual scale is reverted by ArgoCD).
 - **Config/secret change:** edit the GitOps manifest; ArgoCD syncs. Never `kubectl edit` in place.
 
 ## Common failure modes
@@ -53,9 +53,8 @@ triaging an incident that starts on `standing-order`.
 
 ## Disaster recovery
 
-- **RPO/RTO: undefined** — no backup is configured yet (see the prerequisite below), so no recovery-point/time guarantee can be made today.
-- **⚠ Prerequisite NOT met:** this PostgreSQL cluster has **no backup configured** (`barmanObjectStore` absent — prod-readiness C5=1). **DR is not achievable today** and the RPO/RTO targets above do NOT yet apply. Enabling the CNPG backup is the blocking prerequisite (see the backup sweep). Once enabled, the procedure is:
-- **Mechanism (after enablement):** CNPG continuous WAL + base backups → PITR.
+- **RPO target:** ≤ 5 min (continuous archiving). **RTO target:** ≤ 30 min (restore + warm-up).
+- **Mechanism:** CloudNativePG continuous WAL archiving + base backups to S3 (`barmanObjectStore`). Point-in-time recovery (PITR).
 - **Restore:** create a `Cluster` with `bootstrap.recovery` pointing at the backup object store; CNPG replays WAL to the target time. See runbook 0003 (PG major upgrade) for the cluster-recreate mechanics.
 - **Verify:** `kubectl cnpg status <db>-rw -n <ns>` shows the recovered cluster Healthy and the `*-app` secret regenerated.
 

--- a/docs/runbooks/svc-statement.md
+++ b/docs/runbooks/svc-statement.md
@@ -31,14 +31,14 @@ triaging an incident that starts on `statement`.
 ## Health & probes
 
 - Readiness: `GET :8136/q/health/ready` · Liveness: `GET :8136/q/health/live`
-- Metrics: scraped by the fleet PodMonitor (namespace `statement`); dashboards in Grafana.
-- Logs: `kubectl logs -n statement deploy/statement-service -f`, or Loki
-  `{namespace="statement"}`.
+- Metrics: scraped by the fleet PodMonitor (namespace `statements`); dashboards in Grafana.
+- Logs: `kubectl logs -n statements deploy/statement-service -f`, or Loki
+  `{namespace="statements"}`.
 
 ## Routine operations
 
-- **Restart:** `kubectl rollout restart deploy/statement-service -n statement` (rolling, zero-downtime at >1 replica).
-- **Scale:** `kubectl scale deploy/statement-service -n statement --replicas=<n>` (or edit the GitOps Deployment — GitOps is source of truth, a manual scale is reverted by ArgoCD).
+- **Restart:** `kubectl rollout restart deploy/statement-service -n statements` (rolling, zero-downtime at >1 replica).
+- **Scale:** `kubectl scale deploy/statement-service -n statements --replicas=<n>` (or edit the GitOps Deployment — GitOps is source of truth, a manual scale is reverted by ArgoCD).
 - **Config/secret change:** edit the GitOps manifest; ArgoCD syncs. Never `kubectl edit` in place.
 
 ## Common failure modes

--- a/docs/runbooks/svc-swift.md
+++ b/docs/runbooks/svc-swift.md
@@ -23,7 +23,7 @@ exercised DR drill, tracked as TTL'd attestations, never faked here. -->
 ## Dependencies
 
 - **Upstream (this service consumes):** _none declared_
-- **Downstream (depends on this service):** `transaction-service`, `aml-service`
+- **Downstream (depends on this service):** `transaction-service`
 
 A failure here propagates to the downstream services above — check them when
 triaging an incident that starts on `swift`.
@@ -31,14 +31,14 @@ triaging an incident that starts on `swift`.
 ## Health & probes
 
 - Readiness: `GET :8122/q/health/ready` · Liveness: `GET :8122/q/health/live`
-- Metrics: scraped by the fleet PodMonitor (namespace `swift`); dashboards in Grafana.
-- Logs: `kubectl logs -n swift deploy/swift-service -f`, or Loki
-  `{namespace="swift"}`.
+- Metrics: scraped by the fleet PodMonitor (namespace `payments`); dashboards in Grafana.
+- Logs: `kubectl logs -n payments deploy/swift-service -f`, or Loki
+  `{namespace="payments"}`.
 
 ## Routine operations
 
-- **Restart:** `kubectl rollout restart deploy/swift-service -n swift` (rolling, zero-downtime at >1 replica).
-- **Scale:** `kubectl scale deploy/swift-service -n swift --replicas=<n>` (or edit the GitOps Deployment — GitOps is source of truth, a manual scale is reverted by ArgoCD).
+- **Restart:** `kubectl rollout restart deploy/swift-service -n payments` (rolling, zero-downtime at >1 replica).
+- **Scale:** `kubectl scale deploy/swift-service -n payments --replicas=<n>` (or edit the GitOps Deployment — GitOps is source of truth, a manual scale is reverted by ArgoCD).
 - **Config/secret change:** edit the GitOps manifest; ArgoCD syncs. Never `kubectl edit` in place.
 
 ## Common failure modes
@@ -53,9 +53,8 @@ triaging an incident that starts on `swift`.
 
 ## Disaster recovery
 
-- **RPO/RTO: undefined** — no backup is configured yet (see the prerequisite below), so no recovery-point/time guarantee can be made today.
-- **⚠ Prerequisite NOT met:** this PostgreSQL cluster has **no backup configured** (`barmanObjectStore` absent — prod-readiness C5=1). **DR is not achievable today** and the RPO/RTO targets above do NOT yet apply. Enabling the CNPG backup is the blocking prerequisite (see the backup sweep). Once enabled, the procedure is:
-- **Mechanism (after enablement):** CNPG continuous WAL + base backups → PITR.
+- **RPO target:** ≤ 5 min (continuous archiving). **RTO target:** ≤ 30 min (restore + warm-up).
+- **Mechanism:** CloudNativePG continuous WAL archiving + base backups to S3 (`barmanObjectStore`). Point-in-time recovery (PITR).
 - **Restore:** create a `Cluster` with `bootstrap.recovery` pointing at the backup object store; CNPG replays WAL to the target time. See runbook 0003 (PG major upgrade) for the cluster-recreate mechanics.
 - **Verify:** `kubectl cnpg status <db>-rw -n <ns>` shows the recovered cluster Healthy and the `*-app` secret regenerated.
 

--- a/docs/runbooks/svc-tpp-registry.md
+++ b/docs/runbooks/svc-tpp-registry.md
@@ -53,9 +53,8 @@ triaging an incident that starts on `tpp-registry`.
 
 ## Disaster recovery
 
-- **RPO/RTO: undefined** — no backup is configured yet (see the prerequisite below), so no recovery-point/time guarantee can be made today.
-- **⚠ Prerequisite NOT met:** this PostgreSQL cluster has **no backup configured** (`barmanObjectStore` absent — prod-readiness C5=1). **DR is not achievable today** and the RPO/RTO targets above do NOT yet apply. Enabling the CNPG backup is the blocking prerequisite (see the backup sweep). Once enabled, the procedure is:
-- **Mechanism (after enablement):** CNPG continuous WAL + base backups → PITR.
+- **RPO target:** ≤ 5 min (continuous archiving). **RTO target:** ≤ 30 min (restore + warm-up).
+- **Mechanism:** CloudNativePG continuous WAL archiving + base backups to S3 (`barmanObjectStore`). Point-in-time recovery (PITR).
 - **Restore:** create a `Cluster` with `bootstrap.recovery` pointing at the backup object store; CNPG replays WAL to the target time. See runbook 0003 (PG major upgrade) for the cluster-recreate mechanics.
 - **Verify:** `kubectl cnpg status <db>-rw -n <ns>` shows the recovered cluster Healthy and the `*-app` secret regenerated.
 

--- a/docs/runbooks/svc-transaction.md
+++ b/docs/runbooks/svc-transaction.md
@@ -23,7 +23,7 @@ exercised DR drill, tracked as TTL'd attestations, never faked here. -->
 ## Dependencies
 
 - **Upstream (this service consumes):** `fx-service`, `sepa-payment`, `sepa-instant`, `domestic-payment`, `standing-order-service`, `swift-service`, `clearing-service`, `agent-service`
-- **Downstream (depends on this service):** `account-service`, `ledger-service`, `balance-service`, `audit-service`, `notification-service`
+- **Downstream (depends on this service):** `account-service`, `ledger-service`, `balance-service`, `audit-service`
 
 A failure here propagates to the downstream services above — check them when
 triaging an incident that starts on `transaction`.
@@ -31,14 +31,14 @@ triaging an incident that starts on `transaction`.
 ## Health & probes
 
 - Readiness: `GET :8102/q/health/ready` · Liveness: `GET :8102/q/health/live`
-- Metrics: scraped by the fleet PodMonitor (namespace `transaction`); dashboards in Grafana.
-- Logs: `kubectl logs -n transaction deploy/transaction-service -f`, or Loki
-  `{namespace="transaction"}`.
+- Metrics: scraped by the fleet PodMonitor (namespace `payments`); dashboards in Grafana.
+- Logs: `kubectl logs -n payments deploy/transaction-service -f`, or Loki
+  `{namespace="payments"}`.
 
 ## Routine operations
 
-- **Restart:** `kubectl rollout restart deploy/transaction-service -n transaction` (rolling, zero-downtime at >1 replica).
-- **Scale:** `kubectl scale deploy/transaction-service -n transaction --replicas=<n>` (or edit the GitOps Deployment — GitOps is source of truth, a manual scale is reverted by ArgoCD).
+- **Restart:** `kubectl rollout restart deploy/transaction-service -n payments` (rolling, zero-downtime at >1 replica).
+- **Scale:** `kubectl scale deploy/transaction-service -n payments --replicas=<n>` (or edit the GitOps Deployment — GitOps is source of truth, a manual scale is reverted by ArgoCD).
 - **Config/secret change:** edit the GitOps manifest; ArgoCD syncs. Never `kubectl edit` in place.
 
 ## Common failure modes
@@ -53,9 +53,8 @@ triaging an incident that starts on `transaction`.
 
 ## Disaster recovery
 
-- **RPO/RTO: undefined** — no backup is configured yet (see the prerequisite below), so no recovery-point/time guarantee can be made today.
-- **⚠ Prerequisite NOT met:** this PostgreSQL cluster has **no backup configured** (`barmanObjectStore` absent — prod-readiness C5=1). **DR is not achievable today** and the RPO/RTO targets above do NOT yet apply. Enabling the CNPG backup is the blocking prerequisite (see the backup sweep). Once enabled, the procedure is:
-- **Mechanism (after enablement):** CNPG continuous WAL + base backups → PITR.
+- **RPO target:** ≤ 5 min (continuous archiving). **RTO target:** ≤ 30 min (restore + warm-up).
+- **Mechanism:** CloudNativePG continuous WAL archiving + base backups to S3 (`barmanObjectStore`). Point-in-time recovery (PITR).
 - **Restore:** create a `Cluster` with `bootstrap.recovery` pointing at the backup object store; CNPG replays WAL to the target time. See runbook 0003 (PG major upgrade) for the cluster-recreate mechanics.
 - **Verify:** `kubectl cnpg status <db>-rw -n <ns>` shows the recovered cluster Healthy and the `*-app` secret regenerated.
 

--- a/docs/runbooks/svc-vop.md
+++ b/docs/runbooks/svc-vop.md
@@ -3,42 +3,42 @@ service facts. Real scaffolding — EXTEND with operational specifics; do not de
 Bank-grade ops (prod-readiness C9=3 / C6=3) still needs a real on-call rotation and an
 exercised DR drill, tracked as TTL'd attestations, never faked here. -->
 
-# Runbook — openbank-interest-service
+# Runbook — openbank-vop-service
 
-> Operational runbook for the `interest` service. Data domain **payments**,
-> classification **internal**, datastore **PostgreSQL**.
+> Operational runbook for the `vop` service. Data domain **payments**,
+> classification **confidential**, datastore **PostgreSQL**.
 
 ## Service identity
 
 | Field | Value |
 |---|---|
-| Service | `openbank-interest-service` |
-| HTTP port | `8125` |
+| Service | `openbank-vop-service` |
+| HTTP port | `8149` |
 | Data domain | payments |
-| Datastore | PostgreSQL (schema `interest_schema`) |
-| Classification | internal |
-| Retention | 5 years |
+| Datastore | PostgreSQL (schema `vop_schema`) |
+| Classification | confidential |
+| Retention | 13 months |
 | Lineage role | both |
 
 ## Dependencies
 
 - **Upstream (this service consumes):** _none declared_
-- **Downstream (depends on this service):** `account-service`
+- **Downstream (depends on this service):** _none declared_
 
 A failure here propagates to the downstream services above — check them when
-triaging an incident that starts on `interest`.
+triaging an incident that starts on `vop`.
 
 ## Health & probes
 
-- Readiness: `GET :8125/q/health/ready` · Liveness: `GET :8125/q/health/live`
-- Metrics: scraped by the fleet PodMonitor (namespace `interest`); dashboards in Grafana.
-- Logs: `kubectl logs -n interest deploy/interest-service -f`, or Loki
-  `{namespace="interest"}`.
+- Readiness: `GET :8149/q/health/ready` · Liveness: `GET :8149/q/health/live`
+- Metrics: scraped by the fleet PodMonitor (namespace `payments`); dashboards in Grafana.
+- Logs: `kubectl logs -n payments deploy/vop-service -f`, or Loki
+  `{namespace="payments"}`.
 
 ## Routine operations
 
-- **Restart:** `kubectl rollout restart deploy/interest-service -n interest` (rolling, zero-downtime at >1 replica).
-- **Scale:** `kubectl scale deploy/interest-service -n interest --replicas=<n>` (or edit the GitOps Deployment — GitOps is source of truth, a manual scale is reverted by ArgoCD).
+- **Restart:** `kubectl rollout restart deploy/vop-service -n payments` (rolling, zero-downtime at >1 replica).
+- **Scale:** `kubectl scale deploy/vop-service -n payments --replicas=<n>` (or edit the GitOps Deployment — GitOps is source of truth, a manual scale is reverted by ArgoCD).
 - **Config/secret change:** edit the GitOps manifest; ArgoCD syncs. Never `kubectl edit` in place.
 
 ## Common failure modes
@@ -60,11 +60,11 @@ triaging an incident that starts on `interest`.
 
 > RPO/RTO above are documented targets. They become **Bank-grade** (prod-readiness
 > C6=3) only once a restore/failover drill has actually been rehearsed and attested
-> (`openbank-libs/governance/attestations.yaml: interest.dr_drill`).
+> (`openbank-libs/governance/attestations.yaml: vop.dr_drill`).
 
 ## Escalation & break-glass
 
 - First responder: the owning squad's on-call (rotation tracked as the
-  `interest.oncall` attestation — until that is live, escalate via the team channel).
+  `vop.oncall` attestation — until that is live, escalate via the team channel).
 - Break-glass cluster access is audited; use it only for a declared incident and
   record the justification.

--- a/openbank-infra/scripts/generate-service-runbooks.py
+++ b/openbank-infra/scripts/generate-service-runbooks.py
@@ -64,6 +64,54 @@ def http_port(short: str) -> str:
     return "?"
 
 
+def nearest_kustomize_namespace(manifest: Path) -> str | None:
+    for parent in manifest.parents:
+        if parent != GITOPS and GITOPS not in parent.parents:
+            break
+        m = re.search(r"^namespace:\s*(\S+)", read(parent / "kustomization.yaml"), re.M)
+        if m:
+            return m.group(1)
+    return None
+
+
+def service_namespace(short: str) -> str:
+    """The namespace this service's Deployment/Rollout actually lands in.
+
+    The runbook used to interpolate the service short name as its namespace, which is
+    wrong for a third of the fleet: document-service runs in `documents`, ap2 and mcp in
+    `platform`, settlement/vop/card-issuance/standing-order in `payments`. Every
+    `kubectl -n <ns>` line in those runbooks named a namespace that does not exist, so
+    the first command an on-call engineer copied out of them returned nothing. Resolve it
+    from the manifest that IS the workload — a NetworkPolicy peer or an env var merely
+    mentioning the service must not resolve, or the answer would be some caller's
+    namespace.
+    """
+    names = {f"{short}-service", f"openbank-{short}-service"}
+    for f in sorted(GITOPS.rglob("*.yaml")):
+        text = read(f)
+        if f"openbank-{short}-service" not in text:
+            continue
+        for doc in text.split("\n---"):
+            kind = re.search(r"^kind:\s*(\S+)", doc, re.M)
+            if not kind or kind.group(1) not in ("Deployment", "Rollout"):
+                continue
+            name = re.search(r"^\s{2}name:\s*(\S+)", doc, re.M)
+            if not name or name.group(1) not in names:
+                continue
+            ns = re.search(r"^\s{2}namespace:\s*(\S+)", doc, re.M)
+            if ns:
+                return ns.group(1)
+            inherited = nearest_kustomize_namespace(f)
+            if inherited:
+                return inherited
+    return short
+
+
+def is_stateless(datastore: str) -> bool:
+    """A service that declares no primary datastore. `none` / `n/a` / empty all count."""
+    return (datastore or "").strip().lower() in ("", "none", "n/a", "—", "-")
+
+
 def backup_configured(short: str) -> bool:
     """True iff a deployed manifest configures a backup for this service's datastore
     (CNPG barmanObjectStore). Mirrors the readiness collector's C5 detection so the
@@ -80,6 +128,18 @@ def backup_configured(short: str) -> bool:
 
 def dr_for(datastore: str, has_backup: bool) -> str:
     d = (datastore or "").lower()
+    if is_stateless(datastore):
+        # A stateless service has nothing to restore, and telling an on-call engineer to
+        # "restore from the datastore's managed backup" sends them hunting for a backup
+        # that does not exist — during an incident, at 3am. Its recovery is a redeploy.
+        return ("- **Mechanism:** none needed — this service declares no primary datastore, so it "
+                "holds no state to lose. Recovery is a redeploy from the GitOps manifests, which "
+                "are the source of truth.\n"
+                "- **Restore:** re-sync the ArgoCD Application (or `kubectl rollout restart` the "
+                "Deployment). Any state this service reads lives in its upstream services above — "
+                "recover those first, using their own runbooks.\n"
+                "- **Verify:** health endpoint green, then re-drive one request end to end against "
+                "an upstream that is already known-good.")
     if "postgres" in d:
         proc = ("- **Restore:** create a `Cluster` with `bootstrap.recovery` pointing at the "
                 "backup object store; CNPG replays WAL to the target time. See runbook 0003 "
@@ -141,23 +201,19 @@ triaging an incident that starts on `{short}`.
 ## Health & probes
 
 - Readiness: `GET :{port}/q/health/ready` · Liveness: `GET :{port}/q/health/live`
-- Metrics: scraped by the fleet PodMonitor (namespace `{short}`); dashboards in Grafana.
-- Logs: `kubectl logs -n {short} deploy/{short}-service -f`, or Loki
-  `{{namespace="{short}"}}`.
+- Metrics: scraped by the fleet PodMonitor (namespace `{ns}`); dashboards in Grafana.
+- Logs: `kubectl logs -n {ns} deploy/{short}-service -f`, or Loki
+  `{{namespace="{ns}"}}`.
 
 ## Routine operations
 
-- **Restart:** `kubectl rollout restart deploy/{short}-service -n {short}` (rolling, zero-downtime at >1 replica).
-- **Scale:** `kubectl scale deploy/{short}-service -n {short} --replicas=<n>` (or edit the GitOps Deployment — GitOps is source of truth, a manual scale is reverted by ArgoCD).
+- **Restart:** `kubectl rollout restart deploy/{short}-service -n {ns}` (rolling, zero-downtime at >1 replica).
+- **Scale:** `kubectl scale deploy/{short}-service -n {ns} --replicas=<n>` (or edit the GitOps Deployment — GitOps is source of truth, a manual scale is reverted by ArgoCD).
 - **Config/secret change:** edit the GitOps manifest; ArgoCD syncs. Never `kubectl edit` in place.
 
 ## Common failure modes
 
-- **Pod CrashLoopBackOff at boot:** usually a missing/invalid config or secret
-  (`ExternalSecret` not synced) or a Flyway checksum mismatch. Check
-  `kubectl describe pod` events and the first 50 log lines.
-- **Readiness flapping:** datastore ({datastore}) unreachable or saturated — check the
-  datastore pod/cluster health and connection-pool metrics.
+{failure_modes}
 - **Downstream errors:** verify the upstream dependencies above are healthy before
   assuming the fault is local.
 
@@ -183,15 +239,38 @@ def render(short: str) -> str:
     f = gov_facts(short)
     up = ", ".join(f"`{s}`" for s in f.get("upstream", [])) or "_none declared_"
     down = ", ".join(f"`{s}`" for s in f.get("downstream", [])) or "_none declared_"
-    has_backup = backup_configured(short)
-    rpo = ("- **RPO target:** ≤ 5 min (continuous archiving). **RTO target:** ≤ 30 min (restore + warm-up)."
-           if has_backup else
-           "- **RPO/RTO: undefined** — no backup is configured yet (see the prerequisite below), so "
-           "no recovery-point/time guarantee can be made today.")
+    datastore = f.get("primaryDatastore", "—")
+    stateless = is_stateless(datastore)
+    has_backup = False if stateless else backup_configured(short)
+    if stateless:
+        rpo = ("- **RPO: n/a** — no persistent state. **RTO target:** ≤ 10 min "
+               "(image pull + rollout).")
+        failure_modes = (
+            "- **Pod CrashLoopBackOff at boot:** usually a missing/invalid config or secret\n"
+            "  (`ExternalSecret` not synced). Check `kubectl describe pod` events and the\n"
+            "  first 50 log lines.\n"
+            "- **Readiness flapping:** this service holds no datastore, so look outward — an\n"
+            "  upstream dependency below, or the OPA sidecar if `AUTHZ_ENFORCE` is on (with no\n"
+            "  reachable PDP, `@Authorize` fails closed)."
+        )
+    else:
+        rpo = ("- **RPO target:** ≤ 5 min (continuous archiving). **RTO target:** ≤ 30 min (restore + warm-up)."
+               if has_backup else
+               "- **RPO/RTO: undefined** — no backup is configured yet (see the prerequisite below), so "
+               "no recovery-point/time guarantee can be made today.")
+        failure_modes = (
+            "- **Pod CrashLoopBackOff at boot:** usually a missing/invalid config or secret\n"
+            "  (`ExternalSecret` not synced) or a Flyway checksum mismatch. Check\n"
+            "  `kubectl describe pod` events and the first 50 log lines.\n"
+            f"- **Readiness flapping:** datastore ({datastore}) unreachable or saturated — check the\n"
+            "  datastore pod/cluster health and connection-pool metrics."
+        )
     return TEMPLATE.format(
         short=short,
+        ns=service_namespace(short),
+        failure_modes=failure_modes,
         domain=f.get("dataDomain", "—"),
-        datastore=f.get("primaryDatastore", "—"),
+        datastore=datastore,
         schema=f.get("schemaName", "—"),
         classification=f.get("dataClassification", "—"),
         retention=f.get("retentionPolicy", "—"),

--- a/openbank-infra/scripts/generate_service_runbooks_test.py
+++ b/openbank-infra/scripts/generate_service_runbooks_test.py
@@ -1,0 +1,190 @@
+#!/usr/bin/env python3
+# SPDX-License-Identifier: Apache-2.0
+"""Unit tests for generate-service-runbooks.py (run by ci.yml's governance-script step).
+
+Covers the two behaviours a runbook is actively harmful without, both found by issue #2255:
+
+* **namespace resolution** — the runbook used to interpolate the service short name as its
+  namespace, so every `kubectl -n <ns>` line in a third of the fleet named a namespace that
+  does not exist (document-service runs in `documents`, ap2/mcp in `platform`,
+  settlement/vop/card-issuance/standing-order in `payments`).
+* **the stateless DR branch** — a service declaring no datastore used to be handed the
+  generic "restore from the datastore's managed backup" text, sending an on-call engineer
+  hunting for a backup that does not exist, mid-incident.
+"""
+from __future__ import annotations
+
+import importlib.util
+import tempfile
+import unittest
+from pathlib import Path
+
+HERE = Path(__file__).resolve().parent
+
+
+def load_module(repo_root: Path):
+    """Import the hyphenated generator with REPO/GITOPS/RUNBOOKS pointed at a fixture."""
+    spec = importlib.util.spec_from_file_location(
+        "gen_runbooks", HERE / "generate-service-runbooks.py"
+    )
+    mod = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(mod)
+    mod.REPO = repo_root
+    mod.GITOPS = repo_root / "openbank-infra" / "gitops"
+    mod.RUNBOOKS = repo_root / "docs" / "runbooks"
+    return mod
+
+
+GOVERNANCE = """dataDomain: platform
+primaryDatastore: {datastore}
+schemaName: {schema}
+dataClassification: internal
+retentionPolicy: 1 year
+dataLineageRole: consumer
+lineage:
+  upstream:
+    - serviceName: ledger-service
+      relationType: api
+      description: reads balances
+"""
+
+WORKLOAD = """apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: {short}-service
+{ns_line}spec:
+  template:
+    spec:
+      containers:
+        - name: {short}-service
+          image: openbank-{short}-service:1.0.0
+"""
+
+# A NetworkPolicy in a DIFFERENT namespace that merely names the service as a peer. If the
+# resolver ever counted a mention instead of the workload, this would win and every kubectl
+# line in the runbook would point at the caller's namespace.
+DECOY = """apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: allow-egress-to-widget
+  namespace: some-caller-namespace
+spec:
+  egress:
+    - to:
+        - podSelector:
+            matchLabels:
+              app.kubernetes.io/name: openbank-widget-service
+"""
+
+
+class RunbookGeneratorTest(unittest.TestCase):
+    def setUp(self):
+        self.tmp = tempfile.TemporaryDirectory()
+        self.root = Path(self.tmp.name)
+        self.comp = self.root / "openbank-infra" / "gitops" / "components" / "widget"
+        self.comp.mkdir(parents=True)
+        (self.root / "docs" / "runbooks").mkdir(parents=True)
+        self.mod = load_module(self.root)
+
+    def tearDown(self):
+        self.tmp.cleanup()
+
+    def write_service(self, datastore="none", schema="n/a", ns="widgets", inherit=False):
+        svc = self.root / "openbank-widget-service"
+        (svc / "src" / "main" / "resources").mkdir(parents=True, exist_ok=True)
+        (svc / "governance.yaml").write_text(
+            GOVERNANCE.format(datastore=datastore, schema=schema)
+        )
+        (svc / "src" / "main" / "resources" / "application.yaml").write_text(
+            "quarkus:\n  http:\n    port: 8199\n"
+        )
+        ns_line = "" if inherit else f"  namespace: {ns}\n"
+        (self.comp / "widget-service.yaml").write_text(
+            WORKLOAD.format(short="widget", ns_line=ns_line)
+        )
+        (self.comp / "decoy-netpol.yaml").write_text(DECOY)
+        if inherit:
+            (self.comp / "kustomization.yaml").write_text(f"namespace: {ns}\nresources: []\n")
+
+    # -- namespace resolution ------------------------------------------------
+    def test_namespace_comes_from_the_workload_not_the_service_name(self):
+        self.write_service(ns="widgets")
+        self.assertEqual(self.mod.service_namespace("widget"), "widgets")
+
+    def test_namespace_inherited_from_kustomization(self):
+        self.write_service(ns="platform", inherit=True)
+        self.assertEqual(self.mod.service_namespace("widget"), "platform")
+
+    def test_a_mere_mention_does_not_resolve_the_namespace(self):
+        """The decoy NetworkPolicy peer must never win over the real workload."""
+        self.write_service(ns="widgets")
+        self.assertNotEqual(self.mod.service_namespace("widget"), "some-caller-namespace")
+
+    def test_rendered_kubectl_lines_use_the_resolved_namespace(self):
+        self.write_service(ns="widgets")
+        out = self.mod.render("widget")
+        self.assertIn("kubectl logs -n widgets deploy/widget-service", out)
+        self.assertIn('{namespace="widgets"}', out)
+        self.assertNotIn("-n widget ", out)
+
+    def test_namespace_falls_back_to_the_short_name_when_undeployed(self):
+        """A service with no workload in gitops still renders — it just cannot do better."""
+        self.write_service(ns="widgets")
+        (self.comp / "widget-service.yaml").unlink()
+        self.assertEqual(self.mod.service_namespace("widget"), "widget")
+
+    # -- stateless DR branch -------------------------------------------------
+    def test_stateless_service_is_not_told_to_restore_a_database(self):
+        self.write_service(datastore="none")
+        out = self.mod.render("widget")
+        self.assertIn("no primary datastore", out)
+        self.assertIn("redeploy from the GitOps manifests", out)
+        self.assertIn("**RPO: n/a**", out)
+        self.assertNotIn("managed backup", out)
+        self.assertNotIn("Flyway checksum", out)
+        self.assertNotIn("connection-pool metrics", out)
+
+    def test_is_stateless_accepts_the_spellings_the_fleet_actually_uses(self):
+        for value in ("none", "None", "n/a", "", "  ", "—", "-"):
+            self.assertTrue(self.mod.is_stateless(value), f"{value!r} should be stateless")
+        for value in ("postgresql", "PostgreSQL 18", "cassandra"):
+            self.assertFalse(self.mod.is_stateless(value), f"{value!r} should be stateful")
+
+    def test_stateful_service_keeps_the_datastore_recovery_text(self):
+        self.write_service(datastore="postgresql", schema="widget")
+        out = self.mod.render("widget")
+        self.assertIn("Disaster recovery", out)
+        self.assertIn("connection-pool metrics", out)
+        self.assertNotIn("no primary datastore", out)
+
+    def test_stateful_service_without_a_backup_says_dr_is_not_achievable(self):
+        """The honest case: a Postgres service whose cluster has no barmanObjectStore."""
+        self.write_service(datastore="postgresql", schema="widget")
+        out = self.mod.render("widget")
+        self.assertIn("no backup configured", out)
+        self.assertIn("RPO/RTO: undefined", out)
+
+    def test_stateful_service_with_a_backup_states_the_rpo_target(self):
+        self.write_service(datastore="postgresql", schema="widget")
+        (self.comp / "widget-db.yaml").write_text(
+            "apiVersion: postgresql.cnpg.io/v1\n"
+            "kind: Cluster\n"
+            "metadata:\n  name: widget-db\n  namespace: widgets\n"
+            "spec:\n  backup:\n    barmanObjectStore:\n      destinationPath: s3://backups/widget\n"
+        )
+        out = self.mod.render("widget")
+        self.assertIn("**RPO target:**", out)
+        self.assertIn("barmanObjectStore", out)
+        self.assertNotIn("RPO/RTO: undefined", out)
+
+    # -- the C6 contract the readiness collector reads ----------------------
+    def test_every_rendered_runbook_carries_the_disaster_recovery_heading(self):
+        """prod-readiness C6=2 is detected by this exact heading — stateless included."""
+        for datastore in ("none", "postgresql", "cassandra"):
+            self.write_service(datastore=datastore)
+            out = self.mod.render("widget")
+            self.assertRegex(out, r"(?m)^#+\s*Disaster recovery")
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## What

Fixes two content bugs in the runbook generator, regenerates all 37 `docs/runbooks/svc-*.md`,
adds a drift gate, and adds the generator's first unit-test suite.

`Refs #2255`

## Why

These runbooks are generated, and nothing had ever checked them. They had drifted into being
actively misleading, and both bugs bite exactly when a runbook is read — mid-incident.

**1. The namespace was the service short name.** Wrong for a third of the fleet:
document-service runs in `documents`, ap2 and mcp in `platform`, settlement/vop/card-issuance/
standing-order in `payments`. Every `kubectl -n <ns>` line, the Loki selector and the PodMonitor
note named a namespace that does not exist — the first command an on-call engineer copied out
returned nothing. Now resolved from the manifest that **is** the workload; a NetworkPolicy peer
or env var merely mentioning the service must not resolve, or the answer would be some caller's
namespace.

**2. A stateless service was told to restore a database.** ap2, copilot, finrep and mcp declare
no datastore, yet got the generic "restore from the datastore's managed backup" text — sending
that engineer hunting for a backup that does not exist. They now get a redeploy-from-GitOps
procedure with **RPO n/a**, not a fabricated 5-minute target, and lose the "Flyway checksum
mismatch" / "connection-pool metrics" failure modes they cannot have.

**3. 25 of 30 were stale.** They stated "DR is not achievable today — no backup configured" for
services whose CNPG backups have since been enabled.

## Prod-readiness effect

Seven services had no runbook at all — ap2, billing, document, finrep, mcp, settlement, vop —
which is exactly what the collector reads for **C6** (documented DR procedure) and **C9**
(per-service runbook). Those **14 cells move 1 → 2**, verified by re-running the collector.
C6=3 / C9=3 still need a rehearsed drill and a real on-call rotation, tracked as TTL'd
attestations and deliberately untouched.

## Verification

- **New tests fail first:** 7 of the 11 tests in `generate_service_runbooks_test.py` fail
  against the generator as it stood (5 errors for the missing functions, 2 assertion failures
  on the rendered output). The remaining 4 guard the stateful path against regression, so they
  pass both before and after — by design.
- **The drift gate was falsified before being trusted:** red on a committed deletion, red on a
  committed hand-edit, red on a new service with no committed runbook (via `--intent-to-add`),
  green on this branch. Red on `origin/main` with 32 files drifted.
- Full `openbank-infra/scripts` suite: 63 tests, OK.
- `actionlint`: no new findings versus `origin/main`, compared as finding sets.
- Namespace resolution spot-checked against the manifests for all 13 services whose namespace
  differs from or matches their short name.

## Note on `--force` over tracked files

`--force` overwrites committed runbooks, so before running it the entire diff was categorized
line by line: every change is derived content (backup status, `governance.yaml` lineage,
copilot's data domain). **No hand-written content exists in any of them**, which is what makes
regeneration correct here rather than destructive — and the new drift gate is what keeps that
true going forward.
