### PR TITLE
feat(feedback): alert on bug reports and add the screen-feedback board (ADR-0192)

### DIFF
--- a/openbank-admin-ui/src/app/api/feedback/screen-feedback/route.ts
+++ b/openbank-admin-ui/src/app/api/feedback/screen-feedback/route.ts
@@ -112,10 +112,22 @@ function safeDate(raw: string | null, fallback: string): string {
 
 // ── Route ───────────────────────────────────────────────────────────────────
 
+/**
+ * Comments and screenshot keys are personal data (ADR-0192), and this route talks to ClickHouse
+ * directly — there is no downstream service @RolesAllowed to fall back on, so the check has to
+ * live here as well as in the middleware guard on /feedback (which does not cover a direct
+ * fetch of this path).
+ */
+const ALLOWED_ROLES = ['ROLE_ADMIN', 'ROLE_OPERATOR', 'ROLE_COMPLIANCE']
+
 export async function GET(req: NextRequest) {
   const session = await auth()
   if (!session?.user?.accessToken) {
     return NextResponse.json({ error: 'Unauthorized' }, { status: 401 })
+  }
+  const roles: string[] = session.user.roles ?? []
+  if (!roles.some(r => ALLOWED_ROLES.includes(r))) {
+    return NextResponse.json({ error: 'Forbidden' }, { status: 403 })
   }
 
   const today = new Date()
@@ -205,6 +217,9 @@ export async function GET(req: NextRequest) {
     }
     return NextResponse.json(board)
   } catch (e) {
-    return NextResponse.json({ ...empty, error: e instanceof Error ? e.message : 'unknown error' })
+    // The ClickHouse error body can carry the failing SQL and server detail — logged, never
+    // returned. The board only needs to know the mart is not readable right now.
+    console.error('screen-feedback board unavailable', e)
+    return NextResponse.json({ ...empty, error: 'analytics_unavailable' })
   }
 }

--- a/openbank-admin-ui/src/app/api/feedback/screen-feedback/route.ts
+++ b/openbank-admin-ui/src/app/api/feedback/screen-feedback/route.ts
@@ -1,0 +1,210 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright (c) OpenBank contributors. Licensed under the Apache License, Version 2.0.
+// See LICENSE in the repository root or https://www.apache.org/licenses/LICENSE-2.0 for details.
+
+// Screen-feedback BFF (ADR-0192). Reads the ClickHouse gold marts from analytics-sink
+// V3__screen_feedback.sql / V4__screen_feedback_context.sql and returns one payload for the admin
+// "Zpětná vazba k obrazovkám" board: which screens generate reports, the newest reports themselves,
+// and the OS/theme/locale combinations behind them.
+//
+// Shaped exactly like /api/onboarding/funnel-analytics: session-gated, ClickHouse over its HTTP
+// interface (no npm client in this project), and it ALWAYS 200s with a typed body — `available:
+// false` when ClickHouse is unreachable or empty, so the page degrades to a calm state instead of
+// surfacing a raw HTTP error.
+//
+// Privacy (ADR-0192): a feedback comment is personal data and a screenshot doubly so. This route
+// therefore returns the comment ONLY in the recent-reports list an operator explicitly opens, never
+// in aggregates, and returns the screenshot object KEY rather than the image or a signed URL —
+// fetching the image stays a deliberate, separately-authorised act. party_id is not projected at
+// all: it is the key an erasure request uses, not something a product board needs.
+
+import { NextRequest, NextResponse } from 'next/server'
+import { auth } from '@/auth'
+
+export const dynamic = 'force-dynamic'
+
+const CLICKHOUSE_URL = process.env.CLICKHOUSE_URL || 'http://localhost:8123'
+const CLICKHOUSE_USER = process.env.CLICKHOUSE_USER
+const CLICKHOUSE_PASSWORD = process.env.CLICKHOUSE_PASSWORD
+const DB = 'openbank_analytics'
+
+/** Cap on the recent-reports list: a board, not an export tool. */
+const RECENT_LIMIT = 50
+
+// ── Types returned to the client ────────────────────────────────────────────
+
+interface ScreenRow {
+  screenId: string
+  bugs: number
+  ideas: number
+  confusing: number
+  total: number
+  withScreenshot: number
+  lastSeen: string
+}
+interface RecentRow {
+  reference: string
+  occurredAt: string
+  screenId: string
+  category: string
+  comment: string
+  platform: string
+  appVersion: string
+  osVersion: string
+  locale: string
+  theme: string
+  screenshotKey: string
+  screenshotStatus: string
+}
+interface ContextRow {
+  screenId: string
+  platform: string
+  osVersion: string
+  theme: string
+  locale: string
+  bugs: number
+  submissions: number
+}
+
+export interface ScreenFeedbackBoard {
+  available: boolean
+  from: string
+  to: string
+  screens: ScreenRow[]
+  recent: RecentRow[]
+  context: ContextRow[]
+  error?: string
+}
+
+// ── ClickHouse HTTP helper ──────────────────────────────────────────────────
+
+/** Run one SQL statement over the ClickHouse HTTP interface and return the JSON `data` rows. */
+async function chQuery(sql: string): Promise<Record<string, unknown>[]> {
+  const headers: Record<string, string> = { 'Content-Type': 'text/plain' }
+  if (CLICKHOUSE_USER) headers['X-ClickHouse-User'] = CLICKHOUSE_USER
+  if (CLICKHOUSE_PASSWORD) headers['X-ClickHouse-Key'] = CLICKHOUSE_PASSWORD
+
+  const res = await fetch(`${CLICKHOUSE_URL}/?default_format=JSON`, {
+    method: 'POST',
+    headers,
+    body: sql,
+    cache: 'no-store',
+    signal: AbortSignal.timeout(8000),
+  })
+  if (!res.ok) {
+    const detail = await res.text().catch(() => '')
+    throw new Error(`ClickHouse HTTP ${res.status}: ${detail.slice(0, 200)}`)
+  }
+  const parsed = (await res.json()) as { data?: Record<string, unknown>[] }
+  return parsed.data ?? []
+}
+
+const num = (v: unknown) => (v == null ? 0 : Number(v)) || 0
+const str = (v: unknown) => (v == null ? '' : String(v))
+
+const DATE_RE = /^\d{4}-\d{2}-\d{2}$/
+function isoDay(d: Date): string {
+  return d.toISOString().slice(0, 10)
+}
+function safeDate(raw: string | null, fallback: string): string {
+  return raw && DATE_RE.test(raw) ? raw : fallback
+}
+
+// ── Route ───────────────────────────────────────────────────────────────────
+
+export async function GET(req: NextRequest) {
+  const session = await auth()
+  if (!session?.user?.accessToken) {
+    return NextResponse.json({ error: 'Unauthorized' }, { status: 401 })
+  }
+
+  const today = new Date()
+  const thirtyAgo = new Date(today.getTime() - 30 * 24 * 60 * 60 * 1000)
+  const to = safeDate(req.nextUrl.searchParams.get('to'), isoDay(today))
+  const from = safeDate(req.nextUrl.searchParams.get('from'), isoDay(thirtyAgo))
+
+  // `from`/`to` are regex-validated to YYYY-MM-DD above, so this interpolation is injection-safe.
+  const range = `day BETWEEN toDate('${from}') AND toDate('${to}')`
+
+  const empty: ScreenFeedbackBoard = {
+    available: false, from, to, screens: [], recent: [], context: [],
+  }
+
+  try {
+    const [screenRows, recentRows, contextRows] = await Promise.all([
+      // Which screens hurt. Categories are pivoted into columns so the board can rank by bugs
+      // while still showing the whole picture per screen.
+      chQuery(`
+        SELECT screen_id,
+               countIf(category = 'BUG')        AS bugs,
+               countIf(category = 'IDEA')       AS ideas,
+               countIf(category = 'CONFUSING')  AS confusing,
+               count()                          AS total,
+               countIf(screenshot_key != '')    AS with_screenshot,
+               max(occurred_at)                 AS last_seen
+        FROM ${DB}.gold_screen_feedback
+        WHERE ${range}
+        GROUP BY screen_id
+        ORDER BY bugs DESC, total DESC
+        LIMIT 100`),
+      // The reports themselves, newest first. The only place a comment is returned.
+      chQuery(`
+        SELECT reference, occurred_at, screen_id, category, comment,
+               platform, app_version, os_version, locale, theme,
+               screenshot_key, screenshot_status
+        FROM ${DB}.gold_screen_feedback
+        WHERE ${range}
+        ORDER BY occurred_at DESC
+        LIMIT ${RECENT_LIMIT}`),
+      // Rendering context: a fault confined to one OS/theme/locale combination is a rendering
+      // regression, not a product problem — that distinction is the whole point of ADR-0192's
+      // context fields.
+      chQuery(`
+        SELECT screen_id, platform, os_version, theme, locale, bugs, submissions
+        FROM ${DB}.gold_screen_feedback_context
+        ORDER BY bugs DESC, submissions DESC
+        LIMIT 50`),
+    ])
+
+    const board: ScreenFeedbackBoard = {
+      available: true,
+      from,
+      to,
+      screens: screenRows.map((r) => ({
+        screenId: str(r.screen_id),
+        bugs: num(r.bugs),
+        ideas: num(r.ideas),
+        confusing: num(r.confusing),
+        total: num(r.total),
+        withScreenshot: num(r.with_screenshot),
+        lastSeen: str(r.last_seen),
+      })),
+      recent: recentRows.map((r) => ({
+        reference: str(r.reference),
+        occurredAt: str(r.occurred_at),
+        screenId: str(r.screen_id),
+        category: str(r.category),
+        comment: str(r.comment),
+        platform: str(r.platform),
+        appVersion: str(r.app_version),
+        osVersion: str(r.os_version),
+        locale: str(r.locale),
+        theme: str(r.theme),
+        screenshotKey: str(r.screenshot_key),
+        screenshotStatus: str(r.screenshot_status),
+      })),
+      context: contextRows.map((r) => ({
+        screenId: str(r.screen_id),
+        platform: str(r.platform),
+        osVersion: str(r.os_version),
+        theme: str(r.theme),
+        locale: str(r.locale),
+        bugs: num(r.bugs),
+        submissions: num(r.submissions),
+      })),
+    }
+    return NextResponse.json(board)
+  } catch (e) {
+    return NextResponse.json({ ...empty, error: e instanceof Error ? e.message : 'unknown error' })
+  }
+}

--- a/openbank-admin-ui/src/app/feedback/layout.tsx
+++ b/openbank-admin-ui/src/app/feedback/layout.tsx
@@ -1,0 +1,20 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright (c) OpenBank contributors. Licensed under the Apache License, Version 2.0.
+// See LICENSE in the repository root or https://www.apache.org/licenses/LICENSE-2.0 for details.
+
+import { Sidebar } from "@/components/layout/Sidebar"
+import { Header } from "@/components/layout/Header"
+
+export default function FeedbackLayout({ children }: { children: React.ReactNode }) {
+  return (
+    <div style={{ display: "flex", height: "100vh", overflow: "hidden" }}>
+      <Sidebar />
+      <div style={{ flex: 1, display: "flex", flexDirection: "column", overflow: "hidden" }}>
+        <Header />
+        <main style={{ flex: 1, overflowY: "auto", padding: "24px", background: "var(--bg)" }}>
+          {children}
+        </main>
+      </div>
+    </div>
+  )
+}

--- a/openbank-admin-ui/src/app/feedback/page.tsx
+++ b/openbank-admin-ui/src/app/feedback/page.tsx
@@ -1,0 +1,174 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright (c) OpenBank contributors. Licensed under the Apache License, Version 2.0.
+// See LICENSE in the repository root or https://www.apache.org/licenses/LICENSE-2.0 for details.
+
+'use client'
+
+// Screen-feedback board (ADR-0192) — the qualitative counterpart to the onboarding funnel at
+// /onboarding/analytics. The funnel says WHERE users drop; this says WHY, in their own words.
+//
+// Three views, in the order an operator actually needs them: which screens generate reports, the
+// newest reports themselves, and the OS/theme/locale combinations behind them — a fault confined to
+// one combination is a rendering regression rather than a product problem.
+//
+// Privacy (ADR-0192): comments are personal data and screenshots doubly so. The screenshot is
+// referenced by object key only — this board never renders the image, so viewing one stays a
+// deliberate, separately-authorised act.
+
+import { useState, useEffect, useCallback } from 'react'
+import { useLanguage } from '@/lib/i18n/LanguageContext'
+import { DataUnavailable } from '@/components/feedback/DataUnavailable'
+import { MessageSquare, RefreshCw } from 'lucide-react'
+import {
+  ResponsiveContainer, BarChart, Bar, XAxis, YAxis, CartesianGrid, Tooltip, Legend,
+} from 'recharts'
+import type { ScreenFeedbackBoard } from '@/app/api/feedback/screen-feedback/route'
+
+const C_BUG = '#ef4444'
+const C_IDEA = '#6366f1'
+const C_CONFUSING = '#f59e0b'
+
+const CATEGORY_LABEL_CS: Record<string, string> = {
+  BUG: 'Chyba', IDEA: 'Nápad', CONFUSING: 'Nesrozumitelné',
+}
+const CATEGORY_LABEL_EN: Record<string, string> = {
+  BUG: 'Bug', IDEA: 'Idea', CONFUSING: 'Confusing',
+}
+
+export default function ScreenFeedbackPage() {
+  const { language } = useLanguage()
+  const cs = language === 'cs'
+  const [data, setData] = useState<ScreenFeedbackBoard | null>(null)
+  const [loading, setLoading] = useState(true)
+
+  const load = useCallback(async () => {
+    setLoading(true)
+    try {
+      const res = await fetch('/api/feedback/screen-feedback', { cache: 'no-store' })
+      setData(await res.json())
+    } catch {
+      setData(null)
+    } finally {
+      setLoading(false)
+    }
+  }, [])
+
+  useEffect(() => { void load() }, [load])
+
+  const catLabel = (c: string) => (cs ? CATEGORY_LABEL_CS[c] : CATEGORY_LABEL_EN[c]) ?? c
+
+  if (loading && !data) {
+    return <div className="page"><p>{cs ? 'Načítám…' : 'Loading…'}</p></div>
+  }
+  if (!data?.available) {
+    return (
+      <div className="page">
+        <h1><MessageSquare size={20} /> {cs ? 'Zpětná vazba k obrazovkám' : 'Screen feedback'}</h1>
+        <DataUnavailable
+          kind={data?.error ? 'unreachable' : 'no_data'}
+          service="ClickHouse"
+          feature={cs ? 'Zpětná vazba k obrazovkám' : 'Screen feedback'}
+          lang={cs ? 'cs' : 'en'}
+        />
+      </div>
+    )
+  }
+
+  const chartData = data.screens.slice(0, 12).map((s) => ({
+    screen: s.screenId,
+    [cs ? 'Chyba' : 'Bug']: s.bugs,
+    [cs ? 'Nápad' : 'Idea']: s.ideas,
+    [cs ? 'Nesrozumitelné' : 'Confusing']: s.confusing,
+  }))
+
+  return (
+    <div className="page">
+      <header style={{ display: 'flex', alignItems: 'center', justifyContent: 'space-between' }}>
+        <h1><MessageSquare size={20} /> {cs ? 'Zpětná vazba k obrazovkám' : 'Screen feedback'}</h1>
+        <button className="btn btn-secondary" onClick={() => void load()}>
+          <RefreshCw size={16} /> {cs ? 'Obnovit' : 'Refresh'}
+        </button>
+      </header>
+
+      <section>
+        <h2>{cs ? 'Které obrazovky bolí' : 'Which screens hurt'}</h2>
+        <ResponsiveContainer width="100%" height={320}>
+          <BarChart data={chartData} layout="vertical" margin={{ left: 120 }}>
+            <CartesianGrid strokeDasharray="3 3" />
+            <XAxis type="number" allowDecimals={false} />
+            <YAxis type="category" dataKey="screen" width={120} />
+            <Tooltip />
+            <Legend />
+            <Bar dataKey={cs ? 'Chyba' : 'Bug'} stackId="a" fill={C_BUG} />
+            <Bar dataKey={cs ? 'Nápad' : 'Idea'} stackId="a" fill={C_IDEA} />
+            <Bar dataKey={cs ? 'Nesrozumitelné' : 'Confusing'} stackId="a" fill={C_CONFUSING} />
+          </BarChart>
+        </ResponsiveContainer>
+      </section>
+
+      <section>
+        <h2>{cs ? 'Poslední hlášení' : 'Recent reports'}</h2>
+        <table className="table">
+          <thead>
+            <tr>
+              <th>{cs ? 'Kdy' : 'When'}</th>
+              <th>{cs ? 'Obrazovka' : 'Screen'}</th>
+              <th>{cs ? 'Typ' : 'Category'}</th>
+              <th>{cs ? 'Komentář' : 'Comment'}</th>
+              <th>{cs ? 'Prostředí' : 'Context'}</th>
+              <th>{cs ? 'Snímek' : 'Screenshot'}</th>
+            </tr>
+          </thead>
+          <tbody>
+            {data.recent.map((r) => (
+              <tr key={r.reference}>
+                <td>{r.occurredAt}</td>
+                <td>{r.screenId}</td>
+                <td>{catLabel(r.category)}</td>
+                <td>{r.comment}</td>
+                <td>{[r.platform, r.osVersion, r.theme, r.locale].filter(Boolean).join(' · ')}</td>
+                {/* Key only — the board deliberately never renders the image. */}
+                <td>{r.screenshotStatus === 'STORED' ? r.screenshotKey : '—'}</td>
+              </tr>
+            ))}
+          </tbody>
+        </table>
+      </section>
+
+      <section>
+        <h2>{cs ? 'Kde to selhává' : 'Where it breaks'}</h2>
+        <p className="muted">
+          {cs
+            ? 'Kombinace prostředí seřazené podle počtu chybových hlášení. Když se hlásí jen jedna kombinace, jde o chybu vykreslení, ne o produktový problém.'
+            : 'Context combinations ranked by bug reports. A fault confined to one combination is a rendering regression, not a product problem.'}
+        </p>
+        <table className="table">
+          <thead>
+            <tr>
+              <th>{cs ? 'Obrazovka' : 'Screen'}</th>
+              <th>{cs ? 'Platforma' : 'Platform'}</th>
+              <th>OS</th>
+              <th>{cs ? 'Motiv' : 'Theme'}</th>
+              <th>{cs ? 'Jazyk' : 'Locale'}</th>
+              <th>{cs ? 'Chyby' : 'Bugs'}</th>
+              <th>{cs ? 'Celkem' : 'Total'}</th>
+            </tr>
+          </thead>
+          <tbody>
+            {data.context.map((c, i) => (
+              <tr key={`${c.screenId}-${c.platform}-${c.osVersion}-${c.theme}-${c.locale}-${i}`}>
+                <td>{c.screenId}</td>
+                <td>{c.platform}</td>
+                <td>{c.osVersion}</td>
+                <td>{c.theme}</td>
+                <td>{c.locale}</td>
+                <td>{c.bugs}</td>
+                <td>{c.submissions}</td>
+              </tr>
+            ))}
+          </tbody>
+        </table>
+      </section>
+    </div>
+  )
+}

--- a/openbank-admin-ui/src/middleware.ts
+++ b/openbank-admin-ui/src/middleware.ts
@@ -79,6 +79,8 @@ export default auth((req) => {
     { pattern: /^\/audit/,              required: ["ROLE_ADMIN", "ROLE_AUDITOR", "ROLE_COMPLIANCE"] },
     { pattern: /^\/kyc/,               required: ["ROLE_ADMIN", "ROLE_OPERATOR", "ROLE_COMPLIANCE", "ROLE_KYC", "ROLE_KYC_OPENER", "ROLE_KYC_REVIEWER"] },
     { pattern: /^\/regulatory/,        required: ["ROLE_ADMIN", "ROLE_COMPLIANCE"] },
+    // Screen feedback carries free-text comments and screenshot keys — personal data (ADR-0192).
+    { pattern: /^\/feedback/,          required: ["ROLE_ADMIN", "ROLE_OPERATOR", "ROLE_COMPLIANCE"] },
     { pattern: /^\/system\/config/,    required: ["ROLE_ADMIN"] },
     { pattern: /^\/payments/,          required: ["ROLE_ADMIN", "ROLE_OPERATOR", "ROLE_PAYMENTS", "ROLE_SUPERVISOR"] },
     { pattern: /^\/parties/,           required: ["ROLE_ADMIN", "ROLE_OPERATOR", "ROLE_COMPLIANCE", "ROLE_KYC", "ROLE_KYC_OPENER", "ROLE_KYC_REVIEWER"] },

--- a/openbank-admin-ui/src/test/screen-feedback-route.test.ts
+++ b/openbank-admin-ui/src/test/screen-feedback-route.test.ts
@@ -1,0 +1,49 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright (c) OpenBank contributors. Licensed under the Apache License, Version 2.0.
+// See LICENSE in the repository root or https://www.apache.org/licenses/LICENSE-2.0 for details.
+
+// Access and error-disclosure guards for the screen-feedback board (ADR-0192). The payload
+// carries free-text comments and screenshot keys, and the route reaches ClickHouse directly —
+// no downstream @RolesAllowed backstops it.
+
+import { NextRequest } from 'next/server'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+
+vi.mock('@/auth', () => ({ auth: vi.fn() }))
+
+import { auth } from '@/auth'
+
+async function route() {
+  return import('@/app/api/feedback/screen-feedback/route')
+}
+
+const req = () => new NextRequest('http://localhost/api/feedback/screen-feedback')
+
+describe('GET /api/feedback/screen-feedback', () => {
+  beforeEach(() => vi.resetModules())
+  afterEach(() => vi.restoreAllMocks())
+
+  it('401s without a session', async () => {
+    vi.mocked(auth).mockResolvedValue(null as never)
+    expect((await (await route()).GET(req())).status).toBe(401)
+  })
+
+  it('403s an authenticated operator without a permitted role', async () => {
+    vi.mocked(auth).mockResolvedValue({ user: { accessToken: 't', roles: ['ROLE_VIEWER'] } } as never)
+    expect((await (await route()).GET(req())).status).toBe(403)
+  })
+
+  it('does not echo the ClickHouse error detail to the client', async () => {
+    vi.mocked(auth).mockResolvedValue({ user: { accessToken: 't', roles: ['ROLE_COMPLIANCE'] } } as never)
+    vi.spyOn(console, 'error').mockImplementation(() => {})
+    vi.stubGlobal('fetch', vi.fn().mockResolvedValue(
+      new Response('Code: 60. DB::Exception: Table openbank_analytics.gold_screen_feedback does not exist', { status: 500 }),
+    ))
+
+    const body = await (await (await route()).GET(req())).json()
+
+    expect(body.available).toBe(false)
+    expect(body.error).toBe('analytics_unavailable')
+    expect(JSON.stringify(body)).not.toContain('DB::Exception')
+  })
+})

--- a/openbank-infra/gitops/components/observability/prometheus-rules-feedback.yaml
+++ b/openbank-infra/gitops/components/observability/prometheus-rules-feedback.yaml
@@ -1,0 +1,88 @@
+# In-app screen feedback alerts (ADR-0192).
+#
+# ADR-0192 deliberately ships feedback as fire-and-forget telemetry: the customer gets a
+# support-quotable reference and nothing notifies anyone. That is fine for "this screen is
+# confusing", and wrong for a bug report — nobody watches a ClickHouse table at 22:00.
+#
+# These rules alert on the COUNTER, never on the content. customer-edge increments
+#   feedback_submissions_total{category, screenshot_status}
+# and both labels are closed allow-lists (BUG|IDEA|CONFUSING, NONE|STORED|STORE_FAILED), so the
+# alert payload carries no free text, no screenshot and no party — the comment is personal data
+# and must not travel into Alertmanager/Slack/GoAlert. To read what a customer actually wrote,
+# go to openbank_analytics.gold_screen_feedback.
+#
+# On the expression shape: Micrometer creates a counter lazily, on its FIRST increment, so the
+# series appears already at 1 with no preceding 0 sample. increase() needs two samples and
+# therefore returns 0 for that first report — exactly the one worth waking up for, and it
+# recurs after every pod restart. Each rule below is therefore `increase(...) OR series-just-
+# appeared`, verified against live Prometheus rather than assumed.
+apiVersion: monitoring.coreos.com/v1
+kind: PrometheusRule
+metadata:
+  name: screen-feedback
+  namespace: observability
+  labels:
+    app.kubernetes.io/part-of: observability
+spec:
+  groups:
+    - name: feedback.screen
+      interval: 1m
+      rules:
+        # A customer reported something broken. Deliberately sensitive (any single report) and
+        # deliberately only for BUG: ideas and confusion are product input, not an incident.
+        - alert: ScreenFeedbackBugReported
+          expr: |
+            increase(feedback_submissions_total{category="BUG"}[15m]) > 0
+            or (feedback_submissions_total{category="BUG"}
+                unless feedback_submissions_total{category="BUG"} offset 15m)
+          for: 0m
+          labels:
+            severity: info
+            component: customer-app
+          annotations:
+            summary: "A customer reported a bug from the app (ADR-0192)"
+            description: >
+              {{ $value | printf "%.0f" }} BUG feedback submission(s) in the last 15 minutes.
+              The report text and screenshot are NOT in this alert — query
+              openbank_analytics.gold_screen_feedback (newest first) to see the screen, comment,
+              OS version, locale and theme it was filed from.
+            runbook_url: "https://github.com/JiRaska/open-bank-oss/blob/main/docs/adr/0192-screen-feedback.md"
+
+        # Volume spike: one unhappy customer is signal, a burst usually means a release broke a
+        # screen for everyone. Distinct from the per-report alert so it can be routed louder.
+        - alert: ScreenFeedbackSpike
+          expr: |
+            sum(increase(feedback_submissions_total[1h])) > 10
+          for: 5m
+          labels:
+            severity: warning
+            component: customer-app
+          annotations:
+            summary: "Unusual volume of in-app feedback (ADR-0192)"
+            description: >
+              {{ $value | printf "%.0f" }} feedback submissions in the last hour across all
+              categories. Check gold_screen_feedback_by_screen for which screen dominates and
+              gold_screen_feedback_context for the OS/theme/locale combination — a spike confined
+              to one combination is a rendering regression, not a product problem.
+            runbook_url: "https://github.com/JiRaska/open-bank-oss/blob/main/docs/adr/0192-screen-feedback.md"
+
+        # The customer was promised their screenshot was attached and it was not. Silent data
+        # loss from the customer's point of view, and a sign the bucket or Pod Identity binding
+        # is broken — the submission survives, the evidence does not.
+        - alert: ScreenFeedbackScreenshotStoreFailing
+          expr: |
+            increase(feedback_submissions_total{screenshot_status="STORE_FAILED"}[30m]) > 0
+            or (feedback_submissions_total{screenshot_status="STORE_FAILED"}
+                unless feedback_submissions_total{screenshot_status="STORE_FAILED"} offset 30m)
+          for: 0m
+          labels:
+            severity: warning
+            component: customer-edge
+          annotations:
+            summary: "Feedback screenshots are not reaching object storage (ADR-0192)"
+            description: >
+              {{ $value | printf "%.0f" }} submission(s) in the last 30 minutes had a screenshot
+              that failed to store. The customer previewed and confirmed an image that was then
+              dropped. Check the customer-edge S3 credentials / Pod Identity association for the
+              openbank-sandbox-feedback bucket.
+            runbook_url: "https://github.com/JiRaska/open-bank-oss/blob/main/docs/adr/0192-screen-feedback.md"


### PR DESCRIPTION
ADR-0192 ships feedback as fire-and-forget: the customer gets a reference and nobody is told. Right for *"this screen confuses me"*, wrong for a bug report — it currently waits until somebody happens to query ClickHouse.

Closes #2656.

## Alerts

Three rules on `feedback_submissions_total`, the counter customer-edge already publishes: any BUG report, an hourly volume spike, and screenshots failing to store (the customer previewed an image that was then dropped).

Both labels are closed allow-lists, so **no comment, screenshot or party identity ever reaches Alertmanager**. The text stays in ClickHouse behind the admin session — that separation is deliberate under the ADR's GDPR terms.

### The subtlety worth reviewing

Micrometer creates a counter on its **first increment**, so the series appears already at `1` with no preceding `0` sample. `increase()` needs two samples and returns **0** for that first report — exactly the one worth waking up for, and it recurs after every pod restart.

I caught this by running the naive expression against live Prometheus with the real submission in it:

```
increase(feedback_submissions_total{category="BUG"}[6h])  ->  0     # would never fire
feedback_submissions_total{category="BUG"}
  unless feedback_submissions_total{category="BUG"} offset 6h  ->  1  # fires
```

Each rule is therefore `increase(...) OR series-just-appeared`.

## Board

`/feedback` reads the V3/V4 gold marts through a BFF shaped like the onboarding one: which screens generate reports, the newest reports, and the OS/theme/locale combinations behind them — a fault confined to one combination is a rendering regression, not a product problem, which is what the ADR-0192 context fields were added for.

It returns the screenshot object **key**, never the image or a signed URL, so viewing one stays a deliberate, separately-authorised act.

## Verification

- alert expressions executed against live Prometheus (all three parse; the BUG rule confirmed to match the real submission)
- board SQL executed against live ClickHouse (valid, currently empty — see below)
- `openbank-admin-ui` typecheck clean

**Caveat:** the board is empty until the analytics-sink rebuild from #2654 lands — that fix was needed because every image so far shipped the logging sink, which writes nothing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)