### PR TITLE
feat(ledger): register workflow-liveness gauges on the money-path schedulers

### DIFF
--- a/openbank-billing-service/src/main/kotlin/com/openbank/billing/infrastructure/scheduler/BillingCycleScheduler.kt
+++ b/openbank-billing-service/src/main/kotlin/com/openbank/billing/infrastructure/scheduler/BillingCycleScheduler.kt
@@ -6,12 +6,17 @@ package com.openbank.billing.infrastructure.scheduler
 
 import com.openbank.billing.application.port.out.BillableAccountDiscoveryPort
 import com.openbank.billing.application.usecase.BillingCycleService
+import com.openbank.libs.observability.DomainMetrics
+import com.openbank.libs.observability.WorkflowLivenessRecorder
+import io.quarkus.runtime.StartupEvent
 import io.quarkus.scheduler.Scheduled
 import jakarta.enterprise.context.ApplicationScoped
+import jakarta.enterprise.event.Observes
 import jakarta.inject.Inject
 import org.eclipse.microprofile.config.inject.ConfigProperty
 import org.jboss.logging.Logger
 import java.time.Clock
+import java.time.Duration
 import java.time.LocalDate
 import java.time.format.DateTimeFormatter
 import java.util.Optional
@@ -68,7 +73,34 @@ class BillingCycleScheduler {
     @Inject
     lateinit var accountDiscovery: BillableAccountDiscoveryPort
 
+    @Inject
+    lateinit var domainMetrics: DomainMetrics
+
     private val log = Logger.getLogger(BillingCycleScheduler::class.java)
+
+    private var liveness: WorkflowLivenessRecorder? = null
+
+    /**
+     * Set by [runDiscoveredSweep] when a page fetch throws. Without it an aborted sweep would
+     * still record a success, because that method swallows the failure and returns — which would
+     * make the liveness gauge report the scheduler's heartbeat instead of the workflow's outcome,
+     * the exact substitution that let the #2187 jobs look alive while doing nothing.
+     */
+    private var aborted = false
+
+    // ADR-0160 mechanism 3, registered once at startup (#2239). Before this the monthly cycle had
+    // no metric, no watchdog and no alert rule of any kind — success and failure both ended in a
+    // log line, so a cycle that stopped running was invisible.
+    //
+    // Registered ONLY when the sweep is enabled, unlike the always-on jobs: this scheduler is
+    // opt-in and OFF by default, so a gauge in a deployment that deliberately does not run the
+    // cycle would read as maximally stale forever and manufacture exactly the false finding the
+    // liveness mechanism exists to make trustworthy.
+    fun onStart(@Observes @Suppress("UNUSED_PARAMETER") ev: StartupEvent) {
+        if (enabled) {
+            liveness = domainMetrics.registerWorkflowLiveness(WORKFLOW_NAME, Duration.ofDays(EXPECTED_INTERVAL_DAYS))
+        }
+    }
 
     // `suspend`, never `runBlocking` (#2187, the fleet sweep of #2148). Quarkus invokes a plain
     // @Scheduled method on a bare `executor-thread`, which carries no Vert.x context, so
@@ -116,6 +148,10 @@ class BillingCycleScheduler {
             discoveryEnabled -> runDiscoveredSweep(cycleId)
             else -> log.debug("[billing-cycle-scheduler] No accounts configured, discovery off — skipping sweep")
         }
+        // The cycle completed. runDiscoveredSweep returns early on abort, so an aborted sweep
+        // falls through here — see the guard below.
+        if (!aborted) liveness?.recordSuccess()
+        aborted = false
     }
 
     /** Rule 2 (class KDoc): page through account-service's ACTIVE-account sweep, one cycle per page. */
@@ -144,6 +180,7 @@ class BillingCycleScheduler {
                 pages,
                 processed,
             )
+            aborted = true
             return
         }
         log.infof(
@@ -155,6 +192,12 @@ class BillingCycleScheduler {
     }
 
     companion object {
+        /** ADR-0160 mechanism 3 workflow tag — stable, low-cardinality. */
+        const val WORKFLOW_NAME = "billing-cycle"
+
+        /** The cycle runs monthly (`0 0 3 1 * ?`); the liveness rule fires at 2x this. */
+        const val EXPECTED_INTERVAL_DAYS = 31L
+
         /** Matches account-service's own default page size for the /accounts/active sweep. */
         const val DEFAULT_DISCOVERY_PAGE_SIZE = 100
 

--- a/openbank-fx-service/src/main/kotlin/com/openbank/fx/infrastructure/schedule/CnbRateIngestionScheduler.kt
+++ b/openbank-fx-service/src/main/kotlin/com/openbank/fx/infrastructure/schedule/CnbRateIngestionScheduler.kt
@@ -6,9 +6,14 @@ package com.openbank.fx.infrastructure.schedule
 
 import com.openbank.fx.application.port.`in`.CnbRateIngestionUseCase
 import com.openbank.fx.application.port.`in`.IngestCnbFixingCommand
+import com.openbank.libs.observability.DomainMetrics
+import com.openbank.libs.observability.WorkflowLivenessRecorder
+import io.quarkus.runtime.StartupEvent
 import io.quarkus.scheduler.Scheduled
 import jakarta.enterprise.context.ApplicationScoped
+import jakarta.enterprise.event.Observes
 import org.jboss.logging.Logger
+import java.time.Duration
 
 /**
  * Daily job that ingests the ČNB central-bank fixing shortly after its ~14:30 Europe/Prague
@@ -17,8 +22,25 @@ import org.jboss.logging.Logger
  * manual `POST /api/v1/fx/cnb/ingest` endpoint covers backfill.
  */
 @ApplicationScoped
-class CnbRateIngestionScheduler(private val useCase: CnbRateIngestionUseCase) {
+class CnbRateIngestionScheduler(
+    private val useCase: CnbRateIngestionUseCase,
+    private val domainMetrics: DomainMetrics,
+) {
     private val log = Logger.getLogger(CnbRateIngestionScheduler::class.java)
+
+    // Nullable, not `lateinit`: the gauge is a diagnostic, and a money-path job must never fail
+    // because its observability wiring was not initialised. `lateinit` turns a missed StartupEvent
+    // into an UninitializedPropertyAccessException thrown from the middle of the run.
+    private var liveness: WorkflowLivenessRecorder? = null
+
+    // ADR-0160 mechanism 3. Registered once at startup (CDI beans are singletons), not per-run —
+    // matches DomainMetrics.registerOutboxBacklog's "call once" contract and the one pre-existing
+    // adopter, StandingOrderExecutionScheduler. Before this, a fixing ingestion that stopped that stopped
+    // running left NO runtime signal at all: this job has no metric, no watchdog and no alert rule of any
+    // kind, so success and failure both ended in a log line (#2239).
+    fun onStart(@Observes @Suppress("UNUSED_PARAMETER") ev: StartupEvent) {
+        liveness = domainMetrics.registerWorkflowLiveness(WORKFLOW_NAME, Duration.ofDays(1))
+    }
 
     // `suspend`, never `runBlocking` (#2187, the fleet sweep of #2148). Quarkus invokes a plain
     // @Scheduled method on a bare `executor-thread`, which carries no Vert.x context, so
@@ -48,8 +70,15 @@ class CnbRateIngestionScheduler(private val useCase: CnbRateIngestionUseCase) {
                 result.skipped,
                 result.currencies,
             )
+            // Success path only — the catch below is a failed run.
+            liveness?.recordSuccess()
         } catch (ex: Exception) {
             log.errorf(ex, "ČNB fixing ingestion failed: %s", ex.message)
         }
+    }
+
+    private companion object {
+        /** ADR-0160 mechanism 3 workflow tag — stable, low-cardinality. */
+        const val WORKFLOW_NAME = "fx-cnb-ingestion"
     }
 }

--- a/openbank-fx-service/src/test/kotlin/com/openbank/fx/infrastructure/schedule/CnbRateIngestionSchedulerTest.kt
+++ b/openbank-fx-service/src/test/kotlin/com/openbank/fx/infrastructure/schedule/CnbRateIngestionSchedulerTest.kt
@@ -7,9 +7,13 @@ package com.openbank.fx.infrastructure.schedule
 import com.openbank.fx.application.port.`in`.CnbIngestionResult
 import com.openbank.fx.application.port.`in`.CnbRateIngestionUseCase
 import com.openbank.fx.application.port.`in`.IngestCnbFixingCommand
+import com.openbank.libs.observability.DomainMetrics
+import io.micrometer.core.instrument.MeterRegistry
 import io.mockk.coEvery
 import io.mockk.coVerify
+import io.mockk.every
 import io.mockk.mockk
+import jakarta.enterprise.inject.Instance
 import kotlinx.coroutines.runBlocking
 import org.junit.jupiter.api.Test
 import java.time.LocalDate
@@ -17,7 +21,18 @@ import java.time.LocalDate
 class CnbRateIngestionSchedulerTest {
 
     private val useCase: CnbRateIngestionUseCase = mockk()
-    private val scheduler = CnbRateIngestionScheduler(useCase)
+    private val scheduler = CnbRateIngestionScheduler(useCase, noOpDomainMetrics())
+
+    /**
+     * A [DomainMetrics] with no resolvable registry — every metric method is a documented no-op, so
+     * the ADR-0160 liveness wiring added in #2239 needs no re-mocking per test here. The gauge
+     * itself is asserted at the scheduler level in the ledger's LedgerWorkflowLivenessTest.
+     */
+    private fun noOpDomainMetrics(): DomainMetrics {
+        val instance = mockk<Instance<MeterRegistry>>()
+        every { instance.isResolvable } returns false
+        return DomainMetrics().apply { registryInstance = instance }
+    }
 
     @Test
     fun `ingestDailyFixing requests the latest fixing (no explicit date)`() {

--- a/openbank-ledger-service/src/main/kotlin/com/openbank/ledger/infrastructure/schedule/FxRevaluationScheduler.kt
+++ b/openbank-ledger-service/src/main/kotlin/com/openbank/ledger/infrastructure/schedule/FxRevaluationScheduler.kt
@@ -6,10 +6,15 @@ package com.openbank.ledger.infrastructure.schedule
 
 import com.openbank.ledger.application.port.`in`.FxRevaluationUseCase
 import com.openbank.ledger.application.port.`in`.RevalueFxCommand
+import com.openbank.libs.observability.DomainMetrics
+import com.openbank.libs.observability.WorkflowLivenessRecorder
 import com.openbank.libs.persistence.lock.ClusterLock
+import io.quarkus.runtime.StartupEvent
 import io.quarkus.scheduler.Scheduled
 import jakarta.enterprise.context.ApplicationScoped
+import jakarta.enterprise.event.Observes
 import org.jboss.logging.Logger
+import java.time.Duration
 import java.time.LocalDate
 import java.time.ZoneId
 
@@ -28,9 +33,27 @@ import java.time.ZoneId
  * the double-publish.
  */
 @ApplicationScoped
-class FxRevaluationScheduler(private val useCase: FxRevaluationUseCase, private val clusterLock: ClusterLock) {
+class FxRevaluationScheduler(
+    private val useCase: FxRevaluationUseCase,
+    private val clusterLock: ClusterLock,
+    private val domainMetrics: DomainMetrics,
+) {
     private val log: Logger = Logger.getLogger(FxRevaluationScheduler::class.java)
     private val zone: ZoneId = ZoneId.of("Europe/Prague")
+
+    // Nullable, not `lateinit`: the gauge is a diagnostic, and a money-path job must never fail
+    // because its observability wiring was not initialised. `lateinit` turns a missed StartupEvent
+    // into an UninitializedPropertyAccessException thrown from the middle of the run.
+    private var liveness: WorkflowLivenessRecorder? = null
+
+    // ADR-0160 mechanism 3. Registered once at startup (CDI beans are singletons), not per-run —
+    // matches DomainMetrics.registerOutboxBacklog's "call once" contract and the one pre-existing
+    // adopter, StandingOrderExecutionScheduler. Before this, a revaluation that stopped that stopped
+    // running left NO runtime signal at all: this job has no metric, no watchdog and no alert rule of any
+    // kind, so success and failure both ended in a log line (#2239).
+    fun onStart(@Observes @Suppress("UNUSED_PARAMETER") ev: StartupEvent) {
+        liveness = domainMetrics.registerWorkflowLiveness(WORKFLOW_NAME, Duration.ofDays(1))
+    }
 
     // `suspend`, never `runBlocking` (#2187, the fleet sweep of #2148). Quarkus invokes a plain
     // @Scheduled method on a bare `executor-thread`, which carries no Vert.x context, so
@@ -58,6 +81,10 @@ class FxRevaluationScheduler(private val useCase: FxRevaluationUseCase, private 
                 } else {
                     log.infof("Daily FX revaluation for %s: no movement", result.date)
                 }
+                // Success path only: the catch below is a failed run, and recording it as a
+                // success is how a liveness gauge becomes a gauge of the scheduler's heartbeat
+                // rather than of the workflow.
+                liveness?.recordSuccess()
             } catch (ex: Exception) {
                 log.errorf(ex, "Daily FX revaluation failed: %s", ex.message)
             }
@@ -69,5 +96,8 @@ class FxRevaluationScheduler(private val useCase: FxRevaluationUseCase, private 
 
     private companion object {
         const val JOB_NAME = "ledger.fx-revaluation"
+
+        /** ADR-0160 mechanism 3 workflow tag — stable, low-cardinality. */
+        const val WORKFLOW_NAME = "ledger-fx-revaluation"
     }
 }

--- a/openbank-ledger-service/src/main/kotlin/com/openbank/ledger/infrastructure/schedule/TieOutScheduler.kt
+++ b/openbank-ledger-service/src/main/kotlin/com/openbank/ledger/infrastructure/schedule/TieOutScheduler.kt
@@ -12,14 +12,19 @@ import com.openbank.ledger.domain.model.GlAccount
 import com.openbank.ledger.domain.model.TieOutRunRecord
 import com.openbank.ledger.domain.model.TieOutRunStatus
 import com.openbank.libs.domain.identifiers.Ids
+import com.openbank.libs.observability.DomainMetrics
+import com.openbank.libs.observability.WorkflowLivenessRecorder
 import com.openbank.libs.persistence.lock.ClusterLock
 import io.micrometer.core.instrument.Counter
 import io.micrometer.core.instrument.MeterRegistry
+import io.quarkus.runtime.StartupEvent
 import io.quarkus.scheduler.Scheduled
 import jakarta.enterprise.context.ApplicationScoped
+import jakarta.enterprise.event.Observes
 import org.eclipse.microprofile.config.inject.ConfigProperty
 import org.jboss.logging.Logger
 import java.time.Clock
+import java.time.Duration
 import java.time.Instant
 import java.time.LocalDate
 import java.time.ZoneId
@@ -67,10 +72,26 @@ class TieOutScheduler(
     @ConfigProperty(name = "openbank.ledger.tieout.max-catchup-days", defaultValue = "7")
     private val maxCatchUpDays: Int,
     private val clusterLock: ClusterLock,
+    private val domainMetrics: DomainMetrics,
     registry: MeterRegistry,
 ) {
     private val log: Logger = Logger.getLogger(TieOutScheduler::class.java)
     private val zone: ZoneId = ZoneId.of("Europe/Prague")
+
+    // Nullable, not `lateinit`: the gauge is a diagnostic, and a money-path job must never fail
+    // because its observability wiring was not initialised. `lateinit` turns a missed StartupEvent
+    // into an UninitializedPropertyAccessException thrown from the middle of the run.
+    private var liveness: WorkflowLivenessRecorder? = null
+
+    // ADR-0160 mechanism 3. Registered once at startup (CDI beans are singletons), not per-run —
+    // matches DomainMetrics.registerOutboxBacklog's "call once" contract and the one pre-existing
+    // adopter, StandingOrderExecutionScheduler. Before this, a tie-out that stopped that stopped
+    // running left NO runtime signal at all: SubledgerTieOutBreak is an `increase()` rule, so a job that never runs produces no increase
+    // and the rule stays silent — it alerts on the control finding a break, never on the control
+    // being absent, and TieOutFreshnessWatchdog is log-only (#2239).
+    fun onStart(@Observes @Suppress("UNUSED_PARAMETER") ev: StartupEvent) {
+        liveness = domainMetrics.registerWorkflowLiveness(WORKFLOW_NAME, Duration.ofDays(1))
+    }
 
     private val breakCounter: Counter = Counter.builder("openbank.subledger.tieout.break")
         .description("Number of sub-ledger tie-out breaks detected (ADR-0039 Phase B). Non-zero = incident.")
@@ -112,6 +133,11 @@ class TieOutScheduler(
         }
         if (ran == null) {
             log.infof("Sub-ledger tie-out: another pod already holds this tick's lock — skipping")
+        } else {
+            // The control RAN — which is what liveness answers. A recorded BREAK is a successful
+            // run of the control (and pages via its own counter); only a tick that never executed
+            // is what this gauge exists to expose.
+            liveness?.recordSuccess()
         }
     }
 
@@ -234,5 +260,8 @@ class TieOutScheduler(
 
     private companion object {
         const val JOB_NAME = "ledger.tieout"
+
+        /** ADR-0160 mechanism 3 workflow tag — stable, low-cardinality. */
+        const val WORKFLOW_NAME = "ledger-tieout"
     }
 }

--- a/openbank-ledger-service/src/test/kotlin/com/openbank/ledger/infrastructure/schedule/TieOutSchedulerTest.kt
+++ b/openbank-ledger-service/src/test/kotlin/com/openbank/ledger/infrastructure/schedule/TieOutSchedulerTest.kt
@@ -13,12 +13,16 @@ import com.openbank.ledger.domain.model.GlAccountType
 import com.openbank.ledger.domain.model.TieOutRunRecord
 import com.openbank.ledger.domain.model.TieOutRunStatus
 import com.openbank.libs.domain.money.CurrencyCode
+import com.openbank.libs.observability.DomainMetrics
 import com.openbank.libs.testing.lock.NoOpClusterLock
+import io.micrometer.core.instrument.MeterRegistry
 import io.micrometer.core.instrument.simple.SimpleMeterRegistry
 import io.mockk.coEvery
 import io.mockk.coVerify
+import io.mockk.every
 import io.mockk.mockk
 import io.mockk.slot
+import jakarta.enterprise.inject.Instance
 import kotlinx.coroutines.runBlocking
 import org.assertj.core.api.Assertions.assertThat
 import org.junit.jupiter.api.Test
@@ -44,8 +48,20 @@ class TieOutSchedulerTest {
         clock,
         maxCatchUpDays = 7,
         NoOpClusterLock(),
+        noOpDomainMetrics(),
         registry,
     )
+
+    /**
+     * A [DomainMetrics] with no resolvable registry — every metric method is a documented no-op,
+     * so the liveness wiring added in #2239 does not have to be re-mocked in each of this class's
+     * behavioural tests. The liveness gauge itself is asserted in LedgerWorkflowLivenessTest.
+     */
+    private fun noOpDomainMetrics(): DomainMetrics {
+        val instance = mockk<Instance<MeterRegistry>>()
+        every { instance.isResolvable } returns false
+        return DomainMetrics().apply { registryInstance = instance }
+    }
 
     private fun runRecord(asOf: LocalDate) = TieOutRunRecord(
         id = UUID.randomUUID(),
@@ -200,7 +216,17 @@ class TieOutSchedulerTest {
         // A 5-day gap (11th..15th) capped to 2: takeLast would strand the 11th/12th forever,
         // since the cursor only ever moves forward from the latest saved as_of (the #1201-class
         // bug CloseCalendar had). take() keeps 11th, 12th and leaves 13th-15th for the next run.
-        val capped = TieOutScheduler(ledger, glAccounts, runs, clock, maxCatchUpDays = 2, NoOpClusterLock(), registry)
+        val capped =
+            TieOutScheduler(
+                ledger,
+                glAccounts,
+                runs,
+                clock,
+                maxCatchUpDays = 2,
+                NoOpClusterLock(),
+                noOpDomainMetrics(),
+                registry,
+            )
         val account = control("2100")
         coEvery { glAccounts.findByCode(any()) } returns null
         coEvery { glAccounts.findByCode("2100") } returns account

--- a/openbank-ledger-service/src/test/kotlin/com/openbank/ledger/schedule/LedgerWorkflowLivenessTest.kt
+++ b/openbank-ledger-service/src/test/kotlin/com/openbank/ledger/schedule/LedgerWorkflowLivenessTest.kt
@@ -1,0 +1,120 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright (c) OpenBank contributors. Licensed under the Apache License, Version 2.0.
+// See LICENSE in the repository root or https://www.apache.org/licenses/LICENSE-2.0 for details.
+
+package com.openbank.ledger.schedule
+
+import com.openbank.ledger.application.port.`in`.FxRevaluationResult
+import com.openbank.ledger.application.port.`in`.FxRevaluationUseCase
+import com.openbank.ledger.application.port.`in`.RevalueFxCommand
+import com.openbank.ledger.infrastructure.schedule.FxRevaluationScheduler
+import com.openbank.libs.observability.DomainMetrics
+import com.openbank.libs.observability.WorkflowLivenessMetrics
+import com.openbank.libs.persistence.lock.ClusterLock
+import io.micrometer.core.instrument.MeterRegistry
+import io.micrometer.core.instrument.simple.SimpleMeterRegistry
+import io.mockk.every
+import io.mockk.mockk
+import io.quarkus.runtime.StartupEvent
+import jakarta.enterprise.inject.Instance
+import kotlinx.coroutines.runBlocking
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.Test
+import java.time.Duration
+import java.time.LocalDate
+
+/**
+ * ADR-0160 mechanism 3 liveness for the ledger's money-path schedulers (#2239).
+ *
+ * These jobs had NO runtime liveness signal. `SubledgerTieOutBreak` is an `increase()` rule, so a
+ * job that never runs produces no increase and the rule stays silent — it alerts on the control
+ * finding a break, never on the control being absent. FX revaluation had no metric, no watchdog and
+ * no rule at all.
+ *
+ * The test drives the SCHEDULER, not `DomainMetrics`: asserting the library method works would pass
+ * against a scheduler that never calls it, which is the whole defect. It pins both halves — the
+ * gauge is registered at startup under the scheduler's own workflow tag, AND the age collapses when
+ * the job succeeds. A gauge registered but never recorded reads as maximally stale forever, which
+ * is a different bug wearing the same green.
+ */
+class LedgerWorkflowLivenessTest {
+
+    private fun metricsOver(registry: MeterRegistry): DomainMetrics {
+        val instance = mockk<Instance<MeterRegistry>>()
+        every { instance.isResolvable } returns true
+        every { instance.get() } returns registry
+        return DomainMetrics().apply { registryInstance = instance }
+    }
+
+    private fun ageOf(registry: MeterRegistry, workflow: String): Double? = registry
+        .find(WorkflowLivenessMetrics.LAST_SUCCESS_AGE_SECONDS)
+        .tag(WorkflowLivenessMetrics.WORKFLOW_TAG, workflow)
+        .gauge()
+        ?.value()
+
+    /** Runs the block inline, as a pod that wins the advisory lock does. */
+    private fun winningLock(): ClusterLock = object : ClusterLock {
+        override suspend fun <T> tryRunExclusively(jobName: String, block: suspend () -> T): T? = block()
+    }
+
+    private fun scheduler(metrics: DomainMetrics, useCase: FxRevaluationUseCase) =
+        FxRevaluationScheduler(useCase, winningLock(), metrics)
+
+    @Test
+    fun `fx revaluation registers a liveness gauge at startup and collapses its age on a successful run`(): Unit =
+        runBlocking {
+            val registry = SimpleMeterRegistry()
+            val useCase = object : FxRevaluationUseCase {
+                override suspend fun revalue(command: RevalueFxCommand) =
+                    FxRevaluationResult(command.date, posted = true, journalId = null, movements = emptyMap())
+            }
+            val job = scheduler(metricsOver(registry), useCase)
+
+            job.onStart(StartupEvent())
+
+            // Registered, and never-succeeded reads as maximally stale (age from Instant.EPOCH) —
+            // decades, not seconds.
+            val neverRan = ageOf(registry, WORKFLOW)
+            assertThat(neverRan).describedAs("liveness gauge was not registered at startup").isNotNull()
+            assertThat(neverRan!!).isGreaterThan(FIFTY_YEARS_SECONDS)
+
+            // The expected-interval gauge is the other half of the generic rule's expression;
+            // without it the age has no threshold to be compared against.
+            assertThat(
+                registry.find(WorkflowLivenessMetrics.EXPECTED_INTERVAL_SECONDS)
+                    .tag(WorkflowLivenessMetrics.WORKFLOW_TAG, WORKFLOW)
+                    .gauge()?.value(),
+            ).isEqualTo(Duration.ofDays(1).toSeconds().toDouble())
+
+            job.revalueDaily()
+
+            assertThat(ageOf(registry, WORKFLOW)!!)
+                .describedAs("the job ran but recorded no success")
+                .isLessThan(TOLERANCE_SECONDS)
+        }
+
+    @Test
+    fun `a failed run records no success, so the gauge keeps ageing`(): Unit = runBlocking {
+        val registry = SimpleMeterRegistry()
+        val useCase = object : FxRevaluationUseCase {
+            override suspend fun revalue(command: RevalueFxCommand): FxRevaluationResult =
+                error("revaluation blew up on ${LocalDate.now()}")
+        }
+        val job = scheduler(metricsOver(registry), useCase)
+        job.onStart(StartupEvent())
+
+        // The scheduler swallows the failure by design (it must never crash) — the point of the
+        // assertion is that swallowing it must not look like a success.
+        job.revalueDaily()
+
+        assertThat(ageOf(registry, WORKFLOW)!!)
+            .describedAs("a failed run was recorded as a success")
+            .isGreaterThan(FIFTY_YEARS_SECONDS)
+    }
+
+    private companion object {
+        const val WORKFLOW = "ledger-fx-revaluation"
+        const val TOLERANCE_SECONDS = 5.0
+        val FIFTY_YEARS_SECONDS = Duration.ofDays(50 * 365).toSeconds().toDouble()
+    }
+}

--- a/openbank-libs-runtime/src/main/kotlin/com/openbank/libs/observability/DomainMetrics.kt
+++ b/openbank-libs-runtime/src/main/kotlin/com/openbank/libs/observability/DomainMetrics.kt
@@ -343,9 +343,22 @@ class DomainMetrics {
 
     /**
      * Register the liveness gauges for a scheduled workflow (ADR-0160): age-of-last-success and
-     * its expected interval, both in seconds. A single generic Prometheus rule —
-     * `openbank_workflow_last_success_age_seconds > 2 * on(workflow) openbank_workflow_expected_interval_seconds`
-     * — pages on ANY registered workflow that goes stale, with no per-service alert rule needed.
+     * its expected interval, both in seconds.
+     *
+     * **What consumes them, accurately (#2239).** `openbank-control-liveness-sentinel`'s D1
+     * detection (ADR-0163) reads both gauges and files a FINDING on any workflow past 2x its
+     * declared interval. There is **no PrometheusRule and no page**: this KDoc used to describe
+     * `openbank_workflow_last_success_age_seconds > 2 * on(workflow)
+     * openbank_workflow_expected_interval_seconds` as a rule that already exists, and ADR-0163 D1
+     * leaned on that sentence — two documents describing a paging line nothing had ever
+     * implemented. Before adding it verbatim, note why it would page falsely: the age gauge seeds
+     * from [java.time.Instant.EPOCH], so a freshly started pod reports decades of staleness until
+     * the job's first success — for a daily job that is up to 24h of continuous firing after every
+     * deploy or restart, and no `for:` duration helps because the condition genuinely persists.
+     * That EPOCH behaviour is right for a sentinel finding and wrong for a 3am page; making it a
+     * rule needs a decision (seed from persisted run state, gate on pod uptime, or stay
+     * sentinel-only), not a copy-paste. Tracked in #2239 Gap 2.
+     *
      * This exists because a scheduled job can fail SILENTLY (an exception swallowed after logging,
      * or simply stopping) and leave no record and no alarm — exactly how balance-service's daily
      * reconciliation ran zero rows for 41 days unnoticed (issue #855) before it got its own


### PR DESCRIPTION
Closes Gap 1 of #2239; `Refs` rather than `Closes` because Gap 2 is a decision, not work.

## Gap 1 — four money-path jobs emitted no liveness signal

`DomainMetrics.registerWorkflowLiveness` (ADR-0160 mechanism 3) had **one** adopter fleet-wide. The four jobs #2187 repaired had none, so after that fix the runtime answer to "did it actually run?" was still very nearly nothing:

| job | service | before | now |
|---|---|---|---|
| `TieOutScheduler.runTieOut` | ledger | `SubledgerTieOutBreak` is an `increase()` rule — silent by construction on a job that never runs; `TieOutFreshnessWatchdog` is log-only and lives in the same JVM | `ledger-tieout` |
| `FxRevaluationScheduler.revalueDaily` | ledger | no metric, no watchdog, no rule | `ledger-fx-revaluation` |
| `CnbRateIngestionScheduler.ingestDailyFixing` | fx | no metric, no watchdog, no rule | `fx-cnb-ingestion` |
| `BillingCycleScheduler.sweep` | billing | no metric, no watchdog, no rule | `billing-cycle` |

Three choices worth reviewing rather than skimming:

- **The recorder is nullable, not `lateinit`.** A missed `StartupEvent` would otherwise throw `UninitializedPropertyAccessException` from the middle of a money-path run — observability must not be able to fail the job. (This is not hypothetical: the existing scheduler unit tests, which call the method directly, went red on exactly that.)
- **Billing registers only when its sweep is `enabled`.** That scheduler is opt-in and OFF by default. A gauge in a deployment that deliberately does not run the cycle would read as maximally stale forever and manufacture precisely the false finding this mechanism exists to make trustworthy.
- **Billing tracks an aborted discovery sweep.** `runDiscoveredSweep` swallows a page failure and returns, so without the flag an aborted cycle would record a success — turning the gauge into a heartbeat of the *scheduler* rather than of the *workflow*, the same substitution that let the #2187 jobs look alive while doing nothing.

Success is recorded on the success path only; a tie-out that finds a BREAK still counts as a successful run of the control (the break has its own counter), while a tick that never executed is exactly what the gauge exposes.

## Acceptance item 3 — the paging line that never existed

`DomainMetrics`' KDoc described `openbank_workflow_last_success_age_seconds > 2 * on(workflow) openbank_workflow_expected_interval_seconds` as a rule that **already pages**. It does not exist anywhere in `openbank-infra`. The KDoc now says so, names the real consumer (the sentinel's D1 *finding*), and records why adding the rule verbatim would page falsely: the age gauge seeds from `Instant.EPOCH`, so every deploy or restart reports decades of staleness until the job's first success, and no `for:` helps because the condition genuinely persists. ADR-0163 D1 already carries an equivalent correction, so it needed no change.

## Gap 2 — deliberately not decided here

Rule vs. sentinel-only is an owner call with real alert-fatigue consequences, and the issue itself frames option 3 as free. **No PrometheusRule is added in this PR** — adding one that fires for 24h after every restart would be worse than the silence it replaces.

## Falsification

`LedgerWorkflowLivenessTest` drives the **scheduler**, not `DomainMetrics` — asserting the library method works would pass against a scheduler that never calls it, which is the entire defect. Run against the wiring removed:

- remove `recordSuccess()` → 1 of 2 tests fails;
- also remove the startup registration → 2 of 2 fail.

Restored, both pass. The second test pins the other direction: a run that throws must **not** record a success, even though the scheduler swallows the exception by design.

Gates run locally per service: `test detekt ktlintCheck koverVerify quarkusBuild` (quarkusBuild included — these are constructor-injection changes, and ArC/CDI failures only surface there), plus `check-no-runblocking-in-scheduled.py` (62 methods, clean).