### PR TITLE
test(vop): pin the party-service name lookup with a consumer-driven pact

### DIFF
--- a/openbank-party-service/src/test/kotlin/com/openbank/party/contract/PartyEventPactProviderVerificationTest.kt
+++ b/openbank-party-service/src/test/kotlin/com/openbank/party/contract/PartyEventPactProviderVerificationTest.kt
@@ -248,7 +248,46 @@ class PartyEventPactProviderVerificationTest {
         )
     }
 
+    /**
+     * State for vop-service's `PartyNameLookupPactConsumerTest` (issue #2255): hop 2 of the ADR-0171
+     * §4 VoP name resolution reads `legalName`/`tradingName` off `GET /api/v1/parties/{id}`, and the
+     * adapter falls back to `tradingName` when `legalName` is blank — so both fields must be present
+     * and non-blank on the seeded row, unlike [FIXED_PARTY_ID] above which has a null trading name.
+     *
+     * Seeded as a COMPANY: a party carrying both names is by construction a legal entity, and it
+     * keeps this row from colliding with the individual the KYC-expiry state above inserts.
+     */
+    @State("a party exists with both a legal name and a trading name")
+    fun partyExistsWithLegalAndTradingName() = runOnVertxContext {
+        // Idempotent for the same reason as the state above: pact-jvm 4.7.3 invokes each @State
+        // setup callback twice per interaction, and this one inserts with a fixed id.
+        if (partyRepository.findById(VOP_NAME_PARTY_ID) != null) return@runOnVertxContext
+        partyRepository.save(
+            Party(
+                id = VOP_NAME_PARTY_ID,
+                partyType = PartyType.COMPANY,
+                status = PartyStatus.ACTIVE,
+                legalName = "Pact Verify Trading Company a.s.",
+                tradingName = "PactVerify",
+                dateOfBirth = null,
+                nationality = null,
+                taxId = null,
+                registrationNumber = null,
+                email = "pact-verify-vop@example.com",
+                phone = null,
+                address = null,
+                kycStatus = KycStatus.APPROVED,
+                createdAt = Instant.now(),
+                updatedAt = Instant.now(),
+                amlStatus = AmlStatus.NOT_SCREENED,
+            ),
+        )
+    }
+
     companion object {
         private val FIXED_PARTY_ID = UUID.fromString("aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee")
+
+        /** Must equal `PartyNameLookupPactConsumerTest.PACT_PARTY_ID` (openbank-vop-service). */
+        private val VOP_NAME_PARTY_ID = UUID.fromString("b1b1b1b1-c2c2-4d4d-8e8e-f9f9f9f9f9f9")
     }
 }

--- a/openbank-vop-service/build.gradle.kts
+++ b/openbank-vop-service/build.gradle.kts
@@ -44,6 +44,9 @@ dependencies {
     testImplementation(libs.testcontainers)
     testImplementation(libs.testcontainers.junit)
     testImplementation(libs.testcontainers.postgresql)
+    // Consumer-driven contract test (ADR-0063, issue #2255 dimension C3): vop is a real consumer of
+    // party-service's GET /api/v1/parties/{id} — hop 2 of the ADR-0171 §4 name resolution.
+    testImplementation(libs.pact.consumer)
 }
 
 kover {
@@ -59,4 +62,26 @@ kover {
             }
         }
     }
+}
+
+// Pact: write the generated consumer contract into the repo-root pacts/ dir (git-pact, ADR-0063) so
+// the provider replays it from its own pact loader with no broker in the loop. The consumer test
+// rewrites the file on every run and the result is committed; pact-drift-check.yml fails the build
+// if the committed JSON and a fresh regeneration diverge.
+// NOTE: must be set on the test JVM fork, not the Gradle daemon (System.setProperty would not
+// propagate). The pactbroker.* keys are forwarded so `_service-ci.yml`'s publish step behaves the
+// same way here as in every other consumer module.
+tasks.withType<Test> {
+    systemProperty("pact.rootDir", "${rootProject.projectDir}/pacts")
+    listOf(
+        "pactbroker.url",
+        "pactbroker.auth.username",
+        "pactbroker.auth.password",
+        "pactbroker.enablePending",
+        "pactbroker.providerBranch",
+        "pact.verifier.publishResults",
+        "pact.provider.version",
+        "pact.provider.branch",
+        "pact.provider.tag",
+    ).forEach { key -> System.getProperty(key)?.let { systemProperty(key, it) } }
 }

--- a/openbank-vop-service/src/test/kotlin/com/openbank/vop/contract/PartyNameLookupPactConsumerTest.kt
+++ b/openbank-vop-service/src/test/kotlin/com/openbank/vop/contract/PartyNameLookupPactConsumerTest.kt
@@ -1,0 +1,141 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright (c) OpenBank contributors. Licensed under the Apache License, Version 2.0.
+// See LICENSE in the repository root or https://www.apache.org/licenses/LICENSE-2.0 for details.
+
+package com.openbank.vop.contract
+
+import au.com.dius.pact.consumer.MockServer
+import au.com.dius.pact.consumer.dsl.LambdaDsl.newJsonBody
+import au.com.dius.pact.consumer.dsl.PactDslWithProvider
+import au.com.dius.pact.consumer.junit5.PactConsumerTestExt
+import au.com.dius.pact.consumer.junit5.PactTestFor
+import au.com.dius.pact.core.model.PactSpecVersion
+import au.com.dius.pact.core.model.RequestResponsePact
+import au.com.dius.pact.core.model.annotations.Pact
+import com.fasterxml.jackson.module.kotlin.jacksonObjectMapper
+import com.fasterxml.jackson.module.kotlin.readValue
+import com.openbank.vop.infrastructure.client.PartyServiceClient
+import com.openbank.vop.infrastructure.client.PartySummary
+import io.restassured.RestAssured.given
+import jakarta.ws.rs.Path
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.extension.ExtendWith
+
+/**
+ * Consumer-driven contract for hop 2 of the ADR-0171 §4 VoP name resolution: `GET
+ * /api/v1/parties/{id}`, the call that produces the authoritative payee name VoP compares against.
+ * The generated pact is committed to `pacts/openbank-vop-service-openbank-party-service.json`
+ * (git-pact, ADR-0063) and replayed by `PartyEventPactProviderVerificationTest` in
+ * openbank-party-service — the single `@Provider("openbank-party-service")` class in the repo.
+ *
+ * Why hop 2 and not hop 1: see `AccountHolderNameLookupAdapter`. Both hops are real HTTP, but
+ * party-service is where the *answer* comes from — a renamed or dropped `legalName`/`tradingName`
+ * turns every verification into NO_DATA while every unit test stays green (the port is mocked
+ * there). Hop 1 (account-service `GET /api/v1/accounts/iban/{iban}`) is deliberately NOT pinned in
+ * this PR: account-service's only `@Provider` class is message-only (`MessageTestTarget`, no
+ * Quarkus boot) and its own KDoc records that an HTTP consumer contract would first need it
+ * converted to party-service's per-interaction target dispatch. That conversion is provider-side
+ * work on a money-path service, not a vop test change.
+ *
+ * **The expected path is a LITERAL; only the outgoing request is reflected off the client's
+ * `@Path`** (CLAUDE.md "Contract tests", measured on #2290). Deriving *both* sides is vacuous: the
+ * Pact mock server answers whatever the client asks for, so expectation and request would move
+ * together and the test would stay green against a route that does not exist — exactly how #2269
+ * shipped a finrep call to a ledger path that never existed. Here [assertClientPathMatchesContract]
+ * pins the client's annotations to the literal, so changing [PartyServiceClient]'s `@Path` reddens
+ * this test, and the provider replay independently adjudicates whether party-service serves it.
+ *
+ * The response is bound into the REAL client DTO [PartySummary] rather than asserted off a
+ * JsonPath, so renaming a field on the DTO reddens THIS test — the half of the contract the
+ * provider replay cannot see.
+ *
+ * `tradingName` is pinned as a present string, not omitted: the adapter falls back to it when
+ * `legalName` is blank, so "party-service still sends this field" is load-bearing.
+ *
+ * IMPORTANT — regenerate on change: re-run this test (`./gradlew :openbank-vop-service:test --tests
+ * "*PartyNameLookupPactConsumerTest*"`) and commit the updated pact JSON in the same PR;
+ * `.github/workflows/pact-drift-check.yml` fails the build if they diverge.
+ */
+@ExtendWith(PactConsumerTestExt::class)
+@PactTestFor(providerName = "openbank-party-service", pactVersion = PactSpecVersion.V3)
+class PartyNameLookupPactConsumerTest {
+
+    private val mapper = jacksonObjectMapper()
+
+    @Pact(consumer = CONSUMER, provider = PROVIDER)
+    fun partyWithLegalAndTradingNamePact(builder: PactDslWithProvider): RequestResponsePact = builder
+        .given("a party exists with both a legal name and a trading name")
+        .uponReceiving("GET the party whose name VoP compares the payer-supplied name against")
+        .path(EXPECTED_PARTY_PATH)
+        .method("GET")
+        .headers(mapOf("Accept" to "application/json"))
+        .willRespondWith()
+        .status(200)
+        .headers(mapOf("Content-Type" to "application/json"))
+        .body(
+            newJsonBody { o ->
+                // Type matchers: VoP compares whatever name it is given, it does not care about the
+                // value. What it cannot survive is the field being renamed or absent.
+                o.stringType("legalName", "Pact Verify Trading Company a.s.")
+                o.stringType("tradingName", "PactVerify")
+            }.build(),
+        )
+        .toPact()
+
+    @Test
+    @PactTestFor(pactMethod = "partyWithLegalAndTradingNamePact")
+    fun `the party response binds into PartySummary with both name fields`(mockServer: MockServer) {
+        assertClientPathMatchesContract()
+
+        val raw = given()
+            .baseUri(mockServer.getUrl())
+            .accept("application/json")
+            // Reflected off the client, NOT retyped: this is the request the real client issues.
+            .get(clientDerivedPartyPath())
+            .then()
+            .statusCode(200)
+            .extract().asString()
+
+        val summary = mapper.readValue<PartySummary>(raw)
+        assertThat(summary.legalName).isNotBlank()
+        assertThat(summary.tradingName).isNotBlank()
+    }
+
+    /**
+     * The asymmetry that makes this contract falsifiable at the consumer layer: the path the client
+     * would really call, recomputed from [PartyServiceClient]'s own annotations, must equal the
+     * literal this pact promises party-service. A `@Path` edit on the client reddens here.
+     */
+    private fun assertClientPathMatchesContract() {
+        assertThat(clientDerivedPartyPath())
+            .describedAs(
+                "PartyServiceClient's @Path no longer produces the path this pact pins — either fix " +
+                    "the client or update EXPECTED_PARTY_PATH *and* re-verify against party-service",
+            )
+            .isEqualTo(EXPECTED_PARTY_PATH)
+    }
+
+    private companion object {
+        const val CONSUMER = "openbank-vop-service"
+        const val PROVIDER = "openbank-party-service"
+
+        /** Seeded by party-service's `a party exists with both a legal name and a trading name` state. */
+        const val PACT_PARTY_ID = "b1b1b1b1-c2c2-4d4d-8e8e-f9f9f9f9f9f9"
+
+        /**
+         * LITERAL, deliberately retyped from party-service's `PartyResource` (`@Path("/api/v1/parties")`
+         * + `@GET @Path("/{id}")`). Never derive this from the client — see the class KDoc.
+         */
+        const val EXPECTED_PARTY_PATH = "/api/v1/parties/$PACT_PARTY_ID"
+
+        fun clientDerivedPartyPath(): String {
+            val base = PartyServiceClient::class.java.getAnnotation(Path::class.java).value
+            val method = PartyServiceClient::class.java.methods
+                .single { it.name == "getParty" }
+                .getAnnotation(Path::class.java)
+                .value
+            return (base + method).replace("{id}", PACT_PARTY_ID)
+        }
+    }
+}

--- a/pacts/openbank-vop-service-openbank-party-service.json
+++ b/pacts/openbank-vop-service-openbank-party-service.json
@@ -1,0 +1,63 @@
+{
+  "consumer": {
+    "name": "openbank-vop-service"
+  },
+  "interactions": [
+    {
+      "description": "GET the party whose name VoP compares the payer-supplied name against",
+      "providerStates": [
+        {
+          "name": "a party exists with both a legal name and a trading name"
+        }
+      ],
+      "request": {
+        "headers": {
+          "Accept": "application/json"
+        },
+        "method": "GET",
+        "path": "/api/v1/parties/b1b1b1b1-c2c2-4d4d-8e8e-f9f9f9f9f9f9"
+      },
+      "response": {
+        "body": {
+          "legalName": "Pact Verify Trading Company a.s.",
+          "tradingName": "PactVerify"
+        },
+        "headers": {
+          "Content-Type": "application/json"
+        },
+        "matchingRules": {
+          "body": {
+            "$.legalName": {
+              "combine": "AND",
+              "matchers": [
+                {
+                  "match": "type"
+                }
+              ]
+            },
+            "$.tradingName": {
+              "combine": "AND",
+              "matchers": [
+                {
+                  "match": "type"
+                }
+              ]
+            }
+          }
+        },
+        "status": 200
+      }
+    }
+  ],
+  "metadata": {
+    "pact-jvm": {
+      "version": "4.7.3"
+    },
+    "pactSpecification": {
+      "version": "3.0.0"
+    }
+  },
+  "provider": {
+    "name": "openbank-party-service"
+  }
+}


### PR DESCRIPTION
## What

vop-service had an `openapi.yaml` and **no contract test** (issue #2255, dimension C3) while making two real cross-service calls. This pins hop 2 of the ADR-0171 §4 VoP name resolution with a consumer-driven pact (git-pact, ADR-0063) and adds the provider `@State` that lets party-service replay it.

## Pinned

| interaction | why |
|---|---|
| `GET /api/v1/parties/{id}` → `legalName` + `tradingName` | This is where the VoP **answer** comes from. `AccountHolderNameLookupAdapter` reads `legalName`, falling back to `tradingName`; if either field is renamed or dropped, every verification silently degrades to NO_DATA — and no unit test can see it, because `AccountHolderNameLookupPort` is mocked in all of them. |

## Skipped, with reasons

| interaction | why not |
|---|---|
| account-service `GET /api/v1/accounts/iban/{iban}` (hop 1) | The repo's only `@Provider("openbank-account-service")` class is **message-only** (`MessageTestTarget`, no Quarkus boot). Its own KDoc states that an HTTP consumer contract "needs party-service's per-interaction target dispatch" first. Adding a consumer pact with no provider replay is worth nothing against the likeliest defect (CLAUDE.md, #2269), and converting a money-path provider's verification class is not a vop test change. Tracked below. |
| the 404 → NO_DATA branch | A 404 from the real provider does not prove the route exists — Quarkus answers 404 for an absent route too — so the interaction would be satisfied by a broken client. Route existence is proved by the 200 interaction above. |

## The asymmetry (CLAUDE.md "Contract tests", #2290)

The expected path is a **literal**; only the outgoing request is reflected off `PartyServiceClient`'s `@Path`. Deriving both sides moves expectation and request together, so the test stays green against a route that does not exist. `assertClientPathMatchesContract()` pins the client's annotations to the literal, so a client `@Path` edit reddens the consumer, and the provider replay independently adjudicates whether party-service actually serves it.

## Falsified both ways (not just trusting the green)

**1. Consumer must catch a DTO field rename.** `@JsonProperty("legal_name")` on `PartySummary.legalName`, then re-ran the consumer test:

```
PartyNameLookupPactConsumerTest > the party response binds into PartySummary with both name fields FAILED
java.lang.AssertionError: Expecting not blank but was: null
```

**2. Provider must catch a wrong request path (the consumer cannot).** Repointed the pinned path at `/api/v1/parties/by-id/{id}` and re-ran party-service's verification:

```
1.1) status: expected status of 200 but was 404
1.2) body: $ Actual map is missing the following keys: legalName, tradingName
   +  "code": "NOT_FOUND",
```

Restored after each. Verdicts read from the JUnit XML, not the console.

`PartyEventPactProviderVerificationTest` is `@PactBroker`-gated, so it does not run locally or on the PR lane. To exercise it I **temporarily** swapped `@PactBroker` → `@PactFolder("../pacts")` and dropped `@EnabledIfSystemProperty`, and confirmed a clean green first (`tests=1 failures=0`, `pass openbank-vop-service - GET the party whose name VoP compares…`) before breaking it. **That swap is not committed** — #1166 records why the broker loader must stay (it is the only thing `can-i-deploy` reads).

## Gate

- `:openbank-vop-service:test --tests "*PartyNameLookupPactConsumerTest*"` → `tests=1 failures=0 errors=0 skipped=0` (count read from the XML — the `runBlocking` silent-skip footgun does not apply here, but the count is what proves it ran)
- `:openbank-party-service:test --tests "*PartyEventPactProviderVerificationTest*"` (temporary `@PactFolder`) → `tests=1 failures=0`
- `:openbank-vop-service:build` → BUILD SUCCESSFUL
- `:openbank-vop-service:ktlintCheck detekt`, `:openbank-party-service:ktlintCheck detekt` → BUILD SUCCESSFUL
- `:openbank-vop-service:koverVerify`, `:openbank-party-service:compileTestKotlin` → BUILD SUCCESSFUL

## Follow-ups (not in this PR)

1. `.github/workflows/pact-drift-check.yml` needs `:openbank-vop-service:test --tests "com.openbank.vop.contract.*PactConsumerTest"` added to its regenerate step — an omitted consumer reads as **passing** there, per that file's own comment. Not edited here because PR #2309 is rewriting that workflow; a consolidated PR should add it.
2. Convert `AccountEventPactProviderVerificationTest` to per-interaction target dispatch so account-service can back an HTTP consumer contract (its KDoc already anticipates this), then pin hop 1.

Refs #2255