### PR TITLE
ci(psd2): enforce that the anonymous OPA grant stays behind eIDAS mTLS

### DIFF
--- a/.github/scripts/check-psd2-anonymous-grant-paths.py
+++ b/.github/scripts/check-psd2-anonymous-grant-paths.py
@@ -1,0 +1,241 @@
+#!/usr/bin/env python3
+# SPDX-License-Identifier: Apache-2.0
+# Copyright (c) OpenBank contributors. Licensed under the Apache License, Version 2.0.
+"""Guard: every psd2 action granted to an ANONYMOUS principal must sit behind EidasMtlsFilter.
+
+`psd2_rest_ext.rego` grants five actions — psd2.list/read/create/initiate/delete — to
+`input.principal.type == "ANONYMOUS"`. That is safe ONLY because a TPP has already been
+authenticated upstream by `EidasMtlsFilter` (@Priority(AUTHENTICATION)), which 401s a missing or
+unauthorized TPP identity on the path prefixes it gates. The rego says so in a comment; nothing
+checked it (issue #2169).
+
+The failure this prevents: someone adds `@Authorize(action = "psd2.initiate")` on a handler outside
+the filter's gated prefixes — a new admin route, a debug endpoint, a resource class that moved, or
+anything under `open-banking/sandbox/` — and the PDP hands payment initiation to a genuinely
+unauthenticated caller while every gate in CI stays green.
+
+BOTH SIDES ARE DERIVED, never re-declared here:
+  * the granted ACTION set is read out of the rego rule;
+  * the gated PATH prefixes are read out of `EidasMtlsFilter.kt`'s `gated` predicate, including its
+    negated exclusions (`!path.startsWith("open-banking/sandbox/")`).
+A guard that kept its own copy of either list would be the drift class it exists to prevent.
+
+Usage: check-psd2-anonymous-grant-paths.py [--enforce]
+Advisory (::warning, exit 0) unless --enforce.
+"""
+
+from __future__ import annotations
+
+import argparse
+import re
+import sys
+from pathlib import Path
+
+REPO = Path(__file__).resolve().parents[2]
+REGO = REPO / "openbank-infra/gitops/components/psd2-service/psd2_rest_ext.rego"
+FILTER = REPO / (
+    "openbank-psd2-service/src/main/kotlin/com/openbank/psd2/"
+    "infrastructure/rest/filter/EidasMtlsFilter.kt"
+)
+SOURCES = REPO / "openbank-psd2-service/src/main/kotlin"
+
+ANONYMOUS_RULE = "psd2-tpp-eidas-qwac"
+
+
+def strip_kotlin_comments(src: str) -> str:
+    """Remove // and /* */ comments, honouring the fact that Kotlin block comments NEST.
+
+    A guard over source text must have an explicit rule for code-about-code: this file's own
+    docstring quotes `@Authorize(action = "psd2.initiate")`, and the rego + the filter are both
+    thick with prose naming the very annotations being matched. Comments are stripped BY DESIGN, so
+    a KDoc example can never be reported as a real endpoint — and, conversely, prose that names a
+    dead identifier is invisible to this guard forever.
+    """
+    out: list[str] = []
+    i, n, depth = 0, len(src), 0
+    in_line_comment = False
+    in_string = False
+    string_delim = ""
+    while i < n:
+        two = src[i : i + 2]
+        if depth > 0:
+            if two == "/*":
+                depth += 1
+                i += 2
+                continue
+            if two == "*/":
+                depth -= 1
+                i += 2
+                continue
+            i += 1
+            continue
+        if in_line_comment:
+            if src[i] == "\n":
+                in_line_comment = False
+                out.append("\n")
+            i += 1
+            continue
+        if in_string:
+            out.append(src[i])
+            if src[i] == "\\":
+                if i + 1 < n:
+                    out.append(src[i + 1])
+                i += 2
+                continue
+            if src.startswith(string_delim, i):
+                out.append(src[i + 1 : i + len(string_delim)])
+                i += len(string_delim)
+                in_string = False
+                continue
+            i += 1
+            continue
+        if src.startswith('"""', i):
+            in_string, string_delim = True, '"""'
+            out.append('"""')
+            i += 3
+            continue
+        if src[i] == '"':
+            in_string, string_delim = True, '"'
+            out.append('"')
+            i += 1
+            continue
+        if two == "/*":
+            depth = 1
+            i += 2
+            continue
+        if two == "//":
+            in_line_comment = True
+            i += 2
+            continue
+        out.append(src[i])
+        i += 1
+    return "".join(out)
+
+
+def strip_rego_comments(src: str) -> str:
+    return "\n".join(line.split("#", 1)[0] for line in src.splitlines())
+
+
+def granted_actions() -> set[str]:
+    """The action set the ANONYMOUS rule grants, read out of the rego (comments stripped)."""
+    body = strip_rego_comments(REGO.read_text())
+    match = re.search(
+        rf'allowed_reasons contains "{ANONYMOUS_RULE}" if \{{(.*?)\n\}}',
+        body,
+        re.DOTALL,
+    )
+    if not match:
+        sys.exit(f"FATAL: rule '{ANONYMOUS_RULE}' not found in {REGO.relative_to(REPO)}")
+    rule = match.group(1)
+    if "ANONYMOUS" not in rule:
+        # The rule stopped being an anonymous grant. That is a policy change big enough that this
+        # guard must not silently keep passing on a premise that no longer holds.
+        sys.exit(f"FATAL: rule '{ANONYMOUS_RULE}' no longer gates on an ANONYMOUS principal")
+    return set(re.findall(r'"(psd2\.[a-z]+)"', rule))
+
+
+def gated_prefixes() -> tuple[set[str], set[str]]:
+    """(gated prefixes, excluded prefixes) read out of EidasMtlsFilter's `gated` predicate."""
+    src = strip_kotlin_comments(FILTER.read_text())
+    match = re.search(r"val gated\s*=(.*?)\n\s*if \(!gated\)", src, re.DOTALL)
+    if not match:
+        sys.exit(f"FATAL: `val gated = ... ; if (!gated)` not found in {FILTER.relative_to(REPO)}")
+    expr = match.group(1)
+    included, excluded = set(), set()
+    for negated, prefix in re.findall(r'(!?)path\.startsWith\("([^"]+)"\)', expr):
+        (excluded if negated else included).add(prefix)
+    if not included:
+        sys.exit("FATAL: EidasMtlsFilter's `gated` predicate declares no path prefixes")
+    return included, excluded
+
+
+def annotation_block(lines: list[str], idx: int) -> list[str]:
+    """The contiguous run of annotation lines containing `lines[idx]`."""
+    start = idx
+    while start > 0 and lines[start - 1].strip().startswith("@"):
+        start -= 1
+    end = idx
+    while end + 1 < len(lines) and lines[end + 1].strip().startswith("@"):
+        end += 1
+    return lines[start : end + 1]
+
+
+def annotated_endpoints() -> list[tuple[Path, int, str, str]]:
+    """(file, line, action, resolved path) for every @Authorize in psd2-service's main sources."""
+    found = []
+    for file in sorted(SOURCES.rglob("*.kt")):
+        src = strip_kotlin_comments(file.read_text())
+        lines = src.splitlines()
+        class_path = ""
+        class_match = re.search(r'^@Path\("([^"]*)"\)', src, re.MULTILINE)
+        if class_match:
+            class_path = class_match.group(1)
+        for idx, line in enumerate(lines):
+            authorize = re.search(r'@Authorize\(action\s*=\s*"([^"]+)"', line)
+            if not authorize:
+                continue
+            # The method @Path, if any, is in the CONTIGUOUS annotation block this @Authorize
+            # belongs to — bounded in both directions by the first non-annotation line, so a
+            # neighbouring method's @Path can never be attributed to this one.
+            method_path = ""
+            for probe in annotation_block(lines, idx):
+                probe_match = re.match(r'\s+@Path\("([^"]*)"\)', probe)
+                if probe_match:
+                    method_path = probe_match.group(1)
+                    break
+            resolved = (class_path.rstrip("/") + "/" + method_path.lstrip("/")).strip("/")
+            found.append((file, idx + 1, authorize.group(1), resolved))
+    return found
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--enforce", action="store_true")
+    args = parser.parse_args()
+
+    actions = granted_actions()
+    included, excluded = gated_prefixes()
+    endpoints = annotated_endpoints()
+
+    violations = []
+    checked = 0
+    for file, line, action, path in endpoints:
+        if action not in actions:
+            continue
+        checked += 1
+        gated = any(path.startswith(p) for p in included) and not any(
+            path.startswith(p) for p in excluded
+        )
+        if not gated:
+            violations.append((file, line, action, path))
+
+    print(f"psd2 anonymous-grant path guard (issue #2169)")
+    print(f"  granted to ANONYMOUS : {', '.join(sorted(actions))}")
+    print(f"  gated prefixes       : {', '.join(sorted(included))}")
+    print(f"  excluded prefixes    : {', '.join(sorted(excluded)) or '(none)'}")
+    print(f"  annotated endpoints  : {len(endpoints)} ({checked} carry a granted action)")
+
+    if not checked:
+        # A scope that matched nothing reads as a pass while having checked nothing — the exact
+        # vacuous green this repo has been bitten by. Say so loudly.
+        print("::error::guard matched ZERO annotated endpoints — its parser has drifted from the source")
+        return 1
+
+    if not violations:
+        print(f"  OK: all {checked} anonymous-granted endpoints sit behind EidasMtlsFilter")
+        return 0
+
+    for file, line, action, path in violations:
+        rel = file.relative_to(REPO)
+        level = "error" if args.enforce else "warning"
+        print(
+            f"::{level} file={rel},line={line}::{action} on '/{path}' is granted to an ANONYMOUS "
+            f"principal by psd2_rest_ext.rego but is NOT behind EidasMtlsFilter's gated prefixes "
+            f"— an unauthenticated caller would be allowed. Add the prefix to the filter's `gated` "
+            f"predicate in the same change, or give the endpoint an action outside the granted set."
+        )
+    return 1 if args.enforce else 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -799,6 +799,20 @@ jobs:
       - name: "no dead-code SERVICE-principal rego rule (enforced)"
         run: bash .github/scripts/check-no-service-principal-type.sh .
 
+      # psd2's ANONYMOUS OPA grant rests on upstream eIDAS mTLS authentication
+      # (issue #2169, rules.yaml: authz_policy). psd2_rest_ext.rego grants
+      # psd2.list/read/create/initiate/delete to an ANONYMOUS principal because a
+      # TPP presents an eIDAS QWAC and no bearer; that is safe ONLY while every
+      # annotated endpoint sits behind EidasMtlsFilter's gated path prefixes. The
+      # guard derives the action set from the rego and the prefixes (with their
+      # negated exclusions) from the filter source — it keeps no copy of either, so
+      # its scope cannot drift from what it checks. Falsified in both directions
+      # before merge: an @Authorize on an ungated path and on the excluded
+      # `open-banking/sandbox/` prefix are both flagged; the same annotation quoted
+      # in a KDoc is not. 0 violations on origin/main at introduction. ENFORCED.
+      - name: "psd2 anonymous grant stays behind eIDAS mTLS (issue #2169, enforced)"
+        run: python3 .github/scripts/check-psd2-anonymous-grant-paths.py --enforce
+
       # openbank-mcp-service caller-auth ordering guard (BLOCKER #2206). The MCP
       # threat model (#2200) established the service authenticates nobody today —
       # resolveContext() hardcodes the "agent:mcp-anonymous" placeholder and the OPA

--- a/openbank-infra/gitops/components/accounts/account-opa-bundle.yaml
+++ b/openbank-infra/gitops/components/accounts/account-opa-bundle.yaml
@@ -9,7 +9,7 @@ metadata:
     app.kubernetes.io/name: account-service
     app.kubernetes.io/part-of: accounts
   annotations:
-    openbank.tech/policy-checksum: "8f3a4abe770f6116"
+    openbank.tech/policy-checksum: "18f052d805d1505a"
 data:
   rest.rego: |
     # SPDX-License-Identifier: Apache-2.0
@@ -2576,6 +2576,25 @@ data:
       # edge-service-notification rule and rest_test.rego's
       # test_deny_operator_read_any_does_not_cover_write).
       ci_producer: ".github/scripts/check-no-service-principal-type.sh"
+
+      # psd2_rest_ext.rego grants five actions — psd2.list/read/create/initiate/delete — to an
+      # ANONYMOUS principal, because a TPP authenticates by eIDAS QWAC (mTLS) and carries no
+      # bearer, so it reaches OPA as ANONYMOUS. That grant is safe ONLY because EidasMtlsFilter
+      # (@Priority(AUTHENTICATION)) has already 401'd a missing or unauthorized TPP on the path
+      # prefixes it gates. Until issue #2169 that invariant lived in a rego comment: an
+      # @Authorize(action = "psd2.initiate") added on a path the filter does NOT gate — a new
+      # admin route, a debug endpoint, anything under `open-banking/sandbox/` — would hand
+      # payment initiation to a genuinely unauthenticated caller with every CI gate green.
+      #
+      # The guard derives BOTH sides from source: the action set out of the rego rule, the gated
+      # prefixes (and their negated exclusions) out of EidasMtlsFilter's `gated` predicate. It
+      # keeps no copy of either — a guard whose scope is a hand-kept list of the thing it checks
+      # reads as passing when the list is short. Kotlin comments are stripped (block comments
+      # NEST) so an @Authorize quoted in a KDoc is never reported as an endpoint, and a run that
+      # matches zero endpoints FAILS rather than passing vacuously.
+      # 0 violations on origin/main at introduction — a regression guard. ENFORCED.
+      anonymous_grants_require_upstream_authn: true
+      anonymous_grant_ci_producer: ".github/scripts/check-psd2-anonymous-grant-paths.py"
 
     # ---------------------------------------------------------------------------------------
     # Scheduled-method invariants (issue #2148, fleet sweep #2187).

--- a/openbank-infra/gitops/components/accounts/account-service.yaml
+++ b/openbank-infra/gitops/components/accounts/account-service.yaml
@@ -37,7 +37,7 @@ spec:
       annotations:
         # Rolls the pod when the OPA bundle changes — subPath mounts do NOT hot-reload.
         # Kept in sync by gen-account-opa-bundle.sh (do not hand-edit).
-        openbank.tech/policy-checksum: "8f3a4abe770f6116"
+        openbank.tech/policy-checksum: "18f052d805d1505a"
     spec:
       securityContext:
         runAsNonRoot: true

--- a/openbank-infra/gitops/components/aml/aml-opa-bundle.yaml
+++ b/openbank-infra/gitops/components/aml/aml-opa-bundle.yaml
@@ -9,7 +9,7 @@ metadata:
     app.kubernetes.io/name: aml-service
     app.kubernetes.io/part-of: aml
   annotations:
-    openbank.tech/policy-checksum: "7c06636572b5edfb"
+    openbank.tech/policy-checksum: "37dbac3711119a9c"
 data:
   rest.rego: |
     # SPDX-License-Identifier: Apache-2.0
@@ -2549,6 +2549,25 @@ data:
       # edge-service-notification rule and rest_test.rego's
       # test_deny_operator_read_any_does_not_cover_write).
       ci_producer: ".github/scripts/check-no-service-principal-type.sh"
+
+      # psd2_rest_ext.rego grants five actions — psd2.list/read/create/initiate/delete — to an
+      # ANONYMOUS principal, because a TPP authenticates by eIDAS QWAC (mTLS) and carries no
+      # bearer, so it reaches OPA as ANONYMOUS. That grant is safe ONLY because EidasMtlsFilter
+      # (@Priority(AUTHENTICATION)) has already 401'd a missing or unauthorized TPP on the path
+      # prefixes it gates. Until issue #2169 that invariant lived in a rego comment: an
+      # @Authorize(action = "psd2.initiate") added on a path the filter does NOT gate — a new
+      # admin route, a debug endpoint, anything under `open-banking/sandbox/` — would hand
+      # payment initiation to a genuinely unauthenticated caller with every CI gate green.
+      #
+      # The guard derives BOTH sides from source: the action set out of the rego rule, the gated
+      # prefixes (and their negated exclusions) out of EidasMtlsFilter's `gated` predicate. It
+      # keeps no copy of either — a guard whose scope is a hand-kept list of the thing it checks
+      # reads as passing when the list is short. Kotlin comments are stripped (block comments
+      # NEST) so an @Authorize quoted in a KDoc is never reported as an endpoint, and a run that
+      # matches zero endpoints FAILS rather than passing vacuously.
+      # 0 violations on origin/main at introduction — a regression guard. ENFORCED.
+      anonymous_grants_require_upstream_authn: true
+      anonymous_grant_ci_producer: ".github/scripts/check-psd2-anonymous-grant-paths.py"
 
     # ---------------------------------------------------------------------------------------
     # Scheduled-method invariants (issue #2148, fleet sweep #2187).

--- a/openbank-infra/gitops/components/aml/aml-service.yaml
+++ b/openbank-infra/gitops/components/aml/aml-service.yaml
@@ -22,7 +22,7 @@ spec:
       annotations:
         # Rolls the pod when the OPA bundle changes (subPath mounts do not hot-reload).
         # Kept in sync by gen-aml-opa-bundle.sh (do not hand-edit).
-        openbank.tech/policy-checksum: "7c06636572b5edfb"
+        openbank.tech/policy-checksum: "37dbac3711119a9c"
     spec:
       securityContext:
         runAsNonRoot: true

--- a/openbank-infra/gitops/components/anacredit/anacredit-opa-bundle.yaml
+++ b/openbank-infra/gitops/components/anacredit/anacredit-opa-bundle.yaml
@@ -9,7 +9,7 @@ metadata:
     app.kubernetes.io/name: anacredit-service
     app.kubernetes.io/part-of: anacredit
   annotations:
-    openbank.tech/policy-checksum: "dd6d5a2c4433aada"
+    openbank.tech/policy-checksum: "a68108be3d33fda0"
 data:
   rest.rego: |
     # SPDX-License-Identifier: Apache-2.0
@@ -2519,6 +2519,25 @@ data:
       # edge-service-notification rule and rest_test.rego's
       # test_deny_operator_read_any_does_not_cover_write).
       ci_producer: ".github/scripts/check-no-service-principal-type.sh"
+
+      # psd2_rest_ext.rego grants five actions — psd2.list/read/create/initiate/delete — to an
+      # ANONYMOUS principal, because a TPP authenticates by eIDAS QWAC (mTLS) and carries no
+      # bearer, so it reaches OPA as ANONYMOUS. That grant is safe ONLY because EidasMtlsFilter
+      # (@Priority(AUTHENTICATION)) has already 401'd a missing or unauthorized TPP on the path
+      # prefixes it gates. Until issue #2169 that invariant lived in a rego comment: an
+      # @Authorize(action = "psd2.initiate") added on a path the filter does NOT gate — a new
+      # admin route, a debug endpoint, anything under `open-banking/sandbox/` — would hand
+      # payment initiation to a genuinely unauthenticated caller with every CI gate green.
+      #
+      # The guard derives BOTH sides from source: the action set out of the rego rule, the gated
+      # prefixes (and their negated exclusions) out of EidasMtlsFilter's `gated` predicate. It
+      # keeps no copy of either — a guard whose scope is a hand-kept list of the thing it checks
+      # reads as passing when the list is short. Kotlin comments are stripped (block comments
+      # NEST) so an @Authorize quoted in a KDoc is never reported as an endpoint, and a run that
+      # matches zero endpoints FAILS rather than passing vacuously.
+      # 0 violations on origin/main at introduction — a regression guard. ENFORCED.
+      anonymous_grants_require_upstream_authn: true
+      anonymous_grant_ci_producer: ".github/scripts/check-psd2-anonymous-grant-paths.py"
 
     # ---------------------------------------------------------------------------------------
     # Scheduled-method invariants (issue #2148, fleet sweep #2187).

--- a/openbank-infra/gitops/components/anacredit/anacredit-service.yaml
+++ b/openbank-infra/gitops/components/anacredit/anacredit-service.yaml
@@ -32,7 +32,7 @@ spec:
       annotations:
         # Rolls the pods when the OPA bundle changes — subPath mounts do NOT hot-reload.
         # Kept in sync by gen-anacredit-opa-bundle.sh (do not hand-edit).
-        openbank.tech/policy-checksum: "dd6d5a2c4433aada"
+        openbank.tech/policy-checksum: "a68108be3d33fda0"
     spec:
       securityContext:
         runAsNonRoot: true

--- a/openbank-infra/gitops/components/ap2/ap2-opa-bundle.yaml
+++ b/openbank-infra/gitops/components/ap2/ap2-opa-bundle.yaml
@@ -9,7 +9,7 @@ metadata:
     app.kubernetes.io/name: mcp-service
     app.kubernetes.io/part-of: platform
   annotations:
-    openbank.tech/policy-checksum: "2c2f017d31e98e3c"
+    openbank.tech/policy-checksum: "2c3dc4da36574695"
 data:
   rest.rego: |
     # SPDX-License-Identifier: Apache-2.0
@@ -2487,6 +2487,25 @@ data:
       # edge-service-notification rule and rest_test.rego's
       # test_deny_operator_read_any_does_not_cover_write).
       ci_producer: ".github/scripts/check-no-service-principal-type.sh"
+
+      # psd2_rest_ext.rego grants five actions — psd2.list/read/create/initiate/delete — to an
+      # ANONYMOUS principal, because a TPP authenticates by eIDAS QWAC (mTLS) and carries no
+      # bearer, so it reaches OPA as ANONYMOUS. That grant is safe ONLY because EidasMtlsFilter
+      # (@Priority(AUTHENTICATION)) has already 401'd a missing or unauthorized TPP on the path
+      # prefixes it gates. Until issue #2169 that invariant lived in a rego comment: an
+      # @Authorize(action = "psd2.initiate") added on a path the filter does NOT gate — a new
+      # admin route, a debug endpoint, anything under `open-banking/sandbox/` — would hand
+      # payment initiation to a genuinely unauthenticated caller with every CI gate green.
+      #
+      # The guard derives BOTH sides from source: the action set out of the rego rule, the gated
+      # prefixes (and their negated exclusions) out of EidasMtlsFilter's `gated` predicate. It
+      # keeps no copy of either — a guard whose scope is a hand-kept list of the thing it checks
+      # reads as passing when the list is short. Kotlin comments are stripped (block comments
+      # NEST) so an @Authorize quoted in a KDoc is never reported as an endpoint, and a run that
+      # matches zero endpoints FAILS rather than passing vacuously.
+      # 0 violations on origin/main at introduction — a regression guard. ENFORCED.
+      anonymous_grants_require_upstream_authn: true
+      anonymous_grant_ci_producer: ".github/scripts/check-psd2-anonymous-grant-paths.py"
 
     # ---------------------------------------------------------------------------------------
     # Scheduled-method invariants (issue #2148, fleet sweep #2187).

--- a/openbank-infra/gitops/components/ap2/ap2-service.yaml
+++ b/openbank-infra/gitops/components/ap2/ap2-service.yaml
@@ -30,7 +30,7 @@ spec:
       annotations:
         # Roll the pod when the OPA policy bundle changes (subPath mounts don't hot-reload).
         # Kept in sync by gen-ap2-opa-bundle.sh (do not hand-edit).
-        openbank.tech/policy-checksum: "2c2f017d31e98e3c"
+        openbank.tech/policy-checksum: "2c3dc4da36574695"
     spec:
       securityContext:
         runAsNonRoot: true

--- a/openbank-infra/gitops/components/audit/audit-opa-bundle.yaml
+++ b/openbank-infra/gitops/components/audit/audit-opa-bundle.yaml
@@ -9,7 +9,7 @@ metadata:
     app.kubernetes.io/name: audit-service
     app.kubernetes.io/part-of: audit
   annotations:
-    openbank.tech/policy-checksum: "a72504cb46301818"
+    openbank.tech/policy-checksum: "e27ea94290a73cb5"
 data:
   rest.rego: |
     # SPDX-License-Identifier: Apache-2.0
@@ -2531,6 +2531,25 @@ data:
       # edge-service-notification rule and rest_test.rego's
       # test_deny_operator_read_any_does_not_cover_write).
       ci_producer: ".github/scripts/check-no-service-principal-type.sh"
+
+      # psd2_rest_ext.rego grants five actions — psd2.list/read/create/initiate/delete — to an
+      # ANONYMOUS principal, because a TPP authenticates by eIDAS QWAC (mTLS) and carries no
+      # bearer, so it reaches OPA as ANONYMOUS. That grant is safe ONLY because EidasMtlsFilter
+      # (@Priority(AUTHENTICATION)) has already 401'd a missing or unauthorized TPP on the path
+      # prefixes it gates. Until issue #2169 that invariant lived in a rego comment: an
+      # @Authorize(action = "psd2.initiate") added on a path the filter does NOT gate — a new
+      # admin route, a debug endpoint, anything under `open-banking/sandbox/` — would hand
+      # payment initiation to a genuinely unauthenticated caller with every CI gate green.
+      #
+      # The guard derives BOTH sides from source: the action set out of the rego rule, the gated
+      # prefixes (and their negated exclusions) out of EidasMtlsFilter's `gated` predicate. It
+      # keeps no copy of either — a guard whose scope is a hand-kept list of the thing it checks
+      # reads as passing when the list is short. Kotlin comments are stripped (block comments
+      # NEST) so an @Authorize quoted in a KDoc is never reported as an endpoint, and a run that
+      # matches zero endpoints FAILS rather than passing vacuously.
+      # 0 violations on origin/main at introduction — a regression guard. ENFORCED.
+      anonymous_grants_require_upstream_authn: true
+      anonymous_grant_ci_producer: ".github/scripts/check-psd2-anonymous-grant-paths.py"
 
     # ---------------------------------------------------------------------------------------
     # Scheduled-method invariants (issue #2148, fleet sweep #2187).

--- a/openbank-infra/gitops/components/audit/audit-service.yaml
+++ b/openbank-infra/gitops/components/audit/audit-service.yaml
@@ -22,7 +22,7 @@ spec:
       annotations:
         # Rolls the pod when the OPA bundle changes (subPath mounts do not hot-reload).
         # Kept in sync by gen-audit-opa-bundle.sh (do not hand-edit).
-        openbank.tech/policy-checksum: "a72504cb46301818"
+        openbank.tech/policy-checksum: "e27ea94290a73cb5"
     spec:
       securityContext:
         runAsNonRoot: true

--- a/openbank-infra/gitops/components/balances/balance-opa-bundle.yaml
+++ b/openbank-infra/gitops/components/balances/balance-opa-bundle.yaml
@@ -9,7 +9,7 @@ metadata:
     app.kubernetes.io/name: balance-service
     app.kubernetes.io/part-of: balances
   annotations:
-    openbank.tech/policy-checksum: "89a0cd57f08b8739"
+    openbank.tech/policy-checksum: "b39b7a2d1050473a"
 data:
   rest.rego: |
     # SPDX-License-Identifier: Apache-2.0
@@ -2620,6 +2620,25 @@ data:
       # edge-service-notification rule and rest_test.rego's
       # test_deny_operator_read_any_does_not_cover_write).
       ci_producer: ".github/scripts/check-no-service-principal-type.sh"
+
+      # psd2_rest_ext.rego grants five actions — psd2.list/read/create/initiate/delete — to an
+      # ANONYMOUS principal, because a TPP authenticates by eIDAS QWAC (mTLS) and carries no
+      # bearer, so it reaches OPA as ANONYMOUS. That grant is safe ONLY because EidasMtlsFilter
+      # (@Priority(AUTHENTICATION)) has already 401'd a missing or unauthorized TPP on the path
+      # prefixes it gates. Until issue #2169 that invariant lived in a rego comment: an
+      # @Authorize(action = "psd2.initiate") added on a path the filter does NOT gate — a new
+      # admin route, a debug endpoint, anything under `open-banking/sandbox/` — would hand
+      # payment initiation to a genuinely unauthenticated caller with every CI gate green.
+      #
+      # The guard derives BOTH sides from source: the action set out of the rego rule, the gated
+      # prefixes (and their negated exclusions) out of EidasMtlsFilter's `gated` predicate. It
+      # keeps no copy of either — a guard whose scope is a hand-kept list of the thing it checks
+      # reads as passing when the list is short. Kotlin comments are stripped (block comments
+      # NEST) so an @Authorize quoted in a KDoc is never reported as an endpoint, and a run that
+      # matches zero endpoints FAILS rather than passing vacuously.
+      # 0 violations on origin/main at introduction — a regression guard. ENFORCED.
+      anonymous_grants_require_upstream_authn: true
+      anonymous_grant_ci_producer: ".github/scripts/check-psd2-anonymous-grant-paths.py"
 
     # ---------------------------------------------------------------------------------------
     # Scheduled-method invariants (issue #2148, fleet sweep #2187).

--- a/openbank-infra/gitops/components/balances/balance-service.yaml
+++ b/openbank-infra/gitops/components/balances/balance-service.yaml
@@ -34,7 +34,7 @@ spec:
       annotations:
         # Rolls the pods when the OPA bundle changes — subPath mounts do NOT hot-reload.
         # Kept in sync by gen-balance-opa-bundle.sh (do not hand-edit).
-        openbank.tech/policy-checksum: "89a0cd57f08b8739"
+        openbank.tech/policy-checksum: "b39b7a2d1050473a"
     spec:
       securityContext:
         runAsNonRoot: true

--- a/openbank-infra/gitops/components/billing/billing-opa-bundle.yaml
+++ b/openbank-infra/gitops/components/billing/billing-opa-bundle.yaml
@@ -9,7 +9,7 @@ metadata:
     app.kubernetes.io/name: billing-service
     app.kubernetes.io/part-of: billing
   annotations:
-    openbank.tech/policy-checksum: "b41a03ec7fd0cd7a"
+    openbank.tech/policy-checksum: "f294f4810474b590"
 data:
   rest.rego: |
     # SPDX-License-Identifier: Apache-2.0
@@ -2525,6 +2525,25 @@ data:
       # edge-service-notification rule and rest_test.rego's
       # test_deny_operator_read_any_does_not_cover_write).
       ci_producer: ".github/scripts/check-no-service-principal-type.sh"
+
+      # psd2_rest_ext.rego grants five actions — psd2.list/read/create/initiate/delete — to an
+      # ANONYMOUS principal, because a TPP authenticates by eIDAS QWAC (mTLS) and carries no
+      # bearer, so it reaches OPA as ANONYMOUS. That grant is safe ONLY because EidasMtlsFilter
+      # (@Priority(AUTHENTICATION)) has already 401'd a missing or unauthorized TPP on the path
+      # prefixes it gates. Until issue #2169 that invariant lived in a rego comment: an
+      # @Authorize(action = "psd2.initiate") added on a path the filter does NOT gate — a new
+      # admin route, a debug endpoint, anything under `open-banking/sandbox/` — would hand
+      # payment initiation to a genuinely unauthenticated caller with every CI gate green.
+      #
+      # The guard derives BOTH sides from source: the action set out of the rego rule, the gated
+      # prefixes (and their negated exclusions) out of EidasMtlsFilter's `gated` predicate. It
+      # keeps no copy of either — a guard whose scope is a hand-kept list of the thing it checks
+      # reads as passing when the list is short. Kotlin comments are stripped (block comments
+      # NEST) so an @Authorize quoted in a KDoc is never reported as an endpoint, and a run that
+      # matches zero endpoints FAILS rather than passing vacuously.
+      # 0 violations on origin/main at introduction — a regression guard. ENFORCED.
+      anonymous_grants_require_upstream_authn: true
+      anonymous_grant_ci_producer: ".github/scripts/check-psd2-anonymous-grant-paths.py"
 
     # ---------------------------------------------------------------------------------------
     # Scheduled-method invariants (issue #2148, fleet sweep #2187).

--- a/openbank-infra/gitops/components/billing/billing-service.yaml
+++ b/openbank-infra/gitops/components/billing/billing-service.yaml
@@ -27,7 +27,7 @@ spec:
       annotations:
         # Rolls the pods when the OPA bundle changes — subPath mounts do NOT hot-reload.
         # Kept in sync by gen-billing-opa-bundle.sh (do not hand-edit).
-        openbank.tech/policy-checksum: "b41a03ec7fd0cd7a"
+        openbank.tech/policy-checksum: "f294f4810474b590"
     spec:
       securityContext:
         runAsNonRoot: true

--- a/openbank-infra/gitops/components/consent/consent-opa-bundle.yaml
+++ b/openbank-infra/gitops/components/consent/consent-opa-bundle.yaml
@@ -9,7 +9,7 @@ metadata:
     app.kubernetes.io/name: consent-service
     app.kubernetes.io/part-of: consent
   annotations:
-    openbank.tech/policy-checksum: "014508f0b3d9c59e"
+    openbank.tech/policy-checksum: "fa6d928578aea09f"
 data:
   rest.rego: |
     # SPDX-License-Identifier: Apache-2.0
@@ -2583,6 +2583,25 @@ data:
       # edge-service-notification rule and rest_test.rego's
       # test_deny_operator_read_any_does_not_cover_write).
       ci_producer: ".github/scripts/check-no-service-principal-type.sh"
+
+      # psd2_rest_ext.rego grants five actions — psd2.list/read/create/initiate/delete — to an
+      # ANONYMOUS principal, because a TPP authenticates by eIDAS QWAC (mTLS) and carries no
+      # bearer, so it reaches OPA as ANONYMOUS. That grant is safe ONLY because EidasMtlsFilter
+      # (@Priority(AUTHENTICATION)) has already 401'd a missing or unauthorized TPP on the path
+      # prefixes it gates. Until issue #2169 that invariant lived in a rego comment: an
+      # @Authorize(action = "psd2.initiate") added on a path the filter does NOT gate — a new
+      # admin route, a debug endpoint, anything under `open-banking/sandbox/` — would hand
+      # payment initiation to a genuinely unauthenticated caller with every CI gate green.
+      #
+      # The guard derives BOTH sides from source: the action set out of the rego rule, the gated
+      # prefixes (and their negated exclusions) out of EidasMtlsFilter's `gated` predicate. It
+      # keeps no copy of either — a guard whose scope is a hand-kept list of the thing it checks
+      # reads as passing when the list is short. Kotlin comments are stripped (block comments
+      # NEST) so an @Authorize quoted in a KDoc is never reported as an endpoint, and a run that
+      # matches zero endpoints FAILS rather than passing vacuously.
+      # 0 violations on origin/main at introduction — a regression guard. ENFORCED.
+      anonymous_grants_require_upstream_authn: true
+      anonymous_grant_ci_producer: ".github/scripts/check-psd2-anonymous-grant-paths.py"
 
     # ---------------------------------------------------------------------------------------
     # Scheduled-method invariants (issue #2148, fleet sweep #2187).

--- a/openbank-infra/gitops/components/consent/consent-service.yaml
+++ b/openbank-infra/gitops/components/consent/consent-service.yaml
@@ -28,7 +28,7 @@ spec:
       annotations:
         # Rolls the pods when the OPA bundle changes — subPath mounts do NOT hot-reload.
         # Kept in sync by gen-consent-opa-bundle.sh (do not hand-edit).
-        openbank.tech/policy-checksum: "014508f0b3d9c59e"
+        openbank.tech/policy-checksum: "fa6d928578aea09f"
     spec:
       securityContext:
         runAsNonRoot: true

--- a/openbank-infra/gitops/components/copilot/copilot-opa-bundle.yaml
+++ b/openbank-infra/gitops/components/copilot/copilot-opa-bundle.yaml
@@ -9,7 +9,7 @@ metadata:
     app.kubernetes.io/name: copilot-service
     app.kubernetes.io/part-of: platform
   annotations:
-    openbank.tech/policy-checksum: "4a18f7c046ce99c6"
+    openbank.tech/policy-checksum: "8b799186606ed55e"
 data:
   rest.rego: |
     # SPDX-License-Identifier: Apache-2.0
@@ -2611,6 +2611,25 @@ data:
       # edge-service-notification rule and rest_test.rego's
       # test_deny_operator_read_any_does_not_cover_write).
       ci_producer: ".github/scripts/check-no-service-principal-type.sh"
+
+      # psd2_rest_ext.rego grants five actions — psd2.list/read/create/initiate/delete — to an
+      # ANONYMOUS principal, because a TPP authenticates by eIDAS QWAC (mTLS) and carries no
+      # bearer, so it reaches OPA as ANONYMOUS. That grant is safe ONLY because EidasMtlsFilter
+      # (@Priority(AUTHENTICATION)) has already 401'd a missing or unauthorized TPP on the path
+      # prefixes it gates. Until issue #2169 that invariant lived in a rego comment: an
+      # @Authorize(action = "psd2.initiate") added on a path the filter does NOT gate — a new
+      # admin route, a debug endpoint, anything under `open-banking/sandbox/` — would hand
+      # payment initiation to a genuinely unauthenticated caller with every CI gate green.
+      #
+      # The guard derives BOTH sides from source: the action set out of the rego rule, the gated
+      # prefixes (and their negated exclusions) out of EidasMtlsFilter's `gated` predicate. It
+      # keeps no copy of either — a guard whose scope is a hand-kept list of the thing it checks
+      # reads as passing when the list is short. Kotlin comments are stripped (block comments
+      # NEST) so an @Authorize quoted in a KDoc is never reported as an endpoint, and a run that
+      # matches zero endpoints FAILS rather than passing vacuously.
+      # 0 violations on origin/main at introduction — a regression guard. ENFORCED.
+      anonymous_grants_require_upstream_authn: true
+      anonymous_grant_ci_producer: ".github/scripts/check-psd2-anonymous-grant-paths.py"
 
     # ---------------------------------------------------------------------------------------
     # Scheduled-method invariants (issue #2148, fleet sweep #2187).

--- a/openbank-infra/gitops/components/copilot/copilot-service.yaml
+++ b/openbank-infra/gitops/components/copilot/copilot-service.yaml
@@ -29,7 +29,7 @@ spec:
       annotations:
         # Rolls the pod when the OPA bundle changes — subPath mounts do NOT hot-reload.
         # Kept in sync by gen-copilot-opa-bundle.sh (do not hand-edit).
-        openbank.tech/policy-checksum: "4a18f7c046ce99c6"
+        openbank.tech/policy-checksum: "8b799186606ed55e"
     spec:
       securityContext:
         runAsNonRoot: true

--- a/openbank-infra/gitops/components/customer-edge/customer-edge-opa-bundle.yaml
+++ b/openbank-infra/gitops/components/customer-edge/customer-edge-opa-bundle.yaml
@@ -10,7 +10,7 @@ metadata:
     app.kubernetes.io/name: customer-edge
     app.kubernetes.io/part-of: customer-edge
   annotations:
-    openbank.tech/policy-checksum: "5370eab5af57bb71"
+    openbank.tech/policy-checksum: "2592909d9461fccf"
 data:
   rest.rego: |
     # SPDX-License-Identifier: Apache-2.0
@@ -1710,6 +1710,25 @@ data:
       # edge-service-notification rule and rest_test.rego's
       # test_deny_operator_read_any_does_not_cover_write).
       ci_producer: ".github/scripts/check-no-service-principal-type.sh"
+
+      # psd2_rest_ext.rego grants five actions — psd2.list/read/create/initiate/delete — to an
+      # ANONYMOUS principal, because a TPP authenticates by eIDAS QWAC (mTLS) and carries no
+      # bearer, so it reaches OPA as ANONYMOUS. That grant is safe ONLY because EidasMtlsFilter
+      # (@Priority(AUTHENTICATION)) has already 401'd a missing or unauthorized TPP on the path
+      # prefixes it gates. Until issue #2169 that invariant lived in a rego comment: an
+      # @Authorize(action = "psd2.initiate") added on a path the filter does NOT gate — a new
+      # admin route, a debug endpoint, anything under `open-banking/sandbox/` — would hand
+      # payment initiation to a genuinely unauthenticated caller with every CI gate green.
+      #
+      # The guard derives BOTH sides from source: the action set out of the rego rule, the gated
+      # prefixes (and their negated exclusions) out of EidasMtlsFilter's `gated` predicate. It
+      # keeps no copy of either — a guard whose scope is a hand-kept list of the thing it checks
+      # reads as passing when the list is short. Kotlin comments are stripped (block comments
+      # NEST) so an @Authorize quoted in a KDoc is never reported as an endpoint, and a run that
+      # matches zero endpoints FAILS rather than passing vacuously.
+      # 0 violations on origin/main at introduction — a regression guard. ENFORCED.
+      anonymous_grants_require_upstream_authn: true
+      anonymous_grant_ci_producer: ".github/scripts/check-psd2-anonymous-grant-paths.py"
 
     # ---------------------------------------------------------------------------------------
     # Scheduled-method invariants (issue #2148, fleet sweep #2187).

--- a/openbank-infra/gitops/components/customer-edge/customer-edge.yaml
+++ b/openbank-infra/gitops/components/customer-edge/customer-edge.yaml
@@ -65,7 +65,7 @@ spec:
       annotations:
         # Rolls the pod when the OPA bundle changes — subPath mounts do NOT hot-reload.
         # Kept in sync by gen-customer-edge-opa-bundle.sh (do not hand-edit).
-        openbank.tech/policy-checksum: "5370eab5af57bb71"
+        openbank.tech/policy-checksum: "2592909d9461fccf"
     spec:
       # Dedicated SA so EKS Pod Identity can hand the edge (and ONLY the edge) the
       # feedback-screenshots S3 role — ADR-0192, openbank-infra/aws/envs/sandbox-platform/

--- a/openbank-infra/gitops/components/dispute-service/dispute-opa-bundle.yaml
+++ b/openbank-infra/gitops/components/dispute-service/dispute-opa-bundle.yaml
@@ -9,7 +9,7 @@ metadata:
     app.kubernetes.io/name: dispute-service
     app.kubernetes.io/part-of: dispute
   annotations:
-    openbank.tech/policy-checksum: "57d18c6aa30e7fad"
+    openbank.tech/policy-checksum: "66ea7f990813ccd4"
 data:
   rest.rego: |
     # SPDX-License-Identifier: Apache-2.0
@@ -2661,6 +2661,25 @@ data:
       # edge-service-notification rule and rest_test.rego's
       # test_deny_operator_read_any_does_not_cover_write).
       ci_producer: ".github/scripts/check-no-service-principal-type.sh"
+
+      # psd2_rest_ext.rego grants five actions — psd2.list/read/create/initiate/delete — to an
+      # ANONYMOUS principal, because a TPP authenticates by eIDAS QWAC (mTLS) and carries no
+      # bearer, so it reaches OPA as ANONYMOUS. That grant is safe ONLY because EidasMtlsFilter
+      # (@Priority(AUTHENTICATION)) has already 401'd a missing or unauthorized TPP on the path
+      # prefixes it gates. Until issue #2169 that invariant lived in a rego comment: an
+      # @Authorize(action = "psd2.initiate") added on a path the filter does NOT gate — a new
+      # admin route, a debug endpoint, anything under `open-banking/sandbox/` — would hand
+      # payment initiation to a genuinely unauthenticated caller with every CI gate green.
+      #
+      # The guard derives BOTH sides from source: the action set out of the rego rule, the gated
+      # prefixes (and their negated exclusions) out of EidasMtlsFilter's `gated` predicate. It
+      # keeps no copy of either — a guard whose scope is a hand-kept list of the thing it checks
+      # reads as passing when the list is short. Kotlin comments are stripped (block comments
+      # NEST) so an @Authorize quoted in a KDoc is never reported as an endpoint, and a run that
+      # matches zero endpoints FAILS rather than passing vacuously.
+      # 0 violations on origin/main at introduction — a regression guard. ENFORCED.
+      anonymous_grants_require_upstream_authn: true
+      anonymous_grant_ci_producer: ".github/scripts/check-psd2-anonymous-grant-paths.py"
 
     # ---------------------------------------------------------------------------------------
     # Scheduled-method invariants (issue #2148, fleet sweep #2187).

--- a/openbank-infra/gitops/components/dispute-service/dispute-service.yaml
+++ b/openbank-infra/gitops/components/dispute-service/dispute-service.yaml
@@ -15,7 +15,7 @@ spec:
       annotations:
         # Rolls the pod when the OPA bundle changes — subPath mounts do NOT hot-reload.
         # Kept in sync by gen-dispute-opa-bundle.sh (do not hand-edit).
-        openbank.tech/policy-checksum: "57d18c6aa30e7fad"
+        openbank.tech/policy-checksum: "66ea7f990813ccd4"
       labels: {app.kubernetes.io/name: dispute-service, app.kubernetes.io/part-of: dispute}
     spec:
       securityContext:

--- a/openbank-infra/gitops/components/document-service/document-service-opa-bundle.yaml
+++ b/openbank-infra/gitops/components/document-service/document-service-opa-bundle.yaml
@@ -10,7 +10,7 @@ metadata:
     app.kubernetes.io/name: document-service
     app.kubernetes.io/part-of: documents
   annotations:
-    openbank.tech/policy-checksum: "5370eab5af57bb71"
+    openbank.tech/policy-checksum: "2592909d9461fccf"
 data:
   rest.rego: |
     # SPDX-License-Identifier: Apache-2.0
@@ -1710,6 +1710,25 @@ data:
       # edge-service-notification rule and rest_test.rego's
       # test_deny_operator_read_any_does_not_cover_write).
       ci_producer: ".github/scripts/check-no-service-principal-type.sh"
+
+      # psd2_rest_ext.rego grants five actions — psd2.list/read/create/initiate/delete — to an
+      # ANONYMOUS principal, because a TPP authenticates by eIDAS QWAC (mTLS) and carries no
+      # bearer, so it reaches OPA as ANONYMOUS. That grant is safe ONLY because EidasMtlsFilter
+      # (@Priority(AUTHENTICATION)) has already 401'd a missing or unauthorized TPP on the path
+      # prefixes it gates. Until issue #2169 that invariant lived in a rego comment: an
+      # @Authorize(action = "psd2.initiate") added on a path the filter does NOT gate — a new
+      # admin route, a debug endpoint, anything under `open-banking/sandbox/` — would hand
+      # payment initiation to a genuinely unauthenticated caller with every CI gate green.
+      #
+      # The guard derives BOTH sides from source: the action set out of the rego rule, the gated
+      # prefixes (and their negated exclusions) out of EidasMtlsFilter's `gated` predicate. It
+      # keeps no copy of either — a guard whose scope is a hand-kept list of the thing it checks
+      # reads as passing when the list is short. Kotlin comments are stripped (block comments
+      # NEST) so an @Authorize quoted in a KDoc is never reported as an endpoint, and a run that
+      # matches zero endpoints FAILS rather than passing vacuously.
+      # 0 violations on origin/main at introduction — a regression guard. ENFORCED.
+      anonymous_grants_require_upstream_authn: true
+      anonymous_grant_ci_producer: ".github/scripts/check-psd2-anonymous-grant-paths.py"
 
     # ---------------------------------------------------------------------------------------
     # Scheduled-method invariants (issue #2148, fleet sweep #2187).

--- a/openbank-infra/gitops/components/document-service/document-service-service.yaml
+++ b/openbank-infra/gitops/components/document-service/document-service-service.yaml
@@ -43,7 +43,7 @@ spec:
       annotations:
         # Rolls the pods when the OPA bundle changes — subPath mounts do NOT hot-reload.
         # Kept in sync by gen-document-service-opa-bundle.sh (do not hand-edit).
-        openbank.tech/policy-checksum: "5370eab5af57bb71"
+        openbank.tech/policy-checksum: "2592909d9461fccf"
     spec:
       # ADR-0162 D4 (continued): a dedicated SA (not `default`) is what OpenBao's Kubernetes-auth
       # role `document-service-signing` is bound to — least-privilege, one identity per consumer.

--- a/openbank-infra/gitops/components/fraud-service/fraud-opa-bundle.yaml
+++ b/openbank-infra/gitops/components/fraud-service/fraud-opa-bundle.yaml
@@ -9,7 +9,7 @@ metadata:
     app.kubernetes.io/name: fraud-service
     app.kubernetes.io/part-of: fraud
   annotations:
-    openbank.tech/policy-checksum: "b4b5df85eb26b62c"
+    openbank.tech/policy-checksum: "a79143054d56f7e5"
 data:
   rest.rego: |
     # SPDX-License-Identifier: Apache-2.0
@@ -2536,6 +2536,25 @@ data:
       # edge-service-notification rule and rest_test.rego's
       # test_deny_operator_read_any_does_not_cover_write).
       ci_producer: ".github/scripts/check-no-service-principal-type.sh"
+
+      # psd2_rest_ext.rego grants five actions — psd2.list/read/create/initiate/delete — to an
+      # ANONYMOUS principal, because a TPP authenticates by eIDAS QWAC (mTLS) and carries no
+      # bearer, so it reaches OPA as ANONYMOUS. That grant is safe ONLY because EidasMtlsFilter
+      # (@Priority(AUTHENTICATION)) has already 401'd a missing or unauthorized TPP on the path
+      # prefixes it gates. Until issue #2169 that invariant lived in a rego comment: an
+      # @Authorize(action = "psd2.initiate") added on a path the filter does NOT gate — a new
+      # admin route, a debug endpoint, anything under `open-banking/sandbox/` — would hand
+      # payment initiation to a genuinely unauthenticated caller with every CI gate green.
+      #
+      # The guard derives BOTH sides from source: the action set out of the rego rule, the gated
+      # prefixes (and their negated exclusions) out of EidasMtlsFilter's `gated` predicate. It
+      # keeps no copy of either — a guard whose scope is a hand-kept list of the thing it checks
+      # reads as passing when the list is short. Kotlin comments are stripped (block comments
+      # NEST) so an @Authorize quoted in a KDoc is never reported as an endpoint, and a run that
+      # matches zero endpoints FAILS rather than passing vacuously.
+      # 0 violations on origin/main at introduction — a regression guard. ENFORCED.
+      anonymous_grants_require_upstream_authn: true
+      anonymous_grant_ci_producer: ".github/scripts/check-psd2-anonymous-grant-paths.py"
 
     # ---------------------------------------------------------------------------------------
     # Scheduled-method invariants (issue #2148, fleet sweep #2187).

--- a/openbank-infra/gitops/components/fraud-service/fraud-service.yaml
+++ b/openbank-infra/gitops/components/fraud-service/fraud-service.yaml
@@ -23,7 +23,7 @@ spec:
       annotations:
         # Rolls the pods when the OPA bundle changes — subPath mounts do NOT hot-reload.
         # Kept in sync by gen-fraud-opa-bundle.sh (do not hand-edit).
-        openbank.tech/policy-checksum: "b4b5df85eb26b62c"
+        openbank.tech/policy-checksum: "a79143054d56f7e5"
     spec:
       securityContext:
         runAsNonRoot: true

--- a/openbank-infra/gitops/components/fx-service/fx-opa-bundle.yaml
+++ b/openbank-infra/gitops/components/fx-service/fx-opa-bundle.yaml
@@ -9,7 +9,7 @@ metadata:
     app.kubernetes.io/name: fx-service
     app.kubernetes.io/part-of: fx
   annotations:
-    openbank.tech/policy-checksum: "e210004e675250c4"
+    openbank.tech/policy-checksum: "8f32f0c20d7202fd"
 data:
   rest.rego: |
     # SPDX-License-Identifier: Apache-2.0
@@ -2587,6 +2587,25 @@ data:
       # edge-service-notification rule and rest_test.rego's
       # test_deny_operator_read_any_does_not_cover_write).
       ci_producer: ".github/scripts/check-no-service-principal-type.sh"
+
+      # psd2_rest_ext.rego grants five actions — psd2.list/read/create/initiate/delete — to an
+      # ANONYMOUS principal, because a TPP authenticates by eIDAS QWAC (mTLS) and carries no
+      # bearer, so it reaches OPA as ANONYMOUS. That grant is safe ONLY because EidasMtlsFilter
+      # (@Priority(AUTHENTICATION)) has already 401'd a missing or unauthorized TPP on the path
+      # prefixes it gates. Until issue #2169 that invariant lived in a rego comment: an
+      # @Authorize(action = "psd2.initiate") added on a path the filter does NOT gate — a new
+      # admin route, a debug endpoint, anything under `open-banking/sandbox/` — would hand
+      # payment initiation to a genuinely unauthenticated caller with every CI gate green.
+      #
+      # The guard derives BOTH sides from source: the action set out of the rego rule, the gated
+      # prefixes (and their negated exclusions) out of EidasMtlsFilter's `gated` predicate. It
+      # keeps no copy of either — a guard whose scope is a hand-kept list of the thing it checks
+      # reads as passing when the list is short. Kotlin comments are stripped (block comments
+      # NEST) so an @Authorize quoted in a KDoc is never reported as an endpoint, and a run that
+      # matches zero endpoints FAILS rather than passing vacuously.
+      # 0 violations on origin/main at introduction — a regression guard. ENFORCED.
+      anonymous_grants_require_upstream_authn: true
+      anonymous_grant_ci_producer: ".github/scripts/check-psd2-anonymous-grant-paths.py"
 
     # ---------------------------------------------------------------------------------------
     # Scheduled-method invariants (issue #2148, fleet sweep #2187).

--- a/openbank-infra/gitops/components/fx-service/fx-service.yaml
+++ b/openbank-infra/gitops/components/fx-service/fx-service.yaml
@@ -22,7 +22,7 @@ spec:
       annotations:
         # Rolls the pods when the OPA bundle changes — subPath mounts do NOT hot-reload.
         # Kept in sync by gen-fx-opa-bundle.sh (do not hand-edit).
-        openbank.tech/policy-checksum: "e210004e675250c4"
+        openbank.tech/policy-checksum: "8f32f0c20d7202fd"
     spec:
       securityContext:
         runAsNonRoot: true

--- a/openbank-infra/gitops/components/interest-service/interest-opa-bundle.yaml
+++ b/openbank-infra/gitops/components/interest-service/interest-opa-bundle.yaml
@@ -9,7 +9,7 @@ metadata:
     app.kubernetes.io/name: interest-service
     app.kubernetes.io/part-of: interest
   annotations:
-    openbank.tech/policy-checksum: "5145fe52020bc631"
+    openbank.tech/policy-checksum: "4412f6d1af5bbc11"
 data:
   rest.rego: |
     # SPDX-License-Identifier: Apache-2.0
@@ -2521,6 +2521,25 @@ data:
       # edge-service-notification rule and rest_test.rego's
       # test_deny_operator_read_any_does_not_cover_write).
       ci_producer: ".github/scripts/check-no-service-principal-type.sh"
+
+      # psd2_rest_ext.rego grants five actions — psd2.list/read/create/initiate/delete — to an
+      # ANONYMOUS principal, because a TPP authenticates by eIDAS QWAC (mTLS) and carries no
+      # bearer, so it reaches OPA as ANONYMOUS. That grant is safe ONLY because EidasMtlsFilter
+      # (@Priority(AUTHENTICATION)) has already 401'd a missing or unauthorized TPP on the path
+      # prefixes it gates. Until issue #2169 that invariant lived in a rego comment: an
+      # @Authorize(action = "psd2.initiate") added on a path the filter does NOT gate — a new
+      # admin route, a debug endpoint, anything under `open-banking/sandbox/` — would hand
+      # payment initiation to a genuinely unauthenticated caller with every CI gate green.
+      #
+      # The guard derives BOTH sides from source: the action set out of the rego rule, the gated
+      # prefixes (and their negated exclusions) out of EidasMtlsFilter's `gated` predicate. It
+      # keeps no copy of either — a guard whose scope is a hand-kept list of the thing it checks
+      # reads as passing when the list is short. Kotlin comments are stripped (block comments
+      # NEST) so an @Authorize quoted in a KDoc is never reported as an endpoint, and a run that
+      # matches zero endpoints FAILS rather than passing vacuously.
+      # 0 violations on origin/main at introduction — a regression guard. ENFORCED.
+      anonymous_grants_require_upstream_authn: true
+      anonymous_grant_ci_producer: ".github/scripts/check-psd2-anonymous-grant-paths.py"
 
     # ---------------------------------------------------------------------------------------
     # Scheduled-method invariants (issue #2148, fleet sweep #2187).

--- a/openbank-infra/gitops/components/interest-service/interest-service.yaml
+++ b/openbank-infra/gitops/components/interest-service/interest-service.yaml
@@ -16,7 +16,7 @@ spec:
       annotations:
         # Rolls the pods when the OPA bundle changes — subPath mounts do NOT hot-reload.
         # Kept in sync by gen-interest-opa-bundle.sh (do not hand-edit).
-        openbank.tech/policy-checksum: "5145fe52020bc631"
+        openbank.tech/policy-checksum: "4412f6d1af5bbc11"
     spec:
       securityContext:
         runAsNonRoot: true

--- a/openbank-infra/gitops/components/kyc/kyc-opa-bundle.yaml
+++ b/openbank-infra/gitops/components/kyc/kyc-opa-bundle.yaml
@@ -9,7 +9,7 @@ metadata:
     app.kubernetes.io/name: kyc-service
     app.kubernetes.io/part-of: kyc
   annotations:
-    openbank.tech/policy-checksum: "9df4f9bfb3f60654"
+    openbank.tech/policy-checksum: "2e12ec37a1a677d2"
 data:
   rest.rego: |
     # SPDX-License-Identifier: Apache-2.0
@@ -2549,6 +2549,25 @@ data:
       # edge-service-notification rule and rest_test.rego's
       # test_deny_operator_read_any_does_not_cover_write).
       ci_producer: ".github/scripts/check-no-service-principal-type.sh"
+
+      # psd2_rest_ext.rego grants five actions — psd2.list/read/create/initiate/delete — to an
+      # ANONYMOUS principal, because a TPP authenticates by eIDAS QWAC (mTLS) and carries no
+      # bearer, so it reaches OPA as ANONYMOUS. That grant is safe ONLY because EidasMtlsFilter
+      # (@Priority(AUTHENTICATION)) has already 401'd a missing or unauthorized TPP on the path
+      # prefixes it gates. Until issue #2169 that invariant lived in a rego comment: an
+      # @Authorize(action = "psd2.initiate") added on a path the filter does NOT gate — a new
+      # admin route, a debug endpoint, anything under `open-banking/sandbox/` — would hand
+      # payment initiation to a genuinely unauthenticated caller with every CI gate green.
+      #
+      # The guard derives BOTH sides from source: the action set out of the rego rule, the gated
+      # prefixes (and their negated exclusions) out of EidasMtlsFilter's `gated` predicate. It
+      # keeps no copy of either — a guard whose scope is a hand-kept list of the thing it checks
+      # reads as passing when the list is short. Kotlin comments are stripped (block comments
+      # NEST) so an @Authorize quoted in a KDoc is never reported as an endpoint, and a run that
+      # matches zero endpoints FAILS rather than passing vacuously.
+      # 0 violations on origin/main at introduction — a regression guard. ENFORCED.
+      anonymous_grants_require_upstream_authn: true
+      anonymous_grant_ci_producer: ".github/scripts/check-psd2-anonymous-grant-paths.py"
 
     # ---------------------------------------------------------------------------------------
     # Scheduled-method invariants (issue #2148, fleet sweep #2187).

--- a/openbank-infra/gitops/components/kyc/kyc-service.yaml
+++ b/openbank-infra/gitops/components/kyc/kyc-service.yaml
@@ -48,7 +48,7 @@ spec:
       annotations:
         # Rolls the pod when the OPA bundle changes (subPath mounts do not hot-reload).
         # Kept in sync by gen-kyc-opa-bundle.sh (do not hand-edit).
-        openbank.tech/policy-checksum: "9df4f9bfb3f60654"
+        openbank.tech/policy-checksum: "2e12ec37a1a677d2"
     spec:
       securityContext:
         runAsNonRoot: true

--- a/openbank-infra/gitops/components/ledger/ledger-opa-bundle.yaml
+++ b/openbank-infra/gitops/components/ledger/ledger-opa-bundle.yaml
@@ -9,7 +9,7 @@ metadata:
     app.kubernetes.io/name: ledger-service
     app.kubernetes.io/part-of: ledger
   annotations:
-    openbank.tech/policy-checksum: "67f03c0b37de64e5"
+    openbank.tech/policy-checksum: "841a194f126b79c3"
 data:
   rest.rego: |
     # SPDX-License-Identifier: Apache-2.0
@@ -2634,6 +2634,25 @@ data:
       # edge-service-notification rule and rest_test.rego's
       # test_deny_operator_read_any_does_not_cover_write).
       ci_producer: ".github/scripts/check-no-service-principal-type.sh"
+
+      # psd2_rest_ext.rego grants five actions — psd2.list/read/create/initiate/delete — to an
+      # ANONYMOUS principal, because a TPP authenticates by eIDAS QWAC (mTLS) and carries no
+      # bearer, so it reaches OPA as ANONYMOUS. That grant is safe ONLY because EidasMtlsFilter
+      # (@Priority(AUTHENTICATION)) has already 401'd a missing or unauthorized TPP on the path
+      # prefixes it gates. Until issue #2169 that invariant lived in a rego comment: an
+      # @Authorize(action = "psd2.initiate") added on a path the filter does NOT gate — a new
+      # admin route, a debug endpoint, anything under `open-banking/sandbox/` — would hand
+      # payment initiation to a genuinely unauthenticated caller with every CI gate green.
+      #
+      # The guard derives BOTH sides from source: the action set out of the rego rule, the gated
+      # prefixes (and their negated exclusions) out of EidasMtlsFilter's `gated` predicate. It
+      # keeps no copy of either — a guard whose scope is a hand-kept list of the thing it checks
+      # reads as passing when the list is short. Kotlin comments are stripped (block comments
+      # NEST) so an @Authorize quoted in a KDoc is never reported as an endpoint, and a run that
+      # matches zero endpoints FAILS rather than passing vacuously.
+      # 0 violations on origin/main at introduction — a regression guard. ENFORCED.
+      anonymous_grants_require_upstream_authn: true
+      anonymous_grant_ci_producer: ".github/scripts/check-psd2-anonymous-grant-paths.py"
 
     # ---------------------------------------------------------------------------------------
     # Scheduled-method invariants (issue #2148, fleet sweep #2187).

--- a/openbank-infra/gitops/components/ledger/ledger-service.yaml
+++ b/openbank-infra/gitops/components/ledger/ledger-service.yaml
@@ -38,7 +38,7 @@ spec:
       annotations:
         # Rolls the pods when the OPA bundle changes — subPath mounts do NOT hot-reload.
         # Kept in sync by gen-ledger-opa-bundle.sh (do not hand-edit).
-        openbank.tech/policy-checksum: "67f03c0b37de64e5"
+        openbank.tech/policy-checksum: "841a194f126b79c3"
     spec:
       securityContext:
         runAsNonRoot: true

--- a/openbank-infra/gitops/components/lending/lending-opa-bundle.yaml
+++ b/openbank-infra/gitops/components/lending/lending-opa-bundle.yaml
@@ -9,7 +9,7 @@ metadata:
     app.kubernetes.io/name: lending-service
     app.kubernetes.io/part-of: lending
   annotations:
-    openbank.tech/policy-checksum: "326d6711ab47b971"
+    openbank.tech/policy-checksum: "c2b316cf03d1de04"
 data:
   rest.rego: |
     # SPDX-License-Identifier: Apache-2.0
@@ -2589,6 +2589,25 @@ data:
       # edge-service-notification rule and rest_test.rego's
       # test_deny_operator_read_any_does_not_cover_write).
       ci_producer: ".github/scripts/check-no-service-principal-type.sh"
+
+      # psd2_rest_ext.rego grants five actions — psd2.list/read/create/initiate/delete — to an
+      # ANONYMOUS principal, because a TPP authenticates by eIDAS QWAC (mTLS) and carries no
+      # bearer, so it reaches OPA as ANONYMOUS. That grant is safe ONLY because EidasMtlsFilter
+      # (@Priority(AUTHENTICATION)) has already 401'd a missing or unauthorized TPP on the path
+      # prefixes it gates. Until issue #2169 that invariant lived in a rego comment: an
+      # @Authorize(action = "psd2.initiate") added on a path the filter does NOT gate — a new
+      # admin route, a debug endpoint, anything under `open-banking/sandbox/` — would hand
+      # payment initiation to a genuinely unauthenticated caller with every CI gate green.
+      #
+      # The guard derives BOTH sides from source: the action set out of the rego rule, the gated
+      # prefixes (and their negated exclusions) out of EidasMtlsFilter's `gated` predicate. It
+      # keeps no copy of either — a guard whose scope is a hand-kept list of the thing it checks
+      # reads as passing when the list is short. Kotlin comments are stripped (block comments
+      # NEST) so an @Authorize quoted in a KDoc is never reported as an endpoint, and a run that
+      # matches zero endpoints FAILS rather than passing vacuously.
+      # 0 violations on origin/main at introduction — a regression guard. ENFORCED.
+      anonymous_grants_require_upstream_authn: true
+      anonymous_grant_ci_producer: ".github/scripts/check-psd2-anonymous-grant-paths.py"
 
     # ---------------------------------------------------------------------------------------
     # Scheduled-method invariants (issue #2148, fleet sweep #2187).

--- a/openbank-infra/gitops/components/lending/lending-service.yaml
+++ b/openbank-infra/gitops/components/lending/lending-service.yaml
@@ -34,7 +34,7 @@ spec:
       annotations:
         # Rolls the pods when the OPA bundle changes — subPath mounts do NOT hot-reload.
         # Kept in sync by gen-lending-opa-bundle.sh (do not hand-edit).
-        openbank.tech/policy-checksum: "326d6711ab47b971"
+        openbank.tech/policy-checksum: "c2b316cf03d1de04"
     spec:
       securityContext:
         runAsNonRoot: true

--- a/openbank-infra/gitops/components/mcp/mcp-opa-bundle.yaml
+++ b/openbank-infra/gitops/components/mcp/mcp-opa-bundle.yaml
@@ -9,7 +9,7 @@ metadata:
     app.kubernetes.io/name: mcp-service
     app.kubernetes.io/part-of: platform
   annotations:
-    openbank.tech/policy-checksum: "2c2f017d31e98e3c"
+    openbank.tech/policy-checksum: "2c3dc4da36574695"
 data:
   rest.rego: |
     # SPDX-License-Identifier: Apache-2.0
@@ -2487,6 +2487,25 @@ data:
       # edge-service-notification rule and rest_test.rego's
       # test_deny_operator_read_any_does_not_cover_write).
       ci_producer: ".github/scripts/check-no-service-principal-type.sh"
+
+      # psd2_rest_ext.rego grants five actions — psd2.list/read/create/initiate/delete — to an
+      # ANONYMOUS principal, because a TPP authenticates by eIDAS QWAC (mTLS) and carries no
+      # bearer, so it reaches OPA as ANONYMOUS. That grant is safe ONLY because EidasMtlsFilter
+      # (@Priority(AUTHENTICATION)) has already 401'd a missing or unauthorized TPP on the path
+      # prefixes it gates. Until issue #2169 that invariant lived in a rego comment: an
+      # @Authorize(action = "psd2.initiate") added on a path the filter does NOT gate — a new
+      # admin route, a debug endpoint, anything under `open-banking/sandbox/` — would hand
+      # payment initiation to a genuinely unauthenticated caller with every CI gate green.
+      #
+      # The guard derives BOTH sides from source: the action set out of the rego rule, the gated
+      # prefixes (and their negated exclusions) out of EidasMtlsFilter's `gated` predicate. It
+      # keeps no copy of either — a guard whose scope is a hand-kept list of the thing it checks
+      # reads as passing when the list is short. Kotlin comments are stripped (block comments
+      # NEST) so an @Authorize quoted in a KDoc is never reported as an endpoint, and a run that
+      # matches zero endpoints FAILS rather than passing vacuously.
+      # 0 violations on origin/main at introduction — a regression guard. ENFORCED.
+      anonymous_grants_require_upstream_authn: true
+      anonymous_grant_ci_producer: ".github/scripts/check-psd2-anonymous-grant-paths.py"
 
     # ---------------------------------------------------------------------------------------
     # Scheduled-method invariants (issue #2148, fleet sweep #2187).

--- a/openbank-infra/gitops/components/mcp/mcp-service.yaml
+++ b/openbank-infra/gitops/components/mcp/mcp-service.yaml
@@ -29,7 +29,7 @@ spec:
       annotations:
         # Rolls the pod when the OPA bundle changes — subPath mounts do NOT hot-reload.
         # Kept in sync by gen-mcp-opa-bundle.sh (do not hand-edit).
-        openbank.tech/policy-checksum: "2c2f017d31e98e3c"
+        openbank.tech/policy-checksum: "2c3dc4da36574695"
     spec:
       securityContext:
         runAsNonRoot: true

--- a/openbank-infra/gitops/components/notifications/notification-service-opa-bundle.yaml
+++ b/openbank-infra/gitops/components/notifications/notification-service-opa-bundle.yaml
@@ -10,7 +10,7 @@ metadata:
     app.kubernetes.io/name: notification-service
     app.kubernetes.io/part-of: notifications
   annotations:
-    openbank.tech/policy-checksum: "5370eab5af57bb71"
+    openbank.tech/policy-checksum: "2592909d9461fccf"
 data:
   rest.rego: |
     # SPDX-License-Identifier: Apache-2.0
@@ -1710,6 +1710,25 @@ data:
       # edge-service-notification rule and rest_test.rego's
       # test_deny_operator_read_any_does_not_cover_write).
       ci_producer: ".github/scripts/check-no-service-principal-type.sh"
+
+      # psd2_rest_ext.rego grants five actions — psd2.list/read/create/initiate/delete — to an
+      # ANONYMOUS principal, because a TPP authenticates by eIDAS QWAC (mTLS) and carries no
+      # bearer, so it reaches OPA as ANONYMOUS. That grant is safe ONLY because EidasMtlsFilter
+      # (@Priority(AUTHENTICATION)) has already 401'd a missing or unauthorized TPP on the path
+      # prefixes it gates. Until issue #2169 that invariant lived in a rego comment: an
+      # @Authorize(action = "psd2.initiate") added on a path the filter does NOT gate — a new
+      # admin route, a debug endpoint, anything under `open-banking/sandbox/` — would hand
+      # payment initiation to a genuinely unauthenticated caller with every CI gate green.
+      #
+      # The guard derives BOTH sides from source: the action set out of the rego rule, the gated
+      # prefixes (and their negated exclusions) out of EidasMtlsFilter's `gated` predicate. It
+      # keeps no copy of either — a guard whose scope is a hand-kept list of the thing it checks
+      # reads as passing when the list is short. Kotlin comments are stripped (block comments
+      # NEST) so an @Authorize quoted in a KDoc is never reported as an endpoint, and a run that
+      # matches zero endpoints FAILS rather than passing vacuously.
+      # 0 violations on origin/main at introduction — a regression guard. ENFORCED.
+      anonymous_grants_require_upstream_authn: true
+      anonymous_grant_ci_producer: ".github/scripts/check-psd2-anonymous-grant-paths.py"
 
     # ---------------------------------------------------------------------------------------
     # Scheduled-method invariants (issue #2148, fleet sweep #2187).

--- a/openbank-infra/gitops/components/notifications/notification-service.yaml
+++ b/openbank-infra/gitops/components/notifications/notification-service.yaml
@@ -39,7 +39,7 @@ spec:
       annotations:
         # Rolls the Deployment when the OPA policy bundle changes (subPath mounts don't
         # hot-reload). Kept in sync by gen-notification-opa-bundle.sh.
-        openbank.tech/policy-checksum: "5370eab5af57bb71"
+        openbank.tech/policy-checksum: "2592909d9461fccf"
       labels:
         app.kubernetes.io/name: notification-service
         app.kubernetes.io/part-of: notifications

--- a/openbank-infra/gitops/components/party/party-opa-bundle.yaml
+++ b/openbank-infra/gitops/components/party/party-opa-bundle.yaml
@@ -9,7 +9,7 @@ metadata:
     app.kubernetes.io/name: party-service
     app.kubernetes.io/part-of: party
   annotations:
-    openbank.tech/policy-checksum: "50775cd525d959d3"
+    openbank.tech/policy-checksum: "d9b02679c725aad6"
 data:
   rest.rego: |
     # SPDX-License-Identifier: Apache-2.0
@@ -2558,6 +2558,25 @@ data:
       # edge-service-notification rule and rest_test.rego's
       # test_deny_operator_read_any_does_not_cover_write).
       ci_producer: ".github/scripts/check-no-service-principal-type.sh"
+
+      # psd2_rest_ext.rego grants five actions — psd2.list/read/create/initiate/delete — to an
+      # ANONYMOUS principal, because a TPP authenticates by eIDAS QWAC (mTLS) and carries no
+      # bearer, so it reaches OPA as ANONYMOUS. That grant is safe ONLY because EidasMtlsFilter
+      # (@Priority(AUTHENTICATION)) has already 401'd a missing or unauthorized TPP on the path
+      # prefixes it gates. Until issue #2169 that invariant lived in a rego comment: an
+      # @Authorize(action = "psd2.initiate") added on a path the filter does NOT gate — a new
+      # admin route, a debug endpoint, anything under `open-banking/sandbox/` — would hand
+      # payment initiation to a genuinely unauthenticated caller with every CI gate green.
+      #
+      # The guard derives BOTH sides from source: the action set out of the rego rule, the gated
+      # prefixes (and their negated exclusions) out of EidasMtlsFilter's `gated` predicate. It
+      # keeps no copy of either — a guard whose scope is a hand-kept list of the thing it checks
+      # reads as passing when the list is short. Kotlin comments are stripped (block comments
+      # NEST) so an @Authorize quoted in a KDoc is never reported as an endpoint, and a run that
+      # matches zero endpoints FAILS rather than passing vacuously.
+      # 0 violations on origin/main at introduction — a regression guard. ENFORCED.
+      anonymous_grants_require_upstream_authn: true
+      anonymous_grant_ci_producer: ".github/scripts/check-psd2-anonymous-grant-paths.py"
 
     # ---------------------------------------------------------------------------------------
     # Scheduled-method invariants (issue #2148, fleet sweep #2187).

--- a/openbank-infra/gitops/components/party/party-service.yaml
+++ b/openbank-infra/gitops/components/party/party-service.yaml
@@ -22,7 +22,7 @@ spec:
       annotations:
         # Rolls the pod when the OPA bundle changes — subPath mounts do NOT hot-reload.
         # Kept in sync by gen-party-opa-bundle.sh (do not hand-edit).
-        openbank.tech/policy-checksum: "50775cd525d959d3"
+        openbank.tech/policy-checksum: "d9b02679c725aad6"
       labels:
         app.kubernetes.io/name: party-service
         app.kubernetes.io/part-of: party

--- a/openbank-infra/gitops/components/payments/card-issuance-opa-bundle.yaml
+++ b/openbank-infra/gitops/components/payments/card-issuance-opa-bundle.yaml
@@ -9,7 +9,7 @@ metadata:
     app.kubernetes.io/name: card-issuance-service
     app.kubernetes.io/part-of: payments
   annotations:
-    openbank.tech/policy-checksum: "965e3c96faa63c57"
+    openbank.tech/policy-checksum: "04a0c84bd0298552"
 data:
   rest.rego: |
     # SPDX-License-Identifier: Apache-2.0
@@ -2542,6 +2542,25 @@ data:
       # edge-service-notification rule and rest_test.rego's
       # test_deny_operator_read_any_does_not_cover_write).
       ci_producer: ".github/scripts/check-no-service-principal-type.sh"
+
+      # psd2_rest_ext.rego grants five actions — psd2.list/read/create/initiate/delete — to an
+      # ANONYMOUS principal, because a TPP authenticates by eIDAS QWAC (mTLS) and carries no
+      # bearer, so it reaches OPA as ANONYMOUS. That grant is safe ONLY because EidasMtlsFilter
+      # (@Priority(AUTHENTICATION)) has already 401'd a missing or unauthorized TPP on the path
+      # prefixes it gates. Until issue #2169 that invariant lived in a rego comment: an
+      # @Authorize(action = "psd2.initiate") added on a path the filter does NOT gate — a new
+      # admin route, a debug endpoint, anything under `open-banking/sandbox/` — would hand
+      # payment initiation to a genuinely unauthenticated caller with every CI gate green.
+      #
+      # The guard derives BOTH sides from source: the action set out of the rego rule, the gated
+      # prefixes (and their negated exclusions) out of EidasMtlsFilter's `gated` predicate. It
+      # keeps no copy of either — a guard whose scope is a hand-kept list of the thing it checks
+      # reads as passing when the list is short. Kotlin comments are stripped (block comments
+      # NEST) so an @Authorize quoted in a KDoc is never reported as an endpoint, and a run that
+      # matches zero endpoints FAILS rather than passing vacuously.
+      # 0 violations on origin/main at introduction — a regression guard. ENFORCED.
+      anonymous_grants_require_upstream_authn: true
+      anonymous_grant_ci_producer: ".github/scripts/check-psd2-anonymous-grant-paths.py"
 
     # ---------------------------------------------------------------------------------------
     # Scheduled-method invariants (issue #2148, fleet sweep #2187).

--- a/openbank-infra/gitops/components/payments/clearing-opa-bundle.yaml
+++ b/openbank-infra/gitops/components/payments/clearing-opa-bundle.yaml
@@ -9,7 +9,7 @@ metadata:
     app.kubernetes.io/name: clearing-service
     app.kubernetes.io/part-of: payments
   annotations:
-    openbank.tech/policy-checksum: "3fdc20ffca424152"
+    openbank.tech/policy-checksum: "aafa5bc2c2821401"
 data:
   rest.rego: |
     # SPDX-License-Identifier: Apache-2.0
@@ -2579,6 +2579,25 @@ data:
       # edge-service-notification rule and rest_test.rego's
       # test_deny_operator_read_any_does_not_cover_write).
       ci_producer: ".github/scripts/check-no-service-principal-type.sh"
+
+      # psd2_rest_ext.rego grants five actions — psd2.list/read/create/initiate/delete — to an
+      # ANONYMOUS principal, because a TPP authenticates by eIDAS QWAC (mTLS) and carries no
+      # bearer, so it reaches OPA as ANONYMOUS. That grant is safe ONLY because EidasMtlsFilter
+      # (@Priority(AUTHENTICATION)) has already 401'd a missing or unauthorized TPP on the path
+      # prefixes it gates. Until issue #2169 that invariant lived in a rego comment: an
+      # @Authorize(action = "psd2.initiate") added on a path the filter does NOT gate — a new
+      # admin route, a debug endpoint, anything under `open-banking/sandbox/` — would hand
+      # payment initiation to a genuinely unauthenticated caller with every CI gate green.
+      #
+      # The guard derives BOTH sides from source: the action set out of the rego rule, the gated
+      # prefixes (and their negated exclusions) out of EidasMtlsFilter's `gated` predicate. It
+      # keeps no copy of either — a guard whose scope is a hand-kept list of the thing it checks
+      # reads as passing when the list is short. Kotlin comments are stripped (block comments
+      # NEST) so an @Authorize quoted in a KDoc is never reported as an endpoint, and a run that
+      # matches zero endpoints FAILS rather than passing vacuously.
+      # 0 violations on origin/main at introduction — a regression guard. ENFORCED.
+      anonymous_grants_require_upstream_authn: true
+      anonymous_grant_ci_producer: ".github/scripts/check-psd2-anonymous-grant-paths.py"
 
     # ---------------------------------------------------------------------------------------
     # Scheduled-method invariants (issue #2148, fleet sweep #2187).

--- a/openbank-infra/gitops/components/payments/domestic-payment-opa-bundle.yaml
+++ b/openbank-infra/gitops/components/payments/domestic-payment-opa-bundle.yaml
@@ -9,7 +9,7 @@ metadata:
     app.kubernetes.io/name: domestic-payment
     app.kubernetes.io/part-of: payments
   annotations:
-    openbank.tech/policy-checksum: "6b5b674af135d7d6"
+    openbank.tech/policy-checksum: "223200b2c8fffe63"
 data:
   rest.rego: |
     # SPDX-License-Identifier: Apache-2.0
@@ -2564,6 +2564,25 @@ data:
       # edge-service-notification rule and rest_test.rego's
       # test_deny_operator_read_any_does_not_cover_write).
       ci_producer: ".github/scripts/check-no-service-principal-type.sh"
+
+      # psd2_rest_ext.rego grants five actions — psd2.list/read/create/initiate/delete — to an
+      # ANONYMOUS principal, because a TPP authenticates by eIDAS QWAC (mTLS) and carries no
+      # bearer, so it reaches OPA as ANONYMOUS. That grant is safe ONLY because EidasMtlsFilter
+      # (@Priority(AUTHENTICATION)) has already 401'd a missing or unauthorized TPP on the path
+      # prefixes it gates. Until issue #2169 that invariant lived in a rego comment: an
+      # @Authorize(action = "psd2.initiate") added on a path the filter does NOT gate — a new
+      # admin route, a debug endpoint, anything under `open-banking/sandbox/` — would hand
+      # payment initiation to a genuinely unauthenticated caller with every CI gate green.
+      #
+      # The guard derives BOTH sides from source: the action set out of the rego rule, the gated
+      # prefixes (and their negated exclusions) out of EidasMtlsFilter's `gated` predicate. It
+      # keeps no copy of either — a guard whose scope is a hand-kept list of the thing it checks
+      # reads as passing when the list is short. Kotlin comments are stripped (block comments
+      # NEST) so an @Authorize quoted in a KDoc is never reported as an endpoint, and a run that
+      # matches zero endpoints FAILS rather than passing vacuously.
+      # 0 violations on origin/main at introduction — a regression guard. ENFORCED.
+      anonymous_grants_require_upstream_authn: true
+      anonymous_grant_ci_producer: ".github/scripts/check-psd2-anonymous-grant-paths.py"
 
     # ---------------------------------------------------------------------------------------
     # Scheduled-method invariants (issue #2148, fleet sweep #2187).

--- a/openbank-infra/gitops/components/payments/payments-services.yaml
+++ b/openbank-infra/gitops/components/payments/payments-services.yaml
@@ -42,7 +42,7 @@ spec:
         # Rolls the pods when the OPA bundle changes — subPath mounts do NOT hot-reload.
         # Kept in sync by gen-transaction-opa-bundle.sh via the trailing marker comment
         # (do not hand-edit, do not drop the marker).
-        openbank.tech/policy-checksum: "f881bb1f3833df31" # transaction-opa-bundle
+        openbank.tech/policy-checksum: "3d17e362ec88ffbb" # transaction-opa-bundle
     spec:
       securityContext:
         runAsNonRoot: true
@@ -375,7 +375,7 @@ spec:
       annotations:
         # Rolls the pods when the OPA bundle changes — subPath mounts do NOT hot-reload.
         # Kept in sync by gen-sepa-payment-opa-bundle.sh (do not hand-edit).
-        openbank.tech/policy-checksum: "59a4ed6d83ead5a6"
+        openbank.tech/policy-checksum: "be9f59fe0f92e046"
     spec:
       securityContext:
         runAsNonRoot: true
@@ -729,7 +729,7 @@ spec:
         # Rolls the pods when the OPA bundle changes — subPath mounts do NOT hot-reload.
         # Kept in sync by gen-domestic-payment-opa-bundle.sh via the trailing marker
         # comment (do not hand-edit, do not drop the marker).
-        openbank.tech/policy-checksum: "6b5b674af135d7d6" # domestic-payment-opa-bundle
+        openbank.tech/policy-checksum: "223200b2c8fffe63" # domestic-payment-opa-bundle
     spec:
       securityContext:
         runAsNonRoot: true
@@ -1053,7 +1053,7 @@ spec:
       annotations:
         # Rolls the pods when the OPA bundle changes — subPath mounts do NOT hot-reload.
         # Kept in sync by gen-sepa-instant-opa-bundle.sh (do not hand-edit).
-        openbank.tech/policy-checksum: "d2589f8c417ec426"
+        openbank.tech/policy-checksum: "a628472b54b845c6"
     spec:
       securityContext:
         runAsNonRoot: true
@@ -1369,7 +1369,7 @@ spec:
         # Rolls the pods when the OPA bundle changes — subPath mounts do NOT hot-reload.
         # Kept in sync by gen-clearing-opa-bundle.sh via the trailing marker comment
         # (do not hand-edit, do not drop the marker).
-        openbank.tech/policy-checksum: "3fdc20ffca424152" # clearing-opa-bundle
+        openbank.tech/policy-checksum: "aafa5bc2c2821401" # clearing-opa-bundle
     spec:
       securityContext:
         runAsNonRoot: true
@@ -1658,7 +1658,7 @@ spec:
       annotations:
         # Rolls the pod when the OPA bundle changes (ADR-0034). Value is stamped by
         # gen-standing-order-opa-bundle.sh — do not hand-edit.
-        openbank.tech/policy-checksum: "156ca771dd3aa0a0" # standing-order-opa-bundle
+        openbank.tech/policy-checksum: "71349354f2e3d1ea" # standing-order-opa-bundle
     spec:
       securityContext:
         runAsNonRoot: true
@@ -1911,7 +1911,7 @@ spec:
       annotations:
         # Rolls the pods when the OPA bundle changes — subPath mounts do NOT hot-reload.
         # Kept in sync by gen-card-issuance-opa-bundle.sh (do not hand-edit).
-        openbank.tech/policy-checksum: "965e3c96faa63c57"
+        openbank.tech/policy-checksum: "04a0c84bd0298552"
     spec:
       securityContext:
         runAsNonRoot: true
@@ -2178,7 +2178,7 @@ spec:
         # Rolls the pods when the OPA bundle changes — subPath mounts do NOT hot-reload.
         # Kept in sync by gen-settlement-opa-bundle.sh via the trailing marker comment
         # (do not hand-edit, do not drop the marker).
-        openbank.tech/policy-checksum: "84be04106d7e1817" # settlement-opa-bundle
+        openbank.tech/policy-checksum: "0574cf706c843626" # settlement-opa-bundle
     spec:
       securityContext:
         runAsNonRoot: true
@@ -2579,7 +2579,7 @@ spec:
       annotations:
         # Rolls the pods when the OPA bundle changes — subPath mounts do NOT hot-reload.
         # Kept in sync by gen-swift-opa-bundle.sh (do not hand-edit).
-        openbank.tech/policy-checksum: "314f09ec705d2363"
+        openbank.tech/policy-checksum: "ad1e0a0cb030bff7"
     spec:
       securityContext:
         runAsNonRoot: true
@@ -2893,7 +2893,7 @@ spec:
       annotations:
         # Rolls the pods when the OPA bundle changes — subPath mounts do NOT hot-reload.
         # Kept in sync by gen-vop-opa-bundle.sh (do not hand-edit).
-        openbank.tech/policy-checksum: "2d588b32c3fc5a4b"
+        openbank.tech/policy-checksum: "4e18fa5e701fa176"
     spec:
       securityContext:
         runAsNonRoot: true

--- a/openbank-infra/gitops/components/payments/sepa-instant-opa-bundle.yaml
+++ b/openbank-infra/gitops/components/payments/sepa-instant-opa-bundle.yaml
@@ -9,7 +9,7 @@ metadata:
     app.kubernetes.io/name: sepa-instant
     app.kubernetes.io/part-of: payments
   annotations:
-    openbank.tech/policy-checksum: "d2589f8c417ec426"
+    openbank.tech/policy-checksum: "a628472b54b845c6"
 data:
   rest.rego: |
     # SPDX-License-Identifier: Apache-2.0
@@ -2537,6 +2537,25 @@ data:
       # edge-service-notification rule and rest_test.rego's
       # test_deny_operator_read_any_does_not_cover_write).
       ci_producer: ".github/scripts/check-no-service-principal-type.sh"
+
+      # psd2_rest_ext.rego grants five actions — psd2.list/read/create/initiate/delete — to an
+      # ANONYMOUS principal, because a TPP authenticates by eIDAS QWAC (mTLS) and carries no
+      # bearer, so it reaches OPA as ANONYMOUS. That grant is safe ONLY because EidasMtlsFilter
+      # (@Priority(AUTHENTICATION)) has already 401'd a missing or unauthorized TPP on the path
+      # prefixes it gates. Until issue #2169 that invariant lived in a rego comment: an
+      # @Authorize(action = "psd2.initiate") added on a path the filter does NOT gate — a new
+      # admin route, a debug endpoint, anything under `open-banking/sandbox/` — would hand
+      # payment initiation to a genuinely unauthenticated caller with every CI gate green.
+      #
+      # The guard derives BOTH sides from source: the action set out of the rego rule, the gated
+      # prefixes (and their negated exclusions) out of EidasMtlsFilter's `gated` predicate. It
+      # keeps no copy of either — a guard whose scope is a hand-kept list of the thing it checks
+      # reads as passing when the list is short. Kotlin comments are stripped (block comments
+      # NEST) so an @Authorize quoted in a KDoc is never reported as an endpoint, and a run that
+      # matches zero endpoints FAILS rather than passing vacuously.
+      # 0 violations on origin/main at introduction — a regression guard. ENFORCED.
+      anonymous_grants_require_upstream_authn: true
+      anonymous_grant_ci_producer: ".github/scripts/check-psd2-anonymous-grant-paths.py"
 
     # ---------------------------------------------------------------------------------------
     # Scheduled-method invariants (issue #2148, fleet sweep #2187).

--- a/openbank-infra/gitops/components/payments/sepa-payment-opa-bundle.yaml
+++ b/openbank-infra/gitops/components/payments/sepa-payment-opa-bundle.yaml
@@ -9,7 +9,7 @@ metadata:
     app.kubernetes.io/name: sepa-payment
     app.kubernetes.io/part-of: payments
   annotations:
-    openbank.tech/policy-checksum: "59a4ed6d83ead5a6"
+    openbank.tech/policy-checksum: "be9f59fe0f92e046"
 data:
   rest.rego: |
     # SPDX-License-Identifier: Apache-2.0
@@ -2558,6 +2558,25 @@ data:
       # edge-service-notification rule and rest_test.rego's
       # test_deny_operator_read_any_does_not_cover_write).
       ci_producer: ".github/scripts/check-no-service-principal-type.sh"
+
+      # psd2_rest_ext.rego grants five actions — psd2.list/read/create/initiate/delete — to an
+      # ANONYMOUS principal, because a TPP authenticates by eIDAS QWAC (mTLS) and carries no
+      # bearer, so it reaches OPA as ANONYMOUS. That grant is safe ONLY because EidasMtlsFilter
+      # (@Priority(AUTHENTICATION)) has already 401'd a missing or unauthorized TPP on the path
+      # prefixes it gates. Until issue #2169 that invariant lived in a rego comment: an
+      # @Authorize(action = "psd2.initiate") added on a path the filter does NOT gate — a new
+      # admin route, a debug endpoint, anything under `open-banking/sandbox/` — would hand
+      # payment initiation to a genuinely unauthenticated caller with every CI gate green.
+      #
+      # The guard derives BOTH sides from source: the action set out of the rego rule, the gated
+      # prefixes (and their negated exclusions) out of EidasMtlsFilter's `gated` predicate. It
+      # keeps no copy of either — a guard whose scope is a hand-kept list of the thing it checks
+      # reads as passing when the list is short. Kotlin comments are stripped (block comments
+      # NEST) so an @Authorize quoted in a KDoc is never reported as an endpoint, and a run that
+      # matches zero endpoints FAILS rather than passing vacuously.
+      # 0 violations on origin/main at introduction — a regression guard. ENFORCED.
+      anonymous_grants_require_upstream_authn: true
+      anonymous_grant_ci_producer: ".github/scripts/check-psd2-anonymous-grant-paths.py"
 
     # ---------------------------------------------------------------------------------------
     # Scheduled-method invariants (issue #2148, fleet sweep #2187).

--- a/openbank-infra/gitops/components/payments/settlement-opa-bundle.yaml
+++ b/openbank-infra/gitops/components/payments/settlement-opa-bundle.yaml
@@ -9,7 +9,7 @@ metadata:
     app.kubernetes.io/name: settlement-service
     app.kubernetes.io/part-of: payments
   annotations:
-    openbank.tech/policy-checksum: "84be04106d7e1817"
+    openbank.tech/policy-checksum: "0574cf706c843626"
 data:
   rest.rego: |
     # SPDX-License-Identifier: Apache-2.0
@@ -2538,6 +2538,25 @@ data:
       # edge-service-notification rule and rest_test.rego's
       # test_deny_operator_read_any_does_not_cover_write).
       ci_producer: ".github/scripts/check-no-service-principal-type.sh"
+
+      # psd2_rest_ext.rego grants five actions — psd2.list/read/create/initiate/delete — to an
+      # ANONYMOUS principal, because a TPP authenticates by eIDAS QWAC (mTLS) and carries no
+      # bearer, so it reaches OPA as ANONYMOUS. That grant is safe ONLY because EidasMtlsFilter
+      # (@Priority(AUTHENTICATION)) has already 401'd a missing or unauthorized TPP on the path
+      # prefixes it gates. Until issue #2169 that invariant lived in a rego comment: an
+      # @Authorize(action = "psd2.initiate") added on a path the filter does NOT gate — a new
+      # admin route, a debug endpoint, anything under `open-banking/sandbox/` — would hand
+      # payment initiation to a genuinely unauthenticated caller with every CI gate green.
+      #
+      # The guard derives BOTH sides from source: the action set out of the rego rule, the gated
+      # prefixes (and their negated exclusions) out of EidasMtlsFilter's `gated` predicate. It
+      # keeps no copy of either — a guard whose scope is a hand-kept list of the thing it checks
+      # reads as passing when the list is short. Kotlin comments are stripped (block comments
+      # NEST) so an @Authorize quoted in a KDoc is never reported as an endpoint, and a run that
+      # matches zero endpoints FAILS rather than passing vacuously.
+      # 0 violations on origin/main at introduction — a regression guard. ENFORCED.
+      anonymous_grants_require_upstream_authn: true
+      anonymous_grant_ci_producer: ".github/scripts/check-psd2-anonymous-grant-paths.py"
 
     # ---------------------------------------------------------------------------------------
     # Scheduled-method invariants (issue #2148, fleet sweep #2187).

--- a/openbank-infra/gitops/components/payments/standing-order-opa-bundle.yaml
+++ b/openbank-infra/gitops/components/payments/standing-order-opa-bundle.yaml
@@ -9,7 +9,7 @@ metadata:
     app.kubernetes.io/name: standing-order-service
     app.kubernetes.io/part-of: payments
   annotations:
-    openbank.tech/policy-checksum: "156ca771dd3aa0a0"
+    openbank.tech/policy-checksum: "71349354f2e3d1ea"
 data:
   rest.rego: |
     # SPDX-License-Identifier: Apache-2.0
@@ -2523,6 +2523,25 @@ data:
       # edge-service-notification rule and rest_test.rego's
       # test_deny_operator_read_any_does_not_cover_write).
       ci_producer: ".github/scripts/check-no-service-principal-type.sh"
+
+      # psd2_rest_ext.rego grants five actions — psd2.list/read/create/initiate/delete — to an
+      # ANONYMOUS principal, because a TPP authenticates by eIDAS QWAC (mTLS) and carries no
+      # bearer, so it reaches OPA as ANONYMOUS. That grant is safe ONLY because EidasMtlsFilter
+      # (@Priority(AUTHENTICATION)) has already 401'd a missing or unauthorized TPP on the path
+      # prefixes it gates. Until issue #2169 that invariant lived in a rego comment: an
+      # @Authorize(action = "psd2.initiate") added on a path the filter does NOT gate — a new
+      # admin route, a debug endpoint, anything under `open-banking/sandbox/` — would hand
+      # payment initiation to a genuinely unauthenticated caller with every CI gate green.
+      #
+      # The guard derives BOTH sides from source: the action set out of the rego rule, the gated
+      # prefixes (and their negated exclusions) out of EidasMtlsFilter's `gated` predicate. It
+      # keeps no copy of either — a guard whose scope is a hand-kept list of the thing it checks
+      # reads as passing when the list is short. Kotlin comments are stripped (block comments
+      # NEST) so an @Authorize quoted in a KDoc is never reported as an endpoint, and a run that
+      # matches zero endpoints FAILS rather than passing vacuously.
+      # 0 violations on origin/main at introduction — a regression guard. ENFORCED.
+      anonymous_grants_require_upstream_authn: true
+      anonymous_grant_ci_producer: ".github/scripts/check-psd2-anonymous-grant-paths.py"
 
     # ---------------------------------------------------------------------------------------
     # Scheduled-method invariants (issue #2148, fleet sweep #2187).

--- a/openbank-infra/gitops/components/payments/swift-opa-bundle.yaml
+++ b/openbank-infra/gitops/components/payments/swift-opa-bundle.yaml
@@ -9,7 +9,7 @@ metadata:
     app.kubernetes.io/name: swift-service
     app.kubernetes.io/part-of: payments
   annotations:
-    openbank.tech/policy-checksum: "314f09ec705d2363"
+    openbank.tech/policy-checksum: "ad1e0a0cb030bff7"
 data:
   rest.rego: |
     # SPDX-License-Identifier: Apache-2.0
@@ -2541,6 +2541,25 @@ data:
       # edge-service-notification rule and rest_test.rego's
       # test_deny_operator_read_any_does_not_cover_write).
       ci_producer: ".github/scripts/check-no-service-principal-type.sh"
+
+      # psd2_rest_ext.rego grants five actions — psd2.list/read/create/initiate/delete — to an
+      # ANONYMOUS principal, because a TPP authenticates by eIDAS QWAC (mTLS) and carries no
+      # bearer, so it reaches OPA as ANONYMOUS. That grant is safe ONLY because EidasMtlsFilter
+      # (@Priority(AUTHENTICATION)) has already 401'd a missing or unauthorized TPP on the path
+      # prefixes it gates. Until issue #2169 that invariant lived in a rego comment: an
+      # @Authorize(action = "psd2.initiate") added on a path the filter does NOT gate — a new
+      # admin route, a debug endpoint, anything under `open-banking/sandbox/` — would hand
+      # payment initiation to a genuinely unauthenticated caller with every CI gate green.
+      #
+      # The guard derives BOTH sides from source: the action set out of the rego rule, the gated
+      # prefixes (and their negated exclusions) out of EidasMtlsFilter's `gated` predicate. It
+      # keeps no copy of either — a guard whose scope is a hand-kept list of the thing it checks
+      # reads as passing when the list is short. Kotlin comments are stripped (block comments
+      # NEST) so an @Authorize quoted in a KDoc is never reported as an endpoint, and a run that
+      # matches zero endpoints FAILS rather than passing vacuously.
+      # 0 violations on origin/main at introduction — a regression guard. ENFORCED.
+      anonymous_grants_require_upstream_authn: true
+      anonymous_grant_ci_producer: ".github/scripts/check-psd2-anonymous-grant-paths.py"
 
     # ---------------------------------------------------------------------------------------
     # Scheduled-method invariants (issue #2148, fleet sweep #2187).

--- a/openbank-infra/gitops/components/payments/transaction-opa-bundle.yaml
+++ b/openbank-infra/gitops/components/payments/transaction-opa-bundle.yaml
@@ -9,7 +9,7 @@ metadata:
     app.kubernetes.io/name: transaction-service
     app.kubernetes.io/part-of: payments
   annotations:
-    openbank.tech/policy-checksum: "f881bb1f3833df31"
+    openbank.tech/policy-checksum: "3d17e362ec88ffbb"
 data:
   rest.rego: |
     # SPDX-License-Identifier: Apache-2.0
@@ -2594,6 +2594,25 @@ data:
       # edge-service-notification rule and rest_test.rego's
       # test_deny_operator_read_any_does_not_cover_write).
       ci_producer: ".github/scripts/check-no-service-principal-type.sh"
+
+      # psd2_rest_ext.rego grants five actions — psd2.list/read/create/initiate/delete — to an
+      # ANONYMOUS principal, because a TPP authenticates by eIDAS QWAC (mTLS) and carries no
+      # bearer, so it reaches OPA as ANONYMOUS. That grant is safe ONLY because EidasMtlsFilter
+      # (@Priority(AUTHENTICATION)) has already 401'd a missing or unauthorized TPP on the path
+      # prefixes it gates. Until issue #2169 that invariant lived in a rego comment: an
+      # @Authorize(action = "psd2.initiate") added on a path the filter does NOT gate — a new
+      # admin route, a debug endpoint, anything under `open-banking/sandbox/` — would hand
+      # payment initiation to a genuinely unauthenticated caller with every CI gate green.
+      #
+      # The guard derives BOTH sides from source: the action set out of the rego rule, the gated
+      # prefixes (and their negated exclusions) out of EidasMtlsFilter's `gated` predicate. It
+      # keeps no copy of either — a guard whose scope is a hand-kept list of the thing it checks
+      # reads as passing when the list is short. Kotlin comments are stripped (block comments
+      # NEST) so an @Authorize quoted in a KDoc is never reported as an endpoint, and a run that
+      # matches zero endpoints FAILS rather than passing vacuously.
+      # 0 violations on origin/main at introduction — a regression guard. ENFORCED.
+      anonymous_grants_require_upstream_authn: true
+      anonymous_grant_ci_producer: ".github/scripts/check-psd2-anonymous-grant-paths.py"
 
     # ---------------------------------------------------------------------------------------
     # Scheduled-method invariants (issue #2148, fleet sweep #2187).

--- a/openbank-infra/gitops/components/payments/vop-opa-bundle.yaml
+++ b/openbank-infra/gitops/components/payments/vop-opa-bundle.yaml
@@ -9,7 +9,7 @@ metadata:
     app.kubernetes.io/name: vop-service
     app.kubernetes.io/part-of: payments
   annotations:
-    openbank.tech/policy-checksum: "2d588b32c3fc5a4b"
+    openbank.tech/policy-checksum: "4e18fa5e701fa176"
 data:
   rest.rego: |
     # SPDX-License-Identifier: Apache-2.0
@@ -2545,6 +2545,25 @@ data:
       # edge-service-notification rule and rest_test.rego's
       # test_deny_operator_read_any_does_not_cover_write).
       ci_producer: ".github/scripts/check-no-service-principal-type.sh"
+
+      # psd2_rest_ext.rego grants five actions — psd2.list/read/create/initiate/delete — to an
+      # ANONYMOUS principal, because a TPP authenticates by eIDAS QWAC (mTLS) and carries no
+      # bearer, so it reaches OPA as ANONYMOUS. That grant is safe ONLY because EidasMtlsFilter
+      # (@Priority(AUTHENTICATION)) has already 401'd a missing or unauthorized TPP on the path
+      # prefixes it gates. Until issue #2169 that invariant lived in a rego comment: an
+      # @Authorize(action = "psd2.initiate") added on a path the filter does NOT gate — a new
+      # admin route, a debug endpoint, anything under `open-banking/sandbox/` — would hand
+      # payment initiation to a genuinely unauthenticated caller with every CI gate green.
+      #
+      # The guard derives BOTH sides from source: the action set out of the rego rule, the gated
+      # prefixes (and their negated exclusions) out of EidasMtlsFilter's `gated` predicate. It
+      # keeps no copy of either — a guard whose scope is a hand-kept list of the thing it checks
+      # reads as passing when the list is short. Kotlin comments are stripped (block comments
+      # NEST) so an @Authorize quoted in a KDoc is never reported as an endpoint, and a run that
+      # matches zero endpoints FAILS rather than passing vacuously.
+      # 0 violations on origin/main at introduction — a regression guard. ENFORCED.
+      anonymous_grants_require_upstream_authn: true
+      anonymous_grant_ci_producer: ".github/scripts/check-psd2-anonymous-grant-paths.py"
 
     # ---------------------------------------------------------------------------------------
     # Scheduled-method invariants (issue #2148, fleet sweep #2187).

--- a/openbank-infra/gitops/components/pid/pid-opa-bundle.yaml
+++ b/openbank-infra/gitops/components/pid/pid-opa-bundle.yaml
@@ -9,7 +9,7 @@ metadata:
     app.kubernetes.io/name: pid-service
     app.kubernetes.io/part-of: pid
   annotations:
-    openbank.tech/policy-checksum: "41420e0d70ef4f52"
+    openbank.tech/policy-checksum: "ba4d00fa1724b300"
 data:
   rest.rego: |
     # SPDX-License-Identifier: Apache-2.0
@@ -2547,6 +2547,25 @@ data:
       # edge-service-notification rule and rest_test.rego's
       # test_deny_operator_read_any_does_not_cover_write).
       ci_producer: ".github/scripts/check-no-service-principal-type.sh"
+
+      # psd2_rest_ext.rego grants five actions — psd2.list/read/create/initiate/delete — to an
+      # ANONYMOUS principal, because a TPP authenticates by eIDAS QWAC (mTLS) and carries no
+      # bearer, so it reaches OPA as ANONYMOUS. That grant is safe ONLY because EidasMtlsFilter
+      # (@Priority(AUTHENTICATION)) has already 401'd a missing or unauthorized TPP on the path
+      # prefixes it gates. Until issue #2169 that invariant lived in a rego comment: an
+      # @Authorize(action = "psd2.initiate") added on a path the filter does NOT gate — a new
+      # admin route, a debug endpoint, anything under `open-banking/sandbox/` — would hand
+      # payment initiation to a genuinely unauthenticated caller with every CI gate green.
+      #
+      # The guard derives BOTH sides from source: the action set out of the rego rule, the gated
+      # prefixes (and their negated exclusions) out of EidasMtlsFilter's `gated` predicate. It
+      # keeps no copy of either — a guard whose scope is a hand-kept list of the thing it checks
+      # reads as passing when the list is short. Kotlin comments are stripped (block comments
+      # NEST) so an @Authorize quoted in a KDoc is never reported as an endpoint, and a run that
+      # matches zero endpoints FAILS rather than passing vacuously.
+      # 0 violations on origin/main at introduction — a regression guard. ENFORCED.
+      anonymous_grants_require_upstream_authn: true
+      anonymous_grant_ci_producer: ".github/scripts/check-psd2-anonymous-grant-paths.py"
 
     # ---------------------------------------------------------------------------------------
     # Scheduled-method invariants (issue #2148, fleet sweep #2187).

--- a/openbank-infra/gitops/components/pid/pid-service.yaml
+++ b/openbank-infra/gitops/components/pid/pid-service.yaml
@@ -22,7 +22,7 @@ spec:
       annotations:
         # Rolls the pod when the OPA bundle changes — subPath mounts do NOT hot-reload.
         # Kept in sync by gen-pid-opa-bundle.sh (do not hand-edit).
-        openbank.tech/policy-checksum: "41420e0d70ef4f52"
+        openbank.tech/policy-checksum: "ba4d00fa1724b300"
     spec:
       securityContext:
         runAsNonRoot: true

--- a/openbank-infra/gitops/components/psd2-service/psd2-opa-bundle.yaml
+++ b/openbank-infra/gitops/components/psd2-service/psd2-opa-bundle.yaml
@@ -9,7 +9,7 @@ metadata:
     app.kubernetes.io/name: psd2-service
     app.kubernetes.io/part-of: psd2
   annotations:
-    openbank.tech/policy-checksum: "9ccfe8b9e8c780a8"
+    openbank.tech/policy-checksum: "4080b8e7bda49031"
 data:
   rest.rego: |
     # SPDX-License-Identifier: Apache-2.0
@@ -2620,6 +2620,25 @@ data:
       # edge-service-notification rule and rest_test.rego's
       # test_deny_operator_read_any_does_not_cover_write).
       ci_producer: ".github/scripts/check-no-service-principal-type.sh"
+
+      # psd2_rest_ext.rego grants five actions — psd2.list/read/create/initiate/delete — to an
+      # ANONYMOUS principal, because a TPP authenticates by eIDAS QWAC (mTLS) and carries no
+      # bearer, so it reaches OPA as ANONYMOUS. That grant is safe ONLY because EidasMtlsFilter
+      # (@Priority(AUTHENTICATION)) has already 401'd a missing or unauthorized TPP on the path
+      # prefixes it gates. Until issue #2169 that invariant lived in a rego comment: an
+      # @Authorize(action = "psd2.initiate") added on a path the filter does NOT gate — a new
+      # admin route, a debug endpoint, anything under `open-banking/sandbox/` — would hand
+      # payment initiation to a genuinely unauthenticated caller with every CI gate green.
+      #
+      # The guard derives BOTH sides from source: the action set out of the rego rule, the gated
+      # prefixes (and their negated exclusions) out of EidasMtlsFilter's `gated` predicate. It
+      # keeps no copy of either — a guard whose scope is a hand-kept list of the thing it checks
+      # reads as passing when the list is short. Kotlin comments are stripped (block comments
+      # NEST) so an @Authorize quoted in a KDoc is never reported as an endpoint, and a run that
+      # matches zero endpoints FAILS rather than passing vacuously.
+      # 0 violations on origin/main at introduction — a regression guard. ENFORCED.
+      anonymous_grants_require_upstream_authn: true
+      anonymous_grant_ci_producer: ".github/scripts/check-psd2-anonymous-grant-paths.py"
 
     # ---------------------------------------------------------------------------------------
     # Scheduled-method invariants (issue #2148, fleet sweep #2187).

--- a/openbank-infra/gitops/components/psd2-service/psd2-service.yaml
+++ b/openbank-infra/gitops/components/psd2-service/psd2-service.yaml
@@ -18,7 +18,7 @@ spec:
       annotations:
         # Rolls the pod when the OPA bundle changes — subPath mounts do NOT hot-reload.
         # Kept in sync by gen-psd2-opa-bundle.sh (do not hand-edit).
-        openbank.tech/policy-checksum: "9ccfe8b9e8c780a8"
+        openbank.tech/policy-checksum: "4080b8e7bda49031"
       labels: {app.kubernetes.io/name: psd2-service, app.kubernetes.io/part-of: psd2}
     spec:
       securityContext:

--- a/openbank-infra/gitops/components/sanctions-service/sanctions-opa-bundle.yaml
+++ b/openbank-infra/gitops/components/sanctions-service/sanctions-opa-bundle.yaml
@@ -9,7 +9,7 @@ metadata:
     app.kubernetes.io/name: sanctions-service
     app.kubernetes.io/part-of: sanctions
   annotations:
-    openbank.tech/policy-checksum: "f89580bca74f304c"
+    openbank.tech/policy-checksum: "a3c0292b94330435"
 data:
   rest.rego: |
     # SPDX-License-Identifier: Apache-2.0
@@ -2525,6 +2525,25 @@ data:
       # edge-service-notification rule and rest_test.rego's
       # test_deny_operator_read_any_does_not_cover_write).
       ci_producer: ".github/scripts/check-no-service-principal-type.sh"
+
+      # psd2_rest_ext.rego grants five actions — psd2.list/read/create/initiate/delete — to an
+      # ANONYMOUS principal, because a TPP authenticates by eIDAS QWAC (mTLS) and carries no
+      # bearer, so it reaches OPA as ANONYMOUS. That grant is safe ONLY because EidasMtlsFilter
+      # (@Priority(AUTHENTICATION)) has already 401'd a missing or unauthorized TPP on the path
+      # prefixes it gates. Until issue #2169 that invariant lived in a rego comment: an
+      # @Authorize(action = "psd2.initiate") added on a path the filter does NOT gate — a new
+      # admin route, a debug endpoint, anything under `open-banking/sandbox/` — would hand
+      # payment initiation to a genuinely unauthenticated caller with every CI gate green.
+      #
+      # The guard derives BOTH sides from source: the action set out of the rego rule, the gated
+      # prefixes (and their negated exclusions) out of EidasMtlsFilter's `gated` predicate. It
+      # keeps no copy of either — a guard whose scope is a hand-kept list of the thing it checks
+      # reads as passing when the list is short. Kotlin comments are stripped (block comments
+      # NEST) so an @Authorize quoted in a KDoc is never reported as an endpoint, and a run that
+      # matches zero endpoints FAILS rather than passing vacuously.
+      # 0 violations on origin/main at introduction — a regression guard. ENFORCED.
+      anonymous_grants_require_upstream_authn: true
+      anonymous_grant_ci_producer: ".github/scripts/check-psd2-anonymous-grant-paths.py"
 
     # ---------------------------------------------------------------------------------------
     # Scheduled-method invariants (issue #2148, fleet sweep #2187).

--- a/openbank-infra/gitops/components/sanctions-service/sanctions-service.yaml
+++ b/openbank-infra/gitops/components/sanctions-service/sanctions-service.yaml
@@ -49,7 +49,7 @@ spec:
       annotations:
         # Rolls the pods when the OPA bundle changes — subPath mounts do NOT hot-reload.
         # Kept in sync by gen-sanctions-opa-bundle.sh (do not hand-edit).
-        openbank.tech/policy-checksum: "f89580bca74f304c"
+        openbank.tech/policy-checksum: "a3c0292b94330435"
     spec:
       securityContext:
         runAsNonRoot: true

--- a/openbank-infra/gitops/components/sca/sca-opa-bundle.yaml
+++ b/openbank-infra/gitops/components/sca/sca-opa-bundle.yaml
@@ -9,7 +9,7 @@ metadata:
     app.kubernetes.io/name: sca-service
     app.kubernetes.io/part-of: sca
   annotations:
-    openbank.tech/policy-checksum: "1126f48edbec0c2c"
+    openbank.tech/policy-checksum: "bc3f99b92965fdf3"
 data:
   rest.rego: |
     # SPDX-License-Identifier: Apache-2.0
@@ -2561,6 +2561,25 @@ data:
       # edge-service-notification rule and rest_test.rego's
       # test_deny_operator_read_any_does_not_cover_write).
       ci_producer: ".github/scripts/check-no-service-principal-type.sh"
+
+      # psd2_rest_ext.rego grants five actions — psd2.list/read/create/initiate/delete — to an
+      # ANONYMOUS principal, because a TPP authenticates by eIDAS QWAC (mTLS) and carries no
+      # bearer, so it reaches OPA as ANONYMOUS. That grant is safe ONLY because EidasMtlsFilter
+      # (@Priority(AUTHENTICATION)) has already 401'd a missing or unauthorized TPP on the path
+      # prefixes it gates. Until issue #2169 that invariant lived in a rego comment: an
+      # @Authorize(action = "psd2.initiate") added on a path the filter does NOT gate — a new
+      # admin route, a debug endpoint, anything under `open-banking/sandbox/` — would hand
+      # payment initiation to a genuinely unauthenticated caller with every CI gate green.
+      #
+      # The guard derives BOTH sides from source: the action set out of the rego rule, the gated
+      # prefixes (and their negated exclusions) out of EidasMtlsFilter's `gated` predicate. It
+      # keeps no copy of either — a guard whose scope is a hand-kept list of the thing it checks
+      # reads as passing when the list is short. Kotlin comments are stripped (block comments
+      # NEST) so an @Authorize quoted in a KDoc is never reported as an endpoint, and a run that
+      # matches zero endpoints FAILS rather than passing vacuously.
+      # 0 violations on origin/main at introduction — a regression guard. ENFORCED.
+      anonymous_grants_require_upstream_authn: true
+      anonymous_grant_ci_producer: ".github/scripts/check-psd2-anonymous-grant-paths.py"
 
     # ---------------------------------------------------------------------------------------
     # Scheduled-method invariants (issue #2148, fleet sweep #2187).

--- a/openbank-infra/gitops/components/sca/sca-service.yaml
+++ b/openbank-infra/gitops/components/sca/sca-service.yaml
@@ -28,7 +28,7 @@ spec:
       annotations:
         # Rolls the pods when the OPA bundle changes — subPath mounts do NOT hot-reload.
         # Kept in sync by gen-sca-opa-bundle.sh (do not hand-edit).
-        openbank.tech/policy-checksum: "1126f48edbec0c2c"
+        openbank.tech/policy-checksum: "bc3f99b92965fdf3"
     spec:
       securityContext:
         runAsNonRoot: true

--- a/openbank-infra/gitops/components/statements/statement-opa-bundle.yaml
+++ b/openbank-infra/gitops/components/statements/statement-opa-bundle.yaml
@@ -9,7 +9,7 @@ metadata:
     app.kubernetes.io/name: statement-service
     app.kubernetes.io/part-of: statements
   annotations:
-    openbank.tech/policy-checksum: "27125c0ea2b3abaa"
+    openbank.tech/policy-checksum: "5f86a99232d519f0"
 data:
   rest.rego: |
     # SPDX-License-Identifier: Apache-2.0
@@ -2591,6 +2591,25 @@ data:
       # edge-service-notification rule and rest_test.rego's
       # test_deny_operator_read_any_does_not_cover_write).
       ci_producer: ".github/scripts/check-no-service-principal-type.sh"
+
+      # psd2_rest_ext.rego grants five actions — psd2.list/read/create/initiate/delete — to an
+      # ANONYMOUS principal, because a TPP authenticates by eIDAS QWAC (mTLS) and carries no
+      # bearer, so it reaches OPA as ANONYMOUS. That grant is safe ONLY because EidasMtlsFilter
+      # (@Priority(AUTHENTICATION)) has already 401'd a missing or unauthorized TPP on the path
+      # prefixes it gates. Until issue #2169 that invariant lived in a rego comment: an
+      # @Authorize(action = "psd2.initiate") added on a path the filter does NOT gate — a new
+      # admin route, a debug endpoint, anything under `open-banking/sandbox/` — would hand
+      # payment initiation to a genuinely unauthenticated caller with every CI gate green.
+      #
+      # The guard derives BOTH sides from source: the action set out of the rego rule, the gated
+      # prefixes (and their negated exclusions) out of EidasMtlsFilter's `gated` predicate. It
+      # keeps no copy of either — a guard whose scope is a hand-kept list of the thing it checks
+      # reads as passing when the list is short. Kotlin comments are stripped (block comments
+      # NEST) so an @Authorize quoted in a KDoc is never reported as an endpoint, and a run that
+      # matches zero endpoints FAILS rather than passing vacuously.
+      # 0 violations on origin/main at introduction — a regression guard. ENFORCED.
+      anonymous_grants_require_upstream_authn: true
+      anonymous_grant_ci_producer: ".github/scripts/check-psd2-anonymous-grant-paths.py"
 
     # ---------------------------------------------------------------------------------------
     # Scheduled-method invariants (issue #2148, fleet sweep #2187).

--- a/openbank-infra/gitops/components/statements/statement-service.yaml
+++ b/openbank-infra/gitops/components/statements/statement-service.yaml
@@ -26,7 +26,7 @@ spec:
       annotations:
         # Rolls the pod when the OPA bundle changes — subPath mounts do NOT hot-reload.
         # Kept in sync by gen-statement-opa-bundle.sh (do not hand-edit).
-        openbank.tech/policy-checksum: "27125c0ea2b3abaa"
+        openbank.tech/policy-checksum: "5f86a99232d519f0"
       labels:
         app.kubernetes.io/name: statement-service
         app.kubernetes.io/part-of: statements

--- a/openbank-infra/gitops/components/tpp-registry/tpp-registry-opa-bundle.yaml
+++ b/openbank-infra/gitops/components/tpp-registry/tpp-registry-opa-bundle.yaml
@@ -9,7 +9,7 @@ metadata:
     app.kubernetes.io/name: tpp-registry-service
     app.kubernetes.io/part-of: tpp-registry
   annotations:
-    openbank.tech/policy-checksum: "5b533deb8a477909"
+    openbank.tech/policy-checksum: "09a45202c0e55795"
 data:
   rest.rego: |
     # SPDX-License-Identifier: Apache-2.0
@@ -2528,6 +2528,25 @@ data:
       # edge-service-notification rule and rest_test.rego's
       # test_deny_operator_read_any_does_not_cover_write).
       ci_producer: ".github/scripts/check-no-service-principal-type.sh"
+
+      # psd2_rest_ext.rego grants five actions — psd2.list/read/create/initiate/delete — to an
+      # ANONYMOUS principal, because a TPP authenticates by eIDAS QWAC (mTLS) and carries no
+      # bearer, so it reaches OPA as ANONYMOUS. That grant is safe ONLY because EidasMtlsFilter
+      # (@Priority(AUTHENTICATION)) has already 401'd a missing or unauthorized TPP on the path
+      # prefixes it gates. Until issue #2169 that invariant lived in a rego comment: an
+      # @Authorize(action = "psd2.initiate") added on a path the filter does NOT gate — a new
+      # admin route, a debug endpoint, anything under `open-banking/sandbox/` — would hand
+      # payment initiation to a genuinely unauthenticated caller with every CI gate green.
+      #
+      # The guard derives BOTH sides from source: the action set out of the rego rule, the gated
+      # prefixes (and their negated exclusions) out of EidasMtlsFilter's `gated` predicate. It
+      # keeps no copy of either — a guard whose scope is a hand-kept list of the thing it checks
+      # reads as passing when the list is short. Kotlin comments are stripped (block comments
+      # NEST) so an @Authorize quoted in a KDoc is never reported as an endpoint, and a run that
+      # matches zero endpoints FAILS rather than passing vacuously.
+      # 0 violations on origin/main at introduction — a regression guard. ENFORCED.
+      anonymous_grants_require_upstream_authn: true
+      anonymous_grant_ci_producer: ".github/scripts/check-psd2-anonymous-grant-paths.py"
 
     # ---------------------------------------------------------------------------------------
     # Scheduled-method invariants (issue #2148, fleet sweep #2187).

--- a/openbank-infra/gitops/components/tpp-registry/tpp-registry-service.yaml
+++ b/openbank-infra/gitops/components/tpp-registry/tpp-registry-service.yaml
@@ -23,7 +23,7 @@ spec:
       annotations:
         # Rolls the pod when the OPA bundle changes (subPath mounts do not hot-reload).
         # Kept in sync by gen-tpp-registry-opa-bundle.sh (do not hand-edit).
-        openbank.tech/policy-checksum: "5b533deb8a477909"
+        openbank.tech/policy-checksum: "09a45202c0e55795"
     spec:
       securityContext:
         runAsNonRoot: true

--- a/openbank-libs/governance/rules.yaml
+++ b/openbank-libs/governance/rules.yaml
@@ -1160,6 +1160,25 @@ authz_policy:
   # test_deny_operator_read_any_does_not_cover_write).
   ci_producer: ".github/scripts/check-no-service-principal-type.sh"
 
+  # psd2_rest_ext.rego grants five actions — psd2.list/read/create/initiate/delete — to an
+  # ANONYMOUS principal, because a TPP authenticates by eIDAS QWAC (mTLS) and carries no
+  # bearer, so it reaches OPA as ANONYMOUS. That grant is safe ONLY because EidasMtlsFilter
+  # (@Priority(AUTHENTICATION)) has already 401'd a missing or unauthorized TPP on the path
+  # prefixes it gates. Until issue #2169 that invariant lived in a rego comment: an
+  # @Authorize(action = "psd2.initiate") added on a path the filter does NOT gate — a new
+  # admin route, a debug endpoint, anything under `open-banking/sandbox/` — would hand
+  # payment initiation to a genuinely unauthenticated caller with every CI gate green.
+  #
+  # The guard derives BOTH sides from source: the action set out of the rego rule, the gated
+  # prefixes (and their negated exclusions) out of EidasMtlsFilter's `gated` predicate. It
+  # keeps no copy of either — a guard whose scope is a hand-kept list of the thing it checks
+  # reads as passing when the list is short. Kotlin comments are stripped (block comments
+  # NEST) so an @Authorize quoted in a KDoc is never reported as an endpoint, and a run that
+  # matches zero endpoints FAILS rather than passing vacuously.
+  # 0 violations on origin/main at introduction — a regression guard. ENFORCED.
+  anonymous_grants_require_upstream_authn: true
+  anonymous_grant_ci_producer: ".github/scripts/check-psd2-anonymous-grant-paths.py"
+
 # ---------------------------------------------------------------------------------------
 # Scheduled-method invariants (issue #2148, fleet sweep #2187).
 # ---------------------------------------------------------------------------------------


### PR DESCRIPTION
Closes #2169.

## The gap

`psd2_rest_ext.rego` grants five actions — `psd2.list`, `psd2.read`, `psd2.create`, `psd2.initiate`, `psd2.delete` — to `input.principal.type == "ANONYMOUS"`. That is correct: a TPP authenticates by eIDAS QWAC (mTLS), carries no bearer, and so reaches OPA as ANONYMOUS. It is safe **only** because `EidasMtlsFilter` (`@Priority(AUTHENTICATION)`) has already 401'd a missing or unauthorized TPP on the path prefixes it gates.

Nothing checked that. The rego says so in a comment. The day an `@Authorize(action = "psd2.initiate")` lands on a path the filter does not gate — a new admin route, a debug endpoint, a resource class that moved, anything under `open-banking/sandbox/` — the PDP grants payment initiation to a genuinely unauthenticated caller and every gate in CI stays green.

## The guard

`.github/scripts/check-psd2-anonymous-grant-paths.py`, registered in `rules.yaml: authz_policy` and run enforced in the `Validate manifests` job.

**Both sides are derived, neither is re-declared:**
- the granted **action set** is parsed out of the rego rule (and the guard hard-fails if that rule stops gating on ANONYMOUS — it must not keep passing on a premise that no longer holds);
- the gated **path prefixes**, *including the negated exclusion* `!path.startsWith("open-banking/sandbox/")`, are parsed out of `EidasMtlsFilter`'s `gated` predicate.

A guard whose scope is a hand-kept list of the thing it checks reads as *passing* when the list is short. Neither list lives here.

**Code-about-code:** Kotlin comments are stripped before matching, and the stripper honours the fact that Kotlin block comments **nest** — the rego, the filter and this script's own docstring are all thick with prose naming the annotations being matched. The corollary is stated in the code: prose naming a dead identifier is invisible to this guard forever.

**Vacuous green:** a run that matches zero annotated endpoints `::error`s and exits 1 rather than reporting "OK".

## Falsification — run before trusting the green

| case | expected | actual |
|---|---|---|
| `@Authorize("psd2.read")` on `open-banking/sandbox/v2/accounts` (excluded prefix) | flag | flagged, exit 1 under `--enforce` |
| `@Authorize("psd2.initiate")` on a new `/internal/debug/dump` resource | flag | flagged, exit 1 |
| the same annotation quoted inside a KDoc containing a **nested** block comment | do **not** flag | not flagged, exit 0 |
| `@Authorize("psd2.debug")` (action outside the granted set) on an ungated path | do **not** flag | not flagged |

Clean run on `origin/main`: 21 annotated endpoints, all 21 carrying a granted action, all behind the filter — matching the count the rego's own endpoint map documents.

## Note on the diff size

Editing `rules.yaml` restamps every service's OPA bundle (each embeds it verbatim and hashes it), so 64 generated files ride along. They were regenerated with the standard `find … gen-*opa-bundle*.sh | xargs -n1 bash` **after** the final `rules.yaml` edit, not before. `actionlint` finding set on `ci.yml` is unchanged vs `origin/main`; `rules.yaml` re-parsed with a duplicate-key-rejecting loader (CI never lints it).

## Out of scope

The `tppId`-absent-from-`AuthzQuery` follow-up noted in the issue is genuinely separate work — no per-TPP policy is expressible in rego until the identity is carried into the query. This PR closes the guard half.