### PR TITLE
test(consent): pin the SCA purpose, status and product code by value, and stop a pact drifting on every run

### DIFF
--- a/openbank-card-issuance-service/src/test/kotlin/com/openbank/cardissuance/contract/ProductCatalogPactConsumerTest.kt
+++ b/openbank-card-issuance-service/src/test/kotlin/com/openbank/cardissuance/contract/ProductCatalogPactConsumerTest.kt
@@ -98,7 +98,13 @@ class ProductCatalogPactConsumerTest {
                 // The seeder rewrites `id` to the canonical derived UUID (ADR-0105), so only the
                 // type is contractual; the consumer never parses it as a UUID.
                 o.stringType("id", "prod-003")
-                o.stringType("code", CARD_ENABLED_CODE)
+                // stringValue, NOT stringType (issue #2425): `code` is echoed from the request
+                // path this interaction pins by literal, and the provider state is named after
+                // it. A product-catalog that answered the by-code lookup with a DIFFERENT
+                // product is precisely the defect this interaction exists to rule out, and a
+                // type matcher accepted any string at all. `id` above stays type-matched — it is
+                // a seed-data surrogate key with no meaning to the consumer.
+                o.stringValue("code", CARD_ENABLED_CODE)
                 o.`object`("cardConfig") { c ->
                     c.booleanType("enabled", true)
                     c.integerType("maxCards", 3)

--- a/openbank-consent-service/src/test/kotlin/com/openbank/consent/contract/ConsentScaChallengePactConsumerTest.kt
+++ b/openbank-consent-service/src/test/kotlin/com/openbank/consent/contract/ConsentScaChallengePactConsumerTest.kt
@@ -44,8 +44,15 @@ class ConsentScaChallengePactConsumerTest {
             newJsonBody { o ->
                 o.uuid("id")
                 o.uuid("partyId")
-                o.stringType("purpose", "CONSENT_GRANT")
-                o.stringType("status", "PENDING")
+                // stringValue, NOT stringType (issue #2425): both are closed vocabularies fixed
+                // by the provider state — "a PENDING SCA challenge exists" names the status
+                // outright, and sca-service's @State handler seeds purpose = CONSENT_GRANT.
+                // consent-service branches on both: `status` decides whether the consent may be
+                // activated at all, and `purpose` is what stops an SCA challenge raised for a
+                // PAYMENT from being spent to grant a consent. A type matcher accepted any
+                // string for either, so the replay was asked nothing about the values.
+                o.stringValue("purpose", "CONSENT_GRANT")
+                o.stringValue("status", "PENDING")
             }.build(),
         )
         .toPact()

--- a/openbank-copilot-service/src/test/kotlin/com/openbank/copilot/contract/CustomerEdgePactConsumerTest.kt
+++ b/openbank-copilot-service/src/test/kotlin/com/openbank/copilot/contract/CustomerEdgePactConsumerTest.kt
@@ -51,6 +51,28 @@ import java.util.UUID
  * (`./gradlew :openbank-copilot-service:test --tests "*CustomerEdgePactConsumerTest*"`) and
  * commit the updated pact JSON in the same PR.
  */
+/**
+ * MATCHER POLICY (issue #2425) — why nothing here is pinned by value.
+ *
+ * The #2425 sweep pins enum-like strings with `stringValue` wherever a `type` matcher made the
+ * assertion vacuous. Every interaction in THIS file was reviewed and every string was deliberately
+ * left type-matched, because they share one property: they are elements of a heterogeneous LIST,
+ * and none of them is echoed from the request.
+ *
+ * A customer legitimately holds a CURRENT and a SAVINGS account, in CZK and in EUR; a DEBIT and a
+ * CREDIT card, on VISA and on Mastercard; transactions of many types and statuses; and the FX
+ * endpoint returns every pair the bank quotes. Pinning `accountType` to "CURRENT" would not assert
+ * "the type is spelled correctly" — it would assert "the customer's only account is a current
+ * account", a claim this contract does not make and the first customer with a savings account
+ * falsifies. The seeded provider state happens to contain one element of each; that is a property
+ * of the fixture, not of the contract.
+ *
+ * The line the sweep draws is echo-or-lifecycle vs list-element: pin a value that the request
+ * determines (a currency in the path, an `asOf` query parameter, a product code) or that the
+ * provider's own lifecycle fixes (a freshly posted journal is POSTED). Leave a list element alone.
+ * The sibling pins under #2533 — fx-service's currency pair, ledger-service's `asOf` and journal
+ * status — are all the former; nothing here is.
+ */
 @ExtendWith(PactConsumerTestExt::class)
 @PactTestFor(providerName = "openbank-customer-edge", pactVersion = PactSpecVersion.V3)
 class CustomerEdgePactConsumerTest {
@@ -234,7 +256,7 @@ class CustomerEdgePactConsumerTest {
         .body(
             LambdaDsl.newJsonArrayMinLike(1) { arr ->
                 arr.`object` { o ->
-                    o.uuid("id", UUID.randomUUID())
+                    o.uuid("id", UUID.fromString("11111111-2222-4333-8444-555555555501"))
                     o.stringType("maskedPan", "**** **** **** 1234")
                     o.stringType("cardType", "DEBIT")
                     o.stringType("network", "VISA")
@@ -273,7 +295,7 @@ class CustomerEdgePactConsumerTest {
         .body(
             LambdaDsl.newJsonArrayMinLike(1) { arr ->
                 arr.`object` { o ->
-                    o.uuid("id", UUID.randomUUID())
+                    o.uuid("id", UUID.fromString("11111111-2222-4333-8444-555555555502"))
                     o.stringType("pocketCurrency", "CZK")
                     o.stringType("periodFrom", "2026-06-01")
                     o.stringType("periodTo", "2026-06-30")
@@ -315,7 +337,7 @@ class CustomerEdgePactConsumerTest {
         .body(
             LambdaDsl.newJsonArrayMinLike(1) { arr ->
                 arr.`object` { o ->
-                    o.uuid("id", UUID.randomUUID())
+                    o.uuid("id", UUID.fromString("11111111-2222-4333-8444-555555555503"))
                     o.stringType("creditorIban", "CZ6508000000192000145399")
                     o.stringType("creditorName", "Elektrárna a.s.")
                     o.stringType("status", "ACTIVE")

--- a/openbank-swift-service/src/test/kotlin/com/openbank/swift/contract/SwiftEventPactConsumerTest.kt
+++ b/openbank-swift-service/src/test/kotlin/com/openbank/swift/contract/SwiftEventPactConsumerTest.kt
@@ -16,6 +16,9 @@ import com.fasterxml.jackson.databind.ObjectMapper
 import org.assertj.core.api.Assertions.assertThat
 import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.extension.ExtendWith
+import java.time.Instant
+import java.util.Date
+import java.util.TimeZone
 import java.util.UUID
 
 /**
@@ -50,7 +53,19 @@ class SwiftEventPactConsumerTest {
                 o.stringMatcher("messageType", "MT103|MT202|MX_PACS_008", "MT103")
                 o.decimalType("amount", 1000.00)
                 o.stringMatcher("currency", "[A-Z]{3}", "EUR")
-                o.datetime("occurredAt", "yyyy-MM-dd'T'HH:mm:ss'Z'")
+                // The example MUST be pinned to a fixed instant in UTC. The no-example overload
+                // renders pact-jvm's base date in the JVM's DEFAULT timezone while labelling it
+                // "Z", so the generated pact differed by the developer's UTC offset: committed
+                // from a CEST machine it read 14:00:00Z, regenerated on a UTC CI runner it read
+                // 13:00:00Z. pact-drift-check.yml regenerates and asserts `git diff
+                // --exit-code -- pacts/`, so that diff was non-empty on every CI run regardless
+                // of whether anything had changed — a gate that could not be satisfied.
+                o.datetime(
+                    "occurredAt",
+                    "yyyy-MM-dd'T'HH:mm:ss'Z'",
+                    Date.from(Instant.parse("2026-01-01T00:00:00Z")),
+                    TimeZone.getTimeZone("UTC"),
+                )
             }.build(),
         )
         .toPact()

--- a/pacts/openbank-card-issuance-service-openbank-product-catalog.json
+++ b/pacts/openbank-card-issuance-service-openbank-product-catalog.json
@@ -114,14 +114,6 @@
                 }
               ]
             },
-            "$.code": {
-              "combine": "AND",
-              "matchers": [
-                {
-                  "match": "type"
-                }
-              ]
-            },
             "$.id": {
               "combine": "AND",
               "matchers": [

--- a/pacts/openbank-consent-service-openbank-sca-service.json
+++ b/pacts/openbank-consent-service-openbank-sca-service.json
@@ -53,22 +53,6 @@
                   "regex": "[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}"
                 }
               ]
-            },
-            "$.purpose": {
-              "combine": "AND",
-              "matchers": [
-                {
-                  "match": "type"
-                }
-              ]
-            },
-            "$.status": {
-              "combine": "AND",
-              "matchers": [
-                {
-                  "match": "type"
-                }
-              ]
             }
           }
         },

--- a/pacts/openbank-copilot-service-openbank-customer-edge.json
+++ b/pacts/openbank-copilot-service-openbank-customer-edge.json
@@ -88,7 +88,7 @@
             "cardType": "DEBIT",
             "currency": "CZK",
             "expiryDate": "2029-12-31",
-            "id": "1cc6f93f-9407-47c8-a4ac-10c7240b047e",
+            "id": "11111111-2222-4333-8444-555555555501",
             "maskedPan": "**** **** **** 1234",
             "network": "VISA",
             "status": "ACTIVE"
@@ -192,7 +192,7 @@
             "creditorName": "Elektr\u00E1rna a.s.",
             "currency": "CZK",
             "frequency": "MONTHLY",
-            "id": "59195df9-7b37-4053-b89d-f4736de73b46",
+            "id": "11111111-2222-4333-8444-555555555503",
             "nextExecutionDate": "2026-08-01",
             "remittanceInfo": "Elekt\u0159ina",
             "status": "ACTIVE"
@@ -451,7 +451,7 @@
           {
             "closingBalance": 1000.00,
             "entryCount": 12,
-            "id": "1761c48d-4290-4e0d-8c26-4eac4e3146ba",
+            "id": "11111111-2222-4333-8444-555555555502",
             "legalSequenceNumber": 7,
             "openingBalance": 900.00,
             "periodFrom": "2026-06-01",

--- a/pacts/openbank-transaction-service-openbank-swift-service.json
+++ b/pacts/openbank-transaction-service-openbank-swift-service.json
@@ -8,7 +8,7 @@
         "amount": 1000.0,
         "currency": "EUR",
         "messageType": "MT103",
-        "occurredAt": "2000-01-31T14:00:00Z",
+        "occurredAt": "2026-01-01T00:00:00Z",
         "paymentSagaRef": "string",
         "status": "COMPLETED",
         "swiftMessageId": "e2490de5-5bd3-43d5-b7c4-526e33f71304"
@@ -16,10 +16,6 @@
       "description": "a swift.message.status-changed event with status COMPLETED",
       "generators": {
         "body": {
-          "$.occurredAt": {
-            "format": "yyyy-MM-dd'T'HH:mm:ss'Z'",
-            "type": "DateTime"
-          },
           "$.paymentSagaRef": {
             "size": 20,
             "type": "RandomString"


### PR DESCRIPTION
The non-money-path tail of the #2425 sweep, after #2533. Same rule as that PR: **pin a value when it is an echo of the request or fixed by the provider's own state; leave it type-matched when it is a list element or a computed judgement.**

## Pinned

| Provider | Field | Why |
|---|---|---|
| **sca-service** | `purpose`, `status` | Both fixed by the provider state — `"a PENDING SCA challenge exists"` names the status outright, and the `@State` handler seeds `purpose = CONSENT_GRANT`. consent-service branches on both: `status` decides whether the consent may be activated, and `purpose` is what stops a challenge raised for a `PAYMENT_INITIATION` being spent to grant a consent. |
| **product-catalog** | `code` | Echoed from the `/by-code/{code}` path the interaction pins by literal. A catalog answering the by-code lookup with a *different* product is the defect the interaction exists to rule out. |

## Deliberately left type-matched — all of copilot-service → customer-edge

This is the file with the most enum-looking fields in the estate (`accountType`, `status`, `network`, `cardType`, `frequency`, `currencyCode`, `type`, FX `base`/`quote`), and **none of them is pinned**. The reasoning is recorded in a `MATCHER POLICY` KDoc block on the test so the next reader sees a decision, not an oversight.

Every string there is an element of a **heterogeneous list**, and none is echoed from the request. A customer legitimately holds a CURRENT *and* a SAVINGS account, in CZK *and* EUR; a DEBIT *and* a CREDIT card, on VISA *and* Mastercard; the FX endpoint returns every pair the bank quotes. Pinning `accountType` to `CURRENT` would not assert "the type is spelled right" — it would assert *"the customer's only account is a current account"*, a claim this contract does not make and the first savings account falsifies. The seeded state happening to hold one of each is a property of the fixture, not of the contract.

Also left: product-catalog's `networks`/`tiers` arrays (the adapter drops them — already documented in the test), its surrogate `id`, and the 404 error prose.

## Falsification — measured, not reasoned

Verdicts read from the JUnit XML, not the console.

**sca-service** — `ScaPactFolderProviderVerificationTest`, provider state seeded `PAYMENT_INITIATION` instead of `CONSENT_GRANT`:

| Pact | Result |
|---|---|
| new (pinned) | **FAIL** — `$.purpose Expected 'PAYMENT_INITIATION' to be equal to 'CONSENT_GRANT'` |
| **old (type-matched)** | **1/1 pass** ← the hole |

**product-catalog** — `ProductCatalogPactProviderVerificationTest`, resource patched to answer `SAVINGS_PERSONAL`:

| Pact | Result |
|---|---|
| new (pinned) | **1 FAIL** — `$.code Expected 'SAVINGS_PERSONAL' to be equal to 'CURRENT_PERSONAL'` |
| **old (type-matched)** | **2/2 pass** ← the hole |

Unmodified providers with the new pacts: product-catalog 2/2, sca-service 1/1, customer-edge 7/7 green.

## Bonus: a gate that could never be green

`pacts/openbank-copilot-service-openbank-customer-edge.json` regenerated with **three fresh random UUIDs on every run** — `uuid("id", UUID.randomUUID())`. `pact-drift-check.yml` regenerates consumer pacts and asserts `git diff --exit-code -- pacts/`, so that file produced a non-empty diff whether or not anything had actually changed — the "gate that cannot be satisfied" class this repo works to avoid.

Fixed examples now. Verified by doing it: two consecutive regenerations are byte-identical, and a full regeneration across all 23 gated modules touches only the three files this PR intends to change.

## Gates

- All pacts regenerated by running their consumer tests — **never hand-edited**.
- Full `derive-pact-drift-scope.sh` regeneration: only the three intended files differ.
- `check-pact-provider-replay.py`: **34/34**, `KNOWN_UNCOVERED` still empty.
- `detekt` + `ktlintCheck` green on all three touched modules.

Closes #2425 — with #2533, every field the sweep judged enum-like or identity-bearing is now pinned by value.