### PR TITLE
fix(copilot): document themeSpec and drop the 501 the stream cannot return

### DIFF
--- a/openbank-copilot-service/src/main/resources/openapi.yaml
+++ b/openbank-copilot-service/src/main/resources/openapi.yaml
@@ -7,7 +7,7 @@ openapi: "3.1.0"
 
 info:
   title: OpenBank Copilot Service API
-  version: "1.1.0"
+  version: "1.2.0"
   description: |
     Customer-facing AI assistant (mobile copilot), per ADR-0089.
 
@@ -50,8 +50,18 @@ paths:
             application/json:
               schema:
                 $ref: "#/components/schemas/ChatReply"
+        "401":
+          description: Authenticated token carries no usable subject
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ErrorResponse"
         "501":
           description: Capability not yet enabled (feature flag off)
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ErrorResponse"
 
   /copilot/chat/stream:
     post:
@@ -63,6 +73,13 @@ paths:
         they arrive from the model backend instead of being buffered until the full reply is
         ready. Tool-call rounds are handled server-side and transparent to the client; only
         the final text response is streamed. First token arrives within ~500 ms.
+
+        Unlike `/copilot/chat`, this endpoint reports nothing through the status code once the
+        stream has opened. A disabled capability is delivered as an ordinary text chunk on the
+        `200` stream (`CopilotChatService.handleStream` emits its disabled message and returns —
+        there is no `501` path here), a refused prompt-injection attempt arrives the same way, and
+        a token with no usable subject yields an empty `200` stream rather than a `401`. Clients
+        must therefore read the body, not the status, to tell these apart.
       security:
         - bearerAuth: []
       requestBody:
@@ -81,8 +98,8 @@ paths:
                 description: >
                   Newline-delimited SSE events. Each `data:` line contains a raw text chunk.
                   No JSON wrapper — clients concatenate chunks to build the full reply.
-        "501":
-          description: Capability not yet enabled (feature flag off)
+                  A disabled capability, a refused prompt injection and a missing subject all
+                  arrive on this same 200 stream — see the operation description.
 
   /copilot/actions/{tokenId}/confirm:
     post:
@@ -158,6 +175,13 @@ components:
         message:
           type: string
           description: The customer's message (treated as untrusted input — ADR-0089 D3).
+        themeSpec:
+          type: string
+          nullable: true
+          description: |
+            The client's active ThemeSpec JSON (ADR-0190), so the theme-designer tool edits relative
+            to what the customer currently sees. Data context only — carries the same trust level as
+            `message` and is never treated as instructions.
     ChatReply:
       type: object
       required: [conversationId, reply]
@@ -173,6 +197,12 @@ components:
             Present when the turn produced a money-path action. A structured, validated proposal the
             app renders as a non-AI-controlled card and routes into the existing edge payment + SCA
             (dynamic-linking) flow. The assistant NEVER executes it (ADR-0089 D2).
+        themeSpec:
+          type: string
+          nullable: true
+          description: |
+            Normalized ThemeSpec JSON produced by the theme-designer tool on this turn (ADR-0190),
+            absent otherwise.
     ActionProposal:
       type: object
       required: [kind, summary, fields]


### PR DESCRIPTION
## Summary

Follow-up to #2323, which fixed the **route-set** half of copilot's spec drift and added
`CopilotApiContractTest` to guard it. That test compares `@Path` annotations to `paths:` — it cannot
see inside a schema or a response map, so the **schema** half was still wrong: two served fields
undocumented, and a `501` the stream endpoint is structurally incapable of returning.

## Type of change

- [x] fix (bug fix)
- [x] docs

## Linked issues

Closes #2351
Refs #2314, #2323

## Changes

- `ChatRequest.themeSpec` and `ChatReply.themeSpec` documented (ADR-0190) — both are on the wire
  today (`CopilotChatResource.ChatRequest`, `domain.ChatReply`) and absent from the spec.
- `/copilot/chat/stream`: the phantom `501` removed. `chatStream` returns `Multi<String>` and never
  a `Response`, and `CopilotChatService.handleStream` answers a disabled capability by emitting its
  message as an ordinary text chunk on the `200` stream. Replaced with an explicit statement that
  this operation reports nothing through the status code once the stream is open — a disabled
  capability, a refused prompt injection and a missing subject all arrive on the 200 body.
- `/copilot/chat`: added the `401` it returns when the token carries no usable subject, and the
  `{"error": …}` body its `501` already sends.
- `info.version` 1.1.0 -> 1.2.0.

## Reviewer notes

The `501` is the one worth a second look. A client written against the published spec branches on a
status that cannot occur, so "copilot is switched off" is silently rendered as a normal assistant
reply. That is a behaviour difference the route-set test is blind to by construction — it is not a
gap in #2323, it is the ceiling of what reflection over `@Path` can prove (#2314).

Measured with the CI-pinned oasdiff 1.22.0: **ERR 0, WARN 0**, and
`check-api-contract.py --enforce` locally returns
`additive change, info.version 1.1.0 -> 1.2.0 — OK (required >= MINOR)`. Unlike the aml correction
(#2317) this one hits no part of the #2313 wall, because everything here is additive — nothing had
to be tightened.

**Deliberately not changed:** `governance.yaml`. copilot has no in-repo caller — no
`@RegisterRestClient(configKey = "copilot…")` anywhere, the KMP app reaches it through its own
ingress — so there is no `lineage.upstream` edge to declare. Adding one by symmetry with #2317 would
have been a fabricated edge, and no runbook regeneration is needed as a result.

Separately raised, not touched here: #2352 — the service's own `CLAUDE.md` calls it a money-path
service and it carries the ADR-0030 threat model, but `rules.yaml: money_path_services` and the
Pyrra money-path SLO file both omit it. That needs a decision, not a cleanup.

## Definition of Done

- [x] Hexagonal layering preserved (no Kotlin changed).
- [ ] Unit tests added/updated — N/A, no code change. `CopilotApiContractTest` (from #2323) still
      passes; it guards the route set, which this PR does not alter.
- [x] OpenAPI spec regenerated (if REST API changed) — hand-corrected; nothing generates it today,
      which is #2314.

## Security checklist

- [x] No secrets, tokens, passwords, or PII in code, config, tests, logs.
- [x] No new `@Suppress`.
- [x] No new third-party dependency.

## Compliance impact

- [x] None

Documentation-only; the served API is unchanged. The `501` removal narrows what the published
contract promises to what the code can actually do.

## Rollout / Rollback

- Deployment strategy: rolling (no runtime behaviour change; the spec ships inside the artifact)
- Rollback plan: revert the commit
- Data migration reversible: N/A
