### PR TITLE
fix(ci): stop the ADR front-matter gate reporting a present key as missing

### DIFF
--- a/.github/scripts/check-adr-registry.sh
+++ b/.github/scripts/check-adr-registry.sh
@@ -153,12 +153,18 @@ for f in "${adrs[@]}"; do
   base=$(basename "$f")
   num=${base%%-*}
 
+  # Capture fm_extract's OWN status. `if ! fm=$(...); then case "$?"` cannot: inside
+  # the branch `$?` is the status of the negated condition, i.e. always 0, so every
+  # parse failure fell through to the generic `*` arm and the 3-vs-4 distinction the
+  # library goes to the trouble of returning was thrown away.
   fm=""
-  if ! fm=$(fm_extract "$f" 2>/dev/null); then
-    case "$?" in
+  fm_rc=0
+  fm=$(fm_extract "$f" 2>/dev/null) || fm_rc=$?
+  if (( fm_rc != 0 )); then
+    case "$fm_rc" in
       3) err "$base: no YAML front-matter block — the file must start with '---'. See docs/adr/SCHEMA.md." ;;
       4) err "$base: front-matter block is never closed by a '---' line. See docs/adr/SCHEMA.md." ;;
-      *) err "$base: front-matter could not be parsed. See docs/adr/SCHEMA.md." ;;
+      *) err "$base: front-matter could not be READ (fm_extract exited $fm_rc) — this is a tool failure, not a schema violation." ;;
     esac
     continue
   fi
@@ -171,8 +177,19 @@ for f in "${adrs[@]}"; do
   # 4b. every required key present; no unknown keys ----------------------------
   # An unknown key is almost always a typo'd required one, which would otherwise
   # read as "field simply absent" and be silently defaulted by every consumer.
+  # A read failure and an absent key are DIFFERENT verdicts and must print
+  # differently: "missing required key 'authors'" names a file and a field and reads
+  # as a genuine finding, so emitting it for a tool failure gets a correct ADR
+  # "fixed" or gets the whole gate ignored. See lib-frontmatter.sh's
+  # NEVER PIPE INTO AN EARLY-EXIT CONSUMER note for how that shipped once already.
   for k in $SCHEMA_KEYS; do
-    fm_has "$fm" "$k" || err "$base: front-matter is missing required key '$k'."
+    fm_has "$fm" "$k" && continue
+    key_rc=$?
+    if (( key_rc > 1 )); then
+      err "$base: front-matter READ FAILED while checking key '$k' (fm_has exited $key_rc) — the key was NOT determined to be missing."
+    else
+      err "$base: front-matter is missing required key '$k'."
+    fi
   done
   while IFS=$'\t' read -r k v; do
     [[ -z "$k" || "$k" == "!malformed" ]] && continue

--- a/docs/adr/lib-frontmatter.sh
+++ b/docs/adr/lib-frontmatter.sh
@@ -20,11 +20,34 @@
 #   fm_field FM KEY   -> stdout: the value for KEY out of a captured fm_extract
 #                        blob, or empty. Distinguishes absent from empty via
 #                        fm_has.
-#   fm_has   FM KEY   -> exit 0 if KEY is present at all (even with an empty value).
+#   fm_has   FM KEY   -> exit 0 if KEY is present at all (even with an empty value),
+#                        1 if it is genuinely absent, and 2 if the blob could not be
+#                        READ (the scanner itself failed). 1 and 2 must never be
+#                        collapsed — see "NEVER PIPE INTO AN EARLY-EXIT CONSUMER".
 #   fm_list  VALUE    -> stdout: one element per line for an inline `[a, b]`
 #                        sequence; nothing at all for `[]`.
 #   fm_unquote VALUE  -> stdout: VALUE with one layer of surrounding double quotes
 #                        removed and `\"` unescaped.
+#
+# NEVER PIPE INTO AN EARLY-EXIT CONSUMER (the defect this shape exists to prevent)
+# ------------------------------------------------------------------------------
+# These helpers used to be `printf '%s\n' "$FM" | awk '... { exit }'`. The awk side
+# exits on the FIRST match, closing the read end of the pipe while printf may still
+# be writing — printf takes SIGPIPE, and because every caller runs under
+# `set -o pipefail`, the pipeline's status becomes 141. The caller's
+# `fm_has "$fm" "$k" || err "... missing required key '$k'."` then reports a key that
+# is demonstrably PRESENT as missing. Observed on PR #2543 (run 30195145028) against
+# 0107-convert-pocket-balance-to-primary.md, a file whose `authors` key is right
+# there, on a branch touching no ADR at all; the tell in the log is
+# `lib-frontmatter.sh: line 65: printf: write error: Broken pipe` immediately above
+# the bogus `::error::`. Note the failure DIRECTION: not a crash, but a specific,
+# plausible, actionable-looking accusation against a correct file — the worst
+# possible output, because someone "fixes" the ADR or learns to ignore the gate.
+#
+# So: read the blob with a here-string (`<<< "$1"`), never a pipe. A here-string is
+# a regular file descriptor, so an early `exit` in awk cannot signal the writer,
+# and there is no pipeline for `pipefail` to poison. Any awk status above 1 is a
+# READ failure and is surfaced as such, never as a schema verdict.
 # -----------------------------------------------------------------------------
 
 fm_extract() {
@@ -58,19 +81,26 @@ fm_extract() {
 }
 
 fm_field() {
-  printf '%s\n' "$1" | awk -F'\t' -v k="$2" '$1 == k { print $2; exit }'
+  awk -F'\t' -v k="$2" '$1 == k { print $2; exit }' <<< "$1"
 }
 
+# 0 = present, 1 = genuinely absent, 2 = the blob could not be read. The caller MUST
+# distinguish 1 from 2: only 1 is a statement about the ADR.
 fm_has() {
-  printf '%s\n' "$1" | awk -F'\t' -v k="$2" '$1 == k { found = 1; exit } END { exit !found }'
+  local rc=0
+  awk -F'\t' -v k="$2" '$1 == k { found = 1; exit } END { exit !found }' <<< "$1" || rc=$?
+  if (( rc > 1 )); then
+    echo "::error title=ADR front-matter::fm_has: could not READ front-matter while looking for key '$2' (scanner exited $rc). This is a tool failure, NOT a missing key." >&2
+    return 2
+  fi
+  return "$rc"
 }
 
 # `[a, b]` -> one element per line. `[]` -> no output. Elements are trimmed; empty
 # elements (a trailing comma, `[ , ]`) are dropped rather than emitted as blanks,
 # so callers can count lines and get the real element count.
 fm_list() {
-  printf '%s\n' "$1" \
-    | sed -E 's/^\[//; s/\]$//' \
+  sed -E 's/^\[//; s/\]$//' <<< "$1" \
     | tr ',' '\n' \
     | sed -E 's/^[[:space:]]+//; s/[[:space:]]+$//; s/^"//; s/"$//' \
     | grep -v '^$' || true
@@ -79,5 +109,5 @@ fm_list() {
 # One layer of surrounding double quotes, and `\"` back to `"`. Left alone if the
 # value is not quoted, so the caller can tell the difference and reject it.
 fm_unquote() {
-  printf '%s\n' "$1" | sed -E 's/^"//; s/"$//; s/\\"/"/g'
+  sed -E 's/^"//; s/"$//; s/\\"/"/g' <<< "$1"
 }


### PR DESCRIPTION
## What

`check-adr-registry.sh` intermittently reports a **false** `front-matter is missing required key 'authors'` against ADRs that plainly have the key — seen on #2543 (run 30195145028), on a branch touching no ADR at all.

## Root cause

`docs/adr/lib-frontmatter.sh` read the captured front-matter blob as:

```bash
printf '%s\n' "$1" | awk -F'\t' -v k="$2" '$1 == k { found = 1; exit } END { exit !found }'
```

The awk side exits on the **first match**, closing the read end while `printf` may still be writing. `printf` takes SIGPIPE; every caller runs under `set -o pipefail`, so the pipeline's status becomes **141**. The caller's

```bash
fm_has "$fm" "$k" || err "$base: front-matter is missing required key '$k'."
```

turns that into an accusation against a correct file. The tell in the CI log is the line immediately above the bogus error:

```
lib-frontmatter.sh: line 65: printf: write error: Broken pipe
```

The failure *direction* is the expensive part. Not a crash — a specific, plausible, actionable-looking finding naming a file and a field. The natural response is to "fix" a correct ADR, or to learn to ignore the gate. Same class as the probe failures CLAUDE.md documents: a check that cannot express its own failure reports a plausible wrong answer.

The Czech diacritics in `authors: [Jiří Raška]` are incidental — the mechanism is the pipe, not the encoding.

## Fix

- **Read with a here-string, not a pipe**, in all four helpers. A here-string is a regular fd, so an early `exit` in the consumer cannot signal the writer, and there is no pipeline for `pipefail` to poison.
- **`fm_has` returns 0 = present, 1 = absent, 2 = could not read**, and prints the read failure itself. The two must never share a message.
- **The validator branches on that**: a key it could not check reports `front-matter READ FAILED ... the key was NOT determined to be missing`, never `missing required key`.
- **A latent sibling of the same class**: `if ! fm=$(fm_extract ...); then case "$?"` cannot see `fm_extract`'s status — inside the branch `$?` is the negated condition, always `0` — so the 3-vs-4 distinction the library returns was discarded and every parse failure took the generic arm. Status is now captured explicitly.

## Verification — both directions, against a known-positive

A guard whose failure path has never run is unfalsified, so each was exercised end-to-end through the real script:

| Case | Result |
|---|---|
| Pre-fix repro: oversized blob, `authors` on line 1 | `fm_has` returned **141** for a present key (deterministic) |
| Post-fix, same blob | `0` |
| (a) `authors:` line genuinely deleted from ADR-0107 | `missing required key 'authors'` ✅ |
| (b) scanner forced to fail on that key | **199×** `READ FAILED`, **0×** `missing required key` ✅ |
| Full gate, clean tree | `OK — 199 ADRs` |
| `gen-index.sh` (the library's other consumer) | no diff — derived artefacts still fresh |

The two `shellcheck` findings on `check-adr-registry.sh` (lines 76, 124) are pre-existing and outside this diff.

## Release impact

None. Touches `docs/adr/` and `.github/` only — no path under a released component, so release-please cuts nothing.

Refs #2543