### PR TITLE
chore(governance): reconcile the AGPL open-core set across every declaration of it

### DIFF
--- a/.github/scripts/check-license-headers.py
+++ b/.github/scripts/check-license-headers.py
@@ -1,0 +1,380 @@
+#!/usr/bin/env python3
+# SPDX-License-Identifier: Apache-2.0
+# Copyright (c) OpenBank contributors. Licensed under the Apache License, Version 2.0.
+"""Verify the multi-license tree is self-consistent (ADR-0123 + ADR-0136).
+
+This repository is Apache-2.0 at the root (ADR-0123) with an AGPL-3.0-only open-core
+subset (ADR-0136, extended by ADR-0181 for mcp-service and ADR-0193 for ap2-service).
+Nothing used to compare the per-file SPDX headers against that declaration, so four
+sources drifted apart: the tree carried 12 AGPL modules while rules.yaml listed 10 and
+the published NOTICE/README named 4 -- implying to any downstream adopter that the other
+8 were Apache-2.0 (#2280). An SPDX scanner reads this as AGPL contamination of an
+Apache-2.0 distribution.
+
+`dependencies.license_boundary_exceptions[0].agpl_modules` in rules.yaml is the single
+source of truth. Every check below compares something against THAT list:
+
+  1. rules.yaml internal consistency -- the denylist-exception `paths` list and the
+     `rule:` string enumerate the same modules as agpl_modules.
+  2. Per-module LICENSE -- every AGPL module has its own LICENSE naming AGPL-3.0-only,
+     and no module outside the list has one (which would mean a 13th appeared silently).
+  3. Per-file SPDX headers -- a file that declares a licence declares the one its module
+     is under. Files with NO header are reported but do not fail (adding headers fleet-wide
+     is out of scope; scripts/add-license-headers.sh stamps new files correctly).
+  4. Copyleft boundary -- no Apache-2.0 module takes a build/compile dependency on an
+     AGPL module. This is the check that keeps the AGPL from actually contaminating the
+     platform; everything else is labelling.
+  5. NOTICE / README -- must point at rules.yaml and must NOT enumerate a partial subset
+     of the AGPL modules. A hand-maintained second copy of the list is precisely how the
+     4-vs-12 drift happened, so a partial enumeration is a hard failure.
+
+REUSE.toml `precedence = "override"` entries win over in-file headers, for files whose
+header cannot be corrected (applied Flyway migrations -- editing one breaks its checksum
+and the service fails at boot).
+
+Usage:
+    .github/scripts/check-license-headers.py            # verify, exit 1 on any violation
+    .github/scripts/check-license-headers.py --selftest # prove the gate can actually fail
+"""
+
+from __future__ import annotations
+
+import re
+import subprocess
+import sys
+import tomllib
+from pathlib import Path
+
+import yaml
+
+REPO = Path(__file__).resolve().parents[2]
+RULES = REPO / "openbank-libs" / "governance" / "rules.yaml"
+REUSE_TOML = REPO / "REUSE.toml"
+NOTICE = REPO / "NOTICE"
+README = REPO / "README.md"
+
+APACHE = "Apache-2.0"
+AGPL = "AGPL-3.0-only"
+
+# Extensions that conventionally carry a header in this tree.
+SOURCE_SUFFIXES = {".kt", ".kts", ".java", ".ts", ".tsx", ".js", ".mjs", ".py", ".sh", ".rego", ".sql", ".yaml", ".yml"}
+
+# Header must be near the top; a match deeper in the file is content, not a declaration.
+HEADER_SCAN_LINES = 8
+SPDX_RE = re.compile(r"SPDX-License-Identifier:\s*([A-Za-z0-9.+-]+)")
+
+errors: list[str] = []
+notes: list[str] = []
+
+
+def fail(msg: str) -> None:
+    errors.append(msg)
+
+
+def load_rules() -> dict:
+    return yaml.safe_load(RULES.read_text(encoding="utf-8")) or {}
+
+
+def canonical_agpl_modules(rules: dict) -> list[str]:
+    """The single source of truth. Absent/empty is fatal -- never fall back to a guess."""
+    exceptions = (rules.get("dependencies") or {}).get("license_boundary_exceptions") or []
+    mods = exceptions[0].get("agpl_modules") if exceptions else None
+    if not mods:
+        sys.exit(
+            "FATAL: rules.yaml dependencies.license_boundary_exceptions[0].agpl_modules "
+            "is missing or empty. Refusing to run -- with no canonical list this gate "
+            "would pass vacuously."
+        )
+    return list(mods)
+
+
+def check_rules_internal_consistency(rules: dict, agpl: list[str]) -> None:
+    """Check 1: the other two copies of the list inside rules.yaml agree with the canonical one."""
+    deps = rules.get("dependencies") or {}
+
+    declared_paths: list[str] = []
+    for exc in deps.get("license_denylist_exceptions") or []:
+        if exc.get("license") == AGPL:
+            declared_paths.extend(exc.get("paths") or [])
+    paths_as_modules = {p.rstrip("/") for p in declared_paths}
+
+    missing = sorted(set(agpl) - paths_as_modules)
+    extra = sorted(paths_as_modules - set(agpl))
+    if missing:
+        fail(
+            "rules.yaml: license_denylist_exceptions.paths is missing "
+            f"{missing} -- present in agpl_modules. A third-party licence scan would flag "
+            "AGPL in those paths as a denylist violation."
+        )
+    if extra:
+        fail(
+            "rules.yaml: license_denylist_exceptions.paths lists "
+            f"{extra} which are NOT in agpl_modules. Remove them or add them to agpl_modules."
+        )
+
+    exceptions = deps.get("license_boundary_exceptions") or []
+    rule_text = exceptions[0].get("rule", "") if exceptions else ""
+    unnamed = sorted(m for m in agpl if f"':{m}'" not in rule_text)
+    if unnamed:
+        fail(
+            f"rules.yaml: license_boundary_exceptions[0].rule does not name {unnamed}. "
+            "The rule string must enumerate every agpl_modules entry so the boundary it "
+            "states matches the boundary that is enforced."
+        )
+
+
+def check_per_module_license(agpl: list[str]) -> None:
+    """Check 2: LICENSE files and the canonical list agree in both directions."""
+    for module in agpl:
+        lic = REPO / module / "LICENSE"
+        if not lic.is_file():
+            fail(f"{module}/LICENSE is missing -- an AGPL module must carry its own LICENSE (ADR-0136).")
+            continue
+        if AGPL not in lic.read_text(encoding="utf-8"):
+            fail(f"{module}/LICENSE does not name {AGPL}.")
+
+    for lic in sorted(REPO.glob("openbank-*/LICENSE")):
+        module = lic.parent.name
+        if module not in agpl:
+            fail(
+                f"{module}/LICENSE exists but {module} is not in rules.yaml agpl_modules. "
+                "Either add it to the canonical list (and to NOTICE's pointer scope) or "
+                "delete the file -- a module-level LICENSE is how a component leaves the "
+                "root Apache-2.0 grant, and it must be declared."
+            )
+
+
+def reuse_overrides() -> dict[str, str]:
+    """REUSE.toml precedence=override entries: repo-relative path -> SPDX id."""
+    if not REUSE_TOML.is_file():
+        return {}
+    data = tomllib.loads(REUSE_TOML.read_text(encoding="utf-8"))
+    out: dict[str, str] = {}
+    for ann in data.get("annotations") or []:
+        if ann.get("precedence") != "override":
+            continue
+        spdx = ann.get("SPDX-License-Identifier")
+        paths = ann.get("path")
+        if isinstance(paths, str):
+            paths = [paths]
+        for p in paths or []:
+            out[p] = spdx
+    return out
+
+
+def tracked_files() -> list[str]:
+    out = subprocess.run(
+        ["git", "-C", str(REPO), "ls-files"], capture_output=True, text=True, check=True
+    ).stdout
+    return [line for line in out.splitlines() if line]
+
+
+def check_headers(agpl: list[str], overrides: dict[str, str]) -> None:
+    """Check 3: every declared header matches its module's licence."""
+    agpl_set = set(agpl)
+    mismatched: list[tuple[str, str, str]] = []
+    missing_agpl = 0
+
+    for rel in tracked_files():
+        path = REPO / rel
+        if path.suffix not in SOURCE_SUFFIXES or not path.is_file():
+            continue
+
+        module = rel.split("/")[0]
+        expected = AGPL if module in agpl_set else APACHE
+
+        override = overrides.get(rel)
+        if override is not None:
+            # The file's own header is known-wrong and frozen; REUSE.toml is the declaration.
+            if override != expected:
+                fail(
+                    f"REUSE.toml declares {rel} as {override} but its module {module} is "
+                    f"{expected}. The override must state the module's licence."
+                )
+            continue
+
+        try:
+            head = "".join(path.open(encoding="utf-8", errors="replace").readlines()[:HEADER_SCAN_LINES])
+        except OSError as exc:  # unreadable file is a real problem, not something to skip
+            fail(f"{rel}: cannot read ({exc})")
+            continue
+
+        match = SPDX_RE.search(head)
+        if not match:
+            if module in agpl_set:
+                missing_agpl += 1
+            continue
+        found = match.group(1)
+        if found != expected:
+            mismatched.append((rel, found, expected))
+
+    for rel, found, expected in mismatched:
+        hint = (
+            "If this migration is already APPLIED anywhere its header is frozen -- editing it "
+            "changes the Flyway checksum and the service fails at boot -- so add a "
+            "precedence=override entry to REUSE.toml instead of editing the file."
+            if Path(rel).suffix == ".sql"
+            else "Fix the header."
+        )
+        fail(f"{rel}: header says {found}, module is {expected}. {hint}")
+
+    if missing_agpl:
+        notes.append(
+            f"{missing_agpl} file(s) in AGPL modules carry no SPDX header at all (not a failure; "
+            "run scripts/add-license-headers.sh --apply, which is path-aware)."
+        )
+
+
+def check_boundary(agpl: list[str]) -> None:
+    """Check 4: the copyleft boundary itself. No Apache module may build-depend on an AGPL one."""
+    agpl_set = set(agpl)
+    for rel in tracked_files():
+        if Path(rel).name not in {"build.gradle.kts", "settings.gradle.kts"}:
+            continue
+        owner = rel.split("/")[0]
+        if owner in agpl_set:
+            continue  # AGPL -> AGPL is fine
+        text = (REPO / rel).read_text(encoding="utf-8")
+        for module in agpl:
+            if re.search(rf"""project\(\s*["']:{re.escape(module)}["']""", text):
+                fail(
+                    f"{rel}: Apache-2.0 module '{owner}' declares a build dependency on AGPL "
+                    f"module '{module}'. This is real copyleft contamination, not a labelling "
+                    "issue -- agent-plane services may only be reached over HTTP (ADR-0136)."
+                )
+
+
+def licensing_text(label: str, path: Path) -> str | None:
+    """The licensing prose only.
+
+    NOTICE is entirely licensing. README mentions nearly every module in its service catalog,
+    so only its "## License" section counts -- otherwise the subset check below would fire on
+    unrelated prose instead of on a licensing claim.
+    """
+    if not path.is_file():
+        fail(f"{label} is missing.")
+        return None
+    text = path.read_text(encoding="utf-8")
+    if label != "README.md":
+        return text
+    match = re.search(r"^## License$(.*?)(?=^## |\Z)", text, re.MULTILINE | re.DOTALL)
+    if not match:
+        fail("README.md has no '## License' section.")
+        return None
+    return match.group(1)
+
+
+def check_published_docs(agpl: list[str]) -> None:
+    """Check 5: NOTICE/README point at the canonical list and never enumerate a subset."""
+    pointer = "openbank-libs/governance/rules.yaml"
+    for label, path in (("NOTICE", NOTICE), ("README.md", README)):
+        text = licensing_text(label, path)
+        if text is None:
+            continue
+
+        named = sorted(m for m in agpl if m in text)
+        if named and len(named) < len(agpl):
+            fail(
+                f"{label} names {len(named)} of {len(agpl)} AGPL modules "
+                f"(missing {sorted(set(agpl) - set(named))}). A partial list tells downstream "
+                "adopters the unnamed modules are covered by the root Apache-2.0 LICENSE, which "
+                f"is false. Reference {pointer} instead of enumerating."
+            )
+        if pointer not in text:
+            fail(
+                f"{label} must reference {pointer} as the authoritative list of AGPL-3.0-only "
+                "components, so the licensing statement cannot drift from the tree."
+            )
+
+
+def selftest(agpl: list[str]) -> int:
+    """Feed each check an input it MUST flag. A gate whose failure path never ran is unfalsified.
+
+    Runs in-memory only -- no file in the working tree is touched.
+    """
+    print("== selftest: each check must reject a known-bad input ==")
+    results: list[tuple[str, bool]] = []
+
+    def run(name: str, fn) -> None:
+        global errors
+        saved = errors
+        errors = []
+        try:
+            fn()
+            flagged = bool(errors)
+        finally:
+            caught, errors = errors, saved
+        results.append((name, flagged))
+        status = "PASS (rejected)" if flagged else "FAIL (accepted bad input!)"
+        print(f"  {name}: {status}")
+        if flagged:
+            print(f"      first message: {caught[0][:120]}")
+
+    truncated = agpl[:-1]  # a list that has silently lost a module
+    rules = load_rules()
+
+    run("paths-vs-agpl_modules drift", lambda: check_rules_internal_consistency(rules, agpl + ["openbank-not-a-module"]))
+    run("rule-string omits a module", lambda: check_rules_internal_consistency(
+        {"dependencies": {
+            "license_denylist_exceptions": [{"license": AGPL, "paths": [f"{m}/" for m in agpl]}],
+            "license_boundary_exceptions": [{"agpl_modules": agpl, "rule": "no Apache-2.0 module may declare anything"}],
+        }}, agpl))
+    run("AGPL module with no LICENSE", lambda: check_per_module_license(agpl + ["openbank-libs-domain"]))
+    run("header/module licence mismatch", lambda: check_headers(truncated, reuse_overrides()))
+    # The boundary check is the one that catches REAL copyleft contamination rather than a
+    # mislabel, so it must be falsified too. openbank-libs-domain is build-depended on by many
+    # Apache-2.0 modules, so calling it AGPL is exactly the forbidden edge.
+    run("Apache module build-depends on AGPL", lambda: check_boundary(agpl + ["openbank-libs-domain"]))
+    # "openbank-libs" is named in both NOTICE and the README License section (as the Apache-2.0
+    # dependency the AGPL modules consume). Pretending it is an AGPL module therefore makes both
+    # documents name 1 of 13 -- exactly the partial-enumeration shape that shipped as "the four
+    # AI agent services" while the tree carried twelve.
+    run("licensing doc enumerates a subset", lambda: check_published_docs(agpl + ["openbank-libs"]))
+
+    ok = all(flagged for _, flagged in results)
+    print()
+    print("selftest: ALL CHECKS CAN FAIL" if ok else "selftest: SOME CHECK IS UNFALSIFIED")
+    return 0 if ok else 1
+
+
+def main() -> int:
+    rules = load_rules()
+    agpl = canonical_agpl_modules(rules)
+
+    if "--selftest" in sys.argv:
+        return selftest(agpl)
+
+    print(f"Canonical AGPL-3.0-only modules (rules.yaml): {len(agpl)}")
+    for m in agpl:
+        print(f"  - {m}")
+    print()
+
+    overrides = reuse_overrides()
+    check_rules_internal_consistency(rules, agpl)
+    check_per_module_license(agpl)
+    check_headers(agpl, overrides)
+    check_boundary(agpl)
+    check_published_docs(agpl)
+
+    for note in notes:
+        print(f"note: {note}")
+
+    if errors:
+        print()
+        print(f"FAIL: {len(errors)} licensing inconsistency/ies")
+        for e in errors:
+            print(f"  - {e}")
+        print()
+        print("The root LICENSE is Apache-2.0; the modules above are AGPL-3.0-only (ADR-0136).")
+        print("Every declaration of that split must agree, or a downstream adopter is misled.")
+        return 1
+
+    print("OK: multi-license tree is self-consistent")
+    print(f"  {len(agpl)} AGPL-3.0-only modules, each with its own LICENSE")
+    print(f"  {len(overrides)} REUSE.toml override(s) for files whose header is frozen")
+    print("  no Apache-2.0 module build-depends on an AGPL module")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -366,6 +366,24 @@ jobs:
       - name: "PodMonitor namespace coverage (issue #2255, enforced)"
         run: python3 .github/scripts/check-podmonitor-namespace-coverage.py
 
+      # issue #2280. This repo is a MULTI-LICENSE tree: Apache-2.0 at the root (ADR-0123) with an
+      # AGPL-3.0-only open-core subset (ADR-0136, extended by ADR-0181 and ADR-0193). NOTHING
+      # compared the per-file SPDX headers against that declaration — no reuse-tool, no licensee,
+      # no license-eye anywhere in CI, and the OpenSSF Scorecard `License` check only asks whether a
+      # recognized licence file exists at the root, never what the files say. So four descriptions of
+      # the same split drifted apart unobserved: the tree carried 12 AGPL modules, rules.yaml listed
+      # 10, and the published NOTICE/README named 4 — telling every downstream adopter of a
+      # nominally Apache-2.0 monorepo that the other 8 were Apache-2.0. That is the failure mode a
+      # licence header exists to prevent, and an SPDX scanner reads it as AGPL contamination.
+      # Root cause was scripts/add-license-headers.sh hardcoding Apache-2.0 for every path — the
+      # ADR-0136 "make this script path-aware" follow-up that was never done.
+      # Its own --selftest below feeds every check an input it MUST flag, because a gate that has
+      # only ever passed is unfalsified.
+      - name: "License header consistency self-test (issue #2280)"
+        run: python3 .github/scripts/check-license-headers.py --selftest
+      - name: "License header consistency (issue #2280, enforced)"
+        run: python3 .github/scripts/check-license-headers.py
+
 
       # issue #2255. docs/runbooks/svc-*.md are GENERATED from governance.yaml + the gitops
       # manifests, and nothing checked them, so 25 of 30 had silently gone stale: they told

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -188,6 +188,23 @@ fire from *outside* it, so they stay here:
   does not match reality" — there is no judgement left to exercise, so advisory just makes the drift
   mergeable. `eu-ai-act-registry` went red twice on #2156 and the PR merged anyway, leaving the EU AI
   Act inventory omitting an AI system until it was regenerated. Tracked as #2216.
+- **The gate that never existed beats the unfalsified one: check whether anything reads the artifact
+  at all before assuming a green covers it.** This repo is a MULTI-LICENSE tree — Apache-2.0 at the
+  root, an AGPL-3.0-only open-core subset (ADR-0136 + ADR-0181/0193) — and *nothing* compared the
+  per-file SPDX headers to that declaration: no `reuse-tool`/`licensee`/`license-eye`/`scancode`
+  anywhere, and the OpenSSF Scorecard `License` check only asks whether a recognized licence file
+  exists at the **root**, never what the files say. So four descriptions of the split drifted in
+  silence: 12 AGPL modules in the tree, 10 in `rules.yaml`, **4** in the published `NOTICE`/`README` —
+  which told every downstream adopter the other 8 were Apache-2.0 (#2280). Two transferable rules.
+  (a) **A licence claim about a *distributed* artifact needs a gate, not prose** — all 12 carry a
+  `version.txt`. (b) **Never let a published doc keep its own copy of a list that lives in
+  `rules.yaml`** — enumerate once, point at it everywhere else; the second hand-maintained copy IS the
+  drift. Root cause was `scripts/add-license-headers.sh` hardcoding Apache-2.0 for every path, the
+  ADR-0136 follow-up nobody did — a stamping script that is not path-aware in a multi-license tree
+  manufactures the violation. Now `rules.yaml: agpl_modules` is canonical and
+  `.github/scripts/check-license-headers.py` enforces every declaration against it. Frozen headers
+  (an applied Flyway migration — editing one breaks its checksum and the service dies at boot) go in
+  `REUSE.toml` with `precedence = "override"`, never edited in place.
 
 ### CI / bot commit signing
 - **What signs a bot commit is the *endpoint*, not the token — and `main-protection` enforces

--- a/NOTICE
+++ b/NOTICE
@@ -9,13 +9,31 @@ You may obtain a copy of the License at
 
     http://www.apache.org/licenses/LICENSE-2.0
 
-The OpenBank AI agent services (openbank-agent-service, openbank-copilot-service,
-openbank-devops-agent, openbank-finops-agent) are OpenBank's open-core component
-and are licensed under the GNU Affero General Public License v3.0 only
+NOT ALL OF THIS REPOSITORY IS APACHE-2.0. The Apache-2.0 grant above covers the
+banking platform. OpenBank's AI agent and agent-plane services are its open-core
+component and are licensed under the GNU Affero General Public License v3.0 only
 (AGPL-3.0-only), with a parallel commercial licence available from the
-maintainer. They are NOT covered by the Apache-2.0 LICENSE/NOTICE; see each
-service's LICENSE file, LICENSES/AGPL-3.0-only.txt, and
-docs/adr/0136-agent-services-agpl-in-repo-open-core.md.
+maintainer. They are NOT covered by the Apache-2.0 LICENSE/NOTICE.
+
+The authoritative list of AGPL-3.0-only modules is the "agpl_modules" key in
+openbank-libs/governance/rules.yaml (dependencies.license_boundary_exceptions).
+It is deliberately not duplicated here: a second hand-maintained copy is how this
+NOTICE came to name four modules while the tree contained twelve. Equivalently,
+a module is AGPL-3.0-only if and only if it contains its own LICENSE file, and
+every file in it carries "SPDX-License-Identifier: AGPL-3.0-only" (with the
+exception of already-applied Flyway migrations, whose frozen headers are
+corrected out-of-tree in REUSE.toml). The agreement of all of these is enforced
+by .github/scripts/check-license-headers.py.
+
+If you redistribute, modify or operate any of those modules -- including offering
+them to users over a network -- the AGPL-3.0 applies, or obtain the commercial
+licence. See each module's LICENSE file, LICENSES/AGPL-3.0-only.txt, and
+docs/adr/0136-agent-services-agpl-in-repo-open-core.md (extended by ADR-0181 and
+ADR-0193, which place two further agent-plane services inside the same boundary).
+
+No Apache-2.0 module takes a build or compile dependency on an AGPL-3.0-only
+module, so the copyleft does not extend to the Apache-2.0 platform; the AGPL
+modules depend on openbank-libs (Apache-2.0), which the AGPL permits.
 
 "OpenBank" is the name of this independent open-source project and is not
 affiliated with, endorsed by, or connected to Santander's "Openbank" or any

--- a/README.md
+++ b/README.md
@@ -236,23 +236,37 @@ OpenBank uses a **dual-license model** (ADR-0123, superseding ADR-0012):
 - ✅ Permissive — no copyleft; forks and downstream may relicense their changes
 - ✅ You may combine OpenBank with proprietary code
 
-Every platform source file carries an SPDX `Apache-2.0` header; the AI agent services carry
-`AGPL-3.0-only` (see below). Contributions are certified via the
+Every platform source file carries an SPDX `Apache-2.0` header; the AI agent and agent-plane services
+carry `AGPL-3.0-only` (see below). Contributions are certified via the
 [Developer Certificate of Origin](https://developercertificate.org/) — no CLA.
 
-**The AI agent services — AGPL-3.0-only + a parallel commercial licence (open-core).**
+**The AI agent / agent-plane services — AGPL-3.0-only + a parallel commercial licence (open-core).**
 
-Per [ADR-0136](docs/adr/0136-agent-services-agpl-in-repo-open-core.md) (superseding the ADR-0031 D8
-separate-repo plan), the part of OpenBank intended for commercialization — the four AI agent services
-**`openbank-agent-service`, `openbank-copilot-service`, `openbank-devops-agent`, `openbank-finops-agent`** —
-is licensed **AGPL-3.0-only in this repo**, with a **commercial licence available from the maintainer** as an
-alternative (open-core dual-licensing). Every file in those services carries
-`// SPDX-License-Identifier: AGPL-3.0-only`; each has its own `LICENSE`, and the full text is in
-[`LICENSES/AGPL-3.0-only.txt`](LICENSES/AGPL-3.0-only.txt).
+⚠️ **This repository is not entirely Apache-2.0.** Per
+[ADR-0136](docs/adr/0136-agent-services-agpl-in-repo-open-core.md) (superseding the ADR-0031 D8
+separate-repo plan, and extended by [ADR-0181](docs/adr/0181-mcp-server-exposing-psd2-and-admin-read-apis-to-governed-ai-agents.md)
+and [ADR-0193](docs/adr/0193-ap2-mandate-verification-model-and-liability-position-promotes-adr-0182.md),
+which place two further agent-plane services inside the same boundary), the part of OpenBank intended
+for commercialization — the agent-plane
+services — is licensed **AGPL-3.0-only in this repo**, with a **commercial licence available from the
+maintainer** as an alternative (open-core dual-licensing). If you redistribute, modify or operate one
+of those modules — including offering it to users over a network — the AGPL-3.0 applies.
 
-The AGPL **does not contaminate the Apache-2.0 platform**: no Apache module takes a build/compile dependency
-on an agent service (they are reached only over HTTP), and the agent services depend only on the Apache-2.0
-`openbank-libs` (copyleft may consume permissive code). `rules.yaml` records this boundary.
+**Which modules?** The authoritative list is the `agpl_modules` key in
+[`openbank-libs/governance/rules.yaml`](openbank-libs/governance/rules.yaml)
+(`dependencies.license_boundary_exceptions`). It is intentionally not repeated here — a second
+hand-maintained copy is how this section came to name four modules while the tree contained twelve.
+Equivalently, and checkably: **a module is AGPL-3.0-only iff it contains its own `LICENSE` file**, and
+every file in it carries `SPDX-License-Identifier: AGPL-3.0-only`. The full licence text is in
+[`LICENSES/AGPL-3.0-only.txt`](LICENSES/AGPL-3.0-only.txt). The one documented exception is
+already-applied Flyway migrations, whose headers are frozen by Flyway's checksum and are therefore
+corrected out-of-tree in [`REUSE.toml`](REUSE.toml). That every one of these declarations agrees is
+enforced on each PR by [`check-license-headers.py`](.github/scripts/check-license-headers.py).
+
+The AGPL **does not contaminate the Apache-2.0 platform**: no Apache module takes a build/compile
+dependency on an AGPL module (they are reached only over HTTP, which the AGPL treats as use rather than
+linking), and the AGPL modules depend only on the Apache-2.0 `openbank-libs` (copyleft may consume
+permissive code). `rules.yaml` records this boundary and the gate above enforces it.
 
 See [`LICENSE`](LICENSE) for full Apache-2.0 text and [ADR-0123](docs/adr/0123-relicense-to-apache-2.0.md) for the
 relicensing rationale (and [ADR-0012](docs/adr/0012-mpl-license-and-dco.md) for the original MPL decision it supersedes).

--- a/REUSE.toml
+++ b/REUSE.toml
@@ -1,0 +1,50 @@
+# SPDX-License-Identifier: Apache-2.0
+# Copyright (c) OpenBank contributors. Licensed under the Apache License, Version 2.0.
+#
+# REUSE 3.2 out-of-tree licensing declarations (https://reuse.software/spec-3.2/).
+#
+# This repository is a MULTI-LICENSE tree: the platform is Apache-2.0 (root LICENSE,
+# ADR-0123) and the AI agent / agent-plane services are AGPL-3.0-only + a parallel
+# commercial licence (open-core, ADR-0136). The authoritative list of AGPL modules is
+# `openbank-libs/governance/rules.yaml` -> dependencies.license_boundary_exceptions[0].agpl_modules.
+#
+# Almost every file states its licence in its own SPDX header. This file exists only for
+# files that CANNOT carry a correct header, so that an SPDX/REUSE scanner still resolves
+# them to the right licence.
+
+version = 1
+SPDX-PackageName = "OpenBank"
+SPDX-PackageSupplier = "OpenBank contributors"
+SPDX-PackageDownloadLocation = "https://github.com/JiRaska/open-bank-oss"
+
+# ---------------------------------------------------------------------------------------
+# Applied Flyway migrations inside AGPL-3.0-only modules.
+#
+# These files carry a stale `SPDX-License-Identifier: Apache-2.0` header. It is WRONG --
+# they belong to AGPL-3.0-only modules -- but it CANNOT be corrected in place: Flyway
+# checksums the entire migration file, comments included, so editing the header makes the
+# checksum diverge from the `flyway_schema_history` row and every affected service fails
+# at boot with "Migration checksum mismatch". All eight are already applied in deployed
+# environments (see each module's version.txt), so the header is frozen.
+#
+# `precedence = "override"` makes this declaration win over the in-file header, which is
+# exactly the intent: the file says Apache-2.0, the truth is AGPL-3.0-only.
+#
+# When a module's schema is next rebuilt from scratch (a squashed baseline migration, i.e.
+# a new file with a new checksum), stamp the AGPL header on the new file and drop its entry
+# here. Do NOT edit these files to shorten this list.
+# ---------------------------------------------------------------------------------------
+[[annotations]]
+path = [
+  "openbank-authz-policy-auditor/src/main/resources/db/migration/V1__init_authzaudit.sql",
+  "openbank-control-liveness-sentinel/src/main/resources/db/migration/V1__init_liveness.sql",
+  "openbank-devops-agent/src/main/resources/db/migration/V1__init_devops.sql",
+  "openbank-docs-truth-agent/src/main/resources/db/migration/V1__init_docstruth.sql",
+  "openbank-finops-agent/src/main/resources/db/migration/V1__init_finops.sql",
+  "openbank-flaky-test-hunter/src/main/resources/db/migration/V1__init_flakytest.sql",
+  "openbank-governance-auditor/src/main/resources/db/migration/V1__init_govaudit.sql",
+  "openbank-release-steward/src/main/resources/db/migration/V1__init_releasesteward.sql",
+]
+precedence = "override"
+SPDX-FileCopyrightText = "Copyright (c) OpenBank contributors"
+SPDX-License-Identifier = "AGPL-3.0-only"

--- a/openbank-ap2-service/governance.yaml
+++ b/openbank-ap2-service/governance.yaml
@@ -1,4 +1,4 @@
-# SPDX-License-Identifier: Apache-2.0
+# SPDX-License-Identifier: AGPL-3.0-only
 # Per-service governance manifest (ADR-0071). Declarative, curatorial facts only.
 dataDomain: payments
 primaryDatastore: none

--- a/openbank-infra/gitops/components/accounts/account-opa-bundle.yaml
+++ b/openbank-infra/gitops/components/accounts/account-opa-bundle.yaml
@@ -9,7 +9,7 @@ metadata:
     app.kubernetes.io/name: account-service
     app.kubernetes.io/part-of: accounts
   annotations:
-    openbank.tech/policy-checksum: "915e917edf55373b"
+    openbank.tech/policy-checksum: "b2c11f30eec8f1b6"
 data:
   rest.rego: |
     # SPDX-License-Identifier: Apache-2.0
@@ -2275,6 +2275,9 @@ data:
       license_denylist_exceptions:
         - license: AGPL-3.0-only
           scope: agent-services                 # in-repo open-core; own LICENSE, commercial dual-license
+          # DERIVED from license_boundary_exceptions[0].agpl_modules below (one entry each, with a
+          # trailing slash). check-license-headers.py fails if the two lists disagree -- they drifted
+          # apart from the tree once already (#2280).
           paths:
             - openbank-agent-service/
             - openbank-copilot-service/
@@ -2286,22 +2289,33 @@ data:
             - openbank-docs-truth-agent/
             - openbank-authz-policy-auditor/
             - openbank-flaky-test-hunter/
+            - openbank-ap2-service/
+            - openbank-mcp-service/
           reason: "open-core: AGPL-3.0-only + commercial dual-licensing of the AI agent services"
           adr: ADR-0136
       license_boundary_exceptions:
         - description: "AGPL/Apache seam (in-repo). The AI agent services are AGPL-3.0-only; no Apache-2.0 module may take a build/compile dependency on them (only network/HTTP use is allowed). They depend on openbank-libs (Apache-2.0), which is permitted -- copyleft may consume permissive code."
+          # CANONICAL list of the in-repo AGPL-3.0-only modules -- the single source of truth for
+          # which components sit outside the root Apache-2.0 LICENSE. NOTICE and README deliberately
+          # do NOT enumerate them (they point here instead), because a hand-maintained second copy
+          # is what let the published NOTICE claim 4 modules while the tree carried 12 (#2280).
+          # Adding a module here means: give it its own LICENSE, stamp AGPL-3.0-only headers
+          # (scripts/add-license-headers.sh is path-aware from this list), and keep the paths list above
+          # in sync. Enforced by .github/scripts/check-license-headers.py.
           agpl_modules:
-            - openbank-agent-service
-            - openbank-copilot-service
-            - openbank-devops-agent
-            - openbank-finops-agent
+            - openbank-agent-service            # ADR-0136
+            - openbank-copilot-service          # ADR-0136
+            - openbank-devops-agent             # ADR-0136
+            - openbank-finops-agent             # ADR-0136
             - openbank-control-liveness-sentinel
             - openbank-governance-auditor
             - openbank-release-steward
             - openbank-docs-truth-agent
             - openbank-authz-policy-auditor
             - openbank-flaky-test-hunter
-          rule: "no Apache-2.0 module may declare project(':openbank-agent-service'|':openbank-copilot-service'|':openbank-devops-agent'|':openbank-finops-agent'|':openbank-control-liveness-sentinel'|':openbank-governance-auditor'|':openbank-release-steward'|':openbank-docs-truth-agent'|':openbank-authz-policy-auditor'|':openbank-flaky-test-hunter') as a dependency"
+            - openbank-ap2-service              # ADR-0193 -- same agent plane as mcp-service
+            - openbank-mcp-service              # ADR-0181 -- explicitly inside the ADR-0136 boundary
+          rule: "no Apache-2.0 module may declare project(':openbank-agent-service'|':openbank-copilot-service'|':openbank-devops-agent'|':openbank-finops-agent'|':openbank-control-liveness-sentinel'|':openbank-governance-auditor'|':openbank-release-steward'|':openbank-docs-truth-agent'|':openbank-authz-policy-auditor'|':openbank-flaky-test-hunter'|':openbank-ap2-service'|':openbank-mcp-service') as a dependency"
           license: "AGPL-3.0-only"
           adr: ADR-0136
       block_on_cve_severity: [CRITICAL, HIGH]

--- a/openbank-infra/gitops/components/accounts/account-service.yaml
+++ b/openbank-infra/gitops/components/accounts/account-service.yaml
@@ -37,7 +37,7 @@ spec:
       annotations:
         # Rolls the pod when the OPA bundle changes — subPath mounts do NOT hot-reload.
         # Kept in sync by gen-account-opa-bundle.sh (do not hand-edit).
-        openbank.tech/policy-checksum: "915e917edf55373b"
+        openbank.tech/policy-checksum: "b2c11f30eec8f1b6"
     spec:
       securityContext:
         runAsNonRoot: true

--- a/openbank-infra/gitops/components/aml/aml-opa-bundle.yaml
+++ b/openbank-infra/gitops/components/aml/aml-opa-bundle.yaml
@@ -9,7 +9,7 @@ metadata:
     app.kubernetes.io/name: aml-service
     app.kubernetes.io/part-of: aml
   annotations:
-    openbank.tech/policy-checksum: "d7592465d131ed41"
+    openbank.tech/policy-checksum: "f0f15c22d1ce793e"
 data:
   rest.rego: |
     # SPDX-License-Identifier: Apache-2.0
@@ -2248,6 +2248,9 @@ data:
       license_denylist_exceptions:
         - license: AGPL-3.0-only
           scope: agent-services                 # in-repo open-core; own LICENSE, commercial dual-license
+          # DERIVED from license_boundary_exceptions[0].agpl_modules below (one entry each, with a
+          # trailing slash). check-license-headers.py fails if the two lists disagree -- they drifted
+          # apart from the tree once already (#2280).
           paths:
             - openbank-agent-service/
             - openbank-copilot-service/
@@ -2259,22 +2262,33 @@ data:
             - openbank-docs-truth-agent/
             - openbank-authz-policy-auditor/
             - openbank-flaky-test-hunter/
+            - openbank-ap2-service/
+            - openbank-mcp-service/
           reason: "open-core: AGPL-3.0-only + commercial dual-licensing of the AI agent services"
           adr: ADR-0136
       license_boundary_exceptions:
         - description: "AGPL/Apache seam (in-repo). The AI agent services are AGPL-3.0-only; no Apache-2.0 module may take a build/compile dependency on them (only network/HTTP use is allowed). They depend on openbank-libs (Apache-2.0), which is permitted -- copyleft may consume permissive code."
+          # CANONICAL list of the in-repo AGPL-3.0-only modules -- the single source of truth for
+          # which components sit outside the root Apache-2.0 LICENSE. NOTICE and README deliberately
+          # do NOT enumerate them (they point here instead), because a hand-maintained second copy
+          # is what let the published NOTICE claim 4 modules while the tree carried 12 (#2280).
+          # Adding a module here means: give it its own LICENSE, stamp AGPL-3.0-only headers
+          # (scripts/add-license-headers.sh is path-aware from this list), and keep the paths list above
+          # in sync. Enforced by .github/scripts/check-license-headers.py.
           agpl_modules:
-            - openbank-agent-service
-            - openbank-copilot-service
-            - openbank-devops-agent
-            - openbank-finops-agent
+            - openbank-agent-service            # ADR-0136
+            - openbank-copilot-service          # ADR-0136
+            - openbank-devops-agent             # ADR-0136
+            - openbank-finops-agent             # ADR-0136
             - openbank-control-liveness-sentinel
             - openbank-governance-auditor
             - openbank-release-steward
             - openbank-docs-truth-agent
             - openbank-authz-policy-auditor
             - openbank-flaky-test-hunter
-          rule: "no Apache-2.0 module may declare project(':openbank-agent-service'|':openbank-copilot-service'|':openbank-devops-agent'|':openbank-finops-agent'|':openbank-control-liveness-sentinel'|':openbank-governance-auditor'|':openbank-release-steward'|':openbank-docs-truth-agent'|':openbank-authz-policy-auditor'|':openbank-flaky-test-hunter') as a dependency"
+            - openbank-ap2-service              # ADR-0193 -- same agent plane as mcp-service
+            - openbank-mcp-service              # ADR-0181 -- explicitly inside the ADR-0136 boundary
+          rule: "no Apache-2.0 module may declare project(':openbank-agent-service'|':openbank-copilot-service'|':openbank-devops-agent'|':openbank-finops-agent'|':openbank-control-liveness-sentinel'|':openbank-governance-auditor'|':openbank-release-steward'|':openbank-docs-truth-agent'|':openbank-authz-policy-auditor'|':openbank-flaky-test-hunter'|':openbank-ap2-service'|':openbank-mcp-service') as a dependency"
           license: "AGPL-3.0-only"
           adr: ADR-0136
       block_on_cve_severity: [CRITICAL, HIGH]

--- a/openbank-infra/gitops/components/aml/aml-service.yaml
+++ b/openbank-infra/gitops/components/aml/aml-service.yaml
@@ -22,7 +22,7 @@ spec:
       annotations:
         # Rolls the pod when the OPA bundle changes (subPath mounts do not hot-reload).
         # Kept in sync by gen-aml-opa-bundle.sh (do not hand-edit).
-        openbank.tech/policy-checksum: "d7592465d131ed41"
+        openbank.tech/policy-checksum: "f0f15c22d1ce793e"
     spec:
       securityContext:
         runAsNonRoot: true

--- a/openbank-infra/gitops/components/anacredit/anacredit-opa-bundle.yaml
+++ b/openbank-infra/gitops/components/anacredit/anacredit-opa-bundle.yaml
@@ -9,7 +9,7 @@ metadata:
     app.kubernetes.io/name: anacredit-service
     app.kubernetes.io/part-of: anacredit
   annotations:
-    openbank.tech/policy-checksum: "4fa2d946aeee1688"
+    openbank.tech/policy-checksum: "226e8c3941b66c12"
 data:
   rest.rego: |
     # SPDX-License-Identifier: Apache-2.0
@@ -2218,6 +2218,9 @@ data:
       license_denylist_exceptions:
         - license: AGPL-3.0-only
           scope: agent-services                 # in-repo open-core; own LICENSE, commercial dual-license
+          # DERIVED from license_boundary_exceptions[0].agpl_modules below (one entry each, with a
+          # trailing slash). check-license-headers.py fails if the two lists disagree -- they drifted
+          # apart from the tree once already (#2280).
           paths:
             - openbank-agent-service/
             - openbank-copilot-service/
@@ -2229,22 +2232,33 @@ data:
             - openbank-docs-truth-agent/
             - openbank-authz-policy-auditor/
             - openbank-flaky-test-hunter/
+            - openbank-ap2-service/
+            - openbank-mcp-service/
           reason: "open-core: AGPL-3.0-only + commercial dual-licensing of the AI agent services"
           adr: ADR-0136
       license_boundary_exceptions:
         - description: "AGPL/Apache seam (in-repo). The AI agent services are AGPL-3.0-only; no Apache-2.0 module may take a build/compile dependency on them (only network/HTTP use is allowed). They depend on openbank-libs (Apache-2.0), which is permitted -- copyleft may consume permissive code."
+          # CANONICAL list of the in-repo AGPL-3.0-only modules -- the single source of truth for
+          # which components sit outside the root Apache-2.0 LICENSE. NOTICE and README deliberately
+          # do NOT enumerate them (they point here instead), because a hand-maintained second copy
+          # is what let the published NOTICE claim 4 modules while the tree carried 12 (#2280).
+          # Adding a module here means: give it its own LICENSE, stamp AGPL-3.0-only headers
+          # (scripts/add-license-headers.sh is path-aware from this list), and keep the paths list above
+          # in sync. Enforced by .github/scripts/check-license-headers.py.
           agpl_modules:
-            - openbank-agent-service
-            - openbank-copilot-service
-            - openbank-devops-agent
-            - openbank-finops-agent
+            - openbank-agent-service            # ADR-0136
+            - openbank-copilot-service          # ADR-0136
+            - openbank-devops-agent             # ADR-0136
+            - openbank-finops-agent             # ADR-0136
             - openbank-control-liveness-sentinel
             - openbank-governance-auditor
             - openbank-release-steward
             - openbank-docs-truth-agent
             - openbank-authz-policy-auditor
             - openbank-flaky-test-hunter
-          rule: "no Apache-2.0 module may declare project(':openbank-agent-service'|':openbank-copilot-service'|':openbank-devops-agent'|':openbank-finops-agent'|':openbank-control-liveness-sentinel'|':openbank-governance-auditor'|':openbank-release-steward'|':openbank-docs-truth-agent'|':openbank-authz-policy-auditor'|':openbank-flaky-test-hunter') as a dependency"
+            - openbank-ap2-service              # ADR-0193 -- same agent plane as mcp-service
+            - openbank-mcp-service              # ADR-0181 -- explicitly inside the ADR-0136 boundary
+          rule: "no Apache-2.0 module may declare project(':openbank-agent-service'|':openbank-copilot-service'|':openbank-devops-agent'|':openbank-finops-agent'|':openbank-control-liveness-sentinel'|':openbank-governance-auditor'|':openbank-release-steward'|':openbank-docs-truth-agent'|':openbank-authz-policy-auditor'|':openbank-flaky-test-hunter'|':openbank-ap2-service'|':openbank-mcp-service') as a dependency"
           license: "AGPL-3.0-only"
           adr: ADR-0136
       block_on_cve_severity: [CRITICAL, HIGH]

--- a/openbank-infra/gitops/components/anacredit/anacredit-service.yaml
+++ b/openbank-infra/gitops/components/anacredit/anacredit-service.yaml
@@ -32,7 +32,7 @@ spec:
       annotations:
         # Rolls the pods when the OPA bundle changes — subPath mounts do NOT hot-reload.
         # Kept in sync by gen-anacredit-opa-bundle.sh (do not hand-edit).
-        openbank.tech/policy-checksum: "4fa2d946aeee1688"
+        openbank.tech/policy-checksum: "226e8c3941b66c12"
     spec:
       securityContext:
         runAsNonRoot: true

--- a/openbank-infra/gitops/components/ap2/ap2-opa-bundle.yaml
+++ b/openbank-infra/gitops/components/ap2/ap2-opa-bundle.yaml
@@ -9,7 +9,7 @@ metadata:
     app.kubernetes.io/name: mcp-service
     app.kubernetes.io/part-of: platform
   annotations:
-    openbank.tech/policy-checksum: "39551e1032eb36b2"
+    openbank.tech/policy-checksum: "8b40f47809078cc9"
 data:
   rest.rego: |
     # SPDX-License-Identifier: Apache-2.0
@@ -2186,6 +2186,9 @@ data:
       license_denylist_exceptions:
         - license: AGPL-3.0-only
           scope: agent-services                 # in-repo open-core; own LICENSE, commercial dual-license
+          # DERIVED from license_boundary_exceptions[0].agpl_modules below (one entry each, with a
+          # trailing slash). check-license-headers.py fails if the two lists disagree -- they drifted
+          # apart from the tree once already (#2280).
           paths:
             - openbank-agent-service/
             - openbank-copilot-service/
@@ -2197,22 +2200,33 @@ data:
             - openbank-docs-truth-agent/
             - openbank-authz-policy-auditor/
             - openbank-flaky-test-hunter/
+            - openbank-ap2-service/
+            - openbank-mcp-service/
           reason: "open-core: AGPL-3.0-only + commercial dual-licensing of the AI agent services"
           adr: ADR-0136
       license_boundary_exceptions:
         - description: "AGPL/Apache seam (in-repo). The AI agent services are AGPL-3.0-only; no Apache-2.0 module may take a build/compile dependency on them (only network/HTTP use is allowed). They depend on openbank-libs (Apache-2.0), which is permitted -- copyleft may consume permissive code."
+          # CANONICAL list of the in-repo AGPL-3.0-only modules -- the single source of truth for
+          # which components sit outside the root Apache-2.0 LICENSE. NOTICE and README deliberately
+          # do NOT enumerate them (they point here instead), because a hand-maintained second copy
+          # is what let the published NOTICE claim 4 modules while the tree carried 12 (#2280).
+          # Adding a module here means: give it its own LICENSE, stamp AGPL-3.0-only headers
+          # (scripts/add-license-headers.sh is path-aware from this list), and keep the paths list above
+          # in sync. Enforced by .github/scripts/check-license-headers.py.
           agpl_modules:
-            - openbank-agent-service
-            - openbank-copilot-service
-            - openbank-devops-agent
-            - openbank-finops-agent
+            - openbank-agent-service            # ADR-0136
+            - openbank-copilot-service          # ADR-0136
+            - openbank-devops-agent             # ADR-0136
+            - openbank-finops-agent             # ADR-0136
             - openbank-control-liveness-sentinel
             - openbank-governance-auditor
             - openbank-release-steward
             - openbank-docs-truth-agent
             - openbank-authz-policy-auditor
             - openbank-flaky-test-hunter
-          rule: "no Apache-2.0 module may declare project(':openbank-agent-service'|':openbank-copilot-service'|':openbank-devops-agent'|':openbank-finops-agent'|':openbank-control-liveness-sentinel'|':openbank-governance-auditor'|':openbank-release-steward'|':openbank-docs-truth-agent'|':openbank-authz-policy-auditor'|':openbank-flaky-test-hunter') as a dependency"
+            - openbank-ap2-service              # ADR-0193 -- same agent plane as mcp-service
+            - openbank-mcp-service              # ADR-0181 -- explicitly inside the ADR-0136 boundary
+          rule: "no Apache-2.0 module may declare project(':openbank-agent-service'|':openbank-copilot-service'|':openbank-devops-agent'|':openbank-finops-agent'|':openbank-control-liveness-sentinel'|':openbank-governance-auditor'|':openbank-release-steward'|':openbank-docs-truth-agent'|':openbank-authz-policy-auditor'|':openbank-flaky-test-hunter'|':openbank-ap2-service'|':openbank-mcp-service') as a dependency"
           license: "AGPL-3.0-only"
           adr: ADR-0136
       block_on_cve_severity: [CRITICAL, HIGH]

--- a/openbank-infra/gitops/components/ap2/ap2-service.yaml
+++ b/openbank-infra/gitops/components/ap2/ap2-service.yaml
@@ -30,7 +30,7 @@ spec:
       annotations:
         # Roll the pod when the OPA policy bundle changes (subPath mounts don't hot-reload).
         # Kept in sync by gen-ap2-opa-bundle.sh (do not hand-edit).
-        openbank.tech/policy-checksum: "39551e1032eb36b2"
+        openbank.tech/policy-checksum: "8b40f47809078cc9"
     spec:
       securityContext:
         runAsNonRoot: true

--- a/openbank-infra/gitops/components/audit/audit-opa-bundle.yaml
+++ b/openbank-infra/gitops/components/audit/audit-opa-bundle.yaml
@@ -9,7 +9,7 @@ metadata:
     app.kubernetes.io/name: audit-service
     app.kubernetes.io/part-of: audit
   annotations:
-    openbank.tech/policy-checksum: "3cd18c2aac6d236b"
+    openbank.tech/policy-checksum: "f831fe5bb5f83319"
 data:
   rest.rego: |
     # SPDX-License-Identifier: Apache-2.0
@@ -2230,6 +2230,9 @@ data:
       license_denylist_exceptions:
         - license: AGPL-3.0-only
           scope: agent-services                 # in-repo open-core; own LICENSE, commercial dual-license
+          # DERIVED from license_boundary_exceptions[0].agpl_modules below (one entry each, with a
+          # trailing slash). check-license-headers.py fails if the two lists disagree -- they drifted
+          # apart from the tree once already (#2280).
           paths:
             - openbank-agent-service/
             - openbank-copilot-service/
@@ -2241,22 +2244,33 @@ data:
             - openbank-docs-truth-agent/
             - openbank-authz-policy-auditor/
             - openbank-flaky-test-hunter/
+            - openbank-ap2-service/
+            - openbank-mcp-service/
           reason: "open-core: AGPL-3.0-only + commercial dual-licensing of the AI agent services"
           adr: ADR-0136
       license_boundary_exceptions:
         - description: "AGPL/Apache seam (in-repo). The AI agent services are AGPL-3.0-only; no Apache-2.0 module may take a build/compile dependency on them (only network/HTTP use is allowed). They depend on openbank-libs (Apache-2.0), which is permitted -- copyleft may consume permissive code."
+          # CANONICAL list of the in-repo AGPL-3.0-only modules -- the single source of truth for
+          # which components sit outside the root Apache-2.0 LICENSE. NOTICE and README deliberately
+          # do NOT enumerate them (they point here instead), because a hand-maintained second copy
+          # is what let the published NOTICE claim 4 modules while the tree carried 12 (#2280).
+          # Adding a module here means: give it its own LICENSE, stamp AGPL-3.0-only headers
+          # (scripts/add-license-headers.sh is path-aware from this list), and keep the paths list above
+          # in sync. Enforced by .github/scripts/check-license-headers.py.
           agpl_modules:
-            - openbank-agent-service
-            - openbank-copilot-service
-            - openbank-devops-agent
-            - openbank-finops-agent
+            - openbank-agent-service            # ADR-0136
+            - openbank-copilot-service          # ADR-0136
+            - openbank-devops-agent             # ADR-0136
+            - openbank-finops-agent             # ADR-0136
             - openbank-control-liveness-sentinel
             - openbank-governance-auditor
             - openbank-release-steward
             - openbank-docs-truth-agent
             - openbank-authz-policy-auditor
             - openbank-flaky-test-hunter
-          rule: "no Apache-2.0 module may declare project(':openbank-agent-service'|':openbank-copilot-service'|':openbank-devops-agent'|':openbank-finops-agent'|':openbank-control-liveness-sentinel'|':openbank-governance-auditor'|':openbank-release-steward'|':openbank-docs-truth-agent'|':openbank-authz-policy-auditor'|':openbank-flaky-test-hunter') as a dependency"
+            - openbank-ap2-service              # ADR-0193 -- same agent plane as mcp-service
+            - openbank-mcp-service              # ADR-0181 -- explicitly inside the ADR-0136 boundary
+          rule: "no Apache-2.0 module may declare project(':openbank-agent-service'|':openbank-copilot-service'|':openbank-devops-agent'|':openbank-finops-agent'|':openbank-control-liveness-sentinel'|':openbank-governance-auditor'|':openbank-release-steward'|':openbank-docs-truth-agent'|':openbank-authz-policy-auditor'|':openbank-flaky-test-hunter'|':openbank-ap2-service'|':openbank-mcp-service') as a dependency"
           license: "AGPL-3.0-only"
           adr: ADR-0136
       block_on_cve_severity: [CRITICAL, HIGH]

--- a/openbank-infra/gitops/components/audit/audit-service.yaml
+++ b/openbank-infra/gitops/components/audit/audit-service.yaml
@@ -22,7 +22,7 @@ spec:
       annotations:
         # Rolls the pod when the OPA bundle changes (subPath mounts do not hot-reload).
         # Kept in sync by gen-audit-opa-bundle.sh (do not hand-edit).
-        openbank.tech/policy-checksum: "3cd18c2aac6d236b"
+        openbank.tech/policy-checksum: "f831fe5bb5f83319"
     spec:
       securityContext:
         runAsNonRoot: true

--- a/openbank-infra/gitops/components/balances/balance-opa-bundle.yaml
+++ b/openbank-infra/gitops/components/balances/balance-opa-bundle.yaml
@@ -9,7 +9,7 @@ metadata:
     app.kubernetes.io/name: balance-service
     app.kubernetes.io/part-of: balances
   annotations:
-    openbank.tech/policy-checksum: "708c35bdca22512d"
+    openbank.tech/policy-checksum: "9228df3fc7bcd9c3"
 data:
   rest.rego: |
     # SPDX-License-Identifier: Apache-2.0
@@ -2319,6 +2319,9 @@ data:
       license_denylist_exceptions:
         - license: AGPL-3.0-only
           scope: agent-services                 # in-repo open-core; own LICENSE, commercial dual-license
+          # DERIVED from license_boundary_exceptions[0].agpl_modules below (one entry each, with a
+          # trailing slash). check-license-headers.py fails if the two lists disagree -- they drifted
+          # apart from the tree once already (#2280).
           paths:
             - openbank-agent-service/
             - openbank-copilot-service/
@@ -2330,22 +2333,33 @@ data:
             - openbank-docs-truth-agent/
             - openbank-authz-policy-auditor/
             - openbank-flaky-test-hunter/
+            - openbank-ap2-service/
+            - openbank-mcp-service/
           reason: "open-core: AGPL-3.0-only + commercial dual-licensing of the AI agent services"
           adr: ADR-0136
       license_boundary_exceptions:
         - description: "AGPL/Apache seam (in-repo). The AI agent services are AGPL-3.0-only; no Apache-2.0 module may take a build/compile dependency on them (only network/HTTP use is allowed). They depend on openbank-libs (Apache-2.0), which is permitted -- copyleft may consume permissive code."
+          # CANONICAL list of the in-repo AGPL-3.0-only modules -- the single source of truth for
+          # which components sit outside the root Apache-2.0 LICENSE. NOTICE and README deliberately
+          # do NOT enumerate them (they point here instead), because a hand-maintained second copy
+          # is what let the published NOTICE claim 4 modules while the tree carried 12 (#2280).
+          # Adding a module here means: give it its own LICENSE, stamp AGPL-3.0-only headers
+          # (scripts/add-license-headers.sh is path-aware from this list), and keep the paths list above
+          # in sync. Enforced by .github/scripts/check-license-headers.py.
           agpl_modules:
-            - openbank-agent-service
-            - openbank-copilot-service
-            - openbank-devops-agent
-            - openbank-finops-agent
+            - openbank-agent-service            # ADR-0136
+            - openbank-copilot-service          # ADR-0136
+            - openbank-devops-agent             # ADR-0136
+            - openbank-finops-agent             # ADR-0136
             - openbank-control-liveness-sentinel
             - openbank-governance-auditor
             - openbank-release-steward
             - openbank-docs-truth-agent
             - openbank-authz-policy-auditor
             - openbank-flaky-test-hunter
-          rule: "no Apache-2.0 module may declare project(':openbank-agent-service'|':openbank-copilot-service'|':openbank-devops-agent'|':openbank-finops-agent'|':openbank-control-liveness-sentinel'|':openbank-governance-auditor'|':openbank-release-steward'|':openbank-docs-truth-agent'|':openbank-authz-policy-auditor'|':openbank-flaky-test-hunter') as a dependency"
+            - openbank-ap2-service              # ADR-0193 -- same agent plane as mcp-service
+            - openbank-mcp-service              # ADR-0181 -- explicitly inside the ADR-0136 boundary
+          rule: "no Apache-2.0 module may declare project(':openbank-agent-service'|':openbank-copilot-service'|':openbank-devops-agent'|':openbank-finops-agent'|':openbank-control-liveness-sentinel'|':openbank-governance-auditor'|':openbank-release-steward'|':openbank-docs-truth-agent'|':openbank-authz-policy-auditor'|':openbank-flaky-test-hunter'|':openbank-ap2-service'|':openbank-mcp-service') as a dependency"
           license: "AGPL-3.0-only"
           adr: ADR-0136
       block_on_cve_severity: [CRITICAL, HIGH]

--- a/openbank-infra/gitops/components/balances/balance-service.yaml
+++ b/openbank-infra/gitops/components/balances/balance-service.yaml
@@ -34,7 +34,7 @@ spec:
       annotations:
         # Rolls the pods when the OPA bundle changes — subPath mounts do NOT hot-reload.
         # Kept in sync by gen-balance-opa-bundle.sh (do not hand-edit).
-        openbank.tech/policy-checksum: "708c35bdca22512d"
+        openbank.tech/policy-checksum: "9228df3fc7bcd9c3"
     spec:
       securityContext:
         runAsNonRoot: true

--- a/openbank-infra/gitops/components/billing/billing-opa-bundle.yaml
+++ b/openbank-infra/gitops/components/billing/billing-opa-bundle.yaml
@@ -9,7 +9,7 @@ metadata:
     app.kubernetes.io/name: billing-service
     app.kubernetes.io/part-of: billing
   annotations:
-    openbank.tech/policy-checksum: "02421ff1a852528c"
+    openbank.tech/policy-checksum: "c3f7dc6dc397fbb0"
 data:
   rest.rego: |
     # SPDX-License-Identifier: Apache-2.0
@@ -2224,6 +2224,9 @@ data:
       license_denylist_exceptions:
         - license: AGPL-3.0-only
           scope: agent-services                 # in-repo open-core; own LICENSE, commercial dual-license
+          # DERIVED from license_boundary_exceptions[0].agpl_modules below (one entry each, with a
+          # trailing slash). check-license-headers.py fails if the two lists disagree -- they drifted
+          # apart from the tree once already (#2280).
           paths:
             - openbank-agent-service/
             - openbank-copilot-service/
@@ -2235,22 +2238,33 @@ data:
             - openbank-docs-truth-agent/
             - openbank-authz-policy-auditor/
             - openbank-flaky-test-hunter/
+            - openbank-ap2-service/
+            - openbank-mcp-service/
           reason: "open-core: AGPL-3.0-only + commercial dual-licensing of the AI agent services"
           adr: ADR-0136
       license_boundary_exceptions:
         - description: "AGPL/Apache seam (in-repo). The AI agent services are AGPL-3.0-only; no Apache-2.0 module may take a build/compile dependency on them (only network/HTTP use is allowed). They depend on openbank-libs (Apache-2.0), which is permitted -- copyleft may consume permissive code."
+          # CANONICAL list of the in-repo AGPL-3.0-only modules -- the single source of truth for
+          # which components sit outside the root Apache-2.0 LICENSE. NOTICE and README deliberately
+          # do NOT enumerate them (they point here instead), because a hand-maintained second copy
+          # is what let the published NOTICE claim 4 modules while the tree carried 12 (#2280).
+          # Adding a module here means: give it its own LICENSE, stamp AGPL-3.0-only headers
+          # (scripts/add-license-headers.sh is path-aware from this list), and keep the paths list above
+          # in sync. Enforced by .github/scripts/check-license-headers.py.
           agpl_modules:
-            - openbank-agent-service
-            - openbank-copilot-service
-            - openbank-devops-agent
-            - openbank-finops-agent
+            - openbank-agent-service            # ADR-0136
+            - openbank-copilot-service          # ADR-0136
+            - openbank-devops-agent             # ADR-0136
+            - openbank-finops-agent             # ADR-0136
             - openbank-control-liveness-sentinel
             - openbank-governance-auditor
             - openbank-release-steward
             - openbank-docs-truth-agent
             - openbank-authz-policy-auditor
             - openbank-flaky-test-hunter
-          rule: "no Apache-2.0 module may declare project(':openbank-agent-service'|':openbank-copilot-service'|':openbank-devops-agent'|':openbank-finops-agent'|':openbank-control-liveness-sentinel'|':openbank-governance-auditor'|':openbank-release-steward'|':openbank-docs-truth-agent'|':openbank-authz-policy-auditor'|':openbank-flaky-test-hunter') as a dependency"
+            - openbank-ap2-service              # ADR-0193 -- same agent plane as mcp-service
+            - openbank-mcp-service              # ADR-0181 -- explicitly inside the ADR-0136 boundary
+          rule: "no Apache-2.0 module may declare project(':openbank-agent-service'|':openbank-copilot-service'|':openbank-devops-agent'|':openbank-finops-agent'|':openbank-control-liveness-sentinel'|':openbank-governance-auditor'|':openbank-release-steward'|':openbank-docs-truth-agent'|':openbank-authz-policy-auditor'|':openbank-flaky-test-hunter'|':openbank-ap2-service'|':openbank-mcp-service') as a dependency"
           license: "AGPL-3.0-only"
           adr: ADR-0136
       block_on_cve_severity: [CRITICAL, HIGH]

--- a/openbank-infra/gitops/components/billing/billing-service.yaml
+++ b/openbank-infra/gitops/components/billing/billing-service.yaml
@@ -27,7 +27,7 @@ spec:
       annotations:
         # Rolls the pods when the OPA bundle changes — subPath mounts do NOT hot-reload.
         # Kept in sync by gen-billing-opa-bundle.sh (do not hand-edit).
-        openbank.tech/policy-checksum: "02421ff1a852528c"
+        openbank.tech/policy-checksum: "c3f7dc6dc397fbb0"
     spec:
       securityContext:
         runAsNonRoot: true

--- a/openbank-infra/gitops/components/consent/consent-opa-bundle.yaml
+++ b/openbank-infra/gitops/components/consent/consent-opa-bundle.yaml
@@ -9,7 +9,7 @@ metadata:
     app.kubernetes.io/name: consent-service
     app.kubernetes.io/part-of: consent
   annotations:
-    openbank.tech/policy-checksum: "19f4216b9a81aeab"
+    openbank.tech/policy-checksum: "25b13153a7d8e394"
 data:
   rest.rego: |
     # SPDX-License-Identifier: Apache-2.0
@@ -2256,6 +2256,9 @@ data:
       license_denylist_exceptions:
         - license: AGPL-3.0-only
           scope: agent-services                 # in-repo open-core; own LICENSE, commercial dual-license
+          # DERIVED from license_boundary_exceptions[0].agpl_modules below (one entry each, with a
+          # trailing slash). check-license-headers.py fails if the two lists disagree -- they drifted
+          # apart from the tree once already (#2280).
           paths:
             - openbank-agent-service/
             - openbank-copilot-service/
@@ -2267,22 +2270,33 @@ data:
             - openbank-docs-truth-agent/
             - openbank-authz-policy-auditor/
             - openbank-flaky-test-hunter/
+            - openbank-ap2-service/
+            - openbank-mcp-service/
           reason: "open-core: AGPL-3.0-only + commercial dual-licensing of the AI agent services"
           adr: ADR-0136
       license_boundary_exceptions:
         - description: "AGPL/Apache seam (in-repo). The AI agent services are AGPL-3.0-only; no Apache-2.0 module may take a build/compile dependency on them (only network/HTTP use is allowed). They depend on openbank-libs (Apache-2.0), which is permitted -- copyleft may consume permissive code."
+          # CANONICAL list of the in-repo AGPL-3.0-only modules -- the single source of truth for
+          # which components sit outside the root Apache-2.0 LICENSE. NOTICE and README deliberately
+          # do NOT enumerate them (they point here instead), because a hand-maintained second copy
+          # is what let the published NOTICE claim 4 modules while the tree carried 12 (#2280).
+          # Adding a module here means: give it its own LICENSE, stamp AGPL-3.0-only headers
+          # (scripts/add-license-headers.sh is path-aware from this list), and keep the paths list above
+          # in sync. Enforced by .github/scripts/check-license-headers.py.
           agpl_modules:
-            - openbank-agent-service
-            - openbank-copilot-service
-            - openbank-devops-agent
-            - openbank-finops-agent
+            - openbank-agent-service            # ADR-0136
+            - openbank-copilot-service          # ADR-0136
+            - openbank-devops-agent             # ADR-0136
+            - openbank-finops-agent             # ADR-0136
             - openbank-control-liveness-sentinel
             - openbank-governance-auditor
             - openbank-release-steward
             - openbank-docs-truth-agent
             - openbank-authz-policy-auditor
             - openbank-flaky-test-hunter
-          rule: "no Apache-2.0 module may declare project(':openbank-agent-service'|':openbank-copilot-service'|':openbank-devops-agent'|':openbank-finops-agent'|':openbank-control-liveness-sentinel'|':openbank-governance-auditor'|':openbank-release-steward'|':openbank-docs-truth-agent'|':openbank-authz-policy-auditor'|':openbank-flaky-test-hunter') as a dependency"
+            - openbank-ap2-service              # ADR-0193 -- same agent plane as mcp-service
+            - openbank-mcp-service              # ADR-0181 -- explicitly inside the ADR-0136 boundary
+          rule: "no Apache-2.0 module may declare project(':openbank-agent-service'|':openbank-copilot-service'|':openbank-devops-agent'|':openbank-finops-agent'|':openbank-control-liveness-sentinel'|':openbank-governance-auditor'|':openbank-release-steward'|':openbank-docs-truth-agent'|':openbank-authz-policy-auditor'|':openbank-flaky-test-hunter'|':openbank-ap2-service'|':openbank-mcp-service') as a dependency"
           license: "AGPL-3.0-only"
           adr: ADR-0136
       block_on_cve_severity: [CRITICAL, HIGH]

--- a/openbank-infra/gitops/components/consent/consent-service.yaml
+++ b/openbank-infra/gitops/components/consent/consent-service.yaml
@@ -28,7 +28,7 @@ spec:
       annotations:
         # Rolls the pods when the OPA bundle changes — subPath mounts do NOT hot-reload.
         # Kept in sync by gen-consent-opa-bundle.sh (do not hand-edit).
-        openbank.tech/policy-checksum: "19f4216b9a81aeab"
+        openbank.tech/policy-checksum: "25b13153a7d8e394"
     spec:
       securityContext:
         runAsNonRoot: true

--- a/openbank-infra/gitops/components/copilot/copilot-opa-bundle.yaml
+++ b/openbank-infra/gitops/components/copilot/copilot-opa-bundle.yaml
@@ -9,7 +9,7 @@ metadata:
     app.kubernetes.io/name: copilot-service
     app.kubernetes.io/part-of: platform
   annotations:
-    openbank.tech/policy-checksum: "cb371a6499189e24"
+    openbank.tech/policy-checksum: "f252537f3721dd9c"
 data:
   rest.rego: |
     # SPDX-License-Identifier: Apache-2.0
@@ -2310,6 +2310,9 @@ data:
       license_denylist_exceptions:
         - license: AGPL-3.0-only
           scope: agent-services                 # in-repo open-core; own LICENSE, commercial dual-license
+          # DERIVED from license_boundary_exceptions[0].agpl_modules below (one entry each, with a
+          # trailing slash). check-license-headers.py fails if the two lists disagree -- they drifted
+          # apart from the tree once already (#2280).
           paths:
             - openbank-agent-service/
             - openbank-copilot-service/
@@ -2321,22 +2324,33 @@ data:
             - openbank-docs-truth-agent/
             - openbank-authz-policy-auditor/
             - openbank-flaky-test-hunter/
+            - openbank-ap2-service/
+            - openbank-mcp-service/
           reason: "open-core: AGPL-3.0-only + commercial dual-licensing of the AI agent services"
           adr: ADR-0136
       license_boundary_exceptions:
         - description: "AGPL/Apache seam (in-repo). The AI agent services are AGPL-3.0-only; no Apache-2.0 module may take a build/compile dependency on them (only network/HTTP use is allowed). They depend on openbank-libs (Apache-2.0), which is permitted -- copyleft may consume permissive code."
+          # CANONICAL list of the in-repo AGPL-3.0-only modules -- the single source of truth for
+          # which components sit outside the root Apache-2.0 LICENSE. NOTICE and README deliberately
+          # do NOT enumerate them (they point here instead), because a hand-maintained second copy
+          # is what let the published NOTICE claim 4 modules while the tree carried 12 (#2280).
+          # Adding a module here means: give it its own LICENSE, stamp AGPL-3.0-only headers
+          # (scripts/add-license-headers.sh is path-aware from this list), and keep the paths list above
+          # in sync. Enforced by .github/scripts/check-license-headers.py.
           agpl_modules:
-            - openbank-agent-service
-            - openbank-copilot-service
-            - openbank-devops-agent
-            - openbank-finops-agent
+            - openbank-agent-service            # ADR-0136
+            - openbank-copilot-service          # ADR-0136
+            - openbank-devops-agent             # ADR-0136
+            - openbank-finops-agent             # ADR-0136
             - openbank-control-liveness-sentinel
             - openbank-governance-auditor
             - openbank-release-steward
             - openbank-docs-truth-agent
             - openbank-authz-policy-auditor
             - openbank-flaky-test-hunter
-          rule: "no Apache-2.0 module may declare project(':openbank-agent-service'|':openbank-copilot-service'|':openbank-devops-agent'|':openbank-finops-agent'|':openbank-control-liveness-sentinel'|':openbank-governance-auditor'|':openbank-release-steward'|':openbank-docs-truth-agent'|':openbank-authz-policy-auditor'|':openbank-flaky-test-hunter') as a dependency"
+            - openbank-ap2-service              # ADR-0193 -- same agent plane as mcp-service
+            - openbank-mcp-service              # ADR-0181 -- explicitly inside the ADR-0136 boundary
+          rule: "no Apache-2.0 module may declare project(':openbank-agent-service'|':openbank-copilot-service'|':openbank-devops-agent'|':openbank-finops-agent'|':openbank-control-liveness-sentinel'|':openbank-governance-auditor'|':openbank-release-steward'|':openbank-docs-truth-agent'|':openbank-authz-policy-auditor'|':openbank-flaky-test-hunter'|':openbank-ap2-service'|':openbank-mcp-service') as a dependency"
           license: "AGPL-3.0-only"
           adr: ADR-0136
       block_on_cve_severity: [CRITICAL, HIGH]

--- a/openbank-infra/gitops/components/copilot/copilot-service.yaml
+++ b/openbank-infra/gitops/components/copilot/copilot-service.yaml
@@ -29,7 +29,7 @@ spec:
       annotations:
         # Rolls the pod when the OPA bundle changes — subPath mounts do NOT hot-reload.
         # Kept in sync by gen-copilot-opa-bundle.sh (do not hand-edit).
-        openbank.tech/policy-checksum: "cb371a6499189e24"
+        openbank.tech/policy-checksum: "f252537f3721dd9c"
     spec:
       securityContext:
         runAsNonRoot: true

--- a/openbank-infra/gitops/components/customer-edge/customer-edge-opa-bundle.yaml
+++ b/openbank-infra/gitops/components/customer-edge/customer-edge-opa-bundle.yaml
@@ -10,7 +10,7 @@ metadata:
     app.kubernetes.io/name: customer-edge
     app.kubernetes.io/part-of: customer-edge
   annotations:
-    openbank.tech/policy-checksum: "f86f4fd928041707"
+    openbank.tech/policy-checksum: "1006b34bb3e0708e"
 data:
   rest.rego: |
     # SPDX-License-Identifier: Apache-2.0
@@ -1409,6 +1409,9 @@ data:
       license_denylist_exceptions:
         - license: AGPL-3.0-only
           scope: agent-services                 # in-repo open-core; own LICENSE, commercial dual-license
+          # DERIVED from license_boundary_exceptions[0].agpl_modules below (one entry each, with a
+          # trailing slash). check-license-headers.py fails if the two lists disagree -- they drifted
+          # apart from the tree once already (#2280).
           paths:
             - openbank-agent-service/
             - openbank-copilot-service/
@@ -1420,22 +1423,33 @@ data:
             - openbank-docs-truth-agent/
             - openbank-authz-policy-auditor/
             - openbank-flaky-test-hunter/
+            - openbank-ap2-service/
+            - openbank-mcp-service/
           reason: "open-core: AGPL-3.0-only + commercial dual-licensing of the AI agent services"
           adr: ADR-0136
       license_boundary_exceptions:
         - description: "AGPL/Apache seam (in-repo). The AI agent services are AGPL-3.0-only; no Apache-2.0 module may take a build/compile dependency on them (only network/HTTP use is allowed). They depend on openbank-libs (Apache-2.0), which is permitted -- copyleft may consume permissive code."
+          # CANONICAL list of the in-repo AGPL-3.0-only modules -- the single source of truth for
+          # which components sit outside the root Apache-2.0 LICENSE. NOTICE and README deliberately
+          # do NOT enumerate them (they point here instead), because a hand-maintained second copy
+          # is what let the published NOTICE claim 4 modules while the tree carried 12 (#2280).
+          # Adding a module here means: give it its own LICENSE, stamp AGPL-3.0-only headers
+          # (scripts/add-license-headers.sh is path-aware from this list), and keep the paths list above
+          # in sync. Enforced by .github/scripts/check-license-headers.py.
           agpl_modules:
-            - openbank-agent-service
-            - openbank-copilot-service
-            - openbank-devops-agent
-            - openbank-finops-agent
+            - openbank-agent-service            # ADR-0136
+            - openbank-copilot-service          # ADR-0136
+            - openbank-devops-agent             # ADR-0136
+            - openbank-finops-agent             # ADR-0136
             - openbank-control-liveness-sentinel
             - openbank-governance-auditor
             - openbank-release-steward
             - openbank-docs-truth-agent
             - openbank-authz-policy-auditor
             - openbank-flaky-test-hunter
-          rule: "no Apache-2.0 module may declare project(':openbank-agent-service'|':openbank-copilot-service'|':openbank-devops-agent'|':openbank-finops-agent'|':openbank-control-liveness-sentinel'|':openbank-governance-auditor'|':openbank-release-steward'|':openbank-docs-truth-agent'|':openbank-authz-policy-auditor'|':openbank-flaky-test-hunter') as a dependency"
+            - openbank-ap2-service              # ADR-0193 -- same agent plane as mcp-service
+            - openbank-mcp-service              # ADR-0181 -- explicitly inside the ADR-0136 boundary
+          rule: "no Apache-2.0 module may declare project(':openbank-agent-service'|':openbank-copilot-service'|':openbank-devops-agent'|':openbank-finops-agent'|':openbank-control-liveness-sentinel'|':openbank-governance-auditor'|':openbank-release-steward'|':openbank-docs-truth-agent'|':openbank-authz-policy-auditor'|':openbank-flaky-test-hunter'|':openbank-ap2-service'|':openbank-mcp-service') as a dependency"
           license: "AGPL-3.0-only"
           adr: ADR-0136
       block_on_cve_severity: [CRITICAL, HIGH]

--- a/openbank-infra/gitops/components/customer-edge/customer-edge.yaml
+++ b/openbank-infra/gitops/components/customer-edge/customer-edge.yaml
@@ -65,7 +65,7 @@ spec:
       annotations:
         # Rolls the pod when the OPA bundle changes — subPath mounts do NOT hot-reload.
         # Kept in sync by gen-customer-edge-opa-bundle.sh (do not hand-edit).
-        openbank.tech/policy-checksum: "f86f4fd928041707"
+        openbank.tech/policy-checksum: "1006b34bb3e0708e"
     spec:
       # Dedicated SA so EKS Pod Identity can hand the edge (and ONLY the edge) the
       # feedback-screenshots S3 role — ADR-0192, openbank-infra/aws/envs/sandbox-platform/

--- a/openbank-infra/gitops/components/dispute-service/dispute-opa-bundle.yaml
+++ b/openbank-infra/gitops/components/dispute-service/dispute-opa-bundle.yaml
@@ -9,7 +9,7 @@ metadata:
     app.kubernetes.io/name: dispute-service
     app.kubernetes.io/part-of: dispute
   annotations:
-    openbank.tech/policy-checksum: "ea30405c7e03db2d"
+    openbank.tech/policy-checksum: "3571083a922904f3"
 data:
   rest.rego: |
     # SPDX-License-Identifier: Apache-2.0
@@ -2360,6 +2360,9 @@ data:
       license_denylist_exceptions:
         - license: AGPL-3.0-only
           scope: agent-services                 # in-repo open-core; own LICENSE, commercial dual-license
+          # DERIVED from license_boundary_exceptions[0].agpl_modules below (one entry each, with a
+          # trailing slash). check-license-headers.py fails if the two lists disagree -- they drifted
+          # apart from the tree once already (#2280).
           paths:
             - openbank-agent-service/
             - openbank-copilot-service/
@@ -2371,22 +2374,33 @@ data:
             - openbank-docs-truth-agent/
             - openbank-authz-policy-auditor/
             - openbank-flaky-test-hunter/
+            - openbank-ap2-service/
+            - openbank-mcp-service/
           reason: "open-core: AGPL-3.0-only + commercial dual-licensing of the AI agent services"
           adr: ADR-0136
       license_boundary_exceptions:
         - description: "AGPL/Apache seam (in-repo). The AI agent services are AGPL-3.0-only; no Apache-2.0 module may take a build/compile dependency on them (only network/HTTP use is allowed). They depend on openbank-libs (Apache-2.0), which is permitted -- copyleft may consume permissive code."
+          # CANONICAL list of the in-repo AGPL-3.0-only modules -- the single source of truth for
+          # which components sit outside the root Apache-2.0 LICENSE. NOTICE and README deliberately
+          # do NOT enumerate them (they point here instead), because a hand-maintained second copy
+          # is what let the published NOTICE claim 4 modules while the tree carried 12 (#2280).
+          # Adding a module here means: give it its own LICENSE, stamp AGPL-3.0-only headers
+          # (scripts/add-license-headers.sh is path-aware from this list), and keep the paths list above
+          # in sync. Enforced by .github/scripts/check-license-headers.py.
           agpl_modules:
-            - openbank-agent-service
-            - openbank-copilot-service
-            - openbank-devops-agent
-            - openbank-finops-agent
+            - openbank-agent-service            # ADR-0136
+            - openbank-copilot-service          # ADR-0136
+            - openbank-devops-agent             # ADR-0136
+            - openbank-finops-agent             # ADR-0136
             - openbank-control-liveness-sentinel
             - openbank-governance-auditor
             - openbank-release-steward
             - openbank-docs-truth-agent
             - openbank-authz-policy-auditor
             - openbank-flaky-test-hunter
-          rule: "no Apache-2.0 module may declare project(':openbank-agent-service'|':openbank-copilot-service'|':openbank-devops-agent'|':openbank-finops-agent'|':openbank-control-liveness-sentinel'|':openbank-governance-auditor'|':openbank-release-steward'|':openbank-docs-truth-agent'|':openbank-authz-policy-auditor'|':openbank-flaky-test-hunter') as a dependency"
+            - openbank-ap2-service              # ADR-0193 -- same agent plane as mcp-service
+            - openbank-mcp-service              # ADR-0181 -- explicitly inside the ADR-0136 boundary
+          rule: "no Apache-2.0 module may declare project(':openbank-agent-service'|':openbank-copilot-service'|':openbank-devops-agent'|':openbank-finops-agent'|':openbank-control-liveness-sentinel'|':openbank-governance-auditor'|':openbank-release-steward'|':openbank-docs-truth-agent'|':openbank-authz-policy-auditor'|':openbank-flaky-test-hunter'|':openbank-ap2-service'|':openbank-mcp-service') as a dependency"
           license: "AGPL-3.0-only"
           adr: ADR-0136
       block_on_cve_severity: [CRITICAL, HIGH]

--- a/openbank-infra/gitops/components/dispute-service/dispute-service.yaml
+++ b/openbank-infra/gitops/components/dispute-service/dispute-service.yaml
@@ -15,7 +15,7 @@ spec:
       annotations:
         # Rolls the pod when the OPA bundle changes — subPath mounts do NOT hot-reload.
         # Kept in sync by gen-dispute-opa-bundle.sh (do not hand-edit).
-        openbank.tech/policy-checksum: "ea30405c7e03db2d"
+        openbank.tech/policy-checksum: "3571083a922904f3"
       labels: {app.kubernetes.io/name: dispute-service, app.kubernetes.io/part-of: dispute}
     spec:
       securityContext:

--- a/openbank-infra/gitops/components/document-service/document-service-opa-bundle.yaml
+++ b/openbank-infra/gitops/components/document-service/document-service-opa-bundle.yaml
@@ -10,7 +10,7 @@ metadata:
     app.kubernetes.io/name: document-service
     app.kubernetes.io/part-of: documents
   annotations:
-    openbank.tech/policy-checksum: "f86f4fd928041707"
+    openbank.tech/policy-checksum: "1006b34bb3e0708e"
 data:
   rest.rego: |
     # SPDX-License-Identifier: Apache-2.0
@@ -1409,6 +1409,9 @@ data:
       license_denylist_exceptions:
         - license: AGPL-3.0-only
           scope: agent-services                 # in-repo open-core; own LICENSE, commercial dual-license
+          # DERIVED from license_boundary_exceptions[0].agpl_modules below (one entry each, with a
+          # trailing slash). check-license-headers.py fails if the two lists disagree -- they drifted
+          # apart from the tree once already (#2280).
           paths:
             - openbank-agent-service/
             - openbank-copilot-service/
@@ -1420,22 +1423,33 @@ data:
             - openbank-docs-truth-agent/
             - openbank-authz-policy-auditor/
             - openbank-flaky-test-hunter/
+            - openbank-ap2-service/
+            - openbank-mcp-service/
           reason: "open-core: AGPL-3.0-only + commercial dual-licensing of the AI agent services"
           adr: ADR-0136
       license_boundary_exceptions:
         - description: "AGPL/Apache seam (in-repo). The AI agent services are AGPL-3.0-only; no Apache-2.0 module may take a build/compile dependency on them (only network/HTTP use is allowed). They depend on openbank-libs (Apache-2.0), which is permitted -- copyleft may consume permissive code."
+          # CANONICAL list of the in-repo AGPL-3.0-only modules -- the single source of truth for
+          # which components sit outside the root Apache-2.0 LICENSE. NOTICE and README deliberately
+          # do NOT enumerate them (they point here instead), because a hand-maintained second copy
+          # is what let the published NOTICE claim 4 modules while the tree carried 12 (#2280).
+          # Adding a module here means: give it its own LICENSE, stamp AGPL-3.0-only headers
+          # (scripts/add-license-headers.sh is path-aware from this list), and keep the paths list above
+          # in sync. Enforced by .github/scripts/check-license-headers.py.
           agpl_modules:
-            - openbank-agent-service
-            - openbank-copilot-service
-            - openbank-devops-agent
-            - openbank-finops-agent
+            - openbank-agent-service            # ADR-0136
+            - openbank-copilot-service          # ADR-0136
+            - openbank-devops-agent             # ADR-0136
+            - openbank-finops-agent             # ADR-0136
             - openbank-control-liveness-sentinel
             - openbank-governance-auditor
             - openbank-release-steward
             - openbank-docs-truth-agent
             - openbank-authz-policy-auditor
             - openbank-flaky-test-hunter
-          rule: "no Apache-2.0 module may declare project(':openbank-agent-service'|':openbank-copilot-service'|':openbank-devops-agent'|':openbank-finops-agent'|':openbank-control-liveness-sentinel'|':openbank-governance-auditor'|':openbank-release-steward'|':openbank-docs-truth-agent'|':openbank-authz-policy-auditor'|':openbank-flaky-test-hunter') as a dependency"
+            - openbank-ap2-service              # ADR-0193 -- same agent plane as mcp-service
+            - openbank-mcp-service              # ADR-0181 -- explicitly inside the ADR-0136 boundary
+          rule: "no Apache-2.0 module may declare project(':openbank-agent-service'|':openbank-copilot-service'|':openbank-devops-agent'|':openbank-finops-agent'|':openbank-control-liveness-sentinel'|':openbank-governance-auditor'|':openbank-release-steward'|':openbank-docs-truth-agent'|':openbank-authz-policy-auditor'|':openbank-flaky-test-hunter'|':openbank-ap2-service'|':openbank-mcp-service') as a dependency"
           license: "AGPL-3.0-only"
           adr: ADR-0136
       block_on_cve_severity: [CRITICAL, HIGH]

--- a/openbank-infra/gitops/components/document-service/document-service-service.yaml
+++ b/openbank-infra/gitops/components/document-service/document-service-service.yaml
@@ -43,7 +43,7 @@ spec:
       annotations:
         # Rolls the pods when the OPA bundle changes — subPath mounts do NOT hot-reload.
         # Kept in sync by gen-document-service-opa-bundle.sh (do not hand-edit).
-        openbank.tech/policy-checksum: "f86f4fd928041707"
+        openbank.tech/policy-checksum: "1006b34bb3e0708e"
     spec:
       # ADR-0162 D4 (continued): a dedicated SA (not `default`) is what OpenBao's Kubernetes-auth
       # role `document-service-signing` is bound to — least-privilege, one identity per consumer.

--- a/openbank-infra/gitops/components/fraud-service/fraud-opa-bundle.yaml
+++ b/openbank-infra/gitops/components/fraud-service/fraud-opa-bundle.yaml
@@ -9,7 +9,7 @@ metadata:
     app.kubernetes.io/name: fraud-service
     app.kubernetes.io/part-of: fraud
   annotations:
-    openbank.tech/policy-checksum: "5a6ea4eeeab0fcf6"
+    openbank.tech/policy-checksum: "6fcdb2e89930414f"
 data:
   rest.rego: |
     # SPDX-License-Identifier: Apache-2.0
@@ -2235,6 +2235,9 @@ data:
       license_denylist_exceptions:
         - license: AGPL-3.0-only
           scope: agent-services                 # in-repo open-core; own LICENSE, commercial dual-license
+          # DERIVED from license_boundary_exceptions[0].agpl_modules below (one entry each, with a
+          # trailing slash). check-license-headers.py fails if the two lists disagree -- they drifted
+          # apart from the tree once already (#2280).
           paths:
             - openbank-agent-service/
             - openbank-copilot-service/
@@ -2246,22 +2249,33 @@ data:
             - openbank-docs-truth-agent/
             - openbank-authz-policy-auditor/
             - openbank-flaky-test-hunter/
+            - openbank-ap2-service/
+            - openbank-mcp-service/
           reason: "open-core: AGPL-3.0-only + commercial dual-licensing of the AI agent services"
           adr: ADR-0136
       license_boundary_exceptions:
         - description: "AGPL/Apache seam (in-repo). The AI agent services are AGPL-3.0-only; no Apache-2.0 module may take a build/compile dependency on them (only network/HTTP use is allowed). They depend on openbank-libs (Apache-2.0), which is permitted -- copyleft may consume permissive code."
+          # CANONICAL list of the in-repo AGPL-3.0-only modules -- the single source of truth for
+          # which components sit outside the root Apache-2.0 LICENSE. NOTICE and README deliberately
+          # do NOT enumerate them (they point here instead), because a hand-maintained second copy
+          # is what let the published NOTICE claim 4 modules while the tree carried 12 (#2280).
+          # Adding a module here means: give it its own LICENSE, stamp AGPL-3.0-only headers
+          # (scripts/add-license-headers.sh is path-aware from this list), and keep the paths list above
+          # in sync. Enforced by .github/scripts/check-license-headers.py.
           agpl_modules:
-            - openbank-agent-service
-            - openbank-copilot-service
-            - openbank-devops-agent
-            - openbank-finops-agent
+            - openbank-agent-service            # ADR-0136
+            - openbank-copilot-service          # ADR-0136
+            - openbank-devops-agent             # ADR-0136
+            - openbank-finops-agent             # ADR-0136
             - openbank-control-liveness-sentinel
             - openbank-governance-auditor
             - openbank-release-steward
             - openbank-docs-truth-agent
             - openbank-authz-policy-auditor
             - openbank-flaky-test-hunter
-          rule: "no Apache-2.0 module may declare project(':openbank-agent-service'|':openbank-copilot-service'|':openbank-devops-agent'|':openbank-finops-agent'|':openbank-control-liveness-sentinel'|':openbank-governance-auditor'|':openbank-release-steward'|':openbank-docs-truth-agent'|':openbank-authz-policy-auditor'|':openbank-flaky-test-hunter') as a dependency"
+            - openbank-ap2-service              # ADR-0193 -- same agent plane as mcp-service
+            - openbank-mcp-service              # ADR-0181 -- explicitly inside the ADR-0136 boundary
+          rule: "no Apache-2.0 module may declare project(':openbank-agent-service'|':openbank-copilot-service'|':openbank-devops-agent'|':openbank-finops-agent'|':openbank-control-liveness-sentinel'|':openbank-governance-auditor'|':openbank-release-steward'|':openbank-docs-truth-agent'|':openbank-authz-policy-auditor'|':openbank-flaky-test-hunter'|':openbank-ap2-service'|':openbank-mcp-service') as a dependency"
           license: "AGPL-3.0-only"
           adr: ADR-0136
       block_on_cve_severity: [CRITICAL, HIGH]

--- a/openbank-infra/gitops/components/fraud-service/fraud-service.yaml
+++ b/openbank-infra/gitops/components/fraud-service/fraud-service.yaml
@@ -23,7 +23,7 @@ spec:
       annotations:
         # Rolls the pods when the OPA bundle changes — subPath mounts do NOT hot-reload.
         # Kept in sync by gen-fraud-opa-bundle.sh (do not hand-edit).
-        openbank.tech/policy-checksum: "5a6ea4eeeab0fcf6"
+        openbank.tech/policy-checksum: "6fcdb2e89930414f"
     spec:
       securityContext:
         runAsNonRoot: true

--- a/openbank-infra/gitops/components/fx-service/fx-opa-bundle.yaml
+++ b/openbank-infra/gitops/components/fx-service/fx-opa-bundle.yaml
@@ -9,7 +9,7 @@ metadata:
     app.kubernetes.io/name: fx-service
     app.kubernetes.io/part-of: fx
   annotations:
-    openbank.tech/policy-checksum: "bdf8a13c435719ec"
+    openbank.tech/policy-checksum: "47283df1ad14242f"
 data:
   rest.rego: |
     # SPDX-License-Identifier: Apache-2.0
@@ -2286,6 +2286,9 @@ data:
       license_denylist_exceptions:
         - license: AGPL-3.0-only
           scope: agent-services                 # in-repo open-core; own LICENSE, commercial dual-license
+          # DERIVED from license_boundary_exceptions[0].agpl_modules below (one entry each, with a
+          # trailing slash). check-license-headers.py fails if the two lists disagree -- they drifted
+          # apart from the tree once already (#2280).
           paths:
             - openbank-agent-service/
             - openbank-copilot-service/
@@ -2297,22 +2300,33 @@ data:
             - openbank-docs-truth-agent/
             - openbank-authz-policy-auditor/
             - openbank-flaky-test-hunter/
+            - openbank-ap2-service/
+            - openbank-mcp-service/
           reason: "open-core: AGPL-3.0-only + commercial dual-licensing of the AI agent services"
           adr: ADR-0136
       license_boundary_exceptions:
         - description: "AGPL/Apache seam (in-repo). The AI agent services are AGPL-3.0-only; no Apache-2.0 module may take a build/compile dependency on them (only network/HTTP use is allowed). They depend on openbank-libs (Apache-2.0), which is permitted -- copyleft may consume permissive code."
+          # CANONICAL list of the in-repo AGPL-3.0-only modules -- the single source of truth for
+          # which components sit outside the root Apache-2.0 LICENSE. NOTICE and README deliberately
+          # do NOT enumerate them (they point here instead), because a hand-maintained second copy
+          # is what let the published NOTICE claim 4 modules while the tree carried 12 (#2280).
+          # Adding a module here means: give it its own LICENSE, stamp AGPL-3.0-only headers
+          # (scripts/add-license-headers.sh is path-aware from this list), and keep the paths list above
+          # in sync. Enforced by .github/scripts/check-license-headers.py.
           agpl_modules:
-            - openbank-agent-service
-            - openbank-copilot-service
-            - openbank-devops-agent
-            - openbank-finops-agent
+            - openbank-agent-service            # ADR-0136
+            - openbank-copilot-service          # ADR-0136
+            - openbank-devops-agent             # ADR-0136
+            - openbank-finops-agent             # ADR-0136
             - openbank-control-liveness-sentinel
             - openbank-governance-auditor
             - openbank-release-steward
             - openbank-docs-truth-agent
             - openbank-authz-policy-auditor
             - openbank-flaky-test-hunter
-          rule: "no Apache-2.0 module may declare project(':openbank-agent-service'|':openbank-copilot-service'|':openbank-devops-agent'|':openbank-finops-agent'|':openbank-control-liveness-sentinel'|':openbank-governance-auditor'|':openbank-release-steward'|':openbank-docs-truth-agent'|':openbank-authz-policy-auditor'|':openbank-flaky-test-hunter') as a dependency"
+            - openbank-ap2-service              # ADR-0193 -- same agent plane as mcp-service
+            - openbank-mcp-service              # ADR-0181 -- explicitly inside the ADR-0136 boundary
+          rule: "no Apache-2.0 module may declare project(':openbank-agent-service'|':openbank-copilot-service'|':openbank-devops-agent'|':openbank-finops-agent'|':openbank-control-liveness-sentinel'|':openbank-governance-auditor'|':openbank-release-steward'|':openbank-docs-truth-agent'|':openbank-authz-policy-auditor'|':openbank-flaky-test-hunter'|':openbank-ap2-service'|':openbank-mcp-service') as a dependency"
           license: "AGPL-3.0-only"
           adr: ADR-0136
       block_on_cve_severity: [CRITICAL, HIGH]

--- a/openbank-infra/gitops/components/fx-service/fx-service.yaml
+++ b/openbank-infra/gitops/components/fx-service/fx-service.yaml
@@ -22,7 +22,7 @@ spec:
       annotations:
         # Rolls the pods when the OPA bundle changes — subPath mounts do NOT hot-reload.
         # Kept in sync by gen-fx-opa-bundle.sh (do not hand-edit).
-        openbank.tech/policy-checksum: "bdf8a13c435719ec"
+        openbank.tech/policy-checksum: "47283df1ad14242f"
     spec:
       securityContext:
         runAsNonRoot: true

--- a/openbank-infra/gitops/components/interest-service/interest-opa-bundle.yaml
+++ b/openbank-infra/gitops/components/interest-service/interest-opa-bundle.yaml
@@ -9,7 +9,7 @@ metadata:
     app.kubernetes.io/name: interest-service
     app.kubernetes.io/part-of: interest
   annotations:
-    openbank.tech/policy-checksum: "2c7f3a3883ca331b"
+    openbank.tech/policy-checksum: "f1d9706d1387cc7e"
 data:
   rest.rego: |
     # SPDX-License-Identifier: Apache-2.0
@@ -2220,6 +2220,9 @@ data:
       license_denylist_exceptions:
         - license: AGPL-3.0-only
           scope: agent-services                 # in-repo open-core; own LICENSE, commercial dual-license
+          # DERIVED from license_boundary_exceptions[0].agpl_modules below (one entry each, with a
+          # trailing slash). check-license-headers.py fails if the two lists disagree -- they drifted
+          # apart from the tree once already (#2280).
           paths:
             - openbank-agent-service/
             - openbank-copilot-service/
@@ -2231,22 +2234,33 @@ data:
             - openbank-docs-truth-agent/
             - openbank-authz-policy-auditor/
             - openbank-flaky-test-hunter/
+            - openbank-ap2-service/
+            - openbank-mcp-service/
           reason: "open-core: AGPL-3.0-only + commercial dual-licensing of the AI agent services"
           adr: ADR-0136
       license_boundary_exceptions:
         - description: "AGPL/Apache seam (in-repo). The AI agent services are AGPL-3.0-only; no Apache-2.0 module may take a build/compile dependency on them (only network/HTTP use is allowed). They depend on openbank-libs (Apache-2.0), which is permitted -- copyleft may consume permissive code."
+          # CANONICAL list of the in-repo AGPL-3.0-only modules -- the single source of truth for
+          # which components sit outside the root Apache-2.0 LICENSE. NOTICE and README deliberately
+          # do NOT enumerate them (they point here instead), because a hand-maintained second copy
+          # is what let the published NOTICE claim 4 modules while the tree carried 12 (#2280).
+          # Adding a module here means: give it its own LICENSE, stamp AGPL-3.0-only headers
+          # (scripts/add-license-headers.sh is path-aware from this list), and keep the paths list above
+          # in sync. Enforced by .github/scripts/check-license-headers.py.
           agpl_modules:
-            - openbank-agent-service
-            - openbank-copilot-service
-            - openbank-devops-agent
-            - openbank-finops-agent
+            - openbank-agent-service            # ADR-0136
+            - openbank-copilot-service          # ADR-0136
+            - openbank-devops-agent             # ADR-0136
+            - openbank-finops-agent             # ADR-0136
             - openbank-control-liveness-sentinel
             - openbank-governance-auditor
             - openbank-release-steward
             - openbank-docs-truth-agent
             - openbank-authz-policy-auditor
             - openbank-flaky-test-hunter
-          rule: "no Apache-2.0 module may declare project(':openbank-agent-service'|':openbank-copilot-service'|':openbank-devops-agent'|':openbank-finops-agent'|':openbank-control-liveness-sentinel'|':openbank-governance-auditor'|':openbank-release-steward'|':openbank-docs-truth-agent'|':openbank-authz-policy-auditor'|':openbank-flaky-test-hunter') as a dependency"
+            - openbank-ap2-service              # ADR-0193 -- same agent plane as mcp-service
+            - openbank-mcp-service              # ADR-0181 -- explicitly inside the ADR-0136 boundary
+          rule: "no Apache-2.0 module may declare project(':openbank-agent-service'|':openbank-copilot-service'|':openbank-devops-agent'|':openbank-finops-agent'|':openbank-control-liveness-sentinel'|':openbank-governance-auditor'|':openbank-release-steward'|':openbank-docs-truth-agent'|':openbank-authz-policy-auditor'|':openbank-flaky-test-hunter'|':openbank-ap2-service'|':openbank-mcp-service') as a dependency"
           license: "AGPL-3.0-only"
           adr: ADR-0136
       block_on_cve_severity: [CRITICAL, HIGH]

--- a/openbank-infra/gitops/components/interest-service/interest-service.yaml
+++ b/openbank-infra/gitops/components/interest-service/interest-service.yaml
@@ -16,7 +16,7 @@ spec:
       annotations:
         # Rolls the pods when the OPA bundle changes — subPath mounts do NOT hot-reload.
         # Kept in sync by gen-interest-opa-bundle.sh (do not hand-edit).
-        openbank.tech/policy-checksum: "2c7f3a3883ca331b"
+        openbank.tech/policy-checksum: "f1d9706d1387cc7e"
     spec:
       securityContext:
         runAsNonRoot: true

--- a/openbank-infra/gitops/components/kyc/kyc-opa-bundle.yaml
+++ b/openbank-infra/gitops/components/kyc/kyc-opa-bundle.yaml
@@ -9,7 +9,7 @@ metadata:
     app.kubernetes.io/name: kyc-service
     app.kubernetes.io/part-of: kyc
   annotations:
-    openbank.tech/policy-checksum: "19f51a88d908f326"
+    openbank.tech/policy-checksum: "31a14a6b991e8fe3"
 data:
   rest.rego: |
     # SPDX-License-Identifier: Apache-2.0
@@ -2248,6 +2248,9 @@ data:
       license_denylist_exceptions:
         - license: AGPL-3.0-only
           scope: agent-services                 # in-repo open-core; own LICENSE, commercial dual-license
+          # DERIVED from license_boundary_exceptions[0].agpl_modules below (one entry each, with a
+          # trailing slash). check-license-headers.py fails if the two lists disagree -- they drifted
+          # apart from the tree once already (#2280).
           paths:
             - openbank-agent-service/
             - openbank-copilot-service/
@@ -2259,22 +2262,33 @@ data:
             - openbank-docs-truth-agent/
             - openbank-authz-policy-auditor/
             - openbank-flaky-test-hunter/
+            - openbank-ap2-service/
+            - openbank-mcp-service/
           reason: "open-core: AGPL-3.0-only + commercial dual-licensing of the AI agent services"
           adr: ADR-0136
       license_boundary_exceptions:
         - description: "AGPL/Apache seam (in-repo). The AI agent services are AGPL-3.0-only; no Apache-2.0 module may take a build/compile dependency on them (only network/HTTP use is allowed). They depend on openbank-libs (Apache-2.0), which is permitted -- copyleft may consume permissive code."
+          # CANONICAL list of the in-repo AGPL-3.0-only modules -- the single source of truth for
+          # which components sit outside the root Apache-2.0 LICENSE. NOTICE and README deliberately
+          # do NOT enumerate them (they point here instead), because a hand-maintained second copy
+          # is what let the published NOTICE claim 4 modules while the tree carried 12 (#2280).
+          # Adding a module here means: give it its own LICENSE, stamp AGPL-3.0-only headers
+          # (scripts/add-license-headers.sh is path-aware from this list), and keep the paths list above
+          # in sync. Enforced by .github/scripts/check-license-headers.py.
           agpl_modules:
-            - openbank-agent-service
-            - openbank-copilot-service
-            - openbank-devops-agent
-            - openbank-finops-agent
+            - openbank-agent-service            # ADR-0136
+            - openbank-copilot-service          # ADR-0136
+            - openbank-devops-agent             # ADR-0136
+            - openbank-finops-agent             # ADR-0136
             - openbank-control-liveness-sentinel
             - openbank-governance-auditor
             - openbank-release-steward
             - openbank-docs-truth-agent
             - openbank-authz-policy-auditor
             - openbank-flaky-test-hunter
-          rule: "no Apache-2.0 module may declare project(':openbank-agent-service'|':openbank-copilot-service'|':openbank-devops-agent'|':openbank-finops-agent'|':openbank-control-liveness-sentinel'|':openbank-governance-auditor'|':openbank-release-steward'|':openbank-docs-truth-agent'|':openbank-authz-policy-auditor'|':openbank-flaky-test-hunter') as a dependency"
+            - openbank-ap2-service              # ADR-0193 -- same agent plane as mcp-service
+            - openbank-mcp-service              # ADR-0181 -- explicitly inside the ADR-0136 boundary
+          rule: "no Apache-2.0 module may declare project(':openbank-agent-service'|':openbank-copilot-service'|':openbank-devops-agent'|':openbank-finops-agent'|':openbank-control-liveness-sentinel'|':openbank-governance-auditor'|':openbank-release-steward'|':openbank-docs-truth-agent'|':openbank-authz-policy-auditor'|':openbank-flaky-test-hunter'|':openbank-ap2-service'|':openbank-mcp-service') as a dependency"
           license: "AGPL-3.0-only"
           adr: ADR-0136
       block_on_cve_severity: [CRITICAL, HIGH]

--- a/openbank-infra/gitops/components/kyc/kyc-service.yaml
+++ b/openbank-infra/gitops/components/kyc/kyc-service.yaml
@@ -48,7 +48,7 @@ spec:
       annotations:
         # Rolls the pod when the OPA bundle changes (subPath mounts do not hot-reload).
         # Kept in sync by gen-kyc-opa-bundle.sh (do not hand-edit).
-        openbank.tech/policy-checksum: "19f51a88d908f326"
+        openbank.tech/policy-checksum: "31a14a6b991e8fe3"
     spec:
       securityContext:
         runAsNonRoot: true

--- a/openbank-infra/gitops/components/ledger/ledger-opa-bundle.yaml
+++ b/openbank-infra/gitops/components/ledger/ledger-opa-bundle.yaml
@@ -9,7 +9,7 @@ metadata:
     app.kubernetes.io/name: ledger-service
     app.kubernetes.io/part-of: ledger
   annotations:
-    openbank.tech/policy-checksum: "b27fef0b0d139a8a"
+    openbank.tech/policy-checksum: "eaafce8789d05c26"
 data:
   rest.rego: |
     # SPDX-License-Identifier: Apache-2.0
@@ -2333,6 +2333,9 @@ data:
       license_denylist_exceptions:
         - license: AGPL-3.0-only
           scope: agent-services                 # in-repo open-core; own LICENSE, commercial dual-license
+          # DERIVED from license_boundary_exceptions[0].agpl_modules below (one entry each, with a
+          # trailing slash). check-license-headers.py fails if the two lists disagree -- they drifted
+          # apart from the tree once already (#2280).
           paths:
             - openbank-agent-service/
             - openbank-copilot-service/
@@ -2344,22 +2347,33 @@ data:
             - openbank-docs-truth-agent/
             - openbank-authz-policy-auditor/
             - openbank-flaky-test-hunter/
+            - openbank-ap2-service/
+            - openbank-mcp-service/
           reason: "open-core: AGPL-3.0-only + commercial dual-licensing of the AI agent services"
           adr: ADR-0136
       license_boundary_exceptions:
         - description: "AGPL/Apache seam (in-repo). The AI agent services are AGPL-3.0-only; no Apache-2.0 module may take a build/compile dependency on them (only network/HTTP use is allowed). They depend on openbank-libs (Apache-2.0), which is permitted -- copyleft may consume permissive code."
+          # CANONICAL list of the in-repo AGPL-3.0-only modules -- the single source of truth for
+          # which components sit outside the root Apache-2.0 LICENSE. NOTICE and README deliberately
+          # do NOT enumerate them (they point here instead), because a hand-maintained second copy
+          # is what let the published NOTICE claim 4 modules while the tree carried 12 (#2280).
+          # Adding a module here means: give it its own LICENSE, stamp AGPL-3.0-only headers
+          # (scripts/add-license-headers.sh is path-aware from this list), and keep the paths list above
+          # in sync. Enforced by .github/scripts/check-license-headers.py.
           agpl_modules:
-            - openbank-agent-service
-            - openbank-copilot-service
-            - openbank-devops-agent
-            - openbank-finops-agent
+            - openbank-agent-service            # ADR-0136
+            - openbank-copilot-service          # ADR-0136
+            - openbank-devops-agent             # ADR-0136
+            - openbank-finops-agent             # ADR-0136
             - openbank-control-liveness-sentinel
             - openbank-governance-auditor
             - openbank-release-steward
             - openbank-docs-truth-agent
             - openbank-authz-policy-auditor
             - openbank-flaky-test-hunter
-          rule: "no Apache-2.0 module may declare project(':openbank-agent-service'|':openbank-copilot-service'|':openbank-devops-agent'|':openbank-finops-agent'|':openbank-control-liveness-sentinel'|':openbank-governance-auditor'|':openbank-release-steward'|':openbank-docs-truth-agent'|':openbank-authz-policy-auditor'|':openbank-flaky-test-hunter') as a dependency"
+            - openbank-ap2-service              # ADR-0193 -- same agent plane as mcp-service
+            - openbank-mcp-service              # ADR-0181 -- explicitly inside the ADR-0136 boundary
+          rule: "no Apache-2.0 module may declare project(':openbank-agent-service'|':openbank-copilot-service'|':openbank-devops-agent'|':openbank-finops-agent'|':openbank-control-liveness-sentinel'|':openbank-governance-auditor'|':openbank-release-steward'|':openbank-docs-truth-agent'|':openbank-authz-policy-auditor'|':openbank-flaky-test-hunter'|':openbank-ap2-service'|':openbank-mcp-service') as a dependency"
           license: "AGPL-3.0-only"
           adr: ADR-0136
       block_on_cve_severity: [CRITICAL, HIGH]

--- a/openbank-infra/gitops/components/ledger/ledger-service.yaml
+++ b/openbank-infra/gitops/components/ledger/ledger-service.yaml
@@ -38,7 +38,7 @@ spec:
       annotations:
         # Rolls the pods when the OPA bundle changes — subPath mounts do NOT hot-reload.
         # Kept in sync by gen-ledger-opa-bundle.sh (do not hand-edit).
-        openbank.tech/policy-checksum: "b27fef0b0d139a8a"
+        openbank.tech/policy-checksum: "eaafce8789d05c26"
     spec:
       securityContext:
         runAsNonRoot: true

--- a/openbank-infra/gitops/components/lending/lending-opa-bundle.yaml
+++ b/openbank-infra/gitops/components/lending/lending-opa-bundle.yaml
@@ -9,7 +9,7 @@ metadata:
     app.kubernetes.io/name: lending-service
     app.kubernetes.io/part-of: lending
   annotations:
-    openbank.tech/policy-checksum: "2ede447a33813aae"
+    openbank.tech/policy-checksum: "21f4df2e27c3165c"
 data:
   rest.rego: |
     # SPDX-License-Identifier: Apache-2.0
@@ -2288,6 +2288,9 @@ data:
       license_denylist_exceptions:
         - license: AGPL-3.0-only
           scope: agent-services                 # in-repo open-core; own LICENSE, commercial dual-license
+          # DERIVED from license_boundary_exceptions[0].agpl_modules below (one entry each, with a
+          # trailing slash). check-license-headers.py fails if the two lists disagree -- they drifted
+          # apart from the tree once already (#2280).
           paths:
             - openbank-agent-service/
             - openbank-copilot-service/
@@ -2299,22 +2302,33 @@ data:
             - openbank-docs-truth-agent/
             - openbank-authz-policy-auditor/
             - openbank-flaky-test-hunter/
+            - openbank-ap2-service/
+            - openbank-mcp-service/
           reason: "open-core: AGPL-3.0-only + commercial dual-licensing of the AI agent services"
           adr: ADR-0136
       license_boundary_exceptions:
         - description: "AGPL/Apache seam (in-repo). The AI agent services are AGPL-3.0-only; no Apache-2.0 module may take a build/compile dependency on them (only network/HTTP use is allowed). They depend on openbank-libs (Apache-2.0), which is permitted -- copyleft may consume permissive code."
+          # CANONICAL list of the in-repo AGPL-3.0-only modules -- the single source of truth for
+          # which components sit outside the root Apache-2.0 LICENSE. NOTICE and README deliberately
+          # do NOT enumerate them (they point here instead), because a hand-maintained second copy
+          # is what let the published NOTICE claim 4 modules while the tree carried 12 (#2280).
+          # Adding a module here means: give it its own LICENSE, stamp AGPL-3.0-only headers
+          # (scripts/add-license-headers.sh is path-aware from this list), and keep the paths list above
+          # in sync. Enforced by .github/scripts/check-license-headers.py.
           agpl_modules:
-            - openbank-agent-service
-            - openbank-copilot-service
-            - openbank-devops-agent
-            - openbank-finops-agent
+            - openbank-agent-service            # ADR-0136
+            - openbank-copilot-service          # ADR-0136
+            - openbank-devops-agent             # ADR-0136
+            - openbank-finops-agent             # ADR-0136
             - openbank-control-liveness-sentinel
             - openbank-governance-auditor
             - openbank-release-steward
             - openbank-docs-truth-agent
             - openbank-authz-policy-auditor
             - openbank-flaky-test-hunter
-          rule: "no Apache-2.0 module may declare project(':openbank-agent-service'|':openbank-copilot-service'|':openbank-devops-agent'|':openbank-finops-agent'|':openbank-control-liveness-sentinel'|':openbank-governance-auditor'|':openbank-release-steward'|':openbank-docs-truth-agent'|':openbank-authz-policy-auditor'|':openbank-flaky-test-hunter') as a dependency"
+            - openbank-ap2-service              # ADR-0193 -- same agent plane as mcp-service
+            - openbank-mcp-service              # ADR-0181 -- explicitly inside the ADR-0136 boundary
+          rule: "no Apache-2.0 module may declare project(':openbank-agent-service'|':openbank-copilot-service'|':openbank-devops-agent'|':openbank-finops-agent'|':openbank-control-liveness-sentinel'|':openbank-governance-auditor'|':openbank-release-steward'|':openbank-docs-truth-agent'|':openbank-authz-policy-auditor'|':openbank-flaky-test-hunter'|':openbank-ap2-service'|':openbank-mcp-service') as a dependency"
           license: "AGPL-3.0-only"
           adr: ADR-0136
       block_on_cve_severity: [CRITICAL, HIGH]

--- a/openbank-infra/gitops/components/lending/lending-service.yaml
+++ b/openbank-infra/gitops/components/lending/lending-service.yaml
@@ -34,7 +34,7 @@ spec:
       annotations:
         # Rolls the pods when the OPA bundle changes — subPath mounts do NOT hot-reload.
         # Kept in sync by gen-lending-opa-bundle.sh (do not hand-edit).
-        openbank.tech/policy-checksum: "2ede447a33813aae"
+        openbank.tech/policy-checksum: "21f4df2e27c3165c"
     spec:
       securityContext:
         runAsNonRoot: true

--- a/openbank-infra/gitops/components/mcp/mcp-opa-bundle.yaml
+++ b/openbank-infra/gitops/components/mcp/mcp-opa-bundle.yaml
@@ -9,7 +9,7 @@ metadata:
     app.kubernetes.io/name: mcp-service
     app.kubernetes.io/part-of: platform
   annotations:
-    openbank.tech/policy-checksum: "39551e1032eb36b2"
+    openbank.tech/policy-checksum: "8b40f47809078cc9"
 data:
   rest.rego: |
     # SPDX-License-Identifier: Apache-2.0
@@ -2186,6 +2186,9 @@ data:
       license_denylist_exceptions:
         - license: AGPL-3.0-only
           scope: agent-services                 # in-repo open-core; own LICENSE, commercial dual-license
+          # DERIVED from license_boundary_exceptions[0].agpl_modules below (one entry each, with a
+          # trailing slash). check-license-headers.py fails if the two lists disagree -- they drifted
+          # apart from the tree once already (#2280).
           paths:
             - openbank-agent-service/
             - openbank-copilot-service/
@@ -2197,22 +2200,33 @@ data:
             - openbank-docs-truth-agent/
             - openbank-authz-policy-auditor/
             - openbank-flaky-test-hunter/
+            - openbank-ap2-service/
+            - openbank-mcp-service/
           reason: "open-core: AGPL-3.0-only + commercial dual-licensing of the AI agent services"
           adr: ADR-0136
       license_boundary_exceptions:
         - description: "AGPL/Apache seam (in-repo). The AI agent services are AGPL-3.0-only; no Apache-2.0 module may take a build/compile dependency on them (only network/HTTP use is allowed). They depend on openbank-libs (Apache-2.0), which is permitted -- copyleft may consume permissive code."
+          # CANONICAL list of the in-repo AGPL-3.0-only modules -- the single source of truth for
+          # which components sit outside the root Apache-2.0 LICENSE. NOTICE and README deliberately
+          # do NOT enumerate them (they point here instead), because a hand-maintained second copy
+          # is what let the published NOTICE claim 4 modules while the tree carried 12 (#2280).
+          # Adding a module here means: give it its own LICENSE, stamp AGPL-3.0-only headers
+          # (scripts/add-license-headers.sh is path-aware from this list), and keep the paths list above
+          # in sync. Enforced by .github/scripts/check-license-headers.py.
           agpl_modules:
-            - openbank-agent-service
-            - openbank-copilot-service
-            - openbank-devops-agent
-            - openbank-finops-agent
+            - openbank-agent-service            # ADR-0136
+            - openbank-copilot-service          # ADR-0136
+            - openbank-devops-agent             # ADR-0136
+            - openbank-finops-agent             # ADR-0136
             - openbank-control-liveness-sentinel
             - openbank-governance-auditor
             - openbank-release-steward
             - openbank-docs-truth-agent
             - openbank-authz-policy-auditor
             - openbank-flaky-test-hunter
-          rule: "no Apache-2.0 module may declare project(':openbank-agent-service'|':openbank-copilot-service'|':openbank-devops-agent'|':openbank-finops-agent'|':openbank-control-liveness-sentinel'|':openbank-governance-auditor'|':openbank-release-steward'|':openbank-docs-truth-agent'|':openbank-authz-policy-auditor'|':openbank-flaky-test-hunter') as a dependency"
+            - openbank-ap2-service              # ADR-0193 -- same agent plane as mcp-service
+            - openbank-mcp-service              # ADR-0181 -- explicitly inside the ADR-0136 boundary
+          rule: "no Apache-2.0 module may declare project(':openbank-agent-service'|':openbank-copilot-service'|':openbank-devops-agent'|':openbank-finops-agent'|':openbank-control-liveness-sentinel'|':openbank-governance-auditor'|':openbank-release-steward'|':openbank-docs-truth-agent'|':openbank-authz-policy-auditor'|':openbank-flaky-test-hunter'|':openbank-ap2-service'|':openbank-mcp-service') as a dependency"
           license: "AGPL-3.0-only"
           adr: ADR-0136
       block_on_cve_severity: [CRITICAL, HIGH]

--- a/openbank-infra/gitops/components/mcp/mcp-service.yaml
+++ b/openbank-infra/gitops/components/mcp/mcp-service.yaml
@@ -29,7 +29,7 @@ spec:
       annotations:
         # Rolls the pod when the OPA bundle changes — subPath mounts do NOT hot-reload.
         # Kept in sync by gen-mcp-opa-bundle.sh (do not hand-edit).
-        openbank.tech/policy-checksum: "39551e1032eb36b2"
+        openbank.tech/policy-checksum: "8b40f47809078cc9"
     spec:
       securityContext:
         runAsNonRoot: true

--- a/openbank-infra/gitops/components/notifications/notification-service-opa-bundle.yaml
+++ b/openbank-infra/gitops/components/notifications/notification-service-opa-bundle.yaml
@@ -10,7 +10,7 @@ metadata:
     app.kubernetes.io/name: notification-service
     app.kubernetes.io/part-of: notifications
   annotations:
-    openbank.tech/policy-checksum: "f86f4fd928041707"
+    openbank.tech/policy-checksum: "1006b34bb3e0708e"
 data:
   rest.rego: |
     # SPDX-License-Identifier: Apache-2.0
@@ -1409,6 +1409,9 @@ data:
       license_denylist_exceptions:
         - license: AGPL-3.0-only
           scope: agent-services                 # in-repo open-core; own LICENSE, commercial dual-license
+          # DERIVED from license_boundary_exceptions[0].agpl_modules below (one entry each, with a
+          # trailing slash). check-license-headers.py fails if the two lists disagree -- they drifted
+          # apart from the tree once already (#2280).
           paths:
             - openbank-agent-service/
             - openbank-copilot-service/
@@ -1420,22 +1423,33 @@ data:
             - openbank-docs-truth-agent/
             - openbank-authz-policy-auditor/
             - openbank-flaky-test-hunter/
+            - openbank-ap2-service/
+            - openbank-mcp-service/
           reason: "open-core: AGPL-3.0-only + commercial dual-licensing of the AI agent services"
           adr: ADR-0136
       license_boundary_exceptions:
         - description: "AGPL/Apache seam (in-repo). The AI agent services are AGPL-3.0-only; no Apache-2.0 module may take a build/compile dependency on them (only network/HTTP use is allowed). They depend on openbank-libs (Apache-2.0), which is permitted -- copyleft may consume permissive code."
+          # CANONICAL list of the in-repo AGPL-3.0-only modules -- the single source of truth for
+          # which components sit outside the root Apache-2.0 LICENSE. NOTICE and README deliberately
+          # do NOT enumerate them (they point here instead), because a hand-maintained second copy
+          # is what let the published NOTICE claim 4 modules while the tree carried 12 (#2280).
+          # Adding a module here means: give it its own LICENSE, stamp AGPL-3.0-only headers
+          # (scripts/add-license-headers.sh is path-aware from this list), and keep the paths list above
+          # in sync. Enforced by .github/scripts/check-license-headers.py.
           agpl_modules:
-            - openbank-agent-service
-            - openbank-copilot-service
-            - openbank-devops-agent
-            - openbank-finops-agent
+            - openbank-agent-service            # ADR-0136
+            - openbank-copilot-service          # ADR-0136
+            - openbank-devops-agent             # ADR-0136
+            - openbank-finops-agent             # ADR-0136
             - openbank-control-liveness-sentinel
             - openbank-governance-auditor
             - openbank-release-steward
             - openbank-docs-truth-agent
             - openbank-authz-policy-auditor
             - openbank-flaky-test-hunter
-          rule: "no Apache-2.0 module may declare project(':openbank-agent-service'|':openbank-copilot-service'|':openbank-devops-agent'|':openbank-finops-agent'|':openbank-control-liveness-sentinel'|':openbank-governance-auditor'|':openbank-release-steward'|':openbank-docs-truth-agent'|':openbank-authz-policy-auditor'|':openbank-flaky-test-hunter') as a dependency"
+            - openbank-ap2-service              # ADR-0193 -- same agent plane as mcp-service
+            - openbank-mcp-service              # ADR-0181 -- explicitly inside the ADR-0136 boundary
+          rule: "no Apache-2.0 module may declare project(':openbank-agent-service'|':openbank-copilot-service'|':openbank-devops-agent'|':openbank-finops-agent'|':openbank-control-liveness-sentinel'|':openbank-governance-auditor'|':openbank-release-steward'|':openbank-docs-truth-agent'|':openbank-authz-policy-auditor'|':openbank-flaky-test-hunter'|':openbank-ap2-service'|':openbank-mcp-service') as a dependency"
           license: "AGPL-3.0-only"
           adr: ADR-0136
       block_on_cve_severity: [CRITICAL, HIGH]

--- a/openbank-infra/gitops/components/notifications/notification-service.yaml
+++ b/openbank-infra/gitops/components/notifications/notification-service.yaml
@@ -39,7 +39,7 @@ spec:
       annotations:
         # Rolls the Deployment when the OPA policy bundle changes (subPath mounts don't
         # hot-reload). Kept in sync by gen-notification-opa-bundle.sh.
-        openbank.tech/policy-checksum: "f86f4fd928041707"
+        openbank.tech/policy-checksum: "1006b34bb3e0708e"
       labels:
         app.kubernetes.io/name: notification-service
         app.kubernetes.io/part-of: notifications

--- a/openbank-infra/gitops/components/party/party-opa-bundle.yaml
+++ b/openbank-infra/gitops/components/party/party-opa-bundle.yaml
@@ -9,7 +9,7 @@ metadata:
     app.kubernetes.io/name: party-service
     app.kubernetes.io/part-of: party
   annotations:
-    openbank.tech/policy-checksum: "e438f37d8d705163"
+    openbank.tech/policy-checksum: "e2a272cecfa288f6"
 data:
   rest.rego: |
     # SPDX-License-Identifier: Apache-2.0
@@ -2257,6 +2257,9 @@ data:
       license_denylist_exceptions:
         - license: AGPL-3.0-only
           scope: agent-services                 # in-repo open-core; own LICENSE, commercial dual-license
+          # DERIVED from license_boundary_exceptions[0].agpl_modules below (one entry each, with a
+          # trailing slash). check-license-headers.py fails if the two lists disagree -- they drifted
+          # apart from the tree once already (#2280).
           paths:
             - openbank-agent-service/
             - openbank-copilot-service/
@@ -2268,22 +2271,33 @@ data:
             - openbank-docs-truth-agent/
             - openbank-authz-policy-auditor/
             - openbank-flaky-test-hunter/
+            - openbank-ap2-service/
+            - openbank-mcp-service/
           reason: "open-core: AGPL-3.0-only + commercial dual-licensing of the AI agent services"
           adr: ADR-0136
       license_boundary_exceptions:
         - description: "AGPL/Apache seam (in-repo). The AI agent services are AGPL-3.0-only; no Apache-2.0 module may take a build/compile dependency on them (only network/HTTP use is allowed). They depend on openbank-libs (Apache-2.0), which is permitted -- copyleft may consume permissive code."
+          # CANONICAL list of the in-repo AGPL-3.0-only modules -- the single source of truth for
+          # which components sit outside the root Apache-2.0 LICENSE. NOTICE and README deliberately
+          # do NOT enumerate them (they point here instead), because a hand-maintained second copy
+          # is what let the published NOTICE claim 4 modules while the tree carried 12 (#2280).
+          # Adding a module here means: give it its own LICENSE, stamp AGPL-3.0-only headers
+          # (scripts/add-license-headers.sh is path-aware from this list), and keep the paths list above
+          # in sync. Enforced by .github/scripts/check-license-headers.py.
           agpl_modules:
-            - openbank-agent-service
-            - openbank-copilot-service
-            - openbank-devops-agent
-            - openbank-finops-agent
+            - openbank-agent-service            # ADR-0136
+            - openbank-copilot-service          # ADR-0136
+            - openbank-devops-agent             # ADR-0136
+            - openbank-finops-agent             # ADR-0136
             - openbank-control-liveness-sentinel
             - openbank-governance-auditor
             - openbank-release-steward
             - openbank-docs-truth-agent
             - openbank-authz-policy-auditor
             - openbank-flaky-test-hunter
-          rule: "no Apache-2.0 module may declare project(':openbank-agent-service'|':openbank-copilot-service'|':openbank-devops-agent'|':openbank-finops-agent'|':openbank-control-liveness-sentinel'|':openbank-governance-auditor'|':openbank-release-steward'|':openbank-docs-truth-agent'|':openbank-authz-policy-auditor'|':openbank-flaky-test-hunter') as a dependency"
+            - openbank-ap2-service              # ADR-0193 -- same agent plane as mcp-service
+            - openbank-mcp-service              # ADR-0181 -- explicitly inside the ADR-0136 boundary
+          rule: "no Apache-2.0 module may declare project(':openbank-agent-service'|':openbank-copilot-service'|':openbank-devops-agent'|':openbank-finops-agent'|':openbank-control-liveness-sentinel'|':openbank-governance-auditor'|':openbank-release-steward'|':openbank-docs-truth-agent'|':openbank-authz-policy-auditor'|':openbank-flaky-test-hunter'|':openbank-ap2-service'|':openbank-mcp-service') as a dependency"
           license: "AGPL-3.0-only"
           adr: ADR-0136
       block_on_cve_severity: [CRITICAL, HIGH]

--- a/openbank-infra/gitops/components/party/party-service.yaml
+++ b/openbank-infra/gitops/components/party/party-service.yaml
@@ -22,7 +22,7 @@ spec:
       annotations:
         # Rolls the pod when the OPA bundle changes — subPath mounts do NOT hot-reload.
         # Kept in sync by gen-party-opa-bundle.sh (do not hand-edit).
-        openbank.tech/policy-checksum: "e438f37d8d705163"
+        openbank.tech/policy-checksum: "e2a272cecfa288f6"
       labels:
         app.kubernetes.io/name: party-service
         app.kubernetes.io/part-of: party

--- a/openbank-infra/gitops/components/payments/card-issuance-opa-bundle.yaml
+++ b/openbank-infra/gitops/components/payments/card-issuance-opa-bundle.yaml
@@ -9,7 +9,7 @@ metadata:
     app.kubernetes.io/name: card-issuance-service
     app.kubernetes.io/part-of: payments
   annotations:
-    openbank.tech/policy-checksum: "df81c4ecd69a86e2"
+    openbank.tech/policy-checksum: "2acb58a175df8489"
 data:
   rest.rego: |
     # SPDX-License-Identifier: Apache-2.0
@@ -2241,6 +2241,9 @@ data:
       license_denylist_exceptions:
         - license: AGPL-3.0-only
           scope: agent-services                 # in-repo open-core; own LICENSE, commercial dual-license
+          # DERIVED from license_boundary_exceptions[0].agpl_modules below (one entry each, with a
+          # trailing slash). check-license-headers.py fails if the two lists disagree -- they drifted
+          # apart from the tree once already (#2280).
           paths:
             - openbank-agent-service/
             - openbank-copilot-service/
@@ -2252,22 +2255,33 @@ data:
             - openbank-docs-truth-agent/
             - openbank-authz-policy-auditor/
             - openbank-flaky-test-hunter/
+            - openbank-ap2-service/
+            - openbank-mcp-service/
           reason: "open-core: AGPL-3.0-only + commercial dual-licensing of the AI agent services"
           adr: ADR-0136
       license_boundary_exceptions:
         - description: "AGPL/Apache seam (in-repo). The AI agent services are AGPL-3.0-only; no Apache-2.0 module may take a build/compile dependency on them (only network/HTTP use is allowed). They depend on openbank-libs (Apache-2.0), which is permitted -- copyleft may consume permissive code."
+          # CANONICAL list of the in-repo AGPL-3.0-only modules -- the single source of truth for
+          # which components sit outside the root Apache-2.0 LICENSE. NOTICE and README deliberately
+          # do NOT enumerate them (they point here instead), because a hand-maintained second copy
+          # is what let the published NOTICE claim 4 modules while the tree carried 12 (#2280).
+          # Adding a module here means: give it its own LICENSE, stamp AGPL-3.0-only headers
+          # (scripts/add-license-headers.sh is path-aware from this list), and keep the paths list above
+          # in sync. Enforced by .github/scripts/check-license-headers.py.
           agpl_modules:
-            - openbank-agent-service
-            - openbank-copilot-service
-            - openbank-devops-agent
-            - openbank-finops-agent
+            - openbank-agent-service            # ADR-0136
+            - openbank-copilot-service          # ADR-0136
+            - openbank-devops-agent             # ADR-0136
+            - openbank-finops-agent             # ADR-0136
             - openbank-control-liveness-sentinel
             - openbank-governance-auditor
             - openbank-release-steward
             - openbank-docs-truth-agent
             - openbank-authz-policy-auditor
             - openbank-flaky-test-hunter
-          rule: "no Apache-2.0 module may declare project(':openbank-agent-service'|':openbank-copilot-service'|':openbank-devops-agent'|':openbank-finops-agent'|':openbank-control-liveness-sentinel'|':openbank-governance-auditor'|':openbank-release-steward'|':openbank-docs-truth-agent'|':openbank-authz-policy-auditor'|':openbank-flaky-test-hunter') as a dependency"
+            - openbank-ap2-service              # ADR-0193 -- same agent plane as mcp-service
+            - openbank-mcp-service              # ADR-0181 -- explicitly inside the ADR-0136 boundary
+          rule: "no Apache-2.0 module may declare project(':openbank-agent-service'|':openbank-copilot-service'|':openbank-devops-agent'|':openbank-finops-agent'|':openbank-control-liveness-sentinel'|':openbank-governance-auditor'|':openbank-release-steward'|':openbank-docs-truth-agent'|':openbank-authz-policy-auditor'|':openbank-flaky-test-hunter'|':openbank-ap2-service'|':openbank-mcp-service') as a dependency"
           license: "AGPL-3.0-only"
           adr: ADR-0136
       block_on_cve_severity: [CRITICAL, HIGH]

--- a/openbank-infra/gitops/components/payments/clearing-opa-bundle.yaml
+++ b/openbank-infra/gitops/components/payments/clearing-opa-bundle.yaml
@@ -9,7 +9,7 @@ metadata:
     app.kubernetes.io/name: clearing-service
     app.kubernetes.io/part-of: payments
   annotations:
-    openbank.tech/policy-checksum: "0315d8d7d8fc567f"
+    openbank.tech/policy-checksum: "363e83e5f07e68c9"
 data:
   rest.rego: |
     # SPDX-License-Identifier: Apache-2.0
@@ -2278,6 +2278,9 @@ data:
       license_denylist_exceptions:
         - license: AGPL-3.0-only
           scope: agent-services                 # in-repo open-core; own LICENSE, commercial dual-license
+          # DERIVED from license_boundary_exceptions[0].agpl_modules below (one entry each, with a
+          # trailing slash). check-license-headers.py fails if the two lists disagree -- they drifted
+          # apart from the tree once already (#2280).
           paths:
             - openbank-agent-service/
             - openbank-copilot-service/
@@ -2289,22 +2292,33 @@ data:
             - openbank-docs-truth-agent/
             - openbank-authz-policy-auditor/
             - openbank-flaky-test-hunter/
+            - openbank-ap2-service/
+            - openbank-mcp-service/
           reason: "open-core: AGPL-3.0-only + commercial dual-licensing of the AI agent services"
           adr: ADR-0136
       license_boundary_exceptions:
         - description: "AGPL/Apache seam (in-repo). The AI agent services are AGPL-3.0-only; no Apache-2.0 module may take a build/compile dependency on them (only network/HTTP use is allowed). They depend on openbank-libs (Apache-2.0), which is permitted -- copyleft may consume permissive code."
+          # CANONICAL list of the in-repo AGPL-3.0-only modules -- the single source of truth for
+          # which components sit outside the root Apache-2.0 LICENSE. NOTICE and README deliberately
+          # do NOT enumerate them (they point here instead), because a hand-maintained second copy
+          # is what let the published NOTICE claim 4 modules while the tree carried 12 (#2280).
+          # Adding a module here means: give it its own LICENSE, stamp AGPL-3.0-only headers
+          # (scripts/add-license-headers.sh is path-aware from this list), and keep the paths list above
+          # in sync. Enforced by .github/scripts/check-license-headers.py.
           agpl_modules:
-            - openbank-agent-service
-            - openbank-copilot-service
-            - openbank-devops-agent
-            - openbank-finops-agent
+            - openbank-agent-service            # ADR-0136
+            - openbank-copilot-service          # ADR-0136
+            - openbank-devops-agent             # ADR-0136
+            - openbank-finops-agent             # ADR-0136
             - openbank-control-liveness-sentinel
             - openbank-governance-auditor
             - openbank-release-steward
             - openbank-docs-truth-agent
             - openbank-authz-policy-auditor
             - openbank-flaky-test-hunter
-          rule: "no Apache-2.0 module may declare project(':openbank-agent-service'|':openbank-copilot-service'|':openbank-devops-agent'|':openbank-finops-agent'|':openbank-control-liveness-sentinel'|':openbank-governance-auditor'|':openbank-release-steward'|':openbank-docs-truth-agent'|':openbank-authz-policy-auditor'|':openbank-flaky-test-hunter') as a dependency"
+            - openbank-ap2-service              # ADR-0193 -- same agent plane as mcp-service
+            - openbank-mcp-service              # ADR-0181 -- explicitly inside the ADR-0136 boundary
+          rule: "no Apache-2.0 module may declare project(':openbank-agent-service'|':openbank-copilot-service'|':openbank-devops-agent'|':openbank-finops-agent'|':openbank-control-liveness-sentinel'|':openbank-governance-auditor'|':openbank-release-steward'|':openbank-docs-truth-agent'|':openbank-authz-policy-auditor'|':openbank-flaky-test-hunter'|':openbank-ap2-service'|':openbank-mcp-service') as a dependency"
           license: "AGPL-3.0-only"
           adr: ADR-0136
       block_on_cve_severity: [CRITICAL, HIGH]

--- a/openbank-infra/gitops/components/payments/domestic-payment-opa-bundle.yaml
+++ b/openbank-infra/gitops/components/payments/domestic-payment-opa-bundle.yaml
@@ -9,7 +9,7 @@ metadata:
     app.kubernetes.io/name: domestic-payment
     app.kubernetes.io/part-of: payments
   annotations:
-    openbank.tech/policy-checksum: "5df1031a168b5539"
+    openbank.tech/policy-checksum: "b4540595c0ef58d2"
 data:
   rest.rego: |
     # SPDX-License-Identifier: Apache-2.0
@@ -2263,6 +2263,9 @@ data:
       license_denylist_exceptions:
         - license: AGPL-3.0-only
           scope: agent-services                 # in-repo open-core; own LICENSE, commercial dual-license
+          # DERIVED from license_boundary_exceptions[0].agpl_modules below (one entry each, with a
+          # trailing slash). check-license-headers.py fails if the two lists disagree -- they drifted
+          # apart from the tree once already (#2280).
           paths:
             - openbank-agent-service/
             - openbank-copilot-service/
@@ -2274,22 +2277,33 @@ data:
             - openbank-docs-truth-agent/
             - openbank-authz-policy-auditor/
             - openbank-flaky-test-hunter/
+            - openbank-ap2-service/
+            - openbank-mcp-service/
           reason: "open-core: AGPL-3.0-only + commercial dual-licensing of the AI agent services"
           adr: ADR-0136
       license_boundary_exceptions:
         - description: "AGPL/Apache seam (in-repo). The AI agent services are AGPL-3.0-only; no Apache-2.0 module may take a build/compile dependency on them (only network/HTTP use is allowed). They depend on openbank-libs (Apache-2.0), which is permitted -- copyleft may consume permissive code."
+          # CANONICAL list of the in-repo AGPL-3.0-only modules -- the single source of truth for
+          # which components sit outside the root Apache-2.0 LICENSE. NOTICE and README deliberately
+          # do NOT enumerate them (they point here instead), because a hand-maintained second copy
+          # is what let the published NOTICE claim 4 modules while the tree carried 12 (#2280).
+          # Adding a module here means: give it its own LICENSE, stamp AGPL-3.0-only headers
+          # (scripts/add-license-headers.sh is path-aware from this list), and keep the paths list above
+          # in sync. Enforced by .github/scripts/check-license-headers.py.
           agpl_modules:
-            - openbank-agent-service
-            - openbank-copilot-service
-            - openbank-devops-agent
-            - openbank-finops-agent
+            - openbank-agent-service            # ADR-0136
+            - openbank-copilot-service          # ADR-0136
+            - openbank-devops-agent             # ADR-0136
+            - openbank-finops-agent             # ADR-0136
             - openbank-control-liveness-sentinel
             - openbank-governance-auditor
             - openbank-release-steward
             - openbank-docs-truth-agent
             - openbank-authz-policy-auditor
             - openbank-flaky-test-hunter
-          rule: "no Apache-2.0 module may declare project(':openbank-agent-service'|':openbank-copilot-service'|':openbank-devops-agent'|':openbank-finops-agent'|':openbank-control-liveness-sentinel'|':openbank-governance-auditor'|':openbank-release-steward'|':openbank-docs-truth-agent'|':openbank-authz-policy-auditor'|':openbank-flaky-test-hunter') as a dependency"
+            - openbank-ap2-service              # ADR-0193 -- same agent plane as mcp-service
+            - openbank-mcp-service              # ADR-0181 -- explicitly inside the ADR-0136 boundary
+          rule: "no Apache-2.0 module may declare project(':openbank-agent-service'|':openbank-copilot-service'|':openbank-devops-agent'|':openbank-finops-agent'|':openbank-control-liveness-sentinel'|':openbank-governance-auditor'|':openbank-release-steward'|':openbank-docs-truth-agent'|':openbank-authz-policy-auditor'|':openbank-flaky-test-hunter'|':openbank-ap2-service'|':openbank-mcp-service') as a dependency"
           license: "AGPL-3.0-only"
           adr: ADR-0136
       block_on_cve_severity: [CRITICAL, HIGH]

--- a/openbank-infra/gitops/components/payments/payments-services.yaml
+++ b/openbank-infra/gitops/components/payments/payments-services.yaml
@@ -42,7 +42,7 @@ spec:
         # Rolls the pods when the OPA bundle changes — subPath mounts do NOT hot-reload.
         # Kept in sync by gen-transaction-opa-bundle.sh via the trailing marker comment
         # (do not hand-edit, do not drop the marker).
-        openbank.tech/policy-checksum: "6cb1baed6742783f" # transaction-opa-bundle
+        openbank.tech/policy-checksum: "5b163df5ea95e183" # transaction-opa-bundle
     spec:
       securityContext:
         runAsNonRoot: true
@@ -375,7 +375,7 @@ spec:
       annotations:
         # Rolls the pods when the OPA bundle changes — subPath mounts do NOT hot-reload.
         # Kept in sync by gen-sepa-payment-opa-bundle.sh (do not hand-edit).
-        openbank.tech/policy-checksum: "5bf847199fb4acb1"
+        openbank.tech/policy-checksum: "320fe86de35da3d5"
     spec:
       securityContext:
         runAsNonRoot: true
@@ -729,7 +729,7 @@ spec:
         # Rolls the pods when the OPA bundle changes — subPath mounts do NOT hot-reload.
         # Kept in sync by gen-domestic-payment-opa-bundle.sh via the trailing marker
         # comment (do not hand-edit, do not drop the marker).
-        openbank.tech/policy-checksum: "5df1031a168b5539" # domestic-payment-opa-bundle
+        openbank.tech/policy-checksum: "b4540595c0ef58d2" # domestic-payment-opa-bundle
     spec:
       securityContext:
         runAsNonRoot: true
@@ -1053,7 +1053,7 @@ spec:
       annotations:
         # Rolls the pods when the OPA bundle changes — subPath mounts do NOT hot-reload.
         # Kept in sync by gen-sepa-instant-opa-bundle.sh (do not hand-edit).
-        openbank.tech/policy-checksum: "b621ca294c0d80f6"
+        openbank.tech/policy-checksum: "29c81f3157dde4b7"
     spec:
       securityContext:
         runAsNonRoot: true
@@ -1369,7 +1369,7 @@ spec:
         # Rolls the pods when the OPA bundle changes — subPath mounts do NOT hot-reload.
         # Kept in sync by gen-clearing-opa-bundle.sh via the trailing marker comment
         # (do not hand-edit, do not drop the marker).
-        openbank.tech/policy-checksum: "0315d8d7d8fc567f" # clearing-opa-bundle
+        openbank.tech/policy-checksum: "363e83e5f07e68c9" # clearing-opa-bundle
     spec:
       securityContext:
         runAsNonRoot: true
@@ -1658,7 +1658,7 @@ spec:
       annotations:
         # Rolls the pod when the OPA bundle changes (ADR-0034). Value is stamped by
         # gen-standing-order-opa-bundle.sh — do not hand-edit.
-        openbank.tech/policy-checksum: "d9afa135beb74727" # standing-order-opa-bundle
+        openbank.tech/policy-checksum: "17bd6322d62baad5" # standing-order-opa-bundle
     spec:
       securityContext:
         runAsNonRoot: true
@@ -1911,7 +1911,7 @@ spec:
       annotations:
         # Rolls the pods when the OPA bundle changes — subPath mounts do NOT hot-reload.
         # Kept in sync by gen-card-issuance-opa-bundle.sh (do not hand-edit).
-        openbank.tech/policy-checksum: "df81c4ecd69a86e2"
+        openbank.tech/policy-checksum: "2acb58a175df8489"
     spec:
       securityContext:
         runAsNonRoot: true
@@ -2178,7 +2178,7 @@ spec:
         # Rolls the pods when the OPA bundle changes — subPath mounts do NOT hot-reload.
         # Kept in sync by gen-settlement-opa-bundle.sh via the trailing marker comment
         # (do not hand-edit, do not drop the marker).
-        openbank.tech/policy-checksum: "645336d77720a24e" # settlement-opa-bundle
+        openbank.tech/policy-checksum: "8bc47c2b78b8267c" # settlement-opa-bundle
     spec:
       securityContext:
         runAsNonRoot: true
@@ -2579,7 +2579,7 @@ spec:
       annotations:
         # Rolls the pods when the OPA bundle changes — subPath mounts do NOT hot-reload.
         # Kept in sync by gen-swift-opa-bundle.sh (do not hand-edit).
-        openbank.tech/policy-checksum: "12dcf4bca2e2366b"
+        openbank.tech/policy-checksum: "b6d939fd1e7d24eb"
     spec:
       securityContext:
         runAsNonRoot: true
@@ -2893,7 +2893,7 @@ spec:
       annotations:
         # Rolls the pods when the OPA bundle changes — subPath mounts do NOT hot-reload.
         # Kept in sync by gen-vop-opa-bundle.sh (do not hand-edit).
-        openbank.tech/policy-checksum: "226b220834fe5b7f"
+        openbank.tech/policy-checksum: "df8449abde7b5cea"
     spec:
       securityContext:
         runAsNonRoot: true

--- a/openbank-infra/gitops/components/payments/sepa-instant-opa-bundle.yaml
+++ b/openbank-infra/gitops/components/payments/sepa-instant-opa-bundle.yaml
@@ -9,7 +9,7 @@ metadata:
     app.kubernetes.io/name: sepa-instant
     app.kubernetes.io/part-of: payments
   annotations:
-    openbank.tech/policy-checksum: "b621ca294c0d80f6"
+    openbank.tech/policy-checksum: "29c81f3157dde4b7"
 data:
   rest.rego: |
     # SPDX-License-Identifier: Apache-2.0
@@ -2236,6 +2236,9 @@ data:
       license_denylist_exceptions:
         - license: AGPL-3.0-only
           scope: agent-services                 # in-repo open-core; own LICENSE, commercial dual-license
+          # DERIVED from license_boundary_exceptions[0].agpl_modules below (one entry each, with a
+          # trailing slash). check-license-headers.py fails if the two lists disagree -- they drifted
+          # apart from the tree once already (#2280).
           paths:
             - openbank-agent-service/
             - openbank-copilot-service/
@@ -2247,22 +2250,33 @@ data:
             - openbank-docs-truth-agent/
             - openbank-authz-policy-auditor/
             - openbank-flaky-test-hunter/
+            - openbank-ap2-service/
+            - openbank-mcp-service/
           reason: "open-core: AGPL-3.0-only + commercial dual-licensing of the AI agent services"
           adr: ADR-0136
       license_boundary_exceptions:
         - description: "AGPL/Apache seam (in-repo). The AI agent services are AGPL-3.0-only; no Apache-2.0 module may take a build/compile dependency on them (only network/HTTP use is allowed). They depend on openbank-libs (Apache-2.0), which is permitted -- copyleft may consume permissive code."
+          # CANONICAL list of the in-repo AGPL-3.0-only modules -- the single source of truth for
+          # which components sit outside the root Apache-2.0 LICENSE. NOTICE and README deliberately
+          # do NOT enumerate them (they point here instead), because a hand-maintained second copy
+          # is what let the published NOTICE claim 4 modules while the tree carried 12 (#2280).
+          # Adding a module here means: give it its own LICENSE, stamp AGPL-3.0-only headers
+          # (scripts/add-license-headers.sh is path-aware from this list), and keep the paths list above
+          # in sync. Enforced by .github/scripts/check-license-headers.py.
           agpl_modules:
-            - openbank-agent-service
-            - openbank-copilot-service
-            - openbank-devops-agent
-            - openbank-finops-agent
+            - openbank-agent-service            # ADR-0136
+            - openbank-copilot-service          # ADR-0136
+            - openbank-devops-agent             # ADR-0136
+            - openbank-finops-agent             # ADR-0136
             - openbank-control-liveness-sentinel
             - openbank-governance-auditor
             - openbank-release-steward
             - openbank-docs-truth-agent
             - openbank-authz-policy-auditor
             - openbank-flaky-test-hunter
-          rule: "no Apache-2.0 module may declare project(':openbank-agent-service'|':openbank-copilot-service'|':openbank-devops-agent'|':openbank-finops-agent'|':openbank-control-liveness-sentinel'|':openbank-governance-auditor'|':openbank-release-steward'|':openbank-docs-truth-agent'|':openbank-authz-policy-auditor'|':openbank-flaky-test-hunter') as a dependency"
+            - openbank-ap2-service              # ADR-0193 -- same agent plane as mcp-service
+            - openbank-mcp-service              # ADR-0181 -- explicitly inside the ADR-0136 boundary
+          rule: "no Apache-2.0 module may declare project(':openbank-agent-service'|':openbank-copilot-service'|':openbank-devops-agent'|':openbank-finops-agent'|':openbank-control-liveness-sentinel'|':openbank-governance-auditor'|':openbank-release-steward'|':openbank-docs-truth-agent'|':openbank-authz-policy-auditor'|':openbank-flaky-test-hunter'|':openbank-ap2-service'|':openbank-mcp-service') as a dependency"
           license: "AGPL-3.0-only"
           adr: ADR-0136
       block_on_cve_severity: [CRITICAL, HIGH]

--- a/openbank-infra/gitops/components/payments/sepa-payment-opa-bundle.yaml
+++ b/openbank-infra/gitops/components/payments/sepa-payment-opa-bundle.yaml
@@ -9,7 +9,7 @@ metadata:
     app.kubernetes.io/name: sepa-payment
     app.kubernetes.io/part-of: payments
   annotations:
-    openbank.tech/policy-checksum: "5bf847199fb4acb1"
+    openbank.tech/policy-checksum: "320fe86de35da3d5"
 data:
   rest.rego: |
     # SPDX-License-Identifier: Apache-2.0
@@ -2257,6 +2257,9 @@ data:
       license_denylist_exceptions:
         - license: AGPL-3.0-only
           scope: agent-services                 # in-repo open-core; own LICENSE, commercial dual-license
+          # DERIVED from license_boundary_exceptions[0].agpl_modules below (one entry each, with a
+          # trailing slash). check-license-headers.py fails if the two lists disagree -- they drifted
+          # apart from the tree once already (#2280).
           paths:
             - openbank-agent-service/
             - openbank-copilot-service/
@@ -2268,22 +2271,33 @@ data:
             - openbank-docs-truth-agent/
             - openbank-authz-policy-auditor/
             - openbank-flaky-test-hunter/
+            - openbank-ap2-service/
+            - openbank-mcp-service/
           reason: "open-core: AGPL-3.0-only + commercial dual-licensing of the AI agent services"
           adr: ADR-0136
       license_boundary_exceptions:
         - description: "AGPL/Apache seam (in-repo). The AI agent services are AGPL-3.0-only; no Apache-2.0 module may take a build/compile dependency on them (only network/HTTP use is allowed). They depend on openbank-libs (Apache-2.0), which is permitted -- copyleft may consume permissive code."
+          # CANONICAL list of the in-repo AGPL-3.0-only modules -- the single source of truth for
+          # which components sit outside the root Apache-2.0 LICENSE. NOTICE and README deliberately
+          # do NOT enumerate them (they point here instead), because a hand-maintained second copy
+          # is what let the published NOTICE claim 4 modules while the tree carried 12 (#2280).
+          # Adding a module here means: give it its own LICENSE, stamp AGPL-3.0-only headers
+          # (scripts/add-license-headers.sh is path-aware from this list), and keep the paths list above
+          # in sync. Enforced by .github/scripts/check-license-headers.py.
           agpl_modules:
-            - openbank-agent-service
-            - openbank-copilot-service
-            - openbank-devops-agent
-            - openbank-finops-agent
+            - openbank-agent-service            # ADR-0136
+            - openbank-copilot-service          # ADR-0136
+            - openbank-devops-agent             # ADR-0136
+            - openbank-finops-agent             # ADR-0136
             - openbank-control-liveness-sentinel
             - openbank-governance-auditor
             - openbank-release-steward
             - openbank-docs-truth-agent
             - openbank-authz-policy-auditor
             - openbank-flaky-test-hunter
-          rule: "no Apache-2.0 module may declare project(':openbank-agent-service'|':openbank-copilot-service'|':openbank-devops-agent'|':openbank-finops-agent'|':openbank-control-liveness-sentinel'|':openbank-governance-auditor'|':openbank-release-steward'|':openbank-docs-truth-agent'|':openbank-authz-policy-auditor'|':openbank-flaky-test-hunter') as a dependency"
+            - openbank-ap2-service              # ADR-0193 -- same agent plane as mcp-service
+            - openbank-mcp-service              # ADR-0181 -- explicitly inside the ADR-0136 boundary
+          rule: "no Apache-2.0 module may declare project(':openbank-agent-service'|':openbank-copilot-service'|':openbank-devops-agent'|':openbank-finops-agent'|':openbank-control-liveness-sentinel'|':openbank-governance-auditor'|':openbank-release-steward'|':openbank-docs-truth-agent'|':openbank-authz-policy-auditor'|':openbank-flaky-test-hunter'|':openbank-ap2-service'|':openbank-mcp-service') as a dependency"
           license: "AGPL-3.0-only"
           adr: ADR-0136
       block_on_cve_severity: [CRITICAL, HIGH]

--- a/openbank-infra/gitops/components/payments/settlement-opa-bundle.yaml
+++ b/openbank-infra/gitops/components/payments/settlement-opa-bundle.yaml
@@ -9,7 +9,7 @@ metadata:
     app.kubernetes.io/name: settlement-service
     app.kubernetes.io/part-of: payments
   annotations:
-    openbank.tech/policy-checksum: "645336d77720a24e"
+    openbank.tech/policy-checksum: "8bc47c2b78b8267c"
 data:
   rest.rego: |
     # SPDX-License-Identifier: Apache-2.0
@@ -2237,6 +2237,9 @@ data:
       license_denylist_exceptions:
         - license: AGPL-3.0-only
           scope: agent-services                 # in-repo open-core; own LICENSE, commercial dual-license
+          # DERIVED from license_boundary_exceptions[0].agpl_modules below (one entry each, with a
+          # trailing slash). check-license-headers.py fails if the two lists disagree -- they drifted
+          # apart from the tree once already (#2280).
           paths:
             - openbank-agent-service/
             - openbank-copilot-service/
@@ -2248,22 +2251,33 @@ data:
             - openbank-docs-truth-agent/
             - openbank-authz-policy-auditor/
             - openbank-flaky-test-hunter/
+            - openbank-ap2-service/
+            - openbank-mcp-service/
           reason: "open-core: AGPL-3.0-only + commercial dual-licensing of the AI agent services"
           adr: ADR-0136
       license_boundary_exceptions:
         - description: "AGPL/Apache seam (in-repo). The AI agent services are AGPL-3.0-only; no Apache-2.0 module may take a build/compile dependency on them (only network/HTTP use is allowed). They depend on openbank-libs (Apache-2.0), which is permitted -- copyleft may consume permissive code."
+          # CANONICAL list of the in-repo AGPL-3.0-only modules -- the single source of truth for
+          # which components sit outside the root Apache-2.0 LICENSE. NOTICE and README deliberately
+          # do NOT enumerate them (they point here instead), because a hand-maintained second copy
+          # is what let the published NOTICE claim 4 modules while the tree carried 12 (#2280).
+          # Adding a module here means: give it its own LICENSE, stamp AGPL-3.0-only headers
+          # (scripts/add-license-headers.sh is path-aware from this list), and keep the paths list above
+          # in sync. Enforced by .github/scripts/check-license-headers.py.
           agpl_modules:
-            - openbank-agent-service
-            - openbank-copilot-service
-            - openbank-devops-agent
-            - openbank-finops-agent
+            - openbank-agent-service            # ADR-0136
+            - openbank-copilot-service          # ADR-0136
+            - openbank-devops-agent             # ADR-0136
+            - openbank-finops-agent             # ADR-0136
             - openbank-control-liveness-sentinel
             - openbank-governance-auditor
             - openbank-release-steward
             - openbank-docs-truth-agent
             - openbank-authz-policy-auditor
             - openbank-flaky-test-hunter
-          rule: "no Apache-2.0 module may declare project(':openbank-agent-service'|':openbank-copilot-service'|':openbank-devops-agent'|':openbank-finops-agent'|':openbank-control-liveness-sentinel'|':openbank-governance-auditor'|':openbank-release-steward'|':openbank-docs-truth-agent'|':openbank-authz-policy-auditor'|':openbank-flaky-test-hunter') as a dependency"
+            - openbank-ap2-service              # ADR-0193 -- same agent plane as mcp-service
+            - openbank-mcp-service              # ADR-0181 -- explicitly inside the ADR-0136 boundary
+          rule: "no Apache-2.0 module may declare project(':openbank-agent-service'|':openbank-copilot-service'|':openbank-devops-agent'|':openbank-finops-agent'|':openbank-control-liveness-sentinel'|':openbank-governance-auditor'|':openbank-release-steward'|':openbank-docs-truth-agent'|':openbank-authz-policy-auditor'|':openbank-flaky-test-hunter'|':openbank-ap2-service'|':openbank-mcp-service') as a dependency"
           license: "AGPL-3.0-only"
           adr: ADR-0136
       block_on_cve_severity: [CRITICAL, HIGH]

--- a/openbank-infra/gitops/components/payments/standing-order-opa-bundle.yaml
+++ b/openbank-infra/gitops/components/payments/standing-order-opa-bundle.yaml
@@ -9,7 +9,7 @@ metadata:
     app.kubernetes.io/name: standing-order-service
     app.kubernetes.io/part-of: payments
   annotations:
-    openbank.tech/policy-checksum: "d9afa135beb74727"
+    openbank.tech/policy-checksum: "17bd6322d62baad5"
 data:
   rest.rego: |
     # SPDX-License-Identifier: Apache-2.0
@@ -2222,6 +2222,9 @@ data:
       license_denylist_exceptions:
         - license: AGPL-3.0-only
           scope: agent-services                 # in-repo open-core; own LICENSE, commercial dual-license
+          # DERIVED from license_boundary_exceptions[0].agpl_modules below (one entry each, with a
+          # trailing slash). check-license-headers.py fails if the two lists disagree -- they drifted
+          # apart from the tree once already (#2280).
           paths:
             - openbank-agent-service/
             - openbank-copilot-service/
@@ -2233,22 +2236,33 @@ data:
             - openbank-docs-truth-agent/
             - openbank-authz-policy-auditor/
             - openbank-flaky-test-hunter/
+            - openbank-ap2-service/
+            - openbank-mcp-service/
           reason: "open-core: AGPL-3.0-only + commercial dual-licensing of the AI agent services"
           adr: ADR-0136
       license_boundary_exceptions:
         - description: "AGPL/Apache seam (in-repo). The AI agent services are AGPL-3.0-only; no Apache-2.0 module may take a build/compile dependency on them (only network/HTTP use is allowed). They depend on openbank-libs (Apache-2.0), which is permitted -- copyleft may consume permissive code."
+          # CANONICAL list of the in-repo AGPL-3.0-only modules -- the single source of truth for
+          # which components sit outside the root Apache-2.0 LICENSE. NOTICE and README deliberately
+          # do NOT enumerate them (they point here instead), because a hand-maintained second copy
+          # is what let the published NOTICE claim 4 modules while the tree carried 12 (#2280).
+          # Adding a module here means: give it its own LICENSE, stamp AGPL-3.0-only headers
+          # (scripts/add-license-headers.sh is path-aware from this list), and keep the paths list above
+          # in sync. Enforced by .github/scripts/check-license-headers.py.
           agpl_modules:
-            - openbank-agent-service
-            - openbank-copilot-service
-            - openbank-devops-agent
-            - openbank-finops-agent
+            - openbank-agent-service            # ADR-0136
+            - openbank-copilot-service          # ADR-0136
+            - openbank-devops-agent             # ADR-0136
+            - openbank-finops-agent             # ADR-0136
             - openbank-control-liveness-sentinel
             - openbank-governance-auditor
             - openbank-release-steward
             - openbank-docs-truth-agent
             - openbank-authz-policy-auditor
             - openbank-flaky-test-hunter
-          rule: "no Apache-2.0 module may declare project(':openbank-agent-service'|':openbank-copilot-service'|':openbank-devops-agent'|':openbank-finops-agent'|':openbank-control-liveness-sentinel'|':openbank-governance-auditor'|':openbank-release-steward'|':openbank-docs-truth-agent'|':openbank-authz-policy-auditor'|':openbank-flaky-test-hunter') as a dependency"
+            - openbank-ap2-service              # ADR-0193 -- same agent plane as mcp-service
+            - openbank-mcp-service              # ADR-0181 -- explicitly inside the ADR-0136 boundary
+          rule: "no Apache-2.0 module may declare project(':openbank-agent-service'|':openbank-copilot-service'|':openbank-devops-agent'|':openbank-finops-agent'|':openbank-control-liveness-sentinel'|':openbank-governance-auditor'|':openbank-release-steward'|':openbank-docs-truth-agent'|':openbank-authz-policy-auditor'|':openbank-flaky-test-hunter'|':openbank-ap2-service'|':openbank-mcp-service') as a dependency"
           license: "AGPL-3.0-only"
           adr: ADR-0136
       block_on_cve_severity: [CRITICAL, HIGH]

--- a/openbank-infra/gitops/components/payments/swift-opa-bundle.yaml
+++ b/openbank-infra/gitops/components/payments/swift-opa-bundle.yaml
@@ -9,7 +9,7 @@ metadata:
     app.kubernetes.io/name: swift-service
     app.kubernetes.io/part-of: payments
   annotations:
-    openbank.tech/policy-checksum: "12dcf4bca2e2366b"
+    openbank.tech/policy-checksum: "b6d939fd1e7d24eb"
 data:
   rest.rego: |
     # SPDX-License-Identifier: Apache-2.0
@@ -2240,6 +2240,9 @@ data:
       license_denylist_exceptions:
         - license: AGPL-3.0-only
           scope: agent-services                 # in-repo open-core; own LICENSE, commercial dual-license
+          # DERIVED from license_boundary_exceptions[0].agpl_modules below (one entry each, with a
+          # trailing slash). check-license-headers.py fails if the two lists disagree -- they drifted
+          # apart from the tree once already (#2280).
           paths:
             - openbank-agent-service/
             - openbank-copilot-service/
@@ -2251,22 +2254,33 @@ data:
             - openbank-docs-truth-agent/
             - openbank-authz-policy-auditor/
             - openbank-flaky-test-hunter/
+            - openbank-ap2-service/
+            - openbank-mcp-service/
           reason: "open-core: AGPL-3.0-only + commercial dual-licensing of the AI agent services"
           adr: ADR-0136
       license_boundary_exceptions:
         - description: "AGPL/Apache seam (in-repo). The AI agent services are AGPL-3.0-only; no Apache-2.0 module may take a build/compile dependency on them (only network/HTTP use is allowed). They depend on openbank-libs (Apache-2.0), which is permitted -- copyleft may consume permissive code."
+          # CANONICAL list of the in-repo AGPL-3.0-only modules -- the single source of truth for
+          # which components sit outside the root Apache-2.0 LICENSE. NOTICE and README deliberately
+          # do NOT enumerate them (they point here instead), because a hand-maintained second copy
+          # is what let the published NOTICE claim 4 modules while the tree carried 12 (#2280).
+          # Adding a module here means: give it its own LICENSE, stamp AGPL-3.0-only headers
+          # (scripts/add-license-headers.sh is path-aware from this list), and keep the paths list above
+          # in sync. Enforced by .github/scripts/check-license-headers.py.
           agpl_modules:
-            - openbank-agent-service
-            - openbank-copilot-service
-            - openbank-devops-agent
-            - openbank-finops-agent
+            - openbank-agent-service            # ADR-0136
+            - openbank-copilot-service          # ADR-0136
+            - openbank-devops-agent             # ADR-0136
+            - openbank-finops-agent             # ADR-0136
             - openbank-control-liveness-sentinel
             - openbank-governance-auditor
             - openbank-release-steward
             - openbank-docs-truth-agent
             - openbank-authz-policy-auditor
             - openbank-flaky-test-hunter
-          rule: "no Apache-2.0 module may declare project(':openbank-agent-service'|':openbank-copilot-service'|':openbank-devops-agent'|':openbank-finops-agent'|':openbank-control-liveness-sentinel'|':openbank-governance-auditor'|':openbank-release-steward'|':openbank-docs-truth-agent'|':openbank-authz-policy-auditor'|':openbank-flaky-test-hunter') as a dependency"
+            - openbank-ap2-service              # ADR-0193 -- same agent plane as mcp-service
+            - openbank-mcp-service              # ADR-0181 -- explicitly inside the ADR-0136 boundary
+          rule: "no Apache-2.0 module may declare project(':openbank-agent-service'|':openbank-copilot-service'|':openbank-devops-agent'|':openbank-finops-agent'|':openbank-control-liveness-sentinel'|':openbank-governance-auditor'|':openbank-release-steward'|':openbank-docs-truth-agent'|':openbank-authz-policy-auditor'|':openbank-flaky-test-hunter'|':openbank-ap2-service'|':openbank-mcp-service') as a dependency"
           license: "AGPL-3.0-only"
           adr: ADR-0136
       block_on_cve_severity: [CRITICAL, HIGH]

--- a/openbank-infra/gitops/components/payments/transaction-opa-bundle.yaml
+++ b/openbank-infra/gitops/components/payments/transaction-opa-bundle.yaml
@@ -9,7 +9,7 @@ metadata:
     app.kubernetes.io/name: transaction-service
     app.kubernetes.io/part-of: payments
   annotations:
-    openbank.tech/policy-checksum: "6cb1baed6742783f"
+    openbank.tech/policy-checksum: "5b163df5ea95e183"
 data:
   rest.rego: |
     # SPDX-License-Identifier: Apache-2.0
@@ -2293,6 +2293,9 @@ data:
       license_denylist_exceptions:
         - license: AGPL-3.0-only
           scope: agent-services                 # in-repo open-core; own LICENSE, commercial dual-license
+          # DERIVED from license_boundary_exceptions[0].agpl_modules below (one entry each, with a
+          # trailing slash). check-license-headers.py fails if the two lists disagree -- they drifted
+          # apart from the tree once already (#2280).
           paths:
             - openbank-agent-service/
             - openbank-copilot-service/
@@ -2304,22 +2307,33 @@ data:
             - openbank-docs-truth-agent/
             - openbank-authz-policy-auditor/
             - openbank-flaky-test-hunter/
+            - openbank-ap2-service/
+            - openbank-mcp-service/
           reason: "open-core: AGPL-3.0-only + commercial dual-licensing of the AI agent services"
           adr: ADR-0136
       license_boundary_exceptions:
         - description: "AGPL/Apache seam (in-repo). The AI agent services are AGPL-3.0-only; no Apache-2.0 module may take a build/compile dependency on them (only network/HTTP use is allowed). They depend on openbank-libs (Apache-2.0), which is permitted -- copyleft may consume permissive code."
+          # CANONICAL list of the in-repo AGPL-3.0-only modules -- the single source of truth for
+          # which components sit outside the root Apache-2.0 LICENSE. NOTICE and README deliberately
+          # do NOT enumerate them (they point here instead), because a hand-maintained second copy
+          # is what let the published NOTICE claim 4 modules while the tree carried 12 (#2280).
+          # Adding a module here means: give it its own LICENSE, stamp AGPL-3.0-only headers
+          # (scripts/add-license-headers.sh is path-aware from this list), and keep the paths list above
+          # in sync. Enforced by .github/scripts/check-license-headers.py.
           agpl_modules:
-            - openbank-agent-service
-            - openbank-copilot-service
-            - openbank-devops-agent
-            - openbank-finops-agent
+            - openbank-agent-service            # ADR-0136
+            - openbank-copilot-service          # ADR-0136
+            - openbank-devops-agent             # ADR-0136
+            - openbank-finops-agent             # ADR-0136
             - openbank-control-liveness-sentinel
             - openbank-governance-auditor
             - openbank-release-steward
             - openbank-docs-truth-agent
             - openbank-authz-policy-auditor
             - openbank-flaky-test-hunter
-          rule: "no Apache-2.0 module may declare project(':openbank-agent-service'|':openbank-copilot-service'|':openbank-devops-agent'|':openbank-finops-agent'|':openbank-control-liveness-sentinel'|':openbank-governance-auditor'|':openbank-release-steward'|':openbank-docs-truth-agent'|':openbank-authz-policy-auditor'|':openbank-flaky-test-hunter') as a dependency"
+            - openbank-ap2-service              # ADR-0193 -- same agent plane as mcp-service
+            - openbank-mcp-service              # ADR-0181 -- explicitly inside the ADR-0136 boundary
+          rule: "no Apache-2.0 module may declare project(':openbank-agent-service'|':openbank-copilot-service'|':openbank-devops-agent'|':openbank-finops-agent'|':openbank-control-liveness-sentinel'|':openbank-governance-auditor'|':openbank-release-steward'|':openbank-docs-truth-agent'|':openbank-authz-policy-auditor'|':openbank-flaky-test-hunter'|':openbank-ap2-service'|':openbank-mcp-service') as a dependency"
           license: "AGPL-3.0-only"
           adr: ADR-0136
       block_on_cve_severity: [CRITICAL, HIGH]

--- a/openbank-infra/gitops/components/payments/vop-opa-bundle.yaml
+++ b/openbank-infra/gitops/components/payments/vop-opa-bundle.yaml
@@ -9,7 +9,7 @@ metadata:
     app.kubernetes.io/name: vop-service
     app.kubernetes.io/part-of: payments
   annotations:
-    openbank.tech/policy-checksum: "226b220834fe5b7f"
+    openbank.tech/policy-checksum: "df8449abde7b5cea"
 data:
   rest.rego: |
     # SPDX-License-Identifier: Apache-2.0
@@ -2244,6 +2244,9 @@ data:
       license_denylist_exceptions:
         - license: AGPL-3.0-only
           scope: agent-services                 # in-repo open-core; own LICENSE, commercial dual-license
+          # DERIVED from license_boundary_exceptions[0].agpl_modules below (one entry each, with a
+          # trailing slash). check-license-headers.py fails if the two lists disagree -- they drifted
+          # apart from the tree once already (#2280).
           paths:
             - openbank-agent-service/
             - openbank-copilot-service/
@@ -2255,22 +2258,33 @@ data:
             - openbank-docs-truth-agent/
             - openbank-authz-policy-auditor/
             - openbank-flaky-test-hunter/
+            - openbank-ap2-service/
+            - openbank-mcp-service/
           reason: "open-core: AGPL-3.0-only + commercial dual-licensing of the AI agent services"
           adr: ADR-0136
       license_boundary_exceptions:
         - description: "AGPL/Apache seam (in-repo). The AI agent services are AGPL-3.0-only; no Apache-2.0 module may take a build/compile dependency on them (only network/HTTP use is allowed). They depend on openbank-libs (Apache-2.0), which is permitted -- copyleft may consume permissive code."
+          # CANONICAL list of the in-repo AGPL-3.0-only modules -- the single source of truth for
+          # which components sit outside the root Apache-2.0 LICENSE. NOTICE and README deliberately
+          # do NOT enumerate them (they point here instead), because a hand-maintained second copy
+          # is what let the published NOTICE claim 4 modules while the tree carried 12 (#2280).
+          # Adding a module here means: give it its own LICENSE, stamp AGPL-3.0-only headers
+          # (scripts/add-license-headers.sh is path-aware from this list), and keep the paths list above
+          # in sync. Enforced by .github/scripts/check-license-headers.py.
           agpl_modules:
-            - openbank-agent-service
-            - openbank-copilot-service
-            - openbank-devops-agent
-            - openbank-finops-agent
+            - openbank-agent-service            # ADR-0136
+            - openbank-copilot-service          # ADR-0136
+            - openbank-devops-agent             # ADR-0136
+            - openbank-finops-agent             # ADR-0136
             - openbank-control-liveness-sentinel
             - openbank-governance-auditor
             - openbank-release-steward
             - openbank-docs-truth-agent
             - openbank-authz-policy-auditor
             - openbank-flaky-test-hunter
-          rule: "no Apache-2.0 module may declare project(':openbank-agent-service'|':openbank-copilot-service'|':openbank-devops-agent'|':openbank-finops-agent'|':openbank-control-liveness-sentinel'|':openbank-governance-auditor'|':openbank-release-steward'|':openbank-docs-truth-agent'|':openbank-authz-policy-auditor'|':openbank-flaky-test-hunter') as a dependency"
+            - openbank-ap2-service              # ADR-0193 -- same agent plane as mcp-service
+            - openbank-mcp-service              # ADR-0181 -- explicitly inside the ADR-0136 boundary
+          rule: "no Apache-2.0 module may declare project(':openbank-agent-service'|':openbank-copilot-service'|':openbank-devops-agent'|':openbank-finops-agent'|':openbank-control-liveness-sentinel'|':openbank-governance-auditor'|':openbank-release-steward'|':openbank-docs-truth-agent'|':openbank-authz-policy-auditor'|':openbank-flaky-test-hunter'|':openbank-ap2-service'|':openbank-mcp-service') as a dependency"
           license: "AGPL-3.0-only"
           adr: ADR-0136
       block_on_cve_severity: [CRITICAL, HIGH]

--- a/openbank-infra/gitops/components/pid/pid-opa-bundle.yaml
+++ b/openbank-infra/gitops/components/pid/pid-opa-bundle.yaml
@@ -9,7 +9,7 @@ metadata:
     app.kubernetes.io/name: pid-service
     app.kubernetes.io/part-of: pid
   annotations:
-    openbank.tech/policy-checksum: "7e7619eba7637de1"
+    openbank.tech/policy-checksum: "85d202e19234dd4f"
 data:
   rest.rego: |
     # SPDX-License-Identifier: Apache-2.0
@@ -2246,6 +2246,9 @@ data:
       license_denylist_exceptions:
         - license: AGPL-3.0-only
           scope: agent-services                 # in-repo open-core; own LICENSE, commercial dual-license
+          # DERIVED from license_boundary_exceptions[0].agpl_modules below (one entry each, with a
+          # trailing slash). check-license-headers.py fails if the two lists disagree -- they drifted
+          # apart from the tree once already (#2280).
           paths:
             - openbank-agent-service/
             - openbank-copilot-service/
@@ -2257,22 +2260,33 @@ data:
             - openbank-docs-truth-agent/
             - openbank-authz-policy-auditor/
             - openbank-flaky-test-hunter/
+            - openbank-ap2-service/
+            - openbank-mcp-service/
           reason: "open-core: AGPL-3.0-only + commercial dual-licensing of the AI agent services"
           adr: ADR-0136
       license_boundary_exceptions:
         - description: "AGPL/Apache seam (in-repo). The AI agent services are AGPL-3.0-only; no Apache-2.0 module may take a build/compile dependency on them (only network/HTTP use is allowed). They depend on openbank-libs (Apache-2.0), which is permitted -- copyleft may consume permissive code."
+          # CANONICAL list of the in-repo AGPL-3.0-only modules -- the single source of truth for
+          # which components sit outside the root Apache-2.0 LICENSE. NOTICE and README deliberately
+          # do NOT enumerate them (they point here instead), because a hand-maintained second copy
+          # is what let the published NOTICE claim 4 modules while the tree carried 12 (#2280).
+          # Adding a module here means: give it its own LICENSE, stamp AGPL-3.0-only headers
+          # (scripts/add-license-headers.sh is path-aware from this list), and keep the paths list above
+          # in sync. Enforced by .github/scripts/check-license-headers.py.
           agpl_modules:
-            - openbank-agent-service
-            - openbank-copilot-service
-            - openbank-devops-agent
-            - openbank-finops-agent
+            - openbank-agent-service            # ADR-0136
+            - openbank-copilot-service          # ADR-0136
+            - openbank-devops-agent             # ADR-0136
+            - openbank-finops-agent             # ADR-0136
             - openbank-control-liveness-sentinel
             - openbank-governance-auditor
             - openbank-release-steward
             - openbank-docs-truth-agent
             - openbank-authz-policy-auditor
             - openbank-flaky-test-hunter
-          rule: "no Apache-2.0 module may declare project(':openbank-agent-service'|':openbank-copilot-service'|':openbank-devops-agent'|':openbank-finops-agent'|':openbank-control-liveness-sentinel'|':openbank-governance-auditor'|':openbank-release-steward'|':openbank-docs-truth-agent'|':openbank-authz-policy-auditor'|':openbank-flaky-test-hunter') as a dependency"
+            - openbank-ap2-service              # ADR-0193 -- same agent plane as mcp-service
+            - openbank-mcp-service              # ADR-0181 -- explicitly inside the ADR-0136 boundary
+          rule: "no Apache-2.0 module may declare project(':openbank-agent-service'|':openbank-copilot-service'|':openbank-devops-agent'|':openbank-finops-agent'|':openbank-control-liveness-sentinel'|':openbank-governance-auditor'|':openbank-release-steward'|':openbank-docs-truth-agent'|':openbank-authz-policy-auditor'|':openbank-flaky-test-hunter'|':openbank-ap2-service'|':openbank-mcp-service') as a dependency"
           license: "AGPL-3.0-only"
           adr: ADR-0136
       block_on_cve_severity: [CRITICAL, HIGH]

--- a/openbank-infra/gitops/components/pid/pid-service.yaml
+++ b/openbank-infra/gitops/components/pid/pid-service.yaml
@@ -22,7 +22,7 @@ spec:
       annotations:
         # Rolls the pod when the OPA bundle changes — subPath mounts do NOT hot-reload.
         # Kept in sync by gen-pid-opa-bundle.sh (do not hand-edit).
-        openbank.tech/policy-checksum: "7e7619eba7637de1"
+        openbank.tech/policy-checksum: "85d202e19234dd4f"
     spec:
       securityContext:
         runAsNonRoot: true

--- a/openbank-infra/gitops/components/psd2-service/psd2-opa-bundle.yaml
+++ b/openbank-infra/gitops/components/psd2-service/psd2-opa-bundle.yaml
@@ -9,7 +9,7 @@ metadata:
     app.kubernetes.io/name: psd2-service
     app.kubernetes.io/part-of: psd2
   annotations:
-    openbank.tech/policy-checksum: "960d13b2074ebc61"
+    openbank.tech/policy-checksum: "fdd1405b77d5fbba"
 data:
   rest.rego: |
     # SPDX-License-Identifier: Apache-2.0
@@ -2319,6 +2319,9 @@ data:
       license_denylist_exceptions:
         - license: AGPL-3.0-only
           scope: agent-services                 # in-repo open-core; own LICENSE, commercial dual-license
+          # DERIVED from license_boundary_exceptions[0].agpl_modules below (one entry each, with a
+          # trailing slash). check-license-headers.py fails if the two lists disagree -- they drifted
+          # apart from the tree once already (#2280).
           paths:
             - openbank-agent-service/
             - openbank-copilot-service/
@@ -2330,22 +2333,33 @@ data:
             - openbank-docs-truth-agent/
             - openbank-authz-policy-auditor/
             - openbank-flaky-test-hunter/
+            - openbank-ap2-service/
+            - openbank-mcp-service/
           reason: "open-core: AGPL-3.0-only + commercial dual-licensing of the AI agent services"
           adr: ADR-0136
       license_boundary_exceptions:
         - description: "AGPL/Apache seam (in-repo). The AI agent services are AGPL-3.0-only; no Apache-2.0 module may take a build/compile dependency on them (only network/HTTP use is allowed). They depend on openbank-libs (Apache-2.0), which is permitted -- copyleft may consume permissive code."
+          # CANONICAL list of the in-repo AGPL-3.0-only modules -- the single source of truth for
+          # which components sit outside the root Apache-2.0 LICENSE. NOTICE and README deliberately
+          # do NOT enumerate them (they point here instead), because a hand-maintained second copy
+          # is what let the published NOTICE claim 4 modules while the tree carried 12 (#2280).
+          # Adding a module here means: give it its own LICENSE, stamp AGPL-3.0-only headers
+          # (scripts/add-license-headers.sh is path-aware from this list), and keep the paths list above
+          # in sync. Enforced by .github/scripts/check-license-headers.py.
           agpl_modules:
-            - openbank-agent-service
-            - openbank-copilot-service
-            - openbank-devops-agent
-            - openbank-finops-agent
+            - openbank-agent-service            # ADR-0136
+            - openbank-copilot-service          # ADR-0136
+            - openbank-devops-agent             # ADR-0136
+            - openbank-finops-agent             # ADR-0136
             - openbank-control-liveness-sentinel
             - openbank-governance-auditor
             - openbank-release-steward
             - openbank-docs-truth-agent
             - openbank-authz-policy-auditor
             - openbank-flaky-test-hunter
-          rule: "no Apache-2.0 module may declare project(':openbank-agent-service'|':openbank-copilot-service'|':openbank-devops-agent'|':openbank-finops-agent'|':openbank-control-liveness-sentinel'|':openbank-governance-auditor'|':openbank-release-steward'|':openbank-docs-truth-agent'|':openbank-authz-policy-auditor'|':openbank-flaky-test-hunter') as a dependency"
+            - openbank-ap2-service              # ADR-0193 -- same agent plane as mcp-service
+            - openbank-mcp-service              # ADR-0181 -- explicitly inside the ADR-0136 boundary
+          rule: "no Apache-2.0 module may declare project(':openbank-agent-service'|':openbank-copilot-service'|':openbank-devops-agent'|':openbank-finops-agent'|':openbank-control-liveness-sentinel'|':openbank-governance-auditor'|':openbank-release-steward'|':openbank-docs-truth-agent'|':openbank-authz-policy-auditor'|':openbank-flaky-test-hunter'|':openbank-ap2-service'|':openbank-mcp-service') as a dependency"
           license: "AGPL-3.0-only"
           adr: ADR-0136
       block_on_cve_severity: [CRITICAL, HIGH]

--- a/openbank-infra/gitops/components/psd2-service/psd2-service.yaml
+++ b/openbank-infra/gitops/components/psd2-service/psd2-service.yaml
@@ -18,7 +18,7 @@ spec:
       annotations:
         # Rolls the pod when the OPA bundle changes — subPath mounts do NOT hot-reload.
         # Kept in sync by gen-psd2-opa-bundle.sh (do not hand-edit).
-        openbank.tech/policy-checksum: "960d13b2074ebc61"
+        openbank.tech/policy-checksum: "fdd1405b77d5fbba"
       labels: {app.kubernetes.io/name: psd2-service, app.kubernetes.io/part-of: psd2}
     spec:
       securityContext:

--- a/openbank-infra/gitops/components/sanctions-service/sanctions-opa-bundle.yaml
+++ b/openbank-infra/gitops/components/sanctions-service/sanctions-opa-bundle.yaml
@@ -9,7 +9,7 @@ metadata:
     app.kubernetes.io/name: sanctions-service
     app.kubernetes.io/part-of: sanctions
   annotations:
-    openbank.tech/policy-checksum: "d4c654f78a2c3e2d"
+    openbank.tech/policy-checksum: "a7a453bd99cfeb9e"
 data:
   rest.rego: |
     # SPDX-License-Identifier: Apache-2.0
@@ -2224,6 +2224,9 @@ data:
       license_denylist_exceptions:
         - license: AGPL-3.0-only
           scope: agent-services                 # in-repo open-core; own LICENSE, commercial dual-license
+          # DERIVED from license_boundary_exceptions[0].agpl_modules below (one entry each, with a
+          # trailing slash). check-license-headers.py fails if the two lists disagree -- they drifted
+          # apart from the tree once already (#2280).
           paths:
             - openbank-agent-service/
             - openbank-copilot-service/
@@ -2235,22 +2238,33 @@ data:
             - openbank-docs-truth-agent/
             - openbank-authz-policy-auditor/
             - openbank-flaky-test-hunter/
+            - openbank-ap2-service/
+            - openbank-mcp-service/
           reason: "open-core: AGPL-3.0-only + commercial dual-licensing of the AI agent services"
           adr: ADR-0136
       license_boundary_exceptions:
         - description: "AGPL/Apache seam (in-repo). The AI agent services are AGPL-3.0-only; no Apache-2.0 module may take a build/compile dependency on them (only network/HTTP use is allowed). They depend on openbank-libs (Apache-2.0), which is permitted -- copyleft may consume permissive code."
+          # CANONICAL list of the in-repo AGPL-3.0-only modules -- the single source of truth for
+          # which components sit outside the root Apache-2.0 LICENSE. NOTICE and README deliberately
+          # do NOT enumerate them (they point here instead), because a hand-maintained second copy
+          # is what let the published NOTICE claim 4 modules while the tree carried 12 (#2280).
+          # Adding a module here means: give it its own LICENSE, stamp AGPL-3.0-only headers
+          # (scripts/add-license-headers.sh is path-aware from this list), and keep the paths list above
+          # in sync. Enforced by .github/scripts/check-license-headers.py.
           agpl_modules:
-            - openbank-agent-service
-            - openbank-copilot-service
-            - openbank-devops-agent
-            - openbank-finops-agent
+            - openbank-agent-service            # ADR-0136
+            - openbank-copilot-service          # ADR-0136
+            - openbank-devops-agent             # ADR-0136
+            - openbank-finops-agent             # ADR-0136
             - openbank-control-liveness-sentinel
             - openbank-governance-auditor
             - openbank-release-steward
             - openbank-docs-truth-agent
             - openbank-authz-policy-auditor
             - openbank-flaky-test-hunter
-          rule: "no Apache-2.0 module may declare project(':openbank-agent-service'|':openbank-copilot-service'|':openbank-devops-agent'|':openbank-finops-agent'|':openbank-control-liveness-sentinel'|':openbank-governance-auditor'|':openbank-release-steward'|':openbank-docs-truth-agent'|':openbank-authz-policy-auditor'|':openbank-flaky-test-hunter') as a dependency"
+            - openbank-ap2-service              # ADR-0193 -- same agent plane as mcp-service
+            - openbank-mcp-service              # ADR-0181 -- explicitly inside the ADR-0136 boundary
+          rule: "no Apache-2.0 module may declare project(':openbank-agent-service'|':openbank-copilot-service'|':openbank-devops-agent'|':openbank-finops-agent'|':openbank-control-liveness-sentinel'|':openbank-governance-auditor'|':openbank-release-steward'|':openbank-docs-truth-agent'|':openbank-authz-policy-auditor'|':openbank-flaky-test-hunter'|':openbank-ap2-service'|':openbank-mcp-service') as a dependency"
           license: "AGPL-3.0-only"
           adr: ADR-0136
       block_on_cve_severity: [CRITICAL, HIGH]

--- a/openbank-infra/gitops/components/sanctions-service/sanctions-service.yaml
+++ b/openbank-infra/gitops/components/sanctions-service/sanctions-service.yaml
@@ -49,7 +49,7 @@ spec:
       annotations:
         # Rolls the pods when the OPA bundle changes — subPath mounts do NOT hot-reload.
         # Kept in sync by gen-sanctions-opa-bundle.sh (do not hand-edit).
-        openbank.tech/policy-checksum: "d4c654f78a2c3e2d"
+        openbank.tech/policy-checksum: "a7a453bd99cfeb9e"
     spec:
       securityContext:
         runAsNonRoot: true

--- a/openbank-infra/gitops/components/sca/sca-opa-bundle.yaml
+++ b/openbank-infra/gitops/components/sca/sca-opa-bundle.yaml
@@ -9,7 +9,7 @@ metadata:
     app.kubernetes.io/name: sca-service
     app.kubernetes.io/part-of: sca
   annotations:
-    openbank.tech/policy-checksum: "d40355816e8a75d6"
+    openbank.tech/policy-checksum: "640d35a7ff744529"
 data:
   rest.rego: |
     # SPDX-License-Identifier: Apache-2.0
@@ -2260,6 +2260,9 @@ data:
       license_denylist_exceptions:
         - license: AGPL-3.0-only
           scope: agent-services                 # in-repo open-core; own LICENSE, commercial dual-license
+          # DERIVED from license_boundary_exceptions[0].agpl_modules below (one entry each, with a
+          # trailing slash). check-license-headers.py fails if the two lists disagree -- they drifted
+          # apart from the tree once already (#2280).
           paths:
             - openbank-agent-service/
             - openbank-copilot-service/
@@ -2271,22 +2274,33 @@ data:
             - openbank-docs-truth-agent/
             - openbank-authz-policy-auditor/
             - openbank-flaky-test-hunter/
+            - openbank-ap2-service/
+            - openbank-mcp-service/
           reason: "open-core: AGPL-3.0-only + commercial dual-licensing of the AI agent services"
           adr: ADR-0136
       license_boundary_exceptions:
         - description: "AGPL/Apache seam (in-repo). The AI agent services are AGPL-3.0-only; no Apache-2.0 module may take a build/compile dependency on them (only network/HTTP use is allowed). They depend on openbank-libs (Apache-2.0), which is permitted -- copyleft may consume permissive code."
+          # CANONICAL list of the in-repo AGPL-3.0-only modules -- the single source of truth for
+          # which components sit outside the root Apache-2.0 LICENSE. NOTICE and README deliberately
+          # do NOT enumerate them (they point here instead), because a hand-maintained second copy
+          # is what let the published NOTICE claim 4 modules while the tree carried 12 (#2280).
+          # Adding a module here means: give it its own LICENSE, stamp AGPL-3.0-only headers
+          # (scripts/add-license-headers.sh is path-aware from this list), and keep the paths list above
+          # in sync. Enforced by .github/scripts/check-license-headers.py.
           agpl_modules:
-            - openbank-agent-service
-            - openbank-copilot-service
-            - openbank-devops-agent
-            - openbank-finops-agent
+            - openbank-agent-service            # ADR-0136
+            - openbank-copilot-service          # ADR-0136
+            - openbank-devops-agent             # ADR-0136
+            - openbank-finops-agent             # ADR-0136
             - openbank-control-liveness-sentinel
             - openbank-governance-auditor
             - openbank-release-steward
             - openbank-docs-truth-agent
             - openbank-authz-policy-auditor
             - openbank-flaky-test-hunter
-          rule: "no Apache-2.0 module may declare project(':openbank-agent-service'|':openbank-copilot-service'|':openbank-devops-agent'|':openbank-finops-agent'|':openbank-control-liveness-sentinel'|':openbank-governance-auditor'|':openbank-release-steward'|':openbank-docs-truth-agent'|':openbank-authz-policy-auditor'|':openbank-flaky-test-hunter') as a dependency"
+            - openbank-ap2-service              # ADR-0193 -- same agent plane as mcp-service
+            - openbank-mcp-service              # ADR-0181 -- explicitly inside the ADR-0136 boundary
+          rule: "no Apache-2.0 module may declare project(':openbank-agent-service'|':openbank-copilot-service'|':openbank-devops-agent'|':openbank-finops-agent'|':openbank-control-liveness-sentinel'|':openbank-governance-auditor'|':openbank-release-steward'|':openbank-docs-truth-agent'|':openbank-authz-policy-auditor'|':openbank-flaky-test-hunter'|':openbank-ap2-service'|':openbank-mcp-service') as a dependency"
           license: "AGPL-3.0-only"
           adr: ADR-0136
       block_on_cve_severity: [CRITICAL, HIGH]

--- a/openbank-infra/gitops/components/sca/sca-service.yaml
+++ b/openbank-infra/gitops/components/sca/sca-service.yaml
@@ -28,7 +28,7 @@ spec:
       annotations:
         # Rolls the pods when the OPA bundle changes — subPath mounts do NOT hot-reload.
         # Kept in sync by gen-sca-opa-bundle.sh (do not hand-edit).
-        openbank.tech/policy-checksum: "d40355816e8a75d6"
+        openbank.tech/policy-checksum: "640d35a7ff744529"
     spec:
       securityContext:
         runAsNonRoot: true

--- a/openbank-infra/gitops/components/statements/statement-opa-bundle.yaml
+++ b/openbank-infra/gitops/components/statements/statement-opa-bundle.yaml
@@ -9,7 +9,7 @@ metadata:
     app.kubernetes.io/name: statement-service
     app.kubernetes.io/part-of: statements
   annotations:
-    openbank.tech/policy-checksum: "a2927c75d3d7b76d"
+    openbank.tech/policy-checksum: "9e5ef35b94c72f78"
 data:
   rest.rego: |
     # SPDX-License-Identifier: Apache-2.0
@@ -2290,6 +2290,9 @@ data:
       license_denylist_exceptions:
         - license: AGPL-3.0-only
           scope: agent-services                 # in-repo open-core; own LICENSE, commercial dual-license
+          # DERIVED from license_boundary_exceptions[0].agpl_modules below (one entry each, with a
+          # trailing slash). check-license-headers.py fails if the two lists disagree -- they drifted
+          # apart from the tree once already (#2280).
           paths:
             - openbank-agent-service/
             - openbank-copilot-service/
@@ -2301,22 +2304,33 @@ data:
             - openbank-docs-truth-agent/
             - openbank-authz-policy-auditor/
             - openbank-flaky-test-hunter/
+            - openbank-ap2-service/
+            - openbank-mcp-service/
           reason: "open-core: AGPL-3.0-only + commercial dual-licensing of the AI agent services"
           adr: ADR-0136
       license_boundary_exceptions:
         - description: "AGPL/Apache seam (in-repo). The AI agent services are AGPL-3.0-only; no Apache-2.0 module may take a build/compile dependency on them (only network/HTTP use is allowed). They depend on openbank-libs (Apache-2.0), which is permitted -- copyleft may consume permissive code."
+          # CANONICAL list of the in-repo AGPL-3.0-only modules -- the single source of truth for
+          # which components sit outside the root Apache-2.0 LICENSE. NOTICE and README deliberately
+          # do NOT enumerate them (they point here instead), because a hand-maintained second copy
+          # is what let the published NOTICE claim 4 modules while the tree carried 12 (#2280).
+          # Adding a module here means: give it its own LICENSE, stamp AGPL-3.0-only headers
+          # (scripts/add-license-headers.sh is path-aware from this list), and keep the paths list above
+          # in sync. Enforced by .github/scripts/check-license-headers.py.
           agpl_modules:
-            - openbank-agent-service
-            - openbank-copilot-service
-            - openbank-devops-agent
-            - openbank-finops-agent
+            - openbank-agent-service            # ADR-0136
+            - openbank-copilot-service          # ADR-0136
+            - openbank-devops-agent             # ADR-0136
+            - openbank-finops-agent             # ADR-0136
             - openbank-control-liveness-sentinel
             - openbank-governance-auditor
             - openbank-release-steward
             - openbank-docs-truth-agent
             - openbank-authz-policy-auditor
             - openbank-flaky-test-hunter
-          rule: "no Apache-2.0 module may declare project(':openbank-agent-service'|':openbank-copilot-service'|':openbank-devops-agent'|':openbank-finops-agent'|':openbank-control-liveness-sentinel'|':openbank-governance-auditor'|':openbank-release-steward'|':openbank-docs-truth-agent'|':openbank-authz-policy-auditor'|':openbank-flaky-test-hunter') as a dependency"
+            - openbank-ap2-service              # ADR-0193 -- same agent plane as mcp-service
+            - openbank-mcp-service              # ADR-0181 -- explicitly inside the ADR-0136 boundary
+          rule: "no Apache-2.0 module may declare project(':openbank-agent-service'|':openbank-copilot-service'|':openbank-devops-agent'|':openbank-finops-agent'|':openbank-control-liveness-sentinel'|':openbank-governance-auditor'|':openbank-release-steward'|':openbank-docs-truth-agent'|':openbank-authz-policy-auditor'|':openbank-flaky-test-hunter'|':openbank-ap2-service'|':openbank-mcp-service') as a dependency"
           license: "AGPL-3.0-only"
           adr: ADR-0136
       block_on_cve_severity: [CRITICAL, HIGH]

--- a/openbank-infra/gitops/components/statements/statement-service.yaml
+++ b/openbank-infra/gitops/components/statements/statement-service.yaml
@@ -26,7 +26,7 @@ spec:
       annotations:
         # Rolls the pod when the OPA bundle changes — subPath mounts do NOT hot-reload.
         # Kept in sync by gen-statement-opa-bundle.sh (do not hand-edit).
-        openbank.tech/policy-checksum: "a2927c75d3d7b76d"
+        openbank.tech/policy-checksum: "9e5ef35b94c72f78"
       labels:
         app.kubernetes.io/name: statement-service
         app.kubernetes.io/part-of: statements

--- a/openbank-infra/gitops/components/tpp-registry/tpp-registry-opa-bundle.yaml
+++ b/openbank-infra/gitops/components/tpp-registry/tpp-registry-opa-bundle.yaml
@@ -9,7 +9,7 @@ metadata:
     app.kubernetes.io/name: tpp-registry-service
     app.kubernetes.io/part-of: tpp-registry
   annotations:
-    openbank.tech/policy-checksum: "4a32a771eb5ace52"
+    openbank.tech/policy-checksum: "cc1f2ec22dbd6a01"
 data:
   rest.rego: |
     # SPDX-License-Identifier: Apache-2.0
@@ -2227,6 +2227,9 @@ data:
       license_denylist_exceptions:
         - license: AGPL-3.0-only
           scope: agent-services                 # in-repo open-core; own LICENSE, commercial dual-license
+          # DERIVED from license_boundary_exceptions[0].agpl_modules below (one entry each, with a
+          # trailing slash). check-license-headers.py fails if the two lists disagree -- they drifted
+          # apart from the tree once already (#2280).
           paths:
             - openbank-agent-service/
             - openbank-copilot-service/
@@ -2238,22 +2241,33 @@ data:
             - openbank-docs-truth-agent/
             - openbank-authz-policy-auditor/
             - openbank-flaky-test-hunter/
+            - openbank-ap2-service/
+            - openbank-mcp-service/
           reason: "open-core: AGPL-3.0-only + commercial dual-licensing of the AI agent services"
           adr: ADR-0136
       license_boundary_exceptions:
         - description: "AGPL/Apache seam (in-repo). The AI agent services are AGPL-3.0-only; no Apache-2.0 module may take a build/compile dependency on them (only network/HTTP use is allowed). They depend on openbank-libs (Apache-2.0), which is permitted -- copyleft may consume permissive code."
+          # CANONICAL list of the in-repo AGPL-3.0-only modules -- the single source of truth for
+          # which components sit outside the root Apache-2.0 LICENSE. NOTICE and README deliberately
+          # do NOT enumerate them (they point here instead), because a hand-maintained second copy
+          # is what let the published NOTICE claim 4 modules while the tree carried 12 (#2280).
+          # Adding a module here means: give it its own LICENSE, stamp AGPL-3.0-only headers
+          # (scripts/add-license-headers.sh is path-aware from this list), and keep the paths list above
+          # in sync. Enforced by .github/scripts/check-license-headers.py.
           agpl_modules:
-            - openbank-agent-service
-            - openbank-copilot-service
-            - openbank-devops-agent
-            - openbank-finops-agent
+            - openbank-agent-service            # ADR-0136
+            - openbank-copilot-service          # ADR-0136
+            - openbank-devops-agent             # ADR-0136
+            - openbank-finops-agent             # ADR-0136
             - openbank-control-liveness-sentinel
             - openbank-governance-auditor
             - openbank-release-steward
             - openbank-docs-truth-agent
             - openbank-authz-policy-auditor
             - openbank-flaky-test-hunter
-          rule: "no Apache-2.0 module may declare project(':openbank-agent-service'|':openbank-copilot-service'|':openbank-devops-agent'|':openbank-finops-agent'|':openbank-control-liveness-sentinel'|':openbank-governance-auditor'|':openbank-release-steward'|':openbank-docs-truth-agent'|':openbank-authz-policy-auditor'|':openbank-flaky-test-hunter') as a dependency"
+            - openbank-ap2-service              # ADR-0193 -- same agent plane as mcp-service
+            - openbank-mcp-service              # ADR-0181 -- explicitly inside the ADR-0136 boundary
+          rule: "no Apache-2.0 module may declare project(':openbank-agent-service'|':openbank-copilot-service'|':openbank-devops-agent'|':openbank-finops-agent'|':openbank-control-liveness-sentinel'|':openbank-governance-auditor'|':openbank-release-steward'|':openbank-docs-truth-agent'|':openbank-authz-policy-auditor'|':openbank-flaky-test-hunter'|':openbank-ap2-service'|':openbank-mcp-service') as a dependency"
           license: "AGPL-3.0-only"
           adr: ADR-0136
       block_on_cve_severity: [CRITICAL, HIGH]

--- a/openbank-infra/gitops/components/tpp-registry/tpp-registry-service.yaml
+++ b/openbank-infra/gitops/components/tpp-registry/tpp-registry-service.yaml
@@ -23,7 +23,7 @@ spec:
       annotations:
         # Rolls the pod when the OPA bundle changes (subPath mounts do not hot-reload).
         # Kept in sync by gen-tpp-registry-opa-bundle.sh (do not hand-edit).
-        openbank.tech/policy-checksum: "4a32a771eb5ace52"
+        openbank.tech/policy-checksum: "cc1f2ec22dbd6a01"
     spec:
       securityContext:
         runAsNonRoot: true

--- a/openbank-libs/governance/rules.yaml
+++ b/openbank-libs/governance/rules.yaml
@@ -858,6 +858,9 @@ dependencies:
   license_denylist_exceptions:
     - license: AGPL-3.0-only
       scope: agent-services                 # in-repo open-core; own LICENSE, commercial dual-license
+      # DERIVED from license_boundary_exceptions[0].agpl_modules below (one entry each, with a
+      # trailing slash). check-license-headers.py fails if the two lists disagree -- they drifted
+      # apart from the tree once already (#2280).
       paths:
         - openbank-agent-service/
         - openbank-copilot-service/
@@ -869,22 +872,33 @@ dependencies:
         - openbank-docs-truth-agent/
         - openbank-authz-policy-auditor/
         - openbank-flaky-test-hunter/
+        - openbank-ap2-service/
+        - openbank-mcp-service/
       reason: "open-core: AGPL-3.0-only + commercial dual-licensing of the AI agent services"
       adr: ADR-0136
   license_boundary_exceptions:
     - description: "AGPL/Apache seam (in-repo). The AI agent services are AGPL-3.0-only; no Apache-2.0 module may take a build/compile dependency on them (only network/HTTP use is allowed). They depend on openbank-libs (Apache-2.0), which is permitted -- copyleft may consume permissive code."
+      # CANONICAL list of the in-repo AGPL-3.0-only modules -- the single source of truth for
+      # which components sit outside the root Apache-2.0 LICENSE. NOTICE and README deliberately
+      # do NOT enumerate them (they point here instead), because a hand-maintained second copy
+      # is what let the published NOTICE claim 4 modules while the tree carried 12 (#2280).
+      # Adding a module here means: give it its own LICENSE, stamp AGPL-3.0-only headers
+      # (scripts/add-license-headers.sh is path-aware from this list), and keep the paths list above
+      # in sync. Enforced by .github/scripts/check-license-headers.py.
       agpl_modules:
-        - openbank-agent-service
-        - openbank-copilot-service
-        - openbank-devops-agent
-        - openbank-finops-agent
+        - openbank-agent-service            # ADR-0136
+        - openbank-copilot-service          # ADR-0136
+        - openbank-devops-agent             # ADR-0136
+        - openbank-finops-agent             # ADR-0136
         - openbank-control-liveness-sentinel
         - openbank-governance-auditor
         - openbank-release-steward
         - openbank-docs-truth-agent
         - openbank-authz-policy-auditor
         - openbank-flaky-test-hunter
-      rule: "no Apache-2.0 module may declare project(':openbank-agent-service'|':openbank-copilot-service'|':openbank-devops-agent'|':openbank-finops-agent'|':openbank-control-liveness-sentinel'|':openbank-governance-auditor'|':openbank-release-steward'|':openbank-docs-truth-agent'|':openbank-authz-policy-auditor'|':openbank-flaky-test-hunter') as a dependency"
+        - openbank-ap2-service              # ADR-0193 -- same agent plane as mcp-service
+        - openbank-mcp-service              # ADR-0181 -- explicitly inside the ADR-0136 boundary
+      rule: "no Apache-2.0 module may declare project(':openbank-agent-service'|':openbank-copilot-service'|':openbank-devops-agent'|':openbank-finops-agent'|':openbank-control-liveness-sentinel'|':openbank-governance-auditor'|':openbank-release-steward'|':openbank-docs-truth-agent'|':openbank-authz-policy-auditor'|':openbank-flaky-test-hunter'|':openbank-ap2-service'|':openbank-mcp-service') as a dependency"
       license: "AGPL-3.0-only"
       adr: ADR-0136
   block_on_cve_severity: [CRITICAL, HIGH]

--- a/openbank-mcp-service/governance.yaml
+++ b/openbank-mcp-service/governance.yaml
@@ -1,4 +1,4 @@
-# SPDX-License-Identifier: Apache-2.0
+# SPDX-License-Identifier: AGPL-3.0-only
 # Per-service governance manifest (ADR-0071). Declarative, curatorial facts only.
 dataDomain: payments
 primaryDatastore: none

--- a/scripts/add-license-headers.sh
+++ b/scripts/add-license-headers.sh
@@ -1,38 +1,96 @@
 #!/usr/bin/env bash
-# Add SPDX Apache-2.0 license headers to source files that lack them.
+# Add SPDX license headers to source files that lack them -- PATH-AWARE.
 #
-# Apache-2.0 recommends a per-file header; the SPDX identifier is the compact
-# form and improves license-scanner accuracy and downstream clarity.
+# This repository is a MULTI-LICENSE tree (ADR-0136): the platform is Apache-2.0 and the
+# agent-plane services are AGPL-3.0-only + a parallel commercial licence (open-core). The
+# header a file gets therefore depends on WHICH MODULE it lives in.
+#
+# The AGPL module list is read at runtime from the single source of truth,
+# openbank-libs/governance/rules.yaml -> dependencies.license_boundary_exceptions[0].agpl_modules.
+# It is never duplicated here: this script hardcoding Apache-2.0 for every path is what
+# stamped Apache-2.0 headers into AGPL modules and let the published NOTICE understate the
+# AGPL set (#2280 -- the ADR-0136 "make this script path-aware" follow-up).
+#
+# Scope: .kt/.kts/.ts/.tsx only. Deliberately NOT .sql -- Flyway checksums migration files
+# including comments, so stamping a header onto an applied migration makes every affected
+# service fail at boot with "Migration checksum mismatch". Existing .sql files with the wrong
+# licence are declared out-of-tree in REUSE.toml instead.
 #
 # Usage:
 #   ./scripts/add-license-headers.sh            # dry-run, list files that would be modified
 #   ./scripts/add-license-headers.sh --apply    # actually modify files
+#
+# Verify the result with: .github/scripts/check-license-headers.py
 
 set -euo pipefail
 
 APPLY="${1:-}"
 ROOT="$(cd "$(dirname "$0")/.." && pwd)"
+RULES="$ROOT/openbank-libs/governance/rules.yaml"
 
-KT_HEADER='// SPDX-License-Identifier: Apache-2.0
+APACHE_HEADER='// SPDX-License-Identifier: Apache-2.0
 // Copyright (c) OpenBank contributors. Licensed under the Apache License, Version 2.0.
 // See LICENSE in the repository root or https://www.apache.org/licenses/LICENSE-2.0 for details.
 '
 
-TS_HEADER='// SPDX-License-Identifier: Apache-2.0
-// Copyright (c) OpenBank contributors. Licensed under the Apache License, Version 2.0.
-// See LICENSE in the repository root or https://www.apache.org/licenses/LICENSE-2.0 for details.
+AGPL_HEADER='// SPDX-License-Identifier: AGPL-3.0-only
+// Copyright (c) OpenBank contributors. Licensed under the GNU Affero General Public License v3.0 only.
+// A commercial licence is available from the maintainers as an alternative to the AGPL-3.0.
+// See LICENSES/AGPL-3.0-only.txt or https://www.gnu.org/licenses/agpl-3.0.html for details.
 '
+
+# Canonical AGPL module list, straight out of rules.yaml. Fail loudly rather than silently
+# falling back to "everything is Apache-2.0" -- that fallback is the original bug.
+if [[ ! -f "$RULES" ]]; then
+  echo "FATAL: cannot read $RULES -- refusing to guess licences." >&2
+  exit 1
+fi
+AGPL_MODULES="$(python3 -c '
+import sys, yaml
+with open(sys.argv[1], encoding="utf-8") as fh:
+    doc = yaml.safe_load(fh) or {}
+ex = (doc.get("dependencies") or {}).get("license_boundary_exceptions") or []
+mods = ex[0].get("agpl_modules") if ex else None
+if not mods:
+    sys.exit("FATAL: dependencies.license_boundary_exceptions[0].agpl_modules missing/empty")
+print("\n".join(mods))
+' "$RULES")"
+
+echo "AGPL-3.0-only modules (from rules.yaml): $(echo "$AGPL_MODULES" | wc -l | tr -d ' ')"
+
+# Is the file inside an AGPL module? Compare on the repo-relative first path segment.
+license_for() {
+  local rel="${1#"$ROOT"/}"
+  local module="${rel%%/*}"
+  if grep -qxF "$module" <<<"$AGPL_MODULES"; then
+    echo agpl
+  else
+    echo apache
+  fi
+}
 
 count_total=0
 count_modified=0
+count_agpl=0
 
 process_file() {
   local file="$1"
-  local header="$2"
   count_total=$((count_total + 1))
 
+  # A file that already declares a licence is left alone. Whether that declaration is the
+  # CORRECT one is check-license-headers.py's job, not this script's -- rewriting an existing
+  # header here would silently relicense code.
   if head -3 "$file" | grep -q "SPDX-License-Identifier"; then
     return
+  fi
+
+  local header kind
+  kind="$(license_for "$file")"
+  if [[ "$kind" == agpl ]]; then
+    header="$AGPL_HEADER"
+    count_agpl=$((count_agpl + 1))
+  else
+    header="$APACHE_HEADER"
   fi
 
   count_modified=$((count_modified + 1))
@@ -41,29 +99,30 @@ process_file() {
     tmp="$(mktemp)"
     { printf '%s\n' "$header"; cat "$file"; } > "$tmp"
     mv "$tmp" "$file"
-    echo "  modified: $file"
+    echo "  modified [$kind]: $file"
   else
-    echo "  would modify: $file"
+    echo "  would modify [$kind]: $file"
   fi
 }
 
 echo "== Kotlin sources =="
 while IFS= read -r -d '' f; do
-  process_file "$f" "$KT_HEADER"
+  process_file "$f"
 done < <(find "$ROOT" \
   -type d \( -name node_modules -o -name build -o -name .gradle -o -name .next -o -name attic -o -name .sisyphus \) -prune -o \
   -type f \( -name '*.kt' -o -name '*.kts' \) -print0 2>/dev/null)
 
 echo "== TypeScript / TSX sources =="
 while IFS= read -r -d '' f; do
-  process_file "$f" "$TS_HEADER"
+  process_file "$f"
 done < <(find "$ROOT" \
   -type d \( -name node_modules -o -name build -o -name .gradle -o -name .next -o -name attic -o -name .sisyphus -o -name dist \) -prune -o \
   -type f \( -name '*.ts' -o -name '*.tsx' \) -print0 2>/dev/null)
 
 echo
-echo "Files scanned:    $count_total"
-echo "Files to modify:  $count_modified"
+echo "Files scanned:       $count_total"
+echo "Files to modify:     $count_modified"
+echo "  of which AGPL:     $count_agpl"
 if [[ "$APPLY" != "--apply" ]]; then
   echo
   echo "Dry-run. Re-run with --apply to actually modify files."


### PR DESCRIPTION
## Summary

The repo is a deliberate **multi-license** tree: Apache-2.0 at the root (ADR-0123) with an
AGPL-3.0-only open-core subset (ADR-0136, extended by ADR-0181 for `mcp-service` and ADR-0193 for
`ap2-service`). **The AGPL headers are correct and intended — nothing here relicenses any code.**

What was wrong is that four descriptions of that split disagreed, and no gate compared them:

| Source | AGPL modules named |
|---|---|
| SPDX headers + per-module `LICENSE` (ground truth, mutually consistent) | **12** |
| `rules.yaml` `agpl_modules` / `license_denylist_exceptions.paths` | 10 |
| `NOTICE` | 4 |
| `README.md` "## License" | 4 |

`NOTICE` was the legally material one. It enumerated four modules and said they *"are NOT covered by
the Apache-2.0 LICENSE/NOTICE"* — telling any downstream adopter of a nominally Apache-2.0 monorepo
that the other **eight** AGPL modules *were* Apache-2.0. All twelve carry a `version.txt`, so all
twelve ship as released artifacts, and an SPDX scanner reads this as AGPL contamination of an
Apache-2.0 distribution.

**Root cause:** `scripts/add-license-headers.sh` hardcoded an Apache-2.0 header for every path — the
follow-up ADR-0136's own Consequences section asked for ("must be made path-aware") and which was
never done. Running `--apply` today stamped Apache-2.0 onto new AGPL-module files.

**The boundary itself was already sound:** no Apache-2.0 module build-depends on any of the twelve,
and they depend only on `openbank-libs-*` (Apache-2.0), which the AGPL permits. This was a labelling
defect, not contamination.

## Type of change

- [x] chore (build / tooling)
- [x] docs

## Linked issues

Refs #2280

## Changes

- **`rules.yaml`** — add `ap2-service` + `mcp-service` to both the denylist carve-out and the
  boundary rule. `agpl_modules` is now the **single canonical list**; the two other copies inside the
  file are marked derived from it, and the gate fails if they drift.
- **`NOTICE` / `README.md`** — stop enumerating, point at that list. A second hand-maintained copy is
  exactly how 4-vs-12 happened, so the fix is to remove the copy rather than correct it. Both now
  state plainly that the repository is not entirely Apache-2.0.
- **`{ap2,mcp}-service/governance.yaml`** — `Apache-2.0` → `AGPL-3.0-only`, matching their own
  sources and their own ADRs (these were the only 2 of the 12 with an Apache-2.0 manifest).
- **`REUSE.toml` (new)** — eight V1 Flyway migrations in AGPL modules carry a stale Apache-2.0 header
  that **cannot** be corrected in place: Flyway checksums the file including comments and these are
  already applied, so editing one makes the service fail at boot on a checksum mismatch. Declared
  out-of-tree with `precedence = "override"` instead.
- **`check-license-headers.py` (new, enforced in `Validate manifests`)** — compares every declaration
  against the canonical list: rules.yaml internal consistency, per-module `LICENSE` in both
  directions, per-file headers, the Apache→AGPL build-dependency boundary, and that the published
  docs never enumerate a subset.

### Nothing looked at SPDX headers before this

Worth stating explicitly, since the question was whether an existing gate was passing only because it
did not compare: **nothing compared at all.** No `reuse-tool`, `licensee`, `license-eye`, `scancode`
or `spdx-tools` anywhere in `.github/`; `public-readiness.yml` has no licence reference; and
`scorecard.yml`'s OpenSSF `License` check only asks whether a recognized licence file exists at the
repository root. This gate is not replacing a weaker one.

### Verification

`--selftest` feeds all six checks an input each MUST flag, and is wired as its own CI step, because a
gate that has only ever passed is unfalsified. Locally:

```
paths-vs-agpl_modules drift:        PASS (rejected)
rule-string omits a module:         PASS (rejected)
AGPL module with no LICENSE:        PASS (rejected)
header/module licence mismatch:     PASS (rejected)
Apache module build-depends on AGPL: PASS (rejected)
licensing doc enumerates a subset:  PASS (rejected)
selftest: ALL CHECKS CAN FAIL
```

Real run green. The path-aware stamper was confirmed against a **known-positive**: a headerless
`.kt` dropped into `mcp-service` gets AGPL, one in `ledger-service` gets Apache (probes removed
after). `actionlint` finding sets diffed branch-vs-`origin/main` — 2 pre-existing on both, none new.
Ten other `Validate manifests` gates run locally green (that job stops at the first failure, so a
green tail proves nothing on its own).

### Why 74 files

Editing `rules.yaml` restamps every service OPA bundle and its pod-roll annotation — 37 generators
hash it. All generators re-run clean (idempotent) and were verified **cwd-independent**, since CI
invokes each from its own directory and I first ran them from the repo root.

⚠️ Short shelf life. #2247 also regenerates 22 of these bundles; will merge with `--auto`.

## Definition of Done

- [x] Docs updated (README, NOTICE).
- [x] No Kotlin/API/DB/event changes — layering, unit/integration/contract tests, OpenAPI, Flyway and
      Avro items are all N/A. The one DB-adjacent item is the *refusal* to edit applied migrations.
- [x] No new lint warnings (`actionlint` finding-set diff; `bash -n`; YAML/TOML parse).
- [x] New gate exercised against inputs it must flag, not just a green run.

## Security checklist

- [x] No secrets, tokens, passwords, or PII.
- [x] No new `@Suppress`.
- [x] No new third-party dependency (`yaml` + stdlib `tomllib` only, both already used in
      `.github/scripts`).
- [x] No auth / crypto / payment code changed.
- [x] No PII or cardholder-data path changed.

## Note for the reviewer — the one judgement call left

The six auditor-type agents (`control-liveness-sentinel`, `governance-auditor`, `release-steward`,
`docs-truth-agent`, `authz-policy-auditor`, `flaky-test-hunter`) are AGPL by `rules.yaml` + their
headers + their own `LICENSE`, but **no ADR records that decision** — only the four ADR-0136 services
and the two later ADR-0181/0193 ones have one. This PR treats `rules.yaml` as authoritative and does
not invent a decision. If you want that written down, it wants its own ADR extending ADR-0136 to the
full set of twelve.

Deliberately a hidden commit type: no shipped code changes, so no release should be cut
(`rules.yaml: release_scope_mismatch`).
