### PR TITLE
fix(infra): stop scoring a comment as a contract test

### DIFF
--- a/openbank-infra/scripts/prod-readiness-collector.py
+++ b/openbank-infra/scripts/prod-readiness-collector.py
@@ -221,21 +221,62 @@ def score_c2_tests(short: str, att, today) -> tuple[int, str]:
     return s, f"{len(unit)} unit, {len(it)} IT, kover={'y' if kover else 'n'}"
 
 
+def has_contract_test(short: str) -> tuple[bool, str]:
+    """True when the service ships an actual contract test, with what proves it.
+
+    This used to be `grep_any(src/test, ["Pact", "ContractTest", "contract"])` — a substring
+    scan that counted the word "contract" ANYWHERE, including comments and KDoc. Five services
+    matched on prose alone, and three of them (pid, psd2, sanctions) scored C3=Verified purely
+    on a sentence like `// the mark-and-sweep reconciliation contract` while shipping no
+    contract test at all. ap2 flipped 1→2 the moment an unrelated PR added the comment
+    `// Cardinality + evidence contract: …`, which nobody wrote with a score in mind — the
+    clearest possible demonstration that prose must never be evidence.
+
+    So this asks for artifacts a contract test cannot exist without: the pact library imported,
+    or the fleet's test-class naming (`*Pact*Test.kt`, `*ContractTest.kt`). It is the same
+    correction the C8 scorer needed, where a comment in the PodMonitor claiming a service was
+    scraped scored it as scraped (#2255).
+    """
+    test = svc_dir(short) / "src" / "test"
+    if not test.is_dir():
+        return False, ""
+    by_import: list[str] = []
+    by_name: list[str] = []
+    for f in test.rglob("*.kt"):
+        if "au.com.dius.pact" in read(f):
+            by_import.append(f.name)
+        elif "Pact" in f.name or f.name.endswith("ContractTest.kt"):
+            by_name.append(f.name)
+    if by_import:
+        return True, f"{len(by_import)} pact test(s)"
+    if by_name:
+        return True, f"{len(by_name)} contract test(s) by naming"
+    return False, ""
+
+
+def committed_pacts(short: str) -> list[str]:
+    """Pact files in the repo-root `pacts/` dir naming this service on either side (ADR-0063)."""
+    pacts = REPO / "pacts"
+    if not pacts.is_dir():
+        return []
+    token = f"openbank-{short}-service"
+    return sorted(p.name for p in pacts.glob("*.json") if token in p.name)
+
+
 def score_c3_api(short: str, att, today) -> tuple[int, str]:
     d = svc_dir(short)
     openapi = (d / "src" / "main" / "resources" / "openapi.yaml").exists()
-    contract = grep_any(d / "src" / "test", ["Pact", "ContractTest", "contract"])
-    diff_gate = any(n in read(d / "build.gradle.kts") for n in ("oasdiff", "spectral"))
+    contract, how = has_contract_test(short)
+    pacts = committed_pacts(short)
     if not openapi:
         return 0, "no openapi.yaml"
-    s = 1
-    if contract:
-        s = 2
-    if contract and diff_gate:
-        s = 2  # cap; bank-grade (3) needs external consumer-verified pacts
+    s = 2 if contract else 1
     if attest_fresh(att, short, "contract_verified", today):
-        s = 3
-    return s, f"openapi=y, contract={'y' if contract else 'n'}, diffgate={'y' if diff_gate else 'n'}"
+        s = 3  # bank-grade needs an external consumer-verified pact (attested)
+    ev = ["openapi=y", how if contract else "NO contract test in src/test"]
+    if pacts:
+        ev.append(f"{len(pacts)} committed pact(s)")
+    return s, ", ".join(ev)
 
 
 def score_c4_data(short: str, att, today) -> tuple[int, str]:

--- a/openbank-infra/scripts/prod_readiness_collector_test.py
+++ b/openbank-infra/scripts/prod_readiness_collector_test.py
@@ -166,6 +166,80 @@ class CollectorScorerTest(unittest.TestCase):
         self.assertEqual(score, 1)
         self.assertIn("skeleton", evidence)
 
+    # -- C3: a contract test is an artifact, not a word in a comment --------
+    def openapi(self):
+        p = self.svc / "src" / "main" / "resources" / "openapi.yaml"
+        p.parent.mkdir(parents=True, exist_ok=True)
+        p.write_text("openapi: 3.0.3\ninfo:\n  title: Widget\n  version: 1.0.0\npaths: {}\n")
+
+    def write_test_kt(self, name: str, body: str):
+        p = self.svc / "src" / "test" / "kotlin" / "com" / "openbank" / "widget" / name
+        p.parent.mkdir(parents=True, exist_ok=True)
+        p.write_text(body)
+
+    def test_c3_the_word_contract_in_a_comment_is_not_a_contract_test(self):
+        """The exact line that scored pid, psd2 and sanctions as Verified."""
+        self.governance()
+        self.openapi()
+        self.write_test_kt(
+            "WidgetServiceTest.kt",
+            "// the mark-and-sweep reconciliation contract\nclass WidgetServiceTest\n",
+        )
+        score, evidence = self.mod.score_c3_api("widget", {}, "2026-07-25")
+        self.assertEqual(score, 1, evidence)
+        self.assertIn("NO contract test", evidence)
+
+    def test_c3_the_word_contract_in_kdoc_is_not_a_contract_test(self):
+        """psd2's actual hit was a KDoc line, not a `//` comment."""
+        self.governance()
+        self.openapi()
+        self.write_test_kt(
+            "KafkaOutboxPublisherTest.kt",
+            "/**\n * exactly as the shared header contract prescribes.\n */\nclass K\n",
+        )
+        score, evidence = self.mod.score_c3_api("widget", {}, "2026-07-25")
+        self.assertEqual(score, 1, evidence)
+
+    def test_c3_a_pact_import_is_a_contract_test(self):
+        self.governance()
+        self.openapi()
+        self.write_test_kt(
+            "WidgetLedgerPactConsumerTest.kt",
+            "import au.com.dius.pact.consumer.junit5.PactConsumerTestExt\nclass W\n",
+        )
+        score, evidence = self.mod.score_c3_api("widget", {}, "2026-07-25")
+        self.assertEqual(score, 2, evidence)
+        self.assertIn("pact test", evidence)
+
+    def test_c3_the_fleet_test_class_naming_is_a_contract_test(self):
+        """A spec-conformance test named *ContractTest.kt counts without the pact library."""
+        self.governance()
+        self.openapi()
+        self.write_test_kt("WidgetApiContractTest.kt", "class WidgetApiContractTest\n")
+        score, evidence = self.mod.score_c3_api("widget", {}, "2026-07-25")
+        self.assertEqual(score, 2, evidence)
+        self.assertIn("by naming", evidence)
+
+    def test_c3_no_openapi_still_scores_zero(self):
+        self.governance()
+        self.write_test_kt("WidgetPactConsumerTest.kt", "import au.com.dius.pact.consumer.X\nclass W\n")
+        score, evidence = self.mod.score_c3_api("widget", {}, "2026-07-25")
+        self.assertEqual(score, 0, evidence)
+
+    def test_c3_reports_committed_pacts_as_extra_evidence(self):
+        self.governance()
+        self.openapi()
+        self.write_test_kt(
+            "WidgetPactConsumerTest.kt", "import au.com.dius.pact.consumer.X\nclass W\n"
+        )
+        pacts = self.root / "pacts"
+        pacts.mkdir(parents=True, exist_ok=True)
+        (pacts / "openbank-widget-service-openbank-ledger-service.json").write_text("{}")
+        (pacts / "openbank-other-service-openbank-thing-service.json").write_text("{}")
+        score, evidence = self.mod.score_c3_api("widget", {}, "2026-07-25")
+        self.assertEqual(score, 2, evidence)
+        self.assertIn("1 committed pact", evidence)
+
     # -- C4: the data dimension of a service with no data -------------------
     def test_c4_stateless_service_is_not_penalised_for_having_no_migration(self):
         self.governance(datastore="none")


### PR DESCRIPTION
## What

The C3 scorer counted the word **"contract"** anywhere in a test file — comments and KDoc
included. Replaced with a check for artifacts a contract test cannot exist without.

`Refs #2255`

## The false positives, quoted

Three services had been sitting at **Verified with no contract test at all**:

| service | the line that scored it |
|---|---|
| pid | `* ROLE_OPERATOR, so a 200 here also guards the RBAC contract …` |
| psd2 | `* outgoing record exactly as the shared header contract prescribes.` |
| sanctions | `// ──── deactivateMissing — the mark-and-sweep reconciliation contract ────` |

**ap2 is the clearest case.** It scored 1 this morning and 2 this afternoon. The only thing that
changed was an unrelated instrumentation PR (#2282) adding
`// Cardinality + evidence contract: the issuer arrives in the request body …`. Nobody wrote that
line with a score in mind. A metric that moves on a sentence nobody aimed at it is not measuring
anything.

This is the **same defect as the C8 scorer fixed in #2266**, where a comment in the PodMonitor
claiming a service was scraped scored it as scraped while its metrics reached nothing. Same shape:
prose treated as evidence.

## The fix

A contract test must leave an artifact: the pact library imported (`au.com.dius.pact`), or the
fleet's test-class naming (`*Pact*Test.kt` / `*ContractTest.kt`). Committed pacts under `pacts/`
naming the service on either side are reported as extra evidence. Evidence now reads
`NO contract test in src/test` rather than `contract=n`, which read like a flag instead of a gap.

Also **drops the `diffgate` term**: it looked for `oasdiff`/`spectral` in `build.gradle.kts`, which
no service has and none should — the OpenAPI diff classifier is
`.github/scripts/check-api-contract.py`, a fleet-wide CI gate. It could never fire, and it could
not change the score either: `if contract and diff_gate: s = 2` was already the value of `contract`
alone. It only printed a false `diffgate=n` on every row.

## Verification

- 6 new cases, **5 fail against the scorer as it stood**. The 6th (no `openapi.yaml` still scores
  0) is a regression guard that passes both ways by design.
- Two of them are the **literal comment and KDoc lines** quoted above, so this specific false
  positive cannot return.
- Full `openbank-infra/scripts` suite: **85 tests, OK**.

## Fleet effect — the number goes the wrong way, on purpose

**C3 cells below Verified: 5 → 9.** pid, psd2, sanctions and ap2 join aml, copilot, finrep, mcp and
vop. **GO: 20 → 16 of 37.**

Nothing regressed. Four services never had contract coverage and the matrix has been saying they
did. Worth stating plainly against the goal of this sweep ("at least 2 everywhere"): part of what
looked like progress was prose. The remaining nine are now real work, tracked in #2255.
