### PR TITLE
test(sca): ratchet kover line floor 45 → 64 to match real coverage

### DIFF
--- a/openbank-sca-service/build.gradle.kts
+++ b/openbank-sca-service/build.gradle.kts
@@ -63,7 +63,7 @@ kover {
         verify {
             rule {
                 bound {
-                    minValue = 45
+                    minValue = 64
                     coverageUnits = kotlinx.kover.gradle.plugin.dsl.CoverageUnit.LINE
                 }
             }


### PR DESCRIPTION
## What

`openbank-sca-service` koverVerify line floor was **45%** while measured coverage is **65.2%** (474/727 lines) — a ~20pp stale gap that let real regressions slip on a **money-path** auth service.

Ratchet the floor to **64** (≈1pp CI headroom under actual), aligning with the other money-path floors: ledger 65, balance 67.

## How verified

- `:openbank-sca-service:koverXmlReport` → 65.2% line coverage (JDK 25 toolchain)
- `:openbank-sca-service:koverVerify` → **BUILD SUCCESSFUL** with floor 64

No production code touched — only `build.gradle.kts`. No `version.txt` bump (change is outside `src/main/**`). No API/DB/event change.

## Linked issues

N/A — governance hygiene (coverage-floor ratchet); no tracker item.

## Notes

Money-path service ⇒ needs 2 approvals per ADR-0030. Threat model unchanged (no new surface). Follow-up (separate PR) to genuinely raise SCA coverage toward money-path target with new factor-logic tests.

🤖 Generated with [Claude Code](https://claude.com/claude-code)