### PR TITLE
test(sca): replay the consent-service provider pact before merge, not after

### DIFF
--- a/.github/scripts/check-pact-provider-replay.py
+++ b/.github/scripts/check-pact-provider-replay.py
@@ -49,10 +49,12 @@ PACTS = ROOT / "pacts"
 # ~44 generated files and give the PR a short shelf life. The list belongs next to the code that
 # reads it.
 KNOWN_UNCOVERED = {
-    "pacts/openbank-consent-service-openbank-sca-service.json",
-    # Landed 2026-07-25, after the #2327 audit counted 16 of 27: same three providers
-    # (balance/transaction/party), so the same debt, not a new class of it. The estate went
-    # 27 -> 33 pacts in a day, which is the argument for a gate rather than another audit.
+    # The last one, and the only entry that is BLOCKED rather than merely undone. Adding a
+    # @PactFolder class to openbank-swift-service would not help: its own build.gradle.kts
+    # statically excludes both SwiftEventPactConsumerTest and ClearingSimulatorPactConsumerTest
+    # whenever CI=true, so the pact is never regenerated there either (#2319, and #2318's drift
+    # gate declares the same exclusion for the same reason). Clear #2319 first, then delete this
+    # line and this comment together.
     "pacts/openbank-transaction-service-openbank-swift-service.json",
 }
 

--- a/openbank-sca-service/src/test/kotlin/com/openbank/sca/contract/ScaPactFolderProviderVerificationTest.kt
+++ b/openbank-sca-service/src/test/kotlin/com/openbank/sca/contract/ScaPactFolderProviderVerificationTest.kt
@@ -1,0 +1,154 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright (c) OpenBank contributors. Licensed under the Apache License, Version 2.0.
+// See LICENSE in the repository root or https://www.apache.org/licenses/LICENSE-2.0 for details.
+
+package com.openbank.sca.contract
+
+import au.com.dius.pact.provider.junit5.HttpTestTarget
+import au.com.dius.pact.provider.junit5.PactVerificationContext
+import au.com.dius.pact.provider.junit5.PactVerificationInvocationContextProvider
+import au.com.dius.pact.provider.junitsupport.IgnoreNoPactsToVerify
+import au.com.dius.pact.provider.junitsupport.Provider
+import au.com.dius.pact.provider.junitsupport.State
+import au.com.dius.pact.provider.junitsupport.loader.PactFolder
+import com.openbank.sca.application.port.out.ScaChallengeRepository
+import com.openbank.sca.domain.model.ScaChallenge
+import com.openbank.sca.domain.model.ScaMethod
+import com.openbank.sca.domain.model.ScaPurpose
+import com.openbank.sca.domain.model.ScaStatus
+import io.quarkus.test.common.QuarkusTestResource
+import io.quarkus.test.junit.QuarkusTest
+import io.quarkus.test.security.TestSecurity
+import io.quarkus.vertx.core.runtime.context.VertxContextSafetyToggle
+import io.vertx.core.Vertx
+import io.vertx.core.impl.ContextInternal
+import jakarta.inject.Inject
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.asCoroutineDispatcher
+import kotlinx.coroutines.launch
+import org.eclipse.microprofile.config.inject.ConfigProperty
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.TestTemplate
+import org.junit.jupiter.api.extension.ExtendWith
+import java.time.OffsetDateTime
+import java.util.UUID
+import java.util.concurrent.CompletableFuture
+import java.util.concurrent.Executor
+import java.util.concurrent.TimeUnit
+
+/**
+ * Git-pact provider verification for sca-service — the half that actually runs before a merge
+ * (issue #2327, gated by `check-pact-provider-replay.py` per #2338). Last provider in that sweep
+ * that was unblocked; only the two swift pacts remain, and those are stuck behind #2319.
+ *
+ * sca-service is the provider for one committed pact: consent-service's
+ * `GET /api/v1/sca/challenges/{id}`, which consent-service reads before activating a consent. Its
+ * only verification class was [ScaPactProviderVerificationTest] — `@PactBroker`-sourced and
+ * `@EnabledIfSystemProperty(pactbroker.url)`-gated. On a pull request that property is empty
+ * (`_service-ci.yml` puts the PR lane on `ubuntu-latest` and blanks `PACT_BROKER_URL` off
+ * main-push, because the broker has no public ingress, ADR-0056), so it skipped and the contract
+ * was replayed only AFTER the merge. A consumer pact cannot catch a wrong request path; only the
+ * provider replay can (#2269).
+ *
+ * ## Additive, not a replacement
+ *
+ * The broker twin stays as it is: its published verification result is the only thing ADR-0092's
+ * `can-i-deploy` reads, and the same swap elsewhere in the fleet blocked deploys for days
+ * (party-service #371/#1166, account-service #372/#1166). Git source for the PR lane, broker
+ * source for the published result — the pair openbank-ledger-service carries. Two `@Provider`
+ * classes collide only when BOTH pull from the broker, since each then fetches every pact it holds.
+ *
+ * ## What this replay does and does not prove
+ *
+ * It proves the route exists, answers 200, and returns `id`/`partyId` matching the UUID regex and
+ * `purpose`/`status` as strings. It does NOT pin the VALUES of `purpose` and `status`, which are
+ * `type` matchers — so a challenge answering with any status verifies green. That is safe here and
+ * worth stating why, rather than leaving the next reader to work it out: `ConsentService`
+ * .activateConsent fails CLOSED on it (`if (scaChallenge.status != "COMPLETED") throw
+ * ConsentScaNotCompletedException`), and `ScaStatus` really does carry `COMPLETED`, so an
+ * unexpected status denies activation rather than granting it. The matcher is still weaker than
+ * the field deserves; tracked with the other instances on #2425.
+ *
+ * ## Upkeep
+ *
+ * A deliberate duplicate of the broker twin's body: same `@State` handler and seeded challenge row.
+ * A change to one belongs in the other, or the same contract passes from git and fails from the
+ * broker (or the reverse).
+ */
+@QuarkusTest
+@QuarkusTestResource(com.openbank.sca.it.PostgresRedisTestResource::class)
+@TestSecurity(user = "pact-verifier", roles = ["ROLE_SERVICE", "ROLE_OPERATOR"])
+@Provider("openbank-sca-service")
+@PactFolder("../pacts")
+@IgnoreNoPactsToVerify(ignoreIoErrors = "true")
+class ScaPactFolderProviderVerificationTest {
+
+    companion object {
+        private val CHALLENGE_ID = UUID.fromString("99999999-9999-9999-9999-999999999999")
+        private val PARTY_ID = UUID.fromString("aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa")
+    }
+
+    @ConfigProperty(name = "quarkus.http.test-port", defaultValue = "8081")
+    lateinit var testPort: String
+
+    @Inject
+    lateinit var challengeRepo: ScaChallengeRepository
+
+    @Inject
+    lateinit var vertx: Vertx
+
+    @BeforeEach
+    fun configureTarget(context: PactVerificationContext?) {
+        context?.target = HttpTestTarget("localhost", testPort.toInt())
+        context?.addStateChangeHandlers(this)
+    }
+
+    /**
+     * Bridges a reactive-Panache block into Pact-JVM's synchronous `@State` callback. Pact-JVM
+     * invokes `@State` methods directly via reflection on the JUnit test thread, which has no
+     * Vert.x context — `Panache.withTransaction`/`withSession` (used by [challengeRepo]) requires
+     * one, so a bare `runBlocking { challengeRepo.save(...) }` throws `IllegalStateException: No
+     * current Vertx context found`. Confirmed live: this silently broke every
+     * consent-service<->sca-service pact verification (result 2026-07-14T11:28:06Z) without ever
+     * being noticed, because the failure only actually blocks a deploy once `can-i-deploy` is
+     * reached. Same fix as balance-service's `BalancePactProviderVerificationTest` (which
+     * documents why a plain `vertx.runOnContext { runBlocking { ... } }` is NOT sufficient).
+     */
+    private fun runOnVertxContext(block: suspend () -> Unit) {
+        val future = CompletableFuture<Unit>()
+        val duplicated = (vertx.orCreateContext as ContextInternal).duplicate()
+        VertxContextSafetyToggle.setContextSafe(duplicated, true)
+        val dispatcher = Executor { command -> duplicated.runOnContext { command.run() } }.asCoroutineDispatcher()
+        CoroutineScope(dispatcher).launch {
+            try {
+                block()
+                future.complete(Unit)
+            } catch (t: Throwable) {
+                future.completeExceptionally(t)
+            }
+        }
+        future.get(10, TimeUnit.SECONDS)
+    }
+
+    @TestTemplate
+    @ExtendWith(PactVerificationInvocationContextProvider::class)
+    fun verifyPacts(context: PactVerificationContext?) {
+        context?.verifyInteraction()
+    }
+
+    @State("a PENDING SCA challenge exists")
+    fun statePendingChallengeExists() = runOnVertxContext {
+        challengeRepo.save(
+            ScaChallenge(
+                id = CHALLENGE_ID,
+                partyId = PARTY_ID,
+                purpose = ScaPurpose.CONSENT_GRANT,
+                method = ScaMethod.PUSH_NOTIFICATION,
+                status = ScaStatus.PENDING,
+                expiresAt = OffsetDateTime.now().plusMinutes(5),
+                createdAt = OffsetDateTime.now(),
+            ),
+        )
+        Unit
+    }
+}


### PR DESCRIPTION
## Summary

> **Eighth and last in the stack — merge order #2413 → #2417 → #2422 → #2424 → #2427 → #2428 → #2430 → this.** Base is `ci/pact-replay-fx-service`.

`sca-service` is the provider for **one** committed pact — consent-service's `GET /api/v1/sca/challenges/{id}`, read before a consent is activated. Its only verification class is `@PactBroker`-sourced and `@EnabledIfSystemProperty(pactbroker.url)`-gated, so it skips on every PR.

**This finishes the unblocked half of #2327: coverage 32 of 33.**

## Type of change

- [ ] feat (new functionality)
- [ ] fix (bug fix)
- [ ] refactor (no behavior change)
- [ ] perf (performance)
- [ ] docs
- [x] chore (build / tooling)
- [ ] security (private until disclosed)
- [ ] breaking change

Commit type is `test` — hidden, no release-please bump. No production code changed.

## Linked issues

Refs #2327
Refs #2269
Refs #2425
Refs #2319

## Changes

- **New `ScaPactFolderProviderVerificationTest`** — `@PactFolder("../pacts")`, no gating annotation, same `@State` handler and seeded challenge row as the broker twin.
- **`KNOWN_UNCOVERED`** loses the sca pact: coverage **31 → 32**, backlog **2 → 1**.
- **Rewrote the `KNOWN_UNCOVERED` comment.** It still described entries that have since been cleared. A shrinking list with stale prose beside it is exactly the drift this gate exists to prevent, so the comment now says what is actually left and why.

## Reviewer notes

**The one remaining entry is blocked, not undone.** Adding a `@PactFolder` class to swift-service would not help: its `build.gradle.kts` statically excludes both consumer pact tests when `CI=true`, so the pact is never regenerated there either. #2319 has to clear first — then that line and its comment get deleted together.

**Verified from the JUnit XML, not the console:** `tests=1 failures=0` (17.1 s).

**Falsified:** renaming `ScaResource`'s `@Path` to `/api/v1/sca-MOVED` turns it **red**. Resource restored and the suite re-run green before committing.

**Fourth instance of the matcher problem — and this time I checked whether it was dangerous before writing it down.** `$.purpose` and `$.status` are `type` matchers, so a challenge answering with any status verifies green. On an SCA field that reads like a bypass, so it was worth tracing rather than assuming either way:

- `ConsentService.activateConsent` fails **closed**: `if (scaChallenge.status != "COMPLETED") throw ConsentScaNotCompletedException`
- `ScaStatus` really does carry `COMPLETED`, so the string the consumer requires is one the provider can emit — no dead check either

So an unexpected status **denies** activation rather than granting it. Safe, and the reasoning is in the KDoc so the next reader does not have to redo it. The matcher is still weaker than an authorisation-adjacent field deserves; tracked on #2425 with the others.

**Additive, not a replacement.** The broker twin is untouched — its published verification result is the only thing ADR-0092's `can-i-deploy` reads (party-service #371/#1166, account-service #372/#1166).

## Definition of Done

- [x] Hexagonal layering preserved (domain has zero framework imports).
- [x] Unit tests added/updated. — this PR is the test
- [x] Integration tests added/updated (if service boundary involved). — one provider-side replay
- [x] Contract tests updated (if public API changed). — no pact content changed; it is now replayed pre-merge
- [x] `./gradlew detekt ktlintCheck koverVerify build` passes. — ktlintCheck + compileTestKotlin + the test itself
- [x] No new lint warnings.
- [ ] OpenAPI spec regenerated (if REST API changed). — N/A
- [ ] Flyway migration added + rollback note (if DB changed). — N/A
- [ ] Avro schema versioned backward-compatibly (if event changed). — N/A
- [x] Docs updated (README, ADR if architectural). — KDoc

## Security checklist

- [x] No secrets, tokens, passwords, or PII in code, config, tests, logs.
- [x] No new `@SuppressWarnings`, `as Any`, `@Suppress("...")` without justification.
- [x] No new third-party dependency.
- [x] Auth / crypto / payment code changed? → **no code changed**; the SCA status matcher was traced and confirmed to fail closed, see Reviewer notes
- [ ] PII path changed? → N/A
- [ ] Cardholder data path changed? → N/A

## Compliance impact

- [x] None *(touches the PSD2/SCA read path, but changes no behaviour)*

## Rollout / Rollback

- Deployment strategy: N/A — test-only, no service artifact
- Rollback plan: revert the commit; the broker twin is untouched, so `can-i-deploy` is unaffected either way
- Data migration reversible: N/A
