### PR TITLE
test(psd2): pin the tpp-registry eIDAS licence gate with a consumer pact

### DIFF
--- a/openbank-psd2-service/build.gradle.kts
+++ b/openbank-psd2-service/build.gradle.kts
@@ -54,6 +54,9 @@ dependencies {
     testImplementation(libs.testcontainers)
     testImplementation(libs.testcontainers.junit)
     testImplementation(libs.testcontainers.postgresql)
+    // Consumer-driven contract test (ADR-0063, issue #2255 dimension C3): psd2 is a real consumer of
+    // tpp-registry's eIDAS licence gate, GET /api/v1/tpp-registry/check.
+    testImplementation(libs.pact.consumer)
 }
 
 kover {
@@ -67,4 +70,25 @@ kover {
             }
         }
     }
+}
+
+// Pact: write the generated consumer contract into the repo-root pacts/ dir (git-pact, ADR-0063) so
+// the provider replays it from @PactFolder("../pacts") with no broker in the loop. The consumer test
+// rewrites the file on every run and the result is committed; pact-drift-check.yml fails the build
+// if the committed JSON and a fresh regeneration diverge.
+// NOTE: must be set on the test JVM fork, not the Gradle daemon (System.setProperty would not
+// propagate). The pactbroker.* keys are forwarded so CI's publish step behaves as it does elsewhere.
+tasks.withType<Test> {
+    systemProperty("pact.rootDir", "${rootProject.projectDir}/pacts")
+    listOf(
+        "pactbroker.url",
+        "pactbroker.auth.username",
+        "pactbroker.auth.password",
+        "pactbroker.enablePending",
+        "pactbroker.providerBranch",
+        "pact.verifier.publishResults",
+        "pact.provider.version",
+        "pact.provider.branch",
+        "pact.provider.tag",
+    ).forEach { key -> System.getProperty(key)?.let { systemProperty(key, it) } }
 }

--- a/openbank-psd2-service/src/test/kotlin/com/openbank/psd2/contract/TppRegistryCheckPactConsumerTest.kt
+++ b/openbank-psd2-service/src/test/kotlin/com/openbank/psd2/contract/TppRegistryCheckPactConsumerTest.kt
@@ -1,0 +1,156 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright (c) OpenBank contributors. Licensed under the Apache License, Version 2.0.
+// See LICENSE in the repository root or https://www.apache.org/licenses/LICENSE-2.0 for details.
+
+package com.openbank.psd2.contract
+
+import au.com.dius.pact.consumer.MockServer
+import au.com.dius.pact.consumer.dsl.LambdaDsl.newJsonBody
+import au.com.dius.pact.consumer.dsl.PactDslWithProvider
+import au.com.dius.pact.consumer.junit5.PactConsumerTestExt
+import au.com.dius.pact.consumer.junit5.PactTestFor
+import au.com.dius.pact.core.model.PactSpecVersion
+import au.com.dius.pact.core.model.RequestResponsePact
+import au.com.dius.pact.core.model.annotations.Pact
+import com.fasterxml.jackson.module.kotlin.jacksonObjectMapper
+import com.fasterxml.jackson.module.kotlin.readValue
+import com.openbank.psd2.infrastructure.client.TppAuthorizationResponse
+import com.openbank.psd2.infrastructure.client.TppRegistryRestClient
+import io.restassured.RestAssured.given
+import jakarta.ws.rs.Path
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.extension.ExtendWith
+
+/**
+ * Consumer-driven contract for the eIDAS licence gate every XS2A request passes through:
+ * tpp-registry `GET /api/v1/tpp-registry/check?tppId=&role=`, called by
+ * [com.openbank.psd2.infrastructure.client.TppAuthorizationGuard]. The generated pact is committed
+ * to `pacts/openbank-psd2-service-openbank-tpp-registry-service.json` (git-pact, ADR-0063) and
+ * replayed by `TppRegistryPactProviderVerificationTest` (`@PactFolder("../pacts")`) — that test
+ * always runs, no broker involved.
+ *
+ * psd2-service had an `openapi.yaml` and no contract test at all (issue #2255 dimension C3), while
+ * this call decides whether a TPP may act as an AISP/PISP.
+ *
+ * Pinned: the **refusal** — an unregistered TPP answers HTTP **403** carrying the result body.
+ * `TppRegistryRestClient` declares a plain return type, so a non-2xx becomes a
+ * `WebApplicationException`, and that is what makes [TppAuthorizationGuard] fail closed. A
+ * 200-carrying-`authorized:false` would silently defeat it, so pinning the 403 pins the security
+ * property, not merely a status code. It also *proves the route exists*, which a 404 interaction
+ * could not: Quarkus answers 404 for an absent route too, so a pact pinned to a 404 is satisfied by
+ * a client pointed at nothing. This is the sharpest available form of the #2269 check — finrep
+ * shipped a call to a ledger path that had never existed while its unit tests passed against a
+ * mocked port. No seeded data is needed; nothing registers the id this interaction uses.
+ *
+ * WITHHELD, deliberately: the **allow** branch (HTTP 200, `authorized: true`, `roles: ["AISP"]`).
+ * It is written and it FAILS against a real tpp-registry — `TppRepositoryImpl.toDomain()` maps the
+ * entity's `BIGSERIAL` id through `UUID.fromString(id.toString())`, so reading any registered row
+ * throws and the endpoint answers 400 `"Invalid UUID string: 2"` (issue #2340). The provider replay
+ * is what found it; this consumer test was green throughout, which is the asymmetry CLAUDE.md
+ * records. Committing that interaction would leave a permanently red provider gate, so it lands with
+ * the fix. Note what this means for the contract as it stands: the refusal branch is verified, the
+ * allow branch is currently unreachable in production.
+ *
+ * **The expected path is a LITERAL; only the outgoing requests are reflected off the client's
+ * `@Path`** (CLAUDE.md "Contract tests", measured on #2290). Deriving both sides is vacuous —
+ * expectation and request move together, so the test stays green against a route that does not
+ * exist. [assertClientPathMatchesContract] pins the annotations to the literal instead.
+ *
+ * IMPORTANT — regenerate on change: re-run this test (`./gradlew :openbank-psd2-service:test
+ * --tests "*TppRegistryCheckPactConsumerTest*"`) and commit the updated pact JSON in the same PR;
+ * `.github/workflows/pact-drift-check.yml` fails the build if they diverge.
+ */
+@ExtendWith(PactConsumerTestExt::class)
+@PactTestFor(providerName = "openbank-tpp-registry-service", pactVersion = PactSpecVersion.V3)
+class TppRegistryCheckPactConsumerTest {
+
+    private val mapper = jacksonObjectMapper()
+
+    @Pact(consumer = CONSUMER, provider = PROVIDER)
+    fun unregisteredTppRefusedPact(builder: PactDslWithProvider): RequestResponsePact = builder
+        .given("no registry entry exists for the pact unknown-TPP id")
+        .uponReceiving("GET check an unregistered TPP — the fail-closed refusal")
+        .path(EXPECTED_CHECK_PATH)
+        .query("tppId=$UNKNOWN_TPP_ID&role=$AISP_ROLE")
+        .method("GET")
+        .headers(mapOf("Accept" to "application/json"))
+        .willRespondWith()
+        // 403, not 200-with-authorized:false. The client's plain return type turns this into a
+        // WebApplicationException, which is what makes TppAuthorizationGuard fail closed.
+        .status(403)
+        .headers(mapOf("Content-Type" to "application/json"))
+        .body(
+            newJsonBody { o ->
+                o.stringValue("tppId", UNKNOWN_TPP_ID)
+                o.booleanValue("authorized", false)
+                o.array("roles")
+                o.stringType("reason", "TPP not found in registry")
+            }.build(),
+        )
+        .toPact()
+
+    @Test
+    @PactTestFor(pactMethod = "unregisteredTppRefusedPact")
+    fun `an unregistered TPP is refused with 403 and a reason`(mockServer: MockServer) {
+        assertClientPathMatchesContract()
+
+        val raw = check(mockServer, UNKNOWN_TPP_ID, 403)
+
+        val response = mapper.readValue<TppAuthorizationResponse>(raw)
+        assertThat(response.authorized).isFalse()
+        assertThat(response.roles).isEmpty()
+        assertThat(response.reason).isNotBlank()
+    }
+
+    private fun check(mockServer: MockServer, tppId: String, expectedStatus: Int): String = given()
+        .baseUri(mockServer.getUrl())
+        .accept("application/json")
+        .queryParam("tppId", tppId)
+        .queryParam("role", AISP_ROLE)
+        // Reflected off the client, NOT retyped: this is the request the real client issues.
+        .get(clientDerivedCheckPath())
+        .then()
+        .statusCode(expectedStatus)
+        .extract().asString()
+
+    /**
+     * The asymmetry that makes this contract falsifiable at the consumer layer: the path the client
+     * would really call, recomputed from [TppRegistryRestClient]'s own annotations, must equal the
+     * literal this pact promises tpp-registry. A `@Path` edit on the client reddens here.
+     */
+    private fun assertClientPathMatchesContract() {
+        assertThat(clientDerivedCheckPath())
+            .describedAs(
+                "TppRegistryRestClient's @Path no longer produces the path this pact pins — either " +
+                    "fix the client or update EXPECTED_CHECK_PATH *and* re-verify against tpp-registry",
+            )
+            .isEqualTo(EXPECTED_CHECK_PATH)
+    }
+
+    private companion object {
+        const val CONSUMER = "openbank-psd2-service"
+        const val PROVIDER = "openbank-tpp-registry-service"
+
+        /** Never registered — a fresh Testcontainer DB satisfies the refusal state by construction. */
+        const val UNKNOWN_TPP_ID = "CZ-CNB-PACT-UNREGISTERED"
+
+        /** `TppRole.AISP`, sent as the exact enum name the provider's `valueOf` accepts. */
+        const val AISP_ROLE = "AISP"
+
+        /**
+         * LITERAL, deliberately retyped from tpp-registry's `TppRegistryResource`
+         * (`@Path("/api/v1/tpp-registry")` + `@GET @Path("/check")`). Never derive from the client.
+         */
+        const val EXPECTED_CHECK_PATH = "/api/v1/tpp-registry/check"
+
+        fun clientDerivedCheckPath(): String {
+            val base = TppRegistryRestClient::class.java.getAnnotation(Path::class.java).value
+            val method = TppRegistryRestClient::class.java.methods
+                .single { it.name == "checkAuthorization" }
+                .getAnnotation(Path::class.java)
+                .value
+            return base + method
+        }
+    }
+}

--- a/openbank-tpp-registry-service/build.gradle.kts
+++ b/openbank-tpp-registry-service/build.gradle.kts
@@ -44,6 +44,12 @@ dependencies {
     testImplementation(libs.testcontainers)
     testImplementation(libs.testcontainers.junit)
     testImplementation(libs.testcontainers.postgresql)
+    // Provider-side verification (ADR-0063 git-pact): TppRegistryPactProviderVerificationTest replays
+    // the consumer pacts in pacts/ naming openbank-tpp-registry-service as provider (issue #2255).
+    // quarkus-test-security supplies the @TestSecurity identity for the replayed requests, since
+    // checkAuthorization is @RolesAllowed and @TestSecurity cannot annotate pact's @TestTemplate.
+    testImplementation(libs.pact.provider)
+    testImplementation(libs.quarkus.test.security)
 }
 
 kover {

--- a/openbank-tpp-registry-service/src/test/kotlin/com/openbank/tppregistry/contract/TppRegistryPactProviderVerificationTest.kt
+++ b/openbank-tpp-registry-service/src/test/kotlin/com/openbank/tppregistry/contract/TppRegistryPactProviderVerificationTest.kt
@@ -1,0 +1,99 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright (c) OpenBank contributors. Licensed under the Apache License, Version 2.0.
+// See LICENSE in the repository root or https://www.apache.org/licenses/LICENSE-2.0 for details.
+
+package com.openbank.tppregistry.contract
+
+import au.com.dius.pact.provider.junit5.HttpTestTarget
+import au.com.dius.pact.provider.junit5.PactVerificationContext
+import au.com.dius.pact.provider.junit5.PactVerificationInvocationContextProvider
+import au.com.dius.pact.provider.junitsupport.IgnoreNoPactsToVerify
+import au.com.dius.pact.provider.junitsupport.Provider
+import au.com.dius.pact.provider.junitsupport.State
+import au.com.dius.pact.provider.junitsupport.loader.PactFolder
+import io.quarkus.test.common.QuarkusTestResource
+import io.quarkus.test.common.QuarkusTestResourceLifecycleManager
+import io.quarkus.test.junit.QuarkusTest
+import io.quarkus.test.security.TestSecurity
+import io.smallrye.reactive.messaging.memory.InMemoryConnector
+import org.eclipse.microprofile.config.inject.ConfigProperty
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.TestTemplate
+import org.junit.jupiter.api.extension.ExtendWith
+
+/**
+ * Provider-side Pact verification for tpp-registry (issue #2255 dimension C3). Replays
+ * psd2-service's `TppRegistryCheckPactConsumerTest` contract for the eIDAS licence gate
+ * (`GET /api/v1/tpp-registry/check`) against a real booted instance.
+ *
+ * Git-pact (`@PactFolder`, ADR-0063): reads the consumer pacts from the monorepo-root `pacts/` dir
+ * (resolved relative to this module's working directory) and **always runs** — no broker, no CI
+ * secret, no gate. That matters more than usual here: a committed pact nobody replays is worthless
+ * against the likeliest defect, a request path the provider does not serve, and that is exactly how
+ * finrep shipped a call to a ledger route that had never existed while its unit tests passed
+ * against a mocked port (#2269).
+ *
+ * **This must remain the ONLY `@Provider("openbank-tpp-registry-service")` class in the repo.** Two
+ * classes with the same provider name each pull every pact naming that provider and fight over the
+ * same `@BeforeEach` target, so they collide.
+ *
+ * The state seeds nothing, and that is a property of the fixture rather than a shortcut: nothing
+ * registers the unknown TPP id the refusal interaction uses, so a fresh Testcontainer DB satisfies
+ * it by construction.
+ *
+ * The allow branch is NOT in the committed pact yet, and the reason is worth knowing before adding
+ * a `@State` for it: `TppRepositoryImpl.toDomain()` maps this entity's `BIGSERIAL` id through
+ * `UUID.fromString(id.toString())`, so reading ANY registered row throws and the endpoint answers
+ * 400 `"Invalid UUID string: 2"` — issue #2340, found by this very replay while psd2's consumer test
+ * stayed green. `V1__init.sql` already seeds `CZ-CNB-TEST-AISP` as an ACTIVE AISP, so once #2340 is
+ * fixed the allow interaction needs only a no-op `@State` here.
+ *
+ * `@TestSecurity` matches `checkAuthorization`'s `@RolesAllowed("ROLE_SERVICE", "ROLE_OPERATOR",
+ * "ROLE_ADMIN")` — psd2 calls it with an M2M client-credentials token in production (ADR-0018).
+ * `@TestSecurity` cannot annotate a `@TestTemplate`, hence the class-level annotation. The lone
+ * `tpp-events-out` Kafka emitter is swapped to the in-memory connector so no broker is needed to
+ * boot (same as `TppRegistryBootSmokeIT`).
+ *
+ * IMPORTANT: if psd2 changes its contract, regenerate the pact JSON on the consumer side and commit
+ * it in the same PR, or this test verifies a stale contract.
+ * `@IgnoreNoPactsToVerify(ignoreIoErrors)` makes a missing/unreadable pact a skip, not a failure.
+ */
+@QuarkusTest
+@QuarkusTestResource(TppRegistryPactProviderVerificationTest.InMemoryKafkaResource::class)
+@QuarkusTestResource(com.openbank.tppregistry.it.PostgresRedisTestResource::class)
+@TestSecurity(user = "pact-verifier", roles = ["ROLE_SERVICE", "ROLE_OPERATOR"])
+@Provider("openbank-tpp-registry-service")
+@PactFolder("../pacts")
+@IgnoreNoPactsToVerify(ignoreIoErrors = "true")
+class TppRegistryPactProviderVerificationTest {
+
+    class InMemoryKafkaResource : QuarkusTestResourceLifecycleManager {
+        override fun start(): Map<String, String> = InMemoryConnector.switchOutgoingChannelsToInMemory("tpp-events-out")
+
+        override fun stop() = InMemoryConnector.clear()
+    }
+
+    @ConfigProperty(name = "quarkus.http.test-port", defaultValue = "8081")
+    lateinit var testPort: String
+
+    @BeforeEach
+    fun configureTarget(context: PactVerificationContext?) {
+        if (context == null) return
+        context.target = HttpTestTarget("localhost", testPort.toInt())
+        context.addStateChangeHandlers(this)
+    }
+
+    @TestTemplate
+    @ExtendWith(PactVerificationInvocationContextProvider::class)
+    fun verifyPacts(context: PactVerificationContext?) {
+        // context is null on the @IgnoreNoPactsToVerify dummy invocation — skip gracefully.
+        context?.verifyInteraction()
+    }
+
+    @State("no registry entry exists for the pact unknown-TPP id")
+    fun unknownTppIsNotRegistered() {
+        // No setup: nothing registers CZ-CNB-PACT-UNREGISTERED. Declared so the state is an
+        // explicit part of the contract rather than a name pact-jvm passes over silently — an
+        // unhandled state is not an error, which is how #468's missing states stayed invisible.
+    }
+}

--- a/pacts/openbank-psd2-service-openbank-tpp-registry-service.json
+++ b/pacts/openbank-psd2-service-openbank-tpp-registry-service.json
@@ -1,0 +1,67 @@
+{
+  "consumer": {
+    "name": "openbank-psd2-service"
+  },
+  "interactions": [
+    {
+      "description": "GET check an unregistered TPP \u2014 the fail-closed refusal",
+      "providerStates": [
+        {
+          "name": "no registry entry exists for the pact unknown-TPP id"
+        }
+      ],
+      "request": {
+        "headers": {
+          "Accept": "application/json"
+        },
+        "method": "GET",
+        "path": "/api/v1/tpp-registry/check",
+        "query": {
+          "role": [
+            "AISP"
+          ],
+          "tppId": [
+            "CZ-CNB-PACT-UNREGISTERED"
+          ]
+        }
+      },
+      "response": {
+        "body": {
+          "authorized": false,
+          "reason": "TPP not found in registry",
+          "roles": [
+
+          ],
+          "tppId": "CZ-CNB-PACT-UNREGISTERED"
+        },
+        "headers": {
+          "Content-Type": "application/json"
+        },
+        "matchingRules": {
+          "body": {
+            "$.reason": {
+              "combine": "AND",
+              "matchers": [
+                {
+                  "match": "type"
+                }
+              ]
+            }
+          }
+        },
+        "status": 403
+      }
+    }
+  ],
+  "metadata": {
+    "pact-jvm": {
+      "version": "4.7.3"
+    },
+    "pactSpecification": {
+      "version": "3.0.0"
+    }
+  },
+  "provider": {
+    "name": "openbank-tpp-registry-service"
+  }
+}


### PR DESCRIPTION
## What

psd2-service had an `openapi.yaml` and **no contract test at all** (issue #2255, dimension C3), while `TppAuthorizationGuard`'s call to tpp-registry decides whether a TPP may act as an AISP/PISP on every XS2A request. This pins that call (git-pact, ADR-0063) and adds the provider verification tpp-registry never had.

## ⚠️ The replay found a live defect: #2340

The allow interaction (`authorized: true`) is written and **reddens against a real tpp-registry**:

```
1.1) status: expected status of 200 but was 400
1.2) body: $ Actual map is missing the following keys: authorized, roles, tppId
   +  "code": "VALIDATION_ERROR",
   +  "message": "Invalid UUID string: 2",
```

`TppEntryEntity` extends `PanacheEntity` (id is `Long`, backed by `BIGSERIAL`), but `TppRepositoryImpl.toDomain()` does `UUID.fromString(id.toString())`. So **every** read of a registered TPP throws — `check` (allow branch), `getTpp`, `listTpps`, `blacklistTpp`. The eIDAS licence gate can never authorize anybody. Fail-closed, so not a confidentiality issue, but a total functional outage of the PSD2 surface once tpp-registry is in the request path. Filed as **#2340** with a fix sketch (the domain id's type is a decision, not a mechanical change, hence an issue rather than a drive-by fix in a `test`-scoped PR).

**The allow interaction is deliberately NOT committed** — it would leave a permanently red provider gate — and lands with the fix. Both test classes document exactly this, so the next person does not re-derive it. Note the consumer test was **green throughout**: this is the asymmetry CLAUDE.md records, and it is the whole reason a pact without a replay is worthless.

## Pinned

| interaction | why |
|---|---|
| `GET /api/v1/tpp-registry/check?tppId=&role=` → **403** for an unregistered TPP | `TppRegistryRestClient` declares a plain return type, so a non-2xx becomes a `WebApplicationException` — that is what makes `TppAuthorizationGuard` fail closed, and a `200`-carrying-`authorized:false` would silently defeat it. The status code **is** the security property. It also proves the route exists, which a 404 interaction could not (Quarkus answers 404 for an absent route too, so a pact pinned to a 404 is satisfied by a client pointed at nothing). No seeded data needed. |

## Skipped, with reasons

| interaction | why not |
|---|---|
| `check` → 200 allow branch | Reddens against the real provider — #2340 above. |
| consent-service `GET /consents/{id}` and `POST /consents/{id}/validate` | The single `@Provider("openbank-consent-service")` class arrives in **#2336** (mcp's PR); adding a second one collides, and adding a pact with no replay is the thing this PR argues against. Follow-up once #2336 merges: add the psd2 `@State` to that class. Note the provider *behaviour* of `POST …/validate` is already pinned and replayed from mcp's side in #2336 — what remains uncovered is psd2's own DTO binding. |

## Provider verification

`TppRegistryPactProviderVerificationTest` — `@PactFolder("../pacts")`, **always runs**, no broker, no gate, no CI secret. tpp-registry had no `@Provider` class at all before this.

```
tests=1 failures=0 errors=0
   pass openbank-psd2-service - GET check an unregistered TPP — the fail-closed refusal
```

## Falsified both ways

**1. Consumer must catch a response-field rename.** `@JsonProperty("denial_reason")` on `TppAuthorizationResponse.reason`:

```
TppRegistryCheckPactConsumerTest > an unregistered TPP is refused with 403 and a reason FAILED
UnrecognizedPropertyException: Unrecognized field "reason" (class ...TppAuthorizationResponse),
not marked as ignorable (4 known properties: "authorized", "denial_reason", "roles", "tppId")
```

**2. Provider must catch a wrong request path (the consumer cannot).** Repointed the pinned path at `/api/v1/tpp-registry/authorize`:

```
1.1) status: expected status of 403 but was 404
1.2) body: $ Actual map is missing the following keys: authorized, reason, roles, tppId
```

Restored after each and re-confirmed green (`tests=1 failures=0`).

**Two probe footguns hit while measuring this, both of which report success while checking nothing:**
1. `./gradlew :…:test` after editing only the pact JSON finished `BUILD SUCCESSFUL in 5s` — the pact file is not a declared task input, so the task was UP-TO-DATE and the XML I read was the *previous* run's. `--rerun-tasks` is required when the only change is to a pact under `pacts/`.
2. pact-jvm **merges** into an existing pact file rather than replacing it. After removing the allow interaction from the consumer test, the regenerated JSON still contained it, and the provider then failed on a contract the consumer no longer declares. `rm` the pact before regenerating when an interaction is *removed*.

## Gate (all local — CI is unavailable, see below)

- `:openbank-psd2-service:test --tests "*TppRegistryCheckPactConsumerTest*"` → `tests=1 failures=0`
- `:openbank-tpp-registry-service:test --tests "*TppRegistryPactProviderVerificationTest*"` → `tests=1 failures=0 errors=0`
- `:openbank-psd2-service:build` + `koverVerify` → BUILD SUCCESSFUL
- `:openbank-tpp-registry-service:build` → BUILD SUCCESSFUL (note: `build -x test` fails `koverVerify` for the obvious reason — no coverage data; `koverVerify` alone exits 0)
- `detekt` + `ktlintCheck` on psd2 and tpp-registry → BUILD SUCCESSFUL

Scope discipline: this PR touches **only** psd2's `src/test` + `build.gradle.kts` (plus tpp-registry's test tree). No gitops, no rego, no `application.yaml` — the psd2 OPA/sidecar work on `security/psd2-opa-sidecar-1797` is untouched.

GitHub Actions is in a **major outage** (incident "Actions run failures and delays", started 12:31Z, Critical); runs complete with `conclusion=failure` and **zero jobs**, including on `main` before this branch existed. A red check here is not a signal about this work. Auto-merge is armed.

## Follow-ups

1. **#2340** — fix the id mapping, then commit the allow interaction (its `@State` is a no-op: `V1__init.sql` already seeds `CZ-CNB-TEST-AISP` as an ACTIVE AISP).
2. `.github/workflows/pact-drift-check.yml` needs `:openbank-psd2-service:test --tests "com.openbank.psd2.contract.*PactConsumerTest"` — an omitted consumer reads as **passing** there. Not edited here: #2309 is rewriting that workflow and #2318 proposes deriving its scope, which would make the entry unnecessary.
3. Once #2336 merges, add psd2's consent-service pact + its `@State` to `ConsentPactProviderVerificationTest`.

Refs #2255
Refs #2340