### PR TITLE
docs(adr): correct ADR-0006 — the schema registry is deployed, and the format choice is still undecided

### DIFF
--- a/docs/adr/0006-asyncapi-for-kafka-topics.md
+++ b/docs/adr/0006-asyncapi-for-kafka-topics.md
@@ -12,11 +12,31 @@ summary: "Every Kafka topic is documented in AsyncAPI 3.0 under openbank-contrac
 
 # 6. AsyncAPI 3.0 for all Kafka topics
 
-**Delivery note (updated 2026-07-01):**
+**Delivery note (updated 2026-07-26):**
 - **CI linting gate** — ✅ Shipped: AsyncAPI specs linted in CI; missing or malformed specs block release.
 - **Per-service specs** (`openbank-contracts/<service>/asyncapi.yaml`) — ⬜ Pending: specs exist for documented topics; full fleet coverage is the outstanding work.
-- **Schema Registry** (Apicurio or Confluent, runtime enforcement) — ⬜ Pending: not yet deployed; consumer-driven contract tests (ADR-0063) provide schema compatibility checks in the interim.
+- **Schema Registry** (Apicurio or Confluent) — 🟡 Partial. **Deployed**, not yet enforcing.
+  Apicurio runs in-cluster (`openbank-infra/gitops/apps/apicurio.yaml` plus
+  `components/apicurio/{namespace,registry,postgres,network-policies}.yaml`), and
+  `openbank-analytics-sink` reads it via `ApicurioSchemaCatalogSource` (unit test + IT).
+  What is NOT delivered is the part this ADR actually decides: **runtime enforcement**.
+  No topic has a registered message schema — there are zero `.avsc` and zero registered
+  JSON Schemas fleet-wide — so no producer fails fast on a schema violation, and the
+  registry currently holds no contract to enforce. Compatibility is still signalled only
+  by `check-event-schema-compat.py` (a Kotlin constructor diff) and the ADR-0063
+  consumer-driven contract tests.
+  *(Corrected 2026-07-26: this line previously read "not yet deployed", which was false
+  and made the remaining work look larger and differently shaped than it is — the gap is
+  registration + enforcement, not provisioning.)*
 - **Consumer SDK generation** from specs — ⬜ Pending.
+
+**Open question, not yet decided by this ADR.** The Decision below says message schemas
+may be "Avro or JSON Schema" and deliberately does not pick one. Choosing between them —
+and choosing how an existing live topic migrates from hand-built JSON to a registered,
+enforced schema without breaking in-flight consumers on a rolling deploy — is a decision
+this ADR still owes, not an implementation detail. It should be settled here (or in a
+successor ADR) before the first schema is registered, because the first one registered
+sets the fleet pattern. Tracked in #1916.
 
 ## Context
 


### PR DESCRIPTION
## The correction

ADR-0006's delivery note claimed the Schema Registry was **"not yet deployed"**. That is false, and has been for some time:

- `openbank-infra/gitops/apps/apicurio.yaml` + `components/apicurio/{namespace,registry,postgres,network-policies}.yaml`
- `openbank-analytics-sink` already consumes it via `ApicurioSchemaCatalogSource` (unit test **and** IT)

This is not a cosmetic docs nit — **it mis-shapes the remaining work**. Read literally, the outstanding task was "provision a registry". The actual gap is that **no topic has a registered message schema** (zero `.avsc` *and* zero registered JSON Schemas fleet-wide), so no producer fails fast on a schema violation and the registry holds no contract to enforce. Provisioning is done; registration and enforcement are not. #1916's body inherited the same stale premise.

The line now reads 🟡 Partial — *deployed, not yet enforcing* — and says which half is missing.

## Why I did not ship a first schema

The obvious bounded slice ("one `.avsc` + wire one producer, as a pattern-setter") **is not actually bounded**, for two reasons that both sit above the code:

1. **The ADR never picks a format.** Its Decision permits *"Avro or JSON Schema"* and leaves it open. #1916's title assumes Avro; the ADR does not. Whichever schema is registered first sets the fleet pattern.
2. **Migrating a live topic is a rolling-deploy compatibility exercise**, on money-path events, from hand-built JSON to a registered enforced schema — not an implementation detail.

`BACKWARD` compatibility itself *is* already decided by the ADR ("backward-compatible by default; breaking changes require a `*-v2-events-out` topic and parallel running"), so that part needs no new decision. The format choice and the migration mechanics do.

So this PR records the open question in the ADR rather than pre-empting it in a PR that happens to touch one topic. That decision is the owner's.

## Verification

- `delivery-status: partial` unchanged — correct both before and after.
- Derived artefacts (`README.md` / `DIGEST.md` / `index.json`) regenerated via `docs/adr/gen-index.sh`; **unchanged**, since the `summary` front matter was not touched.
- `check-adr-registry.sh`: `OK — 201 ADRs: unique numbers, headings match filenames, front-matter valid, supersession bidirectional, derived artefacts fresh.`

## Linked issues

Refs #1916