### PR TITLE
fix(authz): grant ROLE_API to the M2M account, sweep the dead ROLE_SERVICE name, enforce parity (#2442)

### DIFF
--- a/.github/scripts/check-roles-allowed-realm.py
+++ b/.github/scripts/check-roles-allowed-realm.py
@@ -23,12 +23,15 @@
 #   is unreachable by construction: there is no token any Keycloak in this platform can mint that
 #   satisfies it. This is a mechanical fact, not a policy judgement, which is why it blocks.
 #
-#   ADVISORY (::warning) — an individual unknown role inside a list that also names a live one
-#   (e.g. `("ROLE_SERVICE", "ROLE_OPERATOR", "ROLE_ADMIN")`). Humans still get in; only the caller
-#   the dead name was meant for is silently denied. Fleet-wide there are ~150 of these across ~29
-#   services (ROLE_SERVICE, ROLE_CREDIT_RISK, ROLE_LENDING_OFFICER), and clearing them is a real
-#   decision per service — grant the role in Keycloak, or delete the path it was reserved for.
-#   Tracked separately; warning here so the number stays visible instead of being rediscovered.
+#   HARD (exit 1) — an individual unknown role inside a list that also names a live one
+#   (e.g. the old `("ROLE_SERVICE", "ROLE_OPERATOR", "ROLE_ADMIN")`). Humans still get in, so this
+#   fails quietly: only the caller the dead name was meant for is denied, forever, with nothing to
+#   read. This was ADVISORY at introduction because 163 sites across 29 modules were in that state
+#   (ROLE_SERVICE ×152, ROLE_CREDIT_RISK ×9, ROLE_LENDING_OFFICER ×6) and clearing them needed a
+#   decision, not a rename: #2442 granted ROLE_API to service-account-openbank-services, created
+#   the two lending roles, and swept ROLE_SERVICE -> ROLE_API fleet-wide. The count is 0, so the
+#   warning became a hard gate — an advisory over a set that is empty is just a future regression
+#   waiting to be merged.
 #
 # COMMENTS ARE STRIPPED FIRST, and that is load-bearing rather than tidy. #2403 fixed finrep by
 # replacing the literals and writing a KDoc that QUOTES the broken annotation to explain what went
@@ -144,27 +147,23 @@ def main() -> int:
             f"this endpoint answers 403 to every caller. Known roles: {', '.join(sorted(known))}",
         )
 
-    if partial:
-        by_role = {}
-        for _, _, dead in partial:
-            for d in dead:
-                by_role[d] = by_role.get(d, 0) + 1
-        detail = ", ".join(f"{r}×{c}" for r, c in sorted(by_role.items(), key=lambda kv: -kv[1]))
-        print(
-            f"::warning title=RolesAllowed realm parity::{len(partial)} @RolesAllowed site(s) name "
-            f"a role no realm issues alongside a live one — the caller it was reserved for is "
-            f"silently denied ({detail}). Grant the role in Keycloak or delete the path.",
+    for rel, line, dead in partial:
+        errors.append(
+            f"{rel}:{line} — @RolesAllowed names {', '.join(dead)}, which no realm issues. The "
+            f"endpoint still admits its other roles, so this fails quietly: only the caller the "
+            f"dead name was reserved for is denied, and nothing else says so. Grant the role in "
+            f"Keycloak or delete it from the annotation.",
         )
 
     if errors:
         for e in errors:
             sys.stderr.write(f"::error title=RolesAllowed realm parity::{e}\n")
-        sys.stderr.write(f"::error::check-roles-allowed-realm: {len(errors)} unreachable endpoint(s).\n")
+        sys.stderr.write(f"::error::check-roles-allowed-realm: {len(errors)} @RolesAllowed name(s) no realm issues.\n")
         return 1
 
     print(
         f"roles-allowed parity: {checked} @RolesAllowed site(s) checked against "
-        f"{len(known)} role(s) from {', '.join(realm_files)}; 0 unreachable, {len(partial)} advisory.",
+        f"{len(known)} role(s) from {', '.join(realm_files)}; every named role is issued by a realm.",
     )
     return 0
 

--- a/openbank-account-service/src/main/kotlin/com/openbank/account/infrastructure/rest/AccountResource.kt
+++ b/openbank-account-service/src/main/kotlin/com/openbank/account/infrastructure/rest/AccountResource.kt
@@ -155,7 +155,7 @@ class AccountResource(
 
     @GET
     @Path("/{accountId}")
-    @RolesAllowed(Roles.SERVICE, Roles.VIEWER, Roles.OPERATOR, Roles.ADMIN)
+    @RolesAllowed(Roles.API, Roles.VIEWER, Roles.OPERATOR, Roles.ADMIN)
     @Authorize(action = "account.read", resource = "#accountId")
     @Operation(summary = "Get account by ID")
     suspend fun getAccount(
@@ -169,7 +169,7 @@ class AccountResource(
 
     @GET
     @Path("/iban/{iban}")
-    @RolesAllowed(Roles.SERVICE, Roles.VIEWER, Roles.OPERATOR, Roles.ADMIN)
+    @RolesAllowed(Roles.API, Roles.VIEWER, Roles.OPERATOR, Roles.ADMIN)
     @Authorize(action = "account.read", resource = "#iban")
     @Operation(summary = "Get account by IBAN")
     suspend fun getAccountByIban(
@@ -182,7 +182,7 @@ class AccountResource(
     }
 
     @GET
-    @RolesAllowed(Roles.SERVICE, Roles.VIEWER, Roles.OPERATOR, Roles.ADMIN)
+    @RolesAllowed(Roles.API, Roles.VIEWER, Roles.OPERATOR, Roles.ADMIN)
     @Authorize(action = "account.list")
     @Operation(summary = "List accounts for a party")
     suspend fun listAccounts(
@@ -197,7 +197,7 @@ class AccountResource(
 
     @GET
     @Path("/search")
-    @RolesAllowed(Roles.SERVICE, Roles.VIEWER, Roles.OPERATOR, Roles.ADMIN)
+    @RolesAllowed(Roles.API, Roles.VIEWER, Roles.OPERATOR, Roles.ADMIN)
     @Authorize(action = "account.search")
     @Operation(summary = "Search accounts by IBAN fragment (trigram), cursor-paginated")
     suspend fun searchAccounts(
@@ -218,7 +218,7 @@ class AccountResource(
     // segment wins over the /{accountId} template per JAX-RS matching, so no route ambiguity.
     @GET
     @Path("/active")
-    @RolesAllowed(Roles.SERVICE, Roles.VIEWER, Roles.OPERATOR, Roles.ADMIN)
+    @RolesAllowed(Roles.API, Roles.VIEWER, Roles.OPERATOR, Roles.ADMIN)
     @Authorize(action = "account.list")
     @Operation(summary = "List all ACTIVE accounts fleet-wide, cursor-paginated (billing discovery)")
     suspend fun listActiveAccounts(
@@ -231,7 +231,7 @@ class AccountResource(
 
     @GET
     @Path("/{accountId}/balance")
-    @RolesAllowed(Roles.SERVICE, Roles.VIEWER, Roles.OPERATOR, Roles.ADMIN)
+    @RolesAllowed(Roles.API, Roles.VIEWER, Roles.OPERATOR, Roles.ADMIN)
     @Authorize(action = "account.read", resource = "#accountId")
     @Operation(summary = "Get account balance")
     suspend fun getBalance(
@@ -258,7 +258,7 @@ class AccountResource(
 
     @GET
     @Path("/{accountId}/pockets")
-    @RolesAllowed(Roles.SERVICE, Roles.VIEWER, Roles.OPERATOR, Roles.ADMIN)
+    @RolesAllowed(Roles.API, Roles.VIEWER, Roles.OPERATOR, Roles.ADMIN)
     @Authorize(action = "account.read", resource = "#accountId")
     @Operation(summary = "List currency pockets of an account")
     suspend fun listPockets(
@@ -370,7 +370,7 @@ class AccountResource(
 
     @GET
     @Path("/{accountId}/pockets/resolve")
-    @RolesAllowed(Roles.SERVICE, Roles.VIEWER, Roles.OPERATOR, Roles.ADMIN)
+    @RolesAllowed(Roles.API, Roles.VIEWER, Roles.OPERATOR, Roles.ADMIN)
     @Authorize(action = "account.read", resource = "#accountId")
     @Operation(summary = "Resolve which pocket settles a payment in a given currency")
     suspend fun resolvePocket(

--- a/openbank-account-service/src/main/kotlin/com/openbank/account/infrastructure/rest/AuthorizationResource.kt
+++ b/openbank-account-service/src/main/kotlin/com/openbank/account/infrastructure/rest/AuthorizationResource.kt
@@ -32,7 +32,7 @@ import java.util.UUID
 class AuthorizationResource(private val authorizationUseCase: AuthorizationUseCase) {
 
     @GET
-    @RolesAllowed(Roles.SERVICE, Roles.VIEWER, Roles.OPERATOR, Roles.ADMIN)
+    @RolesAllowed(Roles.API, Roles.VIEWER, Roles.OPERATOR, Roles.ADMIN)
     @Authorize(action = "account.read", resource = "#accountId")
     suspend fun list(@PathParam("accountId") accountId: UUID): List<AuthorizationResponse> =
         authorizationUseCase.listAuthorizations(ListAuthorizationsQuery(accountId))
@@ -79,7 +79,7 @@ class AuthorizationResource(private val authorizationUseCase: AuthorizationUseCa
 
     @GET
     @Path("/check")
-    @RolesAllowed(Roles.SERVICE, Roles.VIEWER, Roles.OPERATOR, Roles.ADMIN)
+    @RolesAllowed(Roles.API, Roles.VIEWER, Roles.OPERATOR, Roles.ADMIN)
     @Authorize(action = "account.read", resource = "#accountId")
     suspend fun check(
         @PathParam("accountId") accountId: UUID,

--- a/openbank-account-service/src/test/kotlin/com/openbank/account/infrastructure/rest/AccountSecurityContractTest.kt
+++ b/openbank-account-service/src/test/kotlin/com/openbank/account/infrastructure/rest/AccountSecurityContractTest.kt
@@ -64,7 +64,7 @@ class AccountSecurityContractTest {
         ).forEach { name ->
             assertThat(rolesOf(name))
                 .describedAs("%s read roles", name)
-                .containsExactlyInAnyOrder("ROLE_SERVICE", "ROLE_VIEWER", "ROLE_OPERATOR", "ROLE_ADMIN")
+                .containsExactlyInAnyOrder("ROLE_API", "ROLE_VIEWER", "ROLE_OPERATOR", "ROLE_ADMIN")
         }
     }
 

--- a/openbank-account-service/src/test/kotlin/com/openbank/account/integration/ReconciliationSummaryIT.kt
+++ b/openbank-account-service/src/test/kotlin/com/openbank/account/integration/ReconciliationSummaryIT.kt
@@ -53,7 +53,7 @@ class ReconciliationSummaryIT {
 
     @Test
     @Order(3)
-    @TestSecurity(user = "analytics-sink", roles = ["ROLE_SERVICE"])
+    @TestSecurity(user = "analytics-sink", roles = ["ROLE_API"])
     fun `the service-to-service caller gets the summary projection`() {
         Given { this } When {
             get(path)
@@ -102,7 +102,7 @@ class ReconciliationSummaryIT {
      */
     @Test
     @Order(5)
-    @TestSecurity(user = "analytics-sink", roles = ["ROLE_SERVICE"])
+    @TestSecurity(user = "analytics-sink", roles = ["ROLE_API"])
     fun `a freshly opened account falls inside the incremental since-window`() {
         Given {
             queryParam("since", openedAfter.toString())

--- a/openbank-aml-service/src/main/kotlin/com/openbank/aml/infrastructure/rest/AmlCaseResource.kt
+++ b/openbank-aml-service/src/main/kotlin/com/openbank/aml/infrastructure/rest/AmlCaseResource.kt
@@ -70,14 +70,14 @@ class AmlCaseResource(
 
     @GET
     @Path("/{caseId}")
-    @RolesAllowed("ROLE_VIEWER", "ROLE_OPERATOR", "ROLE_ADMIN", "ROLE_COMPLIANCE", "ROLE_SERVICE")
+    @RolesAllowed("ROLE_VIEWER", "ROLE_OPERATOR", "ROLE_ADMIN", "ROLE_COMPLIANCE", "ROLE_API")
     @Authorize(action = "amlCase.read", resource = "#caseId")
     @Operation(summary = "Get AML case by ID")
     suspend fun getCase(@PathParam("caseId") caseId: UUID): Response =
         Response.ok(amlCaseUseCase.getCase(caseId).toResponse()).build()
 
     @GET
-    @RolesAllowed("ROLE_VIEWER", "ROLE_OPERATOR", "ROLE_ADMIN", "ROLE_COMPLIANCE", "ROLE_SERVICE")
+    @RolesAllowed("ROLE_VIEWER", "ROLE_OPERATOR", "ROLE_ADMIN", "ROLE_COMPLIANCE", "ROLE_API")
     @Authorize(action = "amlCase.list")
     @Operation(summary = "List AML screening cases")
     suspend fun listCases(

--- a/openbank-aml-service/src/test/kotlin/com/openbank/aml/contract/AmlPactProviderVerificationTest.kt
+++ b/openbank-aml-service/src/test/kotlin/com/openbank/aml/contract/AmlPactProviderVerificationTest.kt
@@ -48,7 +48,7 @@ import org.junit.jupiter.api.extension.ExtendWith
  * Authentication: `POST /api/v1/aml/cases` is `@RolesAllowed("ROLE_OPERATOR", "ROLE_ADMIN",
  * "ROLE_COMPLIANCE")`. `@TestSecurity` cannot annotate a `@TestTemplate` method, so it is applied at
  * class level and Pact replays every interaction as that principal. Note the POST — unlike the
- * `@GET` reads — does NOT accept `ROLE_SERVICE`, so the caller's Keycloak client must carry an
+ * `@GET` reads — does NOT accept `ROLE_API`, so the caller's Keycloak client must carry an
  * operator-grade role; the pact cannot assert that, only that the endpoint honours the contract once
  * the caller is authorised.
  */

--- a/openbank-anacredit-service/src/main/kotlin/com/openbank/anacredit/infrastructure/rest/AnaCreditResource.kt
+++ b/openbank-anacredit-service/src/main/kotlin/com/openbank/anacredit/infrastructure/rest/AnaCreditResource.kt
@@ -29,7 +29,7 @@ import java.time.LocalDate
 @ApplicationScoped
 @Path("/api/v1/anacredit")
 @Produces(MediaType.APPLICATION_JSON)
-@RolesAllowed("ROLE_OPERATOR", "ROLE_ADMIN", "ROLE_AUDITOR", "ROLE_COMPLIANCE", "ROLE_SERVICE")
+@RolesAllowed("ROLE_OPERATOR", "ROLE_ADMIN", "ROLE_AUDITOR", "ROLE_COMPLIANCE", "ROLE_API")
 class AnaCreditResource(
     private val register: RegisterExposureUseCase,
     private val listExposures: ListExposuresUseCase,

--- a/openbank-anacredit-service/src/main/resources/docs/01-overview.cs.md
+++ b/openbank-anacredit-service/src/main/resources/docs/01-overview.cs.md
@@ -46,7 +46,7 @@
 ## Kdo službu volá
 
 - **admin-ui / operátoři** (přes Keycloak token) — compliance a pracovníci regulatorního výkaznictví registrují expozice a stahují měsíční výkaz.
-- **upstream feed / servisní účty** (`ROLE_SERVICE`) — dávková nebo navazující služba posílající kontokorentní expozice (v1: manuálně/REST; budoucnost: event-driven).
+- **upstream feed / servisní účty** (`ROLE_API`) — dávková nebo navazující služba posílající kontokorentní expozice (v1: manuálně/REST; budoucnost: event-driven).
 - **auditoři** (`ROLE_AUDITOR`) — čtou výkaz včetně stopy vyloučení jako důkaz.
 
 ## Závislosti

--- a/openbank-anacredit-service/src/main/resources/docs/01-overview.en.md
+++ b/openbank-anacredit-service/src/main/resources/docs/01-overview.en.md
@@ -46,7 +46,7 @@
 ## Callers
 
 - **admin-ui / operators** (via Keycloak token) — compliance and regulatory-reporting staff registering exposures and pulling the monthly return.
-- **upstream feed / service accounts** (`ROLE_SERVICE`) — a batch or upstream service that pushes overdraft exposures (v1: manual/REST; future: event-driven).
+- **upstream feed / service accounts** (`ROLE_API`) — a batch or upstream service that pushes overdraft exposures (v1: manual/REST; future: event-driven).
 - **auditors** (`ROLE_AUDITOR`) — read the return plus its exclusion trail for evidence.
 
 ## Dependencies

--- a/openbank-anacredit-service/src/main/resources/docs/02-architecture.cs.md
+++ b/openbank-anacredit-service/src/main/resources/docs/02-architecture.cs.md
@@ -5,7 +5,7 @@
 ```mermaid
 graph LR
   admin[admin-ui / operátor]
-  feed[upstream feed<br/>ROLE_SERVICE]
+  feed[upstream feed<br/>ROLE_API]
   fx[fx-service]
 
   ana[(anacredit-service)]:::svc

--- a/openbank-anacredit-service/src/main/resources/docs/02-architecture.en.md
+++ b/openbank-anacredit-service/src/main/resources/docs/02-architecture.en.md
@@ -5,7 +5,7 @@
 ```mermaid
 graph LR
   admin[admin-ui / operator]
-  feed[upstream feed<br/>ROLE_SERVICE]
+  feed[upstream feed<br/>ROLE_API]
   fx[fx-service]
 
   ana[(anacredit-service)]:::svc

--- a/openbank-anacredit-service/src/main/resources/docs/03-api.cs.md
+++ b/openbank-anacredit-service/src/main/resources/docs/03-api.cs.md
@@ -13,13 +13,13 @@ REST kontrakt je formalizován v [`openapi.yaml`](../openapi.yaml) (OpenAPI 3.0.
 Všechny endpointy vyžadují **Keycloak Bearer token** (realm `openbank`). Resource je role-gated na úrovni třídy:
 
 ```
-@RolesAllowed("ROLE_OPERATOR", "ROLE_ADMIN", "ROLE_AUDITOR", "ROLE_COMPLIANCE", "ROLE_SERVICE")
+@RolesAllowed("ROLE_OPERATOR", "ROLE_ADMIN", "ROLE_AUDITOR", "ROLE_COMPLIANCE", "ROLE_API")
 ```
 
 | Role | Typické použití |
 |---|---|
 | `ROLE_OPERATOR` | registrace expozic, vykreslení výkazů |
-| `ROLE_SERVICE` | upstream feed posílající expozice |
+| `ROLE_API` | upstream feed posílající expozice |
 | `ROLE_AUDITOR` | čtení výkazů + stopy vyloučení |
 | `ROLE_COMPLIANCE` | regulatorní review |
 | `ROLE_ADMIN` | vše |

--- a/openbank-anacredit-service/src/main/resources/docs/03-api.en.md
+++ b/openbank-anacredit-service/src/main/resources/docs/03-api.en.md
@@ -13,13 +13,13 @@ The REST contract is formalized in [`openapi.yaml`](../openapi.yaml) (OpenAPI 3.
 All endpoints require a **Keycloak Bearer token** (realm `openbank`). The resource is class-level role-gated:
 
 ```
-@RolesAllowed("ROLE_OPERATOR", "ROLE_ADMIN", "ROLE_AUDITOR", "ROLE_COMPLIANCE", "ROLE_SERVICE")
+@RolesAllowed("ROLE_OPERATOR", "ROLE_ADMIN", "ROLE_AUDITOR", "ROLE_COMPLIANCE", "ROLE_API")
 ```
 
 | Role | Typical use |
 |---|---|
 | `ROLE_OPERATOR` | register exposures, render returns |
-| `ROLE_SERVICE` | upstream feed pushing exposures |
+| `ROLE_API` | upstream feed pushing exposures |
 | `ROLE_AUDITOR` | read returns + exclusion trail |
 | `ROLE_COMPLIANCE` | regulatory review |
 | `ROLE_ADMIN` | everything |

--- a/openbank-anacredit-service/src/main/resources/docs/05-operations.cs.md
+++ b/openbank-anacredit-service/src/main/resources/docs/05-operations.cs.md
@@ -90,7 +90,7 @@ _Toto jsou cílové návrhové SLO pro produkčně tvarované nasazení — v je
 
 ### 403 na každém volání
 
-Resource vyžaduje jednu z rolí `ROLE_OPERATOR / ROLE_ADMIN / ROLE_AUDITOR / ROLE_COMPLIANCE / ROLE_SERVICE`. Zkontroluj realm role tokenu.
+Resource vyžaduje jednu z rolí `ROLE_OPERATOR / ROLE_ADMIN / ROLE_AUDITOR / ROLE_COMPLIANCE / ROLE_API`. Zkontroluj realm role tokenu.
 
 ## Matice verzí tech stacku
 

--- a/openbank-anacredit-service/src/main/resources/docs/05-operations.en.md
+++ b/openbank-anacredit-service/src/main/resources/docs/05-operations.en.md
@@ -90,7 +90,7 @@ _These are design-target SLOs for a production-shaped deployment — they are no
 
 ### 403 on every call
 
-The resource requires one of `ROLE_OPERATOR / ROLE_ADMIN / ROLE_AUDITOR / ROLE_COMPLIANCE / ROLE_SERVICE`. Check the token's realm roles.
+The resource requires one of `ROLE_OPERATOR / ROLE_ADMIN / ROLE_AUDITOR / ROLE_COMPLIANCE / ROLE_API`. Check the token's realm roles.
 
 ## Tech-stack version matrix
 

--- a/openbank-anacredit-service/src/main/resources/docs/06-compliance.cs.md
+++ b/openbank-anacredit-service/src/main/resources/docs/06-compliance.cs.md
@@ -66,7 +66,7 @@ Výkaz AnaCredit je **sebe-auditující**: každý nástroj se objeví buď jako
 ## Bezpečnostní kontroly
 
 - ✅ AuthN: Keycloak OIDC bearer token (realm `openbank`)
-- ✅ AuthZ: Quarkus `@RolesAllowed` (`ROLE_OPERATOR / ROLE_ADMIN / ROLE_AUDITOR / ROLE_COMPLIANCE / ROLE_SERVICE`)
+- ✅ AuthZ: Quarkus `@RolesAllowed` (`ROLE_OPERATOR / ROLE_ADMIN / ROLE_AUDITOR / ROLE_COMPLIANCE / ROLE_API`)
 - ✅ Zpevněné HTTP hlavičky: CSP `default-src 'self'`, HSTS, `X-Frame-Options: DENY`, `X-Content-Type-Options: nosniff`, Referrer-Policy, Permissions-Policy
 - ✅ CORS: omezeno na originy admin-UI
 - ✅ Validace vstupu: typové enumy (`CounterpartyType`, `InstrumentType`), `BigDecimal` částky, parsování ISO data

--- a/openbank-anacredit-service/src/main/resources/docs/06-compliance.en.md
+++ b/openbank-anacredit-service/src/main/resources/docs/06-compliance.en.md
@@ -66,7 +66,7 @@ The AnaCredit return is **self-auditing**: every instrument either appears as a 
 ## Security controls
 
 - ✅ AuthN: Keycloak OIDC bearer token (realm `openbank`)
-- ✅ AuthZ: Quarkus `@RolesAllowed` (`ROLE_OPERATOR / ROLE_ADMIN / ROLE_AUDITOR / ROLE_COMPLIANCE / ROLE_SERVICE`)
+- ✅ AuthZ: Quarkus `@RolesAllowed` (`ROLE_OPERATOR / ROLE_ADMIN / ROLE_AUDITOR / ROLE_COMPLIANCE / ROLE_API`)
 - ✅ Hardened HTTP headers: CSP `default-src 'self'`, HSTS, `X-Frame-Options: DENY`, `X-Content-Type-Options: nosniff`, Referrer-Policy, Permissions-Policy
 - ✅ CORS: restricted to the admin-UI origins
 - ✅ Input validation: typed enums (`CounterpartyType`, `InstrumentType`), `BigDecimal` amounts, ISO-date parsing

--- a/openbank-anacredit-service/src/main/resources/docs/README.cs.md
+++ b/openbank-anacredit-service/src/main/resources/docs/README.cs.md
@@ -22,5 +22,5 @@ Tato dokumentace je publikována přímo službou na management endpointu `/q/op
 - **Persistence:** **PostgreSQL** (`openbank_anacredit`, governance schema label `anacredit_schema`, ADR-0037 v2 — vzor `openbank-product-catalog`). Tabulka `credit_exposures`, Flyway migrace, reaktivní Panache adaptér.
 - **Outbox / události:** **žádné** — derive-only, služba neemituje žádné doménové události ani žádné nekonzumuje.
 - **Idempotence:** žádná — registrace expozice je `upsert` klíčovaný `instrumentId` (přirozeně idempotentní); čtení jsou čistá.
-- **Auth:** Keycloak OIDC, role `ROLE_OPERATOR`, `ROLE_ADMIN`, `ROLE_AUDITOR`, `ROLE_COMPLIANCE`, `ROLE_SERVICE`.
+- **Auth:** Keycloak OIDC, role `ROLE_OPERATOR`, `ROLE_ADMIN`, `ROLE_AUDITOR`, `ROLE_COMPLIANCE`, `ROLE_API`.
 - **Money-path:** **Ne** — mimo bránu ADR-0030 (bez požadavku na threat model / 2 schválení).

--- a/openbank-anacredit-service/src/main/resources/docs/README.en.md
+++ b/openbank-anacredit-service/src/main/resources/docs/README.en.md
@@ -22,5 +22,5 @@ This documentation is published directly by the service at the management endpoi
 - **Persistence:** **PostgreSQL** (`openbank_anacredit`, governance schema label `anacredit_schema`, ADR-0037 v2 — the `openbank-product-catalog` pattern). `credit_exposures` table, Flyway-migrated, reactive-Panache-backed.
 - **Outbox / events:** **none** — derive-only, the service emits no domain events and consumes none.
 - **Idempotency:** none — exposure registration is an `upsert` keyed by `instrumentId` (naturally idempotent); reads are pure.
-- **Auth:** Keycloak OIDC, roles `ROLE_OPERATOR`, `ROLE_ADMIN`, `ROLE_AUDITOR`, `ROLE_COMPLIANCE`, `ROLE_SERVICE`.
+- **Auth:** Keycloak OIDC, roles `ROLE_OPERATOR`, `ROLE_ADMIN`, `ROLE_AUDITOR`, `ROLE_COMPLIANCE`, `ROLE_API`.
 - **Money-path:** **No** — off the ADR-0030 gate (no threat model / 2-approval requirement).

--- a/openbank-balance-service/src/main/kotlin/com/openbank/balance/infrastructure/rest/BalanceResource.kt
+++ b/openbank-balance-service/src/main/kotlin/com/openbank/balance/infrastructure/rest/BalanceResource.kt
@@ -45,7 +45,7 @@ import java.util.UUID
  * pass, per the libs authz contract, so OPA strengthens rather than replaces RBAC. See
  * `openbank-infra/gitops/components/balances/gen-balance-opa-bundle.sh` for the composed policy and
  * the verified in-repo M2M caller map (residual risk: OPA cannot distinguish between SERVICE callers
- * beyond ROLE_SERVICE, so `balance.credit`/`balance.debit` admit any ROLE_SERVICE caller, not just
+ * beyond ROLE_API, so `balance.credit`/`balance.debit` admit any ROLE_API caller, not just
  * the one verified caller, settlement-service).
  *
  * Customer ownership (A1 / issue #628): if X-Customer-Party-Id is present (set by customer-edge for
@@ -65,7 +65,7 @@ class BalanceResource(private val svc: BalanceUseCase, private val accountClient
 
     @GET
     @Path("/{accountId}")
-    @RolesAllowed(Roles.SERVICE, Roles.VIEWER, Roles.OPERATOR, Roles.ADMIN)
+    @RolesAllowed(Roles.API, Roles.VIEWER, Roles.OPERATOR, Roles.ADMIN)
     @Authorize(action = "balance.read", resource = "#accountId")
     suspend fun getBalances(
         @PathParam("accountId") accountId: UUID,
@@ -80,7 +80,7 @@ class BalanceResource(private val svc: BalanceUseCase, private val accountClient
 
     @GET
     @Path("/{accountId}/{currency}")
-    @RolesAllowed(Roles.SERVICE, Roles.VIEWER, Roles.OPERATOR, Roles.ADMIN)
+    @RolesAllowed(Roles.API, Roles.VIEWER, Roles.OPERATOR, Roles.ADMIN)
     @Authorize(action = "balance.read", resource = "#accountId")
     suspend fun getBalance(
         @PathParam("accountId") accountId: UUID,
@@ -99,7 +99,7 @@ class BalanceResource(private val svc: BalanceUseCase, private val accountClient
 
     @POST
     @Path("/{accountId}/holds")
-    @RolesAllowed(Roles.SERVICE, Roles.OPERATOR, Roles.ADMIN)
+    @RolesAllowed(Roles.API, Roles.OPERATOR, Roles.ADMIN)
     @Authorize(action = "balance.hold", resource = "#accountId")
     suspend fun placeHold(@PathParam("accountId") accountId: UUID, body: PlaceHoldRequest): Response {
         val hold = svc.placeHold(
@@ -110,28 +110,28 @@ class BalanceResource(private val svc: BalanceUseCase, private val accountClient
 
     @DELETE
     @Path("/holds/{holdId}")
-    @RolesAllowed(Roles.SERVICE, Roles.OPERATOR, Roles.ADMIN)
+    @RolesAllowed(Roles.API, Roles.OPERATOR, Roles.ADMIN)
     @Authorize(action = "balance.holdRelease", resource = "#holdId")
     suspend fun releaseHold(@PathParam("holdId") holdId: UUID): Response =
         Response.ok(svc.releaseHold(ReleaseHoldCommand(holdId))).build()
 
     @POST
     @Path("/{accountId}/credit")
-    @RolesAllowed(Roles.SERVICE, Roles.OPERATOR, Roles.ADMIN)
+    @RolesAllowed(Roles.API, Roles.OPERATOR, Roles.ADMIN)
     @Authorize(action = "balance.credit", resource = "#accountId")
     suspend fun credit(@PathParam("accountId") accountId: UUID, body: BalanceOperationRequest): Response =
         Response.ok(svc.credit(CreditAccountCommand(accountId, body.amount, body.currency, body.referenceId))).build()
 
     @POST
     @Path("/{accountId}/debit")
-    @RolesAllowed(Roles.SERVICE, Roles.OPERATOR, Roles.ADMIN)
+    @RolesAllowed(Roles.API, Roles.OPERATOR, Roles.ADMIN)
     @Authorize(action = "balance.debit", resource = "#accountId")
     suspend fun debit(@PathParam("accountId") accountId: UUID, body: BalanceOperationRequest): Response =
         Response.ok(svc.debit(DebitAccountCommand(accountId, body.amount, body.currency, body.referenceId))).build()
 
     @POST
     @Path("/{accountId}/initialize")
-    @RolesAllowed(Roles.SERVICE, Roles.OPERATOR, Roles.ADMIN)
+    @RolesAllowed(Roles.API, Roles.OPERATOR, Roles.ADMIN)
     @Authorize(action = "balance.initialize", resource = "#accountId")
     suspend fun initialize(@PathParam("accountId") accountId: UUID, body: InitializeRequest): Response {
         val balance = svc.initializeBalance(

--- a/openbank-balance-service/src/main/kotlin/com/openbank/balance/infrastructure/rest/ReconciliationResource.kt
+++ b/openbank-balance-service/src/main/kotlin/com/openbank/balance/infrastructure/rest/ReconciliationResource.kt
@@ -35,7 +35,7 @@ class ReconciliationResource(private val reconcile: ReconcileBalancesUseCase, pr
 
     @GET
     @Path("/latest")
-    @RolesAllowed(Roles.SERVICE, Roles.AUDITOR, Roles.VIEWER, Roles.OPERATOR, Roles.ADMIN)
+    @RolesAllowed(Roles.API, Roles.AUDITOR, Roles.VIEWER, Roles.OPERATOR, Roles.ADMIN)
     @Authorize(action = "balance.reconciliation.read")
     suspend fun latest(): Response = reconcile.latest()
         ?.let { Response.ok(it).build() }

--- a/openbank-balance-service/src/test/kotlin/com/openbank/balance/contract/BalancePactFolderProviderVerificationTest.kt
+++ b/openbank-balance-service/src/test/kotlin/com/openbank/balance/contract/BalancePactFolderProviderVerificationTest.kt
@@ -67,7 +67,7 @@ import java.util.concurrent.TimeUnit
  */
 @QuarkusTest
 @QuarkusTestResource(com.openbank.balance.it.PostgresRedpandaTestResource::class)
-@TestSecurity(user = "pact-verifier", roles = ["ROLE_SERVICE", "ROLE_OPERATOR"])
+@TestSecurity(user = "pact-verifier", roles = ["ROLE_API", "ROLE_OPERATOR"])
 @Provider("openbank-balance-service")
 @PactFolder("../pacts")
 @IgnoreNoPactsToVerify(ignoreIoErrors = "true")

--- a/openbank-balance-service/src/test/kotlin/com/openbank/balance/contract/BalancePactProviderVerificationTest.kt
+++ b/openbank-balance-service/src/test/kotlin/com/openbank/balance/contract/BalancePactProviderVerificationTest.kt
@@ -53,7 +53,7 @@ import java.util.concurrent.TimeUnit
  */
 @QuarkusTest
 @QuarkusTestResource(com.openbank.balance.it.PostgresRedpandaTestResource::class)
-@TestSecurity(user = "pact-verifier", roles = ["ROLE_SERVICE", "ROLE_OPERATOR"])
+@TestSecurity(user = "pact-verifier", roles = ["ROLE_API", "ROLE_OPERATOR"])
 @Provider("openbank-balance-service")
 @PactBroker
 @IgnoreNoPactsToVerify(ignoreIoErrors = "true")

--- a/openbank-balance-service/src/test/kotlin/com/openbank/balance/infrastructure/rest/BalanceSecurityContractTest.kt
+++ b/openbank-balance-service/src/test/kotlin/com/openbank/balance/infrastructure/rest/BalanceSecurityContractTest.kt
@@ -56,7 +56,7 @@ class BalanceSecurityContractTest {
             val m = BalanceResource::class.java.declaredMethods.single { it.name == name }
             assertThat(rolesOf(m))
                 .describedAs("%s roles", name)
-                .containsExactlyInAnyOrder("ROLE_SERVICE", "ROLE_OPERATOR", "ROLE_ADMIN")
+                .containsExactlyInAnyOrder("ROLE_API", "ROLE_OPERATOR", "ROLE_ADMIN")
         }
     }
 

--- a/openbank-balance-service/src/test/kotlin/com/openbank/balance/integration/BalanceApiIT.kt
+++ b/openbank-balance-service/src/test/kotlin/com/openbank/balance/integration/BalanceApiIT.kt
@@ -64,7 +64,7 @@ class BalanceApiIT {
 
     @Test
     @Order(4)
-    @TestSecurity(user = "00000000-0000-0000-0000-000000000099", roles = ["ROLE_SERVICE"])
+    @TestSecurity(user = "00000000-0000-0000-0000-000000000099", roles = ["ROLE_API"])
     fun `POST initialize creates a CZK pocket with opening balance`() {
         Given {
             contentType("application/json")
@@ -81,7 +81,7 @@ class BalanceApiIT {
 
     @Test
     @Order(5)
-    @TestSecurity(user = "00000000-0000-0000-0000-000000000099", roles = ["ROLE_SERVICE"])
+    @TestSecurity(user = "00000000-0000-0000-0000-000000000099", roles = ["ROLE_API"])
     fun `POST initialize is idempotent - replay returns the existing pocket unchanged`() {
         // Second initialize for the same (account, currency) must NOT reset the balance.
         val replay = (
@@ -101,7 +101,7 @@ class BalanceApiIT {
 
     @Test
     @Order(6)
-    @TestSecurity(user = "00000000-0000-0000-0000-000000000099", roles = ["ROLE_SERVICE"])
+    @TestSecurity(user = "00000000-0000-0000-0000-000000000099", roles = ["ROLE_API"])
     fun `POST initialize creates a second currency pocket (EUR) on the same account`() {
         Given {
             contentType("application/json")
@@ -176,7 +176,7 @@ class BalanceApiIT {
 
     @Test
     @Order(11)
-    @TestSecurity(user = "00000000-0000-0000-0000-000000000099", roles = ["ROLE_SERVICE"])
+    @TestSecurity(user = "00000000-0000-0000-0000-000000000099", roles = ["ROLE_API"])
     fun `POST hold reserves funds and reduces available, not booked`() {
         val response = (
             Given {
@@ -207,7 +207,7 @@ class BalanceApiIT {
 
     @Test
     @Order(12)
-    @TestSecurity(user = "00000000-0000-0000-0000-000000000099", roles = ["ROLE_SERVICE"])
+    @TestSecurity(user = "00000000-0000-0000-0000-000000000099", roles = ["ROLE_API"])
     fun `POST hold beyond available funds returns 422 INSUFFICIENT_FUNDS`() {
         Given {
             contentType("application/json")
@@ -222,7 +222,7 @@ class BalanceApiIT {
 
     @Test
     @Order(13)
-    @TestSecurity(user = "00000000-0000-0000-0000-000000000099", roles = ["ROLE_SERVICE"])
+    @TestSecurity(user = "00000000-0000-0000-0000-000000000099", roles = ["ROLE_API"])
     fun `DELETE hold releases the reservation and restores available`() {
         val id = holdId ?: return
         Given { this } When {
@@ -243,7 +243,7 @@ class BalanceApiIT {
 
     @Test
     @Order(14)
-    @TestSecurity(user = "00000000-0000-0000-0000-000000000099", roles = ["ROLE_SERVICE"])
+    @TestSecurity(user = "00000000-0000-0000-0000-000000000099", roles = ["ROLE_API"])
     fun `DELETE unknown hold returns 404`() {
         Given { this } When {
             delete("/api/v1/balances/holds/${UUID.randomUUID()}")

--- a/openbank-balance-service/src/test/kotlin/com/openbank/balance/integration/BalanceMovementIdempotencyApiIT.kt
+++ b/openbank-balance-service/src/test/kotlin/com/openbank/balance/integration/BalanceMovementIdempotencyApiIT.kt
@@ -65,7 +65,7 @@ class BalanceMovementIdempotencyApiIT {
 
     @Test
     @Order(1)
-    @TestSecurity(user = "00000000-0000-0000-0000-000000000099", roles = ["ROLE_SERVICE"])
+    @TestSecurity(user = "00000000-0000-0000-0000-000000000099", roles = ["ROLE_API"])
     fun `initialize the CZK pocket with a zero balance`() {
         Given {
             contentType("application/json")
@@ -81,7 +81,7 @@ class BalanceMovementIdempotencyApiIT {
 
     @Test
     @Order(2)
-    @TestSecurity(user = "00000000-0000-0000-0000-000000000099", roles = ["ROLE_SERVICE"])
+    @TestSecurity(user = "00000000-0000-0000-0000-000000000099", roles = ["ROLE_API"])
     fun `credit with a referenceId books the funds once`() {
         val response = postMovement("credit", "250.00", CREDIT_REF)
         assertThat(amount(response, "bookedAmount")).isEqualByComparingTo(BigDecimal("250.00"))
@@ -90,7 +90,7 @@ class BalanceMovementIdempotencyApiIT {
 
     @Test
     @Order(3)
-    @TestSecurity(user = "00000000-0000-0000-0000-000000000099", roles = ["ROLE_SERVICE"])
+    @TestSecurity(user = "00000000-0000-0000-0000-000000000099", roles = ["ROLE_API"])
     fun `credit replay with the SAME referenceId is NOT re-applied (one posting)`() {
         // At-least-once redelivery: same (account, currency, referenceId, CREDIT) → marker row in
         // balance_movement (V8) short-circuits, the booked amount must not double.
@@ -101,7 +101,7 @@ class BalanceMovementIdempotencyApiIT {
 
     @Test
     @Order(4)
-    @TestSecurity(user = "00000000-0000-0000-0000-000000000099", roles = ["ROLE_SERVICE"])
+    @TestSecurity(user = "00000000-0000-0000-0000-000000000099", roles = ["ROLE_API"])
     fun `credit with a DIFFERENT referenceId applies again (dedup keys on reference, not amount)`() {
         val response = postMovement("credit", "250.00", "saga-credit-0002")
         assertThat(amount(response, "bookedAmount")).isEqualByComparingTo(BigDecimal("500.00"))
@@ -109,7 +109,7 @@ class BalanceMovementIdempotencyApiIT {
 
     @Test
     @Order(5)
-    @TestSecurity(user = "00000000-0000-0000-0000-000000000099", roles = ["ROLE_SERVICE"])
+    @TestSecurity(user = "00000000-0000-0000-0000-000000000099", roles = ["ROLE_API"])
     fun `debit with a referenceId books the outflow once`() {
         val response = postMovement("debit", "100.00", DEBIT_REF)
         assertThat(amount(response, "bookedAmount")).isEqualByComparingTo(BigDecimal("400.00"))
@@ -118,7 +118,7 @@ class BalanceMovementIdempotencyApiIT {
 
     @Test
     @Order(6)
-    @TestSecurity(user = "00000000-0000-0000-0000-000000000099", roles = ["ROLE_SERVICE"])
+    @TestSecurity(user = "00000000-0000-0000-0000-000000000099", roles = ["ROLE_API"])
     fun `debit replay with the SAME referenceId is NOT re-applied (one posting)`() {
         val replay = postMovement("debit", "100.00", DEBIT_REF)
         assertThat(amount(replay, "bookedAmount")).isEqualByComparingTo(BigDecimal("400.00"))
@@ -127,7 +127,7 @@ class BalanceMovementIdempotencyApiIT {
 
     @Test
     @Order(7)
-    @TestSecurity(user = "00000000-0000-0000-0000-000000000099", roles = ["ROLE_SERVICE"])
+    @TestSecurity(user = "00000000-0000-0000-0000-000000000099", roles = ["ROLE_API"])
     fun `debit and credit with the SAME referenceId are independent operations`() {
         // The V8 idempotency key includes the operation: a CREDIT marker must not swallow a DEBIT
         // that happens to reuse the reference string (and vice versa).
@@ -137,7 +137,7 @@ class BalanceMovementIdempotencyApiIT {
 
     @Test
     @Order(8)
-    @TestSecurity(user = "00000000-0000-0000-0000-000000000099", roles = ["ROLE_SERVICE"])
+    @TestSecurity(user = "00000000-0000-0000-0000-000000000099", roles = ["ROLE_API"])
     fun `debit beyond available funds returns 422 and books nothing`() {
         Given {
             contentType("application/json")
@@ -153,7 +153,7 @@ class BalanceMovementIdempotencyApiIT {
 
     @Test
     @Order(9)
-    @TestSecurity(user = "00000000-0000-0000-0000-000000000099", roles = ["ROLE_SERVICE"])
+    @TestSecurity(user = "00000000-0000-0000-0000-000000000099", roles = ["ROLE_API"])
     fun `a rejected debit leaves the referenceId free - the retry with funds succeeds`() {
         // The idempotency marker is written in the same transaction as the mutation, so a FAILED
         // attempt must not poison the referenceId for the saga's later (funded) retry.
@@ -163,7 +163,7 @@ class BalanceMovementIdempotencyApiIT {
 
     @Test
     @Order(10)
-    @TestSecurity(user = "00000000-0000-0000-0000-000000000099", roles = ["ROLE_SERVICE"])
+    @TestSecurity(user = "00000000-0000-0000-0000-000000000099", roles = ["ROLE_API"])
     fun `credit to an unknown currency pocket returns 404, no implicit pocket creation`() {
         Given {
             contentType("application/json")

--- a/openbank-clearing-service/src/main/kotlin/com/openbank/clearing/infrastructure/rest/ClearingResource.kt
+++ b/openbank-clearing-service/src/main/kotlin/com/openbank/clearing/infrastructure/rest/ClearingResource.kt
@@ -66,7 +66,7 @@ class ClearingResource(
 
     @POST
     @Path("/submit")
-    @RolesAllowed(Roles.SERVICE, Roles.PAYMENTS, Roles.ADMIN)
+    @RolesAllowed(Roles.API, Roles.PAYMENTS, Roles.ADMIN)
     @Authorize(action = "clearingBatch.submit")
     @Operation(summary = "Submit payment for clearing")
     fun submit(request: SubmitPaymentRequest): Uni<Response> = submitUseCase.submit(request)
@@ -75,7 +75,7 @@ class ClearingResource(
 
     @GET
     @Path("/batches")
-    @RolesAllowed(Roles.SERVICE, Roles.VIEWER, Roles.OPERATOR, Roles.PAYMENTS, Roles.ADMIN)
+    @RolesAllowed(Roles.API, Roles.VIEWER, Roles.OPERATOR, Roles.PAYMENTS, Roles.ADMIN)
     @Authorize(action = "clearingBatch.list")
     @Operation(summary = "List clearing batches")
     fun listBatches(
@@ -86,7 +86,7 @@ class ClearingResource(
 
     @GET
     @Path("/batches/{id}")
-    @RolesAllowed(Roles.SERVICE, Roles.VIEWER, Roles.OPERATOR, Roles.PAYMENTS, Roles.ADMIN)
+    @RolesAllowed(Roles.API, Roles.VIEWER, Roles.OPERATOR, Roles.PAYMENTS, Roles.ADMIN)
     @Authorize(action = "clearingBatch.read", resource = "#id")
     @Operation(summary = "Get clearing batch by ID")
     fun getBatch(@PathParam("id") id: UUID): Uni<Response> = getBatchUseCase.getBatch(id)
@@ -94,7 +94,7 @@ class ClearingResource(
 
     @GET
     @Path("/batches/{id}/items")
-    @RolesAllowed(Roles.SERVICE, Roles.VIEWER, Roles.OPERATOR, Roles.PAYMENTS, Roles.ADMIN)
+    @RolesAllowed(Roles.API, Roles.VIEWER, Roles.OPERATOR, Roles.PAYMENTS, Roles.ADMIN)
     @Authorize(action = "clearingBatch.readItems", resource = "#id")
     @Operation(summary = "List items in a clearing batch")
     fun getBatchItems(@PathParam("id") id: UUID): Uni<List<ClearingItem>> = getItemUseCase.listItemsByBatch(id)
@@ -120,7 +120,7 @@ class ClearingResource(
 
     @GET
     @Path("/positions/{cycleId}")
-    @RolesAllowed(Roles.SERVICE, Roles.VIEWER, Roles.OPERATOR, Roles.PAYMENTS, Roles.ADMIN)
+    @RolesAllowed(Roles.API, Roles.VIEWER, Roles.OPERATOR, Roles.PAYMENTS, Roles.ADMIN)
     @Authorize(action = "clearingBatch.readPositions")
     @Operation(summary = "Get settlement positions for a cycle")
     fun getPositions(@PathParam("cycleId") cycleId: String): Uni<List<SettlementPosition>> =
@@ -128,7 +128,7 @@ class ClearingResource(
 
     @GET
     @Path("/items/{id}")
-    @RolesAllowed(Roles.SERVICE, Roles.VIEWER, Roles.OPERATOR, Roles.PAYMENTS, Roles.ADMIN)
+    @RolesAllowed(Roles.API, Roles.VIEWER, Roles.OPERATOR, Roles.PAYMENTS, Roles.ADMIN)
     @Authorize(action = "clearingBatch.readItem", resource = "#id")
     @Operation(summary = "Get clearing item by ID")
     fun getItem(@PathParam("id") id: UUID): Uni<Response> = getItemUseCase.getItem(id)
@@ -136,7 +136,7 @@ class ClearingResource(
 
     @GET
     @Path("/items/by-payment/{paymentId}")
-    @RolesAllowed(Roles.SERVICE, Roles.VIEWER, Roles.OPERATOR, Roles.PAYMENTS, Roles.ADMIN)
+    @RolesAllowed(Roles.API, Roles.VIEWER, Roles.OPERATOR, Roles.PAYMENTS, Roles.ADMIN)
     @Authorize(action = "clearingBatch.readItemsByPayment", resource = "#paymentId")
     @Operation(summary = "Get clearing items by payment ID")
     fun getItemsByPayment(@PathParam("paymentId") paymentId: UUID): Uni<List<ClearingItem>> =

--- a/openbank-clearing-service/src/main/resources/docs/01-overview.cs.md
+++ b/openbank-clearing-service/src/main/resources/docs/01-overview.cs.md
@@ -53,7 +53,7 @@ Podporované platební raily: `SEPA_SCT`, `SEPA_SCT_INST`, `SWIFT`, `DOMESTIC`, 
 
 ## Volající
 
-- **platební služby** (`sepa-payment`, `sepa-instant`, `domestic-payment`, `swift-service`) — předávají platby ke clearingu (`ROLE_SERVICE` / `ROLE_PAYMENTS`).
+- **platební služby** (`sepa-payment`, `sepa-instant`, `domestic-payment`, `swift-service`) — předávají platby ke clearingu (`ROLE_API` / `ROLE_PAYMENTS`).
 - **provoz / payment-ops** (přes admin UI, Keycloak token) — spouští cykly a zúčtovávají dávky (`ROLE_PAYMENTS` / `ROLE_ADMIN`).
 - **admin-ui / vieweři / operátoři** — read-only pohledy na dávky, položky a pozice.
 

--- a/openbank-clearing-service/src/main/resources/docs/01-overview.en.md
+++ b/openbank-clearing-service/src/main/resources/docs/01-overview.en.md
@@ -53,7 +53,7 @@ Supported payment rails: `SEPA_SCT`, `SEPA_SCT_INST`, `SWIFT`, `DOMESTIC`, `INTE
 
 ## Callers
 
-- **payment services** (`sepa-payment`, `sepa-instant`, `domestic-payment`, `swift-service`) — submit payments for clearing (`ROLE_SERVICE` / `ROLE_PAYMENTS`).
+- **payment services** (`sepa-payment`, `sepa-instant`, `domestic-payment`, `swift-service`) — submit payments for clearing (`ROLE_API` / `ROLE_PAYMENTS`).
 - **operations / payment-ops** (via admin UI, Keycloak token) — trigger cycles and settle batches (`ROLE_PAYMENTS` / `ROLE_ADMIN`).
 - **admin-ui / viewers / operators** — read-only views of batches, items and positions.
 

--- a/openbank-clearing-simulator/src/main/kotlin/com/openbank/clearingsimulator/infrastructure/rest/ClearingResource.kt
+++ b/openbank-clearing-simulator/src/main/kotlin/com/openbank/clearingsimulator/infrastructure/rest/ClearingResource.kt
@@ -46,7 +46,7 @@ class ClearingResource {
     @Path("/credit-transfers")
     @Consumes(MediaType.APPLICATION_XML)
     @Produces(MediaType.APPLICATION_XML)
-    @RolesAllowed("ROLE_SERVICE", "ROLE_OPERATOR", "ROLE_ADMIN")
+    @RolesAllowed("ROLE_API", "ROLE_OPERATOR", "ROLE_ADMIN")
     @Operation(summary = "Submit a pacs.008; receive a pacs.002 status report")
     fun submitCreditTransfer(pacs008Xml: String): Response =
         Response.ok(simulator.clear(pacs008Xml).statusReportXml).build()
@@ -60,7 +60,7 @@ class ClearingResource {
     @Path("/returns")
     @Consumes(MediaType.APPLICATION_JSON)
     @Produces(MediaType.APPLICATION_JSON)
-    @RolesAllowed("ROLE_SERVICE", "ROLE_OPERATOR", "ROLE_ADMIN")
+    @RolesAllowed("ROLE_API", "ROLE_OPERATOR", "ROLE_ADMIN")
     @Operation(summary = "Simulate a pacs.004 payment return — calls sepa-payment return handler")
     fun simulateReturn(request: ReturnRequest): Response {
         val pacs004Xml = simulator.generateReturn(request)
@@ -78,7 +78,7 @@ class ClearingResource {
     @Path("/notifications")
     @Consumes(MediaType.APPLICATION_XML)
     @Produces(MediaType.APPLICATION_XML)
-    @RolesAllowed("ROLE_SERVICE", "ROLE_OPERATOR", "ROLE_ADMIN")
+    @RolesAllowed("ROLE_API", "ROLE_OPERATOR", "ROLE_ADMIN")
     @Operation(summary = "Submit a pacs.008; receive the camt.054 credit notification if it settles")
     fun creditNotification(pacs008Xml: String): Response {
         val result = simulator.clear(pacs008Xml)

--- a/openbank-clearing-simulator/src/test/kotlin/com/openbank/clearingsimulator/ClearingSimulatorApiIT.kt
+++ b/openbank-clearing-simulator/src/test/kotlin/com/openbank/clearingsimulator/ClearingSimulatorApiIT.kt
@@ -61,7 +61,7 @@ class ClearingSimulatorApiIT {
     }
 
     @Test
-    @TestSecurity(user = "rail", roles = ["ROLE_SERVICE"])
+    @TestSecurity(user = "rail", roles = ["ROLE_API"])
     fun `submitting a pacs_008 returns an ACSC pacs_002`() {
         val body = (
             Given {

--- a/openbank-clearing-simulator/src/test/kotlin/com/openbank/clearingsimulator/contract/ClearingSimulatorPactProviderVerificationTest.kt
+++ b/openbank-clearing-simulator/src/test/kotlin/com/openbank/clearingsimulator/contract/ClearingSimulatorPactProviderVerificationTest.kt
@@ -28,12 +28,12 @@ import org.junit.jupiter.api.extension.ExtendWith
  * Git-pact (`@PactFolder`, resolved relative to this module's working directory at `../pacts` =
  * the monorepo-root `pacts/` dir), matching `LedgerPactProviderVerificationTest`'s pattern — always
  * runs, no broker, no CI secret required. `@TestSecurity` matches the endpoint's
- * `@RolesAllowed("ROLE_SERVICE", "ROLE_OPERATOR", "ROLE_ADMIN")`, mirroring how every real rail
+ * `@RolesAllowed("ROLE_API", "ROLE_OPERATOR", "ROLE_ADMIN")`, mirroring how every real rail
  * authenticates (`ClearingSimulatorApiIT`'s own `@TestSecurity(user = "rail", roles =
- * ["ROLE_SERVICE"])`).
+ * ["ROLE_API"])`).
  */
 @QuarkusTest
-@TestSecurity(user = "rail", roles = ["ROLE_SERVICE"])
+@TestSecurity(user = "rail", roles = ["ROLE_API"])
 @Provider("openbank-clearing-simulator")
 @PactFolder("../pacts")
 @IgnoreNoPactsToVerify(ignoreIoErrors = "true")

--- a/openbank-consent-service/src/main/kotlin/com/openbank/consent/infrastructure/rest/ConsentResource.kt
+++ b/openbank-consent-service/src/main/kotlin/com/openbank/consent/infrastructure/rest/ConsentResource.kt
@@ -45,7 +45,7 @@ import java.util.UUID
 @Path("/api/v1/consents")
 @Produces(MediaType.APPLICATION_JSON)
 @Consumes(MediaType.APPLICATION_JSON)
-@RolesAllowed("ROLE_SERVICE", "ROLE_OPERATOR", "ROLE_ADMIN")
+@RolesAllowed("ROLE_API", "ROLE_OPERATOR", "ROLE_ADMIN")
 class ConsentResource(
     private val createConsent: CreateConsentUseCase,
     private val revokeConsent: RevokeConsentUseCase,

--- a/openbank-consent-service/src/test/kotlin/com/openbank/consent/contract/ConsentPactProviderVerificationTest.kt
+++ b/openbank-consent-service/src/test/kotlin/com/openbank/consent/contract/ConsentPactProviderVerificationTest.kt
@@ -43,7 +43,7 @@ import javax.sql.DataSource
  * classes with the same provider name each pull every pact naming that provider and fight over the
  * same `@BeforeEach` target, so they collide.
  *
- * Authentication: `ConsentResource` is `@RolesAllowed("ROLE_SERVICE", "ROLE_OPERATOR", "ROLE_ADMIN")`
+ * Authentication: `ConsentResource` is `@RolesAllowed("ROLE_API", "ROLE_OPERATOR", "ROLE_ADMIN")`
  * at class level. `@TestSecurity` cannot annotate a `@TestTemplate`, so it is applied to the class
  * and Quarkus's test-security extension supplies the identity on every replayed request — matching
  * the production path, where callers present an M2M client-credentials token (ADR-0018). The
@@ -67,7 +67,7 @@ import javax.sql.DataSource
 @QuarkusTest
 @QuarkusTestResource(ConsentPactProviderVerificationTest.InMemoryKafkaResource::class)
 @QuarkusTestResource(ConsentPostgresRedisTestResource::class)
-@TestSecurity(user = "pact-verifier", roles = ["ROLE_SERVICE", "ROLE_OPERATOR"])
+@TestSecurity(user = "pact-verifier", roles = ["ROLE_API", "ROLE_OPERATOR"])
 @Provider("openbank-consent-service")
 @PactFolder("../pacts")
 @IgnoreNoPactsToVerify(ignoreIoErrors = "true")

--- a/openbank-dispute-service/src/main/kotlin/com/openbank/dispute/infrastructure/rest/ComplaintResource.kt
+++ b/openbank-dispute-service/src/main/kotlin/com/openbank/dispute/infrastructure/rest/ComplaintResource.kt
@@ -33,7 +33,7 @@ import java.util.UUID
 @Produces(MediaType.APPLICATION_JSON)
 @Consumes(MediaType.APPLICATION_JSON)
 @Tag(name = "Complaints", description = "Regulatory complaints handling with statutory deadline clock (ADR-0085)")
-@RolesAllowed("ROLE_VIEWER", "ROLE_OPERATOR", "ROLE_ADMIN", "ROLE_SERVICE")
+@RolesAllowed("ROLE_VIEWER", "ROLE_OPERATOR", "ROLE_ADMIN", "ROLE_API")
 class ComplaintResource(
     private val fileUseCase: FileComplaintUseCase,
     private val handleUseCase: HandleComplaintUseCase,
@@ -41,7 +41,7 @@ class ComplaintResource(
 ) {
     @POST
     @Operation(summary = "File a new complaint")
-    @RolesAllowed("ROLE_OPERATOR", "ROLE_ADMIN", "ROLE_SERVICE")
+    @RolesAllowed("ROLE_OPERATOR", "ROLE_ADMIN", "ROLE_API")
     fun file(request: FileComplaintRequest): Uni<Response> =
         fileUseCase.file(request).map { Response.status(HTTP_CREATED).entity(it).build() }
             .onFailure().recoverWithItem { e -> Response.serverError().entity(mapOf("error" to e.message)).build() }
@@ -63,7 +63,7 @@ class ComplaintResource(
 
     @POST
     @Path("/{id}/interim-reply")
-    @RolesAllowed("ROLE_OPERATOR", "ROLE_ADMIN", "ROLE_SERVICE")
+    @RolesAllowed("ROLE_OPERATOR", "ROLE_ADMIN", "ROLE_API")
     @Authorize(action = "complaint.update", resource = "#id")
     @Operation(summary = "Record an interim reply (extends the statutory deadline to 35 business days)")
     fun interimReply(@PathParam("id") id: UUID, request: InterimReplyRequest): Uni<Response> =
@@ -74,7 +74,7 @@ class ComplaintResource(
 
     @POST
     @Path("/{id}/resolve")
-    @RolesAllowed("ROLE_OPERATOR", "ROLE_ADMIN", "ROLE_SERVICE")
+    @RolesAllowed("ROLE_OPERATOR", "ROLE_ADMIN", "ROLE_API")
     @Authorize(action = "complaint.update", resource = "#id")
     @Operation(summary = "Resolve a complaint (records an outcome + optional redress flag)")
     fun resolve(@PathParam("id") id: UUID, request: ResolveComplaintRequest): Uni<Response> =
@@ -85,7 +85,7 @@ class ComplaintResource(
 
     @POST
     @Path("/{id}/close")
-    @RolesAllowed("ROLE_OPERATOR", "ROLE_ADMIN", "ROLE_SERVICE")
+    @RolesAllowed("ROLE_OPERATOR", "ROLE_ADMIN", "ROLE_API")
     @Authorize(action = "complaint.update", resource = "#id")
     @Operation(summary = "Close a complaint (records outcome + root-cause code + optional redress flag)")
     fun close(@PathParam("id") id: UUID, request: CloseComplaintRequest): Uni<Response> =

--- a/openbank-dispute-service/src/main/kotlin/com/openbank/dispute/infrastructure/rest/DisputeResource.kt
+++ b/openbank-dispute-service/src/main/kotlin/com/openbank/dispute/infrastructure/rest/DisputeResource.kt
@@ -20,7 +20,7 @@ import java.util.UUID
 @Produces(MediaType.APPLICATION_JSON)
 @Consumes(MediaType.APPLICATION_JSON)
 @Tag(name = "Disputes", description = "Dispute and chargeback management")
-@RolesAllowed("ROLE_VIEWER", "ROLE_OPERATOR", "ROLE_ADMIN", "ROLE_SERVICE")
+@RolesAllowed("ROLE_VIEWER", "ROLE_OPERATOR", "ROLE_ADMIN", "ROLE_API")
 class DisputeResource(
     private val openUseCase: OpenDisputeUseCase,
     private val updateUseCase: UpdateDisputeUseCase,
@@ -28,7 +28,7 @@ class DisputeResource(
 ) {
     @POST
     @Operation(summary = "Open a new dispute")
-    @RolesAllowed("ROLE_OPERATOR", "ROLE_ADMIN", "ROLE_SERVICE")
+    @RolesAllowed("ROLE_OPERATOR", "ROLE_ADMIN", "ROLE_API")
     fun open(request: OpenDisputeRequest): Uni<Response> =
         openUseCase.open(request).map { Response.status(201).entity(it).build() }
             .onFailure().recoverWithItem { e -> Response.serverError().entity(mapOf("error" to e.message)).build() }
@@ -64,7 +64,7 @@ class DisputeResource(
 
     @PUT
     @Path("/{id}")
-    @RolesAllowed("ROLE_OPERATOR", "ROLE_ADMIN", "ROLE_SERVICE")
+    @RolesAllowed("ROLE_OPERATOR", "ROLE_ADMIN", "ROLE_API")
     @Authorize(action = "dispute.update", resource = "#id")
     @Operation(summary = "Update dispute status/resolution")
     fun update(@PathParam("id") id: UUID, request: UpdateDisputeRequest): Uni<Response> =
@@ -73,28 +73,28 @@ class DisputeResource(
 
     @POST
     @Path("/{id}/evidence")
-    @RolesAllowed("ROLE_OPERATOR", "ROLE_ADMIN", "ROLE_SERVICE")
+    @RolesAllowed("ROLE_OPERATOR", "ROLE_ADMIN", "ROLE_API")
     @Operation(summary = "Add evidence to a dispute")
     fun addEvidence(@PathParam("id") id: UUID, evidence: DisputeEvidence): Uni<Response> =
         updateUseCase.addEvidence(id, evidence).map { Response.status(201).entity(it).build() }
 
     @POST
     @Path("/{id}/withdraw")
-    @RolesAllowed("ROLE_OPERATOR", "ROLE_ADMIN", "ROLE_SERVICE")
+    @RolesAllowed("ROLE_OPERATOR", "ROLE_ADMIN", "ROLE_API")
     @Operation(summary = "Withdraw a dispute")
     fun withdraw(@PathParam("id") id: UUID, @QueryParam("actor") actor: String): Uni<Response> =
         updateUseCase.withdraw(id, actor).map { Response.ok(it).build() }
 
     @POST
     @Path("/{id}/escalate")
-    @RolesAllowed("ROLE_OPERATOR", "ROLE_ADMIN", "ROLE_SERVICE")
+    @RolesAllowed("ROLE_OPERATOR", "ROLE_ADMIN", "ROLE_API")
     @Operation(summary = "Escalate a dispute")
     fun escalate(@PathParam("id") id: UUID, @QueryParam("actor") actor: String): Uni<Response> =
         updateUseCase.escalate(id, actor).map { Response.ok(it).build() }
 
     @POST
     @Path("/{id}/resolve")
-    @RolesAllowed("ROLE_OPERATOR", "ROLE_ADMIN", "ROLE_SERVICE")
+    @RolesAllowed("ROLE_OPERATOR", "ROLE_ADMIN", "ROLE_API")
     @Authorize(action = "dispute.resolve", resource = "#id")
     @Operation(
         summary = "Record a dispute's remediation outcome",
@@ -125,7 +125,7 @@ class DisputeResource(
 
     @GET
     @Path("/{id}/evidence/verify")
-    @RolesAllowed("ROLE_OPERATOR", "ROLE_ADMIN", "ROLE_SERVICE")
+    @RolesAllowed("ROLE_OPERATOR", "ROLE_ADMIN", "ROLE_API")
     @Authorize(action = "dispute.read", resource = "#id")
     @Operation(summary = "Walk and verify a dispute's evidence hash chain (ADR-0117/ADR-0133 pattern)")
     fun verifyEvidenceChain(@PathParam("id") id: UUID): Uni<EvidenceChainVerification> =

--- a/openbank-dispute-service/src/main/resources/docs/01-overview.cs.md
+++ b/openbank-dispute-service/src/main/resources/docs/01-overview.cs.md
@@ -52,7 +52,7 @@ Reklamace nese SLA: `resolutionDeadline = filingDate + resolution-sla-days` (vý
 
 - **admin-ui** (přes Keycloak token) — operátoři a compliance pracovníci spravující reklamace
 - **zákaznická app / API** — otevírání reklamace a nahrávání referencí na důkazy jménem držitele karty
-- **servisní volající** (`ROLE_SERVICE`) — automatizované toky otevírající nebo aktualizující reklamace
+- **servisní volající** (`ROLE_API`) — automatizované toky otevírající nebo aktualizující reklamace
 
 ## Závislosti
 

--- a/openbank-dispute-service/src/main/resources/docs/01-overview.en.md
+++ b/openbank-dispute-service/src/main/resources/docs/01-overview.en.md
@@ -52,7 +52,7 @@ A dispute carries an SLA: `resolutionDeadline = filingDate + resolution-sla-days
 
 - **admin-ui** (via Keycloak token) — operators and compliance staff managing disputes
 - **customer app / API** — opening a dispute and uploading evidence references on behalf of the cardholder
-- **service callers** (`ROLE_SERVICE`) — automated flows that open or update disputes
+- **service callers** (`ROLE_API`) — automated flows that open or update disputes
 
 ## Dependencies
 

--- a/openbank-dispute-service/src/main/resources/docs/03-api.cs.md
+++ b/openbank-dispute-service/src/main/resources/docs/03-api.cs.md
@@ -8,7 +8,7 @@ REST kontrakt je popsán v [`openapi.yaml`](../openapi.yaml) (OpenAPI **3.1.0**,
 
 - **Base path:** `/api/v1/disputes`
 - **Media type:** `application/json` (consumes & produces)
-- **Autentizace:** Bearer JWT (Keycloak OIDC). Na úrovni třídy `@RolesAllowed("ROLE_VIEWER","ROLE_OPERATOR","ROLE_ADMIN","ROLE_SERVICE")`; čtení povolují `ROLE_VIEWER`, zápisy vyžadují `ROLE_OPERATOR`/`ROLE_ADMIN`/`ROLE_SERVICE`.
+- **Autentizace:** Bearer JWT (Keycloak OIDC). Na úrovni třídy `@RolesAllowed("ROLE_VIEWER","ROLE_OPERATOR","ROLE_ADMIN","ROLE_API")`; čtení povolují `ROLE_VIEWER`, zápisy vyžadují `ROLE_OPERATOR`/`ROLE_ADMIN`/`ROLE_API`.
 
 ## Endpointy
 

--- a/openbank-dispute-service/src/main/resources/docs/03-api.en.md
+++ b/openbank-dispute-service/src/main/resources/docs/03-api.en.md
@@ -8,7 +8,7 @@ The REST contract is described in [`openapi.yaml`](../openapi.yaml) (OpenAPI **3
 
 - **Base path:** `/api/v1/disputes`
 - **Media type:** `application/json` (consumes & produces)
-- **Auth:** Bearer JWT (Keycloak OIDC). Class-level `@RolesAllowed("ROLE_VIEWER","ROLE_OPERATOR","ROLE_ADMIN","ROLE_SERVICE")`; reads allow `ROLE_VIEWER`, mutations require `ROLE_OPERATOR`/`ROLE_ADMIN`/`ROLE_SERVICE`.
+- **Auth:** Bearer JWT (Keycloak OIDC). Class-level `@RolesAllowed("ROLE_VIEWER","ROLE_OPERATOR","ROLE_ADMIN","ROLE_API")`; reads allow `ROLE_VIEWER`, mutations require `ROLE_OPERATOR`/`ROLE_ADMIN`/`ROLE_API`.
 
 ## Endpoints
 

--- a/openbank-dispute-service/src/main/resources/docs/05-operations.cs.md
+++ b/openbank-dispute-service/src/main/resources/docs/05-operations.cs.md
@@ -66,7 +66,7 @@ Nikdy needituj aplikovanou migraci. Nastav `QUARKUS_FLYWAY_REPAIR_AT_START=true`
 Migrace sekvence V3 se neaplikovala. Spusť migrace znovu / ověř, že V3 je přítomna.
 
 ### 401/403 na API
-Ověř, že bearer token pochází z realmu `openbank` a nese `ROLE_VIEWER` (čtení) nebo `ROLE_OPERATOR`/`ROLE_ADMIN`/`ROLE_SERVICE` (zápisy). Pokud bylo zapnuto vynucení OPA (`AUTHZ_ENFORCE=true`), zkontroluj rozhodovací logy OPA sidecaru.
+Ověř, že bearer token pochází z realmu `openbank` a nese `ROLE_VIEWER` (čtení) nebo `ROLE_OPERATOR`/`ROLE_ADMIN`/`ROLE_API` (zápisy). Pokud bylo zapnuto vynucení OPA (`AUTHZ_ENFORCE=true`), zkontroluj rozhodovací logy OPA sidecaru.
 
 ## Release
 

--- a/openbank-dispute-service/src/main/resources/docs/05-operations.en.md
+++ b/openbank-dispute-service/src/main/resources/docs/05-operations.en.md
@@ -66,7 +66,7 @@ Never edit an applied migration. Set `QUARKUS_FLYWAY_REPAIR_AT_START=true` in th
 The V3 sequence migration did not apply. Re-run migrations / confirm V3 is present.
 
 ### 401/403 on the API
-Confirm the bearer token comes from the `openbank` realm and carries `ROLE_VIEWER` (reads) or `ROLE_OPERATOR`/`ROLE_ADMIN`/`ROLE_SERVICE` (mutations). If OPA enforcement was flipped on (`AUTHZ_ENFORCE=true`), check the OPA sidecar decision logs.
+Confirm the bearer token comes from the `openbank` realm and carries `ROLE_VIEWER` (reads) or `ROLE_OPERATOR`/`ROLE_ADMIN`/`ROLE_API` (mutations). If OPA enforcement was flipped on (`AUTHZ_ENFORCE=true`), check the OPA sidecar decision logs.
 
 ## Release
 

--- a/openbank-dispute-service/src/main/resources/docs/README.cs.md
+++ b/openbank-dispute-service/src/main/resources/docs/README.cs.md
@@ -22,5 +22,5 @@ Tato dokumentace je publikována přímo službou na management endpointu `/q/op
 - **Perzistence:** PostgreSQL databáze `openbank_dispute`, Flyway migrace V1..V4
 - **Outbox:** tabulka `dispute_outbox` → Kafka topic `openbank.disputes.dispute.event` (kanál `dispute-events-out`)
 - **Idempotence:** `Idempotency-Key` je povolen v CORS; Redis klient je k dispozici, ale vynucení **zatím není zapojeno** (TBD) — otevření používá generovanou referenci `DSP-<epochMillis>`
-- **Autentizace:** Keycloak OIDC (realm `openbank`, klient `openbank-services`); role `ROLE_VIEWER` (čtení), `ROLE_OPERATOR`/`ROLE_ADMIN`/`ROLE_SERVICE` (zápisy); OPA/`@Authorize` poradní režim (ADR-0034)
+- **Autentizace:** Keycloak OIDC (realm `openbank`, klient `openbank-services`); role `ROLE_VIEWER` (čtení), `ROLE_OPERATOR`/`ROLE_ADMIN`/`ROLE_API` (zápisy); OPA/`@Authorize` poradní režim (ADR-0034)
 - **Money-path:** **Ne** — není uvedena v `rules.yaml: money_path_services` (1 schválení, threat model není vyžadován)

--- a/openbank-dispute-service/src/main/resources/docs/README.en.md
+++ b/openbank-dispute-service/src/main/resources/docs/README.en.md
@@ -22,5 +22,5 @@ This documentation is published directly by the service at the management endpoi
 - **Persistence:** PostgreSQL database `openbank_dispute`, Flyway migrations V1..V4
 - **Outbox:** `dispute_outbox` table → Kafka topic `openbank.disputes.dispute.event` (channel `dispute-events-out`)
 - **Idempotency:** `Idempotency-Key` accepted by CORS; a Redis client is available but enforcement is **not yet wired** (TBD) — open uses a generated `DSP-<epochMillis>` reference
-- **Auth:** Keycloak OIDC (realm `openbank`, client `openbank-services`); roles `ROLE_VIEWER` (read), `ROLE_OPERATOR`/`ROLE_ADMIN`/`ROLE_SERVICE` (mutations); OPA/`@Authorize` advisory (ADR-0034)
+- **Auth:** Keycloak OIDC (realm `openbank`, client `openbank-services`); roles `ROLE_VIEWER` (read), `ROLE_OPERATOR`/`ROLE_ADMIN`/`ROLE_API` (mutations); OPA/`@Authorize` advisory (ADR-0034)
 - **Money-path:** **No** — not listed in `rules.yaml: money_path_services` (1 approval, no threat model required)

--- a/openbank-document-service/src/main/kotlin/com/openbank/document/infrastructure/rest/DocumentResource.kt
+++ b/openbank-document-service/src/main/kotlin/com/openbank/document/infrastructure/rest/DocumentResource.kt
@@ -55,7 +55,7 @@ class DocumentResource(
      */
     @POST
     @Path("/onboarding-agreement")
-    @RolesAllowed("ROLE_SERVICE", "ROLE_OPERATOR", "ROLE_ADMIN")
+    @RolesAllowed("ROLE_API", "ROLE_OPERATOR", "ROLE_ADMIN")
     suspend fun ensureOnboardingAgreement(req: EnsureOnboardingAgreementRequest): OnboardingAgreementResponse {
         if (req.partyRef.isBlank()) throw BadRequestException("partyRef is required")
         return onboardingUseCase.ensureOnboardingAgreement(req.partyRef, req.lang).toResponse()
@@ -63,7 +63,7 @@ class DocumentResource(
 
     @POST
     @Path("/templates")
-    @RolesAllowed("ROLE_SERVICE", "ROLE_OPERATOR", "ROLE_ADMIN")
+    @RolesAllowed("ROLE_API", "ROLE_OPERATOR", "ROLE_ADMIN")
     suspend fun createTemplate(req: CreateTemplateRequest): Response {
         val template = templateUseCase.createTemplate(
             CreateTemplateCommand(
@@ -83,7 +83,7 @@ class DocumentResource(
 
     @POST
     @Path("/templates/preview")
-    @RolesAllowed("ROLE_SERVICE", "ROLE_OPERATOR", "ROLE_ADMIN")
+    @RolesAllowed("ROLE_API", "ROLE_OPERATOR", "ROLE_ADMIN")
     fun previewTemplate(req: PreviewTemplateRequest): PreviewTemplateResponse {
         if (req.bodyHtml.length > MAX_PREVIEW_BODY_LENGTH) {
             throw BadRequestException("bodyHtml exceeds the $MAX_PREVIEW_BODY_LENGTH character preview limit")
@@ -93,32 +93,32 @@ class DocumentResource(
 
     @POST
     @Path("/templates/{id}/publish")
-    @RolesAllowed("ROLE_SERVICE", "ROLE_OPERATOR", "ROLE_ADMIN")
+    @RolesAllowed("ROLE_API", "ROLE_OPERATOR", "ROLE_ADMIN")
     @Authorize(action = "documentTemplate.publish", resource = "#id")
     suspend fun publishTemplate(@PathParam("id") id: UUID) = templateUseCase.publishTemplate(id).toResponse()
 
     @POST
     @Path("/templates/{id}/retire")
-    @RolesAllowed("ROLE_SERVICE", "ROLE_OPERATOR", "ROLE_ADMIN")
+    @RolesAllowed("ROLE_API", "ROLE_OPERATOR", "ROLE_ADMIN")
     @Authorize(action = "documentTemplate.retire", resource = "#id")
     suspend fun retireTemplate(@PathParam("id") id: UUID) = templateUseCase.retireTemplate(id).toResponse()
 
     @GET
     @Path("/templates")
-    @RolesAllowed("ROLE_SERVICE", "ROLE_OPERATOR", "ROLE_ADMIN")
+    @RolesAllowed("ROLE_API", "ROLE_OPERATOR", "ROLE_ADMIN")
     suspend fun listTemplates(@QueryParam("limit") @DefaultValue("50") limit: Int) =
         templateUseCase.listTemplates(limit).map { it.toResponse() }
 
     @GET
     @Path("/templates/{id}")
-    @RolesAllowed("ROLE_SERVICE", "ROLE_OPERATOR", "ROLE_ADMIN")
+    @RolesAllowed("ROLE_API", "ROLE_OPERATOR", "ROLE_ADMIN")
     @Authorize(action = "documentTemplate.read", resource = "#id")
     suspend fun getTemplate(@PathParam("id") id: UUID) =
         templateUseCase.getTemplate(id)?.toResponse() ?: throw NotFoundException()
 
     @POST
     @Path("/render")
-    @RolesAllowed("ROLE_SERVICE", "ROLE_OPERATOR", "ROLE_ADMIN")
+    @RolesAllowed("ROLE_API", "ROLE_OPERATOR", "ROLE_ADMIN")
     suspend fun render(req: RenderDocumentRequest): Response {
         val document = renderUseCase.render(
             RenderDocumentCommand(
@@ -136,7 +136,7 @@ class DocumentResource(
     }
 
     @GET
-    @RolesAllowed("ROLE_SERVICE", "ROLE_OPERATOR", "ROLE_ADMIN")
+    @RolesAllowed("ROLE_API", "ROLE_OPERATOR", "ROLE_ADMIN")
     suspend fun listByParty(@QueryParam("partyRef") partyRef: String?): List<DocumentResponse> {
         if (partyRef.isNullOrBlank()) throw BadRequestException("partyRef query parameter is required")
         return queryUseCase.listByParty(partyRef).map { it.toResponse() }
@@ -144,7 +144,7 @@ class DocumentResource(
 
     @GET
     @Path("/{id}")
-    @RolesAllowed("ROLE_SERVICE", "ROLE_OPERATOR", "ROLE_ADMIN")
+    @RolesAllowed("ROLE_API", "ROLE_OPERATOR", "ROLE_ADMIN")
     @Authorize(action = "document.read", resource = "#id")
     suspend fun getDocument(@PathParam("id") id: UUID) =
         queryUseCase.getMetadata(id)?.toResponse() ?: throw NotFoundException()
@@ -152,7 +152,7 @@ class DocumentResource(
     @GET
     @Path("/{id}/content")
     @Produces(MediaType.APPLICATION_OCTET_STREAM)
-    @RolesAllowed("ROLE_SERVICE", "ROLE_OPERATOR", "ROLE_ADMIN")
+    @RolesAllowed("ROLE_API", "ROLE_OPERATOR", "ROLE_ADMIN")
     @Authorize(action = "document.readContent", resource = "#id")
     suspend fun getContent(@PathParam("id") id: UUID): Response {
         val bytes = queryUseCase.getContent(id) ?: throw NotFoundException()

--- a/openbank-document-service/src/main/kotlin/com/openbank/document/infrastructure/rest/SignatureCeremonyResource.kt
+++ b/openbank-document-service/src/main/kotlin/com/openbank/document/infrastructure/rest/SignatureCeremonyResource.kt
@@ -28,7 +28,7 @@ import java.util.UUID
 class SignatureCeremonyResource(private val useCase: SignatureCeremonyUseCase) {
 
     @POST
-    @RolesAllowed("ROLE_SERVICE", "ROLE_OPERATOR", "ROLE_ADMIN")
+    @RolesAllowed("ROLE_API", "ROLE_OPERATOR", "ROLE_ADMIN")
     suspend fun open(req: OpenCeremonyRequest): Response {
         val ceremony = useCase.openCeremony(
             OpenCeremonyCommand(
@@ -42,13 +42,13 @@ class SignatureCeremonyResource(private val useCase: SignatureCeremonyUseCase) {
 
     @GET
     @Path("/{id}")
-    @RolesAllowed("ROLE_SERVICE", "ROLE_OPERATOR", "ROLE_ADMIN")
+    @RolesAllowed("ROLE_API", "ROLE_OPERATOR", "ROLE_ADMIN")
     @Authorize(action = "signatureCeremony.read", resource = "#id")
     suspend fun get(@PathParam("id") id: UUID) = useCase.getCeremony(id)?.toResponse() ?: throw NotFoundException()
 
     @POST
     @Path("/{id}/decisions")
-    @RolesAllowed("ROLE_SERVICE", "ROLE_OPERATOR", "ROLE_ADMIN")
+    @RolesAllowed("ROLE_API", "ROLE_OPERATOR", "ROLE_ADMIN")
     @Authorize(action = "signatureCeremony.recordDecision", resource = "#id")
     suspend fun recordDecision(@PathParam("id") id: UUID, req: RecordDecisionRequest) =
         useCase.recordDecision(id, req.partyRef, req.decision, req.evidenceRef).toResponse()

--- a/openbank-domestic-payment/src/main/kotlin/com/openbank/domestic/infrastructure/rest/DomesticPaymentResource.kt
+++ b/openbank-domestic-payment/src/main/kotlin/com/openbank/domestic/infrastructure/rest/DomesticPaymentResource.kt
@@ -91,7 +91,7 @@ class DomesticPaymentResource(
         Response.ok(paymentUseCase.getPayment(paymentId).toResponse()).build()
 
     @GET
-    @RolesAllowed("ROLE_VIEWER", "ROLE_OPERATOR", "ROLE_ADMIN", "ROLE_PAYMENTS", "ROLE_SERVICE")
+    @RolesAllowed("ROLE_VIEWER", "ROLE_OPERATOR", "ROLE_ADMIN", "ROLE_PAYMENTS", "ROLE_API")
     @Authorize(action = "domestic-payment.list")
     @Operation(summary = "List domestic payments")
     suspend fun listPayments(

--- a/openbank-domestic-payment/src/main/resources/docs/01-overview.cs.md
+++ b/openbank-domestic-payment/src/main/resources/docs/01-overview.cs.md
@@ -51,7 +51,7 @@
 
 - **platební kanály / operátoři** (přes Keycloak token, role `ROLE_OPERATOR` / `ROLE_ADMIN` / `ROLE_PAYMENTS`) — zakládají a řídí platby.
 - **admin-ui / compliance ops** — čtou detail a seznamy plateb, ruční přechody stavu, kontrola držených plateb.
-- **další služby** (`ROLE_SERVICE`) — read-only přístup k výpisu.
+- **další služby** (`ROLE_API`) — read-only přístup k výpisu.
 
 ## Závislosti
 

--- a/openbank-domestic-payment/src/main/resources/docs/01-overview.en.md
+++ b/openbank-domestic-payment/src/main/resources/docs/01-overview.en.md
@@ -51,7 +51,7 @@
 
 - **payment channels / operators** (via Keycloak token, roles `ROLE_OPERATOR` / `ROLE_ADMIN` / `ROLE_PAYMENTS`) — create and drive payments.
 - **admin-ui / compliance ops** — read payment detail and lists, manual status transitions, review held payments.
-- **other services** (`ROLE_SERVICE`) — read-only list access.
+- **other services** (`ROLE_API`) — read-only list access.
 
 ## Dependencies
 

--- a/openbank-domestic-payment/src/main/resources/docs/03-api.cs.md
+++ b/openbank-domestic-payment/src/main/resources/docs/03-api.cs.md
@@ -16,7 +16,7 @@ Všechny endpointy vyžadují **Keycloak Bearer token** (realm `openbank`, RS256
 |---|---|
 | `POST /domestic-payments` | `ROLE_OPERATOR`, `ROLE_ADMIN`, `ROLE_PAYMENTS` |
 | `GET /domestic-payments/{paymentId}` | `ROLE_VIEWER`, `ROLE_OPERATOR`, `ROLE_ADMIN`, `ROLE_PAYMENTS` |
-| `GET /domestic-payments` | `ROLE_VIEWER`, `ROLE_OPERATOR`, `ROLE_ADMIN`, `ROLE_PAYMENTS`, `ROLE_SERVICE` |
+| `GET /domestic-payments` | `ROLE_VIEWER`, `ROLE_OPERATOR`, `ROLE_ADMIN`, `ROLE_PAYMENTS`, `ROLE_API` |
 | `PATCH /domestic-payments/{paymentId}/status` | `ROLE_OPERATOR`, `ROLE_ADMIN`, `ROLE_PAYMENTS` + `@Authorize(action="domesticPayment.transitionStatus")` (OPA, ADR-0034) |
 
 OIDC je vypnuté pouze v profilech `%dev` a `%test`.

--- a/openbank-domestic-payment/src/main/resources/docs/03-api.en.md
+++ b/openbank-domestic-payment/src/main/resources/docs/03-api.en.md
@@ -16,7 +16,7 @@ All endpoints require a **Keycloak Bearer token** (realm `openbank`, RS256 JWT).
 |---|---|
 | `POST /domestic-payments` | `ROLE_OPERATOR`, `ROLE_ADMIN`, `ROLE_PAYMENTS` |
 | `GET /domestic-payments/{paymentId}` | `ROLE_VIEWER`, `ROLE_OPERATOR`, `ROLE_ADMIN`, `ROLE_PAYMENTS` |
-| `GET /domestic-payments` | `ROLE_VIEWER`, `ROLE_OPERATOR`, `ROLE_ADMIN`, `ROLE_PAYMENTS`, `ROLE_SERVICE` |
+| `GET /domestic-payments` | `ROLE_VIEWER`, `ROLE_OPERATOR`, `ROLE_ADMIN`, `ROLE_PAYMENTS`, `ROLE_API` |
 | `PATCH /domestic-payments/{paymentId}/status` | `ROLE_OPERATOR`, `ROLE_ADMIN`, `ROLE_PAYMENTS` + `@Authorize(action="domesticPayment.transitionStatus")` (OPA, ADR-0034) |
 
 OIDC is disabled only in `%dev` and `%test` profiles.

--- a/openbank-finrep-service/src/main/kotlin/com/openbank/finrep/infrastructure/rest/FinrepResource.kt
+++ b/openbank-finrep-service/src/main/kotlin/com/openbank/finrep/infrastructure/rest/FinrepResource.kt
@@ -28,10 +28,12 @@ import java.time.LocalDate
  * Roles come from [Roles], never string literals: this class shipped with
  * `@RolesAllowed("SERVICE", "ADMIN", "OPERATOR")` and the Keycloak realm issues no role by any of
  * those three names (it issues `ROLE_ADMIN`, `ROLE_OPERATOR`, …), so every authenticated request
- * to this resource was rejected 403 for every caller. `ROLE_SERVICE` is deliberately NOT in the
- * replacement set: it exists as a [Roles] constant but is granted to no realm client, so listing
- * it would re-add a dead entry that reads like an M2M grant. The only caller is the admin-UI BFF
- * (see the finrep-service ingress allow-list), whose operators carry ROLE_ADMIN / ROLE_OPERATOR.
+ * to this resource was rejected 403 for every caller (#2403).
+ *
+ * No M2M grant here on purpose. [Roles.API] is now a real, granted role (#2442), so adding it
+ * would genuinely open FINREP/COREP to every service-account token — the only caller is the
+ * admin-UI BFF (see the finrep-service ingress allow-list), whose operators carry ROLE_ADMIN /
+ * ROLE_OPERATOR. Widening this is a decision, not a rename.
  */
 @ApplicationScoped
 @Path("/api/v1/finrep")

--- a/openbank-fraud-service/src/main/kotlin/com/openbank/fraud/infrastructure/rest/FraudResource.kt
+++ b/openbank-fraud-service/src/main/kotlin/com/openbank/fraud/infrastructure/rest/FraudResource.kt
@@ -37,7 +37,7 @@ class FraudResource {
      */
     @POST
     @Path("/score")
-    @RolesAllowed("ROLE_SERVICE", "ROLE_OPERATOR", "ROLE_ADMIN")
+    @RolesAllowed("ROLE_API", "ROLE_OPERATOR", "ROLE_ADMIN")
     @Authorize(action = "fraud.score")
     @Operation(summary = "Score a payment intent and return a fraud verdict (ALLOW/CHALLENGE/REVIEW/DECLINE)")
     suspend fun score(req: ScoreFraudRequest): Response {

--- a/openbank-fraud-service/src/test/kotlin/com/openbank/fraud/contract/FraudPactFolderProviderVerificationTest.kt
+++ b/openbank-fraud-service/src/test/kotlin/com/openbank/fraud/contract/FraudPactFolderProviderVerificationTest.kt
@@ -52,7 +52,7 @@ import org.junit.jupiter.api.extension.ExtendWith
  */
 @QuarkusTest
 @QuarkusTestResource(com.openbank.fraud.it.PostgresRedisTestResource::class)
-@TestSecurity(user = "pact-verifier", roles = ["ROLE_SERVICE", "ROLE_OPERATOR"])
+@TestSecurity(user = "pact-verifier", roles = ["ROLE_API", "ROLE_OPERATOR"])
 @Provider("openbank-fraud-service")
 @PactFolder("../pacts")
 @IgnoreNoPactsToVerify(ignoreIoErrors = "true")

--- a/openbank-fraud-service/src/test/kotlin/com/openbank/fraud/contract/FraudPactProviderVerificationTest.kt
+++ b/openbank-fraud-service/src/test/kotlin/com/openbank/fraud/contract/FraudPactProviderVerificationTest.kt
@@ -49,7 +49,7 @@ import org.junit.jupiter.api.extension.ExtendWith
  */
 @QuarkusTest
 @QuarkusTestResource(com.openbank.fraud.it.PostgresRedisTestResource::class)
-@TestSecurity(user = "pact-verifier", roles = ["ROLE_SERVICE", "ROLE_OPERATOR"])
+@TestSecurity(user = "pact-verifier", roles = ["ROLE_API", "ROLE_OPERATOR"])
 @Provider("openbank-fraud-service")
 @PactBroker(enablePendingPacts = "true")
 @IgnoreNoPactsToVerify(ignoreIoErrors = "true")

--- a/openbank-fraud-service/src/test/kotlin/com/openbank/fraud/infrastructure/rest/FraudResourceAuthzTest.kt
+++ b/openbank-fraud-service/src/test/kotlin/com/openbank/fraud/infrastructure/rest/FraudResourceAuthzTest.kt
@@ -43,7 +43,7 @@ class FraudResourceAuthzTest {
     }
 
     @Test
-    @TestSecurity(user = "fx-service", roles = ["ROLE_SERVICE"])
+    @TestSecurity(user = "fx-service", roles = ["ROLE_API"])
     fun `advisory mode does not block the M2M scoring path`() {
         // The fx-service shadow-scoring shape (FraudScoreClient) — the exact M2M call the
         // service-fraud-scoring ext-policy rule grants once AUTHZ_ENFORCE flips.

--- a/openbank-fraud-service/src/test/kotlin/com/openbank/fraud/integration/FraudApiIT.kt
+++ b/openbank-fraud-service/src/test/kotlin/com/openbank/fraud/integration/FraudApiIT.kt
@@ -30,7 +30,7 @@ class FraudApiIT {
     }
 
     @Test
-    @TestSecurity(user = "00000000-0000-0000-0000-000000000099", roles = ["ROLE_SERVICE"])
+    @TestSecurity(user = "00000000-0000-0000-0000-000000000099", roles = ["ROLE_API"])
     fun `POST score returns the baseline ALLOW verdict`() {
         val payload = """
             {

--- a/openbank-fx-service/src/test/kotlin/com/openbank/fx/contract/FxPactProviderVerificationTest.kt
+++ b/openbank-fx-service/src/test/kotlin/com/openbank/fx/contract/FxPactProviderVerificationTest.kt
@@ -42,11 +42,13 @@ import java.util.concurrent.TimeUnit
  * (ADR-0063 P2 Batch B). Seeds an EUR/CZK SPOT rate so that GET /api/v1/fx/rates/EUR/CZK
  * returns 200 with the expected shape. `@TestSecurity` must grant a role the endpoint's
  * `@RolesAllowed("ROLE_VIEWER", "ROLE_OPERATOR", "ROLE_ADMIN", "ROLE_PAYMENTS")` actually
- * accepts — `ROLE_SERVICE` is not in that list and, per the Keycloak realm config
- * (`openbank-realm.json` / `realm-template.json`), isn't even a realm role any real client
- * is ever granted. The real M2M caller (transaction-service, via the shared
- * `openbank-services` client) authenticates as `service-account-openbank-services`, whose
- * realmRoles is `["ROLE_OPERATOR"]` — that's the role this test must present too, or every
+ * accepts — the M2M role is not in that list. Since #2442 that role is `ROLE_API`, granted to
+ * `service-account-openbank-services` in both realms; before it, the name in use here was
+ * `ROLE_SERVICE`, which no realm declared at all. Either way this endpoint does not admit the
+ * M2M principal, so the test must present an operator-grade role: the real M2M caller
+ * (transaction-service, via the shared `openbank-services` client) authenticates as
+ * `service-account-openbank-services`, which also carries `ROLE_OPERATOR` in the dev realm —
+ * that's the role this test presents, or every
  * verification 403s before reaching the resource method (confirmed live: verification result
  * #2247, 2026-07-11, and broken since this test was added on 2026-07-02 without ever being
  * noticed locally, since it's `@EnabledIfSystemProperty(pactbroker.url)`-skipped without a

--- a/openbank-infra/docker/keycloak/realm/openbank-realm.json
+++ b/openbank-infra/docker/keycloak/realm/openbank-realm.json
@@ -152,7 +152,8 @@
       "enabled": true,
       "serviceAccountClientId": "openbank-services",
       "realmRoles": [
-        "ROLE_OPERATOR"
+        "ROLE_OPERATOR",
+        "ROLE_API"
       ]
     }
   ]

--- a/openbank-infra/gitops/components/keycloak/realm-template.json
+++ b/openbank-infra/gitops/components/keycloak/realm-template.json
@@ -69,6 +69,14 @@
       {
         "name": "ROLE_PAYMENTS",
         "description": "Payment ops: initiation, recall, return, clearing reconciliation"
+      },
+      {
+        "name": "ROLE_CREDIT_RISK",
+        "description": "Credit-risk officer: takes the credit decision on a loan application (openbank-lending-service). Declared in @RolesAllowed since the service shipped; created here by issue #2442"
+      },
+      {
+        "name": "ROLE_LENDING_OFFICER",
+        "description": "Lending officer: opens and services loan applications, cannot take the credit decision (four-eyes with ROLE_CREDIT_RISK). Declared in @RolesAllowed since the service shipped; created here by issue #2442"
       }
     ]
   },
@@ -326,6 +334,14 @@
       "serviceAccountClientId": "openbank-edge",
       "realmRoles": [
         "ROLE_OPERATOR"
+      ]
+    },
+    {
+      "username": "service-account-openbank-services",
+      "enabled": true,
+      "serviceAccountClientId": "openbank-services",
+      "realmRoles": [
+        "ROLE_API"
       ]
     }
   ]

--- a/openbank-interest-service/src/main/kotlin/com/openbank/interest/infrastructure/client/AccountServiceClient.kt
+++ b/openbank-interest-service/src/main/kotlin/com/openbank/interest/infrastructure/client/AccountServiceClient.kt
@@ -22,7 +22,7 @@ import java.util.UUID
 /**
  * REST client for `openbank-account-service`, used by the daily accrual run to discover accounts
  * and read balances. OIDC service-to-service auth is attached by [OidcClientRequestReactiveFilter]
- * (the `openbank-services` M2M token, ROLE_SERVICE — the same principal billing-service uses for
+ * (the `openbank-services` M2M token, ROLE_API — the same principal billing-service uses for
  * these exact endpoints, so no new OPA policy is required).
  */
 @RegisterRestClient(configKey = "account-service")

--- a/openbank-interest-service/src/main/kotlin/com/openbank/interest/infrastructure/rest/InterestResource.kt
+++ b/openbank-interest-service/src/main/kotlin/com/openbank/interest/infrastructure/rest/InterestResource.kt
@@ -40,7 +40,7 @@ import java.util.UUID
 @Produces(MediaType.APPLICATION_JSON)
 @Consumes(MediaType.APPLICATION_JSON)
 @Tag(name = "Interest", description = "Interest accrual and capitalization")
-@RolesAllowed("ROLE_VIEWER", "ROLE_OPERATOR", "ROLE_ADMIN", "ROLE_SERVICE")
+@RolesAllowed("ROLE_VIEWER", "ROLE_OPERATOR", "ROLE_ADMIN", "ROLE_API")
 class InterestResource(
     private val accrueUseCase: AccrueInterestUseCase,
     private val capitalizeUseCase: CapitalizeInterestUseCase,
@@ -64,7 +64,7 @@ class InterestResource(
     @POST
     @Path("/accrue")
     @Operation(summary = "Accrue interest for an account")
-    @RolesAllowed("ROLE_OPERATOR", "ROLE_ADMIN", "ROLE_SERVICE")
+    @RolesAllowed("ROLE_OPERATOR", "ROLE_ADMIN", "ROLE_API")
     @Authorize(action = "interest.create", resource = "")
     fun accrue(request: AccrualRequest): Uni<Response> = accrueUseCase.accrue(request)
         .map { Response.status(201).entity(it).build() }
@@ -77,7 +77,7 @@ class InterestResource(
     @POST
     @Path("/accrue/all")
     @Operation(summary = "Trigger daily accrual for all accounts")
-    @RolesAllowed("ROLE_OPERATOR", "ROLE_ADMIN", "ROLE_SERVICE")
+    @RolesAllowed("ROLE_OPERATOR", "ROLE_ADMIN", "ROLE_API")
     @Authorize(action = "interest.trigger", resource = "")
     fun accrueAll(@QueryParam("date") date: String?): Uni<Response> =
         accrueUseCase.accrueAll(date?.let { LocalDate.parse(it) } ?: LocalDate.now(clock))
@@ -86,7 +86,7 @@ class InterestResource(
     @POST
     @Path("/capitalize/{accountId}")
     @Operation(summary = "Capitalize accrued interest for an account")
-    @RolesAllowed("ROLE_OPERATOR", "ROLE_ADMIN", "ROLE_SERVICE")
+    @RolesAllowed("ROLE_OPERATOR", "ROLE_ADMIN", "ROLE_API")
     @Authorize(action = "interest.create", resource = "#accountId")
     fun capitalize(
         @PathParam("accountId") accountId: UUID,
@@ -132,7 +132,7 @@ class InterestResource(
     @POST
     @Path("/rates")
     @Operation(summary = "Create interest rate configuration")
-    @RolesAllowed("ROLE_OPERATOR", "ROLE_ADMIN", "ROLE_SERVICE")
+    @RolesAllowed("ROLE_OPERATOR", "ROLE_ADMIN", "ROLE_API")
     @Authorize(action = "interest.create", resource = "")
     fun createRateConfig(config: InterestRateConfig): Uni<Response> = rateConfigUseCase.createConfig(config)
         .map { Response.status(201).entity(it).build() }
@@ -168,7 +168,7 @@ class InterestResource(
     @DELETE
     @Path("/rates/{id}")
     @Operation(summary = "Deactivate interest rate configuration")
-    @RolesAllowed("ROLE_OPERATOR", "ROLE_ADMIN", "ROLE_SERVICE")
+    @RolesAllowed("ROLE_OPERATOR", "ROLE_ADMIN", "ROLE_API")
     @Authorize(action = "interest.delete", resource = "#id")
     fun deactivateRateConfig(@PathParam("id") id: UUID): Uni<Response> = rateConfigUseCase.deactivateConfig(id)
         .map { Response.ok(it).build() }

--- a/openbank-interest-service/src/main/kotlin/com/openbank/interest/infrastructure/rest/WithholdingRemittanceResource.kt
+++ b/openbank-interest-service/src/main/kotlin/com/openbank/interest/infrastructure/rest/WithholdingRemittanceResource.kt
@@ -26,10 +26,10 @@ import org.eclipse.microprofile.openapi.annotations.tags.Tag
 @Path("/api/v1/interest/withholding/remittances")
 @Produces(MediaType.APPLICATION_JSON)
 @Tag(name = "Withholding remittance", description = "Monthly withholding-tax remittance (§38d ZDP)")
-@RolesAllowed("ROLE_VIEWER", "ROLE_OPERATOR", "ROLE_ADMIN", "ROLE_AUDITOR", "ROLE_SERVICE")
+@RolesAllowed("ROLE_VIEWER", "ROLE_OPERATOR", "ROLE_ADMIN", "ROLE_AUDITOR", "ROLE_API")
 class WithholdingRemittanceResource(private val remitUseCase: RemitWithholdingUseCase) {
     @POST
-    @RolesAllowed("ROLE_OPERATOR", "ROLE_ADMIN", "ROLE_SERVICE")
+    @RolesAllowed("ROLE_OPERATOR", "ROLE_ADMIN", "ROLE_API")
     @Authorize(action = "interest.create", resource = "")
     @Operation(summary = "Assemble (or return) the monthly withholding remittance for a tax period")
     fun assemble(@QueryParam("year") year: Int, @QueryParam("month") month: Int): Uni<Response> =

--- a/openbank-interest-service/src/main/resources/docs/01-overview.cs.md
+++ b/openbank-interest-service/src/main/resources/docs/01-overview.cs.md
@@ -53,7 +53,7 @@
 
 - **admin-ui** (přes Keycloak token) — operátoři konfigurují sazby, spouští accrual/kapitalizaci a sestavují odvody.
 - **scheduler** (interní Quarkus `@Scheduled`) — denní accrual cron `0 0 1 * * ?` a měsíční kapitalizační cron `0 0 2 1 * ?`.
-- **servisní volající** (`ROLE_SERVICE`) — dávkové / orchestrační spouštěče.
+- **servisní volající** (`ROLE_API`) — dávkové / orchestrační spouštěče.
 
 ## Závislosti
 

--- a/openbank-interest-service/src/main/resources/docs/01-overview.en.md
+++ b/openbank-interest-service/src/main/resources/docs/01-overview.en.md
@@ -53,7 +53,7 @@
 
 - **admin-ui** (via Keycloak token) — operators configure rates, trigger accrual/capitalization, and assemble remittances.
 - **scheduler** (internal Quarkus `@Scheduled`) — daily accrual cron `0 0 1 * * ?` and monthly capitalization cron `0 0 2 1 * ?`.
-- **service callers** (`ROLE_SERVICE`) — batch / orchestration triggers.
+- **service callers** (`ROLE_API`) — batch / orchestration triggers.
 
 ## Dependencies
 

--- a/openbank-interest-service/src/main/resources/docs/03-api.cs.md
+++ b/openbank-interest-service/src/main/resources/docs/03-api.cs.md
@@ -16,8 +16,8 @@ Všechny endpointy vyžadují **Keycloak Bearer token** (realm `openbank`). Role
 
 | Třída operace | Povolené role |
 |---|---|
-| Čtení (`GET` accrualy, souhrn, kapitalizace, sazby, odvody) | `ROLE_VIEWER`, `ROLE_OPERATOR`, `ROLE_ADMIN`, `ROLE_SERVICE` (odvody navíc `ROLE_AUDITOR`) |
-| Mutace (`POST` accrue, capitalize, rates, remittances; `DELETE` rate) | `ROLE_OPERATOR`, `ROLE_ADMIN`, `ROLE_SERVICE` |
+| Čtení (`GET` accrualy, souhrn, kapitalizace, sazby, odvody) | `ROLE_VIEWER`, `ROLE_OPERATOR`, `ROLE_ADMIN`, `ROLE_API` (odvody navíc `ROLE_AUDITOR`) |
+| Mutace (`POST` accrue, capitalize, rates, remittances; `DELETE` rate) | `ROLE_OPERATOR`, `ROLE_ADMIN`, `ROLE_API` |
 
 ## Idempotence
 

--- a/openbank-interest-service/src/main/resources/docs/03-api.en.md
+++ b/openbank-interest-service/src/main/resources/docs/03-api.en.md
@@ -16,8 +16,8 @@ All endpoints require a **Keycloak Bearer token** (realm `openbank`). Roles are 
 
 | Operation class | Allowed roles |
 |---|---|
-| Reads (`GET` accruals, summary, capitalizations, rates, remittances) | `ROLE_VIEWER`, `ROLE_OPERATOR`, `ROLE_ADMIN`, `ROLE_SERVICE` (remittances also `ROLE_AUDITOR`) |
-| Mutations (`POST` accrue, capitalize, rates, remittances; `DELETE` rate) | `ROLE_OPERATOR`, `ROLE_ADMIN`, `ROLE_SERVICE` |
+| Reads (`GET` accruals, summary, capitalizations, rates, remittances) | `ROLE_VIEWER`, `ROLE_OPERATOR`, `ROLE_ADMIN`, `ROLE_API` (remittances also `ROLE_AUDITOR`) |
+| Mutations (`POST` accrue, capitalize, rates, remittances; `DELETE` rate) | `ROLE_OPERATOR`, `ROLE_ADMIN`, `ROLE_API` |
 
 ## Idempotence
 

--- a/openbank-interest-service/src/main/resources/docs/README.cs.md
+++ b/openbank-interest-service/src/main/resources/docs/README.cs.md
@@ -22,7 +22,7 @@ Tuto dokumentaci publikuje služba přímo na management endpointu `/q/openbank/
 - **Persistence:** dedikovaná PostgreSQL databáze `openbank_interest`, Flyway migrace V1..V5
 - **Outbox:** `interest_outbox` → Kafka topic `openbank.interest.accrual.event` (události `interest.withholding.recorded.v1`, `interest.withholding.remitted.v1`)
 - **Idempotence:** mutace ve v1 nejsou hlídány hlavičkou `Idempotency-Key`; sestavení odvodu je idempotentní podle `(year, month)` (jeden batch na zdaňovací období)
-- **Auth:** Keycloak OIDC; čtení vyžaduje `ROLE_VIEWER`/`ROLE_OPERATOR`/`ROLE_ADMIN`/`ROLE_SERVICE`, mutace vyžadují `ROLE_OPERATOR`/`ROLE_ADMIN`/`ROLE_SERVICE`
+- **Auth:** Keycloak OIDC; čtení vyžaduje `ROLE_VIEWER`/`ROLE_OPERATOR`/`ROLE_ADMIN`/`ROLE_API`, mutace vyžadují `ROLE_OPERATOR`/`ROLE_ADMIN`/`ROLE_API`
 - **Daň:** česká srážková daň z CZK úrokového výnosu (15 % rezident fyzická osoba; 35 % nespolupracující stát; smluvní sazba; právnické osoby se nesráží) — ADR-0033
 - **Money path:** **Ne** — `interest-service` není v `rules.yaml: money_path_services` (nepřesouvá hotovost; peněžní část je delegována)
 - **Release verze:** viz `version.txt` (v době psaní 0.3.0); **verze API kontraktu** `1.2.0` ⇒ URL `/api/v1` (ADR-0048)

--- a/openbank-interest-service/src/main/resources/docs/README.en.md
+++ b/openbank-interest-service/src/main/resources/docs/README.en.md
@@ -22,7 +22,7 @@ This documentation is published directly by the service at the management endpoi
 - **Persistence:** dedicated PostgreSQL database `openbank_interest`, Flyway migrations V1..V5
 - **Outbox:** `interest_outbox` → Kafka topic `openbank.interest.accrual.event` (events `interest.withholding.recorded.v1`, `interest.withholding.remitted.v1`)
 - **Idempotency:** mutations are not `Idempotency-Key`-gated in v1; the remittance assembly is idempotent by `(year, month)` (one batch per tax period)
-- **Auth:** Keycloak OIDC; reads require `ROLE_VIEWER`/`ROLE_OPERATOR`/`ROLE_ADMIN`/`ROLE_SERVICE`, mutations require `ROLE_OPERATOR`/`ROLE_ADMIN`/`ROLE_SERVICE`
+- **Auth:** Keycloak OIDC; reads require `ROLE_VIEWER`/`ROLE_OPERATOR`/`ROLE_ADMIN`/`ROLE_API`, mutations require `ROLE_OPERATOR`/`ROLE_ADMIN`/`ROLE_API`
 - **Tax:** Czech final withholding on CZK credit interest (15 % resident individual; 35 % non-cooperating state; treaty rate; legal entities not withheld) — ADR-0033
 - **Money path:** **No** — `interest-service` is not in `rules.yaml: money_path_services` (it moves no cash; the cash leg is delegated)
 - **Release version:** see `version.txt` (0.3.0 at time of writing); **API contract version** `1.2.0` ⇒ URL `/api/v1` (ADR-0048)

--- a/openbank-kyc-service/src/main/kotlin/com/openbank/kyc/infrastructure/rest/KycResource.kt
+++ b/openbank-kyc-service/src/main/kotlin/com/openbank/kyc/infrastructure/rest/KycResource.kt
@@ -59,7 +59,7 @@ class KycResource {
         Roles.KYC_OPENER,
         Roles.KYC_REVIEWER,
         Roles.COMPLIANCE,
-        Roles.SERVICE,
+        Roles.API,
     )
     @Operation(
         summary = "List KYC cases. Optional ?status= filter for the onboarding cockpit funnel (ADR-0068).",
@@ -102,7 +102,7 @@ class KycResource {
         Roles.KYC_OPENER,
         Roles.KYC_REVIEWER,
         Roles.COMPLIANCE,
-        Roles.SERVICE,
+        Roles.API,
     )
     @Operation(summary = "Get KYC case by ID")
     suspend fun getCase(@PathParam("id") id: UUID): Response = Response.ok(kycService.getCase(id)).build()
@@ -117,7 +117,7 @@ class KycResource {
         Roles.KYC_OPENER,
         Roles.KYC_REVIEWER,
         Roles.COMPLIANCE,
-        Roles.SERVICE,
+        Roles.API,
     )
     @Operation(summary = "Get latest KYC case for a party")
     suspend fun getCaseByParty(@PathParam("partyId") partyId: UUID): Response {

--- a/openbank-kyc-service/src/main/resources/docs/01-overview.cs.md
+++ b/openbank-kyc-service/src/main/resources/docs/01-overview.cs.md
@@ -54,7 +54,7 @@ Případ otevírá buď operátor (`POST /api/v1/kyc/cases`), nebo se otevře au
 - **admin-ui** (přes Keycloak token) — KYC pracovníci, compliance ops, funnel onboarding cockpitu (ADR-0068)
 - **party-service** (události) — upstream producent `PARTY_CREATED`; downstream konzument schválení pro aktivaci
 - **aml-service / sanctions-service** — konzumují KYC události pro spuštění nebo korelaci screeningu
-- **service-to-service čtenáři** (`ROLE_SERVICE`) — čtou KYC stav party během onboardingu
+- **service-to-service čtenáři** (`ROLE_API`) — čtou KYC stav party během onboardingu
 
 ## Závislosti
 

--- a/openbank-kyc-service/src/main/resources/docs/01-overview.en.md
+++ b/openbank-kyc-service/src/main/resources/docs/01-overview.en.md
@@ -54,7 +54,7 @@ A case is opened either by an operator (`POST /api/v1/kyc/cases`) or automatical
 - **admin-ui** (via Keycloak token) — KYC officers, compliance ops, the onboarding cockpit funnel (ADR-0068)
 - **party-service** (events) — upstream producer of `PARTY_CREATED`; downstream consumer of approval for activation
 - **aml-service / sanctions-service** — consume KYC events to trigger or correlate screening
-- **service-to-service readers** (`ROLE_SERVICE`) — read a party's KYC status during onboarding
+- **service-to-service readers** (`ROLE_API`) — read a party's KYC status during onboarding
 
 ## Dependencies
 

--- a/openbank-kyc-service/src/main/resources/docs/03-api.cs.md
+++ b/openbank-kyc-service/src/main/resources/docs/03-api.cs.md
@@ -8,7 +8,7 @@ REST kontrakt je popsán v [`openapi.yaml`](../openapi.yaml) (`info.version: 1.1
 
 | Metoda | Cesta | Role | Účel |
 |---|---|---|---|
-| `GET` | `/api/v1/kyc/cases?page=&size=&status=` | `ROLE_VIEWER`,`ROLE_OPERATOR`,`ROLE_ADMIN`,`ROLE_KYC`,`ROLE_COMPLIANCE`,`ROLE_SERVICE` | Stránkovaný výpis; volitelný `status` filtr funnelu (ADR-0068) |
+| `GET` | `/api/v1/kyc/cases?page=&size=&status=` | `ROLE_VIEWER`,`ROLE_OPERATOR`,`ROLE_ADMIN`,`ROLE_KYC`,`ROLE_COMPLIANCE`,`ROLE_API` | Stránkovaný výpis; volitelný `status` filtr funnelu (ADR-0068) |
 | `POST` | `/api/v1/kyc/cases` | `ROLE_OPERATOR`,`ROLE_ADMIN`,`ROLE_KYC` | Otevření nového případu pro party |
 | `GET` | `/api/v1/kyc/cases/{id}` | viewer/operator/admin/kyc/compliance/service | Načtení případu podle id |
 | `GET` | `/api/v1/kyc/cases/party/{partyId}` | viewer/operator/admin/kyc/compliance/service | Načtení posledního případu pro party (404 pokud žádný) |

--- a/openbank-kyc-service/src/main/resources/docs/03-api.en.md
+++ b/openbank-kyc-service/src/main/resources/docs/03-api.en.md
@@ -8,7 +8,7 @@ The REST contract is described in [`openapi.yaml`](../openapi.yaml) (`info.versi
 
 | Method | Path | Roles | Purpose |
 |---|---|---|---|
-| `GET` | `/api/v1/kyc/cases?page=&size=&status=` | `ROLE_VIEWER`,`ROLE_OPERATOR`,`ROLE_ADMIN`,`ROLE_KYC`,`ROLE_COMPLIANCE`,`ROLE_SERVICE` | Paginated list; optional `status` funnel filter (ADR-0068) |
+| `GET` | `/api/v1/kyc/cases?page=&size=&status=` | `ROLE_VIEWER`,`ROLE_OPERATOR`,`ROLE_ADMIN`,`ROLE_KYC`,`ROLE_COMPLIANCE`,`ROLE_API` | Paginated list; optional `status` funnel filter (ADR-0068) |
 | `POST` | `/api/v1/kyc/cases` | `ROLE_OPERATOR`,`ROLE_ADMIN`,`ROLE_KYC` | Open a new case for a party |
 | `GET` | `/api/v1/kyc/cases/{id}` | viewer/operator/admin/kyc/compliance/service | Get case by id |
 | `GET` | `/api/v1/kyc/cases/party/{partyId}` | viewer/operator/admin/kyc/compliance/service | Get latest case for a party (404 if none) |

--- a/openbank-ledger-service/src/main/kotlin/com/openbank/ledger/infrastructure/rest/ControlAccountResource.kt
+++ b/openbank-ledger-service/src/main/kotlin/com/openbank/ledger/infrastructure/rest/ControlAccountResource.kt
@@ -39,7 +39,7 @@ class ControlAccountResource(private val clock: Clock, private val ledgerUseCase
      */
     @GET
     @Path("/{controlAccountId}/tie-out")
-    @RolesAllowed(Roles.SERVICE, Roles.AUDITOR, Roles.OPERATOR, Roles.ADMIN)
+    @RolesAllowed(Roles.API, Roles.AUDITOR, Roles.OPERATOR, Roles.ADMIN)
     @Authorize(action = "ledger.read", resource = "#controlAccountId")
     @Operation(summary = "Sub-ledger tie-out for a deposit-control GL account (ADR-0039 Phase B)")
     suspend fun controlAccountTieOut(

--- a/openbank-ledger-service/src/main/kotlin/com/openbank/ledger/infrastructure/rest/LedgerResource.kt
+++ b/openbank-ledger-service/src/main/kotlin/com/openbank/ledger/infrastructure/rest/LedgerResource.kt
@@ -62,7 +62,7 @@ class LedgerResource(
 ) {
 
     @GET
-    @RolesAllowed(Roles.SERVICE, Roles.AUDITOR, Roles.VIEWER, Roles.OPERATOR, Roles.ADMIN)
+    @RolesAllowed(Roles.API, Roles.AUDITOR, Roles.VIEWER, Roles.OPERATOR, Roles.ADMIN)
     @Authorize(action = "ledger.list", resource = "")
     @Operation(summary = "List journal entries")
     suspend fun listJournals(
@@ -79,7 +79,7 @@ class LedgerResource(
 
     @GET
     @Path("/trial-balance")
-    @RolesAllowed(Roles.SERVICE, Roles.AUDITOR, Roles.VIEWER, Roles.OPERATOR, Roles.ADMIN)
+    @RolesAllowed(Roles.API, Roles.AUDITOR, Roles.VIEWER, Roles.OPERATOR, Roles.ADMIN)
     @Authorize(action = "ledger.read", resource = "")
     @Operation(summary = "Trial balance — debit/credit totals per GL account (must net to zero)")
     suspend fun trialBalance(@QueryParam("asOf") asOf: String?): Response {
@@ -90,7 +90,7 @@ class LedgerResource(
 
     @GET
     @Path("/sub-ledger-balances")
-    @RolesAllowed(Roles.SERVICE, Roles.AUDITOR, Roles.VIEWER, Roles.OPERATOR, Roles.ADMIN)
+    @RolesAllowed(Roles.API, Roles.AUDITOR, Roles.VIEWER, Roles.OPERATOR, Roles.ADMIN)
     @Authorize(action = "ledger.read", resource = "")
     @Operation(summary = "Per-customer deposit-control sub-ledger balances (ADR-0039 Phase B)")
     suspend fun subLedgerBalances(
@@ -108,7 +108,7 @@ class LedgerResource(
 
     @GET
     @Path("/{journalId}")
-    @RolesAllowed(Roles.SERVICE, Roles.AUDITOR, Roles.VIEWER, Roles.OPERATOR, Roles.ADMIN)
+    @RolesAllowed(Roles.API, Roles.AUDITOR, Roles.VIEWER, Roles.OPERATOR, Roles.ADMIN)
     @Authorize(action = "ledger.read", resource = "#journalId")
     @Operation(summary = "Get journal entry by ID")
     suspend fun getJournal(@PathParam("journalId") journalId: UUID): Response {
@@ -118,7 +118,7 @@ class LedgerResource(
 
     @GET
     @Path("/transaction/{transactionId}")
-    @RolesAllowed(Roles.SERVICE, Roles.AUDITOR, Roles.VIEWER, Roles.OPERATOR, Roles.ADMIN)
+    @RolesAllowed(Roles.API, Roles.AUDITOR, Roles.VIEWER, Roles.OPERATOR, Roles.ADMIN)
     @Authorize(action = "ledger.read", resource = "#transactionId")
     @Operation(summary = "Get journal entries by transaction ID")
     suspend fun getJournalsByTransaction(@PathParam("transactionId") transactionId: UUID): Response {

--- a/openbank-ledger-service/src/main/kotlin/com/openbank/ledger/infrastructure/rest/YearCloseResource.kt
+++ b/openbank-ledger-service/src/main/kotlin/com/openbank/ledger/infrastructure/rest/YearCloseResource.kt
@@ -56,7 +56,7 @@ class YearCloseResource(private val yearCloseUseCase: YearCloseUseCase) {
 
     @GET
     @Path("/trial-balance")
-    @RolesAllowed(Roles.SERVICE, Roles.AUDITOR, Roles.VIEWER, Roles.OPERATOR, Roles.ADMIN)
+    @RolesAllowed(Roles.API, Roles.AUDITOR, Roles.VIEWER, Roles.OPERATOR, Roles.ADMIN)
     @Authorize(action = "ledger.read", resource = "")
     @Operation(summary = "Fiscal-year GL trial balance, grouped by account type (computed on demand)")
     suspend fun trialBalance(@QueryParam("fiscalYear") fiscalYear: Int?): Response {
@@ -68,7 +68,7 @@ class YearCloseResource(private val yearCloseUseCase: YearCloseUseCase) {
 
     @GET
     @Path("/{fiscalYear}")
-    @RolesAllowed(Roles.SERVICE, Roles.AUDITOR, Roles.VIEWER, Roles.OPERATOR, Roles.ADMIN)
+    @RolesAllowed(Roles.API, Roles.AUDITOR, Roles.VIEWER, Roles.OPERATOR, Roles.ADMIN)
     @Authorize(action = "ledger.read", resource = "#fiscalYear")
     @Operation(summary = "Get the year-close record for a fiscal year")
     suspend fun getYearClose(@PathParam("fiscalYear") fiscalYear: Int): Response {
@@ -90,7 +90,7 @@ class YearCloseResource(private val yearCloseUseCase: YearCloseUseCase) {
 
     @GET
     @Path("/{fiscalYear}/verify")
-    @RolesAllowed(Roles.SERVICE, Roles.AUDITOR, Roles.VIEWER, Roles.OPERATOR, Roles.ADMIN)
+    @RolesAllowed(Roles.API, Roles.AUDITOR, Roles.VIEWER, Roles.OPERATOR, Roles.ADMIN)
     @Authorize(action = "ledger.read", resource = "#fiscalYear")
     @Operation(
         summary = "Re-verify a year close's content hash against a fresh trial balance (read-only, " +

--- a/openbank-ledger-service/src/main/resources/docs/01-overview.cs.md
+++ b/openbank-ledger-service/src/main/resources/docs/01-overview.cs.md
@@ -53,8 +53,8 @@ Služba také provádí **denní FX revalvaci** (mark-to-ČNB devizových pozic,
 
 ## Volající
 
-- **transaction-service** (`ROLE_OPERATOR`/`ROLE_SERVICE`) — účtuje vyvážený zápis pro každou vypořádanou transakci; jediný zapisovatel obchodních zápisů.
-- **balance-service** (`ROLE_SERVICE`) — čte hlavní knihu / analytickou evidenci pro rekonciliaci proti read-modelu zůstatků (ADR-0039).
+- **transaction-service** (`ROLE_OPERATOR`/`ROLE_API`) — účtuje vyvážený zápis pro každou vypořádanou transakci; jediný zapisovatel obchodních zápisů.
+- **balance-service** (`ROLE_API`) — čte hlavní knihu / analytickou evidenci pro rekonciliaci proti read-modelu zůstatků (ADR-0039).
 - **audit-service** — konzumuje proud událostí `JournalPosted` pro neměnný audit řetězec.
 - **admin-ui** (`ROLE_OPERATOR` / `ROLE_AUDITOR` / `ROLE_VIEWER`) — operátoři a auditoři prochází zápisy, předvahu, analytiku; operátoři spouští backfill FX revalvace.
 - **FxRevaluationScheduler** (v procesu) — automaticky řídí denní revalvaci.

--- a/openbank-ledger-service/src/main/resources/docs/01-overview.en.md
+++ b/openbank-ledger-service/src/main/resources/docs/01-overview.en.md
@@ -53,8 +53,8 @@ It also runs the **daily FX revaluation** (mark-to-ČNB of foreign FX positions,
 
 ## Callers
 
-- **transaction-service** (`ROLE_OPERATOR`/`ROLE_SERVICE`) — posts the balanced journal for every settled transaction; the only writer of business postings.
-- **balance-service** (`ROLE_SERVICE`) — reads the ledger / sub-ledger for reconciliation against the balance read-model (ADR-0039).
+- **transaction-service** (`ROLE_OPERATOR`/`ROLE_API`) — posts the balanced journal for every settled transaction; the only writer of business postings.
+- **balance-service** (`ROLE_API`) — reads the ledger / sub-ledger for reconciliation against the balance read-model (ADR-0039).
 - **audit-service** — consumes the `JournalPosted` event stream for the tamper-evident audit chain.
 - **admin-ui** (`ROLE_OPERATOR` / `ROLE_AUDITOR` / `ROLE_VIEWER`) — operators and auditors browse journals, trial balance, sub-ledger; operators trigger FX-revaluation backfill.
 - **FxRevaluationScheduler** (in-process) — drives the daily revaluation automatically.

--- a/openbank-ledger-service/src/main/resources/docs/03-api.cs.md
+++ b/openbank-ledger-service/src/main/resources/docs/03-api.cs.md
@@ -16,7 +16,7 @@ Keycloak OIDC, RS256 bearer JWT. Žádný endpoint není `@PermitAll` — hlavn�
 
 | Operace | Vyžadované role |
 |---|---|
-| Všechna čtení (list/get/trial-balance/sub-ledger/by-transaction) | `ROLE_SERVICE`, `ROLE_AUDITOR`, `ROLE_VIEWER`, `ROLE_OPERATOR`, `ROLE_ADMIN` |
+| Všechna čtení (list/get/trial-balance/sub-ledger/by-transaction) | `ROLE_API`, `ROLE_AUDITOR`, `ROLE_VIEWER`, `ROLE_OPERATOR`, `ROLE_ADMIN` |
 | `POST /journals` (zaúčtování) | `ROLE_OPERATOR` |
 | `POST /journals/{id}/reverse` | `ROLE_OPERATOR` |
 | `POST /ledger/fx-revaluation` | `ROLE_OPERATOR` |

--- a/openbank-ledger-service/src/main/resources/docs/03-api.en.md
+++ b/openbank-ledger-service/src/main/resources/docs/03-api.en.md
@@ -16,7 +16,7 @@ Keycloak OIDC, RS256 bearer JWT. No endpoint is `@PermitAll` — the general led
 
 | Operation | Required role(s) |
 |---|---|
-| All reads (list/get/trial-balance/sub-ledger/by-transaction) | `ROLE_SERVICE`, `ROLE_AUDITOR`, `ROLE_VIEWER`, `ROLE_OPERATOR`, `ROLE_ADMIN` |
+| All reads (list/get/trial-balance/sub-ledger/by-transaction) | `ROLE_API`, `ROLE_AUDITOR`, `ROLE_VIEWER`, `ROLE_OPERATOR`, `ROLE_ADMIN` |
 | `POST /journals` (post) | `ROLE_OPERATOR` |
 | `POST /journals/{id}/reverse` | `ROLE_OPERATOR` |
 | `POST /ledger/fx-revaluation` | `ROLE_OPERATOR` |

--- a/openbank-ledger-service/src/main/resources/docs/README.cs.md
+++ b/openbank-ledger-service/src/main/resources/docs/README.cs.md
@@ -23,4 +23,4 @@ Tato dokumentace je publikována přímo službou na management endpointu `/q/op
 - **Perzistence:** dedikovaná PostgreSQL databáze `openbank_ledger`, Flyway migrace V1..V8; `journal_entries` je RANGE-partitionováno podle `entry_date` (po letech)
 - **Outbox:** `ledger_outbox` → Kafka topic `openbank.ledger.journal.posted` (regulatorní dispatch, ADR-0050)
 - **Idempotence:** pole `idempotencyKey` v požadavku na zaúčtování → tabulka `ledger_idempotency` (v DB, ne Redis)
-- **Auth:** Keycloak OIDC (RS256 JWT). Čtení omezeno na `ROLE_SERVICE`/`ROLE_AUDITOR`/`ROLE_VIEWER`/`ROLE_OPERATOR`/`ROLE_ADMIN`; účtování/storno/FX revalvace jen `ROLE_OPERATOR`. Žádný endpoint není neautentizovaný (ADR-0018).
+- **Auth:** Keycloak OIDC (RS256 JWT). Čtení omezeno na `ROLE_API`/`ROLE_AUDITOR`/`ROLE_VIEWER`/`ROLE_OPERATOR`/`ROLE_ADMIN`; účtování/storno/FX revalvace jen `ROLE_OPERATOR`. Žádný endpoint není neautentizovaný (ADR-0018).

--- a/openbank-ledger-service/src/main/resources/docs/README.en.md
+++ b/openbank-ledger-service/src/main/resources/docs/README.en.md
@@ -23,4 +23,4 @@ This documentation is published directly by the service at the management endpoi
 - **Persistence:** dedicated PostgreSQL database `openbank_ledger`, Flyway migrations V1..V8; `journal_entries` is RANGE-partitioned by `entry_date` (per-year)
 - **Outbox:** `ledger_outbox` → Kafka topic `openbank.ledger.journal.posted` (regulatory-grade dispatch, ADR-0050)
 - **Idempotency:** `idempotencyKey` field on the post-journal request → `ledger_idempotency` table (DB-backed, not Redis)
-- **Auth:** Keycloak OIDC (RS256 JWT). Reads gated to `ROLE_SERVICE`/`ROLE_AUDITOR`/`ROLE_VIEWER`/`ROLE_OPERATOR`/`ROLE_ADMIN`; posting/reversing/FX-revaluation are `ROLE_OPERATOR` only. No endpoint is unauthenticated (ADR-0018).
+- **Auth:** Keycloak OIDC (RS256 JWT). Reads gated to `ROLE_API`/`ROLE_AUDITOR`/`ROLE_VIEWER`/`ROLE_OPERATOR`/`ROLE_ADMIN`; posting/reversing/FX-revaluation are `ROLE_OPERATOR` only. No endpoint is unauthenticated (ADR-0018).

--- a/openbank-ledger-service/src/test/kotlin/com/openbank/ledger/contract/LedgerPactBrokerProviderVerificationTest.kt
+++ b/openbank-ledger-service/src/test/kotlin/com/openbank/ledger/contract/LedgerPactBrokerProviderVerificationTest.kt
@@ -46,7 +46,7 @@ import org.junit.jupiter.api.extension.ExtendWith
  */
 @QuarkusTest
 @QuarkusTestResource(com.openbank.ledger.it.PostgresRedpandaTestResource::class)
-@TestSecurity(user = "pact-verifier", roles = ["ROLE_SERVICE", "ROLE_OPERATOR"])
+@TestSecurity(user = "pact-verifier", roles = ["ROLE_API", "ROLE_OPERATOR"])
 @Provider("openbank-ledger-service")
 @PactBroker
 @IgnoreNoPactsToVerify(ignoreIoErrors = "true")

--- a/openbank-ledger-service/src/test/kotlin/com/openbank/ledger/contract/LedgerPactProviderVerificationTest.kt
+++ b/openbank-ledger-service/src/test/kotlin/com/openbank/ledger/contract/LedgerPactProviderVerificationTest.kt
@@ -44,7 +44,7 @@ import org.junit.jupiter.api.extension.ExtendWith
  */
 @QuarkusTest
 @QuarkusTestResource(com.openbank.ledger.it.PostgresRedpandaTestResource::class)
-@TestSecurity(user = "pact-verifier", roles = ["ROLE_SERVICE", "ROLE_OPERATOR"])
+@TestSecurity(user = "pact-verifier", roles = ["ROLE_API", "ROLE_OPERATOR"])
 @Provider("openbank-ledger-service")
 @PactFolder("../pacts")
 @IgnoreNoPactsToVerify(ignoreIoErrors = "true")

--- a/openbank-ledger-service/src/test/kotlin/com/openbank/ledger/infrastructure/rest/LedgerSecurityContractTest.kt
+++ b/openbank-ledger-service/src/test/kotlin/com/openbank/ledger/infrastructure/rest/LedgerSecurityContractTest.kt
@@ -32,7 +32,7 @@ class LedgerSecurityContractTest {
         ).forEach { name ->
             assertThat(rolesOf(name))
                 .describedAs("%s read roles (financial-control evidence)", name)
-                .containsExactlyInAnyOrder("ROLE_SERVICE", "ROLE_AUDITOR", "ROLE_VIEWER", "ROLE_OPERATOR", "ROLE_ADMIN")
+                .containsExactlyInAnyOrder("ROLE_API", "ROLE_AUDITOR", "ROLE_VIEWER", "ROLE_OPERATOR", "ROLE_ADMIN")
         }
     }
 

--- a/openbank-ledger-service/src/test/kotlin/com/openbank/ledger/infrastructure/rest/YearCloseSecurityContractTest.kt
+++ b/openbank-ledger-service/src/test/kotlin/com/openbank/ledger/infrastructure/rest/YearCloseSecurityContractTest.kt
@@ -29,7 +29,7 @@ class YearCloseSecurityContractTest {
         listOf("trialBalance", "getYearClose").forEach { name ->
             assertThat(rolesOf(name))
                 .describedAs("%s read roles (financial-control evidence)", name)
-                .containsExactlyInAnyOrder("ROLE_SERVICE", "ROLE_AUDITOR", "ROLE_VIEWER", "ROLE_OPERATOR", "ROLE_ADMIN")
+                .containsExactlyInAnyOrder("ROLE_API", "ROLE_AUDITOR", "ROLE_VIEWER", "ROLE_OPERATOR", "ROLE_ADMIN")
         }
     }
 

--- a/openbank-libs-domain/src/main/kotlin/com/openbank/libs/security/Roles.kt
+++ b/openbank-libs-domain/src/main/kotlin/com/openbank/libs/security/Roles.kt
@@ -61,30 +61,20 @@ object Roles {
     const val PAYMENTS = "ROLE_PAYMENTS"
 
     /**
-     * Machine-to-machine API access — the realm's own name for what a service-account token
-     * should carry (`ROLE_API`, "Machine-to-machine API access" in realm-template.json).
+     * Machine-to-machine API access — the realm's role for a service-account token, and the only
+     * M2M grant in this platform.
      *
-     * NOTE: no service account is granted this role today, so an endpoint gated on it alone is
-     * still unreachable until someone grants it in Keycloak (issue #2404). That is a deliberate,
-     * visible gap rather than the invisible one [SERVICE] created.
+     * Granted to `service-account-openbank-services` (issue #2442), the service account behind the
+     * `openbank-services` OIDC client that 23 services use for outbound calls. Before that grant
+     * the account existed in no realm template at all, so every M2M token carried an EMPTY role
+     * set and no `@RolesAllowed` could ever admit it — which is why the dead `ROLE_SERVICE` name
+     * it replaced went unnoticed for so long: both were unreachable, for different reasons.
+     *
+     * Prefer this over widening an M2M path to [OPERATOR]: real staff hold that role too, so
+     * gating on it admits every human operator as well — the JWT-role twin of the over-grant the
+     * rego side already documents.
      */
     const val API = "ROLE_API"
-
-    /**
-     * Service-to-service authentication.
-     *
-     * DEAD: no realm in this platform declares `ROLE_SERVICE` — not the staff realm, not the
-     * customers realm — so no token can ever carry it and this name authorizes nobody. It appears
-     * at ~150 `@RolesAllowed` sites across ~29 services, always alongside a live role, so humans
-     * still get in and only the M2M caller it was reserved for is silently denied (issue #2404).
-     * The JWT-role twin of the unreachable `principal.type == "SERVICE"` rego rules that
-     * `check-no-service-principal-type.sh` already forbids.
-     *
-     * Use [API] for new M2M grants. Retiring the existing sites is a per-service decision — grant
-     * the role or delete the path — not a mechanical rename, so this constant stays until they
-     * are cleared rather than breaking 29 services' compilation today.
-     */
-    const val SERVICE = "ROLE_SERVICE"
 
     /** All canonical roles, in declaration order. Use for policy/audit enumeration. */
     val ALL: List<String> = listOf(
@@ -99,6 +89,5 @@ object Roles {
         KYC_REVIEWER,
         PAYMENTS,
         API,
-        SERVICE,
     )
 }

--- a/openbank-libs-runtime/src/main/kotlin/com/openbank/libs/analytics/ReconciliationSummaryContract.kt
+++ b/openbank-libs-runtime/src/main/kotlin/com/openbank/libs/analytics/ReconciliationSummaryContract.kt
@@ -56,7 +56,7 @@ data class ServiceReconciliationSummary(
  *
  * **Security:** role-gated, never `@PermitAll` (the metadata is audit material). The caller is the
  * analytics-sink calling service-to-service under the `openbank-services` client-credentials grant, so
- * [Roles.SERVICE] must be allowed; the human audit roles let an examiner-facing operator read it too.
+ * [Roles.API] must be allowed; the human audit roles let an examiner-facing operator read it too.
  *
  * **Performance:** implementations must serve this off the customer path — read-only, off-peak (the
  * sink drives it from its off-peak cron), ideally a read-replica, and `since`-windowed where the table
@@ -77,6 +77,6 @@ interface ReconciliationSummaryContract {
      */
     @GET
     @Produces(MediaType.APPLICATION_JSON)
-    @RolesAllowed(Roles.SERVICE, Roles.AUDITOR, Roles.ADMIN, Roles.COMPLIANCE)
+    @RolesAllowed(Roles.API, Roles.AUDITOR, Roles.ADMIN, Roles.COMPLIANCE)
     fun reconciliationSummary(@QueryParam("since") since: String?): Uni<ServiceReconciliationSummary>
 }

--- a/openbank-libs-runtime/src/test/kotlin/com/openbank/libs/security/SecurityContextExtensionsTest.kt
+++ b/openbank-libs-runtime/src/test/kotlin/com/openbank/libs/security/SecurityContextExtensionsTest.kt
@@ -64,9 +64,9 @@ class SecurityContextExtensionsTest {
     @Test
     fun `actorType returns the single held role`() {
         val ctx = contextWith("svc")
-        every { ctx.isUserInRole(Roles.SERVICE) } returns true
+        every { ctx.isUserInRole(Roles.API) } returns true
 
-        assertThat(ctx.actorType).isEqualTo(Roles.SERVICE)
+        assertThat(ctx.actorType).isEqualTo(Roles.API)
     }
 
     @Test

--- a/openbank-notification-service/src/main/kotlin/com/openbank/notification/infrastructure/rest/DeviceResource.kt
+++ b/openbank-notification-service/src/main/kotlin/com/openbank/notification/infrastructure/rest/DeviceResource.kt
@@ -52,7 +52,7 @@ class DeviceResource {
     )
 
     @POST
-    @RolesAllowed("ROLE_OPERATOR", "ROLE_SERVICE", "ROLE_ADMIN")
+    @RolesAllowed("ROLE_OPERATOR", "ROLE_API", "ROLE_ADMIN")
     @Authorize(action = "device.create", resource = "")
     @Operation(summary = "Register (upsert) a push device token for a party")
     suspend fun register(req: RegisterDeviceRequest): Response {
@@ -77,7 +77,7 @@ class DeviceResource {
     }
 
     @GET
-    @RolesAllowed("ROLE_VIEWER", "ROLE_OPERATOR", "ROLE_ADMIN", "ROLE_SERVICE")
+    @RolesAllowed("ROLE_VIEWER", "ROLE_OPERATOR", "ROLE_ADMIN", "ROLE_API")
     @Authorize(action = "device.list", resource = "")
     @Operation(summary = "List a party's registered devices (no tokens returned)")
     suspend fun list(@QueryParam("partyId") partyId: UUID?): Response {
@@ -88,11 +88,11 @@ class DeviceResource {
 
     @DELETE
     @Path("/{deviceId}")
-    @RolesAllowed("ROLE_OPERATOR", "ROLE_SERVICE", "ROLE_ADMIN")
+    @RolesAllowed("ROLE_OPERATOR", "ROLE_API", "ROLE_ADMIN")
     @Authorize(action = "device.delete", resource = "")
     @Operation(summary = "Deactivate a push device token (logout / uninstall)")
     suspend fun deactivate(@PathParam("deviceId") deviceId: UUID, @QueryParam("partyId") partyId: UUID?): Response {
-        // customer-edge translates the mobile app JWT to ROLE_SERVICE and injects the
+        // customer-edge translates the mobile app JWT to ROLE_API and injects the
         // authoritative partyId — no direct ROLE_CUSTOMER access (prevents IDOR at the edge).
         // When partyId is supplied the UPDATE is scoped to that party's tokens only.
         val deactivated = repo.deactivate(deviceId, partyId)

--- a/openbank-notification-service/src/main/kotlin/com/openbank/notification/infrastructure/rest/NotificationPreferenceResource.kt
+++ b/openbank-notification-service/src/main/kotlin/com/openbank/notification/infrastructure/rest/NotificationPreferenceResource.kt
@@ -37,7 +37,7 @@ class NotificationPreferenceResource {
 
     @GET
     @Path("/party/{partyId}")
-    @RolesAllowed("ROLE_SERVICE", "ROLE_OPERATOR", "ROLE_ADMIN", "ROLE_CUSTOMER")
+    @RolesAllowed("ROLE_API", "ROLE_OPERATOR", "ROLE_ADMIN", "ROLE_CUSTOMER")
     @Authorize(action = "notification.preferences.read", resource = "#partyId")
     @Operation(summary = "Get a party's push preferences (all-on when never set)")
     suspend fun get(@PathParam("partyId") partyId: UUID): NotificationPreferenceDto {
@@ -47,7 +47,7 @@ class NotificationPreferenceResource {
 
     @PUT
     @Path("/party/{partyId}")
-    @RolesAllowed("ROLE_SERVICE", "ROLE_OPERATOR", "ROLE_ADMIN", "ROLE_CUSTOMER")
+    @RolesAllowed("ROLE_API", "ROLE_OPERATOR", "ROLE_ADMIN", "ROLE_CUSTOMER")
     @Authorize(action = "notification.preferences.update", resource = "#partyId")
     @Operation(summary = "Set a party's push preferences")
     suspend fun set(@PathParam("partyId") partyId: UUID, req: NotificationPreferenceDto): NotificationPreferenceDto {

--- a/openbank-notification-service/src/main/kotlin/com/openbank/notification/infrastructure/rest/NotificationResource.kt
+++ b/openbank-notification-service/src/main/kotlin/com/openbank/notification/infrastructure/rest/NotificationResource.kt
@@ -36,7 +36,7 @@ class NotificationResource {
     @Inject lateinit var repo: NotificationRepository
 
     @GET
-    @RolesAllowed("ROLE_VIEWER", "ROLE_OPERATOR", "ROLE_ADMIN", "ROLE_SERVICE")
+    @RolesAllowed("ROLE_VIEWER", "ROLE_OPERATOR", "ROLE_ADMIN", "ROLE_API")
     @Authorize(action = "notification.list", resource = "")
     @Operation(summary = "List notifications (paginated)")
     suspend fun listNotifications(
@@ -74,7 +74,7 @@ class NotificationResource {
 
     @GET
     @Path("/{id}")
-    @RolesAllowed("ROLE_VIEWER", "ROLE_OPERATOR", "ROLE_ADMIN", "ROLE_SERVICE")
+    @RolesAllowed("ROLE_VIEWER", "ROLE_OPERATOR", "ROLE_ADMIN", "ROLE_API")
     @Authorize(action = "notification.read", resource = "#id")
     @Operation(summary = "Get notification by ID")
     suspend fun getNotification(@PathParam("id") id: UUID): Response {
@@ -86,13 +86,13 @@ class NotificationResource {
      * Party-scoped single read for the customer app's fetch-on-tap (ADR-0135 §3, issue #1182).
      * The push payload now carries no amount/PII (see NotificationConsumer.sendPush); on tap the
      * app calls this to load the full detail. partyId is the edge-injected authoritative identity
-     * (customer-edge translates the mobile JWT to ROLE_SERVICE and injects it) — the repository
+     * (customer-edge translates the mobile JWT to ROLE_API and injects it) — the repository
      * SELECT is scoped by it, so a caller can never read another party's notification (IDOR guard,
      * same shape as [markRead]). A missing/other-party id is a 404 with no existence oracle.
      */
     @GET
     @Path("/{id}/self")
-    @RolesAllowed("ROLE_OPERATOR", "ROLE_SERVICE", "ROLE_ADMIN")
+    @RolesAllowed("ROLE_OPERATOR", "ROLE_API", "ROLE_ADMIN")
     @Authorize(action = "notification.read.self", resource = "#id")
     @Operation(summary = "Get one of the caller's own notifications (party-scoped)")
     suspend fun getOwnNotification(@PathParam("id") id: UUID, @QueryParam("partyId") partyId: UUID?): Response {
@@ -126,7 +126,7 @@ class NotificationResource {
      */
     @PATCH
     @Path("/{id}/read")
-    @RolesAllowed("ROLE_OPERATOR", "ROLE_SERVICE", "ROLE_ADMIN")
+    @RolesAllowed("ROLE_OPERATOR", "ROLE_API", "ROLE_ADMIN")
     @Authorize(action = "notification.mark-read", resource = "#id")
     @Operation(summary = "Mark a notification as read")
     suspend fun markRead(@PathParam("id") id: UUID, @QueryParam("partyId") partyId: UUID?): Response {
@@ -143,7 +143,7 @@ class NotificationResource {
     /** Mark ALL of a party's notifications read. Returns the number flipped. */
     @PATCH
     @Path("/read-all")
-    @RolesAllowed("ROLE_OPERATOR", "ROLE_SERVICE", "ROLE_ADMIN")
+    @RolesAllowed("ROLE_OPERATOR", "ROLE_API", "ROLE_ADMIN")
     @Authorize(action = "notification.mark-read", resource = "")
     @Operation(summary = "Mark all of a party's notifications as read")
     suspend fun markAllRead(@QueryParam("partyId") partyId: UUID?): Response {

--- a/openbank-notification-service/src/main/resources/docs/03-api.cs.md
+++ b/openbank-notification-service/src/main/resources/docs/03-api.cs.md
@@ -10,9 +10,9 @@ Keycloak OIDC (`realms/openbank`, klient `openbank-services`), RS256 bearer toke
 
 | Plocha | Role |
 |---|---|
-| Čtení notifikací (`GET /notifications…`) | `ROLE_VIEWER`, `ROLE_OPERATOR`, `ROLE_ADMIN`, `ROLE_SERVICE` |
-| Výpis zařízení (`GET /devices`) | `ROLE_VIEWER`, `ROLE_OPERATOR`, `ROLE_ADMIN`, `ROLE_SERVICE` |
-| Registrace zařízení (`POST /devices`) | `ROLE_OPERATOR`, `ROLE_SERVICE`, `ROLE_ADMIN` |
+| Čtení notifikací (`GET /notifications…`) | `ROLE_VIEWER`, `ROLE_OPERATOR`, `ROLE_ADMIN`, `ROLE_API` |
+| Výpis zařízení (`GET /devices`) | `ROLE_VIEWER`, `ROLE_OPERATOR`, `ROLE_ADMIN`, `ROLE_API` |
+| Registrace zařízení (`POST /devices`) | `ROLE_OPERATOR`, `ROLE_API`, `ROLE_ADMIN` |
 | Řízení výpravy (`/ops/dispatch…`) | `ROLE_OPERATOR`, `ROLE_ADMIN` (čtení i `ROLE_AUDITOR`) |
 
 U řízení výpravy se **identita aktéra bere z autentizovaného JWT subjektu**, nikdy z těla požadavku — aby four-eyes pravidlo nešlo podvrhnout. `ROLE_SRE` je zamýšlená operátorská role, jakmile bude v realmu existovat; do té doby je gated na `ROLE_OPERATOR`/`ROLE_ADMIN`.

--- a/openbank-notification-service/src/main/resources/docs/03-api.en.md
+++ b/openbank-notification-service/src/main/resources/docs/03-api.en.md
@@ -10,9 +10,9 @@ Keycloak OIDC (`realms/openbank`, client `openbank-services`), RS256 bearer toke
 
 | Surface | Roles |
 |---|---|
-| Read notifications (`GET /notifications…`) | `ROLE_VIEWER`, `ROLE_OPERATOR`, `ROLE_ADMIN`, `ROLE_SERVICE` |
-| List devices (`GET /devices`) | `ROLE_VIEWER`, `ROLE_OPERATOR`, `ROLE_ADMIN`, `ROLE_SERVICE` |
-| Register device (`POST /devices`) | `ROLE_OPERATOR`, `ROLE_SERVICE`, `ROLE_ADMIN` |
+| Read notifications (`GET /notifications…`) | `ROLE_VIEWER`, `ROLE_OPERATOR`, `ROLE_ADMIN`, `ROLE_API` |
+| List devices (`GET /devices`) | `ROLE_VIEWER`, `ROLE_OPERATOR`, `ROLE_ADMIN`, `ROLE_API` |
+| Register device (`POST /devices`) | `ROLE_OPERATOR`, `ROLE_API`, `ROLE_ADMIN` |
 | Dispatch control (`/ops/dispatch…`) | `ROLE_OPERATOR`, `ROLE_ADMIN` (read also `ROLE_AUDITOR`) |
 
 For dispatch-control, the **actor identity is taken from the authenticated JWT subject**, never from the request body — so the four-eyes rule cannot be spoofed. `ROLE_SRE` is the intended operator role once it exists in the realm; until then it is gated on `ROLE_OPERATOR`/`ROLE_ADMIN`.

--- a/openbank-notification-service/src/main/resources/docs/README.cs.md
+++ b/openbank-notification-service/src/main/resources/docs/README.cs.md
@@ -24,4 +24,4 @@ Tuto dokumentaci publikuje sama služba na management endpointu `/q/openbank/doc
 - **Outbox:** tabulka `notification_outbox` → kanál dispatcheru `notification-events-out` (obecné outbox-relay; navázání odchozího Kafka topicu je **TBD** — zatím není v `application.yaml`).
 - **Push:** adaptéry FCM / APNs, **ve výchozím stavu vypnuté** (přihlašovací údaje injektované z Vaultu); vypnutý adaptér zaznamená úspěšný no-op. PUSH se rozesílá na každý ACTIVE device token registrovaný pro party.
 - **Idempotence:** na vstupní cestě záměrně žádná — doručení je at-least-once a redelivery uloží nový řádek (přijatelné, protože nejde o peněžní cestu).
-- **Auth:** Keycloak OIDC. Čtecí API vyžadují `ROLE_VIEWER`/`ROLE_OPERATOR`/`ROLE_ADMIN`/`ROLE_SERVICE`; řízení výpravy (break-glass) vyžaduje `ROLE_OPERATOR`/`ROLE_ADMIN` s four-eyes při resume.
+- **Auth:** Keycloak OIDC. Čtecí API vyžadují `ROLE_VIEWER`/`ROLE_OPERATOR`/`ROLE_ADMIN`/`ROLE_API`; řízení výpravy (break-glass) vyžaduje `ROLE_OPERATOR`/`ROLE_ADMIN` s four-eyes při resume.

--- a/openbank-notification-service/src/main/resources/docs/README.en.md
+++ b/openbank-notification-service/src/main/resources/docs/README.en.md
@@ -24,4 +24,4 @@ This documentation is published directly by the service at the management endpoi
 - **Outbox:** table `notification_outbox` → dispatcher channel `notification-events-out` (a generic outbox-relay; the outgoing Kafka topic binding is **TBD** — not yet wired in `application.yaml`).
 - **Push:** FCM / APNs adapters, **off by default** (Vault-injected credentials); a disabled adapter records a successful no-op. PUSH fans out to every ACTIVE device token registered for the party.
 - **Idempotency:** none on the inbound path by design — delivery is at-least-once and a redelivery re-persists a fresh row (acceptable because no money path).
-- **Auth:** Keycloak OIDC. Read APIs require `ROLE_VIEWER`/`ROLE_OPERATOR`/`ROLE_ADMIN`/`ROLE_SERVICE`; dispatch-control (break-glass) requires `ROLE_OPERATOR`/`ROLE_ADMIN` with four-eyes on resume.
+- **Auth:** Keycloak OIDC. Read APIs require `ROLE_VIEWER`/`ROLE_OPERATOR`/`ROLE_ADMIN`/`ROLE_API`; dispatch-control (break-glass) requires `ROLE_OPERATOR`/`ROLE_ADMIN` with four-eyes on resume.

--- a/openbank-party-service/src/main/kotlin/com/openbank/party/infrastructure/client/AccountServiceClient.kt
+++ b/openbank-party-service/src/main/kotlin/com/openbank/party/infrastructure/client/AccountServiceClient.kt
@@ -26,7 +26,7 @@ import java.util.UUID
  * `@RolesAllowed(SERVICE, VIEWER, OPERATOR, ADMIN)`, so the call carries an M2M bearer via
  * [OidcClientRequestReactiveFilter] — the `openbank-services` client_credentials token resolves to
  * ROLE_OPERATOR, which is what actually satisfies the check (nothing in either Keycloak realm
- * grants ROLE_SERVICE, so that constant in the list is dead).
+ * grants ROLE_API, so that constant in the list is dead).
  */
 @RegisterRestClient(configKey = "account-service")
 @RegisterProvider(OidcClientRequestReactiveFilter::class)

--- a/openbank-party-service/src/main/kotlin/com/openbank/party/infrastructure/rest/PartyResource.kt
+++ b/openbank-party-service/src/main/kotlin/com/openbank/party/infrastructure/rest/PartyResource.kt
@@ -85,7 +85,7 @@ class PartyResource {
     lateinit var securityIdentity: SecurityIdentity
 
     @GET
-    @RolesAllowed("ROLE_VIEWER", "ROLE_OPERATOR", "ROLE_ADMIN", "ROLE_KYC", "ROLE_SERVICE")
+    @RolesAllowed("ROLE_VIEWER", "ROLE_OPERATOR", "ROLE_ADMIN", "ROLE_KYC", "ROLE_API")
     @Operation(
         summary = "List parties (paginated). Optional ?status= filter for onboarding cockpit funnel views (ADR-0068).",
     )
@@ -106,7 +106,7 @@ class PartyResource {
 
     @GET
     @Path("/search")
-    @RolesAllowed("ROLE_VIEWER", "ROLE_OPERATOR", "ROLE_ADMIN", "ROLE_KYC", "ROLE_SERVICE")
+    @RolesAllowed("ROLE_VIEWER", "ROLE_OPERATOR", "ROLE_ADMIN", "ROLE_KYC", "ROLE_API")
     @FeatureFlag(flag = "party-search")
     @Operation(
         summary = "Search parties by name (trigram), cursor-paginated (ADR-0055). Gated by feature flag party-search.",
@@ -132,7 +132,7 @@ class PartyResource {
 
     @GET
     @Path("/{id}")
-    @RolesAllowed("ROLE_VIEWER", "ROLE_OPERATOR", "ROLE_ADMIN", "ROLE_KYC", "ROLE_SERVICE")
+    @RolesAllowed("ROLE_VIEWER", "ROLE_OPERATOR", "ROLE_ADMIN", "ROLE_KYC", "ROLE_API")
     @Operation(summary = "Get party by ID")
     suspend fun getParty(@PathParam("id") id: UUID): Response =
         Response.ok(partyUseCase.getParty(id).toResponse()).build()
@@ -207,7 +207,7 @@ class PartyResource {
 
     @GET
     @Path("/{id}/documents")
-    @RolesAllowed("ROLE_VIEWER", "ROLE_OPERATOR", "ROLE_ADMIN", "ROLE_KYC", "ROLE_SERVICE")
+    @RolesAllowed("ROLE_VIEWER", "ROLE_OPERATOR", "ROLE_ADMIN", "ROLE_KYC", "ROLE_API")
     @Operation(summary = "List party documents")
     suspend fun listDocuments(@PathParam("id") id: UUID): Response = Response.ok(partyUseCase.listDocuments(id)).build()
 
@@ -419,12 +419,12 @@ class PartyResource {
      * to the response. Returns 200 + party summary when found, 404 when no match, 503 when
      * pepper is unconfigured (dedup is off and callers must not assume uniqueness).
      *
-     * Internal-only endpoint — requires ROLE_SERVICE so only trusted back-end callers
+     * Internal-only endpoint — requires ROLE_API so only trusted back-end callers
      * (customer-edge, onboarding service) can use it during the self-registration flow.
      */
     @POST
     @Path("/resolve")
-    @RolesAllowed("ROLE_SERVICE", "ROLE_ADMIN")
+    @RolesAllowed("ROLE_API", "ROLE_ADMIN")
     @Authorize(action = "party:resolve")
     @Operation(summary = "Resolve a party by RČ blind index (ADR-0072 dedup gate, internal only)")
     suspend fun resolveParty(req: ResolvePartyRequest): Response {

--- a/openbank-party-service/src/main/resources/docs/03-api.cs.md
+++ b/openbank-party-service/src/main/resources/docs/03-api.cs.md
@@ -14,7 +14,7 @@ Všechny endpointy vyžadují **Keycloak Bearer token** (realm `openbank`). Role
 
 | Endpoint | Role |
 |---|---|
-| `GET /parties`, `GET /parties/search`, `GET /parties/{id}`, `GET /parties/{id}/documents` | `ROLE_VIEWER`, `ROLE_OPERATOR`, `ROLE_ADMIN`, `ROLE_KYC`, `ROLE_SERVICE` |
+| `GET /parties`, `GET /parties/search`, `GET /parties/{id}`, `GET /parties/{id}/documents` | `ROLE_VIEWER`, `ROLE_OPERATOR`, `ROLE_ADMIN`, `ROLE_KYC`, `ROLE_API` |
 | `POST /parties`, `POST /parties/{id}/documents` | `ROLE_OPERATOR`, `ROLE_ADMIN`, `ROLE_KYC` |
 | `PATCH /parties/{id}` | `ROLE_OPERATOR`, `ROLE_ADMIN` (+ `@Authorize(action="party.update")` přes OPA, advisory) |
 | `PUT /parties/{id}/kyc-status` | `ROLE_ADMIN`, `ROLE_KYC` |

--- a/openbank-party-service/src/main/resources/docs/03-api.en.md
+++ b/openbank-party-service/src/main/resources/docs/03-api.en.md
@@ -14,7 +14,7 @@ All endpoints require a **Keycloak Bearer token** (realm `openbank`). Per-endpoi
 
 | Endpoint | Roles |
 |---|---|
-| `GET /parties`, `GET /parties/search`, `GET /parties/{id}`, `GET /parties/{id}/documents` | `ROLE_VIEWER`, `ROLE_OPERATOR`, `ROLE_ADMIN`, `ROLE_KYC`, `ROLE_SERVICE` |
+| `GET /parties`, `GET /parties/search`, `GET /parties/{id}`, `GET /parties/{id}/documents` | `ROLE_VIEWER`, `ROLE_OPERATOR`, `ROLE_ADMIN`, `ROLE_KYC`, `ROLE_API` |
 | `POST /parties`, `POST /parties/{id}/documents` | `ROLE_OPERATOR`, `ROLE_ADMIN`, `ROLE_KYC` |
 | `PATCH /parties/{id}` | `ROLE_OPERATOR`, `ROLE_ADMIN` (+ `@Authorize(action="party.update")` via OPA, advisory) |
 | `PUT /parties/{id}/kyc-status` | `ROLE_ADMIN`, `ROLE_KYC` |

--- a/openbank-party-service/src/main/resources/docs/README.cs.md
+++ b/openbank-party-service/src/main/resources/docs/README.cs.md
@@ -23,5 +23,5 @@ Tuto dokumentaci služba publikuje přímo na management endpointu `/q/openbank/
 - **Outbox:** `party_outbox` → Kafka topic `openbank.party.events` (dispatcher pollne každých 5 s s fault-tolerancí: circuit breaker + retry + bulkhead + timeout)
 - **Příchozí eventy:** konzumuje `openbank.kyc.events` a `openbank.aml.events` pro řízení dvouklíčové KYC+AML aktivační brány
 - **Idempotence:** hlavička `Idempotency-Key` je povinná na `POST /api/v1/parties`; unikátní omezení na e-mail navíc deduplikuje party (409 při replay)
-- **Auth:** Keycloak OIDC, role `ROLE_VIEWER` / `ROLE_OPERATOR` / `ROLE_ADMIN` / `ROLE_KYC` / `ROLE_SERVICE`; OPA authz v advisory režimu (ADR-0034)
+- **Auth:** Keycloak OIDC, role `ROLE_VIEWER` / `ROLE_OPERATOR` / `ROLE_ADMIN` / `ROLE_KYC` / `ROLE_API`; OPA authz v advisory režimu (ADR-0034)
 - **Klasifikace dat:** `restricted` — služba drží PII (jméno, e-mail, telefon, adresu, národnost, DIČ). Není to money-path služba.

--- a/openbank-party-service/src/main/resources/docs/README.en.md
+++ b/openbank-party-service/src/main/resources/docs/README.en.md
@@ -23,5 +23,5 @@ This documentation is published directly by the service at the management endpoi
 - **Outbox:** `party_outbox` → Kafka topic `openbank.party.events` (dispatcher polls every 5 s with fault-tolerance: circuit breaker + retry + bulkhead + timeout)
 - **Inbound events:** consumes `openbank.kyc.events` and `openbank.aml.events` to drive the two-key KYC+AML activation gate
 - **Idempotency:** `Idempotency-Key` header is required on `POST /api/v1/parties`; the email uniqueness constraint additionally de-duplicates parties (409 on replay)
-- **Auth:** Keycloak OIDC, roles `ROLE_VIEWER` / `ROLE_OPERATOR` / `ROLE_ADMIN` / `ROLE_KYC` / `ROLE_SERVICE`; OPA authz in advisory mode (ADR-0034)
+- **Auth:** Keycloak OIDC, roles `ROLE_VIEWER` / `ROLE_OPERATOR` / `ROLE_ADMIN` / `ROLE_KYC` / `ROLE_API`; OPA authz in advisory mode (ADR-0034)
 - **Data classification:** `restricted` — this service holds PII (legal name, e-mail, phone, address, nationality, tax id). Not a money-path service.

--- a/openbank-pid-service/src/main/kotlin/com/openbank/pid/infrastructure/rest/EudiCredentialIssuerResource.kt
+++ b/openbank-pid-service/src/main/kotlin/com/openbank/pid/infrastructure/rest/EudiCredentialIssuerResource.kt
@@ -70,7 +70,7 @@ class EudiCredentialIssuerResource(
     @POST
     @Path("credential-offers")
     @Consumes(MediaType.APPLICATION_JSON)
-    @RolesAllowed("ROLE_SERVICE", "ROLE_OPERATOR", "ROLE_ADMIN")
+    @RolesAllowed("ROLE_API", "ROLE_OPERATOR", "ROLE_ADMIN")
     @Authorize(action = "identity.eudi.issue")
     @Operation(summary = "Create an OpenID4VCI credential offer for a verified identity (ADR-0094)")
     suspend fun createOffer(body: String): Response {
@@ -164,7 +164,7 @@ class EudiCredentialIssuerResource(
 
     @POST
     @Path("credentials/{index}/revoke")
-    @RolesAllowed("ROLE_SERVICE", "ROLE_OPERATOR", "ROLE_ADMIN")
+    @RolesAllowed("ROLE_API", "ROLE_OPERATOR", "ROLE_ADMIN")
     @Authorize(action = "identity.eudi.revoke")
     @Operation(summary = "Revoke a previously-issued credential by its status-list index (ADR-0094)")
     suspend fun revoke(@PathParam("index") index: Long): Response {

--- a/openbank-pid-service/src/main/kotlin/com/openbank/pid/infrastructure/rest/EudiOpenId4VpResource.kt
+++ b/openbank-pid-service/src/main/kotlin/com/openbank/pid/infrastructure/rest/EudiOpenId4VpResource.kt
@@ -49,7 +49,7 @@ class EudiOpenId4VpResource(
 
     @POST
     @Path("/presentation-requests")
-    @RolesAllowed("ROLE_SERVICE", "ROLE_OPERATOR", "ROLE_ADMIN")
+    @RolesAllowed("ROLE_API", "ROLE_OPERATOR", "ROLE_ADMIN")
     @Authorize(action = "identity.eudi.request")
     @Operation(summary = "Start an OpenID4VP presentation exchange; returns the wallet authorization request URI")
     suspend fun createPresentationRequest(): Response {
@@ -69,7 +69,7 @@ class EudiOpenId4VpResource(
 
     @GET
     @Path("/presentation-requests/{id}")
-    @RolesAllowed("ROLE_SERVICE", "ROLE_OPERATOR", "ROLE_ADMIN")
+    @RolesAllowed("ROLE_API", "ROLE_OPERATOR", "ROLE_ADMIN")
     @Authorize(action = "identity.eudi.poll")
     @Operation(summary = "Poll an OpenID4VP exchange for the wallet's resolved presentation result")
     suspend fun getPresentationExchange(@PathParam("id") id: String): Response {

--- a/openbank-pid-service/src/main/kotlin/com/openbank/pid/infrastructure/rest/EudiPresentationResource.kt
+++ b/openbank-pid-service/src/main/kotlin/com/openbank/pid/infrastructure/rest/EudiPresentationResource.kt
@@ -35,7 +35,7 @@ class EudiPresentationResource(private val eudiVerify: EudiVerifyPresentationUse
 
     @POST
     @Path("/verify-presentation")
-    @RolesAllowed("ROLE_SERVICE", "ROLE_OPERATOR", "ROLE_ADMIN")
+    @RolesAllowed("ROLE_API", "ROLE_OPERATOR", "ROLE_ADMIN")
     @Authorize(action = "identity.eudi.verify")
     @Operation(summary = "Verify an EUDI wallet PID presentation and resolve the identity (ADR-0094 tier-0)")
     suspend fun verifyPresentation(request: VerifyPresentationRequest): Response {
@@ -51,7 +51,7 @@ class EudiPresentationResource(private val eudiVerify: EudiVerifyPresentationUse
 
     @POST
     @Path("/verify-mdoc")
-    @RolesAllowed("ROLE_SERVICE", "ROLE_OPERATOR", "ROLE_ADMIN")
+    @RolesAllowed("ROLE_API", "ROLE_OPERATOR", "ROLE_ADMIN")
     @Authorize(action = "identity.eudi.verify")
     @Operation(summary = "Verify an ISO 18013-5 mdoc PID (CBOR/COSE) and resolve the identity (ADR-0094 tier-0)")
     suspend fun verifyMdoc(request: VerifyMdocRequest): Response {

--- a/openbank-pid-service/src/main/kotlin/com/openbank/pid/infrastructure/rest/PartyResource.kt
+++ b/openbank-pid-service/src/main/kotlin/com/openbank/pid/infrastructure/rest/PartyResource.kt
@@ -101,7 +101,7 @@ class PartyResource(
      */
     @POST
     @Path("/register-identity")
-    @RolesAllowed("ROLE_SERVICE", "ROLE_OPERATOR", "ROLE_ADMIN")
+    @RolesAllowed("ROLE_API", "ROLE_OPERATOR", "ROLE_ADMIN")
     @Authorize(action = "identity.register")
     @Operation(summary = "Register an onboarded identity into the pid resolver index (issue #1294)")
     suspend fun registerIdentity(request: RegisterIdentityRequest): Response {
@@ -138,7 +138,7 @@ class PartyResource(
      */
     @POST
     @Path("/resolve")
-    @RolesAllowed("ROLE_SERVICE", "ROLE_OPERATOR", "ROLE_ADMIN")
+    @RolesAllowed("ROLE_API", "ROLE_OPERATOR", "ROLE_ADMIN")
     @Authorize(action = "identity.resolve")
     @Operation(summary = "Resolve applicant identity before party creation (ADR-0072, issue #699)")
     suspend fun resolve(request: ResolvePartyRequest): Response {
@@ -233,7 +233,7 @@ class PartyResource(
      */
     @POST
     @Path("/{id}/external-ids")
-    @RolesAllowed("ROLE_SERVICE", "ROLE_OPERATOR", "ROLE_ADMIN")
+    @RolesAllowed("ROLE_API", "ROLE_OPERATOR", "ROLE_ADMIN")
     @Authorize(action = "identity.link")
     @Operation(summary = "Link an external identifier to an existing party (ADR-0072 §5)")
     suspend fun linkExternalId(@PathParam("id") id: UUID, request: LinkExternalIdRequest): Response {

--- a/openbank-psd2-service/src/main/kotlin/com/openbank/psd2/infrastructure/client/ConsentServiceRestClient.kt
+++ b/openbank-psd2-service/src/main/kotlin/com/openbank/psd2/infrastructure/client/ConsentServiceRestClient.kt
@@ -26,7 +26,7 @@ import java.time.LocalDate
 /**
  * Typed client for consent-service's real REST surface (`/api/v1/consents`), replacing the
  * always-`ACTIVE`/always-`true` [StubConsentServiceClient] for the load-bearing AIS read/validate
- * gate (issue #1500). Every endpoint is `@RolesAllowed(ROLE_SERVICE, ROLE_OPERATOR, ROLE_ADMIN)`
+ * gate (issue #1500). Every endpoint is `@RolesAllowed(ROLE_API, ROLE_OPERATOR, ROLE_ADMIN)`
  * plus an OPA `@Authorize` action on consent-service, so calls carry an M2M bearer via
  * [OidcClientRequestReactiveFilter] (oidc-client `openbank-services` → ROLE_OPERATOR), the same
  * pattern account-service's `TransactionServiceRestClient` uses.

--- a/openbank-sanctions-service/src/main/kotlin/com/openbank/sanctions/infrastructure/rest/SanctionsListResource.kt
+++ b/openbank-sanctions-service/src/main/kotlin/com/openbank/sanctions/infrastructure/rest/SanctionsListResource.kt
@@ -25,13 +25,13 @@ import java.util.UUID
 class SanctionsListResource(private val service: SanctionsListService) {
 
     @GET
-    @RolesAllowed("ROLE_VIEWER", "ROLE_OPERATOR", "ROLE_ADMIN", "ROLE_SERVICE")
+    @RolesAllowed("ROLE_VIEWER", "ROLE_OPERATOR", "ROLE_ADMIN", "ROLE_API")
     @Authorize(action = "sanctions.list", resource = "")
     suspend fun listAll(): Response = Response.ok(service.listAll()).build()
 
     @GET
     @Path("/{id}")
-    @RolesAllowed("ROLE_VIEWER", "ROLE_OPERATOR", "ROLE_ADMIN", "ROLE_SERVICE")
+    @RolesAllowed("ROLE_VIEWER", "ROLE_OPERATOR", "ROLE_ADMIN", "ROLE_API")
     @Authorize(action = "sanctions.read", resource = "#id")
     suspend fun getById(@PathParam("id") id: UUID): Response =
         service.getById(id)?.let { Response.ok(it).build() } ?: Response.status(404).build()

--- a/openbank-sanctions-service/src/main/kotlin/com/openbank/sanctions/infrastructure/rest/SanctionsResource.kt
+++ b/openbank-sanctions-service/src/main/kotlin/com/openbank/sanctions/infrastructure/rest/SanctionsResource.kt
@@ -26,13 +26,13 @@ import java.util.UUID
 class SanctionsResource(private val useCase: SanctionsUseCase) {
 
     @GET
-    @RolesAllowed("ROLE_VIEWER", "ROLE_OPERATOR", "ROLE_ADMIN", "ROLE_SERVICE")
+    @RolesAllowed("ROLE_VIEWER", "ROLE_OPERATOR", "ROLE_ADMIN", "ROLE_API")
     @Authorize(action = "sanctions.list", resource = "")
     suspend fun listAll() = useCase.listChecks()
 
     @POST
     @Path("/screen")
-    @RolesAllowed("ROLE_OPERATOR", "ROLE_ADMIN", "ROLE_SERVICE")
+    @RolesAllowed("ROLE_OPERATOR", "ROLE_ADMIN", "ROLE_API")
     @Authorize(action = "sanctions.create", resource = "")
     suspend fun screen(cmd: ScreenEntityCommand) = Response.status(201).entity(useCase.screen(cmd)).build()
 
@@ -42,25 +42,25 @@ class SanctionsResource(private val useCase: SanctionsUseCase) {
     // Renamed from sanctions.review (issue #938 follow-up): "clear" is a distinctive four-eyes
     // verb, kept apart from `release` (payment-hold release elsewhere in the fleet) for clean
     // audit separation — a wrongly-cleared true positive here is a real sanctions violation.
-    // No ROLE_SERVICE on this endpoint, confirmed no M2M caller — safe to four-eyes gate.
+    // No ROLE_API on this endpoint, confirmed no M2M caller — safe to four-eyes gate.
     @Authorize(action = "sanctions.clear", resource = "")
     suspend fun review(cmd: ReviewCommand) = useCase.review(cmd)
 
     @GET
     @Path("/{id}")
-    @RolesAllowed("ROLE_VIEWER", "ROLE_OPERATOR", "ROLE_ADMIN", "ROLE_SERVICE")
+    @RolesAllowed("ROLE_VIEWER", "ROLE_OPERATOR", "ROLE_ADMIN", "ROLE_API")
     @Authorize(action = "sanctions.read", resource = "#id")
     suspend fun get(@PathParam("id") id: UUID) = useCase.getById(id) ?: throw NotFoundException()
 
     @GET
     @Path("/hits")
-    @RolesAllowed("ROLE_VIEWER", "ROLE_OPERATOR", "ROLE_ADMIN", "ROLE_SERVICE")
+    @RolesAllowed("ROLE_VIEWER", "ROLE_OPERATOR", "ROLE_ADMIN", "ROLE_API")
     @Authorize(action = "sanctions.list", resource = "")
     suspend fun hits() = useCase.listHits()
 
     @GET
     @Path("/pending")
-    @RolesAllowed("ROLE_VIEWER", "ROLE_OPERATOR", "ROLE_ADMIN", "ROLE_SERVICE")
+    @RolesAllowed("ROLE_VIEWER", "ROLE_OPERATOR", "ROLE_ADMIN", "ROLE_API")
     @Authorize(action = "sanctions.list", resource = "")
     suspend fun pending() = useCase.listPending()
 }

--- a/openbank-sanctions-service/src/test/kotlin/com/openbank/sanctions/contract/SanctionsPactProviderVerificationTest.kt
+++ b/openbank-sanctions-service/src/test/kotlin/com/openbank/sanctions/contract/SanctionsPactProviderVerificationTest.kt
@@ -49,7 +49,7 @@ import org.junit.jupiter.api.extension.ExtendWith
  * failure — relevant if the folder is ever emptied ahead of a broker migration.
  *
  * Authentication: `POST /api/v1/sanctions/screen` is
- * `@RolesAllowed("ROLE_OPERATOR", "ROLE_ADMIN", "ROLE_SERVICE")`. `@TestSecurity` cannot annotate a
+ * `@RolesAllowed("ROLE_OPERATOR", "ROLE_ADMIN", "ROLE_API")`. `@TestSecurity` cannot annotate a
  * `@TestTemplate` method, so it is applied at class level and Pact replays every interaction as that
  * principal. The endpoint additionally carries `@Authorize(action = "sanctions.create")`; with
  * `authz.enforce` at its production default of `true` and no OPA sidecar in a test JVM the

--- a/openbank-sca-service/src/main/kotlin/com/openbank/sca/infrastructure/rest/ScaResource.kt
+++ b/openbank-sca-service/src/main/kotlin/com/openbank/sca/infrastructure/rest/ScaResource.kt
@@ -200,7 +200,7 @@ class ScaResource(
 
     @POST
     @Path("/challenges")
-    @RolesAllowed("ROLE_SERVICE", "ROLE_OPERATOR", "ROLE_ADMIN")
+    @RolesAllowed("ROLE_API", "ROLE_OPERATOR", "ROLE_ADMIN")
     @Authorize(action = "scaChallenge.initiate")
     suspend fun initiate(
         request: InitiateScaRequest,
@@ -241,7 +241,7 @@ class ScaResource(
 
     @POST
     @Path("/challenges/{id}/verify")
-    @RolesAllowed("ROLE_SERVICE", "ROLE_OPERATOR", "ROLE_ADMIN")
+    @RolesAllowed("ROLE_API", "ROLE_OPERATOR", "ROLE_ADMIN")
     @Authorize(action = "scaChallenge.verify", resource = "#id")
     suspend fun verify(@PathParam("id") id: UUID, request: VerifyScaRequest): ScaChallengeResponse {
         val challenge = verifySca.verify(VerifyScaCommand(id, request.partyId, request.otp))
@@ -250,7 +250,7 @@ class ScaResource(
 
     @GET
     @Path("/challenges/{id}")
-    @RolesAllowed("ROLE_SERVICE", "ROLE_OPERATOR", "ROLE_ADMIN")
+    @RolesAllowed("ROLE_API", "ROLE_OPERATOR", "ROLE_ADMIN")
     @Authorize(action = "scaChallenge.read", resource = "#id")
     suspend fun get(@PathParam("id") id: UUID): ScaChallengeResponse =
         ScaChallengeResponse.from(getSca.getChallenge(id))
@@ -263,7 +263,7 @@ class ScaResource(
      */
     @GET
     @Path("/parties/{partyId}/challenges/pending")
-    @RolesAllowed("ROLE_SERVICE", "ROLE_OPERATOR", "ROLE_ADMIN", "ROLE_CUSTOMER")
+    @RolesAllowed("ROLE_API", "ROLE_OPERATOR", "ROLE_ADMIN", "ROLE_CUSTOMER")
     @Authorize(action = "scaChallenge.read", resource = "#partyId")
     suspend fun listPending(@PathParam("partyId") partyId: UUID): List<PendingScaResponse> =
         getSca.listPendingByParty(partyId).map { PendingScaResponse.from(it) }
@@ -275,7 +275,7 @@ class ScaResource(
      */
     @GET
     @Path("/parties/{partyId}/devices")
-    @RolesAllowed("ROLE_SERVICE", "ROLE_OPERATOR", "ROLE_ADMIN", "ROLE_CUSTOMER")
+    @RolesAllowed("ROLE_API", "ROLE_OPERATOR", "ROLE_ADMIN", "ROLE_CUSTOMER")
     @Authorize(action = "device.list", resource = "#partyId")
     suspend fun listDevices(@PathParam("partyId") partyId: UUID): List<EnrolledDeviceResponse> {
         val principalName = identity.principal?.name
@@ -294,7 +294,7 @@ class ScaResource(
      */
     @POST
     @Path("/parties/{partyId}/devices")
-    @RolesAllowed("ROLE_SERVICE", "ROLE_OPERATOR", "ROLE_ADMIN", "ROLE_CUSTOMER")
+    @RolesAllowed("ROLE_API", "ROLE_OPERATOR", "ROLE_ADMIN", "ROLE_CUSTOMER")
     @Authorize(action = "device.enroll", resource = "#partyId")
     suspend fun enroll(@PathParam("partyId") partyId: UUID, request: EnrollDeviceRequest): Response {
         // P1 ownership enforcement (defense-in-depth over OPA advisory mode, ADR-0021 security review):
@@ -330,7 +330,7 @@ class ScaResource(
      */
     @POST
     @Path("/challenges/{id}/decision")
-    @RolesAllowed("ROLE_SERVICE", "ROLE_OPERATOR", "ROLE_ADMIN", "ROLE_CUSTOMER")
+    @RolesAllowed("ROLE_API", "ROLE_OPERATOR", "ROLE_ADMIN", "ROLE_CUSTOMER")
     @Authorize(action = "scaChallenge.decide", resource = "#id")
     suspend fun decide(@PathParam("id") id: UUID, request: RecordDecisionRequest): ScaChallengeResponse {
         val challenge = recordDecision.recordDecision(
@@ -358,7 +358,7 @@ class ScaResource(
      */
     @POST
     @Path("/challenges/{id}/consume")
-    @RolesAllowed("ROLE_OPERATOR", "ROLE_SERVICE", "ROLE_ADMIN")
+    @RolesAllowed("ROLE_OPERATOR", "ROLE_API", "ROLE_ADMIN")
     @Authorize(action = "scaChallenge.consume", resource = "#id")
     suspend fun consume(@PathParam("id") id: UUID, request: ConsumeScaRequest): ScaChallengeResponse {
         val challenge = consumeSca.consume(

--- a/openbank-sca-service/src/test/kotlin/com/openbank/sca/contract/ScaPactFolderProviderVerificationTest.kt
+++ b/openbank-sca-service/src/test/kotlin/com/openbank/sca/contract/ScaPactFolderProviderVerificationTest.kt
@@ -77,7 +77,7 @@ import java.util.concurrent.TimeUnit
  */
 @QuarkusTest
 @QuarkusTestResource(com.openbank.sca.it.PostgresRedisTestResource::class)
-@TestSecurity(user = "pact-verifier", roles = ["ROLE_SERVICE", "ROLE_OPERATOR"])
+@TestSecurity(user = "pact-verifier", roles = ["ROLE_API", "ROLE_OPERATOR"])
 @Provider("openbank-sca-service")
 @PactFolder("../pacts")
 @IgnoreNoPactsToVerify(ignoreIoErrors = "true")

--- a/openbank-sca-service/src/test/kotlin/com/openbank/sca/contract/ScaPactProviderVerificationTest.kt
+++ b/openbank-sca-service/src/test/kotlin/com/openbank/sca/contract/ScaPactProviderVerificationTest.kt
@@ -46,7 +46,7 @@ import java.util.concurrent.TimeUnit
  */
 @QuarkusTest
 @QuarkusTestResource(com.openbank.sca.it.PostgresRedisTestResource::class)
-@TestSecurity(user = "pact-verifier", roles = ["ROLE_SERVICE", "ROLE_OPERATOR"])
+@TestSecurity(user = "pact-verifier", roles = ["ROLE_API", "ROLE_OPERATOR"])
 @Provider("openbank-sca-service")
 @PactBroker
 @IgnoreNoPactsToVerify(ignoreIoErrors = "true")

--- a/openbank-sdd-service/src/main/kotlin/com/openbank/sdd/infrastructure/rest/SddResource.kt
+++ b/openbank-sdd-service/src/main/kotlin/com/openbank/sdd/infrastructure/rest/SddResource.kt
@@ -47,7 +47,7 @@ import java.util.UUID
     name = "SEPA Direct Debit",
     description = "Debtor-side SDD mandate vault, authorisation and refund assessment (ADR-0036)",
 )
-@RolesAllowed("ROLE_OPERATOR", "ROLE_ADMIN", "ROLE_PAYMENTS", "ROLE_SERVICE")
+@RolesAllowed("ROLE_OPERATOR", "ROLE_ADMIN", "ROLE_PAYMENTS", "ROLE_API")
 class SddResource(
     private val register: RegisterMandateUseCase,
     private val confirm: ConfirmMandateUseCase,
@@ -82,7 +82,7 @@ class SddResource(
 
     @GET
     @Path("/mandates")
-    @RolesAllowed("ROLE_VIEWER", "ROLE_OPERATOR", "ROLE_ADMIN", "ROLE_PAYMENTS", "ROLE_SERVICE")
+    @RolesAllowed("ROLE_VIEWER", "ROLE_OPERATOR", "ROLE_ADMIN", "ROLE_PAYMENTS", "ROLE_API")
     @Authorize(action = "sdd.list")
     @Operation(summary = "List an account's mandates")
     fun listMandates(@QueryParam("accountId") accountId: UUID): Uni<Response> =
@@ -90,7 +90,7 @@ class SddResource(
 
     @GET
     @Path("/mandates/{id}")
-    @RolesAllowed("ROLE_VIEWER", "ROLE_OPERATOR", "ROLE_ADMIN", "ROLE_PAYMENTS", "ROLE_SERVICE")
+    @RolesAllowed("ROLE_VIEWER", "ROLE_OPERATOR", "ROLE_ADMIN", "ROLE_PAYMENTS", "ROLE_API")
     @Authorize(action = "sdd.read", resource = "#id")
     @Operation(summary = "Fetch a single mandate")
     fun getMandate(@PathParam("id") id: UUID): Uni<Response> =
@@ -161,7 +161,7 @@ class SddResource(
 
     @GET
     @Path("/mandates/{id}/refund-assessment")
-    @RolesAllowed("ROLE_VIEWER", "ROLE_OPERATOR", "ROLE_ADMIN", "ROLE_PAYMENTS", "ROLE_SERVICE")
+    @RolesAllowed("ROLE_VIEWER", "ROLE_OPERATOR", "ROLE_ADMIN", "ROLE_PAYMENTS", "ROLE_API")
     @Authorize(action = "sdd.read", resource = "#id")
     @Operation(summary = "Assess a post-settlement refund claim (8-week unconditional / B2B none)")
     fun assessRefund(

--- a/openbank-sdd-service/src/main/resources/docs/03-api.cs.md
+++ b/openbank-sdd-service/src/main/resources/docs/03-api.cs.md
@@ -109,5 +109,5 @@ Mandátové závady mapuje `MandateNotFoundMapper` (404) a `IllegalMandateTransi
 ## Autentizace a autorizace
 
 - **AuthN:** Keycloak OIDC, RS256 JWT bearer token (`auth-server-url .../realms/openbank`, klient `openbank-services`).
-- **AuthZ:** Quarkus `@RolesAllowed`. Mutace vyžadují jednu z `ROLE_OPERATOR`, `ROLE_ADMIN`, `ROLE_PAYMENTS`, `ROLE_SERVICE`; read endpointy (`GET` výpis/načtení, `GET refund-assessment`) navíc povolují `ROLE_VIEWER`.
+- **AuthZ:** Quarkus `@RolesAllowed`. Mutace vyžadují jednu z `ROLE_OPERATOR`, `ROLE_ADMIN`, `ROLE_PAYMENTS`, `ROLE_API`; read endpointy (`GET` výpis/načtení, `GET refund-assessment`) navíc povolují `ROLE_VIEWER`.
 - CORS je v dodávané konfiguraci omezen na `http://localhost:3000`; bezpečnostní hlavičky (CSP, HSTS, X-Frame-Options DENY, nosniff) jsou nastaveny na každé odpovědi.

--- a/openbank-sdd-service/src/main/resources/docs/03-api.en.md
+++ b/openbank-sdd-service/src/main/resources/docs/03-api.en.md
@@ -109,5 +109,5 @@ Mandate faults are mapped by `MandateNotFoundMapper` (404) and `IllegalMandateTr
 ## Authentication & authorisation
 
 - **AuthN:** Keycloak OIDC, RS256 JWT bearer token (`auth-server-url .../realms/openbank`, client `openbank-services`).
-- **AuthZ:** Quarkus `@RolesAllowed`. Mutations require one of `ROLE_OPERATOR`, `ROLE_ADMIN`, `ROLE_PAYMENTS`, `ROLE_SERVICE`; read endpoints (`GET` list/fetch, `GET refund-assessment`) additionally allow `ROLE_VIEWER`.
+- **AuthZ:** Quarkus `@RolesAllowed`. Mutations require one of `ROLE_OPERATOR`, `ROLE_ADMIN`, `ROLE_PAYMENTS`, `ROLE_API`; read endpoints (`GET` list/fetch, `GET refund-assessment`) additionally allow `ROLE_VIEWER`.
 - CORS is restricted to `http://localhost:3000` in the shipped config; security headers (CSP, HSTS, X-Frame-Options DENY, nosniff) are set on every response.

--- a/openbank-sdd-service/src/main/resources/docs/README.cs.md
+++ b/openbank-sdd-service/src/main/resources/docs/README.cs.md
@@ -22,5 +22,5 @@ Tato dokumentace je publikována přímo službou na management endpointu `/q/op
 - **Persistence:** PostgreSQL databáze `openbank_sdd`, Flyway migrace `V1` (tabulky `sdd_mandate`, `sdd_outbox`).
 - **Outbox:** `sdd_outbox` → Kafka topic `openbank.sdd.event` (kanál `sdd-events-out`).
 - **Idempotence:** idempotence přes přirozený klíč — opětovná registrace stejného `(creditorIdentifier, UMR)` vrátí uložený mandát. Žádná hlavička `Idempotency-Key` / Redis.
-- **Auth:** Keycloak OIDC (RS256 JWT); mutace vyžadují `ROLE_OPERATOR`/`ROLE_ADMIN`/`ROLE_PAYMENTS`/`ROLE_SERVICE`, čtení navíc povoluje `ROLE_VIEWER`.
+- **Auth:** Keycloak OIDC (RS256 JWT); mutace vyžadují `ROLE_OPERATOR`/`ROLE_ADMIN`/`ROLE_PAYMENTS`/`ROLE_API`, čtení navíc povoluje `ROLE_VIEWER`.
 - **Money-path:** **Ne** — `openbank-sdd-service` není v `rules.yaml: money_path_services`; v1 nikdy neprovádí nevratné zaúčtování.

--- a/openbank-sdd-service/src/main/resources/docs/README.en.md
+++ b/openbank-sdd-service/src/main/resources/docs/README.en.md
@@ -22,5 +22,5 @@ This documentation is published directly by the service at the management endpoi
 - **Persistence:** PostgreSQL database `openbank_sdd`, Flyway migration `V1` (tables `sdd_mandate`, `sdd_outbox`).
 - **Outbox:** `sdd_outbox` → Kafka topic `openbank.sdd.event` (channel `sdd-events-out`).
 - **Idempotency:** natural-key idempotent — re-registering the same `(creditorIdentifier, UMR)` returns the stored mandate. No `Idempotency-Key` header / Redis.
-- **Auth:** Keycloak OIDC (RS256 JWT); mutations require `ROLE_OPERATOR`/`ROLE_ADMIN`/`ROLE_PAYMENTS`/`ROLE_SERVICE`, reads additionally allow `ROLE_VIEWER`.
+- **Auth:** Keycloak OIDC (RS256 JWT); mutations require `ROLE_OPERATOR`/`ROLE_ADMIN`/`ROLE_PAYMENTS`/`ROLE_API`, reads additionally allow `ROLE_VIEWER`.
 - **Money-path:** **No** — `openbank-sdd-service` is not in `rules.yaml: money_path_services`; v1 never executes an irreversible posting.

--- a/openbank-sepa-instant/src/main/kotlin/com/openbank/sepainstant/infrastructure/rest/SctInstResource.kt
+++ b/openbank-sepa-instant/src/main/kotlin/com/openbank/sepainstant/infrastructure/rest/SctInstResource.kt
@@ -41,7 +41,7 @@ class SctInstResource @Inject constructor(
 ) {
 
     @GET
-    @RolesAllowed("ROLE_VIEWER", "ROLE_OPERATOR", "ROLE_ADMIN", "ROLE_PAYMENTS", "ROLE_SERVICE")
+    @RolesAllowed("ROLE_VIEWER", "ROLE_OPERATOR", "ROLE_ADMIN", "ROLE_PAYMENTS", "ROLE_API")
     @Authorize(action = "sctInstPayment.list")
     @Operation(summary = "List SCT Inst payments")
     fun listAll(): Uni<Response> = getUseCase.listAll().map { list ->
@@ -82,7 +82,7 @@ class SctInstResource @Inject constructor(
 
     @GET
     @Path("/debtor/{debtorAccountId}")
-    @RolesAllowed("ROLE_VIEWER", "ROLE_OPERATOR", "ROLE_ADMIN", "ROLE_PAYMENTS", "ROLE_SERVICE")
+    @RolesAllowed("ROLE_VIEWER", "ROLE_OPERATOR", "ROLE_ADMIN", "ROLE_PAYMENTS", "ROLE_API")
     @Authorize(action = "sctInstPayment.list", resource = "#debtorAccountId")
     @Operation(summary = "List payments by debtor account")
     fun listByDebtor(

--- a/openbank-sepa-payment/src/main/kotlin/com/openbank/sepa/infrastructure/rest/SepaPaymentResource.kt
+++ b/openbank-sepa-payment/src/main/kotlin/com/openbank/sepa/infrastructure/rest/SepaPaymentResource.kt
@@ -78,7 +78,7 @@ class SepaPaymentResource(
         Response.ok(paymentUseCase.getPayment(paymentId).toResponse()).build()
 
     @GET
-    @RolesAllowed("ROLE_VIEWER", "ROLE_OPERATOR", "ROLE_ADMIN", "ROLE_PAYMENTS", "ROLE_SERVICE")
+    @RolesAllowed("ROLE_VIEWER", "ROLE_OPERATOR", "ROLE_ADMIN", "ROLE_PAYMENTS", "ROLE_API")
     @Authorize(action = "sepaPayment.list")
     @Operation(summary = "List SEPA payments")
     suspend fun listPayments(
@@ -115,7 +115,7 @@ class SepaPaymentResource(
     @Path("/returns")
     @Consumes(MediaType.APPLICATION_XML)
     @Produces(MediaType.APPLICATION_JSON)
-    @RolesAllowed("ROLE_SERVICE", "ROLE_ADMIN")
+    @RolesAllowed("ROLE_API", "ROLE_ADMIN")
     @Authorize(action = "sepaPayment.handleReturn")
     @Operation(summary = "Handle inbound pacs.004 payment return from clearing")
     suspend fun handlePaymentReturn(pacs004Xml: String): Response {

--- a/openbank-sepa-payment/src/main/resources/docs/01-overview.cs.md
+++ b/openbank-sepa-payment/src/main/resources/docs/01-overview.cs.md
@@ -52,7 +52,7 @@
 - **admin-ui / platbu iniciující kanály** (přes Keycloak token) — operátoři s `ROLE_PAYMENTS` / `ROLE_OPERATOR` iniciují převody.
 - **clearing / ledger pipeline** — konzumují emitované Kafka události (ne přímí REST volající).
 - **provoz / clearing back-office** — řídí stavové přechody (`PROCESSING` → `COMPLETED` / `RETURNED`).
-- **service volající** — `ROLE_SERVICE` smí vypisovat platby.
+- **service volající** — `ROLE_API` smí vypisovat platby.
 
 ## Závislosti
 

--- a/openbank-sepa-payment/src/main/resources/docs/01-overview.en.md
+++ b/openbank-sepa-payment/src/main/resources/docs/01-overview.en.md
@@ -52,7 +52,7 @@
 - **admin-ui / payment-initiating channels** (via Keycloak token) — operators with `ROLE_PAYMENTS` / `ROLE_OPERATOR` initiate transfers.
 - **clearing / ledger pipeline** — consume the emitted Kafka events (not direct REST callers).
 - **operations / clearing back-office** — drive status transitions (`PROCESSING` → `COMPLETED` / `RETURNED`).
-- **service callers** — `ROLE_SERVICE` may list payments.
+- **service callers** — `ROLE_API` may list payments.
 
 ## Dependencies
 

--- a/openbank-sepa-payment/src/main/resources/docs/03-api.cs.md
+++ b/openbank-sepa-payment/src/main/resources/docs/03-api.cs.md
@@ -18,7 +18,7 @@ Všechny endpointy vyžadují **Keycloak Bearer token** (realm `openbank`). Role
 |---|---|
 | `POST /sepa-payments` | `ROLE_OPERATOR`, `ROLE_ADMIN`, `ROLE_PAYMENTS` |
 | `GET /sepa-payments/{id}` | `ROLE_VIEWER`, `ROLE_OPERATOR`, `ROLE_ADMIN`, `ROLE_PAYMENTS` |
-| `GET /sepa-payments` | `ROLE_VIEWER`, `ROLE_OPERATOR`, `ROLE_ADMIN`, `ROLE_PAYMENTS`, `ROLE_SERVICE` |
+| `GET /sepa-payments` | `ROLE_VIEWER`, `ROLE_OPERATOR`, `ROLE_ADMIN`, `ROLE_PAYMENTS`, `ROLE_API` |
 | `PATCH /sepa-payments/{id}/status` | `ROLE_OPERATOR`, `ROLE_ADMIN`, `ROLE_PAYMENTS` |
 
 Stavový přechod je navíc střežen OPA přes `@Authorize(action = "sepaPayment.transitionStatus", resource = "#paymentId")` — defaultně advisory, vynucováno při `AUTHZ_ENFORCE=true` (ADR-0034).

--- a/openbank-sepa-payment/src/main/resources/docs/03-api.en.md
+++ b/openbank-sepa-payment/src/main/resources/docs/03-api.en.md
@@ -18,7 +18,7 @@ All endpoints require a **Keycloak Bearer token** (realm `openbank`). Roles are 
 |---|---|
 | `POST /sepa-payments` | `ROLE_OPERATOR`, `ROLE_ADMIN`, `ROLE_PAYMENTS` |
 | `GET /sepa-payments/{id}` | `ROLE_VIEWER`, `ROLE_OPERATOR`, `ROLE_ADMIN`, `ROLE_PAYMENTS` |
-| `GET /sepa-payments` | `ROLE_VIEWER`, `ROLE_OPERATOR`, `ROLE_ADMIN`, `ROLE_PAYMENTS`, `ROLE_SERVICE` |
+| `GET /sepa-payments` | `ROLE_VIEWER`, `ROLE_OPERATOR`, `ROLE_ADMIN`, `ROLE_PAYMENTS`, `ROLE_API` |
 | `PATCH /sepa-payments/{id}/status` | `ROLE_OPERATOR`, `ROLE_ADMIN`, `ROLE_PAYMENTS` |
 
 The status transition is additionally guarded by OPA via `@Authorize(action = "sepaPayment.transitionStatus", resource = "#paymentId")` — advisory by default, enforced when `AUTHZ_ENFORCE=true` (ADR-0034).

--- a/openbank-sepa-payment/src/main/resources/openapi.yaml
+++ b/openbank-sepa-payment/src/main/resources/openapi.yaml
@@ -3,7 +3,7 @@
 openapi: 3.1.0
 info:
   title: SEPA Payment Service API
-  version: 1.3.0
+  version: 1.4.0
   description: >-
     SEPA credit transfer lifecycle — create, query, status transitions. On create, debtor and
     creditor names are synchronously screened against the sanctions lists (ADR-0032): a clean payment

--- a/openbank-sepa-payment/src/main/resources/openapi.yaml
+++ b/openbank-sepa-payment/src/main/resources/openapi.yaml
@@ -94,7 +94,7 @@ paths:
       summary: Handle inbound pacs.004 payment return from clearing
       operationId: handleSepaPaymentReturn
       security:
-        - bearerAuth: [ROLE_SERVICE, ROLE_ADMIN]
+        - bearerAuth: [ROLE_API, ROLE_ADMIN]
       requestBody:
         required: true
         content:

--- a/openbank-settlement-service/src/main/kotlin/com/openbank/settlement/infrastructure/rest/SettlementResource.kt
+++ b/openbank-settlement-service/src/main/kotlin/com/openbank/settlement/infrastructure/rest/SettlementResource.kt
@@ -39,7 +39,7 @@ import java.util.UUID
 class SettlementResource(private val settlementUseCase: SettlementUseCase) {
 
     @POST
-    @RolesAllowed(Roles.SERVICE, Roles.OPERATOR, Roles.ADMIN)
+    @RolesAllowed(Roles.API, Roles.OPERATOR, Roles.ADMIN)
     @Authorize(action = "settlement.create", resource = "")
     @Operation(summary = "Originate a settlement and start its workflow")
     suspend fun originate(request: CreateSettlementRequest): Response {

--- a/openbank-standing-order-service/src/main/kotlin/com/openbank/standingorder/infrastructure/rest/StandingOrderResource.kt
+++ b/openbank-standing-order-service/src/main/kotlin/com/openbank/standingorder/infrastructure/rest/StandingOrderResource.kt
@@ -30,7 +30,7 @@ import java.util.UUID
 class StandingOrderResource(private val useCase: StandingOrderUseCase) {
 
     @POST
-    @RolesAllowed("ROLE_SERVICE", "ROLE_OPERATOR", "ROLE_ADMIN")
+    @RolesAllowed("ROLE_API", "ROLE_OPERATOR", "ROLE_ADMIN")
     suspend fun create(req: CreateStandingOrderRequest): Response {
         val order = useCase.create(
             CreateStandingOrderCommand(
@@ -45,35 +45,35 @@ class StandingOrderResource(private val useCase: StandingOrderUseCase) {
     }
 
     @GET
-    @RolesAllowed("ROLE_SERVICE", "ROLE_OPERATOR", "ROLE_ADMIN")
+    @RolesAllowed("ROLE_API", "ROLE_OPERATOR", "ROLE_ADMIN")
     suspend fun listAll() = useCase.listAll().map { it.toResponse() }
 
     @GET
     @Path("/{id}")
-    @RolesAllowed("ROLE_SERVICE", "ROLE_OPERATOR", "ROLE_ADMIN")
+    @RolesAllowed("ROLE_API", "ROLE_OPERATOR", "ROLE_ADMIN")
     suspend fun get(@PathParam("id") id: UUID) = useCase.getById(id) ?: throw NotFoundException()
 
     @GET
     @Path("/party/{partyId}")
-    @RolesAllowed("ROLE_SERVICE", "ROLE_OPERATOR", "ROLE_ADMIN")
+    @RolesAllowed("ROLE_API", "ROLE_OPERATOR", "ROLE_ADMIN")
     suspend fun listByParty(@PathParam("partyId") partyId: UUID) = useCase.listByParty(partyId).map { it.toResponse() }
 
     @POST
     @Path("/{id}/pause")
-    @RolesAllowed("ROLE_SERVICE", "ROLE_OPERATOR", "ROLE_ADMIN")
+    @RolesAllowed("ROLE_API", "ROLE_OPERATOR", "ROLE_ADMIN")
     @Authorize(action = "standingOrder.pause", resource = "#id")
     suspend fun pause(@PathParam("id") id: UUID, @HeaderParam("X-Customer-Party-Id") actor: String?) =
         useCase.pause(id, actor(actor)).toResponse()
 
     @POST
     @Path("/{id}/resume")
-    @RolesAllowed("ROLE_SERVICE", "ROLE_OPERATOR", "ROLE_ADMIN")
+    @RolesAllowed("ROLE_API", "ROLE_OPERATOR", "ROLE_ADMIN")
     suspend fun resume(@PathParam("id") id: UUID, @HeaderParam("X-Customer-Party-Id") actor: String?) =
         useCase.resume(id, actor(actor)).toResponse()
 
     @DELETE
     @Path("/{id}")
-    @RolesAllowed("ROLE_SERVICE", "ROLE_OPERATOR", "ROLE_ADMIN")
+    @RolesAllowed("ROLE_API", "ROLE_OPERATOR", "ROLE_ADMIN")
     suspend fun cancel(@PathParam("id") id: UUID, @HeaderParam("X-Customer-Party-Id") actor: String?): Response {
         useCase.cancel(id, actor(actor))
         return Response.noContent().build()
@@ -81,13 +81,13 @@ class StandingOrderResource(private val useCase: StandingOrderUseCase) {
 
     @PATCH
     @Path("/{id}/record-execution")
-    @RolesAllowed("ROLE_SERVICE", "ROLE_OPERATOR", "ROLE_ADMIN")
+    @RolesAllowed("ROLE_API", "ROLE_OPERATOR", "ROLE_ADMIN")
     suspend fun recordExecution(@PathParam("id") id: UUID): Response =
         Response.ok(useCase.confirmExecution(id).toResponse()).build()
 
     @PATCH
     @Path("/{id}/record-failure")
-    @RolesAllowed("ROLE_SERVICE", "ROLE_OPERATOR", "ROLE_ADMIN")
+    @RolesAllowed("ROLE_API", "ROLE_OPERATOR", "ROLE_ADMIN")
     suspend fun recordFailure(@PathParam("id") id: UUID): Response =
         Response.ok(useCase.recordFailure(id).toResponse()).build()
 

--- a/openbank-statement-service/src/main/kotlin/com/openbank/statement/infrastructure/rest/CloseRunResource.kt
+++ b/openbank-statement-service/src/main/kotlin/com/openbank/statement/infrastructure/rest/CloseRunResource.kt
@@ -30,7 +30,7 @@ import java.util.UUID
 @Path("/api/v1/statements/close-runs")
 @Produces(MediaType.APPLICATION_JSON)
 @Tag(name = "Statement close runs", description = "Scheduled close cadence telemetry + manual retry (ADR-0069)")
-@RolesAllowed("ROLE_VIEWER", "ROLE_OPERATOR", "ROLE_ADMIN", "ROLE_AUDITOR", "ROLE_SERVICE")
+@RolesAllowed("ROLE_VIEWER", "ROLE_OPERATOR", "ROLE_ADMIN", "ROLE_AUDITOR", "ROLE_API")
 class CloseRunResource(private val query: CloseRunQueryUseCase, private val runClose: RunCloseUseCase) {
 
     @GET
@@ -55,7 +55,7 @@ class CloseRunResource(private val query: CloseRunQueryUseCase, private val runC
         query.failuresForRun(runId).map { Response.ok(it).build() }
 
     @POST
-    @RolesAllowed("ROLE_OPERATOR", "ROLE_ADMIN", "ROLE_SERVICE")
+    @RolesAllowed("ROLE_OPERATOR", "ROLE_ADMIN", "ROLE_API")
     @Authorize(action = "statement.close-run.trigger", resource = "")
     @Operation(summary = "Trigger a manual catch-up close pass now (operator retry)")
     fun trigger(): Uni<Response> = runClose.runClose(CloseTrigger.MANUAL).map { Response.accepted(it).build() }

--- a/openbank-statement-service/src/main/kotlin/com/openbank/statement/infrastructure/rest/StatementResource.kt
+++ b/openbank-statement-service/src/main/kotlin/com/openbank/statement/infrastructure/rest/StatementResource.kt
@@ -32,7 +32,7 @@ import java.util.UUID
 @Produces(MediaType.APPLICATION_JSON)
 @Consumes(MediaType.APPLICATION_JSON)
 @Tag(name = "Statements", description = "Account statements: per-pocket period-close + on-demand render (ADR-0035)")
-@RolesAllowed("ROLE_VIEWER", "ROLE_OPERATOR", "ROLE_ADMIN", "ROLE_AUDITOR", "ROLE_SERVICE")
+@RolesAllowed("ROLE_VIEWER", "ROLE_OPERATOR", "ROLE_ADMIN", "ROLE_AUDITOR", "ROLE_API")
 class StatementResource(
     private val closePeriod: ClosePeriodUseCase,
     private val renderStatement: RenderStatementUseCase,
@@ -42,7 +42,7 @@ class StatementResource(
 
     @POST
     @Path("/{accountId}/close")
-    @RolesAllowed("ROLE_OPERATOR", "ROLE_ADMIN", "ROLE_SERVICE")
+    @RolesAllowed("ROLE_OPERATOR", "ROLE_ADMIN", "ROLE_API")
     @Authorize(action = "statement.close", resource = "#accountId")
     @Operation(summary = "Close a month for every pocket of an account (assigns sequences, reconciles fail-closed)")
     fun close(

--- a/openbank-statement-service/src/main/resources/docs/03-api.cs.md
+++ b/openbank-statement-service/src/main/resources/docs/03-api.cs.md
@@ -6,8 +6,8 @@ REST kontrakt je formalizován v [`openapi.yaml`](../openapi.yaml) (OpenAPI 3.1.
 
 Keycloak OIDC (RS256 bearer). Resource jsou role-gated přes `@RolesAllowed`:
 
-- **Čtení** (list, render, export, dotazy na close-run): `ROLE_VIEWER`, `ROLE_OPERATOR`, `ROLE_ADMIN`, `ROLE_AUDITOR`, `ROLE_SERVICE`.
-- **Mutace** (uzávěrka období, manuální spuštění close-run): `ROLE_OPERATOR`, `ROLE_ADMIN`, `ROLE_SERVICE`.
+- **Čtení** (list, render, export, dotazy na close-run): `ROLE_VIEWER`, `ROLE_OPERATOR`, `ROLE_ADMIN`, `ROLE_AUDITOR`, `ROLE_API`.
+- **Mutace** (uzávěrka období, manuální spuštění close-run): `ROLE_OPERATOR`, `ROLE_ADMIN`, `ROLE_API`.
 
 Odchozí volání do služeb transaction / balance / account / party nesou samostatný **client-credentials** M2M token (`openbank-services`, `ROLE_OPERATOR`), přidaný `OidcClientRequestReactiveFilter`.
 

--- a/openbank-statement-service/src/main/resources/docs/03-api.en.md
+++ b/openbank-statement-service/src/main/resources/docs/03-api.en.md
@@ -6,8 +6,8 @@ The REST contract is formalised in [`openapi.yaml`](../openapi.yaml) (OpenAPI 3.
 
 Keycloak OIDC (RS256 bearer). The resources are role-gated with `@RolesAllowed`:
 
-- **Reads** (list, render, export, close-run queries): `ROLE_VIEWER`, `ROLE_OPERATOR`, `ROLE_ADMIN`, `ROLE_AUDITOR`, `ROLE_SERVICE`.
-- **Mutations** (period-close, manual close-run trigger): `ROLE_OPERATOR`, `ROLE_ADMIN`, `ROLE_SERVICE`.
+- **Reads** (list, render, export, close-run queries): `ROLE_VIEWER`, `ROLE_OPERATOR`, `ROLE_ADMIN`, `ROLE_AUDITOR`, `ROLE_API`.
+- **Mutations** (period-close, manual close-run trigger): `ROLE_OPERATOR`, `ROLE_ADMIN`, `ROLE_API`.
 
 Outbound calls to transaction / balance / account / party services carry a separate **client-credentials** M2M token (`openbank-services`, `ROLE_OPERATOR`), attached by `OidcClientRequestReactiveFilter`.
 

--- a/openbank-statement-service/src/main/resources/docs/README.cs.md
+++ b/openbank-statement-service/src/main/resources/docs/README.cs.md
@@ -22,5 +22,5 @@ Tato dokumentace je publikována přímo službou na management endpointu `/q/op
 - **Perzistence:** dedikovaná databáze `openbank_statement`, Flyway migrace V1..V3. Ukládá se pouze záznam uzávěrky období — nikdy ne vyrenderované bajty výpisu.
 - **Outbox:** `statement_outbox` → Kafka topic `openbank.statement.event` (událost `account.statement.period.closed.v1`); příchozí projekce z `openbank.accounts.account.created`.
 - **Idempotence:** uzávěrka období je idempotentní na `(accountId, pocketCurrency, periodFrom, periodTo)` — opakované spuštění vrátí existující uzávěrku, nikdy ne novou právní sekvenci.
-- **Autentizace:** Keycloak OIDC; čtení povoluje `ROLE_VIEWER`/`ROLE_OPERATOR`/`ROLE_ADMIN`/`ROLE_AUDITOR`/`ROLE_SERVICE`, mutace (uzávěrka, manuální běh) vyžadují `ROLE_OPERATOR`/`ROLE_ADMIN`/`ROLE_SERVICE`. Odchozí čtení upstreamů používají M2M token client-credentials.
+- **Autentizace:** Keycloak OIDC; čtení povoluje `ROLE_VIEWER`/`ROLE_OPERATOR`/`ROLE_ADMIN`/`ROLE_AUDITOR`/`ROLE_API`, mutace (uzávěrka, manuální běh) vyžadují `ROLE_OPERATOR`/`ROLE_ADMIN`/`ROLE_API`. Odchozí čtení upstreamů používají M2M token client-credentials.
 - **Money-path:** Ne — statement-service není v `rules.yaml: money_path_services` (rekonciliuje proti penězům, ale s nimi nehýbe).

--- a/openbank-statement-service/src/main/resources/docs/README.en.md
+++ b/openbank-statement-service/src/main/resources/docs/README.en.md
@@ -22,5 +22,5 @@ This documentation is published directly by the service at the management endpoi
 - **Persistence:** dedicated database `openbank_statement`, Flyway migrations V1..V3. Only the period-close record is stored — never rendered statement bytes.
 - **Outbox:** `statement_outbox` → Kafka topic `openbank.statement.event` (event `account.statement.period.closed.v1`); inbound projection from `openbank.accounts.account.created`.
 - **Idempotency:** period-close is idempotent on `(accountId, pocketCurrency, periodFrom, periodTo)` — a re-run returns the existing close, never a new legal sequence.
-- **Auth:** Keycloak OIDC; reads allow `ROLE_VIEWER`/`ROLE_OPERATOR`/`ROLE_ADMIN`/`ROLE_AUDITOR`/`ROLE_SERVICE`, mutations (close, manual run) require `ROLE_OPERATOR`/`ROLE_ADMIN`/`ROLE_SERVICE`. Outbound upstream reads use a client-credentials M2M token.
+- **Auth:** Keycloak OIDC; reads allow `ROLE_VIEWER`/`ROLE_OPERATOR`/`ROLE_ADMIN`/`ROLE_AUDITOR`/`ROLE_API`, mutations (close, manual run) require `ROLE_OPERATOR`/`ROLE_ADMIN`/`ROLE_API`. Outbound upstream reads use a client-credentials M2M token.
 - **Money-path:** No — statement-service is not in `rules.yaml: money_path_services` (it reconciles against, but does not move, money).

--- a/openbank-tpp-registry-service/src/main/kotlin/com/openbank/tppregistry/infrastructure/rest/TppRegistryResource.kt
+++ b/openbank-tpp-registry-service/src/main/kotlin/com/openbank/tppregistry/infrastructure/rest/TppRegistryResource.kt
@@ -37,7 +37,7 @@ class TppRegistryResource(
 ) {
     @GET
     @Path("/check")
-    @RolesAllowed("ROLE_SERVICE", "ROLE_OPERATOR", "ROLE_ADMIN")
+    @RolesAllowed("ROLE_API", "ROLE_OPERATOR", "ROLE_ADMIN")
     suspend fun checkAuthorization(@QueryParam("tppId") tppId: String, @QueryParam("role") role: String): Response {
         val result = svc.checkAuthorization(
             CheckTppAuthorizationQuery(tppId, TppRole.valueOf(role.uppercase())),
@@ -72,7 +72,7 @@ class TppRegistryResource(
     }
 
     @GET
-    @RolesAllowed("ROLE_SERVICE", "ROLE_OPERATOR", "ROLE_ADMIN")
+    @RolesAllowed("ROLE_API", "ROLE_OPERATOR", "ROLE_ADMIN")
     suspend fun listTpps(
         @QueryParam("countryCode") countryCode: String?,
         @QueryParam("role") role: String?,
@@ -94,7 +94,7 @@ class TppRegistryResource(
 
     @GET
     @Path("/{tppId}")
-    @RolesAllowed("ROLE_SERVICE", "ROLE_OPERATOR", "ROLE_ADMIN")
+    @RolesAllowed("ROLE_API", "ROLE_OPERATOR", "ROLE_ADMIN")
     suspend fun getTpp(@PathParam("tppId") tppId: String): Response =
         Response.ok(svc.getTpp(GetTppQuery(tppId))).build()
 
@@ -126,7 +126,7 @@ class TppRegistryResource(
 
     @POST
     @Path("/sync/eba")
-    @RolesAllowed("ROLE_SERVICE", "ROLE_OPERATOR", "ROLE_ADMIN")
+    @RolesAllowed("ROLE_API", "ROLE_OPERATOR", "ROLE_ADMIN")
     suspend fun triggerEbaSync(@HeaderParam("Idempotency-Key") idempotencyKey: String?): Response {
         val cacheKey = idempotencyKey?.takeIf { it.isNotBlank() }?.let(::syncKey)
         cacheKey?.let { key ->
@@ -146,7 +146,7 @@ class TppRegistryResource(
 
     @GET
     @Path("/sync/state")
-    @RolesAllowed("ROLE_SERVICE", "ROLE_OPERATOR", "ROLE_ADMIN")
+    @RolesAllowed("ROLE_API", "ROLE_OPERATOR", "ROLE_ADMIN")
     suspend fun getSyncState(): Response = Response.ok(svc.getSyncState()).build()
 
     private fun registerKey(tppId: String, idempotencyKey: String) = "tpp:register:$tppId:$idempotencyKey"

--- a/openbank-tpp-registry-service/src/test/kotlin/com/openbank/tppregistry/contract/TppRegistryPactProviderVerificationTest.kt
+++ b/openbank-tpp-registry-service/src/test/kotlin/com/openbank/tppregistry/contract/TppRegistryPactProviderVerificationTest.kt
@@ -48,7 +48,7 @@ import org.junit.jupiter.api.extension.ExtendWith
  * `V1__init.sql` already seeds `CZ-CNB-TEST-AISP` ACTIVE/AISP with no QWAC expiry, so the state
  * handler below needs no setup either.
  *
- * `@TestSecurity` matches `checkAuthorization`'s `@RolesAllowed("ROLE_SERVICE", "ROLE_OPERATOR",
+ * `@TestSecurity` matches `checkAuthorization`'s `@RolesAllowed("ROLE_API", "ROLE_OPERATOR",
  * "ROLE_ADMIN")` — psd2 calls it with an M2M client-credentials token in production (ADR-0018).
  * `@TestSecurity` cannot annotate a `@TestTemplate`, hence the class-level annotation. The lone
  * `tpp-events-out` Kafka emitter is swapped to the in-memory connector so no broker is needed to
@@ -61,7 +61,7 @@ import org.junit.jupiter.api.extension.ExtendWith
 @QuarkusTest
 @QuarkusTestResource(TppRegistryPactProviderVerificationTest.InMemoryKafkaResource::class)
 @QuarkusTestResource(com.openbank.tppregistry.it.PostgresRedisTestResource::class)
-@TestSecurity(user = "pact-verifier", roles = ["ROLE_SERVICE", "ROLE_OPERATOR"])
+@TestSecurity(user = "pact-verifier", roles = ["ROLE_API", "ROLE_OPERATOR"])
 @Provider("openbank-tpp-registry-service")
 @PactFolder("../pacts")
 @IgnoreNoPactsToVerify(ignoreIoErrors = "true")

--- a/openbank-transaction-service/src/main/kotlin/com/openbank/transaction/infrastructure/rest/ApprovalResource.kt
+++ b/openbank-transaction-service/src/main/kotlin/com/openbank/transaction/infrastructure/rest/ApprovalResource.kt
@@ -27,7 +27,7 @@ import org.eclipse.microprofile.openapi.annotations.tags.Tag
  * [com.openbank.libs.authz.AuthorizeInterceptor] with HTTP 202 and a
  * `PendingApproval` id; a DIFFERENT operator decides it here, then the maker
  * retries the original call with an `X-Approval-Id` header. Note `transaction.reverse`
- * also permits `Roles.SERVICE` (M2M) makers, unlike account.freeze's human-only maker
+ * also permits `Roles.API` (M2M) makers, unlike account.freeze's human-only maker
  * set — this endpoint's checker role set is unaffected either way, since
  * `authz.four-eyes.enforce` stays false and no blocking behavior is introduced here.
  */

--- a/openbank-transaction-service/src/main/kotlin/com/openbank/transaction/infrastructure/rest/TransactionResource.kt
+++ b/openbank-transaction-service/src/main/kotlin/com/openbank/transaction/infrastructure/rest/TransactionResource.kt
@@ -57,7 +57,7 @@ class TransactionResource(
 ) {
 
     @GET
-    @RolesAllowed(Roles.SERVICE, Roles.VIEWER, Roles.OPERATOR, Roles.ADMIN)
+    @RolesAllowed(Roles.API, Roles.VIEWER, Roles.OPERATOR, Roles.ADMIN)
     @Authorize(action = "transaction.list", resource = "")
     @Operation(summary = "List transactions for an account")
     suspend fun listTransactions(
@@ -71,7 +71,7 @@ class TransactionResource(
 
     @GET
     @Path("/search")
-    @RolesAllowed(Roles.SERVICE, Roles.VIEWER, Roles.OPERATOR, Roles.ADMIN)
+    @RolesAllowed(Roles.API, Roles.VIEWER, Roles.OPERATOR, Roles.ADMIN)
     @Authorize(action = "transaction.search", resource = "")
     @Operation(summary = "Search transactions — BIAN aligned, supports IBAN/BBAN/reference/counterparty/amount/date")
     @Suppress("LongParameterList")
@@ -121,7 +121,7 @@ class TransactionResource(
 
     @GET
     @Path("/{transactionId}")
-    @RolesAllowed(Roles.SERVICE, Roles.VIEWER, Roles.OPERATOR, Roles.ADMIN)
+    @RolesAllowed(Roles.API, Roles.VIEWER, Roles.OPERATOR, Roles.ADMIN)
     @Authorize(action = "transaction.read", resource = "#transactionId")
     @Operation(summary = "Get transaction by ID")
     suspend fun getTransaction(@PathParam("transactionId") transactionId: UUID): Response {
@@ -166,7 +166,7 @@ class TransactionResource(
 
     @POST
     @Path("/{transactionId}/reverse")
-    @RolesAllowed(Roles.SERVICE, Roles.OPERATOR, Roles.ADMIN)
+    @RolesAllowed(Roles.API, Roles.OPERATOR, Roles.ADMIN)
     @Authorize(action = "transaction.reverse", resource = "")
     @Operation(summary = "Reverse a completed transaction — R-transaction return path (ADR-0111)")
     suspend fun reverseTransaction(

--- a/openbank-transaction-service/src/main/resources/docs/01-overview.cs.md
+++ b/openbank-transaction-service/src/main/resources/docs/01-overview.cs.md
@@ -52,9 +52,9 @@ Když je transakce iniciována, ságu spustí synchronně: vloží hold na zdroj
 
 ## Volající
 
-- **platební služby** (`sepa-payment`, `sepa-instant`, `domestic-payment`, `swift-service`, `standing-order-service`, `clearing-service`) — iniciují transakce (`ROLE_SERVICE`/`ROLE_OPERATOR`).
+- **platební služby** (`sepa-payment`, `sepa-instant`, `domestic-payment`, `swift-service`, `standing-order-service`, `clearing-service`) — iniciují transakce (`ROLE_API`/`ROLE_OPERATOR`).
 - **fx-service** — upstream zdroj kurzů pro zúčtování v jiné měně (tato služba volá *směrem ven* k němu).
-- **agent-service** — read-only MCP nástroj nad historií transakcí (`ROLE_SERVICE`).
+- **agent-service** — read-only MCP nástroj nad historií transakcí (`ROLE_API`).
 - **admin-ui** — operátoři / compliance čtou historii transakcí a vyhledávají.
 
 ## Závislosti

--- a/openbank-transaction-service/src/main/resources/docs/01-overview.en.md
+++ b/openbank-transaction-service/src/main/resources/docs/01-overview.en.md
@@ -52,9 +52,9 @@ When a transaction is initiated it runs the saga synchronously: place a hold on 
 
 ## Callers
 
-- **payment services** (`sepa-payment`, `sepa-instant`, `domestic-payment`, `swift-service`, `standing-order-service`, `clearing-service`) — initiate transactions (`ROLE_SERVICE`/`ROLE_OPERATOR`).
+- **payment services** (`sepa-payment`, `sepa-instant`, `domestic-payment`, `swift-service`, `standing-order-service`, `clearing-service`) — initiate transactions (`ROLE_API`/`ROLE_OPERATOR`).
 - **fx-service** — upstream rate source for cross-currency settlement (this service calls *out* to it).
-- **agent-service** — read-only MCP tool over transaction history (`ROLE_SERVICE`).
+- **agent-service** — read-only MCP tool over transaction history (`ROLE_API`).
 - **admin-ui** — operators / compliance read transaction history and search.
 
 ## Dependencies

--- a/openbank-transaction-service/src/main/resources/docs/README.cs.md
+++ b/openbank-transaction-service/src/main/resources/docs/README.cs.md
@@ -23,5 +23,5 @@ Tato dokumentace je publikována přímo službou na management endpointu `/q/op
 - **Outbox:** `transaction_outbox` → Kafka topic `openbank.transactions.transaction.initiated` (a typy událostí `.completed` / `.failed`)
 - **Idempotence:** `idempotencyKey` od volajícího na iniciačním příkazu → unique constraint na `(idempotency_key, booking_date)` a na platební sáze
 - **Orchestrace:** synchronní platební sága (hold → zaúčtování → debet/kredit → dokončení, s kompenzací)
-- **Auth:** Keycloak OIDC; čtení vyžaduje `ROLE_SERVICE`/`ROLE_VIEWER`/`ROLE_OPERATOR`/`ROLE_ADMIN`, iniciace vyžaduje `ROLE_OPERATOR`
+- **Auth:** Keycloak OIDC; čtení vyžaduje `ROLE_API`/`ROLE_VIEWER`/`ROLE_OPERATOR`/`ROLE_ADMIN`, iniciace vyžaduje `ROLE_OPERATOR`
 - **Money-path služba** (viz `rules.yaml: money_path_services`) — 2 schválení + threat model u každé změny

--- a/openbank-transaction-service/src/main/resources/docs/README.en.md
+++ b/openbank-transaction-service/src/main/resources/docs/README.en.md
@@ -23,5 +23,5 @@ This documentation is published directly by the service at the management endpoi
 - **Outbox:** `transaction_outbox` → Kafka topic `openbank.transactions.transaction.initiated` (also `.completed` / `.failed` event types)
 - **Idempotency:** caller-supplied `idempotencyKey` on the initiate command → unique constraint on `(idempotency_key, booking_date)` and on the payment saga
 - **Orchestration:** synchronous payment saga (hold → ledger post → debit/credit → complete, with compensation)
-- **Auth:** Keycloak OIDC; reads require `ROLE_SERVICE`/`ROLE_VIEWER`/`ROLE_OPERATOR`/`ROLE_ADMIN`, initiation requires `ROLE_OPERATOR`
+- **Auth:** Keycloak OIDC; reads require `ROLE_API`/`ROLE_VIEWER`/`ROLE_OPERATOR`/`ROLE_ADMIN`, initiation requires `ROLE_OPERATOR`
 - **Money-path service** (see `rules.yaml: money_path_services`) — 2 approvals + threat model on every change

--- a/openbank-transaction-service/src/test/kotlin/com/openbank/transaction/infrastructure/rest/TransactionSecurityContractTest.kt
+++ b/openbank-transaction-service/src/test/kotlin/com/openbank/transaction/infrastructure/rest/TransactionSecurityContractTest.kt
@@ -55,7 +55,7 @@ class TransactionSecurityContractTest {
         listOf("listTransactions", "searchTransactions", "getTransaction").forEach { name ->
             assertThat(rolesOf(name))
                 .describedAs("%s read roles", name)
-                .containsExactlyInAnyOrder("ROLE_SERVICE", "ROLE_VIEWER", "ROLE_OPERATOR", "ROLE_ADMIN")
+                .containsExactlyInAnyOrder("ROLE_API", "ROLE_VIEWER", "ROLE_OPERATOR", "ROLE_ADMIN")
         }
     }
 

--- a/openbank-vop-service/src/main/kotlin/com/openbank/vop/infrastructure/client/AccountServiceClient.kt
+++ b/openbank-vop-service/src/main/kotlin/com/openbank/vop/infrastructure/client/AccountServiceClient.kt
@@ -22,7 +22,7 @@ import org.eclipse.microprofile.rest.client.inject.RegisterRestClient
  *
  * We deliberately do NOT send the `X-Customer-Party-Id` header account-service uses for
  * owner-scoping: VoP is a service-to-service check on behalf of a payer who is *not* the account
- * owner, so the M2M token (ROLE_SERVICE) is the right identity and owner-scoping must not apply.
+ * owner, so the M2M token (ROLE_API) is the right identity and owner-scoping must not apply.
  */
 @RegisterRestClient(configKey = "account-service")
 @RegisterProvider(OidcClientRequestReactiveFilter::class)


### PR DESCRIPTION
## Co

Uzavírá #2442 podle sekvencování z issue: **nejdřív grant, pak sweep, nakonec zatvrzení brány**. Tři commity v tom pořadí, protože jinak by každý krok zvlášť byl buď nefunkční, nebo lživý.

## 1. Grant — a horší nález, než issue popisoval

`service-account-openbank-services` v gitops realm template **vůbec neexistoval**. Přitom 23 služeb bere M2M token z klienta `openbank-services` (`grant.type: client`). Každý takový token nesl **prázdnou množinu realm rolí** — žádné `@RolesAllowed` ho nemohlo pustit pod žádným jménem.

To je druhý, nezávislý důvod téhož 403: jméno `ROLE_SERVICE` bylo mrtvé **a** volající byl bez rolí. Proto si toho nikdo nevšiml — obě poloviny selhávaly tiše a navzájem se maskovaly.

- `service-account-openbank-services` → `realmRoles: ["ROLE_API"]` (dev realm účet už měl, přibylo ROLE_API k jeho ROLE_OPERATOR)
- `ROLE_CREDIT_RISK` + `ROLE_LENDING_OFFICER` vytvořeny jako reálné realm role — v `@RolesAllowed` lending-service jsou od jeho vzniku, v realmu nebyly nikdy, takže credit-risk officer se ke svým endpointům nikdy nedostal (procházel jen ROLE_ADMIN/ROLE_COMPLIANCE). Vytvořeny, ne smazány: four-eyes rozdělení (officer otevírá, credit risk rozhoduje) je dokumentovaný návrh služby.

**ROLE_API, ne ROLE_OPERATOR** — `service-account-openbank-edge` dnes nese ROLE_OPERATOR, což drží i každý lidský operátor; recyklovat ji by znamenalo pustit personál všude, kde se otevře M2M cesta.

**Známé omezení, řečené předem:** Keycloak čte tyhle JSONy přes `--import-realm` jen při **cold startu**. Na živém sandboxu je potřeba roli účtu jednou přiřadit ručně (admin konzole / kcadm). Soubor je zdroj pravdy pro čerstvý cluster, ne live-apply mechanismus.

## 2. Sweep

152 `@RolesAllowed` míst ve 28 modulech (16 money-path, plus sdílený `ReconciliationSummaryContract` v `libs-runtime`) → `ROLE_API`.

Teprve po kroku 1 to není kosmetika: ty endpointy se stávají dostupnými pro M2M volajícího, kterého tam autoři zamýšleli.

- 153 literálů + 47 `Roles.SERVICE` → `ROLE_API` / `Roles.API`
- `Roles.SERVICE` **smazána**, ne deprecated — konstanta se stejnou hodnotou jen zve k obnovení rozkolu
- 87 zmínek v próze: 67 service docs + `bearerAuth` scope list v sepa-payment `openapi.yaml`. Grepnuto **zvlášť**, protože brána komentáře strippuje a nikdy by je neoznačila — přesně lekce zachycená v #2464

Tři komentáře musely ručně, protože mechanická náhrada by z nich udělala lež:
- **FinrepResource** vysvětloval, že ROLE_API je vynechána *protože ji nikdo nemá*. Teď ji někdo má, takže se změnil důvod: FINREP/COREP M2M grant pořád nemají, ale je to rozhodnutí o admin-UI-only ploše, ne pozorování o mrtvé roli.
- **FxPactProviderVerificationTest** tvrdil, že účet má `realmRoles: ["ROLE_OPERATOR"]` — pravda o dev realmu, nepravda o gitops, kde účet neexistoval.
- **AmlPactProviderVerificationTest** — tvrzení platí i pod novým jménem.

`ROLE_SERVICE_PSD2` v balance docs netknuto: jiný identifikátor (chycen word boundary), vlastní — stále otevřená — otázka.

## 3. Brána zatvrzena

Partial case (mrtvé jméno vedle živého) byl `::warning`, protože 163 míst čekalo na rozhodnutí. Rozhodnutí padla, počet je 0 → hard-fail.

Proč si ta tišší polovina blokování zaslouží: endpoint dál pouští ostatní role, takže zvenčí nic nevypadá rozbitě — jen volající, pro kterého bylo mrtvé jméno vyhrazeno, je odmítán donekonečna a nikde není chyba. Advisory nad prázdnou množinou je jen budoucí regrese čekající na merge.

## Ověření

| co | výsledek |
|---|---|
| falsifikace: `"ROLE_SERVICE"` zpět do jedné živé anotace | exit 1 s tím nálezem |
| obnoveno | exit 0, `346 sites checked against 15 role(s); every named role is issued by a realm` |
| ktlint + detekt + test (JDK 25) | zeleně: libs-domain, libs-runtime, account, ledger, notification, sca, pid, sepa-payment, fx, aml, finrep |
| ostatní brány | `check-advisory-gate-registration`, `check-authz-pdp-parity --enforce`, `check-no-service-principal-type` — vše 0 |
| generátory | `gen-network-policies.py` i všechny OPA bundle generátory bez diffu (žádná editace `rules.yaml`/rego ⇒ žádný restamp) |

Komentáře v `rules.yaml` a `rest.rego` o tom, že `ROLE_SERVICE` nikdo nedostane, jsem **nechal** — jsou dál faktograficky pravdivé (role v realmu není) a jejich úprava by restampovala 44 bundle souborů kvůli prózi.

## Linked issues

Closes #2442
