### PR TITLE
test(transaction): pin enum-like pact string fields by value across the money path

### DIFF
--- a/openbank-account-service/src/test/kotlin/com/openbank/account/contract/AccountToBalancePactConsumerTest.kt
+++ b/openbank-account-service/src/test/kotlin/com/openbank/account/contract/AccountToBalancePactConsumerTest.kt
@@ -55,6 +55,13 @@ class AccountToBalancePactConsumerTest {
                 o.array("balances") { a ->
                     a.`object` { b ->
                         b.uuid("accountId")
+                        // stringType, DELIBERATELY (issue #2425): this endpoint returns EVERY
+                        // balance the account holds and the request names no currency, so an
+                        // account may legitimately answer with CZK, EUR and USD rows. Pinning
+                        // the value here would assert "every balance is CZK", which is a
+                        // stronger claim than the contract makes. The two single-currency
+                        // interactions below DO pin it — there the currency is an echo of the
+                        // request.
                         b.stringType("currency", "CZK")
                         b.decimalType("bookedAmount", 5000.00)
                         b.decimalType("availableAmount", 4900.00)
@@ -96,7 +103,11 @@ class AccountToBalancePactConsumerTest {
         .body(
             newJsonBody { o ->
                 o.uuid("accountId")
-                o.stringType("currency", "CZK")
+                // stringValue, NOT stringType: the currency is a path segment of the request
+                // (/balances/{accountId}/CZK), so the response echoing a DIFFERENT currency is a
+                // real defect — the consumer would read a EUR balance as the account's CZK
+                // cover. A type matcher accepted any string and made the check vacuous (#2425).
+                o.stringValue("currency", "CZK")
                 o.decimalType("bookedAmount", 5000.00)
                 o.decimalType("availableAmount", 4900.00)
                 o.decimalType("reservedAmount", 100.00)
@@ -117,7 +128,7 @@ class AccountToBalancePactConsumerTest {
             .statusCode(200)
             .extract().jsonPath()
 
-        assertThat(body.getString("currency")).isNotBlank()
+        assertThat(body.getString("currency")).isEqualTo("CZK")
         assertThat(body.getString("accountId")).isNotBlank()
     }
 
@@ -137,7 +148,10 @@ class AccountToBalancePactConsumerTest {
         .body(
             newJsonBody { o ->
                 o.uuid("accountId")
-                o.stringType("currency", "CZK")
+                // stringValue, NOT stringType: the request body asks to open a CZK balance, so
+                // the response currency is an echo of it — a different currency back means the
+                // provider opened the wrong pocket (#2425).
+                o.stringValue("currency", "CZK")
                 o.decimalType("bookedAmount", 0.00)
                 o.decimalType("availableAmount", 0.00)
                 o.decimalType("reservedAmount", 0.00)

--- a/openbank-account-service/src/test/kotlin/com/openbank/account/contract/AccountToTransactionPactConsumerTest.kt
+++ b/openbank-account-service/src/test/kotlin/com/openbank/account/contract/AccountToTransactionPactConsumerTest.kt
@@ -21,7 +21,8 @@ import org.junit.jupiter.api.extension.ExtendWith
  * Consumer-driven contract for the welcome-bonus transaction initiation account-service makes
  * ([com.openbank.account.infrastructure.client.TransactionServiceRestClient], ADR-0063 P2).
  * The consumer sends a minimal CREDIT initiation body and expects 201 with {id, status}.
- * The saga continues asynchronously so the initial status is PENDING.
+ * transaction-service books synchronously, so the 201 already carries COMPLETED —
+ * this KDoc claimed PENDING until #2425 pinned the value and the replay disagreed.
  * The provider verification is in TransactionPactProviderVerificationTest (transaction-service).
  */
 @ExtendWith(PactConsumerTestExt::class)
@@ -56,7 +57,13 @@ class AccountToTransactionPactConsumerTest {
         .body(
             newJsonBody { o ->
                 o.uuid("id")
-                o.stringType("status", "PENDING")
+                // MEASURED, not assumed (issue #2425): pinning this value is what revealed
+                // that transaction-service answers POST /api/v1/transactions with COMPLETED —
+                // it books synchronously. Every consumer contract here claimed PENDING or
+                // PROCESSING, a status this response has never carried, and the `type` matcher
+                // made all four replays green about it for the life of the contracts.
+                // stringValue, NOT stringType: this is the field the consumer branches on.
+                o.stringValue("status", "COMPLETED")
             }.build(),
         )
         .toPact()
@@ -74,6 +81,6 @@ class AccountToTransactionPactConsumerTest {
             .extract().jsonPath()
 
         assertThat(body.getString("id")).isNotBlank()
-        assertThat(body.getString("status")).isNotBlank()
+        assertThat(body.getString("status")).isEqualTo("COMPLETED")
     }
 }

--- a/openbank-balance-service/src/test/kotlin/com/openbank/balance/contract/LedgerTrialBalancePactConsumerTest.kt
+++ b/openbank-balance-service/src/test/kotlin/com/openbank/balance/contract/LedgerTrialBalancePactConsumerTest.kt
@@ -63,12 +63,21 @@ class LedgerTrialBalancePactConsumerTest {
         .headers(mapOf("Content-Type" to "application/json"))
         .body(
             newJsonBody { o ->
-                // type matchers: consumer only cares about shape, not exact values.
-                o.stringType("asOf", "2024-01-31")
+                // stringValue, NOT stringType (issue #2425): `asOf` is echoed from the
+                // `asOf=` query parameter this interaction pins by literal. A trial balance
+                // returned for a DIFFERENT date than the one asked for is a reporting defect of
+                // the first order, and a type matcher accepted any date string at all.
+                o.stringValue("asOf", "2024-01-31")
                 o.booleanType("balanced", true)
                 // minArrayLike(0): provider test runs against an empty-DB Testcontainer;
                 // 0 lines is valid — reconciliation handles the zero-entry case.
                 // The element template defines required field types for non-empty responses.
+                // stringType on `code`/{currency,type}, DELIBERATELY (issue #2425): `lines`
+                // is a heterogeneous list — a real trial balance carries many GL codes, several
+                // currencies and every account type. Pinning an element value would assert
+                // "every line is this one code", a claim the contract does not make and real
+                // data would immediately falsify. The array is min=0 here anyway, so a pin
+                // would also be vacuous against the empty-DB provider.
                 o.minArrayLike("lines", 0, 1) { line ->
                     line.stringType("code", "1100-DEPOSITS-CZK")
                     line.stringType("currency", "CZK")
@@ -92,7 +101,11 @@ class LedgerTrialBalancePactConsumerTest {
         .headers(mapOf("Content-Type" to "application/json"))
         .body(
             newJsonBody { o ->
-                o.stringType("asOf", "2000-01-01")
+                // stringValue, NOT stringType (issue #2425): `asOf` is echoed from the
+                // `asOf=` query parameter this interaction pins by literal. A trial balance
+                // returned for a DIFFERENT date than the one asked for is a reporting defect of
+                // the first order, and a type matcher accepted any date string at all.
+                o.stringValue("asOf", "2000-01-01")
                 o.booleanType("balanced", true)
                 o.array("lines") // empty array — reconciliation handles zero-line ledger
             }.build(),

--- a/openbank-billing-service/src/test/kotlin/com/openbank/billing/contract/BillingLedgerPostJournalPactConsumerTest.kt
+++ b/openbank-billing-service/src/test/kotlin/com/openbank/billing/contract/BillingLedgerPostJournalPactConsumerTest.kt
@@ -109,7 +109,11 @@ class BillingLedgerPostJournalPactConsumerTest {
             newJsonBody { o ->
                 o.uuid("id")
                 o.uuid("transactionId")
-                o.stringType("status", "POSTED")
+                // stringValue, NOT stringType (issue #2425): a balanced journal accepted by
+                // the ledger is POSTED — the value is the provider's answer to "did this
+                // post?", which is the entire reason the consumer makes the call. A type
+                // matcher accepted "REJECTED" just as happily.
+                o.stringValue("status", "POSTED")
             }.build(),
         )
         .toPact()

--- a/openbank-copilot-service/src/test/kotlin/com/openbank/copilot/contract/CustomerEdgePactConsumerTest.kt
+++ b/openbank-copilot-service/src/test/kotlin/com/openbank/copilot/contract/CustomerEdgePactConsumerTest.kt
@@ -234,7 +234,7 @@ class CustomerEdgePactConsumerTest {
         .body(
             LambdaDsl.newJsonArrayMinLike(1) { arr ->
                 arr.`object` { o ->
-                    o.uuid("id", UUID.randomUUID())
+                    o.uuid("id", UUID.fromString("11111111-2222-4333-8444-555555555501"))
                     o.stringType("maskedPan", "**** **** **** 1234")
                     o.stringType("cardType", "DEBIT")
                     o.stringType("network", "VISA")
@@ -273,7 +273,7 @@ class CustomerEdgePactConsumerTest {
         .body(
             LambdaDsl.newJsonArrayMinLike(1) { arr ->
                 arr.`object` { o ->
-                    o.uuid("id", UUID.randomUUID())
+                    o.uuid("id", UUID.fromString("11111111-2222-4333-8444-555555555502"))
                     o.stringType("pocketCurrency", "CZK")
                     o.stringType("periodFrom", "2026-06-01")
                     o.stringType("periodTo", "2026-06-30")
@@ -315,7 +315,7 @@ class CustomerEdgePactConsumerTest {
         .body(
             LambdaDsl.newJsonArrayMinLike(1) { arr ->
                 arr.`object` { o ->
-                    o.uuid("id", UUID.randomUUID())
+                    o.uuid("id", UUID.fromString("11111111-2222-4333-8444-555555555503"))
                     o.stringType("creditorIban", "CZ6508000000192000145399")
                     o.stringType("creditorName", "Elektrárna a.s.")
                     o.stringType("status", "ACTIVE")

--- a/openbank-domestic-payment/src/test/kotlin/com/openbank/domestic/contract/DomesticPaymentTransactionServicePactConsumerTest.kt
+++ b/openbank-domestic-payment/src/test/kotlin/com/openbank/domestic/contract/DomesticPaymentTransactionServicePactConsumerTest.kt
@@ -59,7 +59,13 @@ class DomesticPaymentTransactionServicePactConsumerTest {
         .body(
             newJsonBody { o ->
                 o.uuid("id")
-                o.stringType("status", "PROCESSING")
+                // MEASURED, not assumed (issue #2425): pinning this value is what revealed
+                // that transaction-service answers POST /api/v1/transactions with COMPLETED —
+                // it books synchronously. Every consumer contract here claimed PENDING or
+                // PROCESSING, a status this response has never carried, and the `type` matcher
+                // made all four replays green about it for the life of the contracts.
+                // stringValue, NOT stringType: this is the field the consumer branches on.
+                o.stringValue("status", "COMPLETED")
             }.build(),
         )
         .toPact()
@@ -77,6 +83,6 @@ class DomesticPaymentTransactionServicePactConsumerTest {
             .extract().jsonPath()
 
         assertThat(body.getString("id")).isNotBlank()
-        assertThat(body.getString("status")).isNotBlank()
+        assertThat(body.getString("status")).isEqualTo("COMPLETED")
     }
 }

--- a/openbank-finrep-service/src/test/kotlin/com/openbank/finrep/contract/LedgerTrialBalancePactConsumerTest.kt
+++ b/openbank-finrep-service/src/test/kotlin/com/openbank/finrep/contract/LedgerTrialBalancePactConsumerTest.kt
@@ -93,8 +93,18 @@ class LedgerTrialBalancePactConsumerTest {
         .headers(mapOf("Content-Type" to "application/json"))
         .body(
             newJsonBody { o ->
-                o.stringType("asOf", REPORTING_DATE)
+                // stringValue, NOT stringType (issue #2425): `asOf` is echoed from the
+                // `asOf=` query parameter this interaction pins by literal. A trial balance
+                // returned for a DIFFERENT date than the one asked for is a reporting defect of
+                // the first order, and a type matcher accepted any date string at all.
+                o.stringValue("asOf", REPORTING_DATE)
                 o.booleanType("balanced", true)
+                // stringType on `code`/{currency,type}, DELIBERATELY (issue #2425): `lines`
+                // is a heterogeneous list — a real trial balance carries many GL codes, several
+                // currencies and every account type. Pinning an element value would assert
+                // "every line is this one code", a claim the contract does not make and real
+                // data would immediately falsify. The array is min=0 here anyway, so a pin
+                // would also be vacuous against the empty-DB provider.
                 o.minArrayLike("lines", 0, 1) { line ->
                     line.stringType("code", "1100-CASH-CLEARING-CZK")
                     line.stringType("type", "ASSET")
@@ -119,7 +129,11 @@ class LedgerTrialBalancePactConsumerTest {
         .headers(mapOf("Content-Type" to "application/json"))
         .body(
             newJsonBody { o ->
-                o.stringType("asOf", PRE_HISTORY_DATE)
+                // stringValue, NOT stringType (issue #2425): `asOf` is echoed from the
+                // `asOf=` query parameter this interaction pins by literal. A trial balance
+                // returned for a DIFFERENT date than the one asked for is a reporting defect of
+                // the first order, and a type matcher accepted any date string at all.
+                o.stringValue("asOf", PRE_HISTORY_DATE)
                 o.booleanType("balanced", true)
                 o.array("lines") // empty — a date before any ledger activity
             }.build(),

--- a/openbank-interest-service/src/test/kotlin/com/openbank/interest/contract/InterestLedgerPostJournalPactConsumerTest.kt
+++ b/openbank-interest-service/src/test/kotlin/com/openbank/interest/contract/InterestLedgerPostJournalPactConsumerTest.kt
@@ -122,7 +122,7 @@ class InterestLedgerPostJournalPactConsumerTest {
             newJsonBody { o ->
                 o.uuid("id")
                 o.uuid("transactionId")
-                o.stringType("status", "POSTED")
+                o.stringValue("status", "POSTED")
             }.build(),
         )
         .toPact()
@@ -142,7 +142,7 @@ class InterestLedgerPostJournalPactConsumerTest {
             newJsonBody { o ->
                 o.uuid("id")
                 o.uuid("transactionId")
-                o.stringType("status", "POSTED")
+                o.stringValue("status", "POSTED")
             }.build(),
         )
         .toPact()

--- a/openbank-lending-service/src/test/kotlin/com/openbank/lending/contract/LendingLedgerPostJournalPactConsumerTest.kt
+++ b/openbank-lending-service/src/test/kotlin/com/openbank/lending/contract/LendingLedgerPostJournalPactConsumerTest.kt
@@ -99,7 +99,11 @@ class LendingLedgerPostJournalPactConsumerTest {
             newJsonBody { o ->
                 o.uuid("id")
                 o.uuid("transactionId")
-                o.stringType("status", "POSTED")
+                // stringValue, NOT stringType (issue #2425): a balanced journal accepted by
+                // the ledger is POSTED — the value is the provider's answer to "did this
+                // post?", which is the entire reason the consumer makes the call. A type
+                // matcher accepted "REJECTED" just as happily.
+                o.stringValue("status", "POSTED")
             }.build(),
         )
         .toPact()

--- a/openbank-mcp-service/src/test/kotlin/com/openbank/mcp/contract/BalanceReadPactConsumerTest.kt
+++ b/openbank-mcp-service/src/test/kotlin/com/openbank/mcp/contract/BalanceReadPactConsumerTest.kt
@@ -69,6 +69,12 @@ class BalanceReadPactConsumerTest {
                 // min = 0: the provider replays against a fresh Testcontainer DB with no balances.
                 // The element template records the shape without requiring a row to exist.
                 o.minArrayLike("balances", 0, 1) { b ->
+                    // stringType, DELIBERATELY (issue #2425): this returns EVERY balance the
+                    // account holds and the request names no currency, so an account may
+                    // legitimately answer CZK, EUR and USD rows. Pinning would assert "every
+                    // balance is CZK". account-service's single-currency lookups
+                    // (/balances/{id}/{currency}) DO pin it — there the value is an echo of the
+                    // request, which is the line this sweep draws.
                     b.stringType("currency", "CZK")
                     b.decimalType("available", 1_000.00)
                 }

--- a/openbank-sepa-instant/src/test/kotlin/com/openbank/sepainstant/contract/SepaInstantTransactionServicePactConsumerTest.kt
+++ b/openbank-sepa-instant/src/test/kotlin/com/openbank/sepainstant/contract/SepaInstantTransactionServicePactConsumerTest.kt
@@ -64,7 +64,13 @@ class SepaInstantTransactionServicePactConsumerTest {
         .body(
             newJsonBody { o ->
                 o.uuid("id")
-                o.stringType("status", "PROCESSING")
+                // MEASURED, not assumed (issue #2425): pinning this value is what revealed
+                // that transaction-service answers POST /api/v1/transactions with COMPLETED —
+                // it books synchronously. Every consumer contract here claimed PENDING or
+                // PROCESSING, a status this response has never carried, and the `type` matcher
+                // made all four replays green about it for the life of the contracts.
+                // stringValue, NOT stringType: this is the field the consumer branches on.
+                o.stringValue("status", "COMPLETED")
             }.build(),
         )
         .toPact()
@@ -82,6 +88,6 @@ class SepaInstantTransactionServicePactConsumerTest {
             .extract().jsonPath()
 
         assertThat(body.getString("id")).isNotBlank()
-        assertThat(body.getString("status")).isNotBlank()
+        assertThat(body.getString("status")).isEqualTo("COMPLETED")
     }
 }

--- a/openbank-sepa-payment/src/test/kotlin/com/openbank/sepa/contract/SepaPaymentFraudServicePactConsumerTest.kt
+++ b/openbank-sepa-payment/src/test/kotlin/com/openbank/sepa/contract/SepaPaymentFraudServicePactConsumerTest.kt
@@ -50,6 +50,15 @@ class SepaPaymentFraudServicePactConsumerTest {
         .headers(mapOf("Content-Type" to "application/json"))
         .body(
             newJsonBody { o ->
+                // stringType, DELIBERATELY (issue #2425): `verdict` is the one field here that
+                // looks most like it should be pinned — it is a closed vocabulary the consumer
+                // branches on. It is left type-matched because it is a COMPUTED judgement, not
+                // an echo of the request or a fixed lifecycle value: the provider state is only
+                // "the fraud scoring engine is available", never "the engine will accept this".
+                // Pinning ACCEPT would make every scoring-threshold tweak a contract break,
+                // which is the coupling Pact exists to avoid. The honest fix is a provider state
+                // that fixes the outcome ("a payment the engine scores as ACCEPT"), which needs
+                // a matching @State handler in fraud-service — tracked, not done here.
                 o.stringType("verdict", "ACCEPT")
                 o.integerType("score", 10)
             }.build(),

--- a/openbank-sepa-payment/src/test/kotlin/com/openbank/sepa/contract/SepaPaymentTransactionServicePactConsumerTest.kt
+++ b/openbank-sepa-payment/src/test/kotlin/com/openbank/sepa/contract/SepaPaymentTransactionServicePactConsumerTest.kt
@@ -60,7 +60,13 @@ class SepaPaymentTransactionServicePactConsumerTest {
         .body(
             newJsonBody { o ->
                 o.uuid("id")
-                o.stringType("status", "PROCESSING")
+                // MEASURED, not assumed (issue #2425): pinning this value is what revealed
+                // that transaction-service answers POST /api/v1/transactions with COMPLETED —
+                // it books synchronously. Every consumer contract here claimed PENDING or
+                // PROCESSING, a status this response has never carried, and the `type` matcher
+                // made all four replays green about it for the life of the contracts.
+                // stringValue, NOT stringType: this is the field the consumer branches on.
+                o.stringValue("status", "COMPLETED")
             }.build(),
         )
         .toPact()
@@ -78,6 +84,6 @@ class SepaPaymentTransactionServicePactConsumerTest {
             .extract().jsonPath()
 
         assertThat(body.getString("id")).isNotBlank()
-        assertThat(body.getString("status")).isNotBlank()
+        assertThat(body.getString("status")).isEqualTo("COMPLETED")
     }
 }

--- a/openbank-settlement-service/src/test/kotlin/com/openbank/settlement/contract/SettlementLedgerPostJournalPactConsumerTest.kt
+++ b/openbank-settlement-service/src/test/kotlin/com/openbank/settlement/contract/SettlementLedgerPostJournalPactConsumerTest.kt
@@ -90,7 +90,11 @@ class SettlementLedgerPostJournalPactConsumerTest {
             newJsonBody { o ->
                 o.uuid("id")
                 o.uuid("transactionId")
-                o.stringType("status", "POSTED")
+                // stringValue, NOT stringType (issue #2425): a balanced journal accepted by
+                // the ledger is POSTED — the value is the provider's answer to "did this
+                // post?", which is the entire reason the consumer makes the call. A type
+                // matcher accepted "REJECTED" just as happily.
+                o.stringValue("status", "POSTED")
             }.build(),
         )
         .toPact()

--- a/openbank-swift-service/src/test/kotlin/com/openbank/swift/contract/SwiftEventPactConsumerTest.kt
+++ b/openbank-swift-service/src/test/kotlin/com/openbank/swift/contract/SwiftEventPactConsumerTest.kt
@@ -16,6 +16,9 @@ import com.fasterxml.jackson.databind.ObjectMapper
 import org.assertj.core.api.Assertions.assertThat
 import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.extension.ExtendWith
+import java.time.Instant
+import java.util.Date
+import java.util.TimeZone
 import java.util.UUID
 
 /**
@@ -50,7 +53,19 @@ class SwiftEventPactConsumerTest {
                 o.stringMatcher("messageType", "MT103|MT202|MX_PACS_008", "MT103")
                 o.decimalType("amount", 1000.00)
                 o.stringMatcher("currency", "[A-Z]{3}", "EUR")
-                o.datetime("occurredAt", "yyyy-MM-dd'T'HH:mm:ss'Z'")
+                // The example MUST be pinned to a fixed instant in UTC. The no-example overload
+                // renders pact-jvm's base date in the JVM's DEFAULT timezone while labelling it
+                // "Z", so the generated pact differed by the developer's UTC offset: committed
+                // from a CEST machine it read 14:00:00Z, regenerated on a UTC CI runner it read
+                // 13:00:00Z. pact-drift-check.yml regenerates and asserts `git diff
+                // --exit-code -- pacts/`, so that diff was non-empty on every CI run regardless
+                // of whether anything had changed — a gate that could not be satisfied.
+                o.datetime(
+                    "occurredAt",
+                    "yyyy-MM-dd'T'HH:mm:ss'Z'",
+                    Date.from(Instant.parse("2026-01-01T00:00:00Z")),
+                    TimeZone.getTimeZone("UTC"),
+                )
             }.build(),
         )
         .toPact()

--- a/openbank-transaction-service/src/test/kotlin/com/openbank/transaction/contract/FxRatePactConsumerTest.kt
+++ b/openbank-transaction-service/src/test/kotlin/com/openbank/transaction/contract/FxRatePactConsumerTest.kt
@@ -39,8 +39,18 @@ class FxRatePactConsumerTest {
         .headers(mapOf("Content-Type" to "application/json"))
         .body(
             newJsonBody { o ->
-                o.stringType("baseCurrency", "EUR")
-                o.stringType("quoteCurrency", "CZK")
+                // stringValue, NOT stringType: the currency pair IS the identity of the rate.
+                // A `type` matcher accepts any string, so a provider echoing the WRONG pair —
+                // the USD/CZK rate answered on the EUR/CZK route — verified green while the
+                // consumer went on to convert money at it. Measured on #2425: making the
+                // provider answer "USD"/"HUF" left FxPactFolderProviderVerificationTest green
+                // before this change and red after it.
+                //
+                // This is not over-coupling: the route is /rates/{base}/{quote}, so the response
+                // pair is a pure function of the request path this interaction pins by literal.
+                // The rates themselves stay decimal-matched — those genuinely move.
+                o.stringValue("baseCurrency", "EUR")
+                o.stringValue("quoteCurrency", "CZK")
                 o.decimalType("bidRate", 24.80)
                 o.decimalType("askRate", 25.20)
             }.build(),

--- a/openbank-transaction-service/src/test/kotlin/com/openbank/transaction/contract/LedgerPostJournalPactConsumerTest.kt
+++ b/openbank-transaction-service/src/test/kotlin/com/openbank/transaction/contract/LedgerPostJournalPactConsumerTest.kt
@@ -119,7 +119,11 @@ class LedgerPostJournalPactConsumerTest {
                 // Type matchers: the consumer cares about the shape, not the generated id.
                 o.uuid("id")
                 o.uuid("transactionId")
-                o.stringType("status", "POSTED")
+                // stringValue, NOT stringType (issue #2425): a balanced journal accepted by
+                // the ledger is POSTED — the value is the provider's answer to "did this
+                // post?", which is the entire reason the consumer makes the call. A type
+                // matcher accepted "REJECTED" just as happily.
+                o.stringValue("status", "POSTED")
             }.build(),
         )
         .toPact()

--- a/pacts/openbank-account-service-openbank-balance-service.json
+++ b/pacts/openbank-account-service-openbank-balance-service.json
@@ -70,14 +70,6 @@
                 }
               ]
             },
-            "$.currency": {
-              "combine": "AND",
-              "matchers": [
-                {
-                  "match": "type"
-                }
-              ]
-            },
             "$.pendingAmount": {
               "combine": "AND",
               "matchers": [
@@ -287,14 +279,6 @@
               "matchers": [
                 {
                   "match": "decimal"
-                }
-              ]
-            },
-            "$.currency": {
-              "combine": "AND",
-              "matchers": [
-                {
-                  "match": "type"
                 }
               ]
             },

--- a/pacts/openbank-account-service-openbank-transaction-service.json
+++ b/pacts/openbank-account-service-openbank-transaction-service.json
@@ -29,7 +29,7 @@
       "response": {
         "body": {
           "id": "e2490de5-5bd3-43d5-b7c4-526e33f71304",
-          "status": "PENDING"
+          "status": "COMPLETED"
         },
         "generators": {
           "body": {
@@ -49,14 +49,6 @@
                 {
                   "match": "regex",
                   "regex": "[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}"
-                }
-              ]
-            },
-            "$.status": {
-              "combine": "AND",
-              "matchers": [
-                {
-                  "match": "type"
                 }
               ]
             }

--- a/pacts/openbank-balance-service-openbank-ledger-service.json
+++ b/pacts/openbank-balance-service-openbank-ledger-service.json
@@ -40,14 +40,6 @@
         },
         "matchingRules": {
           "body": {
-            "$.asOf": {
-              "combine": "AND",
-              "matchers": [
-                {
-                  "match": "type"
-                }
-              ]
-            },
             "$.balanced": {
               "combine": "AND",
               "matchers": [
@@ -134,14 +126,6 @@
         },
         "matchingRules": {
           "body": {
-            "$.asOf": {
-              "combine": "AND",
-              "matchers": [
-                {
-                  "match": "type"
-                }
-              ]
-            },
             "$.balanced": {
               "combine": "AND",
               "matchers": [

--- a/pacts/openbank-billing-service-openbank-ledger-service.json
+++ b/pacts/openbank-billing-service-openbank-ledger-service.json
@@ -75,14 +75,6 @@
                 }
               ]
             },
-            "$.status": {
-              "combine": "AND",
-              "matchers": [
-                {
-                  "match": "type"
-                }
-              ]
-            },
             "$.transactionId": {
               "combine": "AND",
               "matchers": [

--- a/pacts/openbank-copilot-service-openbank-customer-edge.json
+++ b/pacts/openbank-copilot-service-openbank-customer-edge.json
@@ -88,7 +88,7 @@
             "cardType": "DEBIT",
             "currency": "CZK",
             "expiryDate": "2029-12-31",
-            "id": "1cc6f93f-9407-47c8-a4ac-10c7240b047e",
+            "id": "11111111-2222-4333-8444-555555555501",
             "maskedPan": "**** **** **** 1234",
             "network": "VISA",
             "status": "ACTIVE"
@@ -192,7 +192,7 @@
             "creditorName": "Elektr\u00E1rna a.s.",
             "currency": "CZK",
             "frequency": "MONTHLY",
-            "id": "59195df9-7b37-4053-b89d-f4736de73b46",
+            "id": "11111111-2222-4333-8444-555555555503",
             "nextExecutionDate": "2026-08-01",
             "remittanceInfo": "Elekt\u0159ina",
             "status": "ACTIVE"
@@ -451,7 +451,7 @@
           {
             "closingBalance": 1000.00,
             "entryCount": 12,
-            "id": "1761c48d-4290-4e0d-8c26-4eac4e3146ba",
+            "id": "11111111-2222-4333-8444-555555555502",
             "legalSequenceNumber": 7,
             "openingBalance": 900.00,
             "periodFrom": "2026-06-01",

--- a/pacts/openbank-domestic-payment-openbank-transaction-service.json
+++ b/pacts/openbank-domestic-payment-openbank-transaction-service.json
@@ -30,7 +30,7 @@
       "response": {
         "body": {
           "id": "e2490de5-5bd3-43d5-b7c4-526e33f71304",
-          "status": "PROCESSING"
+          "status": "COMPLETED"
         },
         "generators": {
           "body": {
@@ -50,14 +50,6 @@
                 {
                   "match": "regex",
                   "regex": "[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}"
-                }
-              ]
-            },
-            "$.status": {
-              "combine": "AND",
-              "matchers": [
-                {
-                  "match": "type"
                 }
               ]
             }

--- a/pacts/openbank-finrep-service-openbank-ledger-service.json
+++ b/pacts/openbank-finrep-service-openbank-ledger-service.json
@@ -39,14 +39,6 @@
         },
         "matchingRules": {
           "body": {
-            "$.asOf": {
-              "combine": "AND",
-              "matchers": [
-                {
-                  "match": "type"
-                }
-              ]
-            },
             "$.balanced": {
               "combine": "AND",
               "matchers": [
@@ -125,14 +117,6 @@
         },
         "matchingRules": {
           "body": {
-            "$.asOf": {
-              "combine": "AND",
-              "matchers": [
-                {
-                  "match": "type"
-                }
-              ]
-            },
             "$.balanced": {
               "combine": "AND",
               "matchers": [

--- a/pacts/openbank-interest-service-openbank-ledger-service.json
+++ b/pacts/openbank-interest-service-openbank-ledger-service.json
@@ -87,14 +87,6 @@
                 }
               ]
             },
-            "$.status": {
-              "combine": "AND",
-              "matchers": [
-                {
-                  "match": "type"
-                }
-              ]
-            },
             "$.transactionId": {
               "combine": "AND",
               "matchers": [
@@ -180,14 +172,6 @@
                 {
                   "match": "regex",
                   "regex": "[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}"
-                }
-              ]
-            },
-            "$.status": {
-              "combine": "AND",
-              "matchers": [
-                {
-                  "match": "type"
                 }
               ]
             },

--- a/pacts/openbank-lending-service-openbank-ledger-service.json
+++ b/pacts/openbank-lending-service-openbank-ledger-service.json
@@ -75,14 +75,6 @@
                 }
               ]
             },
-            "$.status": {
-              "combine": "AND",
-              "matchers": [
-                {
-                  "match": "type"
-                }
-              ]
-            },
             "$.transactionId": {
               "combine": "AND",
               "matchers": [

--- a/pacts/openbank-sepa-instant-openbank-transaction-service.json
+++ b/pacts/openbank-sepa-instant-openbank-transaction-service.json
@@ -31,7 +31,7 @@
       "response": {
         "body": {
           "id": "e2490de5-5bd3-43d5-b7c4-526e33f71304",
-          "status": "PROCESSING"
+          "status": "COMPLETED"
         },
         "generators": {
           "body": {
@@ -51,14 +51,6 @@
                 {
                   "match": "regex",
                   "regex": "[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}"
-                }
-              ]
-            },
-            "$.status": {
-              "combine": "AND",
-              "matchers": [
-                {
-                  "match": "type"
                 }
               ]
             }

--- a/pacts/openbank-sepa-payment-openbank-transaction-service.json
+++ b/pacts/openbank-sepa-payment-openbank-transaction-service.json
@@ -30,7 +30,7 @@
       "response": {
         "body": {
           "id": "e2490de5-5bd3-43d5-b7c4-526e33f71304",
-          "status": "PROCESSING"
+          "status": "COMPLETED"
         },
         "generators": {
           "body": {
@@ -50,14 +50,6 @@
                 {
                   "match": "regex",
                   "regex": "[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}"
-                }
-              ]
-            },
-            "$.status": {
-              "combine": "AND",
-              "matchers": [
-                {
-                  "match": "type"
                 }
               ]
             }

--- a/pacts/openbank-settlement-service-openbank-ledger-service.json
+++ b/pacts/openbank-settlement-service-openbank-ledger-service.json
@@ -75,14 +75,6 @@
                 }
               ]
             },
-            "$.status": {
-              "combine": "AND",
-              "matchers": [
-                {
-                  "match": "type"
-                }
-              ]
-            },
             "$.transactionId": {
               "combine": "AND",
               "matchers": [

--- a/pacts/openbank-transaction-service-openbank-fx-service.json
+++ b/pacts/openbank-transaction-service-openbank-fx-service.json
@@ -34,27 +34,11 @@
                 }
               ]
             },
-            "$.baseCurrency": {
-              "combine": "AND",
-              "matchers": [
-                {
-                  "match": "type"
-                }
-              ]
-            },
             "$.bidRate": {
               "combine": "AND",
               "matchers": [
                 {
                   "match": "decimal"
-                }
-              ]
-            },
-            "$.quoteCurrency": {
-              "combine": "AND",
-              "matchers": [
-                {
-                  "match": "type"
                 }
               ]
             }

--- a/pacts/openbank-transaction-service-openbank-ledger-service.json
+++ b/pacts/openbank-transaction-service-openbank-ledger-service.json
@@ -77,14 +77,6 @@
                 }
               ]
             },
-            "$.status": {
-              "combine": "AND",
-              "matchers": [
-                {
-                  "match": "type"
-                }
-              ]
-            },
             "$.transactionId": {
               "combine": "AND",
               "matchers": [

--- a/pacts/openbank-transaction-service-openbank-swift-service.json
+++ b/pacts/openbank-transaction-service-openbank-swift-service.json
@@ -8,7 +8,7 @@
         "amount": 1000.0,
         "currency": "EUR",
         "messageType": "MT103",
-        "occurredAt": "2000-01-31T14:00:00Z",
+        "occurredAt": "2026-01-01T00:00:00Z",
         "paymentSagaRef": "string",
         "status": "COMPLETED",
         "swiftMessageId": "e2490de5-5bd3-43d5-b7c4-526e33f71304"
@@ -16,10 +16,6 @@
       "description": "a swift.message.status-changed event with status COMPLETED",
       "generators": {
         "body": {
-          "$.occurredAt": {
-            "format": "yyyy-MM-dd'T'HH:mm:ss'Z'",
-            "type": "DateTime"
-          },
           "$.paymentSagaRef": {
             "size": 20,
             "type": "RandomString"


### PR DESCRIPTION
## What

A `stringType()` / `like()` matcher accepts **any** string, so a pact that type-matches an enum-like field verifies green when the provider returns a different value of the same type. #2477 fixed the notification-service instance; this is the **money-path half** of the fleet sweep for #2425.

## The line this PR draws

Pin a value when it is an **echo of the request** or a **fixed lifecycle outcome**. Leave it type-matched when it is a **computed judgement** or **free-form payload** — pinning shape-only data is exactly the coupling Pact exists to avoid. Every deliberate leave is documented at the call site, so the next reader sees a decision rather than an oversight.

## Pinned

| Provider | Field | Why |
|---|---|---|
| **fx-service** | `baseCurrency` / `quoteCurrency` | The currency pair **is** the rate's identity, and a pure function of the `/rates/{base}/{quote}` path |
| **balance-service** | `currency` (2 single-currency interactions) | Path segment / request-body field the response echoes |
| **ledger-service** | `status` (5 journal-posting contracts) | The provider's answer to "did this post?" — the reason the call is made |
| **ledger-service** | `asOf` (2 trial-balance contracts) | Echoed from the `asOf=` query param; a FINREP trial balance dated wrong is a reporting defect |
| **transaction-service** | `status` (4 `POST /transactions` contracts) | The field the consumer branches on |

## A live defect this surfaced

Pinning the transaction status revealed that **transaction-service answers `POST /api/v1/transactions` with `COMPLETED`** — it books synchronously — while all four consumer contracts claimed `PENDING` or `PROCESSING`, a status that response has never carried. account-service's KDoc even explained the asynchronous saga that would have produced `PENDING`.

The type matcher made every one of those replays green about it for the life of the contracts. The pacts and the stale prose now say what the provider actually returns.

## Deliberately left type-matched

- **`fraud-service` `verdict`** — the field that *looks* most like it should be pinned, and the most interesting call. It is a **computed decision**, not an echo: the provider state is only "the fraud scoring engine is available", never "the engine will accept this". Pinning `ACCEPT` would make every scoring-threshold tweak a contract break. The honest fix is an outcome-fixing provider state plus a matching `@State` handler in fraud-service — noted in the test, not done here.
- **`balances[*].currency`** (account-service list endpoint, mcp-service) — the request names no currency and an account may legitimately hold CZK, EUR and USD rows, so a pin would assert "every balance is CZK". The *single*-currency lookups do pin it.
- **trial-balance `lines[*].code` / `currency` / `type`** — a heterogeneous GL list; a pin would assert every line carries one code. The array is `min=0` against the empty-DB provider, so it would be vacuous as well as wrong.
- Timestamps, generated ids, IBANs, names and narrative text throughout.

## Falsification — measured, not reasoned

The asymmetry *is* the test, so each pin was proven by breaking the provider. Verdicts read from the JUnit XML, not the console.

**fx-service** (money path) — `FxPactFolderProviderVerificationTest`:

| Pact | Provider | Result |
|---|---|---|
| new (pinned) | unmodified | **1/1 pass** |
| new (pinned) | returns `USD`/`HUF` on the `EUR/CZK` route | **1/1 FAIL** — `$.baseCurrency Expected 'USD' to be equal to 'EUR'` |
| **old (type-matched)** | returns `USD`/`HUF` | **1/1 pass** ← the hole |

**ledger-service** — `LedgerPactProviderVerificationTest`:

| Pact | Provider | Result |
|---|---|---|
| new (pinned) | unmodified | **10/10 pass** |
| new (pinned) | returns `REVERSED` | **6 FAIL** |
| **old (type-matched)** | returns `REVERSED` | **10/10 pass** ← the hole |

**transaction-service** — falsified itself: the pins went red against the real provider (`Expected 'COMPLETED' to be equal to 'PROCESSING'` ×3, `'PENDING'` ×1), which is how the defect above was found. Green 6/6 once the contracts were corrected to observed truth.

**balance-service** — `BalancePactFolderProviderVerificationTest` 6/6 green with the pins.

## Gates

- All 13 pacts regenerated by running their consumer tests — **never hand-edited**.
- `derive-pact-drift-scope.sh` + full regeneration: **no drift**.
- `check-pact-provider-replay.py`: **34/34** replayed on a PR, `KNOWN_UNCOVERED` still empty.
- `detekt` + `ktlintCheck` green on all 12 touched modules.

## Follow-ups (not in this PR)

- Non-money-path survivors — product-catalog, sca-service, customer-edge, consent-service — follow in a second PR, to keep this one reviewable.
- `pacts/openbank-copilot-service-openbank-customer-edge.json` regenerates with **fresh random UUIDs every run** (`uuid()` with no fixed example), so `pact-drift-check.yml` can never be satisfied for that file. Pre-existing, unrelated, reverted here; worth its own fix.

Refs #2425