### PR TITLE
docs(copilot): say "money-path adjacent", not "money-path service"

### DIFF
--- a/openbank-copilot-service/CLAUDE.md
+++ b/openbank-copilot-service/CLAUDE.md
@@ -1,7 +1,9 @@
 # openbank-copilot-service
 
 Customer-facing AI assistant (mobile copilot) for the KMP app (ADR-0064/0065). **ADR-0089** is the
-source of truth; **money-path** service (action tools propose state changes). Threat model:
+source of truth; **money-path adjacent**: action tools *propose* state changes that other services
+execute — this service never moves funds and never completes SCA, and it is deliberately NOT in
+`rules.yaml: money_path_services` (#2352). Threat model:
 [`docs/threat-models/openbank-copilot-service.md`](../docs/threat-models/openbank-copilot-service.md).
 
 ## The one principle


### PR DESCRIPTION
## What

`openbank-copilot-service/CLAUDE.md` opened with *"**money-path** service (action tools propose state changes)"*. In this repo "money-path" is not descriptive prose — it names membership of `rules.yaml: money_path_services`, which arms:

- the 2-approval + threat-model requirement (`change_classes`)
- `t0_baseline: money_path_services` — T0 tier membership
- the Pyrra availability + latency SLO pair (`check-slo-registry.py`, a required check)
- `money_path_scopes` in `rest.rego` — a service absent from the list derives no scope

copilot is in none of them, so the line was a false membership claim.

## Why this is a reconciliation, not a decision

The same file already contradicted it two paragraphs down — *"the model proposes; the bank disposes"*, *"money never moves on the model's word"*, action tools emit a proposal gated by HITL + SCA that **other services** execute. The wording now matches the file's own principle and states explicitly that the absence from `money_path_services` is deliberate, so the next reader does not re-open the question from the doc alone.

## What is deliberately NOT here

Whether copilot *should* join `money_path_services` stays open on #2352. That direction is a coordinated change — list + threat model + Pyrra SLO pair (the PR is red until they exist) + `money_path_scopes` + a full OPA bundle restamp — and is an owner call, not a one-line fix.

`Refs #2352`