### PR TITLE
feat(ap2): instrument mandate verdicts, signature stages and PDP decisions

### DIFF
--- a/openbank-ap2-service/src/main/kotlin/com/openbank/ap2/application/Ap2MandateVerifier.kt
+++ b/openbank-ap2-service/src/main/kotlin/com/openbank/ap2/application/Ap2MandateVerifier.kt
@@ -4,7 +4,9 @@
 // See LICENSES/AGPL-3.0-only.txt or https://www.gnu.org/licenses/agpl-3.0.html for details.
 package com.openbank.ap2.application
 
+import com.openbank.ap2.application.port.out.Ap2MetricsPort
 import com.openbank.ap2.application.port.out.MandateKeyResolver
+import com.openbank.ap2.application.port.out.MandateSignatureOutcome
 import com.openbank.ap2.application.port.out.SignatureVerifier
 import com.openbank.ap2.domain.Ap2Mandate
 import com.openbank.ap2.domain.ConstraintResult
@@ -14,6 +16,7 @@ import com.openbank.ap2.domain.PresentedPayment
 import com.openbank.ap2.domain.VerificationEvidence
 import jakarta.enterprise.context.ApplicationScoped
 import java.security.MessageDigest
+import java.time.Duration
 import java.util.HexFormat
 
 /**
@@ -24,36 +27,28 @@ import java.util.HexFormat
  * This class NEVER moves funds and never decides SCA exemption — it answers only "is this mandate
  * valid, and what does it authorize?" The verdict is evidence the SCA/payment path may later consult
  * (openbank-sca-service), gated by the HITL threshold, and only once a further ADR wires it in.
+ *
+ * Both stages report to [Ap2MetricsPort] separately, because they fail for opposite reasons: a
+ * signature-stage failure is usually **ours** (a rotated or mis-seeded trust list rejecting a
+ * legitimate issuer, which looks exactly like a forgery on the wire), while a constraint failure is
+ * **theirs** (a payment outside the delegated authority). The free-text `failures` list is for the
+ * caller and the evidence record; it is never a metric tag — it embeds the issuer, which is
+ * attacker-controlled.
  */
 @ApplicationScoped
 class Ap2MandateVerifier(
     private val signatureVerifier: SignatureVerifier,
     private val keyResolver: MandateKeyResolver,
+    private val metrics: Ap2MetricsPort,
 ) {
 
-    @Suppress("TooGenericExceptionCaught")
     fun verify(mandate: Ap2Mandate, payment: PresentedPayment): MandateVerdict {
+        val startedAt = System.nanoTime()
         val failures = mutableListOf<String>()
 
         // Stage 1: signature chain against a TRUSTED issuer key (fail closed on either miss).
-        val spki = keyResolver.resolve(mandate.issuer)
-        val signatureValid = when {
-            spki == null -> {
-                failures.add("issuer not trusted: ${mandate.issuer}")
-                false
-            }
-            else -> {
-                val ok = try {
-                    signatureVerifier.verify(mandate.algorithm, spki, mandate.signingInput, mandate.signatureB64)
-                } catch (ex: Exception) {
-                    // A malformed key/signature is a verification failure, never an exception out.
-                    failures.add("signature verification error: ${ex.message}")
-                    false
-                }
-                if (!ok && failures.isEmpty()) failures.add("signature invalid")
-                ok
-            }
-        }
+        val signature = verifySignature(mandate, failures)
+        val signatureValid = signature == MandateSignatureOutcome.VALID
 
         // Stage 2: pure constraint check (payee, amount cap, currency, expiry).
         val constraintsSatisfied = when (val cr = MandateConstraintChecks.check(mandate, payment)) {
@@ -73,7 +68,42 @@ class Ap2MandateVerifier(
             signatureValid = signatureValid,
             constraintsSatisfied = constraintsSatisfied,
         )
-        return MandateVerdict(valid = signatureValid && constraintsSatisfied, evidence = evidence, failures = failures)
+        val valid = signatureValid && constraintsSatisfied
+        metrics.mandateVerified(
+            kind = mandate.kind,
+            signature = signature,
+            constraintsSatisfied = constraintsSatisfied,
+            valid = valid,
+            duration = Duration.ofNanos(System.nanoTime() - startedAt),
+        )
+        return MandateVerdict(valid = valid, evidence = evidence, failures = failures)
+    }
+
+    /**
+     * Classify the signature stage into a bounded outcome and append the human-readable reason.
+     * `ISSUER_NOT_TRUSTED` is kept distinct from `INVALID` on purpose: the first is a trust-list
+     * defect on our side, the second is a genuinely bad signature, and the HTTP response cannot tell
+     * them apart.
+     */
+    @Suppress("TooGenericExceptionCaught") // any crypto/key malformation is a failed verdict, never a throw
+    private fun verifySignature(mandate: Ap2Mandate, failures: MutableList<String>): MandateSignatureOutcome {
+        val spki = keyResolver.resolve(mandate.issuer)
+        if (spki == null) {
+            failures.add("issuer not trusted: ${mandate.issuer}")
+            return MandateSignatureOutcome.ISSUER_NOT_TRUSTED
+        }
+        return try {
+            if (signatureVerifier.verify(mandate.algorithm, spki, mandate.signingInput, mandate.signatureB64)) {
+                MandateSignatureOutcome.VALID
+            } else {
+                failures.add("signature invalid")
+                MandateSignatureOutcome.INVALID
+            }
+        } catch (ex: Exception) {
+            // A malformed key/signature is a verification failure, never an exception out.
+            failures.add("signature verification error: ${ex.message}")
+            MandateSignatureOutcome.VERIFICATION_ERROR
+        }
     }
 
     /** Data minimisation (ADR-0193 GDPR row): store the mandate hash, not the credential. */

--- a/openbank-ap2-service/src/main/kotlin/com/openbank/ap2/application/port/out/Ap2MetricsPort.kt
+++ b/openbank-ap2-service/src/main/kotlin/com/openbank/ap2/application/port/out/Ap2MetricsPort.kt
@@ -1,0 +1,75 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+// Copyright (c) OpenBank contributors. Licensed under the GNU Affero General Public License v3.0 only.
+// A commercial licence is available from the maintainers as an alternative to the AGPL-3.0.
+// See LICENSES/AGPL-3.0-only.txt or https://www.gnu.org/licenses/agpl-3.0.html for details.
+package com.openbank.ap2.application.port.out
+
+import com.openbank.ap2.domain.MandateKind
+import java.time.Duration
+
+/**
+ * Outbound observability port (ADR-0002 / ADR-0077 Tier C) for AP2 mandate verification (ADR-0193).
+ *
+ * ap2-service answers "is this agent-presented mandate valid, and what does it authorize?" It moves
+ * no funds — so it has no downstream that notices when it starts answering wrongly, and every one of
+ * its failure modes is a well-formed `invalid` verdict:
+ *
+ *  - **`issuer_not_trusted` is the one that matters.** A rotated or mis-seeded trust list makes the
+ *    resolver return null for a legitimate issuer, and *every* mandate from that issuer then fails
+ *    closed. That is the correct behaviour and it is indistinguishable, from the response, from an
+ *    attacker presenting a forged issuer. Only the rate tells them apart.
+ *  - **`pdp_unavailable`.** The endpoint calls the shared PDP directly rather than through the
+ *    `@Authorize` interceptor, so it emits no `openbank_authz_decisions_total`. A PDP outage denies
+ *    every agent (correctly, fail-closed) and previously left nothing but a WARN line.
+ *
+ * Kept as a port rather than a direct `MeterRegistry` dependency so the application layer stays free
+ * of the metrics framework, and so the counters are exercised through the real adapter (over a
+ * `SimpleMeterRegistry`) in unit tests.
+ *
+ * Implemented by [com.openbank.ap2.infrastructure.observability.Ap2MetricsAdapter].
+ */
+interface Ap2MetricsPort {
+
+    /**
+     * Record one completed verification. Both stages are reported separately because they fail for
+     * completely different reasons: a signature stage failure is a key/trust problem (ours), a
+     * constraint failure is the presented payment being outside the mandate's authority (theirs).
+     */
+    fun mandateVerified(
+        kind: MandateKind,
+        signature: MandateSignatureOutcome,
+        constraintsSatisfied: Boolean,
+        valid: Boolean,
+        duration: Duration,
+    )
+
+    /** Record one authorization decision on the verify surface. */
+    fun authorizationDecision(outcome: Ap2AuthorizationOutcome)
+}
+
+/** How the signature stage resolved. A bounded set — safe as a tag. */
+enum class MandateSignatureOutcome {
+    /** Anchored to a trusted issuer key and the signature verified. */
+    VALID,
+
+    /** The issuer resolved to no trusted key. Sustained non-zero is a trust-list defect, not an attack. */
+    ISSUER_NOT_TRUSTED,
+
+    /** A trusted key was found and the signature did not verify against it. */
+    INVALID,
+
+    /** A malformed key or signature made verification throw. Treated as a failure, never propagated. */
+    VERIFICATION_ERROR,
+}
+
+/** Outcome of the PDP gate on `POST /ap2/verify`. A bounded set — safe as a tag. */
+enum class Ap2AuthorizationOutcome {
+    /** OPA allowed the agent to verify. */
+    ALLOWED,
+
+    /** OPA denied. */
+    DENIED,
+
+    /** The PDP could not be reached, so the call was denied fail-closed (503). */
+    PDP_UNAVAILABLE,
+}

--- a/openbank-ap2-service/src/main/kotlin/com/openbank/ap2/infrastructure/observability/Ap2MetricsAdapter.kt
+++ b/openbank-ap2-service/src/main/kotlin/com/openbank/ap2/infrastructure/observability/Ap2MetricsAdapter.kt
@@ -1,0 +1,117 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+// Copyright (c) OpenBank contributors. Licensed under the GNU Affero General Public License v3.0 only.
+// A commercial licence is available from the maintainers as an alternative to the AGPL-3.0.
+// See LICENSES/AGPL-3.0-only.txt or https://www.gnu.org/licenses/agpl-3.0.html for details.
+package com.openbank.ap2.infrastructure.observability
+
+import com.openbank.ap2.application.port.out.Ap2AuthorizationOutcome
+import com.openbank.ap2.application.port.out.Ap2MetricsPort
+import com.openbank.ap2.application.port.out.MandateSignatureOutcome
+import com.openbank.ap2.domain.MandateKind
+import io.micrometer.core.instrument.Counter
+import io.micrometer.core.instrument.MeterRegistry
+import io.micrometer.core.instrument.Timer
+import jakarta.enterprise.context.ApplicationScoped
+import jakarta.enterprise.inject.Instance
+import jakarta.inject.Inject
+import java.time.Duration
+
+/**
+ * Micrometer adapter for [Ap2MetricsPort] (ADR-0077 Tier C). Emits, all tagged `service="ap2"`:
+ *
+ *  - `openbank_ap2_mandate_verifications_total{kind,verdict}` — the headline rate. AP2 is an
+ *    AI-agent-facing payment-authorization surface, so the valid:invalid ratio is the first thing an
+ *    incident asks for.
+ *  - `openbank_ap2_mandate_signature_total{kind,outcome}` — the signature stage, split. A sustained
+ *    `issuer_not_trusted` is a rotated or mis-seeded trust list rejecting a legitimate issuer, which
+ *    on the wire is indistinguishable from a forged one; `verification_error` is a malformed
+ *    key/signature that the verifier deliberately swallows into a failed verdict.
+ *  - `openbank_ap2_mandate_constraints_total{kind,outcome}` — the pure constraint stage (payee, cap,
+ *    currency, expiry). `violated` is a presented payment outside the delegated authority: normal in
+ *    small numbers, an agent misbehaving in large ones.
+ *  - `openbank_ap2_mandate_verification_duration_seconds{kind}` — the crypto path's latency.
+ *  - `openbank_ap2_authorization_decisions_total{outcome}` — the PDP gate. The endpoint calls the
+ *    shared PDP directly rather than via the `@Authorize` interceptor, so no
+ *    `openbank_authz_decisions_total` is emitted for it and `pdp_unavailable` — which denies every
+ *    agent, fail-closed — previously produced only a WARN log line.
+ *
+ * No mandate hash, issuer, subject, agent id or amount is ever a tag: `kind` is a 3-value enum and
+ * every other tag is a closed enum (cardinality contract). The issuer in particular is attacker-
+ * controlled — tagging it would be an unbounded-series hole on an agent-facing surface.
+ *
+ * Service-local `MeterRegistry`, null-safe via [Instance] exactly like libs `DomainMetrics`: mandate
+ * verification counters are AP2-specific, so adding them to the shared libs facade would force a
+ * fleet-wide rebuild for a one-service concern.
+ */
+@ApplicationScoped
+class Ap2MetricsAdapter(private val registry: MeterRegistry?) : Ap2MetricsPort {
+
+    // CDI constructor: MeterRegistry is optional (absent when no Prometheus registry is on the
+    // classpath, e.g. slim test slices). Without an explicit @Inject ctor, ArC sees two constructors,
+    // registers no bean, and Ap2MandateVerifier is left with an unsatisfied dependency at build time.
+    @Inject
+    constructor(registryInstance: Instance<MeterRegistry>) : this(
+        if (registryInstance.isResolvable) registryInstance.get() else null,
+    )
+
+    override fun mandateVerified(
+        kind: MandateKind,
+        signature: MandateSignatureOutcome,
+        constraintsSatisfied: Boolean,
+        valid: Boolean,
+        duration: Duration,
+    ) {
+        val r = registry ?: return
+        val kindTag = kind.name
+        counter(r, "openbank.ap2.mandate.verifications", kindTag, "verdict", if (valid) "valid" else "invalid")
+            .increment()
+        counter(r, "openbank.ap2.mandate.signature", kindTag, "outcome", signature.name.lowercase()).increment()
+        counter(
+            r,
+            "openbank.ap2.mandate.constraints",
+            kindTag,
+            "outcome",
+            if (constraintsSatisfied) "satisfied" else "violated",
+        ).increment()
+        Timer.builder("openbank.ap2.mandate.verification.duration")
+            .tag("service", SERVICE)
+            .tag("kind", kindTag)
+            .publishPercentiles(P50, P95, P99)
+            .publishPercentileHistogram()
+            .description("Time to verify one AP2 mandate, both stages")
+            .register(r)
+            .record(duration)
+    }
+
+    override fun authorizationDecision(outcome: Ap2AuthorizationOutcome) {
+        registry?.let { r ->
+            Counter.builder("openbank.ap2.authorization.decisions")
+                .tag("service", SERVICE)
+                .tag("outcome", outcome.name.lowercase())
+                .description("PDP decisions on the AP2 verify surface")
+                .register(r)
+                .increment()
+        }
+    }
+
+    private fun counter(
+        registry: MeterRegistry,
+        name: String,
+        kind: String,
+        tagKey: String,
+        tagValue: String,
+    ): Counter = Counter.builder(name)
+        .tag("service", SERVICE)
+        .tag("kind", kind)
+        .tag(tagKey, tagValue)
+        .register(registry)
+
+    companion object {
+        private const val SERVICE = "ap2"
+
+        // The fleet-standard percentile set (libs DomainMetrics publishes the same three).
+        private const val P50 = 0.5
+        private const val P95 = 0.95
+        private const val P99 = 0.99
+    }
+}

--- a/openbank-ap2-service/src/main/kotlin/com/openbank/ap2/infrastructure/rest/Ap2VerifyEndpoint.kt
+++ b/openbank-ap2-service/src/main/kotlin/com/openbank/ap2/infrastructure/rest/Ap2VerifyEndpoint.kt
@@ -5,6 +5,8 @@
 package com.openbank.ap2.infrastructure.rest
 
 import com.openbank.ap2.application.Ap2MandateVerifier
+import com.openbank.ap2.application.port.out.Ap2AuthorizationOutcome
+import com.openbank.ap2.application.port.out.Ap2MetricsPort
 import com.openbank.ap2.domain.Ap2Mandate
 import com.openbank.ap2.domain.MandateVerdict
 import com.openbank.ap2.domain.PresentedPayment
@@ -30,11 +32,19 @@ import org.jboss.logging.Logger
  * `verify.mandate`), the same plane as openbank-mcp-service (ADR-0181). Deny-by-default via a single
  * capability; a PDP outage fails CLOSED. The acting agent id is the `X-Agent-Id` header, `agent:`-
  * prefixed so the shared rego classifies it AI_AGENT; the OAuth 2.1 binding is phase 2.
+ *
+ * Because the PDP is called **directly** rather than through the `@Authorize` interceptor, this
+ * surface emits no `openbank_authz_decisions_total` — so its own decisions are counted on
+ * [Ap2MetricsPort]. `pdp_unavailable` matters most: it denies every agent, correctly and silently.
  */
 @Path("/ap2/verify")
 @Consumes(MediaType.APPLICATION_JSON)
 @Produces(MediaType.APPLICATION_JSON)
-class Ap2VerifyEndpoint(private val verifier: Ap2MandateVerifier, private val pdp: PolicyDecisionPoint) {
+class Ap2VerifyEndpoint(
+    private val verifier: Ap2MandateVerifier,
+    private val pdp: PolicyDecisionPoint,
+    private val metrics: Ap2MetricsPort,
+) {
 
     private val log = Logger.getLogger(Ap2VerifyEndpoint::class.java)
 
@@ -57,14 +67,17 @@ class Ap2VerifyEndpoint(private val verifier: Ap2MandateVerifier, private val pd
         } catch (ex: Exception) {
             // Fail closed: a PDP outage denies (never fail-open on a payment-authorization surface).
             log.warnf("PDP error authorizing verify.mandate: %s — denying", ex.message)
+            metrics.authorizationDecision(Ap2AuthorizationOutcome.PDP_UNAVAILABLE)
             return Response.status(Response.Status.SERVICE_UNAVAILABLE)
                 .entity(mapOf("error" to "authorization unavailable")).build()
         }
         if (!decision.allow) {
+            metrics.authorizationDecision(Ap2AuthorizationOutcome.DENIED)
             return Response.status(Response.Status.FORBIDDEN)
                 .entity(mapOf("error" to "denied by policy", "reason" to (decision.reason ?: "no matching allow rule")))
                 .build()
         }
+        metrics.authorizationDecision(Ap2AuthorizationOutcome.ALLOWED)
 
         val verdict: MandateVerdict = verifier.verify(request.mandate, request.payment)
         return Response.ok(verdict).build()

--- a/openbank-ap2-service/src/test/kotlin/com/openbank/ap2/Ap2MandateVerifierTest.kt
+++ b/openbank-ap2-service/src/test/kotlin/com/openbank/ap2/Ap2MandateVerifierTest.kt
@@ -10,6 +10,8 @@ import com.openbank.ap2.domain.MandateKind
 import com.openbank.ap2.domain.MandateSignatureAlgorithm
 import com.openbank.ap2.domain.PresentedPayment
 import com.openbank.ap2.infrastructure.crypto.JcaSignatureVerifier
+import com.openbank.ap2.infrastructure.observability.Ap2MetricsAdapter
+import io.micrometer.core.instrument.simple.SimpleMeterRegistry
 import org.assertj.core.api.Assertions.assertThat
 import org.junit.jupiter.api.Test
 import java.security.KeyPairGenerator
@@ -42,7 +44,12 @@ class Ap2MandateVerifierTest {
         override fun resolve(issuer: String): String? = map[issuer]
     }
 
-    private fun verifier(trust: Map<String, String>) = Ap2MandateVerifier(JcaSignatureVerifier(), resolver(trust))
+    // The REAL metrics adapter over a SimpleMeterRegistry rather than a mock port, so the
+    // instrumentation assertions below fail if the verifier stops emitting.
+    private val registry = SimpleMeterRegistry()
+
+    private fun verifier(trust: Map<String, String>) =
+        Ap2MandateVerifier(JcaSignatureVerifier(), resolver(trust), Ap2MetricsAdapter(registry))
 
     private fun mandate(sig: String, cap: Long = 100_00) = Ap2Mandate(
         kind = MandateKind.PAYMENT,
@@ -98,4 +105,65 @@ class Ap2MandateVerifierTest {
         assertThat(v.valid).isFalse()
         assertThat(v.evidence.signatureValid).isFalse()
     }
+
+    @Test
+    fun `a valid mandate is counted by kind, verdict and both stage outcomes, and timed`() {
+        verifier(mapOf("issuer-1" to spkiB64)).verify(mandate(sign(signingInput)), goodPayment)
+
+        assertThat(counter("openbank.ap2.mandate.verifications", "verdict", "valid")).isEqualTo(1.0)
+        assertThat(counter("openbank.ap2.mandate.signature", "outcome", "valid")).isEqualTo(1.0)
+        assertThat(counter("openbank.ap2.mandate.constraints", "outcome", "satisfied")).isEqualTo(1.0)
+        assertThat(
+            registry.get("openbank.ap2.mandate.verification.duration")
+                .tag("service", "ap2").tag("kind", "PAYMENT").timer().count(),
+        ).isEqualTo(1L)
+    }
+
+    @Test
+    fun `an untrusted issuer is counted as issuer_not_trusted, NOT as an invalid signature`() {
+        // The distinction is the whole point: a rotated or mis-seeded trust list rejects a legitimate
+        // issuer and looks identical, on the wire, to a forged one. Collapsing them would make a
+        // configuration defect indistinguishable from an attack.
+        verifier(emptyMap()).verify(mandate(sign(signingInput)), goodPayment)
+
+        assertThat(counter("openbank.ap2.mandate.signature", "outcome", "issuer_not_trusted")).isEqualTo(1.0)
+        assertThat(
+            registry.find("openbank.ap2.mandate.signature").tag("outcome", "invalid").counters(),
+        ).isEmpty()
+        assertThat(counter("openbank.ap2.mandate.verifications", "verdict", "invalid")).isEqualTo(1.0)
+    }
+
+    @Test
+    fun `a tampered signature is counted as invalid and a malformed one as verification_error`() {
+        verifier(mapOf("issuer-1" to spkiB64)).verify(mandate(sign("a-different-payload")), goodPayment)
+        verifier(mapOf("issuer-1" to spkiB64)).verify(mandate("!!!not-base64-sig!!!"), goodPayment)
+
+        assertThat(counter("openbank.ap2.mandate.signature", "outcome", "invalid")).isEqualTo(1.0)
+        assertThat(counter("openbank.ap2.mandate.signature", "outcome", "verification_error")).isEqualTo(1.0)
+    }
+
+    @Test
+    fun `an out-of-constraint payment is counted as a violated CONSTRAINT with a valid signature`() {
+        val overCap = PresentedPayment(payee, 200_00, "CZK", Instant.parse("2026-06-01T00:00:00Z"))
+
+        verifier(mapOf("issuer-1" to spkiB64)).verify(mandate(sign(signingInput), cap = 100_00), overCap)
+
+        assertThat(counter("openbank.ap2.mandate.signature", "outcome", "valid")).isEqualTo(1.0)
+        assertThat(counter("openbank.ap2.mandate.constraints", "outcome", "violated")).isEqualTo(1.0)
+        assertThat(counter("openbank.ap2.mandate.verifications", "verdict", "invalid")).isEqualTo(1.0)
+    }
+
+    @Test
+    fun `no meter carries the attacker-controlled issuer or the mandate hash as a tag`() {
+        // Cardinality + evidence contract: the issuer arrives in the request body on an agent-facing
+        // surface, so tagging it would be an unbounded-series hole.
+        verifier(mapOf("issuer-1" to spkiB64)).verify(mandate(sign(signingInput)), goodPayment)
+
+        val tags = registry.meters.flatMap { it.id.tags }
+        assertThat(tags.map { it.key }).doesNotContain("issuer", "subject", "mandate_hash", "payee")
+        assertThat(tags.map { it.value }).doesNotContain("issuer-1", "cust-1", payee)
+    }
+
+    private fun counter(name: String, tagKey: String, tagValue: String): Double =
+        registry.get(name).tag("service", "ap2").tag("kind", "PAYMENT").tag(tagKey, tagValue).counter().count()
 }

--- a/openbank-ap2-service/src/test/kotlin/com/openbank/ap2/Ap2MetricsAdapterTest.kt
+++ b/openbank-ap2-service/src/test/kotlin/com/openbank/ap2/Ap2MetricsAdapterTest.kt
@@ -1,0 +1,93 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+// Copyright (c) OpenBank contributors. Licensed under the GNU Affero General Public License v3.0 only.
+package com.openbank.ap2
+
+import com.openbank.ap2.application.port.out.Ap2AuthorizationOutcome
+import com.openbank.ap2.application.port.out.MandateSignatureOutcome
+import com.openbank.ap2.domain.MandateKind
+import com.openbank.ap2.infrastructure.observability.Ap2MetricsAdapter
+import io.micrometer.core.instrument.simple.SimpleMeterRegistry
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.Test
+import java.time.Duration
+
+class Ap2MetricsAdapterTest {
+
+    private val registry = SimpleMeterRegistry()
+    private val adapter = Ap2MetricsAdapter(registry)
+
+    @Test
+    fun `the mandate kind is a tag, so INTENT and PAYMENT are separable`() {
+        adapter.mandateVerified(
+            MandateKind.INTENT,
+            MandateSignatureOutcome.VALID,
+            constraintsSatisfied = true,
+            valid = true,
+            duration = Duration.ofMillis(3),
+        )
+        adapter.mandateVerified(
+            MandateKind.PAYMENT,
+            MandateSignatureOutcome.VALID,
+            constraintsSatisfied = true,
+            valid = true,
+            duration = Duration.ofMillis(3),
+        )
+
+        assertThat(verdicts(MandateKind.INTENT, "valid")).isEqualTo(1.0)
+        assertThat(verdicts(MandateKind.PAYMENT, "valid")).isEqualTo(1.0)
+    }
+
+    @Test
+    fun `every signature outcome gets a distinct lower-cased tag value`() {
+        MandateSignatureOutcome.entries.forEach {
+            adapter.mandateVerified(
+                MandateKind.PAYMENT,
+                it,
+                constraintsSatisfied = false,
+                valid = false,
+                duration = Duration.ZERO,
+            )
+        }
+
+        MandateSignatureOutcome.entries.forEach { outcome ->
+            assertThat(
+                registry.get("openbank.ap2.mandate.signature")
+                    .tag("kind", "PAYMENT").tag("outcome", outcome.name.lowercase()).counter().count(),
+            ).isEqualTo(1.0)
+        }
+    }
+
+    @Test
+    fun `every authorization outcome gets a distinct lower-cased tag value`() {
+        Ap2AuthorizationOutcome.entries.forEach { adapter.authorizationDecision(it) }
+
+        Ap2AuthorizationOutcome.entries.forEach { outcome ->
+            assertThat(
+                registry.get("openbank.ap2.authorization.decisions")
+                    .tag("service", "ap2").tag("outcome", outcome.name.lowercase()).counter().count(),
+            ).isEqualTo(1.0)
+        }
+    }
+
+    @Test
+    fun `is a silent no-op when no meter registry is resolvable`() {
+        // Slim slices without a Prometheus registry must not crash a verification.
+        val noRegistry = Ap2MetricsAdapter(null)
+
+        noRegistry.mandateVerified(
+            MandateKind.CART,
+            MandateSignatureOutcome.VALID,
+            constraintsSatisfied = true,
+            valid = true,
+            duration = Duration.ZERO,
+        )
+        noRegistry.authorizationDecision(Ap2AuthorizationOutcome.ALLOWED)
+    }
+
+    private fun verdicts(kind: MandateKind, verdict: String): Double =
+        registry.get("openbank.ap2.mandate.verifications")
+            .tag("service", "ap2")
+            .tag("kind", kind.name)
+            .tag("verdict", verdict)
+            .counter().count()
+}

--- a/openbank-ap2-service/src/test/kotlin/com/openbank/ap2/Ap2VerifyEndpointTest.kt
+++ b/openbank-ap2-service/src/test/kotlin/com/openbank/ap2/Ap2VerifyEndpointTest.kt
@@ -11,11 +11,13 @@ import com.openbank.ap2.domain.MandateSignatureAlgorithm
 import com.openbank.ap2.domain.MandateVerdict
 import com.openbank.ap2.domain.PresentedPayment
 import com.openbank.ap2.infrastructure.crypto.JcaSignatureVerifier
+import com.openbank.ap2.infrastructure.observability.Ap2MetricsAdapter
 import com.openbank.ap2.infrastructure.rest.Ap2VerifyEndpoint
 import com.openbank.ap2.infrastructure.rest.VerifyRequest
 import com.openbank.libs.authz.AuthzDecision
 import com.openbank.libs.authz.AuthzQuery
 import com.openbank.libs.authz.PolicyDecisionPoint
+import io.micrometer.core.instrument.simple.SimpleMeterRegistry
 import org.assertj.core.api.Assertions.assertThat
 import org.junit.jupiter.api.Test
 import java.time.Instant
@@ -23,11 +25,16 @@ import java.time.Instant
 /** The OPA AI_AGENT gate on the verify surface (ADR-0193 §5): allow → 200, deny → 403, PDP outage → 503. */
 class Ap2VerifyEndpointTest {
 
+    // The REAL metrics adapter over a SimpleMeterRegistry rather than a mock port, so the
+    // authorization-decision assertions below fail if the endpoint stops emitting.
+    private val registry = SimpleMeterRegistry()
+
     private val verifier = Ap2MandateVerifier(
         JcaSignatureVerifier(),
         object : MandateKeyResolver {
             override fun resolve(issuer: String): String? = null
         },
+        Ap2MetricsAdapter(registry),
     )
 
     private val request = VerifyRequest(
@@ -43,7 +50,7 @@ class Ap2VerifyEndpointTest {
         payment = PresentedPayment("CZ65", 50_00, "CZK", Instant.parse("2026-06-01T00:00:00Z")),
     )
 
-    private fun endpoint(pdp: PolicyDecisionPoint) = Ap2VerifyEndpoint(verifier, pdp)
+    private fun endpoint(pdp: PolicyDecisionPoint) = Ap2VerifyEndpoint(verifier, pdp, Ap2MetricsAdapter(registry))
 
     @Test
     fun `allow returns 200 with a verdict`() {
@@ -75,4 +82,31 @@ class Ap2VerifyEndpointTest {
     private fun exploding() = object : PolicyDecisionPoint {
         override suspend fun allow(query: AuthzQuery): AuthzDecision = error("PDP down")
     }
+
+    @Test
+    fun `each PDP outcome is counted, including the fail-closed outage`() {
+        // The endpoint calls the PDP directly rather than through the @Authorize interceptor, so it
+        // emits no openbank_authz_decisions_total. A PDP outage denies EVERY agent and previously
+        // left nothing behind but a WARN line.
+        endpoint(allow()).verify(request, "agent:test")
+        endpoint(deny()).verify(request, "agent:test")
+        endpoint(exploding()).verify(request, "agent:test")
+
+        assertThat(decisions("allowed")).isEqualTo(1.0)
+        assertThat(decisions("denied")).isEqualTo(1.0)
+        assertThat(decisions("pdp_unavailable")).isEqualTo(1.0)
+    }
+
+    @Test
+    fun `a denied call verifies no mandate, so it publishes no verification counter`() {
+        endpoint(deny()).verify(request, "agent:test")
+
+        assertThat(decisions("denied")).isEqualTo(1.0)
+        assertThat(registry.find("openbank.ap2.mandate.verifications").counters()).isEmpty()
+    }
+
+    private fun decisions(outcome: String): Double = registry.get("openbank.ap2.authorization.decisions")
+        .tag("service", "ap2")
+        .tag("outcome", outcome)
+        .counter().count()
 }


### PR DESCRIPTION
## Summary

`openbank-ap2-service` emitted only default JVM/HTTP metrics — zero domain instrumentation
(prod-readiness C8, #2255). It moves no funds, so nothing downstream notices when it starts
answering wrongly, and every failure mode is a well-formed `invalid` verdict. Adds an
`Ap2MetricsPort` and a Micrometer adapter, following the service-local pattern already used by
fraud-service and agent-service.

## Type of change

- [x] feat (new functionality)

## Linked issues

Refs #2255

## Changes

**Meters added, and why these:**

| Meter | Why an operator needs it |
|---|---|
| `openbank_ap2_mandate_verifications_total{kind,verdict}` | AP2 is an **AI-agent-facing payment-authorization surface**; the valid:invalid ratio per mandate kind (INTENT/CART/PAYMENT) is the first thing an incident asks for. |
| `openbank_ap2_mandate_signature_total{kind,outcome}` | **The one that matters.** `issuer_not_trusted` means a rotated or mis-seeded trust list is rejecting a *legitimate* issuer — every mandate from it fails closed, which is correct behaviour and on the wire is **indistinguishable from an attacker presenting a forgery**. Only the rate tells them apart. `verification_error` is a malformed key/signature that the verifier deliberately swallows into a failed verdict. |
| `openbank_ap2_mandate_constraints_total{kind,outcome}` | The pure constraint stage (payee, cap, currency, expiry). `violated` is a presented payment outside the delegated authority: normal in small numbers, an agent misbehaving in large ones. |
| `openbank_ap2_mandate_verification_duration_seconds{kind}` | The crypto path's latency. |
| `openbank_ap2_authorization_decisions_total{outcome}` | The endpoint calls the shared PDP **directly**, not through the `@Authorize` interceptor, so this surface emits no `openbank_authz_decisions_total` at all. `pdp_unavailable` denies **every** agent, fail-closed, and previously produced only a WARN log line. |

**Code:**

- new `application/port/out/Ap2MetricsPort.kt` (+ `MandateSignatureOutcome`, `Ap2AuthorizationOutcome`)
- new `infrastructure/observability/Ap2MetricsAdapter.kt` — service-local `MeterRegistry`, null-safe via
  `Instance<MeterRegistry>` like libs `DomainMetrics`, with the explicit `@Inject` constructor ArC needs
- `Ap2MandateVerifier`: the signature branch extracted into `verifySignature`, classifying into a bounded
  `MandateSignatureOutcome` instead of only a boolean. **Behaviour is unchanged** — same verdict, same
  free-text `failures` strings, same fail-closed semantics; every pre-existing test still passes untouched.
- `Ap2VerifyEndpoint` counts all three PDP outcomes

### Why the two stages are counted separately

They fail for opposite reasons. A signature-stage failure is usually **ours** (a trust-list defect);
a constraint failure is **theirs** (a payment outside the mandate's authority). One aggregate
"invalid" counter would make a configuration outage look like an attack, and vice versa.

## Definition of Done

- [x] Hexagonal layering preserved (domain untouched and still crypto-free; port in `application/port/out`, Micrometer only in `infrastructure/observability`).
- [x] Unit tests added/updated.
- [x] Integration tests added/updated (if service boundary involved). — `quarkusBuild` validates the ArC wiring of the new bean.
- [x] Contract tests updated (if public API changed). — n/a, no API change (ap2's missing contract test is a separate C3 item in #2255).
- [x] `detekt ktlintCheck koverVerify build` passes (module-scoped, see below).
- [x] No new lint warnings.
- [x] OpenAPI spec regenerated (if REST API changed). — n/a
- [x] Flyway migration added + rollback note (if DB changed). — n/a, ap2 is stateless
- [x] Avro schema versioned backward-compatibly (if event changed). — n/a
- [x] Docs updated — KDoc on the port/adapter states what each meter is for and why.

### The tests were falsified, not just run

The tests drive the **real** adapter over a `SimpleMeterRegistry` rather than a mock port. Verified
by disabling `metrics.mandateVerified(...)` in the verifier and deleting the `PDP_UNAVAILABLE` call
from the endpoint:

```
Ap2MandateVerifierTest > a tampered signature is counted as invalid and a malformed one as verification_error() FAILED
    io.micrometer.core.instrument.search.MeterNotFoundException
Ap2MandateVerifierTest > an out-of-constraint payment is counted as a violated CONSTRAINT with a valid signature() FAILED
Ap2MandateVerifierTest > an untrusted issuer is counted as issuer_not_trusted, NOT as an invalid signature() FAILED
Ap2MandateVerifierTest > a valid mandate is counted by kind, verdict and both stage outcomes, and timed() FAILED
Ap2VerifyEndpointTest > each PDP outcome is counted, including the fail-closed outage() FAILED
    io.micrometer.core.instrument.search.MeterNotFoundException
```

Restored → `BUILD SUCCESSFUL`; full module run: **25 tests, 0 failures, 0 errors, 0 skipped**
(`:openbank-ap2-service:build :quarkusBuild :detekt :ktlintCheck :koverVerify`).

## Security checklist

- [x] No secrets, tokens, passwords, or PII in code, config, tests, logs. — **the issuer is attacker-controlled** (it arrives in the request body on an agent-facing surface), so it is never a tag; nor is the subject, mandate hash, payee, agent id or amount. There is a dedicated test asserting no meter carries any of them as a tag key or value.
- [x] No new `@Suppress` without justification. — `TooGenericExceptionCaught` moved with the crypto block it guards into `verifySignature`, with the reason inline; the endpoint's existing suppressions are unchanged.
- [x] No new third-party dependency. — `quarkus-micrometer-registry-prometheus` was already on the classpath.
- [x] Auth / crypto / payment code changed? → **yes, structurally**: the signature-verification branch was refactored. Semantics are identical (same verdict, same failure strings, same fail-closed on untrusted issuer / bad signature / malformed input) and the five pre-existing `Ap2MandateVerifierTest` cases — which use real Ed25519 crypto — pass unmodified. Tagging `security-review-required`.
- [x] PII path changed? — no
- [x] Cardholder data path changed? — no

## Compliance impact

- [x] PSD2 / SCA / RTS — AP2 mandate verdicts are authorization evidence the SCA path may later consult (ADR-0193); the signature-stage split is what makes a trust-anchor failure distinguishable from a rejected forgery.
