### PR TITLE
fix(notification): remove SMS and IN_APP — both were logging stubs reporting success

### DIFF
--- a/docs/asyncapi/openbank-events.yaml
+++ b/docs/asyncapi/openbank-events.yaml
@@ -722,7 +722,7 @@ components:
           format: uuid
         channel:
           type: string
-          enum: [EMAIL, SMS, PUSH]
+          enum: [EMAIL, PUSH]
         templateId:
           type: string
           enum: [ACCOUNT_OPENED, PAYMENT_COMPLETED, KYC_REJECTED, OTP_CODE, WELCOME]

--- a/openbank-notification-service/src/main/kotlin/com/openbank/notification/application/NotificationConsumer.kt
+++ b/openbank-notification-service/src/main/kotlin/com/openbank/notification/application/NotificationConsumer.kt
@@ -163,15 +163,7 @@ class NotificationConsumer {
             .chain { _ ->
                 when (req.channel) {
                     NotificationChannel.EMAIL -> sendEmail(req, subject, body, entity)
-                    NotificationChannel.SMS -> {
-                        log.infof("SMS stub: to=%s template=%s", req.recipient, req.template)
-                        Uni.createFrom().voidItem()
-                    }
                     NotificationChannel.PUSH -> maybeSendPush(req, subject, entity)
-                    NotificationChannel.IN_APP -> {
-                        log.infof("IN_APP stub: to=%s template=%s", req.recipient, req.template)
-                        Uni.createFrom().voidItem()
-                    }
                 }
             }
             // Oversight side-channel (ADR-0059): for allow-listed risk templates, also

--- a/openbank-notification-service/src/main/kotlin/com/openbank/notification/application/OperatorMessageService.kt
+++ b/openbank-notification-service/src/main/kotlin/com/openbank/notification/application/OperatorMessageService.kt
@@ -36,9 +36,10 @@ class OperatorMessageRejected(message: String) : RuntimeException(message)
  * EMAIL only, for now. PUSH is refused: `sendPush` puts rendered content in the APNs/FCM payload,
  * which ADR-0135 §3 forbids (issue #1182, unresolved, blocked on the customer app's fetch-on-tap
  * handling in another repository) — adding a second producer onto that broken path would make it
- * worse, not better. IN_APP is refused because it is a stub that never leaves `PENDING` (no real
- * delivery exists yet). SMS was never implemented for any template. Real multi-channel delivery is
- * the remaining ADR-0176 D2/D3 work.
+ * worse, not better. SMS and IN_APP are not options at all — issue #2372 removed them from
+ * [com.openbank.notification.domain.model.NotificationChannel] because neither ever delivered
+ * anything (both were logging stubs that reported success). Real multi-channel delivery is the
+ * remaining ADR-0176 D2/D3 work.
  *
  * **`partyId` is trusted, unvalidated, caller-supplied input (issue #1384, explicit decision, not
  * an oversight).** Every other write into `notifications.party_id` originates from an

--- a/openbank-notification-service/src/main/kotlin/com/openbank/notification/domain/model/Notification.kt
+++ b/openbank-notification-service/src/main/kotlin/com/openbank/notification/domain/model/Notification.kt
@@ -9,9 +9,9 @@ import java.util.UUID
 
 // SMS and IN_APP were declared but never implemented — the dispatch `when` in NotificationConsumer
 // only logged and returned success for either, so a caller requesting them got silent non-delivery
-// with no error (issue #2372). Removed rather than fixed to match ADR-0200 D7's blocking-dependency
-// stance: IN_APP needs a terminal status transition + wake signal design, SMS needs a real provider
-// port — both are real builds, not something this narrowing should speculatively half-do.
+// with no error (issue #2372). Removed rather than fixed: IN_APP needs a terminal status transition
+// and a wake-signal design, SMS needs a real provider port — both are real builds, not something
+// this narrowing should speculatively half-do.
 enum class NotificationChannel { EMAIL, PUSH }
 enum class NotificationStatus { PENDING, SENT, FAILED, BOUNCED }
 

--- a/openbank-notification-service/src/main/kotlin/com/openbank/notification/domain/model/Notification.kt
+++ b/openbank-notification-service/src/main/kotlin/com/openbank/notification/domain/model/Notification.kt
@@ -7,7 +7,12 @@ package com.openbank.notification.domain.model
 import java.time.Instant
 import java.util.UUID
 
-enum class NotificationChannel { EMAIL, SMS, PUSH, IN_APP }
+// SMS and IN_APP were declared but never implemented — the dispatch `when` in NotificationConsumer
+// only logged and returned success for either, so a caller requesting them got silent non-delivery
+// with no error (issue #2372). Removed rather than fixed to match ADR-0200 D7's blocking-dependency
+// stance: IN_APP needs a terminal status transition + wake signal design, SMS needs a real provider
+// port — both are real builds, not something this narrowing should speculatively half-do.
+enum class NotificationChannel { EMAIL, PUSH }
 enum class NotificationStatus { PENDING, SENT, FAILED, BOUNCED }
 
 /**

--- a/openbank-notification-service/src/main/resources/openapi.yaml
+++ b/openbank-notification-service/src/main/resources/openapi.yaml
@@ -3,7 +3,7 @@
 openapi: 3.1.0
 info:
   title: Notification Service API
-  version: 1.7.0
+  version: 1.8.0
   description: Notification delivery management — query sent/pending notifications, manage push device tokens.
   license:
     name: Apache-2.0
@@ -527,7 +527,7 @@ components:
 
     NotificationChannel:
       type: string
-      enum: [EMAIL, SMS, PUSH, IN_APP]
+      enum: [EMAIL, PUSH]
 
     NotificationStatus:
       type: string

--- a/openbank-notification-service/src/test/kotlin/com/openbank/notification/domain/model/NotificationModelTest.kt
+++ b/openbank-notification-service/src/test/kotlin/com/openbank/notification/domain/model/NotificationModelTest.kt
@@ -15,9 +15,7 @@ class NotificationModelTest {
     fun `NotificationChannel has all expected values`() {
         assertThat(NotificationChannel.values()).containsExactlyInAnyOrder(
             NotificationChannel.EMAIL,
-            NotificationChannel.SMS,
             NotificationChannel.PUSH,
-            NotificationChannel.IN_APP,
         )
     }
 
@@ -71,12 +69,12 @@ class NotificationModelTest {
     fun `NotificationRequest data class construction`() {
         val req = NotificationRequest(
             partyId = UUID.randomUUID(),
-            channel = NotificationChannel.SMS,
+            channel = NotificationChannel.PUSH,
             template = NotificationTemplate.OTP_CODE,
             recipient = "+420123456789",
             variables = mapOf("code" to "123456"),
         )
-        assertThat(req.channel).isEqualTo(NotificationChannel.SMS)
+        assertThat(req.channel).isEqualTo(NotificationChannel.PUSH)
         assertThat(req.variables).containsEntry("code", "123456")
     }
 }


### PR DESCRIPTION
## Summary

Removes `SMS` and `IN_APP` from `NotificationChannel` (#2372). Both were declared but never
implemented — the dispatch `when` in `NotificationConsumer` logged a "stub" line and returned a
successful `Uni` for either, so any caller requesting them got silent non-delivery with no error and
no metric. Fleet-wide, nothing requests either channel today, which kept the gap latent.

## Type of change

- [x] fix (bug fix)
- [x] breaking change (API-contract, additive per oasdiff — see below; not source-breaking for any
      existing caller since none requests these values)

## Linked issues

Refs #2372

## Changes

- `NotificationChannel`: `EMAIL, SMS, PUSH, IN_APP` → `EMAIL, PUSH`.
- `NotificationConsumer.dispatch`: the two stub `when` branches removed along with their log lines.
- `openbank-notification-service/src/main/resources/openapi.yaml`: `NotificationChannel` enum
  narrowed to match; `info.version` bumped `1.7.0` → `1.8.0`.
- `docs/asyncapi/openbank-events.yaml`: its channel enum already omitted `IN_APP` (a pre-existing
  drift from the Kotlin enum, left uncorrected until now since fixing it alone wasn't in scope);
  narrowed to `[EMAIL, PUSH]` to match.
- `OperatorMessageService` KDoc: updated from "SMS/IN_APP are refused" to "SMS/IN_APP are not options
  at all" — the refusal was prose-only; the code already hardcodes `"EMAIL"` and never branched on
  the enum.
- `NotificationModelTest`: the exhaustive-enum-values test narrowed; the one test using `SMS` purely
  as a generic non-EMAIL channel fixture switched to `PUSH`.

## Definition of Done

- [x] Hexagonal layering preserved — no domain framework imports added.
- [x] Unit tests updated — `NotificationModelTest` (5/5 pass).
- [x] Integration tests — `NotificationConsumerIT` (7/7 pass, exercises `dispatch` against real
      Kafka/DB dev-services) and `OperatorMessageServiceIT` (6/6 pass) both green, confirming the
      narrowed `when` compiles and dispatches correctly for the surviving channels.
- [x] Contract tests — n/a to Pact (no consumer contract references `SMS`/`IN_APP`), but the OpenAPI
      contract itself changed — see API-contract section.
- [x] `./gradlew :openbank-notification-service:detekt :openbank-notification-service:ktlintCheck`
      passes.
- [x] No new lint warnings.
- [x] OpenAPI spec regenerated/updated + version bumped (see below) — this **is** the API change.
- [x] Docs updated (OperatorMessageService KDoc, asyncapi spec).

### API contract (ADR-0048)

Ran `oasdiff` (pinned v1.22.0) against `origin/main`'s spec locally, since this repo's own gate
(`.github/scripts/check-api-contract.py`) classifies from the diff rather than a declared marker:

```
$ oasdiff breaking <base> <head>
No breaking changes to report, but the specs are different.

$ python3 .github/scripts/check-api-contract.py --base origin/main --oasdiff oasdiff
api-contract gate: openbank-notification-service: additive change, info.version 1.7.0 -> 1.8.0 — OK (required >= MINOR).
```

`channel` appears only in three response schemas (`GET /api/v1/notifications`,
`GET /api/v1/notifications/{id}`, `GET /api/v1/notifications/{id}/self}`) — never a request body — so
this is an enum-value narrowing on output, which `oasdiff` reports as six `info`-level
`response-property-enum-value-removed` changes, zero `error`-level. Per the gate's own classification
table that is `additive`, requiring a MINOR bump, which is what's applied. Major stays `1`, so the
ADR-0048 D2 URL-major invariant is unaffected.

## Security checklist

- [x] No secrets, tokens, passwords, or PII.
- [x] No new third-party dependency (oasdiff was used locally only, to classify the bump — not added
      to the build).
- [x] No new `@Suppress`.

## Compliance impact

- [ ] PCI DSS · [ ] DORA · [ ] GDPR · [ ] PSD2 / SCA / RTS · [ ] AML / 5AMLD · [ ] CNB reporting · [x] None

## Rollout / Rollback

- Deployment strategy: rolling, same as any other `notification-service` release.
- Rollback plan: revert the commit (and the `info.version` bump reverts with it — no separate action
  needed since both land in one PR).
- Data migration reversible: N/A — no schema change. Existing `notifications.channel` rows with value
  `SMS`/`IN_APP` (if any exist from historical stub sends) are untouched; they were never a delivery
  guarantee to begin with, and no code path reads the column expecting only the narrowed set (it's
  stored as a plain string, not a DB enum constraint) — confirmed no `CHECK` constraint exists on that
  column via the migration history.

## Reviewer notes

Scoped to exactly what #2372 asked for as "step 1" — subtraction only. `IN_APP` becoming real delivery
(rows already persist before dispatch and the inbox read path doesn't filter on status, so it's closer
to working than the removed stub suggested — it needs a terminal status transition and a wake-signal
design) and `SMS` needing an actual provider port are separate, larger pieces of work #2372 tracks;
this PR deliberately does not attempt either.
