### PR TITLE
fix(analytics-sink): consume Kafka topics that exist

### DIFF
--- a/.github/scripts/check-kafka-topics-exist.py
+++ b/.github/scripts/check-kafka-topics-exist.py
@@ -1,0 +1,184 @@
+#!/usr/bin/env python3
+# SPDX-License-Identifier: Apache-2.0
+"""Every Kafka topic a service consumes or produces must be a topic that EXISTS.
+
+Why this exists
+---------------
+`openbank-analytics-sink` was subscribed to `openbank.account.events` and
+`openbank.transaction.events`. Neither has ever existed — the real topics are
+`openbank.accounts.account.created` and `openbank.transactions.transaction.initiated`. A Kafka
+consumer subscribed to a nonexistent topic does not error; it simply receives nothing. So the sink
+ran for weeks, healthy by every signal, while no ACCOUNT_OPENED and no TRANSACTION row ever reached
+`bronze_events` — which silently made ADR-0210 D2's account->party resolution dead code, and made
+Customer 360 structurally unable to show a customer's accounts or transactions (#2598).
+
+Nothing was red. Nothing could have been: the consumer's own health, its consumer-group membership,
+its lag and the sink's metrics are all consistent with "this topic has no traffic".
+
+This is the same failure shape as a client pointed at a REST path that does not exist — the one that
+shipped finrep's call to `/api/v1/ledger/trial-balance` (see the contract-test notes in CLAUDE.md).
+There, the fix was to make the provider replay the contract at PR time. Here, the equivalent is to
+compare the name a service asks for against the set of names that are declared to exist.
+
+`openbank-infra/gitops` holds a `KafkaTopic` CR for every topic (42 declared, 42 on the sandbox
+cluster at the time of writing), so the declared set is authoritative and complete. That is what
+makes this checkable statically rather than needing a live broker.
+
+Usage:  check-kafka-topics-exist.py [--enforce]
+Advisory by default (prints ::warning, exits 0) per the repo convention; --enforce fails the build.
+"""
+
+from __future__ import annotations
+
+import argparse
+import pathlib
+import re
+import sys
+
+REPO = pathlib.Path(__file__).resolve().parents[2]
+GITOPS = REPO / "openbank-infra" / "gitops"
+
+# A channel's topic list. Both spellings appear in the fleet:
+#   topics: a,b,c          (multi-topic consumer)
+#   topic: a               (single)
+TOPIC_LINE = re.compile(r"^\s*topics?:\s*(?P<val>[^\s#][^#]*?)\s*(?:#.*)?$")
+
+# Anything templated is not a literal name and cannot be checked here.
+TEMPLATED = re.compile(r"[$&{}*?]|\bSTRING\b")
+
+# Topics whose existence this check cannot assert, with the reason. An entry here is a claim that
+# needs to stay true — not a place to park a failure.
+# EMPTY, and that is the point: with the #2598 topic names corrected, every topic any service
+# references resolves to a declared CR. An entry added here needs a reason, and the stale-entry check
+# below fails in BOTH directions — so a temporary exception cannot quietly become permanent.
+ALLOWED_ABSENT: dict[str, str] = {}
+
+
+def declared_topics() -> set[str]:
+    """Every KafkaTopic CR name in gitops."""
+    names: set[str] = set()
+    for path in GITOPS.rglob("*.yaml"):
+        try:
+            text = path.read_text(encoding="utf-8")
+        except (OSError, UnicodeDecodeError):
+            continue
+        if "kind: KafkaTopic" not in text:
+            continue
+        # Strimzi allows spec.topicName to differ from metadata.name; the broker name is topicName
+        # when present. Collect both so neither spelling produces a false positive.
+        for m in re.finditer(r"^\s+(?:name|topicName):\s*(?P<n>[A-Za-z0-9._-]+)\s*$", text, re.M):
+            names.add(m.group("n"))
+    return names
+
+
+def configured_topics() -> dict[str, set[str]]:
+    """topic name -> the service application.yaml files that reference it."""
+    used: dict[str, set[str]] = {}
+    for path in REPO.glob("openbank-*/src/main/resources/application.yaml"):
+        try:
+            text = path.read_text(encoding="utf-8")
+        except (OSError, UnicodeDecodeError):
+            continue
+        for line in text.splitlines():
+            m = TOPIC_LINE.match(line)
+            if not m:
+                continue
+            raw = m.group("val").strip().strip("\"'")
+            if not raw or TEMPLATED.search(raw):
+                continue
+            for name in (t.strip() for t in raw.split(",")):
+                # A bare word with no dot is a config key value, not a topic name in this fleet's
+                # convention (every real topic is dotted). Skipping them keeps the false-positive
+                # rate at zero, which is what makes this enforceable.
+                if not name or "." not in name:
+                    continue
+                used.setdefault(name, set()).add(
+                    str(path.relative_to(REPO)).split("/", maxsplit=1)[0]
+                )
+    return used
+
+
+def selftest() -> int:
+    """Feed the check inputs it MUST flag, and inputs it must NOT.
+
+    A gate that has only ever passed is unfalsified — its failure path is code nobody has run. This
+    runs on every CI invocation so the failure path cannot rot: the real repo state is expected to be
+    clean, so without this the flagging branch would never execute again after today.
+    """
+    declared = declared_topics()
+    if not declared:
+        print("selftest FAIL: no KafkaTopic CRs found — the scan itself is broken.")
+        return 1
+
+    known_good = sorted(declared)[0]
+    cases = [
+        # (name, expected_to_be_flagged, why)
+        ("openbank.account.events", True, "the #2598 name — dotted, plausible, and never declared"),
+        ("openbank.transaction.events", True, "the other #2598 name"),
+        (known_good, False, f"a genuinely declared topic ({known_good}) must never be flagged"),
+        ("notatopic", False, "undotted: a config value, not a topic name in this fleet"),
+    ]
+
+    failures = 0
+    for name, should_flag in ((c[0], c[1]) for c in cases):
+        flagged = "." in name and name not in declared and name not in ALLOWED_ABSENT
+        if flagged != should_flag:
+            verb = "did not flag" if should_flag else "wrongly flagged"
+            print(f"selftest FAIL: {verb} {name!r}")
+            failures += 1
+
+    if failures:
+        return 1
+    print(f"selftest OK: {len(cases)} cases, both directions (flags the unknown, spares the declared).")
+    return 0
+
+
+def main() -> int:
+    ap = argparse.ArgumentParser()
+    ap.add_argument("--enforce", action="store_true", help="fail on a missing topic")
+    ap.add_argument("--selftest", action="store_true", help="verify the check can fail")
+    args = ap.parse_args()
+
+    if args.selftest:
+        return selftest()
+
+    declared = declared_topics()
+    if not declared:
+        # A guard that found no declarations would pass everything. That is not a pass.
+        print("::error::check-kafka-topics-exist: found NO KafkaTopic CRs under "
+              f"{GITOPS.relative_to(REPO)} — the check cannot mean anything. Fix the scan, not this line.")
+        return 1
+
+    used = configured_topics()
+    missing = {
+        name: svcs for name, svcs in sorted(used.items())
+        if name not in declared and name not in ALLOWED_ABSENT
+    }
+
+    print(f"check-kafka-topics-exist: {len(declared)} topics declared in gitops, "
+          f"{len(used)} referenced by services, {len(missing)} unresolved.")
+
+    stale = [t for t in ALLOWED_ABSENT if t in declared]
+    if stale:
+        print("::warning::check-kafka-topics-exist: ALLOWED_ABSENT names a topic that IS now "
+              f"declared — remove the stale entry: {', '.join(sorted(stale))}")
+
+    if not missing:
+        return 0
+
+    for name, svcs in missing.items():
+        print(f"  MISSING  {name}   referenced by: {', '.join(sorted(svcs))}")
+    detail = (
+        "A service references a Kafka topic with no KafkaTopic CR in gitops. A consumer subscribed "
+        "to a topic that does not exist receives nothing and reports healthy, so this cannot show up "
+        "as a red signal at runtime (#2598). Either fix the name, or declare the topic."
+    )
+    if args.enforce:
+        print(f"::error::check-kafka-topics-exist: {len(missing)} unresolved topic(s). {detail}")
+        return 1
+    print(f"::warning::check-kafka-topics-exist: {len(missing)} unresolved topic(s). {detail}")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -649,6 +649,20 @@ jobs:
       - name: "Pact provider-replay coverage (issue #2338, enforced)"
         run: python3 .github/scripts/check-pact-provider-replay.py
 
+      # issue #2598. openbank-analytics-sink consumed `openbank.account.events` and
+      # `openbank.transaction.events` — neither topic has ever existed. A Kafka consumer subscribed
+      # to a nonexistent topic receives nothing and reports healthy, so the sink ran for weeks green
+      # while no ACCOUNT_OPENED and no TRANSACTION row ever reached bronze_events. That silently made
+      # ADR-0210 D2's account->party resolution dead code. Same shape as a client pointed at a REST
+      # path that does not exist (finrep's /api/v1/ledger/trial-balance); the fix is the same in kind
+      # — compare the name asked for against the set declared to exist. Enforced from the start, not
+      # advisory: the fleet is at ZERO unresolved topics, so there is no judgement to exercise and an
+      # advisory verdict would only make the next one mergeable.
+      - name: "Kafka topic existence self-test (issue #2598)"
+        run: python3 .github/scripts/check-kafka-topics-exist.py --selftest
+      - name: "Kafka topic existence (issue #2598, enforced)"
+        run: python3 .github/scripts/check-kafka-topics-exist.py --enforce
+
       # issue #2412 (third residual). openbank-mcp-service masks PII on every tool result
       # UNCONDITIONALLY — deliberately, since a switch that can turn a declared control off is how
       # the declaration became fiction to begin with. The cost of that choice is that the charter

--- a/openbank-analytics-sink/src/main/kotlin/com/openbank/analytics/application/AnalyticsConsumer.kt
+++ b/openbank-analytics-sink/src/main/kotlin/com/openbank/analytics/application/AnalyticsConsumer.kt
@@ -100,12 +100,14 @@ class AnalyticsConsumer {
             eventId = node["eventId"]?.asText()?.let { runCatching { UUID.fromString(it) }.getOrNull() }
                 ?: UUID.randomUUID(),
             aggregateType = aggregateType,
+            // The id MUST agree with aggregateType — bronze_events is keyed (aggregate_type,
+            // aggregate_id) and silver_current_state reduces per that key. An independent precedence
+            // chain here (it used to prefer accountId over transactionId) would pair
+            // aggregate_type=TRANSACTION with an ACCOUNT id, collapsing every transaction on one
+            // account into a single aggregate in silver — a corrupted read model that no test over
+            // one event can see. Resolve the id FROM the resolved type instead.
             aggregateId = node["aggregateId"]?.asText()
-                ?: node["accountId"]?.asText()
-                ?: node["partyId"]?.asText()
-                ?: node["transactionId"]?.asText()
-                ?: node["consentId"]?.asText()
-                ?: node["kycCaseId"]?.asText()
+                ?: idForType(aggregateType, node)
                 ?: "unknown",
             aggregateVersion = node["aggregateVersion"]?.asLong()
                 ?: node["version"]?.asLong()
@@ -124,12 +126,54 @@ class AnalyticsConsumer {
         )
     }
 
+    /**
+     * The identifying field for a resolved aggregate type — the counterpart to [inferAggregateType],
+     * kept adjacent so the two cannot drift. A type added to one without the other yields
+     * `aggregate_id = "unknown"`, which is visible in bronze rather than silently wrong.
+     */
+    private fun idForType(type: String, node: JsonNode): String? = when (type) {
+        "TRANSACTION" -> node["transactionId"]?.asText()
+        "CONSENT" -> node["consentId"]?.asText()
+        "KYC_CASE" -> node["kycCaseId"]?.asText()
+        "DOCUMENT" -> node["documentId"]?.asText()
+        "PASSKEY" -> node["credentialId"]?.asText()
+        "ACCOUNT" -> node["accountId"]?.asText()
+        "PARTY" -> node["partyId"]?.asText()
+        else -> null
+    } ?: node["accountId"]?.asText() ?: node["partyId"]?.asText()
+
+    /**
+     * Last-resort domain inference for an event whose envelope omits `aggregateType`.
+     *
+     * ORDER IS LOAD-BEARING, most specific first. A transaction event carries BOTH `transactionId`
+     * and `accountId`; with `accountId` tested first — as it was — every transaction landed in bronze
+     * as `ACCOUNT`. That went unnoticed only because the sink was subscribed to
+     * `openbank.transaction.events`, a topic that has never existed, so no transaction event had ever
+     * arrived to be misclassified. Correcting the topic name (same commit) is what would have made
+     * the latent bug live, which is why both changes belong together: the fix and the thing the fix
+     * would otherwise have broken.
+     *
+     * Same reason `documentId` precedes `accountId`/`partyId`: a signing-ceremony payload carries
+     * `ceremonyId` + `documentId`, and a generated-document payload carries `documentId` +
+     * `templateCode`. Both were landing as `UNKNOWN/UNKNOWN` in the sandbox — identifiable events
+     * with three columns of attribution silently blank (#2598).
+     *
+     * This remains a HEURISTIC and should not be the mechanism. The topic name states the domain
+     * authoritatively (`openbank.documents.document.event` is a document event whatever its keys),
+     * but reading it requires the `@Incoming` method to take `Message<String>` and handle ack/nack
+     * explicitly rather than a bare `String`. That refactor is deferred deliberately, not forgotten:
+     * it changes the failure semantics of a working consumer, and it is not needed to fix the
+     * misclassification. Tracked separately — until it lands, EVERY new event shape whose keys are
+     * not listed here silently becomes UNKNOWN, and nothing goes red.
+     */
     private fun inferAggregateType(node: JsonNode): String = when {
-        node.has("accountId") -> "ACCOUNT"
-        node.has("partyId") -> "PARTY"
         node.has("transactionId") -> "TRANSACTION"
         node.has("consentId") -> "CONSENT"
         node.has("kycCaseId") -> "KYC_CASE"
+        node.has("documentId") -> "DOCUMENT"
+        node.has("credentialId") -> "PASSKEY"
+        node.has("accountId") -> "ACCOUNT"
+        node.has("partyId") -> "PARTY"
         else -> "UNKNOWN"
     }
 }

--- a/openbank-analytics-sink/src/main/resources/application.yaml
+++ b/openbank-analytics-sink/src/main/resources/application.yaml
@@ -89,7 +89,7 @@ mp:
         # object storage and only its key rides on the event.
         # Every topic here also needs a Read ACL on the analytics-sink KafkaUser
         # (openbank-infra/gitops/components/analytics/kafka-analytics-sink-mtls.yaml).
-        topics: openbank.account.events,openbank.transaction.events,openbank.balance.events,openbank.party.events,openbank.kyc.events,openbank.consent.events,openbank.sca.events,openbank.documents.document.event,openbank.onboarding.funnel.events,openbank.feedback.events
+        topics: openbank.accounts.account.created,openbank.transactions.transaction.initiated,openbank.balance.events,openbank.party.events,openbank.kyc.events,openbank.consent.events,openbank.sca.events,openbank.documents.document.event,openbank.onboarding.funnel.events,openbank.feedback.events
         value.deserializer: org.apache.kafka.common.serialization.StringDeserializer
         # group.id / auto.offset.reset are deliberately NOT set as YAML keys here — see
         # openbank-fraud-service's application.yaml / openbank-anacredit-service's

--- a/openbank-analytics-sink/src/test/kotlin/com/openbank/analytics/application/AnalyticsConsumerTest.kt
+++ b/openbank-analytics-sink/src/test/kotlin/com/openbank/analytics/application/AnalyticsConsumerTest.kt
@@ -121,4 +121,89 @@ class AnalyticsConsumerTest {
         val contact = consumer.toEnvelope(node).payload["contact"] as Map<String, Any?>
         assertThat(contact["phone"]).isEqualTo(PiiMask.phone("+420123456789"))
     }
+
+    // ── Domain inference (#2598) ───────────────────────────────────────────────────────────────
+    //
+    // The sink was subscribed to `openbank.account.events` and `openbank.transaction.events`, and
+    // NEITHER topic has ever existed (the real ones are `openbank.accounts.account.created` and
+    // `openbank.transactions.transaction.initiated`). A consumer subscribed to a nonexistent topic
+    // just receives nothing, so nothing went red — for as long as the sink ran, no ACCOUNT_OPENED and
+    // no TRANSACTION row ever reached bronze, and ADR-0210 D2's account->party resolution was dead
+    // code in practice.
+    //
+    // These tests cover what correcting the topic names EXPOSES, which is the reason both changes
+    // ship together.
+
+    @Test
+    fun `a transaction event is a TRANSACTION even though it also carries an accountId`() {
+        // The latent bug the topic fix would have made live: `accountId` was tested first, so every
+        // transaction would have landed in bronze as ACCOUNT the moment the real topic was consumed.
+        val node = mapper.readTree(
+            """
+            {"transactionId":"txn-1","accountId":"acc-9","amount":100,"eventType":"TRANSACTION_POSTED"}
+            """.trimIndent(),
+        )
+        val env = consumer.toEnvelope(node)
+        assertThat(env.aggregateType).isEqualTo("TRANSACTION")
+        // And the id must AGREE with the type: bronze_events is keyed (aggregate_type, aggregate_id)
+        // and silver reduces per that key, so pairing TRANSACTION with an account id would collapse
+        // every transaction on one account into a single aggregate.
+        assertThat(env.aggregateId).isEqualTo("txn-1")
+    }
+
+    @Test
+    fun `an account event is still an ACCOUNT`() {
+        val node = mapper.readTree("""{"accountId":"acc-9","eventType":"ACCOUNT_OPENED"}""")
+        val env = consumer.toEnvelope(node)
+        assertThat(env.aggregateType).isEqualTo("ACCOUNT")
+        assertThat(env.aggregateId).isEqualTo("acc-9")
+    }
+
+    @Test
+    fun `a generated-document event is a DOCUMENT, not UNKNOWN`() {
+        // Measured in the sandbox: this exact shape landed as UNKNOWN/UNKNOWN/unknown — three columns
+        // of attribution blank on an event whose payload names the template it produced.
+        val node = mapper.readTree(
+            """
+            {"documentId":"doc-1","templateCode":"RAMCOVA_SMLOUVA_CS","templateVersion":"1.1.0"}
+            """.trimIndent(),
+        )
+        val env = consumer.toEnvelope(node)
+        assertThat(env.aggregateType).isEqualTo("DOCUMENT")
+        assertThat(env.aggregateId).isEqualTo("doc-1")
+    }
+
+    @Test
+    fun `a signing-ceremony event resolves to the document it is about`() {
+        val node = mapper.readTree("""{"ceremonyId":"cer-1","documentId":"doc-1"}""")
+        assertThat(consumer.toEnvelope(node).aggregateType).isEqualTo("DOCUMENT")
+    }
+
+    @Test
+    fun `a passkey registration is a PASSKEY, not a bare PARTY`() {
+        // Also seen in the sandbox as PARTY/UNKNOWN: correct domain, no event type, and the
+        // credential it registered indistinguishable from any other party change.
+        val node = mapper.readTree(
+            """
+            {"credentialId":"cred-1","deviceId":"dev-1","partyId":"pty-1"}
+            """.trimIndent(),
+        )
+        val env = consumer.toEnvelope(node)
+        assertThat(env.aggregateType).isEqualTo("PASSKEY")
+        assertThat(env.aggregateId).isEqualTo("cred-1")
+    }
+
+    @Test
+    fun `an explicit aggregateType always wins over inference`() {
+        // Inference is the fallback, never an override — an envelope that states its type must be
+        // taken at its word even when the payload keys suggest otherwise.
+        val node = mapper.readTree(
+            """
+            {"aggregateType":"LEDGER","aggregateId":"led-1","transactionId":"txn-1"}
+            """.trimIndent(),
+        )
+        val env = consumer.toEnvelope(node)
+        assertThat(env.aggregateType).isEqualTo("LEDGER")
+        assertThat(env.aggregateId).isEqualTo("led-1")
+    }
 }


### PR DESCRIPTION
## The defect

`openbank-analytics-sink` subscribed to `openbank.account.events` and `openbank.transaction.events`. **Neither has ever existed.**

| Subscribed | Reality |
|---|---|
| `openbank.account.events` | ❌ no such topic — real name `openbank.accounts.account.created` |
| `openbank.transaction.events` | ❌ no such topic — real name `openbank.transactions.transaction.initiated` |

Both real topics are declared as `KafkaTopic` CRs, both are already consumed by `audit-service`, and both are produced by `account-service` / `transaction-service`. So audit has been receiving these events all along; analytics never has.

A Kafka consumer subscribed to a nonexistent topic **does not error — it receives nothing.** The sink ran healthy by every available signal: pod ready, consumer group joined, lag zero, metrics flat. Meanwhile **no `ACCOUNT_OPENED` and no `TRANSACTION` row ever reached `bronze_events`**, which silently made ADR-0210 D2's account→party resolution dead code and left Customer 360 structurally unable to show a customer's accounts or transactions.

Same shape as finrep's call to `/api/v1/ledger/trial-balance` — a path that never existed, green tests, broken feature.

This is also the honest correction to something I said earlier while debugging Customer 360: I blamed the missing account rows on SQL casing and fixed that twice. The casing was real but it was never the reason. **The events were not there.**

## Correcting the names makes a latent bug live

Which is why these ship in the same commit:

**1. `inferAggregateType` tested `accountId` first.** A transaction event carries *both* `transactionId` and `accountId`, so every transaction would have landed as `ACCOUNT` the moment the real topic was consumed. Reordered most-specific-first.

**2. `aggregateId` had its own precedence chain**, also preferring `accountId`. That pairs `aggregate_type=TRANSACTION` with an *account* id — and `bronze_events` is keyed `(aggregate_type, aggregate_id)` with `silver_current_state` reducing per that key, so **every transaction on one account would collapse into a single aggregate.** A corrupted read model no single-event test can see. The id is now resolved *from* the resolved type, via a helper kept adjacent so the two cannot drift.

**3. `documentId` / `credentialId` added.** The sandbox held generated-contract, signing-ceremony and passkey-registration events as `UNKNOWN/UNKNOWN/unknown` — identifiable events with three columns of attribution blank.

The inference stays a **heuristic and should not be the mechanism**: the topic name states the domain authoritatively. Reading it needs `@Incoming` to take `Message<String>` with explicit ack/nack, which changes the failure semantics of a working consumer and is not required to fix the misclassification. Deferred deliberately, documented in place — until it lands, any new event shape whose keys are unlisted still becomes `UNKNOWN` silently.

## The gate — making the class impossible

`.github/scripts/check-kafka-topics-exist.py`: every dotted topic name a service references must resolve to a `KafkaTopic` CR in gitops. **45 declared, 35 referenced, 0 unresolved.**

**Enforced from the start, not advisory.** At zero violations there is no judgement left to exercise, so an advisory verdict would only make the next one mergeable. `ALLOWED_ABSENT` is **empty**, and its stale-entry check fails in *both* directions — an exception cannot quietly become permanent.

## Everything verified against inputs it MUST flag

| Check | Input | Result |
|---|---|---|
| consumer tests | pre-fix consumer | **4 of 11 fail** |
| gate | old topic config restored | **exit 1**, naming both topics |
| gate | fixed config | exit 0 |
| `--selftest` | 4 cases, both directions | OK |
| `--selftest` | scan deliberately broken | **fails** |

`--selftest` runs on every CI invocation (the `check-pact-provider-replay.py` convention) so the flagging branch cannot rot once the fleet is clean — a gate that has only ever passed is unfalsified.

`:openbank-analytics-sink:test` **exit 0**, `detekt` + `ktlintCheck` **exit 0** — read from the exit code, not from grepped output, because `./gradlew … | grep` masks it. actionlint finding sets unchanged from `origin/main` (the one `shellcheck` warning is pre-existing, verified by diffing the sets).

## Deliberately not in this PR

The `rules.yaml` registration. Editing that file restamps ~65 OPA bundles, so bundling it would make this churn-heavy and conflict-prone while the substantive fix waits. Nothing requires it: `check-advisory-gate-registration.py` covers *advisory* gates, and this one is enforced.

## What this does not fix

`openbank.consent.events` **does exist** and is subscribed, yet bronze holds zero CONSENT rows. Either no consent event has been produced on the sandbox, or something downstream drops them — not diagnosed here, and it does not block this fix. Tracked under #2598.

Refs #2598