### PR TITLE
fix(ci): build analytics-sink with the ClickHouse sink binding

### DIFF
--- a/.github/workflows/auto-deploy.yml
+++ b/.github/workflows/auto-deploy.yml
@@ -349,6 +349,13 @@ jobs:
 
       - name: Build fast-jars (parallel)
         id: build
+        # analytics-sink selects its AnalyticsSink binding with @IfBuildProperty, which Quarkus
+        # resolves at AUGMENTATION time — the runtime env var the gitops manifest sets cannot
+        # reach it. Without this the image ships the @Default LoggingAnalyticsSink, which logs
+        # every event and writes none, so ClickHouse silently stays empty while the consumer
+        # looks perfectly healthy. Harmless for the other services: only this module reads it.
+        env:
+          ANALYTICS_SINK_TYPE: clickhouse
         run: |
           set -euo pipefail
           SERVICES='${{ needs.changes.outputs.services }}'


### PR DESCRIPTION
## The bug

`analytics-sink` selects its `AnalyticsSink` implementation with `@IfBuildProperty(name = "openbank.analytics.sink.type", stringValue = "clickhouse")`. Quarkus resolves that at **augmentation time**. The gitops manifest sets `ANALYTICS_SINK_TYPE=clickhouse` as a **runtime** env var, and its comment even claims *"the image is built with ANALYTICS_SINK_TYPE=clickhouse"* — but the build step never set it. Every image this pipeline produced therefore shipped the `@Default` `LoggingAnalyticsSink`.

## Why it went unnoticed

The failure is silent and looks healthy. The consumer subscribes to its topics, polls, logs `analytics row eventId=... type=...` for each event, commits offsets and reports `UP` — while writing nothing to ClickHouse. Nothing is dead-lettered, because nothing failed.

It surfaced through ADR-0192: a screen-feedback submission reached the edge, the screenshot landed in S3 (`customer-edge/feedback/019f9fad-...png`) and the sink logged the event as consumed — yet `bronze_events` had zero `SCREEN_FEEDBACK` rows and `gold_screen_feedback` stayed empty.

## The fix

Set it as build-step env. Smallest change that matches what the manifest already documents, and only this module reads the property, so other services are unaffected.

## After merge

Auto deploy has to rebuild **openbank-analytics-sink** so an image with the binding actually exists — the currently deployed `sandbox-ee41caf6` does not have it.

Worth a follow-up: a build-time toggle that a runtime env var appears to control is a trap that will catch someone again. Either make ClickHouse the default binding, or switch to a runtime lookup so the manifest's env var means what it looks like it means.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Closes #2655
