### PR TITLE
feat(finops): run the ADR-0057 tier classifier daily and surface it in the admin-ui

### DIFF
--- a/openbank-admin-ui/src/app/api/finops/tier-classifier/route.ts
+++ b/openbank-admin-ui/src/app/api/finops/tier-classifier/route.ts
@@ -1,0 +1,40 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright (c) OpenBank contributors. Licensed under the Apache License, Version 2.0.
+// See LICENSE in the repository root or https://www.apache.org/licenses/LICENSE-2.0 for details.
+
+import { NextResponse } from 'next/server'
+import { promises as fs } from 'fs'
+
+export const dynamic = 'force-dynamic'
+
+// ── FinOps tier classifier (ADR-0057, measured side) — rules.yaml: finops_tiers.classifier.
+// Serves the daily markdown report written by the finops-tier-classifier CronJob
+// (openbank-infra/scripts/finops-tier-classifier.py --report) into the
+// admin-ui-tier-classifier ConfigMap (mounted at OPENBANK_TIER_CLASSIFIER): per-service
+// declared-vs-recommended tier with drift flags, ready to render in a <pre>.
+// House style (mirrors /api/finops/allocation): always 200, available:false before the
+// first CronJob run — the admin-ui stays a READ-ONLY consumer (rule #3).
+
+export async function GET() {
+  const file = process.env.OPENBANK_TIER_CLASSIFIER
+  let report: string | null = null
+  if (file) {
+    try {
+      report = await fs.readFile(file, 'utf-8')
+    } catch {
+      report = null
+    }
+  }
+  if (!report) {
+    return NextResponse.json({
+      available: false,
+      reason: 'tier-classifier report not produced yet (the daily finops-tier-classifier CronJob has not landed)',
+    })
+  }
+  const firstLine = report.split('\n', 1)[0] ?? ''
+  return NextResponse.json({
+    available: true,
+    finding: firstLine.replace('FINOPS_TIER_CLASSIFIER_FINDING=', ''),
+    report,
+  })
+}

--- a/openbank-infra/gitops/components/admin-ui/admin-ui.yaml
+++ b/openbank-infra/gitops/components/admin-ui/admin-ui.yaml
@@ -96,6 +96,11 @@ spec:
             # the file is absent (before the first CronJob run).
             - name: OPENBANK_COST_REPORT_LIVE
               value: /config/cost/cost-report.json
+            # FinOps tier classifier (ADR-0057 measured side): live ConfigMap written
+            # daily by the finops-tier-classifier CronJob (tier-classifier.yaml).
+            # Falls back to available:false until the first run lands.
+            - name: OPENBANK_TIER_CLASSIFIER
+              value: /config/tier-classifier/finops-tier-classifier.md
             # Infra CVE scan: point the lifecycle route at the live ConfigMap written
             # daily by the infra-vuln-scanner CronJob (infra-vuln-scanner.yaml).
             # Falls back to the baked infra-vulns.json snapshot if the file is absent
@@ -150,6 +155,9 @@ spec:
             - name: cost-report
               mountPath: /config/cost
               readOnly: true
+            - name: tier-classifier
+              mountPath: /config/tier-classifier
+              readOnly: true
             - name: infra-vulns
               mountPath: /config/infra-vulns
               readOnly: true
@@ -183,6 +191,12 @@ spec:
         - name: cost-report
           configMap:
             name: admin-ui-cost-report
+            optional: true
+        # Daily FinOps tier-classifier report written by the finops-tier-classifier
+        # CronJob (tier-classifier.yaml). optional before the first run.
+        - name: tier-classifier
+          configMap:
+            name: admin-ui-tier-classifier
             optional: true
         # Daily Grype CVE scan written by the infra-vuln-scanner CronJob
         # (infra-vuln-scanner.yaml). optional=true so the pod starts before the

--- a/openbank-infra/gitops/components/admin-ui/tier-classifier.yaml
+++ b/openbank-infra/gitops/components/admin-ui/tier-classifier.yaml
@@ -1,0 +1,158 @@
+# ---------------------------------------------------------------------------
+# FinOps tier classifier — the MEASURED side of ADR-0057 (rules.yaml:
+# finops_tiers.classifier). check-finops-tiers.py validates the declared side in
+# CI; this CronJob reads the measured signals (http rate/idle, kafka lag/active,
+# cpu, replicas) from the in-cluster Prometheus, derives a recommended tier per
+# service by the policy's own axes, and publishes the report as the
+# admin-ui-tier-classifier ConfigMap, which the admin-ui mounts read-only (same
+# live > baked precedence as the cost report — ADR-0062).
+#
+# The ConfigMap is collector-owned (created/updated by this CronJob, not
+# declared in git) so ArgoCD selfHeal never reverts the daily data. The job
+# NEVER fails on drift: `finops-tier-drift` is `enforced: advisory` until
+# 2026-09-30 (rules.yaml) — drift lands in the report, not in an alert, until
+# the policy flips. Failing the job only when the report itself could not be
+# produced (Prometheus unreachable, clone failed) — the sbom-drift-scanner
+# lesson: a report that silently never lands reads as coverage.
+# ---------------------------------------------------------------------------
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: finops-tier-classifier
+  namespace: admin-ui
+  labels:
+    app.kubernetes.io/name: finops-tier-classifier
+    app.kubernetes.io/part-of: admin-ui
+---
+# Least-privilege RBAC: write the single report ConfigMap, nothing else.
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  name: finops-tier-classifier
+  namespace: admin-ui
+  labels:
+    app.kubernetes.io/name: finops-tier-classifier
+rules:
+  - apiGroups: [""]
+    resources: ["configmaps"]
+    resourceNames: ["admin-ui-tier-classifier"]
+    verbs: ["get", "patch", "update"]
+  - apiGroups: [""]
+    resources: ["configmaps"]
+    verbs: ["create"]
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: finops-tier-classifier
+  namespace: admin-ui
+  labels:
+    app.kubernetes.io/name: finops-tier-classifier
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: Role
+  name: finops-tier-classifier
+subjects:
+  - kind: ServiceAccount
+    name: finops-tier-classifier
+    namespace: admin-ui
+---
+apiVersion: batch/v1
+kind: CronJob
+metadata:
+  name: finops-tier-classifier
+  namespace: admin-ui
+  labels:
+    app.kubernetes.io/name: finops-tier-classifier
+    app.kubernetes.io/part-of: admin-ui
+spec:
+  # Daily, offset off the hour — the signal window is 24h, so a daily run keeps
+  # the report one window fresh without burning Prometheus queries.
+  schedule: "37 4 * * *"
+  timeZone: "UTC"
+  concurrencyPolicy: Forbid
+  successfulJobsHistoryLimit: 3
+  failedJobsHistoryLimit: 3
+  startingDeadlineSeconds: 600
+  jobTemplate:
+    spec:
+      activeDeadlineSeconds: 900
+      backoffLimit: 1
+      template:
+        metadata:
+          labels:
+            app.kubernetes.io/name: finops-tier-classifier
+        spec:
+          serviceAccountName: finops-tier-classifier
+          restartPolicy: Never
+          securityContext:
+            runAsNonRoot: true
+            runAsUser: 1000
+            runAsGroup: 1000
+            fsGroup: 1000
+            seccompProfile:
+              type: RuntimeDefault
+          initContainers:
+            - name: classify
+              image: docker.io/alpine/k8s:1.34.1
+              command: ["/bin/sh", "-ec"]
+              securityContext:
+                allowPrivilegeEscalation: false
+                readOnlyRootFilesystem: false
+                capabilities:
+                  drop: ["ALL"]
+              env:
+                - name: HOME
+                  value: /tmp
+                - name: PROMETHEUS_URL
+                  value: http://kube-prometheus-stack-prometheus.observability.svc:9090
+              args:
+                - |
+                  set -eu
+                  echo "Cloning openbank-oss (public repo, unauthenticated, depth=1)..."
+                  git clone --depth 1 --quiet \
+                    https://github.com/JiRaska/open-bank-oss.git /tmp/repo
+
+                  echo "Running the tier classifier against $PROMETHEUS_URL ..."
+                  python3 /tmp/repo/openbank-infra/scripts/finops-tier-classifier.py \
+                    --prometheus-url "$PROMETHEUS_URL" \
+                    --window 24h --report > /work/finops-tier-classifier.md
+
+                  echo "Publishing admin-ui-tier-classifier ConfigMap..."
+                  kubectl create configmap admin-ui-tier-classifier \
+                    --namespace admin-ui \
+                    --from-file=finops-tier-classifier.md=/work/finops-tier-classifier.md \
+                    --dry-run=client -o yaml | kubectl apply -f -
+                  echo "Published."
+              volumeMounts:
+                - name: work
+                  mountPath: /work
+                - name: tmp
+                  mountPath: /tmp
+          containers:
+            - name: verify
+              image: docker.io/alpine/k8s:1.34.1
+              command: ["/bin/sh", "-ec"]
+              securityContext:
+                allowPrivilegeEscalation: false
+                readOnlyRootFilesystem: true
+                capabilities:
+                  drop: ["ALL"]
+              env:
+                - name: HOME
+                  value: /tmp
+              args:
+                - |
+                  set -eu
+                  # The report must exist and carry content; drift itself never fails the
+                  # job (advisory until 2026-09-30), a missing report does.
+                  kubectl get configmap admin-ui-tier-classifier -n admin-ui \
+                    -o jsonpath='{.data.finops-tier-classifier\.md}' | head -5
+                  LINES=$(kubectl get configmap admin-ui-tier-classifier -n admin-ui \
+                    -o jsonpath='{.data.finops-tier-classifier\.md}' | wc -l)
+                  [ "$LINES" -gt 3 ] || { echo "ERROR: report has $LINES lines — treat as not produced" >&2; exit 1; }
+          volumes:
+            - name: work
+              emptyDir: {}
+            - name: tmp
+              emptyDir: {}


### PR DESCRIPTION
## Co a proč

`rules.yaml: finops_tiers` drží `finops-tier-drift` gate na `advisory` s `blocked_on`: **"the measured-signal classifier has not shipped yet"** — deadline 2026-09-30. Measured-side classifier (`openbank-infra/scripts/finops-tier-classifier.py`) v main existoval, ale **neběžel nikde**. Tento PR ho nasazuje + surfacuje.

## Změny

- **`tier-classifier.yaml`** (nový) — denní CronJob (04:37 UTC): clone repo → classifier proti in-cluster Prometheus (`--window 24h --report`) → publish `admin-ui-tier-classifier` ConfigMap (collector-owned, ArgoCD selfHeal-safe). Verify kontejner failuje job, když report nevznikne — drift NIKDY (advisory do 2026-09-30)
- **`admin-ui.yaml`** — mount ConfigMapu + `OPENBANK_TIER_CLASSIFIER` env (stejný live>baked pattern jako cost report, ADR-0062)
- **`/api/finops/tier-classifier`** (nová route) — serve markdown report, `available:false` do prvního běhu

## Live důkaz (před PR)

CronJob aplikován a spuštěn ručně: `Complete 1/1`, report v ConfigMapu. První běh okamžitě našel reálný drift:

```
openbank-product-catalog  T0  →  T1  0.005 cores  ⚠️ DRIFT
  declared T0 but measured behaviour recommends T1 (HTTP, idle)
```

Přesně ADR-0057 teze — a caller routing pro T1 re-entry právě doručuje #2699 (interceptor).

## Co zůstává na 2026-09-30 timeline

- `finops-tier-drift` gate flip advisory → block (až poběží pár týdnů dat)
- T1 re-declare pro product-catalog po SLO re-measurement na interceptor cestě (#2699)

Refs ADR-0057, #2221
