### PR TITLE
ci(gradle): self-heal a corrupted module cache before build

### DIFF
--- a/.github/scripts/heal-gradle-verification-failure.sh
+++ b/.github/scripts/heal-gradle-verification-failure.sh
@@ -1,0 +1,62 @@
+#!/usr/bin/env bash
+# Reactive, narrow fix for an interrupted-download-corrupted Gradle module
+# cache entry: an artifact whose .pom downloaded but whose .jar hash-dir
+# never got created (or a sibling daemon on a shared GRADLE_USER_HOME wrote
+# a partial one). Gradle reports this as a checksum/verification failure,
+# not a "file not found" — the message below is what --write-verification-metadata
+# style dependency verification prints when the artifact can't be fetched to
+# compare against the pinned checksum:
+#
+#   2 artifacts failed verification:
+#     - foo-1.2.3.jar (com.example:foo:1.2.3) from repository maven
+#
+# Deliberately narrow: this parses ONLY that exact message and removes ONLY
+# the named artifact/version's cache dir (forcing a clean re-resolve of just
+# that one dependency). It does NOT scan the cache for other "suspicious"
+# entries — an earlier version of this idea did a blanket scan and it turned
+# out most artifacts consumed only as a BOM/import or an unused transitive
+# dependency legitimately have a .pom with no .jar ever downloaded, so a
+# pom-without-jar heuristic alone is not a valid corruption signal and
+# produces false positives (do not resurrect that approach).
+#
+# Usage: heal-gradle-verification-failure.sh <path-to-build-log>
+# Exit 0 with HEALED>=1 if it removed at least one artifact's cache dir
+# (caller should retry the build). Exit 1 if the log doesn't match this
+# specific failure signature (some other problem — do not retry blindly).
+set -uo pipefail
+
+LOG="${1:-}"
+if [ -z "$LOG" ] || [ ! -f "$LOG" ]; then
+  echo "usage: $0 <path-to-build-log>" >&2
+  exit 1
+fi
+
+GRADLE_HOME="${GRADLE_USER_HOME:-$HOME/.gradle}"
+BASE="$GRADLE_HOME/caches/modules-2/files-2.1"
+
+healed=0
+
+while IFS= read -r coord; do
+  [ -z "$coord" ] && continue
+  group="${coord%%:*}"
+  rest="${coord#*:}"
+  artifact="${rest%%:*}"
+  version="${rest#*:}"
+  [ -z "$group" ] || [ -z "$artifact" ] || [ -z "$version" ] && continue
+
+  group_path=$(echo "$group" | tr -d '\r')
+  target="$BASE/$group_path/$artifact/$version"
+  if [ -d "$target" ]; then
+    echo "::warning::healing corrupted Gradle cache entry from verification failure: $group:$artifact:$version ($target)"
+    rm -rf "$target"
+    healed=$((healed + 1))
+  fi
+done < <(grep -oE '\([^:()]+:[^:()]+:[^:()]+\) from repository maven' "$LOG" | sed -E 's/^\(([^)]+)\).*/\1/')
+
+if [ "$healed" -eq 0 ]; then
+  echo "no Gradle dependency-verification failure found in $LOG — not a cache-corruption pattern, nothing healed"
+  exit 1
+fi
+
+echo "healed $healed artifact(s), retry the build"
+exit 0

--- a/.github/workflows/_service-ci.yml
+++ b/.github/workflows/_service-ci.yml
@@ -158,6 +158,38 @@ jobs:
             echo "GRADLE_USER_HOME=${HOME}/.gradle" >> "$GITHUB_ENV"
           fi
 
+      # Warm this service's Gradle dependency cache BEFORE "Build + test" runs, so an
+      # interrupted-download-corrupted module cache entry (a .pom downloaded with no
+      # matching .jar — a sibling job/daemon writing to the same shared/persistent
+      # GRADLE_USER_HOME concurrently: the ARC node-local hostPath cache, or the
+      # Mac/Hetzner persistent per-service home) is caught and healed HERE, not inside
+      # "Build + test". That step must run exactly once — it re-runs `test` differently
+      # depending on PUBLISH_RESULTS (the #1009 Pact-publish hazard documented below), so
+      # retrying it on failure risks a double/uncredentialed Pact Broker publish. This
+      # warm-up runs no test code and has no side effects, so it is safe to retry.
+      # `quarkusDependenciesBuild` resolves exactly the runtime classpath that failed with
+      # a dependency-verification error in the incident this guards against; it does not
+      # compile or run anything. Deliberately narrow: heal-gradle-verification-failure.sh
+      # only removes the exact artifact/version Gradle names in its own verification-failure
+      # message — it does not scan the cache for "suspicious" entries (an earlier, broader
+      # heuristic — pom present, jar absent — flagged legitimate BOM-only and
+      # never-downloaded transitive dependencies as corrupt; do not resurrect that).
+      - name: Warm Gradle dependency cache (self-heal corrupted entries)
+        continue-on-error: true
+        run: |
+          set +e
+          ./gradlew :${{ inputs.service }}:quarkusDependenciesBuild --console=plain > /tmp/gradle-warmup.log 2>&1
+          warmup_status=$?
+          if [ $warmup_status -ne 0 ]; then
+            cat /tmp/gradle-warmup.log
+            if .github/scripts/heal-gradle-verification-failure.sh /tmp/gradle-warmup.log; then
+              echo "retrying dependency warm-up after healing corrupted cache entries"
+              ./gradlew :${{ inputs.service }}:quarkusDependenciesBuild --console=plain
+            else
+              echo "::warning::dependency warm-up failed for a reason other than cache corruption — leaving it to the real Build step to report"
+            fi
+          fi
+
       # Normalize the Testcontainers Docker endpoint across the MIXED runner pool
       # (ARC dind + Hetzner + Mac mini/OrbStack — all serve Docker at the unix socket:
       # arc-runners.tf pins DOCKER_HOST=unix:///var/run/docker.sock, Hetzner uses the


### PR DESCRIPTION
## Summary

Self-heals a Gradle module-cache artifact left with a `.pom` but no `.jar` (interrupted
download on a shared/persistent `GRADLE_USER_HOME`) before the sensitive "Build + test"
step, instead of failing with a misleading dependency-verification error or a cryptic
`NoClassDefFoundError`.

## Type of change

- [ ] feat (new functionality)
- [ ] fix (bug fix)
- [ ] refactor (no behavior change)
- [ ] perf (performance)
- [ ] docs
- [x] chore (build / tooling)
- [ ] security (private until disclosed)
- [ ] breaking change

## Linked issues

N/A — CI hygiene fix for a locally-reproduced, non-security cache-corruption bug; not
filed as an issue since the fix landed the same day it was found.

## Changes

- Add a "Warm Gradle dependency cache" step to `_service-ci.yml`, before the
  Pact-publish-sensitive "Build + test" step (which must run exactly once — #1009 hazard
  — so it cannot itself be retried). Runs only `quarkusDependenciesBuild`: no tests, no
  side effects, safe to retry.
- Add `.github/scripts/heal-gradle-verification-failure.sh`: parses Gradle's own
  `Dependency verification failed ... (group:artifact:version) from repository maven`
  message and removes only the named artifact/version cache dir. Deliberately reactive,
  not a proactive scan of the whole cache — an earlier attempt at scanning for "pom
  present, jar absent" false-positived heavily (BOM-only and never-downloaded transitive
  dependencies are indistinguishable from real corruption by that signal alone).

## Definition of Done

- [ ] Hexagonal layering preserved (domain has zero framework imports). — N/A, no service code touched
- [ ] Unit tests added/updated. — N/A, CI workflow + shell script
- [ ] Integration tests added/updated (if service boundary involved). — N/A
- [ ] Contract tests updated (if public API changed). — N/A
- [ ] `./gradlew detekt ktlintCheck koverVerify build` passes. — N/A, no Kotlin changed
- [x] No new lint warnings. — `actionlint` clean, `bash -n` clean under both bash 5 and macOS bash 3.2
- [ ] OpenAPI spec regenerated (if REST API changed). — N/A
- [ ] Flyway migration added + rollback note (if DB changed). — N/A
- [ ] Avro schema versioned backward-compatibly (if event changed). — N/A
- [x] Docs updated (README, ADR if architectural). — inline comments explain the #1009 constraint and the false-positive trap; no ADR-level decision

## Testing

- Heal script unit-tested against a synthetic scratch `GRADLE_USER_HOME`: positive case
  (removes exactly the named corrupted artifact dirs), negative case (unrelated failure
  log → no-op, exit 1), already-healed case (target missing → no-op, exit 1).
- Warm-up step logic run locally (explicit bash) against the real repo on a healthy
  cache: succeeds, no healing triggered.
- `openbank-aml-service:quarkusBuild` re-verified green after all local testing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)