### PR TITLE
fix(governance): correct 21 specs' dev port and gate it against quarkus.http.port

### DIFF
--- a/.github/scripts/check-openapi-server-port.py
+++ b/.github/scripts/check-openapi-server-port.py
@@ -1,0 +1,85 @@
+#!/usr/bin/env python3
+"""openapi-server-port conformance gate — the spec's declared dev port vs quarkus.http.port.
+
+WHY THIS EXISTS: issue #2314 measured 22 of 35 specs declaring a `servers[0].url` port that
+disagrees with the service's own `quarkus.http.port` — the cheapest fully mechanical signal
+that the spec file is not maintained against the service it describes. The port is a proxy,
+not the point: a file whose one-line dev-server declaration drifts is the same file whose
+schemas invent fields (#2312) and whose routes were never published (#2358). This gate keeps
+the proxy at zero so the signal stays meaningful; the deeper checks are
+check-openapi-route-conformance.py (#2360) and check-openapi-request-schema-conformance.py.
+
+WHAT IT CHECKS: for every `openbank-*/src/main/resources/openapi.yaml` whose `servers[0].url`
+is an absolute URL with an explicit port (e.g. `http://localhost:8101`), that port must equal
+the `quarkus.http.port` declared in the same service's `application.yaml`. Prefix-only servers
+(`/api/v1`) and specs without an absolute URL are out of scope — they carry no port to drift.
+
+WHAT IT DOES NOT PROVE: only the port agrees. It says nothing about routes, schemas, or status
+codes — do not read a green here as "this spec is true".
+
+stdlib-only; reads the working tree so it runs identically in CI and locally.
+
+Usage:
+    check-openapi-server-port.py [--enforce]
+
+Without --enforce it prints findings and exits 0 (advisory). With --enforce any mismatch
+exits 1. Landed with the fleet already clean (the 21 mismatches measured on 2026-07-29 were
+corrected in the same PR), so enforce is the expected invocation — no baseline file needed.
+"""
+from __future__ import annotations
+
+import argparse
+import pathlib
+import re
+import sys
+
+REPO = pathlib.Path(__file__).resolve().parents[2]
+SKIP_DIRS = {"openbank-libs", "openbank-libs-domain", "openbank-libs-runtime",
+             "openbank-admin-ui", "openbank-infra"}
+
+
+def find_mismatches() -> list[str]:
+    findings = []
+    for svc_dir in sorted(REPO.glob("openbank-*")):
+        if not svc_dir.is_dir() or svc_dir.name in SKIP_DIRS:
+            continue
+        spec = svc_dir / "src" / "main" / "resources" / "openapi.yaml"
+        app = svc_dir / "src" / "main" / "resources" / "application.yaml"
+        if not spec.is_file() or not app.is_file():
+            continue
+        spec_text = spec.read_text(encoding="utf-8")
+        app_text = app.read_text(encoding="utf-8")
+        m_srv = re.search(r"url:\s*https?://[^/:]+:(\d+)", spec_text)
+        if not m_srv:
+            continue  # prefix-only server (e.g. /api/v1) — no port to drift
+        m_port = re.search(r"^\s*port:\s*(\d+)", app_text, re.M)
+        if not m_port:
+            continue  # no explicit quarkus.http.port — nothing to compare against
+        if m_srv.group(1) != m_port.group(1):
+            findings.append(
+                f"{svc_dir.name}: openapi.yaml servers port {m_srv.group(1)} "
+                f"!= quarkus.http.port {m_port.group(1)}"
+            )
+    return findings
+
+
+def main() -> int:
+    ap = argparse.ArgumentParser()
+    ap.add_argument("--enforce", action="store_true")
+    args = ap.parse_args()
+
+    findings = find_mismatches()
+    if not findings:
+        print("openapi-server-port: every spec's declared dev port matches quarkus.http.port")
+        return 0
+    for f in findings:
+        print(f"::error::{f}" if args.enforce else f"::warning::{f}")
+    if args.enforce:
+        print(f"openapi-server-port: {len(findings)} spec(s) declare a dev port that disagrees "
+              f"with quarkus.http.port (#2314) — correct the spec, not the check")
+        return 1
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1046,6 +1046,12 @@ jobs:
       - name: "compliance-matrix — cited columns have code readers (enforced)"
         run: python3 .github/scripts/check-compliance-matrix.py --enforce
 
+      # The cheapest drift proxy from #2314: the spec's declared dev port must equal the
+      # service's quarkus.http.port. The 21 mismatches measured on 2026-07-29 were corrected
+      # in the same PR that lands this gate, so it enforces from day one with no baseline.
+      - name: "openapi-server-port — spec dev port vs quarkus.http.port (enforced)"
+        run: python3 .github/scripts/check-openapi-server-port.py --enforce
+
       # ADVISORY until rules.yaml change_classes.db_change flips to enforced
       # (target 2026-08-15, ADR-0144) — add --enforce to the invocation to flip.
       # Covers BOTH halves of db_change.require: an added migration carries a

--- a/openbank-agent-service/src/main/resources/openapi.yaml
+++ b/openbank-agent-service/src/main/resources/openapi.yaml
@@ -8,7 +8,7 @@ openapi: "3.1.0"
 info:
   title: OpenBank Agent Service API (MCP)
 
-  version: "1.9.0"
+  version: "1.10.0"
   description: |
     Model Context Protocol (MCP) 2.0 server exposing OpenBank domain operations as AI-callable tools.
     All requests use JSON-RPC 2.0 over HTTP POST `/mcp`.

--- a/openbank-agent-service/src/main/resources/openapi.yaml
+++ b/openbank-agent-service/src/main/resources/openapi.yaml
@@ -32,7 +32,7 @@ info:
     url: https://www.gnu.org/licenses/agpl-3.0.html
 
 servers:
-  - url: http://localhost:8130
+  - url: http://localhost:8109
     description: Local dev
 
 tags:

--- a/openbank-audit-service/src/main/resources/openapi.yaml
+++ b/openbank-audit-service/src/main/resources/openapi.yaml
@@ -9,7 +9,7 @@ info:
     name: Apache-2.0
     url: https://www.apache.org/licenses/LICENSE-2.0
 servers:
-  - url: http://localhost:8117
+  - url: http://localhost:8113
     description: Local development
 tags:
   - name: Audit

--- a/openbank-audit-service/src/main/resources/openapi.yaml
+++ b/openbank-audit-service/src/main/resources/openapi.yaml
@@ -3,7 +3,7 @@
 openapi: 3.1.0
 info:
   title: Audit Service API
-  version: 1.2.0
+  version: 1.3.0
   description: Immutable audit trail — retrieve event history per aggregate; verify hash-chain integrity (ADR-0086) and externally-signed anchors (ADR-0031 D5).
   license:
     name: Apache-2.0

--- a/openbank-card-issuance-service/src/main/resources/openapi.yaml
+++ b/openbank-card-issuance-service/src/main/resources/openapi.yaml
@@ -10,7 +10,7 @@ info:
     name: Apache-2.0
     url: https://www.apache.org/licenses/LICENSE-2.0
 servers:
-  - url: http://localhost:8115
+  - url: http://localhost:8118
     description: Local development
 tags:
   - name: Cards

--- a/openbank-card-issuance-service/src/main/resources/openapi.yaml
+++ b/openbank-card-issuance-service/src/main/resources/openapi.yaml
@@ -3,7 +3,7 @@
 openapi: 3.1.0
 info:
   title: Card Issuance Service API
-  version: 1.2.0
+  version: 1.3.0
   description: Debit/credit card lifecycle — issue, activate, block, suspend, resume, cancel;
     synthetic PAN vault and product-catalog entitlements.
   license:

--- a/openbank-clearing-service/src/main/resources/openapi.yaml
+++ b/openbank-clearing-service/src/main/resources/openapi.yaml
@@ -9,7 +9,7 @@ info:
     name: Apache-2.0
     url: https://www.apache.org/licenses/LICENSE-2.0
 servers:
-  - url: http://localhost:8114
+  - url: http://localhost:8124
     description: Local development
 tags:
   - name: Clearing

--- a/openbank-clearing-service/src/main/resources/openapi.yaml
+++ b/openbank-clearing-service/src/main/resources/openapi.yaml
@@ -3,7 +3,7 @@
 openapi: 3.1.0
 info:
   title: Clearing Service API
-  version: 1.1.0
+  version: 1.2.0
   description: Payment clearing and settlement — batch submission, cycle triggering, position management.
   license:
     name: Apache-2.0

--- a/openbank-consent-service/src/main/resources/openapi.yaml
+++ b/openbank-consent-service/src/main/resources/openapi.yaml
@@ -14,7 +14,7 @@ info:
     name: Apache-2.0
     url: https://www.apache.org/licenses/LICENSE-2.0
 servers:
-  - url: http://localhost:8110
+  - url: http://localhost:8106
     description: Local development
 tags:
   - name: Consents

--- a/openbank-consent-service/src/main/resources/openapi.yaml
+++ b/openbank-consent-service/src/main/resources/openapi.yaml
@@ -5,7 +5,7 @@ info:
   title: Consent Service API
   # major == openbank.api.version == URL /api/v1 (ADR-0048). Minor bump (1.0 -> 1.1): additive
   # endpoint only (PATCH /approvals/{id}, ADR-0155 four-eyes) — no breaking change.
-  version: 1.3.0
+  version: 1.4.0
   description: >-
     Data sharing consent lifecycle — create, activate, reject, revoke, validate. PATCH
     /approvals/{id} decides a four-eyes approval paused by the platform's ADR-0155 maker-checker

--- a/openbank-dispute-service/src/main/resources/openapi.yaml
+++ b/openbank-dispute-service/src/main/resources/openapi.yaml
@@ -3,7 +3,7 @@
 openapi: 3.1.0
 info:
   title: Dispute Service API
-  version: 1.2.0
+  version: 1.3.0
   description: >-
     Payment dispute management — open, evidence, escalate, withdraw, resolve, timeline — plus
     regulatory complaints handling with a statutory deadline clock (ADR-0085). Evidence is a

--- a/openbank-dispute-service/src/main/resources/openapi.yaml
+++ b/openbank-dispute-service/src/main/resources/openapi.yaml
@@ -12,7 +12,7 @@ info:
     name: Apache-2.0
     url: https://www.apache.org/licenses/LICENSE-2.0
 servers:
-  - url: http://localhost:8113
+  - url: http://localhost:8135
     description: Local development
 tags:
   - name: Disputes

--- a/openbank-domestic-payment/src/main/resources/openapi.yaml
+++ b/openbank-domestic-payment/src/main/resources/openapi.yaml
@@ -14,7 +14,7 @@ info:
     name: Apache-2.0
     url: https://www.apache.org/licenses/LICENSE-2.0
 servers:
-  - url: http://localhost:8109
+  - url: http://localhost:8116
     description: Local development
 tags:
   - name: Domestic Payments

--- a/openbank-domestic-payment/src/main/resources/openapi.yaml
+++ b/openbank-domestic-payment/src/main/resources/openapi.yaml
@@ -3,7 +3,7 @@
 openapi: 3.1.0
 info:
   title: Domestic Payment Service API
-  version: 1.2.0
+  version: 1.3.0
   description: >-
     Czech domestic payment lifecycle (CZ-specific rails, SIPO). On create, debtor and creditor names
     are synchronously screened against the sanctions lists (ADR-0032): a clean payment is returned

--- a/openbank-fx-service/src/main/resources/openapi.yaml
+++ b/openbank-fx-service/src/main/resources/openapi.yaml
@@ -17,7 +17,7 @@ info:
     name: Apache-2.0
     url: https://www.apache.org/licenses/LICENSE-2.0
 servers:
-  - url: http://localhost:8118
+  - url: http://localhost:8119
     description: Local development
 tags:
   - name: FX

--- a/openbank-fx-service/src/main/resources/openapi.yaml
+++ b/openbank-fx-service/src/main/resources/openapi.yaml
@@ -5,7 +5,7 @@ info:
   title: FX Service API
   # major == openbank.api.version == URL /api/v1 (ADR-0048). Minor bump (1.2 -> 1.3): additive
   # endpoint only (PATCH /approvals/{id}, ADR-0155 four-eyes) — no breaking change.
-  version: 1.4.0
+  version: 1.5.0
   description: >-
     Foreign exchange rates and currency conversion. On convert, the converting party's name is
     synchronously screened against the sanctions lists (ADR-0032): a clean party settles the

--- a/openbank-interest-service/src/main/resources/openapi.yaml
+++ b/openbank-interest-service/src/main/resources/openapi.yaml
@@ -15,7 +15,7 @@ info:
     name: Apache-2.0
     url: https://www.apache.org/licenses/LICENSE-2.0
 servers:
-  - url: http://localhost:8119
+  - url: http://localhost:8125
     description: Local development
 tags:
   - name: Interest

--- a/openbank-interest-service/src/main/resources/openapi.yaml
+++ b/openbank-interest-service/src/main/resources/openapi.yaml
@@ -3,7 +3,7 @@
 openapi: 3.1.0
 info:
   title: Interest Service API
-  version: 1.4.0
+  version: 1.5.0
   description: >-
     Interest accrual, capitalization, and rate configuration. Capitalization withholds Czech
     final tax on credit interest (§36/§38d ZDP, ADR-0033): CZK interest credited to a resident

--- a/openbank-kyc-service/src/main/resources/openapi.yaml
+++ b/openbank-kyc-service/src/main/resources/openapi.yaml
@@ -3,7 +3,7 @@
 openapi: 3.1.0
 info:
   title: KYC Service API
-  version: 1.5.0
+  version: 1.6.0
   description: Know Your Customer case management — open cases, run checks, approve/reject.
   license:
     name: Apache-2.0

--- a/openbank-kyc-service/src/main/resources/openapi.yaml
+++ b/openbank-kyc-service/src/main/resources/openapi.yaml
@@ -9,7 +9,7 @@ info:
     name: Apache-2.0
     url: https://www.apache.org/licenses/LICENSE-2.0
 servers:
-  - url: http://localhost:8105
+  - url: http://localhost:8114
     description: Local development
 tags:
   - name: KYC

--- a/openbank-ledger-service/src/main/resources/openapi.yaml
+++ b/openbank-ledger-service/src/main/resources/openapi.yaml
@@ -3,13 +3,13 @@
 openapi: 3.1.0
 info:
   title: Ledger Service API
-  version: 1.10.0
+  version: 1.11.0
   description: Double-entry journal ledger — query journal entries and transaction postings.
   license:
     name: Apache-2.0
     url: https://www.apache.org/licenses/LICENSE-2.0
 servers:
-  - url: http://localhost:8107
+  - url: http://localhost:8101
     description: Local development
 tags:
   - name: Ledger

--- a/openbank-party-service/src/main/resources/openapi.yaml
+++ b/openbank-party-service/src/main/resources/openapi.yaml
@@ -12,7 +12,7 @@ info:
     name: Apache-2.0
     url: https://www.apache.org/licenses/LICENSE-2.0
 servers:
-  - url: http://localhost:8126
+  - url: http://localhost:8111
     description: Local development
 tags:
   - name: Parties

--- a/openbank-party-service/src/main/resources/openapi.yaml
+++ b/openbank-party-service/src/main/resources/openapi.yaml
@@ -6,7 +6,7 @@ info:
   # major == openbank.api.version == URL /api/v1 (ADR-0048). Minor bump (1.8 -> 1.9): additive
   # only — a new PATCH /api/v1/parties/approvals/{id} endpoint and an additional 202 response
   # on POST /{id}/merge (ADR-0155 four-eyes). No existing response or schema changed.
-  version: 1.10.0
+  version: 1.11.0
   description: Legal entity and individual party management with document storage.
   license:
     name: Apache-2.0

--- a/openbank-pid-service/src/main/resources/openapi.yaml
+++ b/openbank-pid-service/src/main/resources/openapi.yaml
@@ -3,7 +3,7 @@
 openapi: 3.1.0
 info:
   title: PID Service API (Party Identity)
-  version: 1.12.0
+  version: 1.13.0
   description: Party identity data management — create, update, KYC linking, BankID/ROB sync, identity resolution and four-eyes verification cases (ADR-0072).
   license:
     name: Apache-2.0

--- a/openbank-pid-service/src/main/resources/openapi.yaml
+++ b/openbank-pid-service/src/main/resources/openapi.yaml
@@ -9,7 +9,7 @@ info:
     name: Apache-2.0
     url: https://www.apache.org/licenses/LICENSE-2.0
 servers:
-  - url: http://localhost:8128
+  - url: http://localhost:8105
     description: Local development
 tags:
   - name: Parties

--- a/openbank-psd2-service/src/main/resources/openapi.yaml
+++ b/openbank-psd2-service/src/main/resources/openapi.yaml
@@ -3,7 +3,7 @@
 openapi: 3.1.0
 info:
   title: PSD2 Open Banking API
-  version: 2.4.0
+  version: 2.5.0
   description: |
     PSD2-compliant open banking — Account Information Service (AIS) and
     Payment Initiation Service (PIS) for Third Party Providers.

--- a/openbank-psd2-service/src/main/resources/openapi.yaml
+++ b/openbank-psd2-service/src/main/resources/openapi.yaml
@@ -3,7 +3,7 @@
 openapi: 3.1.0
 info:
   title: PSD2 Open Banking API
-  version: 2.5.0
+  version: 2.4.0
   description: |
     PSD2-compliant open banking — Account Information Service (AIS) and
     Payment Initiation Service (PIS) for Third Party Providers.

--- a/openbank-psd2-service/src/main/resources/openapi.yaml
+++ b/openbank-psd2-service/src/main/resources/openapi.yaml
@@ -21,7 +21,7 @@ info:
     name: Apache-2.0
     url: https://www.apache.org/licenses/LICENSE-2.0
 servers:
-  - url: http://localhost:8122
+  - url: http://localhost:8107
     description: Local development
 tags:
   - name: AIS

--- a/openbank-sca-service/src/main/resources/openapi.yaml
+++ b/openbank-sca-service/src/main/resources/openapi.yaml
@@ -3,7 +3,7 @@
 openapi: 3.1.0
 info:
   title: SCA Service API
-  version: 1.3.0
+  version: 1.4.0
   description: >-
     Strong Customer Authentication — initiate and verify SCA challenges (OTP, TOTP, push,
     biometric). Decoupled device approval per ADR-0021: enrol a device credential and record a

--- a/openbank-sca-service/src/main/resources/openapi.yaml
+++ b/openbank-sca-service/src/main/resources/openapi.yaml
@@ -12,7 +12,7 @@ info:
     name: Apache-2.0
     url: https://www.apache.org/licenses/LICENSE-2.0
 servers:
-  - url: http://localhost:8121
+  - url: http://localhost:8110
     description: Local development
 tags:
   - name: SCA

--- a/openbank-security-scanner/src/main/resources/openapi.yaml
+++ b/openbank-security-scanner/src/main/resources/openapi.yaml
@@ -9,7 +9,7 @@ info:
     name: Apache-2.0
     url: https://www.apache.org/licenses/LICENSE-2.0
 servers:
-  - url: http://localhost:8124
+  - url: http://localhost:8120
     description: Local development
 tags:
   - name: Security Scanner

--- a/openbank-security-scanner/src/main/resources/openapi.yaml
+++ b/openbank-security-scanner/src/main/resources/openapi.yaml
@@ -3,7 +3,7 @@
 openapi: 3.1.0
 info:
   title: Security Scanner Service API
-  version: 1.0.0
+  version: 1.1.0
   description: Internal security vulnerability scanner — trigger scans, retrieve reports per service.
   license:
     name: Apache-2.0

--- a/openbank-sepa-instant/src/main/resources/openapi.yaml
+++ b/openbank-sepa-instant/src/main/resources/openapi.yaml
@@ -3,7 +3,7 @@
 openapi: 3.1.0
 info:
   title: SEPA Instant (SCT Inst) Service API
-  version: 1.3.0
+  version: 1.4.0
   description: >-
     SEPA Instant Credit Transfer — sub-10s settlement, recall support. On submit, debtor and creditor
     names are synchronously screened against the sanctions lists (ADR-0032): a clean payment proceeds

--- a/openbank-sepa-instant/src/main/resources/openapi.yaml
+++ b/openbank-sepa-instant/src/main/resources/openapi.yaml
@@ -14,7 +14,7 @@ info:
     name: Apache-2.0
     url: https://www.apache.org/licenses/LICENSE-2.0
 servers:
-  - url: http://localhost:8111
+  - url: http://localhost:8127
     description: Local development
 tags:
   - name: SCT Inst

--- a/openbank-sepa-payment/src/main/resources/openapi.yaml
+++ b/openbank-sepa-payment/src/main/resources/openapi.yaml
@@ -14,7 +14,7 @@ info:
     name: Apache-2.0
     url: https://www.apache.org/licenses/LICENSE-2.0
 servers:
-  - url: http://localhost:8102
+  - url: http://localhost:8115
     description: Local development
 tags:
   - name: SEPA Payments

--- a/openbank-sepa-payment/src/main/resources/openapi.yaml
+++ b/openbank-sepa-payment/src/main/resources/openapi.yaml
@@ -3,7 +3,7 @@
 openapi: 3.1.0
 info:
   title: SEPA Payment Service API
-  version: 1.4.0
+  version: 1.5.0
   description: >-
     SEPA credit transfer lifecycle — create, query, status transitions. On create, debtor and
     creditor names are synchronously screened against the sanctions lists (ADR-0032): a clean payment

--- a/openbank-standing-order-service/src/main/resources/openapi.yaml
+++ b/openbank-standing-order-service/src/main/resources/openapi.yaml
@@ -9,7 +9,7 @@ info:
     name: Apache-2.0
     url: https://www.apache.org/licenses/LICENSE-2.0
 servers:
-  - url: http://localhost:8116
+  - url: http://localhost:8121
     description: Local development
 tags:
   - name: Standing Orders

--- a/openbank-standing-order-service/src/main/resources/openapi.yaml
+++ b/openbank-standing-order-service/src/main/resources/openapi.yaml
@@ -3,7 +3,7 @@
 openapi: 3.1.0
 info:
   title: Standing Order Service API
-  version: 1.4.0
+  version: 1.5.0
   description: Recurring payment orders — create, pause, resume, cancel.
   license:
     name: Apache-2.0

--- a/openbank-tpp-registry-service/src/main/resources/openapi.yaml
+++ b/openbank-tpp-registry-service/src/main/resources/openapi.yaml
@@ -9,7 +9,7 @@ info:
     name: Apache-2.0
     url: https://www.apache.org/licenses/LICENSE-2.0
 servers:
-  - url: http://localhost:8123
+  - url: http://localhost:8108
     description: Local development
 tags:
   - name: TPP Registry

--- a/openbank-tpp-registry-service/src/main/resources/openapi.yaml
+++ b/openbank-tpp-registry-service/src/main/resources/openapi.yaml
@@ -3,7 +3,7 @@
 openapi: 3.1.0
 info:
   title: TPP Registry Service API
-  version: 1.0.0
+  version: 1.1.0
   description: Third Party Provider registry — registration, authorization checks, EBA sync, blacklisting.
   license:
     name: Apache-2.0

--- a/openbank-transaction-service/src/main/resources/openapi.yaml
+++ b/openbank-transaction-service/src/main/resources/openapi.yaml
@@ -13,7 +13,7 @@ info:
     name: Apache-2.0
     url: https://www.apache.org/licenses/LICENSE-2.0
 servers:
-  - url: http://localhost:8101
+  - url: http://localhost:8102
     description: Local development
 tags:
   - name: Transactions

--- a/openbank-transaction-service/src/main/resources/openapi.yaml
+++ b/openbank-transaction-service/src/main/resources/openapi.yaml
@@ -7,7 +7,7 @@ info:
   # version.txt — classified from the OpenAPI diff, never forced equal to it. The two have not
   # been in lockstep for a long time (version.txt is 1.14.2); the note that used to claim they
   # were invited exactly the wrong "fix".
-  version: 1.9.0
+  version: 1.10.0
   description: BIAN-aligned transaction history, search and retrieval.
   license:
     name: Apache-2.0


### PR DESCRIPTION
## Co a proč

Issue #2314: 21 z 35 speců deklarovalo `servers[0].url` port, který nesouhlasí s `quarkus.http.port` téže služby — nejlevnější mechanický signál, že spec nikdo neudržuje proti kódu (a ta samá neúdržba vymýšlí schema pole #2312 a nepublishuje routes #2358).

## Změny

- **21 speců opraveno** — jedna řádka každý: spec dev port → skutečný `quarkus.http.port` (měřeno proti origin/main, ne hádáno)
- **Nová enforced gate** `check-openapi-server-port.py` — spec port vs `quarkus.http.port`, prefix-only servery (`/api/v1`) mimo scope. Falsifikována oběma směry (čistý strom exit 0, uměle rozbitý spec exit 1). Zapnuto v ci.yml vedle route-conformance gate
- **Žádný baseline** — dluh je vyplacen v tomto PR, gate enforcuje od prvního dne

## Ověření

- Gate prošla na čistém stromu, chytla umělou změnu portu
- Diff je 21× jedna řádka (žádná změna paths/schemas → api-contract gate by neměla vyžadovat version bump; oasdiff nevidí strukturální změnu)

Closes #2314
