### PR TITLE
ci(pact): add mcp, psd2 and vop to the drift gate's module scope

### DIFF
--- a/.github/workflows/pact-drift-check.yml
+++ b/.github/workflows/pact-drift-check.yml
@@ -51,6 +51,9 @@ jobs:
       # regenerated, so an omitted consumer's committed pact is never rewritten and so never
       # differs. Add the module in the same PR that adds the pact (finrep arrived with #2269's).
       # The "Verify every committed pact was actually regenerated" step below now enforces that.
+      # mcp/psd2/vop are the backlog of that failure mode (#2255 dim C3): three consumers landed in
+      # #2336/#2346/#2324 while this list stayed at 17 modules, so the gate was green for all three
+      # having regenerated none of their five pacts.
       #
       # --rerun is load-bearing, not a belt-and-braces flag (#2291). The generated pact JSON is
       # not a declared output of the `test` task, so nothing invalidates `test` when pacts/
@@ -87,12 +90,15 @@ jobs:
             :openbank-interest-service:test --rerun --tests "com.openbank.interest.contract.*PactConsumerTest" \
             :openbank-kyc-service:test --rerun --tests "com.openbank.kyc.contract.*PactConsumerTest" \
             :openbank-lending-service:test --rerun --tests "com.openbank.lending.contract.*PactConsumerTest" \
+            :openbank-mcp-service:test --rerun --tests "com.openbank.mcp.contract.*PactConsumerTest" \
             :openbank-notification-service:test --rerun --tests "com.openbank.notification.contract.*PactConsumerTest" \
             :openbank-onboarding-service:test --rerun --tests "com.openbank.onboarding.contract.*PactConsumerTest" \
+            :openbank-psd2-service:test --rerun --tests "com.openbank.psd2.contract.*PactConsumerTest" \
             :openbank-sepa-instant:test --rerun --tests "com.openbank.sepainstant.contract.*PactConsumerTest" \
             :openbank-sepa-payment:test --rerun --tests "com.openbank.sepa.contract.*PactConsumerTest" \
             :openbank-settlement-service:test --rerun --tests "com.openbank.settlement.contract.*PactConsumerTest" \
-            :openbank-transaction-service:test --rerun --tests "com.openbank.transaction.contract.*PactConsumerTest"
+            :openbank-transaction-service:test --rerun --tests "com.openbank.transaction.contract.*PactConsumerTest" \
+            :openbank-vop-service:test --rerun --tests "com.openbank.vop.contract.*PactConsumerTest"
 
       # Belt to --rerun's braces, and the thing that keeps the module list above honest. The diff
       # step cannot tell "regenerated and identical" from "never regenerated" — both look clean.


### PR DESCRIPTION
## What

Adds `openbank-mcp-service`, `openbank-psd2-service` and `openbank-vop-service` to the module list
that `pact-drift-check.yml` regenerates.

## Why

The drift gate's scope is a hand-written list. Three consumers landed while the list stayed at 17
modules:

| Consumer | Provider(s) | PR |
| --- | --- | --- |
| vop | party-service | #2324 |
| mcp | consent, balance, transaction | #2336 |
| psd2 | tpp-registry | #2346 |

Their five committed pacts under `pacts/` were therefore never regenerated, and the diff step only
ever sees files that step rewrote — so the gate reported green having read none of them.

`#2309` (merged) added a coverage step that turns this class of omission red instead of green. This
PR is the backlog that step now has: without it the gate is legitimately red for five files.

## Verification — the failure path, not just the green

Per `CLAUDE.md` ("a gate that has only ever passed is unfalsified"), both steps were exercised
locally against inputs they MUST flag, reading what they print:

1. **Drift step, committed tamper.** Committed an extra interaction into
   `pacts/openbank-vop-service-openbank-party-service.json` that no consumer test generates, then
   ran the regeneration. `git diff --exit-code -- pacts/` exited **1** and printed the removal of
   exactly that interaction from exactly that file. A second, independent tamper (renaming an
   interaction in the psd2 pact) likewise reddened only the psd2 file.
2. **Coverage step.** With only the three new modules regenerated, its loop flagged the 28 pacts
   that were not rewritten and flagged **none** of the five belonging to mcp/psd2/vop — i.e. the
   three added entries do produce fresh files, which is the property the step checks.
3. **Baseline.** On an untampered tree the regeneration is idempotent: `git diff --exit-code --
   pacts/` exits 0.

Also confirmed while measuring: `pact.writer.overwrite=true` (set fleet-wide in
`build-logic/.../openbank.quarkus-service.gradle.kts`) is what makes 1. work — under pact-jvm's
default merge the stale interaction survives regeneration and the diff is empty.

## Scope note

`#2318` ("derive the drift gate's module scope") is still open. If it merges, this hand-added list
goes away with the rest of it; until then the list has to be correct.

## Linked issues

Refs #2255
