### PR TITLE
ci(admin-ui): make the eslint 10 / typescript 7 block self-clearing, not hand-polled

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -75,6 +75,14 @@ updates:
     # Majors the ecosystem cannot satisfy yet. Each PR can never go green, so
     # dependabot would just re-open a red PR every Monday. Drop the entry once
     # the unblock criterion in #1314 is met.
+    #
+    # Every entry below MUST also be declared in `WATCHES` in
+    # .github/scripts/check-upstream-unblock.py — the Upstream unblock watch
+    # re-derives each criterion monthly and comments on the issue the day a
+    # block goes stale, and fails this PR if the two lists drift. An entry
+    # whose blocker lives in THIS repo is declared there with `upstream: None`;
+    # it is never simply omitted, because an omitted entry is a block nothing
+    # watches. (#1314)
     ignore:
       # eslint 10 removed context.getFilename(); the eslint-plugin-react that
       # eslint-config-next@16 bundles still calls it and peers on eslint <=9.

--- a/.github/scripts/check-upstream-unblock.py
+++ b/.github/scripts/check-upstream-unblock.py
@@ -1,0 +1,353 @@
+#!/usr/bin/env python3
+# SPDX-License-Identifier: Apache-2.0
+# Copyright (c) OpenBank contributors. Licensed under the Apache License, Version 2.0.
+#
+# Upstream-unblock watch: turn a hand-polled "blocked on the ecosystem" issue into a
+# self-clearing one (issue #1314).
+#
+# WHY THIS EXISTS
+#   `.github/dependabot.yml` carries `ignore:` entries for majors the ecosystem cannot
+#   satisfy yet (eslint 10, typescript 7). Each entry's comment says "drop it once the
+#   criterion in #1314 is met" — but nothing ever evaluates that criterion. The only
+#   mechanism was a human re-running two `npm view` commands, and the issue's own comment
+#   history shows exactly what that produces: three separate triage passes across ten days,
+#   each re-deriving the same "still blocked", each costing a full investigation.
+#
+#   The failure mode is not that the block is wrong. It is that the block has no expiry:
+#   the day the peer range DOES admit eslint 10, nothing notices, and the ignore entry
+#   silently becomes a permanent unexplained pin. A block nobody re-checks is
+#   indistinguishable from a decision.
+#
+# WHAT IT CHECKS
+#   1. DRIFT, both directions. Every npm `ignore:` entry in dependabot.yml must be declared
+#      in WATCHES below, and every WATCHES entry must correspond to a live ignore entry.
+#      This is the repo's derived-scope rule (never let a gate's coverage set be maintained
+#      separately from the artifacts it covers): an ignore entry added without a watch
+#      would otherwise be a block this script reports nothing about, while still passing.
+#   2. LIVENESS. For each watch that names an upstream criterion, resolve the published
+#      peer range from the npm registry and test whether it now admits the blocked major.
+#      Satisfied => the block is stale => report it, loudly.
+#
+#   A watch may legitimately have NO upstream criterion (`upstream: None`) — tailwindcss v4
+#   is blocked on a migration in THIS repo, not on anyone else. Those are declared, not
+#   omitted, so the drift check stays exact.
+#
+# EXIT CODES
+#   0  every block still justified, no drift
+#   1  at least one block is now stale (or drift) — the actionable state
+#   2  the probe itself could not run (network, registry shape change)
+#
+#   Note the separation of 1 and 2. A registry fetch that fails must NEVER be reported as
+#   "still blocked" — that is the shape where a broken probe's silence reads as evidence of
+#   absence. `--self-test` exercises the range matcher against inputs it MUST accept and
+#   inputs it MUST reject, so the matcher is not trusted purely on having never fired.
+#
+# Run:  python3 .github/scripts/check-upstream-unblock.py [--root .] [--self-test]
+
+import argparse
+import json
+import pathlib
+import re
+import sys
+import urllib.error
+import urllib.parse
+import urllib.request
+
+REGISTRY = "https://registry.npmjs.org"
+
+# Keyed by the dependabot `dependency-name` being ignored.
+WATCHES = {
+    "eslint": {
+        "issue": 1314,
+        # eslint 10 removed context.getFilename(); the eslint-plugin-react that
+        # eslint-config-next bundles still calls it and peers on eslint <= 9.
+        "upstream": {
+            "package": "eslint-plugin-react",
+            "peer": "eslint",
+            "probe": "10.0.0",
+        },
+    },
+    "typescript": {
+        "issue": 1314,
+        # typescript-eslint's parser does not support the TypeScript 7 compiler API.
+        "upstream": {
+            "package": "@typescript-eslint/parser",
+            "peer": "typescript",
+            "probe": "7.0.0",
+        },
+    },
+    "tailwindcss": {
+        "issue": 1653,
+        # Blocked on a deliberate migration in THIS repo (CSS-first @theme, PostCSS plugin
+        # rename, darkMode syntax), not on any upstream peer range. Declared with no
+        # upstream criterion so the drift check above stays exact — there is nothing to
+        # poll, and pretending otherwise would manufacture a signal.
+        "upstream": None,
+    },
+}
+
+# --------------------------------------------------------------------------------------
+# Minimal semver-range satisfaction, covering the subset npm peerDependencies actually use:
+# `||`-separated alternatives, each a space-separated AND-set of `^X[.Y[.Z]]`, `~X.Y.Z`,
+# `>=`/`>`/`<=`/`<`/`=` comparators, a bare version, or `*`. Deliberately NOT a full semver
+# implementation — prereleases and hyphen ranges are not used by the peers we watch, and a
+# range this script cannot parse raises rather than quietly evaluating to False.
+# --------------------------------------------------------------------------------------
+
+_NUM = re.compile(r"^\d+$")
+
+
+def _parse_version(text):
+    core = text.strip().split("-", 1)[0].split("+", 1)[0]
+    parts = core.split(".")
+    out = []
+    for p in parts[:3]:
+        if not _NUM.match(p):
+            raise ValueError(f"unparseable version component {p!r} in {text!r}")
+        out.append(int(p))
+    while len(out) < 3:
+        out.append(0)
+    return tuple(out)
+
+
+def _parse_partial(text):
+    """Parse a possibly-partial version like `9`, `9.7`, `9.7.1` -> (tuple, specificity)."""
+    core = text.strip().split("-", 1)[0].split("+", 1)[0]
+    parts = [p for p in core.split(".") if p != ""]
+    nums = []
+    for p in parts[:3]:
+        if p in ("x", "X", "*"):
+            break
+        if not _NUM.match(p):
+            raise ValueError(f"unparseable version component {p!r} in {text!r}")
+        nums.append(int(p))
+    spec = len(nums)
+    while len(nums) < 3:
+        nums.append(0)
+    return tuple(nums), spec
+
+
+def _caret_bounds(base, spec):
+    """Upper bound (exclusive) for ^base, per npm's caret semantics."""
+    major, minor, _patch = base
+    if major > 0:
+        return (major + 1, 0, 0)
+    if minor > 0 or spec >= 2:
+        return (0, minor + 1, 0)
+    return (1, 0, 0)
+
+
+def _comparator_ok(cmp_text, version):
+    cmp_text = cmp_text.strip()
+    if cmp_text in ("", "*", "x", "X"):
+        return True
+    if cmp_text.startswith("^"):
+        base, spec = _parse_partial(cmp_text[1:])
+        return base <= version < _caret_bounds(base, spec)
+    if cmp_text.startswith("~"):
+        base, spec = _parse_partial(cmp_text[1:])
+        upper = (base[0], base[1] + 1, 0) if spec >= 2 else (base[0] + 1, 0, 0)
+        return base <= version < upper
+    for op in (">=", "<=", ">", "<", "="):
+        if cmp_text.startswith(op):
+            base, _spec = _parse_partial(cmp_text[len(op):])
+            if op == ">=":
+                return version >= base
+            if op == "<=":
+                return version <= base
+            if op == ">":
+                return version > base
+            if op == "<":
+                return version < base
+            return version == base
+    base, spec = _parse_partial(cmp_text)
+    if spec == 3:
+        return version == base
+    # A bare partial (`9`, `9.7`) means the same set as `^`-less x-range.
+    upper = (base[0] + 1, 0, 0) if spec <= 1 else (base[0], base[1] + 1, 0)
+    return base <= version < upper
+
+
+def satisfies(version_text, range_text):
+    """True iff `version_text` is admitted by npm range `range_text`."""
+    version = _parse_version(version_text)
+    for alternative in range_text.split("||"):
+        clauses = [c for c in alternative.strip().split() if c]
+        if not clauses:
+            continue
+        if all(_comparator_ok(c, version) for c in clauses):
+            return True
+    return False
+
+
+# --------------------------------------------------------------------------------------
+
+
+def npm_ignore_entries(root):
+    """dependency-name -> the raw `versions` list, for the npm ecosystem in dependabot.yml."""
+    try:
+        import yaml
+    except ImportError:
+        sys.stderr.write("PyYAML required: pip install pyyaml\n")
+        sys.exit(2)
+    path = root / ".github" / "dependabot.yml"
+    doc = yaml.safe_load(path.read_text(encoding="utf-8"))
+    found = {}
+    for update in doc.get("updates", []) or []:
+        if update.get("package-ecosystem") != "npm":
+            continue
+        for entry in update.get("ignore", []) or []:
+            name = entry.get("dependency-name")
+            if name:
+                found[name] = entry.get("versions", [])
+    return found
+
+
+def fetch_peer_range(package, peer):
+    url = f"{REGISTRY}/{urllib.parse.quote(package, safe='@')}/latest"
+    req = urllib.request.Request(url, headers={"Accept": "application/json"})
+    with urllib.request.urlopen(req, timeout=30) as resp:  # noqa: S310 - fixed https host
+        payload = json.load(resp)
+    peers = payload.get("peerDependencies") or {}
+    if peer not in peers:
+        raise KeyError(
+            f"{package}@{payload.get('version')} declares no peerDependencies[{peer!r}] — "
+            "the criterion this watch is written against no longer exists upstream; "
+            "re-derive it by hand rather than trusting this probe."
+        )
+    return payload.get("version"), peers[peer]
+
+
+def self_test():
+    """The matcher must accept what it should and REJECT what it should not.
+
+    Written because a range matcher that has only ever returned False is
+    indistinguishable from one that always returns False — which would report every
+    block as permanently justified, forever, with a green exit code.
+    """
+    cases = [
+        # (version, range, expected)
+        ("10.0.0", "^3 || ^4 || ^5 || ^6 || ^7 || ^8 || ^9.7", False),  # today's real range
+        ("10.0.0", "^3 || ^9.7 || ^10.0.0", True),  # the unblock we are waiting for
+        ("9.7.1", "^3 || ^4 || ^5 || ^6 || ^7 || ^8 || ^9.7", True),
+        ("9.6.0", "^9.7", False),
+        ("7.0.0", ">=4.8.4 <6.1.0", False),  # today's real range
+        ("7.0.0", ">=4.8.4 <8.0.0", True),  # the unblock we are waiting for
+        ("5.9.0", ">=4.8.4 <6.1.0", True),
+        ("10.0.0", "^8.57.0 || ^9.0.0 || ^10.0.0", True),
+        ("11.0.0", "^8.57.0 || ^9.0.0 || ^10.0.0", False),
+        ("4.0.0", "*", True),
+        ("0.29.0", "^0.28.5", False),
+        ("0.28.9", "^0.28.5", True),
+    ]
+    failures = []
+    for version, rng, expected in cases:
+        try:
+            actual = satisfies(version, rng)
+        except Exception as exc:  # noqa: BLE001 - a raise is itself a matcher failure
+            failures.append(f"  {version} vs {rng!r}: raised {exc}")
+            continue
+        if actual != expected:
+            failures.append(f"  {version} vs {rng!r}: expected {expected}, got {actual}")
+    if failures:
+        print("self-test FAILED:")
+        print("\n".join(failures))
+        return 1
+    print(f"self-test OK — {len(cases)} cases, including known-positives that MUST unblock.")
+    return 0
+
+
+def main():
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--root", default=".", type=pathlib.Path)
+    parser.add_argument(
+        "--self-test",
+        action="store_true",
+        help="exercise the range matcher against known-positive and known-negative inputs",
+    )
+    args = parser.parse_args()
+
+    if args.self_test:
+        return self_test()
+
+    ignores = npm_ignore_entries(args.root)
+
+    problems = []
+    for name in sorted(set(ignores) - set(WATCHES)):
+        problems.append(
+            f"dependabot.yml ignores {name!r} but WATCHES has no entry for it — an "
+            "undeclared block is one this script silently reports nothing about. Add a "
+            "watch (with `upstream: None` if the blocker is in this repo)."
+        )
+    for name in sorted(set(WATCHES) - set(ignores)):
+        problems.append(
+            f"WATCHES declares {name!r} but dependabot.yml no longer ignores it — the "
+            "block is gone; drop the stale watch."
+        )
+
+    stale = []
+    print("Upstream-unblock watch")
+    print("=" * 70)
+    for name in sorted(WATCHES):
+        watch = WATCHES[name]
+        if name not in ignores:
+            continue
+        upstream = watch["upstream"]
+        if upstream is None:
+            print(f"{name:<14} blocked in-repo (#{watch['issue']}) — nothing upstream to poll")
+            continue
+        try:
+            resolved, peer_range = fetch_peer_range(upstream["package"], upstream["peer"])
+        except (urllib.error.URLError, TimeoutError, json.JSONDecodeError, KeyError) as exc:
+            # NOT a "still blocked" verdict. A probe that could not run has no verdict.
+            sys.stderr.write(
+                f"PROBE FAILED for {name}: {upstream['package']} peer "
+                f"{upstream['peer']!r}: {exc}\n"
+            )
+            return 2
+        admitted = satisfies(upstream["probe"], peer_range)
+        state = "UNBLOCKED" if admitted else "still blocked"
+        print(
+            f"{name:<14} {state:<14} {upstream['package']}@{resolved} "
+            f"peer {upstream['peer']}: {peer_range!r} "
+            f"(probe {upstream['probe']})"
+        )
+        if admitted:
+            stale.append(
+                f"`{name}` is no longer blocked: "
+                f"`{upstream['package']}@{resolved}` now declares "
+                f"`{upstream['peer']}: {peer_range}`, which admits "
+                f"{upstream['probe']}. Drop the `ignore:` entry for `{name}` in "
+                f"`.github/dependabot.yml` and let the major bump through (#{watch['issue']})."
+            )
+
+    print("=" * 70)
+
+    if problems:
+        for p in problems:
+            print(f"::error::upstream-unblock drift: {p}")
+    for s in stale:
+        print(f"::warning::upstream-unblock: {s}")
+
+    summary = []
+    if stale:
+        summary.append("### Upstream block is now stale\n")
+        summary += [f"- {s}\n" for s in stale]
+    if problems:
+        summary.append("### Watch/dependabot drift\n")
+        summary += [f"- {p}\n" for p in problems]
+    if summary:
+        import os
+
+        step_summary = os.environ.get("GITHUB_STEP_SUMMARY")
+        if step_summary:
+            with open(step_summary, "a", encoding="utf-8") as fh:
+                fh.write("".join(summary))
+        return 1
+
+    print("All declared blocks are still justified; no drift.")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/.github/workflows/upstream-unblock-watch.yml
+++ b/.github/workflows/upstream-unblock-watch.yml
@@ -1,0 +1,158 @@
+# -----------------------------------------------------------------------------
+# Upstream-unblock watch (issue #1314).
+#
+# WHY THIS EXISTS
+#   `.github/dependabot.yml` ignores two majors the ecosystem cannot satisfy yet
+#   (eslint 10, typescript 7). Each entry says "drop it once the criterion in
+#   #1314 is met" — and until now the only thing that evaluated that criterion
+#   was a person re-running two `npm view` commands. #1314's comment history is
+#   three separate triage passes across ten days, each re-deriving the same
+#   "still blocked".
+#
+#   The cost of that is not the wasted passes. It is that the block has no
+#   expiry: on the day the peer range DOES admit eslint 10, nothing notices, and
+#   an ignore entry that was a reasoned block quietly becomes an unexplained
+#   permanent pin. This workflow is what makes the block self-clearing — it
+#   re-derives the criterion on a schedule and says so on the issue.
+#
+# WHY IT ALSO RUNS ON PRs
+#   The script's OTHER half is a drift check: every npm `ignore:` entry must be
+#   declared in the script's WATCHES table and vice versa. That is a property of
+#   the committed files, checkable with no network, and it is what stops a new
+#   ignore entry from becoming a block this watch silently knows nothing about.
+#   Running it on PRs that touch either file is the only moment that check can
+#   block anything.
+#
+# ESCALATION
+#   A red push/schedule run is addressed to nobody, so a stale block posts a
+#   comment on its own issue and drops the `blocked` label — the state change is
+#   the notification, not the workflow conclusion.
+# -----------------------------------------------------------------------------
+name: Upstream unblock watch
+
+on:
+  schedule:
+    # 06:20 UTC on the 1st of the month. Monthly is the right cadence: these are
+    # upstream peer ranges that move on a major-release timescale, and #1314's
+    # own comments recommend re-checking monthly rather than re-triaging.
+    - cron: "20 6 1 * *"
+  pull_request:
+    paths:
+      - ".github/dependabot.yml"
+      - ".github/scripts/check-upstream-unblock.py"
+      - ".github/workflows/upstream-unblock-watch.yml"
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+concurrency:
+  group: upstream-unblock-watch-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  watch:
+    name: upstream-unblock-watch
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    permissions:
+      contents: read
+      issues: write
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+
+      - name: Install PyYAML
+        run: python3 -m pip install --quiet pyyaml
+
+      # The matcher decides whether a block is stale. A matcher that has only
+      # ever returned "still blocked" is indistinguishable from one that always
+      # returns it — so it is exercised against inputs it MUST accept before its
+      # verdict is trusted. This step failing means the verdict below is void.
+      - name: Self-test the range matcher
+        run: python3 .github/scripts/check-upstream-unblock.py --self-test
+
+      - name: Evaluate declared blocks
+        id: watch
+        run: |
+          set +e
+          python3 .github/scripts/check-upstream-unblock.py --root . | tee /tmp/unblock.txt
+          code=${PIPESTATUS[0]}
+          set -e
+          echo "code=$code" >> "$GITHUB_OUTPUT"
+          case "$code" in
+            0) echo "All declared blocks still justified." ;;
+            1) echo "::notice::A declared block is stale, or the watch has drifted." ;;
+            *) echo "::error::The unblock probe could not run — this is NOT a "
+               echo "::error::'still blocked' verdict. Investigate before trusting it."
+               exit "$code" ;;
+          esac
+
+      # On a PR the drift half is the gate: fail so it cannot merge undeclared.
+      # (The liveness half also lands here, which is correct — a PR touching
+      # dependabot.yml is exactly when someone should learn the block is stale.)
+      - name: Fail the PR on drift or a stale block
+        if: ${{ github.event_name == 'pull_request' && steps.watch.outputs.code != '0' }}
+        run: |
+          echo "::error::upstream-unblock: see the log above."
+          exit 1
+
+      - name: Report a stale block on its issue
+        if: ${{ github.event_name != 'pull_request' && steps.watch.outputs.code == '1' }}
+        uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9.0.0
+        with:
+          script: |
+            const fs = require('fs')
+            const report = fs.readFileSync('/tmp/unblock.txt', 'utf8')
+            const MARKER = '<!-- upstream-unblock-watch -->'
+            // The issues named by the WATCHES table. Kept here rather than
+            // parsed out of the report so a formatting change cannot silently
+            // retarget a comment at the wrong issue.
+            const issues = [1314, 1653]
+            const body = [
+              MARKER,
+              '## Upstream unblock watch — a declared block looks stale',
+              '',
+              'The scheduled watch re-derived the unblock criteria and something',
+              'changed. Full output:',
+              '',
+              '```',
+              report.trim(),
+              '```',
+              '',
+              'If a dependency reads `UNBLOCKED`, drop its `ignore:` entry in',
+              '`.github/dependabot.yml` (and its `WATCHES` entry in',
+              '`.github/scripts/check-upstream-unblock.py`) and let the major bump',
+              'through. If this is drift, reconcile the two files.',
+              '',
+              `_Automated: \`${context.workflow}\` run ${context.runId}._`,
+            ].join('\n')
+
+            for (const issue_number of issues) {
+              let issue
+              try {
+                issue = (await github.rest.issues.get({
+                  ...context.repo, issue_number,
+                })).data
+              } catch (e) {
+                core.warning(`issue #${issue_number}: ${e.message}`)
+                continue
+              }
+              if (issue.state !== 'open') {
+                core.notice(`issue #${issue_number} is closed — not commenting`)
+                continue
+              }
+              await github.rest.issues.createComment({
+                ...context.repo, issue_number, body,
+              })
+              // Drop `blocked`: the label is the thing that tells a human to
+              // skip this issue, and it is now the wrong signal.
+              if ((issue.labels ?? []).some(l => (l.name ?? l) === 'blocked')) {
+                try {
+                  await github.rest.issues.removeLabel({
+                    ...context.repo, issue_number, name: 'blocked',
+                  })
+                } catch (e) {
+                  core.warning(`could not remove 'blocked' from #${issue_number}: ${e.message}`)
+                }
+              }
+            }


### PR DESCRIPTION
## What

`.github/dependabot.yml` ignores two majors the ecosystem cannot satisfy yet (eslint 10, typescript 7). Each entry says *"drop it once the unblock criterion in #1314 is met"* — and nothing has ever evaluated that criterion. #1314's comment history is three separate triage passes across ten days, each re-running the same two `npm view` commands and re-deriving the same "still blocked".

The wasted passes are not the problem. The problem is that **the block has no expiry**: on the day `eslint-plugin-react`'s peer range does admit eslint 10, nothing notices, and a reasoned block quietly becomes an unexplained permanent pin.

This adds `.github/scripts/check-upstream-unblock.py` and a monthly `Upstream unblock watch` workflow.

## Live verification (2026-07-26)

Re-checked against the npm registry before writing any code — **both criteria are still unmet**, so this PR contains no version bump:

| criterion | live value | admits? |
|---|---|---|
| `eslint-plugin-react@7.37.5` peer `eslint` | `^3 \|\| ^4 \|\| ^5 \|\| ^6 \|\| ^7 \|\| ^8 \|\| ^9.7` | no `^10` |
| `@typescript-eslint/parser@8.65.0` peer `typescript` | `>=4.8.4 <6.1.0` | excludes 7.x |

## What the gate does

1. **Liveness** (monthly + `workflow_dispatch`) — re-derives each criterion from the registry. When a block goes stale it comments on the issue and drops the `blocked` label. A red scheduled run on a schedule is addressed to nobody, so the *state change* is the notification, not the workflow conclusion.
2. **Drift, both directions** (on any PR touching either file) — every npm `ignore:` entry must be declared in the script's `WATCHES` table and vice versa. This is the repo's derived-scope rule: an ignore entry added without a watch would otherwise be a block this gate silently reports nothing about, *while passing green*. A blocker that lives in this repo (tailwindcss v4, #1653) is declared with `upstream: None` rather than omitted — an omitted entry is a block nothing watches.

Because this PR touches `.github/dependabot.yml`, the new gate runs on this PR.

## Falsified before being trusted

Per the repo's unfalsified-gate rule, every path was fed an input it MUST flag and the **printed output** was read, not just the exit code:

- undeclared `ignore:` entry → `::error` drift, exit 1 ✅
- criterion genuinely satisfied (probed eslint `9.7.0`, which the live range *does* admit) → `UNBLOCKED`, exit 1 ✅
- peer key absent upstream → **exit 2**, explicitly *not* a "still blocked" verdict ✅

That last separation is deliberate. A probe that could not run has no verdict; reporting its silence as evidence of absence is exactly the failure mode this repo keeps paying for. The range matcher also self-tests against 12 known-positive/known-negative cases as its own workflow step — a matcher that has only ever returned "still blocked" is indistinguishable from one that always does.

## Not done here

No `rules.yaml` entry: editing it restamps all ~65 OPA bundles for a workflow-local gate, and this is not a fleet invariant. The gate is enforced (fails the PR), not advisory, so `check-advisory-gate-registration.py` requires no registration — verified locally, still passes.

## Linked issues

Refs #1314