### PR TITLE
fix(statement): pin the period close to the injected clock and an explicit cron zone (#1302)

### DIFF
--- a/docs/adr/0078-accounting-close-model.md
+++ b/docs/adr/0078-accounting-close-model.md
@@ -20,6 +20,14 @@ summary: "Period-end close is modelled as completeness rather than atomicity, se
 - **Operational closes** — ✅ Shipped: End-of-Day, End-of-Month, End-of-Year closes live with period lock + re-verify endpoint, four-eyes maker≠checker attestation, statement-close hardening, and trial-balance attestation.
 - **Statutory close** — ⬜ Deferred: entity-level statutory close (rozvaha/VZZ/EoY) explicitly deferred to ADR-0096; completeness alerting partial (runs but alert routing off).
 
+**Correction (2026-07-29, closing audit #1302):** the "period lock" claim above is true only at
+**fiscal-year** granularity — `LedgerService.postJournal` guards `requireOpenPeriod(entryDate.year)`
+against ATTESTED years. **No day- or month-granularity lock exists in code**: `entryDate` is
+caller-supplied and freely backdatable into days already tied out and statement-closed, and
+reversals inherit the original `entryDate`, so a July reversal rewrites March. The month lock +
+late-entry routing is the #1302 backlog (ADR-0096, delivery-status Planned). Read every "period
+lock" mention in this ADR as "year lock" until that lands.
+
 ## Context
 
 "Závěrka" (close) is an overloaded word in this platform. A single operational question —

--- a/openbank-statement-service/src/main/kotlin/com/openbank/statement/application/usecase/CloseOrchestrator.kt
+++ b/openbank-statement-service/src/main/kotlin/com/openbank/statement/application/usecase/CloseOrchestrator.kt
@@ -23,6 +23,7 @@ import io.smallrye.mutiny.Multi
 import io.smallrye.mutiny.Uni
 import jakarta.enterprise.context.ApplicationScoped
 import org.jboss.logging.Logger
+import java.time.Clock
 import java.time.Instant
 import java.time.LocalDate
 import java.util.UUID
@@ -46,14 +47,19 @@ class CloseOrchestrator(
     private val runs: CloseRunRepository,
     private val outbox: StatementOutbox,
     private val metrics: CloseMetricsPort,
+    private val wallClock: Clock,
 ) : RunCloseUseCase,
     CloseRunQueryUseCase {
 
     private val log = Logger.getLogger(CloseOrchestrator::class.java)
 
-    /** Clock seam (overridable in tests); CDI uses the default. */
-    internal var clock: () -> Instant = Instant::now
-    internal var today: () -> LocalDate = LocalDate::now
+    // Clock seam (overridable in tests); CDI defaults to the injected fleet Clock — the
+    // #1302 fix. `LocalDate::now` (JVM-default zone) was the third clock regime in the
+    // closing audit: a pod whose default zone is not the fleet's closes a different
+    // accounting day than the cron intended. `LocalDate.now(wallClock)` pins the day to
+    // the same authority every other service reads (ADR-0100's injected Clock).
+    internal var clock: () -> Instant = { Instant.now(wallClock) }
+    internal var today: () -> LocalDate = { LocalDate.now(wallClock) }
 
     override fun runClose(trigger: CloseTrigger): Uni<CloseRun> {
         val (from, to) = CloseCalendar.priorMonthBounds(today())

--- a/openbank-statement-service/src/main/kotlin/com/openbank/statement/infrastructure/scheduler/PeriodCloseScheduler.kt
+++ b/openbank-statement-service/src/main/kotlin/com/openbank/statement/infrastructure/scheduler/PeriodCloseScheduler.kt
@@ -30,7 +30,15 @@ class PeriodCloseScheduler(
 ) {
     private val log = Logger.getLogger(PeriodCloseScheduler::class.java)
 
-    @Scheduled(cron = "{openbank.statement.close-cron}", concurrentExecution = Scheduled.ConcurrentExecution.SKIP)
+    // Europe/Prague is explicit, not incidental (#1302): an unset @Scheduled timeZone means
+    // JVM-default, so the close fires on the pod's zone, not the bank's accounting day —
+    // the third clock regime from the closing audit. Prague matches ledger's BANK_TIME, so
+    // the month-end close runs on the same day the ledger closed.
+    @Scheduled(
+        cron = "{openbank.statement.close-cron}",
+        timeZone = "Europe/Prague",
+        concurrentExecution = Scheduled.ConcurrentExecution.SKIP,
+    )
     fun monthlyClose(): Uni<Void> {
         if (!enabled) {
             log.debug("Scheduled period-close disabled; use POST /{accountId}/close or the operator retry")

--- a/openbank-statement-service/src/test/kotlin/com/openbank/statement/application/usecase/CloseOrchestratorTest.kt
+++ b/openbank-statement-service/src/test/kotlin/com/openbank/statement/application/usecase/CloseOrchestratorTest.kt
@@ -20,6 +20,7 @@ import io.smallrye.mutiny.Uni
 import org.assertj.core.api.Assertions.assertThat
 import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Test
+import java.time.Clock
 import java.time.Instant
 import java.time.LocalDate
 import java.util.UUID
@@ -38,7 +39,17 @@ class CloseOrchestratorTest {
 
     @BeforeEach
     fun setUp() {
-        orchestrator = CloseOrchestrator(accountRegistry, accountInfo, periods, closePocket, runs, outbox, metrics)
+        orchestrator =
+            CloseOrchestrator(
+                accountRegistry,
+                accountInfo,
+                periods,
+                closePocket,
+                runs,
+                outbox,
+                metrics,
+                Clock.systemUTC(),
+            )
         orchestrator.clock = { Instant.parse("2026-06-20T10:00:00Z") }
         orchestrator.today = { LocalDate.parse("2026-06-20") }
 


### PR DESCRIPTION
## Co a proč (#1302, closing audit P1 — bounded část)

Audit #1302 item 1: tři clock regimes koexistují (Prague hardcoded v ledger, UTC v ClockProducers, **JVM default** v statement-service). Tento PR uzavírá tu třetí — statement-service:

1. **`CloseOrchestrator`**: `LocalDate::now`/`Instant::now` (JVM-default zone) → injected fleet `Clock` (ADR-0100). `LocalDate.now(wallClock)` — accounting day pinned na stejnou autoritu jako zbytek fleet. Test seam (`internal var clock/today`) zachován.
2. **`PeriodCloseScheduler`**: cron `{openbank.statement.close-cron}` neměl `timeZone` → fires on JVM-default. Explicitně `Europe/Prague` (= ledger's BANK_TIME, accounting day zone).
3. **ADR-0078 header correction**: header tvrdil "period lock" — reálně existuje jen **fiscal-year** lock (`requireOpenPeriod(entryDate.year)`). Day/month lock neexistuje (entryDate je caller-supplied, backdatable přes tied-out dny). Correction note přidána do ADR.

## Co záměrně NENÍ v scope

Root-cause program #1302: jednotná "current accounting day" autorita (day state OPEN→CUTOFF→TIED_OUT→LOCKED), month-granularity lock + late-entry routing (ADR-0096), FX rate staleness, statement correction path. To je multi-week design+implementation program — tenhle PR je bounded quick-win část, kterou audit explicitně jmenuje ("give the statement cron an explicit timeZone; make CloseOrchestrator use its injected Clock").

## Ověření

`:openbank-statement-service:test + ktlintCheck + detekt` — BUILD SUCCESSFUL

Refs #1302
