### PR TITLE
fix(notification): fail closed on marketing push and suppress marketing email (ADR-0198 D4)

### DIFF
--- a/openbank-notification-service/src/main/kotlin/com/openbank/notification/application/NotificationConsumer.kt
+++ b/openbank-notification-service/src/main/kotlin/com/openbank/notification/application/NotificationConsumer.kt
@@ -162,7 +162,7 @@ class NotificationConsumer {
         return Panache.withTransaction { notificationRepo.persist(entity) }
             .chain { _ ->
                 when (req.channel) {
-                    NotificationChannel.EMAIL -> sendEmail(req, subject, body, entity)
+                    NotificationChannel.EMAIL -> maybeSendEmail(req, subject, body, entity)
                     NotificationChannel.PUSH -> maybeSendPush(req, subject, entity)
                 }
             }
@@ -251,6 +251,40 @@ class NotificationConsumer {
     // error AFTER a successful send would silently mark the row FAILED for a message the
     // customer actually received, and the "stub mode" log message conflated the two failure
     // cases into one line.
+    /**
+     * Refuses to send a MARKETING-category EMAIL, and otherwise sends (ADR-0198 D4, issue #2369).
+     *
+     * EMAIL previously had NO gate of any kind — unlike PUSH it never consulted even the local
+     * preference row, so a marketing email would have gone out unconditionally. That asymmetry is
+     * not fixable by reading `notification_preference`: its columns (`payments_push`,
+     * `product_push`, `marketing_push`) are push-specific, and none of them is the GDPR Art. 6(1)(a)
+     * consent record anyway — consent-service owns that (`party-service:marketing-comms`,
+     * ADR-0205 D3).
+     *
+     * So this fails CLOSED rather than pretending to check: consent-gated email is SUPPRESSED until
+     * a real consent check exists. PAYMENTS / PRODUCT / SECURITY email is unchanged (contract and
+     * legitimate-interest bases, no opt-in required), so no live traffic changes. No template maps
+     * to MARKETING today (`NotificationTemplateCategoryTest` guards that), which is why declining
+     * here is correct rather than a feature regression — there is nothing to decline yet.
+     */
+    private fun maybeSendEmail(
+        req: NotificationRequest,
+        subject: String,
+        body: String,
+        entity: NotificationEntity,
+    ): Uni<Void> {
+        if (req.template.category == NotificationCategory.MARKETING) {
+            log.warnf(
+                "EMAIL suppressed: template=%s is MARKETING-category and no consent check is wired " +
+                    "(ADR-0198 D4). Wire consent-service validate (scope MARKETING_COMMS_EMAIL) before " +
+                    "sending consent-gated email.",
+                req.template,
+            )
+            return markStatus(entity, "SUPPRESSED")
+        }
+        return sendEmail(req, subject, body, entity)
+    }
+
     private fun sendEmail(
         req: NotificationRequest,
         subject: String,

--- a/openbank-notification-service/src/main/kotlin/com/openbank/notification/application/NotificationConsumer.kt
+++ b/openbank-notification-service/src/main/kotlin/com/openbank/notification/application/NotificationConsumer.kt
@@ -298,6 +298,21 @@ class NotificationConsumer {
      * Gate a PUSH by the party's preferences (#2). SECURITY-category notifications (OTP, SCA, KYC,
      * account freeze) always send. For a togglable category, a missing preference row means "on";
      * a muted category records the notification as SUPPRESSED and skips egress.
+     *
+     * MARKETING is the exception and is fail-CLOSED (ADR-0198 D4, issue #2369). PAYMENTS/PRODUCT
+     * ride contract / legitimate-interest bases, so "no preference row yet" legitimately means
+     * "send". Marketing does not: under GDPR Art. 6(1)(a) it needs an affirmative opt-in, and
+     * `notification_preference.marketing_push` is a LOCAL toggle, not that consent record —
+     * consent-service owns it (`party-service:marketing-comms`, ADR-0205 D3). Defaulting to `true`
+     * here meant an absent preference row would have sent marketing to a party who never consented.
+     *
+     * No template maps to MARKETING today ([NotificationTemplate.category] is exhaustive and never
+     * yields it), so this branch is currently unreachable — deliberately NOT wired to a
+     * consent-service HTTP call, which would add a money-path dependency for a caller that does not
+     * exist. `NotificationTemplateCategoryTest` asserts that unreachability, so the day a MARKETING
+     * template IS added the test goes red and whoever adds it has to wire the real consent check
+     * (consent-service `POST /api/v1/consents/{id}/validate`, scope MARKETING_COMMS_PUSH) rather
+     * than inheriting a silent local-toggle default.
      */
     private fun maybeSendPush(req: NotificationRequest, subject: String, entity: NotificationEntity): Uni<Void> {
         val category = req.template.category
@@ -306,7 +321,8 @@ class NotificationConsumer {
             val enabled = when (category) {
                 NotificationCategory.PAYMENTS -> pref?.paymentsPush ?: true
                 NotificationCategory.PRODUCT -> pref?.productPush ?: true
-                NotificationCategory.MARKETING -> pref?.marketingPush ?: true
+                // Fail-closed: absent preference row => do NOT send (see KDoc above).
+                NotificationCategory.MARKETING -> pref?.marketingPush ?: false
                 NotificationCategory.SECURITY -> true
             }
             if (enabled) {

--- a/openbank-notification-service/src/main/kotlin/com/openbank/notification/application/NotificationConsumer.kt
+++ b/openbank-notification-service/src/main/kotlin/com/openbank/notification/application/NotificationConsumer.kt
@@ -161,9 +161,18 @@ class NotificationConsumer {
         }
         return Panache.withTransaction { notificationRepo.persist(entity) }
             .chain { _ ->
-                when (req.channel) {
-                    NotificationChannel.EMAIL -> maybeSendEmail(req, subject, body, entity)
-                    NotificationChannel.PUSH -> maybeSendPush(req, subject, entity)
+                // Consent gate BEFORE the channel dispatch (ADR-0198 D4, issue #2369). Deliberately
+                // NOT a per-channel check: the defect the issue names is precisely that gating lived
+                // inside the channel branches, so PUSH got a (default-true) check and EMAIL got none,
+                // and any channel added later would inherit whichever the author remembered. One gate
+                // ahead of the `when` cannot be forgotten by a new branch.
+                if (req.template.category == NotificationCategory.MARKETING) {
+                    suppressUnconsentedMarketing(req, entity)
+                } else {
+                    when (req.channel) {
+                        NotificationChannel.EMAIL -> sendEmail(req, subject, body, entity)
+                        NotificationChannel.PUSH -> maybeSendPush(req, subject, entity)
+                    }
                 }
             }
             // Oversight side-channel (ADR-0059): for allow-listed risk templates, also
@@ -252,37 +261,63 @@ class NotificationConsumer {
     // customer actually received, and the "stub mode" log message conflated the two failure
     // cases into one line.
     /**
-     * Refuses to send a MARKETING-category EMAIL, and otherwise sends (ADR-0198 D4, issue #2369).
+     * Records a marketing send as SUPPRESSED and emits an audit event (ADR-0198 §"A marketing send
+     * with no ACTIVE consent for the target channel records SUPPRESSED and emits an audit event").
      *
-     * EMAIL previously had NO gate of any kind — unlike PUSH it never consulted even the local
-     * preference row, so a marketing email would have gone out unconditionally. That asymmetry is
-     * not fixable by reading `notification_preference`: its columns (`payments_push`,
-     * `product_push`, `marketing_push`) are push-specific, and none of them is the GDPR Art. 6(1)(a)
-     * consent record anyway — consent-service owns that (`party-service:marketing-comms`,
-     * ADR-0205 D3).
+     * This fails CLOSED on every channel rather than pretending to check consent. The real record
+     * is consent-service's, under grantee `party-service:marketing-comms` (ADR-0205 D3, shipped);
+     * `notification_preference`'s columns (`payments_push` / `product_push` / `marketing_push`) are
+     * a per-channel mute *within* a granted consent — a different and legitimate control, but not
+     * the GDPR Art. 6(1)(a) basis.
      *
-     * So this fails CLOSED rather than pretending to check: consent-gated email is SUPPRESSED until
-     * a real consent check exists. PAYMENTS / PRODUCT / SECURITY email is unchanged (contract and
-     * legitimate-interest bases, no opt-in required), so no live traffic changes. No template maps
-     * to MARKETING today (`NotificationTemplateCategoryTest` guards that), which is why declining
-     * here is correct rather than a feature regression — there is nothing to decline yet.
+     * Not wiring a consent-service call yet is deliberate: no template maps to MARKETING
+     * ([NotificationTemplateCategoryTest] guards that), so an HTTP client here would be a
+     * money-path dependency for a caller that does not exist. When the first MARKETING template
+     * lands, that guard goes red and this method is where the live check
+     * (`POST /api/v1/consents/{id}/validate`, scope `MARKETING_COMMS_EMAIL` / `_PUSH`) replaces the
+     * unconditional suppression — ADR-0198 requires a call per send, not a cached copy.
      */
-    private fun maybeSendEmail(
-        req: NotificationRequest,
-        subject: String,
-        body: String,
-        entity: NotificationEntity,
-    ): Uni<Void> {
-        if (req.template.category == NotificationCategory.MARKETING) {
-            log.warnf(
-                "EMAIL suppressed: template=%s is MARKETING-category and no consent check is wired " +
-                    "(ADR-0198 D4). Wire consent-service validate (scope MARKETING_COMMS_EMAIL) before " +
-                    "sending consent-gated email.",
-                req.template,
-            )
-            return markStatus(entity, "SUPPRESSED")
+    private fun suppressUnconsentedMarketing(req: NotificationRequest, entity: NotificationEntity): Uni<Void> {
+        log.warnf(
+            "MARKETING %s suppressed: template=%s party=%s — no consent check is wired yet " +
+                "(ADR-0198 D4, #2369)",
+            req.channel,
+            req.template,
+            req.partyId,
+        )
+        return markStatus(entity, "SUPPRESSED").invoke { _ -> auditMarketingSuppressed(req) }
+    }
+
+    /**
+     * Audit trail for a suppressed marketing send. Same `runBlocking` trade-off, and the same
+     * constraint, as [auditWebhookSent] — safe only while the wired publisher is the synchronous
+     * [com.openbank.libs.audit.LoggingAuditEventPublisher].
+     */
+    private fun auditMarketingSuppressed(req: NotificationRequest) {
+        try {
+            runBlocking {
+                audit.publish(
+                    AuditEvent(
+                        actorId = "system",
+                        actorType = "SYSTEM",
+                        operation = "notification.marketing.suppressed",
+                        resourceType = "notification",
+                        resourceId = req.template.name,
+                        result = AuditResult.DENIED,
+                        payload = mapOf(
+                            "template" to req.template.name,
+                            "channel" to req.channel.name,
+                            "partyId" to req.partyId.toString(),
+                            "reason" to "no_consent_check_wired",
+                        ),
+                    ),
+                )
+            }
+        } catch (e: Exception) {
+            // An audit failure must not swallow the suppression itself — the notification stays
+            // SUPPRESSED either way, which is the safe outcome. Logged so the gap is visible.
+            log.warnf(e, "Failed to audit marketing suppression for template=%s", req.template)
         }
-        return sendEmail(req, subject, body, entity)
     }
 
     private fun sendEmail(
@@ -333,20 +368,13 @@ class NotificationConsumer {
      * account freeze) always send. For a togglable category, a missing preference row means "on";
      * a muted category records the notification as SUPPRESSED and skips egress.
      *
-     * MARKETING is the exception and is fail-CLOSED (ADR-0198 D4, issue #2369). PAYMENTS/PRODUCT
-     * ride contract / legitimate-interest bases, so "no preference row yet" legitimately means
-     * "send". Marketing does not: under GDPR Art. 6(1)(a) it needs an affirmative opt-in, and
-     * `notification_preference.marketing_push` is a LOCAL toggle, not that consent record —
-     * consent-service owns it (`party-service:marketing-comms`, ADR-0205 D3). Defaulting to `true`
-     * here meant an absent preference row would have sent marketing to a party who never consented.
-     *
-     * No template maps to MARKETING today ([NotificationTemplate.category] is exhaustive and never
-     * yields it), so this branch is currently unreachable — deliberately NOT wired to a
-     * consent-service HTTP call, which would add a money-path dependency for a caller that does not
-     * exist. `NotificationTemplateCategoryTest` asserts that unreachability, so the day a MARKETING
-     * template IS added the test goes red and whoever adds it has to wire the real consent check
-     * (consent-service `POST /api/v1/consents/{id}/validate`, scope MARKETING_COMMS_PUSH) rather
-     * than inheriting a silent local-toggle default.
+     * MARKETING never reaches here — [suppressUnconsentedMarketing] catches it ahead of the channel
+     * dispatch. The branch below stays for `when` exhaustiveness and is deliberately fail-CLOSED
+     * (`?: false`) as defence in depth: `marketing_push` is a per-channel mute *within* a granted
+     * consent, not the GDPR Art. 6(1)(a) record (consent-service owns that,
+     * `party-service:marketing-comms`, ADR-0205 D3), so it must never be the thing that decides a
+     * marketing send. It previously defaulted to `true`, which would have sent marketing to a party
+     * with no preference row at all.
      */
     private fun maybeSendPush(req: NotificationRequest, subject: String, entity: NotificationEntity): Uni<Void> {
         val category = req.template.category

--- a/openbank-notification-service/src/test/kotlin/com/openbank/notification/domain/model/NotificationTemplateCategoryTest.kt
+++ b/openbank-notification-service/src/test/kotlin/com/openbank/notification/domain/model/NotificationTemplateCategoryTest.kt
@@ -1,0 +1,62 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright (c) OpenBank contributors. Licensed under the Apache License, Version 2.0.
+// See LICENSE in the repository root or https://www.apache.org/licenses/LICENSE-2.0 for details.
+
+package com.openbank.notification.domain.model
+
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.Test
+
+/**
+ * Guards the MARKETING push gate's precondition (ADR-0198 D4, issue #2369).
+ *
+ * `NotificationConsumer.maybeSendPush` gates MARKETING on `marketing_push`, a LOCAL preference
+ * toggle — NOT the GDPR Art. 6(1)(a) consent record, which consent-service owns under grantee
+ * `party-service:marketing-comms` (ADR-0205 D3). That is acceptable today only because no template
+ * maps to MARKETING, so the branch is unreachable and wiring a consent-service HTTP call into this
+ * money-path consumer would be speculative — a dependency for a caller that does not exist.
+ *
+ * This test is what keeps that "acceptable today" honest. The moment a MARKETING template is added,
+ * it goes RED, and whoever adds it must wire the real consent check (consent-service
+ * `POST /api/v1/consents/{id}/validate`, scope `MARKETING_COMMS_PUSH`) instead of silently
+ * inheriting a local-toggle decision for consent-gated traffic.
+ *
+ * Do NOT "fix" a failure here by adding the template to the expected set. The failure means a
+ * consent gate is now required.
+ */
+class NotificationTemplateCategoryTest {
+
+    @Test
+    fun `no template maps to MARKETING - adding one requires wiring the consent-service gate first`() {
+        val marketingTemplates = NotificationTemplate.entries.filter {
+            it.category == NotificationCategory.MARKETING
+        }
+
+        assertThat(marketingTemplates)
+            .describedAs(
+                "A template now maps to NotificationCategory.MARKETING. NotificationConsumer gates " +
+                    "MARKETING on the local marketing_push toggle, which is NOT the GDPR consent " +
+                    "record — wire consent-service validate (scope MARKETING_COMMS_PUSH, grantee " +
+                    "party-service:marketing-comms) before shipping this. See ADR-0198 D4 / #2369.",
+            )
+            .isEmpty()
+    }
+
+    @Test
+    fun `every template resolves a category`() {
+        // Cheap exhaustiveness canary: `category` is a `when` over `this` with no else branch, so a
+        // new enum constant fails to compile — but only if something actually evaluates it.
+        assertThat(NotificationTemplate.entries).allSatisfy { assertThat(it.category).isNotNull() }
+    }
+
+    @Test
+    fun `security templates can never be silenced`() {
+        val security = NotificationTemplate.entries.filter { it.category == NotificationCategory.SECURITY }
+
+        assertThat(security).contains(
+            NotificationTemplate.OTP_CODE,
+            NotificationTemplate.SCA_APPROVAL,
+            NotificationTemplate.ACCOUNT_FROZEN,
+        )
+    }
+}

--- a/openbank-notification-service/src/test/kotlin/com/openbank/notification/domain/model/NotificationTemplateCategoryTest.kt
+++ b/openbank-notification-service/src/test/kotlin/com/openbank/notification/domain/model/NotificationTemplateCategoryTest.kt
@@ -8,18 +8,23 @@ import org.assertj.core.api.Assertions.assertThat
 import org.junit.jupiter.api.Test
 
 /**
- * Guards the MARKETING push gate's precondition (ADR-0198 D4, issue #2369).
+ * Guards the precondition both MARKETING channel gates rely on (ADR-0198 D4, issue #2369).
  *
- * `NotificationConsumer.maybeSendPush` gates MARKETING on `marketing_push`, a LOCAL preference
- * toggle — NOT the GDPR Art. 6(1)(a) consent record, which consent-service owns under grantee
- * `party-service:marketing-comms` (ADR-0205 D3). That is acceptable today only because no template
- * maps to MARKETING, so the branch is unreachable and wiring a consent-service HTTP call into this
- * money-path consumer would be speculative — a dependency for a caller that does not exist.
+ * Neither channel actually checks GDPR consent today:
+ *  - `maybeSendPush` gates MARKETING on `marketing_push`, a LOCAL preference toggle (now
+ *    fail-closed when the row is absent) — not the Art. 6(1)(a) consent record.
+ *  - `maybeSendEmail` cannot even do that: `notification_preference`'s columns are push-specific,
+ *    so it SUPPRESSES MARKETING email outright rather than pretend to check.
+ *
+ * The real consent record is consent-service's, under grantee `party-service:marketing-comms`
+ * (ADR-0205 D3). Not wiring an HTTP call to it is acceptable ONLY because no template maps to
+ * MARKETING, so both branches are unreachable — a consent client here would be a money-path
+ * dependency for a caller that does not exist.
  *
  * This test is what keeps that "acceptable today" honest. The moment a MARKETING template is added,
- * it goes RED, and whoever adds it must wire the real consent check (consent-service
- * `POST /api/v1/consents/{id}/validate`, scope `MARKETING_COMMS_PUSH`) instead of silently
- * inheriting a local-toggle decision for consent-gated traffic.
+ * it goes RED, and whoever adds it must wire the real check (consent-service
+ * `POST /api/v1/consents/{id}/validate`, scope `MARKETING_COMMS_EMAIL` / `MARKETING_COMMS_PUSH`)
+ * instead of inheriting a local-toggle decision (push) or a blanket suppression (email).
  *
  * Do NOT "fix" a failure here by adding the template to the expected set. The failure means a
  * consent gate is now required.
@@ -34,9 +39,10 @@ class NotificationTemplateCategoryTest {
 
         assertThat(marketingTemplates)
             .describedAs(
-                "A template now maps to NotificationCategory.MARKETING. NotificationConsumer gates " +
-                    "MARKETING on the local marketing_push toggle, which is NOT the GDPR consent " +
-                    "record — wire consent-service validate (scope MARKETING_COMMS_PUSH, grantee " +
+                "A template now maps to NotificationCategory.MARKETING. Neither channel checks GDPR " +
+                    "consent: PUSH reads the local marketing_push toggle (fail-closed, but not the " +
+                    "consent record) and EMAIL suppresses outright. Wire consent-service validate " +
+                    "(scopes MARKETING_COMMS_EMAIL / MARKETING_COMMS_PUSH, grantee " +
                     "party-service:marketing-comms) before shipping this. See ADR-0198 D4 / #2369.",
             )
             .isEmpty()


### PR DESCRIPTION
## Summary
Addresses the **push default** and the **ungated email path** from #2369. Does **not** fully close it — see Outstanding below.

A single consent gate now runs **before** `when (req.channel)`. That placement is the point: the defect #2369 names is that gating lived *inside* the channel branches, so PUSH got a default-true check, EMAIL got none, and any channel added later would inherit whichever the author remembered.

- **PUSH** — `pref?.marketingPush ?: true` meant a party with **no** `notification_preference` row would be sent marketing push. PAYMENTS/PRODUCT ride contract / legitimate-interest bases where "no row yet" legitimately means send; marketing needs an affirmative Art. 6(1)(a) opt-in. The branch is now unreachable (the pre-dispatch gate catches MARKETING first) but kept fail-closed as defence in depth: `marketing_push` is a per-channel mute *within* a granted consent, never the lawful basis itself.
- **EMAIL** — previously went straight to `sendEmail` with **no gate of any kind**.
- **Audit** — ADR-0198 requires a suppressed marketing send to emit an audit event, not just record `SUPPRESSED`. Adds `notification.marketing.suppressed` (`AuditResult.DENIED`) through the already-injected `AuditEventPublisher`, reusing `auditWebhookSent`'s `runBlocking` trade-off and inheriting its documented constraint. An audit failure is logged and never swallows the suppression.

**What is deliberately NOT built:** a consent-service HTTP client. No template maps to `NotificationCategory.MARKETING` (`NotificationTemplate.category` is an exhaustive `when` over all 14 constants), so the path is unreachable and a client would be a money-path dependency for a caller that does not exist. The real record is consent-service's, under grantee `party-service:marketing-comms` (ADR-0205 D3, shipped). `NotificationTemplateCategoryTest` asserts that unreachability, so the day a MARKETING template lands it goes **red** and `suppressUnconsentedMarketing` is the single place the live check (`POST /api/v1/consents/{id}/validate`) replaces the unconditional suppression.

No live traffic changes: PAYMENTS / PRODUCT / SECURITY are untouched on both channels, and nothing is being declined yet.

## Outstanding (do not auto-close #2369)
- The live consent-service call itself, which only becomes meaningful with a MARKETING template.
- Suppression has no end-to-end test, and cannot have one while MARKETING is unreachable — driving it would require inventing a MARKETING template, which is the very thing the guard forbids until the consent check exists. Existing ITs (`OTP is delivered…`, `non-secret template still stores its rendered body`, `PUSH delivery persists SENT…`) do cover the regression risk that matters now: they go red if the new gate ever catches a non-marketing category.
- Reviewer also flagged, as pre-existing and out of scope: `notifications.status` is `VARCHAR(10)` and `"SUPPRESSED"` is exactly 10 characters with no CHECK constraint, and `openapi.yaml`'s `NotificationStatus` enum (`PENDING, SENT, FAILED, BOUNCED`) does not declare `SUPPRESSED` even though the push path already emits it.

## Test plan
- [x] `./gradlew :openbank-notification-service:detekt :openbank-notification-service:ktlintCheck :openbank-notification-service:test` — **exit 0** (checked the exit code, not `| tail`)
- [x] **Guard verified against a known-positive, twice** — once on the first pass and again after the pre-dispatch restructure: mapping `WELCOME` to `MARKETING` fails the guard with the intended message; reverted and confirmed a clean diff each time. A guard that has only ever passed is unfalsified.

Refs #2369

🤖 Generated with [Claude Code](https://claude.com/claude-code)