### PR TITLE
docs(liveness): register the control-liveness-sentinel system.v2 prompt + enforce the gate (#1918)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -416,12 +416,26 @@ jobs:
 
       # ADR-0148: the prompt registry (openbank-libs/governance/prompts/) must stay resolvable —
       # every prompt file names a real charter, uses <name>.v<N>.md, is non-empty, and never
-      # re-uses a shipped version (a prompt is immutable, like a Flyway migration). ADVISORY first
-      # (ADR-0144): coverage gaps are ::warning while services still hold inline prompt constants;
-      # graduate to enforced (drop continue-on-error) once they load from the registry and a
-      # deployed prompt_hash can be resolved. Structural corruption still exits non-zero.
-      - name: "prompt-registry integrity (ADR-0148, advisory)"
-        continue-on-error: true
+      # re-uses a shipped version (a prompt is immutable, like a Flyway migration).
+      #
+      # ENFORCED (was advisory). What the advisory period actually bought: nothing. It went red on
+      # main from cffc5ff9 (#2321) until #2363 — the PR that added the injection-hardened
+      # system.v2.md left it unlisted in registry.yaml, so the one prompt written specifically to
+      # resist prompt injection sat outside the reviewed set, and continue-on-error meant no PR
+      # ever saw it. Coverage gaps were never the failing half; they are ::warning by construction
+      # inside the script (`pending` charters), and stay that way after this flip. Everything that
+      # exits non-zero here is structural and fixable in the same PR that breaks it: a prompt for a
+      # charter that does not exist in agents.yaml, a malformed filename, an empty file, a re-used
+      # version, or a registry.yaml claim that contradicts the tree. So the original graduation
+      # condition ("once services load from the registry and a deployed prompt_hash resolves") was
+      # never a precondition for THESE errors — it gates the byte-for-byte parity check, which this
+      # script does not yet perform (2 of 5 registered charters load from the registry today:
+      # devops-agent #2240, control-liveness-sentinel #2321).
+      #
+      # This step runs in `Validate manifests`, a required check, so it now blocks merge — and that
+      # job stops at its first failing gate, leaving later steps `skipped`, not `pass`. Run it
+      # locally before pushing: python3 .github/scripts/check-prompt-registry.py
+      - name: "prompt-registry integrity (ADR-0148, enforced)"
         run: python3 .github/scripts/check-prompt-registry.py
 
       # ADR-0148 evals gate — structure check. The eval registry

--- a/openbank-control-liveness-sentinel/src/main/kotlin/com/openbank/liveness/infrastructure/adapter/LlmDiagnosisAdapter.kt
+++ b/openbank-control-liveness-sentinel/src/main/kotlin/com/openbank/liveness/infrastructure/adapter/LlmDiagnosisAdapter.kt
@@ -19,7 +19,7 @@ import jakarta.inject.Inject
  *    deterministic placeholder exactly as before; the adapter is now injectable, so an eval can
  *    drive it with a stub gateway.
  *  - The system prompt is loaded from the ADR-0148 prompt registry (the
- *    control-liveness-sentinel `system.v1.md` file), packaged at build time (see
+ *    control-liveness-sentinel `system.v2.md` file), packaged at build time (see
  *    build.gradle.kts) and read verbatim, so the runtime prompt equals the registered content
  *    byte-for-byte — the `prompt_hash` in an AI-attributed AuditEvent now resolves.
  *

--- a/openbank-libs/governance/prompts/README.md
+++ b/openbank-libs/governance/prompts/README.md
@@ -55,17 +55,22 @@ control-liveness-sentinel), **6 pending** (the stub ops-agents, ADR-0164–0168 
 coding-agent session), **2 not-applicable** (mcp-anonymous, ap2-anonymous — identity-only
 principals).
 
-| File | Source (to be replaced by a registry load) |
-|---|---|
-| `compliance-officer/oversight.v1.md` | `OversightService.systemPrompt()` |
-| `ui-assistant/system.v1.md` | `AgentChatService.systemPrompt()` |
-| `customer-copilot/system.v1.md` | `CopilotChatService.systemPrompt()` |
-| `devops-agent/diagnosis.v1.md` | `LlmDiagnosisAdapter.DIAGNOSIS_SYSTEM` |
-| `devops-agent/remediation.v1.md` | `LlmDiagnosisAdapter.REMEDIATION_SYSTEM` |
-| `control-liveness-sentinel/system.v1.md` | `LlmDiagnosisAdapter.SYSTEM_PROMPT` |
+| File | Source | Loaded from here? |
+|---|---|---|
+| `compliance-officer/oversight.v1.md` | `OversightService.systemPrompt()` | no — inline constant |
+| `ui-assistant/system.v1.md` | `AgentChatService.systemPrompt()` | no — inline constant |
+| `customer-copilot/system.v1.md` | `CopilotChatService.systemPrompt()` | no — inline constant |
+| `devops-agent/diagnosis.v1.md` | `LlmDiagnosisAdapter.DIAGNOSIS_SYSTEM` | yes (#2240) |
+| `devops-agent/remediation.v1.md` | `LlmDiagnosisAdapter.REMEDIATION_SYSTEM` | yes (#2240) |
+| `control-liveness-sentinel/system.v1.md` | `LlmDiagnosisAdapter.SYSTEM_PROMPT` | superseded by v2 |
+| `control-liveness-sentinel/system.v2.md` | `LlmDiagnosisAdapter.SYSTEM_PROMPT` | yes (#2321) |
 
-The services still hold the inline constant; wiring them to load from here is the ADR-0148 code
-follow-up.
+The remaining three services still hold the inline constant; wiring them to load from here is the
+ADR-0148 code follow-up.
+
+A superseded file stays in the tree and in `registry.yaml`: a shipped prompt is immutable, and an
+AuditEvent written while it was live carries its `prompt_hash` — delisting the file makes that hash
+unresolvable, which defeats the record-keeping property the registry exists for.
 
 ### Templated prompts
 

--- a/openbank-libs/governance/prompts/registry.yaml
+++ b/openbank-libs/governance/prompts/registry.yaml
@@ -69,8 +69,14 @@ charters:
 
   - id: control-liveness-sentinel
     status: registered
-    prompts: [system.v1]
-    source: openbank-control-liveness-sentinel LlmDiagnosisAdapter.SYSTEM_PROMPT
+    prompts: [system.v1, system.v2]
+    # v2 is what the adapter loads today (see the resource path in loadRegisteredPrompt): it forbids
+    # emitting a concrete, copy-pasteable remediation command anywhere in the output, after the
+    # #1918 evals gate caught v1 partially complying with an injected `kubectl scale --replicas=0`.
+    # v1 stays listed and on disk because a shipped prompt is immutable — an AuditEvent written
+    # while v1 was live carries its prompt_hash, and delisting the file makes that hash unresolvable,
+    # which is the exact EU AI Act Art. 12 property this registry exists to hold.
+    source: openbank-control-liveness-sentinel LlmDiagnosisAdapter.SYSTEM_PROMPT (loads system.v2)
     placeholders: []
 
   - id: rca-investigator


### PR DESCRIPTION
## What

Two commits, deliberately in this order.

**1. Register `system.v2`.** `cffc5ff9` ("security(liveness): strengthen the control-liveness-sentinel prompt against injected remediation commands", #2321) added `openbank-libs/governance/prompts/control-liveness-sentinel/system.v2.md` and repointed `LlmDiagnosisAdapter.loadRegisteredPrompt()` at it, but left the registry entry at `prompts: [system.v1]`. `.github/scripts/check-prompt-registry.py` has been red on `origin/main` ever since:

```
::error title=Prompt registry::prompts/control-liveness-sentinel/system.v2.md exists but is not listed in registry.yaml (control-liveness-sentinel.prompts) — an unlisted prompt is outside the reviewed set
```

**Worth stating plainly:** the unregistered file is the *security-hardened* prompt. The file that exists specifically to resist prompt injection — it forbids emitting a copy-pasteable `kubectl`/`helm`/SQL command and declares alert telemetry untrusted — is the one that was sitting outside the reviewed set.

**2. Enforce the gate.** Nothing went red because the `ci.yml` step *prompt-registry integrity (ADR-0148, advisory)* set `continue-on-error: true`. That is the whole yield of the advisory period: a gate that correctly detected a real security-relevant drift, for a month, addressed to nobody. `continue-on-error` is dropped and the step renamed `(ADR-0148, enforced)`.

## Why the documented graduation condition does not block the flip

The old comment said graduate "once services load from the registry and a deployed `prompt_hash` can be resolved". That condition gates the **byte-for-byte parity check**, which this script does not perform (its own header lists it under "not yet checked"). Everything the script actually exits non-zero on is structural and fixable inside the PR that breaks it:

- a prompt directory for a charter absent from `agents.yaml`
- a filename that is not `<name>.v<N>.md`
- an empty prompt file
- a re-used version (a shipped prompt is immutable, like a Flyway migration)
- a `registry.yaml` claim that contradicts the tree

The half that genuinely waits on the migration — **coverage** — is `::warning` inside the script (`pending` charters) and stays advisory after this flip. Today: 2 of 5 registered charters load from the registry (devops-agent #2240, control-liveness-sentinel #2321); the other 3 still hold inline constants and produce no error.

## Ordering

The step runs in `Validate manifests`, which **is** one of the five required checks (`all-green`, `Validate manifests`, `Gitleaks`, `issue-hygiene`, `OPA policy gate`). Enforcing it while `main` is red would block every open PR on an error none of them introduced — the SBOM Audit→Enforce shape. So the fix and the flip ride the same PR: commit 1 makes the gate green, commit 2 gives it teeth, and there is no window where `main` is both enforcing and failing. Note also that `Validate manifests` stops at its first failing gate, so a violation now leaves every later step `skipped`, not `pass`.

## Changes

- **`registry.yaml`** — `prompts: [system.v1, system.v2]`, and `source:` names which version the adapter loads. **v1 is retained, not replaced:** a shipped prompt is immutable, and an AuditEvent written while v1 was live carries its `prompt_hash`; delisting the file makes that hash unresolvable, defeating the EU AI Act Art. 12 record-keeping property the registry exists for.
- **`ci.yml`** — drop `continue-on-error`, rename the step, and replace the stale graduation comment with what is actually enforced vs still advisory.
- **`LlmDiagnosisAdapter`** — the class KDoc said it loads `system.v1.md` while `loadRegisteredPrompt()` reads `system.v2.md`. Comment only; no behaviour change.
- **`prompts/README.md`** — the file table listed only `system.v1` and claimed the services "still hold the inline constant", stale since #2240 and #2321. Now records per-file whether it is loaded from here.

`placeholders: []` stays correct — the prompt is read verbatim, no substitution. `registry.yaml` has no `prompt_hash` field (the checker prints a digest, it stores none), so nothing else needed updating.

## Verification

```
python3 .github/scripts/check-prompt-registry.py
prompt-registry: 7 prompt(s) across 5 charter(s), integrity OK; coverage across 15 charter(s): 2 external, 2 not-applicable, 6 pending, 5 registered.
EXIT=0
```

Falsified against a known-positive before trusting the green: with `prompts: [system.v2]` (v1 delisted) the gate raises the mirror-image error for `system.v1.md` and exits 1. So the 0-violation result is a check that ran, not a check that stopped checking.

`actionlint` and `yamllint` under the CI job's own inline config report **identical finding sets** to `origin/main` (0 errors) — the flip adds no workflow-lint debt.

## Not in scope

- The sibling `evals-registry integrity (ADR-0148, advisory)` step is untouched.
- No `rules.yaml` entry. The prompt registry has no rule there today, and editing `rules.yaml` restamps every service's OPA bundle (~44 files) — a governance-record change that deserves its own PR rather than riding a gate flip.

## Linked issues

Refs #1918