### PR TITLE
feat(infra): detect Keycloak realm drift between the template and the realm that runs

### DIFF
--- a/.github/scripts/check-realm-role-parity.py
+++ b/.github/scripts/check-realm-role-parity.py
@@ -1,0 +1,235 @@
+#!/usr/bin/env python3
+# SPDX-License-Identifier: Apache-2.0
+# Copyright (c) OpenBank contributors. Licensed under the Apache License, Version 2.0.
+#
+# Detector: does the Keycloak realm that ACTUALLY RUNS hold the roles the realm
+# template declares — and only those? (issue #2540)
+#
+# WHY THIS EXISTS
+#   check-roles-allowed-realm.py (#2404, #2418) compares every `@RolesAllowed` string to
+#   `openbank-infra/gitops/components/keycloak/*realm-template*.json`. That closes one gap and
+#   opens the assumption that the template describes the running realm. Nothing checked that.
+#
+#   It does not, and it drifts BY CONSTRUCTION. Keycloak reads those JSONs via `--import-realm`,
+#   which runs on COLD START ONLY. Every role added to a template after the realm first came up is
+#   a file change that reaches nothing. There is no reconciler and no ArgoCD hook, and ArgoCD
+#   reports Synced/Healthy throughout — the resource it manages does match the repo. The drift is
+#   one layer below anything ArgoCD or a PR-time gate can see.
+#
+#   Worse, the template in git is not even the artifact Keycloak reads: the `realm-import` volume
+#   in keycloak.yaml projects the out-of-band SECRETS `keycloak-realm-import` and
+#   `keycloak-customers-realm-import`. So the file the CI gate reads and the file Keycloak imports
+#   are two different objects with no link between them. That is a second, independent drift layer,
+#   and this detector is deliberately positioned to catch BOTH at once by reading the live realm
+#   rather than either file.
+#
+#   Measured on the sandbox 2026-07-26 (issue #2540): four roles were declared in the template and
+#   absent from the live realm — ROLE_KYC, ROLE_KYC_OPENER, ROLE_KYC_REVIEWER, ROLE_SUPERVISOR —
+#   and ROLE_DEMO existed live and nowhere in git. Twenty `@RolesAllowed` sites named the four
+#   missing roles. None 403'd, because each annotation also listed a live role; the cost was
+#   quieter and worse. ADR-0116's KYC four-eyes could not be enforced: ROLE_KYC_OPENER (opens the
+#   case) and ROLE_KYC_REVIEWER (approves it, must be a different identity) did not exist, so both
+#   halves fell through to ROLE_ADMIN/ROLE_OPERATOR and ONE identity could do both. Separation of
+#   duties was declared in the annotations, documented in the ADR, and unenforceable in the
+#   running system — with every gate green.
+#
+# WHY IT IS NOT A PR-TIME GATE
+#   The live realm is not reachable from a PR runner: the Keycloak admin REST API is blocked at
+#   the nginx edge by design (keycloak.yaml), no workflow holds cluster access, and the admin
+#   credential is an out-of-band secret. This script is therefore a pure function over two
+#   snapshots — the templates in the repo, and a role list captured from a live realm — so that
+#   the CAPTURE can happen in-cluster (the keycloak-realm-drift CronJob) while the COMPARISON is
+#   ordinary, reviewable, unit-tested repo code.
+#
+# WHAT IT REPORTS — both directions, because they are different defects:
+#   declared-not-live  a grant that never applied. Every `@RolesAllowed` naming it silently
+#                      degrades to whatever else the annotation lists; a four-eyes split
+#                      collapses. This is the ADR-0116 failure above.
+#   live-not-declared  an undeclared role. It works today and a cold-started cluster loses it —
+#                      a disaster-recovery landmine that no test can see, because the only thing
+#                      that triggers it is a rebuild.
+#   unreachable-live   (highest severity) a role named by an `@RolesAllowed` in the code that the
+#                      LIVE realm does not issue. The template agreeing is no comfort: the token
+#                      cannot be minted, so that caller is denied and nothing says so.
+#
+# Keycloak's own built-ins (offline_access, uma_authorization, default-roles-<realm>) are created
+# by the server, never appear in a template, and would otherwise be a permanent live-not-declared
+# finding — a detector that always fires is a detector nobody reads. They are excluded by name.
+#
+# Run:
+#   python3 .github/scripts/check-realm-role-parity.py --live openbank=/tmp/openbank-roles.json
+# where the file is `kcadm.sh get roles -r openbank` output (or a plain JSON array of names).
+# A realm with no --live snapshot is reported as unchecked, never as clean.
+
+import argparse
+import importlib.util
+import json
+import pathlib
+import sys
+
+REALM_GLOB = "openbank-infra/gitops/components/keycloak/*realm-template*.json"
+SIBLING_GATE = ".github/scripts/check-roles-allowed-realm.py"
+
+
+def keycloak_builtins(realm: str) -> set:
+    """Roles the Keycloak server creates itself; never declared in a template."""
+    return {"offline_access", "uma_authorization", f"default-roles-{realm.lower()}"}
+
+
+def template_roles(root: pathlib.Path) -> dict:
+    """{realm name: {role names}} from every *realm-template*.json in the repo."""
+    out = {}
+    for p in sorted(root.glob(REALM_GLOB)):
+        doc = json.loads(p.read_text())
+        realm = doc.get("realm")
+        if not realm:
+            raise SystemExit(f"{p}: no `realm` key — cannot tell which realm it describes")
+        roles = doc.get("roles", {}) or {}
+        names = {r["name"] for r in (roles.get("realm") or [])}
+        for client_roles in (roles.get("client", {}) or {}).values():
+            names |= {r["name"] for r in client_roles or []}
+        out.setdefault(realm, set())
+        out[realm] |= names
+    return out
+
+
+def load_live(spec: str) -> tuple:
+    """Parse a `realm=path` snapshot. Accepts kcadm's array-of-objects or an array of strings."""
+    if "=" not in spec:
+        raise SystemExit(f"--live expects realm=path, got {spec!r}")
+    realm, _, path = spec.partition("=")
+    raw = sys.stdin.read() if path == "-" else pathlib.Path(path).read_text()
+    doc = json.loads(raw)
+    if isinstance(doc, dict):  # tolerate {"roles": [...]}
+        doc = doc.get("roles", [])
+    names = set()
+    for entry in doc:
+        if isinstance(entry, str):
+            names.add(entry)
+        elif isinstance(entry, dict) and entry.get("name"):
+            names.add(entry["name"])
+        else:
+            raise SystemExit(f"{path}: unrecognised role entry {entry!r}")
+    if not names:
+        # An empty snapshot is a capture failure (bad credential, wrong realm), not a realm with
+        # no roles — Keycloak always issues at least its own built-ins. Refusing to treat it as
+        # data is what stops this reporting "everything is missing" on an auth error.
+        raise SystemExit(f"{path}: no roles parsed — treating as a failed capture, not an empty realm")
+    return realm, names
+
+
+def annotation_roles(root: pathlib.Path) -> dict:
+    """{role name: [\"path:line\", ...]} for every role any @RolesAllowed names.
+
+    Reuses the sibling gate's scanner rather than re-implementing it: its comment stripping is
+    load-bearing (a KDoc that quotes a broken annotation must not be scanned as code) and two
+    copies of that logic would drift.
+    """
+    spec = importlib.util.spec_from_file_location("roles_allowed_gate", root / SIBLING_GATE)
+    if spec is None or spec.loader is None:
+        return {}
+    mod = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(mod)
+    consts = mod.role_constants(root)
+    sites = {}
+    for rel, line, names, _dead in mod.scan(root, set(), consts):
+        for n in names:
+            sites.setdefault(n, []).append(f"{rel}:{line}")
+    return sites
+
+
+def main() -> int:
+    ap = argparse.ArgumentParser()
+    ap.add_argument("--root", default=".")
+    ap.add_argument(
+        "--live",
+        action="append",
+        default=[],
+        metavar="REALM=PATH",
+        help="live role snapshot for a realm; PATH may be - for stdin. Repeatable.",
+    )
+    ap.add_argument(
+        "--skip-annotations",
+        action="store_true",
+        help="skip the @RolesAllowed cross-check (for a snapshot taken outside a repo checkout)",
+    )
+    args = ap.parse_args()
+    root = pathlib.Path(args.root).resolve()
+
+    declared = template_roles(root)
+    if not declared:
+        sys.stderr.write(f"::error::no realm template found under {REALM_GLOB} — cannot run blind\n")
+        return 1
+    live = dict(load_live(s) for s in args.live)
+    sites = {} if args.skip_annotations else annotation_roles(root)
+
+    findings, report = [], {"realms": {}}
+    for realm in sorted(set(declared) | set(live)):
+        want = declared.get(realm, set())
+        have = live.get(realm)
+        if have is None:
+            findings.append(
+                f"realm `{realm}` has a template in git but no live snapshot was supplied — "
+                f"UNCHECKED, not clean. Capture it with `kcadm.sh get roles -r {realm}`.",
+            )
+            report["realms"][realm] = {"status": "unchecked"}
+            continue
+        # Subtract the built-ins from BOTH sides. Only the live side is obvious; the customers
+        # template also declares `default-roles-openbank-customers` explicitly, so excluding it
+        # live-side only turns a server-managed role into a permanent declared-not-live finding.
+        # (Caught by check_realm_role_parity_test.py's identical-sets case, which is exactly what
+        # a negative case is for.)
+        builtins = keycloak_builtins(realm)
+        want, have = want - builtins, have - builtins
+        if not want:
+            findings.append(f"realm `{realm}` is live but no template in git declares it")
+        missing = sorted(want - have)
+        extra = sorted(have - want)
+        # Only the realm the platform authenticates against carries @RolesAllowed names.
+        unreachable = sorted(r for r in missing if r in sites) if want else []
+        report["realms"][realm] = {
+            "status": "checked",
+            "declaredNotLive": missing,
+            "liveNotDeclared": extra,
+            "namedByCodeButNotLive": unreachable,
+            "inSync": not missing and not extra,
+        }
+        for r in missing:
+            where = sites.get(r)
+            if where:
+                findings.append(
+                    f"realm `{realm}`: `{r}` is declared in the template and NOT issued by the "
+                    f"live realm, and {len(where)} @RolesAllowed site(s) name it "
+                    f"({', '.join(where[:3])}{', …' if len(where) > 3 else ''}). No token can "
+                    f"carry it: that caller is denied, or the annotation degrades to whatever "
+                    f"else it lists. Create the role (`kcadm.sh create roles -r {realm} -s "
+                    f"name={r}`) or delete the declaration.",
+                )
+            else:
+                findings.append(
+                    f"realm `{realm}`: `{r}` is declared in the template and NOT issued by the "
+                    f"live realm. The grant never applied — --import-realm runs on cold start only.",
+                )
+        for r in extra:
+            findings.append(
+                f"realm `{realm}`: `{r}` is issued by the live realm and declared nowhere in git. "
+                f"It works today and a cold-started cluster would not have it. Add it to the "
+                f"template, or delete it from the realm.",
+            )
+
+    print(json.dumps(report, indent=2, sort_keys=True))
+    if findings:
+        for f in findings:
+            sys.stderr.write(f"::error title=Keycloak realm parity::{f}\n")
+        sys.stderr.write(
+            f"::error::check-realm-role-parity: {len(findings)} realm drift finding(s). "
+            f"The template and the running realm disagree.\n",
+        )
+        return 1
+    checked = ", ".join(sorted(live))
+    print(f"realm role parity: template and live realm agree for {checked}.", file=sys.stderr)
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/openbank-infra/gitops/apps/keycloak-realm-drift.yaml
+++ b/openbank-infra/gitops/apps/keycloak-realm-drift.yaml
@@ -1,0 +1,30 @@
+# SPDX-License-Identifier: Apache-2.0
+# Copyright (c) OpenBank contributors. Licensed under the Apache License, Version 2.0.
+#
+# Issue #2540: nothing compared the Keycloak realm template to the realm that actually runs.
+# Its own Application rather than folding into the keycloak component, so the detector can be
+# synced, suspended or rolled back without touching the identity provider itself.
+# See gitops/components/keycloak-realm-drift/ for the design rationale.
+apiVersion: argoproj.io/v1alpha1
+kind: Application
+metadata:
+  name: keycloak-realm-drift
+  namespace: argocd
+  finalizers:
+    - resources-finalizer.argocd.argoproj.io
+spec:
+  project: default
+  source:
+    repoURL: git@github.com:JiRaska/open-bank-oss.git
+    targetRevision: main
+    path: openbank-infra/gitops/components/keycloak-realm-drift
+  destination:
+    server: https://kubernetes.default.svc
+    namespace: iam
+  syncPolicy:
+    automated:
+      prune: true
+      selfHeal: true
+    syncOptions:
+      - CreateNamespace=false
+      - ServerSideApply=true

--- a/openbank-infra/gitops/components/keycloak-realm-drift/keycloak-realm-drift.yaml
+++ b/openbank-infra/gitops/components/keycloak-realm-drift/keycloak-realm-drift.yaml
@@ -1,0 +1,271 @@
+# SPDX-License-Identifier: Apache-2.0
+# Copyright (c) OpenBank contributors. Licensed under the Apache License, Version 2.0.
+#
+# ---------------------------------------------------------------------------
+# Keycloak realm drift detector (issue #2540).
+#
+# THE GAP THIS CLOSES
+#   `check-roles-allowed-realm.py` compares every `@RolesAllowed` string to the realm TEMPLATE in
+#   git. Nothing compared that template to the realm that actually runs — and the two drift by
+#   construction, because Keycloak reads the templates via `--import-realm`, which runs on COLD
+#   START ONLY. A role added to a template after the realm first came up is a file change that
+#   reaches nothing. There is no reconciler and no ArgoCD hook.
+#
+#   ArgoCD reports Synced/Healthy throughout, correctly: the object it manages does match the
+#   repo. The drift is one layer below what ArgoCD can see. And the template in git is not even
+#   the artifact Keycloak reads — keycloak.yaml's `realm-import` volume projects the out-of-band
+#   secrets `keycloak-realm-import` / `keycloak-customers-realm-import`, so the file the CI gate
+#   reads and the file Keycloak imports are two unrelated objects. Reading the LIVE realm is the
+#   only observation that covers both layers at once.
+#
+#   Measured 2026-07-26: ROLE_KYC, ROLE_KYC_OPENER, ROLE_KYC_REVIEWER and ROLE_SUPERVISOR were
+#   declared and absent; ROLE_DEMO was live and undeclared. 20 `@RolesAllowed` sites named the
+#   four missing roles and none 403'd — each also listed a live role — so ADR-0116's KYC
+#   four-eyes silently degraded to ROLE_ADMIN/ROLE_OPERATOR and one identity could both open and
+#   approve a case. Separation of duties, declared everywhere and enforced nowhere.
+#
+# WHY A CronJob AND NOT A CI GATE
+#   The live realm is unreachable from a PR runner: the admin REST API is blocked at the nginx
+#   edge by design (keycloak.yaml), no workflow holds cluster credentials, and the admin secret is
+#   out-of-band. So the CAPTURE happens here, in-cluster, and the COMPARISON is ordinary
+#   repo code — `.github/scripts/check-realm-role-parity.py`, unit-tested in both directions by
+#   `openbank-infra/scripts/check_realm_role_parity_test.py`. This pod holds no logic worth
+#   testing; it holds a credential and a network path.
+#
+# WHY IT FAILS THE JOB RATHER THAN JUST WRITING A REPORT
+#   The sbom-drift-scanner lesson (2026-07-12): a finding that only lands in a ConfigMap is a
+#   finding nobody acts on. The report is published FIRST, then the Job fails, so the alert fires
+#   with the detail already readable.
+#
+# WHAT IT DELIBERATELY DOES NOT DO
+#   It does not reconcile. Issue #2540 leaves open whether the realm should be made to follow the
+#   template (a `kcadm` Job, or keycloak-config-cli); detection first, on purpose — a reconciler
+#   that writes to the identity provider is a much larger blast radius and wants its own decision.
+#   It also checks role EXISTENCE only, not role ASSIGNMENT. `service-account-openbank-services`
+#   held ROLE_OPERATOR live while the template declared no such user at all (#2442) — the same
+#   class one level deeper, and the natural next increment.
+#
+# NAMESPACE: `iam`, deliberately. Keycloak's ingress allow-list admits `podSelector: {}` — the
+# whole of `iam` — so a same-namespace caller needs no NetworkPolicy change, and the generated
+# policy (gen-network-policies.py derives edges from Deployments) would not have covered a
+# CronJob anyway.
+# ---------------------------------------------------------------------------
+
+# ─── ServiceAccount ─────────────────────────────────────────────────────────
+
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: keycloak-realm-drift
+  namespace: iam
+  labels:
+    app.kubernetes.io/name: keycloak-realm-drift
+    app.kubernetes.io/part-of: iam
+
+---
+# ─── RBAC: write the single report ConfigMap, nothing else ──────────────────
+# No secret read verb is granted: the admin credential arrives via secretKeyRef on the pod spec,
+# which the kubelet resolves — the ServiceAccount never needs API access to it. Granting `get`
+# on secrets here would hand any future exec into this pod the bootstrap admin.
+
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  name: keycloak-realm-drift-configmap
+  namespace: iam
+  labels:
+    app.kubernetes.io/name: keycloak-realm-drift
+rules:
+  - apiGroups: [""]
+    resources: ["configmaps"]
+    resourceNames: ["keycloak-realm-drift"]
+    verbs: ["get", "patch", "update"]
+  # create: resourceNames cannot gate create — needed for the first run only.
+  - apiGroups: [""]
+    resources: ["configmaps"]
+    verbs: ["create"]
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: keycloak-realm-drift-configmap
+  namespace: iam
+  labels:
+    app.kubernetes.io/name: keycloak-realm-drift
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: Role
+  name: keycloak-realm-drift-configmap
+subjects:
+  - kind: ServiceAccount
+    name: keycloak-realm-drift
+    namespace: iam
+
+---
+# ─── CronJob ────────────────────────────────────────────────────────────────
+
+apiVersion: batch/v1
+kind: CronJob
+metadata:
+  name: keycloak-realm-drift
+  namespace: iam
+  labels:
+    app.kubernetes.io/name: keycloak-realm-drift
+    app.kubernetes.io/part-of: iam
+spec:
+  # 03:40 UTC daily — after sbom-drift-scanner's 03:10, so the two in-cluster drift reports do
+  # not contend for the same window.
+  schedule: "40 3 * * *"
+  timeZone: "UTC"
+  concurrencyPolicy: Forbid
+  successfulJobsHistoryLimit: 3
+  failedJobsHistoryLimit: 3
+  startingDeadlineSeconds: 600
+  jobTemplate:
+    spec:
+      activeDeadlineSeconds: 600
+      backoffLimit: 1
+      template:
+        metadata:
+          labels:
+            app.kubernetes.io/name: keycloak-realm-drift
+        spec:
+          serviceAccountName: keycloak-realm-drift
+          restartPolicy: Never
+          securityContext:
+            runAsNonRoot: true
+            runAsUser: 1000
+            runAsGroup: 1000
+            fsGroup: 1000
+            seccompProfile:
+              type: RuntimeDefault
+          initContainers:
+            # Phase 1 — capture the live role sets and run the committed comparison.
+            # The comparison logic is NOT inlined here: it lives in the repo, where it is
+            # reviewable and unit-tested. This container clones the public repo (unauthenticated,
+            # depth 1 — the same pattern sbom-drift-scanner uses) and executes it.
+            - name: capture-and-compare
+              image: docker.io/alpine/k8s:1.34.1
+              command: ["/bin/sh", "-ec"]
+              securityContext:
+                allowPrivilegeEscalation: false
+                readOnlyRootFilesystem: false
+                capabilities:
+                  drop: ["ALL"]
+              env:
+                - name: HOME
+                  value: /tmp
+                - name: KC_URL
+                  value: http://keycloak.iam.svc:8080
+                - name: KC_ADMIN_USER
+                  valueFrom:
+                    secretKeyRef:
+                      name: keycloak-bootstrap
+                      key: admin-username
+                - name: KC_ADMIN_PASSWORD
+                  valueFrom:
+                    secretKeyRef:
+                      name: keycloak-bootstrap
+                      key: admin-password
+              args:
+                - |
+                  set -eu
+                  echo "Cloning openbank-oss (public repo, unauthenticated, depth=1)..."
+                  git clone --depth 1 --quiet \
+                    https://github.com/JiRaska/open-bank-oss.git /tmp/repo
+
+                  # `admin-cli` is the only client in the master realm that accepts a direct
+                  # password grant (see the sandbox admin-token note in the repo runbook).
+                  # --data-urlencode reads the value from the env, so the password is never an
+                  # argv entry visible in `ps` or echoed by `set -x`.
+                  echo "Requesting an admin token..."
+                  TOKEN=$(curl -sS --fail-with-body \
+                    -X POST "${KC_URL}/realms/master/protocol/openid-connect/token" \
+                    -d "client_id=admin-cli" -d "grant_type=password" \
+                    --data-urlencode "username=${KC_ADMIN_USER}" \
+                    --data-urlencode "password=${KC_ADMIN_PASSWORD}" \
+                    | python3 -c 'import json,sys; print(json.load(sys.stdin)["access_token"])')
+
+                  for REALM in openbank openbank-customers; do
+                    echo "Capturing roles for realm ${REALM}..."
+                    # briefRepresentation + an explicit max: Keycloak's default page size is 100,
+                    # and a silently truncated page would read as "these roles are missing" —
+                    # a detector's worst failure mode is inventing findings.
+                    curl -sS --fail-with-body \
+                      -H "Authorization: Bearer ${TOKEN}" \
+                      "${KC_URL}/admin/realms/${REALM}/roles?briefRepresentation=true&first=0&max=2000" \
+                      > "/work/${REALM}-roles.json"
+                    echo "  $(python3 -c "import json;print(len(json.load(open('/work/${REALM}-roles.json'))))") role(s)"
+                  done
+
+                  # --skip-annotations is NOT passed: the clone is a full checkout, so the
+                  # @RolesAllowed cross-check runs and a role the code needs but the live realm
+                  # does not issue is reported with its call sites.
+                  cd /tmp/repo
+                  python3 .github/scripts/check-realm-role-parity.py \
+                    --root /tmp/repo \
+                    --live "openbank=/work/openbank-roles.json" \
+                    --live "openbank-customers=/work/openbank-customers-roles.json" \
+                    > /work/final.json 2> /work/findings.txt \
+                    || echo "findings" > /work/findings
+                  cat /work/findings.txt
+              volumeMounts:
+                - name: work
+                  mountPath: /work
+                - name: tmp
+                  mountPath: /tmp
+
+          containers:
+            # Phase 2 — publish the report, THEN fail. Order is load-bearing: the alert must fire
+            # with the detail already readable, not with a promise of it.
+            - name: publish
+              image: docker.io/alpine/k8s:1.34.1
+              command: ["/bin/sh", "-ec"]
+              securityContext:
+                allowPrivilegeEscalation: false
+                readOnlyRootFilesystem: true
+                capabilities:
+                  drop: ["ALL"]
+              env:
+                - name: HOME
+                  value: /tmp
+              args:
+                - |
+                  set -eu
+                  python3 - <<'PY' > /tmp/final.json
+                  import datetime, json, pathlib
+                  raw = pathlib.Path("/work/final.json").read_text().strip()
+                  report = json.loads(raw) if raw else {"realms": {}, "captureFailed": True}
+                  report["scannedAt"] = datetime.datetime.now(datetime.timezone.utc).strftime(
+                      "%Y-%m-%dT%H:%M:%SZ")
+                  report["checkScope"] = "keycloak realm ROLE EXISTENCE, template vs live"
+                  report["doesNotVerify"] = "role ASSIGNMENTS to users/service accounts (#2540 follow-up)"
+                  findings = pathlib.Path("/work/findings.txt")
+                  report["findings"] = findings.read_text().splitlines() if findings.is_file() else []
+                  print(json.dumps(report, indent=2, sort_keys=True))
+                  PY
+
+                  cat /tmp/final.json
+                  kubectl create configmap keycloak-realm-drift \
+                    --namespace iam \
+                    --from-file=keycloak-realm-drift.json=/tmp/final.json \
+                    --dry-run=client -o yaml | kubectl apply -f -
+                  echo "Published."
+
+                  if [ -f /work/findings ]; then
+                    echo "ERROR: the realm template and the running realm disagree — see above." >&2
+                    exit 1
+                  fi
+                  echo "Done: template and live realm agree."
+              volumeMounts:
+                - name: work
+                  mountPath: /work
+                  readOnly: true
+                - name: tmp
+                  mountPath: /tmp
+
+          volumes:
+            - name: work
+              emptyDir: {}
+            - name: tmp
+              emptyDir: {}

--- a/openbank-infra/gitops/components/keycloak-realm-drift/prometheus-rules.yaml
+++ b/openbank-infra/gitops/components/keycloak-realm-drift/prometheus-rules.yaml
@@ -1,0 +1,59 @@
+# SPDX-License-Identifier: Apache-2.0
+# Copyright (c) OpenBank contributors. Licensed under the Apache License, Version 2.0.
+#
+# Alerts for the keycloak-realm-drift CronJob (issue #2540).
+#
+# SEVERITY MUST BE `critical` OR `warning` — nothing else. Alertmanager routes only those two
+# (kube-prometheus-stack.yaml); the top-level route's default receiver is `null`, so any other
+# value is silently BLACK-HOLED. An alert that routes nowhere is indistinguishable from no alert,
+# which is the exact failure class this detector exists to close.
+---
+apiVersion: monitoring.coreos.com/v1
+kind: PrometheusRule
+metadata:
+  name: openbank-keycloak-realm-drift-alerts
+  namespace: iam
+  labels:
+    app.kubernetes.io/part-of: openbank
+    app.kubernetes.io/name: keycloak-realm-drift
+spec:
+  groups:
+    - name: openbank.iam.realmdrift
+      rules:
+        # Fires when the realm template and the running realm disagree in either direction — a
+        # declared role the realm never got, or a live role no template declares.
+        - alert: KeycloakRealmDrift
+          expr: kube_job_failed{namespace="iam", job_name=~"keycloak-realm-drift-.*"} > 0
+          for: 5m
+          labels:
+            severity: warning
+            component: iam
+          annotations:
+            summary: "Keycloak realm template and the running realm disagree"
+            description: >-
+              The daily realm parity scan failed. Either a role declared in
+              gitops/components/keycloak/*realm-template*.json is not issued by the live realm
+              (the grant never applied — --import-realm runs on cold start only, so the file
+              change reached nothing), or a role exists live that no template declares (it works
+              today and a cold-started cluster loses it). If the missing role is named by an
+              @RolesAllowed, the endpoints that name it are degraded right now: they fall through
+              to whatever other role the annotation lists, which is how ADR-0116's KYC four-eyes
+              became unenforceable while every gate was green (#2540). Read the
+              `keycloak-realm-drift` ConfigMap in the `iam` namespace for the per-role detail.
+
+        # A detector that quietly stops running is indistinguishable from a clean realm.
+        - alert: KeycloakRealmDriftScanStale
+          # 26h: the schedule is daily (03:40 UTC); allow one missed run plus slack.
+          expr: >-
+            time() - kube_cronjob_status_last_successful_time{namespace="iam",
+            cronjob="keycloak-realm-drift"} > 93600
+          for: 30m
+          labels:
+            severity: warning
+            component: iam
+          annotations:
+            summary: "keycloak-realm-drift has not completed successfully in >26h"
+            description: >-
+              The realm parity scan has not had a successful run in over 26 hours. Treat the
+              realm's conformance to its template as UNKNOWN, not healthy — an absent signal
+              reads exactly like a clean one.

--- a/openbank-infra/scripts/check_realm_role_parity_test.py
+++ b/openbank-infra/scripts/check_realm_role_parity_test.py
@@ -1,0 +1,127 @@
+#!/usr/bin/env python3
+# SPDX-License-Identifier: Apache-2.0
+# Copyright (c) OpenBank contributors. Licensed under the Apache License, Version 2.0.
+"""Falsification suite for .github/scripts/check-realm-role-parity.py (issue #2540).
+
+A gate that has only ever passed is unfalsified. Every case below feeds the detector an input it
+MUST classify a particular way, in BOTH directions — a role declared and not live, a role live and
+not declared, and (the case that actually costs money) a role no realm issues that the code names.
+The negative cases matter just as much: a detector that fires on Keycloak's own built-ins, or that
+reads an auth failure as "the realm has no roles", is one nobody reads by week two.
+
+Run: python3 -m unittest discover -s openbank-infra/scripts -p '*_test.py'
+"""
+
+import json
+import pathlib
+import subprocess
+import sys
+import tempfile
+import unittest
+
+REPO = pathlib.Path(__file__).resolve().parents[2]
+SCRIPT = REPO / ".github" / "scripts" / "check-realm-role-parity.py"
+TEMPLATE = REPO / "openbank-infra/gitops/components/keycloak/realm-template.json"
+
+BUILTINS = ["offline_access", "uma_authorization", "default-roles-openbank"]
+
+
+def declared_roles() -> list:
+    doc = json.loads(TEMPLATE.read_text())
+    return sorted(r["name"] for r in doc["roles"]["realm"])
+
+
+def run(live_roles, realm="openbank", extra=()):
+    """Run the detector against the REAL repo templates and a synthetic live snapshot."""
+    with tempfile.NamedTemporaryFile("w", suffix=".json", delete=False) as fh:
+        json.dump([{"name": n} for n in live_roles], fh)
+        path = fh.name
+    # The customers realm has a template too; supply it verbatim so it never colours the result.
+    customers = json.loads(
+        (REPO / "openbank-infra/gitops/components/keycloak/customers-realm-template.json").read_text(),
+    )
+    cust_names = [r["name"] for r in (customers.get("roles", {}).get("realm") or [])]
+    with tempfile.NamedTemporaryFile("w", suffix=".json", delete=False) as fh:
+        json.dump([{"name": n} for n in cust_names + ["offline_access"]], fh)
+        cust_path = fh.name
+    cmd = [
+        sys.executable, str(SCRIPT), "--root", str(REPO),
+        "--live", f"{realm}={path}",
+        "--live", f"{customers['realm']}={cust_path}",
+        *extra,
+    ]
+    return subprocess.run(cmd, capture_output=True, text=True)
+
+
+class RealmRoleParityTest(unittest.TestCase):
+    # --- the case it must NOT flag ------------------------------------------------------------
+    def test_identical_sets_pass(self):
+        """Template == live (plus Keycloak's built-ins) is clean. Built-ins are not findings."""
+        r = run(declared_roles() + BUILTINS)
+        self.assertEqual(0, r.returncode, r.stderr)
+        self.assertNotIn("::error", r.stderr)
+
+    def test_builtins_alone_are_not_live_not_declared(self):
+        """default-roles-<realm>/offline_access/uma_authorization exist in every realm and in no
+        template. If they were reported, the detector would fire forever and be ignored."""
+        r = run(declared_roles() + BUILTINS)
+        self.assertNotIn("offline_access", r.stderr)
+        self.assertNotIn("default-roles-openbank", r.stderr)
+
+    # --- direction 1: declared in the template, absent from the live realm ---------------------
+    def test_role_missing_from_live_realm_is_flagged(self):
+        """The real #2540 defect: ROLE_KYC_REVIEWER declared, never created live."""
+        live = [n for n in declared_roles() if n != "ROLE_KYC_REVIEWER"] + BUILTINS
+        r = run(live)
+        self.assertEqual(1, r.returncode, "a declared-but-absent role must fail the detector")
+        self.assertIn("ROLE_KYC_REVIEWER", r.stderr)
+        self.assertIn("NOT issued by the live realm", r.stderr)
+
+    def test_missing_role_named_by_code_reports_its_call_sites(self):
+        """Highest-severity direction: the live realm cannot mint a token the code demands. The
+        finding has to name where, or it is a puzzle rather than a ticket."""
+        live = [n for n in declared_roles() if n != "ROLE_KYC_REVIEWER"] + BUILTINS
+        r = run(live)
+        self.assertIn("@RolesAllowed site(s) name it", r.stderr)
+        self.assertIn(".kt:", r.stderr)
+        report = json.loads(r.stdout)
+        self.assertIn("ROLE_KYC_REVIEWER", report["realms"]["openbank"]["namedByCodeButNotLive"])
+
+    # --- direction 2: live in the realm, declared nowhere in git -------------------------------
+    def test_undeclared_live_role_is_flagged(self):
+        """The other real half of #2540: ROLE_DEMO existed live and in no template. It works
+        today and a cold-started cluster silently loses it."""
+        r = run(declared_roles() + BUILTINS + ["ROLE_SOMETHING_UNDECLARED"])
+        self.assertEqual(1, r.returncode, "a live-but-undeclared role must fail the detector")
+        self.assertIn("ROLE_SOMETHING_UNDECLARED", r.stderr)
+        self.assertIn("declared nowhere in git", r.stderr)
+
+    # --- capture failures must not read as data ------------------------------------------------
+    def test_missing_snapshot_is_unchecked_not_clean(self):
+        """A realm with a template and no snapshot must fail as UNCHECKED. Reporting it clean is
+        how a detector certifies the thing it never looked at."""
+        with tempfile.NamedTemporaryFile("w", suffix=".json", delete=False) as fh:
+            json.dump([{"name": n} for n in declared_roles() + BUILTINS], fh)
+            path = fh.name
+        r = subprocess.run(
+            [sys.executable, str(SCRIPT), "--root", str(REPO), "--live", f"openbank={path}"],
+            capture_output=True, text=True,
+        )
+        self.assertEqual(1, r.returncode)
+        self.assertIn("UNCHECKED, not clean", r.stderr)
+
+    def test_empty_snapshot_is_a_capture_failure(self):
+        """An empty role list means the admin call failed (bad credential, wrong realm) — Keycloak
+        always issues its own built-ins. Treating it as data would report the whole template
+        missing and bury the real signal."""
+        r = run([])
+        self.assertNotEqual(0, r.returncode)
+        self.assertIn("failed capture", r.stderr)
+
+    # --- the detector must be reading the real repo, not a fixture -----------------------------
+    def test_reads_the_committed_template(self):
+        self.assertIn("ROLE_KYC_REVIEWER", declared_roles(), "template lost the four-eyes roles")
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
Refs #2540 — this is the **in-repo half only**. It builds the detector; it does not mutate the live realm, and it does not reconcile. See "Left for the owner" below.

## What was wrong

`check-roles-allowed-realm.py` (#2404/#2418, enforced) compares every `@RolesAllowed` string to `openbank-infra/gitops/components/keycloak/*realm-template*.json`. Nothing compared that template to the realm that actually runs — and the two drift **by construction**: Keycloak reads those JSONs via `--import-realm`, which runs on **cold start only**. Every role added to a template afterwards is a file change that reaches nothing. ArgoCD reports `Synced/Healthy` throughout, correctly — the object it manages *does* match the repo. The drift is one layer below what ArgoCD can see.

While reading `keycloak.yaml` for this I found a second, independent layer: the `realm-import` volume does not mount the git file at all, it projects the out-of-band secrets `keycloak-realm-import` / `keycloak-customers-realm-import`. **The file the CI gate reads and the file Keycloak imports are two unrelated objects with no link between them.** Reading the *live* realm is the only observation that covers both layers at once, which is why the detector is shaped the way it is.

Measured on the sandbox 2026-07-26 (from the issue): `ROLE_KYC`, `ROLE_KYC_OPENER`, `ROLE_KYC_REVIEWER`, `ROLE_SUPERVISOR` declared and absent; `ROLE_DEMO` live and undeclared. 20 `@RolesAllowed` sites named the four missing roles; none 403'd, because each also listed a live role. So ADR-0116's KYC four-eyes degraded silently to `ROLE_ADMIN`/`ROLE_OPERATOR` and **one identity could both open and approve a KYC case** — separation of duties declared in the annotations, documented in the ADR, unenforceable in the running system, with every gate green.

## What this adds

**`.github/scripts/check-realm-role-parity.py`** — a pure comparison over two snapshots (the templates in the repo; a role list captured from a live realm). It reports three things, deliberately separated because they are different defects:

| finding | what it means |
|---|---|
| `declaredNotLive` | a grant that never applied — the ADR-0116 failure above |
| `liveNotDeclared` | works today, and a **cold-started cluster loses it** — a DR landmine no test can see |
| `namedByCodeButNotLive` | highest severity: an `@RolesAllowed` names a role no token can carry. Reported **with its call sites** |

Keycloak's server-managed built-ins (`offline_access`, `uma_authorization`, `default-roles-<realm>`) are excluded from **both** sides — see the falsification note. A realm with a template and no snapshot is reported `unchecked`, never clean; an empty snapshot is treated as a **failed capture**, not as a realm with no roles (an auth error must not print "the entire template is missing").

**`openbank-infra/gitops/components/keycloak-realm-drift/`** — a daily CronJob in `iam` that captures the live role sets from the admin API and runs the *committed* comparison (public-repo shallow clone, the `sbom-drift-scanner` pattern). It publishes the report to a ConfigMap and *then* fails the Job, in that order, so the alert fires with the detail already readable — the 2026-07-12 lesson that a finding which only lands in a ConfigMap is a finding nobody acts on. Plus a `PrometheusRule` for drift **and for staleness**: a detector that quietly stops running is indistinguishable from a clean realm.

Why a CronJob and not a CI gate: the live realm is unreachable from a PR runner — the admin REST API is blocked at the nginx edge by design, no workflow holds cluster credentials, the admin secret is out-of-band. So the *capture* happens in-cluster and the *comparison* is ordinary, reviewable, unit-tested repo code. The pod holds no logic worth testing; it holds a credential and a network path. It is granted no `get` on secrets — the credential arrives via `secretKeyRef`, resolved by the kubelet — and it lives in `iam`, where Keycloak's ingress allow-list already admits `podSelector: {}`, so no NetworkPolicy change is needed (and `gen-network-policies.py` derives edges from Deployments, so it would not have covered a CronJob anyway).

## Falsification — both directions, and the negative cases

`openbank-infra/scripts/check_realm_role_parity_test.py` (8 tests, picked up by `ci.yml`'s existing `unittest discover`). Each was run against an input it must classify, and the detector was then deliberately broken to confirm the tests go red:

- **declared-not-live**: dropped `ROLE_KYC_REVIEWER` from the live snapshot → exit 1, names the role and its `.kt` call sites. ✅
- **live-not-declared**: added an undeclared role → exit 1. ✅
- **neutered both directions** (`missing = []`, `extra = []`): 3 tests went **red**, confirming they were testing the detector and not themselves. ✅
- **must NOT flag**: template == live → exit 0. **This negative case found a real bug in the first implementation** — the customers template declares `default-roles-openbank-customers` explicitly, so excluding built-ins live-side only turned a server-managed role into a permanent `declaredNotLive` finding. A detector that always fires is one nobody reads by week two. Built-ins are now subtracted from both sides.
- **capture failures**: a missing snapshot fails as `UNCHECKED, not clean`; an empty one fails as `failed capture`. ✅

Also verified: `check-roles-allowed-realm.py` still green (346 sites), full `openbank-infra/scripts` suite green (125 tests), `yamllint` with ci.yml's exact config, `check-gitops-secret-refs.py`, `check-critical-alert-egress.py`, `check-podmonitor-namespace-coverage.py`, `check-license-headers.py`, `check-duplicate-yaml-keys.sh`. No `rules.yaml` or `.rego` touched, so no OPA bundle restamp.

## Left for the owner (why `Refs`, not `Closes`)

1. **Nothing here mutates the live realm.** The four roles were already created by hand and `ROLE_DEMO` added to the template in #2538, so the sets currently match — but the first scheduled run is the only thing that will confirm that, and it needs the Application synced.
2. **Reconciliation is still undecided.** #2540 lists three options; this ships option (1)'s detector half. Option (2) — an idempotent `kcadm` Job that makes the template *mean* what it appears to mean — is the smaller trap-disarming change, but it writes to the identity provider and wants its own decision.
3. **Role ASSIGNMENT parity is not covered.** `service-account-openbank-services` held `ROLE_OPERATOR` live while the template declared no such user (#2442) — the same class one level deeper, and the natural next increment.