### PR TITLE
docs(governance): correct the pact-path advice — a derived expectation proves nothing

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -153,9 +153,16 @@ These are real, repeatable gotchas — worth knowing before they cost you a debu
   replays is therefore worthless against the likeliest defect — and that is exactly how
   finrep-service shipped a call to `/api/v1/ledger/trial-balance`, a ledger path that has never
   existed, breaking every FINREP/COREP render while its unit tests passed against a mocked port
-  (#2269). Corollary: derive the path in the consumer test from the client's own `@Path` rather than
-  retyping it, and never add a consumer pact without wiring (or confirming) the provider's
-  `@PactFolder` replay.
+  (#2269). Never add a consumer pact without wiring (or confirming) the provider's `@PactFolder`
+  replay.
+- **In a consumer test the expected path must be a LITERAL; only the outgoing request may be
+  reflected off the client's `@Path`.** Deriving *both* sides from the annotation feels DRY and is
+  vacuous — expectation and request move together, so the test stays green when the client points
+  at a route that does not exist. Measured on #2290: with the assertion removed, a pact whose path
+  came from the annotation passed against the broken `/api/v1/ledger/trial-balance`; with the path
+  written as a literal, both interactions went red. The asymmetry IS the test.
+  (`ProductCatalogPactConsumerTest` from #2283 still has the symmetric shape, and its KDoc promises
+  a redness it cannot deliver at the consumer layer — the provider replay is what backstops it.)
 - **Read the pact verdict from the JUnit XML, not the console.** pact-jvm prints
   `Not all of the N were verified` even on a fully green run — it is an artifact, not a failure.
   (`./gradlew … | tail` also masks the exit code; see the Kotlin block-comment note.)


### PR DESCRIPTION
## What

Corrects a bullet I added in #2296. `Refs #2255`

## The mistake

#2296 said: *"derive the path in the consumer test from the client's own `@Path` rather than retyping it."*

That is wrong. When **both** the expected path and the outgoing request come from the annotation, they move together — so the test stays green against a client pointed at a route that does not exist. It is the DRY-looking version of having no assertion at all, and #2296 recommended it in the very bullet warning about #2269.

## Measured, both directions (#2290)

| consumer-test shape | client path broken to `/api/v1/ledger/trial-balance` |
|---|---|
| expected path **reflected** off `@Path`, guard assertion removed | **passed** — vacuous |
| expected path written as a **literal** | both interactions **RED** |

The asymmetry — literal expectation, reflected request — is what does the pinning.

## Also named: where the bad shape still lives

`ProductCatalogPactConsumerTest` (#2283) has the symmetric shape, and its KDoc promises *"rename the path … and this test goes red"*, which it cannot deliver at the consumer layer. Its provider replay is what actually backstops it. A separate background task tracks the fix; the note is in `CLAUDE.md` now so nobody copies the shape in the meantime.

## Note on the correction itself

This is the third-order version of the lesson the file already teaches: a guard that cannot express the failure reads as success. I wrote one into the guidance while documenting exactly that failure mode, and it took a subagent deleting its own assertion and watching the test stay green to catch it. `docs` is a hidden type, so no release.