### PR TITLE
docs(admin-ui): correct the compliance row that contradicts its own page

### DIFF
--- a/openbank-admin-ui/src/app/docs/compliance/page.tsx
+++ b/openbank-admin-ui/src/app/docs/compliance/page.tsx
@@ -93,7 +93,7 @@ const COMPLIANCE_AREAS: ComplianceArea[] = [
     id: 'cnb',
     title: ['Regulace ČNB (CZ)', 'CNB Regulation (CZ)'],
     authority: ['Česká národní banka', 'Czech National Bank'],
-    status: 'compliant',
+    status: 'partial',
     items: [
       { req: ['Konstantní symbol (platební styk)', 'Constant symbol (payment system)'], status: 'ok', note: ['constant_symbol s regex constraint V2', 'constant_symbol with regex constraint V2'] },
       { req: ['Specifický symbol', 'Specific symbol'], status: 'ok', note: ['specific_symbol v domestic_payments V2', 'specific_symbol in domestic_payments V2'] },
@@ -101,7 +101,7 @@ const COMPLIANCE_AREAS: ComplianceArea[] = [
       { req: ['Monitoring dormance', 'Dormancy monitoring'], status: 'ok', note: ['dormancy_date + idx_accounts_dormancy V2', 'dormancy_date + idx_accounts_dormancy V2'] },
       { req: ['Přidělení IBAN', 'IBAN allocation'], status: 'ok', note: ['sloupec iban + unique index v accounts V2', 'iban column + unique index in accounts V2'] },
       { req: ['Regulatorní výkaznický kód', 'Regulatory reporting code'], status: 'ok', note: ['regulatory_reporting_code v transactions V2, výkaznictví AnaCredit přes anacredit-service', 'regulatory_reporting_code in transactions V2, AnaCredit reporting via anacredit-service'] },
-      { req: ['Záznamy 10 let po uzavření', 'Records for 10 years after closure'], status: 'ok', note: ['data_retention_until v accounts V2', 'data_retention_until in accounts V2'] },
+      { req: ['Záznamy 10 let po uzavření', 'Records for 10 years after closure'], status: 'warn', note: ['data_retention_until (accounts V2) — sloupec bez čtenáře v kódu, stejný jako řádek „Politika uchovávání dat“, issue #2370', 'data_retention_until (accounts V2) — column has no code reader, same as the "Data retention policy" row, issue #2370'] },
     ],
   },
   {


### PR DESCRIPTION
## What

`openbank-admin-ui/src/app/docs/compliance/page.tsx` contradicted itself:

| section | row | status | evidence |
|---|---|---|---|
| GDPR | Data retention policy | `warn` | `data_retention_until` (accounts + parties V2) — **column has no code reader**, #2370 |
| CNB | Records for 10 years after closure | `ok` | `data_retention_until in accounts V2` |

The same column, cited as dead in one row and as the sole proof of compliance in another. PR #2378 fixed the six citation errors this issue named; this one was 29 lines further down and survived.

Relabelled `warn` with the same note; the CNB area status follows the GDPR area's precedent (`compliant` → `partial`) now that it carries a warn row. No judgement was involved — the page already stated the fact that falsifies the green.

## Evidence

Probe run with a known-positive control (`iban` → 5 files) so a false "0 results" could not pass as evidence. `data_retention_until` appears in **two Flyway migrations** (`openbank-account-service/…/V4__compliance_fields.sql`, `openbank-party-service/…/V2__compliance_fields.sql`) and in **zero** Kotlin files, snake_case or camelCase.

## Deliberately not in scope

The same probe found **20 more `ok` rows** whose only evidence is a DB column no Kotlin reads. Those are *not* mechanically the same finding — some (`no_update_audit`, `idx_accounts_dormancy`) are DB rules and indexes that need no code reader to be true, so relabelling them is a per-row judgement, and the mechanism question (Option A generator vs Option B honest downgrade) is owner-gated on #2370. The measurement is posted on that issue.

`Refs #2370` — the remaining half is the gate, still an owner decision.