### PR TITLE
docs(infra): capture the realm-import and fleet-rebuild footguns (#2540, #2549)

### DIFF
--- a/openbank-infra/CLAUDE.md
+++ b/openbank-infra/CLAUDE.md
@@ -8,6 +8,28 @@ out of it (they are path-scoped, not less important — several are live-inciden
 ## Engineering notes (common pitfalls)
 
 ### GitOps / Kubernetes
+- **`realm-template.json` is read ONLY on Keycloak's cold start (`--import-realm`), so editing it
+  changes nothing on a running realm — and ArgoCD reports `Synced/Healthy` throughout.** ArgoCD
+  manages the ConfigMap, and the ConfigMap does match the repo; the drift is one layer below what it
+  can see. Measured 2026-07-26 (#2540): the live sandbox realm was missing `ROLE_KYC`,
+  `ROLE_KYC_OPENER`, `ROLE_KYC_REVIEWER` and `ROLE_SUPERVISOR` that the template declared, and
+  carried `ROLE_DEMO` that it did not. Nothing 403'd — every `@RolesAllowed` also listed a role that
+  did exist — but the ADR-0116 KYC four-eyes split cannot be enforced by roles that are absent, so
+  opener and reviewer both fell through to ROLE_ADMIN/ROLE_OPERATOR and one identity could do both.
+  `check-roles-allowed-realm.py` was green the whole time: it compares the code to the TEMPLATE.
+  Verify against the realm that actually runs (`kcadm.sh get roles -r openbank`) before believing any
+  claim about which roles exist, and apply additions with `kcadm` — the file alone will not.
+- **A change under `openbank-libs-*/src/main/**` rebuilds the WHOLE fleet, and the deploy that
+  follows fails on pacts that do not exist yet.** `Detect changed services` returned 58 modules for
+  the #2475 role sweep; at `max-parallel: 4` and ~45 min a service that is ~11 h of queue. Auto-deploy
+  fires on `push`, runs immediately, and `can-i-deploy` answers `NOT deployable` — not because a
+  contract regressed but because the build has not published anything yet ("no pacts or verifications
+  have been published for version X"). Both readings print identically. Auto-deploy has no
+  `workflow_run` trigger and no schedule, so it never retries: the services stay on the old image
+  until some later commit happens to touch them (issue #2549). After any libs-level change, expect to
+  re-dispatch `auto-deploy.yml` per service once Services CI finishes, and check
+  `GET /pacticipants/openbank-<svc>/versions/<sha>` on the broker before concluding anything from a
+  `can-i-deploy` verdict.
 - **A no-swap node under memory pressure can hang whole-guest instead of OOM-killing.** Kernel
   reclaim livelocks; kubelet and the SSM agent starve together while EC2 status checks stay `ok`,
   so the node lingers NotReady and singleton pods (e.g. the ArgoCD application-controller) strand


### PR DESCRIPTION
## Co

Dvě lekce ze srovnávání sandboxu po #2442. Obě pálí při práci v `openbank-infra/`, takže patří sem, ne do root `CLAUDE.md` (`rules.yaml: knowledge_capture`).

### 1. `realm-template.json` se aplikuje jen při cold startu — a ArgoCD ten drift nevidí

ArgoCD spravuje ConfigMap, ConfigMap repu odpovídá, takže `Synced/Healthy` je pravdivé a k ničemu. Živý realm postrádal **čtyři role**, které template deklaruje, a nesl jednu, kterou nedeklaruje.

Nic neházelo 403 — každá `@RolesAllowed` uváděla i roli, která existovala. Proto to přežilo. Cena byla jinde: **ADR-0116 KYC four-eyes nemůže být vynucený rolemi, které neexistují**, takže opener i reviewer propadli na `ROLE_ADMIN`/`ROLE_OPERATOR` a jedna identita mohla udělat obojí.

`check-roles-allowed-realm.py` byl celou dobu zelený — porovnává kód s **template**. Template s běžícím realmem neporovnává nic (#2540).

### 2. Změna v libs přestaví celou flotilu a následný deploy selže na pactech, které ještě nevznikly

`Detect changed services` vrátil pro #2475 **58 modulů**; při `max-parallel: 4` a ~45 min na službu je to ~11 hodin fronty. Auto-deploy se spouští na `push`, běží hned, a `can-i-deploy` odpoví `NOT deployable` — ne proto, že se rozbil kontrakt, ale protože build ještě nic nepublikoval. **Obě čtení se vypíšou stejně.** A protože auto-deploy nemá `workflow_run` ani schedule, už to nikdy nezkusí (#2549).

## Proč to stojí za zápis

Obojí je tvar, který tenhle repo platí opakovaně: kontrola má pravdu o tom, co měří, a mlčí o tom, co neměří. U obou je zapsaná i **sonda, která by to odhalila** — `kcadm.sh get roles -r openbank`, `GET /pacticipants/<svc>/versions/<sha>` — protože v obou případech byla odpověď otázkou minut, jakmile někdo položil správnou otázku.

## Linked issues

Refs #2540, #2549