### PR TITLE
test(ap2): assert the served API matches the committed openapi.yaml

### DIFF
--- a/openbank-ap2-service/build.gradle.kts
+++ b/openbank-ap2-service/build.gradle.kts
@@ -29,6 +29,12 @@ dependencies {
     implementation(project(":openbank-libs-runtime"))
     testImplementation(libs.quarkus.junit5)
     testImplementation(libs.assertj)
+    // Ap2ApiContractTest drives the real endpoint and compares the wire JSON against the committed
+    // openapi.yaml, which it PARSES rather than greps. jackson-dataformat-yaml carries no version:
+    // it is managed by the enforcedPlatform(quarkus.bom) above (testImplementation extends
+    // implementation), so it can never drift from the Jackson the runtime already uses.
+    testImplementation(libs.rest.assured.kotlin)
+    testImplementation("com.fasterxml.jackson.dataformat:jackson-dataformat-yaml")
 }
 
 kover {

--- a/openbank-ap2-service/src/test/kotlin/com/openbank/ap2/contract/Ap2ApiContractTest.kt
+++ b/openbank-ap2-service/src/test/kotlin/com/openbank/ap2/contract/Ap2ApiContractTest.kt
@@ -1,0 +1,314 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+// Copyright (c) OpenBank contributors. Licensed under the GNU Affero General Public License v3.0 only.
+// A commercial licence is available from the maintainers as an alternative to the AGPL-3.0.
+// See LICENSES/AGPL-3.0-only.txt or https://www.gnu.org/licenses/agpl-3.0.html for details.
+package com.openbank.ap2.contract
+
+import com.fasterxml.jackson.databind.JsonNode
+import com.fasterxml.jackson.dataformat.yaml.YAMLMapper
+import io.quarkus.arc.Arc
+import io.quarkus.test.junit.QuarkusTest
+import io.restassured.RestAssured.given
+import io.restassured.http.ContentType
+import jakarta.ws.rs.DELETE
+import jakarta.ws.rs.GET
+import jakarta.ws.rs.HEAD
+import jakarta.ws.rs.OPTIONS
+import jakarta.ws.rs.PATCH
+import jakarta.ws.rs.POST
+import jakarta.ws.rs.PUT
+import jakarta.ws.rs.Path
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.Test
+import java.io.File
+import java.lang.reflect.Method
+import jakarta.enterprise.inject.Any as CdiAny
+
+/**
+ * Spec-conformance contract test for the AP2 verify surface (ADR-0193, issue #2255 dimension C3).
+ *
+ * ## Why this is not a Pact
+ *
+ * openbank-ap2-service has no in-repo consumer and calls nothing in-repo — its caller is an external
+ * agent wallet. A consumer-driven pact needs a real consumer to drive it, and a pact written against
+ * a fictional consumer pins nothing: it would only prove that a test agrees with itself. So the
+ * counterparty here is the **committed `openapi.yaml`**, which is what an external integrator
+ * actually codes against, and the assertion is that the running service and that document describe
+ * the same API.
+ *
+ * This service scored C3=2 before #2291 on a **false positive**: the old scorer matched the bare word
+ * "contract" anywhere under `src/test`, and this tree happened to contain one. Nothing checked the
+ * spec against the implementation. Older reports claiming ap2 is covered are wrong.
+ *
+ * ## The spec is PARSED, never grepped
+ *
+ * Every expectation below is derived from `openapi.yaml` by JSON-Pointer navigation, so the test
+ * cannot pass by matching prose. A `contains("valid")` over the YAML text — the failure mode #2291
+ * documents — sees neither of the drift directions this catches.
+ *
+ * ## Bidirectional, at two levels
+ *
+ * Direction two is the one that catches a live defect class in this repo: copilot-service turned out
+ * to serve a money-path confirm endpoint that was absent from its spec, so checking only "everything
+ * declared is served" would have called it healthy.
+ *
+ *  - **Operations.** The declared `(method, path)` set is compared for *exact* set equality with the
+ *   set the service really serves. The served set is discovered by reflection over the JAX-RS
+ *   resource beans in the CDI container — not by a list maintained here, which would drift the same
+ *   way the spec does. A new endpoint therefore fails this test until it is documented.
+ *  - **Response properties.** The 200 verdict's property names are compared for exact set equality
+ *   with what the endpoint really emits, and each declared property's JSON type is checked against
+ *   the live value.
+ *
+ * `servers:` is resolved before comparing. ap2 declares none, so `/ap2/verify` is the literal served
+ * path — but the resolution is done explicitly rather than assumed, because reading `paths:` alone is
+ * exactly how copilot's spec was misread as broken when its `servers: [- url: /api/v1]` made it
+ * correct.
+ *
+ * The served set is scoped to this service's own package. The four `com.openbank.libs.*` resources
+ * every service inherits from the shared runtime (`/api/v1/info`, `/api/v1/config`,
+ * `/q/openbank/sbom`, `/q/openbank/docs`) are fleet platform surface that no service's `openapi.yaml`
+ * declares; folding them in would make this assertion fail everywhere for a reason that has nothing
+ * to do with ap2's contract.
+ *
+ * ## Driven for real
+ *
+ * `@QuarkusTest` + RestAssured rather than calling the endpoint as a Kotlin object, because the wire
+ * JSON is what the contract is about: Jackson property naming, enum spelling and nullability only
+ * exist after serialisation. In particular a Kotlin `is`/`has`-prefixed property does NOT serialise
+ * the way plain Jackson would (jackson-module-kotlin keeps the constructor-parameter name, so
+ * `isFoo` stays `isFoo` — measured on #2290), so the JSON name is read off the running endpoint here
+ * and never guessed. [com.openbank.ap2.Ap2VerifyEndpointTest] already covers the decision logic
+ * in-process; this test covers the wire format.
+ */
+@QuarkusTest
+class Ap2ApiContractTest {
+
+    private val spec: JsonNode = YAMLMapper().readTree(File(SPEC_PATH))
+
+    private val verifyPost: JsonNode
+        get() = spec.at("/paths/~1ap2~1verify/post").also {
+            assertThat(it.isMissingNode)
+                .describedAs("%s must declare POST /ap2/verify", SPEC_PATH)
+                .isFalse()
+        }
+
+    // ---------------------------------------------------------------- operations, both directions
+
+    @Test
+    fun `the spec declares exactly the operations the service serves`() {
+        val declared = declaredOperations()
+        val served = servedOperations()
+
+        assertThat(declared)
+            .describedAs("operations in %s, resolved against servers:, vs the JAX-RS surface", SPEC_PATH)
+            .isNotEmpty()
+        // Exact set equality is both directions at once: a declared-but-unserved operation is a lie
+        // to integrators, and a served-but-undeclared one is the copilot defect class.
+        assertThat(served)
+            .describedAs("served operations vs declared — extras are undocumented endpoints")
+            .containsExactlyInAnyOrderElementsOf(declared)
+    }
+
+    @Test
+    fun `every declared operation answers on the wire, so no declared path is a 404`() {
+        declaredOperations().forEach { operation ->
+            val (method, path) = operation.split(' ', limit = 2)
+            assertThat(method).isEqualTo("POST") // the only verb this surface has; see the set above
+            val status = postVerify(path, TestPolicyDecisionPoint.ALLOWED_KIND).then().extract().statusCode()
+            // 404 = the path is not routed at all; 405 = it is routed but not for this verb. Both mean
+            // the spec documents an operation the service does not serve. 405 is the likelier of the
+            // two whenever a sibling path template overlaps, so neither is enough on its own.
+            assertThat(status)
+                .describedAs("declared operation '%s' must be routed (got %s)", operation, status)
+                .isNotIn(404, 405)
+        }
+    }
+
+    // ------------------------------------------------------------ response schema, both directions
+
+    @Test
+    fun `the verdict body carries exactly the properties the spec declares`() {
+        val body = verdictBody()
+
+        assertThat(body.keys)
+            .describedAs("live verdict properties vs the 200 schema in %s", SPEC_PATH)
+            .containsExactlyInAnyOrderElementsOf(declaredVerdictProperties().keys)
+    }
+
+    @Test
+    fun `each declared verdict property has the JSON type the spec declares`() {
+        val body = verdictBody()
+
+        declaredVerdictProperties().forEach { (name, schema) ->
+            val declaredType = schema.get("type").asText()
+            val actual = body[name]
+            assertThat(actual).describedAs("verdict property '%s' is absent", name).isNotNull()
+            val matches = when (declaredType) {
+                "boolean" -> actual is Boolean
+                "array" -> actual is List<*>
+                "object" -> actual is Map<*, *>
+                "string" -> actual is String
+                "number", "integer" -> actual is Number
+                else -> error("unhandled declared type '$declaredType' for '$name' — extend this test")
+            }
+            assertThat(matches)
+                .describedAs("'%s' is declared %s but the wire value was %s", name, declaredType, actual)
+                .isTrue()
+        }
+    }
+
+    // ------------------------------------------------------------------------- request-side schema
+
+    @Test
+    fun `every mandate kind and algorithm the spec declares is accepted on the wire`() {
+        val mandateSchema = verifyPost.at("/requestBody/content/application~1json/schema/properties/mandate")
+        val kinds = mandateSchema.at("/properties/kind/enum").map { it.asText() }
+        val algorithms = mandateSchema.at("/properties/algorithm/enum").map { it.asText() }
+        assertThat(kinds).describedAs("declared mandate kinds").isNotEmpty()
+        assertThat(algorithms).describedAs("declared signature algorithms").isNotEmpty()
+
+        // A declared enum value the service cannot deserialise answers 400 — the spelling-drift class
+        // (the spec keeps a kind the enum dropped, or vice versa) that no schema-free test can see.
+        kinds.forEach { kind ->
+            val status = postVerify(VERIFY_PATH, kind).then().extract().statusCode()
+            assertThat(status)
+                .describedAs("declared mandate kind '%s' must deserialise (200 allowed / 403 denied)", kind)
+                .isIn(200, 403)
+        }
+        algorithms.forEach { algorithm ->
+            val status = postVerify(VERIFY_PATH, TestPolicyDecisionPoint.ALLOWED_KIND, algorithm)
+                .then().extract().statusCode()
+            assertThat(status)
+                .describedAs("declared algorithm '%s' must deserialise", algorithm)
+                .isEqualTo(200)
+        }
+    }
+
+    @Test
+    fun `a request missing a spec-required top-level field is rejected, not silently defaulted`() {
+        val required = verifyPost.at("/requestBody/content/application~1json/schema/required").map { it.asText() }
+        assertThat(required).contains("mandate", "payment")
+
+        // Fail-closed is the whole point of an authorization-evidence surface: a 200 here would be a
+        // verdict rendered over an absent mandate.
+        val status = given()
+            .contentType(ContentType.JSON)
+            .header(AGENT_HEADER, AGENT_ID)
+            .body(mapOf("payment" to payment))
+            .post(VERIFY_PATH)
+            .then().extract().statusCode()
+        assertThat(status).describedAs("POST %s without the required 'mandate'", VERIFY_PATH).isNotEqualTo(200)
+    }
+
+    @Test
+    fun `the spec documents the fail-closed denial status the endpoint really returns`() {
+        assertThat(verifyPost.at("/responses/403").isMissingNode)
+            .describedAs("%s must document the policy-denied response", SPEC_PATH)
+            .isFalse()
+
+        postVerify(VERIFY_PATH, TestPolicyDecisionPoint.DENIED_KIND).then().statusCode(403)
+    }
+
+    // ------------------------------------------------------------------------------------ helpers
+
+    /** `(METHOD, path)` pairs the spec declares, each resolved against the `servers:` base path. */
+    private fun declaredOperations(): Set<String> {
+        // Read `servers:` explicitly. A spec whose paths look wrong is often a spec whose server base
+        // path was never applied — the mistake #2255 nearly repeated on copilot-service.
+        val base = spec.at("/servers/0/url").let { if (it.isMissingNode) "" else it.asText() }
+            .trimEnd('/')
+        return spec.at("/paths").properties().flatMap { (rawPath, pathItem) ->
+            pathItem.fieldNames().asSequence()
+                .map { it.uppercase() }
+                .filter { it in HTTP_METHODS }
+                .map { method -> "$method ${normalise(base + rawPath)}" }
+                .toList()
+        }.toSet()
+    }
+
+    /**
+     * `(METHOD, path)` pairs the running service really serves, discovered from the CDI container:
+     * every JAX-RS resource in Quarkus is a bean, so this cannot miss one the way a hand-kept list
+     * would. Scoped to this service's package — see the class KDoc on the shared `com.openbank.libs`
+     * platform resources.
+     */
+    private fun servedOperations(): Set<String> =
+        Arc.container().beanManager().getBeans(Any::class.java, CdiAny.Literal.INSTANCE)
+            .asSequence()
+            .map { it.beanClass }
+            .filter { it.name.startsWith(SERVICE_PACKAGE) && it.getAnnotation(Path::class.java) != null }
+            .flatMap { resource ->
+                val basePath = resource.getAnnotation(Path::class.java).value
+                resource.declaredMethods.asSequence().mapNotNull { method ->
+                    httpMethodOf(method)?.let { verb ->
+                        val sub = method.getAnnotation(Path::class.java)?.value ?: ""
+                        "$verb ${normalise("$basePath/$sub")}"
+                    }
+                }
+            }
+            .toSet()
+
+    private fun httpMethodOf(method: Method): String? = when {
+        method.getAnnotation(GET::class.java) != null -> "GET"
+        method.getAnnotation(POST::class.java) != null -> "POST"
+        method.getAnnotation(PUT::class.java) != null -> "PUT"
+        method.getAnnotation(DELETE::class.java) != null -> "DELETE"
+        method.getAnnotation(PATCH::class.java) != null -> "PATCH"
+        method.getAnnotation(HEAD::class.java) != null -> "HEAD"
+        method.getAnnotation(OPTIONS::class.java) != null -> "OPTIONS"
+        else -> null
+    }
+
+    /** Collapse duplicate separators and drop a trailing one, so `/a//b/` and `/a/b` compare equal. */
+    private fun normalise(path: String): String = "/" + path.split('/').filter { it.isNotEmpty() }.joinToString("/")
+
+    /** The 200 verdict schema's declared properties, name -> schema node. */
+    private fun declaredVerdictProperties(): Map<String, JsonNode> =
+        verifyPost.at("/responses/200/content/application~1json/schema/properties")
+            .properties().associate { it.key to it.value }
+
+    private fun verdictBody(): Map<String, Any> = postVerify(VERIFY_PATH, TestPolicyDecisionPoint.ALLOWED_KIND)
+        .then().statusCode(200)
+        .extract().body().jsonPath().getMap("")
+
+    private fun postVerify(path: String, kind: String, algorithm: String = "ED25519") = given()
+        .contentType(ContentType.JSON)
+        .header(AGENT_HEADER, AGENT_ID)
+        .body(mapOf("mandate" to mandate(kind, algorithm), "payment" to payment))
+        .post(path)
+
+    private fun mandate(kind: String, algorithm: String) = mapOf(
+        "kind" to kind,
+        "issuer" to "did:example:issuer-1",
+        "subject" to "cust-1",
+        "algorithm" to algorithm,
+        "signingInput" to "header.payload",
+        "signatureB64" to "c2lnbmF0dXJl",
+        "constraints" to mapOf(
+            "payee" to PAYEE,
+            "amountCapMinor" to 100_00,
+            "currency" to "CZK",
+            "expiresAt" to "2026-12-31T00:00:00Z",
+            "singleUse" to false,
+        ),
+    )
+
+    /** Inside every constraint, so the verdict is shaped by the signature stage alone. */
+    private val payment = mapOf(
+        "payee" to PAYEE,
+        "amountMinor" to 50_00,
+        "currency" to "CZK",
+        "at" to "2026-06-01T00:00:00Z",
+    )
+
+    private companion object {
+        const val SPEC_PATH = "src/main/resources/openapi.yaml"
+        const val SERVICE_PACKAGE = "com.openbank.ap2."
+        const val VERIFY_PATH = "/ap2/verify"
+        const val AGENT_HEADER = "X-Agent-Id"
+        const val AGENT_ID = "agent:contract-test"
+        const val PAYEE = "CZ6508000000192000145399"
+        val HTTP_METHODS = setOf("GET", "POST", "PUT", "DELETE", "PATCH", "HEAD", "OPTIONS")
+    }
+}

--- a/openbank-ap2-service/src/test/kotlin/com/openbank/ap2/contract/TestPolicyDecisionPoint.kt
+++ b/openbank-ap2-service/src/test/kotlin/com/openbank/ap2/contract/TestPolicyDecisionPoint.kt
@@ -1,0 +1,41 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+// Copyright (c) OpenBank contributors. Licensed under the GNU Affero General Public License v3.0 only.
+// A commercial licence is available from the maintainers as an alternative to the AGPL-3.0.
+// See LICENSES/AGPL-3.0-only.txt or https://www.gnu.org/licenses/agpl-3.0.html for details.
+package com.openbank.ap2.contract
+
+import com.openbank.libs.authz.AuthzDecision
+import com.openbank.libs.authz.AuthzQuery
+import com.openbank.libs.authz.PolicyDecisionPoint
+import jakarta.annotation.Priority
+import jakarta.enterprise.context.ApplicationScoped
+import jakarta.enterprise.inject.Alternative
+
+/**
+ * Stands in for the OPA sidecar, which does not exist in a test JVM. Without it `AuthzProducer`
+ * builds a client against `localhost:8181`, [com.openbank.ap2.infrastructure.rest.Ap2VerifyEndpoint]
+ * fails **closed** with 503 on every call, and the 200 branch — the only branch `openapi.yaml` gives
+ * a response schema for — is unreachable. Fail-closed is correct behaviour; it just means the wire
+ * contract cannot be observed without a PDP.
+ *
+ * Deterministic rather than a mock, so one running container serves both documented outcomes without
+ * per-test stubbing: a `PAYMENT` mandate is allowed, every other kind denied. The decision is keyed
+ * on the `mandateKind` attribute the endpoint really passes, so this alternative also fails if the
+ * endpoint stops sending it.
+ */
+@ApplicationScoped
+@Alternative
+@Priority(1)
+class TestPolicyDecisionPoint : PolicyDecisionPoint {
+    override suspend fun allow(query: AuthzQuery): AuthzDecision =
+        if (query.attributes["mandateKind"] == ALLOWED_KIND) {
+            AuthzDecision(allow = true)
+        } else {
+            AuthzDecision(allow = false, reason = "no matching allow rule")
+        }
+
+    companion object {
+        const val ALLOWED_KIND = "PAYMENT"
+        const val DENIED_KIND = "INTENT"
+    }
+}


### PR DESCRIPTION
## What

`Ap2ApiContractTest` — openbank-ap2-service's first contract coverage (issue #2255, dimension C3).

Before #2291 this service scored C3=2 on a **false positive**: the old scorer matched the bare word
"contract" anywhere under `src/test`, and this tree happened to contain one. Nothing checked the spec
against the implementation. Older output claiming ap2 is covered is wrong.

## Why this is not a Pact

Nothing in-repo calls ap2 and ap2 calls nothing in-repo — its caller is an external agent wallet. A
consumer-driven pact needs a real consumer to drive it, and one written against a fictional consumer
pins nothing: it would prove only that a test agrees with itself. So the counterparty is the
**committed `openapi.yaml`**, the document an external integrator actually codes against, and the
assertion is that it and the running service describe the same API.

The spec is **parsed**, never grepped — every expectation is derived by JSON-Pointer navigation, so
no check can pass by matching prose (the #2291 failure mode).

## Bidirectional, at two levels

Direction two is the one that matters: copilot-service turned out to serve a money-path confirm
endpoint absent from its spec, so checking only "everything declared is served" calls that healthy.

- **Operations** — the declared `(method, path)` set is compared for *exact set equality* against the
  set the service really serves. The served set is discovered by reflection over the JAX-RS resource
  beans in the CDI container, not from a list kept in the test, which would drift exactly the way the
  spec does. A new endpoint fails this test until it is documented.
- **Response properties** — the 200 verdict's property names are compared for exact set equality with
  what the endpoint really emits, and each declared property's JSON type against the live value.

Plus: every declared operation is driven and must not answer 404 **or 405** (a routed path with the
wrong verb — the likelier of the two whenever a sibling path template overlaps); every declared
`kind`/`algorithm` enum value must deserialise; a request missing a spec-required field must not
produce a verdict; and the documented 403 fail-closed status is driven for real.

`servers:` is resolved before comparing. ap2 declares none, so `/ap2/verify` is the literal path —
but the resolution is explicit rather than assumed, because reading `paths:` alone is exactly how
copilot's spec was misread as broken when its `servers: [- url: /api/v1]` made it correct.

The served set is scoped to `com.openbank.ap2.*`. The four `com.openbank.libs.*` resources every
service inherits from the shared runtime (`/api/v1/info`, `/api/v1/config`, `/q/openbank/sbom`,
`/q/openbank/docs`) are fleet platform surface that no service `openapi.yaml` declares; folding them
in would fail this assertion everywhere for a reason unrelated to ap2's contract.

Driven with `@QuarkusTest` + RestAssured rather than as a Kotlin call, because the wire JSON is what
the contract is about — Jackson naming, enum spelling and nullability only exist after serialisation.
No JSON name is guessed: jackson-module-kotlin keeps the constructor-parameter name, so an
`is`-prefixed property stays `isFoo` rather than becoming `foo` (measured on #2290). ap2's verdict has
no such property, but the names are read off the running endpoint either way.

`TestPolicyDecisionPoint` stands in for the OPA sidecar, which does not exist in a test JVM — without
it the endpoint fails **closed** with 503 on every call and the 200 branch, the only branch with a
declared response schema, is unreachable. It is deterministic rather than a mock (allows `PAYMENT`,
denies every other kind), so one container serves both the documented 200 and the documented 403, and
it keys on the `mandateKind` attribute the endpoint really passes — so it also fails if the endpoint
stops sending it.

## Spec vs implementation

**They agree.** All seven checks pass against the committed `openapi.yaml` with **no spec change** —
this PR is a pure `test` commit. Had they disagreed, the spec fix would have been a separate
`fix(ap2)` PR.

One thing worth a follow-up, deliberately *not* fixed here because it would be a spec change: the 200
schema declares `evidence: { type: object }` with no properties, so an integrator gets no schema for
the evidence body. The test pins what the spec declares; it cannot pin what the spec omits.

## Falsified in three directions — measured, not asserted

Verdicts read from the JUnit XML, not the console.

**1. Service emits a field the spec does not declare** (added `undocumentedField` to `MandateVerdict`):
```
tests="7" failures="1"
Expecting actual:  ["valid", "evidence", "failures", "undocumentedField"]
to contain exactly in any order: ["valid", "failures", "evidence"]
but the following elements were unexpected: ["undocumentedField"]
```

**2. Spec declares a property the service does not emit** (added `reasonCode` to the 200 schema):
```
tests="7" failures="2"
Expecting actual: ["valid", "evidence", "failures"]
to contain exactly in any order: ["valid", "failures", "reasonCode", "evidence"]
but could not find the following elements: ["reasonCode"]
---
[verdict property 'reasonCode' is absent] Expecting actual not to be null
```

**3. An undocumented endpoint appears** — the copilot defect class (added a `GET
/ap2/verify/undocumented-confirm`):
```
tests="7" failures="1"
[served operations vs declared — extras are undocumented endpoints]
Expecting actual: ["GET /ap2/verify/undocumented-confirm", "POST /ap2/verify"]
to contain exactly in any order: ["POST /ap2/verify"]
but the following elements were unexpected: ["GET /ap2/verify/undocumented-confirm"]
```

All three edits were reverted; the green state is `tests="7" skipped="0" failures="0" errors="0"`,
and every test name is listed in the XML, so the count is the proof they all ran.

## Gates

`:openbank-ap2-service:build :quarkusBuild :detekt :ktlintCheck :koverVerify` → `BUILD SUCCESSFUL`.

## Dependencies

`jackson-dataformat-yaml` is declared with **no version** — managed by the `enforcedPlatform(quarkus.bom)`
already in this file (`testImplementation` extends `implementation`), so it cannot drift from the
Jackson the runtime uses. It was already resolvable transitively via `quarkus-config-yaml`; declaring
it makes the dependency intentional rather than accidental.

## Release scope

Type `test` is hidden, so this cuts no release even though `build.gradle.kts` sits on a releasing path.

Refs #2255
