### PR TITLE
test(account): replay both provider pacts before merge, not after

### DIFF
--- a/.github/scripts/check-pact-provider-replay.py
+++ b/.github/scripts/check-pact-provider-replay.py
@@ -49,12 +49,10 @@ PACTS = ROOT / "pacts"
 # ~44 generated files and give the PR a short shelf life. The list belongs next to the code that
 # reads it.
 KNOWN_UNCOVERED = {
-    "pacts/openbank-balance-service-openbank-account-service.json",
     "pacts/openbank-consent-service-openbank-sca-service.json",
     # Landed 2026-07-25, after the #2327 audit counted 16 of 27: same provider
     # (balance-service), so the same debt, not a new class of it. The estate went 27 -> 33 pacts in
     # a day, which is the argument for a gate rather than another audit.
-    "pacts/openbank-notification-service-openbank-account-service.json",
     "pacts/openbank-sepa-payment-openbank-fraud-service.json",
     "pacts/openbank-transaction-service-openbank-swift-service.json",
 }

--- a/openbank-account-service/src/test/kotlin/com/openbank/account/contract/AccountPactFolderProviderVerificationTest.kt
+++ b/openbank-account-service/src/test/kotlin/com/openbank/account/contract/AccountPactFolderProviderVerificationTest.kt
@@ -1,0 +1,117 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright (c) OpenBank contributors. Licensed under the Apache License, Version 2.0.
+// See LICENSE in the repository root or https://www.apache.org/licenses/LICENSE-2.0 for details.
+
+package com.openbank.account.contract
+
+import au.com.dius.pact.provider.PactVerifyProvider
+import au.com.dius.pact.provider.junit5.MessageTestTarget
+import au.com.dius.pact.provider.junit5.PactVerificationContext
+import au.com.dius.pact.provider.junit5.PactVerificationInvocationContextProvider
+import au.com.dius.pact.provider.junitsupport.IgnoreNoPactsToVerify
+import au.com.dius.pact.provider.junitsupport.Provider
+import au.com.dius.pact.provider.junitsupport.State
+import au.com.dius.pact.provider.junitsupport.loader.PactFolder
+import com.fasterxml.jackson.datatype.jsr310.JavaTimeModule
+import com.fasterxml.jackson.module.kotlin.jacksonObjectMapper
+import com.openbank.account.domain.event.AccountCreatedEvent
+import com.openbank.account.domain.model.AccountType
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.TestTemplate
+import org.junit.jupiter.api.extension.ExtendWith
+import java.util.UUID
+
+/**
+ * Git-pact provider verification for account-service — the half that actually runs before a merge
+ * (issue #2327, gated by `check-pact-provider-replay.py` per #2338).
+ *
+ * account-service is the provider for two committed pacts, both message-only: balance-service's
+ * `AccountCreated` and notification-service's `TRANSACTION_COMPLETED`. Its only verification class
+ * was [AccountEventPactProviderVerificationTest] — `@PactBroker`-sourced and
+ * `@EnabledIfSystemProperty(pactbroker.url)`-gated. On a pull request that property is empty
+ * (`_service-ci.yml` puts the PR lane on `ubuntu-latest` and blanks `PACT_BROKER_URL` off
+ * main-push, because the broker has no public ingress, ADR-0056), so it skipped and both contracts
+ * were replayed only AFTER the merge.
+ *
+ * ## Additive, not a replacement — this class does NOT undo #1166
+ *
+ * The broker twin stays exactly as it is. Flipping it to `@PactFolder` is precisely what #372 did
+ * and #1166 reverted: nothing then pulled the consumers' pacts back out of the broker to verify
+ * them and publish a result, and since `can-i-deploy` reads the broker and nothing else, it saw
+ * "no verified pact" for every consumer of account-service and blocked their deploys —
+ * notification-service #1180 and #1303 both merged clean, built green, then failed the gate. Git
+ * source for the PR lane, broker source for the published result: the pair
+ * openbank-ledger-service carries. Two `@Provider` classes collide only when BOTH pull from the
+ * broker, since each then fetches every pact it holds.
+ *
+ * ## Cheap, because there is nothing to boot
+ *
+ * Both pacts are message-only, so a [MessageTestTarget] alone is correct and no Quarkus instance
+ * or Testcontainer is needed — this adds a plain JVM test, not another `@QuarkusTest`. If an HTTP
+ * consumer contract against account-service is ever added, this needs party-service's
+ * per-interaction target dispatch, and so does the broker twin.
+ *
+ * ## Upkeep
+ *
+ * A deliberate duplicate of the broker twin's body: same `@State` handlers and same
+ * [PactVerifyProvider] producers. A change to one belongs in the other, or the same contract
+ * passes from git and fails from the broker (or the reverse).
+ */
+@Provider("openbank-account-service")
+@PactFolder("../pacts")
+@IgnoreNoPactsToVerify(ignoreIoErrors = "true")
+class AccountPactFolderProviderVerificationTest {
+
+    private val objectMapper = jacksonObjectMapper().registerModule(JavaTimeModule())
+
+    @BeforeEach
+    fun setTarget(context: PactVerificationContext?) {
+        // Limit the @PactVerifyProvider scan to this package — the default classpath-wide scan
+        // (ClassGraph) throws on the JDK 25 toolchain.
+        context?.target = MessageTestTarget(listOf("com.openbank.account.contract"))
+    }
+
+    @TestTemplate
+    @ExtendWith(PactVerificationInvocationContextProvider::class)
+    fun verifyPacts(context: PactVerificationContext?) {
+        context?.verifyInteraction()
+    }
+
+    @State("an account has been created")
+    fun accountHasBeenCreated() {
+        // No setup: the message is produced deterministically by the @PactVerifyProvider method below.
+    }
+
+    @PactVerifyProvider("an AccountCreated event")
+    fun produceAccountCreatedEvent(): String {
+        val event = AccountCreatedEvent(
+            aggregateId = UUID.randomUUID(),
+            version = 1L,
+            accountNumber = "CZ6508000000192000145399",
+            accountType = AccountType.CURRENT,
+            partyId = UUID.randomUUID(),
+            productId = UUID.randomUUID(),
+            currency = "CZK",
+            occurredAt = java.time.Instant.parse("2026-01-01T00:00:00Z"),
+        )
+        return objectMapper.writeValueAsString(event)
+    }
+
+    @State("account-service has posted an incoming credit")
+    fun accountHasPostedIncomingCredit() {
+        // No setup: notification request is produced deterministically below.
+    }
+
+    @PactVerifyProvider("a TRANSACTION_COMPLETED notification request")
+    fun produceTransactionCompletedNotification(): String {
+        val partyId = UUID.randomUUID()
+        val request = linkedMapOf(
+            "partyId" to partyId.toString(),
+            "channel" to "PUSH",
+            "template" to "TRANSACTION_COMPLETED",
+            "recipient" to partyId.toString(),
+            "variables" to mapOf("amount" to "50.00", "currency" to "CZK"),
+        )
+        return objectMapper.writeValueAsString(request)
+    }
+}


### PR DESCRIPTION
> **Rebuilt on current `main`** — supersedes #2427, which was stacked on a branch that has since been rebased away. Identical content, verification and falsification; only the base changed.

## Summary

> **Fifth in a stack — merge order #2413 → #2417 → #2422 → #2424 → this.** Base is `ci/pact-replay-balance-service`.

`account-service` is the provider for **two** committed pacts, both message-only, and its only verification class is `@PactBroker`-sourced and `@EnabledIfSystemProperty(pactbroker.url)`-gated — so it skips on every PR and both contracts were replayed only *after* the merge.

## Type of change

- [ ] feat (new functionality)
- [ ] fix (bug fix)
- [ ] refactor (no behavior change)
- [ ] perf (performance)
- [ ] docs
- [x] chore (build / tooling)
- [ ] security (private until disclosed)
- [ ] breaking change

Commit type is `test` — hidden, no release-please bump. No production code changed.

## Linked issues

Refs #2327
Refs #2269
Refs #2425

## Changes

- **New `AccountPactFolderProviderVerificationTest`** — `@PactFolder("../pacts")`, no gating annotation, same `@State` handlers and `@PactVerifyProvider` producers as the broker twin.
- **`KNOWN_UNCOVERED`** loses both account pacts: coverage **27 → 29**, backlog **6 → 4**.

## Reviewer notes

**Cheapest one in this sweep by a wide margin.** Both pacts are message-only, so a `MessageTestTarget` alone is correct and nothing boots — the whole class runs in **3.2 s**. A plain JVM test, not another `@QuarkusTest` with Testcontainers. The FinOps objection I raised on #2424 does not apply here.

**Verified from the JUnit XML, not the console:**

```
tests=2 failures=0 errors=0  (3.2s)
  notification-service - a TRANSACTION_COMPLETED notification request
  balance-service      - an AccountCreated event
```

**Falsification took three attempts, and the two that did NOT redden are the interesting part** — each looked like a bug and only one was:

| break | result | reading |
| --- | --- | --- |
| `accountType` `CURRENT` → `SAVINGS` | green | **correct.** balance-service's pact carries only `aggregateId`, `currency` and `eventType`; `accountType` is outside the contract entirely |
| `channel` `PUSH` → `CARRIER_PIGEON` | green | **a real weakness.** Every field of the notification pact is a `type` matcher, so it pins shape and no value — including `template` (which message the customer gets) and `channel` (push vs SMS vs email). Filed as #2425; not fixed here, since it is the consumer's contract to tighten |
| remove the `template` field | **red** | as it must be — shape is what this pact pins, and the replay does bite on it |

Worth stating plainly: had I stopped at the first green, I would have reported this replay as falsified when it was not. The contrast is one file over — `openbank-balance-service-openbank-account-service.json` leaves `eventType` with **no** matcher, so it is compared by exact value, which is the right treatment for a discriminator.

**Additive, not a replacement.** Flipping the existing class to `@PactFolder` is exactly what #372 did and #1166 reverted: `can-i-deploy` reads the broker and nothing else, so account-service's consumers were blocked (notification-service #1180 and #1303 both merged clean, built green, then failed the gate). The broker twin is untouched.

## Definition of Done

- [x] Hexagonal layering preserved (domain has zero framework imports).
- [x] Unit tests added/updated. — this PR is the test
- [x] Integration tests added/updated (if service boundary involved). — two provider-side replays
- [x] Contract tests updated (if public API changed). — no pact content changed; they are now replayed pre-merge
- [x] `./gradlew detekt ktlintCheck koverVerify build` passes. — ktlintCheck + compileTestKotlin + the test itself
- [x] No new lint warnings.
- [ ] OpenAPI spec regenerated (if REST API changed). — N/A
- [ ] Flyway migration added + rollback note (if DB changed). — N/A
- [ ] Avro schema versioned backward-compatibly (if event changed). — N/A
- [x] Docs updated (README, ADR if architectural). — KDoc

## Security checklist

- [x] No secrets, tokens, passwords, or PII in code, config, tests, logs.
- [x] No new `@SuppressWarnings`, `as Any`, `@Suppress("...")` without justification.
- [x] No new third-party dependency.
- [ ] Auth / crypto / payment code changed? → N/A — test-only
- [ ] PII path changed? → N/A — synthetic pact fixtures
- [ ] Cardholder data path changed? → N/A

## Compliance impact

- [x] None

## Rollout / Rollback

- Deployment strategy: N/A — test-only, no service artifact
- Rollback plan: revert the commit; the broker twin is untouched, so `can-i-deploy` is unaffected either way
- Data migration reversible: N/A

