### PR TITLE
fix(copilot): declare the datastore copilot actually has, which is none

### DIFF
--- a/docs/runbooks/svc-copilot.md
+++ b/docs/runbooks/svc-copilot.md
@@ -6,7 +6,7 @@ exercised DR drill, tracked as TTL'd attestations, never faked here. -->
 # Runbook — openbank-copilot-service
 
 > Operational runbook for the `copilot` service. Data domain **platform**,
-> classification **confidential**, datastore **PostgreSQL**.
+> classification **confidential**, datastore **none**.
 
 ## Service identity
 
@@ -15,7 +15,7 @@ exercised DR drill, tracked as TTL'd attestations, never faked here. -->
 | Service | `openbank-copilot-service` |
 | HTTP port | `8131` |
 | Data domain | platform |
-| Datastore | PostgreSQL (schema `copilot_schema`) |
+| Datastore | none (schema `—`) |
 | Classification | confidential |
 | Retention | 1 year |
 | Lineage role | internal |
@@ -44,19 +44,20 @@ triaging an incident that starts on `copilot`.
 ## Common failure modes
 
 - **Pod CrashLoopBackOff at boot:** usually a missing/invalid config or secret
-  (`ExternalSecret` not synced) or a Flyway checksum mismatch. Check
-  `kubectl describe pod` events and the first 50 log lines.
-- **Readiness flapping:** datastore (PostgreSQL) unreachable or saturated — check the
-  datastore pod/cluster health and connection-pool metrics.
+  (`ExternalSecret` not synced). Check `kubectl describe pod` events and the
+  first 50 log lines.
+- **Readiness flapping:** this service holds no datastore, so look outward — an
+  upstream dependency below, or the OPA sidecar if `AUTHZ_ENFORCE` is on (with no
+  reachable PDP, `@Authorize` fails closed).
 - **Downstream errors:** verify the upstream dependencies above are healthy before
   assuming the fault is local.
 
 ## Disaster recovery
 
-- **RPO target:** ≤ 5 min (continuous archiving). **RTO target:** ≤ 30 min (restore + warm-up).
-- **Mechanism:** CloudNativePG continuous WAL archiving + base backups to S3 (`barmanObjectStore`). Point-in-time recovery (PITR).
-- **Restore:** create a `Cluster` with `bootstrap.recovery` pointing at the backup object store; CNPG replays WAL to the target time. See runbook 0003 (PG major upgrade) for the cluster-recreate mechanics.
-- **Verify:** `kubectl cnpg status <db>-rw -n <ns>` shows the recovered cluster Healthy and the `*-app` secret regenerated.
+- **RPO: n/a** — no persistent state. **RTO target:** ≤ 10 min (image pull + rollout).
+- **Mechanism:** none needed — this service declares no primary datastore, so it holds no state to lose. Recovery is a redeploy from the GitOps manifests, which are the source of truth.
+- **Restore:** re-sync the ArgoCD Application (or `kubectl rollout restart` the Deployment). Any state this service reads lives in its upstream services above — recover those first, using their own runbooks.
+- **Verify:** health endpoint green, then re-drive one request end to end against an upstream that is already known-good.
 
 > RPO/RTO above are documented targets. They become **Bank-grade** (prod-readiness
 > C6=3) only once a restore/failover drill has actually been rehearsed and attested

--- a/openbank-copilot-service/governance.yaml
+++ b/openbank-copilot-service/governance.yaml
@@ -3,8 +3,8 @@
 # derived fields (Flyway/apiVersion) and runtime drift live elsewhere. Schema:
 # openbank-libs/governance/governance.schema.json
 dataDomain: platform
-primaryDatastore: PostgreSQL
-schemaName: copilot_schema
+primaryDatastore: none
+stateless: true
 dataLineageRole: internal
 dataClassification: confidential
 retentionPolicy: 1 year
@@ -23,6 +23,3 @@ lineage:
     - serviceName: fx-service
       relationType: api
       description: READ tool (FX rates)
-schemaLineage:
-  ownedSchemas:
-    - copilot_schema


### PR DESCRIPTION
## What

`openbank-copilot-service/governance.yaml` declared a PostgreSQL datastore and an owned schema
that do not exist. Corrected to the canonical stateless declaration, and `svc-copilot.md`
regenerated.

`Refs #2255`

## Why it matters beyond a matrix cell

| declared | reality |
|---|---|
| `primaryDatastore: PostgreSQL` | zero datasource configuration |
| `schemaName: copilot_schema` | zero `@Entity` classes |
| `schemaLineage.ownedSchemas: [copilot_schema]` | zero Flyway migrations |

These are the curatorial facts ADR-0071 publishes. They feed the governance manifest, the
admin-UI data-lineage view, and the generated runbook — which until now told an on-call engineer
that copilot's readiness flapping meant "PostgreSQL unreachable or saturated" and that recovery
meant a point-in-time restore with a 5-minute RPO. **There is no database to restore.**

## The fix

The canonical stateless form the schema mandates and ap2/mcp already use: `primaryDatastore: none`
+ explicit `stateless: true`, no `schemaName`. The schema is deliberate that this is an assertion,
not an inference from a missing field. `schemaLineage` is **dropped** rather than rewritten with a
guessed `dependentSchemas` list.

## How it was found

The repaired C4 scorer in #2266. The old one returned a hardcoded `no flyway (stateless?)` for any
service without migrations, so "declares a datastore and ships no schema for it" was
indistinguishable from "correctly has neither". Reading the declared fact instead of guessing from
Flyway is what surfaced it — and the new scorer reports it as a finding rather than a pass.

## Verification

- `node scripts/generate-governance.mjs` (the ADR-0071 gate, ajv against `governance.schema.json`):
  **53 modules, 0 gaps**.
- Collector with #2266's scorer applied: copilot C4 `1 → 2` with evidence
  `n/a — declares no datastore (stateless)`, C5 likewise. Confirmed by running both collectors
  against this tree.
- `svc-copilot.md` regenerated as the runbook drift gate requires; the diff is exactly the
  stateless switch (datastore row, failure modes, DR section).

## Deliberately NOT fixed here

copilot lists the four services it **reads from** (balance, transaction, ledger, fx — every
description says "READ tool") under `lineage.downstream`, while finrep uses `upstream` for the
services it reads. The generated runbook therefore claims those four services depend on copilot.
The schema does not define which direction is which, so inverting it blindly could break whatever
the admin-UI lineage view already assumes. Needs a decision, not a guess.

## Release behaviour

`fix` + a path inside the copilot package ⇒ this releases copilot-service. That is correct and
intended; `version.txt` and `CHANGELOG.md` are left to release-please.
