### PR TITLE
feat(mcp): instrument tool-call outcomes, JSON-RPC methods and caller identity

### DIFF
--- a/openbank-mcp-service/src/main/kotlin/com/openbank/mcp/application/port/out/McpMetricsPort.kt
+++ b/openbank-mcp-service/src/main/kotlin/com/openbank/mcp/application/port/out/McpMetricsPort.kt
@@ -1,0 +1,69 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+// Copyright (c) OpenBank contributors. Licensed under the GNU Affero General Public License v3.0 only.
+// A commercial licence is available from the maintainers as an alternative to the AGPL-3.0.
+// See LICENSES/AGPL-3.0-only.txt or https://www.gnu.org/licenses/agpl-3.0.html for details.
+package com.openbank.mcp.application.port.out
+
+import com.openbank.libs.audit.AuditResult
+import com.openbank.mcp.application.McpCallAuditor
+import java.time.Duration
+
+/**
+ * Outbound observability port (ADR-0002 / ADR-0077 Tier C) for the MCP server (ADR-0181).
+ *
+ * This is the bank's AI-agent surface: every `tools/call` is an AI-initiated action against customer
+ * data or (for `propose_payment`) the payment path. The audit trail already records **what** each
+ * call did, one event at a time; these meters answer the questions an audit trail cannot — the rate,
+ * the outcome mix, and the latency — without querying the audit store:
+ *
+ *  - `decision=UNAVAILABLE` means the PDP could not be reached and **every** agent call is being
+ *    denied, fail-closed. Correct, and previously nothing but a WARN line.
+ *  - `tool="unmapped"` is the deny-by-default gate firing: an agent asking for a tool that has no
+ *    capability entry. One is a client bug; a stream of them is enumeration of the tool surface.
+ *  - [callerIdentityResolved] measures how many calls still run under the **phase-1 placeholder
+ *    identity** (`agent:mcp-anonymous`) rather than a validated OAuth token. That is blocker #2206
+ *    expressed as a number instead of a code comment: it must reach zero before a real read port
+ *    replaces the stub.
+ *
+ * Kept as a port rather than a direct `MeterRegistry` dependency so the endpoint stays testable
+ * without Micrometer, and so the counters are exercised through the real adapter (over a
+ * `SimpleMeterRegistry`) in unit tests.
+ *
+ * **Cardinality:** both the JSON-RPC `method` and the `tool` name are caller-supplied strings on a
+ * public agent surface. The endpoint maps each to a bounded value before it reaches this port — an
+ * unrecognised method becomes [UNKNOWN_METHOD] and an unmapped tool becomes [UNMAPPED_TOOL] — so a
+ * client cannot mint unbounded metric series by inventing names.
+ *
+ * Implemented by [com.openbank.mcp.infrastructure.observability.McpMetricsAdapter].
+ */
+interface McpMetricsPort {
+
+    /** Record one JSON-RPC request, by (bounded) method name. */
+    fun requestHandled(method: String)
+
+    /** Record one completed `tools/call`, mirroring the tags of its audit event. */
+    fun toolCallCompleted(tool: String, decision: McpCallAuditor.Decision, result: AuditResult, duration: Duration)
+
+    /** Record how the acting agent's identity was established for one `tools/call`. */
+    fun callerIdentityResolved(source: CallerIdentitySource)
+
+    companion object {
+        /** Tag value for a JSON-RPC method this server does not implement. */
+        const val UNKNOWN_METHOD = "unknown"
+
+        /** Tag value for a tool with no capability mapping — the deny-by-default gate firing. */
+        const val UNMAPPED_TOOL = "unmapped"
+    }
+}
+
+/** Where the acting agent's identity came from. A bounded set — safe as a tag. */
+enum class CallerIdentitySource {
+    /** A validated OAuth 2.1 agent token supplied `sub` and `consent_id` (ADR-0195). */
+    TOKEN,
+
+    /** No agent token was presented, so the phase-1 placeholder identity was used (blocker #2206). */
+    ANONYMOUS_FALLBACK,
+
+    /** An agent token was present but malformed, so the call was denied fail-closed. */
+    RESOLUTION_FAILED,
+}

--- a/openbank-mcp-service/src/main/kotlin/com/openbank/mcp/infrastructure/mcp/McpEndpoint.kt
+++ b/openbank-mcp-service/src/main/kotlin/com/openbank/mcp/infrastructure/mcp/McpEndpoint.kt
@@ -13,7 +13,9 @@ import com.openbank.libs.authz.PolicyDecisionPoint
 import com.openbank.libs.authz.Principal
 import com.openbank.mcp.application.McpCallAuditor
 import com.openbank.mcp.application.McpToolRegistry
+import com.openbank.mcp.application.port.out.CallerIdentitySource
 import com.openbank.mcp.application.port.out.ConsentContext
+import com.openbank.mcp.application.port.out.McpMetricsPort
 import com.openbank.mcp.application.protocol.InitializeResult
 import com.openbank.mcp.application.protocol.McpError
 import com.openbank.mcp.application.protocol.McpErrorCode
@@ -23,6 +25,7 @@ import com.openbank.mcp.application.protocol.ServerInfo
 import com.openbank.mcp.application.protocol.ToolCallResult
 import com.openbank.mcp.application.protocol.ToolContent
 import com.openbank.mcp.application.protocol.ToolsListResult
+import jakarta.inject.Inject
 import jakarta.ws.rs.Consumes
 import jakarta.ws.rs.POST
 import jakarta.ws.rs.Path
@@ -32,6 +35,7 @@ import jakarta.ws.rs.core.Response
 import kotlinx.coroutines.runBlocking
 import org.eclipse.microprofile.config.inject.ConfigProperty
 import org.jboss.logging.Logger
+import java.time.Duration
 
 /**
  * The Model Context Protocol server (ADR-0181): JSON-RPC 2.0 over HTTP POST, exposing the curated
@@ -44,6 +48,12 @@ import org.jboss.logging.Logger
  * AI-attributed [McpCallAuditor] audit event (ADR-0031 D5 / ADR-0086), so an AI-initiated action
  * against the bank is reconstructable. `tools/list`, `initialize` and `ping` do not: they touch no
  * customer data and expose only the static tool catalogue.
+ *
+ * The same terminal branches also report to [McpMetricsPort] — audit and meter are emitted from one
+ * place so the aggregate can never disagree with the per-call trail. The audit event answers "what
+ * did this agent do"; the meters answer the questions a trail cannot without a query: the rate, the
+ * outcome mix, the latency, and — via `caller_identity` — how many calls still run under the phase-1
+ * placeholder identity rather than a validated token (blocker #2206).
  *
  * Caller identity (ADR-0195): the acting agent + presented consent come from the caller's validated
  * OAuth 2.1 access token via [CallerContextResolver] — `sub` (`agent:<id>`, classified AI_AGENT by
@@ -68,6 +78,15 @@ class McpEndpoint(
     private val protocolVersion: String,
 ) {
 
+    /**
+     * Field-injected rather than a constructor parameter: the constructor already carries the four
+     * collaborators plus the three `@ConfigProperty` server-identity strings, and a ninth parameter
+     * trips detekt's `LongParameterList`. Same shape as `LoanStageEventConsumer` / `VopRateLimitFilter`
+     * elsewhere in the fleet.
+     */
+    @Inject
+    lateinit var metrics: McpMetricsPort
+
     private val log = Logger.getLogger(McpEndpoint::class.java)
 
     @POST
@@ -76,6 +95,10 @@ class McpEndpoint(
         val id = body.path("id").let { if (it.isMissingNode) NullNode.instance else it }
         val method = body.path("method").asText("")
         val params = body.path("params")
+
+        // Bounded before it becomes a tag: `method` is a caller-supplied string on a public agent
+        // surface, so an unrecognised value must not mint a new metric series (cardinality contract).
+        metrics.requestHandled(if (method in KNOWN_METHODS) method else McpMetricsPort.UNKNOWN_METHOD)
 
         val result: Any = when (method) {
             "initialize" -> InitializeResult(
@@ -94,11 +117,16 @@ class McpEndpoint(
 
     @Suppress("ReturnCount", "TooGenericExceptionCaught")
     private fun handleToolCall(id: JsonNode, params: JsonNode): Response {
+        val startedAt = System.nanoTime()
         val toolName = params.path("name").asText("")
         val arguments = params.path("arguments").let { if (it.isMissingNode) mapper.createObjectNode() else it }
         // Argument KEY names only — the values are customer data and must never enter the audit
         // trail (McpCallAuditor KDoc).
         val argumentKeys = arguments.fieldNames().asSequence().sorted().toList()
+        // Bounded before it becomes a tag: an unmapped tool name is caller-supplied, so it is
+        // reported as the single "unmapped" value rather than as itself (cardinality contract). The
+        // audit event still carries the exact name — that is a per-call record, not a label.
+        val toolTag = if (registry.capabilities.containsKey(toolName)) toolName else McpMetricsPort.UNMAPPED_TOOL
 
         // Caller authentication (ADR-0195): the acting agent + presented consent come from the
         // validated OAuth token. A malformed agent token (e.g. no consent_id) fails CLOSED — a
@@ -106,6 +134,8 @@ class McpEndpoint(
         val ctx = resolveCaller(toolName, argumentKeys)
             ?: return toolError(id, "Authorization unavailable")
 
+        // Audit and meter together, at every terminal branch, so the aggregate can never disagree
+        // with the per-call trail about what happened.
         fun audit(
             capability: String?,
             decision: McpCallAuditor.Decision,
@@ -124,6 +154,7 @@ class McpEndpoint(
                     argumentKeys = argumentKeys,
                 ),
             )
+            metrics.toolCallCompleted(toolTag, decision, result, Duration.ofNanos(System.nanoTime() - startedAt))
         }
 
         // Deny-by-default: no capability mapping ⇒ no OPA action ⇒ refuse.
@@ -180,6 +211,7 @@ class McpEndpoint(
         resolveContext()
     } catch (ex: Exception) {
         log.warnf("caller context resolution failed for %s: %s — denying", toolName, ex.message)
+        metrics.callerIdentityResolved(CallerIdentitySource.RESOLUTION_FAILED)
         runBlocking {
             auditor.toolCallCompleted(
                 McpCallAuditor.ToolCall(
@@ -203,8 +235,18 @@ class McpEndpoint(
     // deployed stub surface keeps working unchanged. The `agent:mcp-anonymous` literal deliberately
     // lives HERE: the #2206 CI guard keys on it, refusing to let a real read port land while this
     // fallback is still reachable. It is removed when OIDC is enabled and a token becomes mandatory.
-    private fun resolveContext(): ConsentContext = callerResolver.resolveOrNull()
-        ?: ConsentContext(agentId = "agent:mcp-anonymous", consentId = "none", grantedAccounts = emptyList())
+    //
+    // Which of the two branches was taken is METERED, because "the fallback is still reachable" is
+    // exactly the #2206 precondition and a code comment cannot be evaluated against production.
+    // `caller_identity{source="anonymous_fallback"}` must be zero before a real read port lands.
+    private fun resolveContext(): ConsentContext {
+        val fromToken = callerResolver.resolveOrNull()
+        metrics.callerIdentityResolved(
+            if (fromToken == null) CallerIdentitySource.ANONYMOUS_FALLBACK else CallerIdentitySource.TOKEN,
+        )
+        return fromToken
+            ?: ConsentContext(agentId = "agent:mcp-anonymous", consentId = "none", grantedAccounts = emptyList())
+    }
 
     private fun toolError(id: JsonNode, message: String): Response = Response.ok(
         McpResponse(id = id, result = ToolCallResult(listOf(ToolContent(text = message)), isError = true)),
@@ -212,4 +254,12 @@ class McpEndpoint(
 
     private fun error(id: JsonNode, code: Int, message: String): Response =
         Response.ok(McpResponse(id = id, error = McpError(code, message))).build()
+
+    private companion object {
+        /**
+         * The JSON-RPC methods this server implements. Used ONLY to bound the `method` metric tag —
+         * the dispatch itself is the `when` in [handle], which stays the single source of behaviour.
+         */
+        val KNOWN_METHODS = setOf("initialize", "notifications/initialized", "ping", "tools/list", "tools/call")
+    }
 }

--- a/openbank-mcp-service/src/main/kotlin/com/openbank/mcp/infrastructure/observability/McpMetricsAdapter.kt
+++ b/openbank-mcp-service/src/main/kotlin/com/openbank/mcp/infrastructure/observability/McpMetricsAdapter.kt
@@ -1,0 +1,107 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+// Copyright (c) OpenBank contributors. Licensed under the GNU Affero General Public License v3.0 only.
+// A commercial licence is available from the maintainers as an alternative to the AGPL-3.0.
+// See LICENSES/AGPL-3.0-only.txt or https://www.gnu.org/licenses/agpl-3.0.html for details.
+package com.openbank.mcp.infrastructure.observability
+
+import com.openbank.libs.audit.AuditResult
+import com.openbank.mcp.application.McpCallAuditor
+import com.openbank.mcp.application.port.out.CallerIdentitySource
+import com.openbank.mcp.application.port.out.McpMetricsPort
+import io.micrometer.core.instrument.Counter
+import io.micrometer.core.instrument.MeterRegistry
+import io.micrometer.core.instrument.Timer
+import jakarta.enterprise.context.ApplicationScoped
+import jakarta.enterprise.inject.Instance
+import jakarta.inject.Inject
+import java.time.Duration
+
+/**
+ * Micrometer adapter for [McpMetricsPort] (ADR-0077 Tier C). Emits, all tagged `service="mcp"`:
+ *
+ *  - `openbank_mcp_requests_total{method}` — the JSON-RPC method mix, `method="unknown"` for anything
+ *    this server does not implement.
+ *  - `openbank_mcp_tool_calls_total{tool,decision,result}` — the AI-attribution counter, carrying the
+ *    same three facts as the call's audit event. `decision="UNAVAILABLE"` is a PDP outage denying
+ *    every agent; `tool="unmapped"` is the deny-by-default gate firing.
+ *  - `openbank_mcp_tool_call_duration_seconds{tool}` — includes the PDP round-trip and the tool's own
+ *    work, i.e. what the agent actually waits for.
+ *  - `openbank_mcp_caller_identity_total{source}` — `anonymous_fallback` is the count of calls still
+ *    running under the phase-1 placeholder identity rather than a validated OAuth token (blocker
+ *    #2206). It must be zero before a real read port replaces the stub.
+ *
+ * No agent id, consent id, argument value or tool result is ever a tag: the tool name is mapped to a
+ * bounded value by the endpoint (see the port's cardinality note) and everything else is a closed
+ * enum. The audit event remains the per-call record; this is the aggregate.
+ *
+ * Service-local `MeterRegistry`, null-safe via [Instance] exactly like libs `DomainMetrics`: MCP
+ * tool-call counters are mcp-specific, so adding them to the shared libs facade would force a
+ * fleet-wide rebuild for a one-service concern.
+ */
+@ApplicationScoped
+class McpMetricsAdapter(private val registry: MeterRegistry?) : McpMetricsPort {
+
+    // CDI constructor: MeterRegistry is optional (absent when no Prometheus registry is on the
+    // classpath, e.g. slim test slices). Without an explicit @Inject ctor, ArC sees two constructors,
+    // registers no bean, and McpEndpoint is left with an unsatisfied dependency at build time.
+    @Inject
+    constructor(registryInstance: Instance<MeterRegistry>) : this(
+        if (registryInstance.isResolvable) registryInstance.get() else null,
+    )
+
+    override fun requestHandled(method: String) {
+        registry?.let { r ->
+            Counter.builder("openbank.mcp.requests")
+                .tag("service", SERVICE)
+                .tag("method", method)
+                .description("MCP JSON-RPC requests by method")
+                .register(r)
+                .increment()
+        }
+    }
+
+    override fun toolCallCompleted(
+        tool: String,
+        decision: McpCallAuditor.Decision,
+        result: AuditResult,
+        duration: Duration,
+    ) {
+        val r = registry ?: return
+        Counter.builder("openbank.mcp.tool_calls")
+            .tag("service", SERVICE)
+            .tag("tool", tool)
+            .tag("decision", decision.name)
+            .tag("result", result.name)
+            .description("MCP tool calls by tool, policy decision and outcome")
+            .register(r)
+            .increment()
+        Timer.builder("openbank.mcp.tool_call.duration")
+            .tag("service", SERVICE)
+            .tag("tool", tool)
+            .publishPercentiles(P50, P95, P99)
+            .publishPercentileHistogram()
+            .description("End-to-end MCP tool-call latency, including the PDP round-trip")
+            .register(r)
+            .record(duration)
+    }
+
+    override fun callerIdentityResolved(source: CallerIdentitySource) {
+        registry?.let { r ->
+            Counter.builder("openbank.mcp.caller_identity")
+                .tag("service", SERVICE)
+                .tag("source", source.name.lowercase())
+                .description("How the acting agent's identity was established for a tool call")
+                .register(r)
+                .increment()
+        }
+    }
+
+    companion object {
+        private const val SERVICE = "mcp"
+
+        // The fleet-standard percentile set (libs DomainMetrics publishes the same three).
+        private const val P50 = 0.5
+        private const val P95 = 0.95
+        private const val P99 = 0.99
+    }
+}

--- a/openbank-mcp-service/src/test/kotlin/com/openbank/mcp/McpEndpointTest.kt
+++ b/openbank-mcp-service/src/test/kotlin/com/openbank/mcp/McpEndpointTest.kt
@@ -17,6 +17,8 @@ import com.openbank.mcp.application.port.out.ConsentContext
 import com.openbank.mcp.application.port.out.ProposalPort
 import com.openbank.mcp.infrastructure.mcp.CallerContextResolver
 import com.openbank.mcp.infrastructure.mcp.McpEndpoint
+import com.openbank.mcp.infrastructure.observability.McpMetricsAdapter
+import io.micrometer.core.instrument.simple.SimpleMeterRegistry
 import org.assertj.core.api.Assertions.assertThat
 import org.junit.jupiter.api.Test
 
@@ -31,13 +33,26 @@ class McpEndpointTest {
 
     private val audit = Recorder()
 
+    // The REAL metrics adapter over a SimpleMeterRegistry rather than a mock port, so the
+    // instrumentation assertions below fail if the endpoint stops emitting.
+    private val registry = SimpleMeterRegistry()
+
     private fun endpoint(pdp: PolicyDecisionPoint): McpEndpoint {
         val stub = StubReads(mapper)
-        val registry = McpToolRegistry(stub, stub, mapper)
+        val toolRegistry = McpToolRegistry(stub, stub, mapper)
         // Anonymous JWT (no `sub`) → the resolver returns null → the endpoint uses the phase-1
         // placeholder identity, so these protocol/authorization assertions are unchanged (ADR-0195).
         val caller = CallerContextResolver(TestJsonWebToken())
-        return McpEndpoint(registry, pdp, McpCallAuditor(audit), caller, mapper, "openbank-mcp", "0.1.0", "2025-06-18")
+        return McpEndpoint(
+            registry = toolRegistry,
+            pdp = pdp,
+            auditor = McpCallAuditor(audit),
+            callerResolver = caller,
+            mapper = mapper,
+            serverName = "openbank-mcp",
+            serverVersion = "0.1.0",
+            protocolVersion = "2025-06-18",
+        ).apply { metrics = McpMetricsAdapter(registry) }
     }
 
     private fun rpc(method: String, params: Map<String, Any?> = emptyMap()): JsonNode =
@@ -168,6 +183,98 @@ class McpEndpointTest {
         val rendered = audit.events.single().payload.toString()
         assertThat(rendered).contains("accountId").doesNotContain(SECRET)
     }
+
+    // ── ADR-0077 Tier C: the same outcomes as an aggregate ──────────────────────────────────
+
+    @Test
+    fun `an allowed tool call is metered with the same three facts as its audit event`() {
+        endpoint(allowAll()).handle(
+            rpc("tools/call", mapOf("name" to "list_accounts", "arguments" to emptyMap<String, Any>())),
+        )
+
+        assertThat(toolCalls("list_accounts", "ALLOW", "SUCCESS")).isEqualTo(1.0)
+        assertThat(
+            registry.get("openbank.mcp.tool_call.duration")
+                .tag("service", "mcp").tag("tool", "list_accounts").timer().count(),
+        ).isEqualTo(1L)
+    }
+
+    @Test
+    fun `a PDP outage is metered as UNAVAILABLE, distinct from a policy DENY`() {
+        // Fail-closed on a money-adjacent surface denies EVERY agent. Correct, and previously
+        // nothing but a WARN line.
+        endpoint(exploding()).handle(
+            rpc("tools/call", mapOf("name" to "list_accounts", "arguments" to emptyMap<String, Any>())),
+        )
+        endpoint(denyAll()).handle(
+            rpc("tools/call", mapOf("name" to "list_accounts", "arguments" to emptyMap<String, Any>())),
+        )
+
+        assertThat(toolCalls("list_accounts", "UNAVAILABLE", "DENIED")).isEqualTo(1.0)
+        assertThat(toolCalls("list_accounts", "DENY", "DENIED")).isEqualTo(1.0)
+    }
+
+    @Test
+    fun `an unmapped tool is metered as tool=unmapped, never under its caller-supplied name`() {
+        // Cardinality contract: the tool name arrives in the request body on a public agent surface,
+        // so an agent enumerating the tool surface must not be able to mint a series per guess. The
+        // audit event still records the exact name — that is a per-call record, not a label.
+        endpoint(exploding()).handle(
+            rpc("tools/call", mapOf("name" to "delete_everything", "arguments" to emptyMap<String, Any>())),
+        )
+
+        assertThat(toolCalls("unmapped", "DENY", "DENIED")).isEqualTo(1.0)
+        assertThat(registry.find("openbank.mcp.tool_calls").tag("tool", "delete_everything").counters()).isEmpty()
+        assertThat(audit.events.single().resourceId).isEqualTo("delete_everything")
+    }
+
+    @Test
+    fun `an unknown JSON-RPC method is metered as method=unknown`() {
+        endpoint(allowAll()).handle(rpc("tools/list"))
+        endpoint(allowAll()).handle(rpc("evil/method"))
+
+        assertThat(requests("tools/list")).isEqualTo(1.0)
+        assertThat(requests("unknown")).isEqualTo(1.0)
+        assertThat(registry.find("openbank.mcp.requests").tag("method", "evil/method").counters()).isEmpty()
+    }
+
+    @Test
+    fun `a call under the phase-1 placeholder identity is metered as anonymous_fallback`() {
+        // This is blocker #2206 expressed as a number rather than a code comment: it must reach zero
+        // before a real read port replaces the stub. TestJsonWebToken carries no `sub`, so the
+        // resolver returns null and the endpoint takes the fallback branch.
+        endpoint(allowAll()).handle(
+            rpc("tools/call", mapOf("name" to "list_accounts", "arguments" to emptyMap<String, Any>())),
+        )
+
+        assertThat(
+            registry.get("openbank.mcp.caller_identity")
+                .tag("service", "mcp").tag("source", "anonymous_fallback").counter().count(),
+        ).isEqualTo(1.0)
+        assertThat(registry.find("openbank.mcp.caller_identity").tag("source", "token").counters()).isEmpty()
+    }
+
+    @Test
+    fun `no meter carries the agent id, consent id or an argument value`() {
+        endpoint(allowAll()).handle(
+            rpc("tools/call", mapOf("name" to "get_balance", "arguments" to mapOf("accountId" to SECRET))),
+        )
+
+        val tags = registry.meters.flatMap { it.id.tags }
+        assertThat(tags.map { it.key }).doesNotContain("agent_id", "consent_id", "charter", "account_id")
+        assertThat(tags.map { it.value }).doesNotContain(SECRET, "agent:mcp-anonymous")
+    }
+
+    private fun toolCalls(tool: String, decision: String, result: String): Double =
+        registry.get("openbank.mcp.tool_calls")
+            .tag("service", "mcp")
+            .tag("tool", tool)
+            .tag("decision", decision)
+            .tag("result", result)
+            .counter().count()
+
+    private fun requests(method: String): Double =
+        registry.get("openbank.mcp.requests").tag("service", "mcp").tag("method", method).counter().count()
 
     private class Recorder : AuditEventPublisher {
         val events = mutableListOf<AuditEvent>()

--- a/openbank-mcp-service/src/test/kotlin/com/openbank/mcp/McpMetricsAdapterTest.kt
+++ b/openbank-mcp-service/src/test/kotlin/com/openbank/mcp/McpMetricsAdapterTest.kt
@@ -1,0 +1,74 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+// Copyright (c) OpenBank contributors. Licensed under the GNU Affero General Public License v3.0 only.
+package com.openbank.mcp
+
+import com.openbank.libs.audit.AuditResult
+import com.openbank.mcp.application.McpCallAuditor
+import com.openbank.mcp.application.port.out.CallerIdentitySource
+import com.openbank.mcp.application.port.out.McpMetricsPort
+import com.openbank.mcp.infrastructure.observability.McpMetricsAdapter
+import io.micrometer.core.instrument.simple.SimpleMeterRegistry
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.Test
+import java.time.Duration
+
+class McpMetricsAdapterTest {
+
+    private val registry = SimpleMeterRegistry()
+    private val adapter = McpMetricsAdapter(registry)
+
+    @Test
+    fun `every policy decision keeps its own series`() {
+        McpCallAuditor.Decision.entries.forEach {
+            adapter.toolCallCompleted("list_accounts", it, AuditResult.DENIED, Duration.ofMillis(5))
+        }
+
+        McpCallAuditor.Decision.entries.forEach { decision ->
+            assertThat(
+                registry.get("openbank.mcp.tool_calls")
+                    .tag("tool", "list_accounts").tag("decision", decision.name).tag("result", "DENIED")
+                    .counter().count(),
+            ).isEqualTo(1.0)
+        }
+        assertThat(registry.get("openbank.mcp.tool_call.duration").tag("tool", "list_accounts").timer().count())
+            .isEqualTo(McpCallAuditor.Decision.entries.size.toLong())
+    }
+
+    @Test
+    fun `every caller-identity source gets a distinct lower-cased tag value`() {
+        CallerIdentitySource.entries.forEach { adapter.callerIdentityResolved(it) }
+
+        CallerIdentitySource.entries.forEach { source ->
+            assertThat(
+                registry.get("openbank.mcp.caller_identity")
+                    .tag("service", "mcp").tag("source", source.name.lowercase()).counter().count(),
+            ).isEqualTo(1.0)
+        }
+    }
+
+    @Test
+    fun `the bounded tag constants are the values the endpoint is expected to pass`() {
+        adapter.requestHandled(McpMetricsPort.UNKNOWN_METHOD)
+        adapter.toolCallCompleted(
+            McpMetricsPort.UNMAPPED_TOOL,
+            McpCallAuditor.Decision.DENY,
+            AuditResult.DENIED,
+            Duration.ZERO,
+        )
+
+        assertThat(registry.get("openbank.mcp.requests").tag("method", "unknown").counter().count()).isEqualTo(1.0)
+        assertThat(
+            registry.get("openbank.mcp.tool_calls").tag("tool", "unmapped").counter().count(),
+        ).isEqualTo(1.0)
+    }
+
+    @Test
+    fun `is a silent no-op when no meter registry is resolvable`() {
+        // Slim slices without a Prometheus registry must not crash a tool call.
+        val noRegistry = McpMetricsAdapter(null)
+
+        noRegistry.requestHandled("ping")
+        noRegistry.toolCallCompleted("ping", McpCallAuditor.Decision.ALLOW, AuditResult.SUCCESS, Duration.ZERO)
+        noRegistry.callerIdentityResolved(CallerIdentitySource.TOKEN)
+    }
+}


### PR DESCRIPTION
## Summary

`openbank-mcp-service` emitted only default JVM/HTTP metrics — zero domain instrumentation
(prod-readiness C8, #2255). This is the bank's **AI-agent surface**: every `tools/call` is an
AI-initiated action against customer data, or (for `propose_payment`) against the payment path. The
audit trail already records *what* each call did, one event at a time; nothing answered the
questions a trail cannot without a query — rate, outcome mix, latency. Adds an `McpMetricsPort` and
a Micrometer adapter, following the service-local pattern already used by fraud-service and
agent-service.

## Type of change

- [x] feat (new functionality)

## Linked issues

Refs #2255 · relates to #2206 (see `caller_identity` below)

## Changes

**Meters added, and why these:**

| Meter | Why an operator needs it |
|---|---|
| `openbank_mcp_tool_calls_total{tool,decision,result}` | The AI-attribution aggregate, carrying the same three facts as each call's audit event. `decision="UNAVAILABLE"` is a **PDP outage denying every agent**, fail-closed — correct, and previously nothing but a WARN line. `tool="unmapped"` is the deny-by-default gate firing: one is a client bug, a stream of them is enumeration of the tool surface. |
| `openbank_mcp_tool_call_duration_seconds{tool}` | Includes the PDP round-trip and the tool's own work — what the agent actually waits for. |
| `openbank_mcp_requests_total{method}` | The JSON-RPC method mix, including `method="unknown"`. |
| `openbank_mcp_caller_identity_total{source}` | **`anonymous_fallback` is blocker #2206 expressed as a number instead of a code comment.** It counts calls still running under the phase-1 placeholder identity (`agent:mcp-anonymous`) rather than a validated OAuth token — and it must reach zero before a real read port replaces the stub. Today that precondition exists only as prose in a KDoc and a grep-based CI guard; now it is measurable against production. |

**Code:**

- new `application/port/out/McpMetricsPort.kt` (+ `CallerIdentitySource`, and the two bounded tag constants)
- new `infrastructure/observability/McpMetricsAdapter.kt` — service-local `MeterRegistry`, null-safe via
  `Instance<MeterRegistry>` like libs `DomainMetrics`, with the explicit `@Inject` constructor ArC needs
- `McpEndpoint`: audit and meter emitted from the **same** terminal branches (the existing local `audit()`
  helper), so the aggregate can never disagree with the per-call trail

### Cardinality — the part that needed care

Both the JSON-RPC `method` and the `tool` name are **caller-supplied strings on a public agent
surface**. Each is mapped to a bounded value *before* it reaches the port (`unknown` / `unmapped`),
so an agent cannot mint a metric series per guess. The audit event still records the exact name —
that is a per-call record, not a label. There are tests asserting
`tool_calls{tool="delete_everything"}` does not exist while the audit event's `resourceId` still
does, and that no meter carries the agent id, consent id or an argument value.

### `metrics` is field-injected, deliberately

A ninth constructor parameter trips detekt's `LongParameterList` (threshold 9). Field injection is
the fleet convention for exactly this case — `LoanStageEventConsumer`, `VopRateLimitFilter`. The
reason is stated in a KDoc on the field so it does not read as an accident.

### The #2206 guard still holds

`resolveContext()` keeps the `agent:mcp-anonymous` literal that
`.github/scripts/check-mcp-stub-ports-vs-caller-auth.sh` anchors on. Re-ran it on this branch:

```
check-mcp-stub-ports-vs-caller-auth: OK — placeholder identity still in place, only stub (or @Vetoed) ports wired (phase 1).
```

## Definition of Done

- [x] Hexagonal layering preserved (port in `application/port/out`, Micrometer only in `infrastructure/observability`; `McpTypes` Jackson stays out of `domain`).
- [x] Unit tests added/updated.
- [x] Integration tests added/updated (if service boundary involved). — `McpAuditEventIT` and `McpBootSmokeTest` (both `@QuarkusTest`) exercise the CDI field injection; `quarkusBuild` validates ArC.
- [x] Contract tests updated (if public API changed). — n/a, no API change (mcp's missing contract test is a separate C3 item in #2255).
- [x] `detekt ktlintCheck koverVerify build` passes (module-scoped, see below).
- [x] No new lint warnings.
- [x] OpenAPI spec regenerated (if REST API changed). — n/a
- [x] Flyway migration added + rollback note (if DB changed). — n/a, mcp is stateless
- [x] Avro schema versioned backward-compatibly (if event changed). — n/a; the audit envelope is unchanged
- [x] Docs updated — KDoc on the port/adapter/endpoint states what each meter is for and why.

### The tests were falsified, not just run

The tests drive the **real** adapter over a `SimpleMeterRegistry` rather than a mock port. Verified
by removing all three call sites (`toolCallCompleted`, `requestHandled`, `callerIdentityResolved`):

```
McpEndpointTest > an unmapped tool is metered as tool=unmapped, never under its caller-supplied name() FAILED
    io.micrometer.core.instrument.search.MeterNotFoundException
McpEndpointTest > a call under the phase-1 placeholder identity is metered as anonymous_fallback() FAILED
McpEndpointTest > a PDP outage is metered as UNAVAILABLE, distinct from a policy DENY() FAILED
McpEndpointTest > an allowed tool call is metered with the same three facts as its audit event() FAILED
McpEndpointTest > an unknown JSON-RPC method is metered as method=unknown() FAILED
    io.micrometer.core.instrument.search.MeterNotFoundException
```

Restored → `BUILD SUCCESSFUL`; full module run: **39 tests, 0 failures, 0 errors, 0 skipped**
(`:openbank-mcp-service:build :quarkusBuild :detekt :ktlintCheck :koverVerify`).

## Security checklist

- [x] No secrets, tokens, passwords, or PII in code, config, tests, logs. — see the cardinality section: no agent id, consent id, tool argument or tool result is ever a tag, and there is a test asserting it.
- [x] No new `@Suppress` without justification. — none added; the endpoint's existing `ReturnCount` / `TooGenericExceptionCaught` are unchanged.
- [x] No new third-party dependency. — `quarkus-micrometer-registry-prometheus` was already on the classpath.
- [x] Auth / crypto / payment code changed? — the authorization *decision* logic is untouched; `resolveContext()` gained a meter call around the same two branches and returns the same values. The #2206 guard re-run confirms the placeholder anchor is intact.
- [x] PII path changed? — no
- [x] Cardholder data path changed? — no

## Compliance impact

- [x] GDPR — the metrics are deliberately the *aggregate* half of the ADR-0031 D5 / ADR-0086 AI audit trail: no customer data enters a label (data minimisation), while the AI-attribution facts stay queryable.
- [x] PSD2 / SCA / RTS — `propose_payment` is consent-scoped and HITL-gated; the `tool_calls` and `caller_identity` series are what make an unauthenticated-identity regression detectable rather than inferable.
