### PR TITLE
feat(admin-ui): add the consents page (ADR-0208 D1 second consumer)

### DIFF
--- a/openbank-admin-ui/e2e/ui-primitives.spec.ts
+++ b/openbank-admin-ui/e2e/ui-primitives.spec.ts
@@ -1,0 +1,144 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright (c) OpenBank contributors. Licensed under the Apache License, Version 2.0.
+// See LICENSE in the repository root or https://www.apache.org/licenses/LICENSE-2.0 for details.
+
+// E2E coverage for the ADR-0208 shared UI primitives, in a real browser with the real
+// stylesheet applied.
+//
+// WHY THIS SUITE EXISTS — it is not "more tests", it covers a specific blind spot.
+// PR #2556 shipped three visual regressions that `tsc --noEmit`, `eslint` and the
+// mount-only `render-smoke` suite ALL passed:
+//   1. score swatches applied `BADGE_CLASS` and overrode width/height inline, but `.badge`
+//      sets `padding: 4px 10px; border-radius: 20px` and globals.css sets a global
+//      `box-sizing: border-box` — so an 18px swatch had 20px of horizontal padding inside an
+//      18px box (zero content width) and a 26px tile rendered as a circle;
+//   2. a header icon was silently dropped in a migration;
+//   3. StatCard tinted only its label, so a red/green metric value rendered plain.
+// None of those are type errors, lint errors, or mount failures. They are only observable
+// once CSS is applied and geometry is measured — which is exactly what a browser does and
+// jsdom does not. So the assertions below are deliberately about COMPUTED STYLE and
+// BOUNDING BOXES, not about text being present.
+//
+// All BFF traffic is intercepted with page.route(); no live services required.
+
+import { expect, test } from '@playwright/test'
+import { signInAsOperator } from './helpers/auth'
+
+test.beforeEach(async ({ context, baseURL }) => {
+  await signInAsOperator(context, baseURL!)
+})
+
+const READINESS = {
+  generated_for: 'e2e',
+  dimensions: [
+    { code: 'C1', name: 'Code' },
+    { code: 'C2', name: 'Backup' },
+  ],
+  services: [
+    { service: 'svc-go', money_path: true, scores: { C1: 3, C2: 3 }, evidence: {}, gate: 'GO' },
+    { service: 'svc-nogo', money_path: false, scores: { C1: 0, C2: 1 }, evidence: {}, gate: 'NO-GO' },
+  ],
+}
+
+const CONSENTS = [
+  {
+    id: 'c1', partyId: '11111111-1111-1111-1111-111111111111',
+    granteeId: 'party-service:marketing-comms', granteeType: 'INTERNAL_SERVICE',
+    granteeName: 'Party marketing preferences',
+    scopes: ['MARKETING_COMMS_EMAIL'], accountIbans: null, status: 'ACTIVE',
+    validFrom: '2026-07-01T00:00:00Z', validTo: '2027-06-30T00:00:00Z', createdAt: '2026-07-01T00:00:00Z',
+  },
+  {
+    id: 'c2', partyId: '22222222-2222-2222-2222-222222222222',
+    granteeId: 'party-service:marketing-comms', granteeType: 'INTERNAL_SERVICE',
+    granteeName: 'Party marketing preferences',
+    scopes: ['MARKETING_COMMS_PUSH'], accountIbans: null, status: 'REVOKED',
+    validFrom: '2026-01-01T00:00:00Z', validTo: '2027-01-01T00:00:00Z', createdAt: '2026-01-01T00:00:00Z',
+  },
+]
+
+test.describe('ADR-0208 primitives render with real CSS applied', () => {
+  test('tone swatches are square with zero padding, at both sizes', async ({ page }) => {
+    await page.route('**/api/prod-readiness', route =>
+      route.fulfill({ status: 200, body: JSON.stringify(READINESS) }),
+    )
+    await page.goto('/system/readiness')
+
+    const swatch = page.locator('.tone-swatch').first()
+    await expect(swatch).toBeVisible()
+
+    // The regression: `.badge`'s padding collapsed the content box and its 20px radius
+    // turned the tile into a circle. `.tone-swatch` must own its geometry instead.
+    const box = await swatch.boundingBox()
+    expect(box).not.toBeNull()
+    expect(Math.round(box!.width)).toBe(26)
+    expect(Math.round(box!.height)).toBe(26)
+    expect(await swatch.evaluate(el => getComputedStyle(el).padding)).toBe('0px')
+    // A square tile, not a pill: radius must be well under half the 26px side.
+    const radius = await swatch.evaluate(el => parseFloat(getComputedStyle(el).borderTopLeftRadius))
+    expect(radius).toBeLessThan(13)
+
+    // The small legend variant is where zero content width showed up first.
+    const small = page.locator('.tone-swatch-sm').first()
+    await expect(small).toBeVisible()
+    const smallBox = await small.boundingBox()
+    expect(Math.round(smallBox!.width)).toBe(18)
+    expect(Math.round(smallBox!.height)).toBe(18)
+    // The digit must actually be inside it — zero content width renders an empty box.
+    expect((await small.textContent())?.trim()).not.toBe('')
+  })
+
+  test('StatCard tints both its label and its value when a tone is set', async ({ page }) => {
+    await page.route('**/api/prod-readiness', route =>
+      route.fulfill({ status: 200, body: JSON.stringify(READINESS) }),
+    )
+    await page.goto('/system/readiness')
+
+    // Anchor on the LABEL element with an exact-match regex: a plain `hasText: 'GO'` is a
+    // substring match, so it also selects the "NO-GO" card and the locator resolves to two
+    // elements under strict mode.
+    const colourOf = (label: string) =>
+      page
+        .locator('.stat-card')
+        .filter({ has: page.locator('.stat-label', { hasText: new RegExp(`^${label}$`) }) })
+        .locator('.stat-value')
+        .evaluate(el => getComputedStyle(el).color)
+
+    // GO and NO-GO carry a verdict, so their VALUES must differ in colour from each other
+    // and from the untinted tile. Tinting only the label was regression (3).
+    const [go, nogo] = [await colourOf('GO'), await colourOf('NO-GO')]
+    expect(go).not.toBe(nogo)
+
+    const plain = await colourOf('Services')
+    expect(plain).not.toBe(go)
+  })
+
+  test('PageHeader renders its icon slot', async ({ page }) => {
+    await page.route('**/api/prod-readiness', route =>
+      route.fulfill({ status: 200, body: JSON.stringify(READINESS) }),
+    )
+    await page.goto('/system/readiness')
+
+    // Regression (2): the icon was silently dropped when the page moved to PageHeader.
+    await expect(page.locator('.page-header svg').first()).toBeVisible()
+  })
+
+  test('StatusBadge distinguishes ACTIVE from REVOKED by tone, not by text alone', async ({ page }) => {
+    await page.route('**/api/svc/consent-service/api/v1/consents/grantee/**', route =>
+      route.fulfill({ status: 200, body: JSON.stringify(CONSENTS) }),
+    )
+    await page.goto('/consents')
+    await page.getByRole('button', { name: /Vyhledat|Look up/ }).click()
+
+    const active = page.locator('.badge', { hasText: /^ACTIVE$/ })
+    const revoked = page.locator('.badge', { hasText: /^REVOKED$/ })
+    await expect(active).toBeVisible()
+    await expect(revoked).toBeVisible()
+
+    // statusTone maps ACTIVE -> success and REVOKED -> neutral (the consent reading: a
+    // withdrawal under GDPR Art. 7(3) is a right being exercised, not an incident). If the
+    // vocabulary ever collapses to one tone, an operator loses the distinction at a glance.
+    const bg = (l: typeof active) => l.evaluate(el => getComputedStyle(el).backgroundColor)
+    expect(await bg(active)).not.toBe(await bg(revoked))
+  })
+})

--- a/openbank-admin-ui/src/app/consents/layout.tsx
+++ b/openbank-admin-ui/src/app/consents/layout.tsx
@@ -1,0 +1,20 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright (c) OpenBank contributors. Licensed under the Apache License, Version 2.0.
+// See LICENSE in the repository root or https://www.apache.org/licenses/LICENSE-2.0 for details.
+
+import { Sidebar } from "@/components/layout/Sidebar"
+import { Header } from "@/components/layout/Header"
+
+export default function Layout({ children }: { children: React.ReactNode }) {
+  return (
+    <div style={{ display: "flex", height: "100vh", overflow: "hidden" }}>
+      <Sidebar />
+      <div style={{ flex: 1, display: "flex", flexDirection: "column", overflow: "hidden" }}>
+        <Header />
+        <main style={{ flex: 1, overflowY: "auto", padding: "24px", background: "var(--bg)" }}>
+          {children}
+        </main>
+      </div>
+    </div>
+  )
+}

--- a/openbank-admin-ui/src/app/consents/page.tsx
+++ b/openbank-admin-ui/src/app/consents/page.tsx
@@ -1,0 +1,196 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright (c) OpenBank contributors. Licensed under the Apache License, Version 2.0.
+// See LICENSE in the repository root or https://www.apache.org/licenses/LICENSE-2.0 for details.
+
+'use client'
+
+import { useState } from 'react'
+import { FileSignature, Search } from 'lucide-react'
+import { useLanguage } from '@/lib/i18n/LanguageContext'
+import { DataUnavailable, type UnavailableKind } from '@/components/feedback/DataUnavailable'
+import { classifyBffFailure } from '@/lib/services/bff'
+import { PageHeader, StatCard, StatusBadge, statusTone } from '@/components/ui'
+
+// consent-service (ADR-0126) exposes NO "list all consents" endpoint — every read is keyed by
+// consentId, partyId or granteeId. So this is deliberately a LOOKUP page, not a table of everything:
+// inventing a global list would mean adding an unbounded-scan endpoint to a service that correctly
+// refuses to have one.
+//
+// The grantee lens is the one genuinely global view available, and it is the useful one: querying
+// `party-service:marketing-comms` (ADR-0205 D3's fixed internal grantee) answers "who has an ACTIVE
+// marketing consent right now" straight from the owning service, with no projection to drift.
+const MARKETING_GRANTEE = 'party-service:marketing-comms'
+
+interface Consent {
+  id: string
+  partyId: string
+  granteeId: string
+  granteeType: string
+  granteeName: string
+  scopes: string[]
+  accountIbans: string[] | null
+  status: string
+  validFrom: string
+  validTo: string
+  createdAt: string
+}
+
+type Lens = 'party' | 'grantee'
+
+export default function ConsentsPage() {
+  const { t, language } = useLanguage()
+  const [lens, setLens] = useState<Lens>('grantee')
+  const [term, setTerm] = useState(MARKETING_GRANTEE)
+  const [rows, setRows] = useState<Consent[] | null>(null)
+  const [failure, setFailure] = useState<UnavailableKind | null>(null)
+  const [loading, setLoading] = useState(false)
+
+  const lookup = async () => {
+    const q = term.trim()
+    if (!q) return
+    setLoading(true)
+    setFailure(null)
+    setRows(null)
+    try {
+      const path = lens === 'party' ? `party/${encodeURIComponent(q)}` : `grantee/${encodeURIComponent(q)}`
+      const res = await fetch(`/api/svc/consent-service/api/v1/consents/${path}`, { cache: 'no-store' })
+      if (!res.ok) {
+        setFailure(await classifyBffFailure(res))
+        return
+      }
+      const data = (await res.json()) as Consent[]
+      setRows(data)
+      if (data.length === 0) setFailure('no_data')
+    } catch {
+      setFailure('unreachable')
+    } finally {
+      setLoading(false)
+    }
+  }
+
+  const active = rows?.filter(c => c.status === 'ACTIVE').length ?? 0
+  const marketing = rows?.filter(c => c.scopes.some(s => s.startsWith('MARKETING_COMMS_'))).length ?? 0
+  const fmt = (iso: string) =>
+    new Intl.DateTimeFormat(language === 'cs' ? 'cs-CZ' : 'en-GB', { dateStyle: 'medium' }).format(new Date(iso))
+
+  return (
+    <div style={{ padding: '32px', maxWidth: '1280px', margin: '0 auto' }}>
+      <PageHeader
+        icon={<FileSignature size={28} className="tone-text-accent" />}
+        title={t('Souhlasy', 'Consents')}
+        subtitle={t(
+          'Souhlasy vlastní consent-service (ADR-0126/0198). Nemá endpoint pro výpis všeho — hledá se podle party nebo grantee. Marketingový grantee party-service:marketing-comms je globální pohled na aktivní marketingové souhlasy.',
+          'consent-service owns consents (ADR-0126/0198). It has no list-everything endpoint — look up by party or by grantee. The marketing grantee party-service:marketing-comms is the global view of active marketing consents.',
+        )}
+      />
+
+      <div className="card" style={{ marginBottom: '20px' }}>
+        <div style={{ display: 'flex', gap: '10px', flexWrap: 'wrap', alignItems: 'center' }}>
+          <select
+            value={lens}
+            onChange={e => {
+              const next = e.target.value as Lens
+              setLens(next)
+              setTerm(next === 'grantee' ? MARKETING_GRANTEE : '')
+            }}
+            style={{
+              padding: '8px 12px', borderRadius: '8px', border: '1px solid var(--border)',
+              background: 'var(--surface)', color: 'var(--text-primary)', fontSize: '13px', fontWeight: 600,
+            }}
+          >
+            <option value="grantee">{t('Podle grantee', 'By grantee')}</option>
+            <option value="party">{t('Podle party ID', 'By party ID')}</option>
+          </select>
+          <input
+            value={term}
+            onChange={e => setTerm(e.target.value)}
+            onKeyDown={e => { if (e.key === 'Enter') lookup() }}
+            placeholder={lens === 'party' ? t('UUID party', 'Party UUID') : t('ID grantee', 'Grantee id')}
+            style={{
+              flex: '1 1 320px', padding: '8px 12px', borderRadius: '8px', border: '1px solid var(--border)',
+              background: 'var(--surface)', color: 'var(--text-primary)', fontSize: '13px',
+            }}
+          />
+          <button
+            onClick={lookup}
+            disabled={loading || !term.trim()}
+            style={{
+              display: 'flex', alignItems: 'center', gap: '6px', padding: '8px 16px',
+              cursor: loading || !term.trim() ? 'not-allowed' : 'pointer', borderRadius: '8px',
+              border: '1px solid var(--border)', background: 'var(--surface)',
+              color: 'var(--text-secondary)', fontSize: '13px', fontWeight: 600,
+              opacity: loading || !term.trim() ? 0.6 : 1,
+            }}
+          >
+            <Search size={15} /> {t('Vyhledat', 'Look up')}
+          </button>
+        </div>
+      </div>
+
+      {rows && rows.length > 0 && (
+        <div style={{ display: 'grid', gridTemplateColumns: 'repeat(auto-fit, minmax(160px, 1fr))', gap: '12px', marginBottom: '20px' }}>
+          <StatCard label={t('Nalezeno', 'Found')} value={rows.length} />
+          <StatCard label={t('Aktivních', 'Active')} value={active} tone="success" />
+          <StatCard label={t('Marketingových', 'Marketing')} value={marketing} tone="info" />
+        </div>
+      )}
+
+      {loading && (
+        <div style={{ color: 'var(--text-secondary)', padding: '40px', textAlign: 'center' }}>
+          {t('Načítám…', 'Loading…')}
+        </div>
+      )}
+
+      {!loading && failure && (
+        <DataUnavailable
+          kind={failure}
+          service="Consent-service"
+          feature={t('Souhlasy', 'Consents')}
+          lang={language === 'cs' ? 'cs' : 'en'}
+        />
+      )}
+
+      {!loading && rows && rows.length > 0 && (
+        <div className="card" style={{ overflowX: 'auto' }}>
+          <table className="table">
+            <thead>
+              <tr>
+                <th>{t('Party', 'Party')}</th>
+                <th>{t('Grantee', 'Grantee')}</th>
+                <th>{t('Rozsahy', 'Scopes')}</th>
+                <th>{t('Stav', 'Status')}</th>
+                <th>{t('Platnost do', 'Valid to')}</th>
+              </tr>
+            </thead>
+            <tbody>
+              {rows.map(c => (
+                <tr key={c.id}>
+                  <td style={{ fontFamily: 'var(--font-mono, monospace)', fontSize: '11px' }}>{c.partyId}</td>
+                  <td>
+                    <div style={{ fontWeight: 600 }}>{c.granteeName}</div>
+                    <div style={{ fontSize: '11px', color: 'var(--text-tertiary)' }}>{c.granteeId}</div>
+                  </td>
+                  <td>
+                    <div style={{ display: 'flex', gap: '4px', flexWrap: 'wrap' }}>
+                      {c.scopes.map(s => (
+                        <span key={s} className="tag" style={{ fontSize: '10px' }}>{s}</span>
+                      ))}
+                    </div>
+                  </td>
+                  <td>
+                    {/* statusTone treats REVOKED/EXPIRED as neutral, which is the consent reading:
+                        a withdrawal under Art. 7(3) is the customer exercising a right, not an
+                        incident. This page is that domain, so the shared default is correct here and
+                        no `tone` override is passed (ADR-0208 D2). */}
+                    <StatusBadge status={c.status} withDot tone={statusTone(c.status)} />
+                  </td>
+                  <td>{fmt(c.validTo)}</td>
+                </tr>
+              ))}
+            </tbody>
+          </table>
+        </div>
+      )}
+    </div>
+  )
+}

--- a/openbank-admin-ui/src/components/layout/Sidebar.tsx
+++ b/openbank-admin-ui/src/components/layout/Sidebar.tsx
@@ -58,6 +58,7 @@ const complianceNav: NavItem[] = [
   { nameCs: 'AML',                nameEn: 'AML',              href: '/aml',               icon: AlertOctagon,          permission: 'compliance:view' },
   { nameCs: 'Sankce',             nameEn: 'Sanctions',        href: '/sanctions',         icon: Shield,                permission: 'compliance:view' },
   { nameCs: 'Spory',              nameEn: 'Disputes',         href: '/disputes',          icon: MessageSquareWarning,  permission: 'compliance:view' },
+  { nameCs: 'Souhlasy',           nameEn: 'Consents',         href: '/consents',          icon: FileSignature,           permission: 'compliance:view' },
   { nameCs: 'Auditní záznamy',    nameEn: 'Audit Log',        href: '/audit',             icon: ScrollText,            permission: 'audit:view' },
   { nameCs: 'Regulatorní',        nameEn: 'Regulatory',       href: '/regulatory',        icon: FileText,              permission: 'regulatory:view' },
 ]


### PR DESCRIPTION
## Summary
admin-ui had **no consent surface at all**, despite consent-service owning a GDPR Art. 6(1)(a)/7(3) control and the whole ADR-0198/0205/0206 chain having just shipped. Adds one at `/consents`, in the compliance nav group.

**Deliberately a lookup page, not a table of everything.** consent-service exposes no list-all endpoint — every read is keyed by `consentId`, `partyId` or `granteeId`. Inventing a global list would have meant adding an unbounded-scan endpoint to a service that correctly refuses to have one. The grantee lens is the one genuinely global view available, and it is the useful one: querying `party-service:marketing-comms` (ADR-0205 D3's fixed internal grantee) answers *"who holds an ACTIVE marketing consent right now"* straight from the owning service, with no projection to drift.

**Second consumer of the ADR-0208 primitives, which is the point.** It uses `PageHeader`, `StatCard` and `StatusBadge` instead of hand-rolling them, so that layer is now proven by two independent pages rather than one — directly answering the review concern on #2556 that two primitives had shipped with no caller.

It also exercises the domain-ambiguous `EXPIRED`/`REVOKED` default deliberately: **consent is the domain `statusTone`'s `neutral` was chosen for** — a withdrawal under Art. 7(3) is a customer exercising a right, not an incident — so no `tone` override is passed here, unlike `pid` which will need one when it migrates.

Reaches consent-service through the existing BFF (`/api/svc/consent-service`, already in `SERVICE_MAP` at 8106), never directly, and degrades through `DataUnavailable` on every BFF failure class rather than leaking an HTTP status.

## Test plan
- [x] `npm test` — **48 files / 781 tests passed, exit 0** (up from 776; the new page satisfies `render-smoke`, `layout-shell.guard`, `graceful-states.guard` and `i18n.guard` with no baseline entry)
- [x] `npx tsc --noEmit` — exit 0
- [x] `npx eslint src/app/consents src/components/layout/Sidebar.tsx` — 0 errors
- [x] **Verified by rendering, not only by tests** — dumped to static HTML and screenshotted: `ACTIVE` renders success-green with a dot, `REVOKED`/`EXPIRED` render neutral, StatCards tint label and value, scope tags wrap. This is the check that caught three regressions on #2556 that typecheck, lint and the mount-only smoke test all passed.

### Correction to an earlier claim
An earlier revision of this PR body (and #2556's) said the suite carried **5 pre-existing failures**. That was wrong, and so was my verification of it. `npx vitest run` **skips `pretest`** (`generate-governance.mjs` + `generate-catalog.mjs`), so `catalog.json` and the governance fixtures the finops / service-registry tests read never get generated — hence `ENOENT`. I "confirmed pre-existing" by stashing and re-running the *same* wrong command, so the probe carried the very defect it was meant to rule out. Run `npm test`, not `npx vitest run`.

Refs ADR-0208 (merged #2548), ADR-0126/0198/0205.

🤖 Generated with [Claude Code](https://claude.com/claude-code)