### PR TITLE
chore(governance): attest pentest for consent-service and ledger from automated adversarial runs

### DIFF
--- a/openbank-libs/governance/attestations.yaml
+++ b/openbank-libs/governance/attestations.yaml
@@ -28,5 +28,14 @@
 
 ledger:
   restore_drill: { date: 2026-07-26, ttl_days: 180, by: jiri, ref: runbook-0003 }
+  pentest:       { date: 2026-07-26, ttl_days: 21, by: ci-zap-baseline, ref: https://github.com/JiRaska/open-bank-oss/actions/runs/30192274904 }
+
+consent-service:
+  pentest:       { date: 2026-07-28, ttl_days: 21, by: ci-schemathesis, ref: https://github.com/JiRaska/open-bank-oss/actions/runs/30340495749 }
 
 # --- zbytek zatím prázdný: žádná další M-dimenze není dosvědčena (a to je pravda) ---
+# Pozn. k `by:` u automatizovaných běhů — atestant je scheduled CI lane, ne člověk:
+#   ci-schemathesis = api-fuzz.yml (weekly Tue+Thu; consent-service je v default fuzz setu)
+#   ci-zap-baseline = dast-zap-baseline.yml (weekly; target = ledger-service v docker-compose)
+# TTL 21 dní je záměrně krátké: když lane umře, atestace vyprší a dimenze spadne zpět
+# na derived skóre — zelená přežije jen živou lane.


### PR DESCRIPTION
## Co a proč

Issue #2365 drží 20 money-path služeb NO-GO, dokud neexistují TTL'd atestace (`code_complete`, `restore_drill`, `pentest`). Tento PR přidává **dvě reálné, datované `pentest` atestace** s resolvable refs:

| služba | evidence | run |
|---|---|---|
| `consent-service` | schemathesis fuzz (weekly, je v default fuzz setu `api-fuzz.yml`) | [run 30340495749](https://github.com/JiRaska/open-bank-oss/actions/runs/30340495749) (green 2026-07-28) |
| `ledger` | ZAP DAST baseline (`dast-zap-baseline.yml`, target = ledger-service) | [run 30192274904](https://github.com/JiRaska/open-bank-oss/actions/runs/30192274904) (green 2026-07-26) |

## Sufficiency decision (explicitně vyžádaná v #2365)

Issue se ptá: *"stačí automatizovaný DAST/fuzz run proti money-path službě jako evidence pro `pentest`, nebo je nutný human engagement?"*

**Tento PR = návrh odpovědi ANO pro automatizovaný tier.** Merge tohoto PR je samotné rozhodnutí. Odůvodnění:
- Oba lanes běží weekly na schedule — ne jednorázový event, ale kontinuální adversarial coverage
- TTL 21 dní je záměrně krátké: když lane umře nebo zčervená, atestace vyprší a dimenze spadne na derived skóre
- Human pentest engagement zůstává samostatná, silnější atestace (TTL 365 per příklad v hlavičce)

## Co tento PR NEDĚLÁ

- Neattestuje `restore_drill` (zbývá 19 služeb — reálný drill z CNPG zálohy, runbook-0003 mechanika)
- Neattestuje `code_complete` (judgement-heavy; rules.yaml dokumentuje známé gapy — sca four-eyes NOT wired, fraud gate flag off, billing e2e pending — některé služby poctivě "ne")
- Nemění gate — collector počítá TTL'd atestace, jakmile expirují, spadnou

Refs #2365
