### PR TITLE
fix(infra): add ROLE_DEMO to the realm template to close the live-vs-declared drift (#2442)

### DIFF
--- a/openbank-infra/gitops/components/keycloak/realm-template.json
+++ b/openbank-infra/gitops/components/keycloak/realm-template.json
@@ -77,6 +77,10 @@
       {
         "name": "ROLE_LENDING_OFFICER",
         "description": "Lending officer: opens and services loan applications, cannot take the credit decision (four-eyes with ROLE_CREDIT_RISK). Declared in @RolesAllowed since the service shipped; created here by issue #2442"
+      },
+      {
+        "name": "ROLE_DEMO",
+        "description": "Demo/guided-tour badge shown by the admin-UI (src/lib/auth/roles.ts). Existed in the live sandbox realm and in the docker dev realm but was missing here, so a cold-started cluster would not have it — added by the #2442 drift reconciliation"
       }
     ]
   },


### PR DESCRIPTION
## Co

Srovnání sandbox realmu po grantu z #2442 odhalilo drift **v obou směrech** mezi `realm-template.json` a živým realmem:

| směr | role |
|---|---|
| v template, **ne** živě | `ROLE_KYC`, `ROLE_KYC_OPENER`, `ROLE_KYC_REVIEWER`, `ROLE_SUPERVISOR` |
| živě, **ne** v template | `ROLE_DEMO` |

Ty čtyři chybějící jsem vytvořil na živém realmu přes `kcadm` (template se čte jen při `--import-realm`, tedy cold startu — sám by je nikdy neaplikoval). Tenhle commit řeší druhý směr: `ROLE_DEMO` používá admin-UI (`src/lib/auth/roles.ts` ji vykresluje jako badge) a je v docker dev realmu, ale tady chyběla — cold-started cluster by ji neměl.

## Dopad těch čtyř — změřený, ne odhadnutý

20 `@RolesAllowed` míst ve službách kyc, onboarding, balance a party je jmenovalo. **Žádné** nebylo úplně nedostupné — každá anotace uváděla i roli, kterou živý realm má.

Cena byla jemnější: **ADR-0116 KYC four-eyes** (`ROLE_KYC_OPENER` otevírá, `ROLE_KYC_REVIEWER` schvaluje) nemůže být vynucený rolemi, které neexistují. Obě poloviny propadly na `ROLE_ADMIN`/`ROLE_OPERATOR`, takže jedna identita mohla udělat obojí. Separation of duties byla deklarovaná, ale nevynutitelná.

## Co to říká o bráně z #2418

`check-roles-allowed-realm.py` porovnává kód s **template**, takže byla celou dobu zelená — template každou jmenovanou roli deklaroval. **Nic neporovnává template s realmem, který skutečně běží.**

To je táž třída „měří deklaraci, ne realitu", kterou tahle série honí celý den, jen o vrstvu dál. Zakládám samostatně.

## Ověření

- template i živý realm drží identických **14** rolí, nulový rozdíl v obou směrech
- `check-roles-allowed-realm.py` exit 0 proti 16 rolím napříč oběma realm templaty

## Linked issues

Refs #2442