### PR TITLE
test(admin-ui): select the grantee lens before clicking Look up on /consents

### DIFF
--- a/openbank-admin-ui/e2e/ui-primitives.spec.ts
+++ b/openbank-admin-ui/e2e/ui-primitives.spec.ts
@@ -128,7 +128,20 @@ test.describe('ADR-0208 primitives render with real CSS applied', () => {
       route.fulfill({ status: 200, body: JSON.stringify(CONSENTS) }),
     )
     await page.goto('/consents')
-    await page.getByRole('button', { name: /Vyhledat|Look up/ }).click()
+
+    // The grantee lens has to be selected first. #2568 wrote this test when /consents had a
+    // single grantee-id field; #2604 added the party/grantee lens selector and made `party` the
+    // default, so the "Look up" button this test clicks is no longer rendered on load — the
+    // click waited 30 s for a locator that never resolves and every admin-ui PR went red.
+    // Selecting the lens is not a workaround: the mocked route below IS the grantee endpoint,
+    // so this is the flow the test was always asserting about.
+    await page.getByRole('combobox').selectOption('grantee')
+    // Selecting `grantee` seeds the input with MARKETING_GRANTEE, so the button is enabled;
+    // asserting that before clicking keeps a future `disabled` regression from re-reading as
+    // this same 30 s timeout.
+    const lookUp = page.getByRole('button', { name: /Vyhledat|Look up/ })
+    await expect(lookUp).toBeEnabled()
+    await lookUp.click()
 
     const active = page.locator('.badge', { hasText: /^ACTIVE$/ })
     const revoked = page.locator('.badge', { hasText: /^REVOKED$/ })


### PR DESCRIPTION
## The Admin UI build is red on every admin-ui PR right now

Measured on **#2247, #2604, #2605 and #2606** — all four fail the identical test with the identical
30 s timeout:

```
[chromium] › e2e/ui-primitives.spec.ts:126:7 › StatusBadge distinguishes ACTIVE from REVOKED …
  Error: locator.click: Test timeout of 30000ms exceeded.
    - waiting for getByRole('button', { name: /Vyhledat|Look up/ })
```

## Root cause — two PRs that were each fine alone

- **#2568** added `/consents` with a single grantee-id field and wrote this test against it.
- **#2604** (`eab0ff54`, merged today) added the **party / grantee lens selector** and made
  `party` the default. The "Look up" button is inside `{lens === 'grantee' && (…)}`, so on load it
  is **not rendered at all** — the click waits for a locator that never resolves.

Neither PR is wrong; the test's premise moved out from under it. This is the semantic-merge shape:
each passed CI alone, `main` went red.

## The fix

Select the grantee lens first. That is **not** a workaround — the route the test mocks is
`**/api/svc/consent-service/api/v1/consents/grantee/**`, so the grantee lens is the flow this test
was always asserting about; it was only ever reachable by accident of the old default.

It also asserts `toBeEnabled()` before clicking, so a future `disabled` regression fails as itself
rather than re-reading as this same opaque 30 s timeout.

## Verification — both directions, run locally

| | result |
|---|---|
| `npx playwright test e2e/ui-primitives.spec.ts` **with** the change | **4 passed** |
| same test **without** the change (stashed) | **1 failed**, same timeout on the same line |

The tone assertion itself (`ACTIVE` ≠ `REVOKED` background) is unchanged and now actually executes
— it had not run since #2604 merged.

Refs #2568, #2604. Unblocks #2247.