### PR TITLE
feat(consent): answer "does this party consent to this scope" without disclosing the consent

### DIFF
--- a/openbank-consent-service/src/main/kotlin/com/openbank/consent/application/port/in/ConsentUseCases.kt
+++ b/openbank-consent-service/src/main/kotlin/com/openbank/consent/application/port/in/ConsentUseCases.kt
@@ -59,7 +59,26 @@ interface GetConsentUseCase {
 
 interface ValidateConsentUseCase {
     suspend fun validateConsent(command: ValidateConsentCommand): ConsentValidationResult
+
+    /**
+     * Does this party hold an ACTIVE consent for this grantee covering this scope? (ADR-0198 D4.)
+     *
+     * [validateConsent] cannot answer this: it is keyed by consentId, and a caller deciding whether
+     * to send a marketing message holds a partyId and a channel, never a consent id. Reaching it
+     * would mean `GET /party/{partyId}` first — which hands the caller EVERY consent the party has,
+     * including PSD2 account access, to answer a yes/no about marketing. This returns the yes/no.
+     */
+    suspend fun hasActiveConsent(command: CheckConsentCommand): Boolean
 }
+
+/**
+ * A yes/no consent question keyed by what the asking service actually holds.
+ *
+ * Deliberately carries no consent id and returns no consent: ADR-0198 requires a check per send,
+ * and a caller that receives the consent object would be able to cache it, which is the thing the
+ * per-send rule exists to prevent.
+ */
+data class CheckConsentCommand(val partyId: UUID, val granteeId: String, val requiredScope: ConsentScope)
 
 interface ActivateConsentUseCase {
     suspend fun activateConsent(consentId: UUID, scaSessionId: UUID): Consent

--- a/openbank-consent-service/src/main/kotlin/com/openbank/consent/application/usecase/ConsentService.kt
+++ b/openbank-consent-service/src/main/kotlin/com/openbank/consent/application/usecase/ConsentService.kt
@@ -5,6 +5,7 @@
 package com.openbank.consent.application.usecase
 
 import com.openbank.consent.application.port.`in`.ActivateConsentUseCase
+import com.openbank.consent.application.port.`in`.CheckConsentCommand
 import com.openbank.consent.application.port.`in`.CreateConsentCommand
 import com.openbank.consent.application.port.`in`.CreateConsentUseCase
 import com.openbank.consent.application.port.`in`.GetConsentUseCase
@@ -214,6 +215,25 @@ class ConsentService(
 
     override suspend fun listConsentsForGrantee(granteeId: String): List<Consent> =
         consentRepository.findByGranteeId(granteeId)
+
+    /**
+     * ADR-0198 D4's per-send marketing check, answered without disclosing the consent.
+     *
+     * Uses [ConsentRepository.findActiveByGranteeAndParty], which has existed since the repository
+     * was written and had **no caller at all** — the query for this question was already here; only
+     * a way to ask it was missing.
+     *
+     * `isActive` is re-checked in the domain rather than trusted from the repository's ACTIVE
+     * filter, because "status = ACTIVE" and "active right now" are different claims: a consent with
+     * `validTo` in the past still carries status ACTIVE until something transitions it. Asking a
+     * yes/no question is exactly where that difference decides a send.
+     */
+    override suspend fun hasActiveConsent(command: CheckConsentCommand): Boolean {
+        val now = OffsetDateTime.now(clock)
+        return consentRepository
+            .findActiveByGranteeAndParty(command.granteeId, command.partyId)
+            .any { it.isActive(now) && it.hasScope(command.requiredScope) }
+    }
 
     override suspend fun validateConsent(command: ValidateConsentCommand): ConsentValidationResult {
         val consent = consentRepository.findById(command.consentId)

--- a/openbank-consent-service/src/main/kotlin/com/openbank/consent/infrastructure/rest/ConsentResource.kt
+++ b/openbank-consent-service/src/main/kotlin/com/openbank/consent/infrastructure/rest/ConsentResource.kt
@@ -6,6 +6,7 @@ package com.openbank.consent.infrastructure.rest
 
 import com.fasterxml.jackson.databind.ObjectMapper
 import com.openbank.consent.application.port.`in`.ActivateConsentUseCase
+import com.openbank.consent.application.port.`in`.CheckConsentCommand
 import com.openbank.consent.application.port.`in`.CreateConsentCommand
 import com.openbank.consent.application.port.`in`.CreateConsentUseCase
 import com.openbank.consent.application.port.`in`.GetConsentUseCase
@@ -13,6 +14,7 @@ import com.openbank.consent.application.port.`in`.RevokeConsentCommand
 import com.openbank.consent.application.port.`in`.RevokeConsentUseCase
 import com.openbank.consent.application.port.`in`.ValidateConsentCommand
 import com.openbank.consent.application.port.`in`.ValidateConsentUseCase
+import com.openbank.consent.domain.model.ConsentScope
 import com.openbank.consent.infrastructure.rest.dto.ConsentResponse
 import com.openbank.consent.infrastructure.rest.dto.ConsentValidationResponse
 import com.openbank.consent.infrastructure.rest.dto.CreateConsentRequest
@@ -180,6 +182,45 @@ class ConsentResource(
         return ConsentValidationResponse.from(result)
     }
 
+    /**
+     * Does this party hold an ACTIVE marketing (or any) consent for this grantee and scope?
+     * ADR-0198 D4 requires a check per send; this is the call that makes it possible.
+     *
+     * Exists because `POST /{id}/validate` cannot be reached with what a sender holds. A service
+     * deciding whether to send has a partyId and a channel, never a consent id, so it would have to
+     * `GET /party/{partyId}` first — receiving EVERY consent that party holds, PSD2 account access
+     * included, to answer a yes/no about marketing. This returns the yes/no and nothing else.
+     *
+     * Same `consent.validate` action as [validate] on purpose: it is the same question with a
+     * different key, so it needs no new OPA action and no rego change. Authorized on the partyId,
+     * which is the resource the caller actually names.
+     */
+    @GET
+    @Path("/party/{partyId}/grantee/{granteeId}/active")
+    @RolesAllowed("ROLE_OPERATOR", "ROLE_ADMIN", "ROLE_API")
+    @Authorize(action = "consent.validate", resource = "#partyId")
+    @Operation(
+        summary = "Whether a party has an ACTIVE consent for a grantee covering a scope (ADR-0198 D4)",
+    )
+    suspend fun hasActiveConsent(
+        @PathParam("partyId") partyId: UUID,
+        @PathParam("granteeId") granteeId: String,
+        @QueryParam("scope") scope: String,
+    ): ConsentCheckResponse {
+        val required = runCatching { ConsentScope.valueOf(scope) }.getOrNull()
+        requireNotNull(required) { "unknown scope: $scope" }
+        val granted = validateConsent.hasActiveConsent(
+            CheckConsentCommand(partyId = partyId, granteeId = granteeId, requiredScope = required),
+        )
+        return ConsentCheckResponse(granted = granted)
+    }
+
     private fun consentCreateKey(granteeId: String, partyId: UUID, requestId: String) =
         "consent:create:$granteeId:$partyId:$requestId"
 }
+
+/**
+ * The whole answer: a boolean. No consent id, no scopes, no validity window — a caller that
+ * received those could cache them, and ADR-0198 requires a check per send rather than a copy.
+ */
+data class ConsentCheckResponse(val granted: Boolean)

--- a/openbank-consent-service/src/main/resources/openapi.yaml
+++ b/openbank-consent-service/src/main/resources/openapi.yaml
@@ -5,7 +5,7 @@ info:
   title: Consent Service API
   # major == openbank.api.version == URL /api/v1 (ADR-0048). Minor bump (1.0 -> 1.1): additive
   # endpoint only (PATCH /approvals/{id}, ADR-0155 four-eyes) — no breaking change.
-  version: 1.2.0
+  version: 1.3.0
   description: >-
     Data sharing consent lifecycle — create, activate, reject, revoke, validate. PATCH
     /approvals/{id} decides a four-eyes approval paused by the platform's ADR-0155 maker-checker
@@ -71,6 +71,51 @@ paths:
         '403':
           $ref: '#/components/responses/Forbidden'
 
+  /api/v1/consents/party/{partyId}/grantee/{granteeId}/active:
+    get:
+      tags: [Consents]
+      summary: Whether a party holds an ACTIVE consent for a grantee covering a scope (ADR-0198 D4)
+      description: >-
+        Answers the question a sender actually has. `POST /{id}/validate` is keyed by consent id,
+        which a service deciding whether to send a marketing message does not hold — it has a
+        partyId and a channel. Reaching validate would mean listing every consent the party holds,
+        PSD2 account access included, to answer a yes/no about marketing. This returns the yes/no
+        and nothing else: no consent id, no scopes, no validity window, so the answer cannot be
+        cached in place of the per-send check ADR-0198 requires.
+      operationId: hasActiveConsent
+      parameters:
+        - name: partyId
+          in: path
+          required: true
+          schema:
+            type: string
+            format: uuid
+        - name: granteeId
+          in: path
+          required: true
+          description: e.g. the fixed internal marketing grantee `party-service:marketing-comms` (ADR-0205 D3)
+          schema:
+            type: string
+        - name: scope
+          in: query
+          required: true
+          schema:
+            type: string
+            enum: [MARKETING_COMMS_EMAIL, MARKETING_COMMS_PUSH, MARKETING_COMMS_INAPP,
+                   ACCOUNTS_READ, BALANCES_READ, TRANSACTIONS_READ, PAYMENTS_INITIATE]
+      responses:
+        '200':
+          description: Whether the consent exists, is active now, and covers the scope
+          content:
+            application/json:
+              schema:
+                type: object
+                required: [granted]
+                properties:
+                  granted:
+                    type: boolean
+        '400':
+          description: Unknown scope
   /api/v1/consents/party/{partyId}:
     get:
       tags: [Consents]

--- a/openbank-consent-service/src/test/kotlin/com/openbank/consent/application/usecase/ConsentServiceTest.kt
+++ b/openbank-consent-service/src/test/kotlin/com/openbank/consent/application/usecase/ConsentServiceTest.kt
@@ -4,6 +4,7 @@
 
 package com.openbank.consent.application.usecase
 
+import com.openbank.consent.application.port.`in`.CheckConsentCommand
 import com.openbank.consent.application.port.`in`.CreateConsentCommand
 import com.openbank.consent.application.port.`in`.RevokeConsentCommand
 import com.openbank.consent.application.port.`in`.ValidateConsentCommand
@@ -614,4 +615,93 @@ class ConsentServiceTest {
         createdAt = OffsetDateTime.now(),
         updatedAt = OffsetDateTime.now(),
     )
+
+    // ── hasActiveConsent — ADR-0198 D4's per-send marketing check ─────────────────────────────
+    //
+    // `validateConsent` cannot answer this question: it is keyed by consentId, and a service
+    // deciding whether to send a marketing message holds a partyId and a channel. Reaching it would
+    // mean listing EVERY consent the party holds — PSD2 account access included — to answer a
+    // yes/no about marketing.
+
+    @Test
+    fun `hasActiveConsent - an active consent covering the scope grants the send`(): Unit = runBlocking {
+        coEvery { consentRepository.findActiveByGranteeAndParty(MARKETING_GRANTEE, partyId) } returns
+            listOf(consent(granteeId = MARKETING_GRANTEE, scopes = setOf(ConsentScope.MARKETING_COMMS_EMAIL)))
+
+        val granted = service.hasActiveConsent(
+            CheckConsentCommand(partyId, MARKETING_GRANTEE, ConsentScope.MARKETING_COMMS_EMAIL),
+        )
+
+        assertThat(granted).isTrue()
+    }
+
+    @Test
+    fun `hasActiveConsent - consent to email is not consent to push`(): Unit = runBlocking {
+        // Anything coarser than per-scope would leave notification_preference's channel columns as
+        // the only thing separating them — and those are a mute WITHIN a granted consent, not the
+        // GDPR Art. 6(1)(a) basis for sending at all.
+        coEvery { consentRepository.findActiveByGranteeAndParty(MARKETING_GRANTEE, partyId) } returns
+            listOf(consent(granteeId = MARKETING_GRANTEE, scopes = setOf(ConsentScope.MARKETING_COMMS_EMAIL)))
+
+        val granted = service.hasActiveConsent(
+            CheckConsentCommand(partyId, MARKETING_GRANTEE, ConsentScope.MARKETING_COMMS_PUSH),
+        )
+
+        assertThat(granted).isFalse()
+    }
+
+    @Test
+    fun `hasActiveConsent - a REVOKED consent does not grant, even though the repository returned it`(): Unit =
+        runBlocking {
+            // The repository query is named findActive*, so it is tempting to trust its filter and
+            // skip the domain check. This asserts the use case does NOT: `status = ACTIVE` and
+            // "active right now" are different claims, and a yes/no about a send is exactly where
+            // the difference decides whether a message goes out.
+            coEvery { consentRepository.findActiveByGranteeAndParty(MARKETING_GRANTEE, partyId) } returns
+                listOf(
+                    consent(
+                        granteeId = MARKETING_GRANTEE,
+                        status = ConsentStatus.REVOKED,
+                        scopes = setOf(ConsentScope.MARKETING_COMMS_EMAIL),
+                    ),
+                )
+
+            val granted = service.hasActiveConsent(
+                CheckConsentCommand(partyId, MARKETING_GRANTEE, ConsentScope.MARKETING_COMMS_EMAIL),
+            )
+
+            assertThat(granted).isFalse()
+        }
+
+    @Test
+    fun `hasActiveConsent - no consent at all is a refusal, not an error`(): Unit = runBlocking {
+        // Fail closed and quietly: suppressing the send is the normal outcome for most parties,
+        // not an exceptional one, so this must not throw.
+        coEvery { consentRepository.findActiveByGranteeAndParty(MARKETING_GRANTEE, partyId) } returns emptyList()
+
+        val granted = service.hasActiveConsent(
+            CheckConsentCommand(partyId, MARKETING_GRANTEE, ConsentScope.MARKETING_COMMS_EMAIL),
+        )
+
+        assertThat(granted).isFalse()
+    }
+
+    @Test
+    fun `hasActiveConsent - one matching consent among several grants the send`(): Unit = runBlocking {
+        coEvery { consentRepository.findActiveByGranteeAndParty(MARKETING_GRANTEE, partyId) } returns listOf(
+            consent(granteeId = MARKETING_GRANTEE, scopes = setOf(ConsentScope.MARKETING_COMMS_PUSH)),
+            consent(granteeId = MARKETING_GRANTEE, scopes = setOf(ConsentScope.MARKETING_COMMS_EMAIL)),
+        )
+
+        val granted = service.hasActiveConsent(
+            CheckConsentCommand(partyId, MARKETING_GRANTEE, ConsentScope.MARKETING_COMMS_EMAIL),
+        )
+
+        assertThat(granted).isTrue()
+    }
+
+    private companion object {
+        /** ADR-0205 D3's fixed internal grantee. */
+        const val MARKETING_GRANTEE = "party-service:marketing-comms"
+    }
 }


### PR DESCRIPTION
The first real unblock for campaign delivery (ADR-0198 D4 → ADR-0200).

## Marketing sending is currently impossible, and the reason is an unreachable call

`NotificationConsumer.suppressUnconsentedMarketing` suppresses **every** marketing send unconditionally and audits it as:

```
reason: "no_consent_check_wired"
```

The system correctly records that it never checks. ADR-0200 could ship campaign-service complete and it would deliver nothing.

The reason it never checks is that the call its own KDoc names — `POST /api/v1/consents/{id}/validate` — **cannot be made with what a sender holds**. That endpoint is keyed by consent id; a service deciding whether to send has a `partyId` and a channel. The only route is `GET /party/{partyId}` first, which hands the caller **every consent the party holds, PSD2 account access included**, to answer a yes/no about marketing. On a GDPR path that is a data-minimisation problem, not merely an extra hop.

## What this adds

`GET /api/v1/consents/party/{partyId}/grantee/{granteeId}/active?scope=` → `{"granted": true|false}`

Only the boolean. No consent id, no scopes, no validity window — a caller that received those could cache them, which is precisely what the per-send rule exists to prevent.

## The query was already here

`ConsentRepository.findActiveByGranteeAndParty` has existed since the repository was written and has **zero callers anywhere in the tree**. The data access for this question was in place; only a way to ask it was missing.

## Not trusting the method's own name

The use case re-checks `isActive` in the domain rather than relying on `findActive*` having filtered:

> `status = ACTIVE` and "active right now" are different claims — a consent whose `validTo` has passed keeps status ACTIVE until something transitions it.

A yes/no about a send is exactly where that difference decides whether a message goes out. **Falsified:** dropping the `isActive` call turns the REVOKED test red and nothing else — so the test is about that gap and not about the mock.

## Deliberately not in this PR

**The notification-service wiring.** A caller cannot reach an endpoint that is not running yet — the same precondition #2210 states for itself, and the reason that PR has sat in draft since yesterday. This deploys first, then the gate is wired to it. Shipping both together would ship a call to a URL that 404s.

Also not here: reusing the existing `consent.validate` OPA action rather than adding one means **no rego change and no OPA bundle restamp** — it is the same question with a different key.

## Gate

| check | result |
|---|---|
| `ConsentServiceTest` | **38/38**, including the 5 new cases |
| falsification | trusting the repo filter → REVOKED case red |
| `detekt` + `ktlintCheck` | exit 0 |
| `openapi.yaml` | 1.2.0 → **1.3.0** (additive path, ADR-0048) |

`:openbank-consent-service:test` also reports a pre-existing Quarkus class-loading failure (`ResteasyJaxrsProviderBuildItem`) in four unrelated `@QuarkusTest` classes. Reproduced on **clean `origin/main`** before attributing it — where it affects *more* classes, not fewer — so it is a local environment problem, not this change.

Refs ADR-0198, ADR-0205, ADR-0200, #2210