### PR TITLE
fix(ci): make the heap sampler's ceiling the real -Xmx, and stop it contradicting the runner-memory warning

### DIFF
--- a/.github/scripts/gradle-heap-headroom.sh
+++ b/.github/scripts/gradle-heap-headroom.sh
@@ -60,36 +60,61 @@ sample_once() {
 
     info="$(jcmd "$pid" GC.heap_info 2>/dev/null)" || continue
 
-    # Sum "used" across the heap regions the collector reports, and take the ceiling from
-    # "reserved"/"capacity" depending on collector. Values arrive as e.g. "used 1234M" or
-    # "used 1234567K".
-    used_kb="$(printf '%s\n' "$info" | grep -oE 'used [0-9]+[KMG]?' \
+    # Heap USED. Only the collector's heap line — `GC.heap_info` also prints "Metaspace
+    # used ..." and "class space used ...", and summing those in inflated every figure by
+    # roughly a gigabyte per JVM. Metaspace is not heap and is not bounded by -Xmx, so
+    # counting it against -Xmx compared two different things (#2330).
+    used_kb="$(printf '%s\n' "$info" \
+      | grep -vE '^[[:space:]]*(Metaspace|class space)' \
+      | grep -oE 'used [0-9]+[KMG]?' \
       | awk '{v=$2; u=substr(v,length(v)); n=v+0;
               if (u=="G") n*=1048576; else if (u=="M") n*=1024;
               s+=n} END {if (NR>0) printf "%d", s}')"
-    max_kb="$(printf '%s\n' "$info" | grep -oE '(reserved|total reserved|capacity) [0-9]+[KMG]?' \
-      | awk '{v=$NF; u=substr(v,length(v)); n=v+0;
-              if (u=="G") n*=1048576; else if (u=="M") n*=1024;
-              if (n>m) m=n} END {if (NR>0) printf "%d", m}')"
+
+    # Heap CEILING — read the effective -Xmx from VM.flags, never from GC.heap_info.
+    #
+    # This is the whole point of the fix. `GC.heap_info`'s "reserved"/"capacity" is the
+    # collector's current region bookkeeping, NOT the max heap, and on a JVM launched with
+    # `-Xmx6g` the old parse reported a 1344 MiB "ceiling" and therefore "454% of its
+    # configured -Xmx" — a figure that is arithmetically impossible for a real heap
+    # ceiling, since a JVM that exceeded its max heap would have thrown OutOfMemoryError
+    # rather than finished. `-XX:MaxHeapSize` is unambiguous, always present, and always
+    # exactly the effective -Xmx, in bytes.
+    max_kb="$(jcmd "$pid" VM.flags 2>/dev/null | tr ' ' '\n' \
+      | awk -F= '/^-XX:MaxHeapSize=/ {printf "%d", $2/1024; exit}')"
 
     # No parse => say so. Never substitute 0, which would read as "used nothing".
     [ -n "$used_kb" ] || continue
 
     name="$(printf '%s' "$rest" | awk '{print $1}' | sed 's|.*[./]||')"
-    printf '%s\t%s\t%s\t%s\n' "$pid" "${name:-jvm}" "$((used_kb / 1024))" "$(( ${max_kb:-0} / 1024 ))"
+    printf '%s\t%s\t%s\t%s\t%s\n' \
+      "$round" "$pid" "${name:-jvm}" "$((used_kb / 1024))" "$(( ${max_kb:-0} / 1024 ))"
   done >> "$samples"
 
+  # Available system RAM, in MiB. /proc/meminfo is the CI (Linux) path; vm_stat is the
+  # macOS fallback, and it exists purely so the memory-starved branch of the report can be
+  # exercised by hand on a developer machine. A warning path that can only be reached on a
+  # runner is a warning path nobody has ever read — which is how the contradictory advice
+  # below shipped in the first place.
   if [ -r /proc/meminfo ]; then
     awk '/^MemAvailable:/ {print int($2/1024)}' /proc/meminfo >> "$freefile"
+  elif command -v vm_stat >/dev/null 2>&1; then
+    vm_stat 2>/dev/null | awk '
+      /page size of/ { for (i=1;i<=NF;i++) if ($i+0 > 1024) { ps=$i+0; break } }
+      /^Pages free/ || /^Pages inactive/ { gsub(/\./,"",$NF); f += $NF }
+      END { if (ps > 0 && f > 0) print int(f*ps/1048576) }' >> "$freefile"
   fi
 }
 
 sampler_loop() {
+  round=0
   while :; do
+    round=$((round + 1))
     sample_once
     sleep "$SAMPLE_INTERVAL_SECONDS"
   done
 }
+round=0
 
 if command -v jcmd >/dev/null 2>&1; then
   sampler_loop &
@@ -104,6 +129,7 @@ fi
 rc=$?
 
 if [ -n "$sampler_pid" ]; then
+  round=999999           # distinct round id so this sample is its own concurrent snapshot
   sample_once            # one last sample before the JVMs are gone
   kill "$sampler_pid" 2>/dev/null || true
   wait "$sampler_pid" 2>/dev/null || true
@@ -123,16 +149,28 @@ if [ ! -s "$samples" ]; then
   } >> "$report"
   worst=-1
 else
-  # Max used per pid, carrying that pid's ceiling.
+  # Max used per pid, carrying that pid's ceiling. Fields: round pid name used max.
   reduced="$workdir/reduced.tsv"
-  sort -k1,1n "$samples" \
-    | awk -F'\t' '{ if ($3+0 > used[$1]) {used[$1]=$3+0; name[$1]=$2}
-                    if ($4+0 > max[$1]) max[$1]=$4+0 }
-                  END { for (p in used) printf "%s\t%s\t%d\t%d\n", p, name[p], used[p], max[p] }' \
-    | sort -k3,3nr > "$reduced"
+  awk -F'\t' '{ if ($4+0 > used[$2]) {used[$2]=$4+0; name[$2]=$3}
+                if ($5+0 > max[$2]) max[$2]=$5+0 }
+              END { for (p in used) printf "%s\t%s\t%d\t%d\n", p, name[p], used[p], max[p] }' \
+    "$samples" | sort -k3,3nr > "$reduced"
+
+  # PEAK CONCURRENT footprint: the largest per-round sum across all live JVMs.
+  #
+  # On a shared 16 GB runner this is the number that decides whether a worker can fork, and
+  # the per-JVM table cannot express it — that table is a peak-per-pid roll-up over the whole
+  # build, so ~40 rows of `GradleWorkerMain` are mostly JVMs that lived and died at different
+  # times, not 40 at once. Reading it as a concurrent total overstates the load; reading any
+  # single row as the load understates it. Neither is the quantity #2330 is about.
+  peak_concurrent="$(awk -F'\t' '{ s[$1] += $4+0; n[$1]++ }
+                                  END { for (r in s) if (s[r] > m) { m = s[r]; c = n[r] }
+                                        printf "%d %d", m, c }' "$samples")"
+  peak_total="${peak_concurrent%% *}"
+  peak_jvms="${peak_concurrent##* }"
 
   {
-    echo "| JVM | peak heap used | ceiling | used |"
+    echo "| JVM | peak heap used | -Xmx | used |"
     echo "|---|---:|---:|---:|"
     awk -F'\t' '{
       if ($4 > 0) { pct = sprintf("%.0f%%", 100*$3/$4); ceil = $4 " MiB" }
@@ -140,26 +178,47 @@ else
       printf "| `%s` (pid %s) | %s MiB | %s | %s |\n", $2, $1, $3, ceil, pct
     }' "$reduced"
     echo
+    echo "Peak **concurrent** heap across all live JVMs: **${peak_total} MiB** (${peak_jvms} JVMs in that sample)."
+    echo
+    echo "_Rows are peak-per-JVM over the whole build, so they do not sum to a concurrent"
+    echo "total — most of those JVMs never existed at the same moment. Use the concurrent"
+    echo "figure above and the system-memory floor below to judge runner pressure._"
   } >> "$report"
 
   worst="$(awk -F'\t' 'BEGIN{w=-1} $4>0 { p = 100*$3/$4; if (p>w) w=p } END{printf "%d", (w<0 ? -1 : int(w+0.5))}' "$reduced")"
 
   if [ -s "$freefile" ]; then
     min_free="$(sort -n "$freefile" | head -1)"
+    echo >> "$report"
     echo "Lowest available system memory during the build: **${min_free} MiB**." >> "$report"
     if [ "$min_free" -lt "$MIN_FREE_MB" ]; then
+      memory_starved=1
       echo "::warning title=CI runner nearly out of memory::\`$label\` ran with only ${min_free} MiB of available system RAM at its lowest point (floor ${MIN_FREE_MB} MiB). At this level the kernel starts reclaiming, Gradle worker processes fail to start, and the runner can be killed outright — which GitHub reports as a *cancelled* job with no failing step, not as a failure. See #2330."
     fi
   fi
 fi
 
 if [ "$worst" -ge "$WARN_AT_PERCENT" ]; then
-  echo "::warning title=Gradle heap headroom low::\`$label\` peaked at ${worst}% of its configured -Xmx (warn at ${WARN_AT_PERCENT}%). This build did not OOM, but the next fleet growth may. Raise -Xmx in this workflow's GRADLE_OPTS before it goes red, not after. See #2177."
-  echo >> "$report"
-  echo "> :warning: Peaked at **${worst}%** of the configured ceiling — above the ${WARN_AT_PERCENT}% warning line." >> "$report"
+  # "Raise -Xmx" is only sound advice when the MACHINE has memory to give. If the runner
+  # already bottomed out below MIN_FREE_MB, a bigger heap makes the fork failures worse,
+  # not better — and the two warnings would otherwise print adjacent, opposite
+  # instructions. The first real run of this script on the CodeQL job did exactly that:
+  # "only 499 MiB of available system RAM" immediately followed by "raise -Xmx". Advice
+  # that contradicts itself is worse than none, because someone acts on one half.
+  if [ "${memory_starved:-0}" = "1" ]; then
+    echo "::warning title=Gradle heap pressure on a full runner::\`$label\` peaked at ${worst}% of its configured -Xmx AND the runner bottomed out at ${min_free:-?} MiB of available RAM. Do NOT raise -Xmx here — the machine has nothing to give, and a larger heap makes the worker-fork failures worse. Reduce the concurrent footprint instead (fewer parallel workers, a smaller Kotlin daemon heap, or less work per job). See #2330."
+    echo >> "$report"
+    echo "> :warning: Peaked at **${worst}%** of -Xmx **while the runner was memory-starved**" >> "$report"
+    echo "> (${min_free:-?} MiB free at the floor). This is a *reduce the footprint* signal," >> "$report"
+    echo "> not a *raise -Xmx* one." >> "$report"
+  else
+    echo "::warning title=Gradle heap headroom low::\`$label\` peaked at ${worst}% of its configured -Xmx (warn at ${WARN_AT_PERCENT}%). This build did not OOM, but the next fleet growth may. Raise -Xmx in this workflow's GRADLE_OPTS before it goes red, not after. See #2177."
+    echo >> "$report"
+    echo "> :warning: Peaked at **${worst}%** of -Xmx — above the ${WARN_AT_PERCENT}% warning line." >> "$report"
+  fi
 elif [ "$worst" -ge 0 ]; then
   echo >> "$report"
-  echo "Peak was **${worst}%** of the configured ceiling (warning line ${WARN_AT_PERCENT}%)." >> "$report"
+  echo "Peak was **${worst}%** of -Xmx (warning line ${WARN_AT_PERCENT}%)." >> "$report"
 fi
 
 cat "$report"

--- a/.github/scripts/gradle-heap-headroom.sh
+++ b/.github/scripts/gradle-heap-headroom.sh
@@ -46,6 +46,8 @@ workdir="$(mktemp -d)" || workdir=""
 [ -n "$workdir" ] && [ -d "$workdir" ] || { echo "gradle-heap-headroom: cannot create a temp dir" >&2; exit 2; }
 samples="$workdir/samples.tsv"   # pid <TAB> name <TAB> used_mb <TAB> max_mb
 freefile="$workdir/free.txt"
+xmxdir="$workdir/xmx"          # one file per pid, caching that JVM's fixed -Xmx
+mkdir -p "$xmxdir"
 : > "$samples"
 : > "$freefile"
 
@@ -80,8 +82,17 @@ sample_once() {
     # ceiling, since a JVM that exceeded its max heap would have thrown OutOfMemoryError
     # rather than finished. `-XX:MaxHeapSize` is unambiguous, always present, and always
     # exactly the effective -Xmx, in bytes.
-    max_kb="$(jcmd "$pid" VM.flags 2>/dev/null | tr ' ' '\n' \
-      | awk -F= '/^-XX:MaxHeapSize=/ {printf "%d", $2/1024; exit}')"
+    # Cached per pid: -Xmx is fixed for a JVM's lifetime, and `jcmd` is not free — it
+    # attaches to the target over a socket. Re-asking every JVM every five seconds would
+    # add load to the very job whose memory pressure this script exists to measure, which
+    # would be a self-defeating way to instrument it.
+    if [ -s "$xmxdir/$pid" ]; then
+      max_kb="$(cat "$xmxdir/$pid")"
+    else
+      max_kb="$(jcmd "$pid" VM.flags 2>/dev/null | tr ' ' '\n' \
+        | awk -F= '/^-XX:MaxHeapSize=/ {printf "%d", $2/1024; exit}')"
+      [ -n "$max_kb" ] && printf '%s' "$max_kb" > "$xmxdir/$pid"
+    fi
 
     # No parse => say so. Never substitute 0, which would read as "used nothing".
     [ -n "$used_kb" ] || continue


### PR DESCRIPTION
## The finding

#2500 (merged today) wired `gradle-heap-headroom.sh` into the CodeQL `java-kotlin` job — the job #2330 is about — so `-Xmx` would stop being a ratchet discovered by going red. I went to use its output to size a fix for #2330. **The instrument is misreporting, and its advice points the wrong way.**

Verbatim from run [30198139819](https://github.com/JiRaska/open-bank-oss/actions/runs/30198139819), job `89783296232`, two adjacent lines:

```
##[warning] ran with only 499 MiB of available system RAM at its lowest point
          (floor 512 MiB) ... See #2330.
##[warning] peaked at 454% of its configured -Xmx ... Raise -Xmx in this
          workflow's GRADLE_OPTS before it goes red, not after.
```

The runner is out of memory; the next line says give a JVM more of it. Acting on the second makes #2330's `Unable to connect to the child process 'Gradle Worker Daemon 80' ... build machine is extremely loaded` **worse**.

And `454%` is not a real number: a heap cannot exceed its own ceiling — a JVM that did would have thrown `OutOfMemoryError` rather than finishing the build.

## What this changes (instrument only — no build behaviour)

1. **Ceiling = `-XX:MaxHeapSize` from `jcmd VM.flags`**, not `GC.heap_info`'s `reserved`/`capacity`, which is the collector's current region bookkeeping rather than the max heap. That is how a JVM under `-Xmx6g` got a reported ceiling of 1344 MiB.
2. **`used` no longer sums the `Metaspace` / `class space` lines** `GC.heap_info` also prints. Metaspace is not heap and is not bounded by `-Xmx`; counting it put two different quantities in the numerator and denominator.
3. **"Raise `-Xmx`" is gated on the machine having memory to give.** Below `MIN_FREE_MB` the warning instead says reduce the concurrent footprint, and says why.

Plus the number #2330 actually needs and the table could not express: **peak concurrent heap** (max per-sample sum across live JVMs), with an explicit note that the per-JVM rows are a peak-per-pid roll-up over the whole build — the ~40 `GradleWorkerMain` rows are mostly JVMs that lived and died at different times, so reading the table as a snapshot overstates the load while reading one row understates it.

## Falsified, not assumed

| check | result |
|---|---|
| JVM launched `-Xmx512m` | reports **512 MiB**, 88% — sub-100%, where the old path gave 454% in CI |
| real Gradle daemon at `-Xmx3g` | reports **3072 MiB** |
| memory-starved branch | **executed**, printed text read — emits *"Do NOT raise -Xmx here"* |
| exit-code passthrough | `exit 7` → `rc=7`; still never changes a build's verdict |

The starved branch was unreachable on a developer machine (no `/proc/meminfo`), so a `vm_stat` fallback was added to make it exercisable. **A warning path only reachable on a runner is one nobody has ever read — which is precisely how the contradictory advice shipped.**

## Deliberately NOT changed

`maxRunners` (option 1 was already tried and reverted), the CodeQL build scope, `-Xmx6g`, `--max-workers`. The measurement does say the runner is memory-starved — but the instrument producing it was misreporting, so **no footprint change should be justified by this data until the corrected numbers land**. Acting on an unmeasured guess is what #2039 already cost. Analysis posted on #2330.

One further note for #2330: a large share of the `cancelled` CodeQL runs today are this workflow's own `concurrency.cancel-in-progress` superseding runs on rapid-fire main pushes — not livelock. The genuine signal is the 499 MiB floor and the worker-fork timeout.

## Linked issues

Refs #2330, Refs #2039, Refs #2177