### PR TITLE
docs(governance): fix two gate scripts citing rules.yaml keys that do not exist (#2392)

### DIFF
--- a/.github/scripts/check-authz-pdp-parity.py
+++ b/.github/scripts/check-authz-pdp-parity.py
@@ -1,5 +1,5 @@
 #!/usr/bin/env python3
-"""authz-enforce ⇒ OPA PDP sidecar parity guard (issue #1797, rules.yaml: authz_pdp_parity).
+"""authz-enforce ⇒ OPA PDP sidecar parity guard (issue #1797).
 
 WHY THIS EXISTS: eight live services enforced `@Authorize` (`authz.enforce` defaults true) while
 their gitops manifest declared no `opa` sidecar. AuthorizeInterceptor fails closed when the PDP at
@@ -25,9 +25,15 @@ declares the sidecar but the running pod lacks it (manifest-vs-live drift) — a
 see that. Live-drift is a separate detector's job; this guard's contract is "the declared manifest
 is self-consistent".
 
-ADVISORY (ADR-0144 gate-graduation): findings are ::warning:: annotations; exits 0 unless invoked
-with --enforce. The fleet currently carries several known violations (the reason this exists), so it
-graduates to enforce only once they are cleared — see rules.yaml: authz_pdp_parity.target_enforce_date.
+ADVISORY: findings are ::warning:: annotations; exits 0 unless invoked with --enforce. It graduates
+to enforce once the fleet carries no violations — 2 remain on main (finrep-service,
+onboarding-service), so `--enforce` exits 1 today.
+
+There is NO rule for this gate in rules.yaml, and there never has been. Earlier text here cited an
+`authz_pdp_parity.target_enforce_date` key as the graduation deadline; that key does not exist, so
+this gate is invisible to check-gate-graduation.sh (ADR-0144) and had no deadline at all —
+it only read as though it did. Do not re-add the citation without adding the rule: the governance
+half is tracked in #2392, which covers the whole class of CI gates with no rules.yaml entry.
 
 stdlib + PyYAML (already installed for check-governance-lineage.py / check-slo-registry.py).
 Usage: check-authz-pdp-parity.py [--root .] [--enforce]

--- a/openbank-infra/scripts/check-db-migration.py
+++ b/openbank-infra/scripts/check-db-migration.py
@@ -1,5 +1,5 @@
 #!/usr/bin/env python3
-"""db-migration gate (rules.yaml: change_classes.db_change, ADR-0144 graduation).
+"""db-migration gate (rules.yaml: change_requirements.db_change, ADR-0144 graduation).
 
 Discharges the two things `db_change.require` asks of a PR that touches a Flyway migration:
 


### PR DESCRIPTION
## What

Two gate scripts cite `rules.yaml` keys that do not exist. Comment-only change; no gate logic touched.

### 1. `check-authz-pdp-parity.py` — `authz_pdp_parity`

Cited twice: in the module docstring, and as the stated graduation deadline (*"see rules.yaml: authz_pdp_parity.target_enforce_date"*). No such key exists — `grep -n pdp openbank-libs/governance/rules.yaml` returns nothing, and it never has.

The effect is worse than a broken reference. The gate reads as governed by an ADR-0144 deadline, while `check-gate-graduation.sh` — which walks `rules.yaml` and nothing else — cannot see it at all. **A citation to a nonexistent deadline is indistinguishable from having one**, which is exactly how a gate stays advisory forever.

The docstring now says plainly that no rule exists, why that matters, and points at #2392 (the governance half: the whole class of CI gates with no `rules.yaml` entry).

Deliberately **not** fixed by adding the rule instead: that restamps every service's OPA bundle (37 of 38 generators embed `rules.yaml`) and needs a real enforce date, so it belongs in #2392's PR, not a comment fix.

### 2. `check-db-migration.py` — `change_classes.db_change`

Found while checking the first one. The rule exists, but the parent key is `change_requirements`, not `change_classes`. Corrected.

## Measured while here

The parity gate is not merely waiting on a deadline. On main:

```
check-authz-pdp-parity: 37 workload(s) checked; 2 enforce-without-PDP violation(s).
```

`finrep-service` and `onboarding-service` enforce authz by app-default with no `opa` sidecar in their workload. The docstring now names those two blockers instead of the vague "several known violations" it claimed before.

**What that does and does not mean.** My first draft of this PR said every `@Authorize` endpoint on them fails closed. That overstated it, and checking rather than assuming is the whole point: `grep -rn Authorize` over both services returns **nothing** — neither contains a single `@Authorize` annotation today, so nothing is failing closed right now. The violation is a **latent trap** (the first `@Authorize` added to either service bricks that endpoint), not a live outage. Corrected in the commit message and the docstring.

The adjacent question — both services expose real REST resources (`FinrepResource`, `CorepResource`, `OnboardingResource`) with no authorization annotation at all — is a separate finding and needs its own issue, not a comment PR. Note also that #1797, which tracked the enforce-without-PDP class across eight services, is **CLOSED** while these two still trip the gate.

## Verification

- Both scripts parse (`ast.parse`) and run.
- The parity gate reports the identical `37 workload(s) checked; 2 violation(s)` before and after — comment-only, as claimed.
- A scan of every `rules.yaml: <key>` citation across `.github/scripts` + `openbank-infra/scripts` now resolves to a real key. That scan is what surfaced finding #2, and what caught my own first draft: the explanatory text I added initially used the `rules.yaml: <key>` form and so flagged itself. Reworded — a future automated version of this check would otherwise trip on the very comment explaining the problem.

## Linked issues

Refs #2392
