### PR TITLE
test(fraud): replay the sepa-payment provider pact before merge, not after

### DIFF
--- a/.github/scripts/check-pact-provider-replay.py
+++ b/.github/scripts/check-pact-provider-replay.py
@@ -53,7 +53,6 @@ KNOWN_UNCOVERED = {
     # Landed 2026-07-25, after the #2327 audit counted 16 of 27: same provider
     # (balance-service), so the same debt, not a new class of it. The estate went 27 -> 33 pacts in
     # a day, which is the argument for a gate rather than another audit.
-    "pacts/openbank-sepa-payment-openbank-fraud-service.json",
     "pacts/openbank-transaction-service-openbank-swift-service.json",
 }
 

--- a/openbank-fraud-service/src/test/kotlin/com/openbank/fraud/contract/FraudPactFolderProviderVerificationTest.kt
+++ b/openbank-fraud-service/src/test/kotlin/com/openbank/fraud/contract/FraudPactFolderProviderVerificationTest.kt
@@ -1,0 +1,81 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright (c) OpenBank contributors. Licensed under the Apache License, Version 2.0.
+// See LICENSE in the repository root or https://www.apache.org/licenses/LICENSE-2.0 for details.
+
+package com.openbank.fraud.contract
+
+import au.com.dius.pact.provider.junit5.HttpTestTarget
+import au.com.dius.pact.provider.junit5.PactVerificationContext
+import au.com.dius.pact.provider.junit5.PactVerificationInvocationContextProvider
+import au.com.dius.pact.provider.junitsupport.IgnoreNoPactsToVerify
+import au.com.dius.pact.provider.junitsupport.Provider
+import au.com.dius.pact.provider.junitsupport.State
+import au.com.dius.pact.provider.junitsupport.loader.PactFolder
+import io.quarkus.test.common.QuarkusTestResource
+import io.quarkus.test.junit.QuarkusTest
+import io.quarkus.test.security.TestSecurity
+import org.eclipse.microprofile.config.inject.ConfigProperty
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.TestTemplate
+import org.junit.jupiter.api.extension.ExtendWith
+
+/**
+ * Git-pact provider verification for fraud-service — the half that actually runs before a merge
+ * (issue #2327, gated by `check-pact-provider-replay.py` per #2338).
+ *
+ * fraud-service is the provider for one committed pact: sepa-payment's `POST /api/v1/fraud/score`,
+ * the synchronous scoring call on the SEPA payment path (ADR-0084 §1). Its only verification class
+ * was [FraudPactProviderVerificationTest] — `@PactBroker`-sourced and
+ * `@EnabledIfSystemProperty(pactbroker.url)`-gated. On a pull request that property is empty
+ * (`_service-ci.yml` puts the PR lane on `ubuntu-latest` and blanks `PACT_BROKER_URL` off
+ * main-push, because the broker has no public ingress, ADR-0056), so it skipped and the contract
+ * was replayed only AFTER the merge.
+ *
+ * That matters more here than the count suggests. A consumer pact cannot catch a wrong request
+ * path — the Pact mock server answers whatever path the client asks for, so only the provider
+ * replay goes red (#2269) — and this is the call a payment makes before deciding whether to
+ * proceed. One pact, money path.
+ *
+ * ## Additive, not a replacement
+ *
+ * The broker twin stays as it is: its published verification result is the only thing ADR-0092's
+ * `can-i-deploy` reads, and the same swap elsewhere in the fleet blocked deploys for days
+ * (party-service #371/#1166, account-service #372/#1166). Git source for the PR lane, broker
+ * source for the published result — the pair openbank-ledger-service carries. Two `@Provider`
+ * classes collide only when BOTH pull from the broker, since each then fetches every pact it holds.
+ *
+ * ## Upkeep
+ *
+ * A deliberate duplicate of the broker twin's body: same `@State` handler, same target wiring. A
+ * change to one belongs in the other, or the same contract passes from git and fails from the
+ * broker (or the reverse).
+ */
+@QuarkusTest
+@QuarkusTestResource(com.openbank.fraud.it.PostgresRedisTestResource::class)
+@TestSecurity(user = "pact-verifier", roles = ["ROLE_SERVICE", "ROLE_OPERATOR"])
+@Provider("openbank-fraud-service")
+@PactFolder("../pacts")
+@IgnoreNoPactsToVerify(ignoreIoErrors = "true")
+class FraudPactFolderProviderVerificationTest {
+
+    @ConfigProperty(name = "quarkus.http.test-port", defaultValue = "8081")
+    lateinit var testPort: String
+
+    @BeforeEach
+    fun configureTarget(context: PactVerificationContext?) {
+        context?.target = HttpTestTarget("localhost", testPort.toInt())
+        context?.addStateChangeHandlers(this)
+    }
+
+    @TestTemplate
+    @ExtendWith(PactVerificationInvocationContextProvider::class)
+    fun verifyPacts(context: PactVerificationContext?) {
+        context?.verifyInteraction()
+    }
+
+    @State("the fraud scoring engine is available")
+    fun stateScoringEngineAvailable() {
+        // No setup needed: the stub rule set (ADR-0084 §1 Phase 1) always returns ALLOW,
+        // which satisfies the contract's type matchers on verdict/score.
+    }
+}


### PR DESCRIPTION
> **Rebuilt on current `main`** — supersedes #2428, which was stacked on a branch that has since been rebased away. Identical content, verification and falsification; only the base changed.

## Summary

> **Sixth in a stack — merge order #2413 → #2417 → #2422 → #2424 → #2427 → this.** Base is `ci/pact-replay-account-service`.

`fraud-service` is the provider for **one** committed pact — sepa-payment's `POST /api/v1/fraud/score`, the scoring call a SEPA payment makes before deciding whether to proceed. Its only verification class is `@PactBroker`-sourced and `@EnabledIfSystemProperty(pactbroker.url)`-gated, so it skips on every PR and the contract was replayed only *after* the merge. One pact, money path.

## Type of change

- [ ] feat (new functionality)
- [ ] fix (bug fix)
- [ ] refactor (no behavior change)
- [ ] perf (performance)
- [ ] docs
- [x] chore (build / tooling)
- [ ] security (private until disclosed)
- [ ] breaking change

Commit type is `test` — hidden, no release-please bump. No production code changed.

## Linked issues

Refs #2327
Refs #2269
Refs #2425

## Changes

- **New `FraudPactFolderProviderVerificationTest`** — `@PactFolder("../pacts")`, no gating annotation, same `@State` handler and target wiring as the broker twin.
- **`KNOWN_UNCOVERED`** loses the fraud pact: coverage **29 → 30**, backlog **4 → 3**.

## Reviewer notes

**Verified from the JUnit XML, not the console:** `tests=1 failures=0`.

**Falsified in two directions.**

| break | result |
| --- | --- |
| `FraudResource` `@Path` → `/api/v1/fraud-MOVED` | **RED** — the path is matched exactly, so this replay does catch the #2269 defect class |
| a response-value break | **GREEN** — the pact type-matches that field |

The second result, its consequences and the remediation are recorded in a **private security advisory** rather than here. It is inert today (ADR-0084 runs fraud scoring in SHADOW) and this PR changes no behaviour — the advisory exists because the SHADOW→enforce flip is planned. Same matcher class as the public #2425, but on the payment path.

**Not fixed here.** Tightening the matcher is the consumer's contract to change, and the rest is a decision for whoever owns the enforce flip.

## Definition of Done

- [x] Hexagonal layering preserved (domain has zero framework imports).
- [x] Unit tests added/updated. — this PR is the test
- [x] Integration tests added/updated (if service boundary involved). — one provider-side replay
- [x] Contract tests updated (if public API changed). — no pact content changed; it is now replayed pre-merge
- [x] `./gradlew detekt ktlintCheck koverVerify build` passes. — ktlintCheck + compileTestKotlin + the test itself
- [x] No new lint warnings.
- [ ] OpenAPI spec regenerated (if REST API changed). — N/A
- [ ] Flyway migration added + rollback note (if DB changed). — N/A
- [ ] Avro schema versioned backward-compatibly (if event changed). — N/A
- [x] Docs updated (README, ADR if architectural). — KDoc

## Security checklist

- [x] No secrets, tokens, passwords, or PII in code, config, tests, logs.
- [x] No new `@SuppressWarnings`, `as Any`, `@Suppress("...")` without justification.
- [x] No new third-party dependency.
- [x] Auth / crypto / payment code changed? → **no code changed**; a related finding is tracked in a private security advisory, not in this PR
- [ ] PII path changed? → N/A
- [ ] Cardholder data path changed? → N/A

## Compliance impact

- [x] None *(the finding touches ADR-0084 fraud scoring, but this PR changes no behaviour)*

## Rollout / Rollback

- Deployment strategy: N/A — test-only, no service artifact
- Rollback plan: revert the commit; the broker twin is untouched, so `can-i-deploy` is unaffected either way
- Data migration reversible: N/A


