### PR TITLE
feat(anacredit): instrument exposure intake, return shape and lending-event outcomes

### DIFF
--- a/openbank-anacredit-service/src/main/kotlin/com/openbank/anacredit/application/AnaCreditService.kt
+++ b/openbank-anacredit-service/src/main/kotlin/com/openbank/anacredit/application/AnaCreditService.kt
@@ -7,42 +7,60 @@ import com.openbank.anacredit.application.port.`in`.BuildAnaCreditReturnUseCase
 import com.openbank.anacredit.application.port.`in`.ListExposuresUseCase
 import com.openbank.anacredit.application.port.`in`.RegisterExposureCommand
 import com.openbank.anacredit.application.port.`in`.RegisterExposureUseCase
+import com.openbank.anacredit.application.port.out.AnaCreditMetricsPort
 import com.openbank.anacredit.application.port.out.CreditExposureRepository
 import com.openbank.anacredit.domain.model.CreditExposure
 import com.openbank.anacredit.domain.report.AnaCreditReturn
 import com.openbank.anacredit.domain.report.AnaCreditReturnBuilder
 import jakarta.enterprise.context.ApplicationScoped
+import java.time.Duration
 import java.time.LocalDate
 
 /**
  * Application service for the AnaCredit credit-exposure feed: it owns exposure intake and delegates
  * the regulatory return assembly to the pure [AnaCreditReturnBuilder]. Derive-only — it posts no
  * money and emits no events (ADR-0037), so it stays off the money-path gate.
+ *
+ * Both paths are instrumented through [AnaCreditMetricsPort]: derive-only means no downstream
+ * consumer notices when the feed goes quiet or starts under-reporting, so the meters are the only
+ * evidence that the return submitted for a reference date was assembled from a live book.
  */
 @ApplicationScoped
-class AnaCreditService(private val exposures: CreditExposureRepository) :
+class AnaCreditService(private val exposures: CreditExposureRepository, private val metrics: AnaCreditMetricsPort) :
     RegisterExposureUseCase,
     ListExposuresUseCase,
     BuildAnaCreditReturnUseCase {
 
-    override suspend fun register(command: RegisterExposureCommand): CreditExposure = exposures.upsert(
-        CreditExposure(
-            instrumentId = command.instrumentId,
-            debtorId = command.debtorId,
-            debtorType = command.debtorType,
-            instrumentType = command.instrumentType,
-            currency = command.currency,
-            committedAmount = command.committedAmount,
-            drawnAmount = command.drawnAmount,
-            committedAmountEur = command.committedAmountEur,
-            arrearsAmount = command.arrearsAmount,
-            defaulted = command.defaulted,
-            originationDate = command.originationDate,
-        ),
-    )
+    override suspend fun register(command: RegisterExposureCommand): CreditExposure {
+        val stored = exposures.upsert(
+            CreditExposure(
+                instrumentId = command.instrumentId,
+                debtorId = command.debtorId,
+                debtorType = command.debtorType,
+                instrumentType = command.instrumentType,
+                currency = command.currency,
+                committedAmount = command.committedAmount,
+                drawnAmount = command.drawnAmount,
+                committedAmountEur = command.committedAmountEur,
+                arrearsAmount = command.arrearsAmount,
+                defaulted = command.defaulted,
+                originationDate = command.originationDate,
+            ),
+        )
+        metrics.exposureRegistered(stored.instrumentType, stored.currency, stored.defaulted)
+        return stored
+    }
 
     override suspend fun list(): List<CreditExposure> = exposures.listAll()
 
-    override suspend fun build(referenceDate: LocalDate): AnaCreditReturn =
-        AnaCreditReturnBuilder.build(exposures.listAll(), referenceDate)
+    override suspend fun build(referenceDate: LocalDate): AnaCreditReturn {
+        val startedAt = System.nanoTime()
+        val report = AnaCreditReturnBuilder.build(exposures.listAll(), referenceDate)
+        metrics.returnBuilt(
+            recordCount = report.records.size,
+            exclusionCount = report.exclusions.size,
+            duration = Duration.ofNanos(System.nanoTime() - startedAt),
+        )
+        return report
+    }
 }

--- a/openbank-anacredit-service/src/main/kotlin/com/openbank/anacredit/application/port/out/AnaCreditMetricsPort.kt
+++ b/openbank-anacredit-service/src/main/kotlin/com/openbank/anacredit/application/port/out/AnaCreditMetricsPort.kt
@@ -1,0 +1,65 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright (c) OpenBank contributors. Licensed under the Apache License, Version 2.0.
+// See LICENSE in the repository root or https://www.apache.org/licenses/LICENSE-2.0 for details.
+package com.openbank.anacredit.application.port.out
+
+import com.openbank.anacredit.domain.model.InstrumentType
+import java.time.Duration
+
+/**
+ * Outbound observability port (ADR-0002 / ADR-0077 Tier C). AnaCredit is a *derive-only* regulatory
+ * feed: it posts no money and emits no events, so nothing downstream complains when it goes wrong.
+ * The two ways it fails are both silent by construction, and both are what these meters make visible:
+ *
+ *  - the return is assembled from whatever exposures happen to be stored, so a stalled intake
+ *    produces a **smaller but perfectly well-formed** return that is submitted to the regulator;
+ *  - the lending `loan.stage_changed` consumer is poison-pill safe — a malformed or foreign event is
+ *    logged and **acked**, so the IFRS-9 stage projection silently stops advancing.
+ *
+ * Kept as a port rather than a direct `MeterRegistry` dependency so the application layer stays free
+ * of the metrics framework, and so the counters are exercised through the real adapter (over a
+ * `SimpleMeterRegistry`) in unit tests.
+ *
+ * Implemented by [com.openbank.anacredit.infrastructure.observability.AnaCreditMetricsAdapter].
+ */
+interface AnaCreditMetricsPort {
+
+    /** Record one exposure intake (register or replace). */
+    fun exposureRegistered(instrumentType: InstrumentType, currency: String, defaulted: Boolean)
+
+    /**
+     * Record one rendered AnaCredit credit-dataset return: how long it took, how many rows it
+     * carries, and how many instruments were dropped by the eligibility policy. `records` collapsing
+     * or `exclusions` spiking is the only signal that the feed is under-reporting.
+     */
+    fun returnBuilt(recordCount: Int, exclusionCount: Int, duration: Duration)
+
+    /** Record the outcome of one consumed `loan.stage_changed` event. */
+    fun loanStageEvent(outcome: LoanStageEventOutcome)
+}
+
+/**
+ * Terminal outcomes of one `loan.stage_changed` consumption. A bounded set — safe as a metric tag.
+ *
+ * [STALE] and [IGNORED] are normal; [PARSE_ERROR], [MALFORMED] and [APPLY_ERROR] are the acked-and-
+ * dropped population that previously left nothing but a log line behind.
+ */
+enum class LoanStageEventOutcome {
+    /** The projection was advanced. */
+    APPLIED,
+
+    /** A valid event whose timestamp is not newer than the stored projection — correctly discarded. */
+    STALE,
+
+    /** A lending event of some other type — not ours to handle. */
+    IGNORED,
+
+    /** The payload is not JSON. */
+    PARSE_ERROR,
+
+    /** JSON, but missing a `loanId` or `newStage`. */
+    MALFORMED,
+
+    /** The projection write failed. Acked anyway so the consumer group is not wedged. */
+    APPLY_ERROR,
+}

--- a/openbank-anacredit-service/src/main/kotlin/com/openbank/anacredit/infrastructure/kafka/LoanStageEventConsumer.kt
+++ b/openbank-anacredit-service/src/main/kotlin/com/openbank/anacredit/infrastructure/kafka/LoanStageEventConsumer.kt
@@ -4,6 +4,8 @@
 package com.openbank.anacredit.infrastructure.kafka
 
 import com.fasterxml.jackson.databind.ObjectMapper
+import com.openbank.anacredit.application.port.out.AnaCreditMetricsPort
+import com.openbank.anacredit.application.port.out.LoanStageEventOutcome
 import com.openbank.anacredit.application.port.out.LoanStageProjectionRepository
 import com.openbank.anacredit.domain.model.LoanStageProjection
 import jakarta.enterprise.context.ApplicationScoped
@@ -26,6 +28,11 @@ import java.util.UUID
  * logged, and the message is acked — one malformed event must not wedge the consumer group; the
  * canonical lending stream can be replayed).
  *
+ * Every consumption reports its terminal outcome to [AnaCreditMetricsPort]. That is the point of the
+ * meter rather than a nicety: acking a bad event is the correct behaviour, so a broken producer, a
+ * schema change or a wedged projection write leaves the stage projection frozen with nothing but an
+ * INFO/ERROR line to show for it. `outcome=parse_error|malformed|apply_error` is that population.
+ *
  * Idempotent + ordering-safe: [LoanStageProjectionRepository.applyIfNewer] only writes when the
  * incoming event's timestamp is strictly newer than the projection's current value, so an out-of-order
  * redelivery or a duplicate can never regress the projection to an older stage.
@@ -42,6 +49,9 @@ class LoanStageEventConsumer {
     @Inject
     lateinit var clock: Clock
 
+    @Inject
+    lateinit var metrics: AnaCreditMetricsPort
+
     private val log = Logger.getLogger(LoanStageEventConsumer::class.java)
 
     @Incoming("lending-events-in")
@@ -51,20 +61,26 @@ class LoanStageEventConsumer {
             objectMapper.readTree(payload)
         } catch (e: Exception) {
             log.errorf(e, "[lending-events-in] Failed to parse JSON payload: %.200s", payload)
+            metrics.loanStageEvent(LoanStageEventOutcome.PARSE_ERROR)
             return
         }
 
         val eventType = node.path("eventType").asText()
-        if (eventType != "loan.stage_changed") return
+        if (eventType != "loan.stage_changed") {
+            metrics.loanStageEvent(LoanStageEventOutcome.IGNORED)
+            return
+        }
 
         val loanId = runCatching { UUID.fromString(node.path("loanId").asText()) }.getOrNull()
         if (loanId == null) {
             log.warnf("[lending-events-in] loan.stage_changed without a valid loanId, skipping: %.200s", payload)
+            metrics.loanStageEvent(LoanStageEventOutcome.MALFORMED)
             return
         }
         val newStage = node.path("newStage").asText("").ifBlank { null }
         if (newStage == null) {
             log.warnf("[lending-events-in] loan.stage_changed without a newStage, skipping: %.200s", payload)
+            metrics.loanStageEvent(LoanStageEventOutcome.MALFORMED)
             return
         }
         val daysPastDue = node.path("daysPastDue").asInt(0)
@@ -74,32 +90,44 @@ class LoanStageEventConsumer {
             OffsetDateTime.parse(node.path("asOf").asText())
         }.getOrDefault(OffsetDateTime.now(clock))
 
+        apply(
+            LoanStageProjection(
+                loanId = loanId,
+                stage = newStage,
+                daysPastDue = daysPastDue,
+                eventTimestamp = eventTimestamp,
+                updatedAt = OffsetDateTime.now(clock),
+            ),
+        )
+    }
+
+    /**
+     * Write the projection and report the terminal outcome. A write failure is logged, counted and
+     * swallowed — the message is acked so one bad row cannot wedge the consumer group, and the
+     * canonical lending stream can be replayed.
+     */
+    @Suppress("TooGenericExceptionCaught") // any write failure means the same thing: ack and count it
+    private suspend fun apply(projection: LoanStageProjection) {
         try {
-            val applied = projections.applyIfNewer(
-                LoanStageProjection(
-                    loanId = loanId,
-                    stage = newStage,
-                    daysPastDue = daysPastDue,
-                    eventTimestamp = eventTimestamp,
-                    updatedAt = OffsetDateTime.now(clock),
-                ),
-            )
-            if (applied) {
+            if (projections.applyIfNewer(projection)) {
                 log.infof(
                     "[lending-events-in] Applied stage projection for loan %s: %s (DPD %d)",
-                    loanId,
-                    newStage,
-                    daysPastDue,
+                    projection.loanId,
+                    projection.stage,
+                    projection.daysPastDue,
                 )
+                metrics.loanStageEvent(LoanStageEventOutcome.APPLIED)
             } else {
                 log.infof(
                     "[lending-events-in] Ignored stale/duplicate loan.stage_changed for loan %s " +
                         "(existing projection is already at least as recent)",
-                    loanId,
+                    projection.loanId,
                 )
+                metrics.loanStageEvent(LoanStageEventOutcome.STALE)
             }
         } catch (e: Exception) {
-            log.errorf(e, "[lending-events-in] Failed to apply stage projection for loan %s", loanId)
+            log.errorf(e, "[lending-events-in] Failed to apply stage projection for loan %s", projection.loanId)
+            metrics.loanStageEvent(LoanStageEventOutcome.APPLY_ERROR)
         }
     }
 }

--- a/openbank-anacredit-service/src/main/kotlin/com/openbank/anacredit/infrastructure/observability/AnaCreditMetricsAdapter.kt
+++ b/openbank-anacredit-service/src/main/kotlin/com/openbank/anacredit/infrastructure/observability/AnaCreditMetricsAdapter.kt
@@ -1,0 +1,106 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright (c) OpenBank contributors. Licensed under the Apache License, Version 2.0.
+// See LICENSE in the repository root or https://www.apache.org/licenses/LICENSE-2.0 for details.
+package com.openbank.anacredit.infrastructure.observability
+
+import com.openbank.anacredit.application.port.out.AnaCreditMetricsPort
+import com.openbank.anacredit.application.port.out.LoanStageEventOutcome
+import com.openbank.anacredit.domain.model.InstrumentType
+import io.micrometer.core.instrument.Counter
+import io.micrometer.core.instrument.DistributionSummary
+import io.micrometer.core.instrument.MeterRegistry
+import io.micrometer.core.instrument.Timer
+import jakarta.enterprise.context.ApplicationScoped
+import jakarta.enterprise.inject.Instance
+import jakarta.inject.Inject
+import java.time.Duration
+
+/**
+ * Micrometer adapter for [AnaCreditMetricsPort] (ADR-0077 Tier C). Emits, all tagged
+ * `service="anacredit"`:
+ *
+ *  - `openbank_anacredit_exposures_registered_total{instrument_type,currency,defaulted}` — intake
+ *    rate. A flat line during a reporting month means the feed is being assembled from stale data.
+ *  - `openbank_anacredit_return_build_duration_seconds{}` — render latency of the credit dataset.
+ *  - `openbank_anacredit_return_records{}` / `openbank_anacredit_return_exclusions{}` — the size and
+ *    the drop count of the last rendered return, as histograms. Under-reporting shows up here and
+ *    nowhere else: the return is still valid JSON when it is missing half the book.
+ *  - `openbank_anacredit_loan_stage_events_total{outcome}` — the lending-event consumer's outcome
+ *    mix. `outcome=parse_error|malformed|apply_error` is the acked-and-dropped population that the
+ *    poison-pill guard deliberately swallows.
+ *
+ * Service-local `MeterRegistry`, null-safe via [Instance] exactly like libs `DomainMetrics`: a
+ * regulatory-return shape counter is AnaCredit-specific, so adding it to the shared libs facade
+ * would force a fleet-wide rebuild for a one-service concern.
+ */
+@ApplicationScoped
+class AnaCreditMetricsAdapter(private val registry: MeterRegistry?) : AnaCreditMetricsPort {
+
+    // CDI constructor: MeterRegistry is optional (absent when no Prometheus registry is on the
+    // classpath, e.g. slim test slices). Without an explicit @Inject ctor, ArC sees two constructors,
+    // registers no bean, and AnaCreditService is left with an unsatisfied dependency at build time.
+    @Inject
+    constructor(registryInstance: Instance<MeterRegistry>) : this(
+        if (registryInstance.isResolvable) registryInstance.get() else null,
+    )
+
+    override fun exposureRegistered(instrumentType: InstrumentType, currency: String, defaulted: Boolean) {
+        registry?.let { r ->
+            Counter.builder("openbank.anacredit.exposures.registered")
+                .tag("service", SERVICE)
+                .tag("instrument_type", instrumentType.name)
+                .tag("currency", currency)
+                .tag("defaulted", defaulted.toString())
+                .description("AnaCredit credit exposures registered or replaced")
+                .register(r)
+                .increment()
+        }
+    }
+
+    override fun returnBuilt(recordCount: Int, exclusionCount: Int, duration: Duration) {
+        registry?.let { r ->
+            Timer.builder("openbank.anacredit.return.build.duration")
+                .tag("service", SERVICE)
+                .publishPercentiles(P50, P95, P99)
+                .publishPercentileHistogram()
+                .description("Time to render one AnaCredit credit-dataset return")
+                .register(r)
+                .record(duration)
+            summary(r, "openbank.anacredit.return.records", "Rows in a rendered AnaCredit return")
+                .record(recordCount.toDouble())
+            summary(
+                r,
+                "openbank.anacredit.return.exclusions",
+                "Instruments dropped by the AnaCredit eligibility policy",
+            ).record(exclusionCount.toDouble())
+        }
+    }
+
+    override fun loanStageEvent(outcome: LoanStageEventOutcome) {
+        registry?.let { r ->
+            Counter.builder("openbank.anacredit.loan_stage.events")
+                .tag("service", SERVICE)
+                .tag("outcome", outcome.name.lowercase())
+                .description("Consumed lending loan.stage_changed events by outcome")
+                .register(r)
+                .increment()
+        }
+    }
+
+    private fun summary(registry: MeterRegistry, name: String, description: String): DistributionSummary =
+        DistributionSummary.builder(name)
+            .tag("service", SERVICE)
+            .publishPercentiles(P50, P95, P99)
+            .publishPercentileHistogram()
+            .description(description)
+            .register(registry)
+
+    companion object {
+        private const val SERVICE = "anacredit"
+
+        // The fleet-standard percentile set (libs DomainMetrics publishes the same three).
+        private const val P50 = 0.5
+        private const val P95 = 0.95
+        private const val P99 = 0.99
+    }
+}

--- a/openbank-anacredit-service/src/test/kotlin/com/openbank/anacredit/application/AnaCreditServiceMetricsTest.kt
+++ b/openbank-anacredit-service/src/test/kotlin/com/openbank/anacredit/application/AnaCreditServiceMetricsTest.kt
@@ -1,0 +1,98 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright (c) OpenBank contributors. Licensed under the Apache License, Version 2.0.
+// See LICENSE in the repository root or https://www.apache.org/licenses/LICENSE-2.0 for details.
+package com.openbank.anacredit.application
+
+import com.openbank.anacredit.Fixtures
+import com.openbank.anacredit.application.port.`in`.RegisterExposureCommand
+import com.openbank.anacredit.application.port.out.CreditExposureRepository
+import com.openbank.anacredit.domain.model.CounterpartyType
+import com.openbank.anacredit.domain.model.CreditExposure
+import com.openbank.anacredit.domain.model.InstrumentType
+import com.openbank.anacredit.infrastructure.observability.AnaCreditMetricsAdapter
+import io.micrometer.core.instrument.simple.SimpleMeterRegistry
+import io.mockk.coEvery
+import io.mockk.mockk
+import kotlinx.coroutines.runBlocking
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.Test
+import java.math.BigDecimal
+import java.time.LocalDate
+
+/**
+ * Drives the real [AnaCreditMetricsAdapter] over a [SimpleMeterRegistry] rather than a mock port, so
+ * the assertions fail if [AnaCreditService] stops calling the meters — a metrics test that passes
+ * without the instrumentation guards nothing.
+ */
+class AnaCreditServiceMetricsTest {
+
+    private val exposures = mockk<CreditExposureRepository>()
+    private val registry = SimpleMeterRegistry()
+    private val service = AnaCreditService(exposures, AnaCreditMetricsAdapter(registry))
+
+    @Test
+    fun `registering an exposure increments the intake counter with the stored instrument's tags`(): Unit =
+        runBlocking {
+            coEvery { exposures.upsert(any()) } answers { firstArg() }
+
+            service.register(command(instrumentType = InstrumentType.LOAN, currency = "CZK"))
+
+            assertThat(
+                registry.get("openbank.anacredit.exposures.registered")
+                    .tag("service", "anacredit")
+                    .tag("instrument_type", "LOAN")
+                    .tag("currency", "CZK")
+                    .tag("defaulted", "false")
+                    .counter().count(),
+            ).isEqualTo(1.0)
+        }
+
+    @Test
+    fun `rendering a return publishes the row count and the exclusion count actually produced`(): Unit = runBlocking {
+        // One reportable exposure (EUR 40 000 commitment, over the AnaCredit threshold) and one
+        // dropped by the eligibility policy (a natural-person debtor is out of scope).
+        coEvery { exposures.listAll() } returns listOf(
+            Fixtures.exposure(instrumentId = "OD-0001"),
+            Fixtures.exposure(
+                instrumentId = "OD-0002",
+                debtorId = "NP-JOE",
+                debtorType = CounterpartyType.NATURAL_PERSON,
+            ),
+        )
+
+        val report = service.build(LocalDate.parse("2026-06-30"))
+
+        assertThat(report.records).hasSize(1)
+        assertThat(report.exclusions).hasSize(1)
+        assertThat(registry.get("openbank.anacredit.return.build.duration").timer().count()).isEqualTo(1L)
+        assertThat(registry.get("openbank.anacredit.return.records").summary().totalAmount()).isEqualTo(1.0)
+        assertThat(registry.get("openbank.anacredit.return.exclusions").summary().totalAmount()).isEqualTo(1.0)
+    }
+
+    @Test
+    fun `an empty book still publishes a return with zero rows rather than no sample at all`(): Unit = runBlocking {
+        // The under-reporting signal only works if a zero-row return is *sampled*: a missing series
+        // is indistinguishable from a healthy idle service on a Prometheus dashboard.
+        coEvery { exposures.listAll() } returns emptyList<CreditExposure>()
+
+        service.build(LocalDate.parse("2026-06-30"))
+
+        val records = registry.get("openbank.anacredit.return.records").summary()
+        assertThat(records.count()).isEqualTo(1L)
+        assertThat(records.totalAmount()).isEqualTo(0.0)
+    }
+
+    private fun command(instrumentType: InstrumentType, currency: String) = RegisterExposureCommand(
+        instrumentId = "OD-9001",
+        debtorId = "LE-ACME",
+        debtorType = CounterpartyType.LEGAL_ENTITY,
+        instrumentType = instrumentType,
+        currency = currency,
+        committedAmount = BigDecimal("40000.00"),
+        drawnAmount = BigDecimal("12000.00"),
+        committedAmountEur = BigDecimal("40000.00"),
+        arrearsAmount = BigDecimal.ZERO,
+        defaulted = false,
+        originationDate = LocalDate.parse("2025-06-01"),
+    )
+}

--- a/openbank-anacredit-service/src/test/kotlin/com/openbank/anacredit/infrastructure/kafka/LoanStageEventConsumerTest.kt
+++ b/openbank-anacredit-service/src/test/kotlin/com/openbank/anacredit/infrastructure/kafka/LoanStageEventConsumerTest.kt
@@ -7,10 +7,13 @@ package com.openbank.anacredit.infrastructure.kafka
 import com.fasterxml.jackson.databind.ObjectMapper
 import com.openbank.anacredit.application.port.out.LoanStageProjectionRepository
 import com.openbank.anacredit.domain.model.LoanStageProjection
+import com.openbank.anacredit.infrastructure.observability.AnaCreditMetricsAdapter
+import io.micrometer.core.instrument.simple.SimpleMeterRegistry
 import io.mockk.coEvery
 import io.mockk.coVerify
 import io.mockk.mockk
 import kotlinx.coroutines.runBlocking
+import org.assertj.core.api.Assertions.assertThat
 import org.junit.jupiter.api.Test
 import java.time.Clock
 import java.time.Instant
@@ -22,10 +25,15 @@ class LoanStageEventConsumerTest {
 
     private val projections = mockk<LoanStageProjectionRepository>()
     private val fixedClock = Clock.fixed(Instant.parse("2026-07-01T00:00:00Z"), ZoneOffset.UTC)
+
+    // The REAL metrics adapter over a SimpleMeterRegistry, not a mock: the outcome assertions below
+    // then fail if the consumer stops reporting an outcome on any of its acked-and-dropped branches.
+    private val registry = SimpleMeterRegistry()
     private val consumer = LoanStageEventConsumer().also {
         it.projections = projections
         it.objectMapper = ObjectMapper()
         it.clock = fixedClock
+        it.metrics = AnaCreditMetricsAdapter(registry)
     }
 
     @Test
@@ -112,4 +120,32 @@ class LoanStageEventConsumerTest {
             )
         }
     }
+
+    @Test
+    fun `every terminal branch reports its outcome to the metrics port`(): Unit = runBlocking {
+        val loanId = UUID.randomUUID()
+        coEvery { projections.applyIfNewer(any()) } returns true andThen false andThenThrows RuntimeException("db down")
+        val applied = """{"eventType":"loan.stage_changed","loanId":"$loanId","newStage":"STAGE_2",""" +
+            """"daysPastDue":40,"asOf":"2026-07-01"}"""
+
+        consumer.consume(applied) // -> applied
+        consumer.consume(applied) // -> stale (applyIfNewer answers false)
+        consumer.consume(applied) // -> apply_error (the repository throws)
+        consumer.consume("""{"eventType":"loan.provisioned","loanId":"$loanId"}""") // -> ignored
+        consumer.consume("not json") // -> parse_error
+        consumer.consume("""{"eventType":"loan.stage_changed"}""") // -> malformed (no loanId)
+        consumer.consume("""{"eventType":"loan.stage_changed","loanId":"$loanId"}""") // -> malformed (no newStage)
+
+        assertThat(outcome("applied")).isEqualTo(1.0)
+        assertThat(outcome("stale")).isEqualTo(1.0)
+        assertThat(outcome("apply_error")).isEqualTo(1.0)
+        assertThat(outcome("ignored")).isEqualTo(1.0)
+        assertThat(outcome("parse_error")).isEqualTo(1.0)
+        assertThat(outcome("malformed")).isEqualTo(2.0)
+    }
+
+    private fun outcome(value: String): Double = registry.get("openbank.anacredit.loan_stage.events")
+        .tag("service", "anacredit")
+        .tag("outcome", value)
+        .counter().count()
 }

--- a/openbank-anacredit-service/src/test/kotlin/com/openbank/anacredit/infrastructure/observability/AnaCreditMetricsAdapterTest.kt
+++ b/openbank-anacredit-service/src/test/kotlin/com/openbank/anacredit/infrastructure/observability/AnaCreditMetricsAdapterTest.kt
@@ -1,0 +1,77 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright (c) OpenBank contributors. Licensed under the Apache License, Version 2.0.
+// See LICENSE in the repository root or https://www.apache.org/licenses/LICENSE-2.0 for details.
+package com.openbank.anacredit.infrastructure.observability
+
+import com.openbank.anacredit.application.port.out.LoanStageEventOutcome
+import com.openbank.anacredit.domain.model.InstrumentType
+import io.micrometer.core.instrument.simple.SimpleMeterRegistry
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.Test
+import java.time.Duration
+
+class AnaCreditMetricsAdapterTest {
+
+    private val registry = SimpleMeterRegistry()
+    private val adapter = AnaCreditMetricsAdapter(registry)
+
+    @Test
+    fun `exposure intake increments an instrument-type and currency tagged counter`() {
+        adapter.exposureRegistered(InstrumentType.OVERDRAFT, "EUR", defaulted = false)
+        adapter.exposureRegistered(InstrumentType.OVERDRAFT, "EUR", defaulted = false)
+        adapter.exposureRegistered(InstrumentType.LOAN, "CZK", defaulted = true)
+
+        assertThat(
+            registry.get("openbank.anacredit.exposures.registered")
+                .tag("service", "anacredit")
+                .tag("instrument_type", "OVERDRAFT")
+                .tag("currency", "EUR")
+                .tag("defaulted", "false")
+                .counter().count(),
+        ).isEqualTo(2.0)
+        assertThat(
+            registry.get("openbank.anacredit.exposures.registered")
+                .tag("instrument_type", "LOAN")
+                .tag("currency", "CZK")
+                .tag("defaulted", "true")
+                .counter().count(),
+        ).isEqualTo(1.0)
+    }
+
+    @Test
+    fun `a rendered return publishes its duration, row count and exclusion count`() {
+        adapter.returnBuilt(recordCount = 7, exclusionCount = 2, duration = Duration.ofMillis(120))
+
+        assertThat(registry.get("openbank.anacredit.return.build.duration").timer().count()).isEqualTo(1L)
+        val records = registry.get("openbank.anacredit.return.records").summary()
+        assertThat(records.count()).isEqualTo(1L)
+        assertThat(records.totalAmount()).isEqualTo(7.0)
+        val exclusions = registry.get("openbank.anacredit.return.exclusions").summary()
+        assertThat(exclusions.totalAmount()).isEqualTo(2.0)
+    }
+
+    @Test
+    fun `each loan-stage outcome gets its own lower-cased tag value`() {
+        adapter.loanStageEvent(LoanStageEventOutcome.APPLIED)
+        adapter.loanStageEvent(LoanStageEventOutcome.PARSE_ERROR)
+        adapter.loanStageEvent(LoanStageEventOutcome.PARSE_ERROR)
+
+        assertThat(counter("applied")).isEqualTo(1.0)
+        assertThat(counter("parse_error")).isEqualTo(2.0)
+    }
+
+    @Test
+    fun `is a silent no-op when no meter registry is resolvable`() {
+        // Slim slices without a Prometheus registry must not crash the feed.
+        val noRegistry = AnaCreditMetricsAdapter(null)
+
+        noRegistry.exposureRegistered(InstrumentType.LOAN, "EUR", defaulted = false)
+        noRegistry.returnBuilt(1, 0, Duration.ZERO)
+        noRegistry.loanStageEvent(LoanStageEventOutcome.APPLIED)
+    }
+
+    private fun counter(outcome: String): Double = registry.get("openbank.anacredit.loan_stage.events")
+        .tag("service", "anacredit")
+        .tag("outcome", outcome)
+        .counter().count()
+}


### PR DESCRIPTION
## Summary

`openbank-anacredit-service` emitted only default JVM/HTTP metrics — zero domain
instrumentation — so prod-readiness C8 (Observability) scored it 0/1 and, more to the point,
both of its real failure modes were invisible. This adds an `AnaCreditMetricsPort` and a
Micrometer adapter, following the service-local pattern already used by fraud-service and
agent-service.

## Type of change

- [x] feat (new functionality)

## Linked issues

Refs #2255

## Changes

**Meters added, and why these:**

| Meter | Why an operator needs it |
|---|---|
| `openbank_anacredit_exposures_registered_total{instrument_type,currency,defaulted}` | AnaCredit is derive-only: it posts no money and emits no events, so **nothing downstream complains when intake stalls**. The return is then assembled from stale data and is still perfectly well-formed. A flat line here during a reporting month is the only signal. |
| `openbank_anacredit_return_build_duration_seconds` | Render latency over the whole book at the monthly reporting cutoff — the one slow path in the service. |
| `openbank_anacredit_return_records` / `openbank_anacredit_return_exclusions` (histograms) | Under-reporting shows up here and nowhere else. A return missing half the book is still valid JSON with a 200 response. `records` collapsing or `exclusions` spiking is the alarm. A zero-row return is deliberately still **sampled** — a missing series is indistinguishable from a healthy idle service on a dashboard. |
| `openbank_anacredit_loan_stage_events_total{outcome}` | The lending `loan.stage_changed` consumer is poison-pill safe *by design*: a malformed or foreign event is logged and **acked**. So a broken producer or a wedged projection write freezes the IFRS-9 stage projection with nothing but a log line. `outcome=parse_error\|malformed\|apply_error` is exactly that acked-and-dropped population. |

**Code:**

- new `application/port/out/AnaCreditMetricsPort.kt` (+ `LoanStageEventOutcome` enum — a bounded tag set)
- new `infrastructure/observability/AnaCreditMetricsAdapter.kt` — service-local `MeterRegistry`, null-safe
  via `Instance<MeterRegistry>` exactly like libs `DomainMetrics`, with the explicit `@Inject` constructor
  ArC needs to register the bean
- `AnaCreditService` reports intake + the rendered return's shape
- `LoanStageEventConsumer` reports a terminal outcome on **every** branch; the projection write moved
  into a private `apply()` to keep `consume` under detekt's `LongMethod` threshold

## Definition of Done

- [x] Hexagonal layering preserved (domain has zero framework imports; the port is in `application/port/out`, Micrometer only in `infrastructure/observability`).
- [x] Unit tests added/updated.
- [x] Integration tests added/updated (if service boundary involved). — existing `@QuarkusTest`s exercise the CDI wiring; `quarkusBuild` validates ArC.
- [x] Contract tests updated (if public API changed). — n/a, no API change
- [x] `detekt ktlintCheck koverVerify build` passes (module-scoped, see below).
- [x] No new lint warnings.
- [x] OpenAPI spec regenerated (if REST API changed). — n/a
- [x] Flyway migration added + rollback note (if DB changed). — n/a
- [x] Avro schema versioned backward-compatibly (if event changed). — n/a
- [x] Docs updated — KDoc on the port/adapter states what each meter is for.

### The tests were falsified, not just run

A metrics test that passes without the metric guards nothing, so the tests drive the **real**
adapter over a `SimpleMeterRegistry` rather than a mock port. Verified by deleting
`metrics.exposureRegistered(...)` from `AnaCreditService` and
`metrics.loanStageEvent(APPLY_ERROR)` from the consumer:

```
AnaCreditServiceMetricsTest > registering an exposure increments the intake counter ... FAILED
    io.micrometer.core.instrument.search.MeterNotFoundException
LoanStageEventConsumerTest > every terminal branch reports its outcome to the metrics port() FAILED
    io.micrometer.core.instrument.search.MeterNotFoundException
```

Restored → `BUILD SUCCESSFUL`; full module run: **43 tests, 0 failures, 0 errors, 0 skipped**
(`:openbank-anacredit-service:build :quarkusBuild :detekt :ktlintCheck :koverVerify`).

## Security checklist

- [x] No secrets, tokens, passwords, or PII in code, config, tests, logs. — tags are a bounded set (instrument type, ISO currency, boolean, outcome enum); no instrument id, debtor id or amount is ever a tag (cardinality + PII contract).
- [x] No new `@Suppress` without justification. — the one `@Suppress("TooGenericExceptionCaught")` moved with the code it guards into `apply()`, with the reason inline.
- [x] No new third-party dependency. — `quarkus-micrometer-registry-prometheus` was already on the classpath.
- [x] Auth / crypto / payment code changed? — no
- [x] PII path changed? — no
- [x] Cardholder data path changed? — no

## Compliance impact

- [x] CNB reporting — this is the ECB AnaCredit (Reg. (EU) 2016/867) credit-dataset feed; the return-shape histograms are what make an under-reported submission detectable.
