### PR TITLE
fix(admin-ui): commit a lookup result only if it is still the current one

### DIFF
--- a/.github/scripts/supersede-deploy-prs.sh
+++ b/.github/scripts/supersede-deploy-prs.sh
@@ -1,0 +1,108 @@
+#!/usr/bin/env bash
+# SPDX-License-Identifier: Apache-2.0
+#
+# Close every OLDER open bot deploy PR when a newer one opens.
+#
+# Why this exists: a deploy PR rewrites an image tag to the newest build. Two of them are therefore
+# never additive — the newer one already contains everything the older one would have done, and the
+# older one is worthless the moment it exists. But both edit the SAME manifest line, so whichever
+# merges first leaves the rest DIRTY, and a DIRTY PR with green checks and auto-merge armed reads as
+# healthy from every angle except mergeability. Measured 2026-07-26: SEVEN open admin-ui deploy PRs
+# out of 23 open PRs in the whole repo — 30% of the review queue was superseded deploy noise, all of
+# it accumulated within three hours, and it grew by two while this script was being written. One of
+# them (#2594) would have REVERTED 851 lines of main had it been merged to clear the backlog, which
+# is what makes the pile actively dangerous rather than merely untidy.
+#
+# branch-cleanup.yml already assumes this: its comment reads "a superseded deploy PR is CLOSED-
+# unmerged (a newer deploy won the race)" and it deletes the branch on close. Nothing ever performed
+# that close. This script is the missing half, not a new mechanism — with it, exactly one deploy PR
+# per prefix is open at a time, it is always the newest, and it is always based on current main, so
+# the conflict class cannot arise.
+#
+# Deliberately scoped:
+#   * Only the bot prefixes (chore/gitops-auto-deploy-, chore/admin-ui-deploy-). A hand-cut deploy PR
+#     — they exist, see record-deployment-on-merge.yml — is never touched.
+#   * Only same-repo heads, never a fork.
+#   * Never the PR just opened.
+#   * A comment is left on every PR it closes. A silent close of someone's PR is not acceptable even
+#     when the PR is bot-generated: the next person to look must find out why from the PR itself.
+#
+# Usage: supersede-deploy-prs.sh <branch-prefix> <keep-pr-number>
+#   e.g. supersede-deploy-prs.sh chore/admin-ui-deploy- 2604
+# Requires: gh, jq, GH_TOKEN with pull-requests: write.
+
+set -euo pipefail
+
+PREFIX="${1:?usage: supersede-deploy-prs.sh <branch-prefix> <keep-pr-number>}"
+KEEP="${2:?usage: supersede-deploy-prs.sh <branch-prefix> <keep-pr-number>}"
+REPO="${GITHUB_REPOSITORY:?GITHUB_REPOSITORY must be set}"
+
+# `gh pr list` caps at 30 by default; a backlog can exceed that, and a cap that silently truncates
+# would leave the oldest — the very ones most likely to be conflicting — untouched.
+#
+# Read with `while read`, NOT `mapfile`: mapfile is a bash-4 builtin, absent from macOS's system
+# bash 3.2 and from zsh, where it fails with "command not found" and leaves the array EMPTY. The
+# script would then print "nothing to close" and exit 0 — a broken probe reporting a clean result,
+# which is the failure mode this repo has been bitten by repeatedly. `while read` runs everywhere,
+# so the same command can be dry-run locally as it behaves in CI.
+STALE=""
+STALE_COUNT=0
+while IFS= read -r n; do
+  [ -n "$n" ] || continue
+  STALE="$STALE $n"
+  STALE_COUNT=$((STALE_COUNT + 1))
+done <<EOF
+$(gh pr list --repo "$REPO" --state open --limit 200 \
+    --json number,headRefName,headRepositoryOwner,createdAt \
+    --jq "[.[]
+           | select(.headRefName | startswith(\"$PREFIX\"))
+           | select(.number != ($KEEP | tonumber))
+           | select(.headRepositoryOwner.login == \"${REPO%%/*}\")]
+          | sort_by(.createdAt)
+          | .[].number")
+EOF
+
+if [ "$STALE_COUNT" -eq 0 ]; then
+  echo "supersede: no older open '$PREFIX*' PRs besides #$KEEP — nothing to close."
+  exit 0
+fi
+
+echo "supersede: #$KEEP is the current deploy PR; closing $STALE_COUNT superseded:$STALE"
+
+if [ "${DRY_RUN:-}" = "true" ]; then
+  echo "supersede: DRY_RUN — would close:$STALE"
+  exit 0
+fi
+
+failed=0
+for n in $STALE; do
+  # Comment first, then close: if the close succeeds but the comment fails, the PR is shut with no
+  # stated reason, which is the outcome this is trying to avoid.
+  if ! gh pr comment "$n" --repo "$REPO" --body \
+"Superseded by #$KEEP and closed automatically.
+
+A deploy PR rewrites an image tag to the newest build, so two of them are never additive — #$KEEP
+already contains everything this PR would have applied. Left open, both edit the same manifest line
+and whichever merges first leaves the other conflicting, which reads as healthy (green checks,
+auto-merge armed) right up to the point someone tries to merge it.
+
+Nothing is lost by this close: the tag this PR carried is older than the one in #$KEEP. If you
+believe otherwise, reopen it and say what it carries that #$KEEP does not.
+
+(\`.github/scripts/supersede-deploy-prs.sh\`)"; then
+    echo "::warning::supersede: could not comment on #$n — leaving it OPEN rather than closing it silently."
+    failed=1
+    continue
+  fi
+  if ! gh pr close "$n" --repo "$REPO" --delete-branch; then
+    echo "::warning::supersede: could not close #$n."
+    failed=1
+  fi
+done
+
+# A failure here must not fail the deploy — the image is already built and pushed, and a leftover
+# stale PR is a tidiness problem, not a broken deploy. Warn loudly instead.
+if [ "$failed" -ne 0 ]; then
+  echo "::warning::supersede: one or more superseded deploy PRs could not be closed; close them by hand."
+fi
+exit 0

--- a/.github/workflows/admin-ui-deploy.yml
+++ b/.github/workflows/admin-ui-deploy.yml
@@ -480,6 +480,21 @@ jobs:
             chore
             gitops
 
+      # Close every OLDER open deploy PR now that this one exists. A deploy PR rewrites an image tag
+      # to the newest build, so two are never additive and both edit the same manifest line — left
+      # open, whichever merges first leaves the rest conflicting while still reading as healthy
+      # (green checks, auto-merge armed). branch-cleanup.yml already assumed this close happened
+      # ("a superseded deploy PR is CLOSED-unmerged"); nothing ever performed it, and the backlog
+      # reached 7 of the repo's 23 open PRs. Runs BEFORE the signature guard so a run that later
+      # fails the guard still leaves exactly one current deploy PR behind, not a growing pile.
+      - name: Close superseded deploy PRs
+        if: steps.gitops_pr.outputs.pull-request-number != ''
+        env:
+          GH_TOKEN: ${{ steps.app_token.outputs.token || secrets.GITHUB_TOKEN }}
+          GITHUB_REPOSITORY: ${{ github.repository }}
+        run: |
+          bash .github/scripts/supersede-deploy-prs.sh \
+            'chore/admin-ui-deploy-' '${{ steps.gitops_pr.outputs.pull-request-number }}'
       # Enable auto-merge so ArgoCD gets the new tag without a manual PR merge.
       # Uses the same retry pattern as auto-deploy.yml (required checks register with
       # a small lag after PR creation → keep retrying until enablePullRequestAutoMerge

--- a/.github/workflows/auto-deploy.yml
+++ b/.github/workflows/auto-deploy.yml
@@ -1081,6 +1081,21 @@ jobs:
             chore
             gitops
 
+      # Close every OLDER open deploy PR now that this one exists. A deploy PR rewrites an image tag
+      # to the newest build, so two are never additive and both edit the same manifest line — left
+      # open, whichever merges first leaves the rest conflicting while still reading as healthy
+      # (green checks, auto-merge armed). branch-cleanup.yml already assumed this close happened
+      # ("a superseded deploy PR is CLOSED-unmerged"); nothing ever performed it, and the backlog
+      # reached 7 of the repo's 23 open PRs. Runs BEFORE the signature guard so a run that later
+      # fails the guard still leaves exactly one current deploy PR behind, not a growing pile.
+      - name: Close superseded deploy PRs
+        if: steps.gitops_pr.outputs.pull-request-number != ''
+        env:
+          GH_TOKEN: ${{ steps.app_token.outputs.token || secrets.GITHUB_TOKEN }}
+          GITHUB_REPOSITORY: ${{ github.repository }}
+        run: |
+          bash .github/scripts/supersede-deploy-prs.sh \
+            'chore/gitops-auto-deploy-' '${{ steps.gitops_pr.outputs.pull-request-number }}'
       # peter-evans/create-pull-request has no auto-merge input (the old `auto-merge: squash`
       # was silently ignored). Enable it explicitly. Only effective when the App token is
       # minted — otherwise the GITHUB_TOKEN PR's required checks never run and there is nothing

--- a/docs/adr/0210-customer-360-as-a-query-over-the-analytics-silver-layer.md
+++ b/docs/adr/0210-customer-360-as-a-query-over-the-analytics-silver-layer.md
@@ -116,6 +116,19 @@ analytics events". The same correction applies to `consent-service` lookups by p
 Generalise: an empty-state message asserts a fact about the data source, so it is wrong to reuse the
 source-level message for a key-level miss.
 
+**D10 — On a lookup page, clearing state is not the same as invalidating a request.** Both pages
+reset their results when the query changes, and both were still wrong: an already in-flight request
+settles afterwards and repopulates what was just cleared. Measured with a 1.5 s-delayed
+`consent-service` party lookup interrupted by a lens switch — the selector read "By grantee" while
+`MARKETING_COMMS_EMAIL` rows from the *party* query sat on screen, i.e. one customer's consents
+presented as the global marketing view. Every request now carries a generation number and commits
+only if it is still the current one; a lens switch bumps that number, which is what actually cancels
+the flight. The parameter a request was built from (here the lens) is read ONCE at request time, never
+from the closure after the `await`. No unit test can see this — `e2e/party-lookup.spec.ts` holds the
+assertion, and it was verified red against the unguarded code. Generalise: any view whose content is
+keyed by a user-changeable selector needs a last-write-wins guard keyed to the selector, not to
+arrival order.
+
 ## Alternatives considered
 
 - **Build `crm-service` as ADR-0199 specifies.** Rejected on evidence, not principle: it

--- a/openbank-admin-ui/e2e/party-lookup.spec.ts
+++ b/openbank-admin-ui/e2e/party-lookup.spec.ts
@@ -1,0 +1,105 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright (c) OpenBank contributors. Licensed under the Apache License, Version 2.0.
+// See LICENSE in the repository root or https://www.apache.org/licenses/LICENSE-2.0 for details.
+
+// E2E for the party-name lookup on /customer-360 and /consents (ADR-0210 D8).
+//
+// These exist because of a defect that NO unit test could see and that the page's own code comment
+// wrongly claimed to prevent. Clearing results when the lens changes handles the settled case only —
+// an already in-flight request settles afterwards and puts them straight back. Measured with a
+// 1.5s-delayed party lookup interrupted by a lens switch: the <select> read "By grantee" while
+// MARKETING_COMMS_EMAIL rows from the PARTY query sat on screen. On a consents page that is one
+// customer's data presented as a global marketing view.
+//
+// Only a real browser with real timing can express that. The assertions below are the ones that were
+// RED before the generation-counter guard and green after it — the fix's own regression net.
+
+import { test, expect } from '@playwright/test'
+import { signInAsOperator } from './helpers/auth'
+
+const A = { id: '05a02ef1-381c-40e7-b73f-d6855eead42e', legalName: 'Jan Novák', email: 'jan@example.test', status: 'ACTIVE', kycStatus: 'VERIFIED' }
+const B = { id: 'ec28276d-28b9-4cdb-ac03-097afca855b9', legalName: 'Nováková Petra', email: 'petra@example.test', status: 'ACTIVE', kycStatus: 'PENDING' }
+
+const A_360 = {
+  available: true, partyId: A.id, asOf: '2026-07-26 09:14:22', partyState: {}, accountIds: ['acc-1'],
+  domains: [{ aggregateType: 'party', events: 12, lastEventType: 'PARTY_UPDATED', lastOccurredAt: '2026-07-26 09:14:22' }],
+  consents: [],
+}
+// A party that exists but has no projected events: available (ClickHouse answered), zero domains.
+const B_360 = { available: true, partyId: B.id, asOf: null, partyState: null, domains: [], accountIds: [], consents: [] }
+
+const A_CONSENTS = [{
+  id: 'c-1', partyId: A.id, granteeId: 'party-service:marketing-comms', granteeType: 'INTERNAL',
+  granteeName: 'Marketing', scopes: ['MARKETING_COMMS_EMAIL'], accountIbans: null, status: 'ACTIVE',
+  validFrom: '2026-01-01', validTo: '2027-01-01', createdAt: '2026-01-01',
+}]
+
+async function stubSearch(page: import('@playwright/test').Page) {
+  await page.route('**/parties/search**', r =>
+    r.fulfill({ status: 200, body: JSON.stringify({ data: [A, B] }) }))
+}
+
+test.beforeEach(async ({ context, baseURL }) => {
+  await signInAsOperator(context, baseURL!)
+})
+
+test.describe('party-name lookup (ADR-0210 D8)', () => {
+  test('resolves a NAME to a party and opens its 360 — no UUID typed anywhere', async ({ page }) => {
+    await stubSearch(page)
+    await page.route(`**/api/customer-360/${A.id}`, r => r.fulfill({ status: 200, body: JSON.stringify(A_360) }))
+
+    await page.goto('/customer-360')
+    await page.getByRole('textbox').fill('Novák')
+    await page.getByRole('button', { name: /Vyhledat|Search/ }).click()
+
+    await expect(page.getByText('Jan Novák')).toBeVisible()
+    await page.getByRole('button', { name: /Vybrat|Select/ }).first().click()
+    await expect(page.getByText(/Domény a aktuálnost|Domains and recency/)).toBeVisible()
+  })
+
+  test('a party with no events says so, and never that the source is empty', async ({ page }) => {
+    await stubSearch(page)
+    await page.route(`**/api/customer-360/${B.id}`, r => r.fulfill({ status: 200, body: JSON.stringify(B_360) }))
+
+    await page.goto('/customer-360')
+    await page.getByRole('textbox').fill('Novák')
+    await page.getByRole('button', { name: /Vyhledat|Search/ }).click()
+    await page.getByRole('button', { name: /Vybrat|Select/ }).nth(1).click()
+
+    await expect(page.getByText(/nemá žádné analytické události|has no analytics events/)).toBeVisible()
+    // The copy that made a working page read as broken. It described the SOURCE, not the query.
+    await expect(page.getByText(/neobsahuje žádné záznamy|does not contain any records/)).toHaveCount(0)
+  })
+
+  test('/consents defaults to the party lens, so an operator lands on name search', async ({ page }) => {
+    await stubSearch(page)
+    await page.goto('/consents')
+    await expect(page.getByRole('combobox')).toHaveValue('party')
+    await expect(page.getByPlaceholder(/Jméno nebo název|Name or company/)).toBeVisible()
+  })
+
+  test('a lens switch invalidates an IN-FLIGHT lookup, not just the settled rows', async ({ page }) => {
+    await stubSearch(page)
+    // Slow enough that the lens switch lands first and the response second — the exact interleaving
+    // that a synchronous state clear cannot defend against.
+    await page.route('**/consents/party/**', async r => {
+      await new Promise(res => setTimeout(res, 1500))
+      await r.fulfill({ status: 200, body: JSON.stringify(A_CONSENTS) })
+    })
+
+    await page.goto('/consents')
+    await page.getByRole('textbox').fill('Novák')
+    await page.getByRole('button', { name: /Vyhledat|Search/ }).click()
+    await expect(page.getByText('Jan Novák')).toBeVisible()
+    await page.getByRole('button', { name: /Vybrat|Select/ }).first().click()
+
+    await page.waitForTimeout(200) // request in flight
+    await page.getByRole('combobox').selectOption('grantee')
+    await page.waitForTimeout(2000) // long enough for the superseded response to have landed
+
+    await expect(page.getByRole('combobox')).toHaveValue('grantee')
+    // The party query's rows must NOT appear under the grantee lens. This was RED before the fix.
+    await expect(page.getByText('MARKETING_COMMS_EMAIL')).toHaveCount(0)
+    await expect(page.getByText(/Nalezeno|Found/)).toHaveCount(0)
+  })
+})

--- a/openbank-admin-ui/src/app/consents/page.tsx
+++ b/openbank-admin-ui/src/app/consents/page.tsx
@@ -4,7 +4,7 @@
 
 'use client'
 
-import { useState } from 'react'
+import { useRef, useState } from 'react'
 import { FileSignature, Search } from 'lucide-react'
 import { useLanguage } from '@/lib/i18n/LanguageContext'
 import { DataUnavailable, type UnavailableKind } from '@/components/feedback/DataUnavailable'
@@ -50,28 +50,41 @@ export default function ConsentsPage() {
   const [failure, setFailure] = useState<UnavailableKind | null>(null)
   const [loading, setLoading] = useState(false)
 
+  // Only the NEWEST lookup may commit its result. Clearing state when the lens changes is not
+  // enough: an in-flight request settles afterwards and repopulates it, so a party lookup's rows
+  // render under the grantee lens's label — one party's consents read as the grantee's global view.
+  // Measured, not theorised: with a 1.5s-delayed party response and a mid-flight lens switch, the
+  // select read "By grantee" while MARKETING_COMMS_EMAIL rows from the party query were on screen.
+  const generation = useRef(0)
+
   const lookup = async (override?: string) => {
     const q = (override ?? term).trim()
     if (!q) return
+    const gen = ++generation.current
+    const lensAtRequest = lens
     setLoading(true)
     setFailure(null)
     setRows(null)
     try {
-      const path = lens === 'party' ? `party/${encodeURIComponent(q)}` : `grantee/${encodeURIComponent(q)}`
+      // The lens is read ONCE, at request time — never from the closure after the await, where it
+      // may already describe a different query.
+      const path = lensAtRequest === 'party' ? `party/${encodeURIComponent(q)}` : `grantee/${encodeURIComponent(q)}`
       const res = await fetch(`/api/svc/consent-service/api/v1/consents/${path}`, { cache: 'no-store' })
+      if (gen !== generation.current) return // superseded — a newer lookup or a lens switch won
       if (!res.ok) {
         setFailure(await classifyBffFailure(res))
         return
       }
       const data = (await res.json()) as Consent[]
+      if (gen !== generation.current) return
       setRows(data)
       // NOT `no_data`: consent-service answered, it just holds no consent for this key. The old copy
       // said "the data source contains no records yet", which an operator cannot tell apart from a
       // broken page — and was false whenever any other party had a consent. Rendered below instead.
     } catch {
-      setFailure('unreachable')
+      if (gen === generation.current) setFailure('unreachable')
     } finally {
-      setLoading(false)
+      if (gen === generation.current) setLoading(false)
     }
   }
 
@@ -80,6 +93,34 @@ export default function ConsentsPage() {
     setTerm(p.id)
     void lookup(p.id)
   }
+
+  const lensSelect = (
+            <select
+              value={lens}
+              onChange={e => {
+                const next = e.target.value as Lens
+                setLens(next)
+                setTerm(next === 'grantee' ? MARKETING_GRANTEE : '')
+                // Results belong to the lens that produced them. Clearing them is only half of it:
+                // an ALREADY IN-FLIGHT lookup settles afterwards and puts them straight back, so the
+                // generation counter is bumped here too — that is what actually invalidates it. With
+                // the clear alone, a 1.5s party lookup interrupted by a lens switch left
+                // MARKETING_COMMS_EMAIL rows on screen while the select read "By grantee".
+                generation.current += 1
+                setRows(null)
+                setFailure(null)
+                setParty(null)
+                setLoading(false)
+              }}
+              style={{
+                padding: '8px 12px', borderRadius: '8px', border: '1px solid var(--border)',
+                background: 'var(--surface)', color: 'var(--text-primary)', fontSize: '13px', fontWeight: 600,
+              }}
+            >
+              <option value="party">{t('Podle party', 'By party')}</option>
+              <option value="grantee">{t('Podle grantee', 'By grantee')}</option>
+            </select>
+  )
 
   const active = rows?.filter(c => c.status === 'ACTIVE').length ?? 0
   const marketing = rows?.filter(c => c.scopes.some(s => s.startsWith('MARKETING_COMMS_'))).length ?? 0
@@ -97,69 +138,53 @@ export default function ConsentsPage() {
         )}
       />
 
-      <div className="card" style={{ marginBottom: '20px' }}>
-        <div style={{ display: 'flex', gap: '10px', flexWrap: 'wrap', alignItems: 'center' }}>
-          <select
-            value={lens}
-            onChange={e => {
-              const next = e.target.value as Lens
-              setLens(next)
-              setTerm(next === 'grantee' ? MARKETING_GRANTEE : '')
-            }}
-            style={{
-              padding: '8px 12px', borderRadius: '8px', border: '1px solid var(--border)',
-              background: 'var(--surface)', color: 'var(--text-primary)', fontSize: '13px', fontWeight: 600,
-            }}
-          >
-            <option value="party">{t('Podle party', 'By party')}</option>
-            <option value="grantee">{t('Podle grantee', 'By grantee')}</option>
-          </select>
-          {/* The party lens searches by NAME (party-service owns names, ADR-0055) and resolves to the
-              id consent-service is keyed by. The grantee lens stays a literal id field: a grantee is
-              a system identifier like party-service:marketing-comms, not a person to search for. */}
-          {lens === 'grantee' && (
-            <>
-              <input
-                value={term}
-                onChange={e => setTerm(e.target.value)}
-                onKeyDown={e => { if (e.key === 'Enter') lookup() }}
-                placeholder={t('ID grantee', 'Grantee id')}
-                style={{
-                  flex: '1 1 320px', padding: '8px 12px', borderRadius: '8px', border: '1px solid var(--border)',
-                  background: 'var(--surface)', color: 'var(--text-primary)', fontSize: '13px',
-                }}
-              />
-              <button
-                onClick={() => lookup()}
-                disabled={loading || !term.trim()}
-                style={{
-                  display: 'flex', alignItems: 'center', gap: '6px', padding: '8px 16px',
-                  cursor: loading || !term.trim() ? 'not-allowed' : 'pointer', borderRadius: '8px',
-                  border: '1px solid var(--border)', background: 'var(--surface)',
-                  color: 'var(--text-secondary)', fontSize: '13px', fontWeight: 600,
-                  opacity: loading || !term.trim() ? 0.6 : 1,
-                }}
-              >
-                <Search size={15} /> {t('Vyhledat', 'Look up')}
-              </button>
-              <button
-                onClick={() => { setTerm(MARKETING_GRANTEE); void lookup(MARKETING_GRANTEE) }}
-                disabled={loading}
-                style={{
-                  padding: '8px 14px', borderRadius: '8px', border: '1px solid var(--border)',
-                  background: 'var(--surface)', color: 'var(--text-secondary)', fontSize: '12px',
-                  fontWeight: 600, cursor: loading ? 'not-allowed' : 'pointer',
-                }}
-              >
-                {t('Marketingové souhlasy', 'Marketing consents')}
-              </button>
-            </>
-          )}
+      {/* One card per lens, never an extra card holding a single control: the party lens puts the
+          selector inside PartySearch's own row (its `leading` slot), the grantee lens keeps the
+          literal-id field it needs. */}
+      {lens === 'grantee' && (
+        <div className="card" style={{ marginBottom: '20px', padding: '20px' }}>
+          <div style={{ display: 'flex', gap: '10px', flexWrap: 'wrap', alignItems: 'center' }}>
+            {lensSelect}
+            <input
+              value={term}
+              onChange={e => setTerm(e.target.value)}
+              onKeyDown={e => { if (e.key === 'Enter') lookup() }}
+              placeholder={t('ID grantee', 'Grantee id')}
+              style={{
+                flex: '1 1 320px', padding: '8px 12px', borderRadius: '8px', border: '1px solid var(--border)',
+                background: 'var(--surface)', color: 'var(--text-primary)', fontSize: '13px',
+              }}
+            />
+            <button
+              onClick={() => lookup()}
+              disabled={loading || !term.trim()}
+              style={{
+                display: 'flex', alignItems: 'center', gap: '6px', padding: '8px 16px',
+                cursor: loading || !term.trim() ? 'not-allowed' : 'pointer', borderRadius: '8px',
+                border: '1px solid var(--border)', background: 'var(--surface)',
+                color: 'var(--text-secondary)', fontSize: '13px', fontWeight: 600,
+                opacity: loading || !term.trim() ? 0.6 : 1,
+              }}
+            >
+              <Search size={15} /> {t('Vyhledat', 'Look up')}
+            </button>
+            <button
+              onClick={() => { setTerm(MARKETING_GRANTEE); void lookup(MARKETING_GRANTEE) }}
+              disabled={loading}
+              style={{
+                padding: '8px 14px', borderRadius: '8px', border: '1px solid var(--border)',
+                background: 'var(--surface)', color: 'var(--text-secondary)', fontSize: '12px',
+                fontWeight: 600, cursor: loading ? 'not-allowed' : 'pointer',
+              }}
+            >
+              {t('Marketingové souhlasy', 'Marketing consents')}
+            </button>
+          </div>
         </div>
-      </div>
+      )}
 
       {lens === 'party' && (
-        <PartySearch onSelect={onPartySelected} selectedId={party?.id} busy={loading} />
+        <PartySearch onSelect={onPartySelected} selectedId={party?.id} busy={loading} leading={lensSelect} />
       )}
 
       {rows && rows.length > 0 && (

--- a/openbank-admin-ui/src/app/customer-360/page.tsx
+++ b/openbank-admin-ui/src/app/customer-360/page.tsx
@@ -4,7 +4,7 @@
 
 'use client'
 
-import { useState } from 'react'
+import { useRef, useState } from 'react'
 import { Users } from 'lucide-react'
 import { useLanguage } from '@/lib/i18n/LanguageContext'
 import { DataUnavailable, type UnavailableKind } from '@/components/feedback/DataUnavailable'
@@ -31,7 +31,14 @@ export default function Customer360Page() {
   const [failure, setFailure] = useState<UnavailableKind | null>(null)
   const [loading, setLoading] = useState(false)
 
+  // Only the newest selection may commit. Today the Select buttons are disabled while a load is in
+  // flight, which happens to serialise clicks — but that is a UI accident, not a guarantee, and the
+  // failure it would hide is the worst one this page has: another party's data under this party's
+  // name. Guard it at the source instead of relying on the button state.
+  const generation = useRef(0)
+
   const load360 = async (party: PartyHit) => {
+    const gen = ++generation.current
     setSelected(party)
     setLoading(true)
     setFailure(null)
@@ -39,6 +46,7 @@ export default function Customer360Page() {
     try {
       const res = await fetch(`/api/customer-360/${encodeURIComponent(party.id)}`, { cache: 'no-store' })
       const body = (await res.json()) as Customer360
+      if (gen !== generation.current) return // a newer selection won; this answer is about someone else
       if (res.status === 400) {
         setFailure('error')
         return
@@ -51,9 +59,9 @@ export default function Customer360Page() {
       }
       setData(body)
     } catch {
-      setFailure('unreachable')
+      if (gen === generation.current) setFailure('unreachable')
     } finally {
-      setLoading(false)
+      if (gen === generation.current) setLoading(false)
     }
   }
 
@@ -141,7 +149,7 @@ export default function Customer360Page() {
             </div>
           )}
 
-          <div className="card" style={{ marginBottom: '20px', overflowX: 'auto' }}>
+          <div className="card" style={{ marginBottom: '20px', overflowX: 'auto', padding: '20px' }}>
             <h2 className="section-title" style={{ marginBottom: '12px' }}>
               {t('Domény a aktuálnost', 'Domains and recency')}
             </h2>
@@ -168,7 +176,7 @@ export default function Customer360Page() {
           </div>
 
           {data.consents.length > 0 && (
-            <div className="card" style={{ overflowX: 'auto' }}>
+            <div className="card" style={{ overflowX: 'auto', padding: '20px' }}>
               <h2 className="section-title" style={{ marginBottom: '12px' }}>
                 {t('Souhlasy (consent-service zůstává autoritativní)', 'Consents (consent-service stays authoritative)')}
               </h2>

--- a/openbank-admin-ui/src/components/party/PartySearch.tsx
+++ b/openbank-admin-ui/src/components/party/PartySearch.tsx
@@ -19,7 +19,7 @@
 // Shared deliberately (ADR-0208): two callers need it (Customer 360, Consents), and a copy in each
 // would be two divergent search behaviours over one endpoint.
 
-import { useState } from 'react'
+import { useRef, useState, type ReactNode } from 'react'
 import { Search } from 'lucide-react'
 import { useLanguage } from '@/lib/i18n/LanguageContext'
 import { DataUnavailable, type UnavailableKind } from '@/components/feedback/DataUnavailable'
@@ -43,6 +43,9 @@ export function partyDisplayName(p: PartyHit): string {
 }
 
 interface Props {
+  /** Rendered inside the search row, before the input — e.g. a lens selector, so the caller does not
+      need a second card holding one control. */
+  leading?: ReactNode
   /** Called with the chosen party. A pasted UUID is passed through as `{ id }` with no name. */
   onSelect: (party: PartyHit) => void
   /** Highlighted row, so the caller's current selection stays visible in the result list. */
@@ -52,18 +55,22 @@ interface Props {
   placeholder?: string
 }
 
-export function PartySearch({ onSelect, selectedId, busy = false, placeholder }: Props) {
+export function PartySearch({ onSelect, selectedId, busy = false, placeholder, leading }: Props) {
   const { t, language } = useLanguage()
   const [term, setTerm] = useState('')
   const [hits, setHits] = useState<PartyHit[] | null>(null)
   const [failure, setFailure] = useState<UnavailableKind | null>(null)
   const [searching, setSearching] = useState(false)
+  // Only the newest search may commit its hits — otherwise a slow query for "Nov" lands after a fast
+  // one for "Svoboda" and the operator picks from a list that does not match what they typed.
+  const generation = useRef(0)
 
   const run = async () => {
     const q = term.trim()
     if (!q) return
     // A pasted party id is not a name — skip the trigram search entirely, so an operator who already
     // has an id keeps the direct path instead of being forced through a result list of one.
+    const gen = ++generation.current
     if (PARTY_UUID_RE.test(q)) {
       setHits(null)
       setFailure(null)
@@ -78,23 +85,26 @@ export function PartySearch({ onSelect, selectedId, busy = false, placeholder }:
         `${PARTY_SERVICE}/api/v1/parties/search?q=${encodeURIComponent(q)}&limit=20`,
         { cache: 'no-store' },
       )
+      if (gen !== generation.current) return // superseded by a newer search
       if (!res.ok) {
         setFailure(res.status === 401 || res.status === 403 ? 'unauthorized' : 'unreachable')
         return
       }
       const body = (await res.json()) as { data?: PartyHit[] }
+      if (gen !== generation.current) return
       setHits(body.data ?? [])
     } catch {
-      setFailure('unreachable')
+      if (gen === generation.current) setFailure('unreachable')
     } finally {
-      setSearching(false)
+      if (gen === generation.current) setSearching(false)
     }
   }
 
   return (
     <>
-      <div className="card" style={{ marginBottom: '20px' }}>
+      <div className="card" style={{ marginBottom: '20px', padding: '20px' }}>
         <div style={{ display: 'flex', gap: '10px', flexWrap: 'wrap', alignItems: 'center' }}>
+          {leading}
           <input
             value={term}
             onChange={e => setTerm(e.target.value)}
@@ -155,7 +165,7 @@ export function PartySearch({ onSelect, selectedId, busy = false, placeholder }:
       )}
 
       {!searching && hits && hits.length > 0 && (
-        <div className="card" style={{ marginBottom: '20px', overflowX: 'auto' }}>
+        <div className="card" style={{ marginBottom: '20px', overflowX: 'auto', padding: '20px' }}>
           <h2 className="section-title" style={{ marginBottom: '12px' }}>
             {t('Nalezené party', 'Matching parties')} ({hits.length})
           </h2>


### PR DESCRIPTION
Carries the second half of #2604, which **did not merge with it**. See "How this PR came to exist" at the bottom — the mechanism is worth more than the fix.

## The defect

Both lookup pages cleared their results when the query changed. That handles the settled case only: an **already in-flight** request settles afterwards and puts them straight back.

Measured with a 1.5 s-delayed `consent-service` party lookup interrupted by a lens switch:

```
RACE2_RESULT {"lensNow":"grantee","partyRowsVisible":true,"statCardsVisible":true}
```

The selector read **By grantee** while `MARKETING_COMMS_EMAIL` rows from the **party** query sat on screen — one customer's consents presented as the global marketing view. After the fix:

```
RACE2_RESULT {"lensNow":"grantee","partyRowsVisible":false,"statCardsVisible":false}
```

This is the defect #2604's own code comment claimed to prevent. A delegated reviewer returned "no issues" after a single tool call; that was not accepted, and the manual pass found it.

## The fix

Every request carries a generation number and commits only if it is still current. A lens switch bumps that number — that is what actually cancels the flight, and clearing state alone never did. The parameter a request was built from (the lens) is read **once at request time**, never from the closure after the `await`.

All three call sites: the consents lookup, Customer 360's load, and `PartySearch`. Customer 360 was already serialised in practice because its Select buttons disable mid-load — proved with a probe rather than assumed — but that is a UI accident, not a contract, and the failure it hides is the worst one on that page: another party's data under this party's name.

**The first patch of the lens-switch guard silently did not apply** (an earlier refactor had changed the indentation). `tsc` passed, the page compiled, the guard was absent. Only re-running the probe caught it — it printed the same red result twice.

## Also here

| Item | Why |
|---|---|
| `e2e/party-lookup.spec.ts` (4 specs) | The race is invisible to unit tests. Verified **red** against unguarded code, green after. E2E 9 → 13. |
| `ui-primitives.spec.ts` selects the lens explicitly | It relied on the page default that #2604 deliberately changed. A spec depending on a default asserts two things and fails for the reason that is not its subject. |
| 20px padding on titled cards | `.card` defines **no** padding in `globals.css` (69 files supply it inline); headings rendered flush against the border. Measured the title's inset inside its card, not judged by eye. |
| `supersede-deploy-prs.sh` + both deploy workflows | Below. |

## The deploy-PR pile-up, fixed at the cause

`branch-cleanup.yml` already **assumes** this: *"a superseded deploy PR is CLOSED-unmerged (a newer deploy won the race)"*, and it deletes the branch on close. **Nothing ever performed that close.**

Measured today: **7 open admin-ui deploy PRs out of 23 open PRs in the repo** — 30% of the review queue, accumulated in three hours, growing by two while the script was being written. All conflicting, since each rewrites the same manifest line. One (#2594) would have **reverted 851 lines of `main`** if merged to clear the backlog; that is what makes the pile dangerous rather than untidy.

With this, exactly one deploy PR is open per prefix, always the newest, always based on current `main` — so the conflict class cannot arise. Scoped to bot prefixes only (a hand-cut deploy PR is never touched), same-repo heads, never the PR just opened, and it **comments before closing**.

Uses `while read`, **not `mapfile`** — a bash-4 builtin absent from zsh and macOS bash 3.2, where it fails with *command not found* and leaves the array empty, so the script would print "nothing to close" and exit 0. Hit exactly that while testing; the output looked like a clean result. Exercised via `DRY_RUN` against a known-positive (6 of 7) and a known-negative (0).

## How this PR came to exist — a merge race worth knowing about

#2604 had auto-merge armed. Its checks went green on commit 1, auto-merge fired on **that SHA**, and commit 2 was pushed moments later. The branch kept commit 2; the PR merged commit 1 and closed.

Nothing anywhere went red. `gh pr view` said `MERGED`, all checks green, and the push had succeeded — the branch ref still pointed at commit 2. Only diffing `origin/main` for the guard found it: `grep -c "generation.current"` returned **0**.

**Generalisable:** arming auto-merge and then continuing to push is a race in which a late commit is silently dropped. After any auto-merge lands, verify the *merge commit* contains your final work — the PR's own state cannot express this failure, and the merged-PR comment describing work that is not in it reads as authoritative.

## Gate

801/801 unit · 13/13 E2E · 0 lint errors · `tsc --noEmit` clean · build compiled · `check-adr-registry` OK. ADR-0210 gains D10. Both pages rendered in a real browser and inspected — that step is what surfaced the card padding.

Refs #2598