### PR TITLE
ci(governance): audit lineage upstream edges, not just downstream

### DIFF
--- a/.github/scripts/check-governance-lineage.py
+++ b/.github/scripts/check-governance-lineage.py
@@ -11,10 +11,21 @@ checked against code). This script closes the general case for `governance.yaml`
 reusing check-event-consumer-liveness.py's fleet-wide topic map (ADR-0160 mechanism 1) for the
 `topic` half instead of re-scanning the fleet a second time.
 
-WHAT IT CHECKS: for every service's `governance.yaml`, each `lineage.downstream` edge (an
-UPSTREAM edge is a claim about another service's code, not this one's, so it is out of scope here
-— the corresponding downstream edge on the OTHER service's own governance.yaml is what verifies
-that relationship) must be backed by grep-verifiable code in the SAME service:
+WHAT IT CHECKS: for every service's `governance.yaml`, each `lineage` edge must be backed by
+grep-verifiable code. An edge is checked in whichever service's code can actually witness it:
+
+  - a `downstream` edge on S naming T is a claim about S's OWN code, verified in S;
+  - an `upstream` edge on S naming T is a claim about T's code — so it is verified in T, exactly
+    as if T had declared the mirrored downstream edge. It was originally called out of scope for
+    that reason, but "someone else's code" is not "nobody's code": 63 upstream edges across 23
+    services were never opened by anything, and a service declaring ONLY upstream was skipped
+    outright. `openbank-aml-service` had 3 of its 6 upstream edges wrong — two topic sources it
+    consumes nothing from, one API caller that mentions it only in prose (#2312, #2315).
+
+Both directions normalize to the same `<source>-><target>:<relation>` key, so a relationship
+declared from both ends is checked and allowlisted ONCE, not twice under two spellings.
+
+The backing evidence, for the source service of the edge:
   - `relationType: api`  -> a `@RegisterRestClient(configKey = "<serviceName>")` somewhere under
     this service's `src/main/kotlin` (exact match, or matching once both sides have any trailing
     "-service" suffix stripped — `product-catalog` vs `product-catalog-service` naming varies
@@ -24,8 +35,9 @@ that relationship) must be backed by grep-verifiable code in the SAME service:
     by this service — a `topic` edge doesn't name the specific topic, just the service, so this is
     a service-level cross-reference, not a topic-name match.
 
-A service with no `lineage:` key, or no `downstream` list, is skipped entirely (nothing declared,
-nothing to verify). Findings may be allowlisted with a one-line reason (same idiom as mechanism 1)
+A service with no `lineage:` key, or neither list, is skipped entirely (nothing declared,
+nothing to verify). An edge naming a service directory that does not exist is a finding: an
+un-resolvable claim is exactly the class this gate exists for. Findings may be allowlisted with a one-line reason (same idiom as mechanism 1)
 for a legitimate case this heuristic can't see — e.g. a REST call made through a shared/generic
 client class without a per-target configKey.
 
@@ -56,6 +68,16 @@ REGISTER_REST_CLIENT = re.compile(r'@RegisterRestClient\s*\(\s*configKey\s*=\s*"
 
 
 def normalize_service_name(name: str) -> str:
+    """Canonical form for comparing a service name against a `@RegisterRestClient` configKey.
+
+    The fleet spells the same service three ways — `balance-service` (configKey and most
+    governance.yaml entries), `openbank-balance-service` (directory name, and what an upstream
+    edge's target resolves to), and bare `product-catalog` — so both the `openbank-` prefix and
+    the `-service` suffix are stripped. Stripping only the suffix silently failed EVERY upstream
+    api edge, because that side is always the full directory name.
+    """
+    if name.startswith("openbank-"):
+        name = name[len("openbank-"):]
     return name[: -len("-service")] if name.endswith("-service") else name
 
 
@@ -74,12 +96,22 @@ def find_rest_client_config_keys(service_dir: pathlib.Path) -> set[str]:
     return keys
 
 
-def load_governance_downstream(gov_path: pathlib.Path) -> list[dict]:
+def load_governance_lineage(gov_path: pathlib.Path) -> tuple[list[dict], list[dict]]:
+    """(downstream, upstream) edge lists declared in a service's governance.yaml."""
     if not gov_path.exists():
-        return []
+        return [], []
     data = yaml.safe_load(gov_path.read_text(encoding="utf-8")) or {}
     lineage = data.get("lineage") or {}
-    return lineage.get("downstream") or []
+    return (lineage.get("downstream") or []), (lineage.get("upstream") or [])
+
+
+def service_dir_for(root: pathlib.Path, name: str) -> pathlib.Path | None:
+    """The directory of the service an edge names, tolerating the bare/`openbank-` spellings."""
+    for candidate in (name, f"{name}-service", f"openbank-{name}", f"openbank-{name}-service"):
+        path = root / candidate
+        if path.is_dir():
+            return path
+    return None
 
 
 def load_allowlist(rules_path: pathlib.Path) -> dict[str, str]:
@@ -112,47 +144,80 @@ def main() -> int:
 
     violations: list[tuple[str, str]] = []
     allowlisted_hits: list[tuple[str, str]] = []
-    checked = 0
+    seen: set[str] = set()
+    unresolved: list[tuple[str, str]] = []
+    checked = {"downstream": 0, "upstream": 0}
+    rest_client_cache: dict[pathlib.Path, set[str]] = {}
+
+    def rest_client_keys_of(path: pathlib.Path) -> set[str]:
+        if path not in rest_client_cache:
+            rest_client_cache[path] = find_rest_client_config_keys(path)
+        return rest_client_cache[path]
+
+    def topic_names(service: str, produced: bool) -> set[str]:
+        table = all_producers if produced else all_consumers
+        return {topic for topic, services in table.items() if service in services}
+
+    def is_backed(source_dir: pathlib.Path, source: str, target: str, relation: str) -> bool:
+        """Is there code in the SOURCE service witnessing `source -> target` over `relation`?"""
+        if relation == "api":
+            keys = rest_client_keys_of(source_dir)
+            normalized_targets = {target, normalize_service_name(target)}
+            normalized_keys = keys | {normalize_service_name(k) for k in keys}
+            return bool(normalized_targets & normalized_keys)
+        # topic: `relationType: topic` names a service, not a topic, so this is a service-level
+        # cross-reference in either direction (#1021: both sides must be the full directory name).
+        source_full = source if source.startswith("openbank-") else f"openbank-{source}"
+        target_full = target if target.startswith("openbank-") else f"openbank-{target}"
+        return bool(
+            (topic_names(source_full, True) & topic_names(target_full, False))
+            or (topic_names(target_full, True) & topic_names(source_full, False))
+        )
 
     for service_dir in service_dirs:
         service = service_dir.name
-        downstream = load_governance_downstream(service_dir / "governance.yaml")
-        if not downstream:
-            continue
+        downstream, upstream = load_governance_lineage(service_dir / "governance.yaml")
 
-        rest_client_keys = None  # lazily computed only if an api edge is present
-        for edge in downstream:
-            target = edge.get("serviceName")
+        # Normalize both directions to (source, target): a downstream edge on S naming T is
+        # S -> T; an upstream edge on S naming T is T -> S. Same key space, so a relationship
+        # declared from both ends is one check and one allowlist entry.
+        edges = [("downstream", service, edge) for edge in downstream]
+        edges += [("upstream", edge.get("serviceName"), edge) for edge in upstream]
+
+        for direction, source, edge in edges:
+            other = edge.get("serviceName")
             relation = edge.get("relationType")
-            if not target or relation not in ("api", "topic"):
+            if not other or not source or relation not in ("api", "topic"):
                 continue
-            checked += 1
-            edge_key = f"{service}->{target}:{relation}"
+            target = other if direction == "downstream" else service
+            source_dir = service_dir if direction == "downstream" else service_dir_for(root, source)
+            edge_key = f"{source}->{target}:{relation}"
+            checked[direction] += 1
+            if edge_key in seen:
+                continue
+            seen.add(edge_key)
 
-            if relation == "api":
-                if rest_client_keys is None:
-                    rest_client_keys = find_rest_client_config_keys(service_dir)
-                normalized_targets = {target, normalize_service_name(target)}
-                normalized_keys = rest_client_keys | {normalize_service_name(k) for k in rest_client_keys}
-                backed = bool(normalized_targets & normalized_keys)
-            else:  # topic
-                # `target` (governance.yaml's serviceName) is written bare ("audit-service"), but
-                # build_topic_maps() keys its producer/consumer dicts by the full directory name
-                # ("openbank-audit-service") — comparing bare-against-full can never match (#1021).
-                # The `api` branch above already normalizes both sides; this branch didn't.
-                target_full = target if target.startswith("openbank-") else f"openbank-{target}"
-                produces = {t for t, producers in all_producers.items() if service in producers}
-                consumes = {t for t, consumers in all_consumers.items() if service in consumers}
-                target_produces = {t for t, producers in all_producers.items() if target_full in producers}
-                target_consumes = {t for t, consumers in all_consumers.items() if target_full in consumers}
-                backed = bool((produces & target_consumes) or (target_produces & consumes))
+            if source_dir is None:
+                # The edge names something with no directory in this tree: an external system
+                # (github, prometheus, temporal) or a typo. Either way there is no code here to
+                # witness it, and calling that a code-drift violation would be a category error —
+                # so it is reported as its own class rather than folded into the count.
+                unresolved.append((edge_key, source))
+                continue
 
-            if backed:
+            if is_backed(source_dir, source, target, relation):
                 continue
             if edge_key in allowlist:
                 allowlisted_hits.append((edge_key, allowlist[edge_key]))
             else:
                 violations.append((edge_key, relation))
+
+    for edge_key, source in sorted(set(unresolved)):
+        print(
+            f"::notice::lineage-code-audit: {edge_key} names '{source}', which has no service "
+            f"directory in this repo — an external system or a stale name. Not counted as a "
+            f"code-drift violation: there is no in-tree code that could witness it either way."
+        )
 
     for edge_key, reason in sorted(allowlisted_hits):
         print(f"::notice::lineage-code-audit: {edge_key} has no backing code found — allowlisted: {reason}")
@@ -168,9 +233,11 @@ def main() -> int:
         )
 
     print(
-        f"check-governance-lineage: {checked} downstream edge(s) checked across "
-        f"{len(service_dirs)} service(s) with a governance.yaml; {len(violations)} unallowlisted "
-        f"violation(s), {len(allowlisted_hits)} allowlisted."
+        f"check-governance-lineage: {checked['downstream']} downstream + {checked['upstream']} "
+        f"upstream edge(s) declared across {len(service_dirs)} service(s) with a governance.yaml, "
+        f"{len(seen)} distinct relationship(s) checked; {len(violations)} unallowlisted "
+        f"violation(s), {len(allowlisted_hits)} allowlisted, {len(set(unresolved))} naming no "
+        f"in-tree service."
     )
 
     if violations and args.enforce:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -552,10 +552,12 @@ jobs:
         run: python3 .github/scripts/check-no-runblocking-in-scheduled.py
 
       # ADR-0160 mechanism 2 / rules.yaml: change_requirements.lineage_code_audit. Fleet-wide scan
-      # (not diff-scoped): every governance.yaml lineage.downstream edge must be backed by
-      # grep-verifiable code, or a one-line-reasoned allowlist entry. Reuses mechanism 1's topic
-      # map via importlib. ADVISORY (ADR-0144) — findings are ::warning annotations. Flip to
-      # enforced once the 34-edge first-scan triage lands = add --enforce below.
+      # (not diff-scoped): every governance.yaml lineage edge — downstream AND, since #2315,
+      # upstream — must be backed by grep-verifiable code, or a one-line-reasoned allowlist entry.
+      # An upstream edge on S naming T is a claim about T's code, so it is checked in T; both
+      # directions collapse to one <source>-><target> key. Reuses mechanism 1's topic map via
+      # importlib. ADVISORY (ADR-0144) — findings are ::warning annotations. Flip to enforced once
+      # the first-scan triage (34 downstream + 24 upstream) lands = add --enforce below.
       - name: "governance lineage-vs-code audit (ADR-0160, advisory)"
         run: python3 .github/scripts/check-governance-lineage.py
 

--- a/openbank-infra/gitops/components/accounts/account-opa-bundle.yaml
+++ b/openbank-infra/gitops/components/accounts/account-opa-bundle.yaml
@@ -9,7 +9,7 @@ metadata:
     app.kubernetes.io/name: account-service
     app.kubernetes.io/part-of: accounts
   annotations:
-    openbank.tech/policy-checksum: "18f052d805d1505a"
+    openbank.tech/policy-checksum: "52a377ff10ee7830"
 data:
   rest.rego: |
     # SPDX-License-Identifier: Apache-2.0
@@ -1764,10 +1764,17 @@ data:
         # or be explicitly allowlisted below with a one-line reason (a REST call made through a
         # shared/generic client this heuristic's exact-match can't see, or a genuinely-stale edge
         # already tracked for cleanup elsewhere).
-        detect: ["any <service>/governance.yaml lineage.downstream edge"]
+        # BOTH directions since #2315. An `upstream` edge on S naming T is a claim about T's code, so
+        # it is verified in T — exactly as if T had declared the mirrored downstream edge. Treating
+        # "someone else's code" as out of scope meant 63 upstream edges across 23 services were opened
+        # by nothing, and a service declaring ONLY upstream was skipped outright; aml-service had 3 of
+        # its 6 upstream edges wrong (#2312). Both directions normalize to one <source>-><target>
+        # key, so a relationship declared from both ends is one check and one allowlist entry.
+        detect: ["any <service>/governance.yaml lineage.downstream or lineage.upstream edge"]
         require:
           - "api edge has a matching @RegisterRestClient(configKey) in the same service, or an allowlist entry with a reason"
           - "topic edge has an actual topic overlap with the target service (per mechanism 1's producer/consumer map), or an allowlist entry with a reason"
+          - "an edge naming no in-tree service directory (github, prometheus, temporal) is reported as its own class, never counted as code drift"
         gate: lineage-code-audit
         enforced: advisory
         target_enforce_date: "2026-10-15"   # ADR-0144 — later than mechanism 1's date: first scan found a much higher (34/48) violation rate, expect a longer triage
@@ -1784,7 +1791,11 @@ data:
           checker itself (fixed), 19 are stale governance.yaml edges (corrected/removed), 6 below are
           real dependencies the heuristic's exact-match can't see, and 4 are genuine gaps tracked as
           their own issues, not fixed here. A follow-up scan found 7 more edges outside the original
-          34 (the *->admin-ui reversed-direction shape) — not yet triaged."
+          34 (the *->admin-ui reversed-direction shape) — not yet triaged. #2315 then added the
+          upstream direction: the first upstream scan surfaced 24 further unbacked edges (26 total
+          unallowlisted, of which 2 are the pre-existing downstream findings) plus 10 edges naming an
+          external system — all untriaged, which is why target_enforce_date is unchanged and this
+          stays advisory."
         ci_producer: ".github/scripts/check-governance-lineage.py"
         allowlist:
           - edge: "openbank-copilot-service->balance-service:api"

--- a/openbank-infra/gitops/components/accounts/account-service.yaml
+++ b/openbank-infra/gitops/components/accounts/account-service.yaml
@@ -37,7 +37,7 @@ spec:
       annotations:
         # Rolls the pod when the OPA bundle changes — subPath mounts do NOT hot-reload.
         # Kept in sync by gen-account-opa-bundle.sh (do not hand-edit).
-        openbank.tech/policy-checksum: "18f052d805d1505a"
+        openbank.tech/policy-checksum: "52a377ff10ee7830"
     spec:
       securityContext:
         runAsNonRoot: true

--- a/openbank-infra/gitops/components/aml/aml-opa-bundle.yaml
+++ b/openbank-infra/gitops/components/aml/aml-opa-bundle.yaml
@@ -9,7 +9,7 @@ metadata:
     app.kubernetes.io/name: aml-service
     app.kubernetes.io/part-of: aml
   annotations:
-    openbank.tech/policy-checksum: "37dbac3711119a9c"
+    openbank.tech/policy-checksum: "c049395eeca1d6de"
 data:
   rest.rego: |
     # SPDX-License-Identifier: Apache-2.0
@@ -1737,10 +1737,17 @@ data:
         # or be explicitly allowlisted below with a one-line reason (a REST call made through a
         # shared/generic client this heuristic's exact-match can't see, or a genuinely-stale edge
         # already tracked for cleanup elsewhere).
-        detect: ["any <service>/governance.yaml lineage.downstream edge"]
+        # BOTH directions since #2315. An `upstream` edge on S naming T is a claim about T's code, so
+        # it is verified in T — exactly as if T had declared the mirrored downstream edge. Treating
+        # "someone else's code" as out of scope meant 63 upstream edges across 23 services were opened
+        # by nothing, and a service declaring ONLY upstream was skipped outright; aml-service had 3 of
+        # its 6 upstream edges wrong (#2312). Both directions normalize to one <source>-><target>
+        # key, so a relationship declared from both ends is one check and one allowlist entry.
+        detect: ["any <service>/governance.yaml lineage.downstream or lineage.upstream edge"]
         require:
           - "api edge has a matching @RegisterRestClient(configKey) in the same service, or an allowlist entry with a reason"
           - "topic edge has an actual topic overlap with the target service (per mechanism 1's producer/consumer map), or an allowlist entry with a reason"
+          - "an edge naming no in-tree service directory (github, prometheus, temporal) is reported as its own class, never counted as code drift"
         gate: lineage-code-audit
         enforced: advisory
         target_enforce_date: "2026-10-15"   # ADR-0144 — later than mechanism 1's date: first scan found a much higher (34/48) violation rate, expect a longer triage
@@ -1757,7 +1764,11 @@ data:
           checker itself (fixed), 19 are stale governance.yaml edges (corrected/removed), 6 below are
           real dependencies the heuristic's exact-match can't see, and 4 are genuine gaps tracked as
           their own issues, not fixed here. A follow-up scan found 7 more edges outside the original
-          34 (the *->admin-ui reversed-direction shape) — not yet triaged."
+          34 (the *->admin-ui reversed-direction shape) — not yet triaged. #2315 then added the
+          upstream direction: the first upstream scan surfaced 24 further unbacked edges (26 total
+          unallowlisted, of which 2 are the pre-existing downstream findings) plus 10 edges naming an
+          external system — all untriaged, which is why target_enforce_date is unchanged and this
+          stays advisory."
         ci_producer: ".github/scripts/check-governance-lineage.py"
         allowlist:
           - edge: "openbank-copilot-service->balance-service:api"

--- a/openbank-infra/gitops/components/aml/aml-service.yaml
+++ b/openbank-infra/gitops/components/aml/aml-service.yaml
@@ -22,7 +22,7 @@ spec:
       annotations:
         # Rolls the pod when the OPA bundle changes (subPath mounts do not hot-reload).
         # Kept in sync by gen-aml-opa-bundle.sh (do not hand-edit).
-        openbank.tech/policy-checksum: "37dbac3711119a9c"
+        openbank.tech/policy-checksum: "c049395eeca1d6de"
     spec:
       securityContext:
         runAsNonRoot: true

--- a/openbank-infra/gitops/components/anacredit/anacredit-opa-bundle.yaml
+++ b/openbank-infra/gitops/components/anacredit/anacredit-opa-bundle.yaml
@@ -9,7 +9,7 @@ metadata:
     app.kubernetes.io/name: anacredit-service
     app.kubernetes.io/part-of: anacredit
   annotations:
-    openbank.tech/policy-checksum: "a68108be3d33fda0"
+    openbank.tech/policy-checksum: "1668e3b78a9d8109"
 data:
   rest.rego: |
     # SPDX-License-Identifier: Apache-2.0
@@ -1707,10 +1707,17 @@ data:
         # or be explicitly allowlisted below with a one-line reason (a REST call made through a
         # shared/generic client this heuristic's exact-match can't see, or a genuinely-stale edge
         # already tracked for cleanup elsewhere).
-        detect: ["any <service>/governance.yaml lineage.downstream edge"]
+        # BOTH directions since #2315. An `upstream` edge on S naming T is a claim about T's code, so
+        # it is verified in T — exactly as if T had declared the mirrored downstream edge. Treating
+        # "someone else's code" as out of scope meant 63 upstream edges across 23 services were opened
+        # by nothing, and a service declaring ONLY upstream was skipped outright; aml-service had 3 of
+        # its 6 upstream edges wrong (#2312). Both directions normalize to one <source>-><target>
+        # key, so a relationship declared from both ends is one check and one allowlist entry.
+        detect: ["any <service>/governance.yaml lineage.downstream or lineage.upstream edge"]
         require:
           - "api edge has a matching @RegisterRestClient(configKey) in the same service, or an allowlist entry with a reason"
           - "topic edge has an actual topic overlap with the target service (per mechanism 1's producer/consumer map), or an allowlist entry with a reason"
+          - "an edge naming no in-tree service directory (github, prometheus, temporal) is reported as its own class, never counted as code drift"
         gate: lineage-code-audit
         enforced: advisory
         target_enforce_date: "2026-10-15"   # ADR-0144 — later than mechanism 1's date: first scan found a much higher (34/48) violation rate, expect a longer triage
@@ -1727,7 +1734,11 @@ data:
           checker itself (fixed), 19 are stale governance.yaml edges (corrected/removed), 6 below are
           real dependencies the heuristic's exact-match can't see, and 4 are genuine gaps tracked as
           their own issues, not fixed here. A follow-up scan found 7 more edges outside the original
-          34 (the *->admin-ui reversed-direction shape) — not yet triaged."
+          34 (the *->admin-ui reversed-direction shape) — not yet triaged. #2315 then added the
+          upstream direction: the first upstream scan surfaced 24 further unbacked edges (26 total
+          unallowlisted, of which 2 are the pre-existing downstream findings) plus 10 edges naming an
+          external system — all untriaged, which is why target_enforce_date is unchanged and this
+          stays advisory."
         ci_producer: ".github/scripts/check-governance-lineage.py"
         allowlist:
           - edge: "openbank-copilot-service->balance-service:api"

--- a/openbank-infra/gitops/components/anacredit/anacredit-service.yaml
+++ b/openbank-infra/gitops/components/anacredit/anacredit-service.yaml
@@ -32,7 +32,7 @@ spec:
       annotations:
         # Rolls the pods when the OPA bundle changes — subPath mounts do NOT hot-reload.
         # Kept in sync by gen-anacredit-opa-bundle.sh (do not hand-edit).
-        openbank.tech/policy-checksum: "a68108be3d33fda0"
+        openbank.tech/policy-checksum: "1668e3b78a9d8109"
     spec:
       securityContext:
         runAsNonRoot: true

--- a/openbank-infra/gitops/components/ap2/ap2-opa-bundle.yaml
+++ b/openbank-infra/gitops/components/ap2/ap2-opa-bundle.yaml
@@ -9,7 +9,7 @@ metadata:
     app.kubernetes.io/name: mcp-service
     app.kubernetes.io/part-of: platform
   annotations:
-    openbank.tech/policy-checksum: "2c3dc4da36574695"
+    openbank.tech/policy-checksum: "8b78206fe6504344"
 data:
   rest.rego: |
     # SPDX-License-Identifier: Apache-2.0
@@ -1675,10 +1675,17 @@ data:
         # or be explicitly allowlisted below with a one-line reason (a REST call made through a
         # shared/generic client this heuristic's exact-match can't see, or a genuinely-stale edge
         # already tracked for cleanup elsewhere).
-        detect: ["any <service>/governance.yaml lineage.downstream edge"]
+        # BOTH directions since #2315. An `upstream` edge on S naming T is a claim about T's code, so
+        # it is verified in T — exactly as if T had declared the mirrored downstream edge. Treating
+        # "someone else's code" as out of scope meant 63 upstream edges across 23 services were opened
+        # by nothing, and a service declaring ONLY upstream was skipped outright; aml-service had 3 of
+        # its 6 upstream edges wrong (#2312). Both directions normalize to one <source>-><target>
+        # key, so a relationship declared from both ends is one check and one allowlist entry.
+        detect: ["any <service>/governance.yaml lineage.downstream or lineage.upstream edge"]
         require:
           - "api edge has a matching @RegisterRestClient(configKey) in the same service, or an allowlist entry with a reason"
           - "topic edge has an actual topic overlap with the target service (per mechanism 1's producer/consumer map), or an allowlist entry with a reason"
+          - "an edge naming no in-tree service directory (github, prometheus, temporal) is reported as its own class, never counted as code drift"
         gate: lineage-code-audit
         enforced: advisory
         target_enforce_date: "2026-10-15"   # ADR-0144 — later than mechanism 1's date: first scan found a much higher (34/48) violation rate, expect a longer triage
@@ -1695,7 +1702,11 @@ data:
           checker itself (fixed), 19 are stale governance.yaml edges (corrected/removed), 6 below are
           real dependencies the heuristic's exact-match can't see, and 4 are genuine gaps tracked as
           their own issues, not fixed here. A follow-up scan found 7 more edges outside the original
-          34 (the *->admin-ui reversed-direction shape) — not yet triaged."
+          34 (the *->admin-ui reversed-direction shape) — not yet triaged. #2315 then added the
+          upstream direction: the first upstream scan surfaced 24 further unbacked edges (26 total
+          unallowlisted, of which 2 are the pre-existing downstream findings) plus 10 edges naming an
+          external system — all untriaged, which is why target_enforce_date is unchanged and this
+          stays advisory."
         ci_producer: ".github/scripts/check-governance-lineage.py"
         allowlist:
           - edge: "openbank-copilot-service->balance-service:api"

--- a/openbank-infra/gitops/components/ap2/ap2-service.yaml
+++ b/openbank-infra/gitops/components/ap2/ap2-service.yaml
@@ -30,7 +30,7 @@ spec:
       annotations:
         # Roll the pod when the OPA policy bundle changes (subPath mounts don't hot-reload).
         # Kept in sync by gen-ap2-opa-bundle.sh (do not hand-edit).
-        openbank.tech/policy-checksum: "2c3dc4da36574695"
+        openbank.tech/policy-checksum: "8b78206fe6504344"
     spec:
       securityContext:
         runAsNonRoot: true

--- a/openbank-infra/gitops/components/audit/audit-opa-bundle.yaml
+++ b/openbank-infra/gitops/components/audit/audit-opa-bundle.yaml
@@ -9,7 +9,7 @@ metadata:
     app.kubernetes.io/name: audit-service
     app.kubernetes.io/part-of: audit
   annotations:
-    openbank.tech/policy-checksum: "e27ea94290a73cb5"
+    openbank.tech/policy-checksum: "3c4b3558c3e1e8b4"
 data:
   rest.rego: |
     # SPDX-License-Identifier: Apache-2.0
@@ -1719,10 +1719,17 @@ data:
         # or be explicitly allowlisted below with a one-line reason (a REST call made through a
         # shared/generic client this heuristic's exact-match can't see, or a genuinely-stale edge
         # already tracked for cleanup elsewhere).
-        detect: ["any <service>/governance.yaml lineage.downstream edge"]
+        # BOTH directions since #2315. An `upstream` edge on S naming T is a claim about T's code, so
+        # it is verified in T — exactly as if T had declared the mirrored downstream edge. Treating
+        # "someone else's code" as out of scope meant 63 upstream edges across 23 services were opened
+        # by nothing, and a service declaring ONLY upstream was skipped outright; aml-service had 3 of
+        # its 6 upstream edges wrong (#2312). Both directions normalize to one <source>-><target>
+        # key, so a relationship declared from both ends is one check and one allowlist entry.
+        detect: ["any <service>/governance.yaml lineage.downstream or lineage.upstream edge"]
         require:
           - "api edge has a matching @RegisterRestClient(configKey) in the same service, or an allowlist entry with a reason"
           - "topic edge has an actual topic overlap with the target service (per mechanism 1's producer/consumer map), or an allowlist entry with a reason"
+          - "an edge naming no in-tree service directory (github, prometheus, temporal) is reported as its own class, never counted as code drift"
         gate: lineage-code-audit
         enforced: advisory
         target_enforce_date: "2026-10-15"   # ADR-0144 — later than mechanism 1's date: first scan found a much higher (34/48) violation rate, expect a longer triage
@@ -1739,7 +1746,11 @@ data:
           checker itself (fixed), 19 are stale governance.yaml edges (corrected/removed), 6 below are
           real dependencies the heuristic's exact-match can't see, and 4 are genuine gaps tracked as
           their own issues, not fixed here. A follow-up scan found 7 more edges outside the original
-          34 (the *->admin-ui reversed-direction shape) — not yet triaged."
+          34 (the *->admin-ui reversed-direction shape) — not yet triaged. #2315 then added the
+          upstream direction: the first upstream scan surfaced 24 further unbacked edges (26 total
+          unallowlisted, of which 2 are the pre-existing downstream findings) plus 10 edges naming an
+          external system — all untriaged, which is why target_enforce_date is unchanged and this
+          stays advisory."
         ci_producer: ".github/scripts/check-governance-lineage.py"
         allowlist:
           - edge: "openbank-copilot-service->balance-service:api"

--- a/openbank-infra/gitops/components/audit/audit-service.yaml
+++ b/openbank-infra/gitops/components/audit/audit-service.yaml
@@ -22,7 +22,7 @@ spec:
       annotations:
         # Rolls the pod when the OPA bundle changes (subPath mounts do not hot-reload).
         # Kept in sync by gen-audit-opa-bundle.sh (do not hand-edit).
-        openbank.tech/policy-checksum: "e27ea94290a73cb5"
+        openbank.tech/policy-checksum: "3c4b3558c3e1e8b4"
     spec:
       securityContext:
         runAsNonRoot: true

--- a/openbank-infra/gitops/components/balances/balance-opa-bundle.yaml
+++ b/openbank-infra/gitops/components/balances/balance-opa-bundle.yaml
@@ -9,7 +9,7 @@ metadata:
     app.kubernetes.io/name: balance-service
     app.kubernetes.io/part-of: balances
   annotations:
-    openbank.tech/policy-checksum: "b39b7a2d1050473a"
+    openbank.tech/policy-checksum: "6ed576d9967160a8"
 data:
   rest.rego: |
     # SPDX-License-Identifier: Apache-2.0
@@ -1808,10 +1808,17 @@ data:
         # or be explicitly allowlisted below with a one-line reason (a REST call made through a
         # shared/generic client this heuristic's exact-match can't see, or a genuinely-stale edge
         # already tracked for cleanup elsewhere).
-        detect: ["any <service>/governance.yaml lineage.downstream edge"]
+        # BOTH directions since #2315. An `upstream` edge on S naming T is a claim about T's code, so
+        # it is verified in T — exactly as if T had declared the mirrored downstream edge. Treating
+        # "someone else's code" as out of scope meant 63 upstream edges across 23 services were opened
+        # by nothing, and a service declaring ONLY upstream was skipped outright; aml-service had 3 of
+        # its 6 upstream edges wrong (#2312). Both directions normalize to one <source>-><target>
+        # key, so a relationship declared from both ends is one check and one allowlist entry.
+        detect: ["any <service>/governance.yaml lineage.downstream or lineage.upstream edge"]
         require:
           - "api edge has a matching @RegisterRestClient(configKey) in the same service, or an allowlist entry with a reason"
           - "topic edge has an actual topic overlap with the target service (per mechanism 1's producer/consumer map), or an allowlist entry with a reason"
+          - "an edge naming no in-tree service directory (github, prometheus, temporal) is reported as its own class, never counted as code drift"
         gate: lineage-code-audit
         enforced: advisory
         target_enforce_date: "2026-10-15"   # ADR-0144 — later than mechanism 1's date: first scan found a much higher (34/48) violation rate, expect a longer triage
@@ -1828,7 +1835,11 @@ data:
           checker itself (fixed), 19 are stale governance.yaml edges (corrected/removed), 6 below are
           real dependencies the heuristic's exact-match can't see, and 4 are genuine gaps tracked as
           their own issues, not fixed here. A follow-up scan found 7 more edges outside the original
-          34 (the *->admin-ui reversed-direction shape) — not yet triaged."
+          34 (the *->admin-ui reversed-direction shape) — not yet triaged. #2315 then added the
+          upstream direction: the first upstream scan surfaced 24 further unbacked edges (26 total
+          unallowlisted, of which 2 are the pre-existing downstream findings) plus 10 edges naming an
+          external system — all untriaged, which is why target_enforce_date is unchanged and this
+          stays advisory."
         ci_producer: ".github/scripts/check-governance-lineage.py"
         allowlist:
           - edge: "openbank-copilot-service->balance-service:api"

--- a/openbank-infra/gitops/components/balances/balance-service.yaml
+++ b/openbank-infra/gitops/components/balances/balance-service.yaml
@@ -34,7 +34,7 @@ spec:
       annotations:
         # Rolls the pods when the OPA bundle changes — subPath mounts do NOT hot-reload.
         # Kept in sync by gen-balance-opa-bundle.sh (do not hand-edit).
-        openbank.tech/policy-checksum: "b39b7a2d1050473a"
+        openbank.tech/policy-checksum: "6ed576d9967160a8"
     spec:
       securityContext:
         runAsNonRoot: true

--- a/openbank-infra/gitops/components/billing/billing-opa-bundle.yaml
+++ b/openbank-infra/gitops/components/billing/billing-opa-bundle.yaml
@@ -9,7 +9,7 @@ metadata:
     app.kubernetes.io/name: billing-service
     app.kubernetes.io/part-of: billing
   annotations:
-    openbank.tech/policy-checksum: "f294f4810474b590"
+    openbank.tech/policy-checksum: "6b60e6f3c7c74e5a"
 data:
   rest.rego: |
     # SPDX-License-Identifier: Apache-2.0
@@ -1713,10 +1713,17 @@ data:
         # or be explicitly allowlisted below with a one-line reason (a REST call made through a
         # shared/generic client this heuristic's exact-match can't see, or a genuinely-stale edge
         # already tracked for cleanup elsewhere).
-        detect: ["any <service>/governance.yaml lineage.downstream edge"]
+        # BOTH directions since #2315. An `upstream` edge on S naming T is a claim about T's code, so
+        # it is verified in T — exactly as if T had declared the mirrored downstream edge. Treating
+        # "someone else's code" as out of scope meant 63 upstream edges across 23 services were opened
+        # by nothing, and a service declaring ONLY upstream was skipped outright; aml-service had 3 of
+        # its 6 upstream edges wrong (#2312). Both directions normalize to one <source>-><target>
+        # key, so a relationship declared from both ends is one check and one allowlist entry.
+        detect: ["any <service>/governance.yaml lineage.downstream or lineage.upstream edge"]
         require:
           - "api edge has a matching @RegisterRestClient(configKey) in the same service, or an allowlist entry with a reason"
           - "topic edge has an actual topic overlap with the target service (per mechanism 1's producer/consumer map), or an allowlist entry with a reason"
+          - "an edge naming no in-tree service directory (github, prometheus, temporal) is reported as its own class, never counted as code drift"
         gate: lineage-code-audit
         enforced: advisory
         target_enforce_date: "2026-10-15"   # ADR-0144 — later than mechanism 1's date: first scan found a much higher (34/48) violation rate, expect a longer triage
@@ -1733,7 +1740,11 @@ data:
           checker itself (fixed), 19 are stale governance.yaml edges (corrected/removed), 6 below are
           real dependencies the heuristic's exact-match can't see, and 4 are genuine gaps tracked as
           their own issues, not fixed here. A follow-up scan found 7 more edges outside the original
-          34 (the *->admin-ui reversed-direction shape) — not yet triaged."
+          34 (the *->admin-ui reversed-direction shape) — not yet triaged. #2315 then added the
+          upstream direction: the first upstream scan surfaced 24 further unbacked edges (26 total
+          unallowlisted, of which 2 are the pre-existing downstream findings) plus 10 edges naming an
+          external system — all untriaged, which is why target_enforce_date is unchanged and this
+          stays advisory."
         ci_producer: ".github/scripts/check-governance-lineage.py"
         allowlist:
           - edge: "openbank-copilot-service->balance-service:api"

--- a/openbank-infra/gitops/components/billing/billing-service.yaml
+++ b/openbank-infra/gitops/components/billing/billing-service.yaml
@@ -27,7 +27,7 @@ spec:
       annotations:
         # Rolls the pods when the OPA bundle changes — subPath mounts do NOT hot-reload.
         # Kept in sync by gen-billing-opa-bundle.sh (do not hand-edit).
-        openbank.tech/policy-checksum: "f294f4810474b590"
+        openbank.tech/policy-checksum: "6b60e6f3c7c74e5a"
     spec:
       securityContext:
         runAsNonRoot: true

--- a/openbank-infra/gitops/components/consent/consent-opa-bundle.yaml
+++ b/openbank-infra/gitops/components/consent/consent-opa-bundle.yaml
@@ -9,7 +9,7 @@ metadata:
     app.kubernetes.io/name: consent-service
     app.kubernetes.io/part-of: consent
   annotations:
-    openbank.tech/policy-checksum: "fa6d928578aea09f"
+    openbank.tech/policy-checksum: "a193c92d1fc9809d"
 data:
   rest.rego: |
     # SPDX-License-Identifier: Apache-2.0
@@ -1771,10 +1771,17 @@ data:
         # or be explicitly allowlisted below with a one-line reason (a REST call made through a
         # shared/generic client this heuristic's exact-match can't see, or a genuinely-stale edge
         # already tracked for cleanup elsewhere).
-        detect: ["any <service>/governance.yaml lineage.downstream edge"]
+        # BOTH directions since #2315. An `upstream` edge on S naming T is a claim about T's code, so
+        # it is verified in T — exactly as if T had declared the mirrored downstream edge. Treating
+        # "someone else's code" as out of scope meant 63 upstream edges across 23 services were opened
+        # by nothing, and a service declaring ONLY upstream was skipped outright; aml-service had 3 of
+        # its 6 upstream edges wrong (#2312). Both directions normalize to one <source>-><target>
+        # key, so a relationship declared from both ends is one check and one allowlist entry.
+        detect: ["any <service>/governance.yaml lineage.downstream or lineage.upstream edge"]
         require:
           - "api edge has a matching @RegisterRestClient(configKey) in the same service, or an allowlist entry with a reason"
           - "topic edge has an actual topic overlap with the target service (per mechanism 1's producer/consumer map), or an allowlist entry with a reason"
+          - "an edge naming no in-tree service directory (github, prometheus, temporal) is reported as its own class, never counted as code drift"
         gate: lineage-code-audit
         enforced: advisory
         target_enforce_date: "2026-10-15"   # ADR-0144 — later than mechanism 1's date: first scan found a much higher (34/48) violation rate, expect a longer triage
@@ -1791,7 +1798,11 @@ data:
           checker itself (fixed), 19 are stale governance.yaml edges (corrected/removed), 6 below are
           real dependencies the heuristic's exact-match can't see, and 4 are genuine gaps tracked as
           their own issues, not fixed here. A follow-up scan found 7 more edges outside the original
-          34 (the *->admin-ui reversed-direction shape) — not yet triaged."
+          34 (the *->admin-ui reversed-direction shape) — not yet triaged. #2315 then added the
+          upstream direction: the first upstream scan surfaced 24 further unbacked edges (26 total
+          unallowlisted, of which 2 are the pre-existing downstream findings) plus 10 edges naming an
+          external system — all untriaged, which is why target_enforce_date is unchanged and this
+          stays advisory."
         ci_producer: ".github/scripts/check-governance-lineage.py"
         allowlist:
           - edge: "openbank-copilot-service->balance-service:api"

--- a/openbank-infra/gitops/components/consent/consent-service.yaml
+++ b/openbank-infra/gitops/components/consent/consent-service.yaml
@@ -28,7 +28,7 @@ spec:
       annotations:
         # Rolls the pods when the OPA bundle changes — subPath mounts do NOT hot-reload.
         # Kept in sync by gen-consent-opa-bundle.sh (do not hand-edit).
-        openbank.tech/policy-checksum: "fa6d928578aea09f"
+        openbank.tech/policy-checksum: "a193c92d1fc9809d"
     spec:
       securityContext:
         runAsNonRoot: true

--- a/openbank-infra/gitops/components/copilot/copilot-opa-bundle.yaml
+++ b/openbank-infra/gitops/components/copilot/copilot-opa-bundle.yaml
@@ -9,7 +9,7 @@ metadata:
     app.kubernetes.io/name: copilot-service
     app.kubernetes.io/part-of: platform
   annotations:
-    openbank.tech/policy-checksum: "8b799186606ed55e"
+    openbank.tech/policy-checksum: "7b3da65956c4f71f"
 data:
   rest.rego: |
     # SPDX-License-Identifier: Apache-2.0
@@ -1799,10 +1799,17 @@ data:
         # or be explicitly allowlisted below with a one-line reason (a REST call made through a
         # shared/generic client this heuristic's exact-match can't see, or a genuinely-stale edge
         # already tracked for cleanup elsewhere).
-        detect: ["any <service>/governance.yaml lineage.downstream edge"]
+        # BOTH directions since #2315. An `upstream` edge on S naming T is a claim about T's code, so
+        # it is verified in T — exactly as if T had declared the mirrored downstream edge. Treating
+        # "someone else's code" as out of scope meant 63 upstream edges across 23 services were opened
+        # by nothing, and a service declaring ONLY upstream was skipped outright; aml-service had 3 of
+        # its 6 upstream edges wrong (#2312). Both directions normalize to one <source>-><target>
+        # key, so a relationship declared from both ends is one check and one allowlist entry.
+        detect: ["any <service>/governance.yaml lineage.downstream or lineage.upstream edge"]
         require:
           - "api edge has a matching @RegisterRestClient(configKey) in the same service, or an allowlist entry with a reason"
           - "topic edge has an actual topic overlap with the target service (per mechanism 1's producer/consumer map), or an allowlist entry with a reason"
+          - "an edge naming no in-tree service directory (github, prometheus, temporal) is reported as its own class, never counted as code drift"
         gate: lineage-code-audit
         enforced: advisory
         target_enforce_date: "2026-10-15"   # ADR-0144 — later than mechanism 1's date: first scan found a much higher (34/48) violation rate, expect a longer triage
@@ -1819,7 +1826,11 @@ data:
           checker itself (fixed), 19 are stale governance.yaml edges (corrected/removed), 6 below are
           real dependencies the heuristic's exact-match can't see, and 4 are genuine gaps tracked as
           their own issues, not fixed here. A follow-up scan found 7 more edges outside the original
-          34 (the *->admin-ui reversed-direction shape) — not yet triaged."
+          34 (the *->admin-ui reversed-direction shape) — not yet triaged. #2315 then added the
+          upstream direction: the first upstream scan surfaced 24 further unbacked edges (26 total
+          unallowlisted, of which 2 are the pre-existing downstream findings) plus 10 edges naming an
+          external system — all untriaged, which is why target_enforce_date is unchanged and this
+          stays advisory."
         ci_producer: ".github/scripts/check-governance-lineage.py"
         allowlist:
           - edge: "openbank-copilot-service->balance-service:api"

--- a/openbank-infra/gitops/components/copilot/copilot-service.yaml
+++ b/openbank-infra/gitops/components/copilot/copilot-service.yaml
@@ -29,7 +29,7 @@ spec:
       annotations:
         # Rolls the pod when the OPA bundle changes — subPath mounts do NOT hot-reload.
         # Kept in sync by gen-copilot-opa-bundle.sh (do not hand-edit).
-        openbank.tech/policy-checksum: "8b799186606ed55e"
+        openbank.tech/policy-checksum: "7b3da65956c4f71f"
     spec:
       securityContext:
         runAsNonRoot: true

--- a/openbank-infra/gitops/components/customer-edge/customer-edge-opa-bundle.yaml
+++ b/openbank-infra/gitops/components/customer-edge/customer-edge-opa-bundle.yaml
@@ -10,7 +10,7 @@ metadata:
     app.kubernetes.io/name: customer-edge
     app.kubernetes.io/part-of: customer-edge
   annotations:
-    openbank.tech/policy-checksum: "2592909d9461fccf"
+    openbank.tech/policy-checksum: "1eec4da21ded4c3f"
 data:
   rest.rego: |
     # SPDX-License-Identifier: Apache-2.0
@@ -898,10 +898,17 @@ data:
         # or be explicitly allowlisted below with a one-line reason (a REST call made through a
         # shared/generic client this heuristic's exact-match can't see, or a genuinely-stale edge
         # already tracked for cleanup elsewhere).
-        detect: ["any <service>/governance.yaml lineage.downstream edge"]
+        # BOTH directions since #2315. An `upstream` edge on S naming T is a claim about T's code, so
+        # it is verified in T — exactly as if T had declared the mirrored downstream edge. Treating
+        # "someone else's code" as out of scope meant 63 upstream edges across 23 services were opened
+        # by nothing, and a service declaring ONLY upstream was skipped outright; aml-service had 3 of
+        # its 6 upstream edges wrong (#2312). Both directions normalize to one <source>-><target>
+        # key, so a relationship declared from both ends is one check and one allowlist entry.
+        detect: ["any <service>/governance.yaml lineage.downstream or lineage.upstream edge"]
         require:
           - "api edge has a matching @RegisterRestClient(configKey) in the same service, or an allowlist entry with a reason"
           - "topic edge has an actual topic overlap with the target service (per mechanism 1's producer/consumer map), or an allowlist entry with a reason"
+          - "an edge naming no in-tree service directory (github, prometheus, temporal) is reported as its own class, never counted as code drift"
         gate: lineage-code-audit
         enforced: advisory
         target_enforce_date: "2026-10-15"   # ADR-0144 — later than mechanism 1's date: first scan found a much higher (34/48) violation rate, expect a longer triage
@@ -918,7 +925,11 @@ data:
           checker itself (fixed), 19 are stale governance.yaml edges (corrected/removed), 6 below are
           real dependencies the heuristic's exact-match can't see, and 4 are genuine gaps tracked as
           their own issues, not fixed here. A follow-up scan found 7 more edges outside the original
-          34 (the *->admin-ui reversed-direction shape) — not yet triaged."
+          34 (the *->admin-ui reversed-direction shape) — not yet triaged. #2315 then added the
+          upstream direction: the first upstream scan surfaced 24 further unbacked edges (26 total
+          unallowlisted, of which 2 are the pre-existing downstream findings) plus 10 edges naming an
+          external system — all untriaged, which is why target_enforce_date is unchanged and this
+          stays advisory."
         ci_producer: ".github/scripts/check-governance-lineage.py"
         allowlist:
           - edge: "openbank-copilot-service->balance-service:api"

--- a/openbank-infra/gitops/components/customer-edge/customer-edge.yaml
+++ b/openbank-infra/gitops/components/customer-edge/customer-edge.yaml
@@ -65,7 +65,7 @@ spec:
       annotations:
         # Rolls the pod when the OPA bundle changes — subPath mounts do NOT hot-reload.
         # Kept in sync by gen-customer-edge-opa-bundle.sh (do not hand-edit).
-        openbank.tech/policy-checksum: "2592909d9461fccf"
+        openbank.tech/policy-checksum: "1eec4da21ded4c3f"
     spec:
       # Dedicated SA so EKS Pod Identity can hand the edge (and ONLY the edge) the
       # feedback-screenshots S3 role — ADR-0192, openbank-infra/aws/envs/sandbox-platform/

--- a/openbank-infra/gitops/components/dispute-service/dispute-opa-bundle.yaml
+++ b/openbank-infra/gitops/components/dispute-service/dispute-opa-bundle.yaml
@@ -9,7 +9,7 @@ metadata:
     app.kubernetes.io/name: dispute-service
     app.kubernetes.io/part-of: dispute
   annotations:
-    openbank.tech/policy-checksum: "66ea7f990813ccd4"
+    openbank.tech/policy-checksum: "9dd3781307f2a07a"
 data:
   rest.rego: |
     # SPDX-License-Identifier: Apache-2.0
@@ -1849,10 +1849,17 @@ data:
         # or be explicitly allowlisted below with a one-line reason (a REST call made through a
         # shared/generic client this heuristic's exact-match can't see, or a genuinely-stale edge
         # already tracked for cleanup elsewhere).
-        detect: ["any <service>/governance.yaml lineage.downstream edge"]
+        # BOTH directions since #2315. An `upstream` edge on S naming T is a claim about T's code, so
+        # it is verified in T — exactly as if T had declared the mirrored downstream edge. Treating
+        # "someone else's code" as out of scope meant 63 upstream edges across 23 services were opened
+        # by nothing, and a service declaring ONLY upstream was skipped outright; aml-service had 3 of
+        # its 6 upstream edges wrong (#2312). Both directions normalize to one <source>-><target>
+        # key, so a relationship declared from both ends is one check and one allowlist entry.
+        detect: ["any <service>/governance.yaml lineage.downstream or lineage.upstream edge"]
         require:
           - "api edge has a matching @RegisterRestClient(configKey) in the same service, or an allowlist entry with a reason"
           - "topic edge has an actual topic overlap with the target service (per mechanism 1's producer/consumer map), or an allowlist entry with a reason"
+          - "an edge naming no in-tree service directory (github, prometheus, temporal) is reported as its own class, never counted as code drift"
         gate: lineage-code-audit
         enforced: advisory
         target_enforce_date: "2026-10-15"   # ADR-0144 — later than mechanism 1's date: first scan found a much higher (34/48) violation rate, expect a longer triage
@@ -1869,7 +1876,11 @@ data:
           checker itself (fixed), 19 are stale governance.yaml edges (corrected/removed), 6 below are
           real dependencies the heuristic's exact-match can't see, and 4 are genuine gaps tracked as
           their own issues, not fixed here. A follow-up scan found 7 more edges outside the original
-          34 (the *->admin-ui reversed-direction shape) — not yet triaged."
+          34 (the *->admin-ui reversed-direction shape) — not yet triaged. #2315 then added the
+          upstream direction: the first upstream scan surfaced 24 further unbacked edges (26 total
+          unallowlisted, of which 2 are the pre-existing downstream findings) plus 10 edges naming an
+          external system — all untriaged, which is why target_enforce_date is unchanged and this
+          stays advisory."
         ci_producer: ".github/scripts/check-governance-lineage.py"
         allowlist:
           - edge: "openbank-copilot-service->balance-service:api"

--- a/openbank-infra/gitops/components/dispute-service/dispute-service.yaml
+++ b/openbank-infra/gitops/components/dispute-service/dispute-service.yaml
@@ -15,7 +15,7 @@ spec:
       annotations:
         # Rolls the pod when the OPA bundle changes — subPath mounts do NOT hot-reload.
         # Kept in sync by gen-dispute-opa-bundle.sh (do not hand-edit).
-        openbank.tech/policy-checksum: "66ea7f990813ccd4"
+        openbank.tech/policy-checksum: "9dd3781307f2a07a"
       labels: {app.kubernetes.io/name: dispute-service, app.kubernetes.io/part-of: dispute}
     spec:
       securityContext:

--- a/openbank-infra/gitops/components/document-service/document-service-opa-bundle.yaml
+++ b/openbank-infra/gitops/components/document-service/document-service-opa-bundle.yaml
@@ -10,7 +10,7 @@ metadata:
     app.kubernetes.io/name: document-service
     app.kubernetes.io/part-of: documents
   annotations:
-    openbank.tech/policy-checksum: "2592909d9461fccf"
+    openbank.tech/policy-checksum: "1eec4da21ded4c3f"
 data:
   rest.rego: |
     # SPDX-License-Identifier: Apache-2.0
@@ -898,10 +898,17 @@ data:
         # or be explicitly allowlisted below with a one-line reason (a REST call made through a
         # shared/generic client this heuristic's exact-match can't see, or a genuinely-stale edge
         # already tracked for cleanup elsewhere).
-        detect: ["any <service>/governance.yaml lineage.downstream edge"]
+        # BOTH directions since #2315. An `upstream` edge on S naming T is a claim about T's code, so
+        # it is verified in T — exactly as if T had declared the mirrored downstream edge. Treating
+        # "someone else's code" as out of scope meant 63 upstream edges across 23 services were opened
+        # by nothing, and a service declaring ONLY upstream was skipped outright; aml-service had 3 of
+        # its 6 upstream edges wrong (#2312). Both directions normalize to one <source>-><target>
+        # key, so a relationship declared from both ends is one check and one allowlist entry.
+        detect: ["any <service>/governance.yaml lineage.downstream or lineage.upstream edge"]
         require:
           - "api edge has a matching @RegisterRestClient(configKey) in the same service, or an allowlist entry with a reason"
           - "topic edge has an actual topic overlap with the target service (per mechanism 1's producer/consumer map), or an allowlist entry with a reason"
+          - "an edge naming no in-tree service directory (github, prometheus, temporal) is reported as its own class, never counted as code drift"
         gate: lineage-code-audit
         enforced: advisory
         target_enforce_date: "2026-10-15"   # ADR-0144 — later than mechanism 1's date: first scan found a much higher (34/48) violation rate, expect a longer triage
@@ -918,7 +925,11 @@ data:
           checker itself (fixed), 19 are stale governance.yaml edges (corrected/removed), 6 below are
           real dependencies the heuristic's exact-match can't see, and 4 are genuine gaps tracked as
           their own issues, not fixed here. A follow-up scan found 7 more edges outside the original
-          34 (the *->admin-ui reversed-direction shape) — not yet triaged."
+          34 (the *->admin-ui reversed-direction shape) — not yet triaged. #2315 then added the
+          upstream direction: the first upstream scan surfaced 24 further unbacked edges (26 total
+          unallowlisted, of which 2 are the pre-existing downstream findings) plus 10 edges naming an
+          external system — all untriaged, which is why target_enforce_date is unchanged and this
+          stays advisory."
         ci_producer: ".github/scripts/check-governance-lineage.py"
         allowlist:
           - edge: "openbank-copilot-service->balance-service:api"

--- a/openbank-infra/gitops/components/document-service/document-service-service.yaml
+++ b/openbank-infra/gitops/components/document-service/document-service-service.yaml
@@ -43,7 +43,7 @@ spec:
       annotations:
         # Rolls the pods when the OPA bundle changes — subPath mounts do NOT hot-reload.
         # Kept in sync by gen-document-service-opa-bundle.sh (do not hand-edit).
-        openbank.tech/policy-checksum: "2592909d9461fccf"
+        openbank.tech/policy-checksum: "1eec4da21ded4c3f"
     spec:
       # ADR-0162 D4 (continued): a dedicated SA (not `default`) is what OpenBao's Kubernetes-auth
       # role `document-service-signing` is bound to — least-privilege, one identity per consumer.

--- a/openbank-infra/gitops/components/fraud-service/fraud-opa-bundle.yaml
+++ b/openbank-infra/gitops/components/fraud-service/fraud-opa-bundle.yaml
@@ -9,7 +9,7 @@ metadata:
     app.kubernetes.io/name: fraud-service
     app.kubernetes.io/part-of: fraud
   annotations:
-    openbank.tech/policy-checksum: "a79143054d56f7e5"
+    openbank.tech/policy-checksum: "e9d0f1368a509cdb"
 data:
   rest.rego: |
     # SPDX-License-Identifier: Apache-2.0
@@ -1724,10 +1724,17 @@ data:
         # or be explicitly allowlisted below with a one-line reason (a REST call made through a
         # shared/generic client this heuristic's exact-match can't see, or a genuinely-stale edge
         # already tracked for cleanup elsewhere).
-        detect: ["any <service>/governance.yaml lineage.downstream edge"]
+        # BOTH directions since #2315. An `upstream` edge on S naming T is a claim about T's code, so
+        # it is verified in T — exactly as if T had declared the mirrored downstream edge. Treating
+        # "someone else's code" as out of scope meant 63 upstream edges across 23 services were opened
+        # by nothing, and a service declaring ONLY upstream was skipped outright; aml-service had 3 of
+        # its 6 upstream edges wrong (#2312). Both directions normalize to one <source>-><target>
+        # key, so a relationship declared from both ends is one check and one allowlist entry.
+        detect: ["any <service>/governance.yaml lineage.downstream or lineage.upstream edge"]
         require:
           - "api edge has a matching @RegisterRestClient(configKey) in the same service, or an allowlist entry with a reason"
           - "topic edge has an actual topic overlap with the target service (per mechanism 1's producer/consumer map), or an allowlist entry with a reason"
+          - "an edge naming no in-tree service directory (github, prometheus, temporal) is reported as its own class, never counted as code drift"
         gate: lineage-code-audit
         enforced: advisory
         target_enforce_date: "2026-10-15"   # ADR-0144 — later than mechanism 1's date: first scan found a much higher (34/48) violation rate, expect a longer triage
@@ -1744,7 +1751,11 @@ data:
           checker itself (fixed), 19 are stale governance.yaml edges (corrected/removed), 6 below are
           real dependencies the heuristic's exact-match can't see, and 4 are genuine gaps tracked as
           their own issues, not fixed here. A follow-up scan found 7 more edges outside the original
-          34 (the *->admin-ui reversed-direction shape) — not yet triaged."
+          34 (the *->admin-ui reversed-direction shape) — not yet triaged. #2315 then added the
+          upstream direction: the first upstream scan surfaced 24 further unbacked edges (26 total
+          unallowlisted, of which 2 are the pre-existing downstream findings) plus 10 edges naming an
+          external system — all untriaged, which is why target_enforce_date is unchanged and this
+          stays advisory."
         ci_producer: ".github/scripts/check-governance-lineage.py"
         allowlist:
           - edge: "openbank-copilot-service->balance-service:api"

--- a/openbank-infra/gitops/components/fraud-service/fraud-service.yaml
+++ b/openbank-infra/gitops/components/fraud-service/fraud-service.yaml
@@ -23,7 +23,7 @@ spec:
       annotations:
         # Rolls the pods when the OPA bundle changes — subPath mounts do NOT hot-reload.
         # Kept in sync by gen-fraud-opa-bundle.sh (do not hand-edit).
-        openbank.tech/policy-checksum: "a79143054d56f7e5"
+        openbank.tech/policy-checksum: "e9d0f1368a509cdb"
     spec:
       securityContext:
         runAsNonRoot: true

--- a/openbank-infra/gitops/components/fx-service/fx-opa-bundle.yaml
+++ b/openbank-infra/gitops/components/fx-service/fx-opa-bundle.yaml
@@ -9,7 +9,7 @@ metadata:
     app.kubernetes.io/name: fx-service
     app.kubernetes.io/part-of: fx
   annotations:
-    openbank.tech/policy-checksum: "8f32f0c20d7202fd"
+    openbank.tech/policy-checksum: "91582d4a2016ca36"
 data:
   rest.rego: |
     # SPDX-License-Identifier: Apache-2.0
@@ -1775,10 +1775,17 @@ data:
         # or be explicitly allowlisted below with a one-line reason (a REST call made through a
         # shared/generic client this heuristic's exact-match can't see, or a genuinely-stale edge
         # already tracked for cleanup elsewhere).
-        detect: ["any <service>/governance.yaml lineage.downstream edge"]
+        # BOTH directions since #2315. An `upstream` edge on S naming T is a claim about T's code, so
+        # it is verified in T — exactly as if T had declared the mirrored downstream edge. Treating
+        # "someone else's code" as out of scope meant 63 upstream edges across 23 services were opened
+        # by nothing, and a service declaring ONLY upstream was skipped outright; aml-service had 3 of
+        # its 6 upstream edges wrong (#2312). Both directions normalize to one <source>-><target>
+        # key, so a relationship declared from both ends is one check and one allowlist entry.
+        detect: ["any <service>/governance.yaml lineage.downstream or lineage.upstream edge"]
         require:
           - "api edge has a matching @RegisterRestClient(configKey) in the same service, or an allowlist entry with a reason"
           - "topic edge has an actual topic overlap with the target service (per mechanism 1's producer/consumer map), or an allowlist entry with a reason"
+          - "an edge naming no in-tree service directory (github, prometheus, temporal) is reported as its own class, never counted as code drift"
         gate: lineage-code-audit
         enforced: advisory
         target_enforce_date: "2026-10-15"   # ADR-0144 — later than mechanism 1's date: first scan found a much higher (34/48) violation rate, expect a longer triage
@@ -1795,7 +1802,11 @@ data:
           checker itself (fixed), 19 are stale governance.yaml edges (corrected/removed), 6 below are
           real dependencies the heuristic's exact-match can't see, and 4 are genuine gaps tracked as
           their own issues, not fixed here. A follow-up scan found 7 more edges outside the original
-          34 (the *->admin-ui reversed-direction shape) — not yet triaged."
+          34 (the *->admin-ui reversed-direction shape) — not yet triaged. #2315 then added the
+          upstream direction: the first upstream scan surfaced 24 further unbacked edges (26 total
+          unallowlisted, of which 2 are the pre-existing downstream findings) plus 10 edges naming an
+          external system — all untriaged, which is why target_enforce_date is unchanged and this
+          stays advisory."
         ci_producer: ".github/scripts/check-governance-lineage.py"
         allowlist:
           - edge: "openbank-copilot-service->balance-service:api"

--- a/openbank-infra/gitops/components/fx-service/fx-service.yaml
+++ b/openbank-infra/gitops/components/fx-service/fx-service.yaml
@@ -22,7 +22,7 @@ spec:
       annotations:
         # Rolls the pods when the OPA bundle changes — subPath mounts do NOT hot-reload.
         # Kept in sync by gen-fx-opa-bundle.sh (do not hand-edit).
-        openbank.tech/policy-checksum: "8f32f0c20d7202fd"
+        openbank.tech/policy-checksum: "91582d4a2016ca36"
     spec:
       securityContext:
         runAsNonRoot: true

--- a/openbank-infra/gitops/components/interest-service/interest-opa-bundle.yaml
+++ b/openbank-infra/gitops/components/interest-service/interest-opa-bundle.yaml
@@ -9,7 +9,7 @@ metadata:
     app.kubernetes.io/name: interest-service
     app.kubernetes.io/part-of: interest
   annotations:
-    openbank.tech/policy-checksum: "4412f6d1af5bbc11"
+    openbank.tech/policy-checksum: "d43ff39c10a4d3c5"
 data:
   rest.rego: |
     # SPDX-License-Identifier: Apache-2.0
@@ -1709,10 +1709,17 @@ data:
         # or be explicitly allowlisted below with a one-line reason (a REST call made through a
         # shared/generic client this heuristic's exact-match can't see, or a genuinely-stale edge
         # already tracked for cleanup elsewhere).
-        detect: ["any <service>/governance.yaml lineage.downstream edge"]
+        # BOTH directions since #2315. An `upstream` edge on S naming T is a claim about T's code, so
+        # it is verified in T — exactly as if T had declared the mirrored downstream edge. Treating
+        # "someone else's code" as out of scope meant 63 upstream edges across 23 services were opened
+        # by nothing, and a service declaring ONLY upstream was skipped outright; aml-service had 3 of
+        # its 6 upstream edges wrong (#2312). Both directions normalize to one <source>-><target>
+        # key, so a relationship declared from both ends is one check and one allowlist entry.
+        detect: ["any <service>/governance.yaml lineage.downstream or lineage.upstream edge"]
         require:
           - "api edge has a matching @RegisterRestClient(configKey) in the same service, or an allowlist entry with a reason"
           - "topic edge has an actual topic overlap with the target service (per mechanism 1's producer/consumer map), or an allowlist entry with a reason"
+          - "an edge naming no in-tree service directory (github, prometheus, temporal) is reported as its own class, never counted as code drift"
         gate: lineage-code-audit
         enforced: advisory
         target_enforce_date: "2026-10-15"   # ADR-0144 — later than mechanism 1's date: first scan found a much higher (34/48) violation rate, expect a longer triage
@@ -1729,7 +1736,11 @@ data:
           checker itself (fixed), 19 are stale governance.yaml edges (corrected/removed), 6 below are
           real dependencies the heuristic's exact-match can't see, and 4 are genuine gaps tracked as
           their own issues, not fixed here. A follow-up scan found 7 more edges outside the original
-          34 (the *->admin-ui reversed-direction shape) — not yet triaged."
+          34 (the *->admin-ui reversed-direction shape) — not yet triaged. #2315 then added the
+          upstream direction: the first upstream scan surfaced 24 further unbacked edges (26 total
+          unallowlisted, of which 2 are the pre-existing downstream findings) plus 10 edges naming an
+          external system — all untriaged, which is why target_enforce_date is unchanged and this
+          stays advisory."
         ci_producer: ".github/scripts/check-governance-lineage.py"
         allowlist:
           - edge: "openbank-copilot-service->balance-service:api"

--- a/openbank-infra/gitops/components/interest-service/interest-service.yaml
+++ b/openbank-infra/gitops/components/interest-service/interest-service.yaml
@@ -16,7 +16,7 @@ spec:
       annotations:
         # Rolls the pods when the OPA bundle changes — subPath mounts do NOT hot-reload.
         # Kept in sync by gen-interest-opa-bundle.sh (do not hand-edit).
-        openbank.tech/policy-checksum: "4412f6d1af5bbc11"
+        openbank.tech/policy-checksum: "d43ff39c10a4d3c5"
     spec:
       securityContext:
         runAsNonRoot: true

--- a/openbank-infra/gitops/components/kyc/kyc-opa-bundle.yaml
+++ b/openbank-infra/gitops/components/kyc/kyc-opa-bundle.yaml
@@ -9,7 +9,7 @@ metadata:
     app.kubernetes.io/name: kyc-service
     app.kubernetes.io/part-of: kyc
   annotations:
-    openbank.tech/policy-checksum: "2e12ec37a1a677d2"
+    openbank.tech/policy-checksum: "cb7e322aa2d6ac46"
 data:
   rest.rego: |
     # SPDX-License-Identifier: Apache-2.0
@@ -1737,10 +1737,17 @@ data:
         # or be explicitly allowlisted below with a one-line reason (a REST call made through a
         # shared/generic client this heuristic's exact-match can't see, or a genuinely-stale edge
         # already tracked for cleanup elsewhere).
-        detect: ["any <service>/governance.yaml lineage.downstream edge"]
+        # BOTH directions since #2315. An `upstream` edge on S naming T is a claim about T's code, so
+        # it is verified in T — exactly as if T had declared the mirrored downstream edge. Treating
+        # "someone else's code" as out of scope meant 63 upstream edges across 23 services were opened
+        # by nothing, and a service declaring ONLY upstream was skipped outright; aml-service had 3 of
+        # its 6 upstream edges wrong (#2312). Both directions normalize to one <source>-><target>
+        # key, so a relationship declared from both ends is one check and one allowlist entry.
+        detect: ["any <service>/governance.yaml lineage.downstream or lineage.upstream edge"]
         require:
           - "api edge has a matching @RegisterRestClient(configKey) in the same service, or an allowlist entry with a reason"
           - "topic edge has an actual topic overlap with the target service (per mechanism 1's producer/consumer map), or an allowlist entry with a reason"
+          - "an edge naming no in-tree service directory (github, prometheus, temporal) is reported as its own class, never counted as code drift"
         gate: lineage-code-audit
         enforced: advisory
         target_enforce_date: "2026-10-15"   # ADR-0144 — later than mechanism 1's date: first scan found a much higher (34/48) violation rate, expect a longer triage
@@ -1757,7 +1764,11 @@ data:
           checker itself (fixed), 19 are stale governance.yaml edges (corrected/removed), 6 below are
           real dependencies the heuristic's exact-match can't see, and 4 are genuine gaps tracked as
           their own issues, not fixed here. A follow-up scan found 7 more edges outside the original
-          34 (the *->admin-ui reversed-direction shape) — not yet triaged."
+          34 (the *->admin-ui reversed-direction shape) — not yet triaged. #2315 then added the
+          upstream direction: the first upstream scan surfaced 24 further unbacked edges (26 total
+          unallowlisted, of which 2 are the pre-existing downstream findings) plus 10 edges naming an
+          external system — all untriaged, which is why target_enforce_date is unchanged and this
+          stays advisory."
         ci_producer: ".github/scripts/check-governance-lineage.py"
         allowlist:
           - edge: "openbank-copilot-service->balance-service:api"

--- a/openbank-infra/gitops/components/kyc/kyc-service.yaml
+++ b/openbank-infra/gitops/components/kyc/kyc-service.yaml
@@ -48,7 +48,7 @@ spec:
       annotations:
         # Rolls the pod when the OPA bundle changes (subPath mounts do not hot-reload).
         # Kept in sync by gen-kyc-opa-bundle.sh (do not hand-edit).
-        openbank.tech/policy-checksum: "2e12ec37a1a677d2"
+        openbank.tech/policy-checksum: "cb7e322aa2d6ac46"
     spec:
       securityContext:
         runAsNonRoot: true

--- a/openbank-infra/gitops/components/ledger/ledger-opa-bundle.yaml
+++ b/openbank-infra/gitops/components/ledger/ledger-opa-bundle.yaml
@@ -9,7 +9,7 @@ metadata:
     app.kubernetes.io/name: ledger-service
     app.kubernetes.io/part-of: ledger
   annotations:
-    openbank.tech/policy-checksum: "841a194f126b79c3"
+    openbank.tech/policy-checksum: "c7950fa54b6a0d8b"
 data:
   rest.rego: |
     # SPDX-License-Identifier: Apache-2.0
@@ -1822,10 +1822,17 @@ data:
         # or be explicitly allowlisted below with a one-line reason (a REST call made through a
         # shared/generic client this heuristic's exact-match can't see, or a genuinely-stale edge
         # already tracked for cleanup elsewhere).
-        detect: ["any <service>/governance.yaml lineage.downstream edge"]
+        # BOTH directions since #2315. An `upstream` edge on S naming T is a claim about T's code, so
+        # it is verified in T — exactly as if T had declared the mirrored downstream edge. Treating
+        # "someone else's code" as out of scope meant 63 upstream edges across 23 services were opened
+        # by nothing, and a service declaring ONLY upstream was skipped outright; aml-service had 3 of
+        # its 6 upstream edges wrong (#2312). Both directions normalize to one <source>-><target>
+        # key, so a relationship declared from both ends is one check and one allowlist entry.
+        detect: ["any <service>/governance.yaml lineage.downstream or lineage.upstream edge"]
         require:
           - "api edge has a matching @RegisterRestClient(configKey) in the same service, or an allowlist entry with a reason"
           - "topic edge has an actual topic overlap with the target service (per mechanism 1's producer/consumer map), or an allowlist entry with a reason"
+          - "an edge naming no in-tree service directory (github, prometheus, temporal) is reported as its own class, never counted as code drift"
         gate: lineage-code-audit
         enforced: advisory
         target_enforce_date: "2026-10-15"   # ADR-0144 — later than mechanism 1's date: first scan found a much higher (34/48) violation rate, expect a longer triage
@@ -1842,7 +1849,11 @@ data:
           checker itself (fixed), 19 are stale governance.yaml edges (corrected/removed), 6 below are
           real dependencies the heuristic's exact-match can't see, and 4 are genuine gaps tracked as
           their own issues, not fixed here. A follow-up scan found 7 more edges outside the original
-          34 (the *->admin-ui reversed-direction shape) — not yet triaged."
+          34 (the *->admin-ui reversed-direction shape) — not yet triaged. #2315 then added the
+          upstream direction: the first upstream scan surfaced 24 further unbacked edges (26 total
+          unallowlisted, of which 2 are the pre-existing downstream findings) plus 10 edges naming an
+          external system — all untriaged, which is why target_enforce_date is unchanged and this
+          stays advisory."
         ci_producer: ".github/scripts/check-governance-lineage.py"
         allowlist:
           - edge: "openbank-copilot-service->balance-service:api"

--- a/openbank-infra/gitops/components/ledger/ledger-service.yaml
+++ b/openbank-infra/gitops/components/ledger/ledger-service.yaml
@@ -38,7 +38,7 @@ spec:
       annotations:
         # Rolls the pods when the OPA bundle changes — subPath mounts do NOT hot-reload.
         # Kept in sync by gen-ledger-opa-bundle.sh (do not hand-edit).
-        openbank.tech/policy-checksum: "841a194f126b79c3"
+        openbank.tech/policy-checksum: "c7950fa54b6a0d8b"
     spec:
       securityContext:
         runAsNonRoot: true

--- a/openbank-infra/gitops/components/lending/lending-opa-bundle.yaml
+++ b/openbank-infra/gitops/components/lending/lending-opa-bundle.yaml
@@ -9,7 +9,7 @@ metadata:
     app.kubernetes.io/name: lending-service
     app.kubernetes.io/part-of: lending
   annotations:
-    openbank.tech/policy-checksum: "c2b316cf03d1de04"
+    openbank.tech/policy-checksum: "b6f2cf499d023430"
 data:
   rest.rego: |
     # SPDX-License-Identifier: Apache-2.0
@@ -1777,10 +1777,17 @@ data:
         # or be explicitly allowlisted below with a one-line reason (a REST call made through a
         # shared/generic client this heuristic's exact-match can't see, or a genuinely-stale edge
         # already tracked for cleanup elsewhere).
-        detect: ["any <service>/governance.yaml lineage.downstream edge"]
+        # BOTH directions since #2315. An `upstream` edge on S naming T is a claim about T's code, so
+        # it is verified in T — exactly as if T had declared the mirrored downstream edge. Treating
+        # "someone else's code" as out of scope meant 63 upstream edges across 23 services were opened
+        # by nothing, and a service declaring ONLY upstream was skipped outright; aml-service had 3 of
+        # its 6 upstream edges wrong (#2312). Both directions normalize to one <source>-><target>
+        # key, so a relationship declared from both ends is one check and one allowlist entry.
+        detect: ["any <service>/governance.yaml lineage.downstream or lineage.upstream edge"]
         require:
           - "api edge has a matching @RegisterRestClient(configKey) in the same service, or an allowlist entry with a reason"
           - "topic edge has an actual topic overlap with the target service (per mechanism 1's producer/consumer map), or an allowlist entry with a reason"
+          - "an edge naming no in-tree service directory (github, prometheus, temporal) is reported as its own class, never counted as code drift"
         gate: lineage-code-audit
         enforced: advisory
         target_enforce_date: "2026-10-15"   # ADR-0144 — later than mechanism 1's date: first scan found a much higher (34/48) violation rate, expect a longer triage
@@ -1797,7 +1804,11 @@ data:
           checker itself (fixed), 19 are stale governance.yaml edges (corrected/removed), 6 below are
           real dependencies the heuristic's exact-match can't see, and 4 are genuine gaps tracked as
           their own issues, not fixed here. A follow-up scan found 7 more edges outside the original
-          34 (the *->admin-ui reversed-direction shape) — not yet triaged."
+          34 (the *->admin-ui reversed-direction shape) — not yet triaged. #2315 then added the
+          upstream direction: the first upstream scan surfaced 24 further unbacked edges (26 total
+          unallowlisted, of which 2 are the pre-existing downstream findings) plus 10 edges naming an
+          external system — all untriaged, which is why target_enforce_date is unchanged and this
+          stays advisory."
         ci_producer: ".github/scripts/check-governance-lineage.py"
         allowlist:
           - edge: "openbank-copilot-service->balance-service:api"

--- a/openbank-infra/gitops/components/lending/lending-service.yaml
+++ b/openbank-infra/gitops/components/lending/lending-service.yaml
@@ -34,7 +34,7 @@ spec:
       annotations:
         # Rolls the pods when the OPA bundle changes — subPath mounts do NOT hot-reload.
         # Kept in sync by gen-lending-opa-bundle.sh (do not hand-edit).
-        openbank.tech/policy-checksum: "c2b316cf03d1de04"
+        openbank.tech/policy-checksum: "b6f2cf499d023430"
     spec:
       securityContext:
         runAsNonRoot: true

--- a/openbank-infra/gitops/components/mcp/mcp-opa-bundle.yaml
+++ b/openbank-infra/gitops/components/mcp/mcp-opa-bundle.yaml
@@ -9,7 +9,7 @@ metadata:
     app.kubernetes.io/name: mcp-service
     app.kubernetes.io/part-of: platform
   annotations:
-    openbank.tech/policy-checksum: "2c3dc4da36574695"
+    openbank.tech/policy-checksum: "8b78206fe6504344"
 data:
   rest.rego: |
     # SPDX-License-Identifier: Apache-2.0
@@ -1675,10 +1675,17 @@ data:
         # or be explicitly allowlisted below with a one-line reason (a REST call made through a
         # shared/generic client this heuristic's exact-match can't see, or a genuinely-stale edge
         # already tracked for cleanup elsewhere).
-        detect: ["any <service>/governance.yaml lineage.downstream edge"]
+        # BOTH directions since #2315. An `upstream` edge on S naming T is a claim about T's code, so
+        # it is verified in T — exactly as if T had declared the mirrored downstream edge. Treating
+        # "someone else's code" as out of scope meant 63 upstream edges across 23 services were opened
+        # by nothing, and a service declaring ONLY upstream was skipped outright; aml-service had 3 of
+        # its 6 upstream edges wrong (#2312). Both directions normalize to one <source>-><target>
+        # key, so a relationship declared from both ends is one check and one allowlist entry.
+        detect: ["any <service>/governance.yaml lineage.downstream or lineage.upstream edge"]
         require:
           - "api edge has a matching @RegisterRestClient(configKey) in the same service, or an allowlist entry with a reason"
           - "topic edge has an actual topic overlap with the target service (per mechanism 1's producer/consumer map), or an allowlist entry with a reason"
+          - "an edge naming no in-tree service directory (github, prometheus, temporal) is reported as its own class, never counted as code drift"
         gate: lineage-code-audit
         enforced: advisory
         target_enforce_date: "2026-10-15"   # ADR-0144 — later than mechanism 1's date: first scan found a much higher (34/48) violation rate, expect a longer triage
@@ -1695,7 +1702,11 @@ data:
           checker itself (fixed), 19 are stale governance.yaml edges (corrected/removed), 6 below are
           real dependencies the heuristic's exact-match can't see, and 4 are genuine gaps tracked as
           their own issues, not fixed here. A follow-up scan found 7 more edges outside the original
-          34 (the *->admin-ui reversed-direction shape) — not yet triaged."
+          34 (the *->admin-ui reversed-direction shape) — not yet triaged. #2315 then added the
+          upstream direction: the first upstream scan surfaced 24 further unbacked edges (26 total
+          unallowlisted, of which 2 are the pre-existing downstream findings) plus 10 edges naming an
+          external system — all untriaged, which is why target_enforce_date is unchanged and this
+          stays advisory."
         ci_producer: ".github/scripts/check-governance-lineage.py"
         allowlist:
           - edge: "openbank-copilot-service->balance-service:api"

--- a/openbank-infra/gitops/components/mcp/mcp-service.yaml
+++ b/openbank-infra/gitops/components/mcp/mcp-service.yaml
@@ -29,7 +29,7 @@ spec:
       annotations:
         # Rolls the pod when the OPA bundle changes — subPath mounts do NOT hot-reload.
         # Kept in sync by gen-mcp-opa-bundle.sh (do not hand-edit).
-        openbank.tech/policy-checksum: "2c3dc4da36574695"
+        openbank.tech/policy-checksum: "8b78206fe6504344"
     spec:
       securityContext:
         runAsNonRoot: true

--- a/openbank-infra/gitops/components/notifications/notification-service-opa-bundle.yaml
+++ b/openbank-infra/gitops/components/notifications/notification-service-opa-bundle.yaml
@@ -10,7 +10,7 @@ metadata:
     app.kubernetes.io/name: notification-service
     app.kubernetes.io/part-of: notifications
   annotations:
-    openbank.tech/policy-checksum: "2592909d9461fccf"
+    openbank.tech/policy-checksum: "1eec4da21ded4c3f"
 data:
   rest.rego: |
     # SPDX-License-Identifier: Apache-2.0
@@ -898,10 +898,17 @@ data:
         # or be explicitly allowlisted below with a one-line reason (a REST call made through a
         # shared/generic client this heuristic's exact-match can't see, or a genuinely-stale edge
         # already tracked for cleanup elsewhere).
-        detect: ["any <service>/governance.yaml lineage.downstream edge"]
+        # BOTH directions since #2315. An `upstream` edge on S naming T is a claim about T's code, so
+        # it is verified in T — exactly as if T had declared the mirrored downstream edge. Treating
+        # "someone else's code" as out of scope meant 63 upstream edges across 23 services were opened
+        # by nothing, and a service declaring ONLY upstream was skipped outright; aml-service had 3 of
+        # its 6 upstream edges wrong (#2312). Both directions normalize to one <source>-><target>
+        # key, so a relationship declared from both ends is one check and one allowlist entry.
+        detect: ["any <service>/governance.yaml lineage.downstream or lineage.upstream edge"]
         require:
           - "api edge has a matching @RegisterRestClient(configKey) in the same service, or an allowlist entry with a reason"
           - "topic edge has an actual topic overlap with the target service (per mechanism 1's producer/consumer map), or an allowlist entry with a reason"
+          - "an edge naming no in-tree service directory (github, prometheus, temporal) is reported as its own class, never counted as code drift"
         gate: lineage-code-audit
         enforced: advisory
         target_enforce_date: "2026-10-15"   # ADR-0144 — later than mechanism 1's date: first scan found a much higher (34/48) violation rate, expect a longer triage
@@ -918,7 +925,11 @@ data:
           checker itself (fixed), 19 are stale governance.yaml edges (corrected/removed), 6 below are
           real dependencies the heuristic's exact-match can't see, and 4 are genuine gaps tracked as
           their own issues, not fixed here. A follow-up scan found 7 more edges outside the original
-          34 (the *->admin-ui reversed-direction shape) — not yet triaged."
+          34 (the *->admin-ui reversed-direction shape) — not yet triaged. #2315 then added the
+          upstream direction: the first upstream scan surfaced 24 further unbacked edges (26 total
+          unallowlisted, of which 2 are the pre-existing downstream findings) plus 10 edges naming an
+          external system — all untriaged, which is why target_enforce_date is unchanged and this
+          stays advisory."
         ci_producer: ".github/scripts/check-governance-lineage.py"
         allowlist:
           - edge: "openbank-copilot-service->balance-service:api"

--- a/openbank-infra/gitops/components/notifications/notification-service.yaml
+++ b/openbank-infra/gitops/components/notifications/notification-service.yaml
@@ -39,7 +39,7 @@ spec:
       annotations:
         # Rolls the Deployment when the OPA policy bundle changes (subPath mounts don't
         # hot-reload). Kept in sync by gen-notification-opa-bundle.sh.
-        openbank.tech/policy-checksum: "2592909d9461fccf"
+        openbank.tech/policy-checksum: "1eec4da21ded4c3f"
       labels:
         app.kubernetes.io/name: notification-service
         app.kubernetes.io/part-of: notifications

--- a/openbank-infra/gitops/components/party/party-opa-bundle.yaml
+++ b/openbank-infra/gitops/components/party/party-opa-bundle.yaml
@@ -9,7 +9,7 @@ metadata:
     app.kubernetes.io/name: party-service
     app.kubernetes.io/part-of: party
   annotations:
-    openbank.tech/policy-checksum: "d9b02679c725aad6"
+    openbank.tech/policy-checksum: "7062c95df4b167e9"
 data:
   rest.rego: |
     # SPDX-License-Identifier: Apache-2.0
@@ -1746,10 +1746,17 @@ data:
         # or be explicitly allowlisted below with a one-line reason (a REST call made through a
         # shared/generic client this heuristic's exact-match can't see, or a genuinely-stale edge
         # already tracked for cleanup elsewhere).
-        detect: ["any <service>/governance.yaml lineage.downstream edge"]
+        # BOTH directions since #2315. An `upstream` edge on S naming T is a claim about T's code, so
+        # it is verified in T — exactly as if T had declared the mirrored downstream edge. Treating
+        # "someone else's code" as out of scope meant 63 upstream edges across 23 services were opened
+        # by nothing, and a service declaring ONLY upstream was skipped outright; aml-service had 3 of
+        # its 6 upstream edges wrong (#2312). Both directions normalize to one <source>-><target>
+        # key, so a relationship declared from both ends is one check and one allowlist entry.
+        detect: ["any <service>/governance.yaml lineage.downstream or lineage.upstream edge"]
         require:
           - "api edge has a matching @RegisterRestClient(configKey) in the same service, or an allowlist entry with a reason"
           - "topic edge has an actual topic overlap with the target service (per mechanism 1's producer/consumer map), or an allowlist entry with a reason"
+          - "an edge naming no in-tree service directory (github, prometheus, temporal) is reported as its own class, never counted as code drift"
         gate: lineage-code-audit
         enforced: advisory
         target_enforce_date: "2026-10-15"   # ADR-0144 — later than mechanism 1's date: first scan found a much higher (34/48) violation rate, expect a longer triage
@@ -1766,7 +1773,11 @@ data:
           checker itself (fixed), 19 are stale governance.yaml edges (corrected/removed), 6 below are
           real dependencies the heuristic's exact-match can't see, and 4 are genuine gaps tracked as
           their own issues, not fixed here. A follow-up scan found 7 more edges outside the original
-          34 (the *->admin-ui reversed-direction shape) — not yet triaged."
+          34 (the *->admin-ui reversed-direction shape) — not yet triaged. #2315 then added the
+          upstream direction: the first upstream scan surfaced 24 further unbacked edges (26 total
+          unallowlisted, of which 2 are the pre-existing downstream findings) plus 10 edges naming an
+          external system — all untriaged, which is why target_enforce_date is unchanged and this
+          stays advisory."
         ci_producer: ".github/scripts/check-governance-lineage.py"
         allowlist:
           - edge: "openbank-copilot-service->balance-service:api"

--- a/openbank-infra/gitops/components/party/party-service.yaml
+++ b/openbank-infra/gitops/components/party/party-service.yaml
@@ -22,7 +22,7 @@ spec:
       annotations:
         # Rolls the pod when the OPA bundle changes — subPath mounts do NOT hot-reload.
         # Kept in sync by gen-party-opa-bundle.sh (do not hand-edit).
-        openbank.tech/policy-checksum: "d9b02679c725aad6"
+        openbank.tech/policy-checksum: "7062c95df4b167e9"
       labels:
         app.kubernetes.io/name: party-service
         app.kubernetes.io/part-of: party

--- a/openbank-infra/gitops/components/payments/card-issuance-opa-bundle.yaml
+++ b/openbank-infra/gitops/components/payments/card-issuance-opa-bundle.yaml
@@ -9,7 +9,7 @@ metadata:
     app.kubernetes.io/name: card-issuance-service
     app.kubernetes.io/part-of: payments
   annotations:
-    openbank.tech/policy-checksum: "04a0c84bd0298552"
+    openbank.tech/policy-checksum: "92715e4d220aed7d"
 data:
   rest.rego: |
     # SPDX-License-Identifier: Apache-2.0
@@ -1730,10 +1730,17 @@ data:
         # or be explicitly allowlisted below with a one-line reason (a REST call made through a
         # shared/generic client this heuristic's exact-match can't see, or a genuinely-stale edge
         # already tracked for cleanup elsewhere).
-        detect: ["any <service>/governance.yaml lineage.downstream edge"]
+        # BOTH directions since #2315. An `upstream` edge on S naming T is a claim about T's code, so
+        # it is verified in T — exactly as if T had declared the mirrored downstream edge. Treating
+        # "someone else's code" as out of scope meant 63 upstream edges across 23 services were opened
+        # by nothing, and a service declaring ONLY upstream was skipped outright; aml-service had 3 of
+        # its 6 upstream edges wrong (#2312). Both directions normalize to one <source>-><target>
+        # key, so a relationship declared from both ends is one check and one allowlist entry.
+        detect: ["any <service>/governance.yaml lineage.downstream or lineage.upstream edge"]
         require:
           - "api edge has a matching @RegisterRestClient(configKey) in the same service, or an allowlist entry with a reason"
           - "topic edge has an actual topic overlap with the target service (per mechanism 1's producer/consumer map), or an allowlist entry with a reason"
+          - "an edge naming no in-tree service directory (github, prometheus, temporal) is reported as its own class, never counted as code drift"
         gate: lineage-code-audit
         enforced: advisory
         target_enforce_date: "2026-10-15"   # ADR-0144 — later than mechanism 1's date: first scan found a much higher (34/48) violation rate, expect a longer triage
@@ -1750,7 +1757,11 @@ data:
           checker itself (fixed), 19 are stale governance.yaml edges (corrected/removed), 6 below are
           real dependencies the heuristic's exact-match can't see, and 4 are genuine gaps tracked as
           their own issues, not fixed here. A follow-up scan found 7 more edges outside the original
-          34 (the *->admin-ui reversed-direction shape) — not yet triaged."
+          34 (the *->admin-ui reversed-direction shape) — not yet triaged. #2315 then added the
+          upstream direction: the first upstream scan surfaced 24 further unbacked edges (26 total
+          unallowlisted, of which 2 are the pre-existing downstream findings) plus 10 edges naming an
+          external system — all untriaged, which is why target_enforce_date is unchanged and this
+          stays advisory."
         ci_producer: ".github/scripts/check-governance-lineage.py"
         allowlist:
           - edge: "openbank-copilot-service->balance-service:api"

--- a/openbank-infra/gitops/components/payments/clearing-opa-bundle.yaml
+++ b/openbank-infra/gitops/components/payments/clearing-opa-bundle.yaml
@@ -9,7 +9,7 @@ metadata:
     app.kubernetes.io/name: clearing-service
     app.kubernetes.io/part-of: payments
   annotations:
-    openbank.tech/policy-checksum: "aafa5bc2c2821401"
+    openbank.tech/policy-checksum: "19e4675f26654399"
 data:
   rest.rego: |
     # SPDX-License-Identifier: Apache-2.0
@@ -1767,10 +1767,17 @@ data:
         # or be explicitly allowlisted below with a one-line reason (a REST call made through a
         # shared/generic client this heuristic's exact-match can't see, or a genuinely-stale edge
         # already tracked for cleanup elsewhere).
-        detect: ["any <service>/governance.yaml lineage.downstream edge"]
+        # BOTH directions since #2315. An `upstream` edge on S naming T is a claim about T's code, so
+        # it is verified in T — exactly as if T had declared the mirrored downstream edge. Treating
+        # "someone else's code" as out of scope meant 63 upstream edges across 23 services were opened
+        # by nothing, and a service declaring ONLY upstream was skipped outright; aml-service had 3 of
+        # its 6 upstream edges wrong (#2312). Both directions normalize to one <source>-><target>
+        # key, so a relationship declared from both ends is one check and one allowlist entry.
+        detect: ["any <service>/governance.yaml lineage.downstream or lineage.upstream edge"]
         require:
           - "api edge has a matching @RegisterRestClient(configKey) in the same service, or an allowlist entry with a reason"
           - "topic edge has an actual topic overlap with the target service (per mechanism 1's producer/consumer map), or an allowlist entry with a reason"
+          - "an edge naming no in-tree service directory (github, prometheus, temporal) is reported as its own class, never counted as code drift"
         gate: lineage-code-audit
         enforced: advisory
         target_enforce_date: "2026-10-15"   # ADR-0144 — later than mechanism 1's date: first scan found a much higher (34/48) violation rate, expect a longer triage
@@ -1787,7 +1794,11 @@ data:
           checker itself (fixed), 19 are stale governance.yaml edges (corrected/removed), 6 below are
           real dependencies the heuristic's exact-match can't see, and 4 are genuine gaps tracked as
           their own issues, not fixed here. A follow-up scan found 7 more edges outside the original
-          34 (the *->admin-ui reversed-direction shape) — not yet triaged."
+          34 (the *->admin-ui reversed-direction shape) — not yet triaged. #2315 then added the
+          upstream direction: the first upstream scan surfaced 24 further unbacked edges (26 total
+          unallowlisted, of which 2 are the pre-existing downstream findings) plus 10 edges naming an
+          external system — all untriaged, which is why target_enforce_date is unchanged and this
+          stays advisory."
         ci_producer: ".github/scripts/check-governance-lineage.py"
         allowlist:
           - edge: "openbank-copilot-service->balance-service:api"

--- a/openbank-infra/gitops/components/payments/domestic-payment-opa-bundle.yaml
+++ b/openbank-infra/gitops/components/payments/domestic-payment-opa-bundle.yaml
@@ -9,7 +9,7 @@ metadata:
     app.kubernetes.io/name: domestic-payment
     app.kubernetes.io/part-of: payments
   annotations:
-    openbank.tech/policy-checksum: "223200b2c8fffe63"
+    openbank.tech/policy-checksum: "cf3be18dfdd8794c"
 data:
   rest.rego: |
     # SPDX-License-Identifier: Apache-2.0
@@ -1752,10 +1752,17 @@ data:
         # or be explicitly allowlisted below with a one-line reason (a REST call made through a
         # shared/generic client this heuristic's exact-match can't see, or a genuinely-stale edge
         # already tracked for cleanup elsewhere).
-        detect: ["any <service>/governance.yaml lineage.downstream edge"]
+        # BOTH directions since #2315. An `upstream` edge on S naming T is a claim about T's code, so
+        # it is verified in T — exactly as if T had declared the mirrored downstream edge. Treating
+        # "someone else's code" as out of scope meant 63 upstream edges across 23 services were opened
+        # by nothing, and a service declaring ONLY upstream was skipped outright; aml-service had 3 of
+        # its 6 upstream edges wrong (#2312). Both directions normalize to one <source>-><target>
+        # key, so a relationship declared from both ends is one check and one allowlist entry.
+        detect: ["any <service>/governance.yaml lineage.downstream or lineage.upstream edge"]
         require:
           - "api edge has a matching @RegisterRestClient(configKey) in the same service, or an allowlist entry with a reason"
           - "topic edge has an actual topic overlap with the target service (per mechanism 1's producer/consumer map), or an allowlist entry with a reason"
+          - "an edge naming no in-tree service directory (github, prometheus, temporal) is reported as its own class, never counted as code drift"
         gate: lineage-code-audit
         enforced: advisory
         target_enforce_date: "2026-10-15"   # ADR-0144 — later than mechanism 1's date: first scan found a much higher (34/48) violation rate, expect a longer triage
@@ -1772,7 +1779,11 @@ data:
           checker itself (fixed), 19 are stale governance.yaml edges (corrected/removed), 6 below are
           real dependencies the heuristic's exact-match can't see, and 4 are genuine gaps tracked as
           their own issues, not fixed here. A follow-up scan found 7 more edges outside the original
-          34 (the *->admin-ui reversed-direction shape) — not yet triaged."
+          34 (the *->admin-ui reversed-direction shape) — not yet triaged. #2315 then added the
+          upstream direction: the first upstream scan surfaced 24 further unbacked edges (26 total
+          unallowlisted, of which 2 are the pre-existing downstream findings) plus 10 edges naming an
+          external system — all untriaged, which is why target_enforce_date is unchanged and this
+          stays advisory."
         ci_producer: ".github/scripts/check-governance-lineage.py"
         allowlist:
           - edge: "openbank-copilot-service->balance-service:api"

--- a/openbank-infra/gitops/components/payments/payments-services.yaml
+++ b/openbank-infra/gitops/components/payments/payments-services.yaml
@@ -42,7 +42,7 @@ spec:
         # Rolls the pods when the OPA bundle changes — subPath mounts do NOT hot-reload.
         # Kept in sync by gen-transaction-opa-bundle.sh via the trailing marker comment
         # (do not hand-edit, do not drop the marker).
-        openbank.tech/policy-checksum: "3d17e362ec88ffbb" # transaction-opa-bundle
+        openbank.tech/policy-checksum: "6b6ecf7508f4464a" # transaction-opa-bundle
     spec:
       securityContext:
         runAsNonRoot: true
@@ -375,7 +375,7 @@ spec:
       annotations:
         # Rolls the pods when the OPA bundle changes — subPath mounts do NOT hot-reload.
         # Kept in sync by gen-sepa-payment-opa-bundle.sh (do not hand-edit).
-        openbank.tech/policy-checksum: "be9f59fe0f92e046"
+        openbank.tech/policy-checksum: "b251bdf4b9ada0af"
     spec:
       securityContext:
         runAsNonRoot: true
@@ -729,7 +729,7 @@ spec:
         # Rolls the pods when the OPA bundle changes — subPath mounts do NOT hot-reload.
         # Kept in sync by gen-domestic-payment-opa-bundle.sh via the trailing marker
         # comment (do not hand-edit, do not drop the marker).
-        openbank.tech/policy-checksum: "223200b2c8fffe63" # domestic-payment-opa-bundle
+        openbank.tech/policy-checksum: "cf3be18dfdd8794c" # domestic-payment-opa-bundle
     spec:
       securityContext:
         runAsNonRoot: true
@@ -1053,7 +1053,7 @@ spec:
       annotations:
         # Rolls the pods when the OPA bundle changes — subPath mounts do NOT hot-reload.
         # Kept in sync by gen-sepa-instant-opa-bundle.sh (do not hand-edit).
-        openbank.tech/policy-checksum: "a628472b54b845c6"
+        openbank.tech/policy-checksum: "2b30585df0f5a3ca"
     spec:
       securityContext:
         runAsNonRoot: true
@@ -1369,7 +1369,7 @@ spec:
         # Rolls the pods when the OPA bundle changes — subPath mounts do NOT hot-reload.
         # Kept in sync by gen-clearing-opa-bundle.sh via the trailing marker comment
         # (do not hand-edit, do not drop the marker).
-        openbank.tech/policy-checksum: "aafa5bc2c2821401" # clearing-opa-bundle
+        openbank.tech/policy-checksum: "19e4675f26654399" # clearing-opa-bundle
     spec:
       securityContext:
         runAsNonRoot: true
@@ -1658,7 +1658,7 @@ spec:
       annotations:
         # Rolls the pod when the OPA bundle changes (ADR-0034). Value is stamped by
         # gen-standing-order-opa-bundle.sh — do not hand-edit.
-        openbank.tech/policy-checksum: "71349354f2e3d1ea" # standing-order-opa-bundle
+        openbank.tech/policy-checksum: "9a194b7ed93386ce" # standing-order-opa-bundle
     spec:
       securityContext:
         runAsNonRoot: true
@@ -1911,7 +1911,7 @@ spec:
       annotations:
         # Rolls the pods when the OPA bundle changes — subPath mounts do NOT hot-reload.
         # Kept in sync by gen-card-issuance-opa-bundle.sh (do not hand-edit).
-        openbank.tech/policy-checksum: "04a0c84bd0298552"
+        openbank.tech/policy-checksum: "92715e4d220aed7d"
     spec:
       securityContext:
         runAsNonRoot: true
@@ -2178,7 +2178,7 @@ spec:
         # Rolls the pods when the OPA bundle changes — subPath mounts do NOT hot-reload.
         # Kept in sync by gen-settlement-opa-bundle.sh via the trailing marker comment
         # (do not hand-edit, do not drop the marker).
-        openbank.tech/policy-checksum: "0574cf706c843626" # settlement-opa-bundle
+        openbank.tech/policy-checksum: "d63905a267497244" # settlement-opa-bundle
     spec:
       securityContext:
         runAsNonRoot: true
@@ -2579,7 +2579,7 @@ spec:
       annotations:
         # Rolls the pods when the OPA bundle changes — subPath mounts do NOT hot-reload.
         # Kept in sync by gen-swift-opa-bundle.sh (do not hand-edit).
-        openbank.tech/policy-checksum: "ad1e0a0cb030bff7"
+        openbank.tech/policy-checksum: "1d5682af74ac8ac7"
     spec:
       securityContext:
         runAsNonRoot: true
@@ -2893,7 +2893,7 @@ spec:
       annotations:
         # Rolls the pods when the OPA bundle changes — subPath mounts do NOT hot-reload.
         # Kept in sync by gen-vop-opa-bundle.sh (do not hand-edit).
-        openbank.tech/policy-checksum: "4e18fa5e701fa176"
+        openbank.tech/policy-checksum: "1ac01676b031c75f"
     spec:
       securityContext:
         runAsNonRoot: true

--- a/openbank-infra/gitops/components/payments/sepa-instant-opa-bundle.yaml
+++ b/openbank-infra/gitops/components/payments/sepa-instant-opa-bundle.yaml
@@ -9,7 +9,7 @@ metadata:
     app.kubernetes.io/name: sepa-instant
     app.kubernetes.io/part-of: payments
   annotations:
-    openbank.tech/policy-checksum: "a628472b54b845c6"
+    openbank.tech/policy-checksum: "2b30585df0f5a3ca"
 data:
   rest.rego: |
     # SPDX-License-Identifier: Apache-2.0
@@ -1725,10 +1725,17 @@ data:
         # or be explicitly allowlisted below with a one-line reason (a REST call made through a
         # shared/generic client this heuristic's exact-match can't see, or a genuinely-stale edge
         # already tracked for cleanup elsewhere).
-        detect: ["any <service>/governance.yaml lineage.downstream edge"]
+        # BOTH directions since #2315. An `upstream` edge on S naming T is a claim about T's code, so
+        # it is verified in T — exactly as if T had declared the mirrored downstream edge. Treating
+        # "someone else's code" as out of scope meant 63 upstream edges across 23 services were opened
+        # by nothing, and a service declaring ONLY upstream was skipped outright; aml-service had 3 of
+        # its 6 upstream edges wrong (#2312). Both directions normalize to one <source>-><target>
+        # key, so a relationship declared from both ends is one check and one allowlist entry.
+        detect: ["any <service>/governance.yaml lineage.downstream or lineage.upstream edge"]
         require:
           - "api edge has a matching @RegisterRestClient(configKey) in the same service, or an allowlist entry with a reason"
           - "topic edge has an actual topic overlap with the target service (per mechanism 1's producer/consumer map), or an allowlist entry with a reason"
+          - "an edge naming no in-tree service directory (github, prometheus, temporal) is reported as its own class, never counted as code drift"
         gate: lineage-code-audit
         enforced: advisory
         target_enforce_date: "2026-10-15"   # ADR-0144 — later than mechanism 1's date: first scan found a much higher (34/48) violation rate, expect a longer triage
@@ -1745,7 +1752,11 @@ data:
           checker itself (fixed), 19 are stale governance.yaml edges (corrected/removed), 6 below are
           real dependencies the heuristic's exact-match can't see, and 4 are genuine gaps tracked as
           their own issues, not fixed here. A follow-up scan found 7 more edges outside the original
-          34 (the *->admin-ui reversed-direction shape) — not yet triaged."
+          34 (the *->admin-ui reversed-direction shape) — not yet triaged. #2315 then added the
+          upstream direction: the first upstream scan surfaced 24 further unbacked edges (26 total
+          unallowlisted, of which 2 are the pre-existing downstream findings) plus 10 edges naming an
+          external system — all untriaged, which is why target_enforce_date is unchanged and this
+          stays advisory."
         ci_producer: ".github/scripts/check-governance-lineage.py"
         allowlist:
           - edge: "openbank-copilot-service->balance-service:api"

--- a/openbank-infra/gitops/components/payments/sepa-payment-opa-bundle.yaml
+++ b/openbank-infra/gitops/components/payments/sepa-payment-opa-bundle.yaml
@@ -9,7 +9,7 @@ metadata:
     app.kubernetes.io/name: sepa-payment
     app.kubernetes.io/part-of: payments
   annotations:
-    openbank.tech/policy-checksum: "be9f59fe0f92e046"
+    openbank.tech/policy-checksum: "b251bdf4b9ada0af"
 data:
   rest.rego: |
     # SPDX-License-Identifier: Apache-2.0
@@ -1746,10 +1746,17 @@ data:
         # or be explicitly allowlisted below with a one-line reason (a REST call made through a
         # shared/generic client this heuristic's exact-match can't see, or a genuinely-stale edge
         # already tracked for cleanup elsewhere).
-        detect: ["any <service>/governance.yaml lineage.downstream edge"]
+        # BOTH directions since #2315. An `upstream` edge on S naming T is a claim about T's code, so
+        # it is verified in T — exactly as if T had declared the mirrored downstream edge. Treating
+        # "someone else's code" as out of scope meant 63 upstream edges across 23 services were opened
+        # by nothing, and a service declaring ONLY upstream was skipped outright; aml-service had 3 of
+        # its 6 upstream edges wrong (#2312). Both directions normalize to one <source>-><target>
+        # key, so a relationship declared from both ends is one check and one allowlist entry.
+        detect: ["any <service>/governance.yaml lineage.downstream or lineage.upstream edge"]
         require:
           - "api edge has a matching @RegisterRestClient(configKey) in the same service, or an allowlist entry with a reason"
           - "topic edge has an actual topic overlap with the target service (per mechanism 1's producer/consumer map), or an allowlist entry with a reason"
+          - "an edge naming no in-tree service directory (github, prometheus, temporal) is reported as its own class, never counted as code drift"
         gate: lineage-code-audit
         enforced: advisory
         target_enforce_date: "2026-10-15"   # ADR-0144 — later than mechanism 1's date: first scan found a much higher (34/48) violation rate, expect a longer triage
@@ -1766,7 +1773,11 @@ data:
           checker itself (fixed), 19 are stale governance.yaml edges (corrected/removed), 6 below are
           real dependencies the heuristic's exact-match can't see, and 4 are genuine gaps tracked as
           their own issues, not fixed here. A follow-up scan found 7 more edges outside the original
-          34 (the *->admin-ui reversed-direction shape) — not yet triaged."
+          34 (the *->admin-ui reversed-direction shape) — not yet triaged. #2315 then added the
+          upstream direction: the first upstream scan surfaced 24 further unbacked edges (26 total
+          unallowlisted, of which 2 are the pre-existing downstream findings) plus 10 edges naming an
+          external system — all untriaged, which is why target_enforce_date is unchanged and this
+          stays advisory."
         ci_producer: ".github/scripts/check-governance-lineage.py"
         allowlist:
           - edge: "openbank-copilot-service->balance-service:api"

--- a/openbank-infra/gitops/components/payments/settlement-opa-bundle.yaml
+++ b/openbank-infra/gitops/components/payments/settlement-opa-bundle.yaml
@@ -9,7 +9,7 @@ metadata:
     app.kubernetes.io/name: settlement-service
     app.kubernetes.io/part-of: payments
   annotations:
-    openbank.tech/policy-checksum: "0574cf706c843626"
+    openbank.tech/policy-checksum: "d63905a267497244"
 data:
   rest.rego: |
     # SPDX-License-Identifier: Apache-2.0
@@ -1726,10 +1726,17 @@ data:
         # or be explicitly allowlisted below with a one-line reason (a REST call made through a
         # shared/generic client this heuristic's exact-match can't see, or a genuinely-stale edge
         # already tracked for cleanup elsewhere).
-        detect: ["any <service>/governance.yaml lineage.downstream edge"]
+        # BOTH directions since #2315. An `upstream` edge on S naming T is a claim about T's code, so
+        # it is verified in T — exactly as if T had declared the mirrored downstream edge. Treating
+        # "someone else's code" as out of scope meant 63 upstream edges across 23 services were opened
+        # by nothing, and a service declaring ONLY upstream was skipped outright; aml-service had 3 of
+        # its 6 upstream edges wrong (#2312). Both directions normalize to one <source>-><target>
+        # key, so a relationship declared from both ends is one check and one allowlist entry.
+        detect: ["any <service>/governance.yaml lineage.downstream or lineage.upstream edge"]
         require:
           - "api edge has a matching @RegisterRestClient(configKey) in the same service, or an allowlist entry with a reason"
           - "topic edge has an actual topic overlap with the target service (per mechanism 1's producer/consumer map), or an allowlist entry with a reason"
+          - "an edge naming no in-tree service directory (github, prometheus, temporal) is reported as its own class, never counted as code drift"
         gate: lineage-code-audit
         enforced: advisory
         target_enforce_date: "2026-10-15"   # ADR-0144 — later than mechanism 1's date: first scan found a much higher (34/48) violation rate, expect a longer triage
@@ -1746,7 +1753,11 @@ data:
           checker itself (fixed), 19 are stale governance.yaml edges (corrected/removed), 6 below are
           real dependencies the heuristic's exact-match can't see, and 4 are genuine gaps tracked as
           their own issues, not fixed here. A follow-up scan found 7 more edges outside the original
-          34 (the *->admin-ui reversed-direction shape) — not yet triaged."
+          34 (the *->admin-ui reversed-direction shape) — not yet triaged. #2315 then added the
+          upstream direction: the first upstream scan surfaced 24 further unbacked edges (26 total
+          unallowlisted, of which 2 are the pre-existing downstream findings) plus 10 edges naming an
+          external system — all untriaged, which is why target_enforce_date is unchanged and this
+          stays advisory."
         ci_producer: ".github/scripts/check-governance-lineage.py"
         allowlist:
           - edge: "openbank-copilot-service->balance-service:api"

--- a/openbank-infra/gitops/components/payments/standing-order-opa-bundle.yaml
+++ b/openbank-infra/gitops/components/payments/standing-order-opa-bundle.yaml
@@ -9,7 +9,7 @@ metadata:
     app.kubernetes.io/name: standing-order-service
     app.kubernetes.io/part-of: payments
   annotations:
-    openbank.tech/policy-checksum: "71349354f2e3d1ea"
+    openbank.tech/policy-checksum: "9a194b7ed93386ce"
 data:
   rest.rego: |
     # SPDX-License-Identifier: Apache-2.0
@@ -1711,10 +1711,17 @@ data:
         # or be explicitly allowlisted below with a one-line reason (a REST call made through a
         # shared/generic client this heuristic's exact-match can't see, or a genuinely-stale edge
         # already tracked for cleanup elsewhere).
-        detect: ["any <service>/governance.yaml lineage.downstream edge"]
+        # BOTH directions since #2315. An `upstream` edge on S naming T is a claim about T's code, so
+        # it is verified in T — exactly as if T had declared the mirrored downstream edge. Treating
+        # "someone else's code" as out of scope meant 63 upstream edges across 23 services were opened
+        # by nothing, and a service declaring ONLY upstream was skipped outright; aml-service had 3 of
+        # its 6 upstream edges wrong (#2312). Both directions normalize to one <source>-><target>
+        # key, so a relationship declared from both ends is one check and one allowlist entry.
+        detect: ["any <service>/governance.yaml lineage.downstream or lineage.upstream edge"]
         require:
           - "api edge has a matching @RegisterRestClient(configKey) in the same service, or an allowlist entry with a reason"
           - "topic edge has an actual topic overlap with the target service (per mechanism 1's producer/consumer map), or an allowlist entry with a reason"
+          - "an edge naming no in-tree service directory (github, prometheus, temporal) is reported as its own class, never counted as code drift"
         gate: lineage-code-audit
         enforced: advisory
         target_enforce_date: "2026-10-15"   # ADR-0144 — later than mechanism 1's date: first scan found a much higher (34/48) violation rate, expect a longer triage
@@ -1731,7 +1738,11 @@ data:
           checker itself (fixed), 19 are stale governance.yaml edges (corrected/removed), 6 below are
           real dependencies the heuristic's exact-match can't see, and 4 are genuine gaps tracked as
           their own issues, not fixed here. A follow-up scan found 7 more edges outside the original
-          34 (the *->admin-ui reversed-direction shape) — not yet triaged."
+          34 (the *->admin-ui reversed-direction shape) — not yet triaged. #2315 then added the
+          upstream direction: the first upstream scan surfaced 24 further unbacked edges (26 total
+          unallowlisted, of which 2 are the pre-existing downstream findings) plus 10 edges naming an
+          external system — all untriaged, which is why target_enforce_date is unchanged and this
+          stays advisory."
         ci_producer: ".github/scripts/check-governance-lineage.py"
         allowlist:
           - edge: "openbank-copilot-service->balance-service:api"

--- a/openbank-infra/gitops/components/payments/swift-opa-bundle.yaml
+++ b/openbank-infra/gitops/components/payments/swift-opa-bundle.yaml
@@ -9,7 +9,7 @@ metadata:
     app.kubernetes.io/name: swift-service
     app.kubernetes.io/part-of: payments
   annotations:
-    openbank.tech/policy-checksum: "ad1e0a0cb030bff7"
+    openbank.tech/policy-checksum: "1d5682af74ac8ac7"
 data:
   rest.rego: |
     # SPDX-License-Identifier: Apache-2.0
@@ -1729,10 +1729,17 @@ data:
         # or be explicitly allowlisted below with a one-line reason (a REST call made through a
         # shared/generic client this heuristic's exact-match can't see, or a genuinely-stale edge
         # already tracked for cleanup elsewhere).
-        detect: ["any <service>/governance.yaml lineage.downstream edge"]
+        # BOTH directions since #2315. An `upstream` edge on S naming T is a claim about T's code, so
+        # it is verified in T — exactly as if T had declared the mirrored downstream edge. Treating
+        # "someone else's code" as out of scope meant 63 upstream edges across 23 services were opened
+        # by nothing, and a service declaring ONLY upstream was skipped outright; aml-service had 3 of
+        # its 6 upstream edges wrong (#2312). Both directions normalize to one <source>-><target>
+        # key, so a relationship declared from both ends is one check and one allowlist entry.
+        detect: ["any <service>/governance.yaml lineage.downstream or lineage.upstream edge"]
         require:
           - "api edge has a matching @RegisterRestClient(configKey) in the same service, or an allowlist entry with a reason"
           - "topic edge has an actual topic overlap with the target service (per mechanism 1's producer/consumer map), or an allowlist entry with a reason"
+          - "an edge naming no in-tree service directory (github, prometheus, temporal) is reported as its own class, never counted as code drift"
         gate: lineage-code-audit
         enforced: advisory
         target_enforce_date: "2026-10-15"   # ADR-0144 — later than mechanism 1's date: first scan found a much higher (34/48) violation rate, expect a longer triage
@@ -1749,7 +1756,11 @@ data:
           checker itself (fixed), 19 are stale governance.yaml edges (corrected/removed), 6 below are
           real dependencies the heuristic's exact-match can't see, and 4 are genuine gaps tracked as
           their own issues, not fixed here. A follow-up scan found 7 more edges outside the original
-          34 (the *->admin-ui reversed-direction shape) — not yet triaged."
+          34 (the *->admin-ui reversed-direction shape) — not yet triaged. #2315 then added the
+          upstream direction: the first upstream scan surfaced 24 further unbacked edges (26 total
+          unallowlisted, of which 2 are the pre-existing downstream findings) plus 10 edges naming an
+          external system — all untriaged, which is why target_enforce_date is unchanged and this
+          stays advisory."
         ci_producer: ".github/scripts/check-governance-lineage.py"
         allowlist:
           - edge: "openbank-copilot-service->balance-service:api"

--- a/openbank-infra/gitops/components/payments/transaction-opa-bundle.yaml
+++ b/openbank-infra/gitops/components/payments/transaction-opa-bundle.yaml
@@ -9,7 +9,7 @@ metadata:
     app.kubernetes.io/name: transaction-service
     app.kubernetes.io/part-of: payments
   annotations:
-    openbank.tech/policy-checksum: "3d17e362ec88ffbb"
+    openbank.tech/policy-checksum: "6b6ecf7508f4464a"
 data:
   rest.rego: |
     # SPDX-License-Identifier: Apache-2.0
@@ -1782,10 +1782,17 @@ data:
         # or be explicitly allowlisted below with a one-line reason (a REST call made through a
         # shared/generic client this heuristic's exact-match can't see, or a genuinely-stale edge
         # already tracked for cleanup elsewhere).
-        detect: ["any <service>/governance.yaml lineage.downstream edge"]
+        # BOTH directions since #2315. An `upstream` edge on S naming T is a claim about T's code, so
+        # it is verified in T — exactly as if T had declared the mirrored downstream edge. Treating
+        # "someone else's code" as out of scope meant 63 upstream edges across 23 services were opened
+        # by nothing, and a service declaring ONLY upstream was skipped outright; aml-service had 3 of
+        # its 6 upstream edges wrong (#2312). Both directions normalize to one <source>-><target>
+        # key, so a relationship declared from both ends is one check and one allowlist entry.
+        detect: ["any <service>/governance.yaml lineage.downstream or lineage.upstream edge"]
         require:
           - "api edge has a matching @RegisterRestClient(configKey) in the same service, or an allowlist entry with a reason"
           - "topic edge has an actual topic overlap with the target service (per mechanism 1's producer/consumer map), or an allowlist entry with a reason"
+          - "an edge naming no in-tree service directory (github, prometheus, temporal) is reported as its own class, never counted as code drift"
         gate: lineage-code-audit
         enforced: advisory
         target_enforce_date: "2026-10-15"   # ADR-0144 — later than mechanism 1's date: first scan found a much higher (34/48) violation rate, expect a longer triage
@@ -1802,7 +1809,11 @@ data:
           checker itself (fixed), 19 are stale governance.yaml edges (corrected/removed), 6 below are
           real dependencies the heuristic's exact-match can't see, and 4 are genuine gaps tracked as
           their own issues, not fixed here. A follow-up scan found 7 more edges outside the original
-          34 (the *->admin-ui reversed-direction shape) — not yet triaged."
+          34 (the *->admin-ui reversed-direction shape) — not yet triaged. #2315 then added the
+          upstream direction: the first upstream scan surfaced 24 further unbacked edges (26 total
+          unallowlisted, of which 2 are the pre-existing downstream findings) plus 10 edges naming an
+          external system — all untriaged, which is why target_enforce_date is unchanged and this
+          stays advisory."
         ci_producer: ".github/scripts/check-governance-lineage.py"
         allowlist:
           - edge: "openbank-copilot-service->balance-service:api"

--- a/openbank-infra/gitops/components/payments/vop-opa-bundle.yaml
+++ b/openbank-infra/gitops/components/payments/vop-opa-bundle.yaml
@@ -9,7 +9,7 @@ metadata:
     app.kubernetes.io/name: vop-service
     app.kubernetes.io/part-of: payments
   annotations:
-    openbank.tech/policy-checksum: "4e18fa5e701fa176"
+    openbank.tech/policy-checksum: "1ac01676b031c75f"
 data:
   rest.rego: |
     # SPDX-License-Identifier: Apache-2.0
@@ -1733,10 +1733,17 @@ data:
         # or be explicitly allowlisted below with a one-line reason (a REST call made through a
         # shared/generic client this heuristic's exact-match can't see, or a genuinely-stale edge
         # already tracked for cleanup elsewhere).
-        detect: ["any <service>/governance.yaml lineage.downstream edge"]
+        # BOTH directions since #2315. An `upstream` edge on S naming T is a claim about T's code, so
+        # it is verified in T — exactly as if T had declared the mirrored downstream edge. Treating
+        # "someone else's code" as out of scope meant 63 upstream edges across 23 services were opened
+        # by nothing, and a service declaring ONLY upstream was skipped outright; aml-service had 3 of
+        # its 6 upstream edges wrong (#2312). Both directions normalize to one <source>-><target>
+        # key, so a relationship declared from both ends is one check and one allowlist entry.
+        detect: ["any <service>/governance.yaml lineage.downstream or lineage.upstream edge"]
         require:
           - "api edge has a matching @RegisterRestClient(configKey) in the same service, or an allowlist entry with a reason"
           - "topic edge has an actual topic overlap with the target service (per mechanism 1's producer/consumer map), or an allowlist entry with a reason"
+          - "an edge naming no in-tree service directory (github, prometheus, temporal) is reported as its own class, never counted as code drift"
         gate: lineage-code-audit
         enforced: advisory
         target_enforce_date: "2026-10-15"   # ADR-0144 — later than mechanism 1's date: first scan found a much higher (34/48) violation rate, expect a longer triage
@@ -1753,7 +1760,11 @@ data:
           checker itself (fixed), 19 are stale governance.yaml edges (corrected/removed), 6 below are
           real dependencies the heuristic's exact-match can't see, and 4 are genuine gaps tracked as
           their own issues, not fixed here. A follow-up scan found 7 more edges outside the original
-          34 (the *->admin-ui reversed-direction shape) — not yet triaged."
+          34 (the *->admin-ui reversed-direction shape) — not yet triaged. #2315 then added the
+          upstream direction: the first upstream scan surfaced 24 further unbacked edges (26 total
+          unallowlisted, of which 2 are the pre-existing downstream findings) plus 10 edges naming an
+          external system — all untriaged, which is why target_enforce_date is unchanged and this
+          stays advisory."
         ci_producer: ".github/scripts/check-governance-lineage.py"
         allowlist:
           - edge: "openbank-copilot-service->balance-service:api"

--- a/openbank-infra/gitops/components/pid/pid-opa-bundle.yaml
+++ b/openbank-infra/gitops/components/pid/pid-opa-bundle.yaml
@@ -9,7 +9,7 @@ metadata:
     app.kubernetes.io/name: pid-service
     app.kubernetes.io/part-of: pid
   annotations:
-    openbank.tech/policy-checksum: "ba4d00fa1724b300"
+    openbank.tech/policy-checksum: "3601ae1586c3688a"
 data:
   rest.rego: |
     # SPDX-License-Identifier: Apache-2.0
@@ -1735,10 +1735,17 @@ data:
         # or be explicitly allowlisted below with a one-line reason (a REST call made through a
         # shared/generic client this heuristic's exact-match can't see, or a genuinely-stale edge
         # already tracked for cleanup elsewhere).
-        detect: ["any <service>/governance.yaml lineage.downstream edge"]
+        # BOTH directions since #2315. An `upstream` edge on S naming T is a claim about T's code, so
+        # it is verified in T — exactly as if T had declared the mirrored downstream edge. Treating
+        # "someone else's code" as out of scope meant 63 upstream edges across 23 services were opened
+        # by nothing, and a service declaring ONLY upstream was skipped outright; aml-service had 3 of
+        # its 6 upstream edges wrong (#2312). Both directions normalize to one <source>-><target>
+        # key, so a relationship declared from both ends is one check and one allowlist entry.
+        detect: ["any <service>/governance.yaml lineage.downstream or lineage.upstream edge"]
         require:
           - "api edge has a matching @RegisterRestClient(configKey) in the same service, or an allowlist entry with a reason"
           - "topic edge has an actual topic overlap with the target service (per mechanism 1's producer/consumer map), or an allowlist entry with a reason"
+          - "an edge naming no in-tree service directory (github, prometheus, temporal) is reported as its own class, never counted as code drift"
         gate: lineage-code-audit
         enforced: advisory
         target_enforce_date: "2026-10-15"   # ADR-0144 — later than mechanism 1's date: first scan found a much higher (34/48) violation rate, expect a longer triage
@@ -1755,7 +1762,11 @@ data:
           checker itself (fixed), 19 are stale governance.yaml edges (corrected/removed), 6 below are
           real dependencies the heuristic's exact-match can't see, and 4 are genuine gaps tracked as
           their own issues, not fixed here. A follow-up scan found 7 more edges outside the original
-          34 (the *->admin-ui reversed-direction shape) — not yet triaged."
+          34 (the *->admin-ui reversed-direction shape) — not yet triaged. #2315 then added the
+          upstream direction: the first upstream scan surfaced 24 further unbacked edges (26 total
+          unallowlisted, of which 2 are the pre-existing downstream findings) plus 10 edges naming an
+          external system — all untriaged, which is why target_enforce_date is unchanged and this
+          stays advisory."
         ci_producer: ".github/scripts/check-governance-lineage.py"
         allowlist:
           - edge: "openbank-copilot-service->balance-service:api"

--- a/openbank-infra/gitops/components/pid/pid-service.yaml
+++ b/openbank-infra/gitops/components/pid/pid-service.yaml
@@ -22,7 +22,7 @@ spec:
       annotations:
         # Rolls the pod when the OPA bundle changes — subPath mounts do NOT hot-reload.
         # Kept in sync by gen-pid-opa-bundle.sh (do not hand-edit).
-        openbank.tech/policy-checksum: "ba4d00fa1724b300"
+        openbank.tech/policy-checksum: "3601ae1586c3688a"
     spec:
       securityContext:
         runAsNonRoot: true

--- a/openbank-infra/gitops/components/psd2-service/psd2-opa-bundle.yaml
+++ b/openbank-infra/gitops/components/psd2-service/psd2-opa-bundle.yaml
@@ -9,7 +9,7 @@ metadata:
     app.kubernetes.io/name: psd2-service
     app.kubernetes.io/part-of: psd2
   annotations:
-    openbank.tech/policy-checksum: "4080b8e7bda49031"
+    openbank.tech/policy-checksum: "c898c1c406447a0c"
 data:
   rest.rego: |
     # SPDX-License-Identifier: Apache-2.0
@@ -1808,10 +1808,17 @@ data:
         # or be explicitly allowlisted below with a one-line reason (a REST call made through a
         # shared/generic client this heuristic's exact-match can't see, or a genuinely-stale edge
         # already tracked for cleanup elsewhere).
-        detect: ["any <service>/governance.yaml lineage.downstream edge"]
+        # BOTH directions since #2315. An `upstream` edge on S naming T is a claim about T's code, so
+        # it is verified in T — exactly as if T had declared the mirrored downstream edge. Treating
+        # "someone else's code" as out of scope meant 63 upstream edges across 23 services were opened
+        # by nothing, and a service declaring ONLY upstream was skipped outright; aml-service had 3 of
+        # its 6 upstream edges wrong (#2312). Both directions normalize to one <source>-><target>
+        # key, so a relationship declared from both ends is one check and one allowlist entry.
+        detect: ["any <service>/governance.yaml lineage.downstream or lineage.upstream edge"]
         require:
           - "api edge has a matching @RegisterRestClient(configKey) in the same service, or an allowlist entry with a reason"
           - "topic edge has an actual topic overlap with the target service (per mechanism 1's producer/consumer map), or an allowlist entry with a reason"
+          - "an edge naming no in-tree service directory (github, prometheus, temporal) is reported as its own class, never counted as code drift"
         gate: lineage-code-audit
         enforced: advisory
         target_enforce_date: "2026-10-15"   # ADR-0144 — later than mechanism 1's date: first scan found a much higher (34/48) violation rate, expect a longer triage
@@ -1828,7 +1835,11 @@ data:
           checker itself (fixed), 19 are stale governance.yaml edges (corrected/removed), 6 below are
           real dependencies the heuristic's exact-match can't see, and 4 are genuine gaps tracked as
           their own issues, not fixed here. A follow-up scan found 7 more edges outside the original
-          34 (the *->admin-ui reversed-direction shape) — not yet triaged."
+          34 (the *->admin-ui reversed-direction shape) — not yet triaged. #2315 then added the
+          upstream direction: the first upstream scan surfaced 24 further unbacked edges (26 total
+          unallowlisted, of which 2 are the pre-existing downstream findings) plus 10 edges naming an
+          external system — all untriaged, which is why target_enforce_date is unchanged and this
+          stays advisory."
         ci_producer: ".github/scripts/check-governance-lineage.py"
         allowlist:
           - edge: "openbank-copilot-service->balance-service:api"

--- a/openbank-infra/gitops/components/psd2-service/psd2-service.yaml
+++ b/openbank-infra/gitops/components/psd2-service/psd2-service.yaml
@@ -18,7 +18,7 @@ spec:
       annotations:
         # Rolls the pod when the OPA bundle changes — subPath mounts do NOT hot-reload.
         # Kept in sync by gen-psd2-opa-bundle.sh (do not hand-edit).
-        openbank.tech/policy-checksum: "4080b8e7bda49031"
+        openbank.tech/policy-checksum: "c898c1c406447a0c"
       labels: {app.kubernetes.io/name: psd2-service, app.kubernetes.io/part-of: psd2}
     spec:
       securityContext:

--- a/openbank-infra/gitops/components/sanctions-service/sanctions-opa-bundle.yaml
+++ b/openbank-infra/gitops/components/sanctions-service/sanctions-opa-bundle.yaml
@@ -9,7 +9,7 @@ metadata:
     app.kubernetes.io/name: sanctions-service
     app.kubernetes.io/part-of: sanctions
   annotations:
-    openbank.tech/policy-checksum: "a3c0292b94330435"
+    openbank.tech/policy-checksum: "a6391fd7476fe208"
 data:
   rest.rego: |
     # SPDX-License-Identifier: Apache-2.0
@@ -1713,10 +1713,17 @@ data:
         # or be explicitly allowlisted below with a one-line reason (a REST call made through a
         # shared/generic client this heuristic's exact-match can't see, or a genuinely-stale edge
         # already tracked for cleanup elsewhere).
-        detect: ["any <service>/governance.yaml lineage.downstream edge"]
+        # BOTH directions since #2315. An `upstream` edge on S naming T is a claim about T's code, so
+        # it is verified in T — exactly as if T had declared the mirrored downstream edge. Treating
+        # "someone else's code" as out of scope meant 63 upstream edges across 23 services were opened
+        # by nothing, and a service declaring ONLY upstream was skipped outright; aml-service had 3 of
+        # its 6 upstream edges wrong (#2312). Both directions normalize to one <source>-><target>
+        # key, so a relationship declared from both ends is one check and one allowlist entry.
+        detect: ["any <service>/governance.yaml lineage.downstream or lineage.upstream edge"]
         require:
           - "api edge has a matching @RegisterRestClient(configKey) in the same service, or an allowlist entry with a reason"
           - "topic edge has an actual topic overlap with the target service (per mechanism 1's producer/consumer map), or an allowlist entry with a reason"
+          - "an edge naming no in-tree service directory (github, prometheus, temporal) is reported as its own class, never counted as code drift"
         gate: lineage-code-audit
         enforced: advisory
         target_enforce_date: "2026-10-15"   # ADR-0144 — later than mechanism 1's date: first scan found a much higher (34/48) violation rate, expect a longer triage
@@ -1733,7 +1740,11 @@ data:
           checker itself (fixed), 19 are stale governance.yaml edges (corrected/removed), 6 below are
           real dependencies the heuristic's exact-match can't see, and 4 are genuine gaps tracked as
           their own issues, not fixed here. A follow-up scan found 7 more edges outside the original
-          34 (the *->admin-ui reversed-direction shape) — not yet triaged."
+          34 (the *->admin-ui reversed-direction shape) — not yet triaged. #2315 then added the
+          upstream direction: the first upstream scan surfaced 24 further unbacked edges (26 total
+          unallowlisted, of which 2 are the pre-existing downstream findings) plus 10 edges naming an
+          external system — all untriaged, which is why target_enforce_date is unchanged and this
+          stays advisory."
         ci_producer: ".github/scripts/check-governance-lineage.py"
         allowlist:
           - edge: "openbank-copilot-service->balance-service:api"

--- a/openbank-infra/gitops/components/sanctions-service/sanctions-service.yaml
+++ b/openbank-infra/gitops/components/sanctions-service/sanctions-service.yaml
@@ -49,7 +49,7 @@ spec:
       annotations:
         # Rolls the pods when the OPA bundle changes — subPath mounts do NOT hot-reload.
         # Kept in sync by gen-sanctions-opa-bundle.sh (do not hand-edit).
-        openbank.tech/policy-checksum: "a3c0292b94330435"
+        openbank.tech/policy-checksum: "a6391fd7476fe208"
     spec:
       securityContext:
         runAsNonRoot: true

--- a/openbank-infra/gitops/components/sca/sca-opa-bundle.yaml
+++ b/openbank-infra/gitops/components/sca/sca-opa-bundle.yaml
@@ -9,7 +9,7 @@ metadata:
     app.kubernetes.io/name: sca-service
     app.kubernetes.io/part-of: sca
   annotations:
-    openbank.tech/policy-checksum: "bc3f99b92965fdf3"
+    openbank.tech/policy-checksum: "7cfa10c037cc0043"
 data:
   rest.rego: |
     # SPDX-License-Identifier: Apache-2.0
@@ -1749,10 +1749,17 @@ data:
         # or be explicitly allowlisted below with a one-line reason (a REST call made through a
         # shared/generic client this heuristic's exact-match can't see, or a genuinely-stale edge
         # already tracked for cleanup elsewhere).
-        detect: ["any <service>/governance.yaml lineage.downstream edge"]
+        # BOTH directions since #2315. An `upstream` edge on S naming T is a claim about T's code, so
+        # it is verified in T — exactly as if T had declared the mirrored downstream edge. Treating
+        # "someone else's code" as out of scope meant 63 upstream edges across 23 services were opened
+        # by nothing, and a service declaring ONLY upstream was skipped outright; aml-service had 3 of
+        # its 6 upstream edges wrong (#2312). Both directions normalize to one <source>-><target>
+        # key, so a relationship declared from both ends is one check and one allowlist entry.
+        detect: ["any <service>/governance.yaml lineage.downstream or lineage.upstream edge"]
         require:
           - "api edge has a matching @RegisterRestClient(configKey) in the same service, or an allowlist entry with a reason"
           - "topic edge has an actual topic overlap with the target service (per mechanism 1's producer/consumer map), or an allowlist entry with a reason"
+          - "an edge naming no in-tree service directory (github, prometheus, temporal) is reported as its own class, never counted as code drift"
         gate: lineage-code-audit
         enforced: advisory
         target_enforce_date: "2026-10-15"   # ADR-0144 — later than mechanism 1's date: first scan found a much higher (34/48) violation rate, expect a longer triage
@@ -1769,7 +1776,11 @@ data:
           checker itself (fixed), 19 are stale governance.yaml edges (corrected/removed), 6 below are
           real dependencies the heuristic's exact-match can't see, and 4 are genuine gaps tracked as
           their own issues, not fixed here. A follow-up scan found 7 more edges outside the original
-          34 (the *->admin-ui reversed-direction shape) — not yet triaged."
+          34 (the *->admin-ui reversed-direction shape) — not yet triaged. #2315 then added the
+          upstream direction: the first upstream scan surfaced 24 further unbacked edges (26 total
+          unallowlisted, of which 2 are the pre-existing downstream findings) plus 10 edges naming an
+          external system — all untriaged, which is why target_enforce_date is unchanged and this
+          stays advisory."
         ci_producer: ".github/scripts/check-governance-lineage.py"
         allowlist:
           - edge: "openbank-copilot-service->balance-service:api"

--- a/openbank-infra/gitops/components/sca/sca-service.yaml
+++ b/openbank-infra/gitops/components/sca/sca-service.yaml
@@ -28,7 +28,7 @@ spec:
       annotations:
         # Rolls the pods when the OPA bundle changes — subPath mounts do NOT hot-reload.
         # Kept in sync by gen-sca-opa-bundle.sh (do not hand-edit).
-        openbank.tech/policy-checksum: "bc3f99b92965fdf3"
+        openbank.tech/policy-checksum: "7cfa10c037cc0043"
     spec:
       securityContext:
         runAsNonRoot: true

--- a/openbank-infra/gitops/components/statements/statement-opa-bundle.yaml
+++ b/openbank-infra/gitops/components/statements/statement-opa-bundle.yaml
@@ -9,7 +9,7 @@ metadata:
     app.kubernetes.io/name: statement-service
     app.kubernetes.io/part-of: statements
   annotations:
-    openbank.tech/policy-checksum: "5f86a99232d519f0"
+    openbank.tech/policy-checksum: "8a0fefcdc3b02877"
 data:
   rest.rego: |
     # SPDX-License-Identifier: Apache-2.0
@@ -1779,10 +1779,17 @@ data:
         # or be explicitly allowlisted below with a one-line reason (a REST call made through a
         # shared/generic client this heuristic's exact-match can't see, or a genuinely-stale edge
         # already tracked for cleanup elsewhere).
-        detect: ["any <service>/governance.yaml lineage.downstream edge"]
+        # BOTH directions since #2315. An `upstream` edge on S naming T is a claim about T's code, so
+        # it is verified in T — exactly as if T had declared the mirrored downstream edge. Treating
+        # "someone else's code" as out of scope meant 63 upstream edges across 23 services were opened
+        # by nothing, and a service declaring ONLY upstream was skipped outright; aml-service had 3 of
+        # its 6 upstream edges wrong (#2312). Both directions normalize to one <source>-><target>
+        # key, so a relationship declared from both ends is one check and one allowlist entry.
+        detect: ["any <service>/governance.yaml lineage.downstream or lineage.upstream edge"]
         require:
           - "api edge has a matching @RegisterRestClient(configKey) in the same service, or an allowlist entry with a reason"
           - "topic edge has an actual topic overlap with the target service (per mechanism 1's producer/consumer map), or an allowlist entry with a reason"
+          - "an edge naming no in-tree service directory (github, prometheus, temporal) is reported as its own class, never counted as code drift"
         gate: lineage-code-audit
         enforced: advisory
         target_enforce_date: "2026-10-15"   # ADR-0144 — later than mechanism 1's date: first scan found a much higher (34/48) violation rate, expect a longer triage
@@ -1799,7 +1806,11 @@ data:
           checker itself (fixed), 19 are stale governance.yaml edges (corrected/removed), 6 below are
           real dependencies the heuristic's exact-match can't see, and 4 are genuine gaps tracked as
           their own issues, not fixed here. A follow-up scan found 7 more edges outside the original
-          34 (the *->admin-ui reversed-direction shape) — not yet triaged."
+          34 (the *->admin-ui reversed-direction shape) — not yet triaged. #2315 then added the
+          upstream direction: the first upstream scan surfaced 24 further unbacked edges (26 total
+          unallowlisted, of which 2 are the pre-existing downstream findings) plus 10 edges naming an
+          external system — all untriaged, which is why target_enforce_date is unchanged and this
+          stays advisory."
         ci_producer: ".github/scripts/check-governance-lineage.py"
         allowlist:
           - edge: "openbank-copilot-service->balance-service:api"

--- a/openbank-infra/gitops/components/statements/statement-service.yaml
+++ b/openbank-infra/gitops/components/statements/statement-service.yaml
@@ -26,7 +26,7 @@ spec:
       annotations:
         # Rolls the pod when the OPA bundle changes — subPath mounts do NOT hot-reload.
         # Kept in sync by gen-statement-opa-bundle.sh (do not hand-edit).
-        openbank.tech/policy-checksum: "5f86a99232d519f0"
+        openbank.tech/policy-checksum: "8a0fefcdc3b02877"
       labels:
         app.kubernetes.io/name: statement-service
         app.kubernetes.io/part-of: statements

--- a/openbank-infra/gitops/components/tpp-registry/tpp-registry-opa-bundle.yaml
+++ b/openbank-infra/gitops/components/tpp-registry/tpp-registry-opa-bundle.yaml
@@ -9,7 +9,7 @@ metadata:
     app.kubernetes.io/name: tpp-registry-service
     app.kubernetes.io/part-of: tpp-registry
   annotations:
-    openbank.tech/policy-checksum: "09a45202c0e55795"
+    openbank.tech/policy-checksum: "2638a76774b6d62c"
 data:
   rest.rego: |
     # SPDX-License-Identifier: Apache-2.0
@@ -1716,10 +1716,17 @@ data:
         # or be explicitly allowlisted below with a one-line reason (a REST call made through a
         # shared/generic client this heuristic's exact-match can't see, or a genuinely-stale edge
         # already tracked for cleanup elsewhere).
-        detect: ["any <service>/governance.yaml lineage.downstream edge"]
+        # BOTH directions since #2315. An `upstream` edge on S naming T is a claim about T's code, so
+        # it is verified in T — exactly as if T had declared the mirrored downstream edge. Treating
+        # "someone else's code" as out of scope meant 63 upstream edges across 23 services were opened
+        # by nothing, and a service declaring ONLY upstream was skipped outright; aml-service had 3 of
+        # its 6 upstream edges wrong (#2312). Both directions normalize to one <source>-><target>
+        # key, so a relationship declared from both ends is one check and one allowlist entry.
+        detect: ["any <service>/governance.yaml lineage.downstream or lineage.upstream edge"]
         require:
           - "api edge has a matching @RegisterRestClient(configKey) in the same service, or an allowlist entry with a reason"
           - "topic edge has an actual topic overlap with the target service (per mechanism 1's producer/consumer map), or an allowlist entry with a reason"
+          - "an edge naming no in-tree service directory (github, prometheus, temporal) is reported as its own class, never counted as code drift"
         gate: lineage-code-audit
         enforced: advisory
         target_enforce_date: "2026-10-15"   # ADR-0144 — later than mechanism 1's date: first scan found a much higher (34/48) violation rate, expect a longer triage
@@ -1736,7 +1743,11 @@ data:
           checker itself (fixed), 19 are stale governance.yaml edges (corrected/removed), 6 below are
           real dependencies the heuristic's exact-match can't see, and 4 are genuine gaps tracked as
           their own issues, not fixed here. A follow-up scan found 7 more edges outside the original
-          34 (the *->admin-ui reversed-direction shape) — not yet triaged."
+          34 (the *->admin-ui reversed-direction shape) — not yet triaged. #2315 then added the
+          upstream direction: the first upstream scan surfaced 24 further unbacked edges (26 total
+          unallowlisted, of which 2 are the pre-existing downstream findings) plus 10 edges naming an
+          external system — all untriaged, which is why target_enforce_date is unchanged and this
+          stays advisory."
         ci_producer: ".github/scripts/check-governance-lineage.py"
         allowlist:
           - edge: "openbank-copilot-service->balance-service:api"

--- a/openbank-infra/gitops/components/tpp-registry/tpp-registry-service.yaml
+++ b/openbank-infra/gitops/components/tpp-registry/tpp-registry-service.yaml
@@ -23,7 +23,7 @@ spec:
       annotations:
         # Rolls the pod when the OPA bundle changes (subPath mounts do not hot-reload).
         # Kept in sync by gen-tpp-registry-opa-bundle.sh (do not hand-edit).
-        openbank.tech/policy-checksum: "09a45202c0e55795"
+        openbank.tech/policy-checksum: "2638a76774b6d62c"
     spec:
       securityContext:
         runAsNonRoot: true

--- a/openbank-libs/governance/rules.yaml
+++ b/openbank-libs/governance/rules.yaml
@@ -347,10 +347,17 @@ change_requirements:
     # or be explicitly allowlisted below with a one-line reason (a REST call made through a
     # shared/generic client this heuristic's exact-match can't see, or a genuinely-stale edge
     # already tracked for cleanup elsewhere).
-    detect: ["any <service>/governance.yaml lineage.downstream edge"]
+    # BOTH directions since #2315. An `upstream` edge on S naming T is a claim about T's code, so
+    # it is verified in T — exactly as if T had declared the mirrored downstream edge. Treating
+    # "someone else's code" as out of scope meant 63 upstream edges across 23 services were opened
+    # by nothing, and a service declaring ONLY upstream was skipped outright; aml-service had 3 of
+    # its 6 upstream edges wrong (#2312). Both directions normalize to one <source>-><target>
+    # key, so a relationship declared from both ends is one check and one allowlist entry.
+    detect: ["any <service>/governance.yaml lineage.downstream or lineage.upstream edge"]
     require:
       - "api edge has a matching @RegisterRestClient(configKey) in the same service, or an allowlist entry with a reason"
       - "topic edge has an actual topic overlap with the target service (per mechanism 1's producer/consumer map), or an allowlist entry with a reason"
+      - "an edge naming no in-tree service directory (github, prometheus, temporal) is reported as its own class, never counted as code drift"
     gate: lineage-code-audit
     enforced: advisory
     target_enforce_date: "2026-10-15"   # ADR-0144 — later than mechanism 1's date: first scan found a much higher (34/48) violation rate, expect a longer triage
@@ -367,7 +374,11 @@ change_requirements:
       checker itself (fixed), 19 are stale governance.yaml edges (corrected/removed), 6 below are
       real dependencies the heuristic's exact-match can't see, and 4 are genuine gaps tracked as
       their own issues, not fixed here. A follow-up scan found 7 more edges outside the original
-      34 (the *->admin-ui reversed-direction shape) — not yet triaged."
+      34 (the *->admin-ui reversed-direction shape) — not yet triaged. #2315 then added the
+      upstream direction: the first upstream scan surfaced 24 further unbacked edges (26 total
+      unallowlisted, of which 2 are the pre-existing downstream findings) plus 10 edges naming an
+      external system — all untriaged, which is why target_enforce_date is unchanged and this
+      stays advisory."
     ci_producer: ".github/scripts/check-governance-lineage.py"
     allowlist:
       - edge: "openbank-copilot-service->balance-service:api"


### PR DESCRIPTION
Closes #2315.

## The gap

`check-governance-lineage.py` read `lineage.downstream` and nothing else. The header comment declared upstream out of scope because it is "a claim about another service's code" — but that reasoning assumed the mirrored downstream edge exists on the other side, and mostly it doesn't. Result: **63 upstream edges across 23 services opened by nothing**, and any service declaring *only* upstream skipped entirely. `openbank-aml-service` had 3 of its 6 upstream edges wrong (#2312), in a file the gate never read.

## What changed

An upstream edge on S naming T is a claim about **T's** code, so it is verified in T — exactly as if T had declared the mirrored downstream edge. Both directions normalize to one `<source>-><target>:<relation>` key, so a relationship declared from both ends is checked once and takes one allowlist entry.

Two bugs surfaced while wiring it, each of which would have made the new direction lie:

1. **`normalize_service_name` stripped only the `-service` suffix.** The upstream side always resolves to the full directory name, so `transaction-service` (a configKey) never matched `openbank-balance-service` (the target) and **every** upstream api edge failed. Caught by spot-checking a pass I knew should be a pass, not by the summary line. Now both the `openbank-` prefix and the `-service` suffix are stripped.
2. **An edge naming an external system** (`github`, `prometheus`, `temporal`) was indistinguishable from real drift. There is no in-tree code that could witness it either way, so counting it as code drift is a category error. It is now reported as its own class (`::notice`) and excluded from the violation count — 10 such edges.

## Falsification

- **Must flag:** a fabricated `upstream: ledger-service (api)` on balance-service → flagged; `--enforce` exits 1.
- **Must NOT flag:** the real `transaction-service -> openbank-balance-service:api` upstream edge (transaction-service does carry `@RegisterRestClient(configKey = "balance-service")`) → not flagged.
- **No regressions:** the two pre-existing downstream findings were diffed as a *set* against `origin/main` — both still present, none silently lost. (Comparing exit codes would have proven nothing; both runs exit 0, it's advisory.)

## Scan result

```
30 downstream + 63 upstream edge(s) declared across 53 service(s), 93 distinct relationship(s)
checked; 26 unallowlisted violation(s), 5 allowlisted, 10 naming no in-tree service.
```

24 of those 26 are new upstream findings. **Deliberately not allowlisted in bulk** — the issue is explicit that each needs a verdict. The gate stays `advisory` and `target_enforce_date` is unchanged; `rules.yaml` records the new first-scan numbers as the untriaged backlog.

`rules.yaml` was edited (scope + first-scan record), so the OPA bundles are regenerated — that ran **after** the final `rules.yaml` edit. `rules.yaml` re-parsed with a duplicate-key-rejecting loader; `actionlint` finding set on `ci.yml` unchanged vs `origin/main`.