### PR TITLE
fix(ci): stop the api-contract gate demanding a MAJOR bump it also forbids

### DIFF
--- a/.github/scripts/check-api-contract.py
+++ b/.github/scripts/check-api-contract.py
@@ -4,9 +4,20 @@
 For every `openbank-*/src/main/resources/openapi.yaml` changed against the PR
 base, classify the API-contract change from the OpenAPI diff (oasdiff):
 
-    breaking  => info.version MAJOR must move (new URL major, /api/v{N+1})
-    additive  => info.version MINOR (or MAJOR) must move within the same /v{N}
-    editorial => info.version PATCH (or higher) must move
+    breaking   => info.version MAJOR must move (new URL major, /api/v{N+1})
+    correction => a breaking DOCUMENT diff in a PR that changes nothing else in the service:
+                  the served contract is unchanged, so MINOR (see below)
+    additive   => info.version MINOR (or MAJOR) must move within the same /v{N}
+    editorial  => info.version PATCH (or higher) must move
+
+The `correction` class exists because `breaking` and the D2 invariant below are jointly
+unsatisfiable for a spec that never described the running service. Correcting one is red at
+the old version (oasdiff calls it breaking, a MAJOR is demanded) and red at MAJOR+1 (D2 rejects
+it, the served URL major has not moved). Measured both ends on aml-service, #2312/#2313: the
+only green document was one that kept a phantom enum value and a wrong default, so the gate was
+not merely blocking the fix, it was requiring the falsehood. A spec-only PR cannot break a
+working client — the server is byte-identical — so the MAJOR requirement is dropped to MINOR.
+The discriminator is the diff itself, never a declared marker.
 
 and assert the ADR-0048 D2 API invariant on the head revision:
 
@@ -173,17 +184,30 @@ def oasdiff_classify(oasdiff: str, old: Path, new: Path) -> tuple[str, list[str]
     return "none", []
 
 
-REQUIRED_BUMP = {"breaking": "MAJOR", "additive": "MINOR", "editorial": "PATCH"}
+REQUIRED_BUMP = {"breaking": "MAJOR", "correction": "MINOR", "additive": "MINOR", "editorial": "PATCH"}
 
 
 def bump_satisfied(kind: str, old_v: tuple[int, int, int], new_v: tuple[int, int, int]) -> bool:
     if kind == "breaking":
         return new_v[0] > old_v[0]
-    if kind == "additive":
+    if kind in ("additive", "correction"):
         return new_v[0] > old_v[0] or (new_v[0] == old_v[0] and new_v[1] > old_v[1])
     if kind == "editorial":
         return new_v > old_v
     return True
+
+
+# Derived files that cannot change what the service serves, so their presence in a diff does
+# not disqualify a spec correction. release-please writes both.
+BEHAVIOURLESS = {"CHANGELOG.md", "version.txt"}
+
+
+def service_touched_beyond_spec(service: str, spec_rel: str, changed_all: list[str]) -> list[str]:
+    """Files in this service the PR changed other than its openapi.yaml (and derived files)."""
+    return [
+        f for f in changed_all
+        if f.startswith(service + "/") and f != spec_rel and f.rsplit("/", 1)[-1] not in BEHAVIOURLESS
+    ]
 
 
 def main() -> int:
@@ -200,10 +224,8 @@ def main() -> int:
     level = "error" if args.enforce else "warning"
     findings: list[str] = []
 
-    changed = [
-        line for line in sh("git", "diff", "--name-only", args.base, "HEAD").splitlines()
-        if OPENAPI_GLOB.match(line)
-    ]
+    changed_all = sh("git", "diff", "--name-only", args.base, "HEAD").splitlines()
+    changed = [line for line in changed_all if OPENAPI_GLOB.match(line)]
     if not changed:
         print("api-contract gate: no openapi.yaml changed — nothing to classify.")
         return 0
@@ -245,6 +267,44 @@ def main() -> int:
                 kind = None
             finally:
                 old_path.unlink(missing_ok=True)
+
+            # A breaking DOCUMENT diff is not a breaking CONTRACT change when the PR changed
+            # nothing else in the service: the running server is byte-identical, so no client
+            # that works today can stop working. What breaks is a client generated from a
+            # document that never described this server — already broken before the edit.
+            # Demanding a MAJOR bump there is not merely strict, it is unsatisfiable: D2 below
+            # requires major(info.version) == the served URL major, which a spec-only PR cannot
+            # move. Measured on aml (#2312/#2313): red at 1.0.0 for want of a MAJOR, red at
+            # 2.0.0 for violating D2, and the only green spec was one that kept a phantom enum
+            # value and a wrong default.
+            #
+            # The discriminator is mechanical, not declared — no marker file, no PR-body token
+            # to assert a spec "was never served". Touch any other file in the service and the
+            # normal breaking rule applies unchanged.
+            #
+            # This opens no new hole. Landing a genuinely breaking change as code-only in one PR
+            # and the spec in another already escapes this gate entirely, because it is scoped to
+            # spec diffs and the first PR has none. What the reclassification does NOT check is
+            # whether the corrected document is true — that is openapi-route-conformance for the
+            # route set, and still nothing for schemas.
+            if kind == "breaking":
+                others = service_touched_beyond_spec(service, rel, changed_all)
+                if not others:
+                    detail = f" (first: {breaking[0]})" if breaking else ""
+                    print(
+                        f"::notice::api-contract gate: {service}: spec-only PR — reclassifying "
+                        f"{len(breaking)} breaking document change(s){detail} as a CORRECTION. "
+                        f"No other file in {service} changed, so the served contract is unchanged "
+                        f"and a MAJOR bump would violate the ADR-0048 D2 URL-major invariant. "
+                        f"Requiring MINOR instead."
+                    )
+                    kind = "correction"
+                else:
+                    print(
+                        f"api-contract gate: {service}: breaking, and the PR also changes "
+                        f"{len(others)} other file(s) in the service (e.g. {others[0]}) — "
+                        f"treating as a real contract change."
+                    )
 
             if kind is None:
                 pass  # unloadable spec already reported; invariant checks below still run

--- a/openbank-infra/gitops/components/accounts/account-opa-bundle.yaml
+++ b/openbank-infra/gitops/components/accounts/account-opa-bundle.yaml
@@ -9,7 +9,7 @@ metadata:
     app.kubernetes.io/name: account-service
     app.kubernetes.io/part-of: accounts
   annotations:
-    openbank.tech/policy-checksum: "b17ce021f6c1ea11"
+    openbank.tech/policy-checksum: "3d968d4c22d93cc3"
 data:
   rest.rego: |
     # SPDX-License-Identifier: Apache-2.0
@@ -1550,6 +1550,37 @@ data:
         # spec-touching PR (bump info.version to match what the diff did), which the error
         # message spells out.
         ci_producer: ".github/scripts/check-api-contract.py"
+        # A fourth class, `correction`, sits between breaking and additive: a breaking DOCUMENT diff
+        # in a PR that changes NOTHING ELSE in the service. It requires MINOR, not MAJOR.
+        #
+        # Why it had to exist. `breaking` and the D2 invariant are jointly unsatisfiable for a spec
+        # that never described the running service. Measured on aml-service (#2312/#2313) with the
+        # pinned oasdiff: red at 1.0.0 because a MAJOR is demanded, red at 2.0.0 because D2 rejects a
+        # major the served URL has not moved to. There is no third value. Worse, the only document
+        # that went green was one that kept a phantom `status` enum value and a `default` the server
+        # does not use — the gate was not merely blocking the correction, it was requiring the
+        # falsehood, and aml shipped four GATE-CONSTRAINED concessions because of it.
+        #
+        # Why it is safe. A spec-only PR leaves the running server byte-identical, so no client that
+        # works today can stop working; what "breaks" is a client generated from a document that
+        # never described this server, and that client was already broken. Touch any other file in
+        # the service — Kotlin, application.yaml, a test — and the normal breaking rule applies
+        # unchanged. Only CHANGELOG.md and version.txt are exempt, because release-please writes them
+        # and neither can change what is served.
+        #
+        # Why it is not an escape hatch. The discriminator is the diff, not a declaration: there is no
+        # marker file and no PR-body token asserting that a spec "was never served". ~22 specs are
+        # correction candidates (#2314), so anything a human asserts once would become the default
+        # path 22 times over.
+        #
+        # It opens no new hole: landing a breaking change as code in one PR and the spec in another
+        # already escapes this gate, which is scoped to spec diffs. What it does NOT check is whether
+        # the corrected document is TRUE — openapi_route_conformance (below) covers the route set,
+        # and nothing yet covers schemas.
+        #
+        # Unit tests: openbank-infra/scripts/check_api_contract_test.py, run by the
+        # "governance-script unit tests" CI step. The negative cases are the point — a
+        # reclassification that fires too eagerly disables the gate for real breaking changes.
       openapi_route_conformance:
         detect: ["openbank-*/src/main/resources/openapi.yaml", "JAX-RS @Path / @GET / @POST resource classes"]
         require:

--- a/openbank-infra/gitops/components/accounts/account-service.yaml
+++ b/openbank-infra/gitops/components/accounts/account-service.yaml
@@ -37,7 +37,7 @@ spec:
       annotations:
         # Rolls the pod when the OPA bundle changes — subPath mounts do NOT hot-reload.
         # Kept in sync by gen-account-opa-bundle.sh (do not hand-edit).
-        openbank.tech/policy-checksum: "b17ce021f6c1ea11"
+        openbank.tech/policy-checksum: "3d968d4c22d93cc3"
     spec:
       securityContext:
         runAsNonRoot: true

--- a/openbank-infra/gitops/components/aml/aml-opa-bundle.yaml
+++ b/openbank-infra/gitops/components/aml/aml-opa-bundle.yaml
@@ -9,7 +9,7 @@ metadata:
     app.kubernetes.io/name: aml-service
     app.kubernetes.io/part-of: aml
   annotations:
-    openbank.tech/policy-checksum: "7018cf6161fb87a1"
+    openbank.tech/policy-checksum: "eafd54cdab3fe31c"
 data:
   rest.rego: |
     # SPDX-License-Identifier: Apache-2.0
@@ -1523,6 +1523,37 @@ data:
         # spec-touching PR (bump info.version to match what the diff did), which the error
         # message spells out.
         ci_producer: ".github/scripts/check-api-contract.py"
+        # A fourth class, `correction`, sits between breaking and additive: a breaking DOCUMENT diff
+        # in a PR that changes NOTHING ELSE in the service. It requires MINOR, not MAJOR.
+        #
+        # Why it had to exist. `breaking` and the D2 invariant are jointly unsatisfiable for a spec
+        # that never described the running service. Measured on aml-service (#2312/#2313) with the
+        # pinned oasdiff: red at 1.0.0 because a MAJOR is demanded, red at 2.0.0 because D2 rejects a
+        # major the served URL has not moved to. There is no third value. Worse, the only document
+        # that went green was one that kept a phantom `status` enum value and a `default` the server
+        # does not use — the gate was not merely blocking the correction, it was requiring the
+        # falsehood, and aml shipped four GATE-CONSTRAINED concessions because of it.
+        #
+        # Why it is safe. A spec-only PR leaves the running server byte-identical, so no client that
+        # works today can stop working; what "breaks" is a client generated from a document that
+        # never described this server, and that client was already broken. Touch any other file in
+        # the service — Kotlin, application.yaml, a test — and the normal breaking rule applies
+        # unchanged. Only CHANGELOG.md and version.txt are exempt, because release-please writes them
+        # and neither can change what is served.
+        #
+        # Why it is not an escape hatch. The discriminator is the diff, not a declaration: there is no
+        # marker file and no PR-body token asserting that a spec "was never served". ~22 specs are
+        # correction candidates (#2314), so anything a human asserts once would become the default
+        # path 22 times over.
+        #
+        # It opens no new hole: landing a breaking change as code in one PR and the spec in another
+        # already escapes this gate, which is scoped to spec diffs. What it does NOT check is whether
+        # the corrected document is TRUE — openapi_route_conformance (below) covers the route set,
+        # and nothing yet covers schemas.
+        #
+        # Unit tests: openbank-infra/scripts/check_api_contract_test.py, run by the
+        # "governance-script unit tests" CI step. The negative cases are the point — a
+        # reclassification that fires too eagerly disables the gate for real breaking changes.
       openapi_route_conformance:
         detect: ["openbank-*/src/main/resources/openapi.yaml", "JAX-RS @Path / @GET / @POST resource classes"]
         require:

--- a/openbank-infra/gitops/components/aml/aml-service.yaml
+++ b/openbank-infra/gitops/components/aml/aml-service.yaml
@@ -22,7 +22,7 @@ spec:
       annotations:
         # Rolls the pod when the OPA bundle changes (subPath mounts do not hot-reload).
         # Kept in sync by gen-aml-opa-bundle.sh (do not hand-edit).
-        openbank.tech/policy-checksum: "7018cf6161fb87a1"
+        openbank.tech/policy-checksum: "eafd54cdab3fe31c"
     spec:
       securityContext:
         runAsNonRoot: true

--- a/openbank-infra/gitops/components/anacredit/anacredit-opa-bundle.yaml
+++ b/openbank-infra/gitops/components/anacredit/anacredit-opa-bundle.yaml
@@ -9,7 +9,7 @@ metadata:
     app.kubernetes.io/name: anacredit-service
     app.kubernetes.io/part-of: anacredit
   annotations:
-    openbank.tech/policy-checksum: "9ab8f8caea42d258"
+    openbank.tech/policy-checksum: "b66b3861a3de781e"
 data:
   rest.rego: |
     # SPDX-License-Identifier: Apache-2.0
@@ -1493,6 +1493,37 @@ data:
         # spec-touching PR (bump info.version to match what the diff did), which the error
         # message spells out.
         ci_producer: ".github/scripts/check-api-contract.py"
+        # A fourth class, `correction`, sits between breaking and additive: a breaking DOCUMENT diff
+        # in a PR that changes NOTHING ELSE in the service. It requires MINOR, not MAJOR.
+        #
+        # Why it had to exist. `breaking` and the D2 invariant are jointly unsatisfiable for a spec
+        # that never described the running service. Measured on aml-service (#2312/#2313) with the
+        # pinned oasdiff: red at 1.0.0 because a MAJOR is demanded, red at 2.0.0 because D2 rejects a
+        # major the served URL has not moved to. There is no third value. Worse, the only document
+        # that went green was one that kept a phantom `status` enum value and a `default` the server
+        # does not use — the gate was not merely blocking the correction, it was requiring the
+        # falsehood, and aml shipped four GATE-CONSTRAINED concessions because of it.
+        #
+        # Why it is safe. A spec-only PR leaves the running server byte-identical, so no client that
+        # works today can stop working; what "breaks" is a client generated from a document that
+        # never described this server, and that client was already broken. Touch any other file in
+        # the service — Kotlin, application.yaml, a test — and the normal breaking rule applies
+        # unchanged. Only CHANGELOG.md and version.txt are exempt, because release-please writes them
+        # and neither can change what is served.
+        #
+        # Why it is not an escape hatch. The discriminator is the diff, not a declaration: there is no
+        # marker file and no PR-body token asserting that a spec "was never served". ~22 specs are
+        # correction candidates (#2314), so anything a human asserts once would become the default
+        # path 22 times over.
+        #
+        # It opens no new hole: landing a breaking change as code in one PR and the spec in another
+        # already escapes this gate, which is scoped to spec diffs. What it does NOT check is whether
+        # the corrected document is TRUE — openapi_route_conformance (below) covers the route set,
+        # and nothing yet covers schemas.
+        #
+        # Unit tests: openbank-infra/scripts/check_api_contract_test.py, run by the
+        # "governance-script unit tests" CI step. The negative cases are the point — a
+        # reclassification that fires too eagerly disables the gate for real breaking changes.
       openapi_route_conformance:
         detect: ["openbank-*/src/main/resources/openapi.yaml", "JAX-RS @Path / @GET / @POST resource classes"]
         require:

--- a/openbank-infra/gitops/components/anacredit/anacredit-service.yaml
+++ b/openbank-infra/gitops/components/anacredit/anacredit-service.yaml
@@ -32,7 +32,7 @@ spec:
       annotations:
         # Rolls the pods when the OPA bundle changes — subPath mounts do NOT hot-reload.
         # Kept in sync by gen-anacredit-opa-bundle.sh (do not hand-edit).
-        openbank.tech/policy-checksum: "9ab8f8caea42d258"
+        openbank.tech/policy-checksum: "b66b3861a3de781e"
     spec:
       securityContext:
         runAsNonRoot: true

--- a/openbank-infra/gitops/components/ap2/ap2-opa-bundle.yaml
+++ b/openbank-infra/gitops/components/ap2/ap2-opa-bundle.yaml
@@ -9,7 +9,7 @@ metadata:
     app.kubernetes.io/name: mcp-service
     app.kubernetes.io/part-of: platform
   annotations:
-    openbank.tech/policy-checksum: "f64299b3b15fe454"
+    openbank.tech/policy-checksum: "2c7a909e8003c64e"
 data:
   rest.rego: |
     # SPDX-License-Identifier: Apache-2.0
@@ -1461,6 +1461,37 @@ data:
         # spec-touching PR (bump info.version to match what the diff did), which the error
         # message spells out.
         ci_producer: ".github/scripts/check-api-contract.py"
+        # A fourth class, `correction`, sits between breaking and additive: a breaking DOCUMENT diff
+        # in a PR that changes NOTHING ELSE in the service. It requires MINOR, not MAJOR.
+        #
+        # Why it had to exist. `breaking` and the D2 invariant are jointly unsatisfiable for a spec
+        # that never described the running service. Measured on aml-service (#2312/#2313) with the
+        # pinned oasdiff: red at 1.0.0 because a MAJOR is demanded, red at 2.0.0 because D2 rejects a
+        # major the served URL has not moved to. There is no third value. Worse, the only document
+        # that went green was one that kept a phantom `status` enum value and a `default` the server
+        # does not use — the gate was not merely blocking the correction, it was requiring the
+        # falsehood, and aml shipped four GATE-CONSTRAINED concessions because of it.
+        #
+        # Why it is safe. A spec-only PR leaves the running server byte-identical, so no client that
+        # works today can stop working; what "breaks" is a client generated from a document that
+        # never described this server, and that client was already broken. Touch any other file in
+        # the service — Kotlin, application.yaml, a test — and the normal breaking rule applies
+        # unchanged. Only CHANGELOG.md and version.txt are exempt, because release-please writes them
+        # and neither can change what is served.
+        #
+        # Why it is not an escape hatch. The discriminator is the diff, not a declaration: there is no
+        # marker file and no PR-body token asserting that a spec "was never served". ~22 specs are
+        # correction candidates (#2314), so anything a human asserts once would become the default
+        # path 22 times over.
+        #
+        # It opens no new hole: landing a breaking change as code in one PR and the spec in another
+        # already escapes this gate, which is scoped to spec diffs. What it does NOT check is whether
+        # the corrected document is TRUE — openapi_route_conformance (below) covers the route set,
+        # and nothing yet covers schemas.
+        #
+        # Unit tests: openbank-infra/scripts/check_api_contract_test.py, run by the
+        # "governance-script unit tests" CI step. The negative cases are the point — a
+        # reclassification that fires too eagerly disables the gate for real breaking changes.
       openapi_route_conformance:
         detect: ["openbank-*/src/main/resources/openapi.yaml", "JAX-RS @Path / @GET / @POST resource classes"]
         require:

--- a/openbank-infra/gitops/components/ap2/ap2-service.yaml
+++ b/openbank-infra/gitops/components/ap2/ap2-service.yaml
@@ -30,7 +30,7 @@ spec:
       annotations:
         # Roll the pod when the OPA policy bundle changes (subPath mounts don't hot-reload).
         # Kept in sync by gen-ap2-opa-bundle.sh (do not hand-edit).
-        openbank.tech/policy-checksum: "f64299b3b15fe454"
+        openbank.tech/policy-checksum: "2c7a909e8003c64e"
     spec:
       securityContext:
         runAsNonRoot: true

--- a/openbank-infra/gitops/components/audit/audit-opa-bundle.yaml
+++ b/openbank-infra/gitops/components/audit/audit-opa-bundle.yaml
@@ -9,7 +9,7 @@ metadata:
     app.kubernetes.io/name: audit-service
     app.kubernetes.io/part-of: audit
   annotations:
-    openbank.tech/policy-checksum: "cc6d3073df796068"
+    openbank.tech/policy-checksum: "fdd0d3a60fa79e7d"
 data:
   rest.rego: |
     # SPDX-License-Identifier: Apache-2.0
@@ -1505,6 +1505,37 @@ data:
         # spec-touching PR (bump info.version to match what the diff did), which the error
         # message spells out.
         ci_producer: ".github/scripts/check-api-contract.py"
+        # A fourth class, `correction`, sits between breaking and additive: a breaking DOCUMENT diff
+        # in a PR that changes NOTHING ELSE in the service. It requires MINOR, not MAJOR.
+        #
+        # Why it had to exist. `breaking` and the D2 invariant are jointly unsatisfiable for a spec
+        # that never described the running service. Measured on aml-service (#2312/#2313) with the
+        # pinned oasdiff: red at 1.0.0 because a MAJOR is demanded, red at 2.0.0 because D2 rejects a
+        # major the served URL has not moved to. There is no third value. Worse, the only document
+        # that went green was one that kept a phantom `status` enum value and a `default` the server
+        # does not use — the gate was not merely blocking the correction, it was requiring the
+        # falsehood, and aml shipped four GATE-CONSTRAINED concessions because of it.
+        #
+        # Why it is safe. A spec-only PR leaves the running server byte-identical, so no client that
+        # works today can stop working; what "breaks" is a client generated from a document that
+        # never described this server, and that client was already broken. Touch any other file in
+        # the service — Kotlin, application.yaml, a test — and the normal breaking rule applies
+        # unchanged. Only CHANGELOG.md and version.txt are exempt, because release-please writes them
+        # and neither can change what is served.
+        #
+        # Why it is not an escape hatch. The discriminator is the diff, not a declaration: there is no
+        # marker file and no PR-body token asserting that a spec "was never served". ~22 specs are
+        # correction candidates (#2314), so anything a human asserts once would become the default
+        # path 22 times over.
+        #
+        # It opens no new hole: landing a breaking change as code in one PR and the spec in another
+        # already escapes this gate, which is scoped to spec diffs. What it does NOT check is whether
+        # the corrected document is TRUE — openapi_route_conformance (below) covers the route set,
+        # and nothing yet covers schemas.
+        #
+        # Unit tests: openbank-infra/scripts/check_api_contract_test.py, run by the
+        # "governance-script unit tests" CI step. The negative cases are the point — a
+        # reclassification that fires too eagerly disables the gate for real breaking changes.
       openapi_route_conformance:
         detect: ["openbank-*/src/main/resources/openapi.yaml", "JAX-RS @Path / @GET / @POST resource classes"]
         require:

--- a/openbank-infra/gitops/components/audit/audit-service.yaml
+++ b/openbank-infra/gitops/components/audit/audit-service.yaml
@@ -22,7 +22,7 @@ spec:
       annotations:
         # Rolls the pod when the OPA bundle changes (subPath mounts do not hot-reload).
         # Kept in sync by gen-audit-opa-bundle.sh (do not hand-edit).
-        openbank.tech/policy-checksum: "cc6d3073df796068"
+        openbank.tech/policy-checksum: "fdd0d3a60fa79e7d"
     spec:
       securityContext:
         runAsNonRoot: true

--- a/openbank-infra/gitops/components/balances/balance-opa-bundle.yaml
+++ b/openbank-infra/gitops/components/balances/balance-opa-bundle.yaml
@@ -9,7 +9,7 @@ metadata:
     app.kubernetes.io/name: balance-service
     app.kubernetes.io/part-of: balances
   annotations:
-    openbank.tech/policy-checksum: "53c8f463f33f6925"
+    openbank.tech/policy-checksum: "f4aad8a684e66716"
 data:
   rest.rego: |
     # SPDX-License-Identifier: Apache-2.0
@@ -1594,6 +1594,37 @@ data:
         # spec-touching PR (bump info.version to match what the diff did), which the error
         # message spells out.
         ci_producer: ".github/scripts/check-api-contract.py"
+        # A fourth class, `correction`, sits between breaking and additive: a breaking DOCUMENT diff
+        # in a PR that changes NOTHING ELSE in the service. It requires MINOR, not MAJOR.
+        #
+        # Why it had to exist. `breaking` and the D2 invariant are jointly unsatisfiable for a spec
+        # that never described the running service. Measured on aml-service (#2312/#2313) with the
+        # pinned oasdiff: red at 1.0.0 because a MAJOR is demanded, red at 2.0.0 because D2 rejects a
+        # major the served URL has not moved to. There is no third value. Worse, the only document
+        # that went green was one that kept a phantom `status` enum value and a `default` the server
+        # does not use — the gate was not merely blocking the correction, it was requiring the
+        # falsehood, and aml shipped four GATE-CONSTRAINED concessions because of it.
+        #
+        # Why it is safe. A spec-only PR leaves the running server byte-identical, so no client that
+        # works today can stop working; what "breaks" is a client generated from a document that
+        # never described this server, and that client was already broken. Touch any other file in
+        # the service — Kotlin, application.yaml, a test — and the normal breaking rule applies
+        # unchanged. Only CHANGELOG.md and version.txt are exempt, because release-please writes them
+        # and neither can change what is served.
+        #
+        # Why it is not an escape hatch. The discriminator is the diff, not a declaration: there is no
+        # marker file and no PR-body token asserting that a spec "was never served". ~22 specs are
+        # correction candidates (#2314), so anything a human asserts once would become the default
+        # path 22 times over.
+        #
+        # It opens no new hole: landing a breaking change as code in one PR and the spec in another
+        # already escapes this gate, which is scoped to spec diffs. What it does NOT check is whether
+        # the corrected document is TRUE — openapi_route_conformance (below) covers the route set,
+        # and nothing yet covers schemas.
+        #
+        # Unit tests: openbank-infra/scripts/check_api_contract_test.py, run by the
+        # "governance-script unit tests" CI step. The negative cases are the point — a
+        # reclassification that fires too eagerly disables the gate for real breaking changes.
       openapi_route_conformance:
         detect: ["openbank-*/src/main/resources/openapi.yaml", "JAX-RS @Path / @GET / @POST resource classes"]
         require:

--- a/openbank-infra/gitops/components/balances/balance-service.yaml
+++ b/openbank-infra/gitops/components/balances/balance-service.yaml
@@ -34,7 +34,7 @@ spec:
       annotations:
         # Rolls the pods when the OPA bundle changes — subPath mounts do NOT hot-reload.
         # Kept in sync by gen-balance-opa-bundle.sh (do not hand-edit).
-        openbank.tech/policy-checksum: "53c8f463f33f6925"
+        openbank.tech/policy-checksum: "f4aad8a684e66716"
     spec:
       securityContext:
         runAsNonRoot: true

--- a/openbank-infra/gitops/components/billing/billing-opa-bundle.yaml
+++ b/openbank-infra/gitops/components/billing/billing-opa-bundle.yaml
@@ -9,7 +9,7 @@ metadata:
     app.kubernetes.io/name: billing-service
     app.kubernetes.io/part-of: billing
   annotations:
-    openbank.tech/policy-checksum: "971f3cb8e53574bf"
+    openbank.tech/policy-checksum: "4486187188f50042"
 data:
   rest.rego: |
     # SPDX-License-Identifier: Apache-2.0
@@ -1499,6 +1499,37 @@ data:
         # spec-touching PR (bump info.version to match what the diff did), which the error
         # message spells out.
         ci_producer: ".github/scripts/check-api-contract.py"
+        # A fourth class, `correction`, sits between breaking and additive: a breaking DOCUMENT diff
+        # in a PR that changes NOTHING ELSE in the service. It requires MINOR, not MAJOR.
+        #
+        # Why it had to exist. `breaking` and the D2 invariant are jointly unsatisfiable for a spec
+        # that never described the running service. Measured on aml-service (#2312/#2313) with the
+        # pinned oasdiff: red at 1.0.0 because a MAJOR is demanded, red at 2.0.0 because D2 rejects a
+        # major the served URL has not moved to. There is no third value. Worse, the only document
+        # that went green was one that kept a phantom `status` enum value and a `default` the server
+        # does not use — the gate was not merely blocking the correction, it was requiring the
+        # falsehood, and aml shipped four GATE-CONSTRAINED concessions because of it.
+        #
+        # Why it is safe. A spec-only PR leaves the running server byte-identical, so no client that
+        # works today can stop working; what "breaks" is a client generated from a document that
+        # never described this server, and that client was already broken. Touch any other file in
+        # the service — Kotlin, application.yaml, a test — and the normal breaking rule applies
+        # unchanged. Only CHANGELOG.md and version.txt are exempt, because release-please writes them
+        # and neither can change what is served.
+        #
+        # Why it is not an escape hatch. The discriminator is the diff, not a declaration: there is no
+        # marker file and no PR-body token asserting that a spec "was never served". ~22 specs are
+        # correction candidates (#2314), so anything a human asserts once would become the default
+        # path 22 times over.
+        #
+        # It opens no new hole: landing a breaking change as code in one PR and the spec in another
+        # already escapes this gate, which is scoped to spec diffs. What it does NOT check is whether
+        # the corrected document is TRUE — openapi_route_conformance (below) covers the route set,
+        # and nothing yet covers schemas.
+        #
+        # Unit tests: openbank-infra/scripts/check_api_contract_test.py, run by the
+        # "governance-script unit tests" CI step. The negative cases are the point — a
+        # reclassification that fires too eagerly disables the gate for real breaking changes.
       openapi_route_conformance:
         detect: ["openbank-*/src/main/resources/openapi.yaml", "JAX-RS @Path / @GET / @POST resource classes"]
         require:

--- a/openbank-infra/gitops/components/billing/billing-service.yaml
+++ b/openbank-infra/gitops/components/billing/billing-service.yaml
@@ -27,7 +27,7 @@ spec:
       annotations:
         # Rolls the pods when the OPA bundle changes — subPath mounts do NOT hot-reload.
         # Kept in sync by gen-billing-opa-bundle.sh (do not hand-edit).
-        openbank.tech/policy-checksum: "971f3cb8e53574bf"
+        openbank.tech/policy-checksum: "4486187188f50042"
     spec:
       securityContext:
         runAsNonRoot: true

--- a/openbank-infra/gitops/components/consent/consent-opa-bundle.yaml
+++ b/openbank-infra/gitops/components/consent/consent-opa-bundle.yaml
@@ -9,7 +9,7 @@ metadata:
     app.kubernetes.io/name: consent-service
     app.kubernetes.io/part-of: consent
   annotations:
-    openbank.tech/policy-checksum: "93b361fe6a2457e3"
+    openbank.tech/policy-checksum: "de9ad35dac5e9b6e"
 data:
   rest.rego: |
     # SPDX-License-Identifier: Apache-2.0
@@ -1531,6 +1531,37 @@ data:
         # spec-touching PR (bump info.version to match what the diff did), which the error
         # message spells out.
         ci_producer: ".github/scripts/check-api-contract.py"
+        # A fourth class, `correction`, sits between breaking and additive: a breaking DOCUMENT diff
+        # in a PR that changes NOTHING ELSE in the service. It requires MINOR, not MAJOR.
+        #
+        # Why it had to exist. `breaking` and the D2 invariant are jointly unsatisfiable for a spec
+        # that never described the running service. Measured on aml-service (#2312/#2313) with the
+        # pinned oasdiff: red at 1.0.0 because a MAJOR is demanded, red at 2.0.0 because D2 rejects a
+        # major the served URL has not moved to. There is no third value. Worse, the only document
+        # that went green was one that kept a phantom `status` enum value and a `default` the server
+        # does not use — the gate was not merely blocking the correction, it was requiring the
+        # falsehood, and aml shipped four GATE-CONSTRAINED concessions because of it.
+        #
+        # Why it is safe. A spec-only PR leaves the running server byte-identical, so no client that
+        # works today can stop working; what "breaks" is a client generated from a document that
+        # never described this server, and that client was already broken. Touch any other file in
+        # the service — Kotlin, application.yaml, a test — and the normal breaking rule applies
+        # unchanged. Only CHANGELOG.md and version.txt are exempt, because release-please writes them
+        # and neither can change what is served.
+        #
+        # Why it is not an escape hatch. The discriminator is the diff, not a declaration: there is no
+        # marker file and no PR-body token asserting that a spec "was never served". ~22 specs are
+        # correction candidates (#2314), so anything a human asserts once would become the default
+        # path 22 times over.
+        #
+        # It opens no new hole: landing a breaking change as code in one PR and the spec in another
+        # already escapes this gate, which is scoped to spec diffs. What it does NOT check is whether
+        # the corrected document is TRUE — openapi_route_conformance (below) covers the route set,
+        # and nothing yet covers schemas.
+        #
+        # Unit tests: openbank-infra/scripts/check_api_contract_test.py, run by the
+        # "governance-script unit tests" CI step. The negative cases are the point — a
+        # reclassification that fires too eagerly disables the gate for real breaking changes.
       openapi_route_conformance:
         detect: ["openbank-*/src/main/resources/openapi.yaml", "JAX-RS @Path / @GET / @POST resource classes"]
         require:

--- a/openbank-infra/gitops/components/consent/consent-service.yaml
+++ b/openbank-infra/gitops/components/consent/consent-service.yaml
@@ -28,7 +28,7 @@ spec:
       annotations:
         # Rolls the pods when the OPA bundle changes — subPath mounts do NOT hot-reload.
         # Kept in sync by gen-consent-opa-bundle.sh (do not hand-edit).
-        openbank.tech/policy-checksum: "93b361fe6a2457e3"
+        openbank.tech/policy-checksum: "de9ad35dac5e9b6e"
     spec:
       securityContext:
         runAsNonRoot: true

--- a/openbank-infra/gitops/components/copilot/copilot-opa-bundle.yaml
+++ b/openbank-infra/gitops/components/copilot/copilot-opa-bundle.yaml
@@ -9,7 +9,7 @@ metadata:
     app.kubernetes.io/name: copilot-service
     app.kubernetes.io/part-of: platform
   annotations:
-    openbank.tech/policy-checksum: "0e529cf643aba2c8"
+    openbank.tech/policy-checksum: "d7f8f4aeaabcd6e5"
 data:
   rest.rego: |
     # SPDX-License-Identifier: Apache-2.0
@@ -1585,6 +1585,37 @@ data:
         # spec-touching PR (bump info.version to match what the diff did), which the error
         # message spells out.
         ci_producer: ".github/scripts/check-api-contract.py"
+        # A fourth class, `correction`, sits between breaking and additive: a breaking DOCUMENT diff
+        # in a PR that changes NOTHING ELSE in the service. It requires MINOR, not MAJOR.
+        #
+        # Why it had to exist. `breaking` and the D2 invariant are jointly unsatisfiable for a spec
+        # that never described the running service. Measured on aml-service (#2312/#2313) with the
+        # pinned oasdiff: red at 1.0.0 because a MAJOR is demanded, red at 2.0.0 because D2 rejects a
+        # major the served URL has not moved to. There is no third value. Worse, the only document
+        # that went green was one that kept a phantom `status` enum value and a `default` the server
+        # does not use — the gate was not merely blocking the correction, it was requiring the
+        # falsehood, and aml shipped four GATE-CONSTRAINED concessions because of it.
+        #
+        # Why it is safe. A spec-only PR leaves the running server byte-identical, so no client that
+        # works today can stop working; what "breaks" is a client generated from a document that
+        # never described this server, and that client was already broken. Touch any other file in
+        # the service — Kotlin, application.yaml, a test — and the normal breaking rule applies
+        # unchanged. Only CHANGELOG.md and version.txt are exempt, because release-please writes them
+        # and neither can change what is served.
+        #
+        # Why it is not an escape hatch. The discriminator is the diff, not a declaration: there is no
+        # marker file and no PR-body token asserting that a spec "was never served". ~22 specs are
+        # correction candidates (#2314), so anything a human asserts once would become the default
+        # path 22 times over.
+        #
+        # It opens no new hole: landing a breaking change as code in one PR and the spec in another
+        # already escapes this gate, which is scoped to spec diffs. What it does NOT check is whether
+        # the corrected document is TRUE — openapi_route_conformance (below) covers the route set,
+        # and nothing yet covers schemas.
+        #
+        # Unit tests: openbank-infra/scripts/check_api_contract_test.py, run by the
+        # "governance-script unit tests" CI step. The negative cases are the point — a
+        # reclassification that fires too eagerly disables the gate for real breaking changes.
       openapi_route_conformance:
         detect: ["openbank-*/src/main/resources/openapi.yaml", "JAX-RS @Path / @GET / @POST resource classes"]
         require:

--- a/openbank-infra/gitops/components/copilot/copilot-service.yaml
+++ b/openbank-infra/gitops/components/copilot/copilot-service.yaml
@@ -29,7 +29,7 @@ spec:
       annotations:
         # Rolls the pod when the OPA bundle changes — subPath mounts do NOT hot-reload.
         # Kept in sync by gen-copilot-opa-bundle.sh (do not hand-edit).
-        openbank.tech/policy-checksum: "0e529cf643aba2c8"
+        openbank.tech/policy-checksum: "d7f8f4aeaabcd6e5"
     spec:
       securityContext:
         runAsNonRoot: true

--- a/openbank-infra/gitops/components/customer-edge/customer-edge-opa-bundle.yaml
+++ b/openbank-infra/gitops/components/customer-edge/customer-edge-opa-bundle.yaml
@@ -10,7 +10,7 @@ metadata:
     app.kubernetes.io/name: customer-edge
     app.kubernetes.io/part-of: customer-edge
   annotations:
-    openbank.tech/policy-checksum: "a2b96b14213553c8"
+    openbank.tech/policy-checksum: "8bc5fdcd966be1b0"
 data:
   rest.rego: |
     # SPDX-License-Identifier: Apache-2.0
@@ -684,6 +684,37 @@ data:
         # spec-touching PR (bump info.version to match what the diff did), which the error
         # message spells out.
         ci_producer: ".github/scripts/check-api-contract.py"
+        # A fourth class, `correction`, sits between breaking and additive: a breaking DOCUMENT diff
+        # in a PR that changes NOTHING ELSE in the service. It requires MINOR, not MAJOR.
+        #
+        # Why it had to exist. `breaking` and the D2 invariant are jointly unsatisfiable for a spec
+        # that never described the running service. Measured on aml-service (#2312/#2313) with the
+        # pinned oasdiff: red at 1.0.0 because a MAJOR is demanded, red at 2.0.0 because D2 rejects a
+        # major the served URL has not moved to. There is no third value. Worse, the only document
+        # that went green was one that kept a phantom `status` enum value and a `default` the server
+        # does not use — the gate was not merely blocking the correction, it was requiring the
+        # falsehood, and aml shipped four GATE-CONSTRAINED concessions because of it.
+        #
+        # Why it is safe. A spec-only PR leaves the running server byte-identical, so no client that
+        # works today can stop working; what "breaks" is a client generated from a document that
+        # never described this server, and that client was already broken. Touch any other file in
+        # the service — Kotlin, application.yaml, a test — and the normal breaking rule applies
+        # unchanged. Only CHANGELOG.md and version.txt are exempt, because release-please writes them
+        # and neither can change what is served.
+        #
+        # Why it is not an escape hatch. The discriminator is the diff, not a declaration: there is no
+        # marker file and no PR-body token asserting that a spec "was never served". ~22 specs are
+        # correction candidates (#2314), so anything a human asserts once would become the default
+        # path 22 times over.
+        #
+        # It opens no new hole: landing a breaking change as code in one PR and the spec in another
+        # already escapes this gate, which is scoped to spec diffs. What it does NOT check is whether
+        # the corrected document is TRUE — openapi_route_conformance (below) covers the route set,
+        # and nothing yet covers schemas.
+        #
+        # Unit tests: openbank-infra/scripts/check_api_contract_test.py, run by the
+        # "governance-script unit tests" CI step. The negative cases are the point — a
+        # reclassification that fires too eagerly disables the gate for real breaking changes.
       openapi_route_conformance:
         detect: ["openbank-*/src/main/resources/openapi.yaml", "JAX-RS @Path / @GET / @POST resource classes"]
         require:

--- a/openbank-infra/gitops/components/customer-edge/customer-edge.yaml
+++ b/openbank-infra/gitops/components/customer-edge/customer-edge.yaml
@@ -65,7 +65,7 @@ spec:
       annotations:
         # Rolls the pod when the OPA bundle changes — subPath mounts do NOT hot-reload.
         # Kept in sync by gen-customer-edge-opa-bundle.sh (do not hand-edit).
-        openbank.tech/policy-checksum: "a2b96b14213553c8"
+        openbank.tech/policy-checksum: "8bc5fdcd966be1b0"
     spec:
       # Dedicated SA so EKS Pod Identity can hand the edge (and ONLY the edge) the
       # feedback-screenshots S3 role — ADR-0192, openbank-infra/aws/envs/sandbox-platform/

--- a/openbank-infra/gitops/components/dispute-service/dispute-opa-bundle.yaml
+++ b/openbank-infra/gitops/components/dispute-service/dispute-opa-bundle.yaml
@@ -9,7 +9,7 @@ metadata:
     app.kubernetes.io/name: dispute-service
     app.kubernetes.io/part-of: dispute
   annotations:
-    openbank.tech/policy-checksum: "2da523ee282e4ba8"
+    openbank.tech/policy-checksum: "0fa690693e0dcf1a"
 data:
   rest.rego: |
     # SPDX-License-Identifier: Apache-2.0
@@ -1635,6 +1635,37 @@ data:
         # spec-touching PR (bump info.version to match what the diff did), which the error
         # message spells out.
         ci_producer: ".github/scripts/check-api-contract.py"
+        # A fourth class, `correction`, sits between breaking and additive: a breaking DOCUMENT diff
+        # in a PR that changes NOTHING ELSE in the service. It requires MINOR, not MAJOR.
+        #
+        # Why it had to exist. `breaking` and the D2 invariant are jointly unsatisfiable for a spec
+        # that never described the running service. Measured on aml-service (#2312/#2313) with the
+        # pinned oasdiff: red at 1.0.0 because a MAJOR is demanded, red at 2.0.0 because D2 rejects a
+        # major the served URL has not moved to. There is no third value. Worse, the only document
+        # that went green was one that kept a phantom `status` enum value and a `default` the server
+        # does not use — the gate was not merely blocking the correction, it was requiring the
+        # falsehood, and aml shipped four GATE-CONSTRAINED concessions because of it.
+        #
+        # Why it is safe. A spec-only PR leaves the running server byte-identical, so no client that
+        # works today can stop working; what "breaks" is a client generated from a document that
+        # never described this server, and that client was already broken. Touch any other file in
+        # the service — Kotlin, application.yaml, a test — and the normal breaking rule applies
+        # unchanged. Only CHANGELOG.md and version.txt are exempt, because release-please writes them
+        # and neither can change what is served.
+        #
+        # Why it is not an escape hatch. The discriminator is the diff, not a declaration: there is no
+        # marker file and no PR-body token asserting that a spec "was never served". ~22 specs are
+        # correction candidates (#2314), so anything a human asserts once would become the default
+        # path 22 times over.
+        #
+        # It opens no new hole: landing a breaking change as code in one PR and the spec in another
+        # already escapes this gate, which is scoped to spec diffs. What it does NOT check is whether
+        # the corrected document is TRUE — openapi_route_conformance (below) covers the route set,
+        # and nothing yet covers schemas.
+        #
+        # Unit tests: openbank-infra/scripts/check_api_contract_test.py, run by the
+        # "governance-script unit tests" CI step. The negative cases are the point — a
+        # reclassification that fires too eagerly disables the gate for real breaking changes.
       openapi_route_conformance:
         detect: ["openbank-*/src/main/resources/openapi.yaml", "JAX-RS @Path / @GET / @POST resource classes"]
         require:

--- a/openbank-infra/gitops/components/dispute-service/dispute-service.yaml
+++ b/openbank-infra/gitops/components/dispute-service/dispute-service.yaml
@@ -15,7 +15,7 @@ spec:
       annotations:
         # Rolls the pod when the OPA bundle changes — subPath mounts do NOT hot-reload.
         # Kept in sync by gen-dispute-opa-bundle.sh (do not hand-edit).
-        openbank.tech/policy-checksum: "2da523ee282e4ba8"
+        openbank.tech/policy-checksum: "0fa690693e0dcf1a"
       labels: {app.kubernetes.io/name: dispute-service, app.kubernetes.io/part-of: dispute}
     spec:
       securityContext:

--- a/openbank-infra/gitops/components/document-service/document-service-opa-bundle.yaml
+++ b/openbank-infra/gitops/components/document-service/document-service-opa-bundle.yaml
@@ -10,7 +10,7 @@ metadata:
     app.kubernetes.io/name: document-service
     app.kubernetes.io/part-of: documents
   annotations:
-    openbank.tech/policy-checksum: "a2b96b14213553c8"
+    openbank.tech/policy-checksum: "8bc5fdcd966be1b0"
 data:
   rest.rego: |
     # SPDX-License-Identifier: Apache-2.0
@@ -684,6 +684,37 @@ data:
         # spec-touching PR (bump info.version to match what the diff did), which the error
         # message spells out.
         ci_producer: ".github/scripts/check-api-contract.py"
+        # A fourth class, `correction`, sits between breaking and additive: a breaking DOCUMENT diff
+        # in a PR that changes NOTHING ELSE in the service. It requires MINOR, not MAJOR.
+        #
+        # Why it had to exist. `breaking` and the D2 invariant are jointly unsatisfiable for a spec
+        # that never described the running service. Measured on aml-service (#2312/#2313) with the
+        # pinned oasdiff: red at 1.0.0 because a MAJOR is demanded, red at 2.0.0 because D2 rejects a
+        # major the served URL has not moved to. There is no third value. Worse, the only document
+        # that went green was one that kept a phantom `status` enum value and a `default` the server
+        # does not use — the gate was not merely blocking the correction, it was requiring the
+        # falsehood, and aml shipped four GATE-CONSTRAINED concessions because of it.
+        #
+        # Why it is safe. A spec-only PR leaves the running server byte-identical, so no client that
+        # works today can stop working; what "breaks" is a client generated from a document that
+        # never described this server, and that client was already broken. Touch any other file in
+        # the service — Kotlin, application.yaml, a test — and the normal breaking rule applies
+        # unchanged. Only CHANGELOG.md and version.txt are exempt, because release-please writes them
+        # and neither can change what is served.
+        #
+        # Why it is not an escape hatch. The discriminator is the diff, not a declaration: there is no
+        # marker file and no PR-body token asserting that a spec "was never served". ~22 specs are
+        # correction candidates (#2314), so anything a human asserts once would become the default
+        # path 22 times over.
+        #
+        # It opens no new hole: landing a breaking change as code in one PR and the spec in another
+        # already escapes this gate, which is scoped to spec diffs. What it does NOT check is whether
+        # the corrected document is TRUE — openapi_route_conformance (below) covers the route set,
+        # and nothing yet covers schemas.
+        #
+        # Unit tests: openbank-infra/scripts/check_api_contract_test.py, run by the
+        # "governance-script unit tests" CI step. The negative cases are the point — a
+        # reclassification that fires too eagerly disables the gate for real breaking changes.
       openapi_route_conformance:
         detect: ["openbank-*/src/main/resources/openapi.yaml", "JAX-RS @Path / @GET / @POST resource classes"]
         require:

--- a/openbank-infra/gitops/components/document-service/document-service-service.yaml
+++ b/openbank-infra/gitops/components/document-service/document-service-service.yaml
@@ -43,7 +43,7 @@ spec:
       annotations:
         # Rolls the pods when the OPA bundle changes — subPath mounts do NOT hot-reload.
         # Kept in sync by gen-document-service-opa-bundle.sh (do not hand-edit).
-        openbank.tech/policy-checksum: "a2b96b14213553c8"
+        openbank.tech/policy-checksum: "8bc5fdcd966be1b0"
     spec:
       # ADR-0162 D4 (continued): a dedicated SA (not `default`) is what OpenBao's Kubernetes-auth
       # role `document-service-signing` is bound to — least-privilege, one identity per consumer.

--- a/openbank-infra/gitops/components/fraud-service/fraud-opa-bundle.yaml
+++ b/openbank-infra/gitops/components/fraud-service/fraud-opa-bundle.yaml
@@ -9,7 +9,7 @@ metadata:
     app.kubernetes.io/name: fraud-service
     app.kubernetes.io/part-of: fraud
   annotations:
-    openbank.tech/policy-checksum: "2af7b0d36b60dd7d"
+    openbank.tech/policy-checksum: "8842e05bb5e152b5"
 data:
   rest.rego: |
     # SPDX-License-Identifier: Apache-2.0
@@ -1510,6 +1510,37 @@ data:
         # spec-touching PR (bump info.version to match what the diff did), which the error
         # message spells out.
         ci_producer: ".github/scripts/check-api-contract.py"
+        # A fourth class, `correction`, sits between breaking and additive: a breaking DOCUMENT diff
+        # in a PR that changes NOTHING ELSE in the service. It requires MINOR, not MAJOR.
+        #
+        # Why it had to exist. `breaking` and the D2 invariant are jointly unsatisfiable for a spec
+        # that never described the running service. Measured on aml-service (#2312/#2313) with the
+        # pinned oasdiff: red at 1.0.0 because a MAJOR is demanded, red at 2.0.0 because D2 rejects a
+        # major the served URL has not moved to. There is no third value. Worse, the only document
+        # that went green was one that kept a phantom `status` enum value and a `default` the server
+        # does not use — the gate was not merely blocking the correction, it was requiring the
+        # falsehood, and aml shipped four GATE-CONSTRAINED concessions because of it.
+        #
+        # Why it is safe. A spec-only PR leaves the running server byte-identical, so no client that
+        # works today can stop working; what "breaks" is a client generated from a document that
+        # never described this server, and that client was already broken. Touch any other file in
+        # the service — Kotlin, application.yaml, a test — and the normal breaking rule applies
+        # unchanged. Only CHANGELOG.md and version.txt are exempt, because release-please writes them
+        # and neither can change what is served.
+        #
+        # Why it is not an escape hatch. The discriminator is the diff, not a declaration: there is no
+        # marker file and no PR-body token asserting that a spec "was never served". ~22 specs are
+        # correction candidates (#2314), so anything a human asserts once would become the default
+        # path 22 times over.
+        #
+        # It opens no new hole: landing a breaking change as code in one PR and the spec in another
+        # already escapes this gate, which is scoped to spec diffs. What it does NOT check is whether
+        # the corrected document is TRUE — openapi_route_conformance (below) covers the route set,
+        # and nothing yet covers schemas.
+        #
+        # Unit tests: openbank-infra/scripts/check_api_contract_test.py, run by the
+        # "governance-script unit tests" CI step. The negative cases are the point — a
+        # reclassification that fires too eagerly disables the gate for real breaking changes.
       openapi_route_conformance:
         detect: ["openbank-*/src/main/resources/openapi.yaml", "JAX-RS @Path / @GET / @POST resource classes"]
         require:

--- a/openbank-infra/gitops/components/fraud-service/fraud-service.yaml
+++ b/openbank-infra/gitops/components/fraud-service/fraud-service.yaml
@@ -23,7 +23,7 @@ spec:
       annotations:
         # Rolls the pods when the OPA bundle changes — subPath mounts do NOT hot-reload.
         # Kept in sync by gen-fraud-opa-bundle.sh (do not hand-edit).
-        openbank.tech/policy-checksum: "2af7b0d36b60dd7d"
+        openbank.tech/policy-checksum: "8842e05bb5e152b5"
     spec:
       securityContext:
         runAsNonRoot: true

--- a/openbank-infra/gitops/components/fx-service/fx-opa-bundle.yaml
+++ b/openbank-infra/gitops/components/fx-service/fx-opa-bundle.yaml
@@ -9,7 +9,7 @@ metadata:
     app.kubernetes.io/name: fx-service
     app.kubernetes.io/part-of: fx
   annotations:
-    openbank.tech/policy-checksum: "db36bc931d2f7446"
+    openbank.tech/policy-checksum: "11f86f36decbc3ef"
 data:
   rest.rego: |
     # SPDX-License-Identifier: Apache-2.0
@@ -1561,6 +1561,37 @@ data:
         # spec-touching PR (bump info.version to match what the diff did), which the error
         # message spells out.
         ci_producer: ".github/scripts/check-api-contract.py"
+        # A fourth class, `correction`, sits between breaking and additive: a breaking DOCUMENT diff
+        # in a PR that changes NOTHING ELSE in the service. It requires MINOR, not MAJOR.
+        #
+        # Why it had to exist. `breaking` and the D2 invariant are jointly unsatisfiable for a spec
+        # that never described the running service. Measured on aml-service (#2312/#2313) with the
+        # pinned oasdiff: red at 1.0.0 because a MAJOR is demanded, red at 2.0.0 because D2 rejects a
+        # major the served URL has not moved to. There is no third value. Worse, the only document
+        # that went green was one that kept a phantom `status` enum value and a `default` the server
+        # does not use — the gate was not merely blocking the correction, it was requiring the
+        # falsehood, and aml shipped four GATE-CONSTRAINED concessions because of it.
+        #
+        # Why it is safe. A spec-only PR leaves the running server byte-identical, so no client that
+        # works today can stop working; what "breaks" is a client generated from a document that
+        # never described this server, and that client was already broken. Touch any other file in
+        # the service — Kotlin, application.yaml, a test — and the normal breaking rule applies
+        # unchanged. Only CHANGELOG.md and version.txt are exempt, because release-please writes them
+        # and neither can change what is served.
+        #
+        # Why it is not an escape hatch. The discriminator is the diff, not a declaration: there is no
+        # marker file and no PR-body token asserting that a spec "was never served". ~22 specs are
+        # correction candidates (#2314), so anything a human asserts once would become the default
+        # path 22 times over.
+        #
+        # It opens no new hole: landing a breaking change as code in one PR and the spec in another
+        # already escapes this gate, which is scoped to spec diffs. What it does NOT check is whether
+        # the corrected document is TRUE — openapi_route_conformance (below) covers the route set,
+        # and nothing yet covers schemas.
+        #
+        # Unit tests: openbank-infra/scripts/check_api_contract_test.py, run by the
+        # "governance-script unit tests" CI step. The negative cases are the point — a
+        # reclassification that fires too eagerly disables the gate for real breaking changes.
       openapi_route_conformance:
         detect: ["openbank-*/src/main/resources/openapi.yaml", "JAX-RS @Path / @GET / @POST resource classes"]
         require:

--- a/openbank-infra/gitops/components/fx-service/fx-service.yaml
+++ b/openbank-infra/gitops/components/fx-service/fx-service.yaml
@@ -22,7 +22,7 @@ spec:
       annotations:
         # Rolls the pods when the OPA bundle changes — subPath mounts do NOT hot-reload.
         # Kept in sync by gen-fx-opa-bundle.sh (do not hand-edit).
-        openbank.tech/policy-checksum: "db36bc931d2f7446"
+        openbank.tech/policy-checksum: "11f86f36decbc3ef"
     spec:
       securityContext:
         runAsNonRoot: true

--- a/openbank-infra/gitops/components/interest-service/interest-opa-bundle.yaml
+++ b/openbank-infra/gitops/components/interest-service/interest-opa-bundle.yaml
@@ -9,7 +9,7 @@ metadata:
     app.kubernetes.io/name: interest-service
     app.kubernetes.io/part-of: interest
   annotations:
-    openbank.tech/policy-checksum: "95a917eadc826c64"
+    openbank.tech/policy-checksum: "010108918fa2ceaf"
 data:
   rest.rego: |
     # SPDX-License-Identifier: Apache-2.0
@@ -1495,6 +1495,37 @@ data:
         # spec-touching PR (bump info.version to match what the diff did), which the error
         # message spells out.
         ci_producer: ".github/scripts/check-api-contract.py"
+        # A fourth class, `correction`, sits between breaking and additive: a breaking DOCUMENT diff
+        # in a PR that changes NOTHING ELSE in the service. It requires MINOR, not MAJOR.
+        #
+        # Why it had to exist. `breaking` and the D2 invariant are jointly unsatisfiable for a spec
+        # that never described the running service. Measured on aml-service (#2312/#2313) with the
+        # pinned oasdiff: red at 1.0.0 because a MAJOR is demanded, red at 2.0.0 because D2 rejects a
+        # major the served URL has not moved to. There is no third value. Worse, the only document
+        # that went green was one that kept a phantom `status` enum value and a `default` the server
+        # does not use — the gate was not merely blocking the correction, it was requiring the
+        # falsehood, and aml shipped four GATE-CONSTRAINED concessions because of it.
+        #
+        # Why it is safe. A spec-only PR leaves the running server byte-identical, so no client that
+        # works today can stop working; what "breaks" is a client generated from a document that
+        # never described this server, and that client was already broken. Touch any other file in
+        # the service — Kotlin, application.yaml, a test — and the normal breaking rule applies
+        # unchanged. Only CHANGELOG.md and version.txt are exempt, because release-please writes them
+        # and neither can change what is served.
+        #
+        # Why it is not an escape hatch. The discriminator is the diff, not a declaration: there is no
+        # marker file and no PR-body token asserting that a spec "was never served". ~22 specs are
+        # correction candidates (#2314), so anything a human asserts once would become the default
+        # path 22 times over.
+        #
+        # It opens no new hole: landing a breaking change as code in one PR and the spec in another
+        # already escapes this gate, which is scoped to spec diffs. What it does NOT check is whether
+        # the corrected document is TRUE — openapi_route_conformance (below) covers the route set,
+        # and nothing yet covers schemas.
+        #
+        # Unit tests: openbank-infra/scripts/check_api_contract_test.py, run by the
+        # "governance-script unit tests" CI step. The negative cases are the point — a
+        # reclassification that fires too eagerly disables the gate for real breaking changes.
       openapi_route_conformance:
         detect: ["openbank-*/src/main/resources/openapi.yaml", "JAX-RS @Path / @GET / @POST resource classes"]
         require:

--- a/openbank-infra/gitops/components/interest-service/interest-service.yaml
+++ b/openbank-infra/gitops/components/interest-service/interest-service.yaml
@@ -16,7 +16,7 @@ spec:
       annotations:
         # Rolls the pods when the OPA bundle changes — subPath mounts do NOT hot-reload.
         # Kept in sync by gen-interest-opa-bundle.sh (do not hand-edit).
-        openbank.tech/policy-checksum: "95a917eadc826c64"
+        openbank.tech/policy-checksum: "010108918fa2ceaf"
     spec:
       securityContext:
         runAsNonRoot: true

--- a/openbank-infra/gitops/components/kyc/kyc-opa-bundle.yaml
+++ b/openbank-infra/gitops/components/kyc/kyc-opa-bundle.yaml
@@ -9,7 +9,7 @@ metadata:
     app.kubernetes.io/name: kyc-service
     app.kubernetes.io/part-of: kyc
   annotations:
-    openbank.tech/policy-checksum: "9f591177c0ce720b"
+    openbank.tech/policy-checksum: "79011fa2d9bb6249"
 data:
   rest.rego: |
     # SPDX-License-Identifier: Apache-2.0
@@ -1523,6 +1523,37 @@ data:
         # spec-touching PR (bump info.version to match what the diff did), which the error
         # message spells out.
         ci_producer: ".github/scripts/check-api-contract.py"
+        # A fourth class, `correction`, sits between breaking and additive: a breaking DOCUMENT diff
+        # in a PR that changes NOTHING ELSE in the service. It requires MINOR, not MAJOR.
+        #
+        # Why it had to exist. `breaking` and the D2 invariant are jointly unsatisfiable for a spec
+        # that never described the running service. Measured on aml-service (#2312/#2313) with the
+        # pinned oasdiff: red at 1.0.0 because a MAJOR is demanded, red at 2.0.0 because D2 rejects a
+        # major the served URL has not moved to. There is no third value. Worse, the only document
+        # that went green was one that kept a phantom `status` enum value and a `default` the server
+        # does not use — the gate was not merely blocking the correction, it was requiring the
+        # falsehood, and aml shipped four GATE-CONSTRAINED concessions because of it.
+        #
+        # Why it is safe. A spec-only PR leaves the running server byte-identical, so no client that
+        # works today can stop working; what "breaks" is a client generated from a document that
+        # never described this server, and that client was already broken. Touch any other file in
+        # the service — Kotlin, application.yaml, a test — and the normal breaking rule applies
+        # unchanged. Only CHANGELOG.md and version.txt are exempt, because release-please writes them
+        # and neither can change what is served.
+        #
+        # Why it is not an escape hatch. The discriminator is the diff, not a declaration: there is no
+        # marker file and no PR-body token asserting that a spec "was never served". ~22 specs are
+        # correction candidates (#2314), so anything a human asserts once would become the default
+        # path 22 times over.
+        #
+        # It opens no new hole: landing a breaking change as code in one PR and the spec in another
+        # already escapes this gate, which is scoped to spec diffs. What it does NOT check is whether
+        # the corrected document is TRUE — openapi_route_conformance (below) covers the route set,
+        # and nothing yet covers schemas.
+        #
+        # Unit tests: openbank-infra/scripts/check_api_contract_test.py, run by the
+        # "governance-script unit tests" CI step. The negative cases are the point — a
+        # reclassification that fires too eagerly disables the gate for real breaking changes.
       openapi_route_conformance:
         detect: ["openbank-*/src/main/resources/openapi.yaml", "JAX-RS @Path / @GET / @POST resource classes"]
         require:

--- a/openbank-infra/gitops/components/kyc/kyc-service.yaml
+++ b/openbank-infra/gitops/components/kyc/kyc-service.yaml
@@ -48,7 +48,7 @@ spec:
       annotations:
         # Rolls the pod when the OPA bundle changes (subPath mounts do not hot-reload).
         # Kept in sync by gen-kyc-opa-bundle.sh (do not hand-edit).
-        openbank.tech/policy-checksum: "9f591177c0ce720b"
+        openbank.tech/policy-checksum: "79011fa2d9bb6249"
     spec:
       securityContext:
         runAsNonRoot: true

--- a/openbank-infra/gitops/components/ledger/ledger-opa-bundle.yaml
+++ b/openbank-infra/gitops/components/ledger/ledger-opa-bundle.yaml
@@ -9,7 +9,7 @@ metadata:
     app.kubernetes.io/name: ledger-service
     app.kubernetes.io/part-of: ledger
   annotations:
-    openbank.tech/policy-checksum: "5c1037fbe5644d15"
+    openbank.tech/policy-checksum: "7636a950e4c6f6b9"
 data:
   rest.rego: |
     # SPDX-License-Identifier: Apache-2.0
@@ -1608,6 +1608,37 @@ data:
         # spec-touching PR (bump info.version to match what the diff did), which the error
         # message spells out.
         ci_producer: ".github/scripts/check-api-contract.py"
+        # A fourth class, `correction`, sits between breaking and additive: a breaking DOCUMENT diff
+        # in a PR that changes NOTHING ELSE in the service. It requires MINOR, not MAJOR.
+        #
+        # Why it had to exist. `breaking` and the D2 invariant are jointly unsatisfiable for a spec
+        # that never described the running service. Measured on aml-service (#2312/#2313) with the
+        # pinned oasdiff: red at 1.0.0 because a MAJOR is demanded, red at 2.0.0 because D2 rejects a
+        # major the served URL has not moved to. There is no third value. Worse, the only document
+        # that went green was one that kept a phantom `status` enum value and a `default` the server
+        # does not use — the gate was not merely blocking the correction, it was requiring the
+        # falsehood, and aml shipped four GATE-CONSTRAINED concessions because of it.
+        #
+        # Why it is safe. A spec-only PR leaves the running server byte-identical, so no client that
+        # works today can stop working; what "breaks" is a client generated from a document that
+        # never described this server, and that client was already broken. Touch any other file in
+        # the service — Kotlin, application.yaml, a test — and the normal breaking rule applies
+        # unchanged. Only CHANGELOG.md and version.txt are exempt, because release-please writes them
+        # and neither can change what is served.
+        #
+        # Why it is not an escape hatch. The discriminator is the diff, not a declaration: there is no
+        # marker file and no PR-body token asserting that a spec "was never served". ~22 specs are
+        # correction candidates (#2314), so anything a human asserts once would become the default
+        # path 22 times over.
+        #
+        # It opens no new hole: landing a breaking change as code in one PR and the spec in another
+        # already escapes this gate, which is scoped to spec diffs. What it does NOT check is whether
+        # the corrected document is TRUE — openapi_route_conformance (below) covers the route set,
+        # and nothing yet covers schemas.
+        #
+        # Unit tests: openbank-infra/scripts/check_api_contract_test.py, run by the
+        # "governance-script unit tests" CI step. The negative cases are the point — a
+        # reclassification that fires too eagerly disables the gate for real breaking changes.
       openapi_route_conformance:
         detect: ["openbank-*/src/main/resources/openapi.yaml", "JAX-RS @Path / @GET / @POST resource classes"]
         require:

--- a/openbank-infra/gitops/components/ledger/ledger-service.yaml
+++ b/openbank-infra/gitops/components/ledger/ledger-service.yaml
@@ -38,7 +38,7 @@ spec:
       annotations:
         # Rolls the pods when the OPA bundle changes — subPath mounts do NOT hot-reload.
         # Kept in sync by gen-ledger-opa-bundle.sh (do not hand-edit).
-        openbank.tech/policy-checksum: "5c1037fbe5644d15"
+        openbank.tech/policy-checksum: "7636a950e4c6f6b9"
     spec:
       securityContext:
         runAsNonRoot: true

--- a/openbank-infra/gitops/components/lending/lending-opa-bundle.yaml
+++ b/openbank-infra/gitops/components/lending/lending-opa-bundle.yaml
@@ -9,7 +9,7 @@ metadata:
     app.kubernetes.io/name: lending-service
     app.kubernetes.io/part-of: lending
   annotations:
-    openbank.tech/policy-checksum: "9b6cc07787b559f4"
+    openbank.tech/policy-checksum: "3ba589a36538aa51"
 data:
   rest.rego: |
     # SPDX-License-Identifier: Apache-2.0
@@ -1563,6 +1563,37 @@ data:
         # spec-touching PR (bump info.version to match what the diff did), which the error
         # message spells out.
         ci_producer: ".github/scripts/check-api-contract.py"
+        # A fourth class, `correction`, sits between breaking and additive: a breaking DOCUMENT diff
+        # in a PR that changes NOTHING ELSE in the service. It requires MINOR, not MAJOR.
+        #
+        # Why it had to exist. `breaking` and the D2 invariant are jointly unsatisfiable for a spec
+        # that never described the running service. Measured on aml-service (#2312/#2313) with the
+        # pinned oasdiff: red at 1.0.0 because a MAJOR is demanded, red at 2.0.0 because D2 rejects a
+        # major the served URL has not moved to. There is no third value. Worse, the only document
+        # that went green was one that kept a phantom `status` enum value and a `default` the server
+        # does not use — the gate was not merely blocking the correction, it was requiring the
+        # falsehood, and aml shipped four GATE-CONSTRAINED concessions because of it.
+        #
+        # Why it is safe. A spec-only PR leaves the running server byte-identical, so no client that
+        # works today can stop working; what "breaks" is a client generated from a document that
+        # never described this server, and that client was already broken. Touch any other file in
+        # the service — Kotlin, application.yaml, a test — and the normal breaking rule applies
+        # unchanged. Only CHANGELOG.md and version.txt are exempt, because release-please writes them
+        # and neither can change what is served.
+        #
+        # Why it is not an escape hatch. The discriminator is the diff, not a declaration: there is no
+        # marker file and no PR-body token asserting that a spec "was never served". ~22 specs are
+        # correction candidates (#2314), so anything a human asserts once would become the default
+        # path 22 times over.
+        #
+        # It opens no new hole: landing a breaking change as code in one PR and the spec in another
+        # already escapes this gate, which is scoped to spec diffs. What it does NOT check is whether
+        # the corrected document is TRUE — openapi_route_conformance (below) covers the route set,
+        # and nothing yet covers schemas.
+        #
+        # Unit tests: openbank-infra/scripts/check_api_contract_test.py, run by the
+        # "governance-script unit tests" CI step. The negative cases are the point — a
+        # reclassification that fires too eagerly disables the gate for real breaking changes.
       openapi_route_conformance:
         detect: ["openbank-*/src/main/resources/openapi.yaml", "JAX-RS @Path / @GET / @POST resource classes"]
         require:

--- a/openbank-infra/gitops/components/lending/lending-service.yaml
+++ b/openbank-infra/gitops/components/lending/lending-service.yaml
@@ -34,7 +34,7 @@ spec:
       annotations:
         # Rolls the pods when the OPA bundle changes — subPath mounts do NOT hot-reload.
         # Kept in sync by gen-lending-opa-bundle.sh (do not hand-edit).
-        openbank.tech/policy-checksum: "9b6cc07787b559f4"
+        openbank.tech/policy-checksum: "3ba589a36538aa51"
     spec:
       securityContext:
         runAsNonRoot: true

--- a/openbank-infra/gitops/components/mcp/mcp-opa-bundle.yaml
+++ b/openbank-infra/gitops/components/mcp/mcp-opa-bundle.yaml
@@ -9,7 +9,7 @@ metadata:
     app.kubernetes.io/name: mcp-service
     app.kubernetes.io/part-of: platform
   annotations:
-    openbank.tech/policy-checksum: "f64299b3b15fe454"
+    openbank.tech/policy-checksum: "2c7a909e8003c64e"
 data:
   rest.rego: |
     # SPDX-License-Identifier: Apache-2.0
@@ -1461,6 +1461,37 @@ data:
         # spec-touching PR (bump info.version to match what the diff did), which the error
         # message spells out.
         ci_producer: ".github/scripts/check-api-contract.py"
+        # A fourth class, `correction`, sits between breaking and additive: a breaking DOCUMENT diff
+        # in a PR that changes NOTHING ELSE in the service. It requires MINOR, not MAJOR.
+        #
+        # Why it had to exist. `breaking` and the D2 invariant are jointly unsatisfiable for a spec
+        # that never described the running service. Measured on aml-service (#2312/#2313) with the
+        # pinned oasdiff: red at 1.0.0 because a MAJOR is demanded, red at 2.0.0 because D2 rejects a
+        # major the served URL has not moved to. There is no third value. Worse, the only document
+        # that went green was one that kept a phantom `status` enum value and a `default` the server
+        # does not use — the gate was not merely blocking the correction, it was requiring the
+        # falsehood, and aml shipped four GATE-CONSTRAINED concessions because of it.
+        #
+        # Why it is safe. A spec-only PR leaves the running server byte-identical, so no client that
+        # works today can stop working; what "breaks" is a client generated from a document that
+        # never described this server, and that client was already broken. Touch any other file in
+        # the service — Kotlin, application.yaml, a test — and the normal breaking rule applies
+        # unchanged. Only CHANGELOG.md and version.txt are exempt, because release-please writes them
+        # and neither can change what is served.
+        #
+        # Why it is not an escape hatch. The discriminator is the diff, not a declaration: there is no
+        # marker file and no PR-body token asserting that a spec "was never served". ~22 specs are
+        # correction candidates (#2314), so anything a human asserts once would become the default
+        # path 22 times over.
+        #
+        # It opens no new hole: landing a breaking change as code in one PR and the spec in another
+        # already escapes this gate, which is scoped to spec diffs. What it does NOT check is whether
+        # the corrected document is TRUE — openapi_route_conformance (below) covers the route set,
+        # and nothing yet covers schemas.
+        #
+        # Unit tests: openbank-infra/scripts/check_api_contract_test.py, run by the
+        # "governance-script unit tests" CI step. The negative cases are the point — a
+        # reclassification that fires too eagerly disables the gate for real breaking changes.
       openapi_route_conformance:
         detect: ["openbank-*/src/main/resources/openapi.yaml", "JAX-RS @Path / @GET / @POST resource classes"]
         require:

--- a/openbank-infra/gitops/components/mcp/mcp-service.yaml
+++ b/openbank-infra/gitops/components/mcp/mcp-service.yaml
@@ -29,7 +29,7 @@ spec:
       annotations:
         # Rolls the pod when the OPA bundle changes — subPath mounts do NOT hot-reload.
         # Kept in sync by gen-mcp-opa-bundle.sh (do not hand-edit).
-        openbank.tech/policy-checksum: "f64299b3b15fe454"
+        openbank.tech/policy-checksum: "2c7a909e8003c64e"
     spec:
       securityContext:
         runAsNonRoot: true

--- a/openbank-infra/gitops/components/notifications/notification-service-opa-bundle.yaml
+++ b/openbank-infra/gitops/components/notifications/notification-service-opa-bundle.yaml
@@ -10,7 +10,7 @@ metadata:
     app.kubernetes.io/name: notification-service
     app.kubernetes.io/part-of: notifications
   annotations:
-    openbank.tech/policy-checksum: "a2b96b14213553c8"
+    openbank.tech/policy-checksum: "8bc5fdcd966be1b0"
 data:
   rest.rego: |
     # SPDX-License-Identifier: Apache-2.0
@@ -684,6 +684,37 @@ data:
         # spec-touching PR (bump info.version to match what the diff did), which the error
         # message spells out.
         ci_producer: ".github/scripts/check-api-contract.py"
+        # A fourth class, `correction`, sits between breaking and additive: a breaking DOCUMENT diff
+        # in a PR that changes NOTHING ELSE in the service. It requires MINOR, not MAJOR.
+        #
+        # Why it had to exist. `breaking` and the D2 invariant are jointly unsatisfiable for a spec
+        # that never described the running service. Measured on aml-service (#2312/#2313) with the
+        # pinned oasdiff: red at 1.0.0 because a MAJOR is demanded, red at 2.0.0 because D2 rejects a
+        # major the served URL has not moved to. There is no third value. Worse, the only document
+        # that went green was one that kept a phantom `status` enum value and a `default` the server
+        # does not use — the gate was not merely blocking the correction, it was requiring the
+        # falsehood, and aml shipped four GATE-CONSTRAINED concessions because of it.
+        #
+        # Why it is safe. A spec-only PR leaves the running server byte-identical, so no client that
+        # works today can stop working; what "breaks" is a client generated from a document that
+        # never described this server, and that client was already broken. Touch any other file in
+        # the service — Kotlin, application.yaml, a test — and the normal breaking rule applies
+        # unchanged. Only CHANGELOG.md and version.txt are exempt, because release-please writes them
+        # and neither can change what is served.
+        #
+        # Why it is not an escape hatch. The discriminator is the diff, not a declaration: there is no
+        # marker file and no PR-body token asserting that a spec "was never served". ~22 specs are
+        # correction candidates (#2314), so anything a human asserts once would become the default
+        # path 22 times over.
+        #
+        # It opens no new hole: landing a breaking change as code in one PR and the spec in another
+        # already escapes this gate, which is scoped to spec diffs. What it does NOT check is whether
+        # the corrected document is TRUE — openapi_route_conformance (below) covers the route set,
+        # and nothing yet covers schemas.
+        #
+        # Unit tests: openbank-infra/scripts/check_api_contract_test.py, run by the
+        # "governance-script unit tests" CI step. The negative cases are the point — a
+        # reclassification that fires too eagerly disables the gate for real breaking changes.
       openapi_route_conformance:
         detect: ["openbank-*/src/main/resources/openapi.yaml", "JAX-RS @Path / @GET / @POST resource classes"]
         require:

--- a/openbank-infra/gitops/components/notifications/notification-service.yaml
+++ b/openbank-infra/gitops/components/notifications/notification-service.yaml
@@ -39,7 +39,7 @@ spec:
       annotations:
         # Rolls the Deployment when the OPA policy bundle changes (subPath mounts don't
         # hot-reload). Kept in sync by gen-notification-opa-bundle.sh.
-        openbank.tech/policy-checksum: "a2b96b14213553c8"
+        openbank.tech/policy-checksum: "8bc5fdcd966be1b0"
       labels:
         app.kubernetes.io/name: notification-service
         app.kubernetes.io/part-of: notifications

--- a/openbank-infra/gitops/components/party/party-opa-bundle.yaml
+++ b/openbank-infra/gitops/components/party/party-opa-bundle.yaml
@@ -9,7 +9,7 @@ metadata:
     app.kubernetes.io/name: party-service
     app.kubernetes.io/part-of: party
   annotations:
-    openbank.tech/policy-checksum: "0680dacec4173feb"
+    openbank.tech/policy-checksum: "33fd687161fb7811"
 data:
   rest.rego: |
     # SPDX-License-Identifier: Apache-2.0
@@ -1532,6 +1532,37 @@ data:
         # spec-touching PR (bump info.version to match what the diff did), which the error
         # message spells out.
         ci_producer: ".github/scripts/check-api-contract.py"
+        # A fourth class, `correction`, sits between breaking and additive: a breaking DOCUMENT diff
+        # in a PR that changes NOTHING ELSE in the service. It requires MINOR, not MAJOR.
+        #
+        # Why it had to exist. `breaking` and the D2 invariant are jointly unsatisfiable for a spec
+        # that never described the running service. Measured on aml-service (#2312/#2313) with the
+        # pinned oasdiff: red at 1.0.0 because a MAJOR is demanded, red at 2.0.0 because D2 rejects a
+        # major the served URL has not moved to. There is no third value. Worse, the only document
+        # that went green was one that kept a phantom `status` enum value and a `default` the server
+        # does not use — the gate was not merely blocking the correction, it was requiring the
+        # falsehood, and aml shipped four GATE-CONSTRAINED concessions because of it.
+        #
+        # Why it is safe. A spec-only PR leaves the running server byte-identical, so no client that
+        # works today can stop working; what "breaks" is a client generated from a document that
+        # never described this server, and that client was already broken. Touch any other file in
+        # the service — Kotlin, application.yaml, a test — and the normal breaking rule applies
+        # unchanged. Only CHANGELOG.md and version.txt are exempt, because release-please writes them
+        # and neither can change what is served.
+        #
+        # Why it is not an escape hatch. The discriminator is the diff, not a declaration: there is no
+        # marker file and no PR-body token asserting that a spec "was never served". ~22 specs are
+        # correction candidates (#2314), so anything a human asserts once would become the default
+        # path 22 times over.
+        #
+        # It opens no new hole: landing a breaking change as code in one PR and the spec in another
+        # already escapes this gate, which is scoped to spec diffs. What it does NOT check is whether
+        # the corrected document is TRUE — openapi_route_conformance (below) covers the route set,
+        # and nothing yet covers schemas.
+        #
+        # Unit tests: openbank-infra/scripts/check_api_contract_test.py, run by the
+        # "governance-script unit tests" CI step. The negative cases are the point — a
+        # reclassification that fires too eagerly disables the gate for real breaking changes.
       openapi_route_conformance:
         detect: ["openbank-*/src/main/resources/openapi.yaml", "JAX-RS @Path / @GET / @POST resource classes"]
         require:

--- a/openbank-infra/gitops/components/party/party-service.yaml
+++ b/openbank-infra/gitops/components/party/party-service.yaml
@@ -22,7 +22,7 @@ spec:
       annotations:
         # Rolls the pod when the OPA bundle changes — subPath mounts do NOT hot-reload.
         # Kept in sync by gen-party-opa-bundle.sh (do not hand-edit).
-        openbank.tech/policy-checksum: "0680dacec4173feb"
+        openbank.tech/policy-checksum: "33fd687161fb7811"
       labels:
         app.kubernetes.io/name: party-service
         app.kubernetes.io/part-of: party

--- a/openbank-infra/gitops/components/payments/card-issuance-opa-bundle.yaml
+++ b/openbank-infra/gitops/components/payments/card-issuance-opa-bundle.yaml
@@ -9,7 +9,7 @@ metadata:
     app.kubernetes.io/name: card-issuance-service
     app.kubernetes.io/part-of: payments
   annotations:
-    openbank.tech/policy-checksum: "6a5476eb2f186256"
+    openbank.tech/policy-checksum: "b202bafabd1bf555"
 data:
   rest.rego: |
     # SPDX-License-Identifier: Apache-2.0
@@ -1516,6 +1516,37 @@ data:
         # spec-touching PR (bump info.version to match what the diff did), which the error
         # message spells out.
         ci_producer: ".github/scripts/check-api-contract.py"
+        # A fourth class, `correction`, sits between breaking and additive: a breaking DOCUMENT diff
+        # in a PR that changes NOTHING ELSE in the service. It requires MINOR, not MAJOR.
+        #
+        # Why it had to exist. `breaking` and the D2 invariant are jointly unsatisfiable for a spec
+        # that never described the running service. Measured on aml-service (#2312/#2313) with the
+        # pinned oasdiff: red at 1.0.0 because a MAJOR is demanded, red at 2.0.0 because D2 rejects a
+        # major the served URL has not moved to. There is no third value. Worse, the only document
+        # that went green was one that kept a phantom `status` enum value and a `default` the server
+        # does not use — the gate was not merely blocking the correction, it was requiring the
+        # falsehood, and aml shipped four GATE-CONSTRAINED concessions because of it.
+        #
+        # Why it is safe. A spec-only PR leaves the running server byte-identical, so no client that
+        # works today can stop working; what "breaks" is a client generated from a document that
+        # never described this server, and that client was already broken. Touch any other file in
+        # the service — Kotlin, application.yaml, a test — and the normal breaking rule applies
+        # unchanged. Only CHANGELOG.md and version.txt are exempt, because release-please writes them
+        # and neither can change what is served.
+        #
+        # Why it is not an escape hatch. The discriminator is the diff, not a declaration: there is no
+        # marker file and no PR-body token asserting that a spec "was never served". ~22 specs are
+        # correction candidates (#2314), so anything a human asserts once would become the default
+        # path 22 times over.
+        #
+        # It opens no new hole: landing a breaking change as code in one PR and the spec in another
+        # already escapes this gate, which is scoped to spec diffs. What it does NOT check is whether
+        # the corrected document is TRUE — openapi_route_conformance (below) covers the route set,
+        # and nothing yet covers schemas.
+        #
+        # Unit tests: openbank-infra/scripts/check_api_contract_test.py, run by the
+        # "governance-script unit tests" CI step. The negative cases are the point — a
+        # reclassification that fires too eagerly disables the gate for real breaking changes.
       openapi_route_conformance:
         detect: ["openbank-*/src/main/resources/openapi.yaml", "JAX-RS @Path / @GET / @POST resource classes"]
         require:

--- a/openbank-infra/gitops/components/payments/clearing-opa-bundle.yaml
+++ b/openbank-infra/gitops/components/payments/clearing-opa-bundle.yaml
@@ -9,7 +9,7 @@ metadata:
     app.kubernetes.io/name: clearing-service
     app.kubernetes.io/part-of: payments
   annotations:
-    openbank.tech/policy-checksum: "dcb516681861ccc2"
+    openbank.tech/policy-checksum: "d9b5cc156c704ac2"
 data:
   rest.rego: |
     # SPDX-License-Identifier: Apache-2.0
@@ -1553,6 +1553,37 @@ data:
         # spec-touching PR (bump info.version to match what the diff did), which the error
         # message spells out.
         ci_producer: ".github/scripts/check-api-contract.py"
+        # A fourth class, `correction`, sits between breaking and additive: a breaking DOCUMENT diff
+        # in a PR that changes NOTHING ELSE in the service. It requires MINOR, not MAJOR.
+        #
+        # Why it had to exist. `breaking` and the D2 invariant are jointly unsatisfiable for a spec
+        # that never described the running service. Measured on aml-service (#2312/#2313) with the
+        # pinned oasdiff: red at 1.0.0 because a MAJOR is demanded, red at 2.0.0 because D2 rejects a
+        # major the served URL has not moved to. There is no third value. Worse, the only document
+        # that went green was one that kept a phantom `status` enum value and a `default` the server
+        # does not use — the gate was not merely blocking the correction, it was requiring the
+        # falsehood, and aml shipped four GATE-CONSTRAINED concessions because of it.
+        #
+        # Why it is safe. A spec-only PR leaves the running server byte-identical, so no client that
+        # works today can stop working; what "breaks" is a client generated from a document that
+        # never described this server, and that client was already broken. Touch any other file in
+        # the service — Kotlin, application.yaml, a test — and the normal breaking rule applies
+        # unchanged. Only CHANGELOG.md and version.txt are exempt, because release-please writes them
+        # and neither can change what is served.
+        #
+        # Why it is not an escape hatch. The discriminator is the diff, not a declaration: there is no
+        # marker file and no PR-body token asserting that a spec "was never served". ~22 specs are
+        # correction candidates (#2314), so anything a human asserts once would become the default
+        # path 22 times over.
+        #
+        # It opens no new hole: landing a breaking change as code in one PR and the spec in another
+        # already escapes this gate, which is scoped to spec diffs. What it does NOT check is whether
+        # the corrected document is TRUE — openapi_route_conformance (below) covers the route set,
+        # and nothing yet covers schemas.
+        #
+        # Unit tests: openbank-infra/scripts/check_api_contract_test.py, run by the
+        # "governance-script unit tests" CI step. The negative cases are the point — a
+        # reclassification that fires too eagerly disables the gate for real breaking changes.
       openapi_route_conformance:
         detect: ["openbank-*/src/main/resources/openapi.yaml", "JAX-RS @Path / @GET / @POST resource classes"]
         require:

--- a/openbank-infra/gitops/components/payments/domestic-payment-opa-bundle.yaml
+++ b/openbank-infra/gitops/components/payments/domestic-payment-opa-bundle.yaml
@@ -9,7 +9,7 @@ metadata:
     app.kubernetes.io/name: domestic-payment
     app.kubernetes.io/part-of: payments
   annotations:
-    openbank.tech/policy-checksum: "45acc72a57dedce1"
+    openbank.tech/policy-checksum: "e6b80756d377f2a0"
 data:
   rest.rego: |
     # SPDX-License-Identifier: Apache-2.0
@@ -1538,6 +1538,37 @@ data:
         # spec-touching PR (bump info.version to match what the diff did), which the error
         # message spells out.
         ci_producer: ".github/scripts/check-api-contract.py"
+        # A fourth class, `correction`, sits between breaking and additive: a breaking DOCUMENT diff
+        # in a PR that changes NOTHING ELSE in the service. It requires MINOR, not MAJOR.
+        #
+        # Why it had to exist. `breaking` and the D2 invariant are jointly unsatisfiable for a spec
+        # that never described the running service. Measured on aml-service (#2312/#2313) with the
+        # pinned oasdiff: red at 1.0.0 because a MAJOR is demanded, red at 2.0.0 because D2 rejects a
+        # major the served URL has not moved to. There is no third value. Worse, the only document
+        # that went green was one that kept a phantom `status` enum value and a `default` the server
+        # does not use — the gate was not merely blocking the correction, it was requiring the
+        # falsehood, and aml shipped four GATE-CONSTRAINED concessions because of it.
+        #
+        # Why it is safe. A spec-only PR leaves the running server byte-identical, so no client that
+        # works today can stop working; what "breaks" is a client generated from a document that
+        # never described this server, and that client was already broken. Touch any other file in
+        # the service — Kotlin, application.yaml, a test — and the normal breaking rule applies
+        # unchanged. Only CHANGELOG.md and version.txt are exempt, because release-please writes them
+        # and neither can change what is served.
+        #
+        # Why it is not an escape hatch. The discriminator is the diff, not a declaration: there is no
+        # marker file and no PR-body token asserting that a spec "was never served". ~22 specs are
+        # correction candidates (#2314), so anything a human asserts once would become the default
+        # path 22 times over.
+        #
+        # It opens no new hole: landing a breaking change as code in one PR and the spec in another
+        # already escapes this gate, which is scoped to spec diffs. What it does NOT check is whether
+        # the corrected document is TRUE — openapi_route_conformance (below) covers the route set,
+        # and nothing yet covers schemas.
+        #
+        # Unit tests: openbank-infra/scripts/check_api_contract_test.py, run by the
+        # "governance-script unit tests" CI step. The negative cases are the point — a
+        # reclassification that fires too eagerly disables the gate for real breaking changes.
       openapi_route_conformance:
         detect: ["openbank-*/src/main/resources/openapi.yaml", "JAX-RS @Path / @GET / @POST resource classes"]
         require:

--- a/openbank-infra/gitops/components/payments/payments-services.yaml
+++ b/openbank-infra/gitops/components/payments/payments-services.yaml
@@ -42,7 +42,7 @@ spec:
         # Rolls the pods when the OPA bundle changes — subPath mounts do NOT hot-reload.
         # Kept in sync by gen-transaction-opa-bundle.sh via the trailing marker comment
         # (do not hand-edit, do not drop the marker).
-        openbank.tech/policy-checksum: "47102db2519ee360" # transaction-opa-bundle
+        openbank.tech/policy-checksum: "36bf9a9ff2fbde65" # transaction-opa-bundle
     spec:
       securityContext:
         runAsNonRoot: true
@@ -375,7 +375,7 @@ spec:
       annotations:
         # Rolls the pods when the OPA bundle changes — subPath mounts do NOT hot-reload.
         # Kept in sync by gen-sepa-payment-opa-bundle.sh (do not hand-edit).
-        openbank.tech/policy-checksum: "b1ddc2cff5f60203"
+        openbank.tech/policy-checksum: "9f778a6a60625676"
     spec:
       securityContext:
         runAsNonRoot: true
@@ -729,7 +729,7 @@ spec:
         # Rolls the pods when the OPA bundle changes — subPath mounts do NOT hot-reload.
         # Kept in sync by gen-domestic-payment-opa-bundle.sh via the trailing marker
         # comment (do not hand-edit, do not drop the marker).
-        openbank.tech/policy-checksum: "45acc72a57dedce1" # domestic-payment-opa-bundle
+        openbank.tech/policy-checksum: "e6b80756d377f2a0" # domestic-payment-opa-bundle
     spec:
       securityContext:
         runAsNonRoot: true
@@ -1053,7 +1053,7 @@ spec:
       annotations:
         # Rolls the pods when the OPA bundle changes — subPath mounts do NOT hot-reload.
         # Kept in sync by gen-sepa-instant-opa-bundle.sh (do not hand-edit).
-        openbank.tech/policy-checksum: "0616bdce5a27a690"
+        openbank.tech/policy-checksum: "feccf7a47a3f2975"
     spec:
       securityContext:
         runAsNonRoot: true
@@ -1369,7 +1369,7 @@ spec:
         # Rolls the pods when the OPA bundle changes — subPath mounts do NOT hot-reload.
         # Kept in sync by gen-clearing-opa-bundle.sh via the trailing marker comment
         # (do not hand-edit, do not drop the marker).
-        openbank.tech/policy-checksum: "dcb516681861ccc2" # clearing-opa-bundle
+        openbank.tech/policy-checksum: "d9b5cc156c704ac2" # clearing-opa-bundle
     spec:
       securityContext:
         runAsNonRoot: true
@@ -1658,7 +1658,7 @@ spec:
       annotations:
         # Rolls the pod when the OPA bundle changes (ADR-0034). Value is stamped by
         # gen-standing-order-opa-bundle.sh — do not hand-edit.
-        openbank.tech/policy-checksum: "03d68b059298ad38" # standing-order-opa-bundle
+        openbank.tech/policy-checksum: "5f3323fdc148df78" # standing-order-opa-bundle
     spec:
       securityContext:
         runAsNonRoot: true
@@ -1911,7 +1911,7 @@ spec:
       annotations:
         # Rolls the pods when the OPA bundle changes — subPath mounts do NOT hot-reload.
         # Kept in sync by gen-card-issuance-opa-bundle.sh (do not hand-edit).
-        openbank.tech/policy-checksum: "6a5476eb2f186256"
+        openbank.tech/policy-checksum: "b202bafabd1bf555"
     spec:
       securityContext:
         runAsNonRoot: true
@@ -2178,7 +2178,7 @@ spec:
         # Rolls the pods when the OPA bundle changes — subPath mounts do NOT hot-reload.
         # Kept in sync by gen-settlement-opa-bundle.sh via the trailing marker comment
         # (do not hand-edit, do not drop the marker).
-        openbank.tech/policy-checksum: "f3e7229be8562ec2" # settlement-opa-bundle
+        openbank.tech/policy-checksum: "6e4cb27cb39eeff5" # settlement-opa-bundle
     spec:
       securityContext:
         runAsNonRoot: true
@@ -2579,7 +2579,7 @@ spec:
       annotations:
         # Rolls the pods when the OPA bundle changes — subPath mounts do NOT hot-reload.
         # Kept in sync by gen-swift-opa-bundle.sh (do not hand-edit).
-        openbank.tech/policy-checksum: "3bc4dacaacfacc2e"
+        openbank.tech/policy-checksum: "3befb3101ab1e0ba"
     spec:
       securityContext:
         runAsNonRoot: true
@@ -2893,7 +2893,7 @@ spec:
       annotations:
         # Rolls the pods when the OPA bundle changes — subPath mounts do NOT hot-reload.
         # Kept in sync by gen-vop-opa-bundle.sh (do not hand-edit).
-        openbank.tech/policy-checksum: "53e78aae6d6a40c8"
+        openbank.tech/policy-checksum: "0a8fe5b6e51debe2"
     spec:
       securityContext:
         runAsNonRoot: true

--- a/openbank-infra/gitops/components/payments/sepa-instant-opa-bundle.yaml
+++ b/openbank-infra/gitops/components/payments/sepa-instant-opa-bundle.yaml
@@ -9,7 +9,7 @@ metadata:
     app.kubernetes.io/name: sepa-instant
     app.kubernetes.io/part-of: payments
   annotations:
-    openbank.tech/policy-checksum: "0616bdce5a27a690"
+    openbank.tech/policy-checksum: "feccf7a47a3f2975"
 data:
   rest.rego: |
     # SPDX-License-Identifier: Apache-2.0
@@ -1511,6 +1511,37 @@ data:
         # spec-touching PR (bump info.version to match what the diff did), which the error
         # message spells out.
         ci_producer: ".github/scripts/check-api-contract.py"
+        # A fourth class, `correction`, sits between breaking and additive: a breaking DOCUMENT diff
+        # in a PR that changes NOTHING ELSE in the service. It requires MINOR, not MAJOR.
+        #
+        # Why it had to exist. `breaking` and the D2 invariant are jointly unsatisfiable for a spec
+        # that never described the running service. Measured on aml-service (#2312/#2313) with the
+        # pinned oasdiff: red at 1.0.0 because a MAJOR is demanded, red at 2.0.0 because D2 rejects a
+        # major the served URL has not moved to. There is no third value. Worse, the only document
+        # that went green was one that kept a phantom `status` enum value and a `default` the server
+        # does not use — the gate was not merely blocking the correction, it was requiring the
+        # falsehood, and aml shipped four GATE-CONSTRAINED concessions because of it.
+        #
+        # Why it is safe. A spec-only PR leaves the running server byte-identical, so no client that
+        # works today can stop working; what "breaks" is a client generated from a document that
+        # never described this server, and that client was already broken. Touch any other file in
+        # the service — Kotlin, application.yaml, a test — and the normal breaking rule applies
+        # unchanged. Only CHANGELOG.md and version.txt are exempt, because release-please writes them
+        # and neither can change what is served.
+        #
+        # Why it is not an escape hatch. The discriminator is the diff, not a declaration: there is no
+        # marker file and no PR-body token asserting that a spec "was never served". ~22 specs are
+        # correction candidates (#2314), so anything a human asserts once would become the default
+        # path 22 times over.
+        #
+        # It opens no new hole: landing a breaking change as code in one PR and the spec in another
+        # already escapes this gate, which is scoped to spec diffs. What it does NOT check is whether
+        # the corrected document is TRUE — openapi_route_conformance (below) covers the route set,
+        # and nothing yet covers schemas.
+        #
+        # Unit tests: openbank-infra/scripts/check_api_contract_test.py, run by the
+        # "governance-script unit tests" CI step. The negative cases are the point — a
+        # reclassification that fires too eagerly disables the gate for real breaking changes.
       openapi_route_conformance:
         detect: ["openbank-*/src/main/resources/openapi.yaml", "JAX-RS @Path / @GET / @POST resource classes"]
         require:

--- a/openbank-infra/gitops/components/payments/sepa-payment-opa-bundle.yaml
+++ b/openbank-infra/gitops/components/payments/sepa-payment-opa-bundle.yaml
@@ -9,7 +9,7 @@ metadata:
     app.kubernetes.io/name: sepa-payment
     app.kubernetes.io/part-of: payments
   annotations:
-    openbank.tech/policy-checksum: "b1ddc2cff5f60203"
+    openbank.tech/policy-checksum: "9f778a6a60625676"
 data:
   rest.rego: |
     # SPDX-License-Identifier: Apache-2.0
@@ -1532,6 +1532,37 @@ data:
         # spec-touching PR (bump info.version to match what the diff did), which the error
         # message spells out.
         ci_producer: ".github/scripts/check-api-contract.py"
+        # A fourth class, `correction`, sits between breaking and additive: a breaking DOCUMENT diff
+        # in a PR that changes NOTHING ELSE in the service. It requires MINOR, not MAJOR.
+        #
+        # Why it had to exist. `breaking` and the D2 invariant are jointly unsatisfiable for a spec
+        # that never described the running service. Measured on aml-service (#2312/#2313) with the
+        # pinned oasdiff: red at 1.0.0 because a MAJOR is demanded, red at 2.0.0 because D2 rejects a
+        # major the served URL has not moved to. There is no third value. Worse, the only document
+        # that went green was one that kept a phantom `status` enum value and a `default` the server
+        # does not use — the gate was not merely blocking the correction, it was requiring the
+        # falsehood, and aml shipped four GATE-CONSTRAINED concessions because of it.
+        #
+        # Why it is safe. A spec-only PR leaves the running server byte-identical, so no client that
+        # works today can stop working; what "breaks" is a client generated from a document that
+        # never described this server, and that client was already broken. Touch any other file in
+        # the service — Kotlin, application.yaml, a test — and the normal breaking rule applies
+        # unchanged. Only CHANGELOG.md and version.txt are exempt, because release-please writes them
+        # and neither can change what is served.
+        #
+        # Why it is not an escape hatch. The discriminator is the diff, not a declaration: there is no
+        # marker file and no PR-body token asserting that a spec "was never served". ~22 specs are
+        # correction candidates (#2314), so anything a human asserts once would become the default
+        # path 22 times over.
+        #
+        # It opens no new hole: landing a breaking change as code in one PR and the spec in another
+        # already escapes this gate, which is scoped to spec diffs. What it does NOT check is whether
+        # the corrected document is TRUE — openapi_route_conformance (below) covers the route set,
+        # and nothing yet covers schemas.
+        #
+        # Unit tests: openbank-infra/scripts/check_api_contract_test.py, run by the
+        # "governance-script unit tests" CI step. The negative cases are the point — a
+        # reclassification that fires too eagerly disables the gate for real breaking changes.
       openapi_route_conformance:
         detect: ["openbank-*/src/main/resources/openapi.yaml", "JAX-RS @Path / @GET / @POST resource classes"]
         require:

--- a/openbank-infra/gitops/components/payments/settlement-opa-bundle.yaml
+++ b/openbank-infra/gitops/components/payments/settlement-opa-bundle.yaml
@@ -9,7 +9,7 @@ metadata:
     app.kubernetes.io/name: settlement-service
     app.kubernetes.io/part-of: payments
   annotations:
-    openbank.tech/policy-checksum: "f3e7229be8562ec2"
+    openbank.tech/policy-checksum: "6e4cb27cb39eeff5"
 data:
   rest.rego: |
     # SPDX-License-Identifier: Apache-2.0
@@ -1512,6 +1512,37 @@ data:
         # spec-touching PR (bump info.version to match what the diff did), which the error
         # message spells out.
         ci_producer: ".github/scripts/check-api-contract.py"
+        # A fourth class, `correction`, sits between breaking and additive: a breaking DOCUMENT diff
+        # in a PR that changes NOTHING ELSE in the service. It requires MINOR, not MAJOR.
+        #
+        # Why it had to exist. `breaking` and the D2 invariant are jointly unsatisfiable for a spec
+        # that never described the running service. Measured on aml-service (#2312/#2313) with the
+        # pinned oasdiff: red at 1.0.0 because a MAJOR is demanded, red at 2.0.0 because D2 rejects a
+        # major the served URL has not moved to. There is no third value. Worse, the only document
+        # that went green was one that kept a phantom `status` enum value and a `default` the server
+        # does not use — the gate was not merely blocking the correction, it was requiring the
+        # falsehood, and aml shipped four GATE-CONSTRAINED concessions because of it.
+        #
+        # Why it is safe. A spec-only PR leaves the running server byte-identical, so no client that
+        # works today can stop working; what "breaks" is a client generated from a document that
+        # never described this server, and that client was already broken. Touch any other file in
+        # the service — Kotlin, application.yaml, a test — and the normal breaking rule applies
+        # unchanged. Only CHANGELOG.md and version.txt are exempt, because release-please writes them
+        # and neither can change what is served.
+        #
+        # Why it is not an escape hatch. The discriminator is the diff, not a declaration: there is no
+        # marker file and no PR-body token asserting that a spec "was never served". ~22 specs are
+        # correction candidates (#2314), so anything a human asserts once would become the default
+        # path 22 times over.
+        #
+        # It opens no new hole: landing a breaking change as code in one PR and the spec in another
+        # already escapes this gate, which is scoped to spec diffs. What it does NOT check is whether
+        # the corrected document is TRUE — openapi_route_conformance (below) covers the route set,
+        # and nothing yet covers schemas.
+        #
+        # Unit tests: openbank-infra/scripts/check_api_contract_test.py, run by the
+        # "governance-script unit tests" CI step. The negative cases are the point — a
+        # reclassification that fires too eagerly disables the gate for real breaking changes.
       openapi_route_conformance:
         detect: ["openbank-*/src/main/resources/openapi.yaml", "JAX-RS @Path / @GET / @POST resource classes"]
         require:

--- a/openbank-infra/gitops/components/payments/standing-order-opa-bundle.yaml
+++ b/openbank-infra/gitops/components/payments/standing-order-opa-bundle.yaml
@@ -9,7 +9,7 @@ metadata:
     app.kubernetes.io/name: standing-order-service
     app.kubernetes.io/part-of: payments
   annotations:
-    openbank.tech/policy-checksum: "03d68b059298ad38"
+    openbank.tech/policy-checksum: "5f3323fdc148df78"
 data:
   rest.rego: |
     # SPDX-License-Identifier: Apache-2.0
@@ -1497,6 +1497,37 @@ data:
         # spec-touching PR (bump info.version to match what the diff did), which the error
         # message spells out.
         ci_producer: ".github/scripts/check-api-contract.py"
+        # A fourth class, `correction`, sits between breaking and additive: a breaking DOCUMENT diff
+        # in a PR that changes NOTHING ELSE in the service. It requires MINOR, not MAJOR.
+        #
+        # Why it had to exist. `breaking` and the D2 invariant are jointly unsatisfiable for a spec
+        # that never described the running service. Measured on aml-service (#2312/#2313) with the
+        # pinned oasdiff: red at 1.0.0 because a MAJOR is demanded, red at 2.0.0 because D2 rejects a
+        # major the served URL has not moved to. There is no third value. Worse, the only document
+        # that went green was one that kept a phantom `status` enum value and a `default` the server
+        # does not use — the gate was not merely blocking the correction, it was requiring the
+        # falsehood, and aml shipped four GATE-CONSTRAINED concessions because of it.
+        #
+        # Why it is safe. A spec-only PR leaves the running server byte-identical, so no client that
+        # works today can stop working; what "breaks" is a client generated from a document that
+        # never described this server, and that client was already broken. Touch any other file in
+        # the service — Kotlin, application.yaml, a test — and the normal breaking rule applies
+        # unchanged. Only CHANGELOG.md and version.txt are exempt, because release-please writes them
+        # and neither can change what is served.
+        #
+        # Why it is not an escape hatch. The discriminator is the diff, not a declaration: there is no
+        # marker file and no PR-body token asserting that a spec "was never served". ~22 specs are
+        # correction candidates (#2314), so anything a human asserts once would become the default
+        # path 22 times over.
+        #
+        # It opens no new hole: landing a breaking change as code in one PR and the spec in another
+        # already escapes this gate, which is scoped to spec diffs. What it does NOT check is whether
+        # the corrected document is TRUE — openapi_route_conformance (below) covers the route set,
+        # and nothing yet covers schemas.
+        #
+        # Unit tests: openbank-infra/scripts/check_api_contract_test.py, run by the
+        # "governance-script unit tests" CI step. The negative cases are the point — a
+        # reclassification that fires too eagerly disables the gate for real breaking changes.
       openapi_route_conformance:
         detect: ["openbank-*/src/main/resources/openapi.yaml", "JAX-RS @Path / @GET / @POST resource classes"]
         require:

--- a/openbank-infra/gitops/components/payments/swift-opa-bundle.yaml
+++ b/openbank-infra/gitops/components/payments/swift-opa-bundle.yaml
@@ -9,7 +9,7 @@ metadata:
     app.kubernetes.io/name: swift-service
     app.kubernetes.io/part-of: payments
   annotations:
-    openbank.tech/policy-checksum: "3bc4dacaacfacc2e"
+    openbank.tech/policy-checksum: "3befb3101ab1e0ba"
 data:
   rest.rego: |
     # SPDX-License-Identifier: Apache-2.0
@@ -1515,6 +1515,37 @@ data:
         # spec-touching PR (bump info.version to match what the diff did), which the error
         # message spells out.
         ci_producer: ".github/scripts/check-api-contract.py"
+        # A fourth class, `correction`, sits between breaking and additive: a breaking DOCUMENT diff
+        # in a PR that changes NOTHING ELSE in the service. It requires MINOR, not MAJOR.
+        #
+        # Why it had to exist. `breaking` and the D2 invariant are jointly unsatisfiable for a spec
+        # that never described the running service. Measured on aml-service (#2312/#2313) with the
+        # pinned oasdiff: red at 1.0.0 because a MAJOR is demanded, red at 2.0.0 because D2 rejects a
+        # major the served URL has not moved to. There is no third value. Worse, the only document
+        # that went green was one that kept a phantom `status` enum value and a `default` the server
+        # does not use — the gate was not merely blocking the correction, it was requiring the
+        # falsehood, and aml shipped four GATE-CONSTRAINED concessions because of it.
+        #
+        # Why it is safe. A spec-only PR leaves the running server byte-identical, so no client that
+        # works today can stop working; what "breaks" is a client generated from a document that
+        # never described this server, and that client was already broken. Touch any other file in
+        # the service — Kotlin, application.yaml, a test — and the normal breaking rule applies
+        # unchanged. Only CHANGELOG.md and version.txt are exempt, because release-please writes them
+        # and neither can change what is served.
+        #
+        # Why it is not an escape hatch. The discriminator is the diff, not a declaration: there is no
+        # marker file and no PR-body token asserting that a spec "was never served". ~22 specs are
+        # correction candidates (#2314), so anything a human asserts once would become the default
+        # path 22 times over.
+        #
+        # It opens no new hole: landing a breaking change as code in one PR and the spec in another
+        # already escapes this gate, which is scoped to spec diffs. What it does NOT check is whether
+        # the corrected document is TRUE — openapi_route_conformance (below) covers the route set,
+        # and nothing yet covers schemas.
+        #
+        # Unit tests: openbank-infra/scripts/check_api_contract_test.py, run by the
+        # "governance-script unit tests" CI step. The negative cases are the point — a
+        # reclassification that fires too eagerly disables the gate for real breaking changes.
       openapi_route_conformance:
         detect: ["openbank-*/src/main/resources/openapi.yaml", "JAX-RS @Path / @GET / @POST resource classes"]
         require:

--- a/openbank-infra/gitops/components/payments/transaction-opa-bundle.yaml
+++ b/openbank-infra/gitops/components/payments/transaction-opa-bundle.yaml
@@ -9,7 +9,7 @@ metadata:
     app.kubernetes.io/name: transaction-service
     app.kubernetes.io/part-of: payments
   annotations:
-    openbank.tech/policy-checksum: "47102db2519ee360"
+    openbank.tech/policy-checksum: "36bf9a9ff2fbde65"
 data:
   rest.rego: |
     # SPDX-License-Identifier: Apache-2.0
@@ -1568,6 +1568,37 @@ data:
         # spec-touching PR (bump info.version to match what the diff did), which the error
         # message spells out.
         ci_producer: ".github/scripts/check-api-contract.py"
+        # A fourth class, `correction`, sits between breaking and additive: a breaking DOCUMENT diff
+        # in a PR that changes NOTHING ELSE in the service. It requires MINOR, not MAJOR.
+        #
+        # Why it had to exist. `breaking` and the D2 invariant are jointly unsatisfiable for a spec
+        # that never described the running service. Measured on aml-service (#2312/#2313) with the
+        # pinned oasdiff: red at 1.0.0 because a MAJOR is demanded, red at 2.0.0 because D2 rejects a
+        # major the served URL has not moved to. There is no third value. Worse, the only document
+        # that went green was one that kept a phantom `status` enum value and a `default` the server
+        # does not use — the gate was not merely blocking the correction, it was requiring the
+        # falsehood, and aml shipped four GATE-CONSTRAINED concessions because of it.
+        #
+        # Why it is safe. A spec-only PR leaves the running server byte-identical, so no client that
+        # works today can stop working; what "breaks" is a client generated from a document that
+        # never described this server, and that client was already broken. Touch any other file in
+        # the service — Kotlin, application.yaml, a test — and the normal breaking rule applies
+        # unchanged. Only CHANGELOG.md and version.txt are exempt, because release-please writes them
+        # and neither can change what is served.
+        #
+        # Why it is not an escape hatch. The discriminator is the diff, not a declaration: there is no
+        # marker file and no PR-body token asserting that a spec "was never served". ~22 specs are
+        # correction candidates (#2314), so anything a human asserts once would become the default
+        # path 22 times over.
+        #
+        # It opens no new hole: landing a breaking change as code in one PR and the spec in another
+        # already escapes this gate, which is scoped to spec diffs. What it does NOT check is whether
+        # the corrected document is TRUE — openapi_route_conformance (below) covers the route set,
+        # and nothing yet covers schemas.
+        #
+        # Unit tests: openbank-infra/scripts/check_api_contract_test.py, run by the
+        # "governance-script unit tests" CI step. The negative cases are the point — a
+        # reclassification that fires too eagerly disables the gate for real breaking changes.
       openapi_route_conformance:
         detect: ["openbank-*/src/main/resources/openapi.yaml", "JAX-RS @Path / @GET / @POST resource classes"]
         require:

--- a/openbank-infra/gitops/components/payments/vop-opa-bundle.yaml
+++ b/openbank-infra/gitops/components/payments/vop-opa-bundle.yaml
@@ -9,7 +9,7 @@ metadata:
     app.kubernetes.io/name: vop-service
     app.kubernetes.io/part-of: payments
   annotations:
-    openbank.tech/policy-checksum: "53e78aae6d6a40c8"
+    openbank.tech/policy-checksum: "0a8fe5b6e51debe2"
 data:
   rest.rego: |
     # SPDX-License-Identifier: Apache-2.0
@@ -1519,6 +1519,37 @@ data:
         # spec-touching PR (bump info.version to match what the diff did), which the error
         # message spells out.
         ci_producer: ".github/scripts/check-api-contract.py"
+        # A fourth class, `correction`, sits between breaking and additive: a breaking DOCUMENT diff
+        # in a PR that changes NOTHING ELSE in the service. It requires MINOR, not MAJOR.
+        #
+        # Why it had to exist. `breaking` and the D2 invariant are jointly unsatisfiable for a spec
+        # that never described the running service. Measured on aml-service (#2312/#2313) with the
+        # pinned oasdiff: red at 1.0.0 because a MAJOR is demanded, red at 2.0.0 because D2 rejects a
+        # major the served URL has not moved to. There is no third value. Worse, the only document
+        # that went green was one that kept a phantom `status` enum value and a `default` the server
+        # does not use — the gate was not merely blocking the correction, it was requiring the
+        # falsehood, and aml shipped four GATE-CONSTRAINED concessions because of it.
+        #
+        # Why it is safe. A spec-only PR leaves the running server byte-identical, so no client that
+        # works today can stop working; what "breaks" is a client generated from a document that
+        # never described this server, and that client was already broken. Touch any other file in
+        # the service — Kotlin, application.yaml, a test — and the normal breaking rule applies
+        # unchanged. Only CHANGELOG.md and version.txt are exempt, because release-please writes them
+        # and neither can change what is served.
+        #
+        # Why it is not an escape hatch. The discriminator is the diff, not a declaration: there is no
+        # marker file and no PR-body token asserting that a spec "was never served". ~22 specs are
+        # correction candidates (#2314), so anything a human asserts once would become the default
+        # path 22 times over.
+        #
+        # It opens no new hole: landing a breaking change as code in one PR and the spec in another
+        # already escapes this gate, which is scoped to spec diffs. What it does NOT check is whether
+        # the corrected document is TRUE — openapi_route_conformance (below) covers the route set,
+        # and nothing yet covers schemas.
+        #
+        # Unit tests: openbank-infra/scripts/check_api_contract_test.py, run by the
+        # "governance-script unit tests" CI step. The negative cases are the point — a
+        # reclassification that fires too eagerly disables the gate for real breaking changes.
       openapi_route_conformance:
         detect: ["openbank-*/src/main/resources/openapi.yaml", "JAX-RS @Path / @GET / @POST resource classes"]
         require:

--- a/openbank-infra/gitops/components/pid/pid-opa-bundle.yaml
+++ b/openbank-infra/gitops/components/pid/pid-opa-bundle.yaml
@@ -9,7 +9,7 @@ metadata:
     app.kubernetes.io/name: pid-service
     app.kubernetes.io/part-of: pid
   annotations:
-    openbank.tech/policy-checksum: "f79e3a46a75b5147"
+    openbank.tech/policy-checksum: "574cce1567a2bce9"
 data:
   rest.rego: |
     # SPDX-License-Identifier: Apache-2.0
@@ -1521,6 +1521,37 @@ data:
         # spec-touching PR (bump info.version to match what the diff did), which the error
         # message spells out.
         ci_producer: ".github/scripts/check-api-contract.py"
+        # A fourth class, `correction`, sits between breaking and additive: a breaking DOCUMENT diff
+        # in a PR that changes NOTHING ELSE in the service. It requires MINOR, not MAJOR.
+        #
+        # Why it had to exist. `breaking` and the D2 invariant are jointly unsatisfiable for a spec
+        # that never described the running service. Measured on aml-service (#2312/#2313) with the
+        # pinned oasdiff: red at 1.0.0 because a MAJOR is demanded, red at 2.0.0 because D2 rejects a
+        # major the served URL has not moved to. There is no third value. Worse, the only document
+        # that went green was one that kept a phantom `status` enum value and a `default` the server
+        # does not use — the gate was not merely blocking the correction, it was requiring the
+        # falsehood, and aml shipped four GATE-CONSTRAINED concessions because of it.
+        #
+        # Why it is safe. A spec-only PR leaves the running server byte-identical, so no client that
+        # works today can stop working; what "breaks" is a client generated from a document that
+        # never described this server, and that client was already broken. Touch any other file in
+        # the service — Kotlin, application.yaml, a test — and the normal breaking rule applies
+        # unchanged. Only CHANGELOG.md and version.txt are exempt, because release-please writes them
+        # and neither can change what is served.
+        #
+        # Why it is not an escape hatch. The discriminator is the diff, not a declaration: there is no
+        # marker file and no PR-body token asserting that a spec "was never served". ~22 specs are
+        # correction candidates (#2314), so anything a human asserts once would become the default
+        # path 22 times over.
+        #
+        # It opens no new hole: landing a breaking change as code in one PR and the spec in another
+        # already escapes this gate, which is scoped to spec diffs. What it does NOT check is whether
+        # the corrected document is TRUE — openapi_route_conformance (below) covers the route set,
+        # and nothing yet covers schemas.
+        #
+        # Unit tests: openbank-infra/scripts/check_api_contract_test.py, run by the
+        # "governance-script unit tests" CI step. The negative cases are the point — a
+        # reclassification that fires too eagerly disables the gate for real breaking changes.
       openapi_route_conformance:
         detect: ["openbank-*/src/main/resources/openapi.yaml", "JAX-RS @Path / @GET / @POST resource classes"]
         require:

--- a/openbank-infra/gitops/components/pid/pid-service.yaml
+++ b/openbank-infra/gitops/components/pid/pid-service.yaml
@@ -22,7 +22,7 @@ spec:
       annotations:
         # Rolls the pod when the OPA bundle changes — subPath mounts do NOT hot-reload.
         # Kept in sync by gen-pid-opa-bundle.sh (do not hand-edit).
-        openbank.tech/policy-checksum: "f79e3a46a75b5147"
+        openbank.tech/policy-checksum: "574cce1567a2bce9"
     spec:
       securityContext:
         runAsNonRoot: true

--- a/openbank-infra/gitops/components/psd2-service/psd2-opa-bundle.yaml
+++ b/openbank-infra/gitops/components/psd2-service/psd2-opa-bundle.yaml
@@ -9,7 +9,7 @@ metadata:
     app.kubernetes.io/name: psd2-service
     app.kubernetes.io/part-of: psd2
   annotations:
-    openbank.tech/policy-checksum: "4f32b2fe904dc326"
+    openbank.tech/policy-checksum: "95c4d4a69913aec0"
 data:
   rest.rego: |
     # SPDX-License-Identifier: Apache-2.0
@@ -1594,6 +1594,37 @@ data:
         # spec-touching PR (bump info.version to match what the diff did), which the error
         # message spells out.
         ci_producer: ".github/scripts/check-api-contract.py"
+        # A fourth class, `correction`, sits between breaking and additive: a breaking DOCUMENT diff
+        # in a PR that changes NOTHING ELSE in the service. It requires MINOR, not MAJOR.
+        #
+        # Why it had to exist. `breaking` and the D2 invariant are jointly unsatisfiable for a spec
+        # that never described the running service. Measured on aml-service (#2312/#2313) with the
+        # pinned oasdiff: red at 1.0.0 because a MAJOR is demanded, red at 2.0.0 because D2 rejects a
+        # major the served URL has not moved to. There is no third value. Worse, the only document
+        # that went green was one that kept a phantom `status` enum value and a `default` the server
+        # does not use — the gate was not merely blocking the correction, it was requiring the
+        # falsehood, and aml shipped four GATE-CONSTRAINED concessions because of it.
+        #
+        # Why it is safe. A spec-only PR leaves the running server byte-identical, so no client that
+        # works today can stop working; what "breaks" is a client generated from a document that
+        # never described this server, and that client was already broken. Touch any other file in
+        # the service — Kotlin, application.yaml, a test — and the normal breaking rule applies
+        # unchanged. Only CHANGELOG.md and version.txt are exempt, because release-please writes them
+        # and neither can change what is served.
+        #
+        # Why it is not an escape hatch. The discriminator is the diff, not a declaration: there is no
+        # marker file and no PR-body token asserting that a spec "was never served". ~22 specs are
+        # correction candidates (#2314), so anything a human asserts once would become the default
+        # path 22 times over.
+        #
+        # It opens no new hole: landing a breaking change as code in one PR and the spec in another
+        # already escapes this gate, which is scoped to spec diffs. What it does NOT check is whether
+        # the corrected document is TRUE — openapi_route_conformance (below) covers the route set,
+        # and nothing yet covers schemas.
+        #
+        # Unit tests: openbank-infra/scripts/check_api_contract_test.py, run by the
+        # "governance-script unit tests" CI step. The negative cases are the point — a
+        # reclassification that fires too eagerly disables the gate for real breaking changes.
       openapi_route_conformance:
         detect: ["openbank-*/src/main/resources/openapi.yaml", "JAX-RS @Path / @GET / @POST resource classes"]
         require:

--- a/openbank-infra/gitops/components/psd2-service/psd2-service.yaml
+++ b/openbank-infra/gitops/components/psd2-service/psd2-service.yaml
@@ -18,7 +18,7 @@ spec:
       annotations:
         # Rolls the pod when the OPA bundle changes — subPath mounts do NOT hot-reload.
         # Kept in sync by gen-psd2-opa-bundle.sh (do not hand-edit).
-        openbank.tech/policy-checksum: "4f32b2fe904dc326"
+        openbank.tech/policy-checksum: "95c4d4a69913aec0"
       labels: {app.kubernetes.io/name: psd2-service, app.kubernetes.io/part-of: psd2}
     spec:
       securityContext:

--- a/openbank-infra/gitops/components/sanctions-service/sanctions-opa-bundle.yaml
+++ b/openbank-infra/gitops/components/sanctions-service/sanctions-opa-bundle.yaml
@@ -9,7 +9,7 @@ metadata:
     app.kubernetes.io/name: sanctions-service
     app.kubernetes.io/part-of: sanctions
   annotations:
-    openbank.tech/policy-checksum: "dea05b01e7abed13"
+    openbank.tech/policy-checksum: "472cad6b54875e00"
 data:
   rest.rego: |
     # SPDX-License-Identifier: Apache-2.0
@@ -1499,6 +1499,37 @@ data:
         # spec-touching PR (bump info.version to match what the diff did), which the error
         # message spells out.
         ci_producer: ".github/scripts/check-api-contract.py"
+        # A fourth class, `correction`, sits between breaking and additive: a breaking DOCUMENT diff
+        # in a PR that changes NOTHING ELSE in the service. It requires MINOR, not MAJOR.
+        #
+        # Why it had to exist. `breaking` and the D2 invariant are jointly unsatisfiable for a spec
+        # that never described the running service. Measured on aml-service (#2312/#2313) with the
+        # pinned oasdiff: red at 1.0.0 because a MAJOR is demanded, red at 2.0.0 because D2 rejects a
+        # major the served URL has not moved to. There is no third value. Worse, the only document
+        # that went green was one that kept a phantom `status` enum value and a `default` the server
+        # does not use — the gate was not merely blocking the correction, it was requiring the
+        # falsehood, and aml shipped four GATE-CONSTRAINED concessions because of it.
+        #
+        # Why it is safe. A spec-only PR leaves the running server byte-identical, so no client that
+        # works today can stop working; what "breaks" is a client generated from a document that
+        # never described this server, and that client was already broken. Touch any other file in
+        # the service — Kotlin, application.yaml, a test — and the normal breaking rule applies
+        # unchanged. Only CHANGELOG.md and version.txt are exempt, because release-please writes them
+        # and neither can change what is served.
+        #
+        # Why it is not an escape hatch. The discriminator is the diff, not a declaration: there is no
+        # marker file and no PR-body token asserting that a spec "was never served". ~22 specs are
+        # correction candidates (#2314), so anything a human asserts once would become the default
+        # path 22 times over.
+        #
+        # It opens no new hole: landing a breaking change as code in one PR and the spec in another
+        # already escapes this gate, which is scoped to spec diffs. What it does NOT check is whether
+        # the corrected document is TRUE — openapi_route_conformance (below) covers the route set,
+        # and nothing yet covers schemas.
+        #
+        # Unit tests: openbank-infra/scripts/check_api_contract_test.py, run by the
+        # "governance-script unit tests" CI step. The negative cases are the point — a
+        # reclassification that fires too eagerly disables the gate for real breaking changes.
       openapi_route_conformance:
         detect: ["openbank-*/src/main/resources/openapi.yaml", "JAX-RS @Path / @GET / @POST resource classes"]
         require:

--- a/openbank-infra/gitops/components/sanctions-service/sanctions-service.yaml
+++ b/openbank-infra/gitops/components/sanctions-service/sanctions-service.yaml
@@ -49,7 +49,7 @@ spec:
       annotations:
         # Rolls the pods when the OPA bundle changes — subPath mounts do NOT hot-reload.
         # Kept in sync by gen-sanctions-opa-bundle.sh (do not hand-edit).
-        openbank.tech/policy-checksum: "dea05b01e7abed13"
+        openbank.tech/policy-checksum: "472cad6b54875e00"
     spec:
       securityContext:
         runAsNonRoot: true

--- a/openbank-infra/gitops/components/sca/sca-opa-bundle.yaml
+++ b/openbank-infra/gitops/components/sca/sca-opa-bundle.yaml
@@ -9,7 +9,7 @@ metadata:
     app.kubernetes.io/name: sca-service
     app.kubernetes.io/part-of: sca
   annotations:
-    openbank.tech/policy-checksum: "b08d1a5ed1f7c048"
+    openbank.tech/policy-checksum: "ba9cbe1a555eedc0"
 data:
   rest.rego: |
     # SPDX-License-Identifier: Apache-2.0
@@ -1535,6 +1535,37 @@ data:
         # spec-touching PR (bump info.version to match what the diff did), which the error
         # message spells out.
         ci_producer: ".github/scripts/check-api-contract.py"
+        # A fourth class, `correction`, sits between breaking and additive: a breaking DOCUMENT diff
+        # in a PR that changes NOTHING ELSE in the service. It requires MINOR, not MAJOR.
+        #
+        # Why it had to exist. `breaking` and the D2 invariant are jointly unsatisfiable for a spec
+        # that never described the running service. Measured on aml-service (#2312/#2313) with the
+        # pinned oasdiff: red at 1.0.0 because a MAJOR is demanded, red at 2.0.0 because D2 rejects a
+        # major the served URL has not moved to. There is no third value. Worse, the only document
+        # that went green was one that kept a phantom `status` enum value and a `default` the server
+        # does not use — the gate was not merely blocking the correction, it was requiring the
+        # falsehood, and aml shipped four GATE-CONSTRAINED concessions because of it.
+        #
+        # Why it is safe. A spec-only PR leaves the running server byte-identical, so no client that
+        # works today can stop working; what "breaks" is a client generated from a document that
+        # never described this server, and that client was already broken. Touch any other file in
+        # the service — Kotlin, application.yaml, a test — and the normal breaking rule applies
+        # unchanged. Only CHANGELOG.md and version.txt are exempt, because release-please writes them
+        # and neither can change what is served.
+        #
+        # Why it is not an escape hatch. The discriminator is the diff, not a declaration: there is no
+        # marker file and no PR-body token asserting that a spec "was never served". ~22 specs are
+        # correction candidates (#2314), so anything a human asserts once would become the default
+        # path 22 times over.
+        #
+        # It opens no new hole: landing a breaking change as code in one PR and the spec in another
+        # already escapes this gate, which is scoped to spec diffs. What it does NOT check is whether
+        # the corrected document is TRUE — openapi_route_conformance (below) covers the route set,
+        # and nothing yet covers schemas.
+        #
+        # Unit tests: openbank-infra/scripts/check_api_contract_test.py, run by the
+        # "governance-script unit tests" CI step. The negative cases are the point — a
+        # reclassification that fires too eagerly disables the gate for real breaking changes.
       openapi_route_conformance:
         detect: ["openbank-*/src/main/resources/openapi.yaml", "JAX-RS @Path / @GET / @POST resource classes"]
         require:

--- a/openbank-infra/gitops/components/sca/sca-service.yaml
+++ b/openbank-infra/gitops/components/sca/sca-service.yaml
@@ -28,7 +28,7 @@ spec:
       annotations:
         # Rolls the pods when the OPA bundle changes — subPath mounts do NOT hot-reload.
         # Kept in sync by gen-sca-opa-bundle.sh (do not hand-edit).
-        openbank.tech/policy-checksum: "b08d1a5ed1f7c048"
+        openbank.tech/policy-checksum: "ba9cbe1a555eedc0"
     spec:
       securityContext:
         runAsNonRoot: true

--- a/openbank-infra/gitops/components/statements/statement-opa-bundle.yaml
+++ b/openbank-infra/gitops/components/statements/statement-opa-bundle.yaml
@@ -9,7 +9,7 @@ metadata:
     app.kubernetes.io/name: statement-service
     app.kubernetes.io/part-of: statements
   annotations:
-    openbank.tech/policy-checksum: "794b6ea5ac8766f0"
+    openbank.tech/policy-checksum: "8348ceb18163ab8e"
 data:
   rest.rego: |
     # SPDX-License-Identifier: Apache-2.0
@@ -1565,6 +1565,37 @@ data:
         # spec-touching PR (bump info.version to match what the diff did), which the error
         # message spells out.
         ci_producer: ".github/scripts/check-api-contract.py"
+        # A fourth class, `correction`, sits between breaking and additive: a breaking DOCUMENT diff
+        # in a PR that changes NOTHING ELSE in the service. It requires MINOR, not MAJOR.
+        #
+        # Why it had to exist. `breaking` and the D2 invariant are jointly unsatisfiable for a spec
+        # that never described the running service. Measured on aml-service (#2312/#2313) with the
+        # pinned oasdiff: red at 1.0.0 because a MAJOR is demanded, red at 2.0.0 because D2 rejects a
+        # major the served URL has not moved to. There is no third value. Worse, the only document
+        # that went green was one that kept a phantom `status` enum value and a `default` the server
+        # does not use — the gate was not merely blocking the correction, it was requiring the
+        # falsehood, and aml shipped four GATE-CONSTRAINED concessions because of it.
+        #
+        # Why it is safe. A spec-only PR leaves the running server byte-identical, so no client that
+        # works today can stop working; what "breaks" is a client generated from a document that
+        # never described this server, and that client was already broken. Touch any other file in
+        # the service — Kotlin, application.yaml, a test — and the normal breaking rule applies
+        # unchanged. Only CHANGELOG.md and version.txt are exempt, because release-please writes them
+        # and neither can change what is served.
+        #
+        # Why it is not an escape hatch. The discriminator is the diff, not a declaration: there is no
+        # marker file and no PR-body token asserting that a spec "was never served". ~22 specs are
+        # correction candidates (#2314), so anything a human asserts once would become the default
+        # path 22 times over.
+        #
+        # It opens no new hole: landing a breaking change as code in one PR and the spec in another
+        # already escapes this gate, which is scoped to spec diffs. What it does NOT check is whether
+        # the corrected document is TRUE — openapi_route_conformance (below) covers the route set,
+        # and nothing yet covers schemas.
+        #
+        # Unit tests: openbank-infra/scripts/check_api_contract_test.py, run by the
+        # "governance-script unit tests" CI step. The negative cases are the point — a
+        # reclassification that fires too eagerly disables the gate for real breaking changes.
       openapi_route_conformance:
         detect: ["openbank-*/src/main/resources/openapi.yaml", "JAX-RS @Path / @GET / @POST resource classes"]
         require:

--- a/openbank-infra/gitops/components/statements/statement-service.yaml
+++ b/openbank-infra/gitops/components/statements/statement-service.yaml
@@ -26,7 +26,7 @@ spec:
       annotations:
         # Rolls the pod when the OPA bundle changes — subPath mounts do NOT hot-reload.
         # Kept in sync by gen-statement-opa-bundle.sh (do not hand-edit).
-        openbank.tech/policy-checksum: "794b6ea5ac8766f0"
+        openbank.tech/policy-checksum: "8348ceb18163ab8e"
       labels:
         app.kubernetes.io/name: statement-service
         app.kubernetes.io/part-of: statements

--- a/openbank-infra/gitops/components/tpp-registry/tpp-registry-opa-bundle.yaml
+++ b/openbank-infra/gitops/components/tpp-registry/tpp-registry-opa-bundle.yaml
@@ -9,7 +9,7 @@ metadata:
     app.kubernetes.io/name: tpp-registry-service
     app.kubernetes.io/part-of: tpp-registry
   annotations:
-    openbank.tech/policy-checksum: "e0b31c1b8ff62a4f"
+    openbank.tech/policy-checksum: "f712fa5c86371b08"
 data:
   rest.rego: |
     # SPDX-License-Identifier: Apache-2.0
@@ -1502,6 +1502,37 @@ data:
         # spec-touching PR (bump info.version to match what the diff did), which the error
         # message spells out.
         ci_producer: ".github/scripts/check-api-contract.py"
+        # A fourth class, `correction`, sits between breaking and additive: a breaking DOCUMENT diff
+        # in a PR that changes NOTHING ELSE in the service. It requires MINOR, not MAJOR.
+        #
+        # Why it had to exist. `breaking` and the D2 invariant are jointly unsatisfiable for a spec
+        # that never described the running service. Measured on aml-service (#2312/#2313) with the
+        # pinned oasdiff: red at 1.0.0 because a MAJOR is demanded, red at 2.0.0 because D2 rejects a
+        # major the served URL has not moved to. There is no third value. Worse, the only document
+        # that went green was one that kept a phantom `status` enum value and a `default` the server
+        # does not use — the gate was not merely blocking the correction, it was requiring the
+        # falsehood, and aml shipped four GATE-CONSTRAINED concessions because of it.
+        #
+        # Why it is safe. A spec-only PR leaves the running server byte-identical, so no client that
+        # works today can stop working; what "breaks" is a client generated from a document that
+        # never described this server, and that client was already broken. Touch any other file in
+        # the service — Kotlin, application.yaml, a test — and the normal breaking rule applies
+        # unchanged. Only CHANGELOG.md and version.txt are exempt, because release-please writes them
+        # and neither can change what is served.
+        #
+        # Why it is not an escape hatch. The discriminator is the diff, not a declaration: there is no
+        # marker file and no PR-body token asserting that a spec "was never served". ~22 specs are
+        # correction candidates (#2314), so anything a human asserts once would become the default
+        # path 22 times over.
+        #
+        # It opens no new hole: landing a breaking change as code in one PR and the spec in another
+        # already escapes this gate, which is scoped to spec diffs. What it does NOT check is whether
+        # the corrected document is TRUE — openapi_route_conformance (below) covers the route set,
+        # and nothing yet covers schemas.
+        #
+        # Unit tests: openbank-infra/scripts/check_api_contract_test.py, run by the
+        # "governance-script unit tests" CI step. The negative cases are the point — a
+        # reclassification that fires too eagerly disables the gate for real breaking changes.
       openapi_route_conformance:
         detect: ["openbank-*/src/main/resources/openapi.yaml", "JAX-RS @Path / @GET / @POST resource classes"]
         require:

--- a/openbank-infra/gitops/components/tpp-registry/tpp-registry-service.yaml
+++ b/openbank-infra/gitops/components/tpp-registry/tpp-registry-service.yaml
@@ -23,7 +23,7 @@ spec:
       annotations:
         # Rolls the pod when the OPA bundle changes (subPath mounts do not hot-reload).
         # Kept in sync by gen-tpp-registry-opa-bundle.sh (do not hand-edit).
-        openbank.tech/policy-checksum: "e0b31c1b8ff62a4f"
+        openbank.tech/policy-checksum: "f712fa5c86371b08"
     spec:
       securityContext:
         runAsNonRoot: true

--- a/openbank-infra/scripts/check_api_contract_test.py
+++ b/openbank-infra/scripts/check_api_contract_test.py
@@ -1,0 +1,100 @@
+#!/usr/bin/env python3
+"""Unit tests for check-api-contract.py's `correction` reclassification (#2313).
+
+The gate demands a MAJOR bump for a breaking OpenAPI diff, and the ADR-0048 D2 invariant demands
+that major(info.version) equal the served URL major. For a spec that never described the running
+service those two are jointly unsatisfiable — measured on aml-service, red at 1.0.0 and red at
+2.0.0 — so a spec-only PR reclassifies to `correction` and needs only MINOR.
+
+The tests that matter here are the NEGATIVE ones: a reclassification that fires too eagerly turns
+the gate off for real breaking changes. `service_touched_beyond_spec` is the whole discriminator,
+so it is tested against a diff that must disqualify (a Kotlin change), one that must not (only
+release-please's derived files) and the cross-service cases.
+
+The module under test has a hyphenated filename and lives in .github/scripts, so it is loaded via
+importlib — the same technique the sibling tests use.
+
+Run:  python3 -m unittest openbank-infra/scripts/check_api_contract_test.py -v
+"""
+
+from __future__ import annotations
+
+import importlib.util
+import unittest
+from pathlib import Path
+
+_SCRIPT_PATH = Path(__file__).resolve().parents[2] / ".github/scripts/check-api-contract.py"
+_spec = importlib.util.spec_from_file_location("check_api_contract", _SCRIPT_PATH)
+gate = importlib.util.module_from_spec(_spec)
+assert _spec.loader is not None
+_spec.loader.exec_module(gate)
+
+SPEC = "openbank-aml-service/src/main/resources/openapi.yaml"
+SVC = "openbank-aml-service"
+
+
+class ServiceTouchedBeyondSpecTest(unittest.TestCase):
+    """The discriminator. Empty result => the PR is spec-only => reclassify."""
+
+    def test_spec_only_diff_is_spec_only(self):
+        self.assertEqual(gate.service_touched_beyond_spec(SVC, SPEC, [SPEC]), [])
+
+    def test_kotlin_change_disqualifies(self):
+        """The case that MUST keep the breaking rule — code changed, so the contract may have."""
+        changed = [SPEC, f"{SVC}/src/main/kotlin/com/openbank/aml/infrastructure/rest/AmlCaseResource.kt"]
+        self.assertEqual(len(gate.service_touched_beyond_spec(SVC, SPEC, changed)), 1)
+
+    def test_application_yaml_change_disqualifies(self):
+        """Config can change served behaviour (ports, flags, openbank.api.version) — not derived."""
+        changed = [SPEC, f"{SVC}/src/main/resources/application.yaml"]
+        self.assertEqual(len(gate.service_touched_beyond_spec(SVC, SPEC, changed)), 1)
+
+    def test_release_please_derived_files_do_not_disqualify(self):
+        """CHANGELOG.md and version.txt cannot change what the service serves."""
+        changed = [SPEC, f"{SVC}/CHANGELOG.md", f"{SVC}/version.txt"]
+        self.assertEqual(gate.service_touched_beyond_spec(SVC, SPEC, changed), [])
+
+    def test_another_services_code_does_not_disqualify_this_one(self):
+        """A fleet PR correcting several specs must not disqualify each other's services."""
+        changed = [SPEC, "openbank-fx-service/src/main/kotlin/Foo.kt",
+                   "openbank-fx-service/src/main/resources/openapi.yaml"]
+        self.assertEqual(gate.service_touched_beyond_spec(SVC, SPEC, changed), [])
+
+    def test_service_name_prefix_is_not_a_substring_match(self):
+        """openbank-aml-service-extras/ must not count as openbank-aml-service/."""
+        changed = [SPEC, "openbank-aml-service-extras/src/main/kotlin/Foo.kt"]
+        self.assertEqual(gate.service_touched_beyond_spec(SVC, SPEC, changed), [])
+
+    def test_test_sources_disqualify(self):
+        """Conservative on purpose: only the two derived filenames are exempt, nothing else."""
+        changed = [SPEC, f"{SVC}/src/test/kotlin/AmlCaseResourceTest.kt"]
+        self.assertEqual(len(gate.service_touched_beyond_spec(SVC, SPEC, changed)), 1)
+
+
+class BumpSatisfiedTest(unittest.TestCase):
+    """`correction` must accept MINOR and still reject a standstill or a PATCH."""
+
+    def test_correction_accepts_minor(self):
+        self.assertTrue(gate.bump_satisfied("correction", (1, 0, 0), (1, 1, 0)))
+
+    def test_correction_accepts_major(self):
+        self.assertTrue(gate.bump_satisfied("correction", (1, 0, 0), (2, 0, 0)))
+
+    def test_correction_rejects_no_bump(self):
+        self.assertFalse(gate.bump_satisfied("correction", (1, 0, 0), (1, 0, 0)))
+
+    def test_correction_rejects_patch_only(self):
+        self.assertFalse(gate.bump_satisfied("correction", (1, 0, 0), (1, 0, 1)))
+
+    def test_breaking_still_demands_major(self):
+        """The reclassification must not have loosened the real breaking rule."""
+        self.assertFalse(gate.bump_satisfied("breaking", (1, 0, 0), (1, 9, 0)))
+        self.assertTrue(gate.bump_satisfied("breaking", (1, 0, 0), (2, 0, 0)))
+
+    def test_required_bump_table_covers_correction(self):
+        self.assertEqual(gate.REQUIRED_BUMP["correction"], "MINOR")
+        self.assertEqual(gate.REQUIRED_BUMP["breaking"], "MAJOR")
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/openbank-libs/governance/rules.yaml
+++ b/openbank-libs/governance/rules.yaml
@@ -133,6 +133,37 @@ change_requirements:
     # spec-touching PR (bump info.version to match what the diff did), which the error
     # message spells out.
     ci_producer: ".github/scripts/check-api-contract.py"
+    # A fourth class, `correction`, sits between breaking and additive: a breaking DOCUMENT diff
+    # in a PR that changes NOTHING ELSE in the service. It requires MINOR, not MAJOR.
+    #
+    # Why it had to exist. `breaking` and the D2 invariant are jointly unsatisfiable for a spec
+    # that never described the running service. Measured on aml-service (#2312/#2313) with the
+    # pinned oasdiff: red at 1.0.0 because a MAJOR is demanded, red at 2.0.0 because D2 rejects a
+    # major the served URL has not moved to. There is no third value. Worse, the only document
+    # that went green was one that kept a phantom `status` enum value and a `default` the server
+    # does not use — the gate was not merely blocking the correction, it was requiring the
+    # falsehood, and aml shipped four GATE-CONSTRAINED concessions because of it.
+    #
+    # Why it is safe. A spec-only PR leaves the running server byte-identical, so no client that
+    # works today can stop working; what "breaks" is a client generated from a document that
+    # never described this server, and that client was already broken. Touch any other file in
+    # the service — Kotlin, application.yaml, a test — and the normal breaking rule applies
+    # unchanged. Only CHANGELOG.md and version.txt are exempt, because release-please writes them
+    # and neither can change what is served.
+    #
+    # Why it is not an escape hatch. The discriminator is the diff, not a declaration: there is no
+    # marker file and no PR-body token asserting that a spec "was never served". ~22 specs are
+    # correction candidates (#2314), so anything a human asserts once would become the default
+    # path 22 times over.
+    #
+    # It opens no new hole: landing a breaking change as code in one PR and the spec in another
+    # already escapes this gate, which is scoped to spec diffs. What it does NOT check is whether
+    # the corrected document is TRUE — openapi_route_conformance (below) covers the route set,
+    # and nothing yet covers schemas.
+    #
+    # Unit tests: openbank-infra/scripts/check_api_contract_test.py, run by the
+    # "governance-script unit tests" CI step. The negative cases are the point — a
+    # reclassification that fires too eagerly disables the gate for real breaking changes.
   openapi_route_conformance:
     detect: ["openbank-*/src/main/resources/openapi.yaml", "JAX-RS @Path / @GET / @POST resource classes"]
     require:


### PR DESCRIPTION
## Summary

The api-contract gate and the ADR-0048 D2 invariant were **jointly unsatisfiable** for a spec that
never described the running service. Correcting one was red at the old version (oasdiff calls the
diff breaking, a MAJOR is demanded) and red at MAJOR+1 (D2 rejects a major the served URL has not
moved to). Both ends were measured on aml-service with the pinned oasdiff 1.22.0 — there is no
third value.

Worse than blocking the fix, **it required the falsehood**. The only green document aml could ship
kept the phantom `CLOSED`/`SAR_FILED` status values and a `limit` default of 20 against a server
that uses 50, plus four `GATE-CONSTRAINED` concessions.

## Type of change

- [x] fix (bug fix)

## Linked issues

Closes #2313
Refs #2312, #2314, #2360

## Changes

- `.github/scripts/check-api-contract.py` — a fourth class, `correction`: a breaking **document**
  diff in a PR that changes nothing else in the service requires MINOR, not MAJOR. Emits a
  `::notice` naming the count and the first breaking change, so a reclassification is never silent.
- `openbank-infra/scripts/check_api_contract_test.py` — 13 unit tests, picked up by the existing
  `governance-script unit tests` step.
- `openbank-libs/governance/rules.yaml` — the rule and its reasoning.
- 66 gitops files — the usual `rules.yaml` ripple, generated, verified idempotent.

## Reviewer notes — why this is not an escape hatch

I argued against a declared hatch when I raised #2313 and still do: **the discriminator is the diff,
not an assertion.** No marker file, no PR-body token claiming a spec "was never served". ~22 specs
are correction candidates (#2314), so anything a human asserts once becomes the default path
twenty-two times over.

Why it is safe: a spec-only PR leaves the server byte-identical, so no client that works today can
stop working. What "breaks" is a client generated from a document that never described this server
— already broken before the edit. Touch **any** other file in the service and the breaking rule
applies unchanged; only `CHANGELOG.md` and `version.txt` are exempt, because release-please writes
them and neither changes what is served.

It opens no new hole: landing a breaking change as code in one PR and the spec in another already
escapes this gate, which is scoped to spec diffs.

**Proven on the real case, both directions**, rather than in the abstract — the truthful aml spec
(the one I could not ship this morning) restored locally:

| scenario | verdict |
|---|---|
| spec-only | `reclassifying 10 breaking document change(s) … as a CORRECTION`, then `correction change, 1.1.0 -> 1.2.0 — OK`, **exit 0** |
| identical spec + one line appended to `AmlCase.kt` | `breaking API change requires an info.version MAJOR bump`, **exit 1** |

The second is the one that matters. A reclassification that fires too eagerly disables the gate for
genuine breaking changes, so the unit tests are weighted to the negative cases: a Kotlin change
disqualifies, an `application.yaml` change disqualifies, a **test-source** change disqualifies, and
a service-name prefix is not a substring match (`openbank-aml-service-extras/` must not count as
`openbank-aml-service/`). `bump_satisfied("breaking", …)` is asserted to still reject a MINOR.

The probe commits were removed before pushing; `git diff origin/main -- openbank-aml-service` is
empty, so this PR changes only the gate.

## What it still does not check

Whether the corrected document is **true**. #2360 covers the route set; nothing yet covers schemas
(#2314). This change makes a truthful correction *possible* — it does not verify that a given
correction is truthful.

## Follow-up

The six `GATE-CONSTRAINED` concessions in aml (#2317) and copilot (#2353) become removable once this
lands. Separate PR, which will demonstrate the fix in the wild.

## Definition of Done

- [x] Unit tests added — 13, negative-weighted.
- [x] `python3 -m unittest discover -s openbank-infra/scripts -p '*_test.py'` → **98 tests, OK**.
- [x] Full local gate sweep → 34 scripts, 0 non-zero.

## Security checklist

- [x] No secrets, tokens, passwords, or PII.
- [x] No new dependency (stdlib only).
- [x] The change makes a merge gate *more* permissive in one narrow, mechanically-determined case;
      the negative tests above are the control on that.

## Compliance impact

- [x] None

## Rollout / Rollback

- Deployment strategy: OPA bundle annotations change, so pods roll — unavoidable for any
  `rules.yaml` edit.
- Rollback plan: revert and re-run the generators.

**Short shelf life** — any competing `rules.yaml`/`.rego` PR regenerates the same bundles and
conflicts this one. Merge with `--auto`; on conflict take `main`'s bundles wholesale and re-run the
generators rather than hand-resolving a checksum.
