### PR TITLE
ci(governance): score eval coverage against registry.yaml status, not the raw charter list (#2381)

### DIFF
--- a/.github/scripts/check-evals-registry.py
+++ b/.github/scripts/check-evals-registry.py
@@ -43,10 +43,38 @@ VERSION_RE = re.compile(r"^v[0-9]+$")
 ID_RE = re.compile(r"^[a-z0-9-]+$")
 KNOWN_ASSERTS = {"must_not_be_empty", "must_contain", "must_not_contain"}
 
+# Statuses from prompts/registry.yaml that put a charter OUT OF SCOPE for evals rather than in the
+# backlog (issue #2381). Both exclusions are about what the harness can physically do:
+#   not-applicable — the charter causes no model call at all (an identity-only principal), so there
+#                    is no output for a scenario to assert on.
+#   external       — a real model runs, but this repo neither authors the prompt nor makes the call
+#                    (HolmesGPT's own image; an operator's coding-agent session). run-evals.py
+#                    records a run of OUR prompt against OUR model call; for these there is nothing
+#                    to record, and asserting on someone else's output would measure their prompt
+#                    while reading as coverage of ours.
+# `registered` and `pending` stay in the backlog: those are charters this platform does call.
+EVAL_EXEMPT = {"not-applicable", "external"}
+
+REGISTRY = PROMPTS / "registry.yaml"
+
 
 def charter_ids():
     data = yaml.safe_load(AGENTS.read_text())
     return {a.get("id") for a in (data.get("agents", []) or []) if a.get("id")}
+
+
+def charter_status(errors):
+    """Map charter id -> prompts/registry.yaml status (the #1918 coverage vocabulary)."""
+    if not REGISTRY.is_file():
+        errors.append(f"{REGISTRY.relative_to(ROOT)} is missing — eval coverage cannot distinguish "
+                      f"a charter that has no suite yet from one that can never have one")
+        return {}
+    try:
+        doc = yaml.safe_load(REGISTRY.read_text()) or {}
+    except yaml.YAMLError as e:
+        errors.append(f"{REGISTRY.relative_to(ROOT)} — not valid YAML: {e}")
+        return {}
+    return {e.get("id"): e.get("status") for e in (doc.get("charters", []) or []) if e.get("id")}
 
 
 def check_file(path, ids, errors):
@@ -122,10 +150,37 @@ def main():
         if len(errors) == before:
             print(f"  ok  {path.relative_to(ROOT)}")
 
-    missing = sorted(ids - covered)
-    if missing:
-        print(f"::warning title=Evals registry::{len(missing)} charter(s) have no eval suite yet "
-              f"(backlog, ADR-0148): {', '.join(missing)}")
+    # Coverage is scored against the prompt-registry status vocabulary, not against the raw charter
+    # list (issue #2381). Before this, a charter that CANNOT have an eval suite counted as backlog:
+    # mcp-anonymous and ap2-anonymous are identity-only principals that make no model call at all,
+    # so they would have sat in the warning line forever, and a permanently-unclosable item trains
+    # readers to skim the whole warning. That is the exact absent-vs-not-applicable conflation
+    # prompts/registry.yaml was introduced to end (#1918) — check-prompt-registry.py honours the
+    # vocabulary; this half never learned it.
+    status = charter_status(errors)
+    backlog, excluded = [], []
+    for cid in sorted(ids - covered):
+        st = status.get(cid)
+        if st in EVAL_EXEMPT:
+            excluded.append(f"{cid} ({st})")
+        else:
+            backlog.append(cid)
+
+    # A suite for a charter that never causes a model call is a real contradiction: there is no
+    # model output for the scenarios to assert on. Nothing caught it before.
+    for cid in sorted(covered):
+        if status.get(cid) == "not-applicable":
+            errors.append(f"evals/{cid}.yaml exists but prompts/registry.yaml declares "
+                          f"'{cid}' not-applicable (it makes no model call) — an eval suite for a "
+                          f"charter with no model output cannot assert anything")
+
+    if backlog:
+        print(f"::warning title=Evals registry::{len(backlog)} charter(s) have no eval suite yet "
+              f"(backlog, ADR-0148): {', '.join(backlog)}")
+    if excluded:
+        print(f"evals-registry: {len(excluded)} charter(s) out of scope by registry.yaml status "
+              f"(not backlog): {', '.join(excluded)}")
+    missing = backlog
 
     if errors:
         for e in errors:

--- a/openbank-libs/governance/evals/README.md
+++ b/openbank-libs/governance/evals/README.md
@@ -82,6 +82,30 @@ assertion key, …) — and exits non-zero if any behaves the other way round. I
 **enforced** step *ahead of* the advisory replay, so a runner that has quietly lost the ability to
 fail takes the build down with it rather than reporting green.
 
+## Which charters count as coverage backlog
+
+`check-evals-registry.py` scores coverage against the **status vocabulary in
+[`../prompts/registry.yaml`](../prompts/registry.yaml)**, not against the raw `agents.yaml` charter
+list (issue #2381). Only `registered` and `pending` charters are backlog. Two statuses are out of
+scope, and the exclusion is about what the harness can physically do — not about priority:
+
+| status | why it can never have a suite |
+|---|---|
+| `not-applicable` | the charter causes no model call at all (`mcp-anonymous`, `ap2-anonymous` are identity-only principals) — there is no output for a scenario to assert on |
+| `external` | a real model runs, but this repo neither authors the prompt nor makes the call (`rca-investigator` → HolmesGPT's own image; `ledger-domain-engineer` → an operator's coding-agent session). `--record` records *our* prompt against *our* call; here there is nothing to record, and asserting on someone else's output would measure their prompt while reading as coverage of ours |
+
+Before this the warning listed all 10 uncovered charters, 4 of which could never be closed — and a
+permanently-unclosable backlog item trains readers to skim the whole warning. It is also the exact
+absent-vs-not-applicable conflation `registry.yaml` was introduced to end (#1918): the prompt half
+honoured that vocabulary from the start, the evals half never learned it.
+
+The reverse is a hard error: a suite for a charter declared `not-applicable` fails the gate, because
+a suite that can never run is a coverage claim with nothing behind it.
+
+**If a charter's status changes, the coverage number moves with it** — that is the point. Do not
+re-add a hand-maintained exclusion list here; the status in `registry.yaml` is the single place the
+decision lives.
+
 ## Rules
 
 - **A charter's eval suite is immutable once a model/prompt has been promoted against it** — like a


### PR DESCRIPTION
## Co

Uzavírá #2381. `check-evals-registry.py` odvozoval backlog jako `agents.yaml` mínus soubory v `evals/`, takže hlásil 10 charterů bez eval suite — 4 z nich ji ale mít nikdy nemohou.

| status v `registry.yaml` | chartery | proč |
|---|---|---|
| `not-applicable` | `mcp-anonymous`, `ap2-anonymous` | identity-only principal, nedělá **žádné** volání modelu — není výstup, na který by scénář mohl asertovat |
| `external` | `rca-investigator`, `ledger-domain-engineer` | model běží, ale tenhle repo prompt nepíše ani volání nedělá (HolmesGPT image; coding-agent session operátora) |

Skutečný backlog je **6**, hlášeno bylo 10.

## Proč to není kosmetika

Přesně ta záměna *chybí* vs *nelze*, kvůli které vznikl `prompts/registry.yaml` (#1918) — jeho vlastní hlavička říká, že bez toho rozlišení je coverage číslo bezcenné. `check-prompt-registry.py` slovník ctí od začátku; evals půlka se ho nikdy nenaučila.

Trvale neuzavíratelná položka je horší než špatné číslo: učí čtenáře přeskakovat celý warning. Přesně tak přežil neregistrovaný `system.v2` prompt měsíc v červeném (#2363).

## Rozhodnutí zapsané, ne defaultní

Issue explicitně žádal rozhodnout `external` vědomě. Vyloučeno — a důvod je *fyzická schopnost harnessu*, ne priorita: `--record` nahrává **náš** prompt proti **našemu** volání modelu. U externího charteru není co nahrát, a asertovat na cizí výstup by měřilo cizí prompt a četlo se to jako pokrytí našeho. Obě výjimky i s odůvodněním jsou zapsané v `evals/README.md`, včetně poznámky, že se sem nemá vracet ručně udržovaný seznam výjimek — status v `registry.yaml` je jediné místo, kde to rozhodnutí žije.

## Nová tvrdá chyba

Suite pro charter označený `not-applicable` teď gate shodí. Suite pro něco, co nedělá volání modelu, nemůže nic asertovat — dřív to nekontroloval nikdo.

## Ověření

Falsifikováno v obou nových větvích, než jsem uvěřil zelené:

| případ | výsledek |
|---|---|
| suite přidaná pro `mcp-anonymous` | exit 1 s tou novou chybou |
| `prompts/registry.yaml` odstraněn | exit 1 — gate odmítne skórovat naslepo místo tichého návratu k původnímu chování |
| obnovený strom | exit 0, `6 backlog + 4 mimo rozsah` |

Zeleně lokálně: `check-evals-registry`, `check-prompt-registry`, `run-evals` replay, `run-evals --self-test`, `check-advisory-gate-registration`.

## Linked issues

Closes #2381
