### PR TITLE
fix(runbooks): give incident commands for the kind that actually carries the service

### DIFF
--- a/docs/runbooks/svc-account.md
+++ b/docs/runbooks/svc-account.md
@@ -32,13 +32,13 @@ triaging an incident that starts on `account`.
 
 - Readiness: `GET :8100/q/health/ready` · Liveness: `GET :8100/q/health/live`
 - Metrics: scraped by the fleet PodMonitor (namespace `accounts`); dashboards in Grafana.
-- Logs: `kubectl logs -n accounts deploy/account-service -f`, or Loki
+- Logs: `kubectl logs -n accounts -l app.kubernetes.io/name=account-service -f`, or Loki
   `{namespace="accounts"}`.
 
 ## Routine operations
 
-- **Restart:** `kubectl rollout restart deploy/account-service -n accounts` (rolling, zero-downtime at >1 replica).
-- **Scale:** `kubectl scale deploy/account-service -n accounts --replicas=<n>` (or edit the GitOps Deployment — GitOps is source of truth, a manual scale is reverted by ArgoCD).
+- **Restart:** `kubectl argo rollouts restart account-service -n accounts` (Argo Rollout — plain `kubectl rollout restart` does NOT work on the CRD). Without the plugin: `kubectl patch rollout account-service -n accounts --type merge -p '{"spec":{"restartAt":"<RFC3339-now>"}}'`.
+- **Scale:** `kubectl scale rollout/account-service -n accounts --replicas=<n>` (or edit the GitOps manifest — GitOps is source of truth, a manual scale is reverted by ArgoCD).
 - **Config/secret change:** edit the GitOps manifest; ArgoCD syncs. Never `kubectl edit` in place.
 
 ## Common failure modes

--- a/docs/runbooks/svc-agent.md
+++ b/docs/runbooks/svc-agent.md
@@ -38,7 +38,7 @@ triaging an incident that starts on `agent`.
 ## Routine operations
 
 - **Restart:** `kubectl rollout restart deploy/agent-service -n platform` (rolling, zero-downtime at >1 replica).
-- **Scale:** `kubectl scale deploy/agent-service -n platform --replicas=<n>` (or edit the GitOps Deployment — GitOps is source of truth, a manual scale is reverted by ArgoCD).
+- **Scale:** `kubectl scale deploy/agent-service -n platform --replicas=<n>` (or edit the GitOps manifest — GitOps is source of truth, a manual scale is reverted by ArgoCD).
 - **Config/secret change:** edit the GitOps manifest; ArgoCD syncs. Never `kubectl edit` in place.
 
 ## Common failure modes

--- a/docs/runbooks/svc-aml.md
+++ b/docs/runbooks/svc-aml.md
@@ -38,7 +38,7 @@ triaging an incident that starts on `aml`.
 ## Routine operations
 
 - **Restart:** `kubectl rollout restart deploy/aml-service -n aml` (rolling, zero-downtime at >1 replica).
-- **Scale:** `kubectl scale deploy/aml-service -n aml --replicas=<n>` (or edit the GitOps Deployment — GitOps is source of truth, a manual scale is reverted by ArgoCD).
+- **Scale:** `kubectl scale deploy/aml-service -n aml --replicas=<n>` (or edit the GitOps manifest — GitOps is source of truth, a manual scale is reverted by ArgoCD).
 - **Config/secret change:** edit the GitOps manifest; ArgoCD syncs. Never `kubectl edit` in place.
 
 ## Common failure modes

--- a/docs/runbooks/svc-anacredit.md
+++ b/docs/runbooks/svc-anacredit.md
@@ -38,7 +38,7 @@ triaging an incident that starts on `anacredit`.
 ## Routine operations
 
 - **Restart:** `kubectl rollout restart deploy/anacredit-service -n anacredit` (rolling, zero-downtime at >1 replica).
-- **Scale:** `kubectl scale deploy/anacredit-service -n anacredit --replicas=<n>` (or edit the GitOps Deployment — GitOps is source of truth, a manual scale is reverted by ArgoCD).
+- **Scale:** `kubectl scale deploy/anacredit-service -n anacredit --replicas=<n>` (or edit the GitOps manifest — GitOps is source of truth, a manual scale is reverted by ArgoCD).
 - **Config/secret change:** edit the GitOps manifest; ArgoCD syncs. Never `kubectl edit` in place.
 
 ## Common failure modes

--- a/docs/runbooks/svc-ap2.md
+++ b/docs/runbooks/svc-ap2.md
@@ -38,7 +38,7 @@ triaging an incident that starts on `ap2`.
 ## Routine operations
 
 - **Restart:** `kubectl rollout restart deploy/ap2-service -n platform` (rolling, zero-downtime at >1 replica).
-- **Scale:** `kubectl scale deploy/ap2-service -n platform --replicas=<n>` (or edit the GitOps Deployment — GitOps is source of truth, a manual scale is reverted by ArgoCD).
+- **Scale:** `kubectl scale deploy/ap2-service -n platform --replicas=<n>` (or edit the GitOps manifest — GitOps is source of truth, a manual scale is reverted by ArgoCD).
 - **Config/secret change:** edit the GitOps manifest; ArgoCD syncs. Never `kubectl edit` in place.
 
 ## Common failure modes

--- a/docs/runbooks/svc-audit.md
+++ b/docs/runbooks/svc-audit.md
@@ -38,7 +38,7 @@ triaging an incident that starts on `audit`.
 ## Routine operations
 
 - **Restart:** `kubectl rollout restart deploy/audit-service -n audit` (rolling, zero-downtime at >1 replica).
-- **Scale:** `kubectl scale deploy/audit-service -n audit --replicas=<n>` (or edit the GitOps Deployment — GitOps is source of truth, a manual scale is reverted by ArgoCD).
+- **Scale:** `kubectl scale deploy/audit-service -n audit --replicas=<n>` (or edit the GitOps manifest — GitOps is source of truth, a manual scale is reverted by ArgoCD).
 - **Config/secret change:** edit the GitOps manifest; ArgoCD syncs. Never `kubectl edit` in place.
 
 ## Common failure modes

--- a/docs/runbooks/svc-balance.md
+++ b/docs/runbooks/svc-balance.md
@@ -32,13 +32,13 @@ triaging an incident that starts on `balance`.
 
 - Readiness: `GET :8103/q/health/ready` · Liveness: `GET :8103/q/health/live`
 - Metrics: scraped by the fleet PodMonitor (namespace `balances`); dashboards in Grafana.
-- Logs: `kubectl logs -n balances deploy/balance-service -f`, or Loki
+- Logs: `kubectl logs -n balances -l app.kubernetes.io/name=balance-service -f`, or Loki
   `{namespace="balances"}`.
 
 ## Routine operations
 
-- **Restart:** `kubectl rollout restart deploy/balance-service -n balances` (rolling, zero-downtime at >1 replica).
-- **Scale:** `kubectl scale deploy/balance-service -n balances --replicas=<n>` (or edit the GitOps Deployment — GitOps is source of truth, a manual scale is reverted by ArgoCD).
+- **Restart:** `kubectl argo rollouts restart balance-service -n balances` (Argo Rollout — plain `kubectl rollout restart` does NOT work on the CRD). Without the plugin: `kubectl patch rollout balance-service -n balances --type merge -p '{"spec":{"restartAt":"<RFC3339-now>"}}'`.
+- **Scale:** `kubectl scale rollout/balance-service -n balances --replicas=<n>` (or edit the GitOps manifest — GitOps is source of truth, a manual scale is reverted by ArgoCD).
 - **Config/secret change:** edit the GitOps manifest; ArgoCD syncs. Never `kubectl edit` in place.
 
 ## Common failure modes

--- a/docs/runbooks/svc-billing.md
+++ b/docs/runbooks/svc-billing.md
@@ -38,7 +38,7 @@ triaging an incident that starts on `billing`.
 ## Routine operations
 
 - **Restart:** `kubectl rollout restart deploy/billing-service -n billing` (rolling, zero-downtime at >1 replica).
-- **Scale:** `kubectl scale deploy/billing-service -n billing --replicas=<n>` (or edit the GitOps Deployment — GitOps is source of truth, a manual scale is reverted by ArgoCD).
+- **Scale:** `kubectl scale deploy/billing-service -n billing --replicas=<n>` (or edit the GitOps manifest — GitOps is source of truth, a manual scale is reverted by ArgoCD).
 - **Config/secret change:** edit the GitOps manifest; ArgoCD syncs. Never `kubectl edit` in place.
 
 ## Common failure modes

--- a/docs/runbooks/svc-card-issuance.md
+++ b/docs/runbooks/svc-card-issuance.md
@@ -38,7 +38,7 @@ triaging an incident that starts on `card-issuance`.
 ## Routine operations
 
 - **Restart:** `kubectl rollout restart deploy/card-issuance-service -n payments` (rolling, zero-downtime at >1 replica).
-- **Scale:** `kubectl scale deploy/card-issuance-service -n payments --replicas=<n>` (or edit the GitOps Deployment — GitOps is source of truth, a manual scale is reverted by ArgoCD).
+- **Scale:** `kubectl scale deploy/card-issuance-service -n payments --replicas=<n>` (or edit the GitOps manifest — GitOps is source of truth, a manual scale is reverted by ArgoCD).
 - **Config/secret change:** edit the GitOps manifest; ArgoCD syncs. Never `kubectl edit` in place.
 
 ## Common failure modes

--- a/docs/runbooks/svc-clearing.md
+++ b/docs/runbooks/svc-clearing.md
@@ -32,13 +32,13 @@ triaging an incident that starts on `clearing`.
 
 - Readiness: `GET :8124/q/health/ready` · Liveness: `GET :8124/q/health/live`
 - Metrics: scraped by the fleet PodMonitor (namespace `payments`); dashboards in Grafana.
-- Logs: `kubectl logs -n payments deploy/clearing-service -f`, or Loki
+- Logs: `kubectl logs -n payments -l app.kubernetes.io/name=clearing-service -f`, or Loki
   `{namespace="payments"}`.
 
 ## Routine operations
 
-- **Restart:** `kubectl rollout restart deploy/clearing-service -n payments` (rolling, zero-downtime at >1 replica).
-- **Scale:** `kubectl scale deploy/clearing-service -n payments --replicas=<n>` (or edit the GitOps Deployment — GitOps is source of truth, a manual scale is reverted by ArgoCD).
+- **Restart:** `kubectl argo rollouts restart clearing-service -n payments` (Argo Rollout — plain `kubectl rollout restart` does NOT work on the CRD). Without the plugin: `kubectl patch rollout clearing-service -n payments --type merge -p '{"spec":{"restartAt":"<RFC3339-now>"}}'`.
+- **Scale:** `kubectl scale rollout/clearing-service -n payments --replicas=<n>` (or edit the GitOps manifest — GitOps is source of truth, a manual scale is reverted by ArgoCD).
 - **Config/secret change:** edit the GitOps manifest; ArgoCD syncs. Never `kubectl edit` in place.
 
 ## Common failure modes

--- a/docs/runbooks/svc-consent.md
+++ b/docs/runbooks/svc-consent.md
@@ -32,13 +32,13 @@ triaging an incident that starts on `consent`.
 
 - Readiness: `GET :8106/q/health/ready` · Liveness: `GET :8106/q/health/live`
 - Metrics: scraped by the fleet PodMonitor (namespace `consent`); dashboards in Grafana.
-- Logs: `kubectl logs -n consent deploy/consent-service -f`, or Loki
+- Logs: `kubectl logs -n consent -l app.kubernetes.io/name=consent-service -f`, or Loki
   `{namespace="consent"}`.
 
 ## Routine operations
 
-- **Restart:** `kubectl rollout restart deploy/consent-service -n consent` (rolling, zero-downtime at >1 replica).
-- **Scale:** `kubectl scale deploy/consent-service -n consent --replicas=<n>` (or edit the GitOps Deployment — GitOps is source of truth, a manual scale is reverted by ArgoCD).
+- **Restart:** `kubectl argo rollouts restart consent-service -n consent` (Argo Rollout — plain `kubectl rollout restart` does NOT work on the CRD). Without the plugin: `kubectl patch rollout consent-service -n consent --type merge -p '{"spec":{"restartAt":"<RFC3339-now>"}}'`.
+- **Scale:** `kubectl scale rollout/consent-service -n consent --replicas=<n>` (or edit the GitOps manifest — GitOps is source of truth, a manual scale is reverted by ArgoCD).
 - **Config/secret change:** edit the GitOps manifest; ArgoCD syncs. Never `kubectl edit` in place.
 
 ## Common failure modes

--- a/docs/runbooks/svc-copilot.md
+++ b/docs/runbooks/svc-copilot.md
@@ -38,7 +38,7 @@ triaging an incident that starts on `copilot`.
 ## Routine operations
 
 - **Restart:** `kubectl rollout restart deploy/copilot-service -n platform` (rolling, zero-downtime at >1 replica).
-- **Scale:** `kubectl scale deploy/copilot-service -n platform --replicas=<n>` (or edit the GitOps Deployment — GitOps is source of truth, a manual scale is reverted by ArgoCD).
+- **Scale:** `kubectl scale deploy/copilot-service -n platform --replicas=<n>` (or edit the GitOps manifest — GitOps is source of truth, a manual scale is reverted by ArgoCD).
 - **Config/secret change:** edit the GitOps manifest; ArgoCD syncs. Never `kubectl edit` in place.
 
 ## Common failure modes

--- a/docs/runbooks/svc-dispute.md
+++ b/docs/runbooks/svc-dispute.md
@@ -38,7 +38,7 @@ triaging an incident that starts on `dispute`.
 ## Routine operations
 
 - **Restart:** `kubectl rollout restart deploy/dispute-service -n dispute` (rolling, zero-downtime at >1 replica).
-- **Scale:** `kubectl scale deploy/dispute-service -n dispute --replicas=<n>` (or edit the GitOps Deployment — GitOps is source of truth, a manual scale is reverted by ArgoCD).
+- **Scale:** `kubectl scale deploy/dispute-service -n dispute --replicas=<n>` (or edit the GitOps manifest — GitOps is source of truth, a manual scale is reverted by ArgoCD).
 - **Config/secret change:** edit the GitOps manifest; ArgoCD syncs. Never `kubectl edit` in place.
 
 ## Common failure modes

--- a/docs/runbooks/svc-document.md
+++ b/docs/runbooks/svc-document.md
@@ -38,7 +38,7 @@ triaging an incident that starts on `document`.
 ## Routine operations
 
 - **Restart:** `kubectl rollout restart deploy/document-service -n documents` (rolling, zero-downtime at >1 replica).
-- **Scale:** `kubectl scale deploy/document-service -n documents --replicas=<n>` (or edit the GitOps Deployment — GitOps is source of truth, a manual scale is reverted by ArgoCD).
+- **Scale:** `kubectl scale deploy/document-service -n documents --replicas=<n>` (or edit the GitOps manifest — GitOps is source of truth, a manual scale is reverted by ArgoCD).
 - **Config/secret change:** edit the GitOps manifest; ArgoCD syncs. Never `kubectl edit` in place.
 
 ## Common failure modes

--- a/docs/runbooks/svc-domestic-payment.md
+++ b/docs/runbooks/svc-domestic-payment.md
@@ -32,13 +32,13 @@ triaging an incident that starts on `domestic-payment`.
 
 - Readiness: `GET :8116/q/health/ready` · Liveness: `GET :8116/q/health/live`
 - Metrics: scraped by the fleet PodMonitor (namespace `payments`); dashboards in Grafana.
-- Logs: `kubectl logs -n payments deploy/domestic-payment-service -f`, or Loki
+- Logs: `kubectl logs -n payments -l app.kubernetes.io/name=domestic-payment-service -f`, or Loki
   `{namespace="payments"}`.
 
 ## Routine operations
 
-- **Restart:** `kubectl rollout restart deploy/domestic-payment-service -n payments` (rolling, zero-downtime at >1 replica).
-- **Scale:** `kubectl scale deploy/domestic-payment-service -n payments --replicas=<n>` (or edit the GitOps Deployment — GitOps is source of truth, a manual scale is reverted by ArgoCD).
+- **Restart:** `kubectl argo rollouts restart domestic-payment-service -n payments` (Argo Rollout — plain `kubectl rollout restart` does NOT work on the CRD). Without the plugin: `kubectl patch rollout domestic-payment-service -n payments --type merge -p '{"spec":{"restartAt":"<RFC3339-now>"}}'`.
+- **Scale:** `kubectl scale rollout/domestic-payment-service -n payments --replicas=<n>` (or edit the GitOps manifest — GitOps is source of truth, a manual scale is reverted by ArgoCD).
 - **Config/secret change:** edit the GitOps manifest; ArgoCD syncs. Never `kubectl edit` in place.
 
 ## Common failure modes

--- a/docs/runbooks/svc-finrep.md
+++ b/docs/runbooks/svc-finrep.md
@@ -38,7 +38,7 @@ triaging an incident that starts on `finrep`.
 ## Routine operations
 
 - **Restart:** `kubectl rollout restart deploy/finrep-service -n finrep` (rolling, zero-downtime at >1 replica).
-- **Scale:** `kubectl scale deploy/finrep-service -n finrep --replicas=<n>` (or edit the GitOps Deployment — GitOps is source of truth, a manual scale is reverted by ArgoCD).
+- **Scale:** `kubectl scale deploy/finrep-service -n finrep --replicas=<n>` (or edit the GitOps manifest — GitOps is source of truth, a manual scale is reverted by ArgoCD).
 - **Config/secret change:** edit the GitOps manifest; ArgoCD syncs. Never `kubectl edit` in place.
 
 ## Common failure modes

--- a/docs/runbooks/svc-fraud.md
+++ b/docs/runbooks/svc-fraud.md
@@ -32,13 +32,13 @@ triaging an incident that starts on `fraud`.
 
 - Readiness: `GET :8133/q/health/ready` · Liveness: `GET :8133/q/health/live`
 - Metrics: scraped by the fleet PodMonitor (namespace `fraud`); dashboards in Grafana.
-- Logs: `kubectl logs -n fraud deploy/fraud-service -f`, or Loki
+- Logs: `kubectl logs -n fraud -l app.kubernetes.io/name=fraud-service -f`, or Loki
   `{namespace="fraud"}`.
 
 ## Routine operations
 
-- **Restart:** `kubectl rollout restart deploy/fraud-service -n fraud` (rolling, zero-downtime at >1 replica).
-- **Scale:** `kubectl scale deploy/fraud-service -n fraud --replicas=<n>` (or edit the GitOps Deployment — GitOps is source of truth, a manual scale is reverted by ArgoCD).
+- **Restart:** `kubectl argo rollouts restart fraud-service -n fraud` (Argo Rollout — plain `kubectl rollout restart` does NOT work on the CRD). Without the plugin: `kubectl patch rollout fraud-service -n fraud --type merge -p '{"spec":{"restartAt":"<RFC3339-now>"}}'`.
+- **Scale:** `kubectl scale rollout/fraud-service -n fraud --replicas=<n>` (or edit the GitOps manifest — GitOps is source of truth, a manual scale is reverted by ArgoCD).
 - **Config/secret change:** edit the GitOps manifest; ArgoCD syncs. Never `kubectl edit` in place.
 
 ## Common failure modes

--- a/docs/runbooks/svc-fx.md
+++ b/docs/runbooks/svc-fx.md
@@ -32,13 +32,13 @@ triaging an incident that starts on `fx`.
 
 - Readiness: `GET :8119/q/health/ready` · Liveness: `GET :8119/q/health/live`
 - Metrics: scraped by the fleet PodMonitor (namespace `fx`); dashboards in Grafana.
-- Logs: `kubectl logs -n fx deploy/fx-service -f`, or Loki
+- Logs: `kubectl logs -n fx -l app.kubernetes.io/name=fx-service -f`, or Loki
   `{namespace="fx"}`.
 
 ## Routine operations
 
-- **Restart:** `kubectl rollout restart deploy/fx-service -n fx` (rolling, zero-downtime at >1 replica).
-- **Scale:** `kubectl scale deploy/fx-service -n fx --replicas=<n>` (or edit the GitOps Deployment — GitOps is source of truth, a manual scale is reverted by ArgoCD).
+- **Restart:** `kubectl argo rollouts restart fx-service -n fx` (Argo Rollout — plain `kubectl rollout restart` does NOT work on the CRD). Without the plugin: `kubectl patch rollout fx-service -n fx --type merge -p '{"spec":{"restartAt":"<RFC3339-now>"}}'`.
+- **Scale:** `kubectl scale rollout/fx-service -n fx --replicas=<n>` (or edit the GitOps manifest — GitOps is source of truth, a manual scale is reverted by ArgoCD).
 - **Config/secret change:** edit the GitOps manifest; ArgoCD syncs. Never `kubectl edit` in place.
 
 ## Common failure modes

--- a/docs/runbooks/svc-interest.md
+++ b/docs/runbooks/svc-interest.md
@@ -38,7 +38,7 @@ triaging an incident that starts on `interest`.
 ## Routine operations
 
 - **Restart:** `kubectl rollout restart deploy/interest-service -n interest` (rolling, zero-downtime at >1 replica).
-- **Scale:** `kubectl scale deploy/interest-service -n interest --replicas=<n>` (or edit the GitOps Deployment — GitOps is source of truth, a manual scale is reverted by ArgoCD).
+- **Scale:** `kubectl scale deploy/interest-service -n interest --replicas=<n>` (or edit the GitOps manifest — GitOps is source of truth, a manual scale is reverted by ArgoCD).
 - **Config/secret change:** edit the GitOps manifest; ArgoCD syncs. Never `kubectl edit` in place.
 
 ## Common failure modes

--- a/docs/runbooks/svc-kyc.md
+++ b/docs/runbooks/svc-kyc.md
@@ -32,13 +32,13 @@ triaging an incident that starts on `kyc`.
 
 - Readiness: `GET :8114/q/health/ready` · Liveness: `GET :8114/q/health/live`
 - Metrics: scraped by the fleet PodMonitor (namespace `kyc`); dashboards in Grafana.
-- Logs: `kubectl logs -n kyc deploy/kyc-service -f`, or Loki
+- Logs: `kubectl logs -n kyc -l app.kubernetes.io/name=kyc-service -f`, or Loki
   `{namespace="kyc"}`.
 
 ## Routine operations
 
-- **Restart:** `kubectl rollout restart deploy/kyc-service -n kyc` (rolling, zero-downtime at >1 replica).
-- **Scale:** `kubectl scale deploy/kyc-service -n kyc --replicas=<n>` (or edit the GitOps Deployment — GitOps is source of truth, a manual scale is reverted by ArgoCD).
+- **Restart:** `kubectl argo rollouts restart kyc-service -n kyc` (Argo Rollout — plain `kubectl rollout restart` does NOT work on the CRD). Without the plugin: `kubectl patch rollout kyc-service -n kyc --type merge -p '{"spec":{"restartAt":"<RFC3339-now>"}}'`.
+- **Scale:** `kubectl scale rollout/kyc-service -n kyc --replicas=<n>` (or edit the GitOps manifest — GitOps is source of truth, a manual scale is reverted by ArgoCD).
 - **Config/secret change:** edit the GitOps manifest; ArgoCD syncs. Never `kubectl edit` in place.
 
 ## Common failure modes

--- a/docs/runbooks/svc-ledger.md
+++ b/docs/runbooks/svc-ledger.md
@@ -32,13 +32,13 @@ triaging an incident that starts on `ledger`.
 
 - Readiness: `GET :8101/q/health/ready` · Liveness: `GET :8101/q/health/live`
 - Metrics: scraped by the fleet PodMonitor (namespace `ledger`); dashboards in Grafana.
-- Logs: `kubectl logs -n ledger deploy/ledger-service -f`, or Loki
+- Logs: `kubectl logs -n ledger -l app.kubernetes.io/name=ledger-service -f`, or Loki
   `{namespace="ledger"}`.
 
 ## Routine operations
 
-- **Restart:** `kubectl rollout restart deploy/ledger-service -n ledger` (rolling, zero-downtime at >1 replica).
-- **Scale:** `kubectl scale deploy/ledger-service -n ledger --replicas=<n>` (or edit the GitOps Deployment — GitOps is source of truth, a manual scale is reverted by ArgoCD).
+- **Restart:** `kubectl argo rollouts restart ledger-service -n ledger` (Argo Rollout — plain `kubectl rollout restart` does NOT work on the CRD). Without the plugin: `kubectl patch rollout ledger-service -n ledger --type merge -p '{"spec":{"restartAt":"<RFC3339-now>"}}'`.
+- **Scale:** `kubectl scale rollout/ledger-service -n ledger --replicas=<n>` (or edit the GitOps manifest — GitOps is source of truth, a manual scale is reverted by ArgoCD).
 - **Config/secret change:** edit the GitOps manifest; ArgoCD syncs. Never `kubectl edit` in place.
 
 ## Common failure modes

--- a/docs/runbooks/svc-lending.md
+++ b/docs/runbooks/svc-lending.md
@@ -32,13 +32,13 @@ triaging an incident that starts on `lending`.
 
 - Readiness: `GET :8126/q/health/ready` · Liveness: `GET :8126/q/health/live`
 - Metrics: scraped by the fleet PodMonitor (namespace `lending`); dashboards in Grafana.
-- Logs: `kubectl logs -n lending deploy/lending-service -f`, or Loki
+- Logs: `kubectl logs -n lending -l app.kubernetes.io/name=lending-service -f`, or Loki
   `{namespace="lending"}`.
 
 ## Routine operations
 
-- **Restart:** `kubectl rollout restart deploy/lending-service -n lending` (rolling, zero-downtime at >1 replica).
-- **Scale:** `kubectl scale deploy/lending-service -n lending --replicas=<n>` (or edit the GitOps Deployment — GitOps is source of truth, a manual scale is reverted by ArgoCD).
+- **Restart:** `kubectl argo rollouts restart lending-service -n lending` (Argo Rollout — plain `kubectl rollout restart` does NOT work on the CRD). Without the plugin: `kubectl patch rollout lending-service -n lending --type merge -p '{"spec":{"restartAt":"<RFC3339-now>"}}'`.
+- **Scale:** `kubectl scale rollout/lending-service -n lending --replicas=<n>` (or edit the GitOps manifest — GitOps is source of truth, a manual scale is reverted by ArgoCD).
 - **Config/secret change:** edit the GitOps manifest; ArgoCD syncs. Never `kubectl edit` in place.
 
 ## Common failure modes

--- a/docs/runbooks/svc-mcp.md
+++ b/docs/runbooks/svc-mcp.md
@@ -38,7 +38,7 @@ triaging an incident that starts on `mcp`.
 ## Routine operations
 
 - **Restart:** `kubectl rollout restart deploy/mcp-service -n platform` (rolling, zero-downtime at >1 replica).
-- **Scale:** `kubectl scale deploy/mcp-service -n platform --replicas=<n>` (or edit the GitOps Deployment — GitOps is source of truth, a manual scale is reverted by ArgoCD).
+- **Scale:** `kubectl scale deploy/mcp-service -n platform --replicas=<n>` (or edit the GitOps manifest — GitOps is source of truth, a manual scale is reverted by ArgoCD).
 - **Config/secret change:** edit the GitOps manifest; ArgoCD syncs. Never `kubectl edit` in place.
 
 ## Common failure modes

--- a/docs/runbooks/svc-notification.md
+++ b/docs/runbooks/svc-notification.md
@@ -38,7 +38,7 @@ triaging an incident that starts on `notification`.
 ## Routine operations
 
 - **Restart:** `kubectl rollout restart deploy/notification-service -n notifications` (rolling, zero-downtime at >1 replica).
-- **Scale:** `kubectl scale deploy/notification-service -n notifications --replicas=<n>` (or edit the GitOps Deployment — GitOps is source of truth, a manual scale is reverted by ArgoCD).
+- **Scale:** `kubectl scale deploy/notification-service -n notifications --replicas=<n>` (or edit the GitOps manifest — GitOps is source of truth, a manual scale is reverted by ArgoCD).
 - **Config/secret change:** edit the GitOps manifest; ArgoCD syncs. Never `kubectl edit` in place.
 
 ## Common failure modes

--- a/docs/runbooks/svc-onboarding.md
+++ b/docs/runbooks/svc-onboarding.md
@@ -32,13 +32,13 @@ triaging an incident that starts on `onboarding`.
 
 - Readiness: `GET :8130/q/health/ready` · Liveness: `GET :8130/q/health/live`
 - Metrics: scraped by the fleet PodMonitor (namespace `onboarding`); dashboards in Grafana.
-- Logs: `kubectl logs -n onboarding deploy/onboarding-service -f`, or Loki
+- Logs: `kubectl logs -n onboarding -l app.kubernetes.io/name=onboarding-service -f`, or Loki
   `{namespace="onboarding"}`.
 
 ## Routine operations
 
-- **Restart:** `kubectl rollout restart deploy/onboarding-service -n onboarding` (rolling, zero-downtime at >1 replica).
-- **Scale:** `kubectl scale deploy/onboarding-service -n onboarding --replicas=<n>` (or edit the GitOps Deployment — GitOps is source of truth, a manual scale is reverted by ArgoCD).
+- **Restart:** `kubectl argo rollouts restart onboarding-service -n onboarding` (Argo Rollout — plain `kubectl rollout restart` does NOT work on the CRD). Without the plugin: `kubectl patch rollout onboarding-service -n onboarding --type merge -p '{"spec":{"restartAt":"<RFC3339-now>"}}'`.
+- **Scale:** `kubectl scale rollout/onboarding-service -n onboarding --replicas=<n>` (or edit the GitOps manifest — GitOps is source of truth, a manual scale is reverted by ArgoCD).
 - **Config/secret change:** edit the GitOps manifest; ArgoCD syncs. Never `kubectl edit` in place.
 
 ## Common failure modes

--- a/docs/runbooks/svc-party.md
+++ b/docs/runbooks/svc-party.md
@@ -32,13 +32,13 @@ triaging an incident that starts on `party`.
 
 - Readiness: `GET :8111/q/health/ready` · Liveness: `GET :8111/q/health/live`
 - Metrics: scraped by the fleet PodMonitor (namespace `party`); dashboards in Grafana.
-- Logs: `kubectl logs -n party deploy/party-service -f`, or Loki
+- Logs: `kubectl logs -n party -l app.kubernetes.io/name=party-service -f`, or Loki
   `{namespace="party"}`.
 
 ## Routine operations
 
-- **Restart:** `kubectl rollout restart deploy/party-service -n party` (rolling, zero-downtime at >1 replica).
-- **Scale:** `kubectl scale deploy/party-service -n party --replicas=<n>` (or edit the GitOps Deployment — GitOps is source of truth, a manual scale is reverted by ArgoCD).
+- **Restart:** `kubectl argo rollouts restart party-service -n party` (Argo Rollout — plain `kubectl rollout restart` does NOT work on the CRD). Without the plugin: `kubectl patch rollout party-service -n party --type merge -p '{"spec":{"restartAt":"<RFC3339-now>"}}'`.
+- **Scale:** `kubectl scale rollout/party-service -n party --replicas=<n>` (or edit the GitOps manifest — GitOps is source of truth, a manual scale is reverted by ArgoCD).
 - **Config/secret change:** edit the GitOps manifest; ArgoCD syncs. Never `kubectl edit` in place.
 
 ## Common failure modes

--- a/docs/runbooks/svc-pid.md
+++ b/docs/runbooks/svc-pid.md
@@ -38,7 +38,7 @@ triaging an incident that starts on `pid`.
 ## Routine operations
 
 - **Restart:** `kubectl rollout restart deploy/pid-service -n pid` (rolling, zero-downtime at >1 replica).
-- **Scale:** `kubectl scale deploy/pid-service -n pid --replicas=<n>` (or edit the GitOps Deployment — GitOps is source of truth, a manual scale is reverted by ArgoCD).
+- **Scale:** `kubectl scale deploy/pid-service -n pid --replicas=<n>` (or edit the GitOps manifest — GitOps is source of truth, a manual scale is reverted by ArgoCD).
 - **Config/secret change:** edit the GitOps manifest; ArgoCD syncs. Never `kubectl edit` in place.
 
 ## Common failure modes

--- a/docs/runbooks/svc-psd2.md
+++ b/docs/runbooks/svc-psd2.md
@@ -38,7 +38,7 @@ triaging an incident that starts on `psd2`.
 ## Routine operations
 
 - **Restart:** `kubectl rollout restart deploy/psd2-service -n psd2` (rolling, zero-downtime at >1 replica).
-- **Scale:** `kubectl scale deploy/psd2-service -n psd2 --replicas=<n>` (or edit the GitOps Deployment — GitOps is source of truth, a manual scale is reverted by ArgoCD).
+- **Scale:** `kubectl scale deploy/psd2-service -n psd2 --replicas=<n>` (or edit the GitOps manifest — GitOps is source of truth, a manual scale is reverted by ArgoCD).
 - **Config/secret change:** edit the GitOps manifest; ArgoCD syncs. Never `kubectl edit` in place.
 
 ## Common failure modes

--- a/docs/runbooks/svc-sanctions.md
+++ b/docs/runbooks/svc-sanctions.md
@@ -32,13 +32,13 @@ triaging an incident that starts on `sanctions`.
 
 - Readiness: `GET :8123/q/health/ready` · Liveness: `GET :8123/q/health/live`
 - Metrics: scraped by the fleet PodMonitor (namespace `sanctions`); dashboards in Grafana.
-- Logs: `kubectl logs -n sanctions deploy/sanctions-service -f`, or Loki
+- Logs: `kubectl logs -n sanctions -l app.kubernetes.io/name=sanctions-service -f`, or Loki
   `{namespace="sanctions"}`.
 
 ## Routine operations
 
-- **Restart:** `kubectl rollout restart deploy/sanctions-service -n sanctions` (rolling, zero-downtime at >1 replica).
-- **Scale:** `kubectl scale deploy/sanctions-service -n sanctions --replicas=<n>` (or edit the GitOps Deployment — GitOps is source of truth, a manual scale is reverted by ArgoCD).
+- **Restart:** `kubectl argo rollouts restart sanctions-service -n sanctions` (Argo Rollout — plain `kubectl rollout restart` does NOT work on the CRD). Without the plugin: `kubectl patch rollout sanctions-service -n sanctions --type merge -p '{"spec":{"restartAt":"<RFC3339-now>"}}'`.
+- **Scale:** `kubectl scale rollout/sanctions-service -n sanctions --replicas=<n>` (or edit the GitOps manifest — GitOps is source of truth, a manual scale is reverted by ArgoCD).
 - **Config/secret change:** edit the GitOps manifest; ArgoCD syncs. Never `kubectl edit` in place.
 
 ## Common failure modes

--- a/docs/runbooks/svc-sca.md
+++ b/docs/runbooks/svc-sca.md
@@ -32,13 +32,13 @@ triaging an incident that starts on `sca`.
 
 - Readiness: `GET :8110/q/health/ready` · Liveness: `GET :8110/q/health/live`
 - Metrics: scraped by the fleet PodMonitor (namespace `sca`); dashboards in Grafana.
-- Logs: `kubectl logs -n sca deploy/sca-service -f`, or Loki
+- Logs: `kubectl logs -n sca -l app.kubernetes.io/name=sca-service -f`, or Loki
   `{namespace="sca"}`.
 
 ## Routine operations
 
-- **Restart:** `kubectl rollout restart deploy/sca-service -n sca` (rolling, zero-downtime at >1 replica).
-- **Scale:** `kubectl scale deploy/sca-service -n sca --replicas=<n>` (or edit the GitOps Deployment — GitOps is source of truth, a manual scale is reverted by ArgoCD).
+- **Restart:** `kubectl argo rollouts restart sca-service -n sca` (Argo Rollout — plain `kubectl rollout restart` does NOT work on the CRD). Without the plugin: `kubectl patch rollout sca-service -n sca --type merge -p '{"spec":{"restartAt":"<RFC3339-now>"}}'`.
+- **Scale:** `kubectl scale rollout/sca-service -n sca --replicas=<n>` (or edit the GitOps manifest — GitOps is source of truth, a manual scale is reverted by ArgoCD).
 - **Config/secret change:** edit the GitOps manifest; ArgoCD syncs. Never `kubectl edit` in place.
 
 ## Common failure modes

--- a/docs/runbooks/svc-sdd.md
+++ b/docs/runbooks/svc-sdd.md
@@ -38,7 +38,7 @@ triaging an incident that starts on `sdd`.
 ## Routine operations
 
 - **Restart:** `kubectl rollout restart deploy/sdd-service -n sdd` (rolling, zero-downtime at >1 replica).
-- **Scale:** `kubectl scale deploy/sdd-service -n sdd --replicas=<n>` (or edit the GitOps Deployment — GitOps is source of truth, a manual scale is reverted by ArgoCD).
+- **Scale:** `kubectl scale deploy/sdd-service -n sdd --replicas=<n>` (or edit the GitOps manifest — GitOps is source of truth, a manual scale is reverted by ArgoCD).
 - **Config/secret change:** edit the GitOps manifest; ArgoCD syncs. Never `kubectl edit` in place.
 
 ## Common failure modes

--- a/docs/runbooks/svc-sepa-instant.md
+++ b/docs/runbooks/svc-sepa-instant.md
@@ -32,13 +32,13 @@ triaging an incident that starts on `sepa-instant`.
 
 - Readiness: `GET :8127/q/health/ready` · Liveness: `GET :8127/q/health/live`
 - Metrics: scraped by the fleet PodMonitor (namespace `payments`); dashboards in Grafana.
-- Logs: `kubectl logs -n payments deploy/sepa-instant-service -f`, or Loki
+- Logs: `kubectl logs -n payments -l app.kubernetes.io/name=sepa-instant-service -f`, or Loki
   `{namespace="payments"}`.
 
 ## Routine operations
 
-- **Restart:** `kubectl rollout restart deploy/sepa-instant-service -n payments` (rolling, zero-downtime at >1 replica).
-- **Scale:** `kubectl scale deploy/sepa-instant-service -n payments --replicas=<n>` (or edit the GitOps Deployment — GitOps is source of truth, a manual scale is reverted by ArgoCD).
+- **Restart:** `kubectl argo rollouts restart sepa-instant-service -n payments` (Argo Rollout — plain `kubectl rollout restart` does NOT work on the CRD). Without the plugin: `kubectl patch rollout sepa-instant-service -n payments --type merge -p '{"spec":{"restartAt":"<RFC3339-now>"}}'`.
+- **Scale:** `kubectl scale rollout/sepa-instant-service -n payments --replicas=<n>` (or edit the GitOps manifest — GitOps is source of truth, a manual scale is reverted by ArgoCD).
 - **Config/secret change:** edit the GitOps manifest; ArgoCD syncs. Never `kubectl edit` in place.
 
 ## Common failure modes

--- a/docs/runbooks/svc-sepa-payment.md
+++ b/docs/runbooks/svc-sepa-payment.md
@@ -32,13 +32,13 @@ triaging an incident that starts on `sepa-payment`.
 
 - Readiness: `GET :8115/q/health/ready` · Liveness: `GET :8115/q/health/live`
 - Metrics: scraped by the fleet PodMonitor (namespace `payments`); dashboards in Grafana.
-- Logs: `kubectl logs -n payments deploy/sepa-payment-service -f`, or Loki
+- Logs: `kubectl logs -n payments -l app.kubernetes.io/name=sepa-payment-service -f`, or Loki
   `{namespace="payments"}`.
 
 ## Routine operations
 
-- **Restart:** `kubectl rollout restart deploy/sepa-payment-service -n payments` (rolling, zero-downtime at >1 replica).
-- **Scale:** `kubectl scale deploy/sepa-payment-service -n payments --replicas=<n>` (or edit the GitOps Deployment — GitOps is source of truth, a manual scale is reverted by ArgoCD).
+- **Restart:** `kubectl argo rollouts restart sepa-payment-service -n payments` (Argo Rollout — plain `kubectl rollout restart` does NOT work on the CRD). Without the plugin: `kubectl patch rollout sepa-payment-service -n payments --type merge -p '{"spec":{"restartAt":"<RFC3339-now>"}}'`.
+- **Scale:** `kubectl scale rollout/sepa-payment-service -n payments --replicas=<n>` (or edit the GitOps manifest — GitOps is source of truth, a manual scale is reverted by ArgoCD).
 - **Config/secret change:** edit the GitOps manifest; ArgoCD syncs. Never `kubectl edit` in place.
 
 ## Common failure modes

--- a/docs/runbooks/svc-settlement.md
+++ b/docs/runbooks/svc-settlement.md
@@ -32,13 +32,13 @@ triaging an incident that starts on `settlement`.
 
 - Readiness: `GET :8138/q/health/ready` · Liveness: `GET :8138/q/health/live`
 - Metrics: scraped by the fleet PodMonitor (namespace `payments`); dashboards in Grafana.
-- Logs: `kubectl logs -n payments deploy/settlement-service -f`, or Loki
+- Logs: `kubectl logs -n payments -l app.kubernetes.io/name=settlement-service -f`, or Loki
   `{namespace="payments"}`.
 
 ## Routine operations
 
-- **Restart:** `kubectl rollout restart deploy/settlement-service -n payments` (rolling, zero-downtime at >1 replica).
-- **Scale:** `kubectl scale deploy/settlement-service -n payments --replicas=<n>` (or edit the GitOps Deployment — GitOps is source of truth, a manual scale is reverted by ArgoCD).
+- **Restart:** `kubectl argo rollouts restart settlement-service -n payments` (Argo Rollout — plain `kubectl rollout restart` does NOT work on the CRD). Without the plugin: `kubectl patch rollout settlement-service -n payments --type merge -p '{"spec":{"restartAt":"<RFC3339-now>"}}'`.
+- **Scale:** `kubectl scale rollout/settlement-service -n payments --replicas=<n>` (or edit the GitOps manifest — GitOps is source of truth, a manual scale is reverted by ArgoCD).
 - **Config/secret change:** edit the GitOps manifest; ArgoCD syncs. Never `kubectl edit` in place.
 
 ## Common failure modes

--- a/docs/runbooks/svc-standing-order.md
+++ b/docs/runbooks/svc-standing-order.md
@@ -38,7 +38,7 @@ triaging an incident that starts on `standing-order`.
 ## Routine operations
 
 - **Restart:** `kubectl rollout restart deploy/standing-order-service -n payments` (rolling, zero-downtime at >1 replica).
-- **Scale:** `kubectl scale deploy/standing-order-service -n payments --replicas=<n>` (or edit the GitOps Deployment — GitOps is source of truth, a manual scale is reverted by ArgoCD).
+- **Scale:** `kubectl scale deploy/standing-order-service -n payments --replicas=<n>` (or edit the GitOps manifest — GitOps is source of truth, a manual scale is reverted by ArgoCD).
 - **Config/secret change:** edit the GitOps manifest; ArgoCD syncs. Never `kubectl edit` in place.
 
 ## Common failure modes

--- a/docs/runbooks/svc-statement.md
+++ b/docs/runbooks/svc-statement.md
@@ -38,7 +38,7 @@ triaging an incident that starts on `statement`.
 ## Routine operations
 
 - **Restart:** `kubectl rollout restart deploy/statement-service -n statements` (rolling, zero-downtime at >1 replica).
-- **Scale:** `kubectl scale deploy/statement-service -n statements --replicas=<n>` (or edit the GitOps Deployment — GitOps is source of truth, a manual scale is reverted by ArgoCD).
+- **Scale:** `kubectl scale deploy/statement-service -n statements --replicas=<n>` (or edit the GitOps manifest — GitOps is source of truth, a manual scale is reverted by ArgoCD).
 - **Config/secret change:** edit the GitOps manifest; ArgoCD syncs. Never `kubectl edit` in place.
 
 ## Common failure modes

--- a/docs/runbooks/svc-swift.md
+++ b/docs/runbooks/svc-swift.md
@@ -32,13 +32,13 @@ triaging an incident that starts on `swift`.
 
 - Readiness: `GET :8122/q/health/ready` · Liveness: `GET :8122/q/health/live`
 - Metrics: scraped by the fleet PodMonitor (namespace `payments`); dashboards in Grafana.
-- Logs: `kubectl logs -n payments deploy/swift-service -f`, or Loki
+- Logs: `kubectl logs -n payments -l app.kubernetes.io/name=swift-service -f`, or Loki
   `{namespace="payments"}`.
 
 ## Routine operations
 
-- **Restart:** `kubectl rollout restart deploy/swift-service -n payments` (rolling, zero-downtime at >1 replica).
-- **Scale:** `kubectl scale deploy/swift-service -n payments --replicas=<n>` (or edit the GitOps Deployment — GitOps is source of truth, a manual scale is reverted by ArgoCD).
+- **Restart:** `kubectl argo rollouts restart swift-service -n payments` (Argo Rollout — plain `kubectl rollout restart` does NOT work on the CRD). Without the plugin: `kubectl patch rollout swift-service -n payments --type merge -p '{"spec":{"restartAt":"<RFC3339-now>"}}'`.
+- **Scale:** `kubectl scale rollout/swift-service -n payments --replicas=<n>` (or edit the GitOps manifest — GitOps is source of truth, a manual scale is reverted by ArgoCD).
 - **Config/secret change:** edit the GitOps manifest; ArgoCD syncs. Never `kubectl edit` in place.
 
 ## Common failure modes

--- a/docs/runbooks/svc-tpp-registry.md
+++ b/docs/runbooks/svc-tpp-registry.md
@@ -38,7 +38,7 @@ triaging an incident that starts on `tpp-registry`.
 ## Routine operations
 
 - **Restart:** `kubectl rollout restart deploy/tpp-registry-service -n tpp-registry` (rolling, zero-downtime at >1 replica).
-- **Scale:** `kubectl scale deploy/tpp-registry-service -n tpp-registry --replicas=<n>` (or edit the GitOps Deployment — GitOps is source of truth, a manual scale is reverted by ArgoCD).
+- **Scale:** `kubectl scale deploy/tpp-registry-service -n tpp-registry --replicas=<n>` (or edit the GitOps manifest — GitOps is source of truth, a manual scale is reverted by ArgoCD).
 - **Config/secret change:** edit the GitOps manifest; ArgoCD syncs. Never `kubectl edit` in place.
 
 ## Common failure modes

--- a/docs/runbooks/svc-transaction.md
+++ b/docs/runbooks/svc-transaction.md
@@ -32,13 +32,13 @@ triaging an incident that starts on `transaction`.
 
 - Readiness: `GET :8102/q/health/ready` · Liveness: `GET :8102/q/health/live`
 - Metrics: scraped by the fleet PodMonitor (namespace `payments`); dashboards in Grafana.
-- Logs: `kubectl logs -n payments deploy/transaction-service -f`, or Loki
+- Logs: `kubectl logs -n payments -l app.kubernetes.io/name=transaction-service -f`, or Loki
   `{namespace="payments"}`.
 
 ## Routine operations
 
-- **Restart:** `kubectl rollout restart deploy/transaction-service -n payments` (rolling, zero-downtime at >1 replica).
-- **Scale:** `kubectl scale deploy/transaction-service -n payments --replicas=<n>` (or edit the GitOps Deployment — GitOps is source of truth, a manual scale is reverted by ArgoCD).
+- **Restart:** `kubectl argo rollouts restart transaction-service -n payments` (Argo Rollout — plain `kubectl rollout restart` does NOT work on the CRD). Without the plugin: `kubectl patch rollout transaction-service -n payments --type merge -p '{"spec":{"restartAt":"<RFC3339-now>"}}'`.
+- **Scale:** `kubectl scale rollout/transaction-service -n payments --replicas=<n>` (or edit the GitOps manifest — GitOps is source of truth, a manual scale is reverted by ArgoCD).
 - **Config/secret change:** edit the GitOps manifest; ArgoCD syncs. Never `kubectl edit` in place.
 
 ## Common failure modes

--- a/docs/runbooks/svc-vop.md
+++ b/docs/runbooks/svc-vop.md
@@ -32,13 +32,13 @@ triaging an incident that starts on `vop`.
 
 - Readiness: `GET :8149/q/health/ready` · Liveness: `GET :8149/q/health/live`
 - Metrics: scraped by the fleet PodMonitor (namespace `payments`); dashboards in Grafana.
-- Logs: `kubectl logs -n payments deploy/vop-service -f`, or Loki
+- Logs: `kubectl logs -n payments -l app.kubernetes.io/name=vop-service -f`, or Loki
   `{namespace="payments"}`.
 
 ## Routine operations
 
-- **Restart:** `kubectl rollout restart deploy/vop-service -n payments` (rolling, zero-downtime at >1 replica).
-- **Scale:** `kubectl scale deploy/vop-service -n payments --replicas=<n>` (or edit the GitOps Deployment — GitOps is source of truth, a manual scale is reverted by ArgoCD).
+- **Restart:** `kubectl argo rollouts restart vop-service -n payments` (Argo Rollout — plain `kubectl rollout restart` does NOT work on the CRD). Without the plugin: `kubectl patch rollout vop-service -n payments --type merge -p '{"spec":{"restartAt":"<RFC3339-now>"}}'`.
+- **Scale:** `kubectl scale rollout/vop-service -n payments --replicas=<n>` (or edit the GitOps manifest — GitOps is source of truth, a manual scale is reverted by ArgoCD).
 - **Config/secret change:** edit the GitOps manifest; ArgoCD syncs. Never `kubectl edit` in place.
 
 ## Common failure modes

--- a/openbank-infra/scripts/generate-service-runbooks.py
+++ b/openbank-infra/scripts/generate-service-runbooks.py
@@ -214,13 +214,13 @@ triaging an incident that starts on `{short}`.
 
 - Readiness: `GET :{port}/q/health/ready` · Liveness: `GET :{port}/q/health/live`
 - Metrics: scraped by the fleet PodMonitor (namespace `{ns}`); dashboards in Grafana.
-- Logs: `kubectl logs -n {ns} deploy/{short}-service -f`, or Loki
+- Logs: {logs_cmd}, or Loki
   `{{namespace="{ns}"}}`.
 
 ## Routine operations
 
-- **Restart:** `kubectl rollout restart deploy/{short}-service -n {ns}` (rolling, zero-downtime at >1 replica).
-- **Scale:** `kubectl scale deploy/{short}-service -n {ns} --replicas=<n>` (or edit the GitOps Deployment — GitOps is source of truth, a manual scale is reverted by ArgoCD).
+- **Restart:** {restart_cmd}
+- **Scale:** {scale_cmd} (or edit the GitOps manifest — GitOps is source of truth, a manual scale is reverted by ArgoCD).
 - **Config/secret change:** edit the GitOps manifest; ArgoCD syncs. Never `kubectl edit` in place.
 
 ## Common failure modes
@@ -245,6 +245,46 @@ triaging an incident that starts on `{short}`.
 - Break-glass cluster access is audited; use it only for a declared incident and
   record the justification.
 """
+
+
+def ops_commands(short: str, ns: str) -> dict[str, str]:
+    """The three incident commands, correct for the kind that actually carries this service.
+
+    21 of the fleet's workloads are Argo Rollouts — essentially the whole money path — and kubectl
+    does not treat them as Deployments. Every runbook used to say `deploy/<svc>`, so `logs`,
+    `restart` and `scale` all answered `Error from server (NotFound)` for ledger, consent,
+    sepa-payment, transaction, settlement, fraud, sanctions, kyc and twelve more (issue #2662).
+
+    Swapping in `rollout/` fixes only ONE of the three, which is why each form below was run against
+    the live cluster before being written here:
+
+      | command | deploy/ | rollout/ | works |
+      |---------|---------|----------|-------|
+      | logs    | no      | **no**   | `-l app.kubernetes.io/name=<svc>` |
+      | scale   | no      | yes      | `scale rollout/<svc>` |
+      | restart | no      | **no**   | `kubectl argo rollouts restart` |
+
+    `kubectl logs` and `kubectl rollout restart` do not understand the Rollout CRD at all. The
+    plugin-free restart is offered alongside the plugin form on purpose: a runbook that assumes a
+    kubectl plugin on the reader's laptop fails in exactly the situation it exists for.
+    """
+    svc = f"{short}-service"
+    if gitops_facts.workload_kind(short, GITOPS) == "Rollout":
+        return {
+            "logs_cmd": f"`kubectl logs -n {ns} -l app.kubernetes.io/name={svc} -f`",
+            "restart_cmd": (
+                f"`kubectl argo rollouts restart {svc} -n {ns}` (Argo Rollout — plain "
+                f"`kubectl rollout restart` does NOT work on the CRD). Without the plugin: "
+                f"`kubectl patch rollout {svc} -n {ns} --type merge "
+                f'-p \'{{"spec":{{"restartAt":"<RFC3339-now>"}}}}\'`.'
+            ),
+            "scale_cmd": f"`kubectl scale rollout/{svc} -n {ns} --replicas=<n>`",
+        }
+    return {
+        "logs_cmd": f"`kubectl logs -n {ns} deploy/{svc} -f`",
+        "restart_cmd": f"`kubectl rollout restart deploy/{svc} -n {ns}` (rolling, zero-downtime at >1 replica).",
+        "scale_cmd": f"`kubectl scale deploy/{svc} -n {ns} --replicas=<n>`",
+    }
 
 
 def render(short: str) -> str:
@@ -309,6 +349,7 @@ def render(short: str) -> str:
         downstream=down,
         rpo=rpo,
         dr=dr_for(datastore, has_backup, owns_none),
+        **ops_commands(short, service_namespace(short)),
     )
 
 

--- a/openbank-infra/scripts/gitops_facts.py
+++ b/openbank-infra/scripts/gitops_facts.py
@@ -160,6 +160,38 @@ def workload_namespaces(short: str, gitops: Path) -> set[str]:
     return found
 
 
+def workload_kind(short: str, gitops: Path) -> str:
+    """`Rollout` or `Deployment` — which kind actually carries this service.
+
+    They are NOT interchangeable to kubectl, and the fleet is split: 21 Rollouts (essentially the
+    whole money path — ledger, consent, sepa-payment, transaction, settlement, fraud, sanctions, kyc)
+    against 121 Deployments. A runbook that names the wrong one hands an operator
+    `Error from server (NotFound)` during the incident it was written for (issue #2662).
+
+    Same matching discipline as [workload_namespaces]: a manifest that merely MENTIONS the service
+    does not count — a NetworkPolicy naming it as a peer or an env var holding its URL would
+    otherwise decide the kind. The workload's own `metadata.name` must be the service.
+
+    Defaults to `Deployment` when nothing matches, because that is what an unmanaged or not-yet-
+    declared service will be, and because the wrong default is the one that fails loudly rather
+    than the one that silently addresses a resource that happens to exist.
+    """
+    names = module_names(short)
+    haystacks = (f"openbank-{short}-service", f"openbank-{short}")
+    for f in sorted(gitops.rglob("*.yaml")):
+        text = read(f)
+        if not any(h in text for h in haystacks):
+            continue
+        for doc in text.split("\n---"):
+            kind = re.search(r"^kind:\s*(\S+)", doc, re.M)
+            if not kind or kind.group(1) not in ("Deployment", "Rollout"):
+                continue
+            name = re.search(r"^\s{2}name:\s*(\S+)", doc, re.M)
+            if name and name.group(1) in names:
+                return kind.group(1)
+    return "Deployment"
+
+
 def service_namespace(short: str, gitops: Path) -> str | None:
     """The single namespace this service runs in, or None if it is not deployed.
 


### PR DESCRIPTION
Closes #2662.

## 60 broken incident commands

20 of 40 service runbooks told an operator to act on a **Deployment that does not exist**:

```
$ kubectl get deploy/ledger-service -n ledger
Error from server (NotFound): deployments.apps "ledger-service" not found
```

Every affected service runs as an **Argo Rollout**. The three commands each runbook carries — **Logs, Restart, Scale** — are exactly what you reach for during an incident, and all three failed.

**20 runbooks × 3 = 60 broken commands**, across essentially the whole money path: ledger, consent, sepa-payment, sepa-instant, domestic-payment, transaction, settlement, clearing, swift, vop, fraud, sanctions, kyc, party, account, balance, lending, onboarding, fx, sca.

The fleet is **21 Rollouts / 121 Deployments** — and the Rollouts are the services where an incident matters most.

## The obvious fix is two-thirds still broken

Swapping `deploy/` for `rollout/` fixes **one** of the three. Each form below was run against the live cluster *before* being written into the generator:

| command | `deploy/` | `rollout/` | what actually works |
|---|---|---|---|
| logs | ✗ | ✗ **also fails** | `-l app.kubernetes.io/name=<svc>` |
| scale | ✗ | ✓ | `scale rollout/<svc>` |
| restart | ✗ | ✗ **also fails** | `kubectl argo rollouts restart` |

`kubectl logs` and `kubectl rollout restart` do not understand the Rollout CRD at all. Had I patched the obvious way and shipped it, the operator would have rediscovered two thirds of this at 3am.

The plugin-free `kubectl patch rollout … restartAt` form is offered alongside the plugin one deliberately: **a runbook that assumes a kubectl plugin on the reader's laptop fails in exactly the situation it exists for.**

## Fixed in the generator, never in the 40 files

`gitops_facts.workload_kind()` derives the kind from the gitops manifests, reusing `workload_namespaces()`'s matching discipline — a manifest that merely *mentions* the service does not count; the workload's own `metadata.name` must be it. (That rule exists because a NetworkPolicy naming the service as a peer, or an env var holding its URL, would otherwise decide the answer.)

**Validated against the live cluster:** 40 runbook services, 21 live Rollouts, **zero** derived-vs-cluster mismatches.

All 40 runbooks regenerate because the Scale line's parenthetical said *"edit the GitOps **Deployment**"*, which is wrong for a Rollout — it now says "manifest".

## Verified by running the generated strings, not by reading them

| check | result |
|---|---|
| exact generated `logs` + `scale`, Rollout service (ledger) | **work** |
| exact generated `logs` + `scale`, Deployment service (notification) | **work** |
| generator's own unit tests | 14/14 |
| second `--force` run | changes nothing (idempotent) |

While doing that my own test harness reported all four as FAILING — `timeout … sh -c` was swallowing them. Running one directly returned real log lines. Worth stating because a harness that reports failure is as wrong as one that reports success, and the fix looked broken for a minute on no evidence.

## Why it stayed invisible

A runbook is read for the first time during the incident it exists for. Nothing executes one in CI, and the generator produced confident, well-formed commands that were wrong only against a resource kind it never asked about.

Found while verifying a deploy for #2659.