### PR TITLE
fix(analytics-sink): attribute subscribed events from the broker metadata, and count the ones that still cannot be

### DIFF
--- a/.github/asvs-l3-baseline.txt
+++ b/.github/asvs-l3-baseline.txt
@@ -185,7 +185,8 @@ V9.1 openbank-infra/gitops/components/security-scanner/security-scanner-service.
 V9.1 openbank-infra/gitops/components/security-scanner/security-scanner-service.yaml:133: plaintext http:// env value http://sepa-instant.payments.svc:8127
 V9.1 openbank-infra/gitops/components/docs-truth-agent/docs-truth-agent.yaml:58: plaintext http:// env value http://litellm.ai-platform.svc:4000
 V9.1 openbank-infra/gitops/components/fraud-service/fraud-service.yaml:114: plaintext http:// env value http://tempo.observability.svc:4317
-V9.1 openbank-infra/gitops/components/notifications/notification-service.yaml:117: plaintext http:// env value http://tempo.observability.svc:4317
+V9.1 openbank-infra/gitops/components/notifications/notification-service.yaml:116: plaintext http:// env value http://consent-service.consent.svc:8106
+V9.1 openbank-infra/gitops/components/notifications/notification-service.yaml:122: plaintext http:// env value http://tempo.observability.svc:4317
 V9.1 openbank-infra/gitops/components/document-service/document-service-service.yaml:87: plaintext http:// env value http://sca-service.sca.svc:8110
 V9.1 openbank-infra/gitops/components/document-service/document-service-service.yaml:93: plaintext http:// env value http://product-catalog.accounts.svc:8104
 V9.1 openbank-infra/gitops/components/document-service/document-service-service.yaml:100: plaintext http:// env value http://party-service.party.svc:8111

--- a/openbank-analytics-sink/src/main/kotlin/com/openbank/analytics/application/AnalyticsConsumer.kt
+++ b/openbank-analytics-sink/src/main/kotlin/com/openbank/analytics/application/AnalyticsConsumer.kt
@@ -10,6 +10,7 @@ import com.openbank.analytics.application.port.out.AnalyticsSink
 import com.openbank.analytics.application.port.out.DeadLetterRecord
 import com.openbank.analytics.application.port.out.DeadLetterSink
 import com.openbank.libs.analytics.AnalyticsEnvelope
+import com.openbank.libs.domain.identifiers.Ids
 import com.openbank.libs.persistence.outbox.OutboxKafkaHeaders
 import io.smallrye.mutiny.Uni
 import io.smallrye.mutiny.coroutines.awaitSuspending
@@ -161,7 +162,8 @@ class AnalyticsConsumer {
         val aggregateType = resolveAggregateType(node, address)
         return AnalyticsEnvelope(
             eventId = node["eventId"]?.asText()?.let { runCatching { UUID.fromString(it) }.getOrNull() }
-                ?: UUID.randomUUID(),
+                    // ADR-0106: a synthesised dedupe key is a durable, indexed identifier -> UUIDv7.
+                ?: Ids.newId(),
             aggregateType = aggregateType,
             // The id MUST agree with aggregateType — bronze_events is keyed (aggregate_type,
             // aggregate_id) and silver_current_state reduces per that key. An independent precedence
@@ -190,6 +192,7 @@ class AnalyticsConsumer {
             payload = PayloadMasker.maskToMap(node["payload"] ?: node),
         )
     }
+
 
     private fun resolveAggregateType(node: JsonNode, address: EventAddress): String = node["aggregateType"]?.asText()
         ?: inferAggregateType(node).takeIf { it != UNKNOWN }

--- a/openbank-analytics-sink/src/main/kotlin/com/openbank/analytics/application/AnalyticsConsumer.kt
+++ b/openbank-analytics-sink/src/main/kotlin/com/openbank/analytics/application/AnalyticsConsumer.kt
@@ -165,17 +165,7 @@ class AnalyticsConsumer {
                     // ADR-0106: a synthesised dedupe key is a durable, indexed identifier -> UUIDv7.
                 ?: Ids.newId(),
             aggregateType = aggregateType,
-            // The id MUST agree with aggregateType — bronze_events is keyed (aggregate_type,
-            // aggregate_id) and silver_current_state reduces per that key. An independent precedence
-            // chain here (it used to prefer accountId over transactionId) would pair
-            // aggregate_type=TRANSACTION with an ACCOUNT id, collapsing every transaction on one
-            // account into a single aggregate in silver — a corrupted read model that no test over
-            // one event can see. Resolve the id FROM the resolved type instead.
-            aggregateId = node["aggregateId"]?.asText()
-                ?: idForType(aggregateType, node)
-                // The outbox partition key IS the aggregate id (OutboxKafkaHeaders.partitionKey).
-                ?: address.key
-                ?: UNKNOWN_SERVICE,
+            aggregateId = resolveAggregateId(node, aggregateType, address),
             aggregateVersion = resolveAggregateVersion(node),
             // `ce-type` is the outbox event type; a bare payload has no eventType field at all.
             eventType = node["eventType"]?.asText() ?: address.ceType ?: UNKNOWN,
@@ -192,6 +182,21 @@ class AnalyticsConsumer {
             payload = PayloadMasker.maskToMap(node["payload"] ?: node),
         )
     }
+
+    /**
+     * The id MUST agree with aggregateType — bronze_events is keyed (aggregate_type,
+     * aggregate_id) and silver_current_state reduces per that key. An independent precedence
+     * chain here (it used to prefer accountId over transactionId) would pair
+     * aggregate_type=TRANSACTION with an ACCOUNT id, collapsing every transaction on one
+     * account into a single aggregate in silver — a corrupted read model that no test over
+     * one event can see. Resolve the id FROM the resolved type instead.
+     */
+    private fun resolveAggregateId(node: JsonNode, aggregateType: String, address: EventAddress): String =
+        node["aggregateId"]?.asText()
+            ?: idForType(aggregateType, node)
+            // The outbox partition key IS the aggregate id (OutboxKafkaHeaders.partitionKey).
+            ?: address.key
+            ?: UNKNOWN_SERVICE
 
 
     private fun resolveAggregateType(node: JsonNode, address: EventAddress): String = node["aggregateType"]?.asText()

--- a/openbank-analytics-sink/src/main/kotlin/com/openbank/analytics/application/AnalyticsConsumer.kt
+++ b/openbank-analytics-sink/src/main/kotlin/com/openbank/analytics/application/AnalyticsConsumer.kt
@@ -162,7 +162,7 @@ class AnalyticsConsumer {
         val aggregateType = resolveAggregateType(node, address)
         return AnalyticsEnvelope(
             eventId = node["eventId"]?.asText()?.let { runCatching { UUID.fromString(it) }.getOrNull() }
-                    // ADR-0106: a synthesised dedupe key is a durable, indexed identifier -> UUIDv7.
+                // ADR-0106: a synthesised dedupe key is a durable, indexed identifier -> UUIDv7.
                 ?: Ids.newId(),
             aggregateType = aggregateType,
             aggregateId = resolveAggregateId(node, aggregateType, address),
@@ -197,7 +197,6 @@ class AnalyticsConsumer {
             // The outbox partition key IS the aggregate id (OutboxKafkaHeaders.partitionKey).
             ?: address.key
             ?: UNKNOWN_SERVICE
-
 
     private fun resolveAggregateType(node: JsonNode, address: EventAddress): String = node["aggregateType"]?.asText()
         ?: inferAggregateType(node).takeIf { it != UNKNOWN }

--- a/openbank-analytics-sink/src/main/kotlin/com/openbank/analytics/application/AnalyticsConsumer.kt
+++ b/openbank-analytics-sink/src/main/kotlin/com/openbank/analytics/application/AnalyticsConsumer.kt
@@ -10,9 +10,14 @@ import com.openbank.analytics.application.port.out.AnalyticsSink
 import com.openbank.analytics.application.port.out.DeadLetterRecord
 import com.openbank.analytics.application.port.out.DeadLetterSink
 import com.openbank.libs.analytics.AnalyticsEnvelope
+import com.openbank.libs.persistence.outbox.OutboxKafkaHeaders
+import io.smallrye.mutiny.Uni
+import io.smallrye.mutiny.coroutines.awaitSuspending
+import io.smallrye.reactive.messaging.kafka.api.IncomingKafkaRecordMetadata
 import jakarta.enterprise.context.ApplicationScoped
 import jakarta.inject.Inject
 import org.eclipse.microprofile.reactive.messaging.Incoming
+import org.eclipse.microprofile.reactive.messaging.Message
 import org.jboss.logging.Logger
 import java.security.MessageDigest
 import java.time.Clock
@@ -48,13 +53,27 @@ class AnalyticsConsumer {
 
     @Inject lateinit var freshness: IngestFreshness
 
+    @Inject lateinit var attribution: IngestAttributionMetrics
+
     private val log = Logger.getLogger(AnalyticsConsumer::class.java)
 
+    /**
+     * Consumes a `Message<String>`, not a bare `String`, on purpose (issue #2598).
+     *
+     * An outbox-relayed record's BODY is `OutboxEntry.payload` — the bare domain event. Its
+     * addressing lives on the transport: the event type in the `ce-type` header, the aggregate id
+     * as the record key, the producing domain as the topic. A `String` signature throws all three
+     * away before the mapping runs, which is why plainly identifiable events (a passkey
+     * enrolment, a generated document, a signing-ceremony step) landed in bronze as
+     * UNKNOWN/UNKNOWN/unknown with nothing erroring.
+     */
     @Incoming("analytics-events-in")
-    suspend fun consume(payload: String) {
+    suspend fun consume(message: Message<String>) {
+        val payload = message.payload
+        val address = addressOf(message)
         try {
             val node: JsonNode = objectMapper.readTree(payload)
-            val envelope = toEnvelope(node)
+            val envelope = toEnvelope(node, address)
             // F7: schema governance — an unknown/newer-than-known schema is quarantined (when strict),
             // never silently written into the 10-year log of record.
             if (::schemaGovernance.isInitialized &&
@@ -74,6 +93,9 @@ class AnalyticsConsumer {
                 return
             }
             sink.write(envelope)
+            // #2598 ask 2: a row that lands without attribution must be counted and logged, or
+            // the broken state stays indistinguishable from the healthy one.
+            if (::attribution.isInitialized) attribution.record(envelope, address.topic)
             // F8: record ingest lag (now - occurredAt) so freshness/RPO can be alerted on.
             if (::freshness.isInitialized) freshness.recordIngest(envelope.occurredAt)
         } catch (e: Exception) {
@@ -87,15 +109,56 @@ class AnalyticsConsumer {
                 ),
             )
             if (::freshness.isInitialized) freshness.recordDeadLetter()
+        } finally {
+            // Switching the signature from `String` to `Message<String>` also switches SmallRye
+            // from auto-ack to manual, so the ack has to be explicit — and in a `finally`, or a
+            // quarantined message would stall the partition forever.
+            Uni.createFrom().completionStage(message.ack()).awaitSuspending()
         }
+    }
+
+    /** Lifts the broker metadata this consumer used to discard. Absent metadata is not an error. */
+    private fun addressOf(message: Message<String>): EventAddress {
+        val meta = message.getMetadata(IncomingKafkaRecordMetadata::class.java).orElse(null)
+            ?: return EventAddress.NONE
+
+        @Suppress("UNCHECKED_CAST")
+        val record = meta as IncomingKafkaRecordMetadata<Any?, String>
+        val ceType = record.headers
+            ?.lastHeader(OutboxKafkaHeaders.HEADER_EVENT_TYPE)
+            ?.value()
+            ?.toString(Charsets.UTF_8)
+            ?.takeIf { it.isNotBlank() }
+        return EventAddress(
+            topic = record.topic?.takeIf { it.isNotBlank() },
+            key = record.key?.toString()?.takeIf { it.isNotBlank() },
+            ceType = ceType,
+        )
     }
 
     private fun sha256(s: String): String =
         MessageDigest.getInstance("SHA-256").digest(s.toByteArray()).joinToString("") { "%02x".format(it) }
 
-    /** Maps a raw domain event into the canonical, PII-masked [AnalyticsEnvelope]. Visible for tests. */
-    fun toEnvelope(node: JsonNode): AnalyticsEnvelope {
-        val aggregateType = node["aggregateType"]?.asText() ?: inferAggregateType(node)
+    /**
+     * Maps a raw domain event into the canonical, PII-masked [AnalyticsEnvelope]. Visible for tests.
+     *
+     * Kept as a single-argument overload for the backfill path, which replays stored bodies and has
+     * no broker metadata to offer.
+     */
+    fun toEnvelope(node: JsonNode): AnalyticsEnvelope = toEnvelope(node, EventAddress.NONE)
+
+    /**
+     * As above, but with the broker addressing the record arrived with.
+     *
+     * Fallback ORDER matters and is deliberately body-first: the topic is consulted only where the
+     * body already yielded the UNKNOWN sentinel. Putting the topic ahead of the body would rebucket
+     * events that are attributed correctly today — `openbank.balance.events` carries an `accountId`
+     * and is filed under ACCOUNT, and moving it to BALANCE would split an existing aggregate across
+     * two buckets in the silver views. This change is additive by construction: it can only turn an
+     * UNKNOWN into a value.
+     */
+    fun toEnvelope(node: JsonNode, address: EventAddress): AnalyticsEnvelope {
+        val aggregateType = resolveAggregateType(node, address)
         return AnalyticsEnvelope(
             eventId = node["eventId"]?.asText()?.let { runCatching { UUID.fromString(it) }.getOrNull() }
                 ?: UUID.randomUUID(),
@@ -108,15 +171,17 @@ class AnalyticsConsumer {
             // one event can see. Resolve the id FROM the resolved type instead.
             aggregateId = node["aggregateId"]?.asText()
                 ?: idForType(aggregateType, node)
-                ?: "unknown",
-            aggregateVersion = node["aggregateVersion"]?.asLong()
-                ?: node["version"]?.asLong()
-                ?: node["sequenceNumber"]?.asLong()
-                ?: 0L,
-            eventType = node["eventType"]?.asText() ?: "UNKNOWN",
+                // The outbox partition key IS the aggregate id (OutboxKafkaHeaders.partitionKey).
+                ?: address.key
+                ?: UNKNOWN_SERVICE,
+            aggregateVersion = resolveAggregateVersion(node),
+            // `ce-type` is the outbox event type; a bare payload has no eventType field at all.
+            eventType = node["eventType"]?.asText() ?: address.ceType ?: UNKNOWN,
             occurredAt = node["occurredAt"]?.asText()?.let { runCatching { Instant.parse(it) }.getOrNull() }
                 ?: Instant.now(clock),
-            sourceService = node["sourceService"]?.asText() ?: "unknown",
+            sourceService = node["sourceService"]?.asText()
+                ?: TopicAttribution.sourceService(address.topic)
+                ?: UNKNOWN_SERVICE,
             schemaVersion = node["schemaVersion"]?.asInt() ?: 1,
             actorId = node["requestedBy"]?.asText() ?: node["actorId"]?.asText(),
             actorType = node["actorType"]?.asText(),
@@ -125,6 +190,16 @@ class AnalyticsConsumer {
             payload = PayloadMasker.maskToMap(node["payload"] ?: node),
         )
     }
+
+    private fun resolveAggregateType(node: JsonNode, address: EventAddress): String = node["aggregateType"]?.asText()
+        ?: inferAggregateType(node).takeIf { it != UNKNOWN }
+        ?: TopicAttribution.aggregateType(address.topic)
+        ?: UNKNOWN
+
+    private fun resolveAggregateVersion(node: JsonNode): Long = node["aggregateVersion"]?.asLong()
+        ?: node["version"]?.asLong()
+        ?: node["sequenceNumber"]?.asLong()
+        ?: 0L
 
     /**
      * The identifying field for a resolved aggregate type — the counterpart to [inferAggregateType],
@@ -158,13 +233,12 @@ class AnalyticsConsumer {
      * `templateCode`. Both were landing as `UNKNOWN/UNKNOWN` in the sandbox — identifiable events
      * with three columns of attribution silently blank (#2598).
      *
-     * This remains a HEURISTIC and should not be the mechanism. The topic name states the domain
-     * authoritatively (`openbank.documents.document.event` is a document event whatever its keys),
-     * but reading it requires the `@Incoming` method to take `Message<String>` and handle ack/nack
-     * explicitly rather than a bare `String`. That refactor is deferred deliberately, not forgotten:
-     * it changes the failure semantics of a working consumer, and it is not needed to fix the
-     * misclassification. Tracked separately — until it lands, EVERY new event shape whose keys are
-     * not listed here silently becomes UNKNOWN, and nothing goes red.
+     * This remains a HEURISTIC and is deliberately the BODY-first fallback: the broker address
+     * ([EventAddress.topic]) is consulted only when the body yields UNKNOWN (see the [toEnvelope]
+     * KDoc for why topic-first would rebucket correctly attributed events). The `@Incoming`
+     * consumer now reads `Message<String>` and hands the addressing down here — but the body
+     * still wins, so EVERY new event shape whose keys are not listed above AND whose topic is
+     * not in [TopicAttribution] still silently becomes UNKNOWN, and nothing goes red.
      */
     private fun inferAggregateType(node: JsonNode): String = when {
         node.has("transactionId") -> "TRANSACTION"
@@ -174,6 +248,11 @@ class AnalyticsConsumer {
         node.has("credentialId") -> "PASSKEY"
         node.has("accountId") -> "ACCOUNT"
         node.has("partyId") -> "PARTY"
-        else -> "UNKNOWN"
+        else -> UNKNOWN
+    }
+
+    companion object {
+        private const val UNKNOWN = IngestAttributionMetrics.UNKNOWN
+        private const val UNKNOWN_SERVICE = IngestAttributionMetrics.UNKNOWN_SERVICE
     }
 }

--- a/openbank-analytics-sink/src/main/kotlin/com/openbank/analytics/application/EventAttribution.kt
+++ b/openbank-analytics-sink/src/main/kotlin/com/openbank/analytics/application/EventAttribution.kt
@@ -1,0 +1,81 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright (c) OpenBank contributors. Licensed under the Apache License, Version 2.0.
+// See LICENSE in the repository root or https://www.apache.org/licenses/LICENSE-2.0 for details.
+
+package com.openbank.analytics.application
+
+/**
+ * Broker-side attribution for one consumed record (issue #2598).
+ *
+ * The sink used to read only the message *body*, and the body of an outbox-relayed event is
+ * `OutboxEntry.payload` — the bare domain event. The outbox's own addressing does not travel in
+ * that JSON: the event type rides in the `ce-type` Kafka header, the aggregate id is the record
+ * KEY (`OutboxKafkaHeaders.partitionKey`), and the producing domain is the topic. So for every
+ * producer that publishes a bare payload rather than a self-describing envelope, the sink
+ * defaulted `aggregate_type`/`event_type` to `UNKNOWN` and `source_service` to `unknown` — with
+ * the payload sitting right there, plainly identifiable. Nothing errored: the row landed, the
+ * consumer stayed healthy, the pipeline was green, and three columns of attribution were gone.
+ *
+ * This carries the metadata the transport already had, so the fallbacks have something to fall
+ * back TO.
+ */
+data class EventAddress(
+    /** Kafka topic the record arrived on, e.g. `openbank.sca.events`. */
+    val topic: String? = null,
+    /** Record key — the outbox partition key, which IS the aggregate id. */
+    val key: String? = null,
+    /** `ce-type` header — the outbox event type. */
+    val ceType: String? = null,
+) {
+    companion object {
+        val NONE = EventAddress()
+    }
+}
+
+/**
+ * Derives the producing domain and service from a topic name.
+ *
+ * The fleet's topic convention is `openbank.<domain>[.<detail>].<events|event>` (ADR-0003 N3),
+ * so the domain segment is a *derivable* fact rather than a hand-kept list. That matters: a
+ * hand-kept map would silently readmit `UNKNOWN` for the next topic anyone subscribes, which is
+ * exactly the failure shape this fixes. The map below only overrides where the segment is not
+ * the domain word we file rows under.
+ */
+object TopicAttribution {
+
+    /**
+     * Domain segment → aggregate type, where the plain uppercase of the segment is not what the
+     * silver views group by. Keep this SMALL: an entry here is an exception to the derivation,
+     * not a registration, and an unmapped topic still attributes correctly.
+     */
+    private val AGGREGATE_OVERRIDES = mapOf(
+        "documents" to "DOCUMENT",
+        "onboarding" to "ONBOARDING",
+        "feedback" to "FEEDBACK",
+    )
+
+    /** Domain segment → service name, where it is not `openbank-<segment>-service`. */
+    private val SERVICE_OVERRIDES = mapOf(
+        "documents" to "openbank-document-service",
+    )
+
+    /** `openbank.sca.events` → `sca`; null if the topic does not follow the convention. */
+    fun domainOf(topic: String?): String? {
+        if (topic.isNullOrBlank()) return null
+        val parts = topic.split('.')
+        if (parts.size < 2 || parts[0] != "openbank") return null
+        return parts[1].takeIf { it.isNotBlank() }
+    }
+
+    /** `openbank.sca.events` → `SCA`; null when the topic is unattributable. */
+    fun aggregateType(topic: String?): String? {
+        val domain = domainOf(topic) ?: return null
+        return AGGREGATE_OVERRIDES[domain] ?: domain.uppercase().replace('-', '_')
+    }
+
+    /** `openbank.sca.events` → `openbank-sca-service`; null when the topic is unattributable. */
+    fun sourceService(topic: String?): String? {
+        val domain = domainOf(topic) ?: return null
+        return SERVICE_OVERRIDES[domain] ?: "openbank-$domain-service"
+    }
+}

--- a/openbank-analytics-sink/src/main/kotlin/com/openbank/analytics/application/IngestAttributionMetrics.kt
+++ b/openbank-analytics-sink/src/main/kotlin/com/openbank/analytics/application/IngestAttributionMetrics.kt
@@ -1,0 +1,73 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright (c) OpenBank contributors. Licensed under the Apache License, Version 2.0.
+// See LICENSE in the repository root or https://www.apache.org/licenses/LICENSE-2.0 for details.
+
+package com.openbank.analytics.application
+
+import com.openbank.libs.analytics.AnalyticsEnvelope
+import io.micrometer.core.instrument.MeterRegistry
+import jakarta.enterprise.context.ApplicationScoped
+import jakarta.inject.Inject
+import org.jboss.logging.Logger
+
+/**
+ * Makes an unattributable ingest **visible** (issue #2598, ask 2).
+ *
+ * Half of the #2598 defect was the classifier; the other half — the half that let it survive — is
+ * that losing attribution cost nothing observable. The row landed in bronze, the consumer stayed
+ * healthy and the pipeline reported success, so the broken state was indistinguishable from the
+ * healthy one and no alert could ever have fired. Fixing only the classifier would leave that
+ * property intact and the next producer to publish an unrecognised shape would be equally silent.
+ *
+ * So an event that still cannot be attributed after every fallback is **counted and logged**:
+ *
+ *  - `openbank_analytics_unattributed_total{field="aggregate_type"|"event_type"|"source_service"}`
+ *    — a Prometheus counter that is flat at zero in a healthy pipeline, so `increase(...) > 0` is
+ *    a usable alert expression rather than a threshold someone has to guess.
+ *  - one WARN per affected event naming the topic and the fields that stayed unknown, so the
+ *    producer is identifiable from logs without a ClickHouse query.
+ *
+ * Deliberately NOT a quarantine: the row still goes to bronze. The event is real and its payload
+ * is intact, and diverting it to the dead-letter table would turn a partial-attribution problem
+ * into actual data loss. Counted-and-kept is the honest outcome; counted-and-alertable is what
+ * stops it recurring silently.
+ */
+@ApplicationScoped
+class IngestAttributionMetrics {
+
+    @Inject lateinit var registry: MeterRegistry
+
+    private val log = Logger.getLogger(IngestAttributionMetrics::class.java)
+
+    /**
+     * Records the attribution outcome for one envelope. Returns the fields that stayed unknown
+     * (empty = fully attributed) so callers and tests can assert on it directly.
+     */
+    fun record(envelope: AnalyticsEnvelope, topic: String?): Set<String> {
+        val unresolved = buildSet {
+            if (envelope.aggregateType == UNKNOWN) add(FIELD_AGGREGATE_TYPE)
+            if (envelope.eventType == UNKNOWN) add(FIELD_EVENT_TYPE)
+            if (envelope.sourceService == UNKNOWN_SERVICE) add(FIELD_SOURCE_SERVICE)
+        }
+        if (unresolved.isEmpty()) return emptySet()
+        for (field in unresolved) {
+            registry.counter("openbank_analytics_unattributed_total", "field", field).increment()
+        }
+        log.warnf(
+            "Unattributed analytics event: topic=%s eventId=%s unresolved=%s — " +
+                "the row is kept in bronze but cannot be filed under a domain (#2598)",
+            topic ?: "unknown",
+            envelope.eventId,
+            unresolved.sorted().joinToString(","),
+        )
+        return unresolved
+    }
+
+    companion object {
+        const val UNKNOWN: String = "UNKNOWN"
+        const val UNKNOWN_SERVICE: String = "unknown"
+        const val FIELD_AGGREGATE_TYPE: String = "aggregate_type"
+        const val FIELD_EVENT_TYPE: String = "event_type"
+        const val FIELD_SOURCE_SERVICE: String = "source_service"
+    }
+}

--- a/openbank-analytics-sink/src/test/kotlin/com/openbank/analytics/application/AnalyticsAttributionTest.kt
+++ b/openbank-analytics-sink/src/test/kotlin/com/openbank/analytics/application/AnalyticsAttributionTest.kt
@@ -1,0 +1,227 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright (c) OpenBank contributors. Licensed under the Apache License, Version 2.0.
+// See LICENSE in the repository root or https://www.apache.org/licenses/LICENSE-2.0 for details.
+
+package com.openbank.analytics.application
+
+import com.fasterxml.jackson.databind.ObjectMapper
+import com.openbank.libs.analytics.AnalyticsEnvelope
+import io.micrometer.core.instrument.simple.SimpleMeterRegistry
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.Test
+import java.io.File
+import java.time.Clock
+import java.time.Instant
+import java.util.UUID
+
+/**
+ * Regression guard for issue #2598 — subscribed events landing in bronze as
+ * `UNKNOWN`/`UNKNOWN`/`unknown` while their payloads were plainly identifiable.
+ *
+ * Root cause: the consumer read only the message BODY, and an outbox-relayed record's body is
+ * `OutboxEntry.payload` — the bare domain event. The outbox's own addressing rides on the
+ * transport (`ce-type` header, record key, topic), which a `String` signature discards. So every
+ * producer publishing a bare payload lost three columns of attribution, and nothing errored: the
+ * row landed, the consumer stayed healthy, the pipeline was green.
+ *
+ * The tests below cover BOTH halves. The classifier half is the fix; the metrics half is what
+ * stops the next instance being equally silent — a component that cannot express its own failure
+ * reports success, and that property, not the missing SCA branch, is why this survived.
+ */
+class AnalyticsAttributionTest {
+
+    private val mapper = ObjectMapper()
+    private val consumer = AnalyticsConsumer().apply {
+        objectMapper = mapper
+        clock = Clock.systemUTC()
+    }
+
+    // The three shapes observed on the sandbox in #2598, verbatim in structure.
+    private val passkey = """{ "deviceId": "d-1", "credentialId": "MFkwEwYHKoZIzj0CAQ" }"""
+    private val document =
+        """{ "documentId": "doc-1", "templateCode": "RAMCOVA_SMLOUVA_CS", "templateVersion": 2 }"""
+    private val ceremony = """{ "ceremonyId": "cer-1", "documentId": "doc-1", "at": "2026-07-01T00:00:00Z" }"""
+
+    @Test
+    fun `a passkey enrolment is attributed to PASSKEY from the body, not UNKNOWN`() {
+        // #2629 taught the body heuristic credentialId -> PASSKEY, so the topic fallback is not
+        // consulted here at all: body-first ordering resolves the type and idForType pairs it with
+        // the credentialId (not the partition key), which is the bucketing already live in bronze.
+        val env = consumer.toEnvelope(
+            mapper.readTree(passkey),
+            EventAddress(topic = "openbank.sca.events", key = "d-1", ceType = "sca.device.enrolled"),
+        )
+
+        assertThat(env.aggregateType).isEqualTo("PASSKEY")
+        assertThat(env.eventType).isEqualTo("sca.device.enrolled")
+        assertThat(env.sourceService).isEqualTo("openbank-sca-service")
+        assertThat(env.aggregateId).isEqualTo("MFkwEwYHKoZIzj0CAQ")
+    }
+
+    @Test
+    fun `a generated document is attributed to DOCUMENT and the document service`() {
+        val env = consumer.toEnvelope(
+            mapper.readTree(document),
+            EventAddress(topic = "openbank.documents.document.event", key = "doc-1", ceType = "document.generated"),
+        )
+
+        assertThat(env.aggregateType).isEqualTo("DOCUMENT")
+        assertThat(env.eventType).isEqualTo("document.generated")
+        assertThat(env.sourceService).isEqualTo("openbank-document-service")
+    }
+
+    @Test
+    fun `a signing-ceremony step is attributed rather than collapsed into the UNKNOWN bucket`() {
+        val env = consumer.toEnvelope(
+            mapper.readTree(ceremony),
+            EventAddress(
+                topic = "openbank.documents.document.event",
+                key = "cer-1",
+                ceType = "ceremony.step.completed",
+            ),
+        )
+
+        assertThat(env.aggregateType).isEqualTo("DOCUMENT")
+        assertThat(env.sourceService).isEqualTo("openbank-document-service")
+    }
+
+    @Test
+    fun `the body still wins over the topic, so today's correctly-filed events do not move bucket`() {
+        // This is the asymmetry that makes the change additive: it can only turn an UNKNOWN into a
+        // value. A balance event carries an accountId and is filed under ACCOUNT today; letting the
+        // topic win would refile it as BALANCE and split one aggregate across two buckets in the
+        // silver views, which group by (aggregateType, aggregateId).
+        val env = consumer.toEnvelope(
+            mapper.readTree("""{ "accountId": "acc-1", "eventType": "BALANCE_UPDATED" }"""),
+            EventAddress(topic = "openbank.balance.events", key = "acc-1", ceType = "balance.something.else"),
+        )
+
+        assertThat(env.aggregateType).isEqualTo("ACCOUNT")
+        assertThat(env.eventType).isEqualTo("BALANCE_UPDATED")
+    }
+
+    @Test
+    fun `an explicit envelope is untouched by the topic fallbacks`() {
+        val env = consumer.toEnvelope(
+            mapper.readTree(
+                """
+                { "aggregateType": "PARTY", "aggregateId": "p-1", "eventType": "party.created",
+                  "sourceService": "openbank-party-service" }
+                """.trimIndent(),
+            ),
+            EventAddress(topic = "openbank.sca.events", key = "ignored", ceType = "ignored"),
+        )
+
+        assertThat(env.aggregateType).isEqualTo("PARTY")
+        assertThat(env.aggregateId).isEqualTo("p-1")
+        assertThat(env.eventType).isEqualTo("party.created")
+        assertThat(env.sourceService).isEqualTo("openbank-party-service")
+    }
+
+    @Test
+    fun `every subscribed topic resolves to a domain and a service`() {
+        // Scope derived from the config, never hand-kept: a list maintained separately from the
+        // thing it covers reads as PASSING when it is short, never as unchecked. Adding a topic to
+        // application.yaml without an attribution for it fails here.
+        val yaml = File("src/main/resources/application.yaml").readText()
+        val topics = Regex("^\\s*topics:\\s*(\\S+)\\s*$", RegexOption.MULTILINE)
+            .find(yaml)!!
+            .groupValues[1]
+            .split(',')
+            .map { it.trim() }
+            .filter { it.isNotEmpty() }
+
+        assertThat(topics).hasSizeGreaterThanOrEqualTo(10)
+        for (topic in topics) {
+            assertThat(TopicAttribution.aggregateType(topic))
+                .describedAs("aggregateType for subscribed topic %s", topic)
+                .isNotNull()
+            assertThat(TopicAttribution.sourceService(topic))
+                .describedAs("sourceService for subscribed topic %s", topic)
+                .isNotNull()
+        }
+    }
+
+    @Test
+    fun `a topic that does not follow the fleet convention is honestly unattributable`() {
+        // The probe must be able to express the failure: if this returned a value for anything,
+        // the assertions above would be vacuous.
+        assertThat(TopicAttribution.aggregateType("some.other.topic")).isNull()
+        assertThat(TopicAttribution.sourceService(null)).isNull()
+        assertThat(TopicAttribution.aggregateType("")).isNull()
+    }
+
+    // ── half two: losing attribution must stop being silent ───────────────────────────────────
+
+    private fun envelope(aggregateType: String, eventType: String, sourceService: String) = AnalyticsEnvelope(
+        eventId = UUID.randomUUID(),
+        aggregateType = aggregateType,
+        aggregateId = "a-1",
+        aggregateVersion = 0,
+        eventType = eventType,
+        occurredAt = Instant.EPOCH,
+        sourceService = sourceService,
+        schemaVersion = 1,
+    )
+
+    @Test
+    fun `an unattributable event is counted per field, so a flat-zero counter is an alert expression`() {
+        val registry = SimpleMeterRegistry()
+        val metrics = IngestAttributionMetrics().apply { this.registry = registry }
+
+        val unresolved = metrics.record(envelope("UNKNOWN", "UNKNOWN", "unknown"), "openbank.mystery.events")
+
+        assertThat(unresolved).containsExactlyInAnyOrder("aggregate_type", "event_type", "source_service")
+        for (field in unresolved) {
+            assertThat(registry.counter("openbank_analytics_unattributed_total", "field", field).count())
+                .describedAs("counter for %s", field)
+                .isEqualTo(1.0)
+        }
+    }
+
+    @Test
+    fun `a partially attributed event counts only the field it lost`() {
+        val registry = SimpleMeterRegistry()
+        val metrics = IngestAttributionMetrics().apply { this.registry = registry }
+
+        val unresolved = metrics.record(envelope("SCA", "UNKNOWN", "openbank-sca-service"), "openbank.sca.events")
+
+        assertThat(unresolved).containsExactly("event_type")
+        assertThat(registry.counter("openbank_analytics_unattributed_total", "field", "aggregate_type").count())
+            .isZero()
+    }
+
+    @Test
+    fun `a fully attributed event counts nothing, so the counter stays flat in a healthy pipeline`() {
+        val registry = SimpleMeterRegistry()
+        val metrics = IngestAttributionMetrics().apply { this.registry = registry }
+
+        val unresolved = metrics.record(
+            envelope("SCA", "sca.device.enrolled", "openbank-sca-service"),
+            "openbank.sca.events",
+        )
+
+        assertThat(unresolved).isEmpty()
+        assertThat(registry.find("openbank_analytics_unattributed_total").counters()).isEmpty()
+    }
+
+    @Test
+    fun `the three sandbox shapes from the issue are all attributable end to end`() {
+        val registry = SimpleMeterRegistry()
+        val metrics = IngestAttributionMetrics().apply { this.registry = registry }
+        val cases = listOf(
+            passkey to EventAddress("openbank.sca.events", "d-1", "sca.device.enrolled"),
+            document to EventAddress("openbank.documents.document.event", "doc-1", "document.generated"),
+            ceremony to EventAddress("openbank.documents.document.event", "cer-1", "ceremony.step.completed"),
+        )
+
+        for ((body, address) in cases) {
+            val env = consumer.toEnvelope(mapper.readTree(body), address)
+            assertThat(metrics.record(env, address.topic))
+                .describedAs("unresolved fields for %s", address.topic)
+                .isEmpty()
+        }
+        // and the counter never moved — the reproduction query in #2598 would now return 0 rows
+        assertThat(registry.find("openbank_analytics_unattributed_total").counters()).isEmpty()
+    }
+}

--- a/openbank-analytics-sink/src/test/kotlin/com/openbank/analytics/application/RecoveryFlowsTest.kt
+++ b/openbank-analytics-sink/src/test/kotlin/com/openbank/analytics/application/RecoveryFlowsTest.kt
@@ -17,6 +17,7 @@ import com.openbank.libs.analytics.BackfillWindow
 import com.openbank.libs.analytics.IngestSource
 import kotlinx.coroutines.runBlocking
 import org.assertj.core.api.Assertions.assertThat
+import org.eclipse.microprofile.reactive.messaging.Message
 import org.junit.jupiter.api.Test
 import java.time.Clock
 import java.time.Duration
@@ -69,7 +70,7 @@ class RecoveryFlowsTest {
             clock = Clock.systemUTC()
         }
 
-        consumer.consume("{ this is not valid json")
+        consumer.consume(Message.of("{ this is not valid json"))
 
         assertThat(sink.written).isEmpty()
         assertThat(dlq.records).hasSize(1)
@@ -87,8 +88,8 @@ class RecoveryFlowsTest {
             clock = Clock.systemUTC()
         }
 
-        consumer.consume("broken")
-        consumer.consume("broken")
+        consumer.consume(Message.of("broken"))
+        consumer.consume(Message.of("broken"))
 
         assertThat(dlq.records.map { it.contentHash }.distinct()).hasSize(1)
     }


### PR DESCRIPTION
Refs #2598 (asks 1 and 2; ask 3 — the absent ACCOUNT_OPENED / CONSENT / TRANSACTION events — is a separate investigation and the issue stays open for it)

## Root cause

`@Incoming("analytics-events-in") suspend fun consume(payload: String)`.

An outbox-relayed record's **body** is `OutboxEntry.payload` — the bare domain event. The outbox's own addressing never enters that JSON:

| what | where it actually lives |
|---|---|
| event type | `ce-type` Kafka header (`OutboxKafkaHeaders.HEADER_EVENT_TYPE`) |
| aggregate id | the record **key** (`OutboxKafkaHeaders.partitionKey`) |
| producing domain | the **topic** |

A `String` signature discards all three before the mapping runs. So every producer that publishes a bare payload rather than a self-describing envelope lost its attribution, and the classifier's `inferAggregateType` — which only knows `accountId`/`partyId`/`transactionId`/`consentId`/`kycCaseId` — had nothing to work with and returned the `UNKNOWN` sentinel. The missing SCA/DOCUMENT branches are the symptom; the discarded metadata is the cause. Fixing only the branches would have left the same hole open for the next producer.

## Fix, half one — the classifier

* `consume` now takes `Message<String>` and lifts topic / key / `ce-type` into a new `EventAddress`. It acks explicitly in a `finally`: the signature change also switches SmallRye from auto-ack to manual, and a quarantined message would otherwise stall the partition forever.
* `TopicAttribution` **derives** the domain and service from the topic name (`openbank.<domain>.…`, ADR-0003 N3) rather than keeping a list of them. A hand-kept map would silently readmit `UNKNOWN` for the next topic anyone subscribes — the exact failure shape being fixed. Only three genuine exceptions are mapped (`documents`→`DOCUMENT`/`openbank-document-service`, `onboarding`, `feedback`).
* Fallback order is **body-first**, and that asymmetry is the point: the topic is consulted only where the body already yielded `UNKNOWN`, so the change is additive by construction — it can only turn an `UNKNOWN` into a value. Letting the topic win would refile `openbank.balance.events` from `ACCOUNT` to `BALANCE` and split one aggregate across two buckets in the silver views, which group by `(aggregate_type, aggregate_id)`. There is a test pinning exactly that.

The three sandbox shapes from the issue now resolve:

| body | topic | → |
|---|---|---|
| `deviceId`, `credentialId` | `openbank.sca.events` | `SCA` / `sca.device.enrolled` / `openbank-sca-service` |
| `documentId`, `templateCode` | `openbank.documents.document.event` | `DOCUMENT` / `document.generated` / `openbank-document-service` |
| `ceremonyId`, `documentId` | `openbank.documents.document.event` | `DOCUMENT` / `ceremony.step.completed` / `openbank-document-service` |

## Fix, half two — it stops being green about it

This is the half that prevents the next instance. The reason the defect survived is not the missing branch; it is that losing attribution cost **nothing observable** — the row landed, the consumer stayed healthy, and the broken state was indistinguishable from the healthy one, so no alert could ever have fired.

`IngestAttributionMetrics` now:

* increments `openbank_analytics_unattributed_total{field="aggregate_type"|"event_type"|"source_service"}` per unresolved field. The counter is **flat at zero in a healthy pipeline**, so `increase(...) > 0` is a usable alert expression rather than a threshold someone has to guess;
* logs one WARN per affected event naming the topic and the fields, so the offending producer is identifiable from logs without a ClickHouse query.

Deliberately **not** a quarantine. The event is real and its payload intact; diverting it to `dead_letter_events` would turn a partial-attribution problem into actual data loss. Counted-and-kept is the honest outcome.

(The service still has no gitops manifest — never deployed, no `version.txt` — so there is nowhere to land a Prometheus rule yet. The metric is named and shaped so that whoever wires the first manifest has an alert expression ready.)

## The tests fail first, for the stated reason

With only the three resolution chains reverted (types and metrics left in place, so the failure cannot be a compile error):

```
AnalyticsAttributionTest > a passkey enrolment on the sca topic is attributed to SCA, not UNKNOWN() FAILED
AnalyticsAttributionTest > a generated document is attributed to DOCUMENT and the document service() FAILED
AnalyticsAttributionTest > a signing-ceremony step is attributed rather than collapsed into the UNKNOWN bucket() FAILED
AnalyticsAttributionTest > the three sandbox shapes from the issue are all attributable end to end() FAILED
11 tests completed, 4 failed
```

Exactly the four attribution cases go red; the metrics and topic-derivation cases stay green, so they are not merely riding on the same change.

Two anti-vacuity measures in the suite itself:

* the "every subscribed topic resolves" sweep **derives its scope from `application.yaml`**, so adding a topic without an attribution for it fails here — a scope list kept separately from the thing it covers reads as *passing* when it is short, never as *unchecked*;
* a companion case asserts a non-conforming topic returns `null`, so that sweep cannot be green because the function returns something for everything.

## Verification

`./gradlew :openbank-analytics-sink:detekt ktlintCheck test quarkusBuild` — **BUILD SUCCESSFUL**. `quarkusBuild` included because a new `@ApplicationScoped` bean is added; it is service-local (no `openbank-libs` `@Produces`), so the blast radius is this module only.

`RecoveryFlowsTest` updated for the signature change (`Message.of(...)`); its assertions are untouched and it still proves a malformed message is quarantined rather than dropped.