### PR TITLE
fix(admin-ui): Customer 360 matched no accounts — wrong casing, wrong table

### DIFF
--- a/openbank-admin-ui/src/app/api/customer-360/[partyId]/route.ts
+++ b/openbank-admin-ui/src/app/api/customer-360/[partyId]/route.ts
@@ -83,17 +83,30 @@ async function chQuery(sql: string): Promise<Record<string, unknown>[]> {
  * transactions — which is why `customer-360.test.ts` asserts isolation, not just assembly.
  */
 function scopedRowsSql(partyId: string): string {
+  // `aggregate_type` is UPPERCASE in bronze (PARTY, ACCOUNT, ONBOARDING_FUNNEL — confirmed against
+  // the sandbox), so every comparison is folded with upper(). The first version compared against
+  // lowercase literals and silently matched nothing on the account arm: a filter that finds no rows
+  // is indistinguishable from a party that has no accounts, so nothing failed — it just showed
+  // less. Casing is normalised here and again when the rows are grouped.
+  //
+  // party_accounts reads bronze_events, NOT silver_current_state, and that is deliberate: silver
+  // keeps only the LATEST event per aggregate, and an account's latest event is typically
+  // BALANCE_UPDATED, whose payload has accountId but no partyId. Resolving ownership needs the
+  // event that carried it (account opened), which only the full history has.
   return `
     WITH party_accounts AS (
       SELECT DISTINCT aggregate_id
-      FROM ${DB}.silver_current_state
-      WHERE aggregate_type = 'account'
+      FROM ${DB}.bronze_events
+      WHERE upper(aggregate_type) = 'ACCOUNT'
         AND JSONExtractString(payload, 'partyId') = '${partyId}'
     )
     SELECT aggregate_type, aggregate_id, event_type, occurred_at, payload
     FROM ${DB}.silver_current_state
     WHERE JSONExtractString(payload, 'partyId') = '${partyId}'
-       OR (aggregate_type = 'transaction' AND aggregate_id IN (SELECT aggregate_id FROM party_accounts))
+       OR (upper(aggregate_type) = 'TRANSACTION'
+           AND aggregate_id IN (SELECT aggregate_id FROM party_accounts))
+       OR (upper(aggregate_type) = 'ACCOUNT'
+           AND aggregate_id IN (SELECT aggregate_id FROM party_accounts))
     ORDER BY occurred_at DESC
     LIMIT 5000
   `
@@ -132,7 +145,7 @@ export async function GET(_req: NextRequest, ctx: { params: Promise<{ partyId: s
     let asOf: string | null = null
 
     for (const r of rows) {
-      const type = String(r.aggregate_type ?? 'unknown')
+      const type = String(r.aggregate_type ?? 'unknown').toLowerCase()
       const occurredAt = String(r.occurred_at ?? '')
       const eventType = String(r.event_type ?? '')
 

--- a/openbank-admin-ui/src/test/customer-360.test.ts
+++ b/openbank-admin-ui/src/test/customer-360.test.ts
@@ -47,12 +47,19 @@ describe('Customer 360 isolation (ADR-0210 D2)', () => {
 
     // Direct arm: events that carry partyId.
     expect(sql).toContain(`JSONExtractString(payload, 'partyId') = '${PARTY}'`)
-    // Indirect arm: transactions, reached ONLY through this party's accounts.
+    // Indirect arm: transactions and accounts, reached ONLY through this party's accounts.
     expect(sql).toContain('party_accounts')
-    expect(sql).toMatch(/aggregate_type = 'transaction'\s+AND aggregate_id IN \(SELECT aggregate_id FROM party_accounts\)/)
+    expect(sql).toMatch(/upper\(aggregate_type\) = 'TRANSACTION'\s+AND aggregate_id IN \(SELECT aggregate_id FROM party_accounts\)/)
     // The party_accounts CTE must itself be party-scoped — an unscoped CTE is the leak.
     const cte = sql.slice(sql.indexOf('party_accounts AS'), sql.indexOf(')\n', sql.indexOf('party_accounts AS')))
     expect(cte).toContain(`JSONExtractString(payload, 'partyId') = '${PARTY}'`)
+    // Ownership must be resolved from bronze (full history), not silver: an account's LATEST event
+    // is typically BALANCE_UPDATED, which carries accountId but no partyId. Verified against the
+    // sandbox — silver holds no ACCOUNT row with a partyId at all.
+    expect(cte).toContain('bronze_events')
+    // Type comparisons must be case-folded: bronze stores PARTY/ACCOUNT uppercase, and comparing
+    // against lowercase literals matched nothing while looking like "this party has no accounts".
+    expect(sql).not.toMatch(/aggregate_type = '[a-z]+'/)
     // And no other party may appear anywhere in the statement.
     expect(sql).not.toContain(OTHER)
   })
@@ -71,10 +78,10 @@ describe('Customer 360 isolation (ADR-0210 D2)', () => {
 
   it('assembles domains, accounts and consents, and reports staleness', async () => {
     stubClickHouse([
-      { aggregate_type: 'party', aggregate_id: PARTY, event_type: 'PartyUpdated', occurred_at: '2026-07-20 10:00:00.000', payload: JSON.stringify({ partyId: PARTY, legalName: 'Alice' }) },
-      { aggregate_type: 'account', aggregate_id: 'acc-1', event_type: 'AccountOpened', occurred_at: '2026-07-19 10:00:00.000', payload: JSON.stringify({ partyId: PARTY }) },
-      { aggregate_type: 'consent', aggregate_id: 'c-1', event_type: 'ConsentGranted', occurred_at: '2026-07-18 10:00:00.000', payload: JSON.stringify({ partyId: PARTY, status: 'ACTIVE', scopes: ['MARKETING_COMMS_EMAIL'] }) },
-      { aggregate_type: 'transaction', aggregate_id: 'tx-1', event_type: 'TransactionCompleted', occurred_at: '2026-07-17 10:00:00.000', payload: JSON.stringify({ accountId: 'acc-1' }) },
+      { aggregate_type: 'PARTY', aggregate_id: PARTY, event_type: 'PartyUpdated', occurred_at: '2026-07-20 10:00:00.000', payload: JSON.stringify({ partyId: PARTY, legalName: 'Alice' }) },
+      { aggregate_type: 'ACCOUNT', aggregate_id: 'acc-1', event_type: 'AccountOpened', occurred_at: '2026-07-19 10:00:00.000', payload: JSON.stringify({ partyId: PARTY }) },
+      { aggregate_type: 'CONSENT', aggregate_id: 'c-1', event_type: 'ConsentGranted', occurred_at: '2026-07-18 10:00:00.000', payload: JSON.stringify({ partyId: PARTY, status: 'ACTIVE', scopes: ['MARKETING_COMMS_EMAIL'] }) },
+      { aggregate_type: 'TRANSACTION', aggregate_id: 'tx-1', event_type: 'TransactionCompleted', occurred_at: '2026-07-17 10:00:00.000', payload: JSON.stringify({ accountId: 'acc-1' }) },
     ])
     const { GET } = await import('@/app/api/customer-360/[partyId]/route')
     const res = await GET({} as never, { params: Promise.resolve({ partyId: PARTY }) })


### PR DESCRIPTION
## Summary
Found by querying the **sandbox ClickHouse** instead of trusting fixtures I had written myself. Two real defects in #2580, neither of which failed anything.

**1. `aggregate_type` is UPPERCASE in bronze** — `PARTY`, `ACCOUNT`, `ONBOARDING_FUNNEL` (confirmed against the sandbox). My SQL compared against lowercase literals, so the account and transaction arms matched nothing. **Nothing errored**: a filter that finds no rows is indistinguishable from a party that owns no accounts, so the page just showed less. Comparisons are now folded with `upper()`, and row grouping lowercases the type so either spelling resolves.

**2. The account→party CTE read `silver_current_state`, which cannot answer the question.** Silver keeps only the **latest** event per aggregate, and an account's latest event is typically `BALANCE_UPDATED` — `accountId`, no `partyId`. Ownership lives on the event that carried it, so the CTE now reads `bronze_events` (full history).

## Why my tests didn't catch either
Their fixtures used the lowercase spelling **I had invented**, and put a `partyId` on the account row that a real account event at its latest version does not carry. Same mistake this session has hit repeatedly in other forms: asserting against a world of my own making. Tests now use the real casing and assert both fixes — `bronze_events` present in the CTE, and no lowercase `aggregate_type = '…'` comparison anywhere. **Verified falsifiable**: reverting one literal to lowercase fails them (probe exit 1).

## Honest limit this fix does NOT remove
On the sandbox today **no account event carries `partyId` in bronze either** — only `BALANCE_UPDATED`, `HOLD_PLACED` and `HOLD_RELEASED` are present, none of which has it:

```
ACCOUNT  BALANCE_UPDATED  8  with_partyId=0
ACCOUNT  HOLD_RELEASED    3  with_partyId=0
ACCOUNT  HOLD_PLACED      3  with_partyId=0
```

`AccountEvents.kt` does carry `partyId` on account-opened, so the resolution is correct in principle — it simply has nothing to resolve until such an event lands in the retained window. The page shows a party's own domains and an empty accounts list, which is **truthful**. Tracked separately rather than papered over.

Verified the corrected SQL against the live sandbox for a real partyId (`05a02ef1-…`): returns the party's own row, no leakage from other parties.

## Test plan
- [x] `npm test` — 49 files / **791 passed**, exit 0
- [x] `npx tsc --noEmit` — exit 0
- [x] Corrected SQL executed against the **live sandbox ClickHouse**, not a fixture
- [x] Casing assertion verified falsifiable (revert one literal → fail)
- [x] Isolation assertions from #2580 still hold (SQL-level, both arms party-scoped)

Refs ADR-0210 D2. N/A — a follow-up fix to #2580, found during sandbox verification.

🤖 Generated with [Claude Code](https://claude.com/claude-code)