### PR TITLE
feat(mcp): register the campaign-copilot's read-only reach tool, denied until granted

### DIFF
--- a/openbank-mcp-service/src/main/kotlin/com/openbank/mcp/application/McpToolRegistry.kt
+++ b/openbank-mcp-service/src/main/kotlin/com/openbank/mcp/application/McpToolRegistry.kt
@@ -8,6 +8,7 @@ import com.fasterxml.jackson.databind.JsonNode
 import com.fasterxml.jackson.databind.ObjectMapper
 import com.openbank.mcp.application.port.out.AccountReadPort
 import com.openbank.mcp.application.port.out.ConsentContext
+import com.openbank.mcp.application.port.out.MarketingReachPort
 import com.openbank.mcp.application.port.out.ProposalPort
 import com.openbank.mcp.application.protocol.ToolCallResult
 import com.openbank.mcp.application.protocol.ToolContent
@@ -25,6 +26,7 @@ import jakarta.enterprise.context.ApplicationScoped
 class McpToolRegistry(
     private val accounts: AccountReadPort,
     private val proposals: ProposalPort,
+    private val marketingReach: MarketingReachPort,
     private val masker: McpPiiMasker,
     private val mapper: ObjectMapper,
 ) {
@@ -36,6 +38,13 @@ class McpToolRegistry(
         "list_transactions" to "query.transaction.readonly",
         "list_consents" to "query.consent.readonly",
         "propose_payment" to "propose.payment",
+        // ADR-0209 D5. No charter carries this capability yet, so the PDP denies every call — that is
+        // the intended state, not an omission: the grant is a separate change (agents.yaml charter +
+        // tool_tiers + rego), and `McpToolRegistryTest` asserts the denial rather than assuming it.
+        // Registering the capability here is what lets the call REACH the PDP at all; without the
+        // entry McpEndpoint refuses earlier, with "no capability mapping", and the policy would never
+        // be exercised.
+        "count_marketing_consents" to "query.marketing.readonly",
     )
 
     val tools: List<ToolDefinition> = listOf(
@@ -77,6 +86,16 @@ class McpToolRegistry(
             domain = "consent",
         ),
         ToolDefinition(
+            name = "count_marketing_consents",
+            description =
+            "Count ACTIVE marketing consents per scope (campaign reach). Returns COUNTS ONLY — " +
+                "never party ids, names or contact details. Who receives anything is decided by " +
+                "campaign-service under consent-gated delivery, not here.",
+            inputSchema = obj(mapOf<String, Any>(), required = emptyList()),
+            service = "openbank-consent-service",
+            domain = "consent",
+        ),
+        ToolDefinition(
             name = "propose_payment",
             description = "Create a REVIEWABLE payment proposal (never a debit; a human + SCA disposes).",
             inputSchema = obj(
@@ -105,6 +124,10 @@ class McpToolRegistry(
                     arguments.path("limit").asInt(DEFAULT_TX_LIMIT),
                 )
             "list_consents" -> accounts.listConsents(ctx)
+            // `ctx` is deliberately NOT passed: this is an operator-plane aggregate with no consent to
+            // intersect against, and MarketingReachPort's signature says so. See its kdoc before
+            // "fixing" the inconsistency.
+            "count_marketing_consents" -> marketingReach.countMarketingConsents()
             // The PROPOSED-only invariant is enforced HERE, on the call path, not left to whichever
             // ProposalPort is bound (T-E4, #2414). See ProposedOnly for why it is a whitelist of one.
             "propose_payment" -> ProposedOnly.enforce(proposals.proposePayment(ctx, arguments))

--- a/openbank-mcp-service/src/main/kotlin/com/openbank/mcp/application/port/out/ReadPorts.kt
+++ b/openbank-mcp-service/src/main/kotlin/com/openbank/mcp/application/port/out/ReadPorts.kt
@@ -26,6 +26,38 @@ interface AccountReadPort {
 }
 
 /**
+ * Campaign-planning reach, for the ADR-0209 D5 campaign-copilot. AGGREGATE ONLY.
+ *
+ * Two things about this port are deliberate and easy to undo by accident.
+ *
+ * **It returns counts, never people.** A copilot planning a campaign needs the reach of a scope, not
+ * the identities inside it. Who actually receives anything is campaign-service's concern under
+ * ADR-0200's consent-gated delivery, which ADR-0209 D5 explicitly does not authorise here. Returning
+ * an aggregate means no personal data leaves the bank on this path at all — a stronger property than
+ * masking it on the way out, because there is nothing to mask.
+ *
+ * **It takes no [ConsentContext], and that absence is the documentation.** Every other read on this
+ * surface is gated TWICE: the OPA charter capability, and the intersection with the PSD2 consent the
+ * caller presented ([AccountReadPort]). This query has no such consent to intersect with — it is an
+ * operator-plane question about the bank's own marketing reach, not about one customer's data — so it
+ * is gated by the charter capability ALONE. Accepting a ConsentContext it did not use would imply a
+ * scoping that does not happen, and a reviewer comparing this port to AccountReadPort would read two
+ * gates where there is one. Never add the parameter to make the signatures look alike.
+ *
+ * Consequence to keep in view: the capability that grants this is therefore the whole control. It
+ * must never be added to a charter that does not need it, and the charter must stay read-only —
+ * ADR-0209 D5 bars this tool from ever acquiring a write.
+ */
+interface MarketingReachPort {
+    /**
+     * Reach per marketing scope, from `consent-service`'s authoritative view of the ADR-0205 D3
+     * internal grantee `party-service:marketing-comms`. Counts of ACTIVE consents by scope, plus
+     * `asOf`, so a caller can see the answer's age instead of assuming it is live (ADR-0210 D3).
+     */
+    fun countMarketingConsents(): JsonNode
+}
+
+/**
  * Produces a reviewable payment PROPOSAL (never a debit). Mirrors agent-service's HITL draft_ticket:
  * the model proposes, a human disposes — money never moves on the model's word (ADR-0031, ADR-0181).
  * Phase 1 returns a proposal id from an in-memory stub; phase 2 writes a PROPOSED row into the

--- a/openbank-mcp-service/src/main/kotlin/com/openbank/mcp/infrastructure/read/StubMarketingReachPort.kt
+++ b/openbank-mcp-service/src/main/kotlin/com/openbank/mcp/infrastructure/read/StubMarketingReachPort.kt
@@ -1,0 +1,49 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+// Copyright (c) OpenBank contributors. Licensed under the GNU Affero General Public License v3.0 only.
+// A commercial licence is available from the maintainers as an alternative to the AGPL-3.0.
+// See LICENSES/AGPL-3.0-only.txt or https://www.gnu.org/licenses/agpl-3.0.html for details.
+package com.openbank.mcp.infrastructure.read
+
+import com.fasterxml.jackson.databind.JsonNode
+import com.fasterxml.jackson.databind.ObjectMapper
+import com.openbank.mcp.application.port.out.MarketingReachPort
+import jakarta.enterprise.context.ApplicationScoped
+
+/**
+ * PHASE 1 deterministic stub behind [MarketingReachPort] (ADR-0209 D5), mirroring [StubProposalPort].
+ *
+ * It is a stub on purpose rather than an oversight: the real read is
+ * `GET /api/v1/consents/grantee/party-service:marketing-comms` on consent-service, which returns the
+ * consent ROWS and would have to be counted here. Binding that client is phase 2 and belongs with the
+ * charter grant — until a charter carries `query.marketing.readonly`, the OPA PDP denies every call to
+ * this tool, so a real client would be unreachable code that nothing could exercise.
+ *
+ * `phase: 1-stub` is in the response for the same reason `StubProposalPort` carries it: a caller must
+ * be able to tell a placeholder from an answer. A stub that returns plausible-looking numbers with no
+ * marker is indistinguishable from real reach data, and reach data is what a campaign gets sized on.
+ */
+@ApplicationScoped
+class StubMarketingReachPort(private val mapper: ObjectMapper) : MarketingReachPort {
+    override fun countMarketingConsents(): JsonNode = mapper.createObjectNode().apply {
+        put("phase", "1-stub")
+        put(
+            "note",
+            "NOT REAL REACH. Phase 2 counts consent-service's grantee view of " +
+                "party-service:marketing-comms; do not size a campaign on these numbers.",
+        )
+        put("grantee", MARKETING_GRANTEE)
+        // Counts only — never a party id, an email or a phone number. See MarketingReachPort's kdoc:
+        // the aggregate IS the privacy control on this path, not the masker downstream of it.
+        putObject("activeByScope").apply {
+            put("MARKETING_COMMS_EMAIL", 0)
+            put("MARKETING_COMMS_SMS", 0)
+            put("MARKETING_COMMS_PUSH", 0)
+        }
+        put("asOf", null as String?)
+    }
+
+    private companion object {
+        /** ADR-0205 D3's fixed internal grantee. */
+        const val MARKETING_GRANTEE = "party-service:marketing-comms"
+    }
+}

--- a/openbank-mcp-service/src/test/kotlin/com/openbank/mcp/McpBootSmokeTest.kt
+++ b/openbank-mcp-service/src/test/kotlin/com/openbank/mcp/McpBootSmokeTest.kt
@@ -5,6 +5,7 @@ package com.openbank.mcp
 import io.quarkus.test.junit.QuarkusTest
 import io.restassured.RestAssured.given
 import io.restassured.http.ContentType
+import org.hamcrest.Matchers.containsInAnyOrder
 import org.hamcrest.Matchers.equalTo
 import org.junit.jupiter.api.Test
 
@@ -37,6 +38,22 @@ class McpBootSmokeTest {
             .post("/mcp")
             .then()
             .statusCode(200)
-            .body("result.tools.size()", equalTo(5))
+            // The NAMES, not just the count. A count pins how many tools are served but cannot tell a
+            // swap from a no-op: replace one tool with another and `size() == 6` still passes, on a
+            // surface whose whole security model is a curated allowlist. `count_marketing_consents`
+            // (ADR-0209 D5) is read-only and denied by the PDP until a charter grants
+            // `query.marketing.readonly` — it is advertised here, not callable.
+            .body("result.tools.size()", equalTo(6))
+            .body(
+                "result.tools.name",
+                containsInAnyOrder(
+                    "list_accounts",
+                    "get_balance",
+                    "list_transactions",
+                    "list_consents",
+                    "propose_payment",
+                    "count_marketing_consents",
+                ),
+            )
     }
 }

--- a/openbank-mcp-service/src/test/kotlin/com/openbank/mcp/McpEndpointTest.kt
+++ b/openbank-mcp-service/src/test/kotlin/com/openbank/mcp/McpEndpointTest.kt
@@ -20,6 +20,7 @@ import com.openbank.mcp.infrastructure.mcp.CallerContextResolver
 import com.openbank.mcp.infrastructure.mcp.McpEndpoint
 import com.openbank.mcp.infrastructure.observability.McpMetricsAdapter
 import com.openbank.mcp.infrastructure.ratelimit.McpRateLimiter
+import com.openbank.mcp.infrastructure.read.StubMarketingReachPort
 import io.micrometer.core.instrument.simple.SimpleMeterRegistry
 import org.assertj.core.api.Assertions.assertThat
 import org.junit.jupiter.api.Test
@@ -45,7 +46,7 @@ class McpEndpointTest {
     // below builds its own endpoint with an anonymous JWT to cover that (now denying) path instead.
     private fun endpoint(pdp: PolicyDecisionPoint, jwt: TestJsonWebToken = testAgentJwt()): McpEndpoint {
         val stub = StubReads(mapper)
-        val toolRegistry = McpToolRegistry(stub, stub, McpPiiMasker(mapper), mapper)
+        val toolRegistry = McpToolRegistry(stub, stub, StubMarketingReachPort(mapper), McpPiiMasker(mapper), mapper)
         val caller = CallerContextResolver(jwt)
         return McpEndpoint(
             registry = toolRegistry,

--- a/openbank-mcp-service/src/test/kotlin/com/openbank/mcp/McpSpecConformanceTest.kt
+++ b/openbank-mcp-service/src/test/kotlin/com/openbank/mcp/McpSpecConformanceTest.kt
@@ -20,6 +20,7 @@ import com.openbank.mcp.infrastructure.mcp.CallerContextResolver
 import com.openbank.mcp.infrastructure.mcp.McpEndpoint
 import com.openbank.mcp.infrastructure.observability.McpMetricsAdapter
 import com.openbank.mcp.infrastructure.ratelimit.McpRateLimiter
+import com.openbank.mcp.infrastructure.read.StubMarketingReachPort
 import io.micrometer.core.instrument.simple.SimpleMeterRegistry
 import jakarta.ws.rs.core.Response
 import org.assertj.core.api.Assertions.assertThat
@@ -56,7 +57,7 @@ class McpSpecConformanceTest {
     private fun endpoint(): McpEndpoint {
         val stub = ConformanceReads(mapper)
         return McpEndpoint(
-            registry = McpToolRegistry(stub, stub, McpPiiMasker(mapper), mapper),
+            registry = McpToolRegistry(stub, stub, StubMarketingReachPort(mapper), McpPiiMasker(mapper), mapper),
             pdp = AllowAll,
             auditor = McpCallAuditor(SinkPublisher),
             callerResolver = CallerContextResolver(

--- a/openbank-mcp-service/src/test/kotlin/com/openbank/mcp/ProposedOnlyTest.kt
+++ b/openbank-mcp-service/src/test/kotlin/com/openbank/mcp/ProposedOnlyTest.kt
@@ -10,6 +10,7 @@ import com.openbank.mcp.application.ProposedOnly
 import com.openbank.mcp.application.port.out.AccountReadPort
 import com.openbank.mcp.application.port.out.ConsentContext
 import com.openbank.mcp.application.port.out.ProposalPort
+import com.openbank.mcp.infrastructure.read.StubMarketingReachPort
 import org.assertj.core.api.Assertions.assertThat
 import org.assertj.core.api.Assertions.assertThatCode
 import org.assertj.core.api.Assertions.assertThatThrownBy
@@ -154,6 +155,7 @@ class ProposedOnlyTest {
             override fun proposePayment(consentContext: ConsentContext, request: JsonNode): JsonNode =
                 mapper.readTree(json)
         },
+        marketingReach = StubMarketingReachPort(mapper),
         masker = McpPiiMasker(mapper),
         mapper = mapper,
     )

--- a/openbank-mcp-service/src/test/kotlin/com/openbank/mcp/application/McpCampaignToolTest.kt
+++ b/openbank-mcp-service/src/test/kotlin/com/openbank/mcp/application/McpCampaignToolTest.kt
@@ -1,0 +1,127 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+// Copyright (c) OpenBank contributors. Licensed under the GNU Affero General Public License v3.0 only.
+// A commercial licence is available from the maintainers as an alternative to the AGPL-3.0.
+// See LICENSES/AGPL-3.0-only.txt or https://www.gnu.org/licenses/agpl-3.0.html for details.
+package com.openbank.mcp.application
+
+import com.fasterxml.jackson.databind.JsonNode
+import com.fasterxml.jackson.databind.ObjectMapper
+import com.openbank.mcp.application.port.out.AccountReadPort
+import com.openbank.mcp.application.port.out.ConsentContext
+import com.openbank.mcp.application.port.out.ProposalPort
+import com.openbank.mcp.infrastructure.read.StubMarketingReachPort
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.Test
+import java.io.File
+
+/**
+ * ADR-0209 D5 — the campaign-copilot's read-only tool.
+ *
+ * The point of this file is the FIRST test. `count_marketing_consents` is registered and callable by
+ * the registry, and no agent charter grants `query.marketing.readonly`, so the ADR-0034 PDP denies
+ * every call today. That is the intended shipping state, and "deny-by-default holds" is worth nothing
+ * as a claim in a PR body — it has to be an assertion against the file that decides it.
+ *
+ * When the grant lands (agents.yaml charter + tool_tiers + rego), the first test goes RED and must be
+ * changed deliberately, which is the whole reason it is written against `agents.yaml` rather than
+ * against a constant. A grant that slips in without anyone noticing is the failure this prevents.
+ */
+class McpCampaignToolTest {
+
+    private val mapper = ObjectMapper()
+    private val registry = McpToolRegistry(
+        accounts = REFUSING_ACCOUNTS,
+        proposals = REFUSING_PROPOSALS,
+        marketingReach = StubMarketingReachPort(mapper),
+        masker = McpPiiMasker(mapper),
+        mapper = mapper,
+    )
+
+    private companion object {
+        // This test never exercises the consent-scoped reads; binding them to something that throws
+        // makes that explicit, so a future edit that accidentally routes a campaign tool through the
+        // account port fails loudly instead of returning a plausible empty result.
+        private val REFUSING_ACCOUNTS = object : AccountReadPort {
+            override fun listAccounts(consentContext: ConsentContext) = fail()
+            override fun getBalance(consentContext: ConsentContext, accountId: String) = fail()
+            override fun listTransactions(consentContext: ConsentContext, accountId: String, limit: Int) = fail()
+            override fun listConsents(consentContext: ConsentContext) = fail()
+        }
+        private val REFUSING_PROPOSALS = object : ProposalPort {
+            override fun proposePayment(consentContext: ConsentContext, request: JsonNode) = fail()
+        }
+        private fun fail(): Nothing = throw AssertionError("the campaign tool must not reach a consent-scoped port")
+    }
+
+    private val agentsYaml: String by lazy {
+        // Walk up to the repo root: the test's working directory is the module, the file is fleet-wide.
+        var dir = File(".").canonicalFile
+        while (dir.parentFile != null && !File(dir, "openbank-libs/governance/agents.yaml").exists()) {
+            dir = dir.parentFile
+        }
+        File(dir, "openbank-libs/governance/agents.yaml").readText()
+    }
+
+    @Test
+    fun `no charter grants query_marketing_readonly, so the PDP denies every call today`() {
+        // Asserted on the governance file, not on a constant in this test — a constant would agree
+        // with itself forever. If this fails, either the grant landed (update this test and say so in
+        // the commit) or a capability was added to a charter that has no business holding it.
+        assertThat(agentsYaml)
+            .`as`("query.marketing.readonly must not be grantable until the ADR-0209 D5 charter lands")
+            .doesNotContain("query.marketing.readonly")
+    }
+
+    @Test
+    fun `the tool HAS a capability mapping, or the PDP is never reached at all`() {
+        // McpEndpoint refuses a tool with no capability entry before it ever calls the PDP
+        // ("no capability mapping"). Without this entry the policy would never be exercised, and the
+        // eventual grant would be authorising a path nothing had tested.
+        assertThat(registry.capabilities)
+            .containsEntry("count_marketing_consents", "query.marketing.readonly")
+    }
+
+    @Test
+    fun `the tool is advertised with a schema that takes no arguments`() {
+        val tool = registry.tools.single { it.name == "count_marketing_consents" }
+
+        @Suppress("UNCHECKED_CAST")
+        val props = tool.inputSchema["properties"] as Map<String, Any>
+        assertThat(props).isEmpty() // reach is a question about the bank, not about one customer
+        assertThat(tool.inputSchema).doesNotContainKey("required")
+    }
+
+    @Test
+    fun `the result carries counts only — no party id, no contact detail`() {
+        // The aggregate IS the privacy control on this path (MarketingReachPort's kdoc), so this
+        // asserts the shape rather than trusting the masker downstream. A future real implementation
+        // that returned rows would fail here, which is the point.
+        val json = mapper.writeValueAsString(StubMarketingReachPort(mapper).countMarketingConsents())
+        for (forbidden in listOf("partyId", "email", "phone", "legalName", "consentId")) {
+            assertThat(json).`as`(forbidden).doesNotContain(forbidden)
+        }
+        val node = mapper.readTree(json)
+        assertThat(node["activeByScope"].fieldNames().asSequence().toList())
+            .containsExactlyInAnyOrder(
+                "MARKETING_COMMS_EMAIL",
+                "MARKETING_COMMS_SMS",
+                "MARKETING_COMMS_PUSH",
+            )
+        node["activeByScope"].forEach { assertThat(it.isInt).isTrue() }
+    }
+
+    @Test
+    fun `the stub says it is a stub, so nobody sizes a campaign on it`() {
+        val node = StubMarketingReachPort(mapper).countMarketingConsents()
+        assertThat(node["phase"].asText()).isEqualTo("1-stub")
+        assertThat(node["note"].asText()).contains("NOT REAL REACH")
+    }
+
+    @Test
+    fun `it is read-only — ADR-0209 D5 bars this tool from ever gaining a write`() {
+        // A write capability here would bypass ADR-0200 D5's campaign.activate four-eyes entirely.
+        assertThat(registry.capabilities["count_marketing_consents"]).startsWith("query.")
+        assertThat(registry.capabilities.keys.filter { it.startsWith("count_") })
+            .containsExactly("count_marketing_consents")
+    }
+}

--- a/openbank-mcp-service/src/test/kotlin/com/openbank/mcp/application/McpPiiMaskingTest.kt
+++ b/openbank-mcp-service/src/test/kotlin/com/openbank/mcp/application/McpPiiMaskingTest.kt
@@ -7,6 +7,7 @@ import com.fasterxml.jackson.databind.ObjectMapper
 import com.openbank.mcp.application.port.out.AccountReadPort
 import com.openbank.mcp.application.port.out.ConsentContext
 import com.openbank.mcp.application.port.out.ProposalPort
+import com.openbank.mcp.infrastructure.read.StubMarketingReachPort
 import org.junit.jupiter.api.Assertions.assertEquals
 import org.junit.jupiter.api.Assertions.assertFalse
 import org.junit.jupiter.api.Assertions.assertTrue
@@ -51,6 +52,7 @@ class McpPiiMaskingTest {
     private fun registry(payload: String) = McpToolRegistry(
         accounts = FixedReadPort(mapper.readTree(payload)),
         proposals = DenyingProposalPort,
+        marketingReach = StubMarketingReachPort(mapper),
         masker = masker,
         mapper = mapper,
     )

--- a/openbank-mcp-service/src/test/kotlin/com/openbank/mcp/application/McpUntrustedDataTest.kt
+++ b/openbank-mcp-service/src/test/kotlin/com/openbank/mcp/application/McpUntrustedDataTest.kt
@@ -7,6 +7,7 @@ import com.fasterxml.jackson.databind.ObjectMapper
 import com.openbank.mcp.application.port.out.AccountReadPort
 import com.openbank.mcp.application.port.out.ConsentContext
 import com.openbank.mcp.application.port.out.ProposalPort
+import com.openbank.mcp.infrastructure.read.StubMarketingReachPort
 import org.junit.jupiter.api.Assertions.assertEquals
 import org.junit.jupiter.api.Assertions.assertFalse
 import org.junit.jupiter.api.Assertions.assertTrue
@@ -33,6 +34,7 @@ class McpUntrustedDataTest {
     private fun registry(payload: String) = McpToolRegistry(
         accounts = FixedReadPort(mapper.readTree(payload)),
         proposals = DenyingProposalPort,
+        marketingReach = StubMarketingReachPort(mapper),
         masker = masker,
         mapper = mapper,
     )


### PR DESCRIPTION
ADR-0209 D5 · Closes #2574

The cheapest useful thing in the CRM/campaign area: **no new service, no pod, no database, no topic.** A tool on an MCP surface that already enforces the ADR-0195 consent binding and per-call audit.

## First, a correction to my own cost estimate

I recommended this as "a tool registration, not a build". That was right about **runtime** — FinOps delta is zero — and **wrong about change size** if taken to include the grant. Measured: the last two agent charters added (`ap2-anonymous`, `mcp-anonymous`) cost **58 and 61 files, 32–34 of them regenerated OPA bundles**, because every `gen-*-opa-bundle.sh` embeds `agents.yaml` verbatim and hashes it.

So this PR is the half that carries no governance files. The grant is separate — see below.

## Two decisions that go further than the issue asked

**It returns counts, never people.** A copilot planning a campaign needs the *reach* of a scope, not the identities inside it. Who actually receives anything is campaign-service's concern under ADR-0200's consent-gated delivery, which D5 explicitly does not authorise here. An aggregate means **no personal data leaves the bank on this path at all** — a stronger property than masking it on the way out, because there is nothing to mask.

**`MarketingReachPort` takes no `ConsentContext`, and that absence is the documentation.** Every other read on this surface is gated **twice**: the OPA charter capability, *and* the intersection with the PSD2 consent the caller presented. This query has no consent to intersect with — it is an operator-plane question about the bank's own reach, not about one customer's data — so the capability is the whole control.

Accepting a `ConsentContext` it did not use would imply a scoping that does not happen, and a reviewer comparing the two ports would read two gates where there is one. The kdoc says explicitly: do not add the parameter to make the signatures match.

## It ships DENIED, and that is asserted

No charter carries `query.marketing.readonly`, so the ADR-0034 PDP refuses every call. The capability entry in the registry is what makes the call **reach** the PDP at all — without it `McpEndpoint` refuses earlier with `no capability mapping` and the policy is never exercised.

`McpCampaignToolTest` asserts the denial **against `agents.yaml` itself**, not against a constant that would agree with itself forever:

```
KNOWN-POSITIVE: added query.marketing.readonly to agents.yaml
  -> McpCampaignToolTest > no charter grants query_marketing_readonly ... FAILED
restored -> 6/6 pass
```

So the grant has to turn this red and be changed deliberately. A grant slipping in unnoticed is the failure this prevents.

## Also: the smoke test could not see a swap

`McpBootSmokeTest` pinned `result.tools.size()`. A count cannot tell a swap from a no-op — replace one tool with another and `size() == 6` still passes, on a surface whose **entire security model is a curated allowlist**. It now asserts the tool **names**.

The five other registry construction sites are updated because the new constructor parameter breaks them at compile time. That is the right failure: a tool surface should not be extensible without every test that pins it having to say so.

## What is deliberately NOT here

The grant: `agents.yaml` charter (`plane: business` — this would be the **first** business-plane agent; the plane enum today is control/development/customer), the `tool_tiers.read` capability, the rego rule, and ~34 regenerated OPA bundles. Held back because #2247 is already in flight across 38 governance files, and two competing bundle restamps conflict by construction.

Note for that follow-up: `AuthorizeInterceptor` never emits `principal.type == "SERVICE"`, and the GHSA-58jq-9hq3-66jr shared-M2M write prohibition means a role-only rule grants this caller nothing. An identity-scoped rule on `input.principal.id` is the only sanctioned route — which is the correct constraint for a read-only tool anyway.

The stub is a stub on purpose: the real read is `GET /api/v1/consents/grantee/party-service:marketing-comms`, and binding that client before any charter can call the tool would be unreachable code nothing could exercise. It answers `phase: 1-stub` with `NOT REAL REACH` in the payload, because a placeholder that returns plausible numbers with no marker is indistinguishable from reach data — and reach data is what a campaign gets sized on.

## Gate

87/87 tests · `detekt` + `ktlintCheck` exit 0 · domain purity 0 new violations · license headers pass (no Apache→AGPL dependency) · no `openapi.yaml` in this module (JSON-RPC surface), so no contract axis to bump.