### PR TITLE
ci(governance): compare published request schemas to the DTOs that parse them

### DIFF
--- a/.github/scripts/check-openapi-request-schema-conformance.py
+++ b/.github/scripts/check-openapi-request-schema-conformance.py
@@ -1,0 +1,159 @@
+#!/usr/bin/env python3
+"""openapi-request-schema-conformance gate — published request bodies vs the DTOs that parse them.
+
+WHY THIS EXISTS: check-openapi-route-conformance.py (#2360) closed the ROUTE half of "does the
+published contract describe the code" — it never looks inside a schema. That gap is exactly how
+aml-service published `CreateAmlCaseRequest.triggerType/riskScore/notes` and
+`UpdateDecisionRequest.decision/analystId`, fields that exist nowhere in the DTOs the resource
+actually deserializes into (#2312). This closes the request-body half of that gap.
+
+WHY NOT THE RESPONSE HALF TOO. Investigated and rejected — not deferred out of laziness. 457
+handler methods fleet-wide return a raw `jakarta.ws.rs.core.Response`, which erases the body type
+at the JVM level: the MicroProfile OpenAPI scanner that produces the generated document below has
+no static type to build a response schema from, and emits `"schema": {}` for the response body's
+`200`/`201`. Measured on aml-service (#2312's own defect): `AmlCaseResponse` does not appear
+ANYWHERE in the generated document. A generic response-schema gate over this fleet would report
+"empty schema" as if it were "no schema published" on the majority of endpoints — indistinguishable
+from the real defect, so it cannot be built without producing more noise than signal. The response
+half needs a per-endpoint contract test asserting the DTO shape directly (the shape
+`CopilotApiContractTest` and the fx/aml pact tests already use), not a generic diff. See the
+tracking issue for specifics.
+
+WHAT THIS CHECKS: for each REQUEST body schema referenced from `paths:` (only bodies with a
+`$ref` to a `components.schemas` entry — inline schemas are already visible in the spec text and
+not this gate's job), the PROPERTY NAME SET declared in `openapi.yaml` against the same schema
+in the Quarkus-generated document (`quarkus.smallrye-openapi.store-schema-directory`, produced as
+a side effect of the existing `:service:build` — confirmed via `--dry-run` that `quarkusBuild` is
+already in that task's graph, so this costs no extra build). Reports both directions:
+
+    published-not-parsed   a property the spec declares that the DTO does not have
+    parsed-not-published   a property the DTO has that the spec does not declare
+
+WHAT THIS DELIBERATELY DOES NOT CHECK, and why a green here is not "this schema is true":
+  - `required` / optional-ness — SmallRye OpenAPI does not read Kotlin nullability (no
+    jackson-module-kotlin integration in the scanner), so it marks nearly every constructor
+    parameter required regardless of `?`. Comparing required-ness would be near-100% noise.
+    Measured on aml: `accountId: UUID?` and `transactionId: UUID?` both come back `required`.
+  - types, formats, enum values — inconsistently present (a `$ref`'d type loses the nullable
+    union a plain `String` keeps; an enum typed as `String` in the DTO with a manual `.valueOf()`
+    conversion carries no enum constraint at all, which is aml's own pattern).
+  - response bodies — see above.
+  - anything for a service whose generated document was not supplied (this is a per-service check
+    invoked with an explicit path, not a fleet crawl — the CI wiring runs it once per service,
+    right after the build that produces the artifact it reads).
+
+stdlib-only.
+
+Usage:
+    check-openapi-request-schema-conformance.py --service <name> --generated <path/to/openapi.yaml> [--enforce]
+
+Exits 0 (with a ::notice) if the generated file does not exist — a missing artifact is a CI wiring
+question, not a schema-conformance finding, and must never silently read as "no findings".
+"""
+
+from __future__ import annotations
+
+import argparse
+import re
+import sys
+from pathlib import Path
+
+try:
+    import yaml
+except ImportError:
+    print("::error::openapi-request-schema-conformance: PyYAML not available")
+    sys.exit(1)
+
+
+def request_body_refs(spec: dict) -> dict[str, str]:
+    """{schema_name: first "operationId or METHOD path" that references it as a requestBody}."""
+    refs: dict[str, str] = {}
+    for path, methods in (spec.get("paths") or {}).items():
+        if not isinstance(methods, dict):
+            continue
+        for verb, op in methods.items():
+            if verb not in ("get", "put", "post", "delete", "patch", "head", "options"):
+                continue
+            if not isinstance(op, dict):
+                continue
+            body = (op.get("requestBody") or {}).get("content", {}).get("application/json", {})
+            ref = (body.get("schema") or {}).get("$ref", "")
+            m = re.match(r"^#/components/schemas/(\S+)$", ref)
+            if m and m.group(1) not in refs:
+                refs[m.group(1)] = op.get("operationId") or f"{verb.upper()} {path}"
+    return refs
+
+
+def schema_properties(spec: dict, name: str) -> set[str] | None:
+    schema = (spec.get("components") or {}).get("schemas", {}).get(name)
+    if not isinstance(schema, dict):
+        return None
+    return set((schema.get("properties") or {}).keys())
+
+
+def main() -> int:
+    ap = argparse.ArgumentParser()
+    ap.add_argument("--service", required=True)
+    ap.add_argument("--generated", required=True, help="path to the Quarkus-generated openapi.yaml")
+    ap.add_argument("--enforce", action="store_true")
+    args = ap.parse_args()
+
+    level = "error" if args.enforce else "warning"
+    committed_path = Path(args.service) / "src/main/resources/openapi.yaml"
+    generated_path = Path(args.generated)
+
+    if not generated_path.is_file():
+        print(
+            f"::notice::openapi-request-schema-conformance: {args.service}: no generated schema at "
+            f"{generated_path} — check-api-contract's build step may not have produced one for this "
+            "service (e.g. it serves no own /api/v{N} path). Not a finding."
+        )
+        return 0
+
+    committed = yaml.safe_load(committed_path.read_text(encoding="utf-8"))
+    generated = yaml.safe_load(generated_path.read_text(encoding="utf-8"))
+
+    committed_refs = request_body_refs(committed)
+    generated_refs = request_body_refs(generated)
+
+    findings = 0
+    checked = 0
+    for name, where in sorted(committed_refs.items()):
+        if name not in generated_refs:
+            # The route-conformance gate (#2360) already reports the route itself as
+            # published-not-served in this case; don't double-report the schema.
+            continue
+        pub = schema_properties(committed, name)
+        real = schema_properties(generated, name)
+        if pub is None or real is None:
+            continue
+        checked += 1
+        for prop in sorted(pub - real):
+            findings += 1
+            print(
+                f"::{level}::openapi-request-schema-conformance: {args.service}: "
+                f"published-not-parsed — {name}.{prop} (used by {where}) is declared in "
+                f"openapi.yaml but the request DTO has no such property"
+            )
+        for prop in sorted(real - pub):
+            findings += 1
+            print(
+                f"::{level}::openapi-request-schema-conformance: {args.service}: "
+                f"parsed-not-published — {name}.{prop} (used by {where}) exists on the request "
+                f"DTO and is absent from openapi.yaml"
+            )
+
+    print(
+        f"check-openapi-request-schema-conformance: {args.service}: {checked} request schema(s) "
+        f"compared, {findings} finding(s)."
+    )
+    if findings and not args.enforce:
+        print(
+            "check-openapi-request-schema-conformance: advisory — will become a hard gate once the "
+            "backlog is cleared (see rules.yaml: openapi_request_schema_conformance)."
+        )
+    return 1 if (findings and args.enforce) else 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/.github/workflows/_service-ci.yml
+++ b/.github/workflows/_service-ci.yml
@@ -435,7 +435,14 @@ jobs:
           # cached and does not re-execute uncredentialed (the #1009 hazard documented below).
           RERUN=""
           if [ "${PUBLISH_RESULTS}" = "true" ]; then RERUN="--rerun-tasks"; fi
+          # -Dquarkus.smallrye-openapi.store-schema-directory writes the document Quarkus actually
+          # serves, as a side effect of the SAME quarkusBuild task this :build already runs
+          # (confirmed via --dry-run: quarkusBuild is already in :build's task graph for every
+          # Quarkus module here, so this adds zero extra build time). Read by the
+          # openapi-request-schema-conformance step below — rules.yaml:
+          # openapi_request_schema_conformance.
           ./gradlew :${{ inputs.service }}:build ${RERUN} --build-cache --console=plain --stacktrace \
+            -Dquarkus.smallrye-openapi.store-schema-directory="${{ inputs.service }}/build/openapi-generated" \
             -Dpactbroker.url="${PACT_BROKER_URL:-}" \
             -Dpactbroker.auth.username="${PACT_BROKER_USERNAME:-}" \
             -Dpactbroker.auth.password="${PACT_BROKER_PASSWORD:-}" \
@@ -445,6 +452,23 @@ jobs:
             -Dpact.provider.version="${GITHUB_SHA}" \
             -Dpact.provider.branch="${BRANCH}" \
             -Dpact.provider.tag="${BRANCH}"
+
+      # rules.yaml: openapi_request_schema_conformance (advisory). Only the REQUEST-body half of
+      # schema-vs-code — see the script header for why the response half is not attempted. The
+      # existence guard is a bash `[ -f ]` rather than a YAML `if: hashFiles(...)` composition —
+      # no precedent for hashFiles(format(...)) elsewhere in this repo's workflows, and per the
+      # project's own note on workflow files, a mistaken expression here is invisible until an
+      # actual CI run reaches it. A bash guard is checkable with `bash -n` before that.
+      - name: "openapi request-schema conformance (advisory)"
+        run: |
+          SPEC="${{ inputs.service }}/src/main/resources/openapi.yaml"
+          if [ ! -f "$SPEC" ]; then
+            echo "openapi-request-schema-conformance: ${{ inputs.service }} has no openapi.yaml — skipping."
+            exit 0
+          fi
+          python3 .github/scripts/check-openapi-request-schema-conformance.py \
+            --service "${{ inputs.service }}" \
+            --generated "${{ inputs.service }}/build/openapi-generated/openapi.yaml"
 
       # Coverage upload (Codecov is free for public repos; tokenless via the OIDC
       # id-token this job already has). Advisory only — never gates the build.

--- a/openbank-infra/gitops/components/accounts/account-opa-bundle.yaml
+++ b/openbank-infra/gitops/components/accounts/account-opa-bundle.yaml
@@ -9,7 +9,7 @@ metadata:
     app.kubernetes.io/name: account-service
     app.kubernetes.io/part-of: accounts
   annotations:
-    openbank.tech/policy-checksum: "3d968d4c22d93cc3"
+    openbank.tech/policy-checksum: "b9bf1bbb7eafc20e"
 data:
   rest.rego: |
     # SPDX-License-Identifier: Apache-2.0
@@ -1617,6 +1617,44 @@ data:
         #
         # Advisory because 114 pre-existing findings cannot be a merge blocker on day one. Flipping
         # to enforced = add --enforce in ci.yml, once the backlog is cleared.
+      openapi_request_schema_conformance:
+        detect: ["openbank-*/src/main/resources/openapi.yaml", "the JAX-RS request-body DTO the resource actually deserializes into"]
+        require:
+          - "every property a request-body schema declares exists on the DTO the resource parses"
+          - "every property the DTO has is declared on the request-body schema"
+        gate: openapi-request-schema-conformance
+        enforced: advisory
+        target_enforce_date: "2026-09-30"
+        ci_producer: ".github/scripts/check-openapi-request-schema-conformance.py"
+        # openapi_route_conformance (above) is ROUTE SET ONLY — it does not read schemas, so aml's
+        # invented request/response fields passed it clean (#2312). This is the request half of that
+        # gap, using the document Quarkus itself generates
+        # (quarkus.smallrye-openapi.store-schema-directory) as ground truth instead of guessing.
+        # `:build` already runs `quarkusBuild` in its task graph (confirmed via --dry-run), so wiring
+        # this into `_service-ci.yml`'s existing build step costs no extra build time.
+        #
+        # NOT the response half, and that is a decision, not a gap left for later. 457 handler methods
+        # fleet-wide return a raw jakarta.ws.rs.core.Response, which erases the body type at the JVM
+        # level — the scanner that produces the generated document has no static type to build a
+        # response schema from and emits an EMPTY schema for those. Measured directly on aml-service:
+        # AmlCaseResponse does not appear anywhere in the generated document, even though it is real
+        # and correct. A generic response-schema gate over this fleet cannot distinguish "no schema
+        # published" from "the scanner could not see the type" — it would report the majority of
+        # correct endpoints as findings. The response half needs a per-endpoint contract test that
+        # asserts the DTO shape directly, the pattern `CopilotApiContractTest` and the fx/aml
+        # provider-verified pacts already use, not a generic diff.
+        #
+        # `required` is also deliberately not compared: SmallRye OpenAPI's scanner has no
+        # jackson-module-kotlin integration, so it does not read Kotlin nullability and marks nearly
+        # every constructor parameter required regardless of `?`. Measured on aml: `accountId: UUID?`
+        # comes back required. Comparing required-ness would be near-100% noise. Property NAME
+        # presence, by contrast, is unaffected by this and reliable in both directions.
+        #
+        # Found on the day this landed, not hypothetically: openbank-balance-service's
+        # `PlaceHoldRequest` publishes a phantom `expiresAt` and omits the real, USED
+        # `referenceId`/`ttlSeconds` — confirmed against `BalanceResource.placeHold`, which reads
+        # `body.referenceId` and `body.ttlSeconds` directly. A caller following the published spec
+        # cannot construct a valid request.
       db_backup_association:
         detect: ["openbank-infra/gitops/**/*.yaml (kind: Cluster, postgresql.cnpg.io)"]
         require:

--- a/openbank-infra/gitops/components/accounts/account-service.yaml
+++ b/openbank-infra/gitops/components/accounts/account-service.yaml
@@ -37,7 +37,7 @@ spec:
       annotations:
         # Rolls the pod when the OPA bundle changes — subPath mounts do NOT hot-reload.
         # Kept in sync by gen-account-opa-bundle.sh (do not hand-edit).
-        openbank.tech/policy-checksum: "3d968d4c22d93cc3"
+        openbank.tech/policy-checksum: "b9bf1bbb7eafc20e"
     spec:
       securityContext:
         runAsNonRoot: true

--- a/openbank-infra/gitops/components/aml/aml-opa-bundle.yaml
+++ b/openbank-infra/gitops/components/aml/aml-opa-bundle.yaml
@@ -9,7 +9,7 @@ metadata:
     app.kubernetes.io/name: aml-service
     app.kubernetes.io/part-of: aml
   annotations:
-    openbank.tech/policy-checksum: "eafd54cdab3fe31c"
+    openbank.tech/policy-checksum: "05933b234ec1b534"
 data:
   rest.rego: |
     # SPDX-License-Identifier: Apache-2.0
@@ -1590,6 +1590,44 @@ data:
         #
         # Advisory because 114 pre-existing findings cannot be a merge blocker on day one. Flipping
         # to enforced = add --enforce in ci.yml, once the backlog is cleared.
+      openapi_request_schema_conformance:
+        detect: ["openbank-*/src/main/resources/openapi.yaml", "the JAX-RS request-body DTO the resource actually deserializes into"]
+        require:
+          - "every property a request-body schema declares exists on the DTO the resource parses"
+          - "every property the DTO has is declared on the request-body schema"
+        gate: openapi-request-schema-conformance
+        enforced: advisory
+        target_enforce_date: "2026-09-30"
+        ci_producer: ".github/scripts/check-openapi-request-schema-conformance.py"
+        # openapi_route_conformance (above) is ROUTE SET ONLY — it does not read schemas, so aml's
+        # invented request/response fields passed it clean (#2312). This is the request half of that
+        # gap, using the document Quarkus itself generates
+        # (quarkus.smallrye-openapi.store-schema-directory) as ground truth instead of guessing.
+        # `:build` already runs `quarkusBuild` in its task graph (confirmed via --dry-run), so wiring
+        # this into `_service-ci.yml`'s existing build step costs no extra build time.
+        #
+        # NOT the response half, and that is a decision, not a gap left for later. 457 handler methods
+        # fleet-wide return a raw jakarta.ws.rs.core.Response, which erases the body type at the JVM
+        # level — the scanner that produces the generated document has no static type to build a
+        # response schema from and emits an EMPTY schema for those. Measured directly on aml-service:
+        # AmlCaseResponse does not appear anywhere in the generated document, even though it is real
+        # and correct. A generic response-schema gate over this fleet cannot distinguish "no schema
+        # published" from "the scanner could not see the type" — it would report the majority of
+        # correct endpoints as findings. The response half needs a per-endpoint contract test that
+        # asserts the DTO shape directly, the pattern `CopilotApiContractTest` and the fx/aml
+        # provider-verified pacts already use, not a generic diff.
+        #
+        # `required` is also deliberately not compared: SmallRye OpenAPI's scanner has no
+        # jackson-module-kotlin integration, so it does not read Kotlin nullability and marks nearly
+        # every constructor parameter required regardless of `?`. Measured on aml: `accountId: UUID?`
+        # comes back required. Comparing required-ness would be near-100% noise. Property NAME
+        # presence, by contrast, is unaffected by this and reliable in both directions.
+        #
+        # Found on the day this landed, not hypothetically: openbank-balance-service's
+        # `PlaceHoldRequest` publishes a phantom `expiresAt` and omits the real, USED
+        # `referenceId`/`ttlSeconds` — confirmed against `BalanceResource.placeHold`, which reads
+        # `body.referenceId` and `body.ttlSeconds` directly. A caller following the published spec
+        # cannot construct a valid request.
       db_backup_association:
         detect: ["openbank-infra/gitops/**/*.yaml (kind: Cluster, postgresql.cnpg.io)"]
         require:

--- a/openbank-infra/gitops/components/aml/aml-service.yaml
+++ b/openbank-infra/gitops/components/aml/aml-service.yaml
@@ -22,7 +22,7 @@ spec:
       annotations:
         # Rolls the pod when the OPA bundle changes (subPath mounts do not hot-reload).
         # Kept in sync by gen-aml-opa-bundle.sh (do not hand-edit).
-        openbank.tech/policy-checksum: "eafd54cdab3fe31c"
+        openbank.tech/policy-checksum: "05933b234ec1b534"
     spec:
       securityContext:
         runAsNonRoot: true

--- a/openbank-infra/gitops/components/anacredit/anacredit-opa-bundle.yaml
+++ b/openbank-infra/gitops/components/anacredit/anacredit-opa-bundle.yaml
@@ -9,7 +9,7 @@ metadata:
     app.kubernetes.io/name: anacredit-service
     app.kubernetes.io/part-of: anacredit
   annotations:
-    openbank.tech/policy-checksum: "b66b3861a3de781e"
+    openbank.tech/policy-checksum: "e4b2ec38ad958eab"
 data:
   rest.rego: |
     # SPDX-License-Identifier: Apache-2.0
@@ -1560,6 +1560,44 @@ data:
         #
         # Advisory because 114 pre-existing findings cannot be a merge blocker on day one. Flipping
         # to enforced = add --enforce in ci.yml, once the backlog is cleared.
+      openapi_request_schema_conformance:
+        detect: ["openbank-*/src/main/resources/openapi.yaml", "the JAX-RS request-body DTO the resource actually deserializes into"]
+        require:
+          - "every property a request-body schema declares exists on the DTO the resource parses"
+          - "every property the DTO has is declared on the request-body schema"
+        gate: openapi-request-schema-conformance
+        enforced: advisory
+        target_enforce_date: "2026-09-30"
+        ci_producer: ".github/scripts/check-openapi-request-schema-conformance.py"
+        # openapi_route_conformance (above) is ROUTE SET ONLY — it does not read schemas, so aml's
+        # invented request/response fields passed it clean (#2312). This is the request half of that
+        # gap, using the document Quarkus itself generates
+        # (quarkus.smallrye-openapi.store-schema-directory) as ground truth instead of guessing.
+        # `:build` already runs `quarkusBuild` in its task graph (confirmed via --dry-run), so wiring
+        # this into `_service-ci.yml`'s existing build step costs no extra build time.
+        #
+        # NOT the response half, and that is a decision, not a gap left for later. 457 handler methods
+        # fleet-wide return a raw jakarta.ws.rs.core.Response, which erases the body type at the JVM
+        # level — the scanner that produces the generated document has no static type to build a
+        # response schema from and emits an EMPTY schema for those. Measured directly on aml-service:
+        # AmlCaseResponse does not appear anywhere in the generated document, even though it is real
+        # and correct. A generic response-schema gate over this fleet cannot distinguish "no schema
+        # published" from "the scanner could not see the type" — it would report the majority of
+        # correct endpoints as findings. The response half needs a per-endpoint contract test that
+        # asserts the DTO shape directly, the pattern `CopilotApiContractTest` and the fx/aml
+        # provider-verified pacts already use, not a generic diff.
+        #
+        # `required` is also deliberately not compared: SmallRye OpenAPI's scanner has no
+        # jackson-module-kotlin integration, so it does not read Kotlin nullability and marks nearly
+        # every constructor parameter required regardless of `?`. Measured on aml: `accountId: UUID?`
+        # comes back required. Comparing required-ness would be near-100% noise. Property NAME
+        # presence, by contrast, is unaffected by this and reliable in both directions.
+        #
+        # Found on the day this landed, not hypothetically: openbank-balance-service's
+        # `PlaceHoldRequest` publishes a phantom `expiresAt` and omits the real, USED
+        # `referenceId`/`ttlSeconds` — confirmed against `BalanceResource.placeHold`, which reads
+        # `body.referenceId` and `body.ttlSeconds` directly. A caller following the published spec
+        # cannot construct a valid request.
       db_backup_association:
         detect: ["openbank-infra/gitops/**/*.yaml (kind: Cluster, postgresql.cnpg.io)"]
         require:

--- a/openbank-infra/gitops/components/anacredit/anacredit-service.yaml
+++ b/openbank-infra/gitops/components/anacredit/anacredit-service.yaml
@@ -32,7 +32,7 @@ spec:
       annotations:
         # Rolls the pods when the OPA bundle changes — subPath mounts do NOT hot-reload.
         # Kept in sync by gen-anacredit-opa-bundle.sh (do not hand-edit).
-        openbank.tech/policy-checksum: "b66b3861a3de781e"
+        openbank.tech/policy-checksum: "e4b2ec38ad958eab"
     spec:
       securityContext:
         runAsNonRoot: true

--- a/openbank-infra/gitops/components/ap2/ap2-opa-bundle.yaml
+++ b/openbank-infra/gitops/components/ap2/ap2-opa-bundle.yaml
@@ -9,7 +9,7 @@ metadata:
     app.kubernetes.io/name: mcp-service
     app.kubernetes.io/part-of: platform
   annotations:
-    openbank.tech/policy-checksum: "2c7a909e8003c64e"
+    openbank.tech/policy-checksum: "31b69cbacb5b9c85"
 data:
   rest.rego: |
     # SPDX-License-Identifier: Apache-2.0
@@ -1528,6 +1528,44 @@ data:
         #
         # Advisory because 114 pre-existing findings cannot be a merge blocker on day one. Flipping
         # to enforced = add --enforce in ci.yml, once the backlog is cleared.
+      openapi_request_schema_conformance:
+        detect: ["openbank-*/src/main/resources/openapi.yaml", "the JAX-RS request-body DTO the resource actually deserializes into"]
+        require:
+          - "every property a request-body schema declares exists on the DTO the resource parses"
+          - "every property the DTO has is declared on the request-body schema"
+        gate: openapi-request-schema-conformance
+        enforced: advisory
+        target_enforce_date: "2026-09-30"
+        ci_producer: ".github/scripts/check-openapi-request-schema-conformance.py"
+        # openapi_route_conformance (above) is ROUTE SET ONLY — it does not read schemas, so aml's
+        # invented request/response fields passed it clean (#2312). This is the request half of that
+        # gap, using the document Quarkus itself generates
+        # (quarkus.smallrye-openapi.store-schema-directory) as ground truth instead of guessing.
+        # `:build` already runs `quarkusBuild` in its task graph (confirmed via --dry-run), so wiring
+        # this into `_service-ci.yml`'s existing build step costs no extra build time.
+        #
+        # NOT the response half, and that is a decision, not a gap left for later. 457 handler methods
+        # fleet-wide return a raw jakarta.ws.rs.core.Response, which erases the body type at the JVM
+        # level — the scanner that produces the generated document has no static type to build a
+        # response schema from and emits an EMPTY schema for those. Measured directly on aml-service:
+        # AmlCaseResponse does not appear anywhere in the generated document, even though it is real
+        # and correct. A generic response-schema gate over this fleet cannot distinguish "no schema
+        # published" from "the scanner could not see the type" — it would report the majority of
+        # correct endpoints as findings. The response half needs a per-endpoint contract test that
+        # asserts the DTO shape directly, the pattern `CopilotApiContractTest` and the fx/aml
+        # provider-verified pacts already use, not a generic diff.
+        #
+        # `required` is also deliberately not compared: SmallRye OpenAPI's scanner has no
+        # jackson-module-kotlin integration, so it does not read Kotlin nullability and marks nearly
+        # every constructor parameter required regardless of `?`. Measured on aml: `accountId: UUID?`
+        # comes back required. Comparing required-ness would be near-100% noise. Property NAME
+        # presence, by contrast, is unaffected by this and reliable in both directions.
+        #
+        # Found on the day this landed, not hypothetically: openbank-balance-service's
+        # `PlaceHoldRequest` publishes a phantom `expiresAt` and omits the real, USED
+        # `referenceId`/`ttlSeconds` — confirmed against `BalanceResource.placeHold`, which reads
+        # `body.referenceId` and `body.ttlSeconds` directly. A caller following the published spec
+        # cannot construct a valid request.
       db_backup_association:
         detect: ["openbank-infra/gitops/**/*.yaml (kind: Cluster, postgresql.cnpg.io)"]
         require:

--- a/openbank-infra/gitops/components/ap2/ap2-service.yaml
+++ b/openbank-infra/gitops/components/ap2/ap2-service.yaml
@@ -30,7 +30,7 @@ spec:
       annotations:
         # Roll the pod when the OPA policy bundle changes (subPath mounts don't hot-reload).
         # Kept in sync by gen-ap2-opa-bundle.sh (do not hand-edit).
-        openbank.tech/policy-checksum: "2c7a909e8003c64e"
+        openbank.tech/policy-checksum: "31b69cbacb5b9c85"
     spec:
       securityContext:
         runAsNonRoot: true

--- a/openbank-infra/gitops/components/audit/audit-opa-bundle.yaml
+++ b/openbank-infra/gitops/components/audit/audit-opa-bundle.yaml
@@ -9,7 +9,7 @@ metadata:
     app.kubernetes.io/name: audit-service
     app.kubernetes.io/part-of: audit
   annotations:
-    openbank.tech/policy-checksum: "fdd0d3a60fa79e7d"
+    openbank.tech/policy-checksum: "ef5e0d5002945be9"
 data:
   rest.rego: |
     # SPDX-License-Identifier: Apache-2.0
@@ -1572,6 +1572,44 @@ data:
         #
         # Advisory because 114 pre-existing findings cannot be a merge blocker on day one. Flipping
         # to enforced = add --enforce in ci.yml, once the backlog is cleared.
+      openapi_request_schema_conformance:
+        detect: ["openbank-*/src/main/resources/openapi.yaml", "the JAX-RS request-body DTO the resource actually deserializes into"]
+        require:
+          - "every property a request-body schema declares exists on the DTO the resource parses"
+          - "every property the DTO has is declared on the request-body schema"
+        gate: openapi-request-schema-conformance
+        enforced: advisory
+        target_enforce_date: "2026-09-30"
+        ci_producer: ".github/scripts/check-openapi-request-schema-conformance.py"
+        # openapi_route_conformance (above) is ROUTE SET ONLY — it does not read schemas, so aml's
+        # invented request/response fields passed it clean (#2312). This is the request half of that
+        # gap, using the document Quarkus itself generates
+        # (quarkus.smallrye-openapi.store-schema-directory) as ground truth instead of guessing.
+        # `:build` already runs `quarkusBuild` in its task graph (confirmed via --dry-run), so wiring
+        # this into `_service-ci.yml`'s existing build step costs no extra build time.
+        #
+        # NOT the response half, and that is a decision, not a gap left for later. 457 handler methods
+        # fleet-wide return a raw jakarta.ws.rs.core.Response, which erases the body type at the JVM
+        # level — the scanner that produces the generated document has no static type to build a
+        # response schema from and emits an EMPTY schema for those. Measured directly on aml-service:
+        # AmlCaseResponse does not appear anywhere in the generated document, even though it is real
+        # and correct. A generic response-schema gate over this fleet cannot distinguish "no schema
+        # published" from "the scanner could not see the type" — it would report the majority of
+        # correct endpoints as findings. The response half needs a per-endpoint contract test that
+        # asserts the DTO shape directly, the pattern `CopilotApiContractTest` and the fx/aml
+        # provider-verified pacts already use, not a generic diff.
+        #
+        # `required` is also deliberately not compared: SmallRye OpenAPI's scanner has no
+        # jackson-module-kotlin integration, so it does not read Kotlin nullability and marks nearly
+        # every constructor parameter required regardless of `?`. Measured on aml: `accountId: UUID?`
+        # comes back required. Comparing required-ness would be near-100% noise. Property NAME
+        # presence, by contrast, is unaffected by this and reliable in both directions.
+        #
+        # Found on the day this landed, not hypothetically: openbank-balance-service's
+        # `PlaceHoldRequest` publishes a phantom `expiresAt` and omits the real, USED
+        # `referenceId`/`ttlSeconds` — confirmed against `BalanceResource.placeHold`, which reads
+        # `body.referenceId` and `body.ttlSeconds` directly. A caller following the published spec
+        # cannot construct a valid request.
       db_backup_association:
         detect: ["openbank-infra/gitops/**/*.yaml (kind: Cluster, postgresql.cnpg.io)"]
         require:

--- a/openbank-infra/gitops/components/audit/audit-service.yaml
+++ b/openbank-infra/gitops/components/audit/audit-service.yaml
@@ -22,7 +22,7 @@ spec:
       annotations:
         # Rolls the pod when the OPA bundle changes (subPath mounts do not hot-reload).
         # Kept in sync by gen-audit-opa-bundle.sh (do not hand-edit).
-        openbank.tech/policy-checksum: "fdd0d3a60fa79e7d"
+        openbank.tech/policy-checksum: "ef5e0d5002945be9"
     spec:
       securityContext:
         runAsNonRoot: true

--- a/openbank-infra/gitops/components/balances/balance-opa-bundle.yaml
+++ b/openbank-infra/gitops/components/balances/balance-opa-bundle.yaml
@@ -9,7 +9,7 @@ metadata:
     app.kubernetes.io/name: balance-service
     app.kubernetes.io/part-of: balances
   annotations:
-    openbank.tech/policy-checksum: "f4aad8a684e66716"
+    openbank.tech/policy-checksum: "67731c88dca68691"
 data:
   rest.rego: |
     # SPDX-License-Identifier: Apache-2.0
@@ -1661,6 +1661,44 @@ data:
         #
         # Advisory because 114 pre-existing findings cannot be a merge blocker on day one. Flipping
         # to enforced = add --enforce in ci.yml, once the backlog is cleared.
+      openapi_request_schema_conformance:
+        detect: ["openbank-*/src/main/resources/openapi.yaml", "the JAX-RS request-body DTO the resource actually deserializes into"]
+        require:
+          - "every property a request-body schema declares exists on the DTO the resource parses"
+          - "every property the DTO has is declared on the request-body schema"
+        gate: openapi-request-schema-conformance
+        enforced: advisory
+        target_enforce_date: "2026-09-30"
+        ci_producer: ".github/scripts/check-openapi-request-schema-conformance.py"
+        # openapi_route_conformance (above) is ROUTE SET ONLY — it does not read schemas, so aml's
+        # invented request/response fields passed it clean (#2312). This is the request half of that
+        # gap, using the document Quarkus itself generates
+        # (quarkus.smallrye-openapi.store-schema-directory) as ground truth instead of guessing.
+        # `:build` already runs `quarkusBuild` in its task graph (confirmed via --dry-run), so wiring
+        # this into `_service-ci.yml`'s existing build step costs no extra build time.
+        #
+        # NOT the response half, and that is a decision, not a gap left for later. 457 handler methods
+        # fleet-wide return a raw jakarta.ws.rs.core.Response, which erases the body type at the JVM
+        # level — the scanner that produces the generated document has no static type to build a
+        # response schema from and emits an EMPTY schema for those. Measured directly on aml-service:
+        # AmlCaseResponse does not appear anywhere in the generated document, even though it is real
+        # and correct. A generic response-schema gate over this fleet cannot distinguish "no schema
+        # published" from "the scanner could not see the type" — it would report the majority of
+        # correct endpoints as findings. The response half needs a per-endpoint contract test that
+        # asserts the DTO shape directly, the pattern `CopilotApiContractTest` and the fx/aml
+        # provider-verified pacts already use, not a generic diff.
+        #
+        # `required` is also deliberately not compared: SmallRye OpenAPI's scanner has no
+        # jackson-module-kotlin integration, so it does not read Kotlin nullability and marks nearly
+        # every constructor parameter required regardless of `?`. Measured on aml: `accountId: UUID?`
+        # comes back required. Comparing required-ness would be near-100% noise. Property NAME
+        # presence, by contrast, is unaffected by this and reliable in both directions.
+        #
+        # Found on the day this landed, not hypothetically: openbank-balance-service's
+        # `PlaceHoldRequest` publishes a phantom `expiresAt` and omits the real, USED
+        # `referenceId`/`ttlSeconds` — confirmed against `BalanceResource.placeHold`, which reads
+        # `body.referenceId` and `body.ttlSeconds` directly. A caller following the published spec
+        # cannot construct a valid request.
       db_backup_association:
         detect: ["openbank-infra/gitops/**/*.yaml (kind: Cluster, postgresql.cnpg.io)"]
         require:

--- a/openbank-infra/gitops/components/balances/balance-service.yaml
+++ b/openbank-infra/gitops/components/balances/balance-service.yaml
@@ -34,7 +34,7 @@ spec:
       annotations:
         # Rolls the pods when the OPA bundle changes — subPath mounts do NOT hot-reload.
         # Kept in sync by gen-balance-opa-bundle.sh (do not hand-edit).
-        openbank.tech/policy-checksum: "f4aad8a684e66716"
+        openbank.tech/policy-checksum: "67731c88dca68691"
     spec:
       securityContext:
         runAsNonRoot: true

--- a/openbank-infra/gitops/components/billing/billing-opa-bundle.yaml
+++ b/openbank-infra/gitops/components/billing/billing-opa-bundle.yaml
@@ -9,7 +9,7 @@ metadata:
     app.kubernetes.io/name: billing-service
     app.kubernetes.io/part-of: billing
   annotations:
-    openbank.tech/policy-checksum: "4486187188f50042"
+    openbank.tech/policy-checksum: "71f7cfd7be956882"
 data:
   rest.rego: |
     # SPDX-License-Identifier: Apache-2.0
@@ -1566,6 +1566,44 @@ data:
         #
         # Advisory because 114 pre-existing findings cannot be a merge blocker on day one. Flipping
         # to enforced = add --enforce in ci.yml, once the backlog is cleared.
+      openapi_request_schema_conformance:
+        detect: ["openbank-*/src/main/resources/openapi.yaml", "the JAX-RS request-body DTO the resource actually deserializes into"]
+        require:
+          - "every property a request-body schema declares exists on the DTO the resource parses"
+          - "every property the DTO has is declared on the request-body schema"
+        gate: openapi-request-schema-conformance
+        enforced: advisory
+        target_enforce_date: "2026-09-30"
+        ci_producer: ".github/scripts/check-openapi-request-schema-conformance.py"
+        # openapi_route_conformance (above) is ROUTE SET ONLY — it does not read schemas, so aml's
+        # invented request/response fields passed it clean (#2312). This is the request half of that
+        # gap, using the document Quarkus itself generates
+        # (quarkus.smallrye-openapi.store-schema-directory) as ground truth instead of guessing.
+        # `:build` already runs `quarkusBuild` in its task graph (confirmed via --dry-run), so wiring
+        # this into `_service-ci.yml`'s existing build step costs no extra build time.
+        #
+        # NOT the response half, and that is a decision, not a gap left for later. 457 handler methods
+        # fleet-wide return a raw jakarta.ws.rs.core.Response, which erases the body type at the JVM
+        # level — the scanner that produces the generated document has no static type to build a
+        # response schema from and emits an EMPTY schema for those. Measured directly on aml-service:
+        # AmlCaseResponse does not appear anywhere in the generated document, even though it is real
+        # and correct. A generic response-schema gate over this fleet cannot distinguish "no schema
+        # published" from "the scanner could not see the type" — it would report the majority of
+        # correct endpoints as findings. The response half needs a per-endpoint contract test that
+        # asserts the DTO shape directly, the pattern `CopilotApiContractTest` and the fx/aml
+        # provider-verified pacts already use, not a generic diff.
+        #
+        # `required` is also deliberately not compared: SmallRye OpenAPI's scanner has no
+        # jackson-module-kotlin integration, so it does not read Kotlin nullability and marks nearly
+        # every constructor parameter required regardless of `?`. Measured on aml: `accountId: UUID?`
+        # comes back required. Comparing required-ness would be near-100% noise. Property NAME
+        # presence, by contrast, is unaffected by this and reliable in both directions.
+        #
+        # Found on the day this landed, not hypothetically: openbank-balance-service's
+        # `PlaceHoldRequest` publishes a phantom `expiresAt` and omits the real, USED
+        # `referenceId`/`ttlSeconds` — confirmed against `BalanceResource.placeHold`, which reads
+        # `body.referenceId` and `body.ttlSeconds` directly. A caller following the published spec
+        # cannot construct a valid request.
       db_backup_association:
         detect: ["openbank-infra/gitops/**/*.yaml (kind: Cluster, postgresql.cnpg.io)"]
         require:

--- a/openbank-infra/gitops/components/billing/billing-service.yaml
+++ b/openbank-infra/gitops/components/billing/billing-service.yaml
@@ -27,7 +27,7 @@ spec:
       annotations:
         # Rolls the pods when the OPA bundle changes — subPath mounts do NOT hot-reload.
         # Kept in sync by gen-billing-opa-bundle.sh (do not hand-edit).
-        openbank.tech/policy-checksum: "4486187188f50042"
+        openbank.tech/policy-checksum: "71f7cfd7be956882"
     spec:
       securityContext:
         runAsNonRoot: true

--- a/openbank-infra/gitops/components/consent/consent-opa-bundle.yaml
+++ b/openbank-infra/gitops/components/consent/consent-opa-bundle.yaml
@@ -9,7 +9,7 @@ metadata:
     app.kubernetes.io/name: consent-service
     app.kubernetes.io/part-of: consent
   annotations:
-    openbank.tech/policy-checksum: "de9ad35dac5e9b6e"
+    openbank.tech/policy-checksum: "f95ac62dfc1e2a99"
 data:
   rest.rego: |
     # SPDX-License-Identifier: Apache-2.0
@@ -1598,6 +1598,44 @@ data:
         #
         # Advisory because 114 pre-existing findings cannot be a merge blocker on day one. Flipping
         # to enforced = add --enforce in ci.yml, once the backlog is cleared.
+      openapi_request_schema_conformance:
+        detect: ["openbank-*/src/main/resources/openapi.yaml", "the JAX-RS request-body DTO the resource actually deserializes into"]
+        require:
+          - "every property a request-body schema declares exists on the DTO the resource parses"
+          - "every property the DTO has is declared on the request-body schema"
+        gate: openapi-request-schema-conformance
+        enforced: advisory
+        target_enforce_date: "2026-09-30"
+        ci_producer: ".github/scripts/check-openapi-request-schema-conformance.py"
+        # openapi_route_conformance (above) is ROUTE SET ONLY — it does not read schemas, so aml's
+        # invented request/response fields passed it clean (#2312). This is the request half of that
+        # gap, using the document Quarkus itself generates
+        # (quarkus.smallrye-openapi.store-schema-directory) as ground truth instead of guessing.
+        # `:build` already runs `quarkusBuild` in its task graph (confirmed via --dry-run), so wiring
+        # this into `_service-ci.yml`'s existing build step costs no extra build time.
+        #
+        # NOT the response half, and that is a decision, not a gap left for later. 457 handler methods
+        # fleet-wide return a raw jakarta.ws.rs.core.Response, which erases the body type at the JVM
+        # level — the scanner that produces the generated document has no static type to build a
+        # response schema from and emits an EMPTY schema for those. Measured directly on aml-service:
+        # AmlCaseResponse does not appear anywhere in the generated document, even though it is real
+        # and correct. A generic response-schema gate over this fleet cannot distinguish "no schema
+        # published" from "the scanner could not see the type" — it would report the majority of
+        # correct endpoints as findings. The response half needs a per-endpoint contract test that
+        # asserts the DTO shape directly, the pattern `CopilotApiContractTest` and the fx/aml
+        # provider-verified pacts already use, not a generic diff.
+        #
+        # `required` is also deliberately not compared: SmallRye OpenAPI's scanner has no
+        # jackson-module-kotlin integration, so it does not read Kotlin nullability and marks nearly
+        # every constructor parameter required regardless of `?`. Measured on aml: `accountId: UUID?`
+        # comes back required. Comparing required-ness would be near-100% noise. Property NAME
+        # presence, by contrast, is unaffected by this and reliable in both directions.
+        #
+        # Found on the day this landed, not hypothetically: openbank-balance-service's
+        # `PlaceHoldRequest` publishes a phantom `expiresAt` and omits the real, USED
+        # `referenceId`/`ttlSeconds` — confirmed against `BalanceResource.placeHold`, which reads
+        # `body.referenceId` and `body.ttlSeconds` directly. A caller following the published spec
+        # cannot construct a valid request.
       db_backup_association:
         detect: ["openbank-infra/gitops/**/*.yaml (kind: Cluster, postgresql.cnpg.io)"]
         require:

--- a/openbank-infra/gitops/components/consent/consent-service.yaml
+++ b/openbank-infra/gitops/components/consent/consent-service.yaml
@@ -28,7 +28,7 @@ spec:
       annotations:
         # Rolls the pods when the OPA bundle changes — subPath mounts do NOT hot-reload.
         # Kept in sync by gen-consent-opa-bundle.sh (do not hand-edit).
-        openbank.tech/policy-checksum: "de9ad35dac5e9b6e"
+        openbank.tech/policy-checksum: "f95ac62dfc1e2a99"
     spec:
       securityContext:
         runAsNonRoot: true

--- a/openbank-infra/gitops/components/copilot/copilot-opa-bundle.yaml
+++ b/openbank-infra/gitops/components/copilot/copilot-opa-bundle.yaml
@@ -9,7 +9,7 @@ metadata:
     app.kubernetes.io/name: copilot-service
     app.kubernetes.io/part-of: platform
   annotations:
-    openbank.tech/policy-checksum: "d7f8f4aeaabcd6e5"
+    openbank.tech/policy-checksum: "a99f8ebad4ebc92b"
 data:
   rest.rego: |
     # SPDX-License-Identifier: Apache-2.0
@@ -1652,6 +1652,44 @@ data:
         #
         # Advisory because 114 pre-existing findings cannot be a merge blocker on day one. Flipping
         # to enforced = add --enforce in ci.yml, once the backlog is cleared.
+      openapi_request_schema_conformance:
+        detect: ["openbank-*/src/main/resources/openapi.yaml", "the JAX-RS request-body DTO the resource actually deserializes into"]
+        require:
+          - "every property a request-body schema declares exists on the DTO the resource parses"
+          - "every property the DTO has is declared on the request-body schema"
+        gate: openapi-request-schema-conformance
+        enforced: advisory
+        target_enforce_date: "2026-09-30"
+        ci_producer: ".github/scripts/check-openapi-request-schema-conformance.py"
+        # openapi_route_conformance (above) is ROUTE SET ONLY — it does not read schemas, so aml's
+        # invented request/response fields passed it clean (#2312). This is the request half of that
+        # gap, using the document Quarkus itself generates
+        # (quarkus.smallrye-openapi.store-schema-directory) as ground truth instead of guessing.
+        # `:build` already runs `quarkusBuild` in its task graph (confirmed via --dry-run), so wiring
+        # this into `_service-ci.yml`'s existing build step costs no extra build time.
+        #
+        # NOT the response half, and that is a decision, not a gap left for later. 457 handler methods
+        # fleet-wide return a raw jakarta.ws.rs.core.Response, which erases the body type at the JVM
+        # level — the scanner that produces the generated document has no static type to build a
+        # response schema from and emits an EMPTY schema for those. Measured directly on aml-service:
+        # AmlCaseResponse does not appear anywhere in the generated document, even though it is real
+        # and correct. A generic response-schema gate over this fleet cannot distinguish "no schema
+        # published" from "the scanner could not see the type" — it would report the majority of
+        # correct endpoints as findings. The response half needs a per-endpoint contract test that
+        # asserts the DTO shape directly, the pattern `CopilotApiContractTest` and the fx/aml
+        # provider-verified pacts already use, not a generic diff.
+        #
+        # `required` is also deliberately not compared: SmallRye OpenAPI's scanner has no
+        # jackson-module-kotlin integration, so it does not read Kotlin nullability and marks nearly
+        # every constructor parameter required regardless of `?`. Measured on aml: `accountId: UUID?`
+        # comes back required. Comparing required-ness would be near-100% noise. Property NAME
+        # presence, by contrast, is unaffected by this and reliable in both directions.
+        #
+        # Found on the day this landed, not hypothetically: openbank-balance-service's
+        # `PlaceHoldRequest` publishes a phantom `expiresAt` and omits the real, USED
+        # `referenceId`/`ttlSeconds` — confirmed against `BalanceResource.placeHold`, which reads
+        # `body.referenceId` and `body.ttlSeconds` directly. A caller following the published spec
+        # cannot construct a valid request.
       db_backup_association:
         detect: ["openbank-infra/gitops/**/*.yaml (kind: Cluster, postgresql.cnpg.io)"]
         require:

--- a/openbank-infra/gitops/components/copilot/copilot-service.yaml
+++ b/openbank-infra/gitops/components/copilot/copilot-service.yaml
@@ -29,7 +29,7 @@ spec:
       annotations:
         # Rolls the pod when the OPA bundle changes — subPath mounts do NOT hot-reload.
         # Kept in sync by gen-copilot-opa-bundle.sh (do not hand-edit).
-        openbank.tech/policy-checksum: "d7f8f4aeaabcd6e5"
+        openbank.tech/policy-checksum: "a99f8ebad4ebc92b"
     spec:
       securityContext:
         runAsNonRoot: true

--- a/openbank-infra/gitops/components/customer-edge/customer-edge-opa-bundle.yaml
+++ b/openbank-infra/gitops/components/customer-edge/customer-edge-opa-bundle.yaml
@@ -10,7 +10,7 @@ metadata:
     app.kubernetes.io/name: customer-edge
     app.kubernetes.io/part-of: customer-edge
   annotations:
-    openbank.tech/policy-checksum: "8bc5fdcd966be1b0"
+    openbank.tech/policy-checksum: "79c797e60711208b"
 data:
   rest.rego: |
     # SPDX-License-Identifier: Apache-2.0
@@ -751,6 +751,44 @@ data:
         #
         # Advisory because 114 pre-existing findings cannot be a merge blocker on day one. Flipping
         # to enforced = add --enforce in ci.yml, once the backlog is cleared.
+      openapi_request_schema_conformance:
+        detect: ["openbank-*/src/main/resources/openapi.yaml", "the JAX-RS request-body DTO the resource actually deserializes into"]
+        require:
+          - "every property a request-body schema declares exists on the DTO the resource parses"
+          - "every property the DTO has is declared on the request-body schema"
+        gate: openapi-request-schema-conformance
+        enforced: advisory
+        target_enforce_date: "2026-09-30"
+        ci_producer: ".github/scripts/check-openapi-request-schema-conformance.py"
+        # openapi_route_conformance (above) is ROUTE SET ONLY — it does not read schemas, so aml's
+        # invented request/response fields passed it clean (#2312). This is the request half of that
+        # gap, using the document Quarkus itself generates
+        # (quarkus.smallrye-openapi.store-schema-directory) as ground truth instead of guessing.
+        # `:build` already runs `quarkusBuild` in its task graph (confirmed via --dry-run), so wiring
+        # this into `_service-ci.yml`'s existing build step costs no extra build time.
+        #
+        # NOT the response half, and that is a decision, not a gap left for later. 457 handler methods
+        # fleet-wide return a raw jakarta.ws.rs.core.Response, which erases the body type at the JVM
+        # level — the scanner that produces the generated document has no static type to build a
+        # response schema from and emits an EMPTY schema for those. Measured directly on aml-service:
+        # AmlCaseResponse does not appear anywhere in the generated document, even though it is real
+        # and correct. A generic response-schema gate over this fleet cannot distinguish "no schema
+        # published" from "the scanner could not see the type" — it would report the majority of
+        # correct endpoints as findings. The response half needs a per-endpoint contract test that
+        # asserts the DTO shape directly, the pattern `CopilotApiContractTest` and the fx/aml
+        # provider-verified pacts already use, not a generic diff.
+        #
+        # `required` is also deliberately not compared: SmallRye OpenAPI's scanner has no
+        # jackson-module-kotlin integration, so it does not read Kotlin nullability and marks nearly
+        # every constructor parameter required regardless of `?`. Measured on aml: `accountId: UUID?`
+        # comes back required. Comparing required-ness would be near-100% noise. Property NAME
+        # presence, by contrast, is unaffected by this and reliable in both directions.
+        #
+        # Found on the day this landed, not hypothetically: openbank-balance-service's
+        # `PlaceHoldRequest` publishes a phantom `expiresAt` and omits the real, USED
+        # `referenceId`/`ttlSeconds` — confirmed against `BalanceResource.placeHold`, which reads
+        # `body.referenceId` and `body.ttlSeconds` directly. A caller following the published spec
+        # cannot construct a valid request.
       db_backup_association:
         detect: ["openbank-infra/gitops/**/*.yaml (kind: Cluster, postgresql.cnpg.io)"]
         require:

--- a/openbank-infra/gitops/components/customer-edge/customer-edge.yaml
+++ b/openbank-infra/gitops/components/customer-edge/customer-edge.yaml
@@ -65,7 +65,7 @@ spec:
       annotations:
         # Rolls the pod when the OPA bundle changes — subPath mounts do NOT hot-reload.
         # Kept in sync by gen-customer-edge-opa-bundle.sh (do not hand-edit).
-        openbank.tech/policy-checksum: "8bc5fdcd966be1b0"
+        openbank.tech/policy-checksum: "79c797e60711208b"
     spec:
       # Dedicated SA so EKS Pod Identity can hand the edge (and ONLY the edge) the
       # feedback-screenshots S3 role — ADR-0192, openbank-infra/aws/envs/sandbox-platform/

--- a/openbank-infra/gitops/components/dispute-service/dispute-opa-bundle.yaml
+++ b/openbank-infra/gitops/components/dispute-service/dispute-opa-bundle.yaml
@@ -9,7 +9,7 @@ metadata:
     app.kubernetes.io/name: dispute-service
     app.kubernetes.io/part-of: dispute
   annotations:
-    openbank.tech/policy-checksum: "0fa690693e0dcf1a"
+    openbank.tech/policy-checksum: "f3eba3091b4c7747"
 data:
   rest.rego: |
     # SPDX-License-Identifier: Apache-2.0
@@ -1702,6 +1702,44 @@ data:
         #
         # Advisory because 114 pre-existing findings cannot be a merge blocker on day one. Flipping
         # to enforced = add --enforce in ci.yml, once the backlog is cleared.
+      openapi_request_schema_conformance:
+        detect: ["openbank-*/src/main/resources/openapi.yaml", "the JAX-RS request-body DTO the resource actually deserializes into"]
+        require:
+          - "every property a request-body schema declares exists on the DTO the resource parses"
+          - "every property the DTO has is declared on the request-body schema"
+        gate: openapi-request-schema-conformance
+        enforced: advisory
+        target_enforce_date: "2026-09-30"
+        ci_producer: ".github/scripts/check-openapi-request-schema-conformance.py"
+        # openapi_route_conformance (above) is ROUTE SET ONLY — it does not read schemas, so aml's
+        # invented request/response fields passed it clean (#2312). This is the request half of that
+        # gap, using the document Quarkus itself generates
+        # (quarkus.smallrye-openapi.store-schema-directory) as ground truth instead of guessing.
+        # `:build` already runs `quarkusBuild` in its task graph (confirmed via --dry-run), so wiring
+        # this into `_service-ci.yml`'s existing build step costs no extra build time.
+        #
+        # NOT the response half, and that is a decision, not a gap left for later. 457 handler methods
+        # fleet-wide return a raw jakarta.ws.rs.core.Response, which erases the body type at the JVM
+        # level — the scanner that produces the generated document has no static type to build a
+        # response schema from and emits an EMPTY schema for those. Measured directly on aml-service:
+        # AmlCaseResponse does not appear anywhere in the generated document, even though it is real
+        # and correct. A generic response-schema gate over this fleet cannot distinguish "no schema
+        # published" from "the scanner could not see the type" — it would report the majority of
+        # correct endpoints as findings. The response half needs a per-endpoint contract test that
+        # asserts the DTO shape directly, the pattern `CopilotApiContractTest` and the fx/aml
+        # provider-verified pacts already use, not a generic diff.
+        #
+        # `required` is also deliberately not compared: SmallRye OpenAPI's scanner has no
+        # jackson-module-kotlin integration, so it does not read Kotlin nullability and marks nearly
+        # every constructor parameter required regardless of `?`. Measured on aml: `accountId: UUID?`
+        # comes back required. Comparing required-ness would be near-100% noise. Property NAME
+        # presence, by contrast, is unaffected by this and reliable in both directions.
+        #
+        # Found on the day this landed, not hypothetically: openbank-balance-service's
+        # `PlaceHoldRequest` publishes a phantom `expiresAt` and omits the real, USED
+        # `referenceId`/`ttlSeconds` — confirmed against `BalanceResource.placeHold`, which reads
+        # `body.referenceId` and `body.ttlSeconds` directly. A caller following the published spec
+        # cannot construct a valid request.
       db_backup_association:
         detect: ["openbank-infra/gitops/**/*.yaml (kind: Cluster, postgresql.cnpg.io)"]
         require:

--- a/openbank-infra/gitops/components/dispute-service/dispute-service.yaml
+++ b/openbank-infra/gitops/components/dispute-service/dispute-service.yaml
@@ -15,7 +15,7 @@ spec:
       annotations:
         # Rolls the pod when the OPA bundle changes — subPath mounts do NOT hot-reload.
         # Kept in sync by gen-dispute-opa-bundle.sh (do not hand-edit).
-        openbank.tech/policy-checksum: "0fa690693e0dcf1a"
+        openbank.tech/policy-checksum: "f3eba3091b4c7747"
       labels: {app.kubernetes.io/name: dispute-service, app.kubernetes.io/part-of: dispute}
     spec:
       securityContext:

--- a/openbank-infra/gitops/components/document-service/document-service-opa-bundle.yaml
+++ b/openbank-infra/gitops/components/document-service/document-service-opa-bundle.yaml
@@ -10,7 +10,7 @@ metadata:
     app.kubernetes.io/name: document-service
     app.kubernetes.io/part-of: documents
   annotations:
-    openbank.tech/policy-checksum: "8bc5fdcd966be1b0"
+    openbank.tech/policy-checksum: "79c797e60711208b"
 data:
   rest.rego: |
     # SPDX-License-Identifier: Apache-2.0
@@ -751,6 +751,44 @@ data:
         #
         # Advisory because 114 pre-existing findings cannot be a merge blocker on day one. Flipping
         # to enforced = add --enforce in ci.yml, once the backlog is cleared.
+      openapi_request_schema_conformance:
+        detect: ["openbank-*/src/main/resources/openapi.yaml", "the JAX-RS request-body DTO the resource actually deserializes into"]
+        require:
+          - "every property a request-body schema declares exists on the DTO the resource parses"
+          - "every property the DTO has is declared on the request-body schema"
+        gate: openapi-request-schema-conformance
+        enforced: advisory
+        target_enforce_date: "2026-09-30"
+        ci_producer: ".github/scripts/check-openapi-request-schema-conformance.py"
+        # openapi_route_conformance (above) is ROUTE SET ONLY — it does not read schemas, so aml's
+        # invented request/response fields passed it clean (#2312). This is the request half of that
+        # gap, using the document Quarkus itself generates
+        # (quarkus.smallrye-openapi.store-schema-directory) as ground truth instead of guessing.
+        # `:build` already runs `quarkusBuild` in its task graph (confirmed via --dry-run), so wiring
+        # this into `_service-ci.yml`'s existing build step costs no extra build time.
+        #
+        # NOT the response half, and that is a decision, not a gap left for later. 457 handler methods
+        # fleet-wide return a raw jakarta.ws.rs.core.Response, which erases the body type at the JVM
+        # level — the scanner that produces the generated document has no static type to build a
+        # response schema from and emits an EMPTY schema for those. Measured directly on aml-service:
+        # AmlCaseResponse does not appear anywhere in the generated document, even though it is real
+        # and correct. A generic response-schema gate over this fleet cannot distinguish "no schema
+        # published" from "the scanner could not see the type" — it would report the majority of
+        # correct endpoints as findings. The response half needs a per-endpoint contract test that
+        # asserts the DTO shape directly, the pattern `CopilotApiContractTest` and the fx/aml
+        # provider-verified pacts already use, not a generic diff.
+        #
+        # `required` is also deliberately not compared: SmallRye OpenAPI's scanner has no
+        # jackson-module-kotlin integration, so it does not read Kotlin nullability and marks nearly
+        # every constructor parameter required regardless of `?`. Measured on aml: `accountId: UUID?`
+        # comes back required. Comparing required-ness would be near-100% noise. Property NAME
+        # presence, by contrast, is unaffected by this and reliable in both directions.
+        #
+        # Found on the day this landed, not hypothetically: openbank-balance-service's
+        # `PlaceHoldRequest` publishes a phantom `expiresAt` and omits the real, USED
+        # `referenceId`/`ttlSeconds` — confirmed against `BalanceResource.placeHold`, which reads
+        # `body.referenceId` and `body.ttlSeconds` directly. A caller following the published spec
+        # cannot construct a valid request.
       db_backup_association:
         detect: ["openbank-infra/gitops/**/*.yaml (kind: Cluster, postgresql.cnpg.io)"]
         require:

--- a/openbank-infra/gitops/components/document-service/document-service-service.yaml
+++ b/openbank-infra/gitops/components/document-service/document-service-service.yaml
@@ -43,7 +43,7 @@ spec:
       annotations:
         # Rolls the pods when the OPA bundle changes — subPath mounts do NOT hot-reload.
         # Kept in sync by gen-document-service-opa-bundle.sh (do not hand-edit).
-        openbank.tech/policy-checksum: "8bc5fdcd966be1b0"
+        openbank.tech/policy-checksum: "79c797e60711208b"
     spec:
       # ADR-0162 D4 (continued): a dedicated SA (not `default`) is what OpenBao's Kubernetes-auth
       # role `document-service-signing` is bound to — least-privilege, one identity per consumer.

--- a/openbank-infra/gitops/components/fraud-service/fraud-opa-bundle.yaml
+++ b/openbank-infra/gitops/components/fraud-service/fraud-opa-bundle.yaml
@@ -9,7 +9,7 @@ metadata:
     app.kubernetes.io/name: fraud-service
     app.kubernetes.io/part-of: fraud
   annotations:
-    openbank.tech/policy-checksum: "8842e05bb5e152b5"
+    openbank.tech/policy-checksum: "2e60f7471d4d698b"
 data:
   rest.rego: |
     # SPDX-License-Identifier: Apache-2.0
@@ -1577,6 +1577,44 @@ data:
         #
         # Advisory because 114 pre-existing findings cannot be a merge blocker on day one. Flipping
         # to enforced = add --enforce in ci.yml, once the backlog is cleared.
+      openapi_request_schema_conformance:
+        detect: ["openbank-*/src/main/resources/openapi.yaml", "the JAX-RS request-body DTO the resource actually deserializes into"]
+        require:
+          - "every property a request-body schema declares exists on the DTO the resource parses"
+          - "every property the DTO has is declared on the request-body schema"
+        gate: openapi-request-schema-conformance
+        enforced: advisory
+        target_enforce_date: "2026-09-30"
+        ci_producer: ".github/scripts/check-openapi-request-schema-conformance.py"
+        # openapi_route_conformance (above) is ROUTE SET ONLY — it does not read schemas, so aml's
+        # invented request/response fields passed it clean (#2312). This is the request half of that
+        # gap, using the document Quarkus itself generates
+        # (quarkus.smallrye-openapi.store-schema-directory) as ground truth instead of guessing.
+        # `:build` already runs `quarkusBuild` in its task graph (confirmed via --dry-run), so wiring
+        # this into `_service-ci.yml`'s existing build step costs no extra build time.
+        #
+        # NOT the response half, and that is a decision, not a gap left for later. 457 handler methods
+        # fleet-wide return a raw jakarta.ws.rs.core.Response, which erases the body type at the JVM
+        # level — the scanner that produces the generated document has no static type to build a
+        # response schema from and emits an EMPTY schema for those. Measured directly on aml-service:
+        # AmlCaseResponse does not appear anywhere in the generated document, even though it is real
+        # and correct. A generic response-schema gate over this fleet cannot distinguish "no schema
+        # published" from "the scanner could not see the type" — it would report the majority of
+        # correct endpoints as findings. The response half needs a per-endpoint contract test that
+        # asserts the DTO shape directly, the pattern `CopilotApiContractTest` and the fx/aml
+        # provider-verified pacts already use, not a generic diff.
+        #
+        # `required` is also deliberately not compared: SmallRye OpenAPI's scanner has no
+        # jackson-module-kotlin integration, so it does not read Kotlin nullability and marks nearly
+        # every constructor parameter required regardless of `?`. Measured on aml: `accountId: UUID?`
+        # comes back required. Comparing required-ness would be near-100% noise. Property NAME
+        # presence, by contrast, is unaffected by this and reliable in both directions.
+        #
+        # Found on the day this landed, not hypothetically: openbank-balance-service's
+        # `PlaceHoldRequest` publishes a phantom `expiresAt` and omits the real, USED
+        # `referenceId`/`ttlSeconds` — confirmed against `BalanceResource.placeHold`, which reads
+        # `body.referenceId` and `body.ttlSeconds` directly. A caller following the published spec
+        # cannot construct a valid request.
       db_backup_association:
         detect: ["openbank-infra/gitops/**/*.yaml (kind: Cluster, postgresql.cnpg.io)"]
         require:

--- a/openbank-infra/gitops/components/fraud-service/fraud-service.yaml
+++ b/openbank-infra/gitops/components/fraud-service/fraud-service.yaml
@@ -23,7 +23,7 @@ spec:
       annotations:
         # Rolls the pods when the OPA bundle changes — subPath mounts do NOT hot-reload.
         # Kept in sync by gen-fraud-opa-bundle.sh (do not hand-edit).
-        openbank.tech/policy-checksum: "8842e05bb5e152b5"
+        openbank.tech/policy-checksum: "2e60f7471d4d698b"
     spec:
       securityContext:
         runAsNonRoot: true

--- a/openbank-infra/gitops/components/fx-service/fx-opa-bundle.yaml
+++ b/openbank-infra/gitops/components/fx-service/fx-opa-bundle.yaml
@@ -9,7 +9,7 @@ metadata:
     app.kubernetes.io/name: fx-service
     app.kubernetes.io/part-of: fx
   annotations:
-    openbank.tech/policy-checksum: "11f86f36decbc3ef"
+    openbank.tech/policy-checksum: "60b499a653fb2057"
 data:
   rest.rego: |
     # SPDX-License-Identifier: Apache-2.0
@@ -1628,6 +1628,44 @@ data:
         #
         # Advisory because 114 pre-existing findings cannot be a merge blocker on day one. Flipping
         # to enforced = add --enforce in ci.yml, once the backlog is cleared.
+      openapi_request_schema_conformance:
+        detect: ["openbank-*/src/main/resources/openapi.yaml", "the JAX-RS request-body DTO the resource actually deserializes into"]
+        require:
+          - "every property a request-body schema declares exists on the DTO the resource parses"
+          - "every property the DTO has is declared on the request-body schema"
+        gate: openapi-request-schema-conformance
+        enforced: advisory
+        target_enforce_date: "2026-09-30"
+        ci_producer: ".github/scripts/check-openapi-request-schema-conformance.py"
+        # openapi_route_conformance (above) is ROUTE SET ONLY — it does not read schemas, so aml's
+        # invented request/response fields passed it clean (#2312). This is the request half of that
+        # gap, using the document Quarkus itself generates
+        # (quarkus.smallrye-openapi.store-schema-directory) as ground truth instead of guessing.
+        # `:build` already runs `quarkusBuild` in its task graph (confirmed via --dry-run), so wiring
+        # this into `_service-ci.yml`'s existing build step costs no extra build time.
+        #
+        # NOT the response half, and that is a decision, not a gap left for later. 457 handler methods
+        # fleet-wide return a raw jakarta.ws.rs.core.Response, which erases the body type at the JVM
+        # level — the scanner that produces the generated document has no static type to build a
+        # response schema from and emits an EMPTY schema for those. Measured directly on aml-service:
+        # AmlCaseResponse does not appear anywhere in the generated document, even though it is real
+        # and correct. A generic response-schema gate over this fleet cannot distinguish "no schema
+        # published" from "the scanner could not see the type" — it would report the majority of
+        # correct endpoints as findings. The response half needs a per-endpoint contract test that
+        # asserts the DTO shape directly, the pattern `CopilotApiContractTest` and the fx/aml
+        # provider-verified pacts already use, not a generic diff.
+        #
+        # `required` is also deliberately not compared: SmallRye OpenAPI's scanner has no
+        # jackson-module-kotlin integration, so it does not read Kotlin nullability and marks nearly
+        # every constructor parameter required regardless of `?`. Measured on aml: `accountId: UUID?`
+        # comes back required. Comparing required-ness would be near-100% noise. Property NAME
+        # presence, by contrast, is unaffected by this and reliable in both directions.
+        #
+        # Found on the day this landed, not hypothetically: openbank-balance-service's
+        # `PlaceHoldRequest` publishes a phantom `expiresAt` and omits the real, USED
+        # `referenceId`/`ttlSeconds` — confirmed against `BalanceResource.placeHold`, which reads
+        # `body.referenceId` and `body.ttlSeconds` directly. A caller following the published spec
+        # cannot construct a valid request.
       db_backup_association:
         detect: ["openbank-infra/gitops/**/*.yaml (kind: Cluster, postgresql.cnpg.io)"]
         require:

--- a/openbank-infra/gitops/components/fx-service/fx-service.yaml
+++ b/openbank-infra/gitops/components/fx-service/fx-service.yaml
@@ -22,7 +22,7 @@ spec:
       annotations:
         # Rolls the pods when the OPA bundle changes — subPath mounts do NOT hot-reload.
         # Kept in sync by gen-fx-opa-bundle.sh (do not hand-edit).
-        openbank.tech/policy-checksum: "11f86f36decbc3ef"
+        openbank.tech/policy-checksum: "60b499a653fb2057"
     spec:
       securityContext:
         runAsNonRoot: true

--- a/openbank-infra/gitops/components/interest-service/interest-opa-bundle.yaml
+++ b/openbank-infra/gitops/components/interest-service/interest-opa-bundle.yaml
@@ -9,7 +9,7 @@ metadata:
     app.kubernetes.io/name: interest-service
     app.kubernetes.io/part-of: interest
   annotations:
-    openbank.tech/policy-checksum: "010108918fa2ceaf"
+    openbank.tech/policy-checksum: "3e465e59083b46c4"
 data:
   rest.rego: |
     # SPDX-License-Identifier: Apache-2.0
@@ -1562,6 +1562,44 @@ data:
         #
         # Advisory because 114 pre-existing findings cannot be a merge blocker on day one. Flipping
         # to enforced = add --enforce in ci.yml, once the backlog is cleared.
+      openapi_request_schema_conformance:
+        detect: ["openbank-*/src/main/resources/openapi.yaml", "the JAX-RS request-body DTO the resource actually deserializes into"]
+        require:
+          - "every property a request-body schema declares exists on the DTO the resource parses"
+          - "every property the DTO has is declared on the request-body schema"
+        gate: openapi-request-schema-conformance
+        enforced: advisory
+        target_enforce_date: "2026-09-30"
+        ci_producer: ".github/scripts/check-openapi-request-schema-conformance.py"
+        # openapi_route_conformance (above) is ROUTE SET ONLY — it does not read schemas, so aml's
+        # invented request/response fields passed it clean (#2312). This is the request half of that
+        # gap, using the document Quarkus itself generates
+        # (quarkus.smallrye-openapi.store-schema-directory) as ground truth instead of guessing.
+        # `:build` already runs `quarkusBuild` in its task graph (confirmed via --dry-run), so wiring
+        # this into `_service-ci.yml`'s existing build step costs no extra build time.
+        #
+        # NOT the response half, and that is a decision, not a gap left for later. 457 handler methods
+        # fleet-wide return a raw jakarta.ws.rs.core.Response, which erases the body type at the JVM
+        # level — the scanner that produces the generated document has no static type to build a
+        # response schema from and emits an EMPTY schema for those. Measured directly on aml-service:
+        # AmlCaseResponse does not appear anywhere in the generated document, even though it is real
+        # and correct. A generic response-schema gate over this fleet cannot distinguish "no schema
+        # published" from "the scanner could not see the type" — it would report the majority of
+        # correct endpoints as findings. The response half needs a per-endpoint contract test that
+        # asserts the DTO shape directly, the pattern `CopilotApiContractTest` and the fx/aml
+        # provider-verified pacts already use, not a generic diff.
+        #
+        # `required` is also deliberately not compared: SmallRye OpenAPI's scanner has no
+        # jackson-module-kotlin integration, so it does not read Kotlin nullability and marks nearly
+        # every constructor parameter required regardless of `?`. Measured on aml: `accountId: UUID?`
+        # comes back required. Comparing required-ness would be near-100% noise. Property NAME
+        # presence, by contrast, is unaffected by this and reliable in both directions.
+        #
+        # Found on the day this landed, not hypothetically: openbank-balance-service's
+        # `PlaceHoldRequest` publishes a phantom `expiresAt` and omits the real, USED
+        # `referenceId`/`ttlSeconds` — confirmed against `BalanceResource.placeHold`, which reads
+        # `body.referenceId` and `body.ttlSeconds` directly. A caller following the published spec
+        # cannot construct a valid request.
       db_backup_association:
         detect: ["openbank-infra/gitops/**/*.yaml (kind: Cluster, postgresql.cnpg.io)"]
         require:

--- a/openbank-infra/gitops/components/interest-service/interest-service.yaml
+++ b/openbank-infra/gitops/components/interest-service/interest-service.yaml
@@ -16,7 +16,7 @@ spec:
       annotations:
         # Rolls the pods when the OPA bundle changes — subPath mounts do NOT hot-reload.
         # Kept in sync by gen-interest-opa-bundle.sh (do not hand-edit).
-        openbank.tech/policy-checksum: "010108918fa2ceaf"
+        openbank.tech/policy-checksum: "3e465e59083b46c4"
     spec:
       securityContext:
         runAsNonRoot: true

--- a/openbank-infra/gitops/components/kyc/kyc-opa-bundle.yaml
+++ b/openbank-infra/gitops/components/kyc/kyc-opa-bundle.yaml
@@ -9,7 +9,7 @@ metadata:
     app.kubernetes.io/name: kyc-service
     app.kubernetes.io/part-of: kyc
   annotations:
-    openbank.tech/policy-checksum: "79011fa2d9bb6249"
+    openbank.tech/policy-checksum: "3ea78fd3be905325"
 data:
   rest.rego: |
     # SPDX-License-Identifier: Apache-2.0
@@ -1590,6 +1590,44 @@ data:
         #
         # Advisory because 114 pre-existing findings cannot be a merge blocker on day one. Flipping
         # to enforced = add --enforce in ci.yml, once the backlog is cleared.
+      openapi_request_schema_conformance:
+        detect: ["openbank-*/src/main/resources/openapi.yaml", "the JAX-RS request-body DTO the resource actually deserializes into"]
+        require:
+          - "every property a request-body schema declares exists on the DTO the resource parses"
+          - "every property the DTO has is declared on the request-body schema"
+        gate: openapi-request-schema-conformance
+        enforced: advisory
+        target_enforce_date: "2026-09-30"
+        ci_producer: ".github/scripts/check-openapi-request-schema-conformance.py"
+        # openapi_route_conformance (above) is ROUTE SET ONLY — it does not read schemas, so aml's
+        # invented request/response fields passed it clean (#2312). This is the request half of that
+        # gap, using the document Quarkus itself generates
+        # (quarkus.smallrye-openapi.store-schema-directory) as ground truth instead of guessing.
+        # `:build` already runs `quarkusBuild` in its task graph (confirmed via --dry-run), so wiring
+        # this into `_service-ci.yml`'s existing build step costs no extra build time.
+        #
+        # NOT the response half, and that is a decision, not a gap left for later. 457 handler methods
+        # fleet-wide return a raw jakarta.ws.rs.core.Response, which erases the body type at the JVM
+        # level — the scanner that produces the generated document has no static type to build a
+        # response schema from and emits an EMPTY schema for those. Measured directly on aml-service:
+        # AmlCaseResponse does not appear anywhere in the generated document, even though it is real
+        # and correct. A generic response-schema gate over this fleet cannot distinguish "no schema
+        # published" from "the scanner could not see the type" — it would report the majority of
+        # correct endpoints as findings. The response half needs a per-endpoint contract test that
+        # asserts the DTO shape directly, the pattern `CopilotApiContractTest` and the fx/aml
+        # provider-verified pacts already use, not a generic diff.
+        #
+        # `required` is also deliberately not compared: SmallRye OpenAPI's scanner has no
+        # jackson-module-kotlin integration, so it does not read Kotlin nullability and marks nearly
+        # every constructor parameter required regardless of `?`. Measured on aml: `accountId: UUID?`
+        # comes back required. Comparing required-ness would be near-100% noise. Property NAME
+        # presence, by contrast, is unaffected by this and reliable in both directions.
+        #
+        # Found on the day this landed, not hypothetically: openbank-balance-service's
+        # `PlaceHoldRequest` publishes a phantom `expiresAt` and omits the real, USED
+        # `referenceId`/`ttlSeconds` — confirmed against `BalanceResource.placeHold`, which reads
+        # `body.referenceId` and `body.ttlSeconds` directly. A caller following the published spec
+        # cannot construct a valid request.
       db_backup_association:
         detect: ["openbank-infra/gitops/**/*.yaml (kind: Cluster, postgresql.cnpg.io)"]
         require:

--- a/openbank-infra/gitops/components/kyc/kyc-service.yaml
+++ b/openbank-infra/gitops/components/kyc/kyc-service.yaml
@@ -48,7 +48,7 @@ spec:
       annotations:
         # Rolls the pod when the OPA bundle changes (subPath mounts do not hot-reload).
         # Kept in sync by gen-kyc-opa-bundle.sh (do not hand-edit).
-        openbank.tech/policy-checksum: "79011fa2d9bb6249"
+        openbank.tech/policy-checksum: "3ea78fd3be905325"
     spec:
       securityContext:
         runAsNonRoot: true

--- a/openbank-infra/gitops/components/ledger/ledger-opa-bundle.yaml
+++ b/openbank-infra/gitops/components/ledger/ledger-opa-bundle.yaml
@@ -9,7 +9,7 @@ metadata:
     app.kubernetes.io/name: ledger-service
     app.kubernetes.io/part-of: ledger
   annotations:
-    openbank.tech/policy-checksum: "7636a950e4c6f6b9"
+    openbank.tech/policy-checksum: "e0463574dd4bac09"
 data:
   rest.rego: |
     # SPDX-License-Identifier: Apache-2.0
@@ -1675,6 +1675,44 @@ data:
         #
         # Advisory because 114 pre-existing findings cannot be a merge blocker on day one. Flipping
         # to enforced = add --enforce in ci.yml, once the backlog is cleared.
+      openapi_request_schema_conformance:
+        detect: ["openbank-*/src/main/resources/openapi.yaml", "the JAX-RS request-body DTO the resource actually deserializes into"]
+        require:
+          - "every property a request-body schema declares exists on the DTO the resource parses"
+          - "every property the DTO has is declared on the request-body schema"
+        gate: openapi-request-schema-conformance
+        enforced: advisory
+        target_enforce_date: "2026-09-30"
+        ci_producer: ".github/scripts/check-openapi-request-schema-conformance.py"
+        # openapi_route_conformance (above) is ROUTE SET ONLY — it does not read schemas, so aml's
+        # invented request/response fields passed it clean (#2312). This is the request half of that
+        # gap, using the document Quarkus itself generates
+        # (quarkus.smallrye-openapi.store-schema-directory) as ground truth instead of guessing.
+        # `:build` already runs `quarkusBuild` in its task graph (confirmed via --dry-run), so wiring
+        # this into `_service-ci.yml`'s existing build step costs no extra build time.
+        #
+        # NOT the response half, and that is a decision, not a gap left for later. 457 handler methods
+        # fleet-wide return a raw jakarta.ws.rs.core.Response, which erases the body type at the JVM
+        # level — the scanner that produces the generated document has no static type to build a
+        # response schema from and emits an EMPTY schema for those. Measured directly on aml-service:
+        # AmlCaseResponse does not appear anywhere in the generated document, even though it is real
+        # and correct. A generic response-schema gate over this fleet cannot distinguish "no schema
+        # published" from "the scanner could not see the type" — it would report the majority of
+        # correct endpoints as findings. The response half needs a per-endpoint contract test that
+        # asserts the DTO shape directly, the pattern `CopilotApiContractTest` and the fx/aml
+        # provider-verified pacts already use, not a generic diff.
+        #
+        # `required` is also deliberately not compared: SmallRye OpenAPI's scanner has no
+        # jackson-module-kotlin integration, so it does not read Kotlin nullability and marks nearly
+        # every constructor parameter required regardless of `?`. Measured on aml: `accountId: UUID?`
+        # comes back required. Comparing required-ness would be near-100% noise. Property NAME
+        # presence, by contrast, is unaffected by this and reliable in both directions.
+        #
+        # Found on the day this landed, not hypothetically: openbank-balance-service's
+        # `PlaceHoldRequest` publishes a phantom `expiresAt` and omits the real, USED
+        # `referenceId`/`ttlSeconds` — confirmed against `BalanceResource.placeHold`, which reads
+        # `body.referenceId` and `body.ttlSeconds` directly. A caller following the published spec
+        # cannot construct a valid request.
       db_backup_association:
         detect: ["openbank-infra/gitops/**/*.yaml (kind: Cluster, postgresql.cnpg.io)"]
         require:

--- a/openbank-infra/gitops/components/ledger/ledger-service.yaml
+++ b/openbank-infra/gitops/components/ledger/ledger-service.yaml
@@ -38,7 +38,7 @@ spec:
       annotations:
         # Rolls the pods when the OPA bundle changes — subPath mounts do NOT hot-reload.
         # Kept in sync by gen-ledger-opa-bundle.sh (do not hand-edit).
-        openbank.tech/policy-checksum: "7636a950e4c6f6b9"
+        openbank.tech/policy-checksum: "e0463574dd4bac09"
     spec:
       securityContext:
         runAsNonRoot: true

--- a/openbank-infra/gitops/components/lending/lending-opa-bundle.yaml
+++ b/openbank-infra/gitops/components/lending/lending-opa-bundle.yaml
@@ -9,7 +9,7 @@ metadata:
     app.kubernetes.io/name: lending-service
     app.kubernetes.io/part-of: lending
   annotations:
-    openbank.tech/policy-checksum: "3ba589a36538aa51"
+    openbank.tech/policy-checksum: "669991550ba7aad6"
 data:
   rest.rego: |
     # SPDX-License-Identifier: Apache-2.0
@@ -1630,6 +1630,44 @@ data:
         #
         # Advisory because 114 pre-existing findings cannot be a merge blocker on day one. Flipping
         # to enforced = add --enforce in ci.yml, once the backlog is cleared.
+      openapi_request_schema_conformance:
+        detect: ["openbank-*/src/main/resources/openapi.yaml", "the JAX-RS request-body DTO the resource actually deserializes into"]
+        require:
+          - "every property a request-body schema declares exists on the DTO the resource parses"
+          - "every property the DTO has is declared on the request-body schema"
+        gate: openapi-request-schema-conformance
+        enforced: advisory
+        target_enforce_date: "2026-09-30"
+        ci_producer: ".github/scripts/check-openapi-request-schema-conformance.py"
+        # openapi_route_conformance (above) is ROUTE SET ONLY — it does not read schemas, so aml's
+        # invented request/response fields passed it clean (#2312). This is the request half of that
+        # gap, using the document Quarkus itself generates
+        # (quarkus.smallrye-openapi.store-schema-directory) as ground truth instead of guessing.
+        # `:build` already runs `quarkusBuild` in its task graph (confirmed via --dry-run), so wiring
+        # this into `_service-ci.yml`'s existing build step costs no extra build time.
+        #
+        # NOT the response half, and that is a decision, not a gap left for later. 457 handler methods
+        # fleet-wide return a raw jakarta.ws.rs.core.Response, which erases the body type at the JVM
+        # level — the scanner that produces the generated document has no static type to build a
+        # response schema from and emits an EMPTY schema for those. Measured directly on aml-service:
+        # AmlCaseResponse does not appear anywhere in the generated document, even though it is real
+        # and correct. A generic response-schema gate over this fleet cannot distinguish "no schema
+        # published" from "the scanner could not see the type" — it would report the majority of
+        # correct endpoints as findings. The response half needs a per-endpoint contract test that
+        # asserts the DTO shape directly, the pattern `CopilotApiContractTest` and the fx/aml
+        # provider-verified pacts already use, not a generic diff.
+        #
+        # `required` is also deliberately not compared: SmallRye OpenAPI's scanner has no
+        # jackson-module-kotlin integration, so it does not read Kotlin nullability and marks nearly
+        # every constructor parameter required regardless of `?`. Measured on aml: `accountId: UUID?`
+        # comes back required. Comparing required-ness would be near-100% noise. Property NAME
+        # presence, by contrast, is unaffected by this and reliable in both directions.
+        #
+        # Found on the day this landed, not hypothetically: openbank-balance-service's
+        # `PlaceHoldRequest` publishes a phantom `expiresAt` and omits the real, USED
+        # `referenceId`/`ttlSeconds` — confirmed against `BalanceResource.placeHold`, which reads
+        # `body.referenceId` and `body.ttlSeconds` directly. A caller following the published spec
+        # cannot construct a valid request.
       db_backup_association:
         detect: ["openbank-infra/gitops/**/*.yaml (kind: Cluster, postgresql.cnpg.io)"]
         require:

--- a/openbank-infra/gitops/components/lending/lending-service.yaml
+++ b/openbank-infra/gitops/components/lending/lending-service.yaml
@@ -34,7 +34,7 @@ spec:
       annotations:
         # Rolls the pods when the OPA bundle changes — subPath mounts do NOT hot-reload.
         # Kept in sync by gen-lending-opa-bundle.sh (do not hand-edit).
-        openbank.tech/policy-checksum: "3ba589a36538aa51"
+        openbank.tech/policy-checksum: "669991550ba7aad6"
     spec:
       securityContext:
         runAsNonRoot: true

--- a/openbank-infra/gitops/components/mcp/mcp-opa-bundle.yaml
+++ b/openbank-infra/gitops/components/mcp/mcp-opa-bundle.yaml
@@ -9,7 +9,7 @@ metadata:
     app.kubernetes.io/name: mcp-service
     app.kubernetes.io/part-of: platform
   annotations:
-    openbank.tech/policy-checksum: "2c7a909e8003c64e"
+    openbank.tech/policy-checksum: "31b69cbacb5b9c85"
 data:
   rest.rego: |
     # SPDX-License-Identifier: Apache-2.0
@@ -1528,6 +1528,44 @@ data:
         #
         # Advisory because 114 pre-existing findings cannot be a merge blocker on day one. Flipping
         # to enforced = add --enforce in ci.yml, once the backlog is cleared.
+      openapi_request_schema_conformance:
+        detect: ["openbank-*/src/main/resources/openapi.yaml", "the JAX-RS request-body DTO the resource actually deserializes into"]
+        require:
+          - "every property a request-body schema declares exists on the DTO the resource parses"
+          - "every property the DTO has is declared on the request-body schema"
+        gate: openapi-request-schema-conformance
+        enforced: advisory
+        target_enforce_date: "2026-09-30"
+        ci_producer: ".github/scripts/check-openapi-request-schema-conformance.py"
+        # openapi_route_conformance (above) is ROUTE SET ONLY — it does not read schemas, so aml's
+        # invented request/response fields passed it clean (#2312). This is the request half of that
+        # gap, using the document Quarkus itself generates
+        # (quarkus.smallrye-openapi.store-schema-directory) as ground truth instead of guessing.
+        # `:build` already runs `quarkusBuild` in its task graph (confirmed via --dry-run), so wiring
+        # this into `_service-ci.yml`'s existing build step costs no extra build time.
+        #
+        # NOT the response half, and that is a decision, not a gap left for later. 457 handler methods
+        # fleet-wide return a raw jakarta.ws.rs.core.Response, which erases the body type at the JVM
+        # level — the scanner that produces the generated document has no static type to build a
+        # response schema from and emits an EMPTY schema for those. Measured directly on aml-service:
+        # AmlCaseResponse does not appear anywhere in the generated document, even though it is real
+        # and correct. A generic response-schema gate over this fleet cannot distinguish "no schema
+        # published" from "the scanner could not see the type" — it would report the majority of
+        # correct endpoints as findings. The response half needs a per-endpoint contract test that
+        # asserts the DTO shape directly, the pattern `CopilotApiContractTest` and the fx/aml
+        # provider-verified pacts already use, not a generic diff.
+        #
+        # `required` is also deliberately not compared: SmallRye OpenAPI's scanner has no
+        # jackson-module-kotlin integration, so it does not read Kotlin nullability and marks nearly
+        # every constructor parameter required regardless of `?`. Measured on aml: `accountId: UUID?`
+        # comes back required. Comparing required-ness would be near-100% noise. Property NAME
+        # presence, by contrast, is unaffected by this and reliable in both directions.
+        #
+        # Found on the day this landed, not hypothetically: openbank-balance-service's
+        # `PlaceHoldRequest` publishes a phantom `expiresAt` and omits the real, USED
+        # `referenceId`/`ttlSeconds` — confirmed against `BalanceResource.placeHold`, which reads
+        # `body.referenceId` and `body.ttlSeconds` directly. A caller following the published spec
+        # cannot construct a valid request.
       db_backup_association:
         detect: ["openbank-infra/gitops/**/*.yaml (kind: Cluster, postgresql.cnpg.io)"]
         require:

--- a/openbank-infra/gitops/components/mcp/mcp-service.yaml
+++ b/openbank-infra/gitops/components/mcp/mcp-service.yaml
@@ -29,7 +29,7 @@ spec:
       annotations:
         # Rolls the pod when the OPA bundle changes — subPath mounts do NOT hot-reload.
         # Kept in sync by gen-mcp-opa-bundle.sh (do not hand-edit).
-        openbank.tech/policy-checksum: "2c7a909e8003c64e"
+        openbank.tech/policy-checksum: "31b69cbacb5b9c85"
     spec:
       securityContext:
         runAsNonRoot: true

--- a/openbank-infra/gitops/components/notifications/notification-service-opa-bundle.yaml
+++ b/openbank-infra/gitops/components/notifications/notification-service-opa-bundle.yaml
@@ -10,7 +10,7 @@ metadata:
     app.kubernetes.io/name: notification-service
     app.kubernetes.io/part-of: notifications
   annotations:
-    openbank.tech/policy-checksum: "8bc5fdcd966be1b0"
+    openbank.tech/policy-checksum: "79c797e60711208b"
 data:
   rest.rego: |
     # SPDX-License-Identifier: Apache-2.0
@@ -751,6 +751,44 @@ data:
         #
         # Advisory because 114 pre-existing findings cannot be a merge blocker on day one. Flipping
         # to enforced = add --enforce in ci.yml, once the backlog is cleared.
+      openapi_request_schema_conformance:
+        detect: ["openbank-*/src/main/resources/openapi.yaml", "the JAX-RS request-body DTO the resource actually deserializes into"]
+        require:
+          - "every property a request-body schema declares exists on the DTO the resource parses"
+          - "every property the DTO has is declared on the request-body schema"
+        gate: openapi-request-schema-conformance
+        enforced: advisory
+        target_enforce_date: "2026-09-30"
+        ci_producer: ".github/scripts/check-openapi-request-schema-conformance.py"
+        # openapi_route_conformance (above) is ROUTE SET ONLY — it does not read schemas, so aml's
+        # invented request/response fields passed it clean (#2312). This is the request half of that
+        # gap, using the document Quarkus itself generates
+        # (quarkus.smallrye-openapi.store-schema-directory) as ground truth instead of guessing.
+        # `:build` already runs `quarkusBuild` in its task graph (confirmed via --dry-run), so wiring
+        # this into `_service-ci.yml`'s existing build step costs no extra build time.
+        #
+        # NOT the response half, and that is a decision, not a gap left for later. 457 handler methods
+        # fleet-wide return a raw jakarta.ws.rs.core.Response, which erases the body type at the JVM
+        # level — the scanner that produces the generated document has no static type to build a
+        # response schema from and emits an EMPTY schema for those. Measured directly on aml-service:
+        # AmlCaseResponse does not appear anywhere in the generated document, even though it is real
+        # and correct. A generic response-schema gate over this fleet cannot distinguish "no schema
+        # published" from "the scanner could not see the type" — it would report the majority of
+        # correct endpoints as findings. The response half needs a per-endpoint contract test that
+        # asserts the DTO shape directly, the pattern `CopilotApiContractTest` and the fx/aml
+        # provider-verified pacts already use, not a generic diff.
+        #
+        # `required` is also deliberately not compared: SmallRye OpenAPI's scanner has no
+        # jackson-module-kotlin integration, so it does not read Kotlin nullability and marks nearly
+        # every constructor parameter required regardless of `?`. Measured on aml: `accountId: UUID?`
+        # comes back required. Comparing required-ness would be near-100% noise. Property NAME
+        # presence, by contrast, is unaffected by this and reliable in both directions.
+        #
+        # Found on the day this landed, not hypothetically: openbank-balance-service's
+        # `PlaceHoldRequest` publishes a phantom `expiresAt` and omits the real, USED
+        # `referenceId`/`ttlSeconds` — confirmed against `BalanceResource.placeHold`, which reads
+        # `body.referenceId` and `body.ttlSeconds` directly. A caller following the published spec
+        # cannot construct a valid request.
       db_backup_association:
         detect: ["openbank-infra/gitops/**/*.yaml (kind: Cluster, postgresql.cnpg.io)"]
         require:

--- a/openbank-infra/gitops/components/notifications/notification-service.yaml
+++ b/openbank-infra/gitops/components/notifications/notification-service.yaml
@@ -39,7 +39,7 @@ spec:
       annotations:
         # Rolls the Deployment when the OPA policy bundle changes (subPath mounts don't
         # hot-reload). Kept in sync by gen-notification-opa-bundle.sh.
-        openbank.tech/policy-checksum: "8bc5fdcd966be1b0"
+        openbank.tech/policy-checksum: "79c797e60711208b"
       labels:
         app.kubernetes.io/name: notification-service
         app.kubernetes.io/part-of: notifications

--- a/openbank-infra/gitops/components/party/party-opa-bundle.yaml
+++ b/openbank-infra/gitops/components/party/party-opa-bundle.yaml
@@ -9,7 +9,7 @@ metadata:
     app.kubernetes.io/name: party-service
     app.kubernetes.io/part-of: party
   annotations:
-    openbank.tech/policy-checksum: "33fd687161fb7811"
+    openbank.tech/policy-checksum: "691abe294073834f"
 data:
   rest.rego: |
     # SPDX-License-Identifier: Apache-2.0
@@ -1599,6 +1599,44 @@ data:
         #
         # Advisory because 114 pre-existing findings cannot be a merge blocker on day one. Flipping
         # to enforced = add --enforce in ci.yml, once the backlog is cleared.
+      openapi_request_schema_conformance:
+        detect: ["openbank-*/src/main/resources/openapi.yaml", "the JAX-RS request-body DTO the resource actually deserializes into"]
+        require:
+          - "every property a request-body schema declares exists on the DTO the resource parses"
+          - "every property the DTO has is declared on the request-body schema"
+        gate: openapi-request-schema-conformance
+        enforced: advisory
+        target_enforce_date: "2026-09-30"
+        ci_producer: ".github/scripts/check-openapi-request-schema-conformance.py"
+        # openapi_route_conformance (above) is ROUTE SET ONLY — it does not read schemas, so aml's
+        # invented request/response fields passed it clean (#2312). This is the request half of that
+        # gap, using the document Quarkus itself generates
+        # (quarkus.smallrye-openapi.store-schema-directory) as ground truth instead of guessing.
+        # `:build` already runs `quarkusBuild` in its task graph (confirmed via --dry-run), so wiring
+        # this into `_service-ci.yml`'s existing build step costs no extra build time.
+        #
+        # NOT the response half, and that is a decision, not a gap left for later. 457 handler methods
+        # fleet-wide return a raw jakarta.ws.rs.core.Response, which erases the body type at the JVM
+        # level — the scanner that produces the generated document has no static type to build a
+        # response schema from and emits an EMPTY schema for those. Measured directly on aml-service:
+        # AmlCaseResponse does not appear anywhere in the generated document, even though it is real
+        # and correct. A generic response-schema gate over this fleet cannot distinguish "no schema
+        # published" from "the scanner could not see the type" — it would report the majority of
+        # correct endpoints as findings. The response half needs a per-endpoint contract test that
+        # asserts the DTO shape directly, the pattern `CopilotApiContractTest` and the fx/aml
+        # provider-verified pacts already use, not a generic diff.
+        #
+        # `required` is also deliberately not compared: SmallRye OpenAPI's scanner has no
+        # jackson-module-kotlin integration, so it does not read Kotlin nullability and marks nearly
+        # every constructor parameter required regardless of `?`. Measured on aml: `accountId: UUID?`
+        # comes back required. Comparing required-ness would be near-100% noise. Property NAME
+        # presence, by contrast, is unaffected by this and reliable in both directions.
+        #
+        # Found on the day this landed, not hypothetically: openbank-balance-service's
+        # `PlaceHoldRequest` publishes a phantom `expiresAt` and omits the real, USED
+        # `referenceId`/`ttlSeconds` — confirmed against `BalanceResource.placeHold`, which reads
+        # `body.referenceId` and `body.ttlSeconds` directly. A caller following the published spec
+        # cannot construct a valid request.
       db_backup_association:
         detect: ["openbank-infra/gitops/**/*.yaml (kind: Cluster, postgresql.cnpg.io)"]
         require:

--- a/openbank-infra/gitops/components/party/party-service.yaml
+++ b/openbank-infra/gitops/components/party/party-service.yaml
@@ -22,7 +22,7 @@ spec:
       annotations:
         # Rolls the pod when the OPA bundle changes — subPath mounts do NOT hot-reload.
         # Kept in sync by gen-party-opa-bundle.sh (do not hand-edit).
-        openbank.tech/policy-checksum: "33fd687161fb7811"
+        openbank.tech/policy-checksum: "691abe294073834f"
       labels:
         app.kubernetes.io/name: party-service
         app.kubernetes.io/part-of: party

--- a/openbank-infra/gitops/components/payments/card-issuance-opa-bundle.yaml
+++ b/openbank-infra/gitops/components/payments/card-issuance-opa-bundle.yaml
@@ -9,7 +9,7 @@ metadata:
     app.kubernetes.io/name: card-issuance-service
     app.kubernetes.io/part-of: payments
   annotations:
-    openbank.tech/policy-checksum: "b202bafabd1bf555"
+    openbank.tech/policy-checksum: "1091724a64acca05"
 data:
   rest.rego: |
     # SPDX-License-Identifier: Apache-2.0
@@ -1583,6 +1583,44 @@ data:
         #
         # Advisory because 114 pre-existing findings cannot be a merge blocker on day one. Flipping
         # to enforced = add --enforce in ci.yml, once the backlog is cleared.
+      openapi_request_schema_conformance:
+        detect: ["openbank-*/src/main/resources/openapi.yaml", "the JAX-RS request-body DTO the resource actually deserializes into"]
+        require:
+          - "every property a request-body schema declares exists on the DTO the resource parses"
+          - "every property the DTO has is declared on the request-body schema"
+        gate: openapi-request-schema-conformance
+        enforced: advisory
+        target_enforce_date: "2026-09-30"
+        ci_producer: ".github/scripts/check-openapi-request-schema-conformance.py"
+        # openapi_route_conformance (above) is ROUTE SET ONLY — it does not read schemas, so aml's
+        # invented request/response fields passed it clean (#2312). This is the request half of that
+        # gap, using the document Quarkus itself generates
+        # (quarkus.smallrye-openapi.store-schema-directory) as ground truth instead of guessing.
+        # `:build` already runs `quarkusBuild` in its task graph (confirmed via --dry-run), so wiring
+        # this into `_service-ci.yml`'s existing build step costs no extra build time.
+        #
+        # NOT the response half, and that is a decision, not a gap left for later. 457 handler methods
+        # fleet-wide return a raw jakarta.ws.rs.core.Response, which erases the body type at the JVM
+        # level — the scanner that produces the generated document has no static type to build a
+        # response schema from and emits an EMPTY schema for those. Measured directly on aml-service:
+        # AmlCaseResponse does not appear anywhere in the generated document, even though it is real
+        # and correct. A generic response-schema gate over this fleet cannot distinguish "no schema
+        # published" from "the scanner could not see the type" — it would report the majority of
+        # correct endpoints as findings. The response half needs a per-endpoint contract test that
+        # asserts the DTO shape directly, the pattern `CopilotApiContractTest` and the fx/aml
+        # provider-verified pacts already use, not a generic diff.
+        #
+        # `required` is also deliberately not compared: SmallRye OpenAPI's scanner has no
+        # jackson-module-kotlin integration, so it does not read Kotlin nullability and marks nearly
+        # every constructor parameter required regardless of `?`. Measured on aml: `accountId: UUID?`
+        # comes back required. Comparing required-ness would be near-100% noise. Property NAME
+        # presence, by contrast, is unaffected by this and reliable in both directions.
+        #
+        # Found on the day this landed, not hypothetically: openbank-balance-service's
+        # `PlaceHoldRequest` publishes a phantom `expiresAt` and omits the real, USED
+        # `referenceId`/`ttlSeconds` — confirmed against `BalanceResource.placeHold`, which reads
+        # `body.referenceId` and `body.ttlSeconds` directly. A caller following the published spec
+        # cannot construct a valid request.
       db_backup_association:
         detect: ["openbank-infra/gitops/**/*.yaml (kind: Cluster, postgresql.cnpg.io)"]
         require:

--- a/openbank-infra/gitops/components/payments/clearing-opa-bundle.yaml
+++ b/openbank-infra/gitops/components/payments/clearing-opa-bundle.yaml
@@ -9,7 +9,7 @@ metadata:
     app.kubernetes.io/name: clearing-service
     app.kubernetes.io/part-of: payments
   annotations:
-    openbank.tech/policy-checksum: "d9b5cc156c704ac2"
+    openbank.tech/policy-checksum: "cac91627170154ae"
 data:
   rest.rego: |
     # SPDX-License-Identifier: Apache-2.0
@@ -1620,6 +1620,44 @@ data:
         #
         # Advisory because 114 pre-existing findings cannot be a merge blocker on day one. Flipping
         # to enforced = add --enforce in ci.yml, once the backlog is cleared.
+      openapi_request_schema_conformance:
+        detect: ["openbank-*/src/main/resources/openapi.yaml", "the JAX-RS request-body DTO the resource actually deserializes into"]
+        require:
+          - "every property a request-body schema declares exists on the DTO the resource parses"
+          - "every property the DTO has is declared on the request-body schema"
+        gate: openapi-request-schema-conformance
+        enforced: advisory
+        target_enforce_date: "2026-09-30"
+        ci_producer: ".github/scripts/check-openapi-request-schema-conformance.py"
+        # openapi_route_conformance (above) is ROUTE SET ONLY — it does not read schemas, so aml's
+        # invented request/response fields passed it clean (#2312). This is the request half of that
+        # gap, using the document Quarkus itself generates
+        # (quarkus.smallrye-openapi.store-schema-directory) as ground truth instead of guessing.
+        # `:build` already runs `quarkusBuild` in its task graph (confirmed via --dry-run), so wiring
+        # this into `_service-ci.yml`'s existing build step costs no extra build time.
+        #
+        # NOT the response half, and that is a decision, not a gap left for later. 457 handler methods
+        # fleet-wide return a raw jakarta.ws.rs.core.Response, which erases the body type at the JVM
+        # level — the scanner that produces the generated document has no static type to build a
+        # response schema from and emits an EMPTY schema for those. Measured directly on aml-service:
+        # AmlCaseResponse does not appear anywhere in the generated document, even though it is real
+        # and correct. A generic response-schema gate over this fleet cannot distinguish "no schema
+        # published" from "the scanner could not see the type" — it would report the majority of
+        # correct endpoints as findings. The response half needs a per-endpoint contract test that
+        # asserts the DTO shape directly, the pattern `CopilotApiContractTest` and the fx/aml
+        # provider-verified pacts already use, not a generic diff.
+        #
+        # `required` is also deliberately not compared: SmallRye OpenAPI's scanner has no
+        # jackson-module-kotlin integration, so it does not read Kotlin nullability and marks nearly
+        # every constructor parameter required regardless of `?`. Measured on aml: `accountId: UUID?`
+        # comes back required. Comparing required-ness would be near-100% noise. Property NAME
+        # presence, by contrast, is unaffected by this and reliable in both directions.
+        #
+        # Found on the day this landed, not hypothetically: openbank-balance-service's
+        # `PlaceHoldRequest` publishes a phantom `expiresAt` and omits the real, USED
+        # `referenceId`/`ttlSeconds` — confirmed against `BalanceResource.placeHold`, which reads
+        # `body.referenceId` and `body.ttlSeconds` directly. A caller following the published spec
+        # cannot construct a valid request.
       db_backup_association:
         detect: ["openbank-infra/gitops/**/*.yaml (kind: Cluster, postgresql.cnpg.io)"]
         require:

--- a/openbank-infra/gitops/components/payments/domestic-payment-opa-bundle.yaml
+++ b/openbank-infra/gitops/components/payments/domestic-payment-opa-bundle.yaml
@@ -9,7 +9,7 @@ metadata:
     app.kubernetes.io/name: domestic-payment
     app.kubernetes.io/part-of: payments
   annotations:
-    openbank.tech/policy-checksum: "e6b80756d377f2a0"
+    openbank.tech/policy-checksum: "8bc2dee5124ab198"
 data:
   rest.rego: |
     # SPDX-License-Identifier: Apache-2.0
@@ -1605,6 +1605,44 @@ data:
         #
         # Advisory because 114 pre-existing findings cannot be a merge blocker on day one. Flipping
         # to enforced = add --enforce in ci.yml, once the backlog is cleared.
+      openapi_request_schema_conformance:
+        detect: ["openbank-*/src/main/resources/openapi.yaml", "the JAX-RS request-body DTO the resource actually deserializes into"]
+        require:
+          - "every property a request-body schema declares exists on the DTO the resource parses"
+          - "every property the DTO has is declared on the request-body schema"
+        gate: openapi-request-schema-conformance
+        enforced: advisory
+        target_enforce_date: "2026-09-30"
+        ci_producer: ".github/scripts/check-openapi-request-schema-conformance.py"
+        # openapi_route_conformance (above) is ROUTE SET ONLY — it does not read schemas, so aml's
+        # invented request/response fields passed it clean (#2312). This is the request half of that
+        # gap, using the document Quarkus itself generates
+        # (quarkus.smallrye-openapi.store-schema-directory) as ground truth instead of guessing.
+        # `:build` already runs `quarkusBuild` in its task graph (confirmed via --dry-run), so wiring
+        # this into `_service-ci.yml`'s existing build step costs no extra build time.
+        #
+        # NOT the response half, and that is a decision, not a gap left for later. 457 handler methods
+        # fleet-wide return a raw jakarta.ws.rs.core.Response, which erases the body type at the JVM
+        # level — the scanner that produces the generated document has no static type to build a
+        # response schema from and emits an EMPTY schema for those. Measured directly on aml-service:
+        # AmlCaseResponse does not appear anywhere in the generated document, even though it is real
+        # and correct. A generic response-schema gate over this fleet cannot distinguish "no schema
+        # published" from "the scanner could not see the type" — it would report the majority of
+        # correct endpoints as findings. The response half needs a per-endpoint contract test that
+        # asserts the DTO shape directly, the pattern `CopilotApiContractTest` and the fx/aml
+        # provider-verified pacts already use, not a generic diff.
+        #
+        # `required` is also deliberately not compared: SmallRye OpenAPI's scanner has no
+        # jackson-module-kotlin integration, so it does not read Kotlin nullability and marks nearly
+        # every constructor parameter required regardless of `?`. Measured on aml: `accountId: UUID?`
+        # comes back required. Comparing required-ness would be near-100% noise. Property NAME
+        # presence, by contrast, is unaffected by this and reliable in both directions.
+        #
+        # Found on the day this landed, not hypothetically: openbank-balance-service's
+        # `PlaceHoldRequest` publishes a phantom `expiresAt` and omits the real, USED
+        # `referenceId`/`ttlSeconds` — confirmed against `BalanceResource.placeHold`, which reads
+        # `body.referenceId` and `body.ttlSeconds` directly. A caller following the published spec
+        # cannot construct a valid request.
       db_backup_association:
         detect: ["openbank-infra/gitops/**/*.yaml (kind: Cluster, postgresql.cnpg.io)"]
         require:

--- a/openbank-infra/gitops/components/payments/payments-services.yaml
+++ b/openbank-infra/gitops/components/payments/payments-services.yaml
@@ -42,7 +42,7 @@ spec:
         # Rolls the pods when the OPA bundle changes — subPath mounts do NOT hot-reload.
         # Kept in sync by gen-transaction-opa-bundle.sh via the trailing marker comment
         # (do not hand-edit, do not drop the marker).
-        openbank.tech/policy-checksum: "36bf9a9ff2fbde65" # transaction-opa-bundle
+        openbank.tech/policy-checksum: "0c363a146f61b975" # transaction-opa-bundle
     spec:
       securityContext:
         runAsNonRoot: true
@@ -375,7 +375,7 @@ spec:
       annotations:
         # Rolls the pods when the OPA bundle changes — subPath mounts do NOT hot-reload.
         # Kept in sync by gen-sepa-payment-opa-bundle.sh (do not hand-edit).
-        openbank.tech/policy-checksum: "9f778a6a60625676"
+        openbank.tech/policy-checksum: "ec66667ec5f81d5e"
     spec:
       securityContext:
         runAsNonRoot: true
@@ -729,7 +729,7 @@ spec:
         # Rolls the pods when the OPA bundle changes — subPath mounts do NOT hot-reload.
         # Kept in sync by gen-domestic-payment-opa-bundle.sh via the trailing marker
         # comment (do not hand-edit, do not drop the marker).
-        openbank.tech/policy-checksum: "e6b80756d377f2a0" # domestic-payment-opa-bundle
+        openbank.tech/policy-checksum: "8bc2dee5124ab198" # domestic-payment-opa-bundle
     spec:
       securityContext:
         runAsNonRoot: true
@@ -1053,7 +1053,7 @@ spec:
       annotations:
         # Rolls the pods when the OPA bundle changes — subPath mounts do NOT hot-reload.
         # Kept in sync by gen-sepa-instant-opa-bundle.sh (do not hand-edit).
-        openbank.tech/policy-checksum: "feccf7a47a3f2975"
+        openbank.tech/policy-checksum: "0e3ef7b260b92f2f"
     spec:
       securityContext:
         runAsNonRoot: true
@@ -1369,7 +1369,7 @@ spec:
         # Rolls the pods when the OPA bundle changes — subPath mounts do NOT hot-reload.
         # Kept in sync by gen-clearing-opa-bundle.sh via the trailing marker comment
         # (do not hand-edit, do not drop the marker).
-        openbank.tech/policy-checksum: "d9b5cc156c704ac2" # clearing-opa-bundle
+        openbank.tech/policy-checksum: "cac91627170154ae" # clearing-opa-bundle
     spec:
       securityContext:
         runAsNonRoot: true
@@ -1658,7 +1658,7 @@ spec:
       annotations:
         # Rolls the pod when the OPA bundle changes (ADR-0034). Value is stamped by
         # gen-standing-order-opa-bundle.sh — do not hand-edit.
-        openbank.tech/policy-checksum: "5f3323fdc148df78" # standing-order-opa-bundle
+        openbank.tech/policy-checksum: "bd54a9e7a91cc902" # standing-order-opa-bundle
     spec:
       securityContext:
         runAsNonRoot: true
@@ -1911,7 +1911,7 @@ spec:
       annotations:
         # Rolls the pods when the OPA bundle changes — subPath mounts do NOT hot-reload.
         # Kept in sync by gen-card-issuance-opa-bundle.sh (do not hand-edit).
-        openbank.tech/policy-checksum: "b202bafabd1bf555"
+        openbank.tech/policy-checksum: "1091724a64acca05"
     spec:
       securityContext:
         runAsNonRoot: true
@@ -2178,7 +2178,7 @@ spec:
         # Rolls the pods when the OPA bundle changes — subPath mounts do NOT hot-reload.
         # Kept in sync by gen-settlement-opa-bundle.sh via the trailing marker comment
         # (do not hand-edit, do not drop the marker).
-        openbank.tech/policy-checksum: "6e4cb27cb39eeff5" # settlement-opa-bundle
+        openbank.tech/policy-checksum: "869d473fbdf96b03" # settlement-opa-bundle
     spec:
       securityContext:
         runAsNonRoot: true
@@ -2579,7 +2579,7 @@ spec:
       annotations:
         # Rolls the pods when the OPA bundle changes — subPath mounts do NOT hot-reload.
         # Kept in sync by gen-swift-opa-bundle.sh (do not hand-edit).
-        openbank.tech/policy-checksum: "3befb3101ab1e0ba"
+        openbank.tech/policy-checksum: "2c494fcb4f689765"
     spec:
       securityContext:
         runAsNonRoot: true
@@ -2893,7 +2893,7 @@ spec:
       annotations:
         # Rolls the pods when the OPA bundle changes — subPath mounts do NOT hot-reload.
         # Kept in sync by gen-vop-opa-bundle.sh (do not hand-edit).
-        openbank.tech/policy-checksum: "0a8fe5b6e51debe2"
+        openbank.tech/policy-checksum: "3a2488a8fd758825"
     spec:
       securityContext:
         runAsNonRoot: true

--- a/openbank-infra/gitops/components/payments/sepa-instant-opa-bundle.yaml
+++ b/openbank-infra/gitops/components/payments/sepa-instant-opa-bundle.yaml
@@ -9,7 +9,7 @@ metadata:
     app.kubernetes.io/name: sepa-instant
     app.kubernetes.io/part-of: payments
   annotations:
-    openbank.tech/policy-checksum: "feccf7a47a3f2975"
+    openbank.tech/policy-checksum: "0e3ef7b260b92f2f"
 data:
   rest.rego: |
     # SPDX-License-Identifier: Apache-2.0
@@ -1578,6 +1578,44 @@ data:
         #
         # Advisory because 114 pre-existing findings cannot be a merge blocker on day one. Flipping
         # to enforced = add --enforce in ci.yml, once the backlog is cleared.
+      openapi_request_schema_conformance:
+        detect: ["openbank-*/src/main/resources/openapi.yaml", "the JAX-RS request-body DTO the resource actually deserializes into"]
+        require:
+          - "every property a request-body schema declares exists on the DTO the resource parses"
+          - "every property the DTO has is declared on the request-body schema"
+        gate: openapi-request-schema-conformance
+        enforced: advisory
+        target_enforce_date: "2026-09-30"
+        ci_producer: ".github/scripts/check-openapi-request-schema-conformance.py"
+        # openapi_route_conformance (above) is ROUTE SET ONLY — it does not read schemas, so aml's
+        # invented request/response fields passed it clean (#2312). This is the request half of that
+        # gap, using the document Quarkus itself generates
+        # (quarkus.smallrye-openapi.store-schema-directory) as ground truth instead of guessing.
+        # `:build` already runs `quarkusBuild` in its task graph (confirmed via --dry-run), so wiring
+        # this into `_service-ci.yml`'s existing build step costs no extra build time.
+        #
+        # NOT the response half, and that is a decision, not a gap left for later. 457 handler methods
+        # fleet-wide return a raw jakarta.ws.rs.core.Response, which erases the body type at the JVM
+        # level — the scanner that produces the generated document has no static type to build a
+        # response schema from and emits an EMPTY schema for those. Measured directly on aml-service:
+        # AmlCaseResponse does not appear anywhere in the generated document, even though it is real
+        # and correct. A generic response-schema gate over this fleet cannot distinguish "no schema
+        # published" from "the scanner could not see the type" — it would report the majority of
+        # correct endpoints as findings. The response half needs a per-endpoint contract test that
+        # asserts the DTO shape directly, the pattern `CopilotApiContractTest` and the fx/aml
+        # provider-verified pacts already use, not a generic diff.
+        #
+        # `required` is also deliberately not compared: SmallRye OpenAPI's scanner has no
+        # jackson-module-kotlin integration, so it does not read Kotlin nullability and marks nearly
+        # every constructor parameter required regardless of `?`. Measured on aml: `accountId: UUID?`
+        # comes back required. Comparing required-ness would be near-100% noise. Property NAME
+        # presence, by contrast, is unaffected by this and reliable in both directions.
+        #
+        # Found on the day this landed, not hypothetically: openbank-balance-service's
+        # `PlaceHoldRequest` publishes a phantom `expiresAt` and omits the real, USED
+        # `referenceId`/`ttlSeconds` — confirmed against `BalanceResource.placeHold`, which reads
+        # `body.referenceId` and `body.ttlSeconds` directly. A caller following the published spec
+        # cannot construct a valid request.
       db_backup_association:
         detect: ["openbank-infra/gitops/**/*.yaml (kind: Cluster, postgresql.cnpg.io)"]
         require:

--- a/openbank-infra/gitops/components/payments/sepa-payment-opa-bundle.yaml
+++ b/openbank-infra/gitops/components/payments/sepa-payment-opa-bundle.yaml
@@ -9,7 +9,7 @@ metadata:
     app.kubernetes.io/name: sepa-payment
     app.kubernetes.io/part-of: payments
   annotations:
-    openbank.tech/policy-checksum: "9f778a6a60625676"
+    openbank.tech/policy-checksum: "ec66667ec5f81d5e"
 data:
   rest.rego: |
     # SPDX-License-Identifier: Apache-2.0
@@ -1599,6 +1599,44 @@ data:
         #
         # Advisory because 114 pre-existing findings cannot be a merge blocker on day one. Flipping
         # to enforced = add --enforce in ci.yml, once the backlog is cleared.
+      openapi_request_schema_conformance:
+        detect: ["openbank-*/src/main/resources/openapi.yaml", "the JAX-RS request-body DTO the resource actually deserializes into"]
+        require:
+          - "every property a request-body schema declares exists on the DTO the resource parses"
+          - "every property the DTO has is declared on the request-body schema"
+        gate: openapi-request-schema-conformance
+        enforced: advisory
+        target_enforce_date: "2026-09-30"
+        ci_producer: ".github/scripts/check-openapi-request-schema-conformance.py"
+        # openapi_route_conformance (above) is ROUTE SET ONLY — it does not read schemas, so aml's
+        # invented request/response fields passed it clean (#2312). This is the request half of that
+        # gap, using the document Quarkus itself generates
+        # (quarkus.smallrye-openapi.store-schema-directory) as ground truth instead of guessing.
+        # `:build` already runs `quarkusBuild` in its task graph (confirmed via --dry-run), so wiring
+        # this into `_service-ci.yml`'s existing build step costs no extra build time.
+        #
+        # NOT the response half, and that is a decision, not a gap left for later. 457 handler methods
+        # fleet-wide return a raw jakarta.ws.rs.core.Response, which erases the body type at the JVM
+        # level — the scanner that produces the generated document has no static type to build a
+        # response schema from and emits an EMPTY schema for those. Measured directly on aml-service:
+        # AmlCaseResponse does not appear anywhere in the generated document, even though it is real
+        # and correct. A generic response-schema gate over this fleet cannot distinguish "no schema
+        # published" from "the scanner could not see the type" — it would report the majority of
+        # correct endpoints as findings. The response half needs a per-endpoint contract test that
+        # asserts the DTO shape directly, the pattern `CopilotApiContractTest` and the fx/aml
+        # provider-verified pacts already use, not a generic diff.
+        #
+        # `required` is also deliberately not compared: SmallRye OpenAPI's scanner has no
+        # jackson-module-kotlin integration, so it does not read Kotlin nullability and marks nearly
+        # every constructor parameter required regardless of `?`. Measured on aml: `accountId: UUID?`
+        # comes back required. Comparing required-ness would be near-100% noise. Property NAME
+        # presence, by contrast, is unaffected by this and reliable in both directions.
+        #
+        # Found on the day this landed, not hypothetically: openbank-balance-service's
+        # `PlaceHoldRequest` publishes a phantom `expiresAt` and omits the real, USED
+        # `referenceId`/`ttlSeconds` — confirmed against `BalanceResource.placeHold`, which reads
+        # `body.referenceId` and `body.ttlSeconds` directly. A caller following the published spec
+        # cannot construct a valid request.
       db_backup_association:
         detect: ["openbank-infra/gitops/**/*.yaml (kind: Cluster, postgresql.cnpg.io)"]
         require:

--- a/openbank-infra/gitops/components/payments/settlement-opa-bundle.yaml
+++ b/openbank-infra/gitops/components/payments/settlement-opa-bundle.yaml
@@ -9,7 +9,7 @@ metadata:
     app.kubernetes.io/name: settlement-service
     app.kubernetes.io/part-of: payments
   annotations:
-    openbank.tech/policy-checksum: "6e4cb27cb39eeff5"
+    openbank.tech/policy-checksum: "869d473fbdf96b03"
 data:
   rest.rego: |
     # SPDX-License-Identifier: Apache-2.0
@@ -1579,6 +1579,44 @@ data:
         #
         # Advisory because 114 pre-existing findings cannot be a merge blocker on day one. Flipping
         # to enforced = add --enforce in ci.yml, once the backlog is cleared.
+      openapi_request_schema_conformance:
+        detect: ["openbank-*/src/main/resources/openapi.yaml", "the JAX-RS request-body DTO the resource actually deserializes into"]
+        require:
+          - "every property a request-body schema declares exists on the DTO the resource parses"
+          - "every property the DTO has is declared on the request-body schema"
+        gate: openapi-request-schema-conformance
+        enforced: advisory
+        target_enforce_date: "2026-09-30"
+        ci_producer: ".github/scripts/check-openapi-request-schema-conformance.py"
+        # openapi_route_conformance (above) is ROUTE SET ONLY — it does not read schemas, so aml's
+        # invented request/response fields passed it clean (#2312). This is the request half of that
+        # gap, using the document Quarkus itself generates
+        # (quarkus.smallrye-openapi.store-schema-directory) as ground truth instead of guessing.
+        # `:build` already runs `quarkusBuild` in its task graph (confirmed via --dry-run), so wiring
+        # this into `_service-ci.yml`'s existing build step costs no extra build time.
+        #
+        # NOT the response half, and that is a decision, not a gap left for later. 457 handler methods
+        # fleet-wide return a raw jakarta.ws.rs.core.Response, which erases the body type at the JVM
+        # level — the scanner that produces the generated document has no static type to build a
+        # response schema from and emits an EMPTY schema for those. Measured directly on aml-service:
+        # AmlCaseResponse does not appear anywhere in the generated document, even though it is real
+        # and correct. A generic response-schema gate over this fleet cannot distinguish "no schema
+        # published" from "the scanner could not see the type" — it would report the majority of
+        # correct endpoints as findings. The response half needs a per-endpoint contract test that
+        # asserts the DTO shape directly, the pattern `CopilotApiContractTest` and the fx/aml
+        # provider-verified pacts already use, not a generic diff.
+        #
+        # `required` is also deliberately not compared: SmallRye OpenAPI's scanner has no
+        # jackson-module-kotlin integration, so it does not read Kotlin nullability and marks nearly
+        # every constructor parameter required regardless of `?`. Measured on aml: `accountId: UUID?`
+        # comes back required. Comparing required-ness would be near-100% noise. Property NAME
+        # presence, by contrast, is unaffected by this and reliable in both directions.
+        #
+        # Found on the day this landed, not hypothetically: openbank-balance-service's
+        # `PlaceHoldRequest` publishes a phantom `expiresAt` and omits the real, USED
+        # `referenceId`/`ttlSeconds` — confirmed against `BalanceResource.placeHold`, which reads
+        # `body.referenceId` and `body.ttlSeconds` directly. A caller following the published spec
+        # cannot construct a valid request.
       db_backup_association:
         detect: ["openbank-infra/gitops/**/*.yaml (kind: Cluster, postgresql.cnpg.io)"]
         require:

--- a/openbank-infra/gitops/components/payments/standing-order-opa-bundle.yaml
+++ b/openbank-infra/gitops/components/payments/standing-order-opa-bundle.yaml
@@ -9,7 +9,7 @@ metadata:
     app.kubernetes.io/name: standing-order-service
     app.kubernetes.io/part-of: payments
   annotations:
-    openbank.tech/policy-checksum: "5f3323fdc148df78"
+    openbank.tech/policy-checksum: "bd54a9e7a91cc902"
 data:
   rest.rego: |
     # SPDX-License-Identifier: Apache-2.0
@@ -1564,6 +1564,44 @@ data:
         #
         # Advisory because 114 pre-existing findings cannot be a merge blocker on day one. Flipping
         # to enforced = add --enforce in ci.yml, once the backlog is cleared.
+      openapi_request_schema_conformance:
+        detect: ["openbank-*/src/main/resources/openapi.yaml", "the JAX-RS request-body DTO the resource actually deserializes into"]
+        require:
+          - "every property a request-body schema declares exists on the DTO the resource parses"
+          - "every property the DTO has is declared on the request-body schema"
+        gate: openapi-request-schema-conformance
+        enforced: advisory
+        target_enforce_date: "2026-09-30"
+        ci_producer: ".github/scripts/check-openapi-request-schema-conformance.py"
+        # openapi_route_conformance (above) is ROUTE SET ONLY — it does not read schemas, so aml's
+        # invented request/response fields passed it clean (#2312). This is the request half of that
+        # gap, using the document Quarkus itself generates
+        # (quarkus.smallrye-openapi.store-schema-directory) as ground truth instead of guessing.
+        # `:build` already runs `quarkusBuild` in its task graph (confirmed via --dry-run), so wiring
+        # this into `_service-ci.yml`'s existing build step costs no extra build time.
+        #
+        # NOT the response half, and that is a decision, not a gap left for later. 457 handler methods
+        # fleet-wide return a raw jakarta.ws.rs.core.Response, which erases the body type at the JVM
+        # level — the scanner that produces the generated document has no static type to build a
+        # response schema from and emits an EMPTY schema for those. Measured directly on aml-service:
+        # AmlCaseResponse does not appear anywhere in the generated document, even though it is real
+        # and correct. A generic response-schema gate over this fleet cannot distinguish "no schema
+        # published" from "the scanner could not see the type" — it would report the majority of
+        # correct endpoints as findings. The response half needs a per-endpoint contract test that
+        # asserts the DTO shape directly, the pattern `CopilotApiContractTest` and the fx/aml
+        # provider-verified pacts already use, not a generic diff.
+        #
+        # `required` is also deliberately not compared: SmallRye OpenAPI's scanner has no
+        # jackson-module-kotlin integration, so it does not read Kotlin nullability and marks nearly
+        # every constructor parameter required regardless of `?`. Measured on aml: `accountId: UUID?`
+        # comes back required. Comparing required-ness would be near-100% noise. Property NAME
+        # presence, by contrast, is unaffected by this and reliable in both directions.
+        #
+        # Found on the day this landed, not hypothetically: openbank-balance-service's
+        # `PlaceHoldRequest` publishes a phantom `expiresAt` and omits the real, USED
+        # `referenceId`/`ttlSeconds` — confirmed against `BalanceResource.placeHold`, which reads
+        # `body.referenceId` and `body.ttlSeconds` directly. A caller following the published spec
+        # cannot construct a valid request.
       db_backup_association:
         detect: ["openbank-infra/gitops/**/*.yaml (kind: Cluster, postgresql.cnpg.io)"]
         require:

--- a/openbank-infra/gitops/components/payments/swift-opa-bundle.yaml
+++ b/openbank-infra/gitops/components/payments/swift-opa-bundle.yaml
@@ -9,7 +9,7 @@ metadata:
     app.kubernetes.io/name: swift-service
     app.kubernetes.io/part-of: payments
   annotations:
-    openbank.tech/policy-checksum: "3befb3101ab1e0ba"
+    openbank.tech/policy-checksum: "2c494fcb4f689765"
 data:
   rest.rego: |
     # SPDX-License-Identifier: Apache-2.0
@@ -1582,6 +1582,44 @@ data:
         #
         # Advisory because 114 pre-existing findings cannot be a merge blocker on day one. Flipping
         # to enforced = add --enforce in ci.yml, once the backlog is cleared.
+      openapi_request_schema_conformance:
+        detect: ["openbank-*/src/main/resources/openapi.yaml", "the JAX-RS request-body DTO the resource actually deserializes into"]
+        require:
+          - "every property a request-body schema declares exists on the DTO the resource parses"
+          - "every property the DTO has is declared on the request-body schema"
+        gate: openapi-request-schema-conformance
+        enforced: advisory
+        target_enforce_date: "2026-09-30"
+        ci_producer: ".github/scripts/check-openapi-request-schema-conformance.py"
+        # openapi_route_conformance (above) is ROUTE SET ONLY — it does not read schemas, so aml's
+        # invented request/response fields passed it clean (#2312). This is the request half of that
+        # gap, using the document Quarkus itself generates
+        # (quarkus.smallrye-openapi.store-schema-directory) as ground truth instead of guessing.
+        # `:build` already runs `quarkusBuild` in its task graph (confirmed via --dry-run), so wiring
+        # this into `_service-ci.yml`'s existing build step costs no extra build time.
+        #
+        # NOT the response half, and that is a decision, not a gap left for later. 457 handler methods
+        # fleet-wide return a raw jakarta.ws.rs.core.Response, which erases the body type at the JVM
+        # level — the scanner that produces the generated document has no static type to build a
+        # response schema from and emits an EMPTY schema for those. Measured directly on aml-service:
+        # AmlCaseResponse does not appear anywhere in the generated document, even though it is real
+        # and correct. A generic response-schema gate over this fleet cannot distinguish "no schema
+        # published" from "the scanner could not see the type" — it would report the majority of
+        # correct endpoints as findings. The response half needs a per-endpoint contract test that
+        # asserts the DTO shape directly, the pattern `CopilotApiContractTest` and the fx/aml
+        # provider-verified pacts already use, not a generic diff.
+        #
+        # `required` is also deliberately not compared: SmallRye OpenAPI's scanner has no
+        # jackson-module-kotlin integration, so it does not read Kotlin nullability and marks nearly
+        # every constructor parameter required regardless of `?`. Measured on aml: `accountId: UUID?`
+        # comes back required. Comparing required-ness would be near-100% noise. Property NAME
+        # presence, by contrast, is unaffected by this and reliable in both directions.
+        #
+        # Found on the day this landed, not hypothetically: openbank-balance-service's
+        # `PlaceHoldRequest` publishes a phantom `expiresAt` and omits the real, USED
+        # `referenceId`/`ttlSeconds` — confirmed against `BalanceResource.placeHold`, which reads
+        # `body.referenceId` and `body.ttlSeconds` directly. A caller following the published spec
+        # cannot construct a valid request.
       db_backup_association:
         detect: ["openbank-infra/gitops/**/*.yaml (kind: Cluster, postgresql.cnpg.io)"]
         require:

--- a/openbank-infra/gitops/components/payments/transaction-opa-bundle.yaml
+++ b/openbank-infra/gitops/components/payments/transaction-opa-bundle.yaml
@@ -9,7 +9,7 @@ metadata:
     app.kubernetes.io/name: transaction-service
     app.kubernetes.io/part-of: payments
   annotations:
-    openbank.tech/policy-checksum: "36bf9a9ff2fbde65"
+    openbank.tech/policy-checksum: "0c363a146f61b975"
 data:
   rest.rego: |
     # SPDX-License-Identifier: Apache-2.0
@@ -1635,6 +1635,44 @@ data:
         #
         # Advisory because 114 pre-existing findings cannot be a merge blocker on day one. Flipping
         # to enforced = add --enforce in ci.yml, once the backlog is cleared.
+      openapi_request_schema_conformance:
+        detect: ["openbank-*/src/main/resources/openapi.yaml", "the JAX-RS request-body DTO the resource actually deserializes into"]
+        require:
+          - "every property a request-body schema declares exists on the DTO the resource parses"
+          - "every property the DTO has is declared on the request-body schema"
+        gate: openapi-request-schema-conformance
+        enforced: advisory
+        target_enforce_date: "2026-09-30"
+        ci_producer: ".github/scripts/check-openapi-request-schema-conformance.py"
+        # openapi_route_conformance (above) is ROUTE SET ONLY — it does not read schemas, so aml's
+        # invented request/response fields passed it clean (#2312). This is the request half of that
+        # gap, using the document Quarkus itself generates
+        # (quarkus.smallrye-openapi.store-schema-directory) as ground truth instead of guessing.
+        # `:build` already runs `quarkusBuild` in its task graph (confirmed via --dry-run), so wiring
+        # this into `_service-ci.yml`'s existing build step costs no extra build time.
+        #
+        # NOT the response half, and that is a decision, not a gap left for later. 457 handler methods
+        # fleet-wide return a raw jakarta.ws.rs.core.Response, which erases the body type at the JVM
+        # level — the scanner that produces the generated document has no static type to build a
+        # response schema from and emits an EMPTY schema for those. Measured directly on aml-service:
+        # AmlCaseResponse does not appear anywhere in the generated document, even though it is real
+        # and correct. A generic response-schema gate over this fleet cannot distinguish "no schema
+        # published" from "the scanner could not see the type" — it would report the majority of
+        # correct endpoints as findings. The response half needs a per-endpoint contract test that
+        # asserts the DTO shape directly, the pattern `CopilotApiContractTest` and the fx/aml
+        # provider-verified pacts already use, not a generic diff.
+        #
+        # `required` is also deliberately not compared: SmallRye OpenAPI's scanner has no
+        # jackson-module-kotlin integration, so it does not read Kotlin nullability and marks nearly
+        # every constructor parameter required regardless of `?`. Measured on aml: `accountId: UUID?`
+        # comes back required. Comparing required-ness would be near-100% noise. Property NAME
+        # presence, by contrast, is unaffected by this and reliable in both directions.
+        #
+        # Found on the day this landed, not hypothetically: openbank-balance-service's
+        # `PlaceHoldRequest` publishes a phantom `expiresAt` and omits the real, USED
+        # `referenceId`/`ttlSeconds` — confirmed against `BalanceResource.placeHold`, which reads
+        # `body.referenceId` and `body.ttlSeconds` directly. A caller following the published spec
+        # cannot construct a valid request.
       db_backup_association:
         detect: ["openbank-infra/gitops/**/*.yaml (kind: Cluster, postgresql.cnpg.io)"]
         require:

--- a/openbank-infra/gitops/components/payments/vop-opa-bundle.yaml
+++ b/openbank-infra/gitops/components/payments/vop-opa-bundle.yaml
@@ -9,7 +9,7 @@ metadata:
     app.kubernetes.io/name: vop-service
     app.kubernetes.io/part-of: payments
   annotations:
-    openbank.tech/policy-checksum: "0a8fe5b6e51debe2"
+    openbank.tech/policy-checksum: "3a2488a8fd758825"
 data:
   rest.rego: |
     # SPDX-License-Identifier: Apache-2.0
@@ -1586,6 +1586,44 @@ data:
         #
         # Advisory because 114 pre-existing findings cannot be a merge blocker on day one. Flipping
         # to enforced = add --enforce in ci.yml, once the backlog is cleared.
+      openapi_request_schema_conformance:
+        detect: ["openbank-*/src/main/resources/openapi.yaml", "the JAX-RS request-body DTO the resource actually deserializes into"]
+        require:
+          - "every property a request-body schema declares exists on the DTO the resource parses"
+          - "every property the DTO has is declared on the request-body schema"
+        gate: openapi-request-schema-conformance
+        enforced: advisory
+        target_enforce_date: "2026-09-30"
+        ci_producer: ".github/scripts/check-openapi-request-schema-conformance.py"
+        # openapi_route_conformance (above) is ROUTE SET ONLY — it does not read schemas, so aml's
+        # invented request/response fields passed it clean (#2312). This is the request half of that
+        # gap, using the document Quarkus itself generates
+        # (quarkus.smallrye-openapi.store-schema-directory) as ground truth instead of guessing.
+        # `:build` already runs `quarkusBuild` in its task graph (confirmed via --dry-run), so wiring
+        # this into `_service-ci.yml`'s existing build step costs no extra build time.
+        #
+        # NOT the response half, and that is a decision, not a gap left for later. 457 handler methods
+        # fleet-wide return a raw jakarta.ws.rs.core.Response, which erases the body type at the JVM
+        # level — the scanner that produces the generated document has no static type to build a
+        # response schema from and emits an EMPTY schema for those. Measured directly on aml-service:
+        # AmlCaseResponse does not appear anywhere in the generated document, even though it is real
+        # and correct. A generic response-schema gate over this fleet cannot distinguish "no schema
+        # published" from "the scanner could not see the type" — it would report the majority of
+        # correct endpoints as findings. The response half needs a per-endpoint contract test that
+        # asserts the DTO shape directly, the pattern `CopilotApiContractTest` and the fx/aml
+        # provider-verified pacts already use, not a generic diff.
+        #
+        # `required` is also deliberately not compared: SmallRye OpenAPI's scanner has no
+        # jackson-module-kotlin integration, so it does not read Kotlin nullability and marks nearly
+        # every constructor parameter required regardless of `?`. Measured on aml: `accountId: UUID?`
+        # comes back required. Comparing required-ness would be near-100% noise. Property NAME
+        # presence, by contrast, is unaffected by this and reliable in both directions.
+        #
+        # Found on the day this landed, not hypothetically: openbank-balance-service's
+        # `PlaceHoldRequest` publishes a phantom `expiresAt` and omits the real, USED
+        # `referenceId`/`ttlSeconds` — confirmed against `BalanceResource.placeHold`, which reads
+        # `body.referenceId` and `body.ttlSeconds` directly. A caller following the published spec
+        # cannot construct a valid request.
       db_backup_association:
         detect: ["openbank-infra/gitops/**/*.yaml (kind: Cluster, postgresql.cnpg.io)"]
         require:

--- a/openbank-infra/gitops/components/pid/pid-opa-bundle.yaml
+++ b/openbank-infra/gitops/components/pid/pid-opa-bundle.yaml
@@ -9,7 +9,7 @@ metadata:
     app.kubernetes.io/name: pid-service
     app.kubernetes.io/part-of: pid
   annotations:
-    openbank.tech/policy-checksum: "574cce1567a2bce9"
+    openbank.tech/policy-checksum: "df896ffb207c9c5c"
 data:
   rest.rego: |
     # SPDX-License-Identifier: Apache-2.0
@@ -1588,6 +1588,44 @@ data:
         #
         # Advisory because 114 pre-existing findings cannot be a merge blocker on day one. Flipping
         # to enforced = add --enforce in ci.yml, once the backlog is cleared.
+      openapi_request_schema_conformance:
+        detect: ["openbank-*/src/main/resources/openapi.yaml", "the JAX-RS request-body DTO the resource actually deserializes into"]
+        require:
+          - "every property a request-body schema declares exists on the DTO the resource parses"
+          - "every property the DTO has is declared on the request-body schema"
+        gate: openapi-request-schema-conformance
+        enforced: advisory
+        target_enforce_date: "2026-09-30"
+        ci_producer: ".github/scripts/check-openapi-request-schema-conformance.py"
+        # openapi_route_conformance (above) is ROUTE SET ONLY — it does not read schemas, so aml's
+        # invented request/response fields passed it clean (#2312). This is the request half of that
+        # gap, using the document Quarkus itself generates
+        # (quarkus.smallrye-openapi.store-schema-directory) as ground truth instead of guessing.
+        # `:build` already runs `quarkusBuild` in its task graph (confirmed via --dry-run), so wiring
+        # this into `_service-ci.yml`'s existing build step costs no extra build time.
+        #
+        # NOT the response half, and that is a decision, not a gap left for later. 457 handler methods
+        # fleet-wide return a raw jakarta.ws.rs.core.Response, which erases the body type at the JVM
+        # level — the scanner that produces the generated document has no static type to build a
+        # response schema from and emits an EMPTY schema for those. Measured directly on aml-service:
+        # AmlCaseResponse does not appear anywhere in the generated document, even though it is real
+        # and correct. A generic response-schema gate over this fleet cannot distinguish "no schema
+        # published" from "the scanner could not see the type" — it would report the majority of
+        # correct endpoints as findings. The response half needs a per-endpoint contract test that
+        # asserts the DTO shape directly, the pattern `CopilotApiContractTest` and the fx/aml
+        # provider-verified pacts already use, not a generic diff.
+        #
+        # `required` is also deliberately not compared: SmallRye OpenAPI's scanner has no
+        # jackson-module-kotlin integration, so it does not read Kotlin nullability and marks nearly
+        # every constructor parameter required regardless of `?`. Measured on aml: `accountId: UUID?`
+        # comes back required. Comparing required-ness would be near-100% noise. Property NAME
+        # presence, by contrast, is unaffected by this and reliable in both directions.
+        #
+        # Found on the day this landed, not hypothetically: openbank-balance-service's
+        # `PlaceHoldRequest` publishes a phantom `expiresAt` and omits the real, USED
+        # `referenceId`/`ttlSeconds` — confirmed against `BalanceResource.placeHold`, which reads
+        # `body.referenceId` and `body.ttlSeconds` directly. A caller following the published spec
+        # cannot construct a valid request.
       db_backup_association:
         detect: ["openbank-infra/gitops/**/*.yaml (kind: Cluster, postgresql.cnpg.io)"]
         require:

--- a/openbank-infra/gitops/components/pid/pid-service.yaml
+++ b/openbank-infra/gitops/components/pid/pid-service.yaml
@@ -22,7 +22,7 @@ spec:
       annotations:
         # Rolls the pod when the OPA bundle changes — subPath mounts do NOT hot-reload.
         # Kept in sync by gen-pid-opa-bundle.sh (do not hand-edit).
-        openbank.tech/policy-checksum: "574cce1567a2bce9"
+        openbank.tech/policy-checksum: "df896ffb207c9c5c"
     spec:
       securityContext:
         runAsNonRoot: true

--- a/openbank-infra/gitops/components/psd2-service/psd2-opa-bundle.yaml
+++ b/openbank-infra/gitops/components/psd2-service/psd2-opa-bundle.yaml
@@ -9,7 +9,7 @@ metadata:
     app.kubernetes.io/name: psd2-service
     app.kubernetes.io/part-of: psd2
   annotations:
-    openbank.tech/policy-checksum: "95c4d4a69913aec0"
+    openbank.tech/policy-checksum: "1f5f2160e3f395d6"
 data:
   rest.rego: |
     # SPDX-License-Identifier: Apache-2.0
@@ -1661,6 +1661,44 @@ data:
         #
         # Advisory because 114 pre-existing findings cannot be a merge blocker on day one. Flipping
         # to enforced = add --enforce in ci.yml, once the backlog is cleared.
+      openapi_request_schema_conformance:
+        detect: ["openbank-*/src/main/resources/openapi.yaml", "the JAX-RS request-body DTO the resource actually deserializes into"]
+        require:
+          - "every property a request-body schema declares exists on the DTO the resource parses"
+          - "every property the DTO has is declared on the request-body schema"
+        gate: openapi-request-schema-conformance
+        enforced: advisory
+        target_enforce_date: "2026-09-30"
+        ci_producer: ".github/scripts/check-openapi-request-schema-conformance.py"
+        # openapi_route_conformance (above) is ROUTE SET ONLY — it does not read schemas, so aml's
+        # invented request/response fields passed it clean (#2312). This is the request half of that
+        # gap, using the document Quarkus itself generates
+        # (quarkus.smallrye-openapi.store-schema-directory) as ground truth instead of guessing.
+        # `:build` already runs `quarkusBuild` in its task graph (confirmed via --dry-run), so wiring
+        # this into `_service-ci.yml`'s existing build step costs no extra build time.
+        #
+        # NOT the response half, and that is a decision, not a gap left for later. 457 handler methods
+        # fleet-wide return a raw jakarta.ws.rs.core.Response, which erases the body type at the JVM
+        # level — the scanner that produces the generated document has no static type to build a
+        # response schema from and emits an EMPTY schema for those. Measured directly on aml-service:
+        # AmlCaseResponse does not appear anywhere in the generated document, even though it is real
+        # and correct. A generic response-schema gate over this fleet cannot distinguish "no schema
+        # published" from "the scanner could not see the type" — it would report the majority of
+        # correct endpoints as findings. The response half needs a per-endpoint contract test that
+        # asserts the DTO shape directly, the pattern `CopilotApiContractTest` and the fx/aml
+        # provider-verified pacts already use, not a generic diff.
+        #
+        # `required` is also deliberately not compared: SmallRye OpenAPI's scanner has no
+        # jackson-module-kotlin integration, so it does not read Kotlin nullability and marks nearly
+        # every constructor parameter required regardless of `?`. Measured on aml: `accountId: UUID?`
+        # comes back required. Comparing required-ness would be near-100% noise. Property NAME
+        # presence, by contrast, is unaffected by this and reliable in both directions.
+        #
+        # Found on the day this landed, not hypothetically: openbank-balance-service's
+        # `PlaceHoldRequest` publishes a phantom `expiresAt` and omits the real, USED
+        # `referenceId`/`ttlSeconds` — confirmed against `BalanceResource.placeHold`, which reads
+        # `body.referenceId` and `body.ttlSeconds` directly. A caller following the published spec
+        # cannot construct a valid request.
       db_backup_association:
         detect: ["openbank-infra/gitops/**/*.yaml (kind: Cluster, postgresql.cnpg.io)"]
         require:

--- a/openbank-infra/gitops/components/psd2-service/psd2-service.yaml
+++ b/openbank-infra/gitops/components/psd2-service/psd2-service.yaml
@@ -18,7 +18,7 @@ spec:
       annotations:
         # Rolls the pod when the OPA bundle changes — subPath mounts do NOT hot-reload.
         # Kept in sync by gen-psd2-opa-bundle.sh (do not hand-edit).
-        openbank.tech/policy-checksum: "95c4d4a69913aec0"
+        openbank.tech/policy-checksum: "1f5f2160e3f395d6"
       labels: {app.kubernetes.io/name: psd2-service, app.kubernetes.io/part-of: psd2}
     spec:
       securityContext:

--- a/openbank-infra/gitops/components/sanctions-service/sanctions-opa-bundle.yaml
+++ b/openbank-infra/gitops/components/sanctions-service/sanctions-opa-bundle.yaml
@@ -9,7 +9,7 @@ metadata:
     app.kubernetes.io/name: sanctions-service
     app.kubernetes.io/part-of: sanctions
   annotations:
-    openbank.tech/policy-checksum: "472cad6b54875e00"
+    openbank.tech/policy-checksum: "b4b0757045e2925e"
 data:
   rest.rego: |
     # SPDX-License-Identifier: Apache-2.0
@@ -1566,6 +1566,44 @@ data:
         #
         # Advisory because 114 pre-existing findings cannot be a merge blocker on day one. Flipping
         # to enforced = add --enforce in ci.yml, once the backlog is cleared.
+      openapi_request_schema_conformance:
+        detect: ["openbank-*/src/main/resources/openapi.yaml", "the JAX-RS request-body DTO the resource actually deserializes into"]
+        require:
+          - "every property a request-body schema declares exists on the DTO the resource parses"
+          - "every property the DTO has is declared on the request-body schema"
+        gate: openapi-request-schema-conformance
+        enforced: advisory
+        target_enforce_date: "2026-09-30"
+        ci_producer: ".github/scripts/check-openapi-request-schema-conformance.py"
+        # openapi_route_conformance (above) is ROUTE SET ONLY — it does not read schemas, so aml's
+        # invented request/response fields passed it clean (#2312). This is the request half of that
+        # gap, using the document Quarkus itself generates
+        # (quarkus.smallrye-openapi.store-schema-directory) as ground truth instead of guessing.
+        # `:build` already runs `quarkusBuild` in its task graph (confirmed via --dry-run), so wiring
+        # this into `_service-ci.yml`'s existing build step costs no extra build time.
+        #
+        # NOT the response half, and that is a decision, not a gap left for later. 457 handler methods
+        # fleet-wide return a raw jakarta.ws.rs.core.Response, which erases the body type at the JVM
+        # level — the scanner that produces the generated document has no static type to build a
+        # response schema from and emits an EMPTY schema for those. Measured directly on aml-service:
+        # AmlCaseResponse does not appear anywhere in the generated document, even though it is real
+        # and correct. A generic response-schema gate over this fleet cannot distinguish "no schema
+        # published" from "the scanner could not see the type" — it would report the majority of
+        # correct endpoints as findings. The response half needs a per-endpoint contract test that
+        # asserts the DTO shape directly, the pattern `CopilotApiContractTest` and the fx/aml
+        # provider-verified pacts already use, not a generic diff.
+        #
+        # `required` is also deliberately not compared: SmallRye OpenAPI's scanner has no
+        # jackson-module-kotlin integration, so it does not read Kotlin nullability and marks nearly
+        # every constructor parameter required regardless of `?`. Measured on aml: `accountId: UUID?`
+        # comes back required. Comparing required-ness would be near-100% noise. Property NAME
+        # presence, by contrast, is unaffected by this and reliable in both directions.
+        #
+        # Found on the day this landed, not hypothetically: openbank-balance-service's
+        # `PlaceHoldRequest` publishes a phantom `expiresAt` and omits the real, USED
+        # `referenceId`/`ttlSeconds` — confirmed against `BalanceResource.placeHold`, which reads
+        # `body.referenceId` and `body.ttlSeconds` directly. A caller following the published spec
+        # cannot construct a valid request.
       db_backup_association:
         detect: ["openbank-infra/gitops/**/*.yaml (kind: Cluster, postgresql.cnpg.io)"]
         require:

--- a/openbank-infra/gitops/components/sanctions-service/sanctions-service.yaml
+++ b/openbank-infra/gitops/components/sanctions-service/sanctions-service.yaml
@@ -49,7 +49,7 @@ spec:
       annotations:
         # Rolls the pods when the OPA bundle changes — subPath mounts do NOT hot-reload.
         # Kept in sync by gen-sanctions-opa-bundle.sh (do not hand-edit).
-        openbank.tech/policy-checksum: "472cad6b54875e00"
+        openbank.tech/policy-checksum: "b4b0757045e2925e"
     spec:
       securityContext:
         runAsNonRoot: true

--- a/openbank-infra/gitops/components/sca/sca-opa-bundle.yaml
+++ b/openbank-infra/gitops/components/sca/sca-opa-bundle.yaml
@@ -9,7 +9,7 @@ metadata:
     app.kubernetes.io/name: sca-service
     app.kubernetes.io/part-of: sca
   annotations:
-    openbank.tech/policy-checksum: "ba9cbe1a555eedc0"
+    openbank.tech/policy-checksum: "ee6599ff3797aa1e"
 data:
   rest.rego: |
     # SPDX-License-Identifier: Apache-2.0
@@ -1602,6 +1602,44 @@ data:
         #
         # Advisory because 114 pre-existing findings cannot be a merge blocker on day one. Flipping
         # to enforced = add --enforce in ci.yml, once the backlog is cleared.
+      openapi_request_schema_conformance:
+        detect: ["openbank-*/src/main/resources/openapi.yaml", "the JAX-RS request-body DTO the resource actually deserializes into"]
+        require:
+          - "every property a request-body schema declares exists on the DTO the resource parses"
+          - "every property the DTO has is declared on the request-body schema"
+        gate: openapi-request-schema-conformance
+        enforced: advisory
+        target_enforce_date: "2026-09-30"
+        ci_producer: ".github/scripts/check-openapi-request-schema-conformance.py"
+        # openapi_route_conformance (above) is ROUTE SET ONLY — it does not read schemas, so aml's
+        # invented request/response fields passed it clean (#2312). This is the request half of that
+        # gap, using the document Quarkus itself generates
+        # (quarkus.smallrye-openapi.store-schema-directory) as ground truth instead of guessing.
+        # `:build` already runs `quarkusBuild` in its task graph (confirmed via --dry-run), so wiring
+        # this into `_service-ci.yml`'s existing build step costs no extra build time.
+        #
+        # NOT the response half, and that is a decision, not a gap left for later. 457 handler methods
+        # fleet-wide return a raw jakarta.ws.rs.core.Response, which erases the body type at the JVM
+        # level — the scanner that produces the generated document has no static type to build a
+        # response schema from and emits an EMPTY schema for those. Measured directly on aml-service:
+        # AmlCaseResponse does not appear anywhere in the generated document, even though it is real
+        # and correct. A generic response-schema gate over this fleet cannot distinguish "no schema
+        # published" from "the scanner could not see the type" — it would report the majority of
+        # correct endpoints as findings. The response half needs a per-endpoint contract test that
+        # asserts the DTO shape directly, the pattern `CopilotApiContractTest` and the fx/aml
+        # provider-verified pacts already use, not a generic diff.
+        #
+        # `required` is also deliberately not compared: SmallRye OpenAPI's scanner has no
+        # jackson-module-kotlin integration, so it does not read Kotlin nullability and marks nearly
+        # every constructor parameter required regardless of `?`. Measured on aml: `accountId: UUID?`
+        # comes back required. Comparing required-ness would be near-100% noise. Property NAME
+        # presence, by contrast, is unaffected by this and reliable in both directions.
+        #
+        # Found on the day this landed, not hypothetically: openbank-balance-service's
+        # `PlaceHoldRequest` publishes a phantom `expiresAt` and omits the real, USED
+        # `referenceId`/`ttlSeconds` — confirmed against `BalanceResource.placeHold`, which reads
+        # `body.referenceId` and `body.ttlSeconds` directly. A caller following the published spec
+        # cannot construct a valid request.
       db_backup_association:
         detect: ["openbank-infra/gitops/**/*.yaml (kind: Cluster, postgresql.cnpg.io)"]
         require:

--- a/openbank-infra/gitops/components/sca/sca-service.yaml
+++ b/openbank-infra/gitops/components/sca/sca-service.yaml
@@ -28,7 +28,7 @@ spec:
       annotations:
         # Rolls the pods when the OPA bundle changes — subPath mounts do NOT hot-reload.
         # Kept in sync by gen-sca-opa-bundle.sh (do not hand-edit).
-        openbank.tech/policy-checksum: "ba9cbe1a555eedc0"
+        openbank.tech/policy-checksum: "ee6599ff3797aa1e"
     spec:
       securityContext:
         runAsNonRoot: true

--- a/openbank-infra/gitops/components/statements/statement-opa-bundle.yaml
+++ b/openbank-infra/gitops/components/statements/statement-opa-bundle.yaml
@@ -9,7 +9,7 @@ metadata:
     app.kubernetes.io/name: statement-service
     app.kubernetes.io/part-of: statements
   annotations:
-    openbank.tech/policy-checksum: "8348ceb18163ab8e"
+    openbank.tech/policy-checksum: "20d83ffd9665d3f6"
 data:
   rest.rego: |
     # SPDX-License-Identifier: Apache-2.0
@@ -1632,6 +1632,44 @@ data:
         #
         # Advisory because 114 pre-existing findings cannot be a merge blocker on day one. Flipping
         # to enforced = add --enforce in ci.yml, once the backlog is cleared.
+      openapi_request_schema_conformance:
+        detect: ["openbank-*/src/main/resources/openapi.yaml", "the JAX-RS request-body DTO the resource actually deserializes into"]
+        require:
+          - "every property a request-body schema declares exists on the DTO the resource parses"
+          - "every property the DTO has is declared on the request-body schema"
+        gate: openapi-request-schema-conformance
+        enforced: advisory
+        target_enforce_date: "2026-09-30"
+        ci_producer: ".github/scripts/check-openapi-request-schema-conformance.py"
+        # openapi_route_conformance (above) is ROUTE SET ONLY — it does not read schemas, so aml's
+        # invented request/response fields passed it clean (#2312). This is the request half of that
+        # gap, using the document Quarkus itself generates
+        # (quarkus.smallrye-openapi.store-schema-directory) as ground truth instead of guessing.
+        # `:build` already runs `quarkusBuild` in its task graph (confirmed via --dry-run), so wiring
+        # this into `_service-ci.yml`'s existing build step costs no extra build time.
+        #
+        # NOT the response half, and that is a decision, not a gap left for later. 457 handler methods
+        # fleet-wide return a raw jakarta.ws.rs.core.Response, which erases the body type at the JVM
+        # level — the scanner that produces the generated document has no static type to build a
+        # response schema from and emits an EMPTY schema for those. Measured directly on aml-service:
+        # AmlCaseResponse does not appear anywhere in the generated document, even though it is real
+        # and correct. A generic response-schema gate over this fleet cannot distinguish "no schema
+        # published" from "the scanner could not see the type" — it would report the majority of
+        # correct endpoints as findings. The response half needs a per-endpoint contract test that
+        # asserts the DTO shape directly, the pattern `CopilotApiContractTest` and the fx/aml
+        # provider-verified pacts already use, not a generic diff.
+        #
+        # `required` is also deliberately not compared: SmallRye OpenAPI's scanner has no
+        # jackson-module-kotlin integration, so it does not read Kotlin nullability and marks nearly
+        # every constructor parameter required regardless of `?`. Measured on aml: `accountId: UUID?`
+        # comes back required. Comparing required-ness would be near-100% noise. Property NAME
+        # presence, by contrast, is unaffected by this and reliable in both directions.
+        #
+        # Found on the day this landed, not hypothetically: openbank-balance-service's
+        # `PlaceHoldRequest` publishes a phantom `expiresAt` and omits the real, USED
+        # `referenceId`/`ttlSeconds` — confirmed against `BalanceResource.placeHold`, which reads
+        # `body.referenceId` and `body.ttlSeconds` directly. A caller following the published spec
+        # cannot construct a valid request.
       db_backup_association:
         detect: ["openbank-infra/gitops/**/*.yaml (kind: Cluster, postgresql.cnpg.io)"]
         require:

--- a/openbank-infra/gitops/components/statements/statement-service.yaml
+++ b/openbank-infra/gitops/components/statements/statement-service.yaml
@@ -26,7 +26,7 @@ spec:
       annotations:
         # Rolls the pod when the OPA bundle changes — subPath mounts do NOT hot-reload.
         # Kept in sync by gen-statement-opa-bundle.sh (do not hand-edit).
-        openbank.tech/policy-checksum: "8348ceb18163ab8e"
+        openbank.tech/policy-checksum: "20d83ffd9665d3f6"
       labels:
         app.kubernetes.io/name: statement-service
         app.kubernetes.io/part-of: statements

--- a/openbank-infra/gitops/components/tpp-registry/tpp-registry-opa-bundle.yaml
+++ b/openbank-infra/gitops/components/tpp-registry/tpp-registry-opa-bundle.yaml
@@ -9,7 +9,7 @@ metadata:
     app.kubernetes.io/name: tpp-registry-service
     app.kubernetes.io/part-of: tpp-registry
   annotations:
-    openbank.tech/policy-checksum: "f712fa5c86371b08"
+    openbank.tech/policy-checksum: "d86f35f6821e1edb"
 data:
   rest.rego: |
     # SPDX-License-Identifier: Apache-2.0
@@ -1569,6 +1569,44 @@ data:
         #
         # Advisory because 114 pre-existing findings cannot be a merge blocker on day one. Flipping
         # to enforced = add --enforce in ci.yml, once the backlog is cleared.
+      openapi_request_schema_conformance:
+        detect: ["openbank-*/src/main/resources/openapi.yaml", "the JAX-RS request-body DTO the resource actually deserializes into"]
+        require:
+          - "every property a request-body schema declares exists on the DTO the resource parses"
+          - "every property the DTO has is declared on the request-body schema"
+        gate: openapi-request-schema-conformance
+        enforced: advisory
+        target_enforce_date: "2026-09-30"
+        ci_producer: ".github/scripts/check-openapi-request-schema-conformance.py"
+        # openapi_route_conformance (above) is ROUTE SET ONLY — it does not read schemas, so aml's
+        # invented request/response fields passed it clean (#2312). This is the request half of that
+        # gap, using the document Quarkus itself generates
+        # (quarkus.smallrye-openapi.store-schema-directory) as ground truth instead of guessing.
+        # `:build` already runs `quarkusBuild` in its task graph (confirmed via --dry-run), so wiring
+        # this into `_service-ci.yml`'s existing build step costs no extra build time.
+        #
+        # NOT the response half, and that is a decision, not a gap left for later. 457 handler methods
+        # fleet-wide return a raw jakarta.ws.rs.core.Response, which erases the body type at the JVM
+        # level — the scanner that produces the generated document has no static type to build a
+        # response schema from and emits an EMPTY schema for those. Measured directly on aml-service:
+        # AmlCaseResponse does not appear anywhere in the generated document, even though it is real
+        # and correct. A generic response-schema gate over this fleet cannot distinguish "no schema
+        # published" from "the scanner could not see the type" — it would report the majority of
+        # correct endpoints as findings. The response half needs a per-endpoint contract test that
+        # asserts the DTO shape directly, the pattern `CopilotApiContractTest` and the fx/aml
+        # provider-verified pacts already use, not a generic diff.
+        #
+        # `required` is also deliberately not compared: SmallRye OpenAPI's scanner has no
+        # jackson-module-kotlin integration, so it does not read Kotlin nullability and marks nearly
+        # every constructor parameter required regardless of `?`. Measured on aml: `accountId: UUID?`
+        # comes back required. Comparing required-ness would be near-100% noise. Property NAME
+        # presence, by contrast, is unaffected by this and reliable in both directions.
+        #
+        # Found on the day this landed, not hypothetically: openbank-balance-service's
+        # `PlaceHoldRequest` publishes a phantom `expiresAt` and omits the real, USED
+        # `referenceId`/`ttlSeconds` — confirmed against `BalanceResource.placeHold`, which reads
+        # `body.referenceId` and `body.ttlSeconds` directly. A caller following the published spec
+        # cannot construct a valid request.
       db_backup_association:
         detect: ["openbank-infra/gitops/**/*.yaml (kind: Cluster, postgresql.cnpg.io)"]
         require:

--- a/openbank-infra/gitops/components/tpp-registry/tpp-registry-service.yaml
+++ b/openbank-infra/gitops/components/tpp-registry/tpp-registry-service.yaml
@@ -23,7 +23,7 @@ spec:
       annotations:
         # Rolls the pod when the OPA bundle changes (subPath mounts do not hot-reload).
         # Kept in sync by gen-tpp-registry-opa-bundle.sh (do not hand-edit).
-        openbank.tech/policy-checksum: "f712fa5c86371b08"
+        openbank.tech/policy-checksum: "d86f35f6821e1edb"
     spec:
       securityContext:
         runAsNonRoot: true

--- a/openbank-libs/governance/rules.yaml
+++ b/openbank-libs/governance/rules.yaml
@@ -200,6 +200,44 @@ change_requirements:
     #
     # Advisory because 114 pre-existing findings cannot be a merge blocker on day one. Flipping
     # to enforced = add --enforce in ci.yml, once the backlog is cleared.
+  openapi_request_schema_conformance:
+    detect: ["openbank-*/src/main/resources/openapi.yaml", "the JAX-RS request-body DTO the resource actually deserializes into"]
+    require:
+      - "every property a request-body schema declares exists on the DTO the resource parses"
+      - "every property the DTO has is declared on the request-body schema"
+    gate: openapi-request-schema-conformance
+    enforced: advisory
+    target_enforce_date: "2026-09-30"
+    ci_producer: ".github/scripts/check-openapi-request-schema-conformance.py"
+    # openapi_route_conformance (above) is ROUTE SET ONLY — it does not read schemas, so aml's
+    # invented request/response fields passed it clean (#2312). This is the request half of that
+    # gap, using the document Quarkus itself generates
+    # (quarkus.smallrye-openapi.store-schema-directory) as ground truth instead of guessing.
+    # `:build` already runs `quarkusBuild` in its task graph (confirmed via --dry-run), so wiring
+    # this into `_service-ci.yml`'s existing build step costs no extra build time.
+    #
+    # NOT the response half, and that is a decision, not a gap left for later. 457 handler methods
+    # fleet-wide return a raw jakarta.ws.rs.core.Response, which erases the body type at the JVM
+    # level — the scanner that produces the generated document has no static type to build a
+    # response schema from and emits an EMPTY schema for those. Measured directly on aml-service:
+    # AmlCaseResponse does not appear anywhere in the generated document, even though it is real
+    # and correct. A generic response-schema gate over this fleet cannot distinguish "no schema
+    # published" from "the scanner could not see the type" — it would report the majority of
+    # correct endpoints as findings. The response half needs a per-endpoint contract test that
+    # asserts the DTO shape directly, the pattern `CopilotApiContractTest` and the fx/aml
+    # provider-verified pacts already use, not a generic diff.
+    #
+    # `required` is also deliberately not compared: SmallRye OpenAPI's scanner has no
+    # jackson-module-kotlin integration, so it does not read Kotlin nullability and marks nearly
+    # every constructor parameter required regardless of `?`. Measured on aml: `accountId: UUID?`
+    # comes back required. Comparing required-ness would be near-100% noise. Property NAME
+    # presence, by contrast, is unaffected by this and reliable in both directions.
+    #
+    # Found on the day this landed, not hypothetically: openbank-balance-service's
+    # `PlaceHoldRequest` publishes a phantom `expiresAt` and omits the real, USED
+    # `referenceId`/`ttlSeconds` — confirmed against `BalanceResource.placeHold`, which reads
+    # `body.referenceId` and `body.ttlSeconds` directly. A caller following the published spec
+    # cannot construct a valid request.
   db_backup_association:
     detect: ["openbank-infra/gitops/**/*.yaml (kind: Cluster, postgresql.cnpg.io)"]
     require:


### PR DESCRIPTION
## Summary

`check-openapi-route-conformance.py` (#2360) closed the route-set half of spec-vs-code. It never
looks inside a schema — an invented request field still passes clean, which is the entire aml-service
defect (#2312). This closes the request-body half, using the document Quarkus itself generates as
ground truth instead of guessing.

## Type of change

- [x] chore (build / tooling)

## Linked issues

Refs #2314, #2312, #2360

## Changes

- `.github/scripts/check-openapi-request-schema-conformance.py` — compares request-body schema
  PROPERTY NAME SETS between the committed `openapi.yaml` and the Quarkus-generated document.
- `.github/workflows/_service-ci.yml` — adds `-Dquarkus.smallrye-openapi.store-schema-directory=...`
  to the *existing* `:${service}:build` invocation (confirmed via `--dry-run` that `quarkusBuild` is
  already in that task's graph — zero extra build time), plus a new advisory step that reads it.
- `openbank-libs/governance/rules.yaml` — `openapi_request_schema_conformance`, advisory,
  `target_enforce_date: 2026-09-30`.

## Reviewer notes — scope is a decision, not an oversight

**Not the response half.** 457 handler methods fleet-wide return a raw `jakarta.ws.rs.core.Response`,
erasing the body type at the JVM level. The scanner has no static type to build a response schema
from and emits an empty one. Measured directly: `AmlCaseResponse` does not appear anywhere in
aml-service's generated document, despite being real and correct. A response-schema gate here could
not tell "no schema published" from "the scanner couldn't see the type" — it would flag most correct
endpoints. That needs a per-endpoint contract test asserting the DTO shape directly (the
`CopilotApiContractTest` / fx-aml pact pattern), not a generic diff.

**Not `required`.** SmallRye OpenAPI's scanner has no `jackson-module-kotlin` integration, so it
never reads Kotlin nullability and marks nearly every constructor parameter required regardless of
`?`. Measured on aml: `accountId: UUID?` comes back `required`. Property NAME presence is unaffected
by this and reliable both directions; required-ness is not comparable at all, so the gate does not
attempt it.

Both are recorded in `rules.yaml` with the measurement behind them, not left as unstated gaps.

## How this was falsified, and what it found

A synthetic fixture (one phantom published field, one undeclared real field) reports both directions
and nothing else; identical committed/generated specs report zero; `--enforce` exits 1 on the drift.

Then run against **six real generated schemas** — not just the synthetic case:

| service | result |
|---|---|
| aml | 0 findings (already corrected in #2373) |
| fx, ledger | 0 findings |
| balance | **3 findings** — see below |
| sepa-payment | **6 findings** — see below |
| transaction | 1 finding — real, minor (`bookingDate` undocumented) |

Each finding source-verified, not trusted from the tool alone:

- **`openbank-balance-service` `PlaceHoldRequest`** publishes a phantom `expiresAt` and omits
  `referenceId`/`ttlSeconds` — confirmed `BalanceResource.placeHold` reads `body.referenceId` and
  `body.ttlSeconds` directly. A caller following the published contract cannot build a request the
  handler accepts.
- **`openbank-sepa-payment` `CreateSepaPaymentRequest`** publishes `currencyCode` and
  `requestedExecutionDate` (neither exists on the DTO) and omits `type`, `debtorIban`, `debtorName`
  and the real `currency` field — on a money-path payment-creation endpoint.

Both left unfixed here on purpose, same sequencing as #2360: land the gate, then work the backlog.

## Definition of Done

- [x] `python3 -m unittest discover -s openbank-infra/scripts -p '*_test.py'` → 117 tests, OK
      (no new unit tests for this script itself — it has no logic beyond set operations already
      exercised by the fixture-based falsification above; the sibling suite is unaffected).
- [x] Full local gate sweep, 35 scripts: 0 unexpected failures (the one script requiring
      `--service`/`--generated` correctly errors when invoked bare — not a bug, `argparse
      required=True`).
- [x] Workflow YAML parses; `bash -n` on the extracted new `run:` block is clean.

## Security checklist

- [x] No secrets, tokens, passwords, or PII.
- [x] No new third-party dependency (PyYAML already used elsewhere in `.github/scripts`).
- [x] New `run:` step interpolates `${{ inputs.service }}` — an existing trust boundary already used
      identically one line above in the same step, not a new injection surface.

## Compliance impact

- [x] None directly — tooling. Indirect: found a real defect on a SEPA payment-creation endpoint.

## Rollout / Rollback

- Deployment strategy: CI-only change, no runtime impact.
- Rollback plan: revert the commit.
