### PR TITLE
docs(devops-agent): correct three comments still naming the dead platform-admin role (#2442)

### DIFF
--- a/openbank-admin-ui/src/app/api/devops/decide/route.ts
+++ b/openbank-admin-ui/src/app/api/devops/decide/route.ts
@@ -8,7 +8,14 @@ export const dynamic = 'force-dynamic'
 
 // BFF proxy for the HITL decision on a DevOps finding (ADR-0119 / ADR-0031 D4). A human operator
 // approves or rejects a proposed remediation; this forwards to the devops-agent. The admin-UI is
-// already behind AuthGuard; the agent enforces @RolesAllowed("platform-admin") on its side.
+// already behind AuthGuard; the agent enforces @RolesAllowed(ROLE_ADMIN) on its side (it read
+// `platform-admin` until #2418 — a role no Keycloak realm has ever issued, so the endpoint 403'd
+// for everyone).
+//
+// NOTE: the fetch below sends no Authorization header, unlike the sibling proxies under
+// src/app/api/agent/ and src/app/api/svc/. An unauthenticated request cannot satisfy any
+// @RolesAllowed, so this path stays broken on the agent side even now that the role name is real —
+// the M2M token story is issue #2442. Do not read the corrected comment as "this works".
 
 function devopsBase(): string {
   if (process.env.SERVICES_HOST === 'container') {

--- a/openbank-devops-agent/src/main/kotlin/com/openbank/devops/application/port/incoming/DevOpsUseCases.kt
+++ b/openbank-devops-agent/src/main/kotlin/com/openbank/devops/application/port/incoming/DevOpsUseCases.kt
@@ -20,7 +20,7 @@ interface GetFindingsUseCase {
 
 /**
  * Human-in-the-loop decision on a finding (ADR-0031 D4). The agent proposes; a human disposes — these
- * transitions are driven only by an operator (REST is @RolesAllowed platform-admin), never by the agent.
+ * transitions are driven only by an operator (REST is @RolesAllowed ROLE_ADMIN), never by the agent.
  * Returns the updated finding, or null if the id is unknown.
  */
 interface DecideFindingUseCase {

--- a/openbank-devops-agent/src/main/kotlin/com/openbank/devops/infrastructure/rest/DevOpsResource.kt
+++ b/openbank-devops-agent/src/main/kotlin/com/openbank/devops/infrastructure/rest/DevOpsResource.kt
@@ -52,8 +52,8 @@ class DevOpsResource(
     suspend fun getFinding(@PathParam("id") id: String): DevOpsFinding =
         getFindings.getById(id) ?: throw NotFoundException("Finding $id not found")
 
-    // HITL decisions (ADR-0031 D4). platform-admin only — a human operator disposes; the agent
-    // (a viewer at most) can never approve its own proposal (segregation of duties).
+    // HITL decisions (ADR-0031 D4). ROLE_ADMIN only — a human operator disposes; the agent
+    // (ROLE_VIEWER at most) can never approve its own proposal (segregation of duties).
     @POST
     @Path("/findings/{id}/approve")
     @RolesAllowed("ROLE_ADMIN")


### PR DESCRIPTION
## What

#2418 replaced `platform-admin` / `platform-viewer` — names no Keycloak realm has ever issued — with `ROLE_ADMIN` / `ROLE_VIEWER` across eight agent services. Three comments kept describing the old vocabulary:

| file | said |
|---|---|
| `DevOpsResource.kt:55` | `platform-admin only — a human operator disposes` |
| `DevOpsUseCases.kt:23` | `REST is @RolesAllowed platform-admin` |
| `openbank-admin-ui/.../api/devops/decide/route.ts:11` | `the agent enforces @RolesAllowed("platform-admin")` |

## Why a gate will never catch these

`check-roles-allowed-realm.py` strips comments before scanning — deliberately, because #2403's fix *quotes* the broken annotation to explain it, and the first draft of that script flagged its own explanation. That exemption is right, and it is precisely why stale prose has to be corrected by hand: the guard cannot flag a comment describing a role as though it existed, and prose asserting a role name is how three invented vocabularies spread to 39 endpoints in the first place.

The admin-UI one is the most misleading of the three: it is the **caller** asserting what the callee enforces, so it reads as verification of a contract nobody ever checked.

## Second problem found in that file — stated, not silently fixed

`src/app/api/devops/decide/route.ts` sends **no `Authorization` header**, unlike the sibling proxies under `src/app/api/agent/` and `src/app/api/svc/`. An unauthenticated request satisfies no `@RolesAllowed`, so the HITL approve/reject path stays broken on the agent side *even now that the role name is real*.

The comment now says that explicitly. Correcting only the role name would have left a line that reads "this works" — swapping one false reassurance for a subtler one. Attaching a token is a real auth change tied to the M2M story in #2442, not a comment fix, so it is not done here.

## Verification

- `:openbank-devops-agent:ktlintCheck :detekt :test` green on JDK 25.
- `check-roles-allowed-realm.py` still exits 0 (comments never affected it — that is the point).
- No line exceeds 120 chars; admin-ui change is comment-only, nothing observable in the browser to drive.

## Linked issues

Refs #2442
