### PR TITLE
ci(mcp): make the caller-auth guard fail on a reintroduced shared fallback identity

### DIFF
--- a/.github/scripts/check-mcp-stub-ports-vs-caller-auth.sh
+++ b/.github/scripts/check-mcp-stub-ports-vs-caller-auth.sh
@@ -31,8 +31,15 @@
 #   those, only a class that is actually reachable.
 #
 #   This guard fails if a non-Stub, non-@Vetoed port implementation exists in the service
-#   while McpEndpoint still carries the `agent:mcp-anonymous` placeholder constant. It is a
-#   REGRESSION guard: 0 violations today (StubReadPorts wired; RealAccountReadPort @Vetoed).
+#   while McpEndpoint still carries the `agent:mcp-anonymous` placeholder constant.
+#
+# POST-CUTOVER (#2401) — the invariant above is now UNREACHABLE, and that is why there is a
+# second one. ADR-0195 step 4 completed the cutover: the placeholder is gone from McpEndpoint,
+# RealAccountReadPort is wired, and `placeholder_present` is therefore permanently 0, so the
+# pre-cutover rule can never fire again. A guard whose trigger was deleted by the fix it guarded
+# still reads as coverage while checking nothing. Section 3 inverts it: after the cutover the
+# SHARED FALLBACK IDENTITY is the violation, because every caller now presents its own `sub` and
+# reintroducing one id would silently collapse them all onto one charter's grant.
 #
 # Kotlin class headers routinely span multiple lines, so the scan uses python3 (this repo's
 # existing convention for structural guards, e.g. check-threat-models.py) rather than a
@@ -57,10 +64,85 @@ if [[ ! -f "$ENDPOINT" ]]; then
   exit 1
 fi
 
-# 1. Is resolveContext still the phase-1 placeholder? The load-bearing signal is
-#    the literal placeholder principal id; a real OAuth/consent resolution removes it.
+# Does a Kotlin file contain the forbidden id as CODE (not in a comment)? Prints the path when it
+# does, nothing when it does not. Kotlin block comments NEST, so the stripper mirrors that; a KDoc
+# containing "/*" must not close the comment early and leak the rest of the file back into scope.
+kotlin_code_mentions() {
+  python3 - "$@" <<'PYSTRIP'
+import sys
+from pathlib import Path
+
+FORBIDDEN = "agent:mcp-anonymous"
+
+
+def strip_comments(text: str) -> str:
+    """Kotlin source with // and (NESTING) /* */ comments removed, string literals preserved."""
+    out = []
+    i, n, depth = 0, len(text), 0
+    while i < n:
+        two = text[i:i + 2]
+        if depth:
+            if two == "/*":
+                depth += 1
+                i += 2
+            elif two == "*/":
+                depth -= 1
+                i += 2
+            else:
+                i += 1
+            continue
+        if two == "/*":
+            depth = 1
+            i += 2
+        elif two == "//":
+            j = text.find("\n", i)
+            i = n if j == -1 else j
+        elif text[i] == '"':
+            if text[i:i + 3] == '"""':
+                j = text.find('"""', i + 3)
+                j = n if j == -1 else j + 3
+                out.append(text[i:j])
+                i = j
+            else:
+                j = i + 1
+                while j < n and text[j] != '"':
+                    j += 2 if text[j] == "\\" else 1
+                out.append(text[i:j + 1])
+                i = j + 1
+        else:
+            out.append(text[i])
+            i += 1
+    return "".join(out)
+
+
+targets = []
+for arg in sys.argv[1:]:
+    path = Path(arg)
+    targets.extend(sorted(path.rglob("*.kt")) if path.is_dir() else [path])
+print("\n".join(str(p) for p in targets if FORBIDDEN in strip_comments(p.read_text())))
+PYSTRIP
+}
+
+# 0. Has the ADR-0195 step-4 cutover happened? McpEndpoint resolving the caller through
+#    CallerContextResolver is the structural signal — it is the class that reads the token's real
+#    `sub`. This selects WHICH invariant applies below, so that neither one is silently vacuous:
+#    pre-cutover the placeholder is expected and a real port is the violation; post-cutover the
+#    placeholder is itself the violation. Without this split the pre-cutover rule survives the fix
+#    that made it unreachable and keeps reporting a green about nothing.
+cutover_done=0
+if grep -q 'CallerContextResolver' "$ENDPOINT"; then
+  cutover_done=1
+fi
+
+# 1. Is resolveContext still the phase-1 placeholder? The load-bearing signal is the literal
+#    placeholder principal id, IN CODE. Deliberately not a raw grep: this repo has been bitten
+#    three times by a text guard flagging the prose that explains the bug it exists to catch, and
+#    that is not hypothetical here — with a raw grep, adding a KDoc that merely mentions the
+#    retired `agent:mcp-anonymous` made this guard fire and announce an "UNAUTHENTICATED read of
+#    any account" that did not exist. Comments are stripped (Kotlin block comments NEST) so only a
+#    real constant counts.
 placeholder_present=0
-if grep -qE 'agent:mcp-anonymous' "$ENDPOINT"; then
+if [[ -n "$(kotlin_code_mentions "$ENDPOINT")" ]]; then
   placeholder_present=1
 fi
 
@@ -140,13 +222,39 @@ print("\n".join(offenders))
 PY
 )
 
-if [[ "$placeholder_present" -eq 1 && -n "$non_stub" ]]; then
+if [[ "$cutover_done" -eq 0 && "$placeholder_present" -eq 1 && -n "$non_stub" ]]; then
   echo "::error title=MCP caller-auth guard (BLOCKER #2206)::A non-stub, non-@Vetoed read/proposal port is wired while McpEndpoint.resolveContext() still returns the hardcoded 'agent:mcp-anonymous' placeholder. This turns get_balance/list_accounts into an UNAUTHENTICATED read of any account. Land real caller identity + PSD2 consent binding (resolveContext) BEFORE or ATOMICALLY WITH the real port — or mark the class @Vetoed if it is intentionally not yet reachable. Offending impl(s): $(echo "$non_stub" | tr '\n' '; ')" >&2
   exit 1
 fi
 
-if [[ "$placeholder_present" -eq 1 ]]; then
-  echo "check-mcp-stub-ports-vs-caller-auth: OK — placeholder identity still in place, only stub (or @Vetoed) ports wired (phase 1)."
-else
-  echo "check-mcp-stub-ports-vs-caller-auth: OK — placeholder identity removed; real caller auth landed, real ports permitted."
+if [[ "$cutover_done" -eq 0 ]]; then
+  echo "check-mcp-stub-ports-vs-caller-auth: OK — pre-cutover; placeholder identity in place, only stub (or @Vetoed) ports wired (phase 1)."
+  exit 0
 fi
+
+# 3. POST-CUTOVER (#2401). Everything above is a pre-cutover guard, and ADR-0195 step 4 finished
+#    the cutover: `agent:mcp-anonymous` no longer appears in McpEndpoint, so `placeholder_present`
+#    is now permanently 0 and section 1 can never fire again. A guard whose trigger condition was
+#    deleted by the fix it was guarding does not become harmless — it becomes a green that asserts
+#    nothing, which is worse than no guard because it still reads as coverage.
+#
+#    So the invariant inverts. Before the cutover the placeholder was the accepted state and a real
+#    port was the danger. After it, the placeholder itself is the danger: every MCP caller now
+#    presents its own `sub`, and reintroducing a shared fallback id would silently collapse all of
+#    them back onto the single `mcp-anonymous` charter's five-tool grant — a second caller
+#    inheriting the first's authorization by construction, while per-caller identity still looks
+#    correct in the audit trail. That is exactly the widening #2401 is open about, and no other
+#    gate can see it.
+#
+#    Checked against CODE, not prose: Kotlin comments are stripped first (block comments NEST in
+#    Kotlin, so a KDoc containing "/*" must not close the comment early), because this guard's own
+#    documentation quotes the forbidden id and a naive text match would flag the explanation of the
+#    bug instead of the bug.
+fallback_reintroduced="$(kotlin_code_mentions "$SVC")"
+
+if [[ -n "$fallback_reintroduced" ]]; then
+  echo "::error title=MCP shared-fallback identity reintroduced (#2401)::Caller authentication has landed (ADR-0195 step 4): every MCP caller presents its own token 'sub' and the PDP is asked about that caller. A source file now hardcodes 'agent:mcp-anonymous' again, which collapses every caller back onto that single charter's five-tool grant — a new caller silently inherits the previous one's authorization while the audit trail still shows per-caller identity. Give the caller its own charter in openbank-libs/governance/agents.yaml instead. Offending file(s): $(echo "$fallback_reintroduced" | tr '\n' '; ')" >&2
+  exit 1
+fi
+
+echo "check-mcp-stub-ports-vs-caller-auth: OK — caller auth landed, real ports permitted, and no shared fallback identity reintroduced."

--- a/openbank-mcp-service/src/main/kotlin/com/openbank/mcp/infrastructure/mcp/CallerContextResolver.kt
+++ b/openbank-mcp-service/src/main/kotlin/com/openbank/mcp/infrastructure/mcp/CallerContextResolver.kt
@@ -14,9 +14,12 @@ import org.eclipse.microprofile.jwt.JsonWebToken
  * PDP must be asked about the *real* agent and the *real* consent, not the phase-1 placeholder.
  *
  * Returns `null` when no agent token is present — OIDC is still tenant-disabled, or the call is
- * anonymous — so [McpEndpoint] can fall back to the phase-1 placeholder identity WITHOUT this class
- * carrying that constant. That keeps the fallback (and the #2206 CI guard's `agent:mcp-anonymous`
- * anchor) in one place, `McpEndpoint`.
+ * anonymous. There is no longer any fallback identity behind that `null`: [McpEndpoint] audits the
+ * failure as `unknown`/DENIED and answers "Authorization unavailable". The phase-1
+ * `agent:mcp-anonymous` placeholder this KDoc used to describe as the fallback was removed by the
+ * cutover itself, and a shared fallback must not come back — reintroducing one would collapse every
+ * caller onto a single charter's grant, so `check-mcp-stub-ports-vs-caller-auth.sh` now fails on the
+ * constant appearing anywhere in this service's code (#2401).
  *
  * The token's `sub` (shape `agent:<id>`, which the shared `AuthorizeInterceptor` classifies as
  * `AI_AGENT`) is the OPA principal id; the `consent_id` claim names the presented consent.


### PR DESCRIPTION
## Refs #2401 — the half that needs no owner input, plus a vacuous gate and a false alarm found on the way

#2401's substantive ask is per-caller OAuth clients and per-caller charters. That needs the list of real MCP callers and their intended scopes, which is an owner decision — the triage says so and I agree. **This PR does not touch `agents.yaml`** (and so does not restamp all ~64 OPA bundles). What it does is make the *absence* of that work detectable, and fix two things found while looking.

### 1. The guard protecting this area had become vacuous

`check-mcp-stub-ports-vs-caller-auth.sh` was a **pre-cutover** guard: fire when a real read port is wired while `McpEndpoint` still hardcodes `agent:mcp-anonymous`. ADR-0195 step 4 removed that constant. `grep -c 'mcp-anonymous' McpEndpoint.kt` → **0**. Its trigger condition has been permanently false ever since.

That did not make it harmless. It made it a green that asserts nothing while still reading as coverage in the required job — the failure class this repo keeps re-encountering, reached here from an unusual direction: not a gate that was never exercised, but one whose reason to exist was **deleted by the fix it was guarding**.

### 2. The invariant inverts, so make the script pick which one applies

Before the cutover, the placeholder was the accepted state and a real port was the danger. After it, every caller presents its own token `sub` — so the **shared fallback is** the danger. Reintroducing one id collapses every caller back onto the single `mcp-anonymous` charter's five-tool grant: a second caller inherits the first's authorization by construction, while per-caller identity still looks perfectly correct in the audit trail. That is exactly the silent widening #2401 is open about, and nothing else in CI can see it.

The script now derives cutover state from `McpEndpoint` resolving through `CallerContextResolver`, and post-cutover fails on the constant appearing anywhere in the service's Kotlin **code**. This is the "guard that the fallback is not used" half — it does not create the per-caller charters, but it means shipping a caller *without* one can no longer pass quietly.

### 3. A real false alarm, found only by falsifying against a case the guard must NOT flag

Section 1 grepped the **raw** file. So adding a KDoc that merely *mentions* the retired id made the guard fire and announce an `UNAUTHENTICATED read of any account` that did not exist — the guard flagging the prose that explains the bug it exists to catch, for the fourth time in this repo. Both sections now strip comments first, mirroring Kotlin's **nesting** block comments so a KDoc containing `/*` cannot close early and leak the rest of the file back into scope.

I would not have found this by testing that the guard passes. It only appeared in the "must not flag" column.

### 4. Stale prose naming a dead mechanism

`CallerContextResolver`'s KDoc still told the reader that `McpEndpoint` "can fall back to the phase-1 placeholder identity". It cannot — it audits `unknown`/DENIED and answers `Authorization unavailable`. A text guard is blind to this kind of drift forever, so it has to be read and corrected by hand. Done.

### Falsification

Five inputs, including the two the guard must **not** flag:

| input | must | result |
|---|---|---|
| real `const val = "agent:mcp-anonymous"` in `McpEndpoint` | FLAG | flagged, with the **post-cutover** message (before this change: flagged with the wrong pre-cutover one) |
| same constant in a **different** file (`RealAccountReadPort`) | FLAG | flagged — scope is the service, not one file |
| KDoc mentioning the id, containing a nested `/*` | do NOT flag | clean (raw grep flagged it) |
| line comment mentioning the id | do NOT flag | clean (raw grep flagged it) |
| unmodified tree | clean | clean |

`:openbank-mcp-service:detekt ktlintCheck test` — BUILD SUCCESSFUL.

### Left for the owner

Per-caller Keycloak clients and their `agents.yaml` charters, and retiring the `mcp-anonymous` charter entry itself. Both need the caller list. Note also that the `mcp-anonymous` charter's own comment in `agents.yaml` is now false — it still describes the fixed principal `McpEndpoint.resolveContext()` sets, which no longer exists — but correcting it means editing `agents.yaml`, which restamps every OPA bundle, so it belongs in the same change that actually retires the charter rather than in a drive-by.

🤖 Generated with [Claude Code](https://claude.com/claude-code)