### PR TITLE
feat(mcp): enforce the charter's data_scope.pii masking on every tool result

### DIFF
--- a/openbank-mcp-service/src/main/kotlin/com/openbank/mcp/application/McpPiiMasker.kt
+++ b/openbank-mcp-service/src/main/kotlin/com/openbank/mcp/application/McpPiiMasker.kt
@@ -1,0 +1,98 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+// Copyright (c) OpenBank contributors. Licensed under the GNU Affero General Public License v3.0 only.
+// A commercial licence is available from the maintainers as an alternative to the AGPL-3.0.
+// See LICENSES/AGPL-3.0-only.txt or https://www.gnu.org/licenses/agpl-3.0.html for details.
+package com.openbank.mcp.application
+
+import com.fasterxml.jackson.databind.JsonNode
+import com.fasterxml.jackson.databind.ObjectMapper
+import com.fasterxml.jackson.databind.node.ObjectNode
+import com.fasterxml.jackson.databind.node.TextNode
+import jakarta.enterprise.context.ApplicationScoped
+
+/**
+ * Enforces the `mcp-anonymous` charter's `data_scope.pii: masked`
+ * (`openbank-libs/governance/agents.yaml`) on everything an MCP tool hands back to a calling model.
+ *
+ * Until this existed the charter advertised a control that no code implemented: after ADR-0195
+ * step 4 wired the real read ports, `get_balance` / `list_transactions` / `list_accounts` returned
+ * raw IBANs, account-holder and counterparty names and free-text remittance narratives verbatim
+ * into a model context (#2412). The masking is applied ONCE, as a single response-shaping step in
+ * [McpToolRegistry.call], deliberately not field-by-field inside each read adapter — a per-adapter
+ * policy drifts per tool, and a NEW tool would silently ship unmasked.
+ *
+ * Policy (deny-by-default in spirit: an unrecognised field is left alone only because it is not
+ * PII-shaped; anything that *looks* like an IBAN is masked wherever it appears, whatever its key):
+ *  - IBAN-shaped values and IBAN-named fields keep only the last [IBAN_TAIL] characters, so a model
+ *    can still correlate "the account ending 1234" across tool calls without holding the identifier.
+ *  - Natural-person identifiers (names, contact details, addresses, national/tax/document ids,
+ *    dates of birth) and free-text payment narratives are replaced wholesale with [MASK].
+ *  - Amounts, currencies, timestamps, statuses and internal surrogate ids are NOT masked — they
+ *    carry no natural-person identity and are the whole point of a consent-scoped read.
+ *
+ * Masking is unconditional: there is no config toggle, because the only charter this service acts
+ * under says `masked` and a switch that can turn a declared control off is how the declaration
+ * became fiction in the first place.
+ */
+@ApplicationScoped
+class McpPiiMasker(private val mapper: ObjectMapper) {
+
+    /** Returns a masked deep copy of [node]; the input is never mutated. */
+    fun mask(node: JsonNode): JsonNode = maskNode(node, fieldName = null)
+
+    private fun maskNode(node: JsonNode, fieldName: String?): JsonNode = when {
+        node.isObject -> maskObject(node)
+        node.isArray -> mapper.createArrayNode().apply {
+            node.forEach { add(maskNode(it, fieldName)) }
+        }
+        node.isTextual -> maskText(node.asText(), fieldName)
+        else -> node
+    }
+
+    private fun maskObject(node: JsonNode): ObjectNode = mapper.createObjectNode().apply {
+        node.fields().forEach { (name, value) -> set<JsonNode>(name, maskNode(value, name)) }
+    }
+
+    private fun maskText(value: String, fieldName: String?): JsonNode {
+        val key = fieldName?.lowercase().orEmpty()
+        return when {
+            IBAN_FIELDS.any { key.contains(it) } || looksLikeIban(value) -> TextNode.valueOf(tail(value))
+            // A surrogate id (account/consent/transaction UUID) identifies a row, not a person, and
+            // is what lets a model chain one tool call into the next — never redacted.
+            UUID_PATTERN.matches(value) -> TextNode.valueOf(value)
+            REDACTED_FIELDS.any { key.contains(it) } -> TextNode.valueOf(MASK)
+            else -> TextNode.valueOf(value)
+        }
+    }
+
+    private fun looksLikeIban(value: String): Boolean = IBAN_PATTERN.matches(value.replace(" ", ""))
+
+    /** Keeps the last [IBAN_TAIL] characters of an identifier, e.g. `CZ65…4567` -> `****4567`. */
+    private fun tail(value: String): String {
+        val compact = value.replace(" ", "")
+        return if (compact.length <= IBAN_TAIL) MASK else MASK_PREFIX + compact.takeLast(IBAN_TAIL)
+    }
+
+    private companion object {
+        const val MASK = "***"
+        const val MASK_PREFIX = "****"
+        const val IBAN_TAIL = 4
+
+        val IBAN_PATTERN = Regex("^[A-Z]{2}[0-9]{2}[A-Z0-9]{10,30}$")
+        val UUID_PATTERN = Regex("^[0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{12}$")
+
+        /** Field-name fragments whose value is an account identifier — masked to a correlatable tail. */
+        val IBAN_FIELDS = setOf("iban", "accountnumber", "bban", "pan", "cardnumber")
+
+        /**
+         * Field-name fragments whose value identifies a natural person or is free text a payer
+         * typed (which routinely carries a name, a phone number or a case reference).
+         */
+        val REDACTED_FIELDS = setOf(
+            "name", "holder", "owner", "counterparty", "payee", "payer", "debtor", "creditor",
+            "email", "phone", "msisdn", "address", "street", "city", "postal", "zip",
+            "birth", "nationalid", "personalid", "taxid", "ssn", "passport", "identitydocument",
+            "narrative", "description", "remittance", "memo", "note", "message", "purpose",
+        )
+    }
+}

--- a/openbank-mcp-service/src/main/kotlin/com/openbank/mcp/application/McpPiiMasker.kt
+++ b/openbank-mcp-service/src/main/kotlin/com/openbank/mcp/application/McpPiiMasker.kt
@@ -50,7 +50,7 @@ class McpPiiMasker(private val mapper: ObjectMapper) {
     }
 
     private fun maskObject(node: JsonNode): ObjectNode = mapper.createObjectNode().apply {
-        node.fields().forEach { (name, value) -> set<JsonNode>(name, maskNode(value, name)) }
+        node.properties().forEach { (name, value) -> set<JsonNode>(name, maskNode(value, name)) }
     }
 
     private fun maskText(value: String, fieldName: String?): JsonNode {

--- a/openbank-mcp-service/src/main/kotlin/com/openbank/mcp/application/McpToolRegistry.kt
+++ b/openbank-mcp-service/src/main/kotlin/com/openbank/mcp/application/McpToolRegistry.kt
@@ -25,6 +25,7 @@ import jakarta.enterprise.context.ApplicationScoped
 class McpToolRegistry(
     private val accounts: AccountReadPort,
     private val proposals: ProposalPort,
+    private val masker: McpPiiMasker,
     private val mapper: ObjectMapper,
 ) {
 
@@ -107,7 +108,9 @@ class McpToolRegistry(
             "propose_payment" -> proposals.proposePayment(ctx, arguments)
             else -> return ToolCallResult(listOf(ToolContent(text = "Unknown tool: $toolName")), isError = true)
         }
-        return ToolCallResult(listOf(ToolContent(text = mapper.writeValueAsString(result))))
+        // The charter's `data_scope.pii: masked` (agents.yaml, `mcp-anonymous`) is enforced HERE —
+        // one response-shaping step every tool passes through, so a new tool cannot forget it (#2412).
+        return ToolCallResult(listOf(ToolContent(text = mapper.writeValueAsString(masker.mask(result)))))
     }
 
     private fun JsonNode.reqText(field: String): String = path(field).takeIf { it.isTextual }?.asText()

--- a/openbank-mcp-service/src/test/kotlin/com/openbank/mcp/McpEndpointTest.kt
+++ b/openbank-mcp-service/src/test/kotlin/com/openbank/mcp/McpEndpointTest.kt
@@ -11,6 +11,7 @@ import com.openbank.libs.authz.AuthzDecision
 import com.openbank.libs.authz.AuthzQuery
 import com.openbank.libs.authz.PolicyDecisionPoint
 import com.openbank.mcp.application.McpCallAuditor
+import com.openbank.mcp.application.McpPiiMasker
 import com.openbank.mcp.application.McpToolRegistry
 import com.openbank.mcp.application.port.out.AccountReadPort
 import com.openbank.mcp.application.port.out.ConsentContext
@@ -43,7 +44,7 @@ class McpEndpointTest {
     // below builds its own endpoint with an anonymous JWT to cover that (now denying) path instead.
     private fun endpoint(pdp: PolicyDecisionPoint, jwt: TestJsonWebToken = testAgentJwt()): McpEndpoint {
         val stub = StubReads(mapper)
-        val toolRegistry = McpToolRegistry(stub, stub, mapper)
+        val toolRegistry = McpToolRegistry(stub, stub, McpPiiMasker(mapper), mapper)
         val caller = CallerContextResolver(jwt)
         return McpEndpoint(
             registry = toolRegistry,

--- a/openbank-mcp-service/src/test/kotlin/com/openbank/mcp/application/McpPiiMaskingTest.kt
+++ b/openbank-mcp-service/src/test/kotlin/com/openbank/mcp/application/McpPiiMaskingTest.kt
@@ -1,0 +1,102 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+// Copyright (c) OpenBank contributors. Licensed under the GNU Affero General Public License v3.0 only.
+package com.openbank.mcp.application
+
+import com.fasterxml.jackson.databind.JsonNode
+import com.fasterxml.jackson.databind.ObjectMapper
+import com.openbank.mcp.application.port.out.AccountReadPort
+import com.openbank.mcp.application.port.out.ConsentContext
+import com.openbank.mcp.application.port.out.ProposalPort
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Assertions.assertFalse
+import org.junit.jupiter.api.Assertions.assertTrue
+import org.junit.jupiter.api.Test
+
+/**
+ * The `mcp-anonymous` charter advertises `data_scope.pii: masked` (agents.yaml). These assertions
+ * are what makes that true rather than documentation (#2412): they fail against the pre-fix
+ * `McpToolRegistry.call`, which serialized the read port's response verbatim into the model-facing
+ * `ToolCallResult`.
+ */
+class McpPiiMaskingTest {
+
+    private val mapper = ObjectMapper()
+    private val masker = McpPiiMasker(mapper)
+    private val ctx = ConsentContext("agent:mcp-anonymous", "11111111-2222-3333-4444-555555555555", emptyList())
+
+    private val accountJson = """
+        {
+          "id": "6f1d2c3b-4a5e-4f60-8a71-9b0c1d2e3f40",
+          "iban": "CZ6508000000192000145399",
+          "holderName": "Jan Novak",
+          "currency": "CZK",
+          "status": "ACTIVE"
+        }
+    """.trimIndent()
+
+    private val transactionsJson = """
+        [
+          {
+            "id": "7a2e3f40-5b6c-4d7e-8f90-0a1b2c3d4e5f",
+            "amount": "1250.00",
+            "currency": "CZK",
+            "counterpartyIban": "DE89370400440532013000",
+            "counterpartyName": "Petra Svobodova",
+            "remittanceInformation": "rent June, contact 777123456",
+            "bookedAt": "2026-06-01T10:15:30Z"
+          }
+        ]
+    """.trimIndent()
+
+    private fun registry(payload: String) = McpToolRegistry(
+        accounts = FixedReadPort(mapper.readTree(payload)),
+        proposals = DenyingProposalPort,
+        masker = masker,
+        mapper = mapper,
+    )
+
+    @Test
+    fun `list_accounts never returns a raw IBAN or holder name to the model`() {
+        val text = registry(accountJson).call("list_accounts", mapper.createObjectNode(), ctx).content.single().text
+
+        assertFalse(text.contains("CZ6508000000192000145399"), "raw IBAN leaked to the model: $text")
+        assertFalse(text.contains("Jan Novak"), "raw holder name leaked to the model: $text")
+        assertTrue(text.contains("****5399"), "expected a correlatable IBAN tail, got: $text")
+        // Non-PII payload must survive: masking that ate the answer would be a different bug.
+        assertTrue(text.contains("ACTIVE") && text.contains("CZK"), "non-PII fields were masked: $text")
+        assertTrue(text.contains("6f1d2c3b-4a5e-4f60-8a71-9b0c1d2e3f40"), "surrogate id was masked: $text")
+    }
+
+    @Test
+    fun `list_transactions never returns a counterparty name or a free-text narrative`() {
+        val args = mapper.createObjectNode().put("accountId", "CZ6508000000192000145399")
+        val text = registry(transactionsJson).call("list_transactions", args, ctx).content.single().text
+
+        assertFalse(text.contains("Petra Svobodova"), "counterparty name leaked: $text")
+        assertFalse(text.contains("777123456"), "narrative PII leaked: $text")
+        assertFalse(text.contains("DE89370400440532013000"), "counterparty IBAN leaked: $text")
+        assertTrue(text.contains("1250.00"), "the amount — the point of the read — was masked: $text")
+    }
+
+    @Test
+    fun `an IBAN-shaped value is masked wherever it appears, whatever the field is called`() {
+        val node = mapper.readTree("""{"somethingElse":"GB33BUKB20201555555555","free":["CZ6508000000192000145399"]}""")
+
+        val masked = masker.mask(node)
+
+        assertEquals("****5555", masked.path("somethingElse").asText())
+        assertEquals("****5399", masked.path("free").path(0).asText())
+    }
+
+    private class FixedReadPort(private val payload: JsonNode) : AccountReadPort {
+        override fun listAccounts(consentContext: ConsentContext): JsonNode = payload
+        override fun getBalance(consentContext: ConsentContext, accountId: String): JsonNode = payload
+        override fun listTransactions(consentContext: ConsentContext, accountId: String, limit: Int): JsonNode = payload
+        override fun listConsents(consentContext: ConsentContext): JsonNode = payload
+    }
+
+    private object DenyingProposalPort : ProposalPort {
+        override fun proposePayment(consentContext: ConsentContext, request: JsonNode): JsonNode =
+            error("not exercised by this test")
+    }
+}

--- a/openbank-mcp-service/src/test/kotlin/com/openbank/mcp/application/McpPiiMaskingTest.kt
+++ b/openbank-mcp-service/src/test/kotlin/com/openbank/mcp/application/McpPiiMaskingTest.kt
@@ -88,6 +88,32 @@ class McpPiiMaskingTest {
         assertEquals("****5399", masked.path("free").path(0).asText())
     }
 
+    /**
+     * Guards the object-recursion path itself: masking walks an object's properties and rebuilds
+     * it, so a nested object must be descended into and every sibling key preserved. A recursion
+     * that silently visited only the top level would still pass the flat-payload assertions above.
+     */
+    @Test
+    fun `masking descends into a nested object and preserves every key`() {
+        val node = mapper.readTree(
+            """
+            {
+              "status": "ACTIVE",
+              "owner": {"holderName": "Jan Novak", "iban": "CZ6508000000192000145399", "currency": "CZK"}
+            }
+            """.trimIndent(),
+        )
+
+        val masked = masker.mask(node)
+
+        assertEquals("***", masked.path("owner").path("holderName").asText())
+        assertEquals("****5399", masked.path("owner").path("iban").asText())
+        assertEquals("CZK", masked.path("owner").path("currency").asText())
+        assertEquals("ACTIVE", masked.path("status").asText())
+        assertEquals(2, masked.size(), "a key was dropped while rebuilding the object: $masked")
+        assertEquals(3, masked.path("owner").size(), "a nested key was dropped: $masked")
+    }
+
     private class FixedReadPort(private val payload: JsonNode) : AccountReadPort {
         override fun listAccounts(consentContext: ConsentContext): JsonNode = payload
         override fun getBalance(consentContext: ConsentContext, accountId: String): JsonNode = payload


### PR DESCRIPTION
## Why

`openbank-libs/governance/agents.yaml` declares, for the `mcp-anonymous` charter, `data_scope: { pii: masked }`. Nothing in `openbank-mcp-service` ever read `data_scope`. Before #2316 that was latent — the tools returned a stub note. After it, the four read tools return real balances, IBANs, holder/counterparty names and free-text remittance narratives straight into a calling model's context. The declaration was documentation, not a control.

## What

- `McpPiiMasker` (application layer): a deep, non-mutating JSON walk that
  - masks IBAN-shaped values **wherever they appear, whatever the field is called**, keeping a correlatable 4-character tail (`****5399`), so a model can still say "the account ending 5399";
  - redacts natural-person identifiers (names, contact details, addresses, national/tax/document ids, birth dates) and payer free text (narrative / remittance / memo / purpose);
  - leaves amounts, currencies, timestamps, statuses and surrogate UUIDs alone — masking that ate the answer would be a different bug.
- Applied in `McpToolRegistry.call`, i.e. **once**, at the single point every tool result passes through. Deliberately not field-by-field in the read adapters: that policy drifts per tool, and a new tool would silently ship unmasked.
- No config toggle. The only charter this service acts under says `masked`, and a switch that can turn a declared control off is how the declaration became fiction in the first place.

## Falsification

The new assertions were run against the **unfixed** `McpToolRegistry.call` first (masking removed): 2 of the 3 tests fail, on the raw IBAN, the holder name, the counterparty name and the narrative. With the masking restored, all 3 pass. The third test exercises `McpPiiMasker` directly, so it is green either way by construction.

Gate run locally: `:openbank-mcp-service:test detekt ktlintCheck quarkusBuild` — green (quarkusBuild included so an ArC/CDI wiring failure on the new bean would surface).

## Scope

`Refs` rather than `Closes`: this implements the masking the charter advertises, but does not add a CI gate binding the code to `agents.yaml` — a charter that flips `pii` to something else still would not change behaviour. That binding is worth a follow-up; the leak is what was urgent.

Refs #2412