### PR TITLE
docs: capture four gate lessons from the ADR-0148/authz sweep (#2392)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -273,6 +273,31 @@ fire from *outside* it, so they stay here:
   `.github/scripts/check-license-headers.py` enforces every declaration against it. Frozen headers
   (an applied Flyway migration — editing one breaks its checksum and the service dies at boot) go in
   `REUSE.toml` with `precedence = "override"`, never edited in place.
+- **A text-matching guard flags the very text that explains the bug it exists to catch — decide that
+  precedence before the first run.** Three in one session, each caught only by running the new guard
+  against a case it must NOT flag: `check-roles-allowed-realm.py` reported finrep as still broken
+  because #2403's fix quotes the old `@RolesAllowed("SERVICE", …)` in a KDoc (fixed by stripping
+  comments — Kotlin's block comments NEST, so mirror that or a KDoc containing `/*` closes early);
+  `check-advisory-gate-registration.py` flagged **itself**, its own step being named
+  `advisory-gate registration (…, enforced)` (fixed by making `enforced` in a step name beat
+  `advisory`); and the `platform-admin` prose in `DevOpsResource` survived the sweep that renamed
+  the annotation, because comments are stripped *by design* (#2450). Generalize: a guard over source
+  text needs an explicit rule for code-about-code, and stale prose naming a dead identifier is
+  invisible to it forever — grep the prose separately after any vocabulary rename.
+- **An "advisory" gate is usually advisory INSIDE the script, not via `continue-on-error`** — 11 of
+  12 here print `::warning` and exit 0 unless passed `--enforce`. A sweep for `continue-on-error:
+  true` therefore finds one and silently reports the other eleven as enforced. Check both forms
+  before claiming anything about what blocks (#2392).
+- **Regenerating the OPA bundles must be the LAST step before pushing a `rules.yaml` PR, and the
+  "run twice, expect no diff" check does not prove you did that.** Idempotency only proves the
+  generators are stable against whatever `rules.yaml` said at that moment: on #2457 the bundles were
+  regenerated, verified idempotent, and *then* a duplicate-key fix landed in `rules.yaml` — all 65
+  files embedded the superseded text and the OPA gate went red on every one. Re-run after the final
+  edit, not after the first.
+- **`rules.yaml` is never linted by CI** — the yamllint step's scope is `openbank-infra .github`. A
+  duplicate key there is silently resolved by SnakeYAML keeping the LAST occurrence, so a new value
+  added above an existing one is dropped with no error anywhere. Diff yamllint finding *sets*
+  against `origin/main` when editing it (that is the only thing that caught it on #2457).
 
 ### CI / bot commit signing
 - **What signs a bot commit is the *endpoint*, not the token — and `main-protection` enforces


### PR DESCRIPTION
## Co

Čtyři věci, které tahle série PR zaplatila a nikde nebyly zapsané. Routováno podle `rules.yaml: knowledge_capture` — jde o operational footguns, které pálí fleet-wide, takže root `CLAUDE.md`, sekce "CI gates", ne scoped soubor.

### 1. Textová brána označí právě ten text, který vysvětluje chybu, kvůli níž existuje

Tři případy v jedné session:

- `check-roles-allowed-realm.py` hlásil finrep jako stále rozbitý — protože oprava v #2403 cituje starou anotaci v KDoc.
- `check-advisory-gate-registration.py` označil **sám sebe**; jeho vlastní krok se jmenuje `advisory-gate registration (…, enforced)`.
- Prózu `platform-admin` v `DevOpsResource` přejmenování anotace minulo, protože komentáře se strippují **záměrně** (#2450).

Každý z nich odhalilo až spuštění brány proti případu, který **nesmí** označit. To je opačný směr než pravidlo „nakrm ji vstupem, který musí označit" — a to pravidlo ho nepokrývá.

Důsledek pro repo: brána nad zdrojovým textem potřebuje explicitní pravidlo pro *kód o kódu*, a zastaralá próza s mrtvým identifikátorem je pro ni navždy neviditelná — po každém přejmenování vokabuláře je nutné grepnout prózu zvlášť.

### 2. „Advisory" je obvykle uvnitř skriptu, ne přes `continue-on-error`

11 z 12 zdejších bran tiskne `::warning` a končí 0, dokud nedostanou `--enforce`. Sweep přes `continue-on-error: true` tedy najde jednu a zbylých jedenáct tiše ohlásí jako enforced (#2392).

### 3. Regenerace OPA bundlů musí být POSLEDNÍ krok před pushem

A kontrola „spusť dvakrát, čekej nulový diff" to nedokazuje — ta ověří jen stabilitu generátorů vůči tomu, co `rules.yaml` říkal *v tu chvíli*. Na #2457 byly bundly zregenerované, ověřené jako idempotentní, a **až potom** přistála oprava duplicitního klíče: všech 65 souborů neslo překonaný text a OPA brána zčervenala na každém.

### 4. `rules.yaml` CI nikdy nelintuje

Scope yamllint kroku je `openbank-infra .github`. Duplicitní klíč tam SnakeYAML tiše vyřeší tak, že si nechá **poslední** výskyt — hodnota přidaná nad existující zmizí bez jediné chyby. Chytilo to jen porovnání *množin* yamllint nálezů proti `origin/main` (20 vs 17).

## Proč do trackovaného `CLAUDE.md`

Všechny čtyři pálí napříč flotilou nebo *mimo* konkrétní strom (#3 a #4 kousnou každého, kdo sáhne na `rules.yaml`, ať dělá cokoliv). Žádná neobsahuje interní detaily — jen mechaniku bran, čísla PR a měřené hodnoty.

## Linked issues

Refs #2392
