### PR TITLE
test(notification): pin the notification channel and template by value, not by type

### DIFF
--- a/openbank-notification-service/src/test/kotlin/com/openbank/notification/contract/NotificationRequestMessagePactConsumerTest.kt
+++ b/openbank-notification-service/src/test/kotlin/com/openbank/notification/contract/NotificationRequestMessagePactConsumerTest.kt
@@ -27,6 +27,18 @@ import java.util.UUID
  *
  * The consumer reads {partyId, channel, template, recipient, variables} from the Kafka message.
  * account-service verifies this via AccountEventPactProviderVerificationTest.
+ *
+ * MATCHER POLICY (issue #2425): `channel` and `template` are pinned BY VALUE; everything else is
+ * type-matched. The split is deliberate — a `type` matcher is right for free-form payload and
+ * wrong for a discriminator, because it makes the assertion vacuous exactly where the value is
+ * the contract. Nothing in CI can see that: `pact-drift-check.yml` only asks whether the
+ * committed pact matches what this test generates, and `check-pact-provider-replay.py` only asks
+ * whether something replays it. Neither can tell that the replay is being asked nothing.
+ *
+ * IMPORTANT — regenerate on change: re-run
+ * `./gradlew :openbank-notification-service:test --tests "*NotificationRequestMessagePactConsumerTest*"`
+ * and commit the updated `pacts/openbank-notification-service-openbank-account-service.json` in
+ * the same PR. `pact-drift-check.yml` enforces this.
  */
 @ExtendWith(PactConsumerTestExt::class)
 @PactTestFor(
@@ -43,8 +55,25 @@ class NotificationRequestMessagePactConsumerTest {
         .withContent(
             newJsonBody { o ->
                 o.uuid("partyId")
-                o.stringType("channel", "PUSH")
-                o.stringType("template", "TRANSACTION_COMPLETED")
+                // stringValue, NOT stringType: `channel` and `template` are closed
+                // vocabularies whose VALUE is the whole point of the message — channel decides
+                // whether the customer gets a push, an SMS or an email, template decides which
+                // message they receive. A type matcher accepts any string, so the contract
+                // pinned the shape and nothing else: measured on #2425, changing the producer
+                // to emit `"channel": "CARRIER_PIGEON"` left the provider replay GREEN, while
+                // deleting the field correctly went red — the replay works, it simply was not
+                // being asked anything about values.
+                //
+                // The producer (account-service's KafkaNotificationRequestPublisher) emits
+                // these two as literals for this event, so an exact match is the honest
+                // contract, not over-coupling. The sibling pact one file over
+                // (openbank-balance-service-openbank-account-service.json) already treats its
+                // `eventType` discriminator this way.
+                o.stringValue("channel", "PUSH")
+                o.stringValue("template", "TRANSACTION_COMPLETED")
+                // Free-form per message — recipient is a party id / address and the amounts
+                // vary, so pinning their VALUES would be exactly the coupling Pact exists to
+                // avoid. Type matchers are right here.
                 o.stringType("recipient")
                 o.`object`("variables") { v ->
                     v.stringType("amount", "50.00")

--- a/pacts/openbank-notification-service-openbank-account-service.json
+++ b/pacts/openbank-notification-service-openbank-account-service.json
@@ -28,14 +28,6 @@
       },
       "matchingRules": {
         "body": {
-          "$.channel": {
-            "combine": "AND",
-            "matchers": [
-              {
-                "match": "type"
-              }
-            ]
-          },
           "$.partyId": {
             "combine": "AND",
             "matchers": [
@@ -46,14 +38,6 @@
             ]
           },
           "$.recipient": {
-            "combine": "AND",
-            "matchers": [
-              {
-                "match": "type"
-              }
-            ]
-          },
-          "$.template": {
             "combine": "AND",
             "matchers": [
               {


### PR DESCRIPTION
Refs #2425 — fixes the notification pact; the sweep tallied in the comments stays open.

## What

`channel` and `template` in the `TRANSACTION_COMPLETED` notification pact move from `stringType` to `stringValue`, so they are compared by exact value instead of by shape. The pact is regenerated in the same commit (`pact-drift-check.yml` requires it).

`recipient`, `variables.amount` and `variables.currency` stay type-matched — those are genuinely free-form per message, and pinning them would be the coupling Pact exists to avoid.

## Why these two specifically

They are closed vocabularies whose **value is the message**: `channel` decides whether the customer gets a push, an SMS or an email; `template` decides which message they receive. A type matcher accepts any string, so the contract asserted nothing about either.

The sibling pact one directory over (`openbank-balance-service-openbank-account-service.json`) already leaves its `eventType` discriminator unmatched, i.e. compared by value. This brings the notification pact to the same convention.

## Verification — done, not read off the matchers

| | result |
|---|---|
| producer emits `"channel": "CARRIER_PIGEON"` | `AccountPactFolderProviderVerificationTest` **FAILED** |
| unmodified producer | `BUILD SUCCESSFUL` |
| `:openbank-notification-service:ktlintCheck detekt` | `BUILD SUCCESSFUL` |

Before this change the first row was **green** — that is the whole defect.

Also confirmed account-service's `KafkaNotificationRequestPublisher` emits both fields as literals for this event, so the exact match cannot over-constrain a real producer.

## Not in scope

The issue's sweep note: `transaction-service → fx-service` type-matches `baseCurrency`/`quoteCurrency`, and `consent-service → sca-service` type-matches `purpose`/`status` (traced as safe — it fails closed). Those are separate pacts and separate PRs; #2425's tally is the right place to track them.

🤖 Generated with [Claude Code](https://claude.com/claude-code)