### PR TITLE
fix(pid): document the two endpoints openapi.yaml omits

### DIFF
--- a/openbank-pid-service/src/main/resources/openapi.yaml
+++ b/openbank-pid-service/src/main/resources/openapi.yaml
@@ -3,7 +3,7 @@
 openapi: 3.1.0
 info:
   title: PID Service API (Party Identity)
-  version: 1.11.0
+  version: 1.12.0
   description: Party identity data management — create, update, KYC linking, BankID/ROB sync, identity resolution and four-eyes verification cases (ADR-0072).
   license:
     name: Apache-2.0
@@ -692,6 +692,39 @@ paths:
               schema:
                 $ref: '#/components/schemas/PartyResponse'
 
+  /api/v1/parties/{id}/external-ids:
+    post:
+      tags: [Parties]
+      summary: Link an external identifier to an existing party (ADR-0072 section 5)
+      description: |
+        The identity-unification merge. Called when POST /api/v1/parties/resolve returns
+        MATCH_EXISTING for a returning person arriving through a new channel, so both identities
+        map to one party. Without this call the MATCH_EXISTING decision cannot be acted on.
+
+        Idempotent: re-linking an identifier the party already owns succeeds unchanged.
+      operationId: linkExternalId
+      parameters:
+        - $ref: '#/components/parameters/partyId'
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/LinkExternalIdRequest'
+      responses:
+        '200':
+          description: Party with the identifier linked
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/PartyResponse'
+        '404':
+          $ref: '#/components/responses/NotFound'
+        '409':
+          description: The identifier already belongs to a different party
+      security:
+        - bearerAuth: []
+
   /api/v1/parties/{id}/contact:
     patch:
       tags: [Parties]
@@ -742,6 +775,37 @@ paths:
       responses:
         '200':
           description: Updated
+
+  /api/v1/parties/{id}/case:
+    patch:
+      tags: [Parties]
+      summary: Transition the party's PID verification case lifecycle
+      description: |
+        Moves the party's embedded verification case to a new status, recording the acting operator
+        and a reason code. Distinct from /api/v1/parties/cases/{id}/decision, which records a
+        four-eyes verdict on a standalone verification case.
+      operationId: transitionPartyCase
+      parameters:
+        - $ref: '#/components/parameters/partyId'
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/TransitionCaseRequest'
+      responses:
+        '200':
+          description: Party with the transitioned case
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/PartyResponse'
+        '404':
+          $ref: '#/components/responses/NotFound'
+        '409':
+          description: The requested transition is not legal from the case's current status
+      security:
+        - bearerAuth: []
 
   /api/v1/parties/{id}/sync/bankid:
     post:
@@ -1253,6 +1317,48 @@ components:
             Verified EUDI PID subject identifier (ADR-0094). Set only after cryptographic
             verification by EudiVerifyPresentationService — never the raw, unverified value.
             Blind-indexed with the same pepper as RČ; raw value is never stored.
+
+    LinkExternalIdRequest:
+      type: object
+      required: [type, value]
+      properties:
+        type:
+          type: string
+          description: |
+            Identifier namespace. BIRTH_NUMBER and EUDI_PID_SUBJECT carry a keyed blind index
+            (HMAC-SHA256 hex), never a plaintext value.
+          enum:
+            - KEYCLOAK_ID
+            - BANKID_SUB
+            - ROB_AIFO
+            - ICO
+            - PASSPORT_NUMBER
+            - ID_CARD_NUMBER
+            - BIRTH_NUMBER
+            - EUDI_PID_SUB
+        value:
+          type: string
+
+    TransitionCaseRequest:
+      type: object
+      required: [status, actor, reasonCode]
+      properties:
+        status:
+          type: string
+          enum: [DRAFT, OPEN, IN_REVIEW, WAITING_FOR_CUSTOMER, WAITING_FOR_EXTERNAL_PARTY, APPROVED, REJECTED, CLOSED, CANCELLED]
+        actor:
+          type: string
+          description: The operator performing the transition, recorded on the case history.
+        reasonCode:
+          type: string
+          enum: [CREATED, REVIEW_STARTED, INFORMATION_REQUESTED, INFORMATION_RECEIVED, EXTERNAL_DEPENDENCY, APPROVED, REJECTED, CLOSED, CANCELLED, REOPENED, MANUAL_UPDATE]
+        reason:
+          type: string
+          nullable: true
+        metadata:
+          type: object
+          additionalProperties:
+            type: string
 
     ApiError:
       type: object


### PR DESCRIPTION
## The defect

`PartyResource` serves two endpoints that `openbank-pid-service/src/main/resources/openapi.yaml` does
not declare:

| Served | Roles | Authz |
|---|---|---|
| `POST /api/v1/parties/{id}/external-ids` | `ROLE_SERVICE`, `ROLE_OPERATOR`, `ROLE_ADMIN` | `@Authorize(action = "identity.link")` |
| `PATCH /api/v1/parties/{id}/case` | `openbank-employee`, `openbank-admin` | — |

The first one matters. Its own KDoc calls it "the identity-unification merge of ADR-0072 §5 — called
when resolution returns `MATCH_EXISTING` for a returning person arriving through a new channel, so
both identities map to one party." It accepts `ROLE_SERVICE`, so it is an M2M surface. And
`POST /api/v1/parties/resolve` **is** documented, including its `MATCH_EXISTING` decision — so the
published contract tells an integrator how to discover that a person already exists and then offers no
documented way to act on it. The one call that completes that flow is invisible.

## How it was found

By the bidirectional operation-inventory assertion in `PidApiContractTest` (#2255, dimension C3), on
its first real run. It compares the declared `(method, path)` set against the JAX-RS surface discovered
by reflection over the CDI container, so neither direction can hide:

```
served count 32   declared count 30

=== SERVED but NOT DECLARED (undocumented endpoints) ===
  PATCH /api/v1/parties/{id}/case
  POST  /api/v1/parties/{id}/external-ids

=== DECLARED but NOT SERVED ===
  (none)
```

Confirmed through a second, independent representation before being believed — a line-based YAML parse
rather than the test's Jackson parse — which produced the identical two-element difference.

This is not a new failure mode for this service. `rules.yaml: change_requirements.api_contract` records
why the api-contract gate graduated to `enforce`, and cites this very spec: "#1161 added
`PATCH /api/v1/parties/{id}/consent` and left 1.6.0 -> 1.6.0". These two endpoints are the residue of
that same habit, from before the gate was enforcing.

## Which side changed, and why

**The spec.** Both endpoints are deployed, role-gated and callable; removing them would break live
callers, including an M2M one. The document was never updated, so the document is what is wrong.

- `info.version` `1.11.0` → `1.12.0` — additive within `/v1`, per ADR-0048 D5. No URL major change:
  nothing existing was altered or removed.
- Two new component schemas, `LinkExternalIdRequest` and `TransitionCaseRequest`.
- Enum values are **transcribed from the source enums**, not guessed: `ExternalIdType` (verified
  member-for-member against the Kotlin enum — my first draft wrote `EUDI_PID_SUBJECT`, the real value
  is `EUDI_PID_SUB`), and the shared `CaseStatus` / `CaseReasonCode` from `openbank-libs-domain`.
- `409` is documented on both: `external-ids` conflicts when the identifier belongs to a different
  party, `case` when the transition is illegal from the current status.

## Verification

After this change the declared set and the served set are equal, with nothing left over in either
direction:

```
declared: 32 served: 32
served-declared: []
declared-served: []
```

The spec parses, carries no duplicate path keys, and both new schemas resolve.

`PidApiContractTest` — the test that found this — is a **separate `test(pid)` PR** stacked on this
branch, so the spec fix stays a `fix` (and cuts its release) and is not smuggled into a test commit.
That PR goes green the moment this one merges.

Refs #2255
