### PR TITLE
ci(governance): enforce openapi-route-conformance against a declared baseline (+ #2395 comment fix)

### DIFF
--- a/.github/openapi-route-conformance-baseline.txt
+++ b/.github/openapi-route-conformance-baseline.txt
@@ -1,0 +1,118 @@
+# openapi-route-conformance — DECLARED BACKLOG (see the script's module docstring).
+#
+# Every line is a route-level finding that already existed when the gate flipped to --enforce
+# on 2026-07-26 (issue #2314). The gate still compares every service on every run; this file
+# only declares which of its findings are known debt.
+#
+#   a finding not listed here  => NEW drift, the build fails
+#   a line here with no finding => the debt was paid, the build fails until the line is deleted
+#
+# So: to correct a spec, delete its line(s) here in the same PR. Never add a line to silence a
+# new finding — publishing the route (or deleting it) is the fix. Draining this file to empty
+# closes #2314; the per-service corrections are blocked on the unsatisfiable-bump gap (#2313).
+#
+# Format: <service> <served-not-published|published-not-served> <VERB> <absolute path>
+openbank-account-service served-not-published DELETE /api/v1/accounts/{accountId}/authorizations/{authorizationId}
+openbank-account-service served-not-published DELETE /api/v1/accounts/{accountId}/pockets/{currency}
+openbank-account-service served-not-published GET /api/v1/accounts/{accountId}/authorizations
+openbank-account-service served-not-published GET /api/v1/accounts/{accountId}/authorizations/check
+openbank-account-service served-not-published GET /api/v1/accounts/{accountId}/pockets
+openbank-account-service served-not-published GET /api/v1/accounts/{accountId}/pockets/resolve
+openbank-account-service served-not-published POST /api/v1/accounts/{accountId}/authorizations
+openbank-account-service served-not-published POST /api/v1/accounts/{accountId}/pockets
+openbank-agent-service published-not-served GET /q/health/live
+openbank-agent-service published-not-served GET /q/health/ready
+openbank-agent-service served-not-published GET /api/v1/admin/agents/halts
+openbank-agent-service served-not-published POST /api/v1/admin/agents/halt
+openbank-agent-service served-not-published POST /api/v1/admin/agents/resume
+openbank-balance-service served-not-published PUT /api/v1/balances/{accountId}/{currency}/overdraft-limit
+openbank-billing-service published-not-served GET /api/v1/info
+openbank-card-issuance-service served-not-published GET /api/v1/cards
+openbank-card-issuance-service served-not-published PUT /api/v1/cards/{id}/controls
+openbank-card-issuance-service served-not-published PUT /api/v1/cards/{id}/limits
+openbank-customer-edge served-not-published DELETE /customer/v1/accounts/{accountId}/pockets/{currency}
+openbank-customer-edge served-not-published DELETE /customer/v1/consents/{id}
+openbank-customer-edge served-not-published DELETE /customer/v1/devices/{id}
+openbank-customer-edge served-not-published DELETE /customer/v1/standing-orders/{id}
+openbank-customer-edge served-not-published GET /customer/v1/accounts/{accountId}/fees
+openbank-customer-edge served-not-published GET /customer/v1/accounts/{accountId}/interest
+openbank-customer-edge served-not-published GET /customer/v1/accounts/{accountId}/pockets
+openbank-customer-edge served-not-published GET /customer/v1/accounts/{accountId}/pockets/resolve
+openbank-customer-edge served-not-published GET /customer/v1/accounts/{accountId}/pockets/supported
+openbank-customer-edge served-not-published GET /customer/v1/accounts/{accountId}/pockets/{currency}/convert/quote
+openbank-customer-edge served-not-published GET /customer/v1/consents
+openbank-customer-edge served-not-published GET /customer/v1/disputes
+openbank-customer-edge served-not-published GET /customer/v1/kyc
+openbank-customer-edge served-not-published GET /customer/v1/loans
+openbank-customer-edge served-not-published GET /customer/v1/loans/{loanId}/schedule
+openbank-customer-edge served-not-published GET /customer/v1/notification-preferences
+openbank-customer-edge served-not-published GET /customer/v1/notifications/{id}
+openbank-customer-edge served-not-published GET /customer/v1/onboarding/terms
+openbank-customer-edge served-not-published GET /customer/v1/onboarding/terms/{code}/content
+openbank-customer-edge served-not-published GET /customer/v1/payment-sessions/{token}
+openbank-customer-edge served-not-published GET /customer/v1/payment-sessions/{token}/status
+openbank-customer-edge served-not-published GET /customer/v1/sca/pending
+openbank-customer-edge served-not-published GET /customer/v1/sdd/mandates
+openbank-customer-edge served-not-published GET /customer/v1/sepa-instant
+openbank-customer-edge served-not-published GET /customer/v1/standing-orders
+openbank-customer-edge served-not-published PATCH /customer/v1/profile/consent
+openbank-customer-edge served-not-published POST /customer/v1/accounts/{accountId}/pockets
+openbank-customer-edge served-not-published POST /customer/v1/accounts/{accountId}/pockets/{currency}/convert
+openbank-customer-edge served-not-published POST /customer/v1/accounts/{accountId}/pockets/{fromCurrency}/exchange
+openbank-customer-edge served-not-published POST /customer/v1/complaints
+openbank-customer-edge served-not-published POST /customer/v1/disputes
+openbank-customer-edge served-not-published POST /customer/v1/payment-sessions
+openbank-customer-edge served-not-published POST /customer/v1/sdd/mandates
+openbank-customer-edge served-not-published POST /customer/v1/sdd/mandates/{id}/cancel
+openbank-customer-edge served-not-published POST /customer/v1/sdd/mandates/{id}/resume
+openbank-customer-edge served-not-published POST /customer/v1/sdd/mandates/{id}/suspend
+openbank-customer-edge served-not-published POST /customer/v1/sepa-instant
+openbank-customer-edge served-not-published POST /customer/v1/sepa-instant/{paymentId}/recall
+openbank-customer-edge served-not-published POST /customer/v1/standing-orders
+openbank-customer-edge served-not-published POST /customer/v1/standing-orders/{id}/pause
+openbank-customer-edge served-not-published POST /customer/v1/standing-orders/{id}/resume
+openbank-customer-edge served-not-published POST /customer/v1/swift
+openbank-customer-edge served-not-published POST /customer/v1/transfers
+openbank-customer-edge served-not-published POST /customer/v1/vop/verify
+openbank-customer-edge served-not-published POST /customer/v1/webauthn/session/refresh
+openbank-customer-edge served-not-published POST /customer/v1/webauthn/session/revoke
+openbank-customer-edge served-not-published PUT /customer/v1/notification-preferences
+openbank-fx-service served-not-published GET /api/v1/fx/cnb/rates/{base}
+openbank-fx-service served-not-published POST /api/v1/fx/cnb/ingest
+openbank-interest-service served-not-published GET /api/v1/interest/accounts/{accountId}/effective-rate
+openbank-interest-service served-not-published GET /api/v1/interest/accruals
+openbank-ledger-service served-not-published POST /api/v1/ledger/fx-revaluation
+openbank-notification-service served-not-published GET /api/v1/preferences/party/{partyId}
+openbank-notification-service served-not-published PUT /api/v1/preferences/party/{partyId}
+openbank-party-service served-not-published DELETE /api/v1/parties/{id}
+openbank-party-service served-not-published GET /api/v1/parties/{id}/documents/{fileId}/content
+openbank-pid-service published-not-served GET /api/v1/parties/eudi/status-lists/{id}
+openbank-pid-service published-not-served POST /api/v1/parties/eudi/credential
+openbank-pid-service published-not-served POST /api/v1/parties/eudi/credential-offers
+openbank-pid-service published-not-served POST /api/v1/parties/eudi/credentials/{index}/revoke
+openbank-pid-service published-not-served POST /api/v1/parties/eudi/token
+openbank-pid-service served-not-published GET /api/v1/parties/eudistatus-lists/{id}
+openbank-pid-service served-not-published POST /api/v1/parties/eudicredential
+openbank-pid-service served-not-published POST /api/v1/parties/eudicredential-offers
+openbank-pid-service served-not-published POST /api/v1/parties/eudicredentials/{index}/revoke
+openbank-pid-service served-not-published POST /api/v1/parties/euditoken
+openbank-psd2-service served-not-published DELETE /open-banking/v2/consents/{consentId}
+openbank-psd2-service served-not-published GET /open-banking/sandbox/v2/accounts
+openbank-psd2-service served-not-published GET /open-banking/sandbox/v2/accounts/{accountId}/balances
+openbank-psd2-service served-not-published GET /open-banking/sandbox/v2/accounts/{accountId}/transactions
+openbank-psd2-service served-not-published GET /open-banking/sandbox/v2/health
+openbank-psd2-service served-not-published GET /open-banking/v2/consents/{consentId}
+openbank-psd2-service served-not-published GET /open-banking/v2/consents/{consentId}/status
+openbank-psd2-service served-not-published POST /open-banking/sandbox/v2/consents
+openbank-psd2-service served-not-published POST /open-banking/sandbox/v2/payments/{product}
+openbank-psd2-service served-not-published POST /open-banking/v2/consents
+openbank-sca-service served-not-published GET /api/v1/sca/parties/{partyId}/challenges/pending
+openbank-sca-service served-not-published POST /api/v1/sca/challenges/{id}/consume
+openbank-security-scanner served-not-published GET /api/v1/ict-incidents
+openbank-security-scanner served-not-published GET /api/v1/ict-incidents/{id}
+openbank-security-scanner served-not-published PATCH /api/v1/ict-incidents/{id}/status
+openbank-security-scanner served-not-published POST /api/v1/ict-incidents
+openbank-security-scanner served-not-published POST /api/v1/ict-incidents/{id}/regulatory-report
+openbank-sepa-instant served-not-published GET /api/v1/sepa-instant
+openbank-standing-order-service served-not-published GET /api/v1/standing-orders
+openbank-swift-service served-not-published GET /api/v1/swift/messages

--- a/.github/scripts/check-openapi-route-conformance.py
+++ b/.github/scripts/check-openapi-route-conformance.py
@@ -40,10 +40,30 @@ working tree, so it runs identically in CI and locally.
 
 Usage:
     check-openapi-route-conformance.py [--enforce] [--service <name>]
+                                       [--baseline <file>] [--write-baseline <file>]
 
 Modes (ADR-0144 gate graduation):
     default    advisory — findings are ::warning annotations, exit 0
     --enforce  findings are ::error annotations, exit 1
+
+THE BASELINE, and why it is not a hand-kept scope list. Enforcing on day one was impossible:
+104 pre-existing route-level findings across 21 services, and correcting a spec is blocked on
+the unsatisfiable-bump problem (#2313), so the backlog cannot be drained in one PR. The
+alternative — leaving the gate advisory — is the shape this repo has already ruled against: an
+advisory check over a GENERATED comparison has no judgement left to exercise, it just makes the
+drift mergeable (#2216).
+
+So the gate is ENFORCED against a declared baseline of the exact findings that existed on the
+day it flipped. Two directions, both hard failures:
+
+    a finding NOT in the baseline   NEW drift — the thing the gate exists to stop. Fails.
+    a baseline entry with NO finding  STALE — the debt was paid. Fails, telling you to delete
+                                    the line, so the list cannot outlive the debt it declares.
+
+That is deliberately the `KNOWN_UNCOVERED` shape of check-pact-provider-replay.py, and it is
+NOT the failure mode of pact-drift-check.yml (#2284): the baseline does not narrow what the
+gate *looks at* — every service is still compared every run — it only declares which of the
+findings it produces are already-known debt. The exclusions are the thing a human justifies.
 """
 
 from __future__ import annotations
@@ -55,6 +75,23 @@ from pathlib import Path
 
 HTTP_VERBS = ("GET", "POST", "PUT", "DELETE", "PATCH", "HEAD", "OPTIONS")
 SPEC_METHODS = tuple(v.lower() for v in HTTP_VERBS)
+
+BASELINE_HEADER = """\
+# openapi-route-conformance — DECLARED BACKLOG (see the script's module docstring).
+#
+# Every line is a route-level finding that already existed when the gate flipped to --enforce
+# on 2026-07-26 (issue #2314). The gate still compares every service on every run; this file
+# only declares which of its findings are known debt.
+#
+#   a finding not listed here  => NEW drift, the build fails
+#   a line here with no finding => the debt was paid, the build fails until the line is deleted
+#
+# So: to correct a spec, delete its line(s) here in the same PR. Never add a line to silence a
+# new finding — publishing the route (or deleting it) is the fix. Draining this file to empty
+# closes #2314; the per-service corrections are blocked on the unsatisfiable-bump gap (#2313).
+#
+# Format: <service> <served-not-published|published-not-served> <VERB> <absolute path>
+"""
 
 # A JAX-RS *client* stub carries the CALLEE's routes, not this service's served contract.
 CLIENT_HINT = re.compile(r"@RegisterRestClient")
@@ -171,10 +208,22 @@ def code_routes(service_dir: Path) -> set[str]:
     return routes
 
 
+def load_baseline(path: Path) -> set[str]:
+    """Declared, already-known findings — one `<service> <direction> <VERB> <path>` per line."""
+    entries: set[str] = set()
+    for raw in path.read_text(encoding="utf-8").splitlines():
+        line = raw.split("#", 1)[0].strip()
+        if line:
+            entries.add(" ".join(line.split()))
+    return entries
+
+
 def main() -> int:
     ap = argparse.ArgumentParser()
     ap.add_argument("--enforce", action="store_true")
     ap.add_argument("--service", help="check a single openbank-* module (default: the whole fleet)")
+    ap.add_argument("--baseline", help="file of declared, already-known findings (see module docstring)")
+    ap.add_argument("--write-baseline", help="rewrite the baseline file from the current findings")
     args = ap.parse_args()
 
     level = "error" if args.enforce else "warning"
@@ -185,7 +234,7 @@ def main() -> int:
             print(f"::error::openapi-route-conformance: no openapi.yaml for service {args.service!r}")
             return 1
 
-    findings = 0
+    found: dict[str, str] = {}   # "<service> <direction> <VERB> <path>" -> human sentence
     checked = 0
     no_resources: list[str] = []
 
@@ -204,24 +253,46 @@ def main() -> int:
 
         checked += 1
         for route in sorted(served - declared):
-            findings += 1
-            print(f"::{level}::openapi-route-conformance: {service}: served-not-published — "
-                  f"{route} is answered by a resource class and absent from openapi.yaml")
+            found[f"{service} served-not-published {route}"] = (
+                f"{service}: served-not-published — {route} is answered by a resource class "
+                f"and absent from openapi.yaml")
         for route in sorted(declared - served):
-            findings += 1
-            print(f"::{level}::openapi-route-conformance: {service}: published-not-served — "
-                  f"{route} is promised by openapi.yaml and no resource class declares it")
+            found[f"{service} published-not-served {route}"] = (
+                f"{service}: published-not-served — {route} is promised by openapi.yaml "
+                f"and no resource class declares it")
+
+    if args.write_baseline:
+        Path(args.write_baseline).write_text(
+            BASELINE_HEADER + "".join(f"{k}\n" for k in sorted(found)), encoding="utf-8")
+        print(f"check-openapi-route-conformance: wrote {len(found)} entr(ies) to {args.write_baseline}")
+        return 0
+
+    baseline = load_baseline(Path(args.baseline)) if args.baseline else set()
+    # `--service` compares one module, so the rest of the baseline is legitimately unmatched.
+    scoped = {e for e in baseline if not args.service or e.split(" ", 1)[0] == args.service}
+
+    new = sorted(k for k in found if k not in baseline)
+    stale = sorted(scoped - set(found))
+
+    for key in new:
+        print(f"::{level}::openapi-route-conformance: {found[key]}")
+    for key in sorted(k for k in found if k in baseline):
+        print(f"::notice::openapi-route-conformance: declared backlog — {found[key]}")
+    for key in stale:
+        print(f"::{level}::openapi-route-conformance: STALE baseline entry — {key!r} is no longer "
+              f"a finding. Delete the line from {args.baseline}; the declared backlog must not "
+              f"outlive the debt.")
 
     print(
         f"check-openapi-route-conformance: {checked} service(s) compared, "
         f"{len(no_resources)} skipped with no annotated resource class"
         + (f" ({', '.join(no_resources)})" if no_resources else "")
-        + f", {findings} route-level finding(s)."
+        + f", {len(found)} route-level finding(s), {len(baseline)} declared in the baseline, "
+        f"{len(new)} NEW, {len(stale)} stale."
     )
-    if findings and not args.enforce:
-        print("check-openapi-route-conformance: advisory — will become a hard gate "
-              "once the backlog is cleared (see rules.yaml: openapi_route_conformance).")
-    return 1 if (findings and args.enforce) else 0
+    if (new or stale) and not args.enforce:
+        print("check-openapi-route-conformance: advisory — no --enforce, so this is a warning.")
+    return 1 if ((new or stale) and args.enforce) else 0
 
 
 if __name__ == "__main__":

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -923,8 +923,14 @@ jobs:
           sudo install -m 0755 /tmp/oasdiff /usr/local/bin/oasdiff
           python3 .github/scripts/check-api-contract.py --base "${PR_DIFF_BASE}" --enforce
 
-      # ADVISORY — 114 findings on main the day this landed, so it cannot enforce yet; the
-      # backlog is tracked in rules.yaml: openapi_route_conformance. Add --enforce to flip.
+      # ENFORCED against a declared baseline (#2314). It landed advisory because 104 findings
+      # cannot be a merge blocker on day one — but an advisory check over a GENERATED comparison
+      # is a contradiction (#2216): there is no judgement left to exercise, advisory just makes
+      # the drift mergeable. So it now runs with --enforce against a file that declares those 104
+      # findings verbatim. A finding absent from the baseline fails the build; a baseline line
+      # with no matching finding ALSO fails, so the declaration cannot outlive the debt. The
+      # baseline does not narrow what is compared — every service is compared every run.
+      # Falsified before merge on all three paths (new finding / stale line / debt paid).
       #
       # The gate above classifies a spec's version bump against the previous revision of the
       # same document. Nothing asked whether the document is TRUE, which is how aml-service
@@ -935,8 +941,10 @@ jobs:
       #
       # Route SET only — it does not read schemas or status codes. Do not read a green here as
       # "this spec is true"; see the script header for the precise limits.
-      - name: "openapi-route-conformance — published contract vs served routes (advisory)"
-        run: python3 .github/scripts/check-openapi-route-conformance.py
+      - name: "openapi-route-conformance — published contract vs served routes (enforced)"
+        run: |
+          python3 .github/scripts/check-openapi-route-conformance.py --enforce \
+            --baseline .github/openapi-route-conformance-baseline.txt
 
       # ADVISORY until rules.yaml change_classes.db_change flips to enforced
       # (target 2026-08-15, ADR-0144) — add --enforce to the invocation to flip.

--- a/openbank-infra/gitops/components/accounts/account-opa-bundle.yaml
+++ b/openbank-infra/gitops/components/accounts/account-opa-bundle.yaml
@@ -9,7 +9,7 @@ metadata:
     app.kubernetes.io/name: account-service
     app.kubernetes.io/part-of: accounts
   annotations:
-    openbank.tech/policy-checksum: "eccc3eb7700f8bd8"
+    openbank.tech/policy-checksum: "e3b4cdb8c851f2a6"
 data:
   rest.rego: |
     # SPDX-License-Identifier: Apache-2.0
@@ -1587,9 +1587,9 @@ data:
           - "every route a resource class answers is published in that service's openapi.yaml"
           - "every route openapi.yaml promises is declared by a resource class"
         gate: openapi-route-conformance
-        enforced: advisory
-        target_enforce_date: "2026-09-30"
+        enforced: enforce                 # ADR-0144 graduation, ahead of the 2026-09-30 target (#2314)
         ci_producer: ".github/scripts/check-openapi-route-conformance.py"
+        baseline: ".github/openapi-route-conformance-baseline.txt"
         # api_contract (above) classifies a spec's version bump against the PREVIOUS REVISION of the
         # same document. Nothing asked whether the document is TRUE. ADR-0005 says "CI lints it with
         # Spectral so docs cannot drift from runtime" — there is no Spectral config in this repo and
@@ -1615,8 +1615,17 @@ data:
         # is a MISSING pair across two trees, so a PR touching only Kotlin never touches the spec and
         # a diff-scoped gate would see nothing.
         #
-        # Advisory because 114 pre-existing findings cannot be a merge blocker on day one. Flipping
-        # to enforced = add --enforce in ci.yml, once the backlog is cleared.
+        # ENFORCED AGAINST A DECLARED BASELINE (#2314). 104 pre-existing findings could not be a
+        # merge blocker on day one, and correcting a spec is blocked on the unsatisfiable-bump gap
+        # (#2313) — but leaving it advisory is the shape this repo has already ruled against: an
+        # advisory check over a GENERATED comparison has no judgement left to exercise, it just makes
+        # the drift mergeable (#2216). So the gate runs with --enforce against
+        # .github/openapi-route-conformance-baseline.txt, which declares those 104 findings verbatim.
+        # A finding NOT in that file fails the build (new drift, the thing the gate is for); a
+        # baseline line with no matching finding ALSO fails (the debt was paid — delete the line), so
+        # the declaration cannot outlive the debt. The baseline does not narrow what the gate LOOKS
+        # AT — every service is compared every run — which is what separates it from the
+        # pact-drift-check scope bug (#2284). #2314 closes when the file is empty.
       openapi_request_schema_conformance:
         detect: ["openbank-*/src/main/resources/openapi.yaml", "the JAX-RS request-body DTO the resource actually deserializes into"]
         require:

--- a/openbank-infra/gitops/components/accounts/account-opa-bundle.yaml
+++ b/openbank-infra/gitops/components/accounts/account-opa-bundle.yaml
@@ -9,7 +9,7 @@ metadata:
     app.kubernetes.io/name: account-service
     app.kubernetes.io/part-of: accounts
   annotations:
-    openbank.tech/policy-checksum: "e3b4cdb8c851f2a6"
+    openbank.tech/policy-checksum: "8f3a4abe770f6116"
 data:
   rest.rego: |
     # SPDX-License-Identifier: Apache-2.0
@@ -2281,12 +2281,36 @@ data:
         # fx + sepa-payment, sepa-instant, domestic-payment, fraud (SSDLC-audit rollout 2026-07-06) +
         # sanctions (2026-07-11: 3 domain files — screening/matching decision logic — matches the
         # "substantive domain math" criterion, not the thin-domain one; 67% local baseline).
-        # The remaining 7 (sca, consent, billing, clearing, swift, lending, settlement) stay excluded:
-        # each has only 1-2 domain files, and those files are plain data models (no branching
-        # money-movement logic), so mutation testing there is noise, not signal — re-confirmed by
-        # file count on 2026-07-11 (settlement and sanctions were both added to money_path_services
-        # after the 2026-07-07 note above; settlement re-confirmed thin, sanctions was the one that
-        # wasn't). Revisit if any of the remaining 7 grows real decision logic in its domain layer.
+        # The remaining 7 (sca, consent, billing, clearing, swift, lending, settlement) stay excluded.
+        #
+        # This list used to be justified by one blanket claim — "each has only 1-2 domain files, and
+        # those files are plain data models (no branching money-movement logic)". The file count was
+        # re-confirmed; the NO-BRANCHING half was never measured, and it is FALSE for three of the
+        # seven (#2395). Measured on 2026-07-26, counting `if (` / `when (` / `require(` / `check(`
+        # over every `src/main/kotlin/**/domain/**.kt` in each module — a deliberately narrow matcher,
+        # so these are lower bounds:
+        #
+        #     service     domain files   branch sites
+        #     sca                    2             11
+        #     consent                2              6
+        #     swift                  1              5
+        #     clearing               3              1
+        #     billing                2              0
+        #     lending                1              0
+        #     settlement             1              0
+        #
+        # So the exclusion rests on a DIFFERENT judgement, and it is stated here rather than hidden
+        # behind an inaccurate blanket: what sca, consent and swift branch on is input VALIDATION and
+        # state-transition legality, not money-movement arithmetic — pitest's value is in the
+        # arithmetic, and no pitest plugin is wired for any of the 7. billing needs its own reason:
+        # its domain layer genuinely does not branch, but its real fee-waiver logic (ADR-0143 phase 2)
+        # lives in `application/usecase/FeeAssessmentService`, OUTSIDE pitest's `domain.*`
+        # targetClasses — so widening the target would be the fix there, not adding the module.
+        #
+        # Revisit if any of the 7 grows money-movement ARITHMETIC in its domain layer; a rising branch
+        # count alone is not the trigger, and re-measure before repeating any claim in this block.
+        # (Historical note: settlement and sanctions were both added to money_path_services after the
+        # 2026-07-07 note above; settlement re-confirmed thin, sanctions was the one that wasn't.)
         # True baselines at rollout (after fixing the KILLED-quote parsing bug): account 49%,
         # transaction 46%, balance 55%, ledger 65%, fx 73%.
         blocked_on: "blocking flip requires each service to sustain >=70% mutation kill score on the weekly run; account/transaction/balance/ledger are below it today (see baselines above)"

--- a/openbank-infra/gitops/components/accounts/account-service.yaml
+++ b/openbank-infra/gitops/components/accounts/account-service.yaml
@@ -37,7 +37,7 @@ spec:
       annotations:
         # Rolls the pod when the OPA bundle changes — subPath mounts do NOT hot-reload.
         # Kept in sync by gen-account-opa-bundle.sh (do not hand-edit).
-        openbank.tech/policy-checksum: "eccc3eb7700f8bd8"
+        openbank.tech/policy-checksum: "e3b4cdb8c851f2a6"
     spec:
       securityContext:
         runAsNonRoot: true

--- a/openbank-infra/gitops/components/accounts/account-service.yaml
+++ b/openbank-infra/gitops/components/accounts/account-service.yaml
@@ -37,7 +37,7 @@ spec:
       annotations:
         # Rolls the pod when the OPA bundle changes — subPath mounts do NOT hot-reload.
         # Kept in sync by gen-account-opa-bundle.sh (do not hand-edit).
-        openbank.tech/policy-checksum: "e3b4cdb8c851f2a6"
+        openbank.tech/policy-checksum: "8f3a4abe770f6116"
     spec:
       securityContext:
         runAsNonRoot: true

--- a/openbank-infra/gitops/components/aml/aml-opa-bundle.yaml
+++ b/openbank-infra/gitops/components/aml/aml-opa-bundle.yaml
@@ -9,7 +9,7 @@ metadata:
     app.kubernetes.io/name: aml-service
     app.kubernetes.io/part-of: aml
   annotations:
-    openbank.tech/policy-checksum: "d0720f559d3dcbfd"
+    openbank.tech/policy-checksum: "b7c3ea0bf9fb96ad"
 data:
   rest.rego: |
     # SPDX-License-Identifier: Apache-2.0
@@ -1560,9 +1560,9 @@ data:
           - "every route a resource class answers is published in that service's openapi.yaml"
           - "every route openapi.yaml promises is declared by a resource class"
         gate: openapi-route-conformance
-        enforced: advisory
-        target_enforce_date: "2026-09-30"
+        enforced: enforce                 # ADR-0144 graduation, ahead of the 2026-09-30 target (#2314)
         ci_producer: ".github/scripts/check-openapi-route-conformance.py"
+        baseline: ".github/openapi-route-conformance-baseline.txt"
         # api_contract (above) classifies a spec's version bump against the PREVIOUS REVISION of the
         # same document. Nothing asked whether the document is TRUE. ADR-0005 says "CI lints it with
         # Spectral so docs cannot drift from runtime" — there is no Spectral config in this repo and
@@ -1588,8 +1588,17 @@ data:
         # is a MISSING pair across two trees, so a PR touching only Kotlin never touches the spec and
         # a diff-scoped gate would see nothing.
         #
-        # Advisory because 114 pre-existing findings cannot be a merge blocker on day one. Flipping
-        # to enforced = add --enforce in ci.yml, once the backlog is cleared.
+        # ENFORCED AGAINST A DECLARED BASELINE (#2314). 104 pre-existing findings could not be a
+        # merge blocker on day one, and correcting a spec is blocked on the unsatisfiable-bump gap
+        # (#2313) — but leaving it advisory is the shape this repo has already ruled against: an
+        # advisory check over a GENERATED comparison has no judgement left to exercise, it just makes
+        # the drift mergeable (#2216). So the gate runs with --enforce against
+        # .github/openapi-route-conformance-baseline.txt, which declares those 104 findings verbatim.
+        # A finding NOT in that file fails the build (new drift, the thing the gate is for); a
+        # baseline line with no matching finding ALSO fails (the debt was paid — delete the line), so
+        # the declaration cannot outlive the debt. The baseline does not narrow what the gate LOOKS
+        # AT — every service is compared every run — which is what separates it from the
+        # pact-drift-check scope bug (#2284). #2314 closes when the file is empty.
       openapi_request_schema_conformance:
         detect: ["openbank-*/src/main/resources/openapi.yaml", "the JAX-RS request-body DTO the resource actually deserializes into"]
         require:

--- a/openbank-infra/gitops/components/aml/aml-opa-bundle.yaml
+++ b/openbank-infra/gitops/components/aml/aml-opa-bundle.yaml
@@ -9,7 +9,7 @@ metadata:
     app.kubernetes.io/name: aml-service
     app.kubernetes.io/part-of: aml
   annotations:
-    openbank.tech/policy-checksum: "b7c3ea0bf9fb96ad"
+    openbank.tech/policy-checksum: "7c06636572b5edfb"
 data:
   rest.rego: |
     # SPDX-License-Identifier: Apache-2.0
@@ -2254,12 +2254,36 @@ data:
         # fx + sepa-payment, sepa-instant, domestic-payment, fraud (SSDLC-audit rollout 2026-07-06) +
         # sanctions (2026-07-11: 3 domain files — screening/matching decision logic — matches the
         # "substantive domain math" criterion, not the thin-domain one; 67% local baseline).
-        # The remaining 7 (sca, consent, billing, clearing, swift, lending, settlement) stay excluded:
-        # each has only 1-2 domain files, and those files are plain data models (no branching
-        # money-movement logic), so mutation testing there is noise, not signal — re-confirmed by
-        # file count on 2026-07-11 (settlement and sanctions were both added to money_path_services
-        # after the 2026-07-07 note above; settlement re-confirmed thin, sanctions was the one that
-        # wasn't). Revisit if any of the remaining 7 grows real decision logic in its domain layer.
+        # The remaining 7 (sca, consent, billing, clearing, swift, lending, settlement) stay excluded.
+        #
+        # This list used to be justified by one blanket claim — "each has only 1-2 domain files, and
+        # those files are plain data models (no branching money-movement logic)". The file count was
+        # re-confirmed; the NO-BRANCHING half was never measured, and it is FALSE for three of the
+        # seven (#2395). Measured on 2026-07-26, counting `if (` / `when (` / `require(` / `check(`
+        # over every `src/main/kotlin/**/domain/**.kt` in each module — a deliberately narrow matcher,
+        # so these are lower bounds:
+        #
+        #     service     domain files   branch sites
+        #     sca                    2             11
+        #     consent                2              6
+        #     swift                  1              5
+        #     clearing               3              1
+        #     billing                2              0
+        #     lending                1              0
+        #     settlement             1              0
+        #
+        # So the exclusion rests on a DIFFERENT judgement, and it is stated here rather than hidden
+        # behind an inaccurate blanket: what sca, consent and swift branch on is input VALIDATION and
+        # state-transition legality, not money-movement arithmetic — pitest's value is in the
+        # arithmetic, and no pitest plugin is wired for any of the 7. billing needs its own reason:
+        # its domain layer genuinely does not branch, but its real fee-waiver logic (ADR-0143 phase 2)
+        # lives in `application/usecase/FeeAssessmentService`, OUTSIDE pitest's `domain.*`
+        # targetClasses — so widening the target would be the fix there, not adding the module.
+        #
+        # Revisit if any of the 7 grows money-movement ARITHMETIC in its domain layer; a rising branch
+        # count alone is not the trigger, and re-measure before repeating any claim in this block.
+        # (Historical note: settlement and sanctions were both added to money_path_services after the
+        # 2026-07-07 note above; settlement re-confirmed thin, sanctions was the one that wasn't.)
         # True baselines at rollout (after fixing the KILLED-quote parsing bug): account 49%,
         # transaction 46%, balance 55%, ledger 65%, fx 73%.
         blocked_on: "blocking flip requires each service to sustain >=70% mutation kill score on the weekly run; account/transaction/balance/ledger are below it today (see baselines above)"

--- a/openbank-infra/gitops/components/aml/aml-service.yaml
+++ b/openbank-infra/gitops/components/aml/aml-service.yaml
@@ -22,7 +22,7 @@ spec:
       annotations:
         # Rolls the pod when the OPA bundle changes (subPath mounts do not hot-reload).
         # Kept in sync by gen-aml-opa-bundle.sh (do not hand-edit).
-        openbank.tech/policy-checksum: "b7c3ea0bf9fb96ad"
+        openbank.tech/policy-checksum: "7c06636572b5edfb"
     spec:
       securityContext:
         runAsNonRoot: true

--- a/openbank-infra/gitops/components/aml/aml-service.yaml
+++ b/openbank-infra/gitops/components/aml/aml-service.yaml
@@ -22,7 +22,7 @@ spec:
       annotations:
         # Rolls the pod when the OPA bundle changes (subPath mounts do not hot-reload).
         # Kept in sync by gen-aml-opa-bundle.sh (do not hand-edit).
-        openbank.tech/policy-checksum: "d0720f559d3dcbfd"
+        openbank.tech/policy-checksum: "b7c3ea0bf9fb96ad"
     spec:
       securityContext:
         runAsNonRoot: true

--- a/openbank-infra/gitops/components/anacredit/anacredit-opa-bundle.yaml
+++ b/openbank-infra/gitops/components/anacredit/anacredit-opa-bundle.yaml
@@ -9,7 +9,7 @@ metadata:
     app.kubernetes.io/name: anacredit-service
     app.kubernetes.io/part-of: anacredit
   annotations:
-    openbank.tech/policy-checksum: "fafaf7d72f82aab7"
+    openbank.tech/policy-checksum: "be32b09731a5fa9e"
 data:
   rest.rego: |
     # SPDX-License-Identifier: Apache-2.0
@@ -1530,9 +1530,9 @@ data:
           - "every route a resource class answers is published in that service's openapi.yaml"
           - "every route openapi.yaml promises is declared by a resource class"
         gate: openapi-route-conformance
-        enforced: advisory
-        target_enforce_date: "2026-09-30"
+        enforced: enforce                 # ADR-0144 graduation, ahead of the 2026-09-30 target (#2314)
         ci_producer: ".github/scripts/check-openapi-route-conformance.py"
+        baseline: ".github/openapi-route-conformance-baseline.txt"
         # api_contract (above) classifies a spec's version bump against the PREVIOUS REVISION of the
         # same document. Nothing asked whether the document is TRUE. ADR-0005 says "CI lints it with
         # Spectral so docs cannot drift from runtime" — there is no Spectral config in this repo and
@@ -1558,8 +1558,17 @@ data:
         # is a MISSING pair across two trees, so a PR touching only Kotlin never touches the spec and
         # a diff-scoped gate would see nothing.
         #
-        # Advisory because 114 pre-existing findings cannot be a merge blocker on day one. Flipping
-        # to enforced = add --enforce in ci.yml, once the backlog is cleared.
+        # ENFORCED AGAINST A DECLARED BASELINE (#2314). 104 pre-existing findings could not be a
+        # merge blocker on day one, and correcting a spec is blocked on the unsatisfiable-bump gap
+        # (#2313) — but leaving it advisory is the shape this repo has already ruled against: an
+        # advisory check over a GENERATED comparison has no judgement left to exercise, it just makes
+        # the drift mergeable (#2216). So the gate runs with --enforce against
+        # .github/openapi-route-conformance-baseline.txt, which declares those 104 findings verbatim.
+        # A finding NOT in that file fails the build (new drift, the thing the gate is for); a
+        # baseline line with no matching finding ALSO fails (the debt was paid — delete the line), so
+        # the declaration cannot outlive the debt. The baseline does not narrow what the gate LOOKS
+        # AT — every service is compared every run — which is what separates it from the
+        # pact-drift-check scope bug (#2284). #2314 closes when the file is empty.
       openapi_request_schema_conformance:
         detect: ["openbank-*/src/main/resources/openapi.yaml", "the JAX-RS request-body DTO the resource actually deserializes into"]
         require:

--- a/openbank-infra/gitops/components/anacredit/anacredit-opa-bundle.yaml
+++ b/openbank-infra/gitops/components/anacredit/anacredit-opa-bundle.yaml
@@ -9,7 +9,7 @@ metadata:
     app.kubernetes.io/name: anacredit-service
     app.kubernetes.io/part-of: anacredit
   annotations:
-    openbank.tech/policy-checksum: "be32b09731a5fa9e"
+    openbank.tech/policy-checksum: "dd6d5a2c4433aada"
 data:
   rest.rego: |
     # SPDX-License-Identifier: Apache-2.0
@@ -2224,12 +2224,36 @@ data:
         # fx + sepa-payment, sepa-instant, domestic-payment, fraud (SSDLC-audit rollout 2026-07-06) +
         # sanctions (2026-07-11: 3 domain files — screening/matching decision logic — matches the
         # "substantive domain math" criterion, not the thin-domain one; 67% local baseline).
-        # The remaining 7 (sca, consent, billing, clearing, swift, lending, settlement) stay excluded:
-        # each has only 1-2 domain files, and those files are plain data models (no branching
-        # money-movement logic), so mutation testing there is noise, not signal — re-confirmed by
-        # file count on 2026-07-11 (settlement and sanctions were both added to money_path_services
-        # after the 2026-07-07 note above; settlement re-confirmed thin, sanctions was the one that
-        # wasn't). Revisit if any of the remaining 7 grows real decision logic in its domain layer.
+        # The remaining 7 (sca, consent, billing, clearing, swift, lending, settlement) stay excluded.
+        #
+        # This list used to be justified by one blanket claim — "each has only 1-2 domain files, and
+        # those files are plain data models (no branching money-movement logic)". The file count was
+        # re-confirmed; the NO-BRANCHING half was never measured, and it is FALSE for three of the
+        # seven (#2395). Measured on 2026-07-26, counting `if (` / `when (` / `require(` / `check(`
+        # over every `src/main/kotlin/**/domain/**.kt` in each module — a deliberately narrow matcher,
+        # so these are lower bounds:
+        #
+        #     service     domain files   branch sites
+        #     sca                    2             11
+        #     consent                2              6
+        #     swift                  1              5
+        #     clearing               3              1
+        #     billing                2              0
+        #     lending                1              0
+        #     settlement             1              0
+        #
+        # So the exclusion rests on a DIFFERENT judgement, and it is stated here rather than hidden
+        # behind an inaccurate blanket: what sca, consent and swift branch on is input VALIDATION and
+        # state-transition legality, not money-movement arithmetic — pitest's value is in the
+        # arithmetic, and no pitest plugin is wired for any of the 7. billing needs its own reason:
+        # its domain layer genuinely does not branch, but its real fee-waiver logic (ADR-0143 phase 2)
+        # lives in `application/usecase/FeeAssessmentService`, OUTSIDE pitest's `domain.*`
+        # targetClasses — so widening the target would be the fix there, not adding the module.
+        #
+        # Revisit if any of the 7 grows money-movement ARITHMETIC in its domain layer; a rising branch
+        # count alone is not the trigger, and re-measure before repeating any claim in this block.
+        # (Historical note: settlement and sanctions were both added to money_path_services after the
+        # 2026-07-07 note above; settlement re-confirmed thin, sanctions was the one that wasn't.)
         # True baselines at rollout (after fixing the KILLED-quote parsing bug): account 49%,
         # transaction 46%, balance 55%, ledger 65%, fx 73%.
         blocked_on: "blocking flip requires each service to sustain >=70% mutation kill score on the weekly run; account/transaction/balance/ledger are below it today (see baselines above)"

--- a/openbank-infra/gitops/components/anacredit/anacredit-service.yaml
+++ b/openbank-infra/gitops/components/anacredit/anacredit-service.yaml
@@ -32,7 +32,7 @@ spec:
       annotations:
         # Rolls the pods when the OPA bundle changes — subPath mounts do NOT hot-reload.
         # Kept in sync by gen-anacredit-opa-bundle.sh (do not hand-edit).
-        openbank.tech/policy-checksum: "fafaf7d72f82aab7"
+        openbank.tech/policy-checksum: "be32b09731a5fa9e"
     spec:
       securityContext:
         runAsNonRoot: true

--- a/openbank-infra/gitops/components/anacredit/anacredit-service.yaml
+++ b/openbank-infra/gitops/components/anacredit/anacredit-service.yaml
@@ -32,7 +32,7 @@ spec:
       annotations:
         # Rolls the pods when the OPA bundle changes — subPath mounts do NOT hot-reload.
         # Kept in sync by gen-anacredit-opa-bundle.sh (do not hand-edit).
-        openbank.tech/policy-checksum: "be32b09731a5fa9e"
+        openbank.tech/policy-checksum: "dd6d5a2c4433aada"
     spec:
       securityContext:
         runAsNonRoot: true

--- a/openbank-infra/gitops/components/ap2/ap2-opa-bundle.yaml
+++ b/openbank-infra/gitops/components/ap2/ap2-opa-bundle.yaml
@@ -9,7 +9,7 @@ metadata:
     app.kubernetes.io/name: mcp-service
     app.kubernetes.io/part-of: platform
   annotations:
-    openbank.tech/policy-checksum: "ed42feaabd3fac7a"
+    openbank.tech/policy-checksum: "2c2f017d31e98e3c"
 data:
   rest.rego: |
     # SPDX-License-Identifier: Apache-2.0
@@ -2192,12 +2192,36 @@ data:
         # fx + sepa-payment, sepa-instant, domestic-payment, fraud (SSDLC-audit rollout 2026-07-06) +
         # sanctions (2026-07-11: 3 domain files — screening/matching decision logic — matches the
         # "substantive domain math" criterion, not the thin-domain one; 67% local baseline).
-        # The remaining 7 (sca, consent, billing, clearing, swift, lending, settlement) stay excluded:
-        # each has only 1-2 domain files, and those files are plain data models (no branching
-        # money-movement logic), so mutation testing there is noise, not signal — re-confirmed by
-        # file count on 2026-07-11 (settlement and sanctions were both added to money_path_services
-        # after the 2026-07-07 note above; settlement re-confirmed thin, sanctions was the one that
-        # wasn't). Revisit if any of the remaining 7 grows real decision logic in its domain layer.
+        # The remaining 7 (sca, consent, billing, clearing, swift, lending, settlement) stay excluded.
+        #
+        # This list used to be justified by one blanket claim — "each has only 1-2 domain files, and
+        # those files are plain data models (no branching money-movement logic)". The file count was
+        # re-confirmed; the NO-BRANCHING half was never measured, and it is FALSE for three of the
+        # seven (#2395). Measured on 2026-07-26, counting `if (` / `when (` / `require(` / `check(`
+        # over every `src/main/kotlin/**/domain/**.kt` in each module — a deliberately narrow matcher,
+        # so these are lower bounds:
+        #
+        #     service     domain files   branch sites
+        #     sca                    2             11
+        #     consent                2              6
+        #     swift                  1              5
+        #     clearing               3              1
+        #     billing                2              0
+        #     lending                1              0
+        #     settlement             1              0
+        #
+        # So the exclusion rests on a DIFFERENT judgement, and it is stated here rather than hidden
+        # behind an inaccurate blanket: what sca, consent and swift branch on is input VALIDATION and
+        # state-transition legality, not money-movement arithmetic — pitest's value is in the
+        # arithmetic, and no pitest plugin is wired for any of the 7. billing needs its own reason:
+        # its domain layer genuinely does not branch, but its real fee-waiver logic (ADR-0143 phase 2)
+        # lives in `application/usecase/FeeAssessmentService`, OUTSIDE pitest's `domain.*`
+        # targetClasses — so widening the target would be the fix there, not adding the module.
+        #
+        # Revisit if any of the 7 grows money-movement ARITHMETIC in its domain layer; a rising branch
+        # count alone is not the trigger, and re-measure before repeating any claim in this block.
+        # (Historical note: settlement and sanctions were both added to money_path_services after the
+        # 2026-07-07 note above; settlement re-confirmed thin, sanctions was the one that wasn't.)
         # True baselines at rollout (after fixing the KILLED-quote parsing bug): account 49%,
         # transaction 46%, balance 55%, ledger 65%, fx 73%.
         blocked_on: "blocking flip requires each service to sustain >=70% mutation kill score on the weekly run; account/transaction/balance/ledger are below it today (see baselines above)"

--- a/openbank-infra/gitops/components/ap2/ap2-opa-bundle.yaml
+++ b/openbank-infra/gitops/components/ap2/ap2-opa-bundle.yaml
@@ -9,7 +9,7 @@ metadata:
     app.kubernetes.io/name: mcp-service
     app.kubernetes.io/part-of: platform
   annotations:
-    openbank.tech/policy-checksum: "a4190eed6dd3b779"
+    openbank.tech/policy-checksum: "ed42feaabd3fac7a"
 data:
   rest.rego: |
     # SPDX-License-Identifier: Apache-2.0
@@ -1498,9 +1498,9 @@ data:
           - "every route a resource class answers is published in that service's openapi.yaml"
           - "every route openapi.yaml promises is declared by a resource class"
         gate: openapi-route-conformance
-        enforced: advisory
-        target_enforce_date: "2026-09-30"
+        enforced: enforce                 # ADR-0144 graduation, ahead of the 2026-09-30 target (#2314)
         ci_producer: ".github/scripts/check-openapi-route-conformance.py"
+        baseline: ".github/openapi-route-conformance-baseline.txt"
         # api_contract (above) classifies a spec's version bump against the PREVIOUS REVISION of the
         # same document. Nothing asked whether the document is TRUE. ADR-0005 says "CI lints it with
         # Spectral so docs cannot drift from runtime" — there is no Spectral config in this repo and
@@ -1526,8 +1526,17 @@ data:
         # is a MISSING pair across two trees, so a PR touching only Kotlin never touches the spec and
         # a diff-scoped gate would see nothing.
         #
-        # Advisory because 114 pre-existing findings cannot be a merge blocker on day one. Flipping
-        # to enforced = add --enforce in ci.yml, once the backlog is cleared.
+        # ENFORCED AGAINST A DECLARED BASELINE (#2314). 104 pre-existing findings could not be a
+        # merge blocker on day one, and correcting a spec is blocked on the unsatisfiable-bump gap
+        # (#2313) — but leaving it advisory is the shape this repo has already ruled against: an
+        # advisory check over a GENERATED comparison has no judgement left to exercise, it just makes
+        # the drift mergeable (#2216). So the gate runs with --enforce against
+        # .github/openapi-route-conformance-baseline.txt, which declares those 104 findings verbatim.
+        # A finding NOT in that file fails the build (new drift, the thing the gate is for); a
+        # baseline line with no matching finding ALSO fails (the debt was paid — delete the line), so
+        # the declaration cannot outlive the debt. The baseline does not narrow what the gate LOOKS
+        # AT — every service is compared every run — which is what separates it from the
+        # pact-drift-check scope bug (#2284). #2314 closes when the file is empty.
       openapi_request_schema_conformance:
         detect: ["openbank-*/src/main/resources/openapi.yaml", "the JAX-RS request-body DTO the resource actually deserializes into"]
         require:

--- a/openbank-infra/gitops/components/ap2/ap2-service.yaml
+++ b/openbank-infra/gitops/components/ap2/ap2-service.yaml
@@ -30,7 +30,7 @@ spec:
       annotations:
         # Roll the pod when the OPA policy bundle changes (subPath mounts don't hot-reload).
         # Kept in sync by gen-ap2-opa-bundle.sh (do not hand-edit).
-        openbank.tech/policy-checksum: "a4190eed6dd3b779"
+        openbank.tech/policy-checksum: "ed42feaabd3fac7a"
     spec:
       securityContext:
         runAsNonRoot: true

--- a/openbank-infra/gitops/components/ap2/ap2-service.yaml
+++ b/openbank-infra/gitops/components/ap2/ap2-service.yaml
@@ -30,7 +30,7 @@ spec:
       annotations:
         # Roll the pod when the OPA policy bundle changes (subPath mounts don't hot-reload).
         # Kept in sync by gen-ap2-opa-bundle.sh (do not hand-edit).
-        openbank.tech/policy-checksum: "ed42feaabd3fac7a"
+        openbank.tech/policy-checksum: "2c2f017d31e98e3c"
     spec:
       securityContext:
         runAsNonRoot: true

--- a/openbank-infra/gitops/components/audit/audit-opa-bundle.yaml
+++ b/openbank-infra/gitops/components/audit/audit-opa-bundle.yaml
@@ -9,7 +9,7 @@ metadata:
     app.kubernetes.io/name: audit-service
     app.kubernetes.io/part-of: audit
   annotations:
-    openbank.tech/policy-checksum: "f3d212877a68293c"
+    openbank.tech/policy-checksum: "e4cd7f6af7415e10"
 data:
   rest.rego: |
     # SPDX-License-Identifier: Apache-2.0
@@ -1542,9 +1542,9 @@ data:
           - "every route a resource class answers is published in that service's openapi.yaml"
           - "every route openapi.yaml promises is declared by a resource class"
         gate: openapi-route-conformance
-        enforced: advisory
-        target_enforce_date: "2026-09-30"
+        enforced: enforce                 # ADR-0144 graduation, ahead of the 2026-09-30 target (#2314)
         ci_producer: ".github/scripts/check-openapi-route-conformance.py"
+        baseline: ".github/openapi-route-conformance-baseline.txt"
         # api_contract (above) classifies a spec's version bump against the PREVIOUS REVISION of the
         # same document. Nothing asked whether the document is TRUE. ADR-0005 says "CI lints it with
         # Spectral so docs cannot drift from runtime" — there is no Spectral config in this repo and
@@ -1570,8 +1570,17 @@ data:
         # is a MISSING pair across two trees, so a PR touching only Kotlin never touches the spec and
         # a diff-scoped gate would see nothing.
         #
-        # Advisory because 114 pre-existing findings cannot be a merge blocker on day one. Flipping
-        # to enforced = add --enforce in ci.yml, once the backlog is cleared.
+        # ENFORCED AGAINST A DECLARED BASELINE (#2314). 104 pre-existing findings could not be a
+        # merge blocker on day one, and correcting a spec is blocked on the unsatisfiable-bump gap
+        # (#2313) — but leaving it advisory is the shape this repo has already ruled against: an
+        # advisory check over a GENERATED comparison has no judgement left to exercise, it just makes
+        # the drift mergeable (#2216). So the gate runs with --enforce against
+        # .github/openapi-route-conformance-baseline.txt, which declares those 104 findings verbatim.
+        # A finding NOT in that file fails the build (new drift, the thing the gate is for); a
+        # baseline line with no matching finding ALSO fails (the debt was paid — delete the line), so
+        # the declaration cannot outlive the debt. The baseline does not narrow what the gate LOOKS
+        # AT — every service is compared every run — which is what separates it from the
+        # pact-drift-check scope bug (#2284). #2314 closes when the file is empty.
       openapi_request_schema_conformance:
         detect: ["openbank-*/src/main/resources/openapi.yaml", "the JAX-RS request-body DTO the resource actually deserializes into"]
         require:

--- a/openbank-infra/gitops/components/audit/audit-opa-bundle.yaml
+++ b/openbank-infra/gitops/components/audit/audit-opa-bundle.yaml
@@ -9,7 +9,7 @@ metadata:
     app.kubernetes.io/name: audit-service
     app.kubernetes.io/part-of: audit
   annotations:
-    openbank.tech/policy-checksum: "e4cd7f6af7415e10"
+    openbank.tech/policy-checksum: "a72504cb46301818"
 data:
   rest.rego: |
     # SPDX-License-Identifier: Apache-2.0
@@ -2236,12 +2236,36 @@ data:
         # fx + sepa-payment, sepa-instant, domestic-payment, fraud (SSDLC-audit rollout 2026-07-06) +
         # sanctions (2026-07-11: 3 domain files — screening/matching decision logic — matches the
         # "substantive domain math" criterion, not the thin-domain one; 67% local baseline).
-        # The remaining 7 (sca, consent, billing, clearing, swift, lending, settlement) stay excluded:
-        # each has only 1-2 domain files, and those files are plain data models (no branching
-        # money-movement logic), so mutation testing there is noise, not signal — re-confirmed by
-        # file count on 2026-07-11 (settlement and sanctions were both added to money_path_services
-        # after the 2026-07-07 note above; settlement re-confirmed thin, sanctions was the one that
-        # wasn't). Revisit if any of the remaining 7 grows real decision logic in its domain layer.
+        # The remaining 7 (sca, consent, billing, clearing, swift, lending, settlement) stay excluded.
+        #
+        # This list used to be justified by one blanket claim — "each has only 1-2 domain files, and
+        # those files are plain data models (no branching money-movement logic)". The file count was
+        # re-confirmed; the NO-BRANCHING half was never measured, and it is FALSE for three of the
+        # seven (#2395). Measured on 2026-07-26, counting `if (` / `when (` / `require(` / `check(`
+        # over every `src/main/kotlin/**/domain/**.kt` in each module — a deliberately narrow matcher,
+        # so these are lower bounds:
+        #
+        #     service     domain files   branch sites
+        #     sca                    2             11
+        #     consent                2              6
+        #     swift                  1              5
+        #     clearing               3              1
+        #     billing                2              0
+        #     lending                1              0
+        #     settlement             1              0
+        #
+        # So the exclusion rests on a DIFFERENT judgement, and it is stated here rather than hidden
+        # behind an inaccurate blanket: what sca, consent and swift branch on is input VALIDATION and
+        # state-transition legality, not money-movement arithmetic — pitest's value is in the
+        # arithmetic, and no pitest plugin is wired for any of the 7. billing needs its own reason:
+        # its domain layer genuinely does not branch, but its real fee-waiver logic (ADR-0143 phase 2)
+        # lives in `application/usecase/FeeAssessmentService`, OUTSIDE pitest's `domain.*`
+        # targetClasses — so widening the target would be the fix there, not adding the module.
+        #
+        # Revisit if any of the 7 grows money-movement ARITHMETIC in its domain layer; a rising branch
+        # count alone is not the trigger, and re-measure before repeating any claim in this block.
+        # (Historical note: settlement and sanctions were both added to money_path_services after the
+        # 2026-07-07 note above; settlement re-confirmed thin, sanctions was the one that wasn't.)
         # True baselines at rollout (after fixing the KILLED-quote parsing bug): account 49%,
         # transaction 46%, balance 55%, ledger 65%, fx 73%.
         blocked_on: "blocking flip requires each service to sustain >=70% mutation kill score on the weekly run; account/transaction/balance/ledger are below it today (see baselines above)"

--- a/openbank-infra/gitops/components/audit/audit-service.yaml
+++ b/openbank-infra/gitops/components/audit/audit-service.yaml
@@ -22,7 +22,7 @@ spec:
       annotations:
         # Rolls the pod when the OPA bundle changes (subPath mounts do not hot-reload).
         # Kept in sync by gen-audit-opa-bundle.sh (do not hand-edit).
-        openbank.tech/policy-checksum: "e4cd7f6af7415e10"
+        openbank.tech/policy-checksum: "a72504cb46301818"
     spec:
       securityContext:
         runAsNonRoot: true

--- a/openbank-infra/gitops/components/audit/audit-service.yaml
+++ b/openbank-infra/gitops/components/audit/audit-service.yaml
@@ -22,7 +22,7 @@ spec:
       annotations:
         # Rolls the pod when the OPA bundle changes (subPath mounts do not hot-reload).
         # Kept in sync by gen-audit-opa-bundle.sh (do not hand-edit).
-        openbank.tech/policy-checksum: "f3d212877a68293c"
+        openbank.tech/policy-checksum: "e4cd7f6af7415e10"
     spec:
       securityContext:
         runAsNonRoot: true

--- a/openbank-infra/gitops/components/balances/balance-opa-bundle.yaml
+++ b/openbank-infra/gitops/components/balances/balance-opa-bundle.yaml
@@ -9,7 +9,7 @@ metadata:
     app.kubernetes.io/name: balance-service
     app.kubernetes.io/part-of: balances
   annotations:
-    openbank.tech/policy-checksum: "fa4f6aabac7682de"
+    openbank.tech/policy-checksum: "89a0cd57f08b8739"
 data:
   rest.rego: |
     # SPDX-License-Identifier: Apache-2.0
@@ -2325,12 +2325,36 @@ data:
         # fx + sepa-payment, sepa-instant, domestic-payment, fraud (SSDLC-audit rollout 2026-07-06) +
         # sanctions (2026-07-11: 3 domain files — screening/matching decision logic — matches the
         # "substantive domain math" criterion, not the thin-domain one; 67% local baseline).
-        # The remaining 7 (sca, consent, billing, clearing, swift, lending, settlement) stay excluded:
-        # each has only 1-2 domain files, and those files are plain data models (no branching
-        # money-movement logic), so mutation testing there is noise, not signal — re-confirmed by
-        # file count on 2026-07-11 (settlement and sanctions were both added to money_path_services
-        # after the 2026-07-07 note above; settlement re-confirmed thin, sanctions was the one that
-        # wasn't). Revisit if any of the remaining 7 grows real decision logic in its domain layer.
+        # The remaining 7 (sca, consent, billing, clearing, swift, lending, settlement) stay excluded.
+        #
+        # This list used to be justified by one blanket claim — "each has only 1-2 domain files, and
+        # those files are plain data models (no branching money-movement logic)". The file count was
+        # re-confirmed; the NO-BRANCHING half was never measured, and it is FALSE for three of the
+        # seven (#2395). Measured on 2026-07-26, counting `if (` / `when (` / `require(` / `check(`
+        # over every `src/main/kotlin/**/domain/**.kt` in each module — a deliberately narrow matcher,
+        # so these are lower bounds:
+        #
+        #     service     domain files   branch sites
+        #     sca                    2             11
+        #     consent                2              6
+        #     swift                  1              5
+        #     clearing               3              1
+        #     billing                2              0
+        #     lending                1              0
+        #     settlement             1              0
+        #
+        # So the exclusion rests on a DIFFERENT judgement, and it is stated here rather than hidden
+        # behind an inaccurate blanket: what sca, consent and swift branch on is input VALIDATION and
+        # state-transition legality, not money-movement arithmetic — pitest's value is in the
+        # arithmetic, and no pitest plugin is wired for any of the 7. billing needs its own reason:
+        # its domain layer genuinely does not branch, but its real fee-waiver logic (ADR-0143 phase 2)
+        # lives in `application/usecase/FeeAssessmentService`, OUTSIDE pitest's `domain.*`
+        # targetClasses — so widening the target would be the fix there, not adding the module.
+        #
+        # Revisit if any of the 7 grows money-movement ARITHMETIC in its domain layer; a rising branch
+        # count alone is not the trigger, and re-measure before repeating any claim in this block.
+        # (Historical note: settlement and sanctions were both added to money_path_services after the
+        # 2026-07-07 note above; settlement re-confirmed thin, sanctions was the one that wasn't.)
         # True baselines at rollout (after fixing the KILLED-quote parsing bug): account 49%,
         # transaction 46%, balance 55%, ledger 65%, fx 73%.
         blocked_on: "blocking flip requires each service to sustain >=70% mutation kill score on the weekly run; account/transaction/balance/ledger are below it today (see baselines above)"

--- a/openbank-infra/gitops/components/balances/balance-opa-bundle.yaml
+++ b/openbank-infra/gitops/components/balances/balance-opa-bundle.yaml
@@ -9,7 +9,7 @@ metadata:
     app.kubernetes.io/name: balance-service
     app.kubernetes.io/part-of: balances
   annotations:
-    openbank.tech/policy-checksum: "635682aeb4074515"
+    openbank.tech/policy-checksum: "fa4f6aabac7682de"
 data:
   rest.rego: |
     # SPDX-License-Identifier: Apache-2.0
@@ -1631,9 +1631,9 @@ data:
           - "every route a resource class answers is published in that service's openapi.yaml"
           - "every route openapi.yaml promises is declared by a resource class"
         gate: openapi-route-conformance
-        enforced: advisory
-        target_enforce_date: "2026-09-30"
+        enforced: enforce                 # ADR-0144 graduation, ahead of the 2026-09-30 target (#2314)
         ci_producer: ".github/scripts/check-openapi-route-conformance.py"
+        baseline: ".github/openapi-route-conformance-baseline.txt"
         # api_contract (above) classifies a spec's version bump against the PREVIOUS REVISION of the
         # same document. Nothing asked whether the document is TRUE. ADR-0005 says "CI lints it with
         # Spectral so docs cannot drift from runtime" — there is no Spectral config in this repo and
@@ -1659,8 +1659,17 @@ data:
         # is a MISSING pair across two trees, so a PR touching only Kotlin never touches the spec and
         # a diff-scoped gate would see nothing.
         #
-        # Advisory because 114 pre-existing findings cannot be a merge blocker on day one. Flipping
-        # to enforced = add --enforce in ci.yml, once the backlog is cleared.
+        # ENFORCED AGAINST A DECLARED BASELINE (#2314). 104 pre-existing findings could not be a
+        # merge blocker on day one, and correcting a spec is blocked on the unsatisfiable-bump gap
+        # (#2313) — but leaving it advisory is the shape this repo has already ruled against: an
+        # advisory check over a GENERATED comparison has no judgement left to exercise, it just makes
+        # the drift mergeable (#2216). So the gate runs with --enforce against
+        # .github/openapi-route-conformance-baseline.txt, which declares those 104 findings verbatim.
+        # A finding NOT in that file fails the build (new drift, the thing the gate is for); a
+        # baseline line with no matching finding ALSO fails (the debt was paid — delete the line), so
+        # the declaration cannot outlive the debt. The baseline does not narrow what the gate LOOKS
+        # AT — every service is compared every run — which is what separates it from the
+        # pact-drift-check scope bug (#2284). #2314 closes when the file is empty.
       openapi_request_schema_conformance:
         detect: ["openbank-*/src/main/resources/openapi.yaml", "the JAX-RS request-body DTO the resource actually deserializes into"]
         require:

--- a/openbank-infra/gitops/components/balances/balance-service.yaml
+++ b/openbank-infra/gitops/components/balances/balance-service.yaml
@@ -34,7 +34,7 @@ spec:
       annotations:
         # Rolls the pods when the OPA bundle changes — subPath mounts do NOT hot-reload.
         # Kept in sync by gen-balance-opa-bundle.sh (do not hand-edit).
-        openbank.tech/policy-checksum: "fa4f6aabac7682de"
+        openbank.tech/policy-checksum: "89a0cd57f08b8739"
     spec:
       securityContext:
         runAsNonRoot: true

--- a/openbank-infra/gitops/components/balances/balance-service.yaml
+++ b/openbank-infra/gitops/components/balances/balance-service.yaml
@@ -34,7 +34,7 @@ spec:
       annotations:
         # Rolls the pods when the OPA bundle changes — subPath mounts do NOT hot-reload.
         # Kept in sync by gen-balance-opa-bundle.sh (do not hand-edit).
-        openbank.tech/policy-checksum: "635682aeb4074515"
+        openbank.tech/policy-checksum: "fa4f6aabac7682de"
     spec:
       securityContext:
         runAsNonRoot: true

--- a/openbank-infra/gitops/components/billing/billing-opa-bundle.yaml
+++ b/openbank-infra/gitops/components/billing/billing-opa-bundle.yaml
@@ -9,7 +9,7 @@ metadata:
     app.kubernetes.io/name: billing-service
     app.kubernetes.io/part-of: billing
   annotations:
-    openbank.tech/policy-checksum: "5008956e59bcd427"
+    openbank.tech/policy-checksum: "b41a03ec7fd0cd7a"
 data:
   rest.rego: |
     # SPDX-License-Identifier: Apache-2.0
@@ -2230,12 +2230,36 @@ data:
         # fx + sepa-payment, sepa-instant, domestic-payment, fraud (SSDLC-audit rollout 2026-07-06) +
         # sanctions (2026-07-11: 3 domain files — screening/matching decision logic — matches the
         # "substantive domain math" criterion, not the thin-domain one; 67% local baseline).
-        # The remaining 7 (sca, consent, billing, clearing, swift, lending, settlement) stay excluded:
-        # each has only 1-2 domain files, and those files are plain data models (no branching
-        # money-movement logic), so mutation testing there is noise, not signal — re-confirmed by
-        # file count on 2026-07-11 (settlement and sanctions were both added to money_path_services
-        # after the 2026-07-07 note above; settlement re-confirmed thin, sanctions was the one that
-        # wasn't). Revisit if any of the remaining 7 grows real decision logic in its domain layer.
+        # The remaining 7 (sca, consent, billing, clearing, swift, lending, settlement) stay excluded.
+        #
+        # This list used to be justified by one blanket claim — "each has only 1-2 domain files, and
+        # those files are plain data models (no branching money-movement logic)". The file count was
+        # re-confirmed; the NO-BRANCHING half was never measured, and it is FALSE for three of the
+        # seven (#2395). Measured on 2026-07-26, counting `if (` / `when (` / `require(` / `check(`
+        # over every `src/main/kotlin/**/domain/**.kt` in each module — a deliberately narrow matcher,
+        # so these are lower bounds:
+        #
+        #     service     domain files   branch sites
+        #     sca                    2             11
+        #     consent                2              6
+        #     swift                  1              5
+        #     clearing               3              1
+        #     billing                2              0
+        #     lending                1              0
+        #     settlement             1              0
+        #
+        # So the exclusion rests on a DIFFERENT judgement, and it is stated here rather than hidden
+        # behind an inaccurate blanket: what sca, consent and swift branch on is input VALIDATION and
+        # state-transition legality, not money-movement arithmetic — pitest's value is in the
+        # arithmetic, and no pitest plugin is wired for any of the 7. billing needs its own reason:
+        # its domain layer genuinely does not branch, but its real fee-waiver logic (ADR-0143 phase 2)
+        # lives in `application/usecase/FeeAssessmentService`, OUTSIDE pitest's `domain.*`
+        # targetClasses — so widening the target would be the fix there, not adding the module.
+        #
+        # Revisit if any of the 7 grows money-movement ARITHMETIC in its domain layer; a rising branch
+        # count alone is not the trigger, and re-measure before repeating any claim in this block.
+        # (Historical note: settlement and sanctions were both added to money_path_services after the
+        # 2026-07-07 note above; settlement re-confirmed thin, sanctions was the one that wasn't.)
         # True baselines at rollout (after fixing the KILLED-quote parsing bug): account 49%,
         # transaction 46%, balance 55%, ledger 65%, fx 73%.
         blocked_on: "blocking flip requires each service to sustain >=70% mutation kill score on the weekly run; account/transaction/balance/ledger are below it today (see baselines above)"

--- a/openbank-infra/gitops/components/billing/billing-opa-bundle.yaml
+++ b/openbank-infra/gitops/components/billing/billing-opa-bundle.yaml
@@ -9,7 +9,7 @@ metadata:
     app.kubernetes.io/name: billing-service
     app.kubernetes.io/part-of: billing
   annotations:
-    openbank.tech/policy-checksum: "80d45595f71fb050"
+    openbank.tech/policy-checksum: "5008956e59bcd427"
 data:
   rest.rego: |
     # SPDX-License-Identifier: Apache-2.0
@@ -1536,9 +1536,9 @@ data:
           - "every route a resource class answers is published in that service's openapi.yaml"
           - "every route openapi.yaml promises is declared by a resource class"
         gate: openapi-route-conformance
-        enforced: advisory
-        target_enforce_date: "2026-09-30"
+        enforced: enforce                 # ADR-0144 graduation, ahead of the 2026-09-30 target (#2314)
         ci_producer: ".github/scripts/check-openapi-route-conformance.py"
+        baseline: ".github/openapi-route-conformance-baseline.txt"
         # api_contract (above) classifies a spec's version bump against the PREVIOUS REVISION of the
         # same document. Nothing asked whether the document is TRUE. ADR-0005 says "CI lints it with
         # Spectral so docs cannot drift from runtime" — there is no Spectral config in this repo and
@@ -1564,8 +1564,17 @@ data:
         # is a MISSING pair across two trees, so a PR touching only Kotlin never touches the spec and
         # a diff-scoped gate would see nothing.
         #
-        # Advisory because 114 pre-existing findings cannot be a merge blocker on day one. Flipping
-        # to enforced = add --enforce in ci.yml, once the backlog is cleared.
+        # ENFORCED AGAINST A DECLARED BASELINE (#2314). 104 pre-existing findings could not be a
+        # merge blocker on day one, and correcting a spec is blocked on the unsatisfiable-bump gap
+        # (#2313) — but leaving it advisory is the shape this repo has already ruled against: an
+        # advisory check over a GENERATED comparison has no judgement left to exercise, it just makes
+        # the drift mergeable (#2216). So the gate runs with --enforce against
+        # .github/openapi-route-conformance-baseline.txt, which declares those 104 findings verbatim.
+        # A finding NOT in that file fails the build (new drift, the thing the gate is for); a
+        # baseline line with no matching finding ALSO fails (the debt was paid — delete the line), so
+        # the declaration cannot outlive the debt. The baseline does not narrow what the gate LOOKS
+        # AT — every service is compared every run — which is what separates it from the
+        # pact-drift-check scope bug (#2284). #2314 closes when the file is empty.
       openapi_request_schema_conformance:
         detect: ["openbank-*/src/main/resources/openapi.yaml", "the JAX-RS request-body DTO the resource actually deserializes into"]
         require:

--- a/openbank-infra/gitops/components/billing/billing-service.yaml
+++ b/openbank-infra/gitops/components/billing/billing-service.yaml
@@ -27,7 +27,7 @@ spec:
       annotations:
         # Rolls the pods when the OPA bundle changes — subPath mounts do NOT hot-reload.
         # Kept in sync by gen-billing-opa-bundle.sh (do not hand-edit).
-        openbank.tech/policy-checksum: "5008956e59bcd427"
+        openbank.tech/policy-checksum: "b41a03ec7fd0cd7a"
     spec:
       securityContext:
         runAsNonRoot: true

--- a/openbank-infra/gitops/components/billing/billing-service.yaml
+++ b/openbank-infra/gitops/components/billing/billing-service.yaml
@@ -27,7 +27,7 @@ spec:
       annotations:
         # Rolls the pods when the OPA bundle changes — subPath mounts do NOT hot-reload.
         # Kept in sync by gen-billing-opa-bundle.sh (do not hand-edit).
-        openbank.tech/policy-checksum: "80d45595f71fb050"
+        openbank.tech/policy-checksum: "5008956e59bcd427"
     spec:
       securityContext:
         runAsNonRoot: true

--- a/openbank-infra/gitops/components/consent/consent-opa-bundle.yaml
+++ b/openbank-infra/gitops/components/consent/consent-opa-bundle.yaml
@@ -9,7 +9,7 @@ metadata:
     app.kubernetes.io/name: consent-service
     app.kubernetes.io/part-of: consent
   annotations:
-    openbank.tech/policy-checksum: "cd4fc657c5070876"
+    openbank.tech/policy-checksum: "ebec3a2a764408e8"
 data:
   rest.rego: |
     # SPDX-License-Identifier: Apache-2.0
@@ -1594,9 +1594,9 @@ data:
           - "every route a resource class answers is published in that service's openapi.yaml"
           - "every route openapi.yaml promises is declared by a resource class"
         gate: openapi-route-conformance
-        enforced: advisory
-        target_enforce_date: "2026-09-30"
+        enforced: enforce                 # ADR-0144 graduation, ahead of the 2026-09-30 target (#2314)
         ci_producer: ".github/scripts/check-openapi-route-conformance.py"
+        baseline: ".github/openapi-route-conformance-baseline.txt"
         # api_contract (above) classifies a spec's version bump against the PREVIOUS REVISION of the
         # same document. Nothing asked whether the document is TRUE. ADR-0005 says "CI lints it with
         # Spectral so docs cannot drift from runtime" — there is no Spectral config in this repo and
@@ -1622,8 +1622,17 @@ data:
         # is a MISSING pair across two trees, so a PR touching only Kotlin never touches the spec and
         # a diff-scoped gate would see nothing.
         #
-        # Advisory because 114 pre-existing findings cannot be a merge blocker on day one. Flipping
-        # to enforced = add --enforce in ci.yml, once the backlog is cleared.
+        # ENFORCED AGAINST A DECLARED BASELINE (#2314). 104 pre-existing findings could not be a
+        # merge blocker on day one, and correcting a spec is blocked on the unsatisfiable-bump gap
+        # (#2313) — but leaving it advisory is the shape this repo has already ruled against: an
+        # advisory check over a GENERATED comparison has no judgement left to exercise, it just makes
+        # the drift mergeable (#2216). So the gate runs with --enforce against
+        # .github/openapi-route-conformance-baseline.txt, which declares those 104 findings verbatim.
+        # A finding NOT in that file fails the build (new drift, the thing the gate is for); a
+        # baseline line with no matching finding ALSO fails (the debt was paid — delete the line), so
+        # the declaration cannot outlive the debt. The baseline does not narrow what the gate LOOKS
+        # AT — every service is compared every run — which is what separates it from the
+        # pact-drift-check scope bug (#2284). #2314 closes when the file is empty.
       openapi_request_schema_conformance:
         detect: ["openbank-*/src/main/resources/openapi.yaml", "the JAX-RS request-body DTO the resource actually deserializes into"]
         require:

--- a/openbank-infra/gitops/components/consent/consent-opa-bundle.yaml
+++ b/openbank-infra/gitops/components/consent/consent-opa-bundle.yaml
@@ -9,7 +9,7 @@ metadata:
     app.kubernetes.io/name: consent-service
     app.kubernetes.io/part-of: consent
   annotations:
-    openbank.tech/policy-checksum: "ebec3a2a764408e8"
+    openbank.tech/policy-checksum: "014508f0b3d9c59e"
 data:
   rest.rego: |
     # SPDX-License-Identifier: Apache-2.0
@@ -2288,12 +2288,36 @@ data:
         # fx + sepa-payment, sepa-instant, domestic-payment, fraud (SSDLC-audit rollout 2026-07-06) +
         # sanctions (2026-07-11: 3 domain files — screening/matching decision logic — matches the
         # "substantive domain math" criterion, not the thin-domain one; 67% local baseline).
-        # The remaining 7 (sca, consent, billing, clearing, swift, lending, settlement) stay excluded:
-        # each has only 1-2 domain files, and those files are plain data models (no branching
-        # money-movement logic), so mutation testing there is noise, not signal — re-confirmed by
-        # file count on 2026-07-11 (settlement and sanctions were both added to money_path_services
-        # after the 2026-07-07 note above; settlement re-confirmed thin, sanctions was the one that
-        # wasn't). Revisit if any of the remaining 7 grows real decision logic in its domain layer.
+        # The remaining 7 (sca, consent, billing, clearing, swift, lending, settlement) stay excluded.
+        #
+        # This list used to be justified by one blanket claim — "each has only 1-2 domain files, and
+        # those files are plain data models (no branching money-movement logic)". The file count was
+        # re-confirmed; the NO-BRANCHING half was never measured, and it is FALSE for three of the
+        # seven (#2395). Measured on 2026-07-26, counting `if (` / `when (` / `require(` / `check(`
+        # over every `src/main/kotlin/**/domain/**.kt` in each module — a deliberately narrow matcher,
+        # so these are lower bounds:
+        #
+        #     service     domain files   branch sites
+        #     sca                    2             11
+        #     consent                2              6
+        #     swift                  1              5
+        #     clearing               3              1
+        #     billing                2              0
+        #     lending                1              0
+        #     settlement             1              0
+        #
+        # So the exclusion rests on a DIFFERENT judgement, and it is stated here rather than hidden
+        # behind an inaccurate blanket: what sca, consent and swift branch on is input VALIDATION and
+        # state-transition legality, not money-movement arithmetic — pitest's value is in the
+        # arithmetic, and no pitest plugin is wired for any of the 7. billing needs its own reason:
+        # its domain layer genuinely does not branch, but its real fee-waiver logic (ADR-0143 phase 2)
+        # lives in `application/usecase/FeeAssessmentService`, OUTSIDE pitest's `domain.*`
+        # targetClasses — so widening the target would be the fix there, not adding the module.
+        #
+        # Revisit if any of the 7 grows money-movement ARITHMETIC in its domain layer; a rising branch
+        # count alone is not the trigger, and re-measure before repeating any claim in this block.
+        # (Historical note: settlement and sanctions were both added to money_path_services after the
+        # 2026-07-07 note above; settlement re-confirmed thin, sanctions was the one that wasn't.)
         # True baselines at rollout (after fixing the KILLED-quote parsing bug): account 49%,
         # transaction 46%, balance 55%, ledger 65%, fx 73%.
         blocked_on: "blocking flip requires each service to sustain >=70% mutation kill score on the weekly run; account/transaction/balance/ledger are below it today (see baselines above)"

--- a/openbank-infra/gitops/components/consent/consent-service.yaml
+++ b/openbank-infra/gitops/components/consent/consent-service.yaml
@@ -28,7 +28,7 @@ spec:
       annotations:
         # Rolls the pods when the OPA bundle changes — subPath mounts do NOT hot-reload.
         # Kept in sync by gen-consent-opa-bundle.sh (do not hand-edit).
-        openbank.tech/policy-checksum: "cd4fc657c5070876"
+        openbank.tech/policy-checksum: "ebec3a2a764408e8"
     spec:
       securityContext:
         runAsNonRoot: true

--- a/openbank-infra/gitops/components/consent/consent-service.yaml
+++ b/openbank-infra/gitops/components/consent/consent-service.yaml
@@ -28,7 +28,7 @@ spec:
       annotations:
         # Rolls the pods when the OPA bundle changes — subPath mounts do NOT hot-reload.
         # Kept in sync by gen-consent-opa-bundle.sh (do not hand-edit).
-        openbank.tech/policy-checksum: "ebec3a2a764408e8"
+        openbank.tech/policy-checksum: "014508f0b3d9c59e"
     spec:
       securityContext:
         runAsNonRoot: true

--- a/openbank-infra/gitops/components/copilot/copilot-opa-bundle.yaml
+++ b/openbank-infra/gitops/components/copilot/copilot-opa-bundle.yaml
@@ -9,7 +9,7 @@ metadata:
     app.kubernetes.io/name: copilot-service
     app.kubernetes.io/part-of: platform
   annotations:
-    openbank.tech/policy-checksum: "883709e2b6fc4132"
+    openbank.tech/policy-checksum: "4a18f7c046ce99c6"
 data:
   rest.rego: |
     # SPDX-License-Identifier: Apache-2.0
@@ -2316,12 +2316,36 @@ data:
         # fx + sepa-payment, sepa-instant, domestic-payment, fraud (SSDLC-audit rollout 2026-07-06) +
         # sanctions (2026-07-11: 3 domain files — screening/matching decision logic — matches the
         # "substantive domain math" criterion, not the thin-domain one; 67% local baseline).
-        # The remaining 7 (sca, consent, billing, clearing, swift, lending, settlement) stay excluded:
-        # each has only 1-2 domain files, and those files are plain data models (no branching
-        # money-movement logic), so mutation testing there is noise, not signal — re-confirmed by
-        # file count on 2026-07-11 (settlement and sanctions were both added to money_path_services
-        # after the 2026-07-07 note above; settlement re-confirmed thin, sanctions was the one that
-        # wasn't). Revisit if any of the remaining 7 grows real decision logic in its domain layer.
+        # The remaining 7 (sca, consent, billing, clearing, swift, lending, settlement) stay excluded.
+        #
+        # This list used to be justified by one blanket claim — "each has only 1-2 domain files, and
+        # those files are plain data models (no branching money-movement logic)". The file count was
+        # re-confirmed; the NO-BRANCHING half was never measured, and it is FALSE for three of the
+        # seven (#2395). Measured on 2026-07-26, counting `if (` / `when (` / `require(` / `check(`
+        # over every `src/main/kotlin/**/domain/**.kt` in each module — a deliberately narrow matcher,
+        # so these are lower bounds:
+        #
+        #     service     domain files   branch sites
+        #     sca                    2             11
+        #     consent                2              6
+        #     swift                  1              5
+        #     clearing               3              1
+        #     billing                2              0
+        #     lending                1              0
+        #     settlement             1              0
+        #
+        # So the exclusion rests on a DIFFERENT judgement, and it is stated here rather than hidden
+        # behind an inaccurate blanket: what sca, consent and swift branch on is input VALIDATION and
+        # state-transition legality, not money-movement arithmetic — pitest's value is in the
+        # arithmetic, and no pitest plugin is wired for any of the 7. billing needs its own reason:
+        # its domain layer genuinely does not branch, but its real fee-waiver logic (ADR-0143 phase 2)
+        # lives in `application/usecase/FeeAssessmentService`, OUTSIDE pitest's `domain.*`
+        # targetClasses — so widening the target would be the fix there, not adding the module.
+        #
+        # Revisit if any of the 7 grows money-movement ARITHMETIC in its domain layer; a rising branch
+        # count alone is not the trigger, and re-measure before repeating any claim in this block.
+        # (Historical note: settlement and sanctions were both added to money_path_services after the
+        # 2026-07-07 note above; settlement re-confirmed thin, sanctions was the one that wasn't.)
         # True baselines at rollout (after fixing the KILLED-quote parsing bug): account 49%,
         # transaction 46%, balance 55%, ledger 65%, fx 73%.
         blocked_on: "blocking flip requires each service to sustain >=70% mutation kill score on the weekly run; account/transaction/balance/ledger are below it today (see baselines above)"

--- a/openbank-infra/gitops/components/copilot/copilot-opa-bundle.yaml
+++ b/openbank-infra/gitops/components/copilot/copilot-opa-bundle.yaml
@@ -9,7 +9,7 @@ metadata:
     app.kubernetes.io/name: copilot-service
     app.kubernetes.io/part-of: platform
   annotations:
-    openbank.tech/policy-checksum: "787ee5d8d1839648"
+    openbank.tech/policy-checksum: "883709e2b6fc4132"
 data:
   rest.rego: |
     # SPDX-License-Identifier: Apache-2.0
@@ -1622,9 +1622,9 @@ data:
           - "every route a resource class answers is published in that service's openapi.yaml"
           - "every route openapi.yaml promises is declared by a resource class"
         gate: openapi-route-conformance
-        enforced: advisory
-        target_enforce_date: "2026-09-30"
+        enforced: enforce                 # ADR-0144 graduation, ahead of the 2026-09-30 target (#2314)
         ci_producer: ".github/scripts/check-openapi-route-conformance.py"
+        baseline: ".github/openapi-route-conformance-baseline.txt"
         # api_contract (above) classifies a spec's version bump against the PREVIOUS REVISION of the
         # same document. Nothing asked whether the document is TRUE. ADR-0005 says "CI lints it with
         # Spectral so docs cannot drift from runtime" — there is no Spectral config in this repo and
@@ -1650,8 +1650,17 @@ data:
         # is a MISSING pair across two trees, so a PR touching only Kotlin never touches the spec and
         # a diff-scoped gate would see nothing.
         #
-        # Advisory because 114 pre-existing findings cannot be a merge blocker on day one. Flipping
-        # to enforced = add --enforce in ci.yml, once the backlog is cleared.
+        # ENFORCED AGAINST A DECLARED BASELINE (#2314). 104 pre-existing findings could not be a
+        # merge blocker on day one, and correcting a spec is blocked on the unsatisfiable-bump gap
+        # (#2313) — but leaving it advisory is the shape this repo has already ruled against: an
+        # advisory check over a GENERATED comparison has no judgement left to exercise, it just makes
+        # the drift mergeable (#2216). So the gate runs with --enforce against
+        # .github/openapi-route-conformance-baseline.txt, which declares those 104 findings verbatim.
+        # A finding NOT in that file fails the build (new drift, the thing the gate is for); a
+        # baseline line with no matching finding ALSO fails (the debt was paid — delete the line), so
+        # the declaration cannot outlive the debt. The baseline does not narrow what the gate LOOKS
+        # AT — every service is compared every run — which is what separates it from the
+        # pact-drift-check scope bug (#2284). #2314 closes when the file is empty.
       openapi_request_schema_conformance:
         detect: ["openbank-*/src/main/resources/openapi.yaml", "the JAX-RS request-body DTO the resource actually deserializes into"]
         require:

--- a/openbank-infra/gitops/components/copilot/copilot-service.yaml
+++ b/openbank-infra/gitops/components/copilot/copilot-service.yaml
@@ -29,7 +29,7 @@ spec:
       annotations:
         # Rolls the pod when the OPA bundle changes — subPath mounts do NOT hot-reload.
         # Kept in sync by gen-copilot-opa-bundle.sh (do not hand-edit).
-        openbank.tech/policy-checksum: "883709e2b6fc4132"
+        openbank.tech/policy-checksum: "4a18f7c046ce99c6"
     spec:
       securityContext:
         runAsNonRoot: true

--- a/openbank-infra/gitops/components/copilot/copilot-service.yaml
+++ b/openbank-infra/gitops/components/copilot/copilot-service.yaml
@@ -29,7 +29,7 @@ spec:
       annotations:
         # Rolls the pod when the OPA bundle changes — subPath mounts do NOT hot-reload.
         # Kept in sync by gen-copilot-opa-bundle.sh (do not hand-edit).
-        openbank.tech/policy-checksum: "787ee5d8d1839648"
+        openbank.tech/policy-checksum: "883709e2b6fc4132"
     spec:
       securityContext:
         runAsNonRoot: true

--- a/openbank-infra/gitops/components/customer-edge/customer-edge-opa-bundle.yaml
+++ b/openbank-infra/gitops/components/customer-edge/customer-edge-opa-bundle.yaml
@@ -10,7 +10,7 @@ metadata:
     app.kubernetes.io/name: customer-edge
     app.kubernetes.io/part-of: customer-edge
   annotations:
-    openbank.tech/policy-checksum: "9b1c5823d258c9d9"
+    openbank.tech/policy-checksum: "5370eab5af57bb71"
 data:
   rest.rego: |
     # SPDX-License-Identifier: Apache-2.0
@@ -1415,12 +1415,36 @@ data:
         # fx + sepa-payment, sepa-instant, domestic-payment, fraud (SSDLC-audit rollout 2026-07-06) +
         # sanctions (2026-07-11: 3 domain files — screening/matching decision logic — matches the
         # "substantive domain math" criterion, not the thin-domain one; 67% local baseline).
-        # The remaining 7 (sca, consent, billing, clearing, swift, lending, settlement) stay excluded:
-        # each has only 1-2 domain files, and those files are plain data models (no branching
-        # money-movement logic), so mutation testing there is noise, not signal — re-confirmed by
-        # file count on 2026-07-11 (settlement and sanctions were both added to money_path_services
-        # after the 2026-07-07 note above; settlement re-confirmed thin, sanctions was the one that
-        # wasn't). Revisit if any of the remaining 7 grows real decision logic in its domain layer.
+        # The remaining 7 (sca, consent, billing, clearing, swift, lending, settlement) stay excluded.
+        #
+        # This list used to be justified by one blanket claim — "each has only 1-2 domain files, and
+        # those files are plain data models (no branching money-movement logic)". The file count was
+        # re-confirmed; the NO-BRANCHING half was never measured, and it is FALSE for three of the
+        # seven (#2395). Measured on 2026-07-26, counting `if (` / `when (` / `require(` / `check(`
+        # over every `src/main/kotlin/**/domain/**.kt` in each module — a deliberately narrow matcher,
+        # so these are lower bounds:
+        #
+        #     service     domain files   branch sites
+        #     sca                    2             11
+        #     consent                2              6
+        #     swift                  1              5
+        #     clearing               3              1
+        #     billing                2              0
+        #     lending                1              0
+        #     settlement             1              0
+        #
+        # So the exclusion rests on a DIFFERENT judgement, and it is stated here rather than hidden
+        # behind an inaccurate blanket: what sca, consent and swift branch on is input VALIDATION and
+        # state-transition legality, not money-movement arithmetic — pitest's value is in the
+        # arithmetic, and no pitest plugin is wired for any of the 7. billing needs its own reason:
+        # its domain layer genuinely does not branch, but its real fee-waiver logic (ADR-0143 phase 2)
+        # lives in `application/usecase/FeeAssessmentService`, OUTSIDE pitest's `domain.*`
+        # targetClasses — so widening the target would be the fix there, not adding the module.
+        #
+        # Revisit if any of the 7 grows money-movement ARITHMETIC in its domain layer; a rising branch
+        # count alone is not the trigger, and re-measure before repeating any claim in this block.
+        # (Historical note: settlement and sanctions were both added to money_path_services after the
+        # 2026-07-07 note above; settlement re-confirmed thin, sanctions was the one that wasn't.)
         # True baselines at rollout (after fixing the KILLED-quote parsing bug): account 49%,
         # transaction 46%, balance 55%, ledger 65%, fx 73%.
         blocked_on: "blocking flip requires each service to sustain >=70% mutation kill score on the weekly run; account/transaction/balance/ledger are below it today (see baselines above)"

--- a/openbank-infra/gitops/components/customer-edge/customer-edge-opa-bundle.yaml
+++ b/openbank-infra/gitops/components/customer-edge/customer-edge-opa-bundle.yaml
@@ -10,7 +10,7 @@ metadata:
     app.kubernetes.io/name: customer-edge
     app.kubernetes.io/part-of: customer-edge
   annotations:
-    openbank.tech/policy-checksum: "c30ed48a4b8b2831"
+    openbank.tech/policy-checksum: "9b1c5823d258c9d9"
 data:
   rest.rego: |
     # SPDX-License-Identifier: Apache-2.0
@@ -721,9 +721,9 @@ data:
           - "every route a resource class answers is published in that service's openapi.yaml"
           - "every route openapi.yaml promises is declared by a resource class"
         gate: openapi-route-conformance
-        enforced: advisory
-        target_enforce_date: "2026-09-30"
+        enforced: enforce                 # ADR-0144 graduation, ahead of the 2026-09-30 target (#2314)
         ci_producer: ".github/scripts/check-openapi-route-conformance.py"
+        baseline: ".github/openapi-route-conformance-baseline.txt"
         # api_contract (above) classifies a spec's version bump against the PREVIOUS REVISION of the
         # same document. Nothing asked whether the document is TRUE. ADR-0005 says "CI lints it with
         # Spectral so docs cannot drift from runtime" — there is no Spectral config in this repo and
@@ -749,8 +749,17 @@ data:
         # is a MISSING pair across two trees, so a PR touching only Kotlin never touches the spec and
         # a diff-scoped gate would see nothing.
         #
-        # Advisory because 114 pre-existing findings cannot be a merge blocker on day one. Flipping
-        # to enforced = add --enforce in ci.yml, once the backlog is cleared.
+        # ENFORCED AGAINST A DECLARED BASELINE (#2314). 104 pre-existing findings could not be a
+        # merge blocker on day one, and correcting a spec is blocked on the unsatisfiable-bump gap
+        # (#2313) — but leaving it advisory is the shape this repo has already ruled against: an
+        # advisory check over a GENERATED comparison has no judgement left to exercise, it just makes
+        # the drift mergeable (#2216). So the gate runs with --enforce against
+        # .github/openapi-route-conformance-baseline.txt, which declares those 104 findings verbatim.
+        # A finding NOT in that file fails the build (new drift, the thing the gate is for); a
+        # baseline line with no matching finding ALSO fails (the debt was paid — delete the line), so
+        # the declaration cannot outlive the debt. The baseline does not narrow what the gate LOOKS
+        # AT — every service is compared every run — which is what separates it from the
+        # pact-drift-check scope bug (#2284). #2314 closes when the file is empty.
       openapi_request_schema_conformance:
         detect: ["openbank-*/src/main/resources/openapi.yaml", "the JAX-RS request-body DTO the resource actually deserializes into"]
         require:

--- a/openbank-infra/gitops/components/customer-edge/customer-edge.yaml
+++ b/openbank-infra/gitops/components/customer-edge/customer-edge.yaml
@@ -65,7 +65,7 @@ spec:
       annotations:
         # Rolls the pod when the OPA bundle changes — subPath mounts do NOT hot-reload.
         # Kept in sync by gen-customer-edge-opa-bundle.sh (do not hand-edit).
-        openbank.tech/policy-checksum: "c30ed48a4b8b2831"
+        openbank.tech/policy-checksum: "9b1c5823d258c9d9"
     spec:
       # Dedicated SA so EKS Pod Identity can hand the edge (and ONLY the edge) the
       # feedback-screenshots S3 role — ADR-0192, openbank-infra/aws/envs/sandbox-platform/

--- a/openbank-infra/gitops/components/customer-edge/customer-edge.yaml
+++ b/openbank-infra/gitops/components/customer-edge/customer-edge.yaml
@@ -65,7 +65,7 @@ spec:
       annotations:
         # Rolls the pod when the OPA bundle changes — subPath mounts do NOT hot-reload.
         # Kept in sync by gen-customer-edge-opa-bundle.sh (do not hand-edit).
-        openbank.tech/policy-checksum: "9b1c5823d258c9d9"
+        openbank.tech/policy-checksum: "5370eab5af57bb71"
     spec:
       # Dedicated SA so EKS Pod Identity can hand the edge (and ONLY the edge) the
       # feedback-screenshots S3 role — ADR-0192, openbank-infra/aws/envs/sandbox-platform/

--- a/openbank-infra/gitops/components/dispute-service/dispute-opa-bundle.yaml
+++ b/openbank-infra/gitops/components/dispute-service/dispute-opa-bundle.yaml
@@ -9,7 +9,7 @@ metadata:
     app.kubernetes.io/name: dispute-service
     app.kubernetes.io/part-of: dispute
   annotations:
-    openbank.tech/policy-checksum: "24b04754c9423ba3"
+    openbank.tech/policy-checksum: "e846242d12246f26"
 data:
   rest.rego: |
     # SPDX-License-Identifier: Apache-2.0
@@ -1672,9 +1672,9 @@ data:
           - "every route a resource class answers is published in that service's openapi.yaml"
           - "every route openapi.yaml promises is declared by a resource class"
         gate: openapi-route-conformance
-        enforced: advisory
-        target_enforce_date: "2026-09-30"
+        enforced: enforce                 # ADR-0144 graduation, ahead of the 2026-09-30 target (#2314)
         ci_producer: ".github/scripts/check-openapi-route-conformance.py"
+        baseline: ".github/openapi-route-conformance-baseline.txt"
         # api_contract (above) classifies a spec's version bump against the PREVIOUS REVISION of the
         # same document. Nothing asked whether the document is TRUE. ADR-0005 says "CI lints it with
         # Spectral so docs cannot drift from runtime" — there is no Spectral config in this repo and
@@ -1700,8 +1700,17 @@ data:
         # is a MISSING pair across two trees, so a PR touching only Kotlin never touches the spec and
         # a diff-scoped gate would see nothing.
         #
-        # Advisory because 114 pre-existing findings cannot be a merge blocker on day one. Flipping
-        # to enforced = add --enforce in ci.yml, once the backlog is cleared.
+        # ENFORCED AGAINST A DECLARED BASELINE (#2314). 104 pre-existing findings could not be a
+        # merge blocker on day one, and correcting a spec is blocked on the unsatisfiable-bump gap
+        # (#2313) — but leaving it advisory is the shape this repo has already ruled against: an
+        # advisory check over a GENERATED comparison has no judgement left to exercise, it just makes
+        # the drift mergeable (#2216). So the gate runs with --enforce against
+        # .github/openapi-route-conformance-baseline.txt, which declares those 104 findings verbatim.
+        # A finding NOT in that file fails the build (new drift, the thing the gate is for); a
+        # baseline line with no matching finding ALSO fails (the debt was paid — delete the line), so
+        # the declaration cannot outlive the debt. The baseline does not narrow what the gate LOOKS
+        # AT — every service is compared every run — which is what separates it from the
+        # pact-drift-check scope bug (#2284). #2314 closes when the file is empty.
       openapi_request_schema_conformance:
         detect: ["openbank-*/src/main/resources/openapi.yaml", "the JAX-RS request-body DTO the resource actually deserializes into"]
         require:

--- a/openbank-infra/gitops/components/dispute-service/dispute-opa-bundle.yaml
+++ b/openbank-infra/gitops/components/dispute-service/dispute-opa-bundle.yaml
@@ -9,7 +9,7 @@ metadata:
     app.kubernetes.io/name: dispute-service
     app.kubernetes.io/part-of: dispute
   annotations:
-    openbank.tech/policy-checksum: "e846242d12246f26"
+    openbank.tech/policy-checksum: "57d18c6aa30e7fad"
 data:
   rest.rego: |
     # SPDX-License-Identifier: Apache-2.0
@@ -2366,12 +2366,36 @@ data:
         # fx + sepa-payment, sepa-instant, domestic-payment, fraud (SSDLC-audit rollout 2026-07-06) +
         # sanctions (2026-07-11: 3 domain files — screening/matching decision logic — matches the
         # "substantive domain math" criterion, not the thin-domain one; 67% local baseline).
-        # The remaining 7 (sca, consent, billing, clearing, swift, lending, settlement) stay excluded:
-        # each has only 1-2 domain files, and those files are plain data models (no branching
-        # money-movement logic), so mutation testing there is noise, not signal — re-confirmed by
-        # file count on 2026-07-11 (settlement and sanctions were both added to money_path_services
-        # after the 2026-07-07 note above; settlement re-confirmed thin, sanctions was the one that
-        # wasn't). Revisit if any of the remaining 7 grows real decision logic in its domain layer.
+        # The remaining 7 (sca, consent, billing, clearing, swift, lending, settlement) stay excluded.
+        #
+        # This list used to be justified by one blanket claim — "each has only 1-2 domain files, and
+        # those files are plain data models (no branching money-movement logic)". The file count was
+        # re-confirmed; the NO-BRANCHING half was never measured, and it is FALSE for three of the
+        # seven (#2395). Measured on 2026-07-26, counting `if (` / `when (` / `require(` / `check(`
+        # over every `src/main/kotlin/**/domain/**.kt` in each module — a deliberately narrow matcher,
+        # so these are lower bounds:
+        #
+        #     service     domain files   branch sites
+        #     sca                    2             11
+        #     consent                2              6
+        #     swift                  1              5
+        #     clearing               3              1
+        #     billing                2              0
+        #     lending                1              0
+        #     settlement             1              0
+        #
+        # So the exclusion rests on a DIFFERENT judgement, and it is stated here rather than hidden
+        # behind an inaccurate blanket: what sca, consent and swift branch on is input VALIDATION and
+        # state-transition legality, not money-movement arithmetic — pitest's value is in the
+        # arithmetic, and no pitest plugin is wired for any of the 7. billing needs its own reason:
+        # its domain layer genuinely does not branch, but its real fee-waiver logic (ADR-0143 phase 2)
+        # lives in `application/usecase/FeeAssessmentService`, OUTSIDE pitest's `domain.*`
+        # targetClasses — so widening the target would be the fix there, not adding the module.
+        #
+        # Revisit if any of the 7 grows money-movement ARITHMETIC in its domain layer; a rising branch
+        # count alone is not the trigger, and re-measure before repeating any claim in this block.
+        # (Historical note: settlement and sanctions were both added to money_path_services after the
+        # 2026-07-07 note above; settlement re-confirmed thin, sanctions was the one that wasn't.)
         # True baselines at rollout (after fixing the KILLED-quote parsing bug): account 49%,
         # transaction 46%, balance 55%, ledger 65%, fx 73%.
         blocked_on: "blocking flip requires each service to sustain >=70% mutation kill score on the weekly run; account/transaction/balance/ledger are below it today (see baselines above)"

--- a/openbank-infra/gitops/components/dispute-service/dispute-service.yaml
+++ b/openbank-infra/gitops/components/dispute-service/dispute-service.yaml
@@ -15,7 +15,7 @@ spec:
       annotations:
         # Rolls the pod when the OPA bundle changes — subPath mounts do NOT hot-reload.
         # Kept in sync by gen-dispute-opa-bundle.sh (do not hand-edit).
-        openbank.tech/policy-checksum: "24b04754c9423ba3"
+        openbank.tech/policy-checksum: "e846242d12246f26"
       labels: {app.kubernetes.io/name: dispute-service, app.kubernetes.io/part-of: dispute}
     spec:
       securityContext:

--- a/openbank-infra/gitops/components/dispute-service/dispute-service.yaml
+++ b/openbank-infra/gitops/components/dispute-service/dispute-service.yaml
@@ -15,7 +15,7 @@ spec:
       annotations:
         # Rolls the pod when the OPA bundle changes — subPath mounts do NOT hot-reload.
         # Kept in sync by gen-dispute-opa-bundle.sh (do not hand-edit).
-        openbank.tech/policy-checksum: "e846242d12246f26"
+        openbank.tech/policy-checksum: "57d18c6aa30e7fad"
       labels: {app.kubernetes.io/name: dispute-service, app.kubernetes.io/part-of: dispute}
     spec:
       securityContext:

--- a/openbank-infra/gitops/components/document-service/document-service-opa-bundle.yaml
+++ b/openbank-infra/gitops/components/document-service/document-service-opa-bundle.yaml
@@ -10,7 +10,7 @@ metadata:
     app.kubernetes.io/name: document-service
     app.kubernetes.io/part-of: documents
   annotations:
-    openbank.tech/policy-checksum: "c30ed48a4b8b2831"
+    openbank.tech/policy-checksum: "9b1c5823d258c9d9"
 data:
   rest.rego: |
     # SPDX-License-Identifier: Apache-2.0
@@ -721,9 +721,9 @@ data:
           - "every route a resource class answers is published in that service's openapi.yaml"
           - "every route openapi.yaml promises is declared by a resource class"
         gate: openapi-route-conformance
-        enforced: advisory
-        target_enforce_date: "2026-09-30"
+        enforced: enforce                 # ADR-0144 graduation, ahead of the 2026-09-30 target (#2314)
         ci_producer: ".github/scripts/check-openapi-route-conformance.py"
+        baseline: ".github/openapi-route-conformance-baseline.txt"
         # api_contract (above) classifies a spec's version bump against the PREVIOUS REVISION of the
         # same document. Nothing asked whether the document is TRUE. ADR-0005 says "CI lints it with
         # Spectral so docs cannot drift from runtime" — there is no Spectral config in this repo and
@@ -749,8 +749,17 @@ data:
         # is a MISSING pair across two trees, so a PR touching only Kotlin never touches the spec and
         # a diff-scoped gate would see nothing.
         #
-        # Advisory because 114 pre-existing findings cannot be a merge blocker on day one. Flipping
-        # to enforced = add --enforce in ci.yml, once the backlog is cleared.
+        # ENFORCED AGAINST A DECLARED BASELINE (#2314). 104 pre-existing findings could not be a
+        # merge blocker on day one, and correcting a spec is blocked on the unsatisfiable-bump gap
+        # (#2313) — but leaving it advisory is the shape this repo has already ruled against: an
+        # advisory check over a GENERATED comparison has no judgement left to exercise, it just makes
+        # the drift mergeable (#2216). So the gate runs with --enforce against
+        # .github/openapi-route-conformance-baseline.txt, which declares those 104 findings verbatim.
+        # A finding NOT in that file fails the build (new drift, the thing the gate is for); a
+        # baseline line with no matching finding ALSO fails (the debt was paid — delete the line), so
+        # the declaration cannot outlive the debt. The baseline does not narrow what the gate LOOKS
+        # AT — every service is compared every run — which is what separates it from the
+        # pact-drift-check scope bug (#2284). #2314 closes when the file is empty.
       openapi_request_schema_conformance:
         detect: ["openbank-*/src/main/resources/openapi.yaml", "the JAX-RS request-body DTO the resource actually deserializes into"]
         require:

--- a/openbank-infra/gitops/components/document-service/document-service-opa-bundle.yaml
+++ b/openbank-infra/gitops/components/document-service/document-service-opa-bundle.yaml
@@ -10,7 +10,7 @@ metadata:
     app.kubernetes.io/name: document-service
     app.kubernetes.io/part-of: documents
   annotations:
-    openbank.tech/policy-checksum: "9b1c5823d258c9d9"
+    openbank.tech/policy-checksum: "5370eab5af57bb71"
 data:
   rest.rego: |
     # SPDX-License-Identifier: Apache-2.0
@@ -1415,12 +1415,36 @@ data:
         # fx + sepa-payment, sepa-instant, domestic-payment, fraud (SSDLC-audit rollout 2026-07-06) +
         # sanctions (2026-07-11: 3 domain files — screening/matching decision logic — matches the
         # "substantive domain math" criterion, not the thin-domain one; 67% local baseline).
-        # The remaining 7 (sca, consent, billing, clearing, swift, lending, settlement) stay excluded:
-        # each has only 1-2 domain files, and those files are plain data models (no branching
-        # money-movement logic), so mutation testing there is noise, not signal — re-confirmed by
-        # file count on 2026-07-11 (settlement and sanctions were both added to money_path_services
-        # after the 2026-07-07 note above; settlement re-confirmed thin, sanctions was the one that
-        # wasn't). Revisit if any of the remaining 7 grows real decision logic in its domain layer.
+        # The remaining 7 (sca, consent, billing, clearing, swift, lending, settlement) stay excluded.
+        #
+        # This list used to be justified by one blanket claim — "each has only 1-2 domain files, and
+        # those files are plain data models (no branching money-movement logic)". The file count was
+        # re-confirmed; the NO-BRANCHING half was never measured, and it is FALSE for three of the
+        # seven (#2395). Measured on 2026-07-26, counting `if (` / `when (` / `require(` / `check(`
+        # over every `src/main/kotlin/**/domain/**.kt` in each module — a deliberately narrow matcher,
+        # so these are lower bounds:
+        #
+        #     service     domain files   branch sites
+        #     sca                    2             11
+        #     consent                2              6
+        #     swift                  1              5
+        #     clearing               3              1
+        #     billing                2              0
+        #     lending                1              0
+        #     settlement             1              0
+        #
+        # So the exclusion rests on a DIFFERENT judgement, and it is stated here rather than hidden
+        # behind an inaccurate blanket: what sca, consent and swift branch on is input VALIDATION and
+        # state-transition legality, not money-movement arithmetic — pitest's value is in the
+        # arithmetic, and no pitest plugin is wired for any of the 7. billing needs its own reason:
+        # its domain layer genuinely does not branch, but its real fee-waiver logic (ADR-0143 phase 2)
+        # lives in `application/usecase/FeeAssessmentService`, OUTSIDE pitest's `domain.*`
+        # targetClasses — so widening the target would be the fix there, not adding the module.
+        #
+        # Revisit if any of the 7 grows money-movement ARITHMETIC in its domain layer; a rising branch
+        # count alone is not the trigger, and re-measure before repeating any claim in this block.
+        # (Historical note: settlement and sanctions were both added to money_path_services after the
+        # 2026-07-07 note above; settlement re-confirmed thin, sanctions was the one that wasn't.)
         # True baselines at rollout (after fixing the KILLED-quote parsing bug): account 49%,
         # transaction 46%, balance 55%, ledger 65%, fx 73%.
         blocked_on: "blocking flip requires each service to sustain >=70% mutation kill score on the weekly run; account/transaction/balance/ledger are below it today (see baselines above)"

--- a/openbank-infra/gitops/components/document-service/document-service-service.yaml
+++ b/openbank-infra/gitops/components/document-service/document-service-service.yaml
@@ -43,7 +43,7 @@ spec:
       annotations:
         # Rolls the pods when the OPA bundle changes — subPath mounts do NOT hot-reload.
         # Kept in sync by gen-document-service-opa-bundle.sh (do not hand-edit).
-        openbank.tech/policy-checksum: "9b1c5823d258c9d9"
+        openbank.tech/policy-checksum: "5370eab5af57bb71"
     spec:
       # ADR-0162 D4 (continued): a dedicated SA (not `default`) is what OpenBao's Kubernetes-auth
       # role `document-service-signing` is bound to — least-privilege, one identity per consumer.

--- a/openbank-infra/gitops/components/document-service/document-service-service.yaml
+++ b/openbank-infra/gitops/components/document-service/document-service-service.yaml
@@ -43,7 +43,7 @@ spec:
       annotations:
         # Rolls the pods when the OPA bundle changes — subPath mounts do NOT hot-reload.
         # Kept in sync by gen-document-service-opa-bundle.sh (do not hand-edit).
-        openbank.tech/policy-checksum: "c30ed48a4b8b2831"
+        openbank.tech/policy-checksum: "9b1c5823d258c9d9"
     spec:
       # ADR-0162 D4 (continued): a dedicated SA (not `default`) is what OpenBao's Kubernetes-auth
       # role `document-service-signing` is bound to — least-privilege, one identity per consumer.

--- a/openbank-infra/gitops/components/fraud-service/fraud-opa-bundle.yaml
+++ b/openbank-infra/gitops/components/fraud-service/fraud-opa-bundle.yaml
@@ -9,7 +9,7 @@ metadata:
     app.kubernetes.io/name: fraud-service
     app.kubernetes.io/part-of: fraud
   annotations:
-    openbank.tech/policy-checksum: "d557a22989d178ea"
+    openbank.tech/policy-checksum: "8ceef6359f217b65"
 data:
   rest.rego: |
     # SPDX-License-Identifier: Apache-2.0
@@ -1547,9 +1547,9 @@ data:
           - "every route a resource class answers is published in that service's openapi.yaml"
           - "every route openapi.yaml promises is declared by a resource class"
         gate: openapi-route-conformance
-        enforced: advisory
-        target_enforce_date: "2026-09-30"
+        enforced: enforce                 # ADR-0144 graduation, ahead of the 2026-09-30 target (#2314)
         ci_producer: ".github/scripts/check-openapi-route-conformance.py"
+        baseline: ".github/openapi-route-conformance-baseline.txt"
         # api_contract (above) classifies a spec's version bump against the PREVIOUS REVISION of the
         # same document. Nothing asked whether the document is TRUE. ADR-0005 says "CI lints it with
         # Spectral so docs cannot drift from runtime" — there is no Spectral config in this repo and
@@ -1575,8 +1575,17 @@ data:
         # is a MISSING pair across two trees, so a PR touching only Kotlin never touches the spec and
         # a diff-scoped gate would see nothing.
         #
-        # Advisory because 114 pre-existing findings cannot be a merge blocker on day one. Flipping
-        # to enforced = add --enforce in ci.yml, once the backlog is cleared.
+        # ENFORCED AGAINST A DECLARED BASELINE (#2314). 104 pre-existing findings could not be a
+        # merge blocker on day one, and correcting a spec is blocked on the unsatisfiable-bump gap
+        # (#2313) — but leaving it advisory is the shape this repo has already ruled against: an
+        # advisory check over a GENERATED comparison has no judgement left to exercise, it just makes
+        # the drift mergeable (#2216). So the gate runs with --enforce against
+        # .github/openapi-route-conformance-baseline.txt, which declares those 104 findings verbatim.
+        # A finding NOT in that file fails the build (new drift, the thing the gate is for); a
+        # baseline line with no matching finding ALSO fails (the debt was paid — delete the line), so
+        # the declaration cannot outlive the debt. The baseline does not narrow what the gate LOOKS
+        # AT — every service is compared every run — which is what separates it from the
+        # pact-drift-check scope bug (#2284). #2314 closes when the file is empty.
       openapi_request_schema_conformance:
         detect: ["openbank-*/src/main/resources/openapi.yaml", "the JAX-RS request-body DTO the resource actually deserializes into"]
         require:

--- a/openbank-infra/gitops/components/fraud-service/fraud-opa-bundle.yaml
+++ b/openbank-infra/gitops/components/fraud-service/fraud-opa-bundle.yaml
@@ -9,7 +9,7 @@ metadata:
     app.kubernetes.io/name: fraud-service
     app.kubernetes.io/part-of: fraud
   annotations:
-    openbank.tech/policy-checksum: "8ceef6359f217b65"
+    openbank.tech/policy-checksum: "b4b5df85eb26b62c"
 data:
   rest.rego: |
     # SPDX-License-Identifier: Apache-2.0
@@ -2241,12 +2241,36 @@ data:
         # fx + sepa-payment, sepa-instant, domestic-payment, fraud (SSDLC-audit rollout 2026-07-06) +
         # sanctions (2026-07-11: 3 domain files — screening/matching decision logic — matches the
         # "substantive domain math" criterion, not the thin-domain one; 67% local baseline).
-        # The remaining 7 (sca, consent, billing, clearing, swift, lending, settlement) stay excluded:
-        # each has only 1-2 domain files, and those files are plain data models (no branching
-        # money-movement logic), so mutation testing there is noise, not signal — re-confirmed by
-        # file count on 2026-07-11 (settlement and sanctions were both added to money_path_services
-        # after the 2026-07-07 note above; settlement re-confirmed thin, sanctions was the one that
-        # wasn't). Revisit if any of the remaining 7 grows real decision logic in its domain layer.
+        # The remaining 7 (sca, consent, billing, clearing, swift, lending, settlement) stay excluded.
+        #
+        # This list used to be justified by one blanket claim — "each has only 1-2 domain files, and
+        # those files are plain data models (no branching money-movement logic)". The file count was
+        # re-confirmed; the NO-BRANCHING half was never measured, and it is FALSE for three of the
+        # seven (#2395). Measured on 2026-07-26, counting `if (` / `when (` / `require(` / `check(`
+        # over every `src/main/kotlin/**/domain/**.kt` in each module — a deliberately narrow matcher,
+        # so these are lower bounds:
+        #
+        #     service     domain files   branch sites
+        #     sca                    2             11
+        #     consent                2              6
+        #     swift                  1              5
+        #     clearing               3              1
+        #     billing                2              0
+        #     lending                1              0
+        #     settlement             1              0
+        #
+        # So the exclusion rests on a DIFFERENT judgement, and it is stated here rather than hidden
+        # behind an inaccurate blanket: what sca, consent and swift branch on is input VALIDATION and
+        # state-transition legality, not money-movement arithmetic — pitest's value is in the
+        # arithmetic, and no pitest plugin is wired for any of the 7. billing needs its own reason:
+        # its domain layer genuinely does not branch, but its real fee-waiver logic (ADR-0143 phase 2)
+        # lives in `application/usecase/FeeAssessmentService`, OUTSIDE pitest's `domain.*`
+        # targetClasses — so widening the target would be the fix there, not adding the module.
+        #
+        # Revisit if any of the 7 grows money-movement ARITHMETIC in its domain layer; a rising branch
+        # count alone is not the trigger, and re-measure before repeating any claim in this block.
+        # (Historical note: settlement and sanctions were both added to money_path_services after the
+        # 2026-07-07 note above; settlement re-confirmed thin, sanctions was the one that wasn't.)
         # True baselines at rollout (after fixing the KILLED-quote parsing bug): account 49%,
         # transaction 46%, balance 55%, ledger 65%, fx 73%.
         blocked_on: "blocking flip requires each service to sustain >=70% mutation kill score on the weekly run; account/transaction/balance/ledger are below it today (see baselines above)"

--- a/openbank-infra/gitops/components/fraud-service/fraud-service.yaml
+++ b/openbank-infra/gitops/components/fraud-service/fraud-service.yaml
@@ -23,7 +23,7 @@ spec:
       annotations:
         # Rolls the pods when the OPA bundle changes — subPath mounts do NOT hot-reload.
         # Kept in sync by gen-fraud-opa-bundle.sh (do not hand-edit).
-        openbank.tech/policy-checksum: "d557a22989d178ea"
+        openbank.tech/policy-checksum: "8ceef6359f217b65"
     spec:
       securityContext:
         runAsNonRoot: true

--- a/openbank-infra/gitops/components/fraud-service/fraud-service.yaml
+++ b/openbank-infra/gitops/components/fraud-service/fraud-service.yaml
@@ -23,7 +23,7 @@ spec:
       annotations:
         # Rolls the pods when the OPA bundle changes — subPath mounts do NOT hot-reload.
         # Kept in sync by gen-fraud-opa-bundle.sh (do not hand-edit).
-        openbank.tech/policy-checksum: "8ceef6359f217b65"
+        openbank.tech/policy-checksum: "b4b5df85eb26b62c"
     spec:
       securityContext:
         runAsNonRoot: true

--- a/openbank-infra/gitops/components/fx-service/fx-opa-bundle.yaml
+++ b/openbank-infra/gitops/components/fx-service/fx-opa-bundle.yaml
@@ -9,7 +9,7 @@ metadata:
     app.kubernetes.io/name: fx-service
     app.kubernetes.io/part-of: fx
   annotations:
-    openbank.tech/policy-checksum: "6a89a82288fcb40c"
+    openbank.tech/policy-checksum: "10902d39cf2d68ae"
 data:
   rest.rego: |
     # SPDX-License-Identifier: Apache-2.0
@@ -1598,9 +1598,9 @@ data:
           - "every route a resource class answers is published in that service's openapi.yaml"
           - "every route openapi.yaml promises is declared by a resource class"
         gate: openapi-route-conformance
-        enforced: advisory
-        target_enforce_date: "2026-09-30"
+        enforced: enforce                 # ADR-0144 graduation, ahead of the 2026-09-30 target (#2314)
         ci_producer: ".github/scripts/check-openapi-route-conformance.py"
+        baseline: ".github/openapi-route-conformance-baseline.txt"
         # api_contract (above) classifies a spec's version bump against the PREVIOUS REVISION of the
         # same document. Nothing asked whether the document is TRUE. ADR-0005 says "CI lints it with
         # Spectral so docs cannot drift from runtime" — there is no Spectral config in this repo and
@@ -1626,8 +1626,17 @@ data:
         # is a MISSING pair across two trees, so a PR touching only Kotlin never touches the spec and
         # a diff-scoped gate would see nothing.
         #
-        # Advisory because 114 pre-existing findings cannot be a merge blocker on day one. Flipping
-        # to enforced = add --enforce in ci.yml, once the backlog is cleared.
+        # ENFORCED AGAINST A DECLARED BASELINE (#2314). 104 pre-existing findings could not be a
+        # merge blocker on day one, and correcting a spec is blocked on the unsatisfiable-bump gap
+        # (#2313) — but leaving it advisory is the shape this repo has already ruled against: an
+        # advisory check over a GENERATED comparison has no judgement left to exercise, it just makes
+        # the drift mergeable (#2216). So the gate runs with --enforce against
+        # .github/openapi-route-conformance-baseline.txt, which declares those 104 findings verbatim.
+        # A finding NOT in that file fails the build (new drift, the thing the gate is for); a
+        # baseline line with no matching finding ALSO fails (the debt was paid — delete the line), so
+        # the declaration cannot outlive the debt. The baseline does not narrow what the gate LOOKS
+        # AT — every service is compared every run — which is what separates it from the
+        # pact-drift-check scope bug (#2284). #2314 closes when the file is empty.
       openapi_request_schema_conformance:
         detect: ["openbank-*/src/main/resources/openapi.yaml", "the JAX-RS request-body DTO the resource actually deserializes into"]
         require:

--- a/openbank-infra/gitops/components/fx-service/fx-opa-bundle.yaml
+++ b/openbank-infra/gitops/components/fx-service/fx-opa-bundle.yaml
@@ -9,7 +9,7 @@ metadata:
     app.kubernetes.io/name: fx-service
     app.kubernetes.io/part-of: fx
   annotations:
-    openbank.tech/policy-checksum: "10902d39cf2d68ae"
+    openbank.tech/policy-checksum: "e210004e675250c4"
 data:
   rest.rego: |
     # SPDX-License-Identifier: Apache-2.0
@@ -2292,12 +2292,36 @@ data:
         # fx + sepa-payment, sepa-instant, domestic-payment, fraud (SSDLC-audit rollout 2026-07-06) +
         # sanctions (2026-07-11: 3 domain files — screening/matching decision logic — matches the
         # "substantive domain math" criterion, not the thin-domain one; 67% local baseline).
-        # The remaining 7 (sca, consent, billing, clearing, swift, lending, settlement) stay excluded:
-        # each has only 1-2 domain files, and those files are plain data models (no branching
-        # money-movement logic), so mutation testing there is noise, not signal — re-confirmed by
-        # file count on 2026-07-11 (settlement and sanctions were both added to money_path_services
-        # after the 2026-07-07 note above; settlement re-confirmed thin, sanctions was the one that
-        # wasn't). Revisit if any of the remaining 7 grows real decision logic in its domain layer.
+        # The remaining 7 (sca, consent, billing, clearing, swift, lending, settlement) stay excluded.
+        #
+        # This list used to be justified by one blanket claim — "each has only 1-2 domain files, and
+        # those files are plain data models (no branching money-movement logic)". The file count was
+        # re-confirmed; the NO-BRANCHING half was never measured, and it is FALSE for three of the
+        # seven (#2395). Measured on 2026-07-26, counting `if (` / `when (` / `require(` / `check(`
+        # over every `src/main/kotlin/**/domain/**.kt` in each module — a deliberately narrow matcher,
+        # so these are lower bounds:
+        #
+        #     service     domain files   branch sites
+        #     sca                    2             11
+        #     consent                2              6
+        #     swift                  1              5
+        #     clearing               3              1
+        #     billing                2              0
+        #     lending                1              0
+        #     settlement             1              0
+        #
+        # So the exclusion rests on a DIFFERENT judgement, and it is stated here rather than hidden
+        # behind an inaccurate blanket: what sca, consent and swift branch on is input VALIDATION and
+        # state-transition legality, not money-movement arithmetic — pitest's value is in the
+        # arithmetic, and no pitest plugin is wired for any of the 7. billing needs its own reason:
+        # its domain layer genuinely does not branch, but its real fee-waiver logic (ADR-0143 phase 2)
+        # lives in `application/usecase/FeeAssessmentService`, OUTSIDE pitest's `domain.*`
+        # targetClasses — so widening the target would be the fix there, not adding the module.
+        #
+        # Revisit if any of the 7 grows money-movement ARITHMETIC in its domain layer; a rising branch
+        # count alone is not the trigger, and re-measure before repeating any claim in this block.
+        # (Historical note: settlement and sanctions were both added to money_path_services after the
+        # 2026-07-07 note above; settlement re-confirmed thin, sanctions was the one that wasn't.)
         # True baselines at rollout (after fixing the KILLED-quote parsing bug): account 49%,
         # transaction 46%, balance 55%, ledger 65%, fx 73%.
         blocked_on: "blocking flip requires each service to sustain >=70% mutation kill score on the weekly run; account/transaction/balance/ledger are below it today (see baselines above)"

--- a/openbank-infra/gitops/components/fx-service/fx-service.yaml
+++ b/openbank-infra/gitops/components/fx-service/fx-service.yaml
@@ -22,7 +22,7 @@ spec:
       annotations:
         # Rolls the pods when the OPA bundle changes — subPath mounts do NOT hot-reload.
         # Kept in sync by gen-fx-opa-bundle.sh (do not hand-edit).
-        openbank.tech/policy-checksum: "10902d39cf2d68ae"
+        openbank.tech/policy-checksum: "e210004e675250c4"
     spec:
       securityContext:
         runAsNonRoot: true

--- a/openbank-infra/gitops/components/fx-service/fx-service.yaml
+++ b/openbank-infra/gitops/components/fx-service/fx-service.yaml
@@ -22,7 +22,7 @@ spec:
       annotations:
         # Rolls the pods when the OPA bundle changes — subPath mounts do NOT hot-reload.
         # Kept in sync by gen-fx-opa-bundle.sh (do not hand-edit).
-        openbank.tech/policy-checksum: "6a89a82288fcb40c"
+        openbank.tech/policy-checksum: "10902d39cf2d68ae"
     spec:
       securityContext:
         runAsNonRoot: true

--- a/openbank-infra/gitops/components/interest-service/interest-opa-bundle.yaml
+++ b/openbank-infra/gitops/components/interest-service/interest-opa-bundle.yaml
@@ -9,7 +9,7 @@ metadata:
     app.kubernetes.io/name: interest-service
     app.kubernetes.io/part-of: interest
   annotations:
-    openbank.tech/policy-checksum: "eb25680a3a54e137"
+    openbank.tech/policy-checksum: "f47a5aa90f4d3369"
 data:
   rest.rego: |
     # SPDX-License-Identifier: Apache-2.0
@@ -1532,9 +1532,9 @@ data:
           - "every route a resource class answers is published in that service's openapi.yaml"
           - "every route openapi.yaml promises is declared by a resource class"
         gate: openapi-route-conformance
-        enforced: advisory
-        target_enforce_date: "2026-09-30"
+        enforced: enforce                 # ADR-0144 graduation, ahead of the 2026-09-30 target (#2314)
         ci_producer: ".github/scripts/check-openapi-route-conformance.py"
+        baseline: ".github/openapi-route-conformance-baseline.txt"
         # api_contract (above) classifies a spec's version bump against the PREVIOUS REVISION of the
         # same document. Nothing asked whether the document is TRUE. ADR-0005 says "CI lints it with
         # Spectral so docs cannot drift from runtime" — there is no Spectral config in this repo and
@@ -1560,8 +1560,17 @@ data:
         # is a MISSING pair across two trees, so a PR touching only Kotlin never touches the spec and
         # a diff-scoped gate would see nothing.
         #
-        # Advisory because 114 pre-existing findings cannot be a merge blocker on day one. Flipping
-        # to enforced = add --enforce in ci.yml, once the backlog is cleared.
+        # ENFORCED AGAINST A DECLARED BASELINE (#2314). 104 pre-existing findings could not be a
+        # merge blocker on day one, and correcting a spec is blocked on the unsatisfiable-bump gap
+        # (#2313) — but leaving it advisory is the shape this repo has already ruled against: an
+        # advisory check over a GENERATED comparison has no judgement left to exercise, it just makes
+        # the drift mergeable (#2216). So the gate runs with --enforce against
+        # .github/openapi-route-conformance-baseline.txt, which declares those 104 findings verbatim.
+        # A finding NOT in that file fails the build (new drift, the thing the gate is for); a
+        # baseline line with no matching finding ALSO fails (the debt was paid — delete the line), so
+        # the declaration cannot outlive the debt. The baseline does not narrow what the gate LOOKS
+        # AT — every service is compared every run — which is what separates it from the
+        # pact-drift-check scope bug (#2284). #2314 closes when the file is empty.
       openapi_request_schema_conformance:
         detect: ["openbank-*/src/main/resources/openapi.yaml", "the JAX-RS request-body DTO the resource actually deserializes into"]
         require:

--- a/openbank-infra/gitops/components/interest-service/interest-opa-bundle.yaml
+++ b/openbank-infra/gitops/components/interest-service/interest-opa-bundle.yaml
@@ -9,7 +9,7 @@ metadata:
     app.kubernetes.io/name: interest-service
     app.kubernetes.io/part-of: interest
   annotations:
-    openbank.tech/policy-checksum: "f47a5aa90f4d3369"
+    openbank.tech/policy-checksum: "5145fe52020bc631"
 data:
   rest.rego: |
     # SPDX-License-Identifier: Apache-2.0
@@ -2226,12 +2226,36 @@ data:
         # fx + sepa-payment, sepa-instant, domestic-payment, fraud (SSDLC-audit rollout 2026-07-06) +
         # sanctions (2026-07-11: 3 domain files — screening/matching decision logic — matches the
         # "substantive domain math" criterion, not the thin-domain one; 67% local baseline).
-        # The remaining 7 (sca, consent, billing, clearing, swift, lending, settlement) stay excluded:
-        # each has only 1-2 domain files, and those files are plain data models (no branching
-        # money-movement logic), so mutation testing there is noise, not signal — re-confirmed by
-        # file count on 2026-07-11 (settlement and sanctions were both added to money_path_services
-        # after the 2026-07-07 note above; settlement re-confirmed thin, sanctions was the one that
-        # wasn't). Revisit if any of the remaining 7 grows real decision logic in its domain layer.
+        # The remaining 7 (sca, consent, billing, clearing, swift, lending, settlement) stay excluded.
+        #
+        # This list used to be justified by one blanket claim — "each has only 1-2 domain files, and
+        # those files are plain data models (no branching money-movement logic)". The file count was
+        # re-confirmed; the NO-BRANCHING half was never measured, and it is FALSE for three of the
+        # seven (#2395). Measured on 2026-07-26, counting `if (` / `when (` / `require(` / `check(`
+        # over every `src/main/kotlin/**/domain/**.kt` in each module — a deliberately narrow matcher,
+        # so these are lower bounds:
+        #
+        #     service     domain files   branch sites
+        #     sca                    2             11
+        #     consent                2              6
+        #     swift                  1              5
+        #     clearing               3              1
+        #     billing                2              0
+        #     lending                1              0
+        #     settlement             1              0
+        #
+        # So the exclusion rests on a DIFFERENT judgement, and it is stated here rather than hidden
+        # behind an inaccurate blanket: what sca, consent and swift branch on is input VALIDATION and
+        # state-transition legality, not money-movement arithmetic — pitest's value is in the
+        # arithmetic, and no pitest plugin is wired for any of the 7. billing needs its own reason:
+        # its domain layer genuinely does not branch, but its real fee-waiver logic (ADR-0143 phase 2)
+        # lives in `application/usecase/FeeAssessmentService`, OUTSIDE pitest's `domain.*`
+        # targetClasses — so widening the target would be the fix there, not adding the module.
+        #
+        # Revisit if any of the 7 grows money-movement ARITHMETIC in its domain layer; a rising branch
+        # count alone is not the trigger, and re-measure before repeating any claim in this block.
+        # (Historical note: settlement and sanctions were both added to money_path_services after the
+        # 2026-07-07 note above; settlement re-confirmed thin, sanctions was the one that wasn't.)
         # True baselines at rollout (after fixing the KILLED-quote parsing bug): account 49%,
         # transaction 46%, balance 55%, ledger 65%, fx 73%.
         blocked_on: "blocking flip requires each service to sustain >=70% mutation kill score on the weekly run; account/transaction/balance/ledger are below it today (see baselines above)"

--- a/openbank-infra/gitops/components/interest-service/interest-service.yaml
+++ b/openbank-infra/gitops/components/interest-service/interest-service.yaml
@@ -16,7 +16,7 @@ spec:
       annotations:
         # Rolls the pods when the OPA bundle changes — subPath mounts do NOT hot-reload.
         # Kept in sync by gen-interest-opa-bundle.sh (do not hand-edit).
-        openbank.tech/policy-checksum: "eb25680a3a54e137"
+        openbank.tech/policy-checksum: "f47a5aa90f4d3369"
     spec:
       securityContext:
         runAsNonRoot: true

--- a/openbank-infra/gitops/components/interest-service/interest-service.yaml
+++ b/openbank-infra/gitops/components/interest-service/interest-service.yaml
@@ -16,7 +16,7 @@ spec:
       annotations:
         # Rolls the pods when the OPA bundle changes — subPath mounts do NOT hot-reload.
         # Kept in sync by gen-interest-opa-bundle.sh (do not hand-edit).
-        openbank.tech/policy-checksum: "f47a5aa90f4d3369"
+        openbank.tech/policy-checksum: "5145fe52020bc631"
     spec:
       securityContext:
         runAsNonRoot: true

--- a/openbank-infra/gitops/components/kyc/kyc-opa-bundle.yaml
+++ b/openbank-infra/gitops/components/kyc/kyc-opa-bundle.yaml
@@ -9,7 +9,7 @@ metadata:
     app.kubernetes.io/name: kyc-service
     app.kubernetes.io/part-of: kyc
   annotations:
-    openbank.tech/policy-checksum: "cb77e314d305cfab"
+    openbank.tech/policy-checksum: "9df4f9bfb3f60654"
 data:
   rest.rego: |
     # SPDX-License-Identifier: Apache-2.0
@@ -2254,12 +2254,36 @@ data:
         # fx + sepa-payment, sepa-instant, domestic-payment, fraud (SSDLC-audit rollout 2026-07-06) +
         # sanctions (2026-07-11: 3 domain files — screening/matching decision logic — matches the
         # "substantive domain math" criterion, not the thin-domain one; 67% local baseline).
-        # The remaining 7 (sca, consent, billing, clearing, swift, lending, settlement) stay excluded:
-        # each has only 1-2 domain files, and those files are plain data models (no branching
-        # money-movement logic), so mutation testing there is noise, not signal — re-confirmed by
-        # file count on 2026-07-11 (settlement and sanctions were both added to money_path_services
-        # after the 2026-07-07 note above; settlement re-confirmed thin, sanctions was the one that
-        # wasn't). Revisit if any of the remaining 7 grows real decision logic in its domain layer.
+        # The remaining 7 (sca, consent, billing, clearing, swift, lending, settlement) stay excluded.
+        #
+        # This list used to be justified by one blanket claim — "each has only 1-2 domain files, and
+        # those files are plain data models (no branching money-movement logic)". The file count was
+        # re-confirmed; the NO-BRANCHING half was never measured, and it is FALSE for three of the
+        # seven (#2395). Measured on 2026-07-26, counting `if (` / `when (` / `require(` / `check(`
+        # over every `src/main/kotlin/**/domain/**.kt` in each module — a deliberately narrow matcher,
+        # so these are lower bounds:
+        #
+        #     service     domain files   branch sites
+        #     sca                    2             11
+        #     consent                2              6
+        #     swift                  1              5
+        #     clearing               3              1
+        #     billing                2              0
+        #     lending                1              0
+        #     settlement             1              0
+        #
+        # So the exclusion rests on a DIFFERENT judgement, and it is stated here rather than hidden
+        # behind an inaccurate blanket: what sca, consent and swift branch on is input VALIDATION and
+        # state-transition legality, not money-movement arithmetic — pitest's value is in the
+        # arithmetic, and no pitest plugin is wired for any of the 7. billing needs its own reason:
+        # its domain layer genuinely does not branch, but its real fee-waiver logic (ADR-0143 phase 2)
+        # lives in `application/usecase/FeeAssessmentService`, OUTSIDE pitest's `domain.*`
+        # targetClasses — so widening the target would be the fix there, not adding the module.
+        #
+        # Revisit if any of the 7 grows money-movement ARITHMETIC in its domain layer; a rising branch
+        # count alone is not the trigger, and re-measure before repeating any claim in this block.
+        # (Historical note: settlement and sanctions were both added to money_path_services after the
+        # 2026-07-07 note above; settlement re-confirmed thin, sanctions was the one that wasn't.)
         # True baselines at rollout (after fixing the KILLED-quote parsing bug): account 49%,
         # transaction 46%, balance 55%, ledger 65%, fx 73%.
         blocked_on: "blocking flip requires each service to sustain >=70% mutation kill score on the weekly run; account/transaction/balance/ledger are below it today (see baselines above)"

--- a/openbank-infra/gitops/components/kyc/kyc-opa-bundle.yaml
+++ b/openbank-infra/gitops/components/kyc/kyc-opa-bundle.yaml
@@ -9,7 +9,7 @@ metadata:
     app.kubernetes.io/name: kyc-service
     app.kubernetes.io/part-of: kyc
   annotations:
-    openbank.tech/policy-checksum: "96acaf2d92b65484"
+    openbank.tech/policy-checksum: "cb77e314d305cfab"
 data:
   rest.rego: |
     # SPDX-License-Identifier: Apache-2.0
@@ -1560,9 +1560,9 @@ data:
           - "every route a resource class answers is published in that service's openapi.yaml"
           - "every route openapi.yaml promises is declared by a resource class"
         gate: openapi-route-conformance
-        enforced: advisory
-        target_enforce_date: "2026-09-30"
+        enforced: enforce                 # ADR-0144 graduation, ahead of the 2026-09-30 target (#2314)
         ci_producer: ".github/scripts/check-openapi-route-conformance.py"
+        baseline: ".github/openapi-route-conformance-baseline.txt"
         # api_contract (above) classifies a spec's version bump against the PREVIOUS REVISION of the
         # same document. Nothing asked whether the document is TRUE. ADR-0005 says "CI lints it with
         # Spectral so docs cannot drift from runtime" — there is no Spectral config in this repo and
@@ -1588,8 +1588,17 @@ data:
         # is a MISSING pair across two trees, so a PR touching only Kotlin never touches the spec and
         # a diff-scoped gate would see nothing.
         #
-        # Advisory because 114 pre-existing findings cannot be a merge blocker on day one. Flipping
-        # to enforced = add --enforce in ci.yml, once the backlog is cleared.
+        # ENFORCED AGAINST A DECLARED BASELINE (#2314). 104 pre-existing findings could not be a
+        # merge blocker on day one, and correcting a spec is blocked on the unsatisfiable-bump gap
+        # (#2313) — but leaving it advisory is the shape this repo has already ruled against: an
+        # advisory check over a GENERATED comparison has no judgement left to exercise, it just makes
+        # the drift mergeable (#2216). So the gate runs with --enforce against
+        # .github/openapi-route-conformance-baseline.txt, which declares those 104 findings verbatim.
+        # A finding NOT in that file fails the build (new drift, the thing the gate is for); a
+        # baseline line with no matching finding ALSO fails (the debt was paid — delete the line), so
+        # the declaration cannot outlive the debt. The baseline does not narrow what the gate LOOKS
+        # AT — every service is compared every run — which is what separates it from the
+        # pact-drift-check scope bug (#2284). #2314 closes when the file is empty.
       openapi_request_schema_conformance:
         detect: ["openbank-*/src/main/resources/openapi.yaml", "the JAX-RS request-body DTO the resource actually deserializes into"]
         require:

--- a/openbank-infra/gitops/components/kyc/kyc-service.yaml
+++ b/openbank-infra/gitops/components/kyc/kyc-service.yaml
@@ -48,7 +48,7 @@ spec:
       annotations:
         # Rolls the pod when the OPA bundle changes (subPath mounts do not hot-reload).
         # Kept in sync by gen-kyc-opa-bundle.sh (do not hand-edit).
-        openbank.tech/policy-checksum: "cb77e314d305cfab"
+        openbank.tech/policy-checksum: "9df4f9bfb3f60654"
     spec:
       securityContext:
         runAsNonRoot: true

--- a/openbank-infra/gitops/components/kyc/kyc-service.yaml
+++ b/openbank-infra/gitops/components/kyc/kyc-service.yaml
@@ -48,7 +48,7 @@ spec:
       annotations:
         # Rolls the pod when the OPA bundle changes (subPath mounts do not hot-reload).
         # Kept in sync by gen-kyc-opa-bundle.sh (do not hand-edit).
-        openbank.tech/policy-checksum: "96acaf2d92b65484"
+        openbank.tech/policy-checksum: "cb77e314d305cfab"
     spec:
       securityContext:
         runAsNonRoot: true

--- a/openbank-infra/gitops/components/ledger/ledger-opa-bundle.yaml
+++ b/openbank-infra/gitops/components/ledger/ledger-opa-bundle.yaml
@@ -9,7 +9,7 @@ metadata:
     app.kubernetes.io/name: ledger-service
     app.kubernetes.io/part-of: ledger
   annotations:
-    openbank.tech/policy-checksum: "c104f9483dfa03c7"
+    openbank.tech/policy-checksum: "67f03c0b37de64e5"
 data:
   rest.rego: |
     # SPDX-License-Identifier: Apache-2.0
@@ -2339,12 +2339,36 @@ data:
         # fx + sepa-payment, sepa-instant, domestic-payment, fraud (SSDLC-audit rollout 2026-07-06) +
         # sanctions (2026-07-11: 3 domain files — screening/matching decision logic — matches the
         # "substantive domain math" criterion, not the thin-domain one; 67% local baseline).
-        # The remaining 7 (sca, consent, billing, clearing, swift, lending, settlement) stay excluded:
-        # each has only 1-2 domain files, and those files are plain data models (no branching
-        # money-movement logic), so mutation testing there is noise, not signal — re-confirmed by
-        # file count on 2026-07-11 (settlement and sanctions were both added to money_path_services
-        # after the 2026-07-07 note above; settlement re-confirmed thin, sanctions was the one that
-        # wasn't). Revisit if any of the remaining 7 grows real decision logic in its domain layer.
+        # The remaining 7 (sca, consent, billing, clearing, swift, lending, settlement) stay excluded.
+        #
+        # This list used to be justified by one blanket claim — "each has only 1-2 domain files, and
+        # those files are plain data models (no branching money-movement logic)". The file count was
+        # re-confirmed; the NO-BRANCHING half was never measured, and it is FALSE for three of the
+        # seven (#2395). Measured on 2026-07-26, counting `if (` / `when (` / `require(` / `check(`
+        # over every `src/main/kotlin/**/domain/**.kt` in each module — a deliberately narrow matcher,
+        # so these are lower bounds:
+        #
+        #     service     domain files   branch sites
+        #     sca                    2             11
+        #     consent                2              6
+        #     swift                  1              5
+        #     clearing               3              1
+        #     billing                2              0
+        #     lending                1              0
+        #     settlement             1              0
+        #
+        # So the exclusion rests on a DIFFERENT judgement, and it is stated here rather than hidden
+        # behind an inaccurate blanket: what sca, consent and swift branch on is input VALIDATION and
+        # state-transition legality, not money-movement arithmetic — pitest's value is in the
+        # arithmetic, and no pitest plugin is wired for any of the 7. billing needs its own reason:
+        # its domain layer genuinely does not branch, but its real fee-waiver logic (ADR-0143 phase 2)
+        # lives in `application/usecase/FeeAssessmentService`, OUTSIDE pitest's `domain.*`
+        # targetClasses — so widening the target would be the fix there, not adding the module.
+        #
+        # Revisit if any of the 7 grows money-movement ARITHMETIC in its domain layer; a rising branch
+        # count alone is not the trigger, and re-measure before repeating any claim in this block.
+        # (Historical note: settlement and sanctions were both added to money_path_services after the
+        # 2026-07-07 note above; settlement re-confirmed thin, sanctions was the one that wasn't.)
         # True baselines at rollout (after fixing the KILLED-quote parsing bug): account 49%,
         # transaction 46%, balance 55%, ledger 65%, fx 73%.
         blocked_on: "blocking flip requires each service to sustain >=70% mutation kill score on the weekly run; account/transaction/balance/ledger are below it today (see baselines above)"

--- a/openbank-infra/gitops/components/ledger/ledger-opa-bundle.yaml
+++ b/openbank-infra/gitops/components/ledger/ledger-opa-bundle.yaml
@@ -9,7 +9,7 @@ metadata:
     app.kubernetes.io/name: ledger-service
     app.kubernetes.io/part-of: ledger
   annotations:
-    openbank.tech/policy-checksum: "5ff515f95eec7a0b"
+    openbank.tech/policy-checksum: "c104f9483dfa03c7"
 data:
   rest.rego: |
     # SPDX-License-Identifier: Apache-2.0
@@ -1645,9 +1645,9 @@ data:
           - "every route a resource class answers is published in that service's openapi.yaml"
           - "every route openapi.yaml promises is declared by a resource class"
         gate: openapi-route-conformance
-        enforced: advisory
-        target_enforce_date: "2026-09-30"
+        enforced: enforce                 # ADR-0144 graduation, ahead of the 2026-09-30 target (#2314)
         ci_producer: ".github/scripts/check-openapi-route-conformance.py"
+        baseline: ".github/openapi-route-conformance-baseline.txt"
         # api_contract (above) classifies a spec's version bump against the PREVIOUS REVISION of the
         # same document. Nothing asked whether the document is TRUE. ADR-0005 says "CI lints it with
         # Spectral so docs cannot drift from runtime" — there is no Spectral config in this repo and
@@ -1673,8 +1673,17 @@ data:
         # is a MISSING pair across two trees, so a PR touching only Kotlin never touches the spec and
         # a diff-scoped gate would see nothing.
         #
-        # Advisory because 114 pre-existing findings cannot be a merge blocker on day one. Flipping
-        # to enforced = add --enforce in ci.yml, once the backlog is cleared.
+        # ENFORCED AGAINST A DECLARED BASELINE (#2314). 104 pre-existing findings could not be a
+        # merge blocker on day one, and correcting a spec is blocked on the unsatisfiable-bump gap
+        # (#2313) — but leaving it advisory is the shape this repo has already ruled against: an
+        # advisory check over a GENERATED comparison has no judgement left to exercise, it just makes
+        # the drift mergeable (#2216). So the gate runs with --enforce against
+        # .github/openapi-route-conformance-baseline.txt, which declares those 104 findings verbatim.
+        # A finding NOT in that file fails the build (new drift, the thing the gate is for); a
+        # baseline line with no matching finding ALSO fails (the debt was paid — delete the line), so
+        # the declaration cannot outlive the debt. The baseline does not narrow what the gate LOOKS
+        # AT — every service is compared every run — which is what separates it from the
+        # pact-drift-check scope bug (#2284). #2314 closes when the file is empty.
       openapi_request_schema_conformance:
         detect: ["openbank-*/src/main/resources/openapi.yaml", "the JAX-RS request-body DTO the resource actually deserializes into"]
         require:

--- a/openbank-infra/gitops/components/ledger/ledger-service.yaml
+++ b/openbank-infra/gitops/components/ledger/ledger-service.yaml
@@ -38,7 +38,7 @@ spec:
       annotations:
         # Rolls the pods when the OPA bundle changes — subPath mounts do NOT hot-reload.
         # Kept in sync by gen-ledger-opa-bundle.sh (do not hand-edit).
-        openbank.tech/policy-checksum: "c104f9483dfa03c7"
+        openbank.tech/policy-checksum: "67f03c0b37de64e5"
     spec:
       securityContext:
         runAsNonRoot: true

--- a/openbank-infra/gitops/components/ledger/ledger-service.yaml
+++ b/openbank-infra/gitops/components/ledger/ledger-service.yaml
@@ -38,7 +38,7 @@ spec:
       annotations:
         # Rolls the pods when the OPA bundle changes — subPath mounts do NOT hot-reload.
         # Kept in sync by gen-ledger-opa-bundle.sh (do not hand-edit).
-        openbank.tech/policy-checksum: "5ff515f95eec7a0b"
+        openbank.tech/policy-checksum: "c104f9483dfa03c7"
     spec:
       securityContext:
         runAsNonRoot: true

--- a/openbank-infra/gitops/components/lending/lending-opa-bundle.yaml
+++ b/openbank-infra/gitops/components/lending/lending-opa-bundle.yaml
@@ -9,7 +9,7 @@ metadata:
     app.kubernetes.io/name: lending-service
     app.kubernetes.io/part-of: lending
   annotations:
-    openbank.tech/policy-checksum: "e187e5d37e547bb1"
+    openbank.tech/policy-checksum: "92cf3e4dcfb7a5d3"
 data:
   rest.rego: |
     # SPDX-License-Identifier: Apache-2.0
@@ -1600,9 +1600,9 @@ data:
           - "every route a resource class answers is published in that service's openapi.yaml"
           - "every route openapi.yaml promises is declared by a resource class"
         gate: openapi-route-conformance
-        enforced: advisory
-        target_enforce_date: "2026-09-30"
+        enforced: enforce                 # ADR-0144 graduation, ahead of the 2026-09-30 target (#2314)
         ci_producer: ".github/scripts/check-openapi-route-conformance.py"
+        baseline: ".github/openapi-route-conformance-baseline.txt"
         # api_contract (above) classifies a spec's version bump against the PREVIOUS REVISION of the
         # same document. Nothing asked whether the document is TRUE. ADR-0005 says "CI lints it with
         # Spectral so docs cannot drift from runtime" — there is no Spectral config in this repo and
@@ -1628,8 +1628,17 @@ data:
         # is a MISSING pair across two trees, so a PR touching only Kotlin never touches the spec and
         # a diff-scoped gate would see nothing.
         #
-        # Advisory because 114 pre-existing findings cannot be a merge blocker on day one. Flipping
-        # to enforced = add --enforce in ci.yml, once the backlog is cleared.
+        # ENFORCED AGAINST A DECLARED BASELINE (#2314). 104 pre-existing findings could not be a
+        # merge blocker on day one, and correcting a spec is blocked on the unsatisfiable-bump gap
+        # (#2313) — but leaving it advisory is the shape this repo has already ruled against: an
+        # advisory check over a GENERATED comparison has no judgement left to exercise, it just makes
+        # the drift mergeable (#2216). So the gate runs with --enforce against
+        # .github/openapi-route-conformance-baseline.txt, which declares those 104 findings verbatim.
+        # A finding NOT in that file fails the build (new drift, the thing the gate is for); a
+        # baseline line with no matching finding ALSO fails (the debt was paid — delete the line), so
+        # the declaration cannot outlive the debt. The baseline does not narrow what the gate LOOKS
+        # AT — every service is compared every run — which is what separates it from the
+        # pact-drift-check scope bug (#2284). #2314 closes when the file is empty.
       openapi_request_schema_conformance:
         detect: ["openbank-*/src/main/resources/openapi.yaml", "the JAX-RS request-body DTO the resource actually deserializes into"]
         require:

--- a/openbank-infra/gitops/components/lending/lending-opa-bundle.yaml
+++ b/openbank-infra/gitops/components/lending/lending-opa-bundle.yaml
@@ -9,7 +9,7 @@ metadata:
     app.kubernetes.io/name: lending-service
     app.kubernetes.io/part-of: lending
   annotations:
-    openbank.tech/policy-checksum: "92cf3e4dcfb7a5d3"
+    openbank.tech/policy-checksum: "326d6711ab47b971"
 data:
   rest.rego: |
     # SPDX-License-Identifier: Apache-2.0
@@ -2294,12 +2294,36 @@ data:
         # fx + sepa-payment, sepa-instant, domestic-payment, fraud (SSDLC-audit rollout 2026-07-06) +
         # sanctions (2026-07-11: 3 domain files — screening/matching decision logic — matches the
         # "substantive domain math" criterion, not the thin-domain one; 67% local baseline).
-        # The remaining 7 (sca, consent, billing, clearing, swift, lending, settlement) stay excluded:
-        # each has only 1-2 domain files, and those files are plain data models (no branching
-        # money-movement logic), so mutation testing there is noise, not signal — re-confirmed by
-        # file count on 2026-07-11 (settlement and sanctions were both added to money_path_services
-        # after the 2026-07-07 note above; settlement re-confirmed thin, sanctions was the one that
-        # wasn't). Revisit if any of the remaining 7 grows real decision logic in its domain layer.
+        # The remaining 7 (sca, consent, billing, clearing, swift, lending, settlement) stay excluded.
+        #
+        # This list used to be justified by one blanket claim — "each has only 1-2 domain files, and
+        # those files are plain data models (no branching money-movement logic)". The file count was
+        # re-confirmed; the NO-BRANCHING half was never measured, and it is FALSE for three of the
+        # seven (#2395). Measured on 2026-07-26, counting `if (` / `when (` / `require(` / `check(`
+        # over every `src/main/kotlin/**/domain/**.kt` in each module — a deliberately narrow matcher,
+        # so these are lower bounds:
+        #
+        #     service     domain files   branch sites
+        #     sca                    2             11
+        #     consent                2              6
+        #     swift                  1              5
+        #     clearing               3              1
+        #     billing                2              0
+        #     lending                1              0
+        #     settlement             1              0
+        #
+        # So the exclusion rests on a DIFFERENT judgement, and it is stated here rather than hidden
+        # behind an inaccurate blanket: what sca, consent and swift branch on is input VALIDATION and
+        # state-transition legality, not money-movement arithmetic — pitest's value is in the
+        # arithmetic, and no pitest plugin is wired for any of the 7. billing needs its own reason:
+        # its domain layer genuinely does not branch, but its real fee-waiver logic (ADR-0143 phase 2)
+        # lives in `application/usecase/FeeAssessmentService`, OUTSIDE pitest's `domain.*`
+        # targetClasses — so widening the target would be the fix there, not adding the module.
+        #
+        # Revisit if any of the 7 grows money-movement ARITHMETIC in its domain layer; a rising branch
+        # count alone is not the trigger, and re-measure before repeating any claim in this block.
+        # (Historical note: settlement and sanctions were both added to money_path_services after the
+        # 2026-07-07 note above; settlement re-confirmed thin, sanctions was the one that wasn't.)
         # True baselines at rollout (after fixing the KILLED-quote parsing bug): account 49%,
         # transaction 46%, balance 55%, ledger 65%, fx 73%.
         blocked_on: "blocking flip requires each service to sustain >=70% mutation kill score on the weekly run; account/transaction/balance/ledger are below it today (see baselines above)"

--- a/openbank-infra/gitops/components/lending/lending-service.yaml
+++ b/openbank-infra/gitops/components/lending/lending-service.yaml
@@ -34,7 +34,7 @@ spec:
       annotations:
         # Rolls the pods when the OPA bundle changes — subPath mounts do NOT hot-reload.
         # Kept in sync by gen-lending-opa-bundle.sh (do not hand-edit).
-        openbank.tech/policy-checksum: "92cf3e4dcfb7a5d3"
+        openbank.tech/policy-checksum: "326d6711ab47b971"
     spec:
       securityContext:
         runAsNonRoot: true

--- a/openbank-infra/gitops/components/lending/lending-service.yaml
+++ b/openbank-infra/gitops/components/lending/lending-service.yaml
@@ -34,7 +34,7 @@ spec:
       annotations:
         # Rolls the pods when the OPA bundle changes — subPath mounts do NOT hot-reload.
         # Kept in sync by gen-lending-opa-bundle.sh (do not hand-edit).
-        openbank.tech/policy-checksum: "e187e5d37e547bb1"
+        openbank.tech/policy-checksum: "92cf3e4dcfb7a5d3"
     spec:
       securityContext:
         runAsNonRoot: true

--- a/openbank-infra/gitops/components/mcp/mcp-opa-bundle.yaml
+++ b/openbank-infra/gitops/components/mcp/mcp-opa-bundle.yaml
@@ -9,7 +9,7 @@ metadata:
     app.kubernetes.io/name: mcp-service
     app.kubernetes.io/part-of: platform
   annotations:
-    openbank.tech/policy-checksum: "ed42feaabd3fac7a"
+    openbank.tech/policy-checksum: "2c2f017d31e98e3c"
 data:
   rest.rego: |
     # SPDX-License-Identifier: Apache-2.0
@@ -2192,12 +2192,36 @@ data:
         # fx + sepa-payment, sepa-instant, domestic-payment, fraud (SSDLC-audit rollout 2026-07-06) +
         # sanctions (2026-07-11: 3 domain files — screening/matching decision logic — matches the
         # "substantive domain math" criterion, not the thin-domain one; 67% local baseline).
-        # The remaining 7 (sca, consent, billing, clearing, swift, lending, settlement) stay excluded:
-        # each has only 1-2 domain files, and those files are plain data models (no branching
-        # money-movement logic), so mutation testing there is noise, not signal — re-confirmed by
-        # file count on 2026-07-11 (settlement and sanctions were both added to money_path_services
-        # after the 2026-07-07 note above; settlement re-confirmed thin, sanctions was the one that
-        # wasn't). Revisit if any of the remaining 7 grows real decision logic in its domain layer.
+        # The remaining 7 (sca, consent, billing, clearing, swift, lending, settlement) stay excluded.
+        #
+        # This list used to be justified by one blanket claim — "each has only 1-2 domain files, and
+        # those files are plain data models (no branching money-movement logic)". The file count was
+        # re-confirmed; the NO-BRANCHING half was never measured, and it is FALSE for three of the
+        # seven (#2395). Measured on 2026-07-26, counting `if (` / `when (` / `require(` / `check(`
+        # over every `src/main/kotlin/**/domain/**.kt` in each module — a deliberately narrow matcher,
+        # so these are lower bounds:
+        #
+        #     service     domain files   branch sites
+        #     sca                    2             11
+        #     consent                2              6
+        #     swift                  1              5
+        #     clearing               3              1
+        #     billing                2              0
+        #     lending                1              0
+        #     settlement             1              0
+        #
+        # So the exclusion rests on a DIFFERENT judgement, and it is stated here rather than hidden
+        # behind an inaccurate blanket: what sca, consent and swift branch on is input VALIDATION and
+        # state-transition legality, not money-movement arithmetic — pitest's value is in the
+        # arithmetic, and no pitest plugin is wired for any of the 7. billing needs its own reason:
+        # its domain layer genuinely does not branch, but its real fee-waiver logic (ADR-0143 phase 2)
+        # lives in `application/usecase/FeeAssessmentService`, OUTSIDE pitest's `domain.*`
+        # targetClasses — so widening the target would be the fix there, not adding the module.
+        #
+        # Revisit if any of the 7 grows money-movement ARITHMETIC in its domain layer; a rising branch
+        # count alone is not the trigger, and re-measure before repeating any claim in this block.
+        # (Historical note: settlement and sanctions were both added to money_path_services after the
+        # 2026-07-07 note above; settlement re-confirmed thin, sanctions was the one that wasn't.)
         # True baselines at rollout (after fixing the KILLED-quote parsing bug): account 49%,
         # transaction 46%, balance 55%, ledger 65%, fx 73%.
         blocked_on: "blocking flip requires each service to sustain >=70% mutation kill score on the weekly run; account/transaction/balance/ledger are below it today (see baselines above)"

--- a/openbank-infra/gitops/components/mcp/mcp-opa-bundle.yaml
+++ b/openbank-infra/gitops/components/mcp/mcp-opa-bundle.yaml
@@ -9,7 +9,7 @@ metadata:
     app.kubernetes.io/name: mcp-service
     app.kubernetes.io/part-of: platform
   annotations:
-    openbank.tech/policy-checksum: "a4190eed6dd3b779"
+    openbank.tech/policy-checksum: "ed42feaabd3fac7a"
 data:
   rest.rego: |
     # SPDX-License-Identifier: Apache-2.0
@@ -1498,9 +1498,9 @@ data:
           - "every route a resource class answers is published in that service's openapi.yaml"
           - "every route openapi.yaml promises is declared by a resource class"
         gate: openapi-route-conformance
-        enforced: advisory
-        target_enforce_date: "2026-09-30"
+        enforced: enforce                 # ADR-0144 graduation, ahead of the 2026-09-30 target (#2314)
         ci_producer: ".github/scripts/check-openapi-route-conformance.py"
+        baseline: ".github/openapi-route-conformance-baseline.txt"
         # api_contract (above) classifies a spec's version bump against the PREVIOUS REVISION of the
         # same document. Nothing asked whether the document is TRUE. ADR-0005 says "CI lints it with
         # Spectral so docs cannot drift from runtime" — there is no Spectral config in this repo and
@@ -1526,8 +1526,17 @@ data:
         # is a MISSING pair across two trees, so a PR touching only Kotlin never touches the spec and
         # a diff-scoped gate would see nothing.
         #
-        # Advisory because 114 pre-existing findings cannot be a merge blocker on day one. Flipping
-        # to enforced = add --enforce in ci.yml, once the backlog is cleared.
+        # ENFORCED AGAINST A DECLARED BASELINE (#2314). 104 pre-existing findings could not be a
+        # merge blocker on day one, and correcting a spec is blocked on the unsatisfiable-bump gap
+        # (#2313) — but leaving it advisory is the shape this repo has already ruled against: an
+        # advisory check over a GENERATED comparison has no judgement left to exercise, it just makes
+        # the drift mergeable (#2216). So the gate runs with --enforce against
+        # .github/openapi-route-conformance-baseline.txt, which declares those 104 findings verbatim.
+        # A finding NOT in that file fails the build (new drift, the thing the gate is for); a
+        # baseline line with no matching finding ALSO fails (the debt was paid — delete the line), so
+        # the declaration cannot outlive the debt. The baseline does not narrow what the gate LOOKS
+        # AT — every service is compared every run — which is what separates it from the
+        # pact-drift-check scope bug (#2284). #2314 closes when the file is empty.
       openapi_request_schema_conformance:
         detect: ["openbank-*/src/main/resources/openapi.yaml", "the JAX-RS request-body DTO the resource actually deserializes into"]
         require:

--- a/openbank-infra/gitops/components/mcp/mcp-service.yaml
+++ b/openbank-infra/gitops/components/mcp/mcp-service.yaml
@@ -29,7 +29,7 @@ spec:
       annotations:
         # Rolls the pod when the OPA bundle changes — subPath mounts do NOT hot-reload.
         # Kept in sync by gen-mcp-opa-bundle.sh (do not hand-edit).
-        openbank.tech/policy-checksum: "a4190eed6dd3b779"
+        openbank.tech/policy-checksum: "ed42feaabd3fac7a"
     spec:
       securityContext:
         runAsNonRoot: true

--- a/openbank-infra/gitops/components/mcp/mcp-service.yaml
+++ b/openbank-infra/gitops/components/mcp/mcp-service.yaml
@@ -29,7 +29,7 @@ spec:
       annotations:
         # Rolls the pod when the OPA bundle changes — subPath mounts do NOT hot-reload.
         # Kept in sync by gen-mcp-opa-bundle.sh (do not hand-edit).
-        openbank.tech/policy-checksum: "ed42feaabd3fac7a"
+        openbank.tech/policy-checksum: "2c2f017d31e98e3c"
     spec:
       securityContext:
         runAsNonRoot: true

--- a/openbank-infra/gitops/components/notifications/notification-service-opa-bundle.yaml
+++ b/openbank-infra/gitops/components/notifications/notification-service-opa-bundle.yaml
@@ -10,7 +10,7 @@ metadata:
     app.kubernetes.io/name: notification-service
     app.kubernetes.io/part-of: notifications
   annotations:
-    openbank.tech/policy-checksum: "c30ed48a4b8b2831"
+    openbank.tech/policy-checksum: "9b1c5823d258c9d9"
 data:
   rest.rego: |
     # SPDX-License-Identifier: Apache-2.0
@@ -721,9 +721,9 @@ data:
           - "every route a resource class answers is published in that service's openapi.yaml"
           - "every route openapi.yaml promises is declared by a resource class"
         gate: openapi-route-conformance
-        enforced: advisory
-        target_enforce_date: "2026-09-30"
+        enforced: enforce                 # ADR-0144 graduation, ahead of the 2026-09-30 target (#2314)
         ci_producer: ".github/scripts/check-openapi-route-conformance.py"
+        baseline: ".github/openapi-route-conformance-baseline.txt"
         # api_contract (above) classifies a spec's version bump against the PREVIOUS REVISION of the
         # same document. Nothing asked whether the document is TRUE. ADR-0005 says "CI lints it with
         # Spectral so docs cannot drift from runtime" — there is no Spectral config in this repo and
@@ -749,8 +749,17 @@ data:
         # is a MISSING pair across two trees, so a PR touching only Kotlin never touches the spec and
         # a diff-scoped gate would see nothing.
         #
-        # Advisory because 114 pre-existing findings cannot be a merge blocker on day one. Flipping
-        # to enforced = add --enforce in ci.yml, once the backlog is cleared.
+        # ENFORCED AGAINST A DECLARED BASELINE (#2314). 104 pre-existing findings could not be a
+        # merge blocker on day one, and correcting a spec is blocked on the unsatisfiable-bump gap
+        # (#2313) — but leaving it advisory is the shape this repo has already ruled against: an
+        # advisory check over a GENERATED comparison has no judgement left to exercise, it just makes
+        # the drift mergeable (#2216). So the gate runs with --enforce against
+        # .github/openapi-route-conformance-baseline.txt, which declares those 104 findings verbatim.
+        # A finding NOT in that file fails the build (new drift, the thing the gate is for); a
+        # baseline line with no matching finding ALSO fails (the debt was paid — delete the line), so
+        # the declaration cannot outlive the debt. The baseline does not narrow what the gate LOOKS
+        # AT — every service is compared every run — which is what separates it from the
+        # pact-drift-check scope bug (#2284). #2314 closes when the file is empty.
       openapi_request_schema_conformance:
         detect: ["openbank-*/src/main/resources/openapi.yaml", "the JAX-RS request-body DTO the resource actually deserializes into"]
         require:

--- a/openbank-infra/gitops/components/notifications/notification-service-opa-bundle.yaml
+++ b/openbank-infra/gitops/components/notifications/notification-service-opa-bundle.yaml
@@ -10,7 +10,7 @@ metadata:
     app.kubernetes.io/name: notification-service
     app.kubernetes.io/part-of: notifications
   annotations:
-    openbank.tech/policy-checksum: "9b1c5823d258c9d9"
+    openbank.tech/policy-checksum: "5370eab5af57bb71"
 data:
   rest.rego: |
     # SPDX-License-Identifier: Apache-2.0
@@ -1415,12 +1415,36 @@ data:
         # fx + sepa-payment, sepa-instant, domestic-payment, fraud (SSDLC-audit rollout 2026-07-06) +
         # sanctions (2026-07-11: 3 domain files — screening/matching decision logic — matches the
         # "substantive domain math" criterion, not the thin-domain one; 67% local baseline).
-        # The remaining 7 (sca, consent, billing, clearing, swift, lending, settlement) stay excluded:
-        # each has only 1-2 domain files, and those files are plain data models (no branching
-        # money-movement logic), so mutation testing there is noise, not signal — re-confirmed by
-        # file count on 2026-07-11 (settlement and sanctions were both added to money_path_services
-        # after the 2026-07-07 note above; settlement re-confirmed thin, sanctions was the one that
-        # wasn't). Revisit if any of the remaining 7 grows real decision logic in its domain layer.
+        # The remaining 7 (sca, consent, billing, clearing, swift, lending, settlement) stay excluded.
+        #
+        # This list used to be justified by one blanket claim — "each has only 1-2 domain files, and
+        # those files are plain data models (no branching money-movement logic)". The file count was
+        # re-confirmed; the NO-BRANCHING half was never measured, and it is FALSE for three of the
+        # seven (#2395). Measured on 2026-07-26, counting `if (` / `when (` / `require(` / `check(`
+        # over every `src/main/kotlin/**/domain/**.kt` in each module — a deliberately narrow matcher,
+        # so these are lower bounds:
+        #
+        #     service     domain files   branch sites
+        #     sca                    2             11
+        #     consent                2              6
+        #     swift                  1              5
+        #     clearing               3              1
+        #     billing                2              0
+        #     lending                1              0
+        #     settlement             1              0
+        #
+        # So the exclusion rests on a DIFFERENT judgement, and it is stated here rather than hidden
+        # behind an inaccurate blanket: what sca, consent and swift branch on is input VALIDATION and
+        # state-transition legality, not money-movement arithmetic — pitest's value is in the
+        # arithmetic, and no pitest plugin is wired for any of the 7. billing needs its own reason:
+        # its domain layer genuinely does not branch, but its real fee-waiver logic (ADR-0143 phase 2)
+        # lives in `application/usecase/FeeAssessmentService`, OUTSIDE pitest's `domain.*`
+        # targetClasses — so widening the target would be the fix there, not adding the module.
+        #
+        # Revisit if any of the 7 grows money-movement ARITHMETIC in its domain layer; a rising branch
+        # count alone is not the trigger, and re-measure before repeating any claim in this block.
+        # (Historical note: settlement and sanctions were both added to money_path_services after the
+        # 2026-07-07 note above; settlement re-confirmed thin, sanctions was the one that wasn't.)
         # True baselines at rollout (after fixing the KILLED-quote parsing bug): account 49%,
         # transaction 46%, balance 55%, ledger 65%, fx 73%.
         blocked_on: "blocking flip requires each service to sustain >=70% mutation kill score on the weekly run; account/transaction/balance/ledger are below it today (see baselines above)"

--- a/openbank-infra/gitops/components/notifications/notification-service.yaml
+++ b/openbank-infra/gitops/components/notifications/notification-service.yaml
@@ -39,7 +39,7 @@ spec:
       annotations:
         # Rolls the Deployment when the OPA policy bundle changes (subPath mounts don't
         # hot-reload). Kept in sync by gen-notification-opa-bundle.sh.
-        openbank.tech/policy-checksum: "9b1c5823d258c9d9"
+        openbank.tech/policy-checksum: "5370eab5af57bb71"
       labels:
         app.kubernetes.io/name: notification-service
         app.kubernetes.io/part-of: notifications

--- a/openbank-infra/gitops/components/notifications/notification-service.yaml
+++ b/openbank-infra/gitops/components/notifications/notification-service.yaml
@@ -39,7 +39,7 @@ spec:
       annotations:
         # Rolls the Deployment when the OPA policy bundle changes (subPath mounts don't
         # hot-reload). Kept in sync by gen-notification-opa-bundle.sh.
-        openbank.tech/policy-checksum: "c30ed48a4b8b2831"
+        openbank.tech/policy-checksum: "9b1c5823d258c9d9"
       labels:
         app.kubernetes.io/name: notification-service
         app.kubernetes.io/part-of: notifications

--- a/openbank-infra/gitops/components/party/party-opa-bundle.yaml
+++ b/openbank-infra/gitops/components/party/party-opa-bundle.yaml
@@ -9,7 +9,7 @@ metadata:
     app.kubernetes.io/name: party-service
     app.kubernetes.io/part-of: party
   annotations:
-    openbank.tech/policy-checksum: "24061622dd88c488"
+    openbank.tech/policy-checksum: "6f1789524f87cb5c"
 data:
   rest.rego: |
     # SPDX-License-Identifier: Apache-2.0
@@ -1569,9 +1569,9 @@ data:
           - "every route a resource class answers is published in that service's openapi.yaml"
           - "every route openapi.yaml promises is declared by a resource class"
         gate: openapi-route-conformance
-        enforced: advisory
-        target_enforce_date: "2026-09-30"
+        enforced: enforce                 # ADR-0144 graduation, ahead of the 2026-09-30 target (#2314)
         ci_producer: ".github/scripts/check-openapi-route-conformance.py"
+        baseline: ".github/openapi-route-conformance-baseline.txt"
         # api_contract (above) classifies a spec's version bump against the PREVIOUS REVISION of the
         # same document. Nothing asked whether the document is TRUE. ADR-0005 says "CI lints it with
         # Spectral so docs cannot drift from runtime" — there is no Spectral config in this repo and
@@ -1597,8 +1597,17 @@ data:
         # is a MISSING pair across two trees, so a PR touching only Kotlin never touches the spec and
         # a diff-scoped gate would see nothing.
         #
-        # Advisory because 114 pre-existing findings cannot be a merge blocker on day one. Flipping
-        # to enforced = add --enforce in ci.yml, once the backlog is cleared.
+        # ENFORCED AGAINST A DECLARED BASELINE (#2314). 104 pre-existing findings could not be a
+        # merge blocker on day one, and correcting a spec is blocked on the unsatisfiable-bump gap
+        # (#2313) — but leaving it advisory is the shape this repo has already ruled against: an
+        # advisory check over a GENERATED comparison has no judgement left to exercise, it just makes
+        # the drift mergeable (#2216). So the gate runs with --enforce against
+        # .github/openapi-route-conformance-baseline.txt, which declares those 104 findings verbatim.
+        # A finding NOT in that file fails the build (new drift, the thing the gate is for); a
+        # baseline line with no matching finding ALSO fails (the debt was paid — delete the line), so
+        # the declaration cannot outlive the debt. The baseline does not narrow what the gate LOOKS
+        # AT — every service is compared every run — which is what separates it from the
+        # pact-drift-check scope bug (#2284). #2314 closes when the file is empty.
       openapi_request_schema_conformance:
         detect: ["openbank-*/src/main/resources/openapi.yaml", "the JAX-RS request-body DTO the resource actually deserializes into"]
         require:

--- a/openbank-infra/gitops/components/party/party-opa-bundle.yaml
+++ b/openbank-infra/gitops/components/party/party-opa-bundle.yaml
@@ -9,7 +9,7 @@ metadata:
     app.kubernetes.io/name: party-service
     app.kubernetes.io/part-of: party
   annotations:
-    openbank.tech/policy-checksum: "6f1789524f87cb5c"
+    openbank.tech/policy-checksum: "50775cd525d959d3"
 data:
   rest.rego: |
     # SPDX-License-Identifier: Apache-2.0
@@ -2263,12 +2263,36 @@ data:
         # fx + sepa-payment, sepa-instant, domestic-payment, fraud (SSDLC-audit rollout 2026-07-06) +
         # sanctions (2026-07-11: 3 domain files — screening/matching decision logic — matches the
         # "substantive domain math" criterion, not the thin-domain one; 67% local baseline).
-        # The remaining 7 (sca, consent, billing, clearing, swift, lending, settlement) stay excluded:
-        # each has only 1-2 domain files, and those files are plain data models (no branching
-        # money-movement logic), so mutation testing there is noise, not signal — re-confirmed by
-        # file count on 2026-07-11 (settlement and sanctions were both added to money_path_services
-        # after the 2026-07-07 note above; settlement re-confirmed thin, sanctions was the one that
-        # wasn't). Revisit if any of the remaining 7 grows real decision logic in its domain layer.
+        # The remaining 7 (sca, consent, billing, clearing, swift, lending, settlement) stay excluded.
+        #
+        # This list used to be justified by one blanket claim — "each has only 1-2 domain files, and
+        # those files are plain data models (no branching money-movement logic)". The file count was
+        # re-confirmed; the NO-BRANCHING half was never measured, and it is FALSE for three of the
+        # seven (#2395). Measured on 2026-07-26, counting `if (` / `when (` / `require(` / `check(`
+        # over every `src/main/kotlin/**/domain/**.kt` in each module — a deliberately narrow matcher,
+        # so these are lower bounds:
+        #
+        #     service     domain files   branch sites
+        #     sca                    2             11
+        #     consent                2              6
+        #     swift                  1              5
+        #     clearing               3              1
+        #     billing                2              0
+        #     lending                1              0
+        #     settlement             1              0
+        #
+        # So the exclusion rests on a DIFFERENT judgement, and it is stated here rather than hidden
+        # behind an inaccurate blanket: what sca, consent and swift branch on is input VALIDATION and
+        # state-transition legality, not money-movement arithmetic — pitest's value is in the
+        # arithmetic, and no pitest plugin is wired for any of the 7. billing needs its own reason:
+        # its domain layer genuinely does not branch, but its real fee-waiver logic (ADR-0143 phase 2)
+        # lives in `application/usecase/FeeAssessmentService`, OUTSIDE pitest's `domain.*`
+        # targetClasses — so widening the target would be the fix there, not adding the module.
+        #
+        # Revisit if any of the 7 grows money-movement ARITHMETIC in its domain layer; a rising branch
+        # count alone is not the trigger, and re-measure before repeating any claim in this block.
+        # (Historical note: settlement and sanctions were both added to money_path_services after the
+        # 2026-07-07 note above; settlement re-confirmed thin, sanctions was the one that wasn't.)
         # True baselines at rollout (after fixing the KILLED-quote parsing bug): account 49%,
         # transaction 46%, balance 55%, ledger 65%, fx 73%.
         blocked_on: "blocking flip requires each service to sustain >=70% mutation kill score on the weekly run; account/transaction/balance/ledger are below it today (see baselines above)"

--- a/openbank-infra/gitops/components/party/party-service.yaml
+++ b/openbank-infra/gitops/components/party/party-service.yaml
@@ -22,7 +22,7 @@ spec:
       annotations:
         # Rolls the pod when the OPA bundle changes — subPath mounts do NOT hot-reload.
         # Kept in sync by gen-party-opa-bundle.sh (do not hand-edit).
-        openbank.tech/policy-checksum: "24061622dd88c488"
+        openbank.tech/policy-checksum: "6f1789524f87cb5c"
       labels:
         app.kubernetes.io/name: party-service
         app.kubernetes.io/part-of: party

--- a/openbank-infra/gitops/components/party/party-service.yaml
+++ b/openbank-infra/gitops/components/party/party-service.yaml
@@ -22,7 +22,7 @@ spec:
       annotations:
         # Rolls the pod when the OPA bundle changes — subPath mounts do NOT hot-reload.
         # Kept in sync by gen-party-opa-bundle.sh (do not hand-edit).
-        openbank.tech/policy-checksum: "6f1789524f87cb5c"
+        openbank.tech/policy-checksum: "50775cd525d959d3"
       labels:
         app.kubernetes.io/name: party-service
         app.kubernetes.io/part-of: party

--- a/openbank-infra/gitops/components/payments/card-issuance-opa-bundle.yaml
+++ b/openbank-infra/gitops/components/payments/card-issuance-opa-bundle.yaml
@@ -9,7 +9,7 @@ metadata:
     app.kubernetes.io/name: card-issuance-service
     app.kubernetes.io/part-of: payments
   annotations:
-    openbank.tech/policy-checksum: "29a44a535ee9e118"
+    openbank.tech/policy-checksum: "b6b93078b1e93703"
 data:
   rest.rego: |
     # SPDX-License-Identifier: Apache-2.0
@@ -1553,9 +1553,9 @@ data:
           - "every route a resource class answers is published in that service's openapi.yaml"
           - "every route openapi.yaml promises is declared by a resource class"
         gate: openapi-route-conformance
-        enforced: advisory
-        target_enforce_date: "2026-09-30"
+        enforced: enforce                 # ADR-0144 graduation, ahead of the 2026-09-30 target (#2314)
         ci_producer: ".github/scripts/check-openapi-route-conformance.py"
+        baseline: ".github/openapi-route-conformance-baseline.txt"
         # api_contract (above) classifies a spec's version bump against the PREVIOUS REVISION of the
         # same document. Nothing asked whether the document is TRUE. ADR-0005 says "CI lints it with
         # Spectral so docs cannot drift from runtime" — there is no Spectral config in this repo and
@@ -1581,8 +1581,17 @@ data:
         # is a MISSING pair across two trees, so a PR touching only Kotlin never touches the spec and
         # a diff-scoped gate would see nothing.
         #
-        # Advisory because 114 pre-existing findings cannot be a merge blocker on day one. Flipping
-        # to enforced = add --enforce in ci.yml, once the backlog is cleared.
+        # ENFORCED AGAINST A DECLARED BASELINE (#2314). 104 pre-existing findings could not be a
+        # merge blocker on day one, and correcting a spec is blocked on the unsatisfiable-bump gap
+        # (#2313) — but leaving it advisory is the shape this repo has already ruled against: an
+        # advisory check over a GENERATED comparison has no judgement left to exercise, it just makes
+        # the drift mergeable (#2216). So the gate runs with --enforce against
+        # .github/openapi-route-conformance-baseline.txt, which declares those 104 findings verbatim.
+        # A finding NOT in that file fails the build (new drift, the thing the gate is for); a
+        # baseline line with no matching finding ALSO fails (the debt was paid — delete the line), so
+        # the declaration cannot outlive the debt. The baseline does not narrow what the gate LOOKS
+        # AT — every service is compared every run — which is what separates it from the
+        # pact-drift-check scope bug (#2284). #2314 closes when the file is empty.
       openapi_request_schema_conformance:
         detect: ["openbank-*/src/main/resources/openapi.yaml", "the JAX-RS request-body DTO the resource actually deserializes into"]
         require:

--- a/openbank-infra/gitops/components/payments/card-issuance-opa-bundle.yaml
+++ b/openbank-infra/gitops/components/payments/card-issuance-opa-bundle.yaml
@@ -9,7 +9,7 @@ metadata:
     app.kubernetes.io/name: card-issuance-service
     app.kubernetes.io/part-of: payments
   annotations:
-    openbank.tech/policy-checksum: "b6b93078b1e93703"
+    openbank.tech/policy-checksum: "965e3c96faa63c57"
 data:
   rest.rego: |
     # SPDX-License-Identifier: Apache-2.0
@@ -2247,12 +2247,36 @@ data:
         # fx + sepa-payment, sepa-instant, domestic-payment, fraud (SSDLC-audit rollout 2026-07-06) +
         # sanctions (2026-07-11: 3 domain files — screening/matching decision logic — matches the
         # "substantive domain math" criterion, not the thin-domain one; 67% local baseline).
-        # The remaining 7 (sca, consent, billing, clearing, swift, lending, settlement) stay excluded:
-        # each has only 1-2 domain files, and those files are plain data models (no branching
-        # money-movement logic), so mutation testing there is noise, not signal — re-confirmed by
-        # file count on 2026-07-11 (settlement and sanctions were both added to money_path_services
-        # after the 2026-07-07 note above; settlement re-confirmed thin, sanctions was the one that
-        # wasn't). Revisit if any of the remaining 7 grows real decision logic in its domain layer.
+        # The remaining 7 (sca, consent, billing, clearing, swift, lending, settlement) stay excluded.
+        #
+        # This list used to be justified by one blanket claim — "each has only 1-2 domain files, and
+        # those files are plain data models (no branching money-movement logic)". The file count was
+        # re-confirmed; the NO-BRANCHING half was never measured, and it is FALSE for three of the
+        # seven (#2395). Measured on 2026-07-26, counting `if (` / `when (` / `require(` / `check(`
+        # over every `src/main/kotlin/**/domain/**.kt` in each module — a deliberately narrow matcher,
+        # so these are lower bounds:
+        #
+        #     service     domain files   branch sites
+        #     sca                    2             11
+        #     consent                2              6
+        #     swift                  1              5
+        #     clearing               3              1
+        #     billing                2              0
+        #     lending                1              0
+        #     settlement             1              0
+        #
+        # So the exclusion rests on a DIFFERENT judgement, and it is stated here rather than hidden
+        # behind an inaccurate blanket: what sca, consent and swift branch on is input VALIDATION and
+        # state-transition legality, not money-movement arithmetic — pitest's value is in the
+        # arithmetic, and no pitest plugin is wired for any of the 7. billing needs its own reason:
+        # its domain layer genuinely does not branch, but its real fee-waiver logic (ADR-0143 phase 2)
+        # lives in `application/usecase/FeeAssessmentService`, OUTSIDE pitest's `domain.*`
+        # targetClasses — so widening the target would be the fix there, not adding the module.
+        #
+        # Revisit if any of the 7 grows money-movement ARITHMETIC in its domain layer; a rising branch
+        # count alone is not the trigger, and re-measure before repeating any claim in this block.
+        # (Historical note: settlement and sanctions were both added to money_path_services after the
+        # 2026-07-07 note above; settlement re-confirmed thin, sanctions was the one that wasn't.)
         # True baselines at rollout (after fixing the KILLED-quote parsing bug): account 49%,
         # transaction 46%, balance 55%, ledger 65%, fx 73%.
         blocked_on: "blocking flip requires each service to sustain >=70% mutation kill score on the weekly run; account/transaction/balance/ledger are below it today (see baselines above)"

--- a/openbank-infra/gitops/components/payments/clearing-opa-bundle.yaml
+++ b/openbank-infra/gitops/components/payments/clearing-opa-bundle.yaml
@@ -9,7 +9,7 @@ metadata:
     app.kubernetes.io/name: clearing-service
     app.kubernetes.io/part-of: payments
   annotations:
-    openbank.tech/policy-checksum: "5a2d83fcbbd768a2"
+    openbank.tech/policy-checksum: "3fdc20ffca424152"
 data:
   rest.rego: |
     # SPDX-License-Identifier: Apache-2.0
@@ -2284,12 +2284,36 @@ data:
         # fx + sepa-payment, sepa-instant, domestic-payment, fraud (SSDLC-audit rollout 2026-07-06) +
         # sanctions (2026-07-11: 3 domain files — screening/matching decision logic — matches the
         # "substantive domain math" criterion, not the thin-domain one; 67% local baseline).
-        # The remaining 7 (sca, consent, billing, clearing, swift, lending, settlement) stay excluded:
-        # each has only 1-2 domain files, and those files are plain data models (no branching
-        # money-movement logic), so mutation testing there is noise, not signal — re-confirmed by
-        # file count on 2026-07-11 (settlement and sanctions were both added to money_path_services
-        # after the 2026-07-07 note above; settlement re-confirmed thin, sanctions was the one that
-        # wasn't). Revisit if any of the remaining 7 grows real decision logic in its domain layer.
+        # The remaining 7 (sca, consent, billing, clearing, swift, lending, settlement) stay excluded.
+        #
+        # This list used to be justified by one blanket claim — "each has only 1-2 domain files, and
+        # those files are plain data models (no branching money-movement logic)". The file count was
+        # re-confirmed; the NO-BRANCHING half was never measured, and it is FALSE for three of the
+        # seven (#2395). Measured on 2026-07-26, counting `if (` / `when (` / `require(` / `check(`
+        # over every `src/main/kotlin/**/domain/**.kt` in each module — a deliberately narrow matcher,
+        # so these are lower bounds:
+        #
+        #     service     domain files   branch sites
+        #     sca                    2             11
+        #     consent                2              6
+        #     swift                  1              5
+        #     clearing               3              1
+        #     billing                2              0
+        #     lending                1              0
+        #     settlement             1              0
+        #
+        # So the exclusion rests on a DIFFERENT judgement, and it is stated here rather than hidden
+        # behind an inaccurate blanket: what sca, consent and swift branch on is input VALIDATION and
+        # state-transition legality, not money-movement arithmetic — pitest's value is in the
+        # arithmetic, and no pitest plugin is wired for any of the 7. billing needs its own reason:
+        # its domain layer genuinely does not branch, but its real fee-waiver logic (ADR-0143 phase 2)
+        # lives in `application/usecase/FeeAssessmentService`, OUTSIDE pitest's `domain.*`
+        # targetClasses — so widening the target would be the fix there, not adding the module.
+        #
+        # Revisit if any of the 7 grows money-movement ARITHMETIC in its domain layer; a rising branch
+        # count alone is not the trigger, and re-measure before repeating any claim in this block.
+        # (Historical note: settlement and sanctions were both added to money_path_services after the
+        # 2026-07-07 note above; settlement re-confirmed thin, sanctions was the one that wasn't.)
         # True baselines at rollout (after fixing the KILLED-quote parsing bug): account 49%,
         # transaction 46%, balance 55%, ledger 65%, fx 73%.
         blocked_on: "blocking flip requires each service to sustain >=70% mutation kill score on the weekly run; account/transaction/balance/ledger are below it today (see baselines above)"

--- a/openbank-infra/gitops/components/payments/clearing-opa-bundle.yaml
+++ b/openbank-infra/gitops/components/payments/clearing-opa-bundle.yaml
@@ -9,7 +9,7 @@ metadata:
     app.kubernetes.io/name: clearing-service
     app.kubernetes.io/part-of: payments
   annotations:
-    openbank.tech/policy-checksum: "e50b2409c7868501"
+    openbank.tech/policy-checksum: "5a2d83fcbbd768a2"
 data:
   rest.rego: |
     # SPDX-License-Identifier: Apache-2.0
@@ -1590,9 +1590,9 @@ data:
           - "every route a resource class answers is published in that service's openapi.yaml"
           - "every route openapi.yaml promises is declared by a resource class"
         gate: openapi-route-conformance
-        enforced: advisory
-        target_enforce_date: "2026-09-30"
+        enforced: enforce                 # ADR-0144 graduation, ahead of the 2026-09-30 target (#2314)
         ci_producer: ".github/scripts/check-openapi-route-conformance.py"
+        baseline: ".github/openapi-route-conformance-baseline.txt"
         # api_contract (above) classifies a spec's version bump against the PREVIOUS REVISION of the
         # same document. Nothing asked whether the document is TRUE. ADR-0005 says "CI lints it with
         # Spectral so docs cannot drift from runtime" — there is no Spectral config in this repo and
@@ -1618,8 +1618,17 @@ data:
         # is a MISSING pair across two trees, so a PR touching only Kotlin never touches the spec and
         # a diff-scoped gate would see nothing.
         #
-        # Advisory because 114 pre-existing findings cannot be a merge blocker on day one. Flipping
-        # to enforced = add --enforce in ci.yml, once the backlog is cleared.
+        # ENFORCED AGAINST A DECLARED BASELINE (#2314). 104 pre-existing findings could not be a
+        # merge blocker on day one, and correcting a spec is blocked on the unsatisfiable-bump gap
+        # (#2313) — but leaving it advisory is the shape this repo has already ruled against: an
+        # advisory check over a GENERATED comparison has no judgement left to exercise, it just makes
+        # the drift mergeable (#2216). So the gate runs with --enforce against
+        # .github/openapi-route-conformance-baseline.txt, which declares those 104 findings verbatim.
+        # A finding NOT in that file fails the build (new drift, the thing the gate is for); a
+        # baseline line with no matching finding ALSO fails (the debt was paid — delete the line), so
+        # the declaration cannot outlive the debt. The baseline does not narrow what the gate LOOKS
+        # AT — every service is compared every run — which is what separates it from the
+        # pact-drift-check scope bug (#2284). #2314 closes when the file is empty.
       openapi_request_schema_conformance:
         detect: ["openbank-*/src/main/resources/openapi.yaml", "the JAX-RS request-body DTO the resource actually deserializes into"]
         require:

--- a/openbank-infra/gitops/components/payments/domestic-payment-opa-bundle.yaml
+++ b/openbank-infra/gitops/components/payments/domestic-payment-opa-bundle.yaml
@@ -9,7 +9,7 @@ metadata:
     app.kubernetes.io/name: domestic-payment
     app.kubernetes.io/part-of: payments
   annotations:
-    openbank.tech/policy-checksum: "d1e8dea12f5b5ef9"
+    openbank.tech/policy-checksum: "6b5b674af135d7d6"
 data:
   rest.rego: |
     # SPDX-License-Identifier: Apache-2.0
@@ -2269,12 +2269,36 @@ data:
         # fx + sepa-payment, sepa-instant, domestic-payment, fraud (SSDLC-audit rollout 2026-07-06) +
         # sanctions (2026-07-11: 3 domain files — screening/matching decision logic — matches the
         # "substantive domain math" criterion, not the thin-domain one; 67% local baseline).
-        # The remaining 7 (sca, consent, billing, clearing, swift, lending, settlement) stay excluded:
-        # each has only 1-2 domain files, and those files are plain data models (no branching
-        # money-movement logic), so mutation testing there is noise, not signal — re-confirmed by
-        # file count on 2026-07-11 (settlement and sanctions were both added to money_path_services
-        # after the 2026-07-07 note above; settlement re-confirmed thin, sanctions was the one that
-        # wasn't). Revisit if any of the remaining 7 grows real decision logic in its domain layer.
+        # The remaining 7 (sca, consent, billing, clearing, swift, lending, settlement) stay excluded.
+        #
+        # This list used to be justified by one blanket claim — "each has only 1-2 domain files, and
+        # those files are plain data models (no branching money-movement logic)". The file count was
+        # re-confirmed; the NO-BRANCHING half was never measured, and it is FALSE for three of the
+        # seven (#2395). Measured on 2026-07-26, counting `if (` / `when (` / `require(` / `check(`
+        # over every `src/main/kotlin/**/domain/**.kt` in each module — a deliberately narrow matcher,
+        # so these are lower bounds:
+        #
+        #     service     domain files   branch sites
+        #     sca                    2             11
+        #     consent                2              6
+        #     swift                  1              5
+        #     clearing               3              1
+        #     billing                2              0
+        #     lending                1              0
+        #     settlement             1              0
+        #
+        # So the exclusion rests on a DIFFERENT judgement, and it is stated here rather than hidden
+        # behind an inaccurate blanket: what sca, consent and swift branch on is input VALIDATION and
+        # state-transition legality, not money-movement arithmetic — pitest's value is in the
+        # arithmetic, and no pitest plugin is wired for any of the 7. billing needs its own reason:
+        # its domain layer genuinely does not branch, but its real fee-waiver logic (ADR-0143 phase 2)
+        # lives in `application/usecase/FeeAssessmentService`, OUTSIDE pitest's `domain.*`
+        # targetClasses — so widening the target would be the fix there, not adding the module.
+        #
+        # Revisit if any of the 7 grows money-movement ARITHMETIC in its domain layer; a rising branch
+        # count alone is not the trigger, and re-measure before repeating any claim in this block.
+        # (Historical note: settlement and sanctions were both added to money_path_services after the
+        # 2026-07-07 note above; settlement re-confirmed thin, sanctions was the one that wasn't.)
         # True baselines at rollout (after fixing the KILLED-quote parsing bug): account 49%,
         # transaction 46%, balance 55%, ledger 65%, fx 73%.
         blocked_on: "blocking flip requires each service to sustain >=70% mutation kill score on the weekly run; account/transaction/balance/ledger are below it today (see baselines above)"

--- a/openbank-infra/gitops/components/payments/domestic-payment-opa-bundle.yaml
+++ b/openbank-infra/gitops/components/payments/domestic-payment-opa-bundle.yaml
@@ -9,7 +9,7 @@ metadata:
     app.kubernetes.io/name: domestic-payment
     app.kubernetes.io/part-of: payments
   annotations:
-    openbank.tech/policy-checksum: "f86ee5595fb4af21"
+    openbank.tech/policy-checksum: "d1e8dea12f5b5ef9"
 data:
   rest.rego: |
     # SPDX-License-Identifier: Apache-2.0
@@ -1575,9 +1575,9 @@ data:
           - "every route a resource class answers is published in that service's openapi.yaml"
           - "every route openapi.yaml promises is declared by a resource class"
         gate: openapi-route-conformance
-        enforced: advisory
-        target_enforce_date: "2026-09-30"
+        enforced: enforce                 # ADR-0144 graduation, ahead of the 2026-09-30 target (#2314)
         ci_producer: ".github/scripts/check-openapi-route-conformance.py"
+        baseline: ".github/openapi-route-conformance-baseline.txt"
         # api_contract (above) classifies a spec's version bump against the PREVIOUS REVISION of the
         # same document. Nothing asked whether the document is TRUE. ADR-0005 says "CI lints it with
         # Spectral so docs cannot drift from runtime" — there is no Spectral config in this repo and
@@ -1603,8 +1603,17 @@ data:
         # is a MISSING pair across two trees, so a PR touching only Kotlin never touches the spec and
         # a diff-scoped gate would see nothing.
         #
-        # Advisory because 114 pre-existing findings cannot be a merge blocker on day one. Flipping
-        # to enforced = add --enforce in ci.yml, once the backlog is cleared.
+        # ENFORCED AGAINST A DECLARED BASELINE (#2314). 104 pre-existing findings could not be a
+        # merge blocker on day one, and correcting a spec is blocked on the unsatisfiable-bump gap
+        # (#2313) — but leaving it advisory is the shape this repo has already ruled against: an
+        # advisory check over a GENERATED comparison has no judgement left to exercise, it just makes
+        # the drift mergeable (#2216). So the gate runs with --enforce against
+        # .github/openapi-route-conformance-baseline.txt, which declares those 104 findings verbatim.
+        # A finding NOT in that file fails the build (new drift, the thing the gate is for); a
+        # baseline line with no matching finding ALSO fails (the debt was paid — delete the line), so
+        # the declaration cannot outlive the debt. The baseline does not narrow what the gate LOOKS
+        # AT — every service is compared every run — which is what separates it from the
+        # pact-drift-check scope bug (#2284). #2314 closes when the file is empty.
       openapi_request_schema_conformance:
         detect: ["openbank-*/src/main/resources/openapi.yaml", "the JAX-RS request-body DTO the resource actually deserializes into"]
         require:

--- a/openbank-infra/gitops/components/payments/payments-services.yaml
+++ b/openbank-infra/gitops/components/payments/payments-services.yaml
@@ -42,7 +42,7 @@ spec:
         # Rolls the pods when the OPA bundle changes — subPath mounts do NOT hot-reload.
         # Kept in sync by gen-transaction-opa-bundle.sh via the trailing marker comment
         # (do not hand-edit, do not drop the marker).
-        openbank.tech/policy-checksum: "abb92bc7665154d9" # transaction-opa-bundle
+        openbank.tech/policy-checksum: "f881bb1f3833df31" # transaction-opa-bundle
     spec:
       securityContext:
         runAsNonRoot: true
@@ -375,7 +375,7 @@ spec:
       annotations:
         # Rolls the pods when the OPA bundle changes — subPath mounts do NOT hot-reload.
         # Kept in sync by gen-sepa-payment-opa-bundle.sh (do not hand-edit).
-        openbank.tech/policy-checksum: "3216cf5c741f34a6"
+        openbank.tech/policy-checksum: "59a4ed6d83ead5a6"
     spec:
       securityContext:
         runAsNonRoot: true
@@ -729,7 +729,7 @@ spec:
         # Rolls the pods when the OPA bundle changes — subPath mounts do NOT hot-reload.
         # Kept in sync by gen-domestic-payment-opa-bundle.sh via the trailing marker
         # comment (do not hand-edit, do not drop the marker).
-        openbank.tech/policy-checksum: "d1e8dea12f5b5ef9" # domestic-payment-opa-bundle
+        openbank.tech/policy-checksum: "6b5b674af135d7d6" # domestic-payment-opa-bundle
     spec:
       securityContext:
         runAsNonRoot: true
@@ -1053,7 +1053,7 @@ spec:
       annotations:
         # Rolls the pods when the OPA bundle changes — subPath mounts do NOT hot-reload.
         # Kept in sync by gen-sepa-instant-opa-bundle.sh (do not hand-edit).
-        openbank.tech/policy-checksum: "ce182ff135871ad0"
+        openbank.tech/policy-checksum: "d2589f8c417ec426"
     spec:
       securityContext:
         runAsNonRoot: true
@@ -1369,7 +1369,7 @@ spec:
         # Rolls the pods when the OPA bundle changes — subPath mounts do NOT hot-reload.
         # Kept in sync by gen-clearing-opa-bundle.sh via the trailing marker comment
         # (do not hand-edit, do not drop the marker).
-        openbank.tech/policy-checksum: "5a2d83fcbbd768a2" # clearing-opa-bundle
+        openbank.tech/policy-checksum: "3fdc20ffca424152" # clearing-opa-bundle
     spec:
       securityContext:
         runAsNonRoot: true
@@ -1658,7 +1658,7 @@ spec:
       annotations:
         # Rolls the pod when the OPA bundle changes (ADR-0034). Value is stamped by
         # gen-standing-order-opa-bundle.sh — do not hand-edit.
-        openbank.tech/policy-checksum: "a86bb9a75f728d6b" # standing-order-opa-bundle
+        openbank.tech/policy-checksum: "156ca771dd3aa0a0" # standing-order-opa-bundle
     spec:
       securityContext:
         runAsNonRoot: true
@@ -1911,7 +1911,7 @@ spec:
       annotations:
         # Rolls the pods when the OPA bundle changes — subPath mounts do NOT hot-reload.
         # Kept in sync by gen-card-issuance-opa-bundle.sh (do not hand-edit).
-        openbank.tech/policy-checksum: "b6b93078b1e93703"
+        openbank.tech/policy-checksum: "965e3c96faa63c57"
     spec:
       securityContext:
         runAsNonRoot: true
@@ -2178,7 +2178,7 @@ spec:
         # Rolls the pods when the OPA bundle changes — subPath mounts do NOT hot-reload.
         # Kept in sync by gen-settlement-opa-bundle.sh via the trailing marker comment
         # (do not hand-edit, do not drop the marker).
-        openbank.tech/policy-checksum: "e031d21c8afa6a7d" # settlement-opa-bundle
+        openbank.tech/policy-checksum: "84be04106d7e1817" # settlement-opa-bundle
     spec:
       securityContext:
         runAsNonRoot: true
@@ -2579,7 +2579,7 @@ spec:
       annotations:
         # Rolls the pods when the OPA bundle changes — subPath mounts do NOT hot-reload.
         # Kept in sync by gen-swift-opa-bundle.sh (do not hand-edit).
-        openbank.tech/policy-checksum: "c0e200d7c7d6aa86"
+        openbank.tech/policy-checksum: "314f09ec705d2363"
     spec:
       securityContext:
         runAsNonRoot: true
@@ -2893,7 +2893,7 @@ spec:
       annotations:
         # Rolls the pods when the OPA bundle changes — subPath mounts do NOT hot-reload.
         # Kept in sync by gen-vop-opa-bundle.sh (do not hand-edit).
-        openbank.tech/policy-checksum: "d84a5ad1e82faf4d"
+        openbank.tech/policy-checksum: "2d588b32c3fc5a4b"
     spec:
       securityContext:
         runAsNonRoot: true

--- a/openbank-infra/gitops/components/payments/payments-services.yaml
+++ b/openbank-infra/gitops/components/payments/payments-services.yaml
@@ -42,7 +42,7 @@ spec:
         # Rolls the pods when the OPA bundle changes — subPath mounts do NOT hot-reload.
         # Kept in sync by gen-transaction-opa-bundle.sh via the trailing marker comment
         # (do not hand-edit, do not drop the marker).
-        openbank.tech/policy-checksum: "554dfd7e418e7b2c" # transaction-opa-bundle
+        openbank.tech/policy-checksum: "abb92bc7665154d9" # transaction-opa-bundle
     spec:
       securityContext:
         runAsNonRoot: true
@@ -375,7 +375,7 @@ spec:
       annotations:
         # Rolls the pods when the OPA bundle changes — subPath mounts do NOT hot-reload.
         # Kept in sync by gen-sepa-payment-opa-bundle.sh (do not hand-edit).
-        openbank.tech/policy-checksum: "378e754f4796cf5c"
+        openbank.tech/policy-checksum: "3216cf5c741f34a6"
     spec:
       securityContext:
         runAsNonRoot: true
@@ -729,7 +729,7 @@ spec:
         # Rolls the pods when the OPA bundle changes — subPath mounts do NOT hot-reload.
         # Kept in sync by gen-domestic-payment-opa-bundle.sh via the trailing marker
         # comment (do not hand-edit, do not drop the marker).
-        openbank.tech/policy-checksum: "f86ee5595fb4af21" # domestic-payment-opa-bundle
+        openbank.tech/policy-checksum: "d1e8dea12f5b5ef9" # domestic-payment-opa-bundle
     spec:
       securityContext:
         runAsNonRoot: true
@@ -1053,7 +1053,7 @@ spec:
       annotations:
         # Rolls the pods when the OPA bundle changes — subPath mounts do NOT hot-reload.
         # Kept in sync by gen-sepa-instant-opa-bundle.sh (do not hand-edit).
-        openbank.tech/policy-checksum: "8ea6424c9da913d9"
+        openbank.tech/policy-checksum: "ce182ff135871ad0"
     spec:
       securityContext:
         runAsNonRoot: true
@@ -1369,7 +1369,7 @@ spec:
         # Rolls the pods when the OPA bundle changes — subPath mounts do NOT hot-reload.
         # Kept in sync by gen-clearing-opa-bundle.sh via the trailing marker comment
         # (do not hand-edit, do not drop the marker).
-        openbank.tech/policy-checksum: "e50b2409c7868501" # clearing-opa-bundle
+        openbank.tech/policy-checksum: "5a2d83fcbbd768a2" # clearing-opa-bundle
     spec:
       securityContext:
         runAsNonRoot: true
@@ -1658,7 +1658,7 @@ spec:
       annotations:
         # Rolls the pod when the OPA bundle changes (ADR-0034). Value is stamped by
         # gen-standing-order-opa-bundle.sh — do not hand-edit.
-        openbank.tech/policy-checksum: "2d5c88a185d1733f" # standing-order-opa-bundle
+        openbank.tech/policy-checksum: "a86bb9a75f728d6b" # standing-order-opa-bundle
     spec:
       securityContext:
         runAsNonRoot: true
@@ -1911,7 +1911,7 @@ spec:
       annotations:
         # Rolls the pods when the OPA bundle changes — subPath mounts do NOT hot-reload.
         # Kept in sync by gen-card-issuance-opa-bundle.sh (do not hand-edit).
-        openbank.tech/policy-checksum: "29a44a535ee9e118"
+        openbank.tech/policy-checksum: "b6b93078b1e93703"
     spec:
       securityContext:
         runAsNonRoot: true
@@ -2178,7 +2178,7 @@ spec:
         # Rolls the pods when the OPA bundle changes — subPath mounts do NOT hot-reload.
         # Kept in sync by gen-settlement-opa-bundle.sh via the trailing marker comment
         # (do not hand-edit, do not drop the marker).
-        openbank.tech/policy-checksum: "0529d2c36d591611" # settlement-opa-bundle
+        openbank.tech/policy-checksum: "e031d21c8afa6a7d" # settlement-opa-bundle
     spec:
       securityContext:
         runAsNonRoot: true
@@ -2579,7 +2579,7 @@ spec:
       annotations:
         # Rolls the pods when the OPA bundle changes — subPath mounts do NOT hot-reload.
         # Kept in sync by gen-swift-opa-bundle.sh (do not hand-edit).
-        openbank.tech/policy-checksum: "ea1bc63d4f34e5aa"
+        openbank.tech/policy-checksum: "c0e200d7c7d6aa86"
     spec:
       securityContext:
         runAsNonRoot: true
@@ -2893,7 +2893,7 @@ spec:
       annotations:
         # Rolls the pods when the OPA bundle changes — subPath mounts do NOT hot-reload.
         # Kept in sync by gen-vop-opa-bundle.sh (do not hand-edit).
-        openbank.tech/policy-checksum: "06c74fbe07dd77f8"
+        openbank.tech/policy-checksum: "d84a5ad1e82faf4d"
     spec:
       securityContext:
         runAsNonRoot: true

--- a/openbank-infra/gitops/components/payments/sepa-instant-opa-bundle.yaml
+++ b/openbank-infra/gitops/components/payments/sepa-instant-opa-bundle.yaml
@@ -9,7 +9,7 @@ metadata:
     app.kubernetes.io/name: sepa-instant
     app.kubernetes.io/part-of: payments
   annotations:
-    openbank.tech/policy-checksum: "8ea6424c9da913d9"
+    openbank.tech/policy-checksum: "ce182ff135871ad0"
 data:
   rest.rego: |
     # SPDX-License-Identifier: Apache-2.0
@@ -1548,9 +1548,9 @@ data:
           - "every route a resource class answers is published in that service's openapi.yaml"
           - "every route openapi.yaml promises is declared by a resource class"
         gate: openapi-route-conformance
-        enforced: advisory
-        target_enforce_date: "2026-09-30"
+        enforced: enforce                 # ADR-0144 graduation, ahead of the 2026-09-30 target (#2314)
         ci_producer: ".github/scripts/check-openapi-route-conformance.py"
+        baseline: ".github/openapi-route-conformance-baseline.txt"
         # api_contract (above) classifies a spec's version bump against the PREVIOUS REVISION of the
         # same document. Nothing asked whether the document is TRUE. ADR-0005 says "CI lints it with
         # Spectral so docs cannot drift from runtime" — there is no Spectral config in this repo and
@@ -1576,8 +1576,17 @@ data:
         # is a MISSING pair across two trees, so a PR touching only Kotlin never touches the spec and
         # a diff-scoped gate would see nothing.
         #
-        # Advisory because 114 pre-existing findings cannot be a merge blocker on day one. Flipping
-        # to enforced = add --enforce in ci.yml, once the backlog is cleared.
+        # ENFORCED AGAINST A DECLARED BASELINE (#2314). 104 pre-existing findings could not be a
+        # merge blocker on day one, and correcting a spec is blocked on the unsatisfiable-bump gap
+        # (#2313) — but leaving it advisory is the shape this repo has already ruled against: an
+        # advisory check over a GENERATED comparison has no judgement left to exercise, it just makes
+        # the drift mergeable (#2216). So the gate runs with --enforce against
+        # .github/openapi-route-conformance-baseline.txt, which declares those 104 findings verbatim.
+        # A finding NOT in that file fails the build (new drift, the thing the gate is for); a
+        # baseline line with no matching finding ALSO fails (the debt was paid — delete the line), so
+        # the declaration cannot outlive the debt. The baseline does not narrow what the gate LOOKS
+        # AT — every service is compared every run — which is what separates it from the
+        # pact-drift-check scope bug (#2284). #2314 closes when the file is empty.
       openapi_request_schema_conformance:
         detect: ["openbank-*/src/main/resources/openapi.yaml", "the JAX-RS request-body DTO the resource actually deserializes into"]
         require:

--- a/openbank-infra/gitops/components/payments/sepa-instant-opa-bundle.yaml
+++ b/openbank-infra/gitops/components/payments/sepa-instant-opa-bundle.yaml
@@ -9,7 +9,7 @@ metadata:
     app.kubernetes.io/name: sepa-instant
     app.kubernetes.io/part-of: payments
   annotations:
-    openbank.tech/policy-checksum: "ce182ff135871ad0"
+    openbank.tech/policy-checksum: "d2589f8c417ec426"
 data:
   rest.rego: |
     # SPDX-License-Identifier: Apache-2.0
@@ -2242,12 +2242,36 @@ data:
         # fx + sepa-payment, sepa-instant, domestic-payment, fraud (SSDLC-audit rollout 2026-07-06) +
         # sanctions (2026-07-11: 3 domain files — screening/matching decision logic — matches the
         # "substantive domain math" criterion, not the thin-domain one; 67% local baseline).
-        # The remaining 7 (sca, consent, billing, clearing, swift, lending, settlement) stay excluded:
-        # each has only 1-2 domain files, and those files are plain data models (no branching
-        # money-movement logic), so mutation testing there is noise, not signal — re-confirmed by
-        # file count on 2026-07-11 (settlement and sanctions were both added to money_path_services
-        # after the 2026-07-07 note above; settlement re-confirmed thin, sanctions was the one that
-        # wasn't). Revisit if any of the remaining 7 grows real decision logic in its domain layer.
+        # The remaining 7 (sca, consent, billing, clearing, swift, lending, settlement) stay excluded.
+        #
+        # This list used to be justified by one blanket claim — "each has only 1-2 domain files, and
+        # those files are plain data models (no branching money-movement logic)". The file count was
+        # re-confirmed; the NO-BRANCHING half was never measured, and it is FALSE for three of the
+        # seven (#2395). Measured on 2026-07-26, counting `if (` / `when (` / `require(` / `check(`
+        # over every `src/main/kotlin/**/domain/**.kt` in each module — a deliberately narrow matcher,
+        # so these are lower bounds:
+        #
+        #     service     domain files   branch sites
+        #     sca                    2             11
+        #     consent                2              6
+        #     swift                  1              5
+        #     clearing               3              1
+        #     billing                2              0
+        #     lending                1              0
+        #     settlement             1              0
+        #
+        # So the exclusion rests on a DIFFERENT judgement, and it is stated here rather than hidden
+        # behind an inaccurate blanket: what sca, consent and swift branch on is input VALIDATION and
+        # state-transition legality, not money-movement arithmetic — pitest's value is in the
+        # arithmetic, and no pitest plugin is wired for any of the 7. billing needs its own reason:
+        # its domain layer genuinely does not branch, but its real fee-waiver logic (ADR-0143 phase 2)
+        # lives in `application/usecase/FeeAssessmentService`, OUTSIDE pitest's `domain.*`
+        # targetClasses — so widening the target would be the fix there, not adding the module.
+        #
+        # Revisit if any of the 7 grows money-movement ARITHMETIC in its domain layer; a rising branch
+        # count alone is not the trigger, and re-measure before repeating any claim in this block.
+        # (Historical note: settlement and sanctions were both added to money_path_services after the
+        # 2026-07-07 note above; settlement re-confirmed thin, sanctions was the one that wasn't.)
         # True baselines at rollout (after fixing the KILLED-quote parsing bug): account 49%,
         # transaction 46%, balance 55%, ledger 65%, fx 73%.
         blocked_on: "blocking flip requires each service to sustain >=70% mutation kill score on the weekly run; account/transaction/balance/ledger are below it today (see baselines above)"

--- a/openbank-infra/gitops/components/payments/sepa-payment-opa-bundle.yaml
+++ b/openbank-infra/gitops/components/payments/sepa-payment-opa-bundle.yaml
@@ -9,7 +9,7 @@ metadata:
     app.kubernetes.io/name: sepa-payment
     app.kubernetes.io/part-of: payments
   annotations:
-    openbank.tech/policy-checksum: "3216cf5c741f34a6"
+    openbank.tech/policy-checksum: "59a4ed6d83ead5a6"
 data:
   rest.rego: |
     # SPDX-License-Identifier: Apache-2.0
@@ -2263,12 +2263,36 @@ data:
         # fx + sepa-payment, sepa-instant, domestic-payment, fraud (SSDLC-audit rollout 2026-07-06) +
         # sanctions (2026-07-11: 3 domain files — screening/matching decision logic — matches the
         # "substantive domain math" criterion, not the thin-domain one; 67% local baseline).
-        # The remaining 7 (sca, consent, billing, clearing, swift, lending, settlement) stay excluded:
-        # each has only 1-2 domain files, and those files are plain data models (no branching
-        # money-movement logic), so mutation testing there is noise, not signal — re-confirmed by
-        # file count on 2026-07-11 (settlement and sanctions were both added to money_path_services
-        # after the 2026-07-07 note above; settlement re-confirmed thin, sanctions was the one that
-        # wasn't). Revisit if any of the remaining 7 grows real decision logic in its domain layer.
+        # The remaining 7 (sca, consent, billing, clearing, swift, lending, settlement) stay excluded.
+        #
+        # This list used to be justified by one blanket claim — "each has only 1-2 domain files, and
+        # those files are plain data models (no branching money-movement logic)". The file count was
+        # re-confirmed; the NO-BRANCHING half was never measured, and it is FALSE for three of the
+        # seven (#2395). Measured on 2026-07-26, counting `if (` / `when (` / `require(` / `check(`
+        # over every `src/main/kotlin/**/domain/**.kt` in each module — a deliberately narrow matcher,
+        # so these are lower bounds:
+        #
+        #     service     domain files   branch sites
+        #     sca                    2             11
+        #     consent                2              6
+        #     swift                  1              5
+        #     clearing               3              1
+        #     billing                2              0
+        #     lending                1              0
+        #     settlement             1              0
+        #
+        # So the exclusion rests on a DIFFERENT judgement, and it is stated here rather than hidden
+        # behind an inaccurate blanket: what sca, consent and swift branch on is input VALIDATION and
+        # state-transition legality, not money-movement arithmetic — pitest's value is in the
+        # arithmetic, and no pitest plugin is wired for any of the 7. billing needs its own reason:
+        # its domain layer genuinely does not branch, but its real fee-waiver logic (ADR-0143 phase 2)
+        # lives in `application/usecase/FeeAssessmentService`, OUTSIDE pitest's `domain.*`
+        # targetClasses — so widening the target would be the fix there, not adding the module.
+        #
+        # Revisit if any of the 7 grows money-movement ARITHMETIC in its domain layer; a rising branch
+        # count alone is not the trigger, and re-measure before repeating any claim in this block.
+        # (Historical note: settlement and sanctions were both added to money_path_services after the
+        # 2026-07-07 note above; settlement re-confirmed thin, sanctions was the one that wasn't.)
         # True baselines at rollout (after fixing the KILLED-quote parsing bug): account 49%,
         # transaction 46%, balance 55%, ledger 65%, fx 73%.
         blocked_on: "blocking flip requires each service to sustain >=70% mutation kill score on the weekly run; account/transaction/balance/ledger are below it today (see baselines above)"

--- a/openbank-infra/gitops/components/payments/sepa-payment-opa-bundle.yaml
+++ b/openbank-infra/gitops/components/payments/sepa-payment-opa-bundle.yaml
@@ -9,7 +9,7 @@ metadata:
     app.kubernetes.io/name: sepa-payment
     app.kubernetes.io/part-of: payments
   annotations:
-    openbank.tech/policy-checksum: "378e754f4796cf5c"
+    openbank.tech/policy-checksum: "3216cf5c741f34a6"
 data:
   rest.rego: |
     # SPDX-License-Identifier: Apache-2.0
@@ -1569,9 +1569,9 @@ data:
           - "every route a resource class answers is published in that service's openapi.yaml"
           - "every route openapi.yaml promises is declared by a resource class"
         gate: openapi-route-conformance
-        enforced: advisory
-        target_enforce_date: "2026-09-30"
+        enforced: enforce                 # ADR-0144 graduation, ahead of the 2026-09-30 target (#2314)
         ci_producer: ".github/scripts/check-openapi-route-conformance.py"
+        baseline: ".github/openapi-route-conformance-baseline.txt"
         # api_contract (above) classifies a spec's version bump against the PREVIOUS REVISION of the
         # same document. Nothing asked whether the document is TRUE. ADR-0005 says "CI lints it with
         # Spectral so docs cannot drift from runtime" — there is no Spectral config in this repo and
@@ -1597,8 +1597,17 @@ data:
         # is a MISSING pair across two trees, so a PR touching only Kotlin never touches the spec and
         # a diff-scoped gate would see nothing.
         #
-        # Advisory because 114 pre-existing findings cannot be a merge blocker on day one. Flipping
-        # to enforced = add --enforce in ci.yml, once the backlog is cleared.
+        # ENFORCED AGAINST A DECLARED BASELINE (#2314). 104 pre-existing findings could not be a
+        # merge blocker on day one, and correcting a spec is blocked on the unsatisfiable-bump gap
+        # (#2313) — but leaving it advisory is the shape this repo has already ruled against: an
+        # advisory check over a GENERATED comparison has no judgement left to exercise, it just makes
+        # the drift mergeable (#2216). So the gate runs with --enforce against
+        # .github/openapi-route-conformance-baseline.txt, which declares those 104 findings verbatim.
+        # A finding NOT in that file fails the build (new drift, the thing the gate is for); a
+        # baseline line with no matching finding ALSO fails (the debt was paid — delete the line), so
+        # the declaration cannot outlive the debt. The baseline does not narrow what the gate LOOKS
+        # AT — every service is compared every run — which is what separates it from the
+        # pact-drift-check scope bug (#2284). #2314 closes when the file is empty.
       openapi_request_schema_conformance:
         detect: ["openbank-*/src/main/resources/openapi.yaml", "the JAX-RS request-body DTO the resource actually deserializes into"]
         require:

--- a/openbank-infra/gitops/components/payments/settlement-opa-bundle.yaml
+++ b/openbank-infra/gitops/components/payments/settlement-opa-bundle.yaml
@@ -9,7 +9,7 @@ metadata:
     app.kubernetes.io/name: settlement-service
     app.kubernetes.io/part-of: payments
   annotations:
-    openbank.tech/policy-checksum: "e031d21c8afa6a7d"
+    openbank.tech/policy-checksum: "84be04106d7e1817"
 data:
   rest.rego: |
     # SPDX-License-Identifier: Apache-2.0
@@ -2243,12 +2243,36 @@ data:
         # fx + sepa-payment, sepa-instant, domestic-payment, fraud (SSDLC-audit rollout 2026-07-06) +
         # sanctions (2026-07-11: 3 domain files — screening/matching decision logic — matches the
         # "substantive domain math" criterion, not the thin-domain one; 67% local baseline).
-        # The remaining 7 (sca, consent, billing, clearing, swift, lending, settlement) stay excluded:
-        # each has only 1-2 domain files, and those files are plain data models (no branching
-        # money-movement logic), so mutation testing there is noise, not signal — re-confirmed by
-        # file count on 2026-07-11 (settlement and sanctions were both added to money_path_services
-        # after the 2026-07-07 note above; settlement re-confirmed thin, sanctions was the one that
-        # wasn't). Revisit if any of the remaining 7 grows real decision logic in its domain layer.
+        # The remaining 7 (sca, consent, billing, clearing, swift, lending, settlement) stay excluded.
+        #
+        # This list used to be justified by one blanket claim — "each has only 1-2 domain files, and
+        # those files are plain data models (no branching money-movement logic)". The file count was
+        # re-confirmed; the NO-BRANCHING half was never measured, and it is FALSE for three of the
+        # seven (#2395). Measured on 2026-07-26, counting `if (` / `when (` / `require(` / `check(`
+        # over every `src/main/kotlin/**/domain/**.kt` in each module — a deliberately narrow matcher,
+        # so these are lower bounds:
+        #
+        #     service     domain files   branch sites
+        #     sca                    2             11
+        #     consent                2              6
+        #     swift                  1              5
+        #     clearing               3              1
+        #     billing                2              0
+        #     lending                1              0
+        #     settlement             1              0
+        #
+        # So the exclusion rests on a DIFFERENT judgement, and it is stated here rather than hidden
+        # behind an inaccurate blanket: what sca, consent and swift branch on is input VALIDATION and
+        # state-transition legality, not money-movement arithmetic — pitest's value is in the
+        # arithmetic, and no pitest plugin is wired for any of the 7. billing needs its own reason:
+        # its domain layer genuinely does not branch, but its real fee-waiver logic (ADR-0143 phase 2)
+        # lives in `application/usecase/FeeAssessmentService`, OUTSIDE pitest's `domain.*`
+        # targetClasses — so widening the target would be the fix there, not adding the module.
+        #
+        # Revisit if any of the 7 grows money-movement ARITHMETIC in its domain layer; a rising branch
+        # count alone is not the trigger, and re-measure before repeating any claim in this block.
+        # (Historical note: settlement and sanctions were both added to money_path_services after the
+        # 2026-07-07 note above; settlement re-confirmed thin, sanctions was the one that wasn't.)
         # True baselines at rollout (after fixing the KILLED-quote parsing bug): account 49%,
         # transaction 46%, balance 55%, ledger 65%, fx 73%.
         blocked_on: "blocking flip requires each service to sustain >=70% mutation kill score on the weekly run; account/transaction/balance/ledger are below it today (see baselines above)"

--- a/openbank-infra/gitops/components/payments/settlement-opa-bundle.yaml
+++ b/openbank-infra/gitops/components/payments/settlement-opa-bundle.yaml
@@ -9,7 +9,7 @@ metadata:
     app.kubernetes.io/name: settlement-service
     app.kubernetes.io/part-of: payments
   annotations:
-    openbank.tech/policy-checksum: "0529d2c36d591611"
+    openbank.tech/policy-checksum: "e031d21c8afa6a7d"
 data:
   rest.rego: |
     # SPDX-License-Identifier: Apache-2.0
@@ -1549,9 +1549,9 @@ data:
           - "every route a resource class answers is published in that service's openapi.yaml"
           - "every route openapi.yaml promises is declared by a resource class"
         gate: openapi-route-conformance
-        enforced: advisory
-        target_enforce_date: "2026-09-30"
+        enforced: enforce                 # ADR-0144 graduation, ahead of the 2026-09-30 target (#2314)
         ci_producer: ".github/scripts/check-openapi-route-conformance.py"
+        baseline: ".github/openapi-route-conformance-baseline.txt"
         # api_contract (above) classifies a spec's version bump against the PREVIOUS REVISION of the
         # same document. Nothing asked whether the document is TRUE. ADR-0005 says "CI lints it with
         # Spectral so docs cannot drift from runtime" — there is no Spectral config in this repo and
@@ -1577,8 +1577,17 @@ data:
         # is a MISSING pair across two trees, so a PR touching only Kotlin never touches the spec and
         # a diff-scoped gate would see nothing.
         #
-        # Advisory because 114 pre-existing findings cannot be a merge blocker on day one. Flipping
-        # to enforced = add --enforce in ci.yml, once the backlog is cleared.
+        # ENFORCED AGAINST A DECLARED BASELINE (#2314). 104 pre-existing findings could not be a
+        # merge blocker on day one, and correcting a spec is blocked on the unsatisfiable-bump gap
+        # (#2313) — but leaving it advisory is the shape this repo has already ruled against: an
+        # advisory check over a GENERATED comparison has no judgement left to exercise, it just makes
+        # the drift mergeable (#2216). So the gate runs with --enforce against
+        # .github/openapi-route-conformance-baseline.txt, which declares those 104 findings verbatim.
+        # A finding NOT in that file fails the build (new drift, the thing the gate is for); a
+        # baseline line with no matching finding ALSO fails (the debt was paid — delete the line), so
+        # the declaration cannot outlive the debt. The baseline does not narrow what the gate LOOKS
+        # AT — every service is compared every run — which is what separates it from the
+        # pact-drift-check scope bug (#2284). #2314 closes when the file is empty.
       openapi_request_schema_conformance:
         detect: ["openbank-*/src/main/resources/openapi.yaml", "the JAX-RS request-body DTO the resource actually deserializes into"]
         require:

--- a/openbank-infra/gitops/components/payments/standing-order-opa-bundle.yaml
+++ b/openbank-infra/gitops/components/payments/standing-order-opa-bundle.yaml
@@ -9,7 +9,7 @@ metadata:
     app.kubernetes.io/name: standing-order-service
     app.kubernetes.io/part-of: payments
   annotations:
-    openbank.tech/policy-checksum: "a86bb9a75f728d6b"
+    openbank.tech/policy-checksum: "156ca771dd3aa0a0"
 data:
   rest.rego: |
     # SPDX-License-Identifier: Apache-2.0
@@ -2228,12 +2228,36 @@ data:
         # fx + sepa-payment, sepa-instant, domestic-payment, fraud (SSDLC-audit rollout 2026-07-06) +
         # sanctions (2026-07-11: 3 domain files — screening/matching decision logic — matches the
         # "substantive domain math" criterion, not the thin-domain one; 67% local baseline).
-        # The remaining 7 (sca, consent, billing, clearing, swift, lending, settlement) stay excluded:
-        # each has only 1-2 domain files, and those files are plain data models (no branching
-        # money-movement logic), so mutation testing there is noise, not signal — re-confirmed by
-        # file count on 2026-07-11 (settlement and sanctions were both added to money_path_services
-        # after the 2026-07-07 note above; settlement re-confirmed thin, sanctions was the one that
-        # wasn't). Revisit if any of the remaining 7 grows real decision logic in its domain layer.
+        # The remaining 7 (sca, consent, billing, clearing, swift, lending, settlement) stay excluded.
+        #
+        # This list used to be justified by one blanket claim — "each has only 1-2 domain files, and
+        # those files are plain data models (no branching money-movement logic)". The file count was
+        # re-confirmed; the NO-BRANCHING half was never measured, and it is FALSE for three of the
+        # seven (#2395). Measured on 2026-07-26, counting `if (` / `when (` / `require(` / `check(`
+        # over every `src/main/kotlin/**/domain/**.kt` in each module — a deliberately narrow matcher,
+        # so these are lower bounds:
+        #
+        #     service     domain files   branch sites
+        #     sca                    2             11
+        #     consent                2              6
+        #     swift                  1              5
+        #     clearing               3              1
+        #     billing                2              0
+        #     lending                1              0
+        #     settlement             1              0
+        #
+        # So the exclusion rests on a DIFFERENT judgement, and it is stated here rather than hidden
+        # behind an inaccurate blanket: what sca, consent and swift branch on is input VALIDATION and
+        # state-transition legality, not money-movement arithmetic — pitest's value is in the
+        # arithmetic, and no pitest plugin is wired for any of the 7. billing needs its own reason:
+        # its domain layer genuinely does not branch, but its real fee-waiver logic (ADR-0143 phase 2)
+        # lives in `application/usecase/FeeAssessmentService`, OUTSIDE pitest's `domain.*`
+        # targetClasses — so widening the target would be the fix there, not adding the module.
+        #
+        # Revisit if any of the 7 grows money-movement ARITHMETIC in its domain layer; a rising branch
+        # count alone is not the trigger, and re-measure before repeating any claim in this block.
+        # (Historical note: settlement and sanctions were both added to money_path_services after the
+        # 2026-07-07 note above; settlement re-confirmed thin, sanctions was the one that wasn't.)
         # True baselines at rollout (after fixing the KILLED-quote parsing bug): account 49%,
         # transaction 46%, balance 55%, ledger 65%, fx 73%.
         blocked_on: "blocking flip requires each service to sustain >=70% mutation kill score on the weekly run; account/transaction/balance/ledger are below it today (see baselines above)"

--- a/openbank-infra/gitops/components/payments/standing-order-opa-bundle.yaml
+++ b/openbank-infra/gitops/components/payments/standing-order-opa-bundle.yaml
@@ -9,7 +9,7 @@ metadata:
     app.kubernetes.io/name: standing-order-service
     app.kubernetes.io/part-of: payments
   annotations:
-    openbank.tech/policy-checksum: "2d5c88a185d1733f"
+    openbank.tech/policy-checksum: "a86bb9a75f728d6b"
 data:
   rest.rego: |
     # SPDX-License-Identifier: Apache-2.0
@@ -1534,9 +1534,9 @@ data:
           - "every route a resource class answers is published in that service's openapi.yaml"
           - "every route openapi.yaml promises is declared by a resource class"
         gate: openapi-route-conformance
-        enforced: advisory
-        target_enforce_date: "2026-09-30"
+        enforced: enforce                 # ADR-0144 graduation, ahead of the 2026-09-30 target (#2314)
         ci_producer: ".github/scripts/check-openapi-route-conformance.py"
+        baseline: ".github/openapi-route-conformance-baseline.txt"
         # api_contract (above) classifies a spec's version bump against the PREVIOUS REVISION of the
         # same document. Nothing asked whether the document is TRUE. ADR-0005 says "CI lints it with
         # Spectral so docs cannot drift from runtime" — there is no Spectral config in this repo and
@@ -1562,8 +1562,17 @@ data:
         # is a MISSING pair across two trees, so a PR touching only Kotlin never touches the spec and
         # a diff-scoped gate would see nothing.
         #
-        # Advisory because 114 pre-existing findings cannot be a merge blocker on day one. Flipping
-        # to enforced = add --enforce in ci.yml, once the backlog is cleared.
+        # ENFORCED AGAINST A DECLARED BASELINE (#2314). 104 pre-existing findings could not be a
+        # merge blocker on day one, and correcting a spec is blocked on the unsatisfiable-bump gap
+        # (#2313) — but leaving it advisory is the shape this repo has already ruled against: an
+        # advisory check over a GENERATED comparison has no judgement left to exercise, it just makes
+        # the drift mergeable (#2216). So the gate runs with --enforce against
+        # .github/openapi-route-conformance-baseline.txt, which declares those 104 findings verbatim.
+        # A finding NOT in that file fails the build (new drift, the thing the gate is for); a
+        # baseline line with no matching finding ALSO fails (the debt was paid — delete the line), so
+        # the declaration cannot outlive the debt. The baseline does not narrow what the gate LOOKS
+        # AT — every service is compared every run — which is what separates it from the
+        # pact-drift-check scope bug (#2284). #2314 closes when the file is empty.
       openapi_request_schema_conformance:
         detect: ["openbank-*/src/main/resources/openapi.yaml", "the JAX-RS request-body DTO the resource actually deserializes into"]
         require:

--- a/openbank-infra/gitops/components/payments/swift-opa-bundle.yaml
+++ b/openbank-infra/gitops/components/payments/swift-opa-bundle.yaml
@@ -9,7 +9,7 @@ metadata:
     app.kubernetes.io/name: swift-service
     app.kubernetes.io/part-of: payments
   annotations:
-    openbank.tech/policy-checksum: "c0e200d7c7d6aa86"
+    openbank.tech/policy-checksum: "314f09ec705d2363"
 data:
   rest.rego: |
     # SPDX-License-Identifier: Apache-2.0
@@ -2246,12 +2246,36 @@ data:
         # fx + sepa-payment, sepa-instant, domestic-payment, fraud (SSDLC-audit rollout 2026-07-06) +
         # sanctions (2026-07-11: 3 domain files — screening/matching decision logic — matches the
         # "substantive domain math" criterion, not the thin-domain one; 67% local baseline).
-        # The remaining 7 (sca, consent, billing, clearing, swift, lending, settlement) stay excluded:
-        # each has only 1-2 domain files, and those files are plain data models (no branching
-        # money-movement logic), so mutation testing there is noise, not signal — re-confirmed by
-        # file count on 2026-07-11 (settlement and sanctions were both added to money_path_services
-        # after the 2026-07-07 note above; settlement re-confirmed thin, sanctions was the one that
-        # wasn't). Revisit if any of the remaining 7 grows real decision logic in its domain layer.
+        # The remaining 7 (sca, consent, billing, clearing, swift, lending, settlement) stay excluded.
+        #
+        # This list used to be justified by one blanket claim — "each has only 1-2 domain files, and
+        # those files are plain data models (no branching money-movement logic)". The file count was
+        # re-confirmed; the NO-BRANCHING half was never measured, and it is FALSE for three of the
+        # seven (#2395). Measured on 2026-07-26, counting `if (` / `when (` / `require(` / `check(`
+        # over every `src/main/kotlin/**/domain/**.kt` in each module — a deliberately narrow matcher,
+        # so these are lower bounds:
+        #
+        #     service     domain files   branch sites
+        #     sca                    2             11
+        #     consent                2              6
+        #     swift                  1              5
+        #     clearing               3              1
+        #     billing                2              0
+        #     lending                1              0
+        #     settlement             1              0
+        #
+        # So the exclusion rests on a DIFFERENT judgement, and it is stated here rather than hidden
+        # behind an inaccurate blanket: what sca, consent and swift branch on is input VALIDATION and
+        # state-transition legality, not money-movement arithmetic — pitest's value is in the
+        # arithmetic, and no pitest plugin is wired for any of the 7. billing needs its own reason:
+        # its domain layer genuinely does not branch, but its real fee-waiver logic (ADR-0143 phase 2)
+        # lives in `application/usecase/FeeAssessmentService`, OUTSIDE pitest's `domain.*`
+        # targetClasses — so widening the target would be the fix there, not adding the module.
+        #
+        # Revisit if any of the 7 grows money-movement ARITHMETIC in its domain layer; a rising branch
+        # count alone is not the trigger, and re-measure before repeating any claim in this block.
+        # (Historical note: settlement and sanctions were both added to money_path_services after the
+        # 2026-07-07 note above; settlement re-confirmed thin, sanctions was the one that wasn't.)
         # True baselines at rollout (after fixing the KILLED-quote parsing bug): account 49%,
         # transaction 46%, balance 55%, ledger 65%, fx 73%.
         blocked_on: "blocking flip requires each service to sustain >=70% mutation kill score on the weekly run; account/transaction/balance/ledger are below it today (see baselines above)"

--- a/openbank-infra/gitops/components/payments/swift-opa-bundle.yaml
+++ b/openbank-infra/gitops/components/payments/swift-opa-bundle.yaml
@@ -9,7 +9,7 @@ metadata:
     app.kubernetes.io/name: swift-service
     app.kubernetes.io/part-of: payments
   annotations:
-    openbank.tech/policy-checksum: "ea1bc63d4f34e5aa"
+    openbank.tech/policy-checksum: "c0e200d7c7d6aa86"
 data:
   rest.rego: |
     # SPDX-License-Identifier: Apache-2.0
@@ -1552,9 +1552,9 @@ data:
           - "every route a resource class answers is published in that service's openapi.yaml"
           - "every route openapi.yaml promises is declared by a resource class"
         gate: openapi-route-conformance
-        enforced: advisory
-        target_enforce_date: "2026-09-30"
+        enforced: enforce                 # ADR-0144 graduation, ahead of the 2026-09-30 target (#2314)
         ci_producer: ".github/scripts/check-openapi-route-conformance.py"
+        baseline: ".github/openapi-route-conformance-baseline.txt"
         # api_contract (above) classifies a spec's version bump against the PREVIOUS REVISION of the
         # same document. Nothing asked whether the document is TRUE. ADR-0005 says "CI lints it with
         # Spectral so docs cannot drift from runtime" — there is no Spectral config in this repo and
@@ -1580,8 +1580,17 @@ data:
         # is a MISSING pair across two trees, so a PR touching only Kotlin never touches the spec and
         # a diff-scoped gate would see nothing.
         #
-        # Advisory because 114 pre-existing findings cannot be a merge blocker on day one. Flipping
-        # to enforced = add --enforce in ci.yml, once the backlog is cleared.
+        # ENFORCED AGAINST A DECLARED BASELINE (#2314). 104 pre-existing findings could not be a
+        # merge blocker on day one, and correcting a spec is blocked on the unsatisfiable-bump gap
+        # (#2313) — but leaving it advisory is the shape this repo has already ruled against: an
+        # advisory check over a GENERATED comparison has no judgement left to exercise, it just makes
+        # the drift mergeable (#2216). So the gate runs with --enforce against
+        # .github/openapi-route-conformance-baseline.txt, which declares those 104 findings verbatim.
+        # A finding NOT in that file fails the build (new drift, the thing the gate is for); a
+        # baseline line with no matching finding ALSO fails (the debt was paid — delete the line), so
+        # the declaration cannot outlive the debt. The baseline does not narrow what the gate LOOKS
+        # AT — every service is compared every run — which is what separates it from the
+        # pact-drift-check scope bug (#2284). #2314 closes when the file is empty.
       openapi_request_schema_conformance:
         detect: ["openbank-*/src/main/resources/openapi.yaml", "the JAX-RS request-body DTO the resource actually deserializes into"]
         require:

--- a/openbank-infra/gitops/components/payments/transaction-opa-bundle.yaml
+++ b/openbank-infra/gitops/components/payments/transaction-opa-bundle.yaml
@@ -9,7 +9,7 @@ metadata:
     app.kubernetes.io/name: transaction-service
     app.kubernetes.io/part-of: payments
   annotations:
-    openbank.tech/policy-checksum: "554dfd7e418e7b2c"
+    openbank.tech/policy-checksum: "abb92bc7665154d9"
 data:
   rest.rego: |
     # SPDX-License-Identifier: Apache-2.0
@@ -1605,9 +1605,9 @@ data:
           - "every route a resource class answers is published in that service's openapi.yaml"
           - "every route openapi.yaml promises is declared by a resource class"
         gate: openapi-route-conformance
-        enforced: advisory
-        target_enforce_date: "2026-09-30"
+        enforced: enforce                 # ADR-0144 graduation, ahead of the 2026-09-30 target (#2314)
         ci_producer: ".github/scripts/check-openapi-route-conformance.py"
+        baseline: ".github/openapi-route-conformance-baseline.txt"
         # api_contract (above) classifies a spec's version bump against the PREVIOUS REVISION of the
         # same document. Nothing asked whether the document is TRUE. ADR-0005 says "CI lints it with
         # Spectral so docs cannot drift from runtime" — there is no Spectral config in this repo and
@@ -1633,8 +1633,17 @@ data:
         # is a MISSING pair across two trees, so a PR touching only Kotlin never touches the spec and
         # a diff-scoped gate would see nothing.
         #
-        # Advisory because 114 pre-existing findings cannot be a merge blocker on day one. Flipping
-        # to enforced = add --enforce in ci.yml, once the backlog is cleared.
+        # ENFORCED AGAINST A DECLARED BASELINE (#2314). 104 pre-existing findings could not be a
+        # merge blocker on day one, and correcting a spec is blocked on the unsatisfiable-bump gap
+        # (#2313) — but leaving it advisory is the shape this repo has already ruled against: an
+        # advisory check over a GENERATED comparison has no judgement left to exercise, it just makes
+        # the drift mergeable (#2216). So the gate runs with --enforce against
+        # .github/openapi-route-conformance-baseline.txt, which declares those 104 findings verbatim.
+        # A finding NOT in that file fails the build (new drift, the thing the gate is for); a
+        # baseline line with no matching finding ALSO fails (the debt was paid — delete the line), so
+        # the declaration cannot outlive the debt. The baseline does not narrow what the gate LOOKS
+        # AT — every service is compared every run — which is what separates it from the
+        # pact-drift-check scope bug (#2284). #2314 closes when the file is empty.
       openapi_request_schema_conformance:
         detect: ["openbank-*/src/main/resources/openapi.yaml", "the JAX-RS request-body DTO the resource actually deserializes into"]
         require:

--- a/openbank-infra/gitops/components/payments/transaction-opa-bundle.yaml
+++ b/openbank-infra/gitops/components/payments/transaction-opa-bundle.yaml
@@ -9,7 +9,7 @@ metadata:
     app.kubernetes.io/name: transaction-service
     app.kubernetes.io/part-of: payments
   annotations:
-    openbank.tech/policy-checksum: "abb92bc7665154d9"
+    openbank.tech/policy-checksum: "f881bb1f3833df31"
 data:
   rest.rego: |
     # SPDX-License-Identifier: Apache-2.0
@@ -2299,12 +2299,36 @@ data:
         # fx + sepa-payment, sepa-instant, domestic-payment, fraud (SSDLC-audit rollout 2026-07-06) +
         # sanctions (2026-07-11: 3 domain files — screening/matching decision logic — matches the
         # "substantive domain math" criterion, not the thin-domain one; 67% local baseline).
-        # The remaining 7 (sca, consent, billing, clearing, swift, lending, settlement) stay excluded:
-        # each has only 1-2 domain files, and those files are plain data models (no branching
-        # money-movement logic), so mutation testing there is noise, not signal — re-confirmed by
-        # file count on 2026-07-11 (settlement and sanctions were both added to money_path_services
-        # after the 2026-07-07 note above; settlement re-confirmed thin, sanctions was the one that
-        # wasn't). Revisit if any of the remaining 7 grows real decision logic in its domain layer.
+        # The remaining 7 (sca, consent, billing, clearing, swift, lending, settlement) stay excluded.
+        #
+        # This list used to be justified by one blanket claim — "each has only 1-2 domain files, and
+        # those files are plain data models (no branching money-movement logic)". The file count was
+        # re-confirmed; the NO-BRANCHING half was never measured, and it is FALSE for three of the
+        # seven (#2395). Measured on 2026-07-26, counting `if (` / `when (` / `require(` / `check(`
+        # over every `src/main/kotlin/**/domain/**.kt` in each module — a deliberately narrow matcher,
+        # so these are lower bounds:
+        #
+        #     service     domain files   branch sites
+        #     sca                    2             11
+        #     consent                2              6
+        #     swift                  1              5
+        #     clearing               3              1
+        #     billing                2              0
+        #     lending                1              0
+        #     settlement             1              0
+        #
+        # So the exclusion rests on a DIFFERENT judgement, and it is stated here rather than hidden
+        # behind an inaccurate blanket: what sca, consent and swift branch on is input VALIDATION and
+        # state-transition legality, not money-movement arithmetic — pitest's value is in the
+        # arithmetic, and no pitest plugin is wired for any of the 7. billing needs its own reason:
+        # its domain layer genuinely does not branch, but its real fee-waiver logic (ADR-0143 phase 2)
+        # lives in `application/usecase/FeeAssessmentService`, OUTSIDE pitest's `domain.*`
+        # targetClasses — so widening the target would be the fix there, not adding the module.
+        #
+        # Revisit if any of the 7 grows money-movement ARITHMETIC in its domain layer; a rising branch
+        # count alone is not the trigger, and re-measure before repeating any claim in this block.
+        # (Historical note: settlement and sanctions were both added to money_path_services after the
+        # 2026-07-07 note above; settlement re-confirmed thin, sanctions was the one that wasn't.)
         # True baselines at rollout (after fixing the KILLED-quote parsing bug): account 49%,
         # transaction 46%, balance 55%, ledger 65%, fx 73%.
         blocked_on: "blocking flip requires each service to sustain >=70% mutation kill score on the weekly run; account/transaction/balance/ledger are below it today (see baselines above)"

--- a/openbank-infra/gitops/components/payments/vop-opa-bundle.yaml
+++ b/openbank-infra/gitops/components/payments/vop-opa-bundle.yaml
@@ -9,7 +9,7 @@ metadata:
     app.kubernetes.io/name: vop-service
     app.kubernetes.io/part-of: payments
   annotations:
-    openbank.tech/policy-checksum: "06c74fbe07dd77f8"
+    openbank.tech/policy-checksum: "d84a5ad1e82faf4d"
 data:
   rest.rego: |
     # SPDX-License-Identifier: Apache-2.0
@@ -1556,9 +1556,9 @@ data:
           - "every route a resource class answers is published in that service's openapi.yaml"
           - "every route openapi.yaml promises is declared by a resource class"
         gate: openapi-route-conformance
-        enforced: advisory
-        target_enforce_date: "2026-09-30"
+        enforced: enforce                 # ADR-0144 graduation, ahead of the 2026-09-30 target (#2314)
         ci_producer: ".github/scripts/check-openapi-route-conformance.py"
+        baseline: ".github/openapi-route-conformance-baseline.txt"
         # api_contract (above) classifies a spec's version bump against the PREVIOUS REVISION of the
         # same document. Nothing asked whether the document is TRUE. ADR-0005 says "CI lints it with
         # Spectral so docs cannot drift from runtime" — there is no Spectral config in this repo and
@@ -1584,8 +1584,17 @@ data:
         # is a MISSING pair across two trees, so a PR touching only Kotlin never touches the spec and
         # a diff-scoped gate would see nothing.
         #
-        # Advisory because 114 pre-existing findings cannot be a merge blocker on day one. Flipping
-        # to enforced = add --enforce in ci.yml, once the backlog is cleared.
+        # ENFORCED AGAINST A DECLARED BASELINE (#2314). 104 pre-existing findings could not be a
+        # merge blocker on day one, and correcting a spec is blocked on the unsatisfiable-bump gap
+        # (#2313) — but leaving it advisory is the shape this repo has already ruled against: an
+        # advisory check over a GENERATED comparison has no judgement left to exercise, it just makes
+        # the drift mergeable (#2216). So the gate runs with --enforce against
+        # .github/openapi-route-conformance-baseline.txt, which declares those 104 findings verbatim.
+        # A finding NOT in that file fails the build (new drift, the thing the gate is for); a
+        # baseline line with no matching finding ALSO fails (the debt was paid — delete the line), so
+        # the declaration cannot outlive the debt. The baseline does not narrow what the gate LOOKS
+        # AT — every service is compared every run — which is what separates it from the
+        # pact-drift-check scope bug (#2284). #2314 closes when the file is empty.
       openapi_request_schema_conformance:
         detect: ["openbank-*/src/main/resources/openapi.yaml", "the JAX-RS request-body DTO the resource actually deserializes into"]
         require:

--- a/openbank-infra/gitops/components/payments/vop-opa-bundle.yaml
+++ b/openbank-infra/gitops/components/payments/vop-opa-bundle.yaml
@@ -9,7 +9,7 @@ metadata:
     app.kubernetes.io/name: vop-service
     app.kubernetes.io/part-of: payments
   annotations:
-    openbank.tech/policy-checksum: "d84a5ad1e82faf4d"
+    openbank.tech/policy-checksum: "2d588b32c3fc5a4b"
 data:
   rest.rego: |
     # SPDX-License-Identifier: Apache-2.0
@@ -2250,12 +2250,36 @@ data:
         # fx + sepa-payment, sepa-instant, domestic-payment, fraud (SSDLC-audit rollout 2026-07-06) +
         # sanctions (2026-07-11: 3 domain files — screening/matching decision logic — matches the
         # "substantive domain math" criterion, not the thin-domain one; 67% local baseline).
-        # The remaining 7 (sca, consent, billing, clearing, swift, lending, settlement) stay excluded:
-        # each has only 1-2 domain files, and those files are plain data models (no branching
-        # money-movement logic), so mutation testing there is noise, not signal — re-confirmed by
-        # file count on 2026-07-11 (settlement and sanctions were both added to money_path_services
-        # after the 2026-07-07 note above; settlement re-confirmed thin, sanctions was the one that
-        # wasn't). Revisit if any of the remaining 7 grows real decision logic in its domain layer.
+        # The remaining 7 (sca, consent, billing, clearing, swift, lending, settlement) stay excluded.
+        #
+        # This list used to be justified by one blanket claim — "each has only 1-2 domain files, and
+        # those files are plain data models (no branching money-movement logic)". The file count was
+        # re-confirmed; the NO-BRANCHING half was never measured, and it is FALSE for three of the
+        # seven (#2395). Measured on 2026-07-26, counting `if (` / `when (` / `require(` / `check(`
+        # over every `src/main/kotlin/**/domain/**.kt` in each module — a deliberately narrow matcher,
+        # so these are lower bounds:
+        #
+        #     service     domain files   branch sites
+        #     sca                    2             11
+        #     consent                2              6
+        #     swift                  1              5
+        #     clearing               3              1
+        #     billing                2              0
+        #     lending                1              0
+        #     settlement             1              0
+        #
+        # So the exclusion rests on a DIFFERENT judgement, and it is stated here rather than hidden
+        # behind an inaccurate blanket: what sca, consent and swift branch on is input VALIDATION and
+        # state-transition legality, not money-movement arithmetic — pitest's value is in the
+        # arithmetic, and no pitest plugin is wired for any of the 7. billing needs its own reason:
+        # its domain layer genuinely does not branch, but its real fee-waiver logic (ADR-0143 phase 2)
+        # lives in `application/usecase/FeeAssessmentService`, OUTSIDE pitest's `domain.*`
+        # targetClasses — so widening the target would be the fix there, not adding the module.
+        #
+        # Revisit if any of the 7 grows money-movement ARITHMETIC in its domain layer; a rising branch
+        # count alone is not the trigger, and re-measure before repeating any claim in this block.
+        # (Historical note: settlement and sanctions were both added to money_path_services after the
+        # 2026-07-07 note above; settlement re-confirmed thin, sanctions was the one that wasn't.)
         # True baselines at rollout (after fixing the KILLED-quote parsing bug): account 49%,
         # transaction 46%, balance 55%, ledger 65%, fx 73%.
         blocked_on: "blocking flip requires each service to sustain >=70% mutation kill score on the weekly run; account/transaction/balance/ledger are below it today (see baselines above)"

--- a/openbank-infra/gitops/components/pid/pid-opa-bundle.yaml
+++ b/openbank-infra/gitops/components/pid/pid-opa-bundle.yaml
@@ -9,7 +9,7 @@ metadata:
     app.kubernetes.io/name: pid-service
     app.kubernetes.io/part-of: pid
   annotations:
-    openbank.tech/policy-checksum: "6bad7377703fb5c3"
+    openbank.tech/policy-checksum: "984f31043e19c9db"
 data:
   rest.rego: |
     # SPDX-License-Identifier: Apache-2.0
@@ -1558,9 +1558,9 @@ data:
           - "every route a resource class answers is published in that service's openapi.yaml"
           - "every route openapi.yaml promises is declared by a resource class"
         gate: openapi-route-conformance
-        enforced: advisory
-        target_enforce_date: "2026-09-30"
+        enforced: enforce                 # ADR-0144 graduation, ahead of the 2026-09-30 target (#2314)
         ci_producer: ".github/scripts/check-openapi-route-conformance.py"
+        baseline: ".github/openapi-route-conformance-baseline.txt"
         # api_contract (above) classifies a spec's version bump against the PREVIOUS REVISION of the
         # same document. Nothing asked whether the document is TRUE. ADR-0005 says "CI lints it with
         # Spectral so docs cannot drift from runtime" — there is no Spectral config in this repo and
@@ -1586,8 +1586,17 @@ data:
         # is a MISSING pair across two trees, so a PR touching only Kotlin never touches the spec and
         # a diff-scoped gate would see nothing.
         #
-        # Advisory because 114 pre-existing findings cannot be a merge blocker on day one. Flipping
-        # to enforced = add --enforce in ci.yml, once the backlog is cleared.
+        # ENFORCED AGAINST A DECLARED BASELINE (#2314). 104 pre-existing findings could not be a
+        # merge blocker on day one, and correcting a spec is blocked on the unsatisfiable-bump gap
+        # (#2313) — but leaving it advisory is the shape this repo has already ruled against: an
+        # advisory check over a GENERATED comparison has no judgement left to exercise, it just makes
+        # the drift mergeable (#2216). So the gate runs with --enforce against
+        # .github/openapi-route-conformance-baseline.txt, which declares those 104 findings verbatim.
+        # A finding NOT in that file fails the build (new drift, the thing the gate is for); a
+        # baseline line with no matching finding ALSO fails (the debt was paid — delete the line), so
+        # the declaration cannot outlive the debt. The baseline does not narrow what the gate LOOKS
+        # AT — every service is compared every run — which is what separates it from the
+        # pact-drift-check scope bug (#2284). #2314 closes when the file is empty.
       openapi_request_schema_conformance:
         detect: ["openbank-*/src/main/resources/openapi.yaml", "the JAX-RS request-body DTO the resource actually deserializes into"]
         require:

--- a/openbank-infra/gitops/components/pid/pid-opa-bundle.yaml
+++ b/openbank-infra/gitops/components/pid/pid-opa-bundle.yaml
@@ -9,7 +9,7 @@ metadata:
     app.kubernetes.io/name: pid-service
     app.kubernetes.io/part-of: pid
   annotations:
-    openbank.tech/policy-checksum: "984f31043e19c9db"
+    openbank.tech/policy-checksum: "41420e0d70ef4f52"
 data:
   rest.rego: |
     # SPDX-License-Identifier: Apache-2.0
@@ -2252,12 +2252,36 @@ data:
         # fx + sepa-payment, sepa-instant, domestic-payment, fraud (SSDLC-audit rollout 2026-07-06) +
         # sanctions (2026-07-11: 3 domain files — screening/matching decision logic — matches the
         # "substantive domain math" criterion, not the thin-domain one; 67% local baseline).
-        # The remaining 7 (sca, consent, billing, clearing, swift, lending, settlement) stay excluded:
-        # each has only 1-2 domain files, and those files are plain data models (no branching
-        # money-movement logic), so mutation testing there is noise, not signal — re-confirmed by
-        # file count on 2026-07-11 (settlement and sanctions were both added to money_path_services
-        # after the 2026-07-07 note above; settlement re-confirmed thin, sanctions was the one that
-        # wasn't). Revisit if any of the remaining 7 grows real decision logic in its domain layer.
+        # The remaining 7 (sca, consent, billing, clearing, swift, lending, settlement) stay excluded.
+        #
+        # This list used to be justified by one blanket claim — "each has only 1-2 domain files, and
+        # those files are plain data models (no branching money-movement logic)". The file count was
+        # re-confirmed; the NO-BRANCHING half was never measured, and it is FALSE for three of the
+        # seven (#2395). Measured on 2026-07-26, counting `if (` / `when (` / `require(` / `check(`
+        # over every `src/main/kotlin/**/domain/**.kt` in each module — a deliberately narrow matcher,
+        # so these are lower bounds:
+        #
+        #     service     domain files   branch sites
+        #     sca                    2             11
+        #     consent                2              6
+        #     swift                  1              5
+        #     clearing               3              1
+        #     billing                2              0
+        #     lending                1              0
+        #     settlement             1              0
+        #
+        # So the exclusion rests on a DIFFERENT judgement, and it is stated here rather than hidden
+        # behind an inaccurate blanket: what sca, consent and swift branch on is input VALIDATION and
+        # state-transition legality, not money-movement arithmetic — pitest's value is in the
+        # arithmetic, and no pitest plugin is wired for any of the 7. billing needs its own reason:
+        # its domain layer genuinely does not branch, but its real fee-waiver logic (ADR-0143 phase 2)
+        # lives in `application/usecase/FeeAssessmentService`, OUTSIDE pitest's `domain.*`
+        # targetClasses — so widening the target would be the fix there, not adding the module.
+        #
+        # Revisit if any of the 7 grows money-movement ARITHMETIC in its domain layer; a rising branch
+        # count alone is not the trigger, and re-measure before repeating any claim in this block.
+        # (Historical note: settlement and sanctions were both added to money_path_services after the
+        # 2026-07-07 note above; settlement re-confirmed thin, sanctions was the one that wasn't.)
         # True baselines at rollout (after fixing the KILLED-quote parsing bug): account 49%,
         # transaction 46%, balance 55%, ledger 65%, fx 73%.
         blocked_on: "blocking flip requires each service to sustain >=70% mutation kill score on the weekly run; account/transaction/balance/ledger are below it today (see baselines above)"

--- a/openbank-infra/gitops/components/pid/pid-service.yaml
+++ b/openbank-infra/gitops/components/pid/pid-service.yaml
@@ -22,7 +22,7 @@ spec:
       annotations:
         # Rolls the pod when the OPA bundle changes — subPath mounts do NOT hot-reload.
         # Kept in sync by gen-pid-opa-bundle.sh (do not hand-edit).
-        openbank.tech/policy-checksum: "984f31043e19c9db"
+        openbank.tech/policy-checksum: "41420e0d70ef4f52"
     spec:
       securityContext:
         runAsNonRoot: true

--- a/openbank-infra/gitops/components/pid/pid-service.yaml
+++ b/openbank-infra/gitops/components/pid/pid-service.yaml
@@ -22,7 +22,7 @@ spec:
       annotations:
         # Rolls the pod when the OPA bundle changes — subPath mounts do NOT hot-reload.
         # Kept in sync by gen-pid-opa-bundle.sh (do not hand-edit).
-        openbank.tech/policy-checksum: "6bad7377703fb5c3"
+        openbank.tech/policy-checksum: "984f31043e19c9db"
     spec:
       securityContext:
         runAsNonRoot: true

--- a/openbank-infra/gitops/components/psd2-service/psd2-opa-bundle.yaml
+++ b/openbank-infra/gitops/components/psd2-service/psd2-opa-bundle.yaml
@@ -9,7 +9,7 @@ metadata:
     app.kubernetes.io/name: psd2-service
     app.kubernetes.io/part-of: psd2
   annotations:
-    openbank.tech/policy-checksum: "91bd5b33d7849623"
+    openbank.tech/policy-checksum: "9ccfe8b9e8c780a8"
 data:
   rest.rego: |
     # SPDX-License-Identifier: Apache-2.0
@@ -2325,12 +2325,36 @@ data:
         # fx + sepa-payment, sepa-instant, domestic-payment, fraud (SSDLC-audit rollout 2026-07-06) +
         # sanctions (2026-07-11: 3 domain files — screening/matching decision logic — matches the
         # "substantive domain math" criterion, not the thin-domain one; 67% local baseline).
-        # The remaining 7 (sca, consent, billing, clearing, swift, lending, settlement) stay excluded:
-        # each has only 1-2 domain files, and those files are plain data models (no branching
-        # money-movement logic), so mutation testing there is noise, not signal — re-confirmed by
-        # file count on 2026-07-11 (settlement and sanctions were both added to money_path_services
-        # after the 2026-07-07 note above; settlement re-confirmed thin, sanctions was the one that
-        # wasn't). Revisit if any of the remaining 7 grows real decision logic in its domain layer.
+        # The remaining 7 (sca, consent, billing, clearing, swift, lending, settlement) stay excluded.
+        #
+        # This list used to be justified by one blanket claim — "each has only 1-2 domain files, and
+        # those files are plain data models (no branching money-movement logic)". The file count was
+        # re-confirmed; the NO-BRANCHING half was never measured, and it is FALSE for three of the
+        # seven (#2395). Measured on 2026-07-26, counting `if (` / `when (` / `require(` / `check(`
+        # over every `src/main/kotlin/**/domain/**.kt` in each module — a deliberately narrow matcher,
+        # so these are lower bounds:
+        #
+        #     service     domain files   branch sites
+        #     sca                    2             11
+        #     consent                2              6
+        #     swift                  1              5
+        #     clearing               3              1
+        #     billing                2              0
+        #     lending                1              0
+        #     settlement             1              0
+        #
+        # So the exclusion rests on a DIFFERENT judgement, and it is stated here rather than hidden
+        # behind an inaccurate blanket: what sca, consent and swift branch on is input VALIDATION and
+        # state-transition legality, not money-movement arithmetic — pitest's value is in the
+        # arithmetic, and no pitest plugin is wired for any of the 7. billing needs its own reason:
+        # its domain layer genuinely does not branch, but its real fee-waiver logic (ADR-0143 phase 2)
+        # lives in `application/usecase/FeeAssessmentService`, OUTSIDE pitest's `domain.*`
+        # targetClasses — so widening the target would be the fix there, not adding the module.
+        #
+        # Revisit if any of the 7 grows money-movement ARITHMETIC in its domain layer; a rising branch
+        # count alone is not the trigger, and re-measure before repeating any claim in this block.
+        # (Historical note: settlement and sanctions were both added to money_path_services after the
+        # 2026-07-07 note above; settlement re-confirmed thin, sanctions was the one that wasn't.)
         # True baselines at rollout (after fixing the KILLED-quote parsing bug): account 49%,
         # transaction 46%, balance 55%, ledger 65%, fx 73%.
         blocked_on: "blocking flip requires each service to sustain >=70% mutation kill score on the weekly run; account/transaction/balance/ledger are below it today (see baselines above)"

--- a/openbank-infra/gitops/components/psd2-service/psd2-opa-bundle.yaml
+++ b/openbank-infra/gitops/components/psd2-service/psd2-opa-bundle.yaml
@@ -9,7 +9,7 @@ metadata:
     app.kubernetes.io/name: psd2-service
     app.kubernetes.io/part-of: psd2
   annotations:
-    openbank.tech/policy-checksum: "7e2013d2c9a946f4"
+    openbank.tech/policy-checksum: "91bd5b33d7849623"
 data:
   rest.rego: |
     # SPDX-License-Identifier: Apache-2.0
@@ -1631,9 +1631,9 @@ data:
           - "every route a resource class answers is published in that service's openapi.yaml"
           - "every route openapi.yaml promises is declared by a resource class"
         gate: openapi-route-conformance
-        enforced: advisory
-        target_enforce_date: "2026-09-30"
+        enforced: enforce                 # ADR-0144 graduation, ahead of the 2026-09-30 target (#2314)
         ci_producer: ".github/scripts/check-openapi-route-conformance.py"
+        baseline: ".github/openapi-route-conformance-baseline.txt"
         # api_contract (above) classifies a spec's version bump against the PREVIOUS REVISION of the
         # same document. Nothing asked whether the document is TRUE. ADR-0005 says "CI lints it with
         # Spectral so docs cannot drift from runtime" — there is no Spectral config in this repo and
@@ -1659,8 +1659,17 @@ data:
         # is a MISSING pair across two trees, so a PR touching only Kotlin never touches the spec and
         # a diff-scoped gate would see nothing.
         #
-        # Advisory because 114 pre-existing findings cannot be a merge blocker on day one. Flipping
-        # to enforced = add --enforce in ci.yml, once the backlog is cleared.
+        # ENFORCED AGAINST A DECLARED BASELINE (#2314). 104 pre-existing findings could not be a
+        # merge blocker on day one, and correcting a spec is blocked on the unsatisfiable-bump gap
+        # (#2313) — but leaving it advisory is the shape this repo has already ruled against: an
+        # advisory check over a GENERATED comparison has no judgement left to exercise, it just makes
+        # the drift mergeable (#2216). So the gate runs with --enforce against
+        # .github/openapi-route-conformance-baseline.txt, which declares those 104 findings verbatim.
+        # A finding NOT in that file fails the build (new drift, the thing the gate is for); a
+        # baseline line with no matching finding ALSO fails (the debt was paid — delete the line), so
+        # the declaration cannot outlive the debt. The baseline does not narrow what the gate LOOKS
+        # AT — every service is compared every run — which is what separates it from the
+        # pact-drift-check scope bug (#2284). #2314 closes when the file is empty.
       openapi_request_schema_conformance:
         detect: ["openbank-*/src/main/resources/openapi.yaml", "the JAX-RS request-body DTO the resource actually deserializes into"]
         require:

--- a/openbank-infra/gitops/components/psd2-service/psd2-service.yaml
+++ b/openbank-infra/gitops/components/psd2-service/psd2-service.yaml
@@ -18,7 +18,7 @@ spec:
       annotations:
         # Rolls the pod when the OPA bundle changes — subPath mounts do NOT hot-reload.
         # Kept in sync by gen-psd2-opa-bundle.sh (do not hand-edit).
-        openbank.tech/policy-checksum: "91bd5b33d7849623"
+        openbank.tech/policy-checksum: "9ccfe8b9e8c780a8"
       labels: {app.kubernetes.io/name: psd2-service, app.kubernetes.io/part-of: psd2}
     spec:
       securityContext:

--- a/openbank-infra/gitops/components/psd2-service/psd2-service.yaml
+++ b/openbank-infra/gitops/components/psd2-service/psd2-service.yaml
@@ -18,7 +18,7 @@ spec:
       annotations:
         # Rolls the pod when the OPA bundle changes — subPath mounts do NOT hot-reload.
         # Kept in sync by gen-psd2-opa-bundle.sh (do not hand-edit).
-        openbank.tech/policy-checksum: "7e2013d2c9a946f4"
+        openbank.tech/policy-checksum: "91bd5b33d7849623"
       labels: {app.kubernetes.io/name: psd2-service, app.kubernetes.io/part-of: psd2}
     spec:
       securityContext:

--- a/openbank-infra/gitops/components/sanctions-service/sanctions-opa-bundle.yaml
+++ b/openbank-infra/gitops/components/sanctions-service/sanctions-opa-bundle.yaml
@@ -9,7 +9,7 @@ metadata:
     app.kubernetes.io/name: sanctions-service
     app.kubernetes.io/part-of: sanctions
   annotations:
-    openbank.tech/policy-checksum: "782bb039ab5519f2"
+    openbank.tech/policy-checksum: "f89580bca74f304c"
 data:
   rest.rego: |
     # SPDX-License-Identifier: Apache-2.0
@@ -2230,12 +2230,36 @@ data:
         # fx + sepa-payment, sepa-instant, domestic-payment, fraud (SSDLC-audit rollout 2026-07-06) +
         # sanctions (2026-07-11: 3 domain files — screening/matching decision logic — matches the
         # "substantive domain math" criterion, not the thin-domain one; 67% local baseline).
-        # The remaining 7 (sca, consent, billing, clearing, swift, lending, settlement) stay excluded:
-        # each has only 1-2 domain files, and those files are plain data models (no branching
-        # money-movement logic), so mutation testing there is noise, not signal — re-confirmed by
-        # file count on 2026-07-11 (settlement and sanctions were both added to money_path_services
-        # after the 2026-07-07 note above; settlement re-confirmed thin, sanctions was the one that
-        # wasn't). Revisit if any of the remaining 7 grows real decision logic in its domain layer.
+        # The remaining 7 (sca, consent, billing, clearing, swift, lending, settlement) stay excluded.
+        #
+        # This list used to be justified by one blanket claim — "each has only 1-2 domain files, and
+        # those files are plain data models (no branching money-movement logic)". The file count was
+        # re-confirmed; the NO-BRANCHING half was never measured, and it is FALSE for three of the
+        # seven (#2395). Measured on 2026-07-26, counting `if (` / `when (` / `require(` / `check(`
+        # over every `src/main/kotlin/**/domain/**.kt` in each module — a deliberately narrow matcher,
+        # so these are lower bounds:
+        #
+        #     service     domain files   branch sites
+        #     sca                    2             11
+        #     consent                2              6
+        #     swift                  1              5
+        #     clearing               3              1
+        #     billing                2              0
+        #     lending                1              0
+        #     settlement             1              0
+        #
+        # So the exclusion rests on a DIFFERENT judgement, and it is stated here rather than hidden
+        # behind an inaccurate blanket: what sca, consent and swift branch on is input VALIDATION and
+        # state-transition legality, not money-movement arithmetic — pitest's value is in the
+        # arithmetic, and no pitest plugin is wired for any of the 7. billing needs its own reason:
+        # its domain layer genuinely does not branch, but its real fee-waiver logic (ADR-0143 phase 2)
+        # lives in `application/usecase/FeeAssessmentService`, OUTSIDE pitest's `domain.*`
+        # targetClasses — so widening the target would be the fix there, not adding the module.
+        #
+        # Revisit if any of the 7 grows money-movement ARITHMETIC in its domain layer; a rising branch
+        # count alone is not the trigger, and re-measure before repeating any claim in this block.
+        # (Historical note: settlement and sanctions were both added to money_path_services after the
+        # 2026-07-07 note above; settlement re-confirmed thin, sanctions was the one that wasn't.)
         # True baselines at rollout (after fixing the KILLED-quote parsing bug): account 49%,
         # transaction 46%, balance 55%, ledger 65%, fx 73%.
         blocked_on: "blocking flip requires each service to sustain >=70% mutation kill score on the weekly run; account/transaction/balance/ledger are below it today (see baselines above)"

--- a/openbank-infra/gitops/components/sanctions-service/sanctions-opa-bundle.yaml
+++ b/openbank-infra/gitops/components/sanctions-service/sanctions-opa-bundle.yaml
@@ -9,7 +9,7 @@ metadata:
     app.kubernetes.io/name: sanctions-service
     app.kubernetes.io/part-of: sanctions
   annotations:
-    openbank.tech/policy-checksum: "95a245a7331440fe"
+    openbank.tech/policy-checksum: "782bb039ab5519f2"
 data:
   rest.rego: |
     # SPDX-License-Identifier: Apache-2.0
@@ -1536,9 +1536,9 @@ data:
           - "every route a resource class answers is published in that service's openapi.yaml"
           - "every route openapi.yaml promises is declared by a resource class"
         gate: openapi-route-conformance
-        enforced: advisory
-        target_enforce_date: "2026-09-30"
+        enforced: enforce                 # ADR-0144 graduation, ahead of the 2026-09-30 target (#2314)
         ci_producer: ".github/scripts/check-openapi-route-conformance.py"
+        baseline: ".github/openapi-route-conformance-baseline.txt"
         # api_contract (above) classifies a spec's version bump against the PREVIOUS REVISION of the
         # same document. Nothing asked whether the document is TRUE. ADR-0005 says "CI lints it with
         # Spectral so docs cannot drift from runtime" — there is no Spectral config in this repo and
@@ -1564,8 +1564,17 @@ data:
         # is a MISSING pair across two trees, so a PR touching only Kotlin never touches the spec and
         # a diff-scoped gate would see nothing.
         #
-        # Advisory because 114 pre-existing findings cannot be a merge blocker on day one. Flipping
-        # to enforced = add --enforce in ci.yml, once the backlog is cleared.
+        # ENFORCED AGAINST A DECLARED BASELINE (#2314). 104 pre-existing findings could not be a
+        # merge blocker on day one, and correcting a spec is blocked on the unsatisfiable-bump gap
+        # (#2313) — but leaving it advisory is the shape this repo has already ruled against: an
+        # advisory check over a GENERATED comparison has no judgement left to exercise, it just makes
+        # the drift mergeable (#2216). So the gate runs with --enforce against
+        # .github/openapi-route-conformance-baseline.txt, which declares those 104 findings verbatim.
+        # A finding NOT in that file fails the build (new drift, the thing the gate is for); a
+        # baseline line with no matching finding ALSO fails (the debt was paid — delete the line), so
+        # the declaration cannot outlive the debt. The baseline does not narrow what the gate LOOKS
+        # AT — every service is compared every run — which is what separates it from the
+        # pact-drift-check scope bug (#2284). #2314 closes when the file is empty.
       openapi_request_schema_conformance:
         detect: ["openbank-*/src/main/resources/openapi.yaml", "the JAX-RS request-body DTO the resource actually deserializes into"]
         require:

--- a/openbank-infra/gitops/components/sanctions-service/sanctions-service.yaml
+++ b/openbank-infra/gitops/components/sanctions-service/sanctions-service.yaml
@@ -49,7 +49,7 @@ spec:
       annotations:
         # Rolls the pods when the OPA bundle changes — subPath mounts do NOT hot-reload.
         # Kept in sync by gen-sanctions-opa-bundle.sh (do not hand-edit).
-        openbank.tech/policy-checksum: "95a245a7331440fe"
+        openbank.tech/policy-checksum: "782bb039ab5519f2"
     spec:
       securityContext:
         runAsNonRoot: true

--- a/openbank-infra/gitops/components/sanctions-service/sanctions-service.yaml
+++ b/openbank-infra/gitops/components/sanctions-service/sanctions-service.yaml
@@ -49,7 +49,7 @@ spec:
       annotations:
         # Rolls the pods when the OPA bundle changes — subPath mounts do NOT hot-reload.
         # Kept in sync by gen-sanctions-opa-bundle.sh (do not hand-edit).
-        openbank.tech/policy-checksum: "782bb039ab5519f2"
+        openbank.tech/policy-checksum: "f89580bca74f304c"
     spec:
       securityContext:
         runAsNonRoot: true

--- a/openbank-infra/gitops/components/sca/sca-opa-bundle.yaml
+++ b/openbank-infra/gitops/components/sca/sca-opa-bundle.yaml
@@ -9,7 +9,7 @@ metadata:
     app.kubernetes.io/name: sca-service
     app.kubernetes.io/part-of: sca
   annotations:
-    openbank.tech/policy-checksum: "3e5688917ab44f97"
+    openbank.tech/policy-checksum: "1126f48edbec0c2c"
 data:
   rest.rego: |
     # SPDX-License-Identifier: Apache-2.0
@@ -2266,12 +2266,36 @@ data:
         # fx + sepa-payment, sepa-instant, domestic-payment, fraud (SSDLC-audit rollout 2026-07-06) +
         # sanctions (2026-07-11: 3 domain files — screening/matching decision logic — matches the
         # "substantive domain math" criterion, not the thin-domain one; 67% local baseline).
-        # The remaining 7 (sca, consent, billing, clearing, swift, lending, settlement) stay excluded:
-        # each has only 1-2 domain files, and those files are plain data models (no branching
-        # money-movement logic), so mutation testing there is noise, not signal — re-confirmed by
-        # file count on 2026-07-11 (settlement and sanctions were both added to money_path_services
-        # after the 2026-07-07 note above; settlement re-confirmed thin, sanctions was the one that
-        # wasn't). Revisit if any of the remaining 7 grows real decision logic in its domain layer.
+        # The remaining 7 (sca, consent, billing, clearing, swift, lending, settlement) stay excluded.
+        #
+        # This list used to be justified by one blanket claim — "each has only 1-2 domain files, and
+        # those files are plain data models (no branching money-movement logic)". The file count was
+        # re-confirmed; the NO-BRANCHING half was never measured, and it is FALSE for three of the
+        # seven (#2395). Measured on 2026-07-26, counting `if (` / `when (` / `require(` / `check(`
+        # over every `src/main/kotlin/**/domain/**.kt` in each module — a deliberately narrow matcher,
+        # so these are lower bounds:
+        #
+        #     service     domain files   branch sites
+        #     sca                    2             11
+        #     consent                2              6
+        #     swift                  1              5
+        #     clearing               3              1
+        #     billing                2              0
+        #     lending                1              0
+        #     settlement             1              0
+        #
+        # So the exclusion rests on a DIFFERENT judgement, and it is stated here rather than hidden
+        # behind an inaccurate blanket: what sca, consent and swift branch on is input VALIDATION and
+        # state-transition legality, not money-movement arithmetic — pitest's value is in the
+        # arithmetic, and no pitest plugin is wired for any of the 7. billing needs its own reason:
+        # its domain layer genuinely does not branch, but its real fee-waiver logic (ADR-0143 phase 2)
+        # lives in `application/usecase/FeeAssessmentService`, OUTSIDE pitest's `domain.*`
+        # targetClasses — so widening the target would be the fix there, not adding the module.
+        #
+        # Revisit if any of the 7 grows money-movement ARITHMETIC in its domain layer; a rising branch
+        # count alone is not the trigger, and re-measure before repeating any claim in this block.
+        # (Historical note: settlement and sanctions were both added to money_path_services after the
+        # 2026-07-07 note above; settlement re-confirmed thin, sanctions was the one that wasn't.)
         # True baselines at rollout (after fixing the KILLED-quote parsing bug): account 49%,
         # transaction 46%, balance 55%, ledger 65%, fx 73%.
         blocked_on: "blocking flip requires each service to sustain >=70% mutation kill score on the weekly run; account/transaction/balance/ledger are below it today (see baselines above)"

--- a/openbank-infra/gitops/components/sca/sca-opa-bundle.yaml
+++ b/openbank-infra/gitops/components/sca/sca-opa-bundle.yaml
@@ -9,7 +9,7 @@ metadata:
     app.kubernetes.io/name: sca-service
     app.kubernetes.io/part-of: sca
   annotations:
-    openbank.tech/policy-checksum: "050d04dfcb36854c"
+    openbank.tech/policy-checksum: "3e5688917ab44f97"
 data:
   rest.rego: |
     # SPDX-License-Identifier: Apache-2.0
@@ -1572,9 +1572,9 @@ data:
           - "every route a resource class answers is published in that service's openapi.yaml"
           - "every route openapi.yaml promises is declared by a resource class"
         gate: openapi-route-conformance
-        enforced: advisory
-        target_enforce_date: "2026-09-30"
+        enforced: enforce                 # ADR-0144 graduation, ahead of the 2026-09-30 target (#2314)
         ci_producer: ".github/scripts/check-openapi-route-conformance.py"
+        baseline: ".github/openapi-route-conformance-baseline.txt"
         # api_contract (above) classifies a spec's version bump against the PREVIOUS REVISION of the
         # same document. Nothing asked whether the document is TRUE. ADR-0005 says "CI lints it with
         # Spectral so docs cannot drift from runtime" — there is no Spectral config in this repo and
@@ -1600,8 +1600,17 @@ data:
         # is a MISSING pair across two trees, so a PR touching only Kotlin never touches the spec and
         # a diff-scoped gate would see nothing.
         #
-        # Advisory because 114 pre-existing findings cannot be a merge blocker on day one. Flipping
-        # to enforced = add --enforce in ci.yml, once the backlog is cleared.
+        # ENFORCED AGAINST A DECLARED BASELINE (#2314). 104 pre-existing findings could not be a
+        # merge blocker on day one, and correcting a spec is blocked on the unsatisfiable-bump gap
+        # (#2313) — but leaving it advisory is the shape this repo has already ruled against: an
+        # advisory check over a GENERATED comparison has no judgement left to exercise, it just makes
+        # the drift mergeable (#2216). So the gate runs with --enforce against
+        # .github/openapi-route-conformance-baseline.txt, which declares those 104 findings verbatim.
+        # A finding NOT in that file fails the build (new drift, the thing the gate is for); a
+        # baseline line with no matching finding ALSO fails (the debt was paid — delete the line), so
+        # the declaration cannot outlive the debt. The baseline does not narrow what the gate LOOKS
+        # AT — every service is compared every run — which is what separates it from the
+        # pact-drift-check scope bug (#2284). #2314 closes when the file is empty.
       openapi_request_schema_conformance:
         detect: ["openbank-*/src/main/resources/openapi.yaml", "the JAX-RS request-body DTO the resource actually deserializes into"]
         require:

--- a/openbank-infra/gitops/components/sca/sca-service.yaml
+++ b/openbank-infra/gitops/components/sca/sca-service.yaml
@@ -28,7 +28,7 @@ spec:
       annotations:
         # Rolls the pods when the OPA bundle changes — subPath mounts do NOT hot-reload.
         # Kept in sync by gen-sca-opa-bundle.sh (do not hand-edit).
-        openbank.tech/policy-checksum: "3e5688917ab44f97"
+        openbank.tech/policy-checksum: "1126f48edbec0c2c"
     spec:
       securityContext:
         runAsNonRoot: true

--- a/openbank-infra/gitops/components/sca/sca-service.yaml
+++ b/openbank-infra/gitops/components/sca/sca-service.yaml
@@ -28,7 +28,7 @@ spec:
       annotations:
         # Rolls the pods when the OPA bundle changes — subPath mounts do NOT hot-reload.
         # Kept in sync by gen-sca-opa-bundle.sh (do not hand-edit).
-        openbank.tech/policy-checksum: "050d04dfcb36854c"
+        openbank.tech/policy-checksum: "3e5688917ab44f97"
     spec:
       securityContext:
         runAsNonRoot: true

--- a/openbank-infra/gitops/components/statements/statement-opa-bundle.yaml
+++ b/openbank-infra/gitops/components/statements/statement-opa-bundle.yaml
@@ -9,7 +9,7 @@ metadata:
     app.kubernetes.io/name: statement-service
     app.kubernetes.io/part-of: statements
   annotations:
-    openbank.tech/policy-checksum: "f87ab950b3ddbf64"
+    openbank.tech/policy-checksum: "fc01139e5926e7fd"
 data:
   rest.rego: |
     # SPDX-License-Identifier: Apache-2.0
@@ -1602,9 +1602,9 @@ data:
           - "every route a resource class answers is published in that service's openapi.yaml"
           - "every route openapi.yaml promises is declared by a resource class"
         gate: openapi-route-conformance
-        enforced: advisory
-        target_enforce_date: "2026-09-30"
+        enforced: enforce                 # ADR-0144 graduation, ahead of the 2026-09-30 target (#2314)
         ci_producer: ".github/scripts/check-openapi-route-conformance.py"
+        baseline: ".github/openapi-route-conformance-baseline.txt"
         # api_contract (above) classifies a spec's version bump against the PREVIOUS REVISION of the
         # same document. Nothing asked whether the document is TRUE. ADR-0005 says "CI lints it with
         # Spectral so docs cannot drift from runtime" — there is no Spectral config in this repo and
@@ -1630,8 +1630,17 @@ data:
         # is a MISSING pair across two trees, so a PR touching only Kotlin never touches the spec and
         # a diff-scoped gate would see nothing.
         #
-        # Advisory because 114 pre-existing findings cannot be a merge blocker on day one. Flipping
-        # to enforced = add --enforce in ci.yml, once the backlog is cleared.
+        # ENFORCED AGAINST A DECLARED BASELINE (#2314). 104 pre-existing findings could not be a
+        # merge blocker on day one, and correcting a spec is blocked on the unsatisfiable-bump gap
+        # (#2313) — but leaving it advisory is the shape this repo has already ruled against: an
+        # advisory check over a GENERATED comparison has no judgement left to exercise, it just makes
+        # the drift mergeable (#2216). So the gate runs with --enforce against
+        # .github/openapi-route-conformance-baseline.txt, which declares those 104 findings verbatim.
+        # A finding NOT in that file fails the build (new drift, the thing the gate is for); a
+        # baseline line with no matching finding ALSO fails (the debt was paid — delete the line), so
+        # the declaration cannot outlive the debt. The baseline does not narrow what the gate LOOKS
+        # AT — every service is compared every run — which is what separates it from the
+        # pact-drift-check scope bug (#2284). #2314 closes when the file is empty.
       openapi_request_schema_conformance:
         detect: ["openbank-*/src/main/resources/openapi.yaml", "the JAX-RS request-body DTO the resource actually deserializes into"]
         require:

--- a/openbank-infra/gitops/components/statements/statement-opa-bundle.yaml
+++ b/openbank-infra/gitops/components/statements/statement-opa-bundle.yaml
@@ -9,7 +9,7 @@ metadata:
     app.kubernetes.io/name: statement-service
     app.kubernetes.io/part-of: statements
   annotations:
-    openbank.tech/policy-checksum: "fc01139e5926e7fd"
+    openbank.tech/policy-checksum: "27125c0ea2b3abaa"
 data:
   rest.rego: |
     # SPDX-License-Identifier: Apache-2.0
@@ -2296,12 +2296,36 @@ data:
         # fx + sepa-payment, sepa-instant, domestic-payment, fraud (SSDLC-audit rollout 2026-07-06) +
         # sanctions (2026-07-11: 3 domain files — screening/matching decision logic — matches the
         # "substantive domain math" criterion, not the thin-domain one; 67% local baseline).
-        # The remaining 7 (sca, consent, billing, clearing, swift, lending, settlement) stay excluded:
-        # each has only 1-2 domain files, and those files are plain data models (no branching
-        # money-movement logic), so mutation testing there is noise, not signal — re-confirmed by
-        # file count on 2026-07-11 (settlement and sanctions were both added to money_path_services
-        # after the 2026-07-07 note above; settlement re-confirmed thin, sanctions was the one that
-        # wasn't). Revisit if any of the remaining 7 grows real decision logic in its domain layer.
+        # The remaining 7 (sca, consent, billing, clearing, swift, lending, settlement) stay excluded.
+        #
+        # This list used to be justified by one blanket claim — "each has only 1-2 domain files, and
+        # those files are plain data models (no branching money-movement logic)". The file count was
+        # re-confirmed; the NO-BRANCHING half was never measured, and it is FALSE for three of the
+        # seven (#2395). Measured on 2026-07-26, counting `if (` / `when (` / `require(` / `check(`
+        # over every `src/main/kotlin/**/domain/**.kt` in each module — a deliberately narrow matcher,
+        # so these are lower bounds:
+        #
+        #     service     domain files   branch sites
+        #     sca                    2             11
+        #     consent                2              6
+        #     swift                  1              5
+        #     clearing               3              1
+        #     billing                2              0
+        #     lending                1              0
+        #     settlement             1              0
+        #
+        # So the exclusion rests on a DIFFERENT judgement, and it is stated here rather than hidden
+        # behind an inaccurate blanket: what sca, consent and swift branch on is input VALIDATION and
+        # state-transition legality, not money-movement arithmetic — pitest's value is in the
+        # arithmetic, and no pitest plugin is wired for any of the 7. billing needs its own reason:
+        # its domain layer genuinely does not branch, but its real fee-waiver logic (ADR-0143 phase 2)
+        # lives in `application/usecase/FeeAssessmentService`, OUTSIDE pitest's `domain.*`
+        # targetClasses — so widening the target would be the fix there, not adding the module.
+        #
+        # Revisit if any of the 7 grows money-movement ARITHMETIC in its domain layer; a rising branch
+        # count alone is not the trigger, and re-measure before repeating any claim in this block.
+        # (Historical note: settlement and sanctions were both added to money_path_services after the
+        # 2026-07-07 note above; settlement re-confirmed thin, sanctions was the one that wasn't.)
         # True baselines at rollout (after fixing the KILLED-quote parsing bug): account 49%,
         # transaction 46%, balance 55%, ledger 65%, fx 73%.
         blocked_on: "blocking flip requires each service to sustain >=70% mutation kill score on the weekly run; account/transaction/balance/ledger are below it today (see baselines above)"

--- a/openbank-infra/gitops/components/statements/statement-service.yaml
+++ b/openbank-infra/gitops/components/statements/statement-service.yaml
@@ -26,7 +26,7 @@ spec:
       annotations:
         # Rolls the pod when the OPA bundle changes — subPath mounts do NOT hot-reload.
         # Kept in sync by gen-statement-opa-bundle.sh (do not hand-edit).
-        openbank.tech/policy-checksum: "fc01139e5926e7fd"
+        openbank.tech/policy-checksum: "27125c0ea2b3abaa"
       labels:
         app.kubernetes.io/name: statement-service
         app.kubernetes.io/part-of: statements

--- a/openbank-infra/gitops/components/statements/statement-service.yaml
+++ b/openbank-infra/gitops/components/statements/statement-service.yaml
@@ -26,7 +26,7 @@ spec:
       annotations:
         # Rolls the pod when the OPA bundle changes — subPath mounts do NOT hot-reload.
         # Kept in sync by gen-statement-opa-bundle.sh (do not hand-edit).
-        openbank.tech/policy-checksum: "f87ab950b3ddbf64"
+        openbank.tech/policy-checksum: "fc01139e5926e7fd"
       labels:
         app.kubernetes.io/name: statement-service
         app.kubernetes.io/part-of: statements

--- a/openbank-infra/gitops/components/tpp-registry/tpp-registry-opa-bundle.yaml
+++ b/openbank-infra/gitops/components/tpp-registry/tpp-registry-opa-bundle.yaml
@@ -9,7 +9,7 @@ metadata:
     app.kubernetes.io/name: tpp-registry-service
     app.kubernetes.io/part-of: tpp-registry
   annotations:
-    openbank.tech/policy-checksum: "2ea6a217d336340f"
+    openbank.tech/policy-checksum: "5b533deb8a477909"
 data:
   rest.rego: |
     # SPDX-License-Identifier: Apache-2.0
@@ -2233,12 +2233,36 @@ data:
         # fx + sepa-payment, sepa-instant, domestic-payment, fraud (SSDLC-audit rollout 2026-07-06) +
         # sanctions (2026-07-11: 3 domain files — screening/matching decision logic — matches the
         # "substantive domain math" criterion, not the thin-domain one; 67% local baseline).
-        # The remaining 7 (sca, consent, billing, clearing, swift, lending, settlement) stay excluded:
-        # each has only 1-2 domain files, and those files are plain data models (no branching
-        # money-movement logic), so mutation testing there is noise, not signal — re-confirmed by
-        # file count on 2026-07-11 (settlement and sanctions were both added to money_path_services
-        # after the 2026-07-07 note above; settlement re-confirmed thin, sanctions was the one that
-        # wasn't). Revisit if any of the remaining 7 grows real decision logic in its domain layer.
+        # The remaining 7 (sca, consent, billing, clearing, swift, lending, settlement) stay excluded.
+        #
+        # This list used to be justified by one blanket claim — "each has only 1-2 domain files, and
+        # those files are plain data models (no branching money-movement logic)". The file count was
+        # re-confirmed; the NO-BRANCHING half was never measured, and it is FALSE for three of the
+        # seven (#2395). Measured on 2026-07-26, counting `if (` / `when (` / `require(` / `check(`
+        # over every `src/main/kotlin/**/domain/**.kt` in each module — a deliberately narrow matcher,
+        # so these are lower bounds:
+        #
+        #     service     domain files   branch sites
+        #     sca                    2             11
+        #     consent                2              6
+        #     swift                  1              5
+        #     clearing               3              1
+        #     billing                2              0
+        #     lending                1              0
+        #     settlement             1              0
+        #
+        # So the exclusion rests on a DIFFERENT judgement, and it is stated here rather than hidden
+        # behind an inaccurate blanket: what sca, consent and swift branch on is input VALIDATION and
+        # state-transition legality, not money-movement arithmetic — pitest's value is in the
+        # arithmetic, and no pitest plugin is wired for any of the 7. billing needs its own reason:
+        # its domain layer genuinely does not branch, but its real fee-waiver logic (ADR-0143 phase 2)
+        # lives in `application/usecase/FeeAssessmentService`, OUTSIDE pitest's `domain.*`
+        # targetClasses — so widening the target would be the fix there, not adding the module.
+        #
+        # Revisit if any of the 7 grows money-movement ARITHMETIC in its domain layer; a rising branch
+        # count alone is not the trigger, and re-measure before repeating any claim in this block.
+        # (Historical note: settlement and sanctions were both added to money_path_services after the
+        # 2026-07-07 note above; settlement re-confirmed thin, sanctions was the one that wasn't.)
         # True baselines at rollout (after fixing the KILLED-quote parsing bug): account 49%,
         # transaction 46%, balance 55%, ledger 65%, fx 73%.
         blocked_on: "blocking flip requires each service to sustain >=70% mutation kill score on the weekly run; account/transaction/balance/ledger are below it today (see baselines above)"

--- a/openbank-infra/gitops/components/tpp-registry/tpp-registry-opa-bundle.yaml
+++ b/openbank-infra/gitops/components/tpp-registry/tpp-registry-opa-bundle.yaml
@@ -9,7 +9,7 @@ metadata:
     app.kubernetes.io/name: tpp-registry-service
     app.kubernetes.io/part-of: tpp-registry
   annotations:
-    openbank.tech/policy-checksum: "6de1614dedbbcdcf"
+    openbank.tech/policy-checksum: "2ea6a217d336340f"
 data:
   rest.rego: |
     # SPDX-License-Identifier: Apache-2.0
@@ -1539,9 +1539,9 @@ data:
           - "every route a resource class answers is published in that service's openapi.yaml"
           - "every route openapi.yaml promises is declared by a resource class"
         gate: openapi-route-conformance
-        enforced: advisory
-        target_enforce_date: "2026-09-30"
+        enforced: enforce                 # ADR-0144 graduation, ahead of the 2026-09-30 target (#2314)
         ci_producer: ".github/scripts/check-openapi-route-conformance.py"
+        baseline: ".github/openapi-route-conformance-baseline.txt"
         # api_contract (above) classifies a spec's version bump against the PREVIOUS REVISION of the
         # same document. Nothing asked whether the document is TRUE. ADR-0005 says "CI lints it with
         # Spectral so docs cannot drift from runtime" — there is no Spectral config in this repo and
@@ -1567,8 +1567,17 @@ data:
         # is a MISSING pair across two trees, so a PR touching only Kotlin never touches the spec and
         # a diff-scoped gate would see nothing.
         #
-        # Advisory because 114 pre-existing findings cannot be a merge blocker on day one. Flipping
-        # to enforced = add --enforce in ci.yml, once the backlog is cleared.
+        # ENFORCED AGAINST A DECLARED BASELINE (#2314). 104 pre-existing findings could not be a
+        # merge blocker on day one, and correcting a spec is blocked on the unsatisfiable-bump gap
+        # (#2313) — but leaving it advisory is the shape this repo has already ruled against: an
+        # advisory check over a GENERATED comparison has no judgement left to exercise, it just makes
+        # the drift mergeable (#2216). So the gate runs with --enforce against
+        # .github/openapi-route-conformance-baseline.txt, which declares those 104 findings verbatim.
+        # A finding NOT in that file fails the build (new drift, the thing the gate is for); a
+        # baseline line with no matching finding ALSO fails (the debt was paid — delete the line), so
+        # the declaration cannot outlive the debt. The baseline does not narrow what the gate LOOKS
+        # AT — every service is compared every run — which is what separates it from the
+        # pact-drift-check scope bug (#2284). #2314 closes when the file is empty.
       openapi_request_schema_conformance:
         detect: ["openbank-*/src/main/resources/openapi.yaml", "the JAX-RS request-body DTO the resource actually deserializes into"]
         require:

--- a/openbank-infra/gitops/components/tpp-registry/tpp-registry-service.yaml
+++ b/openbank-infra/gitops/components/tpp-registry/tpp-registry-service.yaml
@@ -23,7 +23,7 @@ spec:
       annotations:
         # Rolls the pod when the OPA bundle changes (subPath mounts do not hot-reload).
         # Kept in sync by gen-tpp-registry-opa-bundle.sh (do not hand-edit).
-        openbank.tech/policy-checksum: "6de1614dedbbcdcf"
+        openbank.tech/policy-checksum: "2ea6a217d336340f"
     spec:
       securityContext:
         runAsNonRoot: true

--- a/openbank-infra/gitops/components/tpp-registry/tpp-registry-service.yaml
+++ b/openbank-infra/gitops/components/tpp-registry/tpp-registry-service.yaml
@@ -23,7 +23,7 @@ spec:
       annotations:
         # Rolls the pod when the OPA bundle changes (subPath mounts do not hot-reload).
         # Kept in sync by gen-tpp-registry-opa-bundle.sh (do not hand-edit).
-        openbank.tech/policy-checksum: "2ea6a217d336340f"
+        openbank.tech/policy-checksum: "5b533deb8a477909"
     spec:
       securityContext:
         runAsNonRoot: true

--- a/openbank-libs/governance/rules.yaml
+++ b/openbank-libs/governance/rules.yaml
@@ -170,9 +170,9 @@ change_requirements:
       - "every route a resource class answers is published in that service's openapi.yaml"
       - "every route openapi.yaml promises is declared by a resource class"
     gate: openapi-route-conformance
-    enforced: advisory
-    target_enforce_date: "2026-09-30"
+    enforced: enforce                 # ADR-0144 graduation, ahead of the 2026-09-30 target (#2314)
     ci_producer: ".github/scripts/check-openapi-route-conformance.py"
+    baseline: ".github/openapi-route-conformance-baseline.txt"
     # api_contract (above) classifies a spec's version bump against the PREVIOUS REVISION of the
     # same document. Nothing asked whether the document is TRUE. ADR-0005 says "CI lints it with
     # Spectral so docs cannot drift from runtime" — there is no Spectral config in this repo and
@@ -198,8 +198,17 @@ change_requirements:
     # is a MISSING pair across two trees, so a PR touching only Kotlin never touches the spec and
     # a diff-scoped gate would see nothing.
     #
-    # Advisory because 114 pre-existing findings cannot be a merge blocker on day one. Flipping
-    # to enforced = add --enforce in ci.yml, once the backlog is cleared.
+    # ENFORCED AGAINST A DECLARED BASELINE (#2314). 104 pre-existing findings could not be a
+    # merge blocker on day one, and correcting a spec is blocked on the unsatisfiable-bump gap
+    # (#2313) — but leaving it advisory is the shape this repo has already ruled against: an
+    # advisory check over a GENERATED comparison has no judgement left to exercise, it just makes
+    # the drift mergeable (#2216). So the gate runs with --enforce against
+    # .github/openapi-route-conformance-baseline.txt, which declares those 104 findings verbatim.
+    # A finding NOT in that file fails the build (new drift, the thing the gate is for); a
+    # baseline line with no matching finding ALSO fails (the debt was paid — delete the line), so
+    # the declaration cannot outlive the debt. The baseline does not narrow what the gate LOOKS
+    # AT — every service is compared every run — which is what separates it from the
+    # pact-drift-check scope bug (#2284). #2314 closes when the file is empty.
   openapi_request_schema_conformance:
     detect: ["openbank-*/src/main/resources/openapi.yaml", "the JAX-RS request-body DTO the resource actually deserializes into"]
     require:

--- a/openbank-libs/governance/rules.yaml
+++ b/openbank-libs/governance/rules.yaml
@@ -864,12 +864,36 @@ coverage:
     # fx + sepa-payment, sepa-instant, domestic-payment, fraud (SSDLC-audit rollout 2026-07-06) +
     # sanctions (2026-07-11: 3 domain files — screening/matching decision logic — matches the
     # "substantive domain math" criterion, not the thin-domain one; 67% local baseline).
-    # The remaining 7 (sca, consent, billing, clearing, swift, lending, settlement) stay excluded:
-    # each has only 1-2 domain files, and those files are plain data models (no branching
-    # money-movement logic), so mutation testing there is noise, not signal — re-confirmed by
-    # file count on 2026-07-11 (settlement and sanctions were both added to money_path_services
-    # after the 2026-07-07 note above; settlement re-confirmed thin, sanctions was the one that
-    # wasn't). Revisit if any of the remaining 7 grows real decision logic in its domain layer.
+    # The remaining 7 (sca, consent, billing, clearing, swift, lending, settlement) stay excluded.
+    #
+    # This list used to be justified by one blanket claim — "each has only 1-2 domain files, and
+    # those files are plain data models (no branching money-movement logic)". The file count was
+    # re-confirmed; the NO-BRANCHING half was never measured, and it is FALSE for three of the
+    # seven (#2395). Measured on 2026-07-26, counting `if (` / `when (` / `require(` / `check(`
+    # over every `src/main/kotlin/**/domain/**.kt` in each module — a deliberately narrow matcher,
+    # so these are lower bounds:
+    #
+    #     service     domain files   branch sites
+    #     sca                    2             11
+    #     consent                2              6
+    #     swift                  1              5
+    #     clearing               3              1
+    #     billing                2              0
+    #     lending                1              0
+    #     settlement             1              0
+    #
+    # So the exclusion rests on a DIFFERENT judgement, and it is stated here rather than hidden
+    # behind an inaccurate blanket: what sca, consent and swift branch on is input VALIDATION and
+    # state-transition legality, not money-movement arithmetic — pitest's value is in the
+    # arithmetic, and no pitest plugin is wired for any of the 7. billing needs its own reason:
+    # its domain layer genuinely does not branch, but its real fee-waiver logic (ADR-0143 phase 2)
+    # lives in `application/usecase/FeeAssessmentService`, OUTSIDE pitest's `domain.*`
+    # targetClasses — so widening the target would be the fix there, not adding the module.
+    #
+    # Revisit if any of the 7 grows money-movement ARITHMETIC in its domain layer; a rising branch
+    # count alone is not the trigger, and re-measure before repeating any claim in this block.
+    # (Historical note: settlement and sanctions were both added to money_path_services after the
+    # 2026-07-07 note above; settlement re-confirmed thin, sanctions was the one that wasn't.)
     # True baselines at rollout (after fixing the KILLED-quote parsing bug): account 49%,
     # transaction 46%, balance 55%, ledger 65%, fx 73%.
     blocked_on: "blocking flip requires each service to sustain >=70% mutation kill score on the weekly run; account/transaction/balance/ledger are below it today (see baselines above)"


### PR DESCRIPTION
## What

`.github/scripts/check-openapi-route-conformance.py` was wired at `ci.yml` **without `--enforce`** — `::warning`, exit 0. Per this repo's own rule, an advisory check over a *generated* comparison is a contradiction: there is no judgement left to exercise, advisory just makes the drift mergeable (#2216).

## Why a baseline, not a straight flip

Measured on `origin/main` today: **104 route-level findings across 21 services**. Correcting a spec is blocked on the unsatisfiable-bump gap (#2313), so the backlog cannot be drained in one PR — and leaving it advisory indefinitely is the failure this issue is about.

So the gate is **enforced against a declared baseline** (`.github/openapi-route-conformance-baseline.txt`), in the `KNOWN_UNCOVERED` shape of `check-pact-provider-replay.py`:

| condition | result |
|---|---|
| a finding **not** in the baseline | NEW drift — build fails |
| a baseline line with **no** matching finding | debt paid — build fails until the line is deleted |

The baseline does **not** narrow what the gate looks at — every service is compared on every run. That is the distinction from the `pact-drift-check.yml` scope bug (#2284), where the coverage *set* was hand-kept and a missing module read as green. Here the exclusions are the thing a human has to justify, and the declaration cannot outlive the debt.

## Falsification (read the output, not the exit code)

| input | printed | exit |
|---|---|---|
| clean tree | `104 findings, 104 declared, 0 NEW, 0 stale` | 0 |
| bogus baseline line | `::error:: STALE baseline entry — …` | 1 |
| unserved path added to fx's `openapi.yaml` | `::error:: published-not-served — GET /fx/bogus-new-route …` | 1 |
| baseline line deleted without fixing the spec | that finding reported as NEW | 1 |

## Also

- `rules.yaml: openapi_route_conformance` flips `enforced: advisory` → `enforce` (ADR-0144 graduation, ahead of the 2026-09-30 target) and records the baseline path.
- That restamps every OPA bundle + pod-roll annotation. All `gen-*opa-bundle*.sh` were re-run **as the last step, after the final `rules.yaml` edit** (the #2457 trap). No bundle hand-edited.
- No new `actionlint` or `yamllint` finding classes vs `origin/main` (finding *sets* diffed, not just exit codes); no new duplicate keys in `rules.yaml`.

`Refs #2314` — the issue closes when the baseline file is empty, i.e. when the 104 spec corrections land.

---

## Second commit: `docs(governance)` — #2395, folded in deliberately

#2395's triage explicitly deferred itself with the reason *"a documentation-only correction lands as a ~65-file PR with a short shelf life … a few minutes' work for whoever picks it up **alongside another rules.yaml change**"*. This is that change — folding it in costs one bundle regeneration instead of two conflicting ones.

`money_path_depth` excluded 7 money-path services from pitest behind one blanket sentence: *"those files are plain data models (no branching money-movement logic)"*. The file count was real; the no-branching half was never measured and is **false for three of the seven**. Measured (`if (` / `when (` / `require(` / `check(` over every `src/main/kotlin/**/domain/**.kt`, narrow matcher so these are lower bounds):

| service | domain files | branch sites |
|---|---|---|
| sca | 2 | **11** |
| consent | 2 | **6** |
| swift | 1 | **5** |
| clearing | 3 | 1 |
| billing | 2 | 0 |
| lending | 1 | 0 |
| settlement | 1 | 0 |

The exclusions stay — but for a stated reason instead of an inaccurate blanket: sca/consent/swift branch on input validation and state-transition legality, not money-movement arithmetic. billing needs a third reason again (its fee-waiver logic is in `application/usecase/FeeAssessmentService`, outside pitest's `domain.*` targetClasses). The revisit trigger is corrected to *arithmetic*, since a rising branch count alone is not it.

`Closes #2395`