### PR TITLE
feat(finrep): instrument template renders, input size, balance and data gaps

### DIFF
--- a/openbank-finrep-service/src/main/kotlin/com/openbank/finrep/application/port/out/FinrepMetricsPort.kt
+++ b/openbank-finrep-service/src/main/kotlin/com/openbank/finrep/application/port/out/FinrepMetricsPort.kt
@@ -1,0 +1,71 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright (c) OpenBank contributors. Licensed under the Apache License, Version 2.0.
+// See LICENSE in the repository root or https://www.apache.org/licenses/LICENSE-2.0 for details.
+
+package com.openbank.finrep.application.port.out
+
+import java.time.Duration
+
+/**
+ * Outbound observability port (ADR-0002 / ADR-0077 Tier C) for the FINREP/COREP rendering service
+ * (ADR-0097).
+ *
+ * finrep-service is a pure derivation over `openbank-ledger-service`'s trial balance: it stores
+ * nothing and emits nothing, so **every** way it can be wrong produces a well-formed 200 response.
+ * That is what these meters exist for:
+ *
+ *  - an empty or truncated trial balance renders a template of honest-looking zeros. `trial_balance
+ *    .lines` collapsing is the only place that shows;
+ *  - a FINREP balance sheet that does not balance ([TemplateRender.balanced] false) is a regulatory
+ *    red flag that nothing currently surfaces — `FinrepTemplate.isBalanced` is computed, serialised,
+ *    and then nobody looks;
+ *  - COREP C 01.00 reports capital-structure rows as flagged data gaps (ADR-0097: never a silent
+ *    gap). The count of gap cells is the measure of how much of the return is not yet real.
+ *
+ * Kept as a port rather than a direct `MeterRegistry` dependency so the application layer stays free
+ * of the metrics framework, and so the counters are exercised through the real adapter (over a
+ * `SimpleMeterRegistry`) in unit tests.
+ *
+ * Implemented by [com.openbank.finrep.infrastructure.observability.FinrepMetricsAdapter].
+ */
+interface FinrepMetricsPort {
+
+    /** Record one successfully rendered template. */
+    fun templateRendered(render: TemplateRender)
+
+    /**
+     * Record one render that produced no template.
+     *
+     * Deliberately takes no template id: the id is a caller-supplied path parameter, so tagging the
+     * failure with it would let any client mint unbounded metric series (the cardinality contract).
+     * The *rendered* counter can safely carry the id because only the closed set the mappers
+     * recognise ever reaches it.
+     */
+    fun templateFailed(framework: RegulatoryFramework, reason: TemplateFailureReason)
+}
+
+/**
+ * One rendered template's shape. `balanced` is null for frameworks that define no balance identity
+ * (COREP), which the adapter renders as a distinct tag value rather than pretending it balanced.
+ */
+data class TemplateRender(
+    val framework: RegulatoryFramework,
+    val templateId: String,
+    val trialBalanceLines: Int,
+    val cells: Int,
+    val dataGapCells: Int,
+    val balanced: Boolean?,
+    val duration: Duration,
+)
+
+/** Which supervisory framework a render belongs to. A bounded set — safe as a tag. */
+enum class RegulatoryFramework { FINREP, COREP }
+
+/** Why a render produced no template. A bounded set — safe as a tag. */
+enum class TemplateFailureReason {
+    /** The requested template id is not one this increment implements. A client error. */
+    UNKNOWN_TEMPLATE,
+
+    /** The ledger trial-balance hop failed, so no report can be produced at all. An outage. */
+    LEDGER_UNAVAILABLE,
+}

--- a/openbank-finrep-service/src/main/kotlin/com/openbank/finrep/application/usecase/CorepService.kt
+++ b/openbank-finrep-service/src/main/kotlin/com/openbank/finrep/application/usecase/CorepService.kt
@@ -6,24 +6,66 @@ package com.openbank.finrep.application.usecase
 
 import com.openbank.finrep.application.port.inbound.CorepUseCase
 import com.openbank.finrep.application.port.inbound.GetCorepTemplateQuery
+import com.openbank.finrep.application.port.out.FinrepMetricsPort
 import com.openbank.finrep.application.port.out.LedgerPort
+import com.openbank.finrep.application.port.out.RegulatoryFramework
+import com.openbank.finrep.application.port.out.TemplateFailureReason
+import com.openbank.finrep.application.port.out.TemplateRender
+import com.openbank.finrep.application.port.out.TrialBalanceLineDto
 import com.openbank.finrep.domain.mapper.C0100Mapper
 import com.openbank.finrep.domain.model.CorepTemplate
 import jakarta.enterprise.context.ApplicationScoped
+import java.time.Duration
+import java.time.LocalDate
 
 /**
  * COREP report generation (ADR-0097 Phase 2, first increment). Only C 01.00 (Own Funds) is
  * implemented; every other COREP template (C 02.00 own funds requirements, C 05.01 transitional
  * provisions, etc.) is out of scope for this increment.
+ *
+ * The rendered return deliberately carries **flagged data gaps** rather than silent omissions
+ * (ADR-0097): capital-structure rows have no GL accounts behind them yet, so they are reported as
+ * explicit zeros marked `isDataGap`. That flag is the honest thing to do and also invisible — the
+ * `data_gap_cells` histogram on [FinrepMetricsPort] is how far the report is from submittable.
  */
 @ApplicationScoped
-class CorepService(private val ledgerPort: LedgerPort) : CorepUseCase {
+class CorepService(private val ledgerPort: LedgerPort, private val metrics: FinrepMetricsPort) : CorepUseCase {
 
     override suspend fun getTemplate(query: GetCorepTemplateQuery): CorepTemplate {
-        val lines = ledgerPort.getTrialBalance(query.asOf)
-        return when (query.templateId) {
+        val startedAt = System.nanoTime()
+        val lines = trialBalance(query.asOf)
+        val template = when (query.templateId) {
             "C_01.00" -> C0100Mapper.map(lines, query.asOf)
-            else -> throw IllegalArgumentException("Unknown or unimplemented COREP template: ${query.templateId}")
+            else -> {
+                metrics.templateFailed(RegulatoryFramework.COREP, TemplateFailureReason.UNKNOWN_TEMPLATE)
+                throw IllegalArgumentException("Unknown or unimplemented COREP template: ${query.templateId}")
+            }
         }
+        metrics.templateRendered(
+            TemplateRender(
+                framework = RegulatoryFramework.COREP,
+                templateId = template.templateId,
+                trialBalanceLines = lines.size,
+                cells = template.cells.size,
+                dataGapCells = template.cells.count { it.isDataGap },
+                // COREP defines no balance-sheet identity, so "balanced" is neither true nor false.
+                balanced = null,
+                duration = Duration.ofNanos(System.nanoTime() - startedAt),
+            ),
+        )
+        return template
+    }
+
+    /**
+     * Count-and-rethrow: an unreachable ledger means no regulatory report can be produced at all,
+     * which the caller must still see as a failure. The catch is deliberately broad because every
+     * REST-client failure mode (connect, timeout, 5xx, deserialisation) means the same thing here.
+     */
+    @Suppress("TooGenericExceptionCaught")
+    private suspend fun trialBalance(asOf: LocalDate): List<TrialBalanceLineDto> = try {
+        ledgerPort.getTrialBalance(asOf)
+    } catch (e: Exception) {
+        metrics.templateFailed(RegulatoryFramework.COREP, TemplateFailureReason.LEDGER_UNAVAILABLE)
+        throw e
     }
 }

--- a/openbank-finrep-service/src/main/kotlin/com/openbank/finrep/application/usecase/FinrepService.kt
+++ b/openbank-finrep-service/src/main/kotlin/com/openbank/finrep/application/usecase/FinrepService.kt
@@ -6,21 +6,65 @@ package com.openbank.finrep.application.usecase
 
 import com.openbank.finrep.application.port.inbound.FinrepUseCase
 import com.openbank.finrep.application.port.inbound.GetFinrepTemplateQuery
+import com.openbank.finrep.application.port.out.FinrepMetricsPort
 import com.openbank.finrep.application.port.out.LedgerPort
+import com.openbank.finrep.application.port.out.RegulatoryFramework
+import com.openbank.finrep.application.port.out.TemplateFailureReason
+import com.openbank.finrep.application.port.out.TemplateRender
+import com.openbank.finrep.application.port.out.TrialBalanceLineDto
 import com.openbank.finrep.domain.mapper.F0101Mapper
 import com.openbank.finrep.domain.mapper.F0200Mapper
 import com.openbank.finrep.domain.model.FinrepTemplate
 import jakarta.enterprise.context.ApplicationScoped
+import java.time.Duration
+import java.time.LocalDate
 
+/**
+ * FINREP template rendering (ADR-0097 Phase 1). A pure derivation over the ledger trial balance — it
+ * stores nothing and emits nothing, so **every** way it can be wrong still produces a well-formed 200
+ * response. [FinrepMetricsPort] is what makes those ways visible: an empty trial balance renders a
+ * template of honest-looking zeros, and a balance sheet that does not balance is currently computed
+ * into `FinrepTemplate.isBalanced`, serialised, and never looked at again.
+ */
 @ApplicationScoped
-class FinrepService(private val ledgerPort: LedgerPort) : FinrepUseCase {
+class FinrepService(private val ledgerPort: LedgerPort, private val metrics: FinrepMetricsPort) : FinrepUseCase {
 
     override suspend fun getTemplate(query: GetFinrepTemplateQuery): FinrepTemplate {
-        val lines = ledgerPort.getTrialBalance(query.asOf)
-        return when (query.templateId) {
+        val startedAt = System.nanoTime()
+        val lines = trialBalance(query.asOf)
+        val template = when (query.templateId) {
             "F01.01" -> F0101Mapper.map(lines, query.asOf)
             "F02.00" -> F0200Mapper.map(lines, query.asOf)
-            else -> throw IllegalArgumentException("Unknown FINREP template: ${query.templateId}")
+            else -> {
+                metrics.templateFailed(RegulatoryFramework.FINREP, TemplateFailureReason.UNKNOWN_TEMPLATE)
+                throw IllegalArgumentException("Unknown FINREP template: ${query.templateId}")
+            }
         }
+        metrics.templateRendered(
+            TemplateRender(
+                framework = RegulatoryFramework.FINREP,
+                templateId = template.templateId,
+                trialBalanceLines = lines.size,
+                cells = template.cells.size,
+                // FINREP cells carry no data-gap flag; only COREP C 01.00 has unavailable inputs today.
+                dataGapCells = 0,
+                balanced = template.isBalanced,
+                duration = Duration.ofNanos(System.nanoTime() - startedAt),
+            ),
+        )
+        return template
+    }
+
+    /**
+     * Count-and-rethrow: an unreachable ledger means no regulatory report can be produced at all,
+     * which the caller must still see as a failure. The catch is deliberately broad because every
+     * REST-client failure mode (connect, timeout, 5xx, deserialisation) means the same thing here.
+     */
+    @Suppress("TooGenericExceptionCaught")
+    private suspend fun trialBalance(asOf: LocalDate): List<TrialBalanceLineDto> = try {
+        ledgerPort.getTrialBalance(asOf)
+    } catch (e: Exception) {
+        metrics.templateFailed(RegulatoryFramework.FINREP, TemplateFailureReason.LEDGER_UNAVAILABLE)
+        throw e
     }
 }

--- a/openbank-finrep-service/src/main/kotlin/com/openbank/finrep/infrastructure/observability/FinrepMetricsAdapter.kt
+++ b/openbank-finrep-service/src/main/kotlin/com/openbank/finrep/infrastructure/observability/FinrepMetricsAdapter.kt
@@ -1,0 +1,117 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright (c) OpenBank contributors. Licensed under the Apache License, Version 2.0.
+// See LICENSE in the repository root or https://www.apache.org/licenses/LICENSE-2.0 for details.
+
+package com.openbank.finrep.infrastructure.observability
+
+import com.openbank.finrep.application.port.out.FinrepMetricsPort
+import com.openbank.finrep.application.port.out.RegulatoryFramework
+import com.openbank.finrep.application.port.out.TemplateFailureReason
+import com.openbank.finrep.application.port.out.TemplateRender
+import io.micrometer.core.instrument.Counter
+import io.micrometer.core.instrument.DistributionSummary
+import io.micrometer.core.instrument.MeterRegistry
+import io.micrometer.core.instrument.Timer
+import jakarta.enterprise.context.ApplicationScoped
+import jakarta.enterprise.inject.Instance
+import jakarta.inject.Inject
+
+/**
+ * Micrometer adapter for [FinrepMetricsPort] (ADR-0077 Tier C). Emits, all tagged
+ * `service="finrep"`:
+ *
+ *  - `openbank_finrep_templates_rendered_total{framework,template,balanced}` — render rate, and for
+ *    FINREP whether the balance sheet actually balanced. `balanced="false"` is a supervisory defect,
+ *    not a warning; `balanced="not_applicable"` is COREP, which defines no such identity.
+ *  - `openbank_finrep_template_render_duration_seconds{framework,template}` — includes the ledger
+ *    trial-balance hop, which is the only I/O on the path.
+ *  - `openbank_finrep_trial_balance_lines{framework,template}` — the size of the input the report was
+ *    derived from. A collapse to zero renders a template of honest-looking zeros with a 200 response;
+ *    this is the only series where that shows.
+ *  - `openbank_finrep_template_cells{framework,template}` /
+ *    `openbank_finrep_template_data_gap_cells{framework,template}` — how much of the return is real.
+ *    COREP C 01.00 flags capital-structure rows as explicit gaps (ADR-0097 forbids silent ones), and
+ *    the gap:cell ratio is how far the report is from being submittable.
+ *  - `openbank_finrep_template_failures_total{framework,reason}` — `unknown_template` is a client
+ *    error, `ledger_unavailable` is an outage that means no regulatory report can be produced at all.
+ *
+ * Service-local `MeterRegistry`, null-safe via [Instance] exactly like libs `DomainMetrics`: report
+ * shape counters are finrep-specific, so adding them to the shared libs facade would force a
+ * fleet-wide rebuild for a one-service concern.
+ */
+@ApplicationScoped
+class FinrepMetricsAdapter(private val registry: MeterRegistry?) : FinrepMetricsPort {
+
+    // CDI constructor: MeterRegistry is optional (absent when no Prometheus registry is on the
+    // classpath, e.g. slim test slices). Without an explicit @Inject ctor, ArC sees two constructors,
+    // registers no bean, and FinrepService is left with an unsatisfied dependency at build time.
+    @Inject
+    constructor(registryInstance: Instance<MeterRegistry>) : this(
+        if (registryInstance.isResolvable) registryInstance.get() else null,
+    )
+
+    override fun templateRendered(render: TemplateRender) {
+        val r = registry ?: return
+        val framework = render.framework.name.lowercase()
+        Counter.builder("openbank.finrep.templates.rendered")
+            .tag("service", SERVICE)
+            .tag("framework", framework)
+            .tag("template", render.templateId)
+            .tag("balanced", render.balanced?.toString() ?: NOT_APPLICABLE)
+            .description("Rendered FINREP/COREP templates")
+            .register(r)
+            .increment()
+        Timer.builder("openbank.finrep.template.render.duration")
+            .tag("service", SERVICE)
+            .tag("framework", framework)
+            .tag("template", render.templateId)
+            .publishPercentiles(P50, P95, P99)
+            .publishPercentileHistogram()
+            .description("Time to render one template, including the ledger trial-balance hop")
+            .register(r)
+            .record(render.duration)
+        summary(r, "openbank.finrep.trial_balance.lines", framework, render.templateId)
+            .record(render.trialBalanceLines.toDouble())
+        summary(r, "openbank.finrep.template.cells", framework, render.templateId)
+            .record(render.cells.toDouble())
+        summary(r, "openbank.finrep.template.data_gap_cells", framework, render.templateId)
+            .record(render.dataGapCells.toDouble())
+    }
+
+    override fun templateFailed(framework: RegulatoryFramework, reason: TemplateFailureReason) {
+        registry?.let { r ->
+            Counter.builder("openbank.finrep.template.failures")
+                .tag("service", SERVICE)
+                .tag("framework", framework.name.lowercase())
+                .tag("reason", reason.name.lowercase())
+                .description("Template renders that produced no report")
+                .register(r)
+                .increment()
+        }
+    }
+
+    private fun summary(
+        registry: MeterRegistry,
+        name: String,
+        framework: String,
+        template: String,
+    ): DistributionSummary = DistributionSummary.builder(name)
+        .tag("service", SERVICE)
+        .tag("framework", framework)
+        .tag("template", template)
+        .publishPercentiles(P50, P95, P99)
+        .publishPercentileHistogram()
+        .register(registry)
+
+    companion object {
+        private const val SERVICE = "finrep"
+
+        /** COREP defines no balance-sheet identity, so `balanced` is neither true nor false there. */
+        private const val NOT_APPLICABLE = "not_applicable"
+
+        // The fleet-standard percentile set (libs DomainMetrics publishes the same three).
+        private const val P50 = 0.5
+        private const val P95 = 0.95
+        private const val P99 = 0.99
+    }
+}

--- a/openbank-finrep-service/src/test/kotlin/com/openbank/finrep/application/usecase/CorepServiceTest.kt
+++ b/openbank-finrep-service/src/test/kotlin/com/openbank/finrep/application/usecase/CorepServiceTest.kt
@@ -7,6 +7,8 @@ package com.openbank.finrep.application.usecase
 import com.openbank.finrep.application.port.inbound.GetCorepTemplateQuery
 import com.openbank.finrep.application.port.out.LedgerPort
 import com.openbank.finrep.application.port.out.TrialBalanceLineDto
+import com.openbank.finrep.infrastructure.observability.FinrepMetricsAdapter
+import io.micrometer.core.instrument.simple.SimpleMeterRegistry
 import io.mockk.coEvery
 import io.mockk.coVerify
 import io.mockk.mockk
@@ -21,6 +23,10 @@ class CorepServiceTest {
 
     private val ledgerPort: LedgerPort = mockk()
 
+    // The REAL metrics adapter over a SimpleMeterRegistry rather than a mock port, so the
+    // instrumentation assertions below fail if the use case stops emitting.
+    private val registry = SimpleMeterRegistry()
+
     @Test
     fun `getTemplate dispatches C_01_00 to the own funds mapper`(): Unit = runBlocking {
         val asOf = LocalDate.of(2026, 6, 30)
@@ -29,7 +35,7 @@ class CorepServiceTest {
             TrialBalanceLineDto(code = "2000", accountType = "LIABILITY", net = BigDecimal("300000")),
         )
         coEvery { ledgerPort.getTrialBalance(asOf) } returns lines
-        val service = CorepService(ledgerPort)
+        val service = CorepService(ledgerPort, FinrepMetricsAdapter(registry))
 
         val template = service.getTemplate(GetCorepTemplateQuery(templateId = "C_01.00", asOf = asOf))
 
@@ -43,12 +49,64 @@ class CorepServiceTest {
     fun `getTemplate throws for an unknown or unimplemented COREP template id`(): Unit = runBlocking {
         val asOf = LocalDate.of(2026, 6, 30)
         coEvery { ledgerPort.getTrialBalance(asOf) } returns emptyList()
-        val service = CorepService(ledgerPort)
+        val service = CorepService(ledgerPort, FinrepMetricsAdapter(registry))
 
         assertThatThrownBy {
             runBlocking { service.getTemplate(GetCorepTemplateQuery(templateId = "C_02.00", asOf = asOf)) }
         }
             .isInstanceOf(IllegalArgumentException::class.java)
             .hasMessageContaining("C_02.00")
+    }
+
+    @Test
+    fun `a rendered COREP template publishes its flagged data-gap cell count`(): Unit = runBlocking {
+        // ADR-0097 forbids silent gaps, so C 01.00's capital-structure rows ship as explicit flagged
+        // zeros. That honesty is invisible without a series counting them.
+        val asOf = LocalDate.of(2026, 6, 30)
+        coEvery { ledgerPort.getTrialBalance(asOf) } returns listOf(
+            TrialBalanceLineDto(code = "1000", accountType = "ASSET", net = BigDecimal("500000")),
+        )
+        val service = CorepService(ledgerPort, FinrepMetricsAdapter(registry))
+
+        val template = service.getTemplate(GetCorepTemplateQuery(templateId = "C_01.00", asOf = asOf))
+        val expectedGaps = template.cells.count { it.isDataGap }
+
+        assertThat(expectedGaps).isGreaterThan(0)
+        assertThat(
+            registry.get("openbank.finrep.template.data_gap_cells")
+                .tag("framework", "corep").tag("template", "C_01.00").summary().totalAmount(),
+        ).isEqualTo(expectedGaps.toDouble())
+    }
+
+    @Test
+    fun `COREP is tagged balanced=not_applicable rather than pretending it balanced`(): Unit = runBlocking {
+        val asOf = LocalDate.of(2026, 6, 30)
+        coEvery { ledgerPort.getTrialBalance(asOf) } returns emptyList()
+        val service = CorepService(ledgerPort, FinrepMetricsAdapter(registry))
+
+        service.getTemplate(GetCorepTemplateQuery(templateId = "C_01.00", asOf = asOf))
+
+        assertThat(
+            registry.get("openbank.finrep.templates.rendered")
+                .tag("service", "finrep").tag("framework", "corep").tag("template", "C_01.00")
+                .tag("balanced", "not_applicable")
+                .counter().count(),
+        ).isEqualTo(1.0)
+    }
+
+    @Test
+    fun `an unimplemented COREP template is counted as a framework-tagged failure`(): Unit = runBlocking {
+        val asOf = LocalDate.of(2026, 6, 30)
+        coEvery { ledgerPort.getTrialBalance(asOf) } returns emptyList()
+        val service = CorepService(ledgerPort, FinrepMetricsAdapter(registry))
+
+        assertThatThrownBy {
+            runBlocking { service.getTemplate(GetCorepTemplateQuery(templateId = "C_02.00", asOf = asOf)) }
+        }.isInstanceOf(IllegalArgumentException::class.java)
+
+        assertThat(
+            registry.get("openbank.finrep.template.failures")
+                .tag("framework", "corep").tag("reason", "unknown_template").counter().count(),
+        ).isEqualTo(1.0)
     }
 }

--- a/openbank-finrep-service/src/test/kotlin/com/openbank/finrep/application/usecase/FinrepServiceTest.kt
+++ b/openbank-finrep-service/src/test/kotlin/com/openbank/finrep/application/usecase/FinrepServiceTest.kt
@@ -7,6 +7,8 @@ package com.openbank.finrep.application.usecase
 import com.openbank.finrep.application.port.inbound.GetFinrepTemplateQuery
 import com.openbank.finrep.application.port.out.LedgerPort
 import com.openbank.finrep.application.port.out.TrialBalanceLineDto
+import com.openbank.finrep.infrastructure.observability.FinrepMetricsAdapter
+import io.micrometer.core.instrument.simple.SimpleMeterRegistry
 import io.mockk.coEvery
 import io.mockk.coVerify
 import io.mockk.mockk
@@ -21,6 +23,10 @@ class FinrepServiceTest {
 
     private val ledgerPort: LedgerPort = mockk()
 
+    // The REAL metrics adapter over a SimpleMeterRegistry rather than a mock port, so the
+    // instrumentation assertions below fail if the use case stops emitting.
+    private val registry = SimpleMeterRegistry()
+
     @Test
     fun `getTemplate dispatches F01_01 to the balance sheet mapper`(): Unit = runBlocking {
         val asOf = LocalDate.of(2026, 6, 30)
@@ -29,7 +35,7 @@ class FinrepServiceTest {
             TrialBalanceLineDto(code = "2000", accountType = "LIABILITY", net = BigDecimal("300000")),
         )
         coEvery { ledgerPort.getTrialBalance(asOf) } returns lines
-        val service = FinrepService(ledgerPort)
+        val service = FinrepService(ledgerPort, FinrepMetricsAdapter(registry))
 
         val template = service.getTemplate(GetFinrepTemplateQuery(templateId = "F01.01", asOf = asOf))
 
@@ -47,7 +53,7 @@ class FinrepServiceTest {
             TrialBalanceLineDto(code = "5000", accountType = "EXPENSE", net = BigDecimal("80000")),
         )
         coEvery { ledgerPort.getTrialBalance(asOf) } returns lines
-        val service = FinrepService(ledgerPort)
+        val service = FinrepService(ledgerPort, FinrepMetricsAdapter(registry))
 
         val template = service.getTemplate(GetFinrepTemplateQuery(templateId = "F02.00", asOf = asOf))
 
@@ -59,12 +65,91 @@ class FinrepServiceTest {
     fun `getTemplate throws for an unknown template id`(): Unit = runBlocking {
         val asOf = LocalDate.of(2026, 6, 30)
         coEvery { ledgerPort.getTrialBalance(asOf) } returns emptyList()
-        val service = FinrepService(ledgerPort)
+        val service = FinrepService(ledgerPort, FinrepMetricsAdapter(registry))
 
         assertThatThrownBy {
             runBlocking { service.getTemplate(GetFinrepTemplateQuery(templateId = "F99.99", asOf = asOf)) }
         }
             .isInstanceOf(IllegalArgumentException::class.java)
             .hasMessageContaining("F99.99")
+    }
+
+    @Test
+    fun `a rendered template publishes its input size, cell count and balanced flag`(): Unit = runBlocking {
+        val asOf = LocalDate.of(2026, 6, 30)
+        coEvery { ledgerPort.getTrialBalance(asOf) } returns listOf(
+            TrialBalanceLineDto(code = "1000", accountType = "ASSET", net = BigDecimal("500000")),
+            TrialBalanceLineDto(code = "2000", accountType = "LIABILITY", net = BigDecimal("300000")),
+        )
+        val service = FinrepService(ledgerPort, FinrepMetricsAdapter(registry))
+
+        val template = service.getTemplate(GetFinrepTemplateQuery(templateId = "F01.01", asOf = asOf))
+
+        assertThat(
+            registry.get("openbank.finrep.templates.rendered")
+                .tag("service", "finrep").tag("framework", "finrep").tag("template", "F01.01")
+                .tag("balanced", template.isBalanced.toString())
+                .counter().count(),
+        ).isEqualTo(1.0)
+        assertThat(
+            registry.get("openbank.finrep.template.render.duration").tag("template", "F01.01").timer().count(),
+        ).isEqualTo(1L)
+        assertThat(
+            registry.get("openbank.finrep.trial_balance.lines").tag("template", "F01.01").summary().totalAmount(),
+        ).isEqualTo(2.0)
+        assertThat(
+            registry.get("openbank.finrep.template.cells").tag("template", "F01.01").summary().totalAmount(),
+        ).isEqualTo(template.cells.size.toDouble())
+    }
+
+    @Test
+    fun `an empty trial balance is still sampled, because a report of zeros still returns 200`(): Unit = runBlocking {
+        // This is the under-reporting detector: a truncated ledger response renders a well-formed
+        // template of honest-looking zeros, and `trial_balance.lines` is the only series that shows it.
+        val asOf = LocalDate.of(2026, 6, 30)
+        coEvery { ledgerPort.getTrialBalance(asOf) } returns emptyList()
+        val service = FinrepService(ledgerPort, FinrepMetricsAdapter(registry))
+
+        service.getTemplate(GetFinrepTemplateQuery(templateId = "F01.01", asOf = asOf))
+
+        val lines = registry.get("openbank.finrep.trial_balance.lines").tag("template", "F01.01").summary()
+        assertThat(lines.count()).isEqualTo(1L)
+        assertThat(lines.totalAmount()).isEqualTo(0.0)
+    }
+
+    @Test
+    fun `an unknown template is counted WITHOUT its caller-supplied id as a tag`(): Unit = runBlocking {
+        // Cardinality contract: the template id is a path parameter, so tagging the failure with it
+        // would let any client mint unbounded series.
+        val asOf = LocalDate.of(2026, 6, 30)
+        coEvery { ledgerPort.getTrialBalance(asOf) } returns emptyList()
+        val service = FinrepService(ledgerPort, FinrepMetricsAdapter(registry))
+
+        assertThatThrownBy {
+            runBlocking { service.getTemplate(GetFinrepTemplateQuery(templateId = "F99.99", asOf = asOf)) }
+        }.isInstanceOf(IllegalArgumentException::class.java)
+
+        val failures = registry.get("openbank.finrep.template.failures")
+            .tag("framework", "finrep").tag("reason", "unknown_template").counter()
+        assertThat(failures.count()).isEqualTo(1.0)
+        assertThat(failures.id.tags.map { it.key }).doesNotContain("template")
+    }
+
+    @Test
+    fun `a ledger outage is counted as ledger_unavailable and still rethrown`(): Unit = runBlocking {
+        val asOf = LocalDate.of(2026, 6, 30)
+        coEvery { ledgerPort.getTrialBalance(asOf) } throws RuntimeException("ledger-service unreachable")
+        val service = FinrepService(ledgerPort, FinrepMetricsAdapter(registry))
+
+        assertThatThrownBy {
+            runBlocking { service.getTemplate(GetFinrepTemplateQuery(templateId = "F01.01", asOf = asOf)) }
+        }.isInstanceOf(RuntimeException::class.java)
+
+        assertThat(
+            registry.get("openbank.finrep.template.failures")
+                .tag("framework", "finrep").tag("reason", "ledger_unavailable").counter().count(),
+        ).isEqualTo(1.0)
+        // No render happened, so nothing must claim one did.
+        assertThat(registry.find("openbank.finrep.templates.rendered").counters()).isEmpty()
     }
 }

--- a/openbank-finrep-service/src/test/kotlin/com/openbank/finrep/infrastructure/observability/FinrepMetricsAdapterTest.kt
+++ b/openbank-finrep-service/src/test/kotlin/com/openbank/finrep/infrastructure/observability/FinrepMetricsAdapterTest.kt
@@ -1,0 +1,96 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright (c) OpenBank contributors. Licensed under the Apache License, Version 2.0.
+// See LICENSE in the repository root or https://www.apache.org/licenses/LICENSE-2.0 for details.
+
+package com.openbank.finrep.infrastructure.observability
+
+import com.openbank.finrep.application.port.out.RegulatoryFramework
+import com.openbank.finrep.application.port.out.TemplateFailureReason
+import com.openbank.finrep.application.port.out.TemplateRender
+import io.micrometer.core.instrument.simple.SimpleMeterRegistry
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.Test
+import java.time.Duration
+
+class FinrepMetricsAdapterTest {
+
+    private val registry = SimpleMeterRegistry()
+    private val adapter = FinrepMetricsAdapter(registry)
+
+    @Test
+    fun `an unbalanced FINREP render is tagged balanced=false`() {
+        // A balance sheet that does not balance is a supervisory defect; `isBalanced` was previously
+        // computed, serialised and never looked at.
+        adapter.templateRendered(render(balanced = false))
+
+        assertThat(
+            registry.get("openbank.finrep.templates.rendered")
+                .tag("service", "finrep").tag("framework", "finrep").tag("template", "F01.01")
+                .tag("balanced", "false")
+                .counter().count(),
+        ).isEqualTo(1.0)
+    }
+
+    @Test
+    fun `a null balanced flag renders as not_applicable, never as true`() {
+        adapter.templateRendered(render(framework = RegulatoryFramework.COREP, template = "C_01.00", balanced = null))
+
+        assertThat(
+            registry.get("openbank.finrep.templates.rendered")
+                .tag("framework", "corep").tag("balanced", "not_applicable").counter().count(),
+        ).isEqualTo(1.0)
+        assertThat(registry.find("openbank.finrep.templates.rendered").tag("balanced", "true").counters()).isEmpty()
+    }
+
+    @Test
+    fun `a render publishes duration, input lines, cells and data-gap cells`() {
+        adapter.templateRendered(render(trialBalanceLines = 12, cells = 30, dataGapCells = 4))
+
+        assertThat(registry.get("openbank.finrep.template.render.duration").timer().count()).isEqualTo(1L)
+        assertThat(registry.get("openbank.finrep.trial_balance.lines").summary().totalAmount()).isEqualTo(12.0)
+        assertThat(registry.get("openbank.finrep.template.cells").summary().totalAmount()).isEqualTo(30.0)
+        assertThat(registry.get("openbank.finrep.template.data_gap_cells").summary().totalAmount()).isEqualTo(4.0)
+    }
+
+    @Test
+    fun `a failure counter carries the framework and reason but never a template tag`() {
+        adapter.templateFailed(RegulatoryFramework.FINREP, TemplateFailureReason.UNKNOWN_TEMPLATE)
+        adapter.templateFailed(RegulatoryFramework.COREP, TemplateFailureReason.LEDGER_UNAVAILABLE)
+
+        val unknown = registry.get("openbank.finrep.template.failures")
+            .tag("framework", "finrep").tag("reason", "unknown_template").counter()
+        assertThat(unknown.count()).isEqualTo(1.0)
+        // The id is caller-supplied, so it must never become a label.
+        assertThat(unknown.id.tags.map { it.key }).containsExactlyInAnyOrder("service", "framework", "reason")
+        assertThat(
+            registry.get("openbank.finrep.template.failures")
+                .tag("framework", "corep").tag("reason", "ledger_unavailable").counter().count(),
+        ).isEqualTo(1.0)
+    }
+
+    @Test
+    fun `is a silent no-op when no meter registry is resolvable`() {
+        // Slim slices without a Prometheus registry must not crash a render.
+        val noRegistry = FinrepMetricsAdapter(null)
+
+        noRegistry.templateRendered(render())
+        noRegistry.templateFailed(RegulatoryFramework.FINREP, TemplateFailureReason.UNKNOWN_TEMPLATE)
+    }
+
+    private fun render(
+        framework: RegulatoryFramework = RegulatoryFramework.FINREP,
+        template: String = "F01.01",
+        trialBalanceLines: Int = 5,
+        cells: Int = 20,
+        dataGapCells: Int = 0,
+        balanced: Boolean? = true,
+    ) = TemplateRender(
+        framework = framework,
+        templateId = template,
+        trialBalanceLines = trialBalanceLines,
+        cells = cells,
+        dataGapCells = dataGapCells,
+        balanced = balanced,
+        duration = Duration.ofMillis(33),
+    )
+}


### PR DESCRIPTION
## Summary

`openbank-finrep-service` emitted only default JVM/HTTP metrics — zero domain instrumentation
(prod-readiness C8, #2255). It is a *pure derivation* over ledger's trial balance: it stores
nothing and emits nothing, so **every** way it can be wrong still returns a well-formed 200.
Adds a `FinrepMetricsPort` and a Micrometer adapter, following the service-local pattern already
used by fraud-service and agent-service.

## Type of change

- [x] feat (new functionality)

## Linked issues

Refs #2255

## Changes

**Meters added, and why these:**

| Meter | Why an operator needs it |
|---|---|
| `openbank_finrep_templates_rendered_total{framework,template,balanced}` | Render rate — and for FINREP, whether the balance sheet **actually balanced**. `FinrepTemplate.isBalanced` was already computed, serialised into the response, and then nobody ever looked at it. `balanced="false"` is a supervisory defect, not a warning. |
| `openbank_finrep_template_render_duration_seconds{framework,template}` | Includes the ledger trial-balance hop, which is the only I/O on the path. |
| `openbank_finrep_trial_balance_lines{framework,template}` | The size of the input the report was derived from. An empty or truncated ledger response renders a template of honest-looking zeros with a 200 — this is the only series where that shows. |
| `openbank_finrep_template_cells` / `openbank_finrep_template_data_gap_cells{framework,template}` | ADR-0097 forbids silent gaps, so COREP C 01.00 ships capital-structure rows as **explicit flagged zeros**. That honesty is invisible without a series counting them; the gap:cell ratio is how far the return is from submittable. |
| `openbank_finrep_template_failures_total{framework,reason}` | `unknown_template` is a client error; `ledger_unavailable` is an outage meaning **no regulatory report can be produced at all**. Previously the second one was just a propagated exception. |

**Code:**

- new `application/port/out/FinrepMetricsPort.kt` (+ `TemplateRender`, `RegulatoryFramework`, `TemplateFailureReason`)
- new `infrastructure/observability/FinrepMetricsAdapter.kt` — service-local `MeterRegistry`, null-safe
  via `Instance<MeterRegistry>` like libs `DomainMetrics`, with the explicit `@Inject` constructor ArC needs
- `FinrepService` / `CorepService` report renders and both failure reasons; the ledger hop is wrapped
  **count-and-rethrow**, so caller-visible behaviour is byte-for-byte unchanged

### Two deliberate design calls

**The failure counter carries no `template` tag.** The template id is a caller-supplied path
parameter (`GET /api/v1/finrep/templates/{templateId}`), so tagging failures with it would let any
client mint unbounded metric series. Only the closed set the mappers recognise (`F01.01`, `F02.00`,
`C_01.00`) ever reaches the *rendered* counter, which is why that one can safely carry it. There
are tests asserting the failure counter's tag keys are exactly `{service, framework, reason}`.

**COREP is tagged `balanced="not_applicable"`, not `"true"`.** COREP defines no balance-sheet
identity; reporting `true` would be a fabricated attestation. `TemplateRender.balanced` is
therefore nullable and the adapter renders null as a distinct tag value, with a test asserting no
`balanced="true"` series appears for COREP.

## Definition of Done

- [x] Hexagonal layering preserved (domain untouched; port in `application/port/out`, Micrometer only in `infrastructure/observability`).
- [x] Unit tests added/updated.
- [x] Integration tests added/updated (if service boundary involved). — `FinrepBootSmokeTest` exercises the CDI wiring; `quarkusBuild` validates ArC.
- [x] Contract tests updated (if public API changed). — n/a, no API change (finrep has no `openapi.yaml`; that gap is tracked separately in #2255 as a C3 item and is out of scope here).
- [x] `detekt ktlintCheck koverVerify build` passes (module-scoped, see below).
- [x] No new lint warnings.
- [x] OpenAPI spec regenerated (if REST API changed). — n/a
- [x] Flyway migration added + rollback note (if DB changed). — n/a, finrep is stateless
- [x] Avro schema versioned backward-compatibly (if event changed). — n/a
- [x] Docs updated — KDoc on the port/adapter states what each meter is for and why.

### The tests were falsified, not just run

The tests drive the **real** adapter over a `SimpleMeterRegistry` rather than a mock port. Verified
by disabling `metrics.templateRendered(...)` in `FinrepService` and deleting
`metrics.templateFailed(...)` from `CorepService`'s unknown-template branch:

```
CorepServiceTest > an unimplemented COREP template is counted as a framework-tagged failure() FAILED
    io.micrometer.core.instrument.search.MeterNotFoundException
FinrepServiceTest > an empty trial balance is still sampled, because a report of zeros still returns 200() FAILED
FinrepServiceTest > a rendered template publishes its input size, cell count and balanced flag() FAILED
    io.micrometer.core.instrument.search.MeterNotFoundException
```

Restored → `BUILD SUCCESSFUL`; full module run: **28 tests, 0 failures, 0 errors, 0 skipped**
(`:openbank-finrep-service:build :quarkusBuild :detekt :ktlintCheck :koverVerify`).

## Security checklist

- [x] No secrets, tokens, passwords, or PII in code, config, tests, logs. — no monetary value, GL account code or reference date is ever a tag; see the cardinality note above for the one caller-controlled input and how it is excluded.
- [x] No new `@Suppress` without justification. — two `@Suppress("TooGenericExceptionCaught")` on the count-and-rethrow ledger wrappers; the reason (every REST-client failure mode means the same thing here, and the exception is rethrown) is stated in the KDoc at each site.
- [x] No new third-party dependency. — `quarkus-micrometer-registry-prometheus` was already on the classpath.
- [x] Auth / crypto / payment code changed? — no
- [x] PII path changed? — no
- [x] Cardholder data path changed? — no

## Compliance impact

- [x] CNB reporting — FINREP/COREP supervisory reporting (ADR-0097). The `balanced` tag, `trial_balance_lines` and `data_gap_cells` are precisely the evidence that a rendered return is complete and internally consistent rather than a well-formed page of zeros.
