### PR TITLE
test(transaction): replay all six provider pacts before merge, not after

### DIFF
--- a/.github/scripts/check-pact-provider-replay.py
+++ b/.github/scripts/check-pact-provider-replay.py
@@ -51,23 +51,17 @@ PACTS = ROOT / "pacts"
 KNOWN_UNCOVERED = {
     "pacts/openbank-account-service-openbank-balance-service.json",
     "pacts/openbank-account-service-openbank-party-service.json",
-    "pacts/openbank-account-service-openbank-transaction-service.json",
     "pacts/openbank-balance-service-openbank-account-service.json",
     "pacts/openbank-consent-service-openbank-sca-service.json",
-    "pacts/openbank-domestic-payment-openbank-transaction-service.json",
-    "pacts/openbank-fraud-service-openbank-transaction-service.json",
     "pacts/openbank-kyc-service-openbank-party-service.json",
     # Landed 2026-07-25, after the #2327 audit counted 16 of 27: same three providers
     # (balance/transaction/party), so the same debt, not a new class of it. The estate went
     # 27 -> 33 pacts in a day, which is the argument for a gate rather than another audit.
     "pacts/openbank-mcp-service-openbank-balance-service.json",
-    "pacts/openbank-mcp-service-openbank-transaction-service.json",
     "pacts/openbank-vop-service-openbank-party-service.json",
     "pacts/openbank-notification-service-openbank-account-service.json",
     "pacts/openbank-onboarding-service-openbank-party-service.json",
-    "pacts/openbank-sepa-instant-openbank-transaction-service.json",
     "pacts/openbank-sepa-payment-openbank-fraud-service.json",
-    "pacts/openbank-sepa-payment-openbank-transaction-service.json",
     "pacts/openbank-transaction-service-openbank-balance-service.json",
     "pacts/openbank-transaction-service-openbank-fx-service.json",
     "pacts/openbank-transaction-service-openbank-swift-service.json",

--- a/openbank-transaction-service/src/test/kotlin/com/openbank/transaction/contract/TransactionPactFolderProviderVerificationTest.kt
+++ b/openbank-transaction-service/src/test/kotlin/com/openbank/transaction/contract/TransactionPactFolderProviderVerificationTest.kt
@@ -1,0 +1,153 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright (c) OpenBank contributors. Licensed under the Apache License, Version 2.0.
+// See LICENSE in the repository root or https://www.apache.org/licenses/LICENSE-2.0 for details.
+
+package com.openbank.transaction.contract
+
+import au.com.dius.pact.provider.PactVerifyProvider
+import au.com.dius.pact.provider.junit5.HttpTestTarget
+import au.com.dius.pact.provider.junit5.MessageTestTarget
+import au.com.dius.pact.provider.junit5.PactVerificationContext
+import au.com.dius.pact.provider.junit5.PactVerificationInvocationContextProvider
+import au.com.dius.pact.provider.junitsupport.IgnoreNoPactsToVerify
+import au.com.dius.pact.provider.junitsupport.Provider
+import au.com.dius.pact.provider.junitsupport.State
+import au.com.dius.pact.provider.junitsupport.loader.PactFolder
+import com.fasterxml.jackson.databind.SerializationFeature
+import com.fasterxml.jackson.datatype.jsr310.JavaTimeModule
+import com.fasterxml.jackson.module.kotlin.jacksonObjectMapper
+import com.openbank.libs.domain.payment.InstructionType
+import com.openbank.libs.domain.payment.PaymentRail
+import com.openbank.transaction.domain.event.TransactionInitiatedEvent
+import com.openbank.transaction.domain.model.TransactionType
+import io.quarkus.test.common.QuarkusTestResource
+import io.quarkus.test.junit.QuarkusTest
+import io.quarkus.test.security.TestSecurity
+import org.eclipse.microprofile.config.inject.ConfigProperty
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.TestTemplate
+import org.junit.jupiter.api.extension.ExtendWith
+import java.math.BigDecimal
+import java.util.UUID
+
+/**
+ * Git-pact provider verification for transaction-service — the half that actually runs before a
+ * merge (issue #2327, gated by `check-pact-provider-replay.py` per #2338).
+ *
+ * ## Why this class exists at all
+ *
+ * A consumer pact CANNOT catch a wrong request path: the Pact mock server answers whatever path the
+ * client asks for, so a client pointed at a route that does not exist leaves the consumer test
+ * green. Only the provider replay goes red — that is how finrep-service shipped a call to a ledger
+ * route which has never existed (#2269). Transaction-service is the provider for six committed
+ * pacts, and its only verification class was [TransactionPactProviderVerificationTest], which is
+ * `@PactBroker`-sourced and `@EnabledIfSystemProperty(pactbroker.url)`-gated. On a pull request that
+ * property is empty — `_service-ci.yml` puts the PR lane on `ubuntu-latest` and blanks
+ * `PACT_BROKER_URL` off main-push, because the broker has no public ingress (ADR-0056) — so the
+ * class skipped and all six contracts were replayed only AFTER the merge.
+ *
+ * This class reads the same contracts from the committed `pacts/` directory (ADR-0063 git-pact), so
+ * it needs no broker, no CI secret and no network, and it runs on every PR.
+ *
+ * ## Two `@Provider` classes is deliberate here, not the footgun
+ *
+ * `CLAUDE.md` warns against two verification classes for one provider. That collision is two classes
+ * both pulling from the BROKER: each fetches every pact the broker holds, so an HTTP-targeted class
+ * also drags in the message pact and dies in its state-change callback. The sanctioned pair — the
+ * one openbank-ledger-service already carries — is one `@PactFolder` class plus one `@PactBroker`
+ * class, because each loads from its own source. This is that pair. Keep the two in sync: a `@State`
+ * or [PactVerifyProvider] added to one belongs in the other, or the same contract passes from git
+ * and fails from the broker (or the reverse).
+ *
+ * ## Both interaction kinds, one class
+ *
+ * Six pacts, five HTTP and one message, so the target is chosen per interaction in
+ * [configureTarget] exactly as in the broker twin: a [MessageTestTarget] for the fraud-service
+ * `transaction.initiated` contract, an [HttpTestTarget] for the rest. The [MessageTestTarget] is
+ * package-scoped on purpose — a classpath-wide ClassGraph scan throws on the JDK 25 toolchain.
+ *
+ * ## When this goes red
+ *
+ * Either a consumer changed its pact and did not regenerate it (`pact-drift-check.yml` catches that
+ * first), or transaction-service genuinely broke a contract — a renamed field, a moved route, a
+ * changed status code. Do not "fix" it by relaxing the pact: regenerate from the consumer test and
+ * read what changed.
+ */
+@QuarkusTest
+@QuarkusTestResource(com.openbank.transaction.it.PostgresRedpandaTestResource::class)
+@TestSecurity(user = "pact-verifier", roles = ["ROLE_OPERATOR"])
+@Provider("openbank-transaction-service")
+@PactFolder("../pacts")
+@IgnoreNoPactsToVerify(ignoreIoErrors = "true")
+class TransactionPactFolderProviderVerificationTest {
+
+    @ConfigProperty(name = "quarkus.http.test-port", defaultValue = "8081")
+    lateinit var testPort: String
+
+    private val objectMapper = jacksonObjectMapper()
+        .registerModule(JavaTimeModule())
+        .disable(SerializationFeature.WRITE_DATES_AS_TIMESTAMPS)
+
+    @BeforeEach
+    fun configureTarget(context: PactVerificationContext?) {
+        if (context == null) return
+        context.target = if (context.interaction.isAsynchronousMessage()) {
+            MessageTestTarget(listOf("com.openbank.transaction.contract"))
+        } else {
+            HttpTestTarget("localhost", testPort.toInt())
+        }
+        context.addStateChangeHandlers(this)
+    }
+
+    @TestTemplate
+    @ExtendWith(PactVerificationInvocationContextProvider::class)
+    fun verifyPacts(context: PactVerificationContext?) {
+        context?.verifyInteraction()
+    }
+
+    @State("the transaction service is available")
+    fun stateServiceAvailable() {
+        // TemporalTestResource provides an in-process Temporal server with NoOpPaymentWorkflow
+        // registered to return COMPLETED — no per-interaction setup needed here.
+    }
+
+    @State("a valid source account exists")
+    fun stateValidSourceAccountExists() {
+        // Shared by domestic-payment, sepa-payment and sepa-instant. No setup needed:
+        // initiateTransaction does not require the account to pre-exist in this test's Postgres,
+        // only that sourceAccountId parses as a UUID.
+    }
+
+    @State("transaction-service is reachable and holds no transactions for the pact account")
+    fun stateNoTransactionsForPactAccount() {
+        // mcp-service's TransactionListPactConsumerTest (#2255, ADR-0195). Intentionally empty — a
+        // fresh Testcontainer DB satisfies it by construction. Declared so the state is an explicit
+        // part of the contract: pact-jvm passes silently over an UNHANDLED state name, which is how
+        // #468's missing states stayed invisible.
+    }
+
+    @State("transaction-service has initiated a payment transaction")
+    fun stateTransactionInitiated() {
+        // No setup needed: the message producer below returns a deterministic payload.
+    }
+
+    @PactVerifyProvider("a transaction.initiated event for fraud screening")
+    fun produceTransactionInitiated(): String {
+        val event = TransactionInitiatedEvent(
+            aggregateId = UUID.fromString("11111111-1111-1111-1111-111111111111"),
+            version = 1L,
+            referenceNumber = "TXN-PACT-001",
+            type = TransactionType.DEBIT,
+            sourceAccountId = UUID.fromString("22222222-2222-2222-2222-222222222222"),
+            // ADR-0084 §3 v4: non-null so the fraud-service consumer pact (which asserts
+            // targetAccountId is a present UUID) verifies against a realistic payload.
+            targetAccountId = UUID.fromString("33333333-3333-3333-3333-333333333333"),
+            amount = BigDecimal("250.00"),
+            currencyCode = "CZK",
+            rail = PaymentRail.INTERNAL,
+            instructionType = InstructionType.ONE_OFF,
+            occurredAt = java.time.Instant.parse("2026-01-01T00:00:00Z"),
+        )
+        return objectMapper.writeValueAsString(event)
+    }
+}


### PR DESCRIPTION
## Summary

> **Stacked on #2413 — merge that first.** Its base is `ci/pact-provider-replay-coverage`, because `KNOWN_UNCOVERED` only exists there. Landing this against `main` alone would leave the six pacts listed as uncovered while they are covered, which #2413's own stale-entry check turns red.

`transaction-service` is the provider for **six** committed pacts and its only verification class is `@PactBroker`-sourced and `@EnabledIfSystemProperty(pactbroker.url)`-gated — so on a PR it skips and all six contracts were replayed only *after* the merge. This adds the `@PactFolder` twin that runs on every PR. Largest single block of #2327: 6 of 19.

## Type of change

- [ ] feat (new functionality)
- [ ] fix (bug fix)
- [ ] refactor (no behavior change)
- [ ] perf (performance)
- [ ] docs
- [x] chore (build / tooling)
- [ ] security (private until disclosed)
- [ ] breaking change

Commit type is `test` — hidden, no release-please bump. No production code changed.

## Linked issues

Refs #2327
Refs #2269
Refs #2338

## Changes

- **New `TransactionPactFolderProviderVerificationTest`** — `@PactFolder("../pacts")`, no gating annotation, so it runs on every PR with no broker, no CI secret and no network. Picks the target per interaction exactly as the broker twin does: `MessageTestTarget` for the fraud-service `transaction.initiated` contract, `HttpTestTarget` for the five HTTP ones. Same `@State` handlers and `@PactVerifyProvider` producer.
- **`KNOWN_UNCOVERED`** loses the six transaction pacts: coverage **14 → 20**, backlog **19 → 13**.

## Reviewer notes

**Verified from the JUnit XML, not the console** — pact-jvm prints `Not all of the N were verified` on a fully green run, so the console is not the verdict:

```
tests=6 failures=0 errors=0
  PASS openbank-sepa-payment     - POST initiate SEPA transaction
  PASS openbank-mcp-service      - GET the transaction page list_transactions returns verbatim
  PASS openbank-account-service  - POST initiate a CREDIT welcome bonus transaction
  PASS openbank-domestic-payment - POST initiate domestic transaction
  PASS openbank-sepa-instant     - POST initiate SCT Inst settlement transaction
  PASS openbank-fraud-service    - a transaction.initiated event for fraud screening
```

**Falsified, not assumed.** Renaming `TransactionResource`'s `@Path` to `/api/v1/transactions-MOVED` and re-running:

```
tests=6 failures=5
  FAIL  (all five HTTP interactions)
  PASS  openbank-fraud-service - a transaction.initiated event for fraud screening
```

All five HTTP interactions go red; the message interaction correctly stays green because it touches no route. That is the #2269 defect class — a client pointed at a route the provider does not serve — reproduced and caught, on contracts that would previously have skipped at PR time. The resource file was restored and the suite re-run green before committing.

**Two `@Provider` classes for one provider is deliberate here.** The collision `CLAUDE.md` warns about is two classes both pulling from the **broker**: each fetches every pact the broker holds, so an HTTP-targeted class also drags in the message pact and dies in its state-change callback. A `@PactFolder` class plus a `@PactBroker` class each load from their own source — the pair `openbank-ledger-service` already carries. The new class's KDoc states the upkeep this buys: a `@State` or `@PactVerifyProvider` added to one belongs in the other, or the same contract passes from git and fails from the broker.

**Cost:** one more `@QuarkusTest` with Testcontainers in transaction-service's PR build, measured at **~1 min 18 s** locally on a warm cache. That is the price of six money-path contracts being checked before merge instead of after.

## Definition of Done

- [x] Hexagonal layering preserved (domain has zero framework imports).
- [x] Unit tests added/updated. — this PR is the test
- [x] Integration tests added/updated (if service boundary involved). — six provider-side replays
- [x] Contract tests updated (if public API changed). — no pact content changed; they are now replayed pre-merge
- [x] `./gradlew detekt ktlintCheck koverVerify build` passes. — ktlintCheck + compileTestKotlin + the test itself
- [x] No new lint warnings.
- [ ] OpenAPI spec regenerated (if REST API changed). — N/A
- [ ] Flyway migration added + rollback note (if DB changed). — N/A
- [ ] Avro schema versioned backward-compatibly (if event changed). — N/A
- [x] Docs updated (README, ADR if architectural). — KDoc; the fleet rule is in `CLAUDE.md` via #2413

## Security checklist

- [x] No secrets, tokens, passwords, or PII in code, config, tests, logs.
- [x] No new `@SuppressWarnings`, `as Any`, `@Suppress("...")` without justification.
- [x] No new third-party dependency.
- [ ] Auth / crypto / payment code changed? → N/A — test-only
- [ ] PII path changed? → N/A
- [ ] Cardholder data path changed? → N/A

## Compliance impact

- [x] None

## Rollout / Rollback

- Deployment strategy: N/A — test-only, no service artifact
- Rollback plan: revert the commit; the broker twin is untouched
- Data migration reversible: N/A
