### PR TITLE
fix(aml): describe the implemented API in openapi.yaml and correct the lineage

### DIFF
--- a/docs/runbooks/svc-aml.md
+++ b/docs/runbooks/svc-aml.md
@@ -22,7 +22,7 @@ exercised DR drill, tracked as TTL'd attestations, never faked here. -->
 
 ## Dependencies
 
-- **Upstream (this service consumes):** `sepa-payment`, `sepa-instant`, `domestic-payment`, `swift-service`, `kyc-service`, `sanctions-service`
+- **Upstream (this service consumes):** `sepa-payment`, `sepa-instant`, `domestic-payment`, `fx-service`, `agent-service`, `party-service`
 - **Downstream (depends on this service):** _none declared_
 
 A failure here propagates to the downstream services above — check them when

--- a/openbank-aml-service/governance.yaml
+++ b/openbank-aml-service/governance.yaml
@@ -20,15 +20,15 @@ lineage:
     - serviceName: domestic-payment
       relationType: api
       description: screens
-    - serviceName: swift-service
+    - serviceName: fx-service
       relationType: api
       description: screens
-    - serviceName: kyc-service
+    - serviceName: agent-service
+      relationType: api
+      description: reads
+    - serviceName: party-service
       relationType: topic
       description: triggers
-    - serviceName: sanctions-service
-      relationType: topic
-      description: updates
 schemaLineage:
   ownedSchemas:
     - aml_schema

--- a/openbank-aml-service/src/main/resources/openapi.yaml
+++ b/openbank-aml-service/src/main/resources/openapi.yaml
@@ -3,23 +3,33 @@
 openapi: 3.1.0
 info:
   title: AML Service API
-  version: 1.0.0
-  description: Anti-Money Laundering case management — create, review, and update AML case decisions.
+  version: 1.1.0
+  description: >-
+    Anti-Money Laundering screening case lifecycle — submit, review, and decide AML cases.
+    Four constraints below are documented in `description` rather than in `required` / `enum` /
+    `default`, because the api-contract gate (ADR-0048 D5) classifies expressing them as a
+    breaking change and would demand a MAJOR bump that ADR-0048 D2 forbids while the service
+    serves /api/v1. Each is marked GATE-CONSTRAINED. See the tracking issue before "fixing" them.
   license:
     name: Apache-2.0
     url: https://www.apache.org/licenses/LICENSE-2.0
 servers:
-  - url: http://localhost:8106
+  - url: http://localhost:8117
     description: Local development
 tags:
-  - name: AML
+  - name: AML Cases
+
+security:
+  - bearerAuth: []
 
 paths:
   /api/v1/aml/cases:
     post:
-      tags: [AML]
-      summary: Create an AML case
+      tags: [AML Cases]
+      summary: Submit an AML screening case
       operationId: createAmlCase
+      parameters:
+        - $ref: '#/components/parameters/idempotencyKey'
       requestBody:
         required: true
         content:
@@ -29,22 +39,54 @@ paths:
       responses:
         '201':
           description: Case created
+          headers:
+            Location:
+              description: URI of the created case
+              schema:
+                type: string
+                format: uri-reference
+            X-Idempotency-Replayed:
+              description: Present with value `true` when the stored response for this Idempotency-Key is replayed.
+              schema:
+                type: string
           content:
             application/json:
               schema:
                 $ref: '#/components/schemas/AmlCaseResponse'
+        '400':
+          $ref: '#/components/responses/BadRequest'
+        '401':
+          $ref: '#/components/responses/Unauthorized'
+        '403':
+          $ref: '#/components/responses/Forbidden'
     get:
-      tags: [AML]
-      summary: List AML cases
+      tags: [AML Cases]
+      summary: List AML screening cases
       operationId: listAmlCases
       parameters:
         - name: status
           in: query
+          description: >-
+            GATE-CONSTRAINED — only the five AmlCaseStatus values are accepted; `CLOSED` and
+            `SAR_FILED` are not in the enum and produce a 400. They are retained here because
+            removing an accepted enum value is `request-parameter-enum-value-removed` (ERR).
           schema:
             type: string
-            enum: [OPEN, UNDER_REVIEW, CLOSED, ESCALATED, SAR_FILED]
+            enum: [OPEN, UNDER_REVIEW, CLEARED, BLOCKED, ESCALATED, CLOSED, SAR_FILED]
+        - name: partyId
+          in: query
+          schema:
+            type: string
+            format: uuid
+        - name: screeningType
+          in: query
+          schema:
+            $ref: '#/components/schemas/ScreeningType'
         - name: limit
           in: query
+          description: >-
+            GATE-CONSTRAINED — the server default is 50 (`@DefaultValue("50")`), not 20. Changing
+            a declared default is `request-parameter-default-value-changed` (ERR).
           schema:
             type: integer
             default: 20
@@ -62,10 +104,16 @@ paths:
                 type: array
                 items:
                   $ref: '#/components/schemas/AmlCaseResponse'
+        '400':
+          $ref: '#/components/responses/BadRequest'
+        '401':
+          $ref: '#/components/responses/Unauthorized'
+        '403':
+          $ref: '#/components/responses/Forbidden'
 
   /api/v1/aml/cases/{caseId}:
     get:
-      tags: [AML]
+      tags: [AML Cases]
       summary: Get AML case by ID
       operationId: getAmlCase
       parameters:
@@ -77,12 +125,16 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/AmlCaseResponse'
+        '401':
+          $ref: '#/components/responses/Unauthorized'
+        '403':
+          $ref: '#/components/responses/Forbidden'
         '404':
           $ref: '#/components/responses/NotFound'
 
   /api/v1/aml/cases/{caseId}/decision:
     put:
-      tags: [AML]
+      tags: [AML Cases]
       summary: Update AML case decision
       operationId: updateAmlDecision
       parameters:
@@ -92,10 +144,24 @@ paths:
         content:
           application/json:
             schema:
-              $ref: '#/components/schemas/UpdateDecisionRequest'
+              $ref: '#/components/schemas/UpdateAmlDecisionRequest'
       responses:
         '200':
-          description: Decision updated
+          description: Decision applied
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/AmlCaseResponse'
+        '400':
+          $ref: '#/components/responses/BadRequest'
+        '401':
+          $ref: '#/components/responses/Unauthorized'
+        '403':
+          $ref: '#/components/responses/Forbidden'
+        '404':
+          $ref: '#/components/responses/NotFound'
+        '409':
+          $ref: '#/components/responses/Conflict'
 
 components:
   securitySchemes:
@@ -112,55 +178,72 @@ components:
       schema:
         type: string
         format: uuid
+    idempotencyKey:
+      name: Idempotency-Key
+      in: header
+      required: false
+      description: >-
+        GATE-CONSTRAINED — mandatory in practice. AmlCaseResource.createCase rejects a blank or
+        absent value, so a caller that omits this header always fails; `required: false` is stated
+        only because adding a required parameter is `new-required-request-parameter` (ERR).
+        A repeat with the same key replays the stored 201 response.
+      schema:
+        type: string
+        minLength: 1
 
   responses:
+    BadRequest:
+      description: Validation error
+      content:
+        application/json:
+          schema:
+            $ref: '#/components/schemas/ApiError'
+    Unauthorized:
+      description: Missing or invalid bearer token
+      content:
+        application/json:
+          schema:
+            $ref: '#/components/schemas/ApiError'
+    Forbidden:
+      description: Caller lacks a required role
+      content:
+        application/json:
+          schema:
+            $ref: '#/components/schemas/ApiError'
     NotFound:
       description: Not found
       content:
         application/json:
           schema:
             $ref: '#/components/schemas/ApiError'
+    Conflict:
+      description: Invalid AML case status transition
+      content:
+        application/json:
+          schema:
+            $ref: '#/components/schemas/ApiError'
 
   schemas:
+    AmlCaseStatus:
+      type: string
+      enum: [OPEN, UNDER_REVIEW, CLEARED, BLOCKED, ESCALATED]
+
+    ScreeningType:
+      type: string
+      enum: [CUSTOMER_ONBOARDING, TRANSACTION_MONITORING, PERIODIC_REVIEW, MANUAL_INVESTIGATION]
+
+    AmlRiskLevel:
+      type: string
+      enum: [LOW, MEDIUM, HIGH, CRITICAL]
+
     CreateAmlCaseRequest:
       type: object
-      required: [partyId, triggerType, riskScore]
+      description: >-
+        GATE-CONSTRAINED — customerReference, screeningType, riskLevel and alertCode are
+        non-nullable on the Kotlin DTO and are rejected when absent, but cannot be listed in
+        `required`: adding one is `new-required-request-property` (ERR).
+      required: [partyId]
       properties:
-        partyId:
-          type: string
-          format: uuid
-        accountId:
-          type: string
-          format: uuid
-        triggerType:
-          type: string
-          enum: [TRANSACTION_THRESHOLD, UNUSUAL_PATTERN, SANCTIONS_HIT, MANUAL]
-        riskScore:
-          type: number
-          minimum: 0
-          maximum: 100
-        notes:
-          type: string
-
-    UpdateDecisionRequest:
-      type: object
-      required: [decision, analystId]
-      properties:
-        decision:
-          type: string
-          enum: [NO_ACTION, MONITOR, CLOSE, ESCALATE, FILE_SAR]
-        analystId:
-          type: string
-          format: uuid
-        notes:
-          type: string
-
-    AmlCaseResponse:
-      type: object
-      properties:
-        id:
-          type: string
-          format: uuid
         partyId:
           type: string
           format: uuid
@@ -168,14 +251,106 @@ components:
           type: string
           format: uuid
           nullable: true
-        triggerType:
+        transactionId:
           type: string
+          format: uuid
+          nullable: true
+        customerReference:
+          type: string
+        screeningType:
+          $ref: '#/components/schemas/ScreeningType'
+        riskLevel:
+          $ref: '#/components/schemas/AmlRiskLevel'
+        alertCode:
+          type: string
+        alertDetail:
+          type: string
+          nullable: true
+        matchedEntity:
+          type: string
+          nullable: true
+
+    UpdateAmlDecisionRequest:
+      type: object
+      description: >-
+        GATE-CONSTRAINED — targetStatus and decidedBy are non-nullable on the Kotlin DTO and
+        `decidedBy` is additionally rejected when blank, but neither can be listed in `required`:
+        adding one is `new-required-request-property` (ERR).
+      properties:
+        targetStatus:
+          $ref: '#/components/schemas/AmlCaseStatus'
+        decisionReason:
+          type: string
+          nullable: true
+          description: Required when targetStatus is BLOCKED.
+        assignedAnalyst:
+          type: string
+          nullable: true
+        decidedBy:
+          type: string
+
+    AmlCaseResponse:
+      type: object
+      required:
+        - id
+        - idempotencyKey
+        - partyId
+        - customerReference
+        - screeningType
+        - riskLevel
+        - status
+        - alertCode
+        - screenedAt
+        - createdAt
+        - updatedAt
+      properties:
+        id:
+          type: string
+          format: uuid
+        idempotencyKey:
+          type: string
+        partyId:
+          type: string
+          format: uuid
+        accountId:
+          type: string
+          format: uuid
+          nullable: true
+        transactionId:
+          type: string
+          format: uuid
+          nullable: true
+        customerReference:
+          type: string
+        screeningType:
+          $ref: '#/components/schemas/ScreeningType'
+        riskLevel:
+          $ref: '#/components/schemas/AmlRiskLevel'
         status:
+          $ref: '#/components/schemas/AmlCaseStatus'
+        alertCode:
           type: string
-        riskScore:
-          type: number
-        decision:
+        alertDetail:
           type: string
+          nullable: true
+        matchedEntity:
+          type: string
+          nullable: true
+        decisionReason:
+          type: string
+          nullable: true
+        assignedAnalyst:
+          type: string
+          nullable: true
+        decidedBy:
+          type: string
+          nullable: true
+        screenedAt:
+          type: string
+          format: date-time
+        decidedAt:
+          type: string
+          format: date-time
           nullable: true
         createdAt:
           type: string
@@ -186,8 +361,32 @@ components:
 
     ApiError:
       type: object
+      required: [traceId, status, code, message]
       properties:
+        traceId:
+          type: string
+        status:
+          type: integer
         code:
           type: string
         message:
           type: string
+        timestamp:
+          type: string
+          format: date-time
+        details:
+          type: array
+          nullable: true
+          items:
+            $ref: '#/components/schemas/FieldError'
+
+    FieldError:
+      type: object
+      required: [field, message]
+      properties:
+        field:
+          type: string
+        message:
+          type: string
+        rejectedValue:
+          nullable: true


### PR DESCRIPTION
## Summary

`openbank-aml-service`'s `openapi.yaml` described an API that was never served — invented request
fields, invented response fields, an enum with two values the service rejects, and the wrong port.
This replaces it with the implemented contract, derived from the DTOs and cross-checked against the
provider-verified pact, and corrects `governance.yaml` `lineage.upstream`, which named three
services that do not touch this one and omitted both real callers.

## Type of change

- [x] fix (bug fix)
- [x] docs

## Linked issues

Closes #2312
Refs #2255, #2313, #2314, #2315

## Changes

- `openapi.yaml`: `CreateAmlCaseRequest`, `UpdateAmlDecisionRequest` and `AmlCaseResponse` now match
  `AmlCaseDtos.kt`; `AmlCaseStatus` / `ScreeningType` / `AmlRiskLevel` are real enums from
  `AmlCase.kt`. The invented `triggerType`, `riskScore`, `notes`, `decision` and `analystId` are gone.
- `openapi.yaml`: dev server port `8106` -> `8117` (`application.yaml` binds 8117); added the
  `partyId` and `screeningType` query parameters; documented the `Idempotency-Key` header, the 201
  `Location` and `X-Idempotency-Replayed` headers, the `AmlCaseResponse` body on `PUT /decision`,
  the real shared `ApiError` shape, and the 400/401/403/409 responses; added the `bearerAuth`
  security requirement every method already enforces via `@RolesAllowed`.
- `openapi.yaml`: `info.version` 1.0.0 -> 1.1.0 (additive per `oasdiff`; see below).
- `governance.yaml`: `lineage.upstream` drops `swift-service`, `kyc-service` and
  `sanctions-service`, adds `fx-service`, `agent-service` and `party-service`.
- `docs/runbooks/svc-aml.md`: regenerated (`generate-service-runbooks.py --force`). The false
  lineage was propagating into the on-call runbook's Dependencies section, so an engineer
  debugging an AML failure was being pointed at swift, kyc and sanctions — none of which call
  this service — and away from fx and agent, which do.

## Reviewer notes

**Four true constraints ship as `GATE-CONSTRAINED` `description` prose rather than as
`required` / `enum` / `default`.** This is deliberate and measured, not an oversight — the
api-contract gate cannot accept them. Running `.github/scripts/check-api-contract.py --enforce`
locally with the CI-pinned `oasdiff` 1.22.0, both ends fail:

- at `1.0.0`: `::error:: breaking API change requires an info.version MAJOR bump`
- at `2.0.0`: `::error:: major(info.version)=2 but openbank.api.version=1` and
  `::error:: ... the newest served URL major is /api/v1` (ADR-0048 D2/D4)

Only *stating* the truth is ERR-level; removing the invented fields is level 2 and passes. Omitting
rather than misstating is also ERR (`request-parameter-default-value-removed`,
`request-parameter-enum-value-removed`), so the only green spec is one that keeps `default: 20`
(real: 50) and the phantom `CLOSED`/`SAR_FILED` status values. Each concession is labelled
`GATE-CONSTRAINED` in the file with the reason, so the next reader does not rediscover this wall.
Tracked in #2313.

Three deliberate non-goals, each with its own issue: the gate fix (#2313), the fleet-wide absence
of any spec-vs-code check — 22 of 35 specs declare the wrong port, and ADR-0005's claim that
Spectral lints them is describing a control that does not exist (#2314), and
`check-governance-lineage.py` reading only `downstream`, leaving 63 upstream edges across 23
services never audited, which is why this file's lineage rotted (#2315).

Note for merge ordering: #2247 is open and also edits both
`openbank-aml-service/governance.yaml` (immediately below the block changed here) and
`docs/runbooks/svc-aml.md`. Expect a conflict on both; whichever lands second rebases and re-runs
the runbook generator rather than hand-resolving the generated file.

## Definition of Done

- [x] Hexagonal layering preserved (no Kotlin changed).
- [ ] Unit tests added/updated — N/A, no code change. The contract is already pinned by
      `AmlCaseCreationPactConsumerTest` (fx) and replayed by `AmlPactProviderVerificationTest`.
- [x] Contract tests updated (if public API changed) — the pact from #2284 is what this spec was
      reconciled against.
- [x] OpenAPI spec regenerated (if REST API changed) — hand-corrected; nothing generates it today,
      which is #2314.
- [x] No new lint warnings (`check-duplicate-yaml-keys`, `check-license-headers`,
      `check-manifest-types-only`, `check-app-version-override`, `check-exception-mapper-collision`,
      `check-governance-lineage` all run locally, all exit 0).

## Security checklist

- [x] No secrets, tokens, passwords, or PII in code, config, tests, logs.
- [x] No new `@Suppress`.
- [x] No new third-party dependency.

## Compliance impact

- [x] AML / 5AMLD

Documentation-only: the served AML API is unchanged by this PR. The impact is that the published
contract for a compliance service now matches what it does — previously an integrator following the
spec would have sent `triggerType`/`riskScore` and been rejected.

## Rollout / Rollback

- Deployment strategy: rolling (no runtime behaviour change; the spec ships inside the artifact)
- Rollback plan: revert the commit
- Data migration reversible: N/A
