### PR TITLE
fix(consent): scope operator-consent-write away from the shared M2M identity

### DIFF
--- a/openbank-infra/gitops/components/consent/consent-opa-bundle.yaml
+++ b/openbank-infra/gitops/components/consent/consent-opa-bundle.yaml
@@ -9,7 +9,7 @@ metadata:
     app.kubernetes.io/name: consent-service
     app.kubernetes.io/part-of: consent
   annotations:
-    openbank.tech/policy-checksum: "a193c92d1fc9809d"
+    openbank.tech/policy-checksum: "8dfa8672122b8cad"
 data:
   rest.rego: |
     # SPDX-License-Identifier: Apache-2.0
@@ -408,8 +408,20 @@ data:
 
     # Operators and admins may perform ANY consent lifecycle operation — the ops
     # console path (create on behalf of a party, revoke, resolve a stuck PENDING_SCA).
+    #
+    # EXCLUDES the shared M2M identity (found during ADR-0206 D5): every backend service on the
+    # `openbank-services` Keycloak client authenticates as `service-account-openbank-services`, and
+    # that service-account carries ROLE_OPERATOR in the realm (openbank-realm.json) — a role-only
+    # check here would let ANY such caller perform ANY consent.* write, unconditionally, the exact
+    # blanket-M2M-allow rules.yaml's own guardrail note (dependencies.principal_type_service_unreachable)
+    # already warns against ("ROLE_OPERATOR is shared with real human staff, so a role-only check
+    # over-grants"). This rule's header comment and the "service-consent-m2m" rule below both claimed
+    # consent.grant/consent.revoke were M2M-unreachable — false the whole time this exclusion was
+    # missing. M2M access to consent.grant/consent.revoke is scoped exclusively through
+    # "service-consent-m2m-marketing" below now.
     allowed_reasons contains "operator-consent-write" if {
     	input.principal.type == "HUMAN"
+    	not input.principal.id == "service-account-openbank-services"
     	some role in {"ROLE_OPERATOR", "ROLE_ADMIN"}
     	role in input.principal.roles
     	startswith(input.action, "consent.")

--- a/openbank-infra/gitops/components/consent/consent-service.yaml
+++ b/openbank-infra/gitops/components/consent/consent-service.yaml
@@ -28,7 +28,7 @@ spec:
       annotations:
         # Rolls the pods when the OPA bundle changes — subPath mounts do NOT hot-reload.
         # Kept in sync by gen-consent-opa-bundle.sh (do not hand-edit).
-        openbank.tech/policy-checksum: "a193c92d1fc9809d"
+        openbank.tech/policy-checksum: "8dfa8672122b8cad"
     spec:
       securityContext:
         runAsNonRoot: true

--- a/openbank-infra/gitops/components/consent/consent_rest_ext.rego
+++ b/openbank-infra/gitops/components/consent/consent_rest_ext.rego
@@ -1,0 +1,107 @@
+# SPDX-License-Identifier: Apache-2.0
+# Consent-service REST extension (ADR-0034 Phase 5, ADR-0126 D5, issue #263).
+# Extends openbank.rest with consent-domain allow reasons.
+# Mounted alongside rest.rego in the same OPA bundle — OPA merges same-package rules.
+#
+# Actions gated (ConsentResource):
+#   consent.grant     — create (PENDING_SCA); operator console / onboarding flows (renamed from
+#                       consent.create, issue #938 follow-up: "grant" is a distinctive four-eyes
+#                       verb, so it cannot silently gate every OTHER money-path service's
+#                       unrelated `.create` action fleet-wide); four-eyes gated. ALSO grantable by
+#                       the shared M2M principal, but ONLY for grantee=party-service:marketing-comms
+#                       (ADR-0206) — see service-consent-m2m-marketing below.
+#   consent.read      — getById
+#   consent.list      — listByParty (#partyId), listByGrantee (#granteeId)
+#   consent.revoke    — revoke (DELETE); four-eyes gated (operator-initiated denial of a
+#                       customer's active consent, rules.yaml four_eyes.verbs). Same M2M exception
+#                       as consent.grant above (ADR-0206), same grantee restriction.
+#   consent.activate  — activate after SCA challenge completes. Deliberately NOT four-eyes
+#                       gated (issue #938 follow-up): the M2M grant below already reserves this
+#                       action for a possible SCA-completion-callback caller — four_eyes_required
+#                       has no awareness of caller identity, so gating it would risk pausing that
+#                       automated flow too, not just a risky operator-console path.
+#   consent.reject    — reject (customer cancelled SCA)
+#   consent.validate  — validate scope/account coverage (resource servers)
+#
+# Actions gated (ApprovalResource, ADR-0155):
+#   consent.approval.decide — a DIFFERENT operator decides a paused consent.grant /
+#                             consent.revoke request (#id)
+#
+# Base rest.rego already grants: operator-read-any / compliance-read-any for
+# consent.read + consent.list, and party-self-service for consent.list when the
+# JWT sub equals the {partyId}/{granteeId} path parameter.
+
+package openbank.rest
+
+import rego.v1
+
+# Operators and admins may perform ANY consent lifecycle operation — the ops
+# console path (create on behalf of a party, revoke, resolve a stuck PENDING_SCA).
+#
+# EXCLUDES the shared M2M identity (found during ADR-0206 D5): every backend service on the
+# `openbank-services` Keycloak client authenticates as `service-account-openbank-services`, and
+# that service-account carries ROLE_OPERATOR in the realm (openbank-realm.json) — a role-only
+# check here would let ANY such caller perform ANY consent.* write, unconditionally, the exact
+# blanket-M2M-allow rules.yaml's own guardrail note (dependencies.principal_type_service_unreachable)
+# already warns against ("ROLE_OPERATOR is shared with real human staff, so a role-only check
+# over-grants"). This rule's header comment and the "service-consent-m2m" rule below both claimed
+# consent.grant/consent.revoke were M2M-unreachable — false the whole time this exclusion was
+# missing. M2M access to consent.grant/consent.revoke is scoped exclusively through
+# "service-consent-m2m-marketing" below now.
+allowed_reasons contains "operator-consent-write" if {
+	input.principal.type == "HUMAN"
+	not input.principal.id == "service-account-openbank-services"
+	some role in {"ROLE_OPERATOR", "ROLE_ADMIN"}
+	role in input.principal.roles
+	startswith(input.action, "consent.")
+}
+
+# M2M resource servers acting in the consent ceremony: psd2-service validates a
+# consent before serving an AIS/PIS call (consent.read / consent.validate), and
+# the SCA completion callback activates or rejects a PENDING_SCA consent
+# (consent.activate / consent.reject). Deliberately narrow: consent.grant and
+# consent.revoke are otherwise NOT granted to M2M clients — those originate from a human
+# channel (customer or operator), mirroring edge-service-notification's stance
+# that a blanket SERVICE allow would open every @Authorize endpoint to any
+# M2M client (the narrow, grantee-scoped exception below is the sanctioned deviation —
+# ADR-0206 — not a reopening of that blanket-allow question). This is also why
+# consent.activate stays OUT of four_eyes.verbs (rules.yaml) despite being a
+# risk-relevant action — see that file's guardrail note (issue #938 follow-up).
+#
+# NOTE (found post-merge, issue tracked separately): AuthorizeInterceptor never
+# emits principal.type == "SERVICE" — M2M callers authenticate via Keycloak
+# client_credentials JWTs, which the interceptor classifies as HUMAN. Nearly
+# every backend service (psd2-service, sca-service included) shares ONE
+# Keycloak client `openbank-services`, whose service-account identity is
+# `service-account-openbank-services` — gate on that identity instead of a
+# type/role that never fires. This means psd2-service and sca-service (and any
+# other `openbank-services`-client caller) are NOT distinguishable from each
+# other at this layer — this rule grants the listed actions to ANY backend
+# service using that shared client, not just the two verified callers.
+allowed_reasons contains "service-consent-m2m" if {
+	input.principal.type == "HUMAN"
+	input.principal.id == "service-account-openbank-services"
+	input.action in {"consent.read", "consent.validate", "consent.activate", "consent.reject"}
+}
+
+# ADR-0206: narrow, resource-scoped exception to the "M2M never grants/revokes" stance above.
+# party-service forwards the mobile app's marketing-consent toggle here (ADR-0198/ADR-0205) —
+# it authenticates via the SAME shared M2M client as every other backend service, so this rule
+# cannot distinguish party-service from any other `openbank-services` caller by identity alone.
+# It instead scopes by RESOURCE: AuthorizeInterceptor's dotted-path extraction
+# (ADR-0206 D1, `#request.granteeId` on create / `#granteeId` on revoke) binds
+# input.resource.id to the request's own granteeId field, and this rule only fires when that
+# equals the one fixed grantee party-service's forwarder uses. Any other `openbank-services`
+# caller — or party-service itself, for any OTHER granteeId — still falls through to deny,
+# same as before this rule existed. ConsentService.revokeConsent additionally cross-checks the
+# passed granteeId against the loaded consent's actual granteeId before revoking (defense in
+# depth: the OPA decision alone can't see the DB row on this action, and — see rules.yaml's
+# openbank-consent-service guardrail note — AUTHZ_FOUR_EYES_ENFORCE is false for this service
+# today, so this M2M path isn't paused pending a second human approver; revisit before ever
+# flipping that flag here).
+allowed_reasons contains "service-consent-m2m-marketing" if {
+	input.principal.type == "HUMAN"
+	input.principal.id == "service-account-openbank-services"
+	input.action in {"consent.grant", "consent.revoke"}
+	input.resource.id == "party-service:marketing-comms"
+}

--- a/openbank-infra/gitops/components/consent/consent_rest_ext_test.rego
+++ b/openbank-infra/gitops/components/consent/consent_rest_ext_test.rego
@@ -1,0 +1,110 @@
+# SPDX-License-Identifier: Apache-2.0
+# Unit tests for consent_rest_ext.rego (ADR-0206).
+#
+# Run EXPLICITLY by file (the sibling *-opa-bundle.yaml is not valid rego, and `opa test <dir>`
+# would try to load it as data and die with a merge error):
+#   opa test openbank-libs/governance/policies/rest.rego \
+#            openbank-infra/gitops/components/consent/consent_rest_ext.rego \
+#            openbank-infra/gitops/components/consent/consent_rest_ext_test.rego
+#
+# Do NOT add another service's *_rest_ext.rego to the same invocation: they all extend the
+# same package and would cross-contaminate allowed_reasons (issue #1797 follow-up 2).
+
+package openbank.rest
+
+import rego.v1
+
+operator := {"type": "HUMAN", "id": "u-op", "roles": ["ROLE_OPERATOR"]}
+
+admin := {"type": "HUMAN", "id": "u-admin", "roles": ["ROLE_ADMIN"]}
+
+viewer := {"type": "HUMAN", "id": "u-view", "roles": ["ROLE_VIEWER"]}
+
+# The shared M2M identity — classified HUMAN, carries ROLE_OPERATOR (openbank-realm.json). This
+# is the exact regression consent_rest_ext.rego had until ADR-0206 D5's fix: operator-consent-write
+# was role-only, so this identity could call ANY consent.* action unconditionally despite the
+# rule's own header comment claiming consent.grant/consent.revoke were M2M-unreachable.
+services_m2m := {"type": "HUMAN", "id": "service-account-openbank-services", "roles": ["ROLE_OPERATOR"]}
+
+marketing_resource := {"type": "consent", "id": "party-service:marketing-comms"}
+
+other_resource := {"type": "consent", "id": "some-other-tpp"}
+
+# --- operators/admins: unrestricted, as before ---
+
+test_operator_grants_consent if {
+	"operator-consent-write" in allowed_reasons with input as {"principal": operator, "action": "consent.grant"}
+}
+
+test_admin_revokes_consent if {
+	"operator-consent-write" in allowed_reasons with input as {"principal": admin, "action": "consent.revoke"}
+}
+
+test_viewer_cannot_grant_consent if {
+	count(allowed_reasons) == 0 with input as {"principal": viewer, "action": "consent.grant"}
+}
+
+# --- the regression: shared M2M identity must NOT ride operator-consent-write ---
+
+test_services_m2m_cannot_grant_via_operator_rule if {
+	not "operator-consent-write" in allowed_reasons with input as {"principal": services_m2m, "action": "consent.grant"}
+}
+
+test_services_m2m_cannot_revoke_via_operator_rule if {
+	not "operator-consent-write" in allowed_reasons
+		with input as {"principal": services_m2m, "action": "consent.revoke"}
+}
+
+test_services_m2m_cannot_grant_arbitrary_grantee if {
+	count(allowed_reasons) == 0 with input as {
+		"principal": services_m2m,
+		"action": "consent.grant",
+		"resource": other_resource,
+	}
+}
+
+test_services_m2m_cannot_revoke_arbitrary_grantee if {
+	count(allowed_reasons) == 0 with input as {
+		"principal": services_m2m,
+		"action": "consent.revoke",
+		"resource": other_resource,
+	}
+}
+
+test_services_m2m_cannot_grant_with_no_resource if {
+	count(allowed_reasons) == 0 with input as {"principal": services_m2m, "action": "consent.grant"}
+}
+
+# --- the sanctioned exception: scoped to the marketing grantee only (ADR-0206 D2) ---
+
+test_services_m2m_grants_marketing_consent if {
+	"service-consent-m2m-marketing" in allowed_reasons with input as {
+		"principal": services_m2m,
+		"action": "consent.grant",
+		"resource": marketing_resource,
+	}
+}
+
+test_services_m2m_revokes_marketing_consent if {
+	"service-consent-m2m-marketing" in allowed_reasons with input as {
+		"principal": services_m2m,
+		"action": "consent.revoke",
+		"resource": marketing_resource,
+	}
+}
+
+# --- unaffected M2M actions (unchanged by this fix) ---
+
+test_services_m2m_reads_consent if {
+	"service-consent-m2m" in allowed_reasons with input as {"principal": services_m2m, "action": "consent.read"}
+}
+
+test_services_m2m_activates_consent if {
+	"service-consent-m2m" in allowed_reasons with input as {"principal": services_m2m, "action": "consent.activate"}
+}
+
+# --- operators are still unrestricted for every other consent.* action ---
+
+test_operator_lists_consents if {
+	"operator-consent-write" in allowed_reasons with input as {"principal": operator, "action": "consent.list"}
+}

--- a/openbank-infra/gitops/components/consent/gen-consent-opa-bundle.sh
+++ b/openbank-infra/gitops/components/consent/gen-consent-opa-bundle.sh
@@ -3,114 +3,18 @@ set -euo pipefail
 REPO="$(git rev-parse --show-toplevel)"
 
 REST_REGO=$REPO/openbank-libs/governance/policies/rest.rego
+CONSENT_REST_EXT=$REPO/openbank-infra/gitops/components/consent/consent_rest_ext.rego
 AGENTS_REGO=$REPO/openbank-infra/opa/policies/agents.rego
 AGENTS_YAML=$REPO/openbank-libs/governance/agents.yaml
 RULES_YAML=$REPO/openbank-libs/governance/rules.yaml
 MANIFEST=$REPO/openbank-infra/opa/bundle.manifest
 
-# Consent REST extension — consent lifecycle allow reasons (ADR-0126 D5, issue #263)
-CONSENT_REST_EXT=$(cat << 'REGO'
-# SPDX-License-Identifier: Apache-2.0
-# Consent-service REST extension (ADR-0034 Phase 5, ADR-0126 D5, issue #263).
-# Extends openbank.rest with consent-domain allow reasons.
-# Mounted alongside rest.rego in the same OPA bundle — OPA merges same-package rules.
-#
-# Actions gated (ConsentResource):
-#   consent.grant     — create (PENDING_SCA); operator console / onboarding flows (renamed from
-#                       consent.create, issue #938 follow-up: "grant" is a distinctive four-eyes
-#                       verb, so it cannot silently gate every OTHER money-path service's
-#                       unrelated `.create` action fleet-wide); four-eyes gated. ALSO grantable by
-#                       the shared M2M principal, but ONLY for grantee=party-service:marketing-comms
-#                       (ADR-0206) — see service-consent-m2m-marketing below.
-#   consent.read      — getById
-#   consent.list      — listByParty (#partyId), listByGrantee (#granteeId)
-#   consent.revoke    — revoke (DELETE); four-eyes gated (operator-initiated denial of a
-#                       customer's active consent, rules.yaml four_eyes.verbs). Same M2M exception
-#                       as consent.grant above (ADR-0206), same grantee restriction.
-#   consent.activate  — activate after SCA challenge completes. Deliberately NOT four-eyes
-#                       gated (issue #938 follow-up): the M2M grant below already reserves this
-#                       action for a possible SCA-completion-callback caller — four_eyes_required
-#                       has no awareness of caller identity, so gating it would risk pausing that
-#                       automated flow too, not just a risky operator-console path.
-#   consent.reject    — reject (customer cancelled SCA)
-#   consent.validate  — validate scope/account coverage (resource servers)
-#
-# Actions gated (ApprovalResource, ADR-0155):
-#   consent.approval.decide — a DIFFERENT operator decides a paused consent.grant /
-#                             consent.revoke request (#id)
-#
-# Base rest.rego already grants: operator-read-any / compliance-read-any for
-# consent.read + consent.list, and party-self-service for consent.list when the
-# JWT sub equals the {partyId}/{granteeId} path parameter.
-
-package openbank.rest
-
-import rego.v1
-
-# Operators and admins may perform ANY consent lifecycle operation — the ops
-# console path (create on behalf of a party, revoke, resolve a stuck PENDING_SCA).
-allowed_reasons contains "operator-consent-write" if {
-	input.principal.type == "HUMAN"
-	some role in {"ROLE_OPERATOR", "ROLE_ADMIN"}
-	role in input.principal.roles
-	startswith(input.action, "consent.")
-}
-
-# M2M resource servers acting in the consent ceremony: psd2-service validates a
-# consent before serving an AIS/PIS call (consent.read / consent.validate), and
-# the SCA completion callback activates or rejects a PENDING_SCA consent
-# (consent.activate / consent.reject). Deliberately narrow: consent.grant and
-# consent.revoke are otherwise NOT granted to M2M clients — those originate from a human
-# channel (customer or operator), mirroring edge-service-notification's stance
-# that a blanket SERVICE allow would open every @Authorize endpoint to any
-# M2M client (the narrow, grantee-scoped exception below is the sanctioned deviation —
-# ADR-0206 — not a reopening of that blanket-allow question). This is also why
-# consent.activate stays OUT of four_eyes.verbs (rules.yaml) despite being a
-# risk-relevant action — see that file's guardrail note (issue #938 follow-up).
-#
-# NOTE (found post-merge, issue tracked separately): AuthorizeInterceptor never
-# emits principal.type == "SERVICE" — M2M callers authenticate via Keycloak
-# client_credentials JWTs, which the interceptor classifies as HUMAN. Nearly
-# every backend service (psd2-service, sca-service included) shares ONE
-# Keycloak client `openbank-services`, whose service-account identity is
-# `service-account-openbank-services` — gate on that identity instead of a
-# type/role that never fires. This means psd2-service and sca-service (and any
-# other `openbank-services`-client caller) are NOT distinguishable from each
-# other at this layer — this rule grants the listed actions to ANY backend
-# service using that shared client, not just the two verified callers.
-allowed_reasons contains "service-consent-m2m" if {
-	input.principal.type == "HUMAN"
-	input.principal.id == "service-account-openbank-services"
-	input.action in {"consent.read", "consent.validate", "consent.activate", "consent.reject"}
-}
-
-# ADR-0206: narrow, resource-scoped exception to the "M2M never grants/revokes" stance above.
-# party-service forwards the mobile app's marketing-consent toggle here (ADR-0198/ADR-0205) —
-# it authenticates via the SAME shared M2M client as every other backend service, so this rule
-# cannot distinguish party-service from any other `openbank-services` caller by identity alone.
-# It instead scopes by RESOURCE: AuthorizeInterceptor's dotted-path extraction
-# (ADR-0206 D1, `#request.granteeId` on create / `#granteeId` on revoke) binds
-# input.resource.id to the request's own granteeId field, and this rule only fires when that
-# equals the one fixed grantee party-service's forwarder uses. Any other `openbank-services`
-# caller — or party-service itself, for any OTHER granteeId — still falls through to deny,
-# same as before this rule existed. ConsentService.revokeConsent additionally cross-checks the
-# passed granteeId against the loaded consent's actual granteeId before revoking (defense in
-# depth: the OPA decision alone can't see the DB row on this action, and — see rules.yaml's
-# openbank-consent-service guardrail note — AUTHZ_FOUR_EYES_ENFORCE is false for this service
-# today, so this M2M path isn't paused pending a second human approver; revisit before ever
-# flipping that flag here).
-allowed_reasons contains "service-consent-m2m-marketing" if {
-	input.principal.type == "HUMAN"
-	input.principal.id == "service-account-openbank-services"
-	input.action in {"consent.grant", "consent.revoke"}
-	input.resource.id == "party-service:marketing-comms"
-}
-REGO
-)
-
+# Extracted to a standalone consent_rest_ext.rego (matches kyc/psd2/aml's convention) so
+# `opa test` can run it directly — ADR-0206 D5 added consent_rest_ext_test.rego, which needs a
+# real file to load, not a heredoc trapped inside this script.
 CHECKSUM=$(printf '%s\n' \
     "$(cat "$REST_REGO")" \
-    "$(echo "$CONSENT_REST_EXT")" \
+    "$(cat "$CONSENT_REST_EXT")" \
     "$(cat "$AGENTS_REGO")" \
     "$(cat "$AGENTS_YAML")" \
     "$(cat "$RULES_YAML")" \
@@ -136,7 +40,7 @@ OUT=$REPO/openbank-infra/gitops/components/consent/consent-opa-bundle.yaml
   echo "  rest.rego: |"
   sed 's/^/    /' "$REST_REGO" | sed 's/[[:space:]]*$//'
   echo "  consent_rest_ext.rego: |"
-  echo "$CONSENT_REST_EXT" | sed 's/^/    /' | sed 's/[[:space:]]*$//'
+  sed 's/^/    /' "$CONSENT_REST_EXT" | sed 's/[[:space:]]*$//'
   echo "  agents.rego: |"
   sed 's/^/    /' "$AGENTS_REGO" | sed 's/[[:space:]]*$//'
   echo "  agents-data.yaml: |"


### PR DESCRIPTION
## Summary
- `operator-consent-write` granted ANY `consent.*` action to any `HUMAN` principal carrying `ROLE_OPERATOR`/`ROLE_ADMIN`. The shared M2M Keycloak client `openbank-services` (used by nearly every backend service) has a service-account carrying `ROLE_OPERATOR`, so this role-only rule let any such caller grant/revoke ANY party's consent, unconditionally — found while wiring ADR-0206's grantee-scoped M2M rule for party-service's marketing-consent forwarder.
- Excludes the shared M2M identity (`service-account-openbank-services`) from `operator-consent-write` by `principal.id`, matching `rules.yaml`'s own existing guardrail against this exact anti-pattern.
- M2M access to `consent.grant`/`consent.revoke` remains available exclusively through the grantee-scoped `service-consent-m2m-marketing` rule (ADR-0206), unaffected by this change. `consent.read`/`consent.validate`/`consent.activate`/`consent.reject` (`service-consent-m2m`) are also unaffected.
- Extracts the previously heredoc-embedded rego into a standalone `consent_rest_ext.rego` (matching kyc/psd2/aml's convention) so the new `consent_rest_ext_test.rego` can run with `opa test` — this policy had no test coverage before.

## Test plan
- [x] `opa test` — 13/13 new tests pass, including the exact regression (M2M cannot grant/revoke for an arbitrary grantee, or without a resource, via the operator rule)
- [x] Verified the regression tests actually catch the bug: ran them against the pre-fix rule — 5/13 fail
- [x] Confirmed no in-repo M2M caller relies on `operator-consent-write` for an action not already covered by `service-consent-m2m`/`service-consent-m2m-marketing` (psd2-service's `ConsentServiceRestClient` only calls `consent.read`/`consent.validate`)

N/A — found and fixed during ADR-0206 D5 implementation; not tracked by a separate backlog issue.

🤖 Generated with [Claude Code](https://claude.com/claude-code)