### PR TITLE
feat(consent): scope M2M consent.grant/consent.revoke to marketing grantee (ADR-0206 D2)

### DIFF
--- a/openbank-consent-service/src/main/kotlin/com/openbank/consent/application/port/in/ConsentUseCases.kt
+++ b/openbank-consent-service/src/main/kotlin/com/openbank/consent/application/port/in/ConsentUseCases.kt
@@ -25,7 +25,16 @@ data class CreateConsentCommand(
     val userAgent: String?,
 )
 
-data class RevokeConsentCommand(val consentId: UUID, val partyId: UUID, val reason: String)
+// expectedGranteeId is null for a human/operator-initiated revoke (no cross-check, matches
+// today's behavior); an M2M caller authorized via the grantee-scoped OPA rule (ADR-0206) must
+// pass its own granteeId so the use case can confirm the consent it's revoking is actually the
+// one that rule authorized — the OPA resource check alone can't see the DB row.
+data class RevokeConsentCommand(
+    val consentId: UUID,
+    val partyId: UUID,
+    val reason: String,
+    val expectedGranteeId: String? = null,
+)
 
 data class ValidateConsentCommand(
     val consentId: UUID,

--- a/openbank-consent-service/src/main/kotlin/com/openbank/consent/application/usecase/ConsentService.kt
+++ b/openbank-consent-service/src/main/kotlin/com/openbank/consent/application/usecase/ConsentService.kt
@@ -45,6 +45,12 @@ class ConsentMixedScopeException(scopes: Set<ConsentScope>) :
         "Cannot mix GDPR-only scopes with SCA-required scopes in one consent request: $scopes. " +
             "Request the GDPR-only and SCA-required scopes separately (ADR-0205 D1).",
     )
+class ConsentGranteeMismatchException(id: UUID, expectedGranteeId: String) :
+    RuntimeException(
+        "Consent $id does not belong to grantee $expectedGranteeId — refusing to revoke. " +
+            "The M2M OPA rule scopes consent.revoke to this exact grantee (ADR-0206); a caller " +
+            "presenting the right grantee string for the wrong consent is rejected here too.",
+    )
 
 @ApplicationScoped
 class ConsentService(
@@ -183,6 +189,9 @@ class ConsentService(
 
         if (consent.partyId != command.partyId) {
             throw ConsentNotOwnedByPartyException(command.consentId, command.partyId)
+        }
+        if (command.expectedGranteeId != null && consent.granteeId != command.expectedGranteeId) {
+            throw ConsentGranteeMismatchException(command.consentId, command.expectedGranteeId)
         }
 
         val revoked = consent.revoke(command.reason, OffsetDateTime.now(clock))

--- a/openbank-consent-service/src/main/kotlin/com/openbank/consent/infrastructure/rest/ConsentResource.kt
+++ b/openbank-consent-service/src/main/kotlin/com/openbank/consent/infrastructure/rest/ConsentResource.kt
@@ -61,7 +61,11 @@ class ConsentResource(
     // Renamed from consent.create (issue #938 follow-up): "grant" is a distinctive verb so
     // adding it to rules.yaml four_eyes.verbs cannot silently four-eyes-gate every OTHER
     // money-path service's unrelated `.create` action fleet-wide.
-    @Authorize(action = "consent.grant")
+    // Dotted-path resource extraction (ADR-0206 D1/D2): scopes the shared M2M principal's
+    // consent.grant to grantee=party-service:marketing-comms only (consent-opa-bundle.yaml's
+    // service-consent-m2m-marketing rule) instead of opening it fleet-wide. Human/operator
+    // callers are unaffected — their existing OPA rule doesn't inspect this resource.
+    @Authorize(action = "consent.grant", resource = "#request.granteeId")
     suspend fun create(
         request: CreateConsentRequest?,
         @HeaderParam("X-Request-ID") xRequestId: String?,
@@ -132,14 +136,21 @@ class ConsentResource(
     @Operation(summary = "Revoke an ACTIVE consent; transitions to REVOKED and enqueues ConsentRevoked event")
     @DELETE
     @Path("/{id}")
+    // "resource = #id" is unaffected (unscoped human/operator rule). The optional granteeId
+    // query param is for the M2M path (ADR-0206 D2): consent-opa-bundle.yaml's
+    // service-consent-m2m-marketing rule checks it via #granteeId directly (no dotted path
+    // needed here — it's already a top-level parameter), and the use case cross-checks it
+    // against the loaded consent's actual granteeId before revoking, since the OPA decision
+    // can't see the DB row this endpoint hasn't loaded yet.
     @Authorize(action = "consent.revoke", resource = "#id")
     suspend fun revoke(
         @PathParam("id") id: UUID,
         @QueryParam("partyId") partyId: UUID,
+        @QueryParam("granteeId") granteeId: String?,
         request: RevokeConsentRequest?,
     ): ConsentResponse {
         requireNotNull(request) { "request body is required" }
-        val consent = revokeConsent.revokeConsent(RevokeConsentCommand(id, partyId, request.reason))
+        val consent = revokeConsent.revokeConsent(RevokeConsentCommand(id, partyId, request.reason, granteeId))
         return ConsentResponse.from(consent)
     }
 

--- a/openbank-consent-service/src/main/kotlin/com/openbank/consent/infrastructure/rest/ExceptionMappers.kt
+++ b/openbank-consent-service/src/main/kotlin/com/openbank/consent/infrastructure/rest/ExceptionMappers.kt
@@ -28,6 +28,13 @@ class ConsentNotOwnedMapper : ExceptionMapper<ConsentNotOwnedByPartyException> {
 }
 
 @Provider
+class ConsentGranteeMismatchMapper : ExceptionMapper<ConsentGranteeMismatchException> {
+    override fun toResponse(e: ConsentGranteeMismatchException): Response =
+        Response.status(ErrorCode.FORBIDDEN.httpStatus)
+            .entity(errorResponse(ErrorCode.FORBIDDEN, e.message ?: "Forbidden")).build()
+}
+
+@Provider
 class ConsentAlreadyActiveMapper : ExceptionMapper<ConsentAlreadyActiveException> {
     override fun toResponse(e: ConsentAlreadyActiveException): Response =
         Response.status(409).entity(errorResponse(ErrorCode.CONFLICT, e.message ?: "Already active")).build()

--- a/openbank-consent-service/src/test/kotlin/com/openbank/consent/application/usecase/ConsentServiceTest.kt
+++ b/openbank-consent-service/src/test/kotlin/com/openbank/consent/application/usecase/ConsentServiceTest.kt
@@ -244,6 +244,61 @@ class ConsentServiceTest {
     }
 
     @Test
+    fun `revokeConsent throws ConsentGranteeMismatchException when expectedGranteeId does not match`() {
+        coEvery { consentRepository.findById(consentId) } returns consent(granteeId = "party-service:marketing-comms")
+
+        assertThrows<ConsentGranteeMismatchException> {
+            runBlocking {
+                service.revokeConsent(
+                    RevokeConsentCommand(
+                        consentId = consentId,
+                        partyId = partyId,
+                        reason = "toggle off",
+                        expectedGranteeId = "some-other-grantee",
+                    ),
+                )
+            }
+        }
+    }
+
+    @Test
+    fun `revokeConsent succeeds when expectedGranteeId matches the consent's own granteeId`(): Unit = runBlocking {
+        val consent = consent(granteeId = "party-service:marketing-comms")
+        coEvery { consentRepository.findById(consentId) } returns consent
+        coEvery { consentRepository.save(any(), any()) } answers { firstArg() }
+
+        val result = service.revokeConsent(
+            RevokeConsentCommand(
+                consentId = consentId,
+                partyId = partyId,
+                reason = "toggle off",
+                expectedGranteeId = "party-service:marketing-comms",
+            ),
+        )
+
+        assertThat(result.status).isEqualTo(ConsentStatus.REVOKED)
+    }
+
+    @Test
+    fun `revokeConsent skips the grantee cross-check when expectedGranteeId is null (human path unchanged)`(): Unit =
+        runBlocking {
+            val consent = consent(granteeId = granteeId)
+            coEvery { consentRepository.findById(consentId) } returns consent
+            coEvery { consentRepository.save(any(), any()) } answers { firstArg() }
+
+            val result = service.revokeConsent(
+                RevokeConsentCommand(
+                    consentId = consentId,
+                    partyId = partyId,
+                    reason = "operator revoke",
+                    expectedGranteeId = null,
+                ),
+            )
+
+            assertThat(result.status).isEqualTo(ConsentStatus.REVOKED)
+        }
+
+    @Test
     fun `validateConsent returns Invalid when consent not found`(): Unit = runBlocking {
         coEvery { consentRepository.findById(consentId) } returns null
 

--- a/openbank-infra/gitops/components/accounts/account-opa-bundle.yaml
+++ b/openbank-infra/gitops/components/accounts/account-opa-bundle.yaml
@@ -9,7 +9,7 @@ metadata:
     app.kubernetes.io/name: account-service
     app.kubernetes.io/part-of: accounts
   annotations:
-    openbank.tech/policy-checksum: "abde04c20c68fa12"
+    openbank.tech/policy-checksum: "eccc3eb7700f8bd8"
 data:
   rest.rego: |
     # SPDX-License-Identifier: Apache-2.0
@@ -2028,10 +2028,20 @@ data:
                                                # confirmed M2M automated caller (customer-edge) — gating either would brick
                                                # production automation once enforcement is ever flipped on, not just close
                                                # the risky operator-console gap. See the four_eyes.verbs guardrail note below.
-      - openbank-consent-service               # four-eyes wired (issue #938 follow-up) on consent.grant/consent.revoke —
-                                                # both confirmed human-operator-only (no M2M caller). consent.activate
-                                                # deliberately left ungated: its rego already reserves an M2M grant for a
-                                                # possible SCA-completion-callback caller.
+      - openbank-consent-service               # four-eyes wired (issue #938 follow-up) on consent.grant/consent.revoke.
+                                                # UPDATED (ADR-0206): no longer exclusively human-operator — the shared
+                                                # M2M principal may now call both, but ONLY for
+                                                # grantee=party-service:marketing-comms (consent-opa-bundle.yaml's
+                                                # service-consent-m2m-marketing rule), a low-risk SCA-exempt marketing
+                                                # toggle (ADR-0205 D1). AUTHZ_FOUR_EYES_ENFORCE is false today for
+                                                # consent-service (consent-service.yaml has no override), so this M2M
+                                                # path is not currently blocked by the maker/checker pause — but if
+                                                # four-eyes enforcement is ever flipped on for this service, the
+                                                # party-service forwarder (no human in the loop) would stall on the
+                                                # missing second approver. Flag that rollout precondition before
+                                                # flipping AUTHZ_FOUR_EYES_ENFORCE here. consent.activate deliberately
+                                                # left ungated: its rego already reserves an M2M grant for a possible
+                                                # SCA-completion-callback caller.
       - openbank-fraud-service                # ADR-0084: v4 rule engine live; domestic-payment enforcement gate merged (issue #667, flag default-off pending risk-team threshold calibration)
                                                # four-eyes assessed (issue #938 follow-up): the only REST surface today is a stateless
                                                # POST /fraud/score (fraud.score) — no operator case-decision, rule-config, or manual

--- a/openbank-infra/gitops/components/accounts/account-service.yaml
+++ b/openbank-infra/gitops/components/accounts/account-service.yaml
@@ -37,7 +37,7 @@ spec:
       annotations:
         # Rolls the pod when the OPA bundle changes — subPath mounts do NOT hot-reload.
         # Kept in sync by gen-account-opa-bundle.sh (do not hand-edit).
-        openbank.tech/policy-checksum: "abde04c20c68fa12"
+        openbank.tech/policy-checksum: "eccc3eb7700f8bd8"
     spec:
       securityContext:
         runAsNonRoot: true

--- a/openbank-infra/gitops/components/aml/aml-opa-bundle.yaml
+++ b/openbank-infra/gitops/components/aml/aml-opa-bundle.yaml
@@ -9,7 +9,7 @@ metadata:
     app.kubernetes.io/name: aml-service
     app.kubernetes.io/part-of: aml
   annotations:
-    openbank.tech/policy-checksum: "7959961a5a9f67c8"
+    openbank.tech/policy-checksum: "d0720f559d3dcbfd"
 data:
   rest.rego: |
     # SPDX-License-Identifier: Apache-2.0
@@ -2001,10 +2001,20 @@ data:
                                                # confirmed M2M automated caller (customer-edge) — gating either would brick
                                                # production automation once enforcement is ever flipped on, not just close
                                                # the risky operator-console gap. See the four_eyes.verbs guardrail note below.
-      - openbank-consent-service               # four-eyes wired (issue #938 follow-up) on consent.grant/consent.revoke —
-                                                # both confirmed human-operator-only (no M2M caller). consent.activate
-                                                # deliberately left ungated: its rego already reserves an M2M grant for a
-                                                # possible SCA-completion-callback caller.
+      - openbank-consent-service               # four-eyes wired (issue #938 follow-up) on consent.grant/consent.revoke.
+                                                # UPDATED (ADR-0206): no longer exclusively human-operator — the shared
+                                                # M2M principal may now call both, but ONLY for
+                                                # grantee=party-service:marketing-comms (consent-opa-bundle.yaml's
+                                                # service-consent-m2m-marketing rule), a low-risk SCA-exempt marketing
+                                                # toggle (ADR-0205 D1). AUTHZ_FOUR_EYES_ENFORCE is false today for
+                                                # consent-service (consent-service.yaml has no override), so this M2M
+                                                # path is not currently blocked by the maker/checker pause — but if
+                                                # four-eyes enforcement is ever flipped on for this service, the
+                                                # party-service forwarder (no human in the loop) would stall on the
+                                                # missing second approver. Flag that rollout precondition before
+                                                # flipping AUTHZ_FOUR_EYES_ENFORCE here. consent.activate deliberately
+                                                # left ungated: its rego already reserves an M2M grant for a possible
+                                                # SCA-completion-callback caller.
       - openbank-fraud-service                # ADR-0084: v4 rule engine live; domestic-payment enforcement gate merged (issue #667, flag default-off pending risk-team threshold calibration)
                                                # four-eyes assessed (issue #938 follow-up): the only REST surface today is a stateless
                                                # POST /fraud/score (fraud.score) — no operator case-decision, rule-config, or manual

--- a/openbank-infra/gitops/components/aml/aml-service.yaml
+++ b/openbank-infra/gitops/components/aml/aml-service.yaml
@@ -22,7 +22,7 @@ spec:
       annotations:
         # Rolls the pod when the OPA bundle changes (subPath mounts do not hot-reload).
         # Kept in sync by gen-aml-opa-bundle.sh (do not hand-edit).
-        openbank.tech/policy-checksum: "7959961a5a9f67c8"
+        openbank.tech/policy-checksum: "d0720f559d3dcbfd"
     spec:
       securityContext:
         runAsNonRoot: true

--- a/openbank-infra/gitops/components/anacredit/anacredit-opa-bundle.yaml
+++ b/openbank-infra/gitops/components/anacredit/anacredit-opa-bundle.yaml
@@ -9,7 +9,7 @@ metadata:
     app.kubernetes.io/name: anacredit-service
     app.kubernetes.io/part-of: anacredit
   annotations:
-    openbank.tech/policy-checksum: "f9db8b225bdfecd8"
+    openbank.tech/policy-checksum: "fafaf7d72f82aab7"
 data:
   rest.rego: |
     # SPDX-License-Identifier: Apache-2.0
@@ -1971,10 +1971,20 @@ data:
                                                # confirmed M2M automated caller (customer-edge) — gating either would brick
                                                # production automation once enforcement is ever flipped on, not just close
                                                # the risky operator-console gap. See the four_eyes.verbs guardrail note below.
-      - openbank-consent-service               # four-eyes wired (issue #938 follow-up) on consent.grant/consent.revoke —
-                                                # both confirmed human-operator-only (no M2M caller). consent.activate
-                                                # deliberately left ungated: its rego already reserves an M2M grant for a
-                                                # possible SCA-completion-callback caller.
+      - openbank-consent-service               # four-eyes wired (issue #938 follow-up) on consent.grant/consent.revoke.
+                                                # UPDATED (ADR-0206): no longer exclusively human-operator — the shared
+                                                # M2M principal may now call both, but ONLY for
+                                                # grantee=party-service:marketing-comms (consent-opa-bundle.yaml's
+                                                # service-consent-m2m-marketing rule), a low-risk SCA-exempt marketing
+                                                # toggle (ADR-0205 D1). AUTHZ_FOUR_EYES_ENFORCE is false today for
+                                                # consent-service (consent-service.yaml has no override), so this M2M
+                                                # path is not currently blocked by the maker/checker pause — but if
+                                                # four-eyes enforcement is ever flipped on for this service, the
+                                                # party-service forwarder (no human in the loop) would stall on the
+                                                # missing second approver. Flag that rollout precondition before
+                                                # flipping AUTHZ_FOUR_EYES_ENFORCE here. consent.activate deliberately
+                                                # left ungated: its rego already reserves an M2M grant for a possible
+                                                # SCA-completion-callback caller.
       - openbank-fraud-service                # ADR-0084: v4 rule engine live; domestic-payment enforcement gate merged (issue #667, flag default-off pending risk-team threshold calibration)
                                                # four-eyes assessed (issue #938 follow-up): the only REST surface today is a stateless
                                                # POST /fraud/score (fraud.score) — no operator case-decision, rule-config, or manual

--- a/openbank-infra/gitops/components/anacredit/anacredit-service.yaml
+++ b/openbank-infra/gitops/components/anacredit/anacredit-service.yaml
@@ -32,7 +32,7 @@ spec:
       annotations:
         # Rolls the pods when the OPA bundle changes — subPath mounts do NOT hot-reload.
         # Kept in sync by gen-anacredit-opa-bundle.sh (do not hand-edit).
-        openbank.tech/policy-checksum: "f9db8b225bdfecd8"
+        openbank.tech/policy-checksum: "fafaf7d72f82aab7"
     spec:
       securityContext:
         runAsNonRoot: true

--- a/openbank-infra/gitops/components/ap2/ap2-opa-bundle.yaml
+++ b/openbank-infra/gitops/components/ap2/ap2-opa-bundle.yaml
@@ -9,7 +9,7 @@ metadata:
     app.kubernetes.io/name: mcp-service
     app.kubernetes.io/part-of: platform
   annotations:
-    openbank.tech/policy-checksum: "c5b9e80930a29004"
+    openbank.tech/policy-checksum: "a4190eed6dd3b779"
 data:
   rest.rego: |
     # SPDX-License-Identifier: Apache-2.0
@@ -1939,10 +1939,20 @@ data:
                                                # confirmed M2M automated caller (customer-edge) — gating either would brick
                                                # production automation once enforcement is ever flipped on, not just close
                                                # the risky operator-console gap. See the four_eyes.verbs guardrail note below.
-      - openbank-consent-service               # four-eyes wired (issue #938 follow-up) on consent.grant/consent.revoke —
-                                                # both confirmed human-operator-only (no M2M caller). consent.activate
-                                                # deliberately left ungated: its rego already reserves an M2M grant for a
-                                                # possible SCA-completion-callback caller.
+      - openbank-consent-service               # four-eyes wired (issue #938 follow-up) on consent.grant/consent.revoke.
+                                                # UPDATED (ADR-0206): no longer exclusively human-operator — the shared
+                                                # M2M principal may now call both, but ONLY for
+                                                # grantee=party-service:marketing-comms (consent-opa-bundle.yaml's
+                                                # service-consent-m2m-marketing rule), a low-risk SCA-exempt marketing
+                                                # toggle (ADR-0205 D1). AUTHZ_FOUR_EYES_ENFORCE is false today for
+                                                # consent-service (consent-service.yaml has no override), so this M2M
+                                                # path is not currently blocked by the maker/checker pause — but if
+                                                # four-eyes enforcement is ever flipped on for this service, the
+                                                # party-service forwarder (no human in the loop) would stall on the
+                                                # missing second approver. Flag that rollout precondition before
+                                                # flipping AUTHZ_FOUR_EYES_ENFORCE here. consent.activate deliberately
+                                                # left ungated: its rego already reserves an M2M grant for a possible
+                                                # SCA-completion-callback caller.
       - openbank-fraud-service                # ADR-0084: v4 rule engine live; domestic-payment enforcement gate merged (issue #667, flag default-off pending risk-team threshold calibration)
                                                # four-eyes assessed (issue #938 follow-up): the only REST surface today is a stateless
                                                # POST /fraud/score (fraud.score) — no operator case-decision, rule-config, or manual

--- a/openbank-infra/gitops/components/ap2/ap2-service.yaml
+++ b/openbank-infra/gitops/components/ap2/ap2-service.yaml
@@ -30,7 +30,7 @@ spec:
       annotations:
         # Roll the pod when the OPA policy bundle changes (subPath mounts don't hot-reload).
         # Kept in sync by gen-ap2-opa-bundle.sh (do not hand-edit).
-        openbank.tech/policy-checksum: "c5b9e80930a29004"
+        openbank.tech/policy-checksum: "a4190eed6dd3b779"
     spec:
       securityContext:
         runAsNonRoot: true

--- a/openbank-infra/gitops/components/audit/audit-opa-bundle.yaml
+++ b/openbank-infra/gitops/components/audit/audit-opa-bundle.yaml
@@ -9,7 +9,7 @@ metadata:
     app.kubernetes.io/name: audit-service
     app.kubernetes.io/part-of: audit
   annotations:
-    openbank.tech/policy-checksum: "bf2ef29105621768"
+    openbank.tech/policy-checksum: "f3d212877a68293c"
 data:
   rest.rego: |
     # SPDX-License-Identifier: Apache-2.0
@@ -1983,10 +1983,20 @@ data:
                                                # confirmed M2M automated caller (customer-edge) — gating either would brick
                                                # production automation once enforcement is ever flipped on, not just close
                                                # the risky operator-console gap. See the four_eyes.verbs guardrail note below.
-      - openbank-consent-service               # four-eyes wired (issue #938 follow-up) on consent.grant/consent.revoke —
-                                                # both confirmed human-operator-only (no M2M caller). consent.activate
-                                                # deliberately left ungated: its rego already reserves an M2M grant for a
-                                                # possible SCA-completion-callback caller.
+      - openbank-consent-service               # four-eyes wired (issue #938 follow-up) on consent.grant/consent.revoke.
+                                                # UPDATED (ADR-0206): no longer exclusively human-operator — the shared
+                                                # M2M principal may now call both, but ONLY for
+                                                # grantee=party-service:marketing-comms (consent-opa-bundle.yaml's
+                                                # service-consent-m2m-marketing rule), a low-risk SCA-exempt marketing
+                                                # toggle (ADR-0205 D1). AUTHZ_FOUR_EYES_ENFORCE is false today for
+                                                # consent-service (consent-service.yaml has no override), so this M2M
+                                                # path is not currently blocked by the maker/checker pause — but if
+                                                # four-eyes enforcement is ever flipped on for this service, the
+                                                # party-service forwarder (no human in the loop) would stall on the
+                                                # missing second approver. Flag that rollout precondition before
+                                                # flipping AUTHZ_FOUR_EYES_ENFORCE here. consent.activate deliberately
+                                                # left ungated: its rego already reserves an M2M grant for a possible
+                                                # SCA-completion-callback caller.
       - openbank-fraud-service                # ADR-0084: v4 rule engine live; domestic-payment enforcement gate merged (issue #667, flag default-off pending risk-team threshold calibration)
                                                # four-eyes assessed (issue #938 follow-up): the only REST surface today is a stateless
                                                # POST /fraud/score (fraud.score) — no operator case-decision, rule-config, or manual

--- a/openbank-infra/gitops/components/audit/audit-service.yaml
+++ b/openbank-infra/gitops/components/audit/audit-service.yaml
@@ -22,7 +22,7 @@ spec:
       annotations:
         # Rolls the pod when the OPA bundle changes (subPath mounts do not hot-reload).
         # Kept in sync by gen-audit-opa-bundle.sh (do not hand-edit).
-        openbank.tech/policy-checksum: "bf2ef29105621768"
+        openbank.tech/policy-checksum: "f3d212877a68293c"
     spec:
       securityContext:
         runAsNonRoot: true

--- a/openbank-infra/gitops/components/balances/balance-opa-bundle.yaml
+++ b/openbank-infra/gitops/components/balances/balance-opa-bundle.yaml
@@ -9,7 +9,7 @@ metadata:
     app.kubernetes.io/name: balance-service
     app.kubernetes.io/part-of: balances
   annotations:
-    openbank.tech/policy-checksum: "ef5a7f9378ef1eca"
+    openbank.tech/policy-checksum: "635682aeb4074515"
 data:
   rest.rego: |
     # SPDX-License-Identifier: Apache-2.0
@@ -2072,10 +2072,20 @@ data:
                                                # confirmed M2M automated caller (customer-edge) — gating either would brick
                                                # production automation once enforcement is ever flipped on, not just close
                                                # the risky operator-console gap. See the four_eyes.verbs guardrail note below.
-      - openbank-consent-service               # four-eyes wired (issue #938 follow-up) on consent.grant/consent.revoke —
-                                                # both confirmed human-operator-only (no M2M caller). consent.activate
-                                                # deliberately left ungated: its rego already reserves an M2M grant for a
-                                                # possible SCA-completion-callback caller.
+      - openbank-consent-service               # four-eyes wired (issue #938 follow-up) on consent.grant/consent.revoke.
+                                                # UPDATED (ADR-0206): no longer exclusively human-operator — the shared
+                                                # M2M principal may now call both, but ONLY for
+                                                # grantee=party-service:marketing-comms (consent-opa-bundle.yaml's
+                                                # service-consent-m2m-marketing rule), a low-risk SCA-exempt marketing
+                                                # toggle (ADR-0205 D1). AUTHZ_FOUR_EYES_ENFORCE is false today for
+                                                # consent-service (consent-service.yaml has no override), so this M2M
+                                                # path is not currently blocked by the maker/checker pause — but if
+                                                # four-eyes enforcement is ever flipped on for this service, the
+                                                # party-service forwarder (no human in the loop) would stall on the
+                                                # missing second approver. Flag that rollout precondition before
+                                                # flipping AUTHZ_FOUR_EYES_ENFORCE here. consent.activate deliberately
+                                                # left ungated: its rego already reserves an M2M grant for a possible
+                                                # SCA-completion-callback caller.
       - openbank-fraud-service                # ADR-0084: v4 rule engine live; domestic-payment enforcement gate merged (issue #667, flag default-off pending risk-team threshold calibration)
                                                # four-eyes assessed (issue #938 follow-up): the only REST surface today is a stateless
                                                # POST /fraud/score (fraud.score) — no operator case-decision, rule-config, or manual

--- a/openbank-infra/gitops/components/balances/balance-service.yaml
+++ b/openbank-infra/gitops/components/balances/balance-service.yaml
@@ -34,7 +34,7 @@ spec:
       annotations:
         # Rolls the pods when the OPA bundle changes — subPath mounts do NOT hot-reload.
         # Kept in sync by gen-balance-opa-bundle.sh (do not hand-edit).
-        openbank.tech/policy-checksum: "ef5a7f9378ef1eca"
+        openbank.tech/policy-checksum: "635682aeb4074515"
     spec:
       securityContext:
         runAsNonRoot: true

--- a/openbank-infra/gitops/components/billing/billing-opa-bundle.yaml
+++ b/openbank-infra/gitops/components/billing/billing-opa-bundle.yaml
@@ -9,7 +9,7 @@ metadata:
     app.kubernetes.io/name: billing-service
     app.kubernetes.io/part-of: billing
   annotations:
-    openbank.tech/policy-checksum: "2ef9ee8202272eb1"
+    openbank.tech/policy-checksum: "80d45595f71fb050"
 data:
   rest.rego: |
     # SPDX-License-Identifier: Apache-2.0
@@ -1977,10 +1977,20 @@ data:
                                                # confirmed M2M automated caller (customer-edge) — gating either would brick
                                                # production automation once enforcement is ever flipped on, not just close
                                                # the risky operator-console gap. See the four_eyes.verbs guardrail note below.
-      - openbank-consent-service               # four-eyes wired (issue #938 follow-up) on consent.grant/consent.revoke —
-                                                # both confirmed human-operator-only (no M2M caller). consent.activate
-                                                # deliberately left ungated: its rego already reserves an M2M grant for a
-                                                # possible SCA-completion-callback caller.
+      - openbank-consent-service               # four-eyes wired (issue #938 follow-up) on consent.grant/consent.revoke.
+                                                # UPDATED (ADR-0206): no longer exclusively human-operator — the shared
+                                                # M2M principal may now call both, but ONLY for
+                                                # grantee=party-service:marketing-comms (consent-opa-bundle.yaml's
+                                                # service-consent-m2m-marketing rule), a low-risk SCA-exempt marketing
+                                                # toggle (ADR-0205 D1). AUTHZ_FOUR_EYES_ENFORCE is false today for
+                                                # consent-service (consent-service.yaml has no override), so this M2M
+                                                # path is not currently blocked by the maker/checker pause — but if
+                                                # four-eyes enforcement is ever flipped on for this service, the
+                                                # party-service forwarder (no human in the loop) would stall on the
+                                                # missing second approver. Flag that rollout precondition before
+                                                # flipping AUTHZ_FOUR_EYES_ENFORCE here. consent.activate deliberately
+                                                # left ungated: its rego already reserves an M2M grant for a possible
+                                                # SCA-completion-callback caller.
       - openbank-fraud-service                # ADR-0084: v4 rule engine live; domestic-payment enforcement gate merged (issue #667, flag default-off pending risk-team threshold calibration)
                                                # four-eyes assessed (issue #938 follow-up): the only REST surface today is a stateless
                                                # POST /fraud/score (fraud.score) — no operator case-decision, rule-config, or manual

--- a/openbank-infra/gitops/components/billing/billing-service.yaml
+++ b/openbank-infra/gitops/components/billing/billing-service.yaml
@@ -27,7 +27,7 @@ spec:
       annotations:
         # Rolls the pods when the OPA bundle changes — subPath mounts do NOT hot-reload.
         # Kept in sync by gen-billing-opa-bundle.sh (do not hand-edit).
-        openbank.tech/policy-checksum: "2ef9ee8202272eb1"
+        openbank.tech/policy-checksum: "80d45595f71fb050"
     spec:
       securityContext:
         runAsNonRoot: true

--- a/openbank-infra/gitops/components/consent/consent-opa-bundle.yaml
+++ b/openbank-infra/gitops/components/consent/consent-opa-bundle.yaml
@@ -9,7 +9,7 @@ metadata:
     app.kubernetes.io/name: consent-service
     app.kubernetes.io/part-of: consent
   annotations:
-    openbank.tech/policy-checksum: "9308b6b7977b8749"
+    openbank.tech/policy-checksum: "cd4fc657c5070876"
 data:
   rest.rego: |
     # SPDX-License-Identifier: Apache-2.0
@@ -378,11 +378,14 @@ data:
     #   consent.grant     — create (PENDING_SCA); operator console / onboarding flows (renamed from
     #                       consent.create, issue #938 follow-up: "grant" is a distinctive four-eyes
     #                       verb, so it cannot silently gate every OTHER money-path service's
-    #                       unrelated `.create` action fleet-wide); four-eyes gated, no M2M caller
+    #                       unrelated `.create` action fleet-wide); four-eyes gated. ALSO grantable by
+    #                       the shared M2M principal, but ONLY for grantee=party-service:marketing-comms
+    #                       (ADR-0206) — see service-consent-m2m-marketing below.
     #   consent.read      — getById
     #   consent.list      — listByParty (#partyId), listByGrantee (#granteeId)
     #   consent.revoke    — revoke (DELETE); four-eyes gated (operator-initiated denial of a
-    #                       customer's active consent, rules.yaml four_eyes.verbs), no M2M caller
+    #                       customer's active consent, rules.yaml four_eyes.verbs). Same M2M exception
+    #                       as consent.grant above (ADR-0206), same grantee restriction.
     #   consent.activate  — activate after SCA challenge completes. Deliberately NOT four-eyes
     #                       gated (issue #938 follow-up): the M2M grant below already reserves this
     #                       action for a possible SCA-completion-callback caller — four_eyes_required
@@ -416,12 +419,13 @@ data:
     # consent before serving an AIS/PIS call (consent.read / consent.validate), and
     # the SCA completion callback activates or rejects a PENDING_SCA consent
     # (consent.activate / consent.reject). Deliberately narrow: consent.grant and
-    # consent.revoke are NOT granted to M2M clients — those originate from a human
+    # consent.revoke are otherwise NOT granted to M2M clients — those originate from a human
     # channel (customer or operator), mirroring edge-service-notification's stance
     # that a blanket SERVICE allow would open every @Authorize endpoint to any
-    # M2M client. This is also why consent.activate stays OUT of four_eyes.verbs
-    # (rules.yaml) despite being a risk-relevant action — see that file's guardrail
-    # note (issue #938 follow-up).
+    # M2M client (the narrow, grantee-scoped exception below is the sanctioned deviation —
+    # ADR-0206 — not a reopening of that blanket-allow question). This is also why
+    # consent.activate stays OUT of four_eyes.verbs (rules.yaml) despite being a
+    # risk-relevant action — see that file's guardrail note (issue #938 follow-up).
     #
     # NOTE (found post-merge, issue tracked separately): AuthorizeInterceptor never
     # emits principal.type == "SERVICE" — M2M callers authenticate via Keycloak
@@ -437,6 +441,28 @@ data:
     	input.principal.type == "HUMAN"
     	input.principal.id == "service-account-openbank-services"
     	input.action in {"consent.read", "consent.validate", "consent.activate", "consent.reject"}
+    }
+
+    # ADR-0206: narrow, resource-scoped exception to the "M2M never grants/revokes" stance above.
+    # party-service forwards the mobile app's marketing-consent toggle here (ADR-0198/ADR-0205) —
+    # it authenticates via the SAME shared M2M client as every other backend service, so this rule
+    # cannot distinguish party-service from any other `openbank-services` caller by identity alone.
+    # It instead scopes by RESOURCE: AuthorizeInterceptor's dotted-path extraction
+    # (ADR-0206 D1, `#request.granteeId` on create / `#granteeId` on revoke) binds
+    # input.resource.id to the request's own granteeId field, and this rule only fires when that
+    # equals the one fixed grantee party-service's forwarder uses. Any other `openbank-services`
+    # caller — or party-service itself, for any OTHER granteeId — still falls through to deny,
+    # same as before this rule existed. ConsentService.revokeConsent additionally cross-checks the
+    # passed granteeId against the loaded consent's actual granteeId before revoking (defense in
+    # depth: the OPA decision alone can't see the DB row on this action, and — see rules.yaml's
+    # openbank-consent-service guardrail note — AUTHZ_FOUR_EYES_ENFORCE is false for this service
+    # today, so this M2M path isn't paused pending a second human approver; revisit before ever
+    # flipping that flag here).
+    allowed_reasons contains "service-consent-m2m-marketing" if {
+    	input.principal.type == "HUMAN"
+    	input.principal.id == "service-account-openbank-services"
+    	input.action in {"consent.grant", "consent.revoke"}
+    	input.resource.id == "party-service:marketing-comms"
     }
   agents.rego: |
     # SPDX-License-Identifier: Apache-2.0
@@ -2009,10 +2035,20 @@ data:
                                                # confirmed M2M automated caller (customer-edge) — gating either would brick
                                                # production automation once enforcement is ever flipped on, not just close
                                                # the risky operator-console gap. See the four_eyes.verbs guardrail note below.
-      - openbank-consent-service               # four-eyes wired (issue #938 follow-up) on consent.grant/consent.revoke —
-                                                # both confirmed human-operator-only (no M2M caller). consent.activate
-                                                # deliberately left ungated: its rego already reserves an M2M grant for a
-                                                # possible SCA-completion-callback caller.
+      - openbank-consent-service               # four-eyes wired (issue #938 follow-up) on consent.grant/consent.revoke.
+                                                # UPDATED (ADR-0206): no longer exclusively human-operator — the shared
+                                                # M2M principal may now call both, but ONLY for
+                                                # grantee=party-service:marketing-comms (consent-opa-bundle.yaml's
+                                                # service-consent-m2m-marketing rule), a low-risk SCA-exempt marketing
+                                                # toggle (ADR-0205 D1). AUTHZ_FOUR_EYES_ENFORCE is false today for
+                                                # consent-service (consent-service.yaml has no override), so this M2M
+                                                # path is not currently blocked by the maker/checker pause — but if
+                                                # four-eyes enforcement is ever flipped on for this service, the
+                                                # party-service forwarder (no human in the loop) would stall on the
+                                                # missing second approver. Flag that rollout precondition before
+                                                # flipping AUTHZ_FOUR_EYES_ENFORCE here. consent.activate deliberately
+                                                # left ungated: its rego already reserves an M2M grant for a possible
+                                                # SCA-completion-callback caller.
       - openbank-fraud-service                # ADR-0084: v4 rule engine live; domestic-payment enforcement gate merged (issue #667, flag default-off pending risk-team threshold calibration)
                                                # four-eyes assessed (issue #938 follow-up): the only REST surface today is a stateless
                                                # POST /fraud/score (fraud.score) — no operator case-decision, rule-config, or manual

--- a/openbank-infra/gitops/components/consent/consent-service.yaml
+++ b/openbank-infra/gitops/components/consent/consent-service.yaml
@@ -28,7 +28,7 @@ spec:
       annotations:
         # Rolls the pods when the OPA bundle changes — subPath mounts do NOT hot-reload.
         # Kept in sync by gen-consent-opa-bundle.sh (do not hand-edit).
-        openbank.tech/policy-checksum: "9308b6b7977b8749"
+        openbank.tech/policy-checksum: "cd4fc657c5070876"
     spec:
       securityContext:
         runAsNonRoot: true

--- a/openbank-infra/gitops/components/consent/gen-consent-opa-bundle.sh
+++ b/openbank-infra/gitops/components/consent/gen-consent-opa-bundle.sh
@@ -19,11 +19,14 @@ CONSENT_REST_EXT=$(cat << 'REGO'
 #   consent.grant     — create (PENDING_SCA); operator console / onboarding flows (renamed from
 #                       consent.create, issue #938 follow-up: "grant" is a distinctive four-eyes
 #                       verb, so it cannot silently gate every OTHER money-path service's
-#                       unrelated `.create` action fleet-wide); four-eyes gated, no M2M caller
+#                       unrelated `.create` action fleet-wide); four-eyes gated. ALSO grantable by
+#                       the shared M2M principal, but ONLY for grantee=party-service:marketing-comms
+#                       (ADR-0206) — see service-consent-m2m-marketing below.
 #   consent.read      — getById
 #   consent.list      — listByParty (#partyId), listByGrantee (#granteeId)
 #   consent.revoke    — revoke (DELETE); four-eyes gated (operator-initiated denial of a
-#                       customer's active consent, rules.yaml four_eyes.verbs), no M2M caller
+#                       customer's active consent, rules.yaml four_eyes.verbs). Same M2M exception
+#                       as consent.grant above (ADR-0206), same grantee restriction.
 #   consent.activate  — activate after SCA challenge completes. Deliberately NOT four-eyes
 #                       gated (issue #938 follow-up): the M2M grant below already reserves this
 #                       action for a possible SCA-completion-callback caller — four_eyes_required
@@ -57,12 +60,13 @@ allowed_reasons contains "operator-consent-write" if {
 # consent before serving an AIS/PIS call (consent.read / consent.validate), and
 # the SCA completion callback activates or rejects a PENDING_SCA consent
 # (consent.activate / consent.reject). Deliberately narrow: consent.grant and
-# consent.revoke are NOT granted to M2M clients — those originate from a human
+# consent.revoke are otherwise NOT granted to M2M clients — those originate from a human
 # channel (customer or operator), mirroring edge-service-notification's stance
 # that a blanket SERVICE allow would open every @Authorize endpoint to any
-# M2M client. This is also why consent.activate stays OUT of four_eyes.verbs
-# (rules.yaml) despite being a risk-relevant action — see that file's guardrail
-# note (issue #938 follow-up).
+# M2M client (the narrow, grantee-scoped exception below is the sanctioned deviation —
+# ADR-0206 — not a reopening of that blanket-allow question). This is also why
+# consent.activate stays OUT of four_eyes.verbs (rules.yaml) despite being a
+# risk-relevant action — see that file's guardrail note (issue #938 follow-up).
 #
 # NOTE (found post-merge, issue tracked separately): AuthorizeInterceptor never
 # emits principal.type == "SERVICE" — M2M callers authenticate via Keycloak
@@ -78,6 +82,28 @@ allowed_reasons contains "service-consent-m2m" if {
 	input.principal.type == "HUMAN"
 	input.principal.id == "service-account-openbank-services"
 	input.action in {"consent.read", "consent.validate", "consent.activate", "consent.reject"}
+}
+
+# ADR-0206: narrow, resource-scoped exception to the "M2M never grants/revokes" stance above.
+# party-service forwards the mobile app's marketing-consent toggle here (ADR-0198/ADR-0205) —
+# it authenticates via the SAME shared M2M client as every other backend service, so this rule
+# cannot distinguish party-service from any other `openbank-services` caller by identity alone.
+# It instead scopes by RESOURCE: AuthorizeInterceptor's dotted-path extraction
+# (ADR-0206 D1, `#request.granteeId` on create / `#granteeId` on revoke) binds
+# input.resource.id to the request's own granteeId field, and this rule only fires when that
+# equals the one fixed grantee party-service's forwarder uses. Any other `openbank-services`
+# caller — or party-service itself, for any OTHER granteeId — still falls through to deny,
+# same as before this rule existed. ConsentService.revokeConsent additionally cross-checks the
+# passed granteeId against the loaded consent's actual granteeId before revoking (defense in
+# depth: the OPA decision alone can't see the DB row on this action, and — see rules.yaml's
+# openbank-consent-service guardrail note — AUTHZ_FOUR_EYES_ENFORCE is false for this service
+# today, so this M2M path isn't paused pending a second human approver; revisit before ever
+# flipping that flag here).
+allowed_reasons contains "service-consent-m2m-marketing" if {
+	input.principal.type == "HUMAN"
+	input.principal.id == "service-account-openbank-services"
+	input.action in {"consent.grant", "consent.revoke"}
+	input.resource.id == "party-service:marketing-comms"
 }
 REGO
 )

--- a/openbank-infra/gitops/components/copilot/copilot-opa-bundle.yaml
+++ b/openbank-infra/gitops/components/copilot/copilot-opa-bundle.yaml
@@ -9,7 +9,7 @@ metadata:
     app.kubernetes.io/name: copilot-service
     app.kubernetes.io/part-of: platform
   annotations:
-    openbank.tech/policy-checksum: "13ad3e5756ca1bad"
+    openbank.tech/policy-checksum: "787ee5d8d1839648"
 data:
   rest.rego: |
     # SPDX-License-Identifier: Apache-2.0
@@ -2063,10 +2063,20 @@ data:
                                                # confirmed M2M automated caller (customer-edge) — gating either would brick
                                                # production automation once enforcement is ever flipped on, not just close
                                                # the risky operator-console gap. See the four_eyes.verbs guardrail note below.
-      - openbank-consent-service               # four-eyes wired (issue #938 follow-up) on consent.grant/consent.revoke —
-                                                # both confirmed human-operator-only (no M2M caller). consent.activate
-                                                # deliberately left ungated: its rego already reserves an M2M grant for a
-                                                # possible SCA-completion-callback caller.
+      - openbank-consent-service               # four-eyes wired (issue #938 follow-up) on consent.grant/consent.revoke.
+                                                # UPDATED (ADR-0206): no longer exclusively human-operator — the shared
+                                                # M2M principal may now call both, but ONLY for
+                                                # grantee=party-service:marketing-comms (consent-opa-bundle.yaml's
+                                                # service-consent-m2m-marketing rule), a low-risk SCA-exempt marketing
+                                                # toggle (ADR-0205 D1). AUTHZ_FOUR_EYES_ENFORCE is false today for
+                                                # consent-service (consent-service.yaml has no override), so this M2M
+                                                # path is not currently blocked by the maker/checker pause — but if
+                                                # four-eyes enforcement is ever flipped on for this service, the
+                                                # party-service forwarder (no human in the loop) would stall on the
+                                                # missing second approver. Flag that rollout precondition before
+                                                # flipping AUTHZ_FOUR_EYES_ENFORCE here. consent.activate deliberately
+                                                # left ungated: its rego already reserves an M2M grant for a possible
+                                                # SCA-completion-callback caller.
       - openbank-fraud-service                # ADR-0084: v4 rule engine live; domestic-payment enforcement gate merged (issue #667, flag default-off pending risk-team threshold calibration)
                                                # four-eyes assessed (issue #938 follow-up): the only REST surface today is a stateless
                                                # POST /fraud/score (fraud.score) — no operator case-decision, rule-config, or manual

--- a/openbank-infra/gitops/components/copilot/copilot-service.yaml
+++ b/openbank-infra/gitops/components/copilot/copilot-service.yaml
@@ -29,7 +29,7 @@ spec:
       annotations:
         # Rolls the pod when the OPA bundle changes — subPath mounts do NOT hot-reload.
         # Kept in sync by gen-copilot-opa-bundle.sh (do not hand-edit).
-        openbank.tech/policy-checksum: "13ad3e5756ca1bad"
+        openbank.tech/policy-checksum: "787ee5d8d1839648"
     spec:
       securityContext:
         runAsNonRoot: true

--- a/openbank-infra/gitops/components/customer-edge/customer-edge-opa-bundle.yaml
+++ b/openbank-infra/gitops/components/customer-edge/customer-edge-opa-bundle.yaml
@@ -10,7 +10,7 @@ metadata:
     app.kubernetes.io/name: customer-edge
     app.kubernetes.io/part-of: customer-edge
   annotations:
-    openbank.tech/policy-checksum: "4cbd1f661b104602"
+    openbank.tech/policy-checksum: "c30ed48a4b8b2831"
 data:
   rest.rego: |
     # SPDX-License-Identifier: Apache-2.0
@@ -1162,10 +1162,20 @@ data:
                                                # confirmed M2M automated caller (customer-edge) — gating either would brick
                                                # production automation once enforcement is ever flipped on, not just close
                                                # the risky operator-console gap. See the four_eyes.verbs guardrail note below.
-      - openbank-consent-service               # four-eyes wired (issue #938 follow-up) on consent.grant/consent.revoke —
-                                                # both confirmed human-operator-only (no M2M caller). consent.activate
-                                                # deliberately left ungated: its rego already reserves an M2M grant for a
-                                                # possible SCA-completion-callback caller.
+      - openbank-consent-service               # four-eyes wired (issue #938 follow-up) on consent.grant/consent.revoke.
+                                                # UPDATED (ADR-0206): no longer exclusively human-operator — the shared
+                                                # M2M principal may now call both, but ONLY for
+                                                # grantee=party-service:marketing-comms (consent-opa-bundle.yaml's
+                                                # service-consent-m2m-marketing rule), a low-risk SCA-exempt marketing
+                                                # toggle (ADR-0205 D1). AUTHZ_FOUR_EYES_ENFORCE is false today for
+                                                # consent-service (consent-service.yaml has no override), so this M2M
+                                                # path is not currently blocked by the maker/checker pause — but if
+                                                # four-eyes enforcement is ever flipped on for this service, the
+                                                # party-service forwarder (no human in the loop) would stall on the
+                                                # missing second approver. Flag that rollout precondition before
+                                                # flipping AUTHZ_FOUR_EYES_ENFORCE here. consent.activate deliberately
+                                                # left ungated: its rego already reserves an M2M grant for a possible
+                                                # SCA-completion-callback caller.
       - openbank-fraud-service                # ADR-0084: v4 rule engine live; domestic-payment enforcement gate merged (issue #667, flag default-off pending risk-team threshold calibration)
                                                # four-eyes assessed (issue #938 follow-up): the only REST surface today is a stateless
                                                # POST /fraud/score (fraud.score) — no operator case-decision, rule-config, or manual

--- a/openbank-infra/gitops/components/customer-edge/customer-edge.yaml
+++ b/openbank-infra/gitops/components/customer-edge/customer-edge.yaml
@@ -65,7 +65,7 @@ spec:
       annotations:
         # Rolls the pod when the OPA bundle changes — subPath mounts do NOT hot-reload.
         # Kept in sync by gen-customer-edge-opa-bundle.sh (do not hand-edit).
-        openbank.tech/policy-checksum: "4cbd1f661b104602"
+        openbank.tech/policy-checksum: "c30ed48a4b8b2831"
     spec:
       # Dedicated SA so EKS Pod Identity can hand the edge (and ONLY the edge) the
       # feedback-screenshots S3 role — ADR-0192, openbank-infra/aws/envs/sandbox-platform/

--- a/openbank-infra/gitops/components/dispute-service/dispute-opa-bundle.yaml
+++ b/openbank-infra/gitops/components/dispute-service/dispute-opa-bundle.yaml
@@ -9,7 +9,7 @@ metadata:
     app.kubernetes.io/name: dispute-service
     app.kubernetes.io/part-of: dispute
   annotations:
-    openbank.tech/policy-checksum: "b60aa9bb667a3041"
+    openbank.tech/policy-checksum: "24b04754c9423ba3"
 data:
   rest.rego: |
     # SPDX-License-Identifier: Apache-2.0
@@ -2113,10 +2113,20 @@ data:
                                                # confirmed M2M automated caller (customer-edge) — gating either would brick
                                                # production automation once enforcement is ever flipped on, not just close
                                                # the risky operator-console gap. See the four_eyes.verbs guardrail note below.
-      - openbank-consent-service               # four-eyes wired (issue #938 follow-up) on consent.grant/consent.revoke —
-                                                # both confirmed human-operator-only (no M2M caller). consent.activate
-                                                # deliberately left ungated: its rego already reserves an M2M grant for a
-                                                # possible SCA-completion-callback caller.
+      - openbank-consent-service               # four-eyes wired (issue #938 follow-up) on consent.grant/consent.revoke.
+                                                # UPDATED (ADR-0206): no longer exclusively human-operator — the shared
+                                                # M2M principal may now call both, but ONLY for
+                                                # grantee=party-service:marketing-comms (consent-opa-bundle.yaml's
+                                                # service-consent-m2m-marketing rule), a low-risk SCA-exempt marketing
+                                                # toggle (ADR-0205 D1). AUTHZ_FOUR_EYES_ENFORCE is false today for
+                                                # consent-service (consent-service.yaml has no override), so this M2M
+                                                # path is not currently blocked by the maker/checker pause — but if
+                                                # four-eyes enforcement is ever flipped on for this service, the
+                                                # party-service forwarder (no human in the loop) would stall on the
+                                                # missing second approver. Flag that rollout precondition before
+                                                # flipping AUTHZ_FOUR_EYES_ENFORCE here. consent.activate deliberately
+                                                # left ungated: its rego already reserves an M2M grant for a possible
+                                                # SCA-completion-callback caller.
       - openbank-fraud-service                # ADR-0084: v4 rule engine live; domestic-payment enforcement gate merged (issue #667, flag default-off pending risk-team threshold calibration)
                                                # four-eyes assessed (issue #938 follow-up): the only REST surface today is a stateless
                                                # POST /fraud/score (fraud.score) — no operator case-decision, rule-config, or manual

--- a/openbank-infra/gitops/components/dispute-service/dispute-service.yaml
+++ b/openbank-infra/gitops/components/dispute-service/dispute-service.yaml
@@ -15,7 +15,7 @@ spec:
       annotations:
         # Rolls the pod when the OPA bundle changes — subPath mounts do NOT hot-reload.
         # Kept in sync by gen-dispute-opa-bundle.sh (do not hand-edit).
-        openbank.tech/policy-checksum: "b60aa9bb667a3041"
+        openbank.tech/policy-checksum: "24b04754c9423ba3"
       labels: {app.kubernetes.io/name: dispute-service, app.kubernetes.io/part-of: dispute}
     spec:
       securityContext:

--- a/openbank-infra/gitops/components/document-service/document-service-opa-bundle.yaml
+++ b/openbank-infra/gitops/components/document-service/document-service-opa-bundle.yaml
@@ -10,7 +10,7 @@ metadata:
     app.kubernetes.io/name: document-service
     app.kubernetes.io/part-of: documents
   annotations:
-    openbank.tech/policy-checksum: "4cbd1f661b104602"
+    openbank.tech/policy-checksum: "c30ed48a4b8b2831"
 data:
   rest.rego: |
     # SPDX-License-Identifier: Apache-2.0
@@ -1162,10 +1162,20 @@ data:
                                                # confirmed M2M automated caller (customer-edge) — gating either would brick
                                                # production automation once enforcement is ever flipped on, not just close
                                                # the risky operator-console gap. See the four_eyes.verbs guardrail note below.
-      - openbank-consent-service               # four-eyes wired (issue #938 follow-up) on consent.grant/consent.revoke —
-                                                # both confirmed human-operator-only (no M2M caller). consent.activate
-                                                # deliberately left ungated: its rego already reserves an M2M grant for a
-                                                # possible SCA-completion-callback caller.
+      - openbank-consent-service               # four-eyes wired (issue #938 follow-up) on consent.grant/consent.revoke.
+                                                # UPDATED (ADR-0206): no longer exclusively human-operator — the shared
+                                                # M2M principal may now call both, but ONLY for
+                                                # grantee=party-service:marketing-comms (consent-opa-bundle.yaml's
+                                                # service-consent-m2m-marketing rule), a low-risk SCA-exempt marketing
+                                                # toggle (ADR-0205 D1). AUTHZ_FOUR_EYES_ENFORCE is false today for
+                                                # consent-service (consent-service.yaml has no override), so this M2M
+                                                # path is not currently blocked by the maker/checker pause — but if
+                                                # four-eyes enforcement is ever flipped on for this service, the
+                                                # party-service forwarder (no human in the loop) would stall on the
+                                                # missing second approver. Flag that rollout precondition before
+                                                # flipping AUTHZ_FOUR_EYES_ENFORCE here. consent.activate deliberately
+                                                # left ungated: its rego already reserves an M2M grant for a possible
+                                                # SCA-completion-callback caller.
       - openbank-fraud-service                # ADR-0084: v4 rule engine live; domestic-payment enforcement gate merged (issue #667, flag default-off pending risk-team threshold calibration)
                                                # four-eyes assessed (issue #938 follow-up): the only REST surface today is a stateless
                                                # POST /fraud/score (fraud.score) — no operator case-decision, rule-config, or manual

--- a/openbank-infra/gitops/components/document-service/document-service-service.yaml
+++ b/openbank-infra/gitops/components/document-service/document-service-service.yaml
@@ -43,7 +43,7 @@ spec:
       annotations:
         # Rolls the pods when the OPA bundle changes — subPath mounts do NOT hot-reload.
         # Kept in sync by gen-document-service-opa-bundle.sh (do not hand-edit).
-        openbank.tech/policy-checksum: "4cbd1f661b104602"
+        openbank.tech/policy-checksum: "c30ed48a4b8b2831"
     spec:
       # ADR-0162 D4 (continued): a dedicated SA (not `default`) is what OpenBao's Kubernetes-auth
       # role `document-service-signing` is bound to — least-privilege, one identity per consumer.

--- a/openbank-infra/gitops/components/fraud-service/fraud-opa-bundle.yaml
+++ b/openbank-infra/gitops/components/fraud-service/fraud-opa-bundle.yaml
@@ -9,7 +9,7 @@ metadata:
     app.kubernetes.io/name: fraud-service
     app.kubernetes.io/part-of: fraud
   annotations:
-    openbank.tech/policy-checksum: "5c6767232dc5fa37"
+    openbank.tech/policy-checksum: "d557a22989d178ea"
 data:
   rest.rego: |
     # SPDX-License-Identifier: Apache-2.0
@@ -1988,10 +1988,20 @@ data:
                                                # confirmed M2M automated caller (customer-edge) — gating either would brick
                                                # production automation once enforcement is ever flipped on, not just close
                                                # the risky operator-console gap. See the four_eyes.verbs guardrail note below.
-      - openbank-consent-service               # four-eyes wired (issue #938 follow-up) on consent.grant/consent.revoke —
-                                                # both confirmed human-operator-only (no M2M caller). consent.activate
-                                                # deliberately left ungated: its rego already reserves an M2M grant for a
-                                                # possible SCA-completion-callback caller.
+      - openbank-consent-service               # four-eyes wired (issue #938 follow-up) on consent.grant/consent.revoke.
+                                                # UPDATED (ADR-0206): no longer exclusively human-operator — the shared
+                                                # M2M principal may now call both, but ONLY for
+                                                # grantee=party-service:marketing-comms (consent-opa-bundle.yaml's
+                                                # service-consent-m2m-marketing rule), a low-risk SCA-exempt marketing
+                                                # toggle (ADR-0205 D1). AUTHZ_FOUR_EYES_ENFORCE is false today for
+                                                # consent-service (consent-service.yaml has no override), so this M2M
+                                                # path is not currently blocked by the maker/checker pause — but if
+                                                # four-eyes enforcement is ever flipped on for this service, the
+                                                # party-service forwarder (no human in the loop) would stall on the
+                                                # missing second approver. Flag that rollout precondition before
+                                                # flipping AUTHZ_FOUR_EYES_ENFORCE here. consent.activate deliberately
+                                                # left ungated: its rego already reserves an M2M grant for a possible
+                                                # SCA-completion-callback caller.
       - openbank-fraud-service                # ADR-0084: v4 rule engine live; domestic-payment enforcement gate merged (issue #667, flag default-off pending risk-team threshold calibration)
                                                # four-eyes assessed (issue #938 follow-up): the only REST surface today is a stateless
                                                # POST /fraud/score (fraud.score) — no operator case-decision, rule-config, or manual

--- a/openbank-infra/gitops/components/fraud-service/fraud-service.yaml
+++ b/openbank-infra/gitops/components/fraud-service/fraud-service.yaml
@@ -23,7 +23,7 @@ spec:
       annotations:
         # Rolls the pods when the OPA bundle changes — subPath mounts do NOT hot-reload.
         # Kept in sync by gen-fraud-opa-bundle.sh (do not hand-edit).
-        openbank.tech/policy-checksum: "5c6767232dc5fa37"
+        openbank.tech/policy-checksum: "d557a22989d178ea"
     spec:
       securityContext:
         runAsNonRoot: true

--- a/openbank-infra/gitops/components/fx-service/fx-opa-bundle.yaml
+++ b/openbank-infra/gitops/components/fx-service/fx-opa-bundle.yaml
@@ -9,7 +9,7 @@ metadata:
     app.kubernetes.io/name: fx-service
     app.kubernetes.io/part-of: fx
   annotations:
-    openbank.tech/policy-checksum: "96adffcfbd78395d"
+    openbank.tech/policy-checksum: "6a89a82288fcb40c"
 data:
   rest.rego: |
     # SPDX-License-Identifier: Apache-2.0
@@ -2039,10 +2039,20 @@ data:
                                                # confirmed M2M automated caller (customer-edge) — gating either would brick
                                                # production automation once enforcement is ever flipped on, not just close
                                                # the risky operator-console gap. See the four_eyes.verbs guardrail note below.
-      - openbank-consent-service               # four-eyes wired (issue #938 follow-up) on consent.grant/consent.revoke —
-                                                # both confirmed human-operator-only (no M2M caller). consent.activate
-                                                # deliberately left ungated: its rego already reserves an M2M grant for a
-                                                # possible SCA-completion-callback caller.
+      - openbank-consent-service               # four-eyes wired (issue #938 follow-up) on consent.grant/consent.revoke.
+                                                # UPDATED (ADR-0206): no longer exclusively human-operator — the shared
+                                                # M2M principal may now call both, but ONLY for
+                                                # grantee=party-service:marketing-comms (consent-opa-bundle.yaml's
+                                                # service-consent-m2m-marketing rule), a low-risk SCA-exempt marketing
+                                                # toggle (ADR-0205 D1). AUTHZ_FOUR_EYES_ENFORCE is false today for
+                                                # consent-service (consent-service.yaml has no override), so this M2M
+                                                # path is not currently blocked by the maker/checker pause — but if
+                                                # four-eyes enforcement is ever flipped on for this service, the
+                                                # party-service forwarder (no human in the loop) would stall on the
+                                                # missing second approver. Flag that rollout precondition before
+                                                # flipping AUTHZ_FOUR_EYES_ENFORCE here. consent.activate deliberately
+                                                # left ungated: its rego already reserves an M2M grant for a possible
+                                                # SCA-completion-callback caller.
       - openbank-fraud-service                # ADR-0084: v4 rule engine live; domestic-payment enforcement gate merged (issue #667, flag default-off pending risk-team threshold calibration)
                                                # four-eyes assessed (issue #938 follow-up): the only REST surface today is a stateless
                                                # POST /fraud/score (fraud.score) — no operator case-decision, rule-config, or manual

--- a/openbank-infra/gitops/components/fx-service/fx-service.yaml
+++ b/openbank-infra/gitops/components/fx-service/fx-service.yaml
@@ -22,7 +22,7 @@ spec:
       annotations:
         # Rolls the pods when the OPA bundle changes — subPath mounts do NOT hot-reload.
         # Kept in sync by gen-fx-opa-bundle.sh (do not hand-edit).
-        openbank.tech/policy-checksum: "96adffcfbd78395d"
+        openbank.tech/policy-checksum: "6a89a82288fcb40c"
     spec:
       securityContext:
         runAsNonRoot: true

--- a/openbank-infra/gitops/components/interest-service/interest-opa-bundle.yaml
+++ b/openbank-infra/gitops/components/interest-service/interest-opa-bundle.yaml
@@ -9,7 +9,7 @@ metadata:
     app.kubernetes.io/name: interest-service
     app.kubernetes.io/part-of: interest
   annotations:
-    openbank.tech/policy-checksum: "580c2df7b5474cfb"
+    openbank.tech/policy-checksum: "eb25680a3a54e137"
 data:
   rest.rego: |
     # SPDX-License-Identifier: Apache-2.0
@@ -1973,10 +1973,20 @@ data:
                                                # confirmed M2M automated caller (customer-edge) — gating either would brick
                                                # production automation once enforcement is ever flipped on, not just close
                                                # the risky operator-console gap. See the four_eyes.verbs guardrail note below.
-      - openbank-consent-service               # four-eyes wired (issue #938 follow-up) on consent.grant/consent.revoke —
-                                                # both confirmed human-operator-only (no M2M caller). consent.activate
-                                                # deliberately left ungated: its rego already reserves an M2M grant for a
-                                                # possible SCA-completion-callback caller.
+      - openbank-consent-service               # four-eyes wired (issue #938 follow-up) on consent.grant/consent.revoke.
+                                                # UPDATED (ADR-0206): no longer exclusively human-operator — the shared
+                                                # M2M principal may now call both, but ONLY for
+                                                # grantee=party-service:marketing-comms (consent-opa-bundle.yaml's
+                                                # service-consent-m2m-marketing rule), a low-risk SCA-exempt marketing
+                                                # toggle (ADR-0205 D1). AUTHZ_FOUR_EYES_ENFORCE is false today for
+                                                # consent-service (consent-service.yaml has no override), so this M2M
+                                                # path is not currently blocked by the maker/checker pause — but if
+                                                # four-eyes enforcement is ever flipped on for this service, the
+                                                # party-service forwarder (no human in the loop) would stall on the
+                                                # missing second approver. Flag that rollout precondition before
+                                                # flipping AUTHZ_FOUR_EYES_ENFORCE here. consent.activate deliberately
+                                                # left ungated: its rego already reserves an M2M grant for a possible
+                                                # SCA-completion-callback caller.
       - openbank-fraud-service                # ADR-0084: v4 rule engine live; domestic-payment enforcement gate merged (issue #667, flag default-off pending risk-team threshold calibration)
                                                # four-eyes assessed (issue #938 follow-up): the only REST surface today is a stateless
                                                # POST /fraud/score (fraud.score) — no operator case-decision, rule-config, or manual

--- a/openbank-infra/gitops/components/interest-service/interest-service.yaml
+++ b/openbank-infra/gitops/components/interest-service/interest-service.yaml
@@ -16,7 +16,7 @@ spec:
       annotations:
         # Rolls the pods when the OPA bundle changes — subPath mounts do NOT hot-reload.
         # Kept in sync by gen-interest-opa-bundle.sh (do not hand-edit).
-        openbank.tech/policy-checksum: "580c2df7b5474cfb"
+        openbank.tech/policy-checksum: "eb25680a3a54e137"
     spec:
       securityContext:
         runAsNonRoot: true

--- a/openbank-infra/gitops/components/kyc/kyc-opa-bundle.yaml
+++ b/openbank-infra/gitops/components/kyc/kyc-opa-bundle.yaml
@@ -9,7 +9,7 @@ metadata:
     app.kubernetes.io/name: kyc-service
     app.kubernetes.io/part-of: kyc
   annotations:
-    openbank.tech/policy-checksum: "e97442718f9d0cb0"
+    openbank.tech/policy-checksum: "96acaf2d92b65484"
 data:
   rest.rego: |
     # SPDX-License-Identifier: Apache-2.0
@@ -2001,10 +2001,20 @@ data:
                                                # confirmed M2M automated caller (customer-edge) — gating either would brick
                                                # production automation once enforcement is ever flipped on, not just close
                                                # the risky operator-console gap. See the four_eyes.verbs guardrail note below.
-      - openbank-consent-service               # four-eyes wired (issue #938 follow-up) on consent.grant/consent.revoke —
-                                                # both confirmed human-operator-only (no M2M caller). consent.activate
-                                                # deliberately left ungated: its rego already reserves an M2M grant for a
-                                                # possible SCA-completion-callback caller.
+      - openbank-consent-service               # four-eyes wired (issue #938 follow-up) on consent.grant/consent.revoke.
+                                                # UPDATED (ADR-0206): no longer exclusively human-operator — the shared
+                                                # M2M principal may now call both, but ONLY for
+                                                # grantee=party-service:marketing-comms (consent-opa-bundle.yaml's
+                                                # service-consent-m2m-marketing rule), a low-risk SCA-exempt marketing
+                                                # toggle (ADR-0205 D1). AUTHZ_FOUR_EYES_ENFORCE is false today for
+                                                # consent-service (consent-service.yaml has no override), so this M2M
+                                                # path is not currently blocked by the maker/checker pause — but if
+                                                # four-eyes enforcement is ever flipped on for this service, the
+                                                # party-service forwarder (no human in the loop) would stall on the
+                                                # missing second approver. Flag that rollout precondition before
+                                                # flipping AUTHZ_FOUR_EYES_ENFORCE here. consent.activate deliberately
+                                                # left ungated: its rego already reserves an M2M grant for a possible
+                                                # SCA-completion-callback caller.
       - openbank-fraud-service                # ADR-0084: v4 rule engine live; domestic-payment enforcement gate merged (issue #667, flag default-off pending risk-team threshold calibration)
                                                # four-eyes assessed (issue #938 follow-up): the only REST surface today is a stateless
                                                # POST /fraud/score (fraud.score) — no operator case-decision, rule-config, or manual

--- a/openbank-infra/gitops/components/kyc/kyc-service.yaml
+++ b/openbank-infra/gitops/components/kyc/kyc-service.yaml
@@ -48,7 +48,7 @@ spec:
       annotations:
         # Rolls the pod when the OPA bundle changes (subPath mounts do not hot-reload).
         # Kept in sync by gen-kyc-opa-bundle.sh (do not hand-edit).
-        openbank.tech/policy-checksum: "e97442718f9d0cb0"
+        openbank.tech/policy-checksum: "96acaf2d92b65484"
     spec:
       securityContext:
         runAsNonRoot: true

--- a/openbank-infra/gitops/components/ledger/ledger-opa-bundle.yaml
+++ b/openbank-infra/gitops/components/ledger/ledger-opa-bundle.yaml
@@ -9,7 +9,7 @@ metadata:
     app.kubernetes.io/name: ledger-service
     app.kubernetes.io/part-of: ledger
   annotations:
-    openbank.tech/policy-checksum: "b314548623fb5bfa"
+    openbank.tech/policy-checksum: "5ff515f95eec7a0b"
 data:
   rest.rego: |
     # SPDX-License-Identifier: Apache-2.0
@@ -2086,10 +2086,20 @@ data:
                                                # confirmed M2M automated caller (customer-edge) — gating either would brick
                                                # production automation once enforcement is ever flipped on, not just close
                                                # the risky operator-console gap. See the four_eyes.verbs guardrail note below.
-      - openbank-consent-service               # four-eyes wired (issue #938 follow-up) on consent.grant/consent.revoke —
-                                                # both confirmed human-operator-only (no M2M caller). consent.activate
-                                                # deliberately left ungated: its rego already reserves an M2M grant for a
-                                                # possible SCA-completion-callback caller.
+      - openbank-consent-service               # four-eyes wired (issue #938 follow-up) on consent.grant/consent.revoke.
+                                                # UPDATED (ADR-0206): no longer exclusively human-operator — the shared
+                                                # M2M principal may now call both, but ONLY for
+                                                # grantee=party-service:marketing-comms (consent-opa-bundle.yaml's
+                                                # service-consent-m2m-marketing rule), a low-risk SCA-exempt marketing
+                                                # toggle (ADR-0205 D1). AUTHZ_FOUR_EYES_ENFORCE is false today for
+                                                # consent-service (consent-service.yaml has no override), so this M2M
+                                                # path is not currently blocked by the maker/checker pause — but if
+                                                # four-eyes enforcement is ever flipped on for this service, the
+                                                # party-service forwarder (no human in the loop) would stall on the
+                                                # missing second approver. Flag that rollout precondition before
+                                                # flipping AUTHZ_FOUR_EYES_ENFORCE here. consent.activate deliberately
+                                                # left ungated: its rego already reserves an M2M grant for a possible
+                                                # SCA-completion-callback caller.
       - openbank-fraud-service                # ADR-0084: v4 rule engine live; domestic-payment enforcement gate merged (issue #667, flag default-off pending risk-team threshold calibration)
                                                # four-eyes assessed (issue #938 follow-up): the only REST surface today is a stateless
                                                # POST /fraud/score (fraud.score) — no operator case-decision, rule-config, or manual

--- a/openbank-infra/gitops/components/ledger/ledger-service.yaml
+++ b/openbank-infra/gitops/components/ledger/ledger-service.yaml
@@ -38,7 +38,7 @@ spec:
       annotations:
         # Rolls the pods when the OPA bundle changes — subPath mounts do NOT hot-reload.
         # Kept in sync by gen-ledger-opa-bundle.sh (do not hand-edit).
-        openbank.tech/policy-checksum: "b314548623fb5bfa"
+        openbank.tech/policy-checksum: "5ff515f95eec7a0b"
     spec:
       securityContext:
         runAsNonRoot: true

--- a/openbank-infra/gitops/components/lending/lending-opa-bundle.yaml
+++ b/openbank-infra/gitops/components/lending/lending-opa-bundle.yaml
@@ -9,7 +9,7 @@ metadata:
     app.kubernetes.io/name: lending-service
     app.kubernetes.io/part-of: lending
   annotations:
-    openbank.tech/policy-checksum: "fe26beb0e6c1df30"
+    openbank.tech/policy-checksum: "e187e5d37e547bb1"
 data:
   rest.rego: |
     # SPDX-License-Identifier: Apache-2.0
@@ -2041,10 +2041,20 @@ data:
                                                # confirmed M2M automated caller (customer-edge) — gating either would brick
                                                # production automation once enforcement is ever flipped on, not just close
                                                # the risky operator-console gap. See the four_eyes.verbs guardrail note below.
-      - openbank-consent-service               # four-eyes wired (issue #938 follow-up) on consent.grant/consent.revoke —
-                                                # both confirmed human-operator-only (no M2M caller). consent.activate
-                                                # deliberately left ungated: its rego already reserves an M2M grant for a
-                                                # possible SCA-completion-callback caller.
+      - openbank-consent-service               # four-eyes wired (issue #938 follow-up) on consent.grant/consent.revoke.
+                                                # UPDATED (ADR-0206): no longer exclusively human-operator — the shared
+                                                # M2M principal may now call both, but ONLY for
+                                                # grantee=party-service:marketing-comms (consent-opa-bundle.yaml's
+                                                # service-consent-m2m-marketing rule), a low-risk SCA-exempt marketing
+                                                # toggle (ADR-0205 D1). AUTHZ_FOUR_EYES_ENFORCE is false today for
+                                                # consent-service (consent-service.yaml has no override), so this M2M
+                                                # path is not currently blocked by the maker/checker pause — but if
+                                                # four-eyes enforcement is ever flipped on for this service, the
+                                                # party-service forwarder (no human in the loop) would stall on the
+                                                # missing second approver. Flag that rollout precondition before
+                                                # flipping AUTHZ_FOUR_EYES_ENFORCE here. consent.activate deliberately
+                                                # left ungated: its rego already reserves an M2M grant for a possible
+                                                # SCA-completion-callback caller.
       - openbank-fraud-service                # ADR-0084: v4 rule engine live; domestic-payment enforcement gate merged (issue #667, flag default-off pending risk-team threshold calibration)
                                                # four-eyes assessed (issue #938 follow-up): the only REST surface today is a stateless
                                                # POST /fraud/score (fraud.score) — no operator case-decision, rule-config, or manual

--- a/openbank-infra/gitops/components/lending/lending-service.yaml
+++ b/openbank-infra/gitops/components/lending/lending-service.yaml
@@ -34,7 +34,7 @@ spec:
       annotations:
         # Rolls the pods when the OPA bundle changes — subPath mounts do NOT hot-reload.
         # Kept in sync by gen-lending-opa-bundle.sh (do not hand-edit).
-        openbank.tech/policy-checksum: "fe26beb0e6c1df30"
+        openbank.tech/policy-checksum: "e187e5d37e547bb1"
     spec:
       securityContext:
         runAsNonRoot: true

--- a/openbank-infra/gitops/components/mcp/mcp-opa-bundle.yaml
+++ b/openbank-infra/gitops/components/mcp/mcp-opa-bundle.yaml
@@ -9,7 +9,7 @@ metadata:
     app.kubernetes.io/name: mcp-service
     app.kubernetes.io/part-of: platform
   annotations:
-    openbank.tech/policy-checksum: "c5b9e80930a29004"
+    openbank.tech/policy-checksum: "a4190eed6dd3b779"
 data:
   rest.rego: |
     # SPDX-License-Identifier: Apache-2.0
@@ -1939,10 +1939,20 @@ data:
                                                # confirmed M2M automated caller (customer-edge) — gating either would brick
                                                # production automation once enforcement is ever flipped on, not just close
                                                # the risky operator-console gap. See the four_eyes.verbs guardrail note below.
-      - openbank-consent-service               # four-eyes wired (issue #938 follow-up) on consent.grant/consent.revoke —
-                                                # both confirmed human-operator-only (no M2M caller). consent.activate
-                                                # deliberately left ungated: its rego already reserves an M2M grant for a
-                                                # possible SCA-completion-callback caller.
+      - openbank-consent-service               # four-eyes wired (issue #938 follow-up) on consent.grant/consent.revoke.
+                                                # UPDATED (ADR-0206): no longer exclusively human-operator — the shared
+                                                # M2M principal may now call both, but ONLY for
+                                                # grantee=party-service:marketing-comms (consent-opa-bundle.yaml's
+                                                # service-consent-m2m-marketing rule), a low-risk SCA-exempt marketing
+                                                # toggle (ADR-0205 D1). AUTHZ_FOUR_EYES_ENFORCE is false today for
+                                                # consent-service (consent-service.yaml has no override), so this M2M
+                                                # path is not currently blocked by the maker/checker pause — but if
+                                                # four-eyes enforcement is ever flipped on for this service, the
+                                                # party-service forwarder (no human in the loop) would stall on the
+                                                # missing second approver. Flag that rollout precondition before
+                                                # flipping AUTHZ_FOUR_EYES_ENFORCE here. consent.activate deliberately
+                                                # left ungated: its rego already reserves an M2M grant for a possible
+                                                # SCA-completion-callback caller.
       - openbank-fraud-service                # ADR-0084: v4 rule engine live; domestic-payment enforcement gate merged (issue #667, flag default-off pending risk-team threshold calibration)
                                                # four-eyes assessed (issue #938 follow-up): the only REST surface today is a stateless
                                                # POST /fraud/score (fraud.score) — no operator case-decision, rule-config, or manual

--- a/openbank-infra/gitops/components/mcp/mcp-service.yaml
+++ b/openbank-infra/gitops/components/mcp/mcp-service.yaml
@@ -29,7 +29,7 @@ spec:
       annotations:
         # Rolls the pod when the OPA bundle changes — subPath mounts do NOT hot-reload.
         # Kept in sync by gen-mcp-opa-bundle.sh (do not hand-edit).
-        openbank.tech/policy-checksum: "c5b9e80930a29004"
+        openbank.tech/policy-checksum: "a4190eed6dd3b779"
     spec:
       securityContext:
         runAsNonRoot: true

--- a/openbank-infra/gitops/components/notifications/notification-service-opa-bundle.yaml
+++ b/openbank-infra/gitops/components/notifications/notification-service-opa-bundle.yaml
@@ -10,7 +10,7 @@ metadata:
     app.kubernetes.io/name: notification-service
     app.kubernetes.io/part-of: notifications
   annotations:
-    openbank.tech/policy-checksum: "4cbd1f661b104602"
+    openbank.tech/policy-checksum: "c30ed48a4b8b2831"
 data:
   rest.rego: |
     # SPDX-License-Identifier: Apache-2.0
@@ -1162,10 +1162,20 @@ data:
                                                # confirmed M2M automated caller (customer-edge) — gating either would brick
                                                # production automation once enforcement is ever flipped on, not just close
                                                # the risky operator-console gap. See the four_eyes.verbs guardrail note below.
-      - openbank-consent-service               # four-eyes wired (issue #938 follow-up) on consent.grant/consent.revoke —
-                                                # both confirmed human-operator-only (no M2M caller). consent.activate
-                                                # deliberately left ungated: its rego already reserves an M2M grant for a
-                                                # possible SCA-completion-callback caller.
+      - openbank-consent-service               # four-eyes wired (issue #938 follow-up) on consent.grant/consent.revoke.
+                                                # UPDATED (ADR-0206): no longer exclusively human-operator — the shared
+                                                # M2M principal may now call both, but ONLY for
+                                                # grantee=party-service:marketing-comms (consent-opa-bundle.yaml's
+                                                # service-consent-m2m-marketing rule), a low-risk SCA-exempt marketing
+                                                # toggle (ADR-0205 D1). AUTHZ_FOUR_EYES_ENFORCE is false today for
+                                                # consent-service (consent-service.yaml has no override), so this M2M
+                                                # path is not currently blocked by the maker/checker pause — but if
+                                                # four-eyes enforcement is ever flipped on for this service, the
+                                                # party-service forwarder (no human in the loop) would stall on the
+                                                # missing second approver. Flag that rollout precondition before
+                                                # flipping AUTHZ_FOUR_EYES_ENFORCE here. consent.activate deliberately
+                                                # left ungated: its rego already reserves an M2M grant for a possible
+                                                # SCA-completion-callback caller.
       - openbank-fraud-service                # ADR-0084: v4 rule engine live; domestic-payment enforcement gate merged (issue #667, flag default-off pending risk-team threshold calibration)
                                                # four-eyes assessed (issue #938 follow-up): the only REST surface today is a stateless
                                                # POST /fraud/score (fraud.score) — no operator case-decision, rule-config, or manual

--- a/openbank-infra/gitops/components/notifications/notification-service.yaml
+++ b/openbank-infra/gitops/components/notifications/notification-service.yaml
@@ -39,7 +39,7 @@ spec:
       annotations:
         # Rolls the Deployment when the OPA policy bundle changes (subPath mounts don't
         # hot-reload). Kept in sync by gen-notification-opa-bundle.sh.
-        openbank.tech/policy-checksum: "4cbd1f661b104602"
+        openbank.tech/policy-checksum: "c30ed48a4b8b2831"
       labels:
         app.kubernetes.io/name: notification-service
         app.kubernetes.io/part-of: notifications

--- a/openbank-infra/gitops/components/party/party-opa-bundle.yaml
+++ b/openbank-infra/gitops/components/party/party-opa-bundle.yaml
@@ -9,7 +9,7 @@ metadata:
     app.kubernetes.io/name: party-service
     app.kubernetes.io/part-of: party
   annotations:
-    openbank.tech/policy-checksum: "fa99f83a76b0e8b0"
+    openbank.tech/policy-checksum: "24061622dd88c488"
 data:
   rest.rego: |
     # SPDX-License-Identifier: Apache-2.0
@@ -2010,10 +2010,20 @@ data:
                                                # confirmed M2M automated caller (customer-edge) — gating either would brick
                                                # production automation once enforcement is ever flipped on, not just close
                                                # the risky operator-console gap. See the four_eyes.verbs guardrail note below.
-      - openbank-consent-service               # four-eyes wired (issue #938 follow-up) on consent.grant/consent.revoke —
-                                                # both confirmed human-operator-only (no M2M caller). consent.activate
-                                                # deliberately left ungated: its rego already reserves an M2M grant for a
-                                                # possible SCA-completion-callback caller.
+      - openbank-consent-service               # four-eyes wired (issue #938 follow-up) on consent.grant/consent.revoke.
+                                                # UPDATED (ADR-0206): no longer exclusively human-operator — the shared
+                                                # M2M principal may now call both, but ONLY for
+                                                # grantee=party-service:marketing-comms (consent-opa-bundle.yaml's
+                                                # service-consent-m2m-marketing rule), a low-risk SCA-exempt marketing
+                                                # toggle (ADR-0205 D1). AUTHZ_FOUR_EYES_ENFORCE is false today for
+                                                # consent-service (consent-service.yaml has no override), so this M2M
+                                                # path is not currently blocked by the maker/checker pause — but if
+                                                # four-eyes enforcement is ever flipped on for this service, the
+                                                # party-service forwarder (no human in the loop) would stall on the
+                                                # missing second approver. Flag that rollout precondition before
+                                                # flipping AUTHZ_FOUR_EYES_ENFORCE here. consent.activate deliberately
+                                                # left ungated: its rego already reserves an M2M grant for a possible
+                                                # SCA-completion-callback caller.
       - openbank-fraud-service                # ADR-0084: v4 rule engine live; domestic-payment enforcement gate merged (issue #667, flag default-off pending risk-team threshold calibration)
                                                # four-eyes assessed (issue #938 follow-up): the only REST surface today is a stateless
                                                # POST /fraud/score (fraud.score) — no operator case-decision, rule-config, or manual

--- a/openbank-infra/gitops/components/party/party-service.yaml
+++ b/openbank-infra/gitops/components/party/party-service.yaml
@@ -22,7 +22,7 @@ spec:
       annotations:
         # Rolls the pod when the OPA bundle changes — subPath mounts do NOT hot-reload.
         # Kept in sync by gen-party-opa-bundle.sh (do not hand-edit).
-        openbank.tech/policy-checksum: "fa99f83a76b0e8b0"
+        openbank.tech/policy-checksum: "24061622dd88c488"
       labels:
         app.kubernetes.io/name: party-service
         app.kubernetes.io/part-of: party

--- a/openbank-infra/gitops/components/payments/card-issuance-opa-bundle.yaml
+++ b/openbank-infra/gitops/components/payments/card-issuance-opa-bundle.yaml
@@ -9,7 +9,7 @@ metadata:
     app.kubernetes.io/name: card-issuance-service
     app.kubernetes.io/part-of: payments
   annotations:
-    openbank.tech/policy-checksum: "1f164f1a167125de"
+    openbank.tech/policy-checksum: "29a44a535ee9e118"
 data:
   rest.rego: |
     # SPDX-License-Identifier: Apache-2.0
@@ -1994,10 +1994,20 @@ data:
                                                # confirmed M2M automated caller (customer-edge) — gating either would brick
                                                # production automation once enforcement is ever flipped on, not just close
                                                # the risky operator-console gap. See the four_eyes.verbs guardrail note below.
-      - openbank-consent-service               # four-eyes wired (issue #938 follow-up) on consent.grant/consent.revoke —
-                                                # both confirmed human-operator-only (no M2M caller). consent.activate
-                                                # deliberately left ungated: its rego already reserves an M2M grant for a
-                                                # possible SCA-completion-callback caller.
+      - openbank-consent-service               # four-eyes wired (issue #938 follow-up) on consent.grant/consent.revoke.
+                                                # UPDATED (ADR-0206): no longer exclusively human-operator — the shared
+                                                # M2M principal may now call both, but ONLY for
+                                                # grantee=party-service:marketing-comms (consent-opa-bundle.yaml's
+                                                # service-consent-m2m-marketing rule), a low-risk SCA-exempt marketing
+                                                # toggle (ADR-0205 D1). AUTHZ_FOUR_EYES_ENFORCE is false today for
+                                                # consent-service (consent-service.yaml has no override), so this M2M
+                                                # path is not currently blocked by the maker/checker pause — but if
+                                                # four-eyes enforcement is ever flipped on for this service, the
+                                                # party-service forwarder (no human in the loop) would stall on the
+                                                # missing second approver. Flag that rollout precondition before
+                                                # flipping AUTHZ_FOUR_EYES_ENFORCE here. consent.activate deliberately
+                                                # left ungated: its rego already reserves an M2M grant for a possible
+                                                # SCA-completion-callback caller.
       - openbank-fraud-service                # ADR-0084: v4 rule engine live; domestic-payment enforcement gate merged (issue #667, flag default-off pending risk-team threshold calibration)
                                                # four-eyes assessed (issue #938 follow-up): the only REST surface today is a stateless
                                                # POST /fraud/score (fraud.score) — no operator case-decision, rule-config, or manual

--- a/openbank-infra/gitops/components/payments/clearing-opa-bundle.yaml
+++ b/openbank-infra/gitops/components/payments/clearing-opa-bundle.yaml
@@ -9,7 +9,7 @@ metadata:
     app.kubernetes.io/name: clearing-service
     app.kubernetes.io/part-of: payments
   annotations:
-    openbank.tech/policy-checksum: "539ccbf7887678e4"
+    openbank.tech/policy-checksum: "e50b2409c7868501"
 data:
   rest.rego: |
     # SPDX-License-Identifier: Apache-2.0
@@ -2031,10 +2031,20 @@ data:
                                                # confirmed M2M automated caller (customer-edge) — gating either would brick
                                                # production automation once enforcement is ever flipped on, not just close
                                                # the risky operator-console gap. See the four_eyes.verbs guardrail note below.
-      - openbank-consent-service               # four-eyes wired (issue #938 follow-up) on consent.grant/consent.revoke —
-                                                # both confirmed human-operator-only (no M2M caller). consent.activate
-                                                # deliberately left ungated: its rego already reserves an M2M grant for a
-                                                # possible SCA-completion-callback caller.
+      - openbank-consent-service               # four-eyes wired (issue #938 follow-up) on consent.grant/consent.revoke.
+                                                # UPDATED (ADR-0206): no longer exclusively human-operator — the shared
+                                                # M2M principal may now call both, but ONLY for
+                                                # grantee=party-service:marketing-comms (consent-opa-bundle.yaml's
+                                                # service-consent-m2m-marketing rule), a low-risk SCA-exempt marketing
+                                                # toggle (ADR-0205 D1). AUTHZ_FOUR_EYES_ENFORCE is false today for
+                                                # consent-service (consent-service.yaml has no override), so this M2M
+                                                # path is not currently blocked by the maker/checker pause — but if
+                                                # four-eyes enforcement is ever flipped on for this service, the
+                                                # party-service forwarder (no human in the loop) would stall on the
+                                                # missing second approver. Flag that rollout precondition before
+                                                # flipping AUTHZ_FOUR_EYES_ENFORCE here. consent.activate deliberately
+                                                # left ungated: its rego already reserves an M2M grant for a possible
+                                                # SCA-completion-callback caller.
       - openbank-fraud-service                # ADR-0084: v4 rule engine live; domestic-payment enforcement gate merged (issue #667, flag default-off pending risk-team threshold calibration)
                                                # four-eyes assessed (issue #938 follow-up): the only REST surface today is a stateless
                                                # POST /fraud/score (fraud.score) — no operator case-decision, rule-config, or manual

--- a/openbank-infra/gitops/components/payments/domestic-payment-opa-bundle.yaml
+++ b/openbank-infra/gitops/components/payments/domestic-payment-opa-bundle.yaml
@@ -9,7 +9,7 @@ metadata:
     app.kubernetes.io/name: domestic-payment
     app.kubernetes.io/part-of: payments
   annotations:
-    openbank.tech/policy-checksum: "39ad10c438168a6e"
+    openbank.tech/policy-checksum: "f86ee5595fb4af21"
 data:
   rest.rego: |
     # SPDX-License-Identifier: Apache-2.0
@@ -2016,10 +2016,20 @@ data:
                                                # confirmed M2M automated caller (customer-edge) — gating either would brick
                                                # production automation once enforcement is ever flipped on, not just close
                                                # the risky operator-console gap. See the four_eyes.verbs guardrail note below.
-      - openbank-consent-service               # four-eyes wired (issue #938 follow-up) on consent.grant/consent.revoke —
-                                                # both confirmed human-operator-only (no M2M caller). consent.activate
-                                                # deliberately left ungated: its rego already reserves an M2M grant for a
-                                                # possible SCA-completion-callback caller.
+      - openbank-consent-service               # four-eyes wired (issue #938 follow-up) on consent.grant/consent.revoke.
+                                                # UPDATED (ADR-0206): no longer exclusively human-operator — the shared
+                                                # M2M principal may now call both, but ONLY for
+                                                # grantee=party-service:marketing-comms (consent-opa-bundle.yaml's
+                                                # service-consent-m2m-marketing rule), a low-risk SCA-exempt marketing
+                                                # toggle (ADR-0205 D1). AUTHZ_FOUR_EYES_ENFORCE is false today for
+                                                # consent-service (consent-service.yaml has no override), so this M2M
+                                                # path is not currently blocked by the maker/checker pause — but if
+                                                # four-eyes enforcement is ever flipped on for this service, the
+                                                # party-service forwarder (no human in the loop) would stall on the
+                                                # missing second approver. Flag that rollout precondition before
+                                                # flipping AUTHZ_FOUR_EYES_ENFORCE here. consent.activate deliberately
+                                                # left ungated: its rego already reserves an M2M grant for a possible
+                                                # SCA-completion-callback caller.
       - openbank-fraud-service                # ADR-0084: v4 rule engine live; domestic-payment enforcement gate merged (issue #667, flag default-off pending risk-team threshold calibration)
                                                # four-eyes assessed (issue #938 follow-up): the only REST surface today is a stateless
                                                # POST /fraud/score (fraud.score) — no operator case-decision, rule-config, or manual

--- a/openbank-infra/gitops/components/payments/payments-services.yaml
+++ b/openbank-infra/gitops/components/payments/payments-services.yaml
@@ -42,7 +42,7 @@ spec:
         # Rolls the pods when the OPA bundle changes — subPath mounts do NOT hot-reload.
         # Kept in sync by gen-transaction-opa-bundle.sh via the trailing marker comment
         # (do not hand-edit, do not drop the marker).
-        openbank.tech/policy-checksum: "27caa9537242c9ea" # transaction-opa-bundle
+        openbank.tech/policy-checksum: "554dfd7e418e7b2c" # transaction-opa-bundle
     spec:
       securityContext:
         runAsNonRoot: true
@@ -375,7 +375,7 @@ spec:
       annotations:
         # Rolls the pods when the OPA bundle changes — subPath mounts do NOT hot-reload.
         # Kept in sync by gen-sepa-payment-opa-bundle.sh (do not hand-edit).
-        openbank.tech/policy-checksum: "63875d5a61a0558e"
+        openbank.tech/policy-checksum: "378e754f4796cf5c"
     spec:
       securityContext:
         runAsNonRoot: true
@@ -729,7 +729,7 @@ spec:
         # Rolls the pods when the OPA bundle changes — subPath mounts do NOT hot-reload.
         # Kept in sync by gen-domestic-payment-opa-bundle.sh via the trailing marker
         # comment (do not hand-edit, do not drop the marker).
-        openbank.tech/policy-checksum: "39ad10c438168a6e" # domestic-payment-opa-bundle
+        openbank.tech/policy-checksum: "f86ee5595fb4af21" # domestic-payment-opa-bundle
     spec:
       securityContext:
         runAsNonRoot: true
@@ -1053,7 +1053,7 @@ spec:
       annotations:
         # Rolls the pods when the OPA bundle changes — subPath mounts do NOT hot-reload.
         # Kept in sync by gen-sepa-instant-opa-bundle.sh (do not hand-edit).
-        openbank.tech/policy-checksum: "b788c30c6ad8e5a2"
+        openbank.tech/policy-checksum: "8ea6424c9da913d9"
     spec:
       securityContext:
         runAsNonRoot: true
@@ -1369,7 +1369,7 @@ spec:
         # Rolls the pods when the OPA bundle changes — subPath mounts do NOT hot-reload.
         # Kept in sync by gen-clearing-opa-bundle.sh via the trailing marker comment
         # (do not hand-edit, do not drop the marker).
-        openbank.tech/policy-checksum: "539ccbf7887678e4" # clearing-opa-bundle
+        openbank.tech/policy-checksum: "e50b2409c7868501" # clearing-opa-bundle
     spec:
       securityContext:
         runAsNonRoot: true
@@ -1658,7 +1658,7 @@ spec:
       annotations:
         # Rolls the pod when the OPA bundle changes (ADR-0034). Value is stamped by
         # gen-standing-order-opa-bundle.sh — do not hand-edit.
-        openbank.tech/policy-checksum: "94dd39d43bf16b32" # standing-order-opa-bundle
+        openbank.tech/policy-checksum: "2d5c88a185d1733f" # standing-order-opa-bundle
     spec:
       securityContext:
         runAsNonRoot: true
@@ -1911,7 +1911,7 @@ spec:
       annotations:
         # Rolls the pods when the OPA bundle changes — subPath mounts do NOT hot-reload.
         # Kept in sync by gen-card-issuance-opa-bundle.sh (do not hand-edit).
-        openbank.tech/policy-checksum: "1f164f1a167125de"
+        openbank.tech/policy-checksum: "29a44a535ee9e118"
     spec:
       securityContext:
         runAsNonRoot: true
@@ -2178,7 +2178,7 @@ spec:
         # Rolls the pods when the OPA bundle changes — subPath mounts do NOT hot-reload.
         # Kept in sync by gen-settlement-opa-bundle.sh via the trailing marker comment
         # (do not hand-edit, do not drop the marker).
-        openbank.tech/policy-checksum: "21f6ddfae9969c51" # settlement-opa-bundle
+        openbank.tech/policy-checksum: "0529d2c36d591611" # settlement-opa-bundle
     spec:
       securityContext:
         runAsNonRoot: true
@@ -2579,7 +2579,7 @@ spec:
       annotations:
         # Rolls the pods when the OPA bundle changes — subPath mounts do NOT hot-reload.
         # Kept in sync by gen-swift-opa-bundle.sh (do not hand-edit).
-        openbank.tech/policy-checksum: "9c22148d1f051fe9"
+        openbank.tech/policy-checksum: "ea1bc63d4f34e5aa"
     spec:
       securityContext:
         runAsNonRoot: true
@@ -2893,7 +2893,7 @@ spec:
       annotations:
         # Rolls the pods when the OPA bundle changes — subPath mounts do NOT hot-reload.
         # Kept in sync by gen-vop-opa-bundle.sh (do not hand-edit).
-        openbank.tech/policy-checksum: "c3a57481beb12064"
+        openbank.tech/policy-checksum: "06c74fbe07dd77f8"
     spec:
       securityContext:
         runAsNonRoot: true

--- a/openbank-infra/gitops/components/payments/sepa-instant-opa-bundle.yaml
+++ b/openbank-infra/gitops/components/payments/sepa-instant-opa-bundle.yaml
@@ -9,7 +9,7 @@ metadata:
     app.kubernetes.io/name: sepa-instant
     app.kubernetes.io/part-of: payments
   annotations:
-    openbank.tech/policy-checksum: "b788c30c6ad8e5a2"
+    openbank.tech/policy-checksum: "8ea6424c9da913d9"
 data:
   rest.rego: |
     # SPDX-License-Identifier: Apache-2.0
@@ -1989,10 +1989,20 @@ data:
                                                # confirmed M2M automated caller (customer-edge) — gating either would brick
                                                # production automation once enforcement is ever flipped on, not just close
                                                # the risky operator-console gap. See the four_eyes.verbs guardrail note below.
-      - openbank-consent-service               # four-eyes wired (issue #938 follow-up) on consent.grant/consent.revoke —
-                                                # both confirmed human-operator-only (no M2M caller). consent.activate
-                                                # deliberately left ungated: its rego already reserves an M2M grant for a
-                                                # possible SCA-completion-callback caller.
+      - openbank-consent-service               # four-eyes wired (issue #938 follow-up) on consent.grant/consent.revoke.
+                                                # UPDATED (ADR-0206): no longer exclusively human-operator — the shared
+                                                # M2M principal may now call both, but ONLY for
+                                                # grantee=party-service:marketing-comms (consent-opa-bundle.yaml's
+                                                # service-consent-m2m-marketing rule), a low-risk SCA-exempt marketing
+                                                # toggle (ADR-0205 D1). AUTHZ_FOUR_EYES_ENFORCE is false today for
+                                                # consent-service (consent-service.yaml has no override), so this M2M
+                                                # path is not currently blocked by the maker/checker pause — but if
+                                                # four-eyes enforcement is ever flipped on for this service, the
+                                                # party-service forwarder (no human in the loop) would stall on the
+                                                # missing second approver. Flag that rollout precondition before
+                                                # flipping AUTHZ_FOUR_EYES_ENFORCE here. consent.activate deliberately
+                                                # left ungated: its rego already reserves an M2M grant for a possible
+                                                # SCA-completion-callback caller.
       - openbank-fraud-service                # ADR-0084: v4 rule engine live; domestic-payment enforcement gate merged (issue #667, flag default-off pending risk-team threshold calibration)
                                                # four-eyes assessed (issue #938 follow-up): the only REST surface today is a stateless
                                                # POST /fraud/score (fraud.score) — no operator case-decision, rule-config, or manual

--- a/openbank-infra/gitops/components/payments/sepa-payment-opa-bundle.yaml
+++ b/openbank-infra/gitops/components/payments/sepa-payment-opa-bundle.yaml
@@ -9,7 +9,7 @@ metadata:
     app.kubernetes.io/name: sepa-payment
     app.kubernetes.io/part-of: payments
   annotations:
-    openbank.tech/policy-checksum: "63875d5a61a0558e"
+    openbank.tech/policy-checksum: "378e754f4796cf5c"
 data:
   rest.rego: |
     # SPDX-License-Identifier: Apache-2.0
@@ -2010,10 +2010,20 @@ data:
                                                # confirmed M2M automated caller (customer-edge) — gating either would brick
                                                # production automation once enforcement is ever flipped on, not just close
                                                # the risky operator-console gap. See the four_eyes.verbs guardrail note below.
-      - openbank-consent-service               # four-eyes wired (issue #938 follow-up) on consent.grant/consent.revoke —
-                                                # both confirmed human-operator-only (no M2M caller). consent.activate
-                                                # deliberately left ungated: its rego already reserves an M2M grant for a
-                                                # possible SCA-completion-callback caller.
+      - openbank-consent-service               # four-eyes wired (issue #938 follow-up) on consent.grant/consent.revoke.
+                                                # UPDATED (ADR-0206): no longer exclusively human-operator — the shared
+                                                # M2M principal may now call both, but ONLY for
+                                                # grantee=party-service:marketing-comms (consent-opa-bundle.yaml's
+                                                # service-consent-m2m-marketing rule), a low-risk SCA-exempt marketing
+                                                # toggle (ADR-0205 D1). AUTHZ_FOUR_EYES_ENFORCE is false today for
+                                                # consent-service (consent-service.yaml has no override), so this M2M
+                                                # path is not currently blocked by the maker/checker pause — but if
+                                                # four-eyes enforcement is ever flipped on for this service, the
+                                                # party-service forwarder (no human in the loop) would stall on the
+                                                # missing second approver. Flag that rollout precondition before
+                                                # flipping AUTHZ_FOUR_EYES_ENFORCE here. consent.activate deliberately
+                                                # left ungated: its rego already reserves an M2M grant for a possible
+                                                # SCA-completion-callback caller.
       - openbank-fraud-service                # ADR-0084: v4 rule engine live; domestic-payment enforcement gate merged (issue #667, flag default-off pending risk-team threshold calibration)
                                                # four-eyes assessed (issue #938 follow-up): the only REST surface today is a stateless
                                                # POST /fraud/score (fraud.score) — no operator case-decision, rule-config, or manual

--- a/openbank-infra/gitops/components/payments/settlement-opa-bundle.yaml
+++ b/openbank-infra/gitops/components/payments/settlement-opa-bundle.yaml
@@ -9,7 +9,7 @@ metadata:
     app.kubernetes.io/name: settlement-service
     app.kubernetes.io/part-of: payments
   annotations:
-    openbank.tech/policy-checksum: "21f6ddfae9969c51"
+    openbank.tech/policy-checksum: "0529d2c36d591611"
 data:
   rest.rego: |
     # SPDX-License-Identifier: Apache-2.0
@@ -1990,10 +1990,20 @@ data:
                                                # confirmed M2M automated caller (customer-edge) — gating either would brick
                                                # production automation once enforcement is ever flipped on, not just close
                                                # the risky operator-console gap. See the four_eyes.verbs guardrail note below.
-      - openbank-consent-service               # four-eyes wired (issue #938 follow-up) on consent.grant/consent.revoke —
-                                                # both confirmed human-operator-only (no M2M caller). consent.activate
-                                                # deliberately left ungated: its rego already reserves an M2M grant for a
-                                                # possible SCA-completion-callback caller.
+      - openbank-consent-service               # four-eyes wired (issue #938 follow-up) on consent.grant/consent.revoke.
+                                                # UPDATED (ADR-0206): no longer exclusively human-operator — the shared
+                                                # M2M principal may now call both, but ONLY for
+                                                # grantee=party-service:marketing-comms (consent-opa-bundle.yaml's
+                                                # service-consent-m2m-marketing rule), a low-risk SCA-exempt marketing
+                                                # toggle (ADR-0205 D1). AUTHZ_FOUR_EYES_ENFORCE is false today for
+                                                # consent-service (consent-service.yaml has no override), so this M2M
+                                                # path is not currently blocked by the maker/checker pause — but if
+                                                # four-eyes enforcement is ever flipped on for this service, the
+                                                # party-service forwarder (no human in the loop) would stall on the
+                                                # missing second approver. Flag that rollout precondition before
+                                                # flipping AUTHZ_FOUR_EYES_ENFORCE here. consent.activate deliberately
+                                                # left ungated: its rego already reserves an M2M grant for a possible
+                                                # SCA-completion-callback caller.
       - openbank-fraud-service                # ADR-0084: v4 rule engine live; domestic-payment enforcement gate merged (issue #667, flag default-off pending risk-team threshold calibration)
                                                # four-eyes assessed (issue #938 follow-up): the only REST surface today is a stateless
                                                # POST /fraud/score (fraud.score) — no operator case-decision, rule-config, or manual

--- a/openbank-infra/gitops/components/payments/standing-order-opa-bundle.yaml
+++ b/openbank-infra/gitops/components/payments/standing-order-opa-bundle.yaml
@@ -9,7 +9,7 @@ metadata:
     app.kubernetes.io/name: standing-order-service
     app.kubernetes.io/part-of: payments
   annotations:
-    openbank.tech/policy-checksum: "94dd39d43bf16b32"
+    openbank.tech/policy-checksum: "2d5c88a185d1733f"
 data:
   rest.rego: |
     # SPDX-License-Identifier: Apache-2.0
@@ -1975,10 +1975,20 @@ data:
                                                # confirmed M2M automated caller (customer-edge) — gating either would brick
                                                # production automation once enforcement is ever flipped on, not just close
                                                # the risky operator-console gap. See the four_eyes.verbs guardrail note below.
-      - openbank-consent-service               # four-eyes wired (issue #938 follow-up) on consent.grant/consent.revoke —
-                                                # both confirmed human-operator-only (no M2M caller). consent.activate
-                                                # deliberately left ungated: its rego already reserves an M2M grant for a
-                                                # possible SCA-completion-callback caller.
+      - openbank-consent-service               # four-eyes wired (issue #938 follow-up) on consent.grant/consent.revoke.
+                                                # UPDATED (ADR-0206): no longer exclusively human-operator — the shared
+                                                # M2M principal may now call both, but ONLY for
+                                                # grantee=party-service:marketing-comms (consent-opa-bundle.yaml's
+                                                # service-consent-m2m-marketing rule), a low-risk SCA-exempt marketing
+                                                # toggle (ADR-0205 D1). AUTHZ_FOUR_EYES_ENFORCE is false today for
+                                                # consent-service (consent-service.yaml has no override), so this M2M
+                                                # path is not currently blocked by the maker/checker pause — but if
+                                                # four-eyes enforcement is ever flipped on for this service, the
+                                                # party-service forwarder (no human in the loop) would stall on the
+                                                # missing second approver. Flag that rollout precondition before
+                                                # flipping AUTHZ_FOUR_EYES_ENFORCE here. consent.activate deliberately
+                                                # left ungated: its rego already reserves an M2M grant for a possible
+                                                # SCA-completion-callback caller.
       - openbank-fraud-service                # ADR-0084: v4 rule engine live; domestic-payment enforcement gate merged (issue #667, flag default-off pending risk-team threshold calibration)
                                                # four-eyes assessed (issue #938 follow-up): the only REST surface today is a stateless
                                                # POST /fraud/score (fraud.score) — no operator case-decision, rule-config, or manual

--- a/openbank-infra/gitops/components/payments/swift-opa-bundle.yaml
+++ b/openbank-infra/gitops/components/payments/swift-opa-bundle.yaml
@@ -9,7 +9,7 @@ metadata:
     app.kubernetes.io/name: swift-service
     app.kubernetes.io/part-of: payments
   annotations:
-    openbank.tech/policy-checksum: "9c22148d1f051fe9"
+    openbank.tech/policy-checksum: "ea1bc63d4f34e5aa"
 data:
   rest.rego: |
     # SPDX-License-Identifier: Apache-2.0
@@ -1993,10 +1993,20 @@ data:
                                                # confirmed M2M automated caller (customer-edge) — gating either would brick
                                                # production automation once enforcement is ever flipped on, not just close
                                                # the risky operator-console gap. See the four_eyes.verbs guardrail note below.
-      - openbank-consent-service               # four-eyes wired (issue #938 follow-up) on consent.grant/consent.revoke —
-                                                # both confirmed human-operator-only (no M2M caller). consent.activate
-                                                # deliberately left ungated: its rego already reserves an M2M grant for a
-                                                # possible SCA-completion-callback caller.
+      - openbank-consent-service               # four-eyes wired (issue #938 follow-up) on consent.grant/consent.revoke.
+                                                # UPDATED (ADR-0206): no longer exclusively human-operator — the shared
+                                                # M2M principal may now call both, but ONLY for
+                                                # grantee=party-service:marketing-comms (consent-opa-bundle.yaml's
+                                                # service-consent-m2m-marketing rule), a low-risk SCA-exempt marketing
+                                                # toggle (ADR-0205 D1). AUTHZ_FOUR_EYES_ENFORCE is false today for
+                                                # consent-service (consent-service.yaml has no override), so this M2M
+                                                # path is not currently blocked by the maker/checker pause — but if
+                                                # four-eyes enforcement is ever flipped on for this service, the
+                                                # party-service forwarder (no human in the loop) would stall on the
+                                                # missing second approver. Flag that rollout precondition before
+                                                # flipping AUTHZ_FOUR_EYES_ENFORCE here. consent.activate deliberately
+                                                # left ungated: its rego already reserves an M2M grant for a possible
+                                                # SCA-completion-callback caller.
       - openbank-fraud-service                # ADR-0084: v4 rule engine live; domestic-payment enforcement gate merged (issue #667, flag default-off pending risk-team threshold calibration)
                                                # four-eyes assessed (issue #938 follow-up): the only REST surface today is a stateless
                                                # POST /fraud/score (fraud.score) — no operator case-decision, rule-config, or manual

--- a/openbank-infra/gitops/components/payments/transaction-opa-bundle.yaml
+++ b/openbank-infra/gitops/components/payments/transaction-opa-bundle.yaml
@@ -9,7 +9,7 @@ metadata:
     app.kubernetes.io/name: transaction-service
     app.kubernetes.io/part-of: payments
   annotations:
-    openbank.tech/policy-checksum: "27caa9537242c9ea"
+    openbank.tech/policy-checksum: "554dfd7e418e7b2c"
 data:
   rest.rego: |
     # SPDX-License-Identifier: Apache-2.0
@@ -2046,10 +2046,20 @@ data:
                                                # confirmed M2M automated caller (customer-edge) — gating either would brick
                                                # production automation once enforcement is ever flipped on, not just close
                                                # the risky operator-console gap. See the four_eyes.verbs guardrail note below.
-      - openbank-consent-service               # four-eyes wired (issue #938 follow-up) on consent.grant/consent.revoke —
-                                                # both confirmed human-operator-only (no M2M caller). consent.activate
-                                                # deliberately left ungated: its rego already reserves an M2M grant for a
-                                                # possible SCA-completion-callback caller.
+      - openbank-consent-service               # four-eyes wired (issue #938 follow-up) on consent.grant/consent.revoke.
+                                                # UPDATED (ADR-0206): no longer exclusively human-operator — the shared
+                                                # M2M principal may now call both, but ONLY for
+                                                # grantee=party-service:marketing-comms (consent-opa-bundle.yaml's
+                                                # service-consent-m2m-marketing rule), a low-risk SCA-exempt marketing
+                                                # toggle (ADR-0205 D1). AUTHZ_FOUR_EYES_ENFORCE is false today for
+                                                # consent-service (consent-service.yaml has no override), so this M2M
+                                                # path is not currently blocked by the maker/checker pause — but if
+                                                # four-eyes enforcement is ever flipped on for this service, the
+                                                # party-service forwarder (no human in the loop) would stall on the
+                                                # missing second approver. Flag that rollout precondition before
+                                                # flipping AUTHZ_FOUR_EYES_ENFORCE here. consent.activate deliberately
+                                                # left ungated: its rego already reserves an M2M grant for a possible
+                                                # SCA-completion-callback caller.
       - openbank-fraud-service                # ADR-0084: v4 rule engine live; domestic-payment enforcement gate merged (issue #667, flag default-off pending risk-team threshold calibration)
                                                # four-eyes assessed (issue #938 follow-up): the only REST surface today is a stateless
                                                # POST /fraud/score (fraud.score) — no operator case-decision, rule-config, or manual

--- a/openbank-infra/gitops/components/payments/vop-opa-bundle.yaml
+++ b/openbank-infra/gitops/components/payments/vop-opa-bundle.yaml
@@ -9,7 +9,7 @@ metadata:
     app.kubernetes.io/name: vop-service
     app.kubernetes.io/part-of: payments
   annotations:
-    openbank.tech/policy-checksum: "c3a57481beb12064"
+    openbank.tech/policy-checksum: "06c74fbe07dd77f8"
 data:
   rest.rego: |
     # SPDX-License-Identifier: Apache-2.0
@@ -1997,10 +1997,20 @@ data:
                                                # confirmed M2M automated caller (customer-edge) — gating either would brick
                                                # production automation once enforcement is ever flipped on, not just close
                                                # the risky operator-console gap. See the four_eyes.verbs guardrail note below.
-      - openbank-consent-service               # four-eyes wired (issue #938 follow-up) on consent.grant/consent.revoke —
-                                                # both confirmed human-operator-only (no M2M caller). consent.activate
-                                                # deliberately left ungated: its rego already reserves an M2M grant for a
-                                                # possible SCA-completion-callback caller.
+      - openbank-consent-service               # four-eyes wired (issue #938 follow-up) on consent.grant/consent.revoke.
+                                                # UPDATED (ADR-0206): no longer exclusively human-operator — the shared
+                                                # M2M principal may now call both, but ONLY for
+                                                # grantee=party-service:marketing-comms (consent-opa-bundle.yaml's
+                                                # service-consent-m2m-marketing rule), a low-risk SCA-exempt marketing
+                                                # toggle (ADR-0205 D1). AUTHZ_FOUR_EYES_ENFORCE is false today for
+                                                # consent-service (consent-service.yaml has no override), so this M2M
+                                                # path is not currently blocked by the maker/checker pause — but if
+                                                # four-eyes enforcement is ever flipped on for this service, the
+                                                # party-service forwarder (no human in the loop) would stall on the
+                                                # missing second approver. Flag that rollout precondition before
+                                                # flipping AUTHZ_FOUR_EYES_ENFORCE here. consent.activate deliberately
+                                                # left ungated: its rego already reserves an M2M grant for a possible
+                                                # SCA-completion-callback caller.
       - openbank-fraud-service                # ADR-0084: v4 rule engine live; domestic-payment enforcement gate merged (issue #667, flag default-off pending risk-team threshold calibration)
                                                # four-eyes assessed (issue #938 follow-up): the only REST surface today is a stateless
                                                # POST /fraud/score (fraud.score) — no operator case-decision, rule-config, or manual

--- a/openbank-infra/gitops/components/pid/pid-opa-bundle.yaml
+++ b/openbank-infra/gitops/components/pid/pid-opa-bundle.yaml
@@ -9,7 +9,7 @@ metadata:
     app.kubernetes.io/name: pid-service
     app.kubernetes.io/part-of: pid
   annotations:
-    openbank.tech/policy-checksum: "b4314506120822c3"
+    openbank.tech/policy-checksum: "6bad7377703fb5c3"
 data:
   rest.rego: |
     # SPDX-License-Identifier: Apache-2.0
@@ -1999,10 +1999,20 @@ data:
                                                # confirmed M2M automated caller (customer-edge) — gating either would brick
                                                # production automation once enforcement is ever flipped on, not just close
                                                # the risky operator-console gap. See the four_eyes.verbs guardrail note below.
-      - openbank-consent-service               # four-eyes wired (issue #938 follow-up) on consent.grant/consent.revoke —
-                                                # both confirmed human-operator-only (no M2M caller). consent.activate
-                                                # deliberately left ungated: its rego already reserves an M2M grant for a
-                                                # possible SCA-completion-callback caller.
+      - openbank-consent-service               # four-eyes wired (issue #938 follow-up) on consent.grant/consent.revoke.
+                                                # UPDATED (ADR-0206): no longer exclusively human-operator — the shared
+                                                # M2M principal may now call both, but ONLY for
+                                                # grantee=party-service:marketing-comms (consent-opa-bundle.yaml's
+                                                # service-consent-m2m-marketing rule), a low-risk SCA-exempt marketing
+                                                # toggle (ADR-0205 D1). AUTHZ_FOUR_EYES_ENFORCE is false today for
+                                                # consent-service (consent-service.yaml has no override), so this M2M
+                                                # path is not currently blocked by the maker/checker pause — but if
+                                                # four-eyes enforcement is ever flipped on for this service, the
+                                                # party-service forwarder (no human in the loop) would stall on the
+                                                # missing second approver. Flag that rollout precondition before
+                                                # flipping AUTHZ_FOUR_EYES_ENFORCE here. consent.activate deliberately
+                                                # left ungated: its rego already reserves an M2M grant for a possible
+                                                # SCA-completion-callback caller.
       - openbank-fraud-service                # ADR-0084: v4 rule engine live; domestic-payment enforcement gate merged (issue #667, flag default-off pending risk-team threshold calibration)
                                                # four-eyes assessed (issue #938 follow-up): the only REST surface today is a stateless
                                                # POST /fraud/score (fraud.score) — no operator case-decision, rule-config, or manual

--- a/openbank-infra/gitops/components/pid/pid-service.yaml
+++ b/openbank-infra/gitops/components/pid/pid-service.yaml
@@ -22,7 +22,7 @@ spec:
       annotations:
         # Rolls the pod when the OPA bundle changes — subPath mounts do NOT hot-reload.
         # Kept in sync by gen-pid-opa-bundle.sh (do not hand-edit).
-        openbank.tech/policy-checksum: "b4314506120822c3"
+        openbank.tech/policy-checksum: "6bad7377703fb5c3"
     spec:
       securityContext:
         runAsNonRoot: true

--- a/openbank-infra/gitops/components/psd2-service/psd2-opa-bundle.yaml
+++ b/openbank-infra/gitops/components/psd2-service/psd2-opa-bundle.yaml
@@ -9,7 +9,7 @@ metadata:
     app.kubernetes.io/name: psd2-service
     app.kubernetes.io/part-of: psd2
   annotations:
-    openbank.tech/policy-checksum: "1c9a00ab875d5ce4"
+    openbank.tech/policy-checksum: "7e2013d2c9a946f4"
 data:
   rest.rego: |
     # SPDX-License-Identifier: Apache-2.0
@@ -2072,10 +2072,20 @@ data:
                                                # confirmed M2M automated caller (customer-edge) — gating either would brick
                                                # production automation once enforcement is ever flipped on, not just close
                                                # the risky operator-console gap. See the four_eyes.verbs guardrail note below.
-      - openbank-consent-service               # four-eyes wired (issue #938 follow-up) on consent.grant/consent.revoke —
-                                                # both confirmed human-operator-only (no M2M caller). consent.activate
-                                                # deliberately left ungated: its rego already reserves an M2M grant for a
-                                                # possible SCA-completion-callback caller.
+      - openbank-consent-service               # four-eyes wired (issue #938 follow-up) on consent.grant/consent.revoke.
+                                                # UPDATED (ADR-0206): no longer exclusively human-operator — the shared
+                                                # M2M principal may now call both, but ONLY for
+                                                # grantee=party-service:marketing-comms (consent-opa-bundle.yaml's
+                                                # service-consent-m2m-marketing rule), a low-risk SCA-exempt marketing
+                                                # toggle (ADR-0205 D1). AUTHZ_FOUR_EYES_ENFORCE is false today for
+                                                # consent-service (consent-service.yaml has no override), so this M2M
+                                                # path is not currently blocked by the maker/checker pause — but if
+                                                # four-eyes enforcement is ever flipped on for this service, the
+                                                # party-service forwarder (no human in the loop) would stall on the
+                                                # missing second approver. Flag that rollout precondition before
+                                                # flipping AUTHZ_FOUR_EYES_ENFORCE here. consent.activate deliberately
+                                                # left ungated: its rego already reserves an M2M grant for a possible
+                                                # SCA-completion-callback caller.
       - openbank-fraud-service                # ADR-0084: v4 rule engine live; domestic-payment enforcement gate merged (issue #667, flag default-off pending risk-team threshold calibration)
                                                # four-eyes assessed (issue #938 follow-up): the only REST surface today is a stateless
                                                # POST /fraud/score (fraud.score) — no operator case-decision, rule-config, or manual

--- a/openbank-infra/gitops/components/psd2-service/psd2-service.yaml
+++ b/openbank-infra/gitops/components/psd2-service/psd2-service.yaml
@@ -18,7 +18,7 @@ spec:
       annotations:
         # Rolls the pod when the OPA bundle changes — subPath mounts do NOT hot-reload.
         # Kept in sync by gen-psd2-opa-bundle.sh (do not hand-edit).
-        openbank.tech/policy-checksum: "1c9a00ab875d5ce4"
+        openbank.tech/policy-checksum: "7e2013d2c9a946f4"
       labels: {app.kubernetes.io/name: psd2-service, app.kubernetes.io/part-of: psd2}
     spec:
       securityContext:

--- a/openbank-infra/gitops/components/sanctions-service/sanctions-opa-bundle.yaml
+++ b/openbank-infra/gitops/components/sanctions-service/sanctions-opa-bundle.yaml
@@ -9,7 +9,7 @@ metadata:
     app.kubernetes.io/name: sanctions-service
     app.kubernetes.io/part-of: sanctions
   annotations:
-    openbank.tech/policy-checksum: "80b6f5bccb19973b"
+    openbank.tech/policy-checksum: "95a245a7331440fe"
 data:
   rest.rego: |
     # SPDX-License-Identifier: Apache-2.0
@@ -1977,10 +1977,20 @@ data:
                                                # confirmed M2M automated caller (customer-edge) — gating either would brick
                                                # production automation once enforcement is ever flipped on, not just close
                                                # the risky operator-console gap. See the four_eyes.verbs guardrail note below.
-      - openbank-consent-service               # four-eyes wired (issue #938 follow-up) on consent.grant/consent.revoke —
-                                                # both confirmed human-operator-only (no M2M caller). consent.activate
-                                                # deliberately left ungated: its rego already reserves an M2M grant for a
-                                                # possible SCA-completion-callback caller.
+      - openbank-consent-service               # four-eyes wired (issue #938 follow-up) on consent.grant/consent.revoke.
+                                                # UPDATED (ADR-0206): no longer exclusively human-operator — the shared
+                                                # M2M principal may now call both, but ONLY for
+                                                # grantee=party-service:marketing-comms (consent-opa-bundle.yaml's
+                                                # service-consent-m2m-marketing rule), a low-risk SCA-exempt marketing
+                                                # toggle (ADR-0205 D1). AUTHZ_FOUR_EYES_ENFORCE is false today for
+                                                # consent-service (consent-service.yaml has no override), so this M2M
+                                                # path is not currently blocked by the maker/checker pause — but if
+                                                # four-eyes enforcement is ever flipped on for this service, the
+                                                # party-service forwarder (no human in the loop) would stall on the
+                                                # missing second approver. Flag that rollout precondition before
+                                                # flipping AUTHZ_FOUR_EYES_ENFORCE here. consent.activate deliberately
+                                                # left ungated: its rego already reserves an M2M grant for a possible
+                                                # SCA-completion-callback caller.
       - openbank-fraud-service                # ADR-0084: v4 rule engine live; domestic-payment enforcement gate merged (issue #667, flag default-off pending risk-team threshold calibration)
                                                # four-eyes assessed (issue #938 follow-up): the only REST surface today is a stateless
                                                # POST /fraud/score (fraud.score) — no operator case-decision, rule-config, or manual

--- a/openbank-infra/gitops/components/sanctions-service/sanctions-service.yaml
+++ b/openbank-infra/gitops/components/sanctions-service/sanctions-service.yaml
@@ -49,7 +49,7 @@ spec:
       annotations:
         # Rolls the pods when the OPA bundle changes — subPath mounts do NOT hot-reload.
         # Kept in sync by gen-sanctions-opa-bundle.sh (do not hand-edit).
-        openbank.tech/policy-checksum: "80b6f5bccb19973b"
+        openbank.tech/policy-checksum: "95a245a7331440fe"
     spec:
       securityContext:
         runAsNonRoot: true

--- a/openbank-infra/gitops/components/sca/sca-opa-bundle.yaml
+++ b/openbank-infra/gitops/components/sca/sca-opa-bundle.yaml
@@ -9,7 +9,7 @@ metadata:
     app.kubernetes.io/name: sca-service
     app.kubernetes.io/part-of: sca
   annotations:
-    openbank.tech/policy-checksum: "950dbc4fc12aab3d"
+    openbank.tech/policy-checksum: "050d04dfcb36854c"
 data:
   rest.rego: |
     # SPDX-License-Identifier: Apache-2.0
@@ -2013,10 +2013,20 @@ data:
                                                # confirmed M2M automated caller (customer-edge) — gating either would brick
                                                # production automation once enforcement is ever flipped on, not just close
                                                # the risky operator-console gap. See the four_eyes.verbs guardrail note below.
-      - openbank-consent-service               # four-eyes wired (issue #938 follow-up) on consent.grant/consent.revoke —
-                                                # both confirmed human-operator-only (no M2M caller). consent.activate
-                                                # deliberately left ungated: its rego already reserves an M2M grant for a
-                                                # possible SCA-completion-callback caller.
+      - openbank-consent-service               # four-eyes wired (issue #938 follow-up) on consent.grant/consent.revoke.
+                                                # UPDATED (ADR-0206): no longer exclusively human-operator — the shared
+                                                # M2M principal may now call both, but ONLY for
+                                                # grantee=party-service:marketing-comms (consent-opa-bundle.yaml's
+                                                # service-consent-m2m-marketing rule), a low-risk SCA-exempt marketing
+                                                # toggle (ADR-0205 D1). AUTHZ_FOUR_EYES_ENFORCE is false today for
+                                                # consent-service (consent-service.yaml has no override), so this M2M
+                                                # path is not currently blocked by the maker/checker pause — but if
+                                                # four-eyes enforcement is ever flipped on for this service, the
+                                                # party-service forwarder (no human in the loop) would stall on the
+                                                # missing second approver. Flag that rollout precondition before
+                                                # flipping AUTHZ_FOUR_EYES_ENFORCE here. consent.activate deliberately
+                                                # left ungated: its rego already reserves an M2M grant for a possible
+                                                # SCA-completion-callback caller.
       - openbank-fraud-service                # ADR-0084: v4 rule engine live; domestic-payment enforcement gate merged (issue #667, flag default-off pending risk-team threshold calibration)
                                                # four-eyes assessed (issue #938 follow-up): the only REST surface today is a stateless
                                                # POST /fraud/score (fraud.score) — no operator case-decision, rule-config, or manual

--- a/openbank-infra/gitops/components/sca/sca-service.yaml
+++ b/openbank-infra/gitops/components/sca/sca-service.yaml
@@ -28,7 +28,7 @@ spec:
       annotations:
         # Rolls the pods when the OPA bundle changes — subPath mounts do NOT hot-reload.
         # Kept in sync by gen-sca-opa-bundle.sh (do not hand-edit).
-        openbank.tech/policy-checksum: "950dbc4fc12aab3d"
+        openbank.tech/policy-checksum: "050d04dfcb36854c"
     spec:
       securityContext:
         runAsNonRoot: true

--- a/openbank-infra/gitops/components/statements/statement-opa-bundle.yaml
+++ b/openbank-infra/gitops/components/statements/statement-opa-bundle.yaml
@@ -9,7 +9,7 @@ metadata:
     app.kubernetes.io/name: statement-service
     app.kubernetes.io/part-of: statements
   annotations:
-    openbank.tech/policy-checksum: "0892762fbf0b46ec"
+    openbank.tech/policy-checksum: "f87ab950b3ddbf64"
 data:
   rest.rego: |
     # SPDX-License-Identifier: Apache-2.0
@@ -2043,10 +2043,20 @@ data:
                                                # confirmed M2M automated caller (customer-edge) — gating either would brick
                                                # production automation once enforcement is ever flipped on, not just close
                                                # the risky operator-console gap. See the four_eyes.verbs guardrail note below.
-      - openbank-consent-service               # four-eyes wired (issue #938 follow-up) on consent.grant/consent.revoke —
-                                                # both confirmed human-operator-only (no M2M caller). consent.activate
-                                                # deliberately left ungated: its rego already reserves an M2M grant for a
-                                                # possible SCA-completion-callback caller.
+      - openbank-consent-service               # four-eyes wired (issue #938 follow-up) on consent.grant/consent.revoke.
+                                                # UPDATED (ADR-0206): no longer exclusively human-operator — the shared
+                                                # M2M principal may now call both, but ONLY for
+                                                # grantee=party-service:marketing-comms (consent-opa-bundle.yaml's
+                                                # service-consent-m2m-marketing rule), a low-risk SCA-exempt marketing
+                                                # toggle (ADR-0205 D1). AUTHZ_FOUR_EYES_ENFORCE is false today for
+                                                # consent-service (consent-service.yaml has no override), so this M2M
+                                                # path is not currently blocked by the maker/checker pause — but if
+                                                # four-eyes enforcement is ever flipped on for this service, the
+                                                # party-service forwarder (no human in the loop) would stall on the
+                                                # missing second approver. Flag that rollout precondition before
+                                                # flipping AUTHZ_FOUR_EYES_ENFORCE here. consent.activate deliberately
+                                                # left ungated: its rego already reserves an M2M grant for a possible
+                                                # SCA-completion-callback caller.
       - openbank-fraud-service                # ADR-0084: v4 rule engine live; domestic-payment enforcement gate merged (issue #667, flag default-off pending risk-team threshold calibration)
                                                # four-eyes assessed (issue #938 follow-up): the only REST surface today is a stateless
                                                # POST /fraud/score (fraud.score) — no operator case-decision, rule-config, or manual

--- a/openbank-infra/gitops/components/statements/statement-service.yaml
+++ b/openbank-infra/gitops/components/statements/statement-service.yaml
@@ -26,7 +26,7 @@ spec:
       annotations:
         # Rolls the pod when the OPA bundle changes — subPath mounts do NOT hot-reload.
         # Kept in sync by gen-statement-opa-bundle.sh (do not hand-edit).
-        openbank.tech/policy-checksum: "0892762fbf0b46ec"
+        openbank.tech/policy-checksum: "f87ab950b3ddbf64"
       labels:
         app.kubernetes.io/name: statement-service
         app.kubernetes.io/part-of: statements

--- a/openbank-infra/gitops/components/tpp-registry/tpp-registry-opa-bundle.yaml
+++ b/openbank-infra/gitops/components/tpp-registry/tpp-registry-opa-bundle.yaml
@@ -9,7 +9,7 @@ metadata:
     app.kubernetes.io/name: tpp-registry-service
     app.kubernetes.io/part-of: tpp-registry
   annotations:
-    openbank.tech/policy-checksum: "34b62dc1b18c9a78"
+    openbank.tech/policy-checksum: "6de1614dedbbcdcf"
 data:
   rest.rego: |
     # SPDX-License-Identifier: Apache-2.0
@@ -1980,10 +1980,20 @@ data:
                                                # confirmed M2M automated caller (customer-edge) — gating either would brick
                                                # production automation once enforcement is ever flipped on, not just close
                                                # the risky operator-console gap. See the four_eyes.verbs guardrail note below.
-      - openbank-consent-service               # four-eyes wired (issue #938 follow-up) on consent.grant/consent.revoke —
-                                                # both confirmed human-operator-only (no M2M caller). consent.activate
-                                                # deliberately left ungated: its rego already reserves an M2M grant for a
-                                                # possible SCA-completion-callback caller.
+      - openbank-consent-service               # four-eyes wired (issue #938 follow-up) on consent.grant/consent.revoke.
+                                                # UPDATED (ADR-0206): no longer exclusively human-operator — the shared
+                                                # M2M principal may now call both, but ONLY for
+                                                # grantee=party-service:marketing-comms (consent-opa-bundle.yaml's
+                                                # service-consent-m2m-marketing rule), a low-risk SCA-exempt marketing
+                                                # toggle (ADR-0205 D1). AUTHZ_FOUR_EYES_ENFORCE is false today for
+                                                # consent-service (consent-service.yaml has no override), so this M2M
+                                                # path is not currently blocked by the maker/checker pause — but if
+                                                # four-eyes enforcement is ever flipped on for this service, the
+                                                # party-service forwarder (no human in the loop) would stall on the
+                                                # missing second approver. Flag that rollout precondition before
+                                                # flipping AUTHZ_FOUR_EYES_ENFORCE here. consent.activate deliberately
+                                                # left ungated: its rego already reserves an M2M grant for a possible
+                                                # SCA-completion-callback caller.
       - openbank-fraud-service                # ADR-0084: v4 rule engine live; domestic-payment enforcement gate merged (issue #667, flag default-off pending risk-team threshold calibration)
                                                # four-eyes assessed (issue #938 follow-up): the only REST surface today is a stateless
                                                # POST /fraud/score (fraud.score) — no operator case-decision, rule-config, or manual

--- a/openbank-infra/gitops/components/tpp-registry/tpp-registry-service.yaml
+++ b/openbank-infra/gitops/components/tpp-registry/tpp-registry-service.yaml
@@ -23,7 +23,7 @@ spec:
       annotations:
         # Rolls the pod when the OPA bundle changes (subPath mounts do not hot-reload).
         # Kept in sync by gen-tpp-registry-opa-bundle.sh (do not hand-edit).
-        openbank.tech/policy-checksum: "34b62dc1b18c9a78"
+        openbank.tech/policy-checksum: "6de1614dedbbcdcf"
     spec:
       securityContext:
         runAsNonRoot: true

--- a/openbank-libs/governance/rules.yaml
+++ b/openbank-libs/governance/rules.yaml
@@ -611,10 +611,20 @@ money_path_services:
                                            # confirmed M2M automated caller (customer-edge) — gating either would brick
                                            # production automation once enforcement is ever flipped on, not just close
                                            # the risky operator-console gap. See the four_eyes.verbs guardrail note below.
-  - openbank-consent-service               # four-eyes wired (issue #938 follow-up) on consent.grant/consent.revoke —
-                                            # both confirmed human-operator-only (no M2M caller). consent.activate
-                                            # deliberately left ungated: its rego already reserves an M2M grant for a
-                                            # possible SCA-completion-callback caller.
+  - openbank-consent-service               # four-eyes wired (issue #938 follow-up) on consent.grant/consent.revoke.
+                                            # UPDATED (ADR-0206): no longer exclusively human-operator — the shared
+                                            # M2M principal may now call both, but ONLY for
+                                            # grantee=party-service:marketing-comms (consent-opa-bundle.yaml's
+                                            # service-consent-m2m-marketing rule), a low-risk SCA-exempt marketing
+                                            # toggle (ADR-0205 D1). AUTHZ_FOUR_EYES_ENFORCE is false today for
+                                            # consent-service (consent-service.yaml has no override), so this M2M
+                                            # path is not currently blocked by the maker/checker pause — but if
+                                            # four-eyes enforcement is ever flipped on for this service, the
+                                            # party-service forwarder (no human in the loop) would stall on the
+                                            # missing second approver. Flag that rollout precondition before
+                                            # flipping AUTHZ_FOUR_EYES_ENFORCE here. consent.activate deliberately
+                                            # left ungated: its rego already reserves an M2M grant for a possible
+                                            # SCA-completion-callback caller.
   - openbank-fraud-service                # ADR-0084: v4 rule engine live; domestic-payment enforcement gate merged (issue #667, flag default-off pending risk-team threshold calibration)
                                            # four-eyes assessed (issue #938 follow-up): the only REST surface today is a stateless
                                            # POST /fraud/score (fraud.score) — no operator case-decision, rule-config, or manual


### PR DESCRIPTION
## Summary
- ADR-0206 D2: new OPA rule `service-consent-m2m-marketing` lets the shared M2M principal call `consent.grant`/`consent.revoke`, scoped to `resource.id == "party-service:marketing-comms"` only — not opened fleet-wide.
- `ConsentResource.create` gains `resource = "#request.granteeId"` (needs D1's dotted-path extraction, #2468 — see Dependencies below). `ConsentResource.revoke` gains an optional `?granteeId=` query param; `ConsentService.revokeConsent` cross-checks it against the loaded consent's actual granteeId (new `ConsentGranteeMismatchException`, 403) since the OPA decision alone can't see the DB row on this action.
- Updates `rules.yaml`'s stale "confirmed no M2M caller" note for consent-service, and flags that `AUTHZ_FOUR_EYES_ENFORCE` is currently `false` for consent-service (this M2M path isn't paused pending a second approver today — but would stall the party-service forwarder, which has no human in the loop, if that flag is ever flipped without a follow-up decision).
- Includes the full fleet-wide `gen-*opa-bundle*.sh` regen output (71 files) triggered by the `rules.yaml` edit — checksum-only elsewhere, per the documented fleet convention.

## Dependencies
- Builds on #2468 (ADR-0206 D1, dotted-path resource extraction). **Safe to merge in either order**: verified the pre-D1 `extractResource` treats `"request.granteeId"` as a literal (unmatched) parameter name and fails closed to `resource = null`, so the new OPA rule simply never fires (M2M stays denied, same as before) until D1 also lands — no regression either order.

## Test plan
- [x] `./gradlew :openbank-consent-service:detekt :openbank-consent-service:ktlintCheck :openbank-consent-service:test` green
- [x] Verified `input.resource.id` is an established rego pattern in this bundle (`rest.rego:131`) before relying on it

Refs ADR-0206 (docs/adr/0206-scope-m2m-consent-grant-revoke-by-grantee-resource.md), merged #2465. N/A — no separate backlog issue; implements a merged ADR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)