### PR TITLE
docs(settlement): document the settlements schema, its rollback and its two real gaps

### DIFF
--- a/openbank-settlement-service/src/main/resources/docs/04-data.cs.md
+++ b/openbank-settlement-service/src/main/resources/docs/04-data.cs.md
@@ -1,0 +1,65 @@
+# Data
+
+## Schéma
+
+Služba vlastní **dedikovanou PostgreSQL databázi** `settlement` (Hibernate Reactive + Panache nad reaktivním PG klientem; JDBC pouze pro Flyway). Tabulky vznikají migracemi ve výchozím schématu `public`; **deklarované logické jméno schématu** v `governance.yaml` je `settlement_schema` (datová domána `payments`, klasifikace `confidential`). `quarkus.hibernate-orm.database.generation` zůstává na výchozí hodnotě `none` — jediná autorita nad schématem je Flyway.
+
+```mermaid
+erDiagram
+  SETTLEMENTS {
+    uuid id PK "domenove UUID, prirazuje aplikace (NENI surrogate)"
+    uuid payer_account_id "odkaz na account-service, bez DB FK"
+    uuid payee_account_id "odkaz na account-service, bez DB FK"
+    numeric amount "NUMERIC(19,4)"
+    varchar currency "ISO-4217, 3 znaky"
+    varchar status "PENDING|DEBITED|CREDITED|BOOKED|REJECTED|REVERSED"
+    timestamptz created_at "DEFAULT NOW(), nemenne"
+    timestamptz updated_at "DEFAULT NOW(), meni se pri kazdem prechodu"
+  }
+```
+
+Měnitelné jsou pouze `status` a `updated_at` — ostatní sloupce mají v `SettlementEntity` `updatable = false`, protože strany a částka settlementu jsou dané při vzniku a mění se jen jeho životní cyklus.
+
+> **Primární klíč přiřazuje aplikace**, není `@GeneratedValue`, takže `persist()` je pro tuto entitu výhradně INSERT: s už nenulovým id Hibernate neodliší transientní instanci od detached, naplánuje INSERT při každém uložení a přechod životního cyklu spadne při flushi na `duplicate key value violates ... settlements_pkey` (ADR-0126 D3 — chyba, která se dostala do produkce v consent-service a standing-order-service a žádný unit test s mockovaným repository ji neviděl).
+>
+> `SettlementRepositoryImpl` se jí vyhýbá a stojí za to vědět jak, protože ty dva bezpečné vzory se mají kopírovat: `create` je **jediný** volající `persist` (INSERT, což persist znamená); `claimForProcessing` posílá bulk HQL `update ... where id = ?3 and status = ?4` jako atomický compare-and-set; a `updateStatus` mění entitu **načtenou ve stejné session**, takže UPDATE vydá dirty checking Hibernate. Žádná update cesta neukládá detached instanci znovu, takže `merge` tady není potřeba.
+
+## Migrace
+
+Flyway, nemměnné historické skripty, pouze dopředu (`migrate-at-start=true`). **Aplikovaná migrace se už nikdy needituje** — Flyway počítá checksum celého souboru včetně komentářů, takže jakákoli úprava shodí start na checksum mismatch. Proto jsou rollback poznámky tady, a ne jako komentáře uvnitř skriptů.
+
+| Skript | Co dělá | Rollback poznámka |
+|---|---|---|
+| `V1__create_settlements.sql` | Tabulka `settlements`: UUID PK přiřazované aplikací, id účtů plátce/příjemce, částka `NUMERIC(19,4)`, ISO-4217 valuta, `status` životního cyklu, `created_at`/`updated_at` s `DEFAULT NOW()` | `DROP TABLE settlements;` — tabulka stojí samostatně (žádné FK ani jedním směrem, žádné sekvence, žádné závislé view), takže drop je úplný a nepotřebuje pořadí. Zničí celou historii settlementů: nejdřív logický dump (`pg_dump -t settlements`), protože tyto řádky jsou jediný záznam o tom, které nohy platby byly zaúčtovány, a platí pro ně sedmiletá `retentionPolicy`. |
+
+## Indexy
+
+**Žádné mimo primární klíč.** `V1` nevytváří sekundární indexy, takže každý dotaz filtrující podle `payer_account_id`, `payee_account_id`, `status` nebo `created_at` je sekvenční scan. Při dnešních objemech to je akceptovatelné a je to zaznamenáno tady jako známá mezera, ne aby se objevila znovu až pod zátěží — sweep životního cyklu filtruje podle `status`, což je první index, který přidat, jak tabulka poroste.
+
+## Retence
+
+| Tabulka | Retence | Důvod |
+|---|---|---|
+| `settlements` | 7 let (deklarovaná `retentionPolicy`) | retence platebních záznamů; řádek je důkaz, že noha settlementu byla zaúčtována |
+
+`evidenceExported: true` v `governance.yaml` — události životního cyklu settlementu jdou jako audit evidence přes Kafku do `audit-service`.
+
+> V tomto schématu **není outbox tabulka**. Služba publikuje audit události přímo, nikoli přes transakční outbox (ADR-0050), takže změna stavu a její událost se necommitují atomicky: pád mezi nimi událost ztratí bez retry a nikdo to nenahlásí. Orchestrace settlementu běží na Temporalu (`SettlementWorkflow`), což pokrývá retry na úrovni workflow, ale ne tohle konkrétní okno dvojího zápisu.
+
+## PII polia (GDPR)
+
+| Pole | Klasifikace | Poznámka |
+|---|---|---|
+| `payer_account_id` / `payee_account_id` | pseudonymizovaná id | odkazují na account-service; žádná jména, IBANy ani adresy tady nejsou |
+| `amount` / `currency` | finanční data | confidential; identifikují hodnotu transakce, ne osobu |
+| `status` / časové značky | provozní | životní cyklus a audit trail |
+
+Záznam je **confidential** (`dataClassification: confidential`). Neobsahuje žádné přímé identifikátory — osoba za účtem se dohledává přes account-service a party-service. GDPR **právo na výmaz** na tyto řádky během sedmileté retence platebních záznamů nedosáhne.
+
+## Datová lineage (governance.yaml)
+
+- **Upstream (api):** ledger-service — dotazuje GL zápisy pro settlement batche.
+- **Upstream (topic):** sepa-payment — konzumuje platební události k settlementu.
+- **Downstream (topic):** audit-service — emituje audit události settlementu.
+- **Vlastněné schéma:** `settlement_schema`. **Závislá schémata:** `ledger_schema`, `transactions_schema`.
+- `dataLineageRole: both` — služba konzumuje platební data a produkuje settlement data.

--- a/openbank-settlement-service/src/main/resources/docs/04-data.en.md
+++ b/openbank-settlement-service/src/main/resources/docs/04-data.en.md
@@ -1,0 +1,65 @@
+# Data
+
+## Schema
+
+The service owns a **dedicated PostgreSQL database** `settlement` (Hibernate Reactive + Panache over the reactive PG client; JDBC only for Flyway). Tables are created in the default `public` schema by the migrations; the **declared logical schema name** in `governance.yaml` is `settlement_schema` (data domain `payments`, classification `confidential`). `quarkus.hibernate-orm.database.generation` is left at its default `none` — Flyway is the sole schema authority.
+
+```mermaid
+erDiagram
+  SETTLEMENTS {
+    uuid id PK "domain UUID, application-assigned (NOT a surrogate)"
+    uuid payer_account_id "FK to account-service, no DB FK"
+    uuid payee_account_id "FK to account-service, no DB FK"
+    numeric amount "NUMERIC(19,4)"
+    varchar currency "ISO-4217, 3 chars"
+    varchar status "PENDING|DEBITED|CREDITED|BOOKED|REJECTED|REVERSED"
+    timestamptz created_at "DEFAULT NOW(), immutable"
+    timestamptz updated_at "DEFAULT NOW(), bumped on every transition"
+  }
+```
+
+`status` and `updated_at` are the only mutable columns — the rest of the row is `updatable = false` in `SettlementEntity`, because a settlement's parties and amount are fixed at creation and only its lifecycle moves.
+
+> **The primary key is application-assigned**, not `@GeneratedValue`, which makes `persist()` INSERT-only for this entity: with a non-null id already set, Hibernate cannot tell a transient instance from a detached one, so it schedules an INSERT on every save and a lifecycle transition fails at flush with `duplicate key value violates ... settlements_pkey` (ADR-0126 D3 — the defect that shipped in consent-service and standing-order-service, invisible to every unit test that mocked the repository).
+>
+> `SettlementRepositoryImpl` avoids it, and it is worth knowing how, because the two safe shapes are the ones to copy: `create` is the **only** caller of `persist` (an INSERT, which is what persist means); `claimForProcessing` issues a bulk HQL `update ... where id = ?3 and status = ?4` as an atomic compare-and-set; and `updateStatus` mutates an entity **loaded inside the same session**, so Hibernate's dirty checking emits the UPDATE. No update path ever re-persists a detached instance, so `merge` is not needed here.
+
+## Migrations
+
+Flyway, immutable historical scripts, forward-only (`migrate-at-start=true`). **A migration is never edited after it has been applied** — Flyway checksums the whole file, comments included, so any edit fails startup with a checksum mismatch. That is also why the rollback notes live here rather than as comments inside the scripts.
+
+| Script | What it does | Rollback note |
+|---|---|---|
+| `V1__create_settlements.sql` | Table `settlements`: application-assigned UUID PK, payer/payee account ids, `NUMERIC(19,4)` amount, ISO-4217 currency, lifecycle `status`, `created_at`/`updated_at` with `DEFAULT NOW()` | `DROP TABLE settlements;` — the table is standalone (no FKs in either direction, no sequences, no dependent views), so the drop is complete and needs no ordering. Destroys all settlement history: take a logical dump first (`pg_dump -t settlements`), because the settlement rows are the only record of which payment legs were booked, and the 7-year `retentionPolicy` applies to them. |
+
+## Indexes
+
+**None beyond the primary key.** `V1` creates no secondary indexes, so any query that filters by `payer_account_id`, `payee_account_id`, `status` or `created_at` is a sequential scan. That is acceptable at current volumes and is recorded here as a known gap rather than left to be rediscovered under load — the settlement lifecycle sweep filters on `status`, which is the first index to add when the table grows.
+
+## Retention
+
+| Table | Retention | Reason |
+|---|---|---|
+| `settlements` | 7 years (declared `retentionPolicy`) | payment-record retention; the row is the evidence that a settlement leg was booked |
+
+`evidenceExported: true` in `governance.yaml` — settlement lifecycle events are exported as audit evidence to `audit-service` over Kafka.
+
+> There is **no outbox table** in this schema. The service publishes its audit events directly rather than through a transactional outbox (ADR-0050), so a status transition and its event are not committed atomically: a crash between the two loses the event with no retry, and nothing reports it. Settlement's orchestration runs on Temporal (`SettlementWorkflow`), which covers workflow-level retries but not this specific dual-write window.
+
+## PII fields (GDPR)
+
+| Field | Classification | Note |
+|---|---|---|
+| `payer_account_id` / `payee_account_id` | pseudonymized ids | reference account-service; no names, IBANs or addresses stored here |
+| `amount` / `currency` | financial data | confidential; identifies a transaction's value, not a person |
+| `status` / timestamps | operational | lifecycle and audit trail |
+
+The record is **confidential** (`dataClassification: confidential`). It holds no direct identifiers — the party behind an account is resolved through account-service and party-service. GDPR **right to erasure** does not reach these rows during the 7-year payment-record retention period.
+
+## Data lineage (governance.yaml)
+
+- **Upstream (api):** ledger-service — queries GL entries for settlement batches.
+- **Upstream (topic):** sepa-payment — consumes payment events for settlement.
+- **Downstream (topic):** audit-service — emits settlement audit events.
+- **Owned schema:** `settlement_schema`. **Dependent schemas:** `ledger_schema`, `transactions_schema`.
+- `dataLineageRole: both` — the service both consumes payment data and produces settlement data.


### PR DESCRIPTION
## What

Adds `04-data.{en,cs}.md` for settlement-service, following the fleet's convention (aml, anacredit),
with the rollback note that `V1__create_settlements.sql` never had.

`Refs #2255`

## Why the note is here and not in the migration

Flyway checksums the **whole file, comments included**, so adding a rollback comment to an applied
migration fails startup with a checksum mismatch. The doc says so explicitly, so the next person
does not reach for the migration either. This is also what the readiness collector reads for C4 —
the cell moves 1 → 2, verified by re-running it.

## Two real gaps it records

Both found while writing the doc, and worth knowing before they are rediscovered at runtime:

- **`V1` creates no secondary indexes.** Any query filtering by `payer_account_id`,
  `payee_account_id`, `status` or `created_at` is a sequential scan. Acceptable at current volume,
  but the lifecycle sweep filters on `status`, which is the first index to add.
- **There is no outbox table.** The service publishes audit events directly rather than through a
  transactional outbox (ADR-0050), so a status transition and its event are not committed
  atomically — a crash between the two loses the event with no retry and nothing reports it.
  Temporal (`SettlementWorkflow`) covers workflow-level retries, not that dual-write window.

## On the assigned-@Id footgun

`settlements` has an application-assigned UUID primary key, the same shape that made every
lifecycle transition 500 in consent-service and standing-order-service (ADR-0126 D3). The doc
records that settlement is **safe**, and why — because the safe shapes are the ones to copy:
`create` is the only caller of `persist`, `claimForProcessing` is a bulk HQL compare-and-set, and
`updateStatus` mutates an entity loaded inside the same session so dirty checking emits the UPDATE.

Worth flagging in review: the first draft of this doc asserted the repository *needed*
`Panache...merge`, inferred from the entity shape. Reading `SettlementRepositoryImpl` showed that
was wrong, and it was corrected before commit. Every other claim in the doc — the status enum
values, `updatable = false` columns, the absence of indexes, the absence of an outbox, the
datasource and Flyway config, the lineage — was read out of the service rather than assumed.

## Release behaviour

`docs` is a hidden type, so this does not cut a settlement release even though
`src/main/resources/**` is on the release path. Both axes are required and only one is present.
