### PR TITLE
security(sca): remove SMS_OTP — its only implementation logs the OTP instead of delivering it

### DIFF
--- a/openbank-sca-service/src/main/kotlin/com/openbank/sca/application/port/out/ScaPorts.kt
+++ b/openbank-sca-service/src/main/kotlin/com/openbank/sca/application/port/out/ScaPorts.kt
@@ -52,12 +52,10 @@ interface ScaIdempotencyStore {
     suspend fun save(key: String, challengeId: UUID, ttlSeconds: Long)
 }
 
-/** Outbound port for delivering SCA challenges to the user out-of-band (push / SMS). */
+/** Outbound port for delivering SCA challenges to the user out-of-band (push). */
 interface NotificationSender {
 
     suspend fun sendPushNotification(partyId: UUID, challengeId: UUID, message: String)
-
-    suspend fun sendSmsOtp(partyId: UUID, otp: String)
 }
 
 /** Durable store of device credentials enrolled to a party (ADR-0021). */

--- a/openbank-sca-service/src/main/kotlin/com/openbank/sca/application/usecase/NotificationDispatchGuard.kt
+++ b/openbank-sca-service/src/main/kotlin/com/openbank/sca/application/usecase/NotificationDispatchGuard.kt
@@ -20,11 +20,4 @@ class NotificationDispatchGuard(private val notificationSender: NotificationSend
     suspend fun sendPushNotification(partyId: UUID, challengeId: UUID, message: String) {
         notificationSender.sendPushNotification(partyId, challengeId, message)
     }
-
-    @Timeout(2000)
-    @Retry(maxRetries = 2, delay = 200, jitter = 100, retryOn = [Exception::class])
-    @CircuitBreaker(requestVolumeThreshold = 10, failureRatio = 0.5, delay = 5000, successThreshold = 2)
-    suspend fun sendSmsOtp(partyId: UUID, otp: String) {
-        notificationSender.sendSmsOtp(partyId, otp)
-    }
 }

--- a/openbank-sca-service/src/main/kotlin/com/openbank/sca/application/usecase/ScaService.kt
+++ b/openbank-sca-service/src/main/kotlin/com/openbank/sca/application/usecase/ScaService.kt
@@ -159,12 +159,9 @@ class ScaService(
         idempotencyStore.save(idempotencyKey, saved.id, minOf(ttlSeconds, idempotencyTtlSeconds))
 
         when (method) {
-            ScaMethod.SMS_OTP, ScaMethod.TOTP -> {
+            ScaMethod.TOTP -> {
                 val otp = otpGenerator.generate()
                 otpStore.store(saved.id, otp, ttlSeconds)
-                if (method == ScaMethod.SMS_OTP) {
-                    notificationDispatchGuard.sendSmsOtp(command.partyId, otp)
-                }
             }
             ScaMethod.PUSH_NOTIFICATION, ScaMethod.BIOMETRIC -> {
                 notificationDispatchGuard.sendPushNotification(
@@ -187,7 +184,7 @@ class ScaService(
         if (!challenge.canAttempt(now)) throw ScaChallengeMaxAttemptsException(command.challengeId)
 
         return when (challenge.method) {
-            ScaMethod.SMS_OTP, ScaMethod.TOTP -> verifyOtp(challenge, command, now)
+            ScaMethod.TOTP -> verifyOtp(challenge, command, now)
             // Decoupled methods (ADR-0021): never auto-approve. The authentication happened
             // out-of-band on the enrolled device; we consult the signature-verified decision
             // recorded by recordDecision(). No decision yet => the challenge stays PENDING

--- a/openbank-sca-service/src/main/kotlin/com/openbank/sca/domain/model/ScaChallenge.kt
+++ b/openbank-sca-service/src/main/kotlin/com/openbank/sca/domain/model/ScaChallenge.kt
@@ -9,7 +9,6 @@ import java.util.UUID
 
 enum class ScaMethod {
     PUSH_NOTIFICATION,
-    SMS_OTP,
     TOTP,
     BIOMETRIC,
 }

--- a/openbank-sca-service/src/main/kotlin/com/openbank/sca/infrastructure/ScaAdapters.kt
+++ b/openbank-sca-service/src/main/kotlin/com/openbank/sca/infrastructure/ScaAdapters.kt
@@ -83,8 +83,4 @@ class LoggingNotificationSender(
         )
         notificationEmitter.send(Record.of(partyId.toString(), objectMapper.writeValueAsString(request)))
     }
-
-    override suspend fun sendSmsOtp(partyId: UUID, otp: String) {
-        log.infof("SMS OTP → partyId=%s otp=%s", partyId, otp)
-    }
 }

--- a/openbank-sca-service/src/main/resources/docs/01-overview.cs.md
+++ b/openbank-sca-service/src/main/resources/docs/01-overview.cs.md
@@ -4,7 +4,7 @@
 
 `openbank-sca-service` je **stroj pro silné ověření zákazníka (SCA)** na platformě OpenBank. Provádí step-up autentizaci, když si jiná služba potřebuje být jistá, že je přítomen skutečný zákazník a schválil citlivou akci. Drží:
 
-- **Agregát ScaChallenge** — jedna autentizační výzva: party, účel (PAYMENT_INITIATION / CONSENT_GRANT / LOGIN / AGENT_ACTION / SENSITIVE_DATA_ACCESS), metoda (SMS_OTP / TOTP / PUSH_NOTIFICATION / BIOMETRIC), stav (PENDING / COMPLETED / FAILED / EXPIRED / CANCELLED), čítač pokusů, expirace a volitelná **data dynamického provázání** (částka, měna, IBAN/jméno příjemce, reference) dle PSD2 RTS čl. 5.
+- **Agregát ScaChallenge** — jedna autentizační výzva: party, účel (PAYMENT_INITIATION / CONSENT_GRANT / LOGIN / AGENT_ACTION / SENSITIVE_DATA_ACCESS), metoda (TOTP / PUSH_NOTIFICATION / BIOMETRIC), stav (PENDING / COMPLETED / FAILED / EXPIRED / CANCELLED), čítač pokusů, expirace a volitelná **data dynamického provázání** (částka, měna, IBAN/jméno příjemce, reference) dle PSD2 RTS čl. 5.
 - **EnrolledDevice** — credential zařízení (veřejný klíč + algoritmus ES256/ED25519) zapsaný k party, slouží k ověření pozdějších podpisů schválení (ADR-0021). Privátní klíč nikdy neopustí hardwarové úložiště zařízení (Secure Enclave / Android Keystore).
 - **DeviceApprovalDecision** — podpisem ověřené, dynamicky provázané rozhodnutí APPROVED/DENIED zaznamenané out-of-band zapsaným zařízením; uloženo přechodně (musí jen přežít svou výzvu).
 

--- a/openbank-sca-service/src/main/resources/docs/01-overview.en.md
+++ b/openbank-sca-service/src/main/resources/docs/01-overview.en.md
@@ -4,7 +4,7 @@
 
 `openbank-sca-service` is the **Strong Customer Authentication (SCA) engine** of the OpenBank platform. It performs step-up authentication when another service needs to be sure a real customer is present and has approved a sensitive action. It holds:
 
-- **ScaChallenge aggregate** — a single authentication challenge: party, purpose (PAYMENT_INITIATION / CONSENT_GRANT / LOGIN / AGENT_ACTION / SENSITIVE_DATA_ACCESS), method (SMS_OTP / TOTP / PUSH_NOTIFICATION / BIOMETRIC), status (PENDING / COMPLETED / FAILED / EXPIRED / CANCELLED), attempt counter, expiry, and optional **dynamic-linking data** (amount, currency, creditor IBAN/name, reference) per PSD2 RTS Art. 5.
+- **ScaChallenge aggregate** — a single authentication challenge: party, purpose (PAYMENT_INITIATION / CONSENT_GRANT / LOGIN / AGENT_ACTION / SENSITIVE_DATA_ACCESS), method (TOTP / PUSH_NOTIFICATION / BIOMETRIC), status (PENDING / COMPLETED / FAILED / EXPIRED / CANCELLED), attempt counter, expiry, and optional **dynamic-linking data** (amount, currency, creditor IBAN/name, reference) per PSD2 RTS Art. 5.
 - **EnrolledDevice** — a device credential (public key + algorithm ES256/ED25519) enrolled to a party, used to verify later out-of-band approval signatures (ADR-0021). The private key never leaves the device's hardware keystore (Secure Enclave / Android Keystore).
 - **DeviceApprovalDecision** — a signature-verified, dynamic-linking-bound APPROVED/DENIED decision recorded out-of-band by the enrolled device; stored transiently (it only needs to outlive its challenge).
 

--- a/openbank-sca-service/src/main/resources/docs/03-api.cs.md
+++ b/openbank-sca-service/src/main/resources/docs/03-api.cs.md
@@ -24,7 +24,7 @@ Request:
 {
   "partyId": "uuid",
   "purpose": "PAYMENT_INITIATION | CONSENT_GRANT | LOGIN | AGENT_ACTION | SENSITIVE_DATA_ACCESS",
-  "preferredMethod": "PUSH_NOTIFICATION | SMS_OTP | TOTP | BIOMETRIC",
+  "preferredMethod": "PUSH_NOTIFICATION | TOTP | BIOMETRIC",
   "dynamicLinkingData": {
     "amount": "100.00", "currency": "EUR",
     "creditorIban": "…", "creditorName": "…", "reference": "…"
@@ -39,7 +39,7 @@ Pošlete `Idempotency-Key` (preferováno) nebo `X-Request-ID`. Replay vrátí ca
 
 ## Ověření — `POST /api/v1/sca/challenges/{id}/verify`
 
-Request: `{ "partyId": "uuid", "otp": "123456" }` (`otp` povinné pro SMS_OTP/TOTP).
+Request: `{ "partyId": "uuid", "otp": "123456" }` (`otp` povinné pro TOTP).
 - **OTP metody**: správné OTP ⇒ `COMPLETED`; chybné OTP zvýší `attemptCount` a po dosažení `maxAttempts` (3) se výzva stane `FAILED` a volání vrátí `401`.
 - **Decoupled metody (PUSH/BIOMETRIC)**: vrací aktuální výzvu. `COMPLETED` jen pokud zapsané zařízení už poslalo APPROVED rozhodnutí; jinak zůstává `PENDING` (pokus se nespotřebuje) — nikdy ne automaticky (ADR-0021).
 

--- a/openbank-sca-service/src/main/resources/docs/03-api.en.md
+++ b/openbank-sca-service/src/main/resources/docs/03-api.en.md
@@ -24,7 +24,7 @@ Request:
 {
   "partyId": "uuid",
   "purpose": "PAYMENT_INITIATION | CONSENT_GRANT | LOGIN | AGENT_ACTION | SENSITIVE_DATA_ACCESS",
-  "preferredMethod": "PUSH_NOTIFICATION | SMS_OTP | TOTP | BIOMETRIC",
+  "preferredMethod": "PUSH_NOTIFICATION | TOTP | BIOMETRIC",
   "dynamicLinkingData": {
     "amount": "100.00", "currency": "EUR",
     "creditorIban": "…", "creditorName": "…", "reference": "…"
@@ -39,7 +39,7 @@ Send `Idempotency-Key` (preferred) or `X-Request-ID`. A replay returns the cache
 
 ## Verify — `POST /api/v1/sca/challenges/{id}/verify`
 
-Request: `{ "partyId": "uuid", "otp": "123456" }` (`otp` required for SMS_OTP/TOTP).
+Request: `{ "partyId": "uuid", "otp": "123456" }` (`otp` required for TOTP).
 - **OTP methods**: a correct OTP ⇒ `COMPLETED`; a wrong OTP increments `attemptCount` and, once `maxAttempts` (3) is reached, the challenge becomes `FAILED` and the call returns `401`.
 - **Decoupled methods (PUSH/BIOMETRIC)**: returns the current challenge. `COMPLETED` only if the enrolled device already posted an APPROVED decision; otherwise it stays `PENDING` (no attempt consumed) — never auto-approved (ADR-0021).
 

--- a/openbank-sca-service/src/test/kotlin/com/openbank/sca/application/usecase/NotificationDispatchGuardTest.kt
+++ b/openbank-sca-service/src/test/kotlin/com/openbank/sca/application/usecase/NotificationDispatchGuardTest.kt
@@ -27,14 +27,4 @@ class NotificationDispatchGuardTest {
 
         coVerify(exactly = 1) { sender.sendPushNotification(partyId, challengeId, "Approve transaction") }
     }
-
-    @Test
-    fun `sendSmsOtp delegates to NotificationSender`(): Unit = runBlocking {
-        val partyId = UUID.randomUUID()
-        coEvery { sender.sendSmsOtp(partyId, any()) } returns Unit
-
-        guard.sendSmsOtp(partyId, "123456")
-
-        coVerify(exactly = 1) { sender.sendSmsOtp(partyId, "123456") }
-    }
 }

--- a/openbank-sca-service/src/test/kotlin/com/openbank/sca/application/usecase/ScaServiceTest.kt
+++ b/openbank-sca-service/src/test/kotlin/com/openbank/sca/application/usecase/ScaServiceTest.kt
@@ -231,33 +231,31 @@ class ScaServiceTest {
     }
 
     @Test
-    fun `initiate generates OTP for SMS_OTP method`(): Unit = runBlocking {
+    fun `initiate generates OTP for TOTP method`(): Unit = runBlocking {
         val partyId = UUID.randomUUID()
         every { otpGenerator.generate() } returns "123456"
         coEvery { idempotencyStore.get(any()) } returns null
         coEvery { repository.save(any()) } answers { firstArg() }
         coEvery { idempotencyStore.save(any(), any(), any()) } returns Unit
         coEvery { otpStore.store(any(), any(), any()) } returns Unit
-        coEvery { notificationDispatchGuard.sendSmsOtp(any(), any()) } returns Unit
 
         val result = service.initiate(
             InitiateScaCommand(
                 partyId = partyId,
                 purpose = ScaPurpose.LOGIN,
-                preferredMethod = ScaMethod.SMS_OTP,
+                preferredMethod = ScaMethod.TOTP,
                 dynamicLinkingData = null,
                 redirectUrl = null,
             ),
         )
 
-        assertThat(result.method).isEqualTo(ScaMethod.SMS_OTP)
+        assertThat(result.method).isEqualTo(ScaMethod.TOTP)
         coVerify(exactly = 1) { otpStore.store(result.id, "123456", 300L) }
-        coVerify(exactly = 1) { notificationDispatchGuard.sendSmsOtp(partyId, "123456") }
     }
 
     @Test
     fun `verify completes challenge on successful OTP verification`(): Unit = runBlocking {
-        val challenge = challenge(method = ScaMethod.SMS_OTP)
+        val challenge = challenge(method = ScaMethod.TOTP)
 
         coEvery { repository.findById(challenge.id) } returns challenge
         coEvery { otpStore.verify(challenge.id, "123456") } returns true
@@ -319,7 +317,7 @@ class ScaServiceTest {
 
     @Test
     fun `verify fails challenge on invalid OTP`(): Unit = runBlocking {
-        val challenge = challenge(method = ScaMethod.SMS_OTP)
+        val challenge = challenge(method = ScaMethod.TOTP)
 
         coEvery { repository.findById(challenge.id) } returns challenge
         coEvery { otpStore.verify(challenge.id, "bad-otp") } returns false
@@ -653,7 +651,7 @@ class ScaServiceTest {
 
     @Test
     fun `verify emits scaChallengeResolved completed on a successful OTP verification`(): Unit = runBlocking {
-        val challenge = challenge(method = ScaMethod.SMS_OTP)
+        val challenge = challenge(method = ScaMethod.TOTP)
         coEvery { repository.findById(challenge.id) } returns challenge
         coEvery { otpStore.verify(challenge.id, "123456") } returns true
         coEvery { otpStore.invalidate(challenge.id) } returns Unit
@@ -667,12 +665,12 @@ class ScaServiceTest {
             ),
         )
 
-        verify(exactly = 1) { metrics.scaChallengeResolved("SMS_OTP", "completed") }
+        verify(exactly = 1) { metrics.scaChallengeResolved("TOTP", "completed") }
     }
 
     @Test
     fun `verify emits scaChallengeResolved failed when the last OTP attempt fails`(): Unit = runBlocking {
-        val challenge = challenge(method = ScaMethod.SMS_OTP, maxAttempts = 1)
+        val challenge = challenge(method = ScaMethod.TOTP, maxAttempts = 1)
         coEvery { repository.findById(challenge.id) } returns challenge
         coEvery { otpStore.verify(challenge.id, "bad") } returns false
         coEvery { repository.save(any()) } answers { firstArg() }
@@ -689,12 +687,12 @@ class ScaServiceTest {
             }
         }.isInstanceOf(ScaVerificationFailedException::class.java)
 
-        verify(exactly = 1) { metrics.scaChallengeResolved("SMS_OTP", "failed") }
+        verify(exactly = 1) { metrics.scaChallengeResolved("TOTP", "failed") }
     }
 
     @Test
     fun `verify does not emit scaChallengeResolved for a retryable OTP failure`(): Unit = runBlocking {
-        val challenge = challenge(method = ScaMethod.SMS_OTP, maxAttempts = 3)
+        val challenge = challenge(method = ScaMethod.TOTP, maxAttempts = 3)
         coEvery { repository.findById(challenge.id) } returns challenge
         coEvery { otpStore.verify(challenge.id, "bad") } returns false
         coEvery { repository.save(any()) } answers { firstArg() }
@@ -1009,7 +1007,7 @@ class ScaServiceTest {
 
     @Test
     fun `a card-management challenge that is not approved cannot be consumed`(): Unit = runBlocking {
-        val ch = cardChallenge().copy(status = ScaStatus.PENDING, method = ScaMethod.SMS_OTP)
+        val ch = cardChallenge().copy(status = ScaStatus.PENDING, method = ScaMethod.TOTP)
         coEvery { repository.findById(ch.id) } returns ch
         assertThatThrownBy {
             runBlocking {
@@ -1061,7 +1059,7 @@ class ScaServiceTest {
     private fun challenge(
         id: UUID = UUID.randomUUID(),
         partyId: UUID = UUID.randomUUID(),
-        method: ScaMethod = ScaMethod.SMS_OTP,
+        method: ScaMethod = ScaMethod.TOTP,
         expiresAt: OffsetDateTime = now.plusMinutes(5),
         attemptCount: Int = 0,
         maxAttempts: Int = 3,

--- a/openbank-sca-service/src/test/kotlin/com/openbank/sca/domain/model/ScaChallengeTest.kt
+++ b/openbank-sca-service/src/test/kotlin/com/openbank/sca/domain/model/ScaChallengeTest.kt
@@ -111,7 +111,7 @@ class ScaChallengeTest {
         id = UUID.randomUUID(),
         partyId = UUID.randomUUID(),
         purpose = ScaPurpose.LOGIN,
-        method = ScaMethod.SMS_OTP,
+        method = ScaMethod.TOTP,
         status = status,
         expiresAt = expiresAt,
         attemptCount = attemptCount,


### PR DESCRIPTION
## Summary

`SMS_OTP` is removed from `ScaMethod`. Its only implementation, `LoggingNotificationSender.sendSmsOtp`,
has never sent an SMS to anyone — it writes the OTP to the application log and returns. There is no SMS
provider anywhere in the fleet. This closes it by subtraction: a capability that cannot be requested
cannot silently fail to deliver it, and cannot write a live SCA credential to a log sink either.

## Type of change

- [x] security (private until disclosed)
- [x] fix (bug fix)
- [x] breaking change

## Linked issues

None — found during the blast-radius check for #2372 (unrelated `notification-service` channel stub
cleanup). Not filed as a public issue per this repo's routing rule (security holes → private advisory
or, as here, same-PR removal); this PR is the disclosure.

## Changes

- `ScaMethod`: removed `SMS_OTP`. Remaining: `PUSH_NOTIFICATION`, `TOTP`, `BIOMETRIC`.
- `ScaService.initiate` / `verify`: TOTP keeps the OTP generate/store/verify path it already shared
  with SMS_OTP; the SMS-specific dispatch call is gone.
- `NotificationSender` / `NotificationDispatchGuard` / `LoggingNotificationSender`: `sendSmsOtp` removed
  fleet-wide — swept for every caller first, there is exactly one and it is deleted here.
- `openbank-sca-service/src/main/resources/docs/{01-overview,03-api}.{cs,en}.md`: `SMS_OTP` references
  removed from the method enum and the verify-request note.
- Tests: `NotificationDispatchGuardTest`'s SMS case removed; `ScaServiceTest`'s SMS-specific test
  renamed and rewritten for TOTP (same behavior — OTP generate/store, no external dispatch); every
  other `ScaMethod.SMS_OTP` occurrence used only as a generic "some OTP method" fixture switched to
  `ScaMethod.TOTP`.

`ADR-0021` is untouched — a historical decision record referencing SMS_OTP as it existed when written.

## Definition of Done

- [x] Hexagonal layering preserved — no domain framework imports added.
- [x] Unit tests updated — 62 affected tests pass
      (`ScaServiceTest` 50, `NotificationDispatchGuardTest` 1, `ScaChallengeTest` 11).
- [ ] Integration / `@QuarkusTest` classes (`ScaResourceAuthzTest`, `ScaOutboxClaimIT`,
      `ScaPactProviderVerificationTest`) — **could not run in this environment**: Gradle dependency
      verification fails on two Quarkus artifacts' checksums
      (`quarkus-arc-test-supplement-decorator`, `quarkus-resteasy-common-spi`) before any test executes.
      Confirmed pre-existing and unrelated to this change — reproduces identically on plain
      `origin/main` with this branch's changes stashed. Flagging for CI, which may have a working
      dependency-verification cache this sandbox does not.
- [x] `./gradlew :openbank-sca-service:detekt :openbank-sca-service:ktlintCheck` passes.
- [x] No new lint warnings.
- [x] Docs updated (the two `03-api`/`01-overview` doc pairs).
- [ ] OpenAPI spec — n/a; `sca-service`'s `openapi.yaml` does not document `ScaMethod` or
      `preferredMethod` at all (pre-existing gap, not touched here).

## Security checklist

- [x] No secrets, tokens, passwords, or PII added. (The point of this PR is removing a path that wrote
      one to a log.)
- [x] No new `@Suppress` / `as Any`.
- [x] No new third-party dependency.
- [x] **Auth / crypto / payment code changed** → tagging `security-review-required`. This touches the
      SCA challenge method enum directly.
- [ ] PII path — no.
- [ ] Cardholder data path — no.

## Compliance impact

- [ ] PCI DSS · [ ] DORA · [ ] GDPR · [x] PSD2 / SCA / RTS · [ ] AML / 5AMLD · [ ] CNB reporting

PSD2 RTS on SCA: this removes one of four SCA methods. `PUSH_NOTIFICATION` (default), `TOTP` and
`BIOMETRIC` are unaffected and remain independently spec-compliant knowledge/possession/inherence
factors per method. No customer-facing SCA capability is lost in practice, since `SMS_OTP` could never
complete for a real customer — this removes a method that was already non-functional, it does not
reduce the platform's genuine SCA coverage.

## Rollout / Rollback

- Deployment strategy: rolling, same as any other `sca-service` release.
- Rollback plan: revert the commit. No data migration, no persisted `SMS_OTP` state to reconcile
  (challenges are TTL'd; nothing durable references the removed enum value).
- Data migration reversible: N/A — no schema change.

## Reviewer notes

**This is the disclosure.** No public issue was filed per the repo's routing rule for security holes;
this PR's description is deliberately factual rather than a full writeup, since the vulnerable code is
deleted in the same change. Please confirm no customer-facing surface (mobile app, admin-ui) offers
`SMS_OTP` as a selectable method before merging — I found none (`preferredMethod` is not documented in
`openapi.yaml` at all, and no admin-ui or customer-edge selector references `SMS_OTP`), but that absence
is exactly the kind of claim worth a second pair of eyes on auth-adjacent code.

The dependency-verification failure blocking the `@QuarkusTest` classes is almost certainly a sandbox
artifact (stale local verification metadata cache), not a real supply-chain finding — but I did not
silence or work around it, and it should be confirmed clean in CI before merge rather than assumed.
