### PR TITLE
test(mcp): assert WHICH PolicyDecisionPoint a test JVM binds, and make the stub win by declaration

### DIFF
--- a/openbank-mcp-service/src/main/kotlin/com/openbank/mcp/infrastructure/authz/AuthzProducer.kt
+++ b/openbank-mcp-service/src/main/kotlin/com/openbank/mcp/infrastructure/authz/AuthzProducer.kt
@@ -5,6 +5,7 @@
 
 import com.openbank.libs.authz.OpaSidecarPolicyDecisionPoint
 import com.openbank.libs.authz.PolicyDecisionPoint
+import io.quarkus.arc.DefaultBean
 import jakarta.enterprise.context.ApplicationScoped
 import jakarta.enterprise.inject.Produces
 import org.eclipse.microprofile.config.inject.ConfigProperty
@@ -21,8 +22,18 @@ class AuthzProducer {
     @ConfigProperty(name = "opa.timeout-ms", defaultValue = "500")
     var opaTimeoutMs: Long = DEFAULT_OPA_TIMEOUT_MS
 
+    /**
+     * `@DefaultBean` so a test JVM can displace this UNCONDITIONALLY (#2494). Without it the only
+     * thing keeping the real sidecar client out of a `@QuarkusTest` is alternative-vs-producer
+     * resolution precedence — which does hold today, but is precedence nobody declared and nothing
+     * asserts, and the failure when it stops holding is a bootstrap timeout against
+     * `localhost:8181` rather than anything that names a bean. Same shape as
+     * `openbank-agent-service`'s `DenyByDefaultPolicyDecisionPoint`. `PdpBeanSelectionIT` asserts
+     * the resulting binding by type.
+     */
     @Produces
     @ApplicationScoped
+    @DefaultBean
     fun policyDecisionPoint(): PolicyDecisionPoint = OpaSidecarPolicyDecisionPoint(
         baseUrl = opaUrl,
         queryPath = opaPath,

--- a/openbank-mcp-service/src/test/kotlin/com/openbank/mcp/PdpBeanSelectionIT.kt
+++ b/openbank-mcp-service/src/test/kotlin/com/openbank/mcp/PdpBeanSelectionIT.kt
@@ -1,0 +1,40 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+// Copyright (c) OpenBank contributors. Licensed under the GNU Affero General Public License v3.0 only.
+package com.openbank.mcp
+
+import com.openbank.libs.authz.PolicyDecisionPoint
+import io.quarkus.arc.ClientProxy
+import io.quarkus.test.junit.QuarkusTest
+import jakarta.inject.Inject
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.Test
+
+/**
+ * Asserts WHICH `PolicyDecisionPoint` the container actually bound in a test JVM — the one thing a
+ * green ALLOW assertion cannot tell you (#2494).
+ *
+ * `McpAuditEventIT`'s ALLOW case is consistent with two different worlds: the test stub is bound, or
+ * the real `OpaSidecarPolicyDecisionPoint` is bound and something reachable on `localhost:8181`
+ * happens to answer. Both are green. That ambiguity is the entire reported defect, and it cannot be
+ * resolved by any assertion about a decision — only by an assertion about the BOUND TYPE. So this
+ * makes the binding itself the thing under test: if a future change to `AuthzProducer`, to the
+ * alternative's `@Priority`, or to Quarkus' resolution order ever hands the test JVM the real
+ * sidecar client, this goes red immediately and by name, instead of turning `McpAuditEventIT` into a
+ * mystery timeout on whichever runner happens to be loaded.
+ */
+@QuarkusTest
+class PdpBeanSelectionIT {
+
+    @Inject
+    lateinit var pdp: PolicyDecisionPoint
+
+    @Test
+    fun `the test JVM binds the deterministic PDP stub, never the real OPA sidecar client`() {
+        assertThat(ClientProxy.unwrap(pdp))
+            .describedAs(
+                "the test JVM must resolve the @Alternative stub; binding the real sidecar client " +
+                    "makes every ALLOW assertion depend on whatever is listening on localhost:8181",
+            )
+            .isInstanceOf(TestPolicyDecisionPoint::class.java)
+    }
+}


### PR DESCRIPTION
## Refs #2494 — partial, and it corrects that issue's premise

**Partial, not `Closes`**: #2494 asks to "wire a reachable PDP" because none exists. One does, and has since #2222 — so the requested work is not the work. What this PR does instead is remove the *ambiguity* that made the report plausible, and I left the issue open with a comment carrying the corrected root cause so the next reader does not repeat the bad grep.

### What #2494 actually got wrong

- `openbank-mcp-service/src/test/kotlin/com/openbank/mcp/TestPolicyDecisionPoint.kt` is an `@Alternative @Priority(1)` `PolicyDecisionPoint` that allows `list_accounts` and denies everything else. It landed **with** the test in #2222, so it predates the report. The issue's grep (`ToolPolicyPort|OpaToolGate|opa\.`) misses it because none of those three names is what this service calls the port — the #2291 failure class, searching for the guessed name instead of the artifact.
- The full suite passes on a host with nothing listening on `:8181`. So the result does not depend on "whichever machine happened to have some other reachable OPA process nearby".
- `PDP error authorizing list_accounts: PDP down — denying` is not emitted by this IT at all. `"PDP down"` occurs in exactly two places in the tree, both `error("PDP down")` inside a test's own deliberate throwing fake — `McpEndpointTest.kt:345` (same module, plain unit test) and `Ap2VerifyEndpointTest.kt:83`. Expected output, interleaved in the same Gradle log.
- What is left of the report is the real stack: `RuntimeException at QuarkusTestExtension.java:668` ← `mutiny.TimeoutException at UniBlockingAwait.java:65` — a Quarkus **bootstrap** timeout, before any test body runs. Resource starvation on a loaded runner. Cross-referenced to #2330.

### What is genuinely worth fixing, and is fixed here

A green ALLOW assertion is consistent with *both* the correct binding and the broken one. Verifying this area by "the ALLOW test is green" is the vacuous check that let the ambiguity stand — so neither change below is verified that way.

1. **`PdpBeanSelectionIT`** — injects `PolicyDecisionPoint`, unwraps the client proxy, asserts it **is** `TestPolicyDecisionPoint`. The binding itself becomes the thing under test. If a future change to `AuthzProducer`, to the alternative's priority, or to Quarkus' resolution order ever hands the test JVM the real sidecar client, this goes red *by name* rather than as a mystery timeout.
2. **`@DefaultBean` on `AuthzProducer.policyDecisionPoint()`** — mirroring `openbank-agent-service`'s `DenyByDefaultPolicyDecisionPoint`, the pattern already in the fleet. Today the stub wins on alternative-vs-producer resolution precedence. That precedence holds, but nobody declared it and nothing asserted it, and the failure mode when it stops holding is a bootstrap timeout against `localhost:8181` that names no bean. `@DefaultBean` makes the displacement unconditional.

### Falsification — both greens were tested against a case they must flag

| experiment | expectation | result |
|---|---|---|
| drop `@ApplicationScoped` from the stub, so the producer must bind | `PdpBeanSelectionIT` RED | **FAILED**, for the stated reason — the assertion is load-bearing, not decorative |
| drop `@Alternative` + `@Priority(1)` from the stub, keeping `@DefaultBean` | still GREEN — the guarantee no longer rests on undeclared precedence | **PASSED** |
| same edit on unmodified `main` (no `@DefaultBean`) | `McpAuditEventIT` ALLOW + DENY RED | **FAILED**, confirming the stub is what keeps them green |

### Gate

`:openbank-mcp-service:detekt ktlintCheck test quarkusBuild` — BUILD SUCCESSFUL. `quarkusBuild` included deliberately: `@DefaultBean` is a bean-resolution change and ArC failures surface nowhere else.

No production behaviour changes: `@DefaultBean` is inert when nothing displaces the producer, which is the case in every deployed profile.

🤖 Generated with [Claude Code](https://claude.com/claude-code)