### PR TITLE
feat(authz): support dotted-path resource extraction in @Authorize (ADR-0206 D1)

### DIFF
--- a/openbank-libs-runtime/src/main/kotlin/com/openbank/libs/authz/AuthorizeInterceptor.kt
+++ b/openbank-libs-runtime/src/main/kotlin/com/openbank/libs/authz/AuthorizeInterceptor.kt
@@ -26,6 +26,7 @@ import org.eclipse.microprofile.config.inject.ConfigProperty
 import org.jboss.logging.Logger
 import java.time.Clock
 import java.time.Instant
+import kotlin.reflect.full.memberProperties
 import kotlin.reflect.jvm.kotlinFunction
 
 /**
@@ -381,7 +382,11 @@ class AuthorizeInterceptor {
 
     private fun extractResource(ctx: InvocationContext, annotation: Authorize, expr: String): ResourceRef? {
         if (!expr.startsWith("#")) return null
-        val paramName = expr.substring(1)
+        // "#param" -> whole parameter; "#param.field" -> one property of that parameter
+        // (ADR-0206), resolved via the parameter's own primary-constructor properties —
+        // one level deep only, no nested paths.
+        val (paramName, fieldName) = expr.substring(1).split('.', limit = 2)
+            .let { it[0] to it.getOrNull(1) }
         val kFunction = ctx.method.kotlinFunction ?: return null
         // First parameter on instance functions is the receiver; skip it.
         val paramIndex = kFunction.parameters
@@ -390,7 +395,14 @@ class AuthorizeInterceptor {
         if (paramIndex < 0 || paramIndex >= ctx.parameters.size) return null
         val argValue = ctx.parameters[paramIndex] ?: return null
         val type = annotation.action.substringBefore('.')
-        return ResourceRef(type = type, id = argValue.toString())
+        val resolvedValue = if (fieldName == null) {
+            argValue
+        } else {
+            val property = argValue::class.memberProperties
+                .firstOrNull { it.name == fieldName } ?: return null
+            property.getter.call(argValue) ?: return null
+        }
+        return ResourceRef(type = type, id = resolvedValue.toString())
     }
 
     private fun principalType(sc: SecurityContext): String {

--- a/openbank-libs-runtime/src/main/kotlin/com/openbank/libs/authz/AuthorizeInterceptor.kt
+++ b/openbank-libs-runtime/src/main/kotlin/com/openbank/libs/authz/AuthorizeInterceptor.kt
@@ -398,9 +398,7 @@ class AuthorizeInterceptor {
         val resolvedValue = if (fieldName == null) {
             argValue
         } else {
-            val property = argValue::class.memberProperties
-                .firstOrNull { it.name == fieldName } ?: return null
-            property.getter.call(argValue) ?: return null
+            resolveResourceField(argValue, fieldName, log) ?: return null
         }
         return ResourceRef(type = type, id = resolvedValue.toString())
     }
@@ -417,4 +415,25 @@ class AuthorizeInterceptor {
         const val APPROVAL_ID_HEADER = "X-Approval-Id"
         const val PENDING_APPROVAL_STATUS = 202
     }
+}
+
+/**
+ * Resolves one property off [target] by name (ADR-0206 dotted-path resource extraction).
+ * Wrapped in a broad catch — a Java-only or proxied parameter type can make
+ * `memberProperties`/`getter.call` throw (e.g. `KotlinReflectionInternalError`) rather than
+ * simply not find the property, and this must fail closed the same way an unrecognized field
+ * name does, not abort the whole authorization decision with an unrelated reflection exception.
+ */
+@Suppress("TooGenericExceptionCaught")
+private fun resolveResourceField(target: Any, fieldName: String, log: Logger): Any? = try {
+    target::class.memberProperties
+        .firstOrNull { it.name == fieldName }
+        ?.getter?.call(target)
+} catch (ex: Exception) {
+    log.warnf(
+        "resource field extraction failed for '%s': %s — falling back to no resource",
+        fieldName,
+        ex.message,
+    )
+    null
 }

--- a/openbank-libs-runtime/src/test/kotlin/com/openbank/libs/authz/AuthorizeInterceptorTest.kt
+++ b/openbank-libs-runtime/src/test/kotlin/com/openbank/libs/authz/AuthorizeInterceptorTest.kt
@@ -98,9 +98,19 @@ class AuthorizeInterceptorTest {
 
     data class DummyRequest(val granteeId: String, val scopes: List<String>)
 
+    data class DummyRequestWithNullableField(val granteeId: String?)
+
     @Suppress("UnusedParameter") // invoked only via InvocationContext reflection, not directly
     @Authorize(action = "consent.grant", resource = "#request.granteeId")
     fun dummyMethodWithDottedResource(request: DummyRequest?) = Unit
+
+    @Suppress("UnusedParameter") // invoked only via InvocationContext reflection, not directly
+    @Authorize(action = "consent.grant", resource = "#request.doesNotExist")
+    fun dummyMethodWithUnknownField(request: DummyRequest?) = Unit
+
+    @Suppress("UnusedParameter") // invoked only via InvocationContext reflection, not directly
+    @Authorize(action = "consent.grant", resource = "#request.granteeId")
+    fun dummyMethodWithNullableFieldResource(request: DummyRequestWithNullableField?) = Unit
 
     private val annotatedMethod: Method =
         AuthorizeInterceptorTest::class.java.getDeclaredMethod("dummyMethod")
@@ -112,6 +122,18 @@ class AuthorizeInterceptorTest {
         AuthorizeInterceptorTest::class.java.getDeclaredMethod(
             "dummyMethodWithDottedResource",
             DummyRequest::class.java,
+        )
+
+    private val annotatedMethodWithUnknownField: Method =
+        AuthorizeInterceptorTest::class.java.getDeclaredMethod(
+            "dummyMethodWithUnknownField",
+            DummyRequest::class.java,
+        )
+
+    private val annotatedMethodWithNullableFieldResource: Method =
+        AuthorizeInterceptorTest::class.java.getDeclaredMethod(
+            "dummyMethodWithNullableFieldResource",
+            DummyRequestWithNullableField::class.java,
         )
 
     @Test
@@ -168,10 +190,46 @@ class AuthorizeInterceptorTest {
             }
         }
         wirePdp(pdp)
-        // Method annotated "#request.granteeId" but the interceptor swaps in a method whose
-        // resolved field name doesn't exist on the param — simulate by passing a request whose
-        // extractResource lookup fails (null param) rather than mutating the annotation itself.
+        val ctx = makeCtx(
+            annotatedMethodWithUnknownField,
+            DummyRequest(granteeId = "party-service:marketing-comms", scopes = listOf("x")),
+        )
+        interceptor.authorize(ctx)
+        assertThat(capturedQuery).hasSize(1)
+        assertThat(capturedQuery[0].resource).isNull()
+    }
+
+    @Test
+    fun `dotted-path resource expression with a null param fails closed to no resource`() {
+        every { identity.roles } returns emptySet()
+        val capturedQuery = mutableListOf<AuthzQuery>()
+        wirePdp(
+            object : PolicyDecisionPoint {
+                override suspend fun allow(query: AuthzQuery): AuthzDecision {
+                    capturedQuery += query
+                    return AuthzDecision(allow = true, reason = "ok", policyVersion = "test")
+                }
+            },
+        )
         val ctx = makeCtx(annotatedMethodWithDottedResource, null)
+        interceptor.authorize(ctx)
+        assertThat(capturedQuery).hasSize(1)
+        assertThat(capturedQuery[0].resource).isNull()
+    }
+
+    @Test
+    fun `dotted-path resource expression whose field resolves to null fails closed to no resource`() {
+        every { identity.roles } returns emptySet()
+        val capturedQuery = mutableListOf<AuthzQuery>()
+        wirePdp(
+            object : PolicyDecisionPoint {
+                override suspend fun allow(query: AuthzQuery): AuthzDecision {
+                    capturedQuery += query
+                    return AuthzDecision(allow = true, reason = "ok", policyVersion = "test")
+                }
+            },
+        )
+        val ctx = makeCtx(annotatedMethodWithNullableFieldResource, DummyRequestWithNullableField(granteeId = null))
         interceptor.authorize(ctx)
         assertThat(capturedQuery).hasSize(1)
         assertThat(capturedQuery[0].resource).isNull()

--- a/openbank-libs-runtime/src/test/kotlin/com/openbank/libs/authz/AuthorizeInterceptorTest.kt
+++ b/openbank-libs-runtime/src/test/kotlin/com/openbank/libs/authz/AuthorizeInterceptorTest.kt
@@ -96,11 +96,23 @@ class AuthorizeInterceptorTest {
     @Authorize(action = "payment.create", attributes = ["time-of-day", "client-ip"])
     fun dummyMethodWithAttrs() = Unit
 
+    data class DummyRequest(val granteeId: String, val scopes: List<String>)
+
+    @Suppress("UnusedParameter") // invoked only via InvocationContext reflection, not directly
+    @Authorize(action = "consent.grant", resource = "#request.granteeId")
+    fun dummyMethodWithDottedResource(request: DummyRequest?) = Unit
+
     private val annotatedMethod: Method =
         AuthorizeInterceptorTest::class.java.getDeclaredMethod("dummyMethod")
 
     private val annotatedMethodWithAttrs: Method =
         AuthorizeInterceptorTest::class.java.getDeclaredMethod("dummyMethodWithAttrs")
+
+    private val annotatedMethodWithDottedResource: Method =
+        AuthorizeInterceptorTest::class.java.getDeclaredMethod(
+            "dummyMethodWithDottedResource",
+            DummyRequest::class.java,
+        )
 
     @Test
     fun `JWT roles propagated into OPA query`() {
@@ -121,6 +133,48 @@ class AuthorizeInterceptorTest {
         assertThat(capturedQuery).hasSize(1)
         assertThat(capturedQuery[0].principal.roles)
             .containsExactlyInAnyOrder("ROLE_OPERATOR", "ROLE_ADMIN")
+    }
+
+    @Test
+    fun `dotted-path resource expression resolves the named field, not the whole request`() {
+        every { identity.roles } returns emptySet()
+        val capturedQuery = mutableListOf<AuthzQuery>()
+        val pdp = object : PolicyDecisionPoint {
+            override suspend fun allow(query: AuthzQuery): AuthzDecision {
+                capturedQuery += query
+                return AuthzDecision(allow = true, reason = "ok", policyVersion = "test")
+            }
+        }
+        wirePdp(pdp)
+        val ctx =
+            makeCtx(
+                annotatedMethodWithDottedResource,
+                DummyRequest(granteeId = "party-service:marketing-comms", scopes = listOf("x")),
+            )
+        interceptor.authorize(ctx)
+        assertThat(capturedQuery).hasSize(1)
+        assertThat(capturedQuery[0].resource?.id).isEqualTo("party-service:marketing-comms")
+        assertThat(capturedQuery[0].resource?.type).isEqualTo("consent")
+    }
+
+    @Test
+    fun `dotted-path resource expression with unknown field fails closed to no resource, not a crash`() {
+        every { identity.roles } returns emptySet()
+        val capturedQuery = mutableListOf<AuthzQuery>()
+        val pdp = object : PolicyDecisionPoint {
+            override suspend fun allow(query: AuthzQuery): AuthzDecision {
+                capturedQuery += query
+                return AuthzDecision(allow = true, reason = "ok", policyVersion = "test")
+            }
+        }
+        wirePdp(pdp)
+        // Method annotated "#request.granteeId" but the interceptor swaps in a method whose
+        // resolved field name doesn't exist on the param — simulate by passing a request whose
+        // extractResource lookup fails (null param) rather than mutating the annotation itself.
+        val ctx = makeCtx(annotatedMethodWithDottedResource, null)
+        interceptor.authorize(ctx)
+        assertThat(capturedQuery).hasSize(1)
+        assertThat(capturedQuery[0].resource).isNull()
     }
 
     @Test


### PR DESCRIPTION
## Summary
- ADR-0206 D1: extend `AuthorizeInterceptor.extractResource` to accept `#paramName.fieldName`, resolved via `memberProperties` on the parameter, one level deep. `#paramName` alone keeps its existing whole-object behavior.
- An unrecognized field name or a null parameter fails closed to no resource (same as today's unrecognized-whole-param-name behavior) — it never widens access, only narrows or no-ops.
- Enables D2 (scoped OPA rule for M2M `consent.grant`/`consent.revoke`) to key on a single request field (`granteeId`) instead of a Kotlin `data class.toString()` blob.

## Test plan
- [x] New unit tests: dotted-path resolves the named field (not whole object); unknown/null param fails closed to `resource = null`
- [x] `./gradlew :openbank-libs-runtime:detekt :openbank-libs-runtime:ktlintCheck :openbank-libs-runtime:build` green

Refs ADR-0206 (docs/adr/0206-scope-m2m-consent-grant-revoke-by-grantee-resource.md), merged #2465. N/A — no separate backlog issue; implements a merged ADR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)