### PR TITLE
fix(clearing): drop the M2M grant from POST /submit — no such caller exists (#2442)

### DIFF
--- a/openbank-clearing-service/src/main/kotlin/com/openbank/clearing/infrastructure/rest/ClearingResource.kt
+++ b/openbank-clearing-service/src/main/kotlin/com/openbank/clearing/infrastructure/rest/ClearingResource.kt
@@ -66,7 +66,13 @@ class ClearingResource(
 
     @POST
     @Path("/submit")
-    @RolesAllowed(Roles.API, Roles.PAYMENTS, Roles.ADMIN)
+    // No M2M grant: this carried the dead `ROLE_SERVICE` name until #2442 made the M2M role real
+    // (ROLE_API, granted to service-account-openbank-services). The post-grant audit found NO
+    // service in this repo that calls it — agent-service is the only holder of a clearing-service
+    // REST client and it uses `GET /batches` only — so admitting a service token here would widen a
+    // money-path submit for a caller that does not exist. Add Roles.API back in the same change
+    // that adds the caller.
+    @RolesAllowed(Roles.PAYMENTS, Roles.ADMIN)
     @Authorize(action = "clearingBatch.submit")
     @Operation(summary = "Submit payment for clearing")
     fun submit(request: SubmitPaymentRequest): Uni<Response> = submitUseCase.submit(request)


### PR DESCRIPTION
## Kontext

Post-grant audit k #2442 — bod, který jsem u předchozího PR označil jako vyžadující kontrolu po nasazení.

## Co audit skutečně měřil

Granting `ROLE_API` účtu `service-account-openbank-services` zpřístupnilo M2M tokenu 153 `@RolesAllowed` míst. **Nově** dostupných je ale jen **5** — účet totiž drží i `ROLE_OPERATOR`, takže každá anotace, která `ROLE_OPERATOR` už obsahovala, service token pouštěla i před celou touhle sérií.

| místo | M2M volající v repu | verdikt |
|---|---|---|
| **clearing-service `POST /submit`** (money-path) | **žádný** — agent-service je jediný držitel `ClearingServiceClient` a deklaruje jen `GET /batches` | **grant odebrán** |
| sepa-payment `POST /returns` (money-path) | ano — `SepaPaymentClient` v clearing-simulatoru, `@Path("/api/v1/sepa-payments/returns")` | ponechán |
| libs-runtime `ReconciliationSummaryContract` `GET` | sdílený read-only kontrakt vedle AUDITOR/COMPLIANCE/ADMIN | ponechán |
| party-service `POST /resolve` | identity resolution, M2M tvarem | ponechán |
| pid-service `GET /pid/resolve` | totéž; uvádí `ROLE_API` **samotné**, odebrání by endpoint zavřelo úplně | ponechán |

## Co audit neměří — a proč na tom záleží

Sweep tyhle granty **nevymyslel**: všech 5 míst mělo předtím `ROLE_SERVICE`, tedy záměr „sem smí služba" tam byl vždy. Změnilo se jen to, že ten záměr **začal fungovat**.

Otázka tedy nikdy nezněla „rozšířil rename něco" (nemůže — množina míst je identická), ale „byl každý původní záměr správný". A to je zodpověditelné jen per-endpoint, proti volajícím, kteří reálně existují.

## Ověření

- `check-roles-allowed-realm.py` exit 0 — `ROLE_PAYMENTS`/`ROLE_ADMIN` jsou obě realm role, takže tohle není all-dead případ, který brána blokuje
- `ktlintCheck` + `detekt` + `test` zeleně na JDK 25

## Živý realm

Grant je už aplikovaný na sandboxu (`kcadm`), protože `--import-realm` čte JSON jen při cold startu. Ověřeno **reálným tokenem**, ne návratovým kódem:

```
sub: service-account-openbank-services
realm_access.roles: ['ROLE_API', 'ROLE_OPERATOR', 'default-roles-openbank', ...]
```

Obě lending role (`ROLE_CREDIT_RISK`, `ROLE_LENDING_OFFICER`) na živém realmu rovněž vytvořeny — v gitops template byly nové, importem by se nikdy nepropsaly.

## Linked issues

Refs #2442
