### PR TITLE
ci(governance): gate that every advisory CI gate is registered in rules.yaml (#2392)

### DIFF
--- a/.github/scripts/check-advisory-gate-registration.py
+++ b/.github/scripts/check-advisory-gate-registration.py
@@ -1,0 +1,177 @@
+#!/usr/bin/env python3
+# SPDX-License-Identifier: Apache-2.0
+# Copyright (c) OpenBank contributors. Licensed under the Apache License, Version 2.0.
+#
+# Guard: every ADVISORY gate in CI must be registered in rules.yaml with a deadline (issue #2392).
+#
+# WHY THIS EXISTS
+#   ADR-0144 says an advisory rule must carry a `target_enforce_date`, and
+#   check-gate-graduation.sh enforces that — but it walks rules.yaml and NOTHING ELSE. So the
+#   invariant only ever applied to gates that had already opted in. A CI gate that never got a
+#   rules.yaml entry was invisible to it: no deadline, no graduation pressure, no failure when it
+#   sat advisory forever.
+#
+#   That is not hypothetical. check-prompt-registry.py ran `continue-on-error: true` with no entry
+#   and was RED on main for a month (#2363) — the unregistered file being the prompt hardened
+#   against injection. check-evals-registry.py the same (#2375). check-authz-pdp-parity.py cited
+#   `rules.yaml: authz_pdp_parity`, a key that never existed, so it read as governed while being
+#   exactly as unwatched (#2393). Each flip happened because a person ran the script by hand.
+#
+#   This script closes the loop from the CI side: rules.yaml can no longer be the only place that
+#   knows a gate exists.
+#
+# WHAT IT CHECKS
+#   For every workflow step that runs a governance checker (`check-*.py|sh`, `run-evals.py`) AND is
+#   advisory — either `continue-on-error: true`, or "advisory" in the step name — the script it runs
+#   must be named as some rules.yaml rule's `ci_producer:`, and that rule must carry both
+#   `enforced: advisory|planned` and a `target_enforce_date`.
+#
+#   Both halves of "advisory" are covered on purpose. `continue-on-error` is the obvious one, but
+#   most advisory gates here are advisory INSIDE the script — it prints ::warning and exits 0 unless
+#   passed --enforce — so a scan for continue-on-error alone would have found 1 of the 12 that exist
+#   today and reported the other 11 as enforced.
+#
+#   Deliberately NOT flagged: non-governance steps with continue-on-error (ECR login, cache warm,
+#   Codecov upload, Trivy install). Those are best-effort infrastructure, not rules with a
+#   graduation story, and demanding a rules.yaml entry for "Install Trivy" would make this gate
+#   noise that gets silenced.
+#
+# Run:  python3 .github/scripts/check-advisory-gate-registration.py [--root .]
+
+import argparse
+import pathlib
+import re
+import sys
+
+try:
+    import yaml
+except ImportError:
+    sys.stderr.write("PyYAML required: pip install pyyaml\n")
+    sys.exit(2)
+
+WORKFLOWS = ".github/workflows/*.yml"
+RULES = "openbank-libs/governance/rules.yaml"
+
+CHECKER_RE = re.compile(r"((?:\.github|openbank-infra)/scripts/(?:check|run)-[a-z0-9-]+\.(?:py|sh))")
+GRADUATING = {"advisory", "planned"}
+
+
+def rules_by_producer(root: pathlib.Path, errors):
+    """Map every ci_producer script path -> (rule name, enforced, has_date).
+
+    Walks the PARSED document, not the raw lines. A line-wise scan (the first draft here) attributes
+    `enforced:`/`ci_producer:` to whichever bare `key:` line it saw last, which is wrong the moment a
+    rule contains a nested mapping — `finops_tiers` holds a `tiers:` sub-tree and declares its own
+    `enforced`/`target_enforce_date` AFTER it, so the fields landed under `T3`. The gate reported a
+    rule as registered while reading another rule's metadata.
+    """
+    f = root / RULES
+    if not f.is_file():
+        errors.append(f"{RULES} not found — cannot check gate registration")
+        return {}
+    try:
+        doc = yaml.safe_load(f.read_text()) or {}
+    except yaml.YAMLError as e:
+        errors.append(f"{RULES} — not valid YAML: {e}")
+        return {}
+
+    out = {}
+
+    def walk(node, name):
+        if not isinstance(node, dict):
+            return
+        producer = node.get("ci_producer")
+        if isinstance(producer, str):
+            for script in CHECKER_RE.findall(producer):
+                out[script] = (name, node.get("enforced"), "target_enforce_date" in node)
+        for key, value in node.items():
+            if isinstance(value, dict):
+                walk(value, key)
+
+    walk(doc, "<root>")
+    return out
+
+
+def advisory_steps(root: pathlib.Path, errors):
+    """Yield (workflow, job, step-name, script) for advisory governance-checker steps."""
+    for wf in sorted(root.glob(WORKFLOWS)):
+        try:
+            doc = yaml.safe_load(wf.read_text()) or {}
+        except yaml.YAMLError as e:
+            errors.append(f"{wf.name} — not valid YAML: {e}")
+            continue
+        for job_name, job in (doc.get("jobs") or {}).items():
+            for step in (job.get("steps") or []):
+                run = str(step.get("run") or "")
+                name = str(step.get("name") or "")
+                scripts = CHECKER_RE.findall(run)
+                if not scripts:
+                    continue
+                # "enforced" in the name WINS over "advisory". Without that precedence this gate
+                # flags itself — its own step is named "advisory-gate registration (…, enforced)",
+                # and a step that says `(ADR-0148, enforced)` while explaining what advisory means
+                # is a normal shape here. Same family as the comment-stripping in
+                # check-roles-allowed-realm.py: a name-matching heuristic that cannot tell a gate
+                # from a gate ABOUT gates manufactures its own findings.
+                label = name.lower()
+                is_advisory = step.get("continue-on-error") is True or (
+                    "advisory" in label and "enforced" not in label
+                )
+                if not is_advisory:
+                    continue
+                for script in scripts:
+                    yield wf.name, job_name, name, script
+
+
+def main() -> int:
+    ap = argparse.ArgumentParser()
+    ap.add_argument("--root", default=".")
+    args = ap.parse_args()
+    root = pathlib.Path(args.root).resolve()
+
+    errors = []
+    producers = rules_by_producer(root, errors)
+    checked = 0
+
+    for wf, job, name, script in advisory_steps(root, errors):
+        checked += 1
+        where = f"{wf} :: {job} :: {name or script}"
+        if script not in producers:
+            errors.append(
+                f"{where} — advisory gate running {script} has no rules.yaml rule naming it as "
+                f"`ci_producer`. An advisory gate with no rule has no target_enforce_date, so "
+                f"check-gate-graduation.sh (ADR-0144) cannot see it and it stays advisory forever. "
+                f"Add a rule with `enforced: advisory` + `target_enforce_date` + `ci_producer`, or "
+                f"make the step enforced.",
+            )
+            continue
+        rule, enforced, has_date = producers[script]
+        if enforced not in GRADUATING:
+            errors.append(
+                f"{where} — rules.yaml `{rule}` declares `enforced: {enforced}` but the CI step is "
+                f"advisory. The rule and the gate disagree about whether this blocks; fix whichever "
+                f"is wrong.",
+            )
+        elif not has_date:
+            errors.append(
+                f"{where} — rules.yaml `{rule}` is `enforced: {enforced}` with no "
+                f"`target_enforce_date` (ADR-0144 requires one).",
+            )
+
+    if errors:
+        for e in errors:
+            sys.stderr.write(f"::error title=Advisory gate registration::{e}\n")
+        sys.stderr.write(
+            f"::error::check-advisory-gate-registration: {len(errors)} unregistered advisory gate(s).\n",
+        )
+        return 1
+
+    print(
+        f"advisory-gate registration: {checked} advisory governance gate(s) checked against "
+        f"{len(producers)} rules.yaml ci_producer entr(ies); all registered with a deadline.",
+    )
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -477,11 +477,16 @@ jobs:
       # recorded model outputs in evals/recordings/ and hard-fails on a STALE recording (the suite
       # version moved, or the registered prompt's sha256 changed) or a pass rate below the
       # baselines.json floor — i.e. a prompt/model promotion cannot land without being re-recorded
-      # and re-passing. ADVISORY first (ADR-0144): no charter has a recorded run yet, so today this
-      # emits ::warning per suite. Graduate by adding --require-recordings and dropping
-      # continue-on-error once every suite has a committed recording.
-      - name: "evals gate replay (ADR-0148, advisory)"
-        continue-on-error: true
+      # and re-passing.
+      #
+      # ENFORCED (was continue-on-error, #2392). The `continue-on-error` was carrying a different
+      # meaning than it looked like: the runner already treats a charter with no recorded run as
+      # ::warning and exits 0 — 4 of the 5 suites are in that state today — so the flag was only
+      # ever suppressing a REAL replay failure (a drifted prompt hash, a model/version move, a pass
+      # rate under the baselines.json floor). That is the one outcome the gate exists to surface.
+      # Remaining graduation step is --require-recordings, once every suite has a committed run;
+      # that is about coverage, not about whether a failure blocks.
+      - name: "evals gate replay (ADR-0148, enforced)"
         run: python3 .github/scripts/run-evals.py
 
       # rules.yaml: alerting.critical_alerts_must_egress. A severity=critical alert must
@@ -730,6 +735,22 @@ jobs:
       - name: "gate graduation guard (ADR-0144, enforced)"
         run: bash .github/scripts/check-gate-graduation.sh
 
+      # The other half of ADR-0144 (issue #2392). The guard above walks rules.yaml and NOTHING
+      # ELSE, so it can only ever see gates that already opted in: a CI gate with no rules.yaml
+      # rule has no target_enforce_date, and therefore no deadline it can miss. Four gates were in
+      # that state — and the cost was measured, not theoretical. check-prompt-registry.py sat
+      # `continue-on-error: true` and RED on main for a month (#2363), the unregistered file being
+      # the prompt hardened against injection; check-authz-pdp-parity.py cited an
+      # `authz_pdp_parity.target_enforce_date` key that never existed (#2393), reading as governed
+      # while nothing watched it.
+      #
+      # This walks the WORKFLOWS instead and requires every advisory governance gate to name a
+      # rules.yaml rule (via that rule's `ci_producer`) carrying `enforced: advisory|planned` +
+      # `target_enforce_date`. rules.yaml can no longer be the only place that knows a gate exists.
+      # ENFORCED from day one — the tree is clean as of this PR.
+      - name: "advisory-gate registration (issue #2392, enforced)"
+        run: python3 .github/scripts/check-advisory-gate-registration.py
+
       # No dead-code SERVICE-principal rego rule (ADR-0034 Phase 5, issue #266,
       # rules.yaml: authz_policy). AuthorizeInterceptor never emits
       # principal.type == "SERVICE" and no Keycloak client is ever granted
@@ -779,10 +800,15 @@ jobs:
       # 503/422 — the opposite of the interceptor's "advisory must never brick an endpoint"
       # invariant. Eight live services were in this state (party fixed per-service in #1798).
       # Checks each gitops workload per-pod-spec (handles shared payments-services.yaml +
-      # pluralized dirs), not the live pod. ADVISORY (ADR-0144): 10 known violations at
-      # introduction — graduate to --enforce once cleared. Exits 0, so placement is safe.
-      - name: "authz-enforce ⇒ PDP sidecar parity (advisory, #1797)"
-        run: python3 .github/scripts/check-authz-pdp-parity.py .
+      # pluralized dirs), not the live pod.
+      #
+      # ENFORCED (was advisory, #2392). It had 10 violations at introduction and the last two —
+      # finrep-service and onboarding-service — were cleared in #2403, so `--enforce` exits 0 on a
+      # clean tree today. The advisory period had no deadline attached because the gate had no
+      # rules.yaml rule at all, and its docstring cited an `authz_pdp_parity.target_enforce_date`
+      # key that never existed (#2393): it read as governed while nothing watched it.
+      - name: "authz-enforce ⇒ PDP sidecar parity (enforced, #1797)"
+        run: python3 .github/scripts/check-authz-pdp-parity.py . --enforce
 
       # @RolesAllowed ⇒ realm parity (issue #2404). The JWT-role half of the check above: a role
       # name that exists in no realm never matches, so the endpoint answers 403 to every caller,

--- a/openbank-infra/gitops/components/accounts/account-opa-bundle.yaml
+++ b/openbank-infra/gitops/components/accounts/account-opa-bundle.yaml
@@ -9,7 +9,7 @@ metadata:
     app.kubernetes.io/name: account-service
     app.kubernetes.io/part-of: accounts
   annotations:
-    openbank.tech/policy-checksum: "28187c0288326888"
+    openbank.tech/policy-checksum: "abde04c20c68fa12"
 data:
   rest.rego: |
     # SPDX-License-Identifier: Apache-2.0
@@ -2798,19 +2798,6 @@ data:
     # MEASURED behaviour by a classifier + CI gate (derive -> enforce -> show, ADR-0029/0054).
     # ---------------------------------------------------------------------------------------
     finops_tiers:
-      # Declared-side validation (check-finops-tiers.py, finops-lifecycle.yml) runs ADVISORY: the
-      # script always exits 0 today, so a tier declared here that contradicts the manifest is a
-      # ::warning. Graduating needs the MEASURED classifier (the derive->enforce->show half below);
-      # until that lands there is nothing to compare a declaration against except itself.
-      #
-      # Registered with a date as part of issue #2392: this gate ran advisory with no `enforced` /
-      # `target_enforce_date` on its rule, so check-gate-graduation.sh (ADR-0144) skipped it entirely
-      # and it had no deadline at all.
-      enforced: advisory
-      target_enforce_date: "2026-12-31"   # ADR-0144 — gated on the measured classifier, not on triage
-      blocked_on: "the measured-side classifier must land before the declared side can hard-fail;
-        without it, enforcing would only assert that the file agrees with itself"
-      ci_producer: "openbank-infra/scripts/check-finops-tiers.py"
       tiers:
         T0:                                   # Always-on
           definition: "Money-path HOT path where a cold-start / scaled-to-zero gap is unacceptable, or a regulator-mandated continuous service."
@@ -2913,6 +2900,9 @@ data:
       enforced: advisory                      # ADR-0057; -> block when the classifier lands
       target_enforce_date: "2026-09-30"   # ADR-0144
       blocked_on: "the measured-signal classifier (http_request_rate, kafka_consumer_lag, cpu/replica utilisation) has not shipped yet — only 2 services have a declared tier today (notification-service, product-catalog)"
+      # Added by issue #2392: the rule carried `enforced`/`target_enforce_date` but never named the
+      # script that produces the finding, so nothing tied the advisory CI step to this deadline.
+      ci_producer: "openbank-infra/scripts/check-finops-tiers.py"
 
     # ---------------------------------------------------------------------------------------
     # FinOps cost-allocation groups — showback business flows (ADR-0062). The /api/finops/costs

--- a/openbank-infra/gitops/components/accounts/account-opa-bundle.yaml
+++ b/openbank-infra/gitops/components/accounts/account-opa-bundle.yaml
@@ -9,7 +9,7 @@ metadata:
     app.kubernetes.io/name: account-service
     app.kubernetes.io/part-of: accounts
   annotations:
-    openbank.tech/policy-checksum: "b9bf1bbb7eafc20e"
+    openbank.tech/policy-checksum: "28187c0288326888"
 data:
   rest.rego: |
     # SPDX-License-Identifier: Apache-2.0
@@ -1863,6 +1863,23 @@ data:
         # (3-dot against the PR base). Findings are ::warning annotations. Flip to enforced =
         # pass --enforce to the script in ci.yml (one-line change).
         ci_producer: "openbank-infra/scripts/check-threat-model-diff.py"
+      mp_messaging_dotted_keys:
+        # SmallRye reactive-messaging config written as a DOTTED key
+        # (`mp.messaging.incoming.x.topic: …`) inside a nested YAML mapping is silently ignored by
+        # SnakeYAML — the channel keeps its default and the consumer subscribes to nothing, with no
+        # error at boot (issue #686). The guard rewrites the shape it can prove wrong.
+        detect: ["<service>/src/main/resources/application.yaml", "mp.messaging.* written as a dotted key under a nested mapping"]
+        require:
+          - "mp.messaging channel config expressed as nested YAML, not a dotted key inside a mapping"
+        gate: dotted-mp-messaging-keys
+        enforced: advisory
+        target_enforce_date: "2026-09-30"   # ADR-0144
+        blocked_on: "1 finding remains fleet-wide; the script already supports --enforce, so graduating
+          is a one-word change in ci.yml once it is cleared"
+        # Registered here as part of issue #2392: this gate ran advisory with no rules.yaml rule at
+        # all, so check-gate-graduation.sh could not see it and it had no deadline. That class is now
+        # itself gated by .github/scripts/check-advisory-gate-registration.py.
+        ci_producer: ".github/scripts/check-dotted-mp-messaging-keys.sh"
       new_service_with_outbox:
         # A service that extends AbstractOutboxEntity / uses OutboxDispatcher but does NOT
         # set openbank.outbox.dispatch-enabled=true silently never dispatches events —
@@ -2781,6 +2798,19 @@ data:
     # MEASURED behaviour by a classifier + CI gate (derive -> enforce -> show, ADR-0029/0054).
     # ---------------------------------------------------------------------------------------
     finops_tiers:
+      # Declared-side validation (check-finops-tiers.py, finops-lifecycle.yml) runs ADVISORY: the
+      # script always exits 0 today, so a tier declared here that contradicts the manifest is a
+      # ::warning. Graduating needs the MEASURED classifier (the derive->enforce->show half below);
+      # until that lands there is nothing to compare a declaration against except itself.
+      #
+      # Registered with a date as part of issue #2392: this gate ran advisory with no `enforced` /
+      # `target_enforce_date` on its rule, so check-gate-graduation.sh (ADR-0144) skipped it entirely
+      # and it had no deadline at all.
+      enforced: advisory
+      target_enforce_date: "2026-12-31"   # ADR-0144 — gated on the measured classifier, not on triage
+      blocked_on: "the measured-side classifier must land before the declared side can hard-fail;
+        without it, enforcing would only assert that the file agrees with itself"
+      ci_producer: "openbank-infra/scripts/check-finops-tiers.py"
       tiers:
         T0:                                   # Always-on
           definition: "Money-path HOT path where a cold-start / scaled-to-zero gap is unacceptable, or a regulator-mandated continuous service."

--- a/openbank-infra/gitops/components/accounts/account-service.yaml
+++ b/openbank-infra/gitops/components/accounts/account-service.yaml
@@ -37,7 +37,7 @@ spec:
       annotations:
         # Rolls the pod when the OPA bundle changes — subPath mounts do NOT hot-reload.
         # Kept in sync by gen-account-opa-bundle.sh (do not hand-edit).
-        openbank.tech/policy-checksum: "28187c0288326888"
+        openbank.tech/policy-checksum: "abde04c20c68fa12"
     spec:
       securityContext:
         runAsNonRoot: true

--- a/openbank-infra/gitops/components/accounts/account-service.yaml
+++ b/openbank-infra/gitops/components/accounts/account-service.yaml
@@ -37,7 +37,7 @@ spec:
       annotations:
         # Rolls the pod when the OPA bundle changes — subPath mounts do NOT hot-reload.
         # Kept in sync by gen-account-opa-bundle.sh (do not hand-edit).
-        openbank.tech/policy-checksum: "b9bf1bbb7eafc20e"
+        openbank.tech/policy-checksum: "28187c0288326888"
     spec:
       securityContext:
         runAsNonRoot: true

--- a/openbank-infra/gitops/components/aml/aml-opa-bundle.yaml
+++ b/openbank-infra/gitops/components/aml/aml-opa-bundle.yaml
@@ -9,7 +9,7 @@ metadata:
     app.kubernetes.io/name: aml-service
     app.kubernetes.io/part-of: aml
   annotations:
-    openbank.tech/policy-checksum: "a2893c45b7a64281"
+    openbank.tech/policy-checksum: "7959961a5a9f67c8"
 data:
   rest.rego: |
     # SPDX-License-Identifier: Apache-2.0
@@ -2771,19 +2771,6 @@ data:
     # MEASURED behaviour by a classifier + CI gate (derive -> enforce -> show, ADR-0029/0054).
     # ---------------------------------------------------------------------------------------
     finops_tiers:
-      # Declared-side validation (check-finops-tiers.py, finops-lifecycle.yml) runs ADVISORY: the
-      # script always exits 0 today, so a tier declared here that contradicts the manifest is a
-      # ::warning. Graduating needs the MEASURED classifier (the derive->enforce->show half below);
-      # until that lands there is nothing to compare a declaration against except itself.
-      #
-      # Registered with a date as part of issue #2392: this gate ran advisory with no `enforced` /
-      # `target_enforce_date` on its rule, so check-gate-graduation.sh (ADR-0144) skipped it entirely
-      # and it had no deadline at all.
-      enforced: advisory
-      target_enforce_date: "2026-12-31"   # ADR-0144 — gated on the measured classifier, not on triage
-      blocked_on: "the measured-side classifier must land before the declared side can hard-fail;
-        without it, enforcing would only assert that the file agrees with itself"
-      ci_producer: "openbank-infra/scripts/check-finops-tiers.py"
       tiers:
         T0:                                   # Always-on
           definition: "Money-path HOT path where a cold-start / scaled-to-zero gap is unacceptable, or a regulator-mandated continuous service."
@@ -2886,6 +2873,9 @@ data:
       enforced: advisory                      # ADR-0057; -> block when the classifier lands
       target_enforce_date: "2026-09-30"   # ADR-0144
       blocked_on: "the measured-signal classifier (http_request_rate, kafka_consumer_lag, cpu/replica utilisation) has not shipped yet — only 2 services have a declared tier today (notification-service, product-catalog)"
+      # Added by issue #2392: the rule carried `enforced`/`target_enforce_date` but never named the
+      # script that produces the finding, so nothing tied the advisory CI step to this deadline.
+      ci_producer: "openbank-infra/scripts/check-finops-tiers.py"
 
     # ---------------------------------------------------------------------------------------
     # FinOps cost-allocation groups — showback business flows (ADR-0062). The /api/finops/costs

--- a/openbank-infra/gitops/components/aml/aml-opa-bundle.yaml
+++ b/openbank-infra/gitops/components/aml/aml-opa-bundle.yaml
@@ -9,7 +9,7 @@ metadata:
     app.kubernetes.io/name: aml-service
     app.kubernetes.io/part-of: aml
   annotations:
-    openbank.tech/policy-checksum: "05933b234ec1b534"
+    openbank.tech/policy-checksum: "a2893c45b7a64281"
 data:
   rest.rego: |
     # SPDX-License-Identifier: Apache-2.0
@@ -1836,6 +1836,23 @@ data:
         # (3-dot against the PR base). Findings are ::warning annotations. Flip to enforced =
         # pass --enforce to the script in ci.yml (one-line change).
         ci_producer: "openbank-infra/scripts/check-threat-model-diff.py"
+      mp_messaging_dotted_keys:
+        # SmallRye reactive-messaging config written as a DOTTED key
+        # (`mp.messaging.incoming.x.topic: …`) inside a nested YAML mapping is silently ignored by
+        # SnakeYAML — the channel keeps its default and the consumer subscribes to nothing, with no
+        # error at boot (issue #686). The guard rewrites the shape it can prove wrong.
+        detect: ["<service>/src/main/resources/application.yaml", "mp.messaging.* written as a dotted key under a nested mapping"]
+        require:
+          - "mp.messaging channel config expressed as nested YAML, not a dotted key inside a mapping"
+        gate: dotted-mp-messaging-keys
+        enforced: advisory
+        target_enforce_date: "2026-09-30"   # ADR-0144
+        blocked_on: "1 finding remains fleet-wide; the script already supports --enforce, so graduating
+          is a one-word change in ci.yml once it is cleared"
+        # Registered here as part of issue #2392: this gate ran advisory with no rules.yaml rule at
+        # all, so check-gate-graduation.sh could not see it and it had no deadline. That class is now
+        # itself gated by .github/scripts/check-advisory-gate-registration.py.
+        ci_producer: ".github/scripts/check-dotted-mp-messaging-keys.sh"
       new_service_with_outbox:
         # A service that extends AbstractOutboxEntity / uses OutboxDispatcher but does NOT
         # set openbank.outbox.dispatch-enabled=true silently never dispatches events —
@@ -2754,6 +2771,19 @@ data:
     # MEASURED behaviour by a classifier + CI gate (derive -> enforce -> show, ADR-0029/0054).
     # ---------------------------------------------------------------------------------------
     finops_tiers:
+      # Declared-side validation (check-finops-tiers.py, finops-lifecycle.yml) runs ADVISORY: the
+      # script always exits 0 today, so a tier declared here that contradicts the manifest is a
+      # ::warning. Graduating needs the MEASURED classifier (the derive->enforce->show half below);
+      # until that lands there is nothing to compare a declaration against except itself.
+      #
+      # Registered with a date as part of issue #2392: this gate ran advisory with no `enforced` /
+      # `target_enforce_date` on its rule, so check-gate-graduation.sh (ADR-0144) skipped it entirely
+      # and it had no deadline at all.
+      enforced: advisory
+      target_enforce_date: "2026-12-31"   # ADR-0144 — gated on the measured classifier, not on triage
+      blocked_on: "the measured-side classifier must land before the declared side can hard-fail;
+        without it, enforcing would only assert that the file agrees with itself"
+      ci_producer: "openbank-infra/scripts/check-finops-tiers.py"
       tiers:
         T0:                                   # Always-on
           definition: "Money-path HOT path where a cold-start / scaled-to-zero gap is unacceptable, or a regulator-mandated continuous service."

--- a/openbank-infra/gitops/components/aml/aml-service.yaml
+++ b/openbank-infra/gitops/components/aml/aml-service.yaml
@@ -22,7 +22,7 @@ spec:
       annotations:
         # Rolls the pod when the OPA bundle changes (subPath mounts do not hot-reload).
         # Kept in sync by gen-aml-opa-bundle.sh (do not hand-edit).
-        openbank.tech/policy-checksum: "a2893c45b7a64281"
+        openbank.tech/policy-checksum: "7959961a5a9f67c8"
     spec:
       securityContext:
         runAsNonRoot: true

--- a/openbank-infra/gitops/components/aml/aml-service.yaml
+++ b/openbank-infra/gitops/components/aml/aml-service.yaml
@@ -22,7 +22,7 @@ spec:
       annotations:
         # Rolls the pod when the OPA bundle changes (subPath mounts do not hot-reload).
         # Kept in sync by gen-aml-opa-bundle.sh (do not hand-edit).
-        openbank.tech/policy-checksum: "05933b234ec1b534"
+        openbank.tech/policy-checksum: "a2893c45b7a64281"
     spec:
       securityContext:
         runAsNonRoot: true

--- a/openbank-infra/gitops/components/anacredit/anacredit-opa-bundle.yaml
+++ b/openbank-infra/gitops/components/anacredit/anacredit-opa-bundle.yaml
@@ -9,7 +9,7 @@ metadata:
     app.kubernetes.io/name: anacredit-service
     app.kubernetes.io/part-of: anacredit
   annotations:
-    openbank.tech/policy-checksum: "e4b2ec38ad958eab"
+    openbank.tech/policy-checksum: "b9adfb3fe87666f1"
 data:
   rest.rego: |
     # SPDX-License-Identifier: Apache-2.0
@@ -1806,6 +1806,23 @@ data:
         # (3-dot against the PR base). Findings are ::warning annotations. Flip to enforced =
         # pass --enforce to the script in ci.yml (one-line change).
         ci_producer: "openbank-infra/scripts/check-threat-model-diff.py"
+      mp_messaging_dotted_keys:
+        # SmallRye reactive-messaging config written as a DOTTED key
+        # (`mp.messaging.incoming.x.topic: …`) inside a nested YAML mapping is silently ignored by
+        # SnakeYAML — the channel keeps its default and the consumer subscribes to nothing, with no
+        # error at boot (issue #686). The guard rewrites the shape it can prove wrong.
+        detect: ["<service>/src/main/resources/application.yaml", "mp.messaging.* written as a dotted key under a nested mapping"]
+        require:
+          - "mp.messaging channel config expressed as nested YAML, not a dotted key inside a mapping"
+        gate: dotted-mp-messaging-keys
+        enforced: advisory
+        target_enforce_date: "2026-09-30"   # ADR-0144
+        blocked_on: "1 finding remains fleet-wide; the script already supports --enforce, so graduating
+          is a one-word change in ci.yml once it is cleared"
+        # Registered here as part of issue #2392: this gate ran advisory with no rules.yaml rule at
+        # all, so check-gate-graduation.sh could not see it and it had no deadline. That class is now
+        # itself gated by .github/scripts/check-advisory-gate-registration.py.
+        ci_producer: ".github/scripts/check-dotted-mp-messaging-keys.sh"
       new_service_with_outbox:
         # A service that extends AbstractOutboxEntity / uses OutboxDispatcher but does NOT
         # set openbank.outbox.dispatch-enabled=true silently never dispatches events —
@@ -2724,6 +2741,19 @@ data:
     # MEASURED behaviour by a classifier + CI gate (derive -> enforce -> show, ADR-0029/0054).
     # ---------------------------------------------------------------------------------------
     finops_tiers:
+      # Declared-side validation (check-finops-tiers.py, finops-lifecycle.yml) runs ADVISORY: the
+      # script always exits 0 today, so a tier declared here that contradicts the manifest is a
+      # ::warning. Graduating needs the MEASURED classifier (the derive->enforce->show half below);
+      # until that lands there is nothing to compare a declaration against except itself.
+      #
+      # Registered with a date as part of issue #2392: this gate ran advisory with no `enforced` /
+      # `target_enforce_date` on its rule, so check-gate-graduation.sh (ADR-0144) skipped it entirely
+      # and it had no deadline at all.
+      enforced: advisory
+      target_enforce_date: "2026-12-31"   # ADR-0144 — gated on the measured classifier, not on triage
+      blocked_on: "the measured-side classifier must land before the declared side can hard-fail;
+        without it, enforcing would only assert that the file agrees with itself"
+      ci_producer: "openbank-infra/scripts/check-finops-tiers.py"
       tiers:
         T0:                                   # Always-on
           definition: "Money-path HOT path where a cold-start / scaled-to-zero gap is unacceptable, or a regulator-mandated continuous service."

--- a/openbank-infra/gitops/components/anacredit/anacredit-opa-bundle.yaml
+++ b/openbank-infra/gitops/components/anacredit/anacredit-opa-bundle.yaml
@@ -9,7 +9,7 @@ metadata:
     app.kubernetes.io/name: anacredit-service
     app.kubernetes.io/part-of: anacredit
   annotations:
-    openbank.tech/policy-checksum: "b9adfb3fe87666f1"
+    openbank.tech/policy-checksum: "f9db8b225bdfecd8"
 data:
   rest.rego: |
     # SPDX-License-Identifier: Apache-2.0
@@ -2741,19 +2741,6 @@ data:
     # MEASURED behaviour by a classifier + CI gate (derive -> enforce -> show, ADR-0029/0054).
     # ---------------------------------------------------------------------------------------
     finops_tiers:
-      # Declared-side validation (check-finops-tiers.py, finops-lifecycle.yml) runs ADVISORY: the
-      # script always exits 0 today, so a tier declared here that contradicts the manifest is a
-      # ::warning. Graduating needs the MEASURED classifier (the derive->enforce->show half below);
-      # until that lands there is nothing to compare a declaration against except itself.
-      #
-      # Registered with a date as part of issue #2392: this gate ran advisory with no `enforced` /
-      # `target_enforce_date` on its rule, so check-gate-graduation.sh (ADR-0144) skipped it entirely
-      # and it had no deadline at all.
-      enforced: advisory
-      target_enforce_date: "2026-12-31"   # ADR-0144 — gated on the measured classifier, not on triage
-      blocked_on: "the measured-side classifier must land before the declared side can hard-fail;
-        without it, enforcing would only assert that the file agrees with itself"
-      ci_producer: "openbank-infra/scripts/check-finops-tiers.py"
       tiers:
         T0:                                   # Always-on
           definition: "Money-path HOT path where a cold-start / scaled-to-zero gap is unacceptable, or a regulator-mandated continuous service."
@@ -2856,6 +2843,9 @@ data:
       enforced: advisory                      # ADR-0057; -> block when the classifier lands
       target_enforce_date: "2026-09-30"   # ADR-0144
       blocked_on: "the measured-signal classifier (http_request_rate, kafka_consumer_lag, cpu/replica utilisation) has not shipped yet — only 2 services have a declared tier today (notification-service, product-catalog)"
+      # Added by issue #2392: the rule carried `enforced`/`target_enforce_date` but never named the
+      # script that produces the finding, so nothing tied the advisory CI step to this deadline.
+      ci_producer: "openbank-infra/scripts/check-finops-tiers.py"
 
     # ---------------------------------------------------------------------------------------
     # FinOps cost-allocation groups — showback business flows (ADR-0062). The /api/finops/costs

--- a/openbank-infra/gitops/components/anacredit/anacredit-service.yaml
+++ b/openbank-infra/gitops/components/anacredit/anacredit-service.yaml
@@ -32,7 +32,7 @@ spec:
       annotations:
         # Rolls the pods when the OPA bundle changes — subPath mounts do NOT hot-reload.
         # Kept in sync by gen-anacredit-opa-bundle.sh (do not hand-edit).
-        openbank.tech/policy-checksum: "b9adfb3fe87666f1"
+        openbank.tech/policy-checksum: "f9db8b225bdfecd8"
     spec:
       securityContext:
         runAsNonRoot: true

--- a/openbank-infra/gitops/components/anacredit/anacredit-service.yaml
+++ b/openbank-infra/gitops/components/anacredit/anacredit-service.yaml
@@ -32,7 +32,7 @@ spec:
       annotations:
         # Rolls the pods when the OPA bundle changes — subPath mounts do NOT hot-reload.
         # Kept in sync by gen-anacredit-opa-bundle.sh (do not hand-edit).
-        openbank.tech/policy-checksum: "e4b2ec38ad958eab"
+        openbank.tech/policy-checksum: "b9adfb3fe87666f1"
     spec:
       securityContext:
         runAsNonRoot: true

--- a/openbank-infra/gitops/components/ap2/ap2-opa-bundle.yaml
+++ b/openbank-infra/gitops/components/ap2/ap2-opa-bundle.yaml
@@ -9,7 +9,7 @@ metadata:
     app.kubernetes.io/name: mcp-service
     app.kubernetes.io/part-of: platform
   annotations:
-    openbank.tech/policy-checksum: "31b69cbacb5b9c85"
+    openbank.tech/policy-checksum: "f396789572bad1ea"
 data:
   rest.rego: |
     # SPDX-License-Identifier: Apache-2.0
@@ -1774,6 +1774,23 @@ data:
         # (3-dot against the PR base). Findings are ::warning annotations. Flip to enforced =
         # pass --enforce to the script in ci.yml (one-line change).
         ci_producer: "openbank-infra/scripts/check-threat-model-diff.py"
+      mp_messaging_dotted_keys:
+        # SmallRye reactive-messaging config written as a DOTTED key
+        # (`mp.messaging.incoming.x.topic: …`) inside a nested YAML mapping is silently ignored by
+        # SnakeYAML — the channel keeps its default and the consumer subscribes to nothing, with no
+        # error at boot (issue #686). The guard rewrites the shape it can prove wrong.
+        detect: ["<service>/src/main/resources/application.yaml", "mp.messaging.* written as a dotted key under a nested mapping"]
+        require:
+          - "mp.messaging channel config expressed as nested YAML, not a dotted key inside a mapping"
+        gate: dotted-mp-messaging-keys
+        enforced: advisory
+        target_enforce_date: "2026-09-30"   # ADR-0144
+        blocked_on: "1 finding remains fleet-wide; the script already supports --enforce, so graduating
+          is a one-word change in ci.yml once it is cleared"
+        # Registered here as part of issue #2392: this gate ran advisory with no rules.yaml rule at
+        # all, so check-gate-graduation.sh could not see it and it had no deadline. That class is now
+        # itself gated by .github/scripts/check-advisory-gate-registration.py.
+        ci_producer: ".github/scripts/check-dotted-mp-messaging-keys.sh"
       new_service_with_outbox:
         # A service that extends AbstractOutboxEntity / uses OutboxDispatcher but does NOT
         # set openbank.outbox.dispatch-enabled=true silently never dispatches events —
@@ -2692,6 +2709,19 @@ data:
     # MEASURED behaviour by a classifier + CI gate (derive -> enforce -> show, ADR-0029/0054).
     # ---------------------------------------------------------------------------------------
     finops_tiers:
+      # Declared-side validation (check-finops-tiers.py, finops-lifecycle.yml) runs ADVISORY: the
+      # script always exits 0 today, so a tier declared here that contradicts the manifest is a
+      # ::warning. Graduating needs the MEASURED classifier (the derive->enforce->show half below);
+      # until that lands there is nothing to compare a declaration against except itself.
+      #
+      # Registered with a date as part of issue #2392: this gate ran advisory with no `enforced` /
+      # `target_enforce_date` on its rule, so check-gate-graduation.sh (ADR-0144) skipped it entirely
+      # and it had no deadline at all.
+      enforced: advisory
+      target_enforce_date: "2026-12-31"   # ADR-0144 — gated on the measured classifier, not on triage
+      blocked_on: "the measured-side classifier must land before the declared side can hard-fail;
+        without it, enforcing would only assert that the file agrees with itself"
+      ci_producer: "openbank-infra/scripts/check-finops-tiers.py"
       tiers:
         T0:                                   # Always-on
           definition: "Money-path HOT path where a cold-start / scaled-to-zero gap is unacceptable, or a regulator-mandated continuous service."

--- a/openbank-infra/gitops/components/ap2/ap2-opa-bundle.yaml
+++ b/openbank-infra/gitops/components/ap2/ap2-opa-bundle.yaml
@@ -9,7 +9,7 @@ metadata:
     app.kubernetes.io/name: mcp-service
     app.kubernetes.io/part-of: platform
   annotations:
-    openbank.tech/policy-checksum: "f396789572bad1ea"
+    openbank.tech/policy-checksum: "c5b9e80930a29004"
 data:
   rest.rego: |
     # SPDX-License-Identifier: Apache-2.0
@@ -2709,19 +2709,6 @@ data:
     # MEASURED behaviour by a classifier + CI gate (derive -> enforce -> show, ADR-0029/0054).
     # ---------------------------------------------------------------------------------------
     finops_tiers:
-      # Declared-side validation (check-finops-tiers.py, finops-lifecycle.yml) runs ADVISORY: the
-      # script always exits 0 today, so a tier declared here that contradicts the manifest is a
-      # ::warning. Graduating needs the MEASURED classifier (the derive->enforce->show half below);
-      # until that lands there is nothing to compare a declaration against except itself.
-      #
-      # Registered with a date as part of issue #2392: this gate ran advisory with no `enforced` /
-      # `target_enforce_date` on its rule, so check-gate-graduation.sh (ADR-0144) skipped it entirely
-      # and it had no deadline at all.
-      enforced: advisory
-      target_enforce_date: "2026-12-31"   # ADR-0144 — gated on the measured classifier, not on triage
-      blocked_on: "the measured-side classifier must land before the declared side can hard-fail;
-        without it, enforcing would only assert that the file agrees with itself"
-      ci_producer: "openbank-infra/scripts/check-finops-tiers.py"
       tiers:
         T0:                                   # Always-on
           definition: "Money-path HOT path where a cold-start / scaled-to-zero gap is unacceptable, or a regulator-mandated continuous service."
@@ -2824,6 +2811,9 @@ data:
       enforced: advisory                      # ADR-0057; -> block when the classifier lands
       target_enforce_date: "2026-09-30"   # ADR-0144
       blocked_on: "the measured-signal classifier (http_request_rate, kafka_consumer_lag, cpu/replica utilisation) has not shipped yet — only 2 services have a declared tier today (notification-service, product-catalog)"
+      # Added by issue #2392: the rule carried `enforced`/`target_enforce_date` but never named the
+      # script that produces the finding, so nothing tied the advisory CI step to this deadline.
+      ci_producer: "openbank-infra/scripts/check-finops-tiers.py"
 
     # ---------------------------------------------------------------------------------------
     # FinOps cost-allocation groups — showback business flows (ADR-0062). The /api/finops/costs

--- a/openbank-infra/gitops/components/ap2/ap2-service.yaml
+++ b/openbank-infra/gitops/components/ap2/ap2-service.yaml
@@ -30,7 +30,7 @@ spec:
       annotations:
         # Roll the pod when the OPA policy bundle changes (subPath mounts don't hot-reload).
         # Kept in sync by gen-ap2-opa-bundle.sh (do not hand-edit).
-        openbank.tech/policy-checksum: "31b69cbacb5b9c85"
+        openbank.tech/policy-checksum: "f396789572bad1ea"
     spec:
       securityContext:
         runAsNonRoot: true

--- a/openbank-infra/gitops/components/ap2/ap2-service.yaml
+++ b/openbank-infra/gitops/components/ap2/ap2-service.yaml
@@ -30,7 +30,7 @@ spec:
       annotations:
         # Roll the pod when the OPA policy bundle changes (subPath mounts don't hot-reload).
         # Kept in sync by gen-ap2-opa-bundle.sh (do not hand-edit).
-        openbank.tech/policy-checksum: "f396789572bad1ea"
+        openbank.tech/policy-checksum: "c5b9e80930a29004"
     spec:
       securityContext:
         runAsNonRoot: true

--- a/openbank-infra/gitops/components/audit/audit-opa-bundle.yaml
+++ b/openbank-infra/gitops/components/audit/audit-opa-bundle.yaml
@@ -9,7 +9,7 @@ metadata:
     app.kubernetes.io/name: audit-service
     app.kubernetes.io/part-of: audit
   annotations:
-    openbank.tech/policy-checksum: "ef5e0d5002945be9"
+    openbank.tech/policy-checksum: "9e755d6592b89902"
 data:
   rest.rego: |
     # SPDX-License-Identifier: Apache-2.0
@@ -1818,6 +1818,23 @@ data:
         # (3-dot against the PR base). Findings are ::warning annotations. Flip to enforced =
         # pass --enforce to the script in ci.yml (one-line change).
         ci_producer: "openbank-infra/scripts/check-threat-model-diff.py"
+      mp_messaging_dotted_keys:
+        # SmallRye reactive-messaging config written as a DOTTED key
+        # (`mp.messaging.incoming.x.topic: …`) inside a nested YAML mapping is silently ignored by
+        # SnakeYAML — the channel keeps its default and the consumer subscribes to nothing, with no
+        # error at boot (issue #686). The guard rewrites the shape it can prove wrong.
+        detect: ["<service>/src/main/resources/application.yaml", "mp.messaging.* written as a dotted key under a nested mapping"]
+        require:
+          - "mp.messaging channel config expressed as nested YAML, not a dotted key inside a mapping"
+        gate: dotted-mp-messaging-keys
+        enforced: advisory
+        target_enforce_date: "2026-09-30"   # ADR-0144
+        blocked_on: "1 finding remains fleet-wide; the script already supports --enforce, so graduating
+          is a one-word change in ci.yml once it is cleared"
+        # Registered here as part of issue #2392: this gate ran advisory with no rules.yaml rule at
+        # all, so check-gate-graduation.sh could not see it and it had no deadline. That class is now
+        # itself gated by .github/scripts/check-advisory-gate-registration.py.
+        ci_producer: ".github/scripts/check-dotted-mp-messaging-keys.sh"
       new_service_with_outbox:
         # A service that extends AbstractOutboxEntity / uses OutboxDispatcher but does NOT
         # set openbank.outbox.dispatch-enabled=true silently never dispatches events —
@@ -2736,6 +2753,19 @@ data:
     # MEASURED behaviour by a classifier + CI gate (derive -> enforce -> show, ADR-0029/0054).
     # ---------------------------------------------------------------------------------------
     finops_tiers:
+      # Declared-side validation (check-finops-tiers.py, finops-lifecycle.yml) runs ADVISORY: the
+      # script always exits 0 today, so a tier declared here that contradicts the manifest is a
+      # ::warning. Graduating needs the MEASURED classifier (the derive->enforce->show half below);
+      # until that lands there is nothing to compare a declaration against except itself.
+      #
+      # Registered with a date as part of issue #2392: this gate ran advisory with no `enforced` /
+      # `target_enforce_date` on its rule, so check-gate-graduation.sh (ADR-0144) skipped it entirely
+      # and it had no deadline at all.
+      enforced: advisory
+      target_enforce_date: "2026-12-31"   # ADR-0144 — gated on the measured classifier, not on triage
+      blocked_on: "the measured-side classifier must land before the declared side can hard-fail;
+        without it, enforcing would only assert that the file agrees with itself"
+      ci_producer: "openbank-infra/scripts/check-finops-tiers.py"
       tiers:
         T0:                                   # Always-on
           definition: "Money-path HOT path where a cold-start / scaled-to-zero gap is unacceptable, or a regulator-mandated continuous service."

--- a/openbank-infra/gitops/components/audit/audit-opa-bundle.yaml
+++ b/openbank-infra/gitops/components/audit/audit-opa-bundle.yaml
@@ -9,7 +9,7 @@ metadata:
     app.kubernetes.io/name: audit-service
     app.kubernetes.io/part-of: audit
   annotations:
-    openbank.tech/policy-checksum: "9e755d6592b89902"
+    openbank.tech/policy-checksum: "bf2ef29105621768"
 data:
   rest.rego: |
     # SPDX-License-Identifier: Apache-2.0
@@ -2753,19 +2753,6 @@ data:
     # MEASURED behaviour by a classifier + CI gate (derive -> enforce -> show, ADR-0029/0054).
     # ---------------------------------------------------------------------------------------
     finops_tiers:
-      # Declared-side validation (check-finops-tiers.py, finops-lifecycle.yml) runs ADVISORY: the
-      # script always exits 0 today, so a tier declared here that contradicts the manifest is a
-      # ::warning. Graduating needs the MEASURED classifier (the derive->enforce->show half below);
-      # until that lands there is nothing to compare a declaration against except itself.
-      #
-      # Registered with a date as part of issue #2392: this gate ran advisory with no `enforced` /
-      # `target_enforce_date` on its rule, so check-gate-graduation.sh (ADR-0144) skipped it entirely
-      # and it had no deadline at all.
-      enforced: advisory
-      target_enforce_date: "2026-12-31"   # ADR-0144 — gated on the measured classifier, not on triage
-      blocked_on: "the measured-side classifier must land before the declared side can hard-fail;
-        without it, enforcing would only assert that the file agrees with itself"
-      ci_producer: "openbank-infra/scripts/check-finops-tiers.py"
       tiers:
         T0:                                   # Always-on
           definition: "Money-path HOT path where a cold-start / scaled-to-zero gap is unacceptable, or a regulator-mandated continuous service."
@@ -2868,6 +2855,9 @@ data:
       enforced: advisory                      # ADR-0057; -> block when the classifier lands
       target_enforce_date: "2026-09-30"   # ADR-0144
       blocked_on: "the measured-signal classifier (http_request_rate, kafka_consumer_lag, cpu/replica utilisation) has not shipped yet — only 2 services have a declared tier today (notification-service, product-catalog)"
+      # Added by issue #2392: the rule carried `enforced`/`target_enforce_date` but never named the
+      # script that produces the finding, so nothing tied the advisory CI step to this deadline.
+      ci_producer: "openbank-infra/scripts/check-finops-tiers.py"
 
     # ---------------------------------------------------------------------------------------
     # FinOps cost-allocation groups — showback business flows (ADR-0062). The /api/finops/costs

--- a/openbank-infra/gitops/components/audit/audit-service.yaml
+++ b/openbank-infra/gitops/components/audit/audit-service.yaml
@@ -22,7 +22,7 @@ spec:
       annotations:
         # Rolls the pod when the OPA bundle changes (subPath mounts do not hot-reload).
         # Kept in sync by gen-audit-opa-bundle.sh (do not hand-edit).
-        openbank.tech/policy-checksum: "9e755d6592b89902"
+        openbank.tech/policy-checksum: "bf2ef29105621768"
     spec:
       securityContext:
         runAsNonRoot: true

--- a/openbank-infra/gitops/components/audit/audit-service.yaml
+++ b/openbank-infra/gitops/components/audit/audit-service.yaml
@@ -22,7 +22,7 @@ spec:
       annotations:
         # Rolls the pod when the OPA bundle changes (subPath mounts do not hot-reload).
         # Kept in sync by gen-audit-opa-bundle.sh (do not hand-edit).
-        openbank.tech/policy-checksum: "ef5e0d5002945be9"
+        openbank.tech/policy-checksum: "9e755d6592b89902"
     spec:
       securityContext:
         runAsNonRoot: true

--- a/openbank-infra/gitops/components/balances/balance-opa-bundle.yaml
+++ b/openbank-infra/gitops/components/balances/balance-opa-bundle.yaml
@@ -9,7 +9,7 @@ metadata:
     app.kubernetes.io/name: balance-service
     app.kubernetes.io/part-of: balances
   annotations:
-    openbank.tech/policy-checksum: "67731c88dca68691"
+    openbank.tech/policy-checksum: "6d2af229245a14b2"
 data:
   rest.rego: |
     # SPDX-License-Identifier: Apache-2.0
@@ -1907,6 +1907,23 @@ data:
         # (3-dot against the PR base). Findings are ::warning annotations. Flip to enforced =
         # pass --enforce to the script in ci.yml (one-line change).
         ci_producer: "openbank-infra/scripts/check-threat-model-diff.py"
+      mp_messaging_dotted_keys:
+        # SmallRye reactive-messaging config written as a DOTTED key
+        # (`mp.messaging.incoming.x.topic: …`) inside a nested YAML mapping is silently ignored by
+        # SnakeYAML — the channel keeps its default and the consumer subscribes to nothing, with no
+        # error at boot (issue #686). The guard rewrites the shape it can prove wrong.
+        detect: ["<service>/src/main/resources/application.yaml", "mp.messaging.* written as a dotted key under a nested mapping"]
+        require:
+          - "mp.messaging channel config expressed as nested YAML, not a dotted key inside a mapping"
+        gate: dotted-mp-messaging-keys
+        enforced: advisory
+        target_enforce_date: "2026-09-30"   # ADR-0144
+        blocked_on: "1 finding remains fleet-wide; the script already supports --enforce, so graduating
+          is a one-word change in ci.yml once it is cleared"
+        # Registered here as part of issue #2392: this gate ran advisory with no rules.yaml rule at
+        # all, so check-gate-graduation.sh could not see it and it had no deadline. That class is now
+        # itself gated by .github/scripts/check-advisory-gate-registration.py.
+        ci_producer: ".github/scripts/check-dotted-mp-messaging-keys.sh"
       new_service_with_outbox:
         # A service that extends AbstractOutboxEntity / uses OutboxDispatcher but does NOT
         # set openbank.outbox.dispatch-enabled=true silently never dispatches events —
@@ -2825,6 +2842,19 @@ data:
     # MEASURED behaviour by a classifier + CI gate (derive -> enforce -> show, ADR-0029/0054).
     # ---------------------------------------------------------------------------------------
     finops_tiers:
+      # Declared-side validation (check-finops-tiers.py, finops-lifecycle.yml) runs ADVISORY: the
+      # script always exits 0 today, so a tier declared here that contradicts the manifest is a
+      # ::warning. Graduating needs the MEASURED classifier (the derive->enforce->show half below);
+      # until that lands there is nothing to compare a declaration against except itself.
+      #
+      # Registered with a date as part of issue #2392: this gate ran advisory with no `enforced` /
+      # `target_enforce_date` on its rule, so check-gate-graduation.sh (ADR-0144) skipped it entirely
+      # and it had no deadline at all.
+      enforced: advisory
+      target_enforce_date: "2026-12-31"   # ADR-0144 — gated on the measured classifier, not on triage
+      blocked_on: "the measured-side classifier must land before the declared side can hard-fail;
+        without it, enforcing would only assert that the file agrees with itself"
+      ci_producer: "openbank-infra/scripts/check-finops-tiers.py"
       tiers:
         T0:                                   # Always-on
           definition: "Money-path HOT path where a cold-start / scaled-to-zero gap is unacceptable, or a regulator-mandated continuous service."

--- a/openbank-infra/gitops/components/balances/balance-opa-bundle.yaml
+++ b/openbank-infra/gitops/components/balances/balance-opa-bundle.yaml
@@ -9,7 +9,7 @@ metadata:
     app.kubernetes.io/name: balance-service
     app.kubernetes.io/part-of: balances
   annotations:
-    openbank.tech/policy-checksum: "6d2af229245a14b2"
+    openbank.tech/policy-checksum: "ef5a7f9378ef1eca"
 data:
   rest.rego: |
     # SPDX-License-Identifier: Apache-2.0
@@ -2842,19 +2842,6 @@ data:
     # MEASURED behaviour by a classifier + CI gate (derive -> enforce -> show, ADR-0029/0054).
     # ---------------------------------------------------------------------------------------
     finops_tiers:
-      # Declared-side validation (check-finops-tiers.py, finops-lifecycle.yml) runs ADVISORY: the
-      # script always exits 0 today, so a tier declared here that contradicts the manifest is a
-      # ::warning. Graduating needs the MEASURED classifier (the derive->enforce->show half below);
-      # until that lands there is nothing to compare a declaration against except itself.
-      #
-      # Registered with a date as part of issue #2392: this gate ran advisory with no `enforced` /
-      # `target_enforce_date` on its rule, so check-gate-graduation.sh (ADR-0144) skipped it entirely
-      # and it had no deadline at all.
-      enforced: advisory
-      target_enforce_date: "2026-12-31"   # ADR-0144 — gated on the measured classifier, not on triage
-      blocked_on: "the measured-side classifier must land before the declared side can hard-fail;
-        without it, enforcing would only assert that the file agrees with itself"
-      ci_producer: "openbank-infra/scripts/check-finops-tiers.py"
       tiers:
         T0:                                   # Always-on
           definition: "Money-path HOT path where a cold-start / scaled-to-zero gap is unacceptable, or a regulator-mandated continuous service."
@@ -2957,6 +2944,9 @@ data:
       enforced: advisory                      # ADR-0057; -> block when the classifier lands
       target_enforce_date: "2026-09-30"   # ADR-0144
       blocked_on: "the measured-signal classifier (http_request_rate, kafka_consumer_lag, cpu/replica utilisation) has not shipped yet — only 2 services have a declared tier today (notification-service, product-catalog)"
+      # Added by issue #2392: the rule carried `enforced`/`target_enforce_date` but never named the
+      # script that produces the finding, so nothing tied the advisory CI step to this deadline.
+      ci_producer: "openbank-infra/scripts/check-finops-tiers.py"
 
     # ---------------------------------------------------------------------------------------
     # FinOps cost-allocation groups — showback business flows (ADR-0062). The /api/finops/costs

--- a/openbank-infra/gitops/components/balances/balance-service.yaml
+++ b/openbank-infra/gitops/components/balances/balance-service.yaml
@@ -34,7 +34,7 @@ spec:
       annotations:
         # Rolls the pods when the OPA bundle changes — subPath mounts do NOT hot-reload.
         # Kept in sync by gen-balance-opa-bundle.sh (do not hand-edit).
-        openbank.tech/policy-checksum: "67731c88dca68691"
+        openbank.tech/policy-checksum: "6d2af229245a14b2"
     spec:
       securityContext:
         runAsNonRoot: true

--- a/openbank-infra/gitops/components/balances/balance-service.yaml
+++ b/openbank-infra/gitops/components/balances/balance-service.yaml
@@ -34,7 +34,7 @@ spec:
       annotations:
         # Rolls the pods when the OPA bundle changes — subPath mounts do NOT hot-reload.
         # Kept in sync by gen-balance-opa-bundle.sh (do not hand-edit).
-        openbank.tech/policy-checksum: "6d2af229245a14b2"
+        openbank.tech/policy-checksum: "ef5a7f9378ef1eca"
     spec:
       securityContext:
         runAsNonRoot: true

--- a/openbank-infra/gitops/components/billing/billing-opa-bundle.yaml
+++ b/openbank-infra/gitops/components/billing/billing-opa-bundle.yaml
@@ -9,7 +9,7 @@ metadata:
     app.kubernetes.io/name: billing-service
     app.kubernetes.io/part-of: billing
   annotations:
-    openbank.tech/policy-checksum: "3c2badcfe6f0ffa2"
+    openbank.tech/policy-checksum: "2ef9ee8202272eb1"
 data:
   rest.rego: |
     # SPDX-License-Identifier: Apache-2.0
@@ -2747,19 +2747,6 @@ data:
     # MEASURED behaviour by a classifier + CI gate (derive -> enforce -> show, ADR-0029/0054).
     # ---------------------------------------------------------------------------------------
     finops_tiers:
-      # Declared-side validation (check-finops-tiers.py, finops-lifecycle.yml) runs ADVISORY: the
-      # script always exits 0 today, so a tier declared here that contradicts the manifest is a
-      # ::warning. Graduating needs the MEASURED classifier (the derive->enforce->show half below);
-      # until that lands there is nothing to compare a declaration against except itself.
-      #
-      # Registered with a date as part of issue #2392: this gate ran advisory with no `enforced` /
-      # `target_enforce_date` on its rule, so check-gate-graduation.sh (ADR-0144) skipped it entirely
-      # and it had no deadline at all.
-      enforced: advisory
-      target_enforce_date: "2026-12-31"   # ADR-0144 — gated on the measured classifier, not on triage
-      blocked_on: "the measured-side classifier must land before the declared side can hard-fail;
-        without it, enforcing would only assert that the file agrees with itself"
-      ci_producer: "openbank-infra/scripts/check-finops-tiers.py"
       tiers:
         T0:                                   # Always-on
           definition: "Money-path HOT path where a cold-start / scaled-to-zero gap is unacceptable, or a regulator-mandated continuous service."
@@ -2862,6 +2849,9 @@ data:
       enforced: advisory                      # ADR-0057; -> block when the classifier lands
       target_enforce_date: "2026-09-30"   # ADR-0144
       blocked_on: "the measured-signal classifier (http_request_rate, kafka_consumer_lag, cpu/replica utilisation) has not shipped yet — only 2 services have a declared tier today (notification-service, product-catalog)"
+      # Added by issue #2392: the rule carried `enforced`/`target_enforce_date` but never named the
+      # script that produces the finding, so nothing tied the advisory CI step to this deadline.
+      ci_producer: "openbank-infra/scripts/check-finops-tiers.py"
 
     # ---------------------------------------------------------------------------------------
     # FinOps cost-allocation groups — showback business flows (ADR-0062). The /api/finops/costs

--- a/openbank-infra/gitops/components/billing/billing-opa-bundle.yaml
+++ b/openbank-infra/gitops/components/billing/billing-opa-bundle.yaml
@@ -9,7 +9,7 @@ metadata:
     app.kubernetes.io/name: billing-service
     app.kubernetes.io/part-of: billing
   annotations:
-    openbank.tech/policy-checksum: "71f7cfd7be956882"
+    openbank.tech/policy-checksum: "3c2badcfe6f0ffa2"
 data:
   rest.rego: |
     # SPDX-License-Identifier: Apache-2.0
@@ -1812,6 +1812,23 @@ data:
         # (3-dot against the PR base). Findings are ::warning annotations. Flip to enforced =
         # pass --enforce to the script in ci.yml (one-line change).
         ci_producer: "openbank-infra/scripts/check-threat-model-diff.py"
+      mp_messaging_dotted_keys:
+        # SmallRye reactive-messaging config written as a DOTTED key
+        # (`mp.messaging.incoming.x.topic: …`) inside a nested YAML mapping is silently ignored by
+        # SnakeYAML — the channel keeps its default and the consumer subscribes to nothing, with no
+        # error at boot (issue #686). The guard rewrites the shape it can prove wrong.
+        detect: ["<service>/src/main/resources/application.yaml", "mp.messaging.* written as a dotted key under a nested mapping"]
+        require:
+          - "mp.messaging channel config expressed as nested YAML, not a dotted key inside a mapping"
+        gate: dotted-mp-messaging-keys
+        enforced: advisory
+        target_enforce_date: "2026-09-30"   # ADR-0144
+        blocked_on: "1 finding remains fleet-wide; the script already supports --enforce, so graduating
+          is a one-word change in ci.yml once it is cleared"
+        # Registered here as part of issue #2392: this gate ran advisory with no rules.yaml rule at
+        # all, so check-gate-graduation.sh could not see it and it had no deadline. That class is now
+        # itself gated by .github/scripts/check-advisory-gate-registration.py.
+        ci_producer: ".github/scripts/check-dotted-mp-messaging-keys.sh"
       new_service_with_outbox:
         # A service that extends AbstractOutboxEntity / uses OutboxDispatcher but does NOT
         # set openbank.outbox.dispatch-enabled=true silently never dispatches events —
@@ -2730,6 +2747,19 @@ data:
     # MEASURED behaviour by a classifier + CI gate (derive -> enforce -> show, ADR-0029/0054).
     # ---------------------------------------------------------------------------------------
     finops_tiers:
+      # Declared-side validation (check-finops-tiers.py, finops-lifecycle.yml) runs ADVISORY: the
+      # script always exits 0 today, so a tier declared here that contradicts the manifest is a
+      # ::warning. Graduating needs the MEASURED classifier (the derive->enforce->show half below);
+      # until that lands there is nothing to compare a declaration against except itself.
+      #
+      # Registered with a date as part of issue #2392: this gate ran advisory with no `enforced` /
+      # `target_enforce_date` on its rule, so check-gate-graduation.sh (ADR-0144) skipped it entirely
+      # and it had no deadline at all.
+      enforced: advisory
+      target_enforce_date: "2026-12-31"   # ADR-0144 — gated on the measured classifier, not on triage
+      blocked_on: "the measured-side classifier must land before the declared side can hard-fail;
+        without it, enforcing would only assert that the file agrees with itself"
+      ci_producer: "openbank-infra/scripts/check-finops-tiers.py"
       tiers:
         T0:                                   # Always-on
           definition: "Money-path HOT path where a cold-start / scaled-to-zero gap is unacceptable, or a regulator-mandated continuous service."

--- a/openbank-infra/gitops/components/billing/billing-service.yaml
+++ b/openbank-infra/gitops/components/billing/billing-service.yaml
@@ -27,7 +27,7 @@ spec:
       annotations:
         # Rolls the pods when the OPA bundle changes — subPath mounts do NOT hot-reload.
         # Kept in sync by gen-billing-opa-bundle.sh (do not hand-edit).
-        openbank.tech/policy-checksum: "71f7cfd7be956882"
+        openbank.tech/policy-checksum: "3c2badcfe6f0ffa2"
     spec:
       securityContext:
         runAsNonRoot: true

--- a/openbank-infra/gitops/components/billing/billing-service.yaml
+++ b/openbank-infra/gitops/components/billing/billing-service.yaml
@@ -27,7 +27,7 @@ spec:
       annotations:
         # Rolls the pods when the OPA bundle changes — subPath mounts do NOT hot-reload.
         # Kept in sync by gen-billing-opa-bundle.sh (do not hand-edit).
-        openbank.tech/policy-checksum: "3c2badcfe6f0ffa2"
+        openbank.tech/policy-checksum: "2ef9ee8202272eb1"
     spec:
       securityContext:
         runAsNonRoot: true

--- a/openbank-infra/gitops/components/consent/consent-opa-bundle.yaml
+++ b/openbank-infra/gitops/components/consent/consent-opa-bundle.yaml
@@ -9,7 +9,7 @@ metadata:
     app.kubernetes.io/name: consent-service
     app.kubernetes.io/part-of: consent
   annotations:
-    openbank.tech/policy-checksum: "f95ac62dfc1e2a99"
+    openbank.tech/policy-checksum: "99cdecbc9852737d"
 data:
   rest.rego: |
     # SPDX-License-Identifier: Apache-2.0
@@ -1844,6 +1844,23 @@ data:
         # (3-dot against the PR base). Findings are ::warning annotations. Flip to enforced =
         # pass --enforce to the script in ci.yml (one-line change).
         ci_producer: "openbank-infra/scripts/check-threat-model-diff.py"
+      mp_messaging_dotted_keys:
+        # SmallRye reactive-messaging config written as a DOTTED key
+        # (`mp.messaging.incoming.x.topic: …`) inside a nested YAML mapping is silently ignored by
+        # SnakeYAML — the channel keeps its default and the consumer subscribes to nothing, with no
+        # error at boot (issue #686). The guard rewrites the shape it can prove wrong.
+        detect: ["<service>/src/main/resources/application.yaml", "mp.messaging.* written as a dotted key under a nested mapping"]
+        require:
+          - "mp.messaging channel config expressed as nested YAML, not a dotted key inside a mapping"
+        gate: dotted-mp-messaging-keys
+        enforced: advisory
+        target_enforce_date: "2026-09-30"   # ADR-0144
+        blocked_on: "1 finding remains fleet-wide; the script already supports --enforce, so graduating
+          is a one-word change in ci.yml once it is cleared"
+        # Registered here as part of issue #2392: this gate ran advisory with no rules.yaml rule at
+        # all, so check-gate-graduation.sh could not see it and it had no deadline. That class is now
+        # itself gated by .github/scripts/check-advisory-gate-registration.py.
+        ci_producer: ".github/scripts/check-dotted-mp-messaging-keys.sh"
       new_service_with_outbox:
         # A service that extends AbstractOutboxEntity / uses OutboxDispatcher but does NOT
         # set openbank.outbox.dispatch-enabled=true silently never dispatches events —
@@ -2762,6 +2779,19 @@ data:
     # MEASURED behaviour by a classifier + CI gate (derive -> enforce -> show, ADR-0029/0054).
     # ---------------------------------------------------------------------------------------
     finops_tiers:
+      # Declared-side validation (check-finops-tiers.py, finops-lifecycle.yml) runs ADVISORY: the
+      # script always exits 0 today, so a tier declared here that contradicts the manifest is a
+      # ::warning. Graduating needs the MEASURED classifier (the derive->enforce->show half below);
+      # until that lands there is nothing to compare a declaration against except itself.
+      #
+      # Registered with a date as part of issue #2392: this gate ran advisory with no `enforced` /
+      # `target_enforce_date` on its rule, so check-gate-graduation.sh (ADR-0144) skipped it entirely
+      # and it had no deadline at all.
+      enforced: advisory
+      target_enforce_date: "2026-12-31"   # ADR-0144 — gated on the measured classifier, not on triage
+      blocked_on: "the measured-side classifier must land before the declared side can hard-fail;
+        without it, enforcing would only assert that the file agrees with itself"
+      ci_producer: "openbank-infra/scripts/check-finops-tiers.py"
       tiers:
         T0:                                   # Always-on
           definition: "Money-path HOT path where a cold-start / scaled-to-zero gap is unacceptable, or a regulator-mandated continuous service."

--- a/openbank-infra/gitops/components/consent/consent-opa-bundle.yaml
+++ b/openbank-infra/gitops/components/consent/consent-opa-bundle.yaml
@@ -9,7 +9,7 @@ metadata:
     app.kubernetes.io/name: consent-service
     app.kubernetes.io/part-of: consent
   annotations:
-    openbank.tech/policy-checksum: "99cdecbc9852737d"
+    openbank.tech/policy-checksum: "9308b6b7977b8749"
 data:
   rest.rego: |
     # SPDX-License-Identifier: Apache-2.0
@@ -2779,19 +2779,6 @@ data:
     # MEASURED behaviour by a classifier + CI gate (derive -> enforce -> show, ADR-0029/0054).
     # ---------------------------------------------------------------------------------------
     finops_tiers:
-      # Declared-side validation (check-finops-tiers.py, finops-lifecycle.yml) runs ADVISORY: the
-      # script always exits 0 today, so a tier declared here that contradicts the manifest is a
-      # ::warning. Graduating needs the MEASURED classifier (the derive->enforce->show half below);
-      # until that lands there is nothing to compare a declaration against except itself.
-      #
-      # Registered with a date as part of issue #2392: this gate ran advisory with no `enforced` /
-      # `target_enforce_date` on its rule, so check-gate-graduation.sh (ADR-0144) skipped it entirely
-      # and it had no deadline at all.
-      enforced: advisory
-      target_enforce_date: "2026-12-31"   # ADR-0144 — gated on the measured classifier, not on triage
-      blocked_on: "the measured-side classifier must land before the declared side can hard-fail;
-        without it, enforcing would only assert that the file agrees with itself"
-      ci_producer: "openbank-infra/scripts/check-finops-tiers.py"
       tiers:
         T0:                                   # Always-on
           definition: "Money-path HOT path where a cold-start / scaled-to-zero gap is unacceptable, or a regulator-mandated continuous service."
@@ -2894,6 +2881,9 @@ data:
       enforced: advisory                      # ADR-0057; -> block when the classifier lands
       target_enforce_date: "2026-09-30"   # ADR-0144
       blocked_on: "the measured-signal classifier (http_request_rate, kafka_consumer_lag, cpu/replica utilisation) has not shipped yet — only 2 services have a declared tier today (notification-service, product-catalog)"
+      # Added by issue #2392: the rule carried `enforced`/`target_enforce_date` but never named the
+      # script that produces the finding, so nothing tied the advisory CI step to this deadline.
+      ci_producer: "openbank-infra/scripts/check-finops-tiers.py"
 
     # ---------------------------------------------------------------------------------------
     # FinOps cost-allocation groups — showback business flows (ADR-0062). The /api/finops/costs

--- a/openbank-infra/gitops/components/consent/consent-service.yaml
+++ b/openbank-infra/gitops/components/consent/consent-service.yaml
@@ -28,7 +28,7 @@ spec:
       annotations:
         # Rolls the pods when the OPA bundle changes — subPath mounts do NOT hot-reload.
         # Kept in sync by gen-consent-opa-bundle.sh (do not hand-edit).
-        openbank.tech/policy-checksum: "f95ac62dfc1e2a99"
+        openbank.tech/policy-checksum: "99cdecbc9852737d"
     spec:
       securityContext:
         runAsNonRoot: true

--- a/openbank-infra/gitops/components/consent/consent-service.yaml
+++ b/openbank-infra/gitops/components/consent/consent-service.yaml
@@ -28,7 +28,7 @@ spec:
       annotations:
         # Rolls the pods when the OPA bundle changes — subPath mounts do NOT hot-reload.
         # Kept in sync by gen-consent-opa-bundle.sh (do not hand-edit).
-        openbank.tech/policy-checksum: "99cdecbc9852737d"
+        openbank.tech/policy-checksum: "9308b6b7977b8749"
     spec:
       securityContext:
         runAsNonRoot: true

--- a/openbank-infra/gitops/components/copilot/copilot-opa-bundle.yaml
+++ b/openbank-infra/gitops/components/copilot/copilot-opa-bundle.yaml
@@ -9,7 +9,7 @@ metadata:
     app.kubernetes.io/name: copilot-service
     app.kubernetes.io/part-of: platform
   annotations:
-    openbank.tech/policy-checksum: "2796c079ff8968c6"
+    openbank.tech/policy-checksum: "13ad3e5756ca1bad"
 data:
   rest.rego: |
     # SPDX-License-Identifier: Apache-2.0
@@ -2833,19 +2833,6 @@ data:
     # MEASURED behaviour by a classifier + CI gate (derive -> enforce -> show, ADR-0029/0054).
     # ---------------------------------------------------------------------------------------
     finops_tiers:
-      # Declared-side validation (check-finops-tiers.py, finops-lifecycle.yml) runs ADVISORY: the
-      # script always exits 0 today, so a tier declared here that contradicts the manifest is a
-      # ::warning. Graduating needs the MEASURED classifier (the derive->enforce->show half below);
-      # until that lands there is nothing to compare a declaration against except itself.
-      #
-      # Registered with a date as part of issue #2392: this gate ran advisory with no `enforced` /
-      # `target_enforce_date` on its rule, so check-gate-graduation.sh (ADR-0144) skipped it entirely
-      # and it had no deadline at all.
-      enforced: advisory
-      target_enforce_date: "2026-12-31"   # ADR-0144 — gated on the measured classifier, not on triage
-      blocked_on: "the measured-side classifier must land before the declared side can hard-fail;
-        without it, enforcing would only assert that the file agrees with itself"
-      ci_producer: "openbank-infra/scripts/check-finops-tiers.py"
       tiers:
         T0:                                   # Always-on
           definition: "Money-path HOT path where a cold-start / scaled-to-zero gap is unacceptable, or a regulator-mandated continuous service."
@@ -2948,6 +2935,9 @@ data:
       enforced: advisory                      # ADR-0057; -> block when the classifier lands
       target_enforce_date: "2026-09-30"   # ADR-0144
       blocked_on: "the measured-signal classifier (http_request_rate, kafka_consumer_lag, cpu/replica utilisation) has not shipped yet — only 2 services have a declared tier today (notification-service, product-catalog)"
+      # Added by issue #2392: the rule carried `enforced`/`target_enforce_date` but never named the
+      # script that produces the finding, so nothing tied the advisory CI step to this deadline.
+      ci_producer: "openbank-infra/scripts/check-finops-tiers.py"
 
     # ---------------------------------------------------------------------------------------
     # FinOps cost-allocation groups — showback business flows (ADR-0062). The /api/finops/costs

--- a/openbank-infra/gitops/components/copilot/copilot-opa-bundle.yaml
+++ b/openbank-infra/gitops/components/copilot/copilot-opa-bundle.yaml
@@ -9,7 +9,7 @@ metadata:
     app.kubernetes.io/name: copilot-service
     app.kubernetes.io/part-of: platform
   annotations:
-    openbank.tech/policy-checksum: "a99f8ebad4ebc92b"
+    openbank.tech/policy-checksum: "2796c079ff8968c6"
 data:
   rest.rego: |
     # SPDX-License-Identifier: Apache-2.0
@@ -1898,6 +1898,23 @@ data:
         # (3-dot against the PR base). Findings are ::warning annotations. Flip to enforced =
         # pass --enforce to the script in ci.yml (one-line change).
         ci_producer: "openbank-infra/scripts/check-threat-model-diff.py"
+      mp_messaging_dotted_keys:
+        # SmallRye reactive-messaging config written as a DOTTED key
+        # (`mp.messaging.incoming.x.topic: …`) inside a nested YAML mapping is silently ignored by
+        # SnakeYAML — the channel keeps its default and the consumer subscribes to nothing, with no
+        # error at boot (issue #686). The guard rewrites the shape it can prove wrong.
+        detect: ["<service>/src/main/resources/application.yaml", "mp.messaging.* written as a dotted key under a nested mapping"]
+        require:
+          - "mp.messaging channel config expressed as nested YAML, not a dotted key inside a mapping"
+        gate: dotted-mp-messaging-keys
+        enforced: advisory
+        target_enforce_date: "2026-09-30"   # ADR-0144
+        blocked_on: "1 finding remains fleet-wide; the script already supports --enforce, so graduating
+          is a one-word change in ci.yml once it is cleared"
+        # Registered here as part of issue #2392: this gate ran advisory with no rules.yaml rule at
+        # all, so check-gate-graduation.sh could not see it and it had no deadline. That class is now
+        # itself gated by .github/scripts/check-advisory-gate-registration.py.
+        ci_producer: ".github/scripts/check-dotted-mp-messaging-keys.sh"
       new_service_with_outbox:
         # A service that extends AbstractOutboxEntity / uses OutboxDispatcher but does NOT
         # set openbank.outbox.dispatch-enabled=true silently never dispatches events —
@@ -2816,6 +2833,19 @@ data:
     # MEASURED behaviour by a classifier + CI gate (derive -> enforce -> show, ADR-0029/0054).
     # ---------------------------------------------------------------------------------------
     finops_tiers:
+      # Declared-side validation (check-finops-tiers.py, finops-lifecycle.yml) runs ADVISORY: the
+      # script always exits 0 today, so a tier declared here that contradicts the manifest is a
+      # ::warning. Graduating needs the MEASURED classifier (the derive->enforce->show half below);
+      # until that lands there is nothing to compare a declaration against except itself.
+      #
+      # Registered with a date as part of issue #2392: this gate ran advisory with no `enforced` /
+      # `target_enforce_date` on its rule, so check-gate-graduation.sh (ADR-0144) skipped it entirely
+      # and it had no deadline at all.
+      enforced: advisory
+      target_enforce_date: "2026-12-31"   # ADR-0144 — gated on the measured classifier, not on triage
+      blocked_on: "the measured-side classifier must land before the declared side can hard-fail;
+        without it, enforcing would only assert that the file agrees with itself"
+      ci_producer: "openbank-infra/scripts/check-finops-tiers.py"
       tiers:
         T0:                                   # Always-on
           definition: "Money-path HOT path where a cold-start / scaled-to-zero gap is unacceptable, or a regulator-mandated continuous service."

--- a/openbank-infra/gitops/components/copilot/copilot-service.yaml
+++ b/openbank-infra/gitops/components/copilot/copilot-service.yaml
@@ -29,7 +29,7 @@ spec:
       annotations:
         # Rolls the pod when the OPA bundle changes — subPath mounts do NOT hot-reload.
         # Kept in sync by gen-copilot-opa-bundle.sh (do not hand-edit).
-        openbank.tech/policy-checksum: "a99f8ebad4ebc92b"
+        openbank.tech/policy-checksum: "2796c079ff8968c6"
     spec:
       securityContext:
         runAsNonRoot: true

--- a/openbank-infra/gitops/components/copilot/copilot-service.yaml
+++ b/openbank-infra/gitops/components/copilot/copilot-service.yaml
@@ -29,7 +29,7 @@ spec:
       annotations:
         # Rolls the pod when the OPA bundle changes — subPath mounts do NOT hot-reload.
         # Kept in sync by gen-copilot-opa-bundle.sh (do not hand-edit).
-        openbank.tech/policy-checksum: "2796c079ff8968c6"
+        openbank.tech/policy-checksum: "13ad3e5756ca1bad"
     spec:
       securityContext:
         runAsNonRoot: true

--- a/openbank-infra/gitops/components/customer-edge/customer-edge-opa-bundle.yaml
+++ b/openbank-infra/gitops/components/customer-edge/customer-edge-opa-bundle.yaml
@@ -10,7 +10,7 @@ metadata:
     app.kubernetes.io/name: customer-edge
     app.kubernetes.io/part-of: customer-edge
   annotations:
-    openbank.tech/policy-checksum: "79c797e60711208b"
+    openbank.tech/policy-checksum: "b008ff50a7934dcf"
 data:
   rest.rego: |
     # SPDX-License-Identifier: Apache-2.0
@@ -997,6 +997,23 @@ data:
         # (3-dot against the PR base). Findings are ::warning annotations. Flip to enforced =
         # pass --enforce to the script in ci.yml (one-line change).
         ci_producer: "openbank-infra/scripts/check-threat-model-diff.py"
+      mp_messaging_dotted_keys:
+        # SmallRye reactive-messaging config written as a DOTTED key
+        # (`mp.messaging.incoming.x.topic: …`) inside a nested YAML mapping is silently ignored by
+        # SnakeYAML — the channel keeps its default and the consumer subscribes to nothing, with no
+        # error at boot (issue #686). The guard rewrites the shape it can prove wrong.
+        detect: ["<service>/src/main/resources/application.yaml", "mp.messaging.* written as a dotted key under a nested mapping"]
+        require:
+          - "mp.messaging channel config expressed as nested YAML, not a dotted key inside a mapping"
+        gate: dotted-mp-messaging-keys
+        enforced: advisory
+        target_enforce_date: "2026-09-30"   # ADR-0144
+        blocked_on: "1 finding remains fleet-wide; the script already supports --enforce, so graduating
+          is a one-word change in ci.yml once it is cleared"
+        # Registered here as part of issue #2392: this gate ran advisory with no rules.yaml rule at
+        # all, so check-gate-graduation.sh could not see it and it had no deadline. That class is now
+        # itself gated by .github/scripts/check-advisory-gate-registration.py.
+        ci_producer: ".github/scripts/check-dotted-mp-messaging-keys.sh"
       new_service_with_outbox:
         # A service that extends AbstractOutboxEntity / uses OutboxDispatcher but does NOT
         # set openbank.outbox.dispatch-enabled=true silently never dispatches events —
@@ -1915,6 +1932,19 @@ data:
     # MEASURED behaviour by a classifier + CI gate (derive -> enforce -> show, ADR-0029/0054).
     # ---------------------------------------------------------------------------------------
     finops_tiers:
+      # Declared-side validation (check-finops-tiers.py, finops-lifecycle.yml) runs ADVISORY: the
+      # script always exits 0 today, so a tier declared here that contradicts the manifest is a
+      # ::warning. Graduating needs the MEASURED classifier (the derive->enforce->show half below);
+      # until that lands there is nothing to compare a declaration against except itself.
+      #
+      # Registered with a date as part of issue #2392: this gate ran advisory with no `enforced` /
+      # `target_enforce_date` on its rule, so check-gate-graduation.sh (ADR-0144) skipped it entirely
+      # and it had no deadline at all.
+      enforced: advisory
+      target_enforce_date: "2026-12-31"   # ADR-0144 — gated on the measured classifier, not on triage
+      blocked_on: "the measured-side classifier must land before the declared side can hard-fail;
+        without it, enforcing would only assert that the file agrees with itself"
+      ci_producer: "openbank-infra/scripts/check-finops-tiers.py"
       tiers:
         T0:                                   # Always-on
           definition: "Money-path HOT path where a cold-start / scaled-to-zero gap is unacceptable, or a regulator-mandated continuous service."

--- a/openbank-infra/gitops/components/customer-edge/customer-edge-opa-bundle.yaml
+++ b/openbank-infra/gitops/components/customer-edge/customer-edge-opa-bundle.yaml
@@ -10,7 +10,7 @@ metadata:
     app.kubernetes.io/name: customer-edge
     app.kubernetes.io/part-of: customer-edge
   annotations:
-    openbank.tech/policy-checksum: "b008ff50a7934dcf"
+    openbank.tech/policy-checksum: "4cbd1f661b104602"
 data:
   rest.rego: |
     # SPDX-License-Identifier: Apache-2.0
@@ -1932,19 +1932,6 @@ data:
     # MEASURED behaviour by a classifier + CI gate (derive -> enforce -> show, ADR-0029/0054).
     # ---------------------------------------------------------------------------------------
     finops_tiers:
-      # Declared-side validation (check-finops-tiers.py, finops-lifecycle.yml) runs ADVISORY: the
-      # script always exits 0 today, so a tier declared here that contradicts the manifest is a
-      # ::warning. Graduating needs the MEASURED classifier (the derive->enforce->show half below);
-      # until that lands there is nothing to compare a declaration against except itself.
-      #
-      # Registered with a date as part of issue #2392: this gate ran advisory with no `enforced` /
-      # `target_enforce_date` on its rule, so check-gate-graduation.sh (ADR-0144) skipped it entirely
-      # and it had no deadline at all.
-      enforced: advisory
-      target_enforce_date: "2026-12-31"   # ADR-0144 — gated on the measured classifier, not on triage
-      blocked_on: "the measured-side classifier must land before the declared side can hard-fail;
-        without it, enforcing would only assert that the file agrees with itself"
-      ci_producer: "openbank-infra/scripts/check-finops-tiers.py"
       tiers:
         T0:                                   # Always-on
           definition: "Money-path HOT path where a cold-start / scaled-to-zero gap is unacceptable, or a regulator-mandated continuous service."
@@ -2047,6 +2034,9 @@ data:
       enforced: advisory                      # ADR-0057; -> block when the classifier lands
       target_enforce_date: "2026-09-30"   # ADR-0144
       blocked_on: "the measured-signal classifier (http_request_rate, kafka_consumer_lag, cpu/replica utilisation) has not shipped yet — only 2 services have a declared tier today (notification-service, product-catalog)"
+      # Added by issue #2392: the rule carried `enforced`/`target_enforce_date` but never named the
+      # script that produces the finding, so nothing tied the advisory CI step to this deadline.
+      ci_producer: "openbank-infra/scripts/check-finops-tiers.py"
 
     # ---------------------------------------------------------------------------------------
     # FinOps cost-allocation groups — showback business flows (ADR-0062). The /api/finops/costs

--- a/openbank-infra/gitops/components/customer-edge/customer-edge.yaml
+++ b/openbank-infra/gitops/components/customer-edge/customer-edge.yaml
@@ -65,7 +65,7 @@ spec:
       annotations:
         # Rolls the pod when the OPA bundle changes — subPath mounts do NOT hot-reload.
         # Kept in sync by gen-customer-edge-opa-bundle.sh (do not hand-edit).
-        openbank.tech/policy-checksum: "79c797e60711208b"
+        openbank.tech/policy-checksum: "b008ff50a7934dcf"
     spec:
       # Dedicated SA so EKS Pod Identity can hand the edge (and ONLY the edge) the
       # feedback-screenshots S3 role — ADR-0192, openbank-infra/aws/envs/sandbox-platform/

--- a/openbank-infra/gitops/components/customer-edge/customer-edge.yaml
+++ b/openbank-infra/gitops/components/customer-edge/customer-edge.yaml
@@ -65,7 +65,7 @@ spec:
       annotations:
         # Rolls the pod when the OPA bundle changes — subPath mounts do NOT hot-reload.
         # Kept in sync by gen-customer-edge-opa-bundle.sh (do not hand-edit).
-        openbank.tech/policy-checksum: "b008ff50a7934dcf"
+        openbank.tech/policy-checksum: "4cbd1f661b104602"
     spec:
       # Dedicated SA so EKS Pod Identity can hand the edge (and ONLY the edge) the
       # feedback-screenshots S3 role — ADR-0192, openbank-infra/aws/envs/sandbox-platform/

--- a/openbank-infra/gitops/components/dispute-service/dispute-opa-bundle.yaml
+++ b/openbank-infra/gitops/components/dispute-service/dispute-opa-bundle.yaml
@@ -9,7 +9,7 @@ metadata:
     app.kubernetes.io/name: dispute-service
     app.kubernetes.io/part-of: dispute
   annotations:
-    openbank.tech/policy-checksum: "f3eba3091b4c7747"
+    openbank.tech/policy-checksum: "cb7d4cbfc114296b"
 data:
   rest.rego: |
     # SPDX-License-Identifier: Apache-2.0
@@ -1948,6 +1948,23 @@ data:
         # (3-dot against the PR base). Findings are ::warning annotations. Flip to enforced =
         # pass --enforce to the script in ci.yml (one-line change).
         ci_producer: "openbank-infra/scripts/check-threat-model-diff.py"
+      mp_messaging_dotted_keys:
+        # SmallRye reactive-messaging config written as a DOTTED key
+        # (`mp.messaging.incoming.x.topic: …`) inside a nested YAML mapping is silently ignored by
+        # SnakeYAML — the channel keeps its default and the consumer subscribes to nothing, with no
+        # error at boot (issue #686). The guard rewrites the shape it can prove wrong.
+        detect: ["<service>/src/main/resources/application.yaml", "mp.messaging.* written as a dotted key under a nested mapping"]
+        require:
+          - "mp.messaging channel config expressed as nested YAML, not a dotted key inside a mapping"
+        gate: dotted-mp-messaging-keys
+        enforced: advisory
+        target_enforce_date: "2026-09-30"   # ADR-0144
+        blocked_on: "1 finding remains fleet-wide; the script already supports --enforce, so graduating
+          is a one-word change in ci.yml once it is cleared"
+        # Registered here as part of issue #2392: this gate ran advisory with no rules.yaml rule at
+        # all, so check-gate-graduation.sh could not see it and it had no deadline. That class is now
+        # itself gated by .github/scripts/check-advisory-gate-registration.py.
+        ci_producer: ".github/scripts/check-dotted-mp-messaging-keys.sh"
       new_service_with_outbox:
         # A service that extends AbstractOutboxEntity / uses OutboxDispatcher but does NOT
         # set openbank.outbox.dispatch-enabled=true silently never dispatches events —
@@ -2866,6 +2883,19 @@ data:
     # MEASURED behaviour by a classifier + CI gate (derive -> enforce -> show, ADR-0029/0054).
     # ---------------------------------------------------------------------------------------
     finops_tiers:
+      # Declared-side validation (check-finops-tiers.py, finops-lifecycle.yml) runs ADVISORY: the
+      # script always exits 0 today, so a tier declared here that contradicts the manifest is a
+      # ::warning. Graduating needs the MEASURED classifier (the derive->enforce->show half below);
+      # until that lands there is nothing to compare a declaration against except itself.
+      #
+      # Registered with a date as part of issue #2392: this gate ran advisory with no `enforced` /
+      # `target_enforce_date` on its rule, so check-gate-graduation.sh (ADR-0144) skipped it entirely
+      # and it had no deadline at all.
+      enforced: advisory
+      target_enforce_date: "2026-12-31"   # ADR-0144 — gated on the measured classifier, not on triage
+      blocked_on: "the measured-side classifier must land before the declared side can hard-fail;
+        without it, enforcing would only assert that the file agrees with itself"
+      ci_producer: "openbank-infra/scripts/check-finops-tiers.py"
       tiers:
         T0:                                   # Always-on
           definition: "Money-path HOT path where a cold-start / scaled-to-zero gap is unacceptable, or a regulator-mandated continuous service."

--- a/openbank-infra/gitops/components/dispute-service/dispute-opa-bundle.yaml
+++ b/openbank-infra/gitops/components/dispute-service/dispute-opa-bundle.yaml
@@ -9,7 +9,7 @@ metadata:
     app.kubernetes.io/name: dispute-service
     app.kubernetes.io/part-of: dispute
   annotations:
-    openbank.tech/policy-checksum: "cb7d4cbfc114296b"
+    openbank.tech/policy-checksum: "b60aa9bb667a3041"
 data:
   rest.rego: |
     # SPDX-License-Identifier: Apache-2.0
@@ -2883,19 +2883,6 @@ data:
     # MEASURED behaviour by a classifier + CI gate (derive -> enforce -> show, ADR-0029/0054).
     # ---------------------------------------------------------------------------------------
     finops_tiers:
-      # Declared-side validation (check-finops-tiers.py, finops-lifecycle.yml) runs ADVISORY: the
-      # script always exits 0 today, so a tier declared here that contradicts the manifest is a
-      # ::warning. Graduating needs the MEASURED classifier (the derive->enforce->show half below);
-      # until that lands there is nothing to compare a declaration against except itself.
-      #
-      # Registered with a date as part of issue #2392: this gate ran advisory with no `enforced` /
-      # `target_enforce_date` on its rule, so check-gate-graduation.sh (ADR-0144) skipped it entirely
-      # and it had no deadline at all.
-      enforced: advisory
-      target_enforce_date: "2026-12-31"   # ADR-0144 — gated on the measured classifier, not on triage
-      blocked_on: "the measured-side classifier must land before the declared side can hard-fail;
-        without it, enforcing would only assert that the file agrees with itself"
-      ci_producer: "openbank-infra/scripts/check-finops-tiers.py"
       tiers:
         T0:                                   # Always-on
           definition: "Money-path HOT path where a cold-start / scaled-to-zero gap is unacceptable, or a regulator-mandated continuous service."
@@ -2998,6 +2985,9 @@ data:
       enforced: advisory                      # ADR-0057; -> block when the classifier lands
       target_enforce_date: "2026-09-30"   # ADR-0144
       blocked_on: "the measured-signal classifier (http_request_rate, kafka_consumer_lag, cpu/replica utilisation) has not shipped yet — only 2 services have a declared tier today (notification-service, product-catalog)"
+      # Added by issue #2392: the rule carried `enforced`/`target_enforce_date` but never named the
+      # script that produces the finding, so nothing tied the advisory CI step to this deadline.
+      ci_producer: "openbank-infra/scripts/check-finops-tiers.py"
 
     # ---------------------------------------------------------------------------------------
     # FinOps cost-allocation groups — showback business flows (ADR-0062). The /api/finops/costs

--- a/openbank-infra/gitops/components/dispute-service/dispute-service.yaml
+++ b/openbank-infra/gitops/components/dispute-service/dispute-service.yaml
@@ -15,7 +15,7 @@ spec:
       annotations:
         # Rolls the pod when the OPA bundle changes — subPath mounts do NOT hot-reload.
         # Kept in sync by gen-dispute-opa-bundle.sh (do not hand-edit).
-        openbank.tech/policy-checksum: "f3eba3091b4c7747"
+        openbank.tech/policy-checksum: "cb7d4cbfc114296b"
       labels: {app.kubernetes.io/name: dispute-service, app.kubernetes.io/part-of: dispute}
     spec:
       securityContext:

--- a/openbank-infra/gitops/components/dispute-service/dispute-service.yaml
+++ b/openbank-infra/gitops/components/dispute-service/dispute-service.yaml
@@ -15,7 +15,7 @@ spec:
       annotations:
         # Rolls the pod when the OPA bundle changes — subPath mounts do NOT hot-reload.
         # Kept in sync by gen-dispute-opa-bundle.sh (do not hand-edit).
-        openbank.tech/policy-checksum: "cb7d4cbfc114296b"
+        openbank.tech/policy-checksum: "b60aa9bb667a3041"
       labels: {app.kubernetes.io/name: dispute-service, app.kubernetes.io/part-of: dispute}
     spec:
       securityContext:

--- a/openbank-infra/gitops/components/document-service/document-service-opa-bundle.yaml
+++ b/openbank-infra/gitops/components/document-service/document-service-opa-bundle.yaml
@@ -10,7 +10,7 @@ metadata:
     app.kubernetes.io/name: document-service
     app.kubernetes.io/part-of: documents
   annotations:
-    openbank.tech/policy-checksum: "b008ff50a7934dcf"
+    openbank.tech/policy-checksum: "4cbd1f661b104602"
 data:
   rest.rego: |
     # SPDX-License-Identifier: Apache-2.0
@@ -1932,19 +1932,6 @@ data:
     # MEASURED behaviour by a classifier + CI gate (derive -> enforce -> show, ADR-0029/0054).
     # ---------------------------------------------------------------------------------------
     finops_tiers:
-      # Declared-side validation (check-finops-tiers.py, finops-lifecycle.yml) runs ADVISORY: the
-      # script always exits 0 today, so a tier declared here that contradicts the manifest is a
-      # ::warning. Graduating needs the MEASURED classifier (the derive->enforce->show half below);
-      # until that lands there is nothing to compare a declaration against except itself.
-      #
-      # Registered with a date as part of issue #2392: this gate ran advisory with no `enforced` /
-      # `target_enforce_date` on its rule, so check-gate-graduation.sh (ADR-0144) skipped it entirely
-      # and it had no deadline at all.
-      enforced: advisory
-      target_enforce_date: "2026-12-31"   # ADR-0144 — gated on the measured classifier, not on triage
-      blocked_on: "the measured-side classifier must land before the declared side can hard-fail;
-        without it, enforcing would only assert that the file agrees with itself"
-      ci_producer: "openbank-infra/scripts/check-finops-tiers.py"
       tiers:
         T0:                                   # Always-on
           definition: "Money-path HOT path where a cold-start / scaled-to-zero gap is unacceptable, or a regulator-mandated continuous service."
@@ -2047,6 +2034,9 @@ data:
       enforced: advisory                      # ADR-0057; -> block when the classifier lands
       target_enforce_date: "2026-09-30"   # ADR-0144
       blocked_on: "the measured-signal classifier (http_request_rate, kafka_consumer_lag, cpu/replica utilisation) has not shipped yet — only 2 services have a declared tier today (notification-service, product-catalog)"
+      # Added by issue #2392: the rule carried `enforced`/`target_enforce_date` but never named the
+      # script that produces the finding, so nothing tied the advisory CI step to this deadline.
+      ci_producer: "openbank-infra/scripts/check-finops-tiers.py"
 
     # ---------------------------------------------------------------------------------------
     # FinOps cost-allocation groups — showback business flows (ADR-0062). The /api/finops/costs

--- a/openbank-infra/gitops/components/document-service/document-service-opa-bundle.yaml
+++ b/openbank-infra/gitops/components/document-service/document-service-opa-bundle.yaml
@@ -10,7 +10,7 @@ metadata:
     app.kubernetes.io/name: document-service
     app.kubernetes.io/part-of: documents
   annotations:
-    openbank.tech/policy-checksum: "79c797e60711208b"
+    openbank.tech/policy-checksum: "b008ff50a7934dcf"
 data:
   rest.rego: |
     # SPDX-License-Identifier: Apache-2.0
@@ -997,6 +997,23 @@ data:
         # (3-dot against the PR base). Findings are ::warning annotations. Flip to enforced =
         # pass --enforce to the script in ci.yml (one-line change).
         ci_producer: "openbank-infra/scripts/check-threat-model-diff.py"
+      mp_messaging_dotted_keys:
+        # SmallRye reactive-messaging config written as a DOTTED key
+        # (`mp.messaging.incoming.x.topic: …`) inside a nested YAML mapping is silently ignored by
+        # SnakeYAML — the channel keeps its default and the consumer subscribes to nothing, with no
+        # error at boot (issue #686). The guard rewrites the shape it can prove wrong.
+        detect: ["<service>/src/main/resources/application.yaml", "mp.messaging.* written as a dotted key under a nested mapping"]
+        require:
+          - "mp.messaging channel config expressed as nested YAML, not a dotted key inside a mapping"
+        gate: dotted-mp-messaging-keys
+        enforced: advisory
+        target_enforce_date: "2026-09-30"   # ADR-0144
+        blocked_on: "1 finding remains fleet-wide; the script already supports --enforce, so graduating
+          is a one-word change in ci.yml once it is cleared"
+        # Registered here as part of issue #2392: this gate ran advisory with no rules.yaml rule at
+        # all, so check-gate-graduation.sh could not see it and it had no deadline. That class is now
+        # itself gated by .github/scripts/check-advisory-gate-registration.py.
+        ci_producer: ".github/scripts/check-dotted-mp-messaging-keys.sh"
       new_service_with_outbox:
         # A service that extends AbstractOutboxEntity / uses OutboxDispatcher but does NOT
         # set openbank.outbox.dispatch-enabled=true silently never dispatches events —
@@ -1915,6 +1932,19 @@ data:
     # MEASURED behaviour by a classifier + CI gate (derive -> enforce -> show, ADR-0029/0054).
     # ---------------------------------------------------------------------------------------
     finops_tiers:
+      # Declared-side validation (check-finops-tiers.py, finops-lifecycle.yml) runs ADVISORY: the
+      # script always exits 0 today, so a tier declared here that contradicts the manifest is a
+      # ::warning. Graduating needs the MEASURED classifier (the derive->enforce->show half below);
+      # until that lands there is nothing to compare a declaration against except itself.
+      #
+      # Registered with a date as part of issue #2392: this gate ran advisory with no `enforced` /
+      # `target_enforce_date` on its rule, so check-gate-graduation.sh (ADR-0144) skipped it entirely
+      # and it had no deadline at all.
+      enforced: advisory
+      target_enforce_date: "2026-12-31"   # ADR-0144 — gated on the measured classifier, not on triage
+      blocked_on: "the measured-side classifier must land before the declared side can hard-fail;
+        without it, enforcing would only assert that the file agrees with itself"
+      ci_producer: "openbank-infra/scripts/check-finops-tiers.py"
       tiers:
         T0:                                   # Always-on
           definition: "Money-path HOT path where a cold-start / scaled-to-zero gap is unacceptable, or a regulator-mandated continuous service."

--- a/openbank-infra/gitops/components/document-service/document-service-service.yaml
+++ b/openbank-infra/gitops/components/document-service/document-service-service.yaml
@@ -43,7 +43,7 @@ spec:
       annotations:
         # Rolls the pods when the OPA bundle changes — subPath mounts do NOT hot-reload.
         # Kept in sync by gen-document-service-opa-bundle.sh (do not hand-edit).
-        openbank.tech/policy-checksum: "79c797e60711208b"
+        openbank.tech/policy-checksum: "b008ff50a7934dcf"
     spec:
       # ADR-0162 D4 (continued): a dedicated SA (not `default`) is what OpenBao's Kubernetes-auth
       # role `document-service-signing` is bound to — least-privilege, one identity per consumer.

--- a/openbank-infra/gitops/components/document-service/document-service-service.yaml
+++ b/openbank-infra/gitops/components/document-service/document-service-service.yaml
@@ -43,7 +43,7 @@ spec:
       annotations:
         # Rolls the pods when the OPA bundle changes — subPath mounts do NOT hot-reload.
         # Kept in sync by gen-document-service-opa-bundle.sh (do not hand-edit).
-        openbank.tech/policy-checksum: "b008ff50a7934dcf"
+        openbank.tech/policy-checksum: "4cbd1f661b104602"
     spec:
       # ADR-0162 D4 (continued): a dedicated SA (not `default`) is what OpenBao's Kubernetes-auth
       # role `document-service-signing` is bound to — least-privilege, one identity per consumer.

--- a/openbank-infra/gitops/components/fraud-service/fraud-opa-bundle.yaml
+++ b/openbank-infra/gitops/components/fraud-service/fraud-opa-bundle.yaml
@@ -9,7 +9,7 @@ metadata:
     app.kubernetes.io/name: fraud-service
     app.kubernetes.io/part-of: fraud
   annotations:
-    openbank.tech/policy-checksum: "7ff48770bb976589"
+    openbank.tech/policy-checksum: "5c6767232dc5fa37"
 data:
   rest.rego: |
     # SPDX-License-Identifier: Apache-2.0
@@ -2758,19 +2758,6 @@ data:
     # MEASURED behaviour by a classifier + CI gate (derive -> enforce -> show, ADR-0029/0054).
     # ---------------------------------------------------------------------------------------
     finops_tiers:
-      # Declared-side validation (check-finops-tiers.py, finops-lifecycle.yml) runs ADVISORY: the
-      # script always exits 0 today, so a tier declared here that contradicts the manifest is a
-      # ::warning. Graduating needs the MEASURED classifier (the derive->enforce->show half below);
-      # until that lands there is nothing to compare a declaration against except itself.
-      #
-      # Registered with a date as part of issue #2392: this gate ran advisory with no `enforced` /
-      # `target_enforce_date` on its rule, so check-gate-graduation.sh (ADR-0144) skipped it entirely
-      # and it had no deadline at all.
-      enforced: advisory
-      target_enforce_date: "2026-12-31"   # ADR-0144 — gated on the measured classifier, not on triage
-      blocked_on: "the measured-side classifier must land before the declared side can hard-fail;
-        without it, enforcing would only assert that the file agrees with itself"
-      ci_producer: "openbank-infra/scripts/check-finops-tiers.py"
       tiers:
         T0:                                   # Always-on
           definition: "Money-path HOT path where a cold-start / scaled-to-zero gap is unacceptable, or a regulator-mandated continuous service."
@@ -2873,6 +2860,9 @@ data:
       enforced: advisory                      # ADR-0057; -> block when the classifier lands
       target_enforce_date: "2026-09-30"   # ADR-0144
       blocked_on: "the measured-signal classifier (http_request_rate, kafka_consumer_lag, cpu/replica utilisation) has not shipped yet — only 2 services have a declared tier today (notification-service, product-catalog)"
+      # Added by issue #2392: the rule carried `enforced`/`target_enforce_date` but never named the
+      # script that produces the finding, so nothing tied the advisory CI step to this deadline.
+      ci_producer: "openbank-infra/scripts/check-finops-tiers.py"
 
     # ---------------------------------------------------------------------------------------
     # FinOps cost-allocation groups — showback business flows (ADR-0062). The /api/finops/costs

--- a/openbank-infra/gitops/components/fraud-service/fraud-opa-bundle.yaml
+++ b/openbank-infra/gitops/components/fraud-service/fraud-opa-bundle.yaml
@@ -9,7 +9,7 @@ metadata:
     app.kubernetes.io/name: fraud-service
     app.kubernetes.io/part-of: fraud
   annotations:
-    openbank.tech/policy-checksum: "2e60f7471d4d698b"
+    openbank.tech/policy-checksum: "7ff48770bb976589"
 data:
   rest.rego: |
     # SPDX-License-Identifier: Apache-2.0
@@ -1823,6 +1823,23 @@ data:
         # (3-dot against the PR base). Findings are ::warning annotations. Flip to enforced =
         # pass --enforce to the script in ci.yml (one-line change).
         ci_producer: "openbank-infra/scripts/check-threat-model-diff.py"
+      mp_messaging_dotted_keys:
+        # SmallRye reactive-messaging config written as a DOTTED key
+        # (`mp.messaging.incoming.x.topic: …`) inside a nested YAML mapping is silently ignored by
+        # SnakeYAML — the channel keeps its default and the consumer subscribes to nothing, with no
+        # error at boot (issue #686). The guard rewrites the shape it can prove wrong.
+        detect: ["<service>/src/main/resources/application.yaml", "mp.messaging.* written as a dotted key under a nested mapping"]
+        require:
+          - "mp.messaging channel config expressed as nested YAML, not a dotted key inside a mapping"
+        gate: dotted-mp-messaging-keys
+        enforced: advisory
+        target_enforce_date: "2026-09-30"   # ADR-0144
+        blocked_on: "1 finding remains fleet-wide; the script already supports --enforce, so graduating
+          is a one-word change in ci.yml once it is cleared"
+        # Registered here as part of issue #2392: this gate ran advisory with no rules.yaml rule at
+        # all, so check-gate-graduation.sh could not see it and it had no deadline. That class is now
+        # itself gated by .github/scripts/check-advisory-gate-registration.py.
+        ci_producer: ".github/scripts/check-dotted-mp-messaging-keys.sh"
       new_service_with_outbox:
         # A service that extends AbstractOutboxEntity / uses OutboxDispatcher but does NOT
         # set openbank.outbox.dispatch-enabled=true silently never dispatches events —
@@ -2741,6 +2758,19 @@ data:
     # MEASURED behaviour by a classifier + CI gate (derive -> enforce -> show, ADR-0029/0054).
     # ---------------------------------------------------------------------------------------
     finops_tiers:
+      # Declared-side validation (check-finops-tiers.py, finops-lifecycle.yml) runs ADVISORY: the
+      # script always exits 0 today, so a tier declared here that contradicts the manifest is a
+      # ::warning. Graduating needs the MEASURED classifier (the derive->enforce->show half below);
+      # until that lands there is nothing to compare a declaration against except itself.
+      #
+      # Registered with a date as part of issue #2392: this gate ran advisory with no `enforced` /
+      # `target_enforce_date` on its rule, so check-gate-graduation.sh (ADR-0144) skipped it entirely
+      # and it had no deadline at all.
+      enforced: advisory
+      target_enforce_date: "2026-12-31"   # ADR-0144 — gated on the measured classifier, not on triage
+      blocked_on: "the measured-side classifier must land before the declared side can hard-fail;
+        without it, enforcing would only assert that the file agrees with itself"
+      ci_producer: "openbank-infra/scripts/check-finops-tiers.py"
       tiers:
         T0:                                   # Always-on
           definition: "Money-path HOT path where a cold-start / scaled-to-zero gap is unacceptable, or a regulator-mandated continuous service."

--- a/openbank-infra/gitops/components/fraud-service/fraud-service.yaml
+++ b/openbank-infra/gitops/components/fraud-service/fraud-service.yaml
@@ -23,7 +23,7 @@ spec:
       annotations:
         # Rolls the pods when the OPA bundle changes — subPath mounts do NOT hot-reload.
         # Kept in sync by gen-fraud-opa-bundle.sh (do not hand-edit).
-        openbank.tech/policy-checksum: "7ff48770bb976589"
+        openbank.tech/policy-checksum: "5c6767232dc5fa37"
     spec:
       securityContext:
         runAsNonRoot: true

--- a/openbank-infra/gitops/components/fraud-service/fraud-service.yaml
+++ b/openbank-infra/gitops/components/fraud-service/fraud-service.yaml
@@ -23,7 +23,7 @@ spec:
       annotations:
         # Rolls the pods when the OPA bundle changes — subPath mounts do NOT hot-reload.
         # Kept in sync by gen-fraud-opa-bundle.sh (do not hand-edit).
-        openbank.tech/policy-checksum: "2e60f7471d4d698b"
+        openbank.tech/policy-checksum: "7ff48770bb976589"
     spec:
       securityContext:
         runAsNonRoot: true

--- a/openbank-infra/gitops/components/fx-service/fx-opa-bundle.yaml
+++ b/openbank-infra/gitops/components/fx-service/fx-opa-bundle.yaml
@@ -9,7 +9,7 @@ metadata:
     app.kubernetes.io/name: fx-service
     app.kubernetes.io/part-of: fx
   annotations:
-    openbank.tech/policy-checksum: "60b499a653fb2057"
+    openbank.tech/policy-checksum: "24bb737eee5c3c85"
 data:
   rest.rego: |
     # SPDX-License-Identifier: Apache-2.0
@@ -1874,6 +1874,23 @@ data:
         # (3-dot against the PR base). Findings are ::warning annotations. Flip to enforced =
         # pass --enforce to the script in ci.yml (one-line change).
         ci_producer: "openbank-infra/scripts/check-threat-model-diff.py"
+      mp_messaging_dotted_keys:
+        # SmallRye reactive-messaging config written as a DOTTED key
+        # (`mp.messaging.incoming.x.topic: …`) inside a nested YAML mapping is silently ignored by
+        # SnakeYAML — the channel keeps its default and the consumer subscribes to nothing, with no
+        # error at boot (issue #686). The guard rewrites the shape it can prove wrong.
+        detect: ["<service>/src/main/resources/application.yaml", "mp.messaging.* written as a dotted key under a nested mapping"]
+        require:
+          - "mp.messaging channel config expressed as nested YAML, not a dotted key inside a mapping"
+        gate: dotted-mp-messaging-keys
+        enforced: advisory
+        target_enforce_date: "2026-09-30"   # ADR-0144
+        blocked_on: "1 finding remains fleet-wide; the script already supports --enforce, so graduating
+          is a one-word change in ci.yml once it is cleared"
+        # Registered here as part of issue #2392: this gate ran advisory with no rules.yaml rule at
+        # all, so check-gate-graduation.sh could not see it and it had no deadline. That class is now
+        # itself gated by .github/scripts/check-advisory-gate-registration.py.
+        ci_producer: ".github/scripts/check-dotted-mp-messaging-keys.sh"
       new_service_with_outbox:
         # A service that extends AbstractOutboxEntity / uses OutboxDispatcher but does NOT
         # set openbank.outbox.dispatch-enabled=true silently never dispatches events —
@@ -2792,6 +2809,19 @@ data:
     # MEASURED behaviour by a classifier + CI gate (derive -> enforce -> show, ADR-0029/0054).
     # ---------------------------------------------------------------------------------------
     finops_tiers:
+      # Declared-side validation (check-finops-tiers.py, finops-lifecycle.yml) runs ADVISORY: the
+      # script always exits 0 today, so a tier declared here that contradicts the manifest is a
+      # ::warning. Graduating needs the MEASURED classifier (the derive->enforce->show half below);
+      # until that lands there is nothing to compare a declaration against except itself.
+      #
+      # Registered with a date as part of issue #2392: this gate ran advisory with no `enforced` /
+      # `target_enforce_date` on its rule, so check-gate-graduation.sh (ADR-0144) skipped it entirely
+      # and it had no deadline at all.
+      enforced: advisory
+      target_enforce_date: "2026-12-31"   # ADR-0144 — gated on the measured classifier, not on triage
+      blocked_on: "the measured-side classifier must land before the declared side can hard-fail;
+        without it, enforcing would only assert that the file agrees with itself"
+      ci_producer: "openbank-infra/scripts/check-finops-tiers.py"
       tiers:
         T0:                                   # Always-on
           definition: "Money-path HOT path where a cold-start / scaled-to-zero gap is unacceptable, or a regulator-mandated continuous service."

--- a/openbank-infra/gitops/components/fx-service/fx-opa-bundle.yaml
+++ b/openbank-infra/gitops/components/fx-service/fx-opa-bundle.yaml
@@ -9,7 +9,7 @@ metadata:
     app.kubernetes.io/name: fx-service
     app.kubernetes.io/part-of: fx
   annotations:
-    openbank.tech/policy-checksum: "24bb737eee5c3c85"
+    openbank.tech/policy-checksum: "96adffcfbd78395d"
 data:
   rest.rego: |
     # SPDX-License-Identifier: Apache-2.0
@@ -2809,19 +2809,6 @@ data:
     # MEASURED behaviour by a classifier + CI gate (derive -> enforce -> show, ADR-0029/0054).
     # ---------------------------------------------------------------------------------------
     finops_tiers:
-      # Declared-side validation (check-finops-tiers.py, finops-lifecycle.yml) runs ADVISORY: the
-      # script always exits 0 today, so a tier declared here that contradicts the manifest is a
-      # ::warning. Graduating needs the MEASURED classifier (the derive->enforce->show half below);
-      # until that lands there is nothing to compare a declaration against except itself.
-      #
-      # Registered with a date as part of issue #2392: this gate ran advisory with no `enforced` /
-      # `target_enforce_date` on its rule, so check-gate-graduation.sh (ADR-0144) skipped it entirely
-      # and it had no deadline at all.
-      enforced: advisory
-      target_enforce_date: "2026-12-31"   # ADR-0144 — gated on the measured classifier, not on triage
-      blocked_on: "the measured-side classifier must land before the declared side can hard-fail;
-        without it, enforcing would only assert that the file agrees with itself"
-      ci_producer: "openbank-infra/scripts/check-finops-tiers.py"
       tiers:
         T0:                                   # Always-on
           definition: "Money-path HOT path where a cold-start / scaled-to-zero gap is unacceptable, or a regulator-mandated continuous service."
@@ -2924,6 +2911,9 @@ data:
       enforced: advisory                      # ADR-0057; -> block when the classifier lands
       target_enforce_date: "2026-09-30"   # ADR-0144
       blocked_on: "the measured-signal classifier (http_request_rate, kafka_consumer_lag, cpu/replica utilisation) has not shipped yet — only 2 services have a declared tier today (notification-service, product-catalog)"
+      # Added by issue #2392: the rule carried `enforced`/`target_enforce_date` but never named the
+      # script that produces the finding, so nothing tied the advisory CI step to this deadline.
+      ci_producer: "openbank-infra/scripts/check-finops-tiers.py"
 
     # ---------------------------------------------------------------------------------------
     # FinOps cost-allocation groups — showback business flows (ADR-0062). The /api/finops/costs

--- a/openbank-infra/gitops/components/fx-service/fx-service.yaml
+++ b/openbank-infra/gitops/components/fx-service/fx-service.yaml
@@ -22,7 +22,7 @@ spec:
       annotations:
         # Rolls the pods when the OPA bundle changes — subPath mounts do NOT hot-reload.
         # Kept in sync by gen-fx-opa-bundle.sh (do not hand-edit).
-        openbank.tech/policy-checksum: "24bb737eee5c3c85"
+        openbank.tech/policy-checksum: "96adffcfbd78395d"
     spec:
       securityContext:
         runAsNonRoot: true

--- a/openbank-infra/gitops/components/fx-service/fx-service.yaml
+++ b/openbank-infra/gitops/components/fx-service/fx-service.yaml
@@ -22,7 +22,7 @@ spec:
       annotations:
         # Rolls the pods when the OPA bundle changes — subPath mounts do NOT hot-reload.
         # Kept in sync by gen-fx-opa-bundle.sh (do not hand-edit).
-        openbank.tech/policy-checksum: "60b499a653fb2057"
+        openbank.tech/policy-checksum: "24bb737eee5c3c85"
     spec:
       securityContext:
         runAsNonRoot: true

--- a/openbank-infra/gitops/components/interest-service/interest-opa-bundle.yaml
+++ b/openbank-infra/gitops/components/interest-service/interest-opa-bundle.yaml
@@ -9,7 +9,7 @@ metadata:
     app.kubernetes.io/name: interest-service
     app.kubernetes.io/part-of: interest
   annotations:
-    openbank.tech/policy-checksum: "3e465e59083b46c4"
+    openbank.tech/policy-checksum: "1e832d8a96f1ae58"
 data:
   rest.rego: |
     # SPDX-License-Identifier: Apache-2.0
@@ -1808,6 +1808,23 @@ data:
         # (3-dot against the PR base). Findings are ::warning annotations. Flip to enforced =
         # pass --enforce to the script in ci.yml (one-line change).
         ci_producer: "openbank-infra/scripts/check-threat-model-diff.py"
+      mp_messaging_dotted_keys:
+        # SmallRye reactive-messaging config written as a DOTTED key
+        # (`mp.messaging.incoming.x.topic: …`) inside a nested YAML mapping is silently ignored by
+        # SnakeYAML — the channel keeps its default and the consumer subscribes to nothing, with no
+        # error at boot (issue #686). The guard rewrites the shape it can prove wrong.
+        detect: ["<service>/src/main/resources/application.yaml", "mp.messaging.* written as a dotted key under a nested mapping"]
+        require:
+          - "mp.messaging channel config expressed as nested YAML, not a dotted key inside a mapping"
+        gate: dotted-mp-messaging-keys
+        enforced: advisory
+        target_enforce_date: "2026-09-30"   # ADR-0144
+        blocked_on: "1 finding remains fleet-wide; the script already supports --enforce, so graduating
+          is a one-word change in ci.yml once it is cleared"
+        # Registered here as part of issue #2392: this gate ran advisory with no rules.yaml rule at
+        # all, so check-gate-graduation.sh could not see it and it had no deadline. That class is now
+        # itself gated by .github/scripts/check-advisory-gate-registration.py.
+        ci_producer: ".github/scripts/check-dotted-mp-messaging-keys.sh"
       new_service_with_outbox:
         # A service that extends AbstractOutboxEntity / uses OutboxDispatcher but does NOT
         # set openbank.outbox.dispatch-enabled=true silently never dispatches events —
@@ -2726,6 +2743,19 @@ data:
     # MEASURED behaviour by a classifier + CI gate (derive -> enforce -> show, ADR-0029/0054).
     # ---------------------------------------------------------------------------------------
     finops_tiers:
+      # Declared-side validation (check-finops-tiers.py, finops-lifecycle.yml) runs ADVISORY: the
+      # script always exits 0 today, so a tier declared here that contradicts the manifest is a
+      # ::warning. Graduating needs the MEASURED classifier (the derive->enforce->show half below);
+      # until that lands there is nothing to compare a declaration against except itself.
+      #
+      # Registered with a date as part of issue #2392: this gate ran advisory with no `enforced` /
+      # `target_enforce_date` on its rule, so check-gate-graduation.sh (ADR-0144) skipped it entirely
+      # and it had no deadline at all.
+      enforced: advisory
+      target_enforce_date: "2026-12-31"   # ADR-0144 — gated on the measured classifier, not on triage
+      blocked_on: "the measured-side classifier must land before the declared side can hard-fail;
+        without it, enforcing would only assert that the file agrees with itself"
+      ci_producer: "openbank-infra/scripts/check-finops-tiers.py"
       tiers:
         T0:                                   # Always-on
           definition: "Money-path HOT path where a cold-start / scaled-to-zero gap is unacceptable, or a regulator-mandated continuous service."

--- a/openbank-infra/gitops/components/interest-service/interest-opa-bundle.yaml
+++ b/openbank-infra/gitops/components/interest-service/interest-opa-bundle.yaml
@@ -9,7 +9,7 @@ metadata:
     app.kubernetes.io/name: interest-service
     app.kubernetes.io/part-of: interest
   annotations:
-    openbank.tech/policy-checksum: "1e832d8a96f1ae58"
+    openbank.tech/policy-checksum: "580c2df7b5474cfb"
 data:
   rest.rego: |
     # SPDX-License-Identifier: Apache-2.0
@@ -2743,19 +2743,6 @@ data:
     # MEASURED behaviour by a classifier + CI gate (derive -> enforce -> show, ADR-0029/0054).
     # ---------------------------------------------------------------------------------------
     finops_tiers:
-      # Declared-side validation (check-finops-tiers.py, finops-lifecycle.yml) runs ADVISORY: the
-      # script always exits 0 today, so a tier declared here that contradicts the manifest is a
-      # ::warning. Graduating needs the MEASURED classifier (the derive->enforce->show half below);
-      # until that lands there is nothing to compare a declaration against except itself.
-      #
-      # Registered with a date as part of issue #2392: this gate ran advisory with no `enforced` /
-      # `target_enforce_date` on its rule, so check-gate-graduation.sh (ADR-0144) skipped it entirely
-      # and it had no deadline at all.
-      enforced: advisory
-      target_enforce_date: "2026-12-31"   # ADR-0144 — gated on the measured classifier, not on triage
-      blocked_on: "the measured-side classifier must land before the declared side can hard-fail;
-        without it, enforcing would only assert that the file agrees with itself"
-      ci_producer: "openbank-infra/scripts/check-finops-tiers.py"
       tiers:
         T0:                                   # Always-on
           definition: "Money-path HOT path where a cold-start / scaled-to-zero gap is unacceptable, or a regulator-mandated continuous service."
@@ -2858,6 +2845,9 @@ data:
       enforced: advisory                      # ADR-0057; -> block when the classifier lands
       target_enforce_date: "2026-09-30"   # ADR-0144
       blocked_on: "the measured-signal classifier (http_request_rate, kafka_consumer_lag, cpu/replica utilisation) has not shipped yet — only 2 services have a declared tier today (notification-service, product-catalog)"
+      # Added by issue #2392: the rule carried `enforced`/`target_enforce_date` but never named the
+      # script that produces the finding, so nothing tied the advisory CI step to this deadline.
+      ci_producer: "openbank-infra/scripts/check-finops-tiers.py"
 
     # ---------------------------------------------------------------------------------------
     # FinOps cost-allocation groups — showback business flows (ADR-0062). The /api/finops/costs

--- a/openbank-infra/gitops/components/interest-service/interest-service.yaml
+++ b/openbank-infra/gitops/components/interest-service/interest-service.yaml
@@ -16,7 +16,7 @@ spec:
       annotations:
         # Rolls the pods when the OPA bundle changes — subPath mounts do NOT hot-reload.
         # Kept in sync by gen-interest-opa-bundle.sh (do not hand-edit).
-        openbank.tech/policy-checksum: "3e465e59083b46c4"
+        openbank.tech/policy-checksum: "1e832d8a96f1ae58"
     spec:
       securityContext:
         runAsNonRoot: true

--- a/openbank-infra/gitops/components/interest-service/interest-service.yaml
+++ b/openbank-infra/gitops/components/interest-service/interest-service.yaml
@@ -16,7 +16,7 @@ spec:
       annotations:
         # Rolls the pods when the OPA bundle changes — subPath mounts do NOT hot-reload.
         # Kept in sync by gen-interest-opa-bundle.sh (do not hand-edit).
-        openbank.tech/policy-checksum: "1e832d8a96f1ae58"
+        openbank.tech/policy-checksum: "580c2df7b5474cfb"
     spec:
       securityContext:
         runAsNonRoot: true

--- a/openbank-infra/gitops/components/kyc/kyc-opa-bundle.yaml
+++ b/openbank-infra/gitops/components/kyc/kyc-opa-bundle.yaml
@@ -9,7 +9,7 @@ metadata:
     app.kubernetes.io/name: kyc-service
     app.kubernetes.io/part-of: kyc
   annotations:
-    openbank.tech/policy-checksum: "7d14200e78c02a4a"
+    openbank.tech/policy-checksum: "e97442718f9d0cb0"
 data:
   rest.rego: |
     # SPDX-License-Identifier: Apache-2.0
@@ -2771,19 +2771,6 @@ data:
     # MEASURED behaviour by a classifier + CI gate (derive -> enforce -> show, ADR-0029/0054).
     # ---------------------------------------------------------------------------------------
     finops_tiers:
-      # Declared-side validation (check-finops-tiers.py, finops-lifecycle.yml) runs ADVISORY: the
-      # script always exits 0 today, so a tier declared here that contradicts the manifest is a
-      # ::warning. Graduating needs the MEASURED classifier (the derive->enforce->show half below);
-      # until that lands there is nothing to compare a declaration against except itself.
-      #
-      # Registered with a date as part of issue #2392: this gate ran advisory with no `enforced` /
-      # `target_enforce_date` on its rule, so check-gate-graduation.sh (ADR-0144) skipped it entirely
-      # and it had no deadline at all.
-      enforced: advisory
-      target_enforce_date: "2026-12-31"   # ADR-0144 — gated on the measured classifier, not on triage
-      blocked_on: "the measured-side classifier must land before the declared side can hard-fail;
-        without it, enforcing would only assert that the file agrees with itself"
-      ci_producer: "openbank-infra/scripts/check-finops-tiers.py"
       tiers:
         T0:                                   # Always-on
           definition: "Money-path HOT path where a cold-start / scaled-to-zero gap is unacceptable, or a regulator-mandated continuous service."
@@ -2886,6 +2873,9 @@ data:
       enforced: advisory                      # ADR-0057; -> block when the classifier lands
       target_enforce_date: "2026-09-30"   # ADR-0144
       blocked_on: "the measured-signal classifier (http_request_rate, kafka_consumer_lag, cpu/replica utilisation) has not shipped yet — only 2 services have a declared tier today (notification-service, product-catalog)"
+      # Added by issue #2392: the rule carried `enforced`/`target_enforce_date` but never named the
+      # script that produces the finding, so nothing tied the advisory CI step to this deadline.
+      ci_producer: "openbank-infra/scripts/check-finops-tiers.py"
 
     # ---------------------------------------------------------------------------------------
     # FinOps cost-allocation groups — showback business flows (ADR-0062). The /api/finops/costs

--- a/openbank-infra/gitops/components/kyc/kyc-opa-bundle.yaml
+++ b/openbank-infra/gitops/components/kyc/kyc-opa-bundle.yaml
@@ -9,7 +9,7 @@ metadata:
     app.kubernetes.io/name: kyc-service
     app.kubernetes.io/part-of: kyc
   annotations:
-    openbank.tech/policy-checksum: "3ea78fd3be905325"
+    openbank.tech/policy-checksum: "7d14200e78c02a4a"
 data:
   rest.rego: |
     # SPDX-License-Identifier: Apache-2.0
@@ -1836,6 +1836,23 @@ data:
         # (3-dot against the PR base). Findings are ::warning annotations. Flip to enforced =
         # pass --enforce to the script in ci.yml (one-line change).
         ci_producer: "openbank-infra/scripts/check-threat-model-diff.py"
+      mp_messaging_dotted_keys:
+        # SmallRye reactive-messaging config written as a DOTTED key
+        # (`mp.messaging.incoming.x.topic: …`) inside a nested YAML mapping is silently ignored by
+        # SnakeYAML — the channel keeps its default and the consumer subscribes to nothing, with no
+        # error at boot (issue #686). The guard rewrites the shape it can prove wrong.
+        detect: ["<service>/src/main/resources/application.yaml", "mp.messaging.* written as a dotted key under a nested mapping"]
+        require:
+          - "mp.messaging channel config expressed as nested YAML, not a dotted key inside a mapping"
+        gate: dotted-mp-messaging-keys
+        enforced: advisory
+        target_enforce_date: "2026-09-30"   # ADR-0144
+        blocked_on: "1 finding remains fleet-wide; the script already supports --enforce, so graduating
+          is a one-word change in ci.yml once it is cleared"
+        # Registered here as part of issue #2392: this gate ran advisory with no rules.yaml rule at
+        # all, so check-gate-graduation.sh could not see it and it had no deadline. That class is now
+        # itself gated by .github/scripts/check-advisory-gate-registration.py.
+        ci_producer: ".github/scripts/check-dotted-mp-messaging-keys.sh"
       new_service_with_outbox:
         # A service that extends AbstractOutboxEntity / uses OutboxDispatcher but does NOT
         # set openbank.outbox.dispatch-enabled=true silently never dispatches events —
@@ -2754,6 +2771,19 @@ data:
     # MEASURED behaviour by a classifier + CI gate (derive -> enforce -> show, ADR-0029/0054).
     # ---------------------------------------------------------------------------------------
     finops_tiers:
+      # Declared-side validation (check-finops-tiers.py, finops-lifecycle.yml) runs ADVISORY: the
+      # script always exits 0 today, so a tier declared here that contradicts the manifest is a
+      # ::warning. Graduating needs the MEASURED classifier (the derive->enforce->show half below);
+      # until that lands there is nothing to compare a declaration against except itself.
+      #
+      # Registered with a date as part of issue #2392: this gate ran advisory with no `enforced` /
+      # `target_enforce_date` on its rule, so check-gate-graduation.sh (ADR-0144) skipped it entirely
+      # and it had no deadline at all.
+      enforced: advisory
+      target_enforce_date: "2026-12-31"   # ADR-0144 — gated on the measured classifier, not on triage
+      blocked_on: "the measured-side classifier must land before the declared side can hard-fail;
+        without it, enforcing would only assert that the file agrees with itself"
+      ci_producer: "openbank-infra/scripts/check-finops-tiers.py"
       tiers:
         T0:                                   # Always-on
           definition: "Money-path HOT path where a cold-start / scaled-to-zero gap is unacceptable, or a regulator-mandated continuous service."

--- a/openbank-infra/gitops/components/kyc/kyc-service.yaml
+++ b/openbank-infra/gitops/components/kyc/kyc-service.yaml
@@ -48,7 +48,7 @@ spec:
       annotations:
         # Rolls the pod when the OPA bundle changes (subPath mounts do not hot-reload).
         # Kept in sync by gen-kyc-opa-bundle.sh (do not hand-edit).
-        openbank.tech/policy-checksum: "3ea78fd3be905325"
+        openbank.tech/policy-checksum: "7d14200e78c02a4a"
     spec:
       securityContext:
         runAsNonRoot: true

--- a/openbank-infra/gitops/components/kyc/kyc-service.yaml
+++ b/openbank-infra/gitops/components/kyc/kyc-service.yaml
@@ -48,7 +48,7 @@ spec:
       annotations:
         # Rolls the pod when the OPA bundle changes (subPath mounts do not hot-reload).
         # Kept in sync by gen-kyc-opa-bundle.sh (do not hand-edit).
-        openbank.tech/policy-checksum: "7d14200e78c02a4a"
+        openbank.tech/policy-checksum: "e97442718f9d0cb0"
     spec:
       securityContext:
         runAsNonRoot: true

--- a/openbank-infra/gitops/components/ledger/ledger-opa-bundle.yaml
+++ b/openbank-infra/gitops/components/ledger/ledger-opa-bundle.yaml
@@ -9,7 +9,7 @@ metadata:
     app.kubernetes.io/name: ledger-service
     app.kubernetes.io/part-of: ledger
   annotations:
-    openbank.tech/policy-checksum: "e0463574dd4bac09"
+    openbank.tech/policy-checksum: "cad4045ee5d68154"
 data:
   rest.rego: |
     # SPDX-License-Identifier: Apache-2.0
@@ -1921,6 +1921,23 @@ data:
         # (3-dot against the PR base). Findings are ::warning annotations. Flip to enforced =
         # pass --enforce to the script in ci.yml (one-line change).
         ci_producer: "openbank-infra/scripts/check-threat-model-diff.py"
+      mp_messaging_dotted_keys:
+        # SmallRye reactive-messaging config written as a DOTTED key
+        # (`mp.messaging.incoming.x.topic: …`) inside a nested YAML mapping is silently ignored by
+        # SnakeYAML — the channel keeps its default and the consumer subscribes to nothing, with no
+        # error at boot (issue #686). The guard rewrites the shape it can prove wrong.
+        detect: ["<service>/src/main/resources/application.yaml", "mp.messaging.* written as a dotted key under a nested mapping"]
+        require:
+          - "mp.messaging channel config expressed as nested YAML, not a dotted key inside a mapping"
+        gate: dotted-mp-messaging-keys
+        enforced: advisory
+        target_enforce_date: "2026-09-30"   # ADR-0144
+        blocked_on: "1 finding remains fleet-wide; the script already supports --enforce, so graduating
+          is a one-word change in ci.yml once it is cleared"
+        # Registered here as part of issue #2392: this gate ran advisory with no rules.yaml rule at
+        # all, so check-gate-graduation.sh could not see it and it had no deadline. That class is now
+        # itself gated by .github/scripts/check-advisory-gate-registration.py.
+        ci_producer: ".github/scripts/check-dotted-mp-messaging-keys.sh"
       new_service_with_outbox:
         # A service that extends AbstractOutboxEntity / uses OutboxDispatcher but does NOT
         # set openbank.outbox.dispatch-enabled=true silently never dispatches events —
@@ -2839,6 +2856,19 @@ data:
     # MEASURED behaviour by a classifier + CI gate (derive -> enforce -> show, ADR-0029/0054).
     # ---------------------------------------------------------------------------------------
     finops_tiers:
+      # Declared-side validation (check-finops-tiers.py, finops-lifecycle.yml) runs ADVISORY: the
+      # script always exits 0 today, so a tier declared here that contradicts the manifest is a
+      # ::warning. Graduating needs the MEASURED classifier (the derive->enforce->show half below);
+      # until that lands there is nothing to compare a declaration against except itself.
+      #
+      # Registered with a date as part of issue #2392: this gate ran advisory with no `enforced` /
+      # `target_enforce_date` on its rule, so check-gate-graduation.sh (ADR-0144) skipped it entirely
+      # and it had no deadline at all.
+      enforced: advisory
+      target_enforce_date: "2026-12-31"   # ADR-0144 — gated on the measured classifier, not on triage
+      blocked_on: "the measured-side classifier must land before the declared side can hard-fail;
+        without it, enforcing would only assert that the file agrees with itself"
+      ci_producer: "openbank-infra/scripts/check-finops-tiers.py"
       tiers:
         T0:                                   # Always-on
           definition: "Money-path HOT path where a cold-start / scaled-to-zero gap is unacceptable, or a regulator-mandated continuous service."

--- a/openbank-infra/gitops/components/ledger/ledger-opa-bundle.yaml
+++ b/openbank-infra/gitops/components/ledger/ledger-opa-bundle.yaml
@@ -9,7 +9,7 @@ metadata:
     app.kubernetes.io/name: ledger-service
     app.kubernetes.io/part-of: ledger
   annotations:
-    openbank.tech/policy-checksum: "cad4045ee5d68154"
+    openbank.tech/policy-checksum: "b314548623fb5bfa"
 data:
   rest.rego: |
     # SPDX-License-Identifier: Apache-2.0
@@ -2856,19 +2856,6 @@ data:
     # MEASURED behaviour by a classifier + CI gate (derive -> enforce -> show, ADR-0029/0054).
     # ---------------------------------------------------------------------------------------
     finops_tiers:
-      # Declared-side validation (check-finops-tiers.py, finops-lifecycle.yml) runs ADVISORY: the
-      # script always exits 0 today, so a tier declared here that contradicts the manifest is a
-      # ::warning. Graduating needs the MEASURED classifier (the derive->enforce->show half below);
-      # until that lands there is nothing to compare a declaration against except itself.
-      #
-      # Registered with a date as part of issue #2392: this gate ran advisory with no `enforced` /
-      # `target_enforce_date` on its rule, so check-gate-graduation.sh (ADR-0144) skipped it entirely
-      # and it had no deadline at all.
-      enforced: advisory
-      target_enforce_date: "2026-12-31"   # ADR-0144 — gated on the measured classifier, not on triage
-      blocked_on: "the measured-side classifier must land before the declared side can hard-fail;
-        without it, enforcing would only assert that the file agrees with itself"
-      ci_producer: "openbank-infra/scripts/check-finops-tiers.py"
       tiers:
         T0:                                   # Always-on
           definition: "Money-path HOT path where a cold-start / scaled-to-zero gap is unacceptable, or a regulator-mandated continuous service."
@@ -2971,6 +2958,9 @@ data:
       enforced: advisory                      # ADR-0057; -> block when the classifier lands
       target_enforce_date: "2026-09-30"   # ADR-0144
       blocked_on: "the measured-signal classifier (http_request_rate, kafka_consumer_lag, cpu/replica utilisation) has not shipped yet — only 2 services have a declared tier today (notification-service, product-catalog)"
+      # Added by issue #2392: the rule carried `enforced`/`target_enforce_date` but never named the
+      # script that produces the finding, so nothing tied the advisory CI step to this deadline.
+      ci_producer: "openbank-infra/scripts/check-finops-tiers.py"
 
     # ---------------------------------------------------------------------------------------
     # FinOps cost-allocation groups — showback business flows (ADR-0062). The /api/finops/costs

--- a/openbank-infra/gitops/components/ledger/ledger-service.yaml
+++ b/openbank-infra/gitops/components/ledger/ledger-service.yaml
@@ -38,7 +38,7 @@ spec:
       annotations:
         # Rolls the pods when the OPA bundle changes — subPath mounts do NOT hot-reload.
         # Kept in sync by gen-ledger-opa-bundle.sh (do not hand-edit).
-        openbank.tech/policy-checksum: "e0463574dd4bac09"
+        openbank.tech/policy-checksum: "cad4045ee5d68154"
     spec:
       securityContext:
         runAsNonRoot: true

--- a/openbank-infra/gitops/components/ledger/ledger-service.yaml
+++ b/openbank-infra/gitops/components/ledger/ledger-service.yaml
@@ -38,7 +38,7 @@ spec:
       annotations:
         # Rolls the pods when the OPA bundle changes — subPath mounts do NOT hot-reload.
         # Kept in sync by gen-ledger-opa-bundle.sh (do not hand-edit).
-        openbank.tech/policy-checksum: "cad4045ee5d68154"
+        openbank.tech/policy-checksum: "b314548623fb5bfa"
     spec:
       securityContext:
         runAsNonRoot: true

--- a/openbank-infra/gitops/components/lending/lending-opa-bundle.yaml
+++ b/openbank-infra/gitops/components/lending/lending-opa-bundle.yaml
@@ -9,7 +9,7 @@ metadata:
     app.kubernetes.io/name: lending-service
     app.kubernetes.io/part-of: lending
   annotations:
-    openbank.tech/policy-checksum: "669991550ba7aad6"
+    openbank.tech/policy-checksum: "f7a839d1f71498fb"
 data:
   rest.rego: |
     # SPDX-License-Identifier: Apache-2.0
@@ -1876,6 +1876,23 @@ data:
         # (3-dot against the PR base). Findings are ::warning annotations. Flip to enforced =
         # pass --enforce to the script in ci.yml (one-line change).
         ci_producer: "openbank-infra/scripts/check-threat-model-diff.py"
+      mp_messaging_dotted_keys:
+        # SmallRye reactive-messaging config written as a DOTTED key
+        # (`mp.messaging.incoming.x.topic: …`) inside a nested YAML mapping is silently ignored by
+        # SnakeYAML — the channel keeps its default and the consumer subscribes to nothing, with no
+        # error at boot (issue #686). The guard rewrites the shape it can prove wrong.
+        detect: ["<service>/src/main/resources/application.yaml", "mp.messaging.* written as a dotted key under a nested mapping"]
+        require:
+          - "mp.messaging channel config expressed as nested YAML, not a dotted key inside a mapping"
+        gate: dotted-mp-messaging-keys
+        enforced: advisory
+        target_enforce_date: "2026-09-30"   # ADR-0144
+        blocked_on: "1 finding remains fleet-wide; the script already supports --enforce, so graduating
+          is a one-word change in ci.yml once it is cleared"
+        # Registered here as part of issue #2392: this gate ran advisory with no rules.yaml rule at
+        # all, so check-gate-graduation.sh could not see it and it had no deadline. That class is now
+        # itself gated by .github/scripts/check-advisory-gate-registration.py.
+        ci_producer: ".github/scripts/check-dotted-mp-messaging-keys.sh"
       new_service_with_outbox:
         # A service that extends AbstractOutboxEntity / uses OutboxDispatcher but does NOT
         # set openbank.outbox.dispatch-enabled=true silently never dispatches events —
@@ -2794,6 +2811,19 @@ data:
     # MEASURED behaviour by a classifier + CI gate (derive -> enforce -> show, ADR-0029/0054).
     # ---------------------------------------------------------------------------------------
     finops_tiers:
+      # Declared-side validation (check-finops-tiers.py, finops-lifecycle.yml) runs ADVISORY: the
+      # script always exits 0 today, so a tier declared here that contradicts the manifest is a
+      # ::warning. Graduating needs the MEASURED classifier (the derive->enforce->show half below);
+      # until that lands there is nothing to compare a declaration against except itself.
+      #
+      # Registered with a date as part of issue #2392: this gate ran advisory with no `enforced` /
+      # `target_enforce_date` on its rule, so check-gate-graduation.sh (ADR-0144) skipped it entirely
+      # and it had no deadline at all.
+      enforced: advisory
+      target_enforce_date: "2026-12-31"   # ADR-0144 — gated on the measured classifier, not on triage
+      blocked_on: "the measured-side classifier must land before the declared side can hard-fail;
+        without it, enforcing would only assert that the file agrees with itself"
+      ci_producer: "openbank-infra/scripts/check-finops-tiers.py"
       tiers:
         T0:                                   # Always-on
           definition: "Money-path HOT path where a cold-start / scaled-to-zero gap is unacceptable, or a regulator-mandated continuous service."

--- a/openbank-infra/gitops/components/lending/lending-opa-bundle.yaml
+++ b/openbank-infra/gitops/components/lending/lending-opa-bundle.yaml
@@ -9,7 +9,7 @@ metadata:
     app.kubernetes.io/name: lending-service
     app.kubernetes.io/part-of: lending
   annotations:
-    openbank.tech/policy-checksum: "f7a839d1f71498fb"
+    openbank.tech/policy-checksum: "fe26beb0e6c1df30"
 data:
   rest.rego: |
     # SPDX-License-Identifier: Apache-2.0
@@ -2811,19 +2811,6 @@ data:
     # MEASURED behaviour by a classifier + CI gate (derive -> enforce -> show, ADR-0029/0054).
     # ---------------------------------------------------------------------------------------
     finops_tiers:
-      # Declared-side validation (check-finops-tiers.py, finops-lifecycle.yml) runs ADVISORY: the
-      # script always exits 0 today, so a tier declared here that contradicts the manifest is a
-      # ::warning. Graduating needs the MEASURED classifier (the derive->enforce->show half below);
-      # until that lands there is nothing to compare a declaration against except itself.
-      #
-      # Registered with a date as part of issue #2392: this gate ran advisory with no `enforced` /
-      # `target_enforce_date` on its rule, so check-gate-graduation.sh (ADR-0144) skipped it entirely
-      # and it had no deadline at all.
-      enforced: advisory
-      target_enforce_date: "2026-12-31"   # ADR-0144 — gated on the measured classifier, not on triage
-      blocked_on: "the measured-side classifier must land before the declared side can hard-fail;
-        without it, enforcing would only assert that the file agrees with itself"
-      ci_producer: "openbank-infra/scripts/check-finops-tiers.py"
       tiers:
         T0:                                   # Always-on
           definition: "Money-path HOT path where a cold-start / scaled-to-zero gap is unacceptable, or a regulator-mandated continuous service."
@@ -2926,6 +2913,9 @@ data:
       enforced: advisory                      # ADR-0057; -> block when the classifier lands
       target_enforce_date: "2026-09-30"   # ADR-0144
       blocked_on: "the measured-signal classifier (http_request_rate, kafka_consumer_lag, cpu/replica utilisation) has not shipped yet — only 2 services have a declared tier today (notification-service, product-catalog)"
+      # Added by issue #2392: the rule carried `enforced`/`target_enforce_date` but never named the
+      # script that produces the finding, so nothing tied the advisory CI step to this deadline.
+      ci_producer: "openbank-infra/scripts/check-finops-tiers.py"
 
     # ---------------------------------------------------------------------------------------
     # FinOps cost-allocation groups — showback business flows (ADR-0062). The /api/finops/costs

--- a/openbank-infra/gitops/components/lending/lending-service.yaml
+++ b/openbank-infra/gitops/components/lending/lending-service.yaml
@@ -34,7 +34,7 @@ spec:
       annotations:
         # Rolls the pods when the OPA bundle changes — subPath mounts do NOT hot-reload.
         # Kept in sync by gen-lending-opa-bundle.sh (do not hand-edit).
-        openbank.tech/policy-checksum: "669991550ba7aad6"
+        openbank.tech/policy-checksum: "f7a839d1f71498fb"
     spec:
       securityContext:
         runAsNonRoot: true

--- a/openbank-infra/gitops/components/lending/lending-service.yaml
+++ b/openbank-infra/gitops/components/lending/lending-service.yaml
@@ -34,7 +34,7 @@ spec:
       annotations:
         # Rolls the pods when the OPA bundle changes — subPath mounts do NOT hot-reload.
         # Kept in sync by gen-lending-opa-bundle.sh (do not hand-edit).
-        openbank.tech/policy-checksum: "f7a839d1f71498fb"
+        openbank.tech/policy-checksum: "fe26beb0e6c1df30"
     spec:
       securityContext:
         runAsNonRoot: true

--- a/openbank-infra/gitops/components/mcp/mcp-opa-bundle.yaml
+++ b/openbank-infra/gitops/components/mcp/mcp-opa-bundle.yaml
@@ -9,7 +9,7 @@ metadata:
     app.kubernetes.io/name: mcp-service
     app.kubernetes.io/part-of: platform
   annotations:
-    openbank.tech/policy-checksum: "31b69cbacb5b9c85"
+    openbank.tech/policy-checksum: "f396789572bad1ea"
 data:
   rest.rego: |
     # SPDX-License-Identifier: Apache-2.0
@@ -1774,6 +1774,23 @@ data:
         # (3-dot against the PR base). Findings are ::warning annotations. Flip to enforced =
         # pass --enforce to the script in ci.yml (one-line change).
         ci_producer: "openbank-infra/scripts/check-threat-model-diff.py"
+      mp_messaging_dotted_keys:
+        # SmallRye reactive-messaging config written as a DOTTED key
+        # (`mp.messaging.incoming.x.topic: …`) inside a nested YAML mapping is silently ignored by
+        # SnakeYAML — the channel keeps its default and the consumer subscribes to nothing, with no
+        # error at boot (issue #686). The guard rewrites the shape it can prove wrong.
+        detect: ["<service>/src/main/resources/application.yaml", "mp.messaging.* written as a dotted key under a nested mapping"]
+        require:
+          - "mp.messaging channel config expressed as nested YAML, not a dotted key inside a mapping"
+        gate: dotted-mp-messaging-keys
+        enforced: advisory
+        target_enforce_date: "2026-09-30"   # ADR-0144
+        blocked_on: "1 finding remains fleet-wide; the script already supports --enforce, so graduating
+          is a one-word change in ci.yml once it is cleared"
+        # Registered here as part of issue #2392: this gate ran advisory with no rules.yaml rule at
+        # all, so check-gate-graduation.sh could not see it and it had no deadline. That class is now
+        # itself gated by .github/scripts/check-advisory-gate-registration.py.
+        ci_producer: ".github/scripts/check-dotted-mp-messaging-keys.sh"
       new_service_with_outbox:
         # A service that extends AbstractOutboxEntity / uses OutboxDispatcher but does NOT
         # set openbank.outbox.dispatch-enabled=true silently never dispatches events —
@@ -2692,6 +2709,19 @@ data:
     # MEASURED behaviour by a classifier + CI gate (derive -> enforce -> show, ADR-0029/0054).
     # ---------------------------------------------------------------------------------------
     finops_tiers:
+      # Declared-side validation (check-finops-tiers.py, finops-lifecycle.yml) runs ADVISORY: the
+      # script always exits 0 today, so a tier declared here that contradicts the manifest is a
+      # ::warning. Graduating needs the MEASURED classifier (the derive->enforce->show half below);
+      # until that lands there is nothing to compare a declaration against except itself.
+      #
+      # Registered with a date as part of issue #2392: this gate ran advisory with no `enforced` /
+      # `target_enforce_date` on its rule, so check-gate-graduation.sh (ADR-0144) skipped it entirely
+      # and it had no deadline at all.
+      enforced: advisory
+      target_enforce_date: "2026-12-31"   # ADR-0144 — gated on the measured classifier, not on triage
+      blocked_on: "the measured-side classifier must land before the declared side can hard-fail;
+        without it, enforcing would only assert that the file agrees with itself"
+      ci_producer: "openbank-infra/scripts/check-finops-tiers.py"
       tiers:
         T0:                                   # Always-on
           definition: "Money-path HOT path where a cold-start / scaled-to-zero gap is unacceptable, or a regulator-mandated continuous service."

--- a/openbank-infra/gitops/components/mcp/mcp-opa-bundle.yaml
+++ b/openbank-infra/gitops/components/mcp/mcp-opa-bundle.yaml
@@ -9,7 +9,7 @@ metadata:
     app.kubernetes.io/name: mcp-service
     app.kubernetes.io/part-of: platform
   annotations:
-    openbank.tech/policy-checksum: "f396789572bad1ea"
+    openbank.tech/policy-checksum: "c5b9e80930a29004"
 data:
   rest.rego: |
     # SPDX-License-Identifier: Apache-2.0
@@ -2709,19 +2709,6 @@ data:
     # MEASURED behaviour by a classifier + CI gate (derive -> enforce -> show, ADR-0029/0054).
     # ---------------------------------------------------------------------------------------
     finops_tiers:
-      # Declared-side validation (check-finops-tiers.py, finops-lifecycle.yml) runs ADVISORY: the
-      # script always exits 0 today, so a tier declared here that contradicts the manifest is a
-      # ::warning. Graduating needs the MEASURED classifier (the derive->enforce->show half below);
-      # until that lands there is nothing to compare a declaration against except itself.
-      #
-      # Registered with a date as part of issue #2392: this gate ran advisory with no `enforced` /
-      # `target_enforce_date` on its rule, so check-gate-graduation.sh (ADR-0144) skipped it entirely
-      # and it had no deadline at all.
-      enforced: advisory
-      target_enforce_date: "2026-12-31"   # ADR-0144 — gated on the measured classifier, not on triage
-      blocked_on: "the measured-side classifier must land before the declared side can hard-fail;
-        without it, enforcing would only assert that the file agrees with itself"
-      ci_producer: "openbank-infra/scripts/check-finops-tiers.py"
       tiers:
         T0:                                   # Always-on
           definition: "Money-path HOT path where a cold-start / scaled-to-zero gap is unacceptable, or a regulator-mandated continuous service."
@@ -2824,6 +2811,9 @@ data:
       enforced: advisory                      # ADR-0057; -> block when the classifier lands
       target_enforce_date: "2026-09-30"   # ADR-0144
       blocked_on: "the measured-signal classifier (http_request_rate, kafka_consumer_lag, cpu/replica utilisation) has not shipped yet — only 2 services have a declared tier today (notification-service, product-catalog)"
+      # Added by issue #2392: the rule carried `enforced`/`target_enforce_date` but never named the
+      # script that produces the finding, so nothing tied the advisory CI step to this deadline.
+      ci_producer: "openbank-infra/scripts/check-finops-tiers.py"
 
     # ---------------------------------------------------------------------------------------
     # FinOps cost-allocation groups — showback business flows (ADR-0062). The /api/finops/costs

--- a/openbank-infra/gitops/components/mcp/mcp-service.yaml
+++ b/openbank-infra/gitops/components/mcp/mcp-service.yaml
@@ -29,7 +29,7 @@ spec:
       annotations:
         # Rolls the pod when the OPA bundle changes — subPath mounts do NOT hot-reload.
         # Kept in sync by gen-mcp-opa-bundle.sh (do not hand-edit).
-        openbank.tech/policy-checksum: "f396789572bad1ea"
+        openbank.tech/policy-checksum: "c5b9e80930a29004"
     spec:
       securityContext:
         runAsNonRoot: true

--- a/openbank-infra/gitops/components/mcp/mcp-service.yaml
+++ b/openbank-infra/gitops/components/mcp/mcp-service.yaml
@@ -29,7 +29,7 @@ spec:
       annotations:
         # Rolls the pod when the OPA bundle changes — subPath mounts do NOT hot-reload.
         # Kept in sync by gen-mcp-opa-bundle.sh (do not hand-edit).
-        openbank.tech/policy-checksum: "31b69cbacb5b9c85"
+        openbank.tech/policy-checksum: "f396789572bad1ea"
     spec:
       securityContext:
         runAsNonRoot: true

--- a/openbank-infra/gitops/components/notifications/notification-service-opa-bundle.yaml
+++ b/openbank-infra/gitops/components/notifications/notification-service-opa-bundle.yaml
@@ -10,7 +10,7 @@ metadata:
     app.kubernetes.io/name: notification-service
     app.kubernetes.io/part-of: notifications
   annotations:
-    openbank.tech/policy-checksum: "b008ff50a7934dcf"
+    openbank.tech/policy-checksum: "4cbd1f661b104602"
 data:
   rest.rego: |
     # SPDX-License-Identifier: Apache-2.0
@@ -1932,19 +1932,6 @@ data:
     # MEASURED behaviour by a classifier + CI gate (derive -> enforce -> show, ADR-0029/0054).
     # ---------------------------------------------------------------------------------------
     finops_tiers:
-      # Declared-side validation (check-finops-tiers.py, finops-lifecycle.yml) runs ADVISORY: the
-      # script always exits 0 today, so a tier declared here that contradicts the manifest is a
-      # ::warning. Graduating needs the MEASURED classifier (the derive->enforce->show half below);
-      # until that lands there is nothing to compare a declaration against except itself.
-      #
-      # Registered with a date as part of issue #2392: this gate ran advisory with no `enforced` /
-      # `target_enforce_date` on its rule, so check-gate-graduation.sh (ADR-0144) skipped it entirely
-      # and it had no deadline at all.
-      enforced: advisory
-      target_enforce_date: "2026-12-31"   # ADR-0144 — gated on the measured classifier, not on triage
-      blocked_on: "the measured-side classifier must land before the declared side can hard-fail;
-        without it, enforcing would only assert that the file agrees with itself"
-      ci_producer: "openbank-infra/scripts/check-finops-tiers.py"
       tiers:
         T0:                                   # Always-on
           definition: "Money-path HOT path where a cold-start / scaled-to-zero gap is unacceptable, or a regulator-mandated continuous service."
@@ -2047,6 +2034,9 @@ data:
       enforced: advisory                      # ADR-0057; -> block when the classifier lands
       target_enforce_date: "2026-09-30"   # ADR-0144
       blocked_on: "the measured-signal classifier (http_request_rate, kafka_consumer_lag, cpu/replica utilisation) has not shipped yet — only 2 services have a declared tier today (notification-service, product-catalog)"
+      # Added by issue #2392: the rule carried `enforced`/`target_enforce_date` but never named the
+      # script that produces the finding, so nothing tied the advisory CI step to this deadline.
+      ci_producer: "openbank-infra/scripts/check-finops-tiers.py"
 
     # ---------------------------------------------------------------------------------------
     # FinOps cost-allocation groups — showback business flows (ADR-0062). The /api/finops/costs

--- a/openbank-infra/gitops/components/notifications/notification-service-opa-bundle.yaml
+++ b/openbank-infra/gitops/components/notifications/notification-service-opa-bundle.yaml
@@ -10,7 +10,7 @@ metadata:
     app.kubernetes.io/name: notification-service
     app.kubernetes.io/part-of: notifications
   annotations:
-    openbank.tech/policy-checksum: "79c797e60711208b"
+    openbank.tech/policy-checksum: "b008ff50a7934dcf"
 data:
   rest.rego: |
     # SPDX-License-Identifier: Apache-2.0
@@ -997,6 +997,23 @@ data:
         # (3-dot against the PR base). Findings are ::warning annotations. Flip to enforced =
         # pass --enforce to the script in ci.yml (one-line change).
         ci_producer: "openbank-infra/scripts/check-threat-model-diff.py"
+      mp_messaging_dotted_keys:
+        # SmallRye reactive-messaging config written as a DOTTED key
+        # (`mp.messaging.incoming.x.topic: …`) inside a nested YAML mapping is silently ignored by
+        # SnakeYAML — the channel keeps its default and the consumer subscribes to nothing, with no
+        # error at boot (issue #686). The guard rewrites the shape it can prove wrong.
+        detect: ["<service>/src/main/resources/application.yaml", "mp.messaging.* written as a dotted key under a nested mapping"]
+        require:
+          - "mp.messaging channel config expressed as nested YAML, not a dotted key inside a mapping"
+        gate: dotted-mp-messaging-keys
+        enforced: advisory
+        target_enforce_date: "2026-09-30"   # ADR-0144
+        blocked_on: "1 finding remains fleet-wide; the script already supports --enforce, so graduating
+          is a one-word change in ci.yml once it is cleared"
+        # Registered here as part of issue #2392: this gate ran advisory with no rules.yaml rule at
+        # all, so check-gate-graduation.sh could not see it and it had no deadline. That class is now
+        # itself gated by .github/scripts/check-advisory-gate-registration.py.
+        ci_producer: ".github/scripts/check-dotted-mp-messaging-keys.sh"
       new_service_with_outbox:
         # A service that extends AbstractOutboxEntity / uses OutboxDispatcher but does NOT
         # set openbank.outbox.dispatch-enabled=true silently never dispatches events —
@@ -1915,6 +1932,19 @@ data:
     # MEASURED behaviour by a classifier + CI gate (derive -> enforce -> show, ADR-0029/0054).
     # ---------------------------------------------------------------------------------------
     finops_tiers:
+      # Declared-side validation (check-finops-tiers.py, finops-lifecycle.yml) runs ADVISORY: the
+      # script always exits 0 today, so a tier declared here that contradicts the manifest is a
+      # ::warning. Graduating needs the MEASURED classifier (the derive->enforce->show half below);
+      # until that lands there is nothing to compare a declaration against except itself.
+      #
+      # Registered with a date as part of issue #2392: this gate ran advisory with no `enforced` /
+      # `target_enforce_date` on its rule, so check-gate-graduation.sh (ADR-0144) skipped it entirely
+      # and it had no deadline at all.
+      enforced: advisory
+      target_enforce_date: "2026-12-31"   # ADR-0144 — gated on the measured classifier, not on triage
+      blocked_on: "the measured-side classifier must land before the declared side can hard-fail;
+        without it, enforcing would only assert that the file agrees with itself"
+      ci_producer: "openbank-infra/scripts/check-finops-tiers.py"
       tiers:
         T0:                                   # Always-on
           definition: "Money-path HOT path where a cold-start / scaled-to-zero gap is unacceptable, or a regulator-mandated continuous service."

--- a/openbank-infra/gitops/components/notifications/notification-service.yaml
+++ b/openbank-infra/gitops/components/notifications/notification-service.yaml
@@ -39,7 +39,7 @@ spec:
       annotations:
         # Rolls the Deployment when the OPA policy bundle changes (subPath mounts don't
         # hot-reload). Kept in sync by gen-notification-opa-bundle.sh.
-        openbank.tech/policy-checksum: "79c797e60711208b"
+        openbank.tech/policy-checksum: "b008ff50a7934dcf"
       labels:
         app.kubernetes.io/name: notification-service
         app.kubernetes.io/part-of: notifications

--- a/openbank-infra/gitops/components/notifications/notification-service.yaml
+++ b/openbank-infra/gitops/components/notifications/notification-service.yaml
@@ -39,7 +39,7 @@ spec:
       annotations:
         # Rolls the Deployment when the OPA policy bundle changes (subPath mounts don't
         # hot-reload). Kept in sync by gen-notification-opa-bundle.sh.
-        openbank.tech/policy-checksum: "b008ff50a7934dcf"
+        openbank.tech/policy-checksum: "4cbd1f661b104602"
       labels:
         app.kubernetes.io/name: notification-service
         app.kubernetes.io/part-of: notifications

--- a/openbank-infra/gitops/components/party/party-opa-bundle.yaml
+++ b/openbank-infra/gitops/components/party/party-opa-bundle.yaml
@@ -9,7 +9,7 @@ metadata:
     app.kubernetes.io/name: party-service
     app.kubernetes.io/part-of: party
   annotations:
-    openbank.tech/policy-checksum: "97ac07b29b62d954"
+    openbank.tech/policy-checksum: "fa99f83a76b0e8b0"
 data:
   rest.rego: |
     # SPDX-License-Identifier: Apache-2.0
@@ -2780,19 +2780,6 @@ data:
     # MEASURED behaviour by a classifier + CI gate (derive -> enforce -> show, ADR-0029/0054).
     # ---------------------------------------------------------------------------------------
     finops_tiers:
-      # Declared-side validation (check-finops-tiers.py, finops-lifecycle.yml) runs ADVISORY: the
-      # script always exits 0 today, so a tier declared here that contradicts the manifest is a
-      # ::warning. Graduating needs the MEASURED classifier (the derive->enforce->show half below);
-      # until that lands there is nothing to compare a declaration against except itself.
-      #
-      # Registered with a date as part of issue #2392: this gate ran advisory with no `enforced` /
-      # `target_enforce_date` on its rule, so check-gate-graduation.sh (ADR-0144) skipped it entirely
-      # and it had no deadline at all.
-      enforced: advisory
-      target_enforce_date: "2026-12-31"   # ADR-0144 — gated on the measured classifier, not on triage
-      blocked_on: "the measured-side classifier must land before the declared side can hard-fail;
-        without it, enforcing would only assert that the file agrees with itself"
-      ci_producer: "openbank-infra/scripts/check-finops-tiers.py"
       tiers:
         T0:                                   # Always-on
           definition: "Money-path HOT path where a cold-start / scaled-to-zero gap is unacceptable, or a regulator-mandated continuous service."
@@ -2895,6 +2882,9 @@ data:
       enforced: advisory                      # ADR-0057; -> block when the classifier lands
       target_enforce_date: "2026-09-30"   # ADR-0144
       blocked_on: "the measured-signal classifier (http_request_rate, kafka_consumer_lag, cpu/replica utilisation) has not shipped yet — only 2 services have a declared tier today (notification-service, product-catalog)"
+      # Added by issue #2392: the rule carried `enforced`/`target_enforce_date` but never named the
+      # script that produces the finding, so nothing tied the advisory CI step to this deadline.
+      ci_producer: "openbank-infra/scripts/check-finops-tiers.py"
 
     # ---------------------------------------------------------------------------------------
     # FinOps cost-allocation groups — showback business flows (ADR-0062). The /api/finops/costs

--- a/openbank-infra/gitops/components/party/party-opa-bundle.yaml
+++ b/openbank-infra/gitops/components/party/party-opa-bundle.yaml
@@ -9,7 +9,7 @@ metadata:
     app.kubernetes.io/name: party-service
     app.kubernetes.io/part-of: party
   annotations:
-    openbank.tech/policy-checksum: "691abe294073834f"
+    openbank.tech/policy-checksum: "97ac07b29b62d954"
 data:
   rest.rego: |
     # SPDX-License-Identifier: Apache-2.0
@@ -1845,6 +1845,23 @@ data:
         # (3-dot against the PR base). Findings are ::warning annotations. Flip to enforced =
         # pass --enforce to the script in ci.yml (one-line change).
         ci_producer: "openbank-infra/scripts/check-threat-model-diff.py"
+      mp_messaging_dotted_keys:
+        # SmallRye reactive-messaging config written as a DOTTED key
+        # (`mp.messaging.incoming.x.topic: …`) inside a nested YAML mapping is silently ignored by
+        # SnakeYAML — the channel keeps its default and the consumer subscribes to nothing, with no
+        # error at boot (issue #686). The guard rewrites the shape it can prove wrong.
+        detect: ["<service>/src/main/resources/application.yaml", "mp.messaging.* written as a dotted key under a nested mapping"]
+        require:
+          - "mp.messaging channel config expressed as nested YAML, not a dotted key inside a mapping"
+        gate: dotted-mp-messaging-keys
+        enforced: advisory
+        target_enforce_date: "2026-09-30"   # ADR-0144
+        blocked_on: "1 finding remains fleet-wide; the script already supports --enforce, so graduating
+          is a one-word change in ci.yml once it is cleared"
+        # Registered here as part of issue #2392: this gate ran advisory with no rules.yaml rule at
+        # all, so check-gate-graduation.sh could not see it and it had no deadline. That class is now
+        # itself gated by .github/scripts/check-advisory-gate-registration.py.
+        ci_producer: ".github/scripts/check-dotted-mp-messaging-keys.sh"
       new_service_with_outbox:
         # A service that extends AbstractOutboxEntity / uses OutboxDispatcher but does NOT
         # set openbank.outbox.dispatch-enabled=true silently never dispatches events —
@@ -2763,6 +2780,19 @@ data:
     # MEASURED behaviour by a classifier + CI gate (derive -> enforce -> show, ADR-0029/0054).
     # ---------------------------------------------------------------------------------------
     finops_tiers:
+      # Declared-side validation (check-finops-tiers.py, finops-lifecycle.yml) runs ADVISORY: the
+      # script always exits 0 today, so a tier declared here that contradicts the manifest is a
+      # ::warning. Graduating needs the MEASURED classifier (the derive->enforce->show half below);
+      # until that lands there is nothing to compare a declaration against except itself.
+      #
+      # Registered with a date as part of issue #2392: this gate ran advisory with no `enforced` /
+      # `target_enforce_date` on its rule, so check-gate-graduation.sh (ADR-0144) skipped it entirely
+      # and it had no deadline at all.
+      enforced: advisory
+      target_enforce_date: "2026-12-31"   # ADR-0144 — gated on the measured classifier, not on triage
+      blocked_on: "the measured-side classifier must land before the declared side can hard-fail;
+        without it, enforcing would only assert that the file agrees with itself"
+      ci_producer: "openbank-infra/scripts/check-finops-tiers.py"
       tiers:
         T0:                                   # Always-on
           definition: "Money-path HOT path where a cold-start / scaled-to-zero gap is unacceptable, or a regulator-mandated continuous service."

--- a/openbank-infra/gitops/components/party/party-service.yaml
+++ b/openbank-infra/gitops/components/party/party-service.yaml
@@ -22,7 +22,7 @@ spec:
       annotations:
         # Rolls the pod when the OPA bundle changes — subPath mounts do NOT hot-reload.
         # Kept in sync by gen-party-opa-bundle.sh (do not hand-edit).
-        openbank.tech/policy-checksum: "97ac07b29b62d954"
+        openbank.tech/policy-checksum: "fa99f83a76b0e8b0"
       labels:
         app.kubernetes.io/name: party-service
         app.kubernetes.io/part-of: party

--- a/openbank-infra/gitops/components/party/party-service.yaml
+++ b/openbank-infra/gitops/components/party/party-service.yaml
@@ -22,7 +22,7 @@ spec:
       annotations:
         # Rolls the pod when the OPA bundle changes — subPath mounts do NOT hot-reload.
         # Kept in sync by gen-party-opa-bundle.sh (do not hand-edit).
-        openbank.tech/policy-checksum: "691abe294073834f"
+        openbank.tech/policy-checksum: "97ac07b29b62d954"
       labels:
         app.kubernetes.io/name: party-service
         app.kubernetes.io/part-of: party

--- a/openbank-infra/gitops/components/payments/card-issuance-opa-bundle.yaml
+++ b/openbank-infra/gitops/components/payments/card-issuance-opa-bundle.yaml
@@ -9,7 +9,7 @@ metadata:
     app.kubernetes.io/name: card-issuance-service
     app.kubernetes.io/part-of: payments
   annotations:
-    openbank.tech/policy-checksum: "1091724a64acca05"
+    openbank.tech/policy-checksum: "0bcfc12ad07ac05a"
 data:
   rest.rego: |
     # SPDX-License-Identifier: Apache-2.0
@@ -1829,6 +1829,23 @@ data:
         # (3-dot against the PR base). Findings are ::warning annotations. Flip to enforced =
         # pass --enforce to the script in ci.yml (one-line change).
         ci_producer: "openbank-infra/scripts/check-threat-model-diff.py"
+      mp_messaging_dotted_keys:
+        # SmallRye reactive-messaging config written as a DOTTED key
+        # (`mp.messaging.incoming.x.topic: …`) inside a nested YAML mapping is silently ignored by
+        # SnakeYAML — the channel keeps its default and the consumer subscribes to nothing, with no
+        # error at boot (issue #686). The guard rewrites the shape it can prove wrong.
+        detect: ["<service>/src/main/resources/application.yaml", "mp.messaging.* written as a dotted key under a nested mapping"]
+        require:
+          - "mp.messaging channel config expressed as nested YAML, not a dotted key inside a mapping"
+        gate: dotted-mp-messaging-keys
+        enforced: advisory
+        target_enforce_date: "2026-09-30"   # ADR-0144
+        blocked_on: "1 finding remains fleet-wide; the script already supports --enforce, so graduating
+          is a one-word change in ci.yml once it is cleared"
+        # Registered here as part of issue #2392: this gate ran advisory with no rules.yaml rule at
+        # all, so check-gate-graduation.sh could not see it and it had no deadline. That class is now
+        # itself gated by .github/scripts/check-advisory-gate-registration.py.
+        ci_producer: ".github/scripts/check-dotted-mp-messaging-keys.sh"
       new_service_with_outbox:
         # A service that extends AbstractOutboxEntity / uses OutboxDispatcher but does NOT
         # set openbank.outbox.dispatch-enabled=true silently never dispatches events —
@@ -2747,6 +2764,19 @@ data:
     # MEASURED behaviour by a classifier + CI gate (derive -> enforce -> show, ADR-0029/0054).
     # ---------------------------------------------------------------------------------------
     finops_tiers:
+      # Declared-side validation (check-finops-tiers.py, finops-lifecycle.yml) runs ADVISORY: the
+      # script always exits 0 today, so a tier declared here that contradicts the manifest is a
+      # ::warning. Graduating needs the MEASURED classifier (the derive->enforce->show half below);
+      # until that lands there is nothing to compare a declaration against except itself.
+      #
+      # Registered with a date as part of issue #2392: this gate ran advisory with no `enforced` /
+      # `target_enforce_date` on its rule, so check-gate-graduation.sh (ADR-0144) skipped it entirely
+      # and it had no deadline at all.
+      enforced: advisory
+      target_enforce_date: "2026-12-31"   # ADR-0144 — gated on the measured classifier, not on triage
+      blocked_on: "the measured-side classifier must land before the declared side can hard-fail;
+        without it, enforcing would only assert that the file agrees with itself"
+      ci_producer: "openbank-infra/scripts/check-finops-tiers.py"
       tiers:
         T0:                                   # Always-on
           definition: "Money-path HOT path where a cold-start / scaled-to-zero gap is unacceptable, or a regulator-mandated continuous service."

--- a/openbank-infra/gitops/components/payments/card-issuance-opa-bundle.yaml
+++ b/openbank-infra/gitops/components/payments/card-issuance-opa-bundle.yaml
@@ -9,7 +9,7 @@ metadata:
     app.kubernetes.io/name: card-issuance-service
     app.kubernetes.io/part-of: payments
   annotations:
-    openbank.tech/policy-checksum: "0bcfc12ad07ac05a"
+    openbank.tech/policy-checksum: "1f164f1a167125de"
 data:
   rest.rego: |
     # SPDX-License-Identifier: Apache-2.0
@@ -2764,19 +2764,6 @@ data:
     # MEASURED behaviour by a classifier + CI gate (derive -> enforce -> show, ADR-0029/0054).
     # ---------------------------------------------------------------------------------------
     finops_tiers:
-      # Declared-side validation (check-finops-tiers.py, finops-lifecycle.yml) runs ADVISORY: the
-      # script always exits 0 today, so a tier declared here that contradicts the manifest is a
-      # ::warning. Graduating needs the MEASURED classifier (the derive->enforce->show half below);
-      # until that lands there is nothing to compare a declaration against except itself.
-      #
-      # Registered with a date as part of issue #2392: this gate ran advisory with no `enforced` /
-      # `target_enforce_date` on its rule, so check-gate-graduation.sh (ADR-0144) skipped it entirely
-      # and it had no deadline at all.
-      enforced: advisory
-      target_enforce_date: "2026-12-31"   # ADR-0144 — gated on the measured classifier, not on triage
-      blocked_on: "the measured-side classifier must land before the declared side can hard-fail;
-        without it, enforcing would only assert that the file agrees with itself"
-      ci_producer: "openbank-infra/scripts/check-finops-tiers.py"
       tiers:
         T0:                                   # Always-on
           definition: "Money-path HOT path where a cold-start / scaled-to-zero gap is unacceptable, or a regulator-mandated continuous service."
@@ -2879,6 +2866,9 @@ data:
       enforced: advisory                      # ADR-0057; -> block when the classifier lands
       target_enforce_date: "2026-09-30"   # ADR-0144
       blocked_on: "the measured-signal classifier (http_request_rate, kafka_consumer_lag, cpu/replica utilisation) has not shipped yet — only 2 services have a declared tier today (notification-service, product-catalog)"
+      # Added by issue #2392: the rule carried `enforced`/`target_enforce_date` but never named the
+      # script that produces the finding, so nothing tied the advisory CI step to this deadline.
+      ci_producer: "openbank-infra/scripts/check-finops-tiers.py"
 
     # ---------------------------------------------------------------------------------------
     # FinOps cost-allocation groups — showback business flows (ADR-0062). The /api/finops/costs

--- a/openbank-infra/gitops/components/payments/clearing-opa-bundle.yaml
+++ b/openbank-infra/gitops/components/payments/clearing-opa-bundle.yaml
@@ -9,7 +9,7 @@ metadata:
     app.kubernetes.io/name: clearing-service
     app.kubernetes.io/part-of: payments
   annotations:
-    openbank.tech/policy-checksum: "cac91627170154ae"
+    openbank.tech/policy-checksum: "c640e8bd154113c1"
 data:
   rest.rego: |
     # SPDX-License-Identifier: Apache-2.0
@@ -1866,6 +1866,23 @@ data:
         # (3-dot against the PR base). Findings are ::warning annotations. Flip to enforced =
         # pass --enforce to the script in ci.yml (one-line change).
         ci_producer: "openbank-infra/scripts/check-threat-model-diff.py"
+      mp_messaging_dotted_keys:
+        # SmallRye reactive-messaging config written as a DOTTED key
+        # (`mp.messaging.incoming.x.topic: …`) inside a nested YAML mapping is silently ignored by
+        # SnakeYAML — the channel keeps its default and the consumer subscribes to nothing, with no
+        # error at boot (issue #686). The guard rewrites the shape it can prove wrong.
+        detect: ["<service>/src/main/resources/application.yaml", "mp.messaging.* written as a dotted key under a nested mapping"]
+        require:
+          - "mp.messaging channel config expressed as nested YAML, not a dotted key inside a mapping"
+        gate: dotted-mp-messaging-keys
+        enforced: advisory
+        target_enforce_date: "2026-09-30"   # ADR-0144
+        blocked_on: "1 finding remains fleet-wide; the script already supports --enforce, so graduating
+          is a one-word change in ci.yml once it is cleared"
+        # Registered here as part of issue #2392: this gate ran advisory with no rules.yaml rule at
+        # all, so check-gate-graduation.sh could not see it and it had no deadline. That class is now
+        # itself gated by .github/scripts/check-advisory-gate-registration.py.
+        ci_producer: ".github/scripts/check-dotted-mp-messaging-keys.sh"
       new_service_with_outbox:
         # A service that extends AbstractOutboxEntity / uses OutboxDispatcher but does NOT
         # set openbank.outbox.dispatch-enabled=true silently never dispatches events —
@@ -2784,6 +2801,19 @@ data:
     # MEASURED behaviour by a classifier + CI gate (derive -> enforce -> show, ADR-0029/0054).
     # ---------------------------------------------------------------------------------------
     finops_tiers:
+      # Declared-side validation (check-finops-tiers.py, finops-lifecycle.yml) runs ADVISORY: the
+      # script always exits 0 today, so a tier declared here that contradicts the manifest is a
+      # ::warning. Graduating needs the MEASURED classifier (the derive->enforce->show half below);
+      # until that lands there is nothing to compare a declaration against except itself.
+      #
+      # Registered with a date as part of issue #2392: this gate ran advisory with no `enforced` /
+      # `target_enforce_date` on its rule, so check-gate-graduation.sh (ADR-0144) skipped it entirely
+      # and it had no deadline at all.
+      enforced: advisory
+      target_enforce_date: "2026-12-31"   # ADR-0144 — gated on the measured classifier, not on triage
+      blocked_on: "the measured-side classifier must land before the declared side can hard-fail;
+        without it, enforcing would only assert that the file agrees with itself"
+      ci_producer: "openbank-infra/scripts/check-finops-tiers.py"
       tiers:
         T0:                                   # Always-on
           definition: "Money-path HOT path where a cold-start / scaled-to-zero gap is unacceptable, or a regulator-mandated continuous service."

--- a/openbank-infra/gitops/components/payments/clearing-opa-bundle.yaml
+++ b/openbank-infra/gitops/components/payments/clearing-opa-bundle.yaml
@@ -9,7 +9,7 @@ metadata:
     app.kubernetes.io/name: clearing-service
     app.kubernetes.io/part-of: payments
   annotations:
-    openbank.tech/policy-checksum: "c640e8bd154113c1"
+    openbank.tech/policy-checksum: "539ccbf7887678e4"
 data:
   rest.rego: |
     # SPDX-License-Identifier: Apache-2.0
@@ -2801,19 +2801,6 @@ data:
     # MEASURED behaviour by a classifier + CI gate (derive -> enforce -> show, ADR-0029/0054).
     # ---------------------------------------------------------------------------------------
     finops_tiers:
-      # Declared-side validation (check-finops-tiers.py, finops-lifecycle.yml) runs ADVISORY: the
-      # script always exits 0 today, so a tier declared here that contradicts the manifest is a
-      # ::warning. Graduating needs the MEASURED classifier (the derive->enforce->show half below);
-      # until that lands there is nothing to compare a declaration against except itself.
-      #
-      # Registered with a date as part of issue #2392: this gate ran advisory with no `enforced` /
-      # `target_enforce_date` on its rule, so check-gate-graduation.sh (ADR-0144) skipped it entirely
-      # and it had no deadline at all.
-      enforced: advisory
-      target_enforce_date: "2026-12-31"   # ADR-0144 — gated on the measured classifier, not on triage
-      blocked_on: "the measured-side classifier must land before the declared side can hard-fail;
-        without it, enforcing would only assert that the file agrees with itself"
-      ci_producer: "openbank-infra/scripts/check-finops-tiers.py"
       tiers:
         T0:                                   # Always-on
           definition: "Money-path HOT path where a cold-start / scaled-to-zero gap is unacceptable, or a regulator-mandated continuous service."
@@ -2916,6 +2903,9 @@ data:
       enforced: advisory                      # ADR-0057; -> block when the classifier lands
       target_enforce_date: "2026-09-30"   # ADR-0144
       blocked_on: "the measured-signal classifier (http_request_rate, kafka_consumer_lag, cpu/replica utilisation) has not shipped yet — only 2 services have a declared tier today (notification-service, product-catalog)"
+      # Added by issue #2392: the rule carried `enforced`/`target_enforce_date` but never named the
+      # script that produces the finding, so nothing tied the advisory CI step to this deadline.
+      ci_producer: "openbank-infra/scripts/check-finops-tiers.py"
 
     # ---------------------------------------------------------------------------------------
     # FinOps cost-allocation groups — showback business flows (ADR-0062). The /api/finops/costs

--- a/openbank-infra/gitops/components/payments/domestic-payment-opa-bundle.yaml
+++ b/openbank-infra/gitops/components/payments/domestic-payment-opa-bundle.yaml
@@ -9,7 +9,7 @@ metadata:
     app.kubernetes.io/name: domestic-payment
     app.kubernetes.io/part-of: payments
   annotations:
-    openbank.tech/policy-checksum: "8bc2dee5124ab198"
+    openbank.tech/policy-checksum: "658d40490e649f1f"
 data:
   rest.rego: |
     # SPDX-License-Identifier: Apache-2.0
@@ -1851,6 +1851,23 @@ data:
         # (3-dot against the PR base). Findings are ::warning annotations. Flip to enforced =
         # pass --enforce to the script in ci.yml (one-line change).
         ci_producer: "openbank-infra/scripts/check-threat-model-diff.py"
+      mp_messaging_dotted_keys:
+        # SmallRye reactive-messaging config written as a DOTTED key
+        # (`mp.messaging.incoming.x.topic: …`) inside a nested YAML mapping is silently ignored by
+        # SnakeYAML — the channel keeps its default and the consumer subscribes to nothing, with no
+        # error at boot (issue #686). The guard rewrites the shape it can prove wrong.
+        detect: ["<service>/src/main/resources/application.yaml", "mp.messaging.* written as a dotted key under a nested mapping"]
+        require:
+          - "mp.messaging channel config expressed as nested YAML, not a dotted key inside a mapping"
+        gate: dotted-mp-messaging-keys
+        enforced: advisory
+        target_enforce_date: "2026-09-30"   # ADR-0144
+        blocked_on: "1 finding remains fleet-wide; the script already supports --enforce, so graduating
+          is a one-word change in ci.yml once it is cleared"
+        # Registered here as part of issue #2392: this gate ran advisory with no rules.yaml rule at
+        # all, so check-gate-graduation.sh could not see it and it had no deadline. That class is now
+        # itself gated by .github/scripts/check-advisory-gate-registration.py.
+        ci_producer: ".github/scripts/check-dotted-mp-messaging-keys.sh"
       new_service_with_outbox:
         # A service that extends AbstractOutboxEntity / uses OutboxDispatcher but does NOT
         # set openbank.outbox.dispatch-enabled=true silently never dispatches events —
@@ -2769,6 +2786,19 @@ data:
     # MEASURED behaviour by a classifier + CI gate (derive -> enforce -> show, ADR-0029/0054).
     # ---------------------------------------------------------------------------------------
     finops_tiers:
+      # Declared-side validation (check-finops-tiers.py, finops-lifecycle.yml) runs ADVISORY: the
+      # script always exits 0 today, so a tier declared here that contradicts the manifest is a
+      # ::warning. Graduating needs the MEASURED classifier (the derive->enforce->show half below);
+      # until that lands there is nothing to compare a declaration against except itself.
+      #
+      # Registered with a date as part of issue #2392: this gate ran advisory with no `enforced` /
+      # `target_enforce_date` on its rule, so check-gate-graduation.sh (ADR-0144) skipped it entirely
+      # and it had no deadline at all.
+      enforced: advisory
+      target_enforce_date: "2026-12-31"   # ADR-0144 — gated on the measured classifier, not on triage
+      blocked_on: "the measured-side classifier must land before the declared side can hard-fail;
+        without it, enforcing would only assert that the file agrees with itself"
+      ci_producer: "openbank-infra/scripts/check-finops-tiers.py"
       tiers:
         T0:                                   # Always-on
           definition: "Money-path HOT path where a cold-start / scaled-to-zero gap is unacceptable, or a regulator-mandated continuous service."

--- a/openbank-infra/gitops/components/payments/domestic-payment-opa-bundle.yaml
+++ b/openbank-infra/gitops/components/payments/domestic-payment-opa-bundle.yaml
@@ -9,7 +9,7 @@ metadata:
     app.kubernetes.io/name: domestic-payment
     app.kubernetes.io/part-of: payments
   annotations:
-    openbank.tech/policy-checksum: "658d40490e649f1f"
+    openbank.tech/policy-checksum: "39ad10c438168a6e"
 data:
   rest.rego: |
     # SPDX-License-Identifier: Apache-2.0
@@ -2786,19 +2786,6 @@ data:
     # MEASURED behaviour by a classifier + CI gate (derive -> enforce -> show, ADR-0029/0054).
     # ---------------------------------------------------------------------------------------
     finops_tiers:
-      # Declared-side validation (check-finops-tiers.py, finops-lifecycle.yml) runs ADVISORY: the
-      # script always exits 0 today, so a tier declared here that contradicts the manifest is a
-      # ::warning. Graduating needs the MEASURED classifier (the derive->enforce->show half below);
-      # until that lands there is nothing to compare a declaration against except itself.
-      #
-      # Registered with a date as part of issue #2392: this gate ran advisory with no `enforced` /
-      # `target_enforce_date` on its rule, so check-gate-graduation.sh (ADR-0144) skipped it entirely
-      # and it had no deadline at all.
-      enforced: advisory
-      target_enforce_date: "2026-12-31"   # ADR-0144 — gated on the measured classifier, not on triage
-      blocked_on: "the measured-side classifier must land before the declared side can hard-fail;
-        without it, enforcing would only assert that the file agrees with itself"
-      ci_producer: "openbank-infra/scripts/check-finops-tiers.py"
       tiers:
         T0:                                   # Always-on
           definition: "Money-path HOT path where a cold-start / scaled-to-zero gap is unacceptable, or a regulator-mandated continuous service."
@@ -2901,6 +2888,9 @@ data:
       enforced: advisory                      # ADR-0057; -> block when the classifier lands
       target_enforce_date: "2026-09-30"   # ADR-0144
       blocked_on: "the measured-signal classifier (http_request_rate, kafka_consumer_lag, cpu/replica utilisation) has not shipped yet — only 2 services have a declared tier today (notification-service, product-catalog)"
+      # Added by issue #2392: the rule carried `enforced`/`target_enforce_date` but never named the
+      # script that produces the finding, so nothing tied the advisory CI step to this deadline.
+      ci_producer: "openbank-infra/scripts/check-finops-tiers.py"
 
     # ---------------------------------------------------------------------------------------
     # FinOps cost-allocation groups — showback business flows (ADR-0062). The /api/finops/costs

--- a/openbank-infra/gitops/components/payments/payments-services.yaml
+++ b/openbank-infra/gitops/components/payments/payments-services.yaml
@@ -42,7 +42,7 @@ spec:
         # Rolls the pods when the OPA bundle changes — subPath mounts do NOT hot-reload.
         # Kept in sync by gen-transaction-opa-bundle.sh via the trailing marker comment
         # (do not hand-edit, do not drop the marker).
-        openbank.tech/policy-checksum: "d23a47015a9f6381" # transaction-opa-bundle
+        openbank.tech/policy-checksum: "27caa9537242c9ea" # transaction-opa-bundle
     spec:
       securityContext:
         runAsNonRoot: true
@@ -375,7 +375,7 @@ spec:
       annotations:
         # Rolls the pods when the OPA bundle changes — subPath mounts do NOT hot-reload.
         # Kept in sync by gen-sepa-payment-opa-bundle.sh (do not hand-edit).
-        openbank.tech/policy-checksum: "7ed9a00a78f805fa"
+        openbank.tech/policy-checksum: "63875d5a61a0558e"
     spec:
       securityContext:
         runAsNonRoot: true
@@ -729,7 +729,7 @@ spec:
         # Rolls the pods when the OPA bundle changes — subPath mounts do NOT hot-reload.
         # Kept in sync by gen-domestic-payment-opa-bundle.sh via the trailing marker
         # comment (do not hand-edit, do not drop the marker).
-        openbank.tech/policy-checksum: "658d40490e649f1f" # domestic-payment-opa-bundle
+        openbank.tech/policy-checksum: "39ad10c438168a6e" # domestic-payment-opa-bundle
     spec:
       securityContext:
         runAsNonRoot: true
@@ -1053,7 +1053,7 @@ spec:
       annotations:
         # Rolls the pods when the OPA bundle changes — subPath mounts do NOT hot-reload.
         # Kept in sync by gen-sepa-instant-opa-bundle.sh (do not hand-edit).
-        openbank.tech/policy-checksum: "a724fbbae9a58610"
+        openbank.tech/policy-checksum: "b788c30c6ad8e5a2"
     spec:
       securityContext:
         runAsNonRoot: true
@@ -1369,7 +1369,7 @@ spec:
         # Rolls the pods when the OPA bundle changes — subPath mounts do NOT hot-reload.
         # Kept in sync by gen-clearing-opa-bundle.sh via the trailing marker comment
         # (do not hand-edit, do not drop the marker).
-        openbank.tech/policy-checksum: "c640e8bd154113c1" # clearing-opa-bundle
+        openbank.tech/policy-checksum: "539ccbf7887678e4" # clearing-opa-bundle
     spec:
       securityContext:
         runAsNonRoot: true
@@ -1658,7 +1658,7 @@ spec:
       annotations:
         # Rolls the pod when the OPA bundle changes (ADR-0034). Value is stamped by
         # gen-standing-order-opa-bundle.sh — do not hand-edit.
-        openbank.tech/policy-checksum: "e9d98d1f7b38cfd7" # standing-order-opa-bundle
+        openbank.tech/policy-checksum: "94dd39d43bf16b32" # standing-order-opa-bundle
     spec:
       securityContext:
         runAsNonRoot: true
@@ -1911,7 +1911,7 @@ spec:
       annotations:
         # Rolls the pods when the OPA bundle changes — subPath mounts do NOT hot-reload.
         # Kept in sync by gen-card-issuance-opa-bundle.sh (do not hand-edit).
-        openbank.tech/policy-checksum: "0bcfc12ad07ac05a"
+        openbank.tech/policy-checksum: "1f164f1a167125de"
     spec:
       securityContext:
         runAsNonRoot: true
@@ -2178,7 +2178,7 @@ spec:
         # Rolls the pods when the OPA bundle changes — subPath mounts do NOT hot-reload.
         # Kept in sync by gen-settlement-opa-bundle.sh via the trailing marker comment
         # (do not hand-edit, do not drop the marker).
-        openbank.tech/policy-checksum: "baaf67bf41b27139" # settlement-opa-bundle
+        openbank.tech/policy-checksum: "21f6ddfae9969c51" # settlement-opa-bundle
     spec:
       securityContext:
         runAsNonRoot: true
@@ -2579,7 +2579,7 @@ spec:
       annotations:
         # Rolls the pods when the OPA bundle changes — subPath mounts do NOT hot-reload.
         # Kept in sync by gen-swift-opa-bundle.sh (do not hand-edit).
-        openbank.tech/policy-checksum: "de7676b58e8c1e35"
+        openbank.tech/policy-checksum: "9c22148d1f051fe9"
     spec:
       securityContext:
         runAsNonRoot: true
@@ -2893,7 +2893,7 @@ spec:
       annotations:
         # Rolls the pods when the OPA bundle changes — subPath mounts do NOT hot-reload.
         # Kept in sync by gen-vop-opa-bundle.sh (do not hand-edit).
-        openbank.tech/policy-checksum: "6352caf3d05b1c3f"
+        openbank.tech/policy-checksum: "c3a57481beb12064"
     spec:
       securityContext:
         runAsNonRoot: true

--- a/openbank-infra/gitops/components/payments/payments-services.yaml
+++ b/openbank-infra/gitops/components/payments/payments-services.yaml
@@ -42,7 +42,7 @@ spec:
         # Rolls the pods when the OPA bundle changes — subPath mounts do NOT hot-reload.
         # Kept in sync by gen-transaction-opa-bundle.sh via the trailing marker comment
         # (do not hand-edit, do not drop the marker).
-        openbank.tech/policy-checksum: "0c363a146f61b975" # transaction-opa-bundle
+        openbank.tech/policy-checksum: "d23a47015a9f6381" # transaction-opa-bundle
     spec:
       securityContext:
         runAsNonRoot: true
@@ -375,7 +375,7 @@ spec:
       annotations:
         # Rolls the pods when the OPA bundle changes — subPath mounts do NOT hot-reload.
         # Kept in sync by gen-sepa-payment-opa-bundle.sh (do not hand-edit).
-        openbank.tech/policy-checksum: "ec66667ec5f81d5e"
+        openbank.tech/policy-checksum: "7ed9a00a78f805fa"
     spec:
       securityContext:
         runAsNonRoot: true
@@ -729,7 +729,7 @@ spec:
         # Rolls the pods when the OPA bundle changes — subPath mounts do NOT hot-reload.
         # Kept in sync by gen-domestic-payment-opa-bundle.sh via the trailing marker
         # comment (do not hand-edit, do not drop the marker).
-        openbank.tech/policy-checksum: "8bc2dee5124ab198" # domestic-payment-opa-bundle
+        openbank.tech/policy-checksum: "658d40490e649f1f" # domestic-payment-opa-bundle
     spec:
       securityContext:
         runAsNonRoot: true
@@ -1053,7 +1053,7 @@ spec:
       annotations:
         # Rolls the pods when the OPA bundle changes — subPath mounts do NOT hot-reload.
         # Kept in sync by gen-sepa-instant-opa-bundle.sh (do not hand-edit).
-        openbank.tech/policy-checksum: "0e3ef7b260b92f2f"
+        openbank.tech/policy-checksum: "a724fbbae9a58610"
     spec:
       securityContext:
         runAsNonRoot: true
@@ -1369,7 +1369,7 @@ spec:
         # Rolls the pods when the OPA bundle changes — subPath mounts do NOT hot-reload.
         # Kept in sync by gen-clearing-opa-bundle.sh via the trailing marker comment
         # (do not hand-edit, do not drop the marker).
-        openbank.tech/policy-checksum: "cac91627170154ae" # clearing-opa-bundle
+        openbank.tech/policy-checksum: "c640e8bd154113c1" # clearing-opa-bundle
     spec:
       securityContext:
         runAsNonRoot: true
@@ -1658,7 +1658,7 @@ spec:
       annotations:
         # Rolls the pod when the OPA bundle changes (ADR-0034). Value is stamped by
         # gen-standing-order-opa-bundle.sh — do not hand-edit.
-        openbank.tech/policy-checksum: "bd54a9e7a91cc902" # standing-order-opa-bundle
+        openbank.tech/policy-checksum: "e9d98d1f7b38cfd7" # standing-order-opa-bundle
     spec:
       securityContext:
         runAsNonRoot: true
@@ -1911,7 +1911,7 @@ spec:
       annotations:
         # Rolls the pods when the OPA bundle changes — subPath mounts do NOT hot-reload.
         # Kept in sync by gen-card-issuance-opa-bundle.sh (do not hand-edit).
-        openbank.tech/policy-checksum: "1091724a64acca05"
+        openbank.tech/policy-checksum: "0bcfc12ad07ac05a"
     spec:
       securityContext:
         runAsNonRoot: true
@@ -2178,7 +2178,7 @@ spec:
         # Rolls the pods when the OPA bundle changes — subPath mounts do NOT hot-reload.
         # Kept in sync by gen-settlement-opa-bundle.sh via the trailing marker comment
         # (do not hand-edit, do not drop the marker).
-        openbank.tech/policy-checksum: "869d473fbdf96b03" # settlement-opa-bundle
+        openbank.tech/policy-checksum: "baaf67bf41b27139" # settlement-opa-bundle
     spec:
       securityContext:
         runAsNonRoot: true
@@ -2579,7 +2579,7 @@ spec:
       annotations:
         # Rolls the pods when the OPA bundle changes — subPath mounts do NOT hot-reload.
         # Kept in sync by gen-swift-opa-bundle.sh (do not hand-edit).
-        openbank.tech/policy-checksum: "2c494fcb4f689765"
+        openbank.tech/policy-checksum: "de7676b58e8c1e35"
     spec:
       securityContext:
         runAsNonRoot: true
@@ -2893,7 +2893,7 @@ spec:
       annotations:
         # Rolls the pods when the OPA bundle changes — subPath mounts do NOT hot-reload.
         # Kept in sync by gen-vop-opa-bundle.sh (do not hand-edit).
-        openbank.tech/policy-checksum: "3a2488a8fd758825"
+        openbank.tech/policy-checksum: "6352caf3d05b1c3f"
     spec:
       securityContext:
         runAsNonRoot: true

--- a/openbank-infra/gitops/components/payments/sepa-instant-opa-bundle.yaml
+++ b/openbank-infra/gitops/components/payments/sepa-instant-opa-bundle.yaml
@@ -9,7 +9,7 @@ metadata:
     app.kubernetes.io/name: sepa-instant
     app.kubernetes.io/part-of: payments
   annotations:
-    openbank.tech/policy-checksum: "0e3ef7b260b92f2f"
+    openbank.tech/policy-checksum: "a724fbbae9a58610"
 data:
   rest.rego: |
     # SPDX-License-Identifier: Apache-2.0
@@ -1824,6 +1824,23 @@ data:
         # (3-dot against the PR base). Findings are ::warning annotations. Flip to enforced =
         # pass --enforce to the script in ci.yml (one-line change).
         ci_producer: "openbank-infra/scripts/check-threat-model-diff.py"
+      mp_messaging_dotted_keys:
+        # SmallRye reactive-messaging config written as a DOTTED key
+        # (`mp.messaging.incoming.x.topic: …`) inside a nested YAML mapping is silently ignored by
+        # SnakeYAML — the channel keeps its default and the consumer subscribes to nothing, with no
+        # error at boot (issue #686). The guard rewrites the shape it can prove wrong.
+        detect: ["<service>/src/main/resources/application.yaml", "mp.messaging.* written as a dotted key under a nested mapping"]
+        require:
+          - "mp.messaging channel config expressed as nested YAML, not a dotted key inside a mapping"
+        gate: dotted-mp-messaging-keys
+        enforced: advisory
+        target_enforce_date: "2026-09-30"   # ADR-0144
+        blocked_on: "1 finding remains fleet-wide; the script already supports --enforce, so graduating
+          is a one-word change in ci.yml once it is cleared"
+        # Registered here as part of issue #2392: this gate ran advisory with no rules.yaml rule at
+        # all, so check-gate-graduation.sh could not see it and it had no deadline. That class is now
+        # itself gated by .github/scripts/check-advisory-gate-registration.py.
+        ci_producer: ".github/scripts/check-dotted-mp-messaging-keys.sh"
       new_service_with_outbox:
         # A service that extends AbstractOutboxEntity / uses OutboxDispatcher but does NOT
         # set openbank.outbox.dispatch-enabled=true silently never dispatches events —
@@ -2742,6 +2759,19 @@ data:
     # MEASURED behaviour by a classifier + CI gate (derive -> enforce -> show, ADR-0029/0054).
     # ---------------------------------------------------------------------------------------
     finops_tiers:
+      # Declared-side validation (check-finops-tiers.py, finops-lifecycle.yml) runs ADVISORY: the
+      # script always exits 0 today, so a tier declared here that contradicts the manifest is a
+      # ::warning. Graduating needs the MEASURED classifier (the derive->enforce->show half below);
+      # until that lands there is nothing to compare a declaration against except itself.
+      #
+      # Registered with a date as part of issue #2392: this gate ran advisory with no `enforced` /
+      # `target_enforce_date` on its rule, so check-gate-graduation.sh (ADR-0144) skipped it entirely
+      # and it had no deadline at all.
+      enforced: advisory
+      target_enforce_date: "2026-12-31"   # ADR-0144 — gated on the measured classifier, not on triage
+      blocked_on: "the measured-side classifier must land before the declared side can hard-fail;
+        without it, enforcing would only assert that the file agrees with itself"
+      ci_producer: "openbank-infra/scripts/check-finops-tiers.py"
       tiers:
         T0:                                   # Always-on
           definition: "Money-path HOT path where a cold-start / scaled-to-zero gap is unacceptable, or a regulator-mandated continuous service."

--- a/openbank-infra/gitops/components/payments/sepa-instant-opa-bundle.yaml
+++ b/openbank-infra/gitops/components/payments/sepa-instant-opa-bundle.yaml
@@ -9,7 +9,7 @@ metadata:
     app.kubernetes.io/name: sepa-instant
     app.kubernetes.io/part-of: payments
   annotations:
-    openbank.tech/policy-checksum: "a724fbbae9a58610"
+    openbank.tech/policy-checksum: "b788c30c6ad8e5a2"
 data:
   rest.rego: |
     # SPDX-License-Identifier: Apache-2.0
@@ -2759,19 +2759,6 @@ data:
     # MEASURED behaviour by a classifier + CI gate (derive -> enforce -> show, ADR-0029/0054).
     # ---------------------------------------------------------------------------------------
     finops_tiers:
-      # Declared-side validation (check-finops-tiers.py, finops-lifecycle.yml) runs ADVISORY: the
-      # script always exits 0 today, so a tier declared here that contradicts the manifest is a
-      # ::warning. Graduating needs the MEASURED classifier (the derive->enforce->show half below);
-      # until that lands there is nothing to compare a declaration against except itself.
-      #
-      # Registered with a date as part of issue #2392: this gate ran advisory with no `enforced` /
-      # `target_enforce_date` on its rule, so check-gate-graduation.sh (ADR-0144) skipped it entirely
-      # and it had no deadline at all.
-      enforced: advisory
-      target_enforce_date: "2026-12-31"   # ADR-0144 — gated on the measured classifier, not on triage
-      blocked_on: "the measured-side classifier must land before the declared side can hard-fail;
-        without it, enforcing would only assert that the file agrees with itself"
-      ci_producer: "openbank-infra/scripts/check-finops-tiers.py"
       tiers:
         T0:                                   # Always-on
           definition: "Money-path HOT path where a cold-start / scaled-to-zero gap is unacceptable, or a regulator-mandated continuous service."
@@ -2874,6 +2861,9 @@ data:
       enforced: advisory                      # ADR-0057; -> block when the classifier lands
       target_enforce_date: "2026-09-30"   # ADR-0144
       blocked_on: "the measured-signal classifier (http_request_rate, kafka_consumer_lag, cpu/replica utilisation) has not shipped yet — only 2 services have a declared tier today (notification-service, product-catalog)"
+      # Added by issue #2392: the rule carried `enforced`/`target_enforce_date` but never named the
+      # script that produces the finding, so nothing tied the advisory CI step to this deadline.
+      ci_producer: "openbank-infra/scripts/check-finops-tiers.py"
 
     # ---------------------------------------------------------------------------------------
     # FinOps cost-allocation groups — showback business flows (ADR-0062). The /api/finops/costs

--- a/openbank-infra/gitops/components/payments/sepa-payment-opa-bundle.yaml
+++ b/openbank-infra/gitops/components/payments/sepa-payment-opa-bundle.yaml
@@ -9,7 +9,7 @@ metadata:
     app.kubernetes.io/name: sepa-payment
     app.kubernetes.io/part-of: payments
   annotations:
-    openbank.tech/policy-checksum: "7ed9a00a78f805fa"
+    openbank.tech/policy-checksum: "63875d5a61a0558e"
 data:
   rest.rego: |
     # SPDX-License-Identifier: Apache-2.0
@@ -2780,19 +2780,6 @@ data:
     # MEASURED behaviour by a classifier + CI gate (derive -> enforce -> show, ADR-0029/0054).
     # ---------------------------------------------------------------------------------------
     finops_tiers:
-      # Declared-side validation (check-finops-tiers.py, finops-lifecycle.yml) runs ADVISORY: the
-      # script always exits 0 today, so a tier declared here that contradicts the manifest is a
-      # ::warning. Graduating needs the MEASURED classifier (the derive->enforce->show half below);
-      # until that lands there is nothing to compare a declaration against except itself.
-      #
-      # Registered with a date as part of issue #2392: this gate ran advisory with no `enforced` /
-      # `target_enforce_date` on its rule, so check-gate-graduation.sh (ADR-0144) skipped it entirely
-      # and it had no deadline at all.
-      enforced: advisory
-      target_enforce_date: "2026-12-31"   # ADR-0144 — gated on the measured classifier, not on triage
-      blocked_on: "the measured-side classifier must land before the declared side can hard-fail;
-        without it, enforcing would only assert that the file agrees with itself"
-      ci_producer: "openbank-infra/scripts/check-finops-tiers.py"
       tiers:
         T0:                                   # Always-on
           definition: "Money-path HOT path where a cold-start / scaled-to-zero gap is unacceptable, or a regulator-mandated continuous service."
@@ -2895,6 +2882,9 @@ data:
       enforced: advisory                      # ADR-0057; -> block when the classifier lands
       target_enforce_date: "2026-09-30"   # ADR-0144
       blocked_on: "the measured-signal classifier (http_request_rate, kafka_consumer_lag, cpu/replica utilisation) has not shipped yet — only 2 services have a declared tier today (notification-service, product-catalog)"
+      # Added by issue #2392: the rule carried `enforced`/`target_enforce_date` but never named the
+      # script that produces the finding, so nothing tied the advisory CI step to this deadline.
+      ci_producer: "openbank-infra/scripts/check-finops-tiers.py"
 
     # ---------------------------------------------------------------------------------------
     # FinOps cost-allocation groups — showback business flows (ADR-0062). The /api/finops/costs

--- a/openbank-infra/gitops/components/payments/sepa-payment-opa-bundle.yaml
+++ b/openbank-infra/gitops/components/payments/sepa-payment-opa-bundle.yaml
@@ -9,7 +9,7 @@ metadata:
     app.kubernetes.io/name: sepa-payment
     app.kubernetes.io/part-of: payments
   annotations:
-    openbank.tech/policy-checksum: "ec66667ec5f81d5e"
+    openbank.tech/policy-checksum: "7ed9a00a78f805fa"
 data:
   rest.rego: |
     # SPDX-License-Identifier: Apache-2.0
@@ -1845,6 +1845,23 @@ data:
         # (3-dot against the PR base). Findings are ::warning annotations. Flip to enforced =
         # pass --enforce to the script in ci.yml (one-line change).
         ci_producer: "openbank-infra/scripts/check-threat-model-diff.py"
+      mp_messaging_dotted_keys:
+        # SmallRye reactive-messaging config written as a DOTTED key
+        # (`mp.messaging.incoming.x.topic: …`) inside a nested YAML mapping is silently ignored by
+        # SnakeYAML — the channel keeps its default and the consumer subscribes to nothing, with no
+        # error at boot (issue #686). The guard rewrites the shape it can prove wrong.
+        detect: ["<service>/src/main/resources/application.yaml", "mp.messaging.* written as a dotted key under a nested mapping"]
+        require:
+          - "mp.messaging channel config expressed as nested YAML, not a dotted key inside a mapping"
+        gate: dotted-mp-messaging-keys
+        enforced: advisory
+        target_enforce_date: "2026-09-30"   # ADR-0144
+        blocked_on: "1 finding remains fleet-wide; the script already supports --enforce, so graduating
+          is a one-word change in ci.yml once it is cleared"
+        # Registered here as part of issue #2392: this gate ran advisory with no rules.yaml rule at
+        # all, so check-gate-graduation.sh could not see it and it had no deadline. That class is now
+        # itself gated by .github/scripts/check-advisory-gate-registration.py.
+        ci_producer: ".github/scripts/check-dotted-mp-messaging-keys.sh"
       new_service_with_outbox:
         # A service that extends AbstractOutboxEntity / uses OutboxDispatcher but does NOT
         # set openbank.outbox.dispatch-enabled=true silently never dispatches events —
@@ -2763,6 +2780,19 @@ data:
     # MEASURED behaviour by a classifier + CI gate (derive -> enforce -> show, ADR-0029/0054).
     # ---------------------------------------------------------------------------------------
     finops_tiers:
+      # Declared-side validation (check-finops-tiers.py, finops-lifecycle.yml) runs ADVISORY: the
+      # script always exits 0 today, so a tier declared here that contradicts the manifest is a
+      # ::warning. Graduating needs the MEASURED classifier (the derive->enforce->show half below);
+      # until that lands there is nothing to compare a declaration against except itself.
+      #
+      # Registered with a date as part of issue #2392: this gate ran advisory with no `enforced` /
+      # `target_enforce_date` on its rule, so check-gate-graduation.sh (ADR-0144) skipped it entirely
+      # and it had no deadline at all.
+      enforced: advisory
+      target_enforce_date: "2026-12-31"   # ADR-0144 — gated on the measured classifier, not on triage
+      blocked_on: "the measured-side classifier must land before the declared side can hard-fail;
+        without it, enforcing would only assert that the file agrees with itself"
+      ci_producer: "openbank-infra/scripts/check-finops-tiers.py"
       tiers:
         T0:                                   # Always-on
           definition: "Money-path HOT path where a cold-start / scaled-to-zero gap is unacceptable, or a regulator-mandated continuous service."

--- a/openbank-infra/gitops/components/payments/settlement-opa-bundle.yaml
+++ b/openbank-infra/gitops/components/payments/settlement-opa-bundle.yaml
@@ -9,7 +9,7 @@ metadata:
     app.kubernetes.io/name: settlement-service
     app.kubernetes.io/part-of: payments
   annotations:
-    openbank.tech/policy-checksum: "869d473fbdf96b03"
+    openbank.tech/policy-checksum: "baaf67bf41b27139"
 data:
   rest.rego: |
     # SPDX-License-Identifier: Apache-2.0
@@ -1825,6 +1825,23 @@ data:
         # (3-dot against the PR base). Findings are ::warning annotations. Flip to enforced =
         # pass --enforce to the script in ci.yml (one-line change).
         ci_producer: "openbank-infra/scripts/check-threat-model-diff.py"
+      mp_messaging_dotted_keys:
+        # SmallRye reactive-messaging config written as a DOTTED key
+        # (`mp.messaging.incoming.x.topic: …`) inside a nested YAML mapping is silently ignored by
+        # SnakeYAML — the channel keeps its default and the consumer subscribes to nothing, with no
+        # error at boot (issue #686). The guard rewrites the shape it can prove wrong.
+        detect: ["<service>/src/main/resources/application.yaml", "mp.messaging.* written as a dotted key under a nested mapping"]
+        require:
+          - "mp.messaging channel config expressed as nested YAML, not a dotted key inside a mapping"
+        gate: dotted-mp-messaging-keys
+        enforced: advisory
+        target_enforce_date: "2026-09-30"   # ADR-0144
+        blocked_on: "1 finding remains fleet-wide; the script already supports --enforce, so graduating
+          is a one-word change in ci.yml once it is cleared"
+        # Registered here as part of issue #2392: this gate ran advisory with no rules.yaml rule at
+        # all, so check-gate-graduation.sh could not see it and it had no deadline. That class is now
+        # itself gated by .github/scripts/check-advisory-gate-registration.py.
+        ci_producer: ".github/scripts/check-dotted-mp-messaging-keys.sh"
       new_service_with_outbox:
         # A service that extends AbstractOutboxEntity / uses OutboxDispatcher but does NOT
         # set openbank.outbox.dispatch-enabled=true silently never dispatches events —
@@ -2743,6 +2760,19 @@ data:
     # MEASURED behaviour by a classifier + CI gate (derive -> enforce -> show, ADR-0029/0054).
     # ---------------------------------------------------------------------------------------
     finops_tiers:
+      # Declared-side validation (check-finops-tiers.py, finops-lifecycle.yml) runs ADVISORY: the
+      # script always exits 0 today, so a tier declared here that contradicts the manifest is a
+      # ::warning. Graduating needs the MEASURED classifier (the derive->enforce->show half below);
+      # until that lands there is nothing to compare a declaration against except itself.
+      #
+      # Registered with a date as part of issue #2392: this gate ran advisory with no `enforced` /
+      # `target_enforce_date` on its rule, so check-gate-graduation.sh (ADR-0144) skipped it entirely
+      # and it had no deadline at all.
+      enforced: advisory
+      target_enforce_date: "2026-12-31"   # ADR-0144 — gated on the measured classifier, not on triage
+      blocked_on: "the measured-side classifier must land before the declared side can hard-fail;
+        without it, enforcing would only assert that the file agrees with itself"
+      ci_producer: "openbank-infra/scripts/check-finops-tiers.py"
       tiers:
         T0:                                   # Always-on
           definition: "Money-path HOT path where a cold-start / scaled-to-zero gap is unacceptable, or a regulator-mandated continuous service."

--- a/openbank-infra/gitops/components/payments/settlement-opa-bundle.yaml
+++ b/openbank-infra/gitops/components/payments/settlement-opa-bundle.yaml
@@ -9,7 +9,7 @@ metadata:
     app.kubernetes.io/name: settlement-service
     app.kubernetes.io/part-of: payments
   annotations:
-    openbank.tech/policy-checksum: "baaf67bf41b27139"
+    openbank.tech/policy-checksum: "21f6ddfae9969c51"
 data:
   rest.rego: |
     # SPDX-License-Identifier: Apache-2.0
@@ -2760,19 +2760,6 @@ data:
     # MEASURED behaviour by a classifier + CI gate (derive -> enforce -> show, ADR-0029/0054).
     # ---------------------------------------------------------------------------------------
     finops_tiers:
-      # Declared-side validation (check-finops-tiers.py, finops-lifecycle.yml) runs ADVISORY: the
-      # script always exits 0 today, so a tier declared here that contradicts the manifest is a
-      # ::warning. Graduating needs the MEASURED classifier (the derive->enforce->show half below);
-      # until that lands there is nothing to compare a declaration against except itself.
-      #
-      # Registered with a date as part of issue #2392: this gate ran advisory with no `enforced` /
-      # `target_enforce_date` on its rule, so check-gate-graduation.sh (ADR-0144) skipped it entirely
-      # and it had no deadline at all.
-      enforced: advisory
-      target_enforce_date: "2026-12-31"   # ADR-0144 — gated on the measured classifier, not on triage
-      blocked_on: "the measured-side classifier must land before the declared side can hard-fail;
-        without it, enforcing would only assert that the file agrees with itself"
-      ci_producer: "openbank-infra/scripts/check-finops-tiers.py"
       tiers:
         T0:                                   # Always-on
           definition: "Money-path HOT path where a cold-start / scaled-to-zero gap is unacceptable, or a regulator-mandated continuous service."
@@ -2875,6 +2862,9 @@ data:
       enforced: advisory                      # ADR-0057; -> block when the classifier lands
       target_enforce_date: "2026-09-30"   # ADR-0144
       blocked_on: "the measured-signal classifier (http_request_rate, kafka_consumer_lag, cpu/replica utilisation) has not shipped yet — only 2 services have a declared tier today (notification-service, product-catalog)"
+      # Added by issue #2392: the rule carried `enforced`/`target_enforce_date` but never named the
+      # script that produces the finding, so nothing tied the advisory CI step to this deadline.
+      ci_producer: "openbank-infra/scripts/check-finops-tiers.py"
 
     # ---------------------------------------------------------------------------------------
     # FinOps cost-allocation groups — showback business flows (ADR-0062). The /api/finops/costs

--- a/openbank-infra/gitops/components/payments/standing-order-opa-bundle.yaml
+++ b/openbank-infra/gitops/components/payments/standing-order-opa-bundle.yaml
@@ -9,7 +9,7 @@ metadata:
     app.kubernetes.io/name: standing-order-service
     app.kubernetes.io/part-of: payments
   annotations:
-    openbank.tech/policy-checksum: "bd54a9e7a91cc902"
+    openbank.tech/policy-checksum: "e9d98d1f7b38cfd7"
 data:
   rest.rego: |
     # SPDX-License-Identifier: Apache-2.0
@@ -1810,6 +1810,23 @@ data:
         # (3-dot against the PR base). Findings are ::warning annotations. Flip to enforced =
         # pass --enforce to the script in ci.yml (one-line change).
         ci_producer: "openbank-infra/scripts/check-threat-model-diff.py"
+      mp_messaging_dotted_keys:
+        # SmallRye reactive-messaging config written as a DOTTED key
+        # (`mp.messaging.incoming.x.topic: …`) inside a nested YAML mapping is silently ignored by
+        # SnakeYAML — the channel keeps its default and the consumer subscribes to nothing, with no
+        # error at boot (issue #686). The guard rewrites the shape it can prove wrong.
+        detect: ["<service>/src/main/resources/application.yaml", "mp.messaging.* written as a dotted key under a nested mapping"]
+        require:
+          - "mp.messaging channel config expressed as nested YAML, not a dotted key inside a mapping"
+        gate: dotted-mp-messaging-keys
+        enforced: advisory
+        target_enforce_date: "2026-09-30"   # ADR-0144
+        blocked_on: "1 finding remains fleet-wide; the script already supports --enforce, so graduating
+          is a one-word change in ci.yml once it is cleared"
+        # Registered here as part of issue #2392: this gate ran advisory with no rules.yaml rule at
+        # all, so check-gate-graduation.sh could not see it and it had no deadline. That class is now
+        # itself gated by .github/scripts/check-advisory-gate-registration.py.
+        ci_producer: ".github/scripts/check-dotted-mp-messaging-keys.sh"
       new_service_with_outbox:
         # A service that extends AbstractOutboxEntity / uses OutboxDispatcher but does NOT
         # set openbank.outbox.dispatch-enabled=true silently never dispatches events —
@@ -2728,6 +2745,19 @@ data:
     # MEASURED behaviour by a classifier + CI gate (derive -> enforce -> show, ADR-0029/0054).
     # ---------------------------------------------------------------------------------------
     finops_tiers:
+      # Declared-side validation (check-finops-tiers.py, finops-lifecycle.yml) runs ADVISORY: the
+      # script always exits 0 today, so a tier declared here that contradicts the manifest is a
+      # ::warning. Graduating needs the MEASURED classifier (the derive->enforce->show half below);
+      # until that lands there is nothing to compare a declaration against except itself.
+      #
+      # Registered with a date as part of issue #2392: this gate ran advisory with no `enforced` /
+      # `target_enforce_date` on its rule, so check-gate-graduation.sh (ADR-0144) skipped it entirely
+      # and it had no deadline at all.
+      enforced: advisory
+      target_enforce_date: "2026-12-31"   # ADR-0144 — gated on the measured classifier, not on triage
+      blocked_on: "the measured-side classifier must land before the declared side can hard-fail;
+        without it, enforcing would only assert that the file agrees with itself"
+      ci_producer: "openbank-infra/scripts/check-finops-tiers.py"
       tiers:
         T0:                                   # Always-on
           definition: "Money-path HOT path where a cold-start / scaled-to-zero gap is unacceptable, or a regulator-mandated continuous service."

--- a/openbank-infra/gitops/components/payments/standing-order-opa-bundle.yaml
+++ b/openbank-infra/gitops/components/payments/standing-order-opa-bundle.yaml
@@ -9,7 +9,7 @@ metadata:
     app.kubernetes.io/name: standing-order-service
     app.kubernetes.io/part-of: payments
   annotations:
-    openbank.tech/policy-checksum: "e9d98d1f7b38cfd7"
+    openbank.tech/policy-checksum: "94dd39d43bf16b32"
 data:
   rest.rego: |
     # SPDX-License-Identifier: Apache-2.0
@@ -2745,19 +2745,6 @@ data:
     # MEASURED behaviour by a classifier + CI gate (derive -> enforce -> show, ADR-0029/0054).
     # ---------------------------------------------------------------------------------------
     finops_tiers:
-      # Declared-side validation (check-finops-tiers.py, finops-lifecycle.yml) runs ADVISORY: the
-      # script always exits 0 today, so a tier declared here that contradicts the manifest is a
-      # ::warning. Graduating needs the MEASURED classifier (the derive->enforce->show half below);
-      # until that lands there is nothing to compare a declaration against except itself.
-      #
-      # Registered with a date as part of issue #2392: this gate ran advisory with no `enforced` /
-      # `target_enforce_date` on its rule, so check-gate-graduation.sh (ADR-0144) skipped it entirely
-      # and it had no deadline at all.
-      enforced: advisory
-      target_enforce_date: "2026-12-31"   # ADR-0144 — gated on the measured classifier, not on triage
-      blocked_on: "the measured-side classifier must land before the declared side can hard-fail;
-        without it, enforcing would only assert that the file agrees with itself"
-      ci_producer: "openbank-infra/scripts/check-finops-tiers.py"
       tiers:
         T0:                                   # Always-on
           definition: "Money-path HOT path where a cold-start / scaled-to-zero gap is unacceptable, or a regulator-mandated continuous service."
@@ -2860,6 +2847,9 @@ data:
       enforced: advisory                      # ADR-0057; -> block when the classifier lands
       target_enforce_date: "2026-09-30"   # ADR-0144
       blocked_on: "the measured-signal classifier (http_request_rate, kafka_consumer_lag, cpu/replica utilisation) has not shipped yet — only 2 services have a declared tier today (notification-service, product-catalog)"
+      # Added by issue #2392: the rule carried `enforced`/`target_enforce_date` but never named the
+      # script that produces the finding, so nothing tied the advisory CI step to this deadline.
+      ci_producer: "openbank-infra/scripts/check-finops-tiers.py"
 
     # ---------------------------------------------------------------------------------------
     # FinOps cost-allocation groups — showback business flows (ADR-0062). The /api/finops/costs

--- a/openbank-infra/gitops/components/payments/swift-opa-bundle.yaml
+++ b/openbank-infra/gitops/components/payments/swift-opa-bundle.yaml
@@ -9,7 +9,7 @@ metadata:
     app.kubernetes.io/name: swift-service
     app.kubernetes.io/part-of: payments
   annotations:
-    openbank.tech/policy-checksum: "de7676b58e8c1e35"
+    openbank.tech/policy-checksum: "9c22148d1f051fe9"
 data:
   rest.rego: |
     # SPDX-License-Identifier: Apache-2.0
@@ -2763,19 +2763,6 @@ data:
     # MEASURED behaviour by a classifier + CI gate (derive -> enforce -> show, ADR-0029/0054).
     # ---------------------------------------------------------------------------------------
     finops_tiers:
-      # Declared-side validation (check-finops-tiers.py, finops-lifecycle.yml) runs ADVISORY: the
-      # script always exits 0 today, so a tier declared here that contradicts the manifest is a
-      # ::warning. Graduating needs the MEASURED classifier (the derive->enforce->show half below);
-      # until that lands there is nothing to compare a declaration against except itself.
-      #
-      # Registered with a date as part of issue #2392: this gate ran advisory with no `enforced` /
-      # `target_enforce_date` on its rule, so check-gate-graduation.sh (ADR-0144) skipped it entirely
-      # and it had no deadline at all.
-      enforced: advisory
-      target_enforce_date: "2026-12-31"   # ADR-0144 — gated on the measured classifier, not on triage
-      blocked_on: "the measured-side classifier must land before the declared side can hard-fail;
-        without it, enforcing would only assert that the file agrees with itself"
-      ci_producer: "openbank-infra/scripts/check-finops-tiers.py"
       tiers:
         T0:                                   # Always-on
           definition: "Money-path HOT path where a cold-start / scaled-to-zero gap is unacceptable, or a regulator-mandated continuous service."
@@ -2878,6 +2865,9 @@ data:
       enforced: advisory                      # ADR-0057; -> block when the classifier lands
       target_enforce_date: "2026-09-30"   # ADR-0144
       blocked_on: "the measured-signal classifier (http_request_rate, kafka_consumer_lag, cpu/replica utilisation) has not shipped yet — only 2 services have a declared tier today (notification-service, product-catalog)"
+      # Added by issue #2392: the rule carried `enforced`/`target_enforce_date` but never named the
+      # script that produces the finding, so nothing tied the advisory CI step to this deadline.
+      ci_producer: "openbank-infra/scripts/check-finops-tiers.py"
 
     # ---------------------------------------------------------------------------------------
     # FinOps cost-allocation groups — showback business flows (ADR-0062). The /api/finops/costs

--- a/openbank-infra/gitops/components/payments/swift-opa-bundle.yaml
+++ b/openbank-infra/gitops/components/payments/swift-opa-bundle.yaml
@@ -9,7 +9,7 @@ metadata:
     app.kubernetes.io/name: swift-service
     app.kubernetes.io/part-of: payments
   annotations:
-    openbank.tech/policy-checksum: "2c494fcb4f689765"
+    openbank.tech/policy-checksum: "de7676b58e8c1e35"
 data:
   rest.rego: |
     # SPDX-License-Identifier: Apache-2.0
@@ -1828,6 +1828,23 @@ data:
         # (3-dot against the PR base). Findings are ::warning annotations. Flip to enforced =
         # pass --enforce to the script in ci.yml (one-line change).
         ci_producer: "openbank-infra/scripts/check-threat-model-diff.py"
+      mp_messaging_dotted_keys:
+        # SmallRye reactive-messaging config written as a DOTTED key
+        # (`mp.messaging.incoming.x.topic: …`) inside a nested YAML mapping is silently ignored by
+        # SnakeYAML — the channel keeps its default and the consumer subscribes to nothing, with no
+        # error at boot (issue #686). The guard rewrites the shape it can prove wrong.
+        detect: ["<service>/src/main/resources/application.yaml", "mp.messaging.* written as a dotted key under a nested mapping"]
+        require:
+          - "mp.messaging channel config expressed as nested YAML, not a dotted key inside a mapping"
+        gate: dotted-mp-messaging-keys
+        enforced: advisory
+        target_enforce_date: "2026-09-30"   # ADR-0144
+        blocked_on: "1 finding remains fleet-wide; the script already supports --enforce, so graduating
+          is a one-word change in ci.yml once it is cleared"
+        # Registered here as part of issue #2392: this gate ran advisory with no rules.yaml rule at
+        # all, so check-gate-graduation.sh could not see it and it had no deadline. That class is now
+        # itself gated by .github/scripts/check-advisory-gate-registration.py.
+        ci_producer: ".github/scripts/check-dotted-mp-messaging-keys.sh"
       new_service_with_outbox:
         # A service that extends AbstractOutboxEntity / uses OutboxDispatcher but does NOT
         # set openbank.outbox.dispatch-enabled=true silently never dispatches events —
@@ -2746,6 +2763,19 @@ data:
     # MEASURED behaviour by a classifier + CI gate (derive -> enforce -> show, ADR-0029/0054).
     # ---------------------------------------------------------------------------------------
     finops_tiers:
+      # Declared-side validation (check-finops-tiers.py, finops-lifecycle.yml) runs ADVISORY: the
+      # script always exits 0 today, so a tier declared here that contradicts the manifest is a
+      # ::warning. Graduating needs the MEASURED classifier (the derive->enforce->show half below);
+      # until that lands there is nothing to compare a declaration against except itself.
+      #
+      # Registered with a date as part of issue #2392: this gate ran advisory with no `enforced` /
+      # `target_enforce_date` on its rule, so check-gate-graduation.sh (ADR-0144) skipped it entirely
+      # and it had no deadline at all.
+      enforced: advisory
+      target_enforce_date: "2026-12-31"   # ADR-0144 — gated on the measured classifier, not on triage
+      blocked_on: "the measured-side classifier must land before the declared side can hard-fail;
+        without it, enforcing would only assert that the file agrees with itself"
+      ci_producer: "openbank-infra/scripts/check-finops-tiers.py"
       tiers:
         T0:                                   # Always-on
           definition: "Money-path HOT path where a cold-start / scaled-to-zero gap is unacceptable, or a regulator-mandated continuous service."

--- a/openbank-infra/gitops/components/payments/transaction-opa-bundle.yaml
+++ b/openbank-infra/gitops/components/payments/transaction-opa-bundle.yaml
@@ -9,7 +9,7 @@ metadata:
     app.kubernetes.io/name: transaction-service
     app.kubernetes.io/part-of: payments
   annotations:
-    openbank.tech/policy-checksum: "d23a47015a9f6381"
+    openbank.tech/policy-checksum: "27caa9537242c9ea"
 data:
   rest.rego: |
     # SPDX-License-Identifier: Apache-2.0
@@ -2816,19 +2816,6 @@ data:
     # MEASURED behaviour by a classifier + CI gate (derive -> enforce -> show, ADR-0029/0054).
     # ---------------------------------------------------------------------------------------
     finops_tiers:
-      # Declared-side validation (check-finops-tiers.py, finops-lifecycle.yml) runs ADVISORY: the
-      # script always exits 0 today, so a tier declared here that contradicts the manifest is a
-      # ::warning. Graduating needs the MEASURED classifier (the derive->enforce->show half below);
-      # until that lands there is nothing to compare a declaration against except itself.
-      #
-      # Registered with a date as part of issue #2392: this gate ran advisory with no `enforced` /
-      # `target_enforce_date` on its rule, so check-gate-graduation.sh (ADR-0144) skipped it entirely
-      # and it had no deadline at all.
-      enforced: advisory
-      target_enforce_date: "2026-12-31"   # ADR-0144 — gated on the measured classifier, not on triage
-      blocked_on: "the measured-side classifier must land before the declared side can hard-fail;
-        without it, enforcing would only assert that the file agrees with itself"
-      ci_producer: "openbank-infra/scripts/check-finops-tiers.py"
       tiers:
         T0:                                   # Always-on
           definition: "Money-path HOT path where a cold-start / scaled-to-zero gap is unacceptable, or a regulator-mandated continuous service."
@@ -2931,6 +2918,9 @@ data:
       enforced: advisory                      # ADR-0057; -> block when the classifier lands
       target_enforce_date: "2026-09-30"   # ADR-0144
       blocked_on: "the measured-signal classifier (http_request_rate, kafka_consumer_lag, cpu/replica utilisation) has not shipped yet — only 2 services have a declared tier today (notification-service, product-catalog)"
+      # Added by issue #2392: the rule carried `enforced`/`target_enforce_date` but never named the
+      # script that produces the finding, so nothing tied the advisory CI step to this deadline.
+      ci_producer: "openbank-infra/scripts/check-finops-tiers.py"
 
     # ---------------------------------------------------------------------------------------
     # FinOps cost-allocation groups — showback business flows (ADR-0062). The /api/finops/costs

--- a/openbank-infra/gitops/components/payments/transaction-opa-bundle.yaml
+++ b/openbank-infra/gitops/components/payments/transaction-opa-bundle.yaml
@@ -9,7 +9,7 @@ metadata:
     app.kubernetes.io/name: transaction-service
     app.kubernetes.io/part-of: payments
   annotations:
-    openbank.tech/policy-checksum: "0c363a146f61b975"
+    openbank.tech/policy-checksum: "d23a47015a9f6381"
 data:
   rest.rego: |
     # SPDX-License-Identifier: Apache-2.0
@@ -1881,6 +1881,23 @@ data:
         # (3-dot against the PR base). Findings are ::warning annotations. Flip to enforced =
         # pass --enforce to the script in ci.yml (one-line change).
         ci_producer: "openbank-infra/scripts/check-threat-model-diff.py"
+      mp_messaging_dotted_keys:
+        # SmallRye reactive-messaging config written as a DOTTED key
+        # (`mp.messaging.incoming.x.topic: …`) inside a nested YAML mapping is silently ignored by
+        # SnakeYAML — the channel keeps its default and the consumer subscribes to nothing, with no
+        # error at boot (issue #686). The guard rewrites the shape it can prove wrong.
+        detect: ["<service>/src/main/resources/application.yaml", "mp.messaging.* written as a dotted key under a nested mapping"]
+        require:
+          - "mp.messaging channel config expressed as nested YAML, not a dotted key inside a mapping"
+        gate: dotted-mp-messaging-keys
+        enforced: advisory
+        target_enforce_date: "2026-09-30"   # ADR-0144
+        blocked_on: "1 finding remains fleet-wide; the script already supports --enforce, so graduating
+          is a one-word change in ci.yml once it is cleared"
+        # Registered here as part of issue #2392: this gate ran advisory with no rules.yaml rule at
+        # all, so check-gate-graduation.sh could not see it and it had no deadline. That class is now
+        # itself gated by .github/scripts/check-advisory-gate-registration.py.
+        ci_producer: ".github/scripts/check-dotted-mp-messaging-keys.sh"
       new_service_with_outbox:
         # A service that extends AbstractOutboxEntity / uses OutboxDispatcher but does NOT
         # set openbank.outbox.dispatch-enabled=true silently never dispatches events —
@@ -2799,6 +2816,19 @@ data:
     # MEASURED behaviour by a classifier + CI gate (derive -> enforce -> show, ADR-0029/0054).
     # ---------------------------------------------------------------------------------------
     finops_tiers:
+      # Declared-side validation (check-finops-tiers.py, finops-lifecycle.yml) runs ADVISORY: the
+      # script always exits 0 today, so a tier declared here that contradicts the manifest is a
+      # ::warning. Graduating needs the MEASURED classifier (the derive->enforce->show half below);
+      # until that lands there is nothing to compare a declaration against except itself.
+      #
+      # Registered with a date as part of issue #2392: this gate ran advisory with no `enforced` /
+      # `target_enforce_date` on its rule, so check-gate-graduation.sh (ADR-0144) skipped it entirely
+      # and it had no deadline at all.
+      enforced: advisory
+      target_enforce_date: "2026-12-31"   # ADR-0144 — gated on the measured classifier, not on triage
+      blocked_on: "the measured-side classifier must land before the declared side can hard-fail;
+        without it, enforcing would only assert that the file agrees with itself"
+      ci_producer: "openbank-infra/scripts/check-finops-tiers.py"
       tiers:
         T0:                                   # Always-on
           definition: "Money-path HOT path where a cold-start / scaled-to-zero gap is unacceptable, or a regulator-mandated continuous service."

--- a/openbank-infra/gitops/components/payments/vop-opa-bundle.yaml
+++ b/openbank-infra/gitops/components/payments/vop-opa-bundle.yaml
@@ -9,7 +9,7 @@ metadata:
     app.kubernetes.io/name: vop-service
     app.kubernetes.io/part-of: payments
   annotations:
-    openbank.tech/policy-checksum: "6352caf3d05b1c3f"
+    openbank.tech/policy-checksum: "c3a57481beb12064"
 data:
   rest.rego: |
     # SPDX-License-Identifier: Apache-2.0
@@ -2767,19 +2767,6 @@ data:
     # MEASURED behaviour by a classifier + CI gate (derive -> enforce -> show, ADR-0029/0054).
     # ---------------------------------------------------------------------------------------
     finops_tiers:
-      # Declared-side validation (check-finops-tiers.py, finops-lifecycle.yml) runs ADVISORY: the
-      # script always exits 0 today, so a tier declared here that contradicts the manifest is a
-      # ::warning. Graduating needs the MEASURED classifier (the derive->enforce->show half below);
-      # until that lands there is nothing to compare a declaration against except itself.
-      #
-      # Registered with a date as part of issue #2392: this gate ran advisory with no `enforced` /
-      # `target_enforce_date` on its rule, so check-gate-graduation.sh (ADR-0144) skipped it entirely
-      # and it had no deadline at all.
-      enforced: advisory
-      target_enforce_date: "2026-12-31"   # ADR-0144 — gated on the measured classifier, not on triage
-      blocked_on: "the measured-side classifier must land before the declared side can hard-fail;
-        without it, enforcing would only assert that the file agrees with itself"
-      ci_producer: "openbank-infra/scripts/check-finops-tiers.py"
       tiers:
         T0:                                   # Always-on
           definition: "Money-path HOT path where a cold-start / scaled-to-zero gap is unacceptable, or a regulator-mandated continuous service."
@@ -2882,6 +2869,9 @@ data:
       enforced: advisory                      # ADR-0057; -> block when the classifier lands
       target_enforce_date: "2026-09-30"   # ADR-0144
       blocked_on: "the measured-signal classifier (http_request_rate, kafka_consumer_lag, cpu/replica utilisation) has not shipped yet — only 2 services have a declared tier today (notification-service, product-catalog)"
+      # Added by issue #2392: the rule carried `enforced`/`target_enforce_date` but never named the
+      # script that produces the finding, so nothing tied the advisory CI step to this deadline.
+      ci_producer: "openbank-infra/scripts/check-finops-tiers.py"
 
     # ---------------------------------------------------------------------------------------
     # FinOps cost-allocation groups — showback business flows (ADR-0062). The /api/finops/costs

--- a/openbank-infra/gitops/components/payments/vop-opa-bundle.yaml
+++ b/openbank-infra/gitops/components/payments/vop-opa-bundle.yaml
@@ -9,7 +9,7 @@ metadata:
     app.kubernetes.io/name: vop-service
     app.kubernetes.io/part-of: payments
   annotations:
-    openbank.tech/policy-checksum: "3a2488a8fd758825"
+    openbank.tech/policy-checksum: "6352caf3d05b1c3f"
 data:
   rest.rego: |
     # SPDX-License-Identifier: Apache-2.0
@@ -1832,6 +1832,23 @@ data:
         # (3-dot against the PR base). Findings are ::warning annotations. Flip to enforced =
         # pass --enforce to the script in ci.yml (one-line change).
         ci_producer: "openbank-infra/scripts/check-threat-model-diff.py"
+      mp_messaging_dotted_keys:
+        # SmallRye reactive-messaging config written as a DOTTED key
+        # (`mp.messaging.incoming.x.topic: …`) inside a nested YAML mapping is silently ignored by
+        # SnakeYAML — the channel keeps its default and the consumer subscribes to nothing, with no
+        # error at boot (issue #686). The guard rewrites the shape it can prove wrong.
+        detect: ["<service>/src/main/resources/application.yaml", "mp.messaging.* written as a dotted key under a nested mapping"]
+        require:
+          - "mp.messaging channel config expressed as nested YAML, not a dotted key inside a mapping"
+        gate: dotted-mp-messaging-keys
+        enforced: advisory
+        target_enforce_date: "2026-09-30"   # ADR-0144
+        blocked_on: "1 finding remains fleet-wide; the script already supports --enforce, so graduating
+          is a one-word change in ci.yml once it is cleared"
+        # Registered here as part of issue #2392: this gate ran advisory with no rules.yaml rule at
+        # all, so check-gate-graduation.sh could not see it and it had no deadline. That class is now
+        # itself gated by .github/scripts/check-advisory-gate-registration.py.
+        ci_producer: ".github/scripts/check-dotted-mp-messaging-keys.sh"
       new_service_with_outbox:
         # A service that extends AbstractOutboxEntity / uses OutboxDispatcher but does NOT
         # set openbank.outbox.dispatch-enabled=true silently never dispatches events —
@@ -2750,6 +2767,19 @@ data:
     # MEASURED behaviour by a classifier + CI gate (derive -> enforce -> show, ADR-0029/0054).
     # ---------------------------------------------------------------------------------------
     finops_tiers:
+      # Declared-side validation (check-finops-tiers.py, finops-lifecycle.yml) runs ADVISORY: the
+      # script always exits 0 today, so a tier declared here that contradicts the manifest is a
+      # ::warning. Graduating needs the MEASURED classifier (the derive->enforce->show half below);
+      # until that lands there is nothing to compare a declaration against except itself.
+      #
+      # Registered with a date as part of issue #2392: this gate ran advisory with no `enforced` /
+      # `target_enforce_date` on its rule, so check-gate-graduation.sh (ADR-0144) skipped it entirely
+      # and it had no deadline at all.
+      enforced: advisory
+      target_enforce_date: "2026-12-31"   # ADR-0144 — gated on the measured classifier, not on triage
+      blocked_on: "the measured-side classifier must land before the declared side can hard-fail;
+        without it, enforcing would only assert that the file agrees with itself"
+      ci_producer: "openbank-infra/scripts/check-finops-tiers.py"
       tiers:
         T0:                                   # Always-on
           definition: "Money-path HOT path where a cold-start / scaled-to-zero gap is unacceptable, or a regulator-mandated continuous service."

--- a/openbank-infra/gitops/components/pid/pid-opa-bundle.yaml
+++ b/openbank-infra/gitops/components/pid/pid-opa-bundle.yaml
@@ -9,7 +9,7 @@ metadata:
     app.kubernetes.io/name: pid-service
     app.kubernetes.io/part-of: pid
   annotations:
-    openbank.tech/policy-checksum: "215ca8fa840179b0"
+    openbank.tech/policy-checksum: "b4314506120822c3"
 data:
   rest.rego: |
     # SPDX-License-Identifier: Apache-2.0
@@ -2769,19 +2769,6 @@ data:
     # MEASURED behaviour by a classifier + CI gate (derive -> enforce -> show, ADR-0029/0054).
     # ---------------------------------------------------------------------------------------
     finops_tiers:
-      # Declared-side validation (check-finops-tiers.py, finops-lifecycle.yml) runs ADVISORY: the
-      # script always exits 0 today, so a tier declared here that contradicts the manifest is a
-      # ::warning. Graduating needs the MEASURED classifier (the derive->enforce->show half below);
-      # until that lands there is nothing to compare a declaration against except itself.
-      #
-      # Registered with a date as part of issue #2392: this gate ran advisory with no `enforced` /
-      # `target_enforce_date` on its rule, so check-gate-graduation.sh (ADR-0144) skipped it entirely
-      # and it had no deadline at all.
-      enforced: advisory
-      target_enforce_date: "2026-12-31"   # ADR-0144 — gated on the measured classifier, not on triage
-      blocked_on: "the measured-side classifier must land before the declared side can hard-fail;
-        without it, enforcing would only assert that the file agrees with itself"
-      ci_producer: "openbank-infra/scripts/check-finops-tiers.py"
       tiers:
         T0:                                   # Always-on
           definition: "Money-path HOT path where a cold-start / scaled-to-zero gap is unacceptable, or a regulator-mandated continuous service."
@@ -2884,6 +2871,9 @@ data:
       enforced: advisory                      # ADR-0057; -> block when the classifier lands
       target_enforce_date: "2026-09-30"   # ADR-0144
       blocked_on: "the measured-signal classifier (http_request_rate, kafka_consumer_lag, cpu/replica utilisation) has not shipped yet — only 2 services have a declared tier today (notification-service, product-catalog)"
+      # Added by issue #2392: the rule carried `enforced`/`target_enforce_date` but never named the
+      # script that produces the finding, so nothing tied the advisory CI step to this deadline.
+      ci_producer: "openbank-infra/scripts/check-finops-tiers.py"
 
     # ---------------------------------------------------------------------------------------
     # FinOps cost-allocation groups — showback business flows (ADR-0062). The /api/finops/costs

--- a/openbank-infra/gitops/components/pid/pid-opa-bundle.yaml
+++ b/openbank-infra/gitops/components/pid/pid-opa-bundle.yaml
@@ -9,7 +9,7 @@ metadata:
     app.kubernetes.io/name: pid-service
     app.kubernetes.io/part-of: pid
   annotations:
-    openbank.tech/policy-checksum: "df896ffb207c9c5c"
+    openbank.tech/policy-checksum: "215ca8fa840179b0"
 data:
   rest.rego: |
     # SPDX-License-Identifier: Apache-2.0
@@ -1834,6 +1834,23 @@ data:
         # (3-dot against the PR base). Findings are ::warning annotations. Flip to enforced =
         # pass --enforce to the script in ci.yml (one-line change).
         ci_producer: "openbank-infra/scripts/check-threat-model-diff.py"
+      mp_messaging_dotted_keys:
+        # SmallRye reactive-messaging config written as a DOTTED key
+        # (`mp.messaging.incoming.x.topic: …`) inside a nested YAML mapping is silently ignored by
+        # SnakeYAML — the channel keeps its default and the consumer subscribes to nothing, with no
+        # error at boot (issue #686). The guard rewrites the shape it can prove wrong.
+        detect: ["<service>/src/main/resources/application.yaml", "mp.messaging.* written as a dotted key under a nested mapping"]
+        require:
+          - "mp.messaging channel config expressed as nested YAML, not a dotted key inside a mapping"
+        gate: dotted-mp-messaging-keys
+        enforced: advisory
+        target_enforce_date: "2026-09-30"   # ADR-0144
+        blocked_on: "1 finding remains fleet-wide; the script already supports --enforce, so graduating
+          is a one-word change in ci.yml once it is cleared"
+        # Registered here as part of issue #2392: this gate ran advisory with no rules.yaml rule at
+        # all, so check-gate-graduation.sh could not see it and it had no deadline. That class is now
+        # itself gated by .github/scripts/check-advisory-gate-registration.py.
+        ci_producer: ".github/scripts/check-dotted-mp-messaging-keys.sh"
       new_service_with_outbox:
         # A service that extends AbstractOutboxEntity / uses OutboxDispatcher but does NOT
         # set openbank.outbox.dispatch-enabled=true silently never dispatches events —
@@ -2752,6 +2769,19 @@ data:
     # MEASURED behaviour by a classifier + CI gate (derive -> enforce -> show, ADR-0029/0054).
     # ---------------------------------------------------------------------------------------
     finops_tiers:
+      # Declared-side validation (check-finops-tiers.py, finops-lifecycle.yml) runs ADVISORY: the
+      # script always exits 0 today, so a tier declared here that contradicts the manifest is a
+      # ::warning. Graduating needs the MEASURED classifier (the derive->enforce->show half below);
+      # until that lands there is nothing to compare a declaration against except itself.
+      #
+      # Registered with a date as part of issue #2392: this gate ran advisory with no `enforced` /
+      # `target_enforce_date` on its rule, so check-gate-graduation.sh (ADR-0144) skipped it entirely
+      # and it had no deadline at all.
+      enforced: advisory
+      target_enforce_date: "2026-12-31"   # ADR-0144 — gated on the measured classifier, not on triage
+      blocked_on: "the measured-side classifier must land before the declared side can hard-fail;
+        without it, enforcing would only assert that the file agrees with itself"
+      ci_producer: "openbank-infra/scripts/check-finops-tiers.py"
       tiers:
         T0:                                   # Always-on
           definition: "Money-path HOT path where a cold-start / scaled-to-zero gap is unacceptable, or a regulator-mandated continuous service."

--- a/openbank-infra/gitops/components/pid/pid-service.yaml
+++ b/openbank-infra/gitops/components/pid/pid-service.yaml
@@ -22,7 +22,7 @@ spec:
       annotations:
         # Rolls the pod when the OPA bundle changes — subPath mounts do NOT hot-reload.
         # Kept in sync by gen-pid-opa-bundle.sh (do not hand-edit).
-        openbank.tech/policy-checksum: "df896ffb207c9c5c"
+        openbank.tech/policy-checksum: "215ca8fa840179b0"
     spec:
       securityContext:
         runAsNonRoot: true

--- a/openbank-infra/gitops/components/pid/pid-service.yaml
+++ b/openbank-infra/gitops/components/pid/pid-service.yaml
@@ -22,7 +22,7 @@ spec:
       annotations:
         # Rolls the pod when the OPA bundle changes — subPath mounts do NOT hot-reload.
         # Kept in sync by gen-pid-opa-bundle.sh (do not hand-edit).
-        openbank.tech/policy-checksum: "215ca8fa840179b0"
+        openbank.tech/policy-checksum: "b4314506120822c3"
     spec:
       securityContext:
         runAsNonRoot: true

--- a/openbank-infra/gitops/components/psd2-service/psd2-opa-bundle.yaml
+++ b/openbank-infra/gitops/components/psd2-service/psd2-opa-bundle.yaml
@@ -9,7 +9,7 @@ metadata:
     app.kubernetes.io/name: psd2-service
     app.kubernetes.io/part-of: psd2
   annotations:
-    openbank.tech/policy-checksum: "1f5f2160e3f395d6"
+    openbank.tech/policy-checksum: "19dec17c765fb9c9"
 data:
   rest.rego: |
     # SPDX-License-Identifier: Apache-2.0
@@ -1907,6 +1907,23 @@ data:
         # (3-dot against the PR base). Findings are ::warning annotations. Flip to enforced =
         # pass --enforce to the script in ci.yml (one-line change).
         ci_producer: "openbank-infra/scripts/check-threat-model-diff.py"
+      mp_messaging_dotted_keys:
+        # SmallRye reactive-messaging config written as a DOTTED key
+        # (`mp.messaging.incoming.x.topic: …`) inside a nested YAML mapping is silently ignored by
+        # SnakeYAML — the channel keeps its default and the consumer subscribes to nothing, with no
+        # error at boot (issue #686). The guard rewrites the shape it can prove wrong.
+        detect: ["<service>/src/main/resources/application.yaml", "mp.messaging.* written as a dotted key under a nested mapping"]
+        require:
+          - "mp.messaging channel config expressed as nested YAML, not a dotted key inside a mapping"
+        gate: dotted-mp-messaging-keys
+        enforced: advisory
+        target_enforce_date: "2026-09-30"   # ADR-0144
+        blocked_on: "1 finding remains fleet-wide; the script already supports --enforce, so graduating
+          is a one-word change in ci.yml once it is cleared"
+        # Registered here as part of issue #2392: this gate ran advisory with no rules.yaml rule at
+        # all, so check-gate-graduation.sh could not see it and it had no deadline. That class is now
+        # itself gated by .github/scripts/check-advisory-gate-registration.py.
+        ci_producer: ".github/scripts/check-dotted-mp-messaging-keys.sh"
       new_service_with_outbox:
         # A service that extends AbstractOutboxEntity / uses OutboxDispatcher but does NOT
         # set openbank.outbox.dispatch-enabled=true silently never dispatches events —
@@ -2825,6 +2842,19 @@ data:
     # MEASURED behaviour by a classifier + CI gate (derive -> enforce -> show, ADR-0029/0054).
     # ---------------------------------------------------------------------------------------
     finops_tiers:
+      # Declared-side validation (check-finops-tiers.py, finops-lifecycle.yml) runs ADVISORY: the
+      # script always exits 0 today, so a tier declared here that contradicts the manifest is a
+      # ::warning. Graduating needs the MEASURED classifier (the derive->enforce->show half below);
+      # until that lands there is nothing to compare a declaration against except itself.
+      #
+      # Registered with a date as part of issue #2392: this gate ran advisory with no `enforced` /
+      # `target_enforce_date` on its rule, so check-gate-graduation.sh (ADR-0144) skipped it entirely
+      # and it had no deadline at all.
+      enforced: advisory
+      target_enforce_date: "2026-12-31"   # ADR-0144 — gated on the measured classifier, not on triage
+      blocked_on: "the measured-side classifier must land before the declared side can hard-fail;
+        without it, enforcing would only assert that the file agrees with itself"
+      ci_producer: "openbank-infra/scripts/check-finops-tiers.py"
       tiers:
         T0:                                   # Always-on
           definition: "Money-path HOT path where a cold-start / scaled-to-zero gap is unacceptable, or a regulator-mandated continuous service."

--- a/openbank-infra/gitops/components/psd2-service/psd2-opa-bundle.yaml
+++ b/openbank-infra/gitops/components/psd2-service/psd2-opa-bundle.yaml
@@ -9,7 +9,7 @@ metadata:
     app.kubernetes.io/name: psd2-service
     app.kubernetes.io/part-of: psd2
   annotations:
-    openbank.tech/policy-checksum: "19dec17c765fb9c9"
+    openbank.tech/policy-checksum: "1c9a00ab875d5ce4"
 data:
   rest.rego: |
     # SPDX-License-Identifier: Apache-2.0
@@ -2842,19 +2842,6 @@ data:
     # MEASURED behaviour by a classifier + CI gate (derive -> enforce -> show, ADR-0029/0054).
     # ---------------------------------------------------------------------------------------
     finops_tiers:
-      # Declared-side validation (check-finops-tiers.py, finops-lifecycle.yml) runs ADVISORY: the
-      # script always exits 0 today, so a tier declared here that contradicts the manifest is a
-      # ::warning. Graduating needs the MEASURED classifier (the derive->enforce->show half below);
-      # until that lands there is nothing to compare a declaration against except itself.
-      #
-      # Registered with a date as part of issue #2392: this gate ran advisory with no `enforced` /
-      # `target_enforce_date` on its rule, so check-gate-graduation.sh (ADR-0144) skipped it entirely
-      # and it had no deadline at all.
-      enforced: advisory
-      target_enforce_date: "2026-12-31"   # ADR-0144 — gated on the measured classifier, not on triage
-      blocked_on: "the measured-side classifier must land before the declared side can hard-fail;
-        without it, enforcing would only assert that the file agrees with itself"
-      ci_producer: "openbank-infra/scripts/check-finops-tiers.py"
       tiers:
         T0:                                   # Always-on
           definition: "Money-path HOT path where a cold-start / scaled-to-zero gap is unacceptable, or a regulator-mandated continuous service."
@@ -2957,6 +2944,9 @@ data:
       enforced: advisory                      # ADR-0057; -> block when the classifier lands
       target_enforce_date: "2026-09-30"   # ADR-0144
       blocked_on: "the measured-signal classifier (http_request_rate, kafka_consumer_lag, cpu/replica utilisation) has not shipped yet — only 2 services have a declared tier today (notification-service, product-catalog)"
+      # Added by issue #2392: the rule carried `enforced`/`target_enforce_date` but never named the
+      # script that produces the finding, so nothing tied the advisory CI step to this deadline.
+      ci_producer: "openbank-infra/scripts/check-finops-tiers.py"
 
     # ---------------------------------------------------------------------------------------
     # FinOps cost-allocation groups — showback business flows (ADR-0062). The /api/finops/costs

--- a/openbank-infra/gitops/components/psd2-service/psd2-service.yaml
+++ b/openbank-infra/gitops/components/psd2-service/psd2-service.yaml
@@ -18,7 +18,7 @@ spec:
       annotations:
         # Rolls the pod when the OPA bundle changes — subPath mounts do NOT hot-reload.
         # Kept in sync by gen-psd2-opa-bundle.sh (do not hand-edit).
-        openbank.tech/policy-checksum: "1f5f2160e3f395d6"
+        openbank.tech/policy-checksum: "19dec17c765fb9c9"
       labels: {app.kubernetes.io/name: psd2-service, app.kubernetes.io/part-of: psd2}
     spec:
       securityContext:

--- a/openbank-infra/gitops/components/psd2-service/psd2-service.yaml
+++ b/openbank-infra/gitops/components/psd2-service/psd2-service.yaml
@@ -18,7 +18,7 @@ spec:
       annotations:
         # Rolls the pod when the OPA bundle changes — subPath mounts do NOT hot-reload.
         # Kept in sync by gen-psd2-opa-bundle.sh (do not hand-edit).
-        openbank.tech/policy-checksum: "19dec17c765fb9c9"
+        openbank.tech/policy-checksum: "1c9a00ab875d5ce4"
       labels: {app.kubernetes.io/name: psd2-service, app.kubernetes.io/part-of: psd2}
     spec:
       securityContext:

--- a/openbank-infra/gitops/components/sanctions-service/sanctions-opa-bundle.yaml
+++ b/openbank-infra/gitops/components/sanctions-service/sanctions-opa-bundle.yaml
@@ -9,7 +9,7 @@ metadata:
     app.kubernetes.io/name: sanctions-service
     app.kubernetes.io/part-of: sanctions
   annotations:
-    openbank.tech/policy-checksum: "88fc4fb76825b04b"
+    openbank.tech/policy-checksum: "80b6f5bccb19973b"
 data:
   rest.rego: |
     # SPDX-License-Identifier: Apache-2.0
@@ -2747,19 +2747,6 @@ data:
     # MEASURED behaviour by a classifier + CI gate (derive -> enforce -> show, ADR-0029/0054).
     # ---------------------------------------------------------------------------------------
     finops_tiers:
-      # Declared-side validation (check-finops-tiers.py, finops-lifecycle.yml) runs ADVISORY: the
-      # script always exits 0 today, so a tier declared here that contradicts the manifest is a
-      # ::warning. Graduating needs the MEASURED classifier (the derive->enforce->show half below);
-      # until that lands there is nothing to compare a declaration against except itself.
-      #
-      # Registered with a date as part of issue #2392: this gate ran advisory with no `enforced` /
-      # `target_enforce_date` on its rule, so check-gate-graduation.sh (ADR-0144) skipped it entirely
-      # and it had no deadline at all.
-      enforced: advisory
-      target_enforce_date: "2026-12-31"   # ADR-0144 — gated on the measured classifier, not on triage
-      blocked_on: "the measured-side classifier must land before the declared side can hard-fail;
-        without it, enforcing would only assert that the file agrees with itself"
-      ci_producer: "openbank-infra/scripts/check-finops-tiers.py"
       tiers:
         T0:                                   # Always-on
           definition: "Money-path HOT path where a cold-start / scaled-to-zero gap is unacceptable, or a regulator-mandated continuous service."
@@ -2862,6 +2849,9 @@ data:
       enforced: advisory                      # ADR-0057; -> block when the classifier lands
       target_enforce_date: "2026-09-30"   # ADR-0144
       blocked_on: "the measured-signal classifier (http_request_rate, kafka_consumer_lag, cpu/replica utilisation) has not shipped yet — only 2 services have a declared tier today (notification-service, product-catalog)"
+      # Added by issue #2392: the rule carried `enforced`/`target_enforce_date` but never named the
+      # script that produces the finding, so nothing tied the advisory CI step to this deadline.
+      ci_producer: "openbank-infra/scripts/check-finops-tiers.py"
 
     # ---------------------------------------------------------------------------------------
     # FinOps cost-allocation groups — showback business flows (ADR-0062). The /api/finops/costs

--- a/openbank-infra/gitops/components/sanctions-service/sanctions-opa-bundle.yaml
+++ b/openbank-infra/gitops/components/sanctions-service/sanctions-opa-bundle.yaml
@@ -9,7 +9,7 @@ metadata:
     app.kubernetes.io/name: sanctions-service
     app.kubernetes.io/part-of: sanctions
   annotations:
-    openbank.tech/policy-checksum: "b4b0757045e2925e"
+    openbank.tech/policy-checksum: "88fc4fb76825b04b"
 data:
   rest.rego: |
     # SPDX-License-Identifier: Apache-2.0
@@ -1812,6 +1812,23 @@ data:
         # (3-dot against the PR base). Findings are ::warning annotations. Flip to enforced =
         # pass --enforce to the script in ci.yml (one-line change).
         ci_producer: "openbank-infra/scripts/check-threat-model-diff.py"
+      mp_messaging_dotted_keys:
+        # SmallRye reactive-messaging config written as a DOTTED key
+        # (`mp.messaging.incoming.x.topic: …`) inside a nested YAML mapping is silently ignored by
+        # SnakeYAML — the channel keeps its default and the consumer subscribes to nothing, with no
+        # error at boot (issue #686). The guard rewrites the shape it can prove wrong.
+        detect: ["<service>/src/main/resources/application.yaml", "mp.messaging.* written as a dotted key under a nested mapping"]
+        require:
+          - "mp.messaging channel config expressed as nested YAML, not a dotted key inside a mapping"
+        gate: dotted-mp-messaging-keys
+        enforced: advisory
+        target_enforce_date: "2026-09-30"   # ADR-0144
+        blocked_on: "1 finding remains fleet-wide; the script already supports --enforce, so graduating
+          is a one-word change in ci.yml once it is cleared"
+        # Registered here as part of issue #2392: this gate ran advisory with no rules.yaml rule at
+        # all, so check-gate-graduation.sh could not see it and it had no deadline. That class is now
+        # itself gated by .github/scripts/check-advisory-gate-registration.py.
+        ci_producer: ".github/scripts/check-dotted-mp-messaging-keys.sh"
       new_service_with_outbox:
         # A service that extends AbstractOutboxEntity / uses OutboxDispatcher but does NOT
         # set openbank.outbox.dispatch-enabled=true silently never dispatches events —
@@ -2730,6 +2747,19 @@ data:
     # MEASURED behaviour by a classifier + CI gate (derive -> enforce -> show, ADR-0029/0054).
     # ---------------------------------------------------------------------------------------
     finops_tiers:
+      # Declared-side validation (check-finops-tiers.py, finops-lifecycle.yml) runs ADVISORY: the
+      # script always exits 0 today, so a tier declared here that contradicts the manifest is a
+      # ::warning. Graduating needs the MEASURED classifier (the derive->enforce->show half below);
+      # until that lands there is nothing to compare a declaration against except itself.
+      #
+      # Registered with a date as part of issue #2392: this gate ran advisory with no `enforced` /
+      # `target_enforce_date` on its rule, so check-gate-graduation.sh (ADR-0144) skipped it entirely
+      # and it had no deadline at all.
+      enforced: advisory
+      target_enforce_date: "2026-12-31"   # ADR-0144 — gated on the measured classifier, not on triage
+      blocked_on: "the measured-side classifier must land before the declared side can hard-fail;
+        without it, enforcing would only assert that the file agrees with itself"
+      ci_producer: "openbank-infra/scripts/check-finops-tiers.py"
       tiers:
         T0:                                   # Always-on
           definition: "Money-path HOT path where a cold-start / scaled-to-zero gap is unacceptable, or a regulator-mandated continuous service."

--- a/openbank-infra/gitops/components/sanctions-service/sanctions-service.yaml
+++ b/openbank-infra/gitops/components/sanctions-service/sanctions-service.yaml
@@ -49,7 +49,7 @@ spec:
       annotations:
         # Rolls the pods when the OPA bundle changes — subPath mounts do NOT hot-reload.
         # Kept in sync by gen-sanctions-opa-bundle.sh (do not hand-edit).
-        openbank.tech/policy-checksum: "b4b0757045e2925e"
+        openbank.tech/policy-checksum: "88fc4fb76825b04b"
     spec:
       securityContext:
         runAsNonRoot: true

--- a/openbank-infra/gitops/components/sanctions-service/sanctions-service.yaml
+++ b/openbank-infra/gitops/components/sanctions-service/sanctions-service.yaml
@@ -49,7 +49,7 @@ spec:
       annotations:
         # Rolls the pods when the OPA bundle changes — subPath mounts do NOT hot-reload.
         # Kept in sync by gen-sanctions-opa-bundle.sh (do not hand-edit).
-        openbank.tech/policy-checksum: "88fc4fb76825b04b"
+        openbank.tech/policy-checksum: "80b6f5bccb19973b"
     spec:
       securityContext:
         runAsNonRoot: true

--- a/openbank-infra/gitops/components/sca/sca-opa-bundle.yaml
+++ b/openbank-infra/gitops/components/sca/sca-opa-bundle.yaml
@@ -9,7 +9,7 @@ metadata:
     app.kubernetes.io/name: sca-service
     app.kubernetes.io/part-of: sca
   annotations:
-    openbank.tech/policy-checksum: "ee6599ff3797aa1e"
+    openbank.tech/policy-checksum: "cf08242b872f92f3"
 data:
   rest.rego: |
     # SPDX-License-Identifier: Apache-2.0
@@ -1848,6 +1848,23 @@ data:
         # (3-dot against the PR base). Findings are ::warning annotations. Flip to enforced =
         # pass --enforce to the script in ci.yml (one-line change).
         ci_producer: "openbank-infra/scripts/check-threat-model-diff.py"
+      mp_messaging_dotted_keys:
+        # SmallRye reactive-messaging config written as a DOTTED key
+        # (`mp.messaging.incoming.x.topic: …`) inside a nested YAML mapping is silently ignored by
+        # SnakeYAML — the channel keeps its default and the consumer subscribes to nothing, with no
+        # error at boot (issue #686). The guard rewrites the shape it can prove wrong.
+        detect: ["<service>/src/main/resources/application.yaml", "mp.messaging.* written as a dotted key under a nested mapping"]
+        require:
+          - "mp.messaging channel config expressed as nested YAML, not a dotted key inside a mapping"
+        gate: dotted-mp-messaging-keys
+        enforced: advisory
+        target_enforce_date: "2026-09-30"   # ADR-0144
+        blocked_on: "1 finding remains fleet-wide; the script already supports --enforce, so graduating
+          is a one-word change in ci.yml once it is cleared"
+        # Registered here as part of issue #2392: this gate ran advisory with no rules.yaml rule at
+        # all, so check-gate-graduation.sh could not see it and it had no deadline. That class is now
+        # itself gated by .github/scripts/check-advisory-gate-registration.py.
+        ci_producer: ".github/scripts/check-dotted-mp-messaging-keys.sh"
       new_service_with_outbox:
         # A service that extends AbstractOutboxEntity / uses OutboxDispatcher but does NOT
         # set openbank.outbox.dispatch-enabled=true silently never dispatches events —
@@ -2766,6 +2783,19 @@ data:
     # MEASURED behaviour by a classifier + CI gate (derive -> enforce -> show, ADR-0029/0054).
     # ---------------------------------------------------------------------------------------
     finops_tiers:
+      # Declared-side validation (check-finops-tiers.py, finops-lifecycle.yml) runs ADVISORY: the
+      # script always exits 0 today, so a tier declared here that contradicts the manifest is a
+      # ::warning. Graduating needs the MEASURED classifier (the derive->enforce->show half below);
+      # until that lands there is nothing to compare a declaration against except itself.
+      #
+      # Registered with a date as part of issue #2392: this gate ran advisory with no `enforced` /
+      # `target_enforce_date` on its rule, so check-gate-graduation.sh (ADR-0144) skipped it entirely
+      # and it had no deadline at all.
+      enforced: advisory
+      target_enforce_date: "2026-12-31"   # ADR-0144 — gated on the measured classifier, not on triage
+      blocked_on: "the measured-side classifier must land before the declared side can hard-fail;
+        without it, enforcing would only assert that the file agrees with itself"
+      ci_producer: "openbank-infra/scripts/check-finops-tiers.py"
       tiers:
         T0:                                   # Always-on
           definition: "Money-path HOT path where a cold-start / scaled-to-zero gap is unacceptable, or a regulator-mandated continuous service."

--- a/openbank-infra/gitops/components/sca/sca-opa-bundle.yaml
+++ b/openbank-infra/gitops/components/sca/sca-opa-bundle.yaml
@@ -9,7 +9,7 @@ metadata:
     app.kubernetes.io/name: sca-service
     app.kubernetes.io/part-of: sca
   annotations:
-    openbank.tech/policy-checksum: "cf08242b872f92f3"
+    openbank.tech/policy-checksum: "950dbc4fc12aab3d"
 data:
   rest.rego: |
     # SPDX-License-Identifier: Apache-2.0
@@ -2783,19 +2783,6 @@ data:
     # MEASURED behaviour by a classifier + CI gate (derive -> enforce -> show, ADR-0029/0054).
     # ---------------------------------------------------------------------------------------
     finops_tiers:
-      # Declared-side validation (check-finops-tiers.py, finops-lifecycle.yml) runs ADVISORY: the
-      # script always exits 0 today, so a tier declared here that contradicts the manifest is a
-      # ::warning. Graduating needs the MEASURED classifier (the derive->enforce->show half below);
-      # until that lands there is nothing to compare a declaration against except itself.
-      #
-      # Registered with a date as part of issue #2392: this gate ran advisory with no `enforced` /
-      # `target_enforce_date` on its rule, so check-gate-graduation.sh (ADR-0144) skipped it entirely
-      # and it had no deadline at all.
-      enforced: advisory
-      target_enforce_date: "2026-12-31"   # ADR-0144 — gated on the measured classifier, not on triage
-      blocked_on: "the measured-side classifier must land before the declared side can hard-fail;
-        without it, enforcing would only assert that the file agrees with itself"
-      ci_producer: "openbank-infra/scripts/check-finops-tiers.py"
       tiers:
         T0:                                   # Always-on
           definition: "Money-path HOT path where a cold-start / scaled-to-zero gap is unacceptable, or a regulator-mandated continuous service."
@@ -2898,6 +2885,9 @@ data:
       enforced: advisory                      # ADR-0057; -> block when the classifier lands
       target_enforce_date: "2026-09-30"   # ADR-0144
       blocked_on: "the measured-signal classifier (http_request_rate, kafka_consumer_lag, cpu/replica utilisation) has not shipped yet — only 2 services have a declared tier today (notification-service, product-catalog)"
+      # Added by issue #2392: the rule carried `enforced`/`target_enforce_date` but never named the
+      # script that produces the finding, so nothing tied the advisory CI step to this deadline.
+      ci_producer: "openbank-infra/scripts/check-finops-tiers.py"
 
     # ---------------------------------------------------------------------------------------
     # FinOps cost-allocation groups — showback business flows (ADR-0062). The /api/finops/costs

--- a/openbank-infra/gitops/components/sca/sca-service.yaml
+++ b/openbank-infra/gitops/components/sca/sca-service.yaml
@@ -28,7 +28,7 @@ spec:
       annotations:
         # Rolls the pods when the OPA bundle changes — subPath mounts do NOT hot-reload.
         # Kept in sync by gen-sca-opa-bundle.sh (do not hand-edit).
-        openbank.tech/policy-checksum: "cf08242b872f92f3"
+        openbank.tech/policy-checksum: "950dbc4fc12aab3d"
     spec:
       securityContext:
         runAsNonRoot: true

--- a/openbank-infra/gitops/components/sca/sca-service.yaml
+++ b/openbank-infra/gitops/components/sca/sca-service.yaml
@@ -28,7 +28,7 @@ spec:
       annotations:
         # Rolls the pods when the OPA bundle changes — subPath mounts do NOT hot-reload.
         # Kept in sync by gen-sca-opa-bundle.sh (do not hand-edit).
-        openbank.tech/policy-checksum: "ee6599ff3797aa1e"
+        openbank.tech/policy-checksum: "cf08242b872f92f3"
     spec:
       securityContext:
         runAsNonRoot: true

--- a/openbank-infra/gitops/components/statements/statement-opa-bundle.yaml
+++ b/openbank-infra/gitops/components/statements/statement-opa-bundle.yaml
@@ -9,7 +9,7 @@ metadata:
     app.kubernetes.io/name: statement-service
     app.kubernetes.io/part-of: statements
   annotations:
-    openbank.tech/policy-checksum: "55fc5c214b650baf"
+    openbank.tech/policy-checksum: "0892762fbf0b46ec"
 data:
   rest.rego: |
     # SPDX-License-Identifier: Apache-2.0
@@ -2813,19 +2813,6 @@ data:
     # MEASURED behaviour by a classifier + CI gate (derive -> enforce -> show, ADR-0029/0054).
     # ---------------------------------------------------------------------------------------
     finops_tiers:
-      # Declared-side validation (check-finops-tiers.py, finops-lifecycle.yml) runs ADVISORY: the
-      # script always exits 0 today, so a tier declared here that contradicts the manifest is a
-      # ::warning. Graduating needs the MEASURED classifier (the derive->enforce->show half below);
-      # until that lands there is nothing to compare a declaration against except itself.
-      #
-      # Registered with a date as part of issue #2392: this gate ran advisory with no `enforced` /
-      # `target_enforce_date` on its rule, so check-gate-graduation.sh (ADR-0144) skipped it entirely
-      # and it had no deadline at all.
-      enforced: advisory
-      target_enforce_date: "2026-12-31"   # ADR-0144 — gated on the measured classifier, not on triage
-      blocked_on: "the measured-side classifier must land before the declared side can hard-fail;
-        without it, enforcing would only assert that the file agrees with itself"
-      ci_producer: "openbank-infra/scripts/check-finops-tiers.py"
       tiers:
         T0:                                   # Always-on
           definition: "Money-path HOT path where a cold-start / scaled-to-zero gap is unacceptable, or a regulator-mandated continuous service."
@@ -2928,6 +2915,9 @@ data:
       enforced: advisory                      # ADR-0057; -> block when the classifier lands
       target_enforce_date: "2026-09-30"   # ADR-0144
       blocked_on: "the measured-signal classifier (http_request_rate, kafka_consumer_lag, cpu/replica utilisation) has not shipped yet — only 2 services have a declared tier today (notification-service, product-catalog)"
+      # Added by issue #2392: the rule carried `enforced`/`target_enforce_date` but never named the
+      # script that produces the finding, so nothing tied the advisory CI step to this deadline.
+      ci_producer: "openbank-infra/scripts/check-finops-tiers.py"
 
     # ---------------------------------------------------------------------------------------
     # FinOps cost-allocation groups — showback business flows (ADR-0062). The /api/finops/costs

--- a/openbank-infra/gitops/components/statements/statement-opa-bundle.yaml
+++ b/openbank-infra/gitops/components/statements/statement-opa-bundle.yaml
@@ -9,7 +9,7 @@ metadata:
     app.kubernetes.io/name: statement-service
     app.kubernetes.io/part-of: statements
   annotations:
-    openbank.tech/policy-checksum: "20d83ffd9665d3f6"
+    openbank.tech/policy-checksum: "55fc5c214b650baf"
 data:
   rest.rego: |
     # SPDX-License-Identifier: Apache-2.0
@@ -1878,6 +1878,23 @@ data:
         # (3-dot against the PR base). Findings are ::warning annotations. Flip to enforced =
         # pass --enforce to the script in ci.yml (one-line change).
         ci_producer: "openbank-infra/scripts/check-threat-model-diff.py"
+      mp_messaging_dotted_keys:
+        # SmallRye reactive-messaging config written as a DOTTED key
+        # (`mp.messaging.incoming.x.topic: …`) inside a nested YAML mapping is silently ignored by
+        # SnakeYAML — the channel keeps its default and the consumer subscribes to nothing, with no
+        # error at boot (issue #686). The guard rewrites the shape it can prove wrong.
+        detect: ["<service>/src/main/resources/application.yaml", "mp.messaging.* written as a dotted key under a nested mapping"]
+        require:
+          - "mp.messaging channel config expressed as nested YAML, not a dotted key inside a mapping"
+        gate: dotted-mp-messaging-keys
+        enforced: advisory
+        target_enforce_date: "2026-09-30"   # ADR-0144
+        blocked_on: "1 finding remains fleet-wide; the script already supports --enforce, so graduating
+          is a one-word change in ci.yml once it is cleared"
+        # Registered here as part of issue #2392: this gate ran advisory with no rules.yaml rule at
+        # all, so check-gate-graduation.sh could not see it and it had no deadline. That class is now
+        # itself gated by .github/scripts/check-advisory-gate-registration.py.
+        ci_producer: ".github/scripts/check-dotted-mp-messaging-keys.sh"
       new_service_with_outbox:
         # A service that extends AbstractOutboxEntity / uses OutboxDispatcher but does NOT
         # set openbank.outbox.dispatch-enabled=true silently never dispatches events —
@@ -2796,6 +2813,19 @@ data:
     # MEASURED behaviour by a classifier + CI gate (derive -> enforce -> show, ADR-0029/0054).
     # ---------------------------------------------------------------------------------------
     finops_tiers:
+      # Declared-side validation (check-finops-tiers.py, finops-lifecycle.yml) runs ADVISORY: the
+      # script always exits 0 today, so a tier declared here that contradicts the manifest is a
+      # ::warning. Graduating needs the MEASURED classifier (the derive->enforce->show half below);
+      # until that lands there is nothing to compare a declaration against except itself.
+      #
+      # Registered with a date as part of issue #2392: this gate ran advisory with no `enforced` /
+      # `target_enforce_date` on its rule, so check-gate-graduation.sh (ADR-0144) skipped it entirely
+      # and it had no deadline at all.
+      enforced: advisory
+      target_enforce_date: "2026-12-31"   # ADR-0144 — gated on the measured classifier, not on triage
+      blocked_on: "the measured-side classifier must land before the declared side can hard-fail;
+        without it, enforcing would only assert that the file agrees with itself"
+      ci_producer: "openbank-infra/scripts/check-finops-tiers.py"
       tiers:
         T0:                                   # Always-on
           definition: "Money-path HOT path where a cold-start / scaled-to-zero gap is unacceptable, or a regulator-mandated continuous service."

--- a/openbank-infra/gitops/components/statements/statement-service.yaml
+++ b/openbank-infra/gitops/components/statements/statement-service.yaml
@@ -26,7 +26,7 @@ spec:
       annotations:
         # Rolls the pod when the OPA bundle changes — subPath mounts do NOT hot-reload.
         # Kept in sync by gen-statement-opa-bundle.sh (do not hand-edit).
-        openbank.tech/policy-checksum: "20d83ffd9665d3f6"
+        openbank.tech/policy-checksum: "55fc5c214b650baf"
       labels:
         app.kubernetes.io/name: statement-service
         app.kubernetes.io/part-of: statements

--- a/openbank-infra/gitops/components/statements/statement-service.yaml
+++ b/openbank-infra/gitops/components/statements/statement-service.yaml
@@ -26,7 +26,7 @@ spec:
       annotations:
         # Rolls the pod when the OPA bundle changes — subPath mounts do NOT hot-reload.
         # Kept in sync by gen-statement-opa-bundle.sh (do not hand-edit).
-        openbank.tech/policy-checksum: "55fc5c214b650baf"
+        openbank.tech/policy-checksum: "0892762fbf0b46ec"
       labels:
         app.kubernetes.io/name: statement-service
         app.kubernetes.io/part-of: statements

--- a/openbank-infra/gitops/components/tpp-registry/tpp-registry-opa-bundle.yaml
+++ b/openbank-infra/gitops/components/tpp-registry/tpp-registry-opa-bundle.yaml
@@ -9,7 +9,7 @@ metadata:
     app.kubernetes.io/name: tpp-registry-service
     app.kubernetes.io/part-of: tpp-registry
   annotations:
-    openbank.tech/policy-checksum: "5654f07e544dcc6d"
+    openbank.tech/policy-checksum: "34b62dc1b18c9a78"
 data:
   rest.rego: |
     # SPDX-License-Identifier: Apache-2.0
@@ -2750,19 +2750,6 @@ data:
     # MEASURED behaviour by a classifier + CI gate (derive -> enforce -> show, ADR-0029/0054).
     # ---------------------------------------------------------------------------------------
     finops_tiers:
-      # Declared-side validation (check-finops-tiers.py, finops-lifecycle.yml) runs ADVISORY: the
-      # script always exits 0 today, so a tier declared here that contradicts the manifest is a
-      # ::warning. Graduating needs the MEASURED classifier (the derive->enforce->show half below);
-      # until that lands there is nothing to compare a declaration against except itself.
-      #
-      # Registered with a date as part of issue #2392: this gate ran advisory with no `enforced` /
-      # `target_enforce_date` on its rule, so check-gate-graduation.sh (ADR-0144) skipped it entirely
-      # and it had no deadline at all.
-      enforced: advisory
-      target_enforce_date: "2026-12-31"   # ADR-0144 — gated on the measured classifier, not on triage
-      blocked_on: "the measured-side classifier must land before the declared side can hard-fail;
-        without it, enforcing would only assert that the file agrees with itself"
-      ci_producer: "openbank-infra/scripts/check-finops-tiers.py"
       tiers:
         T0:                                   # Always-on
           definition: "Money-path HOT path where a cold-start / scaled-to-zero gap is unacceptable, or a regulator-mandated continuous service."
@@ -2865,6 +2852,9 @@ data:
       enforced: advisory                      # ADR-0057; -> block when the classifier lands
       target_enforce_date: "2026-09-30"   # ADR-0144
       blocked_on: "the measured-signal classifier (http_request_rate, kafka_consumer_lag, cpu/replica utilisation) has not shipped yet — only 2 services have a declared tier today (notification-service, product-catalog)"
+      # Added by issue #2392: the rule carried `enforced`/`target_enforce_date` but never named the
+      # script that produces the finding, so nothing tied the advisory CI step to this deadline.
+      ci_producer: "openbank-infra/scripts/check-finops-tiers.py"
 
     # ---------------------------------------------------------------------------------------
     # FinOps cost-allocation groups — showback business flows (ADR-0062). The /api/finops/costs

--- a/openbank-infra/gitops/components/tpp-registry/tpp-registry-opa-bundle.yaml
+++ b/openbank-infra/gitops/components/tpp-registry/tpp-registry-opa-bundle.yaml
@@ -9,7 +9,7 @@ metadata:
     app.kubernetes.io/name: tpp-registry-service
     app.kubernetes.io/part-of: tpp-registry
   annotations:
-    openbank.tech/policy-checksum: "d86f35f6821e1edb"
+    openbank.tech/policy-checksum: "5654f07e544dcc6d"
 data:
   rest.rego: |
     # SPDX-License-Identifier: Apache-2.0
@@ -1815,6 +1815,23 @@ data:
         # (3-dot against the PR base). Findings are ::warning annotations. Flip to enforced =
         # pass --enforce to the script in ci.yml (one-line change).
         ci_producer: "openbank-infra/scripts/check-threat-model-diff.py"
+      mp_messaging_dotted_keys:
+        # SmallRye reactive-messaging config written as a DOTTED key
+        # (`mp.messaging.incoming.x.topic: …`) inside a nested YAML mapping is silently ignored by
+        # SnakeYAML — the channel keeps its default and the consumer subscribes to nothing, with no
+        # error at boot (issue #686). The guard rewrites the shape it can prove wrong.
+        detect: ["<service>/src/main/resources/application.yaml", "mp.messaging.* written as a dotted key under a nested mapping"]
+        require:
+          - "mp.messaging channel config expressed as nested YAML, not a dotted key inside a mapping"
+        gate: dotted-mp-messaging-keys
+        enforced: advisory
+        target_enforce_date: "2026-09-30"   # ADR-0144
+        blocked_on: "1 finding remains fleet-wide; the script already supports --enforce, so graduating
+          is a one-word change in ci.yml once it is cleared"
+        # Registered here as part of issue #2392: this gate ran advisory with no rules.yaml rule at
+        # all, so check-gate-graduation.sh could not see it and it had no deadline. That class is now
+        # itself gated by .github/scripts/check-advisory-gate-registration.py.
+        ci_producer: ".github/scripts/check-dotted-mp-messaging-keys.sh"
       new_service_with_outbox:
         # A service that extends AbstractOutboxEntity / uses OutboxDispatcher but does NOT
         # set openbank.outbox.dispatch-enabled=true silently never dispatches events —
@@ -2733,6 +2750,19 @@ data:
     # MEASURED behaviour by a classifier + CI gate (derive -> enforce -> show, ADR-0029/0054).
     # ---------------------------------------------------------------------------------------
     finops_tiers:
+      # Declared-side validation (check-finops-tiers.py, finops-lifecycle.yml) runs ADVISORY: the
+      # script always exits 0 today, so a tier declared here that contradicts the manifest is a
+      # ::warning. Graduating needs the MEASURED classifier (the derive->enforce->show half below);
+      # until that lands there is nothing to compare a declaration against except itself.
+      #
+      # Registered with a date as part of issue #2392: this gate ran advisory with no `enforced` /
+      # `target_enforce_date` on its rule, so check-gate-graduation.sh (ADR-0144) skipped it entirely
+      # and it had no deadline at all.
+      enforced: advisory
+      target_enforce_date: "2026-12-31"   # ADR-0144 — gated on the measured classifier, not on triage
+      blocked_on: "the measured-side classifier must land before the declared side can hard-fail;
+        without it, enforcing would only assert that the file agrees with itself"
+      ci_producer: "openbank-infra/scripts/check-finops-tiers.py"
       tiers:
         T0:                                   # Always-on
           definition: "Money-path HOT path where a cold-start / scaled-to-zero gap is unacceptable, or a regulator-mandated continuous service."

--- a/openbank-infra/gitops/components/tpp-registry/tpp-registry-service.yaml
+++ b/openbank-infra/gitops/components/tpp-registry/tpp-registry-service.yaml
@@ -23,7 +23,7 @@ spec:
       annotations:
         # Rolls the pod when the OPA bundle changes (subPath mounts do not hot-reload).
         # Kept in sync by gen-tpp-registry-opa-bundle.sh (do not hand-edit).
-        openbank.tech/policy-checksum: "d86f35f6821e1edb"
+        openbank.tech/policy-checksum: "5654f07e544dcc6d"
     spec:
       securityContext:
         runAsNonRoot: true

--- a/openbank-infra/gitops/components/tpp-registry/tpp-registry-service.yaml
+++ b/openbank-infra/gitops/components/tpp-registry/tpp-registry-service.yaml
@@ -23,7 +23,7 @@ spec:
       annotations:
         # Rolls the pod when the OPA bundle changes (subPath mounts do not hot-reload).
         # Kept in sync by gen-tpp-registry-opa-bundle.sh (do not hand-edit).
-        openbank.tech/policy-checksum: "5654f07e544dcc6d"
+        openbank.tech/policy-checksum: "34b62dc1b18c9a78"
     spec:
       securityContext:
         runAsNonRoot: true

--- a/openbank-libs/governance/rules.yaml
+++ b/openbank-libs/governance/rules.yaml
@@ -446,6 +446,23 @@ change_requirements:
     # (3-dot against the PR base). Findings are ::warning annotations. Flip to enforced =
     # pass --enforce to the script in ci.yml (one-line change).
     ci_producer: "openbank-infra/scripts/check-threat-model-diff.py"
+  mp_messaging_dotted_keys:
+    # SmallRye reactive-messaging config written as a DOTTED key
+    # (`mp.messaging.incoming.x.topic: …`) inside a nested YAML mapping is silently ignored by
+    # SnakeYAML — the channel keeps its default and the consumer subscribes to nothing, with no
+    # error at boot (issue #686). The guard rewrites the shape it can prove wrong.
+    detect: ["<service>/src/main/resources/application.yaml", "mp.messaging.* written as a dotted key under a nested mapping"]
+    require:
+      - "mp.messaging channel config expressed as nested YAML, not a dotted key inside a mapping"
+    gate: dotted-mp-messaging-keys
+    enforced: advisory
+    target_enforce_date: "2026-09-30"   # ADR-0144
+    blocked_on: "1 finding remains fleet-wide; the script already supports --enforce, so graduating
+      is a one-word change in ci.yml once it is cleared"
+    # Registered here as part of issue #2392: this gate ran advisory with no rules.yaml rule at
+    # all, so check-gate-graduation.sh could not see it and it had no deadline. That class is now
+    # itself gated by .github/scripts/check-advisory-gate-registration.py.
+    ci_producer: ".github/scripts/check-dotted-mp-messaging-keys.sh"
   new_service_with_outbox:
     # A service that extends AbstractOutboxEntity / uses OutboxDispatcher but does NOT
     # set openbank.outbox.dispatch-enabled=true silently never dispatches events —
@@ -1466,6 +1483,9 @@ finops_tiers:
   enforced: advisory                      # ADR-0057; -> block when the classifier lands
   target_enforce_date: "2026-09-30"   # ADR-0144
   blocked_on: "the measured-signal classifier (http_request_rate, kafka_consumer_lag, cpu/replica utilisation) has not shipped yet — only 2 services have a declared tier today (notification-service, product-catalog)"
+  # Added by issue #2392: the rule carried `enforced`/`target_enforce_date` but never named the
+  # script that produces the finding, so nothing tied the advisory CI step to this deadline.
+  ci_producer: "openbank-infra/scripts/check-finops-tiers.py"
 
 # ---------------------------------------------------------------------------------------
 # FinOps cost-allocation groups — showback business flows (ADR-0062). The /api/finops/costs


### PR DESCRIPTION
## What

Closes #2392. `check-gate-graduation.sh` enforces ADR-0144 — an advisory rule must carry a `target_enforce_date` — but it walks `rules.yaml` and **nothing else**. A CI gate with no rule there has no date, therefore no date it can miss, therefore no graduation pressure. Structurally invisible, not merely overlooked.

Measured cost, not theory: `check-prompt-registry.py` ran `continue-on-error` and was **red on main for a month** (#2363) — the unregistered file being the prompt written to resist injection. `check-evals-registry.py` the same (#2375). `check-authz-pdp-parity.py` cited `rules.yaml: authz_pdp_parity`, a key that never existed (#2393). Every flip so far happened because a person ran the script by hand.

## The gate

`check-advisory-gate-registration.py` walks the **workflows** instead: every advisory governance gate must name a `rules.yaml` rule — via that rule's existing `ci_producer` field — carrying `enforced: advisory|planned` + `target_enforce_date`. Enforced from day one; 10 advisory gates, all registered as of this PR.

It detects **both** forms of advisory, which is the whole point: `continue-on-error: true` is the obvious one, but 11 of the 12 advisory gates here are advisory *inside the script* (`::warning` + exit 0 unless `--enforce`). A `continue-on-error` scan alone finds one and calls the other eleven enforced.

Non-governance `continue-on-error` steps (ECR login, cache warm, Codecov upload, Trivy install) are deliberately not flagged — demanding a governance deadline for "Install Trivy" is how a gate becomes noise that gets silenced.

## The four unregistered gates

Two needed no rule, because they are already clean — so they are **enforced** instead:

- **evals gate replay** — its `continue-on-error` was suppressing a real replay failure (drifted prompt hash, model move, pass rate under the floor). A charter with no recording is already `::warning` + exit 0 inside the runner (4 of 5 suites today), so the flag hid only the one outcome the gate exists to catch.
- **authz-enforce ⇒ PDP parity** — 10 violations at introduction, last two cleared in #2403, so `--enforce` exits 0 on a clean tree.

Two are genuinely advisory and now carry deadlines:

- **`mp_messaging_dotted_keys`** (new rule) — 1 finding fleet-wide, target 2026-09-30.
- **`finops_tiers`** — already had `enforced`/`target_enforce_date`, but never named its producer, so nothing tied the CI step to that deadline. `ci_producer` added, nothing else.

## Two bugs I introduced and caught

**1. Line-wise parsing mis-attributed rule metadata.** The first draft read `enforced:`/`ci_producer:` against the last bare `key:` line. `finops_tiers` holds a nested `tiers:` sub-tree and declares its metadata *after* it, so the fields landed under `T3` — the gate would have reported a rule as registered while reading a different rule's metadata. Replaced with a structural walk of the parsed document.

**2. A duplicate-key YAML bug in my own `rules.yaml` edit.** My first `finops_tiers` change added `enforced`/`target_enforce_date`/`blocked_on` that already existed further down the same block. SnakeYAML keeps only the last of a repeated key, so the new values would have been silently dropped. **Nothing in CI would have caught it** — the gate parsed line-wise at the time, and the yamllint step's scope is `openbank-infra .github`, so `rules.yaml` is never linted. Found only by diffing yamllint finding *sets* against `origin/main` (20 vs 17). Now back to 17.

## Verification

Falsified three ways, plus the false-positive direction:

| case | result |
|---|---|
| new advisory gate with no rule | exit 1 |
| rule stripped of `target_enforce_date` | exit 1 |
| an enforced gate reverted to `continue-on-error` | exit 1 |
| restored tree | exit 0 |

Note the name precedence: **"enforced" beats "advisory"**, or this gate flags *itself* — its own step name contains the word. That is the third self-reference trap in this series, after the KDoc quoting a broken annotation (#2418) and the comment citing a dead role (#2450); each one flagged the very text explaining the bug.

Full `Validate manifests` family run locally, all exit 0: prompt-registry, evals-registry, evals replay, authz-pdp-parity `--enforce`, roles-allowed, gate-graduation, slo-registry. `actionlint` finding set identical to `origin/main`.

## OPA bundles

`rules.yaml` changed, so all 37 generators were re-run and their output committed (65 files, second commit). Re-running them on this tree produces no further diff. Not hand-edited.

**This PR has a short shelf life** — any competing `rules.yaml`/rego change regenerates the same 44 bundle files and conflicts it. Merge with `--auto`.

## Linked issues

Closes #2392
