### PR TITLE
fix(tpp-registry): map the domain id to a real UUID column, not the BIGSERIAL primary key

### DIFF
--- a/openbank-psd2-service/src/test/kotlin/com/openbank/psd2/contract/TppRegistryCheckPactConsumerTest.kt
+++ b/openbank-psd2-service/src/test/kotlin/com/openbank/psd2/contract/TppRegistryCheckPactConsumerTest.kt
@@ -43,14 +43,13 @@ import org.junit.jupiter.api.extension.ExtendWith
  * shipped a call to a ledger path that had never existed while its unit tests passed against a
  * mocked port. No seeded data is needed; nothing registers the id this interaction uses.
  *
- * WITHHELD, deliberately: the **allow** branch (HTTP 200, `authorized: true`, `roles: ["AISP"]`).
- * It is written and it FAILS against a real tpp-registry — `TppRepositoryImpl.toDomain()` maps the
+ * Also pinned: the **allow** branch (HTTP 200, `authorized: true`, `roles: ["AISP"]`), against the
+ * `CZ-CNB-TEST-AISP` fixture `V1__init.sql` already seeds ACTIVE/AISP with no QWAC expiry. This
+ * interaction was WITHHELD until #2340 landed: `TppRepositoryImpl.toDomain()` used to map the
  * entity's `BIGSERIAL` id through `UUID.fromString(id.toString())`, so reading any registered row
- * throws and the endpoint answers 400 `"Invalid UUID string: 2"` (issue #2340). The provider replay
- * is what found it; this consumer test was green throughout, which is the asymmetry CLAUDE.md
- * records. Committing that interaction would leave a permanently red provider gate, so it lands with
- * the fix. Note what this means for the contract as it stands: the refusal branch is verified, the
- * allow branch is currently unreachable in production.
+ * threw and the endpoint answered 400 `"Invalid UUID string: 2"`. The provider replay is what found
+ * it; this consumer test was green throughout, which is the asymmetry CLAUDE.md records — a
+ * committed pact nobody replays is worthless against the request-path/read-path class of defect.
  *
  * **The expected path is a LITERAL; only the outgoing requests are reflected off the client's
  * `@Path`** (CLAUDE.md "Contract tests", measured on #2290). Deriving both sides is vacuous —
@@ -103,6 +102,40 @@ class TppRegistryCheckPactConsumerTest {
         assertThat(response.reason).isNotBlank()
     }
 
+    @Pact(consumer = CONSUMER, provider = PROVIDER)
+    fun registeredAispAllowedPact(builder: PactDslWithProvider): RequestResponsePact = builder
+        .given("the TPP registry has an ACTIVE AISP with an unexpired QWAC")
+        .uponReceiving("GET check a registered, active AISP — the allow branch")
+        .path(EXPECTED_CHECK_PATH)
+        .query("tppId=$REGISTERED_AISP_ID&role=$AISP_ROLE")
+        .method("GET")
+        .headers(mapOf("Accept" to "application/json"))
+        .willRespondWith()
+        .status(200)
+        .headers(mapOf("Content-Type" to "application/json"))
+        .body(
+            newJsonBody { o ->
+                o.stringValue("tppId", REGISTERED_AISP_ID)
+                o.booleanValue("authorized", true)
+                o.array("roles") { a -> a.stringValue("AISP") }
+                o.nullValue("reason")
+            }.build(),
+        )
+        .toPact()
+
+    @Test
+    @PactTestFor(pactMethod = "registeredAispAllowedPact")
+    fun `a registered active AISP with a valid QWAC is authorized`(mockServer: MockServer) {
+        assertClientPathMatchesContract()
+
+        val raw = check(mockServer, REGISTERED_AISP_ID, 200)
+
+        val response = mapper.readValue<TppAuthorizationResponse>(raw)
+        assertThat(response.authorized).isTrue()
+        assertThat(response.roles).containsExactly("AISP")
+        assertThat(response.reason).isNull()
+    }
+
     private fun check(mockServer: MockServer, tppId: String, expectedStatus: Int): String = given()
         .baseUri(mockServer.getUrl())
         .accept("application/json")
@@ -134,6 +167,9 @@ class TppRegistryCheckPactConsumerTest {
 
         /** Never registered — a fresh Testcontainer DB satisfies the refusal state by construction. */
         const val UNKNOWN_TPP_ID = "CZ-CNB-PACT-UNREGISTERED"
+
+        /** Seeded ACTIVE/AISP with no QWAC expiry by V1__init.sql — satisfied by boot-time data. */
+        const val REGISTERED_AISP_ID = "CZ-CNB-TEST-AISP"
 
         /** `TppRole.AISP`, sent as the exact enum name the provider's `valueOf` accepts. */
         const val AISP_ROLE = "AISP"

--- a/openbank-tpp-registry-service/src/main/kotlin/com/openbank/tppregistry/infrastructure/persistence/entity/TppEntryEntity.kt
+++ b/openbank-tpp-registry-service/src/main/kotlin/com/openbank/tppregistry/infrastructure/persistence/entity/TppEntryEntity.kt
@@ -13,6 +13,13 @@ import java.util.UUID
 @Entity
 @Table(name = "tpp_entries")
 class TppEntryEntity : PanacheEntity() {
+    // The domain's TppEntry.id is a UUID; this table's real primary key (inherited `id: Long`
+    // from PanacheEntity, BIGSERIAL) is internal only — never exposed via REST or referenced by
+    // another service. entryUuid is what the domain id actually maps to; DB-generated default,
+    // see V6__tpp_entries_entry_uuid.sql (issue #2340).
+    @Column(name = "entry_uuid", nullable = false)
+    lateinit var entryUuid: UUID
+
     @Column(name = "tpp_id", unique = true, nullable = false)
     lateinit var tppId: String
 

--- a/openbank-tpp-registry-service/src/main/kotlin/com/openbank/tppregistry/infrastructure/persistence/repository/TppRepositoryImpl.kt
+++ b/openbank-tpp-registry-service/src/main/kotlin/com/openbank/tppregistry/infrastructure/persistence/repository/TppRepositoryImpl.kt
@@ -12,8 +12,6 @@ import io.quarkus.hibernate.reactive.panache.Panache
 import io.quarkus.hibernate.reactive.panache.kotlin.PanacheRepository
 import io.smallrye.mutiny.coroutines.awaitSuspending
 import jakarta.enterprise.context.ApplicationScoped
-import java.time.OffsetDateTime
-import java.util.UUID
 
 @ApplicationScoped
 class TppEntryPanacheRepo : PanacheRepository<TppEntryEntity>
@@ -22,56 +20,57 @@ class TppEntryPanacheRepo : PanacheRepository<TppEntryEntity>
 class EbaSyncStatePanacheRepo : PanacheRepository<EbaSyncStateEntity>
 
 @ApplicationScoped
-class TppRepositoryImpl(
-    private val tppRepo: TppEntryPanacheRepo,
-    private val syncRepo: EbaSyncStatePanacheRepo
-) : TppRepository {
+class TppRepositoryImpl(private val tppRepo: TppEntryPanacheRepo, private val syncRepo: EbaSyncStatePanacheRepo) :
+    TppRepository {
 
     override suspend fun findByTppId(tppId: String): TppEntry? =
         Panache.withSession { tppRepo.find("tppId", tppId).firstResult() }.awaitSuspending()?.toDomain()
 
-    override suspend fun save(entry: TppEntry): TppEntry =
-        Panache.withTransaction {
-            val entity = entry.toEntity()
-            tppRepo.persist(entity).replaceWith(entity.toDomain())
-        }.awaitSuspending()
+    override suspend fun save(entry: TppEntry): TppEntry = Panache.withTransaction {
+        val entity = entry.toEntity()
+        tppRepo.persist(entity).replaceWith(entity.toDomain())
+    }.awaitSuspending()
 
-    override suspend fun update(entry: TppEntry): TppEntry =
-        Panache.withTransaction {
-            tppRepo.find("tppId", entry.tppId).firstResult()
-                .invoke { entity ->
-                    if (entity != null) {
-                        entity.status = entry.status.name
-                        entity.blacklistedAt = entry.blacklistedAt
-                        entity.blacklistReason = entry.blacklistReason
-                        entity.updatedAt = entry.updatedAt
-                        entity.roles = entry.roles.joinToString(",") { it.name }
-                        entity.qwacSubjectDn = entry.qwacSubjectDn
-                        entity.qsealSubjectDn = entry.qsealSubjectDn
-                        entity.qwacExpiresAt = entry.qwacExpiresAt
-                        entity.qsealExpiresAt = entry.qsealExpiresAt
-                    }
+    override suspend fun update(entry: TppEntry): TppEntry = Panache.withTransaction {
+        tppRepo.find("tppId", entry.tppId).firstResult()
+            .invoke { entity ->
+                if (entity != null) {
+                    entity.status = entry.status.name
+                    entity.blacklistedAt = entry.blacklistedAt
+                    entity.blacklistReason = entry.blacklistReason
+                    entity.updatedAt = entry.updatedAt
+                    entity.roles = entry.roles.joinToString(",") { it.name }
+                    entity.qwacSubjectDn = entry.qwacSubjectDn
+                    entity.qsealSubjectDn = entry.qsealSubjectDn
+                    entity.qwacExpiresAt = entry.qwacExpiresAt
+                    entity.qsealExpiresAt = entry.qsealExpiresAt
                 }
-                .map { entity -> entity?.toDomain() ?: throw IllegalStateException("TPP ${entry.tppId} not found for update") }
-        }.awaitSuspending()
+            }
+            .map { entity ->
+                entity?.toDomain()
+                    ?: throw IllegalStateException("TPP ${entry.tppId} not found for update")
+            }
+    }.awaitSuspending()
 
     override suspend fun list(
-        countryCode: String?, role: TppRole?, status: TppStatus?, limit: Int, afterCursor: String?
-    ): List<TppEntry> {
-        return Panache.withSession {
-            val query = buildString {
-                val conditions = mutableListOf<String>()
-                if (countryCode != null) conditions += "countryCode = '$countryCode'"
-                if (status != null) conditions += "status = '${status.name}'"
-                if (conditions.isNotEmpty()) append("WHERE ${conditions.joinToString(" AND ")}")
-                append(" ORDER BY registeredAt DESC")
-            }
-            tppRepo.find(query).list()
-        }.awaitSuspending()
-            .filter { role == null || it.roles.split(",").contains(role.name) }
-            .take(limit)
-            .map { it.toDomain() }
-    }
+        countryCode: String?,
+        role: TppRole?,
+        status: TppStatus?,
+        limit: Int,
+        afterCursor: String?,
+    ): List<TppEntry> = Panache.withSession {
+        val query = buildString {
+            val conditions = mutableListOf<String>()
+            if (countryCode != null) conditions += "countryCode = '$countryCode'"
+            if (status != null) conditions += "status = '${status.name}'"
+            if (conditions.isNotEmpty()) append("WHERE ${conditions.joinToString(" AND ")}")
+            append(" ORDER BY registeredAt DESC")
+        }
+        tppRepo.find(query).list()
+    }.awaitSuspending()
+        .filter { role == null || it.roles.split(",").contains(role.name) }
+        .take(limit)
+        .map { it.toDomain() }
 
     override suspend fun saveSyncState(state: EbaRegisterSyncState) {
         Panache.withTransaction {
@@ -106,7 +105,7 @@ class TppRepositoryImpl(
         }
 
     private fun TppEntryEntity.toDomain() = TppEntry(
-        id = UUID.fromString(id.toString()),
+        id = entryUuid,
         tppId = tppId,
         name = name,
         countryCode = countryCode,
@@ -120,10 +119,11 @@ class TppRepositoryImpl(
         registeredAt = registeredAt,
         updatedAt = updatedAt,
         blacklistedAt = blacklistedAt,
-        blacklistReason = blacklistReason
+        blacklistReason = blacklistReason,
     )
 
     private fun TppEntry.toEntity() = TppEntryEntity().apply {
+        entryUuid = this@toEntity.id
         tppId = this@toEntity.tppId
         name = this@toEntity.name
         countryCode = this@toEntity.countryCode

--- a/openbank-tpp-registry-service/src/main/resources/db/migration/V6__tpp_entries_entry_uuid.sql
+++ b/openbank-tpp-registry-service/src/main/resources/db/migration/V6__tpp_entries_entry_uuid.sql
@@ -1,0 +1,9 @@
+-- SPDX-License-Identifier: Apache-2.0
+-- The domain model's TppEntry.id is a UUID, but tpp_entries.id is a BIGSERIAL internal
+-- primary key (V1__init.sql). TppRepositoryImpl.toDomain() bridged the gap with
+-- UUID.fromString(id.toString()), which throws on any real row ("2" is not a UUID) — every
+-- read of a registered TPP fails, so the eIDAS licence gate can never authorize anybody
+-- (issue #2340). This column gives the domain id a real, stable value without touching the
+-- existing BIGSERIAL primary key, which stays internal and is never exposed (no REST
+-- resource, no openapi.yaml schema, no other service reads it).
+ALTER TABLE tpp_entries ADD COLUMN entry_uuid UUID NOT NULL DEFAULT gen_random_uuid();

--- a/openbank-tpp-registry-service/src/test/kotlin/com/openbank/tppregistry/contract/TppRegistryPactProviderVerificationTest.kt
+++ b/openbank-tpp-registry-service/src/test/kotlin/com/openbank/tppregistry/contract/TppRegistryPactProviderVerificationTest.kt
@@ -41,12 +41,12 @@ import org.junit.jupiter.api.extension.ExtendWith
  * registers the unknown TPP id the refusal interaction uses, so a fresh Testcontainer DB satisfies
  * it by construction.
  *
- * The allow branch is NOT in the committed pact yet, and the reason is worth knowing before adding
- * a `@State` for it: `TppRepositoryImpl.toDomain()` maps this entity's `BIGSERIAL` id through
- * `UUID.fromString(id.toString())`, so reading ANY registered row throws and the endpoint answers
- * 400 `"Invalid UUID string: 2"` — issue #2340, found by this very replay while psd2's consumer test
- * stayed green. `V1__init.sql` already seeds `CZ-CNB-TEST-AISP` as an ACTIVE AISP, so once #2340 is
- * fixed the allow interaction needs only a no-op `@State` here.
+ * The allow branch (issue #2340) is now in the committed pact: it was withheld until
+ * `TppRepositoryImpl.toDomain()` stopped mapping the entity's `BIGSERIAL` id through
+ * `UUID.fromString(id.toString())`, which threw on any registered row (400
+ * `"Invalid UUID string: 2"`, found by this very replay while psd2's consumer test stayed green).
+ * `V1__init.sql` already seeds `CZ-CNB-TEST-AISP` ACTIVE/AISP with no QWAC expiry, so the state
+ * handler below needs no setup either.
  *
  * `@TestSecurity` matches `checkAuthorization`'s `@RolesAllowed("ROLE_SERVICE", "ROLE_OPERATOR",
  * "ROLE_ADMIN")` — psd2 calls it with an M2M client-credentials token in production (ADR-0018).
@@ -95,5 +95,12 @@ class TppRegistryPactProviderVerificationTest {
         // No setup: nothing registers CZ-CNB-PACT-UNREGISTERED. Declared so the state is an
         // explicit part of the contract rather than a name pact-jvm passes over silently — an
         // unhandled state is not an error, which is how #468's missing states stayed invisible.
+    }
+
+    @State("the TPP registry has an ACTIVE AISP with an unexpired QWAC")
+    fun activeAispWithValidQwacIsSeeded() {
+        // No setup: V1__init.sql already seeds CZ-CNB-TEST-AISP as ACTIVE/AISP with a NULL
+        // qwac_expires_at, which TppRegistryService.checkAuthorization treats as never-expired.
+        // Declared for the same reason as the state above — an explicit, visible no-op.
     }
 }

--- a/pacts/openbank-psd2-service-openbank-tpp-registry-service.json
+++ b/pacts/openbank-psd2-service-openbank-tpp-registry-service.json
@@ -51,6 +51,43 @@
         },
         "status": 403
       }
+    },
+    {
+      "description": "GET check a registered, active AISP \u2014 the allow branch",
+      "providerStates": [
+        {
+          "name": "the TPP registry has an ACTIVE AISP with an unexpired QWAC"
+        }
+      ],
+      "request": {
+        "headers": {
+          "Accept": "application/json"
+        },
+        "method": "GET",
+        "path": "/api/v1/tpp-registry/check",
+        "query": {
+          "role": [
+            "AISP"
+          ],
+          "tppId": [
+            "CZ-CNB-TEST-AISP"
+          ]
+        }
+      },
+      "response": {
+        "body": {
+          "authorized": true,
+          "reason": null,
+          "roles": [
+            "AISP"
+          ],
+          "tppId": "CZ-CNB-TEST-AISP"
+        },
+        "headers": {
+          "Content-Type": "application/json"
+        },
+        "status": 200
+      }
     }
   ],
   "metadata": {


### PR DESCRIPTION
## What

`TppEntry.id` is a `UUID` in the domain model; `tpp_entries.id` is the table's `BIGSERIAL`
primary key (inherited from `PanacheEntity`, internal only — no REST resource, no
`openapi.yaml` schema, no other service reads it). `toDomain()` bridged the gap with
`UUID.fromString(id.toString())`, which throws on any real row — `"2"` is not a UUID.
**Every read of a registered TPP failed**, so the eIDAS licence gate this service exists
to run could never authorize anybody.

`Closes #2340`

## How it was found and re-confirmed

`TppRegistryPactProviderVerificationTest` replaying psd2's consumer pact against a real
booted instance. The consumer test stayed green the entire time — its refusal interaction
needs no seeded row, so it never exercised a real read. That asymmetry is exactly what the
provider replay is for.

## Fix

Adds `entry_uuid`, a real column the domain id actually maps to
(`V6__tpp_entries_entry_uuid.sql`, `DEFAULT gen_random_uuid()` — PG16 core, no `pgcrypto`
needed, matching the fleet's other UUID-default migrations). `registerTpp` already called
`UUID.randomUUID()` before this landed — the bug was entirely in the read-back, both
`findByTppId` and `save()`'s post-persist `toDomain()`. The `BIGSERIAL` primary key is
untouched; nothing downstream depends on its type.

The allow-branch pact interaction that #2346 (psd2's consumer test) deliberately withheld
lands here: a registered ACTIVE AISP against `V1__init.sql`'s `CZ-CNB-TEST-AISP` fixture,
no new seeding needed since the row was already seeded, just unreadable.

## Verification

- **Falsified the fix, not just the bug**: reverted the read-mapping to
  `UUID.fromString(id.toString())` and re-ran the provider replay — it reproduces the exact
  failure this issue reports, read from the JUnit XML, not the console:
  `expected status of 200 but was 400`, body `Invalid UUID string: 2`. Restored, replay goes
  green again (`tests="2" failures="0"`).
- `:openbank-tpp-registry-service:build :quarkusBuild detekt` — all green (`quarkusBuild`
  force-rerun, 26/26 executed, CDI resolves cleanly).
- `:openbank-psd2-service:build detekt ktlintCheck` — green. Its own consumer test
  regenerates the pact byte-identical to what's committed here (`git diff --stat pacts/`
  empty after `--rerun-tasks`).
- `check-domain-purity.sh`: 11 violations, 0 new, baseline unchanged.
- Confirmed via `derive-pact-drift-scope.sh` (landed in #2318 after this branch started)
  that psd2 is in the derived drift-check scope — no manual entry needed.
- `koverVerify` passes on both modules.

## Note on scope

`ktlintFormat` reformatted the whole `TppRepositoryImpl.kt` file, not just my edit —
removing one import shifted line numbers and desynced the module's `ktlint-baseline.xml`
from four pre-existing, previously-grandfathered violations (constructor formatting,
trailing commas), surfacing them as new. Per CLAUDE.md's ktlint guidance ("let
ktlintFormat collapse multi-line signatures"), that reformat is kept; six other files
ktlintFormat also touched but that I never edited were reverted to keep this diff to
the actual fix.

## Release

`fix` + `src/main` change ⇒ releases tpp-registry-service, correct for a functional-outage
fix. `version.txt`/`CHANGELOG.md` left to release-please.
