### PR TITLE
test(card-issuance): pact the product-catalog card-entitlement lookup

### DIFF
--- a/.github/workflows/pact-drift-check.yml
+++ b/.github/workflows/pact-drift-check.yml
@@ -57,6 +57,7 @@ jobs:
             :openbank-account-service:test --tests "com.openbank.account.contract.*PactConsumerTest" \
             :openbank-balance-service:test --tests "com.openbank.balance.contract.*PactConsumerTest" \
             :openbank-billing-service:test --tests "com.openbank.billing.contract.*PactConsumerTest" \
+            :openbank-card-issuance-service:test --tests "com.openbank.cardissuance.contract.*PactConsumerTest" \
             :openbank-consent-service:test --tests "com.openbank.consent.contract.*PactConsumerTest" \
             :openbank-domestic-payment:test --tests "com.openbank.domestic.contract.*PactConsumerTest" \
             :openbank-fraud-service:test --tests "com.openbank.fraud.contract.*PactConsumerTest" \

--- a/openbank-card-issuance-service/build.gradle.kts
+++ b/openbank-card-issuance-service/build.gradle.kts
@@ -42,12 +42,23 @@ dependencies {
     testImplementation(libs.assertj)
     testImplementation(libs.mockk)
     testImplementation(libs.smallrye.reactive.messaging.inmemory)
+    // Consumer-driven contract test for the product-catalog card-entitlement lookup (ADR-0063).
+    // Consumer side only: card issuance publishes no API that another service pacts against, so
+    // there is no pact-provider dependency here.
+    testImplementation(libs.pact.consumer)
 
     // CI infra sweep (#578): isolated PostgreSQL + Valkey(Redis) per test JVM
     // via Testcontainers. Kafka is already in-memory in the IT (no broker).
     testImplementation(libs.testcontainers)
     testImplementation(libs.testcontainers.junit)
     testImplementation(libs.testcontainers.postgresql)
+}
+
+// Pact: write generated pact files to the shared pacts/ dir at the repo root (git-pact, ADR-0063).
+// The consumer test regenerates the file on every run; developers commit the result.
+// NOTE: must be set on the test JVM fork, not the Gradle daemon (System.setProperty would not propagate).
+tasks.withType<Test> {
+    systemProperty("pact.rootDir", "${rootProject.projectDir}/pacts")
 }
 
 kover {

--- a/openbank-card-issuance-service/src/test/kotlin/com/openbank/cardissuance/contract/ProductCatalogPactConsumerTest.kt
+++ b/openbank-card-issuance-service/src/test/kotlin/com/openbank/cardissuance/contract/ProductCatalogPactConsumerTest.kt
@@ -1,0 +1,184 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright (c) OpenBank contributors. Licensed under the Apache License, Version 2.0.
+// See LICENSE in the repository root or https://www.apache.org/licenses/LICENSE-2.0 for details.
+
+package com.openbank.cardissuance.contract
+
+import au.com.dius.pact.consumer.MockServer
+import au.com.dius.pact.consumer.dsl.LambdaDsl.newJsonBody
+import au.com.dius.pact.consumer.dsl.PactDslJsonRootValue
+import au.com.dius.pact.consumer.dsl.PactDslWithProvider
+import au.com.dius.pact.consumer.junit5.PactConsumerTestExt
+import au.com.dius.pact.consumer.junit5.PactTestFor
+import au.com.dius.pact.core.model.PactSpecVersion
+import au.com.dius.pact.core.model.RequestResponsePact
+import au.com.dius.pact.core.model.annotations.Pact
+import com.fasterxml.jackson.databind.ObjectMapper
+import com.fasterxml.jackson.module.kotlin.registerKotlinModule
+import com.openbank.cardissuance.infrastructure.client.ProductCardConfigResponse
+import com.openbank.cardissuance.infrastructure.client.ProductCatalogClient
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.extension.ExtendWith
+import java.net.URI
+import java.net.http.HttpClient
+import java.net.http.HttpRequest
+import java.net.http.HttpResponse
+import jakarta.ws.rs.Path as JaxrsPath
+
+/**
+ * Consumer-driven contract for the ONE call card issuance makes into `openbank-product-catalog`:
+ * the card-entitlement lookup behind
+ * [com.openbank.cardissuance.infrastructure.client.ProductCatalogAdapter]. The generated pact is
+ * committed to `pacts/` (git-pact pattern, ADR-0063) and replayed by
+ * `ProductCatalogPactProviderVerificationTest` (`@PactFolder("../pacts")`) in
+ * openbank-product-catalog — no Pact Broker involved.
+ *
+ * The two interactions are exactly the two wire outcomes the adapter branches on:
+ *  - 200 with a populated `cardConfig` — the only path that yields `CardConfigLookup.Found`, so
+ *    every field the adapter reads is pinned here;
+ *  - 404 for an unknown product code — the adapter's fail-open path
+ *    (`CardConfigLookup.Unavailable`). Pinning it makes the fail-open deliberate rather than
+ *    accidental: if product-catalog ever answered 200-with-empty-body for a missing code, the
+ *    adapter would take a different branch.
+ *
+ * WHY THE REQUEST PATH IS READ OFF THE CLIENT INTERFACE, not typed as a literal: a contract test
+ * that hard-codes the path it expects passes even when the production client calls a path that does
+ * not exist — that is how finrep shipped a call to a non-existent ledger path (#2269). Here the path
+ * is reflected off [ProductCatalogClient.getByCode]'s own `@Path`, and the response is deserialized
+ * into the client's own [ProductCardConfigResponse]/`CardConfigResponse` DTOs with the Kotlin
+ * Jackson module (so a renamed non-defaulted field throws rather than silently reading null). Rename
+ * the path or a DTO field in the client and this test goes red.
+ *
+ * IMPORTANT — regenerate on change: if the `@Pact` methods change (new interaction, different
+ * matcher, renamed field), re-run
+ * `./gradlew :openbank-card-issuance-service:test --tests "*ProductCatalogPactConsumerTest*"` and
+ * commit the updated `pacts/openbank-card-issuance-service-openbank-product-catalog.json` in the
+ * same PR. `pact-drift-check.yml` enforces this.
+ *
+ * No `Authorization` header is pinned. Production sends an `openbank-services` M2M bearer via
+ * `OidcClientRequestReactiveFilter`, but the provider replays with OIDC disabled under `%test` and
+ * `@TestSecurity` supplying the identity — the same convention as the ledger and party pacts. The
+ * "reads require a token" half of the contract is covered by `ProductCatalogSecurityTest`.
+ *
+ * Type matchers throughout, not value matchers: the provider replays against a fresh Testcontainer
+ * DB seeded from `ProductSeed`, whose `id` is a derived UUID rather than the `prod-NNN` example, and
+ * whose fee/limit values are free to change without breaking a consumer that only reads their shape.
+ */
+@ExtendWith(PactConsumerTestExt::class)
+@PactTestFor(providerName = "openbank-product-catalog", pactVersion = PactSpecVersion.V3)
+class ProductCatalogPactConsumerTest {
+
+    private val mapper: ObjectMapper = ObjectMapper().registerKotlinModule()
+
+    @Pact(consumer = "openbank-card-issuance-service", provider = "openbank-product-catalog")
+    fun cardEnabledProductPact(builder: PactDslWithProvider): RequestResponsePact = builder
+        .given("a product with card configuration exists for code $CARD_ENABLED_CODE")
+        .uponReceiving("GET product by code for a card-enabled product")
+        .path(pathFor(CARD_ENABLED_CODE))
+        .method("GET")
+        .headers(mapOf("Accept" to "application/json"))
+        .willRespondWith()
+        .status(200)
+        .headers(mapOf("Content-Type" to "application/json"))
+        .body(
+            newJsonBody { o ->
+                // The seeder rewrites `id` to the canonical derived UUID (ADR-0105), so only the
+                // type is contractual; the consumer never parses it as a UUID.
+                o.stringType("id", "prod-003")
+                o.stringType("code", CARD_ENABLED_CODE)
+                o.`object`("cardConfig") { c ->
+                    c.booleanType("enabled", true)
+                    c.integerType("maxCards", 3)
+                    // Provider owns a wider CardNetwork/CardTier vocabulary than this service issues
+                    // on, so only "a non-empty array of strings" is contractual — the adapter drops
+                    // networks it cannot issue.
+                    c.minArrayLike("networks", 1, PactDslJsonRootValue.stringType("VISA"), 1)
+                    c.minArrayLike("tiers", 1, PactDslJsonRootValue.stringType("STANDARD"), 1)
+                    c.booleanType("virtualCardAllowed", true)
+                    c.booleanType("contactlessEnabled", true)
+                    c.decimalType("monthlyFeePerCard", 0.0)
+                }
+            }.build(),
+        )
+        .toPact()
+
+    @Pact(consumer = "openbank-card-issuance-service", provider = "openbank-product-catalog")
+    fun unknownProductCodePact(builder: PactDslWithProvider): RequestResponsePact = builder
+        .given("no product exists with code $MISSING_CODE")
+        .uponReceiving("GET product by an unknown code")
+        .path(pathFor(MISSING_CODE))
+        .method("GET")
+        .headers(mapOf("Accept" to "application/json"))
+        .willRespondWith()
+        .status(404)
+        .headers(mapOf("Content-Type" to "application/json"))
+        .body(
+            newJsonBody { o ->
+                o.stringType("error", "Product with code '$MISSING_CODE' not found")
+            }.build(),
+        )
+        .toPact()
+
+    @Test
+    @PactTestFor(pactMethod = "cardEnabledProductPact")
+    fun `the client DTOs parse a card-enabled product into a complete card config`(mockServer: MockServer) {
+        val (status, body) = get(mockServer, pathFor(CARD_ENABLED_CODE))
+
+        assertThat(status).isEqualTo(200)
+        val product = mapper.readValue(body, ProductCardConfigResponse::class.java)
+        assertThat(product.id).isNotBlank()
+        assertThat(product.code).isEqualTo(CARD_ENABLED_CODE)
+
+        // requireNotNull, not a soft assertion: a null cardConfig here means the field the adapter
+        // reads is gone from the wire or from the DTO, which is precisely the drift this test exists
+        // to catch (the adapter would silently degrade to CardConfigLookup.Unavailable in prod).
+        val config = requireNotNull(product.cardConfig) { "cardConfig missing from the parsed product" }
+        assertThat(config.enabled).isTrue()
+        assertThat(config.maxCards).isPositive()
+        assertThat(config.networks).isNotEmpty()
+        assertThat(config.tiers).isNotEmpty()
+        assertThat(config.virtualCardAllowed).isTrue()
+        assertThat(config.contactlessEnabled).isTrue()
+        assertThat(config.monthlyFeePerCard).isGreaterThanOrEqualTo(0.0)
+    }
+
+    @Test
+    @PactTestFor(pactMethod = "unknownProductCodePact")
+    fun `an unknown product code answers 404 with a JSON error body`(mockServer: MockServer) {
+        val (status, body) = get(mockServer, pathFor(MISSING_CODE))
+
+        assertThat(status).isEqualTo(404)
+        // The adapter turns this into CardConfigLookup.Unavailable via WebApplicationException; it
+        // never reads the body, so only "JSON with an error message" is contractual.
+        assertThat(mapper.readTree(body).path("error").asText()).isNotBlank()
+    }
+
+    private fun get(mockServer: MockServer, path: String): Pair<Int, String> {
+        val request = HttpRequest.newBuilder(URI.create(mockServer.getUrl() + path))
+            .header("Accept", "application/json")
+            .GET()
+            .build()
+        val response = HttpClient.newHttpClient().send(request, HttpResponse.BodyHandlers.ofString())
+        return response.statusCode() to response.body()
+    }
+
+    private companion object {
+        /** A seeded product whose `cardConfig.enabled` is true (`ProductSeed`, prod-003). */
+        const val CARD_ENABLED_CODE = "CURRENT_PERSONAL"
+
+        /** Deliberately absent from `ProductSeed`, so the provider answers 404 with no seeding. */
+        const val MISSING_CODE = "NO_SUCH_CARD_PRODUCT"
+
+        /**
+         * The `@Path` template the production client actually calls, read off the interface so a
+         * path change in [ProductCatalogClient] cannot pass this test silently.
+         */
+        private val PATH_TEMPLATE: String = ProductCatalogClient::class.java
+            .getMethod("getByCode", String::class.java)
+            .getAnnotation(JaxrsPath::class.java)
+            .value
+
+        private fun pathFor(code: String): String = PATH_TEMPLATE.replace("{code}", code)
+    }
+}

--- a/openbank-product-catalog/build.gradle.kts
+++ b/openbank-product-catalog/build.gradle.kts
@@ -48,6 +48,17 @@ dependencies {
     // Shared Testcontainers resource kit (issue #467) — pilot migration off the local
     // PostgresTestResource.kt copy.
     testImplementation(project(":openbank-libs-testing"))
+
+    // Provider-side Pact verification of the consumer pacts in the repo-root pacts/ dir
+    // (git-pact, ADR-0063 — no broker). Provider side only: product-catalog calls no other
+    // service's API, so there is no pact-consumer dependency here.
+    testImplementation(libs.pact.provider)
+}
+
+// Pact: provider verification reads pact files from the shared pacts/ dir (git-pact, ADR-0063).
+// Set on the test JVM fork, not the Gradle daemon — System.setProperty would not propagate.
+tasks.withType<Test> {
+    systemProperty("pact.rootDir", "${rootProject.projectDir}/pacts")
 }
 
 // Coverage floor (ADR-0020, ratchet-only — sweep #466: this module previously had NO

--- a/openbank-product-catalog/src/test/kotlin/com/openbank/productcatalog/contract/ProductCatalogPactProviderVerificationTest.kt
+++ b/openbank-product-catalog/src/test/kotlin/com/openbank/productcatalog/contract/ProductCatalogPactProviderVerificationTest.kt
@@ -1,0 +1,97 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright (c) OpenBank contributors. Licensed under the Apache License, Version 2.0.
+// See LICENSE in the repository root or https://www.apache.org/licenses/LICENSE-2.0 for details.
+
+package com.openbank.productcatalog.contract
+
+import au.com.dius.pact.provider.junit5.HttpTestTarget
+import au.com.dius.pact.provider.junit5.PactVerificationContext
+import au.com.dius.pact.provider.junit5.PactVerificationInvocationContextProvider
+import au.com.dius.pact.provider.junitsupport.IgnoreNoPactsToVerify
+import au.com.dius.pact.provider.junitsupport.Provider
+import au.com.dius.pact.provider.junitsupport.State
+import au.com.dius.pact.provider.junitsupport.loader.PactFolder
+import com.openbank.libs.testing.containers.PostgresTestResource
+import io.quarkus.test.common.QuarkusTestResource
+import io.quarkus.test.common.ResourceArg
+import io.quarkus.test.junit.QuarkusTest
+import io.quarkus.test.security.TestSecurity
+import org.eclipse.microprofile.config.inject.ConfigProperty
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.TestTemplate
+import org.junit.jupiter.api.extension.ExtendWith
+
+/**
+ * Provider-side Pact verification for the contracts consumers publish against
+ * `openbank-product-catalog` (ADR-0063 git-pact: the pact JSON is read from the repo-root `pacts/`
+ * dir via [PactFolder], no Pact Broker and no CI secret involved, so this always runs — locally and
+ * on every path-scoped CI build of this module).
+ *
+ * Today that is one consumer: `openbank-card-issuance-service`'s card-entitlement lookup
+ * (`ProductCatalogPactConsumerTest`). Each interaction is replayed against a real Quarkus instance
+ * on a Testcontainers Postgres, so what is proven is the live HTTP + JSON shape, not a hand-written
+ * restatement of it.
+ *
+ * Neither provider state needs to seed anything, and that is a property of this service rather than
+ * a shortcut — see the [State] methods.
+ *
+ * Auth: `%test` disables OIDC (there is no Keycloak on the test stack) and keeps `@Authorize`
+ * advisory, and [TestSecurity] supplies the operator identity every real caller carries. The
+ * consumer pact therefore pins no `Authorization` header; the "reads require a token" half of the
+ * contract is owned by `ProductCatalogSecurityTest`.
+ *
+ * IMPORTANT: if the consumer changes its contract, regenerate the pact
+ * (`./gradlew :openbank-card-issuance-service:test --tests "*ProductCatalogPactConsumerTest*"`) and
+ * commit `pacts/openbank-card-issuance-service-openbank-product-catalog.json` in the same PR, or
+ * this test verifies a stale contract. `pact-drift-check.yml` gates that.
+ *
+ * [IgnoreNoPactsToVerify] makes a missing/unreadable pact folder a skip rather than a failure —
+ * relevant only if `pacts/` is ever emptied ahead of a broker migration.
+ */
+@QuarkusTest
+@QuarkusTestResource(
+    value = PostgresTestResource::class,
+    initArgs = [ResourceArg(name = "db", value = "openbank_products")],
+)
+@TestSecurity(user = "pact-verifier", roles = ["ROLE_OPERATOR"])
+@Provider("openbank-product-catalog")
+@PactFolder("../pacts")
+@IgnoreNoPactsToVerify(ignoreIoErrors = "true")
+class ProductCatalogPactProviderVerificationTest {
+
+    @ConfigProperty(name = "quarkus.http.test-port", defaultValue = "8081")
+    lateinit var testPort: String
+
+    @BeforeEach
+    fun configureTarget(context: PactVerificationContext?) {
+        context?.target = HttpTestTarget("localhost", testPort.toInt())
+    }
+
+    @TestTemplate
+    @ExtendWith(PactVerificationInvocationContextProvider::class)
+    fun verifyPacts(context: PactVerificationContext?) {
+        context?.verifyInteraction()
+    }
+
+    /**
+     * No seeding: `ProductCatalogSeeder` persists the whole canonical catalogue from `ProductSeed`
+     * on first boot, and `CURRENT_PERSONAL` (prod-003) is one of the card-enabled entries. Seeding
+     * it again here would either lose the UNIQUE(code) race or fork a second source of truth for a
+     * product the service already owns. If this state ever starts failing, the cause is a
+     * `ProductSeed` edit that dropped `CURRENT_PERSONAL`'s `cardConfig` — which is exactly the
+     * regression card issuance needs to hear about, so let it fail rather than seeding around it.
+     */
+    @State("a product with card configuration exists for code CURRENT_PERSONAL")
+    fun cardEnabledProductIsSeeded() {
+        // Intentionally empty — see the KDoc above.
+    }
+
+    /**
+     * No seeding: `NO_SUCH_CARD_PRODUCT` is deliberately absent from `ProductSeed`, so the seeded
+     * catalogue already satisfies "no product exists with this code".
+     */
+    @State("no product exists with code NO_SUCH_CARD_PRODUCT")
+    fun unknownProductCodeIsAbsent() {
+        // Intentionally empty — see the KDoc above.
+    }
+}

--- a/pacts/openbank-card-issuance-service-openbank-product-catalog.json
+++ b/pacts/openbank-card-issuance-service-openbank-product-catalog.json
@@ -1,0 +1,186 @@
+{
+  "consumer": {
+    "name": "openbank-card-issuance-service"
+  },
+  "interactions": [
+    {
+      "description": "GET product by code for a card-enabled product",
+      "providerStates": [
+        {
+          "name": "a product with card configuration exists for code CURRENT_PERSONAL"
+        }
+      ],
+      "request": {
+        "headers": {
+          "Accept": "application/json"
+        },
+        "method": "GET",
+        "path": "/api/v1/products/by-code/CURRENT_PERSONAL"
+      },
+      "response": {
+        "body": {
+          "cardConfig": {
+            "contactlessEnabled": true,
+            "enabled": true,
+            "maxCards": 3,
+            "monthlyFeePerCard": 0.0,
+            "networks": [
+              "VISA"
+            ],
+            "tiers": [
+              "STANDARD"
+            ],
+            "virtualCardAllowed": true
+          },
+          "code": "CURRENT_PERSONAL",
+          "id": "prod-003"
+        },
+        "headers": {
+          "Content-Type": "application/json"
+        },
+        "matchingRules": {
+          "body": {
+            "$.cardConfig.contactlessEnabled": {
+              "combine": "AND",
+              "matchers": [
+                {
+                  "match": "type"
+                }
+              ]
+            },
+            "$.cardConfig.enabled": {
+              "combine": "AND",
+              "matchers": [
+                {
+                  "match": "type"
+                }
+              ]
+            },
+            "$.cardConfig.maxCards": {
+              "combine": "AND",
+              "matchers": [
+                {
+                  "match": "integer"
+                }
+              ]
+            },
+            "$.cardConfig.monthlyFeePerCard": {
+              "combine": "AND",
+              "matchers": [
+                {
+                  "match": "decimal"
+                }
+              ]
+            },
+            "$.cardConfig.networks": {
+              "combine": "AND",
+              "matchers": [
+                {
+                  "match": "type",
+                  "min": 1
+                }
+              ]
+            },
+            "$.cardConfig.networks[*]": {
+              "combine": "AND",
+              "matchers": [
+                {
+                  "match": "type"
+                }
+              ]
+            },
+            "$.cardConfig.tiers": {
+              "combine": "AND",
+              "matchers": [
+                {
+                  "match": "type",
+                  "min": 1
+                }
+              ]
+            },
+            "$.cardConfig.tiers[*]": {
+              "combine": "AND",
+              "matchers": [
+                {
+                  "match": "type"
+                }
+              ]
+            },
+            "$.cardConfig.virtualCardAllowed": {
+              "combine": "AND",
+              "matchers": [
+                {
+                  "match": "type"
+                }
+              ]
+            },
+            "$.code": {
+              "combine": "AND",
+              "matchers": [
+                {
+                  "match": "type"
+                }
+              ]
+            },
+            "$.id": {
+              "combine": "AND",
+              "matchers": [
+                {
+                  "match": "type"
+                }
+              ]
+            }
+          }
+        },
+        "status": 200
+      }
+    },
+    {
+      "description": "GET product by an unknown code",
+      "providerStates": [
+        {
+          "name": "no product exists with code NO_SUCH_CARD_PRODUCT"
+        }
+      ],
+      "request": {
+        "headers": {
+          "Accept": "application/json"
+        },
+        "method": "GET",
+        "path": "/api/v1/products/by-code/NO_SUCH_CARD_PRODUCT"
+      },
+      "response": {
+        "body": {
+          "error": "Product with code 'NO_SUCH_CARD_PRODUCT' not found"
+        },
+        "headers": {
+          "Content-Type": "application/json"
+        },
+        "matchingRules": {
+          "body": {
+            "$.error": {
+              "combine": "AND",
+              "matchers": [
+                {
+                  "match": "type"
+                }
+              ]
+            }
+          }
+        },
+        "status": 404
+      }
+    }
+  ],
+  "metadata": {
+    "pact-jvm": {
+      "version": "4.7.3"
+    },
+    "pactSpecification": {
+      "version": "3.0.0"
+    }
+  },
+  "provider": {
+    "name": "openbank-product-catalog"
+  }
+}


### PR DESCRIPTION
## What

`openbank-card-issuance-service` scored **C3=1** in the Prod Readiness matrix — an `openapi.yaml` but no contract test (#2255). It is a *consumer*: `ProductCatalogClient` calls product-catalog's `GET /api/v1/products/by-code/{code}` (config key `product-catalog-api`) to resolve a product's `cardConfig`.

This adds the consumer-driven pact for card-issuance → product-catalog under the git-pact pattern (ADR-0063), **verified on the provider side**.

- `openbank-card-issuance-service/.../contract/ProductCatalogPactConsumerTest.kt` — writes `pacts/openbank-card-issuance-service-openbank-product-catalog.json`.
- `openbank-product-catalog/.../contract/ProductCatalogPactProviderVerificationTest.kt` — replays it from `@PactFolder("../pacts")` against a real Quarkus instance on a Testcontainers Postgres. No broker, no CI secret.
- `pact-drift-check.yml` gains the new consumer test, so an un-regenerated pact cannot silently verify a stale contract.

### Provider-side verification status: VERIFIED

Worth stating explicitly, because `openbank-product-catalog` carries its own `settings.gradle.kts` and `gradlew` and looks like a separate build. It is not: the root `settings.gradle.kts` builds its include list from a glob over every `openbank-*/build.gradle.kts`, so `./gradlew -q projects` lists `:openbank-product-catalog` as a root subproject, and its `build.gradle.kts` even depends on `project(":openbank-libs")` — which only resolves inside the root build. The stand-alone shim is vestigial. The provider test therefore runs in `:openbank-product-catalog:test`, i.e. in `_service-ci.yml` on every path-scoped build of that module, and locally in `./gradlew :openbank-product-catalog:build`.

### Interactions pinned

The two wire outcomes `ProductCatalogAdapter` branches on:

| Given | Request | Response |
|---|---|---|
| a product with card configuration exists for code `CURRENT_PERSONAL` | `GET /api/v1/products/by-code/CURRENT_PERSONAL` | `200` + `id`, `code`, `cardConfig{enabled, maxCards, networks[], tiers[], virtualCardAllowed, contactlessEnabled, monthlyFeePerCard}` |
| no product exists with code `NO_SUCH_CARD_PRODUCT` | `GET /api/v1/products/by-code/NO_SUCH_CARD_PRODUCT` | `404` + `{"error": …}` |

The 404 is not filler: the adapter is deliberately **fail-open**, so pinning the missing-code response makes that fail-open a contract rather than an accident — if product-catalog ever answered `200` with an empty body for a missing code, the adapter would take a different branch and silently skip the entitlement rules.

Neither provider state seeds anything, and that is a property of this service rather than a shortcut: `ProductCatalogSeeder` persists the whole canonical catalogue from `ProductSeed` at boot, so `CURRENT_PERSONAL` (card-enabled) is present and `NO_SUCH_CARD_PRODUCT` deliberately is not. Seeding `CURRENT_PERSONAL` again would either lose the `UNIQUE(code)` race or fork a second source of truth. Documented in the `@State` KDoc, including what a future failure there would actually mean (a `ProductSeed` edit that dropped the `cardConfig`).

## Both guards falsified before being trusted

A contract test that hard-codes the path it expects passes against a client calling a path that does not exist — that is exactly how finrep shipped a call to a non-existent ledger path (#2269). So the consumer test reads its request path off `ProductCatalogClient.getByCode`'s own `@Path` by reflection, and deserializes the response into the client's own DTOs with the Kotlin Jackson module. Both were then fed an input they MUST flag:

**1. Rename `cardConfig` → `cardConfiguration` in the client DTO** ⇒ consumer test RED:

```
ProductCatalogPactConsumerTest > the client DTOs parse a card-enabled product into a complete card config(MockServer) FAILED
    java.lang.IllegalArgumentException at ProductCatalogPactConsumerTest.kt:136
2 tests completed, 1 failed
```

**2. Point the client at `/api/v1/products/code/{code}`** (a path that does not exist) ⇒ the consumer test still passes, because the Pact mock serves whatever the client asks for — but the regenerated pact carries the bogus path and provider verification goes RED:

```
ProductCatalogPactProviderVerificationTest > verifyPacts > openbank-card-issuance-service - GET product by code for a card-enabled product FAILED
ProductCatalogPactProviderVerificationTest > verifyPacts > openbank-card-issuance-service - GET product by an unknown code FAILED
2 tests completed, 2 failed

  expected status of 200 but was 404
  1.2) body: $ Actual map is missing the following keys: cardConfig, id
```

That second case is the whole point of wiring the provider side: the consumer half alone would have shipped the finrep bug green.

Both were restored and re-run green afterwards (`tests="2" skipped="0" failures="0"` on the provider suite).

## Gates run locally

| Command | Verdict |
|---|---|
| `:openbank-card-issuance-service:test --tests "*Pact*"` | BUILD SUCCESSFUL — pact regenerated, byte-identical to the committed JSON |
| `:openbank-product-catalog:test --tests "*ProductCatalogPactProviderVerificationTest*"` | BUILD SUCCESSFUL — `tests="2" skipped="0" failures="0"` |
| `:openbank-card-issuance-service:build` | BUILD SUCCESSFUL (incl. `koverVerify`) |
| `:openbank-product-catalog:build` | BUILD SUCCESSFUL (incl. `koverVerify`) |
| `detekt` + `ktlintCheck` on both modules | BUILD SUCCESSFUL, no baseline edits |
| `actionlint .github/workflows/pact-drift-check.yml` | clean — and validated against a known-positive (an injected bogus job) so the silence means something |

## Release scope

Commit type `test` — a hidden type, so no release is cut, which matters here because the two `build.gradle.kts` edits are on a releasing path (`src/test` is excluded, `build.gradle.kts` is not). No `version.txt`, `CHANGELOG.md` or `openapi.yaml` change: no shipped code and no API surface changed.

Refs #2255