### PR TITLE
test(mcp): pin the consent, balance and transaction reads with consumer pacts

### DIFF
--- a/openbank-balance-service/src/test/kotlin/com/openbank/balance/contract/BalancePactProviderVerificationTest.kt
+++ b/openbank-balance-service/src/test/kotlin/com/openbank/balance/contract/BalancePactProviderVerificationTest.kt
@@ -259,4 +259,18 @@ class BalancePactProviderVerificationTest {
     fun stateInitializeAccountHasNoBalance() {
         // No-op: the Testcontainer DB is clean for e5e5 on every run.
     }
+
+    /**
+     * State for mcp-service's `BalanceReadPactConsumerTest` (issue #2255, ADR-0195). No setup:
+     * `getBalances` skips its owner check when no `X-Customer-Party-Id` header is present (mcp is a
+     * service-to-service reader and sends none) and answers 200 with an empty `balances` array for
+     * an account it holds nothing for. That 200 is the point of the interaction — it proves the
+     * route exists; a 404 would prove nothing, since Quarkus answers 404 for an absent route too.
+     */
+    @State("balance-service is reachable and holds no balances for the pact account")
+    fun stateNoBalancesForPactAccount() {
+        // Intentionally empty — a fresh Testcontainer DB satisfies it by construction. Declared so
+        // the state is an explicit part of the contract; pact-jvm passes silently over an unhandled
+        // state name, which is how the missing states in #468 stayed invisible.
+    }
 }

--- a/openbank-consent-service/build.gradle.kts
+++ b/openbank-consent-service/build.gradle.kts
@@ -49,6 +49,9 @@ dependencies {
     testImplementation(libs.smallrye.reactive.messaging.inmemory)
     // Consumer-driven contract test against sca-service getChallenge (ADR-0063 P2 Batch B).
     testImplementation(libs.pact.consumer)
+    // Provider-side verification (ADR-0063 git-pact): ConsentPactProviderVerificationTest replays the
+    // consumer pacts in pacts/ that name openbank-consent-service as provider (issue #2255).
+    testImplementation(libs.pact.provider)
 }
 
 kover {

--- a/openbank-consent-service/src/test/kotlin/com/openbank/consent/contract/ConsentPactProviderVerificationTest.kt
+++ b/openbank-consent-service/src/test/kotlin/com/openbank/consent/contract/ConsentPactProviderVerificationTest.kt
@@ -1,0 +1,175 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright (c) OpenBank contributors. Licensed under the Apache License, Version 2.0.
+// See LICENSE in the repository root or https://www.apache.org/licenses/LICENSE-2.0 for details.
+
+package com.openbank.consent.contract
+
+import au.com.dius.pact.provider.junit5.HttpTestTarget
+import au.com.dius.pact.provider.junit5.PactVerificationContext
+import au.com.dius.pact.provider.junit5.PactVerificationInvocationContextProvider
+import au.com.dius.pact.provider.junitsupport.IgnoreNoPactsToVerify
+import au.com.dius.pact.provider.junitsupport.Provider
+import au.com.dius.pact.provider.junitsupport.State
+import au.com.dius.pact.provider.junitsupport.loader.PactFolder
+import com.openbank.consent.it.ConsentPostgresRedisTestResource
+import io.quarkus.test.common.QuarkusTestResource
+import io.quarkus.test.common.QuarkusTestResourceLifecycleManager
+import io.quarkus.test.junit.QuarkusTest
+import io.quarkus.test.security.TestSecurity
+import io.smallrye.reactive.messaging.memory.InMemoryConnector
+import jakarta.inject.Inject
+import org.eclipse.microprofile.config.inject.ConfigProperty
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.TestTemplate
+import org.junit.jupiter.api.extension.ExtendWith
+import java.sql.Connection
+import javax.sql.DataSource
+
+/**
+ * Provider-side Pact verification for consent-service (issue #2255 dimension C3). consent-service is
+ * named as provider by consumer pacts in `pacts/` and until now **nothing replayed them** — a
+ * committed pact nobody verifies is worthless against the likeliest defect, a request path the
+ * provider does not serve (CLAUDE.md "Contract tests"; #2269 is that defect shipping).
+ *
+ * Git-pact (`@PactFolder`, ADR-0063): reads the consumer pacts from the monorepo-root `pacts/` dir
+ * (resolved relative to this module's working directory) and replays each interaction against the
+ * running Quarkus test instance. This **always runs** — no broker, no CI secret, no gate — which is
+ * exactly why ADR-0063 chose git-pact over a Pact Broker for the verification that must not be
+ * skippable. (The broker-based classes elsewhere in the fleet exist for ADR-0092's `can-i-deploy`,
+ * a different job; if consent-service is ever added to that gate, extend THIS class rather than
+ * adding a second one — see below.)
+ *
+ * **This must remain the ONLY `@Provider("openbank-consent-service")` class in the repo.** Two
+ * classes with the same provider name each pull every pact naming that provider and fight over the
+ * same `@BeforeEach` target, so they collide.
+ *
+ * Authentication: `ConsentResource` is `@RolesAllowed("ROLE_SERVICE", "ROLE_OPERATOR", "ROLE_ADMIN")`
+ * at class level. `@TestSecurity` cannot annotate a `@TestTemplate`, so it is applied to the class
+ * and Quarkus's test-security extension supplies the identity on every replayed request — matching
+ * the production path, where callers present an M2M client-credentials token (ADR-0018). The
+ * per-method `@Authorize` checks are advisory here: `authz.enforce` defaults to `false`, so no OPA
+ * sidecar is needed for this test (see `application.yaml`).
+ *
+ * Kafka: the outgoing `consent-events-out` emitter is switched to the in-memory connector, and the
+ * outbox dispatcher is disabled — the replayed interactions are reads, so neither is exercised, but
+ * a real broker would otherwise be required just to boot.
+ *
+ * Seeding is done over **JDBC, not the reactive repository**, on purpose: pact-jvm invokes `@State`
+ * callbacks by reflection on the bare JUnit thread, which carries no Vert.x context, so a
+ * `runBlocking { consentRepository.save(...) }` there throws `No current Vertx context found`
+ * (party-service works around this with a duplicated Vert.x context; a plain blocking INSERT is
+ * simpler and the schema here is three flat tables).
+ *
+ * IMPORTANT: if a consumer changes its contract, regenerate the pact JSON on the consumer side and
+ * commit it in the same PR, or this test verifies a stale contract.
+ * `@IgnoreNoPactsToVerify(ignoreIoErrors)` makes a missing/unreadable pact a skip, not a failure.
+ */
+@QuarkusTest
+@QuarkusTestResource(ConsentPactProviderVerificationTest.InMemoryKafkaResource::class)
+@QuarkusTestResource(ConsentPostgresRedisTestResource::class)
+@TestSecurity(user = "pact-verifier", roles = ["ROLE_SERVICE", "ROLE_OPERATOR"])
+@Provider("openbank-consent-service")
+@PactFolder("../pacts")
+@IgnoreNoPactsToVerify(ignoreIoErrors = "true")
+class ConsentPactProviderVerificationTest {
+
+    class InMemoryKafkaResource : QuarkusTestResourceLifecycleManager {
+        override fun start(): Map<String, String> {
+            val props = InMemoryConnector.switchOutgoingChannelsToInMemory("consent-events-out").toMutableMap()
+            props["openbank.outbox.dispatch-enabled"] = "false"
+            return props
+        }
+
+        override fun stop() = InMemoryConnector.clear()
+    }
+
+    @ConfigProperty(name = "quarkus.http.test-port", defaultValue = "8081")
+    lateinit var testPort: String
+
+    @Inject
+    lateinit var dataSource: DataSource
+
+    @BeforeEach
+    fun configureTarget(context: PactVerificationContext?) {
+        if (context == null) return
+        context.target = HttpTestTarget("localhost", testPort.toInt())
+        context.addStateChangeHandlers(this)
+    }
+
+    @TestTemplate
+    @ExtendWith(PactVerificationInvocationContextProvider::class)
+    fun verifyPacts(context: PactVerificationContext?) {
+        // context is null on the @IgnoreNoPactsToVerify dummy invocation — skip gracefully.
+        context?.verifyInteraction()
+    }
+
+    /**
+     * State for mcp-service's `ConsentValidatePactConsumerTest` (ADR-0195): the live-validate call
+     * every MCP banking tool fails closed on. Seeds an ACTIVE AISP consent whose grantee, scope and
+     * covered IBAN all match the request, so `POST /{id}/validate` answers `valid: true` with the
+     * `scopes` / `grantedAccounts` / `frequencyPerDay` projection the consumer reads.
+     *
+     * `frequency_per_day` is stored but NOT what the response reports — `Consent.frequencyPerDay()`
+     * derives 4 from the AISP scope set (PSD2 RTS Art. 10(2)(b)), so the pinned 4 is deterministic
+     * regardless of the column. The column is still written because a CHECK constrains it to 1..4.
+     */
+    @State("an ACTIVE AISP consent covers the pact account for the pact grantee")
+    fun activeAispConsentExists() {
+        dataSource.connection.use { c ->
+            c.autoCommit = false
+            // Idempotent: pact-jvm 4.7.3 invokes each @State setup callback twice per interaction,
+            // and this inserts with a fixed id.
+            if (!consentExists(c)) {
+                insertActiveConsent(c)
+                insertRow(c, "INSERT INTO consent_scopes (consent_id, scope) VALUES (?::uuid, ?)", "ACCOUNTS_READ")
+                insertRow(c, "INSERT INTO consent_accounts (consent_id, iban) VALUES (?::uuid, ?)", PACT_ACCOUNT_IBAN)
+                c.commit()
+            }
+        }
+    }
+
+    private fun consentExists(c: Connection): Boolean =
+        c.prepareStatement("SELECT 1 FROM consents WHERE id = ?::uuid").use { ps ->
+            ps.setString(1, PACT_CONSENT_ID)
+            ps.executeQuery().use { rs -> rs.next() }
+        }
+
+    private fun insertActiveConsent(c: Connection) = c.prepareStatement(INSERT_CONSENT_SQL).use { ps ->
+        ps.setString(1, PACT_CONSENT_ID)
+        ps.setString(2, PACT_PARTY_ID)
+        ps.setString(3, PACT_GRANTEE_ID)
+        ps.executeUpdate()
+    }
+
+    /** Child-table insert: both `consent_scopes` and `consent_accounts` are (consent_id, value). */
+    private fun insertRow(c: Connection, sql: String, value: String) = c.prepareStatement(sql).use { ps ->
+        ps.setString(1, PACT_CONSENT_ID)
+        ps.setString(2, value)
+        ps.executeUpdate()
+    }
+
+    @State("no consent exists with the pact unknown-consent id")
+    fun unknownConsentDoesNotExist() {
+        // No setup: a fresh Testcontainer DB satisfies this by construction, and nothing in this
+        // class inserts that id. Declared so the state is an explicit part of the contract rather
+        // than an unhandled name pact-jvm would pass over silently.
+    }
+
+    private companion object {
+        private val INSERT_CONSENT_SQL = """
+            INSERT INTO consents (
+                id, party_id, grantee_id, grantee_type, grantee_name, status,
+                valid_from, valid_to, frequency_per_day, created_at, updated_at
+            ) VALUES (
+                ?::uuid, ?::uuid, ?, 'CUSTOMER_AGENT', 'Pact Verify MCP Agent', 'ACTIVE',
+                NOW() - INTERVAL '1 day', NOW() + INTERVAL '30 days', 4, NOW(), NOW()
+            )
+        """.trimIndent()
+
+        /** Must equal `ConsentValidatePactConsumerTest.PACT_CONSENT_ID` (openbank-mcp-service). */
+        const val PACT_CONSENT_ID = "c1c1c1c1-d2d2-4e4e-8f8f-a9a9a9a9a9a9"
+        const val PACT_PARTY_ID = "c2c2c2c2-d3d3-4e4e-8f8f-a8a8a8a8a8a8"
+        const val PACT_GRANTEE_ID = "agent:pact-verify-mcp"
+        const val PACT_ACCOUNT_IBAN = "CZ6508000000192000145399"
+    }
+}

--- a/openbank-mcp-service/build.gradle.kts
+++ b/openbank-mcp-service/build.gradle.kts
@@ -34,6 +34,10 @@ dependencies {
     testImplementation(libs.quarkus.junit5)
     testImplementation(libs.assertj)
     testImplementation(libs.rest.assured.kotlin)
+    // Consumer-driven contract tests (ADR-0063, issue #2255 dimension C3). mcp's read ports became
+    // real HTTP clients in #2262 and are not wired as the default yet — pinning the routes now is
+    // what keeps the ADR-0195 cutover from shipping a call to a path that does not exist (#2269).
+    testImplementation(libs.pact.consumer)
 }
 
 kover {
@@ -50,4 +54,24 @@ kover {
             }
         }
     }
+}
+
+// Pact: write the generated consumer contracts into the repo-root pacts/ dir (git-pact, ADR-0063),
+// where the providers replay them. The consumer tests rewrite the files on every run and the result
+// is committed; pact-drift-check.yml fails the build if a committed pact and a fresh regeneration
+// diverge. NOTE: must be set on the test JVM fork, not the Gradle daemon (System.setProperty would
+// not propagate). The pactbroker.* keys are forwarded so CI's publish step behaves as elsewhere.
+tasks.withType<Test> {
+    systemProperty("pact.rootDir", "${rootProject.projectDir}/pacts")
+    listOf(
+        "pactbroker.url",
+        "pactbroker.auth.username",
+        "pactbroker.auth.password",
+        "pactbroker.enablePending",
+        "pactbroker.providerBranch",
+        "pact.verifier.publishResults",
+        "pact.provider.version",
+        "pact.provider.branch",
+        "pact.provider.tag",
+    ).forEach { key -> System.getProperty(key)?.let { systemProperty(key, it) } }
 }

--- a/openbank-mcp-service/src/test/kotlin/com/openbank/mcp/contract/BalanceReadPactConsumerTest.kt
+++ b/openbank-mcp-service/src/test/kotlin/com/openbank/mcp/contract/BalanceReadPactConsumerTest.kt
@@ -1,0 +1,124 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+// Copyright (c) OpenBank contributors. Licensed under the GNU Affero General Public License v3.0 only.
+// A commercial licence is available from the maintainers as an alternative to the AGPL-3.0.
+// See LICENSES/AGPL-3.0-only.txt or https://www.gnu.org/licenses/agpl-3.0.html for details.
+package com.openbank.mcp.contract
+
+import au.com.dius.pact.consumer.MockServer
+import au.com.dius.pact.consumer.dsl.LambdaDsl.newJsonBody
+import au.com.dius.pact.consumer.dsl.PactDslWithProvider
+import au.com.dius.pact.consumer.junit5.PactConsumerTestExt
+import au.com.dius.pact.consumer.junit5.PactTestFor
+import au.com.dius.pact.core.model.PactSpecVersion
+import au.com.dius.pact.core.model.RequestResponsePact
+import au.com.dius.pact.core.model.annotations.Pact
+import com.fasterxml.jackson.databind.ObjectMapper
+import com.openbank.mcp.infrastructure.read.BalanceServiceClient
+import io.restassured.RestAssured.given
+import jakarta.ws.rs.Path
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.extension.ExtendWith
+
+/**
+ * Consumer-driven contract for `GET /api/v1/balances/{accountId}` — the balance read behind the MCP
+ * `get_balance` tool (ADR-0195 step 2). The generated pact is committed to
+ * `pacts/openbank-mcp-service-openbank-balance-service.json` (git-pact, ADR-0063) and replayed by
+ * `BalancePactProviderVerificationTest` in openbank-balance-service.
+ *
+ * What this pact is FOR, and it is not the response shape: mcp's client returns a raw
+ * [com.fasterxml.jackson.databind.JsonNode] which
+ * [com.openbank.mcp.infrastructure.read.RealAccountReadPort] passes straight through to the tool
+ * caller, so no field of the body is load-bearing on this side. The **route** is. A wrong path is
+ * invisible to every unit test (the port is mocked) and invisible to a consumer pact on its own
+ * (the mock server answers anything) — only the provider replay can catch it, and #2269 is what
+ * happens when nobody replays: finrep shipped a call to a ledger path that had never existed. So
+ * this contract exists to be replayed, and the assertion here is deliberately thin.
+ *
+ * The interaction needs no seeded data: `BalanceResource.getBalances` skips its owner check when no
+ * `X-Customer-Party-Id` header is sent (mcp never sends one — it is a service-to-service read) and
+ * answers **200** with an empty `balances` array for an account it holds nothing for. That 200 is
+ * the whole point: a 404 would prove nothing, because Quarkus answers 404 for an absent route too.
+ * `minArrayLike(min = 0)` therefore matches the provider's empty-DB response while still recording
+ * the element shape (the same reason `LedgerTrialBalancePactConsumerTest` uses min = 0).
+ *
+ * **The expected path is a LITERAL; only the outgoing request is reflected off the client's
+ * `@Path`** — deriving both sides would be vacuous (CLAUDE.md "Contract tests", measured on #2290).
+ *
+ * IMPORTANT — regenerate on change: re-run this test (`./gradlew :openbank-mcp-service:test --tests
+ * "*BalanceReadPactConsumerTest*"`) and commit the updated pact JSON in the same PR.
+ */
+@ExtendWith(PactConsumerTestExt::class)
+@PactTestFor(providerName = "openbank-balance-service", pactVersion = PactSpecVersion.V3)
+class BalanceReadPactConsumerTest {
+
+    private val mapper = ObjectMapper()
+
+    @Pact(consumer = CONSUMER, provider = PROVIDER)
+    fun balancesForAccountPact(builder: PactDslWithProvider): RequestResponsePact = builder
+        .given("balance-service is reachable and holds no balances for the pact account")
+        .uponReceiving("GET the balances the MCP get_balance tool returns verbatim")
+        .path(EXPECTED_BALANCES_PATH)
+        .method("GET")
+        .headers(mapOf("Accept" to "application/json"))
+        .willRespondWith()
+        .status(200)
+        .headers(mapOf("Content-Type" to "application/json"))
+        .body(
+            newJsonBody { o ->
+                // min = 0: the provider replays against a fresh Testcontainer DB with no balances.
+                // The element template records the shape without requiring a row to exist.
+                o.minArrayLike("balances", 0, 1) { b ->
+                    b.stringType("currency", "CZK")
+                    b.decimalType("available", 1_000.00)
+                }
+            }.build(),
+        )
+        .toPact()
+
+    @Test
+    @PactTestFor(pactMethod = "balancesForAccountPact")
+    fun `the balances response is a JsonNode the tool passes through unchanged`(mockServer: MockServer) {
+        assertThat(clientDerivedBalancesPath())
+            .describedAs("BalanceServiceClient's @Path no longer produces the path this pact pins")
+            .isEqualTo(EXPECTED_BALANCES_PATH)
+
+        val raw = given()
+            .baseUri(mockServer.getUrl())
+            .accept("application/json")
+            // Reflected off the client, NOT retyped: this is the request the real client issues.
+            .get(clientDerivedBalancesPath())
+            .then()
+            .statusCode(200)
+            .extract().asString()
+
+        // The port hands this straight to the caller, so "parses as JSON and carries the envelope
+        // key" is the whole of mcp's dependency on the body.
+        val node = mapper.readTree(raw)
+        assertThat(node.has("balances")).isTrue()
+        assertThat(node.path("balances").isArray).isTrue()
+    }
+
+    private companion object {
+        const val CONSUMER = "openbank-mcp-service"
+        const val PROVIDER = "openbank-balance-service"
+
+        /** Any well-formed UUID: the provider state deliberately holds no balances for it. */
+        const val PACT_ACCOUNT_ID = "d1d1d1d1-e2e2-4f4f-8a8a-b9b9b9b9b9b9"
+
+        /**
+         * LITERAL, retyped from balance-service's `BalanceResource` (`@Path("/api/v1/balances")` +
+         * `@GET @Path("/{accountId}")`). Never derive this from the client.
+         */
+        const val EXPECTED_BALANCES_PATH = "/api/v1/balances/$PACT_ACCOUNT_ID"
+
+        fun clientDerivedBalancesPath(): String {
+            val base = BalanceServiceClient::class.java.getAnnotation(Path::class.java).value
+            val method = BalanceServiceClient::class.java.methods
+                .single { it.name == "getBalances" }
+                .getAnnotation(Path::class.java)
+                .value
+            return (base + method).replace("{accountId}", PACT_ACCOUNT_ID)
+        }
+    }
+}

--- a/openbank-mcp-service/src/test/kotlin/com/openbank/mcp/contract/ConsentValidatePactConsumerTest.kt
+++ b/openbank-mcp-service/src/test/kotlin/com/openbank/mcp/contract/ConsentValidatePactConsumerTest.kt
@@ -1,0 +1,213 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+// Copyright (c) OpenBank contributors. Licensed under the GNU Affero General Public License v3.0 only.
+// A commercial licence is available from the maintainers as an alternative to the AGPL-3.0.
+// See LICENSES/AGPL-3.0-only.txt or https://www.gnu.org/licenses/agpl-3.0.html for details.
+package com.openbank.mcp.contract
+
+import au.com.dius.pact.consumer.MockServer
+import au.com.dius.pact.consumer.dsl.LambdaDsl.newJsonBody
+import au.com.dius.pact.consumer.dsl.PactDslWithProvider
+import au.com.dius.pact.consumer.junit5.PactConsumerTestExt
+import au.com.dius.pact.consumer.junit5.PactTestFor
+import au.com.dius.pact.core.model.PactSpecVersion
+import au.com.dius.pact.core.model.RequestResponsePact
+import au.com.dius.pact.core.model.annotations.Pact
+import com.fasterxml.jackson.module.kotlin.jacksonObjectMapper
+import com.fasterxml.jackson.module.kotlin.readValue
+import com.openbank.mcp.infrastructure.read.ConsentScopes
+import com.openbank.mcp.infrastructure.read.ConsentValidateClient
+import com.openbank.mcp.infrastructure.read.ConsentValidationResponse
+import com.openbank.mcp.infrastructure.read.ValidateConsentRequest
+import io.restassured.RestAssured.given
+import jakarta.ws.rs.Path
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.extension.ExtendWith
+
+/**
+ * Consumer-driven contract for the single call every MCP banking tool fails closed on:
+ * consent-service `POST /api/v1/consents/{id}/validate` (ADR-0195 / ADR-0126 §D2). The generated
+ * pact is committed to `pacts/openbank-mcp-service-openbank-consent-service.json` (git-pact,
+ * ADR-0063) and replayed by `ConsentPactProviderVerificationTest` (`@PactFolder("../pacts")`) in
+ * openbank-consent-service — that test always runs, no broker involved.
+ *
+ * Why this call above all of mcp's downstream reads: [com.openbank.mcp.infrastructure.read.RealAccountReadPort]
+ * reads `valid` AND `grantedAccounts` off this response, and `grantedAccounts` is the authority for
+ * which IBANs the caller may see — deliberately taken from the live validate response rather than
+ * from the caller's token, so revoke/expire are honoured per call. A drift in either field is a
+ * confidentiality bug, and `RealAccountReadPortTest` cannot see it: the client is mocked there.
+ * The port is still `@Vetoed` (not wired as the default), so this pact exists precisely to make the
+ * ADR-0195 cutover a wiring step rather than a discovery of a route that never existed (#2269).
+ *
+ * **The expected paths are LITERALS; only the outgoing requests are reflected off the client's
+ * `@Path`** (CLAUDE.md "Contract tests", measured on #2290). Deriving both sides is vacuous — the
+ * Pact mock server answers whatever the client asks for, so expectation and request move together
+ * and the test stays green against a nonexistent route. [assertClientPathMatchesContract] pins the
+ * annotations to the literal instead, and the provider replay adjudicates the rest.
+ *
+ * Two interactions, both branches of a fail-closed gate:
+ * - an ACTIVE, in-scope, account-covering consent → `valid: true` plus the projection fields;
+ * - an unknown consent id → HTTP **200** with `valid: false` and `CONSENT_NOT_FOUND`, not a 404.
+ *   `ConsentService.validateConsent` returns an `Invalid` result rather than throwing, so the body
+ *   is the only place the denial appears; a client that trusted the status code would allow it.
+ *
+ * `valid` and `code` are pinned by VALUE, not by a type matcher: a `booleanType` matcher would
+ * accept `false` where the contract says allow, which is exactly the assertion worth making.
+ *
+ * IMPORTANT — regenerate on change: re-run this test (`./gradlew :openbank-mcp-service:test --tests
+ * "*ConsentValidatePactConsumerTest*"`) and commit the updated pact JSON in the same PR;
+ * `.github/workflows/pact-drift-check.yml` fails the build if they diverge.
+ */
+@ExtendWith(PactConsumerTestExt::class)
+@PactTestFor(providerName = "openbank-consent-service", pactVersion = PactSpecVersion.V3)
+class ConsentValidatePactConsumerTest {
+
+    private val mapper = jacksonObjectMapper()
+
+    @Pact(consumer = CONSUMER, provider = PROVIDER)
+    fun activeConsentValidatesPact(builder: PactDslWithProvider): RequestResponsePact = builder
+        .given("an ACTIVE AISP consent covers the pact account for the pact grantee")
+        .uponReceiving("POST validate an ACTIVE ACCOUNTS_READ consent covering the requested IBAN")
+        .path(EXPECTED_VALIDATE_PATH)
+        .method("POST")
+        .headers(mapOf("Accept" to "application/json", "Content-Type" to "application/json"))
+        .body(mapper.writeValueAsString(COVERED_REQUEST))
+        .willRespondWith()
+        .status(200)
+        .headers(mapOf("Content-Type" to "application/json"))
+        .body(
+            newJsonBody { o ->
+                // Value, not type: "the provider allows this" is the contract.
+                o.booleanValue("valid", true)
+                // The projection RealAccountReadPort actually reads. grantedAccounts is the
+                // confidentiality boundary — it decides which IBANs an MCP tool may return.
+                o.array("scopes") { a -> a.stringValue(ConsentScopes.ACCOUNTS_READ) }
+                o.array("grantedAccounts") { a -> a.stringType(PACT_ACCOUNT_IBAN) }
+                // PSD2 RTS Art. 10(2)(b): 4 for any AISP scope, deterministic on the provider.
+                o.numberValue("frequencyPerDay", 4)
+            }.build(),
+        )
+        .toPact()
+
+    @Pact(consumer = CONSUMER, provider = PROVIDER)
+    fun unknownConsentIsDeniedPact(builder: PactDslWithProvider): RequestResponsePact = builder
+        .given("no consent exists with the pact unknown-consent id")
+        .uponReceiving("POST validate an unknown consent id — the fail-closed deny")
+        .path(EXPECTED_UNKNOWN_VALIDATE_PATH)
+        .method("POST")
+        .headers(mapOf("Accept" to "application/json", "Content-Type" to "application/json"))
+        .body(mapper.writeValueAsString(UNKNOWN_REQUEST))
+        .willRespondWith()
+        // 200, not 404 — see the class KDoc. The denial lives in the body.
+        .status(200)
+        .headers(mapOf("Content-Type" to "application/json"))
+        .body(
+            newJsonBody { o ->
+                o.booleanValue("valid", false)
+                o.stringType("reason", "Consent not found")
+                // Value: RealAccountReadPort surfaces this code, and a caller that special-cases
+                // "unknown consent" must be able to rely on it.
+                o.stringValue("code", "CONSENT_NOT_FOUND")
+            }.build(),
+        )
+        .toPact()
+
+    @Test
+    @PactTestFor(pactMethod = "activeConsentValidatesPact")
+    fun `an active in-scope consent validates as allowed and names the granted accounts`(mockServer: MockServer) {
+        assertClientPathMatchesContract(PACT_CONSENT_ID, EXPECTED_VALIDATE_PATH)
+
+        val raw = postValidate(mockServer, clientDerivedValidatePath(PACT_CONSENT_ID), COVERED_REQUEST)
+
+        // Bound into the REAL client DTO, not asserted off a JsonPath: renaming a field on
+        // ConsentValidationResponse reddens HERE, which is the half the provider replay cannot see.
+        val response = mapper.readValue<ConsentValidationResponse>(raw)
+        assertThat(response.valid).isTrue()
+        assertThat(response.grantedAccounts).containsExactly(PACT_ACCOUNT_IBAN)
+        assertThat(response.scopes).containsExactly(ConsentScopes.ACCOUNTS_READ)
+        assertThat(response.frequencyPerDay).isEqualTo(4)
+    }
+
+    @Test
+    @PactTestFor(pactMethod = "unknownConsentIsDeniedPact")
+    fun `an unknown consent id is denied in the body with a machine-readable code`(mockServer: MockServer) {
+        assertClientPathMatchesContract(UNKNOWN_CONSENT_ID, EXPECTED_UNKNOWN_VALIDATE_PATH)
+
+        val raw = postValidate(mockServer, clientDerivedValidatePath(UNKNOWN_CONSENT_ID), UNKNOWN_REQUEST)
+
+        val response = mapper.readValue<ConsentValidationResponse>(raw)
+        assertThat(response.valid).isFalse()
+        assertThat(response.code).isEqualTo("CONSENT_NOT_FOUND")
+        assertThat(response.reason).isNotBlank()
+    }
+
+    private fun postValidate(mockServer: MockServer, path: String, request: ValidateConsentRequest): String = given()
+        .baseUri(mockServer.getUrl())
+        .accept("application/json")
+        .contentType("application/json")
+        .body(mapper.writeValueAsString(request))
+        // Reflected off the client, NOT retyped: this is the request the real client issues.
+        .post(path)
+        .then()
+        .statusCode(200)
+        .extract().asString()
+
+    /**
+     * The asymmetry that makes this contract falsifiable at the consumer layer: the path the client
+     * would really call, recomputed from [ConsentValidateClient]'s own annotations, must equal the
+     * literal this pact promises consent-service. A `@Path` edit on the client reddens here.
+     */
+    private fun assertClientPathMatchesContract(id: String, expected: String) {
+        assertThat(clientDerivedValidatePath(id))
+            .describedAs(
+                "ConsentValidateClient's @Path no longer produces the path this pact pins — either " +
+                    "fix the client or update the literal *and* re-verify against consent-service",
+            )
+            .isEqualTo(expected)
+    }
+
+    private companion object {
+        const val CONSUMER = "openbank-mcp-service"
+        const val PROVIDER = "openbank-consent-service"
+
+        /** Seeded by consent-service's `an ACTIVE AISP consent covers the pact account…` state. */
+        const val PACT_CONSENT_ID = "c1c1c1c1-d2d2-4e4e-8f8f-a9a9a9a9a9a9"
+
+        /** Never seeded — a fresh Testcontainer DB satisfies the unknown-id state by construction. */
+        const val UNKNOWN_CONSENT_ID = "00000000-0000-4000-8000-0000000c0de0"
+
+        const val PACT_GRANTEE_ID = "agent:pact-verify-mcp"
+        const val PACT_ACCOUNT_IBAN = "CZ6508000000192000145399"
+
+        /**
+         * LITERALS, deliberately retyped from consent-service's `ConsentResource`
+         * (`@Path("/api/v1/consents")` + `@POST @Path("/{id}/validate")`). Never derive these from
+         * the client — see the class KDoc.
+         */
+        const val EXPECTED_VALIDATE_PATH = "/api/v1/consents/$PACT_CONSENT_ID/validate"
+        const val EXPECTED_UNKNOWN_VALIDATE_PATH = "/api/v1/consents/$UNKNOWN_CONSENT_ID/validate"
+
+        val COVERED_REQUEST = ValidateConsentRequest(
+            granteeId = PACT_GRANTEE_ID,
+            // The exact ConsentScope enum NAME consent-service deserializes into — a value the
+            // enum lacks would be a 400, which only the provider replay can reveal.
+            requiredScope = ConsentScopes.ACCOUNTS_READ,
+            accountIban = PACT_ACCOUNT_IBAN,
+        )
+
+        val UNKNOWN_REQUEST = ValidateConsentRequest(
+            granteeId = PACT_GRANTEE_ID,
+            requiredScope = ConsentScopes.ACCOUNTS_READ,
+            accountIban = PACT_ACCOUNT_IBAN,
+        )
+
+        fun clientDerivedValidatePath(id: String): String {
+            val base = ConsentValidateClient::class.java.getAnnotation(Path::class.java).value
+            val method = ConsentValidateClient::class.java.methods
+                .single { it.name == "validate" }
+                .getAnnotation(Path::class.java)
+                .value
+            return (base + method).replace("{id}", id)
+        }
+    }
+}

--- a/openbank-mcp-service/src/test/kotlin/com/openbank/mcp/contract/TransactionListPactConsumerTest.kt
+++ b/openbank-mcp-service/src/test/kotlin/com/openbank/mcp/contract/TransactionListPactConsumerTest.kt
@@ -1,0 +1,125 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+// Copyright (c) OpenBank contributors. Licensed under the GNU Affero General Public License v3.0 only.
+// A commercial licence is available from the maintainers as an alternative to the AGPL-3.0.
+// See LICENSES/AGPL-3.0-only.txt or https://www.gnu.org/licenses/agpl-3.0.html for details.
+package com.openbank.mcp.contract
+
+import au.com.dius.pact.consumer.MockServer
+import au.com.dius.pact.consumer.dsl.LambdaDsl.newJsonBody
+import au.com.dius.pact.consumer.dsl.PactDslWithProvider
+import au.com.dius.pact.consumer.junit5.PactConsumerTestExt
+import au.com.dius.pact.consumer.junit5.PactTestFor
+import au.com.dius.pact.core.model.PactSpecVersion
+import au.com.dius.pact.core.model.RequestResponsePact
+import au.com.dius.pact.core.model.annotations.Pact
+import com.fasterxml.jackson.databind.ObjectMapper
+import com.openbank.mcp.infrastructure.read.TransactionServiceClient
+import io.restassured.RestAssured.given
+import jakarta.ws.rs.Path
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.extension.ExtendWith
+
+/**
+ * Consumer-driven contract for `GET /api/v1/transactions?accountId=&limit=` — the read behind the
+ * MCP `list_transactions` tool (ADR-0195 step 2). The generated pact is committed to
+ * `pacts/openbank-mcp-service-openbank-transaction-service.json` (git-pact, ADR-0063) and replayed
+ * by `TransactionPactProviderVerificationTest` in openbank-transaction-service.
+ *
+ * As with the balance read, the value here is the **route and its query contract**, not the body:
+ * the client returns a raw [com.fasterxml.jackson.databind.JsonNode] that
+ * [com.openbank.mcp.infrastructure.read.RealAccountReadPort] passes through untouched. What can
+ * silently break is the collection route — transaction-service exposes the account listing on the
+ * *base* path with `accountId` as a query parameter, while a sibling `GET /search` takes an
+ * overlapping parameter set, so "which of the two did the client wire?" is a real question that
+ * only a provider replay answers. `accountId` is a required `@QueryParam` on the provider (a
+ * non-null `UUID`), so omitting it is a 400 — pinning it here records that.
+ *
+ * No seeded data needed: the listing answers **200** with an empty `data` array and a `pagination`
+ * envelope for an account with no transactions. The 200 is what proves the route exists; a 404
+ * would not, since Quarkus answers 404 for an absent route too. `minArrayLike(min = 0)` matches the
+ * provider's empty-DB response while still recording the element shape.
+ *
+ * **The expected path is a LITERAL; only the outgoing request is reflected off the client's
+ * `@Path`** — deriving both sides would be vacuous (CLAUDE.md "Contract tests", measured on #2290).
+ * For this client the "path" is the interface-level `@Path` alone: `listTransactions` carries no
+ * method-level `@Path`, which is itself part of what this pact pins.
+ *
+ * IMPORTANT — regenerate on change: re-run this test (`./gradlew :openbank-mcp-service:test --tests
+ * "*TransactionListPactConsumerTest*"`) and commit the updated pact JSON in the same PR.
+ */
+@ExtendWith(PactConsumerTestExt::class)
+@PactTestFor(providerName = "openbank-transaction-service", pactVersion = PactSpecVersion.V3)
+class TransactionListPactConsumerTest {
+
+    private val mapper = ObjectMapper()
+
+    @Pact(consumer = CONSUMER, provider = PROVIDER)
+    fun transactionsForAccountPact(builder: PactDslWithProvider): RequestResponsePact = builder
+        .given("transaction-service is reachable and holds no transactions for the pact account")
+        .uponReceiving("GET the transaction page the MCP list_transactions tool returns verbatim")
+        .path(EXPECTED_TRANSACTIONS_PATH)
+        .query("accountId=$PACT_ACCOUNT_ID&limit=$PACT_LIMIT")
+        .method("GET")
+        .headers(mapOf("Accept" to "application/json"))
+        .willRespondWith()
+        .status(200)
+        .headers(mapOf("Content-Type" to "application/json"))
+        .body(
+            newJsonBody { o ->
+                // min = 0: the provider replays against a fresh Testcontainer DB with no rows.
+                o.minArrayLike("data", 0, 1) { t ->
+                    t.stringType("id", "9f8e7d6c-5b4a-4390-8123-456789abcdef")
+                    t.stringType("currency", "CZK")
+                }
+                o.`object`("pagination") { p ->
+                    p.numberType("limit", PACT_LIMIT)
+                    p.booleanType("hasNextPage", false)
+                }
+            }.build(),
+        )
+        .toPact()
+
+    @Test
+    @PactTestFor(pactMethod = "transactionsForAccountPact")
+    fun `the transaction page is a JsonNode the tool passes through unchanged`(mockServer: MockServer) {
+        assertThat(clientDerivedTransactionsPath())
+            .describedAs("TransactionServiceClient's @Path no longer produces the path this pact pins")
+            .isEqualTo(EXPECTED_TRANSACTIONS_PATH)
+
+        val raw = given()
+            .baseUri(mockServer.getUrl())
+            .accept("application/json")
+            .queryParam("accountId", PACT_ACCOUNT_ID)
+            .queryParam("limit", PACT_LIMIT)
+            // Reflected off the client, NOT retyped: this is the request the real client issues.
+            .get(clientDerivedTransactionsPath())
+            .then()
+            .statusCode(200)
+            .extract().asString()
+
+        val node = mapper.readTree(raw)
+        assertThat(node.path("data").isArray).isTrue()
+        assertThat(node.path("pagination").has("limit")).isTrue()
+    }
+
+    private companion object {
+        const val CONSUMER = "openbank-mcp-service"
+        const val PROVIDER = "openbank-transaction-service"
+
+        /** Any well-formed UUID: the provider state deliberately holds no transactions for it. */
+        const val PACT_ACCOUNT_ID = "e1e1e1e1-f2f2-4a4a-8b8b-c9c9c9c9c9c9"
+
+        /** The client's own `@DefaultValue("20")`, sent explicitly so the query contract is pinned. */
+        const val PACT_LIMIT = 20
+
+        /**
+         * LITERAL, retyped from transaction-service's `TransactionResource`
+         * (`@Path("/api/v1/transactions")`, listing on the base path). Never derive from the client.
+         */
+        const val EXPECTED_TRANSACTIONS_PATH = "/api/v1/transactions"
+
+        fun clientDerivedTransactionsPath(): String =
+            TransactionServiceClient::class.java.getAnnotation(Path::class.java).value
+    }
+}

--- a/openbank-transaction-service/src/test/kotlin/com/openbank/transaction/contract/TransactionPactProviderVerificationTest.kt
+++ b/openbank-transaction-service/src/test/kotlin/com/openbank/transaction/contract/TransactionPactProviderVerificationTest.kt
@@ -98,6 +98,20 @@ class TransactionPactProviderVerificationTest {
         // account to pre-exist in this test's Postgres, only that sourceAccountId parses as a UUID.
     }
 
+    /**
+     * State for mcp-service's `TransactionListPactConsumerTest` (issue #2255, ADR-0195). No setup:
+     * `GET /api/v1/transactions?accountId=` answers 200 with an empty `data` array and a
+     * `pagination` envelope for an account that has no rows, and that 200 is the point of the
+     * interaction — it proves the listing route exists on the BASE path with `accountId` as a query
+     * parameter. A 404 would prove nothing, since Quarkus answers 404 for an absent route too.
+     */
+    @State("transaction-service is reachable and holds no transactions for the pact account")
+    fun stateNoTransactionsForPactAccount() {
+        // Intentionally empty — a fresh Testcontainer DB satisfies it by construction. Declared so
+        // the state is an explicit part of the contract; pact-jvm passes silently over an
+        // unhandled state name, which is how #468's missing states stayed invisible.
+    }
+
     @State("transaction-service has initiated a payment transaction")
     fun stateTransactionInitiated() {
         // No setup needed: the message producer below returns a deterministic payload.

--- a/pacts/openbank-mcp-service-openbank-balance-service.json
+++ b/pacts/openbank-mcp-service-openbank-balance-service.json
@@ -1,0 +1,76 @@
+{
+  "consumer": {
+    "name": "openbank-mcp-service"
+  },
+  "interactions": [
+    {
+      "description": "GET the balances the MCP get_balance tool returns verbatim",
+      "providerStates": [
+        {
+          "name": "balance-service is reachable and holds no balances for the pact account"
+        }
+      ],
+      "request": {
+        "headers": {
+          "Accept": "application/json"
+        },
+        "method": "GET",
+        "path": "/api/v1/balances/d1d1d1d1-e2e2-4f4f-8a8a-b9b9b9b9b9b9"
+      },
+      "response": {
+        "body": {
+          "balances": [
+            {
+              "available": 1000.0,
+              "currency": "CZK"
+            }
+          ]
+        },
+        "headers": {
+          "Content-Type": "application/json"
+        },
+        "matchingRules": {
+          "body": {
+            "$.balances": {
+              "combine": "AND",
+              "matchers": [
+                {
+                  "match": "type",
+                  "min": 0
+                }
+              ]
+            },
+            "$.balances[*].available": {
+              "combine": "AND",
+              "matchers": [
+                {
+                  "match": "decimal"
+                }
+              ]
+            },
+            "$.balances[*].currency": {
+              "combine": "AND",
+              "matchers": [
+                {
+                  "match": "type"
+                }
+              ]
+            }
+          }
+        },
+        "status": 200
+      }
+    }
+  ],
+  "metadata": {
+    "pact-jvm": {
+      "version": "4.7.3"
+    },
+    "pactSpecification": {
+      "version": "3.0.0"
+    }
+  },
+  "provider": {
+    "name": "openbank-balance-service"
+  }
+}

--- a/pacts/openbank-mcp-service-openbank-consent-service.json
+++ b/pacts/openbank-mcp-service-openbank-consent-service.json
@@ -1,0 +1,111 @@
+{
+  "consumer": {
+    "name": "openbank-mcp-service"
+  },
+  "interactions": [
+    {
+      "description": "POST validate an ACTIVE ACCOUNTS_READ consent covering the requested IBAN",
+      "providerStates": [
+        {
+          "name": "an ACTIVE AISP consent covers the pact account for the pact grantee"
+        }
+      ],
+      "request": {
+        "body": {
+          "accountIban": "CZ6508000000192000145399",
+          "granteeId": "agent:pact-verify-mcp",
+          "requiredScope": "ACCOUNTS_READ"
+        },
+        "headers": {
+          "Accept": "application/json",
+          "Content-Type": "application/json"
+        },
+        "method": "POST",
+        "path": "/api/v1/consents/c1c1c1c1-d2d2-4e4e-8f8f-a9a9a9a9a9a9/validate"
+      },
+      "response": {
+        "body": {
+          "frequencyPerDay": 4,
+          "grantedAccounts": [
+            "CZ6508000000192000145399"
+          ],
+          "scopes": [
+            "ACCOUNTS_READ"
+          ],
+          "valid": true
+        },
+        "headers": {
+          "Content-Type": "application/json"
+        },
+        "matchingRules": {
+          "body": {
+            "$.grantedAccounts[0]": {
+              "combine": "AND",
+              "matchers": [
+                {
+                  "match": "type"
+                }
+              ]
+            }
+          }
+        },
+        "status": 200
+      }
+    },
+    {
+      "description": "POST validate an unknown consent id \u2014 the fail-closed deny",
+      "providerStates": [
+        {
+          "name": "no consent exists with the pact unknown-consent id"
+        }
+      ],
+      "request": {
+        "body": {
+          "accountIban": "CZ6508000000192000145399",
+          "granteeId": "agent:pact-verify-mcp",
+          "requiredScope": "ACCOUNTS_READ"
+        },
+        "headers": {
+          "Accept": "application/json",
+          "Content-Type": "application/json"
+        },
+        "method": "POST",
+        "path": "/api/v1/consents/00000000-0000-4000-8000-0000000c0de0/validate"
+      },
+      "response": {
+        "body": {
+          "code": "CONSENT_NOT_FOUND",
+          "reason": "Consent not found",
+          "valid": false
+        },
+        "headers": {
+          "Content-Type": "application/json"
+        },
+        "matchingRules": {
+          "body": {
+            "$.reason": {
+              "combine": "AND",
+              "matchers": [
+                {
+                  "match": "type"
+                }
+              ]
+            }
+          }
+        },
+        "status": 200
+      }
+    }
+  ],
+  "metadata": {
+    "pact-jvm": {
+      "version": "4.7.3"
+    },
+    "pactSpecification": {
+      "version": "3.0.0"
+    }
+  },
+  "provider": {
+    "name": "openbank-consent-service"
+  }
+}

--- a/pacts/openbank-mcp-service-openbank-transaction-service.json
+++ b/pacts/openbank-mcp-service-openbank-transaction-service.json
@@ -1,0 +1,104 @@
+{
+  "consumer": {
+    "name": "openbank-mcp-service"
+  },
+  "interactions": [
+    {
+      "description": "GET the transaction page the MCP list_transactions tool returns verbatim",
+      "providerStates": [
+        {
+          "name": "transaction-service is reachable and holds no transactions for the pact account"
+        }
+      ],
+      "request": {
+        "headers": {
+          "Accept": "application/json"
+        },
+        "method": "GET",
+        "path": "/api/v1/transactions",
+        "query": {
+          "accountId": [
+            "e1e1e1e1-f2f2-4a4a-8b8b-c9c9c9c9c9c9"
+          ],
+          "limit": [
+            "20"
+          ]
+        }
+      },
+      "response": {
+        "body": {
+          "data": [
+            {
+              "currency": "CZK",
+              "id": "9f8e7d6c-5b4a-4390-8123-456789abcdef"
+            }
+          ],
+          "pagination": {
+            "hasNextPage": false,
+            "limit": 20
+          }
+        },
+        "headers": {
+          "Content-Type": "application/json"
+        },
+        "matchingRules": {
+          "body": {
+            "$.data": {
+              "combine": "AND",
+              "matchers": [
+                {
+                  "match": "type",
+                  "min": 0
+                }
+              ]
+            },
+            "$.data[*].currency": {
+              "combine": "AND",
+              "matchers": [
+                {
+                  "match": "type"
+                }
+              ]
+            },
+            "$.data[*].id": {
+              "combine": "AND",
+              "matchers": [
+                {
+                  "match": "type"
+                }
+              ]
+            },
+            "$.pagination.hasNextPage": {
+              "combine": "AND",
+              "matchers": [
+                {
+                  "match": "type"
+                }
+              ]
+            },
+            "$.pagination.limit": {
+              "combine": "AND",
+              "matchers": [
+                {
+                  "match": "number"
+                }
+              ]
+            }
+          }
+        },
+        "status": 200
+      }
+    }
+  ],
+  "metadata": {
+    "pact-jvm": {
+      "version": "4.7.3"
+    },
+    "pactSpecification": {
+      "version": "3.0.0"
+    }
+  },
+  "provider": {
+    "name": "openbank-transaction-service"
+  }
+}


### PR DESCRIPTION
## What

mcp-service had an `openapi.yaml` and **no contract test** (issue #2255, dimension C3). Its read ports became real MP Rest Clients in #2262 but are still `@Vetoed`, so nothing has ever exercised these routes end to end — `RealAccountReadPortTest` mocks every client, which is exactly the shape in which finrep shipped a call to a ledger path that had never existed (#2269). Pinning the routes now makes the ADR-0195 cutover a wiring step rather than a discovery.

This PR also adds **`ConsentPactProviderVerificationTest`** (git-pact, `@PactFolder("../pacts")`, always runs — no broker). consent-service was named as a provider by committed pacts and **nothing replayed them**.

## Pinned

| interaction | why |
|---|---|
| consent-service `POST /api/v1/consents/{id}/validate` — allow branch | `RealAccountReadPort` reads `valid` **and** `grantedAccounts` off this response, and `grantedAccounts` is the confidentiality boundary: it decides which IBANs an MCP tool may return. Taken from the live validate response rather than the caller's token so revoke/expire are honoured per call. `scopes` and `frequencyPerDay` (PSD2 RTS Art. 10(2)(b)) are pinned with it. |
| consent-service `POST …/validate` — deny branch | The denial is HTTP **200** with `valid: false` / `CONSENT_NOT_FOUND`, not a 404 (`ConsentService.validateConsent` returns an `Invalid` result rather than throwing). A client that trusted the status code would allow a revoked consent. |
| balance-service `GET /api/v1/balances/{accountId}` | The body is **not** load-bearing — the port passes `JsonNode` straight through. The **route** is, and only a provider replay can adjudicate it. |
| transaction-service `GET /api/v1/transactions?accountId=&limit=` | Same, plus a real ambiguity: the listing lives on the *base* path with `accountId` as a query param while a sibling `GET /search` takes an overlapping parameter set. `accountId` is a required non-null `UUID` `@QueryParam`, so omitting it is a 400. |

Neither the balance nor the transaction interaction needs seeded data: both answer **200** with an empty collection for an unknown account, and that 200 is the point — a 404 would prove nothing, since Quarkus answers 404 for an absent route too. `minArrayLike(min = 0)` matches the provider's empty-DB response while still recording the element shape (same reason as `LedgerTrialBalancePactConsumerTest`).

## Skipped, with reason

| interaction | why not |
|---|---|
| account-service `GET /api/v1/accounts/iban/{iban}` | The repo's only `@Provider("openbank-account-service")` class is **message-only** (`MessageTestTarget`, no Quarkus boot); its own KDoc records that an HTTP consumer contract needs it converted to per-interaction target dispatch first. A pact with no replay is worth nothing against the likeliest defect, so this waits for that provider-side change (same reason as in the vop PR, #2324). |
| `listConsents` | consent-service exposes no list-by-grantee route that `RealAccountReadPort` calls — it re-validates the presented consent instead, which the pinned validate interaction already covers. |

## Provider verification — all four interactions replay green against real providers

| provider | verdict (JUnit XML) |
|---|---|
| consent-service (new `@PactFolder` class, always runs) | `tests=2 failures=0 errors=0` — both `POST …/validate` interactions pass against a seeded ACTIVE AISP consent and an empty DB |
| balance-service | `tests=1 failures=0` |
| transaction-service | `tests=1 failures=0` |

balance-service's and transaction-service's classes are `@PactBroker`-gated, so they do not run locally or on the PR lane. To exercise them I **temporarily** swapped `@PactBroker` → `@PactFolder("../pacts")` and dropped `@EnabledIfSystemProperty`. **Those swaps are not committed** — #1166/#1009 record why the broker loader must stay (it is the only thing `can-i-deploy` reads). What *is* committed for them is the `@State` handler each new interaction needs; pact-jvm passes silently over an unhandled state name, which is how the missing states in #468 stayed invisible.

## Falsified both ways (not just trusting the green)

**1. Consumer must catch a response-field rename.** `@JsonProperty("granted_accounts")` on `ConsentValidationResponse.grantedAccounts`:

```
ConsentValidatePactConsumerTest > an active in-scope consent validates as allowed and names the granted accounts FAILED
com.fasterxml.jackson.databind.exc.UnrecognizedPropertyException: Unrecognized field "grantedAccounts"
(class ...ConsentValidationResponse), not marked as ignorable
(6 known properties: "reason", "granted_accounts", "frequencyPerDay", "valid", "code", "scopes")
```

**2. Provider must catch a wrong request path (the consumer cannot).** Repointed the pinned path at `…/validate-consent`:

```
ConsentPactProviderVerificationTest > … POST validate an ACTIVE ACCOUNTS_READ consent … FAILED
ConsentPactProviderVerificationTest > … POST validate an unknown consent id … FAILED
2 tests completed, 2 failed
1) … : has status code 200
   1.1) status: expected status of 200 but was 404
```

Restored after each, and re-confirmed green afterwards (`tests=2 failures=0`).

## Gate (all local — CI is unavailable, see below)

- `:openbank-mcp-service:test --tests "com.openbank.mcp.contract.*"` → `ConsentValidate tests=2 failures=0`, `BalanceRead tests=1 failures=0`, `TransactionList tests=1 failures=0` (counts read from the XML, so a silently-skipped test would show)
- `:openbank-consent-service:test --tests "*ConsentPactProviderVerificationTest*"` → `tests=2 failures=0 errors=0`
- `:openbank-balance-service:test` / `:openbank-transaction-service:test` provider verification (temporary `@PactFolder`) → `tests=1 failures=0` each
- `:openbank-mcp-service:build` → BUILD SUCCESSFUL · `:openbank-mcp-service:koverVerify` → BUILD SUCCESSFUL
- `detekt` + `ktlintCheck` on mcp, consent, balance, transaction → BUILD SUCCESSFUL (consent's `@State` seeding was refactored to clear a real `NestedBlockDepth` finding, then re-verified green)
- `compileTestKotlin` on consent, balance, transaction → BUILD SUCCESSFUL

GitHub Actions is in a **major outage** (incident "Actions run failures and delays", started 12:31Z, Critical); runs are completing with `conclusion=failure` and **zero jobs**, including on `main` before this branch existed. A red check here is not a signal about this work. Auto-merge is armed; it will merge once checks can run.

## Follow-ups (not in this PR)

1. `.github/workflows/pact-drift-check.yml` needs `:openbank-mcp-service:test --tests "com.openbank.mcp.contract.*PactConsumerTest"` added to its regenerate step — an omitted consumer reads as **passing** there, per that file's own comment. Not edited here because PR #2309 is rewriting it and #2318 proposes deriving the scope instead of hand-listing it; if #2318 lands, this need disappears.
2. Convert `AccountEventPactProviderVerificationTest` to per-interaction target dispatch, then pin the account-service IBAN lookup for both mcp and vop.
3. `ConsentPactProviderVerificationTest` is now the single `@Provider("openbank-consent-service")` class — a psd2→consent-service pact should add its `@State` there rather than a second class.

Refs #2255