### PR TITLE
test(balance): replay all three provider pacts before merge, not after

### DIFF
--- a/.github/scripts/check-pact-provider-replay.py
+++ b/.github/scripts/check-pact-provider-replay.py
@@ -49,16 +49,13 @@ PACTS = ROOT / "pacts"
 # ~44 generated files and give the PR a short shelf life. The list belongs next to the code that
 # reads it.
 KNOWN_UNCOVERED = {
-    "pacts/openbank-account-service-openbank-balance-service.json",
     "pacts/openbank-balance-service-openbank-account-service.json",
     "pacts/openbank-consent-service-openbank-sca-service.json",
     # Landed 2026-07-25, after the #2327 audit counted 16 of 27: same three providers
     # (balance/transaction/party), so the same debt, not a new class of it. The estate went
     # 27 -> 33 pacts in a day, which is the argument for a gate rather than another audit.
-    "pacts/openbank-mcp-service-openbank-balance-service.json",
     "pacts/openbank-notification-service-openbank-account-service.json",
     "pacts/openbank-sepa-payment-openbank-fraud-service.json",
-    "pacts/openbank-transaction-service-openbank-balance-service.json",
     "pacts/openbank-transaction-service-openbank-fx-service.json",
     "pacts/openbank-transaction-service-openbank-swift-service.json",
 }

--- a/.github/scripts/check-pact-provider-replay.py
+++ b/.github/scripts/check-pact-provider-replay.py
@@ -51,23 +51,17 @@ PACTS = ROOT / "pacts"
 KNOWN_UNCOVERED = {
     "pacts/openbank-account-service-openbank-balance-service.json",
     "pacts/openbank-account-service-openbank-party-service.json",
-    "pacts/openbank-account-service-openbank-transaction-service.json",
     "pacts/openbank-balance-service-openbank-account-service.json",
     "pacts/openbank-consent-service-openbank-sca-service.json",
-    "pacts/openbank-domestic-payment-openbank-transaction-service.json",
-    "pacts/openbank-fraud-service-openbank-transaction-service.json",
     "pacts/openbank-kyc-service-openbank-party-service.json",
     # Landed 2026-07-25, after the #2327 audit counted 16 of 27: same three providers
     # (balance/transaction/party), so the same debt, not a new class of it. The estate went
     # 27 -> 33 pacts in a day, which is the argument for a gate rather than another audit.
     "pacts/openbank-mcp-service-openbank-balance-service.json",
-    "pacts/openbank-mcp-service-openbank-transaction-service.json",
     "pacts/openbank-vop-service-openbank-party-service.json",
     "pacts/openbank-notification-service-openbank-account-service.json",
     "pacts/openbank-onboarding-service-openbank-party-service.json",
-    "pacts/openbank-sepa-instant-openbank-transaction-service.json",
     "pacts/openbank-sepa-payment-openbank-fraud-service.json",
-    "pacts/openbank-sepa-payment-openbank-transaction-service.json",
     "pacts/openbank-transaction-service-openbank-balance-service.json",
     "pacts/openbank-transaction-service-openbank-fx-service.json",
     "pacts/openbank-transaction-service-openbank-swift-service.json",

--- a/.github/scripts/check-pact-provider-replay.py
+++ b/.github/scripts/check-pact-provider-replay.py
@@ -1,0 +1,332 @@
+#!/usr/bin/env python3
+# SPDX-License-Identifier: Apache-2.0
+"""Every committed pact must be REPLAYED by a provider test that actually runs on a pull request.
+
+Issue #2338. A consumer pact cannot catch a wrong request path: the Pact mock server answers
+whatever path the client asks for, so pointing a client at a route that does not exist leaves the
+consumer test green. Only the provider replay goes red. That is how finrep-service shipped a call
+to `/api/v1/ledger/trial-balance`, a ledger route that has never existed (#2269).
+
+`CLAUDE.md` states the rule -- never add a consumer pact without wiring the provider's `@PactFolder`
+replay -- and until this script nothing enforced it. The result, measured 2026-07-25: 16 of 27
+committed pacts had no replay that runs before merge (#2327). Their only verification class is
+`@PactBroker`-sourced and `@EnabledIfSystemProperty(named = "pactbroker.url")`-gated, and on a pull
+request that property is empty (`_service-ci.yml` puts the PR lane on `ubuntu-latest` and blanks
+`PACT_BROKER_URL` off main-push -- the broker has no public ingress, ADR-0056), so the class skips
+and the contract is replayed only AFTER the merge.
+
+WHAT COUNTS AS COVERAGE: a `@Provider("<name>")` class that is `@PactFolder`-sourced, carries no
+gating annotation, and is not excluded by its module's build.gradle.kts. A class that exists but
+never runs is the failure mode this checks for -- it is not evidence of anything.
+
+DERIVED, NOT LISTED: the covered set is computed from `pacts/*.json` (the `provider.name` field, not
+the filename -- both halves contain dashes) and from the annotations themselves. A gate whose
+coverage set is maintained separately from the artifacts it covers reads as *passing* when the list
+is short, which is exactly what #2318 had to remove from the drift gate one layer down.
+
+    python3 .github/scripts/check-pact-provider-replay.py            # enforce
+    python3 .github/scripts/check-pact-provider-replay.py --selftest # prove the gate can fail
+"""
+
+from __future__ import annotations
+
+import fnmatch
+import json
+import re
+import sys
+from dataclasses import dataclass, field
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[2]
+PACTS = ROOT / "pacts"
+
+# Pacts with no pre-merge provider replay TODAY. Each line is a debt, not a decision: #2327 empties
+# this list one provider at a time, and an entry that becomes covered fails as stale, so the list
+# cannot quietly outlive the problem.
+#
+# Kept here rather than in rules.yaml on purpose: 25 of the 26 gen-*opa-bundle*.sh hash rules.yaml
+# into every service's OPA bundle checksum, so each line removed from this backlog would restamp
+# ~44 generated files and give the PR a short shelf life. The list belongs next to the code that
+# reads it.
+KNOWN_UNCOVERED = {
+    "pacts/openbank-account-service-openbank-balance-service.json",
+    "pacts/openbank-account-service-openbank-party-service.json",
+    "pacts/openbank-account-service-openbank-transaction-service.json",
+    "pacts/openbank-balance-service-openbank-account-service.json",
+    "pacts/openbank-consent-service-openbank-sca-service.json",
+    "pacts/openbank-domestic-payment-openbank-transaction-service.json",
+    "pacts/openbank-fraud-service-openbank-transaction-service.json",
+    "pacts/openbank-kyc-service-openbank-party-service.json",
+    # Landed 2026-07-25, after the #2327 audit counted 16 of 27: same three providers
+    # (balance/transaction/party), so the same debt, not a new class of it. The estate went
+    # 27 -> 33 pacts in a day, which is the argument for a gate rather than another audit.
+    "pacts/openbank-mcp-service-openbank-balance-service.json",
+    "pacts/openbank-mcp-service-openbank-transaction-service.json",
+    "pacts/openbank-vop-service-openbank-party-service.json",
+    "pacts/openbank-notification-service-openbank-account-service.json",
+    "pacts/openbank-onboarding-service-openbank-party-service.json",
+    "pacts/openbank-sepa-instant-openbank-transaction-service.json",
+    "pacts/openbank-sepa-payment-openbank-fraud-service.json",
+    "pacts/openbank-sepa-payment-openbank-transaction-service.json",
+    "pacts/openbank-transaction-service-openbank-balance-service.json",
+    "pacts/openbank-transaction-service-openbank-fx-service.json",
+    "pacts/openbank-transaction-service-openbank-swift-service.json",
+}
+
+# Annotations that can stop a test class from running. @EnabledIf* is the live one here; the others
+# are listed so a future "temporarily disabled" class cannot be read as coverage either.
+GATING = (
+    "@EnabledIfSystemProperty",
+    "@EnabledIfEnvironmentVariable",
+    "@DisabledIfSystemProperty",
+    "@DisabledIfEnvironmentVariable",
+    "@Disabled",
+)
+
+errors: list[str] = []
+
+
+def fail(msg: str) -> None:
+    errors.append(msg)
+
+
+def strip_comments(src: str) -> str:
+    """Drop // and /* */ so prose about @Provider is never mistaken for an annotation (#2291)."""
+    src = re.sub(r"/\*.*?\*/", "", src, flags=re.S)
+    return re.sub(r"//[^\n]*", "", src)
+
+
+@dataclass
+class VerificationClass:
+    path: str
+    provider: str
+    source: str  # "folder" | "broker" | "none"
+    gates: list[str] = field(default_factory=list)
+    excluded_by_build: str = ""
+
+    @property
+    def runs_on_pr(self) -> bool:
+        return self.source == "folder" and not self.gates and not self.excluded_by_build
+
+    def why_not(self) -> str:
+        if self.source == "broker":
+            return "@PactBroker-sourced, so it needs a broker the PR lane cannot reach"
+        if self.source == "none":
+            return "neither @PactFolder nor @PactBroker — it verifies nothing"
+        if self.gates:
+            return f"gated by {', '.join(self.gates)}"
+        if self.excluded_by_build:
+            return f"excluded by {self.excluded_by_build}"
+        return "runs"
+
+
+def module_of(path: Path) -> str:
+    return path.relative_to(ROOT).parts[0]
+
+
+def build_exclusions(module: str) -> list[str]:
+    """Test-name globs a module's build.gradle.kts drops (exclude / excludeTestsMatching)."""
+    build = ROOT / module / "build.gradle.kts"
+    if not build.is_file():
+        return []
+    src = strip_comments(build.read_text(encoding="utf-8"))
+    return re.findall(r'(?:excludeTestsMatching|exclude)\(\s*"([^"]+)"\s*\)', src)
+
+
+def excluded_by(class_file: Path, patterns: list[str]) -> str:
+    name = class_file.stem
+    for pat in patterns:
+        # Gradle's exclude() takes a path glob, excludeTestsMatching() a class-name glob. Test both
+        # readings: a pattern that matches either is one that stops this class from running.
+        if fnmatch.fnmatch(name, pat) or fnmatch.fnmatch(f"x/{name}.class", pat):
+            return f'build.gradle.kts exclude("{pat}")'
+    return ""
+
+
+def scan_verification_classes() -> list[VerificationClass]:
+    found: list[VerificationClass] = []
+    for path in sorted(ROOT.glob("*/src/test/kotlin/**/*.kt")):
+        src = strip_comments(path.read_text(encoding="utf-8"))
+        m = re.search(r'@Provider\(\s*"([^"]+)"\s*\)', src)
+        if not m:
+            continue
+        # Require the pact library import, not just the annotation text. openbank-flaky-test-hunter
+        # carries a Kotlin sample *inside a string literal* — `@Provider("openbank-sample-service")`
+        # in a fixture it scans — which reads as a verification class to any text match. Detect the
+        # artifact (the dependency), never the text (#2291).
+        if "au.com.dius.pact" not in src:
+            continue
+        source = "folder" if "@PactFolder" in src else "broker" if "@PactBroker" in src else "none"
+        gates = [g for g in GATING if g in src]
+        found.append(
+            VerificationClass(
+                path=str(path.relative_to(ROOT)),
+                provider=m.group(1),
+                source=source,
+                gates=gates,
+                excluded_by_build=excluded_by(path, build_exclusions(module_of(path))),
+            )
+        )
+    return found
+
+
+def scan_pacts() -> dict[str, str]:
+    """{'pacts/<file>.json': '<provider name>'} read from the JSON, never from the filename."""
+    out: dict[str, str] = {}
+    for path in sorted(PACTS.glob("*.json")):
+        data = json.loads(path.read_text(encoding="utf-8"))
+        provider = (data.get("provider") or {}).get("name")
+        rel = str(path.relative_to(ROOT))
+        if not provider:
+            fail(f"{rel} has no provider.name — cannot tell which service must replay it")
+            continue
+        out[rel] = provider
+    return out
+
+
+def check_coverage(pacts: dict[str, str], classes: list[VerificationClass], allow: set[str]) -> None:
+    replaying = {c.provider for c in classes if c.runs_on_pr}
+    for pact, provider in sorted(pacts.items()):
+        covered = provider in replaying
+        if covered and pact in allow:
+            fail(
+                f"{pact} is listed in KNOWN_UNCOVERED but {provider} now has an always-running "
+                "@PactFolder replay — delete the stale entry (#2327 is what empties this list)"
+            )
+            continue
+        if covered or pact in allow:
+            continue
+        candidates = [c for c in classes if c.provider == provider]
+        if candidates:
+            detail = "; ".join(f"{c.path} ({c.why_not()})" for c in candidates)
+            fail(
+                f"{pact} has no provider replay that runs on a PR. Existing classes for "
+                f"{provider}: {detail}. Add a @PactFolder class alongside the broker one — "
+                "openbank-ledger-service carries exactly that pair."
+            )
+        else:
+            fail(
+                f"{pact} names provider {provider}, and NO @Provider(\"{provider}\") verification "
+                "class exists anywhere. Nothing can show this contract still holds."
+            )
+
+
+def check_no_orphan_providers(pacts: dict[str, str], classes: list[VerificationClass]) -> None:
+    named = set(pacts.values())
+    for c in classes:
+        if c.provider not in named:
+            fail(
+                f"{c.path} declares @Provider(\"{c.provider}\") but no pacts/*.json names that "
+                "provider — a typo in the provider name reads exactly like coverage"
+            )
+
+
+def check_allowlist_is_live(pacts: dict[str, str], allow: set[str]) -> None:
+    for pact in sorted(allow):
+        if pact not in pacts:
+            fail(f"KNOWN_UNCOVERED lists {pact}, which is not a committed pact — drop the stale entry")
+
+
+def selftest() -> int:
+    """Feed every check an input it MUST flag. A gate whose failure path never ran is unfalsified.
+
+    In-memory only; no file in the working tree is read or written by these cases.
+    """
+    print("== selftest: each check must reject a known-bad input ==")
+    results: list[tuple[str, bool]] = []
+
+    def run(name: str, fn) -> None:
+        global errors
+        saved, errors = errors, []
+        try:
+            fn()
+            caught = errors
+        finally:
+            errors = saved
+        results.append((name, bool(caught)))
+        print(f"  {name}: {'PASS (rejected)' if caught else 'FAIL (accepted bad input!)'}")
+        if caught:
+            print(f"      first message: {caught[0][:150]}")
+
+    folder = VerificationClass("a/FolderTest.kt", "p", "folder")
+    broker = VerificationClass("a/BrokerTest.kt", "p", "broker", gates=["@EnabledIfSystemProperty"])
+    gated_folder = VerificationClass("a/GatedTest.kt", "p", "folder", gates=["@Disabled"])
+    build_excluded = VerificationClass("a/ExcludedTest.kt", "p", "folder", excluded_by_build='exclude("**/ExcludedTest*")')
+    one_pact = {"pacts/c-p.json": "p"}
+
+    run("pact whose only replay is broker-gated", lambda: check_coverage(one_pact, [broker], set()))
+    run("pact whose replay is @Disabled", lambda: check_coverage(one_pact, [gated_folder], set()))
+    run("pact whose replay is excluded by build.gradle.kts", lambda: check_coverage(one_pact, [build_excluded], set()))
+    run("pact with no @Provider class at all", lambda: check_coverage(one_pact, [], set()))
+    run("covered pact still in KNOWN_UNCOVERED", lambda: check_coverage(one_pact, [folder], {"pacts/c-p.json"}))
+    run("KNOWN_UNCOVERED names a pact that no longer exists", lambda: check_allowlist_is_live(one_pact, {"pacts/gone.json"}))
+    run("@Provider name matches no pact", lambda: check_no_orphan_providers(one_pact, [VerificationClass("a/T.kt", "typo", "folder")]))
+    # The parser itself, both directions. Detect the artifact, never the prose (#2291): grepping
+    # src/test for the word "contract" once scored three services as verified off comment lines.
+    def assert_(name: str, ok: bool, good: str, bad: str) -> None:
+        results.append((name, ok))
+        print(f"  {name}: {'PASS (' + good + ')' if ok else 'FAIL (' + bad + ')'}")
+
+    commented = strip_comments('// @Provider("openbank-ghost") in a comment\n/* @PactFolder("../pacts") */\nclass X\n')
+    assert_(
+        "prose about @Provider is not read as a class",
+        not re.search(r'@Provider\(\s*"[^"]+"\s*\)', commented) and "@PactFolder" not in commented,
+        "ignored", "a comment would count as coverage!",
+    )
+    real = strip_comments(
+        'import au.com.dius.pact.provider.junit5.PactVerificationContext\n'
+        '@Provider("openbank-real")\n@PactFolder("../pacts")\nclass Y\n'
+    )
+    assert_(
+        "real annotation survives comment stripping",
+        bool(re.search(r'@Provider\(\s*"[^"]+"\s*\)', real)) and "@PactFolder" in real,
+        "still seen", "stripped too much!",
+    )
+    # A @Provider inside a string-literal code sample, in a file that never imports pact, must not
+    # count. openbank-flaky-test-hunter has exactly that, and it read as a verification class until
+    # the import precondition was added.
+    sample = '"""\npackage com.openbank.sample\n@Provider("openbank-sample-service")\nclass SamplePactProviderTest\n"""'
+    assert_(
+        "code sample with no pact import is not a class",
+        "au.com.dius.pact" not in strip_comments(sample),
+        "ignored", "a fixture would count as coverage!",
+    )
+
+    ok = all(flagged for _, flagged in results)
+    print()
+    print("selftest: ALL CHECKS CAN FAIL" if ok else "selftest: SOME CHECK IS UNFALSIFIED")
+    return 0 if ok else 1
+
+
+def main() -> int:
+    if "--selftest" in sys.argv:
+        return selftest()
+
+    pacts = scan_pacts()
+    classes = scan_verification_classes()
+
+    check_coverage(pacts, classes, KNOWN_UNCOVERED)
+    check_no_orphan_providers(pacts, classes)
+    check_allowlist_is_live(pacts, KNOWN_UNCOVERED)
+
+    replaying = {c.provider for c in classes if c.runs_on_pr}
+    covered = sum(1 for p in pacts.values() if p in replaying)
+    print(f"Committed pacts: {len(pacts)}")
+    print(f"Replayed on a PR by an always-running @PactFolder class: {covered}")
+    print(f"Declared uncovered (backlog, #2327): {len(KNOWN_UNCOVERED)}")
+    print()
+    for c in sorted(classes, key=lambda c: c.path):
+        print(f"  {'RUNS ' if c.runs_on_pr else 'SKIP '} {c.provider:38s} {c.path}  [{c.why_not()}]")
+    print()
+
+    if errors:
+        for e in errors:
+            print(f"::error::{e}")
+        print(f"\nFAIL: {len(errors)} provider-replay problem(s).")
+        return 1
+    print("OK — every committed pact is either replayed on a PR or a declared, still-accurate exception.")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/.github/scripts/check-pact-provider-replay.py
+++ b/.github/scripts/check-pact-provider-replay.py
@@ -50,17 +50,13 @@ PACTS = ROOT / "pacts"
 # reads it.
 KNOWN_UNCOVERED = {
     "pacts/openbank-account-service-openbank-balance-service.json",
-    "pacts/openbank-account-service-openbank-party-service.json",
     "pacts/openbank-balance-service-openbank-account-service.json",
     "pacts/openbank-consent-service-openbank-sca-service.json",
-    "pacts/openbank-kyc-service-openbank-party-service.json",
     # Landed 2026-07-25, after the #2327 audit counted 16 of 27: same three providers
     # (balance/transaction/party), so the same debt, not a new class of it. The estate went
     # 27 -> 33 pacts in a day, which is the argument for a gate rather than another audit.
     "pacts/openbank-mcp-service-openbank-balance-service.json",
-    "pacts/openbank-vop-service-openbank-party-service.json",
     "pacts/openbank-notification-service-openbank-account-service.json",
-    "pacts/openbank-onboarding-service-openbank-party-service.json",
     "pacts/openbank-sepa-payment-openbank-fraud-service.json",
     "pacts/openbank-transaction-service-openbank-balance-service.json",
     "pacts/openbank-transaction-service-openbank-fx-service.json",

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -585,6 +585,22 @@ jobs:
         if: github.event_name == 'pull_request'
         run: python3 openbank-infra/scripts/check-threat-model-diff.py --base "${PR_DIFF_BASE}"
 
+      # issue #2338. A consumer pact CANNOT catch a wrong request path — the Pact mock server
+      # answers whatever path the client asks for, so only the provider replay goes red. That is
+      # how finrep-service shipped a call to a ledger route that has never existed (#2269), with
+      # its consumer test green the whole time. CLAUDE.md has stated the rule since then — never
+      # add a consumer pact without wiring the provider's @PactFolder replay — and nothing
+      # enforced it, so 16 of 27 pacts had no replay running before merge (#2327); the estate then
+      # went to 33 pacts in a day. This derives the coverage set from pacts/*.json and the
+      # @Provider/@PactFolder annotations rather than any list, and a class that exists but cannot
+      # run (broker-sourced, gated, or excluded by its build.gradle.kts) does not count as
+      # coverage. Its own --selftest below feeds every check an input it MUST flag, because a gate
+      # that has only ever passed is unfalsified.
+      - name: "Pact provider-replay coverage self-test (issue #2338)"
+        run: python3 .github/scripts/check-pact-provider-replay.py --selftest
+      - name: "Pact provider-replay coverage (issue #2338, enforced)"
+        run: python3 .github/scripts/check-pact-provider-replay.py
+
       # CLAUDE.md rule 3 / ADR-0029: a module is a released component iff it has
       # a version.txt, and must be registered in release-please-config.json AND
       # .release-please-manifest.json. stdlib-only gate; catches a new service

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -177,10 +177,14 @@ These are real, repeatable gotchas — worth knowing before they cost you a debu
   main-push (the broker has no public ingress, ADR-0056), so its
   `@EnabledIfSystemProperty(pactbroker.url)` gate skips it and the contract is replayed only *after*
   the merge. Measured 2026-07-25: **16 of 27 committed pacts** were in that state, across eight
-  providers, several money-path (#2327). Nothing enforced the rule — it was prose here and nowhere
-  else, which is why the gap was invisible; a derived coverage check is #2338. Until that lands,
-  confirm the replay by hand: an always-running `@PactFolder` class for that provider, not merely a
-  class bearing its `@Provider` name.
+  providers, several money-path (#2327) — and the estate reached 33 pacts the same day, so an audit
+  was never going to hold it. `check-pact-provider-replay.py` now enforces it (`Validate manifests`,
+  #2338): it derives the covered set from `pacts/*.json` and the `@Provider`/`@PactFolder`
+  annotations, and a class that exists but cannot run — broker-sourced, gated, or excluded by its
+  `build.gradle.kts` — does not count. The pre-existing backlog is declared in that script's
+  `KNOWN_UNCOVERED`, which #2327 empties one provider at a time; an entry that becomes covered fails
+  as stale, so the list cannot outlive the debt. What this buys you: a NEW pact for a provider with
+  no `@PactFolder` replay is red at PR time, instead of being discovered by a later audit.
 - **In a consumer test the expected path must be a LITERAL; only the outgoing request may be
   reflected off the client's `@Path`.** Deriving *both* sides from the annotation feels DRY and is
   vacuous — expectation and request move together, so the test stays green when the client points

--- a/openbank-balance-service/src/test/kotlin/com/openbank/balance/contract/BalancePactFolderProviderVerificationTest.kt
+++ b/openbank-balance-service/src/test/kotlin/com/openbank/balance/contract/BalancePactFolderProviderVerificationTest.kt
@@ -1,0 +1,289 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright (c) OpenBank contributors. Licensed under the Apache License, Version 2.0.
+// See LICENSE in the repository root or https://www.apache.org/licenses/LICENSE-2.0 for details.
+
+package com.openbank.balance.contract
+
+import au.com.dius.pact.provider.junit5.HttpTestTarget
+import au.com.dius.pact.provider.junit5.PactVerificationContext
+import au.com.dius.pact.provider.junit5.PactVerificationInvocationContextProvider
+import au.com.dius.pact.provider.junitsupport.IgnoreNoPactsToVerify
+import au.com.dius.pact.provider.junitsupport.Provider
+import au.com.dius.pact.provider.junitsupport.State
+import au.com.dius.pact.provider.junitsupport.loader.PactFolder
+import com.openbank.balance.application.port.out.BalanceRepository
+import com.openbank.balance.application.port.out.HoldRepository
+import com.openbank.balance.domain.model.Balance
+import com.openbank.balance.domain.model.BalanceHold
+import io.quarkus.test.common.QuarkusTestResource
+import io.quarkus.test.junit.QuarkusTest
+import io.quarkus.test.security.TestSecurity
+import io.quarkus.vertx.core.runtime.context.VertxContextSafetyToggle
+import io.vertx.core.Vertx
+import io.vertx.core.impl.ContextInternal
+import jakarta.inject.Inject
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.asCoroutineDispatcher
+import kotlinx.coroutines.launch
+import org.eclipse.microprofile.config.inject.ConfigProperty
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.TestTemplate
+import org.junit.jupiter.api.extension.ExtendWith
+import java.math.BigDecimal
+import java.time.OffsetDateTime
+import java.util.UUID
+import java.util.concurrent.CompletableFuture
+import java.util.concurrent.Executor
+import java.util.concurrent.TimeUnit
+
+/**
+ * Git-pact provider verification for balance-service — the half that actually runs before a merge
+ * (issue #2327, gated by `check-pact-provider-replay.py` per #2338).
+ *
+ * balance-service is the provider for three committed pacts (six interactions, all HTTP) and its
+ * only verification class was [BalancePactProviderVerificationTest] — `@PactBroker`-sourced and
+ * `@EnabledIfSystemProperty(pactbroker.url)`-gated. On a pull request that property is empty
+ * (`_service-ci.yml` puts the PR lane on `ubuntu-latest` and blanks `PACT_BROKER_URL` off
+ * main-push, because the broker has no public ingress, ADR-0056), so it skipped and all three
+ * contracts were replayed only AFTER the merge. A consumer pact cannot catch a wrong request path;
+ * only the provider replay can (#2269), and balance-service is on the money path: two of these
+ * interactions are transaction-service reserving and releasing payment cover.
+ *
+ * ## Additive, not a replacement
+ *
+ * The broker twin stays exactly as it is. Its published verification result is the only thing
+ * ADR-0092's `can-i-deploy` reads, and dropping it is not hypothetical harm — the same swap on
+ * party-service (#371) left that service's auto-deploy hard-blocked for four days (#1166). Git
+ * source for the PR lane, broker source for the published result: the pair
+ * openbank-ledger-service carries. Two `@Provider` classes collide only when BOTH pull from the
+ * broker, since each then fetches every pact it holds.
+ *
+ * ## Upkeep
+ *
+ * A deliberate duplicate of the broker twin's body: same `@State` handlers, same seeded rows, same
+ * fixed UUIDs. A change to one belongs in the other, or the same contract passes from git and
+ * fails from the broker (or the reverse). Every interaction here is HTTP, so unlike the party and
+ * transaction twins there is no `MessageTestTarget` and no `@PactVerifyProvider` producer.
+ */
+@QuarkusTest
+@QuarkusTestResource(com.openbank.balance.it.PostgresRedpandaTestResource::class)
+@TestSecurity(user = "pact-verifier", roles = ["ROLE_SERVICE", "ROLE_OPERATOR"])
+@Provider("openbank-balance-service")
+@PactFolder("../pacts")
+@IgnoreNoPactsToVerify(ignoreIoErrors = "true")
+class BalancePactFolderProviderVerificationTest {
+
+    companion object {
+        // Fixed UUIDs must match each consumer pact exactly — grouped by consuming service.
+        // P2 pilot: transaction-service placeHold + releaseHold
+        private val HOLDS_ACCOUNT_ID = UUID.fromString("a1a1a1a1-a1a1-a1a1-a1a1-a1a1a1a1a1a1")
+        private val RELEASE_ACCOUNT_ID = UUID.fromString("c3c3c3c3-c3c3-c3c3-c3c3-c3c3c3c3c3c3")
+        private val RELEASE_HOLD_ID = UUID.fromString("b2b2b2b2-b2b2-b2b2-b2b2-b2b2b2b2b2b2")
+
+        // Batch A: account-service getBalances / getBalance / initialize
+        private val LIST_ACCOUNT_ID = UUID.fromString("d4d4d4d4-d4d4-d4d4-d4d4-d4d4d4d4d4d4")
+        private val SINGLE_ACCOUNT_ID = UUID.fromString("d5d5d5d5-d5d5-d5d5-d5d5-d5d5d5d5d5d5")
+    }
+
+    @ConfigProperty(name = "quarkus.http.test-port", defaultValue = "8081")
+    lateinit var testPort: String
+
+    @Inject
+    lateinit var balanceRepo: BalanceRepository
+
+    @Inject
+    lateinit var holdRepo: HoldRepository
+
+    @Inject
+    lateinit var vertx: Vertx
+
+    @BeforeEach
+    fun configureTarget(context: PactVerificationContext?) {
+        context?.target = HttpTestTarget("localhost", testPort.toInt())
+        context?.addStateChangeHandlers(this)
+    }
+
+    /**
+     * Bridges a reactive-Panache block into Pact-JVM's synchronous `@State` callback. Pact-JVM
+     * invokes `@State` methods directly via reflection on the JUnit test thread, which has no
+     * Vert.x context — `Panache.withTransaction`/`withSession` (used by [balanceRepo]/[holdRepo])
+     * require one, so a bare `runBlocking { balanceRepo.save(...) }` throws
+     * `IllegalStateException: No current Vertx context found`. Confirmed live: this broke every
+     * account-service<->balance-service pact verification since 2026-06-21 (verification result
+     * #389) without ever being noticed, because the failure only actually blocks a deploy once
+     * `can-i-deploy` is reached — `fx-service`'s own Pact provider test has the identical
+     * `runBlocking { reactiveRepo.save(...) }` pattern and is presumably equally broken.
+     *
+     * A plain `vertx.runOnContext { runBlocking { ... } }` is NOT sufficient: it throws a
+     * *different* `IllegalStateException` ("current context is not a duplicated context") because
+     * Quarkus's `VertxContextSafetyToggle` requires the reactive Panache call to run on a
+     * duplicated context (the kind Quarkus creates per-request), not a plain event-loop context.
+     * Nesting `runBlocking` inside that context is also independently wrong even once the
+     * duplicated+safe context is set up: it parks the very event-loop thread the reactive chain
+     * needs to resume on, deadlocking instead of throwing (verified empirically — it hung the
+     * test JVM for 15+ minutes). The fix duplicates the context, marks it safe via the same
+     * toggle Quarkus uses internally, and dispatches the coroutine onto it with a plain
+     * `CoroutineDispatcher` that posts via `runOnContext` — never blocking that thread — so
+     * suspension/resumption on the reactive chain completes normally.
+     */
+    private fun runOnVertxContext(block: suspend () -> Unit) {
+        val future = CompletableFuture<Unit>()
+        val duplicated = (vertx.orCreateContext as ContextInternal).duplicate()
+        VertxContextSafetyToggle.setContextSafe(duplicated, true)
+        val dispatcher = Executor { command -> duplicated.runOnContext { command.run() } }.asCoroutineDispatcher()
+        CoroutineScope(dispatcher).launch {
+            try {
+                block()
+                future.complete(Unit)
+            } catch (t: Throwable) {
+                future.completeExceptionally(t)
+            }
+        }
+        future.get(10, TimeUnit.SECONDS)
+    }
+
+    @TestTemplate
+    @ExtendWith(PactVerificationInvocationContextProvider::class)
+    fun verifyPacts(context: PactVerificationContext?) {
+        context?.verifyInteraction()
+    }
+
+    /**
+     * Idempotent seed. The same `@State` can run more than once in one JVM (Pact-JVM runs one
+     * verification per pact *version*, and enablePending/WIP pulls several), while the port's
+     * `save` is Panache `persist` — INSERT-only. The second run used to die on the
+     * `balances_account_id_currency_key` unique constraint (23505) inside the state-change
+     * callback, failing every interaction before it was even compared (issue #1771, verification
+     * results 2485/2486 and 9121/9122). Find-then-update keeps the seed re-runnable; `update`
+     * rewrites the amounts by (accountId, currency), which is exactly the reset the next
+     * verification pass needs.
+     */
+    private suspend fun seedBalance(balance: Balance) {
+        if (balanceRepo.findByAccountIdAndCurrency(balance.accountId, balance.currency) == null) {
+            balanceRepo.save(balance)
+        } else {
+            balanceRepo.update(balance)
+        }
+    }
+
+    /**
+     * Same idempotency for holds: the hold id is fixed, and a verified releaseHold sets
+     * `releasedAt` on the previous run's row — update resets it to active for the next pass.
+     */
+    private suspend fun seedHold(hold: BalanceHold) {
+        if (holdRepo.findById(hold.id) == null) {
+            holdRepo.save(hold)
+        } else {
+            holdRepo.update(hold)
+        }
+    }
+
+    @State("a CZK balance exists for the holds account with sufficient funds")
+    fun stateBalanceExists() = runOnVertxContext {
+        seedBalance(
+            Balance(
+                id = UUID.randomUUID(),
+                accountId = HOLDS_ACCOUNT_ID,
+                currency = "CZK",
+                bookedAmount = BigDecimal("10000.00"),
+                availableAmount = BigDecimal("10000.00"),
+                reservedAmount = BigDecimal.ZERO,
+                pendingAmount = BigDecimal.ZERO,
+                updatedAt = OffsetDateTime.now(),
+                version = 0L,
+            ),
+        )
+        Unit
+    }
+
+    @State("a CZK hold exists for the holds account")
+    fun stateHoldExists() = runOnVertxContext {
+        // Balance must exist before releaseHold — it looks up (accountId, currency) to update.
+        // Uses a distinct RELEASE_ACCOUNT_ID to avoid (accountId, currency) collision with the
+        // stateBalanceExists handler when both run in the same Testcontainer DB.
+        seedBalance(
+            Balance(
+                id = UUID.randomUUID(),
+                accountId = RELEASE_ACCOUNT_ID,
+                currency = "CZK",
+                bookedAmount = BigDecimal("10000.00"),
+                availableAmount = BigDecimal("9900.00"),
+                reservedAmount = BigDecimal("100.00"),
+                pendingAmount = BigDecimal.ZERO,
+                updatedAt = OffsetDateTime.now(),
+                version = 0L,
+            ),
+        )
+        seedHold(
+            BalanceHold(
+                id = RELEASE_HOLD_ID,
+                accountId = RELEASE_ACCOUNT_ID,
+                amount = BigDecimal("100.00"),
+                currency = "CZK",
+                reason = "payment-cover",
+                referenceId = "pact-tx-00000001",
+                expiresAt = null,
+                createdAt = OffsetDateTime.now(),
+                releasedAt = null,
+            ),
+        )
+        Unit
+    }
+
+    // --- Batch A: account-service states ---
+
+    @State("balances exist for the balance account")
+    fun stateBalancesExist() = runOnVertxContext {
+        seedBalance(
+            Balance(
+                id = UUID.randomUUID(),
+                accountId = LIST_ACCOUNT_ID,
+                currency = "CZK",
+                bookedAmount = BigDecimal("5000.00"),
+                availableAmount = BigDecimal("4900.00"),
+                reservedAmount = BigDecimal("100.00"),
+                pendingAmount = BigDecimal.ZERO,
+                updatedAt = OffsetDateTime.now(),
+                version = 0L,
+            ),
+        )
+        Unit
+    }
+
+    @State("a CZK balance exists for the balance account")
+    fun stateSingleCzkBalanceExists() = runOnVertxContext {
+        seedBalance(
+            Balance(
+                id = UUID.randomUUID(),
+                accountId = SINGLE_ACCOUNT_ID,
+                currency = "CZK",
+                bookedAmount = BigDecimal("5000.00"),
+                availableAmount = BigDecimal("4900.00"),
+                reservedAmount = BigDecimal("100.00"),
+                pendingAmount = BigDecimal.ZERO,
+                updatedAt = OffsetDateTime.now(),
+                version = 0L,
+            ),
+        )
+        Unit
+    }
+
+    @State("no CZK balance exists for the initialize account")
+    fun stateInitializeAccountHasNoBalance() {
+        // No-op: the Testcontainer DB is clean for e5e5 on every run.
+    }
+
+    /**
+     * State for mcp-service's `BalanceReadPactConsumerTest` (issue #2255, ADR-0195). No setup:
+     * `getBalances` skips its owner check when no `X-Customer-Party-Id` header is present (mcp is a
+     * service-to-service reader and sends none) and answers 200 with an empty `balances` array for
+     * an account it holds nothing for. That 200 is the point of the interaction — it proves the
+     * route exists; a 404 would prove nothing, since Quarkus answers 404 for an absent route too.
+     */
+    @State("balance-service is reachable and holds no balances for the pact account")
+    fun stateNoBalancesForPactAccount() {
+        // Intentionally empty — a fresh Testcontainer DB satisfies it by construction. Declared so
+        // the state is an explicit part of the contract; pact-jvm passes silently over an unhandled
+        // state name, which is how the missing states in #468 stayed invisible.
+    }
+}

--- a/openbank-party-service/src/test/kotlin/com/openbank/party/contract/PartyPactFolderProviderVerificationTest.kt
+++ b/openbank-party-service/src/test/kotlin/com/openbank/party/contract/PartyPactFolderProviderVerificationTest.kt
@@ -1,0 +1,296 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright (c) OpenBank contributors. Licensed under the Apache License, Version 2.0.
+// See LICENSE in the repository root or https://www.apache.org/licenses/LICENSE-2.0 for details.
+
+package com.openbank.party.contract
+
+import au.com.dius.pact.provider.PactVerifyProvider
+import au.com.dius.pact.provider.junit5.HttpTestTarget
+import au.com.dius.pact.provider.junit5.MessageTestTarget
+import au.com.dius.pact.provider.junit5.PactVerificationContext
+import au.com.dius.pact.provider.junit5.PactVerificationInvocationContextProvider
+import au.com.dius.pact.provider.junitsupport.IgnoreNoPactsToVerify
+import au.com.dius.pact.provider.junitsupport.Provider
+import au.com.dius.pact.provider.junitsupport.State
+import au.com.dius.pact.provider.junitsupport.loader.PactFolder
+import com.fasterxml.jackson.datatype.jsr310.JavaTimeModule
+import com.fasterxml.jackson.module.kotlin.jacksonObjectMapper
+import com.openbank.party.application.port.out.PartyRepository
+import com.openbank.party.domain.model.AmlStatus
+import com.openbank.party.domain.model.KycStatus
+import com.openbank.party.domain.model.Party
+import com.openbank.party.domain.model.PartyStatus
+import com.openbank.party.domain.model.PartyType
+import io.quarkus.test.common.QuarkusTestResource
+import io.quarkus.test.junit.QuarkusTest
+import io.quarkus.test.security.TestSecurity
+import io.quarkus.vertx.core.runtime.context.VertxContextSafetyToggle
+import io.vertx.core.Vertx
+import io.vertx.core.impl.ContextInternal
+import jakarta.inject.Inject
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.asCoroutineDispatcher
+import kotlinx.coroutines.launch
+import org.eclipse.microprofile.config.inject.ConfigProperty
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.TestTemplate
+import org.junit.jupiter.api.extension.ExtendWith
+import java.time.Instant
+import java.util.UUID
+import java.util.concurrent.CompletableFuture
+import java.util.concurrent.Executor
+import java.util.concurrent.TimeUnit
+
+/**
+ * Git-pact provider verification for party-service — the half that actually runs before a merge
+ * (issue #2327, gated by `check-pact-provider-replay.py` per #2338).
+ *
+ * ## Why this exists as a SECOND class rather than a switch on the first one
+ *
+ * party-service is the provider for four committed pacts, and its only verification class was
+ * [PartyEventPactProviderVerificationTest] — `@PactBroker`-sourced and
+ * `@EnabledIfSystemProperty(pactbroker.url)`-gated. On a pull request that property is empty
+ * (`_service-ci.yml` puts the PR lane on `ubuntu-latest` and blanks `PACT_BROKER_URL` off
+ * main-push, because the broker has no public ingress, ADR-0056), so it skipped and all four
+ * contracts were replayed only AFTER the merge. A consumer pact cannot catch a wrong request path;
+ * only the provider replay can (#2269).
+ *
+ * **Do not "fix" that by flipping the existing class to `@PactFolder`. That was tried and reverted.**
+ * #371 switched it for local-dev ergonomics, and party-service then published no verification result
+ * to the broker for any consumer — which is the only thing ADR-0092's `can-i-deploy` reads, so
+ * party-service's sandbox auto-deploy hard-blocked for four days with no way to unblock from the
+ * consumer side (#1166). The broker class must stay exactly as it is. This class is additive: git
+ * source for the PR lane, broker source for the published result. Two `@Provider` classes collide
+ * only when BOTH pull from the broker (each fetches every pact it holds); a folder class and a
+ * broker class each load their own source, which is the pair openbank-ledger-service carries.
+ *
+ * ## Upkeep
+ *
+ * This class is a deliberate duplicate of the broker twin's body: same `@State` handlers, same
+ * [PactVerifyProvider] producers, same seeded rows. A change to one belongs in the other, or the
+ * same contract passes from git and fails from the broker (or the reverse). The duplication is the
+ * conservative choice on purpose — factoring the shared body into a base class would mean editing
+ * the class whose last structural change wedged deploys for four days, for a cosmetic gain.
+ *
+ * ## Both interaction kinds, one class
+ *
+ * Five HTTP interactions (onboarding-service ×4, vop-service ×1) and five message interactions
+ * (account-service ×3, kyc-service ×2), so the target is chosen per interaction in
+ * [configureTarget]. The [MessageTestTarget] is package-scoped: the default classpath-wide
+ * ClassGraph scan throws on the JDK 25 toolchain.
+ */
+@QuarkusTest
+@QuarkusTestResource(com.openbank.party.it.PostgresRedpandaTestResource::class)
+@TestSecurity(user = "pact-verifier", roles = ["ROLE_KYC"])
+@Provider("openbank-party-service")
+@PactFolder("../pacts")
+@IgnoreNoPactsToVerify(ignoreIoErrors = "true")
+class PartyPactFolderProviderVerificationTest {
+
+    @ConfigProperty(name = "quarkus.http.test-port", defaultValue = "8081")
+    lateinit var testPort: String
+
+    @Inject
+    lateinit var partyRepository: PartyRepository
+
+    @Inject
+    lateinit var vertx: Vertx
+
+    private val objectMapper = jacksonObjectMapper().registerModule(JavaTimeModule())
+
+    /**
+     * Bridges a reactive-Panache block into Pact-JVM's synchronous `@State` callback — same fix as
+     * `BalancePactProviderVerificationTest.runOnVertxContext`: pact-jvm invokes `@State` methods
+     * directly via reflection on the JUnit test thread, which has no Vert.x context, so a bare
+     * `runBlocking { partyRepository.save(...) }` throws `IllegalStateException: No current Vertx
+     * context found`.
+     */
+    private fun runOnVertxContext(block: suspend () -> Unit) {
+        val future = CompletableFuture<Unit>()
+        val duplicated = (vertx.orCreateContext as ContextInternal).duplicate()
+        VertxContextSafetyToggle.setContextSafe(duplicated, true)
+        val dispatcher = Executor { command -> duplicated.runOnContext { command.run() } }.asCoroutineDispatcher()
+        CoroutineScope(dispatcher).launch {
+            try {
+                block()
+                future.complete(Unit)
+            } catch (t: Throwable) {
+                future.completeExceptionally(t)
+            }
+        }
+        future.get(10, TimeUnit.SECONDS)
+    }
+
+    @BeforeEach
+    fun configureTarget(context: PactVerificationContext?) {
+        if (context == null) return
+        // Package-scoped scan: the default classpath-wide ClassGraph scan throws on the JDK 25 toolchain.
+        context.target = if (context.interaction.isAsynchronousMessage()) {
+            MessageTestTarget(listOf("com.openbank.party.contract"))
+        } else {
+            HttpTestTarget("localhost", testPort.toInt())
+        }
+        context.addStateChangeHandlers(this)
+    }
+
+    @TestTemplate
+    @ExtendWith(PactVerificationInvocationContextProvider::class)
+    fun verifyPacts(context: PactVerificationContext?) {
+        // context is null on the @IgnoreNoPactsToVerify dummy invocation — skip gracefully.
+        context?.verifyInteraction()
+    }
+
+    @State("a party has been created")
+    fun partyHasBeenCreated() {
+        // No setup: the message is produced deterministically by the @PactVerifyProvider method below.
+    }
+
+    @PactVerifyProvider("a PARTY_CREATED event")
+    fun producePartyCreatedEvent(): String {
+        // Mirrors KafkaPartyEventPublisher.publish("PARTY_CREATED", party): the flat envelope, with
+        // enums serialized to their names (partyType -> "INDIVIDUAL", etc.).
+        val event = linkedMapOf(
+            "eventType" to "PARTY_CREATED",
+            "partyId" to UUID.randomUUID(),
+            "partyType" to PartyType.INDIVIDUAL,
+            "status" to PartyStatus.PENDING_KYC,
+            "kycStatus" to KycStatus.NOT_STARTED,
+            "legalName" to "Jane Smith",
+            "email" to "jane.smith@example.com",
+            "occurredAt" to Instant.now(),
+        )
+        return objectMapper.writeValueAsString(event)
+    }
+
+    @State("a party has been updated")
+    fun partyHasBeenUpdated() {
+        // No setup: produced deterministically by the @PactVerifyProvider method below.
+    }
+
+    @PactVerifyProvider("a PARTY_UPDATED event")
+    fun producePartyUpdatedEvent(): String {
+        val event = linkedMapOf(
+            "eventType" to "PARTY_UPDATED",
+            "partyId" to UUID.randomUUID(),
+            "partyType" to PartyType.INDIVIDUAL,
+            "status" to PartyStatus.ACTIVE,
+            "kycStatus" to KycStatus.APPROVED,
+            "legalName" to "Jane Smith",
+            "email" to "jane.smith@example.com",
+            "occurredAt" to Instant.now(),
+        )
+        return objectMapper.writeValueAsString(event)
+    }
+
+    @State("a party KYC status has changed")
+    fun partyKycStatusHasChanged() {
+        // No setup: produced deterministically by the @PactVerifyProvider method below.
+    }
+
+    @PactVerifyProvider("a KYC_STATUS_CHANGED event")
+    fun produceKycStatusChangedEvent(): String {
+        val event = linkedMapOf(
+            "eventType" to "KYC_STATUS_CHANGED",
+            "partyId" to UUID.randomUUID(),
+            "partyType" to PartyType.INDIVIDUAL,
+            "status" to PartyStatus.ACTIVE,
+            "kycStatus" to KycStatus.APPROVED,
+            "legalName" to "Jane Smith",
+            "email" to "jane.smith@example.com",
+            "occurredAt" to Instant.now(),
+        )
+        return objectMapper.writeValueAsString(event)
+    }
+
+    @State("a party has been erased")
+    fun partyHasBeenErased() {
+        // No setup: produced deterministically by the @PactVerifyProvider method below.
+    }
+
+    @PactVerifyProvider("a PARTY_ERASED event")
+    fun producePartyErasedEvent(): String {
+        // Mirrors KafkaPartyEventPublisher.publishPartyErased: the separate, narrower envelope
+        // (no partyType/status/kycStatus/legalName/email — those are gone by the time GDPR
+        // Art. 17 erasure runs).
+        val event = linkedMapOf(
+            "eventType" to "PARTY_ERASED",
+            "partyId" to UUID.randomUUID(),
+            "erasedAt" to Instant.now(),
+        )
+        return objectMapper.writeValueAsString(event)
+    }
+
+    @State("a party exists and can be suspended for KYC expiry")
+    fun partyExistsAndCanBeSuspended() = runOnVertxContext {
+        // pact-jvm 4.7.3 invokes each @State SETUP callback twice per interaction (visible for
+        // EVERY state in this class, not just this one — harmless for the no-op states above, but
+        // this one does a real insert with a fixed id, so the second call must be a no-op or it
+        // hits the parties_party_id_key unique constraint).
+        if (partyRepository.findById(FIXED_PARTY_ID) != null) return@runOnVertxContext
+        // Seeds the exact party id PartyServicePactConsumerTest's request path embeds
+        // (onboarding-service, issue #468) so PUT /{id}/kyc-status hits a real row.
+        partyRepository.save(
+            Party(
+                id = FIXED_PARTY_ID,
+                partyType = PartyType.INDIVIDUAL,
+                status = PartyStatus.PENDING_KYC,
+                legalName = "Pact Verify Party",
+                tradingName = null,
+                dateOfBirth = null,
+                nationality = null,
+                taxId = null,
+                registrationNumber = null,
+                email = "pact-verify-party@example.com",
+                phone = null,
+                address = null,
+                kycStatus = KycStatus.IN_PROGRESS,
+                createdAt = Instant.now(),
+                updatedAt = Instant.now(),
+                amlStatus = AmlStatus.NOT_SCREENED,
+            ),
+        )
+    }
+
+    /**
+     * State for vop-service's `PartyNameLookupPactConsumerTest` (issue #2255): hop 2 of the ADR-0171
+     * §4 VoP name resolution reads `legalName`/`tradingName` off `GET /api/v1/parties/{id}`, and the
+     * adapter falls back to `tradingName` when `legalName` is blank — so both fields must be present
+     * and non-blank on the seeded row, unlike [FIXED_PARTY_ID] above which has a null trading name.
+     *
+     * Seeded as a COMPANY: a party carrying both names is by construction a legal entity, and it
+     * keeps this row from colliding with the individual the KYC-expiry state above inserts.
+     */
+    @State("a party exists with both a legal name and a trading name")
+    fun partyExistsWithLegalAndTradingName() = runOnVertxContext {
+        // Idempotent for the same reason as the state above: pact-jvm 4.7.3 invokes each @State
+        // setup callback twice per interaction, and this one inserts with a fixed id.
+        if (partyRepository.findById(VOP_NAME_PARTY_ID) != null) return@runOnVertxContext
+        partyRepository.save(
+            Party(
+                id = VOP_NAME_PARTY_ID,
+                partyType = PartyType.COMPANY,
+                status = PartyStatus.ACTIVE,
+                legalName = "Pact Verify Trading Company a.s.",
+                tradingName = "PactVerify",
+                dateOfBirth = null,
+                nationality = null,
+                taxId = null,
+                registrationNumber = null,
+                email = "pact-verify-vop@example.com",
+                phone = null,
+                address = null,
+                kycStatus = KycStatus.APPROVED,
+                createdAt = Instant.now(),
+                updatedAt = Instant.now(),
+                amlStatus = AmlStatus.NOT_SCREENED,
+            ),
+        )
+    }
+
+    companion object {
+        private val FIXED_PARTY_ID = UUID.fromString("aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee")
+
+        /** Must equal `PartyNameLookupPactConsumerTest.PACT_PARTY_ID` (openbank-vop-service). */
+        private val VOP_NAME_PARTY_ID = UUID.fromString("b1b1b1b1-c2c2-4d4d-8e8e-f9f9f9f9f9f9")
+    }
+}

--- a/openbank-transaction-service/src/test/kotlin/com/openbank/transaction/contract/TransactionPactFolderProviderVerificationTest.kt
+++ b/openbank-transaction-service/src/test/kotlin/com/openbank/transaction/contract/TransactionPactFolderProviderVerificationTest.kt
@@ -1,0 +1,153 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright (c) OpenBank contributors. Licensed under the Apache License, Version 2.0.
+// See LICENSE in the repository root or https://www.apache.org/licenses/LICENSE-2.0 for details.
+
+package com.openbank.transaction.contract
+
+import au.com.dius.pact.provider.PactVerifyProvider
+import au.com.dius.pact.provider.junit5.HttpTestTarget
+import au.com.dius.pact.provider.junit5.MessageTestTarget
+import au.com.dius.pact.provider.junit5.PactVerificationContext
+import au.com.dius.pact.provider.junit5.PactVerificationInvocationContextProvider
+import au.com.dius.pact.provider.junitsupport.IgnoreNoPactsToVerify
+import au.com.dius.pact.provider.junitsupport.Provider
+import au.com.dius.pact.provider.junitsupport.State
+import au.com.dius.pact.provider.junitsupport.loader.PactFolder
+import com.fasterxml.jackson.databind.SerializationFeature
+import com.fasterxml.jackson.datatype.jsr310.JavaTimeModule
+import com.fasterxml.jackson.module.kotlin.jacksonObjectMapper
+import com.openbank.libs.domain.payment.InstructionType
+import com.openbank.libs.domain.payment.PaymentRail
+import com.openbank.transaction.domain.event.TransactionInitiatedEvent
+import com.openbank.transaction.domain.model.TransactionType
+import io.quarkus.test.common.QuarkusTestResource
+import io.quarkus.test.junit.QuarkusTest
+import io.quarkus.test.security.TestSecurity
+import org.eclipse.microprofile.config.inject.ConfigProperty
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.TestTemplate
+import org.junit.jupiter.api.extension.ExtendWith
+import java.math.BigDecimal
+import java.util.UUID
+
+/**
+ * Git-pact provider verification for transaction-service — the half that actually runs before a
+ * merge (issue #2327, gated by `check-pact-provider-replay.py` per #2338).
+ *
+ * ## Why this class exists at all
+ *
+ * A consumer pact CANNOT catch a wrong request path: the Pact mock server answers whatever path the
+ * client asks for, so a client pointed at a route that does not exist leaves the consumer test
+ * green. Only the provider replay goes red — that is how finrep-service shipped a call to a ledger
+ * route which has never existed (#2269). Transaction-service is the provider for six committed
+ * pacts, and its only verification class was [TransactionPactProviderVerificationTest], which is
+ * `@PactBroker`-sourced and `@EnabledIfSystemProperty(pactbroker.url)`-gated. On a pull request that
+ * property is empty — `_service-ci.yml` puts the PR lane on `ubuntu-latest` and blanks
+ * `PACT_BROKER_URL` off main-push, because the broker has no public ingress (ADR-0056) — so the
+ * class skipped and all six contracts were replayed only AFTER the merge.
+ *
+ * This class reads the same contracts from the committed `pacts/` directory (ADR-0063 git-pact), so
+ * it needs no broker, no CI secret and no network, and it runs on every PR.
+ *
+ * ## Two `@Provider` classes is deliberate here, not the footgun
+ *
+ * `CLAUDE.md` warns against two verification classes for one provider. That collision is two classes
+ * both pulling from the BROKER: each fetches every pact the broker holds, so an HTTP-targeted class
+ * also drags in the message pact and dies in its state-change callback. The sanctioned pair — the
+ * one openbank-ledger-service already carries — is one `@PactFolder` class plus one `@PactBroker`
+ * class, because each loads from its own source. This is that pair. Keep the two in sync: a `@State`
+ * or [PactVerifyProvider] added to one belongs in the other, or the same contract passes from git
+ * and fails from the broker (or the reverse).
+ *
+ * ## Both interaction kinds, one class
+ *
+ * Six pacts, five HTTP and one message, so the target is chosen per interaction in
+ * [configureTarget] exactly as in the broker twin: a [MessageTestTarget] for the fraud-service
+ * `transaction.initiated` contract, an [HttpTestTarget] for the rest. The [MessageTestTarget] is
+ * package-scoped on purpose — a classpath-wide ClassGraph scan throws on the JDK 25 toolchain.
+ *
+ * ## When this goes red
+ *
+ * Either a consumer changed its pact and did not regenerate it (`pact-drift-check.yml` catches that
+ * first), or transaction-service genuinely broke a contract — a renamed field, a moved route, a
+ * changed status code. Do not "fix" it by relaxing the pact: regenerate from the consumer test and
+ * read what changed.
+ */
+@QuarkusTest
+@QuarkusTestResource(com.openbank.transaction.it.PostgresRedpandaTestResource::class)
+@TestSecurity(user = "pact-verifier", roles = ["ROLE_OPERATOR"])
+@Provider("openbank-transaction-service")
+@PactFolder("../pacts")
+@IgnoreNoPactsToVerify(ignoreIoErrors = "true")
+class TransactionPactFolderProviderVerificationTest {
+
+    @ConfigProperty(name = "quarkus.http.test-port", defaultValue = "8081")
+    lateinit var testPort: String
+
+    private val objectMapper = jacksonObjectMapper()
+        .registerModule(JavaTimeModule())
+        .disable(SerializationFeature.WRITE_DATES_AS_TIMESTAMPS)
+
+    @BeforeEach
+    fun configureTarget(context: PactVerificationContext?) {
+        if (context == null) return
+        context.target = if (context.interaction.isAsynchronousMessage()) {
+            MessageTestTarget(listOf("com.openbank.transaction.contract"))
+        } else {
+            HttpTestTarget("localhost", testPort.toInt())
+        }
+        context.addStateChangeHandlers(this)
+    }
+
+    @TestTemplate
+    @ExtendWith(PactVerificationInvocationContextProvider::class)
+    fun verifyPacts(context: PactVerificationContext?) {
+        context?.verifyInteraction()
+    }
+
+    @State("the transaction service is available")
+    fun stateServiceAvailable() {
+        // TemporalTestResource provides an in-process Temporal server with NoOpPaymentWorkflow
+        // registered to return COMPLETED — no per-interaction setup needed here.
+    }
+
+    @State("a valid source account exists")
+    fun stateValidSourceAccountExists() {
+        // Shared by domestic-payment, sepa-payment and sepa-instant. No setup needed:
+        // initiateTransaction does not require the account to pre-exist in this test's Postgres,
+        // only that sourceAccountId parses as a UUID.
+    }
+
+    @State("transaction-service is reachable and holds no transactions for the pact account")
+    fun stateNoTransactionsForPactAccount() {
+        // mcp-service's TransactionListPactConsumerTest (#2255, ADR-0195). Intentionally empty — a
+        // fresh Testcontainer DB satisfies it by construction. Declared so the state is an explicit
+        // part of the contract: pact-jvm passes silently over an UNHANDLED state name, which is how
+        // #468's missing states stayed invisible.
+    }
+
+    @State("transaction-service has initiated a payment transaction")
+    fun stateTransactionInitiated() {
+        // No setup needed: the message producer below returns a deterministic payload.
+    }
+
+    @PactVerifyProvider("a transaction.initiated event for fraud screening")
+    fun produceTransactionInitiated(): String {
+        val event = TransactionInitiatedEvent(
+            aggregateId = UUID.fromString("11111111-1111-1111-1111-111111111111"),
+            version = 1L,
+            referenceNumber = "TXN-PACT-001",
+            type = TransactionType.DEBIT,
+            sourceAccountId = UUID.fromString("22222222-2222-2222-2222-222222222222"),
+            // ADR-0084 §3 v4: non-null so the fraud-service consumer pact (which asserts
+            // targetAccountId is a present UUID) verifies against a realistic payload.
+            targetAccountId = UUID.fromString("33333333-3333-3333-3333-333333333333"),
+            amount = BigDecimal("250.00"),
+            currencyCode = "CZK",
+            rail = PaymentRail.INTERNAL,
+            instructionType = InstructionType.ONE_OFF,
+            occurredAt = java.time.Instant.parse("2026-01-01T00:00:00Z"),
+        )
+        return objectMapper.writeValueAsString(event)
+    }
+}


### PR DESCRIPTION
## Summary

> **Fourth in a stack — merge order #2413 → #2417 → #2422 → this.** Base is `ci/pact-replay-party-service`.

`balance-service` is the provider for **three** committed pacts (six interactions, all HTTP) and its only verification class is `@PactBroker`-sourced and `@EnabledIfSystemProperty(pactbroker.url)`-gated — so it skips on every PR and those contracts were replayed only *after* the merge. Money path: two of the six are transaction-service reserving and releasing payment cover.

## Type of change

- [ ] feat (new functionality)
- [ ] fix (bug fix)
- [ ] refactor (no behavior change)
- [ ] perf (performance)
- [ ] docs
- [x] chore (build / tooling)
- [ ] security (private until disclosed)
- [ ] breaking change

Commit type is `test` — hidden, no release-please bump. No production code changed.

## Linked issues

Refs #2327
Refs #2269
Refs #2338

## Changes

- **New `BalancePactFolderProviderVerificationTest`** — `@PactFolder("../pacts")`, no gating annotation, same `@State` handlers, seeded rows and fixed UUIDs as the broker twin.
- **`KNOWN_UNCOVERED`** loses the three balance pacts: coverage **24 → 27**, backlog **9 → 6**.

## Reviewer notes

**Simpler than the previous two in the stack.** Every interaction is HTTP, so there is no `MessageTestTarget` and no `@PactVerifyProvider` producer — and therefore none of the duplicate-producer ambiguity #2417 and #2422 had to measure.

**Verified from the JUnit XML, not the console** — pact-jvm prints `Not all of the N were verified` on a fully green run:

```
tests=6 failures=0 errors=0
  transaction-service - POST placeHold to reserve funds for a payment
  transaction-service - DELETE releaseHold to release the payment cover
  account-service     - GET single CZK balance for an account
  account-service     - GET all balances for an account
  account-service     - POST initialize opening balance for an account
  mcp-service         - GET the balances the MCP get_balance tool returns verbatim
```

**Falsified rather than assumed:** renaming `BalanceResource`'s `@Path` to `/api/v1/balances-MOVED` turns **all six red** — the #2269 defect class, caught on contracts that would previously have skipped at PR time. Resource restored and the suite re-run green before committing.

**Additive, not a replacement.** The broker twin is untouched. Its published verification result is the only thing ADR-0092's `can-i-deploy` reads, and dropping it is not hypothetical harm: the same swap on party-service (#371) left that service's auto-deploy hard-blocked for four days (#1166).

**Cost:** one more `@QuarkusTest` with Testcontainers in balance-service's PR build.

## Definition of Done

- [x] Hexagonal layering preserved (domain has zero framework imports).
- [x] Unit tests added/updated. — this PR is the test
- [x] Integration tests added/updated (if service boundary involved). — six provider-side replays
- [x] Contract tests updated (if public API changed). — no pact content changed; they are now replayed pre-merge
- [x] `./gradlew detekt ktlintCheck koverVerify build` passes. — ktlintCheck + compileTestKotlin + the test itself
- [x] No new lint warnings.
- [ ] OpenAPI spec regenerated (if REST API changed). — N/A
- [ ] Flyway migration added + rollback note (if DB changed). — N/A
- [ ] Avro schema versioned backward-compatibly (if event changed). — N/A
- [x] Docs updated (README, ADR if architectural). — KDoc

## Security checklist

- [x] No secrets, tokens, passwords, or PII in code, config, tests, logs.
- [x] No new `@SuppressWarnings`, `as Any`, `@Suppress("...")` without justification.
- [x] No new third-party dependency.
- [ ] Auth / crypto / payment code changed? → N/A — test-only, though it now guards money-path contracts
- [ ] PII path changed? → N/A
- [ ] Cardholder data path changed? → N/A

## Compliance impact

- [x] None

## Rollout / Rollback

- Deployment strategy: N/A — test-only, no service artifact
- Rollback plan: revert the commit; the broker twin is untouched, so `can-i-deploy` is unaffected either way
- Data migration reversible: N/A
