### PR TITLE
docs(governance): record the two detekt footguns every metrics adapter hits

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -137,6 +137,19 @@ These are real, repeatable gotchas — worth knowing before they cost you a debu
   `function-signature` violation surfaces the first time you touch an older file. Let `ktlintFormat`
   collapse multi-line signatures; expand wildcard imports rather than hand-wrapping.
 
+### detekt
+- **`MagicNumber` fires on the fleet-standard percentile triple.** `publishPercentiles(0.5, 0.95, 0.99)`
+  is 3 violations per call site — `DomainMetrics` only escapes via
+  `openbank-libs-runtime/detekt-baseline.xml`, a new per-service adapter has no such cover. Declare
+  `private const val P50/P95/P99` in the adapter's `companion object` (`ignoreConstantDeclaration` is
+  on by default). The `Timer.builder` and `DistributionSummary.builder` call sites usually differ in
+  indentation — a single find-and-replace fixes only one.
+- **`LongParameterList` fires AT the threshold, not above it.** `config/detekt/detekt.yml` sets
+  `constructorThreshold: 9`, so a 9-parameter constructor is reported — adding a metrics port to an
+  8-param endpoint fails the gate. Use field injection
+  (`@Inject lateinit var metrics: XMetricsPort`) as `LoanStageEventConsumer`, `VopRateLimitFilter`
+  and `McpEndpoint` do.
+
 ### Flyway
 - **Never change a migration after it has been applied to a live DB** — Flyway checksums the whole
   file (comments included), so any edit triggers a `checksum mismatch` startup failure.

--- a/config/detekt/detekt.yml
+++ b/config/detekt/detekt.yml
@@ -56,7 +56,7 @@ complexity:
   LongParameterList:
     # Kotlin data classes / hexagonal command objects legitimately carry many
     # constructor parameters; defaulted ones don't add call-site complexity.
-    # Threshold raised to 8: ADR-0100 clock injection adds Clock to CDI
+    # Threshold raised to 9: ADR-0100 clock injection adds Clock to CDI
     # constructors that cannot be split (framework-injected, hexagonal boundary).
     constructorThreshold: 9
     functionThreshold: 9


### PR DESCRIPTION
## What

Adds a `### detekt` subsection to the "Engineering notes (common pitfalls)" part of the root `CLAUDE.md`, immediately after the existing `### ktlint` one.

Two footguns, each of which cost a red gate run while adding the service-local Micrometer metrics adapters (#2270 / #2275 / #2279 / #2282 / #2285):

1. **`MagicNumber` on the fleet-standard percentile triple.** `publishPercentiles(0.5, 0.95, 0.99)` is 3 violations per call site. `openbank-libs-runtime`'s `DomainMetrics` only escapes it via `openbank-libs-runtime/detekt-baseline.xml` (lines 19-21) — a new per-service adapter has no such cover. Fix: `private const val P50/P95/P99` in the adapter's `companion object`; `MagicNumber` has `ignoreConstantDeclaration: true` by default.
2. **`LongParameterList` fires AT the threshold, not above it.** `config/detekt/detekt.yml` sets `constructorThreshold: 9`, so a constructor with exactly 9 parameters is reported. Fix: field injection, as `LoanStageEventConsumer`, `VopRateLimitFilter` and `McpEndpoint` already do.

## Why here

`rules.yaml: knowledge_capture` routes an operational footgun to a one-line bullet in the matching pitfall section. Both fire fleet-wide (any service gaining a metrics adapter), not inside one tree, so root `CLAUDE.md` is the right home rather than a `<service>/CLAUDE.md`. Nothing here is secret or environment-specific.

## Release impact

None — `docs` is a hidden commit type, so release-please cuts nothing. Correct for a docs-only change.

Refs #2255