### PR TITLE
ci(governance): enforce the evals-registry gate instead of advisory (#1918)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -442,10 +442,25 @@ jobs:
       # (openbank-libs/governance/evals/<charter>.yaml) declares per-charter scenario success
       # criteria the promotion ratchet consumes; this guard keeps it well-formed (charter resolves,
       # version is v<N>, scenarios have id/description/input/assert, assert keys the runner
-      # understands, prompt refs resolve). ADVISORY first (ADR-0144): backlog charters are
-      # ::warning; run-evals.py below is the runner that consumes this registry.
-      - name: "evals-registry integrity (ADR-0148, advisory)"
-        continue-on-error: true
+      # understands, prompt refs resolve). run-evals.py below is the runner that consumes this
+      # registry.
+      #
+      # ENFORCED (was advisory), same reasoning as the prompt-registry step above (#2363): every
+      # error this script exits non-zero on is structural and fixable in the PR that introduces it —
+      # a suite naming a charter absent from agents.yaml, a filename that is not <charter>.yaml, a
+      # version that is not v<N>, an empty or malformed scenario list, a duplicate scenario id, an
+      # assert key the runner cannot evaluate, or a dangling prompt reference. None of them waits on
+      # the migration backlog. Coverage — charters with no suite yet — is ::warning inside the
+      # script and stays advisory.
+      #
+      # The dangling-prompt-ref check is what makes this worth enforcing rather than watching: it is
+      # the only thing tying a suite to the prompt registry, so an enforced gate here means deleting
+      # or renaming a registered prompt file cannot silently orphan the eval suite that measures it.
+      #
+      # Runs in `Validate manifests`, a required check, so it now blocks merge — and that job stops
+      # at its first failing gate, leaving later steps `skipped`, not `pass`. Run it locally before
+      # pushing: python3 .github/scripts/check-evals-registry.py
+      - name: "evals-registry integrity (ADR-0148, enforced)"
         run: python3 .github/scripts/check-evals-registry.py
 
       # ADR-0148 evals gate — the RUNNER's self-test. ENFORCED on purpose, and deliberately placed


### PR DESCRIPTION
## What

Second half of #2363, which enforced the sibling *prompt-registry* gate and deliberately left this one alone. `evals-registry integrity (ADR-0148, advisory)` ran with `continue-on-error: true`; this drops it and renames the step `(ADR-0148, enforced)`.

## Why it is safe to flip — checked, not assumed

Everything `check-evals-registry.py` exits non-zero on is structural and fixable inside the PR that introduces it:

- a suite whose `charter:` is not an `id:` in `agents.yaml`
- a filename that is not `<charter>.yaml`
- a `version:` that is not `v<N>`
- an empty or malformed `scenarios:` list
- a duplicate or non-`[a-z0-9-]` scenario id
- an empty `assert`, or an assert key the runner cannot evaluate
- a `prompt:` that does not resolve to `prompts/<charter>/<prompt>.md`

None of them waits on the migration backlog. **Coverage** — the 10 charters with no suite yet — is `::warning` inside the script and stays advisory after the flip.

The **dangling-prompt-ref** check is the reason this is worth enforcing rather than watching: it is the only link between an eval suite and the prompt registry. Enforced, deleting or renaming a registered prompt file can no longer silently orphan the suite that measures it. That link is load-bearing now that `control-liveness-sentinel.yaml` pins `prompt: system.v2` (#2321) and #2363 wrote down why a superseded prompt file must stay on disk.

## Precondition

The gate is **green on the current `origin/main`** (`2120a3cb`):

```
evals-registry: 5 suite(s) across 5 charter(s), structure OK; 10 charter(s) pending.
EXIT=0
```

Unlike the prompt-registry gate — which had been red on main since `cffc5ff9` and needed a fix commit in the same PR — this one has no accumulated red to clear, so the flip stands alone. That check mattered: the step runs in `Validate manifests`, one of the five required contexts, so enforcing it while main was red would have blocked every open PR on an error none of them introduced.

## Verification

Exits 0 on this branch, and falsified against a known-positive **first** — pointing `control-liveness-sentinel.yaml` at a nonexistent `prompt: system.v9`:

```
::error title=Evals registry::openbank-libs/governance/evals/control-liveness-sentinel.yaml — prompt 'system.v9' does not resolve to openbank-libs/governance/prompts/control-liveness-sentinel/system.v9.md (dangling prompt reference)
BROKEN_EXIT=1
```

`actionlint` and `yamllint` under the CI job's own inline config report identical finding sets to `origin/main` (0 errors).

## Follow-up, not done here

The coverage warning lists all 10 charters without a suite — including 2 `not-applicable` (`mcp-anonymous`, `ap2-anonymous`) and 2 `external` (`rca-investigator`, `ledger-domain-engineer`) that can never have one. This script does not read `prompts/registry.yaml`'s status vocabulary the way `check-prompt-registry.py` does, so its backlog number is inflated by 4. That is exactly the absent-vs-not-applicable conflation `registry.yaml` was introduced to end; it deserves its own PR rather than riding a gate flip.

Also still open from #2363: neither ADR-0148 gate has a `rules.yaml` rule entry, so the enforcement fact lives only in `ci.yml`. Adding one restamps every service's OPA bundle.

## Linked issues

Refs #1918