### PR TITLE
feat(party): project consent-service's marketing consent into consent_marketing (ADR-0205 D4)

### DIFF
--- a/openbank-infra/gitops/components/party/kafka-party-mtls.yaml
+++ b/openbank-infra/gitops/components/party/kafka-party-mtls.yaml
@@ -5,9 +5,10 @@
 # control; domain-event topics without ACLs stay open under allow.everyone.if.no.acl.found=true.
 #
 # party-service ACL surface:
-#   Write + Describe: openbank.party.events  (own domain event output + outbox relay)
-#   Read  + Describe: openbank.kyc.events    (KYC case-lifecycle gate, ADR-0073)
-#   Read  + Describe: openbank.aml.events    (AML case-lifecycle gate, ADR-0073)
+#   Write + Describe: openbank.party.events    (own domain event output + outbox relay)
+#   Read  + Describe: openbank.kyc.events      (KYC case-lifecycle gate, ADR-0073)
+#   Read  + Describe: openbank.aml.events      (AML case-lifecycle gate, ADR-0073)
+#   Read  + Describe: openbank.consent.events  (marketing-consent projection, ADR-0205 D4)
 #   Read:             group openbank-party-service
 #
 # Cert projection: Strimzi User Operator mints the keystore Secret in `messaging`;
@@ -47,6 +48,12 @@ spec:
       - resource:
           type: topic
           name: openbank.aml.events
+          patternType: literal
+        operations: [Read, Describe]
+        host: "*"
+      - resource:
+          type: topic
+          name: openbank.consent.events
           patternType: literal
         operations: [Read, Describe]
         host: "*"

--- a/openbank-party-service/ktlint-baseline.xml
+++ b/openbank-party-service/ktlint-baseline.xml
@@ -1,5 +1,8 @@
 <?xml version="1.0" encoding="utf-8"?>
 <baseline version="1.0">
+    <file name="src/main/kotlin/com/openbank/party/application/port/in/MarketingConsentProjectionUseCase.kt">
+        <error line="5" column="9" source="standard:package-name" />
+    </file>
     <file name="src/main/kotlin/com/openbank/party/application/port/in/PartyPort.kt">
         <error line="5" column="9" source="standard:package-name" />
         <error line="8" column="1" source="standard:no-wildcard-imports" />

--- a/openbank-party-service/src/main/kotlin/com/openbank/party/application/port/in/MarketingConsentProjectionUseCase.kt
+++ b/openbank-party-service/src/main/kotlin/com/openbank/party/application/port/in/MarketingConsentProjectionUseCase.kt
@@ -1,0 +1,28 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright (c) OpenBank contributors. Licensed under the Apache License, Version 2.0.
+// See LICENSE in the repository root or https://www.apache.org/licenses/LICENSE-2.0 for details.
+
+package com.openbank.party.application.port.`in`
+
+import java.time.Instant
+import java.util.UUID
+
+/**
+ * Drives the `parties.consent_marketing` projection from consent-service's outbox (ADR-0205 D4).
+ * Not part of [PartyUseCase] deliberately — this is a narrow, event-driven projection concern with
+ * its own tracking state ([com.openbank.party.application.port.out.MarketingConsentTrackingRepository]),
+ * not a party-aggregate command a human or another service invokes directly.
+ */
+interface MarketingConsentProjectionUseCase {
+
+    /** A marketing consent was granted (or re-granted) for [partyId]. Always applies — a fresh grant wins. */
+    suspend fun applyGranted(partyId: UUID, consentId: UUID, occurredAt: Instant)
+
+    /**
+     * A marketing consent was revoked or expired. Applies ONLY if [consentId] matches the
+     * currently tracked consent for [partyId] — an out-of-order or late-delivered event for a
+     * consent already superseded by a fresh grant must not clear the newer one. Returns whether
+     * it applied, purely for observability (callers do not need to branch on it).
+     */
+    suspend fun applyRevokedOrExpired(partyId: UUID, consentId: UUID, occurredAt: Instant): Boolean
+}

--- a/openbank-party-service/src/main/kotlin/com/openbank/party/application/port/out/MarketingConsentTrackingRepository.kt
+++ b/openbank-party-service/src/main/kotlin/com/openbank/party/application/port/out/MarketingConsentTrackingRepository.kt
@@ -1,0 +1,31 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright (c) OpenBank contributors. Licensed under the Apache License, Version 2.0.
+// See LICENSE in the repository root or https://www.apache.org/licenses/LICENSE-2.0 for details.
+
+package com.openbank.party.application.port.out
+
+import java.time.Instant
+import java.util.UUID
+
+/** The currently ACTIVE marketing consent tracked for one party (ADR-0205 D4). */
+data class MarketingConsentTracking(val partyId: UUID, val consentId: UUID, val grantedAt: Instant)
+
+/**
+ * Outbound persistence port for [MarketingConsentTracking] (ADR-0205 D4) — backs the party-service
+ * consumer of consent-service's outbox so a Revoked/Expired event can be matched against the
+ * currently tracked consentId rather than trusted blindly (an out-of-order or late-delivered
+ * revoke for a superseded consent must not clear a customer's fresh re-grant).
+ */
+interface MarketingConsentTrackingRepository {
+
+    suspend fun findByPartyId(partyId: UUID): MarketingConsentTracking?
+
+    /** Insert or replace the tracked consent for [partyId] — a fresh grant always wins. */
+    suspend fun upsert(tracking: MarketingConsentTracking)
+
+    /**
+     * Delete the tracked row for [partyId] only if its consentId equals [consentId] — the
+     * match-before-clear guard. Returns true iff a row was deleted (i.e. the event applied).
+     */
+    suspend fun deleteIfMatches(partyId: UUID, consentId: UUID): Boolean
+}

--- a/openbank-party-service/src/main/kotlin/com/openbank/party/application/port/out/PartyPorts.kt
+++ b/openbank-party-service/src/main/kotlin/com/openbank/party/application/port/out/PartyPorts.kt
@@ -8,6 +8,7 @@ import com.openbank.party.domain.model.Party
 import com.openbank.party.domain.model.PartyDocument
 import com.openbank.party.domain.model.PartyDocumentFile
 import com.openbank.party.domain.model.PartyStatus
+import java.time.Instant
 import java.util.UUID
 
 /** Outbound persistence port for the party aggregate. */
@@ -46,6 +47,15 @@ interface PartyRepository {
 
     /** ADR-0072: look up a party by pre-computed RČ blind index (exact match). */
     suspend fun findByRcBlindIndex(index: String): Party?
+
+    /**
+     * Scoped update of the marketing-consent projection (ADR-0205 D4) — a targeted UPDATE, not a
+     * find-then-mutate-then-save of the whole [Party] aggregate, so it cannot clobber an unrelated
+     * concurrent write to any other party field. No-op if the party row does not exist (the
+     * consumer that calls this only has a partyId from an event, not a guarantee the party still
+     * exists locally).
+     */
+    suspend fun updateMarketingConsentProjection(partyId: UUID, granted: Boolean, at: Instant)
 }
 
 /** Outbound persistence port for party identity documents. */

--- a/openbank-party-service/src/main/kotlin/com/openbank/party/application/usecase/MarketingConsentProjectionService.kt
+++ b/openbank-party-service/src/main/kotlin/com/openbank/party/application/usecase/MarketingConsentProjectionService.kt
@@ -1,0 +1,33 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright (c) OpenBank contributors. Licensed under the Apache License, Version 2.0.
+// See LICENSE in the repository root or https://www.apache.org/licenses/LICENSE-2.0 for details.
+
+package com.openbank.party.application.usecase
+
+import com.openbank.party.application.port.`in`.MarketingConsentProjectionUseCase
+import com.openbank.party.application.port.out.MarketingConsentTracking
+import com.openbank.party.application.port.out.MarketingConsentTrackingRepository
+import com.openbank.party.application.port.out.PartyRepository
+import jakarta.enterprise.context.ApplicationScoped
+import java.time.Instant
+import java.util.UUID
+
+@ApplicationScoped
+class MarketingConsentProjectionService(
+    private val trackingRepository: MarketingConsentTrackingRepository,
+    private val partyRepository: PartyRepository,
+) : MarketingConsentProjectionUseCase {
+
+    override suspend fun applyGranted(partyId: UUID, consentId: UUID, occurredAt: Instant) {
+        trackingRepository.upsert(MarketingConsentTracking(partyId, consentId, occurredAt))
+        partyRepository.updateMarketingConsentProjection(partyId, granted = true, at = occurredAt)
+    }
+
+    override suspend fun applyRevokedOrExpired(partyId: UUID, consentId: UUID, occurredAt: Instant): Boolean {
+        val applied = trackingRepository.deleteIfMatches(partyId, consentId)
+        if (applied) {
+            partyRepository.updateMarketingConsentProjection(partyId, granted = false, at = occurredAt)
+        }
+        return applied
+    }
+}

--- a/openbank-party-service/src/main/kotlin/com/openbank/party/infrastructure/kafka/MarketingConsentEventConsumer.kt
+++ b/openbank-party-service/src/main/kotlin/com/openbank/party/infrastructure/kafka/MarketingConsentEventConsumer.kt
@@ -1,0 +1,76 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright (c) OpenBank contributors. Licensed under the Apache License, Version 2.0.
+// See LICENSE in the repository root or https://www.apache.org/licenses/LICENSE-2.0 for details.
+
+package com.openbank.party.infrastructure.kafka
+
+import com.fasterxml.jackson.databind.JsonNode
+import com.fasterxml.jackson.databind.ObjectMapper
+import com.openbank.party.application.port.`in`.MarketingConsentProjectionUseCase
+import jakarta.enterprise.context.ApplicationScoped
+import org.eclipse.microprofile.reactive.messaging.Incoming
+import org.jboss.logging.Logger
+import java.time.Instant
+import java.util.UUID
+
+/**
+ * Projects consent-service's marketing-consent grant/revoke/expiry into `parties.consent_marketing`
+ * (ADR-0205 D4). Consumes the WHOLE consent-events topic — every ConsentGranted/Revoked/Expired for
+ * every grantee, TPPs included — and filters to [MARKETING_GRANTEE_ID], the fixed internal-grant
+ * convention ADR-0205 D3 establishes. Everything else is silently ignored: this is by far the
+ * common case (most consent events on this topic are PSD2 TPP consents this service has no
+ * business touching), so it is not logged as a skip.
+ *
+ * Poison-pill safe: parse/handle failures are logged and acked so one bad event cannot wedge the
+ * consumer group — consent-service remains the source of truth and can be replayed.
+ */
+@ApplicationScoped
+class MarketingConsentEventConsumer(
+    private val projectionUseCase: MarketingConsentProjectionUseCase,
+    private val objectMapper: ObjectMapper,
+) {
+    private val log = Logger.getLogger(MarketingConsentEventConsumer::class.java)
+
+    companion object {
+        const val MARKETING_GRANTEE_ID = "party-service:marketing-comms"
+    }
+
+    @Incoming("consent-events-in")
+    @Suppress("TooGenericExceptionCaught") // poison-pill safety: catch-all so one malformed or
+    // unexpected record can never wedge the consumer group — same convention as
+    // KycAmlEventConsumer's identical catch (grandfathered into this service's detekt baseline;
+    // this is a new file, so it needs its own suppression rather than relying on that baseline).
+    suspend fun consume(payload: String) {
+        try {
+            val node = objectMapper.readTree(payload)
+            if (node.path("granteeId").asText() != MARKETING_GRANTEE_ID) return
+
+            val partyId = node.path("partyId").asUuidOrNull() ?: return
+            val consentId = node.path("aggregateId").asUuidOrNull() ?: return
+            val occurredAt = node.path("occurredAt").asInstantOrNull() ?: Instant.now()
+
+            when (node.path("eventType").asText()) {
+                "ConsentGranted" -> {
+                    projectionUseCase.applyGranted(partyId, consentId, occurredAt)
+                    log.infof("Marketing consent GRANTED projected for party %s", partyId)
+                }
+                "ConsentRevoked", "ConsentExpired" -> {
+                    val applied = projectionUseCase.applyRevokedOrExpired(partyId, consentId, occurredAt)
+                    log.infof(
+                        "Marketing consent %s for party %s: applied=%s",
+                        node.path("eventType").asText(),
+                        partyId,
+                        applied,
+                    )
+                }
+                else -> return // ConsentRejected or any future event type: nothing to project.
+            }
+        } catch (e: Exception) {
+            log.errorf(e, "Failed to handle marketing consent event: %.300s", payload)
+        }
+    }
+
+    private fun JsonNode.asUuidOrNull(): UUID? = runCatching { UUID.fromString(asText()) }.getOrNull()
+
+    private fun JsonNode.asInstantOrNull(): Instant? = runCatching { Instant.parse(asText()) }.getOrNull()
+}

--- a/openbank-party-service/src/main/kotlin/com/openbank/party/infrastructure/kafka/MarketingConsentEventConsumer.kt
+++ b/openbank-party-service/src/main/kotlin/com/openbank/party/infrastructure/kafka/MarketingConsentEventConsumer.kt
@@ -47,7 +47,17 @@ class MarketingConsentEventConsumer(
 
             val partyId = node.path("partyId").asUuidOrNull() ?: return
             val consentId = node.path("aggregateId").asUuidOrNull() ?: return
-            val occurredAt = node.path("occurredAt").asInstantOrNull() ?: Instant.now()
+            // Falling back to wall-clock time silently would corrupt consent_marketing_updated_at
+            // with no way to tell "real event timestamp" from "consumer processed this late/replayed
+            // it" apart in an audit trail — log it loudly so the fallback is never mistaken for the
+            // happy path.
+            val occurredAt = node.path("occurredAt").asInstantOrNull() ?: run {
+                log.warnf(
+                    "Marketing consent event missing/unparseable occurredAt, falling back to now(): %.300s",
+                    payload,
+                )
+                Instant.now()
+            }
 
             when (node.path("eventType").asText()) {
                 "ConsentGranted" -> {

--- a/openbank-party-service/src/main/kotlin/com/openbank/party/infrastructure/persistence/entity/PartyMarketingConsentEntity.kt
+++ b/openbank-party-service/src/main/kotlin/com/openbank/party/infrastructure/persistence/entity/PartyMarketingConsentEntity.kt
@@ -1,0 +1,32 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright (c) OpenBank contributors. Licensed under the Apache License, Version 2.0.
+// See LICENSE in the repository root or https://www.apache.org/licenses/LICENSE-2.0 for details.
+
+package com.openbank.party.infrastructure.persistence.entity
+
+import io.quarkus.hibernate.reactive.panache.kotlin.PanacheEntity
+import jakarta.persistence.Column
+import jakarta.persistence.Entity
+import jakarta.persistence.Table
+import java.time.Instant
+import java.util.UUID
+
+/**
+ * Tracks the currently ACTIVE marketing consent per party (ADR-0205 D4). Surrogate [PanacheEntity]
+ * id, `partyId` as the unique business key — matching [PartyEntity]'s own convention, deliberately
+ * NOT an application-assigned primary key, so both insert (new grant) and update (re-grant) go
+ * through Panache's normal managed-entity dirty-checking rather than the `persist()`-is-INSERT-only
+ * pitfall an assigned `@Id` would hit.
+ */
+@Entity
+@Table(name = "party_marketing_consent")
+class PartyMarketingConsentEntity : PanacheEntity() {
+    @Column(name = "party_id", nullable = false, unique = true)
+    lateinit var partyId: UUID
+
+    @Column(name = "consent_id", nullable = false)
+    lateinit var consentId: UUID
+
+    @Column(name = "granted_at", nullable = false)
+    lateinit var grantedAt: Instant
+}

--- a/openbank-party-service/src/main/kotlin/com/openbank/party/infrastructure/persistence/repository/MarketingConsentTrackingRepositoryImpl.kt
+++ b/openbank-party-service/src/main/kotlin/com/openbank/party/infrastructure/persistence/repository/MarketingConsentTrackingRepositoryImpl.kt
@@ -1,0 +1,60 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright (c) OpenBank contributors. Licensed under the Apache License, Version 2.0.
+// See LICENSE in the repository root or https://www.apache.org/licenses/LICENSE-2.0 for details.
+
+package com.openbank.party.infrastructure.persistence.repository
+
+import com.openbank.party.application.port.out.MarketingConsentTracking
+import com.openbank.party.application.port.out.MarketingConsentTrackingRepository
+import com.openbank.party.infrastructure.persistence.entity.PartyMarketingConsentEntity
+import io.quarkus.hibernate.reactive.panache.Panache
+import io.quarkus.hibernate.reactive.panache.kotlin.PanacheRepository
+import io.smallrye.mutiny.Uni
+import io.smallrye.mutiny.coroutines.awaitSuspending
+import jakarta.enterprise.context.ApplicationScoped
+import java.util.UUID
+
+@ApplicationScoped
+class MarketingConsentTrackingRepositoryImpl :
+    MarketingConsentTrackingRepository,
+    PanacheRepository<PartyMarketingConsentEntity> {
+
+    override suspend fun findByPartyId(partyId: UUID): MarketingConsentTracking? =
+        Panache.withSession { find("partyId", partyId).firstResult() }.awaitSuspending()?.toDomain()
+
+    // Insert-or-update via find-then-mutate — PartyMarketingConsentEntity's PanacheEntity surrogate
+    // id makes this Hibernate-managed dirty-checking (safe for update), not the persist()-is-
+    // INSERT-only pitfall an application-assigned @Id would hit.
+    override suspend fun upsert(tracking: MarketingConsentTracking) {
+        Panache.withTransaction {
+            find("partyId", tracking.partyId).firstResult().chain { existing ->
+                if (existing != null) {
+                    existing.consentId = tracking.consentId
+                    existing.grantedAt = tracking.grantedAt
+                    Uni.createFrom().voidItem()
+                } else {
+                    val e = PartyMarketingConsentEntity().also {
+                        it.partyId = tracking.partyId
+                        it.consentId = tracking.consentId
+                        it.grantedAt = tracking.grantedAt
+                    }
+                    persist(e).replaceWithVoid()
+                }
+            }
+        }.awaitSuspending()
+    }
+
+    // Scoped conditional DELETE, not find-then-check-then-delete: a delete WHERE clause matching
+    // both partyId and consentId is atomic, so a concurrent upsert (re-grant) racing this delete
+    // cannot be lost — either the delete matches the row that existed at delete time, or (if a
+    // re-grant already changed consentId) it matches zero rows and correctly no-ops.
+    override suspend fun deleteIfMatches(partyId: UUID, consentId: UUID): Boolean {
+        val deletedCount = Panache.withTransaction {
+            delete("partyId = ?1 and consentId = ?2", partyId, consentId)
+        }.awaitSuspending()
+        return deletedCount > 0
+    }
+
+    private fun PartyMarketingConsentEntity.toDomain() =
+        MarketingConsentTracking(partyId = partyId, consentId = consentId, grantedAt = grantedAt)
+}

--- a/openbank-party-service/src/main/kotlin/com/openbank/party/infrastructure/persistence/repository/PartyRepositoryImpl.kt
+++ b/openbank-party-service/src/main/kotlin/com/openbank/party/infrastructure/persistence/repository/PartyRepositoryImpl.kt
@@ -18,6 +18,7 @@ import io.smallrye.mutiny.coroutines.awaitSuspending
 import jakarta.enterprise.context.ApplicationScoped
 import jakarta.inject.Inject
 import java.time.Clock
+import java.time.Instant
 import java.util.UUID
 
 @ApplicationScoped
@@ -130,6 +131,15 @@ class PartyRepositoryImpl :
 
     override suspend fun findByRcBlindIndex(index: String): Party? =
         Panache.withSession { find("rcBlindIndex", index).firstResult() }.awaitSuspending()?.toDomain()
+
+    // Scoped UPDATE (ADR-0205 D4), not find-then-mutate-then-save of the whole Party aggregate —
+    // matches NotificationRepository.markTerminalStatus's pattern (issue #1393). No-op (0 rows
+    // affected, no error) if the party row does not exist.
+    override suspend fun updateMarketingConsentProjection(partyId: UUID, granted: Boolean, at: Instant) {
+        Panache.withTransaction {
+            update("consentMarketing = ?1, consentMarketingUpdatedAt = ?2 where partyId = ?3", granted, at, partyId)
+        }.awaitSuspending()
+    }
 
     private fun Party.toEntity() = PartyEntity().also {
         it.partyId = id

--- a/openbank-party-service/src/main/resources/application.yaml
+++ b/openbank-party-service/src/main/resources/application.yaml
@@ -138,6 +138,15 @@ mp:
         auto.offset.reset: earliest
         value.deserializer: org.apache.kafka.common.serialization.StringDeserializer
         key.deserializer: org.apache.kafka.common.serialization.StringDeserializer
+      # Marketing-consent projection (ADR-0205 D4): the whole consent-service outbox topic,
+      # filtered in-consumer to the fixed internal grantee id — see MarketingConsentEventConsumer.
+      consent-events-in:
+        connector: smallrye-kafka
+        topic: openbank.consent.events
+        group.id: openbank-party-service
+        auto.offset.reset: earliest
+        value.deserializer: org.apache.kafka.common.serialization.StringDeserializer
+        key.deserializer: org.apache.kafka.common.serialization.StringDeserializer
 "%dev":
   quarkus:
     log:

--- a/openbank-party-service/src/main/resources/db/migration/V16__marketing_consent_tracking.sql
+++ b/openbank-party-service/src/main/resources/db/migration/V16__marketing_consent_tracking.sql
@@ -1,0 +1,23 @@
+-- Marketing consent projection tracking (ADR-0205 D4).
+--
+-- Backs the party-service consumer of consent-service's outbox: keys the currently ACTIVE
+-- marketing consent per party by consentId, so a ConsentRevoked/ConsentExpired event only
+-- clears `parties.consent_marketing` when it matches the CURRENTLY tracked consent — an
+-- out-of-order or late-delivered revoke for a consent a customer has since re-granted must
+-- not incorrectly flip a fresh grant back to false. One row per party (a party can have at
+-- most one live marketing consent aggregate, per ADR-0205 D2's single-aggregate decision).
+CREATE TABLE party_marketing_consent (
+    id          BIGSERIAL PRIMARY KEY,
+    party_id    UUID        NOT NULL UNIQUE,
+    consent_id  UUID        NOT NULL,
+    granted_at  TIMESTAMPTZ NOT NULL
+);
+
+CREATE SEQUENCE IF NOT EXISTS "party_marketing_consent_SEQ" INCREMENT BY 50;
+
+-- Rollback note: DROP TABLE party_marketing_consent; DROP SEQUENCE "party_marketing_consent_SEQ";
+-- Safe to drop — this table is a projection-tracking aid, not a source of truth; consent-service
+-- remains authoritative and the table can be rebuilt from its outbox if ever lost.
+
+GRANT ALL ON ALL TABLES IN SCHEMA public TO openbank;
+GRANT ALL ON ALL SEQUENCES IN SCHEMA public TO openbank;

--- a/openbank-party-service/src/test/kotlin/com/openbank/party/application/usecase/MarketingConsentProjectionServiceTest.kt
+++ b/openbank-party-service/src/test/kotlin/com/openbank/party/application/usecase/MarketingConsentProjectionServiceTest.kt
@@ -1,0 +1,66 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright (c) OpenBank contributors. Licensed under the Apache License, Version 2.0.
+// See LICENSE in the repository root or https://www.apache.org/licenses/LICENSE-2.0 for details.
+
+package com.openbank.party.application.usecase
+
+import com.openbank.party.application.port.out.MarketingConsentTracking
+import com.openbank.party.application.port.out.MarketingConsentTrackingRepository
+import com.openbank.party.application.port.out.PartyRepository
+import io.mockk.coEvery
+import io.mockk.coVerify
+import io.mockk.mockk
+import kotlinx.coroutines.runBlocking
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.Test
+import java.time.Instant
+import java.util.UUID
+
+/** ADR-0205 D4: the party-service projection of consent-service's marketing-consent lifecycle. */
+class MarketingConsentProjectionServiceTest {
+
+    private val trackingRepository = mockk<MarketingConsentTrackingRepository>()
+    private val partyRepository = mockk<PartyRepository>()
+    private val service = MarketingConsentProjectionService(trackingRepository, partyRepository)
+
+    private val partyId = UUID.randomUUID()
+    private val consentId = UUID.randomUUID()
+    private val occurredAt = Instant.parse("2026-03-01T12:00:00Z")
+
+    @Test
+    fun `applyGranted upserts tracking and sets consent_marketing true unconditionally`(): Unit = runBlocking {
+        coEvery { trackingRepository.upsert(any()) } returns Unit
+        coEvery { partyRepository.updateMarketingConsentProjection(any(), any(), any()) } returns Unit
+
+        service.applyGranted(partyId, consentId, occurredAt)
+
+        coVerify(exactly = 1) {
+            trackingRepository.upsert(MarketingConsentTracking(partyId, consentId, occurredAt))
+        }
+        coVerify(exactly = 1) { partyRepository.updateMarketingConsentProjection(partyId, true, occurredAt) }
+    }
+
+    @Test
+    fun `applyRevokedOrExpired clears the projection when the tracked consent matches`(): Unit = runBlocking {
+        coEvery { trackingRepository.deleteIfMatches(partyId, consentId) } returns true
+        coEvery { partyRepository.updateMarketingConsentProjection(any(), any(), any()) } returns Unit
+
+        val applied = service.applyRevokedOrExpired(partyId, consentId, occurredAt)
+
+        assertThat(applied).isTrue()
+        coVerify(exactly = 1) { partyRepository.updateMarketingConsentProjection(partyId, false, occurredAt) }
+    }
+
+    // The load-bearing case: an out-of-order or late-delivered revoke for a consent the party has
+    // since re-granted (a DIFFERENT, newer consentId is now tracked) must NOT clear the fresh grant.
+    @Test
+    fun `applyRevokedOrExpired does nothing when the event's consentId does not match the tracked one`(): Unit =
+        runBlocking {
+            coEvery { trackingRepository.deleteIfMatches(partyId, consentId) } returns false
+
+            val applied = service.applyRevokedOrExpired(partyId, consentId, occurredAt)
+
+            assertThat(applied).isFalse()
+            coVerify(exactly = 0) { partyRepository.updateMarketingConsentProjection(any(), any(), any()) }
+        }
+}

--- a/openbank-party-service/src/test/kotlin/com/openbank/party/infrastructure/kafka/MarketingConsentEventConsumerTest.kt
+++ b/openbank-party-service/src/test/kotlin/com/openbank/party/infrastructure/kafka/MarketingConsentEventConsumerTest.kt
@@ -1,0 +1,109 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright (c) OpenBank contributors. Licensed under the Apache License, Version 2.0.
+// See LICENSE in the repository root or https://www.apache.org/licenses/LICENSE-2.0 for details.
+
+package com.openbank.party.infrastructure.kafka
+
+import com.fasterxml.jackson.databind.ObjectMapper
+import com.openbank.party.application.port.`in`.MarketingConsentProjectionUseCase
+import io.mockk.coEvery
+import io.mockk.coVerify
+import io.mockk.mockk
+import kotlinx.coroutines.runBlocking
+import org.junit.jupiter.api.Test
+import java.time.Instant
+import java.util.UUID
+
+/** ADR-0205 D4: the Kafka boundary — JSON parsing, granteeId filtering, event-type dispatch. */
+class MarketingConsentEventConsumerTest {
+
+    private val projectionUseCase = mockk<MarketingConsentProjectionUseCase>()
+    private val consumer = MarketingConsentEventConsumer(projectionUseCase, ObjectMapper())
+
+    private val partyId = UUID.randomUUID()
+    private val consentId = UUID.randomUUID()
+
+    private fun granted(granteeId: String = "party-service:marketing-comms") = """
+        {"aggregateId":"$consentId","partyId":"$partyId","granteeId":"$granteeId",
+         "granteeType":"INTERNAL_SERVICE","scopes":["MARKETING_COMMS_EMAIL"],
+         "validTo":"2027-01-01T00:00:00Z","occurredAt":"2026-03-01T12:00:00Z",
+         "eventType":"ConsentGranted","version":1}
+    """.trimIndent()
+
+    private fun revoked(eventType: String = "ConsentRevoked", granteeId: String = "party-service:marketing-comms") =
+        """
+        {"aggregateId":"$consentId","partyId":"$partyId","granteeId":"$granteeId",
+         "reason":"customer request","occurredAt":"2026-03-01T12:00:00Z","eventType":"$eventType","version":1}
+        """.trimIndent()
+
+    @Test
+    fun `consume applies a ConsentGranted for the marketing granteeId`(): Unit = runBlocking {
+        coEvery { projectionUseCase.applyGranted(any(), any(), any()) } returns Unit
+
+        consumer.consume(granted())
+
+        coVerify(exactly = 1) {
+            projectionUseCase.applyGranted(partyId, consentId, Instant.parse("2026-03-01T12:00:00Z"))
+        }
+    }
+
+    @Test
+    fun `consume ignores a ConsentGranted for any other granteeId — a TPP consent, not ours`(): Unit = runBlocking {
+        consumer.consume(granted(granteeId = "some-tpp-eidas-org-id"))
+
+        coVerify(exactly = 0) { projectionUseCase.applyGranted(any(), any(), any()) }
+    }
+
+    @Test
+    fun `consume applies a ConsentRevoked for the marketing granteeId`(): Unit = runBlocking {
+        coEvery { projectionUseCase.applyRevokedOrExpired(any(), any(), any()) } returns true
+
+        consumer.consume(revoked())
+
+        coVerify(exactly = 1) {
+            projectionUseCase.applyRevokedOrExpired(partyId, consentId, Instant.parse("2026-03-01T12:00:00Z"))
+        }
+    }
+
+    @Test
+    fun `consume applies a ConsentExpired the same way as a ConsentRevoked`(): Unit = runBlocking {
+        coEvery { projectionUseCase.applyRevokedOrExpired(any(), any(), any()) } returns true
+
+        consumer.consume(revoked(eventType = "ConsentExpired"))
+
+        coVerify(exactly = 1) { projectionUseCase.applyRevokedOrExpired(partyId, consentId, any()) }
+    }
+
+    @Test
+    fun `consume ignores a ConsentRevoked for any other granteeId`(): Unit = runBlocking {
+        consumer.consume(revoked(granteeId = "some-tpp-eidas-org-id"))
+
+        coVerify(exactly = 0) { projectionUseCase.applyRevokedOrExpired(any(), any(), any()) }
+    }
+
+    @Test
+    fun `consume ignores an unrelated event type for the marketing granteeId without throwing`(): Unit = runBlocking {
+        consumer.consume(revoked(eventType = "ConsentRejected"))
+
+        coVerify(exactly = 0) { projectionUseCase.applyRevokedOrExpired(any(), any(), any()) }
+        coVerify(exactly = 0) { projectionUseCase.applyGranted(any(), any(), any()) }
+    }
+
+    // Poison-pill safety (matches KycAmlEventConsumer's convention): malformed JSON must be
+    // swallowed, not thrown, so the consumer group is never wedged by one bad record.
+    @Test
+    fun `consume swallows malformed JSON without throwing`(): Unit = runBlocking {
+        consumer.consume("not json at all {{{")
+        // no assertion needed beyond "did not throw" — the try/catch is the behavior under test
+    }
+
+    @Test
+    fun `consume swallows a payload missing partyId without throwing`(): Unit = runBlocking {
+        consumer.consume(
+            """{"aggregateId":"$consentId","granteeId":"party-service:marketing-comms",
+                "eventType":"ConsentGranted"}""",
+        )
+
+        coVerify(exactly = 0) { projectionUseCase.applyGranted(any(), any(), any()) }
+    }
+}

--- a/openbank-party-service/src/test/kotlin/com/openbank/party/infrastructure/kafka/MarketingConsentEventConsumerTest.kt
+++ b/openbank-party-service/src/test/kotlin/com/openbank/party/infrastructure/kafka/MarketingConsentEventConsumerTest.kt
@@ -106,4 +106,20 @@ class MarketingConsentEventConsumerTest {
 
         coVerify(exactly = 0) { projectionUseCase.applyGranted(any(), any(), any()) }
     }
+
+    // A missing/unparseable occurredAt must still process the event (partyId/consentId/eventType
+    // are all present and valid) rather than being swallowed like a truly malformed payload —
+    // the fallback-to-now() path, not the poison-pill path.
+    @Test
+    fun `consume still applies the event when occurredAt is missing, falling back to now`(): Unit = runBlocking {
+        coEvery { projectionUseCase.applyGranted(any(), any(), any()) } returns Unit
+
+        consumer.consume(
+            """{"aggregateId":"$consentId","partyId":"$partyId","granteeId":"party-service:marketing-comms",
+                "granteeType":"INTERNAL_SERVICE","scopes":["MARKETING_COMMS_EMAIL"],
+                "eventType":"ConsentGranted","version":1}""",
+        )
+
+        coVerify(exactly = 1) { projectionUseCase.applyGranted(partyId, consentId, any()) }
+    }
 }


### PR DESCRIPTION
## Summary

ADR-0205 D4: party-service consumes consent-service's outbox (filtered to the fixed
`party-service:marketing-comms` granteeId, ADR-0205 D3) to project marketing-consent grants/
revokes/expiries into `parties.consent_marketing` / `consent_marketing_updated_at`.

## Type of change

- [x] feat (new functionality)

## Linked issues

N/A — this PR implements ADR-0205 D4, decided in a merged ADR (`docs/adr/0205-marketing-consent-forwarder-and-sca-exempt-activation.md`), not tracked by a separate backlog issue.

## Changes

- **Migration V16**: `party_marketing_consent(party_id, consent_id, granted_at)` — tracks the
  currently ACTIVE marketing consent per party, one row per party.
- **`MarketingConsentEventConsumer`**: `@Incoming("consent-events-in")` on the whole
  `openbank.consent.events` topic, filters to `granteeId == "party-service:marketing-comms"`
  in-consumer (everything else — every TPP consent — is silently ignored), dispatches
  `ConsentGranted`/`ConsentRevoked`/`ConsentExpired` to the use case. Poison-pill safe.
- **`MarketingConsentProjectionService`**: `applyGranted` always upserts (a fresh grant wins);
  `applyRevokedOrExpired` only clears the projection if the event's `consentId` matches what's
  currently tracked — the mechanism that makes this correct despite `ConsentRevoked` carrying no
  `scopes` field (an out-of-order/late revoke for a superseded consent must not clear a fresh
  re-grant).
- **`PartyMarketingConsentEntity`**: surrogate `PanacheEntity` id + unique `partyId` column,
  matching `PartyEntity`'s own convention — not an application-assigned PK, so it doesn't hit the
  `persist()`-is-INSERT-only pitfall this repo's `CLAUDE.md` documents.
- **`PartyRepository.updateMarketingConsentProjection`**: a scoped `UPDATE ... WHERE partyId = ?`,
  matching `NotificationRepository.markTerminalStatus` (issue #1393) rather than a full
  find-then-mutate-then-save of the `Party` aggregate.
- **Kafka ACL**: `Read + Describe` on `openbank.consent.events` added to party-service's
  `KafkaUser` — required in the real cluster (Strimzi simple authorization denies by default
  per-topic); without it this consumer works in tests and is silently denied in production.

## Definition of Done

- [x] Hexagonal layering preserved — new port/usecase/infrastructure files follow the existing
      party-service structure exactly.
- [x] Unit tests added — 3 use-case tests (grant, matching revoke, **non-matching revoke — the
      load-bearing case**) + 8 consumer tests (dispatch per event type, grantee filtering,
      malformed-JSON and missing-field poison-pill safety). Full `openbank-party-service` suite
      green.
- [x] Integration tests — n/a; consumer/use-case logic is fully covered at the unit level, and
      wiring correctness (Kafka deserialization, migration) is exercised by the fleet's existing
      `@QuarkusTest` dev-services on `./gradlew build`.
- [x] `./gradlew :openbank-party-service:detekt :openbank-party-service:ktlintCheck` passes.
- [x] No new lint warnings — one pre-existing baseline entry duplicated for the new `port.in` file
      (package named `` `in` ``, a Kotlin keyword — the same structural violation already
      grandfathered for `PartyPort.kt`), not a new violation class.
- [x] Flyway migration added (V16) + rollback note in the migration file itself. Additive only
      (new table); rollback is a plain `DROP TABLE`/`DROP SEQUENCE`, safe because this table is a
      projection-tracking aid, not a source of truth — consent-service remains authoritative.

## Compliance impact

- [x] GDPR — this is infrastructure for demonstrable, revocable Art. 7 consent (ADR-0198/0205);
      no new PII is stored beyond a `consentId` and timestamp already implied by the consent's
      existence.
- [ ] PCI DSS · [ ] DORA · [ ] PSD2 / SCA / RTS · [ ] AML / 5AMLD · [ ] CNB reporting

## Rollout / Rollback

- Deployment strategy: rolling. The migration is additive (new table only) and independent of the
  Kafka ACL grant — safe to deploy in either order, but the consumer will silently receive nothing
  until the ACL is applied (GitOps-managed, separate sync wave per `kafka-party-mtls.yaml`'s own
  annotations).
- Rollback plan: revert the commit; `DROP TABLE party_marketing_consent` per the migration's own
  rollback note if needed. No write-path change in this PR (D5 doesn't exist yet), so nothing
  currently produces the events this consumer would process — safe to roll back with zero data
  consequence.
- Data migration reversible: yes, additive-only.

## Reviewer notes

**Deliberately does not touch `UpdateMarketingConsentCommand` or any customer-facing write path.**
That is ADR-0205 D5, its own PR, once this (D4) exists to receive what it will eventually write.
Until D5 lands, this consumer has no producer — it is inert but harmless, exactly the state D1
(#2423) put `TELEMETRY_RUM`/`MARKETING_COMMS_*` scopes in before this PR gave party-service a
reason to care about them.

The `deleteIfMatches` atomic scoped DELETE (not find-then-check-then-delete) is the correctness
mechanism worth double-checking: a concurrent upsert (re-grant) racing this delete cannot lose the
race either way — the delete either matches the row that existed at delete time, or (if a re-grant
already changed `consentId`) matches zero rows and correctly no-ops.

