### PR TITLE
fix(aml): state the four constraints the gate previously forced into prose

### DIFF
--- a/openbank-aml-service/src/main/resources/openapi.yaml
+++ b/openbank-aml-service/src/main/resources/openapi.yaml
@@ -3,13 +3,9 @@
 openapi: 3.1.0
 info:
   title: AML Service API
-  version: 1.1.0
+  version: 1.2.0
   description: >-
     Anti-Money Laundering screening case lifecycle — submit, review, and decide AML cases.
-    Four constraints below are documented in `description` rather than in `required` / `enum` /
-    `default`, because the api-contract gate (ADR-0048 D5) classifies expressing them as a
-    breaking change and would demand a MAJOR bump that ADR-0048 D2 forbids while the service
-    serves /api/v1. Each is marked GATE-CONSTRAINED. See the tracking issue before "fixing" them.
   license:
     name: Apache-2.0
     url: https://www.apache.org/licenses/LICENSE-2.0
@@ -66,13 +62,8 @@ paths:
       parameters:
         - name: status
           in: query
-          description: >-
-            GATE-CONSTRAINED — only the five AmlCaseStatus values are accepted; `CLOSED` and
-            `SAR_FILED` are not in the enum and produce a 400. They are retained here because
-            removing an accepted enum value is `request-parameter-enum-value-removed` (ERR).
           schema:
-            type: string
-            enum: [OPEN, UNDER_REVIEW, CLEARED, BLOCKED, ESCALATED, CLOSED, SAR_FILED]
+            $ref: '#/components/schemas/AmlCaseStatus'
         - name: partyId
           in: query
           schema:
@@ -84,12 +75,9 @@ paths:
             $ref: '#/components/schemas/ScreeningType'
         - name: limit
           in: query
-          description: >-
-            GATE-CONSTRAINED — the server default is 50 (`@DefaultValue("50")`), not 20. Changing
-            a declared default is `request-parameter-default-value-changed` (ERR).
           schema:
             type: integer
-            default: 20
+            default: 50
         - name: offset
           in: query
           schema:
@@ -181,11 +169,9 @@ components:
     idempotencyKey:
       name: Idempotency-Key
       in: header
-      required: false
+      required: true
       description: >-
-        GATE-CONSTRAINED — mandatory in practice. AmlCaseResource.createCase rejects a blank or
-        absent value, so a caller that omits this header always fails; `required: false` is stated
-        only because adding a required parameter is `new-required-request-parameter` (ERR).
+        Caller-supplied key; `AmlCaseResource.createCase` rejects a blank or absent value.
         A repeat with the same key replays the stored 201 response.
       schema:
         type: string
@@ -238,11 +224,7 @@ components:
 
     CreateAmlCaseRequest:
       type: object
-      description: >-
-        GATE-CONSTRAINED — customerReference, screeningType, riskLevel and alertCode are
-        non-nullable on the Kotlin DTO and are rejected when absent, but cannot be listed in
-        `required`: adding one is `new-required-request-property` (ERR).
-      required: [partyId]
+      required: [partyId, customerReference, screeningType, riskLevel, alertCode]
       properties:
         partyId:
           type: string
@@ -273,9 +255,9 @@ components:
     UpdateAmlDecisionRequest:
       type: object
       description: >-
-        GATE-CONSTRAINED — targetStatus and decidedBy are non-nullable on the Kotlin DTO and
-        `decidedBy` is additionally rejected when blank, but neither can be listed in `required`:
-        adding one is `new-required-request-property` (ERR).
+        `decidedBy` is additionally rejected when blank, and `decisionReason` is mandatory when
+        `targetStatus` is BLOCKED — both enforced in `AmlCase.transitionTo`.
+      required: [targetStatus, decidedBy]
       properties:
         targetStatus:
           $ref: '#/components/schemas/AmlCaseStatus'


### PR DESCRIPTION
## Summary

#2317 shipped this spec with four true constraints written as `GATE-CONSTRAINED` `description` prose
instead of as `required` / `enum` / `default`, because the api-contract gate answered every attempt
to express them with "requires a MAJOR bump" while ADR-0048 D2 rejected that major. #2366 fixed the
gate. This states them.

Until now the published contract documented a `limit` default of **20** against a server using 50,
and offered `CLOSED` and `SAR_FILED` as accepted `status` values that `AmlCaseStatus` does not have
and the server answers 400 to.

## Type of change

- [x] fix (bug fix)

## Linked issues

Refs #2313, #2317, #2366

## Changes

| was | now |
|---|---|
| `Idempotency-Key` `required: false` | `required: true` — `createCase` rejects a blank or absent value |
| `status` enum with phantom `CLOSED`, `SAR_FILED` | `$ref` to `AmlCaseStatus`, the five real values |
| `limit` `default: 20` | `default: 50` (`@DefaultValue("50")`) |
| `CreateAmlCaseRequest` `required: [partyId]` | + `customerReference`, `screeningType`, `riskLevel`, `alertCode` |
| `UpdateAmlDecisionRequest` no `required` | `[targetStatus, decidedBy]` |

`info.version` 1.1.0 → 1.2.0. Zero `GATE-CONSTRAINED` text remains anywhere in the fleet.

## Reviewer notes

**This PR is the field test of #2366.** The gate output is the point:

```
::notice::api-contract gate: openbank-aml-service: spec-only PR — reclassifying 10 breaking
document change(s) (first: for the `query` request parameter `limit`, default value was changed
from `20.00` to `50.00`) as a CORRECTION. No other file in openbank-aml-service changed, so the
served contract is unchanged and a MAJOR bump would violate the ADR-0048 D2 URL-major invariant.
Requiring MINOR instead.
api-contract gate: openbank-aml-service: correction change, info.version 1.1.0 -> 1.2.0 — OK
```

The ten ERR-level changes are unchanged from this morning — `request-property-became-required` ×6,
`request-parameter-enum-value-removed` ×2, `request-parameter-became-required`,
`request-parameter-default-value-changed`. Same diff, same classification, different verdict,
because the gate now distinguishes a breaking *document* change from a breaking *contract* change.
This PR touches nothing but the spec, which is exactly the condition the reclassification keys on.

**One description survives, and not because of the gate.** `UpdateAmlDecisionRequest` keeps prose
for a constraint OpenAPI genuinely cannot express: `decisionReason` is mandatory only when
`targetStatus` is `BLOCKED` (`AmlCase.transitionTo`). Conditional requirement has no `required`
form, so that one is documentation by necessity.

**Correction to #2366's description**, which said the concessions were in "aml (#2317) and copilot
(#2353)". They were only ever in aml — `git grep -c GATE-CONSTRAINED` over the fleet returns exactly
one file. copilot's change was fully additive (ERR 0) and never needed a concession.

Also verified: the spec parses, and `check-openapi-route-conformance` stays silent for this service
(`1 service(s) compared, 0 findings`).

## Definition of Done

- [x] Hexagonal layering preserved (no Kotlin changed).
- [ ] Unit tests — N/A, no code change. The request shape is pinned by the provider-verified pact
      `pacts/openbank-fx-service-openbank-aml-service.json`.
- [x] OpenAPI spec updated + `info.version` bumped.

## Security checklist

- [x] No secrets, tokens, passwords, or PII.
- [x] No new dependency, no code change.

## Compliance impact

- [x] AML / 5AMLD

Documentation-only and strictly corrective: the published contract for a compliance service stops
advertising two case statuses that do not exist and a pagination default the server does not use.

## Rollout / Rollback

- Deployment strategy: rolling; no runtime behaviour change (the spec ships inside the artifact).
- Rollback plan: revert the commit.
- Data migration reversible: N/A
