### PR TITLE
ci(governance): measure Gradle heap headroom per CI build instead of discovering it by OOM

### DIFF
--- a/.github/scripts/gradle-heap-headroom.sh
+++ b/.github/scripts/gradle-heap-headroom.sh
@@ -1,0 +1,169 @@
+#!/usr/bin/env bash
+# SPDX-License-Identifier: Apache-2.0
+# Copyright (c) OpenBank contributors. Licensed under the Apache License, Version 2.0.
+#
+# Measures how much Gradle heap a CI build ACTUALLY used, so `-Xmx` stops being a ratchet
+# discovered by going red (issue #2177 problem 1).
+#
+# Today `fleet-lint`, `dependency-submission` and `security` each carry a hand-raised `-Xmx`
+# (6g, 6g, 6g) with a comment explaining which OOM caused the last raise. Nothing anywhere
+# records how close the current value is to the next one, so the only signal that headroom has run
+# out is the build dying — and #2177 measured what that costs: an OOM'd `fleet-lint` reported a
+# plain red while having silently left half the fleet unlinted.
+#
+# Usage:
+#     .github/scripts/gradle-heap-headroom.sh <label> -- ./gradlew <tasks...>
+#
+# Wraps the command, samples every JVM it spawns, and reports peak heap per JVM against that
+# JVM's own maximum. Writes a table to $GITHUB_STEP_SUMMARY when running under Actions, and always
+# to stdout. Emits a ::warning when any JVM crosses WARN_AT_PERCENT of its ceiling, or when the
+# machine's available RAM drops below MIN_FREE_MB.
+#
+# Deliberately NEVER changes the build's verdict: it exits with the wrapped command's exit code and
+# nothing else. A measurement that can fail a build is a measurement people delete.
+#
+# Two things it is careful about, both learned the hard way in this repo:
+#   * `jcmd` output is parsed for numbers this script itself computes with, so a parse that finds
+#     nothing reports "not measured" rather than a plausible 0 — a silent 0 would read as infinite
+#     headroom, which is the exact wrong direction to fail in.
+#   * A JVM that dies mid-build (the OOM case, the one that matters most) keeps whatever peak it
+#     reached: samples are accumulated per pid as they are taken, never re-read at the end.
+set -uo pipefail
+
+SAMPLE_INTERVAL_SECONDS="${SAMPLE_INTERVAL_SECONDS:-5}"
+WARN_AT_PERCENT="${WARN_AT_PERCENT:-85}"
+MIN_FREE_MB="${MIN_FREE_MB:-512}"
+
+label="${1:?usage: gradle-heap-headroom.sh <label> -- <command...>}"
+shift
+[ "${1:-}" = "--" ] || { echo "gradle-heap-headroom: expected -- before the command" >&2; exit 2; }
+shift
+[ "$#" -gt 0 ] || { echo "gradle-heap-headroom: no command given" >&2; exit 2; }
+
+workdir="$(mktemp -d)" || workdir=""
+# Guard the empty case explicitly: an unset workdir would silently turn every path below into an
+# absolute one ("/samples.tsv") and the script would go on "working" against the filesystem root.
+[ -n "$workdir" ] && [ -d "$workdir" ] || { echo "gradle-heap-headroom: cannot create a temp dir" >&2; exit 2; }
+samples="$workdir/samples.tsv"   # pid <TAB> name <TAB> used_mb <TAB> max_mb
+freefile="$workdir/free.txt"
+: > "$samples"
+: > "$freefile"
+
+# --- the sampler -----------------------------------------------------------------------------
+# One line per (pid, observation). The reducer takes the max per pid, so a JVM that exits early
+# still contributes its peak.
+sample_once() {
+  # `jcmd -l` lists live JVMs as "<pid> <main class or jar>". Skip jcmd's own pid.
+  jcmd -l 2>/dev/null | while read -r pid rest; do
+    case "$pid" in ''|*[!0-9]*) continue ;; esac
+    case "$rest" in *jdk.jcmd*) continue ;; esac
+
+    info="$(jcmd "$pid" GC.heap_info 2>/dev/null)" || continue
+
+    # Sum "used" across the heap regions the collector reports, and take the ceiling from
+    # "reserved"/"capacity" depending on collector. Values arrive as e.g. "used 1234M" or
+    # "used 1234567K".
+    used_kb="$(printf '%s\n' "$info" | grep -oE 'used [0-9]+[KMG]?' \
+      | awk '{v=$2; u=substr(v,length(v)); n=v+0;
+              if (u=="G") n*=1048576; else if (u=="M") n*=1024;
+              s+=n} END {if (NR>0) printf "%d", s}')"
+    max_kb="$(printf '%s\n' "$info" | grep -oE '(reserved|total reserved|capacity) [0-9]+[KMG]?' \
+      | awk '{v=$NF; u=substr(v,length(v)); n=v+0;
+              if (u=="G") n*=1048576; else if (u=="M") n*=1024;
+              if (n>m) m=n} END {if (NR>0) printf "%d", m}')"
+
+    # No parse => say so. Never substitute 0, which would read as "used nothing".
+    [ -n "$used_kb" ] || continue
+
+    name="$(printf '%s' "$rest" | awk '{print $1}' | sed 's|.*[./]||')"
+    printf '%s\t%s\t%s\t%s\n' "$pid" "${name:-jvm}" "$((used_kb / 1024))" "$(( ${max_kb:-0} / 1024 ))"
+  done >> "$samples"
+
+  if [ -r /proc/meminfo ]; then
+    awk '/^MemAvailable:/ {print int($2/1024)}' /proc/meminfo >> "$freefile"
+  fi
+}
+
+sampler_loop() {
+  while :; do
+    sample_once
+    sleep "$SAMPLE_INTERVAL_SECONDS"
+  done
+}
+
+if command -v jcmd >/dev/null 2>&1; then
+  sampler_loop &
+  sampler_pid=$!
+else
+  echo "gradle-heap-headroom: jcmd not on PATH — running the command unmeasured." >&2
+  sampler_pid=""
+fi
+
+# --- the build -------------------------------------------------------------------------------
+"$@"
+rc=$?
+
+if [ -n "$sampler_pid" ]; then
+  sample_once            # one last sample before the JVMs are gone
+  kill "$sampler_pid" 2>/dev/null || true
+  wait "$sampler_pid" 2>/dev/null || true
+fi
+
+# --- the report ------------------------------------------------------------------------------
+report="$workdir/report.md"
+{
+  echo "### Gradle heap headroom — \`$label\`"
+  echo
+} > "$report"
+
+if [ ! -s "$samples" ]; then
+  {
+    echo "No JVM heap samples were taken (no \`jcmd\`, or the build finished inside one sample"
+    echo "interval). Heap headroom is **not measured** for this run — treat it as unknown, not as fine."
+  } >> "$report"
+  worst=-1
+else
+  # Max used per pid, carrying that pid's ceiling.
+  reduced="$workdir/reduced.tsv"
+  sort -k1,1n "$samples" \
+    | awk -F'\t' '{ if ($3+0 > used[$1]) {used[$1]=$3+0; name[$1]=$2}
+                    if ($4+0 > max[$1]) max[$1]=$4+0 }
+                  END { for (p in used) printf "%s\t%s\t%d\t%d\n", p, name[p], used[p], max[p] }' \
+    | sort -k3,3nr > "$reduced"
+
+  {
+    echo "| JVM | peak heap used | ceiling | used |"
+    echo "|---|---:|---:|---:|"
+    awk -F'\t' '{
+      if ($4 > 0) { pct = sprintf("%.0f%%", 100*$3/$4); ceil = $4 " MiB" }
+      else        { pct = "n/a";                        ceil = "not reported" }
+      printf "| `%s` (pid %s) | %s MiB | %s | %s |\n", $2, $1, $3, ceil, pct
+    }' "$reduced"
+    echo
+  } >> "$report"
+
+  worst="$(awk -F'\t' 'BEGIN{w=-1} $4>0 { p = 100*$3/$4; if (p>w) w=p } END{printf "%d", (w<0 ? -1 : int(w+0.5))}' "$reduced")"
+
+  if [ -s "$freefile" ]; then
+    min_free="$(sort -n "$freefile" | head -1)"
+    echo "Lowest available system memory during the build: **${min_free} MiB**." >> "$report"
+    if [ "$min_free" -lt "$MIN_FREE_MB" ]; then
+      echo "::warning title=CI runner nearly out of memory::\`$label\` ran with only ${min_free} MiB of available system RAM at its lowest point (floor ${MIN_FREE_MB} MiB). At this level the kernel starts reclaiming, Gradle worker processes fail to start, and the runner can be killed outright — which GitHub reports as a *cancelled* job with no failing step, not as a failure. See #2330."
+    fi
+  fi
+fi
+
+if [ "$worst" -ge "$WARN_AT_PERCENT" ]; then
+  echo "::warning title=Gradle heap headroom low::\`$label\` peaked at ${worst}% of its configured -Xmx (warn at ${WARN_AT_PERCENT}%). This build did not OOM, but the next fleet growth may. Raise -Xmx in this workflow's GRADLE_OPTS before it goes red, not after. See #2177."
+  echo >> "$report"
+  echo "> :warning: Peaked at **${worst}%** of the configured ceiling — above the ${WARN_AT_PERCENT}% warning line." >> "$report"
+elif [ "$worst" -ge 0 ]; then
+  echo >> "$report"
+  echo "Peak was **${worst}%** of the configured ceiling (warning line ${WARN_AT_PERCENT}%)." >> "$report"
+fi
+
+cat "$report"
+[ -n "${GITHUB_STEP_SUMMARY:-}" ] && cat "$report" >> "$GITHUB_STEP_SUMMARY"
+
+rm -rf "$workdir"
+exit "$rc"

--- a/.github/workflows/dependency-submission.yml
+++ b/.github/workflows/dependency-submission.yml
@@ -104,7 +104,7 @@ jobs:
       # fleet depends on. No tests executed, so no Docker/Testcontainers needed.
       # --continue: one module failing to resolve shouldn't blank out the graph for the rest.
       - name: Resolve fleet dependency graph
-        run: ./gradlew assemble testClasses --continue --no-daemon
+        run: .github/scripts/gradle-heap-headroom.sh dependency-submission -- ./gradlew assemble testClasses --continue --no-daemon
 
   # ── The alarm (issue #1449) ───────────────────────────────────────────────────
   # Why this exists: from 2026-07-14 to 2026-07-17 EVERY run of the job above died

--- a/.github/workflows/fleet-lint.yml
+++ b/.github/workflows/fleet-lint.yml
@@ -187,8 +187,16 @@ jobs:
           set -o pipefail
           log="$RUNNER_TEMP/fleet-lint.log"
           rc=0
-          ./gradlew testClasses detekt ktlintCheck \
-            --continue --build-cache --console=plain --stacktrace 2>&1 | tee "$log" || rc=$?
+          # Wrapped in the heap sampler (#2177 problem 1). The classifier below makes an OOM
+          # legible AFTER it happens; this records how close each healthy run came, so the next
+          # -Xmx raise can be anticipated instead of discovered by going red. The pipeline runs
+          # inside the wrapper (not the wrapper inside the pipeline) so the sampler observes the
+          # whole build, and `pipefail` is re-set in the inner shell so `tee` cannot mask Gradle's
+          # exit code — the failure this repo has already been burnt by twice.
+          # shellcheck disable=SC2016  # $1 is the INNER bash's positional, deliberately unexpanded
+          .github/scripts/gradle-heap-headroom.sh fleet-lint -- \
+            bash -c 'set -o pipefail; ./gradlew testClasses detekt ktlintCheck \
+              --continue --build-cache --console=plain --stacktrace 2>&1 | tee "$1"' _ "$log" || rc=$?
 
           # "N actionable tasks" is Gradle's own count of what it actually got through, so a
           # number well below the healthy fleet total is itself evidence of an early abort.

--- a/.github/workflows/security.yml
+++ b/.github/workflows/security.yml
@@ -170,9 +170,16 @@ jobs:
       # the empty result then sits as the default branch's "current" CodeQL state
       # until the next code-touching main push, showing as a code-scanning
       # configuration error. --no-build-cache forces a real compile every run.
+      # Wrapped in the heap sampler (#2177 problem 1, #2330). This job is the one that keeps
+      # coming back `cancelled` with no failing step while every other job in the same run
+      # succeeds — the signature of a runner killed rather than a build that failed. It compiles
+      # the whole fleet with `--no-build-cache` at `-Xmx6g` alongside the Kotlin daemon and the
+      # per-task worker JVMs, and nothing has ever recorded what that actually costs. Now it does,
+      # in the job summary, whether or not the run is healthy. Advisory only: the sampler exits
+      # with Gradle's exit code and never its own.
       - name: Build (java-kotlin) for CodeQL tracing
         if: matrix.language == 'java-kotlin'
-        run: ./gradlew testClasses --no-build-cache --no-daemon
+        run: .github/scripts/gradle-heap-headroom.sh codeql-java-kotlin -- ./gradlew testClasses --no-build-cache --no-daemon
 
       - uses: github/codeql-action/analyze@7188fc363630916deb702c7fdcf4e481b751f97a # v4
         with:


### PR DESCRIPTION
## Refs #2177 (problem 1) · Refs #2330

Neither `Closes`. #2177's problem 1 asks for "a per-run peak-heap signal **and** an alert on low headroom" — this ships the signal and a warning threshold, but whether 85% is the right line is a judgement that needs a few runs of real data behind it, so I would leave the issue open until the numbers exist. #2330 gets new evidence and the instrument that can settle it, not a fix.

### The gap

`fleet-lint`, `dependency-submission` and the CodeQL `java-kotlin` build each carry a hand-raised `-Xmx6g`, each with a comment naming the OOM that caused the last raise. Nothing records how close the current value is to the next one. So every raise is a ratchet discovered by going red — and #2177 already measured what that costs: an OOM'd `fleet-lint` reported a plain red while having silently left half the fleet unlinted, 455 actionable findings against a true 920.

PR #2479 (problem 2, merged) made that failure **legible after the fact**. It explicitly does not make it predictable. This is the other half.

### What it does

`.github/scripts/gradle-heap-headroom.sh <label> -- ./gradlew …` wraps a Gradle invocation, samples every JVM via `jcmd GC.heap_info` while it runs, and writes a peak-heap-vs-ceiling table into `$GITHUB_STEP_SUMMARY`:

| JVM | peak heap used | ceiling | used |
|---|---:|---:|---:|
| `GradleDaemon` (pid 40049) | 1344 MiB | 3072 MiB | 44% |
| `KotlinCompileDaemon` (pid 72030) | 596 MiB | not reported | n/a |

It warns at 85% of `-Xmx`, and separately when available system RAM drops below 512 MiB.

Three design points worth stating, each because the obvious alternative fails quietly:

- **It samples every JVM on the machine, not just Gradle's children.** The Kotlin compile daemon and the per-task worker JVMs are exactly what turns a comfortable `-Xmx` into an out-of-memory *runner*, and they are not children in any way this could filter on.
- **A failed parse reports "not measured", never 0.** A silent 0 reads as infinite headroom — failing in precisely the wrong direction for a gauge whose whole job is to warn.
- **It is advisory by construction**: it exits with the wrapped command's exit code and never its own. A measurement that can fail a build is a measurement someone eventually deletes.

### What this contributes to #2330

Triage closed the door on #2330 with "1 `cancelled` in 60 runs, not reproduced". Looking at the *job* level rather than the run level tells a different story. Three PR-branch `security.yml` runs this morning:

| run | cancelled job | duration |
|---|---|---|
| 30190267784 | `CodeQL (java-kotlin, manual)` | 4m17s |
| 30189654625 | `CodeQL (java-kotlin, manual)` | 2m15s |
| 30189547186 | `CodeQL (java-kotlin, manual)` | 4m56s |

In each case **only that one job** was cancelled while every other job in the same run succeeded — so this is not the run-level concurrency cancel that a `cancelled` conclusion normally means, and counting run conclusions cannot see it. It is one specific job dying early, repeatedly, with no failing step.

That job compiles the whole fleet with `--no-build-cache --no-daemon` at `-Xmx6g` alongside the Kotlin daemon and the worker JVMs. A runner killed for memory is reported by GitHub as exactly this: `cancelled`, no error. That is a hypothesis, not a conclusion — which is why the low-free-RAM warning is in here and no capacity change is. **I did not touch runner capacity** (#2039's 6→12 was tried and reverted same-day for the scale-set phantom-claim bug), and I did not change any `-Xmx`: changing a heap ceiling on a guess is the thing this PR exists to stop doing.

### Falsification

Every branch was run against an input it must flag. None of these greens is unexercised.

| case | must | result |
|---|---|---|
| healthy build | real table, no warning | GradleDaemon 1344/3072 MiB → 44%, silent |
| `WARN_AT_PERCENT` below the observed peak | warning fires with the right number | fired at 63% |
| `jcmd` genuinely absent | "not measured — treat as unknown, not as fine" | correct; never a plausible 0 |
| `mktemp` unavailable | abort loudly | aborts, instead of writing `/samples.tsv` at the filesystem root |
| wrapped command exits 7 | wrapper exits 7 | 7 |
| rewritten `fleet-lint` pipeline, passing task | rc 0, log + `N actionable tasks` intact | rc 0, count intact — the classifier still greps what it needs |
| rewritten `fleet-lint` pipeline, failing task | rc 1 through wrapper **and** `tee` | rc 1 — the gate cannot be masked |

`actionlint` finding sets were diffed per file against `origin/main` rather than eyeballed: `fleet-lint.yml` was clean on main and is clean here. The one SC2016 the rewrite introduced is a deliberate inner-shell positional, disabled inline **with the reason**, so it does not read as noise later. `shellcheck` on the script itself is clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)