### PR TITLE
test(balance): replay all three provider pacts before merge, not after

### DIFF
--- a/.github/scripts/check-pact-provider-replay.py
+++ b/.github/scripts/check-pact-provider-replay.py
@@ -49,16 +49,13 @@ PACTS = ROOT / "pacts"
 # ~44 generated files and give the PR a short shelf life. The list belongs next to the code that
 # reads it.
 KNOWN_UNCOVERED = {
-    "pacts/openbank-account-service-openbank-balance-service.json",
     "pacts/openbank-balance-service-openbank-account-service.json",
     "pacts/openbank-consent-service-openbank-sca-service.json",
     # Landed 2026-07-25, after the #2327 audit counted 16 of 27: same provider
     # (balance-service), so the same debt, not a new class of it. The estate went 27 -> 33 pacts in
     # a day, which is the argument for a gate rather than another audit.
-    "pacts/openbank-mcp-service-openbank-balance-service.json",
     "pacts/openbank-notification-service-openbank-account-service.json",
     "pacts/openbank-sepa-payment-openbank-fraud-service.json",
-    "pacts/openbank-transaction-service-openbank-balance-service.json",
     "pacts/openbank-transaction-service-openbank-swift-service.json",
 }
 

--- a/openbank-balance-service/src/test/kotlin/com/openbank/balance/contract/BalancePactFolderProviderVerificationTest.kt
+++ b/openbank-balance-service/src/test/kotlin/com/openbank/balance/contract/BalancePactFolderProviderVerificationTest.kt
@@ -1,0 +1,289 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright (c) OpenBank contributors. Licensed under the Apache License, Version 2.0.
+// See LICENSE in the repository root or https://www.apache.org/licenses/LICENSE-2.0 for details.
+
+package com.openbank.balance.contract
+
+import au.com.dius.pact.provider.junit5.HttpTestTarget
+import au.com.dius.pact.provider.junit5.PactVerificationContext
+import au.com.dius.pact.provider.junit5.PactVerificationInvocationContextProvider
+import au.com.dius.pact.provider.junitsupport.IgnoreNoPactsToVerify
+import au.com.dius.pact.provider.junitsupport.Provider
+import au.com.dius.pact.provider.junitsupport.State
+import au.com.dius.pact.provider.junitsupport.loader.PactFolder
+import com.openbank.balance.application.port.out.BalanceRepository
+import com.openbank.balance.application.port.out.HoldRepository
+import com.openbank.balance.domain.model.Balance
+import com.openbank.balance.domain.model.BalanceHold
+import io.quarkus.test.common.QuarkusTestResource
+import io.quarkus.test.junit.QuarkusTest
+import io.quarkus.test.security.TestSecurity
+import io.quarkus.vertx.core.runtime.context.VertxContextSafetyToggle
+import io.vertx.core.Vertx
+import io.vertx.core.impl.ContextInternal
+import jakarta.inject.Inject
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.asCoroutineDispatcher
+import kotlinx.coroutines.launch
+import org.eclipse.microprofile.config.inject.ConfigProperty
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.TestTemplate
+import org.junit.jupiter.api.extension.ExtendWith
+import java.math.BigDecimal
+import java.time.OffsetDateTime
+import java.util.UUID
+import java.util.concurrent.CompletableFuture
+import java.util.concurrent.Executor
+import java.util.concurrent.TimeUnit
+
+/**
+ * Git-pact provider verification for balance-service — the half that actually runs before a merge
+ * (issue #2327, gated by `check-pact-provider-replay.py` per #2338).
+ *
+ * balance-service is the provider for three committed pacts (six interactions, all HTTP) and its
+ * only verification class was [BalancePactProviderVerificationTest] — `@PactBroker`-sourced and
+ * `@EnabledIfSystemProperty(pactbroker.url)`-gated. On a pull request that property is empty
+ * (`_service-ci.yml` puts the PR lane on `ubuntu-latest` and blanks `PACT_BROKER_URL` off
+ * main-push, because the broker has no public ingress, ADR-0056), so it skipped and all three
+ * contracts were replayed only AFTER the merge. A consumer pact cannot catch a wrong request path;
+ * only the provider replay can (#2269), and balance-service is on the money path: two of these
+ * interactions are transaction-service reserving and releasing payment cover.
+ *
+ * ## Additive, not a replacement
+ *
+ * The broker twin stays exactly as it is. Its published verification result is the only thing
+ * ADR-0092's `can-i-deploy` reads, and dropping it is not hypothetical harm — the same swap on
+ * party-service (#371) left that service's auto-deploy hard-blocked for four days (#1166). Git
+ * source for the PR lane, broker source for the published result: the pair
+ * openbank-ledger-service carries. Two `@Provider` classes collide only when BOTH pull from the
+ * broker, since each then fetches every pact it holds.
+ *
+ * ## Upkeep
+ *
+ * A deliberate duplicate of the broker twin's body: same `@State` handlers, same seeded rows, same
+ * fixed UUIDs. A change to one belongs in the other, or the same contract passes from git and
+ * fails from the broker (or the reverse). Every interaction here is HTTP, so unlike the party and
+ * transaction twins there is no `MessageTestTarget` and no `@PactVerifyProvider` producer.
+ */
+@QuarkusTest
+@QuarkusTestResource(com.openbank.balance.it.PostgresRedpandaTestResource::class)
+@TestSecurity(user = "pact-verifier", roles = ["ROLE_SERVICE", "ROLE_OPERATOR"])
+@Provider("openbank-balance-service")
+@PactFolder("../pacts")
+@IgnoreNoPactsToVerify(ignoreIoErrors = "true")
+class BalancePactFolderProviderVerificationTest {
+
+    companion object {
+        // Fixed UUIDs must match each consumer pact exactly — grouped by consuming service.
+        // P2 pilot: transaction-service placeHold + releaseHold
+        private val HOLDS_ACCOUNT_ID = UUID.fromString("a1a1a1a1-a1a1-a1a1-a1a1-a1a1a1a1a1a1")
+        private val RELEASE_ACCOUNT_ID = UUID.fromString("c3c3c3c3-c3c3-c3c3-c3c3-c3c3c3c3c3c3")
+        private val RELEASE_HOLD_ID = UUID.fromString("b2b2b2b2-b2b2-b2b2-b2b2-b2b2b2b2b2b2")
+
+        // Batch A: account-service getBalances / getBalance / initialize
+        private val LIST_ACCOUNT_ID = UUID.fromString("d4d4d4d4-d4d4-d4d4-d4d4-d4d4d4d4d4d4")
+        private val SINGLE_ACCOUNT_ID = UUID.fromString("d5d5d5d5-d5d5-d5d5-d5d5-d5d5d5d5d5d5")
+    }
+
+    @ConfigProperty(name = "quarkus.http.test-port", defaultValue = "8081")
+    lateinit var testPort: String
+
+    @Inject
+    lateinit var balanceRepo: BalanceRepository
+
+    @Inject
+    lateinit var holdRepo: HoldRepository
+
+    @Inject
+    lateinit var vertx: Vertx
+
+    @BeforeEach
+    fun configureTarget(context: PactVerificationContext?) {
+        context?.target = HttpTestTarget("localhost", testPort.toInt())
+        context?.addStateChangeHandlers(this)
+    }
+
+    /**
+     * Bridges a reactive-Panache block into Pact-JVM's synchronous `@State` callback. Pact-JVM
+     * invokes `@State` methods directly via reflection on the JUnit test thread, which has no
+     * Vert.x context — `Panache.withTransaction`/`withSession` (used by [balanceRepo]/[holdRepo])
+     * require one, so a bare `runBlocking { balanceRepo.save(...) }` throws
+     * `IllegalStateException: No current Vertx context found`. Confirmed live: this broke every
+     * account-service<->balance-service pact verification since 2026-06-21 (verification result
+     * #389) without ever being noticed, because the failure only actually blocks a deploy once
+     * `can-i-deploy` is reached — `fx-service`'s own Pact provider test has the identical
+     * `runBlocking { reactiveRepo.save(...) }` pattern and is presumably equally broken.
+     *
+     * A plain `vertx.runOnContext { runBlocking { ... } }` is NOT sufficient: it throws a
+     * *different* `IllegalStateException` ("current context is not a duplicated context") because
+     * Quarkus's `VertxContextSafetyToggle` requires the reactive Panache call to run on a
+     * duplicated context (the kind Quarkus creates per-request), not a plain event-loop context.
+     * Nesting `runBlocking` inside that context is also independently wrong even once the
+     * duplicated+safe context is set up: it parks the very event-loop thread the reactive chain
+     * needs to resume on, deadlocking instead of throwing (verified empirically — it hung the
+     * test JVM for 15+ minutes). The fix duplicates the context, marks it safe via the same
+     * toggle Quarkus uses internally, and dispatches the coroutine onto it with a plain
+     * `CoroutineDispatcher` that posts via `runOnContext` — never blocking that thread — so
+     * suspension/resumption on the reactive chain completes normally.
+     */
+    private fun runOnVertxContext(block: suspend () -> Unit) {
+        val future = CompletableFuture<Unit>()
+        val duplicated = (vertx.orCreateContext as ContextInternal).duplicate()
+        VertxContextSafetyToggle.setContextSafe(duplicated, true)
+        val dispatcher = Executor { command -> duplicated.runOnContext { command.run() } }.asCoroutineDispatcher()
+        CoroutineScope(dispatcher).launch {
+            try {
+                block()
+                future.complete(Unit)
+            } catch (t: Throwable) {
+                future.completeExceptionally(t)
+            }
+        }
+        future.get(10, TimeUnit.SECONDS)
+    }
+
+    @TestTemplate
+    @ExtendWith(PactVerificationInvocationContextProvider::class)
+    fun verifyPacts(context: PactVerificationContext?) {
+        context?.verifyInteraction()
+    }
+
+    /**
+     * Idempotent seed. The same `@State` can run more than once in one JVM (Pact-JVM runs one
+     * verification per pact *version*, and enablePending/WIP pulls several), while the port's
+     * `save` is Panache `persist` — INSERT-only. The second run used to die on the
+     * `balances_account_id_currency_key` unique constraint (23505) inside the state-change
+     * callback, failing every interaction before it was even compared (issue #1771, verification
+     * results 2485/2486 and 9121/9122). Find-then-update keeps the seed re-runnable; `update`
+     * rewrites the amounts by (accountId, currency), which is exactly the reset the next
+     * verification pass needs.
+     */
+    private suspend fun seedBalance(balance: Balance) {
+        if (balanceRepo.findByAccountIdAndCurrency(balance.accountId, balance.currency) == null) {
+            balanceRepo.save(balance)
+        } else {
+            balanceRepo.update(balance)
+        }
+    }
+
+    /**
+     * Same idempotency for holds: the hold id is fixed, and a verified releaseHold sets
+     * `releasedAt` on the previous run's row — update resets it to active for the next pass.
+     */
+    private suspend fun seedHold(hold: BalanceHold) {
+        if (holdRepo.findById(hold.id) == null) {
+            holdRepo.save(hold)
+        } else {
+            holdRepo.update(hold)
+        }
+    }
+
+    @State("a CZK balance exists for the holds account with sufficient funds")
+    fun stateBalanceExists() = runOnVertxContext {
+        seedBalance(
+            Balance(
+                id = UUID.randomUUID(),
+                accountId = HOLDS_ACCOUNT_ID,
+                currency = "CZK",
+                bookedAmount = BigDecimal("10000.00"),
+                availableAmount = BigDecimal("10000.00"),
+                reservedAmount = BigDecimal.ZERO,
+                pendingAmount = BigDecimal.ZERO,
+                updatedAt = OffsetDateTime.now(),
+                version = 0L,
+            ),
+        )
+        Unit
+    }
+
+    @State("a CZK hold exists for the holds account")
+    fun stateHoldExists() = runOnVertxContext {
+        // Balance must exist before releaseHold — it looks up (accountId, currency) to update.
+        // Uses a distinct RELEASE_ACCOUNT_ID to avoid (accountId, currency) collision with the
+        // stateBalanceExists handler when both run in the same Testcontainer DB.
+        seedBalance(
+            Balance(
+                id = UUID.randomUUID(),
+                accountId = RELEASE_ACCOUNT_ID,
+                currency = "CZK",
+                bookedAmount = BigDecimal("10000.00"),
+                availableAmount = BigDecimal("9900.00"),
+                reservedAmount = BigDecimal("100.00"),
+                pendingAmount = BigDecimal.ZERO,
+                updatedAt = OffsetDateTime.now(),
+                version = 0L,
+            ),
+        )
+        seedHold(
+            BalanceHold(
+                id = RELEASE_HOLD_ID,
+                accountId = RELEASE_ACCOUNT_ID,
+                amount = BigDecimal("100.00"),
+                currency = "CZK",
+                reason = "payment-cover",
+                referenceId = "pact-tx-00000001",
+                expiresAt = null,
+                createdAt = OffsetDateTime.now(),
+                releasedAt = null,
+            ),
+        )
+        Unit
+    }
+
+    // --- Batch A: account-service states ---
+
+    @State("balances exist for the balance account")
+    fun stateBalancesExist() = runOnVertxContext {
+        seedBalance(
+            Balance(
+                id = UUID.randomUUID(),
+                accountId = LIST_ACCOUNT_ID,
+                currency = "CZK",
+                bookedAmount = BigDecimal("5000.00"),
+                availableAmount = BigDecimal("4900.00"),
+                reservedAmount = BigDecimal("100.00"),
+                pendingAmount = BigDecimal.ZERO,
+                updatedAt = OffsetDateTime.now(),
+                version = 0L,
+            ),
+        )
+        Unit
+    }
+
+    @State("a CZK balance exists for the balance account")
+    fun stateSingleCzkBalanceExists() = runOnVertxContext {
+        seedBalance(
+            Balance(
+                id = UUID.randomUUID(),
+                accountId = SINGLE_ACCOUNT_ID,
+                currency = "CZK",
+                bookedAmount = BigDecimal("5000.00"),
+                availableAmount = BigDecimal("4900.00"),
+                reservedAmount = BigDecimal("100.00"),
+                pendingAmount = BigDecimal.ZERO,
+                updatedAt = OffsetDateTime.now(),
+                version = 0L,
+            ),
+        )
+        Unit
+    }
+
+    @State("no CZK balance exists for the initialize account")
+    fun stateInitializeAccountHasNoBalance() {
+        // No-op: the Testcontainer DB is clean for e5e5 on every run.
+    }
+
+    /**
+     * State for mcp-service's `BalanceReadPactConsumerTest` (issue #2255, ADR-0195). No setup:
+     * `getBalances` skips its owner check when no `X-Customer-Party-Id` header is present (mcp is a
+     * service-to-service reader and sends none) and answers 200 with an empty `balances` array for
+     * an account it holds nothing for. That 200 is the point of the interaction — it proves the
+     * route exists; a 404 would prove nothing, since Quarkus answers 404 for an absent route too.
+     */
+    @State("balance-service is reachable and holds no balances for the pact account")
+    fun stateNoBalancesForPactAccount() {
+        // Intentionally empty — a fresh Testcontainer DB satisfies it by construction. Declared so
+        // the state is an explicit part of the contract; pact-jvm passes silently over an unhandled
+        // state name, which is how the missing states in #468 stayed invisible.
+    }
+}


### PR DESCRIPTION
> **Rebuilt on current `main`** — supersedes #2424, which was stacked on a branch that has since been rebased away. Identical content, verification and falsification; only the base changed.

## Summary

> **Fourth in a stack — merge order #2413 → #2417 → #2422 → this.** Base is `ci/pact-replay-party-service`.

`balance-service` is the provider for **three** committed pacts (six interactions, all HTTP) and its only verification class is `@PactBroker`-sourced and `@EnabledIfSystemProperty(pactbroker.url)`-gated — so it skips on every PR and those contracts were replayed only *after* the merge. Money path: two of the six are transaction-service reserving and releasing payment cover.

## Type of change

- [ ] feat (new functionality)
- [ ] fix (bug fix)
- [ ] refactor (no behavior change)
- [ ] perf (performance)
- [ ] docs
- [x] chore (build / tooling)
- [ ] security (private until disclosed)
- [ ] breaking change

Commit type is `test` — hidden, no release-please bump. No production code changed.

## Linked issues

Refs #2327
Refs #2269
Refs #2338

## Changes

- **New `BalancePactFolderProviderVerificationTest`** — `@PactFolder("../pacts")`, no gating annotation, same `@State` handlers, seeded rows and fixed UUIDs as the broker twin.
- **`KNOWN_UNCOVERED`** loses the three balance pacts: coverage **24 → 27**, backlog **9 → 6**.

## Reviewer notes

**Simpler than the previous two in the stack.** Every interaction is HTTP, so there is no `MessageTestTarget` and no `@PactVerifyProvider` producer — and therefore none of the duplicate-producer ambiguity #2417 and #2422 had to measure.

**Verified from the JUnit XML, not the console** — pact-jvm prints `Not all of the N were verified` on a fully green run:

```
tests=6 failures=0 errors=0
  transaction-service - POST placeHold to reserve funds for a payment
  transaction-service - DELETE releaseHold to release the payment cover
  account-service     - GET single CZK balance for an account
  account-service     - GET all balances for an account
  account-service     - POST initialize opening balance for an account
  mcp-service         - GET the balances the MCP get_balance tool returns verbatim
```

**Falsified rather than assumed:** renaming `BalanceResource`'s `@Path` to `/api/v1/balances-MOVED` turns **all six red** — the #2269 defect class, caught on contracts that would previously have skipped at PR time. Resource restored and the suite re-run green before committing.

**Additive, not a replacement.** The broker twin is untouched. Its published verification result is the only thing ADR-0092's `can-i-deploy` reads, and dropping it is not hypothetical harm: the same swap on party-service (#371) left that service's auto-deploy hard-blocked for four days (#1166).

**Cost:** one more `@QuarkusTest` with Testcontainers in balance-service's PR build.

## Definition of Done

- [x] Hexagonal layering preserved (domain has zero framework imports).
- [x] Unit tests added/updated. — this PR is the test
- [x] Integration tests added/updated (if service boundary involved). — six provider-side replays
- [x] Contract tests updated (if public API changed). — no pact content changed; they are now replayed pre-merge
- [x] `./gradlew detekt ktlintCheck koverVerify build` passes. — ktlintCheck + compileTestKotlin + the test itself
- [x] No new lint warnings.
- [ ] OpenAPI spec regenerated (if REST API changed). — N/A
- [ ] Flyway migration added + rollback note (if DB changed). — N/A
- [ ] Avro schema versioned backward-compatibly (if event changed). — N/A
- [x] Docs updated (README, ADR if architectural). — KDoc

## Security checklist

- [x] No secrets, tokens, passwords, or PII in code, config, tests, logs.
- [x] No new `@SuppressWarnings`, `as Any`, `@Suppress("...")` without justification.
- [x] No new third-party dependency.
- [ ] Auth / crypto / payment code changed? → N/A — test-only, though it now guards money-path contracts
- [ ] PII path changed? → N/A
- [ ] Cardholder data path changed? → N/A

## Compliance impact

- [x] None

## Rollout / Rollback

- Deployment strategy: N/A — test-only, no service artifact
- Rollback plan: revert the commit; the broker twin is untouched, so `can-i-deploy` is unaffected either way
- Data migration reversible: N/A

