### PR TITLE
feat(party): forward marketing-consent toggle to consent-service (ADR-0198 D3, ADR-0206 D5)

### DIFF
--- a/openbank-party-service/src/main/kotlin/com/openbank/party/application/port/out/PartyPorts.kt
+++ b/openbank-party-service/src/main/kotlin/com/openbank/party/application/port/out/PartyPorts.kt
@@ -103,6 +103,34 @@ interface GdprAggregationPort {
     suspend fun fetchCardData(partyId: java.util.UUID): List<Map<String, Any?>>
 }
 
+/** consent-service refused or was unreachable — the toggle must not silently appear to succeed. */
+class MarketingConsentForwardingException(message: String, cause: Throwable? = null) :
+    RuntimeException(message, cause)
+
+/**
+ * Outbound port to consent-service for the marketing-consent forwarder (ADR-0198 D3, ADR-0205,
+ * ADR-0206 D5). Unlike [GdprAggregationPort] this is a WRITE, not a best-effort read — a failure
+ * here must propagate as [MarketingConsentForwardingException], never degrade silently, or the
+ * caller would believe a toggle succeeded when consent-service never recorded it.
+ *
+ * `parties.consent_marketing` itself is never written here — [MarketingConsentProjectionService]
+ * (ADR-0205 D4) is the sole writer, driven by consent-service's own outbox events, so the two
+ * paths can never race each other into a split brain.
+ */
+interface MarketingConsentForwardingPort {
+    /**
+     * Grants the fixed internal marketing consent for [partyId] (ADR-0205 D3's
+     * `party-service:marketing-comms` grantee, all three MARKETING_COMMS_* scopes). consent-service
+     * auto-activates it synchronously (ADR-0205 D1's GDPR_ONLY_SCOPES path) — returns the new
+     * consent's id, which [MarketingConsentTrackingRepository] does not yet know until the
+     * ConsentGranted event round-trips through Kafka.
+     */
+    suspend fun grant(partyId: java.util.UUID): java.util.UUID
+
+    /** Revokes [consentId] — must belong to [partyId] and the marketing grantee (server-checked). */
+    suspend fun revoke(partyId: java.util.UUID, consentId: java.util.UUID, reason: String)
+}
+
 /**
  * ADR-0179: account-ownership guard for the merge precondition.
  *

--- a/openbank-party-service/src/main/kotlin/com/openbank/party/application/usecase/PartyService.kt
+++ b/openbank-party-service/src/main/kotlin/com/openbank/party/application/usecase/PartyService.kt
@@ -46,6 +46,10 @@ class PartyService : PartyUseCase {
 
     @Inject lateinit var accountGuard: PartyAccountGuardPort
 
+    @Inject lateinit var marketingConsentForwarding: MarketingConsentForwardingPort
+
+    @Inject lateinit var marketingConsentTracking: MarketingConsentTrackingRepository
+
     @Inject lateinit var metrics: DomainMetrics
 
     @Inject lateinit var clock: Clock
@@ -101,16 +105,28 @@ class PartyService : PartyUseCase {
         return saved
     }
 
+    /**
+     * Forwards the toggle to consent-service (ADR-0198 D3, ADR-0206 D5) instead of writing
+     * `consentMarketing` here — [MarketingConsentProjectionService] (ADR-0205 D4) is the sole
+     * writer of that column, driven by consent-service's own ConsentGranted/Revoked events, so
+     * this path can never race it into a split brain. The returned [Party] reflects the caller's
+     * now-accepted intent optimistically (consent-service confirmed synchronously via ADR-0205
+     * D1's auto-activate path); the persisted row catches up asynchronously over Kafka, typically
+     * within milliseconds.
+     */
     override suspend fun updateMarketingConsent(cmd: UpdateMarketingConsentCommand): Party {
         val party = partyRepo.findById(cmd.id) ?: throw PartyNotFoundException(cmd.id)
-        val updated = party.copy(
-            consentMarketing = cmd.marketingConsent,
-            consentMarketingUpdatedAt = Instant.now(clock),
-            updatedAt = Instant.now(clock),
-        )
-        val saved = partyRepo.update(updated)
-        eventPublisher.publishPartyUpdated(saved)
-        return saved
+        if (cmd.marketingConsent) {
+            marketingConsentForwarding.grant(cmd.id)
+        } else {
+            val tracked = marketingConsentTracking.findByPartyId(cmd.id)
+            if (tracked != null) {
+                marketingConsentForwarding.revoke(cmd.id, tracked.consentId, "customer opted out")
+            }
+            // No tracked consent: already off from consent-service's point of view — nothing to
+            // revoke. Still returns the toggled-off Party below so the response matches intent.
+        }
+        return party.copy(consentMarketing = cmd.marketingConsent, consentMarketingUpdatedAt = Instant.now(clock))
     }
 
     /** Computes the RČ blind index when the pepper is configured and [taxId] is a valid Czech RČ. */

--- a/openbank-party-service/src/main/kotlin/com/openbank/party/infrastructure/client/GdprDownstreamClients.kt
+++ b/openbank-party-service/src/main/kotlin/com/openbank/party/infrastructure/client/GdprDownstreamClients.kt
@@ -6,13 +6,18 @@ package com.openbank.party.infrastructure.client
 
 import io.quarkus.oidc.client.reactive.filter.OidcClientRequestReactiveFilter
 import io.smallrye.mutiny.Uni
+import jakarta.ws.rs.Consumes
+import jakarta.ws.rs.DELETE
 import jakarta.ws.rs.GET
+import jakarta.ws.rs.POST
 import jakarta.ws.rs.Path
 import jakarta.ws.rs.PathParam
 import jakarta.ws.rs.Produces
+import jakarta.ws.rs.QueryParam
 import jakarta.ws.rs.core.MediaType
 import org.eclipse.microprofile.rest.client.annotation.RegisterProvider
 import org.eclipse.microprofile.rest.client.inject.RegisterRestClient
+import java.time.OffsetDateTime
 import java.util.UUID
 
 /**
@@ -50,4 +55,56 @@ interface CardServiceRestClient {
     @GET
     @Path("/party/{partyId}")
     fun listByParty(@PathParam("partyId") partyId: UUID): Uni<List<Map<String, Any?>>>
+}
+
+/**
+ * Request/response shapes mirror consent-service's own `ConsentDtos.kt` structurally — this is a
+ * separate Gradle module with no shared DTO dependency, so field names/types are kept in lockstep
+ * by convention (Jackson serializes/deserializes by shape, not class identity). `granteeType` and
+ * `scopes` are plain strings rather than consent-service's enums for the same reason; the values
+ * sent (`INTERNAL_SERVICE`, `MARKETING_COMMS_EMAIL`/`_PUSH`/`_INAPP`) must match those enums' names.
+ */
+data class CreateMarketingConsentRequest(
+    val partyId: UUID,
+    val granteeId: String,
+    val granteeType: String,
+    val granteeName: String,
+    val scopes: Set<String>,
+    val accountIbans: List<String>?,
+    val validTo: OffsetDateTime,
+    val redirectUri: String?,
+    val tppTransactionId: String?,
+)
+
+data class RevokeMarketingConsentRequest(val reason: String)
+
+/** Only the fields the forwarder actually needs from consent-service's ConsentResponse. */
+data class MarketingConsentResponse(val id: UUID, val status: String)
+
+/**
+ * Typed client for consent-service's consent lifecycle, used by the marketing-consent forwarder
+ * (ADR-0206 D5). Both calls are `@Authorize`-gated and scoped to grantee
+ * `party-service:marketing-comms` only (ADR-0206 D2) — this client's M2M identity is the same
+ * shared `openbank-services` client every other REST client in this file uses, so the grantee
+ * scoping in consent-service's OPA policy is what keeps this client from being able to
+ * grant/revoke any OTHER party's or grantee's consent.
+ */
+@RegisterRestClient(configKey = "consent-service")
+@RegisterProvider(OidcClientRequestReactiveFilter::class)
+@Path("/api/v1/consents")
+@Produces(MediaType.APPLICATION_JSON)
+@Consumes(MediaType.APPLICATION_JSON)
+interface ConsentServiceRestClient {
+
+    @POST
+    fun create(request: CreateMarketingConsentRequest): Uni<MarketingConsentResponse>
+
+    @DELETE
+    @Path("/{id}")
+    fun revoke(
+        @PathParam("id") id: UUID,
+        @QueryParam("partyId") partyId: UUID,
+        @QueryParam("granteeId") granteeId: String,
+        request: RevokeMarketingConsentRequest,
+    ): Uni<MarketingConsentResponse>
 }

--- a/openbank-party-service/src/main/kotlin/com/openbank/party/infrastructure/consent/MarketingConsentForwardingAdapter.kt
+++ b/openbank-party-service/src/main/kotlin/com/openbank/party/infrastructure/consent/MarketingConsentForwardingAdapter.kt
@@ -1,0 +1,71 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright (c) OpenBank contributors. Licensed under the Apache License, Version 2.0.
+// See LICENSE in the repository root or https://www.apache.org/licenses/LICENSE-2.0 for details.
+
+package com.openbank.party.infrastructure.consent
+
+import com.openbank.party.application.port.out.MarketingConsentForwardingException
+import com.openbank.party.application.port.out.MarketingConsentForwardingPort
+import com.openbank.party.infrastructure.client.ConsentServiceRestClient
+import com.openbank.party.infrastructure.client.CreateMarketingConsentRequest
+import com.openbank.party.infrastructure.client.RevokeMarketingConsentRequest
+import com.openbank.party.infrastructure.kafka.MarketingConsentEventConsumer.Companion.MARKETING_GRANTEE_ID
+import io.smallrye.mutiny.coroutines.awaitSuspending
+import jakarta.enterprise.context.ApplicationScoped
+import jakarta.ws.rs.WebApplicationException
+import org.eclipse.microprofile.rest.client.inject.RestClient
+import java.time.Clock
+import java.time.OffsetDateTime
+import java.util.UUID
+
+/**
+ * Forwards the mobile app's marketing-consent toggle to consent-service (ADR-0198 D3, ADR-0205,
+ * ADR-0206 D5) instead of party-service writing `consent_marketing` directly. Unlike
+ * [com.openbank.party.infrastructure.gdpr.GdprAggregationAdapter] (a best-effort read), a failure
+ * here always propagates — see [MarketingConsentForwardingPort]'s KDoc.
+ */
+@ApplicationScoped
+class MarketingConsentForwardingAdapter(
+    @RestClient private val consentClient: ConsentServiceRestClient,
+    private val clock: Clock,
+) : MarketingConsentForwardingPort {
+
+    override suspend fun grant(partyId: UUID): UUID {
+        val request = CreateMarketingConsentRequest(
+            partyId = partyId,
+            granteeId = MARKETING_GRANTEE_ID,
+            granteeType = "INTERNAL_SERVICE",
+            granteeName = "Party marketing preferences",
+            scopes = MARKETING_SCOPES,
+            accountIbans = null,
+            // consent-service clamps non-AISP scopes to 365 days server-side regardless of what's
+            // requested (ConsentService.createConsent) — sending the max here just states intent.
+            validTo = OffsetDateTime.now(clock).plusDays(MAX_VALIDITY_DAYS),
+            redirectUri = null,
+            tppTransactionId = null,
+        )
+        return runCatching { consentClient.create(request).awaitSuspending() }
+            .getOrElse { t -> throw forwardingFailure("grant", partyId, t) }
+            .id
+    }
+
+    override suspend fun revoke(partyId: UUID, consentId: UUID, reason: String) {
+        runCatching {
+            consentClient.revoke(consentId, partyId, MARKETING_GRANTEE_ID, RevokeMarketingConsentRequest(reason))
+                .awaitSuspending()
+        }.getOrElse { t -> throw forwardingFailure("revoke", partyId, t) }
+    }
+
+    private fun forwardingFailure(op: String, partyId: UUID, t: Throwable): MarketingConsentForwardingException {
+        val status = (t as? WebApplicationException)?.response?.status
+        return MarketingConsentForwardingException(
+            "consent-service $op failed for party $partyId" + (status?.let { " (HTTP $it)" } ?: ""),
+            t,
+        )
+    }
+
+    companion object {
+        private const val MAX_VALIDITY_DAYS = 365L
+        private val MARKETING_SCOPES = setOf("MARKETING_COMMS_EMAIL", "MARKETING_COMMS_PUSH", "MARKETING_COMMS_INAPP")
+    }
+}

--- a/openbank-party-service/src/main/resources/application.yaml
+++ b/openbank-party-service/src/main/resources/application.yaml
@@ -72,6 +72,11 @@ quarkus:
     card-service:
       url: ${OPENBANK_CARD_SERVICE_URL:http://localhost:8118}
       scope: jakarta.inject.Singleton
+    consent-service:
+      # consent-service listens on 8106 in the `consent` namespace (gitops
+      # components/consent/consent-service.yaml). ADR-0206 D5 marketing-consent forwarder.
+      url: ${OPENBANK_CONSENT_SERVICE_URL:http://consent-service.consent:8106}
+      scope: jakarta.inject.Singleton
   smallrye-reactive-messaging:
     kafka:
       bootstrap-servers: localhost:29092

--- a/openbank-party-service/src/test/kotlin/com/openbank/party/application/usecase/PartyServiceMarketingConsentTest.kt
+++ b/openbank-party-service/src/test/kotlin/com/openbank/party/application/usecase/PartyServiceMarketingConsentTest.kt
@@ -5,6 +5,7 @@
 package com.openbank.party.application.usecase
 
 import com.openbank.party.application.port.`in`.UpdateMarketingConsentCommand
+import com.openbank.party.application.port.out.MarketingConsentForwardingException
 import com.openbank.party.application.port.out.MarketingConsentTracking
 import com.openbank.party.domain.model.Address
 import com.openbank.party.domain.model.AmlStatus
@@ -110,6 +111,23 @@ class PartyServiceMarketingConsentTest {
         assertThat(result.consentMarketingUpdatedAt).isEqualTo(now)
         coVerify(exactly = 1) { service.marketingConsentForwarding.revoke(partyId, trackedConsentId, any()) }
         coVerify(exactly = 0) { service.partyRepo.update(any()) }
+    }
+
+    @Test
+    fun `updateMarketingConsent propagates a forwarding failure on revoke instead of swallowing it`() {
+        val service = newService()
+        val trackedConsentId = UUID.randomUUID()
+        coEvery { service.partyRepo.findById(partyId) } returns existingParty(consentMarketing = true)
+        coEvery { service.marketingConsentTracking.findByPartyId(partyId) } returns
+            MarketingConsentTracking(partyId, trackedConsentId, now)
+        coEvery { service.marketingConsentForwarding.revoke(partyId, trackedConsentId, any()) } throws
+            MarketingConsentForwardingException("consent-service unreachable")
+
+        assertThatThrownBy {
+            runBlocking {
+                service.updateMarketingConsent(UpdateMarketingConsentCommand(partyId, marketingConsent = false))
+            }
+        }.isInstanceOf(MarketingConsentForwardingException::class.java)
     }
 
     @Test

--- a/openbank-party-service/src/test/kotlin/com/openbank/party/application/usecase/PartyServiceMarketingConsentTest.kt
+++ b/openbank-party-service/src/test/kotlin/com/openbank/party/application/usecase/PartyServiceMarketingConsentTest.kt
@@ -5,6 +5,7 @@
 package com.openbank.party.application.usecase
 
 import com.openbank.party.application.port.`in`.UpdateMarketingConsentCommand
+import com.openbank.party.application.port.out.MarketingConsentTracking
 import com.openbank.party.domain.model.Address
 import com.openbank.party.domain.model.AmlStatus
 import com.openbank.party.domain.model.KycStatus
@@ -12,6 +13,7 @@ import com.openbank.party.domain.model.Party
 import com.openbank.party.domain.model.PartyStatus
 import com.openbank.party.domain.model.PartyType
 import io.mockk.coEvery
+import io.mockk.coJustRun
 import io.mockk.coVerify
 import io.mockk.mockk
 import kotlinx.coroutines.runBlocking
@@ -25,8 +27,14 @@ import java.util.Optional
 import java.util.UUID
 
 /**
- * Post-onboarding marketing-consent revocation (mobile app Profile screen). Split into its own
- * class to keep [PartyServiceTest] under detekt's LargeClass threshold.
+ * Post-onboarding marketing-consent toggle (mobile app Profile screen). Split into its own class
+ * to keep [PartyServiceTest] under detekt's LargeClass threshold.
+ *
+ * ADR-0198 D3 / ADR-0206 D5: [PartyService.updateMarketingConsent] now FORWARDS to consent-service
+ * instead of writing `consentMarketing`/calling `publishPartyUpdated` itself —
+ * [MarketingConsentProjectionService] (ADR-0205 D4) is the sole writer of that column, driven by
+ * consent-service's own outbox events. These tests replace the pre-ADR-0206 versions that asserted
+ * a direct `partyRepo.update()` write.
  */
 class PartyServiceMarketingConsentTest {
 
@@ -40,6 +48,8 @@ class PartyServiceMarketingConsentTest {
         eventPublisher = mockk(relaxed = true)
         metrics = mockk(relaxed = true)
         gdprAggregation = mockk(relaxed = true)
+        marketingConsentForwarding = mockk()
+        marketingConsentTracking = mockk()
         rcPepper = Optional.empty()
         clock = Clock.fixed(now, ZoneOffset.UTC)
     }
@@ -68,19 +78,50 @@ class PartyServiceMarketingConsentTest {
     )
 
     @Test
-    fun `updateMarketingConsent flips the value and stamps consentMarketingUpdatedAt`(): Unit = runBlocking {
+    fun `updateMarketingConsent true forwards a grant and does not write partyRepo`(): Unit = runBlocking {
         val service = newService()
+        coEvery { service.partyRepo.findById(partyId) } returns existingParty(consentMarketing = false)
+        coEvery { service.marketingConsentForwarding.grant(partyId) } returns UUID.randomUUID()
+
+        val result = service.updateMarketingConsent(UpdateMarketingConsentCommand(partyId, marketingConsent = true))
+
+        assertThat(result.consentMarketing).isTrue()
+        assertThat(result.consentMarketingUpdatedAt).isEqualTo(now)
+        // The immutable onboarding snapshot must not be touched by a later grant.
+        assertThat(result.consentGdpr).isTrue()
+        assertThat(result.consentCapturedAt).isEqualTo(Instant.parse("2026-01-01T00:00:00Z"))
+        coVerify(exactly = 1) { service.marketingConsentForwarding.grant(partyId) }
+        coVerify(exactly = 0) { service.partyRepo.update(any()) }
+        coVerify(exactly = 0) { service.eventPublisher.publishPartyUpdated(any()) }
+    }
+
+    @Test
+    fun `updateMarketingConsent false forwards a revoke using the tracked consentId`(): Unit = runBlocking {
+        val service = newService()
+        val trackedConsentId = UUID.randomUUID()
         coEvery { service.partyRepo.findById(partyId) } returns existingParty(consentMarketing = true)
-        coEvery { service.partyRepo.update(any()) } answers { firstArg() }
+        coEvery { service.marketingConsentTracking.findByPartyId(partyId) } returns
+            MarketingConsentTracking(partyId, trackedConsentId, now)
+        coJustRun { service.marketingConsentForwarding.revoke(partyId, trackedConsentId, any()) }
 
         val result = service.updateMarketingConsent(UpdateMarketingConsentCommand(partyId, marketingConsent = false))
 
         assertThat(result.consentMarketing).isFalse()
         assertThat(result.consentMarketingUpdatedAt).isEqualTo(now)
-        // The immutable onboarding snapshot must not be touched by a later revoke.
-        assertThat(result.consentGdpr).isTrue()
-        assertThat(result.consentCapturedAt).isEqualTo(Instant.parse("2026-01-01T00:00:00Z"))
-        coVerify { service.eventPublisher.publishPartyUpdated(result) }
+        coVerify(exactly = 1) { service.marketingConsentForwarding.revoke(partyId, trackedConsentId, any()) }
+        coVerify(exactly = 0) { service.partyRepo.update(any()) }
+    }
+
+    @Test
+    fun `updateMarketingConsent false is a no-op forward when nothing is tracked`(): Unit = runBlocking {
+        val service = newService()
+        coEvery { service.partyRepo.findById(partyId) } returns existingParty(consentMarketing = false)
+        coEvery { service.marketingConsentTracking.findByPartyId(partyId) } returns null
+
+        val result = service.updateMarketingConsent(UpdateMarketingConsentCommand(partyId, marketingConsent = false))
+
+        assertThat(result.consentMarketing).isFalse()
+        coVerify(exactly = 0) { service.marketingConsentForwarding.revoke(any(), any(), any()) }
     }
 
     @Test


### PR DESCRIPTION
## Summary
- Completes the ADR-0198/ADR-0205/ADR-0206 marketing-consent chain: `PartyService.updateMarketingConsent` now forwards to consent-service instead of writing `parties.consentMarketing` directly.
- New `MarketingConsentForwardingPort`/`ConsentServiceRestClient`/`MarketingConsentForwardingAdapter`: grant via `POST /api/v1/consents`, revoke via `DELETE /api/v1/consents/{id}` — both authorized through ADR-0206's grantee-scoped M2M OPA rule (`party-service:marketing-comms` only).
- Revoke looks up the currently-tracked `consentId` via `MarketingConsentTrackingRepository` (ADR-0205 D4); no tracked consent = no-op (already off).
- Neither path writes `partyRepo` or calls `publishPartyUpdated` — `MarketingConsentProjectionService` (D4) remains the sole writer, driven by consent-service's own Kafka events, so this can never race D4 into a split brain. The returned `Party` reflects the caller's now-accepted intent optimistically; the persisted row catches up asynchronously (D1's auto-activate path confirms synchronously, so this is typically milliseconds).
- A forwarding failure always throws (`MarketingConsentForwardingException`) rather than degrading silently — this is a write, unlike the best-effort `GdprAggregationPort` read pattern it otherwise mirrors.

## Dependencies
- Builds on #2468 (D1, merged), #2469 (D2, merged), #2496 (operator-consent-write M2M scoping fix, merged) — all already on `main`.

## Test plan
- [x] `./gradlew :openbank-party-service:detekt :openbank-party-service:ktlintCheck :openbank-party-service:test` green
- [x] `./gradlew :openbank-party-service:quarkusBuild -x test` green (CDI wiring for the two new injected ports)
- [x] Rewrote `PartyServiceMarketingConsentTest` (pre-existing, tested the old direct-write behavior) to cover: grant forwards + no partyRepo write, revoke forwards using the tracked consentId, revoke is a no-op with nothing tracked, `PartyNotFoundException` on an unknown id

Refs ADR-0198, ADR-0206 (merged #2465, #2496). N/A — no separate backlog issue; implements merged ADRs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)