### PR TITLE
fix(infra): derive Kafka client edges from mounted ConfigMaps, not just Deployment env

### DIFF
--- a/openbank-infra/gitops/components/kafka/network-policies.yaml
+++ b/openbank-infra/gitops/components/kafka/network-policies.yaml
@@ -53,6 +53,9 @@ spec:
               kubernetes.io/metadata.name: anacredit
         - namespaceSelector:
             matchLabels:
+              kubernetes.io/metadata.name: analytics
+        - namespaceSelector:
+            matchLabels:
               kubernetes.io/metadata.name: audit
         - namespaceSelector:
             matchLabels:

--- a/openbank-infra/scripts/gen-network-policies.py
+++ b/openbank-infra/scripts/gen-network-policies.py
@@ -190,6 +190,33 @@ def main():
                 if kns == MESSAGING_NS:
                     kafka_clients.add(ns)
 
+        elif kind == "ConfigMap" and ns:
+            # A Kafka client edge is NOT always visible in Deployment env (issue #2163).
+            # analytics-sink supplies its bootstrap URL through an `override.properties`
+            # ConfigMap mounted via QUARKUS_CONFIG_LOCATIONS, precisely because SmallRye's
+            # env-var reverse-mapping is ambiguous for its hyphenated channel name (#686) —
+            # so scanning env alone made a live consumer structurally invisible and left
+            # `analytics` out of the derived broker allow-list.
+            #
+            # It is not an outage today only because Strimzi's own
+            # openbank-cluster-network-policy-kafka opens 9092/9093 with no `from` selector
+            # and NetworkPolicies union. The defect is that the derived file reads as an
+            # exhaustive inventory of Kafka clients and is not one — so the day that blanket
+            # policy is tightened (a reasonable hardening step) the missing edges become a
+            # silent outage with no warning from the generator.
+            #
+            # ConfigMaps are namespaced, so the client namespace is the ConfigMap's own — no
+            # mount-tracing needed. A ConfigMap naming the broker in a namespace that does not
+            # actually talk to it would over-admit by one namespace; an unmounted ConfigMap
+            # naming the broker is not a shape this tree has, and over-admitting is the safe
+            # direction for an allow-list compared with silently omitting a live consumer.
+            for v in (doc.get("data") or {}).values():
+                if not isinstance(v, str):
+                    continue
+                for _, kns, _kport in KAFKA_RE.findall(v):
+                    if kns == MESSAGING_NS:
+                        kafka_clients.add(ns)
+
         elif kind == "Kafka" and ns == MESSAGING_NS:
             kafka_dir = os.path.dirname(path)
 


### PR DESCRIPTION
Closes #2163

## What

`gen-network-policies.py` now also scans `ConfigMap` `data` values for a broker bootstrap URL, not only Deployment/StatefulSet/Rollout container env.

## Why

`analytics-sink` is a live Kafka consumer that supplies its bootstrap URL through an `override.properties` ConfigMap mounted via `QUARKUS_CONFIG_LOCATIONS` — deliberately, because SmallRye's env-var reverse-mapping is ambiguous for its hyphenated channel name `analytics-events-in` (#686). Scanning env alone made that edge structurally invisible, so `analytics` was missing from the derived `kafka-broker-ingress-allow-list`. Same class as the env-vs-mounted-config footgun already documented in `openbank-infra/CLAUDE.md`.

It is not an outage today only because Strimzi's own `openbank-cluster-network-policy-kafka` opens 9092/9093 with no `from` selector and NetworkPolicies union. The defect is that a **derived** file reads as an exhaustive inventory and is not one — tighten that blanket policy and the missing edges become a silent outage, with no warning from the generator.

## Validated against a known-positive, not a clean re-run

Regenerating the whole tree produces **exactly one** new edge — `analytics` in `components/kafka/network-policies.yaml` — and changes no other file:

```
+        - namespaceSelector:
+            matchLabels:
+              kubernetes.io/metadata.name: analytics
```

Re-running the generator is idempotent, and the output parses as YAML.

## Scope note

Only the Kafka discovery is extended. The cross-service `URL_RE` edges could have the same blind spot for a mounted config, but nothing in this tree exercises it today and widening that scan changes many more files — worth its own look rather than riding along here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)