### PR TITLE
docs(governance): publish the four-eyes approval endpoint on the ten services that serve it

### DIFF
--- a/openbank-account-service/src/main/resources/openapi.yaml
+++ b/openbank-account-service/src/main/resources/openapi.yaml
@@ -5,7 +5,7 @@ info:
   title: Account Service API
   # API-contract axis (ADR-0048) — bumps are classified from the OpenAPI diff,
   # independently of the release version in version.txt.
-  version: 1.4.0
+  version: 1.5.0
   description: BIAN-aligned account lifecycle management — open, query, freeze, close accounts.
   contact:
     name: OpenBank Platform
@@ -339,6 +339,57 @@ paths:
                 $ref: '#/components/schemas/AccountResponse'
         '403':
           $ref: '#/components/responses/Forbidden'
+
+  /api/v1/accounts/approvals/{id}:
+    patch:
+      tags: [Accounts]
+      summary: Approve or reject a pending four-eyes approval for a account lifecycle (ADR-0155)
+      description: >-
+        Decides an approval the platform's maker-checker gate paused. The checker is taken from the
+        authenticated principal, never from the body, and the store rejects a checker equal to the
+        maker. Requires ROLE_OPERATOR or ROLE_ADMIN.
+      operationId: decideApproval
+      parameters:
+        - name: id
+          in: path
+          required: true
+          schema:
+            type: string
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              type: object
+              required: [approve]
+              properties:
+                approve:
+                  type: boolean
+                  description: true approves the pending action, false rejects it.
+      responses:
+        '200':
+          description: The decided approval
+          content:
+            application/json:
+              schema:
+                type: object
+                required: [id, action, status]
+                properties:
+                  id:
+                    type: string
+                  action:
+                    type: string
+                    description: The gated action this approval was raised for.
+                  resourceId:
+                    type: string
+                    nullable: true
+                  status:
+                    type: string
+                  decidedBy:
+                    type: string
+                    nullable: true
+        '404':
+          $ref: '#/components/responses/NotFound'
 
 components:
   securitySchemes:

--- a/openbank-balance-service/src/main/resources/openapi.yaml
+++ b/openbank-balance-service/src/main/resources/openapi.yaml
@@ -3,7 +3,7 @@
 openapi: 3.1.0
 info:
   title: Balance Service API
-  version: 1.5.0
+  version: 1.6.0
   description: >-
     Account balance management — holds, credits, debits, multi-currency. Per ADR-0039 (Phase A) a
     read-only reconciliation ties out, per currency, the ledger deposit-control balance against the
@@ -233,6 +233,57 @@ paths:
           $ref: '#/components/responses/Forbidden'
         '404':
           description: No reconciliation has been run yet
+
+  /api/v1/balances/approvals/{id}:
+    patch:
+      tags: [Balances]
+      summary: Approve or reject a pending four-eyes approval for a balance adjustment (ADR-0155)
+      description: >-
+        Decides an approval the platform's maker-checker gate paused. The checker is taken from the
+        authenticated principal, never from the body, and the store rejects a checker equal to the
+        maker. Requires ROLE_OPERATOR or ROLE_ADMIN.
+      operationId: decideApproval
+      parameters:
+        - name: id
+          in: path
+          required: true
+          schema:
+            type: string
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              type: object
+              required: [approve]
+              properties:
+                approve:
+                  type: boolean
+                  description: true approves the pending action, false rejects it.
+      responses:
+        '200':
+          description: The decided approval
+          content:
+            application/json:
+              schema:
+                type: object
+                required: [id, action, status]
+                properties:
+                  id:
+                    type: string
+                  action:
+                    type: string
+                    description: The gated action this approval was raised for.
+                  resourceId:
+                    type: string
+                    nullable: true
+                  status:
+                    type: string
+                  decidedBy:
+                    type: string
+                    nullable: true
+        '404':
+          $ref: '#/components/responses/NotFound'
 
 components:
   securitySchemes:

--- a/openbank-balance-service/src/test/kotlin/com/openbank/balance/contract/ReconciliationContractTest.kt
+++ b/openbank-balance-service/src/test/kotlin/com/openbank/balance/contract/ReconciliationContractTest.kt
@@ -23,11 +23,13 @@ class ReconciliationContractTest {
     @Test
     fun `contract version is bumped for the reconciliation change`() {
         val version = Regex("""(?m)^\s+version:\s*"?([^"\s]+)"?\s*$""").find(openapi)?.groupValues?.get(1)
-        // 1.5.0: MINOR — ADR-0178 Phase 3 adds the optional, additive `futureValueDatedPipeline`
-        // property to CurrencyReconciliation (issue #1746). Backward compatible: no property removed,
-        // none made required, no behavior change. Previous 1.4.1 was an editorial bump for the 403
-        // Forbidden documentation added across every operation (ADR-0034 Phase 5, issue #266).
-        assertEquals("1.5.0", version)
+        // 1.6.0: MINOR — publishes PATCH /api/v1/balances/approvals/{id}, the ADR-0155 four-eyes
+        // decision point, which the service has always served and the contract never named
+        // (issue #2358). Additive: a path added, nothing removed or made required.
+        // 1.5.0 was ADR-0178 Phase 3 adding the optional `futureValueDatedPipeline` property to
+        // CurrencyReconciliation (issue #1746); 1.4.1 was an editorial bump for the 403 Forbidden
+        // documentation added across every operation (ADR-0034 Phase 5, issue #266).
+        assertEquals("1.6.0", version)
     }
 
     /**

--- a/openbank-clearing-service/src/main/resources/openapi.yaml
+++ b/openbank-clearing-service/src/main/resources/openapi.yaml
@@ -3,7 +3,7 @@
 openapi: 3.1.0
 info:
   title: Clearing Service API
-  version: 1.0.1
+  version: 1.1.0
   description: Payment clearing and settlement — batch submission, cycle triggering, position management.
   license:
     name: Apache-2.0
@@ -175,6 +175,57 @@ paths:
           description: Reconciliation found a discrepancy
         '403':
           description: Forbidden — OPA policy denied clearingBatch.reconcile (ADR-0034 Phase 5)
+
+  /api/v1/clearing/approvals/{id}:
+    patch:
+      tags: [Clearing]
+      summary: Approve or reject a pending four-eyes approval for a clearing (ADR-0155)
+      description: >-
+        Decides an approval the platform's maker-checker gate paused. The checker is taken from the
+        authenticated principal, never from the body, and the store rejects a checker equal to the
+        maker. Requires ROLE_OPERATOR or ROLE_ADMIN.
+      operationId: decideApproval
+      parameters:
+        - name: id
+          in: path
+          required: true
+          schema:
+            type: string
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              type: object
+              required: [approve]
+              properties:
+                approve:
+                  type: boolean
+                  description: true approves the pending action, false rejects it.
+      responses:
+        '200':
+          description: The decided approval
+          content:
+            application/json:
+              schema:
+                type: object
+                required: [id, action, status]
+                properties:
+                  id:
+                    type: string
+                  action:
+                    type: string
+                    description: The gated action this approval was raised for.
+                  resourceId:
+                    type: string
+                    nullable: true
+                  status:
+                    type: string
+                  decidedBy:
+                    type: string
+                    nullable: true
+        '404':
+          description: No pending approval with that id
 
 components:
   securitySchemes:

--- a/openbank-domestic-payment/src/main/resources/openapi.yaml
+++ b/openbank-domestic-payment/src/main/resources/openapi.yaml
@@ -3,7 +3,7 @@
 openapi: 3.1.0
 info:
   title: Domestic Payment Service API
-  version: 1.1.1
+  version: 1.2.0
   description: >-
     Czech domestic payment lifecycle (CZ-specific rails, SIPO). On create, debtor and creditor names
     are synchronously screened against the sanctions lists (ADR-0032): a clean payment is returned
@@ -119,6 +119,57 @@ paths:
           description: Updated payment
         '403':
           $ref: '#/components/responses/Forbidden'
+
+  /api/v1/domestic-payments/approvals/{id}:
+    patch:
+      tags: [Domestic Payments]
+      summary: Approve or reject a pending four-eyes approval for a domestic payment (ADR-0155)
+      description: >-
+        Decides an approval the platform's maker-checker gate paused. The checker is taken from the
+        authenticated principal, never from the body, and the store rejects a checker equal to the
+        maker. Requires ROLE_OPERATOR or ROLE_ADMIN.
+      operationId: decideApproval
+      parameters:
+        - name: id
+          in: path
+          required: true
+          schema:
+            type: string
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              type: object
+              required: [approve]
+              properties:
+                approve:
+                  type: boolean
+                  description: true approves the pending action, false rejects it.
+      responses:
+        '200':
+          description: The decided approval
+          content:
+            application/json:
+              schema:
+                type: object
+                required: [id, action, status]
+                properties:
+                  id:
+                    type: string
+                  action:
+                    type: string
+                    description: The gated action this approval was raised for.
+                  resourceId:
+                    type: string
+                    nullable: true
+                  status:
+                    type: string
+                  decidedBy:
+                    type: string
+                    nullable: true
+        '404':
+          $ref: '#/components/responses/NotFound'
 
 components:
   securitySchemes:

--- a/openbank-ledger-service/src/main/resources/openapi.yaml
+++ b/openbank-ledger-service/src/main/resources/openapi.yaml
@@ -3,7 +3,7 @@
 openapi: 3.1.0
 info:
   title: Ledger Service API
-  version: 1.8.0
+  version: 1.9.0
   description: Double-entry journal ledger — query journal entries and transaction postings.
   license:
     name: Apache-2.0
@@ -454,6 +454,57 @@ paths:
           $ref: '#/components/responses/Unauthorized'
         '403':
           $ref: '#/components/responses/Forbidden'
+        '404':
+          $ref: '#/components/responses/NotFound'
+
+  /api/v1/journals/approvals/{id}:
+    patch:
+      tags: [Ledger]
+      summary: Approve or reject a pending four-eyes approval for a ledger journal (ADR-0155)
+      description: >-
+        Decides an approval the platform's maker-checker gate paused. The checker is taken from the
+        authenticated principal, never from the body, and the store rejects a checker equal to the
+        maker. Requires ROLE_OPERATOR or ROLE_ADMIN.
+      operationId: decideApproval
+      parameters:
+        - name: id
+          in: path
+          required: true
+          schema:
+            type: string
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              type: object
+              required: [approve]
+              properties:
+                approve:
+                  type: boolean
+                  description: true approves the pending action, false rejects it.
+      responses:
+        '200':
+          description: The decided approval
+          content:
+            application/json:
+              schema:
+                type: object
+                required: [id, action, status]
+                properties:
+                  id:
+                    type: string
+                  action:
+                    type: string
+                    description: The gated action this approval was raised for.
+                  resourceId:
+                    type: string
+                    nullable: true
+                  status:
+                    type: string
+                  decidedBy:
+                    type: string
+                    nullable: true
         '404':
           $ref: '#/components/responses/NotFound'
 

--- a/openbank-lending-service/src/main/resources/openapi.yaml
+++ b/openbank-lending-service/src/main/resources/openapi.yaml
@@ -3,7 +3,7 @@
 openapi: 3.1.0
 info:
   title: Lending Service API
-  version: 1.2.0
+  version: 1.3.0
   description: >-
     Loan origination, servicing, collateral and IFRS 9 provisioning (ADR-0028). The loan book posts
     cash events to ledger-service and never owns balances. Credit decisions and collateral
@@ -267,6 +267,57 @@ paths:
         '403':
           $ref: '#/components/responses/Forbidden'
         '404': { description: Not found }
+  /api/v1/lending/approvals/{id}:
+    patch:
+      tags: [Lending]
+      summary: Approve or reject a pending four-eyes approval for a lending (ADR-0155)
+      description: >-
+        Decides an approval the platform's maker-checker gate paused. The checker is taken from the
+        authenticated principal, never from the body, and the store rejects a checker equal to the
+        maker. Requires ROLE_OPERATOR or ROLE_ADMIN.
+      operationId: decideApproval
+      parameters:
+        - name: id
+          in: path
+          required: true
+          schema:
+            type: string
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              type: object
+              required: [approve]
+              properties:
+                approve:
+                  type: boolean
+                  description: true approves the pending action, false rejects it.
+      responses:
+        '200':
+          description: The decided approval
+          content:
+            application/json:
+              schema:
+                type: object
+                required: [id, action, status]
+                properties:
+                  id:
+                    type: string
+                  action:
+                    type: string
+                    description: The gated action this approval was raised for.
+                  resourceId:
+                    type: string
+                    nullable: true
+                  status:
+                    type: string
+                  decidedBy:
+                    type: string
+                    nullable: true
+        '404':
+          description: No pending approval with that id
+
 components:
   securitySchemes:
     bearerAuth:

--- a/openbank-sepa-instant/src/main/resources/openapi.yaml
+++ b/openbank-sepa-instant/src/main/resources/openapi.yaml
@@ -3,7 +3,7 @@
 openapi: 3.1.0
 info:
   title: SEPA Instant (SCT Inst) Service API
-  version: 1.1.1
+  version: 1.2.0
   description: >-
     SEPA Instant Credit Transfer — sub-10s settlement, recall support. On submit, debtor and creditor
     names are synchronously screened against the sanctions lists (ADR-0032): a clean payment proceeds
@@ -111,6 +111,57 @@ paths:
           description: Recall initiated
         '403':
           $ref: '#/components/responses/Forbidden'
+
+  /api/v1/sepa-instant/approvals/{id}:
+    patch:
+      tags: [SCT Inst]
+      summary: Approve or reject a pending four-eyes approval for a SCT Inst payment (ADR-0155)
+      description: >-
+        Decides an approval the platform's maker-checker gate paused. The checker is taken from the
+        authenticated principal, never from the body, and the store rejects a checker equal to the
+        maker. Requires ROLE_OPERATOR or ROLE_ADMIN.
+      operationId: decideApproval
+      parameters:
+        - name: id
+          in: path
+          required: true
+          schema:
+            type: string
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              type: object
+              required: [approve]
+              properties:
+                approve:
+                  type: boolean
+                  description: true approves the pending action, false rejects it.
+      responses:
+        '200':
+          description: The decided approval
+          content:
+            application/json:
+              schema:
+                type: object
+                required: [id, action, status]
+                properties:
+                  id:
+                    type: string
+                  action:
+                    type: string
+                    description: The gated action this approval was raised for.
+                  resourceId:
+                    type: string
+                    nullable: true
+                  status:
+                    type: string
+                  decidedBy:
+                    type: string
+                    nullable: true
+        '404':
+          $ref: '#/components/responses/NotFound'
 
 components:
   securitySchemes:

--- a/openbank-sepa-payment/src/main/resources/openapi.yaml
+++ b/openbank-sepa-payment/src/main/resources/openapi.yaml
@@ -3,7 +3,7 @@
 openapi: 3.1.0
 info:
   title: SEPA Payment Service API
-  version: 1.2.1
+  version: 1.3.0
   description: >-
     SEPA credit transfer lifecycle — create, query, status transitions. On create, debtor and
     creditor names are synchronously screened against the sanctions lists (ADR-0032): a clean payment
@@ -161,6 +161,57 @@ paths:
                 $ref: '#/components/schemas/SepaPaymentResponse'
         '403':
           $ref: '#/components/responses/Forbidden'
+
+  /api/v1/sepa-payments/approvals/{id}:
+    patch:
+      tags: [SEPA Payments]
+      summary: Approve or reject a pending four-eyes approval for a SEPA payment (ADR-0155)
+      description: >-
+        Decides an approval the platform's maker-checker gate paused. The checker is taken from the
+        authenticated principal, never from the body, and the store rejects a checker equal to the
+        maker. Requires ROLE_OPERATOR or ROLE_ADMIN.
+      operationId: decideApproval
+      parameters:
+        - name: id
+          in: path
+          required: true
+          schema:
+            type: string
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              type: object
+              required: [approve]
+              properties:
+                approve:
+                  type: boolean
+                  description: true approves the pending action, false rejects it.
+      responses:
+        '200':
+          description: The decided approval
+          content:
+            application/json:
+              schema:
+                type: object
+                required: [id, action, status]
+                properties:
+                  id:
+                    type: string
+                  action:
+                    type: string
+                    description: The gated action this approval was raised for.
+                  resourceId:
+                    type: string
+                    nullable: true
+                  status:
+                    type: string
+                  decidedBy:
+                    type: string
+                    nullable: true
+        '404':
+          $ref: '#/components/responses/NotFound'
 
 components:
   securitySchemes:

--- a/openbank-swift-service/src/main/resources/openapi.yaml
+++ b/openbank-swift-service/src/main/resources/openapi.yaml
@@ -6,7 +6,7 @@ openapi: "3.1.0"
 
 info:
   title: OpenBank SWIFT Service API
-  version: "1.0.1"
+  version: "1.1.0"
   description: |
     SWIFT MT/MX message dispatch, acknowledgement, and status tracking.
     Supports MT103 (customer credit transfer), MT202 (bank transfer), MT900/910/940/950 (confirmations/statements).
@@ -213,6 +213,57 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/ErrorResponse'
+
+  /api/v1/swift/approvals/{id}:
+    patch:
+      tags: [swift]
+      summary: Approve or reject a pending four-eyes approval for a SWIFT message (ADR-0155)
+      description: >-
+        Decides an approval the platform's maker-checker gate paused. The checker is taken from the
+        authenticated principal, never from the body, and the store rejects a checker equal to the
+        maker. Requires ROLE_OPERATOR or ROLE_ADMIN.
+      operationId: decideApproval
+      parameters:
+        - name: id
+          in: path
+          required: true
+          schema:
+            type: string
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              type: object
+              required: [approve]
+              properties:
+                approve:
+                  type: boolean
+                  description: true approves the pending action, false rejects it.
+      responses:
+        '200':
+          description: The decided approval
+          content:
+            application/json:
+              schema:
+                type: object
+                required: [id, action, status]
+                properties:
+                  id:
+                    type: string
+                  action:
+                    type: string
+                    description: The gated action this approval was raised for.
+                  resourceId:
+                    type: string
+                    nullable: true
+                  status:
+                    type: string
+                  decidedBy:
+                    type: string
+                    nullable: true
+        '404':
+          $ref: '#/components/responses/NotFound'
 
 components:
   schemas:

--- a/openbank-transaction-service/src/main/resources/openapi.yaml
+++ b/openbank-transaction-service/src/main/resources/openapi.yaml
@@ -7,7 +7,7 @@ info:
   # version.txt — classified from the OpenAPI diff, never forced equal to it. The two have not
   # been in lockstep for a long time (version.txt is 1.14.2); the note that used to claim they
   # were invited exactly the wrong "fix".
-  version: 1.8.0
+  version: 1.9.0
   description: BIAN-aligned transaction history, search and retrieval.
   license:
     name: Apache-2.0
@@ -238,6 +238,57 @@ paths:
           $ref: '#/components/responses/NotFound'
         '422':
           description: Transaction is not in COMPLETED status and cannot be reversed
+
+  /api/v1/transactions/approvals/{id}:
+    patch:
+      tags: [Transactions]
+      summary: Approve or reject a pending four-eyes approval for a transaction (ADR-0155)
+      description: >-
+        Decides an approval the platform's maker-checker gate paused. The checker is taken from the
+        authenticated principal, never from the body, and the store rejects a checker equal to the
+        maker. Requires ROLE_OPERATOR or ROLE_ADMIN.
+      operationId: decideApproval
+      parameters:
+        - name: id
+          in: path
+          required: true
+          schema:
+            type: string
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              type: object
+              required: [approve]
+              properties:
+                approve:
+                  type: boolean
+                  description: true approves the pending action, false rejects it.
+      responses:
+        '200':
+          description: The decided approval
+          content:
+            application/json:
+              schema:
+                type: object
+                required: [id, action, status]
+                properties:
+                  id:
+                    type: string
+                  action:
+                    type: string
+                    description: The gated action this approval was raised for.
+                  resourceId:
+                    type: string
+                    nullable: true
+                  status:
+                    type: string
+                  decidedBy:
+                    type: string
+                    nullable: true
+        '404':
+          $ref: '#/components/responses/NotFound'
 
 components:
   securitySchemes:


### PR DESCRIPTION
## Summary

Every service with an `ApprovalResource` serves `PATCH /api/v1/<svc>/approvals/{id}` — the ADR-0155
maker-checker decision point. Ten of the fifteen never published it. Eight are money-path services.
This is the copilot defect (#2323) repeated ten times on higher-value paths: the control an auditor,
an integrator or an operator console has to know about was absent from the document those parties
build against.

Found by `check-openapi-route-conformance.py`, the gate added in #2360.

## Type of change

- [x] docs

## Linked issues

Closes #2358
Refs #2314, #2360

## Changes

Published the endpoint on: **account, balance, clearing, domestic-payment, ledger, lending,
sepa-instant, sepa-payment, swift, transaction**, each with a MINOR `info.version` bump per
ADR-0048 D5.

| | |
|---|---|
| 1.4.0 → 1.5.0 | account |
| 1.5.0 → 1.6.0 | balance |
| 1.0.1 → 1.1.0 | clearing, swift |
| 1.1.1 → 1.2.0 | domestic-payment, sepa-instant |
| 1.8.0 → 1.9.0 | ledger, transaction |
| 1.2.0 → 1.3.0 | lending |
| 1.2.1 → 1.3.0 | sepa-payment |

## Reviewer notes

**"They are all the same shape" was checked, not assumed — and the first version of that claim was
wrong.** Hashing each whole `ApprovalResource` class gives fifteen distinct values, so I nearly
templated from a false premise. Hashing just the DTO pair gives **one** value across all ten
(`6a0b4465`): identical `DecideApprovalRequest {approve: Boolean}`, identical
`ApprovalResponse {id, action, resourceId?, status, decidedBy?}`, identical 200/404. The class-level
differences are only the path prefix, the roles, and the `@Authorize` action name. The contract is
uniform; the class is not.

**The published block documents the response schema**, which the five already-published specs
(billing, consent, fx, notification, sanctions) do not — `fx` gives `'200'` a bare description. The
DTO is known, so describing it is strictly better and still additive. The two specs with no reusable
`NotFound` response (clearing, lending) get an inline 404 description instead of a dangling `$ref`.

Verified three independent ways:

| check | result |
|---|---|
| YAML parse | 10/10 |
| `oasdiff breaking` vs `main` | **ERR 0** on each of the ten |
| `check-api-contract.py --enforce` | `additive` ×10, exit 0 |
| conformance gate fleet count | **114 → 104**, zero `approvals/{id}` findings left anywhere |

The count moving by *exactly ten* is the check that matters — a per-service "0 findings" alone does
not distinguish fixed from unmeasured.

Adding a path is additive, so unlike the aml correction (#2317) **none of these hits the #2313
wall** and no `GATE-CONSTRAINED` prose was needed.

**No release.** Type `docs`, so the release axis does not move: this documents already-shipped
behaviour and changes no code. ADR-0048 D1 makes the axes independent, and the contract axis — the
one that actually records an API change — is bumped on all ten.

**Out of scope on purpose:** several of these specs also declare the wrong dev server port (ledger
says 8107, binds 8101). That is the #2314 backlog; keeping it out leaves this PR one defect class.

Unrelated pre-existing finding surfaced while sweeping the gates locally, not touched here:
`check-prompt-registry.py` fails on `main` because #2321 added
`prompts/control-liveness-sentinel/system.v2.md` without registering it. It is advisory in ci.yml
(`continue-on-error: true`), which is why nothing went red — worth its own fix, since the
unregistered file is the *security-hardened* prompt.

## Definition of Done

- [x] Hexagonal layering preserved (no Kotlin changed).
- [ ] Unit tests — N/A, documentation of existing endpoints. The route set is now guarded by the
      #2360 conformance gate, which is what found this.
- [x] OpenAPI spec updated + `info.version` bumped on every affected service.

## Security checklist

- [x] No secrets, tokens, passwords, or PII.
- [x] No new dependency, no code change.

## Compliance impact

- [x] DORA
- [x] PSD2 / SCA / RTS

Positive and documentation-only: the four-eyes control on eight money-path services is now part of
the published contract instead of being discoverable only by reading the source.

## Rollout / Rollback

- Deployment strategy: rolling; no runtime behaviour change (the spec ships inside the artifact).
- Rollback plan: revert the commit.
- Data migration reversible: N/A
