### PR TITLE
fix(authz): realm-issued role names across 9 services + enforce @RolesAllowed parity (#2404)

### DIFF
--- a/.github/scripts/check-roles-allowed-realm.py
+++ b/.github/scripts/check-roles-allowed-realm.py
@@ -1,0 +1,173 @@
+#!/usr/bin/env python3
+# SPDX-License-Identifier: Apache-2.0
+# Copyright (c) OpenBank contributors. Licensed under the Apache License, Version 2.0.
+#
+# Guard: every @RolesAllowed role name must exist in a Keycloak realm (issue #2404).
+#
+# WHY THIS EXISTS
+#   `@RolesAllowed` takes a compile-time string, and nothing checked that the string names a role
+#   the realm actually issues. A name that exists nowhere does not fail loudly — it just never
+#   matches, so the endpoint answers 403 to every caller, forever, and no test, lint or gate says
+#   so. openbank-finrep-service shipped `@RolesAllowed("SERVICE", "ADMIN", "OPERATOR")` (the realm
+#   issues ROLE_ADMIN / ROLE_OPERATOR / …) and FINREP + COREP were unreachable from the day they
+#   were written until #2403.
+#
+#   The failure is invisible from every angle a normal PR looks at. In particular a unit test
+#   cannot catch it: `@TestSecurity(roles = ["SERVICE"])` MINTS whatever string it is handed, so a
+#   test written from the annotation matches the annotation and passes against a broken resource.
+#   finrep's did exactly that. A test that supplies both sides of the comparison cannot fail —
+#   which is why this has to be a gate over the realm, not more tests.
+#
+# WHAT IT CHECKS
+#   HARD (exit 1) — an `@RolesAllowed` whose roles are ALL absent from every realm. That endpoint
+#   is unreachable by construction: there is no token any Keycloak in this platform can mint that
+#   satisfies it. This is a mechanical fact, not a policy judgement, which is why it blocks.
+#
+#   ADVISORY (::warning) — an individual unknown role inside a list that also names a live one
+#   (e.g. `("ROLE_SERVICE", "ROLE_OPERATOR", "ROLE_ADMIN")`). Humans still get in; only the caller
+#   the dead name was meant for is silently denied. Fleet-wide there are ~150 of these across ~29
+#   services (ROLE_SERVICE, ROLE_CREDIT_RISK, ROLE_LENDING_OFFICER), and clearing them is a real
+#   decision per service — grant the role in Keycloak, or delete the path it was reserved for.
+#   Tracked separately; warning here so the number stays visible instead of being rediscovered.
+#
+# COMMENTS ARE STRIPPED FIRST, and that is load-bearing rather than tidy. #2403 fixed finrep by
+# replacing the literals and writing a KDoc that QUOTES the broken annotation to explain what went
+# wrong. A scanner that reads raw text flags that comment — the first draft of this script did,
+# reporting finrep as still broken after it was fixed. A guard that cannot tell code from prose
+# about code manufactures its own findings (same class as the prod-readiness scorer that graded
+# services on the word "contract" appearing in a comment, #2291).
+#
+# Run:  python3 .github/scripts/check-roles-allowed-realm.py [--root .]
+
+import argparse
+import json
+import pathlib
+import re
+import sys
+
+REALM_GLOB = "openbank-infra/gitops/components/keycloak/*realm-template*.json"
+ROLES_KT = "openbank-libs-domain/src/main/kotlin/com/openbank/libs/security/Roles.kt"
+
+ANNOTATION_RE = re.compile(r"@RolesAllowed\s*\(([^)]*)\)", re.S)
+ARG_RE = re.compile(r'"([^"]+)"|Roles\.(\w+)')
+CONST_RE = re.compile(r'const\s+val\s+(\w+)\s*[:=][^"]*"([^"]+)"')
+
+# Kotlin block comments NEST (a `/*` inside a KDoc opens a second level) — mirror that, or a KDoc
+# containing one closes early and its tail is scanned as code.
+LINE_COMMENT_RE = re.compile(r"//[^\n]*")
+
+
+def strip_comments(src: str) -> str:
+    """Blank out // line comments and (nesting) /* */ blocks, preserving line numbering."""
+    out = []
+    i, depth, n = 0, 0, len(src)
+    while i < n:
+        if depth == 0 and src.startswith("//", i):
+            j = src.find("\n", i)
+            j = n if j < 0 else j
+            out.append(" " * (j - i))
+            i = j
+            continue
+        if src.startswith("/*", i):
+            depth += 1
+            out.append("  ")
+            i += 2
+            continue
+        if depth and src.startswith("*/", i):
+            depth -= 1
+            out.append("  ")
+            i += 2
+            continue
+        ch = src[i]
+        out.append(ch if (depth == 0 or ch == "\n") else " ")
+        i += 1
+    return "".join(out)
+
+
+def realm_roles(root: pathlib.Path, errors):
+    names, files = set(), []
+    for p in sorted(root.glob(REALM_GLOB)):
+        files.append(p.name)
+        doc = json.loads(p.read_text())
+        roles = doc.get("roles", {})
+        names |= {r["name"] for r in roles.get("realm", []) or []}
+        for client_roles in (roles.get("client", {}) or {}).values():
+            names |= {r["name"] for r in client_roles or []}
+    if not names:
+        errors.append(f"no realm roles found under {REALM_GLOB} — the guard cannot run blind")
+    return names, files
+
+
+def role_constants(root: pathlib.Path):
+    f = root / ROLES_KT
+    if not f.is_file():
+        return {}
+    return dict(CONST_RE.findall(f.read_text()))
+
+
+def scan(root: pathlib.Path, known, consts):
+    """Yield (path, line, all_names, dead_names) for every @RolesAllowed in service main sources."""
+    for f in sorted(root.glob("openbank-*/src/main/kotlin/**/*.kt")):
+        src = strip_comments(f.read_text())
+        for m in ANNOTATION_RE.finditer(src):
+            names = []
+            for literal, const in ARG_RE.findall(m.group(1)):
+                names.append(literal or consts.get(const, f"Roles.{const}"))
+            if not names:
+                continue
+            line = src[: m.start()].count("\n") + 1
+            dead = [n for n in names if n not in known]
+            yield f.relative_to(root), line, names, dead
+
+
+def main() -> int:
+    ap = argparse.ArgumentParser()
+    ap.add_argument("--root", default=".")
+    args = ap.parse_args()
+    root = pathlib.Path(args.root).resolve()
+
+    errors = []
+    known, realm_files = realm_roles(root, errors)
+    consts = role_constants(root)
+
+    unreachable, partial, checked = [], [], 0
+    for rel, line, names, dead in scan(root, known, consts):
+        checked += 1
+        if dead and len(dead) == len(names):
+            unreachable.append((rel, line, names))
+        elif dead:
+            partial.append((rel, line, dead))
+
+    for rel, line, names in unreachable:
+        errors.append(
+            f"{rel}:{line} — @RolesAllowed({', '.join(names)}) names no role any realm issues, so "
+            f"this endpoint answers 403 to every caller. Known roles: {', '.join(sorted(known))}",
+        )
+
+    if partial:
+        by_role = {}
+        for _, _, dead in partial:
+            for d in dead:
+                by_role[d] = by_role.get(d, 0) + 1
+        detail = ", ".join(f"{r}×{c}" for r, c in sorted(by_role.items(), key=lambda kv: -kv[1]))
+        print(
+            f"::warning title=RolesAllowed realm parity::{len(partial)} @RolesAllowed site(s) name "
+            f"a role no realm issues alongside a live one — the caller it was reserved for is "
+            f"silently denied ({detail}). Grant the role in Keycloak or delete the path.",
+        )
+
+    if errors:
+        for e in errors:
+            sys.stderr.write(f"::error title=RolesAllowed realm parity::{e}\n")
+        sys.stderr.write(f"::error::check-roles-allowed-realm: {len(errors)} unreachable endpoint(s).\n")
+        return 1
+
+    print(
+        f"roles-allowed parity: {checked} @RolesAllowed site(s) checked against "
+        f"{len(known)} role(s) from {', '.join(realm_files)}; 0 unreachable, {len(partial)} advisory.",
+    )
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -768,6 +768,22 @@ jobs:
       - name: "authz-enforce ⇒ PDP sidecar parity (advisory, #1797)"
         run: python3 .github/scripts/check-authz-pdp-parity.py .
 
+      # @RolesAllowed ⇒ realm parity (issue #2404). The JWT-role half of the check above: a role
+      # name that exists in no realm never matches, so the endpoint answers 403 to every caller,
+      # silently and forever. finrep's FINREP/COREP shipped that way (#2403), and 39 sites across
+      # 9 services were in the same state at introduction — three invented vocabularies
+      # (`openbank-employee`, `platform-admin`, `SERVICE`) that no Keycloak ever issued.
+      # ENFORCED from day one, on the mechanical half only: it fails when EVERY role in an
+      # @RolesAllowed is unknown (the endpoint is unreachable by construction — a fact, not a
+      # judgement). A single dead name inside an otherwise-live list is ::warning, because
+      # clearing those ~163 sites (ROLE_SERVICE ×152, ROLE_CREDIT_RISK ×9, ROLE_LENDING_OFFICER ×6)
+      # means deciding per service whether to grant the role in Keycloak or delete the path.
+      # A unit test cannot replace this: @TestSecurity mints whatever role string it is handed, so
+      # a test written from the annotation matches the annotation and passes against a resource
+      # that 403s in production — exactly how finrep's stayed green.
+      - name: "@RolesAllowed ⇒ realm parity (issue #2404, enforced)"
+        run: python3 .github/scripts/check-roles-allowed-realm.py
+
       # openbank.outbox.dispatch-enabled guard (the CLAUDE.md "outbox footgun":
       # a service whose OutboxDispatcher actually gates on this flag silently
       # never dispatches if it's left at its false default — no error,

--- a/openbank-authz-policy-auditor/src/main/kotlin/com/openbank/authzaudit/infrastructure/rest/AuthzPolicyResource.kt
+++ b/openbank-authz-policy-auditor/src/main/kotlin/com/openbank/authzaudit/infrastructure/rest/AuthzPolicyResource.kt
@@ -28,21 +28,21 @@ class AuthzPolicyResource(
 ) {
     @POST
     @Path("/check/trigger")
-    @RolesAllowed("platform-admin")
+    @RolesAllowed("ROLE_ADMIN")
     fun triggerCheck(): AuthzPolicyReport = runBlocking {
         runCheck.run(RunTrigger.OPERATOR_MANUAL)
     }
 
     @GET
     @Path("/findings")
-    @RolesAllowed("platform-admin", "platform-viewer")
+    @RolesAllowed("ROLE_ADMIN", "ROLE_VIEWER")
     fun getActiveFindings(): List<AuthzPolicyFinding> = runBlocking {
         getFindings.getActive()
     }
 
     @GET
     @Path("/findings/{id}")
-    @RolesAllowed("platform-admin", "platform-viewer")
+    @RolesAllowed("ROLE_ADMIN", "ROLE_VIEWER")
     fun getFinding(@PathParam("id") id: String): AuthzPolicyFinding = runBlocking {
         getFindings.getById(id) ?: throw NotFoundException("Finding $id not found")
     }

--- a/openbank-control-liveness-sentinel/src/main/kotlin/com/openbank/liveness/infrastructure/rest/LivenessSentinelResource.kt
+++ b/openbank-control-liveness-sentinel/src/main/kotlin/com/openbank/liveness/infrastructure/rest/LivenessSentinelResource.kt
@@ -28,21 +28,21 @@ class LivenessSentinelResource(
 ) {
     @POST
     @Path("/check/trigger")
-    @RolesAllowed("platform-admin")
+    @RolesAllowed("ROLE_ADMIN")
     fun triggerCheck(): LivenessRunReport = runBlocking {
         runCheck.run(RunTrigger.OPERATOR_MANUAL)
     }
 
     @GET
     @Path("/findings")
-    @RolesAllowed("platform-admin", "platform-viewer")
+    @RolesAllowed("ROLE_ADMIN", "ROLE_VIEWER")
     fun getActiveFindings(): List<LivenessFinding> = runBlocking {
         getFindings.getActive()
     }
 
     @GET
     @Path("/findings/{id}")
-    @RolesAllowed("platform-admin", "platform-viewer")
+    @RolesAllowed("ROLE_ADMIN", "ROLE_VIEWER")
     fun getFinding(@PathParam("id") id: String): LivenessFinding = runBlocking {
         getFindings.getById(id) ?: throw NotFoundException("Finding $id not found")
     }

--- a/openbank-devops-agent/src/main/kotlin/com/openbank/devops/infrastructure/rest/DevOpsResource.kt
+++ b/openbank-devops-agent/src/main/kotlin/com/openbank/devops/infrastructure/rest/DevOpsResource.kt
@@ -33,7 +33,7 @@ class DevOpsResource(
     // thread, not the event loop. It touches no reactive DB session, so runBlocking is fine here.
     @POST
     @Path("/analysis/trigger")
-    @RolesAllowed("platform-admin")
+    @RolesAllowed("ROLE_ADMIN")
     @Blocking
     fun triggerAnalysis(): DevOpsRunReport = runBlocking {
         runAnalysis.run(RunTrigger.OPERATOR_MANUAL)
@@ -43,12 +43,12 @@ class DevOpsResource(
     // Kotlin suspend resource methods on one, so the session resolves correctly.
     @GET
     @Path("/findings")
-    @RolesAllowed("platform-admin", "platform-viewer")
+    @RolesAllowed("ROLE_ADMIN", "ROLE_VIEWER")
     suspend fun getActiveFindings(): List<DevOpsFinding> = getFindings.getActive()
 
     @GET
     @Path("/findings/{id}")
-    @RolesAllowed("platform-admin", "platform-viewer")
+    @RolesAllowed("ROLE_ADMIN", "ROLE_VIEWER")
     suspend fun getFinding(@PathParam("id") id: String): DevOpsFinding =
         getFindings.getById(id) ?: throw NotFoundException("Finding $id not found")
 
@@ -56,13 +56,13 @@ class DevOpsResource(
     // (a viewer at most) can never approve its own proposal (segregation of duties).
     @POST
     @Path("/findings/{id}/approve")
-    @RolesAllowed("platform-admin")
+    @RolesAllowed("ROLE_ADMIN")
     suspend fun approve(@PathParam("id") id: String): DevOpsFinding =
         decide.approve(id) ?: throw NotFoundException("Finding $id not found")
 
     @POST
     @Path("/findings/{id}/reject")
-    @RolesAllowed("platform-admin")
+    @RolesAllowed("ROLE_ADMIN")
     suspend fun reject(@PathParam("id") id: String): DevOpsFinding =
         decide.reject(id) ?: throw NotFoundException("Finding $id not found")
 }

--- a/openbank-docs-truth-agent/src/main/kotlin/com/openbank/docstruth/infrastructure/rest/DocsTruthResource.kt
+++ b/openbank-docs-truth-agent/src/main/kotlin/com/openbank/docstruth/infrastructure/rest/DocsTruthResource.kt
@@ -28,7 +28,7 @@ class DocsTruthResource(private val runCheck: RunDocsTruthCheckUseCase, private 
     // thread, not the event loop. It touches no reactive DB session, so runBlocking is fine here.
     @POST
     @Path("/check/trigger")
-    @RolesAllowed("platform-admin")
+    @RolesAllowed("ROLE_ADMIN")
     @Blocking
     fun triggerCheck(): DocsTruthReport = runBlocking {
         runCheck.run(RunTrigger.OPERATOR_MANUAL)
@@ -38,12 +38,12 @@ class DocsTruthResource(private val runCheck: RunDocsTruthCheckUseCase, private 
     // Kotlin suspend resource methods on one, so the session resolves correctly.
     @GET
     @Path("/findings")
-    @RolesAllowed("platform-admin", "platform-viewer")
+    @RolesAllowed("ROLE_ADMIN", "ROLE_VIEWER")
     suspend fun getActiveFindings(): List<DocsTruthFinding> = getFindings.getActive()
 
     @GET
     @Path("/findings/{id}")
-    @RolesAllowed("platform-admin", "platform-viewer")
+    @RolesAllowed("ROLE_ADMIN", "ROLE_VIEWER")
     suspend fun getFinding(@PathParam("id") id: String): DocsTruthFinding =
         getFindings.getById(id) ?: throw NotFoundException("Finding $id not found")
 }

--- a/openbank-finops-agent/src/main/kotlin/com/openbank/finops/infrastructure/rest/FinOpsResource.kt
+++ b/openbank-finops-agent/src/main/kotlin/com/openbank/finops/infrastructure/rest/FinOpsResource.kt
@@ -28,21 +28,21 @@ class FinOpsResource(
 ) {
     @POST
     @Path("/analysis/trigger")
-    @RolesAllowed("platform-admin")
+    @RolesAllowed("ROLE_ADMIN")
     fun triggerAnalysis(): FinOpsRunReport = runBlocking {
         runAnalysis.run(RunTrigger.OPERATOR_MANUAL)
     }
 
     @GET
     @Path("/anomalies")
-    @RolesAllowed("platform-admin", "platform-viewer")
+    @RolesAllowed("ROLE_ADMIN", "ROLE_VIEWER")
     fun getActiveAnomalies(): List<CostAnomaly> = runBlocking {
         getAnomalies.getActive()
     }
 
     @GET
     @Path("/anomalies/{id}")
-    @RolesAllowed("platform-admin", "platform-viewer")
+    @RolesAllowed("ROLE_ADMIN", "ROLE_VIEWER")
     fun getAnomaly(@PathParam("id") id: String): CostAnomaly = runBlocking {
         getAnomalies.getById(id) ?: throw NotFoundException("Anomaly $id not found")
     }

--- a/openbank-flaky-test-hunter/src/main/kotlin/com/openbank/flakytest/infrastructure/rest/FlakyTestResource.kt
+++ b/openbank-flaky-test-hunter/src/main/kotlin/com/openbank/flakytest/infrastructure/rest/FlakyTestResource.kt
@@ -25,21 +25,21 @@ import kotlinx.coroutines.runBlocking
 class FlakyTestResource(private val runCheck: RunFlakyTestCheckUseCase, private val getFindings: GetFindingsUseCase) {
     @POST
     @Path("/check/trigger")
-    @RolesAllowed("platform-admin")
+    @RolesAllowed("ROLE_ADMIN")
     fun triggerCheck(): FlakyTestReport = runBlocking {
         runCheck.run(RunTrigger.OPERATOR_MANUAL)
     }
 
     @GET
     @Path("/findings")
-    @RolesAllowed("platform-admin", "platform-viewer")
+    @RolesAllowed("ROLE_ADMIN", "ROLE_VIEWER")
     fun getActiveFindings(): List<FlakyTestFinding> = runBlocking {
         getFindings.getActive()
     }
 
     @GET
     @Path("/findings/{id}")
-    @RolesAllowed("platform-admin", "platform-viewer")
+    @RolesAllowed("ROLE_ADMIN", "ROLE_VIEWER")
     fun getFinding(@PathParam("id") id: String): FlakyTestFinding = runBlocking {
         getFindings.getById(id) ?: throw NotFoundException("Finding $id not found")
     }

--- a/openbank-governance-auditor/src/main/kotlin/com/openbank/govaudit/infrastructure/rest/GovernanceAuditorResource.kt
+++ b/openbank-governance-auditor/src/main/kotlin/com/openbank/govaudit/infrastructure/rest/GovernanceAuditorResource.kt
@@ -28,21 +28,21 @@ class GovernanceAuditorResource(
 ) {
     @POST
     @Path("/audit/trigger")
-    @RolesAllowed("platform-admin")
+    @RolesAllowed("ROLE_ADMIN")
     fun triggerAudit(): GovernanceAuditReport = runBlocking {
         runAudit.run(RunTrigger.OPERATOR_MANUAL)
     }
 
     @GET
     @Path("/findings")
-    @RolesAllowed("platform-admin", "platform-viewer")
+    @RolesAllowed("ROLE_ADMIN", "ROLE_VIEWER")
     fun getActiveFindings(): List<GovernanceFinding> = runBlocking {
         getFindings.getActive()
     }
 
     @GET
     @Path("/findings/{id}")
-    @RolesAllowed("platform-admin", "platform-viewer")
+    @RolesAllowed("ROLE_ADMIN", "ROLE_VIEWER")
     fun getFinding(@PathParam("id") id: String): GovernanceFinding = runBlocking {
         getFindings.getById(id) ?: throw NotFoundException("Finding $id not found")
     }

--- a/openbank-libs-domain/src/main/kotlin/com/openbank/libs/security/Roles.kt
+++ b/openbank-libs-domain/src/main/kotlin/com/openbank/libs/security/Roles.kt
@@ -10,9 +10,18 @@ package com.openbank.libs.security
  * `@RolesAllowed` requires compile-time string constants, so these are `const val` rather
  * than enum entries. The companion `Role.values()` lets policy/audit code enumerate them.
  *
- * Mapping to JWT claims: each role appears in `resource_access.openbank-services.roles`
- * as the bare suffix (`admin`, `operator`, …); Quarkus OIDC strips the `ROLE_` prefix and
- * we add it back at the boundary, so use the constants below — not raw strings.
+ * Mapping to JWT claims: these are REALM roles, and a token carries them verbatim under
+ * `realm_access.roles` — `ROLE_ADMIN`, not `admin`. Nothing strips or re-adds the prefix: the
+ * realm templates declare no client roles at all, and there is no `SecurityIdentityAugmentor`
+ * anywhere in the fleet (only customer-edge sets `role-claim-path`, and it points at
+ * `realm_access/roles`, which is already the default). An earlier version of this KDoc claimed
+ * the roles arrived as bare suffixes under `resource_access.openbank-services.roles` and were
+ * re-prefixed at the boundary; that was never true, and it is the belief that produced three
+ * parallel invented vocabularies (`openbank-employee`, `platform-admin`, `SERVICE`) at 39
+ * `@RolesAllowed` sites that answered 403 to every caller (issue #2404).
+ *
+ * Use the constants below, not raw strings. `.github/scripts/check-roles-allowed-realm.py`
+ * enforces that every `@RolesAllowed` name exists in a realm.
  */
 object Roles {
     /** Full administrative access to all resources. Reserved for break-glass scenarios. */
@@ -51,7 +60,30 @@ object Roles {
     /** Payment ops: initiation, recall, return, clearing reconciliation. */
     const val PAYMENTS = "ROLE_PAYMENTS"
 
-    /** Service-to-service authentication. Issued to other openbank services via [ServiceTokenProvider]. */
+    /**
+     * Machine-to-machine API access — the realm's own name for what a service-account token
+     * should carry (`ROLE_API`, "Machine-to-machine API access" in realm-template.json).
+     *
+     * NOTE: no service account is granted this role today, so an endpoint gated on it alone is
+     * still unreachable until someone grants it in Keycloak (issue #2404). That is a deliberate,
+     * visible gap rather than the invisible one [SERVICE] created.
+     */
+    const val API = "ROLE_API"
+
+    /**
+     * Service-to-service authentication.
+     *
+     * DEAD: no realm in this platform declares `ROLE_SERVICE` — not the staff realm, not the
+     * customers realm — so no token can ever carry it and this name authorizes nobody. It appears
+     * at ~150 `@RolesAllowed` sites across ~29 services, always alongside a live role, so humans
+     * still get in and only the M2M caller it was reserved for is silently denied (issue #2404).
+     * The JWT-role twin of the unreachable `principal.type == "SERVICE"` rego rules that
+     * `check-no-service-principal-type.sh` already forbids.
+     *
+     * Use [API] for new M2M grants. Retiring the existing sites is a per-service decision — grant
+     * the role or delete the path — not a mechanical rename, so this constant stays until they
+     * are cleared rather than breaking 29 services' compilation today.
+     */
     const val SERVICE = "ROLE_SERVICE"
 
     /** All canonical roles, in declaration order. Use for policy/audit enumeration. */
@@ -66,6 +98,7 @@ object Roles {
         KYC_OPENER,
         KYC_REVIEWER,
         PAYMENTS,
+        API,
         SERVICE,
     )
 }

--- a/openbank-pid-service/src/main/kotlin/com/openbank/pid/infrastructure/rest/PartyResource.kt
+++ b/openbank-pid-service/src/main/kotlin/com/openbank/pid/infrastructure/rest/PartyResource.kt
@@ -5,6 +5,7 @@
 package com.openbank.pid.infrastructure.rest
 
 import com.openbank.libs.authz.Authorize
+import com.openbank.libs.security.Roles
 import com.openbank.pid.application.port.`in`.AddRelationshipCommand
 import com.openbank.pid.application.port.`in`.ChangePartyStatusCommand
 import com.openbank.pid.application.port.`in`.CreatePartyCommand
@@ -202,7 +203,7 @@ class PartyResource(
      */
     @GET
     @Path("/pid/resolve")
-    @RolesAllowed("openbank-service")
+    @RolesAllowed(Roles.API)
     @Authorize(action = "pid.resolve")
     @Operation(
         summary = "Resolve partyId from a pre-computed RČ blind index (ADR-0072, internal M2M)",
@@ -243,7 +244,7 @@ class PartyResource(
     }
 
     @POST
-    @RolesAllowed("openbank-employee", "openbank-admin")
+    @RolesAllowed(Roles.OPERATOR, Roles.ADMIN)
     @Operation(summary = "Create a new party (unified identity)")
     suspend fun createParty(request: CreatePartyRequest): Response {
         val party = createPartyUseCase.createParty(
@@ -268,14 +269,14 @@ class PartyResource(
 
     @GET
     @Path("/{id}")
-    @RolesAllowed("openbank-employee", "openbank-admin", "openbank-customer")
+    @RolesAllowed(Roles.OPERATOR, Roles.ADMIN)
     @Operation(summary = "Get party by internal ID")
     suspend fun getById(@PathParam("id") id: UUID): Response =
         Response.ok(getPartyUseCase.getById(id).toResponse()).build()
 
     @GET
     @Path("/by-external-id")
-    @RolesAllowed("openbank-employee", "openbank-admin")
+    @RolesAllowed(Roles.OPERATOR, Roles.ADMIN)
     @Operation(summary = "Get party by external ID (bankID sub, ROB AIFO, etc.)")
     suspend fun getByExternalId(
         @QueryParam("type") type: ExternalIdType,
@@ -283,7 +284,7 @@ class PartyResource(
     ): Response = Response.ok(getPartyUseCase.getByExternalId(type, value).toResponse()).build()
 
     @GET
-    @RolesAllowed("openbank-employee", "openbank-admin")
+    @RolesAllowed(Roles.OPERATOR, Roles.ADMIN)
     @Operation(summary = "Search parties")
     suspend fun search(
         @QueryParam("givenName") givenName: String?,
@@ -310,7 +311,7 @@ class PartyResource(
 
     @POST
     @Path("/{id}/sync/bankid")
-    @RolesAllowed("openbank-employee", "openbank-admin")
+    @RolesAllowed(Roles.OPERATOR, Roles.ADMIN)
     @Operation(summary = "Sync party attributes from bankID")
     suspend fun syncFromBankId(@PathParam("id") id: UUID, request: SyncFromBankIdRequest): Response {
         val party = updatePartyUseCase.syncFromBankId(
@@ -336,7 +337,7 @@ class PartyResource(
 
     @POST
     @Path("/{id}/sync/rob")
-    @RolesAllowed("openbank-employee", "openbank-admin")
+    @RolesAllowed(Roles.OPERATOR, Roles.ADMIN)
     @Operation(summary = "Sync address from ROB (Registr obyvatel)")
     suspend fun syncFromRob(@PathParam("id") id: UUID, request: SyncFromRobRequest): Response {
         val party = updatePartyUseCase.syncFromRob(
@@ -353,7 +354,7 @@ class PartyResource(
 
     @PATCH
     @Path("/{id}/contact")
-    @RolesAllowed("openbank-employee", "openbank-admin", "openbank-customer")
+    @RolesAllowed(Roles.OPERATOR, Roles.ADMIN)
     @Operation(summary = "Update contact attributes")
     suspend fun updateContact(@PathParam("id") id: UUID, request: UpdateContactRequest): Response {
         val party = updatePartyUseCase.updateContact(
@@ -370,7 +371,7 @@ class PartyResource(
 
     @PUT
     @Path("/{id}/kyc")
-    @RolesAllowed("openbank-employee", "openbank-admin")
+    @RolesAllowed(Roles.OPERATOR, Roles.ADMIN)
     @Operation(summary = "Update KYC/AML attributes")
     suspend fun updateKyc(@PathParam("id") id: UUID, request: UpdateKycRequest): Response {
         val party = updatePartyUseCase.updateKyc(
@@ -387,7 +388,7 @@ class PartyResource(
 
     @PATCH
     @Path("/{id}/status")
-    @RolesAllowed("openbank-admin")
+    @RolesAllowed(Roles.ADMIN)
     @Authorize(action = "party.changeStatus", resource = "#id")
     @Operation(summary = "Change party status (suspend, terminate, etc.)")
     suspend fun changeStatus(@PathParam("id") id: UUID, request: ChangeStatusRequest): Response {
@@ -403,7 +404,7 @@ class PartyResource(
 
     @PATCH
     @Path("/{id}/case")
-    @RolesAllowed("openbank-employee", "openbank-admin")
+    @RolesAllowed(Roles.OPERATOR, Roles.ADMIN)
     @Operation(summary = "Transition PID verification case lifecycle")
     suspend fun transitionCase(@PathParam("id") id: UUID, request: TransitionCaseRequest): Response {
         val party = updatePartyUseCase.transitionCase(
@@ -421,7 +422,7 @@ class PartyResource(
 
     @POST
     @Path("/{id}/relationships")
-    @RolesAllowed("openbank-employee", "openbank-admin")
+    @RolesAllowed(Roles.OPERATOR, Roles.ADMIN)
     @Operation(summary = "Add a role/relationship to a party")
     suspend fun addRelationship(@PathParam("id") id: UUID, request: AddRelationshipRequest): Response {
         val rel = manageRelationshipUseCase.addRelationship(
@@ -438,7 +439,7 @@ class PartyResource(
 
     @DELETE
     @Path("/{id}/relationships/{relationshipId}")
-    @RolesAllowed("openbank-employee", "openbank-admin")
+    @RolesAllowed(Roles.OPERATOR, Roles.ADMIN)
     @Operation(summary = "Terminate a party relationship/role")
     suspend fun terminateRelationship(
         @PathParam("id") id: UUID,

--- a/openbank-release-steward/src/main/kotlin/com/openbank/releasesteward/infrastructure/rest/ReleaseStewardResource.kt
+++ b/openbank-release-steward/src/main/kotlin/com/openbank/releasesteward/infrastructure/rest/ReleaseStewardResource.kt
@@ -31,7 +31,7 @@ class ReleaseStewardResource(
     // thread, not the event loop. It touches no reactive DB session, so runBlocking is fine here.
     @POST
     @Path("/check/trigger")
-    @RolesAllowed("platform-admin")
+    @RolesAllowed("ROLE_ADMIN")
     @Blocking
     fun triggerCheck(): ReleaseStewardReport = runBlocking {
         runCheck.run(RunTrigger.OPERATOR_MANUAL)
@@ -41,12 +41,12 @@ class ReleaseStewardResource(
     // Kotlin suspend resource methods on one, so the session resolves correctly.
     @GET
     @Path("/findings")
-    @RolesAllowed("platform-admin", "platform-viewer")
+    @RolesAllowed("ROLE_ADMIN", "ROLE_VIEWER")
     suspend fun getActiveFindings(): List<ReleaseStewardFinding> = getFindings.getActive()
 
     @GET
     @Path("/findings/{id}")
-    @RolesAllowed("platform-admin", "platform-viewer")
+    @RolesAllowed("ROLE_ADMIN", "ROLE_VIEWER")
     suspend fun getFinding(@PathParam("id") id: String): ReleaseStewardFinding =
         getFindings.getById(id) ?: throw NotFoundException("Finding $id not found")
 }


### PR DESCRIPTION
## What

Closes #2404. Three invented role vocabularies, none of which any Keycloak realm issues, gated **39 endpoints across 9 services** — every one answering 403 to every caller. Fixed, plus an enforced gate so the 40th cannot happen.

## The defect

`@RolesAllowed` takes a compile-time string and nothing compared it to the realm. A name that exists nowhere does not fail loudly; it just never matches.

| vocabulary | services | sites | in any realm? |
|---|---|---|---|
| `openbank-employee` / `openbank-admin` / `openbank-customer` / `openbank-service` | pid-service | 13 | no |
| `platform-admin` / `platform-viewer` | devops-agent, release-steward, governance-auditor, flaky-test-hunter, finops-agent, docs-truth-agent, authz-policy-auditor, control-liveness-sentinel | 26 | no |
| `SERVICE` / `ADMIN` / `OPERATOR` | finrep-service | 2 | no — fixed already in #2403 |

The staff realm issues `ROLE_ADMIN`, `ROLE_OPERATOR`, `ROLE_VIEWER`, `ROLE_API`, `ROLE_KYC*`, `ROLE_COMPLIANCE`, `ROLE_AUDITOR`, `ROLE_SUPERVISOR`, `ROLE_PAYMENTS`; the customers realm issues `ROLE_CUSTOMER`. There are **no client roles anywhere** and **no `SecurityIdentityAugmentor`**, so a token carries those names verbatim from `realm_access.roles`.

Two details worth flagging:

- **pid-service already used `ROLE_*` at 9 other sites in the same file** — so this is a leftover vocabulary, not a second deliberate scheme.
- **The `platform-*` set is identical across all eight agent services**, including on `authz-policy-auditor` — the service that exists to find authorization defects.

## Mapping (approved before any code was written)

`openbank-admin`→`ROLE_ADMIN` · `openbank-employee`→`ROLE_OPERATOR` · `openbank-customer`→**dropped** · `openbank-service`→`ROLE_API` · `platform-admin`→`ROLE_ADMIN` · `platform-viewer`→`ROLE_VIEWER`

`openbank-customer` is dropped rather than translated: pid-service validates against the **staff** realm, where no customer principal can authenticate at all — customers reach party data via customer-edge against the customers realm. Dropping it removes a name that never matched, not access.

**Recorded, not papered over:** `ROLE_API` is granted to no service account today, so pid's `/pid/resolve` stays unreachable for M2M until someone grants it in Keycloak. Deliberately not widened to `ROLE_OPERATOR`, which every human operator also holds — the JWT-role twin of the over-grant trap already documented on the rego side.

`Roles.kt` gains `API` (realm declares `ROLE_API`; libs had no constant) and documents `SERVICE` as dead. Its KDoc also claimed roles arrive as bare suffixes under `resource_access.openbank-services.roles` and get re-prefixed at the boundary — never true, and the most likely origin of all three vocabularies.

## The gate

`check-roles-allowed-realm.py`, **enforced** in `Validate manifests` from day one because the tree is clean as of this PR:

- **HARD** — every role in an `@RolesAllowed` absent from every realm ⇒ unreachable by construction. A fact, not a judgement, so it blocks.
- **WARN** — one dead name in an otherwise-live list: **163 sites** (`ROLE_SERVICE` ×152, `ROLE_CREDIT_RISK` ×9, `ROLE_LENDING_OFFICER` ×6). Humans get in; only the caller the dead name was reserved for is denied. Clearing them is a per-service decision, so it warns rather than blocks.

**Comments are stripped first, and that is load-bearing.** #2403 fixed finrep by writing a KDoc that *quotes* the broken annotation; the first draft of this script flagged that comment and reported finrep as still broken after it was fixed. A guard that cannot tell code from prose about code manufactures its own findings — same class as the readiness scorer that graded services on the word "contract" appearing in a comment (#2291). The stripper mirrors Kotlin's **nesting** block comments.

**Why not a test.** `@TestSecurity` mints whatever role string it is handed, so a test written from the annotation matches the annotation and passes against a resource that 403s in production. finrep's did exactly that for the life of the service. A test that supplies both sides of the comparison cannot fail — the check has to be against the realm.

## Verification

- `:openbank-libs-domain:build`, and `ktlintCheck` + `detekt` + `test` on pid-service and all eight agent services — green on JDK 25.
- Gate falsified **both** directions before trusting it: reintroducing one `platform-admin` → exit 1 with exactly 1 error; adding a *comment* that mentions `@RolesAllowed("platform-admin")` → exit 0; restored → `346 site(s) checked against 13 role(s) from customers-realm-template.json, realm-template.json; 0 unreachable, 163 advisory`.
- `actionlint` / `yamllint` under the CI job's own config: identical finding sets to `origin/main`.

## Follow-up

The 163 advisory sites need a decision per service — grant `ROLE_SERVICE`/`ROLE_CREDIT_RISK`/`ROLE_LENDING_OFFICER` in Keycloak, or delete the paths they were reserved for. `ROLE_SERVICE` alone spans 152 sites in ~29 services, so it is a sweep, not a rename. Filing separately.

## Linked issues

Closes #2404
