### PR TITLE
feat(consent): add per-channel MARKETING_COMMS ConsentScope values (ADR-0198 D1)

### DIFF
--- a/openbank-consent-service/src/main/kotlin/com/openbank/consent/domain/model/Consent.kt
+++ b/openbank-consent-service/src/main/kotlin/com/openbank/consent/domain/model/Consent.kt
@@ -41,6 +41,17 @@ enum class ConsentScope {
     // ingest gateway is gated on. Falls in the 365-day (non-AISP) validity
     // bucket — it is not subject to the PSD2 RTS Art. 10 90-day cap.
     TELEMETRY_RUM,
+
+    // Marketing communications — GDPR Art. 7 data-processing consent (ADR-0198), NOT a PSD2
+    // account-access consent and NOT SCA-gated, same shape as TELEMETRY_RUM. One value per
+    // channel, deliberately: a customer who accepted email marketing has not thereby accepted
+    // push (ADR-0198 force 4, Act 480/2004 §7(3)'s email-only soft opt-in never covers push).
+    // Falls in the 365-day (non-AISP) validity bucket. Default is absent, and absent means
+    // denied. Must NOT be added to AISP_SCOPES below — these are consent-service's only
+    // Art. 7 marketing-basis scopes, not account-access ones.
+    MARKETING_COMMS_EMAIL,
+    MARKETING_COMMS_PUSH,
+    MARKETING_COMMS_INAPP,
 }
 
 enum class GranteeType {

--- a/openbank-consent-service/src/test/kotlin/com/openbank/consent/domain/model/ConsentTest.kt
+++ b/openbank-consent-service/src/test/kotlin/com/openbank/consent/domain/model/ConsentTest.kt
@@ -144,6 +144,77 @@ class ConsentTest {
         assertThat(consent.frequencyPerDay()).isNull()
     }
 
+    // ADR-0198 D1: the three MARKETING_COMMS_* scopes must behave exactly like TELEMETRY_RUM —
+    // GDPR Art. 7, not AISP, not SCA-gated, 365-day bucket. The Negative-consequences section of
+    // ADR-0198 explicitly requires this exclusion from AISP_SCOPES be a reviewed, testable line,
+    // not an assumption resting on exhaustiveness that does not exist in this codebase.
+    @Test
+    fun `MARKETING_COMMS scopes are allowed past 90 days (GDPR, not AISP-capped)`() {
+        val emailConsent = consent(
+            scopes = setOf(ConsentScope.MARKETING_COMMS_EMAIL),
+            accountIbans = null,
+            validFrom = baseValidFrom,
+            validTo = baseValidFrom.plusDays(180),
+        )
+        val pushConsent = consent(
+            scopes = setOf(ConsentScope.MARKETING_COMMS_PUSH),
+            accountIbans = null,
+            validFrom = baseValidFrom,
+            validTo = baseValidFrom.plusDays(180),
+        )
+        val inAppConsent = consent(
+            scopes = setOf(ConsentScope.MARKETING_COMMS_INAPP),
+            accountIbans = null,
+            validFrom = baseValidFrom,
+            validTo = baseValidFrom.plusDays(180),
+        )
+
+        assertThat(emailConsent.hasScope(ConsentScope.MARKETING_COMMS_EMAIL)).isTrue()
+        assertThat(pushConsent.hasScope(ConsentScope.MARKETING_COMMS_PUSH)).isTrue()
+        assertThat(inAppConsent.hasScope(ConsentScope.MARKETING_COMMS_INAPP)).isTrue()
+        assertThat(emailConsent.isActive(OffsetDateTime.now())).isTrue()
+    }
+
+    @Test
+    fun `MARKETING_COMMS scopes are still capped at the 365-day maximum`() {
+        assertThrows<IllegalArgumentException> {
+            consent(
+                scopes = setOf(ConsentScope.MARKETING_COMMS_EMAIL),
+                accountIbans = null,
+                validFrom = baseValidFrom,
+                validTo = baseValidFrom.plusDays(366),
+            )
+        }
+    }
+
+    @Test
+    fun `frequencyPerDay is null for MARKETING_COMMS scopes — they are not AISP_SCOPES`() {
+        val consent = consent(
+            scopes = setOf(ConsentScope.MARKETING_COMMS_PUSH),
+            accountIbans = null,
+            validFrom = baseValidFrom,
+            validTo = baseValidFrom.plusDays(180),
+        )
+
+        assertThat(consent.frequencyPerDay()).isNull()
+    }
+
+    @Test
+    fun `a MARKETING_COMMS scope never triggers the PSD2 90-day AISP cap even mixed with an AISP scope`() {
+        // If a consent ever carried both an AISP scope and a marketing scope, the stricter (AISP)
+        // cap must still apply — this is the mixed-set behavior maxDays already implements via
+        // scopes.any { it in AISP_SCOPES }, asserted here so a future refactor of that predicate
+        // cannot silently let a marketing scope exempt an AISP scope from its 90-day cap.
+        assertThrows<IllegalArgumentException> {
+            consent(
+                scopes = setOf(ConsentScope.ACCOUNTS_READ, ConsentScope.MARKETING_COMMS_EMAIL),
+                accountIbans = listOf("CZ6508000000192000145399"),
+                validFrom = baseValidFrom,
+                validTo = baseValidFrom.plusDays(91),
+            )
+        }
+    }
+
     private fun consent(
         scopes: Set<ConsentScope> = setOf(ConsentScope.PAYMENTS_INITIATE),
         accountIbans: List<String>? = listOf("CZ6508000000192000145399"),


### PR DESCRIPTION
## Summary

ADR-0198 D1 only: adds `MARKETING_COMMS_EMAIL`, `MARKETING_COMMS_PUSH`, `MARKETING_COMMS_INAPP` to
`ConsentScope` in consent-service, following the existing `TELEMETRY_RUM` GDPR Art. 7 pattern exactly.
Self-contained — no migration, no cross-service change.

## Type of change

- [x] feat (new functionality)

## Linked issues

Refs #2369 (the notification-service EMAIL consent gate this eventually closes, once D4 lands)

## Changes

- `ConsentScope`: three new values, one per marketing channel, deliberately excluded from
  `AISP_SCOPES` — not SCA-gated, 365-day validity bucket, not the PSD2 RTS Art. 10 90-day cap.
- `ConsentTest`: four new tests mirroring the existing `TELEMETRY_RUM` coverage — 90-day-exempt,
  365-day-capped, no-frequency-cap across all three new scopes, plus a mixed-scope case proving a
  marketing scope never loosens the AISP cap when combined with an AISP scope in the same consent.
- Verified (not assumed): grepped consent-service for any exhaustive match over `ConsentScope` —
  none exists (`AISP_SCOPES` is a `setOf` allow-list, matching ADR-0198's own finding); checked
  `openapi.yaml` and the OPA bundle for any enumeration of scope values that would need touching —
  none does.

## Definition of Done

- [x] Hexagonal layering preserved — domain-only change, zero framework imports.
- [x] Unit tests added — `ConsentTest` 19/19 pass (4 new).
- [x] `./gradlew :openbank-consent-service:detekt :openbank-consent-service:ktlintCheck` passes.
- [x] No new lint warnings.
- [ ] OpenAPI spec — n/a, `ConsentScope` is not enumerated in `openapi.yaml`.
- [ ] Flyway migration — n/a, no schema change; scopes are stored as a set on the existing column.

## Compliance impact

- [x] GDPR — Art. 7, the consent basis these scopes exist to make demonstrable and revocable
      (full analysis already in ADR-0198's own Compliance impact section).
- [ ] PCI DSS · [ ] DORA · [ ] PSD2 / SCA / RTS · [ ] AML / 5AMLD · [ ] CNB reporting

## Reviewer notes

**Deliberately scoped to D1 only.** ADR-0198 has four parts (D1–D4); D3 (party-service projection +
migration, with the backfill-before-flip ordering hazard the ADR calls out explicitly) and D4
(notification-service consent gate moved before the per-channel dispatch) are each real, separately
reviewable pieces of work — bundling either into this PR would put a live-data migration or a
cross-service runtime dependency in the same review as a pure enum addition. This PR unblocks neither
#2369 nor ADR-0200 by itself; it is the safe, testable first slice.

**Reachability confirmed by independent review, not just claimed:** the generic
`CreateConsentRequest`/`ValidateConsentRequest` DTOs take `Set<ConsentScope>` directly, so a
`POST` to the existing consent-grant endpoint with one of these scope names today creates a real,
correctly-behaved consent. Nothing downstream reads it yet (that's D3/D4), but nothing mishandles it.
