### PR TITLE
ci(governance): a service that disables the scheduler in tests must exercise it somewhere

### DIFF
--- a/.github/scripts/check-scheduler-exercised.py
+++ b/.github/scripts/check-scheduler-exercised.py
@@ -1,0 +1,190 @@
+#!/usr/bin/env python3
+# SPDX-License-Identifier: Apache-2.0
+"""A service that disables the scheduler in tests must exercise it in at least one test.
+
+Why this exists (issue #2204, #2187)
+------------------------------------
+`quarkus.scheduler.enabled: false` under `%test` is a reasonable default — it stops crons
+firing during unrelated tests. Its cost is that the scheduler class becomes structurally
+invisible: what remains is direct method calls, and a direct call SUPPLIES THE VERY VERT.X
+CONTEXT THE REAL SCHEDULER DOES NOT. A test that calls `scheduler.sweep()` therefore passes
+against code that can never work as a cron.
+
+That is not hypothetical. #2187 found five `@Scheduled` methods — three money-path — that had
+**never executed**, in services whose tests were green throughout: a plain (non-`suspend`)
+`@Scheduled` body of `runBlocking { … }` throws `HR000068` on the first reactive Panache call
+and aborts, silently. `check-no-runblocking-in-scheduled.py` now catches that ONE defect shape.
+It cannot catch the next one. Only running the real cron can.
+
+So the rule is about the test, not the code: if a service disables the scheduler under `%test`
+AND has an `@Scheduled` method, some test must turn it back on. The fixes for #2187 did exactly
+that — `LedgerSchedulerVertxContextIT`, `BillingCycleSweepVertxContextIT`,
+`StandingOrderExecutionSweepIT` set `quarkus.scheduler.enabled=true` in a `@TestProfile` and
+shrink the cron expression.
+
+Detection is deliberately narrow
+--------------------------------
+A test counts only if it sets `quarkus.scheduler.enabled` to `true`. An earlier, looser sweep
+for the string `scheduler.enabled` scored `openbank-card-issuance-service` as covered on
+`scheduler(enabled = false).enforceRetention()` — a direct method call with an unrelated
+feature flag, i.e. precisely the shape this check exists to reject. Comments are stripped for
+the same reason: prose describing the setting is not the setting.
+
+Usage:  check-scheduler-exercised.py [--enforce] [--selftest]
+Advisory by default (repo convention). BASELINE holds the services that predate the rule; it
+can only shrink, and a stale entry — a service that now IS covered — is itself reported.
+"""
+
+from __future__ import annotations
+
+import argparse
+import pathlib
+import re
+import sys
+
+REPO = pathlib.Path(__file__).resolve().parents[2]
+
+# The scheduler turned back ON, in any of the spellings a @TestProfile uses.
+REENABLES = re.compile(
+    r"""["']quarkus\.scheduler\.enabled["']\s*(?:to|=|:)\s*["']true["']"""
+    r"""|%test\.quarkus\.scheduler\.enabled\s*[:=]\s*true""",
+)
+DISABLED_NESTED = re.compile(r"scheduler\s*:\s*\n\s+enabled\s*:\s*false")
+DISABLED_FLAT = re.compile(r"%test\.quarkus\.scheduler\.enabled\s*[:=]\s*false")
+TEST_BLOCK = re.compile(r'^"?%test"?\s*:\s*\n(.*?)(?=^\S|\Z)', re.M | re.S)
+
+# Services with a @Scheduled method that disable the scheduler in tests and do not re-enable it
+# anywhere. Measured 2026-07-26 (#2204). This list may only SHRINK.
+BASELINE = {
+    "openbank-aml-service",
+    "openbank-balance-service",
+    "openbank-card-issuance-service",
+    "openbank-interest-service",
+    "openbank-notification-service",
+    "openbank-onboarding-service",
+    "openbank-sanctions-service",
+    "openbank-sdd-service",
+    "openbank-statement-service",
+}
+
+
+def strip_comments(text: str) -> str:
+    return "\n".join(re.sub(r"#.*", "", line) for line in text.splitlines())
+
+
+def strip_kt_comments(text: str) -> str:
+    text = re.sub(r"//.*", "", text)
+    # Kotlin block comments NEST; a non-greedy /* ... */ closes early on a KDoc containing `/*`.
+    out, depth, i = [], 0, 0
+    while i < len(text):
+        if text.startswith("/*", i):
+            depth += 1
+            i += 2
+        elif text.startswith("*/", i) and depth:
+            depth -= 1
+            i += 2
+        else:
+            if not depth:
+                out.append(text[i])
+            i += 1
+    return "".join(out)
+
+
+def scan() -> tuple[set[str], set[str]]:
+    """(services that disable it and have @Scheduled, services whose tests re-enable it)"""
+    disables_with_scheduled, reenables = set(), set()
+    for svc_dir in sorted(REPO.glob("openbank-*/")):
+        svc = svc_dir.name
+        app = svc_dir / "src/main/resources/application.yaml"
+        if not app.is_file():
+            continue
+        try:
+            conf = strip_comments(app.read_text(encoding="utf-8"))
+        except (OSError, UnicodeDecodeError):
+            continue
+        block = TEST_BLOCK.search(conf)
+        disabled = bool(DISABLED_FLAT.search(conf)) or bool(block and DISABLED_NESTED.search(block.group(1)))
+        if not disabled:
+            continue
+        main_src = svc_dir / "src/main"
+        if not any("@Scheduled" in p.read_text(encoding="utf-8", errors="ignore")
+                   for p in main_src.rglob("*.kt")):
+            continue  # nothing to exercise
+        disables_with_scheduled.add(svc)
+        test_src = svc_dir / "src/test"
+        if any(REENABLES.search(strip_kt_comments(p.read_text(encoding="utf-8", errors="ignore")))
+               for p in test_src.rglob("*.kt")):
+            reenables.add(svc)
+    return disables_with_scheduled, reenables
+
+
+def selftest() -> int:
+    """The rule's own examples, both directions — a gate that only ever passes is unfalsified."""
+    ok = True
+    cases = [
+        ('"quarkus.scheduler.enabled" to "true"', True, "the @TestProfile idiom the #2187 fixes use"),
+        ("%test.quarkus.scheduler.enabled=true", True, "the flat spelling"),
+        ("scheduler(enabled = false).enforceRetention()", False,
+         "a direct call with an unrelated flag — the card-issuance false positive"),
+        ('// sets "quarkus.scheduler.enabled" to "true" one day', False, "prose is not the setting"),
+    ]
+    for src, want, why in cases:
+        got = bool(REENABLES.search(strip_kt_comments(src)))
+        if got != want:
+            print(f"selftest FAIL: {src!r} -> {got}, want {want} ({why})")
+            ok = False
+    disabled, _ = scan()
+    for must in ("openbank-ledger-service", "openbank-billing-service"):
+        if must not in disabled:
+            print(f"selftest FAIL: {must} disables the scheduler per #2204 but the scan missed it")
+            ok = False
+    if not ok:
+        return 1
+    print(f"selftest ok: {len(cases)} pattern cases both directions + the two services #2204 names")
+    return 0
+
+
+def main() -> int:
+    ap = argparse.ArgumentParser()
+    ap.add_argument("--enforce", action="store_true")
+    ap.add_argument("--selftest", action="store_true")
+    args = ap.parse_args()
+    if args.selftest:
+        return selftest()
+
+    disabled, reenabled = scan()
+    if not disabled:
+        print("::error::check-scheduler-exercised: found no service disabling the scheduler — "
+              "the scan is broken, not the fleet clean.")
+        return 1
+
+    uncovered = disabled - reenabled
+    print(f"check-scheduler-exercised: {len(disabled)} service(s) disable the scheduler under %test "
+          f"and have @Scheduled; {len(reenabled)} exercise it in a test.")
+
+    fixed = BASELINE - uncovered
+    if fixed:
+        print("::warning::check-scheduler-exercised: BASELINE is stale — these now exercise the "
+              f"scheduler and must be removed from it: {', '.join(sorted(fixed))}")
+
+    new = uncovered - BASELINE
+    for svc in sorted(uncovered):
+        print(f"  {'NEW  ' if svc in new else 'known'}  {svc}")
+
+    if not new:
+        return 0
+    detail = (
+        "A service disabling the scheduler under %test with no test that re-enables it has a "
+        "@Scheduled method NOTHING has ever run as a cron. A direct method call cannot substitute: "
+        "it supplies the Vert.x context the scheduler does not, so it passes against code that can "
+        "never work (#2187 found five such jobs, three money-path, that had never executed). Add a "
+        "@TestProfile setting quarkus.scheduler.enabled=true with a shrunken cron, as "
+        "LedgerSchedulerVertxContextIT does."
+    )
+    marker = "error" if args.enforce else "warning"
+    print(f"::{marker}::check-scheduler-exercised: {len(new)} service(s) NOT in the baseline. {detail}")
+    return 1 if args.enforce else 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -667,6 +667,18 @@ jobs:
       - name: "Kafka topic existence (issue #2598, enforced)"
         run: python3 .github/scripts/check-kafka-topics-exist.py --enforce
 
+      # issue #2204 (the structural gap #2187 closed with). `quarkus.scheduler.enabled: false` under
+      # %test leaves only DIRECT method calls, and a direct call supplies the very Vert.x context the
+      # real scheduler does not — so it passes against a @Scheduled body that can never work as a
+      # cron. #2187 found five such jobs, three money-path, that had NEVER executed while their tests
+      # were green. check-no-runblocking-in-scheduled.py catches that one defect shape; only running
+      # the real cron catches the next one. Ratchet, not a wall: 9 services predate the rule and are
+      # baselined, the list may only shrink, and a stale entry is reported too.
+      - name: "Scheduler-exercised self-test (issue #2204)"
+        run: python3 .github/scripts/check-scheduler-exercised.py --selftest
+      - name: "Scheduler exercised in tests (issue #2204, enforced)"
+        run: python3 .github/scripts/check-scheduler-exercised.py --enforce
+
       # issue #2412 (third residual). openbank-mcp-service masks PII on every tool result
       # UNCONDITIONALLY — deliberately, since a switch that can turn a declared control off is how
       # the declaration became fiction to begin with. The cost of that choice is that the charter

--- a/openbank-infra/gitops/components/accounts/account-opa-bundle.yaml
+++ b/openbank-infra/gitops/components/accounts/account-opa-bundle.yaml
@@ -9,7 +9,7 @@ metadata:
     app.kubernetes.io/name: account-service
     app.kubernetes.io/part-of: accounts
   annotations:
-    openbank.tech/policy-checksum: "3cff4ee22a307a62"
+    openbank.tech/policy-checksum: "2b543bd957b65738"
 data:
   rest.rego: |
     # SPDX-License-Identifier: Apache-2.0
@@ -2816,6 +2816,28 @@ data:
             jdbc-postgresql (build.gradle.kts) — it has no OLTP datasource to reach. The
             reconciliation reads the warehouse and the WORM archive over blocking clients.
       ci_producer: ".github/scripts/check-no-runblocking-in-scheduled.py"
+
+      # The structural reason the HR000068 class was invisible (#2204). `quarkus.scheduler.enabled:
+      # false` under %test is a reasonable default — it stops crons firing during unrelated tests —
+      # but it leaves only DIRECT method calls, and a direct call supplies the very Vert.x context
+      # the scheduler does not. So `scheduler.sweep()` in a test passes against a body that can
+      # never work as a cron. The guard above catches ONE defect shape; only running the real cron
+      # catches the next.
+      #
+      # Rule: a service that disables the scheduler under %test AND has an @Scheduled method must
+      # have at least one test that sets `quarkus.scheduler.enabled=true` (a @TestProfile with a
+      # shrunken cron, as LedgerSchedulerVertxContextIT / BillingCycleSweepVertxContextIT do).
+      #
+      # Measured 2026-07-26: 11 services qualify, only 2 exercise it. The other 9 are baselined in
+      # the producer — the list may only SHRINK, and a stale entry (a service that now IS covered)
+      # is reported too, so the debt cannot quietly become permanent.
+      #
+      # Detection is narrow on purpose: only `quarkus.scheduler.enabled` set to `true` counts. A
+      # looser sweep for the string `scheduler.enabled` scored card-issuance as covered on
+      # `scheduler(enabled = false).enforceRetention()` — a direct call with an unrelated feature
+      # flag, i.e. exactly what this rule rejects.
+      scheduler_exercised_in_tests: true
+      scheduler_exercised_ci_producer: ".github/scripts/check-scheduler-exercised.py"
 
 
     # ---------------------------------------------------------------------------------------

--- a/openbank-infra/gitops/components/accounts/account-service.yaml
+++ b/openbank-infra/gitops/components/accounts/account-service.yaml
@@ -37,7 +37,7 @@ spec:
       annotations:
         # Rolls the pod when the OPA bundle changes — subPath mounts do NOT hot-reload.
         # Kept in sync by gen-account-opa-bundle.sh (do not hand-edit).
-        openbank.tech/policy-checksum: "3cff4ee22a307a62"
+        openbank.tech/policy-checksum: "2b543bd957b65738"
     spec:
       securityContext:
         runAsNonRoot: true

--- a/openbank-infra/gitops/components/aml/aml-opa-bundle.yaml
+++ b/openbank-infra/gitops/components/aml/aml-opa-bundle.yaml
@@ -9,7 +9,7 @@ metadata:
     app.kubernetes.io/name: aml-service
     app.kubernetes.io/part-of: aml
   annotations:
-    openbank.tech/policy-checksum: "b65a1ae2bd8a08b5"
+    openbank.tech/policy-checksum: "f1f8b2661c7be34c"
 data:
   rest.rego: |
     # SPDX-License-Identifier: Apache-2.0
@@ -2789,6 +2789,28 @@ data:
             jdbc-postgresql (build.gradle.kts) — it has no OLTP datasource to reach. The
             reconciliation reads the warehouse and the WORM archive over blocking clients.
       ci_producer: ".github/scripts/check-no-runblocking-in-scheduled.py"
+
+      # The structural reason the HR000068 class was invisible (#2204). `quarkus.scheduler.enabled:
+      # false` under %test is a reasonable default — it stops crons firing during unrelated tests —
+      # but it leaves only DIRECT method calls, and a direct call supplies the very Vert.x context
+      # the scheduler does not. So `scheduler.sweep()` in a test passes against a body that can
+      # never work as a cron. The guard above catches ONE defect shape; only running the real cron
+      # catches the next.
+      #
+      # Rule: a service that disables the scheduler under %test AND has an @Scheduled method must
+      # have at least one test that sets `quarkus.scheduler.enabled=true` (a @TestProfile with a
+      # shrunken cron, as LedgerSchedulerVertxContextIT / BillingCycleSweepVertxContextIT do).
+      #
+      # Measured 2026-07-26: 11 services qualify, only 2 exercise it. The other 9 are baselined in
+      # the producer — the list may only SHRINK, and a stale entry (a service that now IS covered)
+      # is reported too, so the debt cannot quietly become permanent.
+      #
+      # Detection is narrow on purpose: only `quarkus.scheduler.enabled` set to `true` counts. A
+      # looser sweep for the string `scheduler.enabled` scored card-issuance as covered on
+      # `scheduler(enabled = false).enforceRetention()` — a direct call with an unrelated feature
+      # flag, i.e. exactly what this rule rejects.
+      scheduler_exercised_in_tests: true
+      scheduler_exercised_ci_producer: ".github/scripts/check-scheduler-exercised.py"
 
 
     # ---------------------------------------------------------------------------------------

--- a/openbank-infra/gitops/components/aml/aml-service.yaml
+++ b/openbank-infra/gitops/components/aml/aml-service.yaml
@@ -22,7 +22,7 @@ spec:
       annotations:
         # Rolls the pod when the OPA bundle changes (subPath mounts do not hot-reload).
         # Kept in sync by gen-aml-opa-bundle.sh (do not hand-edit).
-        openbank.tech/policy-checksum: "b65a1ae2bd8a08b5"
+        openbank.tech/policy-checksum: "f1f8b2661c7be34c"
     spec:
       securityContext:
         runAsNonRoot: true

--- a/openbank-infra/gitops/components/anacredit/anacredit-opa-bundle.yaml
+++ b/openbank-infra/gitops/components/anacredit/anacredit-opa-bundle.yaml
@@ -9,7 +9,7 @@ metadata:
     app.kubernetes.io/name: anacredit-service
     app.kubernetes.io/part-of: anacredit
   annotations:
-    openbank.tech/policy-checksum: "a11d9c01b3a98c0d"
+    openbank.tech/policy-checksum: "c236e6b79a41adea"
 data:
   rest.rego: |
     # SPDX-License-Identifier: Apache-2.0
@@ -2759,6 +2759,28 @@ data:
             jdbc-postgresql (build.gradle.kts) — it has no OLTP datasource to reach. The
             reconciliation reads the warehouse and the WORM archive over blocking clients.
       ci_producer: ".github/scripts/check-no-runblocking-in-scheduled.py"
+
+      # The structural reason the HR000068 class was invisible (#2204). `quarkus.scheduler.enabled:
+      # false` under %test is a reasonable default — it stops crons firing during unrelated tests —
+      # but it leaves only DIRECT method calls, and a direct call supplies the very Vert.x context
+      # the scheduler does not. So `scheduler.sweep()` in a test passes against a body that can
+      # never work as a cron. The guard above catches ONE defect shape; only running the real cron
+      # catches the next.
+      #
+      # Rule: a service that disables the scheduler under %test AND has an @Scheduled method must
+      # have at least one test that sets `quarkus.scheduler.enabled=true` (a @TestProfile with a
+      # shrunken cron, as LedgerSchedulerVertxContextIT / BillingCycleSweepVertxContextIT do).
+      #
+      # Measured 2026-07-26: 11 services qualify, only 2 exercise it. The other 9 are baselined in
+      # the producer — the list may only SHRINK, and a stale entry (a service that now IS covered)
+      # is reported too, so the debt cannot quietly become permanent.
+      #
+      # Detection is narrow on purpose: only `quarkus.scheduler.enabled` set to `true` counts. A
+      # looser sweep for the string `scheduler.enabled` scored card-issuance as covered on
+      # `scheduler(enabled = false).enforceRetention()` — a direct call with an unrelated feature
+      # flag, i.e. exactly what this rule rejects.
+      scheduler_exercised_in_tests: true
+      scheduler_exercised_ci_producer: ".github/scripts/check-scheduler-exercised.py"
 
 
     # ---------------------------------------------------------------------------------------

--- a/openbank-infra/gitops/components/anacredit/anacredit-service.yaml
+++ b/openbank-infra/gitops/components/anacredit/anacredit-service.yaml
@@ -32,7 +32,7 @@ spec:
       annotations:
         # Rolls the pods when the OPA bundle changes — subPath mounts do NOT hot-reload.
         # Kept in sync by gen-anacredit-opa-bundle.sh (do not hand-edit).
-        openbank.tech/policy-checksum: "a11d9c01b3a98c0d"
+        openbank.tech/policy-checksum: "c236e6b79a41adea"
     spec:
       securityContext:
         runAsNonRoot: true

--- a/openbank-infra/gitops/components/ap2/ap2-opa-bundle.yaml
+++ b/openbank-infra/gitops/components/ap2/ap2-opa-bundle.yaml
@@ -9,7 +9,7 @@ metadata:
     app.kubernetes.io/name: mcp-service
     app.kubernetes.io/part-of: platform
   annotations:
-    openbank.tech/policy-checksum: "465bc216e2560311"
+    openbank.tech/policy-checksum: "4673877eb208bc64"
 data:
   rest.rego: |
     # SPDX-License-Identifier: Apache-2.0
@@ -2727,6 +2727,28 @@ data:
             jdbc-postgresql (build.gradle.kts) — it has no OLTP datasource to reach. The
             reconciliation reads the warehouse and the WORM archive over blocking clients.
       ci_producer: ".github/scripts/check-no-runblocking-in-scheduled.py"
+
+      # The structural reason the HR000068 class was invisible (#2204). `quarkus.scheduler.enabled:
+      # false` under %test is a reasonable default — it stops crons firing during unrelated tests —
+      # but it leaves only DIRECT method calls, and a direct call supplies the very Vert.x context
+      # the scheduler does not. So `scheduler.sweep()` in a test passes against a body that can
+      # never work as a cron. The guard above catches ONE defect shape; only running the real cron
+      # catches the next.
+      #
+      # Rule: a service that disables the scheduler under %test AND has an @Scheduled method must
+      # have at least one test that sets `quarkus.scheduler.enabled=true` (a @TestProfile with a
+      # shrunken cron, as LedgerSchedulerVertxContextIT / BillingCycleSweepVertxContextIT do).
+      #
+      # Measured 2026-07-26: 11 services qualify, only 2 exercise it. The other 9 are baselined in
+      # the producer — the list may only SHRINK, and a stale entry (a service that now IS covered)
+      # is reported too, so the debt cannot quietly become permanent.
+      #
+      # Detection is narrow on purpose: only `quarkus.scheduler.enabled` set to `true` counts. A
+      # looser sweep for the string `scheduler.enabled` scored card-issuance as covered on
+      # `scheduler(enabled = false).enforceRetention()` — a direct call with an unrelated feature
+      # flag, i.e. exactly what this rule rejects.
+      scheduler_exercised_in_tests: true
+      scheduler_exercised_ci_producer: ".github/scripts/check-scheduler-exercised.py"
 
 
     # ---------------------------------------------------------------------------------------

--- a/openbank-infra/gitops/components/ap2/ap2-service.yaml
+++ b/openbank-infra/gitops/components/ap2/ap2-service.yaml
@@ -30,7 +30,7 @@ spec:
       annotations:
         # Roll the pod when the OPA policy bundle changes (subPath mounts don't hot-reload).
         # Kept in sync by gen-ap2-opa-bundle.sh (do not hand-edit).
-        openbank.tech/policy-checksum: "465bc216e2560311"
+        openbank.tech/policy-checksum: "4673877eb208bc64"
     spec:
       securityContext:
         runAsNonRoot: true

--- a/openbank-infra/gitops/components/audit/audit-opa-bundle.yaml
+++ b/openbank-infra/gitops/components/audit/audit-opa-bundle.yaml
@@ -9,7 +9,7 @@ metadata:
     app.kubernetes.io/name: audit-service
     app.kubernetes.io/part-of: audit
   annotations:
-    openbank.tech/policy-checksum: "e30c805fc9b6a6ba"
+    openbank.tech/policy-checksum: "42c911d486f47cb9"
 data:
   rest.rego: |
     # SPDX-License-Identifier: Apache-2.0
@@ -2771,6 +2771,28 @@ data:
             jdbc-postgresql (build.gradle.kts) — it has no OLTP datasource to reach. The
             reconciliation reads the warehouse and the WORM archive over blocking clients.
       ci_producer: ".github/scripts/check-no-runblocking-in-scheduled.py"
+
+      # The structural reason the HR000068 class was invisible (#2204). `quarkus.scheduler.enabled:
+      # false` under %test is a reasonable default — it stops crons firing during unrelated tests —
+      # but it leaves only DIRECT method calls, and a direct call supplies the very Vert.x context
+      # the scheduler does not. So `scheduler.sweep()` in a test passes against a body that can
+      # never work as a cron. The guard above catches ONE defect shape; only running the real cron
+      # catches the next.
+      #
+      # Rule: a service that disables the scheduler under %test AND has an @Scheduled method must
+      # have at least one test that sets `quarkus.scheduler.enabled=true` (a @TestProfile with a
+      # shrunken cron, as LedgerSchedulerVertxContextIT / BillingCycleSweepVertxContextIT do).
+      #
+      # Measured 2026-07-26: 11 services qualify, only 2 exercise it. The other 9 are baselined in
+      # the producer — the list may only SHRINK, and a stale entry (a service that now IS covered)
+      # is reported too, so the debt cannot quietly become permanent.
+      #
+      # Detection is narrow on purpose: only `quarkus.scheduler.enabled` set to `true` counts. A
+      # looser sweep for the string `scheduler.enabled` scored card-issuance as covered on
+      # `scheduler(enabled = false).enforceRetention()` — a direct call with an unrelated feature
+      # flag, i.e. exactly what this rule rejects.
+      scheduler_exercised_in_tests: true
+      scheduler_exercised_ci_producer: ".github/scripts/check-scheduler-exercised.py"
 
 
     # ---------------------------------------------------------------------------------------

--- a/openbank-infra/gitops/components/audit/audit-service.yaml
+++ b/openbank-infra/gitops/components/audit/audit-service.yaml
@@ -22,7 +22,7 @@ spec:
       annotations:
         # Rolls the pod when the OPA bundle changes (subPath mounts do not hot-reload).
         # Kept in sync by gen-audit-opa-bundle.sh (do not hand-edit).
-        openbank.tech/policy-checksum: "e30c805fc9b6a6ba"
+        openbank.tech/policy-checksum: "42c911d486f47cb9"
     spec:
       securityContext:
         runAsNonRoot: true

--- a/openbank-infra/gitops/components/balances/balance-opa-bundle.yaml
+++ b/openbank-infra/gitops/components/balances/balance-opa-bundle.yaml
@@ -9,7 +9,7 @@ metadata:
     app.kubernetes.io/name: balance-service
     app.kubernetes.io/part-of: balances
   annotations:
-    openbank.tech/policy-checksum: "94b91abed915565b"
+    openbank.tech/policy-checksum: "09dc776342295dca"
 data:
   rest.rego: |
     # SPDX-License-Identifier: Apache-2.0
@@ -2860,6 +2860,28 @@ data:
             jdbc-postgresql (build.gradle.kts) — it has no OLTP datasource to reach. The
             reconciliation reads the warehouse and the WORM archive over blocking clients.
       ci_producer: ".github/scripts/check-no-runblocking-in-scheduled.py"
+
+      # The structural reason the HR000068 class was invisible (#2204). `quarkus.scheduler.enabled:
+      # false` under %test is a reasonable default — it stops crons firing during unrelated tests —
+      # but it leaves only DIRECT method calls, and a direct call supplies the very Vert.x context
+      # the scheduler does not. So `scheduler.sweep()` in a test passes against a body that can
+      # never work as a cron. The guard above catches ONE defect shape; only running the real cron
+      # catches the next.
+      #
+      # Rule: a service that disables the scheduler under %test AND has an @Scheduled method must
+      # have at least one test that sets `quarkus.scheduler.enabled=true` (a @TestProfile with a
+      # shrunken cron, as LedgerSchedulerVertxContextIT / BillingCycleSweepVertxContextIT do).
+      #
+      # Measured 2026-07-26: 11 services qualify, only 2 exercise it. The other 9 are baselined in
+      # the producer — the list may only SHRINK, and a stale entry (a service that now IS covered)
+      # is reported too, so the debt cannot quietly become permanent.
+      #
+      # Detection is narrow on purpose: only `quarkus.scheduler.enabled` set to `true` counts. A
+      # looser sweep for the string `scheduler.enabled` scored card-issuance as covered on
+      # `scheduler(enabled = false).enforceRetention()` — a direct call with an unrelated feature
+      # flag, i.e. exactly what this rule rejects.
+      scheduler_exercised_in_tests: true
+      scheduler_exercised_ci_producer: ".github/scripts/check-scheduler-exercised.py"
 
 
     # ---------------------------------------------------------------------------------------

--- a/openbank-infra/gitops/components/balances/balance-service.yaml
+++ b/openbank-infra/gitops/components/balances/balance-service.yaml
@@ -34,7 +34,7 @@ spec:
       annotations:
         # Rolls the pods when the OPA bundle changes — subPath mounts do NOT hot-reload.
         # Kept in sync by gen-balance-opa-bundle.sh (do not hand-edit).
-        openbank.tech/policy-checksum: "94b91abed915565b"
+        openbank.tech/policy-checksum: "09dc776342295dca"
     spec:
       securityContext:
         runAsNonRoot: true

--- a/openbank-infra/gitops/components/billing/billing-opa-bundle.yaml
+++ b/openbank-infra/gitops/components/billing/billing-opa-bundle.yaml
@@ -9,7 +9,7 @@ metadata:
     app.kubernetes.io/name: billing-service
     app.kubernetes.io/part-of: billing
   annotations:
-    openbank.tech/policy-checksum: "bc9ac50a32576806"
+    openbank.tech/policy-checksum: "fb59c01ab81d95c4"
 data:
   rest.rego: |
     # SPDX-License-Identifier: Apache-2.0
@@ -2765,6 +2765,28 @@ data:
             jdbc-postgresql (build.gradle.kts) — it has no OLTP datasource to reach. The
             reconciliation reads the warehouse and the WORM archive over blocking clients.
       ci_producer: ".github/scripts/check-no-runblocking-in-scheduled.py"
+
+      # The structural reason the HR000068 class was invisible (#2204). `quarkus.scheduler.enabled:
+      # false` under %test is a reasonable default — it stops crons firing during unrelated tests —
+      # but it leaves only DIRECT method calls, and a direct call supplies the very Vert.x context
+      # the scheduler does not. So `scheduler.sweep()` in a test passes against a body that can
+      # never work as a cron. The guard above catches ONE defect shape; only running the real cron
+      # catches the next.
+      #
+      # Rule: a service that disables the scheduler under %test AND has an @Scheduled method must
+      # have at least one test that sets `quarkus.scheduler.enabled=true` (a @TestProfile with a
+      # shrunken cron, as LedgerSchedulerVertxContextIT / BillingCycleSweepVertxContextIT do).
+      #
+      # Measured 2026-07-26: 11 services qualify, only 2 exercise it. The other 9 are baselined in
+      # the producer — the list may only SHRINK, and a stale entry (a service that now IS covered)
+      # is reported too, so the debt cannot quietly become permanent.
+      #
+      # Detection is narrow on purpose: only `quarkus.scheduler.enabled` set to `true` counts. A
+      # looser sweep for the string `scheduler.enabled` scored card-issuance as covered on
+      # `scheduler(enabled = false).enforceRetention()` — a direct call with an unrelated feature
+      # flag, i.e. exactly what this rule rejects.
+      scheduler_exercised_in_tests: true
+      scheduler_exercised_ci_producer: ".github/scripts/check-scheduler-exercised.py"
 
 
     # ---------------------------------------------------------------------------------------

--- a/openbank-infra/gitops/components/billing/billing-service.yaml
+++ b/openbank-infra/gitops/components/billing/billing-service.yaml
@@ -27,7 +27,7 @@ spec:
       annotations:
         # Rolls the pods when the OPA bundle changes — subPath mounts do NOT hot-reload.
         # Kept in sync by gen-billing-opa-bundle.sh (do not hand-edit).
-        openbank.tech/policy-checksum: "bc9ac50a32576806"
+        openbank.tech/policy-checksum: "fb59c01ab81d95c4"
     spec:
       securityContext:
         runAsNonRoot: true

--- a/openbank-infra/gitops/components/consent/consent-opa-bundle.yaml
+++ b/openbank-infra/gitops/components/consent/consent-opa-bundle.yaml
@@ -9,7 +9,7 @@ metadata:
     app.kubernetes.io/name: consent-service
     app.kubernetes.io/part-of: consent
   annotations:
-    openbank.tech/policy-checksum: "a559db71ac5033f5"
+    openbank.tech/policy-checksum: "aa283dbce7ef7152"
 data:
   rest.rego: |
     # SPDX-License-Identifier: Apache-2.0
@@ -2835,6 +2835,28 @@ data:
             jdbc-postgresql (build.gradle.kts) — it has no OLTP datasource to reach. The
             reconciliation reads the warehouse and the WORM archive over blocking clients.
       ci_producer: ".github/scripts/check-no-runblocking-in-scheduled.py"
+
+      # The structural reason the HR000068 class was invisible (#2204). `quarkus.scheduler.enabled:
+      # false` under %test is a reasonable default — it stops crons firing during unrelated tests —
+      # but it leaves only DIRECT method calls, and a direct call supplies the very Vert.x context
+      # the scheduler does not. So `scheduler.sweep()` in a test passes against a body that can
+      # never work as a cron. The guard above catches ONE defect shape; only running the real cron
+      # catches the next.
+      #
+      # Rule: a service that disables the scheduler under %test AND has an @Scheduled method must
+      # have at least one test that sets `quarkus.scheduler.enabled=true` (a @TestProfile with a
+      # shrunken cron, as LedgerSchedulerVertxContextIT / BillingCycleSweepVertxContextIT do).
+      #
+      # Measured 2026-07-26: 11 services qualify, only 2 exercise it. The other 9 are baselined in
+      # the producer — the list may only SHRINK, and a stale entry (a service that now IS covered)
+      # is reported too, so the debt cannot quietly become permanent.
+      #
+      # Detection is narrow on purpose: only `quarkus.scheduler.enabled` set to `true` counts. A
+      # looser sweep for the string `scheduler.enabled` scored card-issuance as covered on
+      # `scheduler(enabled = false).enforceRetention()` — a direct call with an unrelated feature
+      # flag, i.e. exactly what this rule rejects.
+      scheduler_exercised_in_tests: true
+      scheduler_exercised_ci_producer: ".github/scripts/check-scheduler-exercised.py"
 
 
     # ---------------------------------------------------------------------------------------

--- a/openbank-infra/gitops/components/consent/consent-service.yaml
+++ b/openbank-infra/gitops/components/consent/consent-service.yaml
@@ -28,7 +28,7 @@ spec:
       annotations:
         # Rolls the pods when the OPA bundle changes — subPath mounts do NOT hot-reload.
         # Kept in sync by gen-consent-opa-bundle.sh (do not hand-edit).
-        openbank.tech/policy-checksum: "a559db71ac5033f5"
+        openbank.tech/policy-checksum: "aa283dbce7ef7152"
     spec:
       securityContext:
         runAsNonRoot: true

--- a/openbank-infra/gitops/components/copilot/copilot-opa-bundle.yaml
+++ b/openbank-infra/gitops/components/copilot/copilot-opa-bundle.yaml
@@ -9,7 +9,7 @@ metadata:
     app.kubernetes.io/name: copilot-service
     app.kubernetes.io/part-of: platform
   annotations:
-    openbank.tech/policy-checksum: "d83f92196abd2945"
+    openbank.tech/policy-checksum: "a755849d16d870f4"
 data:
   rest.rego: |
     # SPDX-License-Identifier: Apache-2.0
@@ -2851,6 +2851,28 @@ data:
             jdbc-postgresql (build.gradle.kts) — it has no OLTP datasource to reach. The
             reconciliation reads the warehouse and the WORM archive over blocking clients.
       ci_producer: ".github/scripts/check-no-runblocking-in-scheduled.py"
+
+      # The structural reason the HR000068 class was invisible (#2204). `quarkus.scheduler.enabled:
+      # false` under %test is a reasonable default — it stops crons firing during unrelated tests —
+      # but it leaves only DIRECT method calls, and a direct call supplies the very Vert.x context
+      # the scheduler does not. So `scheduler.sweep()` in a test passes against a body that can
+      # never work as a cron. The guard above catches ONE defect shape; only running the real cron
+      # catches the next.
+      #
+      # Rule: a service that disables the scheduler under %test AND has an @Scheduled method must
+      # have at least one test that sets `quarkus.scheduler.enabled=true` (a @TestProfile with a
+      # shrunken cron, as LedgerSchedulerVertxContextIT / BillingCycleSweepVertxContextIT do).
+      #
+      # Measured 2026-07-26: 11 services qualify, only 2 exercise it. The other 9 are baselined in
+      # the producer — the list may only SHRINK, and a stale entry (a service that now IS covered)
+      # is reported too, so the debt cannot quietly become permanent.
+      #
+      # Detection is narrow on purpose: only `quarkus.scheduler.enabled` set to `true` counts. A
+      # looser sweep for the string `scheduler.enabled` scored card-issuance as covered on
+      # `scheduler(enabled = false).enforceRetention()` — a direct call with an unrelated feature
+      # flag, i.e. exactly what this rule rejects.
+      scheduler_exercised_in_tests: true
+      scheduler_exercised_ci_producer: ".github/scripts/check-scheduler-exercised.py"
 
 
     # ---------------------------------------------------------------------------------------

--- a/openbank-infra/gitops/components/copilot/copilot-service.yaml
+++ b/openbank-infra/gitops/components/copilot/copilot-service.yaml
@@ -29,7 +29,7 @@ spec:
       annotations:
         # Rolls the pod when the OPA bundle changes — subPath mounts do NOT hot-reload.
         # Kept in sync by gen-copilot-opa-bundle.sh (do not hand-edit).
-        openbank.tech/policy-checksum: "d83f92196abd2945"
+        openbank.tech/policy-checksum: "a755849d16d870f4"
     spec:
       securityContext:
         runAsNonRoot: true

--- a/openbank-infra/gitops/components/customer-edge/customer-edge-opa-bundle.yaml
+++ b/openbank-infra/gitops/components/customer-edge/customer-edge-opa-bundle.yaml
@@ -10,7 +10,7 @@ metadata:
     app.kubernetes.io/name: customer-edge
     app.kubernetes.io/part-of: customer-edge
   annotations:
-    openbank.tech/policy-checksum: "80f3ab7acfa9c205"
+    openbank.tech/policy-checksum: "e0f110332208803b"
 data:
   rest.rego: |
     # SPDX-License-Identifier: Apache-2.0
@@ -1950,6 +1950,28 @@ data:
             jdbc-postgresql (build.gradle.kts) — it has no OLTP datasource to reach. The
             reconciliation reads the warehouse and the WORM archive over blocking clients.
       ci_producer: ".github/scripts/check-no-runblocking-in-scheduled.py"
+
+      # The structural reason the HR000068 class was invisible (#2204). `quarkus.scheduler.enabled:
+      # false` under %test is a reasonable default — it stops crons firing during unrelated tests —
+      # but it leaves only DIRECT method calls, and a direct call supplies the very Vert.x context
+      # the scheduler does not. So `scheduler.sweep()` in a test passes against a body that can
+      # never work as a cron. The guard above catches ONE defect shape; only running the real cron
+      # catches the next.
+      #
+      # Rule: a service that disables the scheduler under %test AND has an @Scheduled method must
+      # have at least one test that sets `quarkus.scheduler.enabled=true` (a @TestProfile with a
+      # shrunken cron, as LedgerSchedulerVertxContextIT / BillingCycleSweepVertxContextIT do).
+      #
+      # Measured 2026-07-26: 11 services qualify, only 2 exercise it. The other 9 are baselined in
+      # the producer — the list may only SHRINK, and a stale entry (a service that now IS covered)
+      # is reported too, so the debt cannot quietly become permanent.
+      #
+      # Detection is narrow on purpose: only `quarkus.scheduler.enabled` set to `true` counts. A
+      # looser sweep for the string `scheduler.enabled` scored card-issuance as covered on
+      # `scheduler(enabled = false).enforceRetention()` — a direct call with an unrelated feature
+      # flag, i.e. exactly what this rule rejects.
+      scheduler_exercised_in_tests: true
+      scheduler_exercised_ci_producer: ".github/scripts/check-scheduler-exercised.py"
 
 
     # ---------------------------------------------------------------------------------------

--- a/openbank-infra/gitops/components/customer-edge/customer-edge.yaml
+++ b/openbank-infra/gitops/components/customer-edge/customer-edge.yaml
@@ -65,7 +65,7 @@ spec:
       annotations:
         # Rolls the pod when the OPA bundle changes — subPath mounts do NOT hot-reload.
         # Kept in sync by gen-customer-edge-opa-bundle.sh (do not hand-edit).
-        openbank.tech/policy-checksum: "80f3ab7acfa9c205"
+        openbank.tech/policy-checksum: "e0f110332208803b"
     spec:
       # Dedicated SA so EKS Pod Identity can hand the edge (and ONLY the edge) the
       # feedback-screenshots S3 role — ADR-0192, openbank-infra/aws/envs/sandbox-platform/

--- a/openbank-infra/gitops/components/dispute-service/dispute-opa-bundle.yaml
+++ b/openbank-infra/gitops/components/dispute-service/dispute-opa-bundle.yaml
@@ -9,7 +9,7 @@ metadata:
     app.kubernetes.io/name: dispute-service
     app.kubernetes.io/part-of: dispute
   annotations:
-    openbank.tech/policy-checksum: "caec3e0cc6a1b2f0"
+    openbank.tech/policy-checksum: "fdec386f7cb627b0"
 data:
   rest.rego: |
     # SPDX-License-Identifier: Apache-2.0
@@ -2901,6 +2901,28 @@ data:
             jdbc-postgresql (build.gradle.kts) — it has no OLTP datasource to reach. The
             reconciliation reads the warehouse and the WORM archive over blocking clients.
       ci_producer: ".github/scripts/check-no-runblocking-in-scheduled.py"
+
+      # The structural reason the HR000068 class was invisible (#2204). `quarkus.scheduler.enabled:
+      # false` under %test is a reasonable default — it stops crons firing during unrelated tests —
+      # but it leaves only DIRECT method calls, and a direct call supplies the very Vert.x context
+      # the scheduler does not. So `scheduler.sweep()` in a test passes against a body that can
+      # never work as a cron. The guard above catches ONE defect shape; only running the real cron
+      # catches the next.
+      #
+      # Rule: a service that disables the scheduler under %test AND has an @Scheduled method must
+      # have at least one test that sets `quarkus.scheduler.enabled=true` (a @TestProfile with a
+      # shrunken cron, as LedgerSchedulerVertxContextIT / BillingCycleSweepVertxContextIT do).
+      #
+      # Measured 2026-07-26: 11 services qualify, only 2 exercise it. The other 9 are baselined in
+      # the producer — the list may only SHRINK, and a stale entry (a service that now IS covered)
+      # is reported too, so the debt cannot quietly become permanent.
+      #
+      # Detection is narrow on purpose: only `quarkus.scheduler.enabled` set to `true` counts. A
+      # looser sweep for the string `scheduler.enabled` scored card-issuance as covered on
+      # `scheduler(enabled = false).enforceRetention()` — a direct call with an unrelated feature
+      # flag, i.e. exactly what this rule rejects.
+      scheduler_exercised_in_tests: true
+      scheduler_exercised_ci_producer: ".github/scripts/check-scheduler-exercised.py"
 
 
     # ---------------------------------------------------------------------------------------

--- a/openbank-infra/gitops/components/dispute-service/dispute-service.yaml
+++ b/openbank-infra/gitops/components/dispute-service/dispute-service.yaml
@@ -15,7 +15,7 @@ spec:
       annotations:
         # Rolls the pod when the OPA bundle changes — subPath mounts do NOT hot-reload.
         # Kept in sync by gen-dispute-opa-bundle.sh (do not hand-edit).
-        openbank.tech/policy-checksum: "caec3e0cc6a1b2f0"
+        openbank.tech/policy-checksum: "fdec386f7cb627b0"
       labels: {app.kubernetes.io/name: dispute-service, app.kubernetes.io/part-of: dispute}
     spec:
       securityContext:

--- a/openbank-infra/gitops/components/document-service/document-service-opa-bundle.yaml
+++ b/openbank-infra/gitops/components/document-service/document-service-opa-bundle.yaml
@@ -10,7 +10,7 @@ metadata:
     app.kubernetes.io/name: document-service
     app.kubernetes.io/part-of: documents
   annotations:
-    openbank.tech/policy-checksum: "80f3ab7acfa9c205"
+    openbank.tech/policy-checksum: "e0f110332208803b"
 data:
   rest.rego: |
     # SPDX-License-Identifier: Apache-2.0
@@ -1950,6 +1950,28 @@ data:
             jdbc-postgresql (build.gradle.kts) — it has no OLTP datasource to reach. The
             reconciliation reads the warehouse and the WORM archive over blocking clients.
       ci_producer: ".github/scripts/check-no-runblocking-in-scheduled.py"
+
+      # The structural reason the HR000068 class was invisible (#2204). `quarkus.scheduler.enabled:
+      # false` under %test is a reasonable default — it stops crons firing during unrelated tests —
+      # but it leaves only DIRECT method calls, and a direct call supplies the very Vert.x context
+      # the scheduler does not. So `scheduler.sweep()` in a test passes against a body that can
+      # never work as a cron. The guard above catches ONE defect shape; only running the real cron
+      # catches the next.
+      #
+      # Rule: a service that disables the scheduler under %test AND has an @Scheduled method must
+      # have at least one test that sets `quarkus.scheduler.enabled=true` (a @TestProfile with a
+      # shrunken cron, as LedgerSchedulerVertxContextIT / BillingCycleSweepVertxContextIT do).
+      #
+      # Measured 2026-07-26: 11 services qualify, only 2 exercise it. The other 9 are baselined in
+      # the producer — the list may only SHRINK, and a stale entry (a service that now IS covered)
+      # is reported too, so the debt cannot quietly become permanent.
+      #
+      # Detection is narrow on purpose: only `quarkus.scheduler.enabled` set to `true` counts. A
+      # looser sweep for the string `scheduler.enabled` scored card-issuance as covered on
+      # `scheduler(enabled = false).enforceRetention()` — a direct call with an unrelated feature
+      # flag, i.e. exactly what this rule rejects.
+      scheduler_exercised_in_tests: true
+      scheduler_exercised_ci_producer: ".github/scripts/check-scheduler-exercised.py"
 
 
     # ---------------------------------------------------------------------------------------

--- a/openbank-infra/gitops/components/document-service/document-service-service.yaml
+++ b/openbank-infra/gitops/components/document-service/document-service-service.yaml
@@ -43,7 +43,7 @@ spec:
       annotations:
         # Rolls the pods when the OPA bundle changes — subPath mounts do NOT hot-reload.
         # Kept in sync by gen-document-service-opa-bundle.sh (do not hand-edit).
-        openbank.tech/policy-checksum: "80f3ab7acfa9c205"
+        openbank.tech/policy-checksum: "e0f110332208803b"
     spec:
       # ADR-0162 D4 (continued): a dedicated SA (not `default`) is what OpenBao's Kubernetes-auth
       # role `document-service-signing` is bound to — least-privilege, one identity per consumer.

--- a/openbank-infra/gitops/components/fraud-service/fraud-opa-bundle.yaml
+++ b/openbank-infra/gitops/components/fraud-service/fraud-opa-bundle.yaml
@@ -9,7 +9,7 @@ metadata:
     app.kubernetes.io/name: fraud-service
     app.kubernetes.io/part-of: fraud
   annotations:
-    openbank.tech/policy-checksum: "de96e6cab0fb84b2"
+    openbank.tech/policy-checksum: "7313fc2da9813995"
 data:
   rest.rego: |
     # SPDX-License-Identifier: Apache-2.0
@@ -2776,6 +2776,28 @@ data:
             jdbc-postgresql (build.gradle.kts) — it has no OLTP datasource to reach. The
             reconciliation reads the warehouse and the WORM archive over blocking clients.
       ci_producer: ".github/scripts/check-no-runblocking-in-scheduled.py"
+
+      # The structural reason the HR000068 class was invisible (#2204). `quarkus.scheduler.enabled:
+      # false` under %test is a reasonable default — it stops crons firing during unrelated tests —
+      # but it leaves only DIRECT method calls, and a direct call supplies the very Vert.x context
+      # the scheduler does not. So `scheduler.sweep()` in a test passes against a body that can
+      # never work as a cron. The guard above catches ONE defect shape; only running the real cron
+      # catches the next.
+      #
+      # Rule: a service that disables the scheduler under %test AND has an @Scheduled method must
+      # have at least one test that sets `quarkus.scheduler.enabled=true` (a @TestProfile with a
+      # shrunken cron, as LedgerSchedulerVertxContextIT / BillingCycleSweepVertxContextIT do).
+      #
+      # Measured 2026-07-26: 11 services qualify, only 2 exercise it. The other 9 are baselined in
+      # the producer — the list may only SHRINK, and a stale entry (a service that now IS covered)
+      # is reported too, so the debt cannot quietly become permanent.
+      #
+      # Detection is narrow on purpose: only `quarkus.scheduler.enabled` set to `true` counts. A
+      # looser sweep for the string `scheduler.enabled` scored card-issuance as covered on
+      # `scheduler(enabled = false).enforceRetention()` — a direct call with an unrelated feature
+      # flag, i.e. exactly what this rule rejects.
+      scheduler_exercised_in_tests: true
+      scheduler_exercised_ci_producer: ".github/scripts/check-scheduler-exercised.py"
 
 
     # ---------------------------------------------------------------------------------------

--- a/openbank-infra/gitops/components/fraud-service/fraud-service.yaml
+++ b/openbank-infra/gitops/components/fraud-service/fraud-service.yaml
@@ -23,7 +23,7 @@ spec:
       annotations:
         # Rolls the pods when the OPA bundle changes — subPath mounts do NOT hot-reload.
         # Kept in sync by gen-fraud-opa-bundle.sh (do not hand-edit).
-        openbank.tech/policy-checksum: "de96e6cab0fb84b2"
+        openbank.tech/policy-checksum: "7313fc2da9813995"
     spec:
       securityContext:
         runAsNonRoot: true

--- a/openbank-infra/gitops/components/fx-service/fx-opa-bundle.yaml
+++ b/openbank-infra/gitops/components/fx-service/fx-opa-bundle.yaml
@@ -9,7 +9,7 @@ metadata:
     app.kubernetes.io/name: fx-service
     app.kubernetes.io/part-of: fx
   annotations:
-    openbank.tech/policy-checksum: "0f41b01fe3c9a582"
+    openbank.tech/policy-checksum: "01f4b78b1203ba63"
 data:
   rest.rego: |
     # SPDX-License-Identifier: Apache-2.0
@@ -2827,6 +2827,28 @@ data:
             jdbc-postgresql (build.gradle.kts) — it has no OLTP datasource to reach. The
             reconciliation reads the warehouse and the WORM archive over blocking clients.
       ci_producer: ".github/scripts/check-no-runblocking-in-scheduled.py"
+
+      # The structural reason the HR000068 class was invisible (#2204). `quarkus.scheduler.enabled:
+      # false` under %test is a reasonable default — it stops crons firing during unrelated tests —
+      # but it leaves only DIRECT method calls, and a direct call supplies the very Vert.x context
+      # the scheduler does not. So `scheduler.sweep()` in a test passes against a body that can
+      # never work as a cron. The guard above catches ONE defect shape; only running the real cron
+      # catches the next.
+      #
+      # Rule: a service that disables the scheduler under %test AND has an @Scheduled method must
+      # have at least one test that sets `quarkus.scheduler.enabled=true` (a @TestProfile with a
+      # shrunken cron, as LedgerSchedulerVertxContextIT / BillingCycleSweepVertxContextIT do).
+      #
+      # Measured 2026-07-26: 11 services qualify, only 2 exercise it. The other 9 are baselined in
+      # the producer — the list may only SHRINK, and a stale entry (a service that now IS covered)
+      # is reported too, so the debt cannot quietly become permanent.
+      #
+      # Detection is narrow on purpose: only `quarkus.scheduler.enabled` set to `true` counts. A
+      # looser sweep for the string `scheduler.enabled` scored card-issuance as covered on
+      # `scheduler(enabled = false).enforceRetention()` — a direct call with an unrelated feature
+      # flag, i.e. exactly what this rule rejects.
+      scheduler_exercised_in_tests: true
+      scheduler_exercised_ci_producer: ".github/scripts/check-scheduler-exercised.py"
 
 
     # ---------------------------------------------------------------------------------------

--- a/openbank-infra/gitops/components/fx-service/fx-service.yaml
+++ b/openbank-infra/gitops/components/fx-service/fx-service.yaml
@@ -22,7 +22,7 @@ spec:
       annotations:
         # Rolls the pods when the OPA bundle changes — subPath mounts do NOT hot-reload.
         # Kept in sync by gen-fx-opa-bundle.sh (do not hand-edit).
-        openbank.tech/policy-checksum: "0f41b01fe3c9a582"
+        openbank.tech/policy-checksum: "01f4b78b1203ba63"
     spec:
       securityContext:
         runAsNonRoot: true

--- a/openbank-infra/gitops/components/interest-service/interest-opa-bundle.yaml
+++ b/openbank-infra/gitops/components/interest-service/interest-opa-bundle.yaml
@@ -9,7 +9,7 @@ metadata:
     app.kubernetes.io/name: interest-service
     app.kubernetes.io/part-of: interest
   annotations:
-    openbank.tech/policy-checksum: "ed145a1c6df72f5c"
+    openbank.tech/policy-checksum: "f7e60a1fc032d5eb"
 data:
   rest.rego: |
     # SPDX-License-Identifier: Apache-2.0
@@ -2761,6 +2761,28 @@ data:
             jdbc-postgresql (build.gradle.kts) — it has no OLTP datasource to reach. The
             reconciliation reads the warehouse and the WORM archive over blocking clients.
       ci_producer: ".github/scripts/check-no-runblocking-in-scheduled.py"
+
+      # The structural reason the HR000068 class was invisible (#2204). `quarkus.scheduler.enabled:
+      # false` under %test is a reasonable default — it stops crons firing during unrelated tests —
+      # but it leaves only DIRECT method calls, and a direct call supplies the very Vert.x context
+      # the scheduler does not. So `scheduler.sweep()` in a test passes against a body that can
+      # never work as a cron. The guard above catches ONE defect shape; only running the real cron
+      # catches the next.
+      #
+      # Rule: a service that disables the scheduler under %test AND has an @Scheduled method must
+      # have at least one test that sets `quarkus.scheduler.enabled=true` (a @TestProfile with a
+      # shrunken cron, as LedgerSchedulerVertxContextIT / BillingCycleSweepVertxContextIT do).
+      #
+      # Measured 2026-07-26: 11 services qualify, only 2 exercise it. The other 9 are baselined in
+      # the producer — the list may only SHRINK, and a stale entry (a service that now IS covered)
+      # is reported too, so the debt cannot quietly become permanent.
+      #
+      # Detection is narrow on purpose: only `quarkus.scheduler.enabled` set to `true` counts. A
+      # looser sweep for the string `scheduler.enabled` scored card-issuance as covered on
+      # `scheduler(enabled = false).enforceRetention()` — a direct call with an unrelated feature
+      # flag, i.e. exactly what this rule rejects.
+      scheduler_exercised_in_tests: true
+      scheduler_exercised_ci_producer: ".github/scripts/check-scheduler-exercised.py"
 
 
     # ---------------------------------------------------------------------------------------

--- a/openbank-infra/gitops/components/interest-service/interest-service.yaml
+++ b/openbank-infra/gitops/components/interest-service/interest-service.yaml
@@ -16,7 +16,7 @@ spec:
       annotations:
         # Rolls the pods when the OPA bundle changes — subPath mounts do NOT hot-reload.
         # Kept in sync by gen-interest-opa-bundle.sh (do not hand-edit).
-        openbank.tech/policy-checksum: "ed145a1c6df72f5c"
+        openbank.tech/policy-checksum: "f7e60a1fc032d5eb"
     spec:
       securityContext:
         runAsNonRoot: true

--- a/openbank-infra/gitops/components/kyc/kyc-opa-bundle.yaml
+++ b/openbank-infra/gitops/components/kyc/kyc-opa-bundle.yaml
@@ -9,7 +9,7 @@ metadata:
     app.kubernetes.io/name: kyc-service
     app.kubernetes.io/part-of: kyc
   annotations:
-    openbank.tech/policy-checksum: "5e4d753703d4db03"
+    openbank.tech/policy-checksum: "81db737709361a04"
 data:
   rest.rego: |
     # SPDX-License-Identifier: Apache-2.0
@@ -2789,6 +2789,28 @@ data:
             jdbc-postgresql (build.gradle.kts) — it has no OLTP datasource to reach. The
             reconciliation reads the warehouse and the WORM archive over blocking clients.
       ci_producer: ".github/scripts/check-no-runblocking-in-scheduled.py"
+
+      # The structural reason the HR000068 class was invisible (#2204). `quarkus.scheduler.enabled:
+      # false` under %test is a reasonable default — it stops crons firing during unrelated tests —
+      # but it leaves only DIRECT method calls, and a direct call supplies the very Vert.x context
+      # the scheduler does not. So `scheduler.sweep()` in a test passes against a body that can
+      # never work as a cron. The guard above catches ONE defect shape; only running the real cron
+      # catches the next.
+      #
+      # Rule: a service that disables the scheduler under %test AND has an @Scheduled method must
+      # have at least one test that sets `quarkus.scheduler.enabled=true` (a @TestProfile with a
+      # shrunken cron, as LedgerSchedulerVertxContextIT / BillingCycleSweepVertxContextIT do).
+      #
+      # Measured 2026-07-26: 11 services qualify, only 2 exercise it. The other 9 are baselined in
+      # the producer — the list may only SHRINK, and a stale entry (a service that now IS covered)
+      # is reported too, so the debt cannot quietly become permanent.
+      #
+      # Detection is narrow on purpose: only `quarkus.scheduler.enabled` set to `true` counts. A
+      # looser sweep for the string `scheduler.enabled` scored card-issuance as covered on
+      # `scheduler(enabled = false).enforceRetention()` — a direct call with an unrelated feature
+      # flag, i.e. exactly what this rule rejects.
+      scheduler_exercised_in_tests: true
+      scheduler_exercised_ci_producer: ".github/scripts/check-scheduler-exercised.py"
 
 
     # ---------------------------------------------------------------------------------------

--- a/openbank-infra/gitops/components/kyc/kyc-service.yaml
+++ b/openbank-infra/gitops/components/kyc/kyc-service.yaml
@@ -48,7 +48,7 @@ spec:
       annotations:
         # Rolls the pod when the OPA bundle changes (subPath mounts do not hot-reload).
         # Kept in sync by gen-kyc-opa-bundle.sh (do not hand-edit).
-        openbank.tech/policy-checksum: "5e4d753703d4db03"
+        openbank.tech/policy-checksum: "81db737709361a04"
     spec:
       securityContext:
         runAsNonRoot: true

--- a/openbank-infra/gitops/components/ledger/ledger-opa-bundle.yaml
+++ b/openbank-infra/gitops/components/ledger/ledger-opa-bundle.yaml
@@ -9,7 +9,7 @@ metadata:
     app.kubernetes.io/name: ledger-service
     app.kubernetes.io/part-of: ledger
   annotations:
-    openbank.tech/policy-checksum: "4159e7507e3d631a"
+    openbank.tech/policy-checksum: "ed7ffd441972bb9d"
 data:
   rest.rego: |
     # SPDX-License-Identifier: Apache-2.0
@@ -2874,6 +2874,28 @@ data:
             jdbc-postgresql (build.gradle.kts) — it has no OLTP datasource to reach. The
             reconciliation reads the warehouse and the WORM archive over blocking clients.
       ci_producer: ".github/scripts/check-no-runblocking-in-scheduled.py"
+
+      # The structural reason the HR000068 class was invisible (#2204). `quarkus.scheduler.enabled:
+      # false` under %test is a reasonable default — it stops crons firing during unrelated tests —
+      # but it leaves only DIRECT method calls, and a direct call supplies the very Vert.x context
+      # the scheduler does not. So `scheduler.sweep()` in a test passes against a body that can
+      # never work as a cron. The guard above catches ONE defect shape; only running the real cron
+      # catches the next.
+      #
+      # Rule: a service that disables the scheduler under %test AND has an @Scheduled method must
+      # have at least one test that sets `quarkus.scheduler.enabled=true` (a @TestProfile with a
+      # shrunken cron, as LedgerSchedulerVertxContextIT / BillingCycleSweepVertxContextIT do).
+      #
+      # Measured 2026-07-26: 11 services qualify, only 2 exercise it. The other 9 are baselined in
+      # the producer — the list may only SHRINK, and a stale entry (a service that now IS covered)
+      # is reported too, so the debt cannot quietly become permanent.
+      #
+      # Detection is narrow on purpose: only `quarkus.scheduler.enabled` set to `true` counts. A
+      # looser sweep for the string `scheduler.enabled` scored card-issuance as covered on
+      # `scheduler(enabled = false).enforceRetention()` — a direct call with an unrelated feature
+      # flag, i.e. exactly what this rule rejects.
+      scheduler_exercised_in_tests: true
+      scheduler_exercised_ci_producer: ".github/scripts/check-scheduler-exercised.py"
 
 
     # ---------------------------------------------------------------------------------------

--- a/openbank-infra/gitops/components/ledger/ledger-service.yaml
+++ b/openbank-infra/gitops/components/ledger/ledger-service.yaml
@@ -38,7 +38,7 @@ spec:
       annotations:
         # Rolls the pods when the OPA bundle changes — subPath mounts do NOT hot-reload.
         # Kept in sync by gen-ledger-opa-bundle.sh (do not hand-edit).
-        openbank.tech/policy-checksum: "4159e7507e3d631a"
+        openbank.tech/policy-checksum: "ed7ffd441972bb9d"
     spec:
       securityContext:
         runAsNonRoot: true

--- a/openbank-infra/gitops/components/lending/lending-opa-bundle.yaml
+++ b/openbank-infra/gitops/components/lending/lending-opa-bundle.yaml
@@ -9,7 +9,7 @@ metadata:
     app.kubernetes.io/name: lending-service
     app.kubernetes.io/part-of: lending
   annotations:
-    openbank.tech/policy-checksum: "c73aa5ccefec4b76"
+    openbank.tech/policy-checksum: "f1895a6b6fe022f4"
 data:
   rest.rego: |
     # SPDX-License-Identifier: Apache-2.0
@@ -2829,6 +2829,28 @@ data:
             jdbc-postgresql (build.gradle.kts) — it has no OLTP datasource to reach. The
             reconciliation reads the warehouse and the WORM archive over blocking clients.
       ci_producer: ".github/scripts/check-no-runblocking-in-scheduled.py"
+
+      # The structural reason the HR000068 class was invisible (#2204). `quarkus.scheduler.enabled:
+      # false` under %test is a reasonable default — it stops crons firing during unrelated tests —
+      # but it leaves only DIRECT method calls, and a direct call supplies the very Vert.x context
+      # the scheduler does not. So `scheduler.sweep()` in a test passes against a body that can
+      # never work as a cron. The guard above catches ONE defect shape; only running the real cron
+      # catches the next.
+      #
+      # Rule: a service that disables the scheduler under %test AND has an @Scheduled method must
+      # have at least one test that sets `quarkus.scheduler.enabled=true` (a @TestProfile with a
+      # shrunken cron, as LedgerSchedulerVertxContextIT / BillingCycleSweepVertxContextIT do).
+      #
+      # Measured 2026-07-26: 11 services qualify, only 2 exercise it. The other 9 are baselined in
+      # the producer — the list may only SHRINK, and a stale entry (a service that now IS covered)
+      # is reported too, so the debt cannot quietly become permanent.
+      #
+      # Detection is narrow on purpose: only `quarkus.scheduler.enabled` set to `true` counts. A
+      # looser sweep for the string `scheduler.enabled` scored card-issuance as covered on
+      # `scheduler(enabled = false).enforceRetention()` — a direct call with an unrelated feature
+      # flag, i.e. exactly what this rule rejects.
+      scheduler_exercised_in_tests: true
+      scheduler_exercised_ci_producer: ".github/scripts/check-scheduler-exercised.py"
 
 
     # ---------------------------------------------------------------------------------------

--- a/openbank-infra/gitops/components/lending/lending-service.yaml
+++ b/openbank-infra/gitops/components/lending/lending-service.yaml
@@ -34,7 +34,7 @@ spec:
       annotations:
         # Rolls the pods when the OPA bundle changes — subPath mounts do NOT hot-reload.
         # Kept in sync by gen-lending-opa-bundle.sh (do not hand-edit).
-        openbank.tech/policy-checksum: "c73aa5ccefec4b76"
+        openbank.tech/policy-checksum: "f1895a6b6fe022f4"
     spec:
       securityContext:
         runAsNonRoot: true

--- a/openbank-infra/gitops/components/mcp/mcp-opa-bundle.yaml
+++ b/openbank-infra/gitops/components/mcp/mcp-opa-bundle.yaml
@@ -9,7 +9,7 @@ metadata:
     app.kubernetes.io/name: mcp-service
     app.kubernetes.io/part-of: platform
   annotations:
-    openbank.tech/policy-checksum: "465bc216e2560311"
+    openbank.tech/policy-checksum: "4673877eb208bc64"
 data:
   rest.rego: |
     # SPDX-License-Identifier: Apache-2.0
@@ -2727,6 +2727,28 @@ data:
             jdbc-postgresql (build.gradle.kts) — it has no OLTP datasource to reach. The
             reconciliation reads the warehouse and the WORM archive over blocking clients.
       ci_producer: ".github/scripts/check-no-runblocking-in-scheduled.py"
+
+      # The structural reason the HR000068 class was invisible (#2204). `quarkus.scheduler.enabled:
+      # false` under %test is a reasonable default — it stops crons firing during unrelated tests —
+      # but it leaves only DIRECT method calls, and a direct call supplies the very Vert.x context
+      # the scheduler does not. So `scheduler.sweep()` in a test passes against a body that can
+      # never work as a cron. The guard above catches ONE defect shape; only running the real cron
+      # catches the next.
+      #
+      # Rule: a service that disables the scheduler under %test AND has an @Scheduled method must
+      # have at least one test that sets `quarkus.scheduler.enabled=true` (a @TestProfile with a
+      # shrunken cron, as LedgerSchedulerVertxContextIT / BillingCycleSweepVertxContextIT do).
+      #
+      # Measured 2026-07-26: 11 services qualify, only 2 exercise it. The other 9 are baselined in
+      # the producer — the list may only SHRINK, and a stale entry (a service that now IS covered)
+      # is reported too, so the debt cannot quietly become permanent.
+      #
+      # Detection is narrow on purpose: only `quarkus.scheduler.enabled` set to `true` counts. A
+      # looser sweep for the string `scheduler.enabled` scored card-issuance as covered on
+      # `scheduler(enabled = false).enforceRetention()` — a direct call with an unrelated feature
+      # flag, i.e. exactly what this rule rejects.
+      scheduler_exercised_in_tests: true
+      scheduler_exercised_ci_producer: ".github/scripts/check-scheduler-exercised.py"
 
 
     # ---------------------------------------------------------------------------------------

--- a/openbank-infra/gitops/components/mcp/mcp-service.yaml
+++ b/openbank-infra/gitops/components/mcp/mcp-service.yaml
@@ -29,7 +29,7 @@ spec:
       annotations:
         # Rolls the pod when the OPA bundle changes — subPath mounts do NOT hot-reload.
         # Kept in sync by gen-mcp-opa-bundle.sh (do not hand-edit).
-        openbank.tech/policy-checksum: "465bc216e2560311"
+        openbank.tech/policy-checksum: "4673877eb208bc64"
     spec:
       securityContext:
         runAsNonRoot: true

--- a/openbank-infra/gitops/components/notifications/notification-service-opa-bundle.yaml
+++ b/openbank-infra/gitops/components/notifications/notification-service-opa-bundle.yaml
@@ -10,7 +10,7 @@ metadata:
     app.kubernetes.io/name: notification-service
     app.kubernetes.io/part-of: notifications
   annotations:
-    openbank.tech/policy-checksum: "80f3ab7acfa9c205"
+    openbank.tech/policy-checksum: "e0f110332208803b"
 data:
   rest.rego: |
     # SPDX-License-Identifier: Apache-2.0
@@ -1950,6 +1950,28 @@ data:
             jdbc-postgresql (build.gradle.kts) — it has no OLTP datasource to reach. The
             reconciliation reads the warehouse and the WORM archive over blocking clients.
       ci_producer: ".github/scripts/check-no-runblocking-in-scheduled.py"
+
+      # The structural reason the HR000068 class was invisible (#2204). `quarkus.scheduler.enabled:
+      # false` under %test is a reasonable default — it stops crons firing during unrelated tests —
+      # but it leaves only DIRECT method calls, and a direct call supplies the very Vert.x context
+      # the scheduler does not. So `scheduler.sweep()` in a test passes against a body that can
+      # never work as a cron. The guard above catches ONE defect shape; only running the real cron
+      # catches the next.
+      #
+      # Rule: a service that disables the scheduler under %test AND has an @Scheduled method must
+      # have at least one test that sets `quarkus.scheduler.enabled=true` (a @TestProfile with a
+      # shrunken cron, as LedgerSchedulerVertxContextIT / BillingCycleSweepVertxContextIT do).
+      #
+      # Measured 2026-07-26: 11 services qualify, only 2 exercise it. The other 9 are baselined in
+      # the producer — the list may only SHRINK, and a stale entry (a service that now IS covered)
+      # is reported too, so the debt cannot quietly become permanent.
+      #
+      # Detection is narrow on purpose: only `quarkus.scheduler.enabled` set to `true` counts. A
+      # looser sweep for the string `scheduler.enabled` scored card-issuance as covered on
+      # `scheduler(enabled = false).enforceRetention()` — a direct call with an unrelated feature
+      # flag, i.e. exactly what this rule rejects.
+      scheduler_exercised_in_tests: true
+      scheduler_exercised_ci_producer: ".github/scripts/check-scheduler-exercised.py"
 
 
     # ---------------------------------------------------------------------------------------

--- a/openbank-infra/gitops/components/notifications/notification-service.yaml
+++ b/openbank-infra/gitops/components/notifications/notification-service.yaml
@@ -39,7 +39,7 @@ spec:
       annotations:
         # Rolls the Deployment when the OPA policy bundle changes (subPath mounts don't
         # hot-reload). Kept in sync by gen-notification-opa-bundle.sh.
-        openbank.tech/policy-checksum: "80f3ab7acfa9c205"
+        openbank.tech/policy-checksum: "e0f110332208803b"
       labels:
         app.kubernetes.io/name: notification-service
         app.kubernetes.io/part-of: notifications

--- a/openbank-infra/gitops/components/party/party-opa-bundle.yaml
+++ b/openbank-infra/gitops/components/party/party-opa-bundle.yaml
@@ -9,7 +9,7 @@ metadata:
     app.kubernetes.io/name: party-service
     app.kubernetes.io/part-of: party
   annotations:
-    openbank.tech/policy-checksum: "cb73b8ffb9f21eef"
+    openbank.tech/policy-checksum: "a1805c717fd53e96"
 data:
   rest.rego: |
     # SPDX-License-Identifier: Apache-2.0
@@ -2798,6 +2798,28 @@ data:
             jdbc-postgresql (build.gradle.kts) — it has no OLTP datasource to reach. The
             reconciliation reads the warehouse and the WORM archive over blocking clients.
       ci_producer: ".github/scripts/check-no-runblocking-in-scheduled.py"
+
+      # The structural reason the HR000068 class was invisible (#2204). `quarkus.scheduler.enabled:
+      # false` under %test is a reasonable default — it stops crons firing during unrelated tests —
+      # but it leaves only DIRECT method calls, and a direct call supplies the very Vert.x context
+      # the scheduler does not. So `scheduler.sweep()` in a test passes against a body that can
+      # never work as a cron. The guard above catches ONE defect shape; only running the real cron
+      # catches the next.
+      #
+      # Rule: a service that disables the scheduler under %test AND has an @Scheduled method must
+      # have at least one test that sets `quarkus.scheduler.enabled=true` (a @TestProfile with a
+      # shrunken cron, as LedgerSchedulerVertxContextIT / BillingCycleSweepVertxContextIT do).
+      #
+      # Measured 2026-07-26: 11 services qualify, only 2 exercise it. The other 9 are baselined in
+      # the producer — the list may only SHRINK, and a stale entry (a service that now IS covered)
+      # is reported too, so the debt cannot quietly become permanent.
+      #
+      # Detection is narrow on purpose: only `quarkus.scheduler.enabled` set to `true` counts. A
+      # looser sweep for the string `scheduler.enabled` scored card-issuance as covered on
+      # `scheduler(enabled = false).enforceRetention()` — a direct call with an unrelated feature
+      # flag, i.e. exactly what this rule rejects.
+      scheduler_exercised_in_tests: true
+      scheduler_exercised_ci_producer: ".github/scripts/check-scheduler-exercised.py"
 
 
     # ---------------------------------------------------------------------------------------

--- a/openbank-infra/gitops/components/party/party-service.yaml
+++ b/openbank-infra/gitops/components/party/party-service.yaml
@@ -22,7 +22,7 @@ spec:
       annotations:
         # Rolls the pod when the OPA bundle changes — subPath mounts do NOT hot-reload.
         # Kept in sync by gen-party-opa-bundle.sh (do not hand-edit).
-        openbank.tech/policy-checksum: "cb73b8ffb9f21eef"
+        openbank.tech/policy-checksum: "a1805c717fd53e96"
       labels:
         app.kubernetes.io/name: party-service
         app.kubernetes.io/part-of: party

--- a/openbank-infra/gitops/components/payments/card-issuance-opa-bundle.yaml
+++ b/openbank-infra/gitops/components/payments/card-issuance-opa-bundle.yaml
@@ -9,7 +9,7 @@ metadata:
     app.kubernetes.io/name: card-issuance-service
     app.kubernetes.io/part-of: payments
   annotations:
-    openbank.tech/policy-checksum: "5d4cf4e1be41a83f"
+    openbank.tech/policy-checksum: "5cd7795c0916c2ef"
 data:
   rest.rego: |
     # SPDX-License-Identifier: Apache-2.0
@@ -2782,6 +2782,28 @@ data:
             jdbc-postgresql (build.gradle.kts) — it has no OLTP datasource to reach. The
             reconciliation reads the warehouse and the WORM archive over blocking clients.
       ci_producer: ".github/scripts/check-no-runblocking-in-scheduled.py"
+
+      # The structural reason the HR000068 class was invisible (#2204). `quarkus.scheduler.enabled:
+      # false` under %test is a reasonable default — it stops crons firing during unrelated tests —
+      # but it leaves only DIRECT method calls, and a direct call supplies the very Vert.x context
+      # the scheduler does not. So `scheduler.sweep()` in a test passes against a body that can
+      # never work as a cron. The guard above catches ONE defect shape; only running the real cron
+      # catches the next.
+      #
+      # Rule: a service that disables the scheduler under %test AND has an @Scheduled method must
+      # have at least one test that sets `quarkus.scheduler.enabled=true` (a @TestProfile with a
+      # shrunken cron, as LedgerSchedulerVertxContextIT / BillingCycleSweepVertxContextIT do).
+      #
+      # Measured 2026-07-26: 11 services qualify, only 2 exercise it. The other 9 are baselined in
+      # the producer — the list may only SHRINK, and a stale entry (a service that now IS covered)
+      # is reported too, so the debt cannot quietly become permanent.
+      #
+      # Detection is narrow on purpose: only `quarkus.scheduler.enabled` set to `true` counts. A
+      # looser sweep for the string `scheduler.enabled` scored card-issuance as covered on
+      # `scheduler(enabled = false).enforceRetention()` — a direct call with an unrelated feature
+      # flag, i.e. exactly what this rule rejects.
+      scheduler_exercised_in_tests: true
+      scheduler_exercised_ci_producer: ".github/scripts/check-scheduler-exercised.py"
 
 
     # ---------------------------------------------------------------------------------------

--- a/openbank-infra/gitops/components/payments/clearing-opa-bundle.yaml
+++ b/openbank-infra/gitops/components/payments/clearing-opa-bundle.yaml
@@ -9,7 +9,7 @@ metadata:
     app.kubernetes.io/name: clearing-service
     app.kubernetes.io/part-of: payments
   annotations:
-    openbank.tech/policy-checksum: "001ed2e9151db3a2"
+    openbank.tech/policy-checksum: "a4c9cd2e9cd4241d"
 data:
   rest.rego: |
     # SPDX-License-Identifier: Apache-2.0
@@ -2819,6 +2819,28 @@ data:
             jdbc-postgresql (build.gradle.kts) — it has no OLTP datasource to reach. The
             reconciliation reads the warehouse and the WORM archive over blocking clients.
       ci_producer: ".github/scripts/check-no-runblocking-in-scheduled.py"
+
+      # The structural reason the HR000068 class was invisible (#2204). `quarkus.scheduler.enabled:
+      # false` under %test is a reasonable default — it stops crons firing during unrelated tests —
+      # but it leaves only DIRECT method calls, and a direct call supplies the very Vert.x context
+      # the scheduler does not. So `scheduler.sweep()` in a test passes against a body that can
+      # never work as a cron. The guard above catches ONE defect shape; only running the real cron
+      # catches the next.
+      #
+      # Rule: a service that disables the scheduler under %test AND has an @Scheduled method must
+      # have at least one test that sets `quarkus.scheduler.enabled=true` (a @TestProfile with a
+      # shrunken cron, as LedgerSchedulerVertxContextIT / BillingCycleSweepVertxContextIT do).
+      #
+      # Measured 2026-07-26: 11 services qualify, only 2 exercise it. The other 9 are baselined in
+      # the producer — the list may only SHRINK, and a stale entry (a service that now IS covered)
+      # is reported too, so the debt cannot quietly become permanent.
+      #
+      # Detection is narrow on purpose: only `quarkus.scheduler.enabled` set to `true` counts. A
+      # looser sweep for the string `scheduler.enabled` scored card-issuance as covered on
+      # `scheduler(enabled = false).enforceRetention()` — a direct call with an unrelated feature
+      # flag, i.e. exactly what this rule rejects.
+      scheduler_exercised_in_tests: true
+      scheduler_exercised_ci_producer: ".github/scripts/check-scheduler-exercised.py"
 
 
     # ---------------------------------------------------------------------------------------

--- a/openbank-infra/gitops/components/payments/domestic-payment-opa-bundle.yaml
+++ b/openbank-infra/gitops/components/payments/domestic-payment-opa-bundle.yaml
@@ -9,7 +9,7 @@ metadata:
     app.kubernetes.io/name: domestic-payment
     app.kubernetes.io/part-of: payments
   annotations:
-    openbank.tech/policy-checksum: "4f1f46e1b2acdbb9"
+    openbank.tech/policy-checksum: "9bcdb6ee235660a6"
 data:
   rest.rego: |
     # SPDX-License-Identifier: Apache-2.0
@@ -2804,6 +2804,28 @@ data:
             jdbc-postgresql (build.gradle.kts) — it has no OLTP datasource to reach. The
             reconciliation reads the warehouse and the WORM archive over blocking clients.
       ci_producer: ".github/scripts/check-no-runblocking-in-scheduled.py"
+
+      # The structural reason the HR000068 class was invisible (#2204). `quarkus.scheduler.enabled:
+      # false` under %test is a reasonable default — it stops crons firing during unrelated tests —
+      # but it leaves only DIRECT method calls, and a direct call supplies the very Vert.x context
+      # the scheduler does not. So `scheduler.sweep()` in a test passes against a body that can
+      # never work as a cron. The guard above catches ONE defect shape; only running the real cron
+      # catches the next.
+      #
+      # Rule: a service that disables the scheduler under %test AND has an @Scheduled method must
+      # have at least one test that sets `quarkus.scheduler.enabled=true` (a @TestProfile with a
+      # shrunken cron, as LedgerSchedulerVertxContextIT / BillingCycleSweepVertxContextIT do).
+      #
+      # Measured 2026-07-26: 11 services qualify, only 2 exercise it. The other 9 are baselined in
+      # the producer — the list may only SHRINK, and a stale entry (a service that now IS covered)
+      # is reported too, so the debt cannot quietly become permanent.
+      #
+      # Detection is narrow on purpose: only `quarkus.scheduler.enabled` set to `true` counts. A
+      # looser sweep for the string `scheduler.enabled` scored card-issuance as covered on
+      # `scheduler(enabled = false).enforceRetention()` — a direct call with an unrelated feature
+      # flag, i.e. exactly what this rule rejects.
+      scheduler_exercised_in_tests: true
+      scheduler_exercised_ci_producer: ".github/scripts/check-scheduler-exercised.py"
 
 
     # ---------------------------------------------------------------------------------------

--- a/openbank-infra/gitops/components/payments/payments-services.yaml
+++ b/openbank-infra/gitops/components/payments/payments-services.yaml
@@ -42,7 +42,7 @@ spec:
         # Rolls the pods when the OPA bundle changes — subPath mounts do NOT hot-reload.
         # Kept in sync by gen-transaction-opa-bundle.sh via the trailing marker comment
         # (do not hand-edit, do not drop the marker).
-        openbank.tech/policy-checksum: "6da51558471f2875" # transaction-opa-bundle
+        openbank.tech/policy-checksum: "4895cf05d59011cc" # transaction-opa-bundle
     spec:
       securityContext:
         runAsNonRoot: true
@@ -375,7 +375,7 @@ spec:
       annotations:
         # Rolls the pods when the OPA bundle changes — subPath mounts do NOT hot-reload.
         # Kept in sync by gen-sepa-payment-opa-bundle.sh (do not hand-edit).
-        openbank.tech/policy-checksum: "08f0b03a11b3819e"
+        openbank.tech/policy-checksum: "409b53b6d8847009"
     spec:
       securityContext:
         runAsNonRoot: true
@@ -729,7 +729,7 @@ spec:
         # Rolls the pods when the OPA bundle changes — subPath mounts do NOT hot-reload.
         # Kept in sync by gen-domestic-payment-opa-bundle.sh via the trailing marker
         # comment (do not hand-edit, do not drop the marker).
-        openbank.tech/policy-checksum: "4f1f46e1b2acdbb9" # domestic-payment-opa-bundle
+        openbank.tech/policy-checksum: "9bcdb6ee235660a6" # domestic-payment-opa-bundle
     spec:
       securityContext:
         runAsNonRoot: true
@@ -1053,7 +1053,7 @@ spec:
       annotations:
         # Rolls the pods when the OPA bundle changes — subPath mounts do NOT hot-reload.
         # Kept in sync by gen-sepa-instant-opa-bundle.sh (do not hand-edit).
-        openbank.tech/policy-checksum: "29630e58c8599c6c"
+        openbank.tech/policy-checksum: "41c7053da1b93906"
     spec:
       securityContext:
         runAsNonRoot: true
@@ -1369,7 +1369,7 @@ spec:
         # Rolls the pods when the OPA bundle changes — subPath mounts do NOT hot-reload.
         # Kept in sync by gen-clearing-opa-bundle.sh via the trailing marker comment
         # (do not hand-edit, do not drop the marker).
-        openbank.tech/policy-checksum: "001ed2e9151db3a2" # clearing-opa-bundle
+        openbank.tech/policy-checksum: "a4c9cd2e9cd4241d" # clearing-opa-bundle
     spec:
       securityContext:
         runAsNonRoot: true
@@ -1658,7 +1658,7 @@ spec:
       annotations:
         # Rolls the pod when the OPA bundle changes (ADR-0034). Value is stamped by
         # gen-standing-order-opa-bundle.sh — do not hand-edit.
-        openbank.tech/policy-checksum: "2846b93818d0ab48" # standing-order-opa-bundle
+        openbank.tech/policy-checksum: "f2549bcf7dbbbdaa" # standing-order-opa-bundle
     spec:
       securityContext:
         runAsNonRoot: true
@@ -1911,7 +1911,7 @@ spec:
       annotations:
         # Rolls the pods when the OPA bundle changes — subPath mounts do NOT hot-reload.
         # Kept in sync by gen-card-issuance-opa-bundle.sh (do not hand-edit).
-        openbank.tech/policy-checksum: "5d4cf4e1be41a83f"
+        openbank.tech/policy-checksum: "5cd7795c0916c2ef"
     spec:
       securityContext:
         runAsNonRoot: true
@@ -2178,7 +2178,7 @@ spec:
         # Rolls the pods when the OPA bundle changes — subPath mounts do NOT hot-reload.
         # Kept in sync by gen-settlement-opa-bundle.sh via the trailing marker comment
         # (do not hand-edit, do not drop the marker).
-        openbank.tech/policy-checksum: "af9e2939f7b4aa44" # settlement-opa-bundle
+        openbank.tech/policy-checksum: "12f0d1fa4770303b" # settlement-opa-bundle
     spec:
       securityContext:
         runAsNonRoot: true
@@ -2579,7 +2579,7 @@ spec:
       annotations:
         # Rolls the pods when the OPA bundle changes — subPath mounts do NOT hot-reload.
         # Kept in sync by gen-swift-opa-bundle.sh (do not hand-edit).
-        openbank.tech/policy-checksum: "ddffbd66c30db2b3"
+        openbank.tech/policy-checksum: "86401a38dca19adf"
     spec:
       securityContext:
         runAsNonRoot: true
@@ -2893,7 +2893,7 @@ spec:
       annotations:
         # Rolls the pods when the OPA bundle changes — subPath mounts do NOT hot-reload.
         # Kept in sync by gen-vop-opa-bundle.sh (do not hand-edit).
-        openbank.tech/policy-checksum: "1a1fed1af16793bb"
+        openbank.tech/policy-checksum: "92b70497e97777e3"
     spec:
       securityContext:
         runAsNonRoot: true

--- a/openbank-infra/gitops/components/payments/sepa-instant-opa-bundle.yaml
+++ b/openbank-infra/gitops/components/payments/sepa-instant-opa-bundle.yaml
@@ -9,7 +9,7 @@ metadata:
     app.kubernetes.io/name: sepa-instant
     app.kubernetes.io/part-of: payments
   annotations:
-    openbank.tech/policy-checksum: "29630e58c8599c6c"
+    openbank.tech/policy-checksum: "41c7053da1b93906"
 data:
   rest.rego: |
     # SPDX-License-Identifier: Apache-2.0
@@ -2777,6 +2777,28 @@ data:
             jdbc-postgresql (build.gradle.kts) — it has no OLTP datasource to reach. The
             reconciliation reads the warehouse and the WORM archive over blocking clients.
       ci_producer: ".github/scripts/check-no-runblocking-in-scheduled.py"
+
+      # The structural reason the HR000068 class was invisible (#2204). `quarkus.scheduler.enabled:
+      # false` under %test is a reasonable default — it stops crons firing during unrelated tests —
+      # but it leaves only DIRECT method calls, and a direct call supplies the very Vert.x context
+      # the scheduler does not. So `scheduler.sweep()` in a test passes against a body that can
+      # never work as a cron. The guard above catches ONE defect shape; only running the real cron
+      # catches the next.
+      #
+      # Rule: a service that disables the scheduler under %test AND has an @Scheduled method must
+      # have at least one test that sets `quarkus.scheduler.enabled=true` (a @TestProfile with a
+      # shrunken cron, as LedgerSchedulerVertxContextIT / BillingCycleSweepVertxContextIT do).
+      #
+      # Measured 2026-07-26: 11 services qualify, only 2 exercise it. The other 9 are baselined in
+      # the producer — the list may only SHRINK, and a stale entry (a service that now IS covered)
+      # is reported too, so the debt cannot quietly become permanent.
+      #
+      # Detection is narrow on purpose: only `quarkus.scheduler.enabled` set to `true` counts. A
+      # looser sweep for the string `scheduler.enabled` scored card-issuance as covered on
+      # `scheduler(enabled = false).enforceRetention()` — a direct call with an unrelated feature
+      # flag, i.e. exactly what this rule rejects.
+      scheduler_exercised_in_tests: true
+      scheduler_exercised_ci_producer: ".github/scripts/check-scheduler-exercised.py"
 
 
     # ---------------------------------------------------------------------------------------

--- a/openbank-infra/gitops/components/payments/sepa-payment-opa-bundle.yaml
+++ b/openbank-infra/gitops/components/payments/sepa-payment-opa-bundle.yaml
@@ -9,7 +9,7 @@ metadata:
     app.kubernetes.io/name: sepa-payment
     app.kubernetes.io/part-of: payments
   annotations:
-    openbank.tech/policy-checksum: "08f0b03a11b3819e"
+    openbank.tech/policy-checksum: "409b53b6d8847009"
 data:
   rest.rego: |
     # SPDX-License-Identifier: Apache-2.0
@@ -2798,6 +2798,28 @@ data:
             jdbc-postgresql (build.gradle.kts) — it has no OLTP datasource to reach. The
             reconciliation reads the warehouse and the WORM archive over blocking clients.
       ci_producer: ".github/scripts/check-no-runblocking-in-scheduled.py"
+
+      # The structural reason the HR000068 class was invisible (#2204). `quarkus.scheduler.enabled:
+      # false` under %test is a reasonable default — it stops crons firing during unrelated tests —
+      # but it leaves only DIRECT method calls, and a direct call supplies the very Vert.x context
+      # the scheduler does not. So `scheduler.sweep()` in a test passes against a body that can
+      # never work as a cron. The guard above catches ONE defect shape; only running the real cron
+      # catches the next.
+      #
+      # Rule: a service that disables the scheduler under %test AND has an @Scheduled method must
+      # have at least one test that sets `quarkus.scheduler.enabled=true` (a @TestProfile with a
+      # shrunken cron, as LedgerSchedulerVertxContextIT / BillingCycleSweepVertxContextIT do).
+      #
+      # Measured 2026-07-26: 11 services qualify, only 2 exercise it. The other 9 are baselined in
+      # the producer — the list may only SHRINK, and a stale entry (a service that now IS covered)
+      # is reported too, so the debt cannot quietly become permanent.
+      #
+      # Detection is narrow on purpose: only `quarkus.scheduler.enabled` set to `true` counts. A
+      # looser sweep for the string `scheduler.enabled` scored card-issuance as covered on
+      # `scheduler(enabled = false).enforceRetention()` — a direct call with an unrelated feature
+      # flag, i.e. exactly what this rule rejects.
+      scheduler_exercised_in_tests: true
+      scheduler_exercised_ci_producer: ".github/scripts/check-scheduler-exercised.py"
 
 
     # ---------------------------------------------------------------------------------------

--- a/openbank-infra/gitops/components/payments/settlement-opa-bundle.yaml
+++ b/openbank-infra/gitops/components/payments/settlement-opa-bundle.yaml
@@ -9,7 +9,7 @@ metadata:
     app.kubernetes.io/name: settlement-service
     app.kubernetes.io/part-of: payments
   annotations:
-    openbank.tech/policy-checksum: "af9e2939f7b4aa44"
+    openbank.tech/policy-checksum: "12f0d1fa4770303b"
 data:
   rest.rego: |
     # SPDX-License-Identifier: Apache-2.0
@@ -2778,6 +2778,28 @@ data:
             jdbc-postgresql (build.gradle.kts) — it has no OLTP datasource to reach. The
             reconciliation reads the warehouse and the WORM archive over blocking clients.
       ci_producer: ".github/scripts/check-no-runblocking-in-scheduled.py"
+
+      # The structural reason the HR000068 class was invisible (#2204). `quarkus.scheduler.enabled:
+      # false` under %test is a reasonable default — it stops crons firing during unrelated tests —
+      # but it leaves only DIRECT method calls, and a direct call supplies the very Vert.x context
+      # the scheduler does not. So `scheduler.sweep()` in a test passes against a body that can
+      # never work as a cron. The guard above catches ONE defect shape; only running the real cron
+      # catches the next.
+      #
+      # Rule: a service that disables the scheduler under %test AND has an @Scheduled method must
+      # have at least one test that sets `quarkus.scheduler.enabled=true` (a @TestProfile with a
+      # shrunken cron, as LedgerSchedulerVertxContextIT / BillingCycleSweepVertxContextIT do).
+      #
+      # Measured 2026-07-26: 11 services qualify, only 2 exercise it. The other 9 are baselined in
+      # the producer — the list may only SHRINK, and a stale entry (a service that now IS covered)
+      # is reported too, so the debt cannot quietly become permanent.
+      #
+      # Detection is narrow on purpose: only `quarkus.scheduler.enabled` set to `true` counts. A
+      # looser sweep for the string `scheduler.enabled` scored card-issuance as covered on
+      # `scheduler(enabled = false).enforceRetention()` — a direct call with an unrelated feature
+      # flag, i.e. exactly what this rule rejects.
+      scheduler_exercised_in_tests: true
+      scheduler_exercised_ci_producer: ".github/scripts/check-scheduler-exercised.py"
 
 
     # ---------------------------------------------------------------------------------------

--- a/openbank-infra/gitops/components/payments/standing-order-opa-bundle.yaml
+++ b/openbank-infra/gitops/components/payments/standing-order-opa-bundle.yaml
@@ -9,7 +9,7 @@ metadata:
     app.kubernetes.io/name: standing-order-service
     app.kubernetes.io/part-of: payments
   annotations:
-    openbank.tech/policy-checksum: "2846b93818d0ab48"
+    openbank.tech/policy-checksum: "f2549bcf7dbbbdaa"
 data:
   rest.rego: |
     # SPDX-License-Identifier: Apache-2.0
@@ -2763,6 +2763,28 @@ data:
             jdbc-postgresql (build.gradle.kts) — it has no OLTP datasource to reach. The
             reconciliation reads the warehouse and the WORM archive over blocking clients.
       ci_producer: ".github/scripts/check-no-runblocking-in-scheduled.py"
+
+      # The structural reason the HR000068 class was invisible (#2204). `quarkus.scheduler.enabled:
+      # false` under %test is a reasonable default — it stops crons firing during unrelated tests —
+      # but it leaves only DIRECT method calls, and a direct call supplies the very Vert.x context
+      # the scheduler does not. So `scheduler.sweep()` in a test passes against a body that can
+      # never work as a cron. The guard above catches ONE defect shape; only running the real cron
+      # catches the next.
+      #
+      # Rule: a service that disables the scheduler under %test AND has an @Scheduled method must
+      # have at least one test that sets `quarkus.scheduler.enabled=true` (a @TestProfile with a
+      # shrunken cron, as LedgerSchedulerVertxContextIT / BillingCycleSweepVertxContextIT do).
+      #
+      # Measured 2026-07-26: 11 services qualify, only 2 exercise it. The other 9 are baselined in
+      # the producer — the list may only SHRINK, and a stale entry (a service that now IS covered)
+      # is reported too, so the debt cannot quietly become permanent.
+      #
+      # Detection is narrow on purpose: only `quarkus.scheduler.enabled` set to `true` counts. A
+      # looser sweep for the string `scheduler.enabled` scored card-issuance as covered on
+      # `scheduler(enabled = false).enforceRetention()` — a direct call with an unrelated feature
+      # flag, i.e. exactly what this rule rejects.
+      scheduler_exercised_in_tests: true
+      scheduler_exercised_ci_producer: ".github/scripts/check-scheduler-exercised.py"
 
 
     # ---------------------------------------------------------------------------------------

--- a/openbank-infra/gitops/components/payments/swift-opa-bundle.yaml
+++ b/openbank-infra/gitops/components/payments/swift-opa-bundle.yaml
@@ -9,7 +9,7 @@ metadata:
     app.kubernetes.io/name: swift-service
     app.kubernetes.io/part-of: payments
   annotations:
-    openbank.tech/policy-checksum: "ddffbd66c30db2b3"
+    openbank.tech/policy-checksum: "86401a38dca19adf"
 data:
   rest.rego: |
     # SPDX-License-Identifier: Apache-2.0
@@ -2781,6 +2781,28 @@ data:
             jdbc-postgresql (build.gradle.kts) — it has no OLTP datasource to reach. The
             reconciliation reads the warehouse and the WORM archive over blocking clients.
       ci_producer: ".github/scripts/check-no-runblocking-in-scheduled.py"
+
+      # The structural reason the HR000068 class was invisible (#2204). `quarkus.scheduler.enabled:
+      # false` under %test is a reasonable default — it stops crons firing during unrelated tests —
+      # but it leaves only DIRECT method calls, and a direct call supplies the very Vert.x context
+      # the scheduler does not. So `scheduler.sweep()` in a test passes against a body that can
+      # never work as a cron. The guard above catches ONE defect shape; only running the real cron
+      # catches the next.
+      #
+      # Rule: a service that disables the scheduler under %test AND has an @Scheduled method must
+      # have at least one test that sets `quarkus.scheduler.enabled=true` (a @TestProfile with a
+      # shrunken cron, as LedgerSchedulerVertxContextIT / BillingCycleSweepVertxContextIT do).
+      #
+      # Measured 2026-07-26: 11 services qualify, only 2 exercise it. The other 9 are baselined in
+      # the producer — the list may only SHRINK, and a stale entry (a service that now IS covered)
+      # is reported too, so the debt cannot quietly become permanent.
+      #
+      # Detection is narrow on purpose: only `quarkus.scheduler.enabled` set to `true` counts. A
+      # looser sweep for the string `scheduler.enabled` scored card-issuance as covered on
+      # `scheduler(enabled = false).enforceRetention()` — a direct call with an unrelated feature
+      # flag, i.e. exactly what this rule rejects.
+      scheduler_exercised_in_tests: true
+      scheduler_exercised_ci_producer: ".github/scripts/check-scheduler-exercised.py"
 
 
     # ---------------------------------------------------------------------------------------

--- a/openbank-infra/gitops/components/payments/transaction-opa-bundle.yaml
+++ b/openbank-infra/gitops/components/payments/transaction-opa-bundle.yaml
@@ -9,7 +9,7 @@ metadata:
     app.kubernetes.io/name: transaction-service
     app.kubernetes.io/part-of: payments
   annotations:
-    openbank.tech/policy-checksum: "6da51558471f2875"
+    openbank.tech/policy-checksum: "4895cf05d59011cc"
 data:
   rest.rego: |
     # SPDX-License-Identifier: Apache-2.0
@@ -2834,6 +2834,28 @@ data:
             jdbc-postgresql (build.gradle.kts) — it has no OLTP datasource to reach. The
             reconciliation reads the warehouse and the WORM archive over blocking clients.
       ci_producer: ".github/scripts/check-no-runblocking-in-scheduled.py"
+
+      # The structural reason the HR000068 class was invisible (#2204). `quarkus.scheduler.enabled:
+      # false` under %test is a reasonable default — it stops crons firing during unrelated tests —
+      # but it leaves only DIRECT method calls, and a direct call supplies the very Vert.x context
+      # the scheduler does not. So `scheduler.sweep()` in a test passes against a body that can
+      # never work as a cron. The guard above catches ONE defect shape; only running the real cron
+      # catches the next.
+      #
+      # Rule: a service that disables the scheduler under %test AND has an @Scheduled method must
+      # have at least one test that sets `quarkus.scheduler.enabled=true` (a @TestProfile with a
+      # shrunken cron, as LedgerSchedulerVertxContextIT / BillingCycleSweepVertxContextIT do).
+      #
+      # Measured 2026-07-26: 11 services qualify, only 2 exercise it. The other 9 are baselined in
+      # the producer — the list may only SHRINK, and a stale entry (a service that now IS covered)
+      # is reported too, so the debt cannot quietly become permanent.
+      #
+      # Detection is narrow on purpose: only `quarkus.scheduler.enabled` set to `true` counts. A
+      # looser sweep for the string `scheduler.enabled` scored card-issuance as covered on
+      # `scheduler(enabled = false).enforceRetention()` — a direct call with an unrelated feature
+      # flag, i.e. exactly what this rule rejects.
+      scheduler_exercised_in_tests: true
+      scheduler_exercised_ci_producer: ".github/scripts/check-scheduler-exercised.py"
 
 
     # ---------------------------------------------------------------------------------------

--- a/openbank-infra/gitops/components/payments/vop-opa-bundle.yaml
+++ b/openbank-infra/gitops/components/payments/vop-opa-bundle.yaml
@@ -9,7 +9,7 @@ metadata:
     app.kubernetes.io/name: vop-service
     app.kubernetes.io/part-of: payments
   annotations:
-    openbank.tech/policy-checksum: "1a1fed1af16793bb"
+    openbank.tech/policy-checksum: "92b70497e97777e3"
 data:
   rest.rego: |
     # SPDX-License-Identifier: Apache-2.0
@@ -2785,6 +2785,28 @@ data:
             jdbc-postgresql (build.gradle.kts) — it has no OLTP datasource to reach. The
             reconciliation reads the warehouse and the WORM archive over blocking clients.
       ci_producer: ".github/scripts/check-no-runblocking-in-scheduled.py"
+
+      # The structural reason the HR000068 class was invisible (#2204). `quarkus.scheduler.enabled:
+      # false` under %test is a reasonable default — it stops crons firing during unrelated tests —
+      # but it leaves only DIRECT method calls, and a direct call supplies the very Vert.x context
+      # the scheduler does not. So `scheduler.sweep()` in a test passes against a body that can
+      # never work as a cron. The guard above catches ONE defect shape; only running the real cron
+      # catches the next.
+      #
+      # Rule: a service that disables the scheduler under %test AND has an @Scheduled method must
+      # have at least one test that sets `quarkus.scheduler.enabled=true` (a @TestProfile with a
+      # shrunken cron, as LedgerSchedulerVertxContextIT / BillingCycleSweepVertxContextIT do).
+      #
+      # Measured 2026-07-26: 11 services qualify, only 2 exercise it. The other 9 are baselined in
+      # the producer — the list may only SHRINK, and a stale entry (a service that now IS covered)
+      # is reported too, so the debt cannot quietly become permanent.
+      #
+      # Detection is narrow on purpose: only `quarkus.scheduler.enabled` set to `true` counts. A
+      # looser sweep for the string `scheduler.enabled` scored card-issuance as covered on
+      # `scheduler(enabled = false).enforceRetention()` — a direct call with an unrelated feature
+      # flag, i.e. exactly what this rule rejects.
+      scheduler_exercised_in_tests: true
+      scheduler_exercised_ci_producer: ".github/scripts/check-scheduler-exercised.py"
 
 
     # ---------------------------------------------------------------------------------------

--- a/openbank-infra/gitops/components/pid/pid-opa-bundle.yaml
+++ b/openbank-infra/gitops/components/pid/pid-opa-bundle.yaml
@@ -9,7 +9,7 @@ metadata:
     app.kubernetes.io/name: pid-service
     app.kubernetes.io/part-of: pid
   annotations:
-    openbank.tech/policy-checksum: "35daa5197486302d"
+    openbank.tech/policy-checksum: "e3cb11c1e76365c7"
 data:
   rest.rego: |
     # SPDX-License-Identifier: Apache-2.0
@@ -2787,6 +2787,28 @@ data:
             jdbc-postgresql (build.gradle.kts) — it has no OLTP datasource to reach. The
             reconciliation reads the warehouse and the WORM archive over blocking clients.
       ci_producer: ".github/scripts/check-no-runblocking-in-scheduled.py"
+
+      # The structural reason the HR000068 class was invisible (#2204). `quarkus.scheduler.enabled:
+      # false` under %test is a reasonable default — it stops crons firing during unrelated tests —
+      # but it leaves only DIRECT method calls, and a direct call supplies the very Vert.x context
+      # the scheduler does not. So `scheduler.sweep()` in a test passes against a body that can
+      # never work as a cron. The guard above catches ONE defect shape; only running the real cron
+      # catches the next.
+      #
+      # Rule: a service that disables the scheduler under %test AND has an @Scheduled method must
+      # have at least one test that sets `quarkus.scheduler.enabled=true` (a @TestProfile with a
+      # shrunken cron, as LedgerSchedulerVertxContextIT / BillingCycleSweepVertxContextIT do).
+      #
+      # Measured 2026-07-26: 11 services qualify, only 2 exercise it. The other 9 are baselined in
+      # the producer — the list may only SHRINK, and a stale entry (a service that now IS covered)
+      # is reported too, so the debt cannot quietly become permanent.
+      #
+      # Detection is narrow on purpose: only `quarkus.scheduler.enabled` set to `true` counts. A
+      # looser sweep for the string `scheduler.enabled` scored card-issuance as covered on
+      # `scheduler(enabled = false).enforceRetention()` — a direct call with an unrelated feature
+      # flag, i.e. exactly what this rule rejects.
+      scheduler_exercised_in_tests: true
+      scheduler_exercised_ci_producer: ".github/scripts/check-scheduler-exercised.py"
 
 
     # ---------------------------------------------------------------------------------------

--- a/openbank-infra/gitops/components/pid/pid-service.yaml
+++ b/openbank-infra/gitops/components/pid/pid-service.yaml
@@ -22,7 +22,7 @@ spec:
       annotations:
         # Rolls the pod when the OPA bundle changes — subPath mounts do NOT hot-reload.
         # Kept in sync by gen-pid-opa-bundle.sh (do not hand-edit).
-        openbank.tech/policy-checksum: "35daa5197486302d"
+        openbank.tech/policy-checksum: "e3cb11c1e76365c7"
     spec:
       securityContext:
         runAsNonRoot: true

--- a/openbank-infra/gitops/components/psd2-service/psd2-opa-bundle.yaml
+++ b/openbank-infra/gitops/components/psd2-service/psd2-opa-bundle.yaml
@@ -9,7 +9,7 @@ metadata:
     app.kubernetes.io/name: psd2-service
     app.kubernetes.io/part-of: psd2
   annotations:
-    openbank.tech/policy-checksum: "203a0633ebaaac95"
+    openbank.tech/policy-checksum: "1a9afe5d0b9295a9"
 data:
   rest.rego: |
     # SPDX-License-Identifier: Apache-2.0
@@ -2860,6 +2860,28 @@ data:
             jdbc-postgresql (build.gradle.kts) — it has no OLTP datasource to reach. The
             reconciliation reads the warehouse and the WORM archive over blocking clients.
       ci_producer: ".github/scripts/check-no-runblocking-in-scheduled.py"
+
+      # The structural reason the HR000068 class was invisible (#2204). `quarkus.scheduler.enabled:
+      # false` under %test is a reasonable default — it stops crons firing during unrelated tests —
+      # but it leaves only DIRECT method calls, and a direct call supplies the very Vert.x context
+      # the scheduler does not. So `scheduler.sweep()` in a test passes against a body that can
+      # never work as a cron. The guard above catches ONE defect shape; only running the real cron
+      # catches the next.
+      #
+      # Rule: a service that disables the scheduler under %test AND has an @Scheduled method must
+      # have at least one test that sets `quarkus.scheduler.enabled=true` (a @TestProfile with a
+      # shrunken cron, as LedgerSchedulerVertxContextIT / BillingCycleSweepVertxContextIT do).
+      #
+      # Measured 2026-07-26: 11 services qualify, only 2 exercise it. The other 9 are baselined in
+      # the producer — the list may only SHRINK, and a stale entry (a service that now IS covered)
+      # is reported too, so the debt cannot quietly become permanent.
+      #
+      # Detection is narrow on purpose: only `quarkus.scheduler.enabled` set to `true` counts. A
+      # looser sweep for the string `scheduler.enabled` scored card-issuance as covered on
+      # `scheduler(enabled = false).enforceRetention()` — a direct call with an unrelated feature
+      # flag, i.e. exactly what this rule rejects.
+      scheduler_exercised_in_tests: true
+      scheduler_exercised_ci_producer: ".github/scripts/check-scheduler-exercised.py"
 
 
     # ---------------------------------------------------------------------------------------

--- a/openbank-infra/gitops/components/psd2-service/psd2-service.yaml
+++ b/openbank-infra/gitops/components/psd2-service/psd2-service.yaml
@@ -18,7 +18,7 @@ spec:
       annotations:
         # Rolls the pod when the OPA bundle changes — subPath mounts do NOT hot-reload.
         # Kept in sync by gen-psd2-opa-bundle.sh (do not hand-edit).
-        openbank.tech/policy-checksum: "203a0633ebaaac95"
+        openbank.tech/policy-checksum: "1a9afe5d0b9295a9"
       labels: {app.kubernetes.io/name: psd2-service, app.kubernetes.io/part-of: psd2}
     spec:
       securityContext:

--- a/openbank-infra/gitops/components/sanctions-service/sanctions-opa-bundle.yaml
+++ b/openbank-infra/gitops/components/sanctions-service/sanctions-opa-bundle.yaml
@@ -9,7 +9,7 @@ metadata:
     app.kubernetes.io/name: sanctions-service
     app.kubernetes.io/part-of: sanctions
   annotations:
-    openbank.tech/policy-checksum: "36012bf14359fa89"
+    openbank.tech/policy-checksum: "bee101daa2f81453"
 data:
   rest.rego: |
     # SPDX-License-Identifier: Apache-2.0
@@ -2765,6 +2765,28 @@ data:
             jdbc-postgresql (build.gradle.kts) — it has no OLTP datasource to reach. The
             reconciliation reads the warehouse and the WORM archive over blocking clients.
       ci_producer: ".github/scripts/check-no-runblocking-in-scheduled.py"
+
+      # The structural reason the HR000068 class was invisible (#2204). `quarkus.scheduler.enabled:
+      # false` under %test is a reasonable default — it stops crons firing during unrelated tests —
+      # but it leaves only DIRECT method calls, and a direct call supplies the very Vert.x context
+      # the scheduler does not. So `scheduler.sweep()` in a test passes against a body that can
+      # never work as a cron. The guard above catches ONE defect shape; only running the real cron
+      # catches the next.
+      #
+      # Rule: a service that disables the scheduler under %test AND has an @Scheduled method must
+      # have at least one test that sets `quarkus.scheduler.enabled=true` (a @TestProfile with a
+      # shrunken cron, as LedgerSchedulerVertxContextIT / BillingCycleSweepVertxContextIT do).
+      #
+      # Measured 2026-07-26: 11 services qualify, only 2 exercise it. The other 9 are baselined in
+      # the producer — the list may only SHRINK, and a stale entry (a service that now IS covered)
+      # is reported too, so the debt cannot quietly become permanent.
+      #
+      # Detection is narrow on purpose: only `quarkus.scheduler.enabled` set to `true` counts. A
+      # looser sweep for the string `scheduler.enabled` scored card-issuance as covered on
+      # `scheduler(enabled = false).enforceRetention()` — a direct call with an unrelated feature
+      # flag, i.e. exactly what this rule rejects.
+      scheduler_exercised_in_tests: true
+      scheduler_exercised_ci_producer: ".github/scripts/check-scheduler-exercised.py"
 
 
     # ---------------------------------------------------------------------------------------

--- a/openbank-infra/gitops/components/sanctions-service/sanctions-service.yaml
+++ b/openbank-infra/gitops/components/sanctions-service/sanctions-service.yaml
@@ -49,7 +49,7 @@ spec:
       annotations:
         # Rolls the pods when the OPA bundle changes — subPath mounts do NOT hot-reload.
         # Kept in sync by gen-sanctions-opa-bundle.sh (do not hand-edit).
-        openbank.tech/policy-checksum: "36012bf14359fa89"
+        openbank.tech/policy-checksum: "bee101daa2f81453"
     spec:
       securityContext:
         runAsNonRoot: true

--- a/openbank-infra/gitops/components/sca/sca-opa-bundle.yaml
+++ b/openbank-infra/gitops/components/sca/sca-opa-bundle.yaml
@@ -9,7 +9,7 @@ metadata:
     app.kubernetes.io/name: sca-service
     app.kubernetes.io/part-of: sca
   annotations:
-    openbank.tech/policy-checksum: "b9af5f6fb370102f"
+    openbank.tech/policy-checksum: "063fa8c5eead820d"
 data:
   rest.rego: |
     # SPDX-License-Identifier: Apache-2.0
@@ -2801,6 +2801,28 @@ data:
             jdbc-postgresql (build.gradle.kts) — it has no OLTP datasource to reach. The
             reconciliation reads the warehouse and the WORM archive over blocking clients.
       ci_producer: ".github/scripts/check-no-runblocking-in-scheduled.py"
+
+      # The structural reason the HR000068 class was invisible (#2204). `quarkus.scheduler.enabled:
+      # false` under %test is a reasonable default — it stops crons firing during unrelated tests —
+      # but it leaves only DIRECT method calls, and a direct call supplies the very Vert.x context
+      # the scheduler does not. So `scheduler.sweep()` in a test passes against a body that can
+      # never work as a cron. The guard above catches ONE defect shape; only running the real cron
+      # catches the next.
+      #
+      # Rule: a service that disables the scheduler under %test AND has an @Scheduled method must
+      # have at least one test that sets `quarkus.scheduler.enabled=true` (a @TestProfile with a
+      # shrunken cron, as LedgerSchedulerVertxContextIT / BillingCycleSweepVertxContextIT do).
+      #
+      # Measured 2026-07-26: 11 services qualify, only 2 exercise it. The other 9 are baselined in
+      # the producer — the list may only SHRINK, and a stale entry (a service that now IS covered)
+      # is reported too, so the debt cannot quietly become permanent.
+      #
+      # Detection is narrow on purpose: only `quarkus.scheduler.enabled` set to `true` counts. A
+      # looser sweep for the string `scheduler.enabled` scored card-issuance as covered on
+      # `scheduler(enabled = false).enforceRetention()` — a direct call with an unrelated feature
+      # flag, i.e. exactly what this rule rejects.
+      scheduler_exercised_in_tests: true
+      scheduler_exercised_ci_producer: ".github/scripts/check-scheduler-exercised.py"
 
 
     # ---------------------------------------------------------------------------------------

--- a/openbank-infra/gitops/components/sca/sca-service.yaml
+++ b/openbank-infra/gitops/components/sca/sca-service.yaml
@@ -28,7 +28,7 @@ spec:
       annotations:
         # Rolls the pods when the OPA bundle changes — subPath mounts do NOT hot-reload.
         # Kept in sync by gen-sca-opa-bundle.sh (do not hand-edit).
-        openbank.tech/policy-checksum: "b9af5f6fb370102f"
+        openbank.tech/policy-checksum: "063fa8c5eead820d"
     spec:
       securityContext:
         runAsNonRoot: true

--- a/openbank-infra/gitops/components/statements/statement-opa-bundle.yaml
+++ b/openbank-infra/gitops/components/statements/statement-opa-bundle.yaml
@@ -9,7 +9,7 @@ metadata:
     app.kubernetes.io/name: statement-service
     app.kubernetes.io/part-of: statements
   annotations:
-    openbank.tech/policy-checksum: "387b29c5274737a1"
+    openbank.tech/policy-checksum: "445251103ea59298"
 data:
   rest.rego: |
     # SPDX-License-Identifier: Apache-2.0
@@ -2831,6 +2831,28 @@ data:
             jdbc-postgresql (build.gradle.kts) — it has no OLTP datasource to reach. The
             reconciliation reads the warehouse and the WORM archive over blocking clients.
       ci_producer: ".github/scripts/check-no-runblocking-in-scheduled.py"
+
+      # The structural reason the HR000068 class was invisible (#2204). `quarkus.scheduler.enabled:
+      # false` under %test is a reasonable default — it stops crons firing during unrelated tests —
+      # but it leaves only DIRECT method calls, and a direct call supplies the very Vert.x context
+      # the scheduler does not. So `scheduler.sweep()` in a test passes against a body that can
+      # never work as a cron. The guard above catches ONE defect shape; only running the real cron
+      # catches the next.
+      #
+      # Rule: a service that disables the scheduler under %test AND has an @Scheduled method must
+      # have at least one test that sets `quarkus.scheduler.enabled=true` (a @TestProfile with a
+      # shrunken cron, as LedgerSchedulerVertxContextIT / BillingCycleSweepVertxContextIT do).
+      #
+      # Measured 2026-07-26: 11 services qualify, only 2 exercise it. The other 9 are baselined in
+      # the producer — the list may only SHRINK, and a stale entry (a service that now IS covered)
+      # is reported too, so the debt cannot quietly become permanent.
+      #
+      # Detection is narrow on purpose: only `quarkus.scheduler.enabled` set to `true` counts. A
+      # looser sweep for the string `scheduler.enabled` scored card-issuance as covered on
+      # `scheduler(enabled = false).enforceRetention()` — a direct call with an unrelated feature
+      # flag, i.e. exactly what this rule rejects.
+      scheduler_exercised_in_tests: true
+      scheduler_exercised_ci_producer: ".github/scripts/check-scheduler-exercised.py"
 
 
     # ---------------------------------------------------------------------------------------

--- a/openbank-infra/gitops/components/statements/statement-service.yaml
+++ b/openbank-infra/gitops/components/statements/statement-service.yaml
@@ -26,7 +26,7 @@ spec:
       annotations:
         # Rolls the pod when the OPA bundle changes — subPath mounts do NOT hot-reload.
         # Kept in sync by gen-statement-opa-bundle.sh (do not hand-edit).
-        openbank.tech/policy-checksum: "387b29c5274737a1"
+        openbank.tech/policy-checksum: "445251103ea59298"
       labels:
         app.kubernetes.io/name: statement-service
         app.kubernetes.io/part-of: statements

--- a/openbank-infra/gitops/components/tpp-registry/tpp-registry-opa-bundle.yaml
+++ b/openbank-infra/gitops/components/tpp-registry/tpp-registry-opa-bundle.yaml
@@ -9,7 +9,7 @@ metadata:
     app.kubernetes.io/name: tpp-registry-service
     app.kubernetes.io/part-of: tpp-registry
   annotations:
-    openbank.tech/policy-checksum: "b9f4512fda708846"
+    openbank.tech/policy-checksum: "d6fb50201013c510"
 data:
   rest.rego: |
     # SPDX-License-Identifier: Apache-2.0
@@ -2768,6 +2768,28 @@ data:
             jdbc-postgresql (build.gradle.kts) — it has no OLTP datasource to reach. The
             reconciliation reads the warehouse and the WORM archive over blocking clients.
       ci_producer: ".github/scripts/check-no-runblocking-in-scheduled.py"
+
+      # The structural reason the HR000068 class was invisible (#2204). `quarkus.scheduler.enabled:
+      # false` under %test is a reasonable default — it stops crons firing during unrelated tests —
+      # but it leaves only DIRECT method calls, and a direct call supplies the very Vert.x context
+      # the scheduler does not. So `scheduler.sweep()` in a test passes against a body that can
+      # never work as a cron. The guard above catches ONE defect shape; only running the real cron
+      # catches the next.
+      #
+      # Rule: a service that disables the scheduler under %test AND has an @Scheduled method must
+      # have at least one test that sets `quarkus.scheduler.enabled=true` (a @TestProfile with a
+      # shrunken cron, as LedgerSchedulerVertxContextIT / BillingCycleSweepVertxContextIT do).
+      #
+      # Measured 2026-07-26: 11 services qualify, only 2 exercise it. The other 9 are baselined in
+      # the producer — the list may only SHRINK, and a stale entry (a service that now IS covered)
+      # is reported too, so the debt cannot quietly become permanent.
+      #
+      # Detection is narrow on purpose: only `quarkus.scheduler.enabled` set to `true` counts. A
+      # looser sweep for the string `scheduler.enabled` scored card-issuance as covered on
+      # `scheduler(enabled = false).enforceRetention()` — a direct call with an unrelated feature
+      # flag, i.e. exactly what this rule rejects.
+      scheduler_exercised_in_tests: true
+      scheduler_exercised_ci_producer: ".github/scripts/check-scheduler-exercised.py"
 
 
     # ---------------------------------------------------------------------------------------

--- a/openbank-infra/gitops/components/tpp-registry/tpp-registry-service.yaml
+++ b/openbank-infra/gitops/components/tpp-registry/tpp-registry-service.yaml
@@ -23,7 +23,7 @@ spec:
       annotations:
         # Rolls the pod when the OPA bundle changes (subPath mounts do not hot-reload).
         # Kept in sync by gen-tpp-registry-opa-bundle.sh (do not hand-edit).
-        openbank.tech/policy-checksum: "b9f4512fda708846"
+        openbank.tech/policy-checksum: "d6fb50201013c510"
     spec:
       securityContext:
         runAsNonRoot: true

--- a/openbank-libs/governance/rules.yaml
+++ b/openbank-libs/governance/rules.yaml
@@ -1330,6 +1330,28 @@ scheduled_methods:
         reconciliation reads the warehouse and the WORM archive over blocking clients.
   ci_producer: ".github/scripts/check-no-runblocking-in-scheduled.py"
 
+  # The structural reason the HR000068 class was invisible (#2204). `quarkus.scheduler.enabled:
+  # false` under %test is a reasonable default — it stops crons firing during unrelated tests —
+  # but it leaves only DIRECT method calls, and a direct call supplies the very Vert.x context
+  # the scheduler does not. So `scheduler.sweep()` in a test passes against a body that can
+  # never work as a cron. The guard above catches ONE defect shape; only running the real cron
+  # catches the next.
+  #
+  # Rule: a service that disables the scheduler under %test AND has an @Scheduled method must
+  # have at least one test that sets `quarkus.scheduler.enabled=true` (a @TestProfile with a
+  # shrunken cron, as LedgerSchedulerVertxContextIT / BillingCycleSweepVertxContextIT do).
+  #
+  # Measured 2026-07-26: 11 services qualify, only 2 exercise it. The other 9 are baselined in
+  # the producer — the list may only SHRINK, and a stale entry (a service that now IS covered)
+  # is reported too, so the debt cannot quietly become permanent.
+  #
+  # Detection is narrow on purpose: only `quarkus.scheduler.enabled` set to `true` counts. A
+  # looser sweep for the string `scheduler.enabled` scored card-issuance as covered on
+  # `scheduler(enabled = false).enforceRetention()` — a direct call with an unrelated feature
+  # flag, i.e. exactly what this rule rejects.
+  scheduler_exercised_in_tests: true
+  scheduler_exercised_ci_producer: ".github/scripts/check-scheduler-exercised.py"
+
 
 # ---------------------------------------------------------------------------------------
 # Kafka topic existence (issue #2598). A service may only reference a topic that exists.


### PR DESCRIPTION
Answers the closing question of #2204 — *"worth checking which other services disable the scheduler in test"* — with a measurement, and encodes the result as a ratchet.

## The measurement

**11 services** disable `quarkus.scheduler.enabled` under `%test` **and** have an `@Scheduled` method. **Only 2 exercise it in a test** — ledger and billing, both from the #2187 fixes.

The other **9** are: `aml`, `balance`, `card-issuance`, `interest`, `notification`, `onboarding`, `sanctions`, `sdd`, `statement`. Six of those are money-path. Their `@Scheduled` methods **have never been run by a real cron, anywhere** — not in production, not in a test.

## Why it matters

This is the structural gap #2187 closed with. Disabling the scheduler in tests is a reasonable default; it stops crons firing during unrelated tests. Its cost is that what remains is **direct method calls — and a direct call supplies the very Vert.x context the scheduler does not.** So `scheduler.sweep()` in a test passes against a body that can never work as a cron.

#2187 found **five such jobs, three money-path, that had never executed** while every test was green. `check-no-runblocking-in-scheduled.py` catches that one defect shape. It cannot catch the next one. Only running the real cron can.

## My own first sweep was wrong, which set the detection rule

The loose version grepped test sources for the string `scheduler.enabled` and scored `card-issuance` as **covered** — on this line:

```kotlin
scheduler(enabled = false).enforceRetention()
```

A direct method call with an unrelated feature flag. Precisely the shape this rule exists to reject, counted as evidence against it. So detection is narrow: only `quarkus.scheduler.enabled` set to `true` counts, and Kotlin comments are stripped with a nesting-aware stripper (Kotlin block comments nest — a non-greedy `/* … */` closes early on a KDoc containing `/*`).

## Ratchet, not a wall

The 9 predate the rule and are baselined, so CI is green today. A **new** service fails. A **stale** entry — one that now *is* covered — is reported too, so the debt cannot quietly become permanent. Same idiom as `scheduled_methods.runblocking_allowlist` directly above it in `rules.yaml`.

## Falsified in both directions, not assumed

| Input | Result |
|---|---|
| drop a service from the baseline | `NEW openbank-sdd-service`, `--enforce` exits **1** |
| add a covered service to the baseline | `BASELINE is stale` warning |
| `--selftest` (runs every CI invocation) | 4 pattern cases both ways, incl. the card-issuance false positive, + asserts the scan still finds the two services #2204 names |

The selftest runs on every invocation for the reason this repo has learned twice: once the fleet is clean the flagging branch would never execute again, and a gate that has only ever passed is unfalsified.

## Diff shape and process

68 files: the guard, the `ci.yml` wiring, `rules.yaml`, and **37 regenerated OPA bundles**.

Bundle regeneration was the **last** step before the commit, verified idempotent, with the runway re-checked for competing governance PRs immediately beforehand (#2457 — idempotency only proves stability against whatever `rules.yaml` said at that moment). yamllint finding **sets** diffed against `origin/main`: identical but for `line-length`, and the added lines sit at the file's own median width.

## What this does NOT do

It does not write the 9 missing tests. Each needs a `@TestProfile` that re-enables the scheduler with a shrunken cron plus domain knowledge of what the job should do — nine separate pieces of work, and #2204's items 3 and 4 (the backfill decision, watching the first live runs) remain the owner's.

Refs #2204, #2187