### PR TITLE
fix(gitops): prefix bare docker.io image refs so the ECR rewrite catches them

### DIFF
--- a/openbank-infra/gitops/apps/holmesgpt.yaml
+++ b/openbank-infra/gitops/apps/holmesgpt.yaml
@@ -29,6 +29,10 @@ spec:
     targetRevision: 0.32.0
     helm:
       valuesObject:
+        # Chart renders the image as `<registry>/<image>`; the chart default
+        # `registry: robustadev` is a bare docker.io ref that bypasses the Kyverno
+        # rewrite-docker-hub rule (matches `^docker\.io/` only) and pulls via NAT.
+        registry: docker.io/robustadev
         # NVIDIA NIM (OpenAI-compatible) via litellm. Key projected from the
         # holmes-llm-secrets ExternalSecret (components/external-secrets/
         # es-holmes-llm.yaml) which reuses the copilot-service NIM key.

--- a/openbank-infra/gitops/apps/kyverno.yaml
+++ b/openbank-infra/gitops/apps/kyverno.yaml
@@ -86,31 +86,31 @@ spec:
         cleanupJobs:
           admissionReports:
             image:
-              repository: bitnamilegacy/kubectl
+              repository: docker.io/bitnamilegacy/kubectl
               tag: 1.28.5
           clusterAdmissionReports:
             image:
-              repository: bitnamilegacy/kubectl
+              repository: docker.io/bitnamilegacy/kubectl
               tag: 1.28.5
           ephemeralReports:
             image:
-              repository: bitnamilegacy/kubectl
+              repository: docker.io/bitnamilegacy/kubectl
               tag: 1.28.5
           clusterEphemeralReports:
             image:
-              repository: bitnamilegacy/kubectl
+              repository: docker.io/bitnamilegacy/kubectl
               tag: 1.28.5
           updateRequests:
             image:
-              repository: bitnamilegacy/kubectl
+              repository: docker.io/bitnamilegacy/kubectl
               tag: 1.28.5
         policyReportsCleanup:
           image:
-            repository: bitnamilegacy/kubectl
+            repository: docker.io/bitnamilegacy/kubectl
             tag: 1.28.5
         webhooksCleanup:
           image:
-            repository: bitnamilegacy/kubectl
+            repository: docker.io/bitnamilegacy/kubectl
             tag: 1.28.5
         # Never let the policy webhook take down the cluster: if Kyverno is down,
         # fail OPEN (admit) rather than block every pod. Tighten to Fail for the

--- a/openbank-infra/gitops/apps/opentelemetry-operator.yaml
+++ b/openbank-infra/gitops/apps/opentelemetry-operator.yaml
@@ -25,7 +25,7 @@ spec:
           # The default collector image the operator stamps into injected
           # workloads; pin to the contrib agent line used elsewhere in the stack.
           collectorImage:
-            repository: otel/opentelemetry-collector-contrib
+            repository: docker.io/otel/opentelemetry-collector-contrib
           resources:
             requests:
               cpu: 50m

--- a/openbank-infra/gitops/apps/otel-collector.yaml
+++ b/openbank-infra/gitops/apps/otel-collector.yaml
@@ -23,7 +23,7 @@ spec:
         mode: deployment
         replicaCount: 1
         image:
-          repository: otel/opentelemetry-collector-contrib
+          repository: docker.io/otel/opentelemetry-collector-contrib
         resources:
           requests:
             cpu: 100m

--- a/openbank-infra/gitops/apps/rum-gateway.yaml
+++ b/openbank-infra/gitops/apps/rum-gateway.yaml
@@ -52,7 +52,7 @@ spec:
             hostnames:
               - kc.open-bank.tech
         image:
-          repository: otel/opentelemetry-collector-contrib
+          repository: docker.io/otel/opentelemetry-collector-contrib
         # PSS restricted (threat E2): non-root, read-only rootfs, no caps.
         securityContext:
           runAsNonRoot: true


### PR DESCRIPTION
## Co a proč (FinOps/NAT)

Ověřeno proti živému clusteru (2026-07-29): pody vytvořené **dnes** v `kyverno` namespace nesou image ref `bitnamilegacy/kubectl:1.28.5` — bare, bez registry prefixu. Kyverno rule `rewrite-docker-hub` matchuje jen `^docker\.io/`, takže bare refs **bypassují ECR pull-through a táhnou z Docker Hubu přes NAT Gateway** (stejná třída chyby jako dřív zdokumentovaná v AGENTS.md).

## Změny

| soubor | změna |
|---|---|
| `apps/kyverno.yaml` | 7× `bitnamilegacy/kubectl` → `docker.io/bitnamilegacy/kubectl` |
| `apps/otel-collector.yaml`, `apps/opentelemetry-operator.yaml`, `apps/rum-gateway.yaml` | `otel/opentelemetry-collector-contrib` → `docker.io/otel/opentelemetry-collector-contrib` |
| `apps/holmesgpt.yaml` | chart default `registry: robustadev` (bare) → override `docker.io/robustadev` |

## Ověření (live cluster, ne dokumentace)

- `rewrite-docker-hub` rule existuje v live ClusterPolicy (5 rules: quay, registry-k8s, ecr-public, docker-hub, ghcr)
- Nově vytvořené pody s prefixovanými registry (ecr-public, quay) se rewriteují správně — důkaz, že mechanismus funguje a chyběly jen prefixy
- CNPG pody jsou z rewrite záměrně vyňaty (operator drift, viz hlavička policy) — #1290 trackuje jejich přesun na pull-through

## Není v scope (zdokumentovaný follow-up)

- `glitchtip/glitchtip:6.1.4`, `grafana/pyroscope:1.13.4`, `temporalio/server`+`admin-tools:1.31.0` — images z Helm chart defaults, ne explicitní refs v repo. Override vyžaduje verifikaci values schema každého chartu (glitchtip chart values fetch selhal; temporal chart je dependency; pyroscope chart repository key neexponuje čistě). Dlouho běžící pody, node-cached — nízká frekvence pullů.
- `kube-prometheus-stack.yaml` grafana: **už je OK** (`public.ecr.aws/d7v4f3x6` mirror, zdokumentováno v komentáři).

Refs #2549
