### PR TITLE
feat(admin-ui): search Customer 360 and Consents by name, not by party UUID

### DIFF
--- a/docs/adr/0210-customer-360-as-a-query-over-the-analytics-silver-layer.md
+++ b/docs/adr/0210-customer-360-as-a-query-over-the-analytics-silver-layer.md
@@ -95,6 +95,27 @@ values nor that parity. So ADR-0209 D4 stands unchanged: ADR-0201 D5 does not st
 phase 2 exists. Building segment training on `silver_as_of` would reintroduce precisely the skew
 ADR-0140 was written to prevent, while looking like it had satisfied the prerequisite.
 
+**D8 — The lookup key is not the search surface.** The 360 is keyed by partyId because the silver
+layer is keyed by aggregate id — but that key must never be what the operator types. The first
+implementation exposed a raw `Party UUID` field, which made the page unusable without a second tab
+open on the Parties page, and was reported as "it does not work" the first time it was seen on the
+sandbox. Names are resolved by `party-service`'s existing trigram `/search` (ADR-0055) through the
+BFF, in a shared `PartySearch` component (ADR-0208), which hands back an id; a pasted UUID
+short-circuits straight through, so the direct path survives. `party-service` stays the only owner of
+a name index — this adds none. Generalise: when a page's backing store is keyed by a synthetic id,
+the id is an implementation detail of the query, and letting it become the input is the data model
+dictating the UX.
+
+**D9 — "The source is empty" and "this key has no rows" are different answers and must read
+differently.** Both this route and the Consents page collapsed a zero-row result into the generic
+`no_data` state, whose copy reads *"the data source is available but does not contain any records
+yet"* — false whenever any other party had rows, and indistinguishable from a broken page for the
+operator who hits it. `available: false` now means only that ClickHouse did not answer; a party with
+no projected events returns `available: true` with empty domains and renders as "this party has no
+analytics events". The same correction applies to `consent-service` lookups by party and by grantee.
+Generalise: an empty-state message asserts a fact about the data source, so it is wrong to reuse the
+source-level message for a key-level miss.
+
 ## Alternatives considered
 
 - **Build `crm-service` as ADR-0199 specifies.** Rejected on evidence, not principle: it

--- a/openbank-admin-ui/src/app/api/customer-360/[partyId]/route.ts
+++ b/openbank-admin-ui/src/app/api/customer-360/[partyId]/route.ts
@@ -136,7 +136,12 @@ export async function GET(_req: NextRequest, ctx: { params: Promise<{ partyId: s
 
   try {
     const rows = await chQuery(scopedRowsSql(partyId))
-    if (rows.length === 0) return NextResponse.json(empty(partyId))
+    // A query that succeeded and matched nothing means THIS PARTY has no projected events — it does
+    // NOT mean the data source is empty. Those are different facts and the page renders different
+    // copy for each, so `available` stays true: ClickHouse answered. Returning false here read as
+    // "the source contains no records yet" while the source held events for other parties, which is
+    // the shape an operator cannot tell apart from a broken page.
+    if (rows.length === 0) return NextResponse.json({ ...empty(partyId), available: true })
 
     const byDomain = new Map<string, DomainSummary>()
     const accountIds = new Set<string>()

--- a/openbank-admin-ui/src/app/consents/page.tsx
+++ b/openbank-admin-ui/src/app/consents/page.tsx
@@ -8,6 +8,7 @@ import { useState } from 'react'
 import { FileSignature, Search } from 'lucide-react'
 import { useLanguage } from '@/lib/i18n/LanguageContext'
 import { DataUnavailable, type UnavailableKind } from '@/components/feedback/DataUnavailable'
+import { PartySearch, partyDisplayName, type PartyHit } from '@/components/party/PartySearch'
 import { classifyBffFailure } from '@/lib/services/bff'
 import { PageHeader, StatCard, StatusBadge, statusTone } from '@/components/ui'
 
@@ -39,14 +40,18 @@ type Lens = 'party' | 'grantee'
 
 export default function ConsentsPage() {
   const { t, language } = useLanguage()
-  const [lens, setLens] = useState<Lens>('grantee')
-  const [term, setTerm] = useState(MARKETING_GRANTEE)
+  // Party is the default lens: an operator arrives with a customer in mind, not a grantee id. The
+  // grantee lens stays because it is the one genuinely global view (see MARKETING_GRANTEE above),
+  // but it is the specialist path, not the landing state.
+  const [lens, setLens] = useState<Lens>('party')
+  const [term, setTerm] = useState('')
+  const [party, setParty] = useState<PartyHit | null>(null)
   const [rows, setRows] = useState<Consent[] | null>(null)
   const [failure, setFailure] = useState<UnavailableKind | null>(null)
   const [loading, setLoading] = useState(false)
 
-  const lookup = async () => {
-    const q = term.trim()
+  const lookup = async (override?: string) => {
+    const q = (override ?? term).trim()
     if (!q) return
     setLoading(true)
     setFailure(null)
@@ -60,12 +65,20 @@ export default function ConsentsPage() {
       }
       const data = (await res.json()) as Consent[]
       setRows(data)
-      if (data.length === 0) setFailure('no_data')
+      // NOT `no_data`: consent-service answered, it just holds no consent for this key. The old copy
+      // said "the data source contains no records yet", which an operator cannot tell apart from a
+      // broken page — and was false whenever any other party had a consent. Rendered below instead.
     } catch {
       setFailure('unreachable')
     } finally {
       setLoading(false)
     }
+  }
+
+  const onPartySelected = (p: PartyHit) => {
+    setParty(p)
+    setTerm(p.id)
+    void lookup(p.id)
   }
 
   const active = rows?.filter(c => c.status === 'ACTIVE').length ?? 0
@@ -98,34 +111,56 @@ export default function ConsentsPage() {
               background: 'var(--surface)', color: 'var(--text-primary)', fontSize: '13px', fontWeight: 600,
             }}
           >
+            <option value="party">{t('Podle party', 'By party')}</option>
             <option value="grantee">{t('Podle grantee', 'By grantee')}</option>
-            <option value="party">{t('Podle party ID', 'By party ID')}</option>
           </select>
-          <input
-            value={term}
-            onChange={e => setTerm(e.target.value)}
-            onKeyDown={e => { if (e.key === 'Enter') lookup() }}
-            placeholder={lens === 'party' ? t('UUID party', 'Party UUID') : t('ID grantee', 'Grantee id')}
-            style={{
-              flex: '1 1 320px', padding: '8px 12px', borderRadius: '8px', border: '1px solid var(--border)',
-              background: 'var(--surface)', color: 'var(--text-primary)', fontSize: '13px',
-            }}
-          />
-          <button
-            onClick={lookup}
-            disabled={loading || !term.trim()}
-            style={{
-              display: 'flex', alignItems: 'center', gap: '6px', padding: '8px 16px',
-              cursor: loading || !term.trim() ? 'not-allowed' : 'pointer', borderRadius: '8px',
-              border: '1px solid var(--border)', background: 'var(--surface)',
-              color: 'var(--text-secondary)', fontSize: '13px', fontWeight: 600,
-              opacity: loading || !term.trim() ? 0.6 : 1,
-            }}
-          >
-            <Search size={15} /> {t('Vyhledat', 'Look up')}
-          </button>
+          {/* The party lens searches by NAME (party-service owns names, ADR-0055) and resolves to the
+              id consent-service is keyed by. The grantee lens stays a literal id field: a grantee is
+              a system identifier like party-service:marketing-comms, not a person to search for. */}
+          {lens === 'grantee' && (
+            <>
+              <input
+                value={term}
+                onChange={e => setTerm(e.target.value)}
+                onKeyDown={e => { if (e.key === 'Enter') lookup() }}
+                placeholder={t('ID grantee', 'Grantee id')}
+                style={{
+                  flex: '1 1 320px', padding: '8px 12px', borderRadius: '8px', border: '1px solid var(--border)',
+                  background: 'var(--surface)', color: 'var(--text-primary)', fontSize: '13px',
+                }}
+              />
+              <button
+                onClick={() => lookup()}
+                disabled={loading || !term.trim()}
+                style={{
+                  display: 'flex', alignItems: 'center', gap: '6px', padding: '8px 16px',
+                  cursor: loading || !term.trim() ? 'not-allowed' : 'pointer', borderRadius: '8px',
+                  border: '1px solid var(--border)', background: 'var(--surface)',
+                  color: 'var(--text-secondary)', fontSize: '13px', fontWeight: 600,
+                  opacity: loading || !term.trim() ? 0.6 : 1,
+                }}
+              >
+                <Search size={15} /> {t('Vyhledat', 'Look up')}
+              </button>
+              <button
+                onClick={() => { setTerm(MARKETING_GRANTEE); void lookup(MARKETING_GRANTEE) }}
+                disabled={loading}
+                style={{
+                  padding: '8px 14px', borderRadius: '8px', border: '1px solid var(--border)',
+                  background: 'var(--surface)', color: 'var(--text-secondary)', fontSize: '12px',
+                  fontWeight: 600, cursor: loading ? 'not-allowed' : 'pointer',
+                }}
+              >
+                {t('Marketingové souhlasy', 'Marketing consents')}
+              </button>
+            </>
+          )}
         </div>
       </div>
+
+      {lens === 'party' && (
+        <PartySearch onSelect={onPartySelected} selectedId={party?.id} busy={loading} />
+      )}
 
       {rows && rows.length > 0 && (
         <div style={{ display: 'grid', gridTemplateColumns: 'repeat(auto-fit, minmax(160px, 1fr))', gap: '12px', marginBottom: '20px' }}>
@@ -148,6 +183,29 @@ export default function ConsentsPage() {
           feature={t('Souhlasy', 'Consents')}
           lang={language === 'cs' ? 'cs' : 'en'}
         />
+      )}
+
+      {/* Answered, but empty for this key. Distinct from an unavailable service (above): the earlier
+          copy claimed the source held no records at all, while it held consents for other parties. */}
+      {!loading && !failure && rows && rows.length === 0 && (
+        <div className="card" style={{ padding: '32px', textAlign: 'center' }}>
+          <p style={{ margin: '0 0 6px', fontWeight: 600, color: 'var(--text-primary)' }}>
+            {lens === 'party'
+              ? t('Tato party nemá žádný souhlas', 'This party has no consent')
+              : t('Tento grantee nemá žádný souhlas', 'This grantee has no consent')}
+          </p>
+          <p style={{ margin: 0, fontSize: '12px', color: 'var(--text-secondary)' }}>
+            {t(
+              'consent-service je dostupná a odpověděla — pro tento dotaz nemá žádný záznam. Nejde o chybu ani o prázdnou databázi.',
+              'consent-service is available and answered — it has no record for this query. This is not an error, nor an empty database.',
+            )}
+          </p>
+          {lens === 'party' && party && (
+            <p style={{ margin: '10px 0 0', fontSize: '11px', fontFamily: 'var(--font-mono, monospace)', color: 'var(--text-tertiary)' }}>
+              {partyDisplayName(party)} · {party.id}
+            </p>
+          )}
+        </div>
       )}
 
       {!loading && rows && rows.length > 0 && (

--- a/openbank-admin-ui/src/app/customer-360/page.tsx
+++ b/openbank-admin-ui/src/app/customer-360/page.tsx
@@ -5,14 +5,20 @@
 'use client'
 
 import { useState } from 'react'
-import { Users, Search } from 'lucide-react'
+import { Users } from 'lucide-react'
 import { useLanguage } from '@/lib/i18n/LanguageContext'
 import { DataUnavailable, type UnavailableKind } from '@/components/feedback/DataUnavailable'
 import { PageHeader, StatCard, StatusBadge } from '@/components/ui'
 import type { Customer360 } from '@/app/api/customer-360/[partyId]/route'
+import { PartySearch, partyDisplayName, type PartyHit } from '@/components/party/PartySearch'
 
 // ADR-0210: a lookup over the analytics silver layer, not a customer list. There is no
 // crm-service and no "list all customers" surface here — party-service owns that.
+//
+// The lookup is keyed by party id because the silver layer is keyed by aggregate id. That key is NOT
+// the search box: PartySearch resolves a name to an id against party-service (ADR-0055), because an
+// operator has a name in hand, not a UUID. The first version exposed the raw id and was unusable
+// without a second tab open on the Parties page — the data model had been allowed to dictate the UX.
 //
 // Everything shown is DERIVED from an event projection and is deliberately non-authoritative
 // (ADR-0210 D3 / ADR-0089): counts, recency and lifecycle state, never balances or transaction
@@ -20,26 +26,27 @@ import type { Customer360 } from '@/app/api/customer-360/[partyId]/route'
 // instead of assuming it is live.
 export default function Customer360Page() {
   const { t, language } = useLanguage()
-  const [term, setTerm] = useState('')
+  const [selected, setSelected] = useState<PartyHit | null>(null)
   const [data, setData] = useState<Customer360 | null>(null)
   const [failure, setFailure] = useState<UnavailableKind | null>(null)
   const [loading, setLoading] = useState(false)
 
-  const lookup = async () => {
-    const q = term.trim()
-    if (!q) return
+  const load360 = async (party: PartyHit) => {
+    setSelected(party)
     setLoading(true)
     setFailure(null)
     setData(null)
     try {
-      const res = await fetch(`/api/customer-360/${encodeURIComponent(q)}`, { cache: 'no-store' })
+      const res = await fetch(`/api/customer-360/${encodeURIComponent(party.id)}`, { cache: 'no-store' })
       const body = (await res.json()) as Customer360
       if (res.status === 400) {
         setFailure('error')
         return
       }
+      // `available: false` means one thing only: ClickHouse did not answer. A party that simply has
+      // no projected events comes back available with empty domains, and is rendered as such below.
       if (!body.available) {
-        setFailure(body.error ? 'unreachable' : 'no_data')
+        setFailure(body.error === 'unauthorized' ? 'unauthorized' : 'unreachable')
         return
       }
       setData(body)
@@ -67,34 +74,7 @@ export default function Customer360Page() {
         )}
       />
 
-      <div className="card" style={{ marginBottom: '20px' }}>
-        <div style={{ display: 'flex', gap: '10px', flexWrap: 'wrap', alignItems: 'center' }}>
-          <input
-            value={term}
-            onChange={e => setTerm(e.target.value)}
-            onKeyDown={e => { if (e.key === 'Enter') lookup() }}
-            placeholder={t('UUID party', 'Party UUID')}
-            style={{
-              flex: '1 1 340px', padding: '8px 12px', borderRadius: '8px', border: '1px solid var(--border)',
-              background: 'var(--surface)', color: 'var(--text-primary)', fontSize: '13px',
-              fontFamily: 'var(--font-mono, monospace)',
-            }}
-          />
-          <button
-            onClick={lookup}
-            disabled={loading || !term.trim()}
-            style={{
-              display: 'flex', alignItems: 'center', gap: '6px', padding: '8px 16px',
-              cursor: loading || !term.trim() ? 'not-allowed' : 'pointer', borderRadius: '8px',
-              border: '1px solid var(--border)', background: 'var(--surface)',
-              color: 'var(--text-secondary)', fontSize: '13px', fontWeight: 600,
-              opacity: loading || !term.trim() ? 0.6 : 1,
-            }}
-          >
-            <Search size={15} /> {t('Vyhledat', 'Look up')}
-          </button>
-        </div>
-      </div>
+      <PartySearch onSelect={load360} selectedId={selected?.id} busy={loading} />
 
       {loading && (
         <div style={{ color: 'var(--text-secondary)', padding: '40px', textAlign: 'center' }}>
@@ -111,8 +91,36 @@ export default function Customer360Page() {
         />
       )}
 
-      {!loading && data && (
+      {/* A party that exists but has no projected events. Stated as exactly that — the source is up,
+          this party simply has no analytics history yet. The earlier copy said the source held no
+          records at all, which an operator cannot distinguish from a broken page. */}
+      {!loading && data && data.domains.length === 0 && (
+        <div className="card" style={{ padding: '32px', textAlign: 'center' }}>
+          <p style={{ margin: '0 0 6px', fontWeight: 600, color: 'var(--text-primary)' }}>
+            {t('Tato party nemá žádné analytické události', 'This party has no analytics events')}
+          </p>
+          <p style={{ margin: 0, fontSize: '12px', color: 'var(--text-secondary)' }}>
+            {t(
+              'Silver vrstva je dostupná a odpověděla — pro tuto party v ní zatím není žádná událost. Nejde o chybu stránky ani o prázdný zdroj.',
+              'The silver layer is available and answered — it holds no event for this party yet. This is not a page error, nor an empty source.',
+            )}
+          </p>
+          {selected && (
+            <p style={{ margin: '10px 0 0', fontSize: '11px', fontFamily: 'var(--font-mono, monospace)', color: 'var(--text-tertiary)' }}>
+              {partyDisplayName(selected)} · {selected.id}
+            </p>
+          )}
+        </div>
+      )}
+
+      {!loading && data && data.domains.length > 0 && (
         <>
+          {selected && (
+            <h2 className="section-title" style={{ marginBottom: '12px' }}>
+              {partyDisplayName(selected)}
+            </h2>
+          )}
+
           <div style={{ display: 'grid', gridTemplateColumns: 'repeat(auto-fit, minmax(160px, 1fr))', gap: '12px', marginBottom: '20px' }}>
             <StatCard label={t('Domén', 'Domains')} value={data.domains.length} />
             <StatCard label={t('Událostí', 'Events')} value={totalEvents} />

--- a/openbank-admin-ui/src/components/party/PartySearch.tsx
+++ b/openbank-admin-ui/src/components/party/PartySearch.tsx
@@ -1,0 +1,200 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright (c) OpenBank contributors. Licensed under the Apache License, Version 2.0.
+// See LICENSE in the repository root or https://www.apache.org/licenses/LICENSE-2.0 for details.
+
+'use client'
+
+// Resolve a HUMAN-READABLE name to a party id.
+//
+// Why this exists: several console pages are keyed by party id because the thing they read is keyed
+// that way — the analytics silver layer by aggregate id, consent-service by partyId. Exposing that
+// key as the search box let the data model dictate the UX: an operator has a name in hand, not a
+// UUID, and a UUID-only field is unusable without a second tab open on the Parties page.
+//
+// party-service owns identity, so name search belongs there — ADR-0055's trigram `/search`, reached
+// through the BFF (ADR-0056). No page keeps its own name index, and this never becomes a second
+// lookup path into the downstream store: it resolves a name to an id, and the id is what the caller
+// queries with.
+//
+// Shared deliberately (ADR-0208): two callers need it (Customer 360, Consents), and a copy in each
+// would be two divergent search behaviours over one endpoint.
+
+import { useState } from 'react'
+import { Search } from 'lucide-react'
+import { useLanguage } from '@/lib/i18n/LanguageContext'
+import { DataUnavailable, type UnavailableKind } from '@/components/feedback/DataUnavailable'
+import { StatusBadge } from '@/components/ui'
+
+const PARTY_SERVICE = '/api/svc/party-service'
+
+export const PARTY_UUID_RE = /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i
+
+export interface PartyHit {
+  id: string
+  legalName?: string | null
+  tradingName?: string | null
+  email?: string | null
+  status?: string | null
+  kycStatus?: string | null
+}
+
+export function partyDisplayName(p: PartyHit): string {
+  return p.legalName || p.tradingName || p.id
+}
+
+interface Props {
+  /** Called with the chosen party. A pasted UUID is passed through as `{ id }` with no name. */
+  onSelect: (party: PartyHit) => void
+  /** Highlighted row, so the caller's current selection stays visible in the result list. */
+  selectedId?: string
+  /** Disables selection while the caller is loading the party's data. */
+  busy?: boolean
+  placeholder?: string
+}
+
+export function PartySearch({ onSelect, selectedId, busy = false, placeholder }: Props) {
+  const { t, language } = useLanguage()
+  const [term, setTerm] = useState('')
+  const [hits, setHits] = useState<PartyHit[] | null>(null)
+  const [failure, setFailure] = useState<UnavailableKind | null>(null)
+  const [searching, setSearching] = useState(false)
+
+  const run = async () => {
+    const q = term.trim()
+    if (!q) return
+    // A pasted party id is not a name — skip the trigram search entirely, so an operator who already
+    // has an id keeps the direct path instead of being forced through a result list of one.
+    if (PARTY_UUID_RE.test(q)) {
+      setHits(null)
+      setFailure(null)
+      onSelect({ id: q })
+      return
+    }
+    setSearching(true)
+    setFailure(null)
+    setHits(null)
+    try {
+      const res = await fetch(
+        `${PARTY_SERVICE}/api/v1/parties/search?q=${encodeURIComponent(q)}&limit=20`,
+        { cache: 'no-store' },
+      )
+      if (!res.ok) {
+        setFailure(res.status === 401 || res.status === 403 ? 'unauthorized' : 'unreachable')
+        return
+      }
+      const body = (await res.json()) as { data?: PartyHit[] }
+      setHits(body.data ?? [])
+    } catch {
+      setFailure('unreachable')
+    } finally {
+      setSearching(false)
+    }
+  }
+
+  return (
+    <>
+      <div className="card" style={{ marginBottom: '20px' }}>
+        <div style={{ display: 'flex', gap: '10px', flexWrap: 'wrap', alignItems: 'center' }}>
+          <input
+            value={term}
+            onChange={e => setTerm(e.target.value)}
+            onKeyDown={e => { if (e.key === 'Enter') run() }}
+            placeholder={placeholder ?? t('Jméno nebo název firmy (nebo UUID party)', 'Name or company name (or party UUID)')}
+            style={{
+              flex: '1 1 340px', padding: '8px 12px', borderRadius: '8px', border: '1px solid var(--border)',
+              background: 'var(--surface)', color: 'var(--text-primary)', fontSize: '13px',
+            }}
+          />
+          <button
+            onClick={run}
+            disabled={searching || busy || !term.trim()}
+            style={{
+              display: 'flex', alignItems: 'center', gap: '6px', padding: '8px 16px',
+              cursor: searching || busy || !term.trim() ? 'not-allowed' : 'pointer', borderRadius: '8px',
+              border: '1px solid var(--border)', background: 'var(--surface)',
+              color: 'var(--text-secondary)', fontSize: '13px', fontWeight: 600,
+              opacity: searching || busy || !term.trim() ? 0.6 : 1,
+            }}
+          >
+            <Search size={15} /> {t('Vyhledat', 'Search')}
+          </button>
+        </div>
+        <p style={{ margin: '10px 0 0', fontSize: '11px', color: 'var(--text-tertiary)' }}>
+          {t(
+            'Hledá se v party-service (ADR-0055) — jména vlastní ta služba.',
+            'Search runs against party-service (ADR-0055) — it owns names.',
+          )}
+        </p>
+      </div>
+
+      {searching && (
+        <div style={{ color: 'var(--text-secondary)', padding: '24px', textAlign: 'center' }}>
+          {t('Hledám…', 'Searching…')}
+        </div>
+      )}
+
+      {!searching && failure && (
+        <DataUnavailable
+          kind={failure}
+          service="party-service"
+          feature={t('Hledání party', 'Party search')}
+          lang={language === 'cs' ? 'cs' : 'en'}
+        />
+      )}
+
+      {!searching && hits && hits.length === 0 && (
+        <div className="card" style={{ padding: '28px', textAlign: 'center', marginBottom: '20px' }}>
+          {/* Stated as a search result, not as an unavailable data source: party-service answered. */}
+          <p style={{ margin: 0, fontWeight: 600, color: 'var(--text-primary)' }}>
+            {t('Žádná party neodpovídá hledání', 'No party matches that search')}
+          </p>
+          <p style={{ margin: '6px 0 0', fontSize: '12px', color: 'var(--text-secondary)' }}>
+            {t('party-service odpověděla — hledaný výraz nic nenašel.', 'party-service answered — the term matched nothing.')}
+          </p>
+        </div>
+      )}
+
+      {!searching && hits && hits.length > 0 && (
+        <div className="card" style={{ marginBottom: '20px', overflowX: 'auto' }}>
+          <h2 className="section-title" style={{ marginBottom: '12px' }}>
+            {t('Nalezené party', 'Matching parties')} ({hits.length})
+          </h2>
+          <table className="table">
+            <thead>
+              <tr>
+                <th>{t('Jméno', 'Name')}</th>
+                <th>{t('E-mail', 'Email')}</th>
+                <th>{t('Stav', 'Status')}</th>
+                <th>KYC</th>
+                <th />
+              </tr>
+            </thead>
+            <tbody>
+              {hits.map(p => (
+                <tr key={p.id} style={{ background: selectedId === p.id ? 'var(--surface-hover)' : undefined }}>
+                  <td style={{ fontWeight: 600 }}>{partyDisplayName(p)}</td>
+                  <td style={{ color: 'var(--text-secondary)' }}>{p.email || '—'}</td>
+                  <td>{p.status ? <StatusBadge status={p.status} withDot /> : '—'}</td>
+                  <td>{p.kycStatus ? <StatusBadge status={p.kycStatus} /> : '—'}</td>
+                  <td style={{ textAlign: 'right' }}>
+                    <button
+                      onClick={() => onSelect(p)}
+                      disabled={busy}
+                      style={{
+                        padding: '5px 12px', borderRadius: '6px', border: '1px solid var(--border)',
+                        background: 'var(--surface)', color: 'var(--text-secondary)', fontSize: '12px',
+                        fontWeight: 600, cursor: busy ? 'not-allowed' : 'pointer',
+                      }}
+                    >
+                      {t('Vybrat', 'Select')}
+                    </button>
+                  </td>
+                </tr>
+              ))}
+            </tbody>
+          </table>
+        </div>
+      )}
+    </>
+  )
+}

--- a/openbank-admin-ui/src/test/customer-360.test.ts
+++ b/openbank-admin-ui/src/test/customer-360.test.ts
@@ -116,4 +116,31 @@ describe('Customer 360 isolation (ADR-0210 D2)', () => {
       expect(iface.toLowerCase(), forbidden).not.toContain(forbidden)
     }
   })
+  // The distinction this asserts was a real defect: a party with no events came back
+  // `available: false`, which the page rendered as "the data source contains no records yet" — while
+  // the source held events for other parties. An operator cannot tell that copy apart from a broken
+  // page, so `available` must mean one thing only: ClickHouse answered.
+  it('reports a party with no events as available, not as an empty data source', async () => {
+    stubClickHouse([])
+    const { GET } = await import('@/app/api/customer-360/[partyId]/route')
+    const res = await GET({} as never, { params: Promise.resolve({ partyId: PARTY }) })
+
+    const body = await res.json()
+    expect(res.status).toBe(200)
+    expect(body.available).toBe(true) // the source answered
+    expect(body.domains).toEqual([]) // this party simply has nothing in it
+    expect(body.error).toBeUndefined() // and nothing went wrong
+  })
+
+  it('still reports an unreachable source as unavailable', async () => {
+    // The other side of the same boundary: `available: false` must remain reachable, or the page
+    // loses its only signal that ClickHouse is down.
+    vi.stubGlobal('fetch', vi.fn(async () => { throw new Error('ETIMEDOUT') }))
+    const { GET } = await import('@/app/api/customer-360/[partyId]/route')
+    const res = await GET({} as never, { params: Promise.resolve({ partyId: OTHER }) })
+
+    const body = await res.json()
+    expect(body.available).toBe(false)
+    expect(body.error).toContain('ETIMEDOUT')
+  })
 })

--- a/openbank-admin-ui/src/test/party-search.test.tsx
+++ b/openbank-admin-ui/src/test/party-search.test.tsx
@@ -1,0 +1,108 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright (c) OpenBank contributors. Licensed under the Apache License, Version 2.0.
+// See LICENSE in the repository root or https://www.apache.org/licenses/LICENSE-2.0 for details.
+
+// PartySearch exists because Customer 360 and Consents were keyed by party UUID and exposed that key
+// as their search box — unusable without a second tab open on the Parties page. It resolves a name
+// to an id against party-service (ADR-0055).
+//
+// What this asserts is the behaviour that is easy to regress and invisible when it breaks:
+//   1. A pasted UUID must NOT be sent to the trigram endpoint. It is already the answer, so it goes
+//      straight to onSelect. If this regressed, a valid id would return an empty result list and the
+//      page would look broken for the one input that is guaranteed correct.
+//   2. Zero matches must NOT render as an unavailable data source. That conflation is the exact
+//      defect this component was written to remove, and it is copy — nothing else would catch it.
+
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest'
+import React from 'react'
+import { render, cleanup, screen, fireEvent, waitFor } from '@testing-library/react'
+import { PartySearch, PARTY_UUID_RE, partyDisplayName } from '@/components/party/PartySearch'
+import { LanguageProvider } from '@/lib/i18n/LanguageContext'
+
+const UUID = '24977cca-20b2-4877-80d1-403b40181a89'
+
+function mount(onSelect: (p: { id: string }) => void) {
+  return render(
+    <LanguageProvider>
+      <PartySearch onSelect={onSelect} />
+    </LanguageProvider>,
+  )
+}
+
+function type(value: string) {
+  const input = screen.getByRole('textbox')
+  fireEvent.change(input, { target: { value } })
+  return input
+}
+
+beforeEach(() => {
+  vi.unstubAllGlobals()
+})
+afterEach(() => cleanup())
+
+describe('PartySearch', () => {
+  it('passes a pasted party UUID straight through, without calling the search endpoint', async () => {
+    const fetchSpy = vi.fn(async () => ({ ok: true, json: async () => ({ data: [] }) }) as unknown as Response)
+    vi.stubGlobal('fetch', fetchSpy)
+    const onSelect = vi.fn()
+
+    mount(onSelect)
+    fireEvent.keyDown(type(UUID), { key: 'Enter' })
+
+    await waitFor(() => expect(onSelect).toHaveBeenCalledWith({ id: UUID }))
+    expect(fetchSpy).not.toHaveBeenCalled() // the id IS the answer — no trigram round-trip
+  })
+
+  it('searches party-service by name and does not select until a row is chosen', async () => {
+    const hit = { id: UUID, legalName: 'Jan Novák', email: 'jan@example.test', status: 'ACTIVE' }
+    const fetchSpy = vi.fn(async () => ({ ok: true, json: async () => ({ data: [hit] }) }) as unknown as Response)
+    vi.stubGlobal('fetch', fetchSpy)
+    const onSelect = vi.fn()
+
+    mount(onSelect)
+    fireEvent.keyDown(type('Novák'), { key: 'Enter' })
+
+    await waitFor(() => expect(screen.getByText('Jan Novák')).toBeTruthy())
+    const url = String(fetchSpy.mock.calls[0][0])
+    expect(url).toContain('/api/svc/party-service/api/v1/parties/search')
+    expect(url).toContain(`q=${encodeURIComponent('Novák')}`)
+    expect(onSelect).not.toHaveBeenCalled() // a result list is not a selection
+
+    fireEvent.click(screen.getByRole('button', { name: /Vybrat|Select/ }))
+    expect(onSelect).toHaveBeenCalledWith(hit)
+  })
+
+  it('renders zero matches as a search result, never as an unavailable data source', async () => {
+    vi.stubGlobal('fetch', vi.fn(async () => ({ ok: true, json: async () => ({ data: [] }) }) as unknown as Response))
+
+    mount(vi.fn())
+    fireEvent.keyDown(type('nobody'), { key: 'Enter' })
+
+    await waitFor(() => expect(screen.getByText(/Žádná party neodpovídá|No party matches/)).toBeTruthy())
+    // The copy that made a working page look broken. It must not appear for an empty result set.
+    expect(screen.queryByText(/neobsahuje žádné záznamy|does not contain any records/)).toBeNull()
+  })
+
+  it('does distinguish an unreachable party-service from zero matches', async () => {
+    vi.stubGlobal('fetch', vi.fn(async () => { throw new Error('ECONNREFUSED') }))
+
+    mount(vi.fn())
+    fireEvent.keyDown(type('Novák'), { key: 'Enter' })
+
+    // DataUnavailable's unreachable copy, not the "no party matches" one.
+    await waitFor(() => expect(screen.queryByText(/Žádná party neodpovídá|No party matches/)).toBeNull())
+  })
+
+  it('accepts only a well-formed UUID as the direct path', () => {
+    expect(PARTY_UUID_RE.test(UUID)).toBe(true)
+    expect(PARTY_UUID_RE.test(UUID.toUpperCase())).toBe(true)
+    expect(PARTY_UUID_RE.test('Novák')).toBe(false)
+    expect(PARTY_UUID_RE.test(UUID.slice(0, -1))).toBe(false) // too short must still be a name search
+  })
+
+  it('falls back through legalName, tradingName, then id for the display name', () => {
+    expect(partyDisplayName({ id: UUID, legalName: 'A', tradingName: 'B' })).toBe('A')
+    expect(partyDisplayName({ id: UUID, legalName: null, tradingName: 'B' })).toBe('B')
+    expect(partyDisplayName({ id: UUID })).toBe(UUID) // never renders an empty cell
+  })
+})


### PR DESCRIPTION
## What this fixes

Two admin-UI pages exposed their backing store's key as the search box:

- **Customer 360** took a raw `Party UUID`.
- **Consents** defaulted to the grantee lens and offered "By party ID".

Neither is usable without a second tab open on the Parties page. This was reported as *"it does not work"* the first time Customer 360 was used on the sandbox — against a page that was answering correctly. The data model had been allowed to dictate the UX.

## How

`party-service` already owns a trigram name search: `GET /api/v1/parties/search?q=` (ADR-0055, feature flag `party-search` — verified **ENABLED** on the sandbox, `defaultVariant: on`). It is reached through the BFF (ADR-0056) from one shared `PartySearch` component, per ADR-0208: there are two callers, so a copy in each would be two divergent search behaviours over one endpoint.

It resolves a name to a party id, which is what each page queries with. A pasted UUID short-circuits straight to selection, so the operator who already has an id keeps the direct path. **`party-service` remains the only owner of a name index — this adds none.**

Consents now defaults to the **party** lens. The grantee lens stays, because `party-service:marketing-comms` is the one genuinely global view, with a one-click preset for it.

## Second defect, same investigation

A zero-row result rendered as `no_data`, whose copy reads *"the data source is available but does not contain any records yet"*. That was **false** whenever any other party had rows, and is indistinguishable from a broken page.

`available: false` now means one thing: ClickHouse did not answer. A party with no projected events returns `available: true` with empty domains and reads *"this party has no analytics events"*. Same correction for `consent-service` lookups by party and by grantee.

## Verification — every guard run against code it must flag

| Guard | Broken input | Result |
|---|---|---|
| UUID pass-through | disabled the short-circuit | ❌ red |
| empty-result copy | restored the misleading text | ❌ red |
| `available` semantics | pre-fix route | ❌ red (`expected false to be true`) |
| unreachable still unavailable | pre-fix route | ✅ green (ratchet guard) |

All green after the fix. **801/801 tests** (50 files), **0 lint errors** (80 pre-existing warnings, none in changed files), `tsc --noEmit` clean, build compiled. The page is covered by `render-smoke.test.tsx`, which auto-discovers via `import.meta.glob`.

## ADR

ADR-0210 gains two decisions:
- **D8** — the lookup key is not the search surface.
- **D9** — "the source is empty" and "this key has no rows" are different answers and must read differently.

`check-adr-registry.sh`: OK, 202 ADRs.

## Note on sandbox data

The sandbox has only 92 bronze events across 2 parties, and no `ACCOUNT_OPENED` / CONSENT / TRANSACTION rows ever reached bronze — that is [#2598](https://github.com/JiRaska/open-bank-oss/issues/2598), not this PR. After merge the page will render truthfully but sparsely. Search itself is unaffected: it reads `party-service`, which has the full party set.

Refs #2598