### PR TITLE
fix(finrep): call the ledger trial-balance path that exists, pinned by a pact

### DIFF
--- a/.github/workflows/pact-drift-check.yml
+++ b/.github/workflows/pact-drift-check.yml
@@ -46,6 +46,11 @@ jobs:
       # pacts/ dir (systemProperty("pact.rootDir", ...) in the consuming service's
       # build.gradle.kts). --continue so one module's failure doesn't hide drift elsewhere.
       #
+      # THIS LIST IS THE GATE'S SCOPE — a new consumer whose module is missing here is not merely
+      # unchecked, it reads as PASSING: the diff step only ever sees pacts/ files this step
+      # regenerated, so an omitted consumer's committed pact is never rewritten and so never
+      # differs. Add the module in the same PR that adds the pact (finrep arrived with #2269's).
+      #
       # openbank-swift-service is deliberately excluded here: its own build.gradle.kts
       # statically excludes SwiftEventPactConsumerTest whenever CI=true (PactConsumerTestExt
       # auto-publishes to pactbroker.url in CI and hangs/401s — issue #2404), so it can never
@@ -60,6 +65,7 @@ jobs:
             :openbank-card-issuance-service:test --tests "com.openbank.cardissuance.contract.*PactConsumerTest" \
             :openbank-consent-service:test --tests "com.openbank.consent.contract.*PactConsumerTest" \
             :openbank-domestic-payment:test --tests "com.openbank.domestic.contract.*PactConsumerTest" \
+            :openbank-finrep-service:test --tests "com.openbank.finrep.contract.*PactConsumerTest" \
             :openbank-fraud-service:test --tests "com.openbank.fraud.contract.*PactConsumerTest" \
             :openbank-kyc-service:test --tests "com.openbank.kyc.contract.*PactConsumerTest" \
             :openbank-lending-service:test --tests "com.openbank.lending.contract.*PactConsumerTest" \

--- a/openbank-finrep-service/build.gradle.kts
+++ b/openbank-finrep-service/build.gradle.kts
@@ -32,6 +32,17 @@ dependencies {
     testImplementation(libs.assertj)
     testImplementation(libs.mockk)
     testImplementation(libs.rest.assured.kotlin)
+    // Consumer-driven contract test for the ledger trial-balance call (ADR-0063, git-pact).
+    // Consumer side only — finrep is not a Pact provider for anyone, so no libs.pact.provider.
+    testImplementation(libs.pact.consumer)
+}
+
+// Pact: write generated pact files to the shared pacts/ dir at the repo root (git-pact, ADR-0063).
+// The consumer test regenerates the file on every run; developers commit the result, and
+// openbank-ledger-service's LedgerPactProviderVerificationTest (@PactFolder("../pacts")) replays it.
+// NOTE: must be set on the test JVM fork, not the Gradle daemon (System.setProperty would not propagate).
+tasks.withType<Test> {
+    systemProperty("pact.rootDir", "${rootProject.projectDir}/pacts")
 }
 
 kover {

--- a/openbank-finrep-service/src/main/kotlin/com/openbank/finrep/infrastructure/client/LedgerClient.kt
+++ b/openbank-finrep-service/src/main/kotlin/com/openbank/finrep/infrastructure/client/LedgerClient.kt
@@ -22,9 +22,25 @@ import org.eclipse.microprofile.rest.client.inject.RestClient
 import java.math.BigDecimal
 import java.time.LocalDate
 
+/**
+ * Outbound client for openbank-ledger-service's GL trial balance.
+ *
+ * The root path is `/api/v1/journals` — the trial balance is served by ledger's `LedgerResource`
+ * at `GET /api/v1/journals/trial-balance` (`operationId: getTrialBalance`). It is deliberately
+ * NOT `/api/v1/ledger/trial-balance`: ledger has no such path (`/api/v1/ledger/...` only roots
+ * `close` and `fx-revaluation`), and the fiscal-year-close variant
+ * `/api/v1/ledger/close/trial-balance` is a different, non-interchangeable resource.
+ *
+ * The path is pinned by the consumer-driven pact in
+ * [com.openbank.finrep.contract.LedgerTrialBalancePactConsumerTest] (git-pact, ADR-0063), which
+ * derives the request path from THESE annotations by reflection and replays it against the pact
+ * mock server — so changing the path here fails that test, and ledger's
+ * `LedgerPactProviderVerificationTest` replay of the committed pact fails if ledger ever moves
+ * the endpoint. Review alone would not catch either direction (#2269).
+ */
 @RegisterRestClient(configKey = "ledger-service")
 @RegisterProvider(OidcClientRequestReactiveFilter::class)
-@Path("/api/v1/ledger")
+@Path("/api/v1/journals")
 @Produces(MediaType.APPLICATION_JSON)
 @Consumes(MediaType.APPLICATION_JSON)
 interface LedgerRestClient {

--- a/openbank-finrep-service/src/main/resources/application.yaml
+++ b/openbank-finrep-service/src/main/resources/application.yaml
@@ -53,6 +53,13 @@ openbank:
   service:
     name: finrep-service
     port: 8140
+  # API-contract major (ADR-0048 D2). MUST equal major(openapi.yaml:info.version) and the
+  # /api/v{N} segment both resources are mounted under; the api-contract gate asserts all three.
+  # Previously absent: the runtime fell back to the openbank-libs default of "1" (so the served
+  # X-API-Version was already v1) while the gate read no key and skipped that half of the check —
+  # moot anyway, since finrep had no openapi.yaml to assert anything against (#2255).
+  api:
+    version: "1"
 
 "%test":
   quarkus:

--- a/openbank-finrep-service/src/main/resources/openapi.yaml
+++ b/openbank-finrep-service/src/main/resources/openapi.yaml
@@ -1,0 +1,216 @@
+# SPDX-License-Identifier: Apache-2.0
+# Copyright (c) OpenBank contributors. Licensed under the Apache License, Version 2.0.
+# See LICENSE in the repository root or https://www.apache.org/licenses/LICENSE-2.0 for details.
+#
+# NOTE ON THE `is`/`has`-PREFIXED FIELD NAMES (isBalanced, isDataGap, hasDataGaps):
+# both resources return the DOMAIN objects directly (`Response.ok(template)`), so these key names
+# are produced by the Jackson/Kotlin naming interplay rather than by an explicit REST DTO. They were
+# measured, not assumed — `TemplateWireFormatTest` asserts the exact key SET this file documents and
+# fails if a Jackson/Kotlin upgrade ever changes it. Do not "tidy" `isBalanced` to `balanced` here:
+# that would make the published contract disagree with the bytes on the wire.
+openapi: 3.0.3
+info:
+  title: OpenBank FINREP / COREP Service
+  description: >-
+    Supervisory financial and prudential reporting (ADR-0097): renders EBA FINREP templates
+    (F01.01 Balance Sheet, F02.00 Profit & Loss) and the COREP C 01.00 Own Funds template from
+    openbank-ledger-service's GL trial balance. Derive-only and stateless — it holds no datastore,
+    moves no money, and has NO ČNB transmission channel; EBA XBRL/DPM taxonomy rendering is
+    explicitly out of scope for this increment.
+
+    Cells are always fully rendered: a value the platform cannot honestly derive is an explicit
+    flagged zero (`isDataGap`), never an omitted row, so a regulatory return never has a silent gap.
+  version: 1.0.0
+tags:
+  - name: FINREP
+  - name: COREP
+paths:
+  /api/v1/finrep/templates/{templateId}:
+    get:
+      tags: [FINREP]
+      summary: Render a FINREP template as of a reporting date
+      description: >-
+        Derives the template from the ledger GL trial balance as of `asOf`. Supported
+        `templateId` values are `F01.01` (Balance Sheet) and `F02.00` (Profit & Loss); any other
+        value is rejected.
+      operationId: getFinrepTemplate
+      parameters:
+        - name: templateId
+          in: path
+          required: true
+          description: EBA FINREP template identifier
+          schema: { type: string, enum: [F01.01, F02.00] }
+        - name: asOf
+          in: query
+          required: false
+          description: Reporting reference date, ISO yyyy-MM-dd. Defaults to today when omitted.
+          schema: { type: string, format: date }
+      responses:
+        '200':
+          description: The rendered FINREP template
+          content:
+            application/json:
+              schema: { $ref: '#/components/schemas/FinrepTemplate' }
+        '400':
+          description: >-
+            Unknown templateId. The use case rejects it with an IllegalArgumentException, which the
+            shared CommonExceptionMappers renders as this envelope.
+          content:
+            application/json:
+              schema: { $ref: '#/components/schemas/ApiError' }
+        '401':
+          description: Missing or invalid access token
+        '403':
+          description: Token lacks one of the SERVICE / ADMIN / OPERATOR roles
+
+  /api/v1/corep/templates/{templateId}:
+    get:
+      tags: [COREP]
+      summary: Render a COREP template as of a reporting date
+      description: >-
+        Derives the template from the ledger GL trial balance as of `asOf`. Only `C_01.00`
+        (Own Funds) is implemented in this increment; any other value is rejected.
+
+        The ledger's chart of accounts has no capital-structure GL accounts today, so every
+        capital row comes back as an explicit zero with `isDataGap: true` and a `gapReason` — a
+        documented gap, never to be read as an attested zero balance.
+      operationId: getCorepTemplate
+      parameters:
+        - name: templateId
+          in: path
+          required: true
+          description: EBA COREP template identifier
+          schema: { type: string, enum: [C_01.00] }
+        - name: asOf
+          in: query
+          required: false
+          description: Reporting reference date, ISO yyyy-MM-dd. Defaults to today when omitted.
+          schema: { type: string, format: date }
+      responses:
+        '200':
+          description: The rendered COREP template
+          content:
+            application/json:
+              schema: { $ref: '#/components/schemas/CorepTemplate' }
+        '400':
+          description: >-
+            Unknown or unimplemented templateId. The use case rejects it with an
+            IllegalArgumentException, which the shared CommonExceptionMappers renders as this
+            envelope.
+          content:
+            application/json:
+              schema: { $ref: '#/components/schemas/ApiError' }
+        '401':
+          description: Missing or invalid access token
+        '403':
+          description: Token lacks one of the SERVICE / ADMIN / OPERATOR roles
+
+components:
+  schemas:
+    FinrepCell:
+      type: object
+      description: One FINREP template cell — an (row, column) coordinate with its monetary value.
+      required: [rowRef, colRef, value, currency]
+      properties:
+        rowRef:
+          type: string
+          description: EBA FINREP row reference
+          example: r010
+        colRef:
+          type: string
+          description: EBA FINREP column reference
+          example: c010
+        value: { type: number }
+        currency: { type: string, example: CZK }
+
+    FinrepTemplate:
+      type: object
+      description: >-
+        One rendered FINREP template. F01.01 populates rows r010 (total assets), r380 (total
+        liabilities) and r490 (derived equity); F02.00 populates r010 (total income), r030 (total
+        expense) and r450 (net profit).
+      required: [templateId, period, cells, isBalanced]
+      properties:
+        templateId: { type: string, example: F01.01 }
+        period:
+          type: string
+          format: date
+          description: The reporting reference date the template was rendered as of
+        cells:
+          type: array
+          items: { $ref: '#/components/schemas/FinrepCell' }
+        isBalanced:
+          type: boolean
+          description: >-
+            Whether the template's internal accounting identity holds. Serialized as `isBalanced`,
+            not `balanced` — see the note at the top of this file.
+
+    CorepCell:
+      type: object
+      description: One COREP template cell — an (row, column) coordinate with its monetary value.
+      required: [rowRef, colRef, label, value, currency, isDataGap]
+      properties:
+        rowRef:
+          type: string
+          description: EBA COREP row reference
+          example: r010
+        colRef:
+          type: string
+          description: EBA COREP column reference
+          example: c010
+        label: { type: string, example: OWN FUNDS }
+        value: { type: number }
+        currency: { type: string, example: CZK }
+        isDataGap:
+          type: boolean
+          description: >-
+            True when the value could NOT be honestly derived from data available in the platform
+            today and is reported as an explicit flagged zero. MUST NOT be read as an attested
+            zero balance.
+        gapReason:
+          type: string
+          nullable: true
+          description: Why the cell is a gap. Present only when `isDataGap` is true.
+
+    CorepTemplate:
+      type: object
+      description: >-
+        One rendered COREP template. A structured representation of the template's cells — NOT an
+        EBA XBRL/DPM taxonomy rendering. Always fully rendered: every row is present even when its
+        value is a flagged gap.
+      required: [templateId, period, cells, hasDataGaps]
+      properties:
+        templateId: { type: string, example: C_01.00 }
+        period:
+          type: string
+          format: date
+          description: The reporting reference date the template was rendered as of
+        cells:
+          type: array
+          items: { $ref: '#/components/schemas/CorepCell' }
+        hasDataGaps:
+          type: boolean
+          description: >-
+            Derived — true when at least one cell has `isDataGap`. A template with data gaps is
+            still fully rendered, never silently truncated.
+
+    ApiError:
+      type: object
+      description: >-
+        Shared error envelope served by openbank-libs-runtime's CommonExceptionMappers
+        (`com.openbank.libs.api.error.ApiError`). Null fields are omitted.
+      required: [traceId, status, code, message]
+      properties:
+        traceId: { type: string }
+        status: { type: integer }
+        code: { type: string, example: VALIDATION_ERROR }
+        message: { type: string }
+        timestamp: { type: string, format: date-time }
+        details:
+          type: array
+          items:
+            type: object
+            properties:
+              field: { type: string }
+              message: { type: string }
+              rejectedValue: {}

--- a/openbank-finrep-service/src/test/kotlin/com/openbank/finrep/contract/LedgerTrialBalancePactConsumerTest.kt
+++ b/openbank-finrep-service/src/test/kotlin/com/openbank/finrep/contract/LedgerTrialBalancePactConsumerTest.kt
@@ -1,0 +1,223 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright (c) OpenBank contributors. Licensed under the Apache License, Version 2.0.
+// See LICENSE in the repository root or https://www.apache.org/licenses/LICENSE-2.0 for details.
+
+package com.openbank.finrep.contract
+
+import au.com.dius.pact.consumer.MockServer
+import au.com.dius.pact.consumer.dsl.LambdaDsl.newJsonBody
+import au.com.dius.pact.consumer.dsl.PactDslWithProvider
+import au.com.dius.pact.consumer.junit5.PactConsumerTestExt
+import au.com.dius.pact.consumer.junit5.PactTestFor
+import au.com.dius.pact.core.model.PactSpecVersion
+import au.com.dius.pact.core.model.RequestResponsePact
+import au.com.dius.pact.core.model.annotations.Pact
+import com.fasterxml.jackson.module.kotlin.jacksonObjectMapper
+import com.fasterxml.jackson.module.kotlin.readValue
+import com.openbank.finrep.application.port.out.TrialBalanceLineDto
+import com.openbank.finrep.domain.mapper.F0101Mapper
+import com.openbank.finrep.infrastructure.client.LedgerRestClient
+import com.openbank.finrep.infrastructure.client.TrialBalanceResponse
+import io.restassured.RestAssured.given
+import jakarta.ws.rs.Path
+import jakarta.ws.rs.QueryParam
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.extension.ExtendWith
+import java.math.BigDecimal
+import java.time.LocalDate
+
+/**
+ * Consumer-driven contract for the ledger GL trial balance that finrep's FINREP/COREP template
+ * rendering reads (ADR-0097). The generated pact is committed to `pacts/` (git-pact pattern,
+ * ADR-0063) and replayed by `LedgerPactProviderVerificationTest` (`@PactFolder("../pacts")`) in
+ * openbank-ledger-service — that test always runs, no Pact Broker involved.
+ *
+ * **Why this test exists (#2269):** finrep's client pointed at `/api/v1/ledger/trial-balance`,
+ * which openbank-ledger-service does not serve, so every F01.01 / F02.00 / C 01.00 render failed
+ * against a real ledger. Nothing caught it: `FinrepResourceTest`/`CorepResourceTest` construct the
+ * resource directly and the use-case tests mock `LedgerPort` — a mocked port cannot have a wrong
+ * URL — and the response DTO happened to be correct, so the code read as working. The one-line
+ * path fix on its own would regress just as silently; this pact is what keeps it fixed.
+ *
+ * **The two sides are deliberately sourced differently.** The interaction declares the contract as
+ * a literal ([LEDGER_TRIAL_BALANCE_PATH]); the REQUEST is issued against [ledgerTrialBalancePath],
+ * derived by reflection from [LedgerRestClient]'s own `@Path` annotations (and [asOfQueryParam] from
+ * its `@QueryParam`). That asymmetry is the whole mechanism: the pact mock server fails the test
+ * when the production client is annotated with anything other than the contract path, and the
+ * provider-side replay of the committed pact fails if ledger ever moves the endpoint.
+ *
+ * Deriving BOTH sides from the annotation — the first cut of this test — is worthless and looks
+ * identical: expectation and request move together, so it passed against the #2269 path. See the
+ * note on [LEDGER_TRIAL_BALANCE_PATH].
+ *
+ * IMPORTANT — regenerate on change: if this test's `@Pact` methods change (new interaction,
+ * different matcher, renamed field), re-run this test (`./gradlew :openbank-finrep-service:test
+ * --tests "*LedgerTrialBalancePactConsumerTest*"`) and commit the updated
+ * `pacts/openbank-finrep-service-openbank-ledger-service.json` in the same PR. There is no CI drift
+ * check yet (planned for ADR-0063 Phase 2) — an un-regenerated pact file silently verifies the OLD
+ * contract on the provider side.
+ *
+ * Note on `minArrayLike(0, 1)` vs `eachLike`: the provider test runs against a fresh Testcontainer
+ * DB with no seeded journal entries. `eachLike` implies min=1, which fails when the DB is empty.
+ * `minArrayLike(0, 1)` sets min=0 so the provider passes with zero or more lines; the element
+ * template still fixes the required field types for a non-empty response, and finrep's mappers fold
+ * over an empty list to an all-zero template.
+ *
+ * Only the three line fields finrep actually consumes (`code`, `type`, `net`) are declared — a
+ * consumer contract must not pin provider fields it does not read (`glAccountId`, `name`,
+ * `currency`, `totalDebit`, `totalCredit` are ledger's business).
+ */
+@ExtendWith(PactConsumerTestExt::class)
+@PactTestFor(providerName = "openbank-ledger-service", pactVersion = PactSpecVersion.V3)
+class LedgerTrialBalancePactConsumerTest {
+
+    private val json = jacksonObjectMapper()
+
+    @Pact(consumer = "openbank-finrep-service", provider = "openbank-ledger-service")
+    fun trialBalanceWithEntriesPact(builder: PactDslWithProvider): RequestResponsePact = builder
+        .given("ledger has journal entries for the reporting date")
+        .uponReceiving("GET the GL trial balance for a FINREP reporting date")
+        .path(LEDGER_TRIAL_BALANCE_PATH)
+        .query("$AS_OF_PARAM=$REPORTING_DATE")
+        .method("GET")
+        .headers(mapOf("Accept" to "application/json"))
+        .willRespondWith()
+        .status(200)
+        .headers(mapOf("Content-Type" to "application/json"))
+        .body(
+            newJsonBody { o ->
+                o.stringType("asOf", REPORTING_DATE)
+                o.booleanType("balanced", true)
+                o.minArrayLike("lines", 0, 1) { line ->
+                    line.stringType("code", "1100-CASH-CLEARING-CZK")
+                    line.stringType("type", "ASSET")
+                    line.decimalType("net", 150_000.00)
+                }
+            }.build(),
+        )
+        .toPact()
+
+    @Pact(consumer = "openbank-finrep-service", provider = "openbank-ledger-service")
+    fun trialBalanceEmptyLedgerPact(builder: PactDslWithProvider): RequestResponsePact = builder
+        .given("ledger has no journal entries")
+        .uponReceiving("GET the GL trial balance for a date with no ledger activity")
+        .path(LEDGER_TRIAL_BALANCE_PATH)
+        // A pre-platform date, so this interaction stays valid even when the provider run shares a
+        // Testcontainer DB with interactions that post journals (they are all dated "today").
+        .query("$AS_OF_PARAM=$PRE_HISTORY_DATE")
+        .method("GET")
+        .headers(mapOf("Accept" to "application/json"))
+        .willRespondWith()
+        .status(200)
+        .headers(mapOf("Content-Type" to "application/json"))
+        .body(
+            newJsonBody { o ->
+                o.stringType("asOf", PRE_HISTORY_DATE)
+                o.booleanType("balanced", true)
+                o.array("lines") // empty — a date before any ledger activity
+            }.build(),
+        )
+        .toPact()
+
+    @Test
+    @PactTestFor(pactMethod = "trialBalanceWithEntriesPact")
+    fun `the ledger client contract yields the fields the FINREP mappers consume`(mockServer: MockServer) {
+        // Guards the reflection helpers themselves: were they ever to return an empty or partial
+        // path, the interaction and the request would still agree with each other and both pact
+        // tests would pass against a contract that pins nothing.
+        assertThat(ledgerTrialBalancePath).isEqualTo(LEDGER_TRIAL_BALANCE_PATH)
+        assertThat(asOfQueryParam).isEqualTo(AS_OF_PARAM)
+
+        val response = fetchTrialBalance(mockServer, REPORTING_DATE)
+
+        assertThat(response.asOf).isNotBlank()
+        assertThat(response.balanced).isTrue()
+        // The three fields LedgerAdapter maps into TrialBalanceLineDto must all deserialize.
+        assertThat(response.lines).isNotEmpty()
+        val line = response.lines.first()
+        assertThat(line.code).isNotBlank()
+        assertThat(line.type).isNotBlank()
+        assertThat(line.net).isNotNull()
+
+        // ... and the mapper must accept them: proves the contract feeds a real F01.01 render,
+        // not merely that some JSON parsed.
+        val template = F0101Mapper.map(
+            response.lines.map { TrialBalanceLineDto(code = it.code, accountType = it.type, net = it.net) },
+            LocalDate.parse(REPORTING_DATE),
+        )
+        assertThat(template.cells.map { it.rowRef }).containsExactly("r010", "r380", "r490")
+        assertThat(template.cells.first().value).isEqualByComparingTo(BigDecimal("150000.00"))
+    }
+
+    @Test
+    @PactTestFor(pactMethod = "trialBalanceEmptyLedgerPact")
+    fun `a zero-line ledger still renders a fully populated zero template`(mockServer: MockServer) {
+        val response = fetchTrialBalance(mockServer, PRE_HISTORY_DATE)
+
+        assertThat(response.balanced).isTrue()
+        assertThat(response.lines).isEmpty()
+
+        // A regulatory report must never be silently truncated (ADR-0097): every row is present,
+        // honestly zero.
+        val template = F0101Mapper.map(emptyList(), LocalDate.parse(PRE_HISTORY_DATE))
+        assertThat(template.cells).hasSize(3)
+        assertThat(template.cells.map { it.value }).allSatisfy { assertThat(it).isEqualByComparingTo(BigDecimal.ZERO) }
+    }
+
+    /** Issues the request against the path the production client is annotated with. */
+    private fun fetchTrialBalance(mockServer: MockServer, asOf: String): TrialBalanceResponse {
+        val body = given()
+            .baseUri(mockServer.getUrl())
+            .accept("application/json")
+            .queryParam(asOfQueryParam, asOf)
+            .get(ledgerTrialBalancePath)
+            .then()
+            .statusCode(200)
+            .extract().body().asString()
+        return json.readValue(body)
+    }
+
+    private companion object {
+        /**
+         * The contract, written out LITERALLY on purpose: openbank-ledger-service serves the GL
+         * trial balance here (`operationId: getTrialBalance` in its `openapi.yaml`).
+         *
+         * It must NOT be derived from [LedgerRestClient] like [ledgerTrialBalancePath] is. Deriving
+         * both sides from the same annotation makes the interaction and the request move together,
+         * so the pact mock server always sees exactly what it expects and the test passes against a
+         * client pointing anywhere at all — verified by temporarily deleting the guard assertion
+         * below and re-running against the #2269 path: it went green. The literal is the fixed point
+         * the annotation is measured against.
+         */
+        const val LEDGER_TRIAL_BALANCE_PATH = "/api/v1/journals/trial-balance"
+
+        /** Ledger's query-parameter name for the as-of date — likewise literal. */
+        const val AS_OF_PARAM = "asOf"
+
+        /** A FINREP quarter-end reference date. */
+        const val REPORTING_DATE = "2026-06-30"
+
+        /** Before any ledger activity can exist, so the empty-lines assertion is stable. */
+        const val PRE_HISTORY_DATE = "2000-01-01"
+
+        private val getTrialBalanceMethod =
+            LedgerRestClient::class.java.getDeclaredMethod("getTrialBalance", String::class.java)
+
+        /**
+         * `@Path` on the interface + `@Path` on the method, joined the way JAX-RS resolves them.
+         * Read from the production client so the contract cannot drift from the code that calls it.
+         */
+        val ledgerTrialBalancePath: String = listOf(
+            LedgerRestClient::class.java.getAnnotation(Path::class.java).value,
+            getTrialBalanceMethod.getAnnotation(Path::class.java).value,
+        ).joinToString("/") { it.trim('/') }.let { "/$it" }
+
+        /** The query-parameter name the production client sends the as-of date under. */
+        val asOfQueryParam: String = getTrialBalanceMethod.parameterAnnotations
+            .flatMap { it.toList() }
+            .filterIsInstance<QueryParam>()
+            .single()
+            .value
+    }
+}

--- a/openbank-finrep-service/src/test/kotlin/com/openbank/finrep/contract/TemplateWireFormatTest.kt
+++ b/openbank-finrep-service/src/test/kotlin/com/openbank/finrep/contract/TemplateWireFormatTest.kt
@@ -1,0 +1,144 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright (c) OpenBank contributors. Licensed under the Apache License, Version 2.0.
+// See LICENSE in the repository root or https://www.apache.org/licenses/LICENSE-2.0 for details.
+
+package com.openbank.finrep.contract
+
+import com.fasterxml.jackson.databind.ObjectMapper
+import com.openbank.finrep.application.port.out.TrialBalanceLineDto
+import com.openbank.finrep.infrastructure.client.LedgerAdapter
+import io.mockk.coEvery
+import io.mockk.mockk
+import io.quarkus.test.junit.QuarkusMock
+import io.quarkus.test.junit.QuarkusTest
+import io.quarkus.test.security.TestSecurity
+import io.restassured.RestAssured.given
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Test
+import java.math.BigDecimal
+import java.time.LocalDate
+
+/**
+ * Spec-conformance test: asserts the WIRE FORMAT the two template endpoints actually emit, so
+ * `src/main/resources/openapi.yaml` documents reality rather than an assumption.
+ *
+ * Why this exists as a test and not a review note: [com.openbank.finrep.infrastructure.rest.FinrepResource]
+ * and [com.openbank.finrep.infrastructure.rest.CorepResource] return the DOMAIN objects directly
+ * (`Response.ok(template)`), so the JSON names of the `is`/`has`-prefixed Kotlin properties
+ * (`FinrepTemplate.isBalanced`, `CorepTemplate.hasDataGaps`, `CorepCell.isDataGap`) are decided by
+ * the Jackson/Kotlin naming interplay, not by anything visible in the source.
+ *
+ * Measured, not assumed — the answer is counter-intuitive: the emitted keys are **`isBalanced`**,
+ * **`isDataGap`** and **`hasDataGaps`**. Kotlin names the getter of an `is`-prefixed property
+ * `isBalanced()` with no `get` prefix, and plain Jackson's `isXxx()` boolean-getter convention
+ * would strip that to `balanced` — but jackson-module-kotlin contributes the primary-constructor
+ * parameter name as the implicit property name, which wins, so the `is` prefix survives on the
+ * wire. Asserting the exact key SET (not `contains`) means a Jackson/Kotlin upgrade that flips
+ * that precedence fails here instead of silently invalidating the published contract.
+ *
+ * Deliberately NOT fixed by mapping the resources to explicit REST DTOs with plain names (the
+ * pattern openbank-ledger-service uses, and the reason ledger never faces this question): that
+ * would change the wire format for existing consumers. This test documents what is served.
+ *
+ * The ledger read port is stubbed via [QuarkusMock] rather than a `@Mock` CDI alternative on
+ * purpose — an alternative would leave the real [LedgerAdapter] unused and eligible for ArC's
+ * unused-bean removal, weakening what `FinrepBootSmokeTest` boots to validate. Note that
+ * `QuarkusMock.installMockForType` checks the mock against the resolved BEAN class, not the
+ * injected type, so the mock must be a [LedgerAdapter] — a `mockk<LedgerPort>()` is rejected with
+ * `is not assignable to class ...LedgerAdapter`.
+ */
+@QuarkusTest
+@TestSecurity(user = "finrep-spec-conformance", roles = ["SERVICE"])
+class TemplateWireFormatTest {
+
+    private val mapper = ObjectMapper()
+
+    /** One line per GL account type so every mapper row is populated with a non-zero value. */
+    private val trialBalance = listOf(
+        TrialBalanceLineDto(code = "1100-CASH-CZK", accountType = "ASSET", net = BigDecimal("150000.00")),
+        TrialBalanceLineDto(code = "2100-DEPOSITS-CZK", accountType = "LIABILITY", net = BigDecimal("120000.00")),
+        TrialBalanceLineDto(code = "4100-FEE-INCOME-CZK", accountType = "INCOME", net = BigDecimal("8000.00")),
+        TrialBalanceLineDto(code = "5100-STAFF-COST-CZK", accountType = "EXPENSE", net = BigDecimal("3000.00")),
+    )
+
+    @BeforeEach
+    fun installLedgerStub() {
+        val ledger = mockk<LedgerAdapter>()
+        coEvery { ledger.getTrialBalance(any()) } returns trialBalance
+        QuarkusMock.installMockForType(ledger, LedgerAdapter::class.java)
+    }
+
+    private fun getJson(path: String, asOf: LocalDate): Map<*, *> {
+        val body = given()
+            .accept("application/json")
+            .queryParam("asOf", asOf.toString())
+            .get(path)
+            .then()
+            .statusCode(200)
+            .extract().body().asString()
+        return mapper.readValue(body, Map::class.java)
+    }
+
+    @Test
+    fun `the FINREP template wire format matches the published openapi schema`() {
+        val json = getJson("/api/v1/finrep/templates/F01.01", LocalDate.of(2026, 6, 30))
+
+        assertThat(json.keys).containsExactlyInAnyOrder("templateId", "period", "cells", "isBalanced")
+        assertThat(json["templateId"]).isEqualTo("F01.01")
+        assertThat(json["period"]).isEqualTo("2026-06-30")
+        assertThat(json["isBalanced"]).isEqualTo(true)
+
+        @Suppress("UNCHECKED_CAST")
+        val cells = json["cells"] as List<Map<*, *>>
+        assertThat(cells).hasSize(3)
+        assertThat(cells.first().keys).containsExactlyInAnyOrder("rowRef", "colRef", "value", "currency")
+        assertThat(cells.map { it["rowRef"] }).containsExactly("r010", "r380", "r490")
+        assertThat(cells.first()["currency"]).isEqualTo("CZK")
+        // r010 total assets, r380 total liabilities, r490 derived equity — proves the cells are
+        // really derived from the ledger trial balance, not a fixed skeleton. `value` is a JSON
+        // NUMBER (schema `type: number`), so compare numerically — an untyped parse of `150000.00`
+        // yields a Double whose toString drops the scale.
+        assertThat(cells.map { (it["value"] as Number).toDouble() })
+            .containsExactly(150_000.00, 120_000.00, 30_000.00)
+    }
+
+    @Test
+    fun `the COREP template wire format matches the published openapi schema`() {
+        val json = getJson("/api/v1/corep/templates/C_01.00", LocalDate.of(2026, 6, 30))
+
+        assertThat(json.keys).containsExactlyInAnyOrder("templateId", "period", "cells", "hasDataGaps")
+        assertThat(json["templateId"]).isEqualTo("C_01.00")
+        assertThat(json["period"]).isEqualTo("2026-06-30")
+        // No EQUITY line in the stubbed trial balance — every capital row is a flagged zero.
+        assertThat(json["hasDataGaps"]).isEqualTo(true)
+
+        @Suppress("UNCHECKED_CAST")
+        val cells = json["cells"] as List<Map<*, *>>
+        assertThat(cells).hasSize(9)
+        assertThat(cells.first().keys)
+            .containsExactlyInAnyOrder("rowRef", "colRef", "label", "value", "currency", "isDataGap", "gapReason")
+        assertThat(cells.first()["rowRef"]).isEqualTo("r010")
+        assertThat(cells.first()["label"]).isEqualTo("OWN FUNDS")
+        assertThat(cells.first()["isDataGap"]).isEqualTo(true)
+        assertThat(cells.first()["gapReason"].toString()).contains("No capital-structure GL accounts")
+    }
+
+    @Test
+    fun `an unknown templateId is a 400 with the shared ApiError envelope`() {
+        // The openapi.yaml documents 400 for an unknown templateId on both endpoints. That status
+        // is not chosen here — it comes from openbank-libs-runtime's CommonExceptionMappers mapping
+        // the use case's IllegalArgumentException — so assert it rather than assume it.
+        listOf("/api/v1/finrep/templates/F99.99", "/api/v1/corep/templates/C_99.99").forEach { path ->
+            val body = given()
+                .accept("application/json")
+                .get(path)
+                .then()
+                .statusCode(400)
+                .extract().body().asString()
+            val error = mapper.readValue(body, Map::class.java)
+            assertThat(error.keys).contains("traceId", "status", "code", "message")
+            assertThat(error["status"]).isEqualTo(400)
+        }
+    }
+}

--- a/pacts/openbank-finrep-service-openbank-ledger-service.json
+++ b/pacts/openbank-finrep-service-openbank-ledger-service.json
@@ -1,0 +1,161 @@
+{
+  "consumer": {
+    "name": "openbank-finrep-service"
+  },
+  "interactions": [
+    {
+      "description": "GET the GL trial balance for a FINREP reporting date",
+      "providerStates": [
+        {
+          "name": "ledger has journal entries for the reporting date"
+        }
+      ],
+      "request": {
+        "headers": {
+          "Accept": "application/json"
+        },
+        "method": "GET",
+        "path": "/api/v1/journals/trial-balance",
+        "query": {
+          "asOf": [
+            "2026-06-30"
+          ]
+        }
+      },
+      "response": {
+        "body": {
+          "asOf": "2026-06-30",
+          "balanced": true,
+          "lines": [
+            {
+              "code": "1100-CASH-CLEARING-CZK",
+              "net": 150000.0,
+              "type": "ASSET"
+            }
+          ]
+        },
+        "headers": {
+          "Content-Type": "application/json"
+        },
+        "matchingRules": {
+          "body": {
+            "$.asOf": {
+              "combine": "AND",
+              "matchers": [
+                {
+                  "match": "type"
+                }
+              ]
+            },
+            "$.balanced": {
+              "combine": "AND",
+              "matchers": [
+                {
+                  "match": "type"
+                }
+              ]
+            },
+            "$.lines": {
+              "combine": "AND",
+              "matchers": [
+                {
+                  "match": "type",
+                  "min": 0
+                }
+              ]
+            },
+            "$.lines[*].code": {
+              "combine": "AND",
+              "matchers": [
+                {
+                  "match": "type"
+                }
+              ]
+            },
+            "$.lines[*].net": {
+              "combine": "AND",
+              "matchers": [
+                {
+                  "match": "decimal"
+                }
+              ]
+            },
+            "$.lines[*].type": {
+              "combine": "AND",
+              "matchers": [
+                {
+                  "match": "type"
+                }
+              ]
+            }
+          }
+        },
+        "status": 200
+      }
+    },
+    {
+      "description": "GET the GL trial balance for a date with no ledger activity",
+      "providerStates": [
+        {
+          "name": "ledger has no journal entries"
+        }
+      ],
+      "request": {
+        "headers": {
+          "Accept": "application/json"
+        },
+        "method": "GET",
+        "path": "/api/v1/journals/trial-balance",
+        "query": {
+          "asOf": [
+            "2000-01-01"
+          ]
+        }
+      },
+      "response": {
+        "body": {
+          "asOf": "2000-01-01",
+          "balanced": true,
+          "lines": [
+
+          ]
+        },
+        "headers": {
+          "Content-Type": "application/json"
+        },
+        "matchingRules": {
+          "body": {
+            "$.asOf": {
+              "combine": "AND",
+              "matchers": [
+                {
+                  "match": "type"
+                }
+              ]
+            },
+            "$.balanced": {
+              "combine": "AND",
+              "matchers": [
+                {
+                  "match": "type"
+                }
+              ]
+            }
+          }
+        },
+        "status": 200
+      }
+    }
+  ],
+  "metadata": {
+    "pact-jvm": {
+      "version": "4.7.3"
+    },
+    "pactSpecification": {
+      "version": "3.0.0"
+    }
+  },
+  "provider": {
+    "name": "openbank-ledger-service"
+  }
+}


### PR DESCRIPTION
Closes #2269
Refs #2255

## The defect

`openbank-finrep-service`'s only outbound client was annotated
`@Path("/api/v1/ledger")` + `@Path("/trial-balance")`, i.e.
`GET /api/v1/ledger/trial-balance` — **a path `openbank-ledger-service` does not
serve.** Its `/api/v1/ledger` root only carries `close` and `fx-revaluation`; the
GL trial balance lives at `/api/v1/journals/trial-balance` (`operationId:
getTrialBalance`), which `openbank-balance-service` already calls and pins in its
committed pact. The fiscal-year-close `/api/v1/ledger/close/trial-balance` is a
different, non-interchangeable resource.

## Blast radius

`LedgerAdapter.getTrialBalance` is the **sole** implementation of `LedgerPort`,
and both `FinrepResource` and `CorepResource` derive every cell from it — so
F01.01 Balance Sheet, F02.00 P&L and C 01.00 Own Funds *all* failed against a
real ledger. This is the ADR-0097 supervisory-reporting surface.

## Why nothing caught it

- No `openapi.yaml` and no contract test — finrep was the fleet's only C3=0.
- `FinrepResourceTest`/`CorepResourceTest` construct the resource directly, and
  the use-case tests mock `LedgerPort`. **A mocked port cannot have a wrong URL.**
- The response DTO happened to be *correct* (`asOf`, `balanced`,
  `lines[].{code,type,net}` all exist in ledger's `TrialBalanceResponse`), so the
  bug was confined to the path and read as working code.

## Why the pact, not the one-line change

The path fix alone would regress just as silently. `LedgerTrialBalancePactConsumerTest`
adds two interactions, replayed by ledger's `LedgerPactProviderVerificationTest`
(`@PactFolder("../pacts")`, no broker):

| interaction | provider state |
|---|---|
| `GET the GL trial balance for a FINREP reporting date` | `ledger has journal entries for the reporting date` |
| `GET the GL trial balance for a date with no ledger activity` | `ledger has no journal entries` |

Both states already exist on the provider; only the three fields finrep actually
consumes are pinned, and `minArrayLike(0, 1)` keeps it satisfiable against the
provider's empty Testcontainer DB.

**The mechanism is an asymmetry, and it is load-bearing.** The interaction
declares the path as a *literal*; the request is issued against the path
*reflected off `LedgerRestClient`'s own annotations*. Deriving both sides from the
annotation was my first cut and is **worthless** — expectation and request move
together, so it passed green against the #2269 path. Verified in both directions:

- broken client path -> pact mock server answers **500**, consumer test red;
- pact carrying the broken path -> **2 of 10** provider interactions red.

## C3 / `openapi.yaml` (#2255)

New `openbank-finrep-service/src/main/resources/openapi.yaml`, `info.version:
1.0.0`, both endpoints, ADR-0048 D2 invariant satisfied
(`major(info.version)` == new explicit `openbank.api.version` == `/api/v1`).

The `is`/`has`-prefixed Kotlin properties were **measured, not assumed** — both
resources return the domain objects directly, so the wire names come from the
Jackson/Kotlin interplay. `TemplateWireFormatTest` (RestAssured, kept as a
spec-conformance test) establishes:

| Kotlin property | JSON key |
|---|---|
| `FinrepTemplate.isBalanced` | **`isBalanced`** |
| `CorepCell.isDataGap` | **`isDataGap`** |
| `CorepTemplate.hasDataGaps` | `hasDataGaps` |

Counter-intuitive: plain Jackson's `isXxx()` boolean-getter rule would strip these
to `balanced`/`dataGap`, but jackson-module-kotlin contributes the
primary-constructor parameter name, which wins. The spec documents that. The
resources are deliberately **not** refactored to explicit REST DTOs (ledger's
pattern, which sidesteps the question) — that would change the wire format.

## Second commit: the drift gate's scope

`pact-drift-check.yml` (merged in #2283, hours ago) enumerates the modules it
regenerates, and its diff step only ever sees `pacts/` files that step rewrote.
A consumer missing from the list is therefore **not merely unchecked — it reads as
PASSING**. finrep is added alongside its pact, with a header note so the next one
arrives the same way.

## Gates

| command | verdict |
|---|---|
| `:openbank-finrep-service:build` | SUCCESS |
| `:openbank-finrep-service:quarkusBuild` (`--rerun-tasks`, `quarkus-app/` populated) | SUCCESS |
| `:openbank-finrep-service:detekt ktlintCheck koverVerify` | SUCCESS |
| `detekt ktlintCheck` (fleet-wide, 469 tasks) | SUCCESS |
| `:openbank-ledger-service:test --tests "*LedgerPactProviderVerificationTest*"` | SUCCESS — **10 tests, 0 failures, 0 skipped** (was 8; both finrep interactions verified) |
| drift-gate command + `git diff -- pacts/` | no drift |

Not hand-edited: `version.txt`, `CHANGELOG.md`, `quarkus.application.version`.
release-please will cut finrep from the `fix` type + `src/main` paths.