### PR TITLE
feat(ci): name the co-deploy set can-i-deploy blocks on, and make deploying it a supported mode

### DIFF
--- a/.github/scripts/derive-codeploy-set.py
+++ b/.github/scripts/derive-codeploy-set.py
@@ -1,0 +1,142 @@
+#!/usr/bin/env python3
+# SPDX-License-Identifier: Apache-2.0
+# Copyright (c) OpenBank contributors. Licensed under the Apache License, Version 2.0.
+# See LICENSE in the repository root or https://www.apache.org/licenses/LICENSE-2.0 for details.
+#
+# ---------------------------------------------------------------------------------------
+r"""Derive the CO-DEPLOY SET behind a can-i-deploy block (issue #1985).
+
+THE PROBLEM THIS SOLVES
+`can-i-deploy --pacticipant <svc> --to-environment sandbox` asks one question about one
+service: is THIS version compatible with what is CURRENTLY DEPLOYED alongside it. That
+question has no answer when two services in the same run must move together — each is
+blocked by the other's not-yet-deployed version, and no ordering of single-service
+deploys resolves it. Neither service is broken: the pair verifies fine at one frozen main
+SHA. Only the deployed state is stale, and it is stale in both directions at once.
+
+WHAT ACTUALLY HAPPENS TODAY, and why this is a safety issue rather than a latency one.
+The gate names the blocked services (#1420) and names the KIND of block (#2549), but
+nothing names the SET, so a human reads the broker matrix by hand and then dispatches a
+co-deploy that bypasses the per-service gate. That bypass was used three times in one
+week, all on the money path: #1979 (sepa-payment/transaction/fraud), #2057
+(swift/transaction), #2059 (domestic-payment/sepa-payment). The recurring hand-driven
+bypass IS the risk — each one establishes contract safety by archaeology instead of by
+the gate.
+
+WHAT THIS DOES
+Reads the can-i-deploy CLI output already captured per blocked service and derives, as a
+pure function of that text, the connected components of blocked services that reference
+each other. A component of size > 1 is a co-deploy set: those services cannot converge
+one at a time and must be offered to the broker together.
+
+It also reports the other shape — a blocked service whose counterpart is NOT part of this
+run at all. That one is NOT a co-deploy set: nothing in this run can move the counterpart,
+so the honest message is that the block waits on a service outside the run.
+
+WHAT THIS DOES NOT DO
+It does not deploy, does not call the broker, and does not weaken the gate: every service
+it names is still blocked. It turns "3 services blocked, work out why" into "these 3
+services must go together, here is the command", which is the difference between a
+supported mode and an undocumented bypass.
+
+WHY A SEPARATE SCRIPT
+The same reason as classify-can-i-deploy-block.sh: inline in auto-deploy.yml this is
+unreachable by any test, and graph logic that silently produces the wrong set would put a
+confident label on a guess — here it is a pure function of its stdin, so
+test-derive-codeploy-set.sh can drive every branch.
+
+Usage:
+  derive-codeploy-set.py <changed-services-space-separated> < blocks
+
+  stdin is a stream of records, one per blocked service:
+      ===SERVICE <name>
+      <that service's verbatim can-i-deploy CLI output>
+
+  <changed-services> is every service in THIS run (deployable or not), so a counterpart
+  can be told apart from one outside the run.
+
+Prints, one finding per line, TAB-separated. Two record types:
+    CODEPLOY\t<svc> <svc> ...        a mutually-blocking set that must deploy together
+    EXTERNAL\t<svc>\t<counterpart>   blocked on a service this run cannot move
+
+Always exits 0 — this is a reporter, not a gate.
+
+stdlib-only, and python3 rather than bash on purpose: bash 3.2 (macOS, the machine a
+contributor runs the unit test on) has no associative arrays, so a bash implementation
+runs ONLY in CI. A graph script that cannot be exercised where it is written is the
+unfalsified-gate shape this repo has already paid for.
+"""
+
+from __future__ import annotations
+
+import re
+import sys
+
+SERVICE_TOKEN = re.compile(r"openbank-[a-z0-9][a-z0-9-]*")
+
+# Only the per-pair explanation lines name a counterpart. The "Computer says no" banner
+# names nobody, and the CONSUMER|PROVIDER matrix table TRUNCATES names to the column width
+# ("openbank-transacti"), so parsing it invents services that do not exist and would name a
+# co-deploy set no dispatch can satisfy. Read the prose lines only.
+PAIR_LINE = ("There is no verified pact", "The verification for the pact between")
+
+
+def derive(changed: set[str], stream) -> list[str]:
+    blocked: list[str] = []
+    edges: dict[str, set[str]] = {}
+    external: set[tuple[str, str]] = set()
+
+    svc: str | None = None
+    for raw in stream:
+        line = raw.rstrip("\n")
+        if line.startswith("===SERVICE "):
+            svc = line[len("===SERVICE "):].strip()
+            if svc not in blocked:
+                blocked.append(svc)
+                edges.setdefault(svc, set())
+            continue
+        if svc is None or not any(m in line for m in PAIR_LINE):
+            continue
+        for token in sorted(set(SERVICE_TOKEN.findall(line))):
+            if token == svc:
+                continue
+            if token in changed:
+                edges.setdefault(svc, set()).add(token)
+                edges.setdefault(token, set()).add(svc)
+            else:
+                external.add((svc, token))
+
+    findings: list[str] = []
+    seen: set[str] = set()
+    for root in blocked:
+        if root in seen:
+            continue
+        component = [root]
+        seen.add(root)
+        i = 0
+        while i < len(component):
+            node = component[i]
+            i += 1
+            for peer in sorted(edges.get(node, ())):
+                # Only BLOCKED services can be part of a co-deploy set: a counterpart that
+                # is in this run and already deployable needs nothing done to it.
+                if peer in blocked and peer not in seen:
+                    seen.add(peer)
+                    component.append(peer)
+        if len(component) > 1:
+            findings.append("CODEPLOY\t" + " ".join(sorted(component)))
+
+    for svc_name, counterpart in sorted(external):
+        findings.append(f"EXTERNAL\t{svc_name}\t{counterpart}")
+    return findings
+
+
+def main() -> int:
+    changed = set(sys.argv[1:])
+    for finding in derive(changed, sys.stdin):
+        print(finding)
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/.github/scripts/test-derive-codeploy-set.sh
+++ b/.github/scripts/test-derive-codeploy-set.sh
@@ -1,0 +1,129 @@
+#!/usr/bin/env bash
+# SPDX-License-Identifier: Apache-2.0
+# Copyright (c) OpenBank contributors. Licensed under the Apache License, Version 2.0.
+# See LICENSE in the repository root or https://www.apache.org/licenses/LICENSE-2.0 for details.
+#
+# Unit test for derive-codeploy-set.py (issue #1985). Pure bash, no network, no Gradle.
+#
+# Every case is driven against output the pact-broker CLI actually prints, including the
+# two shapes that must NOT contribute an edge: the "Computer says no" banner (names nobody)
+# and the CONSUMER|PROVIDER table, whose service names are TRUNCATED to the column width.
+# A parser that reads the table produces `openbank-transaction-servi` — a service that does
+# not exist — and would name a co-deploy set nobody can dispatch. Case 5 is that test.
+set -uo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+DERIVE="${SCRIPT_DIR}/derive-codeploy-set.py"
+
+fails=0
+check() {
+  local name="$1" want="$2" changed="$3" stdin="$4"
+  local got
+  got="$(python3 "$DERIVE" $changed <<< "$stdin")"
+  if [ "$got" = "$want" ]; then
+    echo "  ok   ${name}"
+  else
+    echo "  FAIL ${name}"
+    echo "       want: $(printf '%q' "$want")"
+    echo "       got:  $(printf '%q' "$got")"
+    fails=$((fails + 1))
+  fi
+}
+
+TAB=$'\t'
+
+echo "derive-codeploy-set.py"
+
+# 1. The #1985 case: two blocked services each naming the other. Neither can converge
+#    alone; one deploy round can never fix it. This is the set the three manual co-deploys
+#    (#1979, #2057, #2059) worked out by hand from the broker matrix.
+check "mutual block => one co-deploy set" \
+  "CODEPLOY${TAB}openbank-sepa-payment openbank-transaction-service" \
+  "openbank-sepa-payment openbank-transaction-service" \
+'===SERVICE openbank-sepa-payment
+Computer says no ¯\_(ツ)_/¯
+
+There is no verified pact between version abc123 of openbank-sepa-payment and the version of openbank-transaction-service currently deployed to sandbox
+===SERVICE openbank-transaction-service
+There is no verified pact between version def456 of openbank-transaction-service and the version of openbank-sepa-payment currently deployed to sandbox'
+
+# 2. A single blocked service is NOT a co-deploy set — the per-service gate is the right
+#    tool and the reconcile tick already re-drives it. Reporting a "set" of one would turn
+#    every ordinary transient block into a co-deploy invitation.
+check "lone blocked service => no set" \
+  "EXTERNAL${TAB}openbank-sepa-payment${TAB}openbank-ledger-service" \
+  "openbank-sepa-payment" \
+'===SERVICE openbank-sepa-payment
+There is no verified pact between version abc123 of openbank-sepa-payment and the version of openbank-ledger-service currently deployed to sandbox'
+
+# 3. Transitivity: fraud <-> transaction <-> sepa-payment is ONE component, not two pairs.
+#    Deploying either pair leaves the third stranded — exactly the campaign that stalled at
+#    2/9 in the issue thread.
+check "transitive chain => one component of three" \
+  "CODEPLOY${TAB}openbank-fraud-service openbank-sepa-payment openbank-transaction-service" \
+  "openbank-fraud-service openbank-transaction-service openbank-sepa-payment" \
+'===SERVICE openbank-fraud-service
+There is no verified pact between version a of openbank-fraud-service and the version of openbank-transaction-service currently deployed to sandbox
+===SERVICE openbank-transaction-service
+There is no verified pact between version b of openbank-transaction-service and the version of openbank-fraud-service currently deployed to sandbox
+===SERVICE openbank-sepa-payment
+There is no verified pact between version c of openbank-sepa-payment and the version of openbank-transaction-service currently deployed to sandbox'
+
+# 4. Two independent pairs stay two sets. Merging them would tell an operator to co-deploy
+#    four services when two separate dispatches are correct and smaller.
+check "two disjoint pairs => two sets" \
+  "CODEPLOY${TAB}openbank-fraud-service openbank-transaction-service
+CODEPLOY${TAB}openbank-clearing-simulator openbank-swift-service" \
+  "openbank-fraud-service openbank-transaction-service openbank-swift-service openbank-clearing-simulator" \
+'===SERVICE openbank-fraud-service
+There is no verified pact between version a of openbank-fraud-service and the version of openbank-transaction-service currently deployed to sandbox
+===SERVICE openbank-transaction-service
+There is no verified pact between version b of openbank-transaction-service and the version of openbank-fraud-service currently deployed to sandbox
+===SERVICE openbank-swift-service
+There is no verified pact between version c of openbank-swift-service and the version of openbank-clearing-simulator currently deployed to sandbox
+===SERVICE openbank-clearing-simulator
+There is no verified pact between version d of openbank-clearing-simulator and the version of openbank-swift-service currently deployed to sandbox'
+
+# 5. THE PARSER TEST. The CLI's matrix table truncates names to the column width. A parser
+#    that reads the table derives `openbank-transaction-servi`, a service that exists
+#    nowhere, and names a co-deploy set no dispatch can satisfy. Only the prose lines are
+#    read, so a block whose ONLY counterpart evidence is the table yields nothing at all —
+#    which is the honest answer.
+check "truncated matrix table contributes no edge" \
+  "" \
+  "openbank-sepa-payment openbank-transaction-service" \
+'===SERVICE openbank-sepa-payment
+Computer says no ¯\_(ツ)_/¯
+
+CONSUMER            | C.VERSION | PROVIDER           | P.VERSION | SUCCESS?
+openbank-sepa-payme | abc123    | openbank-transacti | def456    | false'
+
+# 6. A counterpart outside the run is EXTERNAL, never a co-deploy set: nothing in this run
+#    can move it, so telling an operator to "co-deploy" it would be a command that fails.
+check "counterpart outside the run => EXTERNAL, not CODEPLOY" \
+  "EXTERNAL${TAB}openbank-sepa-payment${TAB}openbank-ledger-service" \
+  "openbank-sepa-payment openbank-transaction-service" \
+'===SERVICE openbank-sepa-payment
+There is no verified pact between version abc123 of openbank-sepa-payment and the version of openbank-ledger-service currently deployed to sandbox'
+
+# 7. A verification FAILURE is a contract regression (#2549) and is reported as an edge too
+#    — a regression between two services in the same run is still a set that has to move
+#    together once the contract is fixed — but the classifier, not this script, is what
+#    stops it being silenced as transient.
+check "failed-verification prose also yields an edge" \
+  "CODEPLOY${TAB}openbank-fraud-service openbank-transaction-service" \
+  "openbank-fraud-service openbank-transaction-service" \
+'===SERVICE openbank-fraud-service
+The verification for the pact between openbank-fraud-service and openbank-transaction-service failed
+===SERVICE openbank-transaction-service
+The verification for the pact between openbank-transaction-service and openbank-fraud-service failed'
+
+# 8. No blocks at all: silence. A reporter that printed a header on a clean run would put
+#    a co-deploy hint in every green log.
+check "no blocked services => no output" "" "openbank-fraud-service" ""
+
+if [ "$fails" -gt 0 ]; then
+  echo "derive-codeploy-set.py: ${fails} case(s) FAILED"
+  exit 1
+fi
+echo "derive-codeploy-set.py: all cases passed"

--- a/.github/workflows/auto-deploy.yml
+++ b/.github/workflows/auto-deploy.yml
@@ -62,6 +62,17 @@ on:
         description: "Space-separated module(s) to rebuild, e.g. 'openbank-party-service'. Blank = full deployable fleet."
         required: false
         default: ""
+      codeploy:
+        description: >-
+          Treat `services` as ONE co-deploy set (issue #1985). The contract gate then asks the
+          broker a single question about all of them together — are these versions mutually
+          compatible — instead of asking per service whether each is compatible with the
+          currently-deployed counterpart. Use ONLY with the exact set the gate named as a
+          CO-DEPLOY SET; on any other input it is a strictly weaker check, because it stops
+          asking about the services deployed alongside them.
+        type: boolean
+        required: false
+        default: false
 
 # Restrictive top-level default (Scorecard Token-Permissions wants an explicit top-level
 # block); each job below declares its own override for the access it needs.
@@ -730,6 +741,46 @@ jobs:
           # summary and by the scheduled-tick silencing rule.
           declare -A block_class=()
           declare -A block_reason=()
+          # Verbatim CLI output of every service that ends up blocked, in the record format
+          # derive-codeploy-set.py reads. Written only in the block branch, so a clean run
+          # leaves it empty and the derivation prints nothing (#1985).
+          BLOCKS_FILE="$(mktemp)"
+
+          # ── #1985: co-deploy mode ───────────────────────────────────────────────────────
+          # A set of services that block EACH OTHER cannot converge one deploy at a time:
+          # each is blocked by the other's not-yet-deployed version. `--to-environment
+          # sandbox` has no answer for that, so the set was being hand-driven past the gate
+          # (#1979, #2057, #2059 — all money-path, one week). This asks the broker the
+          # question the humans were asking by hand: are THESE versions mutually compatible.
+          # It is a gate, not a bypass — a red verdict deploys nothing — but it is a
+          # DIFFERENT question from the per-service one, so it is opt-in on workflow_dispatch
+          # and never reachable from a push or a scheduled tick.
+          if [ "${{ github.event_name }}" = "workflow_dispatch" ] \
+             && [ "${{ github.event.inputs.codeploy }}" = "true" ]; then
+            CODEPLOY_ARGS=()
+            for svc in $(echo "$SERVICES" | jq -r '.[]'); do
+              CODEPLOY_ARGS+=(--pacticipant "$svc" --latest main)
+            done
+            echo "==> can-i-deploy CO-DEPLOY SET (#1985): $(echo "$SERVICES" | jq -r 'join(" ")')"
+            if "$CLI" can-i-deploy "${CODEPLOY_ARGS[@]}" \
+                 --broker-base-url "$PACT_BROKER_URL" \
+                 --broker-username "$PACT_BROKER_USERNAME" \
+                 --broker-password "$PACT_BROKER_PASSWORD" \
+                 --retry-while-unknown 3 --retry-interval 5; then
+              echo "  ✓ the whole set is mutually deployable — deploying it as one unit"
+              echo "deployable=${SERVICES}" >> "$GITHUB_OUTPUT"
+              echo "blocked=[]" >> "$GITHUB_OUTPUT"
+              {
+                echo "### can-i-deploy: co-deploy set verified (#1985)"
+                echo "Asked as ONE question, not per service: \`$(echo "$SERVICES" | jq -r 'join(" ")')\`"
+              } >> "$GITHUB_STEP_SUMMARY"
+              exit 0
+            fi
+            echo "::error::can-i-deploy: the requested co-deploy set is NOT mutually deployable — this is a real contract break, not an ordering problem, and no co-deploy can resolve it (#1985)"
+            echo "deployable=[]" >> "$GITHUB_OUTPUT"
+            exit 1
+          fi
+
           for svc in $(echo "$SERVICES" | jq -r '.[]'); do
             # A service that has never published a contract is not a Pacticipant in the
             # broker; `can-i-deploy` then errors with "Pacticipant <svc> not found" (matrix
@@ -808,6 +859,7 @@ jobs:
                 block_class["$svc"]="$cls"
                 block_reason["$svc"]="$cls_why"
                 echo "::error::can-i-deploy: ${svc} NOT deployable [${cls}] — ${cls_why} (ADR-0092, #2549)"
+                printf '===SERVICE %s\n%s\n' "$svc" "$cid_out" >> "$BLOCKS_FILE"
                 rc=1
               fi
             fi
@@ -860,6 +912,37 @@ jobs:
                 echo "- \`${svc}\` — blocked — \`${svc_cls}\`: ${svc_why}" >> "$GITHUB_STEP_SUMMARY"
               fi
             done
+            # ── #1985: name the SET, not just the members ────────────────────────────────
+            # #1420 names who is blocked and #2549 names what kind of block it is; neither
+            # answers "can this be deployed at all, one at a time?". When two blocked
+            # services name each other, the answer is no — and until now that was worked out
+            # by hand from the broker matrix and then hand-dispatched past the gate. Derive
+            # it instead, and print the exact supported command (unit-tested, no network:
+            # .github/scripts/test-derive-codeploy-set.sh).
+            mapfile -t CHANGED_LIST < <(echo "$SERVICES" | jq -r '.[]')
+            CODEPLOY_OUT="$(python3 .github/scripts/derive-codeploy-set.py "${CHANGED_LIST[@]}" < "$BLOCKS_FILE" || true)"
+            if [ -n "$CODEPLOY_OUT" ]; then
+              echo "" >> "$GITHUB_STEP_SUMMARY"
+              while IFS=$'\t' read -r kind a b; do
+                case "$kind" in
+                  CODEPLOY)
+                    echo "::error::CO-DEPLOY SET — [${a}] block each other; no per-service deploy order converges. Re-run: gh workflow run auto-deploy.yml -f services='${a}' -f codeploy=true (issue #1985)"
+                    {
+                      echo "#### Co-deploy set (#1985)"
+                      echo "\`${a}\` block **each other** — none of them can converge one deploy at a time."
+                      echo ""
+                      echo "\`\`\`"
+                      echo "gh workflow run auto-deploy.yml -f services='${a}' -f codeploy=true"
+                      echo "\`\`\`"
+                    } >> "$GITHUB_STEP_SUMMARY"
+                    ;;
+                  EXTERNAL)
+                    echo "::warning::[${a}] is blocked on ${b}, which is NOT part of this run — a co-deploy cannot help; ${b} has to deploy first (issue #1985)"
+                    echo "- \`${a}\` waits on \`${b}\`, outside this run — co-deploy does not apply" >> "$GITHUB_STEP_SUMMARY"
+                    ;;
+                esac
+              done <<< "$CODEPLOY_OUT"
+            fi
             {
               echo ""
               echo "\`PENDING_BUILD\`/\`UNVERIFIED\` clear themselves — the every-3h reconcile tick"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -769,6 +769,16 @@ jobs:
       - name: "can-i-deploy block classifier unit test"
         run: bash .github/scripts/test-classify-can-i-deploy-block.sh
 
+      # co-deploy set derivation unit test (issue #1985). The classifier above says WHAT KIND
+      # of block a service has; this one says whether the block can be resolved by deploying
+      # that service at all. Two services that name each other never converge one at a time,
+      # and until this landed the set was reconstructed from the broker matrix by hand and
+      # dispatched past the gate — three times in one week, all money-path. Its load-bearing
+      # case is the parser one: the CLI's matrix table TRUNCATES service names, so a parser
+      # that reads it names a co-deploy set no dispatch can satisfy.
+      - name: "co-deploy set derivation unit test"
+        run: bash .github/scripts/test-derive-codeploy-set.sh
+
       # gitops ref-integrity guard (rules.yaml: gitops_ref_integrity). The layer below
       # deploy-coverage: that one proves a service gets BUILT, this one proves the manifest
       # it deploys can actually START. A secretKeyRef to a Secret nobody declares passes


### PR DESCRIPTION
## The problem

`can-i-deploy --to-environment sandbox` asks a **per-service** question: is this version compatible with what is *currently deployed* beside it. That question has no answer when two services in the same run must move together — each is blocked by the other's not-yet-deployed version, and no ordering of single-service deploys converges. Neither service is broken; the pair verifies fine at one frozen main SHA. Only the deployed state is stale, and it is stale in both directions at once. The hand-driven co-deploy campaign measured in #1985 stalled at **2/9 deployable** across rounds.

#1420 already names **who** is blocked; #2549 names **what kind** of block it is. Neither answers *"can this be deployed one at a time at all?"* — so the set was reconstructed from the broker matrix by hand and then hand-dispatched past the gate. **Three times in one week, all money-path:** #1979 (sepa-payment/transaction/fraud), #2057 (swift/transaction), #2059 (domestic-payment/sepa-payment). The recurring bypass is the risk here, more than the deploy latency: each one established contract safety by archaeology instead of by the gate.

## What this adds

**Detection** — `derive-codeploy-set.py` reads the can-i-deploy output already captured per blocked service and derives, as a pure function of that text, the connected components of blocked services that name each other. A component of size > 1 is a co-deploy set, reported with the exact command:

```
::error::CO-DEPLOY SET — [openbank-sepa-payment openbank-transaction-service] block each other;
no per-service deploy order converges. Re-run:
gh workflow run auto-deploy.yml -f services='…' -f codeploy=true
```

It also reports the *other* shape — a counterpart that is **not** part of this run — as `EXTERNAL`, because no co-deploy can help there and saying otherwise would print a command that fails.

**Orchestration** — `-f codeploy=true` on `workflow_dispatch` asks the broker **one** question about the whole set (`--pacticipant A --latest main --pacticipant B --latest main`, no `--to-environment`), which is exactly what the three manual co-deploys were asking by hand. It is a **gate, not a bypass**: a red verdict deploys nothing and says the block is a real contract break that no co-deploy resolves. It *is* a different question from the per-service one — it stops asking about the services deployed alongside the set — so it is opt-in and unreachable from a push or a scheduled tick.

The per-service gate is untouched. Every service the derivation names is **still blocked**; nothing deploys that did not deploy before.

## Falsified, not just run

Eight unit cases, wired into `ci.yml`'s governance job beside the existing reconcile and classifier tests.

The load-bearing one is **case 5, the parser test**: the CLI's `CONSUMER | PROVIDER` matrix truncates names to the column width, so a parser that reads the table derives `openbank-transacti` — a service that exists nowhere — and names a co-deploy set no dispatch can satisfy. Only the prose lines are read, and case 5 goes red against any implementation that forgets.

The first draft was bash, and its very first run exposed the same failure class *in the test harness*: bash 3.2 (macOS) has no associative arrays, so three cases printed `ok` while the script had crashed with `declare: -A: invalid option`. Hence python3 — a graph script that can only run in CI is the unfalsified-gate shape this repo has already paid for.

actionlint finding **sets** were diffed against `origin/main` for both workflows rather than read for absence: no new class in either.

## Deliberately not here

The `rules.yaml: deploy_codeploy_set` entry. Editing `rules.yaml` restamps all ~65 OPA bundles and a competing governance PR is in flight; the entry lands separately rather than making this a 65-file diff with a short shelf life.

Refs #1985