### PR TITLE
ci(governance): gate the published OpenAPI contract against the routes served

### DIFF
--- a/.github/scripts/check-openapi-route-conformance.py
+++ b/.github/scripts/check-openapi-route-conformance.py
@@ -1,0 +1,228 @@
+#!/usr/bin/env python3
+"""openapi-route-conformance gate — the published contract vs the routes actually served.
+
+WHY THIS EXISTS: nothing in this repo compared an `openapi.yaml` to the code serving it.
+ADR-0005 states the fleet is design-first and that "CI lints it with Spectral so docs cannot
+drift from runtime" — there is no Spectral config and no workflow references it. The only
+reader of these files, `check-api-contract.py`, does version arithmetic between two revisions
+of the *document*; it never asks whether the document is true. So specs rotted in silence:
+aml-service published request and response schemas whose fields exist nowhere in the service
+(#2312), and copilot-service served the human-in-the-loop confirm endpoint for a money-path
+action proposal without publishing it at all (#2323). This is the #2280 failure class — check
+whether anything reads the artifact before assuming a green covers it.
+
+WHAT IT CHECKS: for every `openbank-*/src/main/resources/openapi.yaml`, the set of
+(HTTP method, absolute path) pairs declared under `paths:` — resolved against `servers[0].url`
+— against the same set read off the JAX-RS annotations of that service's resource classes.
+Drift is reported in both directions:
+
+    served-not-published   a route the code answers and the contract omits
+    published-not-served   a route the contract promises and no resource declares
+
+WHAT IT DOES NOT PROVE. Only the route SET. It does not look inside a schema, so an invented
+request field or a response property that no DTO carries passes clean (that was the whole aml
+defect). It does not check status codes, so a documented response the handler cannot produce
+passes clean (copilot published a 501 its streaming endpoint is structurally incapable of
+returning). It does not boot Quarkus, so a route that exists as an annotation but fails at
+runtime on CDI, a filter or the policy gate passes clean. Treat a green here as "the route
+list agrees", nothing more — the schema half needs the generated document, see the issue
+referenced in rules.yaml.
+
+TWO SERVER CONVENTIONS, both live in this tree and both must be handled or the gate reports
+confident nonsense on half the fleet:
+
+    servers: [{url: "/api/v1"}]                         path prefix — copilot
+    servers: [{url: "http://localhost:8117"}]           absolute, no prefix — aml
+    servers: [{url: "https://host/customer/v1"}]        absolute WITH a prefix — customer-edge
+
+stdlib-only, same as check-api-contract.py; shells out to `git` for nothing — it reads the
+working tree, so it runs identically in CI and locally.
+
+Usage:
+    check-openapi-route-conformance.py [--enforce] [--service <name>]
+
+Modes (ADR-0144 gate graduation):
+    default    advisory — findings are ::warning annotations, exit 0
+    --enforce  findings are ::error annotations, exit 1
+"""
+
+from __future__ import annotations
+
+import argparse
+import re
+import sys
+from pathlib import Path
+
+HTTP_VERBS = ("GET", "POST", "PUT", "DELETE", "PATCH", "HEAD", "OPTIONS")
+SPEC_METHODS = tuple(v.lower() for v in HTTP_VERBS)
+
+# A JAX-RS *client* stub carries the CALLEE's routes, not this service's served contract.
+CLIENT_HINT = re.compile(r"@RegisterRestClient")
+
+
+def normalize(path: str) -> str:
+    """Collapse duplicate slashes and drop a trailing one, so /a//b/ == /a/b."""
+    collapsed = re.sub(r"/+", "/", path)
+    return collapsed.rstrip("/") or "/"
+
+
+def server_prefix(spec_text: str) -> str:
+    """Path prefix implied by servers[0].url — '' when the URL carries no path component."""
+    m = re.search(
+        r"^servers:\s*$\n(?:\s*#.*\n|\s*\n)*\s*-\s*url:\s*[\"']?(\S+?)[\"']?\s*$",
+        spec_text,
+        re.M,
+    )
+    if not m:
+        return ""
+    url = m.group(1)
+    path = url if url.startswith("/") else re.sub(r"^[a-z][a-z0-9+.-]*://[^/]*", "", url)
+    return path.rstrip("/")
+
+
+def spec_routes(spec_text: str) -> set[str]:
+    """(VERB, absolute path) pairs declared under `paths:`, resolved against the server prefix."""
+    prefix = server_prefix(spec_text)
+    routes: set[str] = set()
+    current: str | None = None
+    in_paths = False
+    for line in spec_text.splitlines():
+        if re.match(r"^paths:\s*$", line):
+            in_paths = True
+            continue
+        if in_paths and re.match(r"^[A-Za-z]", line):  # left the paths block
+            in_paths = False
+        if not in_paths:
+            continue
+        path_key = re.match(r"^  ([\"']?)(/\S*?)\1:\s*$", line)
+        if path_key:
+            current = prefix + path_key.group(2)
+            continue
+        method = re.match(r"^    ([a-z]+):\s*$", line)
+        if method and current and method.group(1) in SPEC_METHODS:
+            routes.add(f"{method.group(1).upper()} {normalize(current)}")
+    return routes
+
+
+def code_routes(service_dir: Path) -> set[str]:
+    """(VERB, absolute path) pairs read off the JAX-RS annotations of the service's resources.
+
+    Annotations are collected as the contiguous cluster preceding a `fun`, so the gate does not
+    care whether @Path sits before or after @GET — only that both decorate the same method.
+    """
+    routes: set[str] = set()
+    src = service_dir / "src/main/kotlin"
+    if not src.is_dir():
+        return routes
+    for kt in sorted(src.rglob("*.kt")):
+        if "/client/" in kt.as_posix().lower():
+            continue
+        try:
+            text = kt.read_text(encoding="utf-8", errors="replace")
+        except OSError:
+            continue
+        if CLIENT_HINT.search(text):
+            continue
+        class_path = re.search(r"^@Path\(\s*\"([^\"]*)\"\s*\)", text, re.M)
+        if not class_path:
+            continue
+        base = class_path.group(1).rstrip("/")
+
+        cluster: list[str] = []
+        pending = ""      # an annotation whose argument list spans several lines
+        depth = 0
+        for line in text.splitlines():
+            stripped = line.strip()
+
+            # Continuation of a multi-line annotation, e.g. @Operation(\n  summary = "...",\n).
+            # Without this the closing lines look like ordinary code and would reset the cluster,
+            # dropping the @POST/@Path that preceded them (measured: it hid copilot's confirm route).
+            if pending:
+                pending += " " + stripped
+                depth += stripped.count("(") - stripped.count(")")
+                if depth <= 0:
+                    cluster.append(pending)
+                    pending, depth = "", 0
+                continue
+
+            if stripped.startswith("@"):
+                balance = stripped.count("(") - stripped.count(")")
+                if balance > 0:
+                    pending, depth = stripped, balance
+                else:
+                    cluster.append(stripped)
+                continue
+
+            if not stripped or stripped.startswith("//") or stripped.startswith("*") or stripped.startswith("/*"):
+                continue
+
+            if re.match(r"^(?:(?:public|private|internal|protected|open|override|suspend)\s+)*fun\b", stripped):
+                verbs = [v for v in HTTP_VERBS if any(re.fullmatch(rf"@{v}(\(\))?", a) for a in cluster)]
+                if verbs:
+                    sub = ""
+                    for a in cluster:
+                        m = re.match(r"^@Path\(\s*\"([^\"]*)\"\s*\)$", a)
+                        if m:
+                            sub = m.group(1)
+                            break
+                    for verb in verbs:
+                        routes.add(f"{verb} {normalize(base + sub)}")
+            cluster = []
+    return routes
+
+
+def main() -> int:
+    ap = argparse.ArgumentParser()
+    ap.add_argument("--enforce", action="store_true")
+    ap.add_argument("--service", help="check a single openbank-* module (default: the whole fleet)")
+    args = ap.parse_args()
+
+    level = "error" if args.enforce else "warning"
+    specs = sorted(Path(".").glob("openbank-*/src/main/resources/openapi.yaml"))
+    if args.service:
+        specs = [s for s in specs if s.parts[0] == args.service]
+        if not specs:
+            print(f"::error::openapi-route-conformance: no openapi.yaml for service {args.service!r}")
+            return 1
+
+    findings = 0
+    checked = 0
+    no_resources: list[str] = []
+
+    for spec_path in specs:
+        service_dir = Path(spec_path.parts[0])
+        service = service_dir.name
+        declared = spec_routes(spec_path.read_text(encoding="utf-8", errors="replace"))
+        served = code_routes(service_dir)
+
+        # A service with no annotated resource class at all is not evidence of drift — it is a
+        # service this heuristic cannot see (generated resources, a non-JAX-RS surface). Report
+        # the skip explicitly rather than scoring it clean.
+        if not served:
+            no_resources.append(service)
+            continue
+
+        checked += 1
+        for route in sorted(served - declared):
+            findings += 1
+            print(f"::{level}::openapi-route-conformance: {service}: served-not-published — "
+                  f"{route} is answered by a resource class and absent from openapi.yaml")
+        for route in sorted(declared - served):
+            findings += 1
+            print(f"::{level}::openapi-route-conformance: {service}: published-not-served — "
+                  f"{route} is promised by openapi.yaml and no resource class declares it")
+
+    print(
+        f"check-openapi-route-conformance: {checked} service(s) compared, "
+        f"{len(no_resources)} skipped with no annotated resource class"
+        + (f" ({', '.join(no_resources)})" if no_resources else "")
+        + f", {findings} route-level finding(s)."
+    )
+    if findings and not args.enforce:
+        print("check-openapi-route-conformance: advisory — will become a hard gate "
+              "once the backlog is cleared (see rules.yaml: openapi_route_conformance).")
+    return 1 if (findings and args.enforce) else 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -801,6 +801,21 @@ jobs:
           sudo install -m 0755 /tmp/oasdiff /usr/local/bin/oasdiff
           python3 .github/scripts/check-api-contract.py --base "${PR_DIFF_BASE}" --enforce
 
+      # ADVISORY — 114 findings on main the day this landed, so it cannot enforce yet; the
+      # backlog is tracked in rules.yaml: openapi_route_conformance. Add --enforce to flip.
+      #
+      # The gate above classifies a spec's version bump against the previous revision of the
+      # same document. Nothing asked whether the document is TRUE, which is how aml-service
+      # published schemas whose fields exist nowhere in the code (#2312) and copilot-service
+      # served an unpublished money-path confirm endpoint (#2323). NOT diff-scoped: the defect
+      # is a missing pair between two trees, so a PR that changes only Kotlin never touches the
+      # spec and a diff-scoped gate would see nothing.
+      #
+      # Route SET only — it does not read schemas or status codes. Do not read a green here as
+      # "this spec is true"; see the script header for the precise limits.
+      - name: "openapi-route-conformance — published contract vs served routes (advisory)"
+        run: python3 .github/scripts/check-openapi-route-conformance.py
+
       # ADVISORY until rules.yaml change_classes.db_change flips to enforced
       # (target 2026-08-15, ADR-0144) — add --enforce to the invocation to flip.
       # Covers BOTH halves of db_change.require: an added migration carries a

--- a/openbank-infra/gitops/components/accounts/account-opa-bundle.yaml
+++ b/openbank-infra/gitops/components/accounts/account-opa-bundle.yaml
@@ -9,7 +9,7 @@ metadata:
     app.kubernetes.io/name: account-service
     app.kubernetes.io/part-of: accounts
   annotations:
-    openbank.tech/policy-checksum: "b2c11f30eec8f1b6"
+    openbank.tech/policy-checksum: "b17ce021f6c1ea11"
 data:
   rest.rego: |
     # SPDX-License-Identifier: Apache-2.0
@@ -1550,6 +1550,42 @@ data:
         # spec-touching PR (bump info.version to match what the diff did), which the error
         # message spells out.
         ci_producer: ".github/scripts/check-api-contract.py"
+      openapi_route_conformance:
+        detect: ["openbank-*/src/main/resources/openapi.yaml", "JAX-RS @Path / @GET / @POST resource classes"]
+        require:
+          - "every route a resource class answers is published in that service's openapi.yaml"
+          - "every route openapi.yaml promises is declared by a resource class"
+        gate: openapi-route-conformance
+        enforced: advisory
+        target_enforce_date: "2026-09-30"
+        ci_producer: ".github/scripts/check-openapi-route-conformance.py"
+        # api_contract (above) classifies a spec's version bump against the PREVIOUS REVISION of the
+        # same document. Nothing asked whether the document is TRUE. ADR-0005 says "CI lints it with
+        # Spectral so docs cannot drift from runtime" — there is no Spectral config in this repo and
+        # no workflow references it, so that control has never existed. The #2280 failure class:
+        # check whether anything reads the artifact before assuming a green covers it.
+        #
+        # What the drift actually was, measured on the day this landed: 114 route-level findings
+        # across 44 services. aml-service published request/response schemas whose fields exist
+        # nowhere in the code (#2312, fixed in #2317); copilot-service served the human-in-the-loop
+        # confirm for a money-path action proposal without publishing it (#2323) and declared a 501
+        # its streaming endpoint cannot return (#2351, fixed in #2353). Worst single pattern: 10 of
+        # the 15 services with an ApprovalResource serve PATCH /api/v1/<svc>/approvals/{id} — the
+        # four-eyes control — without publishing it, most of them money-path.
+        #
+        # ROUTE SET ONLY. It does not read schemas, so an invented request field passes clean (that
+        # was the whole aml defect); it does not read status codes, so a documented response the
+        # handler cannot produce passes clean. A reflection test is the floor, not the ceiling — the
+        # schema half needs the Quarkus-generated document
+        # (quarkus.smallrye-openapi.store-schema-directory, a dependency the whole fleet already has
+        # and nothing uses). Do not let a green here be read as "this spec is true".
+        #
+        # NOT diff-scoped, like db_backup_association and unlike api_contract/db_change: the defect
+        # is a MISSING pair across two trees, so a PR touching only Kotlin never touches the spec and
+        # a diff-scoped gate would see nothing.
+        #
+        # Advisory because 114 pre-existing findings cannot be a merge blocker on day one. Flipping
+        # to enforced = add --enforce in ci.yml, once the backlog is cleared.
       db_backup_association:
         detect: ["openbank-infra/gitops/**/*.yaml (kind: Cluster, postgresql.cnpg.io)"]
         require:

--- a/openbank-infra/gitops/components/accounts/account-service.yaml
+++ b/openbank-infra/gitops/components/accounts/account-service.yaml
@@ -37,7 +37,7 @@ spec:
       annotations:
         # Rolls the pod when the OPA bundle changes — subPath mounts do NOT hot-reload.
         # Kept in sync by gen-account-opa-bundle.sh (do not hand-edit).
-        openbank.tech/policy-checksum: "b2c11f30eec8f1b6"
+        openbank.tech/policy-checksum: "b17ce021f6c1ea11"
     spec:
       securityContext:
         runAsNonRoot: true

--- a/openbank-infra/gitops/components/aml/aml-opa-bundle.yaml
+++ b/openbank-infra/gitops/components/aml/aml-opa-bundle.yaml
@@ -9,7 +9,7 @@ metadata:
     app.kubernetes.io/name: aml-service
     app.kubernetes.io/part-of: aml
   annotations:
-    openbank.tech/policy-checksum: "f0f15c22d1ce793e"
+    openbank.tech/policy-checksum: "7018cf6161fb87a1"
 data:
   rest.rego: |
     # SPDX-License-Identifier: Apache-2.0
@@ -1523,6 +1523,42 @@ data:
         # spec-touching PR (bump info.version to match what the diff did), which the error
         # message spells out.
         ci_producer: ".github/scripts/check-api-contract.py"
+      openapi_route_conformance:
+        detect: ["openbank-*/src/main/resources/openapi.yaml", "JAX-RS @Path / @GET / @POST resource classes"]
+        require:
+          - "every route a resource class answers is published in that service's openapi.yaml"
+          - "every route openapi.yaml promises is declared by a resource class"
+        gate: openapi-route-conformance
+        enforced: advisory
+        target_enforce_date: "2026-09-30"
+        ci_producer: ".github/scripts/check-openapi-route-conformance.py"
+        # api_contract (above) classifies a spec's version bump against the PREVIOUS REVISION of the
+        # same document. Nothing asked whether the document is TRUE. ADR-0005 says "CI lints it with
+        # Spectral so docs cannot drift from runtime" — there is no Spectral config in this repo and
+        # no workflow references it, so that control has never existed. The #2280 failure class:
+        # check whether anything reads the artifact before assuming a green covers it.
+        #
+        # What the drift actually was, measured on the day this landed: 114 route-level findings
+        # across 44 services. aml-service published request/response schemas whose fields exist
+        # nowhere in the code (#2312, fixed in #2317); copilot-service served the human-in-the-loop
+        # confirm for a money-path action proposal without publishing it (#2323) and declared a 501
+        # its streaming endpoint cannot return (#2351, fixed in #2353). Worst single pattern: 10 of
+        # the 15 services with an ApprovalResource serve PATCH /api/v1/<svc>/approvals/{id} — the
+        # four-eyes control — without publishing it, most of them money-path.
+        #
+        # ROUTE SET ONLY. It does not read schemas, so an invented request field passes clean (that
+        # was the whole aml defect); it does not read status codes, so a documented response the
+        # handler cannot produce passes clean. A reflection test is the floor, not the ceiling — the
+        # schema half needs the Quarkus-generated document
+        # (quarkus.smallrye-openapi.store-schema-directory, a dependency the whole fleet already has
+        # and nothing uses). Do not let a green here be read as "this spec is true".
+        #
+        # NOT diff-scoped, like db_backup_association and unlike api_contract/db_change: the defect
+        # is a MISSING pair across two trees, so a PR touching only Kotlin never touches the spec and
+        # a diff-scoped gate would see nothing.
+        #
+        # Advisory because 114 pre-existing findings cannot be a merge blocker on day one. Flipping
+        # to enforced = add --enforce in ci.yml, once the backlog is cleared.
       db_backup_association:
         detect: ["openbank-infra/gitops/**/*.yaml (kind: Cluster, postgresql.cnpg.io)"]
         require:

--- a/openbank-infra/gitops/components/aml/aml-service.yaml
+++ b/openbank-infra/gitops/components/aml/aml-service.yaml
@@ -22,7 +22,7 @@ spec:
       annotations:
         # Rolls the pod when the OPA bundle changes (subPath mounts do not hot-reload).
         # Kept in sync by gen-aml-opa-bundle.sh (do not hand-edit).
-        openbank.tech/policy-checksum: "f0f15c22d1ce793e"
+        openbank.tech/policy-checksum: "7018cf6161fb87a1"
     spec:
       securityContext:
         runAsNonRoot: true

--- a/openbank-infra/gitops/components/anacredit/anacredit-opa-bundle.yaml
+++ b/openbank-infra/gitops/components/anacredit/anacredit-opa-bundle.yaml
@@ -9,7 +9,7 @@ metadata:
     app.kubernetes.io/name: anacredit-service
     app.kubernetes.io/part-of: anacredit
   annotations:
-    openbank.tech/policy-checksum: "226e8c3941b66c12"
+    openbank.tech/policy-checksum: "9ab8f8caea42d258"
 data:
   rest.rego: |
     # SPDX-License-Identifier: Apache-2.0
@@ -1493,6 +1493,42 @@ data:
         # spec-touching PR (bump info.version to match what the diff did), which the error
         # message spells out.
         ci_producer: ".github/scripts/check-api-contract.py"
+      openapi_route_conformance:
+        detect: ["openbank-*/src/main/resources/openapi.yaml", "JAX-RS @Path / @GET / @POST resource classes"]
+        require:
+          - "every route a resource class answers is published in that service's openapi.yaml"
+          - "every route openapi.yaml promises is declared by a resource class"
+        gate: openapi-route-conformance
+        enforced: advisory
+        target_enforce_date: "2026-09-30"
+        ci_producer: ".github/scripts/check-openapi-route-conformance.py"
+        # api_contract (above) classifies a spec's version bump against the PREVIOUS REVISION of the
+        # same document. Nothing asked whether the document is TRUE. ADR-0005 says "CI lints it with
+        # Spectral so docs cannot drift from runtime" — there is no Spectral config in this repo and
+        # no workflow references it, so that control has never existed. The #2280 failure class:
+        # check whether anything reads the artifact before assuming a green covers it.
+        #
+        # What the drift actually was, measured on the day this landed: 114 route-level findings
+        # across 44 services. aml-service published request/response schemas whose fields exist
+        # nowhere in the code (#2312, fixed in #2317); copilot-service served the human-in-the-loop
+        # confirm for a money-path action proposal without publishing it (#2323) and declared a 501
+        # its streaming endpoint cannot return (#2351, fixed in #2353). Worst single pattern: 10 of
+        # the 15 services with an ApprovalResource serve PATCH /api/v1/<svc>/approvals/{id} — the
+        # four-eyes control — without publishing it, most of them money-path.
+        #
+        # ROUTE SET ONLY. It does not read schemas, so an invented request field passes clean (that
+        # was the whole aml defect); it does not read status codes, so a documented response the
+        # handler cannot produce passes clean. A reflection test is the floor, not the ceiling — the
+        # schema half needs the Quarkus-generated document
+        # (quarkus.smallrye-openapi.store-schema-directory, a dependency the whole fleet already has
+        # and nothing uses). Do not let a green here be read as "this spec is true".
+        #
+        # NOT diff-scoped, like db_backup_association and unlike api_contract/db_change: the defect
+        # is a MISSING pair across two trees, so a PR touching only Kotlin never touches the spec and
+        # a diff-scoped gate would see nothing.
+        #
+        # Advisory because 114 pre-existing findings cannot be a merge blocker on day one. Flipping
+        # to enforced = add --enforce in ci.yml, once the backlog is cleared.
       db_backup_association:
         detect: ["openbank-infra/gitops/**/*.yaml (kind: Cluster, postgresql.cnpg.io)"]
         require:

--- a/openbank-infra/gitops/components/anacredit/anacredit-service.yaml
+++ b/openbank-infra/gitops/components/anacredit/anacredit-service.yaml
@@ -32,7 +32,7 @@ spec:
       annotations:
         # Rolls the pods when the OPA bundle changes — subPath mounts do NOT hot-reload.
         # Kept in sync by gen-anacredit-opa-bundle.sh (do not hand-edit).
-        openbank.tech/policy-checksum: "226e8c3941b66c12"
+        openbank.tech/policy-checksum: "9ab8f8caea42d258"
     spec:
       securityContext:
         runAsNonRoot: true

--- a/openbank-infra/gitops/components/ap2/ap2-opa-bundle.yaml
+++ b/openbank-infra/gitops/components/ap2/ap2-opa-bundle.yaml
@@ -9,7 +9,7 @@ metadata:
     app.kubernetes.io/name: mcp-service
     app.kubernetes.io/part-of: platform
   annotations:
-    openbank.tech/policy-checksum: "8b40f47809078cc9"
+    openbank.tech/policy-checksum: "f64299b3b15fe454"
 data:
   rest.rego: |
     # SPDX-License-Identifier: Apache-2.0
@@ -1461,6 +1461,42 @@ data:
         # spec-touching PR (bump info.version to match what the diff did), which the error
         # message spells out.
         ci_producer: ".github/scripts/check-api-contract.py"
+      openapi_route_conformance:
+        detect: ["openbank-*/src/main/resources/openapi.yaml", "JAX-RS @Path / @GET / @POST resource classes"]
+        require:
+          - "every route a resource class answers is published in that service's openapi.yaml"
+          - "every route openapi.yaml promises is declared by a resource class"
+        gate: openapi-route-conformance
+        enforced: advisory
+        target_enforce_date: "2026-09-30"
+        ci_producer: ".github/scripts/check-openapi-route-conformance.py"
+        # api_contract (above) classifies a spec's version bump against the PREVIOUS REVISION of the
+        # same document. Nothing asked whether the document is TRUE. ADR-0005 says "CI lints it with
+        # Spectral so docs cannot drift from runtime" — there is no Spectral config in this repo and
+        # no workflow references it, so that control has never existed. The #2280 failure class:
+        # check whether anything reads the artifact before assuming a green covers it.
+        #
+        # What the drift actually was, measured on the day this landed: 114 route-level findings
+        # across 44 services. aml-service published request/response schemas whose fields exist
+        # nowhere in the code (#2312, fixed in #2317); copilot-service served the human-in-the-loop
+        # confirm for a money-path action proposal without publishing it (#2323) and declared a 501
+        # its streaming endpoint cannot return (#2351, fixed in #2353). Worst single pattern: 10 of
+        # the 15 services with an ApprovalResource serve PATCH /api/v1/<svc>/approvals/{id} — the
+        # four-eyes control — without publishing it, most of them money-path.
+        #
+        # ROUTE SET ONLY. It does not read schemas, so an invented request field passes clean (that
+        # was the whole aml defect); it does not read status codes, so a documented response the
+        # handler cannot produce passes clean. A reflection test is the floor, not the ceiling — the
+        # schema half needs the Quarkus-generated document
+        # (quarkus.smallrye-openapi.store-schema-directory, a dependency the whole fleet already has
+        # and nothing uses). Do not let a green here be read as "this spec is true".
+        #
+        # NOT diff-scoped, like db_backup_association and unlike api_contract/db_change: the defect
+        # is a MISSING pair across two trees, so a PR touching only Kotlin never touches the spec and
+        # a diff-scoped gate would see nothing.
+        #
+        # Advisory because 114 pre-existing findings cannot be a merge blocker on day one. Flipping
+        # to enforced = add --enforce in ci.yml, once the backlog is cleared.
       db_backup_association:
         detect: ["openbank-infra/gitops/**/*.yaml (kind: Cluster, postgresql.cnpg.io)"]
         require:

--- a/openbank-infra/gitops/components/ap2/ap2-service.yaml
+++ b/openbank-infra/gitops/components/ap2/ap2-service.yaml
@@ -30,7 +30,7 @@ spec:
       annotations:
         # Roll the pod when the OPA policy bundle changes (subPath mounts don't hot-reload).
         # Kept in sync by gen-ap2-opa-bundle.sh (do not hand-edit).
-        openbank.tech/policy-checksum: "8b40f47809078cc9"
+        openbank.tech/policy-checksum: "f64299b3b15fe454"
     spec:
       securityContext:
         runAsNonRoot: true

--- a/openbank-infra/gitops/components/audit/audit-opa-bundle.yaml
+++ b/openbank-infra/gitops/components/audit/audit-opa-bundle.yaml
@@ -9,7 +9,7 @@ metadata:
     app.kubernetes.io/name: audit-service
     app.kubernetes.io/part-of: audit
   annotations:
-    openbank.tech/policy-checksum: "f831fe5bb5f83319"
+    openbank.tech/policy-checksum: "cc6d3073df796068"
 data:
   rest.rego: |
     # SPDX-License-Identifier: Apache-2.0
@@ -1505,6 +1505,42 @@ data:
         # spec-touching PR (bump info.version to match what the diff did), which the error
         # message spells out.
         ci_producer: ".github/scripts/check-api-contract.py"
+      openapi_route_conformance:
+        detect: ["openbank-*/src/main/resources/openapi.yaml", "JAX-RS @Path / @GET / @POST resource classes"]
+        require:
+          - "every route a resource class answers is published in that service's openapi.yaml"
+          - "every route openapi.yaml promises is declared by a resource class"
+        gate: openapi-route-conformance
+        enforced: advisory
+        target_enforce_date: "2026-09-30"
+        ci_producer: ".github/scripts/check-openapi-route-conformance.py"
+        # api_contract (above) classifies a spec's version bump against the PREVIOUS REVISION of the
+        # same document. Nothing asked whether the document is TRUE. ADR-0005 says "CI lints it with
+        # Spectral so docs cannot drift from runtime" — there is no Spectral config in this repo and
+        # no workflow references it, so that control has never existed. The #2280 failure class:
+        # check whether anything reads the artifact before assuming a green covers it.
+        #
+        # What the drift actually was, measured on the day this landed: 114 route-level findings
+        # across 44 services. aml-service published request/response schemas whose fields exist
+        # nowhere in the code (#2312, fixed in #2317); copilot-service served the human-in-the-loop
+        # confirm for a money-path action proposal without publishing it (#2323) and declared a 501
+        # its streaming endpoint cannot return (#2351, fixed in #2353). Worst single pattern: 10 of
+        # the 15 services with an ApprovalResource serve PATCH /api/v1/<svc>/approvals/{id} — the
+        # four-eyes control — without publishing it, most of them money-path.
+        #
+        # ROUTE SET ONLY. It does not read schemas, so an invented request field passes clean (that
+        # was the whole aml defect); it does not read status codes, so a documented response the
+        # handler cannot produce passes clean. A reflection test is the floor, not the ceiling — the
+        # schema half needs the Quarkus-generated document
+        # (quarkus.smallrye-openapi.store-schema-directory, a dependency the whole fleet already has
+        # and nothing uses). Do not let a green here be read as "this spec is true".
+        #
+        # NOT diff-scoped, like db_backup_association and unlike api_contract/db_change: the defect
+        # is a MISSING pair across two trees, so a PR touching only Kotlin never touches the spec and
+        # a diff-scoped gate would see nothing.
+        #
+        # Advisory because 114 pre-existing findings cannot be a merge blocker on day one. Flipping
+        # to enforced = add --enforce in ci.yml, once the backlog is cleared.
       db_backup_association:
         detect: ["openbank-infra/gitops/**/*.yaml (kind: Cluster, postgresql.cnpg.io)"]
         require:

--- a/openbank-infra/gitops/components/audit/audit-service.yaml
+++ b/openbank-infra/gitops/components/audit/audit-service.yaml
@@ -22,7 +22,7 @@ spec:
       annotations:
         # Rolls the pod when the OPA bundle changes (subPath mounts do not hot-reload).
         # Kept in sync by gen-audit-opa-bundle.sh (do not hand-edit).
-        openbank.tech/policy-checksum: "f831fe5bb5f83319"
+        openbank.tech/policy-checksum: "cc6d3073df796068"
     spec:
       securityContext:
         runAsNonRoot: true

--- a/openbank-infra/gitops/components/balances/balance-opa-bundle.yaml
+++ b/openbank-infra/gitops/components/balances/balance-opa-bundle.yaml
@@ -9,7 +9,7 @@ metadata:
     app.kubernetes.io/name: balance-service
     app.kubernetes.io/part-of: balances
   annotations:
-    openbank.tech/policy-checksum: "9228df3fc7bcd9c3"
+    openbank.tech/policy-checksum: "53c8f463f33f6925"
 data:
   rest.rego: |
     # SPDX-License-Identifier: Apache-2.0
@@ -1594,6 +1594,42 @@ data:
         # spec-touching PR (bump info.version to match what the diff did), which the error
         # message spells out.
         ci_producer: ".github/scripts/check-api-contract.py"
+      openapi_route_conformance:
+        detect: ["openbank-*/src/main/resources/openapi.yaml", "JAX-RS @Path / @GET / @POST resource classes"]
+        require:
+          - "every route a resource class answers is published in that service's openapi.yaml"
+          - "every route openapi.yaml promises is declared by a resource class"
+        gate: openapi-route-conformance
+        enforced: advisory
+        target_enforce_date: "2026-09-30"
+        ci_producer: ".github/scripts/check-openapi-route-conformance.py"
+        # api_contract (above) classifies a spec's version bump against the PREVIOUS REVISION of the
+        # same document. Nothing asked whether the document is TRUE. ADR-0005 says "CI lints it with
+        # Spectral so docs cannot drift from runtime" — there is no Spectral config in this repo and
+        # no workflow references it, so that control has never existed. The #2280 failure class:
+        # check whether anything reads the artifact before assuming a green covers it.
+        #
+        # What the drift actually was, measured on the day this landed: 114 route-level findings
+        # across 44 services. aml-service published request/response schemas whose fields exist
+        # nowhere in the code (#2312, fixed in #2317); copilot-service served the human-in-the-loop
+        # confirm for a money-path action proposal without publishing it (#2323) and declared a 501
+        # its streaming endpoint cannot return (#2351, fixed in #2353). Worst single pattern: 10 of
+        # the 15 services with an ApprovalResource serve PATCH /api/v1/<svc>/approvals/{id} — the
+        # four-eyes control — without publishing it, most of them money-path.
+        #
+        # ROUTE SET ONLY. It does not read schemas, so an invented request field passes clean (that
+        # was the whole aml defect); it does not read status codes, so a documented response the
+        # handler cannot produce passes clean. A reflection test is the floor, not the ceiling — the
+        # schema half needs the Quarkus-generated document
+        # (quarkus.smallrye-openapi.store-schema-directory, a dependency the whole fleet already has
+        # and nothing uses). Do not let a green here be read as "this spec is true".
+        #
+        # NOT diff-scoped, like db_backup_association and unlike api_contract/db_change: the defect
+        # is a MISSING pair across two trees, so a PR touching only Kotlin never touches the spec and
+        # a diff-scoped gate would see nothing.
+        #
+        # Advisory because 114 pre-existing findings cannot be a merge blocker on day one. Flipping
+        # to enforced = add --enforce in ci.yml, once the backlog is cleared.
       db_backup_association:
         detect: ["openbank-infra/gitops/**/*.yaml (kind: Cluster, postgresql.cnpg.io)"]
         require:

--- a/openbank-infra/gitops/components/balances/balance-service.yaml
+++ b/openbank-infra/gitops/components/balances/balance-service.yaml
@@ -34,7 +34,7 @@ spec:
       annotations:
         # Rolls the pods when the OPA bundle changes — subPath mounts do NOT hot-reload.
         # Kept in sync by gen-balance-opa-bundle.sh (do not hand-edit).
-        openbank.tech/policy-checksum: "9228df3fc7bcd9c3"
+        openbank.tech/policy-checksum: "53c8f463f33f6925"
     spec:
       securityContext:
         runAsNonRoot: true

--- a/openbank-infra/gitops/components/billing/billing-opa-bundle.yaml
+++ b/openbank-infra/gitops/components/billing/billing-opa-bundle.yaml
@@ -9,7 +9,7 @@ metadata:
     app.kubernetes.io/name: billing-service
     app.kubernetes.io/part-of: billing
   annotations:
-    openbank.tech/policy-checksum: "c3f7dc6dc397fbb0"
+    openbank.tech/policy-checksum: "971f3cb8e53574bf"
 data:
   rest.rego: |
     # SPDX-License-Identifier: Apache-2.0
@@ -1499,6 +1499,42 @@ data:
         # spec-touching PR (bump info.version to match what the diff did), which the error
         # message spells out.
         ci_producer: ".github/scripts/check-api-contract.py"
+      openapi_route_conformance:
+        detect: ["openbank-*/src/main/resources/openapi.yaml", "JAX-RS @Path / @GET / @POST resource classes"]
+        require:
+          - "every route a resource class answers is published in that service's openapi.yaml"
+          - "every route openapi.yaml promises is declared by a resource class"
+        gate: openapi-route-conformance
+        enforced: advisory
+        target_enforce_date: "2026-09-30"
+        ci_producer: ".github/scripts/check-openapi-route-conformance.py"
+        # api_contract (above) classifies a spec's version bump against the PREVIOUS REVISION of the
+        # same document. Nothing asked whether the document is TRUE. ADR-0005 says "CI lints it with
+        # Spectral so docs cannot drift from runtime" — there is no Spectral config in this repo and
+        # no workflow references it, so that control has never existed. The #2280 failure class:
+        # check whether anything reads the artifact before assuming a green covers it.
+        #
+        # What the drift actually was, measured on the day this landed: 114 route-level findings
+        # across 44 services. aml-service published request/response schemas whose fields exist
+        # nowhere in the code (#2312, fixed in #2317); copilot-service served the human-in-the-loop
+        # confirm for a money-path action proposal without publishing it (#2323) and declared a 501
+        # its streaming endpoint cannot return (#2351, fixed in #2353). Worst single pattern: 10 of
+        # the 15 services with an ApprovalResource serve PATCH /api/v1/<svc>/approvals/{id} — the
+        # four-eyes control — without publishing it, most of them money-path.
+        #
+        # ROUTE SET ONLY. It does not read schemas, so an invented request field passes clean (that
+        # was the whole aml defect); it does not read status codes, so a documented response the
+        # handler cannot produce passes clean. A reflection test is the floor, not the ceiling — the
+        # schema half needs the Quarkus-generated document
+        # (quarkus.smallrye-openapi.store-schema-directory, a dependency the whole fleet already has
+        # and nothing uses). Do not let a green here be read as "this spec is true".
+        #
+        # NOT diff-scoped, like db_backup_association and unlike api_contract/db_change: the defect
+        # is a MISSING pair across two trees, so a PR touching only Kotlin never touches the spec and
+        # a diff-scoped gate would see nothing.
+        #
+        # Advisory because 114 pre-existing findings cannot be a merge blocker on day one. Flipping
+        # to enforced = add --enforce in ci.yml, once the backlog is cleared.
       db_backup_association:
         detect: ["openbank-infra/gitops/**/*.yaml (kind: Cluster, postgresql.cnpg.io)"]
         require:

--- a/openbank-infra/gitops/components/billing/billing-service.yaml
+++ b/openbank-infra/gitops/components/billing/billing-service.yaml
@@ -27,7 +27,7 @@ spec:
       annotations:
         # Rolls the pods when the OPA bundle changes — subPath mounts do NOT hot-reload.
         # Kept in sync by gen-billing-opa-bundle.sh (do not hand-edit).
-        openbank.tech/policy-checksum: "c3f7dc6dc397fbb0"
+        openbank.tech/policy-checksum: "971f3cb8e53574bf"
     spec:
       securityContext:
         runAsNonRoot: true

--- a/openbank-infra/gitops/components/consent/consent-opa-bundle.yaml
+++ b/openbank-infra/gitops/components/consent/consent-opa-bundle.yaml
@@ -9,7 +9,7 @@ metadata:
     app.kubernetes.io/name: consent-service
     app.kubernetes.io/part-of: consent
   annotations:
-    openbank.tech/policy-checksum: "25b13153a7d8e394"
+    openbank.tech/policy-checksum: "93b361fe6a2457e3"
 data:
   rest.rego: |
     # SPDX-License-Identifier: Apache-2.0
@@ -1531,6 +1531,42 @@ data:
         # spec-touching PR (bump info.version to match what the diff did), which the error
         # message spells out.
         ci_producer: ".github/scripts/check-api-contract.py"
+      openapi_route_conformance:
+        detect: ["openbank-*/src/main/resources/openapi.yaml", "JAX-RS @Path / @GET / @POST resource classes"]
+        require:
+          - "every route a resource class answers is published in that service's openapi.yaml"
+          - "every route openapi.yaml promises is declared by a resource class"
+        gate: openapi-route-conformance
+        enforced: advisory
+        target_enforce_date: "2026-09-30"
+        ci_producer: ".github/scripts/check-openapi-route-conformance.py"
+        # api_contract (above) classifies a spec's version bump against the PREVIOUS REVISION of the
+        # same document. Nothing asked whether the document is TRUE. ADR-0005 says "CI lints it with
+        # Spectral so docs cannot drift from runtime" — there is no Spectral config in this repo and
+        # no workflow references it, so that control has never existed. The #2280 failure class:
+        # check whether anything reads the artifact before assuming a green covers it.
+        #
+        # What the drift actually was, measured on the day this landed: 114 route-level findings
+        # across 44 services. aml-service published request/response schemas whose fields exist
+        # nowhere in the code (#2312, fixed in #2317); copilot-service served the human-in-the-loop
+        # confirm for a money-path action proposal without publishing it (#2323) and declared a 501
+        # its streaming endpoint cannot return (#2351, fixed in #2353). Worst single pattern: 10 of
+        # the 15 services with an ApprovalResource serve PATCH /api/v1/<svc>/approvals/{id} — the
+        # four-eyes control — without publishing it, most of them money-path.
+        #
+        # ROUTE SET ONLY. It does not read schemas, so an invented request field passes clean (that
+        # was the whole aml defect); it does not read status codes, so a documented response the
+        # handler cannot produce passes clean. A reflection test is the floor, not the ceiling — the
+        # schema half needs the Quarkus-generated document
+        # (quarkus.smallrye-openapi.store-schema-directory, a dependency the whole fleet already has
+        # and nothing uses). Do not let a green here be read as "this spec is true".
+        #
+        # NOT diff-scoped, like db_backup_association and unlike api_contract/db_change: the defect
+        # is a MISSING pair across two trees, so a PR touching only Kotlin never touches the spec and
+        # a diff-scoped gate would see nothing.
+        #
+        # Advisory because 114 pre-existing findings cannot be a merge blocker on day one. Flipping
+        # to enforced = add --enforce in ci.yml, once the backlog is cleared.
       db_backup_association:
         detect: ["openbank-infra/gitops/**/*.yaml (kind: Cluster, postgresql.cnpg.io)"]
         require:

--- a/openbank-infra/gitops/components/consent/consent-service.yaml
+++ b/openbank-infra/gitops/components/consent/consent-service.yaml
@@ -28,7 +28,7 @@ spec:
       annotations:
         # Rolls the pods when the OPA bundle changes — subPath mounts do NOT hot-reload.
         # Kept in sync by gen-consent-opa-bundle.sh (do not hand-edit).
-        openbank.tech/policy-checksum: "25b13153a7d8e394"
+        openbank.tech/policy-checksum: "93b361fe6a2457e3"
     spec:
       securityContext:
         runAsNonRoot: true

--- a/openbank-infra/gitops/components/copilot/copilot-opa-bundle.yaml
+++ b/openbank-infra/gitops/components/copilot/copilot-opa-bundle.yaml
@@ -9,7 +9,7 @@ metadata:
     app.kubernetes.io/name: copilot-service
     app.kubernetes.io/part-of: platform
   annotations:
-    openbank.tech/policy-checksum: "f252537f3721dd9c"
+    openbank.tech/policy-checksum: "0e529cf643aba2c8"
 data:
   rest.rego: |
     # SPDX-License-Identifier: Apache-2.0
@@ -1585,6 +1585,42 @@ data:
         # spec-touching PR (bump info.version to match what the diff did), which the error
         # message spells out.
         ci_producer: ".github/scripts/check-api-contract.py"
+      openapi_route_conformance:
+        detect: ["openbank-*/src/main/resources/openapi.yaml", "JAX-RS @Path / @GET / @POST resource classes"]
+        require:
+          - "every route a resource class answers is published in that service's openapi.yaml"
+          - "every route openapi.yaml promises is declared by a resource class"
+        gate: openapi-route-conformance
+        enforced: advisory
+        target_enforce_date: "2026-09-30"
+        ci_producer: ".github/scripts/check-openapi-route-conformance.py"
+        # api_contract (above) classifies a spec's version bump against the PREVIOUS REVISION of the
+        # same document. Nothing asked whether the document is TRUE. ADR-0005 says "CI lints it with
+        # Spectral so docs cannot drift from runtime" — there is no Spectral config in this repo and
+        # no workflow references it, so that control has never existed. The #2280 failure class:
+        # check whether anything reads the artifact before assuming a green covers it.
+        #
+        # What the drift actually was, measured on the day this landed: 114 route-level findings
+        # across 44 services. aml-service published request/response schemas whose fields exist
+        # nowhere in the code (#2312, fixed in #2317); copilot-service served the human-in-the-loop
+        # confirm for a money-path action proposal without publishing it (#2323) and declared a 501
+        # its streaming endpoint cannot return (#2351, fixed in #2353). Worst single pattern: 10 of
+        # the 15 services with an ApprovalResource serve PATCH /api/v1/<svc>/approvals/{id} — the
+        # four-eyes control — without publishing it, most of them money-path.
+        #
+        # ROUTE SET ONLY. It does not read schemas, so an invented request field passes clean (that
+        # was the whole aml defect); it does not read status codes, so a documented response the
+        # handler cannot produce passes clean. A reflection test is the floor, not the ceiling — the
+        # schema half needs the Quarkus-generated document
+        # (quarkus.smallrye-openapi.store-schema-directory, a dependency the whole fleet already has
+        # and nothing uses). Do not let a green here be read as "this spec is true".
+        #
+        # NOT diff-scoped, like db_backup_association and unlike api_contract/db_change: the defect
+        # is a MISSING pair across two trees, so a PR touching only Kotlin never touches the spec and
+        # a diff-scoped gate would see nothing.
+        #
+        # Advisory because 114 pre-existing findings cannot be a merge blocker on day one. Flipping
+        # to enforced = add --enforce in ci.yml, once the backlog is cleared.
       db_backup_association:
         detect: ["openbank-infra/gitops/**/*.yaml (kind: Cluster, postgresql.cnpg.io)"]
         require:

--- a/openbank-infra/gitops/components/copilot/copilot-service.yaml
+++ b/openbank-infra/gitops/components/copilot/copilot-service.yaml
@@ -29,7 +29,7 @@ spec:
       annotations:
         # Rolls the pod when the OPA bundle changes — subPath mounts do NOT hot-reload.
         # Kept in sync by gen-copilot-opa-bundle.sh (do not hand-edit).
-        openbank.tech/policy-checksum: "f252537f3721dd9c"
+        openbank.tech/policy-checksum: "0e529cf643aba2c8"
     spec:
       securityContext:
         runAsNonRoot: true

--- a/openbank-infra/gitops/components/customer-edge/customer-edge-opa-bundle.yaml
+++ b/openbank-infra/gitops/components/customer-edge/customer-edge-opa-bundle.yaml
@@ -10,7 +10,7 @@ metadata:
     app.kubernetes.io/name: customer-edge
     app.kubernetes.io/part-of: customer-edge
   annotations:
-    openbank.tech/policy-checksum: "1006b34bb3e0708e"
+    openbank.tech/policy-checksum: "a2b96b14213553c8"
 data:
   rest.rego: |
     # SPDX-License-Identifier: Apache-2.0
@@ -684,6 +684,42 @@ data:
         # spec-touching PR (bump info.version to match what the diff did), which the error
         # message spells out.
         ci_producer: ".github/scripts/check-api-contract.py"
+      openapi_route_conformance:
+        detect: ["openbank-*/src/main/resources/openapi.yaml", "JAX-RS @Path / @GET / @POST resource classes"]
+        require:
+          - "every route a resource class answers is published in that service's openapi.yaml"
+          - "every route openapi.yaml promises is declared by a resource class"
+        gate: openapi-route-conformance
+        enforced: advisory
+        target_enforce_date: "2026-09-30"
+        ci_producer: ".github/scripts/check-openapi-route-conformance.py"
+        # api_contract (above) classifies a spec's version bump against the PREVIOUS REVISION of the
+        # same document. Nothing asked whether the document is TRUE. ADR-0005 says "CI lints it with
+        # Spectral so docs cannot drift from runtime" — there is no Spectral config in this repo and
+        # no workflow references it, so that control has never existed. The #2280 failure class:
+        # check whether anything reads the artifact before assuming a green covers it.
+        #
+        # What the drift actually was, measured on the day this landed: 114 route-level findings
+        # across 44 services. aml-service published request/response schemas whose fields exist
+        # nowhere in the code (#2312, fixed in #2317); copilot-service served the human-in-the-loop
+        # confirm for a money-path action proposal without publishing it (#2323) and declared a 501
+        # its streaming endpoint cannot return (#2351, fixed in #2353). Worst single pattern: 10 of
+        # the 15 services with an ApprovalResource serve PATCH /api/v1/<svc>/approvals/{id} — the
+        # four-eyes control — without publishing it, most of them money-path.
+        #
+        # ROUTE SET ONLY. It does not read schemas, so an invented request field passes clean (that
+        # was the whole aml defect); it does not read status codes, so a documented response the
+        # handler cannot produce passes clean. A reflection test is the floor, not the ceiling — the
+        # schema half needs the Quarkus-generated document
+        # (quarkus.smallrye-openapi.store-schema-directory, a dependency the whole fleet already has
+        # and nothing uses). Do not let a green here be read as "this spec is true".
+        #
+        # NOT diff-scoped, like db_backup_association and unlike api_contract/db_change: the defect
+        # is a MISSING pair across two trees, so a PR touching only Kotlin never touches the spec and
+        # a diff-scoped gate would see nothing.
+        #
+        # Advisory because 114 pre-existing findings cannot be a merge blocker on day one. Flipping
+        # to enforced = add --enforce in ci.yml, once the backlog is cleared.
       db_backup_association:
         detect: ["openbank-infra/gitops/**/*.yaml (kind: Cluster, postgresql.cnpg.io)"]
         require:

--- a/openbank-infra/gitops/components/customer-edge/customer-edge.yaml
+++ b/openbank-infra/gitops/components/customer-edge/customer-edge.yaml
@@ -65,7 +65,7 @@ spec:
       annotations:
         # Rolls the pod when the OPA bundle changes — subPath mounts do NOT hot-reload.
         # Kept in sync by gen-customer-edge-opa-bundle.sh (do not hand-edit).
-        openbank.tech/policy-checksum: "1006b34bb3e0708e"
+        openbank.tech/policy-checksum: "a2b96b14213553c8"
     spec:
       # Dedicated SA so EKS Pod Identity can hand the edge (and ONLY the edge) the
       # feedback-screenshots S3 role — ADR-0192, openbank-infra/aws/envs/sandbox-platform/

--- a/openbank-infra/gitops/components/dispute-service/dispute-opa-bundle.yaml
+++ b/openbank-infra/gitops/components/dispute-service/dispute-opa-bundle.yaml
@@ -9,7 +9,7 @@ metadata:
     app.kubernetes.io/name: dispute-service
     app.kubernetes.io/part-of: dispute
   annotations:
-    openbank.tech/policy-checksum: "3571083a922904f3"
+    openbank.tech/policy-checksum: "2da523ee282e4ba8"
 data:
   rest.rego: |
     # SPDX-License-Identifier: Apache-2.0
@@ -1635,6 +1635,42 @@ data:
         # spec-touching PR (bump info.version to match what the diff did), which the error
         # message spells out.
         ci_producer: ".github/scripts/check-api-contract.py"
+      openapi_route_conformance:
+        detect: ["openbank-*/src/main/resources/openapi.yaml", "JAX-RS @Path / @GET / @POST resource classes"]
+        require:
+          - "every route a resource class answers is published in that service's openapi.yaml"
+          - "every route openapi.yaml promises is declared by a resource class"
+        gate: openapi-route-conformance
+        enforced: advisory
+        target_enforce_date: "2026-09-30"
+        ci_producer: ".github/scripts/check-openapi-route-conformance.py"
+        # api_contract (above) classifies a spec's version bump against the PREVIOUS REVISION of the
+        # same document. Nothing asked whether the document is TRUE. ADR-0005 says "CI lints it with
+        # Spectral so docs cannot drift from runtime" — there is no Spectral config in this repo and
+        # no workflow references it, so that control has never existed. The #2280 failure class:
+        # check whether anything reads the artifact before assuming a green covers it.
+        #
+        # What the drift actually was, measured on the day this landed: 114 route-level findings
+        # across 44 services. aml-service published request/response schemas whose fields exist
+        # nowhere in the code (#2312, fixed in #2317); copilot-service served the human-in-the-loop
+        # confirm for a money-path action proposal without publishing it (#2323) and declared a 501
+        # its streaming endpoint cannot return (#2351, fixed in #2353). Worst single pattern: 10 of
+        # the 15 services with an ApprovalResource serve PATCH /api/v1/<svc>/approvals/{id} — the
+        # four-eyes control — without publishing it, most of them money-path.
+        #
+        # ROUTE SET ONLY. It does not read schemas, so an invented request field passes clean (that
+        # was the whole aml defect); it does not read status codes, so a documented response the
+        # handler cannot produce passes clean. A reflection test is the floor, not the ceiling — the
+        # schema half needs the Quarkus-generated document
+        # (quarkus.smallrye-openapi.store-schema-directory, a dependency the whole fleet already has
+        # and nothing uses). Do not let a green here be read as "this spec is true".
+        #
+        # NOT diff-scoped, like db_backup_association and unlike api_contract/db_change: the defect
+        # is a MISSING pair across two trees, so a PR touching only Kotlin never touches the spec and
+        # a diff-scoped gate would see nothing.
+        #
+        # Advisory because 114 pre-existing findings cannot be a merge blocker on day one. Flipping
+        # to enforced = add --enforce in ci.yml, once the backlog is cleared.
       db_backup_association:
         detect: ["openbank-infra/gitops/**/*.yaml (kind: Cluster, postgresql.cnpg.io)"]
         require:

--- a/openbank-infra/gitops/components/dispute-service/dispute-service.yaml
+++ b/openbank-infra/gitops/components/dispute-service/dispute-service.yaml
@@ -15,7 +15,7 @@ spec:
       annotations:
         # Rolls the pod when the OPA bundle changes — subPath mounts do NOT hot-reload.
         # Kept in sync by gen-dispute-opa-bundle.sh (do not hand-edit).
-        openbank.tech/policy-checksum: "3571083a922904f3"
+        openbank.tech/policy-checksum: "2da523ee282e4ba8"
       labels: {app.kubernetes.io/name: dispute-service, app.kubernetes.io/part-of: dispute}
     spec:
       securityContext:

--- a/openbank-infra/gitops/components/document-service/document-service-opa-bundle.yaml
+++ b/openbank-infra/gitops/components/document-service/document-service-opa-bundle.yaml
@@ -10,7 +10,7 @@ metadata:
     app.kubernetes.io/name: document-service
     app.kubernetes.io/part-of: documents
   annotations:
-    openbank.tech/policy-checksum: "1006b34bb3e0708e"
+    openbank.tech/policy-checksum: "a2b96b14213553c8"
 data:
   rest.rego: |
     # SPDX-License-Identifier: Apache-2.0
@@ -684,6 +684,42 @@ data:
         # spec-touching PR (bump info.version to match what the diff did), which the error
         # message spells out.
         ci_producer: ".github/scripts/check-api-contract.py"
+      openapi_route_conformance:
+        detect: ["openbank-*/src/main/resources/openapi.yaml", "JAX-RS @Path / @GET / @POST resource classes"]
+        require:
+          - "every route a resource class answers is published in that service's openapi.yaml"
+          - "every route openapi.yaml promises is declared by a resource class"
+        gate: openapi-route-conformance
+        enforced: advisory
+        target_enforce_date: "2026-09-30"
+        ci_producer: ".github/scripts/check-openapi-route-conformance.py"
+        # api_contract (above) classifies a spec's version bump against the PREVIOUS REVISION of the
+        # same document. Nothing asked whether the document is TRUE. ADR-0005 says "CI lints it with
+        # Spectral so docs cannot drift from runtime" — there is no Spectral config in this repo and
+        # no workflow references it, so that control has never existed. The #2280 failure class:
+        # check whether anything reads the artifact before assuming a green covers it.
+        #
+        # What the drift actually was, measured on the day this landed: 114 route-level findings
+        # across 44 services. aml-service published request/response schemas whose fields exist
+        # nowhere in the code (#2312, fixed in #2317); copilot-service served the human-in-the-loop
+        # confirm for a money-path action proposal without publishing it (#2323) and declared a 501
+        # its streaming endpoint cannot return (#2351, fixed in #2353). Worst single pattern: 10 of
+        # the 15 services with an ApprovalResource serve PATCH /api/v1/<svc>/approvals/{id} — the
+        # four-eyes control — without publishing it, most of them money-path.
+        #
+        # ROUTE SET ONLY. It does not read schemas, so an invented request field passes clean (that
+        # was the whole aml defect); it does not read status codes, so a documented response the
+        # handler cannot produce passes clean. A reflection test is the floor, not the ceiling — the
+        # schema half needs the Quarkus-generated document
+        # (quarkus.smallrye-openapi.store-schema-directory, a dependency the whole fleet already has
+        # and nothing uses). Do not let a green here be read as "this spec is true".
+        #
+        # NOT diff-scoped, like db_backup_association and unlike api_contract/db_change: the defect
+        # is a MISSING pair across two trees, so a PR touching only Kotlin never touches the spec and
+        # a diff-scoped gate would see nothing.
+        #
+        # Advisory because 114 pre-existing findings cannot be a merge blocker on day one. Flipping
+        # to enforced = add --enforce in ci.yml, once the backlog is cleared.
       db_backup_association:
         detect: ["openbank-infra/gitops/**/*.yaml (kind: Cluster, postgresql.cnpg.io)"]
         require:

--- a/openbank-infra/gitops/components/document-service/document-service-service.yaml
+++ b/openbank-infra/gitops/components/document-service/document-service-service.yaml
@@ -43,7 +43,7 @@ spec:
       annotations:
         # Rolls the pods when the OPA bundle changes — subPath mounts do NOT hot-reload.
         # Kept in sync by gen-document-service-opa-bundle.sh (do not hand-edit).
-        openbank.tech/policy-checksum: "1006b34bb3e0708e"
+        openbank.tech/policy-checksum: "a2b96b14213553c8"
     spec:
       # ADR-0162 D4 (continued): a dedicated SA (not `default`) is what OpenBao's Kubernetes-auth
       # role `document-service-signing` is bound to — least-privilege, one identity per consumer.

--- a/openbank-infra/gitops/components/fraud-service/fraud-opa-bundle.yaml
+++ b/openbank-infra/gitops/components/fraud-service/fraud-opa-bundle.yaml
@@ -9,7 +9,7 @@ metadata:
     app.kubernetes.io/name: fraud-service
     app.kubernetes.io/part-of: fraud
   annotations:
-    openbank.tech/policy-checksum: "6fcdb2e89930414f"
+    openbank.tech/policy-checksum: "2af7b0d36b60dd7d"
 data:
   rest.rego: |
     # SPDX-License-Identifier: Apache-2.0
@@ -1510,6 +1510,42 @@ data:
         # spec-touching PR (bump info.version to match what the diff did), which the error
         # message spells out.
         ci_producer: ".github/scripts/check-api-contract.py"
+      openapi_route_conformance:
+        detect: ["openbank-*/src/main/resources/openapi.yaml", "JAX-RS @Path / @GET / @POST resource classes"]
+        require:
+          - "every route a resource class answers is published in that service's openapi.yaml"
+          - "every route openapi.yaml promises is declared by a resource class"
+        gate: openapi-route-conformance
+        enforced: advisory
+        target_enforce_date: "2026-09-30"
+        ci_producer: ".github/scripts/check-openapi-route-conformance.py"
+        # api_contract (above) classifies a spec's version bump against the PREVIOUS REVISION of the
+        # same document. Nothing asked whether the document is TRUE. ADR-0005 says "CI lints it with
+        # Spectral so docs cannot drift from runtime" — there is no Spectral config in this repo and
+        # no workflow references it, so that control has never existed. The #2280 failure class:
+        # check whether anything reads the artifact before assuming a green covers it.
+        #
+        # What the drift actually was, measured on the day this landed: 114 route-level findings
+        # across 44 services. aml-service published request/response schemas whose fields exist
+        # nowhere in the code (#2312, fixed in #2317); copilot-service served the human-in-the-loop
+        # confirm for a money-path action proposal without publishing it (#2323) and declared a 501
+        # its streaming endpoint cannot return (#2351, fixed in #2353). Worst single pattern: 10 of
+        # the 15 services with an ApprovalResource serve PATCH /api/v1/<svc>/approvals/{id} — the
+        # four-eyes control — without publishing it, most of them money-path.
+        #
+        # ROUTE SET ONLY. It does not read schemas, so an invented request field passes clean (that
+        # was the whole aml defect); it does not read status codes, so a documented response the
+        # handler cannot produce passes clean. A reflection test is the floor, not the ceiling — the
+        # schema half needs the Quarkus-generated document
+        # (quarkus.smallrye-openapi.store-schema-directory, a dependency the whole fleet already has
+        # and nothing uses). Do not let a green here be read as "this spec is true".
+        #
+        # NOT diff-scoped, like db_backup_association and unlike api_contract/db_change: the defect
+        # is a MISSING pair across two trees, so a PR touching only Kotlin never touches the spec and
+        # a diff-scoped gate would see nothing.
+        #
+        # Advisory because 114 pre-existing findings cannot be a merge blocker on day one. Flipping
+        # to enforced = add --enforce in ci.yml, once the backlog is cleared.
       db_backup_association:
         detect: ["openbank-infra/gitops/**/*.yaml (kind: Cluster, postgresql.cnpg.io)"]
         require:

--- a/openbank-infra/gitops/components/fraud-service/fraud-service.yaml
+++ b/openbank-infra/gitops/components/fraud-service/fraud-service.yaml
@@ -23,7 +23,7 @@ spec:
       annotations:
         # Rolls the pods when the OPA bundle changes — subPath mounts do NOT hot-reload.
         # Kept in sync by gen-fraud-opa-bundle.sh (do not hand-edit).
-        openbank.tech/policy-checksum: "6fcdb2e89930414f"
+        openbank.tech/policy-checksum: "2af7b0d36b60dd7d"
     spec:
       securityContext:
         runAsNonRoot: true

--- a/openbank-infra/gitops/components/fx-service/fx-opa-bundle.yaml
+++ b/openbank-infra/gitops/components/fx-service/fx-opa-bundle.yaml
@@ -9,7 +9,7 @@ metadata:
     app.kubernetes.io/name: fx-service
     app.kubernetes.io/part-of: fx
   annotations:
-    openbank.tech/policy-checksum: "47283df1ad14242f"
+    openbank.tech/policy-checksum: "db36bc931d2f7446"
 data:
   rest.rego: |
     # SPDX-License-Identifier: Apache-2.0
@@ -1561,6 +1561,42 @@ data:
         # spec-touching PR (bump info.version to match what the diff did), which the error
         # message spells out.
         ci_producer: ".github/scripts/check-api-contract.py"
+      openapi_route_conformance:
+        detect: ["openbank-*/src/main/resources/openapi.yaml", "JAX-RS @Path / @GET / @POST resource classes"]
+        require:
+          - "every route a resource class answers is published in that service's openapi.yaml"
+          - "every route openapi.yaml promises is declared by a resource class"
+        gate: openapi-route-conformance
+        enforced: advisory
+        target_enforce_date: "2026-09-30"
+        ci_producer: ".github/scripts/check-openapi-route-conformance.py"
+        # api_contract (above) classifies a spec's version bump against the PREVIOUS REVISION of the
+        # same document. Nothing asked whether the document is TRUE. ADR-0005 says "CI lints it with
+        # Spectral so docs cannot drift from runtime" — there is no Spectral config in this repo and
+        # no workflow references it, so that control has never existed. The #2280 failure class:
+        # check whether anything reads the artifact before assuming a green covers it.
+        #
+        # What the drift actually was, measured on the day this landed: 114 route-level findings
+        # across 44 services. aml-service published request/response schemas whose fields exist
+        # nowhere in the code (#2312, fixed in #2317); copilot-service served the human-in-the-loop
+        # confirm for a money-path action proposal without publishing it (#2323) and declared a 501
+        # its streaming endpoint cannot return (#2351, fixed in #2353). Worst single pattern: 10 of
+        # the 15 services with an ApprovalResource serve PATCH /api/v1/<svc>/approvals/{id} — the
+        # four-eyes control — without publishing it, most of them money-path.
+        #
+        # ROUTE SET ONLY. It does not read schemas, so an invented request field passes clean (that
+        # was the whole aml defect); it does not read status codes, so a documented response the
+        # handler cannot produce passes clean. A reflection test is the floor, not the ceiling — the
+        # schema half needs the Quarkus-generated document
+        # (quarkus.smallrye-openapi.store-schema-directory, a dependency the whole fleet already has
+        # and nothing uses). Do not let a green here be read as "this spec is true".
+        #
+        # NOT diff-scoped, like db_backup_association and unlike api_contract/db_change: the defect
+        # is a MISSING pair across two trees, so a PR touching only Kotlin never touches the spec and
+        # a diff-scoped gate would see nothing.
+        #
+        # Advisory because 114 pre-existing findings cannot be a merge blocker on day one. Flipping
+        # to enforced = add --enforce in ci.yml, once the backlog is cleared.
       db_backup_association:
         detect: ["openbank-infra/gitops/**/*.yaml (kind: Cluster, postgresql.cnpg.io)"]
         require:

--- a/openbank-infra/gitops/components/fx-service/fx-service.yaml
+++ b/openbank-infra/gitops/components/fx-service/fx-service.yaml
@@ -22,7 +22,7 @@ spec:
       annotations:
         # Rolls the pods when the OPA bundle changes — subPath mounts do NOT hot-reload.
         # Kept in sync by gen-fx-opa-bundle.sh (do not hand-edit).
-        openbank.tech/policy-checksum: "47283df1ad14242f"
+        openbank.tech/policy-checksum: "db36bc931d2f7446"
     spec:
       securityContext:
         runAsNonRoot: true

--- a/openbank-infra/gitops/components/interest-service/interest-opa-bundle.yaml
+++ b/openbank-infra/gitops/components/interest-service/interest-opa-bundle.yaml
@@ -9,7 +9,7 @@ metadata:
     app.kubernetes.io/name: interest-service
     app.kubernetes.io/part-of: interest
   annotations:
-    openbank.tech/policy-checksum: "f1d9706d1387cc7e"
+    openbank.tech/policy-checksum: "95a917eadc826c64"
 data:
   rest.rego: |
     # SPDX-License-Identifier: Apache-2.0
@@ -1495,6 +1495,42 @@ data:
         # spec-touching PR (bump info.version to match what the diff did), which the error
         # message spells out.
         ci_producer: ".github/scripts/check-api-contract.py"
+      openapi_route_conformance:
+        detect: ["openbank-*/src/main/resources/openapi.yaml", "JAX-RS @Path / @GET / @POST resource classes"]
+        require:
+          - "every route a resource class answers is published in that service's openapi.yaml"
+          - "every route openapi.yaml promises is declared by a resource class"
+        gate: openapi-route-conformance
+        enforced: advisory
+        target_enforce_date: "2026-09-30"
+        ci_producer: ".github/scripts/check-openapi-route-conformance.py"
+        # api_contract (above) classifies a spec's version bump against the PREVIOUS REVISION of the
+        # same document. Nothing asked whether the document is TRUE. ADR-0005 says "CI lints it with
+        # Spectral so docs cannot drift from runtime" — there is no Spectral config in this repo and
+        # no workflow references it, so that control has never existed. The #2280 failure class:
+        # check whether anything reads the artifact before assuming a green covers it.
+        #
+        # What the drift actually was, measured on the day this landed: 114 route-level findings
+        # across 44 services. aml-service published request/response schemas whose fields exist
+        # nowhere in the code (#2312, fixed in #2317); copilot-service served the human-in-the-loop
+        # confirm for a money-path action proposal without publishing it (#2323) and declared a 501
+        # its streaming endpoint cannot return (#2351, fixed in #2353). Worst single pattern: 10 of
+        # the 15 services with an ApprovalResource serve PATCH /api/v1/<svc>/approvals/{id} — the
+        # four-eyes control — without publishing it, most of them money-path.
+        #
+        # ROUTE SET ONLY. It does not read schemas, so an invented request field passes clean (that
+        # was the whole aml defect); it does not read status codes, so a documented response the
+        # handler cannot produce passes clean. A reflection test is the floor, not the ceiling — the
+        # schema half needs the Quarkus-generated document
+        # (quarkus.smallrye-openapi.store-schema-directory, a dependency the whole fleet already has
+        # and nothing uses). Do not let a green here be read as "this spec is true".
+        #
+        # NOT diff-scoped, like db_backup_association and unlike api_contract/db_change: the defect
+        # is a MISSING pair across two trees, so a PR touching only Kotlin never touches the spec and
+        # a diff-scoped gate would see nothing.
+        #
+        # Advisory because 114 pre-existing findings cannot be a merge blocker on day one. Flipping
+        # to enforced = add --enforce in ci.yml, once the backlog is cleared.
       db_backup_association:
         detect: ["openbank-infra/gitops/**/*.yaml (kind: Cluster, postgresql.cnpg.io)"]
         require:

--- a/openbank-infra/gitops/components/interest-service/interest-service.yaml
+++ b/openbank-infra/gitops/components/interest-service/interest-service.yaml
@@ -16,7 +16,7 @@ spec:
       annotations:
         # Rolls the pods when the OPA bundle changes — subPath mounts do NOT hot-reload.
         # Kept in sync by gen-interest-opa-bundle.sh (do not hand-edit).
-        openbank.tech/policy-checksum: "f1d9706d1387cc7e"
+        openbank.tech/policy-checksum: "95a917eadc826c64"
     spec:
       securityContext:
         runAsNonRoot: true

--- a/openbank-infra/gitops/components/kyc/kyc-opa-bundle.yaml
+++ b/openbank-infra/gitops/components/kyc/kyc-opa-bundle.yaml
@@ -9,7 +9,7 @@ metadata:
     app.kubernetes.io/name: kyc-service
     app.kubernetes.io/part-of: kyc
   annotations:
-    openbank.tech/policy-checksum: "31a14a6b991e8fe3"
+    openbank.tech/policy-checksum: "9f591177c0ce720b"
 data:
   rest.rego: |
     # SPDX-License-Identifier: Apache-2.0
@@ -1523,6 +1523,42 @@ data:
         # spec-touching PR (bump info.version to match what the diff did), which the error
         # message spells out.
         ci_producer: ".github/scripts/check-api-contract.py"
+      openapi_route_conformance:
+        detect: ["openbank-*/src/main/resources/openapi.yaml", "JAX-RS @Path / @GET / @POST resource classes"]
+        require:
+          - "every route a resource class answers is published in that service's openapi.yaml"
+          - "every route openapi.yaml promises is declared by a resource class"
+        gate: openapi-route-conformance
+        enforced: advisory
+        target_enforce_date: "2026-09-30"
+        ci_producer: ".github/scripts/check-openapi-route-conformance.py"
+        # api_contract (above) classifies a spec's version bump against the PREVIOUS REVISION of the
+        # same document. Nothing asked whether the document is TRUE. ADR-0005 says "CI lints it with
+        # Spectral so docs cannot drift from runtime" — there is no Spectral config in this repo and
+        # no workflow references it, so that control has never existed. The #2280 failure class:
+        # check whether anything reads the artifact before assuming a green covers it.
+        #
+        # What the drift actually was, measured on the day this landed: 114 route-level findings
+        # across 44 services. aml-service published request/response schemas whose fields exist
+        # nowhere in the code (#2312, fixed in #2317); copilot-service served the human-in-the-loop
+        # confirm for a money-path action proposal without publishing it (#2323) and declared a 501
+        # its streaming endpoint cannot return (#2351, fixed in #2353). Worst single pattern: 10 of
+        # the 15 services with an ApprovalResource serve PATCH /api/v1/<svc>/approvals/{id} — the
+        # four-eyes control — without publishing it, most of them money-path.
+        #
+        # ROUTE SET ONLY. It does not read schemas, so an invented request field passes clean (that
+        # was the whole aml defect); it does not read status codes, so a documented response the
+        # handler cannot produce passes clean. A reflection test is the floor, not the ceiling — the
+        # schema half needs the Quarkus-generated document
+        # (quarkus.smallrye-openapi.store-schema-directory, a dependency the whole fleet already has
+        # and nothing uses). Do not let a green here be read as "this spec is true".
+        #
+        # NOT diff-scoped, like db_backup_association and unlike api_contract/db_change: the defect
+        # is a MISSING pair across two trees, so a PR touching only Kotlin never touches the spec and
+        # a diff-scoped gate would see nothing.
+        #
+        # Advisory because 114 pre-existing findings cannot be a merge blocker on day one. Flipping
+        # to enforced = add --enforce in ci.yml, once the backlog is cleared.
       db_backup_association:
         detect: ["openbank-infra/gitops/**/*.yaml (kind: Cluster, postgresql.cnpg.io)"]
         require:

--- a/openbank-infra/gitops/components/kyc/kyc-service.yaml
+++ b/openbank-infra/gitops/components/kyc/kyc-service.yaml
@@ -48,7 +48,7 @@ spec:
       annotations:
         # Rolls the pod when the OPA bundle changes (subPath mounts do not hot-reload).
         # Kept in sync by gen-kyc-opa-bundle.sh (do not hand-edit).
-        openbank.tech/policy-checksum: "31a14a6b991e8fe3"
+        openbank.tech/policy-checksum: "9f591177c0ce720b"
     spec:
       securityContext:
         runAsNonRoot: true

--- a/openbank-infra/gitops/components/ledger/ledger-opa-bundle.yaml
+++ b/openbank-infra/gitops/components/ledger/ledger-opa-bundle.yaml
@@ -9,7 +9,7 @@ metadata:
     app.kubernetes.io/name: ledger-service
     app.kubernetes.io/part-of: ledger
   annotations:
-    openbank.tech/policy-checksum: "eaafce8789d05c26"
+    openbank.tech/policy-checksum: "5c1037fbe5644d15"
 data:
   rest.rego: |
     # SPDX-License-Identifier: Apache-2.0
@@ -1608,6 +1608,42 @@ data:
         # spec-touching PR (bump info.version to match what the diff did), which the error
         # message spells out.
         ci_producer: ".github/scripts/check-api-contract.py"
+      openapi_route_conformance:
+        detect: ["openbank-*/src/main/resources/openapi.yaml", "JAX-RS @Path / @GET / @POST resource classes"]
+        require:
+          - "every route a resource class answers is published in that service's openapi.yaml"
+          - "every route openapi.yaml promises is declared by a resource class"
+        gate: openapi-route-conformance
+        enforced: advisory
+        target_enforce_date: "2026-09-30"
+        ci_producer: ".github/scripts/check-openapi-route-conformance.py"
+        # api_contract (above) classifies a spec's version bump against the PREVIOUS REVISION of the
+        # same document. Nothing asked whether the document is TRUE. ADR-0005 says "CI lints it with
+        # Spectral so docs cannot drift from runtime" — there is no Spectral config in this repo and
+        # no workflow references it, so that control has never existed. The #2280 failure class:
+        # check whether anything reads the artifact before assuming a green covers it.
+        #
+        # What the drift actually was, measured on the day this landed: 114 route-level findings
+        # across 44 services. aml-service published request/response schemas whose fields exist
+        # nowhere in the code (#2312, fixed in #2317); copilot-service served the human-in-the-loop
+        # confirm for a money-path action proposal without publishing it (#2323) and declared a 501
+        # its streaming endpoint cannot return (#2351, fixed in #2353). Worst single pattern: 10 of
+        # the 15 services with an ApprovalResource serve PATCH /api/v1/<svc>/approvals/{id} — the
+        # four-eyes control — without publishing it, most of them money-path.
+        #
+        # ROUTE SET ONLY. It does not read schemas, so an invented request field passes clean (that
+        # was the whole aml defect); it does not read status codes, so a documented response the
+        # handler cannot produce passes clean. A reflection test is the floor, not the ceiling — the
+        # schema half needs the Quarkus-generated document
+        # (quarkus.smallrye-openapi.store-schema-directory, a dependency the whole fleet already has
+        # and nothing uses). Do not let a green here be read as "this spec is true".
+        #
+        # NOT diff-scoped, like db_backup_association and unlike api_contract/db_change: the defect
+        # is a MISSING pair across two trees, so a PR touching only Kotlin never touches the spec and
+        # a diff-scoped gate would see nothing.
+        #
+        # Advisory because 114 pre-existing findings cannot be a merge blocker on day one. Flipping
+        # to enforced = add --enforce in ci.yml, once the backlog is cleared.
       db_backup_association:
         detect: ["openbank-infra/gitops/**/*.yaml (kind: Cluster, postgresql.cnpg.io)"]
         require:

--- a/openbank-infra/gitops/components/ledger/ledger-service.yaml
+++ b/openbank-infra/gitops/components/ledger/ledger-service.yaml
@@ -38,7 +38,7 @@ spec:
       annotations:
         # Rolls the pods when the OPA bundle changes — subPath mounts do NOT hot-reload.
         # Kept in sync by gen-ledger-opa-bundle.sh (do not hand-edit).
-        openbank.tech/policy-checksum: "eaafce8789d05c26"
+        openbank.tech/policy-checksum: "5c1037fbe5644d15"
     spec:
       securityContext:
         runAsNonRoot: true

--- a/openbank-infra/gitops/components/lending/lending-opa-bundle.yaml
+++ b/openbank-infra/gitops/components/lending/lending-opa-bundle.yaml
@@ -9,7 +9,7 @@ metadata:
     app.kubernetes.io/name: lending-service
     app.kubernetes.io/part-of: lending
   annotations:
-    openbank.tech/policy-checksum: "21f4df2e27c3165c"
+    openbank.tech/policy-checksum: "9b6cc07787b559f4"
 data:
   rest.rego: |
     # SPDX-License-Identifier: Apache-2.0
@@ -1563,6 +1563,42 @@ data:
         # spec-touching PR (bump info.version to match what the diff did), which the error
         # message spells out.
         ci_producer: ".github/scripts/check-api-contract.py"
+      openapi_route_conformance:
+        detect: ["openbank-*/src/main/resources/openapi.yaml", "JAX-RS @Path / @GET / @POST resource classes"]
+        require:
+          - "every route a resource class answers is published in that service's openapi.yaml"
+          - "every route openapi.yaml promises is declared by a resource class"
+        gate: openapi-route-conformance
+        enforced: advisory
+        target_enforce_date: "2026-09-30"
+        ci_producer: ".github/scripts/check-openapi-route-conformance.py"
+        # api_contract (above) classifies a spec's version bump against the PREVIOUS REVISION of the
+        # same document. Nothing asked whether the document is TRUE. ADR-0005 says "CI lints it with
+        # Spectral so docs cannot drift from runtime" — there is no Spectral config in this repo and
+        # no workflow references it, so that control has never existed. The #2280 failure class:
+        # check whether anything reads the artifact before assuming a green covers it.
+        #
+        # What the drift actually was, measured on the day this landed: 114 route-level findings
+        # across 44 services. aml-service published request/response schemas whose fields exist
+        # nowhere in the code (#2312, fixed in #2317); copilot-service served the human-in-the-loop
+        # confirm for a money-path action proposal without publishing it (#2323) and declared a 501
+        # its streaming endpoint cannot return (#2351, fixed in #2353). Worst single pattern: 10 of
+        # the 15 services with an ApprovalResource serve PATCH /api/v1/<svc>/approvals/{id} — the
+        # four-eyes control — without publishing it, most of them money-path.
+        #
+        # ROUTE SET ONLY. It does not read schemas, so an invented request field passes clean (that
+        # was the whole aml defect); it does not read status codes, so a documented response the
+        # handler cannot produce passes clean. A reflection test is the floor, not the ceiling — the
+        # schema half needs the Quarkus-generated document
+        # (quarkus.smallrye-openapi.store-schema-directory, a dependency the whole fleet already has
+        # and nothing uses). Do not let a green here be read as "this spec is true".
+        #
+        # NOT diff-scoped, like db_backup_association and unlike api_contract/db_change: the defect
+        # is a MISSING pair across two trees, so a PR touching only Kotlin never touches the spec and
+        # a diff-scoped gate would see nothing.
+        #
+        # Advisory because 114 pre-existing findings cannot be a merge blocker on day one. Flipping
+        # to enforced = add --enforce in ci.yml, once the backlog is cleared.
       db_backup_association:
         detect: ["openbank-infra/gitops/**/*.yaml (kind: Cluster, postgresql.cnpg.io)"]
         require:

--- a/openbank-infra/gitops/components/lending/lending-service.yaml
+++ b/openbank-infra/gitops/components/lending/lending-service.yaml
@@ -34,7 +34,7 @@ spec:
       annotations:
         # Rolls the pods when the OPA bundle changes — subPath mounts do NOT hot-reload.
         # Kept in sync by gen-lending-opa-bundle.sh (do not hand-edit).
-        openbank.tech/policy-checksum: "21f4df2e27c3165c"
+        openbank.tech/policy-checksum: "9b6cc07787b559f4"
     spec:
       securityContext:
         runAsNonRoot: true

--- a/openbank-infra/gitops/components/mcp/mcp-opa-bundle.yaml
+++ b/openbank-infra/gitops/components/mcp/mcp-opa-bundle.yaml
@@ -9,7 +9,7 @@ metadata:
     app.kubernetes.io/name: mcp-service
     app.kubernetes.io/part-of: platform
   annotations:
-    openbank.tech/policy-checksum: "8b40f47809078cc9"
+    openbank.tech/policy-checksum: "f64299b3b15fe454"
 data:
   rest.rego: |
     # SPDX-License-Identifier: Apache-2.0
@@ -1461,6 +1461,42 @@ data:
         # spec-touching PR (bump info.version to match what the diff did), which the error
         # message spells out.
         ci_producer: ".github/scripts/check-api-contract.py"
+      openapi_route_conformance:
+        detect: ["openbank-*/src/main/resources/openapi.yaml", "JAX-RS @Path / @GET / @POST resource classes"]
+        require:
+          - "every route a resource class answers is published in that service's openapi.yaml"
+          - "every route openapi.yaml promises is declared by a resource class"
+        gate: openapi-route-conformance
+        enforced: advisory
+        target_enforce_date: "2026-09-30"
+        ci_producer: ".github/scripts/check-openapi-route-conformance.py"
+        # api_contract (above) classifies a spec's version bump against the PREVIOUS REVISION of the
+        # same document. Nothing asked whether the document is TRUE. ADR-0005 says "CI lints it with
+        # Spectral so docs cannot drift from runtime" — there is no Spectral config in this repo and
+        # no workflow references it, so that control has never existed. The #2280 failure class:
+        # check whether anything reads the artifact before assuming a green covers it.
+        #
+        # What the drift actually was, measured on the day this landed: 114 route-level findings
+        # across 44 services. aml-service published request/response schemas whose fields exist
+        # nowhere in the code (#2312, fixed in #2317); copilot-service served the human-in-the-loop
+        # confirm for a money-path action proposal without publishing it (#2323) and declared a 501
+        # its streaming endpoint cannot return (#2351, fixed in #2353). Worst single pattern: 10 of
+        # the 15 services with an ApprovalResource serve PATCH /api/v1/<svc>/approvals/{id} — the
+        # four-eyes control — without publishing it, most of them money-path.
+        #
+        # ROUTE SET ONLY. It does not read schemas, so an invented request field passes clean (that
+        # was the whole aml defect); it does not read status codes, so a documented response the
+        # handler cannot produce passes clean. A reflection test is the floor, not the ceiling — the
+        # schema half needs the Quarkus-generated document
+        # (quarkus.smallrye-openapi.store-schema-directory, a dependency the whole fleet already has
+        # and nothing uses). Do not let a green here be read as "this spec is true".
+        #
+        # NOT diff-scoped, like db_backup_association and unlike api_contract/db_change: the defect
+        # is a MISSING pair across two trees, so a PR touching only Kotlin never touches the spec and
+        # a diff-scoped gate would see nothing.
+        #
+        # Advisory because 114 pre-existing findings cannot be a merge blocker on day one. Flipping
+        # to enforced = add --enforce in ci.yml, once the backlog is cleared.
       db_backup_association:
         detect: ["openbank-infra/gitops/**/*.yaml (kind: Cluster, postgresql.cnpg.io)"]
         require:

--- a/openbank-infra/gitops/components/mcp/mcp-service.yaml
+++ b/openbank-infra/gitops/components/mcp/mcp-service.yaml
@@ -29,7 +29,7 @@ spec:
       annotations:
         # Rolls the pod when the OPA bundle changes — subPath mounts do NOT hot-reload.
         # Kept in sync by gen-mcp-opa-bundle.sh (do not hand-edit).
-        openbank.tech/policy-checksum: "8b40f47809078cc9"
+        openbank.tech/policy-checksum: "f64299b3b15fe454"
     spec:
       securityContext:
         runAsNonRoot: true

--- a/openbank-infra/gitops/components/notifications/notification-service-opa-bundle.yaml
+++ b/openbank-infra/gitops/components/notifications/notification-service-opa-bundle.yaml
@@ -10,7 +10,7 @@ metadata:
     app.kubernetes.io/name: notification-service
     app.kubernetes.io/part-of: notifications
   annotations:
-    openbank.tech/policy-checksum: "1006b34bb3e0708e"
+    openbank.tech/policy-checksum: "a2b96b14213553c8"
 data:
   rest.rego: |
     # SPDX-License-Identifier: Apache-2.0
@@ -684,6 +684,42 @@ data:
         # spec-touching PR (bump info.version to match what the diff did), which the error
         # message spells out.
         ci_producer: ".github/scripts/check-api-contract.py"
+      openapi_route_conformance:
+        detect: ["openbank-*/src/main/resources/openapi.yaml", "JAX-RS @Path / @GET / @POST resource classes"]
+        require:
+          - "every route a resource class answers is published in that service's openapi.yaml"
+          - "every route openapi.yaml promises is declared by a resource class"
+        gate: openapi-route-conformance
+        enforced: advisory
+        target_enforce_date: "2026-09-30"
+        ci_producer: ".github/scripts/check-openapi-route-conformance.py"
+        # api_contract (above) classifies a spec's version bump against the PREVIOUS REVISION of the
+        # same document. Nothing asked whether the document is TRUE. ADR-0005 says "CI lints it with
+        # Spectral so docs cannot drift from runtime" — there is no Spectral config in this repo and
+        # no workflow references it, so that control has never existed. The #2280 failure class:
+        # check whether anything reads the artifact before assuming a green covers it.
+        #
+        # What the drift actually was, measured on the day this landed: 114 route-level findings
+        # across 44 services. aml-service published request/response schemas whose fields exist
+        # nowhere in the code (#2312, fixed in #2317); copilot-service served the human-in-the-loop
+        # confirm for a money-path action proposal without publishing it (#2323) and declared a 501
+        # its streaming endpoint cannot return (#2351, fixed in #2353). Worst single pattern: 10 of
+        # the 15 services with an ApprovalResource serve PATCH /api/v1/<svc>/approvals/{id} — the
+        # four-eyes control — without publishing it, most of them money-path.
+        #
+        # ROUTE SET ONLY. It does not read schemas, so an invented request field passes clean (that
+        # was the whole aml defect); it does not read status codes, so a documented response the
+        # handler cannot produce passes clean. A reflection test is the floor, not the ceiling — the
+        # schema half needs the Quarkus-generated document
+        # (quarkus.smallrye-openapi.store-schema-directory, a dependency the whole fleet already has
+        # and nothing uses). Do not let a green here be read as "this spec is true".
+        #
+        # NOT diff-scoped, like db_backup_association and unlike api_contract/db_change: the defect
+        # is a MISSING pair across two trees, so a PR touching only Kotlin never touches the spec and
+        # a diff-scoped gate would see nothing.
+        #
+        # Advisory because 114 pre-existing findings cannot be a merge blocker on day one. Flipping
+        # to enforced = add --enforce in ci.yml, once the backlog is cleared.
       db_backup_association:
         detect: ["openbank-infra/gitops/**/*.yaml (kind: Cluster, postgresql.cnpg.io)"]
         require:

--- a/openbank-infra/gitops/components/notifications/notification-service.yaml
+++ b/openbank-infra/gitops/components/notifications/notification-service.yaml
@@ -39,7 +39,7 @@ spec:
       annotations:
         # Rolls the Deployment when the OPA policy bundle changes (subPath mounts don't
         # hot-reload). Kept in sync by gen-notification-opa-bundle.sh.
-        openbank.tech/policy-checksum: "1006b34bb3e0708e"
+        openbank.tech/policy-checksum: "a2b96b14213553c8"
       labels:
         app.kubernetes.io/name: notification-service
         app.kubernetes.io/part-of: notifications

--- a/openbank-infra/gitops/components/party/party-opa-bundle.yaml
+++ b/openbank-infra/gitops/components/party/party-opa-bundle.yaml
@@ -9,7 +9,7 @@ metadata:
     app.kubernetes.io/name: party-service
     app.kubernetes.io/part-of: party
   annotations:
-    openbank.tech/policy-checksum: "e2a272cecfa288f6"
+    openbank.tech/policy-checksum: "0680dacec4173feb"
 data:
   rest.rego: |
     # SPDX-License-Identifier: Apache-2.0
@@ -1532,6 +1532,42 @@ data:
         # spec-touching PR (bump info.version to match what the diff did), which the error
         # message spells out.
         ci_producer: ".github/scripts/check-api-contract.py"
+      openapi_route_conformance:
+        detect: ["openbank-*/src/main/resources/openapi.yaml", "JAX-RS @Path / @GET / @POST resource classes"]
+        require:
+          - "every route a resource class answers is published in that service's openapi.yaml"
+          - "every route openapi.yaml promises is declared by a resource class"
+        gate: openapi-route-conformance
+        enforced: advisory
+        target_enforce_date: "2026-09-30"
+        ci_producer: ".github/scripts/check-openapi-route-conformance.py"
+        # api_contract (above) classifies a spec's version bump against the PREVIOUS REVISION of the
+        # same document. Nothing asked whether the document is TRUE. ADR-0005 says "CI lints it with
+        # Spectral so docs cannot drift from runtime" — there is no Spectral config in this repo and
+        # no workflow references it, so that control has never existed. The #2280 failure class:
+        # check whether anything reads the artifact before assuming a green covers it.
+        #
+        # What the drift actually was, measured on the day this landed: 114 route-level findings
+        # across 44 services. aml-service published request/response schemas whose fields exist
+        # nowhere in the code (#2312, fixed in #2317); copilot-service served the human-in-the-loop
+        # confirm for a money-path action proposal without publishing it (#2323) and declared a 501
+        # its streaming endpoint cannot return (#2351, fixed in #2353). Worst single pattern: 10 of
+        # the 15 services with an ApprovalResource serve PATCH /api/v1/<svc>/approvals/{id} — the
+        # four-eyes control — without publishing it, most of them money-path.
+        #
+        # ROUTE SET ONLY. It does not read schemas, so an invented request field passes clean (that
+        # was the whole aml defect); it does not read status codes, so a documented response the
+        # handler cannot produce passes clean. A reflection test is the floor, not the ceiling — the
+        # schema half needs the Quarkus-generated document
+        # (quarkus.smallrye-openapi.store-schema-directory, a dependency the whole fleet already has
+        # and nothing uses). Do not let a green here be read as "this spec is true".
+        #
+        # NOT diff-scoped, like db_backup_association and unlike api_contract/db_change: the defect
+        # is a MISSING pair across two trees, so a PR touching only Kotlin never touches the spec and
+        # a diff-scoped gate would see nothing.
+        #
+        # Advisory because 114 pre-existing findings cannot be a merge blocker on day one. Flipping
+        # to enforced = add --enforce in ci.yml, once the backlog is cleared.
       db_backup_association:
         detect: ["openbank-infra/gitops/**/*.yaml (kind: Cluster, postgresql.cnpg.io)"]
         require:

--- a/openbank-infra/gitops/components/party/party-service.yaml
+++ b/openbank-infra/gitops/components/party/party-service.yaml
@@ -22,7 +22,7 @@ spec:
       annotations:
         # Rolls the pod when the OPA bundle changes — subPath mounts do NOT hot-reload.
         # Kept in sync by gen-party-opa-bundle.sh (do not hand-edit).
-        openbank.tech/policy-checksum: "e2a272cecfa288f6"
+        openbank.tech/policy-checksum: "0680dacec4173feb"
       labels:
         app.kubernetes.io/name: party-service
         app.kubernetes.io/part-of: party

--- a/openbank-infra/gitops/components/payments/card-issuance-opa-bundle.yaml
+++ b/openbank-infra/gitops/components/payments/card-issuance-opa-bundle.yaml
@@ -9,7 +9,7 @@ metadata:
     app.kubernetes.io/name: card-issuance-service
     app.kubernetes.io/part-of: payments
   annotations:
-    openbank.tech/policy-checksum: "2acb58a175df8489"
+    openbank.tech/policy-checksum: "6a5476eb2f186256"
 data:
   rest.rego: |
     # SPDX-License-Identifier: Apache-2.0
@@ -1516,6 +1516,42 @@ data:
         # spec-touching PR (bump info.version to match what the diff did), which the error
         # message spells out.
         ci_producer: ".github/scripts/check-api-contract.py"
+      openapi_route_conformance:
+        detect: ["openbank-*/src/main/resources/openapi.yaml", "JAX-RS @Path / @GET / @POST resource classes"]
+        require:
+          - "every route a resource class answers is published in that service's openapi.yaml"
+          - "every route openapi.yaml promises is declared by a resource class"
+        gate: openapi-route-conformance
+        enforced: advisory
+        target_enforce_date: "2026-09-30"
+        ci_producer: ".github/scripts/check-openapi-route-conformance.py"
+        # api_contract (above) classifies a spec's version bump against the PREVIOUS REVISION of the
+        # same document. Nothing asked whether the document is TRUE. ADR-0005 says "CI lints it with
+        # Spectral so docs cannot drift from runtime" — there is no Spectral config in this repo and
+        # no workflow references it, so that control has never existed. The #2280 failure class:
+        # check whether anything reads the artifact before assuming a green covers it.
+        #
+        # What the drift actually was, measured on the day this landed: 114 route-level findings
+        # across 44 services. aml-service published request/response schemas whose fields exist
+        # nowhere in the code (#2312, fixed in #2317); copilot-service served the human-in-the-loop
+        # confirm for a money-path action proposal without publishing it (#2323) and declared a 501
+        # its streaming endpoint cannot return (#2351, fixed in #2353). Worst single pattern: 10 of
+        # the 15 services with an ApprovalResource serve PATCH /api/v1/<svc>/approvals/{id} — the
+        # four-eyes control — without publishing it, most of them money-path.
+        #
+        # ROUTE SET ONLY. It does not read schemas, so an invented request field passes clean (that
+        # was the whole aml defect); it does not read status codes, so a documented response the
+        # handler cannot produce passes clean. A reflection test is the floor, not the ceiling — the
+        # schema half needs the Quarkus-generated document
+        # (quarkus.smallrye-openapi.store-schema-directory, a dependency the whole fleet already has
+        # and nothing uses). Do not let a green here be read as "this spec is true".
+        #
+        # NOT diff-scoped, like db_backup_association and unlike api_contract/db_change: the defect
+        # is a MISSING pair across two trees, so a PR touching only Kotlin never touches the spec and
+        # a diff-scoped gate would see nothing.
+        #
+        # Advisory because 114 pre-existing findings cannot be a merge blocker on day one. Flipping
+        # to enforced = add --enforce in ci.yml, once the backlog is cleared.
       db_backup_association:
         detect: ["openbank-infra/gitops/**/*.yaml (kind: Cluster, postgresql.cnpg.io)"]
         require:

--- a/openbank-infra/gitops/components/payments/clearing-opa-bundle.yaml
+++ b/openbank-infra/gitops/components/payments/clearing-opa-bundle.yaml
@@ -9,7 +9,7 @@ metadata:
     app.kubernetes.io/name: clearing-service
     app.kubernetes.io/part-of: payments
   annotations:
-    openbank.tech/policy-checksum: "363e83e5f07e68c9"
+    openbank.tech/policy-checksum: "dcb516681861ccc2"
 data:
   rest.rego: |
     # SPDX-License-Identifier: Apache-2.0
@@ -1553,6 +1553,42 @@ data:
         # spec-touching PR (bump info.version to match what the diff did), which the error
         # message spells out.
         ci_producer: ".github/scripts/check-api-contract.py"
+      openapi_route_conformance:
+        detect: ["openbank-*/src/main/resources/openapi.yaml", "JAX-RS @Path / @GET / @POST resource classes"]
+        require:
+          - "every route a resource class answers is published in that service's openapi.yaml"
+          - "every route openapi.yaml promises is declared by a resource class"
+        gate: openapi-route-conformance
+        enforced: advisory
+        target_enforce_date: "2026-09-30"
+        ci_producer: ".github/scripts/check-openapi-route-conformance.py"
+        # api_contract (above) classifies a spec's version bump against the PREVIOUS REVISION of the
+        # same document. Nothing asked whether the document is TRUE. ADR-0005 says "CI lints it with
+        # Spectral so docs cannot drift from runtime" — there is no Spectral config in this repo and
+        # no workflow references it, so that control has never existed. The #2280 failure class:
+        # check whether anything reads the artifact before assuming a green covers it.
+        #
+        # What the drift actually was, measured on the day this landed: 114 route-level findings
+        # across 44 services. aml-service published request/response schemas whose fields exist
+        # nowhere in the code (#2312, fixed in #2317); copilot-service served the human-in-the-loop
+        # confirm for a money-path action proposal without publishing it (#2323) and declared a 501
+        # its streaming endpoint cannot return (#2351, fixed in #2353). Worst single pattern: 10 of
+        # the 15 services with an ApprovalResource serve PATCH /api/v1/<svc>/approvals/{id} — the
+        # four-eyes control — without publishing it, most of them money-path.
+        #
+        # ROUTE SET ONLY. It does not read schemas, so an invented request field passes clean (that
+        # was the whole aml defect); it does not read status codes, so a documented response the
+        # handler cannot produce passes clean. A reflection test is the floor, not the ceiling — the
+        # schema half needs the Quarkus-generated document
+        # (quarkus.smallrye-openapi.store-schema-directory, a dependency the whole fleet already has
+        # and nothing uses). Do not let a green here be read as "this spec is true".
+        #
+        # NOT diff-scoped, like db_backup_association and unlike api_contract/db_change: the defect
+        # is a MISSING pair across two trees, so a PR touching only Kotlin never touches the spec and
+        # a diff-scoped gate would see nothing.
+        #
+        # Advisory because 114 pre-existing findings cannot be a merge blocker on day one. Flipping
+        # to enforced = add --enforce in ci.yml, once the backlog is cleared.
       db_backup_association:
         detect: ["openbank-infra/gitops/**/*.yaml (kind: Cluster, postgresql.cnpg.io)"]
         require:

--- a/openbank-infra/gitops/components/payments/domestic-payment-opa-bundle.yaml
+++ b/openbank-infra/gitops/components/payments/domestic-payment-opa-bundle.yaml
@@ -9,7 +9,7 @@ metadata:
     app.kubernetes.io/name: domestic-payment
     app.kubernetes.io/part-of: payments
   annotations:
-    openbank.tech/policy-checksum: "b4540595c0ef58d2"
+    openbank.tech/policy-checksum: "45acc72a57dedce1"
 data:
   rest.rego: |
     # SPDX-License-Identifier: Apache-2.0
@@ -1538,6 +1538,42 @@ data:
         # spec-touching PR (bump info.version to match what the diff did), which the error
         # message spells out.
         ci_producer: ".github/scripts/check-api-contract.py"
+      openapi_route_conformance:
+        detect: ["openbank-*/src/main/resources/openapi.yaml", "JAX-RS @Path / @GET / @POST resource classes"]
+        require:
+          - "every route a resource class answers is published in that service's openapi.yaml"
+          - "every route openapi.yaml promises is declared by a resource class"
+        gate: openapi-route-conformance
+        enforced: advisory
+        target_enforce_date: "2026-09-30"
+        ci_producer: ".github/scripts/check-openapi-route-conformance.py"
+        # api_contract (above) classifies a spec's version bump against the PREVIOUS REVISION of the
+        # same document. Nothing asked whether the document is TRUE. ADR-0005 says "CI lints it with
+        # Spectral so docs cannot drift from runtime" — there is no Spectral config in this repo and
+        # no workflow references it, so that control has never existed. The #2280 failure class:
+        # check whether anything reads the artifact before assuming a green covers it.
+        #
+        # What the drift actually was, measured on the day this landed: 114 route-level findings
+        # across 44 services. aml-service published request/response schemas whose fields exist
+        # nowhere in the code (#2312, fixed in #2317); copilot-service served the human-in-the-loop
+        # confirm for a money-path action proposal without publishing it (#2323) and declared a 501
+        # its streaming endpoint cannot return (#2351, fixed in #2353). Worst single pattern: 10 of
+        # the 15 services with an ApprovalResource serve PATCH /api/v1/<svc>/approvals/{id} — the
+        # four-eyes control — without publishing it, most of them money-path.
+        #
+        # ROUTE SET ONLY. It does not read schemas, so an invented request field passes clean (that
+        # was the whole aml defect); it does not read status codes, so a documented response the
+        # handler cannot produce passes clean. A reflection test is the floor, not the ceiling — the
+        # schema half needs the Quarkus-generated document
+        # (quarkus.smallrye-openapi.store-schema-directory, a dependency the whole fleet already has
+        # and nothing uses). Do not let a green here be read as "this spec is true".
+        #
+        # NOT diff-scoped, like db_backup_association and unlike api_contract/db_change: the defect
+        # is a MISSING pair across two trees, so a PR touching only Kotlin never touches the spec and
+        # a diff-scoped gate would see nothing.
+        #
+        # Advisory because 114 pre-existing findings cannot be a merge blocker on day one. Flipping
+        # to enforced = add --enforce in ci.yml, once the backlog is cleared.
       db_backup_association:
         detect: ["openbank-infra/gitops/**/*.yaml (kind: Cluster, postgresql.cnpg.io)"]
         require:

--- a/openbank-infra/gitops/components/payments/payments-services.yaml
+++ b/openbank-infra/gitops/components/payments/payments-services.yaml
@@ -42,7 +42,7 @@ spec:
         # Rolls the pods when the OPA bundle changes — subPath mounts do NOT hot-reload.
         # Kept in sync by gen-transaction-opa-bundle.sh via the trailing marker comment
         # (do not hand-edit, do not drop the marker).
-        openbank.tech/policy-checksum: "5b163df5ea95e183" # transaction-opa-bundle
+        openbank.tech/policy-checksum: "47102db2519ee360" # transaction-opa-bundle
     spec:
       securityContext:
         runAsNonRoot: true
@@ -375,7 +375,7 @@ spec:
       annotations:
         # Rolls the pods when the OPA bundle changes — subPath mounts do NOT hot-reload.
         # Kept in sync by gen-sepa-payment-opa-bundle.sh (do not hand-edit).
-        openbank.tech/policy-checksum: "320fe86de35da3d5"
+        openbank.tech/policy-checksum: "b1ddc2cff5f60203"
     spec:
       securityContext:
         runAsNonRoot: true
@@ -729,7 +729,7 @@ spec:
         # Rolls the pods when the OPA bundle changes — subPath mounts do NOT hot-reload.
         # Kept in sync by gen-domestic-payment-opa-bundle.sh via the trailing marker
         # comment (do not hand-edit, do not drop the marker).
-        openbank.tech/policy-checksum: "b4540595c0ef58d2" # domestic-payment-opa-bundle
+        openbank.tech/policy-checksum: "45acc72a57dedce1" # domestic-payment-opa-bundle
     spec:
       securityContext:
         runAsNonRoot: true
@@ -1053,7 +1053,7 @@ spec:
       annotations:
         # Rolls the pods when the OPA bundle changes — subPath mounts do NOT hot-reload.
         # Kept in sync by gen-sepa-instant-opa-bundle.sh (do not hand-edit).
-        openbank.tech/policy-checksum: "29c81f3157dde4b7"
+        openbank.tech/policy-checksum: "0616bdce5a27a690"
     spec:
       securityContext:
         runAsNonRoot: true
@@ -1369,7 +1369,7 @@ spec:
         # Rolls the pods when the OPA bundle changes — subPath mounts do NOT hot-reload.
         # Kept in sync by gen-clearing-opa-bundle.sh via the trailing marker comment
         # (do not hand-edit, do not drop the marker).
-        openbank.tech/policy-checksum: "363e83e5f07e68c9" # clearing-opa-bundle
+        openbank.tech/policy-checksum: "dcb516681861ccc2" # clearing-opa-bundle
     spec:
       securityContext:
         runAsNonRoot: true
@@ -1658,7 +1658,7 @@ spec:
       annotations:
         # Rolls the pod when the OPA bundle changes (ADR-0034). Value is stamped by
         # gen-standing-order-opa-bundle.sh — do not hand-edit.
-        openbank.tech/policy-checksum: "17bd6322d62baad5" # standing-order-opa-bundle
+        openbank.tech/policy-checksum: "03d68b059298ad38" # standing-order-opa-bundle
     spec:
       securityContext:
         runAsNonRoot: true
@@ -1911,7 +1911,7 @@ spec:
       annotations:
         # Rolls the pods when the OPA bundle changes — subPath mounts do NOT hot-reload.
         # Kept in sync by gen-card-issuance-opa-bundle.sh (do not hand-edit).
-        openbank.tech/policy-checksum: "2acb58a175df8489"
+        openbank.tech/policy-checksum: "6a5476eb2f186256"
     spec:
       securityContext:
         runAsNonRoot: true
@@ -2178,7 +2178,7 @@ spec:
         # Rolls the pods when the OPA bundle changes — subPath mounts do NOT hot-reload.
         # Kept in sync by gen-settlement-opa-bundle.sh via the trailing marker comment
         # (do not hand-edit, do not drop the marker).
-        openbank.tech/policy-checksum: "8bc47c2b78b8267c" # settlement-opa-bundle
+        openbank.tech/policy-checksum: "f3e7229be8562ec2" # settlement-opa-bundle
     spec:
       securityContext:
         runAsNonRoot: true
@@ -2579,7 +2579,7 @@ spec:
       annotations:
         # Rolls the pods when the OPA bundle changes — subPath mounts do NOT hot-reload.
         # Kept in sync by gen-swift-opa-bundle.sh (do not hand-edit).
-        openbank.tech/policy-checksum: "b6d939fd1e7d24eb"
+        openbank.tech/policy-checksum: "3bc4dacaacfacc2e"
     spec:
       securityContext:
         runAsNonRoot: true
@@ -2893,7 +2893,7 @@ spec:
       annotations:
         # Rolls the pods when the OPA bundle changes — subPath mounts do NOT hot-reload.
         # Kept in sync by gen-vop-opa-bundle.sh (do not hand-edit).
-        openbank.tech/policy-checksum: "df8449abde7b5cea"
+        openbank.tech/policy-checksum: "53e78aae6d6a40c8"
     spec:
       securityContext:
         runAsNonRoot: true

--- a/openbank-infra/gitops/components/payments/sepa-instant-opa-bundle.yaml
+++ b/openbank-infra/gitops/components/payments/sepa-instant-opa-bundle.yaml
@@ -9,7 +9,7 @@ metadata:
     app.kubernetes.io/name: sepa-instant
     app.kubernetes.io/part-of: payments
   annotations:
-    openbank.tech/policy-checksum: "29c81f3157dde4b7"
+    openbank.tech/policy-checksum: "0616bdce5a27a690"
 data:
   rest.rego: |
     # SPDX-License-Identifier: Apache-2.0
@@ -1511,6 +1511,42 @@ data:
         # spec-touching PR (bump info.version to match what the diff did), which the error
         # message spells out.
         ci_producer: ".github/scripts/check-api-contract.py"
+      openapi_route_conformance:
+        detect: ["openbank-*/src/main/resources/openapi.yaml", "JAX-RS @Path / @GET / @POST resource classes"]
+        require:
+          - "every route a resource class answers is published in that service's openapi.yaml"
+          - "every route openapi.yaml promises is declared by a resource class"
+        gate: openapi-route-conformance
+        enforced: advisory
+        target_enforce_date: "2026-09-30"
+        ci_producer: ".github/scripts/check-openapi-route-conformance.py"
+        # api_contract (above) classifies a spec's version bump against the PREVIOUS REVISION of the
+        # same document. Nothing asked whether the document is TRUE. ADR-0005 says "CI lints it with
+        # Spectral so docs cannot drift from runtime" — there is no Spectral config in this repo and
+        # no workflow references it, so that control has never existed. The #2280 failure class:
+        # check whether anything reads the artifact before assuming a green covers it.
+        #
+        # What the drift actually was, measured on the day this landed: 114 route-level findings
+        # across 44 services. aml-service published request/response schemas whose fields exist
+        # nowhere in the code (#2312, fixed in #2317); copilot-service served the human-in-the-loop
+        # confirm for a money-path action proposal without publishing it (#2323) and declared a 501
+        # its streaming endpoint cannot return (#2351, fixed in #2353). Worst single pattern: 10 of
+        # the 15 services with an ApprovalResource serve PATCH /api/v1/<svc>/approvals/{id} — the
+        # four-eyes control — without publishing it, most of them money-path.
+        #
+        # ROUTE SET ONLY. It does not read schemas, so an invented request field passes clean (that
+        # was the whole aml defect); it does not read status codes, so a documented response the
+        # handler cannot produce passes clean. A reflection test is the floor, not the ceiling — the
+        # schema half needs the Quarkus-generated document
+        # (quarkus.smallrye-openapi.store-schema-directory, a dependency the whole fleet already has
+        # and nothing uses). Do not let a green here be read as "this spec is true".
+        #
+        # NOT diff-scoped, like db_backup_association and unlike api_contract/db_change: the defect
+        # is a MISSING pair across two trees, so a PR touching only Kotlin never touches the spec and
+        # a diff-scoped gate would see nothing.
+        #
+        # Advisory because 114 pre-existing findings cannot be a merge blocker on day one. Flipping
+        # to enforced = add --enforce in ci.yml, once the backlog is cleared.
       db_backup_association:
         detect: ["openbank-infra/gitops/**/*.yaml (kind: Cluster, postgresql.cnpg.io)"]
         require:

--- a/openbank-infra/gitops/components/payments/sepa-payment-opa-bundle.yaml
+++ b/openbank-infra/gitops/components/payments/sepa-payment-opa-bundle.yaml
@@ -9,7 +9,7 @@ metadata:
     app.kubernetes.io/name: sepa-payment
     app.kubernetes.io/part-of: payments
   annotations:
-    openbank.tech/policy-checksum: "320fe86de35da3d5"
+    openbank.tech/policy-checksum: "b1ddc2cff5f60203"
 data:
   rest.rego: |
     # SPDX-License-Identifier: Apache-2.0
@@ -1532,6 +1532,42 @@ data:
         # spec-touching PR (bump info.version to match what the diff did), which the error
         # message spells out.
         ci_producer: ".github/scripts/check-api-contract.py"
+      openapi_route_conformance:
+        detect: ["openbank-*/src/main/resources/openapi.yaml", "JAX-RS @Path / @GET / @POST resource classes"]
+        require:
+          - "every route a resource class answers is published in that service's openapi.yaml"
+          - "every route openapi.yaml promises is declared by a resource class"
+        gate: openapi-route-conformance
+        enforced: advisory
+        target_enforce_date: "2026-09-30"
+        ci_producer: ".github/scripts/check-openapi-route-conformance.py"
+        # api_contract (above) classifies a spec's version bump against the PREVIOUS REVISION of the
+        # same document. Nothing asked whether the document is TRUE. ADR-0005 says "CI lints it with
+        # Spectral so docs cannot drift from runtime" — there is no Spectral config in this repo and
+        # no workflow references it, so that control has never existed. The #2280 failure class:
+        # check whether anything reads the artifact before assuming a green covers it.
+        #
+        # What the drift actually was, measured on the day this landed: 114 route-level findings
+        # across 44 services. aml-service published request/response schemas whose fields exist
+        # nowhere in the code (#2312, fixed in #2317); copilot-service served the human-in-the-loop
+        # confirm for a money-path action proposal without publishing it (#2323) and declared a 501
+        # its streaming endpoint cannot return (#2351, fixed in #2353). Worst single pattern: 10 of
+        # the 15 services with an ApprovalResource serve PATCH /api/v1/<svc>/approvals/{id} — the
+        # four-eyes control — without publishing it, most of them money-path.
+        #
+        # ROUTE SET ONLY. It does not read schemas, so an invented request field passes clean (that
+        # was the whole aml defect); it does not read status codes, so a documented response the
+        # handler cannot produce passes clean. A reflection test is the floor, not the ceiling — the
+        # schema half needs the Quarkus-generated document
+        # (quarkus.smallrye-openapi.store-schema-directory, a dependency the whole fleet already has
+        # and nothing uses). Do not let a green here be read as "this spec is true".
+        #
+        # NOT diff-scoped, like db_backup_association and unlike api_contract/db_change: the defect
+        # is a MISSING pair across two trees, so a PR touching only Kotlin never touches the spec and
+        # a diff-scoped gate would see nothing.
+        #
+        # Advisory because 114 pre-existing findings cannot be a merge blocker on day one. Flipping
+        # to enforced = add --enforce in ci.yml, once the backlog is cleared.
       db_backup_association:
         detect: ["openbank-infra/gitops/**/*.yaml (kind: Cluster, postgresql.cnpg.io)"]
         require:

--- a/openbank-infra/gitops/components/payments/settlement-opa-bundle.yaml
+++ b/openbank-infra/gitops/components/payments/settlement-opa-bundle.yaml
@@ -9,7 +9,7 @@ metadata:
     app.kubernetes.io/name: settlement-service
     app.kubernetes.io/part-of: payments
   annotations:
-    openbank.tech/policy-checksum: "8bc47c2b78b8267c"
+    openbank.tech/policy-checksum: "f3e7229be8562ec2"
 data:
   rest.rego: |
     # SPDX-License-Identifier: Apache-2.0
@@ -1512,6 +1512,42 @@ data:
         # spec-touching PR (bump info.version to match what the diff did), which the error
         # message spells out.
         ci_producer: ".github/scripts/check-api-contract.py"
+      openapi_route_conformance:
+        detect: ["openbank-*/src/main/resources/openapi.yaml", "JAX-RS @Path / @GET / @POST resource classes"]
+        require:
+          - "every route a resource class answers is published in that service's openapi.yaml"
+          - "every route openapi.yaml promises is declared by a resource class"
+        gate: openapi-route-conformance
+        enforced: advisory
+        target_enforce_date: "2026-09-30"
+        ci_producer: ".github/scripts/check-openapi-route-conformance.py"
+        # api_contract (above) classifies a spec's version bump against the PREVIOUS REVISION of the
+        # same document. Nothing asked whether the document is TRUE. ADR-0005 says "CI lints it with
+        # Spectral so docs cannot drift from runtime" — there is no Spectral config in this repo and
+        # no workflow references it, so that control has never existed. The #2280 failure class:
+        # check whether anything reads the artifact before assuming a green covers it.
+        #
+        # What the drift actually was, measured on the day this landed: 114 route-level findings
+        # across 44 services. aml-service published request/response schemas whose fields exist
+        # nowhere in the code (#2312, fixed in #2317); copilot-service served the human-in-the-loop
+        # confirm for a money-path action proposal without publishing it (#2323) and declared a 501
+        # its streaming endpoint cannot return (#2351, fixed in #2353). Worst single pattern: 10 of
+        # the 15 services with an ApprovalResource serve PATCH /api/v1/<svc>/approvals/{id} — the
+        # four-eyes control — without publishing it, most of them money-path.
+        #
+        # ROUTE SET ONLY. It does not read schemas, so an invented request field passes clean (that
+        # was the whole aml defect); it does not read status codes, so a documented response the
+        # handler cannot produce passes clean. A reflection test is the floor, not the ceiling — the
+        # schema half needs the Quarkus-generated document
+        # (quarkus.smallrye-openapi.store-schema-directory, a dependency the whole fleet already has
+        # and nothing uses). Do not let a green here be read as "this spec is true".
+        #
+        # NOT diff-scoped, like db_backup_association and unlike api_contract/db_change: the defect
+        # is a MISSING pair across two trees, so a PR touching only Kotlin never touches the spec and
+        # a diff-scoped gate would see nothing.
+        #
+        # Advisory because 114 pre-existing findings cannot be a merge blocker on day one. Flipping
+        # to enforced = add --enforce in ci.yml, once the backlog is cleared.
       db_backup_association:
         detect: ["openbank-infra/gitops/**/*.yaml (kind: Cluster, postgresql.cnpg.io)"]
         require:

--- a/openbank-infra/gitops/components/payments/standing-order-opa-bundle.yaml
+++ b/openbank-infra/gitops/components/payments/standing-order-opa-bundle.yaml
@@ -9,7 +9,7 @@ metadata:
     app.kubernetes.io/name: standing-order-service
     app.kubernetes.io/part-of: payments
   annotations:
-    openbank.tech/policy-checksum: "17bd6322d62baad5"
+    openbank.tech/policy-checksum: "03d68b059298ad38"
 data:
   rest.rego: |
     # SPDX-License-Identifier: Apache-2.0
@@ -1497,6 +1497,42 @@ data:
         # spec-touching PR (bump info.version to match what the diff did), which the error
         # message spells out.
         ci_producer: ".github/scripts/check-api-contract.py"
+      openapi_route_conformance:
+        detect: ["openbank-*/src/main/resources/openapi.yaml", "JAX-RS @Path / @GET / @POST resource classes"]
+        require:
+          - "every route a resource class answers is published in that service's openapi.yaml"
+          - "every route openapi.yaml promises is declared by a resource class"
+        gate: openapi-route-conformance
+        enforced: advisory
+        target_enforce_date: "2026-09-30"
+        ci_producer: ".github/scripts/check-openapi-route-conformance.py"
+        # api_contract (above) classifies a spec's version bump against the PREVIOUS REVISION of the
+        # same document. Nothing asked whether the document is TRUE. ADR-0005 says "CI lints it with
+        # Spectral so docs cannot drift from runtime" — there is no Spectral config in this repo and
+        # no workflow references it, so that control has never existed. The #2280 failure class:
+        # check whether anything reads the artifact before assuming a green covers it.
+        #
+        # What the drift actually was, measured on the day this landed: 114 route-level findings
+        # across 44 services. aml-service published request/response schemas whose fields exist
+        # nowhere in the code (#2312, fixed in #2317); copilot-service served the human-in-the-loop
+        # confirm for a money-path action proposal without publishing it (#2323) and declared a 501
+        # its streaming endpoint cannot return (#2351, fixed in #2353). Worst single pattern: 10 of
+        # the 15 services with an ApprovalResource serve PATCH /api/v1/<svc>/approvals/{id} — the
+        # four-eyes control — without publishing it, most of them money-path.
+        #
+        # ROUTE SET ONLY. It does not read schemas, so an invented request field passes clean (that
+        # was the whole aml defect); it does not read status codes, so a documented response the
+        # handler cannot produce passes clean. A reflection test is the floor, not the ceiling — the
+        # schema half needs the Quarkus-generated document
+        # (quarkus.smallrye-openapi.store-schema-directory, a dependency the whole fleet already has
+        # and nothing uses). Do not let a green here be read as "this spec is true".
+        #
+        # NOT diff-scoped, like db_backup_association and unlike api_contract/db_change: the defect
+        # is a MISSING pair across two trees, so a PR touching only Kotlin never touches the spec and
+        # a diff-scoped gate would see nothing.
+        #
+        # Advisory because 114 pre-existing findings cannot be a merge blocker on day one. Flipping
+        # to enforced = add --enforce in ci.yml, once the backlog is cleared.
       db_backup_association:
         detect: ["openbank-infra/gitops/**/*.yaml (kind: Cluster, postgresql.cnpg.io)"]
         require:

--- a/openbank-infra/gitops/components/payments/swift-opa-bundle.yaml
+++ b/openbank-infra/gitops/components/payments/swift-opa-bundle.yaml
@@ -9,7 +9,7 @@ metadata:
     app.kubernetes.io/name: swift-service
     app.kubernetes.io/part-of: payments
   annotations:
-    openbank.tech/policy-checksum: "b6d939fd1e7d24eb"
+    openbank.tech/policy-checksum: "3bc4dacaacfacc2e"
 data:
   rest.rego: |
     # SPDX-License-Identifier: Apache-2.0
@@ -1515,6 +1515,42 @@ data:
         # spec-touching PR (bump info.version to match what the diff did), which the error
         # message spells out.
         ci_producer: ".github/scripts/check-api-contract.py"
+      openapi_route_conformance:
+        detect: ["openbank-*/src/main/resources/openapi.yaml", "JAX-RS @Path / @GET / @POST resource classes"]
+        require:
+          - "every route a resource class answers is published in that service's openapi.yaml"
+          - "every route openapi.yaml promises is declared by a resource class"
+        gate: openapi-route-conformance
+        enforced: advisory
+        target_enforce_date: "2026-09-30"
+        ci_producer: ".github/scripts/check-openapi-route-conformance.py"
+        # api_contract (above) classifies a spec's version bump against the PREVIOUS REVISION of the
+        # same document. Nothing asked whether the document is TRUE. ADR-0005 says "CI lints it with
+        # Spectral so docs cannot drift from runtime" — there is no Spectral config in this repo and
+        # no workflow references it, so that control has never existed. The #2280 failure class:
+        # check whether anything reads the artifact before assuming a green covers it.
+        #
+        # What the drift actually was, measured on the day this landed: 114 route-level findings
+        # across 44 services. aml-service published request/response schemas whose fields exist
+        # nowhere in the code (#2312, fixed in #2317); copilot-service served the human-in-the-loop
+        # confirm for a money-path action proposal without publishing it (#2323) and declared a 501
+        # its streaming endpoint cannot return (#2351, fixed in #2353). Worst single pattern: 10 of
+        # the 15 services with an ApprovalResource serve PATCH /api/v1/<svc>/approvals/{id} — the
+        # four-eyes control — without publishing it, most of them money-path.
+        #
+        # ROUTE SET ONLY. It does not read schemas, so an invented request field passes clean (that
+        # was the whole aml defect); it does not read status codes, so a documented response the
+        # handler cannot produce passes clean. A reflection test is the floor, not the ceiling — the
+        # schema half needs the Quarkus-generated document
+        # (quarkus.smallrye-openapi.store-schema-directory, a dependency the whole fleet already has
+        # and nothing uses). Do not let a green here be read as "this spec is true".
+        #
+        # NOT diff-scoped, like db_backup_association and unlike api_contract/db_change: the defect
+        # is a MISSING pair across two trees, so a PR touching only Kotlin never touches the spec and
+        # a diff-scoped gate would see nothing.
+        #
+        # Advisory because 114 pre-existing findings cannot be a merge blocker on day one. Flipping
+        # to enforced = add --enforce in ci.yml, once the backlog is cleared.
       db_backup_association:
         detect: ["openbank-infra/gitops/**/*.yaml (kind: Cluster, postgresql.cnpg.io)"]
         require:

--- a/openbank-infra/gitops/components/payments/transaction-opa-bundle.yaml
+++ b/openbank-infra/gitops/components/payments/transaction-opa-bundle.yaml
@@ -9,7 +9,7 @@ metadata:
     app.kubernetes.io/name: transaction-service
     app.kubernetes.io/part-of: payments
   annotations:
-    openbank.tech/policy-checksum: "5b163df5ea95e183"
+    openbank.tech/policy-checksum: "47102db2519ee360"
 data:
   rest.rego: |
     # SPDX-License-Identifier: Apache-2.0
@@ -1568,6 +1568,42 @@ data:
         # spec-touching PR (bump info.version to match what the diff did), which the error
         # message spells out.
         ci_producer: ".github/scripts/check-api-contract.py"
+      openapi_route_conformance:
+        detect: ["openbank-*/src/main/resources/openapi.yaml", "JAX-RS @Path / @GET / @POST resource classes"]
+        require:
+          - "every route a resource class answers is published in that service's openapi.yaml"
+          - "every route openapi.yaml promises is declared by a resource class"
+        gate: openapi-route-conformance
+        enforced: advisory
+        target_enforce_date: "2026-09-30"
+        ci_producer: ".github/scripts/check-openapi-route-conformance.py"
+        # api_contract (above) classifies a spec's version bump against the PREVIOUS REVISION of the
+        # same document. Nothing asked whether the document is TRUE. ADR-0005 says "CI lints it with
+        # Spectral so docs cannot drift from runtime" — there is no Spectral config in this repo and
+        # no workflow references it, so that control has never existed. The #2280 failure class:
+        # check whether anything reads the artifact before assuming a green covers it.
+        #
+        # What the drift actually was, measured on the day this landed: 114 route-level findings
+        # across 44 services. aml-service published request/response schemas whose fields exist
+        # nowhere in the code (#2312, fixed in #2317); copilot-service served the human-in-the-loop
+        # confirm for a money-path action proposal without publishing it (#2323) and declared a 501
+        # its streaming endpoint cannot return (#2351, fixed in #2353). Worst single pattern: 10 of
+        # the 15 services with an ApprovalResource serve PATCH /api/v1/<svc>/approvals/{id} — the
+        # four-eyes control — without publishing it, most of them money-path.
+        #
+        # ROUTE SET ONLY. It does not read schemas, so an invented request field passes clean (that
+        # was the whole aml defect); it does not read status codes, so a documented response the
+        # handler cannot produce passes clean. A reflection test is the floor, not the ceiling — the
+        # schema half needs the Quarkus-generated document
+        # (quarkus.smallrye-openapi.store-schema-directory, a dependency the whole fleet already has
+        # and nothing uses). Do not let a green here be read as "this spec is true".
+        #
+        # NOT diff-scoped, like db_backup_association and unlike api_contract/db_change: the defect
+        # is a MISSING pair across two trees, so a PR touching only Kotlin never touches the spec and
+        # a diff-scoped gate would see nothing.
+        #
+        # Advisory because 114 pre-existing findings cannot be a merge blocker on day one. Flipping
+        # to enforced = add --enforce in ci.yml, once the backlog is cleared.
       db_backup_association:
         detect: ["openbank-infra/gitops/**/*.yaml (kind: Cluster, postgresql.cnpg.io)"]
         require:

--- a/openbank-infra/gitops/components/payments/vop-opa-bundle.yaml
+++ b/openbank-infra/gitops/components/payments/vop-opa-bundle.yaml
@@ -9,7 +9,7 @@ metadata:
     app.kubernetes.io/name: vop-service
     app.kubernetes.io/part-of: payments
   annotations:
-    openbank.tech/policy-checksum: "df8449abde7b5cea"
+    openbank.tech/policy-checksum: "53e78aae6d6a40c8"
 data:
   rest.rego: |
     # SPDX-License-Identifier: Apache-2.0
@@ -1519,6 +1519,42 @@ data:
         # spec-touching PR (bump info.version to match what the diff did), which the error
         # message spells out.
         ci_producer: ".github/scripts/check-api-contract.py"
+      openapi_route_conformance:
+        detect: ["openbank-*/src/main/resources/openapi.yaml", "JAX-RS @Path / @GET / @POST resource classes"]
+        require:
+          - "every route a resource class answers is published in that service's openapi.yaml"
+          - "every route openapi.yaml promises is declared by a resource class"
+        gate: openapi-route-conformance
+        enforced: advisory
+        target_enforce_date: "2026-09-30"
+        ci_producer: ".github/scripts/check-openapi-route-conformance.py"
+        # api_contract (above) classifies a spec's version bump against the PREVIOUS REVISION of the
+        # same document. Nothing asked whether the document is TRUE. ADR-0005 says "CI lints it with
+        # Spectral so docs cannot drift from runtime" — there is no Spectral config in this repo and
+        # no workflow references it, so that control has never existed. The #2280 failure class:
+        # check whether anything reads the artifact before assuming a green covers it.
+        #
+        # What the drift actually was, measured on the day this landed: 114 route-level findings
+        # across 44 services. aml-service published request/response schemas whose fields exist
+        # nowhere in the code (#2312, fixed in #2317); copilot-service served the human-in-the-loop
+        # confirm for a money-path action proposal without publishing it (#2323) and declared a 501
+        # its streaming endpoint cannot return (#2351, fixed in #2353). Worst single pattern: 10 of
+        # the 15 services with an ApprovalResource serve PATCH /api/v1/<svc>/approvals/{id} — the
+        # four-eyes control — without publishing it, most of them money-path.
+        #
+        # ROUTE SET ONLY. It does not read schemas, so an invented request field passes clean (that
+        # was the whole aml defect); it does not read status codes, so a documented response the
+        # handler cannot produce passes clean. A reflection test is the floor, not the ceiling — the
+        # schema half needs the Quarkus-generated document
+        # (quarkus.smallrye-openapi.store-schema-directory, a dependency the whole fleet already has
+        # and nothing uses). Do not let a green here be read as "this spec is true".
+        #
+        # NOT diff-scoped, like db_backup_association and unlike api_contract/db_change: the defect
+        # is a MISSING pair across two trees, so a PR touching only Kotlin never touches the spec and
+        # a diff-scoped gate would see nothing.
+        #
+        # Advisory because 114 pre-existing findings cannot be a merge blocker on day one. Flipping
+        # to enforced = add --enforce in ci.yml, once the backlog is cleared.
       db_backup_association:
         detect: ["openbank-infra/gitops/**/*.yaml (kind: Cluster, postgresql.cnpg.io)"]
         require:

--- a/openbank-infra/gitops/components/pid/pid-opa-bundle.yaml
+++ b/openbank-infra/gitops/components/pid/pid-opa-bundle.yaml
@@ -9,7 +9,7 @@ metadata:
     app.kubernetes.io/name: pid-service
     app.kubernetes.io/part-of: pid
   annotations:
-    openbank.tech/policy-checksum: "85d202e19234dd4f"
+    openbank.tech/policy-checksum: "f79e3a46a75b5147"
 data:
   rest.rego: |
     # SPDX-License-Identifier: Apache-2.0
@@ -1521,6 +1521,42 @@ data:
         # spec-touching PR (bump info.version to match what the diff did), which the error
         # message spells out.
         ci_producer: ".github/scripts/check-api-contract.py"
+      openapi_route_conformance:
+        detect: ["openbank-*/src/main/resources/openapi.yaml", "JAX-RS @Path / @GET / @POST resource classes"]
+        require:
+          - "every route a resource class answers is published in that service's openapi.yaml"
+          - "every route openapi.yaml promises is declared by a resource class"
+        gate: openapi-route-conformance
+        enforced: advisory
+        target_enforce_date: "2026-09-30"
+        ci_producer: ".github/scripts/check-openapi-route-conformance.py"
+        # api_contract (above) classifies a spec's version bump against the PREVIOUS REVISION of the
+        # same document. Nothing asked whether the document is TRUE. ADR-0005 says "CI lints it with
+        # Spectral so docs cannot drift from runtime" — there is no Spectral config in this repo and
+        # no workflow references it, so that control has never existed. The #2280 failure class:
+        # check whether anything reads the artifact before assuming a green covers it.
+        #
+        # What the drift actually was, measured on the day this landed: 114 route-level findings
+        # across 44 services. aml-service published request/response schemas whose fields exist
+        # nowhere in the code (#2312, fixed in #2317); copilot-service served the human-in-the-loop
+        # confirm for a money-path action proposal without publishing it (#2323) and declared a 501
+        # its streaming endpoint cannot return (#2351, fixed in #2353). Worst single pattern: 10 of
+        # the 15 services with an ApprovalResource serve PATCH /api/v1/<svc>/approvals/{id} — the
+        # four-eyes control — without publishing it, most of them money-path.
+        #
+        # ROUTE SET ONLY. It does not read schemas, so an invented request field passes clean (that
+        # was the whole aml defect); it does not read status codes, so a documented response the
+        # handler cannot produce passes clean. A reflection test is the floor, not the ceiling — the
+        # schema half needs the Quarkus-generated document
+        # (quarkus.smallrye-openapi.store-schema-directory, a dependency the whole fleet already has
+        # and nothing uses). Do not let a green here be read as "this spec is true".
+        #
+        # NOT diff-scoped, like db_backup_association and unlike api_contract/db_change: the defect
+        # is a MISSING pair across two trees, so a PR touching only Kotlin never touches the spec and
+        # a diff-scoped gate would see nothing.
+        #
+        # Advisory because 114 pre-existing findings cannot be a merge blocker on day one. Flipping
+        # to enforced = add --enforce in ci.yml, once the backlog is cleared.
       db_backup_association:
         detect: ["openbank-infra/gitops/**/*.yaml (kind: Cluster, postgresql.cnpg.io)"]
         require:

--- a/openbank-infra/gitops/components/pid/pid-service.yaml
+++ b/openbank-infra/gitops/components/pid/pid-service.yaml
@@ -22,7 +22,7 @@ spec:
       annotations:
         # Rolls the pod when the OPA bundle changes — subPath mounts do NOT hot-reload.
         # Kept in sync by gen-pid-opa-bundle.sh (do not hand-edit).
-        openbank.tech/policy-checksum: "85d202e19234dd4f"
+        openbank.tech/policy-checksum: "f79e3a46a75b5147"
     spec:
       securityContext:
         runAsNonRoot: true

--- a/openbank-infra/gitops/components/psd2-service/psd2-opa-bundle.yaml
+++ b/openbank-infra/gitops/components/psd2-service/psd2-opa-bundle.yaml
@@ -9,7 +9,7 @@ metadata:
     app.kubernetes.io/name: psd2-service
     app.kubernetes.io/part-of: psd2
   annotations:
-    openbank.tech/policy-checksum: "fdd1405b77d5fbba"
+    openbank.tech/policy-checksum: "4f32b2fe904dc326"
 data:
   rest.rego: |
     # SPDX-License-Identifier: Apache-2.0
@@ -1594,6 +1594,42 @@ data:
         # spec-touching PR (bump info.version to match what the diff did), which the error
         # message spells out.
         ci_producer: ".github/scripts/check-api-contract.py"
+      openapi_route_conformance:
+        detect: ["openbank-*/src/main/resources/openapi.yaml", "JAX-RS @Path / @GET / @POST resource classes"]
+        require:
+          - "every route a resource class answers is published in that service's openapi.yaml"
+          - "every route openapi.yaml promises is declared by a resource class"
+        gate: openapi-route-conformance
+        enforced: advisory
+        target_enforce_date: "2026-09-30"
+        ci_producer: ".github/scripts/check-openapi-route-conformance.py"
+        # api_contract (above) classifies a spec's version bump against the PREVIOUS REVISION of the
+        # same document. Nothing asked whether the document is TRUE. ADR-0005 says "CI lints it with
+        # Spectral so docs cannot drift from runtime" — there is no Spectral config in this repo and
+        # no workflow references it, so that control has never existed. The #2280 failure class:
+        # check whether anything reads the artifact before assuming a green covers it.
+        #
+        # What the drift actually was, measured on the day this landed: 114 route-level findings
+        # across 44 services. aml-service published request/response schemas whose fields exist
+        # nowhere in the code (#2312, fixed in #2317); copilot-service served the human-in-the-loop
+        # confirm for a money-path action proposal without publishing it (#2323) and declared a 501
+        # its streaming endpoint cannot return (#2351, fixed in #2353). Worst single pattern: 10 of
+        # the 15 services with an ApprovalResource serve PATCH /api/v1/<svc>/approvals/{id} — the
+        # four-eyes control — without publishing it, most of them money-path.
+        #
+        # ROUTE SET ONLY. It does not read schemas, so an invented request field passes clean (that
+        # was the whole aml defect); it does not read status codes, so a documented response the
+        # handler cannot produce passes clean. A reflection test is the floor, not the ceiling — the
+        # schema half needs the Quarkus-generated document
+        # (quarkus.smallrye-openapi.store-schema-directory, a dependency the whole fleet already has
+        # and nothing uses). Do not let a green here be read as "this spec is true".
+        #
+        # NOT diff-scoped, like db_backup_association and unlike api_contract/db_change: the defect
+        # is a MISSING pair across two trees, so a PR touching only Kotlin never touches the spec and
+        # a diff-scoped gate would see nothing.
+        #
+        # Advisory because 114 pre-existing findings cannot be a merge blocker on day one. Flipping
+        # to enforced = add --enforce in ci.yml, once the backlog is cleared.
       db_backup_association:
         detect: ["openbank-infra/gitops/**/*.yaml (kind: Cluster, postgresql.cnpg.io)"]
         require:

--- a/openbank-infra/gitops/components/psd2-service/psd2-service.yaml
+++ b/openbank-infra/gitops/components/psd2-service/psd2-service.yaml
@@ -18,7 +18,7 @@ spec:
       annotations:
         # Rolls the pod when the OPA bundle changes — subPath mounts do NOT hot-reload.
         # Kept in sync by gen-psd2-opa-bundle.sh (do not hand-edit).
-        openbank.tech/policy-checksum: "fdd1405b77d5fbba"
+        openbank.tech/policy-checksum: "4f32b2fe904dc326"
       labels: {app.kubernetes.io/name: psd2-service, app.kubernetes.io/part-of: psd2}
     spec:
       securityContext:

--- a/openbank-infra/gitops/components/sanctions-service/sanctions-opa-bundle.yaml
+++ b/openbank-infra/gitops/components/sanctions-service/sanctions-opa-bundle.yaml
@@ -9,7 +9,7 @@ metadata:
     app.kubernetes.io/name: sanctions-service
     app.kubernetes.io/part-of: sanctions
   annotations:
-    openbank.tech/policy-checksum: "a7a453bd99cfeb9e"
+    openbank.tech/policy-checksum: "dea05b01e7abed13"
 data:
   rest.rego: |
     # SPDX-License-Identifier: Apache-2.0
@@ -1499,6 +1499,42 @@ data:
         # spec-touching PR (bump info.version to match what the diff did), which the error
         # message spells out.
         ci_producer: ".github/scripts/check-api-contract.py"
+      openapi_route_conformance:
+        detect: ["openbank-*/src/main/resources/openapi.yaml", "JAX-RS @Path / @GET / @POST resource classes"]
+        require:
+          - "every route a resource class answers is published in that service's openapi.yaml"
+          - "every route openapi.yaml promises is declared by a resource class"
+        gate: openapi-route-conformance
+        enforced: advisory
+        target_enforce_date: "2026-09-30"
+        ci_producer: ".github/scripts/check-openapi-route-conformance.py"
+        # api_contract (above) classifies a spec's version bump against the PREVIOUS REVISION of the
+        # same document. Nothing asked whether the document is TRUE. ADR-0005 says "CI lints it with
+        # Spectral so docs cannot drift from runtime" — there is no Spectral config in this repo and
+        # no workflow references it, so that control has never existed. The #2280 failure class:
+        # check whether anything reads the artifact before assuming a green covers it.
+        #
+        # What the drift actually was, measured on the day this landed: 114 route-level findings
+        # across 44 services. aml-service published request/response schemas whose fields exist
+        # nowhere in the code (#2312, fixed in #2317); copilot-service served the human-in-the-loop
+        # confirm for a money-path action proposal without publishing it (#2323) and declared a 501
+        # its streaming endpoint cannot return (#2351, fixed in #2353). Worst single pattern: 10 of
+        # the 15 services with an ApprovalResource serve PATCH /api/v1/<svc>/approvals/{id} — the
+        # four-eyes control — without publishing it, most of them money-path.
+        #
+        # ROUTE SET ONLY. It does not read schemas, so an invented request field passes clean (that
+        # was the whole aml defect); it does not read status codes, so a documented response the
+        # handler cannot produce passes clean. A reflection test is the floor, not the ceiling — the
+        # schema half needs the Quarkus-generated document
+        # (quarkus.smallrye-openapi.store-schema-directory, a dependency the whole fleet already has
+        # and nothing uses). Do not let a green here be read as "this spec is true".
+        #
+        # NOT diff-scoped, like db_backup_association and unlike api_contract/db_change: the defect
+        # is a MISSING pair across two trees, so a PR touching only Kotlin never touches the spec and
+        # a diff-scoped gate would see nothing.
+        #
+        # Advisory because 114 pre-existing findings cannot be a merge blocker on day one. Flipping
+        # to enforced = add --enforce in ci.yml, once the backlog is cleared.
       db_backup_association:
         detect: ["openbank-infra/gitops/**/*.yaml (kind: Cluster, postgresql.cnpg.io)"]
         require:

--- a/openbank-infra/gitops/components/sanctions-service/sanctions-service.yaml
+++ b/openbank-infra/gitops/components/sanctions-service/sanctions-service.yaml
@@ -49,7 +49,7 @@ spec:
       annotations:
         # Rolls the pods when the OPA bundle changes — subPath mounts do NOT hot-reload.
         # Kept in sync by gen-sanctions-opa-bundle.sh (do not hand-edit).
-        openbank.tech/policy-checksum: "a7a453bd99cfeb9e"
+        openbank.tech/policy-checksum: "dea05b01e7abed13"
     spec:
       securityContext:
         runAsNonRoot: true

--- a/openbank-infra/gitops/components/sca/sca-opa-bundle.yaml
+++ b/openbank-infra/gitops/components/sca/sca-opa-bundle.yaml
@@ -9,7 +9,7 @@ metadata:
     app.kubernetes.io/name: sca-service
     app.kubernetes.io/part-of: sca
   annotations:
-    openbank.tech/policy-checksum: "640d35a7ff744529"
+    openbank.tech/policy-checksum: "b08d1a5ed1f7c048"
 data:
   rest.rego: |
     # SPDX-License-Identifier: Apache-2.0
@@ -1535,6 +1535,42 @@ data:
         # spec-touching PR (bump info.version to match what the diff did), which the error
         # message spells out.
         ci_producer: ".github/scripts/check-api-contract.py"
+      openapi_route_conformance:
+        detect: ["openbank-*/src/main/resources/openapi.yaml", "JAX-RS @Path / @GET / @POST resource classes"]
+        require:
+          - "every route a resource class answers is published in that service's openapi.yaml"
+          - "every route openapi.yaml promises is declared by a resource class"
+        gate: openapi-route-conformance
+        enforced: advisory
+        target_enforce_date: "2026-09-30"
+        ci_producer: ".github/scripts/check-openapi-route-conformance.py"
+        # api_contract (above) classifies a spec's version bump against the PREVIOUS REVISION of the
+        # same document. Nothing asked whether the document is TRUE. ADR-0005 says "CI lints it with
+        # Spectral so docs cannot drift from runtime" — there is no Spectral config in this repo and
+        # no workflow references it, so that control has never existed. The #2280 failure class:
+        # check whether anything reads the artifact before assuming a green covers it.
+        #
+        # What the drift actually was, measured on the day this landed: 114 route-level findings
+        # across 44 services. aml-service published request/response schemas whose fields exist
+        # nowhere in the code (#2312, fixed in #2317); copilot-service served the human-in-the-loop
+        # confirm for a money-path action proposal without publishing it (#2323) and declared a 501
+        # its streaming endpoint cannot return (#2351, fixed in #2353). Worst single pattern: 10 of
+        # the 15 services with an ApprovalResource serve PATCH /api/v1/<svc>/approvals/{id} — the
+        # four-eyes control — without publishing it, most of them money-path.
+        #
+        # ROUTE SET ONLY. It does not read schemas, so an invented request field passes clean (that
+        # was the whole aml defect); it does not read status codes, so a documented response the
+        # handler cannot produce passes clean. A reflection test is the floor, not the ceiling — the
+        # schema half needs the Quarkus-generated document
+        # (quarkus.smallrye-openapi.store-schema-directory, a dependency the whole fleet already has
+        # and nothing uses). Do not let a green here be read as "this spec is true".
+        #
+        # NOT diff-scoped, like db_backup_association and unlike api_contract/db_change: the defect
+        # is a MISSING pair across two trees, so a PR touching only Kotlin never touches the spec and
+        # a diff-scoped gate would see nothing.
+        #
+        # Advisory because 114 pre-existing findings cannot be a merge blocker on day one. Flipping
+        # to enforced = add --enforce in ci.yml, once the backlog is cleared.
       db_backup_association:
         detect: ["openbank-infra/gitops/**/*.yaml (kind: Cluster, postgresql.cnpg.io)"]
         require:

--- a/openbank-infra/gitops/components/sca/sca-service.yaml
+++ b/openbank-infra/gitops/components/sca/sca-service.yaml
@@ -28,7 +28,7 @@ spec:
       annotations:
         # Rolls the pods when the OPA bundle changes — subPath mounts do NOT hot-reload.
         # Kept in sync by gen-sca-opa-bundle.sh (do not hand-edit).
-        openbank.tech/policy-checksum: "640d35a7ff744529"
+        openbank.tech/policy-checksum: "b08d1a5ed1f7c048"
     spec:
       securityContext:
         runAsNonRoot: true

--- a/openbank-infra/gitops/components/statements/statement-opa-bundle.yaml
+++ b/openbank-infra/gitops/components/statements/statement-opa-bundle.yaml
@@ -9,7 +9,7 @@ metadata:
     app.kubernetes.io/name: statement-service
     app.kubernetes.io/part-of: statements
   annotations:
-    openbank.tech/policy-checksum: "9e5ef35b94c72f78"
+    openbank.tech/policy-checksum: "794b6ea5ac8766f0"
 data:
   rest.rego: |
     # SPDX-License-Identifier: Apache-2.0
@@ -1565,6 +1565,42 @@ data:
         # spec-touching PR (bump info.version to match what the diff did), which the error
         # message spells out.
         ci_producer: ".github/scripts/check-api-contract.py"
+      openapi_route_conformance:
+        detect: ["openbank-*/src/main/resources/openapi.yaml", "JAX-RS @Path / @GET / @POST resource classes"]
+        require:
+          - "every route a resource class answers is published in that service's openapi.yaml"
+          - "every route openapi.yaml promises is declared by a resource class"
+        gate: openapi-route-conformance
+        enforced: advisory
+        target_enforce_date: "2026-09-30"
+        ci_producer: ".github/scripts/check-openapi-route-conformance.py"
+        # api_contract (above) classifies a spec's version bump against the PREVIOUS REVISION of the
+        # same document. Nothing asked whether the document is TRUE. ADR-0005 says "CI lints it with
+        # Spectral so docs cannot drift from runtime" — there is no Spectral config in this repo and
+        # no workflow references it, so that control has never existed. The #2280 failure class:
+        # check whether anything reads the artifact before assuming a green covers it.
+        #
+        # What the drift actually was, measured on the day this landed: 114 route-level findings
+        # across 44 services. aml-service published request/response schemas whose fields exist
+        # nowhere in the code (#2312, fixed in #2317); copilot-service served the human-in-the-loop
+        # confirm for a money-path action proposal without publishing it (#2323) and declared a 501
+        # its streaming endpoint cannot return (#2351, fixed in #2353). Worst single pattern: 10 of
+        # the 15 services with an ApprovalResource serve PATCH /api/v1/<svc>/approvals/{id} — the
+        # four-eyes control — without publishing it, most of them money-path.
+        #
+        # ROUTE SET ONLY. It does not read schemas, so an invented request field passes clean (that
+        # was the whole aml defect); it does not read status codes, so a documented response the
+        # handler cannot produce passes clean. A reflection test is the floor, not the ceiling — the
+        # schema half needs the Quarkus-generated document
+        # (quarkus.smallrye-openapi.store-schema-directory, a dependency the whole fleet already has
+        # and nothing uses). Do not let a green here be read as "this spec is true".
+        #
+        # NOT diff-scoped, like db_backup_association and unlike api_contract/db_change: the defect
+        # is a MISSING pair across two trees, so a PR touching only Kotlin never touches the spec and
+        # a diff-scoped gate would see nothing.
+        #
+        # Advisory because 114 pre-existing findings cannot be a merge blocker on day one. Flipping
+        # to enforced = add --enforce in ci.yml, once the backlog is cleared.
       db_backup_association:
         detect: ["openbank-infra/gitops/**/*.yaml (kind: Cluster, postgresql.cnpg.io)"]
         require:

--- a/openbank-infra/gitops/components/statements/statement-service.yaml
+++ b/openbank-infra/gitops/components/statements/statement-service.yaml
@@ -26,7 +26,7 @@ spec:
       annotations:
         # Rolls the pod when the OPA bundle changes — subPath mounts do NOT hot-reload.
         # Kept in sync by gen-statement-opa-bundle.sh (do not hand-edit).
-        openbank.tech/policy-checksum: "9e5ef35b94c72f78"
+        openbank.tech/policy-checksum: "794b6ea5ac8766f0"
       labels:
         app.kubernetes.io/name: statement-service
         app.kubernetes.io/part-of: statements

--- a/openbank-infra/gitops/components/tpp-registry/tpp-registry-opa-bundle.yaml
+++ b/openbank-infra/gitops/components/tpp-registry/tpp-registry-opa-bundle.yaml
@@ -9,7 +9,7 @@ metadata:
     app.kubernetes.io/name: tpp-registry-service
     app.kubernetes.io/part-of: tpp-registry
   annotations:
-    openbank.tech/policy-checksum: "cc1f2ec22dbd6a01"
+    openbank.tech/policy-checksum: "e0b31c1b8ff62a4f"
 data:
   rest.rego: |
     # SPDX-License-Identifier: Apache-2.0
@@ -1502,6 +1502,42 @@ data:
         # spec-touching PR (bump info.version to match what the diff did), which the error
         # message spells out.
         ci_producer: ".github/scripts/check-api-contract.py"
+      openapi_route_conformance:
+        detect: ["openbank-*/src/main/resources/openapi.yaml", "JAX-RS @Path / @GET / @POST resource classes"]
+        require:
+          - "every route a resource class answers is published in that service's openapi.yaml"
+          - "every route openapi.yaml promises is declared by a resource class"
+        gate: openapi-route-conformance
+        enforced: advisory
+        target_enforce_date: "2026-09-30"
+        ci_producer: ".github/scripts/check-openapi-route-conformance.py"
+        # api_contract (above) classifies a spec's version bump against the PREVIOUS REVISION of the
+        # same document. Nothing asked whether the document is TRUE. ADR-0005 says "CI lints it with
+        # Spectral so docs cannot drift from runtime" — there is no Spectral config in this repo and
+        # no workflow references it, so that control has never existed. The #2280 failure class:
+        # check whether anything reads the artifact before assuming a green covers it.
+        #
+        # What the drift actually was, measured on the day this landed: 114 route-level findings
+        # across 44 services. aml-service published request/response schemas whose fields exist
+        # nowhere in the code (#2312, fixed in #2317); copilot-service served the human-in-the-loop
+        # confirm for a money-path action proposal without publishing it (#2323) and declared a 501
+        # its streaming endpoint cannot return (#2351, fixed in #2353). Worst single pattern: 10 of
+        # the 15 services with an ApprovalResource serve PATCH /api/v1/<svc>/approvals/{id} — the
+        # four-eyes control — without publishing it, most of them money-path.
+        #
+        # ROUTE SET ONLY. It does not read schemas, so an invented request field passes clean (that
+        # was the whole aml defect); it does not read status codes, so a documented response the
+        # handler cannot produce passes clean. A reflection test is the floor, not the ceiling — the
+        # schema half needs the Quarkus-generated document
+        # (quarkus.smallrye-openapi.store-schema-directory, a dependency the whole fleet already has
+        # and nothing uses). Do not let a green here be read as "this spec is true".
+        #
+        # NOT diff-scoped, like db_backup_association and unlike api_contract/db_change: the defect
+        # is a MISSING pair across two trees, so a PR touching only Kotlin never touches the spec and
+        # a diff-scoped gate would see nothing.
+        #
+        # Advisory because 114 pre-existing findings cannot be a merge blocker on day one. Flipping
+        # to enforced = add --enforce in ci.yml, once the backlog is cleared.
       db_backup_association:
         detect: ["openbank-infra/gitops/**/*.yaml (kind: Cluster, postgresql.cnpg.io)"]
         require:

--- a/openbank-infra/gitops/components/tpp-registry/tpp-registry-service.yaml
+++ b/openbank-infra/gitops/components/tpp-registry/tpp-registry-service.yaml
@@ -23,7 +23,7 @@ spec:
       annotations:
         # Rolls the pod when the OPA bundle changes (subPath mounts do not hot-reload).
         # Kept in sync by gen-tpp-registry-opa-bundle.sh (do not hand-edit).
-        openbank.tech/policy-checksum: "cc1f2ec22dbd6a01"
+        openbank.tech/policy-checksum: "e0b31c1b8ff62a4f"
     spec:
       securityContext:
         runAsNonRoot: true

--- a/openbank-libs/governance/rules.yaml
+++ b/openbank-libs/governance/rules.yaml
@@ -133,6 +133,42 @@ change_requirements:
     # spec-touching PR (bump info.version to match what the diff did), which the error
     # message spells out.
     ci_producer: ".github/scripts/check-api-contract.py"
+  openapi_route_conformance:
+    detect: ["openbank-*/src/main/resources/openapi.yaml", "JAX-RS @Path / @GET / @POST resource classes"]
+    require:
+      - "every route a resource class answers is published in that service's openapi.yaml"
+      - "every route openapi.yaml promises is declared by a resource class"
+    gate: openapi-route-conformance
+    enforced: advisory
+    target_enforce_date: "2026-09-30"
+    ci_producer: ".github/scripts/check-openapi-route-conformance.py"
+    # api_contract (above) classifies a spec's version bump against the PREVIOUS REVISION of the
+    # same document. Nothing asked whether the document is TRUE. ADR-0005 says "CI lints it with
+    # Spectral so docs cannot drift from runtime" — there is no Spectral config in this repo and
+    # no workflow references it, so that control has never existed. The #2280 failure class:
+    # check whether anything reads the artifact before assuming a green covers it.
+    #
+    # What the drift actually was, measured on the day this landed: 114 route-level findings
+    # across 44 services. aml-service published request/response schemas whose fields exist
+    # nowhere in the code (#2312, fixed in #2317); copilot-service served the human-in-the-loop
+    # confirm for a money-path action proposal without publishing it (#2323) and declared a 501
+    # its streaming endpoint cannot return (#2351, fixed in #2353). Worst single pattern: 10 of
+    # the 15 services with an ApprovalResource serve PATCH /api/v1/<svc>/approvals/{id} — the
+    # four-eyes control — without publishing it, most of them money-path.
+    #
+    # ROUTE SET ONLY. It does not read schemas, so an invented request field passes clean (that
+    # was the whole aml defect); it does not read status codes, so a documented response the
+    # handler cannot produce passes clean. A reflection test is the floor, not the ceiling — the
+    # schema half needs the Quarkus-generated document
+    # (quarkus.smallrye-openapi.store-schema-directory, a dependency the whole fleet already has
+    # and nothing uses). Do not let a green here be read as "this spec is true".
+    #
+    # NOT diff-scoped, like db_backup_association and unlike api_contract/db_change: the defect
+    # is a MISSING pair across two trees, so a PR touching only Kotlin never touches the spec and
+    # a diff-scoped gate would see nothing.
+    #
+    # Advisory because 114 pre-existing findings cannot be a merge blocker on day one. Flipping
+    # to enforced = add --enforce in ci.yml, once the backlog is cleared.
   db_backup_association:
     detect: ["openbank-infra/gitops/**/*.yaml (kind: Cluster, postgresql.cnpg.io)"]
     require:


### PR DESCRIPTION
## Summary

Adds the spec-vs-code check this repo never had. ADR-0005 claims CI lints every `openapi.yaml`
with Spectral "so docs cannot drift from runtime" — there is no Spectral config in the tree and no
workflow references it. `check-api-contract.py` classifies a version bump between two revisions of
the *document* and never asks whether the document is true. This gate asks.

**114 route-level findings across 44 services** on the day it landed. Advisory, so it cannot block
a merge until the backlog is worked down.

## Type of change

- [x] chore (build / tooling)

## Linked issues

Refs #2314, #2358, #2313

## Changes

- `.github/scripts/check-openapi-route-conformance.py` — compares the (method, absolute path) set
  under `paths:` (resolved against `servers[0].url`) with the set read off the JAX-RS annotations.
  Reports `served-not-published` and `published-not-served`. stdlib-only, `--enforce` and
  `--service` flags.
- `.github/workflows/ci.yml` — advisory step in `Validate manifests`. Not diff-scoped: the defect is
  a missing pair across two trees, so a PR touching only Kotlin never touches the spec.
- `openbank-libs/governance/rules.yaml` — `openapi_route_conformance`, advisory,
  `target_enforce_date: 2026-09-30`.
- 66 gitops files — the usual `rules.yaml` ripple (38 generators embed and hash it). Generated, not
  hand-edited, verified idempotent on a second run.

## Reviewer notes — how this was falsified

A gate that has only ever passed is unfalsified, so this one was fed inputs it must flag:

| case | result |
|---|---|
| five known-clean services (aml, copilot, consent, dispute, sanctions) | silent |
| delete a served route from aml's spec | `served-not-published — PUT /api/v1/aml/cases/{caseId}/decision` |
| add a phantom path to aml's spec | `published-not-served — GET /api/v1/aml/cases/{caseId}/ghost` |
| `--enforce` on a dirty service | exit 1 |

**The first version was wrong and the known-clean check is what caught it.** It reset the annotation
cluster on the continuation lines of a multi-line `@Operation(...)`, losing the `@POST`/`@Path`
above them — so it reported copilot's confirm route as unserved, and the fleet count read 139. Now
parsed by paren depth; the real number is 114 and the 25 difference was entirely my parser.

Two conventions for `servers[0].url` are live in this tree and both are handled — a bare prefix
(`/api/v1`, copilot), an absolute URL with no path (`http://localhost:8117`, aml), and an absolute
URL that carries one (`https://…/customer/v1`, customer-edge). Getting this wrong is not a small
error: before the fix, customer-edge read as 52 spec-only + 99 code-only rather than 0 + 47.

`actionlint` finding sets were diffed branch vs `main` (1 = 1, nothing new) rather than eyeballing
the output, since a post-filtered linter run is how a self-inflicted YAML error hides.

## What it deliberately does not do

Route set only. It does not read schemas, so an invented request field passes clean — that was the
entire aml defect (#2312) — and it does not read status codes, so a documented response the handler
cannot produce passes clean, which was copilot's (#2351). The schema half needs the Quarkus-generated
document; `quarkus.smallrye-openapi.store-schema-directory` is already available fleet-wide and used
nowhere (#2314). **A green here means the route list agrees, nothing more**, and the script header
says so at length so nobody reads it as a truth certificate.

## Rollout / Rollback

- Deployment strategy: the OPA bundle annotations change, so pods roll across the fleet — unavoidable
  for any `rules.yaml` edit, and the bundle content is byte-identical apart from the embedded rules.
- Rollback plan: revert the commit and re-run the generators.
- Data migration reversible: N/A

**Short shelf life** — any competing PR touching `rules.yaml` or a `.rego` regenerates the same 44
bundle files and conflicts this one. Merge with `--auto`; if it conflicts, take `main`'s bundles
wholesale and re-run the generators rather than hand-resolving a checksum.

## Security checklist

- [x] No secrets, tokens, passwords, or PII.
- [x] No new third-party dependency (stdlib-only).
- [x] The new CI step interpolates no `${{ }}` expression, so it carries no workflow-injection surface.

## Compliance impact

- [x] DORA

Indirect and positive: the published contract for a regulated service is now mechanically compared
to what it serves. #2358 (the four-eyes approval endpoint missing from 10 specs, 8 money-path) is the
first finding this produced.
