### PR TITLE
security(party): gate the ADR-0179 identity merge behind four-eyes (maker/checker)

### DIFF
--- a/openbank-infra/gitops/components/accounts/account-opa-bundle.yaml
+++ b/openbank-infra/gitops/components/accounts/account-opa-bundle.yaml
@@ -9,7 +9,7 @@ metadata:
     app.kubernetes.io/name: account-service
     app.kubernetes.io/part-of: accounts
   annotations:
-    openbank.tech/policy-checksum: "fc188e7f88bee500"
+    openbank.tech/policy-checksum: "20a65db75ff4907e"
 data:
   rest.rego: |
     # SPDX-License-Identifier: Apache-2.0
@@ -2388,6 +2388,27 @@ data:
                                              # explicitly excludes any service-account-* principal id
                                              # (rest.rego operator-compose-message), the same exclusion
                                              # m2m-sanctions-screening uses for the opposite carve-out.
+        - party.merge                       # ADR-0179: retire a duplicate identity into a survivor
+                                             # (POST /api/v1/parties/{id}/merge). Gated HERE and not via
+                                             # `verbs` for the same structural reason opsmessage.compose
+                                             # is: party-service is not, and should not become, a
+                                             # money_path_services entry (it moves no value), so the
+                                             # verb clause can never derive a `party` scope and no verb
+                                             # addition could ever reach this action.
+                                             # Why it needs the gate at all: a merge is destructive OF
+                                             # IDENTITY and irreversible in practice — one operator can
+                                             # retire a real customer behind another party id, and every
+                                             # downstream consumer follows `merged_into`. It carried only
+                                             # @RolesAllowed(ROLE_OPERATOR, ROLE_ADMIN) + an audit event,
+                                             # which records who did it but stops nobody.
+                                             # GUARDRAIL check (the one above, applied): confirmed no M2M
+                                             # caller. party-service's own rego states party.merge "has NO
+                                             # in-repo M2M caller today"; the edge M2M identity is granted
+                                             # only {party.consent.update, party:resolve} by the rule that
+                                             # names it (service-edge-party-m2m), and the ADR-0179 sweep
+                                             # counterpart transaction.merge-sweep is already gated by the
+                                             # `sweep` verb — so both halves of the merge flow now pause
+                                             # for a second approver, or neither does.
 
     # ---------------------------------------------------------------------------------------
     # Feature-flag flip governance (ADR-0067 follow-up, issue #419). The OPA PEP (rest.rego)

--- a/openbank-infra/gitops/components/accounts/account-service.yaml
+++ b/openbank-infra/gitops/components/accounts/account-service.yaml
@@ -37,7 +37,7 @@ spec:
       annotations:
         # Rolls the pod when the OPA bundle changes — subPath mounts do NOT hot-reload.
         # Kept in sync by gen-account-opa-bundle.sh (do not hand-edit).
-        openbank.tech/policy-checksum: "fc188e7f88bee500"
+        openbank.tech/policy-checksum: "20a65db75ff4907e"
     spec:
       securityContext:
         runAsNonRoot: true

--- a/openbank-infra/gitops/components/aml/aml-opa-bundle.yaml
+++ b/openbank-infra/gitops/components/aml/aml-opa-bundle.yaml
@@ -9,7 +9,7 @@ metadata:
     app.kubernetes.io/name: aml-service
     app.kubernetes.io/part-of: aml
   annotations:
-    openbank.tech/policy-checksum: "68ea247e63fdbe26"
+    openbank.tech/policy-checksum: "6cb0c7016a768082"
 data:
   rest.rego: |
     # SPDX-License-Identifier: Apache-2.0
@@ -2361,6 +2361,27 @@ data:
                                              # explicitly excludes any service-account-* principal id
                                              # (rest.rego operator-compose-message), the same exclusion
                                              # m2m-sanctions-screening uses for the opposite carve-out.
+        - party.merge                       # ADR-0179: retire a duplicate identity into a survivor
+                                             # (POST /api/v1/parties/{id}/merge). Gated HERE and not via
+                                             # `verbs` for the same structural reason opsmessage.compose
+                                             # is: party-service is not, and should not become, a
+                                             # money_path_services entry (it moves no value), so the
+                                             # verb clause can never derive a `party` scope and no verb
+                                             # addition could ever reach this action.
+                                             # Why it needs the gate at all: a merge is destructive OF
+                                             # IDENTITY and irreversible in practice — one operator can
+                                             # retire a real customer behind another party id, and every
+                                             # downstream consumer follows `merged_into`. It carried only
+                                             # @RolesAllowed(ROLE_OPERATOR, ROLE_ADMIN) + an audit event,
+                                             # which records who did it but stops nobody.
+                                             # GUARDRAIL check (the one above, applied): confirmed no M2M
+                                             # caller. party-service's own rego states party.merge "has NO
+                                             # in-repo M2M caller today"; the edge M2M identity is granted
+                                             # only {party.consent.update, party:resolve} by the rule that
+                                             # names it (service-edge-party-m2m), and the ADR-0179 sweep
+                                             # counterpart transaction.merge-sweep is already gated by the
+                                             # `sweep` verb — so both halves of the merge flow now pause
+                                             # for a second approver, or neither does.
 
     # ---------------------------------------------------------------------------------------
     # Feature-flag flip governance (ADR-0067 follow-up, issue #419). The OPA PEP (rest.rego)

--- a/openbank-infra/gitops/components/aml/aml-service.yaml
+++ b/openbank-infra/gitops/components/aml/aml-service.yaml
@@ -22,7 +22,7 @@ spec:
       annotations:
         # Rolls the pod when the OPA bundle changes (subPath mounts do not hot-reload).
         # Kept in sync by gen-aml-opa-bundle.sh (do not hand-edit).
-        openbank.tech/policy-checksum: "68ea247e63fdbe26"
+        openbank.tech/policy-checksum: "6cb0c7016a768082"
     spec:
       securityContext:
         runAsNonRoot: true

--- a/openbank-infra/gitops/components/anacredit/anacredit-opa-bundle.yaml
+++ b/openbank-infra/gitops/components/anacredit/anacredit-opa-bundle.yaml
@@ -9,7 +9,7 @@ metadata:
     app.kubernetes.io/name: anacredit-service
     app.kubernetes.io/part-of: anacredit
   annotations:
-    openbank.tech/policy-checksum: "9f23ddcca59cb371"
+    openbank.tech/policy-checksum: "45481e5301c6473f"
 data:
   rest.rego: |
     # SPDX-License-Identifier: Apache-2.0
@@ -2331,6 +2331,27 @@ data:
                                              # explicitly excludes any service-account-* principal id
                                              # (rest.rego operator-compose-message), the same exclusion
                                              # m2m-sanctions-screening uses for the opposite carve-out.
+        - party.merge                       # ADR-0179: retire a duplicate identity into a survivor
+                                             # (POST /api/v1/parties/{id}/merge). Gated HERE and not via
+                                             # `verbs` for the same structural reason opsmessage.compose
+                                             # is: party-service is not, and should not become, a
+                                             # money_path_services entry (it moves no value), so the
+                                             # verb clause can never derive a `party` scope and no verb
+                                             # addition could ever reach this action.
+                                             # Why it needs the gate at all: a merge is destructive OF
+                                             # IDENTITY and irreversible in practice — one operator can
+                                             # retire a real customer behind another party id, and every
+                                             # downstream consumer follows `merged_into`. It carried only
+                                             # @RolesAllowed(ROLE_OPERATOR, ROLE_ADMIN) + an audit event,
+                                             # which records who did it but stops nobody.
+                                             # GUARDRAIL check (the one above, applied): confirmed no M2M
+                                             # caller. party-service's own rego states party.merge "has NO
+                                             # in-repo M2M caller today"; the edge M2M identity is granted
+                                             # only {party.consent.update, party:resolve} by the rule that
+                                             # names it (service-edge-party-m2m), and the ADR-0179 sweep
+                                             # counterpart transaction.merge-sweep is already gated by the
+                                             # `sweep` verb — so both halves of the merge flow now pause
+                                             # for a second approver, or neither does.
 
     # ---------------------------------------------------------------------------------------
     # Feature-flag flip governance (ADR-0067 follow-up, issue #419). The OPA PEP (rest.rego)

--- a/openbank-infra/gitops/components/anacredit/anacredit-service.yaml
+++ b/openbank-infra/gitops/components/anacredit/anacredit-service.yaml
@@ -32,7 +32,7 @@ spec:
       annotations:
         # Rolls the pods when the OPA bundle changes — subPath mounts do NOT hot-reload.
         # Kept in sync by gen-anacredit-opa-bundle.sh (do not hand-edit).
-        openbank.tech/policy-checksum: "9f23ddcca59cb371"
+        openbank.tech/policy-checksum: "45481e5301c6473f"
     spec:
       securityContext:
         runAsNonRoot: true

--- a/openbank-infra/gitops/components/ap2/ap2-opa-bundle.yaml
+++ b/openbank-infra/gitops/components/ap2/ap2-opa-bundle.yaml
@@ -9,7 +9,7 @@ metadata:
     app.kubernetes.io/name: mcp-service
     app.kubernetes.io/part-of: platform
   annotations:
-    openbank.tech/policy-checksum: "06bc30d01eb94f43"
+    openbank.tech/policy-checksum: "f4792a0e7be976bc"
 data:
   rest.rego: |
     # SPDX-License-Identifier: Apache-2.0
@@ -2299,6 +2299,27 @@ data:
                                              # explicitly excludes any service-account-* principal id
                                              # (rest.rego operator-compose-message), the same exclusion
                                              # m2m-sanctions-screening uses for the opposite carve-out.
+        - party.merge                       # ADR-0179: retire a duplicate identity into a survivor
+                                             # (POST /api/v1/parties/{id}/merge). Gated HERE and not via
+                                             # `verbs` for the same structural reason opsmessage.compose
+                                             # is: party-service is not, and should not become, a
+                                             # money_path_services entry (it moves no value), so the
+                                             # verb clause can never derive a `party` scope and no verb
+                                             # addition could ever reach this action.
+                                             # Why it needs the gate at all: a merge is destructive OF
+                                             # IDENTITY and irreversible in practice — one operator can
+                                             # retire a real customer behind another party id, and every
+                                             # downstream consumer follows `merged_into`. It carried only
+                                             # @RolesAllowed(ROLE_OPERATOR, ROLE_ADMIN) + an audit event,
+                                             # which records who did it but stops nobody.
+                                             # GUARDRAIL check (the one above, applied): confirmed no M2M
+                                             # caller. party-service's own rego states party.merge "has NO
+                                             # in-repo M2M caller today"; the edge M2M identity is granted
+                                             # only {party.consent.update, party:resolve} by the rule that
+                                             # names it (service-edge-party-m2m), and the ADR-0179 sweep
+                                             # counterpart transaction.merge-sweep is already gated by the
+                                             # `sweep` verb — so both halves of the merge flow now pause
+                                             # for a second approver, or neither does.
 
     # ---------------------------------------------------------------------------------------
     # Feature-flag flip governance (ADR-0067 follow-up, issue #419). The OPA PEP (rest.rego)

--- a/openbank-infra/gitops/components/ap2/ap2-service.yaml
+++ b/openbank-infra/gitops/components/ap2/ap2-service.yaml
@@ -30,7 +30,7 @@ spec:
       annotations:
         # Roll the pod when the OPA policy bundle changes (subPath mounts don't hot-reload).
         # Kept in sync by gen-ap2-opa-bundle.sh (do not hand-edit).
-        openbank.tech/policy-checksum: "06bc30d01eb94f43"
+        openbank.tech/policy-checksum: "f4792a0e7be976bc"
     spec:
       securityContext:
         runAsNonRoot: true

--- a/openbank-infra/gitops/components/audit/audit-opa-bundle.yaml
+++ b/openbank-infra/gitops/components/audit/audit-opa-bundle.yaml
@@ -9,7 +9,7 @@ metadata:
     app.kubernetes.io/name: audit-service
     app.kubernetes.io/part-of: audit
   annotations:
-    openbank.tech/policy-checksum: "061d9469953d3786"
+    openbank.tech/policy-checksum: "d5af5ecf7434a843"
 data:
   rest.rego: |
     # SPDX-License-Identifier: Apache-2.0
@@ -2343,6 +2343,27 @@ data:
                                              # explicitly excludes any service-account-* principal id
                                              # (rest.rego operator-compose-message), the same exclusion
                                              # m2m-sanctions-screening uses for the opposite carve-out.
+        - party.merge                       # ADR-0179: retire a duplicate identity into a survivor
+                                             # (POST /api/v1/parties/{id}/merge). Gated HERE and not via
+                                             # `verbs` for the same structural reason opsmessage.compose
+                                             # is: party-service is not, and should not become, a
+                                             # money_path_services entry (it moves no value), so the
+                                             # verb clause can never derive a `party` scope and no verb
+                                             # addition could ever reach this action.
+                                             # Why it needs the gate at all: a merge is destructive OF
+                                             # IDENTITY and irreversible in practice — one operator can
+                                             # retire a real customer behind another party id, and every
+                                             # downstream consumer follows `merged_into`. It carried only
+                                             # @RolesAllowed(ROLE_OPERATOR, ROLE_ADMIN) + an audit event,
+                                             # which records who did it but stops nobody.
+                                             # GUARDRAIL check (the one above, applied): confirmed no M2M
+                                             # caller. party-service's own rego states party.merge "has NO
+                                             # in-repo M2M caller today"; the edge M2M identity is granted
+                                             # only {party.consent.update, party:resolve} by the rule that
+                                             # names it (service-edge-party-m2m), and the ADR-0179 sweep
+                                             # counterpart transaction.merge-sweep is already gated by the
+                                             # `sweep` verb — so both halves of the merge flow now pause
+                                             # for a second approver, or neither does.
 
     # ---------------------------------------------------------------------------------------
     # Feature-flag flip governance (ADR-0067 follow-up, issue #419). The OPA PEP (rest.rego)

--- a/openbank-infra/gitops/components/audit/audit-service.yaml
+++ b/openbank-infra/gitops/components/audit/audit-service.yaml
@@ -22,7 +22,7 @@ spec:
       annotations:
         # Rolls the pod when the OPA bundle changes (subPath mounts do not hot-reload).
         # Kept in sync by gen-audit-opa-bundle.sh (do not hand-edit).
-        openbank.tech/policy-checksum: "061d9469953d3786"
+        openbank.tech/policy-checksum: "d5af5ecf7434a843"
     spec:
       securityContext:
         runAsNonRoot: true

--- a/openbank-infra/gitops/components/balances/balance-opa-bundle.yaml
+++ b/openbank-infra/gitops/components/balances/balance-opa-bundle.yaml
@@ -9,7 +9,7 @@ metadata:
     app.kubernetes.io/name: balance-service
     app.kubernetes.io/part-of: balances
   annotations:
-    openbank.tech/policy-checksum: "024b271ab09ae5e5"
+    openbank.tech/policy-checksum: "f64375ace704a89a"
 data:
   rest.rego: |
     # SPDX-License-Identifier: Apache-2.0
@@ -2432,6 +2432,27 @@ data:
                                              # explicitly excludes any service-account-* principal id
                                              # (rest.rego operator-compose-message), the same exclusion
                                              # m2m-sanctions-screening uses for the opposite carve-out.
+        - party.merge                       # ADR-0179: retire a duplicate identity into a survivor
+                                             # (POST /api/v1/parties/{id}/merge). Gated HERE and not via
+                                             # `verbs` for the same structural reason opsmessage.compose
+                                             # is: party-service is not, and should not become, a
+                                             # money_path_services entry (it moves no value), so the
+                                             # verb clause can never derive a `party` scope and no verb
+                                             # addition could ever reach this action.
+                                             # Why it needs the gate at all: a merge is destructive OF
+                                             # IDENTITY and irreversible in practice — one operator can
+                                             # retire a real customer behind another party id, and every
+                                             # downstream consumer follows `merged_into`. It carried only
+                                             # @RolesAllowed(ROLE_OPERATOR, ROLE_ADMIN) + an audit event,
+                                             # which records who did it but stops nobody.
+                                             # GUARDRAIL check (the one above, applied): confirmed no M2M
+                                             # caller. party-service's own rego states party.merge "has NO
+                                             # in-repo M2M caller today"; the edge M2M identity is granted
+                                             # only {party.consent.update, party:resolve} by the rule that
+                                             # names it (service-edge-party-m2m), and the ADR-0179 sweep
+                                             # counterpart transaction.merge-sweep is already gated by the
+                                             # `sweep` verb — so both halves of the merge flow now pause
+                                             # for a second approver, or neither does.
 
     # ---------------------------------------------------------------------------------------
     # Feature-flag flip governance (ADR-0067 follow-up, issue #419). The OPA PEP (rest.rego)

--- a/openbank-infra/gitops/components/balances/balance-service.yaml
+++ b/openbank-infra/gitops/components/balances/balance-service.yaml
@@ -34,7 +34,7 @@ spec:
       annotations:
         # Rolls the pods when the OPA bundle changes — subPath mounts do NOT hot-reload.
         # Kept in sync by gen-balance-opa-bundle.sh (do not hand-edit).
-        openbank.tech/policy-checksum: "024b271ab09ae5e5"
+        openbank.tech/policy-checksum: "f64375ace704a89a"
     spec:
       securityContext:
         runAsNonRoot: true

--- a/openbank-infra/gitops/components/billing/billing-opa-bundle.yaml
+++ b/openbank-infra/gitops/components/billing/billing-opa-bundle.yaml
@@ -9,7 +9,7 @@ metadata:
     app.kubernetes.io/name: billing-service
     app.kubernetes.io/part-of: billing
   annotations:
-    openbank.tech/policy-checksum: "49d968954a9b0bb3"
+    openbank.tech/policy-checksum: "2df016f95213a21a"
 data:
   rest.rego: |
     # SPDX-License-Identifier: Apache-2.0
@@ -2337,6 +2337,27 @@ data:
                                              # explicitly excludes any service-account-* principal id
                                              # (rest.rego operator-compose-message), the same exclusion
                                              # m2m-sanctions-screening uses for the opposite carve-out.
+        - party.merge                       # ADR-0179: retire a duplicate identity into a survivor
+                                             # (POST /api/v1/parties/{id}/merge). Gated HERE and not via
+                                             # `verbs` for the same structural reason opsmessage.compose
+                                             # is: party-service is not, and should not become, a
+                                             # money_path_services entry (it moves no value), so the
+                                             # verb clause can never derive a `party` scope and no verb
+                                             # addition could ever reach this action.
+                                             # Why it needs the gate at all: a merge is destructive OF
+                                             # IDENTITY and irreversible in practice — one operator can
+                                             # retire a real customer behind another party id, and every
+                                             # downstream consumer follows `merged_into`. It carried only
+                                             # @RolesAllowed(ROLE_OPERATOR, ROLE_ADMIN) + an audit event,
+                                             # which records who did it but stops nobody.
+                                             # GUARDRAIL check (the one above, applied): confirmed no M2M
+                                             # caller. party-service's own rego states party.merge "has NO
+                                             # in-repo M2M caller today"; the edge M2M identity is granted
+                                             # only {party.consent.update, party:resolve} by the rule that
+                                             # names it (service-edge-party-m2m), and the ADR-0179 sweep
+                                             # counterpart transaction.merge-sweep is already gated by the
+                                             # `sweep` verb — so both halves of the merge flow now pause
+                                             # for a second approver, or neither does.
 
     # ---------------------------------------------------------------------------------------
     # Feature-flag flip governance (ADR-0067 follow-up, issue #419). The OPA PEP (rest.rego)

--- a/openbank-infra/gitops/components/billing/billing-service.yaml
+++ b/openbank-infra/gitops/components/billing/billing-service.yaml
@@ -27,7 +27,7 @@ spec:
       annotations:
         # Rolls the pods when the OPA bundle changes — subPath mounts do NOT hot-reload.
         # Kept in sync by gen-billing-opa-bundle.sh (do not hand-edit).
-        openbank.tech/policy-checksum: "49d968954a9b0bb3"
+        openbank.tech/policy-checksum: "2df016f95213a21a"
     spec:
       securityContext:
         runAsNonRoot: true

--- a/openbank-infra/gitops/components/consent/consent-opa-bundle.yaml
+++ b/openbank-infra/gitops/components/consent/consent-opa-bundle.yaml
@@ -9,7 +9,7 @@ metadata:
     app.kubernetes.io/name: consent-service
     app.kubernetes.io/part-of: consent
   annotations:
-    openbank.tech/policy-checksum: "a23f19cfe418d6aa"
+    openbank.tech/policy-checksum: "b594be4514c227ad"
 data:
   rest.rego: |
     # SPDX-License-Identifier: Apache-2.0
@@ -2407,6 +2407,27 @@ data:
                                              # explicitly excludes any service-account-* principal id
                                              # (rest.rego operator-compose-message), the same exclusion
                                              # m2m-sanctions-screening uses for the opposite carve-out.
+        - party.merge                       # ADR-0179: retire a duplicate identity into a survivor
+                                             # (POST /api/v1/parties/{id}/merge). Gated HERE and not via
+                                             # `verbs` for the same structural reason opsmessage.compose
+                                             # is: party-service is not, and should not become, a
+                                             # money_path_services entry (it moves no value), so the
+                                             # verb clause can never derive a `party` scope and no verb
+                                             # addition could ever reach this action.
+                                             # Why it needs the gate at all: a merge is destructive OF
+                                             # IDENTITY and irreversible in practice — one operator can
+                                             # retire a real customer behind another party id, and every
+                                             # downstream consumer follows `merged_into`. It carried only
+                                             # @RolesAllowed(ROLE_OPERATOR, ROLE_ADMIN) + an audit event,
+                                             # which records who did it but stops nobody.
+                                             # GUARDRAIL check (the one above, applied): confirmed no M2M
+                                             # caller. party-service's own rego states party.merge "has NO
+                                             # in-repo M2M caller today"; the edge M2M identity is granted
+                                             # only {party.consent.update, party:resolve} by the rule that
+                                             # names it (service-edge-party-m2m), and the ADR-0179 sweep
+                                             # counterpart transaction.merge-sweep is already gated by the
+                                             # `sweep` verb — so both halves of the merge flow now pause
+                                             # for a second approver, or neither does.
 
     # ---------------------------------------------------------------------------------------
     # Feature-flag flip governance (ADR-0067 follow-up, issue #419). The OPA PEP (rest.rego)

--- a/openbank-infra/gitops/components/consent/consent-service.yaml
+++ b/openbank-infra/gitops/components/consent/consent-service.yaml
@@ -28,7 +28,7 @@ spec:
       annotations:
         # Rolls the pods when the OPA bundle changes — subPath mounts do NOT hot-reload.
         # Kept in sync by gen-consent-opa-bundle.sh (do not hand-edit).
-        openbank.tech/policy-checksum: "a23f19cfe418d6aa"
+        openbank.tech/policy-checksum: "b594be4514c227ad"
     spec:
       securityContext:
         runAsNonRoot: true

--- a/openbank-infra/gitops/components/copilot/copilot-opa-bundle.yaml
+++ b/openbank-infra/gitops/components/copilot/copilot-opa-bundle.yaml
@@ -9,7 +9,7 @@ metadata:
     app.kubernetes.io/name: copilot-service
     app.kubernetes.io/part-of: platform
   annotations:
-    openbank.tech/policy-checksum: "949a2ebce1c60518"
+    openbank.tech/policy-checksum: "3bf38c46d9360b87"
 data:
   rest.rego: |
     # SPDX-License-Identifier: Apache-2.0
@@ -2423,6 +2423,27 @@ data:
                                              # explicitly excludes any service-account-* principal id
                                              # (rest.rego operator-compose-message), the same exclusion
                                              # m2m-sanctions-screening uses for the opposite carve-out.
+        - party.merge                       # ADR-0179: retire a duplicate identity into a survivor
+                                             # (POST /api/v1/parties/{id}/merge). Gated HERE and not via
+                                             # `verbs` for the same structural reason opsmessage.compose
+                                             # is: party-service is not, and should not become, a
+                                             # money_path_services entry (it moves no value), so the
+                                             # verb clause can never derive a `party` scope and no verb
+                                             # addition could ever reach this action.
+                                             # Why it needs the gate at all: a merge is destructive OF
+                                             # IDENTITY and irreversible in practice — one operator can
+                                             # retire a real customer behind another party id, and every
+                                             # downstream consumer follows `merged_into`. It carried only
+                                             # @RolesAllowed(ROLE_OPERATOR, ROLE_ADMIN) + an audit event,
+                                             # which records who did it but stops nobody.
+                                             # GUARDRAIL check (the one above, applied): confirmed no M2M
+                                             # caller. party-service's own rego states party.merge "has NO
+                                             # in-repo M2M caller today"; the edge M2M identity is granted
+                                             # only {party.consent.update, party:resolve} by the rule that
+                                             # names it (service-edge-party-m2m), and the ADR-0179 sweep
+                                             # counterpart transaction.merge-sweep is already gated by the
+                                             # `sweep` verb — so both halves of the merge flow now pause
+                                             # for a second approver, or neither does.
 
     # ---------------------------------------------------------------------------------------
     # Feature-flag flip governance (ADR-0067 follow-up, issue #419). The OPA PEP (rest.rego)

--- a/openbank-infra/gitops/components/copilot/copilot-service.yaml
+++ b/openbank-infra/gitops/components/copilot/copilot-service.yaml
@@ -29,7 +29,7 @@ spec:
       annotations:
         # Rolls the pod when the OPA bundle changes — subPath mounts do NOT hot-reload.
         # Kept in sync by gen-copilot-opa-bundle.sh (do not hand-edit).
-        openbank.tech/policy-checksum: "949a2ebce1c60518"
+        openbank.tech/policy-checksum: "3bf38c46d9360b87"
     spec:
       securityContext:
         runAsNonRoot: true

--- a/openbank-infra/gitops/components/customer-edge/customer-edge-opa-bundle.yaml
+++ b/openbank-infra/gitops/components/customer-edge/customer-edge-opa-bundle.yaml
@@ -10,7 +10,7 @@ metadata:
     app.kubernetes.io/name: customer-edge
     app.kubernetes.io/part-of: customer-edge
   annotations:
-    openbank.tech/policy-checksum: "25a0a077f15b7fe6"
+    openbank.tech/policy-checksum: "0ea667217d38e962"
 data:
   rest.rego: |
     # SPDX-License-Identifier: Apache-2.0
@@ -1522,6 +1522,27 @@ data:
                                              # explicitly excludes any service-account-* principal id
                                              # (rest.rego operator-compose-message), the same exclusion
                                              # m2m-sanctions-screening uses for the opposite carve-out.
+        - party.merge                       # ADR-0179: retire a duplicate identity into a survivor
+                                             # (POST /api/v1/parties/{id}/merge). Gated HERE and not via
+                                             # `verbs` for the same structural reason opsmessage.compose
+                                             # is: party-service is not, and should not become, a
+                                             # money_path_services entry (it moves no value), so the
+                                             # verb clause can never derive a `party` scope and no verb
+                                             # addition could ever reach this action.
+                                             # Why it needs the gate at all: a merge is destructive OF
+                                             # IDENTITY and irreversible in practice — one operator can
+                                             # retire a real customer behind another party id, and every
+                                             # downstream consumer follows `merged_into`. It carried only
+                                             # @RolesAllowed(ROLE_OPERATOR, ROLE_ADMIN) + an audit event,
+                                             # which records who did it but stops nobody.
+                                             # GUARDRAIL check (the one above, applied): confirmed no M2M
+                                             # caller. party-service's own rego states party.merge "has NO
+                                             # in-repo M2M caller today"; the edge M2M identity is granted
+                                             # only {party.consent.update, party:resolve} by the rule that
+                                             # names it (service-edge-party-m2m), and the ADR-0179 sweep
+                                             # counterpart transaction.merge-sweep is already gated by the
+                                             # `sweep` verb — so both halves of the merge flow now pause
+                                             # for a second approver, or neither does.
 
     # ---------------------------------------------------------------------------------------
     # Feature-flag flip governance (ADR-0067 follow-up, issue #419). The OPA PEP (rest.rego)

--- a/openbank-infra/gitops/components/customer-edge/customer-edge.yaml
+++ b/openbank-infra/gitops/components/customer-edge/customer-edge.yaml
@@ -65,7 +65,7 @@ spec:
       annotations:
         # Rolls the pod when the OPA bundle changes — subPath mounts do NOT hot-reload.
         # Kept in sync by gen-customer-edge-opa-bundle.sh (do not hand-edit).
-        openbank.tech/policy-checksum: "25a0a077f15b7fe6"
+        openbank.tech/policy-checksum: "0ea667217d38e962"
     spec:
       # Dedicated SA so EKS Pod Identity can hand the edge (and ONLY the edge) the
       # feedback-screenshots S3 role — ADR-0192, openbank-infra/aws/envs/sandbox-platform/

--- a/openbank-infra/gitops/components/dispute-service/dispute-opa-bundle.yaml
+++ b/openbank-infra/gitops/components/dispute-service/dispute-opa-bundle.yaml
@@ -9,7 +9,7 @@ metadata:
     app.kubernetes.io/name: dispute-service
     app.kubernetes.io/part-of: dispute
   annotations:
-    openbank.tech/policy-checksum: "5fb193392b935695"
+    openbank.tech/policy-checksum: "d23d2c4c33797246"
 data:
   rest.rego: |
     # SPDX-License-Identifier: Apache-2.0
@@ -2473,6 +2473,27 @@ data:
                                              # explicitly excludes any service-account-* principal id
                                              # (rest.rego operator-compose-message), the same exclusion
                                              # m2m-sanctions-screening uses for the opposite carve-out.
+        - party.merge                       # ADR-0179: retire a duplicate identity into a survivor
+                                             # (POST /api/v1/parties/{id}/merge). Gated HERE and not via
+                                             # `verbs` for the same structural reason opsmessage.compose
+                                             # is: party-service is not, and should not become, a
+                                             # money_path_services entry (it moves no value), so the
+                                             # verb clause can never derive a `party` scope and no verb
+                                             # addition could ever reach this action.
+                                             # Why it needs the gate at all: a merge is destructive OF
+                                             # IDENTITY and irreversible in practice — one operator can
+                                             # retire a real customer behind another party id, and every
+                                             # downstream consumer follows `merged_into`. It carried only
+                                             # @RolesAllowed(ROLE_OPERATOR, ROLE_ADMIN) + an audit event,
+                                             # which records who did it but stops nobody.
+                                             # GUARDRAIL check (the one above, applied): confirmed no M2M
+                                             # caller. party-service's own rego states party.merge "has NO
+                                             # in-repo M2M caller today"; the edge M2M identity is granted
+                                             # only {party.consent.update, party:resolve} by the rule that
+                                             # names it (service-edge-party-m2m), and the ADR-0179 sweep
+                                             # counterpart transaction.merge-sweep is already gated by the
+                                             # `sweep` verb — so both halves of the merge flow now pause
+                                             # for a second approver, or neither does.
 
     # ---------------------------------------------------------------------------------------
     # Feature-flag flip governance (ADR-0067 follow-up, issue #419). The OPA PEP (rest.rego)

--- a/openbank-infra/gitops/components/dispute-service/dispute-service.yaml
+++ b/openbank-infra/gitops/components/dispute-service/dispute-service.yaml
@@ -15,7 +15,7 @@ spec:
       annotations:
         # Rolls the pod when the OPA bundle changes — subPath mounts do NOT hot-reload.
         # Kept in sync by gen-dispute-opa-bundle.sh (do not hand-edit).
-        openbank.tech/policy-checksum: "5fb193392b935695"
+        openbank.tech/policy-checksum: "d23d2c4c33797246"
       labels: {app.kubernetes.io/name: dispute-service, app.kubernetes.io/part-of: dispute}
     spec:
       securityContext:

--- a/openbank-infra/gitops/components/document-service/document-service-opa-bundle.yaml
+++ b/openbank-infra/gitops/components/document-service/document-service-opa-bundle.yaml
@@ -10,7 +10,7 @@ metadata:
     app.kubernetes.io/name: document-service
     app.kubernetes.io/part-of: documents
   annotations:
-    openbank.tech/policy-checksum: "25a0a077f15b7fe6"
+    openbank.tech/policy-checksum: "0ea667217d38e962"
 data:
   rest.rego: |
     # SPDX-License-Identifier: Apache-2.0
@@ -1522,6 +1522,27 @@ data:
                                              # explicitly excludes any service-account-* principal id
                                              # (rest.rego operator-compose-message), the same exclusion
                                              # m2m-sanctions-screening uses for the opposite carve-out.
+        - party.merge                       # ADR-0179: retire a duplicate identity into a survivor
+                                             # (POST /api/v1/parties/{id}/merge). Gated HERE and not via
+                                             # `verbs` for the same structural reason opsmessage.compose
+                                             # is: party-service is not, and should not become, a
+                                             # money_path_services entry (it moves no value), so the
+                                             # verb clause can never derive a `party` scope and no verb
+                                             # addition could ever reach this action.
+                                             # Why it needs the gate at all: a merge is destructive OF
+                                             # IDENTITY and irreversible in practice — one operator can
+                                             # retire a real customer behind another party id, and every
+                                             # downstream consumer follows `merged_into`. It carried only
+                                             # @RolesAllowed(ROLE_OPERATOR, ROLE_ADMIN) + an audit event,
+                                             # which records who did it but stops nobody.
+                                             # GUARDRAIL check (the one above, applied): confirmed no M2M
+                                             # caller. party-service's own rego states party.merge "has NO
+                                             # in-repo M2M caller today"; the edge M2M identity is granted
+                                             # only {party.consent.update, party:resolve} by the rule that
+                                             # names it (service-edge-party-m2m), and the ADR-0179 sweep
+                                             # counterpart transaction.merge-sweep is already gated by the
+                                             # `sweep` verb — so both halves of the merge flow now pause
+                                             # for a second approver, or neither does.
 
     # ---------------------------------------------------------------------------------------
     # Feature-flag flip governance (ADR-0067 follow-up, issue #419). The OPA PEP (rest.rego)

--- a/openbank-infra/gitops/components/document-service/document-service-service.yaml
+++ b/openbank-infra/gitops/components/document-service/document-service-service.yaml
@@ -43,7 +43,7 @@ spec:
       annotations:
         # Rolls the pods when the OPA bundle changes — subPath mounts do NOT hot-reload.
         # Kept in sync by gen-document-service-opa-bundle.sh (do not hand-edit).
-        openbank.tech/policy-checksum: "25a0a077f15b7fe6"
+        openbank.tech/policy-checksum: "0ea667217d38e962"
     spec:
       # ADR-0162 D4 (continued): a dedicated SA (not `default`) is what OpenBao's Kubernetes-auth
       # role `document-service-signing` is bound to — least-privilege, one identity per consumer.

--- a/openbank-infra/gitops/components/fraud-service/fraud-opa-bundle.yaml
+++ b/openbank-infra/gitops/components/fraud-service/fraud-opa-bundle.yaml
@@ -9,7 +9,7 @@ metadata:
     app.kubernetes.io/name: fraud-service
     app.kubernetes.io/part-of: fraud
   annotations:
-    openbank.tech/policy-checksum: "b18a4fc96c97a980"
+    openbank.tech/policy-checksum: "41d1042aa0cfb9b8"
 data:
   rest.rego: |
     # SPDX-License-Identifier: Apache-2.0
@@ -2348,6 +2348,27 @@ data:
                                              # explicitly excludes any service-account-* principal id
                                              # (rest.rego operator-compose-message), the same exclusion
                                              # m2m-sanctions-screening uses for the opposite carve-out.
+        - party.merge                       # ADR-0179: retire a duplicate identity into a survivor
+                                             # (POST /api/v1/parties/{id}/merge). Gated HERE and not via
+                                             # `verbs` for the same structural reason opsmessage.compose
+                                             # is: party-service is not, and should not become, a
+                                             # money_path_services entry (it moves no value), so the
+                                             # verb clause can never derive a `party` scope and no verb
+                                             # addition could ever reach this action.
+                                             # Why it needs the gate at all: a merge is destructive OF
+                                             # IDENTITY and irreversible in practice — one operator can
+                                             # retire a real customer behind another party id, and every
+                                             # downstream consumer follows `merged_into`. It carried only
+                                             # @RolesAllowed(ROLE_OPERATOR, ROLE_ADMIN) + an audit event,
+                                             # which records who did it but stops nobody.
+                                             # GUARDRAIL check (the one above, applied): confirmed no M2M
+                                             # caller. party-service's own rego states party.merge "has NO
+                                             # in-repo M2M caller today"; the edge M2M identity is granted
+                                             # only {party.consent.update, party:resolve} by the rule that
+                                             # names it (service-edge-party-m2m), and the ADR-0179 sweep
+                                             # counterpart transaction.merge-sweep is already gated by the
+                                             # `sweep` verb — so both halves of the merge flow now pause
+                                             # for a second approver, or neither does.
 
     # ---------------------------------------------------------------------------------------
     # Feature-flag flip governance (ADR-0067 follow-up, issue #419). The OPA PEP (rest.rego)

--- a/openbank-infra/gitops/components/fraud-service/fraud-service.yaml
+++ b/openbank-infra/gitops/components/fraud-service/fraud-service.yaml
@@ -23,7 +23,7 @@ spec:
       annotations:
         # Rolls the pods when the OPA bundle changes — subPath mounts do NOT hot-reload.
         # Kept in sync by gen-fraud-opa-bundle.sh (do not hand-edit).
-        openbank.tech/policy-checksum: "b18a4fc96c97a980"
+        openbank.tech/policy-checksum: "41d1042aa0cfb9b8"
     spec:
       securityContext:
         runAsNonRoot: true

--- a/openbank-infra/gitops/components/fx-service/fx-opa-bundle.yaml
+++ b/openbank-infra/gitops/components/fx-service/fx-opa-bundle.yaml
@@ -9,7 +9,7 @@ metadata:
     app.kubernetes.io/name: fx-service
     app.kubernetes.io/part-of: fx
   annotations:
-    openbank.tech/policy-checksum: "775b23c45ba27342"
+    openbank.tech/policy-checksum: "d77b29cc75768c1c"
 data:
   rest.rego: |
     # SPDX-License-Identifier: Apache-2.0
@@ -2399,6 +2399,27 @@ data:
                                              # explicitly excludes any service-account-* principal id
                                              # (rest.rego operator-compose-message), the same exclusion
                                              # m2m-sanctions-screening uses for the opposite carve-out.
+        - party.merge                       # ADR-0179: retire a duplicate identity into a survivor
+                                             # (POST /api/v1/parties/{id}/merge). Gated HERE and not via
+                                             # `verbs` for the same structural reason opsmessage.compose
+                                             # is: party-service is not, and should not become, a
+                                             # money_path_services entry (it moves no value), so the
+                                             # verb clause can never derive a `party` scope and no verb
+                                             # addition could ever reach this action.
+                                             # Why it needs the gate at all: a merge is destructive OF
+                                             # IDENTITY and irreversible in practice — one operator can
+                                             # retire a real customer behind another party id, and every
+                                             # downstream consumer follows `merged_into`. It carried only
+                                             # @RolesAllowed(ROLE_OPERATOR, ROLE_ADMIN) + an audit event,
+                                             # which records who did it but stops nobody.
+                                             # GUARDRAIL check (the one above, applied): confirmed no M2M
+                                             # caller. party-service's own rego states party.merge "has NO
+                                             # in-repo M2M caller today"; the edge M2M identity is granted
+                                             # only {party.consent.update, party:resolve} by the rule that
+                                             # names it (service-edge-party-m2m), and the ADR-0179 sweep
+                                             # counterpart transaction.merge-sweep is already gated by the
+                                             # `sweep` verb — so both halves of the merge flow now pause
+                                             # for a second approver, or neither does.
 
     # ---------------------------------------------------------------------------------------
     # Feature-flag flip governance (ADR-0067 follow-up, issue #419). The OPA PEP (rest.rego)

--- a/openbank-infra/gitops/components/fx-service/fx-service.yaml
+++ b/openbank-infra/gitops/components/fx-service/fx-service.yaml
@@ -22,7 +22,7 @@ spec:
       annotations:
         # Rolls the pods when the OPA bundle changes — subPath mounts do NOT hot-reload.
         # Kept in sync by gen-fx-opa-bundle.sh (do not hand-edit).
-        openbank.tech/policy-checksum: "775b23c45ba27342"
+        openbank.tech/policy-checksum: "d77b29cc75768c1c"
     spec:
       securityContext:
         runAsNonRoot: true

--- a/openbank-infra/gitops/components/interest-service/interest-opa-bundle.yaml
+++ b/openbank-infra/gitops/components/interest-service/interest-opa-bundle.yaml
@@ -9,7 +9,7 @@ metadata:
     app.kubernetes.io/name: interest-service
     app.kubernetes.io/part-of: interest
   annotations:
-    openbank.tech/policy-checksum: "f9d2ebaecf995097"
+    openbank.tech/policy-checksum: "79033f0ebac05d6b"
 data:
   rest.rego: |
     # SPDX-License-Identifier: Apache-2.0
@@ -2333,6 +2333,27 @@ data:
                                              # explicitly excludes any service-account-* principal id
                                              # (rest.rego operator-compose-message), the same exclusion
                                              # m2m-sanctions-screening uses for the opposite carve-out.
+        - party.merge                       # ADR-0179: retire a duplicate identity into a survivor
+                                             # (POST /api/v1/parties/{id}/merge). Gated HERE and not via
+                                             # `verbs` for the same structural reason opsmessage.compose
+                                             # is: party-service is not, and should not become, a
+                                             # money_path_services entry (it moves no value), so the
+                                             # verb clause can never derive a `party` scope and no verb
+                                             # addition could ever reach this action.
+                                             # Why it needs the gate at all: a merge is destructive OF
+                                             # IDENTITY and irreversible in practice — one operator can
+                                             # retire a real customer behind another party id, and every
+                                             # downstream consumer follows `merged_into`. It carried only
+                                             # @RolesAllowed(ROLE_OPERATOR, ROLE_ADMIN) + an audit event,
+                                             # which records who did it but stops nobody.
+                                             # GUARDRAIL check (the one above, applied): confirmed no M2M
+                                             # caller. party-service's own rego states party.merge "has NO
+                                             # in-repo M2M caller today"; the edge M2M identity is granted
+                                             # only {party.consent.update, party:resolve} by the rule that
+                                             # names it (service-edge-party-m2m), and the ADR-0179 sweep
+                                             # counterpart transaction.merge-sweep is already gated by the
+                                             # `sweep` verb — so both halves of the merge flow now pause
+                                             # for a second approver, or neither does.
 
     # ---------------------------------------------------------------------------------------
     # Feature-flag flip governance (ADR-0067 follow-up, issue #419). The OPA PEP (rest.rego)

--- a/openbank-infra/gitops/components/interest-service/interest-service.yaml
+++ b/openbank-infra/gitops/components/interest-service/interest-service.yaml
@@ -16,7 +16,7 @@ spec:
       annotations:
         # Rolls the pods when the OPA bundle changes — subPath mounts do NOT hot-reload.
         # Kept in sync by gen-interest-opa-bundle.sh (do not hand-edit).
-        openbank.tech/policy-checksum: "f9d2ebaecf995097"
+        openbank.tech/policy-checksum: "79033f0ebac05d6b"
     spec:
       securityContext:
         runAsNonRoot: true

--- a/openbank-infra/gitops/components/kyc/kyc-opa-bundle.yaml
+++ b/openbank-infra/gitops/components/kyc/kyc-opa-bundle.yaml
@@ -9,7 +9,7 @@ metadata:
     app.kubernetes.io/name: kyc-service
     app.kubernetes.io/part-of: kyc
   annotations:
-    openbank.tech/policy-checksum: "c52743f5d69de91c"
+    openbank.tech/policy-checksum: "762499115e5c24ad"
 data:
   rest.rego: |
     # SPDX-License-Identifier: Apache-2.0
@@ -2361,6 +2361,27 @@ data:
                                              # explicitly excludes any service-account-* principal id
                                              # (rest.rego operator-compose-message), the same exclusion
                                              # m2m-sanctions-screening uses for the opposite carve-out.
+        - party.merge                       # ADR-0179: retire a duplicate identity into a survivor
+                                             # (POST /api/v1/parties/{id}/merge). Gated HERE and not via
+                                             # `verbs` for the same structural reason opsmessage.compose
+                                             # is: party-service is not, and should not become, a
+                                             # money_path_services entry (it moves no value), so the
+                                             # verb clause can never derive a `party` scope and no verb
+                                             # addition could ever reach this action.
+                                             # Why it needs the gate at all: a merge is destructive OF
+                                             # IDENTITY and irreversible in practice — one operator can
+                                             # retire a real customer behind another party id, and every
+                                             # downstream consumer follows `merged_into`. It carried only
+                                             # @RolesAllowed(ROLE_OPERATOR, ROLE_ADMIN) + an audit event,
+                                             # which records who did it but stops nobody.
+                                             # GUARDRAIL check (the one above, applied): confirmed no M2M
+                                             # caller. party-service's own rego states party.merge "has NO
+                                             # in-repo M2M caller today"; the edge M2M identity is granted
+                                             # only {party.consent.update, party:resolve} by the rule that
+                                             # names it (service-edge-party-m2m), and the ADR-0179 sweep
+                                             # counterpart transaction.merge-sweep is already gated by the
+                                             # `sweep` verb — so both halves of the merge flow now pause
+                                             # for a second approver, or neither does.
 
     # ---------------------------------------------------------------------------------------
     # Feature-flag flip governance (ADR-0067 follow-up, issue #419). The OPA PEP (rest.rego)

--- a/openbank-infra/gitops/components/kyc/kyc-service.yaml
+++ b/openbank-infra/gitops/components/kyc/kyc-service.yaml
@@ -48,7 +48,7 @@ spec:
       annotations:
         # Rolls the pod when the OPA bundle changes (subPath mounts do not hot-reload).
         # Kept in sync by gen-kyc-opa-bundle.sh (do not hand-edit).
-        openbank.tech/policy-checksum: "c52743f5d69de91c"
+        openbank.tech/policy-checksum: "762499115e5c24ad"
     spec:
       securityContext:
         runAsNonRoot: true

--- a/openbank-infra/gitops/components/ledger/ledger-opa-bundle.yaml
+++ b/openbank-infra/gitops/components/ledger/ledger-opa-bundle.yaml
@@ -9,7 +9,7 @@ metadata:
     app.kubernetes.io/name: ledger-service
     app.kubernetes.io/part-of: ledger
   annotations:
-    openbank.tech/policy-checksum: "f7cfc9b7dbdd7485"
+    openbank.tech/policy-checksum: "1e641d8aaa0d9350"
 data:
   rest.rego: |
     # SPDX-License-Identifier: Apache-2.0
@@ -2446,6 +2446,27 @@ data:
                                              # explicitly excludes any service-account-* principal id
                                              # (rest.rego operator-compose-message), the same exclusion
                                              # m2m-sanctions-screening uses for the opposite carve-out.
+        - party.merge                       # ADR-0179: retire a duplicate identity into a survivor
+                                             # (POST /api/v1/parties/{id}/merge). Gated HERE and not via
+                                             # `verbs` for the same structural reason opsmessage.compose
+                                             # is: party-service is not, and should not become, a
+                                             # money_path_services entry (it moves no value), so the
+                                             # verb clause can never derive a `party` scope and no verb
+                                             # addition could ever reach this action.
+                                             # Why it needs the gate at all: a merge is destructive OF
+                                             # IDENTITY and irreversible in practice — one operator can
+                                             # retire a real customer behind another party id, and every
+                                             # downstream consumer follows `merged_into`. It carried only
+                                             # @RolesAllowed(ROLE_OPERATOR, ROLE_ADMIN) + an audit event,
+                                             # which records who did it but stops nobody.
+                                             # GUARDRAIL check (the one above, applied): confirmed no M2M
+                                             # caller. party-service's own rego states party.merge "has NO
+                                             # in-repo M2M caller today"; the edge M2M identity is granted
+                                             # only {party.consent.update, party:resolve} by the rule that
+                                             # names it (service-edge-party-m2m), and the ADR-0179 sweep
+                                             # counterpart transaction.merge-sweep is already gated by the
+                                             # `sweep` verb — so both halves of the merge flow now pause
+                                             # for a second approver, or neither does.
 
     # ---------------------------------------------------------------------------------------
     # Feature-flag flip governance (ADR-0067 follow-up, issue #419). The OPA PEP (rest.rego)

--- a/openbank-infra/gitops/components/ledger/ledger-service.yaml
+++ b/openbank-infra/gitops/components/ledger/ledger-service.yaml
@@ -38,7 +38,7 @@ spec:
       annotations:
         # Rolls the pods when the OPA bundle changes — subPath mounts do NOT hot-reload.
         # Kept in sync by gen-ledger-opa-bundle.sh (do not hand-edit).
-        openbank.tech/policy-checksum: "f7cfc9b7dbdd7485"
+        openbank.tech/policy-checksum: "1e641d8aaa0d9350"
     spec:
       securityContext:
         runAsNonRoot: true

--- a/openbank-infra/gitops/components/lending/lending-opa-bundle.yaml
+++ b/openbank-infra/gitops/components/lending/lending-opa-bundle.yaml
@@ -9,7 +9,7 @@ metadata:
     app.kubernetes.io/name: lending-service
     app.kubernetes.io/part-of: lending
   annotations:
-    openbank.tech/policy-checksum: "66e18b30eebb53c9"
+    openbank.tech/policy-checksum: "536b7b077385c64c"
 data:
   rest.rego: |
     # SPDX-License-Identifier: Apache-2.0
@@ -2401,6 +2401,27 @@ data:
                                              # explicitly excludes any service-account-* principal id
                                              # (rest.rego operator-compose-message), the same exclusion
                                              # m2m-sanctions-screening uses for the opposite carve-out.
+        - party.merge                       # ADR-0179: retire a duplicate identity into a survivor
+                                             # (POST /api/v1/parties/{id}/merge). Gated HERE and not via
+                                             # `verbs` for the same structural reason opsmessage.compose
+                                             # is: party-service is not, and should not become, a
+                                             # money_path_services entry (it moves no value), so the
+                                             # verb clause can never derive a `party` scope and no verb
+                                             # addition could ever reach this action.
+                                             # Why it needs the gate at all: a merge is destructive OF
+                                             # IDENTITY and irreversible in practice — one operator can
+                                             # retire a real customer behind another party id, and every
+                                             # downstream consumer follows `merged_into`. It carried only
+                                             # @RolesAllowed(ROLE_OPERATOR, ROLE_ADMIN) + an audit event,
+                                             # which records who did it but stops nobody.
+                                             # GUARDRAIL check (the one above, applied): confirmed no M2M
+                                             # caller. party-service's own rego states party.merge "has NO
+                                             # in-repo M2M caller today"; the edge M2M identity is granted
+                                             # only {party.consent.update, party:resolve} by the rule that
+                                             # names it (service-edge-party-m2m), and the ADR-0179 sweep
+                                             # counterpart transaction.merge-sweep is already gated by the
+                                             # `sweep` verb — so both halves of the merge flow now pause
+                                             # for a second approver, or neither does.
 
     # ---------------------------------------------------------------------------------------
     # Feature-flag flip governance (ADR-0067 follow-up, issue #419). The OPA PEP (rest.rego)

--- a/openbank-infra/gitops/components/lending/lending-service.yaml
+++ b/openbank-infra/gitops/components/lending/lending-service.yaml
@@ -34,7 +34,7 @@ spec:
       annotations:
         # Rolls the pods when the OPA bundle changes — subPath mounts do NOT hot-reload.
         # Kept in sync by gen-lending-opa-bundle.sh (do not hand-edit).
-        openbank.tech/policy-checksum: "66e18b30eebb53c9"
+        openbank.tech/policy-checksum: "536b7b077385c64c"
     spec:
       securityContext:
         runAsNonRoot: true

--- a/openbank-infra/gitops/components/mcp/mcp-opa-bundle.yaml
+++ b/openbank-infra/gitops/components/mcp/mcp-opa-bundle.yaml
@@ -9,7 +9,7 @@ metadata:
     app.kubernetes.io/name: mcp-service
     app.kubernetes.io/part-of: platform
   annotations:
-    openbank.tech/policy-checksum: "06bc30d01eb94f43"
+    openbank.tech/policy-checksum: "f4792a0e7be976bc"
 data:
   rest.rego: |
     # SPDX-License-Identifier: Apache-2.0
@@ -2299,6 +2299,27 @@ data:
                                              # explicitly excludes any service-account-* principal id
                                              # (rest.rego operator-compose-message), the same exclusion
                                              # m2m-sanctions-screening uses for the opposite carve-out.
+        - party.merge                       # ADR-0179: retire a duplicate identity into a survivor
+                                             # (POST /api/v1/parties/{id}/merge). Gated HERE and not via
+                                             # `verbs` for the same structural reason opsmessage.compose
+                                             # is: party-service is not, and should not become, a
+                                             # money_path_services entry (it moves no value), so the
+                                             # verb clause can never derive a `party` scope and no verb
+                                             # addition could ever reach this action.
+                                             # Why it needs the gate at all: a merge is destructive OF
+                                             # IDENTITY and irreversible in practice — one operator can
+                                             # retire a real customer behind another party id, and every
+                                             # downstream consumer follows `merged_into`. It carried only
+                                             # @RolesAllowed(ROLE_OPERATOR, ROLE_ADMIN) + an audit event,
+                                             # which records who did it but stops nobody.
+                                             # GUARDRAIL check (the one above, applied): confirmed no M2M
+                                             # caller. party-service's own rego states party.merge "has NO
+                                             # in-repo M2M caller today"; the edge M2M identity is granted
+                                             # only {party.consent.update, party:resolve} by the rule that
+                                             # names it (service-edge-party-m2m), and the ADR-0179 sweep
+                                             # counterpart transaction.merge-sweep is already gated by the
+                                             # `sweep` verb — so both halves of the merge flow now pause
+                                             # for a second approver, or neither does.
 
     # ---------------------------------------------------------------------------------------
     # Feature-flag flip governance (ADR-0067 follow-up, issue #419). The OPA PEP (rest.rego)

--- a/openbank-infra/gitops/components/mcp/mcp-service.yaml
+++ b/openbank-infra/gitops/components/mcp/mcp-service.yaml
@@ -29,7 +29,7 @@ spec:
       annotations:
         # Rolls the pod when the OPA bundle changes — subPath mounts do NOT hot-reload.
         # Kept in sync by gen-mcp-opa-bundle.sh (do not hand-edit).
-        openbank.tech/policy-checksum: "06bc30d01eb94f43"
+        openbank.tech/policy-checksum: "f4792a0e7be976bc"
     spec:
       securityContext:
         runAsNonRoot: true

--- a/openbank-infra/gitops/components/notifications/notification-service-opa-bundle.yaml
+++ b/openbank-infra/gitops/components/notifications/notification-service-opa-bundle.yaml
@@ -10,7 +10,7 @@ metadata:
     app.kubernetes.io/name: notification-service
     app.kubernetes.io/part-of: notifications
   annotations:
-    openbank.tech/policy-checksum: "25a0a077f15b7fe6"
+    openbank.tech/policy-checksum: "0ea667217d38e962"
 data:
   rest.rego: |
     # SPDX-License-Identifier: Apache-2.0
@@ -1522,6 +1522,27 @@ data:
                                              # explicitly excludes any service-account-* principal id
                                              # (rest.rego operator-compose-message), the same exclusion
                                              # m2m-sanctions-screening uses for the opposite carve-out.
+        - party.merge                       # ADR-0179: retire a duplicate identity into a survivor
+                                             # (POST /api/v1/parties/{id}/merge). Gated HERE and not via
+                                             # `verbs` for the same structural reason opsmessage.compose
+                                             # is: party-service is not, and should not become, a
+                                             # money_path_services entry (it moves no value), so the
+                                             # verb clause can never derive a `party` scope and no verb
+                                             # addition could ever reach this action.
+                                             # Why it needs the gate at all: a merge is destructive OF
+                                             # IDENTITY and irreversible in practice — one operator can
+                                             # retire a real customer behind another party id, and every
+                                             # downstream consumer follows `merged_into`. It carried only
+                                             # @RolesAllowed(ROLE_OPERATOR, ROLE_ADMIN) + an audit event,
+                                             # which records who did it but stops nobody.
+                                             # GUARDRAIL check (the one above, applied): confirmed no M2M
+                                             # caller. party-service's own rego states party.merge "has NO
+                                             # in-repo M2M caller today"; the edge M2M identity is granted
+                                             # only {party.consent.update, party:resolve} by the rule that
+                                             # names it (service-edge-party-m2m), and the ADR-0179 sweep
+                                             # counterpart transaction.merge-sweep is already gated by the
+                                             # `sweep` verb — so both halves of the merge flow now pause
+                                             # for a second approver, or neither does.
 
     # ---------------------------------------------------------------------------------------
     # Feature-flag flip governance (ADR-0067 follow-up, issue #419). The OPA PEP (rest.rego)

--- a/openbank-infra/gitops/components/notifications/notification-service.yaml
+++ b/openbank-infra/gitops/components/notifications/notification-service.yaml
@@ -39,7 +39,7 @@ spec:
       annotations:
         # Rolls the Deployment when the OPA policy bundle changes (subPath mounts don't
         # hot-reload). Kept in sync by gen-notification-opa-bundle.sh.
-        openbank.tech/policy-checksum: "25a0a077f15b7fe6"
+        openbank.tech/policy-checksum: "0ea667217d38e962"
       labels:
         app.kubernetes.io/name: notification-service
         app.kubernetes.io/part-of: notifications

--- a/openbank-infra/gitops/components/party/network-policies.yaml
+++ b/openbank-infra/gitops/components/party/network-policies.yaml
@@ -80,3 +80,21 @@ spec:
       ports:
         - protocol: TCP
           port: 8085
+---
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: redis-ingress-allow-list
+  namespace: party
+  labels:
+    app.kubernetes.io/part-of: party
+    openbank.io/derived: gen-network-policies
+spec:
+  podSelector:
+    matchLabels:
+      app.kubernetes.io/name: redis
+  policyTypes:
+    - Ingress
+  ingress:
+    - from:
+        - podSelector: {}

--- a/openbank-infra/gitops/components/party/party-opa-bundle.yaml
+++ b/openbank-infra/gitops/components/party/party-opa-bundle.yaml
@@ -9,7 +9,7 @@ metadata:
     app.kubernetes.io/name: party-service
     app.kubernetes.io/part-of: party
   annotations:
-    openbank.tech/policy-checksum: "4e92d775828e88fa"
+    openbank.tech/policy-checksum: "868fac54901567d3"
 data:
   rest.rego: |
     # SPDX-License-Identifier: Apache-2.0
@@ -2370,6 +2370,27 @@ data:
                                              # explicitly excludes any service-account-* principal id
                                              # (rest.rego operator-compose-message), the same exclusion
                                              # m2m-sanctions-screening uses for the opposite carve-out.
+        - party.merge                       # ADR-0179: retire a duplicate identity into a survivor
+                                             # (POST /api/v1/parties/{id}/merge). Gated HERE and not via
+                                             # `verbs` for the same structural reason opsmessage.compose
+                                             # is: party-service is not, and should not become, a
+                                             # money_path_services entry (it moves no value), so the
+                                             # verb clause can never derive a `party` scope and no verb
+                                             # addition could ever reach this action.
+                                             # Why it needs the gate at all: a merge is destructive OF
+                                             # IDENTITY and irreversible in practice — one operator can
+                                             # retire a real customer behind another party id, and every
+                                             # downstream consumer follows `merged_into`. It carried only
+                                             # @RolesAllowed(ROLE_OPERATOR, ROLE_ADMIN) + an audit event,
+                                             # which records who did it but stops nobody.
+                                             # GUARDRAIL check (the one above, applied): confirmed no M2M
+                                             # caller. party-service's own rego states party.merge "has NO
+                                             # in-repo M2M caller today"; the edge M2M identity is granted
+                                             # only {party.consent.update, party:resolve} by the rule that
+                                             # names it (service-edge-party-m2m), and the ADR-0179 sweep
+                                             # counterpart transaction.merge-sweep is already gated by the
+                                             # `sweep` verb — so both halves of the merge flow now pause
+                                             # for a second approver, or neither does.
 
     # ---------------------------------------------------------------------------------------
     # Feature-flag flip governance (ADR-0067 follow-up, issue #419). The OPA PEP (rest.rego)

--- a/openbank-infra/gitops/components/party/party-service.yaml
+++ b/openbank-infra/gitops/components/party/party-service.yaml
@@ -22,7 +22,7 @@ spec:
       annotations:
         # Rolls the pod when the OPA bundle changes — subPath mounts do NOT hot-reload.
         # Kept in sync by gen-party-opa-bundle.sh (do not hand-edit).
-        openbank.tech/policy-checksum: "4e92d775828e88fa"
+        openbank.tech/policy-checksum: "868fac54901567d3"
       labels:
         app.kubernetes.io/name: party-service
         app.kubernetes.io/part-of: party
@@ -137,6 +137,24 @@ spec:
             # explicit `false` is load-bearing.
             - name: AUTHZ_ENFORCE
               value: "false"
+            # Redis for the four-eyes ApprovalStore (ADR-0155), backing the `party.merge`
+            # gate. Load-bearing: the ApprovalConfig bean resolves with or without this, so
+            # a missing Redis does not make the interceptor fall back to its documented
+            # no-ApprovalStore log line — it makes every gated merge fail on a connection
+            # error instead (issue #1354).
+            - name: QUARKUS_REDIS_HOSTS
+              value: redis://redis.party.svc:6379
+            # ADR-0155 four-eyes ENFORCEMENT for party.merge. Deliberately LEFT AT THE APP
+            # DEFAULT (false) by this change: the gate is wired end to end but inert until
+            # this is set to "true", exactly as every other ApprovalStore-wired service in
+            # the fleet ships it. Flipping it is a separate operational decision with two
+            # preconditions — (1) a second ROLE_OPERATOR/ROLE_ADMIN identity must exist in
+            # the running realm, since segregation of duties here is by identity and a
+            # single-operator sandbox would deadlock every merge; (2) the admin-UI merge
+            # action (issue #1984 item 4) must handle the 202 + X-Approval-Id retry, or the
+            # console will read the pause as a failure.
+            # - name: AUTHZ_FOUR_EYES_ENFORCE
+            #   value: "true"
             # ADR-0179 merge account guard: party-service calls account-service to refuse a merge
             # while the retired party still owns an open account. The `.svc`-qualified URL is what
             # the network-policy generator's URL_RE scans to derive the party→accounts:8100 edge —

--- a/openbank-infra/gitops/components/party/redis.yaml
+++ b/openbank-infra/gitops/components/party/redis.yaml
@@ -1,0 +1,84 @@
+# Redis for the four-eyes ApprovalStore (ADR-0155, wired here for the ADR-0179
+# `party.merge` gate) — party-service has no other Redis usage. Ephemeral on purpose —
+# persistence is disabled (--save "" --appendonly no), so a restart just clears in-flight
+# pending approvals, which is acceptable for the sandbox. Prod should use an
+# operator-managed HA Redis. Pinned to the alpine image's redis uid 999/gid 1000 to
+# satisfy PSS restricted; /data is a writable emptyDir so the root fs can stay read-only.
+# Mirrors notifications/redis.yaml exactly — see issue #1354 for what happens when a
+# service ships the ApprovalStore bean without this.
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: redis
+  namespace: party
+  labels:
+    app.kubernetes.io/name: redis
+    app.kubernetes.io/part-of: party
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app.kubernetes.io/name: redis
+  template:
+    metadata:
+      labels:
+        app.kubernetes.io/name: redis
+    spec:
+      securityContext:
+        runAsNonRoot: true
+        runAsUser: 999
+        runAsGroup: 1000
+        fsGroup: 1000
+        seccompProfile:
+          type: RuntimeDefault
+      containers:
+        - name: redis
+          image: docker.io/valkey/valkey:8-alpine
+          args: ["--save", "", "--appendonly", "no"]
+          ports:
+            - name: redis
+              containerPort: 6379
+          securityContext:
+            allowPrivilegeEscalation: false
+            readOnlyRootFilesystem: true
+            capabilities:
+              drop:
+                - ALL
+          volumeMounts:
+            - name: data
+              mountPath: /data
+          readinessProbe:
+            tcpSocket:
+              port: redis
+            initialDelaySeconds: 5
+            periodSeconds: 10
+          livenessProbe:
+            tcpSocket:
+              port: redis
+            initialDelaySeconds: 15
+            periodSeconds: 15
+          resources:
+            requests:
+              cpu: 50m
+              memory: 64Mi
+            limits:
+              cpu: 500m
+              memory: 192Mi
+      volumes:
+        - name: data
+          emptyDir: {}
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: redis
+  namespace: party
+  labels:
+    app.kubernetes.io/name: redis
+spec:
+  selector:
+    app.kubernetes.io/name: redis
+  ports:
+    - name: redis
+      port: 6379
+      targetPort: redis

--- a/openbank-infra/gitops/components/payments/card-issuance-opa-bundle.yaml
+++ b/openbank-infra/gitops/components/payments/card-issuance-opa-bundle.yaml
@@ -9,7 +9,7 @@ metadata:
     app.kubernetes.io/name: card-issuance-service
     app.kubernetes.io/part-of: payments
   annotations:
-    openbank.tech/policy-checksum: "b6fd1b6728a300a4"
+    openbank.tech/policy-checksum: "2fecf2ed56d1b9ef"
 data:
   rest.rego: |
     # SPDX-License-Identifier: Apache-2.0
@@ -2354,6 +2354,27 @@ data:
                                              # explicitly excludes any service-account-* principal id
                                              # (rest.rego operator-compose-message), the same exclusion
                                              # m2m-sanctions-screening uses for the opposite carve-out.
+        - party.merge                       # ADR-0179: retire a duplicate identity into a survivor
+                                             # (POST /api/v1/parties/{id}/merge). Gated HERE and not via
+                                             # `verbs` for the same structural reason opsmessage.compose
+                                             # is: party-service is not, and should not become, a
+                                             # money_path_services entry (it moves no value), so the
+                                             # verb clause can never derive a `party` scope and no verb
+                                             # addition could ever reach this action.
+                                             # Why it needs the gate at all: a merge is destructive OF
+                                             # IDENTITY and irreversible in practice — one operator can
+                                             # retire a real customer behind another party id, and every
+                                             # downstream consumer follows `merged_into`. It carried only
+                                             # @RolesAllowed(ROLE_OPERATOR, ROLE_ADMIN) + an audit event,
+                                             # which records who did it but stops nobody.
+                                             # GUARDRAIL check (the one above, applied): confirmed no M2M
+                                             # caller. party-service's own rego states party.merge "has NO
+                                             # in-repo M2M caller today"; the edge M2M identity is granted
+                                             # only {party.consent.update, party:resolve} by the rule that
+                                             # names it (service-edge-party-m2m), and the ADR-0179 sweep
+                                             # counterpart transaction.merge-sweep is already gated by the
+                                             # `sweep` verb — so both halves of the merge flow now pause
+                                             # for a second approver, or neither does.
 
     # ---------------------------------------------------------------------------------------
     # Feature-flag flip governance (ADR-0067 follow-up, issue #419). The OPA PEP (rest.rego)

--- a/openbank-infra/gitops/components/payments/clearing-opa-bundle.yaml
+++ b/openbank-infra/gitops/components/payments/clearing-opa-bundle.yaml
@@ -9,7 +9,7 @@ metadata:
     app.kubernetes.io/name: clearing-service
     app.kubernetes.io/part-of: payments
   annotations:
-    openbank.tech/policy-checksum: "8cf506ef750a4b83"
+    openbank.tech/policy-checksum: "21aef5f422e902a8"
 data:
   rest.rego: |
     # SPDX-License-Identifier: Apache-2.0
@@ -2391,6 +2391,27 @@ data:
                                              # explicitly excludes any service-account-* principal id
                                              # (rest.rego operator-compose-message), the same exclusion
                                              # m2m-sanctions-screening uses for the opposite carve-out.
+        - party.merge                       # ADR-0179: retire a duplicate identity into a survivor
+                                             # (POST /api/v1/parties/{id}/merge). Gated HERE and not via
+                                             # `verbs` for the same structural reason opsmessage.compose
+                                             # is: party-service is not, and should not become, a
+                                             # money_path_services entry (it moves no value), so the
+                                             # verb clause can never derive a `party` scope and no verb
+                                             # addition could ever reach this action.
+                                             # Why it needs the gate at all: a merge is destructive OF
+                                             # IDENTITY and irreversible in practice — one operator can
+                                             # retire a real customer behind another party id, and every
+                                             # downstream consumer follows `merged_into`. It carried only
+                                             # @RolesAllowed(ROLE_OPERATOR, ROLE_ADMIN) + an audit event,
+                                             # which records who did it but stops nobody.
+                                             # GUARDRAIL check (the one above, applied): confirmed no M2M
+                                             # caller. party-service's own rego states party.merge "has NO
+                                             # in-repo M2M caller today"; the edge M2M identity is granted
+                                             # only {party.consent.update, party:resolve} by the rule that
+                                             # names it (service-edge-party-m2m), and the ADR-0179 sweep
+                                             # counterpart transaction.merge-sweep is already gated by the
+                                             # `sweep` verb — so both halves of the merge flow now pause
+                                             # for a second approver, or neither does.
 
     # ---------------------------------------------------------------------------------------
     # Feature-flag flip governance (ADR-0067 follow-up, issue #419). The OPA PEP (rest.rego)

--- a/openbank-infra/gitops/components/payments/domestic-payment-opa-bundle.yaml
+++ b/openbank-infra/gitops/components/payments/domestic-payment-opa-bundle.yaml
@@ -9,7 +9,7 @@ metadata:
     app.kubernetes.io/name: domestic-payment
     app.kubernetes.io/part-of: payments
   annotations:
-    openbank.tech/policy-checksum: "adea5c7d7dd7a181"
+    openbank.tech/policy-checksum: "14460ee43e2abb73"
 data:
   rest.rego: |
     # SPDX-License-Identifier: Apache-2.0
@@ -2376,6 +2376,27 @@ data:
                                              # explicitly excludes any service-account-* principal id
                                              # (rest.rego operator-compose-message), the same exclusion
                                              # m2m-sanctions-screening uses for the opposite carve-out.
+        - party.merge                       # ADR-0179: retire a duplicate identity into a survivor
+                                             # (POST /api/v1/parties/{id}/merge). Gated HERE and not via
+                                             # `verbs` for the same structural reason opsmessage.compose
+                                             # is: party-service is not, and should not become, a
+                                             # money_path_services entry (it moves no value), so the
+                                             # verb clause can never derive a `party` scope and no verb
+                                             # addition could ever reach this action.
+                                             # Why it needs the gate at all: a merge is destructive OF
+                                             # IDENTITY and irreversible in practice — one operator can
+                                             # retire a real customer behind another party id, and every
+                                             # downstream consumer follows `merged_into`. It carried only
+                                             # @RolesAllowed(ROLE_OPERATOR, ROLE_ADMIN) + an audit event,
+                                             # which records who did it but stops nobody.
+                                             # GUARDRAIL check (the one above, applied): confirmed no M2M
+                                             # caller. party-service's own rego states party.merge "has NO
+                                             # in-repo M2M caller today"; the edge M2M identity is granted
+                                             # only {party.consent.update, party:resolve} by the rule that
+                                             # names it (service-edge-party-m2m), and the ADR-0179 sweep
+                                             # counterpart transaction.merge-sweep is already gated by the
+                                             # `sweep` verb — so both halves of the merge flow now pause
+                                             # for a second approver, or neither does.
 
     # ---------------------------------------------------------------------------------------
     # Feature-flag flip governance (ADR-0067 follow-up, issue #419). The OPA PEP (rest.rego)

--- a/openbank-infra/gitops/components/payments/payments-services.yaml
+++ b/openbank-infra/gitops/components/payments/payments-services.yaml
@@ -42,7 +42,7 @@ spec:
         # Rolls the pods when the OPA bundle changes — subPath mounts do NOT hot-reload.
         # Kept in sync by gen-transaction-opa-bundle.sh via the trailing marker comment
         # (do not hand-edit, do not drop the marker).
-        openbank.tech/policy-checksum: "6ded9de56354976b" # transaction-opa-bundle
+        openbank.tech/policy-checksum: "f771b59a0b4561dd" # transaction-opa-bundle
     spec:
       securityContext:
         runAsNonRoot: true
@@ -375,7 +375,7 @@ spec:
       annotations:
         # Rolls the pods when the OPA bundle changes — subPath mounts do NOT hot-reload.
         # Kept in sync by gen-sepa-payment-opa-bundle.sh (do not hand-edit).
-        openbank.tech/policy-checksum: "93d2b5a698261593"
+        openbank.tech/policy-checksum: "f52b239df6c01116"
     spec:
       securityContext:
         runAsNonRoot: true
@@ -729,7 +729,7 @@ spec:
         # Rolls the pods when the OPA bundle changes — subPath mounts do NOT hot-reload.
         # Kept in sync by gen-domestic-payment-opa-bundle.sh via the trailing marker
         # comment (do not hand-edit, do not drop the marker).
-        openbank.tech/policy-checksum: "adea5c7d7dd7a181" # domestic-payment-opa-bundle
+        openbank.tech/policy-checksum: "14460ee43e2abb73" # domestic-payment-opa-bundle
     spec:
       securityContext:
         runAsNonRoot: true
@@ -1053,7 +1053,7 @@ spec:
       annotations:
         # Rolls the pods when the OPA bundle changes — subPath mounts do NOT hot-reload.
         # Kept in sync by gen-sepa-instant-opa-bundle.sh (do not hand-edit).
-        openbank.tech/policy-checksum: "611cfa8963fea959"
+        openbank.tech/policy-checksum: "25ffa3aa53b6e8d1"
     spec:
       securityContext:
         runAsNonRoot: true
@@ -1369,7 +1369,7 @@ spec:
         # Rolls the pods when the OPA bundle changes — subPath mounts do NOT hot-reload.
         # Kept in sync by gen-clearing-opa-bundle.sh via the trailing marker comment
         # (do not hand-edit, do not drop the marker).
-        openbank.tech/policy-checksum: "8cf506ef750a4b83" # clearing-opa-bundle
+        openbank.tech/policy-checksum: "21aef5f422e902a8" # clearing-opa-bundle
     spec:
       securityContext:
         runAsNonRoot: true
@@ -1658,7 +1658,7 @@ spec:
       annotations:
         # Rolls the pod when the OPA bundle changes (ADR-0034). Value is stamped by
         # gen-standing-order-opa-bundle.sh — do not hand-edit.
-        openbank.tech/policy-checksum: "b322952c245cd84d" # standing-order-opa-bundle
+        openbank.tech/policy-checksum: "bc12d57aed345519" # standing-order-opa-bundle
     spec:
       securityContext:
         runAsNonRoot: true
@@ -1911,7 +1911,7 @@ spec:
       annotations:
         # Rolls the pods when the OPA bundle changes — subPath mounts do NOT hot-reload.
         # Kept in sync by gen-card-issuance-opa-bundle.sh (do not hand-edit).
-        openbank.tech/policy-checksum: "b6fd1b6728a300a4"
+        openbank.tech/policy-checksum: "2fecf2ed56d1b9ef"
     spec:
       securityContext:
         runAsNonRoot: true
@@ -2178,7 +2178,7 @@ spec:
         # Rolls the pods when the OPA bundle changes — subPath mounts do NOT hot-reload.
         # Kept in sync by gen-settlement-opa-bundle.sh via the trailing marker comment
         # (do not hand-edit, do not drop the marker).
-        openbank.tech/policy-checksum: "204b7c6fb498e9f2" # settlement-opa-bundle
+        openbank.tech/policy-checksum: "b7ba009884c854ac" # settlement-opa-bundle
     spec:
       securityContext:
         runAsNonRoot: true
@@ -2579,7 +2579,7 @@ spec:
       annotations:
         # Rolls the pods when the OPA bundle changes — subPath mounts do NOT hot-reload.
         # Kept in sync by gen-swift-opa-bundle.sh (do not hand-edit).
-        openbank.tech/policy-checksum: "2aafe04db459bda0"
+        openbank.tech/policy-checksum: "989d8666ec478883"
     spec:
       securityContext:
         runAsNonRoot: true
@@ -2893,7 +2893,7 @@ spec:
       annotations:
         # Rolls the pods when the OPA bundle changes — subPath mounts do NOT hot-reload.
         # Kept in sync by gen-vop-opa-bundle.sh (do not hand-edit).
-        openbank.tech/policy-checksum: "8e43d9c5b7999ac8"
+        openbank.tech/policy-checksum: "907c410464e8eb75"
     spec:
       securityContext:
         runAsNonRoot: true

--- a/openbank-infra/gitops/components/payments/sepa-instant-opa-bundle.yaml
+++ b/openbank-infra/gitops/components/payments/sepa-instant-opa-bundle.yaml
@@ -9,7 +9,7 @@ metadata:
     app.kubernetes.io/name: sepa-instant
     app.kubernetes.io/part-of: payments
   annotations:
-    openbank.tech/policy-checksum: "611cfa8963fea959"
+    openbank.tech/policy-checksum: "25ffa3aa53b6e8d1"
 data:
   rest.rego: |
     # SPDX-License-Identifier: Apache-2.0
@@ -2349,6 +2349,27 @@ data:
                                              # explicitly excludes any service-account-* principal id
                                              # (rest.rego operator-compose-message), the same exclusion
                                              # m2m-sanctions-screening uses for the opposite carve-out.
+        - party.merge                       # ADR-0179: retire a duplicate identity into a survivor
+                                             # (POST /api/v1/parties/{id}/merge). Gated HERE and not via
+                                             # `verbs` for the same structural reason opsmessage.compose
+                                             # is: party-service is not, and should not become, a
+                                             # money_path_services entry (it moves no value), so the
+                                             # verb clause can never derive a `party` scope and no verb
+                                             # addition could ever reach this action.
+                                             # Why it needs the gate at all: a merge is destructive OF
+                                             # IDENTITY and irreversible in practice — one operator can
+                                             # retire a real customer behind another party id, and every
+                                             # downstream consumer follows `merged_into`. It carried only
+                                             # @RolesAllowed(ROLE_OPERATOR, ROLE_ADMIN) + an audit event,
+                                             # which records who did it but stops nobody.
+                                             # GUARDRAIL check (the one above, applied): confirmed no M2M
+                                             # caller. party-service's own rego states party.merge "has NO
+                                             # in-repo M2M caller today"; the edge M2M identity is granted
+                                             # only {party.consent.update, party:resolve} by the rule that
+                                             # names it (service-edge-party-m2m), and the ADR-0179 sweep
+                                             # counterpart transaction.merge-sweep is already gated by the
+                                             # `sweep` verb — so both halves of the merge flow now pause
+                                             # for a second approver, or neither does.
 
     # ---------------------------------------------------------------------------------------
     # Feature-flag flip governance (ADR-0067 follow-up, issue #419). The OPA PEP (rest.rego)

--- a/openbank-infra/gitops/components/payments/sepa-payment-opa-bundle.yaml
+++ b/openbank-infra/gitops/components/payments/sepa-payment-opa-bundle.yaml
@@ -9,7 +9,7 @@ metadata:
     app.kubernetes.io/name: sepa-payment
     app.kubernetes.io/part-of: payments
   annotations:
-    openbank.tech/policy-checksum: "93d2b5a698261593"
+    openbank.tech/policy-checksum: "f52b239df6c01116"
 data:
   rest.rego: |
     # SPDX-License-Identifier: Apache-2.0
@@ -2370,6 +2370,27 @@ data:
                                              # explicitly excludes any service-account-* principal id
                                              # (rest.rego operator-compose-message), the same exclusion
                                              # m2m-sanctions-screening uses for the opposite carve-out.
+        - party.merge                       # ADR-0179: retire a duplicate identity into a survivor
+                                             # (POST /api/v1/parties/{id}/merge). Gated HERE and not via
+                                             # `verbs` for the same structural reason opsmessage.compose
+                                             # is: party-service is not, and should not become, a
+                                             # money_path_services entry (it moves no value), so the
+                                             # verb clause can never derive a `party` scope and no verb
+                                             # addition could ever reach this action.
+                                             # Why it needs the gate at all: a merge is destructive OF
+                                             # IDENTITY and irreversible in practice — one operator can
+                                             # retire a real customer behind another party id, and every
+                                             # downstream consumer follows `merged_into`. It carried only
+                                             # @RolesAllowed(ROLE_OPERATOR, ROLE_ADMIN) + an audit event,
+                                             # which records who did it but stops nobody.
+                                             # GUARDRAIL check (the one above, applied): confirmed no M2M
+                                             # caller. party-service's own rego states party.merge "has NO
+                                             # in-repo M2M caller today"; the edge M2M identity is granted
+                                             # only {party.consent.update, party:resolve} by the rule that
+                                             # names it (service-edge-party-m2m), and the ADR-0179 sweep
+                                             # counterpart transaction.merge-sweep is already gated by the
+                                             # `sweep` verb — so both halves of the merge flow now pause
+                                             # for a second approver, or neither does.
 
     # ---------------------------------------------------------------------------------------
     # Feature-flag flip governance (ADR-0067 follow-up, issue #419). The OPA PEP (rest.rego)

--- a/openbank-infra/gitops/components/payments/settlement-opa-bundle.yaml
+++ b/openbank-infra/gitops/components/payments/settlement-opa-bundle.yaml
@@ -9,7 +9,7 @@ metadata:
     app.kubernetes.io/name: settlement-service
     app.kubernetes.io/part-of: payments
   annotations:
-    openbank.tech/policy-checksum: "204b7c6fb498e9f2"
+    openbank.tech/policy-checksum: "b7ba009884c854ac"
 data:
   rest.rego: |
     # SPDX-License-Identifier: Apache-2.0
@@ -2350,6 +2350,27 @@ data:
                                              # explicitly excludes any service-account-* principal id
                                              # (rest.rego operator-compose-message), the same exclusion
                                              # m2m-sanctions-screening uses for the opposite carve-out.
+        - party.merge                       # ADR-0179: retire a duplicate identity into a survivor
+                                             # (POST /api/v1/parties/{id}/merge). Gated HERE and not via
+                                             # `verbs` for the same structural reason opsmessage.compose
+                                             # is: party-service is not, and should not become, a
+                                             # money_path_services entry (it moves no value), so the
+                                             # verb clause can never derive a `party` scope and no verb
+                                             # addition could ever reach this action.
+                                             # Why it needs the gate at all: a merge is destructive OF
+                                             # IDENTITY and irreversible in practice — one operator can
+                                             # retire a real customer behind another party id, and every
+                                             # downstream consumer follows `merged_into`. It carried only
+                                             # @RolesAllowed(ROLE_OPERATOR, ROLE_ADMIN) + an audit event,
+                                             # which records who did it but stops nobody.
+                                             # GUARDRAIL check (the one above, applied): confirmed no M2M
+                                             # caller. party-service's own rego states party.merge "has NO
+                                             # in-repo M2M caller today"; the edge M2M identity is granted
+                                             # only {party.consent.update, party:resolve} by the rule that
+                                             # names it (service-edge-party-m2m), and the ADR-0179 sweep
+                                             # counterpart transaction.merge-sweep is already gated by the
+                                             # `sweep` verb — so both halves of the merge flow now pause
+                                             # for a second approver, or neither does.
 
     # ---------------------------------------------------------------------------------------
     # Feature-flag flip governance (ADR-0067 follow-up, issue #419). The OPA PEP (rest.rego)

--- a/openbank-infra/gitops/components/payments/standing-order-opa-bundle.yaml
+++ b/openbank-infra/gitops/components/payments/standing-order-opa-bundle.yaml
@@ -9,7 +9,7 @@ metadata:
     app.kubernetes.io/name: standing-order-service
     app.kubernetes.io/part-of: payments
   annotations:
-    openbank.tech/policy-checksum: "b322952c245cd84d"
+    openbank.tech/policy-checksum: "bc12d57aed345519"
 data:
   rest.rego: |
     # SPDX-License-Identifier: Apache-2.0
@@ -2335,6 +2335,27 @@ data:
                                              # explicitly excludes any service-account-* principal id
                                              # (rest.rego operator-compose-message), the same exclusion
                                              # m2m-sanctions-screening uses for the opposite carve-out.
+        - party.merge                       # ADR-0179: retire a duplicate identity into a survivor
+                                             # (POST /api/v1/parties/{id}/merge). Gated HERE and not via
+                                             # `verbs` for the same structural reason opsmessage.compose
+                                             # is: party-service is not, and should not become, a
+                                             # money_path_services entry (it moves no value), so the
+                                             # verb clause can never derive a `party` scope and no verb
+                                             # addition could ever reach this action.
+                                             # Why it needs the gate at all: a merge is destructive OF
+                                             # IDENTITY and irreversible in practice — one operator can
+                                             # retire a real customer behind another party id, and every
+                                             # downstream consumer follows `merged_into`. It carried only
+                                             # @RolesAllowed(ROLE_OPERATOR, ROLE_ADMIN) + an audit event,
+                                             # which records who did it but stops nobody.
+                                             # GUARDRAIL check (the one above, applied): confirmed no M2M
+                                             # caller. party-service's own rego states party.merge "has NO
+                                             # in-repo M2M caller today"; the edge M2M identity is granted
+                                             # only {party.consent.update, party:resolve} by the rule that
+                                             # names it (service-edge-party-m2m), and the ADR-0179 sweep
+                                             # counterpart transaction.merge-sweep is already gated by the
+                                             # `sweep` verb — so both halves of the merge flow now pause
+                                             # for a second approver, or neither does.
 
     # ---------------------------------------------------------------------------------------
     # Feature-flag flip governance (ADR-0067 follow-up, issue #419). The OPA PEP (rest.rego)

--- a/openbank-infra/gitops/components/payments/swift-opa-bundle.yaml
+++ b/openbank-infra/gitops/components/payments/swift-opa-bundle.yaml
@@ -9,7 +9,7 @@ metadata:
     app.kubernetes.io/name: swift-service
     app.kubernetes.io/part-of: payments
   annotations:
-    openbank.tech/policy-checksum: "2aafe04db459bda0"
+    openbank.tech/policy-checksum: "989d8666ec478883"
 data:
   rest.rego: |
     # SPDX-License-Identifier: Apache-2.0
@@ -2353,6 +2353,27 @@ data:
                                              # explicitly excludes any service-account-* principal id
                                              # (rest.rego operator-compose-message), the same exclusion
                                              # m2m-sanctions-screening uses for the opposite carve-out.
+        - party.merge                       # ADR-0179: retire a duplicate identity into a survivor
+                                             # (POST /api/v1/parties/{id}/merge). Gated HERE and not via
+                                             # `verbs` for the same structural reason opsmessage.compose
+                                             # is: party-service is not, and should not become, a
+                                             # money_path_services entry (it moves no value), so the
+                                             # verb clause can never derive a `party` scope and no verb
+                                             # addition could ever reach this action.
+                                             # Why it needs the gate at all: a merge is destructive OF
+                                             # IDENTITY and irreversible in practice — one operator can
+                                             # retire a real customer behind another party id, and every
+                                             # downstream consumer follows `merged_into`. It carried only
+                                             # @RolesAllowed(ROLE_OPERATOR, ROLE_ADMIN) + an audit event,
+                                             # which records who did it but stops nobody.
+                                             # GUARDRAIL check (the one above, applied): confirmed no M2M
+                                             # caller. party-service's own rego states party.merge "has NO
+                                             # in-repo M2M caller today"; the edge M2M identity is granted
+                                             # only {party.consent.update, party:resolve} by the rule that
+                                             # names it (service-edge-party-m2m), and the ADR-0179 sweep
+                                             # counterpart transaction.merge-sweep is already gated by the
+                                             # `sweep` verb — so both halves of the merge flow now pause
+                                             # for a second approver, or neither does.
 
     # ---------------------------------------------------------------------------------------
     # Feature-flag flip governance (ADR-0067 follow-up, issue #419). The OPA PEP (rest.rego)

--- a/openbank-infra/gitops/components/payments/transaction-opa-bundle.yaml
+++ b/openbank-infra/gitops/components/payments/transaction-opa-bundle.yaml
@@ -9,7 +9,7 @@ metadata:
     app.kubernetes.io/name: transaction-service
     app.kubernetes.io/part-of: payments
   annotations:
-    openbank.tech/policy-checksum: "6ded9de56354976b"
+    openbank.tech/policy-checksum: "f771b59a0b4561dd"
 data:
   rest.rego: |
     # SPDX-License-Identifier: Apache-2.0
@@ -2406,6 +2406,27 @@ data:
                                              # explicitly excludes any service-account-* principal id
                                              # (rest.rego operator-compose-message), the same exclusion
                                              # m2m-sanctions-screening uses for the opposite carve-out.
+        - party.merge                       # ADR-0179: retire a duplicate identity into a survivor
+                                             # (POST /api/v1/parties/{id}/merge). Gated HERE and not via
+                                             # `verbs` for the same structural reason opsmessage.compose
+                                             # is: party-service is not, and should not become, a
+                                             # money_path_services entry (it moves no value), so the
+                                             # verb clause can never derive a `party` scope and no verb
+                                             # addition could ever reach this action.
+                                             # Why it needs the gate at all: a merge is destructive OF
+                                             # IDENTITY and irreversible in practice — one operator can
+                                             # retire a real customer behind another party id, and every
+                                             # downstream consumer follows `merged_into`. It carried only
+                                             # @RolesAllowed(ROLE_OPERATOR, ROLE_ADMIN) + an audit event,
+                                             # which records who did it but stops nobody.
+                                             # GUARDRAIL check (the one above, applied): confirmed no M2M
+                                             # caller. party-service's own rego states party.merge "has NO
+                                             # in-repo M2M caller today"; the edge M2M identity is granted
+                                             # only {party.consent.update, party:resolve} by the rule that
+                                             # names it (service-edge-party-m2m), and the ADR-0179 sweep
+                                             # counterpart transaction.merge-sweep is already gated by the
+                                             # `sweep` verb — so both halves of the merge flow now pause
+                                             # for a second approver, or neither does.
 
     # ---------------------------------------------------------------------------------------
     # Feature-flag flip governance (ADR-0067 follow-up, issue #419). The OPA PEP (rest.rego)

--- a/openbank-infra/gitops/components/payments/vop-opa-bundle.yaml
+++ b/openbank-infra/gitops/components/payments/vop-opa-bundle.yaml
@@ -9,7 +9,7 @@ metadata:
     app.kubernetes.io/name: vop-service
     app.kubernetes.io/part-of: payments
   annotations:
-    openbank.tech/policy-checksum: "8e43d9c5b7999ac8"
+    openbank.tech/policy-checksum: "907c410464e8eb75"
 data:
   rest.rego: |
     # SPDX-License-Identifier: Apache-2.0
@@ -2357,6 +2357,27 @@ data:
                                              # explicitly excludes any service-account-* principal id
                                              # (rest.rego operator-compose-message), the same exclusion
                                              # m2m-sanctions-screening uses for the opposite carve-out.
+        - party.merge                       # ADR-0179: retire a duplicate identity into a survivor
+                                             # (POST /api/v1/parties/{id}/merge). Gated HERE and not via
+                                             # `verbs` for the same structural reason opsmessage.compose
+                                             # is: party-service is not, and should not become, a
+                                             # money_path_services entry (it moves no value), so the
+                                             # verb clause can never derive a `party` scope and no verb
+                                             # addition could ever reach this action.
+                                             # Why it needs the gate at all: a merge is destructive OF
+                                             # IDENTITY and irreversible in practice — one operator can
+                                             # retire a real customer behind another party id, and every
+                                             # downstream consumer follows `merged_into`. It carried only
+                                             # @RolesAllowed(ROLE_OPERATOR, ROLE_ADMIN) + an audit event,
+                                             # which records who did it but stops nobody.
+                                             # GUARDRAIL check (the one above, applied): confirmed no M2M
+                                             # caller. party-service's own rego states party.merge "has NO
+                                             # in-repo M2M caller today"; the edge M2M identity is granted
+                                             # only {party.consent.update, party:resolve} by the rule that
+                                             # names it (service-edge-party-m2m), and the ADR-0179 sweep
+                                             # counterpart transaction.merge-sweep is already gated by the
+                                             # `sweep` verb — so both halves of the merge flow now pause
+                                             # for a second approver, or neither does.
 
     # ---------------------------------------------------------------------------------------
     # Feature-flag flip governance (ADR-0067 follow-up, issue #419). The OPA PEP (rest.rego)

--- a/openbank-infra/gitops/components/pid/pid-opa-bundle.yaml
+++ b/openbank-infra/gitops/components/pid/pid-opa-bundle.yaml
@@ -9,7 +9,7 @@ metadata:
     app.kubernetes.io/name: pid-service
     app.kubernetes.io/part-of: pid
   annotations:
-    openbank.tech/policy-checksum: "c4b4dc229ad7aab8"
+    openbank.tech/policy-checksum: "7e3cc294b056189d"
 data:
   rest.rego: |
     # SPDX-License-Identifier: Apache-2.0
@@ -2359,6 +2359,27 @@ data:
                                              # explicitly excludes any service-account-* principal id
                                              # (rest.rego operator-compose-message), the same exclusion
                                              # m2m-sanctions-screening uses for the opposite carve-out.
+        - party.merge                       # ADR-0179: retire a duplicate identity into a survivor
+                                             # (POST /api/v1/parties/{id}/merge). Gated HERE and not via
+                                             # `verbs` for the same structural reason opsmessage.compose
+                                             # is: party-service is not, and should not become, a
+                                             # money_path_services entry (it moves no value), so the
+                                             # verb clause can never derive a `party` scope and no verb
+                                             # addition could ever reach this action.
+                                             # Why it needs the gate at all: a merge is destructive OF
+                                             # IDENTITY and irreversible in practice — one operator can
+                                             # retire a real customer behind another party id, and every
+                                             # downstream consumer follows `merged_into`. It carried only
+                                             # @RolesAllowed(ROLE_OPERATOR, ROLE_ADMIN) + an audit event,
+                                             # which records who did it but stops nobody.
+                                             # GUARDRAIL check (the one above, applied): confirmed no M2M
+                                             # caller. party-service's own rego states party.merge "has NO
+                                             # in-repo M2M caller today"; the edge M2M identity is granted
+                                             # only {party.consent.update, party:resolve} by the rule that
+                                             # names it (service-edge-party-m2m), and the ADR-0179 sweep
+                                             # counterpart transaction.merge-sweep is already gated by the
+                                             # `sweep` verb — so both halves of the merge flow now pause
+                                             # for a second approver, or neither does.
 
     # ---------------------------------------------------------------------------------------
     # Feature-flag flip governance (ADR-0067 follow-up, issue #419). The OPA PEP (rest.rego)

--- a/openbank-infra/gitops/components/pid/pid-service.yaml
+++ b/openbank-infra/gitops/components/pid/pid-service.yaml
@@ -22,7 +22,7 @@ spec:
       annotations:
         # Rolls the pod when the OPA bundle changes — subPath mounts do NOT hot-reload.
         # Kept in sync by gen-pid-opa-bundle.sh (do not hand-edit).
-        openbank.tech/policy-checksum: "c4b4dc229ad7aab8"
+        openbank.tech/policy-checksum: "7e3cc294b056189d"
     spec:
       securityContext:
         runAsNonRoot: true

--- a/openbank-infra/gitops/components/psd2-service/psd2-opa-bundle.yaml
+++ b/openbank-infra/gitops/components/psd2-service/psd2-opa-bundle.yaml
@@ -9,7 +9,7 @@ metadata:
     app.kubernetes.io/name: psd2-service
     app.kubernetes.io/part-of: psd2
   annotations:
-    openbank.tech/policy-checksum: "d37dfe7668a9cec3"
+    openbank.tech/policy-checksum: "9f2ea53225040cb2"
 data:
   rest.rego: |
     # SPDX-License-Identifier: Apache-2.0
@@ -2432,6 +2432,27 @@ data:
                                              # explicitly excludes any service-account-* principal id
                                              # (rest.rego operator-compose-message), the same exclusion
                                              # m2m-sanctions-screening uses for the opposite carve-out.
+        - party.merge                       # ADR-0179: retire a duplicate identity into a survivor
+                                             # (POST /api/v1/parties/{id}/merge). Gated HERE and not via
+                                             # `verbs` for the same structural reason opsmessage.compose
+                                             # is: party-service is not, and should not become, a
+                                             # money_path_services entry (it moves no value), so the
+                                             # verb clause can never derive a `party` scope and no verb
+                                             # addition could ever reach this action.
+                                             # Why it needs the gate at all: a merge is destructive OF
+                                             # IDENTITY and irreversible in practice — one operator can
+                                             # retire a real customer behind another party id, and every
+                                             # downstream consumer follows `merged_into`. It carried only
+                                             # @RolesAllowed(ROLE_OPERATOR, ROLE_ADMIN) + an audit event,
+                                             # which records who did it but stops nobody.
+                                             # GUARDRAIL check (the one above, applied): confirmed no M2M
+                                             # caller. party-service's own rego states party.merge "has NO
+                                             # in-repo M2M caller today"; the edge M2M identity is granted
+                                             # only {party.consent.update, party:resolve} by the rule that
+                                             # names it (service-edge-party-m2m), and the ADR-0179 sweep
+                                             # counterpart transaction.merge-sweep is already gated by the
+                                             # `sweep` verb — so both halves of the merge flow now pause
+                                             # for a second approver, or neither does.
 
     # ---------------------------------------------------------------------------------------
     # Feature-flag flip governance (ADR-0067 follow-up, issue #419). The OPA PEP (rest.rego)

--- a/openbank-infra/gitops/components/psd2-service/psd2-service.yaml
+++ b/openbank-infra/gitops/components/psd2-service/psd2-service.yaml
@@ -18,7 +18,7 @@ spec:
       annotations:
         # Rolls the pod when the OPA bundle changes — subPath mounts do NOT hot-reload.
         # Kept in sync by gen-psd2-opa-bundle.sh (do not hand-edit).
-        openbank.tech/policy-checksum: "d37dfe7668a9cec3"
+        openbank.tech/policy-checksum: "9f2ea53225040cb2"
       labels: {app.kubernetes.io/name: psd2-service, app.kubernetes.io/part-of: psd2}
     spec:
       securityContext:

--- a/openbank-infra/gitops/components/sanctions-service/sanctions-opa-bundle.yaml
+++ b/openbank-infra/gitops/components/sanctions-service/sanctions-opa-bundle.yaml
@@ -9,7 +9,7 @@ metadata:
     app.kubernetes.io/name: sanctions-service
     app.kubernetes.io/part-of: sanctions
   annotations:
-    openbank.tech/policy-checksum: "5ef4b000ea520b8d"
+    openbank.tech/policy-checksum: "1bd47807af9184ec"
 data:
   rest.rego: |
     # SPDX-License-Identifier: Apache-2.0
@@ -2337,6 +2337,27 @@ data:
                                              # explicitly excludes any service-account-* principal id
                                              # (rest.rego operator-compose-message), the same exclusion
                                              # m2m-sanctions-screening uses for the opposite carve-out.
+        - party.merge                       # ADR-0179: retire a duplicate identity into a survivor
+                                             # (POST /api/v1/parties/{id}/merge). Gated HERE and not via
+                                             # `verbs` for the same structural reason opsmessage.compose
+                                             # is: party-service is not, and should not become, a
+                                             # money_path_services entry (it moves no value), so the
+                                             # verb clause can never derive a `party` scope and no verb
+                                             # addition could ever reach this action.
+                                             # Why it needs the gate at all: a merge is destructive OF
+                                             # IDENTITY and irreversible in practice — one operator can
+                                             # retire a real customer behind another party id, and every
+                                             # downstream consumer follows `merged_into`. It carried only
+                                             # @RolesAllowed(ROLE_OPERATOR, ROLE_ADMIN) + an audit event,
+                                             # which records who did it but stops nobody.
+                                             # GUARDRAIL check (the one above, applied): confirmed no M2M
+                                             # caller. party-service's own rego states party.merge "has NO
+                                             # in-repo M2M caller today"; the edge M2M identity is granted
+                                             # only {party.consent.update, party:resolve} by the rule that
+                                             # names it (service-edge-party-m2m), and the ADR-0179 sweep
+                                             # counterpart transaction.merge-sweep is already gated by the
+                                             # `sweep` verb — so both halves of the merge flow now pause
+                                             # for a second approver, or neither does.
 
     # ---------------------------------------------------------------------------------------
     # Feature-flag flip governance (ADR-0067 follow-up, issue #419). The OPA PEP (rest.rego)

--- a/openbank-infra/gitops/components/sanctions-service/sanctions-service.yaml
+++ b/openbank-infra/gitops/components/sanctions-service/sanctions-service.yaml
@@ -49,7 +49,7 @@ spec:
       annotations:
         # Rolls the pods when the OPA bundle changes — subPath mounts do NOT hot-reload.
         # Kept in sync by gen-sanctions-opa-bundle.sh (do not hand-edit).
-        openbank.tech/policy-checksum: "5ef4b000ea520b8d"
+        openbank.tech/policy-checksum: "1bd47807af9184ec"
     spec:
       securityContext:
         runAsNonRoot: true

--- a/openbank-infra/gitops/components/sca/sca-opa-bundle.yaml
+++ b/openbank-infra/gitops/components/sca/sca-opa-bundle.yaml
@@ -9,7 +9,7 @@ metadata:
     app.kubernetes.io/name: sca-service
     app.kubernetes.io/part-of: sca
   annotations:
-    openbank.tech/policy-checksum: "5afcea53e3143de5"
+    openbank.tech/policy-checksum: "a63be66d739207b3"
 data:
   rest.rego: |
     # SPDX-License-Identifier: Apache-2.0
@@ -2373,6 +2373,27 @@ data:
                                              # explicitly excludes any service-account-* principal id
                                              # (rest.rego operator-compose-message), the same exclusion
                                              # m2m-sanctions-screening uses for the opposite carve-out.
+        - party.merge                       # ADR-0179: retire a duplicate identity into a survivor
+                                             # (POST /api/v1/parties/{id}/merge). Gated HERE and not via
+                                             # `verbs` for the same structural reason opsmessage.compose
+                                             # is: party-service is not, and should not become, a
+                                             # money_path_services entry (it moves no value), so the
+                                             # verb clause can never derive a `party` scope and no verb
+                                             # addition could ever reach this action.
+                                             # Why it needs the gate at all: a merge is destructive OF
+                                             # IDENTITY and irreversible in practice — one operator can
+                                             # retire a real customer behind another party id, and every
+                                             # downstream consumer follows `merged_into`. It carried only
+                                             # @RolesAllowed(ROLE_OPERATOR, ROLE_ADMIN) + an audit event,
+                                             # which records who did it but stops nobody.
+                                             # GUARDRAIL check (the one above, applied): confirmed no M2M
+                                             # caller. party-service's own rego states party.merge "has NO
+                                             # in-repo M2M caller today"; the edge M2M identity is granted
+                                             # only {party.consent.update, party:resolve} by the rule that
+                                             # names it (service-edge-party-m2m), and the ADR-0179 sweep
+                                             # counterpart transaction.merge-sweep is already gated by the
+                                             # `sweep` verb — so both halves of the merge flow now pause
+                                             # for a second approver, or neither does.
 
     # ---------------------------------------------------------------------------------------
     # Feature-flag flip governance (ADR-0067 follow-up, issue #419). The OPA PEP (rest.rego)

--- a/openbank-infra/gitops/components/sca/sca-service.yaml
+++ b/openbank-infra/gitops/components/sca/sca-service.yaml
@@ -28,7 +28,7 @@ spec:
       annotations:
         # Rolls the pods when the OPA bundle changes — subPath mounts do NOT hot-reload.
         # Kept in sync by gen-sca-opa-bundle.sh (do not hand-edit).
-        openbank.tech/policy-checksum: "5afcea53e3143de5"
+        openbank.tech/policy-checksum: "a63be66d739207b3"
     spec:
       securityContext:
         runAsNonRoot: true

--- a/openbank-infra/gitops/components/statements/statement-opa-bundle.yaml
+++ b/openbank-infra/gitops/components/statements/statement-opa-bundle.yaml
@@ -9,7 +9,7 @@ metadata:
     app.kubernetes.io/name: statement-service
     app.kubernetes.io/part-of: statements
   annotations:
-    openbank.tech/policy-checksum: "51a7266938c0c636"
+    openbank.tech/policy-checksum: "147182e7cfdfa9ff"
 data:
   rest.rego: |
     # SPDX-License-Identifier: Apache-2.0
@@ -2403,6 +2403,27 @@ data:
                                              # explicitly excludes any service-account-* principal id
                                              # (rest.rego operator-compose-message), the same exclusion
                                              # m2m-sanctions-screening uses for the opposite carve-out.
+        - party.merge                       # ADR-0179: retire a duplicate identity into a survivor
+                                             # (POST /api/v1/parties/{id}/merge). Gated HERE and not via
+                                             # `verbs` for the same structural reason opsmessage.compose
+                                             # is: party-service is not, and should not become, a
+                                             # money_path_services entry (it moves no value), so the
+                                             # verb clause can never derive a `party` scope and no verb
+                                             # addition could ever reach this action.
+                                             # Why it needs the gate at all: a merge is destructive OF
+                                             # IDENTITY and irreversible in practice — one operator can
+                                             # retire a real customer behind another party id, and every
+                                             # downstream consumer follows `merged_into`. It carried only
+                                             # @RolesAllowed(ROLE_OPERATOR, ROLE_ADMIN) + an audit event,
+                                             # which records who did it but stops nobody.
+                                             # GUARDRAIL check (the one above, applied): confirmed no M2M
+                                             # caller. party-service's own rego states party.merge "has NO
+                                             # in-repo M2M caller today"; the edge M2M identity is granted
+                                             # only {party.consent.update, party:resolve} by the rule that
+                                             # names it (service-edge-party-m2m), and the ADR-0179 sweep
+                                             # counterpart transaction.merge-sweep is already gated by the
+                                             # `sweep` verb — so both halves of the merge flow now pause
+                                             # for a second approver, or neither does.
 
     # ---------------------------------------------------------------------------------------
     # Feature-flag flip governance (ADR-0067 follow-up, issue #419). The OPA PEP (rest.rego)

--- a/openbank-infra/gitops/components/statements/statement-service.yaml
+++ b/openbank-infra/gitops/components/statements/statement-service.yaml
@@ -26,7 +26,7 @@ spec:
       annotations:
         # Rolls the pod when the OPA bundle changes — subPath mounts do NOT hot-reload.
         # Kept in sync by gen-statement-opa-bundle.sh (do not hand-edit).
-        openbank.tech/policy-checksum: "51a7266938c0c636"
+        openbank.tech/policy-checksum: "147182e7cfdfa9ff"
       labels:
         app.kubernetes.io/name: statement-service
         app.kubernetes.io/part-of: statements

--- a/openbank-infra/gitops/components/tpp-registry/tpp-registry-opa-bundle.yaml
+++ b/openbank-infra/gitops/components/tpp-registry/tpp-registry-opa-bundle.yaml
@@ -9,7 +9,7 @@ metadata:
     app.kubernetes.io/name: tpp-registry-service
     app.kubernetes.io/part-of: tpp-registry
   annotations:
-    openbank.tech/policy-checksum: "11a89b3e96e5afe0"
+    openbank.tech/policy-checksum: "a5aaba4479f404a9"
 data:
   rest.rego: |
     # SPDX-License-Identifier: Apache-2.0
@@ -2340,6 +2340,27 @@ data:
                                              # explicitly excludes any service-account-* principal id
                                              # (rest.rego operator-compose-message), the same exclusion
                                              # m2m-sanctions-screening uses for the opposite carve-out.
+        - party.merge                       # ADR-0179: retire a duplicate identity into a survivor
+                                             # (POST /api/v1/parties/{id}/merge). Gated HERE and not via
+                                             # `verbs` for the same structural reason opsmessage.compose
+                                             # is: party-service is not, and should not become, a
+                                             # money_path_services entry (it moves no value), so the
+                                             # verb clause can never derive a `party` scope and no verb
+                                             # addition could ever reach this action.
+                                             # Why it needs the gate at all: a merge is destructive OF
+                                             # IDENTITY and irreversible in practice — one operator can
+                                             # retire a real customer behind another party id, and every
+                                             # downstream consumer follows `merged_into`. It carried only
+                                             # @RolesAllowed(ROLE_OPERATOR, ROLE_ADMIN) + an audit event,
+                                             # which records who did it but stops nobody.
+                                             # GUARDRAIL check (the one above, applied): confirmed no M2M
+                                             # caller. party-service's own rego states party.merge "has NO
+                                             # in-repo M2M caller today"; the edge M2M identity is granted
+                                             # only {party.consent.update, party:resolve} by the rule that
+                                             # names it (service-edge-party-m2m), and the ADR-0179 sweep
+                                             # counterpart transaction.merge-sweep is already gated by the
+                                             # `sweep` verb — so both halves of the merge flow now pause
+                                             # for a second approver, or neither does.
 
     # ---------------------------------------------------------------------------------------
     # Feature-flag flip governance (ADR-0067 follow-up, issue #419). The OPA PEP (rest.rego)

--- a/openbank-infra/gitops/components/tpp-registry/tpp-registry-service.yaml
+++ b/openbank-infra/gitops/components/tpp-registry/tpp-registry-service.yaml
@@ -23,7 +23,7 @@ spec:
       annotations:
         # Rolls the pod when the OPA bundle changes (subPath mounts do not hot-reload).
         # Kept in sync by gen-tpp-registry-opa-bundle.sh (do not hand-edit).
-        openbank.tech/policy-checksum: "11a89b3e96e5afe0"
+        openbank.tech/policy-checksum: "a5aaba4479f404a9"
     spec:
       securityContext:
         runAsNonRoot: true

--- a/openbank-libs/governance/policies/rest_test.rego
+++ b/openbank-libs/governance/policies/rest_test.rego
@@ -61,7 +61,7 @@ rules_real := {
 			"transitionStatus", "recall", "settle", "disburse", "send", "credit", "debit",
 			"collateralRegister", "convert", "grant", "revoke", "clear",
 		],
-		"actions": ["opsmessage.compose"],
+		"actions": ["opsmessage.compose", "party.merge"],
 	},
 	"feature_flags": {
 		"prohibited_flag_combinations": [
@@ -353,6 +353,40 @@ test_four_eyes_required_sanctions_clear_real_action if {
 	# SanctionsResource.kt: @Authorize(action = "sanctions.clear", ...) -- decide a
 	# screening hit (CLEAR/HIT/POTENTIAL_HIT). Confirmed no M2M caller.
 	rest.four_eyes_required with input as {"action": "sanctions.clear"}
+		with data.rules as rules_real
+}
+
+# ---------------------------------------------------------------------------------------
+# party.merge (ADR-0179, issue #1984) -- gated via four_eyes.ACTIONS, not verbs. The three
+# tests below are a set: the first proves the gate fires, the second proves it fires for a
+# structural reason a verb addition could never supply, and the third proves the gate is
+# narrow. Without the second, a reader would reasonably assume `merge` had been added to
+# `verbs` and that party-service was somehow money-path; it is not, and never will be.
+# ---------------------------------------------------------------------------------------
+test_four_eyes_required_party_merge_real_action if {
+	# PartyResource.kt: @Authorize(action = "party.merge", resource = "#id") -- retire a
+	# duplicate identity into a survivor. Destructive of identity, irreversible in practice.
+	rest.four_eyes_required with input as {"action": "party.merge"}
+		with data.rules as rules_real
+}
+
+test_party_is_not_a_money_path_scope if {
+	# The reason party.merge MUST live in four_eyes.actions: `verbs` derives its scopes from
+	# money_path_services, and party-service is not on that list. If this ever flips, revisit
+	# the actions entry -- but until then, no verb addition can reach party.*.
+	not "party" in rest.money_path_scopes with data.rules as rules_real
+}
+
+test_four_eyes_not_required_for_other_party_actions if {
+	# The gate is exact-action, so the rest of the party surface is untouched -- including
+	# party.approval.decide, the checker endpoint itself. Gating that would deadlock the flow.
+	not rest.four_eyes_required with input as {"action": "party.update"}
+		with data.rules as rules_real
+
+	not rest.four_eyes_required with input as {"action": "party.consent.update"}
+		with data.rules as rules_real
+
+	not rest.four_eyes_required with input as {"action": "party.approval.decide"}
 		with data.rules as rules_real
 }
 

--- a/openbank-libs/governance/rules.yaml
+++ b/openbank-libs/governance/rules.yaml
@@ -901,6 +901,27 @@ four_eyes:
                                          # explicitly excludes any service-account-* principal id
                                          # (rest.rego operator-compose-message), the same exclusion
                                          # m2m-sanctions-screening uses for the opposite carve-out.
+    - party.merge                       # ADR-0179: retire a duplicate identity into a survivor
+                                         # (POST /api/v1/parties/{id}/merge). Gated HERE and not via
+                                         # `verbs` for the same structural reason opsmessage.compose
+                                         # is: party-service is not, and should not become, a
+                                         # money_path_services entry (it moves no value), so the
+                                         # verb clause can never derive a `party` scope and no verb
+                                         # addition could ever reach this action.
+                                         # Why it needs the gate at all: a merge is destructive OF
+                                         # IDENTITY and irreversible in practice — one operator can
+                                         # retire a real customer behind another party id, and every
+                                         # downstream consumer follows `merged_into`. It carried only
+                                         # @RolesAllowed(ROLE_OPERATOR, ROLE_ADMIN) + an audit event,
+                                         # which records who did it but stops nobody.
+                                         # GUARDRAIL check (the one above, applied): confirmed no M2M
+                                         # caller. party-service's own rego states party.merge "has NO
+                                         # in-repo M2M caller today"; the edge M2M identity is granted
+                                         # only {party.consent.update, party:resolve} by the rule that
+                                         # names it (service-edge-party-m2m), and the ADR-0179 sweep
+                                         # counterpart transaction.merge-sweep is already gated by the
+                                         # `sweep` verb — so both halves of the merge flow now pause
+                                         # for a second approver, or neither does.
 
 # ---------------------------------------------------------------------------------------
 # Feature-flag flip governance (ADR-0067 follow-up, issue #419). The OPA PEP (rest.rego)

--- a/openbank-party-service/build.gradle.kts
+++ b/openbank-party-service/build.gradle.kts
@@ -32,6 +32,7 @@ dependencies {
     implementation(libs.quarkus.smallrye.fault.tolerance)
     implementation(libs.quarkus.scheduler)
     implementation(libs.quarkus.cache)
+    implementation(libs.quarkus.redis.client) // four-eyes ApprovalStore for party.merge (ADR-0155, ADR-0179)
     implementation(libs.kotlinx.coroutines.core)
     implementation(libs.kotlinx.coroutines.reactive)
     implementation(libs.jackson.module.kotlin)

--- a/openbank-party-service/src/main/kotlin/com/openbank/party/infrastructure/approval/ApprovalConfig.kt
+++ b/openbank-party-service/src/main/kotlin/com/openbank/party/infrastructure/approval/ApprovalConfig.kt
@@ -1,0 +1,34 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright (c) OpenBank contributors. Licensed under the Apache License, Version 2.0.
+// See LICENSE in the repository root or https://www.apache.org/licenses/LICENSE-2.0 for details.
+
+package com.openbank.party.infrastructure.approval
+
+import com.openbank.libs.approval.ApprovalStore
+import com.openbank.libs.approval.impl.RedisApprovalStore
+import io.quarkus.redis.datasource.ReactiveRedisDataSource
+import jakarta.enterprise.context.ApplicationScoped
+import jakarta.enterprise.inject.Produces
+import java.time.Clock
+
+/**
+ * Per-service producer for [ApprovalStore] (ADR-0155, wired for the ADR-0179 `party.merge`
+ * four-eyes gate). Mirrors `com.openbank.notification.infrastructure.approval.ApprovalConfig`
+ * — see [RedisApprovalStore]'s KDoc for why this is a per-service `@Produces` rather than a
+ * libs-side bean (a `@Produces` in openbank-libs-runtime would drag a Redis type into the
+ * Arc type closure of every service in the fleet, including the ~30 with no Redis extension).
+ *
+ * Producing this bean makes `AuthorizeInterceptor.approvalStore.isResolvable` true, which
+ * matters beyond this service: `isResolvable` checks CDI bean presence, not whether
+ * [ReactiveRedisDataSource] can actually reach a Redis instance. `gitops/components/party/
+ * redis.yaml` and the `QUARKUS_REDIS_HOSTS` override on the Deployment are what make that
+ * true here — without them this bean would exist but every call would fail on a Redis
+ * connection error rather than fail open with the interceptor's documented log line
+ * (issue #1354, found live in lending-service's identical wiring with no Redis behind it).
+ */
+@ApplicationScoped
+class ApprovalConfig {
+    @Produces
+    @ApplicationScoped
+    fun approvalStore(redis: ReactiveRedisDataSource, clock: Clock): ApprovalStore = RedisApprovalStore(redis, clock)
+}

--- a/openbank-party-service/src/main/kotlin/com/openbank/party/infrastructure/rest/ApprovalResource.kt
+++ b/openbank-party-service/src/main/kotlin/com/openbank/party/infrastructure/rest/ApprovalResource.kt
@@ -1,0 +1,87 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright (c) OpenBank contributors. Licensed under the Apache License, Version 2.0.
+// See LICENSE in the repository root or https://www.apache.org/licenses/LICENSE-2.0 for details.
+
+package com.openbank.party.infrastructure.rest
+
+import com.openbank.libs.approval.ApprovalStore
+import com.openbank.libs.approval.PendingApproval
+import com.openbank.libs.authz.Authorize
+import io.quarkus.security.identity.SecurityIdentity
+import jakarta.annotation.security.RolesAllowed
+import jakarta.inject.Inject
+import jakarta.ws.rs.NotFoundException
+import jakarta.ws.rs.PATCH
+import jakarta.ws.rs.Path
+import jakarta.ws.rs.PathParam
+import jakarta.ws.rs.Produces
+import jakarta.ws.rs.core.MediaType
+import jakarta.ws.rs.core.Response
+import org.eclipse.microprofile.openapi.annotations.Operation
+import org.eclipse.microprofile.openapi.annotations.tags.Tag
+
+/**
+ * Checker-facing endpoint for the four-eyes gate on `party.merge` — retiring a duplicate
+ * identity into a survivor (ADR-0179), the one destructive-of-identity action this service
+ * exposes. A maker's `POST /api/v1/parties/{id}/merge` is paused by
+ * [com.openbank.libs.authz.AuthorizeInterceptor] with HTTP 202 and a `PendingApproval` id
+ * when OPA flags the action `four_eyes_required` (rules.yaml `four_eyes.actions`); a
+ * DIFFERENT operator decides it here, then the maker retries the original call with an
+ * `X-Approval-Id` header. Mirrors `openbank-consent-service`'s and
+ * `openbank-notification-service`'s `ApprovalResource` — one decide endpoint covers every
+ * gated action on the service.
+ *
+ * Note the checker's roles: ROLE_OPERATOR / ROLE_ADMIN, the SAME pair the merge endpoint
+ * itself admits. Segregation of duties here is by IDENTITY, not by role — enforced in
+ * [ApprovalStore.decide], which throws
+ * [com.openbank.libs.approval.SelfApprovalNotAllowedException] when the checker is the
+ * maker. That choice is deliberate: a role-based split would need a role the running
+ * Keycloak realm actually issues, and issue #2540 measured four template-declared roles
+ * missing from the live realm — a split on one of those would be a gate nobody could pass.
+ * ROLE_OPERATOR and ROLE_ADMIN are both live.
+ */
+@Path("/api/v1/parties/approvals")
+@Produces(MediaType.APPLICATION_JSON)
+@Tag(name = "Party Approvals", description = "Four-eyes decisions for gated party actions")
+class ApprovalResource(private val approvalStore: ApprovalStore) {
+
+    @Inject
+    lateinit var identity: SecurityIdentity
+
+    @PATCH
+    @Path("/{id}")
+    @RolesAllowed("ROLE_OPERATOR", "ROLE_ADMIN")
+    @Authorize(action = "party.approval.decide", resource = "#id")
+    @Operation(summary = "Approve or reject a pending four-eyes approval for a gated party action")
+    suspend fun decide(@PathParam("id") id: String, request: DecideApprovalRequest): Response {
+        val decided = approvalStore.decide(id, checkerId(), request.approve)
+            ?: throw NotFoundException("no pending approval with id=$id")
+        return Response.ok(decided.toApprovalResponse()).build()
+    }
+
+    // .principal.name (preferred_username), NOT .subject (UUID) — MUST match how
+    // AuthorizeInterceptor.buildQuery resolves the maker's Principal.id, or approval.makerId and
+    // this checker's id would be formatted differently for the same real person and the
+    // self-approval guard in ApprovalStore.decide could silently fail to catch a maker approving
+    // their own request. SecurityIdentity (not @Context SecurityContext) since this is a
+    // `suspend fun` — mirrors consent-service's ApprovalResource.
+    private fun checkerId(): String = identity.principal?.name ?: "anonymous"
+}
+
+data class DecideApprovalRequest(val approve: Boolean)
+
+data class ApprovalResponse(
+    val id: String,
+    val action: String,
+    val resourceId: String?,
+    val status: String,
+    val decidedBy: String?,
+)
+
+fun PendingApproval.toApprovalResponse() = ApprovalResponse(
+    id = id,
+    action = action,
+    resourceId = resourceId,
+    status = status.name,
+    decidedBy = decidedBy,
+)

--- a/openbank-party-service/src/main/kotlin/com/openbank/party/infrastructure/rest/PartyResource.kt
+++ b/openbank-party-service/src/main/kotlin/com/openbank/party/infrastructure/rest/PartyResource.kt
@@ -262,13 +262,20 @@ class PartyResource {
     @POST
     @Path("/{id}/merge")
     @RolesAllowed("ROLE_OPERATOR", "ROLE_ADMIN")
-    @Authorize(action = "party.merge")
+    // `resource = "#id"` is load-bearing for the four-eyes gate, not decoration: the interceptor
+    // stamps the PendingApproval with query.resource?.id, so WITHOUT it every approval would be
+    // created (and matched) with resourceId=null — an approval a checker granted to merge party A
+    // would then satisfy a merge of party B by the same maker. See ApprovalResource.
+    @Authorize(action = "party.merge", resource = "#id")
     @Operation(
         summary = "Merge a duplicate party into a surviving party (ADR-0179)",
         description = "Retires {id} as a duplicate, preserving all PII and history. NOT erasure: " +
             "no anonymization, no PARTY_ERASED event. Refuses while the duplicate still owns an " +
             "open account — sweep the balances via a ledger ADJUSTMENT journal entry and close " +
-            "the account first.",
+            "the account first. Four-eyes gated (ADR-0155): when four-eyes enforcement is on, the " +
+            "first call returns 202 with an approvalId; a DIFFERENT operator decides it via " +
+            "PATCH /api/v1/parties/approvals/{approvalId} and the maker retries this call with an " +
+            "X-Approval-Id header.",
     )
     suspend fun mergeParty(@PathParam("id") id: UUID, req: MergePartyRequest): Response {
         val merged = partyUseCase.mergeParty(

--- a/openbank-party-service/src/main/resources/application.yaml
+++ b/openbank-party-service/src/main/resources/application.yaml
@@ -39,6 +39,24 @@ quarkus:
   hibernate-orm:
     database:
       generation: none
+  # Four-eyes ApprovalStore backing store (ADR-0155). party-service has no other Redis
+  # usage. The cluster value comes from QUARKUS_REDIS_HOSTS on the Deployment, pointing at
+  # gitops/components/party/redis.yaml — without a reachable Redis the ApprovalConfig bean
+  # still resolves (so the interceptor believes four-eyes is wired) and every gated merge
+  # fails on a connection error instead: issue #1354.
+  redis:
+    hosts: redis://localhost:6379
+    # Kept OUT of the readiness probe, deliberately — a deviation from the other
+    # ApprovalStore-wired services, and the reason matters. The Quarkus Redis extension
+    # registers a readiness check by default, so a dead Redis would flip party-service to
+    # NotReady and stop ALL party traffic: the registry reads and POST /parties that every
+    # onboarding depends on, plus the GDPR export. Trading a whole service outage for a
+    # four-eyes store that today gates exactly one operator action (and is not even enforced
+    # yet) is the wrong bargain. A Redis failure still surfaces loudly and precisely — the
+    # merge call errors — instead of silently amputating the service. The other services
+    # leave this on because their Redis is on the money path itself; party-service's is not.
+    health:
+      enabled: false
   oidc:
     auth-server-url: http://localhost:8080/realms/openbank
     client-id: openbank-services
@@ -220,3 +238,14 @@ opa:
 # policy is rejecting the right calls.
 authz:
   enforce: "${AUTHZ_ENFORCE:true}"
+  # ADR-0155: four-eyes ENFORCEMENT (pausing a maker's `party.merge` pending a second
+  # approver), independent of the base allow/deny enforce toggle above — the interceptor
+  # reaches the four-eyes branch on an ALLOW regardless of `authz.enforce`. Stays false by
+  # default, the same deliberate separate rollout decision every other service wiring an
+  # ApprovalStore makes (billing/sepa-payment/consent/notification carry the identical
+  # comment): flipping AUTHZ_FOUR_EYES_ENFORCE is a runbook-gated follow-up, not bundled
+  # with the ApprovalStore wiring itself. Until it is flipped in
+  # gitops/components/party/party-service.yaml, the gate is WIRED BUT INERT — the
+  # interceptor records authz_four_eyes{outcome="required_not_enforced"} and proceeds.
+  four-eyes:
+    enforce: "${AUTHZ_FOUR_EYES_ENFORCE:false}"

--- a/openbank-party-service/src/main/resources/openapi.yaml
+++ b/openbank-party-service/src/main/resources/openapi.yaml
@@ -3,7 +3,10 @@
 openapi: 3.1.0
 info:
   title: Party Service API
-  version: 1.8.0
+  # major == openbank.api.version == URL /api/v1 (ADR-0048). Minor bump (1.8 -> 1.9): additive
+  # only — a new PATCH /api/v1/parties/approvals/{id} endpoint and an additional 202 response
+  # on POST /{id}/merge (ADR-0155 four-eyes). No existing response or schema changed.
+  version: 1.9.0
   description: Legal entity and individual party management with document storage.
   license:
     name: Apache-2.0
@@ -152,12 +155,67 @@ paths:
       responses:
         '200':
           description: The retired party, carrying status MERGED and mergedIntoPartyId
+        '202':
+          description: >-
+            Four-eyes gate (ADR-0155): the merge is paused pending a second approver. The body
+            carries `{"status":"PENDING_APPROVAL","approvalId":"<id>"}`. A DIFFERENT operator
+            decides it via PATCH /api/v1/parties/approvals/{approvalId}; the maker then retries
+            this same request with an `X-Approval-Id` header, which unlocks it exactly once.
+            Only returned when four-eyes enforcement is enabled for this deployment
+            (`AUTHZ_FOUR_EYES_ENFORCE`); off by default.
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  status: { type: string, enum: [PENDING_APPROVAL] }
+                  approvalId: { type: string }
         '404':
           $ref: '#/components/responses/NotFound'
         '409':
           description: >-
             A merge precondition failed — already merged, the target is itself merged (chains are
             refused), a party is erased, or the duplicate still owns an open account.
+
+  /api/v1/parties/approvals/{id}:
+    patch:
+      tags: [Parties]
+      summary: >-
+        Approve or reject a pending four-eyes approval for a gated party action
+        (party.merge, ADR-0155/ADR-0179)
+      description: >-
+        The checker half of the maker-checker gate. The decider must be a DIFFERENT identity from
+        the maker — enforced in the shared ApprovalStore, not just here — and an approval can be
+        decided once and consumed once.
+      operationId: decideApproval
+      parameters:
+        - name: id
+          in: path
+          required: true
+          schema:
+            type: string
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              type: object
+              properties:
+                approve: { type: boolean }
+              required: [approve]
+      responses:
+        '200':
+          description: The decided approval
+        '403':
+          description: >-
+            The decider is the original maker — segregation of duties (SelfApprovalNotAllowedMapper
+            in openbank-libs-runtime).
+        '404':
+          description: No pending approval with that id
+        '409':
+          description: >-
+            The approval is not PENDING — already decided, or already consumed
+            (InvalidApprovalStateMapper in openbank-libs-runtime).
 
   /api/v1/parties/{id}/consent:
     patch:


### PR DESCRIPTION
Refs #1984 (item 3 of the ADR-0179 follow-on checklist — the one the triage pass ranked first).

## The gap

`POST /api/v1/parties/{id}/merge` retires a real customer identity behind another party id, and it is irreversible in practice: every downstream consumer follows `merged_into` from that point on. It carried `@RolesAllowed("ROLE_OPERATOR", "ROLE_ADMIN")` plus an audit event. The audit records **who did it**; it stops nobody. Every comparable destructive mutation in the fleet carries a maker/checker gate — `git grep -i "fourEyes|maker"` in party-service matched only a `.mmd` diagram.

Notably the *other half* of the same ADR-0179 flow was already gated: `transaction.merge-sweep` is covered by the `sweep` verb. So the balance movement paused for a second approver while the identity retirement it exists to serve did not.

## What this does

Wires the **existing** fleet mechanism (ADR-0155), no new machinery:

| | |
|---|---|
| `rules.yaml` | `four_eyes.actions` gains `party.merge` — the ADR-0176 D5 **exact-action** clause, deliberately not `verbs` |
| party-service | `ApprovalConfig` (Redis `ApprovalStore`) + `ApprovalResource` — `PATCH /api/v1/parties/approvals/{id}`, mirroring consent/notification verbatim |
| `PartyResource` | `resource = "#id"` added to the merge `@Authorize` |
| gitops | `components/party/redis.yaml` + `QUARKUS_REDIS_HOSTS`; NetworkPolicies regenerated |
| openapi | `1.8.0 → 1.9.0` (additive: new endpoint + a `202` on merge) |
| all 65 OPA bundles | regenerated (`rules.yaml` is a checksum input to 25 of 26 generators) |

**Why `actions` and not `verbs`.** `verbs` derives its scopes from `money_path_services`, and party-service is not on that list and should not be — it moves no value. So no verb addition could ever have reached `party.*`. `rest_test.rego` now pins that structural fact next to the gate, because a reader would otherwise reasonably assume `merge` had been added to `verbs`.

**Why `resource = "#id"` is load-bearing, not cosmetic.** The interceptor stamps the `PendingApproval` with `query.resource?.id`, and `satisfies()` matches on it. Without the annotation every approval would be created *and matched* with `resourceId=null` — an approval a checker granted for merging party A would then satisfy a merge of party B by the same maker. The gate would have existed and been bypassable.

**Guardrail applied.** `rules.yaml`'s own four-eyes guardrail (issue #938 follow-up) says a verb/action is only safe to gate if every real caller fleet-wide is a human. Confirmed: party-service's own rego states `party.merge` "has NO in-repo M2M caller today", and the rule that *names* the edge M2M identity (`service-edge-party-m2m`) grants it only `{party.consent.update, party:resolve}`.

## Two honest caveats — please read before assuming the endpoint is protected

**1. The gate is WIRED BUT INERT today.** `authz.four-eyes.enforce` defaults to `false` and is **not** overridden in gitops, so the interceptor records `authz_four_eyes{outcome="required_not_enforced"}` and proceeds. This is the same state every other `ApprovalStore`-wired service in the fleet ships in — flipping it is a deliberate separate operational decision, and `party-service.yaml` carries the commented-out env plus the two preconditions I would want met first: (a) a second `ROLE_OPERATOR`/`ROLE_ADMIN` identity must exist, since a single-operator sandbox would deadlock every merge; (b) the admin-UI merge action (issue #1984 item 4) must handle the `202` + `X-Approval-Id` retry, or the console reads the pause as a failure. I did not flip it.

**2. The roles it depends on ARE live.** Following the #2540 finding (four template-declared roles absent from the running realm, which made ADR-0116's KYC four-eyes unenforceable): this gate splits duties by **identity**, not by role — `ApprovalStore.decide` throws `SelfApprovalNotAllowedException` when checker == maker. The checker endpoint admits `ROLE_OPERATOR`/`ROLE_ADMIN`, both of which are live (neither is among the four missing). `check-roles-allowed-realm.py` passes: 347 sites, every named role issued.

## One deliberate deviation from the fleet

`quarkus.redis.health.enabled: false`. The Quarkus Redis extension registers a readiness check by default; leaving it on would mean a dead Redis flips party-service to `NotReady` and stops **all** party traffic — the registry reads and `POST /parties` that every onboarding depends on. Trading a whole-service outage for a store that gates one operator action and is not even enforced yet is the wrong bargain. A Redis failure still surfaces loudly and precisely: the merge call errors. The other services keep it on because their Redis is on the money path itself; party-service's is not. (This is also what surfaced it — `PartyApiIT`'s readiness assertion went `200 → 503`.)

## Verification

- **Falsified the new rego tests first.** Removing `party.merge` from the `rules_real` fixture and re-running: `test_four_eyes_required_party_merge_real_action: FAIL`. With it: PASS. `88/90` on the branch vs `85/87` on `origin/main` — the same 2 pre-existing failures (`allow_ai_agent_*`, which need the agents data `build-bundle.sh` supplies), 3 new tests, all passing.
- `:openbank-party-service:` `detekt` `ktlintCheck` `test` `koverVerify` `quarkusBuild` — green. `quarkusBuild` specifically, since the new `@Produces` + Redis extension is CDI wiring that unit tests cannot validate. The `@Produces` is per-service, **not** in `openbank-libs-runtime`, so its blast radius is this one service's Arc type closure.
- OPA generators + `gen-network-policies.py` re-run **after** the final `rules.yaml` edit and confirmed idempotent (empty second diff).
- `check-license-headers.py`, `check-roles-allowed-realm.py`: pass. `check-openapi-route-conformance.py`: the new route is not among the findings, i.e. it matched a served route.
- Duplicate-YAML-key check over every touched yaml: clean.

## Not in scope

Items 1, 2 and 4 of #1984 (ledger `ADJUSTMENT` path, consumer adoption of `merged_into`, admin-UI action) remain open — hence `Refs`, not `Closes`. Item 4 is explicitly gated on this one.

🤖 Generated with [Claude Code](https://claude.com/claude-code)