### PR TITLE
feat(mcp): M2M OIDC client + downstream URLs for consent-validated read ports (ADR-0195 step 3)

### DIFF
--- a/openbank-infra/gitops/components/consent/network-policies.yaml
+++ b/openbank-infra/gitops/components/consent/network-policies.yaml
@@ -47,6 +47,9 @@ spec:
               kubernetes.io/metadata.name: customer-edge
         - namespaceSelector:
             matchLabels:
+              kubernetes.io/metadata.name: platform
+        - namespaceSelector:
+            matchLabels:
               kubernetes.io/metadata.name: psd2
         - namespaceSelector:
             matchLabels:

--- a/openbank-infra/gitops/components/external-secrets/es-mcp-service.yaml
+++ b/openbank-infra/gitops/components/external-secrets/es-mcp-service.yaml
@@ -1,0 +1,33 @@
+# mcp-service secrets from OpenBao → mcp-service-secrets Secret (ADR-0195 step 3).
+#
+# OIDC_CLIENT_SECRET (openbank-services realm client, ADR-0104 D3) — the SAME shared M2M client
+# transaction-service/lending-service/settlement-service/agent-service already use, so
+# RealAccountReadPort's downstream calls (account/balance/transaction/consent-service) authenticate
+# as the identical least-privilege service principal those services already grant reads to. Own KV
+# copy per the fleet convention (each service reads its own <svc>/OIDC_CLIENT_SECRET property, all
+# holding the same underlying client secret value — see agent-service's es-agent-service.yaml).
+#
+# NOT YET SEEDED: this ExternalSecret declares the KV coordinate; an operator must still write the
+# `openbank-services` client's secret value into OpenBao at key `mcp-service`, property
+# `OIDC_CLIENT_SECRET` (manual step, same as agent-service's own bootstrap — mirrors the "Add the
+# key + restart -> real data" comment in agent-service.yaml). Until then the Deployment's
+# `optional: true` secretKeyRef keeps the pod healthy; a downstream M2M call just 401s — no
+# regression, since RealAccountReadPort is still @Vetoed (not CDI-wired) regardless.
+apiVersion: external-secrets.io/v1beta1
+kind: ExternalSecret
+metadata:
+  name: mcp-service-secrets
+  namespace: platform
+spec:
+  refreshInterval: 1h
+  secretStoreRef:
+    name: vault-kv
+    kind: ClusterSecretStore
+  target:
+    name: mcp-service-secrets
+    creationPolicy: Owner
+  data:
+    - secretKey: OIDC_CLIENT_SECRET
+      remoteRef:
+        key: mcp-service
+        property: OIDC_CLIENT_SECRET

--- a/openbank-infra/gitops/components/mcp/mcp-service.yaml
+++ b/openbank-infra/gitops/components/mcp/mcp-service.yaml
@@ -59,6 +59,33 @@ spec:
               value: http://tempo.observability.svc:4317
             - name: OTEL_TRACES_SAMPLER_ARG
               value: "0.1"
+            # ADR-0195 step 3: outbound M2M targets for RealAccountReadPort's downstream calls —
+            # NOT consumed yet (the port is @Vetoed until step 4's CDI cutover), but declared here
+            # now so gen-network-policies.py opens the cross-namespace edges ahead of that cutover
+            # (CLAUDE.md: a URL that lives only in application.yaml gets no NetworkPolicy edge at
+            # all — it must be in this env block, .svc form, for the generator to see it).
+            - name: QUARKUS_REST_CLIENT_ACCOUNT_SERVICE_URL
+              value: http://account-service.accounts.svc:8100
+            - name: QUARKUS_REST_CLIENT_BALANCE_SERVICE_URL
+              value: http://balance-service.balances.svc:8103
+            - name: QUARKUS_REST_CLIENT_TRANSACTION_SERVICE_URL
+              value: http://transaction-service.payments.svc:8102
+            - name: QUARKUS_REST_CLIENT_CONSENT_SERVICE_URL
+              value: http://consent-service.consent.svc:8106
+            # openbank-services client secret (shared M2M identity, ADR-0104 D3 — the SAME client
+            # transaction-service/lending-service/settlement-service/agent-service already use) —
+            # lets RealAccountReadPort's OidcClientRequestReactiveFilter mint a client-credentials
+            # token. Own ExternalSecret (es-mcp-service.yaml), own OpenBao KV copy — the OpenBao
+            # value itself is a manual follow-up (mirrors agent-service's own bootstrap comment).
+            # Optional so the timing gap before that key is seeded doesn't CrashLoop the pod; until
+            # then a downstream M2M call 401s — no worse than the port being unwired, and it isn't
+            # wired yet regardless (still @Vetoed).
+            - name: OIDC_CLIENT_SECRET
+              valueFrom:
+                secretKeyRef:
+                  name: mcp-service-secrets
+                  key: OIDC_CLIENT_SECRET
+                  optional: true
           startupProbe:
             tcpSocket:
               port: management

--- a/openbank-mcp-service/src/main/resources/application.yaml
+++ b/openbank-mcp-service/src/main/resources/application.yaml
@@ -9,8 +9,40 @@ quarkus:
     host: 0.0.0.0
   oidc:
     auth-server-url: ${QUARKUS_OIDC_AUTH_SERVER_URL:http://keycloak.iam.svc:8080/realms/openbank}
-    # Phase 1: OIDC present for health; the OAuth 2.1 -> PSD2-consent binding is phase 2.
+    # Still tenant-disabled (resource-server mode) as of ADR-0195 step 3: enabling this to REQUIRE
+    # an incoming agent token is the step-4 cutover, landed atomically with the McpEndpoint
+    # placeholder removal (#2206 ordering) — flipping it here alone would 401 every current caller
+    # with no real gate benefit yet.
     tenant-enabled: false
+  # Outbound M2M client-credentials auth (ADR-0195 step 3) — mirrors agent-service's oidc-client
+  # exactly: DownstreamClients / ConsentValidateClient (@RegisterProvider
+  # OidcClientRequestReactiveFilter) mint an `openbank-services` token and attach it as a Bearer, so
+  # RealAccountReadPort reaches consent/account/balance/transaction-service as the SAME shared
+  # least-privilege service principal (service-account-openbank-services) those services already
+  # grant reads to (rest.rego: service-consent-m2m / service-account-read / service-balance-read;
+  # transaction-service via base rest.rego operator-read-any, since the shared client's token
+  # carries ROLE_OPERATOR — no NEW rego grant needed for any of the four downstream services).
+  # Not yet consumed: RealAccountReadPort / DownstreamClients / ConsentValidateClient stay @Vetoed
+  # until step 4's CDI cutover, so this config is inert (Quarkus only validates it once injected).
+  oidc-client:
+    auth-server-url: ${QUARKUS_OIDC_AUTH_SERVER_URL:http://keycloak.iam.svc:8080/realms/openbank}
+    client-id: openbank-services
+    credentials:
+      secret: ${OIDC_CLIENT_SECRET:CHANGE_ME_LOCAL_DEV_ONLY}
+    grant:
+      type: client
+    tls:
+      verification: ${OIDC_TLS_VERIFICATION:none}
+  rest-client:
+    # In-cluster ClusterIPs — same targets + ports agent-service's ServiceClients already use.
+    account-service:
+      url: http://localhost:8100
+    balance-service:
+      url: http://localhost:8103
+    transaction-service:
+      url: http://localhost:8102
+    consent-service:
+      url: http://localhost:8106
   smallrye-openapi:
     info-title: OpenBank MCP Server
     info-version: "1.0.0"


### PR DESCRIPTION
## What

Prep step for the ADR-0195 caller-auth cutover. **Config-only** — `RealAccountReadPort` stays `@Vetoed` (unchanged CDI wiring), so this ships **zero behavior change** to the deployed service.

## Changes

- **`application.yaml`** — `oidc-client` block (mirrors agent-service exactly) so `OidcClientRequestReactiveFilter` can mint an `openbank-services` client-credentials token once the real ports are actually injected; `rest-client` config-keys for account/balance/transaction/consent-service.
- **`mcp-service.yaml`** — the four `QUARKUS_REST_CLIENT_*_URL` env vars (in-cluster ClusterIPs, `.svc` form so `gen-network-policies.py` sees them) + `OIDC_CLIENT_SECRET` (`optional: true` — same safety pattern as agent-service, a missing key never crash-loops the pod).
- **`es-mcp-service.yaml`** — mcp-service's own `ExternalSecret` + OpenBao KV coordinate (`mcp-service`/`OIDC_CLIENT_SECRET`), same client-secret **value** as every other M2M caller's own copy (ADR-0104 D3 shared `openbank-services` client, per-service KV entry — `es-agent-service.yaml` is the template). **NOT YET SEEDED** — an operator must still write the actual secret value into OpenBao (manual follow-up, called out in the file's own header).
- **Regenerated `network-policies.yaml`** — exactly one new edge, `platform → consent` (mcp's first caller into that namespace; `accounts`/`balances`/`payments` already allow `platform` from agent-service).

## No new rego grant needed

Verified `service-account-openbank-services` (the shared M2M identity) already has:
- `consent.validate` (`service-consent-m2m` reason, `gen-consent-opa-bundle.sh`)
- `account.read` / `balance.read` (identity-pinned reasons in their own extensions)
- `transaction.read`/`.list` (via base `rest.rego` `operator-read-any` — the shared client's token carries `ROLE_OPERATOR`)

## Why the CDI cutover is deliberately NOT in this PR

Doing it now — before OIDC is enabled for **incoming** calls (still `tenant-enabled: false`) — would make every current placeholder-identity caller (`consentId="none"`) hit `RealAccountReadPort` and fail closed with `"tool error"` instead of the working phase-1 stub response: a real regression to the live sandbox demo. That cutover (`@Vetoed` removal, `StubAccountReadPort` retirement, `McpEndpoint` placeholder removal) lands **atomically with OIDC enable** (step 4) — the point where the placeholder path becomes genuinely unreachable rather than silently broken.

## Verification

`detekt` + `ktlintCheck` + `test` + `quarkusBuild` green. Guard #2230 still passes (no CDI wiring changed).

Refs ADR-0195, #2206, #2230

🤖 Generated with [Claude Code](https://claude.com/claude-code)