### PR TITLE
chore(gitops): pin admin-ui to sandbox-57668082 (Customer 360)

### DIFF
--- a/openbank-infra/gitops/components/admin-ui/admin-ui.yaml
+++ b/openbank-infra/gitops/components/admin-ui/admin-ui.yaml
@@ -38,7 +38,7 @@ spec:
           type: RuntimeDefault
       containers:
         - name: admin-ui
-          image: 265175468565.dkr.ecr.eu-north-1.amazonaws.com/openbank-admin-ui:sandbox-6ca0174f
+          image: 265175468565.dkr.ecr.eu-north-1.amazonaws.com/openbank-admin-ui:sandbox-57668082
           ports:
             - name: http
               containerPort: 3000


### PR DESCRIPTION
## Summary
The Customer 360 deploy (#2580) **built and pushed** `sandbox-57668082` to ECR at 13:16:30 and the workflow reported **success** — but the sandbox still runs `sandbox-68e2063d` and gitops pins `sandbox-6ca0174f`, the commit *before* it. Green deploy, code not deployed.

```
ECR:     sandbox-6ca0174f  13:13:17
         sandbox-57668082  13:16:30   ← exists
gitops:  sandbox-6ca0174f            ← pinned
pod:     sandbox-68e2063d            ← running
```

**Cause:** the bot's deploy PR #2594 is `DIRTY`. Every admin-ui deploy PR edits the same image-tag line, so each conflicts with whichever merged last — and four earlier ones are sitting in exactly that state: #2577, #2569, #2563, #2559.

## This deliberately does not merge #2594
Its branch is based on `576680828`, and `origin/main` has moved on since. Merging it would **revert** what main gained in between — deleted scripts and workflows (`check-claude-fallback-result.sh`, `check-upstream-unblock.py`, `upstream-unblock-watch.yml`), the release-please 0.61.0 bump, and the ADR-0006 correction. `git diff origin/main --stat` on that branch shows **851 deletions**.

That is precisely the footgun `CLAUDE.md` records: *"Never re-create a PR by copying whole files from a stale local checkout onto a fresh origin/main branch — the copy silently reverts everything main gained since your base diverged."* A one-line image pin has no reason to carry that risk.

So this is a fresh **single-line** change off current `main`: the image tag, nothing else.

## Follow-up
#2594 and the four stale deploy PRs should be **closed as superseded**, not merged — each pins an older image than what is now current. Worth a look at why they accumulate: a bot that opens a PR per deploy against a single shared line will always serialise badly.

## Test plan
- [x] `git diff --stat` — 1 file, 1 insertion, 1 deletion
- [x] Confirmed `sandbox-57668082` exists in ECR (`aws ecr describe-images`) before pinning it — pinning a tag that was never pushed would crashloop the pod
- [ ] After merge: confirm the running pod image rolls to `sandbox-57668082`, then verify `/customer-360` renders on the sandbox. I will check the pod, not assume Argo synced.

Refs ADR-0210, #2580.

🤖 Generated with [Claude Code](https://claude.com/claude-code)