### PR TITLE
ci(governance): make check-authz-pdp-parity reason from @Authorize presence, not the manifest alone

### DIFF
--- a/.github/scripts/check-authz-pdp-parity.py
+++ b/.github/scripts/check-authz-pdp-parity.py
@@ -12,22 +12,43 @@ this guard closes the general case so a service can never again enforce authz wi
 
 WHAT IT CHECKS: for every workload (Deployment / argoproj Rollout) under
 openbank-infra/gitops/components/** whose app container runs an `openbank-<svc>-service` image:
+  annotated = the service module's src/main Kotlin carries >= 1 real `@Authorize` annotation
+              (comments stripped first — see below)
   enforces = (app container's AUTHZ_ENFORCE env, if set) else (the service's application.yaml
              `authz.enforce` default: `${AUTHZ_ENFORCE:true}` or an absent `authz:` block ⇒ true;
              `${AUTHZ_ENFORCE:false}` ⇒ false — the libs default is true)
   has_pdp  = that SAME pod spec has a container named `opa`
-  violation iff enforces AND NOT has_pdp
+  violation iff annotated AND enforces AND NOT has_pdp
 The opa check is per-workload, not per-file, so a shared manifest (payments-services.yaml holds
 several Rollouts, each with its own opa sidecar) is handled correctly.
+
+WHY `annotated` IS PART OF THE PREDICATE (issue #2228). Without it the guard reasons purely from
+the manifest and the `AUTHZ_ENFORCE` default, and flags a service that has nothing to fail closed:
+finrep-service and onboarding-service carry ZERO `@Authorize` between them, yet were both reported
+as violations. Nothing on those services was bricked and no sidecar would have fixed anything —
+wiring one is ceremony, not a fix. That matters because the guard's count is read as "how much of
+#1797 is left": a count that can never reach 0 by wiring is a count people stop trusting. The
+converse defect is the one this predicate now also closes and is the reason it stays: a service can
+declare `AUTHZ_ENFORCE=false` and be counted clean forever while growing `@Authorize` annotations
+that will brick the day someone flips the flag. The count now means what its name implies.
+
+The count reaching 0 on `main` today is NOT evidence this predicate works: #2403 set
+`AUTHZ_ENFORCE=false` on both finrep and onboarding manifests, so the old manifest-only reasoning
+also reports 0. The fix is therefore purely preventative, and its falsification lives in
+check_authz_pdp_parity_test.py — which feeds it a service that MUST flag and one that MUST NOT.
+
+COMMENTS ARE STRIPPED BEFORE MATCHING, and the stripper mirrors the fact that Kotlin block comments
+NEST (`/* /* */ */` closes once, not twice). A guard over source text that matches raw text flags
+the very prose that explains the bug it exists to catch — this file's own KDoc writes `@Authorize`
+several times, and a KDoc on a resource saying "this used to carry @Authorize" is not an annotation.
 
 KNOWN LIMITATION: this checks the MANIFEST, not the live pod. standing-order-service's manifest
 declares the sidecar but the running pod lacks it (manifest-vs-live drift) — a manifest guard cannot
 see that. Live-drift is a separate detector's job; this guard's contract is "the declared manifest
 is self-consistent".
 
-ADVISORY: findings are ::warning:: annotations; exits 0 unless invoked with --enforce. It graduates
-to enforce once the fleet carries no violations — 2 remain on main (finrep-service,
-onboarding-service), so `--enforce` exits 1 today.
+ADVISORY: findings are ::warning:: annotations; exits 0 unless invoked with --enforce. It has
+graduated: ci.yml invokes it with `--enforce`, and the fleet carries no violations.
 
 There is NO rule for this gate in rules.yaml, and there never has been. Earlier text here cited an
 `authz_pdp_parity.target_enforce_date` key as the graduation deadline; that key does not exist, so
@@ -49,6 +70,79 @@ import yaml
 
 IMAGE_SVC = re.compile(r"openbank-([a-z0-9-]+-service)\b")
 WORKLOAD_KINDS = {"Deployment", "Rollout"}
+
+# `@Authorize` as an annotation use-site: the identifier must not be part of a longer word
+# (`@AuthorizeSomething`), and an import line is not a use.
+AUTHORIZE_USE = re.compile(r"@Authorize\b(?!\s*\w*\s*=)")
+
+
+def strip_kotlin_comments(src: str) -> str:
+    """Remove Kotlin line and block comments, leaving string literals intact.
+
+    Kotlin block comments NEST — `/* /* */ */` is ONE comment — so a naive scan to the first
+    `*/` closes early and leaks the tail of a KDoc back into the matched text. Raw (`\"\"\"`)
+    and normal string literals are preserved so a literal containing `//` or `/*` cannot
+    swallow real code.
+    """
+    out: list[str] = []
+    i, n, depth = 0, len(src), 0
+    while i < n:
+        if depth:
+            if src.startswith("/*", i):
+                depth += 1
+                i += 2
+            elif src.startswith("*/", i):
+                depth -= 1
+                i += 2
+            else:
+                # Keep newlines so line numbers and blank-line structure survive.
+                if src[i] == "\n":
+                    out.append("\n")
+                i += 1
+            continue
+        if src.startswith("/*", i):
+            depth = 1
+            i += 2
+        elif src.startswith("//", i):
+            while i < n and src[i] != "\n":
+                i += 1
+        elif src.startswith('"""', i):
+            j = src.find('"""', i + 3)
+            j = n if j == -1 else j + 3
+            out.append(src[i:j])
+            i = j
+        elif src[i] == '"':
+            j = i + 1
+            while j < n and src[j] != '"':
+                j += 2 if src[j] == "\\" else 1
+            j = min(j + 1, n)
+            out.append(src[i:j])
+            i = j
+        else:
+            out.append(src[i])
+            i += 1
+    return "".join(out)
+
+
+def has_authorize_annotation(root: pathlib.Path, service_dir_name: str) -> bool:
+    """True iff the module's src/main Kotlin carries at least one real `@Authorize` use.
+
+    Comments are stripped first (see strip_kotlin_comments): this file's own KDoc, and the
+    KDoc of any resource explaining the annotation, must not read as an annotation.
+    """
+    src_main = root / service_dir_name / "src" / "main"
+    if not src_main.exists():
+        return False
+    for kt in src_main.rglob("*.kt"):
+        try:
+            text = kt.read_text(encoding="utf-8")
+        except OSError:
+            continue
+        if "@Authorize" not in text:  # cheap pre-filter; the stripper is the authority
+            continue
+        if AUTHORIZE_USE.search(strip_kotlin_comments(text)):
+            return True
+    return False
 
 
 def app_enforce_default(root: pathlib.Path, service_dir_name: str) -> bool | None:
@@ -112,6 +206,7 @@ def main() -> int:
 
     violations: list[tuple[str, str, str]] = []
     checked = 0
+    unannotated: list[str] = []
 
     for path, workload in iter_workloads(components):
         containers = pod_containers(workload)
@@ -133,6 +228,13 @@ def main() -> int:
             default = app_enforce_default(root, service_dir)
             enforces = bool(default)  # None (no app.yaml) ⇒ treat as not-enforcing, can't assert
 
+        # A service with no `@Authorize` has nothing that can fail closed, so a missing PDP
+        # sidecar is not a defect there — it is the correct absence (#2228).
+        annotated = has_authorize_annotation(root, service_dir)
+        if not annotated:
+            unannotated.append(svc_full)
+            continue
+
         if enforces and not has_pdp:
             rel = path.relative_to(root)
             violations.append((svc_full, str(rel), "env" if env_enforce is not None else "app-default"))
@@ -146,9 +248,13 @@ def main() -> int:
             f"AUTHZ_ENFORCE=false until it is wired."
         )
 
+    # Print the skipped set, so "0 violations" is never mistaken for "everything was examined" —
+    # the reader can see exactly which workloads the annotation predicate took out of scope.
     print(
-        f"check-authz-pdp-parity: {checked} workload(s) checked; {len(violations)} enforce-without-PDP "
-        f"violation(s)."
+        f"check-authz-pdp-parity: {checked} workload(s) checked; "
+        f"{len(unannotated)} skipped (no @Authorize in src/main: "
+        f"{', '.join(sorted(set(unannotated))) or 'none'}); "
+        f"{len(violations)} enforce-without-PDP violation(s)."
     )
     return 1 if (violations and args.enforce) else 0
 

--- a/.github/scripts/check_authz_pdp_parity_test.py
+++ b/.github/scripts/check_authz_pdp_parity_test.py
@@ -1,0 +1,179 @@
+# SPDX-License-Identifier: Apache-2.0
+"""Falsification tests for check-authz-pdp-parity.py (issue #2228).
+
+THE POINT OF THIS FILE. The guard reports 0 violations on `main` today, and that 0 is NOT
+evidence it works: #2403 set `AUTHZ_ENFORCE=false` on the finrep and onboarding manifests, so
+the OLD manifest-only reasoning also reports 0. A gate that has only ever printed 0 is
+unfalsified — its failure path is code nobody has run. So every test here builds a fixture tree
+and asserts what the guard PRINTS, not merely its exit code, in both directions:
+
+  must_flag     — @Authorize present, enforce true, no `opa` sidecar  -> 1 violation
+  must_not_flag — @Authorize present, enforce true, sidecar declared  -> 0 violations
+  must_not_flag — NO @Authorize, enforce true, no sidecar             -> 0 violations, skipped
+  must_flag     — @Authorize only in a NESTED KDoc                    -> not an annotation
+
+Run: python3 .github/scripts/check_authz_pdp_parity_test.py
+"""
+from __future__ import annotations
+
+import importlib.util
+import pathlib
+import subprocess
+import sys
+import tempfile
+import textwrap
+import unittest
+
+import yaml
+
+HERE = pathlib.Path(__file__).resolve().parent
+SCRIPT = HERE / "check-authz-pdp-parity.py"
+
+_spec = importlib.util.spec_from_file_location("check_authz_pdp_parity", SCRIPT)
+mod = importlib.util.module_from_spec(_spec)
+assert _spec.loader is not None
+_spec.loader.exec_module(mod)
+
+
+def workload_yaml(service: str, *, sidecar: bool, enforce: str | None) -> str:
+    """A minimal but REAL workload doc — built as a dict and dumped, so the fixture cannot be
+    quietly malformed. A hand-indented f-string produced `0 workload(s) checked` and every
+    assertion passed vacuously; that near-miss is why this goes through yaml.safe_dump."""
+    app: dict = {"name": "app", "image": f"ghcr.io/jiraska/openbank-{service}:1.0.0"}
+    if enforce is not None:
+        app["env"] = [{"name": "AUTHZ_ENFORCE", "value": enforce}]
+    containers = [app]
+    if sidecar:
+        containers.append({"name": "opa", "image": "openpolicyagent/opa:1.0.0"})
+    return yaml.safe_dump(
+        {
+            "apiVersion": "apps/v1",
+            "kind": "Deployment",
+            "metadata": {"name": service},
+            "spec": {"template": {"spec": {"containers": containers}}},
+        }
+    )
+
+
+class Fixture:
+    """A minimal repo: one gitops workload plus one service module."""
+
+    def __init__(self, service: str, *, sidecar: bool, enforce: str | None, kotlin: str | None):
+        self.tmp = tempfile.TemporaryDirectory()
+        self.root = pathlib.Path(self.tmp.name)
+        comp = self.root / "openbank-infra" / "gitops" / "components" / service
+        comp.mkdir(parents=True)
+        (comp / f"{service}.yaml").write_text(workload_yaml(service, sidecar=sidecar, enforce=enforce))
+        src = self.root / f"openbank-{service}" / "src" / "main" / "kotlin"
+        src.mkdir(parents=True)
+        if kotlin is not None:
+            (src / "Resource.kt").write_text(kotlin)
+        res = self.root / f"openbank-{service}" / "src" / "main" / "resources"
+        res.mkdir(parents=True)
+        res.joinpath("application.yaml").write_text("authz:\n  enforce: \"${AUTHZ_ENFORCE:true}\"\n")
+
+    def run(self, *extra: str) -> tuple[int, str]:
+        proc = subprocess.run(
+            [sys.executable, str(SCRIPT), str(self.root), *extra],
+            capture_output=True,
+            text=True,
+        )
+        return proc.returncode, proc.stdout + proc.stderr
+
+    def __enter__(self):
+        return self
+
+    def __exit__(self, *a):
+        self.tmp.cleanup()
+
+
+ANNOTATED = textwrap.dedent(
+    """\
+    package com.openbank.x
+
+    import com.openbank.libs.authz.Authorize
+
+    class Resource {
+        @Authorize(action = "read", resource = "x")
+        fun get(): String = "ok"
+    }
+    """
+)
+
+# The exact shape that broke sibling guards: prose ABOUT the annotation, inside a KDoc whose
+# nested block comment closes early under a naive stripper.
+PROSE_ONLY = textwrap.dedent(
+    """\
+    package com.openbank.x
+
+    /**
+     * This resource deliberately carries no @Authorize.
+     * /* a nested block, as KDoc code samples routinely contain: @Authorize(action = "x") */
+     * Everything above is commentary, not an annotation.
+     */
+    class Resource {
+        fun get(): String = "ok"
+    }
+    """
+)
+
+
+class TestParity(unittest.TestCase):
+    # ---- direction 1: it MUST flag ------------------------------------------------
+    def test_flags_annotated_service_with_no_sidecar(self):
+        with Fixture("must-flag-service", sidecar=False, enforce="true", kotlin=ANNOTATED) as f:
+            code, out = f.run("--enforce")
+            self.assertIn("1 enforce-without-PDP violation", out, out)
+            self.assertIn("must-flag-service enforces authz", out, out)
+            self.assertIn("::error", out, out)
+            self.assertEqual(1, code, out)
+
+    def test_flags_when_enforce_comes_from_the_application_yaml_default(self):
+        with Fixture("must-flag-service", sidecar=False, enforce=None, kotlin=ANNOTATED) as f:
+            code, out = f.run("--enforce")
+            self.assertIn("1 enforce-without-PDP violation", out, out)
+            self.assertIn("(app-default)", out, out)
+            self.assertEqual(1, code, out)
+
+    # ---- direction 2: it MUST NOT flag --------------------------------------------
+    def test_does_not_flag_annotated_service_that_has_a_sidecar(self):
+        with Fixture("good-service", sidecar=True, enforce="true", kotlin=ANNOTATED) as f:
+            code, out = f.run("--enforce")
+            self.assertIn("0 enforce-without-PDP violation", out, out)
+            self.assertNotIn("0 skipped", out.replace("0 skipped (no @Authorize in src/main: none)", ""), out)
+            self.assertEqual(0, code, out)
+
+    def test_does_not_flag_a_service_with_no_authorize_at_all(self):
+        """finrep/onboarding: nothing to fail closed, so a missing PDP is not a defect."""
+        with Fixture("bare-service", sidecar=False, enforce="true", kotlin=None) as f:
+            code, out = f.run("--enforce")
+            self.assertIn("0 enforce-without-PDP violation", out, out)
+            self.assertIn("skipped (no @Authorize in src/main: bare-service)", out, out)
+            self.assertEqual(0, code, out)
+
+    def test_prose_about_the_annotation_is_not_an_annotation(self):
+        """A KDoc naming @Authorize — including one with a NESTED block comment — must not count."""
+        with Fixture("prose-service", sidecar=False, enforce="true", kotlin=PROSE_ONLY) as f:
+            code, out = f.run("--enforce")
+            self.assertIn("0 enforce-without-PDP violation", out, out)
+            self.assertIn("skipped (no @Authorize in src/main: prose-service)", out, out)
+            self.assertEqual(0, code, out)
+
+
+class TestCommentStripper(unittest.TestCase):
+    def test_nested_block_comments_close_once(self):
+        got = mod.strip_kotlin_comments("a /* x /* y */ z */ b")
+        self.assertNotIn("z", got)
+        self.assertIn("a", got)
+        self.assertIn("b", got)
+
+    def test_string_literals_survive(self):
+        self.assertIn('"// not a comment"', mod.strip_kotlin_comments('val s = "// not a comment"'))
+        self.assertIn("/* not a comment */", mod.strip_kotlin_comments('val s = """/* not a comment */"""'))
+
+    def test_line_comment_removed_but_newline_kept(self):
+        self.assertEqual("val a = 1\nval b = 2\n", mod.strip_kotlin_comments("val a = 1 // c\nval b = 2\n").replace(" \n", "\n"))
+
+
+if __name__ == "__main__":
+    unittest.main(verbosity=2)

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -440,8 +440,14 @@ jobs:
       # generation, authz-coverage) are stdlib Python with committed *_test.py suites that,
       # until now, no workflow ran — a gate whose own logic is untested silently rots. Run
       # them here so a regression in a gate's parser fails the PR that introduced it.
+      # BOTH script directories, not just openbank-infra/scripts: gates live in .github/scripts
+      # too, and a discovery root that covers only one of them is a coverage set maintained
+      # separately from the artifacts it covers — the exact shape that let 16 pacts go
+      # unreplayed (#2327). Adding a *_test.py beside a gate must be enough to have it run.
       - name: governance-script unit tests
-        run: python3 -m unittest discover -s openbank-infra/scripts -p '*_test.py' -v
+        run: |
+          python3 -m unittest discover -s openbank-infra/scripts -p '*_test.py' -v
+          python3 -m unittest discover -s .github/scripts -p '*_test.py' -v
 
       # issue #669 scope item 3 / rules.yaml: slo. Every money_path_services entry needs a
       # matching availability + latency Pyrra ServiceLevelObjective whose target/window match


### PR DESCRIPTION
Closes #2228.

## The defect

`check-authz-pdp-parity.py` decided a service was in violation from its gitops manifest plus the
`application.yaml` `AUTHZ_ENFORCE` default. It never asked whether the service carries any
`@Authorize` at all — so `finrep-service` and `onboarding-service`, which have **zero** between
them, were both reported as violations. Nothing there fails closed and no rego would grant
anything; a sidecar would have been ceremony. That matters because the guard's count is read as
"how much of #1797 is left", and a count that cannot reach 0 by wiring is a count people stop
trusting.

## The fix

`violation iff annotated AND enforces AND NOT has_pdp`.

Adding `annotated` also closes the **converse** defect, which is why it stays after #2403: a
service could declare `AUTHZ_ENFORCE=false`, read as clean forever, and grow `@Authorize`
annotations that brick the day someone flips the flag.

Comments are stripped before matching, and the stripper mirrors the fact that **Kotlin block
comments NEST** (`/* /* */ */` closes once). A guard over source text otherwise flags the very
prose that explains the bug it exists to catch — this script's own KDoc writes `@Authorize`
several times.

The summary line now also names the skipped set, so `0 violations` can never be mistaken for
"everything was examined":

```
check-authz-pdp-parity: 37 workload(s) checked; 5 skipped (no @Authorize in src/main:
agent-service, ap2-service, finrep-service, mcp-service, onboarding-service);
0 enforce-without-PDP violation(s).
```

## Falsification — both directions, and why the green proves nothing on its own

**The 0 on `main` today is not evidence this works.** #2403 set `AUTHZ_ENFORCE=false` on the
finrep and onboarding manifests, so the *old* manifest-only reasoning also prints 0. The change is
purely preventative, and an unfalsified gate is one whose failure path nobody has run — so
`check_authz_pdp_parity_test.py` builds fixture trees and asserts what the guard **prints**, not
merely its exit code:

| fixture | expected | result |
|---|---|---|
| `@Authorize` + enforce true + **no** sidecar | **1 violation**, `::error`, exit 1 | flags |
| `@Authorize` + enforce from `application.yaml` default + no sidecar | 1 violation, `(app-default)` | flags |
| `@Authorize` + enforce true + sidecar declared | 0 violations, exit 0 | does not flag |
| **no** `@Authorize` + enforce true + no sidecar | 0 violations, `skipped` | does not flag |
| `@Authorize` only inside a **nested** KDoc | 0 violations, `skipped` | does not flag |

Plus three unit tests on the stripper itself (nesting, string literals preserved, line comments).

The first fixture was initially built from a hand-indented f-string and produced
`0 workload(s) checked` — every assertion passed **vacuously**. The fixture now goes through
`yaml.safe_dump` so it cannot be quietly malformed; that near-miss is recorded in the file.

## CI wiring

`ci.yml`'s `governance-script unit tests` step discovered only `openbank-infra/scripts`. Gates live
in `.github/scripts` too, so its coverage set was maintained separately from the artifacts it
covers — the shape that let 16 pacts go unreplayed (#2327). It now discovers both roots, so
committing a `*_test.py` beside a gate is enough to have it run.

Verified against the real fleet: 37 workloads checked, 0 violations, `--enforce` exits 0 — no
change to what blocks today.

Refs #1797, #2403.