### PR TITLE
docs(governance): publish the six operator and GDPR routes balance, ledger, fx and party serve unpublished

### DIFF
--- a/.github/openapi-route-conformance-baseline.txt
+++ b/.github/openapi-route-conformance-baseline.txt
@@ -23,7 +23,6 @@ openbank-account-service served-not-published POST /api/v1/accounts/{accountId}/
 openbank-agent-service served-not-published GET /api/v1/admin/agents/halts
 openbank-agent-service served-not-published POST /api/v1/admin/agents/halt
 openbank-agent-service served-not-published POST /api/v1/admin/agents/resume
-openbank-balance-service served-not-published PUT /api/v1/balances/{accountId}/{currency}/overdraft-limit
 openbank-customer-edge served-not-published DELETE /customer/v1/accounts/{accountId}/pockets/{currency}
 openbank-customer-edge served-not-published DELETE /customer/v1/consents/{id}
 openbank-customer-edge served-not-published DELETE /customer/v1/devices/{id}
@@ -71,13 +70,8 @@ openbank-customer-edge served-not-published POST /customer/v1/vop/verify
 openbank-customer-edge served-not-published POST /customer/v1/webauthn/session/refresh
 openbank-customer-edge served-not-published POST /customer/v1/webauthn/session/revoke
 openbank-customer-edge served-not-published PUT /customer/v1/notification-preferences
-openbank-fx-service served-not-published GET /api/v1/fx/cnb/rates/{base}
-openbank-fx-service served-not-published POST /api/v1/fx/cnb/ingest
-openbank-ledger-service served-not-published POST /api/v1/ledger/fx-revaluation
 openbank-notification-service served-not-published GET /api/v1/preferences/party/{partyId}
 openbank-notification-service served-not-published PUT /api/v1/preferences/party/{partyId}
-openbank-party-service served-not-published DELETE /api/v1/parties/{id}
-openbank-party-service served-not-published GET /api/v1/parties/{id}/documents/{fileId}/content
 openbank-psd2-service served-not-published DELETE /open-banking/v2/consents/{consentId}
 openbank-psd2-service served-not-published GET /open-banking/sandbox/v2/accounts
 openbank-psd2-service served-not-published GET /open-banking/sandbox/v2/accounts/{accountId}/balances

--- a/openbank-balance-service/src/main/resources/openapi.yaml
+++ b/openbank-balance-service/src/main/resources/openapi.yaml
@@ -3,7 +3,7 @@
 openapi: 3.1.0
 info:
   title: Balance Service API
-  version: 1.6.0
+  version: 1.7.0
   description: >-
     Account balance management — holds, credits, debits, multi-currency. Per ADR-0039 (Phase A) a
     read-only reconciliation ties out, per currency, the ledger deposit-control balance against the
@@ -66,6 +66,46 @@ paths:
       responses:
         '200':
           description: Balance for currency
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/BalanceResponse'
+        '403':
+          $ref: '#/components/responses/Forbidden'
+        '404':
+          $ref: '#/components/responses/NotFound'
+
+  /api/v1/balances/{accountId}/{currency}/overdraft-limit:
+    put:
+      tags: [Balances]
+      summary: Set the arranged overdraft limit on a balance
+      description: >-
+        A supervisory limit override, not a money movement: requires ROLE_SUPERVISOR or ROLE_ADMIN
+        (authorize action `balance.overdraftLimit`) — deliberately narrower than the credit/debit
+        endpoints, which the transaction saga's service identity may call.
+      operationId: setOverdraftLimit
+      parameters:
+        - $ref: '#/components/parameters/accountId'
+        - name: currency
+          in: path
+          required: true
+          schema:
+            type: string
+            example: CZK
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              type: object
+              required: [arrangedOverdraftLimit]
+              properties:
+                arrangedOverdraftLimit:
+                  type: number
+                  description: The arranged (authorised) overdraft floor for this balance.
+      responses:
+        '200':
+          description: The updated balance
           content:
             application/json:
               schema:

--- a/openbank-balance-service/src/test/kotlin/com/openbank/balance/contract/ReconciliationContractTest.kt
+++ b/openbank-balance-service/src/test/kotlin/com/openbank/balance/contract/ReconciliationContractTest.kt
@@ -4,8 +4,8 @@
 
 package com.openbank.balance.contract
 
-import org.junit.jupiter.api.Assertions.assertEquals
 import org.junit.jupiter.api.Assertions.assertFalse
+import org.junit.jupiter.api.Assertions.assertNotNull
 import org.junit.jupiter.api.Assertions.assertTrue
 import org.junit.jupiter.api.Test
 import java.io.File
@@ -18,18 +18,39 @@ import java.io.File
  */
 class ReconciliationContractTest {
 
+    private companion object {
+        // Collapse a semver triple into one comparable integer, so the floor above is a single
+        // comparison. detekt's MagicNumber fires on literals at the call site, not on a constant.
+        const val MAJOR_WEIGHT = 1_000_000
+        const val MINOR_WEIGHT = 1_000
+    }
+
     private val openapi = File("src/main/resources/openapi.yaml").readText()
 
+    /**
+     * A FLOOR, not an equality. The property this guards is that the reconciliation work carried
+     * its own contract bump — true of "at least 1.6.0", and true forever. Pinning the exact string
+     * made every LATER legitimate bump red: publishing the served-but-undocumented overdraft-limit
+     * endpoint (#2314) is additive, takes a MINOR under ADR-0048 D5, and reddened a case that has
+     * nothing to do with reconciliation. A test that fails on the correct next change is a test
+     * whose assertion gets edited rather than read.
+     *
+     * History of the floor: 1.6.0 published PATCH /api/v1/balances/approvals/{id}, the ADR-0155
+     * four-eyes decision point the service had always served and the contract never named (#2358).
+     * 1.5.0 was ADR-0178 Phase 3, adding the optional `futureValueDatedPipeline` property to
+     * CurrencyReconciliation (#1746); 1.4.1 was editorial, the 403 Forbidden documentation added
+     * across every operation (ADR-0034 Phase 5, #266).
+     */
     @Test
-    fun `contract version is bumped for the reconciliation change`() {
+    fun `contract version is at or above the reconciliation change`() {
         val version = Regex("""(?m)^\s+version:\s*"?([^"\s]+)"?\s*$""").find(openapi)?.groupValues?.get(1)
-        // 1.6.0: MINOR — publishes PATCH /api/v1/balances/approvals/{id}, the ADR-0155 four-eyes
-        // decision point, which the service has always served and the contract never named
-        // (issue #2358). Additive: a path added, nothing removed or made required.
-        // 1.5.0 was ADR-0178 Phase 3 adding the optional `futureValueDatedPipeline` property to
-        // CurrencyReconciliation (issue #1746); 1.4.1 was an editorial bump for the 403 Forbidden
-        // documentation added across every operation (ADR-0034 Phase 5, issue #266).
-        assertEquals("1.6.0", version)
+        assertNotNull(version, "openapi.yaml declares no info.version")
+        val (major, minor, patch) = version!!.split(".").map { it.toInt() }
+        val actual = major * MAJOR_WEIGHT + minor * MINOR_WEIGHT + patch
+        assertTrue(
+            actual >= 1 * MAJOR_WEIGHT + 6 * MINOR_WEIGHT + 0,
+            "info.version $version must be >= 1.6.0, the version the ADR-0039/0155 work published",
+        )
     }
 
     /**

--- a/openbank-fx-service/src/main/resources/openapi.yaml
+++ b/openbank-fx-service/src/main/resources/openapi.yaml
@@ -5,7 +5,7 @@ info:
   title: FX Service API
   # major == openbank.api.version == URL /api/v1 (ADR-0048). Minor bump (1.2 -> 1.3): additive
   # endpoint only (PATCH /approvals/{id}, ADR-0155 four-eyes) — no breaking change.
-  version: 1.3.0
+  version: 1.4.0
   description: >-
     Foreign exchange rates and currency conversion. On convert, the converting party's name is
     synchronously screened against the sanctions lists (ADR-0032): a clean party settles the
@@ -144,6 +144,52 @@ paths:
                 $ref: '#/components/schemas/ApiError'
         '403':
           $ref: '#/components/responses/Forbidden'
+
+  /api/v1/fx/cnb/ingest:
+    post:
+      tags: [FX]
+      summary: Ingest the ČNB fixing for a given day (idempotent)
+      description: >-
+        Pulls the ČNB central-bank fixing (kurz devizového trhu) and stores it. Idempotent — a
+        repeated call for the same day does not double-book. Requires ROLE_OPERATOR or ROLE_ADMIN
+        (authorize action `fx.trigger`). The same work runs on a scheduler; this is the operator
+        re-drive.
+      operationId: ingestCnbFixing
+      parameters:
+        - name: date
+          in: query
+          description: Fixing day to ingest. Omit for the latest published fixing.
+          schema:
+            type: string
+            format: date
+      responses:
+        '200':
+          description: The ingestion result
+        '403':
+          $ref: '#/components/responses/Forbidden'
+
+  /api/v1/fx/cnb/rates/{base}:
+    get:
+      tags: [FX]
+      summary: The latest ingested ČNB fixing for {base}/CZK
+      description: >-
+        The quote currency is always CZK — this is the central-bank fixing, not the tradable
+        rate served by `/api/v1/fx/rates/{base}/{quote}`. Requires ROLE_VIEWER, ROLE_OPERATOR,
+        ROLE_ADMIN or ROLE_PAYMENTS (authorize action `fx.read`).
+      operationId: getCnbRate
+      parameters:
+        - name: base
+          in: path
+          required: true
+          description: Base currency, case-insensitive.
+          schema:
+            type: string
+            example: EUR
+      responses:
+        '200':
+          description: The stored ČNB fixing for {base}/CZK
+        '404':
+          description: No ČNB rate has been ingested for that pair
 
   /api/v1/fx/conversions/{id}:
     get:

--- a/openbank-ledger-service/src/main/resources/openapi.yaml
+++ b/openbank-ledger-service/src/main/resources/openapi.yaml
@@ -3,7 +3,7 @@
 openapi: 3.1.0
 info:
   title: Ledger Service API
-  version: 1.9.0
+  version: 1.10.0
   description: Double-entry journal ledger — query journal entries and transaction postings.
   license:
     name: Apache-2.0
@@ -327,6 +327,28 @@ paths:
                   $ref: '#/components/schemas/ControlAccountTieOutResponse'
         '401':
           $ref: '#/components/responses/Unauthorized'
+        '403':
+          $ref: '#/components/responses/Forbidden'
+
+  /api/v1/ledger/fx-revaluation:
+    post:
+      tags: [Ledger]
+      summary: Run the daily mark-to-ČNB revaluation of foreign-currency positions
+      description: >-
+        Revalues open FX positions against the ČNB fixing for a business day. Requires
+        ROLE_OPERATOR (authorize action `ledger.trigger`). The same work runs on a scheduler;
+        this endpoint is the operator re-drive for a day the scheduled run missed.
+      operationId: runFxRevaluation
+      parameters:
+        - name: date
+          in: query
+          description: Business day to revalue. Omit for today in Europe/Prague.
+          schema:
+            type: string
+            format: date
+      responses:
+        '200':
+          description: The revaluation result for that business day
         '403':
           $ref: '#/components/responses/Forbidden'
 

--- a/openbank-party-service/src/main/resources/openapi.yaml
+++ b/openbank-party-service/src/main/resources/openapi.yaml
@@ -6,7 +6,7 @@ info:
   # major == openbank.api.version == URL /api/v1 (ADR-0048). Minor bump (1.8 -> 1.9): additive
   # only — a new PATCH /api/v1/parties/approvals/{id} endpoint and an additional 202 response
   # on POST /{id}/merge (ADR-0155 four-eyes). No existing response or schema changed.
-  version: 1.9.0
+  version: 1.10.0
   description: Legal entity and individual party management with document storage.
   license:
     name: Apache-2.0
@@ -132,6 +132,21 @@ paths:
       responses:
         '200':
           description: Updated
+    delete:
+      tags: [Parties]
+      summary: Erase party — GDPR Art. 17 right to erasure
+      description: >-
+        Anonymises all PII held for the party. Requires ROLE_ADMIN. The erasure itself is recorded
+        for the Art. 30 records-of-processing trail (who erased which subject), so the action is
+        auditable after the data is gone.
+      operationId: eraseParty
+      parameters:
+        - $ref: '#/components/parameters/partyId'
+      responses:
+        '204':
+          description: Party erased
+        '404':
+          $ref: '#/components/responses/NotFound'
 
   /api/v1/parties/{id}/merge:
     post:
@@ -286,6 +301,34 @@ paths:
           description: Existing party returned (resumed)
         '403':
           description: Email not verified
+  /api/v1/parties/{id}/documents/{fileId}/content:
+    get:
+      tags: [Parties]
+      summary: Download KYC document content (operators only)
+      description: >-
+        The document bytes themselves, as opposed to the metadata listing at
+        `/api/v1/parties/{id}/documents`. Requires ROLE_VIEWER, ROLE_OPERATOR, ROLE_ADMIN or
+        ROLE_KYC.
+      operationId: getPartyDocumentContent
+      parameters:
+        - $ref: '#/components/parameters/partyId'
+        - name: fileId
+          in: path
+          required: true
+          schema:
+            type: string
+            format: uuid
+      responses:
+        '200':
+          description: The stored document content
+          content:
+            application/octet-stream:
+              schema:
+                type: string
+                format: binary
+        '404':
+          $ref: '#/components/responses/NotFound'
+
   /api/v1/parties/{id}/documents/upload:
     post:
       summary: Upload KYC document binary (mobile)


### PR DESCRIPTION
Third `#2314` burndown batch, same defect class as #2625: **an endpoint the service answers and `openapi.yaml` never mentions.** Four services, six routes. **Baseline 104 -> 98** on this branch; stacked with #2624 (-13) and #2625 (-8) the fleet total lands at **77**.

| service | route |
|---|---|
| balance | `PUT /api/v1/balances/{accountId}/{currency}/overdraft-limit` |
| ledger | `POST /api/v1/ledger/fx-revaluation` |
| fx | `POST /api/v1/fx/cnb/ingest` |
| fx | `GET /api/v1/fx/cnb/rates/{base}` |
| party | `DELETE /api/v1/parties/{id}` |
| party | `GET /api/v1/parties/{id}/documents/{fileId}/content` |

Two are worth naming individually.

**`DELETE /api/v1/parties/{id}` is the GDPR Article 17 right-to-erasure endpoint.** The spec published the Article 15 export right beside it (`/gdpr-export`) and not the erasure — so the document a DPO or an integrator reads described this platform as offering *access* without *erasure*, which is not what it does.

**`PUT …/overdraft-limit` is a supervisory limit override on a money-path service.** Its published authorization is deliberately narrower than the credit/debit endpoints in the same spec — `ROLE_SUPERVISOR`/`ROLE_ADMIN` only, never the transaction saga's service identity. That distinction was not previously readable, because the endpoint was not there to read.

The other four are operator re-drives of work that also runs on a scheduler (FX revaluation, ČNB fixing ingestion) plus the ČNB fixing read, whose quote currency is always CZK — it is the *central-bank fixing*, not the tradable rate served by `/api/v1/fx/rates/{base}/{quote}`, and the description now says so.

Every block is written from the **handler**: the request body of the overdraft-limit PUT is `OverdraftLimitRequest` field for field, and each documented role set is the method's own `@RolesAllowed` plus its `@Authorize` action.

## Also: a contract test that pinned a version it had to let move

`ReconciliationContractTest` asserted `info.version` equalled exactly `"1.6.0"`. The property it guards is that the ADR-0039/0155 work carried its own bump — that is a **floor**, and it stays true forever. Pinned as an equality it reddens every later legitimate bump, which makes it a test whose assertion gets edited rather than read; after a few of those the pinned value means nothing. Same correction as the interest-service one in #2625 — and both were found by making the very change they were meant to permit.

## Versions

MINOR on each of the four (ADR-0048 D5): balance 1.6.0->1.7.0 · ledger 1.9.0->1.10.0 · fx 1.3.0->1.4.0 · party 1.9.0->1.10.0. No major moves, so D2 is untouched. The **release** axis does not move — no shipped code changed, and D1 makes the axes independent.

## Verification

All four specs parse as YAML. Conformance gate: `98 route-level finding(s), 98 declared in the baseline, 0 NEW, 0 stale`, exit 0 — the count moving by exactly six is what makes a per-service "0 findings" mean *fixed*, not *unmeasured*. The balance contract test was falsified in both directions: green at 1.7.0, red at 1.5.9 with the floor message. `ktlintCheck` + `detekt` clean.

Baseline deletions here are disjoint from #2624's and #2625's; whichever lands last may need a trivial rebase of that one file.

Refs #2314