### PR TITLE
test(customer-edge): add a provider-verification harness for the copilot pact

### DIFF
--- a/openbank-copilot-service/build.gradle.kts
+++ b/openbank-copilot-service/build.gradle.kts
@@ -44,6 +44,14 @@ dependencies {
     testImplementation(libs.assertj)
     testImplementation(libs.mockk)
     testImplementation(libs.rest.assured.kotlin)
+    // Consumer-driven contract with customer-edge (ADR-0063, issue #2322).
+    testImplementation(libs.pact.consumer)
+}
+
+// Pact: write generated pact files to the shared pacts/ dir at the repo root (git-pact, ADR-0063).
+// NOTE: must be set on the test JVM fork, not the Gradle daemon (System.setProperty would not propagate).
+tasks.withType<Test> {
+    systemProperty("pact.rootDir", "${rootProject.projectDir}/pacts")
 }
 
 kover {

--- a/openbank-copilot-service/src/test/kotlin/com/openbank/copilot/contract/CustomerEdgePactConsumerTest.kt
+++ b/openbank-copilot-service/src/test/kotlin/com/openbank/copilot/contract/CustomerEdgePactConsumerTest.kt
@@ -1,0 +1,396 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+// Copyright (c) OpenBank contributors. Licensed under the GNU Affero General Public License v3.0 only.
+// A commercial licence is available from the maintainers as an alternative to the AGPL-3.0.
+package com.openbank.copilot.contract
+
+import au.com.dius.pact.consumer.MockServer
+import au.com.dius.pact.consumer.dsl.LambdaDsl
+import au.com.dius.pact.consumer.dsl.LambdaDsl.newJsonBody
+import au.com.dius.pact.consumer.dsl.PactDslWithProvider
+import au.com.dius.pact.consumer.junit5.PactConsumerTestExt
+import au.com.dius.pact.consumer.junit5.PactTestFor
+import au.com.dius.pact.core.model.PactSpecVersion
+import au.com.dius.pact.core.model.RequestResponsePact
+import au.com.dius.pact.core.model.annotations.Pact
+import com.fasterxml.jackson.module.kotlin.jacksonObjectMapper
+import com.fasterxml.jackson.module.kotlin.readValue
+import com.openbank.copilot.infrastructure.client.AccountsPage
+import com.openbank.copilot.infrastructure.client.BalanceDto
+import com.openbank.copilot.infrastructure.client.CardDto
+import com.openbank.copilot.infrastructure.client.CustomerEdgeRestClient
+import com.openbank.copilot.infrastructure.client.FxRateDto
+import com.openbank.copilot.infrastructure.client.StandingOrderDto
+import com.openbank.copilot.infrastructure.client.StatementDto
+import com.openbank.copilot.infrastructure.client.TransactionPage
+import io.restassured.RestAssured.given
+import jakarta.ws.rs.Path
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.extension.ExtendWith
+import java.math.BigDecimal
+import java.util.UUID
+
+/**
+ * Consumer-driven contract for the seven `/customer/v1` reads copilot's tools depend on
+ * (issue #2322). The generated pact is committed to
+ * `pacts/openbank-copilot-service-openbank-customer-edge.json` (git-pact, ADR-0063) and replayed
+ * by `CustomerEdgeContractProviderVerificationTest` (`@PactFolder("../pacts")`) — that test always
+ * runs, no broker involved.
+ *
+ * Every read tool (`AccountsTool`, `BalanceTool`, `TransactionTool`, `FxRatesTool`,
+ * `CardStatusTool`, `StatementsTool`, `ScheduledPaymentsTool`, `AccountsWithBalancesTool`) mocks
+ * `CustomerEdgeRestClient` in its own unit test, so a wrong path, a renamed field or a dropped
+ * route on customer-edge's side is invisible there — exactly the finrep #2269 asymmetry.
+ *
+ * **The expected path is a LITERAL in every interaction below; only the outgoing request is
+ * reflected off the client's own `@Path`** (CLAUDE.md "Contract tests", measured on #2290 —
+ * deriving both sides is vacuous). [clientDerivedPath] pins the annotations to the literal
+ * instead.
+ *
+ * IMPORTANT — regenerate on change: re-run this test
+ * (`./gradlew :openbank-copilot-service:test --tests "*CustomerEdgePactConsumerTest*"`) and
+ * commit the updated pact JSON in the same PR.
+ */
+@ExtendWith(PactConsumerTestExt::class)
+@PactTestFor(providerName = "openbank-customer-edge", pactVersion = PactSpecVersion.V3)
+class CustomerEdgePactConsumerTest {
+
+    private val mapper = jacksonObjectMapper()
+
+    // --- accounts -----------------------------------------------------------------------------
+
+    @Pact(consumer = CONSUMER, provider = PROVIDER)
+    fun oneAccountPact(builder: PactDslWithProvider): RequestResponsePact = builder
+        .given("the customer has one account")
+        .uponReceiving("GET the customer's accounts")
+        .path(ACCOUNTS_PATH)
+        .method("GET")
+        .headers(mapOf("Accept" to "application/json"))
+        .willRespondWith()
+        .status(200)
+        .headers(mapOf("Content-Type" to "application/json"))
+        .body(
+            newJsonBody { o ->
+                o.array("data") { a ->
+                    a.`object` { acc ->
+                        acc.uuid("id", UUID.fromString(ACCOUNT_ID))
+                        acc.stringType("accountNumber", "123456789/0800")
+                        acc.stringType("accountType", "CURRENT")
+                        acc.stringType("currencyCode", "CZK")
+                        acc.stringType("status", "ACTIVE")
+                    }
+                }
+            }.build(),
+        )
+        .toPact()
+
+    @Test
+    @PactTestFor(pactMethod = "oneAccountPact")
+    fun `listAccounts parses the edge's real accounts page shape`(mockServer: MockServer) {
+        assertClientPathMatches(ACCOUNTS_PATH, clientDerivedPath("listAccounts"))
+
+        val raw = get(mockServer, clientDerivedPath("listAccounts"))
+
+        val page = mapper.readValue<AccountsPage>(raw)
+        assertThat(page.data).hasSize(1)
+        assertThat(page.data.single().accountNumber).isEqualTo("123456789/0800")
+    }
+
+    // --- balances (the bare-array shape #2458 fixed) -------------------------------------------
+
+    @Pact(consumer = CONSUMER, provider = PROVIDER)
+    fun accountBalancePact(builder: PactDslWithProvider): RequestResponsePact = builder
+        .given("the customer owns an account with a balance")
+        .uponReceiving("GET the balance of an owned account")
+        .path(balancesPath(ACCOUNT_ID))
+        .method("GET")
+        .headers(mapOf("Accept" to "application/json"))
+        .willRespondWith()
+        .status(200)
+        .headers(mapOf("Content-Type" to "application/json"))
+        // A BARE array — not wrapped in {"balances": [...]}. This is the exact shape #2458 fixed;
+        // pinning it as an object here would silently resurrect the bug this pact exists to guard.
+        .body(
+            LambdaDsl.newJsonArrayMinLike(1) { arr ->
+                arr.`object` { o ->
+                    o.stringType("currency", "CZK")
+                    o.decimalType("bookedAmount", BigDecimal("1000.00"))
+                    o.decimalType("availableAmount", BigDecimal("950.00"))
+                }
+            }.build(),
+        )
+        .toPact()
+
+    @Test
+    @PactTestFor(pactMethod = "accountBalancePact")
+    fun `getBalances parses the edge's bare-array balance shape`(mockServer: MockServer) {
+        val path = balancesPath(ACCOUNT_ID)
+        assertClientPathMatches(path, clientDerivedPath("getBalances", ACCOUNT_ID))
+
+        val raw = get(mockServer, clientDerivedPath("getBalances", ACCOUNT_ID))
+
+        val balances: List<BalanceDto> = mapper.readValue(raw)
+        assertThat(balances).hasSize(1)
+        assertThat(balances.single().currency).isEqualTo("CZK")
+        assertThat(balances.single().availableAmount).isEqualByComparingTo(BigDecimal("950.00"))
+    }
+
+    // --- transactions ---------------------------------------------------------------------------
+
+    @Pact(consumer = CONSUMER, provider = PROVIDER)
+    fun accountTransactionsPact(builder: PactDslWithProvider): RequestResponsePact = builder
+        .given("the customer owns an account with transactions")
+        .uponReceiving("GET the transactions of an owned account")
+        .path(TRANSACTIONS_PATH)
+        .query("accountId=$ACCOUNT_ID&limit=10")
+        .method("GET")
+        .headers(mapOf("Accept" to "application/json"))
+        .willRespondWith()
+        .status(200)
+        .headers(mapOf("Content-Type" to "application/json"))
+        .body(
+            newJsonBody { o ->
+                o.array("data") { a ->
+                    a.`object` { t ->
+                        t.decimalType("amount", BigDecimal("250.00"))
+                        t.stringType("currencyCode", "CZK")
+                        t.stringType("type", "PAYMENT")
+                        t.stringType("status", "BOOKED")
+                        t.stringType("bookingDate", "2026-07-01")
+                        t.stringType("description", "Rent")
+                    }
+                }
+            }.build(),
+        )
+        .toPact()
+
+    @Test
+    @PactTestFor(pactMethod = "accountTransactionsPact")
+    fun `listTransactions parses the edge's real transaction page shape`(mockServer: MockServer) {
+        assertClientPathMatches(TRANSACTIONS_PATH, clientDerivedPath("listTransactions"))
+
+        val raw = given()
+            .baseUri(mockServer.getUrl())
+            .accept("application/json")
+            .queryParam("accountId", ACCOUNT_ID)
+            .queryParam("limit", 10)
+            .get(clientDerivedPath("listTransactions"))
+            .then()
+            .statusCode(200)
+            .extract().asString()
+
+        val page = mapper.readValue<TransactionPage>(raw)
+        assertThat(page.data).hasSize(1)
+        assertThat(page.data.single().description).isEqualTo("Rent")
+    }
+
+    // --- fx rates ---------------------------------------------------------------------------
+
+    @Pact(consumer = CONSUMER, provider = PROVIDER)
+    fun fxRatesPact(builder: PactDslWithProvider): RequestResponsePact = builder
+        .given("fx rates are available")
+        .uponReceiving("GET the current FX rates")
+        .path(FX_RATES_PATH)
+        .method("GET")
+        .headers(mapOf("Accept" to "application/json"))
+        .willRespondWith()
+        .status(200)
+        .headers(mapOf("Content-Type" to "application/json"))
+        .body(
+            LambdaDsl.newJsonArrayMinLike(1) { arr ->
+                arr.`object` { o ->
+                    o.stringType("base", "EUR")
+                    o.stringType("quote", "CZK")
+                    o.stringType("rate", "25.0")
+                }
+            }.build(),
+        )
+        .toPact()
+
+    @Test
+    @PactTestFor(pactMethod = "fxRatesPact")
+    fun `getFxRates parses the edge's projected rate list`(mockServer: MockServer) {
+        assertClientPathMatches(FX_RATES_PATH, clientDerivedPath("getFxRates"))
+
+        val raw = get(mockServer, clientDerivedPath("getFxRates"))
+
+        val rates: List<FxRateDto> = mapper.readValue(raw)
+        assertThat(rates).hasSize(1)
+        assertThat(rates.single().base).isEqualTo("EUR")
+    }
+
+    // --- cards ---------------------------------------------------------------------------
+
+    @Pact(consumer = CONSUMER, provider = PROVIDER)
+    fun cardsPact(builder: PactDslWithProvider): RequestResponsePact = builder
+        .given("the customer has a card")
+        .uponReceiving("GET the customer's cards")
+        .path(CARDS_PATH)
+        .method("GET")
+        .headers(mapOf("Accept" to "application/json"))
+        .willRespondWith()
+        .status(200)
+        .headers(mapOf("Content-Type" to "application/json"))
+        .body(
+            LambdaDsl.newJsonArrayMinLike(1) { arr ->
+                arr.`object` { o ->
+                    o.uuid("id", UUID.randomUUID())
+                    o.stringType("maskedPan", "**** **** **** 1234")
+                    o.stringType("cardType", "DEBIT")
+                    o.stringType("network", "VISA")
+                    o.stringType("status", "ACTIVE")
+                    o.stringType("expiryDate", "2029-12-31")
+                    o.stringType("currency", "CZK")
+                }
+            }.build(),
+        )
+        .toPact()
+
+    @Test
+    @PactTestFor(pactMethod = "cardsPact")
+    fun `listCards parses the edge's card list shape`(mockServer: MockServer) {
+        assertClientPathMatches(CARDS_PATH, clientDerivedPath("listCards"))
+
+        val raw = get(mockServer, clientDerivedPath("listCards"))
+
+        val cards: List<CardDto> = mapper.readValue(raw)
+        assertThat(cards).hasSize(1)
+        assertThat(cards.single().network).isEqualTo("VISA")
+    }
+
+    // --- statements ---------------------------------------------------------------------------
+
+    @Pact(consumer = CONSUMER, provider = PROVIDER)
+    fun statementsPact(builder: PactDslWithProvider): RequestResponsePact = builder
+        .given("the customer owns an account with statements")
+        .uponReceiving("GET the statements of an owned account")
+        .path(statementsPath(ACCOUNT_ID))
+        .method("GET")
+        .headers(mapOf("Accept" to "application/json"))
+        .willRespondWith()
+        .status(200)
+        .headers(mapOf("Content-Type" to "application/json"))
+        .body(
+            LambdaDsl.newJsonArrayMinLike(1) { arr ->
+                arr.`object` { o ->
+                    o.uuid("id", UUID.randomUUID())
+                    o.stringType("pocketCurrency", "CZK")
+                    o.stringType("periodFrom", "2026-06-01")
+                    o.stringType("periodTo", "2026-06-30")
+                    o.numberType("legalSequenceNumber", 7)
+                    o.decimalType("openingBalance", BigDecimal("900.00"))
+                    o.decimalType("closingBalance", BigDecimal("1000.00"))
+                    o.numberType("entryCount", 12)
+                    o.stringType("status", "ISSUED")
+                }
+            }.build(),
+        )
+        .toPact()
+
+    @Test
+    @PactTestFor(pactMethod = "statementsPact")
+    fun `listStatements parses the edge's statement list shape`(mockServer: MockServer) {
+        val path = statementsPath(ACCOUNT_ID)
+        assertClientPathMatches(path, clientDerivedPath("listStatements", ACCOUNT_ID))
+
+        val raw = get(mockServer, clientDerivedPath("listStatements", ACCOUNT_ID))
+
+        val statements: List<StatementDto> = mapper.readValue(raw)
+        assertThat(statements).hasSize(1)
+        assertThat(statements.single().legalSequenceNumber).isEqualTo(7)
+    }
+
+    // --- standing orders --------------------------------------------------------------------
+
+    @Pact(consumer = CONSUMER, provider = PROVIDER)
+    fun standingOrdersPact(builder: PactDslWithProvider): RequestResponsePact = builder
+        .given("the customer has a standing order")
+        .uponReceiving("GET the customer's standing orders")
+        .path(STANDING_ORDERS_PATH)
+        .method("GET")
+        .headers(mapOf("Accept" to "application/json"))
+        .willRespondWith()
+        .status(200)
+        .headers(mapOf("Content-Type" to "application/json"))
+        .body(
+            LambdaDsl.newJsonArrayMinLike(1) { arr ->
+                arr.`object` { o ->
+                    o.uuid("id", UUID.randomUUID())
+                    o.stringType("creditorIban", "CZ6508000000192000145399")
+                    o.stringType("creditorName", "Elektrárna a.s.")
+                    o.stringType("status", "ACTIVE")
+                    o.stringType("frequency", "MONTHLY")
+                    o.decimalType("amount", BigDecimal("1500.0"))
+                    o.stringType("currency", "CZK")
+                    o.stringType("nextExecutionDate", "2026-08-01")
+                    o.stringType("remittanceInfo", "Elektřina")
+                }
+            }.build(),
+        )
+        .toPact()
+
+    @Test
+    @PactTestFor(pactMethod = "standingOrdersPact")
+    fun `listStandingOrders parses the edge's standing-order list shape`(mockServer: MockServer) {
+        assertClientPathMatches(STANDING_ORDERS_PATH, clientDerivedPath("listStandingOrders"))
+
+        val raw = get(mockServer, clientDerivedPath("listStandingOrders"))
+
+        val orders: List<StandingOrderDto> = mapper.readValue(raw)
+        assertThat(orders).hasSize(1)
+        assertThat(orders.single().creditorName).isEqualTo("Elektrárna a.s.")
+    }
+
+    // --- shared helpers -----------------------------------------------------------------------
+
+    private fun get(mockServer: MockServer, path: String): String = given()
+        .baseUri(mockServer.getUrl())
+        .accept("application/json")
+        // Reflected off the client, NOT retyped: this is the request the real client issues.
+        .get(path)
+        .then()
+        .statusCode(200)
+        .extract().asString()
+
+    /**
+     * The asymmetry that makes this contract falsifiable at the consumer layer: the path the
+     * client would really call, recomputed from [CustomerEdgeRestClient]'s own annotations, must
+     * equal the LITERAL this pact promises customer-edge. A `@Path` edit on the client reddens
+     * here.
+     */
+    private fun assertClientPathMatches(expected: String, actual: String) {
+        assertThat(actual)
+            .describedAs(
+                "CustomerEdgeRestClient's @Path no longer produces the path this pact pins — " +
+                    "either fix the client or update the literal *and* re-verify against customer-edge",
+            )
+            .isEqualTo(expected)
+    }
+
+    private companion object {
+        const val CONSUMER = "openbank-copilot-service"
+        const val PROVIDER = "openbank-customer-edge"
+
+        const val ACCOUNT_ID = "33333333-3333-3333-3333-333333333333"
+
+        // LITERAL — never derived from the client annotations (CLAUDE.md).
+        const val ACCOUNTS_PATH = "/customer/v1/accounts"
+        const val TRANSACTIONS_PATH = "/customer/v1/transactions"
+        const val FX_RATES_PATH = "/customer/v1/fx/rates"
+        const val CARDS_PATH = "/customer/v1/cards"
+        const val STANDING_ORDERS_PATH = "/customer/v1/standing-orders"
+
+        fun balancesPath(accountId: String) = "/customer/v1/balances/$accountId"
+
+        fun statementsPath(accountId: String) = "/customer/v1/statements/$accountId"
+
+        fun clientDerivedPath(methodName: String, vararg pathParams: String): String {
+            val method = CustomerEdgeRestClient::class.java.methods.single { it.name == methodName }
+            var path = method.getAnnotation(Path::class.java).value
+            pathParams.forEach { value ->
+                path = path.replaceFirst(Regex("\\{[^}]+}"), value)
+            }
+            return path
+        }
+    }
+}

--- a/openbank-customer-edge/build.gradle.kts
+++ b/openbank-customer-edge/build.gradle.kts
@@ -46,6 +46,29 @@ dependencies {
     testImplementation(libs.mockk)
     testImplementation(libs.testcontainers)
     testImplementation(libs.testcontainers.redpanda)
+    // Provider-side Pact verification (ADR-0063, issue #2322): replays copilot's
+    // CustomerEdgeContractConsumerTest against a real booted instance.
+    testImplementation(libs.pact.provider)
+    // Synthesizes the customer JWT (party_id claim) @TestSecurity alone cannot set for a
+    // quarkus-oidc-backed resource server — same mechanism openbank-mcp-service already uses.
+    testImplementation(libs.quarkus.test.security.oidc)
+}
+
+// Pact: read consumer pacts from the shared pacts/ dir at the repo root (git-pact, ADR-0063).
+// NOTE: must be set on the test JVM fork, not the Gradle daemon (System.setProperty would not propagate).
+tasks.withType<Test> {
+    systemProperty("pact.rootDir", "${rootProject.projectDir}/pacts")
+    listOf(
+        "pactbroker.url",
+        "pactbroker.auth.username",
+        "pactbroker.auth.password",
+        "pactbroker.enablePending",
+        "pactbroker.providerBranch",
+        "pact.verifier.publishResults",
+        "pact.provider.version",
+        "pact.provider.branch",
+        "pact.provider.tag",
+    ).forEach { key -> System.getProperty(key)?.let { systemProperty(key, it) } }
 }
 
 // Coverage floor (ADR-0020, ratchet-only — sweep #466: this module previously had NO

--- a/openbank-customer-edge/src/test/kotlin/com/openbank/customeredge/contract/CustomerEdgeContractProviderVerificationTest.kt
+++ b/openbank-customer-edge/src/test/kotlin/com/openbank/customeredge/contract/CustomerEdgeContractProviderVerificationTest.kt
@@ -1,0 +1,181 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright (c) OpenBank contributors. Licensed under the Apache License, Version 2.0.
+// See LICENSE in the repository root or https://www.apache.org/licenses/LICENSE-2.0 for details.
+package com.openbank.customeredge.contract
+
+import au.com.dius.pact.provider.junit5.HttpTestTarget
+import au.com.dius.pact.provider.junit5.PactVerificationContext
+import au.com.dius.pact.provider.junit5.PactVerificationInvocationContextProvider
+import au.com.dius.pact.provider.junitsupport.IgnoreNoPactsToVerify
+import au.com.dius.pact.provider.junitsupport.Provider
+import au.com.dius.pact.provider.junitsupport.State
+import au.com.dius.pact.provider.junitsupport.loader.PactFolder
+import io.quarkus.test.common.QuarkusTestResource
+import io.quarkus.test.junit.QuarkusTest
+import io.quarkus.test.security.TestSecurity
+import io.quarkus.test.security.oidc.Claim
+import io.quarkus.test.security.oidc.OidcSecurity
+import org.eclipse.microprofile.config.inject.ConfigProperty
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.TestTemplate
+import org.junit.jupiter.api.extension.ExtendWith
+
+/**
+ * Provider-side Pact verification for customer-edge (issue #2322). Replays copilot's
+ * `CustomerEdgePactConsumerTest` — the seven `/customer/v1` reads every copilot READ tool is
+ * a thin wrapper over — against a real booted instance.
+ *
+ * Git-pact (`@PactFolder`, ADR-0063): reads consumer pacts from the monorepo-root `pacts/` dir and
+ * **always runs** — no broker, no CI secret, no gate. That matters here specifically: copilot
+ * propagates the customer's OWN bearer on these calls (on-behalf-of, ADR-0065 / ADR-0089 D5), so a
+ * wrong response shape or a route the edge stopped serving degrades a figure the assistant
+ * narrates to the customer, silently. A consumer pact nobody replays cannot catch that — see
+ * CLAUDE.md "Contract tests (Pact)".
+ *
+ * **This must remain the ONLY `@Provider("openbank-customer-edge")` class in the repo** — two
+ * classes with the same provider name both pull every pact and collide.
+ *
+ * Auth: `@TestSecurity` + `@OidcSecurity(claims = [Claim("party_id", ...)])` synthesizes the
+ * customer JWT `CustomerEdgeResource.customer()` reads (`org.eclipse.microprofile.jwt.JsonWebToken`
+ * under `quarkus-oidc`) — the same mechanism `openbank-mcp-service`'s `McpAuditEventIT` already
+ * uses for a `quarkus-oidc`-backed resource server. `@Authorize` is satisfied fleet-wide in tests
+ * by `MockAuthzProducer` (`@Mock`, auto-applied — no PDP needed). The party id is fixed for the
+ * whole class: `@OidcSecurity`'s `claims` must be compile-time constants, so every interaction's
+ * fixture data is built around this one party/account pair.
+ *
+ * Upstreams are stubbed by [StubUpstreamResource] — a single loopback HTTP server standing in for
+ * all seven upstream services plus the Keycloak token endpoint, since customer-edge is a BFF that
+ * calls out through one generic `UpstreamClient`, not seven typed REST clients. Ownership-gated
+ * reads (balances, transactions, statements) additionally need the account-ownership lookup
+ * (`GET /api/v1/accounts/{accountId}`) stubbed — [ownedAccountFixture] is that shared fixture.
+ */
+@QuarkusTest
+@QuarkusTestResource(StubUpstreamResource::class)
+@TestSecurity(user = "customer:$PARTY_ID", roles = ["ROLE_CUSTOMER"])
+@OidcSecurity(claims = [Claim(key = "party_id", value = PARTY_ID)])
+@Provider("openbank-customer-edge")
+@PactFolder("../pacts")
+@IgnoreNoPactsToVerify(ignoreIoErrors = "true")
+class CustomerEdgeContractProviderVerificationTest {
+
+    @ConfigProperty(name = "quarkus.http.test-port", defaultValue = "8081")
+    lateinit var testPort: String
+
+    @BeforeEach
+    fun configureTarget(context: PactVerificationContext?) {
+        StubUpstreamResource.reset()
+        if (context == null) return
+        context.target = HttpTestTarget("localhost", testPort.toInt())
+        context.addStateChangeHandlers(this)
+    }
+
+    @TestTemplate
+    @ExtendWith(PactVerificationInvocationContextProvider::class)
+    fun verifyPacts(context: PactVerificationContext?) {
+        // context is null on the @IgnoreNoPactsToVerify dummy invocation — skip gracefully.
+        context?.verifyInteraction()
+    }
+
+    /** account-service's ownership-check response every ownership-gated read needs first. */
+    private fun ownedAccountFixture(): String = """
+        {"id":"$ACCOUNT_ID","accountNumber":"123456789/0800","accountType":"CURRENT",
+         "partyId":"$PARTY_ID","productId":"current-standard","currencyCode":"CZK"}
+    """.trimIndent()
+
+    @State("the customer has one account")
+    fun customerHasOneAccount() {
+        StubUpstreamResource.stub(
+            "/api/v1/accounts",
+            body = """{"data":[$FULL_ACCOUNT_JSON]}""",
+        )
+    }
+
+    @State("the customer owns an account with a balance")
+    fun customerOwnsAnAccountWithABalance() {
+        StubUpstreamResource.stub("/api/v1/accounts/$ACCOUNT_ID", body = ownedAccountFixture())
+        StubUpstreamResource.stub(
+            "/api/v1/balances/$ACCOUNT_ID",
+            // Bare JSON array — balance-service's real shape (issue #2322 / #2458). NOT wrapped.
+            body = """[{"currency":"CZK","bookedAmount":1000.00,"availableAmount":950.00}]""",
+        )
+    }
+
+    @State("the customer owns an account with transactions")
+    fun customerOwnsAnAccountWithTransactions() {
+        StubUpstreamResource.stub("/api/v1/accounts/$ACCOUNT_ID", body = ownedAccountFixture())
+        StubUpstreamResource.stub(
+            "/api/v1/transactions",
+            body = """
+                {"data":[{"amount":250.00,"currencyCode":"CZK","type":"PAYMENT","status":"BOOKED",
+                          "bookingDate":"2026-07-01","description":"Rent"}],
+                 "pagination":{"limit":10,"hasNextPage":false}}
+            """.trimIndent(),
+        )
+    }
+
+    @State("fx rates are available")
+    fun fxRatesAreAvailable() {
+        StubUpstreamResource.stub(
+            "/api/v1/fx/rates",
+            // Raw fx-service shape (mapFxRateRow reads baseCurrency/quoteCurrency/bidRate/askRate);
+            // source != "CNB" so it lands in the bank-rate list the edge projects, not the CNB
+            // reference map.
+            body = """
+                [{"baseCurrency":"EUR","quoteCurrency":"CZK","bidRate":"24.90","askRate":"25.10",
+                  "source":"INTERNAL","validFrom":"2026-07-25T08:00:00Z"}]
+            """.trimIndent(),
+        )
+    }
+
+    @State("the customer has a card")
+    fun customerHasACard() {
+        StubUpstreamResource.stub(
+            "/api/v1/cards/party/$PARTY_ID",
+            body = """
+                [{"id":"$CARD_ID","maskedPan":"**** **** **** 1234","cardType":"DEBIT",
+                  "network":"VISA","status":"ACTIVE","expiryDate":"2029-12-31","currency":"CZK"}]
+            """.trimIndent(),
+        )
+    }
+
+    @State("the customer owns an account with statements")
+    fun customerOwnsAnAccountWithStatements() {
+        StubUpstreamResource.stub("/api/v1/accounts/$ACCOUNT_ID", body = ownedAccountFixture())
+        StubUpstreamResource.stub(
+            "/api/v1/statements/$ACCOUNT_ID",
+            body = """
+                [{"id":"$STATEMENT_ID","pocketCurrency":"CZK","periodFrom":"2026-06-01",
+                  "periodTo":"2026-06-30","legalSequenceNumber":7,"openingBalance":900.00,
+                  "closingBalance":1000.00,"entryCount":12,"status":"ISSUED"}]
+            """.trimIndent(),
+        )
+    }
+
+    @State("the customer has a standing order")
+    fun customerHasAStandingOrder() {
+        StubUpstreamResource.stub(
+            "/api/v1/standing-orders/party/$PARTY_ID",
+            body = """
+                [{"id":"$STANDING_ORDER_ID","creditorIban":"CZ6508000000192000145399",
+                  "creditorName":"Elektrárna a.s.","status":"ACTIVE","frequency":"MONTHLY",
+                  "amount":1500.0,"currency":"CZK","nextExecutionDate":"2026-08-01",
+                  "remittanceInfo":"Elektřina"}]
+            """.trimIndent(),
+        )
+    }
+
+    companion object {
+        private const val FULL_ACCOUNT_JSON = """
+            {"id":"$ACCOUNT_ID","accountNumber":"123456789/0800","accountType":"CURRENT",
+             "partyId":"$PARTY_ID","productId":"current-standard","currencyCode":"CZK",
+             "status":"ACTIVE"}
+        """
+    }
+}
+
+// Compile-time constants for @OidcSecurity(claims = [...]) — must live outside the class body.
+internal const val PARTY_ID = "22222222-2222-2222-2222-222222222222"
+internal const val ACCOUNT_ID = "33333333-3333-3333-3333-333333333333"
+internal const val CARD_ID = "44444444-4444-4444-4444-444444444444"
+internal const val STATEMENT_ID = "55555555-5555-5555-5555-555555555555"
+internal const val STANDING_ORDER_ID = "66666666-6666-6666-6666-666666666666"

--- a/openbank-customer-edge/src/test/kotlin/com/openbank/customeredge/contract/StubUpstreamResource.kt
+++ b/openbank-customer-edge/src/test/kotlin/com/openbank/customeredge/contract/StubUpstreamResource.kt
@@ -1,0 +1,91 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright (c) OpenBank contributors. Licensed under the Apache License, Version 2.0.
+// See LICENSE in the repository root or https://www.apache.org/licenses/LICENSE-2.0 for details.
+package com.openbank.customeredge.contract
+
+import com.sun.net.httpserver.HttpExchange
+import com.sun.net.httpserver.HttpServer
+import io.quarkus.test.common.QuarkusTestResourceLifecycleManager
+import java.net.InetSocketAddress
+import java.util.concurrent.ConcurrentHashMap
+
+/**
+ * A loopback JDK [HttpServer] standing in for every upstream `UpstreamClient` calls (account-,
+ * balance-, transaction-, fx-, card-issuance-, statement- and standing-order-service) PLUS the
+ * Keycloak token endpoint, for the provider-verification test in this package (issue #2322).
+ *
+ * customer-edge is a BFF: it fronts seven upstream services via one generic [UpstreamClient], not
+ * seven typed MP REST Client interfaces, so there is no single upstream to boot a Testcontainer
+ * for. Config overrides below point every `openbank.edge.*-service-url` property AND
+ * `openbank.upstream.token-url` at this one loopback server; `@State` handlers register the fixed
+ * response each path should answer with before their interaction runs. The token endpoint is
+ * wired unconditionally — it fires on every request via [UpstreamClient.serviceToken] regardless
+ * of which upstream is being called.
+ *
+ * Same JDK `HttpServer` approach [com.openbank.customeredge.UpstreamClientTest] already uses for a
+ * single-call unit test; this is the same idea kept alive for the whole test class instead of one
+ * `withServer { }` block per test, because a `@TestTemplate`-driven Pact verification needs the
+ * config override in place before Quarkus boots, not per-test.
+ */
+class StubUpstreamResource : QuarkusTestResourceLifecycleManager {
+
+    companion object {
+        private var server: HttpServer? = null
+
+        /** path (no query string) -> fixed (status, contentType, body) the stub answers with. */
+        private val routes = ConcurrentHashMap<String, Fixture>()
+
+        data class Fixture(val status: Int, val contentType: String, val body: String)
+
+        /** Registers (or replaces) the fixed response for [path]. Call from a `@State` handler. */
+        fun stub(path: String, status: Int = 200, contentType: String = "application/json", body: String) {
+            routes[path] = Fixture(status, contentType, body)
+        }
+
+        /** Clears every registered route — call at the start of each `@State` handler. */
+        fun reset() = routes.clear()
+    }
+
+    override fun start(): Map<String, String> {
+        val s = HttpServer.create(InetSocketAddress("127.0.0.1", 0), 0)
+        s.createContext("/protocol/openid-connect/token") { exchange ->
+            respond(exchange, 200, "application/json", """{"access_token":"stub-token","expires_in":300}""")
+        }
+        s.createContext("/") { exchange ->
+            val path = exchange.requestURI.path
+            val fixture = routes[path]
+            if (fixture != null) {
+                respond(exchange, fixture.status, fixture.contentType, fixture.body)
+            } else {
+                respond(exchange, 404, "application/json", """{"error":"no stub registered for $path"}""")
+            }
+        }
+        s.executor = null
+        s.start()
+        server = s
+        val base = "http://127.0.0.1:${s.address.port}"
+        return mapOf(
+            "openbank.upstream.token-url" to base,
+            "openbank.edge.account-service-url" to base,
+            "openbank.edge.balance-service-url" to base,
+            "openbank.edge.transaction-service-url" to base,
+            "openbank.edge.statement-service-url" to base,
+            "openbank.edge.standing-order-service-url" to base,
+            "openbank.edge.fx-service-url" to base,
+            "openbank.edge.card-issuance-service-url" to base,
+        )
+    }
+
+    override fun stop() {
+        server?.stop(0)
+        server = null
+        routes.clear()
+    }
+
+    private fun respond(exchange: HttpExchange, status: Int, contentType: String, body: String) {
+        val bytes = body.toByteArray(Charsets.UTF_8)
+        exchange.responseHeaders.add("Content-Type", contentType)
+        exchange.sendResponseHeaders(status, bytes.size.toLong())
+        exchange.responseBody.use { it.write(bytes) }
+    }
+}

--- a/pacts/openbank-copilot-service-openbank-customer-edge.json
+++ b/pacts/openbank-copilot-service-openbank-customer-edge.json
@@ -1,0 +1,660 @@
+{
+  "consumer": {
+    "name": "openbank-copilot-service"
+  },
+  "interactions": [
+    {
+      "description": "GET the current FX rates",
+      "providerStates": [
+        {
+          "name": "fx rates are available"
+        }
+      ],
+      "request": {
+        "headers": {
+          "Accept": "application/json"
+        },
+        "method": "GET",
+        "path": "/customer/v1/fx/rates"
+      },
+      "response": {
+        "body": [
+          {
+            "base": "EUR",
+            "quote": "CZK",
+            "rate": "25.0"
+          }
+        ],
+        "headers": {
+          "Content-Type": "application/json"
+        },
+        "matchingRules": {
+          "body": {
+            "$": {
+              "combine": "AND",
+              "matchers": [
+                {
+                  "match": "type",
+                  "min": 1
+                }
+              ]
+            },
+            "$[*].base": {
+              "combine": "AND",
+              "matchers": [
+                {
+                  "match": "type"
+                }
+              ]
+            },
+            "$[*].quote": {
+              "combine": "AND",
+              "matchers": [
+                {
+                  "match": "type"
+                }
+              ]
+            },
+            "$[*].rate": {
+              "combine": "AND",
+              "matchers": [
+                {
+                  "match": "type"
+                }
+              ]
+            }
+          }
+        },
+        "status": 200
+      }
+    },
+    {
+      "description": "GET the customer's cards",
+      "providerStates": [
+        {
+          "name": "the customer has a card"
+        }
+      ],
+      "request": {
+        "headers": {
+          "Accept": "application/json"
+        },
+        "method": "GET",
+        "path": "/customer/v1/cards"
+      },
+      "response": {
+        "body": [
+          {
+            "cardType": "DEBIT",
+            "currency": "CZK",
+            "expiryDate": "2029-12-31",
+            "id": "1cc6f93f-9407-47c8-a4ac-10c7240b047e",
+            "maskedPan": "**** **** **** 1234",
+            "network": "VISA",
+            "status": "ACTIVE"
+          }
+        ],
+        "headers": {
+          "Content-Type": "application/json"
+        },
+        "matchingRules": {
+          "body": {
+            "$": {
+              "combine": "AND",
+              "matchers": [
+                {
+                  "match": "type",
+                  "min": 1
+                }
+              ]
+            },
+            "$[*].cardType": {
+              "combine": "AND",
+              "matchers": [
+                {
+                  "match": "type"
+                }
+              ]
+            },
+            "$[*].currency": {
+              "combine": "AND",
+              "matchers": [
+                {
+                  "match": "type"
+                }
+              ]
+            },
+            "$[*].expiryDate": {
+              "combine": "AND",
+              "matchers": [
+                {
+                  "match": "type"
+                }
+              ]
+            },
+            "$[*].id": {
+              "combine": "AND",
+              "matchers": [
+                {
+                  "match": "regex",
+                  "regex": "[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}"
+                }
+              ]
+            },
+            "$[*].maskedPan": {
+              "combine": "AND",
+              "matchers": [
+                {
+                  "match": "type"
+                }
+              ]
+            },
+            "$[*].network": {
+              "combine": "AND",
+              "matchers": [
+                {
+                  "match": "type"
+                }
+              ]
+            },
+            "$[*].status": {
+              "combine": "AND",
+              "matchers": [
+                {
+                  "match": "type"
+                }
+              ]
+            }
+          }
+        },
+        "status": 200
+      }
+    },
+    {
+      "description": "GET the customer's standing orders",
+      "providerStates": [
+        {
+          "name": "the customer has a standing order"
+        }
+      ],
+      "request": {
+        "headers": {
+          "Accept": "application/json"
+        },
+        "method": "GET",
+        "path": "/customer/v1/standing-orders"
+      },
+      "response": {
+        "body": [
+          {
+            "amount": 1500.0,
+            "creditorIban": "CZ6508000000192000145399",
+            "creditorName": "Elektr\u00E1rna a.s.",
+            "currency": "CZK",
+            "frequency": "MONTHLY",
+            "id": "59195df9-7b37-4053-b89d-f4736de73b46",
+            "nextExecutionDate": "2026-08-01",
+            "remittanceInfo": "Elekt\u0159ina",
+            "status": "ACTIVE"
+          }
+        ],
+        "headers": {
+          "Content-Type": "application/json"
+        },
+        "matchingRules": {
+          "body": {
+            "$": {
+              "combine": "AND",
+              "matchers": [
+                {
+                  "match": "type",
+                  "min": 1
+                }
+              ]
+            },
+            "$[*].amount": {
+              "combine": "AND",
+              "matchers": [
+                {
+                  "match": "decimal"
+                }
+              ]
+            },
+            "$[*].creditorIban": {
+              "combine": "AND",
+              "matchers": [
+                {
+                  "match": "type"
+                }
+              ]
+            },
+            "$[*].creditorName": {
+              "combine": "AND",
+              "matchers": [
+                {
+                  "match": "type"
+                }
+              ]
+            },
+            "$[*].currency": {
+              "combine": "AND",
+              "matchers": [
+                {
+                  "match": "type"
+                }
+              ]
+            },
+            "$[*].frequency": {
+              "combine": "AND",
+              "matchers": [
+                {
+                  "match": "type"
+                }
+              ]
+            },
+            "$[*].id": {
+              "combine": "AND",
+              "matchers": [
+                {
+                  "match": "regex",
+                  "regex": "[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}"
+                }
+              ]
+            },
+            "$[*].nextExecutionDate": {
+              "combine": "AND",
+              "matchers": [
+                {
+                  "match": "type"
+                }
+              ]
+            },
+            "$[*].remittanceInfo": {
+              "combine": "AND",
+              "matchers": [
+                {
+                  "match": "type"
+                }
+              ]
+            },
+            "$[*].status": {
+              "combine": "AND",
+              "matchers": [
+                {
+                  "match": "type"
+                }
+              ]
+            }
+          }
+        },
+        "status": 200
+      }
+    },
+    {
+      "description": "GET the customer's accounts",
+      "providerStates": [
+        {
+          "name": "the customer has one account"
+        }
+      ],
+      "request": {
+        "headers": {
+          "Accept": "application/json"
+        },
+        "method": "GET",
+        "path": "/customer/v1/accounts"
+      },
+      "response": {
+        "body": {
+          "data": [
+            {
+              "accountNumber": "123456789/0800",
+              "accountType": "CURRENT",
+              "currencyCode": "CZK",
+              "id": "33333333-3333-3333-3333-333333333333",
+              "status": "ACTIVE"
+            }
+          ]
+        },
+        "headers": {
+          "Content-Type": "application/json"
+        },
+        "matchingRules": {
+          "body": {
+            "$.data[0].accountNumber": {
+              "combine": "AND",
+              "matchers": [
+                {
+                  "match": "type"
+                }
+              ]
+            },
+            "$.data[0].accountType": {
+              "combine": "AND",
+              "matchers": [
+                {
+                  "match": "type"
+                }
+              ]
+            },
+            "$.data[0].currencyCode": {
+              "combine": "AND",
+              "matchers": [
+                {
+                  "match": "type"
+                }
+              ]
+            },
+            "$.data[0].id": {
+              "combine": "AND",
+              "matchers": [
+                {
+                  "match": "regex",
+                  "regex": "[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}"
+                }
+              ]
+            },
+            "$.data[0].status": {
+              "combine": "AND",
+              "matchers": [
+                {
+                  "match": "type"
+                }
+              ]
+            }
+          }
+        },
+        "status": 200
+      }
+    },
+    {
+      "description": "GET the balance of an owned account",
+      "providerStates": [
+        {
+          "name": "the customer owns an account with a balance"
+        }
+      ],
+      "request": {
+        "headers": {
+          "Accept": "application/json"
+        },
+        "method": "GET",
+        "path": "/customer/v1/balances/33333333-3333-3333-3333-333333333333"
+      },
+      "response": {
+        "body": [
+          {
+            "availableAmount": 950.00,
+            "bookedAmount": 1000.00,
+            "currency": "CZK"
+          }
+        ],
+        "headers": {
+          "Content-Type": "application/json"
+        },
+        "matchingRules": {
+          "body": {
+            "$": {
+              "combine": "AND",
+              "matchers": [
+                {
+                  "match": "type",
+                  "min": 1
+                }
+              ]
+            },
+            "$[*].availableAmount": {
+              "combine": "AND",
+              "matchers": [
+                {
+                  "match": "decimal"
+                }
+              ]
+            },
+            "$[*].bookedAmount": {
+              "combine": "AND",
+              "matchers": [
+                {
+                  "match": "decimal"
+                }
+              ]
+            },
+            "$[*].currency": {
+              "combine": "AND",
+              "matchers": [
+                {
+                  "match": "type"
+                }
+              ]
+            }
+          }
+        },
+        "status": 200
+      }
+    },
+    {
+      "description": "GET the statements of an owned account",
+      "providerStates": [
+        {
+          "name": "the customer owns an account with statements"
+        }
+      ],
+      "request": {
+        "headers": {
+          "Accept": "application/json"
+        },
+        "method": "GET",
+        "path": "/customer/v1/statements/33333333-3333-3333-3333-333333333333"
+      },
+      "response": {
+        "body": [
+          {
+            "closingBalance": 1000.00,
+            "entryCount": 12,
+            "id": "1761c48d-4290-4e0d-8c26-4eac4e3146ba",
+            "legalSequenceNumber": 7,
+            "openingBalance": 900.00,
+            "periodFrom": "2026-06-01",
+            "periodTo": "2026-06-30",
+            "pocketCurrency": "CZK",
+            "status": "ISSUED"
+          }
+        ],
+        "headers": {
+          "Content-Type": "application/json"
+        },
+        "matchingRules": {
+          "body": {
+            "$": {
+              "combine": "AND",
+              "matchers": [
+                {
+                  "match": "type",
+                  "min": 1
+                }
+              ]
+            },
+            "$[*].closingBalance": {
+              "combine": "AND",
+              "matchers": [
+                {
+                  "match": "decimal"
+                }
+              ]
+            },
+            "$[*].entryCount": {
+              "combine": "AND",
+              "matchers": [
+                {
+                  "match": "number"
+                }
+              ]
+            },
+            "$[*].id": {
+              "combine": "AND",
+              "matchers": [
+                {
+                  "match": "regex",
+                  "regex": "[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}"
+                }
+              ]
+            },
+            "$[*].legalSequenceNumber": {
+              "combine": "AND",
+              "matchers": [
+                {
+                  "match": "number"
+                }
+              ]
+            },
+            "$[*].openingBalance": {
+              "combine": "AND",
+              "matchers": [
+                {
+                  "match": "decimal"
+                }
+              ]
+            },
+            "$[*].periodFrom": {
+              "combine": "AND",
+              "matchers": [
+                {
+                  "match": "type"
+                }
+              ]
+            },
+            "$[*].periodTo": {
+              "combine": "AND",
+              "matchers": [
+                {
+                  "match": "type"
+                }
+              ]
+            },
+            "$[*].pocketCurrency": {
+              "combine": "AND",
+              "matchers": [
+                {
+                  "match": "type"
+                }
+              ]
+            },
+            "$[*].status": {
+              "combine": "AND",
+              "matchers": [
+                {
+                  "match": "type"
+                }
+              ]
+            }
+          }
+        },
+        "status": 200
+      }
+    },
+    {
+      "description": "GET the transactions of an owned account",
+      "providerStates": [
+        {
+          "name": "the customer owns an account with transactions"
+        }
+      ],
+      "request": {
+        "headers": {
+          "Accept": "application/json"
+        },
+        "method": "GET",
+        "path": "/customer/v1/transactions",
+        "query": {
+          "accountId": [
+            "33333333-3333-3333-3333-333333333333"
+          ],
+          "limit": [
+            "10"
+          ]
+        }
+      },
+      "response": {
+        "body": {
+          "data": [
+            {
+              "amount": 250.00,
+              "bookingDate": "2026-07-01",
+              "currencyCode": "CZK",
+              "description": "Rent",
+              "status": "BOOKED",
+              "type": "PAYMENT"
+            }
+          ]
+        },
+        "headers": {
+          "Content-Type": "application/json"
+        },
+        "matchingRules": {
+          "body": {
+            "$.data[0].amount": {
+              "combine": "AND",
+              "matchers": [
+                {
+                  "match": "decimal"
+                }
+              ]
+            },
+            "$.data[0].bookingDate": {
+              "combine": "AND",
+              "matchers": [
+                {
+                  "match": "type"
+                }
+              ]
+            },
+            "$.data[0].currencyCode": {
+              "combine": "AND",
+              "matchers": [
+                {
+                  "match": "type"
+                }
+              ]
+            },
+            "$.data[0].description": {
+              "combine": "AND",
+              "matchers": [
+                {
+                  "match": "type"
+                }
+              ]
+            },
+            "$.data[0].status": {
+              "combine": "AND",
+              "matchers": [
+                {
+                  "match": "type"
+                }
+              ]
+            },
+            "$.data[0].type": {
+              "combine": "AND",
+              "matchers": [
+                {
+                  "match": "type"
+                }
+              ]
+            }
+          }
+        },
+        "status": 200
+      }
+    }
+  ],
+  "metadata": {
+    "pact-jvm": {
+      "version": "4.7.3"
+    },
+    "pactSpecification": {
+      "version": "3.0.0"
+    }
+  },
+  "provider": {
+    "name": "openbank-customer-edge"
+  }
+}


### PR DESCRIPTION
## What

A provider-verification harness for customer-edge, closing the half of copilot's C3 gap left
deliberately unbuilt in #2255: copilot's **consumed** contract with customer-edge (as opposed to
its own **served** contract, closed separately).

`Closes #2322`

## Why customer-edge had none

customer-edge had **no HTTP-level test at all**. Its only real `@QuarkusTest` is a Kafka-consumer
boot check; every existing test on `CustomerEdgeResource` constructs it directly with a mocked
`JsonWebToken` — never a real request over the wire. So a wrong path, a renamed field, or a route
customer-edge stopped serving on any of the **seven** `/customer/v1/*` reads every copilot tool
depends on (accounts, balances, transactions, fx rates, cards, statements, standing orders) was
invisible to every test that existed.

## The harness

`StubUpstreamResource` — a single loopback JDK `HttpServer` standing in for all seven upstream
services **plus** the Keycloak token endpoint. customer-edge is a BFF: it calls out through one
generic `UpstreamClient` (raw JDK `HttpClient`, config-driven base URLs), not seven typed REST
clients — so there is no single upstream to boot a Testcontainer for. One stub server,
config-overridden via `QuarkusTestResourceLifecycleManager.start()`, covers all of it. `@State`
handlers register the fixed response each path answers with before its interaction replays;
ownership-gated reads (balances, transactions, statements) additionally stub the
account-ownership lookup customer-edge makes first.

`CustomerEdgePactConsumerTest` (copilot) pins all seven interactions, **path as a literal** per
CLAUDE.md's "Contract tests" section — only the outgoing request is reflected off
`CustomerEdgeRestClient`'s own `@Path`, since deriving both sides is vacuous (measured on #2290).
Named `*PactConsumerTest.kt` to match `derive-pact-drift-scope.sh`'s discovery glob (#2318) — an
earlier name outside that convention left the pact undetected as an orphan pact.

`CustomerEdgeContractProviderVerificationTest` (customer-edge) replays it via `@PactFolder`,
always running, no broker. Auth: `@TestSecurity` + `@OidcSecurity` synthesizes the customer JWT's
`party_id` claim under `quarkus-oidc` — same mechanism `openbank-mcp-service`'s `McpAuditEventIT`
already uses — plus the class's `ROLE_CUSTOMER`; `@Authorize` is satisfied fleet-wide by the
existing `MockAuthzProducer` (`@Mock`, no PDP needed).

## Verification — both directions falsified, verdicts from JUnit XML

| perturbation | consumer | provider |
|---|---|---|
| renamed a response field in the pact | **RED** (that interaction) | n/a |
| reverted client `@Path` to a route the provider never served | green (mock answers whatever it's asked) | **RED** — `expected status of 200 but was 404` |
| **dropped the served route on customer-edge** (the defect class this harness exists for) | n/a | **RED** — `expected status of 200 but was 404`, `missing keys: data` |

**Worth flagging in review:** the third falsification's first attempt silently ran only 6 of 7
interactions instead of failing the 7th — not a harness gap. `pact.writer.overwrite=true` (the
fleet convention, correct behaviour) had already overwritten the committed pact with only the 6
**passing** interactions from an earlier falsification run whose regeneration I hadn't yet
reverted, so the provider correctly had nothing to check against for the 7th. Re-running in the
right order — regenerate a clean 7-interaction pact first, then falsify only the provider side —
reproduced the 404 correctly. Documented in the commit message so the next person doesn't
misread a similarly-shaped silent-pass as a real gap.

- `check-domain-purity.sh`: 11 violations, 0 new.
- Full `build`/`detekt`/`quarkusBuild` on both modules, all green, re-verified on a **fresh
  worktree cut from the merged main tip** (post-#2458) to rule out any state carried over from
  the falsification runs above.

## Release

Commit type `test` — no `src/main` change on either module, so this cuts no release.

## Depends on

#2458 (merged) — `CustomerEdgePactConsumerTest` needs `CustomerEdgeRestClient.getBalances()`'s
corrected `Uni<List<BalanceDto>>` signature to pin the real bare-array wire shape rather than
resurrecting the bug that fix corrected.
