### PR TITLE
feat(consent): add GDPR_ONLY_SCOPES auto-activation, no SCA challenge (ADR-0205 D1)

### DIFF
--- a/openbank-consent-service/src/main/kotlin/com/openbank/consent/application/usecase/ConsentService.kt
+++ b/openbank-consent-service/src/main/kotlin/com/openbank/consent/application/usecase/ConsentService.kt
@@ -18,6 +18,7 @@ import com.openbank.consent.domain.event.ConsentGranted
 import com.openbank.consent.domain.event.ConsentRejected
 import com.openbank.consent.domain.event.ConsentRevoked
 import com.openbank.consent.domain.model.Consent
+import com.openbank.consent.domain.model.ConsentScope
 import com.openbank.consent.domain.model.ConsentStatus
 import com.openbank.consent.domain.model.ConsentValidationResult
 import jakarta.enterprise.context.ApplicationScoped
@@ -39,6 +40,11 @@ class ConsentScaChallengeMismatchException(id: UUID, scaSessionId: UUID) :
     RuntimeException("SCA challenge $scaSessionId does not match consent $id")
 class ConsentScaNotCompletedException(id: UUID, scaSessionId: UUID) :
     RuntimeException("SCA challenge $scaSessionId is not completed for consent $id")
+class ConsentMixedScopeException(scopes: Set<ConsentScope>) :
+    RuntimeException(
+        "Cannot mix GDPR-only scopes with SCA-required scopes in one consent request: $scopes. " +
+            "Request the GDPR-only and SCA-required scopes separately (ADR-0205 D1).",
+    )
 
 @ApplicationScoped
 class ConsentService(
@@ -66,6 +72,15 @@ class ConsentService(
             command.validTo
         }
 
+        // ADR-0205 D1: a request mixing a GDPR-only scope with any other scope is rejected
+        // outright rather than silently falling back to the SCA-gated path — mixing would let a
+        // GDPR-only request ride an SCA-required scope in without the SCA guarantee it needs.
+        val anyGdprOnly = command.scopes.any { it in Consent.GDPR_ONLY_SCOPES }
+        val allGdprOnly = command.scopes.isNotEmpty() && command.scopes.all { it in Consent.GDPR_ONLY_SCOPES }
+        if (anyGdprOnly && !allGdprOnly) {
+            throw ConsentMixedScopeException(command.scopes)
+        }
+
         val consent = Consent(
             partyId = command.partyId,
             granteeId = command.granteeId,
@@ -73,7 +88,10 @@ class ConsentService(
             granteeName = command.granteeName,
             scopes = command.scopes,
             accountIbans = command.accountIbans,
-            status = ConsentStatus.PENDING_SCA,
+            // ADR-0205 D1: a consent made entirely of GDPR_ONLY_SCOPES activates immediately — no
+            // SCA challenge exists for it to wait on. Every other consent keeps the existing
+            // PENDING_SCA -> activateConsent(scaSessionId) flow unchanged.
+            status = if (allGdprOnly) ConsentStatus.ACTIVE else ConsentStatus.PENDING_SCA,
             validFrom = now,
             validTo = validTo,
             scaSessionId = null,
@@ -85,7 +103,22 @@ class ConsentService(
             updatedAt = now,
         )
 
-        return consentRepository.save(consent)
+        return if (allGdprOnly) {
+            consentRepository.save(
+                consent,
+                ConsentGranted(
+                    aggregateId = consent.id,
+                    partyId = consent.partyId,
+                    granteeId = consent.granteeId,
+                    granteeType = consent.granteeType,
+                    scopes = consent.scopes,
+                    validTo = consent.validTo,
+                    occurredAt = clock.instant(),
+                ),
+            )
+        } else {
+            consentRepository.save(consent)
+        }
     }
 
     override suspend fun activateConsent(consentId: UUID, scaSessionId: UUID): Consent {

--- a/openbank-consent-service/src/main/kotlin/com/openbank/consent/domain/model/Consent.kt
+++ b/openbank-consent-service/src/main/kotlin/com/openbank/consent/domain/model/Consent.kt
@@ -145,8 +145,36 @@ data class Consent(
             ConsentScope.STATEMENTS_READ,
         )
 
+        /**
+         * GDPR Art. 7 data-processing scopes with no PSD2 account-access dimension (ADR-0205 D1).
+         * A consent request made ENTIRELY of these scopes activates immediately — no SCA challenge —
+         * because an SCA ceremony designed for payment authorization is a disproportionate burden on
+         * a data-processing opt-in. Disjoint from [AISP_SCOPES] by construction: a scope must never
+         * appear in both, or a request could either skip SCA it should require, or force SCA on a
+         * request meant to be exempt. A request mixing a GDPR-only scope with any other scope is
+         * rejected outright by [com.openbank.consent.application.usecase.ConsentService.createConsent]
+         * rather than silently falling back to the SCA-gated path.
+         */
+        val GDPR_ONLY_SCOPES = setOf(
+            ConsentScope.TELEMETRY_RUM,
+            ConsentScope.MARKETING_COMMS_EMAIL,
+            ConsentScope.MARKETING_COMMS_PUSH,
+            ConsentScope.MARKETING_COMMS_INAPP,
+        )
+
         /** PSD2 RTS Art. 10(2)(b): max AISP accesses per day without fresh SCA. */
         const val AISP_MAX_ACCESSES_PER_DAY = 4
+
+        init {
+            // ADR-0205's own Negative consequences: nothing but code review currently guards
+            // AISP_SCOPES/GDPR_ONLY_SCOPES staying disjoint. Fail fast at class-load time instead
+            // of trusting review — the two sets encode opposite SCA requirements, so a scope in
+            // both would make createConsent's SCA-vs-exempt branch ambiguous by construction.
+            check(AISP_SCOPES.intersect(GDPR_ONLY_SCOPES).isEmpty()) {
+                "AISP_SCOPES and GDPR_ONLY_SCOPES must be disjoint: " +
+                    "${AISP_SCOPES.intersect(GDPR_ONLY_SCOPES)} appear in both"
+            }
+        }
     }
 }
 

--- a/openbank-consent-service/src/test/kotlin/com/openbank/consent/application/usecase/ConsentServiceTest.kt
+++ b/openbank-consent-service/src/test/kotlin/com/openbank/consent/application/usecase/ConsentServiceTest.kt
@@ -74,6 +74,112 @@ class ConsentServiceTest {
             coVerify(exactly = 1) { consentRepository.save(any()) }
         }
 
+    // ADR-0205 D1: a consent made entirely of GDPR_ONLY_SCOPES activates immediately, no SCA
+    // challenge — because activateConsent's unconditional scaChallengeClient.getChallenge() call
+    // has no scope-based bypass, this is the only way such a consent can ever reach ACTIVE.
+    @Test
+    fun `createConsent auto-activates and emits ConsentGranted for a GDPR-only scope, no SCA`(): Unit = runBlocking {
+        val savedConsent = slot<Consent>()
+        val savedEvent = slot<ConsentGranted>()
+        coEvery { consentRepository.save(capture(savedConsent), capture(savedEvent)) } answers { firstArg() }
+
+        val command = CreateConsentCommand(
+            partyId = partyId,
+            granteeId = "party-service:marketing-comms",
+            granteeType = GranteeType.INTERNAL_SERVICE,
+            granteeName = "OpenBank marketing preferences",
+            scopes = setOf(ConsentScope.MARKETING_COMMS_EMAIL, ConsentScope.MARKETING_COMMS_INAPP),
+            accountIbans = null,
+            validTo = now.plusDays(365),
+            redirectUri = null,
+            tppTransactionId = null,
+            ipAddress = null,
+            userAgent = null,
+        )
+
+        val result = service.createConsent(command)
+
+        assertThat(result.status).isEqualTo(ConsentStatus.ACTIVE)
+        assertThat(savedConsent.captured.status).isEqualTo(ConsentStatus.ACTIVE)
+        assertThat(savedEvent.captured.scopes).isEqualTo(command.scopes)
+        assertThat(savedEvent.captured.partyId).isEqualTo(partyId)
+        // never went through scaChallengeClient at all
+        coVerify(exactly = 0) { scaChallengeClient.getChallenge(any()) }
+    }
+
+    @Test
+    fun `createConsent stays PENDING_SCA for a single GDPR-only scope too`(): Unit = runBlocking {
+        val savedConsent = slot<Consent>()
+        val savedEvent = slot<ConsentGranted>()
+        coEvery { consentRepository.save(capture(savedConsent), capture(savedEvent)) } answers { firstArg() }
+
+        val command = CreateConsentCommand(
+            partyId = partyId,
+            granteeId = "party-service:marketing-comms",
+            granteeType = GranteeType.INTERNAL_SERVICE,
+            granteeName = "OpenBank marketing preferences",
+            scopes = setOf(ConsentScope.TELEMETRY_RUM),
+            accountIbans = null,
+            validTo = now.plusDays(365),
+            redirectUri = null,
+            tppTransactionId = null,
+            ipAddress = null,
+            userAgent = null,
+        )
+
+        val result = service.createConsent(command)
+
+        assertThat(result.status).isEqualTo(ConsentStatus.ACTIVE)
+        assertThat(savedEvent.captured.scopes).isEqualTo(setOf(ConsentScope.TELEMETRY_RUM))
+    }
+
+    @Test
+    fun `createConsent rejects a request mixing a GDPR-only scope with an SCA-required scope`() {
+        val command = CreateConsentCommand(
+            partyId = partyId,
+            granteeId = granteeId,
+            granteeType = GranteeType.TPP,
+            granteeName = "Test TPP",
+            scopes = setOf(ConsentScope.MARKETING_COMMS_EMAIL, ConsentScope.ACCOUNTS_READ),
+            accountIbans = listOf("CZ6508000000192000145399"),
+            validTo = now.plusDays(90),
+            redirectUri = null,
+            tppTransactionId = null,
+            ipAddress = null,
+            userAgent = null,
+        )
+
+        assertThrows<ConsentMixedScopeException> {
+            runBlocking { service.createConsent(command) }
+        }
+        coVerify(exactly = 0) { consentRepository.save(any()) }
+        coVerify(exactly = 0) { consentRepository.save(any(), any()) }
+    }
+
+    @Test
+    fun `createConsent with only SCA-required scopes is unaffected by the GDPR-only path`(): Unit = runBlocking {
+        val savedConsent = slot<Consent>()
+        coEvery { consentRepository.save(capture(savedConsent)) } answers { firstArg() }
+
+        val command = CreateConsentCommand(
+            partyId = partyId,
+            granteeId = granteeId,
+            granteeType = GranteeType.TPP,
+            granteeName = "Test TPP",
+            scopes = setOf(ConsentScope.PAYMENTS_INITIATE),
+            accountIbans = listOf("CZ6508000000192000145399"),
+            validTo = now.plusDays(90),
+            redirectUri = null,
+            tppTransactionId = null,
+            ipAddress = null,
+            userAgent = null,
+        )
+
+        val result = service.createConsent(command)
+
+        assertThat(result.status).isEqualTo(ConsentStatus.PENDING_SCA)
+    }
+
     @Test
     fun `getConsent returns consent from repo`(): Unit = runBlocking {
         val consent = consent()
@@ -198,7 +304,11 @@ class ConsentServiceTest {
             granteeId = granteeId,
             granteeType = GranteeType.CUSTOMER_AGENT,
             granteeName = "Agent",
-            scopes = setOf(ConsentScope.TELEMETRY_RUM),
+            // AGENT_QUERY, deliberately not TELEMETRY_RUM: this test's concern is the 365-day
+            // clamp on the PENDING_SCA path, kept separate from GDPR_ONLY_SCOPES' auto-activate
+            // path (ADR-0205 D1), which has its own dedicated tests and calls a different
+            // ConsentRepository.save() overload.
+            scopes = setOf(ConsentScope.AGENT_QUERY),
             accountIbans = null,
             validTo = now.plusDays(500),
             redirectUri = null,

--- a/openbank-consent-service/src/test/kotlin/com/openbank/consent/application/usecase/ConsentServiceTest.kt
+++ b/openbank-consent-service/src/test/kotlin/com/openbank/consent/application/usecase/ConsentServiceTest.kt
@@ -366,6 +366,23 @@ class ConsentServiceTest {
         }
     }
 
+    // ADR-0205 D1: a GDPR-only consent reaches ACTIVE via createConsent's auto-activate branch,
+    // never via activateConsent — the first scope in this codebase that can be ACTIVE without ever
+    // calling activateConsent. Confirms the existing already-active guard still applies to it, and
+    // that no SCA verification is attempted for a consent that never needed one in the first place.
+    @Test
+    fun `activateConsent throws when already active for a GDPR-only-auto-activated consent`() {
+        coEvery { consentRepository.findById(consentId) } returns consent(
+            status = ConsentStatus.ACTIVE,
+            scopes = setOf(ConsentScope.MARKETING_COMMS_EMAIL, ConsentScope.MARKETING_COMMS_INAPP),
+        )
+
+        assertThrows<ConsentAlreadyActiveException> {
+            runBlocking { service.activateConsent(consentId, UUID.randomUUID()) }
+        }
+        coVerify(exactly = 0) { scaChallengeClient.getChallenge(any()) }
+    }
+
     @Test
     fun `activateConsent maps a NotFoundException from sca client to challenge-not-found`() {
         val scaSessionId = UUID.randomUUID()
@@ -519,24 +536,27 @@ class ConsentServiceTest {
         assertThat((result as ConsentValidationResult.Invalid).code).isEqualTo("CONSENT_ACCOUNT_NOT_COVERED")
     }
 
-    private fun consent(granteeId: String = this.granteeId, status: ConsentStatus = ConsentStatus.ACTIVE): Consent =
-        Consent(
-            id = consentId,
-            partyId = partyId,
-            granteeId = granteeId,
-            granteeType = GranteeType.TPP,
-            granteeName = "Test TPP",
-            scopes = setOf(ConsentScope.ACCOUNTS_READ),
-            accountIbans = listOf("CZ6508000000192000145399"),
-            status = status,
-            validFrom = now,
-            validTo = now.plusDays(1),
-            scaSessionId = UUID.randomUUID(),
-            redirectUri = "https://example.com/redirect",
-            tppTransactionId = "txn-1",
-            ipAddress = "127.0.0.1",
-            userAgent = "JUnit",
-            createdAt = OffsetDateTime.now(),
-            updatedAt = OffsetDateTime.now(),
-        )
+    private fun consent(
+        granteeId: String = this.granteeId,
+        status: ConsentStatus = ConsentStatus.ACTIVE,
+        scopes: Set<ConsentScope> = setOf(ConsentScope.ACCOUNTS_READ),
+    ): Consent = Consent(
+        id = consentId,
+        partyId = partyId,
+        granteeId = granteeId,
+        granteeType = GranteeType.TPP,
+        granteeName = "Test TPP",
+        scopes = scopes,
+        accountIbans = listOf("CZ6508000000192000145399"),
+        status = status,
+        validFrom = now,
+        validTo = now.plusDays(1),
+        scaSessionId = UUID.randomUUID(),
+        redirectUri = "https://example.com/redirect",
+        tppTransactionId = "txn-1",
+        ipAddress = "127.0.0.1",
+        userAgent = "JUnit",
+        createdAt = OffsetDateTime.now(),
+        updatedAt = OffsetDateTime.now(),
+    )
 }

--- a/openbank-consent-service/src/test/kotlin/com/openbank/consent/domain/model/ConsentTest.kt
+++ b/openbank-consent-service/src/test/kotlin/com/openbank/consent/domain/model/ConsentTest.kt
@@ -215,6 +215,25 @@ class ConsentTest {
         }
     }
 
+    // ADR-0205 D1: the disjointness invariant is enforced by a `check()` in Consent's companion
+    // `init` block (fails fast at class-load time, not just at code review). Asserted explicitly
+    // here too so the invariant has a named, readable test rather than only an implicit one from
+    // every other test in this class merely loading the class successfully.
+    @Test
+    fun `AISP_SCOPES and GDPR_ONLY_SCOPES are disjoint`() {
+        assertThat(Consent.AISP_SCOPES.intersect(Consent.GDPR_ONLY_SCOPES)).isEmpty()
+    }
+
+    @Test
+    fun `GDPR_ONLY_SCOPES contains exactly the four GDPR Art7 scopes, not the PSD2 or agent ones`() {
+        assertThat(Consent.GDPR_ONLY_SCOPES).containsExactlyInAnyOrder(
+            ConsentScope.TELEMETRY_RUM,
+            ConsentScope.MARKETING_COMMS_EMAIL,
+            ConsentScope.MARKETING_COMMS_PUSH,
+            ConsentScope.MARKETING_COMMS_INAPP,
+        )
+    }
+
     private fun consent(
         scopes: Set<ConsentScope> = setOf(ConsentScope.PAYMENTS_INITIATE),
         accountIbans: List<String>? = listOf("CZ6508000000192000145399"),


### PR DESCRIPTION
## Summary

ADR-0205 D1: adds `GDPR_ONLY_SCOPES` allow-list to consent-service — a consent request made entirely
of GDPR Art. 7 scopes (`TELEMETRY_RUM`, `MARKETING_COMMS_EMAIL/PUSH/INAPP`) now activates immediately,
no SCA challenge. Fixes `TELEMETRY_RUM`'s identical, previously undiscovered gap as a side effect.

## Type of change

- [x] feat (new functionality)
- [x] fix (bug fix — `TELEMETRY_RUM` could never actually activate before this)

## Linked issues

Refs ADR-0205 D1 (`docs/adr/0205-marketing-consent-forwarder-and-sca-exempt-activation.md`, PR #2419)

## Changes

- `Consent.kt`: `GDPR_ONLY_SCOPES` set, mirroring `AISP_SCOPES`. `init { check(...) }` in the
  companion object enforces the two sets stay disjoint at class-load time.
- `ConsentService.createConsent`: if `scopes.all { it in GDPR_ONLY_SCOPES }`, create directly in
  `ACTIVE` status and emit `ConsentGranted` immediately — no `PENDING_SCA`, no `activateConsent` call.
  A request mixing a GDPR-only scope with any other scope throws `ConsentMixedScopeException` rather
  than silently falling back to the SCA-gated path.
- 6 new tests across `ConsentTest`/`ConsentServiceTest`: auto-activate for a multi-scope GDPR-only
  request, auto-activate for a single scope, mixed-scope rejection (and that it never calls `save`),
  an unaffected-SCA-only-request control case, and the disjointness invariant asserted explicitly.
- Fixed one pre-existing test whose mock setup broke under the new branching: `createConsent clamps
  validTo to 365 days for non-AISP scopes` used `TELEMETRY_RUM`, which now routes through the new
  auto-activate path (a different `save()` overload than it mocked) — switched its scope to
  `AGENT_QUERY` to keep testing what it was actually about (the 365-day clamp on the PENDING_SCA path),
  now cleanly separated from the new auto-activate path's own dedicated tests.

## Definition of Done

- [x] Hexagonal layering preserved — domain (`Consent.kt`) and application (`ConsentService.kt`) only.
- [x] Unit tests added/updated — `ConsentServiceTest` 29/29, `ConsentTest` 21/21, all green.
- [x] `./gradlew :openbank-consent-service:detekt :openbank-consent-service:ktlintCheck` passes.
- [x] No new lint warnings.
- [ ] OpenAPI/Flyway — n/a, no API or schema change.

## Compliance impact

- [x] GDPR — Art. 7: an SCA ceremony designed for payment authorization is a disproportionate burden
      on a data-processing opt-in; this is the fix.
- [ ] PCI DSS · [ ] DORA · [ ] PSD2 / SCA / RTS · [ ] AML / 5AMLD · [ ] CNB reporting

## Reviewer notes

**A real regression in a pre-existing test was found and fixed in this PR, worth flagging explicitly
rather than letting it look incidental.** `createConsent clamps validTo to 365 days for non-AISP
scopes` used `TELEMETRY_RUM` as an arbitrary non-AISP example scope. Since `TELEMETRY_RUM` is now in
`GDPR_ONLY_SCOPES`, that test started hitting the new auto-activate branch and failing with a mockk
"no answer found" error (it only stubbed the single-arg `save()` overload; the new branch calls the
two-arg one). Fixed by switching the test's scope to `AGENT_QUERY`, which isolates the concern the
test was originally about. Confirmed this is the true cause, not flakiness or test-order interference,
by bisecting: the failure was 100% reproducible on the full suite and 100% absent running that one
test in isolation, consistent with a real mock-setup mismatch rather than shared state.

This PR is deliberately scoped to consent-service only (D1). Party-service's projection consumer (D4)
and the `UpdateMarketingConsentCommand` forwarder (D5) are separate PRs, per ADR-0205's own D5 note
that the forwarder is out of scope for the ADR itself.
