### PR TITLE
fix(admin-ui): stamp committed derived artifacts from the input commit, not the wall clock

### DIFF
--- a/openbank-admin-ui/cluster-topology.json
+++ b/openbank-admin-ui/cluster-topology.json
@@ -1,7 +1,7 @@
 {
   "schema": "openbank.cluster-topology/v1",
   "source": "derived (GitOps apps + manifests + a representative Dockerfile + Deployment securityContext) — ADR-0081",
-  "generatedAt": "2026-07-26T12:39:03.181Z",
+  "generatedAt": "2026-07-26T12:43:23.000Z",
   "counts": {
     "namespaces": 66,
     "networkPolicies": 97,

--- a/openbank-admin-ui/scripts/generate-cluster-topology.mjs
+++ b/openbank-admin-ui/scripts/generate-cluster-topology.mjs
@@ -16,6 +16,7 @@
 import { readFileSync, readdirSync, writeFileSync, existsSync } from 'fs'
 import path from 'path'
 import { fileURLToPath } from 'url'
+import { sourceDate } from './lib/source-date.mjs'
 
 const __dirname = path.dirname(fileURLToPath(import.meta.url))
 const arg = (flag, fallback) => {
@@ -25,6 +26,18 @@ const arg = (flag, fallback) => {
 const REPO = path.resolve(arg('--repo', path.resolve(__dirname, '..', '..')))
 const OUT = path.resolve(arg('--out', path.resolve(__dirname, '..', 'cluster-topology.json')))
 const GITOPS = path.join(REPO, 'openbank-infra', 'gitops')
+// Every repo path this generator reads. The provenance stamp is the commit time of the
+// newest of them (issue #2621) — NOT the wall clock, which made every regeneration a
+// guaranteed merge conflict. Keep this list in step with what the walkers below open.
+// The generator script itself is deliberately NOT an input: including it makes the
+// artifact depend on the very commit that regenerates it, so the stamp could never be
+// settled before committing. A logic change shows up in the derived content instead.
+const INPUTS = [
+  'openbank-infra/gitops',
+  'openbank-ledger-service/Dockerfile',
+  'openbank-account-service/Dockerfile',
+  'openbank-party-service/Dockerfile',
+]
 
 const read = (p) => { try { return readFileSync(p, 'utf8') } catch { return null } }
 
@@ -218,7 +231,8 @@ const planVsReality = [
 const out = {
   schema: 'openbank.cluster-topology/v1',
   source: 'derived (GitOps apps + manifests + a representative Dockerfile + Deployment securityContext) — ADR-0081',
-  generatedAt: new Date().toISOString(),
+  // Commit time of the newest input, not the clock — see scripts/lib/source-date.mjs (#2621).
+  generatedAt: sourceDate(REPO, INPUTS),
   counts,
   groups: GROUPS,
   namespaces: ns,

--- a/openbank-admin-ui/scripts/generate-infra-lifecycle.mjs
+++ b/openbank-admin-ui/scripts/generate-infra-lifecycle.mjs
@@ -16,6 +16,7 @@
 import { readdirSync, statSync, readFileSync, writeFileSync, existsSync } from 'fs'
 import path from 'path'
 import { fileURLToPath } from 'url'
+import { sourceDate } from './lib/source-date.mjs'
 
 const __dirname = path.dirname(fileURLToPath(import.meta.url))
 const arg = (flag, def) => {
@@ -26,6 +27,14 @@ const REPO = path.resolve(arg('--repo', path.resolve(__dirname, '..', '..')))
 const OUT = path.resolve(arg('--out', path.resolve(__dirname, '..', 'infra-lifecycle.json')))
 const REGISTRY = path.resolve(__dirname, '..', 'src', 'lib', 'infra-lifecycle', 'registry.json')
 const GITOPS = path.join(REPO, 'openbank-infra', 'gitops')
+// Repo inputs whose newest commit time becomes `generatedAt` (issue #2621). The upstream
+// endoflife.date feed is NOT a repo input: when it moves, the `components` payload itself
+// changes, so that diff is genuine and worth a conflict. What is no longer worth a conflict
+// is the stamp advancing on its own while nothing changed.
+const INPUTS = [
+  'openbank-infra/gitops',
+  'openbank-admin-ui/src/lib/infra-lifecycle/registry.json',
+]
 
 // Recursively collect every text line under the GitOps tree once (cheap; the tree is small).
 function walkFiles(dir, acc = []) {
@@ -138,7 +147,7 @@ async function main() {
   const out = {
     schema: 'openbank.infra-lifecycle/v1',
     source: 'endoflife.date + GitOps image tags — ADR-0079',
-    generatedAt: new Date().toISOString(),
+    generatedAt: sourceDate(REPO, INPUTS),
     components,
   }
   writeFileSync(OUT, JSON.stringify(out, null, 2))

--- a/openbank-admin-ui/scripts/lib/source-date.mjs
+++ b/openbank-admin-ui/scripts/lib/source-date.mjs
@@ -1,0 +1,58 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright (c) OpenBank contributors. Licensed under the Apache License, Version 2.0.
+// See LICENSE in the repository root or https://www.apache.org/licenses/LICENSE-2.0 for details.
+//
+// Deterministic provenance timestamp for COMMITTED derived artifacts (issue #2621).
+//
+// The problem it solves: three artifacts are generated into the repo and committed
+// (cluster-topology.json, infra-lifecycle.json, infra-vulns.json). Each carried
+// `new Date().toISOString()`, so every regeneration rewrote that line with a different
+// value — which means any two PRs that regenerate them conflict BY CONSTRUCTION, not
+// because their content disagrees but because they ran at different instants. That is
+// exactly what put #2247 on a rebase treadmill and what turned #2618 DIRTY the moment
+// it was cut; the conflicting hunk was the timestamp, not the image tag.
+//
+// The fix is the reproducible-builds one: make the artifact a pure function of its
+// inputs. The stamp is the commit time of the newest INPUT the generator read, so two
+// runs off the same base produce byte-identical bytes and only genuine content
+// differences can conflict. It is also strictly more truthful — "as of the commit this
+// was derived from" is the staleness an operator needs, whereas "when CI happened to
+// run" advances while nothing changed, i.e. lies in the reassuring direction.
+//
+// Deliberately Node built-ins only (no node_modules) — same constraint the three
+// generators are written under.
+
+import { execFileSync } from 'child_process'
+
+/**
+ * Commit time of the newest input, as an ISO-8601 UTC string.
+ *
+ * Resolution order:
+ *  1. SOURCE_DATE_EPOCH (the reproducible-builds convention) if set and numeric.
+ *  2. `git log -1 --format=%cI -- <paths>` in `repo`.
+ *  3. `null` — the honest "unknown", already a valid value in every consumer
+ *     (build-push-admin-ui.sh writes `"generatedAt": null` on generator failure and
+ *     the BFF fallbacks render it). NEVER fall back to the wall clock: that would
+ *     reintroduce the non-determinism this module exists to remove.
+ *
+ * @param {string} repo  repository root
+ * @param {string[]} paths  repo-relative pathspecs the generator read
+ * @returns {string|null}
+ */
+export function sourceDate(repo, paths = []) {
+  const epoch = process.env.SOURCE_DATE_EPOCH
+  if (epoch && /^\d+$/.test(epoch.trim())) {
+    return new Date(Number(epoch.trim()) * 1000).toISOString()
+  }
+  const args = ['-C', repo, 'log', '-1', '--format=%cI']
+  if (paths.length) args.push('--', ...paths)
+  let raw
+  try {
+    raw = execFileSync('git', args, { encoding: 'utf8', stdio: ['ignore', 'pipe', 'ignore'] }).trim()
+  } catch {
+    return null // not a git checkout (e.g. a bare Docker build context)
+  }
+  if (!raw) return null // pathspec matched nothing tracked
+  const d = new Date(raw)
+  return Number.isNaN(d.getTime()) ? null : d.toISOString()
+}

--- a/openbank-admin-ui/scripts/scan-infra-vulns.mjs
+++ b/openbank-admin-ui/scripts/scan-infra-vulns.mjs
@@ -16,6 +16,7 @@ import { readdirSync, statSync, readFileSync, writeFileSync, existsSync } from '
 import path from 'path'
 import { execSync } from 'child_process'
 import { fileURLToPath } from 'url'
+import { sourceDate } from './lib/source-date.mjs'
 
 const __dirname = path.dirname(fileURLToPath(import.meta.url))
 const arg = (flag, def) => {
@@ -26,6 +27,13 @@ const REPO = path.resolve(arg('--repo', path.resolve(__dirname, '..', '..')))
 const OUT = path.resolve(arg('--out', path.resolve(__dirname, '..', 'infra-vulns.json')))
 const REGISTRY = path.resolve(__dirname, '..', 'src', 'lib', 'infra-lifecycle', 'registry.json')
 const GITOPS = path.join(REPO, 'openbank-infra', 'gitops')
+// Repo inputs whose newest commit time becomes `scannedAt` (issue #2621). A grype DB
+// refresh that changes the findings changes `images` too — a genuine diff. A rescan that
+// finds nothing new must not rewrite the file, or every deploy PR conflicts by construction.
+const INPUTS = [
+  'openbank-infra/gitops',
+  'openbank-admin-ui/src/lib/infra-lifecycle/registry.json',
+]
 
 function walkFiles(dir, acc = []) {
   let entries = []
@@ -107,7 +115,7 @@ function main() {
   const out = {
     schema: 'openbank.infra-vulns/v1',
     source: 'grype (ADR-0079)',
-    scannedAt: new Date().toISOString(),
+    scannedAt: sourceDate(REPO, INPUTS),
     scanned: Object.keys(images),
     skipped,
     images,

--- a/openbank-admin-ui/src/test/derived-artifact-determinism.test.ts
+++ b/openbank-admin-ui/src/test/derived-artifact-determinism.test.ts
@@ -1,0 +1,147 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright (c) OpenBank contributors. Licensed under the Apache License, Version 2.0.
+// See LICENSE in the repository root or https://www.apache.org/licenses/LICENSE-2.0 for details.
+
+import { describe, expect, it } from 'vitest'
+import { execFileSync } from 'child_process'
+import { mkdtempSync, readFileSync, readdirSync, rmSync } from 'fs'
+import { tmpdir } from 'os'
+import path from 'path'
+import { fileURLToPath } from 'url'
+
+// @ts-expect-error - plain .mjs build script, no type declarations by design
+import { sourceDate } from '../../scripts/lib/source-date.mjs'
+
+// Regression guard for issue #2621.
+//
+// Three artifacts are GENERATED and COMMITTED (cluster-topology.json, infra-lifecycle.json,
+// infra-vulns.json). Each stamped `new Date().toISOString()`, so regeneration rewrote that
+// line every time — which makes any two concurrent PRs conflict BY CONSTRUCTION, with no
+// content disagreement whatsoever. #2247 was rebased three times over it and #2618 went
+// DIRTY on the timestamp hunk, not on the image tag everyone assumed.
+//
+// The invariant these tests lock in: a committed derived artifact is a pure function of its
+// inputs. Note the shape of the first test — it regenerates twice with REAL time passing in
+// between. Two runs inside the same millisecond agree even under the old code, so an
+// idempotency check without a measurable gap proves nothing; the sleep IS the test.
+
+const HERE = path.dirname(fileURLToPath(import.meta.url))
+const ADMIN_UI = path.resolve(HERE, '..', '..')
+const REPO = path.resolve(ADMIN_UI, '..')
+
+// Generators that write a COMMITTED artifact. `generate-security-graph.mjs` also stamps a
+// clock time but its output is not in git, so it cannot conflict anything.
+const COMMITTED_GENERATORS = [
+  'generate-cluster-topology.mjs',
+  'generate-infra-lifecycle.mjs',
+  'scan-infra-vulns.mjs',
+]
+
+describe('committed derived artifacts are a pure function of their inputs (#2621)', () => {
+  it(
+    'regenerating cluster-topology.json after real time passes yields byte-identical output',
+    () => {
+      const dir = mkdtempSync(path.join(tmpdir(), 'derived-determinism-'))
+      try {
+        const gen = (out: string) =>
+          execFileSync('node', [
+            path.join(ADMIN_UI, 'scripts', 'generate-cluster-topology.mjs'),
+            '--repo', REPO,
+            '--out', out,
+          ], { encoding: 'utf8', stdio: ['ignore', 'pipe', 'pipe'] })
+
+        const a = path.join(dir, 'a.json')
+        const b = path.join(dir, 'b.json')
+        gen(a)
+        // Block for longer than the ISO-8601 millisecond resolution the old code stamped.
+        // Sleeping synchronously keeps this honest: the second run genuinely observes a
+        // different wall clock, which is the only condition under which the bug is visible.
+        const until = Date.now() + 1_200
+        while (Date.now() < until) { /* busy-wait: no async escape hatch to mis-order the runs */ }
+
+        gen(b)
+        const first = readFileSync(a, 'utf8')
+        const second = readFileSync(b, 'utf8')
+        expect(second).toBe(first)
+
+        // ...and the stamp is present, not silently dropped to dodge the diff. `generatedAt`
+        // is part of the served contract (the topology route's unavailable-fallback carries
+        // it) and the staleness of a derived view is an operator signal, so the fix had to
+        // keep the field and change where it comes from.
+        const parsed = JSON.parse(first) as { generatedAt: string | null }
+        expect(parsed).toHaveProperty('generatedAt')
+        expect(parsed.generatedAt).not.toBeNull()
+      } finally {
+        rmSync(dir, { recursive: true, force: true })
+      }
+    },
+    60_000,
+  )
+
+  it('stamps the newest input commit, not the moment the generator ran', () => {
+    const expected = execFileSync(
+      'git',
+      ['-C', REPO, 'log', '-1', '--format=%cI', '--', 'openbank-infra/gitops'],
+      { encoding: 'utf8' },
+    ).trim()
+    expect(expected).not.toBe('')
+    expect(sourceDate(REPO, ['openbank-infra/gitops'])).toBe(new Date(expected).toISOString())
+  })
+
+  it('honours SOURCE_DATE_EPOCH and reports an unknowable date as null, never as "now"', () => {
+    const prev = process.env.SOURCE_DATE_EPOCH
+    try {
+      process.env.SOURCE_DATE_EPOCH = '1700000000'
+      expect(sourceDate(REPO, ['openbank-infra/gitops'])).toBe('2023-11-14T22:13:20.000Z')
+    } finally {
+      if (prev === undefined) delete process.env.SOURCE_DATE_EPOCH
+      else process.env.SOURCE_DATE_EPOCH = prev
+    }
+    // A pathspec that matches nothing tracked must yield null — the value every consumer
+    // already renders as "unknown". Falling back to the clock here would quietly restore
+    // the non-determinism for exactly the builds that have no git context.
+    expect(sourceDate(REPO, ['no/such/path/ever'])).toBeNull()
+  })
+
+  it('no generator of a committed artifact reads the wall clock', () => {
+    for (const g of COMMITTED_GENERATORS) {
+      const src = readFileSync(path.join(ADMIN_UI, 'scripts', g), 'utf8')
+      // Strip line comments so the prose above each call site (which necessarily names the
+      // banned construct) cannot flag itself — the code-about-code precedence, decided here
+      // rather than discovered on the first red run.
+      const code = src.replace(/^\s*\/\/.*$/gm, '')
+      expect(code, `${g} must derive its timestamp from its inputs, not from new Date()`)
+        .not.toMatch(/new Date\(\)/)
+      expect(code, `${g} must not call Date.now()`).not.toMatch(/Date\.now\(\)/)
+    }
+  })
+
+  it('the generator list above still matches the committed artifacts on disk', () => {
+    // Guards the blind spot in the check itself: a fourth committed artifact added later
+    // would be unchecked, and a hand-kept scope reads as passing when it is short.
+    const committed = execFileSync(
+      'git',
+      // `:(glob)` keeps `*` from crossing a directory separator — a plain `*.json`
+      // pathspec is recursive in git and would sweep in every src/ data file.
+      ['-C', REPO, 'ls-files', '--', ':(glob)openbank-admin-ui/*.json'],
+      { encoding: 'utf8' },
+    )
+      .split('\n')
+      .filter(Boolean)
+      .map((p) => path.basename(p))
+      .sort()
+    expect(committed).toEqual([
+      'app-status.json', // generator deliberately omits any timestamp
+      'cluster-topology.json',
+      'infra-lifecycle.json',
+      'infra-vulns.json',
+      'package-lock.json',
+      'package.json',
+      'tsconfig.json',
+      'tsconfig.test.json',
+    ])
+    // and every script referenced above actually exists
+    const present = readdirSync(path.join(ADMIN_UI, 'scripts'))
+    for (const g of COMMITTED_GENERATORS) expect(present).toContain(g)
+  })
+})


### PR DESCRIPTION
Closes #2621

## The defect

Three artifacts are generated into the repo **and committed** — `cluster-topology.json`, `infra-lifecycle.json`, `infra-vulns.json` — and each stamped `new Date().toISOString()`. Every regeneration rewrites that line with a different value, so **any two concurrent PRs conflict by construction**: not because their content disagrees, but because they ran at different instants. #2247 was rebased three times over it; #2618 went `DIRTY` on the timestamp hunk, not the image tag.

## Survey

Every `gen-*` / `generate-*` script in the tree was checked for a wall-clock stamp:

| | count |
|---|---|
| generator scripts matching `(gen\|generate)[-_]*.{sh,py,mjs}` | 62 |
| ...that stamp a wall-clock time | **3** (`generate-cluster-topology`, `generate-infra-lifecycle`, `generate-security-graph`) |
| plus `scan-infra-vulns.mjs` (`scannedAt`) | 1 |
| **of those, writing a COMMITTED artifact** | **3** — fixed here |

The ~25 `gen-*-opa-bundle*.sh` do **not** stamp time (they hash `rules.yaml`), so this PR does not restamp them and does not conflict with #2247. `generate-security-graph.mjs` stamps `collectedAt` but its output is not in git, so it cannot conflict anything; it is left alone and documented as such in the test. `generate-app-status`, `generate-catalog`, `generate-governance` and `generate-service-graph` already had the fix in the form of an omitted/null field — the precedent this follows.

## Fix

Not deletion of the field. `generatedAt` is part of the served contract (the topology route carries it in its unavailable-fallback) and the staleness of a derived view is an operator signal — the same argument ADR-0210 D3 makes for the Customer 360 `asOf` chip. The field stays; its **source** changes.

New `scripts/lib/source-date.mjs` (Node built-ins only, matching the constraint the three generators are written under) resolves, in order: `SOURCE_DATE_EPOCH` → the commit time of the newest **input** the generator read → `null`. It never falls back to the clock — that would restore the non-determinism for exactly the builds with no git context, and `null` is already a valid value every consumer renders (`build-push-admin-ui.sh` writes it on generator failure).

The generator script itself is deliberately **not** an input: including it makes the artifact depend on the very commit that regenerates it, so the stamp could never be settled before committing.

## Evidence the output is now byte-identical across different wall-clock times

Idempotency *within the same millisecond* proves nothing — the old code passes that too. Both runs below are separated by real time.

```
$ node scripts/generate-cluster-topology.mjs --out /tmp/ct-a.json
$ sleep 3
$ node scripts/generate-cluster-topology.mjs --out /tmp/ct-b.json
8508ba6d0840779b018f77c62bcd7beb4881615f83b29e46d2571083b6483047  /tmp/ct-a.json
8508ba6d0840779b018f77c62bcd7beb4881615f83b29e46d2571083b6483047  /tmp/ct-b.json
  "generatedAt": "2026-07-26T12:43:23.000Z"      <- commit time of the newest input
```

**Known-positive** (the probe can express the failure): the same two runs against the *pre-fix* generators —

```
/tmp/ct-old-a.json /tmp/ct-old-b.json differ: char 204, line 4
```

## The test fails first, for the stated reason

`src/test/derived-artifact-determinism.test.ts`, run with only the generator changes stashed:

```
× regenerating cluster-topology.json after real time passes yields byte-identical output
× no generator of a committed artifact reads the wall clock
    AssertionError: generate-cluster-topology.mjs must derive its timestamp from its
    inputs, not from new Date()
  Tests  2 failed | 3 passed (5)
```

Five cases: the real-gap double-run; the stamp equals an independently computed `git log -1 --format=%cI`; `SOURCE_DATE_EPOCH` is honoured and an unknowable date is `null` (never "now"); a static guard that no committed-artifact generator reads the clock; and a scope tripwire asserting the hand-kept generator list still matches the committed artifacts on disk — because a hand-kept scope reads as *passing* when it is short, never as *unchecked*.

The static guard strips line comments before matching, so the prose that necessarily names `new Date()` at each call site cannot flag itself — the code-about-code precedence decided up front rather than discovered on the first red run.

## Verification

- `npm test` — 51 files, 806 tests, all pass
- `npm run type-check` — clean
- `eslint` on all five touched/added files — clean
- `cluster-topology.json` regenerated (one-line diff: the stamp). `infra-lifecycle.json` and `infra-vulns.json` need network / grype and will settle deterministically on the next deploy that regenerates them.

## Not done here

The issue's larger question — whether these three need to be *committed* at all, or whether the Docker build should generate them — is untouched. This is the small change that stops the bleeding.