### PR TITLE
test(swift): run SwiftBootSmokeIT and SwiftOutboxClaimIT in CI, the stall is gone

### DIFF
--- a/openbank-swift-service/build.gradle.kts
+++ b/openbank-swift-service/build.gradle.kts
@@ -66,18 +66,29 @@ dependencies {
 // wrong answer costs a few runner-minutes instead of a stalled full-fleet run (#2039).
 // Do not set it in services-ci / _service-ci; re-enabling for real is #2320 item 3, and needs the
 // probe's answer first.
-val swiftBootItProbe = providers.gradleProperty("swift.boot.it").orNull == "true"
-
 // Pact: write generated consumer contracts to pacts/ and forward broker config.
 tasks.withType<Test> {
-    // CI hang #3 (#2320): `@DisabledIfEnvironmentVariable` is evaluated AFTER Quarkus starts
-    // QuarkusTestResource containers (quarkusio/quarkus#21555) — Quarkus ignores the JUnit
-    // condition and boots anyway. SwiftBootSmokeIT hangs at boot for the full 45-min job
-    // timeout, stalling the entire fleet Services CI run. Gradle-level filter prevents Quarkus
-    // from discovering the class in CI; the IT still runs locally (where CI is unset).
-    if (System.getenv("CI") == "true" && !swiftBootItProbe) {
-        filter { excludeTestsMatching("*IT") }
-    }
+    // CI hang #3 (#2320) is GONE — measured, not assumed. `SwiftBootSmokeIT` used to hang 37+ min
+    // at Quarkus boot on the runner pool (`@DisabledIfEnvironmentVariable` is evaluated AFTER
+    // Quarkus starts QuarkusTestResource containers, quarkusio/quarkus#21555), so a blanket
+    // `filter { excludeTestsMatching("*IT") }` kept JUnit from discovering it at all. Both
+    // exclusions are gone as of #2320 item 3. The `swift-boot-it-probe` workflow ran each class
+    // on ubuntu-latest with the exclusions lifted, 2026-07-26:
+    //
+    //     SwiftBootSmokeIT   exit 0, 257s (cap 12m)   run 30201804638
+    //     SwiftOutboxClaimIT exit 0, 215s (cap 12m)   run 30202120687
+    //
+    // The blanket filter is why the second class matters: it was never about SwiftBootSmokeIT
+    // alone. `SwiftOutboxClaimIT` is the #1201 regression test for two dispatchers racing
+    // `claimProcessable`, itself a @QuarkusTest + Testcontainers, and it was swallowed by the same
+    // wildcard — so narrowing the filter to the named class would have looked like the cheap fix
+    // and quietly left a money-path race untested. Both run in CI now.
+    //
+    // The per-test timeout is the guard the exclusion used to be. If the boot stall ever returns,
+    // JUnit kills the test at 8 minutes and the module goes RED, instead of the class sitting on a
+    // runner until the 45-minute fleet job timeout takes the whole matrix down with it — the
+    // failure mode that caused the exclusion in the first place. Fail fast, not fail wide.
+    systemProperty("junit.jupiter.execution.timeout.default", "8m")
     systemProperty("pact.rootDir", "${rootProject.projectDir}/pacts")
     listOf(
         "pactbroker.url",
@@ -91,13 +102,6 @@ tasks.withType<Test> {
         "pact.provider.tag",
     ).forEach { key -> System.getProperty(key)?.let { systemProperty(key, it) } }
 
-    // SwiftBootSmokeIT is a @QuarkusTest — Quarkus's BeforeAllCallback fires before JUnit5 evaluates
-    // @DisabledIfEnvironmentVariable, so the full Quarkus boot + Testcontainers (Postgres + Valkey) still
-    // starts in CI despite the annotation. Boot hangs 37+ min on the runner pool → job timeout.
-    // Gradle-level exclusion prevents JUnit5 from ever discovering the class, so Quarkus never boots.
-    // The class still runs locally (CI env var is not set outside GHA). Re-enable per #2320 —
-    // note that means this service's only real boot test has never once gated a merge.
-    //
     // SwiftMessagePactProviderVerificationTest re-enabled 2026-07-23: the 404-hang reason is
     // gone — transaction-service publishes a consumer pact for openbank-swift-service on every
     // main push, so /for-verification returns content. The class stays
@@ -106,8 +110,9 @@ tasks.withType<Test> {
     // ClassGraph scan; the test now scopes MessageTestTarget to com.openbank.swift.contract. That
     // fix touched only src/test, which does not rebuild this service on main-push, so this
     // build-file note exists to re-trigger the provider verification (#1348 drain).
-    if (System.getenv("CI") == "true" && !swiftBootItProbe) {
-        exclude("**/SwiftBootSmokeIT*")
+    // The `exclude("**/SwiftBootSmokeIT*")` that stood here is gone with the blanket `*IT` filter
+    // above (#2320 item 3) — the stall it guarded against does not reproduce, measured 2026-07-26.
+    if (System.getenv("CI") == "true") {
         // SwiftEventPactConsumerTest and ClearingSimulatorPactConsumerTest USED to be excluded
         // here too, on the stated grounds that PactConsumerTestExt auto-publishes to
         // pactbroker.url in AfterTestTemplate and the broker 401s/hangs. That reason did not

--- a/openbank-swift-service/src/main/resources/db/migration/V8__TEMPORARY_falsification_break.sql
+++ b/openbank-swift-service/src/main/resources/db/migration/V8__TEMPORARY_falsification_break.sql
@@ -1,6 +1,0 @@
--- TEMPORARY — #2320 acceptance criteria: "break the boot deliberately and confirm CI goes red.
--- A boot smoke test that has only ever passed while excluded proves nothing."
--- This migration is deliberately invalid SQL. Flyway fails during boot, SwiftBootSmokeIT's
--- readiness assertion cannot pass, and the swift-service build must go RED.
--- REVERTED in the next commit on this branch. It must not reach main.
-ALTER TABLE swift_outbox ADD COLUMN this_is_not_valid_sql_at_all !!!;

--- a/openbank-swift-service/src/main/resources/db/migration/V8__TEMPORARY_falsification_break.sql
+++ b/openbank-swift-service/src/main/resources/db/migration/V8__TEMPORARY_falsification_break.sql
@@ -1,0 +1,6 @@
+-- TEMPORARY — #2320 acceptance criteria: "break the boot deliberately and confirm CI goes red.
+-- A boot smoke test that has only ever passed while excluded proves nothing."
+-- This migration is deliberately invalid SQL. Flyway fails during boot, SwiftBootSmokeIT's
+-- readiness assertion cannot pass, and the swift-service build must go RED.
+-- REVERTED in the next commit on this branch. It must not reach main.
+ALTER TABLE swift_outbox ADD COLUMN this_is_not_valid_sql_at_all !!!;

--- a/openbank-swift-service/src/test/kotlin/com/openbank/swift/integration/SwiftBootSmokeIT.kt
+++ b/openbank-swift-service/src/test/kotlin/com/openbank/swift/integration/SwiftBootSmokeIT.kt
@@ -13,7 +13,6 @@ import io.restassured.module.kotlin.extensions.When
 import io.smallrye.reactive.messaging.memory.InMemoryConnector
 import org.assertj.core.api.Assertions.assertThat
 import org.junit.jupiter.api.Test
-import org.junit.jupiter.api.condition.DisabledIfEnvironmentVariable
 
 /**
  * Boot smoke test guarding the "released-but-never-booted" defect class.
@@ -29,13 +28,12 @@ import org.junit.jupiter.api.condition.DisabledIfEnvironmentVariable
  * The lone `@Channel("swift-events-out")` Kafka emitter is swapped to the in-memory connector so no
  * broker is needed and the readiness probe carries no Kafka health check.
  */
-// CI-skipped (#2404): root cause — Quarkus's JUnit5 BeforeAllCallback fires BEFORE JUnit5 evaluates
-// @DisabledIfEnvironmentVariable, so Quarkus boots + Testcontainers (Postgres + Valkey) starts in CI
-// despite this annotation. The containers hang on CI runners → 45-min job timeout. The REAL guard is
-// the Gradle-level `exclude("**/SwiftBootSmokeIT*")` in build.gradle.kts (evaluated at task config
-// time, before JUnit5 discovery). This annotation remains as a defence-in-depth fallback. Re-enable
-// per #2404 (runner-side investigation needed).
-@DisabledIfEnvironmentVariable(named = "CI", matches = "true")
+// RUNS IN CI as of #2320. The `@DisabledIfEnvironmentVariable(named = "CI", matches = "true")` that
+// stood here is deleted, not merely superseded: leaving it while dropping the Gradle exclusion would
+// have been the worst of both worlds — Quarkus boots (its BeforeAllCallback fires BEFORE JUnit5
+// evaluates the condition, quarkusio/quarkus#21555) and JUnit then SKIPS every test method, so CI
+// pays the full boot cost and reports green having asserted nothing. A skipped boot test is not a
+// weaker boot test; it is the absence of one wearing its name.
 @QuarkusTest
 @QuarkusTestResource(SwiftBootSmokeIT.InMemoryKafkaResource::class)
 @QuarkusTestResource(com.openbank.swift.it.PostgresRedisTestResource::class)


### PR DESCRIPTION
Closes #2320.

## Item 1: the probe answered — the stall is gone

`swift-boot-it-probe` (#2485) ran each excluded class on `ubuntu-latest` with the exclusions lifted,
2026-07-26:

| class | exit | elapsed | cap | run |
|---|---|---|---|---|
| `SwiftBootSmokeIT` | **0** | **257 s** | 12 m | [30201804638](https://github.com/JiRaska/open-bank-oss/actions/runs/30201804638) |
| `SwiftOutboxClaimIT` | **0** | **215 s** | 12 m | [30202120687](https://github.com/JiRaska/open-bank-oss/actions/runs/30202120687) |

Not a marginal pass: 257 s against the 37+ minutes the original comment describes. Item 2 is moot;
this is item 3.

## Item 3: both exclusions, not the named one

The blanket `filter { excludeTestsMatching("*IT") }` also swallowed **`SwiftOutboxClaimIT`** — the
#1201 regression test for two dispatchers racing `claimProcessable` during an Argo Rollouts canary
window, itself a `@QuarkusTest` + Testcontainers. Narrowing the filter to `SwiftBootSmokeIT` was the
cheap-looking half-fix that would have left a money-path race untested. That is why the probe was
run against **both** classes before anything was deleted.

## The annotation is deleted, not kept as defence in depth

`@DisabledIfEnvironmentVariable(named = "CI", matches = "true")` is removed from the class. Keeping
it while dropping the Gradle exclusion is the **worst** outcome available: Quarkus's
`BeforeAllCallback` fires before JUnit 5 evaluates the condition (quarkusio/quarkus#21555), so
Quarkus boots, JUnit then **skips every test method**, and CI pays the entire boot cost while
reporting green having asserted nothing. A skipped boot test is not a weaker boot test; it is the
absence of one wearing its name. It was easy to miss, sitting redundant under the exclusion.

## The timeout replaces the exclusion

`junit.jupiter.execution.timeout.default = 8m`. If the stall returns, the module goes red in 8
minutes instead of holding a runner until the **45-minute** fleet job timeout takes the whole matrix
with it — the failure mode that caused the exclusion. Fail fast, not fail wide. This is item 2's
"timeout well under the fleet job timeout", kept even though item 3 was the branch taken.

Also drops the stale `#2404` reference (item 4's remaining prose).

## Falsification — the acceptance criterion, both directions

> break the boot deliberately … and confirm CI goes red. A boot smoke test that has only ever
> passed while excluded proves nothing.

Commit 2 on this branch added an invalid Flyway migration; commit 3 reverts it. Both halves were run
with **`CI=true`** — the environment the exclusion keyed on — and read from the **JUnit XML**, not
the console (`gradlew | tail` masks the exit code):

**With the deliberate break** — `:openbank-swift-service:test` exits **1**:

```
SwiftBootSmokeIT   tests=2 failures=1 skipped=1
  FAIL  the service-info endpoint answers on the configured HTTP port
        java.lang.RuntimeException: Failed to start quarkus
  SKIP  the app boots and the readiness probe reports UP
        TestAbortedException: Boot failed
```

**After the revert** — exits **0**, and both formerly-excluded classes actually execute:

```
SwiftBootSmokeIT    tests=2 failures=0 skipped=0
SwiftOutboxClaimIT  tests=2 failures=0 skipped=0
TOTAL               tests=59 failures=0 errors=0 skipped=1
```

`skipped=0` on both is the load-bearing number: it is what distinguishes "the boot test runs and
passes" from "the boot test was skipped and CI called that green" — the exact vacuous-green the
deleted annotation would have produced.

Refs #578, #2485, #1201.