### PR TITLE
feat(mcp): rate-limit tools/call per acting agent

### DIFF
--- a/openbank-mcp-service/src/main/kotlin/com/openbank/mcp/infrastructure/mcp/McpEndpoint.kt
+++ b/openbank-mcp-service/src/main/kotlin/com/openbank/mcp/infrastructure/mcp/McpEndpoint.kt
@@ -25,6 +25,7 @@ import com.openbank.mcp.application.protocol.ServerInfo
 import com.openbank.mcp.application.protocol.ToolCallResult
 import com.openbank.mcp.application.protocol.ToolContent
 import com.openbank.mcp.application.protocol.ToolsListResult
+import com.openbank.mcp.infrastructure.ratelimit.McpRateLimiter
 import jakarta.inject.Inject
 import jakarta.ws.rs.Consumes
 import jakarta.ws.rs.POST
@@ -93,6 +94,10 @@ class McpEndpoint(
      */
     @Inject
     lateinit var metrics: McpMetricsPort
+
+    /** Field-injected for the same reason as [metrics] — see the note above. */
+    @Inject
+    lateinit var rateLimiter: McpRateLimiter
 
     private val log = Logger.getLogger(McpEndpoint::class.java)
 
@@ -193,6 +198,16 @@ class McpEndpoint(
             val reason = decision.reason ?: "no matching allow rule"
             audit(capability, McpCallAuditor.Decision.DENY, AuditResult.DENIED, reason)
             return toolError(id, "Denied by policy: $reason")
+        }
+
+        // Rate limit AFTER the PDP decision, so a denied caller cannot burn the acting agent's
+        // window, and BEFORE the tool executes, which is the fan-out into consent/account/balance/
+        // transaction-service this bounds (#2409). A throttled call is a DENY like any other: same
+        // audit event, same meter, so the aggregate cannot disagree with the trail.
+        val limit = rateLimiter.check(ctx.agentId)
+        if (limit != McpRateLimiter.Outcome.ALLOWED) {
+            audit(capability, McpCallAuditor.Decision.DENY, AuditResult.DENIED, limit.reason)
+            return toolError(id, "Rate limit exceeded: ${limit.reason}")
         }
 
         return try {

--- a/openbank-mcp-service/src/main/kotlin/com/openbank/mcp/infrastructure/ratelimit/McpRateLimiter.kt
+++ b/openbank-mcp-service/src/main/kotlin/com/openbank/mcp/infrastructure/ratelimit/McpRateLimiter.kt
@@ -1,0 +1,121 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+// Copyright (c) OpenBank contributors. Licensed under the GNU Affero General Public License v3.0 only.
+// A commercial licence is available from the maintainers as an alternative to the AGPL-3.0.
+// See LICENSES/AGPL-3.0-only.txt or https://www.gnu.org/licenses/agpl-3.0.html for details.
+package com.openbank.mcp.infrastructure.ratelimit
+
+import jakarta.enterprise.context.ApplicationScoped
+import org.eclipse.microprofile.config.inject.ConfigProperty
+import java.time.Clock
+import java.time.Instant
+import java.util.concurrent.ConcurrentHashMap
+import java.util.concurrent.atomic.AtomicLong
+
+/**
+ * Per-acting-agent rate limit on `tools/call` (#2409).
+ *
+ * **Why this is a control and not throughput management.** Every MCP read tool fans out into
+ * consent-service *and* one of account / balance / transaction-service (see
+ * `infrastructure/read/RealAccountReadPort`), so an unthrottled MCP surface is an amplification
+ * vector into four services, three of them on the money path. Authorization cannot bound it: a
+ * governed agent is *supposed* to be able to read the accounts its consent grants, so the only
+ * thing separating "an agent answering a question" from "an agent draining a consent's whole
+ * transaction history in a loop" is the rate. The `mcp-anonymous` charter already declares
+ * `limits: { runs_per_day: 1000 }` in `openbank-libs/governance/agents.yaml`; until now nothing
+ * read it, and the declared limit was documentation.
+ *
+ * Two windows, because they answer different questions: the per-minute window bounds the burst
+ * (the amplification/DoS shape), the per-day window is the charter's `runs_per_day` budget.
+ *
+ * **In-process, not Valkey — deliberately, and with an expiry date.** `VopRateLimiter` is
+ * Valkey-backed because vop-service runs multiple replicas, where a local counter gives an
+ * attacker `limit × replicas`. `openbank-mcp-service` runs `replicas: 1`
+ * (`openbank-infra/gitops/components/mcp/mcp-service.yaml`), so today the two are exactly
+ * equivalent and the local counter buys the control without adding a store, a secret, an egress
+ * NetworkPolicy and a shared-state single point to a surface that has none. That equivalence is a
+ * property of the replica count, NOT of the design: the day mcp-service scales past one replica
+ * this must move to the shared window, which is why the counter lives behind this class rather
+ * than inline in the endpoint. The limit is also reset by a pod roll — acceptable for a burst
+ * bound, not for a hard daily budget, which is the second reason the Valkey swap is on the table.
+ */
+@ApplicationScoped
+class McpRateLimiter {
+
+    /** Not injected: no `Clock` producer bean exists in this service. Overridden by tests. */
+    var clock: Clock = Clock.systemUTC()
+
+    @ConfigProperty(name = "openbank.mcp.rate-limit.enabled", defaultValue = "true")
+    var enabled: Boolean = true
+
+    @ConfigProperty(name = "openbank.mcp.rate-limit.calls-per-minute", defaultValue = DEFAULT_PER_MINUTE_STR)
+    var callsPerMinute: Int = DEFAULT_PER_MINUTE
+
+    /** Mirrors the `mcp-anonymous` charter's `limits.runs_per_day` (agents.yaml). */
+    @ConfigProperty(name = "openbank.mcp.rate-limit.calls-per-day", defaultValue = DEFAULT_PER_DAY_STR)
+    var callsPerDay: Int = DEFAULT_PER_DAY
+
+    private val counters = ConcurrentHashMap<String, AtomicLong>()
+
+    /**
+     * Consumes one slot for [agentId] and reports whether the call is within both windows.
+     *
+     * Fails CLOSED by construction: there is no store to be unavailable, and an unexpected agent id
+     * simply gets its own fresh window rather than bypassing the check.
+     */
+    fun check(agentId: String): Outcome {
+        if (!enabled) return Outcome.ALLOWED
+        val now = Instant.now(clock).epochSecond
+        val minuteKey = "$agentId|m|${now / SECONDS_PER_MINUTE}"
+        val dayKey = "$agentId|d|${now / SECONDS_PER_DAY}"
+        pruneExpired(now)
+        val minute = hit(minuteKey)
+        val day = hit(dayKey)
+        return when {
+            minute > callsPerMinute -> Outcome.THROTTLED_BURST
+            day > callsPerDay -> Outcome.THROTTLED_DAILY
+            else -> Outcome.ALLOWED
+        }
+    }
+
+    private fun hit(key: String): Long = counters.computeIfAbsent(key) { AtomicLong() }.incrementAndGet()
+
+    /**
+     * Drops counters for windows that have already closed, so the map cannot grow without bound on
+     * a long-lived pod. Only ELAPSED windows are removed — never a live one, which would hand a
+     * caller a fresh budget by filling the map (an eviction policy that forgets current usage is a
+     * rate limiter with a bypass).
+     */
+    private fun pruneExpired(now: Long) {
+        if (counters.size <= MAX_TRACKED_WINDOWS) return
+        val liveMinute = "|m|${now / SECONDS_PER_MINUTE}"
+        val liveDay = "|d|${now / SECONDS_PER_DAY}"
+        counters.keys.removeIf { !it.endsWith(liveMinute) && !it.endsWith(liveDay) }
+    }
+
+    enum class Outcome(val reason: String?) {
+        ALLOWED(null),
+        THROTTLED_BURST("rate limit exceeded"),
+        THROTTLED_DAILY("daily call budget exhausted"),
+    }
+
+    companion object {
+        /**
+         * A judgement call with no production traffic behind it — tune from the tool-call metrics,
+         * not from taste. An agent answering one user question makes single-digit tool calls; 60/min
+         * leaves an order of magnitude of headroom while making a scripted sweep of a consent's
+         * transaction history impractical.
+         */
+        private const val DEFAULT_PER_MINUTE = 60
+        const val DEFAULT_PER_MINUTE_STR = "60"
+
+        /** The charter's `runs_per_day`. */
+        private const val DEFAULT_PER_DAY = 1000
+        const val DEFAULT_PER_DAY_STR = "1000"
+
+        private const val SECONDS_PER_MINUTE = 60L
+        private const val SECONDS_PER_DAY = 86_400L
+
+        /** Above this many tracked windows, [pruneExpired] sweeps the closed ones. */
+        private const val MAX_TRACKED_WINDOWS = 10_000
+    }
+}

--- a/openbank-mcp-service/src/main/resources/application.yaml
+++ b/openbank-mcp-service/src/main/resources/application.yaml
@@ -63,3 +63,13 @@ mcp:
     name: openbank-mcp
     version: "0.1.0"
     protocol-version: "2025-06-18"
+
+# Per-acting-agent rate limit on tools/call (#2409). The defaults are the code defaults
+# (McpRateLimiter); `calls-per-day` mirrors the `mcp-anonymous` charter's `limits.runs_per_day`
+# in openbank-libs/governance/agents.yaml, which nothing read before this landed.
+openbank:
+  mcp:
+    rate-limit:
+      enabled: ${MCP_RATE_LIMIT_ENABLED:true}
+      calls-per-minute: ${MCP_RATE_LIMIT_PER_MINUTE:60}
+      calls-per-day: ${MCP_RATE_LIMIT_PER_DAY:1000}

--- a/openbank-mcp-service/src/test/kotlin/com/openbank/mcp/McpEndpointTest.kt
+++ b/openbank-mcp-service/src/test/kotlin/com/openbank/mcp/McpEndpointTest.kt
@@ -18,6 +18,7 @@ import com.openbank.mcp.application.port.out.ProposalPort
 import com.openbank.mcp.infrastructure.mcp.CallerContextResolver
 import com.openbank.mcp.infrastructure.mcp.McpEndpoint
 import com.openbank.mcp.infrastructure.observability.McpMetricsAdapter
+import com.openbank.mcp.infrastructure.ratelimit.McpRateLimiter
 import io.micrometer.core.instrument.simple.SimpleMeterRegistry
 import org.assertj.core.api.Assertions.assertThat
 import org.junit.jupiter.api.Test
@@ -54,7 +55,33 @@ class McpEndpointTest {
             serverName = "openbank-mcp",
             serverVersion = "0.1.0",
             protocolVersion = "2025-06-18",
-        ).apply { metrics = McpMetricsAdapter(registry) }
+        ).apply {
+            metrics = McpMetricsAdapter(registry)
+            rateLimiter = limiter
+        }
+    }
+
+    /**
+     * One limiter shared by every endpoint a test builds, so a test that wants to exhaust the
+     * window can, and every other test gets the production defaults (60/min) — well above the
+     * handful of calls they each make.
+     */
+    private val limiter = McpRateLimiter()
+
+    @Test
+    fun `tools call is throttled once the acting agent exhausts its per-minute window`() {
+        val ep = endpoint(allowAll())
+        limiter.callsPerMinute = 2
+        val call = rpc("tools/call", mapOf("name" to "list_accounts", "arguments" to emptyMap<String, Any>()))
+
+        repeat(2) { assertThat(body(ep.handle(call).entity).path("result").path("isError").asBoolean(false)).isFalse() }
+        val throttled = body(ep.handle(call).entity)
+
+        assertThat(throttled.path("result").path("isError").asBoolean()).isTrue()
+        assertThat(throttled.path("result").path("content").first().path("text").asText())
+            .contains("Rate limit exceeded")
+        // A throttled call is auditable like any other denial — the trail must not go quiet on it.
+        assertThat(audit.events.last().result).isEqualTo(AuditResult.DENIED)
     }
 
     private fun rpc(method: String, params: Map<String, Any?> = emptyMap()): JsonNode =

--- a/openbank-mcp-service/src/test/kotlin/com/openbank/mcp/ratelimit/McpRateLimiterTest.kt
+++ b/openbank-mcp-service/src/test/kotlin/com/openbank/mcp/ratelimit/McpRateLimiterTest.kt
@@ -1,0 +1,65 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+// Copyright (c) OpenBank contributors. Licensed under the GNU Affero General Public License v3.0 only.
+package com.openbank.mcp.ratelimit
+
+import com.openbank.mcp.infrastructure.ratelimit.McpRateLimiter
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.Test
+import java.time.Clock
+import java.time.Duration
+import java.time.Instant
+import java.time.ZoneOffset
+
+class McpRateLimiterTest {
+
+    private val start = Instant.parse("2026-07-26T10:00:00Z")
+
+    private fun limiterAt(now: Instant) = McpRateLimiter().apply {
+        clock = Clock.fixed(now, ZoneOffset.UTC)
+    }
+
+    @Test
+    fun `the window is per acting agent, not global`() {
+        val limiter = limiterAt(start)
+        limiter.callsPerMinute = 1
+
+        assertThat(limiter.check("agent:a")).isEqualTo(McpRateLimiter.Outcome.ALLOWED)
+        assertThat(limiter.check("agent:a")).isEqualTo(McpRateLimiter.Outcome.THROTTLED_BURST)
+        // A second agent must be untouched by the first one's burst.
+        assertThat(limiter.check("agent:b")).isEqualTo(McpRateLimiter.Outcome.ALLOWED)
+    }
+
+    @Test
+    fun `the burst window reopens in the next minute`() {
+        val limiter = limiterAt(start)
+        limiter.callsPerMinute = 1
+        limiter.check("agent:a")
+        assertThat(limiter.check("agent:a")).isEqualTo(McpRateLimiter.Outcome.THROTTLED_BURST)
+
+        limiter.clock = Clock.fixed(start.plus(Duration.ofMinutes(1)), ZoneOffset.UTC)
+
+        assertThat(limiter.check("agent:a")).isEqualTo(McpRateLimiter.Outcome.ALLOWED)
+    }
+
+    @Test
+    fun `the daily budget survives the burst window reopening`() {
+        val limiter = limiterAt(start)
+        limiter.callsPerMinute = 1000
+        limiter.callsPerDay = 3
+
+        repeat(3) { assertThat(limiter.check("agent:a")).isEqualTo(McpRateLimiter.Outcome.ALLOWED) }
+        limiter.clock = Clock.fixed(start.plus(Duration.ofMinutes(5)), ZoneOffset.UTC)
+
+        assertThat(limiter.check("agent:a")).isEqualTo(McpRateLimiter.Outcome.THROTTLED_DAILY)
+    }
+
+    @Test
+    fun `disabling the limiter is an explicit config choice, not the default`() {
+        assertThat(McpRateLimiter().enabled).isTrue()
+
+        val limiter = limiterAt(start)
+        limiter.enabled = false
+        limiter.callsPerMinute = 1
+        repeat(5) { assertThat(limiter.check("agent:a")).isEqualTo(McpRateLimiter.Outcome.ALLOWED) }
+    }
+}


### PR DESCRIPTION
## Why

`tools/call` had no rate limit. Since the real read ports landed, every tool call fans out into consent-service **plus** one of account / balance / transaction-service — three of those four are money-path, so an unthrottled MCP surface is an amplification vector into them. Authorization can't bound it: a governed agent is *supposed* to read the accounts its consent grants. Rate is the control. Meanwhile the `mcp-anonymous` charter in `agents.yaml` declares `limits: { runs_per_day: 1000 }` and nothing read it.

## What

- `McpRateLimiter` — per-acting-agent fixed windows: a per-minute burst bound (60, tune from the metrics) and the charter's `runs_per_day` daily budget. Only *closed* windows are ever evicted, so filling the map can't hand a caller a fresh budget.
- Enforced in `McpEndpoint.handleToolCall` **after** the PDP decision (so a denied caller can't burn another's window — `VopRateLimitFilter`'s rationale) and **before** the tool executes (the fan-out is the thing being bounded). A throttled call is a `DENY` like any other: same audit event, same meter, so the aggregate can't disagree with the trail.
- Field-injected (`@Inject lateinit var`), like `metrics` — the constructor is already at detekt's `LongParameterList` threshold.
- Config keys added to `application.yaml` with env overrides; verified no duplicate YAML key was introduced.

## Design note — why in-process and not Valkey

`VopRateLimiter` is Valkey-backed because vop-service runs several replicas, where a local counter gives an attacker `limit × replicas`. `openbank-mcp-service` runs `replicas: 1`, so the two are exactly equivalent today, and the local counter avoids adding a store, a secret, an egress NetworkPolicy and a shared-state single point to a surface that has none. **That equivalence is a property of the replica count, not of the design** — hence the dedicated class: the shared-window swap is one file the day it scales out. Called out in the KDoc so it can't be mistaken for a claim that a local counter is sufficient in general.

## Falsification

The endpoint throttle test was run against the enforcement disabled (`if (false && …)`): **1 of 23 fails**, on exactly that test. Restored, the full gate is green: `:openbank-mcp-service:test detekt ktlintCheck koverVerify quarkusBuild`.

Refs #2409