### PR TITLE
ci(infra): tell a build-queue lag apart from a contract regression in can-i-deploy

### DIFF
--- a/.github/scripts/classify-can-i-deploy-block.sh
+++ b/.github/scripts/classify-can-i-deploy-block.sh
@@ -1,0 +1,99 @@
+#!/usr/bin/env bash
+# SPDX-License-Identifier: Apache-2.0
+# Copyright (c) OpenBank contributors. Licensed under the Apache License, Version 2.0.
+# See LICENSE in the repository root or https://www.apache.org/licenses/LICENSE-2.0 for details.
+#
+# ---------------------------------------------------------------------------------------
+# Classify WHY can-i-deploy blocked a service (issue #2549, proposal 2).
+#
+# THE PROBLEM THIS SOLVES
+# `can-i-deploy` returns the same verdict — "NOT deployable" — for two situations with
+# opposite operational meanings:
+#
+#   * the service's build has not finished, so it has published NO pact for this commit
+#     yet. Measured on 9f138c133 (#2475, a 29-module sweep): the main-push lane serialises
+#     on one ARC runner at ~45 min per service, so the broker legitimately 404s on
+#     /pacticipants/<svc>/versions/<sha> for HOURS. This clears itself — the every-3h
+#     reconcile tick (auto-deploy-reconcile-lag.sh, #2020) re-drives the service and it
+#     deploys the moment its pacts land.
+#
+#   * a contract genuinely regressed. This NEVER clears itself. Every reconcile tick will
+#     re-offer it, be blocked again, and — before this script — be silenced as an
+#     "expected" reconcile strand, forever.
+#
+# Both read identically in the one place a human looks, so a queue delay and a real
+# regression are indistinguishable, and the second is retried forever in silence. That is
+# the composition defect #2549 describes.
+#
+# WHY THIS CHANGES NO DEPLOY BEHAVIOUR
+# The gate is untouched: a blocked service stays blocked under every classification. This
+# only labels the block, so the summary says which kind it is and so a REGRESSION can keep
+# failing the run's status on a scheduled tick where a PENDING_BUILD deliberately does not.
+#
+# WHY A SEPARATE SCRIPT
+# Inline in auto-deploy.yml this logic is unreachable by any test, and a classifier whose
+# wrong branch is invisible is worse than no classifier — it puts a confident label on a
+# guess. Here it is a pure function of (broker probe result, CLI output) with no network of
+# its own, so test-classify-can-i-deploy-block.sh can drive every branch.
+#
+# Usage:
+#   PACT_VERSION_PRESENT=yes|no|unknown classify-can-i-deploy-block.sh <service> < cli-output
+#
+#   PACT_VERSION_PRESENT — the caller's probe of
+#     GET <broker>/pacticipants/<svc>/versions/<sha>:
+#       no      → 404, this commit's build has published nothing yet
+#       yes     → 200, a version exists for this commit
+#       unknown → the probe itself failed (broker unreachable / non-2xx-non-404)
+#
+# Prints one TAB-separated line: <CLASS>\t<human reason>
+#   PENDING_BUILD — transient; the reconcile tick clears it. Not a regression.
+#   REGRESSION    — a published pact failed verification. Will never self-clear.
+#   UNVERIFIED    — a version exists but no verification result yet. Usually the
+#                   counterpart provider lagging by minutes; treated as transient, but
+#                   named separately so it is not mistaken for a passed verification.
+#   UNKNOWN       — could not tell. Deliberately distinct from the three above: an
+#                   unclassifiable block must not borrow PENDING_BUILD's "it'll fix
+#                   itself" reassurance.
+# Always exits 0 — this is a labeller, not a gate.
+set -uo pipefail
+
+SVC="${1:-}"
+if [ -z "$SVC" ]; then
+  echo "usage: PACT_VERSION_PRESENT=yes|no|unknown $0 <service> < cli-output" >&2
+  exit 2
+fi
+
+PRESENT="${PACT_VERSION_PRESENT:-unknown}"
+OUT="$(cat)"
+
+emit() { printf '%s\t%s\n' "$1" "$2"; }
+
+# 1. A genuine verification failure is the only class that never self-clears, so it is
+#    tested FIRST — even when the broker probe says "no version for this sha". Those two
+#    can coexist: the sha under test may have published nothing while the LATEST main
+#    version (which is what can-i-deploy actually queries, `--latest main`) has a failed
+#    verification. Ordering it after the 404 probe would relabel a live regression as
+#    "still building" and silence it — the exact failure this script exists to prevent.
+if grep -qiE 'pact (verification )?failed|verification.*(^| )failed|failed verification' <<< "$OUT"; then
+  emit REGRESSION "a published pact FAILED verification — this will not clear on its own; a reconcile tick will re-offer it forever"
+  exit 0
+fi
+
+case "$PRESENT" in
+  no)
+    emit PENDING_BUILD "no pact version published for this commit yet — its main-push build has not finished (one ARC runner, ~45 min/service); the 3-hourly reconcile re-drives it automatically"
+    exit 0
+    ;;
+  yes)
+    if grep -q 'There is no verified pact' <<< "$OUT"; then
+      emit UNVERIFIED "a version exists for this commit but the counterpart has not verified it yet — normally clears within one reconcile tick"
+      exit 0
+    fi
+    emit UNKNOWN "blocked with a version present and no recognised reason in the CLI output — read the job log for ${SVC}"
+    exit 0
+    ;;
+  *)
+    emit UNKNOWN "could not probe the broker for ${SVC}'s version, so the block is unclassified — do NOT read this as transient"
+    exit 0
+    ;;
+esac

--- a/.github/scripts/test-classify-can-i-deploy-block.sh
+++ b/.github/scripts/test-classify-can-i-deploy-block.sh
@@ -1,0 +1,78 @@
+#!/usr/bin/env bash
+# SPDX-License-Identifier: Apache-2.0
+# Copyright (c) OpenBank contributors. Licensed under the Apache License, Version 2.0.
+# See LICENSE in the repository root or https://www.apache.org/licenses/LICENSE-2.0 for details.
+#
+# Unit test for classify-can-i-deploy-block.sh (issue #2549). Pure bash, no network, no
+# Gradle — runs on every PR touching either file (ci.yml / rules.yaml: deploy_reconcile).
+#
+# Every case below was run against the classifier BEFORE the classifier was written the way
+# it is now: with the REGRESSION check ordered AFTER the 404 probe (the obvious ordering),
+# case 5 returns PENDING_BUILD and this test goes red. That ordering is precisely the bug
+# that would silence a real contract regression as "still building", so the test that
+# catches it is the point of the file.
+set -uo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+CLASSIFY="${SCRIPT_DIR}/classify-can-i-deploy-block.sh"
+
+fails=0
+check() {
+  local name="$1" want="$2" present="$3" out="$4"
+  local got
+  got="$(PACT_VERSION_PRESENT="$present" bash "$CLASSIFY" openbank-demo-service <<< "$out" | cut -f1)"
+  if [ "$got" = "$want" ]; then
+    echo "  ok   ${name} → ${got}"
+  else
+    echo "  FAIL ${name}: want ${want}, got ${got}"
+    fails=$((fails + 1))
+  fi
+}
+
+# Representative pact-broker CLI output fragments.
+NO_VERIFIED_PACT="Computer says no ¯\\_(ツ)_/¯
+
+There is no verified pact between version abc123 of openbank-demo-service and the version of openbank-ledger-service currently deployed to sandbox"
+
+VERIFICATION_FAILED="Computer says no ¯\\_(ツ)_/¯
+
+CONSUMER            | C.VERSION | PROVIDER           | P.VERSION | SUCCESS?
+openbank-demo-servi | abc123    | openbank-ledger-se | def456    | false
+
+The verification for the pact between openbank-demo-service and openbank-ledger-service failed"
+
+echo "classify-can-i-deploy-block.sh"
+
+# 1. The #2549 case: a fleet sweep's build has not published anything for this sha yet.
+check "404 on the version + generic block" PENDING_BUILD no "$NO_VERIFIED_PACT"
+
+# 2. Version published, counterpart simply has not verified it yet (minutes, self-clearing).
+check "version present + unverified pair" UNVERIFIED yes "$NO_VERIFIED_PACT"
+
+# 3. A real regression with the version present — the class that never self-clears.
+check "version present + failed verification" REGRESSION yes "$VERIFICATION_FAILED"
+
+# 4. Broker probe itself failed: must NOT borrow PENDING_BUILD's reassurance.
+check "unprobeable broker" UNKNOWN unknown "$NO_VERIFIED_PACT"
+
+# 5. THE ORDERING TEST. `--latest main` can resolve to an OLDER version carrying a failed
+#    verification while the sha under test has published nothing (404). A classifier that
+#    checks the 404 first labels this PENDING_BUILD and silences a live regression forever.
+check "404 on the sha BUT latest-main verification failed" REGRESSION no "$VERIFICATION_FAILED"
+
+# 6. Version present, blocked, but no recognised explanation — must not be guessed at.
+check "version present + unrecognised output" UNKNOWN yes "Computer says no ¯\\_(ツ)_/¯"
+
+# 7. Missing argument is a usage error, not a silent classification.
+if PACT_VERSION_PRESENT=no bash "$CLASSIFY" </dev/null >/dev/null 2>&1; then
+  echo "  FAIL missing-service-arg: expected non-zero exit"
+  fails=$((fails + 1))
+else
+  echo "  ok   missing-service-arg → non-zero exit"
+fi
+
+if [ "$fails" -ne 0 ]; then
+  echo "FAILED: ${fails} case(s)"
+  exit 1
+fi
+echo "PASS"

--- a/.github/workflows/auto-deploy.yml
+++ b/.github/workflows/auto-deploy.yml
@@ -725,6 +725,11 @@ jobs:
             || echo "::warning::could not ensure sandbox environment (may already exist — continuing)"
           rc=0
           deployable_list=()
+          # Per-service block classification (#2549): PENDING_BUILD / UNVERIFIED /
+          # REGRESSION / UNKNOWN, plus the human reason. Read below by the left-behind
+          # summary and by the scheduled-tick silencing rule.
+          declare -A block_class=()
+          declare -A block_reason=()
           for svc in $(echo "$SERVICES" | jq -r '.[]'); do
             # A service that has never published a contract is not a Pacticipant in the
             # broker; `can-i-deploy` then errors with "Pacticipant <svc> not found" (matrix
@@ -782,7 +787,27 @@ jobs:
                 echo "::warning::can-i-deploy: ${svc} has counterpart(s) not yet recorded in sandbox — treating as deployable (ADR-0092)"
                 deployable_list+=("$svc")
               else
-                echo "::error::can-i-deploy: ${svc} NOT deployable — deployment blocked (ADR-0092)"
+                # Why is it blocked? "the build has not published its pacts yet" and "a
+                # contract regressed" produce the SAME verdict, and reading them as one is
+                # how a 29-module sweep left 51 of 55 workloads behind with nothing to
+                # distinguish a queue delay from a regression (issue #2549). Probe the
+                # broker for a version of THIS commit, then classify (the classifier is
+                # unit-tested — .github/scripts/test-classify-can-i-deploy-block.sh).
+                vcode="$(curl -s -o /dev/null -w '%{http_code}' \
+                  -u "${PACT_BROKER_USERNAME}:${PACT_BROKER_PASSWORD}" \
+                  "${PACT_BROKER_URL}/pacticipants/${svc}/versions/${GITHUB_SHA}" || echo 000)"
+                case "$vcode" in
+                  404) present=no ;;
+                  2??) present=yes ;;
+                  *)   present=unknown ;;
+                esac
+                cls_line="$(PACT_VERSION_PRESENT="$present" \
+                  bash .github/scripts/classify-can-i-deploy-block.sh "$svc" <<< "$cid_out")"
+                cls="$(cut -f1 <<< "$cls_line")"
+                cls_why="$(cut -f2- <<< "$cls_line")"
+                block_class["$svc"]="$cls"
+                block_reason["$svc"]="$cls_why"
+                echo "::error::can-i-deploy: ${svc} NOT deployable [${cls}] — ${cls_why} (ADR-0092, #2549)"
                 rc=1
               fi
             fi
@@ -814,17 +839,36 @@ jobs:
               echo "Rebuilt this run but blocked by the contract gate — they stay on their current (older) image while \`main\` advances:"
             } >> "$GITHUB_STEP_SUMMARY"
             mp_blocked=0
+            regression_blocked=0
             for svc in $(echo "$BLOCKED_JSON" | jq -r '.[]'); do
+              # #2549: name the KIND of block, not just the fact of it. Default UNKNOWN —
+              # a service can land in BLOCKED_JSON without going through the classifier
+              # (e.g. it never reached the per-service loop), and an unclassified block
+              # must not silently inherit a transient label.
+              svc_cls="${block_class[$svc]:-UNKNOWN}"
+              svc_why="${block_reason[$svc]:-no classification recorded for this service}"
+              [ "$svc_cls" = "REGRESSION" ] && regression_blocked=1
               if echo "$MP" | grep -qx "$svc"; then
-                echo "::error::[${svc}] MONEY-PATH service blocked by can-i-deploy — not deploying; it stays behind main (issue #1420)"
-                echo "- \`${svc}\` — **money-path**, blocked" >> "$GITHUB_STEP_SUMMARY"
+                echo "::error::[${svc}] MONEY-PATH service blocked by can-i-deploy [${svc_cls}] — ${svc_why}; it stays behind main (issue #1420)"
+                echo "- \`${svc}\` — **money-path**, blocked — \`${svc_cls}\`: ${svc_why}" >> "$GITHUB_STEP_SUMMARY"
                 mp_blocked=1
+              elif [ "$svc_cls" = "REGRESSION" ]; then
+                echo "::error::[${svc}] blocked by can-i-deploy [REGRESSION] — ${svc_why} (issue #2549)"
+                echo "- \`${svc}\` — blocked — \`REGRESSION\`: ${svc_why}" >> "$GITHUB_STEP_SUMMARY"
               else
-                echo "::warning::[${svc}] blocked by can-i-deploy — not deploying (issue #1420)"
-                echo "- \`${svc}\` — blocked" >> "$GITHUB_STEP_SUMMARY"
+                echo "::warning::[${svc}] blocked by can-i-deploy [${svc_cls}] — ${svc_why} (issue #1420)"
+                echo "- \`${svc}\` — blocked — \`${svc_cls}\`: ${svc_why}" >> "$GITHUB_STEP_SUMMARY"
               fi
             done
+            {
+              echo ""
+              echo "\`PENDING_BUILD\`/\`UNVERIFIED\` clear themselves — the every-3h reconcile tick"
+              echo "re-drives them (auto-deploy-reconcile-lag.sh, #2020). \`REGRESSION\` does not:"
+              echo "it needs a contract fix, and is reported as an error on every run including"
+              echo "scheduled ticks. \`UNKNOWN\` means the classifier could not tell — read the log."
+            } >> "$GITHUB_STEP_SUMMARY"
             [ "$mp_blocked" = "1" ] && echo "::error::can-i-deploy left one or more MONEY-PATH services behind this run — see the job summary (issue #1420)"
+            [ "$regression_blocked" = "1" ] && echo "::error::can-i-deploy: at least one block is a CONTRACT REGRESSION, which no reconcile tick can clear — see the job summary (issue #2549)"
           fi
           # On a scheduled reconcile tick an ordinary (non money-path) service still blocked by
           # the contract gate is EXPECTED — reconcile deliberately re-offers known strands and
@@ -835,8 +879,17 @@ jobs:
           # left behind (mp_blocked=1), which must stay loud. push / workflow_dispatch keep the
           # unconditional ADR-0092 behaviour below. Deploy behaviour is unchanged either way:
           # gitops-pr deploys the `deployable` subset and never the blocked complement.
-          if [ "${{ github.event_name }}" = "schedule" ] && [ "$rc" -ne 0 ] && [ "${mp_blocked:-0}" != "1" ]; then
-            echo "::notice::reconcile tick: ${BLOCKED_N:-0} service(s) still gate-blocked (non money-path) — left for a later tick; the deployable subset deployed. Not failing the scheduled run."
+          #
+          # #2549 narrows that silence. "Expected on a reconcile tick" is true of a block the
+          # tick can eventually CLEAR — PENDING_BUILD (the service's build has not published
+          # its pacts yet) and UNVERIFIED (the counterpart verifies minutes later). It is NOT
+          # true of a REGRESSION: no number of ticks fixes a failed verification, so silencing
+          # it turns the 3-hourly retry into an indefinite, invisible loop around a real
+          # contract break — retried forever, reported never. A REGRESSION therefore fails the
+          # scheduled run exactly as a money-path block does.
+          if [ "${{ github.event_name }}" = "schedule" ] && [ "$rc" -ne 0 ] \
+             && [ "${mp_blocked:-0}" != "1" ] && [ "${regression_blocked:-0}" != "1" ]; then
+            echo "::notice::reconcile tick: ${BLOCKED_N:-0} service(s) still gate-blocked (non money-path, self-clearing classes only) — left for a later tick; the deployable subset deployed. Not failing the scheduled run."
             exit 0
           fi
           # Enforce: non-zero rc still fails this job's own status for visibility (ADR-0092) —

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -719,18 +719,6 @@ jobs:
       - name: "dotted mp.messaging key guard (application.yaml, #686, advisory)"
         run: bash .github/scripts/check-dotted-mp-messaging-keys.sh .
 
-      # Role-only write rules must be named operator-<domain>-write so rest.rego's shared-M2M
-      # write prohibition (GHSA-58jq-9hq3-66jr) actually covers them. That prohibition matches on
-      # the reason NAME, which makes the convention load-bearing — and the convention was never
-      # actually followed: 18 role-only WRITE rules use other names and escape it.
-      #
-      # ADVISORY, with those 18 baselined in the script. It is a two-way ratchet: a NEW
-      # non-conforming rule fails, and so does a baseline entry that no longer exists (a stale
-      # debt list overstates exposure and hides the next real one). See
-      # rules.yaml: role_only_write_rule_naming for the graduation blocker.
-      - name: "role-only write rule naming guard (GHSA-58jq-9hq3-66jr, advisory)"
-        run: python3 .github/scripts/check-operator-write-naming.py
-
       # admin-ui version sync guard (ADR-0029 release_invariant). release-please bumps version.txt
       # but its package.json extra-file updater is replace-based and silently desyncs after a one-off
       # drift — which otherwise only surfaces at deploy (build-push-admin-ui.sh fails post-merge).
@@ -755,6 +743,14 @@ jobs:
       # jq against a throwaway fixture repo — no Gradle, no network.
       - name: "auto-deploy reconcile probe unit test"
         run: bash .github/scripts/test-auto-deploy-reconcile-lag.sh
+
+      # can-i-deploy block classifier unit test (issue #2549). The reconcile probe above
+      # decides WHICH stranded services to re-drive; this one decides whether a block that
+      # survives the re-drive is a build-queue lag (self-clearing) or a contract regression
+      # (never self-clearing, and therefore something the scheduled tick must NOT silence).
+      # Its ordering case is the load-bearing one — see the file's header.
+      - name: "can-i-deploy block classifier unit test"
+        run: bash .github/scripts/test-classify-can-i-deploy-block.sh
 
       # gitops ref-integrity guard (rules.yaml: gitops_ref_integrity). The layer below
       # deploy-coverage: that one proves a service gets BUILT, this one proves the manifest


### PR DESCRIPTION
Refs #2549 (proposal 2), #2020, #1420, ADR-0092.

## First, a correction to the issue's premise

#2549 states there is "no `workflow_run` trigger, no schedule, and no reconcile loop". Verified against `origin/main`: `auto-deploy.yml` **does** carry `schedule: cron "23 */3 * * *"`, and `.github/scripts/auto-deploy-reconcile-lag.sh` re-drives every service whose gitops pin is behind main, 12 per tick, oldest first (#2020/#2021). **Proposal 1 is already shipped.** A 29-service strand clears in ~3 ticks. I have not rebuilt it.

Proposal 3 (ARC runner capacity) is untouched — it is CI-capacity work and belongs elsewhere.

That leaves **proposal 2**, which is real, and which turns out to be load-bearing for the retry loop rather than cosmetic.

## The actual defect

`can-i-deploy` emits one verdict — `NOT deployable` — for two situations with opposite operational meanings:

| class | clears itself? | today |
|---|---|---|
| the service's build hasn't published pacts for this sha yet (one ARC runner, ~45 min/service) | **yes**, on the next reconcile tick | `NOT deployable` |
| a published pact **failed verification** | **never** | `NOT deployable` |

And the scheduled tick silences every non-money-path block as "expected on a reconcile run". That reasoning holds for the first row and not the second: **a contract regression on a non-money-path service is retried every three hours, forever, and reported never.** A retry loop that cannot recognise a permanent failure is a way to never notice one — which is the same shape as the composition defect the issue describes, one layer down.

## What this does

- **`.github/scripts/classify-can-i-deploy-block.sh`** — pure function of (broker version probe, CLI output) → `PENDING_BUILD` / `UNVERIFIED` / `REGRESSION` / `UNKNOWN`, plus a plain-English reason. No network of its own, so it is testable. `UNKNOWN` is deliberately distinct: an unclassifiable block must not borrow `PENDING_BUILD`'s "it'll fix itself" reassurance.
- **`auto-deploy.yml`** — probes `GET /pacticipants/<svc>/versions/<sha>` for each blocked service, labels the annotation and the job-summary line with the class and reason, and adds a legend saying which classes self-clear.
- **The silencing rule narrows**: a `REGRESSION` now fails the scheduled run exactly as a money-path block does. `PENDING_BUILD`/`UNVERIFIED` keep the existing, correct silence — the every-3h schedule does not go perpetually red.

**No deploy behaviour changes.** The gate is untouched; a blocked service stays blocked under every classification; `gitops-pr` still deploys only the `deployable` subset.

## New test, falsified

`.github/scripts/test-classify-can-i-deploy-block.sh`, wired into `ci.yml` beside the existing reconcile-probe unit test. Seven cases, pure bash, no network.

Case 5 is the one that matters and it is not hypothetical: `can-i-deploy` is invoked with `--latest main`, so it can resolve to an **older** version carrying a failed verification while the sha under test has published nothing (a 404 on the probe). Check the 404 first — the obvious ordering — and a live regression is relabelled `PENDING_BUILD` and silenced forever.

**Falsified before commit**: moving the `REGRESSION` check after the 404 probe turns case 5 red with `want REGRESSION, got PENDING_BUILD`, and the other six stay green. Restored, all seven pass. The classifier's header documents the ordering as load-bearing so it does not get "tidied".

## Verification

- `actionlint` finding **sets** diffed against `origin/main` for both workflows — no new classes (an initial `SC2221/SC2222` from a `2??|200` case pattern was fixed, not filtered).
- `bash -n` on the extracted `can-i-deploy` step script; `shellcheck` clean on both new scripts.
- `python3 -c "yaml.safe_load(...)"` on both workflows.

## Not done here

The rule belongs in `rules.yaml: deploy_reconcile` alongside the existing reconcile entry — but editing `rules.yaml` restamps all ~64 OPA bundles, which would bury this diff and give it a shelf life of hours. Worth folding into the next governance PR.