### PR TITLE
fix(infra): score the money-path population rules.yaml actually declares

### DIFF
--- a/.github/scripts/check-podmonitor-namespace-coverage.py
+++ b/.github/scripts/check-podmonitor-namespace-coverage.py
@@ -50,7 +50,12 @@ PODMON_REL = Path(
 # (#2255) — so it lives in exactly one place now, tested by
 # openbank-infra/scripts/prod_readiness_collector_test.py and the fixtures in --self-test below.
 sys.path.insert(0, str(REPO / "openbank-infra" / "scripts"))
-from gitops_facts import podmonitor_namespaces, workload_namespaces  # noqa: E402
+from gitops_facts import (  # noqa: E402
+    module_dir,
+    money_path_services,
+    podmonitor_namespaces,
+    workload_namespaces,
+)
 
 
 def audit(repo: Path) -> tuple[dict[str, list[str]], list[str], int]:
@@ -60,11 +65,22 @@ def audit(repo: Path) -> tuple[dict[str, list[str]], list[str], int]:
     missing: dict[str, list[str]] = {}
     no_workload: list[str] = []
     ok = 0
-    for d in sorted(repo.glob("openbank-*-service")):
+    # The `-service` glob alone skipped openbank-sepa-payment, openbank-sepa-instant and
+    # openbank-domestic-payment, so the three modules that move SEPA and domestic payments were
+    # never checked for scrape coverage at all — this gate reported a complete fleet while three
+    # money-path workloads were outside its population (#2364).
+    shorts = set()
+    for d in repo.glob("openbank-*-service"):
         m = re.match(r"openbank-(.+)-service", d.name)
-        if not m:
-            continue
-        short = m.group(1)
+        if m:
+            shorts.add(m.group(1))
+    try:
+        for s in money_path_services(repo):
+            if module_dir(s, repo).is_dir():
+                shorts.add(s)
+    except RuntimeError:
+        pass  # self-test fixtures carry no rules.yaml; the real repo always does
+    for short in sorted(shorts):
         namespaces = workload_namespaces(short, gitops)
         if not namespaces:
             no_workload.append(short)
@@ -82,13 +98,13 @@ def run_gate(repo: Path, quiet: bool = False) -> int:
     say = (lambda *a: None) if quiet else print
     say(f"PodMonitor namespace coverage: {ok} scraped, {len(missing)} missing, {len(no_workload)} not deployed")
     for short in no_workload:
-        say(f"  note: openbank-{short}-service has no Deployment/Rollout in gitops (not deployed yet)")
+        say(f"  note: {short} has no Deployment/Rollout in gitops (not deployed yet)")
     if not missing:
         return 0
     for short, gaps in sorted(missing.items()):
         for ns in gaps:
             say(
-                f"::error file={PODMON_REL}::openbank-{short}-service runs in namespace "
+                f"::error file={PODMON_REL}::{short} runs in namespace "
                 f"'{ns}', which is absent from namespaceSelector.matchNames — its metrics "
                 f"never reach Prometheus and any PrometheusRule over them cannot fire. "
                 f"Add '{ns}' to {PODMON_REL}."

--- a/docs/runbooks/svc-domestic-payment.md
+++ b/docs/runbooks/svc-domestic-payment.md
@@ -1,0 +1,70 @@
+<!-- Generated starter runbook (generate-service-runbooks.py) from declared
+service facts. Real scaffolding — EXTEND with operational specifics; do not delete.
+Bank-grade ops (prod-readiness C9=3 / C6=3) still needs a real on-call rotation and an
+exercised DR drill, tracked as TTL'd attestations, never faked here. -->
+
+# Runbook — openbank-domestic-payment-service
+
+> Operational runbook for the `domestic-payment` service. Data domain **payments**,
+> classification **confidential**, datastore **PostgreSQL**.
+
+## Service identity
+
+| Field | Value |
+|---|---|
+| Service | `openbank-domestic-payment` |
+| HTTP port | `8116` |
+| Data domain | payments |
+| Datastore | PostgreSQL (schema `domestic_schema`) |
+| Classification | confidential |
+| Retention | 7 years |
+| Lineage role | both |
+
+## Dependencies
+
+- **Upstream (this service consumes):** _none declared_
+- **Downstream (depends on this service):** `transaction-service`, `aml-service`
+
+A failure here propagates to the downstream services above — check them when
+triaging an incident that starts on `domestic-payment`.
+
+## Health & probes
+
+- Readiness: `GET :8116/q/health/ready` · Liveness: `GET :8116/q/health/live`
+- Metrics: scraped by the fleet PodMonitor (namespace `payments`); dashboards in Grafana.
+- Logs: `kubectl logs -n payments deploy/domestic-payment-service -f`, or Loki
+  `{namespace="payments"}`.
+
+## Routine operations
+
+- **Restart:** `kubectl rollout restart deploy/domestic-payment-service -n payments` (rolling, zero-downtime at >1 replica).
+- **Scale:** `kubectl scale deploy/domestic-payment-service -n payments --replicas=<n>` (or edit the GitOps Deployment — GitOps is source of truth, a manual scale is reverted by ArgoCD).
+- **Config/secret change:** edit the GitOps manifest; ArgoCD syncs. Never `kubectl edit` in place.
+
+## Common failure modes
+
+- **Pod CrashLoopBackOff at boot:** usually a missing/invalid config or secret
+  (`ExternalSecret` not synced) or a Flyway checksum mismatch. Check
+  `kubectl describe pod` events and the first 50 log lines.
+- **Readiness flapping:** datastore (PostgreSQL) unreachable or saturated — check the
+  datastore pod/cluster health and connection-pool metrics.
+- **Downstream errors:** verify the upstream dependencies above are healthy before
+  assuming the fault is local.
+
+## Disaster recovery
+
+- **RPO target:** ≤ 5 min (continuous archiving). **RTO target:** ≤ 30 min (restore + warm-up).
+- **Mechanism:** CloudNativePG continuous WAL archiving + base backups to S3 (`barmanObjectStore`). Point-in-time recovery (PITR).
+- **Restore:** create a `Cluster` with `bootstrap.recovery` pointing at the backup object store; CNPG replays WAL to the target time. See runbook 0003 (PG major upgrade) for the cluster-recreate mechanics.
+- **Verify:** `kubectl cnpg status <db>-rw -n <ns>` shows the recovered cluster Healthy and the `*-app` secret regenerated.
+
+> RPO/RTO above are documented targets. They become **Bank-grade** (prod-readiness
+> C6=3) only once a restore/failover drill has actually been rehearsed and attested
+> (`openbank-libs/governance/attestations.yaml: domestic-payment.dr_drill`).
+
+## Escalation & break-glass
+
+- First responder: the owning squad's on-call (rotation tracked as the
+  `domestic-payment.oncall` attestation — until that is live, escalate via the team channel).
+- Break-glass cluster access is audited; use it only for a declared incident and
+  record the justification.

--- a/docs/runbooks/svc-sepa-instant.md
+++ b/docs/runbooks/svc-sepa-instant.md
@@ -1,0 +1,70 @@
+<!-- Generated starter runbook (generate-service-runbooks.py) from declared
+service facts. Real scaffolding — EXTEND with operational specifics; do not delete.
+Bank-grade ops (prod-readiness C9=3 / C6=3) still needs a real on-call rotation and an
+exercised DR drill, tracked as TTL'd attestations, never faked here. -->
+
+# Runbook — openbank-sepa-instant-service
+
+> Operational runbook for the `sepa-instant` service. Data domain **payments**,
+> classification **confidential**, datastore **PostgreSQL**.
+
+## Service identity
+
+| Field | Value |
+|---|---|
+| Service | `openbank-sepa-instant` |
+| HTTP port | `8127` |
+| Data domain | payments |
+| Datastore | PostgreSQL (schema `sepa_instant_schema`) |
+| Classification | confidential |
+| Retention | 7 years |
+| Lineage role | both |
+
+## Dependencies
+
+- **Upstream (this service consumes):** _none declared_
+- **Downstream (depends on this service):** `transaction-service`, `aml-service`
+
+A failure here propagates to the downstream services above — check them when
+triaging an incident that starts on `sepa-instant`.
+
+## Health & probes
+
+- Readiness: `GET :8127/q/health/ready` · Liveness: `GET :8127/q/health/live`
+- Metrics: scraped by the fleet PodMonitor (namespace `payments`); dashboards in Grafana.
+- Logs: `kubectl logs -n payments deploy/sepa-instant-service -f`, or Loki
+  `{namespace="payments"}`.
+
+## Routine operations
+
+- **Restart:** `kubectl rollout restart deploy/sepa-instant-service -n payments` (rolling, zero-downtime at >1 replica).
+- **Scale:** `kubectl scale deploy/sepa-instant-service -n payments --replicas=<n>` (or edit the GitOps Deployment — GitOps is source of truth, a manual scale is reverted by ArgoCD).
+- **Config/secret change:** edit the GitOps manifest; ArgoCD syncs. Never `kubectl edit` in place.
+
+## Common failure modes
+
+- **Pod CrashLoopBackOff at boot:** usually a missing/invalid config or secret
+  (`ExternalSecret` not synced) or a Flyway checksum mismatch. Check
+  `kubectl describe pod` events and the first 50 log lines.
+- **Readiness flapping:** datastore (PostgreSQL) unreachable or saturated — check the
+  datastore pod/cluster health and connection-pool metrics.
+- **Downstream errors:** verify the upstream dependencies above are healthy before
+  assuming the fault is local.
+
+## Disaster recovery
+
+- **RPO target:** ≤ 5 min (continuous archiving). **RTO target:** ≤ 30 min (restore + warm-up).
+- **Mechanism:** CloudNativePG continuous WAL archiving + base backups to S3 (`barmanObjectStore`). Point-in-time recovery (PITR).
+- **Restore:** create a `Cluster` with `bootstrap.recovery` pointing at the backup object store; CNPG replays WAL to the target time. See runbook 0003 (PG major upgrade) for the cluster-recreate mechanics.
+- **Verify:** `kubectl cnpg status <db>-rw -n <ns>` shows the recovered cluster Healthy and the `*-app` secret regenerated.
+
+> RPO/RTO above are documented targets. They become **Bank-grade** (prod-readiness
+> C6=3) only once a restore/failover drill has actually been rehearsed and attested
+> (`openbank-libs/governance/attestations.yaml: sepa-instant.dr_drill`).
+
+## Escalation & break-glass
+
+- First responder: the owning squad's on-call (rotation tracked as the
+  `sepa-instant.oncall` attestation — until that is live, escalate via the team channel).
+- Break-glass cluster access is audited; use it only for a declared incident and
+  record the justification.

--- a/docs/runbooks/svc-sepa-payment.md
+++ b/docs/runbooks/svc-sepa-payment.md
@@ -1,0 +1,70 @@
+<!-- Generated starter runbook (generate-service-runbooks.py) from declared
+service facts. Real scaffolding — EXTEND with operational specifics; do not delete.
+Bank-grade ops (prod-readiness C9=3 / C6=3) still needs a real on-call rotation and an
+exercised DR drill, tracked as TTL'd attestations, never faked here. -->
+
+# Runbook — openbank-sepa-payment-service
+
+> Operational runbook for the `sepa-payment` service. Data domain **payments**,
+> classification **confidential**, datastore **PostgreSQL**.
+
+## Service identity
+
+| Field | Value |
+|---|---|
+| Service | `openbank-sepa-payment` |
+| HTTP port | `8115` |
+| Data domain | payments |
+| Datastore | PostgreSQL (schema `sepa_schema`) |
+| Classification | confidential |
+| Retention | 7 years |
+| Lineage role | both |
+
+## Dependencies
+
+- **Upstream (this service consumes):** _none declared_
+- **Downstream (depends on this service):** `transaction-service`, `aml-service`, `audit-service`
+
+A failure here propagates to the downstream services above — check them when
+triaging an incident that starts on `sepa-payment`.
+
+## Health & probes
+
+- Readiness: `GET :8115/q/health/ready` · Liveness: `GET :8115/q/health/live`
+- Metrics: scraped by the fleet PodMonitor (namespace `payments`); dashboards in Grafana.
+- Logs: `kubectl logs -n payments deploy/sepa-payment-service -f`, or Loki
+  `{namespace="payments"}`.
+
+## Routine operations
+
+- **Restart:** `kubectl rollout restart deploy/sepa-payment-service -n payments` (rolling, zero-downtime at >1 replica).
+- **Scale:** `kubectl scale deploy/sepa-payment-service -n payments --replicas=<n>` (or edit the GitOps Deployment — GitOps is source of truth, a manual scale is reverted by ArgoCD).
+- **Config/secret change:** edit the GitOps manifest; ArgoCD syncs. Never `kubectl edit` in place.
+
+## Common failure modes
+
+- **Pod CrashLoopBackOff at boot:** usually a missing/invalid config or secret
+  (`ExternalSecret` not synced) or a Flyway checksum mismatch. Check
+  `kubectl describe pod` events and the first 50 log lines.
+- **Readiness flapping:** datastore (PostgreSQL) unreachable or saturated — check the
+  datastore pod/cluster health and connection-pool metrics.
+- **Downstream errors:** verify the upstream dependencies above are healthy before
+  assuming the fault is local.
+
+## Disaster recovery
+
+- **RPO target:** ≤ 5 min (continuous archiving). **RTO target:** ≤ 30 min (restore + warm-up).
+- **Mechanism:** CloudNativePG continuous WAL archiving + base backups to S3 (`barmanObjectStore`). Point-in-time recovery (PITR).
+- **Restore:** create a `Cluster` with `bootstrap.recovery` pointing at the backup object store; CNPG replays WAL to the target time. See runbook 0003 (PG major upgrade) for the cluster-recreate mechanics.
+- **Verify:** `kubectl cnpg status <db>-rw -n <ns>` shows the recovered cluster Healthy and the `*-app` secret regenerated.
+
+> RPO/RTO above are documented targets. They become **Bank-grade** (prod-readiness
+> C6=3) only once a restore/failover drill has actually been rehearsed and attested
+> (`openbank-libs/governance/attestations.yaml: sepa-payment.dr_drill`).
+
+## Escalation & break-glass
+
+- First responder: the owning squad's on-call (rotation tracked as the
+  `sepa-payment.oncall` attestation — until that is live, escalate via the team channel).
+- Break-glass cluster access is audited; use it only for a declared incident and
+  record the justification.

--- a/openbank-infra/scripts/generate-service-runbooks.py
+++ b/openbank-infra/scripts/generate-service-runbooks.py
@@ -43,7 +43,7 @@ def read(p: Path) -> str:
 
 def gov_facts(short: str) -> dict:
     """Parse the flat scalars + lineage service names from governance.yaml."""
-    txt = read(REPO / f"openbank-{short}-service" / "governance.yaml")
+    txt = read(gitops_facts.module_dir(short, REPO) / "governance.yaml")
     facts = {}
     for key in ("dataDomain", "primaryDatastore", "schemaName",
                 "dataClassification", "retentionPolicy", "dataLineageRole"):
@@ -60,7 +60,7 @@ def gov_facts(short: str) -> dict:
 
 def http_port(short: str) -> str:
     """The Quarkus HTTP port (skip 8085, the shared management port)."""
-    txt = read(REPO / f"openbank-{short}-service" / "src" / "main" / "resources" / "application.yaml")
+    txt = read(gitops_facts.module_dir(short, REPO) / "src" / "main" / "resources" / "application.yaml")
     for p in re.findall(r"port:\s*(\d+)", txt):
         if p != "8085":
             return p
@@ -159,7 +159,7 @@ exercised DR drill, tracked as TTL'd attestations, never faked here. -->
 
 | Field | Value |
 |---|---|
-| Service | `openbank-{short}-service` |
+| Service | `{module}` |
 | HTTP port | `{port}` |
 | Data domain | {domain} |
 | Datastore | {datastore} (schema `{schema}`) |
@@ -244,6 +244,7 @@ def render(short: str) -> str:
         )
     return TEMPLATE.format(
         short=short,
+        module=gitops_facts.module_dir(short, REPO).name,
         ns=service_namespace(short),
         failure_modes=failure_modes,
         domain=f.get("dataDomain", "—"),
@@ -262,11 +263,18 @@ def render(short: str) -> str:
 
 def all_services() -> list[str]:
     out = []
-    for d in sorted(REPO.glob("openbank-*-service")):
+    out = set()
+    for d in REPO.glob("openbank-*-service"):
         m = re.match(r"openbank-(.+)-service", d.name)
         if m:
-            out.append(m.group(1))
-    return out
+            out.add(m.group(1))
+    # Every module rules.yaml declares money-path needs a runbook too — the `-service` glob alone
+    # skipped openbank-sepa-payment, openbank-sepa-instant and openbank-domestic-payment, so the
+    # three modules that move SEPA and domestic payments had no operational runbook at all (#2364).
+    for short in gitops_facts.money_path_services(REPO):
+        if gitops_facts.module_dir(short, REPO).is_dir():
+            out.add(short)
+    return sorted(out)
 
 
 def main():
@@ -278,8 +286,8 @@ def main():
     targets = args.services or all_services()
     created, skipped = 0, 0
     for short in targets:
-        if not (REPO / f"openbank-{short}-service").is_dir():
-            print(f"skip: openbank-{short}-service not found", file=sys.stderr)
+        if not gitops_facts.module_dir(short, REPO).is_dir():
+            print(f"skip: no module directory for {short!r}", file=sys.stderr)
             continue
         out = RUNBOOKS / f"svc-{short}.md"
         if out.exists() and not args.force:

--- a/openbank-infra/scripts/gitops_facts.py
+++ b/openbank-infra/scripts/gitops_facts.py
@@ -30,6 +30,9 @@ from pathlib import Path
 
 __all__ = [
     "read",
+    "module_dir",
+    "module_names",
+    "money_path_services",
     "service_namespace",
     "workload_namespaces",
     "podmonitor_namespaces",
@@ -37,12 +40,78 @@ __all__ = [
     "is_stateless",
 ]
 
+# Most services live in `openbank-<short>-service`, but the three payment modules do not:
+# `openbank-sepa-payment`, `openbank-sepa-instant` and `openbank-domestic-payment` drop the
+# suffix. Anything that hardcodes the suffix silently skips them — which is exactly how they
+# stayed absent from the prod-readiness matrix while `rules.yaml` declared all three money-path
+# (#2364). Resolve the directory instead of assuming its shape.
+_MODULE_SHAPES = ("openbank-{short}-service", "openbank-{short}")
+
 
 def read(path: Path) -> str:
     try:
         return path.read_text(encoding="utf-8", errors="ignore")
     except OSError:
         return ""
+
+
+def module_dir(short: str, repo: Path) -> Path:
+    """The directory of this module, whichever naming shape it uses.
+
+    Falls back to the `-service` form when neither exists, so a caller that only wants a path
+    to report about a missing module still gets a sensible one.
+    """
+    for shape in _MODULE_SHAPES:
+        candidate = repo / shape.format(short=short)
+        if candidate.is_dir():
+            return candidate
+    return repo / _MODULE_SHAPES[0].format(short=short)
+
+
+def module_names(short: str) -> set[str]:
+    """Every name this module is known by — both directory shapes and their bare workload names."""
+    return {
+        f"openbank-{short}-service",
+        f"openbank-{short}",
+        f"{short}-service",
+        short,
+    }
+
+
+def money_path_services(repo: Path) -> set[str]:
+    """Short names of `rules.yaml: money_path_services` — the AUTHORITATIVE money-path set.
+
+    The collector used to carry a hand-copied 14-name literal of this list while rules.yaml
+    declared 20. Six declared money-path services were therefore scored with the lenient
+    non-money-path gate and read GO, and three were absent from the matrix entirely (#2364).
+    CLAUDE.md's rule applies to code as much as to docs: never keep a second copy of a list that
+    lives in rules.yaml — the second copy IS the drift.
+
+    Raises when the list cannot be read. That is deliberate: an empty set would make EVERY
+    service non-money-path and quietly relax the gate for all of them, which is the precise
+    failure mode this repo keeps finding — a broken probe that reports the reassuring answer.
+    """
+    rules = repo / "openbank-libs" / "governance" / "rules.yaml"
+    text = read(rules)
+    if "money_path_services:" not in text:
+        raise RuntimeError(
+            f"money_path_services not found in {rules} — refusing to score with an empty "
+            f"money-path set, which would relax the gate for every service"
+        )
+    out: set[str] = set()
+    for line in text.split("money_path_services:", 1)[1].splitlines():
+        m = re.match(r"^\s+-\s+openbank-([a-z0-9-]+?)(?:-service)?\s*(?:#.*)?$", line)
+        if m:
+            out.add(m.group(1))
+            continue
+        if line.strip() and not line.strip().startswith("#") and not line.startswith(" " * 4):
+            break  # dedented out of the list
+    if not out:
+        raise RuntimeError(
+            f"money_path_services in {rules} parsed to an empty set — refusing to score, "
+            f"since that would silently relax the gate for every service"
+        )
+    return out
 
 
 def _nearest_kustomize_namespace(manifest: Path, gitops: Path) -> str | None:
@@ -64,11 +133,15 @@ def workload_namespaces(short: str, gitops: Path) -> set[str]:
     to some caller's namespace — which is exactly the class of mistake this module exists to
     prevent. The workload's own `metadata.name` must be the service.
     """
-    names = {f"{short}-service", f"openbank-{short}-service"}
+    names = module_names(short)
+    # Pre-filter on the image reference, which carries the module's own name in either shape
+    # (`openbank-sepa-payment:` as much as `openbank-ledger-service:`). Filtering on the
+    # `-service` form alone skipped the three payment modules entirely (#2364).
+    haystacks = (f"openbank-{short}-service", f"openbank-{short}")
     found: set[str] = set()
     for f in sorted(gitops.rglob("*.yaml")):
         text = read(f)
-        if f"openbank-{short}-service" not in text:
+        if not any(h in text for h in haystacks):
             continue
         for doc in text.split("\n---"):
             kind = re.search(r"^kind:\s*(\S+)", doc, re.M)
@@ -119,7 +192,7 @@ def podmonitor_namespaces(gitops: Path) -> set[str]:
 
 def declared_datastore(short: str, repo: Path) -> str:
     """`primaryDatastore` from the service's governance.yaml (ADR-0071), '' when undeclared."""
-    txt = read(repo / f"openbank-{short}-service" / "governance.yaml")
+    txt = read(module_dir(short, repo) / "governance.yaml")
     m = re.search(r"^primaryDatastore:\s*(.+?)\s*$", txt, re.M)
     return m.group(1).strip() if m else ""
 

--- a/openbank-infra/scripts/gitops_facts_test.py
+++ b/openbank-infra/scripts/gitops_facts_test.py
@@ -1,0 +1,136 @@
+#!/usr/bin/env python3
+# SPDX-License-Identifier: Apache-2.0
+"""Unit tests for gitops_facts (run by ci.yml's governance-script step).
+
+Covers the module-naming and money-path resolution added by #2364. The bug being guarded is
+narrow and was expensive: `openbank-sepa-payment`, `openbank-sepa-instant` and
+`openbank-domestic-payment` drop the `-service` suffix every other module carries, so every
+helper that interpolated `openbank-{short}-service` silently answered about a directory that does
+not exist. That produced a confident WRONG answer rather than an error — reading a missing
+governance.yaml as an empty string made three PostgreSQL-backed payment services look stateless.
+"""
+from __future__ import annotations
+
+import importlib.util
+import sys
+import tempfile
+import unittest
+from pathlib import Path
+
+HERE = Path(__file__).resolve().parent
+
+RULES = """# governance rules
+money_path_services:
+    - openbank-ledger-service
+    - openbank-sepa-payment
+    - openbank-domestic-payment  # inline comment must not break the parse
+    - openbank-vop-service
+
+other_key:
+    - openbank-not-money-path-service
+"""
+
+
+def load():
+    spec = importlib.util.spec_from_file_location("gitops_facts_ut", HERE / "gitops_facts.py")
+    mod = importlib.util.module_from_spec(spec)
+    sys.modules[spec.name] = mod
+    spec.loader.exec_module(mod)
+    return mod
+
+
+class GitopsFactsTest(unittest.TestCase):
+    def setUp(self):
+        self.tmp = tempfile.TemporaryDirectory()
+        self.root = Path(self.tmp.name)
+        self.mod = load()
+
+    def tearDown(self):
+        self.tmp.cleanup()
+
+    def write_rules(self, body=RULES):
+        p = self.root / "openbank-libs" / "governance" / "rules.yaml"
+        p.parent.mkdir(parents=True, exist_ok=True)
+        p.write_text(body)
+
+    # -- module_dir: both naming shapes ------------------------------------
+    def test_module_dir_finds_the_service_suffixed_shape(self):
+        (self.root / "openbank-ledger-service").mkdir()
+        self.assertEqual(self.mod.module_dir("ledger", self.root).name, "openbank-ledger-service")
+
+    def test_module_dir_finds_the_unsuffixed_shape(self):
+        """The sepa-payment / sepa-instant / domestic-payment shape."""
+        (self.root / "openbank-sepa-payment").mkdir()
+        self.assertEqual(
+            self.mod.module_dir("sepa-payment", self.root).name, "openbank-sepa-payment"
+        )
+
+    def test_module_dir_prefers_the_service_shape_when_both_exist(self):
+        (self.root / "openbank-thing-service").mkdir()
+        (self.root / "openbank-thing").mkdir()
+        self.assertEqual(self.mod.module_dir("thing", self.root).name, "openbank-thing-service")
+
+    def test_module_dir_falls_back_without_raising(self):
+        """A caller reporting about a missing module still needs a path to name."""
+        self.assertEqual(self.mod.module_dir("ghost", self.root).name, "openbank-ghost-service")
+
+    # -- declared_datastore must follow the resolved directory -------------
+    def test_declared_datastore_reads_an_unsuffixed_module(self):
+        """The concrete #2364 miss: this returned '' and three PostgreSQL services read stateless."""
+        d = self.root / "openbank-sepa-payment"
+        d.mkdir()
+        (d / "governance.yaml").write_text("primaryDatastore: PostgreSQL\nschemaName: sepa_schema\n")
+        self.assertEqual(self.mod.declared_datastore("sepa-payment", self.root), "PostgreSQL")
+        self.assertFalse(self.mod.is_stateless("PostgreSQL"))
+
+    # -- money_path_services: parsed, never copied ------------------------
+    def test_money_path_services_parses_both_naming_shapes(self):
+        self.write_rules()
+        self.assertEqual(
+            self.mod.money_path_services(self.root),
+            {"ledger", "sepa-payment", "domestic-payment", "vop"},
+        )
+
+    def test_money_path_services_stops_at_the_next_key(self):
+        """`other_key`'s entry must not leak into the money-path set."""
+        self.write_rules()
+        self.assertNotIn("not-money-path", self.mod.money_path_services(self.root))
+
+    def test_money_path_services_raises_when_the_key_is_absent(self):
+        """An empty set would mark the WHOLE fleet non-money-path and relax every gate."""
+        self.write_rules("some_other_key:\n    - openbank-x-service\n")
+        with self.assertRaises(RuntimeError) as ctx:
+            self.mod.money_path_services(self.root)
+        self.assertIn("refusing to score", str(ctx.exception))
+
+    def test_money_path_services_raises_when_the_list_is_empty(self):
+        self.write_rules("money_path_services: []\n")
+        with self.assertRaises(RuntimeError):
+            self.mod.money_path_services(self.root)
+
+    def test_money_path_services_raises_when_rules_yaml_is_missing(self):
+        with self.assertRaises(RuntimeError):
+            self.mod.money_path_services(self.root)
+
+    # -- the live repo: the two sets must not diverge ----------------------
+    def test_the_live_money_path_set_is_reachable_and_non_trivial(self):
+        """Guards the wiring end to end: a regex that stops matching rules.yaml's real formatting
+        would raise rather than silently shrink the set."""
+        repo = HERE.parents[1]
+        live = self.mod.money_path_services(repo)
+        self.assertGreaterEqual(len(live), 15, f"suspiciously small money-path set: {sorted(live)}")
+        for expected in ("ledger", "sepa-payment", "domestic-payment", "sepa-instant"):
+            self.assertIn(expected, live)
+
+    def test_every_live_money_path_module_resolves_to_a_real_directory(self):
+        """A declared money-path module with no directory means rules.yaml and the tree disagree."""
+        repo = HERE.parents[1]
+        missing = [
+            s for s in sorted(self.mod.money_path_services(repo))
+            if not self.mod.module_dir(s, repo).is_dir()
+        ]
+        self.assertEqual(missing, [], f"declared money-path but no module directory: {missing}")
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/openbank-infra/scripts/prod-readiness-collector.py
+++ b/openbank-infra/scripts/prod-readiness-collector.py
@@ -32,6 +32,8 @@ sys.path.insert(0, str(Path(__file__).resolve().parent))
 from gitops_facts import (  # noqa: E402  (path must be set before the import)
     declared_datastore,
     is_stateless,
+    module_dir,
+    money_path_services,
     podmonitor_namespaces,
     service_namespace,
 )
@@ -44,13 +46,19 @@ ATTESTATIONS = REPO / "openbank-libs" / "governance" / "attestations.yaml"
 RELEASE_EVIDENCE = REPO / ".github" / "workflows" / "release-please.yml"
 VEX_DIR = REPO / "openbank-libs" / "governance" / "vex"
 
-# Money-path services (mirror of rules.yaml: money_path_services). Kept short
-# here; the real collector would parse rules.yaml. These get a stricter gate.
-MONEY_PATH = {
-    "ledger", "transaction", "account", "balance", "sepa-payment",
-    "sepa-instant", "domestic-payment", "clearing", "swift", "fx",
-    "lending", "sca", "consent", "fraud",
-}
+# Money-path services come from rules.yaml, the authoritative list — never a copy. The literal
+# that used to live here named 14 services while rules.yaml declared 20, so sdd, interest,
+# billing, settlement, sanctions and vop were scored with the LENIENT gate and read GO (#2364).
+# money_path_services() raises rather than returning an empty set, because an empty set would
+# relax the gate for the whole fleet while looking like a clean run.
+def money_path() -> set[str]:
+    """The money-path set, read from rules.yaml at CALL time.
+
+    Deliberately a function, not a module-level constant: REPO is rebindable (the test suite
+    points it at a fixture tree), and a constant evaluated at import would both ignore that
+    rebinding and raise on any tree without a rules.yaml.
+    """
+    return money_path_services(REPO)
 
 DIMENSIONS = [
     ("C1", "Kód"),
@@ -69,7 +77,10 @@ DIMENSIONS = [
 # helpers
 # ---------------------------------------------------------------------------
 def svc_dir(short: str) -> Path:
-    return REPO / f"openbank-{short}-service"
+    # Not every module is `openbank-<short>-service`: the three payment modules
+    # (sepa-payment, sepa-instant, domestic-payment) drop the suffix. Resolving the shape here
+    # is what lets them be scored at all (#2364).
+    return module_dir(short, REPO)
 
 
 def exists_dir(short: str) -> bool:
@@ -259,7 +270,7 @@ def committed_pacts(short: str) -> list[str]:
     pacts = REPO / "pacts"
     if not pacts.is_dir():
         return []
-    token = f"openbank-{short}-service"
+    token = svc_dir(short).name  # module dir name — the payment modules drop the -service suffix
     return sorted(p.name for p in pacts.glob("*.json") if token in p.name)
 
 
@@ -353,7 +364,7 @@ def has_vex_triage(short: str) -> bool:
 
 
 def score_c7_security(short: str, att, today) -> tuple[int, str]:
-    tm = (THREAT_MODELS / f"openbank-{short}-service.md").exists()
+    tm = (THREAT_MODELS / f"{svc_dir(short).name}.md").exists()
     netpol = bool(gitops_files_for(short, "NetworkPolicy"))
     sectest = grep_any(svc_dir(short) / "src" / "test",
                        ["Security", "schemathesis", "Authz"])
@@ -454,7 +465,7 @@ class ServiceReadiness:
 
 
 def collect(short: str, att, today: str) -> ServiceReadiness:
-    r = ServiceReadiness(service=short, money_path=short in MONEY_PATH)
+    r = ServiceReadiness(service=short, money_path=short in money_path())
     for (code, _), scorer in zip(DIMENSIONS, SCORERS):
         s, ev = scorer(short, att, today)
         r.scores[code] = s
@@ -464,12 +475,28 @@ def collect(short: str, att, today: str) -> ServiceReadiness:
 
 
 def all_services() -> list[str]:
-    out = []
-    for d in sorted(REPO.glob("openbank-*-service")):
+    """Every module the matrix scores: the `-service` modules PLUS every declared money-path one.
+
+    The `openbank-*-service` glob alone missed openbank-sepa-payment, openbank-sepa-instant and
+    openbank-domestic-payment — three released components with a governance.yaml, an openapi.yaml
+    and a threat model, which rules.yaml declares money-path and which move SEPA and domestic
+    payments. They had no row at all, so every headline this collector produced ("N cells below
+    Verified", "GO x/37") silently excluded them (#2364). A module governance calls money-path
+    must never be absent from the readiness matrix.
+
+    Deliberately NOT widened to every module carrying a governance.yaml + src/main: that would
+    add 12 further agent/auxiliary modules and is a scoping decision about what the matrix
+    covers, not a correctness fix.
+    """
+    out = set()
+    for d in REPO.glob("openbank-*-service"):
         m = re.match(r"openbank-(.+)-service", d.name)
         if m:
-            out.append(m.group(1))
-    return out
+            out.add(m.group(1))
+    for short in money_path():
+        if module_dir(short, REPO).is_dir():
+            out.add(short)
+    return sorted(out)
 
 
 # ---------------------------------------------------------------------------
@@ -511,7 +538,7 @@ def main():
     results = []
     for short in targets:
         if not exists_dir(short):
-            print(f"skip: openbank-{short}-service not found", file=sys.stderr)
+            print(f"skip: no module directory for {short!r}", file=sys.stderr)
             continue
         results.append(collect(short, att, args.today))
 

--- a/openbank-infra/scripts/prod_readiness_collector_test.py
+++ b/openbank-infra/scripts/prod_readiness_collector_test.py
@@ -128,6 +128,76 @@ class CollectorScorerTest(unittest.TestCase):
         p.parent.mkdir(parents=True, exist_ok=True)
         p.write_text(body)
 
+    # -- the scored population and the money-path set (#2364) --------------
+    def write_rules(self, entries=("openbank-ledger-service", "openbank-sepa-payment")):
+        p = self.root / "openbank-libs" / "governance" / "rules.yaml"
+        p.parent.mkdir(parents=True, exist_ok=True)
+        p.write_text("money_path_services:\n" + "".join(f"    - {e}\n" for e in entries))
+
+    def test_all_services_includes_a_money_path_module_the_glob_would_miss(self):
+        """openbank-sepa-payment has no `-service` suffix, so the glob alone dropped it — and with
+        it every headline the matrix printed (#2364)."""
+        self.write_rules()
+        (self.root / "openbank-ledger-service").mkdir(exist_ok=True)
+        (self.root / "openbank-sepa-payment").mkdir(exist_ok=True)
+        services = self.mod.all_services()
+        self.assertIn("sepa-payment", services)
+        self.assertIn("ledger", services)
+
+    def test_all_services_skips_a_declared_module_with_no_directory(self):
+        self.write_rules(("openbank-ledger-service", "openbank-ghost-service"))
+        (self.root / "openbank-ledger-service").mkdir(exist_ok=True)
+        self.assertNotIn("ghost", self.mod.all_services())
+
+    def test_money_path_comes_from_rules_yaml_not_a_literal(self):
+        """The hardcoded set named 14 while rules.yaml declared 20, so six declared money-path
+        services were gated leniently and read GO."""
+        self.write_rules(("openbank-widget-service",))
+        self.assertEqual(self.mod.money_path(), {"widget"})
+
+    def test_money_path_is_read_at_call_time_not_import_time(self):
+        """A module-level constant would ignore a rebound REPO and raise on a rules-less tree."""
+        self.write_rules(("openbank-alpha-service",))
+        self.assertEqual(self.mod.money_path(), {"alpha"})
+        self.write_rules(("openbank-beta-service",))
+        self.assertEqual(self.mod.money_path(), {"beta"})
+
+    def test_a_money_path_service_needs_three_on_the_critical_cells(self):
+        """The stricter gate is what the six leniently-scored services were missing."""
+        self.write_rules(("openbank-widget-service",))
+        r = self.mod.ServiceReadiness(service="widget", money_path=True)
+        r.scores = {c: 2 for c, _ in self.mod.DIMENSIONS}
+        r.compute_gate()
+        self.assertEqual(r.gate, "NO-GO", "all-2 must not clear the money-path gate")
+        for critical in ("C1", "C5", "C7"):
+            r.scores[critical] = 3
+        r.compute_gate()
+        self.assertEqual(r.gate, "GO")
+
+    def test_a_non_money_path_service_clears_at_all_twos(self):
+        r = self.mod.ServiceReadiness(service="widget", money_path=False)
+        r.scores = {c: 2 for c, _ in self.mod.DIMENSIONS}
+        r.compute_gate()
+        self.assertEqual(r.gate, "GO")
+
+    def test_threat_model_is_looked_up_under_the_resolved_module_name(self):
+        """C7 read docs/threat-models/openbank-sepa-payment-service.md — a file that cannot exist."""
+        (self.root / "openbank-sepa-payment").mkdir(exist_ok=True)
+        tm = self.root / "docs" / "threat-models"
+        tm.mkdir(parents=True, exist_ok=True)
+        (tm / "openbank-sepa-payment.md").write_text("# threat model\n")
+        self.mod.THREAT_MODELS = tm
+        score, evidence = self.mod.score_c7_security("sepa-payment", {}, "2026-07-25")
+        # NOT `assertIn("threat-model", evidence)`: the zero-score evidence string is
+        # "no threat-model/netpol/sectest/provenance", which contains that substring, so the
+        # loose assertion passes against the unfixed code. Same substring trap this whole sweep
+        # has been pulling out of the scorers — assert the positive form.
+        self.assertNotIn("no threat-model", evidence, "C7 found no threat model at all")
+        self.assertTrue(
+            evidence.startswith("threat-model") or ", threat-model" in evidence,
+            f"threat-model not listed as present: {evidence!r}",
+        )
+
     # -- C1: ports live in the package, not the filename --------------------
     def test_c1_counts_an_application_port_package(self):
         """anacredit/onboarding shape: a port package whose files are not named *Port*."""


### PR DESCRIPTION
## What

The collector decided **who gets the strict money-path gate** from a hardcoded 14-name literal, and
**who gets scored at all** from an `openbank-*-service` glob. `rules.yaml` declares **20** money-path
services, three of which drop the `-service` suffix. Both numbers were wrong in the direction that
flatters the matrix.

`Closes #2364` · `Refs #2255, #2365`

## Six services were graded on the wrong curve

`sdd` · `interest` · `billing` · `settlement` · `sanctions` · `vop` — all declared money-path in
`rules.yaml`, all scored with the **lenient** gate, all reading **GO**. Under their real gate each
needs **3** on C1/C5/C7, so all six now read NO-GO. `rules.yaml` is unambiguous about them: sdd
"posts a real debit", interest "capitalize()/write-off post real GL journals", settlement is the
"debit → credit → ledger booking saga".

## Three money-path modules had no row at all

`openbank-sepa-payment` · `openbank-sepa-instant` · `openbank-domestic-payment`

Each is a released component with a `version.txt`, `governance.yaml`, `openapi.yaml` and a threat
model, and between them they move SEPA and domestic payments. **Every headline the collector printed
— "N cells below Verified", "GO x/37" — silently excluded them.** They also had no per-service
runbook (the generator globbed the same way) and sat outside the PodMonitor coverage gate's
population (their namespaces were already in `matchNames`, so nothing was unscraped — the gate
simply wasn't looking).

## Six hardcoded paths, each answering confidently about a directory that does not exist

The worst was `declared_datastore`: a missing `governance.yaml` reads as `""`, and `is_stateless("")`
is true, so three PostgreSQL-backed payment services read as **stateless**.

**Worth flagging in review:** my own first measurement of this change reported a `CONTRADICTION`
finding for all three — *"governance.yaml says datastore 'none' but 6 migration(s) exist"* — and I
was one step from filing an issue about three misdeclared money-path services. It was **entirely
manufactured by the incomplete fix**, and only caught by opening the three `governance.yaml` files by
hand. All three declare `primaryDatastore: PostgreSQL` and always did.

C7 was also looking for `docs/threat-models/openbank-sepa-payment-service.md` — a filename that
cannot exist — so their threat models did not count either.

## The empty-set guard is the load-bearing part

`money_path_services()` **raises** rather than returning an empty set. An empty set would mark the
whole fleet non-money-path and relax every gate *while presenting as a clean run* — the exact failure
shape this repo keeps digging out. It is a **function, not a module constant**: `REPO` is rebindable,
and a constant evaluated at import would both ignore the test fixtures and raise on any tree without
a `rules.yaml`.

## Verification

| check | result |
|---|---|
| new tests vs. the code as it stood | **12 of 16** in `gitops_facts_test` + **4** in the collector suite go RED |
| full `openbank-infra/scripts` suite | **117 tests, OK** (was 85) |
| existing 37 runbooks after the generator change | **byte-identical** — refactor, not rewrite |
| PodMonitor coverage gate | `40 scraped, 0 missing, 0 not deployed`, self-test passes |

One test was **vacuous on the first pass** and is worth recording: the C7 test asserted
`"threat-model" in evidence`, which passes against the unfixed code because the zero-score evidence
string reads `"no threat-model/netpol/sectest/provenance"` and contains that substring. The same
substring trap this sweep pulled out of the C3 and C8 scorers, reproduced in the test written to catch
it. Now asserts the positive form and goes red correctly.

## Fleet effect — GO goes down, which is the point

| | before | after |
|---|---|---|
| services scored | 37 | **40** |
| money-path gated | 11 | **20** |
| GO | 26 | **20** |
| cells below Verified | 0 | **0** |

Nothing regressed. The matrix now grades the population governance declares, against the gate that
population is owed. The remaining NO-GO set is exactly the 20 money-path services, blocked on the
attestations in #2365 — which should be re-scoped from 33 to 60 now that the denominator is right.

## Scope held deliberately

**Not** widened to every module with a `governance.yaml` + `src/main`. That would add 12 further
agent/auxiliary modules (customer-edge, product-catalog, the six auditor agents, …) and is a decision
about what the matrix covers, not a correctness fix. Worth its own issue if wanted.
