### PR TITLE
fix(copilot): stop asking Jackson to parse a balance array as an object

### DIFF
--- a/openbank-copilot-service/src/main/kotlin/com/openbank/copilot/infrastructure/client/CustomerEdgeClient.kt
+++ b/openbank-copilot-service/src/main/kotlin/com/openbank/copilot/infrastructure/client/CustomerEdgeClient.kt
@@ -42,7 +42,7 @@ interface CustomerEdgeRestClient {
 
     @GET
     @Path("/customer/v1/balances/{accountId}")
-    fun getBalances(@PathParam("accountId") accountId: UUID): Uni<BalancesEnvelope>
+    fun getBalances(@PathParam("accountId") accountId: UUID): Uni<List<BalanceDto>>
 
     @GET
     @Path("/customer/v1/transactions")
@@ -77,8 +77,6 @@ data class AccountSummary(
     val currencyCode: String = "",
     val status: String = "",
 )
-
-data class BalancesEnvelope(val balances: List<BalanceDto> = emptyList())
 
 data class BalanceDto(
     val currency: String = "",

--- a/openbank-copilot-service/src/main/kotlin/com/openbank/copilot/infrastructure/tool/AccountsWithBalancesTool.kt
+++ b/openbank-copilot-service/src/main/kotlin/com/openbank/copilot/infrastructure/tool/AccountsWithBalancesTool.kt
@@ -45,7 +45,7 @@ class AccountsWithBalancesTool(@RestClient private val client: CustomerEdgeRestC
             val id = a.id
             val balancePart = if (id != null) {
                 try {
-                    val balances = client.getBalances(id).awaitSuspending().balances
+                    val balances = client.getBalances(id).awaitSuspending()
                     if (balances.isEmpty()) {
                         "zůstatek nedostupný"
                     } else {

--- a/openbank-copilot-service/src/main/kotlin/com/openbank/copilot/infrastructure/tool/BalanceTool.kt
+++ b/openbank-copilot-service/src/main/kotlin/com/openbank/copilot/infrastructure/tool/BalanceTool.kt
@@ -36,7 +36,7 @@ class BalanceTool(@RestClient private val client: CustomerEdgeRestClient) : Copi
         val accountId = runCatching { UUID.fromString(raw) }.getOrNull()
             ?: return ToolResult("'$raw' is not a valid account id.", isError = true)
         return try {
-            val balances = client.getBalances(accountId).awaitSuspending().balances
+            val balances = client.getBalances(accountId).awaitSuspending()
             if (balances.isEmpty()) {
                 ToolResult("No balances found for account $accountId.")
             } else {

--- a/openbank-copilot-service/src/test/kotlin/com/openbank/copilot/infrastructure/tool/AccountsWithBalancesToolTest.kt
+++ b/openbank-copilot-service/src/test/kotlin/com/openbank/copilot/infrastructure/tool/AccountsWithBalancesToolTest.kt
@@ -1,0 +1,101 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+// Copyright (c) OpenBank contributors. Licensed under the GNU Affero General Public License v3.0 only.
+// A commercial licence is available from the maintainers as an alternative to the AGPL-3.0.
+package com.openbank.copilot.infrastructure.tool
+
+import com.fasterxml.jackson.databind.ObjectMapper
+import com.openbank.copilot.infrastructure.client.AccountSummary
+import com.openbank.copilot.infrastructure.client.AccountsPage
+import com.openbank.copilot.infrastructure.client.BalanceDto
+import com.openbank.copilot.infrastructure.client.CustomerEdgeRestClient
+import io.mockk.every
+import io.mockk.mockk
+import io.smallrye.mutiny.Uni
+import kotlinx.coroutines.runBlocking
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.Test
+import java.math.BigDecimal
+import java.util.UUID
+
+/** See BalanceToolTest's KDoc — same missing-coverage / bare-array wire-shape finding (#2322). */
+class AccountsWithBalancesToolTest {
+
+    private val client = mockk<CustomerEdgeRestClient>()
+    private val tool = AccountsWithBalancesTool(client)
+    private val args = ObjectMapper().createObjectNode()
+    private val accountId = UUID.fromString("11111111-1111-1111-1111-111111111111")
+
+    @Test
+    fun `lists each account with its balances from a bare array response`(): Unit = runBlocking {
+        every { client.listAccounts() } returns Uni.createFrom().item(
+            AccountsPage(
+                data = listOf(
+                    AccountSummary(
+                        id = accountId,
+                        accountNumber = "123456789/0800",
+                        accountType = "CURRENT",
+                        currencyCode = "CZK",
+                        status = "ACTIVE",
+                    ),
+                ),
+            ),
+        )
+        // Bare array, as balance-service really sends it — not wrapped in an envelope object.
+        every { client.getBalances(accountId) } returns Uni.createFrom().item(
+            listOf(BalanceDto(currency = "CZK", bookedAmount = BigDecimal("500"), availableAmount = BigDecimal("480"))),
+        )
+
+        val result = tool.call(args)
+
+        assertThat(result.isError).isFalse()
+        assertThat(result.text).contains("123456789/0800")
+        assertThat(result.text).contains("CZK: 480 k dispozici")
+    }
+
+    @Test
+    fun `reports no accounts when the customer has none`(): Unit = runBlocking {
+        every { client.listAccounts() } returns Uni.createFrom().item(AccountsPage(data = emptyList()))
+
+        val result = tool.call(args)
+
+        assertThat(result.isError).isFalse()
+        assertThat(result.text).contains("nemá žádné účty")
+    }
+
+    @Test
+    fun `degrades a single account's balance failure without failing the whole call`(): Unit = runBlocking {
+        every { client.listAccounts() } returns Uni.createFrom().item(
+            AccountsPage(
+                data = listOf(
+                    AccountSummary(
+                        id = accountId,
+                        accountNumber = "1/0800",
+                        accountType = "CURRENT",
+                        currencyCode = "CZK",
+                        status = "ACTIVE",
+                    ),
+                ),
+            ),
+        )
+        every { client.getBalances(accountId) } returns Uni.createFrom().failure(
+            jakarta.ws.rs.WebApplicationException(502),
+        )
+
+        val result = tool.call(args)
+
+        assertThat(result.isError).isFalse()
+        assertThat(result.text).contains("zůstatek nedostupný")
+    }
+
+    @Test
+    fun `fails the whole call when the account list itself is unavailable`(): Unit = runBlocking {
+        every { client.listAccounts() } returns Uni.createFrom().failure(
+            jakarta.ws.rs.WebApplicationException(502),
+        )
+
+        val result = tool.call(args)
+
+        assertThat(result.isError).isTrue()
+        assertThat(result.text).contains("nepodařilo")
+    }
+}

--- a/openbank-copilot-service/src/test/kotlin/com/openbank/copilot/infrastructure/tool/BalanceToolTest.kt
+++ b/openbank-copilot-service/src/test/kotlin/com/openbank/copilot/infrastructure/tool/BalanceToolTest.kt
@@ -1,0 +1,107 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+// Copyright (c) OpenBank contributors. Licensed under the GNU Affero General Public License v3.0 only.
+// A commercial licence is available from the maintainers as an alternative to the AGPL-3.0.
+package com.openbank.copilot.infrastructure.tool
+
+import com.fasterxml.jackson.databind.ObjectMapper
+import com.openbank.copilot.infrastructure.client.BalanceDto
+import com.openbank.copilot.infrastructure.client.CustomerEdgeRestClient
+import io.mockk.every
+import io.mockk.mockk
+import io.smallrye.mutiny.Uni
+import kotlinx.coroutines.runBlocking
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.Test
+import java.math.BigDecimal
+import java.util.UUID
+
+/**
+ * `BalanceTool` and `AccountsWithBalancesTool` had NO test at all before this (issue #2322)
+ * — the only two of copilot's nine READ tools missing coverage. That gap is exactly what let
+ * [CustomerEdgeRestClient.getBalances] declare `Uni<BalancesEnvelope>` — an object wrapper —
+ * against a wire response that is a bare JSON array (customer-edge passes balance-service's own
+ * `GET /api/v1/balances/{accountId}` body through unchanged). Jackson threw
+ * `MismatchedInputException` on every real call; verified against the real classes before fixing
+ * (`mapper.readValue<BalancesEnvelope>("[{...}]")` throws `Cannot deserialize ... from Array
+ * value`). Fixed by making the client return `Uni<List<BalanceDto>>` directly.
+ */
+class BalanceToolTest {
+
+    private val client = mockk<CustomerEdgeRestClient>()
+    private val tool = BalanceTool(client)
+    private val accountId = UUID.fromString("11111111-1111-1111-1111-111111111111")
+    private val args = ObjectMapper().createObjectNode().put("accountId", accountId.toString())
+
+    @Test
+    fun `returns formatted balances when the edge responds with a bare array`(): Unit = runBlocking {
+        // The wire shape: customer-edge forwards balance-service's response verbatim, and
+        // balance-service returns `[BalanceResponse, ...]` — a JSON array, never an object with a
+        // "balances" field. This is the exact shape that broke before the fix.
+        every { client.getBalances(accountId) } returns Uni.createFrom().item(
+            listOf(
+                BalanceDto(
+                    currency = "CZK",
+                    bookedAmount = BigDecimal("1000.00"),
+                    availableAmount = BigDecimal("950.00"),
+                ),
+                BalanceDto(currency = "EUR", bookedAmount = BigDecimal("40.00"), availableAmount = BigDecimal("40.00")),
+            ),
+        )
+
+        val result = tool.call(args)
+
+        assertThat(result.isError).isFalse()
+        assertThat(result.text).contains("CZK: available 950.00, booked 1000.00")
+        assertThat(result.text).contains("EUR: available 40.00, booked 40.00")
+    }
+
+    @Test
+    fun `returns a not-found message when the account has no balances`(): Unit = runBlocking {
+        every { client.getBalances(accountId) } returns Uni.createFrom().item(emptyList())
+
+        val result = tool.call(args)
+
+        assertThat(result.isError).isFalse()
+        assertThat(result.text).contains("No balances found")
+    }
+
+    @Test
+    fun `rejects a missing accountId argument`(): Unit = runBlocking {
+        val result = tool.call(ObjectMapper().createObjectNode())
+
+        assertThat(result.isError).isTrue()
+        assertThat(result.text).contains("Missing required")
+    }
+
+    @Test
+    fun `rejects a malformed accountId argument`(): Unit = runBlocking {
+        val result = tool.call(ObjectMapper().createObjectNode().put("accountId", "not-a-uuid"))
+
+        assertThat(result.isError).isTrue()
+        assertThat(result.text).contains("not a valid account id")
+    }
+
+    @Test
+    fun `maps a 403 from the edge to an inaccessible-account message`(): Unit = runBlocking {
+        every { client.getBalances(accountId) } returns Uni.createFrom().failure(
+            jakarta.ws.rs.WebApplicationException(403),
+        )
+
+        val result = tool.call(args)
+
+        assertThat(result.isError).isTrue()
+        assertThat(result.text).contains("isn't accessible")
+    }
+
+    @Test
+    fun `maps any other upstream failure to a service-unavailable message`(): Unit = runBlocking {
+        every { client.getBalances(accountId) } returns Uni.createFrom().failure(
+            jakarta.ws.rs.WebApplicationException(502),
+        )
+
+        val result = tool.call(args)
+
+        assertThat(result.isError).isTrue()
+        assertThat(result.text).contains("unavailable")
+    }
+}


### PR DESCRIPTION
## What

`CustomerEdgeRestClient.getBalances()` declared `Uni<BalancesEnvelope>` — an object wrapper
`{"balances": [...]}` — but `customer-edge`'s `/customer/v1/balances/{accountId}` is a
byte-for-byte passthrough of balance-service's own response, and
`GET /api/v1/balances/{accountId}` returns a **bare JSON array** (confirmed against
balance-service's own `openapi.yaml`: `content: application/json: schema: {type: array}`,
no wrapper).

`Refs #2322`

## Verified empirically before touching anything

```kotlin
mapper.readValue<BalancesEnvelope>("""[{"currency":"CZK","bookedAmount":"1000.00","availableAmount":"950.00"}]""")
```
against the **real production classes**, via a throwaway test run with `./gradlew`:
```
MismatchedInputException: Cannot deserialize value of type `BalancesEnvelope` from Array value
```

**Every real call to `BalanceTool` or `AccountsWithBalancesTool` threw this on the response-parsing
path** — before the tool's own `try/catch(WebApplicationException)` block, which a Jackson
deserialization failure never reaches. Every "what's my balance" question the assistant was asked
would have failed.

## Why nothing caught it

**Neither tool had ANY test** — the only two of copilot's nine READ tools without one.
`FxRatesTool`, `CardStatusTool`, `StatementsTool` and the rest all have one. Added:

- `BalanceToolTest` — 6 cases, including the exact bare-array shape that broke.
- `AccountsWithBalancesToolTest` — 4 cases, including a per-account balance failure that must
  degrade gracefully without failing the whole call.

## Fix

Declared the client's true wire shape: `Uni<List<BalanceDto>>` instead of
`Uni<BalancesEnvelope>`. `BalancesEnvelope` is removed — nothing else referenced it. Both callers
updated (`.balances` accessor dropped, the list is used directly).

## Verification

- `:openbank-copilot-service:build` (44/44 tasks executed on `--rerun-tasks`, no cache):
  **BUILD SUCCESSFUL**, `koverVerify` passes.
- `:openbank-copilot-service:detekt` — clean.
- `:openbank-copilot-service:quarkusBuild --rerun-tasks` — 27/27 executed, CDI resolves.
- New test counts read from JUnit XML: `BalanceToolTest tests="6"`,
  `AccountsWithBalancesToolTest tests="4"`, all `failures="0"`.

## Release

`fix` + `src/main` change ⇒ releases copilot-service, correct for a defect that broke every real
balance query. `version.txt`/`CHANGELOG.md` left to release-please.
