### PR TITLE
test(sca): cover rest mappers, device entity & push sender; raise floor 45 → 82

### DIFF
--- a/openbank-sca-service/build.gradle.kts
+++ b/openbank-sca-service/build.gradle.kts
@@ -63,7 +63,7 @@ kover {
         verify {
             rule {
                 bound {
-                    minValue = 45
+                    minValue = 82
                     coverageUnits = kotlinx.kover.gradle.plugin.dsl.CoverageUnit.LINE
                 }
             }

--- a/openbank-sca-service/src/test/kotlin/com/openbank/sca/infrastructure/LoggingNotificationSenderTest.kt
+++ b/openbank-sca-service/src/test/kotlin/com/openbank/sca/infrastructure/LoggingNotificationSenderTest.kt
@@ -1,0 +1,107 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright (c) OpenBank contributors. Licensed under the Apache License, Version 2.0.
+// See LICENSE in the repository root or https://www.apache.org/licenses/LICENSE-2.0 for details.
+
+package com.openbank.sca.infrastructure
+
+import com.fasterxml.jackson.databind.ObjectMapper
+import io.mockk.mockk
+import io.mockk.slot
+import io.mockk.verify
+import io.smallrye.reactive.messaging.kafka.Record
+import kotlinx.coroutines.runBlocking
+import org.assertj.core.api.Assertions.assertThat
+import org.eclipse.microprofile.reactive.messaging.Emitter
+import org.junit.jupiter.api.AfterEach
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Test
+import java.util.UUID
+import java.util.logging.Handler
+import java.util.logging.Level
+import java.util.logging.LogRecord
+import java.util.logging.Logger
+
+/**
+ * The push-notification sender (#4) is how a party learns there is a payment to approve — an
+ * un-emitted or malformed SCA_APPROVAL request means the approve-on-device flow silently stalls.
+ * It was 0% covered. Verifies the emitted contract (channel/template/recipient) and that the
+ * CWE-117 log-injection guard actually neutralises CR/LF in the caller-supplied message before it
+ * reaches the log line (the emitted event deliberately carries the raw message; only the log is
+ * sanitised, so the guard can only be observed on the captured log record).
+ */
+class LoggingNotificationSenderTest {
+
+    private val objectMapper = ObjectMapper()
+    private val emitter = mockk<Emitter<Record<String, String>>>(relaxed = true)
+    private val sender = LoggingNotificationSender(objectMapper, emitter)
+
+    private val captured = mutableListOf<LogRecord>()
+    private val captureHandler = object : Handler() {
+        override fun publish(record: LogRecord) {
+            captured += record
+        }
+        override fun flush() = Unit
+        override fun close() = Unit
+    }
+    private val senderLogger = Logger.getLogger(LoggingNotificationSender::class.java.name)
+
+    @BeforeEach
+    fun attachHandler() {
+        senderLogger.level = Level.ALL
+        senderLogger.addHandler(captureHandler)
+    }
+
+    @AfterEach
+    fun detachHandler() {
+        senderLogger.removeHandler(captureHandler)
+    }
+
+    @Test
+    fun `sendPushNotification emits an SCA_APPROVAL push request keyed by partyId`() {
+        val partyId = UUID.randomUUID()
+        val challengeId = UUID.randomUUID()
+        val slot = slot<Record<String, String>>()
+
+        runBlocking { sender.sendPushNotification(partyId, challengeId, "Approve payment of 250 EUR") }
+
+        verify { emitter.send(capture(slot)) }
+        val record = slot.captured
+        assertThat(record.key()).isEqualTo(partyId.toString())
+
+        val payload = objectMapper.readTree(record.value())
+        assertThat(payload["partyId"].asText()).isEqualTo(partyId.toString())
+        assertThat(payload["channel"].asText()).isEqualTo("PUSH")
+        assertThat(payload["template"].asText()).isEqualTo("SCA_APPROVAL")
+        assertThat(payload["recipient"].asText()).isEqualTo(partyId.toString())
+        assertThat(payload["variables"]["detail"].asText()).isEqualTo("Approve payment of 250 EUR")
+    }
+
+    @Test
+    fun `the log line strips CR-LF from the caller-supplied message (CWE-117 guard)`() {
+        val partyId = UUID.randomUUID()
+
+        runBlocking {
+            sender.sendPushNotification(partyId, UUID.randomUUID(), "line1\nFORGED admin=true\r\nline2")
+        }
+
+        // The message flows into the log line as a parameter; the guard must have replaced every
+        // CR/LF with '_' so an attacker cannot forge extra log lines. Render message + params and
+        // assert the forged content survives (message passed through) but not as separate lines.
+        val logRecord = captured.single { it.message.contains("PUSH") }
+        val rendered = logRecord.message + " " + (logRecord.parameters?.joinToString(" ") ?: "")
+        assertThat(rendered).contains("line1_FORGED admin=true")
+        assertThat(rendered).doesNotContain("\n").doesNotContain("\r")
+    }
+
+    @Test
+    fun `sendPushNotification still emits the raw message on the event despite log sanitisation`() {
+        val partyId = UUID.randomUUID()
+        val slot = slot<Record<String, String>>()
+
+        runBlocking { sender.sendPushNotification(partyId, UUID.randomUUID(), "raw\nmessage") }
+
+        verify { emitter.send(capture(slot)) }
+        val payload = objectMapper.readTree(slot.captured.value())
+        assertThat(payload["variables"]["detail"].asText()).isEqualTo("raw\nmessage")
+    }
+}

--- a/openbank-sca-service/src/test/kotlin/com/openbank/sca/infrastructure/persistence/entity/EnrolledDeviceEntityTest.kt
+++ b/openbank-sca-service/src/test/kotlin/com/openbank/sca/infrastructure/persistence/entity/EnrolledDeviceEntityTest.kt
@@ -1,0 +1,56 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright (c) OpenBank contributors. Licensed under the Apache License, Version 2.0.
+// See LICENSE in the repository root or https://www.apache.org/licenses/LICENSE-2.0 for details.
+
+package com.openbank.sca.infrastructure.persistence.entity
+
+import com.openbank.sca.domain.model.EnrolledDevice
+import com.openbank.sca.domain.model.SignatureAlgorithm
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.Test
+import java.time.OffsetDateTime
+import java.util.UUID
+
+/**
+ * The enrolled-device entity mapping was 0% covered. `fromDomain`/`toDomain` is the only place the
+ * device public key or credential id can be silently dropped on a DB round-trip — and a dropped
+ * public key means a valid device assertion can no longer be verified. Pure mapping, no DB.
+ */
+class EnrolledDeviceEntityTest {
+
+    @Test
+    fun `device survives a fromDomain-toDomain round trip`() {
+        val device = EnrolledDevice(
+            id = UUID.randomUUID(),
+            partyId = UUID.randomUUID(),
+            credentialId = "cred-xyz",
+            publicKeySpkiB64 = "MFkwEwYHKoZIzj0CAQ...",
+            algorithm = SignatureAlgorithm.ES256,
+            createdAt = OffsetDateTime.parse("2026-07-25T08:00:00Z"),
+        )
+
+        val restored = EnrolledDeviceEntity.fromDomain(device).toDomain()
+
+        assertThat(restored).isEqualTo(device)
+    }
+
+    @Test
+    fun `fromDomain copies each column`() {
+        val device = EnrolledDevice(
+            partyId = UUID.randomUUID(),
+            credentialId = "cred-1",
+            publicKeySpkiB64 = "spki",
+            algorithm = SignatureAlgorithm.ED25519,
+            createdAt = OffsetDateTime.parse("2026-07-25T08:00:00Z"),
+        )
+
+        val entity = EnrolledDeviceEntity.fromDomain(device)
+
+        assertThat(entity.id).isEqualTo(device.id)
+        assertThat(entity.partyId).isEqualTo(device.partyId)
+        assertThat(entity.credentialId).isEqualTo("cred-1")
+        assertThat(entity.publicKeySpki).isEqualTo("spki")
+        assertThat(entity.algorithm).isEqualTo(SignatureAlgorithm.ED25519)
+        assertThat(entity.createdAt).isEqualTo(device.createdAt)
+    }
+}

--- a/openbank-sca-service/src/test/kotlin/com/openbank/sca/infrastructure/rest/ScaExceptionMapperTest.kt
+++ b/openbank-sca-service/src/test/kotlin/com/openbank/sca/infrastructure/rest/ScaExceptionMapperTest.kt
@@ -1,0 +1,133 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright (c) OpenBank contributors. Licensed under the Apache License, Version 2.0.
+// See LICENSE in the repository root or https://www.apache.org/licenses/LICENSE-2.0 for details.
+
+package com.openbank.sca.infrastructure.rest
+
+import com.openbank.libs.api.error.ApiError
+import com.openbank.libs.api.error.ErrorCode
+import com.openbank.sca.application.usecase.CredentialAlreadyEnrolledException
+import com.openbank.sca.application.usecase.DeviceNotEnrolledException
+import com.openbank.sca.application.usecase.DeviceOwnershipMismatchException
+import com.openbank.sca.application.usecase.InvalidDeviceAssertionException
+import com.openbank.sca.application.usecase.ScaChallengeAlreadyConsumedException
+import com.openbank.sca.application.usecase.ScaChallengeExpiredException
+import com.openbank.sca.application.usecase.ScaChallengeMaxAttemptsException
+import com.openbank.sca.application.usecase.ScaChallengeNotApprovedException
+import com.openbank.sca.application.usecase.ScaChallengeNotAwaitingException
+import com.openbank.sca.application.usecase.ScaChallengeNotFoundException
+import com.openbank.sca.application.usecase.ScaChallengePartyMismatchException
+import com.openbank.sca.application.usecase.ScaDynamicLinkingMismatchException
+import com.openbank.sca.application.usecase.ScaVerificationFailedException
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.Test
+import java.util.UUID
+
+/**
+ * Every SCA exception → HTTP mapper is an authorization/state boundary: the wrong status (or a
+ * leaked exception message) on a money-path auth service changes what the caller does next — a 404
+ * masquerading as a 409 could turn a genuine "already consumed" replay into a silent retry. These
+ * mappers were entirely uncovered, so the status/body contract went unverified.
+ */
+class ScaExceptionMapperTest {
+
+    private val id: UUID = UUID.randomUUID()
+
+    private fun bodyOf(response: jakarta.ws.rs.core.Response): ApiError = response.entity as ApiError
+
+    @Test
+    fun `not-found maps to 404 with NOT_FOUND and carries the exception message`() {
+        val ex = ScaChallengeNotFoundException(id)
+        val response = ScaNotFoundMapper().toResponse(ex)
+
+        assertThat(response.status).isEqualTo(404)
+        val body = bodyOf(response)
+        assertThat(body.code).isEqualTo(ErrorCode.NOT_FOUND.code)
+        assertThat(body.message).isEqualTo(ex.message)
+        assertThat(body.traceId).isNotBlank()
+    }
+
+    @Test
+    fun `expired maps to 422 VALIDATION_ERROR`() {
+        val response = ScaExpiredMapper().toResponse(ScaChallengeExpiredException(id))
+        assertThat(response.status).isEqualTo(422)
+        assertThat(bodyOf(response).code).isEqualTo(ErrorCode.VALIDATION_ERROR.code)
+    }
+
+    @Test
+    fun `max-attempts maps to 429 VALIDATION_ERROR`() {
+        val response = ScaMaxAttemptsMapper().toResponse(ScaChallengeMaxAttemptsException(id))
+        assertThat(response.status).isEqualTo(429)
+        assertThat(bodyOf(response).code).isEqualTo(ErrorCode.VALIDATION_ERROR.code)
+    }
+
+    @Test
+    fun `verification-failed maps to 401 UNAUTHORIZED`() {
+        val response = ScaVerificationFailedMapper().toResponse(ScaVerificationFailedException(id))
+        assertThat(response.status).isEqualTo(401)
+        assertThat(bodyOf(response).code).isEqualTo(ErrorCode.UNAUTHORIZED.code)
+    }
+
+    @Test
+    fun `not-awaiting maps to 409 VALIDATION_ERROR`() {
+        val response = ScaNotAwaitingMapper().toResponse(ScaChallengeNotAwaitingException(id))
+        assertThat(response.status).isEqualTo(409)
+        assertThat(bodyOf(response).code).isEqualTo(ErrorCode.VALIDATION_ERROR.code)
+    }
+
+    @Test
+    fun `device-not-enrolled maps to 404 NOT_FOUND`() {
+        val response = DeviceNotEnrolledMapper().toResponse(DeviceNotEnrolledException("cred-1"))
+        assertThat(response.status).isEqualTo(404)
+        assertThat(bodyOf(response).code).isEqualTo(ErrorCode.NOT_FOUND.code)
+    }
+
+    @Test
+    fun `credential-conflict maps to 409 CONFLICT`() {
+        val response = DeviceCredentialConflictMapper().toResponse(CredentialAlreadyEnrolledException("cred-1"))
+        assertThat(response.status).isEqualTo(409)
+        assertThat(bodyOf(response).code).isEqualTo(ErrorCode.VALIDATION_ERROR.code)
+    }
+
+    @Test
+    fun `device-ownership-mismatch maps to 403 FORBIDDEN`() {
+        val response = DeviceOwnershipMismatchMapper().toResponse(DeviceOwnershipMismatchException("cred-1"))
+        assertThat(response.status).isEqualTo(403)
+        assertThat(bodyOf(response).code).isEqualTo(ErrorCode.FORBIDDEN.code)
+    }
+
+    @Test
+    fun `invalid-device-assertion maps to 401 UNAUTHORIZED`() {
+        val response = InvalidDeviceAssertionMapper().toResponse(InvalidDeviceAssertionException(id))
+        assertThat(response.status).isEqualTo(401)
+        assertThat(bodyOf(response).code).isEqualTo(ErrorCode.UNAUTHORIZED.code)
+    }
+
+    @Test
+    fun `not-approved maps to the VALIDATION_ERROR status`() {
+        val response = ScaNotApprovedMapper().toResponse(ScaChallengeNotApprovedException(id))
+        assertThat(response.status).isEqualTo(ErrorCode.VALIDATION_ERROR.httpStatus)
+        assertThat(bodyOf(response).code).isEqualTo(ErrorCode.VALIDATION_ERROR.code)
+    }
+
+    @Test
+    fun `already-consumed maps to 409 CONFLICT`() {
+        val response = ScaAlreadyConsumedMapper().toResponse(ScaChallengeAlreadyConsumedException(id))
+        assertThat(response.status).isEqualTo(409)
+        assertThat(bodyOf(response).code).isEqualTo(ErrorCode.VALIDATION_ERROR.code)
+    }
+
+    @Test
+    fun `party-mismatch maps to 403 FORBIDDEN`() {
+        val response = ScaPartyMismatchMapper().toResponse(ScaChallengePartyMismatchException(id))
+        assertThat(response.status).isEqualTo(403)
+        assertThat(bodyOf(response).code).isEqualTo(ErrorCode.FORBIDDEN.code)
+    }
+
+    @Test
+    fun `dynamic-linking-mismatch maps to 409 CONFLICT`() {
+        val response = ScaDynamicLinkingMismatchMapper().toResponse(ScaDynamicLinkingMismatchException(id))
+        assertThat(response.status).isEqualTo(409)
+        assertThat(bodyOf(response).code).isEqualTo(ErrorCode.VALIDATION_ERROR.code)
+    }
+}

--- a/openbank-sca-service/src/test/kotlin/com/openbank/sca/infrastructure/rest/ScaResponseMapperTest.kt
+++ b/openbank-sca-service/src/test/kotlin/com/openbank/sca/infrastructure/rest/ScaResponseMapperTest.kt
@@ -1,0 +1,178 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright (c) OpenBank contributors. Licensed under the Apache License, Version 2.0.
+// See LICENSE in the repository root or https://www.apache.org/licenses/LICENSE-2.0 for details.
+
+package com.openbank.sca.infrastructure.rest
+
+import com.openbank.sca.domain.model.DeviceDecisionType
+import com.openbank.sca.domain.model.DynamicLinkingData
+import com.openbank.sca.domain.model.EnrolledDevice
+import com.openbank.sca.domain.model.ScaChallenge
+import com.openbank.sca.domain.model.ScaMethod
+import com.openbank.sca.domain.model.ScaPurpose
+import com.openbank.sca.domain.model.ScaStatus
+import com.openbank.sca.domain.model.SignatureAlgorithm
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.Test
+import java.time.OffsetDateTime
+import java.util.UUID
+
+/**
+ * The REST response DTOs are the wire contract the app and PSD2 TPPs read. Their `from()` mappers
+ * were uncovered, so a field silently dropped or mis-mapped (e.g. the pending-approval projection
+ * losing the creditor the customer must see before signing — RTS Art. 5 dynamic linking) would not
+ * fail any test. These are pure mapping assertions: no framework, no I/O.
+ */
+class ScaResponseMapperTest {
+
+    private val now: OffsetDateTime = OffsetDateTime.parse("2026-07-25T10:15:30Z")
+
+    @Test
+    fun `EnrolledDeviceResponse maps every field and stringifies the timestamp`() {
+        val device = EnrolledDevice(
+            id = UUID.randomUUID(),
+            partyId = UUID.randomUUID(),
+            credentialId = "cred-abc",
+            publicKeySpkiB64 = "spki-b64",
+            algorithm = SignatureAlgorithm.ES256,
+            createdAt = now,
+        )
+
+        val dto = EnrolledDeviceResponse.from(device)
+
+        assertThat(dto.id).isEqualTo(device.id)
+        assertThat(dto.partyId).isEqualTo(device.partyId)
+        assertThat(dto.credentialId).isEqualTo("cred-abc")
+        assertThat(dto.algorithm).isEqualTo(SignatureAlgorithm.ES256)
+        assertThat(dto.enrolledAt).isEqualTo(now.toString())
+    }
+
+    @Test
+    fun `ScaChallengeResponse maps status fields and null-safe timestamps`() {
+        val completed = now.plusMinutes(1)
+        val consumed = now.plusMinutes(2)
+        val challenge = ScaChallenge(
+            partyId = UUID.randomUUID(),
+            purpose = ScaPurpose.PAYMENT_INITIATION,
+            method = ScaMethod.BIOMETRIC,
+            status = ScaStatus.COMPLETED,
+            expiresAt = now.plusMinutes(5),
+            completedAt = completed,
+            consumedAt = consumed,
+            attemptCount = 2,
+            maxAttempts = 3,
+            createdAt = now,
+        )
+
+        val dto = ScaChallengeResponse.from(challenge)
+
+        assertThat(dto.id).isEqualTo(challenge.id)
+        assertThat(dto.status).isEqualTo(ScaStatus.COMPLETED)
+        assertThat(dto.expiresAt).isEqualTo(challenge.expiresAt.toString())
+        assertThat(dto.completedAt).isEqualTo(completed.toString())
+        assertThat(dto.consumedAt).isEqualTo(consumed.toString())
+        assertThat(dto.attemptCount).isEqualTo(2)
+        assertThat(dto.maxAttempts).isEqualTo(3)
+    }
+
+    @Test
+    fun `ScaChallengeResponse leaves optional timestamps null when the challenge is still pending`() {
+        val challenge = ScaChallenge(
+            partyId = UUID.randomUUID(),
+            purpose = ScaPurpose.LOGIN,
+            method = ScaMethod.TOTP,
+            expiresAt = now.plusMinutes(5),
+            createdAt = now,
+        )
+
+        val dto = ScaChallengeResponse.from(challenge)
+
+        assertThat(dto.completedAt).isNull()
+        assertThat(dto.consumedAt).isNull()
+        assertThat(dto.status).isEqualTo(ScaStatus.PENDING)
+    }
+
+    @Test
+    fun `PendingScaResponse surfaces the dynamic-linking data the customer approves`() {
+        val challenge = ScaChallenge(
+            partyId = UUID.randomUUID(),
+            purpose = ScaPurpose.PAYMENT_INITIATION,
+            method = ScaMethod.PUSH_NOTIFICATION,
+            expiresAt = now.plusMinutes(5),
+            dynamicLinkingData = DynamicLinkingData(
+                amount = "250.00",
+                currency = "EUR",
+                creditorIban = "CZ6508000000192000145399",
+                creditorName = "ACME s.r.o.",
+                reference = "invoice-42",
+            ),
+            createdAt = now,
+        )
+
+        val dto = PendingScaResponse.from(challenge)
+
+        assertThat(dto.amount).isEqualTo("250.00")
+        assertThat(dto.currency).isEqualTo("EUR")
+        assertThat(dto.creditorIban).isEqualTo("CZ6508000000192000145399")
+        assertThat(dto.creditorName).isEqualTo("ACME s.r.o.")
+        assertThat(dto.reference).isEqualTo("invoice-42")
+        assertThat(dto.createdAt).isEqualTo(now.toString())
+    }
+
+    @Test
+    fun `PendingScaResponse null-safely projects a challenge with no dynamic-linking data`() {
+        val challenge = ScaChallenge(
+            partyId = UUID.randomUUID(),
+            purpose = ScaPurpose.LOGIN,
+            method = ScaMethod.PUSH_NOTIFICATION,
+            expiresAt = now.plusMinutes(5),
+            dynamicLinkingData = null,
+            createdAt = now,
+        )
+
+        val dto = PendingScaResponse.from(challenge)
+
+        assertThat(dto.amount).isNull()
+        assertThat(dto.currency).isNull()
+        assertThat(dto.creditorIban).isNull()
+        assertThat(dto.creditorName).isNull()
+        assertThat(dto.reference).isNull()
+    }
+
+    @Test
+    fun `request DTOs carry their fields through the constructor`() {
+        val partyId = UUID.randomUUID()
+        val initiate = InitiateScaRequest(
+            partyId = partyId,
+            purpose = ScaPurpose.PAYMENT_INITIATION,
+            preferredMethod = ScaMethod.BIOMETRIC,
+            dynamicLinkingData = null,
+            redirectUrl = "https://app.example/return",
+        )
+        val verify = VerifyScaRequest(partyId = partyId, otp = "123456")
+        val enroll = EnrollDeviceRequest(
+            credentialId = "cred-1",
+            publicKey = "spki",
+            algorithm = SignatureAlgorithm.ED25519,
+        )
+        val decision = RecordDecisionRequest(
+            credentialId = "cred-1",
+            decision = DeviceDecisionType.APPROVED,
+            signature = "sig",
+        )
+        val consume = ConsumeScaRequest(
+            partyId = partyId,
+            amount = "10.00",
+            currency = "CZK",
+            creditor = "192000145399/0800",
+        )
+
+        assertThat(initiate.partyId).isEqualTo(partyId)
+        assertThat(initiate.redirectUrl).isEqualTo("https://app.example/return")
+        assertThat(verify.otp).isEqualTo("123456")
+        assertThat(enroll.algorithm).isEqualTo(SignatureAlgorithm.ED25519)
+        assertThat(decision.decision).isEqualTo(DeviceDecisionType.APPROVED)
+        assertThat(consume.creditor).isEqualTo("192000145399/0800")
+        assertThat(consume.documentSha256).isNull()
+    }
+}


### PR DESCRIPTION
## What

Follow-up to the now-closed #2416. Adds real unit coverage for the previously-untouched infrastructure boundary of `openbank-sca-service` (a **money-path** auth service), lifting line coverage **65.2% → ~84%**, and ratchets the kover line floor **45 → 82**.

## Tests added

| File | Covers | Why it matters |
|------|--------|----------------|
| `ScaExceptionMapperTest` | all 13 exception → HTTP mappers (status + `ApiError` body) | wrong status on an auth boundary changes caller behaviour — an "already consumed" replay mis-read as retryable |
| `ScaResponseMapperTest` | `EnrolledDeviceResponse` / `ScaChallengeResponse` / `PendingScaResponse` `from()` + request DTOs | pending-approval projection must surface the creditor the customer signs (RTS Art. 5 dynamic linking); null + present branches |
| `EnrolledDeviceEntityTest` | `fromDomain`/`toDomain` round-trip | only place a device public key can be silently dropped on a DB round-trip |
| `LoggingNotificationSenderTest` | `SCA_APPROVAL` push contract + **CWE-117 CR/LF log-injection guard, asserted via a captured log record** + raw-message-on-event contract | an un-emitted/malformed push silently stalls approve-on-device; the guard neutralises forged log lines |

## Floor = 82 (not 84)

Measured line coverage runs **84.2–85.0%** locally; the integration suite varies ~6 lines run-to-run, so 82 keeps ~2pp headroom rather than a flaky 1pp gate. Still a +37pp ratchet from 45, well above the other money-path floors (ledger 65, balance 67).

## How verified (JDK 25)

- `:openbank-sca-service:koverXmlReport` → 84.2% line (612/727), all new suites green
- `:openbank-sca-service:koverVerify` with floor 82 → passes with headroom
- `:openbank-sca-service:ktlintCheck` → green

Pure unit tests — no `src/main/**` change, so no `version.txt` bump. No API/DB/event change. Threat model unchanged.

## Pre-merge review

Independent second-model (Sonnet) review ran and initially returned NO-GO: the CWE-117 test was vacuous (asserted only that the emitter was called, would pass even with the guard deleted). **Fixed** — the guard is now asserted on the captured log record (CR/LF stripped, forged text neutralised, non-vacuous under mutation). Floor lowered 84 → 82 to remove the flaky-headroom risk the reviewer also flagged.

## Linked issues

N/A — governance hygiene (test coverage on a money-path service); no tracker item.

## Notes

Money-path ⇒ 2 approvals per ADR-0030. Repository impls (`ScaChallengeRepositoryImpl`, `ScaOutboxRepositoryImpl`) and Redis stores remain the largest uncovered blocks — they need a `@QuarkusTest` + Testcontainers DB pass, deliberately out of scope for this pure-unit PR (separate follow-up).

🤖 Generated with [Claude Code](https://claude.com/claude-code)