### PR TITLE
docs(ledger): record real restore-drill PASS, close issue #2365's ledger slice

### DIFF
--- a/docs/runbooks/0003-postgresql-16-to-18-major-upgrade.md
+++ b/docs/runbooks/0003-postgresql-16-to-18-major-upgrade.md
@@ -112,17 +112,17 @@ Rollback (Path B): repoint back to the still-running 16 Cluster — seconds, no 
 
 | Field | Value |
 |-------|-------|
-| Date | 2026-06-26 |
+| Date | 2026-07-26 |
 | Operator | CNPG 1.29.1 |
 | imageName | ghcr.io/cloudnative-pg/postgresql:18.1 |
 | storageClass | gp3 |
-| targetTime | 2026-06-20T03:00:00Z |
+| targetTime | 2026-07-26T02:05:08Z (stoppedAt of `ledger-db-daily-20260726020500`) |
 | Source | s3://openbank-sandbox-db-backups/ledger-db |
-| RTO | N/A — restore did not complete |
-| Row count | N/A |
-| Result | **FAIL** |
+| RTO | ~84s (Cluster created 06:50:04Z → primary ready 06:51:28Z) |
+| Row count | 96 `journal_entries` — matches the live `ledger-db` primary exactly |
+| Result | **PASS** |
 
-### Diagnostika
+### Attempt 1 (2026-06-26) — FAIL, credentials
 
 Restore cluster `ledger-db-restore-drill` (namespace `ledger`) se nepodařilo spustit.
 Všechny pody `ledger-db-restore-drill-1-full-recovery-*` crashovaly opakovaně
@@ -140,18 +140,48 @@ přístup k S3. Existující `ledger-db` SA má IAM roli přidělenou přes
 `aws/.../db-backups.tf`; nový SA vznikl bez ní — barman `inheritFromIAMRole`
 tedy nenašel credentials.
 
-### Fix (aplikován 2026-06-26)
-
+**Fix (aplikován 2026-06-26, `tofu apply`d jako součást #1759 2026-07):**
 `db-backups.tf` přidává permanentní Pod Identity asociaci pro SA `ledger-db-drill`
 v namespace `ledger`. Restore drill se musí spouštět jako CNPG Cluster
 pojmenovaný **`ledger-db-drill`** (ne `ledger-db-restore-drill`) — CNPG vytvoří
 SA se stejným jménem jako cluster, a tato SA má IAM roli přidělenu.
 
+### Attempt 2 (2026-07-26) — FAIL first try, then PASS: `serverName` gotcha
+
+S IAM fixem live (ověřeno přes `tofu state show` — asociace `ledger-drill` je
+skutečně aplikovaná, ne jen deklarovaná) první pokus stejně selhal, jinou chybou:
+
+```
+"msg":"Error while restoring a backup","error":"no target backup found"
+```
+
+**Root cause:** `barmanObjectStore.serverName` v `externalClusters` **defaultuje
+na jméno externalCluster entry** (`ledger-backup`), ne na jméno originálního
+clusteru. Live `ledger-db` si zapisuje zálohy pod
+`s3://.../ledger-db/ledger-db/{base,wals}/` (server name == cluster name), takže
+barman-cloud-backup-list hledal v neexistujícím `s3://.../ledger-db/ledger-backup/`
+a nenašel nic — bez chyby přístupu, prostě prázdný list. Ověřit vždy přes
+`aws s3 ls s3://<bucket>/<svc>-db/` **před** psaním manifestu, ne až po chybě.
+
+**Fix:** přidat `serverName: <cluster-name>` explicitně pod
+`externalClusters[].barmanObjectStore` (viz manifest níže). Po tomto fixu:
+Healthy za ~84s, row count 96 `journal_entries` sedí přesně na live primary.
+
+Faktická tabulka `journal_entries` je partitioned (`journal_entries_2024`…`_2028`
++ `_default`) — `journal_entry` (singular) z předchozí verze tohoto runbooku
+nikdy neexistovala; oprav si dotaz podle toho.
+
 ### Postup pro příští drill
 
 ```bash
-# 1. Ujisti se, že tofu apply proběhl po přidání ledger-drill do db-backups.tf
-# 2. Aplikuj restore manifest:
+# 1. Ujisti se, že tofu apply proběhl po přidání <svc>-drill do db-backups.tf
+#    (ověř `tofu state show 'aws_eks_pod_identity_association.db_backups_fleet["<svc>-drill"]'`,
+#    ne jen že je v `db-backups.tf` — deklarace bez apply je přesně #1759).
+# 2. Ověř skutečnou S3 strukturu PŘED psaním manifestu:
+aws s3 ls s3://openbank-sandbox-db-backups/<svc>-db/
+# obvykle uvidíš vnořené s3://.../<svc>-db/<svc>-db/{base,wals}/ — serverName == cluster name.
+
+# 3. Aplikuj restore manifest (serverName MUSÍ odpovídat kroku 2):
 kubectl apply -f - <<'EOF'
 apiVersion: postgresql.cnpg.io/v1
 kind: Cluster
@@ -168,10 +198,11 @@ spec:
     recovery:
       source: ledger-backup
       recoveryTarget:
-        targetTime: "2026-06-20T03:00:00Z"
+        targetTime: "2026-07-26T02:05:08Z"
   externalClusters:
     - name: ledger-backup
       barmanObjectStore:
+        serverName: ledger-db   # NOT the externalCluster name above — see Attempt 2
         destinationPath: s3://openbank-sandbox-db-backups/ledger-db
         s3Credentials:
           inheritFromIAMRole: true
@@ -179,18 +210,24 @@ spec:
           compression: gzip
 EOF
 
-# 3. Čekej na Healthy state (obvykle 3-5 min):
+# 4. Čekej na Healthy state (obvykle 3-5 min):
 kubectl get cluster ledger-db-drill -n ledger -w
 
-# 4. Ověř data:
-kubectl exec -n ledger ledger-db-drill-1 -- psql -U postgres -c "SELECT count(*) FROM journal_entry;"
+# 5. Ověř data (skutečná tabulka je `journal_entries`, partitioned):
+kubectl exec -n ledger ledger-db-drill-1 -c postgres -- \
+  psql -U postgres -d openbank_ledger -c "SELECT count(*) FROM journal_entries;"
+# porovnej se stejným dotazem na živý primary (read-only, nic to nemutuje):
+kubectl exec -n ledger ledger-db-2 -c postgres -- \
+  psql -U postgres -d openbank_ledger -c "SELECT count(*) FROM journal_entries;"
 
-# 5. Zaznamenej RTO a row count výše a aktualizuj tabulku.
+# 6. Zaznamenej RTO a row count výše a aktualizuj tabulku.
 
-# 6. Smaž drill cluster:
+# 7. Smaž drill cluster:
 kubectl delete cluster ledger-db-drill -n ledger
 ```
 
 > **Precheck z runbooku** „Backups verified — restore has been test-rehearsed"
-> musí být splněn **před** zahájením PG upgrade (Path A ani B). Fix v TF
-> je připraven; drill zopakovat po `platform-tofu` apply (viz issue #2207).
+> je od 2026-07-26 splněn pro `ledger` — atestováno v
+> `openbank-libs/governance/attestations.yaml: ledger.restore_drill`. Fix v TF
+> byl aplikován jako součást #1759. Zbylých ~19 money-path DB tuto drill zatím
+> nemá — postup výše je teď ověřený end-to-end, jen aplikuj per-service.

--- a/openbank-libs/governance/attestations.yaml
+++ b/openbank-libs/governance/attestations.yaml
@@ -26,4 +26,7 @@
 #   dr_drill:      { date: 2026-06-20, ttl_days: 180, by: jiri, ref: runbook-0006 }
 #   pentest:       { date: 2026-05-01, ttl_days: 365, by: ext,  ref: schemathesis-fleet }
 
-# --- zatím prázdné: žádná M-dimenze není dosvědčena (a to je pravda) ---
+ledger:
+  restore_drill: { date: 2026-07-26, ttl_days: 180, by: jiri, ref: runbook-0003 }
+
+# --- zbytek zatím prázdný: žádná další M-dimenze není dosvědčena (a to je pravda) ---


### PR DESCRIPTION
## Summary
- Ran a **real** CNPG restore drill against `ledger-db`'s live S3 backup (namespace `ledger`, sandbox AWS account) — the first ever completed `restore_drill` attestation for a money-path service under issue #2365.
- Recovered cluster's `journal_entries` count matched the live primary exactly (96 rows); RTO ~84s, well inside the runbook's ≤30 min target.
- Live cluster was never touched — recovery went into a separate `ledger-db-drill` Cluster object, verified, then deleted.
- Found and fixed a second restore-drill footgun (beyond the 2026-06-26 IAM one, which is confirmed applied via #1759): `externalClusters[].barmanObjectStore.serverName` defaults to the *externalCluster's own name*, not the original cluster's — so the first attempt today silently searched an empty S3 prefix (`ledger-db/ledger-backup/` instead of the real `ledger-db/ledger-db/`) and failed with "no target backup found", no credentials error. Documented in runbook 0003 with the fix (explicit `serverName:`).
- Also corrected the runbook's stale example query (`journal_entry` singular never existed — real table is the partitioned `journal_entries`) and its dangling reference to issue #2207 (wrong issue number; the real IAM fix tracker was #1759, already closed).
- Added the real `ledger.restore_drill` attestation to `openbank-libs/governance/attestations.yaml` (180-day TTL, ref: runbook-0003).

## What this does NOT close
Issue #2365 needs 33 more attestations (dr_drill, pentest, code_complete across 20 money-path services) — this PR only lands the one restore_drill slice for one service, as a proven trial run. `dr_drill` (failover) and `pentest` were not attempted and are not attested here.

## Test plan
- [x] Restore drill executed live against production sandbox infra, not simulated
- [x] Row count cross-checked against the live primary in the same session
- [x] Live `ledger-db` cluster confirmed healthy and untouched before and after
- [x] Drill cluster deleted after verification (no leftover resources)
- [x] `tofu state show` used to confirm the IAM Pod Identity association is actually applied, not just declared in `db-backups.tf`

🤖 Generated with [Claude Code](https://claude.com/claude-code)