### PR TITLE
test(admin-ui): stop the render-smoke mounts flaking on vitest's 5 s default

### DIFF
--- a/openbank-admin-ui/src/test/mermaid-labels.test.ts
+++ b/openbank-admin-ui/src/test/mermaid-labels.test.ts
@@ -66,6 +66,9 @@ async function render(id: string, config: object): Promise<string> {
   return svg
 }
 
+/** See the note on the render below — this is a correctness test, not a latency one. */
+const RENDER_TIMEOUT_MS = 30_000
+
 describe('mermaid diagram labels survive DOMPurify', () => {
   beforeAll(() => stubSvgTextMetrics())
 
@@ -81,7 +84,11 @@ describe('mermaid diagram labels survive DOMPurify', () => {
     expect(nodeLabelText(clean)).toContain('Customer Edge')
     expect(nodeLabelText(clean)).toContain('Ledger Service')
     expect(nodeLabelText(clean)).toContain('Outbox Dispatcher')
-  })
+    // A real mermaid render, not a stub — the slowest case in this file, and it
+    // shares the vitest pool with 38 other files. It flaked on the 5 s default
+    // for the same reason render-smoke's page mounts did (#2235); nothing here
+    // asserts latency, so the timeout is generous on purpose.
+  }, RENDER_TIMEOUT_MS)
 
   it('pins htmlLabels at the top level, where mermaid actually reads it', () => {
     // flowchart.htmlLabels is deprecated in mermaid 11 and is NOT a substitute:

--- a/openbank-admin-ui/src/test/render-smoke.test.tsx
+++ b/openbank-admin-ui/src/test/render-smoke.test.tsx
@@ -146,6 +146,26 @@ function mockFetch() {
   })
 }
 
+// ── Why these mounts get a longer timeout than vitest's 5 s default ────────
+// This is a SMOKE test: it asserts "does it mount", never "does it mount fast".
+// A latency assertion is not part of its contract, and vitest's default 5 s was
+// acting as one. Measured 2026-07-25 (#2235): running this file ALONE is 5/5
+// green, but as part of the full 39-file suite 7 of 12 consecutive runs failed
+// with `Test timed out in 5000ms` — never on an assertion. The docs pages are the
+// heaviest mounts in the suite (mermaid + react-syntax-highlighter + long
+// markdown), so under shared-vitest-pool contention they cross 5 s first. The
+// same contention is already recorded in generate-governance.test.ts.
+//
+// The cost of a flake here is not a lost minute — it is that a timeout is
+// INDISTINGUISHABLE from a throw, which is the one signal this file exists to
+// carry. A ~58%-failing file trains people to re-run rather than read, and the
+// next real docs-page mount regression reads as "the flaky one again".
+//
+// So: keep the timeout generous. Do NOT tighten it back toward 5 s to "catch slow
+// pages" — that is a different test, and it would be paid for with the smoke
+// signal. If a page genuinely hangs, 30 s still fails it well inside the job.
+const MOUNT_TIMEOUT_MS = 30_000
+
 describe('admin-ui render-smoke — every page mounts', () => {
   beforeEach(() => {
     vi.stubGlobal('fetch', mockFetch())
@@ -198,6 +218,6 @@ describe('admin-ui render-smoke — every page mounts', () => {
         if (err instanceof Error && err.message === REDIRECT_SENTINEL) return
         throw err
       }
-    })
+    }, MOUNT_TIMEOUT_MS)
   }
 })


### PR DESCRIPTION
Closes #2235

## What

Give the render-smoke page mounts and the real-mermaid render in `mermaid-labels.test.ts` a 30 s per-test timeout instead of vitest's 5 s default.

## Why

Both are correctness smoke tests — "does the page mount", "does the label survive DOMPurify". Neither asserts latency, but the 5 s default was acting as a latency assertion nobody wrote.

Per #2235, measured over 12 consecutive full-suite runs: the file **alone** is 5/5 green, but as part of the 39-file suite **7 of 12** runs failed with `Test timed out in 5000ms` — never on an assertion. It is shared-vitest-pool contention, not a bug in the pages; `generate-governance.test.ts` already carries a comment recording the same failure mode.

The cost is not the lost minute: a timeout is **indistinguishable from a throw**, which is the only signal render-smoke carries. A ~58%-failing file trains people to re-run rather than read, so the next real docs-page mount regression reads as "the flaky one again".

Chose the timeout option over pool isolation because it is the smaller change and does not alter how the rest of the suite is scheduled. The inline comments say explicitly not to tighten it back toward 5 s — that would be a different (latency) test, paid for with the smoke signal.

## Verification

- **Falsified the wiring**: setting `MOUNT_TIMEOUT_MS = 1` reddens the file with `Test timed out in 1ms`, so the constant really gates the case.
- Three consecutive full-suite runs: both files clean in all three.
- Five unrelated files (`finops-*`, `service-registry.guard`, `generate-governance`) fail in a bare worktree because they read CI-generated artifacts that a fresh checkout does not have — pre-existing and untouched by this change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)