### PR TITLE
chore(governance): register the Kafka topic-existence rule in rules.yaml

### DIFF
--- a/openbank-infra/gitops/components/accounts/account-opa-bundle.yaml
+++ b/openbank-infra/gitops/components/accounts/account-opa-bundle.yaml
@@ -9,7 +9,7 @@ metadata:
     app.kubernetes.io/name: account-service
     app.kubernetes.io/part-of: accounts
   annotations:
-    openbank.tech/policy-checksum: "d98ef807906115ef"
+    openbank.tech/policy-checksum: "3cff4ee22a307a62"
 data:
   rest.rego: |
     # SPDX-License-Identifier: Apache-2.0
@@ -2816,6 +2816,50 @@ data:
             jdbc-postgresql (build.gradle.kts) — it has no OLTP datasource to reach. The
             reconciliation reads the warehouse and the WORM archive over blocking clients.
       ci_producer: ".github/scripts/check-no-runblocking-in-scheduled.py"
+
+
+    # ---------------------------------------------------------------------------------------
+    # Kafka topic existence (issue #2598). A service may only reference a topic that exists.
+    # ---------------------------------------------------------------------------------------
+    kafka_topics:
+      referenced_topics_must_be_declared: true
+      # A Kafka consumer subscribed to a topic that does not exist does NOT error. It joins its
+      # consumer group, reports healthy, and receives nothing — forever. There is no runtime
+      # signal that can distinguish it from a topic with no traffic: pod ready, group joined,
+      # lag zero, metrics flat. So this is only catchable statically, before the merge.
+      #
+      # Found live: openbank-analytics-sink subscribed to `openbank.account.events` and
+      # `openbank.transaction.events`. NEITHER has ever existed — the real topics are
+      # `openbank.accounts.account.created` and `openbank.transactions.transaction.initiated`,
+      # both declared, both produced, both already consumed by audit-service. The sink ran for
+      # weeks green while no ACCOUNT_OPENED and no TRANSACTION row ever reached bronze_events,
+      # which silently made ADR-0210 D2's account->party resolution dead code and left Customer
+      # 360 structurally unable to show a customer's accounts or transactions (PR #2629).
+      #
+      # Same failure shape as a client pointed at a REST path that does not exist — the one that
+      # shipped finrep's call to `/api/v1/ledger/trial-balance` (see the contract-test notes in
+      # CLAUDE.md). There the answer was to make the provider replay the contract at PR time;
+      # here it is to compare the name a service asks for against the set declared to exist.
+      #
+      # `openbank-infra/gitops` carries a KafkaTopic CR for every topic, so the declared set is
+      # authoritative and complete — that is what makes this checkable without a live broker.
+      #
+      # ENFORCED from the day it was written, not advisory. The fleet is at zero unresolved
+      # topics, so there is no judgement left to exercise; an advisory verdict over a checkable
+      # fact only makes the next violation mergeable.
+      scope: |
+        Every dotted topic name in a `topics:`/`topic:` key of any
+        openbank-*/src/main/resources/application.yaml must resolve to a KafkaTopic CR
+        (metadata.name or spec.topicName) under openbank-infra/gitops.
+      # EMPTY, and that is the point. An entry needs a reason, and the check fails on a stale
+      # declaration in BOTH directions — a name listed here that IS declared is itself reported —
+      # so a temporary exception cannot quietly become permanent. Same idiom as the pact gate's
+      # KNOWN_UNCOVERED and the runblocking_allowlist above.
+      allowed_absent: []
+      # The check ships with a --selftest that feeds it inputs it MUST flag and inputs it must
+      # NOT, run on every CI invocation: once the fleet is clean the flagging branch would
+      # otherwise never execute again, and a gate that has only ever passed is unfalsified.
+      ci_producer: ".github/scripts/check-kafka-topics-exist.py"
 
     # ---------------------------------------------------------------------------------------
     # Vulnerability-management lifecycle SLAs (ADR-0030 D1). Detection -> closure, in days.

--- a/openbank-infra/gitops/components/accounts/account-service.yaml
+++ b/openbank-infra/gitops/components/accounts/account-service.yaml
@@ -37,7 +37,7 @@ spec:
       annotations:
         # Rolls the pod when the OPA bundle changes — subPath mounts do NOT hot-reload.
         # Kept in sync by gen-account-opa-bundle.sh (do not hand-edit).
-        openbank.tech/policy-checksum: "d98ef807906115ef"
+        openbank.tech/policy-checksum: "3cff4ee22a307a62"
     spec:
       securityContext:
         runAsNonRoot: true

--- a/openbank-infra/gitops/components/aml/aml-opa-bundle.yaml
+++ b/openbank-infra/gitops/components/aml/aml-opa-bundle.yaml
@@ -9,7 +9,7 @@ metadata:
     app.kubernetes.io/name: aml-service
     app.kubernetes.io/part-of: aml
   annotations:
-    openbank.tech/policy-checksum: "925c21233461d0c3"
+    openbank.tech/policy-checksum: "b65a1ae2bd8a08b5"
 data:
   rest.rego: |
     # SPDX-License-Identifier: Apache-2.0
@@ -2789,6 +2789,50 @@ data:
             jdbc-postgresql (build.gradle.kts) — it has no OLTP datasource to reach. The
             reconciliation reads the warehouse and the WORM archive over blocking clients.
       ci_producer: ".github/scripts/check-no-runblocking-in-scheduled.py"
+
+
+    # ---------------------------------------------------------------------------------------
+    # Kafka topic existence (issue #2598). A service may only reference a topic that exists.
+    # ---------------------------------------------------------------------------------------
+    kafka_topics:
+      referenced_topics_must_be_declared: true
+      # A Kafka consumer subscribed to a topic that does not exist does NOT error. It joins its
+      # consumer group, reports healthy, and receives nothing — forever. There is no runtime
+      # signal that can distinguish it from a topic with no traffic: pod ready, group joined,
+      # lag zero, metrics flat. So this is only catchable statically, before the merge.
+      #
+      # Found live: openbank-analytics-sink subscribed to `openbank.account.events` and
+      # `openbank.transaction.events`. NEITHER has ever existed — the real topics are
+      # `openbank.accounts.account.created` and `openbank.transactions.transaction.initiated`,
+      # both declared, both produced, both already consumed by audit-service. The sink ran for
+      # weeks green while no ACCOUNT_OPENED and no TRANSACTION row ever reached bronze_events,
+      # which silently made ADR-0210 D2's account->party resolution dead code and left Customer
+      # 360 structurally unable to show a customer's accounts or transactions (PR #2629).
+      #
+      # Same failure shape as a client pointed at a REST path that does not exist — the one that
+      # shipped finrep's call to `/api/v1/ledger/trial-balance` (see the contract-test notes in
+      # CLAUDE.md). There the answer was to make the provider replay the contract at PR time;
+      # here it is to compare the name a service asks for against the set declared to exist.
+      #
+      # `openbank-infra/gitops` carries a KafkaTopic CR for every topic, so the declared set is
+      # authoritative and complete — that is what makes this checkable without a live broker.
+      #
+      # ENFORCED from the day it was written, not advisory. The fleet is at zero unresolved
+      # topics, so there is no judgement left to exercise; an advisory verdict over a checkable
+      # fact only makes the next violation mergeable.
+      scope: |
+        Every dotted topic name in a `topics:`/`topic:` key of any
+        openbank-*/src/main/resources/application.yaml must resolve to a KafkaTopic CR
+        (metadata.name or spec.topicName) under openbank-infra/gitops.
+      # EMPTY, and that is the point. An entry needs a reason, and the check fails on a stale
+      # declaration in BOTH directions — a name listed here that IS declared is itself reported —
+      # so a temporary exception cannot quietly become permanent. Same idiom as the pact gate's
+      # KNOWN_UNCOVERED and the runblocking_allowlist above.
+      allowed_absent: []
+      # The check ships with a --selftest that feeds it inputs it MUST flag and inputs it must
+      # NOT, run on every CI invocation: once the fleet is clean the flagging branch would
+      # otherwise never execute again, and a gate that has only ever passed is unfalsified.
+      ci_producer: ".github/scripts/check-kafka-topics-exist.py"
 
     # ---------------------------------------------------------------------------------------
     # Vulnerability-management lifecycle SLAs (ADR-0030 D1). Detection -> closure, in days.

--- a/openbank-infra/gitops/components/aml/aml-service.yaml
+++ b/openbank-infra/gitops/components/aml/aml-service.yaml
@@ -22,7 +22,7 @@ spec:
       annotations:
         # Rolls the pod when the OPA bundle changes (subPath mounts do not hot-reload).
         # Kept in sync by gen-aml-opa-bundle.sh (do not hand-edit).
-        openbank.tech/policy-checksum: "925c21233461d0c3"
+        openbank.tech/policy-checksum: "b65a1ae2bd8a08b5"
     spec:
       securityContext:
         runAsNonRoot: true

--- a/openbank-infra/gitops/components/anacredit/anacredit-opa-bundle.yaml
+++ b/openbank-infra/gitops/components/anacredit/anacredit-opa-bundle.yaml
@@ -9,7 +9,7 @@ metadata:
     app.kubernetes.io/name: anacredit-service
     app.kubernetes.io/part-of: anacredit
   annotations:
-    openbank.tech/policy-checksum: "af9fff4b7ad9f9a4"
+    openbank.tech/policy-checksum: "a11d9c01b3a98c0d"
 data:
   rest.rego: |
     # SPDX-License-Identifier: Apache-2.0
@@ -2759,6 +2759,50 @@ data:
             jdbc-postgresql (build.gradle.kts) — it has no OLTP datasource to reach. The
             reconciliation reads the warehouse and the WORM archive over blocking clients.
       ci_producer: ".github/scripts/check-no-runblocking-in-scheduled.py"
+
+
+    # ---------------------------------------------------------------------------------------
+    # Kafka topic existence (issue #2598). A service may only reference a topic that exists.
+    # ---------------------------------------------------------------------------------------
+    kafka_topics:
+      referenced_topics_must_be_declared: true
+      # A Kafka consumer subscribed to a topic that does not exist does NOT error. It joins its
+      # consumer group, reports healthy, and receives nothing — forever. There is no runtime
+      # signal that can distinguish it from a topic with no traffic: pod ready, group joined,
+      # lag zero, metrics flat. So this is only catchable statically, before the merge.
+      #
+      # Found live: openbank-analytics-sink subscribed to `openbank.account.events` and
+      # `openbank.transaction.events`. NEITHER has ever existed — the real topics are
+      # `openbank.accounts.account.created` and `openbank.transactions.transaction.initiated`,
+      # both declared, both produced, both already consumed by audit-service. The sink ran for
+      # weeks green while no ACCOUNT_OPENED and no TRANSACTION row ever reached bronze_events,
+      # which silently made ADR-0210 D2's account->party resolution dead code and left Customer
+      # 360 structurally unable to show a customer's accounts or transactions (PR #2629).
+      #
+      # Same failure shape as a client pointed at a REST path that does not exist — the one that
+      # shipped finrep's call to `/api/v1/ledger/trial-balance` (see the contract-test notes in
+      # CLAUDE.md). There the answer was to make the provider replay the contract at PR time;
+      # here it is to compare the name a service asks for against the set declared to exist.
+      #
+      # `openbank-infra/gitops` carries a KafkaTopic CR for every topic, so the declared set is
+      # authoritative and complete — that is what makes this checkable without a live broker.
+      #
+      # ENFORCED from the day it was written, not advisory. The fleet is at zero unresolved
+      # topics, so there is no judgement left to exercise; an advisory verdict over a checkable
+      # fact only makes the next violation mergeable.
+      scope: |
+        Every dotted topic name in a `topics:`/`topic:` key of any
+        openbank-*/src/main/resources/application.yaml must resolve to a KafkaTopic CR
+        (metadata.name or spec.topicName) under openbank-infra/gitops.
+      # EMPTY, and that is the point. An entry needs a reason, and the check fails on a stale
+      # declaration in BOTH directions — a name listed here that IS declared is itself reported —
+      # so a temporary exception cannot quietly become permanent. Same idiom as the pact gate's
+      # KNOWN_UNCOVERED and the runblocking_allowlist above.
+      allowed_absent: []
+      # The check ships with a --selftest that feeds it inputs it MUST flag and inputs it must
+      # NOT, run on every CI invocation: once the fleet is clean the flagging branch would
+      # otherwise never execute again, and a gate that has only ever passed is unfalsified.
+      ci_producer: ".github/scripts/check-kafka-topics-exist.py"
 
     # ---------------------------------------------------------------------------------------
     # Vulnerability-management lifecycle SLAs (ADR-0030 D1). Detection -> closure, in days.

--- a/openbank-infra/gitops/components/anacredit/anacredit-service.yaml
+++ b/openbank-infra/gitops/components/anacredit/anacredit-service.yaml
@@ -32,7 +32,7 @@ spec:
       annotations:
         # Rolls the pods when the OPA bundle changes — subPath mounts do NOT hot-reload.
         # Kept in sync by gen-anacredit-opa-bundle.sh (do not hand-edit).
-        openbank.tech/policy-checksum: "af9fff4b7ad9f9a4"
+        openbank.tech/policy-checksum: "a11d9c01b3a98c0d"
     spec:
       securityContext:
         runAsNonRoot: true

--- a/openbank-infra/gitops/components/ap2/ap2-opa-bundle.yaml
+++ b/openbank-infra/gitops/components/ap2/ap2-opa-bundle.yaml
@@ -9,7 +9,7 @@ metadata:
     app.kubernetes.io/name: mcp-service
     app.kubernetes.io/part-of: platform
   annotations:
-    openbank.tech/policy-checksum: "717010da54f7207e"
+    openbank.tech/policy-checksum: "465bc216e2560311"
 data:
   rest.rego: |
     # SPDX-License-Identifier: Apache-2.0
@@ -2727,6 +2727,50 @@ data:
             jdbc-postgresql (build.gradle.kts) — it has no OLTP datasource to reach. The
             reconciliation reads the warehouse and the WORM archive over blocking clients.
       ci_producer: ".github/scripts/check-no-runblocking-in-scheduled.py"
+
+
+    # ---------------------------------------------------------------------------------------
+    # Kafka topic existence (issue #2598). A service may only reference a topic that exists.
+    # ---------------------------------------------------------------------------------------
+    kafka_topics:
+      referenced_topics_must_be_declared: true
+      # A Kafka consumer subscribed to a topic that does not exist does NOT error. It joins its
+      # consumer group, reports healthy, and receives nothing — forever. There is no runtime
+      # signal that can distinguish it from a topic with no traffic: pod ready, group joined,
+      # lag zero, metrics flat. So this is only catchable statically, before the merge.
+      #
+      # Found live: openbank-analytics-sink subscribed to `openbank.account.events` and
+      # `openbank.transaction.events`. NEITHER has ever existed — the real topics are
+      # `openbank.accounts.account.created` and `openbank.transactions.transaction.initiated`,
+      # both declared, both produced, both already consumed by audit-service. The sink ran for
+      # weeks green while no ACCOUNT_OPENED and no TRANSACTION row ever reached bronze_events,
+      # which silently made ADR-0210 D2's account->party resolution dead code and left Customer
+      # 360 structurally unable to show a customer's accounts or transactions (PR #2629).
+      #
+      # Same failure shape as a client pointed at a REST path that does not exist — the one that
+      # shipped finrep's call to `/api/v1/ledger/trial-balance` (see the contract-test notes in
+      # CLAUDE.md). There the answer was to make the provider replay the contract at PR time;
+      # here it is to compare the name a service asks for against the set declared to exist.
+      #
+      # `openbank-infra/gitops` carries a KafkaTopic CR for every topic, so the declared set is
+      # authoritative and complete — that is what makes this checkable without a live broker.
+      #
+      # ENFORCED from the day it was written, not advisory. The fleet is at zero unresolved
+      # topics, so there is no judgement left to exercise; an advisory verdict over a checkable
+      # fact only makes the next violation mergeable.
+      scope: |
+        Every dotted topic name in a `topics:`/`topic:` key of any
+        openbank-*/src/main/resources/application.yaml must resolve to a KafkaTopic CR
+        (metadata.name or spec.topicName) under openbank-infra/gitops.
+      # EMPTY, and that is the point. An entry needs a reason, and the check fails on a stale
+      # declaration in BOTH directions — a name listed here that IS declared is itself reported —
+      # so a temporary exception cannot quietly become permanent. Same idiom as the pact gate's
+      # KNOWN_UNCOVERED and the runblocking_allowlist above.
+      allowed_absent: []
+      # The check ships with a --selftest that feeds it inputs it MUST flag and inputs it must
+      # NOT, run on every CI invocation: once the fleet is clean the flagging branch would
+      # otherwise never execute again, and a gate that has only ever passed is unfalsified.
+      ci_producer: ".github/scripts/check-kafka-topics-exist.py"
 
     # ---------------------------------------------------------------------------------------
     # Vulnerability-management lifecycle SLAs (ADR-0030 D1). Detection -> closure, in days.

--- a/openbank-infra/gitops/components/ap2/ap2-service.yaml
+++ b/openbank-infra/gitops/components/ap2/ap2-service.yaml
@@ -30,7 +30,7 @@ spec:
       annotations:
         # Roll the pod when the OPA policy bundle changes (subPath mounts don't hot-reload).
         # Kept in sync by gen-ap2-opa-bundle.sh (do not hand-edit).
-        openbank.tech/policy-checksum: "717010da54f7207e"
+        openbank.tech/policy-checksum: "465bc216e2560311"
     spec:
       securityContext:
         runAsNonRoot: true

--- a/openbank-infra/gitops/components/audit/audit-opa-bundle.yaml
+++ b/openbank-infra/gitops/components/audit/audit-opa-bundle.yaml
@@ -9,7 +9,7 @@ metadata:
     app.kubernetes.io/name: audit-service
     app.kubernetes.io/part-of: audit
   annotations:
-    openbank.tech/policy-checksum: "5560c9f6700b5897"
+    openbank.tech/policy-checksum: "e30c805fc9b6a6ba"
 data:
   rest.rego: |
     # SPDX-License-Identifier: Apache-2.0
@@ -2771,6 +2771,50 @@ data:
             jdbc-postgresql (build.gradle.kts) — it has no OLTP datasource to reach. The
             reconciliation reads the warehouse and the WORM archive over blocking clients.
       ci_producer: ".github/scripts/check-no-runblocking-in-scheduled.py"
+
+
+    # ---------------------------------------------------------------------------------------
+    # Kafka topic existence (issue #2598). A service may only reference a topic that exists.
+    # ---------------------------------------------------------------------------------------
+    kafka_topics:
+      referenced_topics_must_be_declared: true
+      # A Kafka consumer subscribed to a topic that does not exist does NOT error. It joins its
+      # consumer group, reports healthy, and receives nothing — forever. There is no runtime
+      # signal that can distinguish it from a topic with no traffic: pod ready, group joined,
+      # lag zero, metrics flat. So this is only catchable statically, before the merge.
+      #
+      # Found live: openbank-analytics-sink subscribed to `openbank.account.events` and
+      # `openbank.transaction.events`. NEITHER has ever existed — the real topics are
+      # `openbank.accounts.account.created` and `openbank.transactions.transaction.initiated`,
+      # both declared, both produced, both already consumed by audit-service. The sink ran for
+      # weeks green while no ACCOUNT_OPENED and no TRANSACTION row ever reached bronze_events,
+      # which silently made ADR-0210 D2's account->party resolution dead code and left Customer
+      # 360 structurally unable to show a customer's accounts or transactions (PR #2629).
+      #
+      # Same failure shape as a client pointed at a REST path that does not exist — the one that
+      # shipped finrep's call to `/api/v1/ledger/trial-balance` (see the contract-test notes in
+      # CLAUDE.md). There the answer was to make the provider replay the contract at PR time;
+      # here it is to compare the name a service asks for against the set declared to exist.
+      #
+      # `openbank-infra/gitops` carries a KafkaTopic CR for every topic, so the declared set is
+      # authoritative and complete — that is what makes this checkable without a live broker.
+      #
+      # ENFORCED from the day it was written, not advisory. The fleet is at zero unresolved
+      # topics, so there is no judgement left to exercise; an advisory verdict over a checkable
+      # fact only makes the next violation mergeable.
+      scope: |
+        Every dotted topic name in a `topics:`/`topic:` key of any
+        openbank-*/src/main/resources/application.yaml must resolve to a KafkaTopic CR
+        (metadata.name or spec.topicName) under openbank-infra/gitops.
+      # EMPTY, and that is the point. An entry needs a reason, and the check fails on a stale
+      # declaration in BOTH directions — a name listed here that IS declared is itself reported —
+      # so a temporary exception cannot quietly become permanent. Same idiom as the pact gate's
+      # KNOWN_UNCOVERED and the runblocking_allowlist above.
+      allowed_absent: []
+      # The check ships with a --selftest that feeds it inputs it MUST flag and inputs it must
+      # NOT, run on every CI invocation: once the fleet is clean the flagging branch would
+      # otherwise never execute again, and a gate that has only ever passed is unfalsified.
+      ci_producer: ".github/scripts/check-kafka-topics-exist.py"
 
     # ---------------------------------------------------------------------------------------
     # Vulnerability-management lifecycle SLAs (ADR-0030 D1). Detection -> closure, in days.

--- a/openbank-infra/gitops/components/audit/audit-service.yaml
+++ b/openbank-infra/gitops/components/audit/audit-service.yaml
@@ -22,7 +22,7 @@ spec:
       annotations:
         # Rolls the pod when the OPA bundle changes (subPath mounts do not hot-reload).
         # Kept in sync by gen-audit-opa-bundle.sh (do not hand-edit).
-        openbank.tech/policy-checksum: "5560c9f6700b5897"
+        openbank.tech/policy-checksum: "e30c805fc9b6a6ba"
     spec:
       securityContext:
         runAsNonRoot: true

--- a/openbank-infra/gitops/components/balances/balance-opa-bundle.yaml
+++ b/openbank-infra/gitops/components/balances/balance-opa-bundle.yaml
@@ -9,7 +9,7 @@ metadata:
     app.kubernetes.io/name: balance-service
     app.kubernetes.io/part-of: balances
   annotations:
-    openbank.tech/policy-checksum: "0fc071cb2ce21043"
+    openbank.tech/policy-checksum: "94b91abed915565b"
 data:
   rest.rego: |
     # SPDX-License-Identifier: Apache-2.0
@@ -2860,6 +2860,50 @@ data:
             jdbc-postgresql (build.gradle.kts) — it has no OLTP datasource to reach. The
             reconciliation reads the warehouse and the WORM archive over blocking clients.
       ci_producer: ".github/scripts/check-no-runblocking-in-scheduled.py"
+
+
+    # ---------------------------------------------------------------------------------------
+    # Kafka topic existence (issue #2598). A service may only reference a topic that exists.
+    # ---------------------------------------------------------------------------------------
+    kafka_topics:
+      referenced_topics_must_be_declared: true
+      # A Kafka consumer subscribed to a topic that does not exist does NOT error. It joins its
+      # consumer group, reports healthy, and receives nothing — forever. There is no runtime
+      # signal that can distinguish it from a topic with no traffic: pod ready, group joined,
+      # lag zero, metrics flat. So this is only catchable statically, before the merge.
+      #
+      # Found live: openbank-analytics-sink subscribed to `openbank.account.events` and
+      # `openbank.transaction.events`. NEITHER has ever existed — the real topics are
+      # `openbank.accounts.account.created` and `openbank.transactions.transaction.initiated`,
+      # both declared, both produced, both already consumed by audit-service. The sink ran for
+      # weeks green while no ACCOUNT_OPENED and no TRANSACTION row ever reached bronze_events,
+      # which silently made ADR-0210 D2's account->party resolution dead code and left Customer
+      # 360 structurally unable to show a customer's accounts or transactions (PR #2629).
+      #
+      # Same failure shape as a client pointed at a REST path that does not exist — the one that
+      # shipped finrep's call to `/api/v1/ledger/trial-balance` (see the contract-test notes in
+      # CLAUDE.md). There the answer was to make the provider replay the contract at PR time;
+      # here it is to compare the name a service asks for against the set declared to exist.
+      #
+      # `openbank-infra/gitops` carries a KafkaTopic CR for every topic, so the declared set is
+      # authoritative and complete — that is what makes this checkable without a live broker.
+      #
+      # ENFORCED from the day it was written, not advisory. The fleet is at zero unresolved
+      # topics, so there is no judgement left to exercise; an advisory verdict over a checkable
+      # fact only makes the next violation mergeable.
+      scope: |
+        Every dotted topic name in a `topics:`/`topic:` key of any
+        openbank-*/src/main/resources/application.yaml must resolve to a KafkaTopic CR
+        (metadata.name or spec.topicName) under openbank-infra/gitops.
+      # EMPTY, and that is the point. An entry needs a reason, and the check fails on a stale
+      # declaration in BOTH directions — a name listed here that IS declared is itself reported —
+      # so a temporary exception cannot quietly become permanent. Same idiom as the pact gate's
+      # KNOWN_UNCOVERED and the runblocking_allowlist above.
+      allowed_absent: []
+      # The check ships with a --selftest that feeds it inputs it MUST flag and inputs it must
+      # NOT, run on every CI invocation: once the fleet is clean the flagging branch would
+      # otherwise never execute again, and a gate that has only ever passed is unfalsified.
+      ci_producer: ".github/scripts/check-kafka-topics-exist.py"
 
     # ---------------------------------------------------------------------------------------
     # Vulnerability-management lifecycle SLAs (ADR-0030 D1). Detection -> closure, in days.

--- a/openbank-infra/gitops/components/balances/balance-service.yaml
+++ b/openbank-infra/gitops/components/balances/balance-service.yaml
@@ -34,7 +34,7 @@ spec:
       annotations:
         # Rolls the pods when the OPA bundle changes — subPath mounts do NOT hot-reload.
         # Kept in sync by gen-balance-opa-bundle.sh (do not hand-edit).
-        openbank.tech/policy-checksum: "0fc071cb2ce21043"
+        openbank.tech/policy-checksum: "94b91abed915565b"
     spec:
       securityContext:
         runAsNonRoot: true

--- a/openbank-infra/gitops/components/billing/billing-opa-bundle.yaml
+++ b/openbank-infra/gitops/components/billing/billing-opa-bundle.yaml
@@ -9,7 +9,7 @@ metadata:
     app.kubernetes.io/name: billing-service
     app.kubernetes.io/part-of: billing
   annotations:
-    openbank.tech/policy-checksum: "e9207e86c44945e5"
+    openbank.tech/policy-checksum: "bc9ac50a32576806"
 data:
   rest.rego: |
     # SPDX-License-Identifier: Apache-2.0
@@ -2765,6 +2765,50 @@ data:
             jdbc-postgresql (build.gradle.kts) — it has no OLTP datasource to reach. The
             reconciliation reads the warehouse and the WORM archive over blocking clients.
       ci_producer: ".github/scripts/check-no-runblocking-in-scheduled.py"
+
+
+    # ---------------------------------------------------------------------------------------
+    # Kafka topic existence (issue #2598). A service may only reference a topic that exists.
+    # ---------------------------------------------------------------------------------------
+    kafka_topics:
+      referenced_topics_must_be_declared: true
+      # A Kafka consumer subscribed to a topic that does not exist does NOT error. It joins its
+      # consumer group, reports healthy, and receives nothing — forever. There is no runtime
+      # signal that can distinguish it from a topic with no traffic: pod ready, group joined,
+      # lag zero, metrics flat. So this is only catchable statically, before the merge.
+      #
+      # Found live: openbank-analytics-sink subscribed to `openbank.account.events` and
+      # `openbank.transaction.events`. NEITHER has ever existed — the real topics are
+      # `openbank.accounts.account.created` and `openbank.transactions.transaction.initiated`,
+      # both declared, both produced, both already consumed by audit-service. The sink ran for
+      # weeks green while no ACCOUNT_OPENED and no TRANSACTION row ever reached bronze_events,
+      # which silently made ADR-0210 D2's account->party resolution dead code and left Customer
+      # 360 structurally unable to show a customer's accounts or transactions (PR #2629).
+      #
+      # Same failure shape as a client pointed at a REST path that does not exist — the one that
+      # shipped finrep's call to `/api/v1/ledger/trial-balance` (see the contract-test notes in
+      # CLAUDE.md). There the answer was to make the provider replay the contract at PR time;
+      # here it is to compare the name a service asks for against the set declared to exist.
+      #
+      # `openbank-infra/gitops` carries a KafkaTopic CR for every topic, so the declared set is
+      # authoritative and complete — that is what makes this checkable without a live broker.
+      #
+      # ENFORCED from the day it was written, not advisory. The fleet is at zero unresolved
+      # topics, so there is no judgement left to exercise; an advisory verdict over a checkable
+      # fact only makes the next violation mergeable.
+      scope: |
+        Every dotted topic name in a `topics:`/`topic:` key of any
+        openbank-*/src/main/resources/application.yaml must resolve to a KafkaTopic CR
+        (metadata.name or spec.topicName) under openbank-infra/gitops.
+      # EMPTY, and that is the point. An entry needs a reason, and the check fails on a stale
+      # declaration in BOTH directions — a name listed here that IS declared is itself reported —
+      # so a temporary exception cannot quietly become permanent. Same idiom as the pact gate's
+      # KNOWN_UNCOVERED and the runblocking_allowlist above.
+      allowed_absent: []
+      # The check ships with a --selftest that feeds it inputs it MUST flag and inputs it must
+      # NOT, run on every CI invocation: once the fleet is clean the flagging branch would
+      # otherwise never execute again, and a gate that has only ever passed is unfalsified.
+      ci_producer: ".github/scripts/check-kafka-topics-exist.py"
 
     # ---------------------------------------------------------------------------------------
     # Vulnerability-management lifecycle SLAs (ADR-0030 D1). Detection -> closure, in days.

--- a/openbank-infra/gitops/components/billing/billing-service.yaml
+++ b/openbank-infra/gitops/components/billing/billing-service.yaml
@@ -27,7 +27,7 @@ spec:
       annotations:
         # Rolls the pods when the OPA bundle changes — subPath mounts do NOT hot-reload.
         # Kept in sync by gen-billing-opa-bundle.sh (do not hand-edit).
-        openbank.tech/policy-checksum: "e9207e86c44945e5"
+        openbank.tech/policy-checksum: "bc9ac50a32576806"
     spec:
       securityContext:
         runAsNonRoot: true

--- a/openbank-infra/gitops/components/consent/consent-opa-bundle.yaml
+++ b/openbank-infra/gitops/components/consent/consent-opa-bundle.yaml
@@ -9,7 +9,7 @@ metadata:
     app.kubernetes.io/name: consent-service
     app.kubernetes.io/part-of: consent
   annotations:
-    openbank.tech/policy-checksum: "10f75ede25920d1c"
+    openbank.tech/policy-checksum: "a559db71ac5033f5"
 data:
   rest.rego: |
     # SPDX-License-Identifier: Apache-2.0
@@ -2835,6 +2835,50 @@ data:
             jdbc-postgresql (build.gradle.kts) — it has no OLTP datasource to reach. The
             reconciliation reads the warehouse and the WORM archive over blocking clients.
       ci_producer: ".github/scripts/check-no-runblocking-in-scheduled.py"
+
+
+    # ---------------------------------------------------------------------------------------
+    # Kafka topic existence (issue #2598). A service may only reference a topic that exists.
+    # ---------------------------------------------------------------------------------------
+    kafka_topics:
+      referenced_topics_must_be_declared: true
+      # A Kafka consumer subscribed to a topic that does not exist does NOT error. It joins its
+      # consumer group, reports healthy, and receives nothing — forever. There is no runtime
+      # signal that can distinguish it from a topic with no traffic: pod ready, group joined,
+      # lag zero, metrics flat. So this is only catchable statically, before the merge.
+      #
+      # Found live: openbank-analytics-sink subscribed to `openbank.account.events` and
+      # `openbank.transaction.events`. NEITHER has ever existed — the real topics are
+      # `openbank.accounts.account.created` and `openbank.transactions.transaction.initiated`,
+      # both declared, both produced, both already consumed by audit-service. The sink ran for
+      # weeks green while no ACCOUNT_OPENED and no TRANSACTION row ever reached bronze_events,
+      # which silently made ADR-0210 D2's account->party resolution dead code and left Customer
+      # 360 structurally unable to show a customer's accounts or transactions (PR #2629).
+      #
+      # Same failure shape as a client pointed at a REST path that does not exist — the one that
+      # shipped finrep's call to `/api/v1/ledger/trial-balance` (see the contract-test notes in
+      # CLAUDE.md). There the answer was to make the provider replay the contract at PR time;
+      # here it is to compare the name a service asks for against the set declared to exist.
+      #
+      # `openbank-infra/gitops` carries a KafkaTopic CR for every topic, so the declared set is
+      # authoritative and complete — that is what makes this checkable without a live broker.
+      #
+      # ENFORCED from the day it was written, not advisory. The fleet is at zero unresolved
+      # topics, so there is no judgement left to exercise; an advisory verdict over a checkable
+      # fact only makes the next violation mergeable.
+      scope: |
+        Every dotted topic name in a `topics:`/`topic:` key of any
+        openbank-*/src/main/resources/application.yaml must resolve to a KafkaTopic CR
+        (metadata.name or spec.topicName) under openbank-infra/gitops.
+      # EMPTY, and that is the point. An entry needs a reason, and the check fails on a stale
+      # declaration in BOTH directions — a name listed here that IS declared is itself reported —
+      # so a temporary exception cannot quietly become permanent. Same idiom as the pact gate's
+      # KNOWN_UNCOVERED and the runblocking_allowlist above.
+      allowed_absent: []
+      # The check ships with a --selftest that feeds it inputs it MUST flag and inputs it must
+      # NOT, run on every CI invocation: once the fleet is clean the flagging branch would
+      # otherwise never execute again, and a gate that has only ever passed is unfalsified.
+      ci_producer: ".github/scripts/check-kafka-topics-exist.py"
 
     # ---------------------------------------------------------------------------------------
     # Vulnerability-management lifecycle SLAs (ADR-0030 D1). Detection -> closure, in days.

--- a/openbank-infra/gitops/components/consent/consent-service.yaml
+++ b/openbank-infra/gitops/components/consent/consent-service.yaml
@@ -28,7 +28,7 @@ spec:
       annotations:
         # Rolls the pods when the OPA bundle changes — subPath mounts do NOT hot-reload.
         # Kept in sync by gen-consent-opa-bundle.sh (do not hand-edit).
-        openbank.tech/policy-checksum: "10f75ede25920d1c"
+        openbank.tech/policy-checksum: "a559db71ac5033f5"
     spec:
       securityContext:
         runAsNonRoot: true

--- a/openbank-infra/gitops/components/copilot/copilot-opa-bundle.yaml
+++ b/openbank-infra/gitops/components/copilot/copilot-opa-bundle.yaml
@@ -9,7 +9,7 @@ metadata:
     app.kubernetes.io/name: copilot-service
     app.kubernetes.io/part-of: platform
   annotations:
-    openbank.tech/policy-checksum: "3c3636c585f31d12"
+    openbank.tech/policy-checksum: "d83f92196abd2945"
 data:
   rest.rego: |
     # SPDX-License-Identifier: Apache-2.0
@@ -2851,6 +2851,50 @@ data:
             jdbc-postgresql (build.gradle.kts) — it has no OLTP datasource to reach. The
             reconciliation reads the warehouse and the WORM archive over blocking clients.
       ci_producer: ".github/scripts/check-no-runblocking-in-scheduled.py"
+
+
+    # ---------------------------------------------------------------------------------------
+    # Kafka topic existence (issue #2598). A service may only reference a topic that exists.
+    # ---------------------------------------------------------------------------------------
+    kafka_topics:
+      referenced_topics_must_be_declared: true
+      # A Kafka consumer subscribed to a topic that does not exist does NOT error. It joins its
+      # consumer group, reports healthy, and receives nothing — forever. There is no runtime
+      # signal that can distinguish it from a topic with no traffic: pod ready, group joined,
+      # lag zero, metrics flat. So this is only catchable statically, before the merge.
+      #
+      # Found live: openbank-analytics-sink subscribed to `openbank.account.events` and
+      # `openbank.transaction.events`. NEITHER has ever existed — the real topics are
+      # `openbank.accounts.account.created` and `openbank.transactions.transaction.initiated`,
+      # both declared, both produced, both already consumed by audit-service. The sink ran for
+      # weeks green while no ACCOUNT_OPENED and no TRANSACTION row ever reached bronze_events,
+      # which silently made ADR-0210 D2's account->party resolution dead code and left Customer
+      # 360 structurally unable to show a customer's accounts or transactions (PR #2629).
+      #
+      # Same failure shape as a client pointed at a REST path that does not exist — the one that
+      # shipped finrep's call to `/api/v1/ledger/trial-balance` (see the contract-test notes in
+      # CLAUDE.md). There the answer was to make the provider replay the contract at PR time;
+      # here it is to compare the name a service asks for against the set declared to exist.
+      #
+      # `openbank-infra/gitops` carries a KafkaTopic CR for every topic, so the declared set is
+      # authoritative and complete — that is what makes this checkable without a live broker.
+      #
+      # ENFORCED from the day it was written, not advisory. The fleet is at zero unresolved
+      # topics, so there is no judgement left to exercise; an advisory verdict over a checkable
+      # fact only makes the next violation mergeable.
+      scope: |
+        Every dotted topic name in a `topics:`/`topic:` key of any
+        openbank-*/src/main/resources/application.yaml must resolve to a KafkaTopic CR
+        (metadata.name or spec.topicName) under openbank-infra/gitops.
+      # EMPTY, and that is the point. An entry needs a reason, and the check fails on a stale
+      # declaration in BOTH directions — a name listed here that IS declared is itself reported —
+      # so a temporary exception cannot quietly become permanent. Same idiom as the pact gate's
+      # KNOWN_UNCOVERED and the runblocking_allowlist above.
+      allowed_absent: []
+      # The check ships with a --selftest that feeds it inputs it MUST flag and inputs it must
+      # NOT, run on every CI invocation: once the fleet is clean the flagging branch would
+      # otherwise never execute again, and a gate that has only ever passed is unfalsified.
+      ci_producer: ".github/scripts/check-kafka-topics-exist.py"
 
     # ---------------------------------------------------------------------------------------
     # Vulnerability-management lifecycle SLAs (ADR-0030 D1). Detection -> closure, in days.

--- a/openbank-infra/gitops/components/copilot/copilot-service.yaml
+++ b/openbank-infra/gitops/components/copilot/copilot-service.yaml
@@ -29,7 +29,7 @@ spec:
       annotations:
         # Rolls the pod when the OPA bundle changes — subPath mounts do NOT hot-reload.
         # Kept in sync by gen-copilot-opa-bundle.sh (do not hand-edit).
-        openbank.tech/policy-checksum: "3c3636c585f31d12"
+        openbank.tech/policy-checksum: "d83f92196abd2945"
     spec:
       securityContext:
         runAsNonRoot: true

--- a/openbank-infra/gitops/components/customer-edge/customer-edge-opa-bundle.yaml
+++ b/openbank-infra/gitops/components/customer-edge/customer-edge-opa-bundle.yaml
@@ -10,7 +10,7 @@ metadata:
     app.kubernetes.io/name: customer-edge
     app.kubernetes.io/part-of: customer-edge
   annotations:
-    openbank.tech/policy-checksum: "360984fd2deb4202"
+    openbank.tech/policy-checksum: "80f3ab7acfa9c205"
 data:
   rest.rego: |
     # SPDX-License-Identifier: Apache-2.0
@@ -1950,6 +1950,50 @@ data:
             jdbc-postgresql (build.gradle.kts) — it has no OLTP datasource to reach. The
             reconciliation reads the warehouse and the WORM archive over blocking clients.
       ci_producer: ".github/scripts/check-no-runblocking-in-scheduled.py"
+
+
+    # ---------------------------------------------------------------------------------------
+    # Kafka topic existence (issue #2598). A service may only reference a topic that exists.
+    # ---------------------------------------------------------------------------------------
+    kafka_topics:
+      referenced_topics_must_be_declared: true
+      # A Kafka consumer subscribed to a topic that does not exist does NOT error. It joins its
+      # consumer group, reports healthy, and receives nothing — forever. There is no runtime
+      # signal that can distinguish it from a topic with no traffic: pod ready, group joined,
+      # lag zero, metrics flat. So this is only catchable statically, before the merge.
+      #
+      # Found live: openbank-analytics-sink subscribed to `openbank.account.events` and
+      # `openbank.transaction.events`. NEITHER has ever existed — the real topics are
+      # `openbank.accounts.account.created` and `openbank.transactions.transaction.initiated`,
+      # both declared, both produced, both already consumed by audit-service. The sink ran for
+      # weeks green while no ACCOUNT_OPENED and no TRANSACTION row ever reached bronze_events,
+      # which silently made ADR-0210 D2's account->party resolution dead code and left Customer
+      # 360 structurally unable to show a customer's accounts or transactions (PR #2629).
+      #
+      # Same failure shape as a client pointed at a REST path that does not exist — the one that
+      # shipped finrep's call to `/api/v1/ledger/trial-balance` (see the contract-test notes in
+      # CLAUDE.md). There the answer was to make the provider replay the contract at PR time;
+      # here it is to compare the name a service asks for against the set declared to exist.
+      #
+      # `openbank-infra/gitops` carries a KafkaTopic CR for every topic, so the declared set is
+      # authoritative and complete — that is what makes this checkable without a live broker.
+      #
+      # ENFORCED from the day it was written, not advisory. The fleet is at zero unresolved
+      # topics, so there is no judgement left to exercise; an advisory verdict over a checkable
+      # fact only makes the next violation mergeable.
+      scope: |
+        Every dotted topic name in a `topics:`/`topic:` key of any
+        openbank-*/src/main/resources/application.yaml must resolve to a KafkaTopic CR
+        (metadata.name or spec.topicName) under openbank-infra/gitops.
+      # EMPTY, and that is the point. An entry needs a reason, and the check fails on a stale
+      # declaration in BOTH directions — a name listed here that IS declared is itself reported —
+      # so a temporary exception cannot quietly become permanent. Same idiom as the pact gate's
+      # KNOWN_UNCOVERED and the runblocking_allowlist above.
+      allowed_absent: []
+      # The check ships with a --selftest that feeds it inputs it MUST flag and inputs it must
+      # NOT, run on every CI invocation: once the fleet is clean the flagging branch would
+      # otherwise never execute again, and a gate that has only ever passed is unfalsified.
+      ci_producer: ".github/scripts/check-kafka-topics-exist.py"
 
     # ---------------------------------------------------------------------------------------
     # Vulnerability-management lifecycle SLAs (ADR-0030 D1). Detection -> closure, in days.

--- a/openbank-infra/gitops/components/customer-edge/customer-edge.yaml
+++ b/openbank-infra/gitops/components/customer-edge/customer-edge.yaml
@@ -65,7 +65,7 @@ spec:
       annotations:
         # Rolls the pod when the OPA bundle changes — subPath mounts do NOT hot-reload.
         # Kept in sync by gen-customer-edge-opa-bundle.sh (do not hand-edit).
-        openbank.tech/policy-checksum: "360984fd2deb4202"
+        openbank.tech/policy-checksum: "80f3ab7acfa9c205"
     spec:
       # Dedicated SA so EKS Pod Identity can hand the edge (and ONLY the edge) the
       # feedback-screenshots S3 role — ADR-0192, openbank-infra/aws/envs/sandbox-platform/

--- a/openbank-infra/gitops/components/dispute-service/dispute-opa-bundle.yaml
+++ b/openbank-infra/gitops/components/dispute-service/dispute-opa-bundle.yaml
@@ -9,7 +9,7 @@ metadata:
     app.kubernetes.io/name: dispute-service
     app.kubernetes.io/part-of: dispute
   annotations:
-    openbank.tech/policy-checksum: "19018c675825e70c"
+    openbank.tech/policy-checksum: "caec3e0cc6a1b2f0"
 data:
   rest.rego: |
     # SPDX-License-Identifier: Apache-2.0
@@ -2901,6 +2901,50 @@ data:
             jdbc-postgresql (build.gradle.kts) — it has no OLTP datasource to reach. The
             reconciliation reads the warehouse and the WORM archive over blocking clients.
       ci_producer: ".github/scripts/check-no-runblocking-in-scheduled.py"
+
+
+    # ---------------------------------------------------------------------------------------
+    # Kafka topic existence (issue #2598). A service may only reference a topic that exists.
+    # ---------------------------------------------------------------------------------------
+    kafka_topics:
+      referenced_topics_must_be_declared: true
+      # A Kafka consumer subscribed to a topic that does not exist does NOT error. It joins its
+      # consumer group, reports healthy, and receives nothing — forever. There is no runtime
+      # signal that can distinguish it from a topic with no traffic: pod ready, group joined,
+      # lag zero, metrics flat. So this is only catchable statically, before the merge.
+      #
+      # Found live: openbank-analytics-sink subscribed to `openbank.account.events` and
+      # `openbank.transaction.events`. NEITHER has ever existed — the real topics are
+      # `openbank.accounts.account.created` and `openbank.transactions.transaction.initiated`,
+      # both declared, both produced, both already consumed by audit-service. The sink ran for
+      # weeks green while no ACCOUNT_OPENED and no TRANSACTION row ever reached bronze_events,
+      # which silently made ADR-0210 D2's account->party resolution dead code and left Customer
+      # 360 structurally unable to show a customer's accounts or transactions (PR #2629).
+      #
+      # Same failure shape as a client pointed at a REST path that does not exist — the one that
+      # shipped finrep's call to `/api/v1/ledger/trial-balance` (see the contract-test notes in
+      # CLAUDE.md). There the answer was to make the provider replay the contract at PR time;
+      # here it is to compare the name a service asks for against the set declared to exist.
+      #
+      # `openbank-infra/gitops` carries a KafkaTopic CR for every topic, so the declared set is
+      # authoritative and complete — that is what makes this checkable without a live broker.
+      #
+      # ENFORCED from the day it was written, not advisory. The fleet is at zero unresolved
+      # topics, so there is no judgement left to exercise; an advisory verdict over a checkable
+      # fact only makes the next violation mergeable.
+      scope: |
+        Every dotted topic name in a `topics:`/`topic:` key of any
+        openbank-*/src/main/resources/application.yaml must resolve to a KafkaTopic CR
+        (metadata.name or spec.topicName) under openbank-infra/gitops.
+      # EMPTY, and that is the point. An entry needs a reason, and the check fails on a stale
+      # declaration in BOTH directions — a name listed here that IS declared is itself reported —
+      # so a temporary exception cannot quietly become permanent. Same idiom as the pact gate's
+      # KNOWN_UNCOVERED and the runblocking_allowlist above.
+      allowed_absent: []
+      # The check ships with a --selftest that feeds it inputs it MUST flag and inputs it must
+      # NOT, run on every CI invocation: once the fleet is clean the flagging branch would
+      # otherwise never execute again, and a gate that has only ever passed is unfalsified.
+      ci_producer: ".github/scripts/check-kafka-topics-exist.py"
 
     # ---------------------------------------------------------------------------------------
     # Vulnerability-management lifecycle SLAs (ADR-0030 D1). Detection -> closure, in days.

--- a/openbank-infra/gitops/components/dispute-service/dispute-service.yaml
+++ b/openbank-infra/gitops/components/dispute-service/dispute-service.yaml
@@ -15,7 +15,7 @@ spec:
       annotations:
         # Rolls the pod when the OPA bundle changes — subPath mounts do NOT hot-reload.
         # Kept in sync by gen-dispute-opa-bundle.sh (do not hand-edit).
-        openbank.tech/policy-checksum: "19018c675825e70c"
+        openbank.tech/policy-checksum: "caec3e0cc6a1b2f0"
       labels: {app.kubernetes.io/name: dispute-service, app.kubernetes.io/part-of: dispute}
     spec:
       securityContext:

--- a/openbank-infra/gitops/components/document-service/document-service-opa-bundle.yaml
+++ b/openbank-infra/gitops/components/document-service/document-service-opa-bundle.yaml
@@ -10,7 +10,7 @@ metadata:
     app.kubernetes.io/name: document-service
     app.kubernetes.io/part-of: documents
   annotations:
-    openbank.tech/policy-checksum: "360984fd2deb4202"
+    openbank.tech/policy-checksum: "80f3ab7acfa9c205"
 data:
   rest.rego: |
     # SPDX-License-Identifier: Apache-2.0
@@ -1950,6 +1950,50 @@ data:
             jdbc-postgresql (build.gradle.kts) — it has no OLTP datasource to reach. The
             reconciliation reads the warehouse and the WORM archive over blocking clients.
       ci_producer: ".github/scripts/check-no-runblocking-in-scheduled.py"
+
+
+    # ---------------------------------------------------------------------------------------
+    # Kafka topic existence (issue #2598). A service may only reference a topic that exists.
+    # ---------------------------------------------------------------------------------------
+    kafka_topics:
+      referenced_topics_must_be_declared: true
+      # A Kafka consumer subscribed to a topic that does not exist does NOT error. It joins its
+      # consumer group, reports healthy, and receives nothing — forever. There is no runtime
+      # signal that can distinguish it from a topic with no traffic: pod ready, group joined,
+      # lag zero, metrics flat. So this is only catchable statically, before the merge.
+      #
+      # Found live: openbank-analytics-sink subscribed to `openbank.account.events` and
+      # `openbank.transaction.events`. NEITHER has ever existed — the real topics are
+      # `openbank.accounts.account.created` and `openbank.transactions.transaction.initiated`,
+      # both declared, both produced, both already consumed by audit-service. The sink ran for
+      # weeks green while no ACCOUNT_OPENED and no TRANSACTION row ever reached bronze_events,
+      # which silently made ADR-0210 D2's account->party resolution dead code and left Customer
+      # 360 structurally unable to show a customer's accounts or transactions (PR #2629).
+      #
+      # Same failure shape as a client pointed at a REST path that does not exist — the one that
+      # shipped finrep's call to `/api/v1/ledger/trial-balance` (see the contract-test notes in
+      # CLAUDE.md). There the answer was to make the provider replay the contract at PR time;
+      # here it is to compare the name a service asks for against the set declared to exist.
+      #
+      # `openbank-infra/gitops` carries a KafkaTopic CR for every topic, so the declared set is
+      # authoritative and complete — that is what makes this checkable without a live broker.
+      #
+      # ENFORCED from the day it was written, not advisory. The fleet is at zero unresolved
+      # topics, so there is no judgement left to exercise; an advisory verdict over a checkable
+      # fact only makes the next violation mergeable.
+      scope: |
+        Every dotted topic name in a `topics:`/`topic:` key of any
+        openbank-*/src/main/resources/application.yaml must resolve to a KafkaTopic CR
+        (metadata.name or spec.topicName) under openbank-infra/gitops.
+      # EMPTY, and that is the point. An entry needs a reason, and the check fails on a stale
+      # declaration in BOTH directions — a name listed here that IS declared is itself reported —
+      # so a temporary exception cannot quietly become permanent. Same idiom as the pact gate's
+      # KNOWN_UNCOVERED and the runblocking_allowlist above.
+      allowed_absent: []
+      # The check ships with a --selftest that feeds it inputs it MUST flag and inputs it must
+      # NOT, run on every CI invocation: once the fleet is clean the flagging branch would
+      # otherwise never execute again, and a gate that has only ever passed is unfalsified.
+      ci_producer: ".github/scripts/check-kafka-topics-exist.py"
 
     # ---------------------------------------------------------------------------------------
     # Vulnerability-management lifecycle SLAs (ADR-0030 D1). Detection -> closure, in days.

--- a/openbank-infra/gitops/components/document-service/document-service-service.yaml
+++ b/openbank-infra/gitops/components/document-service/document-service-service.yaml
@@ -43,7 +43,7 @@ spec:
       annotations:
         # Rolls the pods when the OPA bundle changes — subPath mounts do NOT hot-reload.
         # Kept in sync by gen-document-service-opa-bundle.sh (do not hand-edit).
-        openbank.tech/policy-checksum: "360984fd2deb4202"
+        openbank.tech/policy-checksum: "80f3ab7acfa9c205"
     spec:
       # ADR-0162 D4 (continued): a dedicated SA (not `default`) is what OpenBao's Kubernetes-auth
       # role `document-service-signing` is bound to — least-privilege, one identity per consumer.

--- a/openbank-infra/gitops/components/fraud-service/fraud-opa-bundle.yaml
+++ b/openbank-infra/gitops/components/fraud-service/fraud-opa-bundle.yaml
@@ -9,7 +9,7 @@ metadata:
     app.kubernetes.io/name: fraud-service
     app.kubernetes.io/part-of: fraud
   annotations:
-    openbank.tech/policy-checksum: "2d3ef48ec34f3243"
+    openbank.tech/policy-checksum: "de96e6cab0fb84b2"
 data:
   rest.rego: |
     # SPDX-License-Identifier: Apache-2.0
@@ -2776,6 +2776,50 @@ data:
             jdbc-postgresql (build.gradle.kts) — it has no OLTP datasource to reach. The
             reconciliation reads the warehouse and the WORM archive over blocking clients.
       ci_producer: ".github/scripts/check-no-runblocking-in-scheduled.py"
+
+
+    # ---------------------------------------------------------------------------------------
+    # Kafka topic existence (issue #2598). A service may only reference a topic that exists.
+    # ---------------------------------------------------------------------------------------
+    kafka_topics:
+      referenced_topics_must_be_declared: true
+      # A Kafka consumer subscribed to a topic that does not exist does NOT error. It joins its
+      # consumer group, reports healthy, and receives nothing — forever. There is no runtime
+      # signal that can distinguish it from a topic with no traffic: pod ready, group joined,
+      # lag zero, metrics flat. So this is only catchable statically, before the merge.
+      #
+      # Found live: openbank-analytics-sink subscribed to `openbank.account.events` and
+      # `openbank.transaction.events`. NEITHER has ever existed — the real topics are
+      # `openbank.accounts.account.created` and `openbank.transactions.transaction.initiated`,
+      # both declared, both produced, both already consumed by audit-service. The sink ran for
+      # weeks green while no ACCOUNT_OPENED and no TRANSACTION row ever reached bronze_events,
+      # which silently made ADR-0210 D2's account->party resolution dead code and left Customer
+      # 360 structurally unable to show a customer's accounts or transactions (PR #2629).
+      #
+      # Same failure shape as a client pointed at a REST path that does not exist — the one that
+      # shipped finrep's call to `/api/v1/ledger/trial-balance` (see the contract-test notes in
+      # CLAUDE.md). There the answer was to make the provider replay the contract at PR time;
+      # here it is to compare the name a service asks for against the set declared to exist.
+      #
+      # `openbank-infra/gitops` carries a KafkaTopic CR for every topic, so the declared set is
+      # authoritative and complete — that is what makes this checkable without a live broker.
+      #
+      # ENFORCED from the day it was written, not advisory. The fleet is at zero unresolved
+      # topics, so there is no judgement left to exercise; an advisory verdict over a checkable
+      # fact only makes the next violation mergeable.
+      scope: |
+        Every dotted topic name in a `topics:`/`topic:` key of any
+        openbank-*/src/main/resources/application.yaml must resolve to a KafkaTopic CR
+        (metadata.name or spec.topicName) under openbank-infra/gitops.
+      # EMPTY, and that is the point. An entry needs a reason, and the check fails on a stale
+      # declaration in BOTH directions — a name listed here that IS declared is itself reported —
+      # so a temporary exception cannot quietly become permanent. Same idiom as the pact gate's
+      # KNOWN_UNCOVERED and the runblocking_allowlist above.
+      allowed_absent: []
+      # The check ships with a --selftest that feeds it inputs it MUST flag and inputs it must
+      # NOT, run on every CI invocation: once the fleet is clean the flagging branch would
+      # otherwise never execute again, and a gate that has only ever passed is unfalsified.
+      ci_producer: ".github/scripts/check-kafka-topics-exist.py"
 
     # ---------------------------------------------------------------------------------------
     # Vulnerability-management lifecycle SLAs (ADR-0030 D1). Detection -> closure, in days.

--- a/openbank-infra/gitops/components/fraud-service/fraud-service.yaml
+++ b/openbank-infra/gitops/components/fraud-service/fraud-service.yaml
@@ -23,7 +23,7 @@ spec:
       annotations:
         # Rolls the pods when the OPA bundle changes — subPath mounts do NOT hot-reload.
         # Kept in sync by gen-fraud-opa-bundle.sh (do not hand-edit).
-        openbank.tech/policy-checksum: "2d3ef48ec34f3243"
+        openbank.tech/policy-checksum: "de96e6cab0fb84b2"
     spec:
       securityContext:
         runAsNonRoot: true

--- a/openbank-infra/gitops/components/fx-service/fx-opa-bundle.yaml
+++ b/openbank-infra/gitops/components/fx-service/fx-opa-bundle.yaml
@@ -9,7 +9,7 @@ metadata:
     app.kubernetes.io/name: fx-service
     app.kubernetes.io/part-of: fx
   annotations:
-    openbank.tech/policy-checksum: "4f5d63b17a4fdc75"
+    openbank.tech/policy-checksum: "0f41b01fe3c9a582"
 data:
   rest.rego: |
     # SPDX-License-Identifier: Apache-2.0
@@ -2827,6 +2827,50 @@ data:
             jdbc-postgresql (build.gradle.kts) — it has no OLTP datasource to reach. The
             reconciliation reads the warehouse and the WORM archive over blocking clients.
       ci_producer: ".github/scripts/check-no-runblocking-in-scheduled.py"
+
+
+    # ---------------------------------------------------------------------------------------
+    # Kafka topic existence (issue #2598). A service may only reference a topic that exists.
+    # ---------------------------------------------------------------------------------------
+    kafka_topics:
+      referenced_topics_must_be_declared: true
+      # A Kafka consumer subscribed to a topic that does not exist does NOT error. It joins its
+      # consumer group, reports healthy, and receives nothing — forever. There is no runtime
+      # signal that can distinguish it from a topic with no traffic: pod ready, group joined,
+      # lag zero, metrics flat. So this is only catchable statically, before the merge.
+      #
+      # Found live: openbank-analytics-sink subscribed to `openbank.account.events` and
+      # `openbank.transaction.events`. NEITHER has ever existed — the real topics are
+      # `openbank.accounts.account.created` and `openbank.transactions.transaction.initiated`,
+      # both declared, both produced, both already consumed by audit-service. The sink ran for
+      # weeks green while no ACCOUNT_OPENED and no TRANSACTION row ever reached bronze_events,
+      # which silently made ADR-0210 D2's account->party resolution dead code and left Customer
+      # 360 structurally unable to show a customer's accounts or transactions (PR #2629).
+      #
+      # Same failure shape as a client pointed at a REST path that does not exist — the one that
+      # shipped finrep's call to `/api/v1/ledger/trial-balance` (see the contract-test notes in
+      # CLAUDE.md). There the answer was to make the provider replay the contract at PR time;
+      # here it is to compare the name a service asks for against the set declared to exist.
+      #
+      # `openbank-infra/gitops` carries a KafkaTopic CR for every topic, so the declared set is
+      # authoritative and complete — that is what makes this checkable without a live broker.
+      #
+      # ENFORCED from the day it was written, not advisory. The fleet is at zero unresolved
+      # topics, so there is no judgement left to exercise; an advisory verdict over a checkable
+      # fact only makes the next violation mergeable.
+      scope: |
+        Every dotted topic name in a `topics:`/`topic:` key of any
+        openbank-*/src/main/resources/application.yaml must resolve to a KafkaTopic CR
+        (metadata.name or spec.topicName) under openbank-infra/gitops.
+      # EMPTY, and that is the point. An entry needs a reason, and the check fails on a stale
+      # declaration in BOTH directions — a name listed here that IS declared is itself reported —
+      # so a temporary exception cannot quietly become permanent. Same idiom as the pact gate's
+      # KNOWN_UNCOVERED and the runblocking_allowlist above.
+      allowed_absent: []
+      # The check ships with a --selftest that feeds it inputs it MUST flag and inputs it must
+      # NOT, run on every CI invocation: once the fleet is clean the flagging branch would
+      # otherwise never execute again, and a gate that has only ever passed is unfalsified.
+      ci_producer: ".github/scripts/check-kafka-topics-exist.py"
 
     # ---------------------------------------------------------------------------------------
     # Vulnerability-management lifecycle SLAs (ADR-0030 D1). Detection -> closure, in days.

--- a/openbank-infra/gitops/components/fx-service/fx-service.yaml
+++ b/openbank-infra/gitops/components/fx-service/fx-service.yaml
@@ -22,7 +22,7 @@ spec:
       annotations:
         # Rolls the pods when the OPA bundle changes — subPath mounts do NOT hot-reload.
         # Kept in sync by gen-fx-opa-bundle.sh (do not hand-edit).
-        openbank.tech/policy-checksum: "4f5d63b17a4fdc75"
+        openbank.tech/policy-checksum: "0f41b01fe3c9a582"
     spec:
       securityContext:
         runAsNonRoot: true

--- a/openbank-infra/gitops/components/interest-service/interest-opa-bundle.yaml
+++ b/openbank-infra/gitops/components/interest-service/interest-opa-bundle.yaml
@@ -9,7 +9,7 @@ metadata:
     app.kubernetes.io/name: interest-service
     app.kubernetes.io/part-of: interest
   annotations:
-    openbank.tech/policy-checksum: "e33c116e9972896b"
+    openbank.tech/policy-checksum: "ed145a1c6df72f5c"
 data:
   rest.rego: |
     # SPDX-License-Identifier: Apache-2.0
@@ -2761,6 +2761,50 @@ data:
             jdbc-postgresql (build.gradle.kts) — it has no OLTP datasource to reach. The
             reconciliation reads the warehouse and the WORM archive over blocking clients.
       ci_producer: ".github/scripts/check-no-runblocking-in-scheduled.py"
+
+
+    # ---------------------------------------------------------------------------------------
+    # Kafka topic existence (issue #2598). A service may only reference a topic that exists.
+    # ---------------------------------------------------------------------------------------
+    kafka_topics:
+      referenced_topics_must_be_declared: true
+      # A Kafka consumer subscribed to a topic that does not exist does NOT error. It joins its
+      # consumer group, reports healthy, and receives nothing — forever. There is no runtime
+      # signal that can distinguish it from a topic with no traffic: pod ready, group joined,
+      # lag zero, metrics flat. So this is only catchable statically, before the merge.
+      #
+      # Found live: openbank-analytics-sink subscribed to `openbank.account.events` and
+      # `openbank.transaction.events`. NEITHER has ever existed — the real topics are
+      # `openbank.accounts.account.created` and `openbank.transactions.transaction.initiated`,
+      # both declared, both produced, both already consumed by audit-service. The sink ran for
+      # weeks green while no ACCOUNT_OPENED and no TRANSACTION row ever reached bronze_events,
+      # which silently made ADR-0210 D2's account->party resolution dead code and left Customer
+      # 360 structurally unable to show a customer's accounts or transactions (PR #2629).
+      #
+      # Same failure shape as a client pointed at a REST path that does not exist — the one that
+      # shipped finrep's call to `/api/v1/ledger/trial-balance` (see the contract-test notes in
+      # CLAUDE.md). There the answer was to make the provider replay the contract at PR time;
+      # here it is to compare the name a service asks for against the set declared to exist.
+      #
+      # `openbank-infra/gitops` carries a KafkaTopic CR for every topic, so the declared set is
+      # authoritative and complete — that is what makes this checkable without a live broker.
+      #
+      # ENFORCED from the day it was written, not advisory. The fleet is at zero unresolved
+      # topics, so there is no judgement left to exercise; an advisory verdict over a checkable
+      # fact only makes the next violation mergeable.
+      scope: |
+        Every dotted topic name in a `topics:`/`topic:` key of any
+        openbank-*/src/main/resources/application.yaml must resolve to a KafkaTopic CR
+        (metadata.name or spec.topicName) under openbank-infra/gitops.
+      # EMPTY, and that is the point. An entry needs a reason, and the check fails on a stale
+      # declaration in BOTH directions — a name listed here that IS declared is itself reported —
+      # so a temporary exception cannot quietly become permanent. Same idiom as the pact gate's
+      # KNOWN_UNCOVERED and the runblocking_allowlist above.
+      allowed_absent: []
+      # The check ships with a --selftest that feeds it inputs it MUST flag and inputs it must
+      # NOT, run on every CI invocation: once the fleet is clean the flagging branch would
+      # otherwise never execute again, and a gate that has only ever passed is unfalsified.
+      ci_producer: ".github/scripts/check-kafka-topics-exist.py"
 
     # ---------------------------------------------------------------------------------------
     # Vulnerability-management lifecycle SLAs (ADR-0030 D1). Detection -> closure, in days.

--- a/openbank-infra/gitops/components/interest-service/interest-service.yaml
+++ b/openbank-infra/gitops/components/interest-service/interest-service.yaml
@@ -16,7 +16,7 @@ spec:
       annotations:
         # Rolls the pods when the OPA bundle changes — subPath mounts do NOT hot-reload.
         # Kept in sync by gen-interest-opa-bundle.sh (do not hand-edit).
-        openbank.tech/policy-checksum: "e33c116e9972896b"
+        openbank.tech/policy-checksum: "ed145a1c6df72f5c"
     spec:
       securityContext:
         runAsNonRoot: true

--- a/openbank-infra/gitops/components/kyc/kyc-opa-bundle.yaml
+++ b/openbank-infra/gitops/components/kyc/kyc-opa-bundle.yaml
@@ -9,7 +9,7 @@ metadata:
     app.kubernetes.io/name: kyc-service
     app.kubernetes.io/part-of: kyc
   annotations:
-    openbank.tech/policy-checksum: "af9a96d520098fc0"
+    openbank.tech/policy-checksum: "5e4d753703d4db03"
 data:
   rest.rego: |
     # SPDX-License-Identifier: Apache-2.0
@@ -2789,6 +2789,50 @@ data:
             jdbc-postgresql (build.gradle.kts) — it has no OLTP datasource to reach. The
             reconciliation reads the warehouse and the WORM archive over blocking clients.
       ci_producer: ".github/scripts/check-no-runblocking-in-scheduled.py"
+
+
+    # ---------------------------------------------------------------------------------------
+    # Kafka topic existence (issue #2598). A service may only reference a topic that exists.
+    # ---------------------------------------------------------------------------------------
+    kafka_topics:
+      referenced_topics_must_be_declared: true
+      # A Kafka consumer subscribed to a topic that does not exist does NOT error. It joins its
+      # consumer group, reports healthy, and receives nothing — forever. There is no runtime
+      # signal that can distinguish it from a topic with no traffic: pod ready, group joined,
+      # lag zero, metrics flat. So this is only catchable statically, before the merge.
+      #
+      # Found live: openbank-analytics-sink subscribed to `openbank.account.events` and
+      # `openbank.transaction.events`. NEITHER has ever existed — the real topics are
+      # `openbank.accounts.account.created` and `openbank.transactions.transaction.initiated`,
+      # both declared, both produced, both already consumed by audit-service. The sink ran for
+      # weeks green while no ACCOUNT_OPENED and no TRANSACTION row ever reached bronze_events,
+      # which silently made ADR-0210 D2's account->party resolution dead code and left Customer
+      # 360 structurally unable to show a customer's accounts or transactions (PR #2629).
+      #
+      # Same failure shape as a client pointed at a REST path that does not exist — the one that
+      # shipped finrep's call to `/api/v1/ledger/trial-balance` (see the contract-test notes in
+      # CLAUDE.md). There the answer was to make the provider replay the contract at PR time;
+      # here it is to compare the name a service asks for against the set declared to exist.
+      #
+      # `openbank-infra/gitops` carries a KafkaTopic CR for every topic, so the declared set is
+      # authoritative and complete — that is what makes this checkable without a live broker.
+      #
+      # ENFORCED from the day it was written, not advisory. The fleet is at zero unresolved
+      # topics, so there is no judgement left to exercise; an advisory verdict over a checkable
+      # fact only makes the next violation mergeable.
+      scope: |
+        Every dotted topic name in a `topics:`/`topic:` key of any
+        openbank-*/src/main/resources/application.yaml must resolve to a KafkaTopic CR
+        (metadata.name or spec.topicName) under openbank-infra/gitops.
+      # EMPTY, and that is the point. An entry needs a reason, and the check fails on a stale
+      # declaration in BOTH directions — a name listed here that IS declared is itself reported —
+      # so a temporary exception cannot quietly become permanent. Same idiom as the pact gate's
+      # KNOWN_UNCOVERED and the runblocking_allowlist above.
+      allowed_absent: []
+      # The check ships with a --selftest that feeds it inputs it MUST flag and inputs it must
+      # NOT, run on every CI invocation: once the fleet is clean the flagging branch would
+      # otherwise never execute again, and a gate that has only ever passed is unfalsified.
+      ci_producer: ".github/scripts/check-kafka-topics-exist.py"
 
     # ---------------------------------------------------------------------------------------
     # Vulnerability-management lifecycle SLAs (ADR-0030 D1). Detection -> closure, in days.

--- a/openbank-infra/gitops/components/kyc/kyc-service.yaml
+++ b/openbank-infra/gitops/components/kyc/kyc-service.yaml
@@ -48,7 +48,7 @@ spec:
       annotations:
         # Rolls the pod when the OPA bundle changes (subPath mounts do not hot-reload).
         # Kept in sync by gen-kyc-opa-bundle.sh (do not hand-edit).
-        openbank.tech/policy-checksum: "af9a96d520098fc0"
+        openbank.tech/policy-checksum: "5e4d753703d4db03"
     spec:
       securityContext:
         runAsNonRoot: true

--- a/openbank-infra/gitops/components/ledger/ledger-opa-bundle.yaml
+++ b/openbank-infra/gitops/components/ledger/ledger-opa-bundle.yaml
@@ -9,7 +9,7 @@ metadata:
     app.kubernetes.io/name: ledger-service
     app.kubernetes.io/part-of: ledger
   annotations:
-    openbank.tech/policy-checksum: "bcd5804f93348d80"
+    openbank.tech/policy-checksum: "4159e7507e3d631a"
 data:
   rest.rego: |
     # SPDX-License-Identifier: Apache-2.0
@@ -2874,6 +2874,50 @@ data:
             jdbc-postgresql (build.gradle.kts) — it has no OLTP datasource to reach. The
             reconciliation reads the warehouse and the WORM archive over blocking clients.
       ci_producer: ".github/scripts/check-no-runblocking-in-scheduled.py"
+
+
+    # ---------------------------------------------------------------------------------------
+    # Kafka topic existence (issue #2598). A service may only reference a topic that exists.
+    # ---------------------------------------------------------------------------------------
+    kafka_topics:
+      referenced_topics_must_be_declared: true
+      # A Kafka consumer subscribed to a topic that does not exist does NOT error. It joins its
+      # consumer group, reports healthy, and receives nothing — forever. There is no runtime
+      # signal that can distinguish it from a topic with no traffic: pod ready, group joined,
+      # lag zero, metrics flat. So this is only catchable statically, before the merge.
+      #
+      # Found live: openbank-analytics-sink subscribed to `openbank.account.events` and
+      # `openbank.transaction.events`. NEITHER has ever existed — the real topics are
+      # `openbank.accounts.account.created` and `openbank.transactions.transaction.initiated`,
+      # both declared, both produced, both already consumed by audit-service. The sink ran for
+      # weeks green while no ACCOUNT_OPENED and no TRANSACTION row ever reached bronze_events,
+      # which silently made ADR-0210 D2's account->party resolution dead code and left Customer
+      # 360 structurally unable to show a customer's accounts or transactions (PR #2629).
+      #
+      # Same failure shape as a client pointed at a REST path that does not exist — the one that
+      # shipped finrep's call to `/api/v1/ledger/trial-balance` (see the contract-test notes in
+      # CLAUDE.md). There the answer was to make the provider replay the contract at PR time;
+      # here it is to compare the name a service asks for against the set declared to exist.
+      #
+      # `openbank-infra/gitops` carries a KafkaTopic CR for every topic, so the declared set is
+      # authoritative and complete — that is what makes this checkable without a live broker.
+      #
+      # ENFORCED from the day it was written, not advisory. The fleet is at zero unresolved
+      # topics, so there is no judgement left to exercise; an advisory verdict over a checkable
+      # fact only makes the next violation mergeable.
+      scope: |
+        Every dotted topic name in a `topics:`/`topic:` key of any
+        openbank-*/src/main/resources/application.yaml must resolve to a KafkaTopic CR
+        (metadata.name or spec.topicName) under openbank-infra/gitops.
+      # EMPTY, and that is the point. An entry needs a reason, and the check fails on a stale
+      # declaration in BOTH directions — a name listed here that IS declared is itself reported —
+      # so a temporary exception cannot quietly become permanent. Same idiom as the pact gate's
+      # KNOWN_UNCOVERED and the runblocking_allowlist above.
+      allowed_absent: []
+      # The check ships with a --selftest that feeds it inputs it MUST flag and inputs it must
+      # NOT, run on every CI invocation: once the fleet is clean the flagging branch would
+      # otherwise never execute again, and a gate that has only ever passed is unfalsified.
+      ci_producer: ".github/scripts/check-kafka-topics-exist.py"
 
     # ---------------------------------------------------------------------------------------
     # Vulnerability-management lifecycle SLAs (ADR-0030 D1). Detection -> closure, in days.

--- a/openbank-infra/gitops/components/ledger/ledger-service.yaml
+++ b/openbank-infra/gitops/components/ledger/ledger-service.yaml
@@ -38,7 +38,7 @@ spec:
       annotations:
         # Rolls the pods when the OPA bundle changes — subPath mounts do NOT hot-reload.
         # Kept in sync by gen-ledger-opa-bundle.sh (do not hand-edit).
-        openbank.tech/policy-checksum: "bcd5804f93348d80"
+        openbank.tech/policy-checksum: "4159e7507e3d631a"
     spec:
       securityContext:
         runAsNonRoot: true

--- a/openbank-infra/gitops/components/lending/lending-opa-bundle.yaml
+++ b/openbank-infra/gitops/components/lending/lending-opa-bundle.yaml
@@ -9,7 +9,7 @@ metadata:
     app.kubernetes.io/name: lending-service
     app.kubernetes.io/part-of: lending
   annotations:
-    openbank.tech/policy-checksum: "5aaf735f9b2860e3"
+    openbank.tech/policy-checksum: "c73aa5ccefec4b76"
 data:
   rest.rego: |
     # SPDX-License-Identifier: Apache-2.0
@@ -2829,6 +2829,50 @@ data:
             jdbc-postgresql (build.gradle.kts) — it has no OLTP datasource to reach. The
             reconciliation reads the warehouse and the WORM archive over blocking clients.
       ci_producer: ".github/scripts/check-no-runblocking-in-scheduled.py"
+
+
+    # ---------------------------------------------------------------------------------------
+    # Kafka topic existence (issue #2598). A service may only reference a topic that exists.
+    # ---------------------------------------------------------------------------------------
+    kafka_topics:
+      referenced_topics_must_be_declared: true
+      # A Kafka consumer subscribed to a topic that does not exist does NOT error. It joins its
+      # consumer group, reports healthy, and receives nothing — forever. There is no runtime
+      # signal that can distinguish it from a topic with no traffic: pod ready, group joined,
+      # lag zero, metrics flat. So this is only catchable statically, before the merge.
+      #
+      # Found live: openbank-analytics-sink subscribed to `openbank.account.events` and
+      # `openbank.transaction.events`. NEITHER has ever existed — the real topics are
+      # `openbank.accounts.account.created` and `openbank.transactions.transaction.initiated`,
+      # both declared, both produced, both already consumed by audit-service. The sink ran for
+      # weeks green while no ACCOUNT_OPENED and no TRANSACTION row ever reached bronze_events,
+      # which silently made ADR-0210 D2's account->party resolution dead code and left Customer
+      # 360 structurally unable to show a customer's accounts or transactions (PR #2629).
+      #
+      # Same failure shape as a client pointed at a REST path that does not exist — the one that
+      # shipped finrep's call to `/api/v1/ledger/trial-balance` (see the contract-test notes in
+      # CLAUDE.md). There the answer was to make the provider replay the contract at PR time;
+      # here it is to compare the name a service asks for against the set declared to exist.
+      #
+      # `openbank-infra/gitops` carries a KafkaTopic CR for every topic, so the declared set is
+      # authoritative and complete — that is what makes this checkable without a live broker.
+      #
+      # ENFORCED from the day it was written, not advisory. The fleet is at zero unresolved
+      # topics, so there is no judgement left to exercise; an advisory verdict over a checkable
+      # fact only makes the next violation mergeable.
+      scope: |
+        Every dotted topic name in a `topics:`/`topic:` key of any
+        openbank-*/src/main/resources/application.yaml must resolve to a KafkaTopic CR
+        (metadata.name or spec.topicName) under openbank-infra/gitops.
+      # EMPTY, and that is the point. An entry needs a reason, and the check fails on a stale
+      # declaration in BOTH directions — a name listed here that IS declared is itself reported —
+      # so a temporary exception cannot quietly become permanent. Same idiom as the pact gate's
+      # KNOWN_UNCOVERED and the runblocking_allowlist above.
+      allowed_absent: []
+      # The check ships with a --selftest that feeds it inputs it MUST flag and inputs it must
+      # NOT, run on every CI invocation: once the fleet is clean the flagging branch would
+      # otherwise never execute again, and a gate that has only ever passed is unfalsified.
+      ci_producer: ".github/scripts/check-kafka-topics-exist.py"
 
     # ---------------------------------------------------------------------------------------
     # Vulnerability-management lifecycle SLAs (ADR-0030 D1). Detection -> closure, in days.

--- a/openbank-infra/gitops/components/lending/lending-service.yaml
+++ b/openbank-infra/gitops/components/lending/lending-service.yaml
@@ -34,7 +34,7 @@ spec:
       annotations:
         # Rolls the pods when the OPA bundle changes — subPath mounts do NOT hot-reload.
         # Kept in sync by gen-lending-opa-bundle.sh (do not hand-edit).
-        openbank.tech/policy-checksum: "5aaf735f9b2860e3"
+        openbank.tech/policy-checksum: "c73aa5ccefec4b76"
     spec:
       securityContext:
         runAsNonRoot: true

--- a/openbank-infra/gitops/components/mcp/mcp-opa-bundle.yaml
+++ b/openbank-infra/gitops/components/mcp/mcp-opa-bundle.yaml
@@ -9,7 +9,7 @@ metadata:
     app.kubernetes.io/name: mcp-service
     app.kubernetes.io/part-of: platform
   annotations:
-    openbank.tech/policy-checksum: "717010da54f7207e"
+    openbank.tech/policy-checksum: "465bc216e2560311"
 data:
   rest.rego: |
     # SPDX-License-Identifier: Apache-2.0
@@ -2727,6 +2727,50 @@ data:
             jdbc-postgresql (build.gradle.kts) — it has no OLTP datasource to reach. The
             reconciliation reads the warehouse and the WORM archive over blocking clients.
       ci_producer: ".github/scripts/check-no-runblocking-in-scheduled.py"
+
+
+    # ---------------------------------------------------------------------------------------
+    # Kafka topic existence (issue #2598). A service may only reference a topic that exists.
+    # ---------------------------------------------------------------------------------------
+    kafka_topics:
+      referenced_topics_must_be_declared: true
+      # A Kafka consumer subscribed to a topic that does not exist does NOT error. It joins its
+      # consumer group, reports healthy, and receives nothing — forever. There is no runtime
+      # signal that can distinguish it from a topic with no traffic: pod ready, group joined,
+      # lag zero, metrics flat. So this is only catchable statically, before the merge.
+      #
+      # Found live: openbank-analytics-sink subscribed to `openbank.account.events` and
+      # `openbank.transaction.events`. NEITHER has ever existed — the real topics are
+      # `openbank.accounts.account.created` and `openbank.transactions.transaction.initiated`,
+      # both declared, both produced, both already consumed by audit-service. The sink ran for
+      # weeks green while no ACCOUNT_OPENED and no TRANSACTION row ever reached bronze_events,
+      # which silently made ADR-0210 D2's account->party resolution dead code and left Customer
+      # 360 structurally unable to show a customer's accounts or transactions (PR #2629).
+      #
+      # Same failure shape as a client pointed at a REST path that does not exist — the one that
+      # shipped finrep's call to `/api/v1/ledger/trial-balance` (see the contract-test notes in
+      # CLAUDE.md). There the answer was to make the provider replay the contract at PR time;
+      # here it is to compare the name a service asks for against the set declared to exist.
+      #
+      # `openbank-infra/gitops` carries a KafkaTopic CR for every topic, so the declared set is
+      # authoritative and complete — that is what makes this checkable without a live broker.
+      #
+      # ENFORCED from the day it was written, not advisory. The fleet is at zero unresolved
+      # topics, so there is no judgement left to exercise; an advisory verdict over a checkable
+      # fact only makes the next violation mergeable.
+      scope: |
+        Every dotted topic name in a `topics:`/`topic:` key of any
+        openbank-*/src/main/resources/application.yaml must resolve to a KafkaTopic CR
+        (metadata.name or spec.topicName) under openbank-infra/gitops.
+      # EMPTY, and that is the point. An entry needs a reason, and the check fails on a stale
+      # declaration in BOTH directions — a name listed here that IS declared is itself reported —
+      # so a temporary exception cannot quietly become permanent. Same idiom as the pact gate's
+      # KNOWN_UNCOVERED and the runblocking_allowlist above.
+      allowed_absent: []
+      # The check ships with a --selftest that feeds it inputs it MUST flag and inputs it must
+      # NOT, run on every CI invocation: once the fleet is clean the flagging branch would
+      # otherwise never execute again, and a gate that has only ever passed is unfalsified.
+      ci_producer: ".github/scripts/check-kafka-topics-exist.py"
 
     # ---------------------------------------------------------------------------------------
     # Vulnerability-management lifecycle SLAs (ADR-0030 D1). Detection -> closure, in days.

--- a/openbank-infra/gitops/components/mcp/mcp-service.yaml
+++ b/openbank-infra/gitops/components/mcp/mcp-service.yaml
@@ -29,7 +29,7 @@ spec:
       annotations:
         # Rolls the pod when the OPA bundle changes — subPath mounts do NOT hot-reload.
         # Kept in sync by gen-mcp-opa-bundle.sh (do not hand-edit).
-        openbank.tech/policy-checksum: "717010da54f7207e"
+        openbank.tech/policy-checksum: "465bc216e2560311"
     spec:
       securityContext:
         runAsNonRoot: true

--- a/openbank-infra/gitops/components/notifications/notification-service-opa-bundle.yaml
+++ b/openbank-infra/gitops/components/notifications/notification-service-opa-bundle.yaml
@@ -10,7 +10,7 @@ metadata:
     app.kubernetes.io/name: notification-service
     app.kubernetes.io/part-of: notifications
   annotations:
-    openbank.tech/policy-checksum: "360984fd2deb4202"
+    openbank.tech/policy-checksum: "80f3ab7acfa9c205"
 data:
   rest.rego: |
     # SPDX-License-Identifier: Apache-2.0
@@ -1950,6 +1950,50 @@ data:
             jdbc-postgresql (build.gradle.kts) — it has no OLTP datasource to reach. The
             reconciliation reads the warehouse and the WORM archive over blocking clients.
       ci_producer: ".github/scripts/check-no-runblocking-in-scheduled.py"
+
+
+    # ---------------------------------------------------------------------------------------
+    # Kafka topic existence (issue #2598). A service may only reference a topic that exists.
+    # ---------------------------------------------------------------------------------------
+    kafka_topics:
+      referenced_topics_must_be_declared: true
+      # A Kafka consumer subscribed to a topic that does not exist does NOT error. It joins its
+      # consumer group, reports healthy, and receives nothing — forever. There is no runtime
+      # signal that can distinguish it from a topic with no traffic: pod ready, group joined,
+      # lag zero, metrics flat. So this is only catchable statically, before the merge.
+      #
+      # Found live: openbank-analytics-sink subscribed to `openbank.account.events` and
+      # `openbank.transaction.events`. NEITHER has ever existed — the real topics are
+      # `openbank.accounts.account.created` and `openbank.transactions.transaction.initiated`,
+      # both declared, both produced, both already consumed by audit-service. The sink ran for
+      # weeks green while no ACCOUNT_OPENED and no TRANSACTION row ever reached bronze_events,
+      # which silently made ADR-0210 D2's account->party resolution dead code and left Customer
+      # 360 structurally unable to show a customer's accounts or transactions (PR #2629).
+      #
+      # Same failure shape as a client pointed at a REST path that does not exist — the one that
+      # shipped finrep's call to `/api/v1/ledger/trial-balance` (see the contract-test notes in
+      # CLAUDE.md). There the answer was to make the provider replay the contract at PR time;
+      # here it is to compare the name a service asks for against the set declared to exist.
+      #
+      # `openbank-infra/gitops` carries a KafkaTopic CR for every topic, so the declared set is
+      # authoritative and complete — that is what makes this checkable without a live broker.
+      #
+      # ENFORCED from the day it was written, not advisory. The fleet is at zero unresolved
+      # topics, so there is no judgement left to exercise; an advisory verdict over a checkable
+      # fact only makes the next violation mergeable.
+      scope: |
+        Every dotted topic name in a `topics:`/`topic:` key of any
+        openbank-*/src/main/resources/application.yaml must resolve to a KafkaTopic CR
+        (metadata.name or spec.topicName) under openbank-infra/gitops.
+      # EMPTY, and that is the point. An entry needs a reason, and the check fails on a stale
+      # declaration in BOTH directions — a name listed here that IS declared is itself reported —
+      # so a temporary exception cannot quietly become permanent. Same idiom as the pact gate's
+      # KNOWN_UNCOVERED and the runblocking_allowlist above.
+      allowed_absent: []
+      # The check ships with a --selftest that feeds it inputs it MUST flag and inputs it must
+      # NOT, run on every CI invocation: once the fleet is clean the flagging branch would
+      # otherwise never execute again, and a gate that has only ever passed is unfalsified.
+      ci_producer: ".github/scripts/check-kafka-topics-exist.py"
 
     # ---------------------------------------------------------------------------------------
     # Vulnerability-management lifecycle SLAs (ADR-0030 D1). Detection -> closure, in days.

--- a/openbank-infra/gitops/components/notifications/notification-service.yaml
+++ b/openbank-infra/gitops/components/notifications/notification-service.yaml
@@ -39,7 +39,7 @@ spec:
       annotations:
         # Rolls the Deployment when the OPA policy bundle changes (subPath mounts don't
         # hot-reload). Kept in sync by gen-notification-opa-bundle.sh.
-        openbank.tech/policy-checksum: "360984fd2deb4202"
+        openbank.tech/policy-checksum: "80f3ab7acfa9c205"
       labels:
         app.kubernetes.io/name: notification-service
         app.kubernetes.io/part-of: notifications

--- a/openbank-infra/gitops/components/party/party-opa-bundle.yaml
+++ b/openbank-infra/gitops/components/party/party-opa-bundle.yaml
@@ -9,7 +9,7 @@ metadata:
     app.kubernetes.io/name: party-service
     app.kubernetes.io/part-of: party
   annotations:
-    openbank.tech/policy-checksum: "702a8df4419a7a81"
+    openbank.tech/policy-checksum: "cb73b8ffb9f21eef"
 data:
   rest.rego: |
     # SPDX-License-Identifier: Apache-2.0
@@ -2798,6 +2798,50 @@ data:
             jdbc-postgresql (build.gradle.kts) — it has no OLTP datasource to reach. The
             reconciliation reads the warehouse and the WORM archive over blocking clients.
       ci_producer: ".github/scripts/check-no-runblocking-in-scheduled.py"
+
+
+    # ---------------------------------------------------------------------------------------
+    # Kafka topic existence (issue #2598). A service may only reference a topic that exists.
+    # ---------------------------------------------------------------------------------------
+    kafka_topics:
+      referenced_topics_must_be_declared: true
+      # A Kafka consumer subscribed to a topic that does not exist does NOT error. It joins its
+      # consumer group, reports healthy, and receives nothing — forever. There is no runtime
+      # signal that can distinguish it from a topic with no traffic: pod ready, group joined,
+      # lag zero, metrics flat. So this is only catchable statically, before the merge.
+      #
+      # Found live: openbank-analytics-sink subscribed to `openbank.account.events` and
+      # `openbank.transaction.events`. NEITHER has ever existed — the real topics are
+      # `openbank.accounts.account.created` and `openbank.transactions.transaction.initiated`,
+      # both declared, both produced, both already consumed by audit-service. The sink ran for
+      # weeks green while no ACCOUNT_OPENED and no TRANSACTION row ever reached bronze_events,
+      # which silently made ADR-0210 D2's account->party resolution dead code and left Customer
+      # 360 structurally unable to show a customer's accounts or transactions (PR #2629).
+      #
+      # Same failure shape as a client pointed at a REST path that does not exist — the one that
+      # shipped finrep's call to `/api/v1/ledger/trial-balance` (see the contract-test notes in
+      # CLAUDE.md). There the answer was to make the provider replay the contract at PR time;
+      # here it is to compare the name a service asks for against the set declared to exist.
+      #
+      # `openbank-infra/gitops` carries a KafkaTopic CR for every topic, so the declared set is
+      # authoritative and complete — that is what makes this checkable without a live broker.
+      #
+      # ENFORCED from the day it was written, not advisory. The fleet is at zero unresolved
+      # topics, so there is no judgement left to exercise; an advisory verdict over a checkable
+      # fact only makes the next violation mergeable.
+      scope: |
+        Every dotted topic name in a `topics:`/`topic:` key of any
+        openbank-*/src/main/resources/application.yaml must resolve to a KafkaTopic CR
+        (metadata.name or spec.topicName) under openbank-infra/gitops.
+      # EMPTY, and that is the point. An entry needs a reason, and the check fails on a stale
+      # declaration in BOTH directions — a name listed here that IS declared is itself reported —
+      # so a temporary exception cannot quietly become permanent. Same idiom as the pact gate's
+      # KNOWN_UNCOVERED and the runblocking_allowlist above.
+      allowed_absent: []
+      # The check ships with a --selftest that feeds it inputs it MUST flag and inputs it must
+      # NOT, run on every CI invocation: once the fleet is clean the flagging branch would
+      # otherwise never execute again, and a gate that has only ever passed is unfalsified.
+      ci_producer: ".github/scripts/check-kafka-topics-exist.py"
 
     # ---------------------------------------------------------------------------------------
     # Vulnerability-management lifecycle SLAs (ADR-0030 D1). Detection -> closure, in days.

--- a/openbank-infra/gitops/components/party/party-service.yaml
+++ b/openbank-infra/gitops/components/party/party-service.yaml
@@ -22,7 +22,7 @@ spec:
       annotations:
         # Rolls the pod when the OPA bundle changes — subPath mounts do NOT hot-reload.
         # Kept in sync by gen-party-opa-bundle.sh (do not hand-edit).
-        openbank.tech/policy-checksum: "702a8df4419a7a81"
+        openbank.tech/policy-checksum: "cb73b8ffb9f21eef"
       labels:
         app.kubernetes.io/name: party-service
         app.kubernetes.io/part-of: party

--- a/openbank-infra/gitops/components/payments/card-issuance-opa-bundle.yaml
+++ b/openbank-infra/gitops/components/payments/card-issuance-opa-bundle.yaml
@@ -9,7 +9,7 @@ metadata:
     app.kubernetes.io/name: card-issuance-service
     app.kubernetes.io/part-of: payments
   annotations:
-    openbank.tech/policy-checksum: "8e7b3878e62b5990"
+    openbank.tech/policy-checksum: "5d4cf4e1be41a83f"
 data:
   rest.rego: |
     # SPDX-License-Identifier: Apache-2.0
@@ -2782,6 +2782,50 @@ data:
             jdbc-postgresql (build.gradle.kts) — it has no OLTP datasource to reach. The
             reconciliation reads the warehouse and the WORM archive over blocking clients.
       ci_producer: ".github/scripts/check-no-runblocking-in-scheduled.py"
+
+
+    # ---------------------------------------------------------------------------------------
+    # Kafka topic existence (issue #2598). A service may only reference a topic that exists.
+    # ---------------------------------------------------------------------------------------
+    kafka_topics:
+      referenced_topics_must_be_declared: true
+      # A Kafka consumer subscribed to a topic that does not exist does NOT error. It joins its
+      # consumer group, reports healthy, and receives nothing — forever. There is no runtime
+      # signal that can distinguish it from a topic with no traffic: pod ready, group joined,
+      # lag zero, metrics flat. So this is only catchable statically, before the merge.
+      #
+      # Found live: openbank-analytics-sink subscribed to `openbank.account.events` and
+      # `openbank.transaction.events`. NEITHER has ever existed — the real topics are
+      # `openbank.accounts.account.created` and `openbank.transactions.transaction.initiated`,
+      # both declared, both produced, both already consumed by audit-service. The sink ran for
+      # weeks green while no ACCOUNT_OPENED and no TRANSACTION row ever reached bronze_events,
+      # which silently made ADR-0210 D2's account->party resolution dead code and left Customer
+      # 360 structurally unable to show a customer's accounts or transactions (PR #2629).
+      #
+      # Same failure shape as a client pointed at a REST path that does not exist — the one that
+      # shipped finrep's call to `/api/v1/ledger/trial-balance` (see the contract-test notes in
+      # CLAUDE.md). There the answer was to make the provider replay the contract at PR time;
+      # here it is to compare the name a service asks for against the set declared to exist.
+      #
+      # `openbank-infra/gitops` carries a KafkaTopic CR for every topic, so the declared set is
+      # authoritative and complete — that is what makes this checkable without a live broker.
+      #
+      # ENFORCED from the day it was written, not advisory. The fleet is at zero unresolved
+      # topics, so there is no judgement left to exercise; an advisory verdict over a checkable
+      # fact only makes the next violation mergeable.
+      scope: |
+        Every dotted topic name in a `topics:`/`topic:` key of any
+        openbank-*/src/main/resources/application.yaml must resolve to a KafkaTopic CR
+        (metadata.name or spec.topicName) under openbank-infra/gitops.
+      # EMPTY, and that is the point. An entry needs a reason, and the check fails on a stale
+      # declaration in BOTH directions — a name listed here that IS declared is itself reported —
+      # so a temporary exception cannot quietly become permanent. Same idiom as the pact gate's
+      # KNOWN_UNCOVERED and the runblocking_allowlist above.
+      allowed_absent: []
+      # The check ships with a --selftest that feeds it inputs it MUST flag and inputs it must
+      # NOT, run on every CI invocation: once the fleet is clean the flagging branch would
+      # otherwise never execute again, and a gate that has only ever passed is unfalsified.
+      ci_producer: ".github/scripts/check-kafka-topics-exist.py"
 
     # ---------------------------------------------------------------------------------------
     # Vulnerability-management lifecycle SLAs (ADR-0030 D1). Detection -> closure, in days.

--- a/openbank-infra/gitops/components/payments/clearing-opa-bundle.yaml
+++ b/openbank-infra/gitops/components/payments/clearing-opa-bundle.yaml
@@ -9,7 +9,7 @@ metadata:
     app.kubernetes.io/name: clearing-service
     app.kubernetes.io/part-of: payments
   annotations:
-    openbank.tech/policy-checksum: "29faba7aa6a7e58c"
+    openbank.tech/policy-checksum: "001ed2e9151db3a2"
 data:
   rest.rego: |
     # SPDX-License-Identifier: Apache-2.0
@@ -2819,6 +2819,50 @@ data:
             jdbc-postgresql (build.gradle.kts) — it has no OLTP datasource to reach. The
             reconciliation reads the warehouse and the WORM archive over blocking clients.
       ci_producer: ".github/scripts/check-no-runblocking-in-scheduled.py"
+
+
+    # ---------------------------------------------------------------------------------------
+    # Kafka topic existence (issue #2598). A service may only reference a topic that exists.
+    # ---------------------------------------------------------------------------------------
+    kafka_topics:
+      referenced_topics_must_be_declared: true
+      # A Kafka consumer subscribed to a topic that does not exist does NOT error. It joins its
+      # consumer group, reports healthy, and receives nothing — forever. There is no runtime
+      # signal that can distinguish it from a topic with no traffic: pod ready, group joined,
+      # lag zero, metrics flat. So this is only catchable statically, before the merge.
+      #
+      # Found live: openbank-analytics-sink subscribed to `openbank.account.events` and
+      # `openbank.transaction.events`. NEITHER has ever existed — the real topics are
+      # `openbank.accounts.account.created` and `openbank.transactions.transaction.initiated`,
+      # both declared, both produced, both already consumed by audit-service. The sink ran for
+      # weeks green while no ACCOUNT_OPENED and no TRANSACTION row ever reached bronze_events,
+      # which silently made ADR-0210 D2's account->party resolution dead code and left Customer
+      # 360 structurally unable to show a customer's accounts or transactions (PR #2629).
+      #
+      # Same failure shape as a client pointed at a REST path that does not exist — the one that
+      # shipped finrep's call to `/api/v1/ledger/trial-balance` (see the contract-test notes in
+      # CLAUDE.md). There the answer was to make the provider replay the contract at PR time;
+      # here it is to compare the name a service asks for against the set declared to exist.
+      #
+      # `openbank-infra/gitops` carries a KafkaTopic CR for every topic, so the declared set is
+      # authoritative and complete — that is what makes this checkable without a live broker.
+      #
+      # ENFORCED from the day it was written, not advisory. The fleet is at zero unresolved
+      # topics, so there is no judgement left to exercise; an advisory verdict over a checkable
+      # fact only makes the next violation mergeable.
+      scope: |
+        Every dotted topic name in a `topics:`/`topic:` key of any
+        openbank-*/src/main/resources/application.yaml must resolve to a KafkaTopic CR
+        (metadata.name or spec.topicName) under openbank-infra/gitops.
+      # EMPTY, and that is the point. An entry needs a reason, and the check fails on a stale
+      # declaration in BOTH directions — a name listed here that IS declared is itself reported —
+      # so a temporary exception cannot quietly become permanent. Same idiom as the pact gate's
+      # KNOWN_UNCOVERED and the runblocking_allowlist above.
+      allowed_absent: []
+      # The check ships with a --selftest that feeds it inputs it MUST flag and inputs it must
+      # NOT, run on every CI invocation: once the fleet is clean the flagging branch would
+      # otherwise never execute again, and a gate that has only ever passed is unfalsified.
+      ci_producer: ".github/scripts/check-kafka-topics-exist.py"
 
     # ---------------------------------------------------------------------------------------
     # Vulnerability-management lifecycle SLAs (ADR-0030 D1). Detection -> closure, in days.

--- a/openbank-infra/gitops/components/payments/domestic-payment-opa-bundle.yaml
+++ b/openbank-infra/gitops/components/payments/domestic-payment-opa-bundle.yaml
@@ -9,7 +9,7 @@ metadata:
     app.kubernetes.io/name: domestic-payment
     app.kubernetes.io/part-of: payments
   annotations:
-    openbank.tech/policy-checksum: "1d101d212143bac3"
+    openbank.tech/policy-checksum: "4f1f46e1b2acdbb9"
 data:
   rest.rego: |
     # SPDX-License-Identifier: Apache-2.0
@@ -2804,6 +2804,50 @@ data:
             jdbc-postgresql (build.gradle.kts) — it has no OLTP datasource to reach. The
             reconciliation reads the warehouse and the WORM archive over blocking clients.
       ci_producer: ".github/scripts/check-no-runblocking-in-scheduled.py"
+
+
+    # ---------------------------------------------------------------------------------------
+    # Kafka topic existence (issue #2598). A service may only reference a topic that exists.
+    # ---------------------------------------------------------------------------------------
+    kafka_topics:
+      referenced_topics_must_be_declared: true
+      # A Kafka consumer subscribed to a topic that does not exist does NOT error. It joins its
+      # consumer group, reports healthy, and receives nothing — forever. There is no runtime
+      # signal that can distinguish it from a topic with no traffic: pod ready, group joined,
+      # lag zero, metrics flat. So this is only catchable statically, before the merge.
+      #
+      # Found live: openbank-analytics-sink subscribed to `openbank.account.events` and
+      # `openbank.transaction.events`. NEITHER has ever existed — the real topics are
+      # `openbank.accounts.account.created` and `openbank.transactions.transaction.initiated`,
+      # both declared, both produced, both already consumed by audit-service. The sink ran for
+      # weeks green while no ACCOUNT_OPENED and no TRANSACTION row ever reached bronze_events,
+      # which silently made ADR-0210 D2's account->party resolution dead code and left Customer
+      # 360 structurally unable to show a customer's accounts or transactions (PR #2629).
+      #
+      # Same failure shape as a client pointed at a REST path that does not exist — the one that
+      # shipped finrep's call to `/api/v1/ledger/trial-balance` (see the contract-test notes in
+      # CLAUDE.md). There the answer was to make the provider replay the contract at PR time;
+      # here it is to compare the name a service asks for against the set declared to exist.
+      #
+      # `openbank-infra/gitops` carries a KafkaTopic CR for every topic, so the declared set is
+      # authoritative and complete — that is what makes this checkable without a live broker.
+      #
+      # ENFORCED from the day it was written, not advisory. The fleet is at zero unresolved
+      # topics, so there is no judgement left to exercise; an advisory verdict over a checkable
+      # fact only makes the next violation mergeable.
+      scope: |
+        Every dotted topic name in a `topics:`/`topic:` key of any
+        openbank-*/src/main/resources/application.yaml must resolve to a KafkaTopic CR
+        (metadata.name or spec.topicName) under openbank-infra/gitops.
+      # EMPTY, and that is the point. An entry needs a reason, and the check fails on a stale
+      # declaration in BOTH directions — a name listed here that IS declared is itself reported —
+      # so a temporary exception cannot quietly become permanent. Same idiom as the pact gate's
+      # KNOWN_UNCOVERED and the runblocking_allowlist above.
+      allowed_absent: []
+      # The check ships with a --selftest that feeds it inputs it MUST flag and inputs it must
+      # NOT, run on every CI invocation: once the fleet is clean the flagging branch would
+      # otherwise never execute again, and a gate that has only ever passed is unfalsified.
+      ci_producer: ".github/scripts/check-kafka-topics-exist.py"
 
     # ---------------------------------------------------------------------------------------
     # Vulnerability-management lifecycle SLAs (ADR-0030 D1). Detection -> closure, in days.

--- a/openbank-infra/gitops/components/payments/payments-services.yaml
+++ b/openbank-infra/gitops/components/payments/payments-services.yaml
@@ -42,7 +42,7 @@ spec:
         # Rolls the pods when the OPA bundle changes — subPath mounts do NOT hot-reload.
         # Kept in sync by gen-transaction-opa-bundle.sh via the trailing marker comment
         # (do not hand-edit, do not drop the marker).
-        openbank.tech/policy-checksum: "a7589150ebe0f9d4" # transaction-opa-bundle
+        openbank.tech/policy-checksum: "6da51558471f2875" # transaction-opa-bundle
     spec:
       securityContext:
         runAsNonRoot: true
@@ -375,7 +375,7 @@ spec:
       annotations:
         # Rolls the pods when the OPA bundle changes — subPath mounts do NOT hot-reload.
         # Kept in sync by gen-sepa-payment-opa-bundle.sh (do not hand-edit).
-        openbank.tech/policy-checksum: "1929007d4217369e"
+        openbank.tech/policy-checksum: "08f0b03a11b3819e"
     spec:
       securityContext:
         runAsNonRoot: true
@@ -729,7 +729,7 @@ spec:
         # Rolls the pods when the OPA bundle changes — subPath mounts do NOT hot-reload.
         # Kept in sync by gen-domestic-payment-opa-bundle.sh via the trailing marker
         # comment (do not hand-edit, do not drop the marker).
-        openbank.tech/policy-checksum: "1d101d212143bac3" # domestic-payment-opa-bundle
+        openbank.tech/policy-checksum: "4f1f46e1b2acdbb9" # domestic-payment-opa-bundle
     spec:
       securityContext:
         runAsNonRoot: true
@@ -1053,7 +1053,7 @@ spec:
       annotations:
         # Rolls the pods when the OPA bundle changes — subPath mounts do NOT hot-reload.
         # Kept in sync by gen-sepa-instant-opa-bundle.sh (do not hand-edit).
-        openbank.tech/policy-checksum: "9e5099a6fb1a2b8c"
+        openbank.tech/policy-checksum: "29630e58c8599c6c"
     spec:
       securityContext:
         runAsNonRoot: true
@@ -1369,7 +1369,7 @@ spec:
         # Rolls the pods when the OPA bundle changes — subPath mounts do NOT hot-reload.
         # Kept in sync by gen-clearing-opa-bundle.sh via the trailing marker comment
         # (do not hand-edit, do not drop the marker).
-        openbank.tech/policy-checksum: "29faba7aa6a7e58c" # clearing-opa-bundle
+        openbank.tech/policy-checksum: "001ed2e9151db3a2" # clearing-opa-bundle
     spec:
       securityContext:
         runAsNonRoot: true
@@ -1658,7 +1658,7 @@ spec:
       annotations:
         # Rolls the pod when the OPA bundle changes (ADR-0034). Value is stamped by
         # gen-standing-order-opa-bundle.sh — do not hand-edit.
-        openbank.tech/policy-checksum: "badbef0faa85d410" # standing-order-opa-bundle
+        openbank.tech/policy-checksum: "2846b93818d0ab48" # standing-order-opa-bundle
     spec:
       securityContext:
         runAsNonRoot: true
@@ -1911,7 +1911,7 @@ spec:
       annotations:
         # Rolls the pods when the OPA bundle changes — subPath mounts do NOT hot-reload.
         # Kept in sync by gen-card-issuance-opa-bundle.sh (do not hand-edit).
-        openbank.tech/policy-checksum: "8e7b3878e62b5990"
+        openbank.tech/policy-checksum: "5d4cf4e1be41a83f"
     spec:
       securityContext:
         runAsNonRoot: true
@@ -2178,7 +2178,7 @@ spec:
         # Rolls the pods when the OPA bundle changes — subPath mounts do NOT hot-reload.
         # Kept in sync by gen-settlement-opa-bundle.sh via the trailing marker comment
         # (do not hand-edit, do not drop the marker).
-        openbank.tech/policy-checksum: "e18615f75105411d" # settlement-opa-bundle
+        openbank.tech/policy-checksum: "af9e2939f7b4aa44" # settlement-opa-bundle
     spec:
       securityContext:
         runAsNonRoot: true
@@ -2579,7 +2579,7 @@ spec:
       annotations:
         # Rolls the pods when the OPA bundle changes — subPath mounts do NOT hot-reload.
         # Kept in sync by gen-swift-opa-bundle.sh (do not hand-edit).
-        openbank.tech/policy-checksum: "f8577d280559d741"
+        openbank.tech/policy-checksum: "ddffbd66c30db2b3"
     spec:
       securityContext:
         runAsNonRoot: true
@@ -2893,7 +2893,7 @@ spec:
       annotations:
         # Rolls the pods when the OPA bundle changes — subPath mounts do NOT hot-reload.
         # Kept in sync by gen-vop-opa-bundle.sh (do not hand-edit).
-        openbank.tech/policy-checksum: "a1b5a0eb7abf3dde"
+        openbank.tech/policy-checksum: "1a1fed1af16793bb"
     spec:
       securityContext:
         runAsNonRoot: true

--- a/openbank-infra/gitops/components/payments/sepa-instant-opa-bundle.yaml
+++ b/openbank-infra/gitops/components/payments/sepa-instant-opa-bundle.yaml
@@ -9,7 +9,7 @@ metadata:
     app.kubernetes.io/name: sepa-instant
     app.kubernetes.io/part-of: payments
   annotations:
-    openbank.tech/policy-checksum: "9e5099a6fb1a2b8c"
+    openbank.tech/policy-checksum: "29630e58c8599c6c"
 data:
   rest.rego: |
     # SPDX-License-Identifier: Apache-2.0
@@ -2777,6 +2777,50 @@ data:
             jdbc-postgresql (build.gradle.kts) — it has no OLTP datasource to reach. The
             reconciliation reads the warehouse and the WORM archive over blocking clients.
       ci_producer: ".github/scripts/check-no-runblocking-in-scheduled.py"
+
+
+    # ---------------------------------------------------------------------------------------
+    # Kafka topic existence (issue #2598). A service may only reference a topic that exists.
+    # ---------------------------------------------------------------------------------------
+    kafka_topics:
+      referenced_topics_must_be_declared: true
+      # A Kafka consumer subscribed to a topic that does not exist does NOT error. It joins its
+      # consumer group, reports healthy, and receives nothing — forever. There is no runtime
+      # signal that can distinguish it from a topic with no traffic: pod ready, group joined,
+      # lag zero, metrics flat. So this is only catchable statically, before the merge.
+      #
+      # Found live: openbank-analytics-sink subscribed to `openbank.account.events` and
+      # `openbank.transaction.events`. NEITHER has ever existed — the real topics are
+      # `openbank.accounts.account.created` and `openbank.transactions.transaction.initiated`,
+      # both declared, both produced, both already consumed by audit-service. The sink ran for
+      # weeks green while no ACCOUNT_OPENED and no TRANSACTION row ever reached bronze_events,
+      # which silently made ADR-0210 D2's account->party resolution dead code and left Customer
+      # 360 structurally unable to show a customer's accounts or transactions (PR #2629).
+      #
+      # Same failure shape as a client pointed at a REST path that does not exist — the one that
+      # shipped finrep's call to `/api/v1/ledger/trial-balance` (see the contract-test notes in
+      # CLAUDE.md). There the answer was to make the provider replay the contract at PR time;
+      # here it is to compare the name a service asks for against the set declared to exist.
+      #
+      # `openbank-infra/gitops` carries a KafkaTopic CR for every topic, so the declared set is
+      # authoritative and complete — that is what makes this checkable without a live broker.
+      #
+      # ENFORCED from the day it was written, not advisory. The fleet is at zero unresolved
+      # topics, so there is no judgement left to exercise; an advisory verdict over a checkable
+      # fact only makes the next violation mergeable.
+      scope: |
+        Every dotted topic name in a `topics:`/`topic:` key of any
+        openbank-*/src/main/resources/application.yaml must resolve to a KafkaTopic CR
+        (metadata.name or spec.topicName) under openbank-infra/gitops.
+      # EMPTY, and that is the point. An entry needs a reason, and the check fails on a stale
+      # declaration in BOTH directions — a name listed here that IS declared is itself reported —
+      # so a temporary exception cannot quietly become permanent. Same idiom as the pact gate's
+      # KNOWN_UNCOVERED and the runblocking_allowlist above.
+      allowed_absent: []
+      # The check ships with a --selftest that feeds it inputs it MUST flag and inputs it must
+      # NOT, run on every CI invocation: once the fleet is clean the flagging branch would
+      # otherwise never execute again, and a gate that has only ever passed is unfalsified.
+      ci_producer: ".github/scripts/check-kafka-topics-exist.py"
 
     # ---------------------------------------------------------------------------------------
     # Vulnerability-management lifecycle SLAs (ADR-0030 D1). Detection -> closure, in days.

--- a/openbank-infra/gitops/components/payments/sepa-payment-opa-bundle.yaml
+++ b/openbank-infra/gitops/components/payments/sepa-payment-opa-bundle.yaml
@@ -9,7 +9,7 @@ metadata:
     app.kubernetes.io/name: sepa-payment
     app.kubernetes.io/part-of: payments
   annotations:
-    openbank.tech/policy-checksum: "1929007d4217369e"
+    openbank.tech/policy-checksum: "08f0b03a11b3819e"
 data:
   rest.rego: |
     # SPDX-License-Identifier: Apache-2.0
@@ -2798,6 +2798,50 @@ data:
             jdbc-postgresql (build.gradle.kts) — it has no OLTP datasource to reach. The
             reconciliation reads the warehouse and the WORM archive over blocking clients.
       ci_producer: ".github/scripts/check-no-runblocking-in-scheduled.py"
+
+
+    # ---------------------------------------------------------------------------------------
+    # Kafka topic existence (issue #2598). A service may only reference a topic that exists.
+    # ---------------------------------------------------------------------------------------
+    kafka_topics:
+      referenced_topics_must_be_declared: true
+      # A Kafka consumer subscribed to a topic that does not exist does NOT error. It joins its
+      # consumer group, reports healthy, and receives nothing — forever. There is no runtime
+      # signal that can distinguish it from a topic with no traffic: pod ready, group joined,
+      # lag zero, metrics flat. So this is only catchable statically, before the merge.
+      #
+      # Found live: openbank-analytics-sink subscribed to `openbank.account.events` and
+      # `openbank.transaction.events`. NEITHER has ever existed — the real topics are
+      # `openbank.accounts.account.created` and `openbank.transactions.transaction.initiated`,
+      # both declared, both produced, both already consumed by audit-service. The sink ran for
+      # weeks green while no ACCOUNT_OPENED and no TRANSACTION row ever reached bronze_events,
+      # which silently made ADR-0210 D2's account->party resolution dead code and left Customer
+      # 360 structurally unable to show a customer's accounts or transactions (PR #2629).
+      #
+      # Same failure shape as a client pointed at a REST path that does not exist — the one that
+      # shipped finrep's call to `/api/v1/ledger/trial-balance` (see the contract-test notes in
+      # CLAUDE.md). There the answer was to make the provider replay the contract at PR time;
+      # here it is to compare the name a service asks for against the set declared to exist.
+      #
+      # `openbank-infra/gitops` carries a KafkaTopic CR for every topic, so the declared set is
+      # authoritative and complete — that is what makes this checkable without a live broker.
+      #
+      # ENFORCED from the day it was written, not advisory. The fleet is at zero unresolved
+      # topics, so there is no judgement left to exercise; an advisory verdict over a checkable
+      # fact only makes the next violation mergeable.
+      scope: |
+        Every dotted topic name in a `topics:`/`topic:` key of any
+        openbank-*/src/main/resources/application.yaml must resolve to a KafkaTopic CR
+        (metadata.name or spec.topicName) under openbank-infra/gitops.
+      # EMPTY, and that is the point. An entry needs a reason, and the check fails on a stale
+      # declaration in BOTH directions — a name listed here that IS declared is itself reported —
+      # so a temporary exception cannot quietly become permanent. Same idiom as the pact gate's
+      # KNOWN_UNCOVERED and the runblocking_allowlist above.
+      allowed_absent: []
+      # The check ships with a --selftest that feeds it inputs it MUST flag and inputs it must
+      # NOT, run on every CI invocation: once the fleet is clean the flagging branch would
+      # otherwise never execute again, and a gate that has only ever passed is unfalsified.
+      ci_producer: ".github/scripts/check-kafka-topics-exist.py"
 
     # ---------------------------------------------------------------------------------------
     # Vulnerability-management lifecycle SLAs (ADR-0030 D1). Detection -> closure, in days.

--- a/openbank-infra/gitops/components/payments/settlement-opa-bundle.yaml
+++ b/openbank-infra/gitops/components/payments/settlement-opa-bundle.yaml
@@ -9,7 +9,7 @@ metadata:
     app.kubernetes.io/name: settlement-service
     app.kubernetes.io/part-of: payments
   annotations:
-    openbank.tech/policy-checksum: "e18615f75105411d"
+    openbank.tech/policy-checksum: "af9e2939f7b4aa44"
 data:
   rest.rego: |
     # SPDX-License-Identifier: Apache-2.0
@@ -2778,6 +2778,50 @@ data:
             jdbc-postgresql (build.gradle.kts) — it has no OLTP datasource to reach. The
             reconciliation reads the warehouse and the WORM archive over blocking clients.
       ci_producer: ".github/scripts/check-no-runblocking-in-scheduled.py"
+
+
+    # ---------------------------------------------------------------------------------------
+    # Kafka topic existence (issue #2598). A service may only reference a topic that exists.
+    # ---------------------------------------------------------------------------------------
+    kafka_topics:
+      referenced_topics_must_be_declared: true
+      # A Kafka consumer subscribed to a topic that does not exist does NOT error. It joins its
+      # consumer group, reports healthy, and receives nothing — forever. There is no runtime
+      # signal that can distinguish it from a topic with no traffic: pod ready, group joined,
+      # lag zero, metrics flat. So this is only catchable statically, before the merge.
+      #
+      # Found live: openbank-analytics-sink subscribed to `openbank.account.events` and
+      # `openbank.transaction.events`. NEITHER has ever existed — the real topics are
+      # `openbank.accounts.account.created` and `openbank.transactions.transaction.initiated`,
+      # both declared, both produced, both already consumed by audit-service. The sink ran for
+      # weeks green while no ACCOUNT_OPENED and no TRANSACTION row ever reached bronze_events,
+      # which silently made ADR-0210 D2's account->party resolution dead code and left Customer
+      # 360 structurally unable to show a customer's accounts or transactions (PR #2629).
+      #
+      # Same failure shape as a client pointed at a REST path that does not exist — the one that
+      # shipped finrep's call to `/api/v1/ledger/trial-balance` (see the contract-test notes in
+      # CLAUDE.md). There the answer was to make the provider replay the contract at PR time;
+      # here it is to compare the name a service asks for against the set declared to exist.
+      #
+      # `openbank-infra/gitops` carries a KafkaTopic CR for every topic, so the declared set is
+      # authoritative and complete — that is what makes this checkable without a live broker.
+      #
+      # ENFORCED from the day it was written, not advisory. The fleet is at zero unresolved
+      # topics, so there is no judgement left to exercise; an advisory verdict over a checkable
+      # fact only makes the next violation mergeable.
+      scope: |
+        Every dotted topic name in a `topics:`/`topic:` key of any
+        openbank-*/src/main/resources/application.yaml must resolve to a KafkaTopic CR
+        (metadata.name or spec.topicName) under openbank-infra/gitops.
+      # EMPTY, and that is the point. An entry needs a reason, and the check fails on a stale
+      # declaration in BOTH directions — a name listed here that IS declared is itself reported —
+      # so a temporary exception cannot quietly become permanent. Same idiom as the pact gate's
+      # KNOWN_UNCOVERED and the runblocking_allowlist above.
+      allowed_absent: []
+      # The check ships with a --selftest that feeds it inputs it MUST flag and inputs it must
+      # NOT, run on every CI invocation: once the fleet is clean the flagging branch would
+      # otherwise never execute again, and a gate that has only ever passed is unfalsified.
+      ci_producer: ".github/scripts/check-kafka-topics-exist.py"
 
     # ---------------------------------------------------------------------------------------
     # Vulnerability-management lifecycle SLAs (ADR-0030 D1). Detection -> closure, in days.

--- a/openbank-infra/gitops/components/payments/standing-order-opa-bundle.yaml
+++ b/openbank-infra/gitops/components/payments/standing-order-opa-bundle.yaml
@@ -9,7 +9,7 @@ metadata:
     app.kubernetes.io/name: standing-order-service
     app.kubernetes.io/part-of: payments
   annotations:
-    openbank.tech/policy-checksum: "badbef0faa85d410"
+    openbank.tech/policy-checksum: "2846b93818d0ab48"
 data:
   rest.rego: |
     # SPDX-License-Identifier: Apache-2.0
@@ -2763,6 +2763,50 @@ data:
             jdbc-postgresql (build.gradle.kts) — it has no OLTP datasource to reach. The
             reconciliation reads the warehouse and the WORM archive over blocking clients.
       ci_producer: ".github/scripts/check-no-runblocking-in-scheduled.py"
+
+
+    # ---------------------------------------------------------------------------------------
+    # Kafka topic existence (issue #2598). A service may only reference a topic that exists.
+    # ---------------------------------------------------------------------------------------
+    kafka_topics:
+      referenced_topics_must_be_declared: true
+      # A Kafka consumer subscribed to a topic that does not exist does NOT error. It joins its
+      # consumer group, reports healthy, and receives nothing — forever. There is no runtime
+      # signal that can distinguish it from a topic with no traffic: pod ready, group joined,
+      # lag zero, metrics flat. So this is only catchable statically, before the merge.
+      #
+      # Found live: openbank-analytics-sink subscribed to `openbank.account.events` and
+      # `openbank.transaction.events`. NEITHER has ever existed — the real topics are
+      # `openbank.accounts.account.created` and `openbank.transactions.transaction.initiated`,
+      # both declared, both produced, both already consumed by audit-service. The sink ran for
+      # weeks green while no ACCOUNT_OPENED and no TRANSACTION row ever reached bronze_events,
+      # which silently made ADR-0210 D2's account->party resolution dead code and left Customer
+      # 360 structurally unable to show a customer's accounts or transactions (PR #2629).
+      #
+      # Same failure shape as a client pointed at a REST path that does not exist — the one that
+      # shipped finrep's call to `/api/v1/ledger/trial-balance` (see the contract-test notes in
+      # CLAUDE.md). There the answer was to make the provider replay the contract at PR time;
+      # here it is to compare the name a service asks for against the set declared to exist.
+      #
+      # `openbank-infra/gitops` carries a KafkaTopic CR for every topic, so the declared set is
+      # authoritative and complete — that is what makes this checkable without a live broker.
+      #
+      # ENFORCED from the day it was written, not advisory. The fleet is at zero unresolved
+      # topics, so there is no judgement left to exercise; an advisory verdict over a checkable
+      # fact only makes the next violation mergeable.
+      scope: |
+        Every dotted topic name in a `topics:`/`topic:` key of any
+        openbank-*/src/main/resources/application.yaml must resolve to a KafkaTopic CR
+        (metadata.name or spec.topicName) under openbank-infra/gitops.
+      # EMPTY, and that is the point. An entry needs a reason, and the check fails on a stale
+      # declaration in BOTH directions — a name listed here that IS declared is itself reported —
+      # so a temporary exception cannot quietly become permanent. Same idiom as the pact gate's
+      # KNOWN_UNCOVERED and the runblocking_allowlist above.
+      allowed_absent: []
+      # The check ships with a --selftest that feeds it inputs it MUST flag and inputs it must
+      # NOT, run on every CI invocation: once the fleet is clean the flagging branch would
+      # otherwise never execute again, and a gate that has only ever passed is unfalsified.
+      ci_producer: ".github/scripts/check-kafka-topics-exist.py"
 
     # ---------------------------------------------------------------------------------------
     # Vulnerability-management lifecycle SLAs (ADR-0030 D1). Detection -> closure, in days.

--- a/openbank-infra/gitops/components/payments/swift-opa-bundle.yaml
+++ b/openbank-infra/gitops/components/payments/swift-opa-bundle.yaml
@@ -9,7 +9,7 @@ metadata:
     app.kubernetes.io/name: swift-service
     app.kubernetes.io/part-of: payments
   annotations:
-    openbank.tech/policy-checksum: "f8577d280559d741"
+    openbank.tech/policy-checksum: "ddffbd66c30db2b3"
 data:
   rest.rego: |
     # SPDX-License-Identifier: Apache-2.0
@@ -2781,6 +2781,50 @@ data:
             jdbc-postgresql (build.gradle.kts) — it has no OLTP datasource to reach. The
             reconciliation reads the warehouse and the WORM archive over blocking clients.
       ci_producer: ".github/scripts/check-no-runblocking-in-scheduled.py"
+
+
+    # ---------------------------------------------------------------------------------------
+    # Kafka topic existence (issue #2598). A service may only reference a topic that exists.
+    # ---------------------------------------------------------------------------------------
+    kafka_topics:
+      referenced_topics_must_be_declared: true
+      # A Kafka consumer subscribed to a topic that does not exist does NOT error. It joins its
+      # consumer group, reports healthy, and receives nothing — forever. There is no runtime
+      # signal that can distinguish it from a topic with no traffic: pod ready, group joined,
+      # lag zero, metrics flat. So this is only catchable statically, before the merge.
+      #
+      # Found live: openbank-analytics-sink subscribed to `openbank.account.events` and
+      # `openbank.transaction.events`. NEITHER has ever existed — the real topics are
+      # `openbank.accounts.account.created` and `openbank.transactions.transaction.initiated`,
+      # both declared, both produced, both already consumed by audit-service. The sink ran for
+      # weeks green while no ACCOUNT_OPENED and no TRANSACTION row ever reached bronze_events,
+      # which silently made ADR-0210 D2's account->party resolution dead code and left Customer
+      # 360 structurally unable to show a customer's accounts or transactions (PR #2629).
+      #
+      # Same failure shape as a client pointed at a REST path that does not exist — the one that
+      # shipped finrep's call to `/api/v1/ledger/trial-balance` (see the contract-test notes in
+      # CLAUDE.md). There the answer was to make the provider replay the contract at PR time;
+      # here it is to compare the name a service asks for against the set declared to exist.
+      #
+      # `openbank-infra/gitops` carries a KafkaTopic CR for every topic, so the declared set is
+      # authoritative and complete — that is what makes this checkable without a live broker.
+      #
+      # ENFORCED from the day it was written, not advisory. The fleet is at zero unresolved
+      # topics, so there is no judgement left to exercise; an advisory verdict over a checkable
+      # fact only makes the next violation mergeable.
+      scope: |
+        Every dotted topic name in a `topics:`/`topic:` key of any
+        openbank-*/src/main/resources/application.yaml must resolve to a KafkaTopic CR
+        (metadata.name or spec.topicName) under openbank-infra/gitops.
+      # EMPTY, and that is the point. An entry needs a reason, and the check fails on a stale
+      # declaration in BOTH directions — a name listed here that IS declared is itself reported —
+      # so a temporary exception cannot quietly become permanent. Same idiom as the pact gate's
+      # KNOWN_UNCOVERED and the runblocking_allowlist above.
+      allowed_absent: []
+      # The check ships with a --selftest that feeds it inputs it MUST flag and inputs it must
+      # NOT, run on every CI invocation: once the fleet is clean the flagging branch would
+      # otherwise never execute again, and a gate that has only ever passed is unfalsified.
+      ci_producer: ".github/scripts/check-kafka-topics-exist.py"
 
     # ---------------------------------------------------------------------------------------
     # Vulnerability-management lifecycle SLAs (ADR-0030 D1). Detection -> closure, in days.

--- a/openbank-infra/gitops/components/payments/transaction-opa-bundle.yaml
+++ b/openbank-infra/gitops/components/payments/transaction-opa-bundle.yaml
@@ -9,7 +9,7 @@ metadata:
     app.kubernetes.io/name: transaction-service
     app.kubernetes.io/part-of: payments
   annotations:
-    openbank.tech/policy-checksum: "a7589150ebe0f9d4"
+    openbank.tech/policy-checksum: "6da51558471f2875"
 data:
   rest.rego: |
     # SPDX-License-Identifier: Apache-2.0
@@ -2834,6 +2834,50 @@ data:
             jdbc-postgresql (build.gradle.kts) — it has no OLTP datasource to reach. The
             reconciliation reads the warehouse and the WORM archive over blocking clients.
       ci_producer: ".github/scripts/check-no-runblocking-in-scheduled.py"
+
+
+    # ---------------------------------------------------------------------------------------
+    # Kafka topic existence (issue #2598). A service may only reference a topic that exists.
+    # ---------------------------------------------------------------------------------------
+    kafka_topics:
+      referenced_topics_must_be_declared: true
+      # A Kafka consumer subscribed to a topic that does not exist does NOT error. It joins its
+      # consumer group, reports healthy, and receives nothing — forever. There is no runtime
+      # signal that can distinguish it from a topic with no traffic: pod ready, group joined,
+      # lag zero, metrics flat. So this is only catchable statically, before the merge.
+      #
+      # Found live: openbank-analytics-sink subscribed to `openbank.account.events` and
+      # `openbank.transaction.events`. NEITHER has ever existed — the real topics are
+      # `openbank.accounts.account.created` and `openbank.transactions.transaction.initiated`,
+      # both declared, both produced, both already consumed by audit-service. The sink ran for
+      # weeks green while no ACCOUNT_OPENED and no TRANSACTION row ever reached bronze_events,
+      # which silently made ADR-0210 D2's account->party resolution dead code and left Customer
+      # 360 structurally unable to show a customer's accounts or transactions (PR #2629).
+      #
+      # Same failure shape as a client pointed at a REST path that does not exist — the one that
+      # shipped finrep's call to `/api/v1/ledger/trial-balance` (see the contract-test notes in
+      # CLAUDE.md). There the answer was to make the provider replay the contract at PR time;
+      # here it is to compare the name a service asks for against the set declared to exist.
+      #
+      # `openbank-infra/gitops` carries a KafkaTopic CR for every topic, so the declared set is
+      # authoritative and complete — that is what makes this checkable without a live broker.
+      #
+      # ENFORCED from the day it was written, not advisory. The fleet is at zero unresolved
+      # topics, so there is no judgement left to exercise; an advisory verdict over a checkable
+      # fact only makes the next violation mergeable.
+      scope: |
+        Every dotted topic name in a `topics:`/`topic:` key of any
+        openbank-*/src/main/resources/application.yaml must resolve to a KafkaTopic CR
+        (metadata.name or spec.topicName) under openbank-infra/gitops.
+      # EMPTY, and that is the point. An entry needs a reason, and the check fails on a stale
+      # declaration in BOTH directions — a name listed here that IS declared is itself reported —
+      # so a temporary exception cannot quietly become permanent. Same idiom as the pact gate's
+      # KNOWN_UNCOVERED and the runblocking_allowlist above.
+      allowed_absent: []
+      # The check ships with a --selftest that feeds it inputs it MUST flag and inputs it must
+      # NOT, run on every CI invocation: once the fleet is clean the flagging branch would
+      # otherwise never execute again, and a gate that has only ever passed is unfalsified.
+      ci_producer: ".github/scripts/check-kafka-topics-exist.py"
 
     # ---------------------------------------------------------------------------------------
     # Vulnerability-management lifecycle SLAs (ADR-0030 D1). Detection -> closure, in days.

--- a/openbank-infra/gitops/components/payments/vop-opa-bundle.yaml
+++ b/openbank-infra/gitops/components/payments/vop-opa-bundle.yaml
@@ -9,7 +9,7 @@ metadata:
     app.kubernetes.io/name: vop-service
     app.kubernetes.io/part-of: payments
   annotations:
-    openbank.tech/policy-checksum: "a1b5a0eb7abf3dde"
+    openbank.tech/policy-checksum: "1a1fed1af16793bb"
 data:
   rest.rego: |
     # SPDX-License-Identifier: Apache-2.0
@@ -2785,6 +2785,50 @@ data:
             jdbc-postgresql (build.gradle.kts) — it has no OLTP datasource to reach. The
             reconciliation reads the warehouse and the WORM archive over blocking clients.
       ci_producer: ".github/scripts/check-no-runblocking-in-scheduled.py"
+
+
+    # ---------------------------------------------------------------------------------------
+    # Kafka topic existence (issue #2598). A service may only reference a topic that exists.
+    # ---------------------------------------------------------------------------------------
+    kafka_topics:
+      referenced_topics_must_be_declared: true
+      # A Kafka consumer subscribed to a topic that does not exist does NOT error. It joins its
+      # consumer group, reports healthy, and receives nothing — forever. There is no runtime
+      # signal that can distinguish it from a topic with no traffic: pod ready, group joined,
+      # lag zero, metrics flat. So this is only catchable statically, before the merge.
+      #
+      # Found live: openbank-analytics-sink subscribed to `openbank.account.events` and
+      # `openbank.transaction.events`. NEITHER has ever existed — the real topics are
+      # `openbank.accounts.account.created` and `openbank.transactions.transaction.initiated`,
+      # both declared, both produced, both already consumed by audit-service. The sink ran for
+      # weeks green while no ACCOUNT_OPENED and no TRANSACTION row ever reached bronze_events,
+      # which silently made ADR-0210 D2's account->party resolution dead code and left Customer
+      # 360 structurally unable to show a customer's accounts or transactions (PR #2629).
+      #
+      # Same failure shape as a client pointed at a REST path that does not exist — the one that
+      # shipped finrep's call to `/api/v1/ledger/trial-balance` (see the contract-test notes in
+      # CLAUDE.md). There the answer was to make the provider replay the contract at PR time;
+      # here it is to compare the name a service asks for against the set declared to exist.
+      #
+      # `openbank-infra/gitops` carries a KafkaTopic CR for every topic, so the declared set is
+      # authoritative and complete — that is what makes this checkable without a live broker.
+      #
+      # ENFORCED from the day it was written, not advisory. The fleet is at zero unresolved
+      # topics, so there is no judgement left to exercise; an advisory verdict over a checkable
+      # fact only makes the next violation mergeable.
+      scope: |
+        Every dotted topic name in a `topics:`/`topic:` key of any
+        openbank-*/src/main/resources/application.yaml must resolve to a KafkaTopic CR
+        (metadata.name or spec.topicName) under openbank-infra/gitops.
+      # EMPTY, and that is the point. An entry needs a reason, and the check fails on a stale
+      # declaration in BOTH directions — a name listed here that IS declared is itself reported —
+      # so a temporary exception cannot quietly become permanent. Same idiom as the pact gate's
+      # KNOWN_UNCOVERED and the runblocking_allowlist above.
+      allowed_absent: []
+      # The check ships with a --selftest that feeds it inputs it MUST flag and inputs it must
+      # NOT, run on every CI invocation: once the fleet is clean the flagging branch would
+      # otherwise never execute again, and a gate that has only ever passed is unfalsified.
+      ci_producer: ".github/scripts/check-kafka-topics-exist.py"
 
     # ---------------------------------------------------------------------------------------
     # Vulnerability-management lifecycle SLAs (ADR-0030 D1). Detection -> closure, in days.

--- a/openbank-infra/gitops/components/pid/pid-opa-bundle.yaml
+++ b/openbank-infra/gitops/components/pid/pid-opa-bundle.yaml
@@ -9,7 +9,7 @@ metadata:
     app.kubernetes.io/name: pid-service
     app.kubernetes.io/part-of: pid
   annotations:
-    openbank.tech/policy-checksum: "6150cdc0edd75bd4"
+    openbank.tech/policy-checksum: "35daa5197486302d"
 data:
   rest.rego: |
     # SPDX-License-Identifier: Apache-2.0
@@ -2787,6 +2787,50 @@ data:
             jdbc-postgresql (build.gradle.kts) — it has no OLTP datasource to reach. The
             reconciliation reads the warehouse and the WORM archive over blocking clients.
       ci_producer: ".github/scripts/check-no-runblocking-in-scheduled.py"
+
+
+    # ---------------------------------------------------------------------------------------
+    # Kafka topic existence (issue #2598). A service may only reference a topic that exists.
+    # ---------------------------------------------------------------------------------------
+    kafka_topics:
+      referenced_topics_must_be_declared: true
+      # A Kafka consumer subscribed to a topic that does not exist does NOT error. It joins its
+      # consumer group, reports healthy, and receives nothing — forever. There is no runtime
+      # signal that can distinguish it from a topic with no traffic: pod ready, group joined,
+      # lag zero, metrics flat. So this is only catchable statically, before the merge.
+      #
+      # Found live: openbank-analytics-sink subscribed to `openbank.account.events` and
+      # `openbank.transaction.events`. NEITHER has ever existed — the real topics are
+      # `openbank.accounts.account.created` and `openbank.transactions.transaction.initiated`,
+      # both declared, both produced, both already consumed by audit-service. The sink ran for
+      # weeks green while no ACCOUNT_OPENED and no TRANSACTION row ever reached bronze_events,
+      # which silently made ADR-0210 D2's account->party resolution dead code and left Customer
+      # 360 structurally unable to show a customer's accounts or transactions (PR #2629).
+      #
+      # Same failure shape as a client pointed at a REST path that does not exist — the one that
+      # shipped finrep's call to `/api/v1/ledger/trial-balance` (see the contract-test notes in
+      # CLAUDE.md). There the answer was to make the provider replay the contract at PR time;
+      # here it is to compare the name a service asks for against the set declared to exist.
+      #
+      # `openbank-infra/gitops` carries a KafkaTopic CR for every topic, so the declared set is
+      # authoritative and complete — that is what makes this checkable without a live broker.
+      #
+      # ENFORCED from the day it was written, not advisory. The fleet is at zero unresolved
+      # topics, so there is no judgement left to exercise; an advisory verdict over a checkable
+      # fact only makes the next violation mergeable.
+      scope: |
+        Every dotted topic name in a `topics:`/`topic:` key of any
+        openbank-*/src/main/resources/application.yaml must resolve to a KafkaTopic CR
+        (metadata.name or spec.topicName) under openbank-infra/gitops.
+      # EMPTY, and that is the point. An entry needs a reason, and the check fails on a stale
+      # declaration in BOTH directions — a name listed here that IS declared is itself reported —
+      # so a temporary exception cannot quietly become permanent. Same idiom as the pact gate's
+      # KNOWN_UNCOVERED and the runblocking_allowlist above.
+      allowed_absent: []
+      # The check ships with a --selftest that feeds it inputs it MUST flag and inputs it must
+      # NOT, run on every CI invocation: once the fleet is clean the flagging branch would
+      # otherwise never execute again, and a gate that has only ever passed is unfalsified.
+      ci_producer: ".github/scripts/check-kafka-topics-exist.py"
 
     # ---------------------------------------------------------------------------------------
     # Vulnerability-management lifecycle SLAs (ADR-0030 D1). Detection -> closure, in days.

--- a/openbank-infra/gitops/components/pid/pid-service.yaml
+++ b/openbank-infra/gitops/components/pid/pid-service.yaml
@@ -22,7 +22,7 @@ spec:
       annotations:
         # Rolls the pod when the OPA bundle changes — subPath mounts do NOT hot-reload.
         # Kept in sync by gen-pid-opa-bundle.sh (do not hand-edit).
-        openbank.tech/policy-checksum: "6150cdc0edd75bd4"
+        openbank.tech/policy-checksum: "35daa5197486302d"
     spec:
       securityContext:
         runAsNonRoot: true

--- a/openbank-infra/gitops/components/psd2-service/psd2-opa-bundle.yaml
+++ b/openbank-infra/gitops/components/psd2-service/psd2-opa-bundle.yaml
@@ -9,7 +9,7 @@ metadata:
     app.kubernetes.io/name: psd2-service
     app.kubernetes.io/part-of: psd2
   annotations:
-    openbank.tech/policy-checksum: "298d4a97c207db80"
+    openbank.tech/policy-checksum: "203a0633ebaaac95"
 data:
   rest.rego: |
     # SPDX-License-Identifier: Apache-2.0
@@ -2860,6 +2860,50 @@ data:
             jdbc-postgresql (build.gradle.kts) — it has no OLTP datasource to reach. The
             reconciliation reads the warehouse and the WORM archive over blocking clients.
       ci_producer: ".github/scripts/check-no-runblocking-in-scheduled.py"
+
+
+    # ---------------------------------------------------------------------------------------
+    # Kafka topic existence (issue #2598). A service may only reference a topic that exists.
+    # ---------------------------------------------------------------------------------------
+    kafka_topics:
+      referenced_topics_must_be_declared: true
+      # A Kafka consumer subscribed to a topic that does not exist does NOT error. It joins its
+      # consumer group, reports healthy, and receives nothing — forever. There is no runtime
+      # signal that can distinguish it from a topic with no traffic: pod ready, group joined,
+      # lag zero, metrics flat. So this is only catchable statically, before the merge.
+      #
+      # Found live: openbank-analytics-sink subscribed to `openbank.account.events` and
+      # `openbank.transaction.events`. NEITHER has ever existed — the real topics are
+      # `openbank.accounts.account.created` and `openbank.transactions.transaction.initiated`,
+      # both declared, both produced, both already consumed by audit-service. The sink ran for
+      # weeks green while no ACCOUNT_OPENED and no TRANSACTION row ever reached bronze_events,
+      # which silently made ADR-0210 D2's account->party resolution dead code and left Customer
+      # 360 structurally unable to show a customer's accounts or transactions (PR #2629).
+      #
+      # Same failure shape as a client pointed at a REST path that does not exist — the one that
+      # shipped finrep's call to `/api/v1/ledger/trial-balance` (see the contract-test notes in
+      # CLAUDE.md). There the answer was to make the provider replay the contract at PR time;
+      # here it is to compare the name a service asks for against the set declared to exist.
+      #
+      # `openbank-infra/gitops` carries a KafkaTopic CR for every topic, so the declared set is
+      # authoritative and complete — that is what makes this checkable without a live broker.
+      #
+      # ENFORCED from the day it was written, not advisory. The fleet is at zero unresolved
+      # topics, so there is no judgement left to exercise; an advisory verdict over a checkable
+      # fact only makes the next violation mergeable.
+      scope: |
+        Every dotted topic name in a `topics:`/`topic:` key of any
+        openbank-*/src/main/resources/application.yaml must resolve to a KafkaTopic CR
+        (metadata.name or spec.topicName) under openbank-infra/gitops.
+      # EMPTY, and that is the point. An entry needs a reason, and the check fails on a stale
+      # declaration in BOTH directions — a name listed here that IS declared is itself reported —
+      # so a temporary exception cannot quietly become permanent. Same idiom as the pact gate's
+      # KNOWN_UNCOVERED and the runblocking_allowlist above.
+      allowed_absent: []
+      # The check ships with a --selftest that feeds it inputs it MUST flag and inputs it must
+      # NOT, run on every CI invocation: once the fleet is clean the flagging branch would
+      # otherwise never execute again, and a gate that has only ever passed is unfalsified.
+      ci_producer: ".github/scripts/check-kafka-topics-exist.py"
 
     # ---------------------------------------------------------------------------------------
     # Vulnerability-management lifecycle SLAs (ADR-0030 D1). Detection -> closure, in days.

--- a/openbank-infra/gitops/components/psd2-service/psd2-service.yaml
+++ b/openbank-infra/gitops/components/psd2-service/psd2-service.yaml
@@ -18,7 +18,7 @@ spec:
       annotations:
         # Rolls the pod when the OPA bundle changes — subPath mounts do NOT hot-reload.
         # Kept in sync by gen-psd2-opa-bundle.sh (do not hand-edit).
-        openbank.tech/policy-checksum: "298d4a97c207db80"
+        openbank.tech/policy-checksum: "203a0633ebaaac95"
       labels: {app.kubernetes.io/name: psd2-service, app.kubernetes.io/part-of: psd2}
     spec:
       securityContext:

--- a/openbank-infra/gitops/components/sanctions-service/sanctions-opa-bundle.yaml
+++ b/openbank-infra/gitops/components/sanctions-service/sanctions-opa-bundle.yaml
@@ -9,7 +9,7 @@ metadata:
     app.kubernetes.io/name: sanctions-service
     app.kubernetes.io/part-of: sanctions
   annotations:
-    openbank.tech/policy-checksum: "7729b9f81c273385"
+    openbank.tech/policy-checksum: "36012bf14359fa89"
 data:
   rest.rego: |
     # SPDX-License-Identifier: Apache-2.0
@@ -2765,6 +2765,50 @@ data:
             jdbc-postgresql (build.gradle.kts) — it has no OLTP datasource to reach. The
             reconciliation reads the warehouse and the WORM archive over blocking clients.
       ci_producer: ".github/scripts/check-no-runblocking-in-scheduled.py"
+
+
+    # ---------------------------------------------------------------------------------------
+    # Kafka topic existence (issue #2598). A service may only reference a topic that exists.
+    # ---------------------------------------------------------------------------------------
+    kafka_topics:
+      referenced_topics_must_be_declared: true
+      # A Kafka consumer subscribed to a topic that does not exist does NOT error. It joins its
+      # consumer group, reports healthy, and receives nothing — forever. There is no runtime
+      # signal that can distinguish it from a topic with no traffic: pod ready, group joined,
+      # lag zero, metrics flat. So this is only catchable statically, before the merge.
+      #
+      # Found live: openbank-analytics-sink subscribed to `openbank.account.events` and
+      # `openbank.transaction.events`. NEITHER has ever existed — the real topics are
+      # `openbank.accounts.account.created` and `openbank.transactions.transaction.initiated`,
+      # both declared, both produced, both already consumed by audit-service. The sink ran for
+      # weeks green while no ACCOUNT_OPENED and no TRANSACTION row ever reached bronze_events,
+      # which silently made ADR-0210 D2's account->party resolution dead code and left Customer
+      # 360 structurally unable to show a customer's accounts or transactions (PR #2629).
+      #
+      # Same failure shape as a client pointed at a REST path that does not exist — the one that
+      # shipped finrep's call to `/api/v1/ledger/trial-balance` (see the contract-test notes in
+      # CLAUDE.md). There the answer was to make the provider replay the contract at PR time;
+      # here it is to compare the name a service asks for against the set declared to exist.
+      #
+      # `openbank-infra/gitops` carries a KafkaTopic CR for every topic, so the declared set is
+      # authoritative and complete — that is what makes this checkable without a live broker.
+      #
+      # ENFORCED from the day it was written, not advisory. The fleet is at zero unresolved
+      # topics, so there is no judgement left to exercise; an advisory verdict over a checkable
+      # fact only makes the next violation mergeable.
+      scope: |
+        Every dotted topic name in a `topics:`/`topic:` key of any
+        openbank-*/src/main/resources/application.yaml must resolve to a KafkaTopic CR
+        (metadata.name or spec.topicName) under openbank-infra/gitops.
+      # EMPTY, and that is the point. An entry needs a reason, and the check fails on a stale
+      # declaration in BOTH directions — a name listed here that IS declared is itself reported —
+      # so a temporary exception cannot quietly become permanent. Same idiom as the pact gate's
+      # KNOWN_UNCOVERED and the runblocking_allowlist above.
+      allowed_absent: []
+      # The check ships with a --selftest that feeds it inputs it MUST flag and inputs it must
+      # NOT, run on every CI invocation: once the fleet is clean the flagging branch would
+      # otherwise never execute again, and a gate that has only ever passed is unfalsified.
+      ci_producer: ".github/scripts/check-kafka-topics-exist.py"
 
     # ---------------------------------------------------------------------------------------
     # Vulnerability-management lifecycle SLAs (ADR-0030 D1). Detection -> closure, in days.

--- a/openbank-infra/gitops/components/sanctions-service/sanctions-service.yaml
+++ b/openbank-infra/gitops/components/sanctions-service/sanctions-service.yaml
@@ -49,7 +49,7 @@ spec:
       annotations:
         # Rolls the pods when the OPA bundle changes — subPath mounts do NOT hot-reload.
         # Kept in sync by gen-sanctions-opa-bundle.sh (do not hand-edit).
-        openbank.tech/policy-checksum: "7729b9f81c273385"
+        openbank.tech/policy-checksum: "36012bf14359fa89"
     spec:
       securityContext:
         runAsNonRoot: true

--- a/openbank-infra/gitops/components/sca/sca-opa-bundle.yaml
+++ b/openbank-infra/gitops/components/sca/sca-opa-bundle.yaml
@@ -9,7 +9,7 @@ metadata:
     app.kubernetes.io/name: sca-service
     app.kubernetes.io/part-of: sca
   annotations:
-    openbank.tech/policy-checksum: "b247ae924db11eda"
+    openbank.tech/policy-checksum: "b9af5f6fb370102f"
 data:
   rest.rego: |
     # SPDX-License-Identifier: Apache-2.0
@@ -2801,6 +2801,50 @@ data:
             jdbc-postgresql (build.gradle.kts) — it has no OLTP datasource to reach. The
             reconciliation reads the warehouse and the WORM archive over blocking clients.
       ci_producer: ".github/scripts/check-no-runblocking-in-scheduled.py"
+
+
+    # ---------------------------------------------------------------------------------------
+    # Kafka topic existence (issue #2598). A service may only reference a topic that exists.
+    # ---------------------------------------------------------------------------------------
+    kafka_topics:
+      referenced_topics_must_be_declared: true
+      # A Kafka consumer subscribed to a topic that does not exist does NOT error. It joins its
+      # consumer group, reports healthy, and receives nothing — forever. There is no runtime
+      # signal that can distinguish it from a topic with no traffic: pod ready, group joined,
+      # lag zero, metrics flat. So this is only catchable statically, before the merge.
+      #
+      # Found live: openbank-analytics-sink subscribed to `openbank.account.events` and
+      # `openbank.transaction.events`. NEITHER has ever existed — the real topics are
+      # `openbank.accounts.account.created` and `openbank.transactions.transaction.initiated`,
+      # both declared, both produced, both already consumed by audit-service. The sink ran for
+      # weeks green while no ACCOUNT_OPENED and no TRANSACTION row ever reached bronze_events,
+      # which silently made ADR-0210 D2's account->party resolution dead code and left Customer
+      # 360 structurally unable to show a customer's accounts or transactions (PR #2629).
+      #
+      # Same failure shape as a client pointed at a REST path that does not exist — the one that
+      # shipped finrep's call to `/api/v1/ledger/trial-balance` (see the contract-test notes in
+      # CLAUDE.md). There the answer was to make the provider replay the contract at PR time;
+      # here it is to compare the name a service asks for against the set declared to exist.
+      #
+      # `openbank-infra/gitops` carries a KafkaTopic CR for every topic, so the declared set is
+      # authoritative and complete — that is what makes this checkable without a live broker.
+      #
+      # ENFORCED from the day it was written, not advisory. The fleet is at zero unresolved
+      # topics, so there is no judgement left to exercise; an advisory verdict over a checkable
+      # fact only makes the next violation mergeable.
+      scope: |
+        Every dotted topic name in a `topics:`/`topic:` key of any
+        openbank-*/src/main/resources/application.yaml must resolve to a KafkaTopic CR
+        (metadata.name or spec.topicName) under openbank-infra/gitops.
+      # EMPTY, and that is the point. An entry needs a reason, and the check fails on a stale
+      # declaration in BOTH directions — a name listed here that IS declared is itself reported —
+      # so a temporary exception cannot quietly become permanent. Same idiom as the pact gate's
+      # KNOWN_UNCOVERED and the runblocking_allowlist above.
+      allowed_absent: []
+      # The check ships with a --selftest that feeds it inputs it MUST flag and inputs it must
+      # NOT, run on every CI invocation: once the fleet is clean the flagging branch would
+      # otherwise never execute again, and a gate that has only ever passed is unfalsified.
+      ci_producer: ".github/scripts/check-kafka-topics-exist.py"
 
     # ---------------------------------------------------------------------------------------
     # Vulnerability-management lifecycle SLAs (ADR-0030 D1). Detection -> closure, in days.

--- a/openbank-infra/gitops/components/sca/sca-service.yaml
+++ b/openbank-infra/gitops/components/sca/sca-service.yaml
@@ -28,7 +28,7 @@ spec:
       annotations:
         # Rolls the pods when the OPA bundle changes — subPath mounts do NOT hot-reload.
         # Kept in sync by gen-sca-opa-bundle.sh (do not hand-edit).
-        openbank.tech/policy-checksum: "b247ae924db11eda"
+        openbank.tech/policy-checksum: "b9af5f6fb370102f"
     spec:
       securityContext:
         runAsNonRoot: true

--- a/openbank-infra/gitops/components/statements/statement-opa-bundle.yaml
+++ b/openbank-infra/gitops/components/statements/statement-opa-bundle.yaml
@@ -9,7 +9,7 @@ metadata:
     app.kubernetes.io/name: statement-service
     app.kubernetes.io/part-of: statements
   annotations:
-    openbank.tech/policy-checksum: "f97881012c66b809"
+    openbank.tech/policy-checksum: "387b29c5274737a1"
 data:
   rest.rego: |
     # SPDX-License-Identifier: Apache-2.0
@@ -2831,6 +2831,50 @@ data:
             jdbc-postgresql (build.gradle.kts) — it has no OLTP datasource to reach. The
             reconciliation reads the warehouse and the WORM archive over blocking clients.
       ci_producer: ".github/scripts/check-no-runblocking-in-scheduled.py"
+
+
+    # ---------------------------------------------------------------------------------------
+    # Kafka topic existence (issue #2598). A service may only reference a topic that exists.
+    # ---------------------------------------------------------------------------------------
+    kafka_topics:
+      referenced_topics_must_be_declared: true
+      # A Kafka consumer subscribed to a topic that does not exist does NOT error. It joins its
+      # consumer group, reports healthy, and receives nothing — forever. There is no runtime
+      # signal that can distinguish it from a topic with no traffic: pod ready, group joined,
+      # lag zero, metrics flat. So this is only catchable statically, before the merge.
+      #
+      # Found live: openbank-analytics-sink subscribed to `openbank.account.events` and
+      # `openbank.transaction.events`. NEITHER has ever existed — the real topics are
+      # `openbank.accounts.account.created` and `openbank.transactions.transaction.initiated`,
+      # both declared, both produced, both already consumed by audit-service. The sink ran for
+      # weeks green while no ACCOUNT_OPENED and no TRANSACTION row ever reached bronze_events,
+      # which silently made ADR-0210 D2's account->party resolution dead code and left Customer
+      # 360 structurally unable to show a customer's accounts or transactions (PR #2629).
+      #
+      # Same failure shape as a client pointed at a REST path that does not exist — the one that
+      # shipped finrep's call to `/api/v1/ledger/trial-balance` (see the contract-test notes in
+      # CLAUDE.md). There the answer was to make the provider replay the contract at PR time;
+      # here it is to compare the name a service asks for against the set declared to exist.
+      #
+      # `openbank-infra/gitops` carries a KafkaTopic CR for every topic, so the declared set is
+      # authoritative and complete — that is what makes this checkable without a live broker.
+      #
+      # ENFORCED from the day it was written, not advisory. The fleet is at zero unresolved
+      # topics, so there is no judgement left to exercise; an advisory verdict over a checkable
+      # fact only makes the next violation mergeable.
+      scope: |
+        Every dotted topic name in a `topics:`/`topic:` key of any
+        openbank-*/src/main/resources/application.yaml must resolve to a KafkaTopic CR
+        (metadata.name or spec.topicName) under openbank-infra/gitops.
+      # EMPTY, and that is the point. An entry needs a reason, and the check fails on a stale
+      # declaration in BOTH directions — a name listed here that IS declared is itself reported —
+      # so a temporary exception cannot quietly become permanent. Same idiom as the pact gate's
+      # KNOWN_UNCOVERED and the runblocking_allowlist above.
+      allowed_absent: []
+      # The check ships with a --selftest that feeds it inputs it MUST flag and inputs it must
+      # NOT, run on every CI invocation: once the fleet is clean the flagging branch would
+      # otherwise never execute again, and a gate that has only ever passed is unfalsified.
+      ci_producer: ".github/scripts/check-kafka-topics-exist.py"
 
     # ---------------------------------------------------------------------------------------
     # Vulnerability-management lifecycle SLAs (ADR-0030 D1). Detection -> closure, in days.

--- a/openbank-infra/gitops/components/statements/statement-service.yaml
+++ b/openbank-infra/gitops/components/statements/statement-service.yaml
@@ -26,7 +26,7 @@ spec:
       annotations:
         # Rolls the pod when the OPA bundle changes — subPath mounts do NOT hot-reload.
         # Kept in sync by gen-statement-opa-bundle.sh (do not hand-edit).
-        openbank.tech/policy-checksum: "f97881012c66b809"
+        openbank.tech/policy-checksum: "387b29c5274737a1"
       labels:
         app.kubernetes.io/name: statement-service
         app.kubernetes.io/part-of: statements

--- a/openbank-infra/gitops/components/tpp-registry/tpp-registry-opa-bundle.yaml
+++ b/openbank-infra/gitops/components/tpp-registry/tpp-registry-opa-bundle.yaml
@@ -9,7 +9,7 @@ metadata:
     app.kubernetes.io/name: tpp-registry-service
     app.kubernetes.io/part-of: tpp-registry
   annotations:
-    openbank.tech/policy-checksum: "a5e7b5a6ab5146b7"
+    openbank.tech/policy-checksum: "b9f4512fda708846"
 data:
   rest.rego: |
     # SPDX-License-Identifier: Apache-2.0
@@ -2768,6 +2768,50 @@ data:
             jdbc-postgresql (build.gradle.kts) — it has no OLTP datasource to reach. The
             reconciliation reads the warehouse and the WORM archive over blocking clients.
       ci_producer: ".github/scripts/check-no-runblocking-in-scheduled.py"
+
+
+    # ---------------------------------------------------------------------------------------
+    # Kafka topic existence (issue #2598). A service may only reference a topic that exists.
+    # ---------------------------------------------------------------------------------------
+    kafka_topics:
+      referenced_topics_must_be_declared: true
+      # A Kafka consumer subscribed to a topic that does not exist does NOT error. It joins its
+      # consumer group, reports healthy, and receives nothing — forever. There is no runtime
+      # signal that can distinguish it from a topic with no traffic: pod ready, group joined,
+      # lag zero, metrics flat. So this is only catchable statically, before the merge.
+      #
+      # Found live: openbank-analytics-sink subscribed to `openbank.account.events` and
+      # `openbank.transaction.events`. NEITHER has ever existed — the real topics are
+      # `openbank.accounts.account.created` and `openbank.transactions.transaction.initiated`,
+      # both declared, both produced, both already consumed by audit-service. The sink ran for
+      # weeks green while no ACCOUNT_OPENED and no TRANSACTION row ever reached bronze_events,
+      # which silently made ADR-0210 D2's account->party resolution dead code and left Customer
+      # 360 structurally unable to show a customer's accounts or transactions (PR #2629).
+      #
+      # Same failure shape as a client pointed at a REST path that does not exist — the one that
+      # shipped finrep's call to `/api/v1/ledger/trial-balance` (see the contract-test notes in
+      # CLAUDE.md). There the answer was to make the provider replay the contract at PR time;
+      # here it is to compare the name a service asks for against the set declared to exist.
+      #
+      # `openbank-infra/gitops` carries a KafkaTopic CR for every topic, so the declared set is
+      # authoritative and complete — that is what makes this checkable without a live broker.
+      #
+      # ENFORCED from the day it was written, not advisory. The fleet is at zero unresolved
+      # topics, so there is no judgement left to exercise; an advisory verdict over a checkable
+      # fact only makes the next violation mergeable.
+      scope: |
+        Every dotted topic name in a `topics:`/`topic:` key of any
+        openbank-*/src/main/resources/application.yaml must resolve to a KafkaTopic CR
+        (metadata.name or spec.topicName) under openbank-infra/gitops.
+      # EMPTY, and that is the point. An entry needs a reason, and the check fails on a stale
+      # declaration in BOTH directions — a name listed here that IS declared is itself reported —
+      # so a temporary exception cannot quietly become permanent. Same idiom as the pact gate's
+      # KNOWN_UNCOVERED and the runblocking_allowlist above.
+      allowed_absent: []
+      # The check ships with a --selftest that feeds it inputs it MUST flag and inputs it must
+      # NOT, run on every CI invocation: once the fleet is clean the flagging branch would
+      # otherwise never execute again, and a gate that has only ever passed is unfalsified.
+      ci_producer: ".github/scripts/check-kafka-topics-exist.py"
 
     # ---------------------------------------------------------------------------------------
     # Vulnerability-management lifecycle SLAs (ADR-0030 D1). Detection -> closure, in days.

--- a/openbank-infra/gitops/components/tpp-registry/tpp-registry-service.yaml
+++ b/openbank-infra/gitops/components/tpp-registry/tpp-registry-service.yaml
@@ -23,7 +23,7 @@ spec:
       annotations:
         # Rolls the pod when the OPA bundle changes (subPath mounts do not hot-reload).
         # Kept in sync by gen-tpp-registry-opa-bundle.sh (do not hand-edit).
-        openbank.tech/policy-checksum: "a5e7b5a6ab5146b7"
+        openbank.tech/policy-checksum: "b9f4512fda708846"
     spec:
       securityContext:
         runAsNonRoot: true

--- a/openbank-libs/governance/rules.yaml
+++ b/openbank-libs/governance/rules.yaml
@@ -1330,6 +1330,50 @@ scheduled_methods:
         reconciliation reads the warehouse and the WORM archive over blocking clients.
   ci_producer: ".github/scripts/check-no-runblocking-in-scheduled.py"
 
+
+# ---------------------------------------------------------------------------------------
+# Kafka topic existence (issue #2598). A service may only reference a topic that exists.
+# ---------------------------------------------------------------------------------------
+kafka_topics:
+  referenced_topics_must_be_declared: true
+  # A Kafka consumer subscribed to a topic that does not exist does NOT error. It joins its
+  # consumer group, reports healthy, and receives nothing — forever. There is no runtime
+  # signal that can distinguish it from a topic with no traffic: pod ready, group joined,
+  # lag zero, metrics flat. So this is only catchable statically, before the merge.
+  #
+  # Found live: openbank-analytics-sink subscribed to `openbank.account.events` and
+  # `openbank.transaction.events`. NEITHER has ever existed — the real topics are
+  # `openbank.accounts.account.created` and `openbank.transactions.transaction.initiated`,
+  # both declared, both produced, both already consumed by audit-service. The sink ran for
+  # weeks green while no ACCOUNT_OPENED and no TRANSACTION row ever reached bronze_events,
+  # which silently made ADR-0210 D2's account->party resolution dead code and left Customer
+  # 360 structurally unable to show a customer's accounts or transactions (PR #2629).
+  #
+  # Same failure shape as a client pointed at a REST path that does not exist — the one that
+  # shipped finrep's call to `/api/v1/ledger/trial-balance` (see the contract-test notes in
+  # CLAUDE.md). There the answer was to make the provider replay the contract at PR time;
+  # here it is to compare the name a service asks for against the set declared to exist.
+  #
+  # `openbank-infra/gitops` carries a KafkaTopic CR for every topic, so the declared set is
+  # authoritative and complete — that is what makes this checkable without a live broker.
+  #
+  # ENFORCED from the day it was written, not advisory. The fleet is at zero unresolved
+  # topics, so there is no judgement left to exercise; an advisory verdict over a checkable
+  # fact only makes the next violation mergeable.
+  scope: |
+    Every dotted topic name in a `topics:`/`topic:` key of any
+    openbank-*/src/main/resources/application.yaml must resolve to a KafkaTopic CR
+    (metadata.name or spec.topicName) under openbank-infra/gitops.
+  # EMPTY, and that is the point. An entry needs a reason, and the check fails on a stale
+  # declaration in BOTH directions — a name listed here that IS declared is itself reported —
+  # so a temporary exception cannot quietly become permanent. Same idiom as the pact gate's
+  # KNOWN_UNCOVERED and the runblocking_allowlist above.
+  allowed_absent: []
+  # The check ships with a --selftest that feeds it inputs it MUST flag and inputs it must
+  # NOT, run on every CI invocation: once the fleet is clean the flagging branch would
+  # otherwise never execute again, and a gate that has only ever passed is unfalsified.
+  ci_producer: ".github/scripts/check-kafka-topics-exist.py"
+
 # ---------------------------------------------------------------------------------------
 # Vulnerability-management lifecycle SLAs (ADR-0030 D1). Detection -> closure, in days.
 # ---------------------------------------------------------------------------------------


### PR DESCRIPTION
The follow-up #2629 promised. CLAUDE.md's knowledge-capture routing says a hard, checkable rule belongs in **`rules.yaml` AND a CI guard**, so it is enforced rather than merely documented. #2629 shipped the guard and deliberately left the registration out: editing `rules.yaml` restamps every OPA bundle, and #2247 was in flight across 38 governance files. #2247 has merged, the runway is clear.

## The rule

Every dotted topic name a service references must resolve to a `KafkaTopic` CR in gitops.

A Kafka consumer subscribed to a topic that **does not exist** does not error. It joins its consumer group, reports healthy, and receives nothing — forever. No runtime signal can tell it apart from a topic with no traffic: pod ready, group joined, lag zero, metrics flat. `openbank-analytics-sink` sat that way on `openbank.account.events` and `openbank.transaction.events`, neither of which has ever existed, and **no `ACCOUNT_OPENED` or `TRANSACTION` row ever reached `bronze_events`** (#2598).

`allowed_absent` is **empty**, and the check reports a stale entry in **both** directions — a name listed there that *is* declared gets flagged too. Same idiom as the pact gate's `KNOWN_UNCOVERED` and `scheduled_methods.runblocking_allowlist` directly above it: an exception cannot quietly become permanent.

## Diff shape

66 files: `rules.yaml` + **37 regenerated OPA bundles** and their pod-roll annotations. All generated — none hand-edited.

## Process, because this is the PR shape that goes wrong

| Step | Why it matters here |
|---|---|
| Bundle regeneration was the **last** step before the commit | #2457: idempotency only proves the generators are stable against whatever `rules.yaml` said *at that moment*. A later edit strands all 37 and the OPA gate goes red on every one. |
| Verified **idempotent** — a second full run changed nothing | |
| Gate re-run on the regenerated tree | `selftest OK`, 45 declared / 35 referenced / **0 unresolved** |
| Runway re-checked for competing governance PRs **immediately before** regenerating | not only at the start — a competing PR opening mid-work is the failure mode |
| yamllint finding **sets** diffed vs `origin/main` | CI does not lint this file, and SnakeYAML silently keeps only the **last** of a duplicated key. Identical except `line-length` 1077 → 1104; the added lines sit at the file's own median width (87 vs 86), so that is house style, not a regression. No duplicate top-level key. |

This PR has a short shelf life by construction — any competing `rules.yaml` or `.rego` change will conflict it. Auto-merge armed.

Refs #2598, #2629