### PR TITLE
feat(vop): instrument verification outcomes, no-data reasons and rate-limit decisions

### DIFF
--- a/openbank-vop-service/src/main/kotlin/com/openbank/vop/application/port/out/VopMetricsPort.kt
+++ b/openbank-vop-service/src/main/kotlin/com/openbank/vop/application/port/out/VopMetricsPort.kt
@@ -1,0 +1,63 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright (c) OpenBank contributors. Licensed under the Apache License, Version 2.0.
+// See LICENSE in the repository root or https://www.apache.org/licenses/LICENSE-2.0 for details.
+
+package com.openbank.vop.application.port.out
+
+import com.openbank.vop.domain.model.VopVerification
+import java.time.Duration
+
+/**
+ * Outbound observability port (ADR-0002 / ADR-0077 Tier C) for Verification of Payee (ADR-0171).
+ *
+ * VoP's two load-bearing behaviours are both **deliberately silent**, and that is why they need
+ * meters rather than log lines:
+ *
+ *  - the service **fails open** (ADR-0171 §3): a down account-service or party-service yields
+ *    `NO_DATA / LOOKUP_UNAVAILABLE` and a WARN, and the payment proceeds. From the outside a
+ *    total lookup outage is indistinguishable from a bank whose customers all pay strangers —
+ *    `no_data{reason=lookup_unavailable}` is the difference.
+ *  - the rate limiter **fails closed** (threat model §4.1): if Valkey is unreachable every
+ *    requester is rejected, which is correct and also invisible. `rate_limit{outcome=throttled}`
+ *    is additionally the only way to see enumeration pressure at all, and the ADR's own note on
+ *    the 60/min default says to "tune from the outcome metrics" — metrics that did not exist.
+ *
+ * Kept as a port rather than a direct `MeterRegistry` dependency so the application layer stays
+ * free of the metrics framework, and so the counters are exercised through the real adapter (over
+ * a `SimpleMeterRegistry`) in unit tests.
+ *
+ * Implemented by [com.openbank.vop.infrastructure.observability.VopMetricsAdapter].
+ */
+interface VopMetricsPort {
+
+    /**
+     * Record one completed verification: its route, its outcome (and NO_DATA reason), and the
+     * end-to-end latency the caller waited — IPR Art. 5c puts VoP on the payment-initiation path,
+     * so its latency is the payer's latency.
+     */
+    fun verificationCompleted(route: VopRoute, verification: VopVerification, duration: Duration)
+
+    /** Record one rate-limit decision on the verify endpoint. */
+    fun rateLimitDecision(outcome: VopRateLimitOutcome)
+}
+
+/** Which of the two ADR-0171 §4 routes answered a verification. A bounded set — safe as a tag. */
+enum class VopRoute {
+    /** Our own IBAN space: resolved locally via account-service → party-service. */
+    DOMESTIC,
+
+    /** Someone else's IBAN: handed to the EPC VoP scheme port. */
+    EXTERNAL,
+}
+
+/** Outcome of the per-requester rate-limit check. A bounded set — safe as a tag. */
+enum class VopRateLimitOutcome {
+    /** Under the limit; the request proceeded. */
+    ALLOWED,
+
+    /** Over the limit; rejected with 429. Sustained non-zero is enumeration pressure. */
+    THROTTLED,
+
+    /** The Valkey window was unreachable, so the request was rejected fail-closed. */
+    STORE_UNAVAILABLE,
+}

--- a/openbank-vop-service/src/main/kotlin/com/openbank/vop/application/usecase/VopVerificationService.kt
+++ b/openbank-vop-service/src/main/kotlin/com/openbank/vop/application/usecase/VopVerificationService.kt
@@ -9,6 +9,8 @@ import com.openbank.vop.application.port.`in`.VerifyPayeeCommand
 import com.openbank.vop.application.port.`in`.VerifyPayeeUseCase
 import com.openbank.vop.application.port.out.AccountHolderNameLookupPort
 import com.openbank.vop.application.port.out.NameLookupUnavailableException
+import com.openbank.vop.application.port.out.VopMetricsPort
+import com.openbank.vop.application.port.out.VopRoute
 import com.openbank.vop.application.port.out.VopSchemeRoutingPort
 import com.openbank.vop.application.port.out.VopVerificationRecordPort
 import com.openbank.vop.domain.match.VopNameMatchPolicy
@@ -21,6 +23,7 @@ import org.eclipse.microprofile.config.inject.ConfigProperty
 import org.jboss.logging.Logger
 import java.security.MessageDigest
 import java.time.Clock
+import java.time.Duration
 import java.time.Instant
 
 /**
@@ -37,12 +40,17 @@ import java.time.Instant
  * closed: a sanctions miss is a legal breach, whereas refusing every payment during a VoP outage
  * would itself breach the IPR execution-time obligation. Do not "fix" this to match its
  * neighbour.
+ *
+ * "Loudly" is what [VopMetricsPort] is for. Failing open means a total downstream outage looks, from
+ * every angle except the meters, exactly like a bank whose customers all pay strangers: the caller
+ * gets a well-formed `NO_DATA`, the payment proceeds, and the only trace is a WARN line.
  */
 @ApplicationScoped
 class VopVerificationService(
     private val nameLookup: AccountHolderNameLookupPort,
     private val schemeRouting: VopSchemeRoutingPort,
     private val records: VopVerificationRecordPort,
+    private val metrics: VopMetricsPort,
     private val clock: Clock,
     @ConfigProperty(name = "openbank.vop.domestic-iban-prefixes", defaultValue = "CZ")
     private val domesticIbanPrefixes: List<String>,
@@ -55,8 +63,21 @@ class VopVerificationService(
 
     override fun verify(command: VerifyPayeeCommand): Uni<VopVerification> {
         val iban = Iban.of(command.iban)
-        val route = if (isDomestic(iban)) resolveLocally(iban, command.payeeName) else resolveExternally(iban, command)
-        return route.call { verification -> record(iban, command, verification) }
+        val route = if (isDomestic(iban)) VopRoute.DOMESTIC else VopRoute.EXTERNAL
+        // `deferred` so the stopwatch starts on SUBSCRIPTION, not on assembly: a Uni built here and
+        // subscribed later would otherwise be timed from the wrong instant.
+        return Uni.createFrom().deferred {
+            val startedAt = System.nanoTime()
+            val resolved = when (route) {
+                VopRoute.DOMESTIC -> resolveLocally(iban, command.payeeName)
+                VopRoute.EXTERNAL -> resolveExternally(iban, command)
+            }
+            resolved
+                .call { verification -> record(iban, command, verification) }
+                .onItem().invoke { verification ->
+                    metrics.verificationCompleted(route, verification, Duration.ofNanos(System.nanoTime() - startedAt))
+                }
+        }
     }
 
     private fun resolveLocally(iban: Iban, suppliedName: String): Uni<VopVerification> =

--- a/openbank-vop-service/src/main/kotlin/com/openbank/vop/infrastructure/observability/VopMetricsAdapter.kt
+++ b/openbank-vop-service/src/main/kotlin/com/openbank/vop/infrastructure/observability/VopMetricsAdapter.kt
@@ -1,0 +1,101 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright (c) OpenBank contributors. Licensed under the Apache License, Version 2.0.
+// See LICENSE in the repository root or https://www.apache.org/licenses/LICENSE-2.0 for details.
+
+package com.openbank.vop.infrastructure.observability
+
+import com.openbank.vop.application.port.out.VopMetricsPort
+import com.openbank.vop.application.port.out.VopRateLimitOutcome
+import com.openbank.vop.application.port.out.VopRoute
+import com.openbank.vop.domain.model.VopOutcome
+import com.openbank.vop.domain.model.VopVerification
+import io.micrometer.core.instrument.Counter
+import io.micrometer.core.instrument.MeterRegistry
+import io.micrometer.core.instrument.Timer
+import jakarta.enterprise.context.ApplicationScoped
+import jakarta.enterprise.inject.Instance
+import jakarta.inject.Inject
+import java.time.Duration
+
+/**
+ * Micrometer adapter for [VopMetricsPort] (ADR-0077 Tier C). Emits, all tagged `service="vop"`:
+ *
+ *  - `openbank_vop_verifications_total{route,outcome}` — the verification mix. The MATCH:NO_MATCH
+ *    ratio is also the anti-enumeration signal: a caller driving NO_MATCH is guessing names.
+ *  - `openbank_vop_no_data_total{route,reason}` — why we could not answer. `reason=lookup_unavailable`
+ *    is a live account-service/party-service outage that VoP is deliberately hiding from the payer
+ *    by failing open (ADR-0171 §3); nothing else distinguishes it from normal traffic.
+ *  - `openbank_vop_verification_duration_seconds{route}` — the latency the payer waits, on the
+ *    payment-initiation path (IPR Art. 5c).
+ *  - `openbank_vop_rate_limit_decisions_total{outcome}` — the enumeration control's own outcomes.
+ *    `throttled` is enumeration pressure; `store_unavailable` is the fail-closed Valkey path, which
+ *    rejects every requester and previously produced nothing but an ERROR log line.
+ *
+ * The NO_DATA reason is a **second series**, not a tag on `verifications_total`: it is populated for
+ * exactly one of the four outcomes, so folding it in would put a `reason="none"` label on every
+ * MATCH and make the common query carry a label it never varies over.
+ *
+ * Service-local `MeterRegistry`, null-safe via [Instance] exactly like libs `DomainMetrics`: a VoP
+ * outcome counter is VoP-specific, so adding it to the shared libs facade would force a fleet-wide
+ * rebuild for a one-service concern.
+ */
+@ApplicationScoped
+class VopMetricsAdapter(private val registry: MeterRegistry?) : VopMetricsPort {
+
+    // CDI constructor: MeterRegistry is optional (absent when no Prometheus registry is on the
+    // classpath, e.g. slim test slices). Without an explicit @Inject ctor, ArC sees two constructors,
+    // registers no bean, and VopVerificationService is left with an unsatisfied dependency at build
+    // time.
+    @Inject
+    constructor(registryInstance: Instance<MeterRegistry>) : this(
+        if (registryInstance.isResolvable) registryInstance.get() else null,
+    )
+
+    override fun verificationCompleted(route: VopRoute, verification: VopVerification, duration: Duration) {
+        val r = registry ?: return
+        Counter.builder("openbank.vop.verifications")
+            .tag("service", SERVICE)
+            .tag("route", route.name.lowercase())
+            .tag("outcome", verification.outcome.name)
+            .description("Completed Verification-of-Payee checks by route and outcome")
+            .register(r)
+            .increment()
+        if (verification.outcome == VopOutcome.NO_DATA) {
+            Counter.builder("openbank.vop.no_data")
+                .tag("service", SERVICE)
+                .tag("route", route.name.lowercase())
+                .tag("reason", verification.noDataReason?.name?.lowercase() ?: "unspecified")
+                .description("Verifications that could not be answered, by reason")
+                .register(r)
+                .increment()
+        }
+        Timer.builder("openbank.vop.verification.duration")
+            .tag("service", SERVICE)
+            .tag("route", route.name.lowercase())
+            .publishPercentiles(P50, P95, P99)
+            .publishPercentileHistogram()
+            .description("End-to-end Verification-of-Payee latency, including the evidence write")
+            .register(r)
+            .record(duration)
+    }
+
+    override fun rateLimitDecision(outcome: VopRateLimitOutcome) {
+        registry?.let { r ->
+            Counter.builder("openbank.vop.rate_limit.decisions")
+                .tag("service", SERVICE)
+                .tag("outcome", outcome.name.lowercase())
+                .description("Per-requester rate-limit decisions on the VoP verify endpoint")
+                .register(r)
+                .increment()
+        }
+    }
+
+    companion object {
+        private const val SERVICE = "vop"
+
+        // The fleet-standard percentile set (libs DomainMetrics publishes the same three).
+        private const val P50 = 0.5
+        private const val P95 = 0.95
+        private const val P99 = 0.99
+    }
+}

--- a/openbank-vop-service/src/main/kotlin/com/openbank/vop/infrastructure/ratelimit/VopRateLimitFilter.kt
+++ b/openbank-vop-service/src/main/kotlin/com/openbank/vop/infrastructure/ratelimit/VopRateLimitFilter.kt
@@ -4,6 +4,8 @@
 
 package com.openbank.vop.infrastructure.ratelimit
 
+import com.openbank.vop.application.port.out.VopMetricsPort
+import com.openbank.vop.application.port.out.VopRateLimitOutcome
 import io.quarkus.logging.Log
 import io.quarkus.security.identity.SecurityIdentity
 import io.smallrye.common.annotation.Blocking
@@ -60,6 +62,9 @@ class VopRateLimitFilter : ContainerRequestFilter {
     @Inject
     lateinit var identity: SecurityIdentity
 
+    @Inject
+    lateinit var metrics: VopMetricsPort
+
     @ConfigProperty(name = "openbank.vop.rate-limit.requests-per-minute", defaultValue = DEFAULT_LIMIT_STR)
     var limitPerMinute: Int = DEFAULT_LIMIT
 
@@ -81,9 +86,10 @@ class VopRateLimitFilter : ContainerRequestFilter {
             return
         }
 
-        val allowed = failClosedOnStoreError(requesterId)
+        val outcome = failClosedOnStoreError(requesterId)
+        metrics.rateLimitDecision(outcome)
 
-        if (!allowed) {
+        if (outcome != VopRateLimitOutcome.ALLOWED) {
             ctx.abortWith(
                 Response.status(HTTP_TOO_MANY_REQUESTS)
                     .header("X-RateLimit-Limit", limitPerMinute)
@@ -105,15 +111,23 @@ class VopRateLimitFilter : ContainerRequestFilter {
      * pool error, and every one of them means the same thing — we cannot prove this caller is
      * under the limit. Narrowing the catch would let an unanticipated client exception escape as a
      * 500 and, worse, skip the limit entirely on the retry path.
+     *
+     * Returns the outcome rather than a boolean so the metric can tell the two rejections apart:
+     * `throttled` is one caller hitting the limit, `store_unavailable` is *every* caller being
+     * rejected because Valkey is down. Both produce a 429 and are indistinguishable on the wire.
      */
     @Suppress("TooGenericExceptionCaught")
-    private fun failClosedOnStoreError(requesterId: String): Boolean = try {
-        rateLimiter.isAllowed(requesterId, limitPerMinute)
+    private fun failClosedOnStoreError(requesterId: String): VopRateLimitOutcome = try {
+        if (rateLimiter.isAllowed(requesterId, limitPerMinute)) {
+            VopRateLimitOutcome.ALLOWED
+        } else {
+            VopRateLimitOutcome.THROTTLED
+        }
     } catch (e: Exception) {
         // Fail closed — see the class doc. A 429 degrades to `no_data` at the caller; it does not
         // block the payment.
         Log.errorf(e, "VoP rate-limit store unavailable; rejecting requester=%s (fail-closed)", requesterId)
-        false
+        VopRateLimitOutcome.STORE_UNAVAILABLE
     }
 
     companion object {

--- a/openbank-vop-service/src/test/kotlin/com/openbank/vop/infrastructure/observability/VopMetricsAdapterTest.kt
+++ b/openbank-vop-service/src/test/kotlin/com/openbank/vop/infrastructure/observability/VopMetricsAdapterTest.kt
@@ -1,0 +1,89 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright (c) OpenBank contributors. Licensed under the Apache License, Version 2.0.
+// See LICENSE in the repository root or https://www.apache.org/licenses/LICENSE-2.0 for details.
+
+package com.openbank.vop.infrastructure.observability
+
+import com.openbank.vop.application.port.out.VopRateLimitOutcome
+import com.openbank.vop.application.port.out.VopRoute
+import com.openbank.vop.domain.model.VopNoDataReason
+import com.openbank.vop.domain.model.VopOutcome
+import com.openbank.vop.domain.model.VopVerification
+import io.micrometer.core.instrument.simple.SimpleMeterRegistry
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.Test
+import java.time.Duration
+import java.time.Instant
+
+class VopMetricsAdapterTest {
+
+    private val registry = SimpleMeterRegistry()
+    private val adapter = VopMetricsAdapter(registry)
+    private val verifiedAt = Instant.parse("2026-07-25T10:00:00Z")
+
+    @Test
+    fun `a NO_DATA verification publishes both the outcome counter and the reason counter`() {
+        adapter.verificationCompleted(
+            VopRoute.EXTERNAL,
+            VopVerification(
+                outcome = VopOutcome.NO_DATA,
+                noDataReason = VopNoDataReason.NO_SCHEME_CONNECTIVITY,
+                verifiedAt = verifiedAt,
+            ),
+            Duration.ofMillis(42),
+        )
+
+        assertThat(
+            registry.get("openbank.vop.verifications")
+                .tag("service", "vop").tag("route", "external").tag("outcome", "NO_DATA")
+                .counter().count(),
+        ).isEqualTo(1.0)
+        assertThat(
+            registry.get("openbank.vop.no_data")
+                .tag("route", "external").tag("reason", "no_scheme_connectivity")
+                .counter().count(),
+        ).isEqualTo(1.0)
+        assertThat(
+            registry.get("openbank.vop.verification.duration").tag("route", "external").timer().count(),
+        ).isEqualTo(1L)
+    }
+
+    @Test
+    fun `a non-NO_DATA outcome publishes no reason series`() {
+        adapter.verificationCompleted(
+            VopRoute.DOMESTIC,
+            VopVerification(outcome = VopOutcome.MATCH, verifiedAt = verifiedAt),
+            Duration.ofMillis(7),
+        )
+
+        assertThat(registry.find("openbank.vop.no_data").counters()).isEmpty()
+    }
+
+    @Test
+    fun `each rate-limit outcome gets its own lower-cased tag value`() {
+        adapter.rateLimitDecision(VopRateLimitOutcome.ALLOWED)
+        adapter.rateLimitDecision(VopRateLimitOutcome.STORE_UNAVAILABLE)
+        adapter.rateLimitDecision(VopRateLimitOutcome.STORE_UNAVAILABLE)
+
+        assertThat(decisions("allowed")).isEqualTo(1.0)
+        assertThat(decisions("store_unavailable")).isEqualTo(2.0)
+    }
+
+    @Test
+    fun `is a silent no-op when no meter registry is resolvable`() {
+        // Slim slices without a Prometheus registry must not crash a verification.
+        val noRegistry = VopMetricsAdapter(null)
+
+        noRegistry.verificationCompleted(
+            VopRoute.DOMESTIC,
+            VopVerification(outcome = VopOutcome.MATCH, verifiedAt = verifiedAt),
+            Duration.ZERO,
+        )
+        noRegistry.rateLimitDecision(VopRateLimitOutcome.THROTTLED)
+    }
+
+    private fun decisions(outcome: String): Double = registry.get("openbank.vop.rate_limit.decisions")
+        .tag("service", "vop")
+        .tag("outcome", outcome)
+        .counter().count()
+}

--- a/openbank-vop-service/src/test/kotlin/com/openbank/vop/ratelimit/VopRateLimitFilterTest.kt
+++ b/openbank-vop-service/src/test/kotlin/com/openbank/vop/ratelimit/VopRateLimitFilterTest.kt
@@ -4,8 +4,10 @@
 
 package com.openbank.vop.ratelimit
 
+import com.openbank.vop.infrastructure.observability.VopMetricsAdapter
 import com.openbank.vop.infrastructure.ratelimit.VopRateLimitFilter
 import com.openbank.vop.infrastructure.ratelimit.VopRateLimiter
+import io.micrometer.core.instrument.simple.SimpleMeterRegistry
 import io.mockk.every
 import io.mockk.mockk
 import io.mockk.slot
@@ -23,9 +25,14 @@ class VopRateLimitFilterTest {
     private val limiter = mockk<VopRateLimiter>()
     private val identity = mockk<SecurityIdentity>()
 
+    // The REAL metrics adapter over a SimpleMeterRegistry, not a mock port: the outcome assertions
+    // below then fail if the filter stops reporting a decision.
+    private val registry = SimpleMeterRegistry()
+
     private fun filter(enabled: Boolean = true, limit: Int = 60) = VopRateLimitFilter().apply {
         rateLimiter = limiter
         this.identity = this@VopRateLimitFilterTest.identity
+        metrics = VopMetricsAdapter(registry)
         limitPerMinute = limit
         this.enabled = enabled
     }
@@ -113,4 +120,41 @@ class VopRateLimitFilterTest {
         verify(exactly = 0) { limiter.isAllowed(any(), any()) }
         verify(exactly = 0) { ctx.abortWith(any()) }
     }
+
+    @Test
+    fun `a throttled requester and an unreachable store are counted as DIFFERENT outcomes`() {
+        // Both answer 429 and are indistinguishable on the wire, but they mean opposite things:
+        // `throttled` is one caller enumerating, `store_unavailable` is every caller being rejected
+        // because Valkey is down. Collapsing them into one counter would hide a fleet-wide outage
+        // inside what looks like healthy enumeration defence.
+        principal("enumerator")
+        every { limiter.isAllowed("enumerator", 60) } returns true andThen false andThenThrows
+            RuntimeException("valkey unreachable")
+        val f = filter()
+
+        f.filter(context())
+        f.filter(context())
+        f.filter(context())
+
+        assertThat(decisions("allowed")).isEqualTo(1.0)
+        assertThat(decisions("throttled")).isEqualTo(1.0)
+        assertThat(decisions("store_unavailable")).isEqualTo(1.0)
+    }
+
+    @Test
+    fun `a request that never reaches the limiter records no decision`() {
+        // An unauthenticated or management request consumes no window slot, so it must not show up
+        // as `allowed` either — that would dilute the very ratio the limit is tuned from.
+        principal(null)
+
+        filter().filter(context())
+        filter().filter(context(path = "/q/health/ready"))
+
+        assertThat(registry.find("openbank.vop.rate_limit.decisions").counters()).isEmpty()
+    }
+
+    private fun decisions(outcome: String): Double = registry.get("openbank.vop.rate_limit.decisions")
+        .tag("service", "vop")
+        .tag("outcome", outcome)
+        .counter().count()
 }

--- a/openbank-vop-service/src/test/kotlin/com/openbank/vop/usecase/VopVerificationServiceTest.kt
+++ b/openbank-vop-service/src/test/kotlin/com/openbank/vop/usecase/VopVerificationServiceTest.kt
@@ -13,6 +13,8 @@ import com.openbank.vop.application.usecase.VopVerificationService
 import com.openbank.vop.domain.model.VopNoDataReason
 import com.openbank.vop.domain.model.VopOutcome
 import com.openbank.vop.domain.model.VopVerification
+import com.openbank.vop.infrastructure.observability.VopMetricsAdapter
+import io.micrometer.core.instrument.simple.SimpleMeterRegistry
 import io.mockk.every
 import io.mockk.mockk
 import io.mockk.slot
@@ -44,10 +46,15 @@ class VopVerificationServiceTest {
         every { records.record(any(), any(), any(), any()) } returns Uni.createFrom().voidItem()
     }
 
+    // The REAL metrics adapter over a SimpleMeterRegistry rather than a mock port, so the
+    // instrumentation assertions below fail if the service stops emitting.
+    private val registry = SimpleMeterRegistry()
+
     private fun service() = VopVerificationService(
         nameLookup = nameLookup,
         schemeRouting = schemeRouting,
         records = records,
+        metrics = VopMetricsAdapter(registry),
         clock = clock,
         domesticIbanPrefixes = listOf("CZ"),
         maxEditDistance = 1,
@@ -155,4 +162,71 @@ class VopVerificationServiceTest {
         assertThat(ibanHash.captured).doesNotContain(domesticIban)
         assertThat(nameHash.captured).doesNotContain("Raška")
     }
+
+    @Test
+    fun `a domestic verification is counted by route and outcome, and timed`() {
+        every { nameLookup.lookupHolderName(domesticIban) } returns Uni.createFrom().item("Jiří Raška")
+
+        verify(domesticIban, "Petr Novák")
+
+        assertThat(verifications(route = "domestic", outcome = "NO_MATCH")).isEqualTo(1.0)
+        assertThat(
+            registry.get("openbank.vop.verification.duration")
+                .tag("service", "vop").tag("route", "domestic").timer().count(),
+        ).isEqualTo(1L)
+    }
+
+    @Test
+    fun `a lookup outage is counted as no_data with reason lookup_unavailable, not as a match`() {
+        // The whole point of the meter: failing open (ADR-0171 §3) means a total account-service
+        // outage looks exactly like normal traffic from every angle except this series.
+        every { nameLookup.lookupHolderName(domesticIban) } returns
+            Uni.createFrom().failure(NameLookupUnavailableException(RuntimeException("account-service down")))
+
+        verify(domesticIban, "Jiří Raška")
+
+        assertThat(verifications(route = "domestic", outcome = "NO_DATA")).isEqualTo(1.0)
+        assertThat(
+            registry.get("openbank.vop.no_data")
+                .tag("service", "vop").tag("route", "domestic").tag("reason", "lookup_unavailable")
+                .counter().count(),
+        ).isEqualTo(1.0)
+    }
+
+    @Test
+    fun `an external verification is tagged route=external`() {
+        every { schemeRouting.verifyExternal(externalIban, any()) } returns Uni.createFrom().item(
+            VopVerification(
+                outcome = VopOutcome.NO_DATA,
+                noDataReason = VopNoDataReason.NO_SCHEME_CONNECTIVITY,
+                verifiedAt = clock.instant(),
+            ),
+        )
+
+        verify(externalIban, "Hans Müller")
+
+        assertThat(verifications(route = "external", outcome = "NO_DATA")).isEqualTo(1.0)
+        assertThat(
+            registry.get("openbank.vop.no_data")
+                .tag("route", "external").tag("reason", "no_scheme_connectivity").counter().count(),
+        ).isEqualTo(1.0)
+    }
+
+    @Test
+    fun `a MATCH publishes no no_data series at all`() {
+        // no_data is a second series rather than a tag precisely so a MATCH does not carry a
+        // reason label it never varies over.
+        every { nameLookup.lookupHolderName(domesticIban) } returns Uni.createFrom().item("Jiří Raška")
+
+        verify(domesticIban, "Jiri Raska")
+
+        assertThat(verifications(route = "domestic", outcome = "MATCH")).isEqualTo(1.0)
+        assertThat(registry.find("openbank.vop.no_data").counters()).isEmpty()
+    }
+
+    private fun verifications(route: String, outcome: String): Double = registry.get("openbank.vop.verifications")
+        .tag("service", "vop")
+        .tag("route", route)
+        .tag("outcome", outcome)
+        .counter().count()
 }


### PR DESCRIPTION
## Summary

`openbank-vop-service` emitted only default JVM/HTTP metrics — zero domain instrumentation — so
prod-readiness C8 (Observability) scored it 1/2 and, more importantly, **both** of VoP's
deliberately silent behaviours were unobservable. Adds a `VopMetricsPort` and a Micrometer
adapter, following the service-local pattern already used by fraud-service and agent-service.

## Type of change

- [x] feat (new functionality)

## Linked issues

Refs #2255

## Changes

**Meters added, and why these:**

| Meter | Why an operator needs it |
|---|---|
| `openbank_vop_verifications_total{route,outcome}` | The verification mix. The MATCH:NO_MATCH ratio is *also* the anti-enumeration signal — a caller driving NO_MATCH is guessing names, which is exactly what the threat model (§4.1) says the rate limit exists to bound. |
| `openbank_vop_no_data_total{route,reason}` | **VoP fails open by design** (ADR-0171 §3): a down account-service or party-service returns a well-formed `NO_DATA`, the payment proceeds, and the only trace is a WARN line. From the outside a *total lookup outage* is indistinguishable from a bank whose customers all pay strangers. `reason=lookup_unavailable` is the difference. |
| `openbank_vop_verification_duration_seconds{route}` | VoP sits on the payment-initiation path (IPR Art. 5c), so its latency is the payer's latency. Split by route because the local two-hop lookup and the (currently stubbed) EPC scheme hop have nothing in common. |
| `openbank_vop_rate_limit_decisions_total{outcome}` | The rate limiter **fails closed**: an unreachable Valkey rejects *every* requester with a 429 that is byte-identical to one caller hitting the limit. Previously that produced nothing but an ERROR log. And ADR-0171's own comment on the 60/min default says to "tune from the outcome metrics, not from taste" — those metrics did not exist. |

**Code:**

- new `application/port/out/VopMetricsPort.kt` (+ `VopRoute`, `VopRateLimitOutcome` enums — bounded tag sets)
- new `infrastructure/observability/VopMetricsAdapter.kt` — service-local `MeterRegistry`, null-safe via
  `Instance<MeterRegistry>` like libs `DomainMetrics`, with the explicit `@Inject` constructor ArC needs
- `VopVerificationService.verify` now wraps its chain in `Uni.createFrom().deferred` so the stopwatch
  starts on **subscription**, not on assembly — a Uni built and subscribed later would otherwise be
  timed from the wrong instant
- `VopRateLimitFilter.failClosedOnStoreError` returns the outcome instead of a boolean, so `throttled`
  and `store_unavailable` stay distinguishable; a request that never reaches the limiter
  (unauthenticated, or `/q/*`) records **no** decision, so it cannot dilute the ratio the limit is tuned from

### Design note: `no_data` is a second series, not a tag

The reason is populated for exactly one of the four outcomes. Folding it into
`verifications_total` would put a `reason="none"` label on every MATCH and make the common query
carry a label it never varies over. There is a test asserting a MATCH publishes no `no_data`
series at all.

## Definition of Done

- [x] Hexagonal layering preserved (domain untouched; the port is in `application/port/out`, Micrometer only in `infrastructure/observability`).
- [x] Unit tests added/updated.
- [x] Integration tests added/updated (if service boundary involved). — `VopBootAndDocsIT` exercises the CDI wiring; `quarkusBuild` validates ArC.
- [x] Contract tests updated (if public API changed). — n/a, no API change
- [x] `detekt ktlintCheck koverVerify build` passes (module-scoped, see below).
- [x] No new lint warnings.
- [x] OpenAPI spec regenerated (if REST API changed). — n/a
- [x] Flyway migration added + rollback note (if DB changed). — n/a
- [x] Avro schema versioned backward-compatibly (if event changed). — n/a
- [x] Docs updated — KDoc on the port/adapter states what each meter is for and why.

### The tests were falsified, not just run

The tests drive the **real** adapter over a `SimpleMeterRegistry` rather than a mock port. Verified
by deleting the `metrics.verificationCompleted(...)` hook from `VopVerificationService` and
`metrics.rateLimitDecision(outcome)` from the filter:

```
VopRateLimitFilterTest > a throttled requester and an unreachable store are counted as DIFFERENT outcomes() FAILED
    io.micrometer.core.instrument.search.MeterNotFoundException
VopVerificationServiceTest > an external verification is tagged route=external() FAILED
VopVerificationServiceTest > a lookup outage is counted as no_data with reason lookup_unavailable, not as a match() FAILED
VopVerificationServiceTest > a domestic verification is counted by route and outcome, and timed() FAILED
VopVerificationServiceTest > a MATCH publishes no no_data series at all() FAILED
    io.micrometer.core.instrument.search.MeterNotFoundException
```

Restored → `BUILD SUCCESSFUL`; full module run: **70 tests, 0 failures, 0 errors, 0 skipped**
(`:openbank-vop-service:build :quarkusBuild :detekt :ktlintCheck :koverVerify`).

## Security checklist

- [x] No secrets, tokens, passwords, or PII in code, config, tests, logs. — **this mattered here**: VoP handles IBANs and payee names, and the evidence row hashes both. No IBAN, payee name, holder name, requester id or amount is ever a metric tag; every tag is a closed enum (route, outcome, no-data reason, rate-limit outcome).
- [x] No new `@Suppress` without justification. — the pre-existing `TooGenericExceptionCaught` on `failClosedOnStoreError` is unchanged; its KDoc now also explains the return-type change.
- [x] No new third-party dependency. — `quarkus-micrometer-registry-prometheus` was already on the classpath.
- [x] Auth / crypto / payment code changed? — the rate-limit filter is a security control; its behaviour is unchanged (same 429, same fail-closed), only the internal return type and a counter were added, and the existing fail-closed test still passes.
- [x] PII path changed? — no; nothing new is stored or logged.
- [x] Cardholder data path changed? — no

## Compliance impact

- [x] PSD2 / SCA / RTS — Verification of Payee under the Instant Payments Regulation (Art. 5c); the latency histogram and the fail-open `no_data` counter are the evidence that the obligation is being met rather than silently degraded.
