### PR TITLE
test(party): replay all four provider pacts before merge, not after

### DIFF
--- a/.github/scripts/check-pact-provider-replay.py
+++ b/.github/scripts/check-pact-provider-replay.py
@@ -50,17 +50,13 @@ PACTS = ROOT / "pacts"
 # reads it.
 KNOWN_UNCOVERED = {
     "pacts/openbank-account-service-openbank-balance-service.json",
-    "pacts/openbank-account-service-openbank-party-service.json",
     "pacts/openbank-balance-service-openbank-account-service.json",
     "pacts/openbank-consent-service-openbank-sca-service.json",
-    "pacts/openbank-kyc-service-openbank-party-service.json",
     # Landed 2026-07-25, after the #2327 audit counted 16 of 27: same three providers
     # (balance/transaction/party), so the same debt, not a new class of it. The estate went
     # 27 -> 33 pacts in a day, which is the argument for a gate rather than another audit.
     "pacts/openbank-mcp-service-openbank-balance-service.json",
-    "pacts/openbank-vop-service-openbank-party-service.json",
     "pacts/openbank-notification-service-openbank-account-service.json",
-    "pacts/openbank-onboarding-service-openbank-party-service.json",
     "pacts/openbank-sepa-payment-openbank-fraud-service.json",
     "pacts/openbank-transaction-service-openbank-balance-service.json",
     "pacts/openbank-transaction-service-openbank-fx-service.json",

--- a/openbank-party-service/src/test/kotlin/com/openbank/party/contract/PartyPactFolderProviderVerificationTest.kt
+++ b/openbank-party-service/src/test/kotlin/com/openbank/party/contract/PartyPactFolderProviderVerificationTest.kt
@@ -1,0 +1,296 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright (c) OpenBank contributors. Licensed under the Apache License, Version 2.0.
+// See LICENSE in the repository root or https://www.apache.org/licenses/LICENSE-2.0 for details.
+
+package com.openbank.party.contract
+
+import au.com.dius.pact.provider.PactVerifyProvider
+import au.com.dius.pact.provider.junit5.HttpTestTarget
+import au.com.dius.pact.provider.junit5.MessageTestTarget
+import au.com.dius.pact.provider.junit5.PactVerificationContext
+import au.com.dius.pact.provider.junit5.PactVerificationInvocationContextProvider
+import au.com.dius.pact.provider.junitsupport.IgnoreNoPactsToVerify
+import au.com.dius.pact.provider.junitsupport.Provider
+import au.com.dius.pact.provider.junitsupport.State
+import au.com.dius.pact.provider.junitsupport.loader.PactFolder
+import com.fasterxml.jackson.datatype.jsr310.JavaTimeModule
+import com.fasterxml.jackson.module.kotlin.jacksonObjectMapper
+import com.openbank.party.application.port.out.PartyRepository
+import com.openbank.party.domain.model.AmlStatus
+import com.openbank.party.domain.model.KycStatus
+import com.openbank.party.domain.model.Party
+import com.openbank.party.domain.model.PartyStatus
+import com.openbank.party.domain.model.PartyType
+import io.quarkus.test.common.QuarkusTestResource
+import io.quarkus.test.junit.QuarkusTest
+import io.quarkus.test.security.TestSecurity
+import io.quarkus.vertx.core.runtime.context.VertxContextSafetyToggle
+import io.vertx.core.Vertx
+import io.vertx.core.impl.ContextInternal
+import jakarta.inject.Inject
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.asCoroutineDispatcher
+import kotlinx.coroutines.launch
+import org.eclipse.microprofile.config.inject.ConfigProperty
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.TestTemplate
+import org.junit.jupiter.api.extension.ExtendWith
+import java.time.Instant
+import java.util.UUID
+import java.util.concurrent.CompletableFuture
+import java.util.concurrent.Executor
+import java.util.concurrent.TimeUnit
+
+/**
+ * Git-pact provider verification for party-service — the half that actually runs before a merge
+ * (issue #2327, gated by `check-pact-provider-replay.py` per #2338).
+ *
+ * ## Why this exists as a SECOND class rather than a switch on the first one
+ *
+ * party-service is the provider for four committed pacts, and its only verification class was
+ * [PartyEventPactProviderVerificationTest] — `@PactBroker`-sourced and
+ * `@EnabledIfSystemProperty(pactbroker.url)`-gated. On a pull request that property is empty
+ * (`_service-ci.yml` puts the PR lane on `ubuntu-latest` and blanks `PACT_BROKER_URL` off
+ * main-push, because the broker has no public ingress, ADR-0056), so it skipped and all four
+ * contracts were replayed only AFTER the merge. A consumer pact cannot catch a wrong request path;
+ * only the provider replay can (#2269).
+ *
+ * **Do not "fix" that by flipping the existing class to `@PactFolder`. That was tried and reverted.**
+ * #371 switched it for local-dev ergonomics, and party-service then published no verification result
+ * to the broker for any consumer — which is the only thing ADR-0092's `can-i-deploy` reads, so
+ * party-service's sandbox auto-deploy hard-blocked for four days with no way to unblock from the
+ * consumer side (#1166). The broker class must stay exactly as it is. This class is additive: git
+ * source for the PR lane, broker source for the published result. Two `@Provider` classes collide
+ * only when BOTH pull from the broker (each fetches every pact it holds); a folder class and a
+ * broker class each load their own source, which is the pair openbank-ledger-service carries.
+ *
+ * ## Upkeep
+ *
+ * This class is a deliberate duplicate of the broker twin's body: same `@State` handlers, same
+ * [PactVerifyProvider] producers, same seeded rows. A change to one belongs in the other, or the
+ * same contract passes from git and fails from the broker (or the reverse). The duplication is the
+ * conservative choice on purpose — factoring the shared body into a base class would mean editing
+ * the class whose last structural change wedged deploys for four days, for a cosmetic gain.
+ *
+ * ## Both interaction kinds, one class
+ *
+ * Five HTTP interactions (onboarding-service ×4, vop-service ×1) and five message interactions
+ * (account-service ×3, kyc-service ×2), so the target is chosen per interaction in
+ * [configureTarget]. The [MessageTestTarget] is package-scoped: the default classpath-wide
+ * ClassGraph scan throws on the JDK 25 toolchain.
+ */
+@QuarkusTest
+@QuarkusTestResource(com.openbank.party.it.PostgresRedpandaTestResource::class)
+@TestSecurity(user = "pact-verifier", roles = ["ROLE_KYC"])
+@Provider("openbank-party-service")
+@PactFolder("../pacts")
+@IgnoreNoPactsToVerify(ignoreIoErrors = "true")
+class PartyPactFolderProviderVerificationTest {
+
+    @ConfigProperty(name = "quarkus.http.test-port", defaultValue = "8081")
+    lateinit var testPort: String
+
+    @Inject
+    lateinit var partyRepository: PartyRepository
+
+    @Inject
+    lateinit var vertx: Vertx
+
+    private val objectMapper = jacksonObjectMapper().registerModule(JavaTimeModule())
+
+    /**
+     * Bridges a reactive-Panache block into Pact-JVM's synchronous `@State` callback — same fix as
+     * `BalancePactProviderVerificationTest.runOnVertxContext`: pact-jvm invokes `@State` methods
+     * directly via reflection on the JUnit test thread, which has no Vert.x context, so a bare
+     * `runBlocking { partyRepository.save(...) }` throws `IllegalStateException: No current Vertx
+     * context found`.
+     */
+    private fun runOnVertxContext(block: suspend () -> Unit) {
+        val future = CompletableFuture<Unit>()
+        val duplicated = (vertx.orCreateContext as ContextInternal).duplicate()
+        VertxContextSafetyToggle.setContextSafe(duplicated, true)
+        val dispatcher = Executor { command -> duplicated.runOnContext { command.run() } }.asCoroutineDispatcher()
+        CoroutineScope(dispatcher).launch {
+            try {
+                block()
+                future.complete(Unit)
+            } catch (t: Throwable) {
+                future.completeExceptionally(t)
+            }
+        }
+        future.get(10, TimeUnit.SECONDS)
+    }
+
+    @BeforeEach
+    fun configureTarget(context: PactVerificationContext?) {
+        if (context == null) return
+        // Package-scoped scan: the default classpath-wide ClassGraph scan throws on the JDK 25 toolchain.
+        context.target = if (context.interaction.isAsynchronousMessage()) {
+            MessageTestTarget(listOf("com.openbank.party.contract"))
+        } else {
+            HttpTestTarget("localhost", testPort.toInt())
+        }
+        context.addStateChangeHandlers(this)
+    }
+
+    @TestTemplate
+    @ExtendWith(PactVerificationInvocationContextProvider::class)
+    fun verifyPacts(context: PactVerificationContext?) {
+        // context is null on the @IgnoreNoPactsToVerify dummy invocation — skip gracefully.
+        context?.verifyInteraction()
+    }
+
+    @State("a party has been created")
+    fun partyHasBeenCreated() {
+        // No setup: the message is produced deterministically by the @PactVerifyProvider method below.
+    }
+
+    @PactVerifyProvider("a PARTY_CREATED event")
+    fun producePartyCreatedEvent(): String {
+        // Mirrors KafkaPartyEventPublisher.publish("PARTY_CREATED", party): the flat envelope, with
+        // enums serialized to their names (partyType -> "INDIVIDUAL", etc.).
+        val event = linkedMapOf(
+            "eventType" to "PARTY_CREATED",
+            "partyId" to UUID.randomUUID(),
+            "partyType" to PartyType.INDIVIDUAL,
+            "status" to PartyStatus.PENDING_KYC,
+            "kycStatus" to KycStatus.NOT_STARTED,
+            "legalName" to "Jane Smith",
+            "email" to "jane.smith@example.com",
+            "occurredAt" to Instant.now(),
+        )
+        return objectMapper.writeValueAsString(event)
+    }
+
+    @State("a party has been updated")
+    fun partyHasBeenUpdated() {
+        // No setup: produced deterministically by the @PactVerifyProvider method below.
+    }
+
+    @PactVerifyProvider("a PARTY_UPDATED event")
+    fun producePartyUpdatedEvent(): String {
+        val event = linkedMapOf(
+            "eventType" to "PARTY_UPDATED",
+            "partyId" to UUID.randomUUID(),
+            "partyType" to PartyType.INDIVIDUAL,
+            "status" to PartyStatus.ACTIVE,
+            "kycStatus" to KycStatus.APPROVED,
+            "legalName" to "Jane Smith",
+            "email" to "jane.smith@example.com",
+            "occurredAt" to Instant.now(),
+        )
+        return objectMapper.writeValueAsString(event)
+    }
+
+    @State("a party KYC status has changed")
+    fun partyKycStatusHasChanged() {
+        // No setup: produced deterministically by the @PactVerifyProvider method below.
+    }
+
+    @PactVerifyProvider("a KYC_STATUS_CHANGED event")
+    fun produceKycStatusChangedEvent(): String {
+        val event = linkedMapOf(
+            "eventType" to "KYC_STATUS_CHANGED",
+            "partyId" to UUID.randomUUID(),
+            "partyType" to PartyType.INDIVIDUAL,
+            "status" to PartyStatus.ACTIVE,
+            "kycStatus" to KycStatus.APPROVED,
+            "legalName" to "Jane Smith",
+            "email" to "jane.smith@example.com",
+            "occurredAt" to Instant.now(),
+        )
+        return objectMapper.writeValueAsString(event)
+    }
+
+    @State("a party has been erased")
+    fun partyHasBeenErased() {
+        // No setup: produced deterministically by the @PactVerifyProvider method below.
+    }
+
+    @PactVerifyProvider("a PARTY_ERASED event")
+    fun producePartyErasedEvent(): String {
+        // Mirrors KafkaPartyEventPublisher.publishPartyErased: the separate, narrower envelope
+        // (no partyType/status/kycStatus/legalName/email — those are gone by the time GDPR
+        // Art. 17 erasure runs).
+        val event = linkedMapOf(
+            "eventType" to "PARTY_ERASED",
+            "partyId" to UUID.randomUUID(),
+            "erasedAt" to Instant.now(),
+        )
+        return objectMapper.writeValueAsString(event)
+    }
+
+    @State("a party exists and can be suspended for KYC expiry")
+    fun partyExistsAndCanBeSuspended() = runOnVertxContext {
+        // pact-jvm 4.7.3 invokes each @State SETUP callback twice per interaction (visible for
+        // EVERY state in this class, not just this one — harmless for the no-op states above, but
+        // this one does a real insert with a fixed id, so the second call must be a no-op or it
+        // hits the parties_party_id_key unique constraint).
+        if (partyRepository.findById(FIXED_PARTY_ID) != null) return@runOnVertxContext
+        // Seeds the exact party id PartyServicePactConsumerTest's request path embeds
+        // (onboarding-service, issue #468) so PUT /{id}/kyc-status hits a real row.
+        partyRepository.save(
+            Party(
+                id = FIXED_PARTY_ID,
+                partyType = PartyType.INDIVIDUAL,
+                status = PartyStatus.PENDING_KYC,
+                legalName = "Pact Verify Party",
+                tradingName = null,
+                dateOfBirth = null,
+                nationality = null,
+                taxId = null,
+                registrationNumber = null,
+                email = "pact-verify-party@example.com",
+                phone = null,
+                address = null,
+                kycStatus = KycStatus.IN_PROGRESS,
+                createdAt = Instant.now(),
+                updatedAt = Instant.now(),
+                amlStatus = AmlStatus.NOT_SCREENED,
+            ),
+        )
+    }
+
+    /**
+     * State for vop-service's `PartyNameLookupPactConsumerTest` (issue #2255): hop 2 of the ADR-0171
+     * §4 VoP name resolution reads `legalName`/`tradingName` off `GET /api/v1/parties/{id}`, and the
+     * adapter falls back to `tradingName` when `legalName` is blank — so both fields must be present
+     * and non-blank on the seeded row, unlike [FIXED_PARTY_ID] above which has a null trading name.
+     *
+     * Seeded as a COMPANY: a party carrying both names is by construction a legal entity, and it
+     * keeps this row from colliding with the individual the KYC-expiry state above inserts.
+     */
+    @State("a party exists with both a legal name and a trading name")
+    fun partyExistsWithLegalAndTradingName() = runOnVertxContext {
+        // Idempotent for the same reason as the state above: pact-jvm 4.7.3 invokes each @State
+        // setup callback twice per interaction, and this one inserts with a fixed id.
+        if (partyRepository.findById(VOP_NAME_PARTY_ID) != null) return@runOnVertxContext
+        partyRepository.save(
+            Party(
+                id = VOP_NAME_PARTY_ID,
+                partyType = PartyType.COMPANY,
+                status = PartyStatus.ACTIVE,
+                legalName = "Pact Verify Trading Company a.s.",
+                tradingName = "PactVerify",
+                dateOfBirth = null,
+                nationality = null,
+                taxId = null,
+                registrationNumber = null,
+                email = "pact-verify-vop@example.com",
+                phone = null,
+                address = null,
+                kycStatus = KycStatus.APPROVED,
+                createdAt = Instant.now(),
+                updatedAt = Instant.now(),
+                amlStatus = AmlStatus.NOT_SCREENED,
+            ),
+        )
+    }
+
+    companion object {
+        private val FIXED_PARTY_ID = UUID.fromString("aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee")
+
+        /** Must equal `PartyNameLookupPactConsumerTest.PACT_PARTY_ID` (openbank-vop-service). */
+        private val VOP_NAME_PARTY_ID = UUID.fromString("b1b1b1b1-c2c2-4d4d-8e8e-f9f9f9f9f9f9")
+    }
+}


### PR DESCRIPTION
## Summary

> **Third in a stack — merge order #2413 → #2417 → this.** Base is `ci/pact-replay-transaction-service`, because `KNOWN_UNCOVERED` lives in #2413 and #2417 already edits it.

`party-service` is the provider for **four** committed pacts (ten interactions) and its only verification class is `@PactBroker`-sourced and `@EnabledIfSystemProperty(pactbroker.url)`-gated — so it skips on every PR and those contracts were replayed only *after* the merge. This adds the `@PactFolder` twin that runs on every PR.

## Type of change

- [ ] feat (new functionality)
- [ ] fix (bug fix)
- [ ] refactor (no behavior change)
- [ ] perf (performance)
- [ ] docs
- [x] chore (build / tooling)
- [ ] security (private until disclosed)
- [ ] breaking change

Commit type is `test` — hidden, no release-please bump. No production code changed.

## Linked issues

Refs #2327
Refs #2269
Refs #2338

## Changes

- **New `PartyPactFolderProviderVerificationTest`** — `@PactFolder("../pacts")`, no gating annotation. Per-interaction target (`MessageTestTarget` package-scoped / `HttpTestTarget`), the same `@State` handlers, `@PactVerifyProvider` producers and seeded rows as the broker twin.
- **`KNOWN_UNCOVERED`** loses the four party pacts: coverage **20 → 24**, backlog **13 → 9**.

## Reviewer notes

**This is not #371 again — read this before suggesting the obvious simplification.** The obvious move is to flip the existing class to `@PactFolder`. That was done in #371 and reverted in #1166: party-service then published no verification result for any consumer, and since that result is the only thing ADR-0092's `can-i-deploy` reads, party-service's sandbox auto-deploy hard-blocked for **four days** with no consumer-side way to unblock. The broker class is untouched here. This one is additive: git source for the PR lane, broker source for the published result — the pair `openbank-ledger-service` already carries. Two `@Provider` classes collide only when **both** pull from the broker, since each then fetches every pact it holds.

**Verified from the JUnit XML, not the console** — pact-jvm prints `Not all of the N were verified` on a fully green run:

```
tests=10 failures=0 errors=0
  onboarding-service ×4 · account-service ×3 · kyc-service ×2 · vop-service ×1
```

**Falsified in both halves**, because a replay that has only ever passed proves nothing:

| break | result |
| --- | --- |
| `PartyResource` `@Path` → `/api/v1/parties-MOVED` | the **2** genuinely synchronous interactions go red (onboarding's `PUT kyc-status`, vop's `GET party`); the 8 message ones correctly stay green |
| this class's `PARTY_CREATED` producer emits a wrong `eventType` | all **3** `PARTY_CREATED` interactions go red, across kyc, onboarding and account |

Worth recording because the pact files mislead a skim: three of onboarding's four entries under `interactions` are `type: Asynchronous/Messages`. Party has **2 HTTP and 8 message** interactions, not 5 and 5.

**On the duplication.** This class is a deliberate copy of the broker twin's body. The second experiment above also answers the question that raises: with two `@PactVerifyProvider` methods of the same name in one package, the **running class's own copy** is the one used — measured, in that direction. The upkeep rule in the KDoc (a change to one belongs in the other) keeps the choice moot, since identical copies make it irrelevant. Factoring the shared body into a base class would mean restructuring the class whose last structural change wedged deploys for four days; not worth it for a cosmetic gain.

**Cost:** one more `@QuarkusTest` with Testcontainers in party-service's PR build. Ratio is worse than #2417 — 4 pacts per test instead of 6 — but party is on the KYC/GDPR path (`PARTY_ERASED` is Art. 17 erasure), so the contracts are worth pre-merge checking.

## Definition of Done

- [x] Hexagonal layering preserved (domain has zero framework imports).
- [x] Unit tests added/updated. — this PR is the test
- [x] Integration tests added/updated (if service boundary involved). — ten provider-side replays
- [x] Contract tests updated (if public API changed). — no pact content changed; they are now replayed pre-merge
- [x] `./gradlew detekt ktlintCheck koverVerify build` passes. — ktlintCheck + compileTestKotlin + the test itself
- [x] No new lint warnings.
- [ ] OpenAPI spec regenerated (if REST API changed). — N/A
- [ ] Flyway migration added + rollback note (if DB changed). — N/A
- [ ] Avro schema versioned backward-compatibly (if event changed). — N/A
- [x] Docs updated (README, ADR if architectural). — KDoc

## Security checklist

- [x] No secrets, tokens, passwords, or PII in code, config, tests, logs.
- [x] No new `@SuppressWarnings`, `as Any`, `@Suppress("...")` without justification.
- [x] No new third-party dependency.
- [ ] Auth / crypto / payment code changed? → N/A — test-only
- [ ] PII path changed? → N/A — the seeded rows are synthetic pact fixtures
- [ ] Cardholder data path changed? → N/A

## Compliance impact

- [x] None

## Rollout / Rollback

- Deployment strategy: N/A — test-only, no service artifact
- Rollback plan: revert the commit; the broker twin is untouched, so `can-i-deploy` is unaffected either way
- Data migration reversible: N/A
