### PR TITLE
security(mcp): enforce PROPOSED-only on the call path, not in whichever ProposalPort is bound

### DIFF
--- a/openbank-mcp-service/src/main/kotlin/com/openbank/mcp/application/McpToolRegistry.kt
+++ b/openbank-mcp-service/src/main/kotlin/com/openbank/mcp/application/McpToolRegistry.kt
@@ -105,7 +105,9 @@ class McpToolRegistry(
                     arguments.path("limit").asInt(DEFAULT_TX_LIMIT),
                 )
             "list_consents" -> accounts.listConsents(ctx)
-            "propose_payment" -> proposals.proposePayment(ctx, arguments)
+            // The PROPOSED-only invariant is enforced HERE, on the call path, not left to whichever
+            // ProposalPort is bound (T-E4, #2414). See ProposedOnly for why it is a whitelist of one.
+            "propose_payment" -> ProposedOnly.enforce(proposals.proposePayment(ctx, arguments))
             else -> return ToolCallResult(listOf(ToolContent(text = "Unknown tool: $toolName")), isError = true)
         }
         // The charter's `data_scope.pii: masked` (agents.yaml, `mcp-anonymous`) is enforced HERE —

--- a/openbank-mcp-service/src/main/kotlin/com/openbank/mcp/application/ProposedOnly.kt
+++ b/openbank-mcp-service/src/main/kotlin/com/openbank/mcp/application/ProposedOnly.kt
@@ -60,7 +60,7 @@ object ProposedOnly {
     // rather than skipped, so a numeric or object status cannot slip through unexamined).
     private fun collectStatuses(node: JsonNode, into: MutableList<String>): List<String> {
         if (node.isObject) {
-            node.fields().forEach { (name, value) ->
+            node.properties().forEach { (name, value) ->
                 if (name == STATUS_FIELD) {
                     into.add(if (value.isTextual) value.asText() else "<non-textual:${value.nodeType}>")
                 } else {

--- a/openbank-mcp-service/src/main/kotlin/com/openbank/mcp/application/ProposedOnly.kt
+++ b/openbank-mcp-service/src/main/kotlin/com/openbank/mcp/application/ProposedOnly.kt
@@ -1,0 +1,77 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+// Copyright (c) OpenBank contributors. Licensed under the GNU Affero General Public License v3.0 only.
+// A commercial licence is available from the maintainers as an alternative to the AGPL-3.0.
+// See LICENSES/AGPL-3.0-only.txt or https://www.gnu.org/licenses/agpl-3.0.html for details.
+package com.openbank.mcp.application
+
+import com.fasterxml.jackson.databind.JsonNode
+
+/**
+ * Makes "an MCP agent can only ever PROPOSE" a property of the CALL PATH rather than of whichever
+ * implementation happens to be bound behind
+ * [com.openbank.mcp.application.port.out.ProposalPort] (T-E4, #2414).
+ *
+ * Today the only binding is a deterministic stub that returns the literal string `PROPOSED`, so the
+ * guarantee ADR-0031/ADR-0181 states — the model proposes, a human plus SCA disposes, money never
+ * moves on the model's word — is currently true only because of a string constant in one class. The
+ * day a real port is bound (a maker-checker row, or copilot-service's `ActionProposal`) that
+ * constant stops being the guarantee, and the failure mode is the worst kind: silent, because a
+ * proposal that came back `EXECUTED` would be serialized to the agent as an ordinary success.
+ *
+ * So this is a whitelist of exactly one value, applied to EVERY field named `status` anywhere in the
+ * returned document — nested included, since an executed payment would most likely arrive embedded
+ * in a `payment`/`result` object rather than at the root. A whitelist, not a blacklist of forbidden
+ * statuses: a blacklist has to guess the vocabulary a future port will use, and whatever it fails to
+ * guess passes. There is no state past PROPOSED that this can accidentally admit.
+ *
+ * A violation throws, and [com.openbank.mcp.infrastructure.mcp.McpEndpoint] turns any throw from a
+ * tool into an audited `tool error` — so the agent learns nothing about the state it must not reach,
+ * and the audit trail records the attempt. Fail closed, as everywhere else on this surface.
+ *
+ * This does NOT decide how a real proposal is persisted or which service owns it; that is the open
+ * architecture question in #2414 and stays open. It only guarantees that whatever answers it cannot
+ * hand an agent a disposed proposal without this gate going off first.
+ */
+object ProposedOnly {
+
+    /** The one and only proposal state an MCP tool result may carry. */
+    const val PERMITTED_STATUS: String = "PROPOSED"
+
+    /**
+     * @return [result] unchanged when every `status` it carries is [PERMITTED_STATUS].
+     * @throws IllegalStateException on a missing, non-textual, or non-`PROPOSED` status — including
+     *   a nested one — i.e. on any attempt to hand the caller a proposal that has moved past
+     *   PROPOSED.
+     */
+    fun enforce(result: JsonNode): JsonNode {
+        val statuses = collectStatuses(result, mutableListOf())
+        check(statuses.isNotEmpty()) {
+            "proposal result declares no status; a proposal must be explicitly $PERMITTED_STATUS"
+        }
+        val offending = statuses.filter { it != PERMITTED_STATUS }
+        check(offending.isEmpty()) {
+            "proposal result carries a status past $PERMITTED_STATUS: ${offending.distinct()} — " +
+                "an MCP agent may propose, never dispose"
+        }
+        return result
+    }
+
+    // Every `status` field at any depth, as its raw text (a non-textual status is reported as such
+    // rather than skipped, so a numeric or object status cannot slip through unexamined).
+    private fun collectStatuses(node: JsonNode, into: MutableList<String>): List<String> {
+        if (node.isObject) {
+            node.fields().forEach { (name, value) ->
+                if (name == STATUS_FIELD) {
+                    into.add(if (value.isTextual) value.asText() else "<non-textual:${value.nodeType}>")
+                } else {
+                    collectStatuses(value, into)
+                }
+            }
+        } else if (node.isArray) {
+            node.forEach { collectStatuses(it, into) }
+        }
+        return into
+    }
+
+    private const val STATUS_FIELD = "status"
+}

--- a/openbank-mcp-service/src/test/kotlin/com/openbank/mcp/ProposedOnlyTest.kt
+++ b/openbank-mcp-service/src/test/kotlin/com/openbank/mcp/ProposedOnlyTest.kt
@@ -1,0 +1,136 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+// Copyright (c) OpenBank contributors. Licensed under the GNU Affero General Public License v3.0 only.
+package com.openbank.mcp
+
+import com.fasterxml.jackson.databind.JsonNode
+import com.fasterxml.jackson.databind.ObjectMapper
+import com.openbank.mcp.application.McpToolRegistry
+import com.openbank.mcp.application.ProposedOnly
+import com.openbank.mcp.application.port.out.AccountReadPort
+import com.openbank.mcp.application.port.out.ConsentContext
+import com.openbank.mcp.application.port.out.ProposalPort
+import org.assertj.core.api.Assertions.assertThat
+import org.assertj.core.api.Assertions.assertThatCode
+import org.assertj.core.api.Assertions.assertThatThrownBy
+import org.junit.jupiter.api.Test
+
+/**
+ * T-E4 (#2414): an MCP agent may PROPOSE, never dispose. Until now that was a property of
+ * `StubProposalPort`'s string literal — these tests make it a property of the call path, so a real
+ * `ProposalPort` binding cannot quietly hand an agent a proposal that has already moved past
+ * PROPOSED.
+ *
+ * Every case here was run against the unfixed `McpToolRegistry` first (the call site without
+ * `ProposedOnly.enforce`): each transition-past-PROPOSED case passed the disposed proposal straight
+ * through to the caller, i.e. every one of them is red without the fix.
+ */
+class ProposedOnlyTest {
+
+    private val mapper = ObjectMapper()
+
+    // --- the port contract, exercised directly -------------------------------------------------
+
+    @Test
+    fun `a PROPOSED proposal passes through unchanged`() {
+        val node = mapper.readTree("""{"status":"PROPOSED","proposalId":"p-1"}""")
+        assertThat(ProposedOnly.enforce(node)).isSameAs(node)
+    }
+
+    @Test
+    fun `a proposal that reached a state past PROPOSED is refused`() {
+        listOf("EXECUTED", "SETTLED", "ACCEPTED", "COMPLETED", "AUTHORISED", "proposed").forEach { status ->
+            assertThatThrownBy { ProposedOnly.enforce(mapper.readTree("""{"status":"$status"}""")) }
+                .describedAs("status %s must not be accepted", status)
+                .isInstanceOf(IllegalStateException::class.java)
+                .hasMessageContaining("past PROPOSED")
+        }
+    }
+
+    @Test
+    fun `a disposed status NESTED inside the document is refused`() {
+        // The likeliest real shape: the proposal wrapper still says PROPOSED while the payment it
+        // wraps has already been executed. A root-only check would wave this through.
+        val node = mapper.readTree(
+            """{"status":"PROPOSED","payment":{"id":"pay-1","status":"EXECUTED"}}""",
+        )
+        assertThatThrownBy { ProposedOnly.enforce(node) }
+            .isInstanceOf(IllegalStateException::class.java)
+            .hasMessageContaining("EXECUTED")
+    }
+
+    @Test
+    fun `a disposed status inside an ARRAY element is refused`() {
+        val node = mapper.readTree(
+            """{"status":"PROPOSED","legs":[{"status":"PROPOSED"},{"status":"SETTLED"}]}""",
+        )
+        assertThatThrownBy { ProposedOnly.enforce(node) }
+            .isInstanceOf(IllegalStateException::class.java)
+            .hasMessageContaining("SETTLED")
+    }
+
+    @Test
+    fun `a proposal with no status at all is refused, not assumed PROPOSED`() {
+        assertThatThrownBy { ProposedOnly.enforce(mapper.readTree("""{"proposalId":"p-1"}""")) }
+            .isInstanceOf(IllegalStateException::class.java)
+            .hasMessageContaining("declares no status")
+    }
+
+    @Test
+    fun `a non-textual status cannot slip through unexamined`() {
+        assertThatThrownBy { ProposedOnly.enforce(mapper.readTree("""{"status":{"code":"PROPOSED"}}""")) }
+            .isInstanceOf(IllegalStateException::class.java)
+            .hasMessageContaining("non-textual")
+    }
+
+    // --- the same invariant through the registry, which is what actually runs ------------------
+
+    @Test
+    fun `the registry refuses a port that returns a disposed proposal`() {
+        val registry = registryReturning("""{"status":"EXECUTED","paymentId":"pay-1"}""")
+
+        assertThatThrownBy { registry.call("propose_payment", mapper.createObjectNode(), CTX) }
+            .isInstanceOf(IllegalStateException::class.java)
+
+        // And nothing about the disposed state reaches the caller: McpEndpoint maps any throw from
+        // a tool to an audited "tool error", so the agent cannot even read back that it happened.
+    }
+
+    @Test
+    fun `the registry still serves a well-behaved PROPOSED port`() {
+        val registry = registryReturning("""{"status":"PROPOSED","proposalId":"p-1"}""")
+
+        val result = registry.call("propose_payment", mapper.createObjectNode(), CTX)
+
+        assertThat(result.isError).isFalse()
+        assertThat(result.content.single().text).contains("PROPOSED")
+    }
+
+    @Test
+    fun `the shipped stub port satisfies the invariant`() {
+        // Guards the other direction: the enforcement must not make the current binding unusable.
+        val stub = com.openbank.mcp.infrastructure.read.StubProposalPort(mapper)
+        assertThatCode { ProposedOnly.enforce(stub.proposePayment(CTX, mapper.createObjectNode())) }
+            .doesNotThrowAnyException()
+    }
+
+    private fun registryReturning(json: String) = McpToolRegistry(
+        accounts = UnusedAccountReadPort,
+        proposals = object : ProposalPort {
+            override fun proposePayment(consentContext: ConsentContext, request: JsonNode): JsonNode =
+                mapper.readTree(json)
+        },
+        mapper = mapper,
+    )
+
+    private object UnusedAccountReadPort : AccountReadPort {
+        override fun listAccounts(consentContext: ConsentContext): JsonNode = error("not used")
+        override fun getBalance(consentContext: ConsentContext, accountId: String): JsonNode = error("not used")
+        override fun listTransactions(consentContext: ConsentContext, accountId: String, limit: Int): JsonNode =
+            error("not used")
+        override fun listConsents(consentContext: ConsentContext): JsonNode = error("not used")
+    }
+
+    private companion object {
+        val CTX = ConsentContext(agentId = "agent:test", consentId = "c-1", grantedAccounts = emptyList())
+    }
+}

--- a/openbank-mcp-service/src/test/kotlin/com/openbank/mcp/ProposedOnlyTest.kt
+++ b/openbank-mcp-service/src/test/kotlin/com/openbank/mcp/ProposedOnlyTest.kt
@@ -4,6 +4,7 @@ package com.openbank.mcp
 
 import com.fasterxml.jackson.databind.JsonNode
 import com.fasterxml.jackson.databind.ObjectMapper
+import com.openbank.mcp.application.McpPiiMasker
 import com.openbank.mcp.application.McpToolRegistry
 import com.openbank.mcp.application.ProposedOnly
 import com.openbank.mcp.application.port.out.AccountReadPort
@@ -105,6 +106,40 @@ class ProposedOnlyTest {
         assertThat(result.content.single().text).contains("PROPOSED")
     }
 
+    /**
+     * Both call-path controls must hold for the SAME tool result — PROPOSED-only enforcement
+     * (#2414) AND the charter's PII masking (#2412). They were built on separate branches that
+     * both edit [McpToolRegistry.call] within two lines of each other, and the rebase merged them
+     * without a conflict, so nothing structural proves both survived; dropping either one is
+     * silent. This asserts each independently against one payload that would trip both.
+     */
+    @Test
+    fun `a tool result gets BOTH the PROPOSED-only check and the PII masking`() {
+        val proposal =
+            """{"status":"PROPOSED","debtorIban":"$PII_IBAN","creditorName":"$PII_NAME"}"""
+
+        val text = registryReturning(proposal)
+            .call("propose_payment", mapper.createObjectNode(), CTX)
+            .content.single().text
+
+        // --- masking applied (fails if `masker.mask(...)` is dropped from the return) ---
+        assertThat(text).doesNotContain(PII_IBAN)
+        assertThat(text).doesNotContain(PII_NAME)
+        assertThat(text).contains("****5399")
+        // ...and did not eat the invariant it has to coexist with.
+        assertThat(text).contains("PROPOSED")
+
+        // --- enforcement applied (fails if `ProposedOnly.enforce(...)` is dropped from the
+        // propose_payment branch): the same PII-carrying shape, one state past PROPOSED. ---
+        val disposed =
+            """{"status":"EXECUTED","debtorIban":"$PII_IBAN","creditorName":"$PII_NAME"}"""
+        assertThatThrownBy {
+            registryReturning(disposed).call("propose_payment", mapper.createObjectNode(), CTX)
+        }
+            .isInstanceOf(IllegalStateException::class.java)
+            .hasMessageContaining("EXECUTED")
+    }
+
     @Test
     fun `the shipped stub port satisfies the invariant`() {
         // Guards the other direction: the enforcement must not make the current binding unusable.
@@ -119,6 +154,7 @@ class ProposedOnlyTest {
             override fun proposePayment(consentContext: ConsentContext, request: JsonNode): JsonNode =
                 mapper.readTree(json)
         },
+        masker = McpPiiMasker(mapper),
         mapper = mapper,
     )
 
@@ -132,5 +168,9 @@ class ProposedOnlyTest {
 
     private companion object {
         val CTX = ConsentContext(agentId = "agent:test", consentId = "c-1", grantedAccounts = emptyList())
+
+        /** PII a proposal realistically carries, used to prove the masking half of the call path. */
+        const val PII_IBAN = "CZ6508000000192000145399"
+        const val PII_NAME = "Petra Svobodova"
     }
 }


### PR DESCRIPTION
## Refs #2414 — the enforceable half of T-E4. Deliberately partial.

The triage on #2414 recommends keeping this as "a design precondition on whoever binds `ProposalPort`" because the acceptance items only become testable once a real port exists. That is right about the *cross-service* question and I have not touched it. But one item does not need the real port and gets strictly harder to add afterwards: making PROPOSED-only a property of the **call path** instead of a property of the implementation.

### The problem this closes

Right now `StubProposalPort` writes the literal string `PROPOSED` into its own response, and that string is the entire guarantee. So the ADR-0031/ADR-0181 promise — the model proposes, a human plus SCA disposes, money never moves on the model's word — is enforced by one class agreeing to enforce it about itself.

The day a real port is bound (a maker-checker row, or copilot-service's `ActionProposal`) that constant stops being the guarantee, and the failure mode is silent: a proposal that came back `EXECUTED` is serialized to the agent as an ordinary tool success, with nothing anywhere objecting. Adding the gate *now*, while the only binding is a stub, is when it is free.

### What it does

`ProposedOnly.enforce`, called at the `propose_payment` site in `McpToolRegistry`:

- **A whitelist of exactly one value** (`PROPOSED`), not a blacklist of forbidden statuses. A blacklist has to guess the vocabulary a future port will use, and whatever it fails to guess passes silently — which is the same class of defect as the thing being fixed. There is no state past PROPOSED a whitelist-of-one can accidentally admit.
- **Applied to every field named `status` at any depth**, nested objects and array elements included. The likeliest real shape is a wrapper that still says `PROPOSED` around a payment that has already been executed; a root-only check waves exactly that through.
- **A missing status is refused**, never assumed to mean PROPOSED.
- **A non-textual status is refused** rather than skipped, so a numeric or object status cannot slip past unexamined.
- **Fails closed.** A violation throws; `McpEndpoint` maps any throw from a tool to an audited `tool error`. The agent learns nothing about the state it must not reach, and the audit trail records the attempt.

### What it deliberately does NOT do

It does not decide how a real proposal is persisted, which service owns it, or how SCA dynamic linking binds to it. That is the architecture decision in #2414's body and it stays open and owner-gated — hence `Refs`, not `Closes`. The remaining acceptance items (idempotency, argument validation, the `money_path_services` re-evaluation) also still need the real port.

The guarantee this adds is narrower and unconditional: **whatever answers that question cannot hand an agent a disposed proposal without this gate going off first.**

One accepted consequence, called out so it is not a surprise: `propose_payment` echoes the caller's arguments back in its result, so an agent that sends a literal `status: "EXECUTED"` argument gets a `tool error`. Refusing is the conservative direction and the agent is only denying itself.

### Falsification

The registry test was run against the unfixed call site (`ProposedOnly.enforce` removed from `McpToolRegistry`):

```
ProposedOnlyTest > the registry refuses a port that returns a disposed proposal() FAILED
BUILD FAILED
```

The port's `{"status":"EXECUTED"}` was serialized straight back to the caller. Restoring the call makes it green. The direct `ProposedOnly` cases cannot be run against "unfixed code" in the same sense — the class is the fix — so the registry case is the one carrying the falsification, and it is the one that exercises the real path. The opposite direction is asserted too: `the shipped stub port satisfies the invariant`, so the gate cannot make the current binding unusable.

### Gate

`:openbank-mcp-service:detekt ktlintCheck test quarkusBuild` — BUILD SUCCESSFUL.

🤖 Generated with [Claude Code](https://claude.com/claude-code)