### PR TITLE
fix(copilot): document the action-confirm endpoint and guard the route set

### DIFF
--- a/openbank-copilot-service/src/main/resources/openapi.yaml
+++ b/openbank-copilot-service/src/main/resources/openapi.yaml
@@ -7,7 +7,7 @@ openapi: "3.1.0"
 
 info:
   title: OpenBank Copilot Service API
-  version: "1.0.0"
+  version: "1.1.0"
   description: |
     Customer-facing AI assistant (mobile copilot), per ADR-0089.
 
@@ -84,6 +84,63 @@ paths:
         "501":
           description: Capability not yet enabled (feature flag off)
 
+  /copilot/actions/{tokenId}/confirm:
+    post:
+      operationId: confirmAction
+      summary: Confirm a copilot action proposal (human-in-the-loop)
+      description: |
+        Exchanges a one-time proposal token for a confirmed action. This is the
+        human-in-the-loop half of "the model proposes, the bank disposes" (ADR-0089 D2): the
+        assistant never executes a money-path action, it only emits a proposal the customer
+        confirms here from a non-AI-controlled card.
+
+        The token is bound to the customer that owns it — a token confirmed by a different
+        subject is refused, and the response deliberately does not distinguish that case from
+        an unknown token. The confirm is re-checked against the OPA policy gate (ADR-0034,
+        fail-closed: an unreachable PDP denies), and the token is single-use — it is deleted on
+        confirm, on expiry, and on an ownership mismatch is left untouched.
+      security:
+        - bearerAuth: []
+      parameters:
+        - name: tokenId
+          in: path
+          required: true
+          description: The proposal token id handed out with the `ActionProposal` (UUID).
+          schema:
+            type: string
+            format: uuid
+      responses:
+        "200":
+          description: Action confirmed
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ActionConfirmation"
+        "401":
+          description: Authenticated token carries no usable subject
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ErrorResponse"
+        "403":
+          description: OPA policy denied the action, or the token belongs to another customer
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ErrorResponse"
+        "404":
+          description: Token not found (also returned for a malformed token id)
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ErrorResponse"
+        "422":
+          description: Token expired (the proposal must be re-issued by a new turn)
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ErrorResponse"
+
 components:
   securitySchemes:
     bearerAuth:
@@ -131,3 +188,23 @@ components:
           additionalProperties:
             type: string
           description: Validated parameters (fromAccountId, payeeIban, amount, currency, …) — authoritative.
+    ActionConfirmation:
+      type: object
+      required: [status, actionId]
+      properties:
+        status:
+          type: string
+          enum: [CONFIRMED]
+        actionId:
+          type: string
+          format: uuid
+          description: Id of the confirmed action, for correlating the downstream execution.
+    ErrorResponse:
+      type: object
+      required: [error]
+      properties:
+        error:
+          type: string
+          description: |
+            Stable machine-readable code where one exists (`PROPOSAL_NOT_FOUND`,
+            `PROPOSAL_EXPIRED`, `ACTION_DENIED`); otherwise a short human-readable reason.

--- a/openbank-copilot-service/src/test/kotlin/com/openbank/copilot/contract/CopilotApiContractTest.kt
+++ b/openbank-copilot-service/src/test/kotlin/com/openbank/copilot/contract/CopilotApiContractTest.kt
@@ -1,0 +1,173 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+// Copyright (c) OpenBank contributors. Licensed under the GNU Affero General Public License v3.0 only.
+// A commercial licence is available from the maintainers as an alternative to the AGPL-3.0.
+// See LICENSES/AGPL-3.0-only.txt or https://www.gnu.org/licenses/agpl-3.0.html for details.
+package com.openbank.copilot.contract
+
+import com.openbank.copilot.infrastructure.rest.ActionConfirmResource
+import com.openbank.copilot.infrastructure.rest.CopilotChatResource
+import jakarta.ws.rs.DELETE
+import jakarta.ws.rs.GET
+import jakarta.ws.rs.HttpMethod
+import jakarta.ws.rs.PATCH
+import jakarta.ws.rs.POST
+import jakarta.ws.rs.PUT
+import jakarta.ws.rs.Path
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.Test
+import java.io.File
+import java.lang.reflect.Method
+
+/**
+ * Bidirectional conformance between the published contract (`src/main/resources/openapi.yaml`) and
+ * the JAX-RS routes this service declares.
+ *
+ * **What this proves, precisely.** It reads the `@Path` / `@POST` / `@GET` … annotations off the
+ * resource classes by reflection and compares that route set with the `paths:` × HTTP-method set
+ * parsed out of the spec, resolved against `servers[0].url` — an OpenAPI path is relative to the
+ * server URL, so `/copilot/chat` under `servers: /api/v1` IS `/api/v1/copilot/chat`. Drift in
+ * either direction fails.
+ *
+ * **What it does NOT prove.** Nothing here boots Quarkus or speaks HTTP: it does not exercise the
+ * handlers, does not check status codes, request/response bodies or auth behaviour, and cannot
+ * catch a route that exists as an annotation but fails at runtime (CDI, filters, policy gate).
+ * Behaviour is covered elsewhere — `ActionConfirmResourceTest` for the confirm flow,
+ * `CopilotServiceBootTest` for CDI wiring. This test's whole job is *route-set* drift, which is
+ * exactly the defect it was written for: `/copilot/actions/{tokenId}/confirm` — the
+ * human-in-the-loop confirmation for a money-path action proposal (ADR-0089 D2) — was served but
+ * absent from the published spec entirely (#2255).
+ */
+class CopilotApiContractTest {
+
+    private val specFile = File("src/main/resources/openapi.yaml")
+    private val restSourceDir = File("src/main/kotlin/com/openbank/copilot/infrastructure/rest")
+
+    /**
+     * Every resource class this test reflects over. An explicit list goes stale silently, so
+     * `every resource class is covered by this test` pins its size to the number of `*Resource.kt`
+     * files on disk — a new resource file fails that guard until it is added here.
+     */
+    private val resourceClasses = listOf(CopilotChatResource::class.java, ActionConfirmResource::class.java)
+
+    @Test
+    fun `every route served is declared in the published spec`() {
+        val served = servedRoutes()
+        assertThat(served).describedAs("reflection found no JAX-RS route at all — the probe is broken").isNotEmpty()
+        assertThat(served - declaredRoutes())
+            .describedAs("served by a @Path resource but MISSING from openapi.yaml")
+            .isEmpty()
+    }
+
+    @Test
+    fun `every route declared in the published spec is served`() {
+        val declared = declaredRoutes()
+        assertThat(declared).describedAs("spec parse found no path at all — the probe is broken").isNotEmpty()
+        assertThat(declared - servedRoutes())
+            .describedAs("declared in openapi.yaml but NOT served by any @Path resource")
+            .isEmpty()
+    }
+
+    @Test
+    fun `the money-path confirm route is both served and declared`() {
+        // Pinned by name, not only by set equality: this is the route whose absence started #2255,
+        // and set equality alone would go green again if BOTH sides lost it.
+        val confirm = "POST /api/v1/copilot/actions/{tokenId}/confirm"
+        assertThat(servedRoutes()).contains(confirm)
+        assertThat(declaredRoutes()).contains(confirm)
+    }
+
+    @Test
+    fun `every resource class is covered by this test`() {
+        val resourceFiles = restSourceDir.listFiles { f: File -> f.name.endsWith("Resource.kt") }.orEmpty()
+        assertThat(resourceFiles.map { it.name }.sorted())
+            .describedAs("a new *Resource.kt must be added to resourceClasses, or its routes go unchecked")
+            .hasSameSizeAs(resourceClasses)
+    }
+
+    // ---------------------------------------------------------------- served side (reflection)
+
+    private fun servedRoutes(): Set<String> = resourceClasses.flatMap { clazz ->
+        val base = clazz.getAnnotation(Path::class.java)?.value.orEmpty()
+        clazz.methods.mapNotNull { method ->
+            httpVerbOf(method)?.let { verb -> "$verb ${join(base, method.getAnnotation(Path::class.java)?.value)}" }
+        }
+    }.toSet()
+
+    private fun httpVerbOf(method: Method): String? =
+        HTTP_METHOD_ANNOTATIONS.entries.firstOrNull { method.isAnnotationPresent(it.key) }?.value
+
+    private fun join(base: String, sub: String?): String =
+        ("/" + listOfNotNull(base, sub).joinToString("/") { it.trim('/') }).replace(MULTI_SLASH, "/").trimEnd('/')
+
+    // ---------------------------------------------------------------- declared side (spec parse)
+
+    /**
+     * Minimal indentation walk of the `paths:` block — deliberately dependency-free, since no YAML
+     * parser sits on this module's test classpath. Block scalars (`|`, `>`) are skipped wholesale so
+     * a `description:` body can never be mistaken for a path or an operation.
+     */
+    private fun declaredRoutes(): Set<String> {
+        val prefix = serverPrefix()
+        val routes = mutableSetOf<String>()
+        var currentPath: String? = null
+        for ((indent, body) in pathsBlockLines()) {
+            if (indent == PATH_INDENT) currentPath = pathKey(body)
+            if (indent != OPERATION_INDENT) continue
+            val verb = verbKey(body)
+            val path = currentPath
+            if (verb != null && path != null) routes += "$verb ${join(prefix, path)}"
+        }
+        return routes
+    }
+
+    /** Significant `(indent, text)` lines inside the top-level `paths:` block, block scalars dropped. */
+    private fun pathsBlockLines(): List<Pair<Int, String>> {
+        val significant = specFile.readLines()
+            .map { line -> line.indexOfFirst { !it.isWhitespace() } to line.trim() }
+            .filter { (indent, body) -> indent >= 0 && body.isNotEmpty() && !body.startsWith("#") }
+        val pathsBlock = significant
+            .dropWhile { (indent, body) -> !(indent == 0 && body == "paths:") }
+            .drop(1)
+            .takeWhile { (indent, _) -> indent > 0 }
+        return withoutBlockScalars(pathsBlock)
+    }
+
+    private fun withoutBlockScalars(lines: List<Pair<Int, String>>): List<Pair<Int, String>> {
+        var scalarAt = -1
+        return lines.filter { (indent, body) ->
+            val insideScalar = scalarAt >= 0 && indent > scalarAt
+            val opensScalar = !insideScalar && BLOCK_SCALAR_TAIL.containsMatchIn(body)
+            if (!insideScalar) scalarAt = if (opensScalar) indent else -1
+            !insideScalar && !opensScalar
+        }
+    }
+
+    private fun pathKey(body: String): String? = body.takeIf { it.startsWith("/") && it.endsWith(":") }?.dropLast(1)
+
+    private fun verbKey(body: String): String? =
+        body.dropLast(1).uppercase().takeIf { body.endsWith(":") && it in HTTP_VERBS }
+
+    /** `servers[0].url` — the prefix every `paths:` key is relative to. */
+    private fun serverPrefix(): String {
+        val servers = specFile.readText().substringAfter("\nservers:", "").substringBefore("\npaths:")
+        return SERVER_URL.find(servers)?.groupValues?.get(1)
+            ?: error("openapi.yaml declares no servers[0].url — paths cannot be resolved")
+    }
+
+    private companion object {
+        const val PATH_INDENT = 2
+        const val OPERATION_INDENT = 4
+        val MULTI_SLASH = Regex("/+")
+        val BLOCK_SCALAR_TAIL = Regex("""[|>][-+]?$""")
+        val SERVER_URL = Regex("""-\s+url:\s*"?([^"\s]+)"?""")
+
+        val HTTP_METHOD_ANNOTATIONS: Map<Class<out Annotation>, String> = mapOf(
+            POST::class.java to HttpMethod.POST,
+            GET::class.java to HttpMethod.GET,
+            PUT::class.java to HttpMethod.PUT,
+            PATCH::class.java to HttpMethod.PATCH,
+            DELETE::class.java to HttpMethod.DELETE,
+        )
+        val HTTP_VERBS: Set<String> = HTTP_METHOD_ANNOTATIONS.values.toSet()
+    }
+}


### PR DESCRIPTION
Closes the C3 cell for `openbank-copilot-service` (#2255): it had an `openapi.yaml` and no contract test.

## The defect

`ActionConfirmResource` serves `POST /api/v1/copilot/actions/{tokenId}/confirm` — the human-in-the-loop confirmation for a money-path action proposal (ADR-0089 D2), the most consequential call copilot serves — and the published `openapi.yaml` did not mention it at all. Any client generated from that spec is missing the only route that disposes of a proposal, so this is `fix`, not `docs`.

The two paths the spec *did* declare (`/copilot/chat`, `/copilot/chat/stream`) are correct: with `servers: [- url: /api/v1]` they resolve to the served `/api/v1/copilot/chat{,/stream}`. (Worth stating because reading `paths:` without `servers:` makes them look wrong.)

## Spec change

Adds the path with the shapes `ActionConfirmResource` really returns — `200 {status, actionId}`, `401` (authenticated token with no usable subject), `403` (OPA deny **or** token-ownership mismatch, deliberately indistinguishable from not-found in the body), `404` (unknown **or** malformed token id), `422` (expired) — plus the `ActionConfirmation` and `ErrorResponse` schemas. `info.version` 1.0.0 -> 1.1.0.

Classification verified with the gate rather than by arithmetic — `check-api-contract.py --base origin/main --enforce` prints:

```
api-contract gate: openbank-copilot-service: additive change, info.version 1.0.0 -> 1.1.0 — OK (required >= MINOR).
```

`version.txt` / `CHANGELOG.md` untouched — release-please owns the release axis (ADR-0048 D1).

## Test shape, and why

`CopilotApiContractTest` is **static/reflective**: it reads the `@Path` / `@POST` … annotations off the resource classes by reflection and compares that route set with the spec's `paths:` × HTTP-method set, resolved against `servers[0].url`. Chosen over a `@QuarkusTest` + RestAssured shape because the question it answers — *does the served route set equal the declared route set* — needs no HTTP: the runtime shape would have to stub the model gateway for the two chat routes and mint a bearer for the confirm route, buying fidelity this assertion cannot spend. Behaviour is already covered by `ActionConfirmResourceTest` (6 tests) and CDI wiring by `CopilotServiceBootTest`.

The KDoc says plainly what it does not prove: no Quarkus boot, no HTTP, no status codes or bodies, and it cannot catch a route that exists as an annotation but fails at runtime. (An overclaiming KDoc is its own defect — #2283/#2300.)

It is **bidirectional**, which is the point: direction 2 ("declared but not served") is ordinary drift, direction 1 ("**served but not declared**") is the one that would have caught this endpoint — and keeps it caught. The explicit resource-class list is the obvious staleness risk, so a fourth test pins its size to the number of `*Resource.kt` files on disk.

Named `*ContractTest.kt` so the C3 scorer detects the artifact, not the prose (#2291).

## Falsification — all three guards were made to fail, then restored

| perturbation | what the test printed |
|---|---|
| removed `/copilot/chat` from the spec | `[served by a @Path resource but MISSING from openapi.yaml] Expecting empty but was: ["POST /api/v1/copilot/chat"]` |
| added a bogus `/copilot/bogus/never-served` GET to the spec | `[declared in openapi.yaml but NOT served by any @Path resource] Expecting empty but was: ["GET /api/v1/copilot/bogus/never-served"]` |
| added a dummy `DummyProbeResource.kt` | `[a new *Resource.kt must be added to resourceClasses…] actual size is: 3 while expected size is: 2` |

Test count read from the JUnit XML, not the console: `tests="4" skipped="0" failures="0" errors="0"` on the green run, `failures="1"` on each perturbation.

## Out of scope, tracked instead

Copilot also *consumes* seven `/customer/v1/*` routes from `openbank-customer-edge`. `openbank-customer-edge` has no pact dependency, no `@Provider` test and no HTTP boot-test harness, and per `CLAUDE.md` a consumer pact whose provider never replays it cannot catch a wrong path at all — so a consumer-only pact would have been theatre. Raised as **#2322** (`tech-debt`) with the seven routes, the bearer-propagation stake, and what a provider harness in customer-edge needs.

## Gates run locally

- `:openbank-copilot-service:build :openbank-copilot-service:quarkusBuild` — `BUILD SUCCESSFUL`
- `:openbank-copilot-service:koverVerify` — `BUILD SUCCESSFUL`
- `check-api-contract.py --enforce` — exit 0, output above

Refs #2255