### PR TITLE
test(fx): replay the transaction-service provider pact before merge, not after

### DIFF
--- a/.github/scripts/check-pact-provider-replay.py
+++ b/.github/scripts/check-pact-provider-replay.py
@@ -63,7 +63,6 @@ KNOWN_UNCOVERED = {
     "pacts/openbank-onboarding-service-openbank-party-service.json",
     "pacts/openbank-sepa-payment-openbank-fraud-service.json",
     "pacts/openbank-transaction-service-openbank-balance-service.json",
-    "pacts/openbank-transaction-service-openbank-fx-service.json",
     "pacts/openbank-transaction-service-openbank-swift-service.json",
 }
 

--- a/openbank-fx-service/src/test/kotlin/com/openbank/fx/contract/FxPactFolderProviderVerificationTest.kt
+++ b/openbank-fx-service/src/test/kotlin/com/openbank/fx/contract/FxPactFolderProviderVerificationTest.kt
@@ -1,0 +1,153 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright (c) OpenBank contributors. Licensed under the Apache License, Version 2.0.
+// See LICENSE in the repository root or https://www.apache.org/licenses/LICENSE-2.0 for details.
+
+package com.openbank.fx.contract
+
+import au.com.dius.pact.provider.junit5.HttpTestTarget
+import au.com.dius.pact.provider.junit5.PactVerificationContext
+import au.com.dius.pact.provider.junit5.PactVerificationInvocationContextProvider
+import au.com.dius.pact.provider.junitsupport.IgnoreNoPactsToVerify
+import au.com.dius.pact.provider.junitsupport.Provider
+import au.com.dius.pact.provider.junitsupport.State
+import au.com.dius.pact.provider.junitsupport.loader.PactFolder
+import com.openbank.fx.application.port.out.FxRateRepository
+import com.openbank.fx.domain.model.FxRate
+import com.openbank.fx.domain.model.RateSource
+import com.openbank.fx.domain.model.RateType
+import io.quarkus.test.common.QuarkusTestResource
+import io.quarkus.test.junit.QuarkusTest
+import io.quarkus.test.security.TestSecurity
+import io.quarkus.vertx.core.runtime.context.VertxContextSafetyToggle
+import io.vertx.core.Vertx
+import io.vertx.core.impl.ContextInternal
+import jakarta.inject.Inject
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.asCoroutineDispatcher
+import kotlinx.coroutines.launch
+import org.eclipse.microprofile.config.inject.ConfigProperty
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.TestTemplate
+import org.junit.jupiter.api.extension.ExtendWith
+import java.math.BigDecimal
+import java.time.Instant
+import java.util.UUID
+import java.util.concurrent.CompletableFuture
+import java.util.concurrent.Executor
+import java.util.concurrent.TimeUnit
+
+/**
+ * Git-pact provider verification for fx-service — the half that actually runs before a merge
+ * (issue #2327, gated by `check-pact-provider-replay.py` per #2338).
+ *
+ * fx-service is the provider for one committed pact: transaction-service's
+ * `GET /api/v1/fx/rates/EUR/CZK`, the rate a cross-currency transaction converts at. Its only
+ * verification class was [FxPactProviderVerificationTest] — `@PactBroker`-sourced and
+ * `@EnabledIfSystemProperty(pactbroker.url)`-gated. On a pull request that property is empty
+ * (`_service-ci.yml` puts the PR lane on `ubuntu-latest` and blanks `PACT_BROKER_URL` off
+ * main-push, because the broker has no public ingress, ADR-0056), so it skipped and the contract
+ * was replayed only AFTER the merge. A consumer pact cannot catch a wrong request path; only the
+ * provider replay can (#2269).
+ *
+ * ## Additive, not a replacement
+ *
+ * The broker twin stays as it is: its published verification result is the only thing ADR-0092's
+ * `can-i-deploy` reads, and the same swap elsewhere in the fleet blocked deploys for days
+ * (party-service #371/#1166, account-service #372/#1166). Git source for the PR lane, broker
+ * source for the published result — the pair openbank-ledger-service carries. Two `@Provider`
+ * classes collide only when BOTH pull from the broker, since each then fetches every pact it holds.
+ *
+ * ## What this replay does and does not prove
+ *
+ * It proves the route exists, answers 200, and returns the four fields with the right types. It
+ * does NOT pin the rate values (`$.askRate`/`$.bidRate` are `decimal` matchers, correctly — rates
+ * move) and it does not pin `$.baseCurrency`/`$.quoteCurrency`, which are `type` matchers: a
+ * response echoing the wrong currency pair would verify green. That is a property of the consumer's
+ * contract, not of this class; see the matcher-quality thread on #2425.
+ *
+ * ## Upkeep
+ *
+ * A deliberate duplicate of the broker twin's body: same `@State` handler and seeded rate row. A
+ * change to one belongs in the other, or the same contract passes from git and fails from the
+ * broker (or the reverse).
+ */
+@QuarkusTest
+@QuarkusTestResource(com.openbank.fx.it.PostgresRedisTestResource::class)
+@TestSecurity(user = "pact-verifier", roles = ["ROLE_OPERATOR"])
+@Provider("openbank-fx-service")
+@PactFolder("../pacts")
+@IgnoreNoPactsToVerify(ignoreIoErrors = "true")
+class FxPactFolderProviderVerificationTest {
+
+    @ConfigProperty(name = "quarkus.http.test-port", defaultValue = "8081")
+    lateinit var testPort: String
+
+    @Inject
+    lateinit var rateRepo: FxRateRepository
+
+    @Inject
+    lateinit var vertx: Vertx
+
+    @BeforeEach
+    fun configureTarget(context: PactVerificationContext?) {
+        context?.target = HttpTestTarget("localhost", testPort.toInt())
+        context?.addStateChangeHandlers(this)
+    }
+
+    /**
+     * Bridges a reactive-Panache block into Pact-JVM's synchronous `@State` callback. Pact-JVM
+     * invokes `@State` methods directly via reflection on the JUnit test thread, which has no
+     * Vert.x context — `Panache.withTransaction`/`withSession` (used by [rateRepo]) requires one,
+     * so a bare `runBlocking { rateRepo.save(...) }` throws `IllegalStateException: No current
+     * Vertx context found`. Same class of bug found live in sca-service's
+     * `ScaPactProviderVerificationTest` (blocking consent-service's deploy); this file has the
+     * identical pattern. Same fix as balance-service's `BalancePactProviderVerificationTest`
+     * (which documents why a plain `vertx.runOnContext { runBlocking { ... } }` is NOT sufficient).
+     */
+    private fun runOnVertxContext(block: suspend () -> Unit) {
+        val future = CompletableFuture<Unit>()
+        val duplicated = (vertx.orCreateContext as ContextInternal).duplicate()
+        VertxContextSafetyToggle.setContextSafe(duplicated, true)
+        val dispatcher = Executor { command -> duplicated.runOnContext { command.run() } }.asCoroutineDispatcher()
+        CoroutineScope(dispatcher).launch {
+            try {
+                block()
+                future.complete(Unit)
+            } catch (t: Throwable) {
+                future.completeExceptionally(t)
+            }
+        }
+        future.get(10, TimeUnit.SECONDS)
+    }
+
+    @TestTemplate
+    @ExtendWith(PactVerificationInvocationContextProvider::class)
+    fun verifyPacts(context: PactVerificationContext?) {
+        context?.verifyInteraction()
+    }
+
+    @State("an EUR/CZK rate exists")
+    fun stateEurCzkRateExists() = runOnVertxContext {
+        // pact-jvm 4.7.3 invokes each @State SETUP callback twice per interaction (same behavior
+        // documented in party-service's PartyEventPactProviderVerificationTest) — without this
+        // guard, a second run.save() would insert a second, duplicate EUR/CZK SPOT row (no unique
+        // constraint on the pair/type/source/validFrom, so it wouldn't even fail loudly).
+        if (rateRepo.findLatest("EUR", "CZK", RateType.SPOT) != null) return@runOnVertxContext
+        val now = Instant.now()
+        rateRepo.save(
+            FxRate(
+                id = UUID.randomUUID(),
+                baseCurrency = "EUR",
+                quoteCurrency = "CZK",
+                bidRate = BigDecimal("24.80"),
+                askRate = BigDecimal("25.20"),
+                rateType = RateType.SPOT,
+                source = RateSource.CNB,
+                validFrom = now.minusSeconds(3600),
+                validTo = now.plusSeconds(86400),
+                createdAt = now,
+            ),
+        )
+        Unit
+    }
+}


### PR DESCRIPTION
> **Rebuilt on current `main`** — supersedes #2430, which was stacked on a branch that has since been rebased away. Identical content, verification and falsification; only the base changed.

## Summary

> **Seventh in a stack — merge order #2413 → #2417 → #2422 → #2424 → #2427 → #2428 → this.** Base is `ci/pact-replay-fraud-service`.

`fx-service` is the provider for **one** committed pact — transaction-service's `GET /api/v1/fx/rates/EUR/CZK`, the rate a cross-currency transaction converts at. Its only verification class is `@PactBroker`-sourced and `@EnabledIfSystemProperty(pactbroker.url)`-gated, so it skips on every PR and the contract was replayed only *after* the merge.

## Type of change

- [ ] feat (new functionality)
- [ ] fix (bug fix)
- [ ] refactor (no behavior change)
- [ ] perf (performance)
- [ ] docs
- [x] chore (build / tooling)
- [ ] security (private until disclosed)
- [ ] breaking change

Commit type is `test` — hidden, no release-please bump. No production code changed.

## Linked issues

Refs #2327
Refs #2269
Refs #2425

## Changes

- **New `FxPactFolderProviderVerificationTest`** — `@PactFolder("../pacts")`, no gating annotation, same `@State` handler and seeded rate row as the broker twin.
- **`KNOWN_UNCOVERED`** loses the fx pact: coverage **30 → 31**, backlog **3 → 2**.

## Reviewer notes

**Verified from the JUnit XML, not the console:** `tests=1 failures=0` (13.4 s).

**Falsified:** renaming `FxResource`'s `@Path` to `/api/v1/fx-MOVED` turns it **red** — the #2269 defect class, caught on a contract that would previously have skipped at PR time. Resource restored and the suite re-run green before committing.

**What this replay does and does not prove**, written into the KDoc rather than left for the next reader to rediscover:

- ✅ the route exists, answers 200, and returns the four fields with the right types
- ❌ it does **not** pin the rate values — `$.askRate`/`$.bidRate` are `decimal` matchers, which is correct here, since rates move
- ❌ it does **not** pin `$.baseCurrency`/`$.quoteCurrency`, which are `type` matchers — a response echoing the **wrong currency pair** verifies green

The last one is the consumer's contract to tighten, not this class's job, and it is the third instance of the same matcher-quality problem in this sweep (after notification's `channel`/`template` and one other). Tracked on #2425.

**Additive, not a replacement.** The broker twin is untouched — its published verification result is the only thing ADR-0092's `can-i-deploy` reads, and the same swap elsewhere in the fleet blocked deploys for days (party-service #371/#1166, account-service #372/#1166).

## Definition of Done

- [x] Hexagonal layering preserved (domain has zero framework imports).
- [x] Unit tests added/updated. — this PR is the test
- [x] Integration tests added/updated (if service boundary involved). — one provider-side replay
- [x] Contract tests updated (if public API changed). — no pact content changed; it is now replayed pre-merge
- [x] `./gradlew detekt ktlintCheck koverVerify build` passes. — ktlintCheck + compileTestKotlin + the test itself
- [x] No new lint warnings.
- [ ] OpenAPI spec regenerated (if REST API changed). — N/A
- [ ] Flyway migration added + rollback note (if DB changed). — N/A
- [ ] Avro schema versioned backward-compatibly (if event changed). — N/A
- [x] Docs updated (README, ADR if architectural). — KDoc

## Security checklist

- [x] No secrets, tokens, passwords, or PII in code, config, tests, logs.
- [x] No new `@SuppressWarnings`, `as Any`, `@Suppress("...")` without justification.
- [x] No new third-party dependency.
- [ ] Auth / crypto / payment code changed? → N/A — test-only
- [ ] PII path changed? → N/A
- [ ] Cardholder data path changed? → N/A

## Compliance impact

- [x] None

## Rollout / Rollback

- Deployment strategy: N/A — test-only, no service artifact
- Rollback plan: revert the commit; the broker twin is untouched, so `can-i-deploy` is unaffected either way
- Data migration reversible: N/A

