### PR TITLE
fix(finrep): realm-issued role names + declare AUTHZ_ENFORCE on finrep/onboarding (#2394)

### DIFF
--- a/openbank-finrep-service/src/main/kotlin/com/openbank/finrep/infrastructure/rest/CorepResource.kt
+++ b/openbank-finrep-service/src/main/kotlin/com/openbank/finrep/infrastructure/rest/CorepResource.kt
@@ -7,6 +7,7 @@ package com.openbank.finrep.infrastructure.rest
 import com.openbank.finrep.application.port.inbound.CorepUseCase
 import com.openbank.finrep.application.port.inbound.GetCorepTemplateQuery
 import com.openbank.finrep.domain.model.CorepTemplate
+import com.openbank.libs.security.Roles
 import jakarta.annotation.security.RolesAllowed
 import jakarta.enterprise.context.ApplicationScoped
 import jakarta.ws.rs.DefaultValue
@@ -28,11 +29,16 @@ import java.time.LocalDate
  * reported as explicit, flagged zeros ([CorepCell.isDataGap]) because the ledger's chart of
  * accounts has no capital-structure GL accounts today; see [com.openbank.finrep.domain.mapper.C0100Mapper]
  * for the detailed rationale.
+ *
+ * Roles come from [Roles], never string literals — see the note on
+ * [com.openbank.finrep.infrastructure.rest.FinrepResource]: the shipped
+ * `@RolesAllowed("SERVICE", "ADMIN", "OPERATOR")` named three roles the realm does not issue, so
+ * this resource answered 403 to every caller.
  */
 @ApplicationScoped
 @Path("/api/v1/corep")
 @Produces(MediaType.APPLICATION_JSON)
-@RolesAllowed("SERVICE", "ADMIN", "OPERATOR")
+@RolesAllowed(Roles.ADMIN, Roles.OPERATOR)
 class CorepResource(private val corepUseCase: CorepUseCase, private val clock: Clock) {
 
     @GET

--- a/openbank-finrep-service/src/main/kotlin/com/openbank/finrep/infrastructure/rest/FinrepResource.kt
+++ b/openbank-finrep-service/src/main/kotlin/com/openbank/finrep/infrastructure/rest/FinrepResource.kt
@@ -7,6 +7,7 @@ package com.openbank.finrep.infrastructure.rest
 import com.openbank.finrep.application.port.inbound.FinrepUseCase
 import com.openbank.finrep.application.port.inbound.GetFinrepTemplateQuery
 import com.openbank.finrep.domain.model.FinrepTemplate
+import com.openbank.libs.security.Roles
 import jakarta.annotation.security.RolesAllowed
 import jakarta.enterprise.context.ApplicationScoped
 import jakarta.ws.rs.DefaultValue
@@ -23,11 +24,19 @@ import java.time.LocalDate
 /**
  * FINREP template REST resource (ADR-0097 Phase 1).
  * Derives F01.01 (Balance Sheet) and F02.00 (P&L) from the ledger trial balance.
+ *
+ * Roles come from [Roles], never string literals: this class shipped with
+ * `@RolesAllowed("SERVICE", "ADMIN", "OPERATOR")` and the Keycloak realm issues no role by any of
+ * those three names (it issues `ROLE_ADMIN`, `ROLE_OPERATOR`, …), so every authenticated request
+ * to this resource was rejected 403 for every caller. `ROLE_SERVICE` is deliberately NOT in the
+ * replacement set: it exists as a [Roles] constant but is granted to no realm client, so listing
+ * it would re-add a dead entry that reads like an M2M grant. The only caller is the admin-UI BFF
+ * (see the finrep-service ingress allow-list), whose operators carry ROLE_ADMIN / ROLE_OPERATOR.
  */
 @ApplicationScoped
 @Path("/api/v1/finrep")
 @Produces(MediaType.APPLICATION_JSON)
-@RolesAllowed("SERVICE", "ADMIN", "OPERATOR")
+@RolesAllowed(Roles.ADMIN, Roles.OPERATOR)
 class FinrepResource(private val finrepUseCase: FinrepUseCase, private val clock: Clock) {
 
     @GET

--- a/openbank-finrep-service/src/test/kotlin/com/openbank/finrep/contract/TemplateWireFormatTest.kt
+++ b/openbank-finrep-service/src/test/kotlin/com/openbank/finrep/contract/TemplateWireFormatTest.kt
@@ -7,6 +7,7 @@ package com.openbank.finrep.contract
 import com.fasterxml.jackson.databind.ObjectMapper
 import com.openbank.finrep.application.port.out.TrialBalanceLineDto
 import com.openbank.finrep.infrastructure.client.LedgerAdapter
+import com.openbank.libs.security.Roles
 import io.mockk.coEvery
 import io.mockk.mockk
 import io.quarkus.test.junit.QuarkusMock
@@ -49,7 +50,13 @@ import java.time.LocalDate
  * `is not assignable to class ...LedgerAdapter`.
  */
 @QuarkusTest
-@TestSecurity(user = "finrep-spec-conformance", roles = ["SERVICE"])
+// The role MUST be one the Keycloak realm actually issues (Roles.OPERATOR == "ROLE_OPERATOR").
+// This test previously declared roles = ["SERVICE"], which matched the resource's own
+// `@RolesAllowed("SERVICE", …)` literal and nothing else in the system: @TestSecurity mints
+// whatever role string it is given, so the test minted the exact role the realm never issues and
+// went green against a resource that answered 403 to every real caller. Asserting through a
+// realm-issued role is what makes this test capable of failing.
+@TestSecurity(user = "finrep-spec-conformance", roles = [Roles.OPERATOR])
 class TemplateWireFormatTest {
 
     private val mapper = ObjectMapper()

--- a/openbank-infra/gitops/components/finrep/finrep-service.yaml
+++ b/openbank-infra/gitops/components/finrep/finrep-service.yaml
@@ -43,6 +43,16 @@ spec:
           env:
             - name: QUARKUS_OIDC_AUTH_SERVER_URL
               value: http://keycloak.iam.svc:8080/realms/openbank
+            # Declared explicitly rather than left to the libs default (`true`), issue #2394.
+            # finrep-service contains no @Authorize annotation, so there is no OPA decision to
+            # make and no `opa` sidecar in this pod. With the default, AuthorizeInterceptor would
+            # be armed to fail closed against a PDP that does not exist — harmless while the
+            # annotation count is zero, and an instant 503/422 on whichever endpoint gets the
+            # first one. Authorization today is JWT roles (@RolesAllowed on FinrepResource /
+            # CorepResource). Flip this to true in the SAME change that adds @Authorize + the
+            # rego rules + the sidecar (ADR-0034 Phase 5), never before.
+            - name: AUTHZ_ENFORCE
+              value: "false"
             - name: LEDGER_SERVICE_URL
               value: http://ledger-service.ledger.svc:8101
           resources:

--- a/openbank-infra/gitops/components/onboarding/onboarding-service.yaml
+++ b/openbank-infra/gitops/components/onboarding/onboarding-service.yaml
@@ -63,6 +63,16 @@ spec:
             - name: management
               containerPort: 8085
           env:
+            # Declared explicitly rather than left to the libs default (`true`), issue #2394.
+            # onboarding-service contains no @Authorize annotation, so there is no OPA decision to
+            # make and no `opa` sidecar in this pod. With the default, AuthorizeInterceptor would
+            # be armed to fail closed against a PDP that does not exist — harmless while the
+            # annotation count is zero, and an instant 503/422 on whichever endpoint gets the
+            # first one. Authorization today is JWT roles (@RolesAllowed on OnboardingResource).
+            # Flip this to true in the SAME change that adds @Authorize + the rego rules + the
+            # sidecar (ADR-0034 Phase 5), never before.
+            - name: AUTHZ_ENFORCE
+              value: "false"
             - name: QUARKUS_DATASOURCE_JDBC_URL
               value: jdbc:postgresql://onboarding-db-rw.onboarding.svc:5432/openbank_onboarding
             - name: QUARKUS_DATASOURCE_REACTIVE_URL


### PR DESCRIPTION
## What

Closes the finrep/onboarding authz gap from #2394. Two commits, because they are two different defects that happened to be found together.

### 1. `fix(finrep)` — FINREP/COREP answered 403 to every caller

Both resources shipped with:

```kotlin
@RolesAllowed("SERVICE", "ADMIN", "OPERATOR")
```

The realm (`gitops/components/keycloak/realm-template.json`) issues no role by any of those names. Its roles are `ROLE_ADMIN`, `ROLE_OPERATOR`, `ROLE_VIEWER`, `ROLE_AUDITOR`, `ROLE_COMPLIANCE`, `ROLE_SUPERVISOR`, `ROLE_KYC*`, `ROLE_PAYMENTS`, `ROLE_API`. So `/api/v1/finrep` and `/api/v1/corep` rejected every authenticated request, from every caller, for as long as they have existed. Now `@RolesAllowed(Roles.ADMIN, Roles.OPERATOR)` — the constants that carry the realm's actual names. The only caller is the admin-UI BFF (per the ingress allow-list), whose operators hold exactly those two.

`ROLE_SERVICE` is deliberately **not** in the replacement set. It exists as a `Roles` constant but appears in no realm template and is granted to no client, so re-adding it would restore a dead entry that reads like an M2M grant — the same shape as the unreachable `principal.type == "SERVICE"` rego rules that `check-no-service-principal-type.sh` exists to forbid. Nothing regresses: it never authorized anyone.

**Why nobody noticed.** The one test that exercises these endpoints declared `@TestSecurity(roles = ["SERVICE"])`. `@TestSecurity` mints whatever role string it is handed, so the test minted the exact role the realm never issues, matched the resource's own broken literal, and went green against endpoints that 403'd in production. A test that supplies both sides of the comparison cannot fail — same shape as the symmetric-pact problem already written up in `CLAUDE.md`. It now asserts through `Roles.OPERATOR`.

### 2. `chore(gitops)` — enforce-without-PDP declared away, not papered over

`check-authz-pdp-parity.py` reported these two workloads as the fleet's only violations: no `AUTHZ_ENFORCE` declared (so the libs default `true` applies) and no `opa` sidecar in the pod. Both now declare `AUTHZ_ENFORCE=false` with the reasoning inline.

This is safe *because* neither service has a single `@Authorize` annotation — there is no interception to fail closed. It was a trap armed for whoever adds the first one, invisible until someone calls that endpoint, which is precisely how #1797 hid on eight services until ADR-0179 added a caller to `party.merge`.

## Chosen approach

Asked before building, since the three options differ by ~2 files vs ~44:

- **Taken:** role fix + explicit `AUTHZ_ENFORCE=false`. Real bug fixed, trap disarmed, gate green, no OPA bundle restamp, no invented policy.
- Not taken: deploying `opa` sidecars. With zero `@Authorize` annotations they would answer no queries — cost for a greener signal and no more actual authorization.
- Not taken: full ADR-0034 Phase 5 wiring (`@Authorize` + rego + sidecars). That needs a policy decision per endpoint and touches ~44 generated bundle files. The inline comments say to flip the flag in that same change, never before.

## Verification

- `:openbank-finrep-service:ktlintCheck :detekt :test` — green on JDK 25, 11 test classes.
- **Falsified first**: with the annotations reverted to the string literals and the test left as fixed, `:openbank-finrep-service:test` **fails** (exit 1). Restored → passes. The test can actually detect this bug now.
- `check-authz-pdp-parity.py .` → `37 workload(s) checked; 0 enforce-without-PDP violation(s)` (was 2). `--enforce` exits 0.
- `gen-network-policies.py` produces no diff; `yamllint` under the CI job's own config reports 0 errors on both manifests.

## Correction to #2394

That issue said these services had "no authorization at all". Wrong, and worth stating plainly: both carry `@RolesAllowed`. Onboarding's were correct all along (`Roles.*`); finrep's named roles that do not exist. The issue is updated.

## Not in scope — a fleet-wide class

Three separate role vocabularies exist in this tree, and only one matches the realm:

| service | literals used | in realm? |
|---|---|---|
| finrep (fixed here) | `SERVICE`, `ADMIN`, `OPERATOR` | no |
| pid-service (`PartyResource`, 13 sites) | `openbank-employee`, `openbank-admin`, `openbank-customer`, `openbank-service` | no |
| devops-agent + 6 other agent services | `platform-admin`, `platform-viewer` | no |

Nothing checks a `@RolesAllowed` literal against the realm template, so each of these is invisible until a real token hits the endpoint. Filed separately rather than swept into this PR.

## Linked issues

Refs #2394
