### PR TITLE
docs(governance): publish the eight served card, interest, payment and SWIFT routes the specs omit

### DIFF
--- a/.github/openapi-route-conformance-baseline.txt
+++ b/.github/openapi-route-conformance-baseline.txt
@@ -24,9 +24,6 @@ openbank-agent-service served-not-published GET /api/v1/admin/agents/halts
 openbank-agent-service served-not-published POST /api/v1/admin/agents/halt
 openbank-agent-service served-not-published POST /api/v1/admin/agents/resume
 openbank-balance-service served-not-published PUT /api/v1/balances/{accountId}/{currency}/overdraft-limit
-openbank-card-issuance-service served-not-published GET /api/v1/cards
-openbank-card-issuance-service served-not-published PUT /api/v1/cards/{id}/controls
-openbank-card-issuance-service served-not-published PUT /api/v1/cards/{id}/limits
 openbank-customer-edge served-not-published DELETE /customer/v1/accounts/{accountId}/pockets/{currency}
 openbank-customer-edge served-not-published DELETE /customer/v1/consents/{id}
 openbank-customer-edge served-not-published DELETE /customer/v1/devices/{id}
@@ -76,8 +73,6 @@ openbank-customer-edge served-not-published POST /customer/v1/webauthn/session/r
 openbank-customer-edge served-not-published PUT /customer/v1/notification-preferences
 openbank-fx-service served-not-published GET /api/v1/fx/cnb/rates/{base}
 openbank-fx-service served-not-published POST /api/v1/fx/cnb/ingest
-openbank-interest-service served-not-published GET /api/v1/interest/accounts/{accountId}/effective-rate
-openbank-interest-service served-not-published GET /api/v1/interest/accruals
 openbank-ledger-service served-not-published POST /api/v1/ledger/fx-revaluation
 openbank-notification-service served-not-published GET /api/v1/preferences/party/{partyId}
 openbank-notification-service served-not-published PUT /api/v1/preferences/party/{partyId}
@@ -100,6 +95,3 @@ openbank-security-scanner served-not-published GET /api/v1/ict-incidents/{id}
 openbank-security-scanner served-not-published PATCH /api/v1/ict-incidents/{id}/status
 openbank-security-scanner served-not-published POST /api/v1/ict-incidents
 openbank-security-scanner served-not-published POST /api/v1/ict-incidents/{id}/regulatory-report
-openbank-sepa-instant served-not-published GET /api/v1/sepa-instant
-openbank-standing-order-service served-not-published GET /api/v1/standing-orders
-openbank-swift-service served-not-published GET /api/v1/swift/messages

--- a/openbank-card-issuance-service/src/main/resources/openapi.yaml
+++ b/openbank-card-issuance-service/src/main/resources/openapi.yaml
@@ -3,7 +3,7 @@
 openapi: 3.1.0
 info:
   title: Card Issuance Service API
-  version: 1.1.0
+  version: 1.2.0
   description: Debit/credit card lifecycle — issue, activate, block, suspend, resume, cancel;
     synthetic PAN vault and product-catalog entitlements.
   license:
@@ -17,6 +17,23 @@ tags:
 
 paths:
   /api/v1/cards:
+    get:
+      tags: [Cards]
+      summary: List every card
+      description: >-
+        The unfiltered collection. Requires ROLE_VIEWER, ROLE_OPERATOR or ROLE_ADMIN (authorize
+        action `card.list`). Never carries PAN/CVV — those are only ever served by
+        `/api/v1/cards/{id}/secure-details`.
+      operationId: listCards
+      responses:
+        '200':
+          description: All cards
+          content:
+            application/json:
+              schema:
+                type: array
+                items:
+                  $ref: '#/components/schemas/CardResponse'
     post:
       tags: [Cards]
       summary: Issue a new card
@@ -237,6 +254,76 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/CardEntitlementsResponse'
+
+  /api/v1/cards/{id}/limits:
+    put:
+      tags: [Cards]
+      summary: Set a card's daily and monthly spending limits
+      operationId: updateCardLimits
+      parameters:
+        - $ref: '#/components/parameters/cardId'
+        - name: X-Operator-Id
+          in: header
+          required: true
+          schema:
+            type: string
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              type: object
+              required: [dailyLimitMinorUnits, monthlyLimitMinorUnits]
+              properties:
+                dailyLimitMinorUnits:
+                  type: integer
+                  format: int64
+                monthlyLimitMinorUnits:
+                  type: integer
+                  format: int64
+      responses:
+        '200':
+          description: Limits updated
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/CardResponse'
+
+  /api/v1/cards/{id}/controls:
+    put:
+      tags: [Cards]
+      summary: Set a card's channel controls (contactless / online / ATM / abroad)
+      operationId: updateCardControls
+      parameters:
+        - $ref: '#/components/parameters/cardId'
+        - name: X-Operator-Id
+          in: header
+          required: true
+          schema:
+            type: string
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              type: object
+              required: [contactlessEnabled, onlineEnabled, atmEnabled, abroadEnabled]
+              properties:
+                contactlessEnabled:
+                  type: boolean
+                onlineEnabled:
+                  type: boolean
+                atmEnabled:
+                  type: boolean
+                abroadEnabled:
+                  type: boolean
+      responses:
+        '200':
+          description: Controls updated
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/CardResponse'
 
   /api/v1/cards/{id}/suspend:
     post:

--- a/openbank-interest-service/src/main/resources/openapi.yaml
+++ b/openbank-interest-service/src/main/resources/openapi.yaml
@@ -3,7 +3,7 @@
 openapi: 3.1.0
 info:
   title: Interest Service API
-  version: 1.3.0
+  version: 1.4.0
   description: >-
     Interest accrual, capitalization, and rate configuration. Capitalization withholds Czech
     final tax on credit interest (§36/§38d ZDP, ADR-0033): CZK interest credited to a resident
@@ -80,6 +80,48 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/Capitalization'
+
+  /api/v1/interest/accruals:
+    get:
+      tags: [Interest]
+      summary: List every interest accrual
+      description: >-
+        The unfiltered collection across all accounts (authorize action `interest.list`). Each
+        entry carries the day-count convention of its rate configuration, defaulting to ACT_365
+        when that configuration is no longer present.
+      operationId: listAllAccruals
+      responses:
+        '200':
+          description: All accruals
+
+  /api/v1/interest/accounts/{accountId}/effective-rate:
+    get:
+      tags: [Interest]
+      summary: The interest rate effective for an account (override, else product default)
+      operationId: getEffectiveRate
+      parameters:
+        - name: accountId
+          in: path
+          required: true
+          schema:
+            type: string
+            format: uuid
+        - name: productId
+          in: query
+          required: true
+          schema:
+            type: string
+        - name: date
+          in: query
+          description: ISO date to resolve the rate on. Defaults to today.
+          schema:
+            type: string
+            format: date
+      responses:
+        '200':
+          description: The effective rate configuration
+        '204':
+          description: No rate configuration applies to this account and product on that date
 
   /api/v1/interest/accruals/{accountId}:
     get:

--- a/openbank-interest-service/src/test/kotlin/com/openbank/interest/contract/CapitalizationContractTest.kt
+++ b/openbank-interest-service/src/test/kotlin/com/openbank/interest/contract/CapitalizationContractTest.kt
@@ -16,12 +16,33 @@ import java.io.File
  */
 class CapitalizationContractTest {
 
+    private companion object {
+        // Collapse a semver triple into one comparable integer, so the floor below is a single
+        // comparison rather than three nested ones. detekt's MagicNumber fires on the literals
+        // at the call site, not on a named constant.
+        const val MAJOR_WEIGHT = 1_000_000
+        const val MINOR_WEIGHT = 1_000
+    }
+
     private val openapi = File("src/main/resources/openapi.yaml").readText()
 
+    /**
+     * A FLOOR, not an equality. The point of this case is that the ADR-0033/0038 remittance work
+     * carried its own contract bump — that is a property of "info.version is at least 1.3.0", and
+     * it stays true forever. Pinning the exact string instead made every LATER legitimate bump
+     * red: publishing the two served-but-undocumented interest routes (#2314) is additive, takes a
+     * MINOR under ADR-0048 D5, and broke this test while changing nothing this test is about. A
+     * test that fails on the correct next change is a test that gets its assertion edited rather
+     * than read, which is how the value it guards stops meaning anything.
+     */
     @Test
-    fun `contract version is bumped for the remittance change`() {
+    fun `contract version is at or above the remittance change`() {
         val version = Regex("""(?m)^\s+version:\s*"?([^"\s]+)"?\s*$""").find(openapi)?.groupValues?.get(1)
-        assertThat(version).isEqualTo("1.3.0")
+        assertThat(version).`as`("openapi.yaml info.version").isNotNull()
+        val (major, minor, patch) = version!!.split(".").map { it.toInt() }
+        assertThat(major * MAJOR_WEIGHT + minor * MINOR_WEIGHT + patch)
+            .`as`("info.version %s must be >= 1.3.0, the version the ADR-0038 remittance work published", version)
+            .isGreaterThanOrEqualTo(1 * MAJOR_WEIGHT + 3 * MINOR_WEIGHT + 0)
     }
 
     @Test

--- a/openbank-sepa-instant/src/main/resources/openapi.yaml
+++ b/openbank-sepa-instant/src/main/resources/openapi.yaml
@@ -3,7 +3,7 @@
 openapi: 3.1.0
 info:
   title: SEPA Instant (SCT Inst) Service API
-  version: 1.2.0
+  version: 1.3.0
   description: >-
     SEPA Instant Credit Transfer — sub-10s settlement, recall support. On submit, debtor and creditor
     names are synchronously screened against the sanctions lists (ADR-0032): a clean payment proceeds
@@ -21,6 +21,24 @@ tags:
 
 paths:
   /api/v1/sepa-instant:
+    get:
+      tags: [SCT Inst]
+      summary: List every SCT Inst payment
+      description: >-
+        The unfiltered collection. Requires ROLE_VIEWER, ROLE_OPERATOR, ROLE_ADMIN, ROLE_PAYMENTS
+        or ROLE_API (authorize action `sctInstPayment.list`).
+      operationId: listSctInstPayments
+      responses:
+        '200':
+          description: All SCT Inst payments
+          content:
+            application/json:
+              schema:
+                type: array
+                items:
+                  $ref: '#/components/schemas/SctInstPaymentResponse'
+        '403':
+          $ref: '#/components/responses/Forbidden'
     post:
       tags: [SCT Inst]
       summary: Submit a SEPA Instant payment

--- a/openbank-standing-order-service/src/main/resources/openapi.yaml
+++ b/openbank-standing-order-service/src/main/resources/openapi.yaml
@@ -3,7 +3,7 @@
 openapi: 3.1.0
 info:
   title: Standing Order Service API
-  version: 1.3.0
+  version: 1.4.0
   description: Recurring payment orders — create, pause, resume, cancel.
   license:
     name: Apache-2.0
@@ -16,6 +16,15 @@ tags:
 
 paths:
   /api/v1/standing-orders:
+    get:
+      tags: [Standing Orders]
+      summary: List every standing order
+      description: >-
+        The unfiltered collection. Requires ROLE_API, ROLE_OPERATOR or ROLE_ADMIN.
+      operationId: listStandingOrders
+      responses:
+        '200':
+          description: All standing orders
     post:
       tags: [Standing Orders]
       summary: Create a standing order

--- a/openbank-swift-service/src/main/resources/openapi.yaml
+++ b/openbank-swift-service/src/main/resources/openapi.yaml
@@ -6,7 +6,7 @@ openapi: "3.1.0"
 
 info:
   title: OpenBank SWIFT Service API
-  version: "1.1.0"
+  version: "1.2.0"
   description: |
     SWIFT MT/MX message dispatch, acknowledgement, and status tracking.
     Supports MT103 (customer credit transfer), MT202 (bank transfer), MT900/910/940/950 (confirmations/statements).
@@ -80,6 +80,26 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/ValidationError'
+
+  /api/v1/swift/messages:
+    get:
+      tags: [swift]
+      operationId: listSwiftMessages
+      summary: List every SWIFT message
+      description: >-
+        The unfiltered collection. Requires ROLE_VIEWER, ROLE_OPERATOR, ROLE_PAYMENTS or ROLE_ADMIN
+        (authorize action `swift.list`).
+      responses:
+        "200":
+          description: All SWIFT messages
+          content:
+            application/json:
+              schema:
+                type: array
+                items:
+                  $ref: '#/components/schemas/SwiftMessage'
+        "403":
+          $ref: '#/components/responses/Forbidden'
 
   /api/v1/swift/{id}:
     get:


### PR DESCRIPTION
Second `#2314` burndown batch, one defect class: **an endpoint the service answers and `openapi.yaml` never mentions.** Five services, eight routes. **Baseline 104 -> 96.**

Six of the eight are the unfiltered collection `GET` of the service's own primary resource — the single most obvious thing an integrator looks for. In every case the by-id and by-filter variants *beside* it were already published, so the omission reads as "this service has no list endpoint" rather than as a gap.

| service | route |
|---|---|
| swift | `GET /api/v1/swift/messages` |
| standing-order | `GET /api/v1/standing-orders` |
| sepa-instant | `GET /api/v1/sepa-instant` |
| card-issuance | `GET /api/v1/cards` |
| interest | `GET /api/v1/interest/accruals` |
| interest | `GET /api/v1/interest/accounts/{accountId}/effective-rate` |
| card-issuance | `PUT /api/v1/cards/{id}/limits` |
| card-issuance | `PUT /api/v1/cards/{id}/controls` |

The last two are card-issuance's write surface for a card's spending limits and its channel controls (contactless / online / ATM / abroad) — operator-facing controls on a payment instrument, unpublished.

Every block is written from the **handler**, not from the neighbouring documentation: the request bodies of the two PUTs are `UpdateLimitsRequest` and `UpdateControlsRequest` field for field, and the described roles are the `@RolesAllowed` and `@Authorize` action of each method.

## Versions

`info.version` takes a MINOR bump on each of the five (ADR-0048 D5) — adding a path item, or a method to an existing path item, is additive, so none of them approaches the #2313 wall that forced `GATE-CONSTRAINED` prose on aml. No major moves, so the D2 invariant is untouched. The **release** axis deliberately does not move: no code changed, and D1 makes the two axes independent.

swift 1.1.0->1.2.0 · standing-order 1.3.0->1.4.0 · sepa-instant 1.2.0->1.3.0 · card-issuance 1.1.0->1.2.0 · interest 1.3.0->1.4.0

## Verification

All five files parse as YAML, and the conformance gate reports `96 route-level finding(s), 96 declared in the baseline, 0 NEW, 0 stale`, exit 0. The fleet count moving by **exactly eight** is what makes a per-service "0 findings" mean *fixed* rather than *unmeasured*.

Stacked alongside #2624 (the gate's own blind spots, 104 -> 91). The two touch disjoint baseline lines; whichever lands second may need a trivial rebase of that file, and the combined result is 83.

Refs #2314