### PR TITLE
feat(mcp): real consent-validated read ports, code-complete but not wired (ADR-0195 step 2)

### DIFF
--- a/.github/scripts/check-mcp-stub-ports-vs-caller-auth.sh
+++ b/.github/scripts/check-mcp-stub-ports-vs-caller-auth.sh
@@ -22,16 +22,21 @@
 #   stays green because nothing in CI knows the stub was the control.
 #
 # THE INVARIANT
-#   A real (non-Stub) AccountReadPort / ProposalPort implementation may be wired
-#   ONLY once resolveContext() no longer returns the hardcoded placeholder
-#   identity. Caller authentication + consent binding must land BEFORE, or
-#   atomically WITH, the real read ports — never as a follow-up (#2206).
+#   A real (non-Stub), CDI-reachable AccountReadPort / ProposalPort implementation may be
+#   wired ONLY once resolveContext() no longer returns the hardcoded placeholder identity.
+#   Caller authentication + consent binding must land BEFORE, or atomically WITH, the real
+#   read ports — never as a follow-up (#2206). A class may exist code-complete but INERT —
+#   annotated `@Vetoed` (jakarta.enterprise.inject), so Quarkus never instantiates it via
+#   CDI — as an explicit "prepared, not wired" step (ADR-0195); this guard does not flag
+#   those, only a class that is actually reachable.
 #
-#   This guard fails if a non-Stub port implementation exists in the service while
-#   McpEndpoint still carries the `agent:mcp-anonymous` placeholder constant. It
-#   is a REGRESSION guard: 0 violations today (only StubReadPorts is wired).
+#   This guard fails if a non-Stub, non-@Vetoed port implementation exists in the service
+#   while McpEndpoint still carries the `agent:mcp-anonymous` placeholder constant. It is a
+#   REGRESSION guard: 0 violations today (StubReadPorts wired; RealAccountReadPort @Vetoed).
 #
-# stdlib-only (grep/awk); no Kotlin parser. ENFORCED.
+# Kotlin class headers routinely span multiple lines, so the scan uses python3 (this repo's
+# existing convention for structural guards, e.g. check-threat-models.py) rather than a
+# single-line grep, which would silently miss a multi-line constructor. ENFORCED.
 # Usage: check-mcp-stub-ports-vs-caller-auth.sh [root]   (default root: .)
 # Exit: 0 = clean, 1 = violation.
 # -----------------------------------------------------------------------------
@@ -59,20 +64,89 @@ if grep -qE 'agent:mcp-anonymous' "$ENDPOINT"; then
   placeholder_present=1
 fi
 
-# 2. Is a NON-Stub AccountReadPort / ProposalPort implementation wired anywhere in
-#    the service? (The interface declarations in port/out/ReadPorts.kt are
-#    `interface AccountReadPort` — only `class X ... : AccountReadPort` matches here.)
-impl_classes=$(grep -rhoE 'class[[:space:]]+[A-Za-z0-9_]+[^{]*:[^{]*\b(AccountReadPort|ProposalPort)\b' "$SVC" 2>/dev/null \
-  | grep -oE 'class[[:space:]]+[A-Za-z0-9_]+' | awk '{print $2}' | sort -u || true)
-non_stub=$(printf '%s\n' "$impl_classes" | grep -vE '^Stub' | grep -v '^$' || true)
+# 2. Is a NON-Stub, NON-@Vetoed AccountReadPort / ProposalPort implementation wired anywhere in
+#    the service? (The interface declarations in port/out/ReadPorts.kt are `interface
+#    AccountReadPort` — only `class X ... : AccountReadPort` matches here.) A Kotlin constructor
+#    routinely spans multiple lines, so this is NOT a single-line grep — parsed with python3
+#    (matching this repo's existing convention for structural guards, e.g. check-threat-models.py)
+#    for a multi-line-safe class-header scan. A class prefixed `@Vetoed` (jakarta.enterprise.inject)
+#    is a CDI-excluded, code-complete-but-inert implementation — ADR-0195's own "code + tests, not
+#    wired" step landed exactly this way (RealAccountReadPort) and must not trip this guard; a
+#    class implementing the port WITHOUT @Vetoed and without CDI exclusion is reachable and unsafe.
+non_stub=$(python3 - "$SVC" <<'PY'
+import re
+import sys
+from pathlib import Path
+
+root = Path(sys.argv[1])
+port_re = re.compile(r'\bclass\s+([A-Za-z0-9_]+)\s*')
+target_re = re.compile(r'\b(?:AccountReadPort|ProposalPort)\b')
+
+def supertype_clause(text: str, class_end: int) -> str | None:
+    """Return the text after a class's primary-constructor param list (or after the class
+    name when it has none) up to the first '{' or end of declaration — i.e. the supertype
+    list — or None if there is no primary constructor closing paren to anchor on within a
+    sane scan window. A constructor parameter's OWN type annotation (e.g. `accounts:
+    AccountReadPort` inside the parens) must never be mistaken for a supertype: only text
+    that appears at PAREN DEPTH 0, after the matching top-level ')', counts."""
+    i = class_end
+    while i < len(text) and text[i] in " \t\r\n":
+        i += 1
+    if i >= len(text):
+        return None
+    if text[i] != "(":
+        # No primary constructor at all — whatever follows the class name up to '{' is
+        # already the supertype clause (still may be absent, e.g. an abstract class).
+        end = text.find("{", i)
+        return text[i:end] if end != -1 else text[i : i + 500]
+    depth = 0
+    j = i
+    while j < len(text):
+        if text[j] == "(":
+            depth += 1
+        elif text[j] == ")":
+            depth -= 1
+            if depth == 0:
+                break
+        j += 1
+    else:
+        return None  # unbalanced within the file — give up rather than guess
+    end = text.find("{", j)
+    return text[j + 1 : end] if end != -1 else text[j + 1 : j + 1 + 500]
+
+offenders = []
+for path in sorted(root.rglob("*.kt")):
+    text = path.read_text()
+    for m in port_re.finditer(text):
+        name = m.group(1)
+        if name.startswith("Stub"):
+            continue
+        clause = supertype_clause(text, m.end())
+        if clause is None or not target_re.search(clause):
+            continue
+        # @Vetoed is a standalone annotation line immediately preceding `class` (skipping
+        # blank lines only — a KDoc block or another annotation in between does NOT count,
+        # so @Vetoed must be the line directly above class, same as a real Kotlin annotation).
+        line_no = text.count("\n", 0, m.start())
+        lines = text.splitlines()
+        k = line_no - 1
+        while k >= 0 and lines[k].strip() == "":
+            k -= 1
+        vetoed = k >= 0 and lines[k].strip() == "@Vetoed"
+        if not vetoed:
+            offenders.append(f"{name} ({path})")
+
+print("\n".join(offenders))
+PY
+)
 
 if [[ "$placeholder_present" -eq 1 && -n "$non_stub" ]]; then
-  echo "::error title=MCP caller-auth guard (BLOCKER #2206)::A non-stub read/proposal port is wired while McpEndpoint.resolveContext() still returns the hardcoded 'agent:mcp-anonymous' placeholder. This turns get_balance/list_accounts into an UNAUTHENTICATED read of any account. Land real caller identity + PSD2 consent binding (resolveContext) BEFORE or ATOMICALLY WITH the real port. Offending non-stub impl(s): $(echo "$non_stub" | tr '\n' ' ')" >&2
+  echo "::error title=MCP caller-auth guard (BLOCKER #2206)::A non-stub, non-@Vetoed read/proposal port is wired while McpEndpoint.resolveContext() still returns the hardcoded 'agent:mcp-anonymous' placeholder. This turns get_balance/list_accounts into an UNAUTHENTICATED read of any account. Land real caller identity + PSD2 consent binding (resolveContext) BEFORE or ATOMICALLY WITH the real port — or mark the class @Vetoed if it is intentionally not yet reachable. Offending impl(s): $(echo "$non_stub" | tr '\n' '; ')" >&2
   exit 1
 fi
 
 if [[ "$placeholder_present" -eq 1 ]]; then
-  echo "check-mcp-stub-ports-vs-caller-auth: OK — placeholder identity still in place, only stub ports wired (phase 1)."
+  echo "check-mcp-stub-ports-vs-caller-auth: OK — placeholder identity still in place, only stub (or @Vetoed) ports wired (phase 1)."
 else
   echo "check-mcp-stub-ports-vs-caller-auth: OK — placeholder identity removed; real caller auth landed, real ports permitted."
 fi

--- a/openbank-mcp-service/build.gradle.kts
+++ b/openbank-mcp-service/build.gradle.kts
@@ -18,6 +18,9 @@ dependencies {
     implementation(libs.quarkus.micrometer.registry.prometheus)
     implementation(libs.quarkus.opentelemetry)
     implementation(libs.quarkus.oidc)
+    // M2M client-credentials token attached to the downstream account/balance/transaction/consent
+    // RestClient calls (ADR-0195 step 2) — same pattern as openbank-agent-service's ServiceClients.
+    implementation(libs.quarkus.oidc.client.reactive.filter)
     implementation(libs.quarkus.config.yaml)
     implementation(libs.quarkus.smallrye.openapi)
     implementation(libs.quarkus.smallrye.fault.tolerance)

--- a/openbank-mcp-service/src/main/kotlin/com/openbank/mcp/infrastructure/read/ConsentValidateClient.kt
+++ b/openbank-mcp-service/src/main/kotlin/com/openbank/mcp/infrastructure/read/ConsentValidateClient.kt
@@ -1,0 +1,59 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+// Copyright (c) OpenBank contributors. Licensed under the GNU Affero General Public License v3.0 only.
+// A commercial licence is available from the maintainers as an alternative to the AGPL-3.0.
+// See LICENSES/AGPL-3.0-only.txt or https://www.gnu.org/licenses/agpl-3.0.html for details.
+package com.openbank.mcp.infrastructure.read
+
+import io.quarkus.oidc.client.reactive.filter.OidcClientRequestReactiveFilter
+import jakarta.ws.rs.Consumes
+import jakarta.ws.rs.POST
+import jakarta.ws.rs.Path
+import jakarta.ws.rs.PathParam
+import jakarta.ws.rs.Produces
+import jakarta.ws.rs.core.MediaType
+import org.eclipse.microprofile.rest.client.annotation.RegisterProvider
+import org.eclipse.microprofile.rest.client.inject.RegisterRestClient
+import java.util.UUID
+
+/**
+ * `POST /api/v1/consents/{id}/validate` (consent-service, ADR-0126) — the single source of truth
+ * for what a presented consent grants (ADR-0195). [OidcClientRequestReactiveFilter] attaches a
+ * client-credentials M2M token (same pattern as agent-service's downstream clients), since the
+ * endpoint is itself `@Authorize(action = "consent.validate")`. NOT wired as the default consent
+ * source yet: mcp-service has no provisioned M2M OIDC client / rego grant for `consent.validate`
+ * today — that infra lands with OIDC enablement (ADR-0195 next step). This interface + its adapter
+ * are code-complete and unit-tested so that step is wiring only, no new Kotlin.
+ */
+@RegisterRestClient(configKey = "consent-service")
+@RegisterProvider(OidcClientRequestReactiveFilter::class)
+@Path("/api/v1/consents")
+@Produces(MediaType.APPLICATION_JSON)
+@Consumes(MediaType.APPLICATION_JSON)
+interface ConsentValidateClient {
+
+    @POST
+    @Path("/{id}/validate")
+    fun validate(@PathParam("id") id: UUID, request: ValidateConsentRequest): ConsentValidationResponse
+}
+
+/** Mirrors consent-service's own request DTO; kept local (not a cross-service import). */
+data class ValidateConsentRequest(val granteeId: String, val requiredScope: String, val accountIban: String?)
+
+/** Mirrors consent-service's own `ConsentValidationResponse` (ADR-0126 D2 projection). No PII. */
+data class ConsentValidationResponse(
+    val valid: Boolean,
+    val reason: String?,
+    val code: String?,
+    val scopes: Set<String>? = null,
+    /** Accounts the consent covers; null (when valid) = all of the party's accounts. */
+    val grantedAccounts: List<String>? = null,
+    val frequencyPerDay: Int? = null,
+)
+
+/** The MCP capability's required consent scope (consent-service `ConsentScope` enum, string form). */
+object ConsentScopes {
+    const val ACCOUNTS_READ = "ACCOUNTS_READ"
+    const val BALANCES_READ = "BALANCES_READ"
+    const val TRANSACTIONS_READ = "TRANSACTIONS_READ"
+    const val PAYMENTS_INITIATE = "PAYMENTS_INITIATE"
+}

--- a/openbank-mcp-service/src/main/kotlin/com/openbank/mcp/infrastructure/read/DownstreamClients.kt
+++ b/openbank-mcp-service/src/main/kotlin/com/openbank/mcp/infrastructure/read/DownstreamClients.kt
@@ -1,0 +1,63 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+// Copyright (c) OpenBank contributors. Licensed under the GNU Affero General Public License v3.0 only.
+// A commercial licence is available from the maintainers as an alternative to the AGPL-3.0.
+// See LICENSES/AGPL-3.0-only.txt or https://www.gnu.org/licenses/agpl-3.0.html for details.
+package com.openbank.mcp.infrastructure.read
+
+import com.fasterxml.jackson.databind.JsonNode
+import io.quarkus.oidc.client.reactive.filter.OidcClientRequestReactiveFilter
+import jakarta.ws.rs.Consumes
+import jakarta.ws.rs.DefaultValue
+import jakarta.ws.rs.GET
+import jakarta.ws.rs.Path
+import jakarta.ws.rs.PathParam
+import jakarta.ws.rs.Produces
+import jakarta.ws.rs.QueryParam
+import jakarta.ws.rs.core.MediaType
+import org.eclipse.microprofile.rest.client.annotation.RegisterProvider
+import org.eclipse.microprofile.rest.client.inject.RegisterRestClient
+
+// Downstream banking-service reads (ADR-0195 step 2), mirroring agent-service's ServiceClients
+// pattern exactly: MP Rest Client interfaces returning raw JsonNode (the tools pass it straight
+// through), M2M-authenticated via OidcClientRequestReactiveFilter (client-credentials, same
+// `openbank-services`-shaped principal the downstream @Authorize checks already grant reads to).
+// Each downstream endpoint + its @Authorize action is cited in the KDoc it backs (RealAccountReadPort).
+
+@RegisterRestClient(configKey = "account-service")
+@RegisterProvider(OidcClientRequestReactiveFilter::class)
+@Path("/api/v1/accounts")
+@Produces(MediaType.APPLICATION_JSON)
+@Consumes(MediaType.APPLICATION_JSON)
+interface AccountServiceClient {
+    /** `GET /api/v1/accounts/iban/{iban}` — `@Authorize(account.read, resource=#iban)`. */
+    @GET
+    @Path("/iban/{iban}")
+    fun getAccountByIban(@PathParam("iban") iban: String): JsonNode
+}
+
+@RegisterRestClient(configKey = "balance-service")
+@RegisterProvider(OidcClientRequestReactiveFilter::class)
+@Path("/api/v1/balances")
+@Produces(MediaType.APPLICATION_JSON)
+@Consumes(MediaType.APPLICATION_JSON)
+interface BalanceServiceClient {
+    /** `GET /api/v1/balances/{accountId}`. */
+    @GET
+    @Path("/{accountId}")
+    fun getBalances(@PathParam("accountId") accountId: String): JsonNode
+}
+
+@RegisterRestClient(configKey = "transaction-service")
+@RegisterProvider(OidcClientRequestReactiveFilter::class)
+@Path("/api/v1/transactions")
+@Produces(MediaType.APPLICATION_JSON)
+@Consumes(MediaType.APPLICATION_JSON)
+interface TransactionServiceClient {
+    /** `GET /api/v1/transactions?accountId=&limit=&cursor=`. */
+    @GET
+    fun listTransactions(
+        @QueryParam("accountId") accountId: String,
+        @QueryParam("limit") @DefaultValue("20") limit: Int,
+        @QueryParam("cursor") cursor: String?,
+    ): JsonNode
+}

--- a/openbank-mcp-service/src/main/kotlin/com/openbank/mcp/infrastructure/read/RealAccountReadPort.kt
+++ b/openbank-mcp-service/src/main/kotlin/com/openbank/mcp/infrastructure/read/RealAccountReadPort.kt
@@ -1,0 +1,103 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+// Copyright (c) OpenBank contributors. Licensed under the GNU Affero General Public License v3.0 only.
+// A commercial licence is available from the maintainers as an alternative to the AGPL-3.0.
+// See LICENSES/AGPL-3.0-only.txt or https://www.gnu.org/licenses/agpl-3.0.html for details.
+package com.openbank.mcp.infrastructure.read
+
+import com.fasterxml.jackson.databind.JsonNode
+import com.fasterxml.jackson.databind.ObjectMapper
+import com.openbank.mcp.application.port.out.AccountReadPort
+import com.openbank.mcp.application.port.out.ConsentContext
+import jakarta.enterprise.inject.Vetoed
+import java.util.UUID
+
+/**
+ * The real read adapter behind [AccountReadPort] (ADR-0195 step 2). Every method LIVE-validates the
+ * presented consent at consent-service `POST /consents/{id}/validate` before touching downstream
+ * data — `grantedAccounts` is read from THAT response, never from the caller's token, so revoke /
+ * expire (ADR-0126 sweeper + outbox) and grantee-match are honoured on every call, not just at
+ * token-issue time.
+ *
+ * MCP tool arguments name an account by its **IBAN** (matching consent-service's own
+ * `Consent.accountIbans` grant shape — a PSD2 AISP consent grants IBANs, not internal account
+ * UUIDs). Each method resolves the IBAN to the account-service UUID via
+ * [AccountServiceClient.getAccountByIban] before calling balance-service / transaction-service,
+ * which are keyed by that UUID.
+ *
+ * NOT WIRED as the default port yet: mcp-service has no provisioned M2M OIDC client for
+ * `consent-service`/`account-service`/`balance-service`/`transaction-service` and no `rest.rego`
+ * grant for `consent.validate` — that infra + the switch away from `StubAccountReadPort` land
+ * together (ADR-0195 next step). The `check-mcp-stub-ports-vs-caller-auth.sh` CI guard (#2230)
+ * refuses that switch until the phase-1 placeholder identity is removed from `McpEndpoint` first.
+ *
+ * [Vetoed]: NOT a CDI bean in this PR — Quarkus's implicit bean discovery would otherwise make it a
+ * `@Default`-qualified `AccountReadPort` candidate ambiguous with `StubAccountReadPort`. The wiring
+ * step (which removes the stub / decides the switch mechanism) adds the scope annotation back.
+ */
+@Vetoed
+class RealAccountReadPort(
+    private val consent: ConsentValidateClient,
+    private val accounts: AccountServiceClient,
+    private val balances: BalanceServiceClient,
+    private val transactions: TransactionServiceClient,
+    private val mapper: ObjectMapper,
+) : AccountReadPort {
+
+    override fun listAccounts(consentContext: ConsentContext): JsonNode {
+        val validated = validate(consentContext, ConsentScopes.ACCOUNTS_READ, accountIban = null)
+        val ibans = validated.grantedAccounts.orEmpty()
+        val result = mapper.createArrayNode()
+        ibans.forEach { iban -> result.add(accounts.getAccountByIban(iban)) }
+        return result
+    }
+
+    override fun getBalance(consentContext: ConsentContext, accountId: String): JsonNode {
+        validate(consentContext, ConsentScopes.BALANCES_READ, accountIban = accountId)
+        val internalId = resolveAccountId(accountId)
+        return balances.getBalances(internalId)
+    }
+
+    override fun listTransactions(consentContext: ConsentContext, accountId: String, limit: Int): JsonNode {
+        validate(consentContext, ConsentScopes.TRANSACTIONS_READ, accountIban = accountId)
+        val internalId = resolveAccountId(accountId)
+        return transactions.listTransactions(internalId, limit, cursor = null)
+    }
+
+    override fun listConsents(consentContext: ConsentContext): JsonNode {
+        // consent-service exposes no "list all consents for this grantee" endpoint today (verified:
+        // ConsentResource has getById(#id) only, no query-by-grantee route) — the presented consent
+        // IS the one consent this call can honestly report on. Validating it also proves it is
+        // still live (not revoked/expired), which a bare GET-by-id would not.
+        val validated = validate(consentContext, ConsentScopes.ACCOUNTS_READ, accountIban = null)
+        return mapper.createArrayNode().add(mapper.valueToTree(validated))
+    }
+
+    /**
+     * Live-validates [consentContext]'s consent for [scope] (and, when given, that [accountIban] is
+     * within its granted accounts). Throws (fails closed — never returns a partially-checked result)
+     * when the consent is invalid, revoked, expired, or does not cover the requested account.
+     */
+    private fun validate(
+        consentContext: ConsentContext,
+        scope: String,
+        accountIban: String?,
+    ): ConsentValidationResponse {
+        val consentId = runCatching { UUID.fromString(consentContext.consentId) }.getOrElse {
+            error("consent id '${consentContext.consentId}' is not a valid PSD2 consent id")
+        }
+        val response = consent.validate(
+            consentId,
+            ValidateConsentRequest(consentContext.agentId, scope, accountIban),
+        )
+        if (!response.valid) {
+            error("consent denied: ${response.reason ?: response.code ?: "not valid"}")
+        }
+        val granted = response.grantedAccounts
+        if (accountIban != null && granted != null && accountIban !in granted) {
+            error("account '$accountIban' is not within the granted consent scope")
+        }
+        return response
+    }
+
+    private fun resolveAccountId(iban: String): String = accounts.getAccountByIban(iban).path("id").asText()
+}

--- a/openbank-mcp-service/src/test/kotlin/com/openbank/mcp/infrastructure/read/RealAccountReadPortTest.kt
+++ b/openbank-mcp-service/src/test/kotlin/com/openbank/mcp/infrastructure/read/RealAccountReadPortTest.kt
@@ -1,0 +1,185 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+// Copyright (c) OpenBank contributors. Licensed under the GNU Affero General Public License v3.0 only.
+package com.openbank.mcp.infrastructure.read
+
+import com.fasterxml.jackson.databind.JsonNode
+import com.fasterxml.jackson.module.kotlin.jacksonObjectMapper
+import com.openbank.mcp.application.port.out.ConsentContext
+import jakarta.enterprise.inject.Vetoed
+import org.assertj.core.api.Assertions.assertThat
+import org.assertj.core.api.Assertions.assertThatThrownBy
+import org.junit.jupiter.api.Test
+import java.util.UUID
+
+/**
+ * The real read adapter (ADR-0195 step 2): every read must live-validate the presented consent and
+ * enforce the [ConsentValidationResponse.grantedAccounts] intersection — a tool must never reach an
+ * account the consent did not grant, and a denied/expired/revoked consent must never leak a partial
+ * result. Plain-unit — fake HTTP-shaped collaborators, no Quarkus context.
+ */
+class RealAccountReadPortTest {
+
+    private val mapper = jacksonObjectMapper()
+    private val consentId = UUID.randomUUID()
+    private val ctx =
+        ConsentContext(agentId = "agent:mcp-tpp-42", consentId = consentId.toString(), grantedAccounts = emptyList())
+
+    private fun accountJson(id: String, iban: String): JsonNode =
+        mapper.createObjectNode().put("id", id).put("iban", iban)
+
+    @Test
+    fun `listAccounts returns only the granted IBANs, resolved to account records`() {
+        val consent = FakeConsentValidateClient(valid = true, grantedAccounts = listOf("CZ01", "CZ02"))
+        val accounts = FakeAccountServiceClient(
+            mapOf(
+                "CZ01" to accountJson("a1", "CZ01"),
+                "CZ02" to accountJson("a2", "CZ02"),
+            ),
+        )
+        val port =
+            RealAccountReadPort(consent, accounts, FakeBalanceServiceClient(), FakeTransactionServiceClient(), mapper)
+
+        val result = port.listAccounts(ctx)
+
+        assertThat(result.map { it.path("id").asText() }).containsExactlyInAnyOrder("a1", "a2")
+        assertThat(consent.lastRequest?.requiredScope).isEqualTo(ConsentScopes.ACCOUNTS_READ)
+    }
+
+    @Test
+    fun `getBalance resolves the IBAN and returns the balance`() {
+        val consent = FakeConsentValidateClient(valid = true, grantedAccounts = listOf("CZ01"))
+        val accounts = FakeAccountServiceClient(mapOf("CZ01" to accountJson("a1", "CZ01")))
+        val balances = FakeBalanceServiceClient(
+            byAccountId = mapOf(
+                "a1" to mapper.createObjectNode().put("available", "100.00"),
+            ),
+        )
+        val port = RealAccountReadPort(consent, accounts, balances, FakeTransactionServiceClient(), mapper)
+
+        val result = port.getBalance(ctx, "CZ01")
+
+        assertThat(result.path("available").asText()).isEqualTo("100.00")
+        assertThat(consent.lastRequest?.requiredScope).isEqualTo(ConsentScopes.BALANCES_READ)
+        assertThat(consent.lastRequest?.accountIban).isEqualTo("CZ01")
+    }
+
+    @Test
+    fun `getBalance denies an account outside the granted scope`() {
+        val consent = FakeConsentValidateClient(valid = true, grantedAccounts = listOf("CZ01"))
+        val port = RealAccountReadPort(
+            consent,
+            FakeAccountServiceClient(emptyMap()),
+            FakeBalanceServiceClient(),
+            FakeTransactionServiceClient(),
+            mapper,
+        )
+
+        assertThatThrownBy { port.getBalance(ctx, "CZ99-not-granted") }
+            .isInstanceOf(IllegalStateException::class.java)
+            .hasMessageContaining("not within the granted consent scope")
+    }
+
+    @Test
+    fun `getBalance denies when the consent itself is invalid (revoked, expired, or wrong grantee)`() {
+        val consent = FakeConsentValidateClient(valid = false, reason = "consent revoked")
+        val port = RealAccountReadPort(
+            consent,
+            FakeAccountServiceClient(emptyMap()),
+            FakeBalanceServiceClient(),
+            FakeTransactionServiceClient(),
+            mapper,
+        )
+
+        assertThatThrownBy { port.getBalance(ctx, "CZ01") }
+            .isInstanceOf(IllegalStateException::class.java)
+            .hasMessageContaining("consent revoked")
+    }
+
+    @Test
+    fun `a null grantedAccounts (all of the party's accounts) allows any account`() {
+        val consent = FakeConsentValidateClient(valid = true, grantedAccounts = null)
+        val accounts = FakeAccountServiceClient(mapOf("CZ07" to accountJson("a7", "CZ07")))
+        val transactions = FakeTransactionServiceClient(byAccountId = mapOf("a7" to mapper.createArrayNode()))
+        val port = RealAccountReadPort(consent, accounts, FakeBalanceServiceClient(), transactions, mapper)
+
+        assertThat(port.listTransactions(ctx, "CZ07", limit = 10)).isNotNull
+    }
+
+    @Test
+    fun `a malformed consent id fails closed`() {
+        val port = RealAccountReadPort(
+            FakeConsentValidateClient(valid = true),
+            FakeAccountServiceClient(emptyMap()),
+            FakeBalanceServiceClient(),
+            FakeTransactionServiceClient(),
+            mapper,
+        )
+        val badCtx =
+            ConsentContext(agentId = "agent:mcp-tpp-42", consentId = "not-a-uuid", grantedAccounts = emptyList())
+
+        assertThatThrownBy { port.listAccounts(badCtx) }.isInstanceOf(IllegalStateException::class.java)
+    }
+
+    @Test
+    fun `listConsents reports the presented consent's own live validation`() {
+        val consent = FakeConsentValidateClient(valid = true, grantedAccounts = listOf("CZ01"), frequencyPerDay = 4)
+        val port = RealAccountReadPort(
+            consent,
+            FakeAccountServiceClient(emptyMap()),
+            FakeBalanceServiceClient(),
+            FakeTransactionServiceClient(),
+            mapper,
+        )
+
+        val result = port.listConsents(ctx)
+
+        assertThat(result).hasSize(1)
+        assertThat(result[0].path("valid").asBoolean()).isTrue()
+        assertThat(result[0].path("frequencyPerDay").asInt()).isEqualTo(4)
+    }
+}
+
+// @Vetoed: Quarkus's implicit bean discovery would otherwise turn these test doubles into CDI
+// bean candidates for the interfaces they implement (RealAccountReadPortTest is a plain-unit test,
+// no Quarkus context — but @QuarkusTest classes elsewhere in this module share one Arc validation).
+@Vetoed
+private class FakeConsentValidateClient(
+    private val valid: Boolean,
+    private val grantedAccounts: List<String>? = null,
+    private val reason: String? = null,
+    private val frequencyPerDay: Int? = null,
+) : ConsentValidateClient {
+    var lastRequest: ValidateConsentRequest? = null
+
+    override fun validate(id: UUID, request: ValidateConsentRequest): ConsentValidationResponse {
+        lastRequest = request
+        return ConsentValidationResponse(
+            valid = valid,
+            reason = reason,
+            code = if (valid) null else "DENIED",
+            scopes = setOf(request.requiredScope),
+            grantedAccounts = grantedAccounts,
+            frequencyPerDay = frequencyPerDay,
+        )
+    }
+}
+
+@Vetoed
+private class FakeAccountServiceClient(private val byIban: Map<String, JsonNode>) : AccountServiceClient {
+    override fun getAccountByIban(iban: String): JsonNode =
+        byIban[iban] ?: throw NoSuchElementException("no such account: $iban")
+}
+
+@Vetoed
+private class FakeBalanceServiceClient(private val byAccountId: Map<String, JsonNode> = emptyMap()) :
+    BalanceServiceClient {
+    override fun getBalances(accountId: String): JsonNode =
+        byAccountId[accountId] ?: throw NoSuchElementException("no balance for: $accountId")
+}
+
+@Vetoed
+private class FakeTransactionServiceClient(private val byAccountId: Map<String, JsonNode> = emptyMap()) :
+    TransactionServiceClient {
+    override fun listTransactions(accountId: String, limit: Int, cursor: String?): JsonNode =
+        byAccountId[accountId] ?: throw NoSuchElementException("no transactions for: $accountId")
+}


### PR DESCRIPTION
## What

Step 2 of MCP phase-2 caller authentication (ADR-0195). Every real read **live-validates** the presented consent at consent-service `POST /consents/{id}/validate` before touching downstream data — `grantedAccounts` comes from that response, **never from the caller's token**, so revoke/expire (ADR-0126 sweeper) and grantee-match are honoured per call, not just at token-issue time.

**Not wired.** `RealAccountReadPort` is `@Vetoed` (jakarta.enterprise.inject) — Quarkus's implicit CDI bean discovery would otherwise make it an ambiguous `@Default AccountReadPort` candidate alongside `StubAccountReadPort`. The switch (removing the stub + the `McpEndpoint` placeholder together) needs an M2M OIDC client + a `rest.rego` grant for `consent.validate` that don't exist yet — that's the next ADR-0195 step. Nothing about the deployed service changes in this PR.

## Changes

- **`ConsentValidateClient`** — MP RestClient mirroring consent-service's own `/validate` contract (local DTOs, no cross-service import). M2M-authenticated via `OidcClientRequestReactiveFilter` (same pattern as agent-service's `ServiceClients`) — the endpoint is itself `@Authorize(consent.validate)`.
- **`DownstreamClients`** — account/balance/transaction-service RestClients. Tool arguments name an account by **IBAN** (consent grants are IBANs, per `Consent.accountIbans`); resolved to the account-service UUID before balance/transaction calls.
- **`RealAccountReadPort`** — enforces the `grantedAccounts` intersection on every method; fails closed on an invalid/revoked/expired consent, an out-of-scope account, or a malformed consent id.

**Scope cut, called out honestly:** `ProposalPort` is left alone here. The "PROPOSED row into the maker-checker queue" the existing interface KDoc describes turns out to be `copilot-service`'s own internal `ActionProposal` domain, not a cross-service endpoint mcp can call — a real `ProposalPort` means designing new API surface, which deserves its own review, not a slip-in here.

## Guard hardening (same PR — found while verifying)

`check-mcp-stub-ports-vs-caller-auth.sh` (#2230) had two real gaps, both fixed here:
1. Its original single-line `grep` **silently missed a multi-line Kotlin constructor** — proven: `RealAccountReadPort`'s actual multi-line header evaded detection entirely.
2. Once rewritten as a multi-line-safe python3 scan, it **false-positived on `McpToolRegistry`'s own `accounts: AccountReadPort` constructor *parameter*** (mistaking a parameter type for a class supertype). Fixed with balanced-paren parsing that scopes the scan to the actual supertype clause, plus `@Vetoed`-awareness so this legitimate "prepared, not wired" pattern passes while a truly reachable real port still fails the gate.

Verified against 4 cases: current state → pass; `@Vetoed` removed → **fails**; restored → pass; placeholder removed + `@Vetoed` port present → pass. `shellcheck -S warning` clean.

## Verification

Local gate (JDK 25): `detekt` + `ktlintCheck` + `test` (fake HTTP-shaped collaborators, `@Vetoed` to avoid CDI collision with `@QuarkusTest`s elsewhere in the module) + `quarkusBuild` (full CDI validation — no ambiguity) — all green.

## Ordering (ADR-0195 / #2206)

Next: the M2M OIDC client + `rest.rego` `consent.validate` grant + the switch away from the stub/placeholder (guarded by #2230) → NetworkPolicy + OIDC enable in gitops → threat-model update.

Money-path: needs 2 approvals.

Refs ADR-0195, #2206, #2230

🤖 Generated with [Claude Code](https://claude.com/claude-code)