### PR TITLE
docs(admin-ui): add the marketing-consent flow explainer (ADR-0208 D5)

### DIFF
--- a/openbank-admin-ui/src/content/bpmn/marketing-consent.yaml
+++ b/openbank-admin-ui/src/content/bpmn/marketing-consent.yaml
@@ -1,0 +1,178 @@
+# SPDX-License-Identifier: Apache-2.0
+# Copyright (c) OpenBank contributors. Licensed under the Apache License, Version 2.0.
+# BPMN process diagram (ADR-0019/0029). Authored as data; validated by
+# src/lib/docs/bpmn/schema.ts at build time. `slug` is the filename.
+#
+# ADR-0208 D5: the first flow explainer authored for the existing BpmnView +
+# FlowParticle renderers rather than as a bespoke page. It deliberately shows the
+# two things that make this chain interesting and are invisible in any single
+# service's code: the OPA grantee-scoped gate that lets one M2M caller do exactly
+# one thing (ADR-0206), and the single-writer invariant — parties.consent_marketing
+# is written ONLY by the Kafka projection, never by the forwarder (ADR-0205 D4).
+
+name: Marketingový souhlas
+desc: >-
+  Přepnutí marketingového souhlasu z mobilní aplikace až do consent-service a zpět
+  projekcí. Souhlas vlastní consent-service (grantee party-service:marketing-comms);
+  party-service ho jen forwarduje a promítá — sloupec parties.consent_marketing má
+  jediného pisatele, kterým je Kafka konzument, nikdy forwarder.
+regulation: GDPR Art. 6(1)(a) + Art. 7(3) · zákon 480/2004 §2 · ADR-0198/0205/0206
+services:
+  - customer-edge
+  - party-service
+  - consent-service
+steps:
+  - id: start
+    type: start
+    x: 60
+    y: 100
+    label: Přepnutí v Profilu (app)
+
+  - id: edge
+    type: task
+    x: 170
+    y: 100
+    label: customer-edge
+    lane: platform
+    apis:
+      - PATCH /customer/v1/profile/consent
+    relatedServices:
+      - customer-edge
+
+  - id: forwarder
+    type: task
+    x: 285
+    y: 100
+    label: party-service forwarder
+    lane: identity
+    apis:
+      - PATCH /api/v1/parties/{id}/consent
+    relatedServices:
+      - party-service
+
+  - id: opa
+    type: task
+    x: 400
+    y: 100
+    label: 'OPA: grantee scope'
+    lane: compliance
+    relatedServices:
+      - consent-service
+
+  - id: direction
+    type: gateway
+    x: 510
+    y: 100
+    label: Zapnout?
+
+  - id: grant
+    type: task
+    x: 620
+    y: 30
+    label: 'consent-service: grant'
+    lane: compliance
+    apis:
+      - POST /api/v1/consents
+    relatedServices:
+      - consent-service
+
+  - id: activate
+    type: task
+    x: 740
+    y: 30
+    label: Auto-aktivace bez SCA
+    lane: compliance
+    relatedServices:
+      - consent-service
+    emits:
+      - openbank.consent.events
+
+  - id: lookup
+    type: task
+    x: 620
+    y: 175
+    label: Dohledat consentId
+    lane: identity
+    relatedServices:
+      - party-service
+
+  - id: revoke
+    type: task
+    x: 740
+    y: 175
+    label: 'consent-service: revoke'
+    lane: compliance
+    apis:
+      - DELETE /api/v1/consents/{id}
+    relatedServices:
+      - consent-service
+    emits:
+      - openbank.consent.events
+
+  - id: events
+    type: event
+    x: 860
+    y: 100
+    label: Consent events
+    consumes:
+      - openbank.consent.events
+
+  - id: projection
+    type: task
+    x: 970
+    y: 100
+    label: Projekce (jediný pisatel)
+    lane: identity
+    relatedServices:
+      - party-service
+    consumes:
+      - openbank.consent.events
+
+  - id: done
+    type: end
+    x: 1080
+    y: 100
+    label: consent_marketing
+
+  - id: denied
+    type: end-err
+    x: 400
+    y: 220
+    label: 403 — jiný grantee
+
+flows:
+  - from: start
+    to: edge
+  - from: edge
+    to: forwarder
+  - from: forwarder
+    to: opa
+  - from: opa
+    to: direction
+  - from: opa
+    to: denied
+    label: jakýkoli jiný grantee
+  - from: direction
+    to: grant
+    label: Ano
+  - from: grant
+    to: activate
+  - from: direction
+    to: lookup
+    label: Ne
+  - from: lookup
+    to: revoke
+  - from: activate
+    to: events
+    kind: async
+    topic: openbank.consent.events
+  - from: revoke
+    to: events
+    kind: async
+    topic: openbank.consent.events
+  - from: events
+    to: projection
+    kind: async
+    topic: openbank.consent.events
+  - from: projection
+    to: done


### PR DESCRIPTION
## Summary
The first flow explainer under ADR-0208 D5 — authored as **data for the renderers that already exist** (`BpmnView`/`ProcessView` + `components/topology/FlowParticle`), not as a bespoke page. **No animation library added**: `framer-motion`, `react-flow`, `d3` and GSAP stay absent. One YAML file, 17th in the catalogue.

It draws the two things that are invisible in any single service's code:
- **The OPA grantee-scoped gate** (ADR-0206) — one shared M2M identity permitted exactly one grantee, with the `403 — jiný grantee` branch drawn explicitly rather than implied.
- **The single-writer invariant** (ADR-0205 D4) — `parties.consent_marketing` is written **only** by the Kafka projection, never by the forwarder. That is the split brain the whole ADR chain exists to prevent, and a diagram is the only place it's visible at a glance.

## Visual verification found two real defects the schema test could not
Both were caught by rendering it and measuring, not by any green check:

1. **`BpmnView.tsx:101` hardcodes `viewBox="0 0 1120 300"`.** My first layout ran to `x: 1195`, so the terminal node sat entirely outside the viewBox and was **silently clipped** — `bpmn-manifest.test.ts` was green the whole time. Rescaled to `max x = 1080` (matching the widest existing diagrams, `dispute` and `lending`, measured at 1080) and confirmed against the rendered SVG: `maxRectRight: 1024`, `maxCircleRight: 1098`, `clipped: false`, all 30 text nodes present.
2. **Two edge captions overlapped** — the grantee string rendered at the edge midpoint, which lands on the OPA node's border, and the converging topic captions crowded the event node. Fixed by shortening the node label and dropping the redundant caption. Notably **not** fixed by dropping the async edge's `topic`: `bpmn-manifest.test.ts` refused that, correctly — every async edge must name its Kafka topic. The test stopped me taking the lazy route.

**Residual, stated rather than hidden:** three async edges converge on one event node inside a 1120-wide viewBox, so their topic captions still crowd slightly. Legible, but genuinely fixing it means widening the viewBox, which is a `BpmnView` change and out of scope for a content-only PR.

## Test plan
- [x] `npx vitest run src/test/bpmn-manifest.test.ts src/test/i18n.guard.test.ts` — 123 passed
- [x] **Schema test verified against a known-positive**: injecting an invalid `lane` fails 4 of 6 manifest tests, so the green above is about this file, not in spite of it
- [x] Rendered to static HTML and inspected in a browser; DOM measurements above
- [x] Czech-only labels match the 16 existing manifests; the i18n guard walks `page.tsx` and `components/**/*.tsx`, not `src/content`, so YAML data is out of its scope by design

Refs ADR-0208 (merged #2548), ADR-0198/0205/0206.

🤖 Generated with [Claude Code](https://claude.com/claude-code)