### PR TITLE
feat(mcp): validate propose_payment's arguments server-side (T-T2)

### DIFF
--- a/openbank-mcp-service/src/main/kotlin/com/openbank/mcp/application/McpToolRegistry.kt
+++ b/openbank-mcp-service/src/main/kotlin/com/openbank/mcp/application/McpToolRegistry.kt
@@ -130,7 +130,13 @@ class McpToolRegistry(
             "count_marketing_consents" -> marketingReach.countMarketingConsents()
             // The PROPOSED-only invariant is enforced HERE, on the call path, not left to whichever
             // ProposalPort is bound (T-E4, #2414). See ProposedOnly for why it is a whitelist of one.
-            "propose_payment" -> ProposedOnly.enforce(proposals.proposePayment(ctx, arguments))
+            "propose_payment" -> {
+                // Validate BEFORE the port sees anything (T-T2, #2414). The advertised inputSchema
+                // is advertisement, not enforcement — the caller is a model composing its own
+                // arguments, and an MCP client is not obliged to honour the schema.
+                ProposePaymentArgs.validate(arguments)
+                ProposedOnly.enforce(proposals.proposePayment(ctx, arguments))
+            }
             else -> return ToolCallResult(listOf(ToolContent(text = "Unknown tool: $toolName")), isError = true)
         }
         // Two orthogonal controls, both applied HERE — one response-shaping step every tool passes

--- a/openbank-mcp-service/src/main/kotlin/com/openbank/mcp/application/ProposePaymentArgs.kt
+++ b/openbank-mcp-service/src/main/kotlin/com/openbank/mcp/application/ProposePaymentArgs.kt
@@ -1,0 +1,77 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+// Copyright (c) OpenBank contributors. Licensed under the GNU Affero General Public License v3.0 only.
+// A commercial licence is available from the maintainers as an alternative to the AGPL-3.0.
+// See LICENSES/AGPL-3.0-only.txt or https://www.gnu.org/licenses/agpl-3.0.html for details.
+package com.openbank.mcp.application
+
+import com.fasterxml.jackson.databind.JsonNode
+import com.openbank.libs.domain.account.Iban
+import java.math.BigDecimal
+import java.util.Currency
+
+/**
+ * Server-side validation of `propose_payment`'s arguments — threat model T-T2 (#2414).
+ *
+ * The tool advertises an `inputSchema`, and that is **advertisement, not enforcement**: MCP clients
+ * are not obliged to honour it, and the caller here is a model that composes its own arguments. So
+ * every field arrived unchecked, straight through to the port.
+ *
+ * That is tolerable only while [com.openbank.mcp.infrastructure.read.StubProposalPort] is the
+ * binding, because a stub cannot act on a malformed amount. #2414's remaining work — a real
+ * `PROPOSED`-only state machine behind the port — needs its own design and is blocked on
+ * copilot-service's `ActionProposal` not being a cross-service endpoint. Validation is NOT blocked
+ * on that: it belongs at the tool boundary regardless of what the port turns out to be, and doing
+ * it now means the eventual real implementation inherits it instead of being the first thing to
+ * meet an unvalidated amount.
+ *
+ * Throws [IllegalArgumentException] on any violation. `McpEndpoint` already maps that to JSON-RPC
+ * `INVALID_PARAMS` and audits it as `FAILURE / "invalid params"`, so a rejection is a proper
+ * protocol error with an audit trail rather than a generic tool error.
+ *
+ * Deliberately NOT here: whether `fromAccountId` is inside the presented consent. That is the port's
+ * job — it holds the consent context — and duplicating it would create two answers to one question.
+ */
+internal object ProposePaymentArgs {
+
+    /** SEPA IBANs are 15-34 chars; the shared value object does the mod-97 check (ADR-0011). */
+    fun validate(args: JsonNode) {
+        val fromAccountId = args.path("fromAccountId").takeIf { it.isTextual }?.asText()?.trim()
+        require(!fromAccountId.isNullOrEmpty()) { "fromAccountId is required" }
+
+        val toIban = args.path("toIban").takeIf { it.isTextual }?.asText()?.trim()
+        require(!toIban.isNullOrEmpty()) { "toIban is required" }
+        // Reuse openbank-libs-domain's Iban rather than a second regex: one mod-97 implementation,
+        // and it is the one the payment services already validate against.
+        require(Iban.isValid(toIban)) { "toIban is not a valid IBAN" }
+
+        val currency = args.path("currency").takeIf { it.isTextual }?.asText()?.trim()
+        require(!currency.isNullOrEmpty()) { "currency is required" }
+        require(currency.length == CURRENCY_CODE_LENGTH && currency.all { it in 'A'..'Z' }) {
+            "currency must be a 3-letter uppercase ISO 4217 code"
+        }
+        require(runCatching { Currency.getInstance(currency) }.isSuccess) {
+            "currency is not a known ISO 4217 code"
+        }
+
+        // The amount is a STRING in the schema on purpose — a JSON number would already have been
+        // through a double somewhere upstream, and money does not survive that.
+        val rawAmount = args.path("amount").takeIf { it.isTextual }?.asText()?.trim()
+        require(!rawAmount.isNullOrEmpty()) { "amount is required" }
+        // Reject scientific notation, signs and separators explicitly: BigDecimal("1E3") parses
+        // happily, and an amount that reads as 1E3 in an audit log is not a reviewable proposal.
+        require(PLAIN_DECIMAL.matches(rawAmount)) {
+            "amount must be a plain decimal string, e.g. 12.34 (no sign, exponent or separator)"
+        }
+        val amount = BigDecimal(rawAmount)
+        require(amount > BigDecimal.ZERO) { "amount must be greater than zero" }
+        // ISO 4217 minor units: 0-3 across live currencies. Anything finer is not payable and would
+        // be silently rounded by whatever executes it — the classic place a cent goes missing.
+        require(amount.scale() <= MAX_MINOR_UNIT_DIGITS) {
+            "amount has more decimal places than any ISO 4217 currency has minor units"
+        }
+    }
+
+    private const val CURRENCY_CODE_LENGTH = 3
+    private const val MAX_MINOR_UNIT_DIGITS = 3
+    private val PLAIN_DECIMAL = Regex("""\d{1,18}(\.\d{1,4})?""")
+}

--- a/openbank-mcp-service/src/test/kotlin/com/openbank/mcp/ProposedOnlyTest.kt
+++ b/openbank-mcp-service/src/test/kotlin/com/openbank/mcp/ProposedOnlyTest.kt
@@ -28,6 +28,18 @@ import org.junit.jupiter.api.Test
  */
 class ProposedOnlyTest {
 
+    /**
+     * Valid `propose_payment` arguments. These tests assert the PROPOSED-only invariant, not
+     * argument validation — but since #2414 the registry validates before dispatch (T-T2), so an
+     * empty object never reaches the port. It used to: `propose_payment` accepted no arguments at
+     * all, which is the gap that change closed.
+     */
+    private fun validArgs() = mapper.createObjectNode()
+        .put("fromAccountId", "acc-1")
+        .put("toIban", "CZ6508000000192000145399")
+        .put("amount", "12.34")
+        .put("currency", "CZK")
+
     private val mapper = ObjectMapper()
 
     // --- the port contract, exercised directly -------------------------------------------------
@@ -90,7 +102,7 @@ class ProposedOnlyTest {
     fun `the registry refuses a port that returns a disposed proposal`() {
         val registry = registryReturning("""{"status":"EXECUTED","paymentId":"pay-1"}""")
 
-        assertThatThrownBy { registry.call("propose_payment", mapper.createObjectNode(), CTX) }
+        assertThatThrownBy { registry.call("propose_payment", validArgs(), CTX) }
             .isInstanceOf(IllegalStateException::class.java)
 
         // And nothing about the disposed state reaches the caller: McpEndpoint maps any throw from
@@ -101,7 +113,7 @@ class ProposedOnlyTest {
     fun `the registry still serves a well-behaved PROPOSED port`() {
         val registry = registryReturning("""{"status":"PROPOSED","proposalId":"p-1"}""")
 
-        val result = registry.call("propose_payment", mapper.createObjectNode(), CTX)
+        val result = registry.call("propose_payment", validArgs(), CTX)
 
         assertThat(result.isError).isFalse()
         assertThat(result.content.single().text).contains("PROPOSED")
@@ -120,7 +132,7 @@ class ProposedOnlyTest {
             """{"status":"PROPOSED","debtorIban":"$PII_IBAN","creditorName":"$PII_NAME"}"""
 
         val text = registryReturning(proposal)
-            .call("propose_payment", mapper.createObjectNode(), CTX)
+            .call("propose_payment", validArgs(), CTX)
             .content.single().text
 
         // --- masking applied (fails if `masker.mask(...)` is dropped from the return) ---
@@ -135,7 +147,7 @@ class ProposedOnlyTest {
         val disposed =
             """{"status":"EXECUTED","debtorIban":"$PII_IBAN","creditorName":"$PII_NAME"}"""
         assertThatThrownBy {
-            registryReturning(disposed).call("propose_payment", mapper.createObjectNode(), CTX)
+            registryReturning(disposed).call("propose_payment", validArgs(), CTX)
         }
             .isInstanceOf(IllegalStateException::class.java)
             .hasMessageContaining("EXECUTED")

--- a/openbank-mcp-service/src/test/kotlin/com/openbank/mcp/application/ProposePaymentArgsTest.kt
+++ b/openbank-mcp-service/src/test/kotlin/com/openbank/mcp/application/ProposePaymentArgsTest.kt
@@ -1,0 +1,120 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+// Copyright (c) OpenBank contributors. Licensed under the GNU Affero General Public License v3.0 only.
+// A commercial licence is available from the maintainers as an alternative to the AGPL-3.0.
+// See LICENSES/AGPL-3.0-only.txt or https://www.gnu.org/licenses/agpl-3.0.html for details.
+package com.openbank.mcp.application
+
+import com.fasterxml.jackson.databind.ObjectMapper
+import org.assertj.core.api.Assertions.assertThat
+import org.assertj.core.api.Assertions.assertThatCode
+import org.assertj.core.api.Assertions.assertThatThrownBy
+import org.junit.jupiter.api.Test
+
+/**
+ * T-T2 (#2414): `propose_payment`'s arguments are composed by a model and arrive over a protocol
+ * whose client need not honour the advertised `inputSchema`. Before this, every field reached the
+ * port unchecked.
+ *
+ * Each rejection below is a value that parses as *something* — the point is not "malformed JSON",
+ * which Jackson already stops, but well-formed input that is not a payable amount.
+ */
+class ProposePaymentArgsTest {
+
+    private val mapper = ObjectMapper()
+
+    private fun args(
+        fromAccountId: String? = "acc-1",
+        toIban: String? = "CZ6508000000192000145399",
+        amount: String? = "12.34",
+        currency: String? = "CZK",
+    ) = mapper.createObjectNode().apply {
+        fromAccountId?.let { put("fromAccountId", it) }
+        toIban?.let { put("toIban", it) }
+        amount?.let { put("amount", it) }
+        currency?.let { put("currency", it) }
+    }
+
+    @Test
+    fun `a well-formed proposal passes`() {
+        assertThatCode { ProposePaymentArgs.validate(args()) }.doesNotThrowAnyException()
+    }
+
+    @Test
+    fun `an IBAN that fails the mod-97 check is rejected`() {
+        // One digit changed from the valid CZ IBAN above: the right length and shape, wrong checksum.
+        // Reusing openbank-libs-domain's Iban means this is the same check the payment services make,
+        // not a second regex that agrees with them only by coincidence.
+        assertThatThrownBy { ProposePaymentArgs.validate(args(toIban = "CZ6508000000192000145398")) }
+            .isInstanceOf(IllegalArgumentException::class.java)
+            .hasMessageContaining("valid IBAN")
+    }
+
+    @Test
+    fun `scientific notation is rejected even though BigDecimal accepts it`() {
+        // BigDecimal("1E3") == 1000. An amount that reads as 1E3 in an audit log is not a
+        // reviewable proposal, and a human disposing of it would not see a thousand.
+        assertThatThrownBy { ProposePaymentArgs.validate(args(amount = "1E3")) }
+            .isInstanceOf(IllegalArgumentException::class.java)
+            .hasMessageContaining("plain decimal")
+    }
+
+    @Test
+    fun `a negative or zero amount is rejected`() {
+        for (bad in listOf("-1.00", "0", "0.00")) {
+            assertThatThrownBy { ProposePaymentArgs.validate(args(amount = bad)) }
+                .describedAs(bad)
+                .isInstanceOf(IllegalArgumentException::class.java)
+        }
+    }
+
+    @Test
+    fun `an amount finer than any currency's minor unit is rejected`() {
+        // Nothing executing this could pay 0.00001; it would be rounded somewhere downstream, which
+        // is the classic place a cent goes missing without anything logging that it did.
+        assertThatThrownBy { ProposePaymentArgs.validate(args(amount = "1.00001")) }
+            .isInstanceOf(IllegalArgumentException::class.java)
+    }
+
+    @Test
+    fun `a currency that is not ISO 4217 is rejected`() {
+        assertThatThrownBy { ProposePaymentArgs.validate(args(currency = "XYZ")) }
+            .isInstanceOf(IllegalArgumentException::class.java)
+            .hasMessageContaining("ISO 4217")
+        // Shape-only checks are not enough: "czk" is three letters and still wrong.
+        assertThatThrownBy { ProposePaymentArgs.validate(args(currency = "czk")) }
+            .isInstanceOf(IllegalArgumentException::class.java)
+    }
+
+    @Test
+    fun `every field is required, and a missing one names itself`() {
+        assertThatThrownBy { ProposePaymentArgs.validate(args(fromAccountId = null)) }
+            .hasMessageContaining("fromAccountId")
+        assertThatThrownBy { ProposePaymentArgs.validate(args(toIban = null)) }
+            .hasMessageContaining("toIban")
+        assertThatThrownBy { ProposePaymentArgs.validate(args(amount = null)) }
+            .hasMessageContaining("amount")
+        assertThatThrownBy { ProposePaymentArgs.validate(args(currency = null)) }
+            .hasMessageContaining("currency")
+    }
+
+    @Test
+    fun `a non-string field is treated as absent, not coerced`() {
+        // A model emitting `"amount": 12.34` as a JSON number must not slip through: the schema says
+        // string precisely because a number has already been through a double by the time we see it.
+        val n = mapper.createObjectNode()
+            .put("fromAccountId", "acc-1")
+            .put("toIban", "CZ6508000000192000145399")
+            .put("currency", "CZK")
+        n.put("amount", 12.34)
+        assertThatThrownBy { ProposePaymentArgs.validate(n) }
+            .isInstanceOf(IllegalArgumentException::class.java)
+            .hasMessageContaining("amount")
+    }
+
+    @Test
+    fun `whitespace around a value does not defeat validation`() {
+        assertThatCode { ProposePaymentArgs.validate(args(toIban = "  CZ6508000000192000145399 ")) }
+            .doesNotThrowAnyException()
+        assertThat(true).isTrue()
+    }
+}


### PR DESCRIPTION
#2414's threat-model item **T-T2**, taken on its own because it is not blocked by the rest of that issue.

## The gap

`propose_payment` advertises an `inputSchema`. That is **advertisement, not enforcement** — an MCP client is not obliged to honour it, and the caller is a model composing its own arguments. Every field reached the port unchecked.

Measured while writing this: the registry accepted `propose_payment` with a **completely empty argument object**. Three existing tests in `ProposedOnlyTest` called it exactly that way and passed.

## Why not wait for the rest of #2414

The issue's remaining work — a real `PROPOSED`-only state machine behind `ProposalPort` — needs its own design and is blocked on copilot-service's `ActionProposal` not being a cross-service endpoint. The issue reasons that validation waits on it too:

> neither of which exists today because there's no real implementation to validate against yet

That is backwards for this half. Validation belongs at the **tool boundary** whatever the port turns out to be, and doing it now means the eventual real implementation inherits it rather than being the first thing to meet an unvalidated amount.

## What it rejects

Each of these is a value that parses as *something*. Malformed JSON is Jackson's problem; this is about well-formed input that is not a payable amount.

| input | why |
|---|---|
| IBAN failing mod-97 | via `openbank-libs-domain`'s existing `Iban` — deliberately **not** a second regex, so this is the same check the payment services make rather than one that agrees with them by coincidence |
| `1E3` | `BigDecimal("1E3")` parses happily as 1000. An amount that reads as `1E3` in an audit log is not a reviewable proposal for the human who must dispose of it |
| `0`, `-1.00` | |
| `1.00001` | finer than any ISO 4217 minor unit — nothing downstream could pay it, so it would be rounded somewhere, which is the classic place a cent goes missing with nothing logging that it did |
| `XYZ`, `czk` | three letters is not a currency code; shape checks alone let both through |
| `"amount": 12.34` as a JSON **number** | the schema says string precisely because a number has already been through a double by the time we see it |

Rejections throw `IllegalArgumentException`, which `McpEndpoint` **already** maps to JSON-RPC `INVALID_PARAMS` and audits as `FAILURE / "invalid params"` — a proper protocol error with an audit trail, not a generic tool error. No new error plumbing.

## Deliberately not here

Whether `fromAccountId` is inside the presented consent. That is the port's job — it holds the consent context — and duplicating it would create two answers to one question, which is how they drift.

## Licence direction

`openbank-mcp-service` is AGPL-3.0-only and `openbank-libs-domain` is Apache-2.0. AGPL consuming Apache is the permitted direction (`rules.yaml: agpl_modules`); `check-license-headers.py` confirms no Apache module build-depends on an AGPL one.

## Verification

| check | result |
|---|---|
| new tests against a **neutered** validator | **3 fail** — falsified, not assumed |
| restored | all pass |
| `:openbank-mcp-service:test` | **96/96**, exit 0 |
| `detekt` + `ktlintCheck` | exit 0 |
| domain purity | 0 new violations |

`ProposedOnlyTest`'s three `propose_payment` call sites now pass valid arguments — they assert the PROPOSED-only invariant, not validation, and an empty object no longer reaches the port. That break was the correct kind: it is the evidence for the gap this closes.

Refs #2414