### PR TITLE
fix(infra): score the prod-readiness dimensions the collector was actually asking about

### DIFF
--- a/.github/scripts/check-podmonitor-namespace-coverage.py
+++ b/.github/scripts/check-podmonitor-namespace-coverage.py
@@ -44,70 +44,19 @@ PODMON_REL = Path(
     "openbank-infra/gitops/components/observability/podmonitor-openbank-services.yaml"
 )
 
-
-def read(p: Path) -> str:
-    try:
-        return p.read_text(encoding="utf-8", errors="ignore")
-    except OSError:
-        return ""
-
-
-def nearest_kustomize_namespace(manifest: Path, gitops: Path) -> str | None:
-    """The `namespace:` of the closest kustomization.yaml at or above the manifest."""
-    for parent in manifest.parents:
-        if parent != gitops and gitops not in parent.parents:
-            break
-        m = re.search(r"^namespace:\s*(\S+)", read(parent / "kustomization.yaml"), re.M)
-        if m:
-            return m.group(1)
-    return None
-
-
-def workload_namespaces(short: str, gitops: Path) -> set[str]:
-    """Namespaces of every Deployment/Rollout that IS this service.
-
-    A manifest merely *mentioning* the service does not count — a NetworkPolicy peer, an env
-    var pointing at its URL or an initContainer waiting on it would otherwise resolve to the
-    wrong namespace. The workload's metadata.name must be the service itself.
-    """
-    names = {f"{short}-service", f"openbank-{short}-service"}
-    out: set[str] = set()
-    for f in gitops.rglob("*.yaml"):
-        text = read(f)
-        if f"openbank-{short}-service" not in text:
-            continue
-        for doc in text.split("\n---"):
-            kind = re.search(r"^kind:\s*(\S+)", doc, re.M)
-            if not kind or kind.group(1) not in ("Deployment", "Rollout"):
-                continue
-            name = re.search(r"^\s{2}name:\s*(\S+)", doc, re.M)
-            if not name or name.group(1) not in names:
-                continue
-            ns = re.search(r"^\s{2}namespace:\s*(\S+)", doc, re.M)
-            out.add(
-                ns.group(1) if ns else (nearest_kustomize_namespace(f, gitops) or "?UNRESOLVED")
-            )
-    return out
-
-
-def match_names(podmon: Path) -> set[str]:
-    text = read(podmon)
-    if "matchNames:" not in text:
-        return set()
-    out: set[str] = set()
-    for line in text.split("matchNames:", 1)[1].splitlines():
-        m = re.match(r"^(\s+)-\s+(\S+)\s*$", line)
-        if m:
-            out.add(m.group(2))
-        elif line.strip():
-            break  # dedented back out of the list
-    return out
+# The namespace resolution below is shared with the prod-readiness collector's C8 scorer and the
+# per-service runbook generator. All three answer "where does this workload actually run", and
+# two of them had already answered it WRONG in two different ways before it was centralised
+# (#2255) — so it lives in exactly one place now, tested by
+# openbank-infra/scripts/prod_readiness_collector_test.py and the fixtures in --self-test below.
+sys.path.insert(0, str(REPO / "openbank-infra" / "scripts"))
+from gitops_facts import podmonitor_namespaces, workload_namespaces  # noqa: E402
 
 
 def audit(repo: Path) -> tuple[dict[str, list[str]], list[str], int]:
     """-> ({service: [missing namespaces]}, [services with no workload], ok_count)"""
     gitops = repo / "openbank-infra" / "gitops"
-    selected = match_names(repo / PODMON_REL)
+    selected = podmonitor_namespaces(gitops)
     missing: dict[str, list[str]] = {}
     no_workload: list[str] = []
     ok = 0

--- a/openbank-infra/scripts/generate-service-runbooks.py
+++ b/openbank-infra/scripts/generate-service-runbooks.py
@@ -26,6 +26,9 @@ import re
 import sys
 from pathlib import Path
 
+sys.path.insert(0, str(Path(__file__).resolve().parent))
+import gitops_facts  # noqa: E402  (path must be set before the import)
+
 REPO = Path(__file__).resolve().parents[2]
 RUNBOOKS = REPO / "docs" / "runbooks"
 GITOPS = REPO / "openbank-infra" / "gitops"
@@ -64,52 +67,26 @@ def http_port(short: str) -> str:
     return "?"
 
 
-def nearest_kustomize_namespace(manifest: Path) -> str | None:
-    for parent in manifest.parents:
-        if parent != GITOPS and GITOPS not in parent.parents:
-            break
-        m = re.search(r"^namespace:\s*(\S+)", read(parent / "kustomization.yaml"), re.M)
-        if m:
-            return m.group(1)
-    return None
-
-
 def service_namespace(short: str) -> str:
     """The namespace this service's Deployment/Rollout actually lands in.
 
-    The runbook used to interpolate the service short name as its namespace, which is
-    wrong for a third of the fleet: document-service runs in `documents`, ap2 and mcp in
-    `platform`, settlement/vop/card-issuance/standing-order in `payments`. Every
-    `kubectl -n <ns>` line in those runbooks named a namespace that does not exist, so
-    the first command an on-call engineer copied out of them returned nothing. Resolve it
-    from the manifest that IS the workload — a NetworkPolicy peer or an env var merely
-    mentioning the service must not resolve, or the answer would be some caller's
-    namespace.
+    The runbook used to interpolate the service short name as its namespace, which is wrong for
+    a third of the fleet: document-service runs in `documents`, ap2 and mcp in `platform`,
+    settlement/vop/card-issuance/standing-order in `payments`. Every `kubectl -n <ns>` line in
+    those runbooks named a namespace that does not exist, so the first command an on-call
+    engineer copied out of them returned nothing.
+
+    The resolution itself now lives in gitops_facts, shared with the prod-readiness collector
+    and the PodMonitor coverage gate — three tools were each growing their own copy of this
+    question, and two of them had already answered it wrong in two different ways (#2255). Only
+    the display fallback is local: a service with no workload still needs *something* to render.
     """
-    names = {f"{short}-service", f"openbank-{short}-service"}
-    for f in sorted(GITOPS.rglob("*.yaml")):
-        text = read(f)
-        if f"openbank-{short}-service" not in text:
-            continue
-        for doc in text.split("\n---"):
-            kind = re.search(r"^kind:\s*(\S+)", doc, re.M)
-            if not kind or kind.group(1) not in ("Deployment", "Rollout"):
-                continue
-            name = re.search(r"^\s{2}name:\s*(\S+)", doc, re.M)
-            if not name or name.group(1) not in names:
-                continue
-            ns = re.search(r"^\s{2}namespace:\s*(\S+)", doc, re.M)
-            if ns:
-                return ns.group(1)
-            inherited = nearest_kustomize_namespace(f)
-            if inherited:
-                return inherited
-    return short
+    return gitops_facts.service_namespace(short, GITOPS) or short
 
 
 def is_stateless(datastore: str) -> bool:
     """A service that declares no primary datastore. `none` / `n/a` / empty all count."""
-    return (datastore or "").strip().lower() in ("", "none", "n/a", "—", "-")
+    return gitops_facts.is_stateless(datastore)
 
 
 def backup_configured(short: str) -> bool:

--- a/openbank-infra/scripts/gitops_facts.py
+++ b/openbank-infra/scripts/gitops_facts.py
@@ -1,0 +1,129 @@
+#!/usr/bin/env python3
+# SPDX-License-Identifier: Apache-2.0
+"""
+Facts about a service that can only be answered from the gitops manifests.
+
+Three different tools were each about to grow their own copy of "which namespace does this
+service run in" — the runbook generator, the prod-readiness collector's C8 scorer, and
+`.github/scripts/check-podmonitor-namespace-coverage.py`. Three copies of a resolver is three
+chances to answer differently, and the whole reason this module exists is that two of those
+tools had already been answering it WRONG in two distinct ways:
+
+* The runbook generator interpolated the service short name, so a third of the fleet's runbooks
+  named a namespace that does not exist (document-service runs in `documents`, ap2/mcp in
+  `platform`, settlement/vop/card-issuance/standing-order in `payments`).
+* The collector's C8 scorer asked `short in read(podmonitor.yaml)` — a substring match over the
+  whole file INCLUDING COMMENTS. A comment claiming sdd-service was covered "via `payments`"
+  was false (sdd runs in namespace `sdd`), and that false claim scored sdd as scraped while its
+  metrics reached nothing (#2255, fixed in #2257).
+
+Both bugs share one shape: the question is "where does the workload actually run", and both
+tools answered it by pattern-matching a name instead. So the answer is derived here, once, from
+the manifest that IS the workload.
+
+Stdlib only, no pyyaml: this module is imported by scripts that must run on a bare runner.
+"""
+from __future__ import annotations
+
+import re
+from pathlib import Path
+
+__all__ = [
+    "read",
+    "service_namespace",
+    "workload_namespaces",
+    "podmonitor_namespaces",
+    "declared_datastore",
+    "is_stateless",
+]
+
+
+def read(path: Path) -> str:
+    try:
+        return path.read_text(encoding="utf-8", errors="ignore")
+    except OSError:
+        return ""
+
+
+def _nearest_kustomize_namespace(manifest: Path, gitops: Path) -> str | None:
+    """The `namespace:` of the closest kustomization.yaml at or above the manifest."""
+    for parent in manifest.parents:
+        if parent != gitops and gitops not in parent.parents:
+            break
+        m = re.search(r"^namespace:\s*(\S+)", read(parent / "kustomization.yaml"), re.M)
+        if m:
+            return m.group(1)
+    return None
+
+
+def workload_namespaces(short: str, gitops: Path) -> set[str]:
+    """Every namespace in which a Deployment/Rollout for this service is declared.
+
+    A manifest that merely MENTIONS the service does not count. A NetworkPolicy naming it as a
+    peer, an env var holding its URL, or an initContainer waiting on it would otherwise resolve
+    to some caller's namespace — which is exactly the class of mistake this module exists to
+    prevent. The workload's own `metadata.name` must be the service.
+    """
+    names = {f"{short}-service", f"openbank-{short}-service"}
+    found: set[str] = set()
+    for f in sorted(gitops.rglob("*.yaml")):
+        text = read(f)
+        if f"openbank-{short}-service" not in text:
+            continue
+        for doc in text.split("\n---"):
+            kind = re.search(r"^kind:\s*(\S+)", doc, re.M)
+            if not kind or kind.group(1) not in ("Deployment", "Rollout"):
+                continue
+            name = re.search(r"^\s{2}name:\s*(\S+)", doc, re.M)
+            if not name or name.group(1) not in names:
+                continue
+            explicit = re.search(r"^\s{2}namespace:\s*(\S+)", doc, re.M)
+            if explicit:
+                found.add(explicit.group(1))
+            else:
+                inherited = _nearest_kustomize_namespace(f, gitops)
+                if inherited:
+                    found.add(inherited)
+    return found
+
+
+def service_namespace(short: str, gitops: Path) -> str | None:
+    """The single namespace this service runs in, or None if it is not deployed.
+
+    Returns None rather than guessing when there is no workload: a caller that needs a
+    displayable value can fall back to the short name, but a caller deciding whether the
+    service is SCRAPED must not be handed a namespace nobody deployed.
+    """
+    namespaces = workload_namespaces(short, gitops)
+    if not namespaces:
+        return None
+    # Deterministic when a service is (unusually) declared in more than one namespace.
+    return sorted(namespaces)[0]
+
+
+def podmonitor_namespaces(gitops: Path) -> set[str]:
+    """`namespaceSelector.matchNames` of the fleet PodMonitor — the namespaces Prometheus scrapes."""
+    podmon = gitops / "components" / "observability" / "podmonitor-openbank-services.yaml"
+    text = read(podmon)
+    if "matchNames:" not in text:
+        return set()
+    out: set[str] = set()
+    for line in text.split("matchNames:", 1)[1].splitlines():
+        m = re.match(r"^(\s+)-\s+(\S+)\s*$", line)
+        if m:
+            out.add(m.group(2))
+        elif line.strip():
+            break  # dedented back out of the list
+    return out
+
+
+def declared_datastore(short: str, repo: Path) -> str:
+    """`primaryDatastore` from the service's governance.yaml (ADR-0071), '' when undeclared."""
+    txt = read(repo / f"openbank-{short}-service" / "governance.yaml")
+    m = re.search(r"^primaryDatastore:\s*(.+?)\s*$", txt, re.M)
+    return m.group(1).strip() if m else ""
+
+
+def is_stateless(datastore: str) -> bool:
+    """True when the service declares no primary datastore at all."""
+    return (datastore or "").strip().lower() in ("", "none", "n/a", "—", "-")

--- a/openbank-infra/scripts/prod-readiness-collector.py
+++ b/openbank-infra/scripts/prod-readiness-collector.py
@@ -28,6 +28,14 @@ from datetime import date
 from dataclasses import dataclass, asdict, field
 from pathlib import Path
 
+sys.path.insert(0, str(Path(__file__).resolve().parent))
+from gitops_facts import (  # noqa: E402  (path must be set before the import)
+    declared_datastore,
+    is_stateless,
+    podmonitor_namespaces,
+    service_namespace,
+)
+
 REPO = Path(__file__).resolve().parents[2]
 GITOPS = REPO / "openbank-infra" / "gitops"
 THREAT_MODELS = REPO / "docs" / "threat-models"
@@ -156,13 +164,33 @@ def attest_fresh(att: dict, svc: str, key: str, today: str) -> bool:
 # ---------------------------------------------------------------------------
 # per-dimension scoring (each returns (score 0-3, evidence str))
 # ---------------------------------------------------------------------------
+def has_declared_ports(main: Path) -> bool:
+    """True when the service declares hexagonal ports (ADR-0002).
+
+    This used to require a FILE NAME containing `Port`, which is not the convention the fleet
+    actually follows: anacredit and onboarding both carry a textbook
+    `application/port/{in,out}` package whose files are named `*Repository.kt`, `*UseCases.kt`
+    and `*Queries.kt`, and both were scored as having no ports at all. The architecture lives in
+    the package, not in the filename — and the fix for a false negative here must never be to
+    rename a file so the probe is satisfied. Either spelling counts now: a `port` package
+    anywhere under the application layer, or the `*Port*.kt` naming other services use.
+    """
+    for p in main.rglob("*.kt"):
+        parts = p.parts
+        if "port" in parts or "ports" in parts:
+            return True
+        if "Port" in p.name:
+            return True
+    return False
+
+
 def score_c1_code(short: str, att, today) -> tuple[int, str]:
     d = svc_dir(short)
     main = d / "src" / "main"
     if not main.is_dir():
         return 0, "no src/main"
     kt = list(main.rglob("*.kt"))
-    has_ports = (main / "kotlin").rglob("*Port*") and any(main.rglob("*Port*.kt"))
+    has_ports = has_declared_ports(main)
     gov = (d / "governance.yaml").exists()
     # skeleton heuristic: very little code
     if len(kt) < 8:
@@ -213,8 +241,21 @@ def score_c3_api(short: str, att, today) -> tuple[int, str]:
 def score_c4_data(short: str, att, today) -> tuple[int, str]:
     d = svc_dir(short)
     migs = list((d).rglob("db/migration/V*.sql"))
+    datastore = declared_datastore(short, REPO)
+    stateless = is_stateless(datastore)
+    if stateless and not migs:
+        # A service that declares no datastore has no migrations to review and no rollback note
+        # to write, so the old hardcoded `1, "no flyway (stateless?)"` made 2 UNREACHABLE for it
+        # — the matrix asked ap2, copilot, finrep and mcp for an artifact that would be wrong to
+        # produce. The dimension is not applicable, and the evidence string says so rather than
+        # implying a migration was reviewed.
+        return 2, "n/a — declares no datastore (stateless)"
+    if stateless and migs:
+        # Declared facts and shipped code disagree. Whichever is wrong, nobody can review a data
+        # dimension that is described two different ways, so this is a finding, not a pass.
+        return 1, f"CONTRADICTION: governance.yaml says datastore '{datastore or 'none'}' but {len(migs)} migration(s) exist"
     if not migs:
-        return 1, "no flyway (stateless?)"
+        return 1, f"declares datastore '{datastore}' but has no Flyway migration"
     # rollback note: a paired comment or docs/rollback reference
     rollback = any("rollback" in read(m).lower() for m in migs) or \
         grep_any(d, ["rollback"], globs=("*.md",))
@@ -223,6 +264,10 @@ def score_c4_data(short: str, att, today) -> tuple[int, str]:
 
 
 def score_c5_backup(short: str, att, today) -> tuple[int, str]:
+    if is_stateless(declared_datastore(short, REPO)):
+        # No datastore, nothing to back up. finrep scored 0 ("no CNPG cluster") for the absence
+        # of a cluster it must not have — an unachievable 0 that read like a missing backup.
+        return 2, "n/a — declares no datastore (stateless), nothing to back up"
     clusters = gitops_files_for(short, "Cluster")
     cnpg = [f for f in clusters if "postgres" in f.name or "cnpg" in read(f).lower()]
     if not cnpg:
@@ -290,26 +335,42 @@ def score_c7_security(short: str, att, today) -> tuple[int, str]:
 
 
 def score_c8_observability(short: str, att, today) -> tuple[int, str]:
-    # fleet podmonitor covers by namespaceSelector; per-service alerts are richer
-    podmon = GITOPS / "components" / "observability" / "podmonitor-openbank-services.yaml"
-    monitored = short in read(podmon)
+    # The fleet PodMonitor scrapes by namespaceSelector.matchNames, so "is this service scraped"
+    # is a question about its NAMESPACE. This used to ask `short in read(podmonitor.yaml)` — a
+    # substring match over the whole file, comments included. A comment asserting sdd-service was
+    # covered "via `payments`" was simply false (sdd runs in namespace `sdd`), and that false
+    # claim scored sdd as scraped while its metrics reached nothing; meanwhile ap2, mcp, vop,
+    # card-issuance, settlement and standing-order WERE scraped via `platform`/`payments` and
+    # scored as if they were not, because their names appear nowhere in the file (#2255).
+    ns = service_namespace(short, GITOPS)
+    scraped_namespaces = podmonitor_namespaces(GITOPS)
+    monitored = ns is not None and ns in scraped_namespaces
     alerts = bool(gitops_files_for(short, "PrometheusRule"))
     metrics = grep_any(svc_dir(short) / "src" / "main",
                        ["MeterRegistry", "DomainMetrics", "@Counted", "@Timed"])
+    # Evidence names the namespace and the specific missing half, so a 0 or 1 is actionable
+    # without re-deriving it: "add the namespace to the PodMonitor" and "instrument the domain"
+    # are different pieces of work and used to be reported identically as "not scraped".
+    ev = []
+    if ns is None:
+        ev.append("not deployed (no Deployment/Rollout in gitops)")
+    elif monitored:
+        ev.append(f"scraped (ns {ns})")
+    else:
+        ev.append(f"NOT scraped — ns '{ns}' absent from PodMonitor matchNames")
+    ev.append("domain metrics" if metrics else "NO domain metrics in src/main")
+    if alerts:
+        ev.append("alerts")
+    evidence = ", ".join(ev)
+
     if not monitored and not metrics:
-        return 0, "not scraped"
+        return 0, evidence
     s = 1
     if monitored and metrics:
-        s = 2
-    if monitored and metrics and alerts:
         s = 2  # bank-grade (3) needs defined SLO + burn-rate alerts (attestation)
     if attest_fresh(att, short, "slo_defined", today):
         s = 3
-    ev = []
-    if monitored: ev.append("scraped")
-    if metrics: ev.append("metrics")
-    if alerts: ev.append("alerts")
-    return s, ", ".join(ev) or "none"
+    return s, evidence
 
 
 def score_c9_ops(short: str, att, today) -> tuple[int, str]:

--- a/openbank-infra/scripts/prod_readiness_collector_test.py
+++ b/openbank-infra/scripts/prod_readiness_collector_test.py
@@ -1,0 +1,264 @@
+#!/usr/bin/env python3
+# SPDX-License-Identifier: Apache-2.0
+"""Unit tests for prod-readiness-collector.py's repaired scorers (issue #2255).
+
+The collector had never had a test, and four of its nine scorers were answering a different
+question from the one the dimension asks. Each test below is written so it FAILS against the
+scorer as it stood:
+
+* **C1** required a FILE NAME containing `Port`, so anacredit and onboarding — both carrying a
+  textbook `application/port/{in,out}` package with files named `*Repository.kt` / `*UseCases.kt`
+  — scored as having no hexagonal ports at all.
+* **C4** returned a hardcoded 1 for "no flyway (stateless?)", making 2 UNREACHABLE for a service
+  that correctly has no datastore, and hiding the opposite case: copilot declares
+  `primaryDatastore: PostgreSQL` and ships no migration, no entity and no datasource config.
+* **C5** scored 0 ("no CNPG cluster") for a service that must not have one.
+* **C8** asked `short in read(podmonitor.yaml)` — a substring match over the whole file,
+  COMMENTS INCLUDED. A false comment scored sdd as scraped while its metrics reached nothing,
+  and six genuinely-scraped services scored as unscraped because their names appear nowhere in
+  that file.
+
+The scorers are pure functions of the tree, so every case here is a fixture tree, never the real
+repo: a test that reads the live fleet passes or fails for reasons that have nothing to do with
+the code under test.
+"""
+from __future__ import annotations
+
+import importlib.util
+import sys
+import tempfile
+import unittest
+from pathlib import Path
+
+HERE = Path(__file__).resolve().parent
+
+PODMONITOR = """apiVersion: monitoring.coreos.com/v1
+kind: PodMonitor
+metadata:
+  name: openbank-services
+  namespace: observability
+spec:
+  namespaceSelector:
+    matchNames:
+      - payments
+      - platform
+  podMetricsEndpoints:
+    - port: management
+"""
+
+# The comment is the trap: it names a service that is NOT covered. The old C8 scorer matched the
+# file as a plain substring, so this sentence alone was enough to score `sdd` as scraped.
+PODMONITOR_WITH_LYING_COMMENT = """# sdd-service is covered via `payments`.
+""" + PODMONITOR
+
+WORKLOAD = """apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: {short}-service
+  namespace: {ns}
+spec:
+  template:
+    spec:
+      containers:
+        - name: {short}-service
+          image: ghcr.io/jiraska/openbank-{short}-service:1.0.0
+"""
+
+GOVERNANCE = """dataDomain: platform
+primaryDatastore: {datastore}
+schemaName: {schema}
+dataClassification: internal
+retentionPolicy: 1 year
+dataLineageRole: consumer
+"""
+
+
+def load_collector(repo: Path):
+    spec = importlib.util.spec_from_file_location(
+        "prod_readiness_collector", HERE / "prod-readiness-collector.py"
+    )
+    mod = importlib.util.module_from_spec(spec)
+    # The collector defines a @dataclass, and dataclasses resolves annotations through
+    # sys.modules[cls.__module__] — so the module must be registered BEFORE exec_module or
+    # every import raises AttributeError on a None module.
+    sys.modules[spec.name] = mod
+    spec.loader.exec_module(mod)
+    mod.REPO = repo
+    mod.GITOPS = repo / "openbank-infra" / "gitops"
+    mod.THREAT_MODELS = repo / "docs" / "threat-models"
+    mod.RUNBOOKS = repo / "docs" / "runbooks"
+    mod.ATTESTATIONS = repo / "openbank-libs" / "governance" / "attestations.yaml"
+    mod.RELEASE_EVIDENCE = repo / ".github" / "workflows" / "release-please.yml"
+    mod.VEX_DIR = repo / "openbank-libs" / "governance" / "vex"
+    return mod
+
+
+class CollectorScorerTest(unittest.TestCase):
+    def setUp(self):
+        self.tmp = tempfile.TemporaryDirectory()
+        self.root = Path(self.tmp.name)
+        self.comp = self.root / "openbank-infra" / "gitops" / "components" / "widget"
+        self.comp.mkdir(parents=True)
+        obs = self.root / "openbank-infra" / "gitops" / "components" / "observability"
+        obs.mkdir(parents=True)
+        (obs / "podmonitor-openbank-services.yaml").write_text(PODMONITOR)
+        self.svc = self.root / "openbank-widget-service"
+        (self.svc / "src" / "main" / "kotlin" / "com" / "openbank" / "widget").mkdir(parents=True)
+        self.mod = load_collector(self.root)
+
+    def tearDown(self):
+        self.tmp.cleanup()
+
+    # -- fixture helpers ----------------------------------------------------
+    def governance(self, datastore="none", schema="n/a"):
+        (self.svc / "governance.yaml").write_text(
+            GOVERNANCE.format(datastore=datastore, schema=schema)
+        )
+
+    def deploy(self, ns="payments"):
+        (self.comp / "widget-service.yaml").write_text(WORKLOAD.format(short="widget", ns=ns))
+
+    def kt(self, relative: str, body: str = "class X\n"):
+        p = self.svc / "src" / "main" / "kotlin" / "com" / "openbank" / "widget" / relative
+        p.parent.mkdir(parents=True, exist_ok=True)
+        p.write_text(body)
+
+    def migration(self, name="V1__create_widgets.sql", body="CREATE TABLE widgets (id UUID);\n"):
+        p = self.svc / "src" / "main" / "resources" / "db" / "migration" / name
+        p.parent.mkdir(parents=True, exist_ok=True)
+        p.write_text(body)
+
+    # -- C1: ports live in the package, not the filename --------------------
+    def test_c1_counts_an_application_port_package(self):
+        """anacredit/onboarding shape: a port package whose files are not named *Port*."""
+        self.governance()
+        for i in range(10):
+            self.kt(f"domain/Model{i}.kt")
+        self.kt("application/port/out/WidgetRepository.kt")
+        self.kt("application/port/in/WidgetUseCases.kt")
+        score, evidence = self.mod.score_c1_code("widget", {}, "2026-07-25")
+        self.assertEqual(score, 2, evidence)
+        self.assertIn("ports=y", evidence)
+
+    def test_c1_still_counts_the_port_suffix_naming(self):
+        """The other half of the fleet names the file itself *Port*.kt — both must count."""
+        self.governance()
+        for i in range(10):
+            self.kt(f"domain/Model{i}.kt")
+        self.kt("application/LedgerPort.kt")
+        score, _ = self.mod.score_c1_code("widget", {}, "2026-07-25")
+        self.assertEqual(score, 2)
+
+    def test_c1_a_service_with_no_ports_at_all_still_scores_one(self):
+        """agent/copilot shape — the fix must not hand out a 2 for free."""
+        self.governance()
+        for i in range(10):
+            self.kt(f"domain/Model{i}.kt")
+        self.kt("application/WidgetService.kt")
+        score, evidence = self.mod.score_c1_code("widget", {}, "2026-07-25")
+        self.assertEqual(score, 1, evidence)
+        self.assertIn("ports=n", evidence)
+
+    def test_c1_a_skeleton_is_still_a_skeleton(self):
+        self.governance()
+        self.kt("application/port/out/WidgetRepository.kt")
+        score, evidence = self.mod.score_c1_code("widget", {}, "2026-07-25")
+        self.assertEqual(score, 1)
+        self.assertIn("skeleton", evidence)
+
+    # -- C4: the data dimension of a service with no data -------------------
+    def test_c4_stateless_service_is_not_penalised_for_having_no_migration(self):
+        self.governance(datastore="none")
+        score, evidence = self.mod.score_c4_data("widget", {}, "2026-07-25")
+        self.assertEqual(score, 2, evidence)
+        self.assertIn("no datastore", evidence)
+
+    def test_c4_declared_datastore_with_no_migration_is_a_finding(self):
+        """copilot's real state: governance.yaml says PostgreSQL, no migration exists."""
+        self.governance(datastore="PostgreSQL", schema="widget_schema")
+        score, evidence = self.mod.score_c4_data("widget", {}, "2026-07-25")
+        self.assertEqual(score, 1, evidence)
+        self.assertIn("no Flyway migration", evidence)
+
+    def test_c4_declared_stateless_but_migrations_exist_is_a_contradiction(self):
+        """Neither fact can be trusted, so this must not silently pass as stateless."""
+        self.governance(datastore="none")
+        self.migration()
+        score, evidence = self.mod.score_c4_data("widget", {}, "2026-07-25")
+        self.assertEqual(score, 1, evidence)
+        self.assertIn("CONTRADICTION", evidence)
+
+    def test_c4_migration_without_a_rollback_note_still_scores_one(self):
+        self.governance(datastore="PostgreSQL", schema="widget_schema")
+        self.migration()
+        score, evidence = self.mod.score_c4_data("widget", {}, "2026-07-25")
+        self.assertEqual(score, 1, evidence)
+        self.assertIn("rollback_note=n", evidence)
+
+    def test_c4_migration_with_a_rollback_note_scores_two(self):
+        self.governance(datastore="PostgreSQL", schema="widget_schema")
+        self.migration(body="-- rollback: DROP TABLE widgets;\nCREATE TABLE widgets (id UUID);\n")
+        score, evidence = self.mod.score_c4_data("widget", {}, "2026-07-25")
+        self.assertEqual(score, 2, evidence)
+
+    # -- C5: backups for a service with nothing to back up ------------------
+    def test_c5_stateless_service_needs_no_backup(self):
+        self.governance(datastore="none")
+        score, evidence = self.mod.score_c5_backup("widget", {}, "2026-07-25")
+        self.assertEqual(score, 2, evidence)
+        self.assertIn("nothing to back up", evidence)
+
+    def test_c5_stateful_service_with_no_cluster_still_scores_zero(self):
+        self.governance(datastore="PostgreSQL", schema="widget_schema")
+        score, evidence = self.mod.score_c5_backup("widget", {}, "2026-07-25")
+        self.assertEqual(score, 0, evidence)
+
+    # -- C8: scraped is a fact about the namespace --------------------------
+    def test_c8_service_in_a_scraped_namespace_counts_as_scraped(self):
+        """ap2/mcp (platform) and vop/settlement (payments) shape."""
+        self.governance()
+        self.deploy(ns="payments")
+        self.kt("infrastructure/Metrics.kt", "import io.micrometer.core.instrument.MeterRegistry\n")
+        score, evidence = self.mod.score_c8_observability("widget", {}, "2026-07-25")
+        self.assertEqual(score, 2, evidence)
+        self.assertIn("scraped (ns payments)", evidence)
+
+    def test_c8_namespace_absent_from_matchnames_is_not_scraped(self):
+        self.governance()
+        self.deploy(ns="widgets")
+        self.kt("infrastructure/Metrics.kt", "import io.micrometer.core.instrument.MeterRegistry\n")
+        score, evidence = self.mod.score_c8_observability("widget", {}, "2026-07-25")
+        self.assertEqual(score, 1, evidence)
+        self.assertIn("absent from PodMonitor matchNames", evidence)
+
+    def test_c8_a_comment_claiming_coverage_does_not_make_it_scraped(self):
+        """The sdd bug: prose in the PodMonitor must carry no weight whatsoever."""
+        obs = self.root / "openbank-infra" / "gitops" / "components" / "observability"
+        (obs / "podmonitor-openbank-services.yaml").write_text(
+            PODMONITOR_WITH_LYING_COMMENT.replace("sdd-service", "widget-service")
+        )
+        self.governance()
+        self.deploy(ns="widgets")
+        self.kt("infrastructure/Metrics.kt", "import io.micrometer.core.instrument.MeterRegistry\n")
+        score, evidence = self.mod.score_c8_observability("widget", {}, "2026-07-25")
+        self.assertEqual(score, 1, evidence)
+        self.assertIn("absent from PodMonitor matchNames", evidence)
+
+    def test_c8_scraped_but_uninstrumented_names_the_missing_half(self):
+        """anacredit/ap2/finrep/mcp/vop: scraped, zero domain metrics. Different work."""
+        self.governance()
+        self.deploy(ns="payments")
+        score, evidence = self.mod.score_c8_observability("widget", {}, "2026-07-25")
+        self.assertEqual(score, 1, evidence)
+        self.assertIn("NO domain metrics", evidence)
+        self.assertIn("scraped (ns payments)", evidence)
+
+    def test_c8_undeployed_service_says_so(self):
+        self.governance()
+        score, evidence = self.mod.score_c8_observability("widget", {}, "2026-07-25")
+        self.assertEqual(score, 0, evidence)
+        self.assertIn("not deployed", evidence)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## What

Repairs four of the prod-readiness collector's nine scorers, gives it its first test suite, and
centralises the namespace resolution that three separate tools were each about to copy.

`Refs #2255`

## Why this is the second PR of the sweep, not the last

13 of the 43 cells below Verified were the **collector's own false negatives**. That matters more
than the count: the obvious way to "fix" a cell the probe is wrong about is to change the
*service*, and every one of those changes would have been wrong — renaming files so a filename
matches, writing a migration for a service that stores nothing, or adding a comment to the
PodMonitor naming a service (which is literally what an earlier sweep did).

| dimension | what it asked | what the dimension means |
|---|---|---|
| **C8** | `short in read(podmonitor.yaml)` — substring over the whole file, **comments included** | is this service's **namespace** in `matchNames` |
| **C1** | is there a file whose **name** contains `Port` | does the service declare hexagonal ports (ADR-0002) |
| **C4** | are there Flyway migrations, else hardcoded `1` | is the data dimension in order **for the datastore it declares** |
| **C5** | is there a CNPG cluster with a backup, else `0` | is the declared datastore backed up |

**C8.** A comment asserting sdd-service was covered "via `payments`" was false — sdd runs in
namespace `sdd` — and that sentence alone scored sdd as *scraped* while its metrics reached
nothing. In the other direction ap2, mcp, vop, card-issuance, settlement and standing-order
**were** scraped via `platform`/`payments` and scored as if they were not, because their names
appear nowhere in that file. Now resolved from the manifest that **is** the workload. The evidence
string also names the missing half — "add the namespace to the PodMonitor" and "instrument the
domain" are different work, and were reported identically as `not scraped`.

**C1.** anacredit and onboarding both carry a textbook `application/port/{in,out}` package whose
files are named `*Repository.kt` / `*UseCases.kt`. Both scored as having no ports. Either
spelling counts now; a service with **no** port package still scores 1, because agent and copilot
genuinely have none.

**C4/C5.** 2 was **unreachable** for a service that correctly has no datastore — the matrix asked
ap2, copilot, finrep and mcp for a migration and a rollback note it would have been wrong to
write, and told finrep it was missing a CNPG cluster it must not have. Both now read the declared
`primaryDatastore` from `governance.yaml` and report `n/a — declares no datastore` rather than
implying an artifact was reviewed.

## A real finding that the old scorer was hiding

Reading the declared fact instead of guessing from Flyway surfaced the opposite case:
**copilot declares `primaryDatastore: PostgreSQL` and `schemaName: copilot_schema` while shipping
zero `@Entity` classes, zero datasource config and zero migrations.** The old `no flyway
(stateless?)` swallowed it. It is now reported as a finding, as is the reverse (declared stateless
but migrations present). Correcting copilot's `governance.yaml` is a **separate PR** because it
releases copilot.

## One resolver, not three

This collector, the runbook generator (#2261) and `check-podmonitor-namespace-coverage.py`
(#2257) all answer "where does this workload actually run", and **two of the three had already
answered it wrong, in two different ways**. It now lives once in
`openbank-infra/scripts/gitops_facts.py`; the other two import it. The refactored generator
produces **byte-identical output for all 37 runbooks** — that is what makes it a refactor.

## Verification

- `prod_readiness_collector_test.py`: 16 cases, **10 fail against the scorers as they stood**.
  The other 6 are deliberate regression guards (a skeleton is still a skeleton; no ports still
  scores 1; a stateful service with no cluster still scores 0) so a probe fix cannot quietly
  become a giveaway. All fixture trees — a test reading the live fleet would pass or fail for
  reasons unrelated to the code.
- Full `openbank-infra/scripts` suite: **79 tests, OK** (up from 63). ci.yml already runs this
  directory, so both new suites are gated with no workflow change.
- The refactored PodMonitor gate re-falsified after the refactor: removing `sdd` from
  `matchNames` prints the sdd finding and exits 1; restored tree exits 0.
- Runbook generator output diffed byte-for-byte before/after the refactor: 0 files changed.

## Fleet effect

Measured before and after on the same tree: **43 cells below Verified → 17**, and **11 of 37
services at GO → 16**. Nothing about any service changed — the matrix now describes what is
there. The remaining 17 are real work, tracked in #2255: C3 contract tests (7), C8 domain
metrics (5), C1 hexagonal ports for agent/copilot (2) and the ap2 skeleton (1), C4 copilot
governance + settlement rollback note (2).
