### PR TITLE
fix(governance): reconcile finops tier declarations with the live fleet (ADR-0173 D3)

### DIFF
--- a/openbank-infra/gitops/components/accounts/account-opa-bundle.yaml
+++ b/openbank-infra/gitops/components/accounts/account-opa-bundle.yaml
@@ -9,7 +9,7 @@ metadata:
     app.kubernetes.io/name: account-service
     app.kubernetes.io/part-of: accounts
   annotations:
-    openbank.tech/policy-checksum: "2b543bd957b65738"
+    openbank.tech/policy-checksum: "6c060585114b8403"
 data:
   rest.rego: |
     # SPDX-License-Identifier: Apache-2.0
@@ -3132,6 +3132,20 @@ data:
       # t0_baseline and need no explicit entry.
       declared:
         openbank-notification-service: T2     # proven pilot, live in sandbox (ADR-0057 best-first target, #228)
+        # ADR-0173 D3 reconciliation (2026-07-29): card-issuance carries a live HTTPScaledObject
+        # with an openbank.io/finops-tier: T1 label and was missing here. Not money-path, so T1
+        # is declarable on the evidence of the live scaled object + classifier-measured idle —
+        # HELD AT min:1 (warm floor) pending a cold-start SLO re-measurement on the current path,
+        # the same hold product-catalog carries below.
+        openbank-card-issuance-service: T1      # live HTTPScaledObject (payments/card-issuance-http), held at min:1 — see ADR-0173 D3
+        # sdd-service and interest-service ALSO carry T1-labeled HTTPScaledObjects (sdd/ and
+        # interest/ namespaces) — but both are money_path_services, so they inherit T0 via
+        # t0_baseline and a T1 label on the deployment is the drift ADR-0173 D3 describes:
+        # demoting either below T0 requires an ADR-0030 threat-model update + 2 approvals, and
+        # neither has happened. Their scaled objects run min:1 (= T0 behaviour today); the label
+        # means nothing until the demotion process runs. NOT declared here on purpose — an
+        # explicit T1 entry would silently demote a money-path service, exactly what
+        # money_path_sacred exists to block (check-finops-tiers.py flags it).
         # openbank-product-catalog was WRONGLY declared T1 here (#2800), citing a
         # non-existent issue (#2083), while only Enabler 2 (HTTPScaledObject) existed —
         # no commit ever added a native build (Enabler 1), so the claimed "native
@@ -3197,7 +3211,7 @@ data:
       gate: finops-tier-drift
       enforced: advisory                      # ADR-0057; -> block when the classifier lands
       target_enforce_date: "2026-09-30"   # ADR-0144
-      blocked_on: "the measured-signal classifier (http_request_rate, kafka_consumer_lag, cpu/replica utilisation) has not shipped yet — only 2 services have a declared tier today (notification-service, product-catalog)"
+      blocked_on: "the measured-signal classifier shipped 2026-07-29 (finops-tier-classifier CronJob, daily report in the admin-ui) — the advisory gate now reads its findings; 3 services have a declared tier today (notification-service T2, product-catalog T0, card-issuance T1-held-at-min:1)"
       # Added by issue #2392: the rule carried `enforced`/`target_enforce_date` but never named the
       # script that produces the finding, so nothing tied the advisory CI step to this deadline.
       ci_producer: "openbank-infra/scripts/check-finops-tiers.py"

--- a/openbank-infra/gitops/components/accounts/account-service.yaml
+++ b/openbank-infra/gitops/components/accounts/account-service.yaml
@@ -37,7 +37,7 @@ spec:
       annotations:
         # Rolls the pod when the OPA bundle changes — subPath mounts do NOT hot-reload.
         # Kept in sync by gen-account-opa-bundle.sh (do not hand-edit).
-        openbank.tech/policy-checksum: "2b543bd957b65738"
+        openbank.tech/policy-checksum: "6c060585114b8403"
     spec:
       securityContext:
         runAsNonRoot: true

--- a/openbank-infra/gitops/components/aml/aml-opa-bundle.yaml
+++ b/openbank-infra/gitops/components/aml/aml-opa-bundle.yaml
@@ -9,7 +9,7 @@ metadata:
     app.kubernetes.io/name: aml-service
     app.kubernetes.io/part-of: aml
   annotations:
-    openbank.tech/policy-checksum: "f1f8b2661c7be34c"
+    openbank.tech/policy-checksum: "1817b01e372a4cfd"
 data:
   rest.rego: |
     # SPDX-License-Identifier: Apache-2.0
@@ -3105,6 +3105,20 @@ data:
       # t0_baseline and need no explicit entry.
       declared:
         openbank-notification-service: T2     # proven pilot, live in sandbox (ADR-0057 best-first target, #228)
+        # ADR-0173 D3 reconciliation (2026-07-29): card-issuance carries a live HTTPScaledObject
+        # with an openbank.io/finops-tier: T1 label and was missing here. Not money-path, so T1
+        # is declarable on the evidence of the live scaled object + classifier-measured idle —
+        # HELD AT min:1 (warm floor) pending a cold-start SLO re-measurement on the current path,
+        # the same hold product-catalog carries below.
+        openbank-card-issuance-service: T1      # live HTTPScaledObject (payments/card-issuance-http), held at min:1 — see ADR-0173 D3
+        # sdd-service and interest-service ALSO carry T1-labeled HTTPScaledObjects (sdd/ and
+        # interest/ namespaces) — but both are money_path_services, so they inherit T0 via
+        # t0_baseline and a T1 label on the deployment is the drift ADR-0173 D3 describes:
+        # demoting either below T0 requires an ADR-0030 threat-model update + 2 approvals, and
+        # neither has happened. Their scaled objects run min:1 (= T0 behaviour today); the label
+        # means nothing until the demotion process runs. NOT declared here on purpose — an
+        # explicit T1 entry would silently demote a money-path service, exactly what
+        # money_path_sacred exists to block (check-finops-tiers.py flags it).
         # openbank-product-catalog was WRONGLY declared T1 here (#2800), citing a
         # non-existent issue (#2083), while only Enabler 2 (HTTPScaledObject) existed —
         # no commit ever added a native build (Enabler 1), so the claimed "native
@@ -3170,7 +3184,7 @@ data:
       gate: finops-tier-drift
       enforced: advisory                      # ADR-0057; -> block when the classifier lands
       target_enforce_date: "2026-09-30"   # ADR-0144
-      blocked_on: "the measured-signal classifier (http_request_rate, kafka_consumer_lag, cpu/replica utilisation) has not shipped yet — only 2 services have a declared tier today (notification-service, product-catalog)"
+      blocked_on: "the measured-signal classifier shipped 2026-07-29 (finops-tier-classifier CronJob, daily report in the admin-ui) — the advisory gate now reads its findings; 3 services have a declared tier today (notification-service T2, product-catalog T0, card-issuance T1-held-at-min:1)"
       # Added by issue #2392: the rule carried `enforced`/`target_enforce_date` but never named the
       # script that produces the finding, so nothing tied the advisory CI step to this deadline.
       ci_producer: "openbank-infra/scripts/check-finops-tiers.py"

--- a/openbank-infra/gitops/components/aml/aml-service.yaml
+++ b/openbank-infra/gitops/components/aml/aml-service.yaml
@@ -22,7 +22,7 @@ spec:
       annotations:
         # Rolls the pod when the OPA bundle changes (subPath mounts do not hot-reload).
         # Kept in sync by gen-aml-opa-bundle.sh (do not hand-edit).
-        openbank.tech/policy-checksum: "f1f8b2661c7be34c"
+        openbank.tech/policy-checksum: "1817b01e372a4cfd"
     spec:
       securityContext:
         runAsNonRoot: true

--- a/openbank-infra/gitops/components/anacredit/anacredit-opa-bundle.yaml
+++ b/openbank-infra/gitops/components/anacredit/anacredit-opa-bundle.yaml
@@ -9,7 +9,7 @@ metadata:
     app.kubernetes.io/name: anacredit-service
     app.kubernetes.io/part-of: anacredit
   annotations:
-    openbank.tech/policy-checksum: "c236e6b79a41adea"
+    openbank.tech/policy-checksum: "3db0652875a7bb51"
 data:
   rest.rego: |
     # SPDX-License-Identifier: Apache-2.0
@@ -3075,6 +3075,20 @@ data:
       # t0_baseline and need no explicit entry.
       declared:
         openbank-notification-service: T2     # proven pilot, live in sandbox (ADR-0057 best-first target, #228)
+        # ADR-0173 D3 reconciliation (2026-07-29): card-issuance carries a live HTTPScaledObject
+        # with an openbank.io/finops-tier: T1 label and was missing here. Not money-path, so T1
+        # is declarable on the evidence of the live scaled object + classifier-measured idle —
+        # HELD AT min:1 (warm floor) pending a cold-start SLO re-measurement on the current path,
+        # the same hold product-catalog carries below.
+        openbank-card-issuance-service: T1      # live HTTPScaledObject (payments/card-issuance-http), held at min:1 — see ADR-0173 D3
+        # sdd-service and interest-service ALSO carry T1-labeled HTTPScaledObjects (sdd/ and
+        # interest/ namespaces) — but both are money_path_services, so they inherit T0 via
+        # t0_baseline and a T1 label on the deployment is the drift ADR-0173 D3 describes:
+        # demoting either below T0 requires an ADR-0030 threat-model update + 2 approvals, and
+        # neither has happened. Their scaled objects run min:1 (= T0 behaviour today); the label
+        # means nothing until the demotion process runs. NOT declared here on purpose — an
+        # explicit T1 entry would silently demote a money-path service, exactly what
+        # money_path_sacred exists to block (check-finops-tiers.py flags it).
         # openbank-product-catalog was WRONGLY declared T1 here (#2800), citing a
         # non-existent issue (#2083), while only Enabler 2 (HTTPScaledObject) existed —
         # no commit ever added a native build (Enabler 1), so the claimed "native
@@ -3140,7 +3154,7 @@ data:
       gate: finops-tier-drift
       enforced: advisory                      # ADR-0057; -> block when the classifier lands
       target_enforce_date: "2026-09-30"   # ADR-0144
-      blocked_on: "the measured-signal classifier (http_request_rate, kafka_consumer_lag, cpu/replica utilisation) has not shipped yet — only 2 services have a declared tier today (notification-service, product-catalog)"
+      blocked_on: "the measured-signal classifier shipped 2026-07-29 (finops-tier-classifier CronJob, daily report in the admin-ui) — the advisory gate now reads its findings; 3 services have a declared tier today (notification-service T2, product-catalog T0, card-issuance T1-held-at-min:1)"
       # Added by issue #2392: the rule carried `enforced`/`target_enforce_date` but never named the
       # script that produces the finding, so nothing tied the advisory CI step to this deadline.
       ci_producer: "openbank-infra/scripts/check-finops-tiers.py"

--- a/openbank-infra/gitops/components/anacredit/anacredit-service.yaml
+++ b/openbank-infra/gitops/components/anacredit/anacredit-service.yaml
@@ -32,7 +32,7 @@ spec:
       annotations:
         # Rolls the pods when the OPA bundle changes — subPath mounts do NOT hot-reload.
         # Kept in sync by gen-anacredit-opa-bundle.sh (do not hand-edit).
-        openbank.tech/policy-checksum: "c236e6b79a41adea"
+        openbank.tech/policy-checksum: "3db0652875a7bb51"
     spec:
       securityContext:
         runAsNonRoot: true

--- a/openbank-infra/gitops/components/ap2/ap2-opa-bundle.yaml
+++ b/openbank-infra/gitops/components/ap2/ap2-opa-bundle.yaml
@@ -9,7 +9,7 @@ metadata:
     app.kubernetes.io/name: mcp-service
     app.kubernetes.io/part-of: platform
   annotations:
-    openbank.tech/policy-checksum: "4673877eb208bc64"
+    openbank.tech/policy-checksum: "e6597e9970958601"
 data:
   rest.rego: |
     # SPDX-License-Identifier: Apache-2.0
@@ -3043,6 +3043,20 @@ data:
       # t0_baseline and need no explicit entry.
       declared:
         openbank-notification-service: T2     # proven pilot, live in sandbox (ADR-0057 best-first target, #228)
+        # ADR-0173 D3 reconciliation (2026-07-29): card-issuance carries a live HTTPScaledObject
+        # with an openbank.io/finops-tier: T1 label and was missing here. Not money-path, so T1
+        # is declarable on the evidence of the live scaled object + classifier-measured idle —
+        # HELD AT min:1 (warm floor) pending a cold-start SLO re-measurement on the current path,
+        # the same hold product-catalog carries below.
+        openbank-card-issuance-service: T1      # live HTTPScaledObject (payments/card-issuance-http), held at min:1 — see ADR-0173 D3
+        # sdd-service and interest-service ALSO carry T1-labeled HTTPScaledObjects (sdd/ and
+        # interest/ namespaces) — but both are money_path_services, so they inherit T0 via
+        # t0_baseline and a T1 label on the deployment is the drift ADR-0173 D3 describes:
+        # demoting either below T0 requires an ADR-0030 threat-model update + 2 approvals, and
+        # neither has happened. Their scaled objects run min:1 (= T0 behaviour today); the label
+        # means nothing until the demotion process runs. NOT declared here on purpose — an
+        # explicit T1 entry would silently demote a money-path service, exactly what
+        # money_path_sacred exists to block (check-finops-tiers.py flags it).
         # openbank-product-catalog was WRONGLY declared T1 here (#2800), citing a
         # non-existent issue (#2083), while only Enabler 2 (HTTPScaledObject) existed —
         # no commit ever added a native build (Enabler 1), so the claimed "native
@@ -3108,7 +3122,7 @@ data:
       gate: finops-tier-drift
       enforced: advisory                      # ADR-0057; -> block when the classifier lands
       target_enforce_date: "2026-09-30"   # ADR-0144
-      blocked_on: "the measured-signal classifier (http_request_rate, kafka_consumer_lag, cpu/replica utilisation) has not shipped yet — only 2 services have a declared tier today (notification-service, product-catalog)"
+      blocked_on: "the measured-signal classifier shipped 2026-07-29 (finops-tier-classifier CronJob, daily report in the admin-ui) — the advisory gate now reads its findings; 3 services have a declared tier today (notification-service T2, product-catalog T0, card-issuance T1-held-at-min:1)"
       # Added by issue #2392: the rule carried `enforced`/`target_enforce_date` but never named the
       # script that produces the finding, so nothing tied the advisory CI step to this deadline.
       ci_producer: "openbank-infra/scripts/check-finops-tiers.py"

--- a/openbank-infra/gitops/components/ap2/ap2-service.yaml
+++ b/openbank-infra/gitops/components/ap2/ap2-service.yaml
@@ -30,7 +30,7 @@ spec:
       annotations:
         # Roll the pod when the OPA policy bundle changes (subPath mounts don't hot-reload).
         # Kept in sync by gen-ap2-opa-bundle.sh (do not hand-edit).
-        openbank.tech/policy-checksum: "4673877eb208bc64"
+        openbank.tech/policy-checksum: "e6597e9970958601"
     spec:
       securityContext:
         runAsNonRoot: true

--- a/openbank-infra/gitops/components/audit/audit-opa-bundle.yaml
+++ b/openbank-infra/gitops/components/audit/audit-opa-bundle.yaml
@@ -9,7 +9,7 @@ metadata:
     app.kubernetes.io/name: audit-service
     app.kubernetes.io/part-of: audit
   annotations:
-    openbank.tech/policy-checksum: "42c911d486f47cb9"
+    openbank.tech/policy-checksum: "22647b1e3fb22ef3"
 data:
   rest.rego: |
     # SPDX-License-Identifier: Apache-2.0
@@ -3087,6 +3087,20 @@ data:
       # t0_baseline and need no explicit entry.
       declared:
         openbank-notification-service: T2     # proven pilot, live in sandbox (ADR-0057 best-first target, #228)
+        # ADR-0173 D3 reconciliation (2026-07-29): card-issuance carries a live HTTPScaledObject
+        # with an openbank.io/finops-tier: T1 label and was missing here. Not money-path, so T1
+        # is declarable on the evidence of the live scaled object + classifier-measured idle —
+        # HELD AT min:1 (warm floor) pending a cold-start SLO re-measurement on the current path,
+        # the same hold product-catalog carries below.
+        openbank-card-issuance-service: T1      # live HTTPScaledObject (payments/card-issuance-http), held at min:1 — see ADR-0173 D3
+        # sdd-service and interest-service ALSO carry T1-labeled HTTPScaledObjects (sdd/ and
+        # interest/ namespaces) — but both are money_path_services, so they inherit T0 via
+        # t0_baseline and a T1 label on the deployment is the drift ADR-0173 D3 describes:
+        # demoting either below T0 requires an ADR-0030 threat-model update + 2 approvals, and
+        # neither has happened. Their scaled objects run min:1 (= T0 behaviour today); the label
+        # means nothing until the demotion process runs. NOT declared here on purpose — an
+        # explicit T1 entry would silently demote a money-path service, exactly what
+        # money_path_sacred exists to block (check-finops-tiers.py flags it).
         # openbank-product-catalog was WRONGLY declared T1 here (#2800), citing a
         # non-existent issue (#2083), while only Enabler 2 (HTTPScaledObject) existed —
         # no commit ever added a native build (Enabler 1), so the claimed "native
@@ -3152,7 +3166,7 @@ data:
       gate: finops-tier-drift
       enforced: advisory                      # ADR-0057; -> block when the classifier lands
       target_enforce_date: "2026-09-30"   # ADR-0144
-      blocked_on: "the measured-signal classifier (http_request_rate, kafka_consumer_lag, cpu/replica utilisation) has not shipped yet — only 2 services have a declared tier today (notification-service, product-catalog)"
+      blocked_on: "the measured-signal classifier shipped 2026-07-29 (finops-tier-classifier CronJob, daily report in the admin-ui) — the advisory gate now reads its findings; 3 services have a declared tier today (notification-service T2, product-catalog T0, card-issuance T1-held-at-min:1)"
       # Added by issue #2392: the rule carried `enforced`/`target_enforce_date` but never named the
       # script that produces the finding, so nothing tied the advisory CI step to this deadline.
       ci_producer: "openbank-infra/scripts/check-finops-tiers.py"

--- a/openbank-infra/gitops/components/audit/audit-service.yaml
+++ b/openbank-infra/gitops/components/audit/audit-service.yaml
@@ -22,7 +22,7 @@ spec:
       annotations:
         # Rolls the pod when the OPA bundle changes (subPath mounts do not hot-reload).
         # Kept in sync by gen-audit-opa-bundle.sh (do not hand-edit).
-        openbank.tech/policy-checksum: "42c911d486f47cb9"
+        openbank.tech/policy-checksum: "22647b1e3fb22ef3"
     spec:
       securityContext:
         runAsNonRoot: true

--- a/openbank-infra/gitops/components/balances/balance-opa-bundle.yaml
+++ b/openbank-infra/gitops/components/balances/balance-opa-bundle.yaml
@@ -9,7 +9,7 @@ metadata:
     app.kubernetes.io/name: balance-service
     app.kubernetes.io/part-of: balances
   annotations:
-    openbank.tech/policy-checksum: "09dc776342295dca"
+    openbank.tech/policy-checksum: "418d1f34610d6c6c"
 data:
   rest.rego: |
     # SPDX-License-Identifier: Apache-2.0
@@ -3176,6 +3176,20 @@ data:
       # t0_baseline and need no explicit entry.
       declared:
         openbank-notification-service: T2     # proven pilot, live in sandbox (ADR-0057 best-first target, #228)
+        # ADR-0173 D3 reconciliation (2026-07-29): card-issuance carries a live HTTPScaledObject
+        # with an openbank.io/finops-tier: T1 label and was missing here. Not money-path, so T1
+        # is declarable on the evidence of the live scaled object + classifier-measured idle —
+        # HELD AT min:1 (warm floor) pending a cold-start SLO re-measurement on the current path,
+        # the same hold product-catalog carries below.
+        openbank-card-issuance-service: T1      # live HTTPScaledObject (payments/card-issuance-http), held at min:1 — see ADR-0173 D3
+        # sdd-service and interest-service ALSO carry T1-labeled HTTPScaledObjects (sdd/ and
+        # interest/ namespaces) — but both are money_path_services, so they inherit T0 via
+        # t0_baseline and a T1 label on the deployment is the drift ADR-0173 D3 describes:
+        # demoting either below T0 requires an ADR-0030 threat-model update + 2 approvals, and
+        # neither has happened. Their scaled objects run min:1 (= T0 behaviour today); the label
+        # means nothing until the demotion process runs. NOT declared here on purpose — an
+        # explicit T1 entry would silently demote a money-path service, exactly what
+        # money_path_sacred exists to block (check-finops-tiers.py flags it).
         # openbank-product-catalog was WRONGLY declared T1 here (#2800), citing a
         # non-existent issue (#2083), while only Enabler 2 (HTTPScaledObject) existed —
         # no commit ever added a native build (Enabler 1), so the claimed "native
@@ -3241,7 +3255,7 @@ data:
       gate: finops-tier-drift
       enforced: advisory                      # ADR-0057; -> block when the classifier lands
       target_enforce_date: "2026-09-30"   # ADR-0144
-      blocked_on: "the measured-signal classifier (http_request_rate, kafka_consumer_lag, cpu/replica utilisation) has not shipped yet — only 2 services have a declared tier today (notification-service, product-catalog)"
+      blocked_on: "the measured-signal classifier shipped 2026-07-29 (finops-tier-classifier CronJob, daily report in the admin-ui) — the advisory gate now reads its findings; 3 services have a declared tier today (notification-service T2, product-catalog T0, card-issuance T1-held-at-min:1)"
       # Added by issue #2392: the rule carried `enforced`/`target_enforce_date` but never named the
       # script that produces the finding, so nothing tied the advisory CI step to this deadline.
       ci_producer: "openbank-infra/scripts/check-finops-tiers.py"

--- a/openbank-infra/gitops/components/balances/balance-service.yaml
+++ b/openbank-infra/gitops/components/balances/balance-service.yaml
@@ -34,7 +34,7 @@ spec:
       annotations:
         # Rolls the pods when the OPA bundle changes — subPath mounts do NOT hot-reload.
         # Kept in sync by gen-balance-opa-bundle.sh (do not hand-edit).
-        openbank.tech/policy-checksum: "09dc776342295dca"
+        openbank.tech/policy-checksum: "418d1f34610d6c6c"
     spec:
       securityContext:
         runAsNonRoot: true

--- a/openbank-infra/gitops/components/billing/billing-opa-bundle.yaml
+++ b/openbank-infra/gitops/components/billing/billing-opa-bundle.yaml
@@ -9,7 +9,7 @@ metadata:
     app.kubernetes.io/name: billing-service
     app.kubernetes.io/part-of: billing
   annotations:
-    openbank.tech/policy-checksum: "fb59c01ab81d95c4"
+    openbank.tech/policy-checksum: "57753c504ee15bec"
 data:
   rest.rego: |
     # SPDX-License-Identifier: Apache-2.0
@@ -3081,6 +3081,20 @@ data:
       # t0_baseline and need no explicit entry.
       declared:
         openbank-notification-service: T2     # proven pilot, live in sandbox (ADR-0057 best-first target, #228)
+        # ADR-0173 D3 reconciliation (2026-07-29): card-issuance carries a live HTTPScaledObject
+        # with an openbank.io/finops-tier: T1 label and was missing here. Not money-path, so T1
+        # is declarable on the evidence of the live scaled object + classifier-measured idle —
+        # HELD AT min:1 (warm floor) pending a cold-start SLO re-measurement on the current path,
+        # the same hold product-catalog carries below.
+        openbank-card-issuance-service: T1      # live HTTPScaledObject (payments/card-issuance-http), held at min:1 — see ADR-0173 D3
+        # sdd-service and interest-service ALSO carry T1-labeled HTTPScaledObjects (sdd/ and
+        # interest/ namespaces) — but both are money_path_services, so they inherit T0 via
+        # t0_baseline and a T1 label on the deployment is the drift ADR-0173 D3 describes:
+        # demoting either below T0 requires an ADR-0030 threat-model update + 2 approvals, and
+        # neither has happened. Their scaled objects run min:1 (= T0 behaviour today); the label
+        # means nothing until the demotion process runs. NOT declared here on purpose — an
+        # explicit T1 entry would silently demote a money-path service, exactly what
+        # money_path_sacred exists to block (check-finops-tiers.py flags it).
         # openbank-product-catalog was WRONGLY declared T1 here (#2800), citing a
         # non-existent issue (#2083), while only Enabler 2 (HTTPScaledObject) existed —
         # no commit ever added a native build (Enabler 1), so the claimed "native
@@ -3146,7 +3160,7 @@ data:
       gate: finops-tier-drift
       enforced: advisory                      # ADR-0057; -> block when the classifier lands
       target_enforce_date: "2026-09-30"   # ADR-0144
-      blocked_on: "the measured-signal classifier (http_request_rate, kafka_consumer_lag, cpu/replica utilisation) has not shipped yet — only 2 services have a declared tier today (notification-service, product-catalog)"
+      blocked_on: "the measured-signal classifier shipped 2026-07-29 (finops-tier-classifier CronJob, daily report in the admin-ui) — the advisory gate now reads its findings; 3 services have a declared tier today (notification-service T2, product-catalog T0, card-issuance T1-held-at-min:1)"
       # Added by issue #2392: the rule carried `enforced`/`target_enforce_date` but never named the
       # script that produces the finding, so nothing tied the advisory CI step to this deadline.
       ci_producer: "openbank-infra/scripts/check-finops-tiers.py"

--- a/openbank-infra/gitops/components/billing/billing-service.yaml
+++ b/openbank-infra/gitops/components/billing/billing-service.yaml
@@ -27,7 +27,7 @@ spec:
       annotations:
         # Rolls the pods when the OPA bundle changes — subPath mounts do NOT hot-reload.
         # Kept in sync by gen-billing-opa-bundle.sh (do not hand-edit).
-        openbank.tech/policy-checksum: "fb59c01ab81d95c4"
+        openbank.tech/policy-checksum: "57753c504ee15bec"
     spec:
       securityContext:
         runAsNonRoot: true

--- a/openbank-infra/gitops/components/consent/consent-opa-bundle.yaml
+++ b/openbank-infra/gitops/components/consent/consent-opa-bundle.yaml
@@ -9,7 +9,7 @@ metadata:
     app.kubernetes.io/name: consent-service
     app.kubernetes.io/part-of: consent
   annotations:
-    openbank.tech/policy-checksum: "aa283dbce7ef7152"
+    openbank.tech/policy-checksum: "c8eea9b19262bbf1"
 data:
   rest.rego: |
     # SPDX-License-Identifier: Apache-2.0
@@ -3151,6 +3151,20 @@ data:
       # t0_baseline and need no explicit entry.
       declared:
         openbank-notification-service: T2     # proven pilot, live in sandbox (ADR-0057 best-first target, #228)
+        # ADR-0173 D3 reconciliation (2026-07-29): card-issuance carries a live HTTPScaledObject
+        # with an openbank.io/finops-tier: T1 label and was missing here. Not money-path, so T1
+        # is declarable on the evidence of the live scaled object + classifier-measured idle —
+        # HELD AT min:1 (warm floor) pending a cold-start SLO re-measurement on the current path,
+        # the same hold product-catalog carries below.
+        openbank-card-issuance-service: T1      # live HTTPScaledObject (payments/card-issuance-http), held at min:1 — see ADR-0173 D3
+        # sdd-service and interest-service ALSO carry T1-labeled HTTPScaledObjects (sdd/ and
+        # interest/ namespaces) — but both are money_path_services, so they inherit T0 via
+        # t0_baseline and a T1 label on the deployment is the drift ADR-0173 D3 describes:
+        # demoting either below T0 requires an ADR-0030 threat-model update + 2 approvals, and
+        # neither has happened. Their scaled objects run min:1 (= T0 behaviour today); the label
+        # means nothing until the demotion process runs. NOT declared here on purpose — an
+        # explicit T1 entry would silently demote a money-path service, exactly what
+        # money_path_sacred exists to block (check-finops-tiers.py flags it).
         # openbank-product-catalog was WRONGLY declared T1 here (#2800), citing a
         # non-existent issue (#2083), while only Enabler 2 (HTTPScaledObject) existed —
         # no commit ever added a native build (Enabler 1), so the claimed "native
@@ -3216,7 +3230,7 @@ data:
       gate: finops-tier-drift
       enforced: advisory                      # ADR-0057; -> block when the classifier lands
       target_enforce_date: "2026-09-30"   # ADR-0144
-      blocked_on: "the measured-signal classifier (http_request_rate, kafka_consumer_lag, cpu/replica utilisation) has not shipped yet — only 2 services have a declared tier today (notification-service, product-catalog)"
+      blocked_on: "the measured-signal classifier shipped 2026-07-29 (finops-tier-classifier CronJob, daily report in the admin-ui) — the advisory gate now reads its findings; 3 services have a declared tier today (notification-service T2, product-catalog T0, card-issuance T1-held-at-min:1)"
       # Added by issue #2392: the rule carried `enforced`/`target_enforce_date` but never named the
       # script that produces the finding, so nothing tied the advisory CI step to this deadline.
       ci_producer: "openbank-infra/scripts/check-finops-tiers.py"

--- a/openbank-infra/gitops/components/consent/consent-service.yaml
+++ b/openbank-infra/gitops/components/consent/consent-service.yaml
@@ -28,7 +28,7 @@ spec:
       annotations:
         # Rolls the pods when the OPA bundle changes — subPath mounts do NOT hot-reload.
         # Kept in sync by gen-consent-opa-bundle.sh (do not hand-edit).
-        openbank.tech/policy-checksum: "aa283dbce7ef7152"
+        openbank.tech/policy-checksum: "c8eea9b19262bbf1"
     spec:
       securityContext:
         runAsNonRoot: true

--- a/openbank-infra/gitops/components/copilot/copilot-opa-bundle.yaml
+++ b/openbank-infra/gitops/components/copilot/copilot-opa-bundle.yaml
@@ -9,7 +9,7 @@ metadata:
     app.kubernetes.io/name: copilot-service
     app.kubernetes.io/part-of: platform
   annotations:
-    openbank.tech/policy-checksum: "a755849d16d870f4"
+    openbank.tech/policy-checksum: "a7f1e1fdc96c85dd"
 data:
   rest.rego: |
     # SPDX-License-Identifier: Apache-2.0
@@ -3167,6 +3167,20 @@ data:
       # t0_baseline and need no explicit entry.
       declared:
         openbank-notification-service: T2     # proven pilot, live in sandbox (ADR-0057 best-first target, #228)
+        # ADR-0173 D3 reconciliation (2026-07-29): card-issuance carries a live HTTPScaledObject
+        # with an openbank.io/finops-tier: T1 label and was missing here. Not money-path, so T1
+        # is declarable on the evidence of the live scaled object + classifier-measured idle —
+        # HELD AT min:1 (warm floor) pending a cold-start SLO re-measurement on the current path,
+        # the same hold product-catalog carries below.
+        openbank-card-issuance-service: T1      # live HTTPScaledObject (payments/card-issuance-http), held at min:1 — see ADR-0173 D3
+        # sdd-service and interest-service ALSO carry T1-labeled HTTPScaledObjects (sdd/ and
+        # interest/ namespaces) — but both are money_path_services, so they inherit T0 via
+        # t0_baseline and a T1 label on the deployment is the drift ADR-0173 D3 describes:
+        # demoting either below T0 requires an ADR-0030 threat-model update + 2 approvals, and
+        # neither has happened. Their scaled objects run min:1 (= T0 behaviour today); the label
+        # means nothing until the demotion process runs. NOT declared here on purpose — an
+        # explicit T1 entry would silently demote a money-path service, exactly what
+        # money_path_sacred exists to block (check-finops-tiers.py flags it).
         # openbank-product-catalog was WRONGLY declared T1 here (#2800), citing a
         # non-existent issue (#2083), while only Enabler 2 (HTTPScaledObject) existed —
         # no commit ever added a native build (Enabler 1), so the claimed "native
@@ -3232,7 +3246,7 @@ data:
       gate: finops-tier-drift
       enforced: advisory                      # ADR-0057; -> block when the classifier lands
       target_enforce_date: "2026-09-30"   # ADR-0144
-      blocked_on: "the measured-signal classifier (http_request_rate, kafka_consumer_lag, cpu/replica utilisation) has not shipped yet — only 2 services have a declared tier today (notification-service, product-catalog)"
+      blocked_on: "the measured-signal classifier shipped 2026-07-29 (finops-tier-classifier CronJob, daily report in the admin-ui) — the advisory gate now reads its findings; 3 services have a declared tier today (notification-service T2, product-catalog T0, card-issuance T1-held-at-min:1)"
       # Added by issue #2392: the rule carried `enforced`/`target_enforce_date` but never named the
       # script that produces the finding, so nothing tied the advisory CI step to this deadline.
       ci_producer: "openbank-infra/scripts/check-finops-tiers.py"

--- a/openbank-infra/gitops/components/copilot/copilot-service.yaml
+++ b/openbank-infra/gitops/components/copilot/copilot-service.yaml
@@ -29,7 +29,7 @@ spec:
       annotations:
         # Rolls the pod when the OPA bundle changes — subPath mounts do NOT hot-reload.
         # Kept in sync by gen-copilot-opa-bundle.sh (do not hand-edit).
-        openbank.tech/policy-checksum: "a755849d16d870f4"
+        openbank.tech/policy-checksum: "a7f1e1fdc96c85dd"
     spec:
       securityContext:
         runAsNonRoot: true

--- a/openbank-infra/gitops/components/customer-edge/customer-edge-opa-bundle.yaml
+++ b/openbank-infra/gitops/components/customer-edge/customer-edge-opa-bundle.yaml
@@ -10,7 +10,7 @@ metadata:
     app.kubernetes.io/name: customer-edge
     app.kubernetes.io/part-of: customer-edge
   annotations:
-    openbank.tech/policy-checksum: "e0f110332208803b"
+    openbank.tech/policy-checksum: "c83800f2882da701"
 data:
   rest.rego: |
     # SPDX-License-Identifier: Apache-2.0
@@ -2266,6 +2266,20 @@ data:
       # t0_baseline and need no explicit entry.
       declared:
         openbank-notification-service: T2     # proven pilot, live in sandbox (ADR-0057 best-first target, #228)
+        # ADR-0173 D3 reconciliation (2026-07-29): card-issuance carries a live HTTPScaledObject
+        # with an openbank.io/finops-tier: T1 label and was missing here. Not money-path, so T1
+        # is declarable on the evidence of the live scaled object + classifier-measured idle —
+        # HELD AT min:1 (warm floor) pending a cold-start SLO re-measurement on the current path,
+        # the same hold product-catalog carries below.
+        openbank-card-issuance-service: T1      # live HTTPScaledObject (payments/card-issuance-http), held at min:1 — see ADR-0173 D3
+        # sdd-service and interest-service ALSO carry T1-labeled HTTPScaledObjects (sdd/ and
+        # interest/ namespaces) — but both are money_path_services, so they inherit T0 via
+        # t0_baseline and a T1 label on the deployment is the drift ADR-0173 D3 describes:
+        # demoting either below T0 requires an ADR-0030 threat-model update + 2 approvals, and
+        # neither has happened. Their scaled objects run min:1 (= T0 behaviour today); the label
+        # means nothing until the demotion process runs. NOT declared here on purpose — an
+        # explicit T1 entry would silently demote a money-path service, exactly what
+        # money_path_sacred exists to block (check-finops-tiers.py flags it).
         # openbank-product-catalog was WRONGLY declared T1 here (#2800), citing a
         # non-existent issue (#2083), while only Enabler 2 (HTTPScaledObject) existed —
         # no commit ever added a native build (Enabler 1), so the claimed "native
@@ -2331,7 +2345,7 @@ data:
       gate: finops-tier-drift
       enforced: advisory                      # ADR-0057; -> block when the classifier lands
       target_enforce_date: "2026-09-30"   # ADR-0144
-      blocked_on: "the measured-signal classifier (http_request_rate, kafka_consumer_lag, cpu/replica utilisation) has not shipped yet — only 2 services have a declared tier today (notification-service, product-catalog)"
+      blocked_on: "the measured-signal classifier shipped 2026-07-29 (finops-tier-classifier CronJob, daily report in the admin-ui) — the advisory gate now reads its findings; 3 services have a declared tier today (notification-service T2, product-catalog T0, card-issuance T1-held-at-min:1)"
       # Added by issue #2392: the rule carried `enforced`/`target_enforce_date` but never named the
       # script that produces the finding, so nothing tied the advisory CI step to this deadline.
       ci_producer: "openbank-infra/scripts/check-finops-tiers.py"

--- a/openbank-infra/gitops/components/customer-edge/customer-edge.yaml
+++ b/openbank-infra/gitops/components/customer-edge/customer-edge.yaml
@@ -65,7 +65,7 @@ spec:
       annotations:
         # Rolls the pod when the OPA bundle changes — subPath mounts do NOT hot-reload.
         # Kept in sync by gen-customer-edge-opa-bundle.sh (do not hand-edit).
-        openbank.tech/policy-checksum: "e0f110332208803b"
+        openbank.tech/policy-checksum: "c83800f2882da701"
     spec:
       # Dedicated SA so EKS Pod Identity can hand the edge (and ONLY the edge) the
       # feedback-screenshots S3 role — ADR-0192, openbank-infra/aws/envs/sandbox-platform/

--- a/openbank-infra/gitops/components/dispute-service/dispute-opa-bundle.yaml
+++ b/openbank-infra/gitops/components/dispute-service/dispute-opa-bundle.yaml
@@ -9,7 +9,7 @@ metadata:
     app.kubernetes.io/name: dispute-service
     app.kubernetes.io/part-of: dispute
   annotations:
-    openbank.tech/policy-checksum: "fdec386f7cb627b0"
+    openbank.tech/policy-checksum: "d60af72d628bf649"
 data:
   rest.rego: |
     # SPDX-License-Identifier: Apache-2.0
@@ -3217,6 +3217,20 @@ data:
       # t0_baseline and need no explicit entry.
       declared:
         openbank-notification-service: T2     # proven pilot, live in sandbox (ADR-0057 best-first target, #228)
+        # ADR-0173 D3 reconciliation (2026-07-29): card-issuance carries a live HTTPScaledObject
+        # with an openbank.io/finops-tier: T1 label and was missing here. Not money-path, so T1
+        # is declarable on the evidence of the live scaled object + classifier-measured idle —
+        # HELD AT min:1 (warm floor) pending a cold-start SLO re-measurement on the current path,
+        # the same hold product-catalog carries below.
+        openbank-card-issuance-service: T1      # live HTTPScaledObject (payments/card-issuance-http), held at min:1 — see ADR-0173 D3
+        # sdd-service and interest-service ALSO carry T1-labeled HTTPScaledObjects (sdd/ and
+        # interest/ namespaces) — but both are money_path_services, so they inherit T0 via
+        # t0_baseline and a T1 label on the deployment is the drift ADR-0173 D3 describes:
+        # demoting either below T0 requires an ADR-0030 threat-model update + 2 approvals, and
+        # neither has happened. Their scaled objects run min:1 (= T0 behaviour today); the label
+        # means nothing until the demotion process runs. NOT declared here on purpose — an
+        # explicit T1 entry would silently demote a money-path service, exactly what
+        # money_path_sacred exists to block (check-finops-tiers.py flags it).
         # openbank-product-catalog was WRONGLY declared T1 here (#2800), citing a
         # non-existent issue (#2083), while only Enabler 2 (HTTPScaledObject) existed —
         # no commit ever added a native build (Enabler 1), so the claimed "native
@@ -3282,7 +3296,7 @@ data:
       gate: finops-tier-drift
       enforced: advisory                      # ADR-0057; -> block when the classifier lands
       target_enforce_date: "2026-09-30"   # ADR-0144
-      blocked_on: "the measured-signal classifier (http_request_rate, kafka_consumer_lag, cpu/replica utilisation) has not shipped yet — only 2 services have a declared tier today (notification-service, product-catalog)"
+      blocked_on: "the measured-signal classifier shipped 2026-07-29 (finops-tier-classifier CronJob, daily report in the admin-ui) — the advisory gate now reads its findings; 3 services have a declared tier today (notification-service T2, product-catalog T0, card-issuance T1-held-at-min:1)"
       # Added by issue #2392: the rule carried `enforced`/`target_enforce_date` but never named the
       # script that produces the finding, so nothing tied the advisory CI step to this deadline.
       ci_producer: "openbank-infra/scripts/check-finops-tiers.py"

--- a/openbank-infra/gitops/components/dispute-service/dispute-service.yaml
+++ b/openbank-infra/gitops/components/dispute-service/dispute-service.yaml
@@ -15,7 +15,7 @@ spec:
       annotations:
         # Rolls the pod when the OPA bundle changes — subPath mounts do NOT hot-reload.
         # Kept in sync by gen-dispute-opa-bundle.sh (do not hand-edit).
-        openbank.tech/policy-checksum: "fdec386f7cb627b0"
+        openbank.tech/policy-checksum: "d60af72d628bf649"
       labels: {app.kubernetes.io/name: dispute-service, app.kubernetes.io/part-of: dispute}
     spec:
       securityContext:

--- a/openbank-infra/gitops/components/document-service/document-service-opa-bundle.yaml
+++ b/openbank-infra/gitops/components/document-service/document-service-opa-bundle.yaml
@@ -10,7 +10,7 @@ metadata:
     app.kubernetes.io/name: document-service
     app.kubernetes.io/part-of: documents
   annotations:
-    openbank.tech/policy-checksum: "e0f110332208803b"
+    openbank.tech/policy-checksum: "c83800f2882da701"
 data:
   rest.rego: |
     # SPDX-License-Identifier: Apache-2.0
@@ -2266,6 +2266,20 @@ data:
       # t0_baseline and need no explicit entry.
       declared:
         openbank-notification-service: T2     # proven pilot, live in sandbox (ADR-0057 best-first target, #228)
+        # ADR-0173 D3 reconciliation (2026-07-29): card-issuance carries a live HTTPScaledObject
+        # with an openbank.io/finops-tier: T1 label and was missing here. Not money-path, so T1
+        # is declarable on the evidence of the live scaled object + classifier-measured idle —
+        # HELD AT min:1 (warm floor) pending a cold-start SLO re-measurement on the current path,
+        # the same hold product-catalog carries below.
+        openbank-card-issuance-service: T1      # live HTTPScaledObject (payments/card-issuance-http), held at min:1 — see ADR-0173 D3
+        # sdd-service and interest-service ALSO carry T1-labeled HTTPScaledObjects (sdd/ and
+        # interest/ namespaces) — but both are money_path_services, so they inherit T0 via
+        # t0_baseline and a T1 label on the deployment is the drift ADR-0173 D3 describes:
+        # demoting either below T0 requires an ADR-0030 threat-model update + 2 approvals, and
+        # neither has happened. Their scaled objects run min:1 (= T0 behaviour today); the label
+        # means nothing until the demotion process runs. NOT declared here on purpose — an
+        # explicit T1 entry would silently demote a money-path service, exactly what
+        # money_path_sacred exists to block (check-finops-tiers.py flags it).
         # openbank-product-catalog was WRONGLY declared T1 here (#2800), citing a
         # non-existent issue (#2083), while only Enabler 2 (HTTPScaledObject) existed —
         # no commit ever added a native build (Enabler 1), so the claimed "native
@@ -2331,7 +2345,7 @@ data:
       gate: finops-tier-drift
       enforced: advisory                      # ADR-0057; -> block when the classifier lands
       target_enforce_date: "2026-09-30"   # ADR-0144
-      blocked_on: "the measured-signal classifier (http_request_rate, kafka_consumer_lag, cpu/replica utilisation) has not shipped yet — only 2 services have a declared tier today (notification-service, product-catalog)"
+      blocked_on: "the measured-signal classifier shipped 2026-07-29 (finops-tier-classifier CronJob, daily report in the admin-ui) — the advisory gate now reads its findings; 3 services have a declared tier today (notification-service T2, product-catalog T0, card-issuance T1-held-at-min:1)"
       # Added by issue #2392: the rule carried `enforced`/`target_enforce_date` but never named the
       # script that produces the finding, so nothing tied the advisory CI step to this deadline.
       ci_producer: "openbank-infra/scripts/check-finops-tiers.py"

--- a/openbank-infra/gitops/components/document-service/document-service-service.yaml
+++ b/openbank-infra/gitops/components/document-service/document-service-service.yaml
@@ -43,7 +43,7 @@ spec:
       annotations:
         # Rolls the pods when the OPA bundle changes — subPath mounts do NOT hot-reload.
         # Kept in sync by gen-document-service-opa-bundle.sh (do not hand-edit).
-        openbank.tech/policy-checksum: "e0f110332208803b"
+        openbank.tech/policy-checksum: "c83800f2882da701"
     spec:
       # ADR-0162 D4 (continued): a dedicated SA (not `default`) is what OpenBao's Kubernetes-auth
       # role `document-service-signing` is bound to — least-privilege, one identity per consumer.

--- a/openbank-infra/gitops/components/fraud-service/fraud-opa-bundle.yaml
+++ b/openbank-infra/gitops/components/fraud-service/fraud-opa-bundle.yaml
@@ -9,7 +9,7 @@ metadata:
     app.kubernetes.io/name: fraud-service
     app.kubernetes.io/part-of: fraud
   annotations:
-    openbank.tech/policy-checksum: "7313fc2da9813995"
+    openbank.tech/policy-checksum: "6d3605dc23a1a9fc"
 data:
   rest.rego: |
     # SPDX-License-Identifier: Apache-2.0
@@ -3092,6 +3092,20 @@ data:
       # t0_baseline and need no explicit entry.
       declared:
         openbank-notification-service: T2     # proven pilot, live in sandbox (ADR-0057 best-first target, #228)
+        # ADR-0173 D3 reconciliation (2026-07-29): card-issuance carries a live HTTPScaledObject
+        # with an openbank.io/finops-tier: T1 label and was missing here. Not money-path, so T1
+        # is declarable on the evidence of the live scaled object + classifier-measured idle —
+        # HELD AT min:1 (warm floor) pending a cold-start SLO re-measurement on the current path,
+        # the same hold product-catalog carries below.
+        openbank-card-issuance-service: T1      # live HTTPScaledObject (payments/card-issuance-http), held at min:1 — see ADR-0173 D3
+        # sdd-service and interest-service ALSO carry T1-labeled HTTPScaledObjects (sdd/ and
+        # interest/ namespaces) — but both are money_path_services, so they inherit T0 via
+        # t0_baseline and a T1 label on the deployment is the drift ADR-0173 D3 describes:
+        # demoting either below T0 requires an ADR-0030 threat-model update + 2 approvals, and
+        # neither has happened. Their scaled objects run min:1 (= T0 behaviour today); the label
+        # means nothing until the demotion process runs. NOT declared here on purpose — an
+        # explicit T1 entry would silently demote a money-path service, exactly what
+        # money_path_sacred exists to block (check-finops-tiers.py flags it).
         # openbank-product-catalog was WRONGLY declared T1 here (#2800), citing a
         # non-existent issue (#2083), while only Enabler 2 (HTTPScaledObject) existed —
         # no commit ever added a native build (Enabler 1), so the claimed "native
@@ -3157,7 +3171,7 @@ data:
       gate: finops-tier-drift
       enforced: advisory                      # ADR-0057; -> block when the classifier lands
       target_enforce_date: "2026-09-30"   # ADR-0144
-      blocked_on: "the measured-signal classifier (http_request_rate, kafka_consumer_lag, cpu/replica utilisation) has not shipped yet — only 2 services have a declared tier today (notification-service, product-catalog)"
+      blocked_on: "the measured-signal classifier shipped 2026-07-29 (finops-tier-classifier CronJob, daily report in the admin-ui) — the advisory gate now reads its findings; 3 services have a declared tier today (notification-service T2, product-catalog T0, card-issuance T1-held-at-min:1)"
       # Added by issue #2392: the rule carried `enforced`/`target_enforce_date` but never named the
       # script that produces the finding, so nothing tied the advisory CI step to this deadline.
       ci_producer: "openbank-infra/scripts/check-finops-tiers.py"

--- a/openbank-infra/gitops/components/fraud-service/fraud-service.yaml
+++ b/openbank-infra/gitops/components/fraud-service/fraud-service.yaml
@@ -23,7 +23,7 @@ spec:
       annotations:
         # Rolls the pods when the OPA bundle changes — subPath mounts do NOT hot-reload.
         # Kept in sync by gen-fraud-opa-bundle.sh (do not hand-edit).
-        openbank.tech/policy-checksum: "7313fc2da9813995"
+        openbank.tech/policy-checksum: "6d3605dc23a1a9fc"
     spec:
       securityContext:
         runAsNonRoot: true

--- a/openbank-infra/gitops/components/fx-service/fx-opa-bundle.yaml
+++ b/openbank-infra/gitops/components/fx-service/fx-opa-bundle.yaml
@@ -9,7 +9,7 @@ metadata:
     app.kubernetes.io/name: fx-service
     app.kubernetes.io/part-of: fx
   annotations:
-    openbank.tech/policy-checksum: "01f4b78b1203ba63"
+    openbank.tech/policy-checksum: "7c8201d30e5eb6b7"
 data:
   rest.rego: |
     # SPDX-License-Identifier: Apache-2.0
@@ -3143,6 +3143,20 @@ data:
       # t0_baseline and need no explicit entry.
       declared:
         openbank-notification-service: T2     # proven pilot, live in sandbox (ADR-0057 best-first target, #228)
+        # ADR-0173 D3 reconciliation (2026-07-29): card-issuance carries a live HTTPScaledObject
+        # with an openbank.io/finops-tier: T1 label and was missing here. Not money-path, so T1
+        # is declarable on the evidence of the live scaled object + classifier-measured idle —
+        # HELD AT min:1 (warm floor) pending a cold-start SLO re-measurement on the current path,
+        # the same hold product-catalog carries below.
+        openbank-card-issuance-service: T1      # live HTTPScaledObject (payments/card-issuance-http), held at min:1 — see ADR-0173 D3
+        # sdd-service and interest-service ALSO carry T1-labeled HTTPScaledObjects (sdd/ and
+        # interest/ namespaces) — but both are money_path_services, so they inherit T0 via
+        # t0_baseline and a T1 label on the deployment is the drift ADR-0173 D3 describes:
+        # demoting either below T0 requires an ADR-0030 threat-model update + 2 approvals, and
+        # neither has happened. Their scaled objects run min:1 (= T0 behaviour today); the label
+        # means nothing until the demotion process runs. NOT declared here on purpose — an
+        # explicit T1 entry would silently demote a money-path service, exactly what
+        # money_path_sacred exists to block (check-finops-tiers.py flags it).
         # openbank-product-catalog was WRONGLY declared T1 here (#2800), citing a
         # non-existent issue (#2083), while only Enabler 2 (HTTPScaledObject) existed —
         # no commit ever added a native build (Enabler 1), so the claimed "native
@@ -3208,7 +3222,7 @@ data:
       gate: finops-tier-drift
       enforced: advisory                      # ADR-0057; -> block when the classifier lands
       target_enforce_date: "2026-09-30"   # ADR-0144
-      blocked_on: "the measured-signal classifier (http_request_rate, kafka_consumer_lag, cpu/replica utilisation) has not shipped yet — only 2 services have a declared tier today (notification-service, product-catalog)"
+      blocked_on: "the measured-signal classifier shipped 2026-07-29 (finops-tier-classifier CronJob, daily report in the admin-ui) — the advisory gate now reads its findings; 3 services have a declared tier today (notification-service T2, product-catalog T0, card-issuance T1-held-at-min:1)"
       # Added by issue #2392: the rule carried `enforced`/`target_enforce_date` but never named the
       # script that produces the finding, so nothing tied the advisory CI step to this deadline.
       ci_producer: "openbank-infra/scripts/check-finops-tiers.py"

--- a/openbank-infra/gitops/components/fx-service/fx-service.yaml
+++ b/openbank-infra/gitops/components/fx-service/fx-service.yaml
@@ -22,7 +22,7 @@ spec:
       annotations:
         # Rolls the pods when the OPA bundle changes — subPath mounts do NOT hot-reload.
         # Kept in sync by gen-fx-opa-bundle.sh (do not hand-edit).
-        openbank.tech/policy-checksum: "01f4b78b1203ba63"
+        openbank.tech/policy-checksum: "7c8201d30e5eb6b7"
     spec:
       securityContext:
         runAsNonRoot: true

--- a/openbank-infra/gitops/components/interest-service/interest-opa-bundle.yaml
+++ b/openbank-infra/gitops/components/interest-service/interest-opa-bundle.yaml
@@ -9,7 +9,7 @@ metadata:
     app.kubernetes.io/name: interest-service
     app.kubernetes.io/part-of: interest
   annotations:
-    openbank.tech/policy-checksum: "f7e60a1fc032d5eb"
+    openbank.tech/policy-checksum: "c58b827e620ef793"
 data:
   rest.rego: |
     # SPDX-License-Identifier: Apache-2.0
@@ -3077,6 +3077,20 @@ data:
       # t0_baseline and need no explicit entry.
       declared:
         openbank-notification-service: T2     # proven pilot, live in sandbox (ADR-0057 best-first target, #228)
+        # ADR-0173 D3 reconciliation (2026-07-29): card-issuance carries a live HTTPScaledObject
+        # with an openbank.io/finops-tier: T1 label and was missing here. Not money-path, so T1
+        # is declarable on the evidence of the live scaled object + classifier-measured idle —
+        # HELD AT min:1 (warm floor) pending a cold-start SLO re-measurement on the current path,
+        # the same hold product-catalog carries below.
+        openbank-card-issuance-service: T1      # live HTTPScaledObject (payments/card-issuance-http), held at min:1 — see ADR-0173 D3
+        # sdd-service and interest-service ALSO carry T1-labeled HTTPScaledObjects (sdd/ and
+        # interest/ namespaces) — but both are money_path_services, so they inherit T0 via
+        # t0_baseline and a T1 label on the deployment is the drift ADR-0173 D3 describes:
+        # demoting either below T0 requires an ADR-0030 threat-model update + 2 approvals, and
+        # neither has happened. Their scaled objects run min:1 (= T0 behaviour today); the label
+        # means nothing until the demotion process runs. NOT declared here on purpose — an
+        # explicit T1 entry would silently demote a money-path service, exactly what
+        # money_path_sacred exists to block (check-finops-tiers.py flags it).
         # openbank-product-catalog was WRONGLY declared T1 here (#2800), citing a
         # non-existent issue (#2083), while only Enabler 2 (HTTPScaledObject) existed —
         # no commit ever added a native build (Enabler 1), so the claimed "native
@@ -3142,7 +3156,7 @@ data:
       gate: finops-tier-drift
       enforced: advisory                      # ADR-0057; -> block when the classifier lands
       target_enforce_date: "2026-09-30"   # ADR-0144
-      blocked_on: "the measured-signal classifier (http_request_rate, kafka_consumer_lag, cpu/replica utilisation) has not shipped yet — only 2 services have a declared tier today (notification-service, product-catalog)"
+      blocked_on: "the measured-signal classifier shipped 2026-07-29 (finops-tier-classifier CronJob, daily report in the admin-ui) — the advisory gate now reads its findings; 3 services have a declared tier today (notification-service T2, product-catalog T0, card-issuance T1-held-at-min:1)"
       # Added by issue #2392: the rule carried `enforced`/`target_enforce_date` but never named the
       # script that produces the finding, so nothing tied the advisory CI step to this deadline.
       ci_producer: "openbank-infra/scripts/check-finops-tiers.py"

--- a/openbank-infra/gitops/components/interest-service/interest-service.yaml
+++ b/openbank-infra/gitops/components/interest-service/interest-service.yaml
@@ -16,7 +16,7 @@ spec:
       annotations:
         # Rolls the pods when the OPA bundle changes — subPath mounts do NOT hot-reload.
         # Kept in sync by gen-interest-opa-bundle.sh (do not hand-edit).
-        openbank.tech/policy-checksum: "f7e60a1fc032d5eb"
+        openbank.tech/policy-checksum: "c58b827e620ef793"
     spec:
       securityContext:
         runAsNonRoot: true

--- a/openbank-infra/gitops/components/kyc/kyc-opa-bundle.yaml
+++ b/openbank-infra/gitops/components/kyc/kyc-opa-bundle.yaml
@@ -9,7 +9,7 @@ metadata:
     app.kubernetes.io/name: kyc-service
     app.kubernetes.io/part-of: kyc
   annotations:
-    openbank.tech/policy-checksum: "81db737709361a04"
+    openbank.tech/policy-checksum: "c939355eabe7ef8a"
 data:
   rest.rego: |
     # SPDX-License-Identifier: Apache-2.0
@@ -3105,6 +3105,20 @@ data:
       # t0_baseline and need no explicit entry.
       declared:
         openbank-notification-service: T2     # proven pilot, live in sandbox (ADR-0057 best-first target, #228)
+        # ADR-0173 D3 reconciliation (2026-07-29): card-issuance carries a live HTTPScaledObject
+        # with an openbank.io/finops-tier: T1 label and was missing here. Not money-path, so T1
+        # is declarable on the evidence of the live scaled object + classifier-measured idle —
+        # HELD AT min:1 (warm floor) pending a cold-start SLO re-measurement on the current path,
+        # the same hold product-catalog carries below.
+        openbank-card-issuance-service: T1      # live HTTPScaledObject (payments/card-issuance-http), held at min:1 — see ADR-0173 D3
+        # sdd-service and interest-service ALSO carry T1-labeled HTTPScaledObjects (sdd/ and
+        # interest/ namespaces) — but both are money_path_services, so they inherit T0 via
+        # t0_baseline and a T1 label on the deployment is the drift ADR-0173 D3 describes:
+        # demoting either below T0 requires an ADR-0030 threat-model update + 2 approvals, and
+        # neither has happened. Their scaled objects run min:1 (= T0 behaviour today); the label
+        # means nothing until the demotion process runs. NOT declared here on purpose — an
+        # explicit T1 entry would silently demote a money-path service, exactly what
+        # money_path_sacred exists to block (check-finops-tiers.py flags it).
         # openbank-product-catalog was WRONGLY declared T1 here (#2800), citing a
         # non-existent issue (#2083), while only Enabler 2 (HTTPScaledObject) existed —
         # no commit ever added a native build (Enabler 1), so the claimed "native
@@ -3170,7 +3184,7 @@ data:
       gate: finops-tier-drift
       enforced: advisory                      # ADR-0057; -> block when the classifier lands
       target_enforce_date: "2026-09-30"   # ADR-0144
-      blocked_on: "the measured-signal classifier (http_request_rate, kafka_consumer_lag, cpu/replica utilisation) has not shipped yet — only 2 services have a declared tier today (notification-service, product-catalog)"
+      blocked_on: "the measured-signal classifier shipped 2026-07-29 (finops-tier-classifier CronJob, daily report in the admin-ui) — the advisory gate now reads its findings; 3 services have a declared tier today (notification-service T2, product-catalog T0, card-issuance T1-held-at-min:1)"
       # Added by issue #2392: the rule carried `enforced`/`target_enforce_date` but never named the
       # script that produces the finding, so nothing tied the advisory CI step to this deadline.
       ci_producer: "openbank-infra/scripts/check-finops-tiers.py"

--- a/openbank-infra/gitops/components/kyc/kyc-service.yaml
+++ b/openbank-infra/gitops/components/kyc/kyc-service.yaml
@@ -48,7 +48,7 @@ spec:
       annotations:
         # Rolls the pod when the OPA bundle changes (subPath mounts do not hot-reload).
         # Kept in sync by gen-kyc-opa-bundle.sh (do not hand-edit).
-        openbank.tech/policy-checksum: "81db737709361a04"
+        openbank.tech/policy-checksum: "c939355eabe7ef8a"
     spec:
       securityContext:
         runAsNonRoot: true

--- a/openbank-infra/gitops/components/ledger/ledger-opa-bundle.yaml
+++ b/openbank-infra/gitops/components/ledger/ledger-opa-bundle.yaml
@@ -9,7 +9,7 @@ metadata:
     app.kubernetes.io/name: ledger-service
     app.kubernetes.io/part-of: ledger
   annotations:
-    openbank.tech/policy-checksum: "ed7ffd441972bb9d"
+    openbank.tech/policy-checksum: "86975e5d591fcfc7"
 data:
   rest.rego: |
     # SPDX-License-Identifier: Apache-2.0
@@ -3190,6 +3190,20 @@ data:
       # t0_baseline and need no explicit entry.
       declared:
         openbank-notification-service: T2     # proven pilot, live in sandbox (ADR-0057 best-first target, #228)
+        # ADR-0173 D3 reconciliation (2026-07-29): card-issuance carries a live HTTPScaledObject
+        # with an openbank.io/finops-tier: T1 label and was missing here. Not money-path, so T1
+        # is declarable on the evidence of the live scaled object + classifier-measured idle —
+        # HELD AT min:1 (warm floor) pending a cold-start SLO re-measurement on the current path,
+        # the same hold product-catalog carries below.
+        openbank-card-issuance-service: T1      # live HTTPScaledObject (payments/card-issuance-http), held at min:1 — see ADR-0173 D3
+        # sdd-service and interest-service ALSO carry T1-labeled HTTPScaledObjects (sdd/ and
+        # interest/ namespaces) — but both are money_path_services, so they inherit T0 via
+        # t0_baseline and a T1 label on the deployment is the drift ADR-0173 D3 describes:
+        # demoting either below T0 requires an ADR-0030 threat-model update + 2 approvals, and
+        # neither has happened. Their scaled objects run min:1 (= T0 behaviour today); the label
+        # means nothing until the demotion process runs. NOT declared here on purpose — an
+        # explicit T1 entry would silently demote a money-path service, exactly what
+        # money_path_sacred exists to block (check-finops-tiers.py flags it).
         # openbank-product-catalog was WRONGLY declared T1 here (#2800), citing a
         # non-existent issue (#2083), while only Enabler 2 (HTTPScaledObject) existed —
         # no commit ever added a native build (Enabler 1), so the claimed "native
@@ -3255,7 +3269,7 @@ data:
       gate: finops-tier-drift
       enforced: advisory                      # ADR-0057; -> block when the classifier lands
       target_enforce_date: "2026-09-30"   # ADR-0144
-      blocked_on: "the measured-signal classifier (http_request_rate, kafka_consumer_lag, cpu/replica utilisation) has not shipped yet — only 2 services have a declared tier today (notification-service, product-catalog)"
+      blocked_on: "the measured-signal classifier shipped 2026-07-29 (finops-tier-classifier CronJob, daily report in the admin-ui) — the advisory gate now reads its findings; 3 services have a declared tier today (notification-service T2, product-catalog T0, card-issuance T1-held-at-min:1)"
       # Added by issue #2392: the rule carried `enforced`/`target_enforce_date` but never named the
       # script that produces the finding, so nothing tied the advisory CI step to this deadline.
       ci_producer: "openbank-infra/scripts/check-finops-tiers.py"

--- a/openbank-infra/gitops/components/ledger/ledger-service.yaml
+++ b/openbank-infra/gitops/components/ledger/ledger-service.yaml
@@ -38,7 +38,7 @@ spec:
       annotations:
         # Rolls the pods when the OPA bundle changes — subPath mounts do NOT hot-reload.
         # Kept in sync by gen-ledger-opa-bundle.sh (do not hand-edit).
-        openbank.tech/policy-checksum: "ed7ffd441972bb9d"
+        openbank.tech/policy-checksum: "86975e5d591fcfc7"
     spec:
       securityContext:
         runAsNonRoot: true

--- a/openbank-infra/gitops/components/lending/lending-opa-bundle.yaml
+++ b/openbank-infra/gitops/components/lending/lending-opa-bundle.yaml
@@ -9,7 +9,7 @@ metadata:
     app.kubernetes.io/name: lending-service
     app.kubernetes.io/part-of: lending
   annotations:
-    openbank.tech/policy-checksum: "f1895a6b6fe022f4"
+    openbank.tech/policy-checksum: "ff8b6349a4b7c129"
 data:
   rest.rego: |
     # SPDX-License-Identifier: Apache-2.0
@@ -3145,6 +3145,20 @@ data:
       # t0_baseline and need no explicit entry.
       declared:
         openbank-notification-service: T2     # proven pilot, live in sandbox (ADR-0057 best-first target, #228)
+        # ADR-0173 D3 reconciliation (2026-07-29): card-issuance carries a live HTTPScaledObject
+        # with an openbank.io/finops-tier: T1 label and was missing here. Not money-path, so T1
+        # is declarable on the evidence of the live scaled object + classifier-measured idle —
+        # HELD AT min:1 (warm floor) pending a cold-start SLO re-measurement on the current path,
+        # the same hold product-catalog carries below.
+        openbank-card-issuance-service: T1      # live HTTPScaledObject (payments/card-issuance-http), held at min:1 — see ADR-0173 D3
+        # sdd-service and interest-service ALSO carry T1-labeled HTTPScaledObjects (sdd/ and
+        # interest/ namespaces) — but both are money_path_services, so they inherit T0 via
+        # t0_baseline and a T1 label on the deployment is the drift ADR-0173 D3 describes:
+        # demoting either below T0 requires an ADR-0030 threat-model update + 2 approvals, and
+        # neither has happened. Their scaled objects run min:1 (= T0 behaviour today); the label
+        # means nothing until the demotion process runs. NOT declared here on purpose — an
+        # explicit T1 entry would silently demote a money-path service, exactly what
+        # money_path_sacred exists to block (check-finops-tiers.py flags it).
         # openbank-product-catalog was WRONGLY declared T1 here (#2800), citing a
         # non-existent issue (#2083), while only Enabler 2 (HTTPScaledObject) existed —
         # no commit ever added a native build (Enabler 1), so the claimed "native
@@ -3210,7 +3224,7 @@ data:
       gate: finops-tier-drift
       enforced: advisory                      # ADR-0057; -> block when the classifier lands
       target_enforce_date: "2026-09-30"   # ADR-0144
-      blocked_on: "the measured-signal classifier (http_request_rate, kafka_consumer_lag, cpu/replica utilisation) has not shipped yet — only 2 services have a declared tier today (notification-service, product-catalog)"
+      blocked_on: "the measured-signal classifier shipped 2026-07-29 (finops-tier-classifier CronJob, daily report in the admin-ui) — the advisory gate now reads its findings; 3 services have a declared tier today (notification-service T2, product-catalog T0, card-issuance T1-held-at-min:1)"
       # Added by issue #2392: the rule carried `enforced`/`target_enforce_date` but never named the
       # script that produces the finding, so nothing tied the advisory CI step to this deadline.
       ci_producer: "openbank-infra/scripts/check-finops-tiers.py"

--- a/openbank-infra/gitops/components/lending/lending-service.yaml
+++ b/openbank-infra/gitops/components/lending/lending-service.yaml
@@ -34,7 +34,7 @@ spec:
       annotations:
         # Rolls the pods when the OPA bundle changes — subPath mounts do NOT hot-reload.
         # Kept in sync by gen-lending-opa-bundle.sh (do not hand-edit).
-        openbank.tech/policy-checksum: "f1895a6b6fe022f4"
+        openbank.tech/policy-checksum: "ff8b6349a4b7c129"
     spec:
       securityContext:
         runAsNonRoot: true

--- a/openbank-infra/gitops/components/mcp/mcp-opa-bundle.yaml
+++ b/openbank-infra/gitops/components/mcp/mcp-opa-bundle.yaml
@@ -9,7 +9,7 @@ metadata:
     app.kubernetes.io/name: mcp-service
     app.kubernetes.io/part-of: platform
   annotations:
-    openbank.tech/policy-checksum: "4673877eb208bc64"
+    openbank.tech/policy-checksum: "e6597e9970958601"
 data:
   rest.rego: |
     # SPDX-License-Identifier: Apache-2.0
@@ -3043,6 +3043,20 @@ data:
       # t0_baseline and need no explicit entry.
       declared:
         openbank-notification-service: T2     # proven pilot, live in sandbox (ADR-0057 best-first target, #228)
+        # ADR-0173 D3 reconciliation (2026-07-29): card-issuance carries a live HTTPScaledObject
+        # with an openbank.io/finops-tier: T1 label and was missing here. Not money-path, so T1
+        # is declarable on the evidence of the live scaled object + classifier-measured idle —
+        # HELD AT min:1 (warm floor) pending a cold-start SLO re-measurement on the current path,
+        # the same hold product-catalog carries below.
+        openbank-card-issuance-service: T1      # live HTTPScaledObject (payments/card-issuance-http), held at min:1 — see ADR-0173 D3
+        # sdd-service and interest-service ALSO carry T1-labeled HTTPScaledObjects (sdd/ and
+        # interest/ namespaces) — but both are money_path_services, so they inherit T0 via
+        # t0_baseline and a T1 label on the deployment is the drift ADR-0173 D3 describes:
+        # demoting either below T0 requires an ADR-0030 threat-model update + 2 approvals, and
+        # neither has happened. Their scaled objects run min:1 (= T0 behaviour today); the label
+        # means nothing until the demotion process runs. NOT declared here on purpose — an
+        # explicit T1 entry would silently demote a money-path service, exactly what
+        # money_path_sacred exists to block (check-finops-tiers.py flags it).
         # openbank-product-catalog was WRONGLY declared T1 here (#2800), citing a
         # non-existent issue (#2083), while only Enabler 2 (HTTPScaledObject) existed —
         # no commit ever added a native build (Enabler 1), so the claimed "native
@@ -3108,7 +3122,7 @@ data:
       gate: finops-tier-drift
       enforced: advisory                      # ADR-0057; -> block when the classifier lands
       target_enforce_date: "2026-09-30"   # ADR-0144
-      blocked_on: "the measured-signal classifier (http_request_rate, kafka_consumer_lag, cpu/replica utilisation) has not shipped yet — only 2 services have a declared tier today (notification-service, product-catalog)"
+      blocked_on: "the measured-signal classifier shipped 2026-07-29 (finops-tier-classifier CronJob, daily report in the admin-ui) — the advisory gate now reads its findings; 3 services have a declared tier today (notification-service T2, product-catalog T0, card-issuance T1-held-at-min:1)"
       # Added by issue #2392: the rule carried `enforced`/`target_enforce_date` but never named the
       # script that produces the finding, so nothing tied the advisory CI step to this deadline.
       ci_producer: "openbank-infra/scripts/check-finops-tiers.py"

--- a/openbank-infra/gitops/components/mcp/mcp-service.yaml
+++ b/openbank-infra/gitops/components/mcp/mcp-service.yaml
@@ -29,7 +29,7 @@ spec:
       annotations:
         # Rolls the pod when the OPA bundle changes — subPath mounts do NOT hot-reload.
         # Kept in sync by gen-mcp-opa-bundle.sh (do not hand-edit).
-        openbank.tech/policy-checksum: "4673877eb208bc64"
+        openbank.tech/policy-checksum: "e6597e9970958601"
     spec:
       securityContext:
         runAsNonRoot: true

--- a/openbank-infra/gitops/components/notifications/notification-service-opa-bundle.yaml
+++ b/openbank-infra/gitops/components/notifications/notification-service-opa-bundle.yaml
@@ -10,7 +10,7 @@ metadata:
     app.kubernetes.io/name: notification-service
     app.kubernetes.io/part-of: notifications
   annotations:
-    openbank.tech/policy-checksum: "e0f110332208803b"
+    openbank.tech/policy-checksum: "c83800f2882da701"
 data:
   rest.rego: |
     # SPDX-License-Identifier: Apache-2.0
@@ -2266,6 +2266,20 @@ data:
       # t0_baseline and need no explicit entry.
       declared:
         openbank-notification-service: T2     # proven pilot, live in sandbox (ADR-0057 best-first target, #228)
+        # ADR-0173 D3 reconciliation (2026-07-29): card-issuance carries a live HTTPScaledObject
+        # with an openbank.io/finops-tier: T1 label and was missing here. Not money-path, so T1
+        # is declarable on the evidence of the live scaled object + classifier-measured idle —
+        # HELD AT min:1 (warm floor) pending a cold-start SLO re-measurement on the current path,
+        # the same hold product-catalog carries below.
+        openbank-card-issuance-service: T1      # live HTTPScaledObject (payments/card-issuance-http), held at min:1 — see ADR-0173 D3
+        # sdd-service and interest-service ALSO carry T1-labeled HTTPScaledObjects (sdd/ and
+        # interest/ namespaces) — but both are money_path_services, so they inherit T0 via
+        # t0_baseline and a T1 label on the deployment is the drift ADR-0173 D3 describes:
+        # demoting either below T0 requires an ADR-0030 threat-model update + 2 approvals, and
+        # neither has happened. Their scaled objects run min:1 (= T0 behaviour today); the label
+        # means nothing until the demotion process runs. NOT declared here on purpose — an
+        # explicit T1 entry would silently demote a money-path service, exactly what
+        # money_path_sacred exists to block (check-finops-tiers.py flags it).
         # openbank-product-catalog was WRONGLY declared T1 here (#2800), citing a
         # non-existent issue (#2083), while only Enabler 2 (HTTPScaledObject) existed —
         # no commit ever added a native build (Enabler 1), so the claimed "native
@@ -2331,7 +2345,7 @@ data:
       gate: finops-tier-drift
       enforced: advisory                      # ADR-0057; -> block when the classifier lands
       target_enforce_date: "2026-09-30"   # ADR-0144
-      blocked_on: "the measured-signal classifier (http_request_rate, kafka_consumer_lag, cpu/replica utilisation) has not shipped yet — only 2 services have a declared tier today (notification-service, product-catalog)"
+      blocked_on: "the measured-signal classifier shipped 2026-07-29 (finops-tier-classifier CronJob, daily report in the admin-ui) — the advisory gate now reads its findings; 3 services have a declared tier today (notification-service T2, product-catalog T0, card-issuance T1-held-at-min:1)"
       # Added by issue #2392: the rule carried `enforced`/`target_enforce_date` but never named the
       # script that produces the finding, so nothing tied the advisory CI step to this deadline.
       ci_producer: "openbank-infra/scripts/check-finops-tiers.py"

--- a/openbank-infra/gitops/components/notifications/notification-service.yaml
+++ b/openbank-infra/gitops/components/notifications/notification-service.yaml
@@ -39,7 +39,7 @@ spec:
       annotations:
         # Rolls the Deployment when the OPA policy bundle changes (subPath mounts don't
         # hot-reload). Kept in sync by gen-notification-opa-bundle.sh.
-        openbank.tech/policy-checksum: "e0f110332208803b"
+        openbank.tech/policy-checksum: "c83800f2882da701"
       labels:
         app.kubernetes.io/name: notification-service
         app.kubernetes.io/part-of: notifications

--- a/openbank-infra/gitops/components/party/party-opa-bundle.yaml
+++ b/openbank-infra/gitops/components/party/party-opa-bundle.yaml
@@ -9,7 +9,7 @@ metadata:
     app.kubernetes.io/name: party-service
     app.kubernetes.io/part-of: party
   annotations:
-    openbank.tech/policy-checksum: "a1805c717fd53e96"
+    openbank.tech/policy-checksum: "0746bed3eb06a618"
 data:
   rest.rego: |
     # SPDX-License-Identifier: Apache-2.0
@@ -3114,6 +3114,20 @@ data:
       # t0_baseline and need no explicit entry.
       declared:
         openbank-notification-service: T2     # proven pilot, live in sandbox (ADR-0057 best-first target, #228)
+        # ADR-0173 D3 reconciliation (2026-07-29): card-issuance carries a live HTTPScaledObject
+        # with an openbank.io/finops-tier: T1 label and was missing here. Not money-path, so T1
+        # is declarable on the evidence of the live scaled object + classifier-measured idle —
+        # HELD AT min:1 (warm floor) pending a cold-start SLO re-measurement on the current path,
+        # the same hold product-catalog carries below.
+        openbank-card-issuance-service: T1      # live HTTPScaledObject (payments/card-issuance-http), held at min:1 — see ADR-0173 D3
+        # sdd-service and interest-service ALSO carry T1-labeled HTTPScaledObjects (sdd/ and
+        # interest/ namespaces) — but both are money_path_services, so they inherit T0 via
+        # t0_baseline and a T1 label on the deployment is the drift ADR-0173 D3 describes:
+        # demoting either below T0 requires an ADR-0030 threat-model update + 2 approvals, and
+        # neither has happened. Their scaled objects run min:1 (= T0 behaviour today); the label
+        # means nothing until the demotion process runs. NOT declared here on purpose — an
+        # explicit T1 entry would silently demote a money-path service, exactly what
+        # money_path_sacred exists to block (check-finops-tiers.py flags it).
         # openbank-product-catalog was WRONGLY declared T1 here (#2800), citing a
         # non-existent issue (#2083), while only Enabler 2 (HTTPScaledObject) existed —
         # no commit ever added a native build (Enabler 1), so the claimed "native
@@ -3179,7 +3193,7 @@ data:
       gate: finops-tier-drift
       enforced: advisory                      # ADR-0057; -> block when the classifier lands
       target_enforce_date: "2026-09-30"   # ADR-0144
-      blocked_on: "the measured-signal classifier (http_request_rate, kafka_consumer_lag, cpu/replica utilisation) has not shipped yet — only 2 services have a declared tier today (notification-service, product-catalog)"
+      blocked_on: "the measured-signal classifier shipped 2026-07-29 (finops-tier-classifier CronJob, daily report in the admin-ui) — the advisory gate now reads its findings; 3 services have a declared tier today (notification-service T2, product-catalog T0, card-issuance T1-held-at-min:1)"
       # Added by issue #2392: the rule carried `enforced`/`target_enforce_date` but never named the
       # script that produces the finding, so nothing tied the advisory CI step to this deadline.
       ci_producer: "openbank-infra/scripts/check-finops-tiers.py"

--- a/openbank-infra/gitops/components/party/party-service.yaml
+++ b/openbank-infra/gitops/components/party/party-service.yaml
@@ -22,7 +22,7 @@ spec:
       annotations:
         # Rolls the pod when the OPA bundle changes — subPath mounts do NOT hot-reload.
         # Kept in sync by gen-party-opa-bundle.sh (do not hand-edit).
-        openbank.tech/policy-checksum: "a1805c717fd53e96"
+        openbank.tech/policy-checksum: "0746bed3eb06a618"
       labels:
         app.kubernetes.io/name: party-service
         app.kubernetes.io/part-of: party

--- a/openbank-infra/gitops/components/payments/card-issuance-opa-bundle.yaml
+++ b/openbank-infra/gitops/components/payments/card-issuance-opa-bundle.yaml
@@ -9,7 +9,7 @@ metadata:
     app.kubernetes.io/name: card-issuance-service
     app.kubernetes.io/part-of: payments
   annotations:
-    openbank.tech/policy-checksum: "5cd7795c0916c2ef"
+    openbank.tech/policy-checksum: "cc334d79025c6e4b"
 data:
   rest.rego: |
     # SPDX-License-Identifier: Apache-2.0
@@ -3098,6 +3098,20 @@ data:
       # t0_baseline and need no explicit entry.
       declared:
         openbank-notification-service: T2     # proven pilot, live in sandbox (ADR-0057 best-first target, #228)
+        # ADR-0173 D3 reconciliation (2026-07-29): card-issuance carries a live HTTPScaledObject
+        # with an openbank.io/finops-tier: T1 label and was missing here. Not money-path, so T1
+        # is declarable on the evidence of the live scaled object + classifier-measured idle —
+        # HELD AT min:1 (warm floor) pending a cold-start SLO re-measurement on the current path,
+        # the same hold product-catalog carries below.
+        openbank-card-issuance-service: T1      # live HTTPScaledObject (payments/card-issuance-http), held at min:1 — see ADR-0173 D3
+        # sdd-service and interest-service ALSO carry T1-labeled HTTPScaledObjects (sdd/ and
+        # interest/ namespaces) — but both are money_path_services, so they inherit T0 via
+        # t0_baseline and a T1 label on the deployment is the drift ADR-0173 D3 describes:
+        # demoting either below T0 requires an ADR-0030 threat-model update + 2 approvals, and
+        # neither has happened. Their scaled objects run min:1 (= T0 behaviour today); the label
+        # means nothing until the demotion process runs. NOT declared here on purpose — an
+        # explicit T1 entry would silently demote a money-path service, exactly what
+        # money_path_sacred exists to block (check-finops-tiers.py flags it).
         # openbank-product-catalog was WRONGLY declared T1 here (#2800), citing a
         # non-existent issue (#2083), while only Enabler 2 (HTTPScaledObject) existed —
         # no commit ever added a native build (Enabler 1), so the claimed "native
@@ -3163,7 +3177,7 @@ data:
       gate: finops-tier-drift
       enforced: advisory                      # ADR-0057; -> block when the classifier lands
       target_enforce_date: "2026-09-30"   # ADR-0144
-      blocked_on: "the measured-signal classifier (http_request_rate, kafka_consumer_lag, cpu/replica utilisation) has not shipped yet — only 2 services have a declared tier today (notification-service, product-catalog)"
+      blocked_on: "the measured-signal classifier shipped 2026-07-29 (finops-tier-classifier CronJob, daily report in the admin-ui) — the advisory gate now reads its findings; 3 services have a declared tier today (notification-service T2, product-catalog T0, card-issuance T1-held-at-min:1)"
       # Added by issue #2392: the rule carried `enforced`/`target_enforce_date` but never named the
       # script that produces the finding, so nothing tied the advisory CI step to this deadline.
       ci_producer: "openbank-infra/scripts/check-finops-tiers.py"

--- a/openbank-infra/gitops/components/payments/clearing-opa-bundle.yaml
+++ b/openbank-infra/gitops/components/payments/clearing-opa-bundle.yaml
@@ -9,7 +9,7 @@ metadata:
     app.kubernetes.io/name: clearing-service
     app.kubernetes.io/part-of: payments
   annotations:
-    openbank.tech/policy-checksum: "a4c9cd2e9cd4241d"
+    openbank.tech/policy-checksum: "5534408d151427b0"
 data:
   rest.rego: |
     # SPDX-License-Identifier: Apache-2.0
@@ -3135,6 +3135,20 @@ data:
       # t0_baseline and need no explicit entry.
       declared:
         openbank-notification-service: T2     # proven pilot, live in sandbox (ADR-0057 best-first target, #228)
+        # ADR-0173 D3 reconciliation (2026-07-29): card-issuance carries a live HTTPScaledObject
+        # with an openbank.io/finops-tier: T1 label and was missing here. Not money-path, so T1
+        # is declarable on the evidence of the live scaled object + classifier-measured idle —
+        # HELD AT min:1 (warm floor) pending a cold-start SLO re-measurement on the current path,
+        # the same hold product-catalog carries below.
+        openbank-card-issuance-service: T1      # live HTTPScaledObject (payments/card-issuance-http), held at min:1 — see ADR-0173 D3
+        # sdd-service and interest-service ALSO carry T1-labeled HTTPScaledObjects (sdd/ and
+        # interest/ namespaces) — but both are money_path_services, so they inherit T0 via
+        # t0_baseline and a T1 label on the deployment is the drift ADR-0173 D3 describes:
+        # demoting either below T0 requires an ADR-0030 threat-model update + 2 approvals, and
+        # neither has happened. Their scaled objects run min:1 (= T0 behaviour today); the label
+        # means nothing until the demotion process runs. NOT declared here on purpose — an
+        # explicit T1 entry would silently demote a money-path service, exactly what
+        # money_path_sacred exists to block (check-finops-tiers.py flags it).
         # openbank-product-catalog was WRONGLY declared T1 here (#2800), citing a
         # non-existent issue (#2083), while only Enabler 2 (HTTPScaledObject) existed —
         # no commit ever added a native build (Enabler 1), so the claimed "native
@@ -3200,7 +3214,7 @@ data:
       gate: finops-tier-drift
       enforced: advisory                      # ADR-0057; -> block when the classifier lands
       target_enforce_date: "2026-09-30"   # ADR-0144
-      blocked_on: "the measured-signal classifier (http_request_rate, kafka_consumer_lag, cpu/replica utilisation) has not shipped yet — only 2 services have a declared tier today (notification-service, product-catalog)"
+      blocked_on: "the measured-signal classifier shipped 2026-07-29 (finops-tier-classifier CronJob, daily report in the admin-ui) — the advisory gate now reads its findings; 3 services have a declared tier today (notification-service T2, product-catalog T0, card-issuance T1-held-at-min:1)"
       # Added by issue #2392: the rule carried `enforced`/`target_enforce_date` but never named the
       # script that produces the finding, so nothing tied the advisory CI step to this deadline.
       ci_producer: "openbank-infra/scripts/check-finops-tiers.py"

--- a/openbank-infra/gitops/components/payments/domestic-payment-opa-bundle.yaml
+++ b/openbank-infra/gitops/components/payments/domestic-payment-opa-bundle.yaml
@@ -9,7 +9,7 @@ metadata:
     app.kubernetes.io/name: domestic-payment
     app.kubernetes.io/part-of: payments
   annotations:
-    openbank.tech/policy-checksum: "9bcdb6ee235660a6"
+    openbank.tech/policy-checksum: "6bf2f77cea73d574"
 data:
   rest.rego: |
     # SPDX-License-Identifier: Apache-2.0
@@ -3120,6 +3120,20 @@ data:
       # t0_baseline and need no explicit entry.
       declared:
         openbank-notification-service: T2     # proven pilot, live in sandbox (ADR-0057 best-first target, #228)
+        # ADR-0173 D3 reconciliation (2026-07-29): card-issuance carries a live HTTPScaledObject
+        # with an openbank.io/finops-tier: T1 label and was missing here. Not money-path, so T1
+        # is declarable on the evidence of the live scaled object + classifier-measured idle —
+        # HELD AT min:1 (warm floor) pending a cold-start SLO re-measurement on the current path,
+        # the same hold product-catalog carries below.
+        openbank-card-issuance-service: T1      # live HTTPScaledObject (payments/card-issuance-http), held at min:1 — see ADR-0173 D3
+        # sdd-service and interest-service ALSO carry T1-labeled HTTPScaledObjects (sdd/ and
+        # interest/ namespaces) — but both are money_path_services, so they inherit T0 via
+        # t0_baseline and a T1 label on the deployment is the drift ADR-0173 D3 describes:
+        # demoting either below T0 requires an ADR-0030 threat-model update + 2 approvals, and
+        # neither has happened. Their scaled objects run min:1 (= T0 behaviour today); the label
+        # means nothing until the demotion process runs. NOT declared here on purpose — an
+        # explicit T1 entry would silently demote a money-path service, exactly what
+        # money_path_sacred exists to block (check-finops-tiers.py flags it).
         # openbank-product-catalog was WRONGLY declared T1 here (#2800), citing a
         # non-existent issue (#2083), while only Enabler 2 (HTTPScaledObject) existed —
         # no commit ever added a native build (Enabler 1), so the claimed "native
@@ -3185,7 +3199,7 @@ data:
       gate: finops-tier-drift
       enforced: advisory                      # ADR-0057; -> block when the classifier lands
       target_enforce_date: "2026-09-30"   # ADR-0144
-      blocked_on: "the measured-signal classifier (http_request_rate, kafka_consumer_lag, cpu/replica utilisation) has not shipped yet — only 2 services have a declared tier today (notification-service, product-catalog)"
+      blocked_on: "the measured-signal classifier shipped 2026-07-29 (finops-tier-classifier CronJob, daily report in the admin-ui) — the advisory gate now reads its findings; 3 services have a declared tier today (notification-service T2, product-catalog T0, card-issuance T1-held-at-min:1)"
       # Added by issue #2392: the rule carried `enforced`/`target_enforce_date` but never named the
       # script that produces the finding, so nothing tied the advisory CI step to this deadline.
       ci_producer: "openbank-infra/scripts/check-finops-tiers.py"

--- a/openbank-infra/gitops/components/payments/payments-services.yaml
+++ b/openbank-infra/gitops/components/payments/payments-services.yaml
@@ -42,7 +42,7 @@ spec:
         # Rolls the pods when the OPA bundle changes — subPath mounts do NOT hot-reload.
         # Kept in sync by gen-transaction-opa-bundle.sh via the trailing marker comment
         # (do not hand-edit, do not drop the marker).
-        openbank.tech/policy-checksum: "4895cf05d59011cc" # transaction-opa-bundle
+        openbank.tech/policy-checksum: "863184ff7c5efff5" # transaction-opa-bundle
     spec:
       securityContext:
         runAsNonRoot: true
@@ -375,7 +375,7 @@ spec:
       annotations:
         # Rolls the pods when the OPA bundle changes — subPath mounts do NOT hot-reload.
         # Kept in sync by gen-sepa-payment-opa-bundle.sh (do not hand-edit).
-        openbank.tech/policy-checksum: "409b53b6d8847009"
+        openbank.tech/policy-checksum: "0e8d3c7fc0ccc83e"
     spec:
       securityContext:
         runAsNonRoot: true
@@ -729,7 +729,7 @@ spec:
         # Rolls the pods when the OPA bundle changes — subPath mounts do NOT hot-reload.
         # Kept in sync by gen-domestic-payment-opa-bundle.sh via the trailing marker
         # comment (do not hand-edit, do not drop the marker).
-        openbank.tech/policy-checksum: "9bcdb6ee235660a6" # domestic-payment-opa-bundle
+        openbank.tech/policy-checksum: "6bf2f77cea73d574" # domestic-payment-opa-bundle
     spec:
       securityContext:
         runAsNonRoot: true
@@ -1053,7 +1053,7 @@ spec:
       annotations:
         # Rolls the pods when the OPA bundle changes — subPath mounts do NOT hot-reload.
         # Kept in sync by gen-sepa-instant-opa-bundle.sh (do not hand-edit).
-        openbank.tech/policy-checksum: "41c7053da1b93906"
+        openbank.tech/policy-checksum: "10b13d1c2851b934"
     spec:
       securityContext:
         runAsNonRoot: true
@@ -1369,7 +1369,7 @@ spec:
         # Rolls the pods when the OPA bundle changes — subPath mounts do NOT hot-reload.
         # Kept in sync by gen-clearing-opa-bundle.sh via the trailing marker comment
         # (do not hand-edit, do not drop the marker).
-        openbank.tech/policy-checksum: "a4c9cd2e9cd4241d" # clearing-opa-bundle
+        openbank.tech/policy-checksum: "5534408d151427b0" # clearing-opa-bundle
     spec:
       securityContext:
         runAsNonRoot: true
@@ -1658,7 +1658,7 @@ spec:
       annotations:
         # Rolls the pod when the OPA bundle changes (ADR-0034). Value is stamped by
         # gen-standing-order-opa-bundle.sh — do not hand-edit.
-        openbank.tech/policy-checksum: "f2549bcf7dbbbdaa" # standing-order-opa-bundle
+        openbank.tech/policy-checksum: "48c74e15da6adce6" # standing-order-opa-bundle
     spec:
       securityContext:
         runAsNonRoot: true
@@ -1911,7 +1911,7 @@ spec:
       annotations:
         # Rolls the pods when the OPA bundle changes — subPath mounts do NOT hot-reload.
         # Kept in sync by gen-card-issuance-opa-bundle.sh (do not hand-edit).
-        openbank.tech/policy-checksum: "5cd7795c0916c2ef"
+        openbank.tech/policy-checksum: "cc334d79025c6e4b"
     spec:
       securityContext:
         runAsNonRoot: true
@@ -2178,7 +2178,7 @@ spec:
         # Rolls the pods when the OPA bundle changes — subPath mounts do NOT hot-reload.
         # Kept in sync by gen-settlement-opa-bundle.sh via the trailing marker comment
         # (do not hand-edit, do not drop the marker).
-        openbank.tech/policy-checksum: "12f0d1fa4770303b" # settlement-opa-bundle
+        openbank.tech/policy-checksum: "80bbb45628844519" # settlement-opa-bundle
     spec:
       securityContext:
         runAsNonRoot: true
@@ -2579,7 +2579,7 @@ spec:
       annotations:
         # Rolls the pods when the OPA bundle changes — subPath mounts do NOT hot-reload.
         # Kept in sync by gen-swift-opa-bundle.sh (do not hand-edit).
-        openbank.tech/policy-checksum: "86401a38dca19adf"
+        openbank.tech/policy-checksum: "1da5c3944d9bfa36"
     spec:
       securityContext:
         runAsNonRoot: true
@@ -2893,7 +2893,7 @@ spec:
       annotations:
         # Rolls the pods when the OPA bundle changes — subPath mounts do NOT hot-reload.
         # Kept in sync by gen-vop-opa-bundle.sh (do not hand-edit).
-        openbank.tech/policy-checksum: "92b70497e97777e3"
+        openbank.tech/policy-checksum: "14ce4c81e21ab3c1"
     spec:
       securityContext:
         runAsNonRoot: true

--- a/openbank-infra/gitops/components/payments/sepa-instant-opa-bundle.yaml
+++ b/openbank-infra/gitops/components/payments/sepa-instant-opa-bundle.yaml
@@ -9,7 +9,7 @@ metadata:
     app.kubernetes.io/name: sepa-instant
     app.kubernetes.io/part-of: payments
   annotations:
-    openbank.tech/policy-checksum: "41c7053da1b93906"
+    openbank.tech/policy-checksum: "10b13d1c2851b934"
 data:
   rest.rego: |
     # SPDX-License-Identifier: Apache-2.0
@@ -3093,6 +3093,20 @@ data:
       # t0_baseline and need no explicit entry.
       declared:
         openbank-notification-service: T2     # proven pilot, live in sandbox (ADR-0057 best-first target, #228)
+        # ADR-0173 D3 reconciliation (2026-07-29): card-issuance carries a live HTTPScaledObject
+        # with an openbank.io/finops-tier: T1 label and was missing here. Not money-path, so T1
+        # is declarable on the evidence of the live scaled object + classifier-measured idle —
+        # HELD AT min:1 (warm floor) pending a cold-start SLO re-measurement on the current path,
+        # the same hold product-catalog carries below.
+        openbank-card-issuance-service: T1      # live HTTPScaledObject (payments/card-issuance-http), held at min:1 — see ADR-0173 D3
+        # sdd-service and interest-service ALSO carry T1-labeled HTTPScaledObjects (sdd/ and
+        # interest/ namespaces) — but both are money_path_services, so they inherit T0 via
+        # t0_baseline and a T1 label on the deployment is the drift ADR-0173 D3 describes:
+        # demoting either below T0 requires an ADR-0030 threat-model update + 2 approvals, and
+        # neither has happened. Their scaled objects run min:1 (= T0 behaviour today); the label
+        # means nothing until the demotion process runs. NOT declared here on purpose — an
+        # explicit T1 entry would silently demote a money-path service, exactly what
+        # money_path_sacred exists to block (check-finops-tiers.py flags it).
         # openbank-product-catalog was WRONGLY declared T1 here (#2800), citing a
         # non-existent issue (#2083), while only Enabler 2 (HTTPScaledObject) existed —
         # no commit ever added a native build (Enabler 1), so the claimed "native
@@ -3158,7 +3172,7 @@ data:
       gate: finops-tier-drift
       enforced: advisory                      # ADR-0057; -> block when the classifier lands
       target_enforce_date: "2026-09-30"   # ADR-0144
-      blocked_on: "the measured-signal classifier (http_request_rate, kafka_consumer_lag, cpu/replica utilisation) has not shipped yet — only 2 services have a declared tier today (notification-service, product-catalog)"
+      blocked_on: "the measured-signal classifier shipped 2026-07-29 (finops-tier-classifier CronJob, daily report in the admin-ui) — the advisory gate now reads its findings; 3 services have a declared tier today (notification-service T2, product-catalog T0, card-issuance T1-held-at-min:1)"
       # Added by issue #2392: the rule carried `enforced`/`target_enforce_date` but never named the
       # script that produces the finding, so nothing tied the advisory CI step to this deadline.
       ci_producer: "openbank-infra/scripts/check-finops-tiers.py"

--- a/openbank-infra/gitops/components/payments/sepa-payment-opa-bundle.yaml
+++ b/openbank-infra/gitops/components/payments/sepa-payment-opa-bundle.yaml
@@ -9,7 +9,7 @@ metadata:
     app.kubernetes.io/name: sepa-payment
     app.kubernetes.io/part-of: payments
   annotations:
-    openbank.tech/policy-checksum: "409b53b6d8847009"
+    openbank.tech/policy-checksum: "0e8d3c7fc0ccc83e"
 data:
   rest.rego: |
     # SPDX-License-Identifier: Apache-2.0
@@ -3114,6 +3114,20 @@ data:
       # t0_baseline and need no explicit entry.
       declared:
         openbank-notification-service: T2     # proven pilot, live in sandbox (ADR-0057 best-first target, #228)
+        # ADR-0173 D3 reconciliation (2026-07-29): card-issuance carries a live HTTPScaledObject
+        # with an openbank.io/finops-tier: T1 label and was missing here. Not money-path, so T1
+        # is declarable on the evidence of the live scaled object + classifier-measured idle —
+        # HELD AT min:1 (warm floor) pending a cold-start SLO re-measurement on the current path,
+        # the same hold product-catalog carries below.
+        openbank-card-issuance-service: T1      # live HTTPScaledObject (payments/card-issuance-http), held at min:1 — see ADR-0173 D3
+        # sdd-service and interest-service ALSO carry T1-labeled HTTPScaledObjects (sdd/ and
+        # interest/ namespaces) — but both are money_path_services, so they inherit T0 via
+        # t0_baseline and a T1 label on the deployment is the drift ADR-0173 D3 describes:
+        # demoting either below T0 requires an ADR-0030 threat-model update + 2 approvals, and
+        # neither has happened. Their scaled objects run min:1 (= T0 behaviour today); the label
+        # means nothing until the demotion process runs. NOT declared here on purpose — an
+        # explicit T1 entry would silently demote a money-path service, exactly what
+        # money_path_sacred exists to block (check-finops-tiers.py flags it).
         # openbank-product-catalog was WRONGLY declared T1 here (#2800), citing a
         # non-existent issue (#2083), while only Enabler 2 (HTTPScaledObject) existed —
         # no commit ever added a native build (Enabler 1), so the claimed "native
@@ -3179,7 +3193,7 @@ data:
       gate: finops-tier-drift
       enforced: advisory                      # ADR-0057; -> block when the classifier lands
       target_enforce_date: "2026-09-30"   # ADR-0144
-      blocked_on: "the measured-signal classifier (http_request_rate, kafka_consumer_lag, cpu/replica utilisation) has not shipped yet — only 2 services have a declared tier today (notification-service, product-catalog)"
+      blocked_on: "the measured-signal classifier shipped 2026-07-29 (finops-tier-classifier CronJob, daily report in the admin-ui) — the advisory gate now reads its findings; 3 services have a declared tier today (notification-service T2, product-catalog T0, card-issuance T1-held-at-min:1)"
       # Added by issue #2392: the rule carried `enforced`/`target_enforce_date` but never named the
       # script that produces the finding, so nothing tied the advisory CI step to this deadline.
       ci_producer: "openbank-infra/scripts/check-finops-tiers.py"

--- a/openbank-infra/gitops/components/payments/settlement-opa-bundle.yaml
+++ b/openbank-infra/gitops/components/payments/settlement-opa-bundle.yaml
@@ -9,7 +9,7 @@ metadata:
     app.kubernetes.io/name: settlement-service
     app.kubernetes.io/part-of: payments
   annotations:
-    openbank.tech/policy-checksum: "12f0d1fa4770303b"
+    openbank.tech/policy-checksum: "80bbb45628844519"
 data:
   rest.rego: |
     # SPDX-License-Identifier: Apache-2.0
@@ -3094,6 +3094,20 @@ data:
       # t0_baseline and need no explicit entry.
       declared:
         openbank-notification-service: T2     # proven pilot, live in sandbox (ADR-0057 best-first target, #228)
+        # ADR-0173 D3 reconciliation (2026-07-29): card-issuance carries a live HTTPScaledObject
+        # with an openbank.io/finops-tier: T1 label and was missing here. Not money-path, so T1
+        # is declarable on the evidence of the live scaled object + classifier-measured idle —
+        # HELD AT min:1 (warm floor) pending a cold-start SLO re-measurement on the current path,
+        # the same hold product-catalog carries below.
+        openbank-card-issuance-service: T1      # live HTTPScaledObject (payments/card-issuance-http), held at min:1 — see ADR-0173 D3
+        # sdd-service and interest-service ALSO carry T1-labeled HTTPScaledObjects (sdd/ and
+        # interest/ namespaces) — but both are money_path_services, so they inherit T0 via
+        # t0_baseline and a T1 label on the deployment is the drift ADR-0173 D3 describes:
+        # demoting either below T0 requires an ADR-0030 threat-model update + 2 approvals, and
+        # neither has happened. Their scaled objects run min:1 (= T0 behaviour today); the label
+        # means nothing until the demotion process runs. NOT declared here on purpose — an
+        # explicit T1 entry would silently demote a money-path service, exactly what
+        # money_path_sacred exists to block (check-finops-tiers.py flags it).
         # openbank-product-catalog was WRONGLY declared T1 here (#2800), citing a
         # non-existent issue (#2083), while only Enabler 2 (HTTPScaledObject) existed —
         # no commit ever added a native build (Enabler 1), so the claimed "native
@@ -3159,7 +3173,7 @@ data:
       gate: finops-tier-drift
       enforced: advisory                      # ADR-0057; -> block when the classifier lands
       target_enforce_date: "2026-09-30"   # ADR-0144
-      blocked_on: "the measured-signal classifier (http_request_rate, kafka_consumer_lag, cpu/replica utilisation) has not shipped yet — only 2 services have a declared tier today (notification-service, product-catalog)"
+      blocked_on: "the measured-signal classifier shipped 2026-07-29 (finops-tier-classifier CronJob, daily report in the admin-ui) — the advisory gate now reads its findings; 3 services have a declared tier today (notification-service T2, product-catalog T0, card-issuance T1-held-at-min:1)"
       # Added by issue #2392: the rule carried `enforced`/`target_enforce_date` but never named the
       # script that produces the finding, so nothing tied the advisory CI step to this deadline.
       ci_producer: "openbank-infra/scripts/check-finops-tiers.py"

--- a/openbank-infra/gitops/components/payments/standing-order-opa-bundle.yaml
+++ b/openbank-infra/gitops/components/payments/standing-order-opa-bundle.yaml
@@ -9,7 +9,7 @@ metadata:
     app.kubernetes.io/name: standing-order-service
     app.kubernetes.io/part-of: payments
   annotations:
-    openbank.tech/policy-checksum: "f2549bcf7dbbbdaa"
+    openbank.tech/policy-checksum: "48c74e15da6adce6"
 data:
   rest.rego: |
     # SPDX-License-Identifier: Apache-2.0
@@ -3079,6 +3079,20 @@ data:
       # t0_baseline and need no explicit entry.
       declared:
         openbank-notification-service: T2     # proven pilot, live in sandbox (ADR-0057 best-first target, #228)
+        # ADR-0173 D3 reconciliation (2026-07-29): card-issuance carries a live HTTPScaledObject
+        # with an openbank.io/finops-tier: T1 label and was missing here. Not money-path, so T1
+        # is declarable on the evidence of the live scaled object + classifier-measured idle —
+        # HELD AT min:1 (warm floor) pending a cold-start SLO re-measurement on the current path,
+        # the same hold product-catalog carries below.
+        openbank-card-issuance-service: T1      # live HTTPScaledObject (payments/card-issuance-http), held at min:1 — see ADR-0173 D3
+        # sdd-service and interest-service ALSO carry T1-labeled HTTPScaledObjects (sdd/ and
+        # interest/ namespaces) — but both are money_path_services, so they inherit T0 via
+        # t0_baseline and a T1 label on the deployment is the drift ADR-0173 D3 describes:
+        # demoting either below T0 requires an ADR-0030 threat-model update + 2 approvals, and
+        # neither has happened. Their scaled objects run min:1 (= T0 behaviour today); the label
+        # means nothing until the demotion process runs. NOT declared here on purpose — an
+        # explicit T1 entry would silently demote a money-path service, exactly what
+        # money_path_sacred exists to block (check-finops-tiers.py flags it).
         # openbank-product-catalog was WRONGLY declared T1 here (#2800), citing a
         # non-existent issue (#2083), while only Enabler 2 (HTTPScaledObject) existed —
         # no commit ever added a native build (Enabler 1), so the claimed "native
@@ -3144,7 +3158,7 @@ data:
       gate: finops-tier-drift
       enforced: advisory                      # ADR-0057; -> block when the classifier lands
       target_enforce_date: "2026-09-30"   # ADR-0144
-      blocked_on: "the measured-signal classifier (http_request_rate, kafka_consumer_lag, cpu/replica utilisation) has not shipped yet — only 2 services have a declared tier today (notification-service, product-catalog)"
+      blocked_on: "the measured-signal classifier shipped 2026-07-29 (finops-tier-classifier CronJob, daily report in the admin-ui) — the advisory gate now reads its findings; 3 services have a declared tier today (notification-service T2, product-catalog T0, card-issuance T1-held-at-min:1)"
       # Added by issue #2392: the rule carried `enforced`/`target_enforce_date` but never named the
       # script that produces the finding, so nothing tied the advisory CI step to this deadline.
       ci_producer: "openbank-infra/scripts/check-finops-tiers.py"

--- a/openbank-infra/gitops/components/payments/swift-opa-bundle.yaml
+++ b/openbank-infra/gitops/components/payments/swift-opa-bundle.yaml
@@ -9,7 +9,7 @@ metadata:
     app.kubernetes.io/name: swift-service
     app.kubernetes.io/part-of: payments
   annotations:
-    openbank.tech/policy-checksum: "86401a38dca19adf"
+    openbank.tech/policy-checksum: "1da5c3944d9bfa36"
 data:
   rest.rego: |
     # SPDX-License-Identifier: Apache-2.0
@@ -3097,6 +3097,20 @@ data:
       # t0_baseline and need no explicit entry.
       declared:
         openbank-notification-service: T2     # proven pilot, live in sandbox (ADR-0057 best-first target, #228)
+        # ADR-0173 D3 reconciliation (2026-07-29): card-issuance carries a live HTTPScaledObject
+        # with an openbank.io/finops-tier: T1 label and was missing here. Not money-path, so T1
+        # is declarable on the evidence of the live scaled object + classifier-measured idle —
+        # HELD AT min:1 (warm floor) pending a cold-start SLO re-measurement on the current path,
+        # the same hold product-catalog carries below.
+        openbank-card-issuance-service: T1      # live HTTPScaledObject (payments/card-issuance-http), held at min:1 — see ADR-0173 D3
+        # sdd-service and interest-service ALSO carry T1-labeled HTTPScaledObjects (sdd/ and
+        # interest/ namespaces) — but both are money_path_services, so they inherit T0 via
+        # t0_baseline and a T1 label on the deployment is the drift ADR-0173 D3 describes:
+        # demoting either below T0 requires an ADR-0030 threat-model update + 2 approvals, and
+        # neither has happened. Their scaled objects run min:1 (= T0 behaviour today); the label
+        # means nothing until the demotion process runs. NOT declared here on purpose — an
+        # explicit T1 entry would silently demote a money-path service, exactly what
+        # money_path_sacred exists to block (check-finops-tiers.py flags it).
         # openbank-product-catalog was WRONGLY declared T1 here (#2800), citing a
         # non-existent issue (#2083), while only Enabler 2 (HTTPScaledObject) existed —
         # no commit ever added a native build (Enabler 1), so the claimed "native
@@ -3162,7 +3176,7 @@ data:
       gate: finops-tier-drift
       enforced: advisory                      # ADR-0057; -> block when the classifier lands
       target_enforce_date: "2026-09-30"   # ADR-0144
-      blocked_on: "the measured-signal classifier (http_request_rate, kafka_consumer_lag, cpu/replica utilisation) has not shipped yet — only 2 services have a declared tier today (notification-service, product-catalog)"
+      blocked_on: "the measured-signal classifier shipped 2026-07-29 (finops-tier-classifier CronJob, daily report in the admin-ui) — the advisory gate now reads its findings; 3 services have a declared tier today (notification-service T2, product-catalog T0, card-issuance T1-held-at-min:1)"
       # Added by issue #2392: the rule carried `enforced`/`target_enforce_date` but never named the
       # script that produces the finding, so nothing tied the advisory CI step to this deadline.
       ci_producer: "openbank-infra/scripts/check-finops-tiers.py"

--- a/openbank-infra/gitops/components/payments/transaction-opa-bundle.yaml
+++ b/openbank-infra/gitops/components/payments/transaction-opa-bundle.yaml
@@ -9,7 +9,7 @@ metadata:
     app.kubernetes.io/name: transaction-service
     app.kubernetes.io/part-of: payments
   annotations:
-    openbank.tech/policy-checksum: "4895cf05d59011cc"
+    openbank.tech/policy-checksum: "863184ff7c5efff5"
 data:
   rest.rego: |
     # SPDX-License-Identifier: Apache-2.0
@@ -3150,6 +3150,20 @@ data:
       # t0_baseline and need no explicit entry.
       declared:
         openbank-notification-service: T2     # proven pilot, live in sandbox (ADR-0057 best-first target, #228)
+        # ADR-0173 D3 reconciliation (2026-07-29): card-issuance carries a live HTTPScaledObject
+        # with an openbank.io/finops-tier: T1 label and was missing here. Not money-path, so T1
+        # is declarable on the evidence of the live scaled object + classifier-measured idle —
+        # HELD AT min:1 (warm floor) pending a cold-start SLO re-measurement on the current path,
+        # the same hold product-catalog carries below.
+        openbank-card-issuance-service: T1      # live HTTPScaledObject (payments/card-issuance-http), held at min:1 — see ADR-0173 D3
+        # sdd-service and interest-service ALSO carry T1-labeled HTTPScaledObjects (sdd/ and
+        # interest/ namespaces) — but both are money_path_services, so they inherit T0 via
+        # t0_baseline and a T1 label on the deployment is the drift ADR-0173 D3 describes:
+        # demoting either below T0 requires an ADR-0030 threat-model update + 2 approvals, and
+        # neither has happened. Their scaled objects run min:1 (= T0 behaviour today); the label
+        # means nothing until the demotion process runs. NOT declared here on purpose — an
+        # explicit T1 entry would silently demote a money-path service, exactly what
+        # money_path_sacred exists to block (check-finops-tiers.py flags it).
         # openbank-product-catalog was WRONGLY declared T1 here (#2800), citing a
         # non-existent issue (#2083), while only Enabler 2 (HTTPScaledObject) existed —
         # no commit ever added a native build (Enabler 1), so the claimed "native
@@ -3215,7 +3229,7 @@ data:
       gate: finops-tier-drift
       enforced: advisory                      # ADR-0057; -> block when the classifier lands
       target_enforce_date: "2026-09-30"   # ADR-0144
-      blocked_on: "the measured-signal classifier (http_request_rate, kafka_consumer_lag, cpu/replica utilisation) has not shipped yet — only 2 services have a declared tier today (notification-service, product-catalog)"
+      blocked_on: "the measured-signal classifier shipped 2026-07-29 (finops-tier-classifier CronJob, daily report in the admin-ui) — the advisory gate now reads its findings; 3 services have a declared tier today (notification-service T2, product-catalog T0, card-issuance T1-held-at-min:1)"
       # Added by issue #2392: the rule carried `enforced`/`target_enforce_date` but never named the
       # script that produces the finding, so nothing tied the advisory CI step to this deadline.
       ci_producer: "openbank-infra/scripts/check-finops-tiers.py"

--- a/openbank-infra/gitops/components/payments/vop-opa-bundle.yaml
+++ b/openbank-infra/gitops/components/payments/vop-opa-bundle.yaml
@@ -9,7 +9,7 @@ metadata:
     app.kubernetes.io/name: vop-service
     app.kubernetes.io/part-of: payments
   annotations:
-    openbank.tech/policy-checksum: "92b70497e97777e3"
+    openbank.tech/policy-checksum: "14ce4c81e21ab3c1"
 data:
   rest.rego: |
     # SPDX-License-Identifier: Apache-2.0
@@ -3101,6 +3101,20 @@ data:
       # t0_baseline and need no explicit entry.
       declared:
         openbank-notification-service: T2     # proven pilot, live in sandbox (ADR-0057 best-first target, #228)
+        # ADR-0173 D3 reconciliation (2026-07-29): card-issuance carries a live HTTPScaledObject
+        # with an openbank.io/finops-tier: T1 label and was missing here. Not money-path, so T1
+        # is declarable on the evidence of the live scaled object + classifier-measured idle —
+        # HELD AT min:1 (warm floor) pending a cold-start SLO re-measurement on the current path,
+        # the same hold product-catalog carries below.
+        openbank-card-issuance-service: T1      # live HTTPScaledObject (payments/card-issuance-http), held at min:1 — see ADR-0173 D3
+        # sdd-service and interest-service ALSO carry T1-labeled HTTPScaledObjects (sdd/ and
+        # interest/ namespaces) — but both are money_path_services, so they inherit T0 via
+        # t0_baseline and a T1 label on the deployment is the drift ADR-0173 D3 describes:
+        # demoting either below T0 requires an ADR-0030 threat-model update + 2 approvals, and
+        # neither has happened. Their scaled objects run min:1 (= T0 behaviour today); the label
+        # means nothing until the demotion process runs. NOT declared here on purpose — an
+        # explicit T1 entry would silently demote a money-path service, exactly what
+        # money_path_sacred exists to block (check-finops-tiers.py flags it).
         # openbank-product-catalog was WRONGLY declared T1 here (#2800), citing a
         # non-existent issue (#2083), while only Enabler 2 (HTTPScaledObject) existed —
         # no commit ever added a native build (Enabler 1), so the claimed "native
@@ -3166,7 +3180,7 @@ data:
       gate: finops-tier-drift
       enforced: advisory                      # ADR-0057; -> block when the classifier lands
       target_enforce_date: "2026-09-30"   # ADR-0144
-      blocked_on: "the measured-signal classifier (http_request_rate, kafka_consumer_lag, cpu/replica utilisation) has not shipped yet — only 2 services have a declared tier today (notification-service, product-catalog)"
+      blocked_on: "the measured-signal classifier shipped 2026-07-29 (finops-tier-classifier CronJob, daily report in the admin-ui) — the advisory gate now reads its findings; 3 services have a declared tier today (notification-service T2, product-catalog T0, card-issuance T1-held-at-min:1)"
       # Added by issue #2392: the rule carried `enforced`/`target_enforce_date` but never named the
       # script that produces the finding, so nothing tied the advisory CI step to this deadline.
       ci_producer: "openbank-infra/scripts/check-finops-tiers.py"

--- a/openbank-infra/gitops/components/pid/pid-opa-bundle.yaml
+++ b/openbank-infra/gitops/components/pid/pid-opa-bundle.yaml
@@ -9,7 +9,7 @@ metadata:
     app.kubernetes.io/name: pid-service
     app.kubernetes.io/part-of: pid
   annotations:
-    openbank.tech/policy-checksum: "e3cb11c1e76365c7"
+    openbank.tech/policy-checksum: "35c4bfeb9f358a0a"
 data:
   rest.rego: |
     # SPDX-License-Identifier: Apache-2.0
@@ -3103,6 +3103,20 @@ data:
       # t0_baseline and need no explicit entry.
       declared:
         openbank-notification-service: T2     # proven pilot, live in sandbox (ADR-0057 best-first target, #228)
+        # ADR-0173 D3 reconciliation (2026-07-29): card-issuance carries a live HTTPScaledObject
+        # with an openbank.io/finops-tier: T1 label and was missing here. Not money-path, so T1
+        # is declarable on the evidence of the live scaled object + classifier-measured idle —
+        # HELD AT min:1 (warm floor) pending a cold-start SLO re-measurement on the current path,
+        # the same hold product-catalog carries below.
+        openbank-card-issuance-service: T1      # live HTTPScaledObject (payments/card-issuance-http), held at min:1 — see ADR-0173 D3
+        # sdd-service and interest-service ALSO carry T1-labeled HTTPScaledObjects (sdd/ and
+        # interest/ namespaces) — but both are money_path_services, so they inherit T0 via
+        # t0_baseline and a T1 label on the deployment is the drift ADR-0173 D3 describes:
+        # demoting either below T0 requires an ADR-0030 threat-model update + 2 approvals, and
+        # neither has happened. Their scaled objects run min:1 (= T0 behaviour today); the label
+        # means nothing until the demotion process runs. NOT declared here on purpose — an
+        # explicit T1 entry would silently demote a money-path service, exactly what
+        # money_path_sacred exists to block (check-finops-tiers.py flags it).
         # openbank-product-catalog was WRONGLY declared T1 here (#2800), citing a
         # non-existent issue (#2083), while only Enabler 2 (HTTPScaledObject) existed —
         # no commit ever added a native build (Enabler 1), so the claimed "native
@@ -3168,7 +3182,7 @@ data:
       gate: finops-tier-drift
       enforced: advisory                      # ADR-0057; -> block when the classifier lands
       target_enforce_date: "2026-09-30"   # ADR-0144
-      blocked_on: "the measured-signal classifier (http_request_rate, kafka_consumer_lag, cpu/replica utilisation) has not shipped yet — only 2 services have a declared tier today (notification-service, product-catalog)"
+      blocked_on: "the measured-signal classifier shipped 2026-07-29 (finops-tier-classifier CronJob, daily report in the admin-ui) — the advisory gate now reads its findings; 3 services have a declared tier today (notification-service T2, product-catalog T0, card-issuance T1-held-at-min:1)"
       # Added by issue #2392: the rule carried `enforced`/`target_enforce_date` but never named the
       # script that produces the finding, so nothing tied the advisory CI step to this deadline.
       ci_producer: "openbank-infra/scripts/check-finops-tiers.py"

--- a/openbank-infra/gitops/components/pid/pid-service.yaml
+++ b/openbank-infra/gitops/components/pid/pid-service.yaml
@@ -22,7 +22,7 @@ spec:
       annotations:
         # Rolls the pod when the OPA bundle changes — subPath mounts do NOT hot-reload.
         # Kept in sync by gen-pid-opa-bundle.sh (do not hand-edit).
-        openbank.tech/policy-checksum: "e3cb11c1e76365c7"
+        openbank.tech/policy-checksum: "35c4bfeb9f358a0a"
     spec:
       securityContext:
         runAsNonRoot: true

--- a/openbank-infra/gitops/components/psd2-service/psd2-opa-bundle.yaml
+++ b/openbank-infra/gitops/components/psd2-service/psd2-opa-bundle.yaml
@@ -9,7 +9,7 @@ metadata:
     app.kubernetes.io/name: psd2-service
     app.kubernetes.io/part-of: psd2
   annotations:
-    openbank.tech/policy-checksum: "1a9afe5d0b9295a9"
+    openbank.tech/policy-checksum: "4a1d59b0da794e39"
 data:
   rest.rego: |
     # SPDX-License-Identifier: Apache-2.0
@@ -3176,6 +3176,20 @@ data:
       # t0_baseline and need no explicit entry.
       declared:
         openbank-notification-service: T2     # proven pilot, live in sandbox (ADR-0057 best-first target, #228)
+        # ADR-0173 D3 reconciliation (2026-07-29): card-issuance carries a live HTTPScaledObject
+        # with an openbank.io/finops-tier: T1 label and was missing here. Not money-path, so T1
+        # is declarable on the evidence of the live scaled object + classifier-measured idle —
+        # HELD AT min:1 (warm floor) pending a cold-start SLO re-measurement on the current path,
+        # the same hold product-catalog carries below.
+        openbank-card-issuance-service: T1      # live HTTPScaledObject (payments/card-issuance-http), held at min:1 — see ADR-0173 D3
+        # sdd-service and interest-service ALSO carry T1-labeled HTTPScaledObjects (sdd/ and
+        # interest/ namespaces) — but both are money_path_services, so they inherit T0 via
+        # t0_baseline and a T1 label on the deployment is the drift ADR-0173 D3 describes:
+        # demoting either below T0 requires an ADR-0030 threat-model update + 2 approvals, and
+        # neither has happened. Their scaled objects run min:1 (= T0 behaviour today); the label
+        # means nothing until the demotion process runs. NOT declared here on purpose — an
+        # explicit T1 entry would silently demote a money-path service, exactly what
+        # money_path_sacred exists to block (check-finops-tiers.py flags it).
         # openbank-product-catalog was WRONGLY declared T1 here (#2800), citing a
         # non-existent issue (#2083), while only Enabler 2 (HTTPScaledObject) existed —
         # no commit ever added a native build (Enabler 1), so the claimed "native
@@ -3241,7 +3255,7 @@ data:
       gate: finops-tier-drift
       enforced: advisory                      # ADR-0057; -> block when the classifier lands
       target_enforce_date: "2026-09-30"   # ADR-0144
-      blocked_on: "the measured-signal classifier (http_request_rate, kafka_consumer_lag, cpu/replica utilisation) has not shipped yet — only 2 services have a declared tier today (notification-service, product-catalog)"
+      blocked_on: "the measured-signal classifier shipped 2026-07-29 (finops-tier-classifier CronJob, daily report in the admin-ui) — the advisory gate now reads its findings; 3 services have a declared tier today (notification-service T2, product-catalog T0, card-issuance T1-held-at-min:1)"
       # Added by issue #2392: the rule carried `enforced`/`target_enforce_date` but never named the
       # script that produces the finding, so nothing tied the advisory CI step to this deadline.
       ci_producer: "openbank-infra/scripts/check-finops-tiers.py"

--- a/openbank-infra/gitops/components/psd2-service/psd2-service.yaml
+++ b/openbank-infra/gitops/components/psd2-service/psd2-service.yaml
@@ -18,7 +18,7 @@ spec:
       annotations:
         # Rolls the pod when the OPA bundle changes — subPath mounts do NOT hot-reload.
         # Kept in sync by gen-psd2-opa-bundle.sh (do not hand-edit).
-        openbank.tech/policy-checksum: "1a9afe5d0b9295a9"
+        openbank.tech/policy-checksum: "4a1d59b0da794e39"
       labels: {app.kubernetes.io/name: psd2-service, app.kubernetes.io/part-of: psd2}
     spec:
       securityContext:

--- a/openbank-infra/gitops/components/sanctions-service/sanctions-opa-bundle.yaml
+++ b/openbank-infra/gitops/components/sanctions-service/sanctions-opa-bundle.yaml
@@ -9,7 +9,7 @@ metadata:
     app.kubernetes.io/name: sanctions-service
     app.kubernetes.io/part-of: sanctions
   annotations:
-    openbank.tech/policy-checksum: "bee101daa2f81453"
+    openbank.tech/policy-checksum: "cd9cc75478363f05"
 data:
   rest.rego: |
     # SPDX-License-Identifier: Apache-2.0
@@ -3081,6 +3081,20 @@ data:
       # t0_baseline and need no explicit entry.
       declared:
         openbank-notification-service: T2     # proven pilot, live in sandbox (ADR-0057 best-first target, #228)
+        # ADR-0173 D3 reconciliation (2026-07-29): card-issuance carries a live HTTPScaledObject
+        # with an openbank.io/finops-tier: T1 label and was missing here. Not money-path, so T1
+        # is declarable on the evidence of the live scaled object + classifier-measured idle —
+        # HELD AT min:1 (warm floor) pending a cold-start SLO re-measurement on the current path,
+        # the same hold product-catalog carries below.
+        openbank-card-issuance-service: T1      # live HTTPScaledObject (payments/card-issuance-http), held at min:1 — see ADR-0173 D3
+        # sdd-service and interest-service ALSO carry T1-labeled HTTPScaledObjects (sdd/ and
+        # interest/ namespaces) — but both are money_path_services, so they inherit T0 via
+        # t0_baseline and a T1 label on the deployment is the drift ADR-0173 D3 describes:
+        # demoting either below T0 requires an ADR-0030 threat-model update + 2 approvals, and
+        # neither has happened. Their scaled objects run min:1 (= T0 behaviour today); the label
+        # means nothing until the demotion process runs. NOT declared here on purpose — an
+        # explicit T1 entry would silently demote a money-path service, exactly what
+        # money_path_sacred exists to block (check-finops-tiers.py flags it).
         # openbank-product-catalog was WRONGLY declared T1 here (#2800), citing a
         # non-existent issue (#2083), while only Enabler 2 (HTTPScaledObject) existed —
         # no commit ever added a native build (Enabler 1), so the claimed "native
@@ -3146,7 +3160,7 @@ data:
       gate: finops-tier-drift
       enforced: advisory                      # ADR-0057; -> block when the classifier lands
       target_enforce_date: "2026-09-30"   # ADR-0144
-      blocked_on: "the measured-signal classifier (http_request_rate, kafka_consumer_lag, cpu/replica utilisation) has not shipped yet — only 2 services have a declared tier today (notification-service, product-catalog)"
+      blocked_on: "the measured-signal classifier shipped 2026-07-29 (finops-tier-classifier CronJob, daily report in the admin-ui) — the advisory gate now reads its findings; 3 services have a declared tier today (notification-service T2, product-catalog T0, card-issuance T1-held-at-min:1)"
       # Added by issue #2392: the rule carried `enforced`/`target_enforce_date` but never named the
       # script that produces the finding, so nothing tied the advisory CI step to this deadline.
       ci_producer: "openbank-infra/scripts/check-finops-tiers.py"

--- a/openbank-infra/gitops/components/sanctions-service/sanctions-service.yaml
+++ b/openbank-infra/gitops/components/sanctions-service/sanctions-service.yaml
@@ -49,7 +49,7 @@ spec:
       annotations:
         # Rolls the pods when the OPA bundle changes — subPath mounts do NOT hot-reload.
         # Kept in sync by gen-sanctions-opa-bundle.sh (do not hand-edit).
-        openbank.tech/policy-checksum: "bee101daa2f81453"
+        openbank.tech/policy-checksum: "cd9cc75478363f05"
     spec:
       securityContext:
         runAsNonRoot: true

--- a/openbank-infra/gitops/components/sca/sca-opa-bundle.yaml
+++ b/openbank-infra/gitops/components/sca/sca-opa-bundle.yaml
@@ -9,7 +9,7 @@ metadata:
     app.kubernetes.io/name: sca-service
     app.kubernetes.io/part-of: sca
   annotations:
-    openbank.tech/policy-checksum: "063fa8c5eead820d"
+    openbank.tech/policy-checksum: "96f7d6249fa79a92"
 data:
   rest.rego: |
     # SPDX-License-Identifier: Apache-2.0
@@ -3117,6 +3117,20 @@ data:
       # t0_baseline and need no explicit entry.
       declared:
         openbank-notification-service: T2     # proven pilot, live in sandbox (ADR-0057 best-first target, #228)
+        # ADR-0173 D3 reconciliation (2026-07-29): card-issuance carries a live HTTPScaledObject
+        # with an openbank.io/finops-tier: T1 label and was missing here. Not money-path, so T1
+        # is declarable on the evidence of the live scaled object + classifier-measured idle —
+        # HELD AT min:1 (warm floor) pending a cold-start SLO re-measurement on the current path,
+        # the same hold product-catalog carries below.
+        openbank-card-issuance-service: T1      # live HTTPScaledObject (payments/card-issuance-http), held at min:1 — see ADR-0173 D3
+        # sdd-service and interest-service ALSO carry T1-labeled HTTPScaledObjects (sdd/ and
+        # interest/ namespaces) — but both are money_path_services, so they inherit T0 via
+        # t0_baseline and a T1 label on the deployment is the drift ADR-0173 D3 describes:
+        # demoting either below T0 requires an ADR-0030 threat-model update + 2 approvals, and
+        # neither has happened. Their scaled objects run min:1 (= T0 behaviour today); the label
+        # means nothing until the demotion process runs. NOT declared here on purpose — an
+        # explicit T1 entry would silently demote a money-path service, exactly what
+        # money_path_sacred exists to block (check-finops-tiers.py flags it).
         # openbank-product-catalog was WRONGLY declared T1 here (#2800), citing a
         # non-existent issue (#2083), while only Enabler 2 (HTTPScaledObject) existed —
         # no commit ever added a native build (Enabler 1), so the claimed "native
@@ -3182,7 +3196,7 @@ data:
       gate: finops-tier-drift
       enforced: advisory                      # ADR-0057; -> block when the classifier lands
       target_enforce_date: "2026-09-30"   # ADR-0144
-      blocked_on: "the measured-signal classifier (http_request_rate, kafka_consumer_lag, cpu/replica utilisation) has not shipped yet — only 2 services have a declared tier today (notification-service, product-catalog)"
+      blocked_on: "the measured-signal classifier shipped 2026-07-29 (finops-tier-classifier CronJob, daily report in the admin-ui) — the advisory gate now reads its findings; 3 services have a declared tier today (notification-service T2, product-catalog T0, card-issuance T1-held-at-min:1)"
       # Added by issue #2392: the rule carried `enforced`/`target_enforce_date` but never named the
       # script that produces the finding, so nothing tied the advisory CI step to this deadline.
       ci_producer: "openbank-infra/scripts/check-finops-tiers.py"

--- a/openbank-infra/gitops/components/sca/sca-service.yaml
+++ b/openbank-infra/gitops/components/sca/sca-service.yaml
@@ -28,7 +28,7 @@ spec:
       annotations:
         # Rolls the pods when the OPA bundle changes — subPath mounts do NOT hot-reload.
         # Kept in sync by gen-sca-opa-bundle.sh (do not hand-edit).
-        openbank.tech/policy-checksum: "063fa8c5eead820d"
+        openbank.tech/policy-checksum: "96f7d6249fa79a92"
     spec:
       securityContext:
         runAsNonRoot: true

--- a/openbank-infra/gitops/components/statements/statement-opa-bundle.yaml
+++ b/openbank-infra/gitops/components/statements/statement-opa-bundle.yaml
@@ -9,7 +9,7 @@ metadata:
     app.kubernetes.io/name: statement-service
     app.kubernetes.io/part-of: statements
   annotations:
-    openbank.tech/policy-checksum: "445251103ea59298"
+    openbank.tech/policy-checksum: "48b3f414ae4d0615"
 data:
   rest.rego: |
     # SPDX-License-Identifier: Apache-2.0
@@ -3147,6 +3147,20 @@ data:
       # t0_baseline and need no explicit entry.
       declared:
         openbank-notification-service: T2     # proven pilot, live in sandbox (ADR-0057 best-first target, #228)
+        # ADR-0173 D3 reconciliation (2026-07-29): card-issuance carries a live HTTPScaledObject
+        # with an openbank.io/finops-tier: T1 label and was missing here. Not money-path, so T1
+        # is declarable on the evidence of the live scaled object + classifier-measured idle —
+        # HELD AT min:1 (warm floor) pending a cold-start SLO re-measurement on the current path,
+        # the same hold product-catalog carries below.
+        openbank-card-issuance-service: T1      # live HTTPScaledObject (payments/card-issuance-http), held at min:1 — see ADR-0173 D3
+        # sdd-service and interest-service ALSO carry T1-labeled HTTPScaledObjects (sdd/ and
+        # interest/ namespaces) — but both are money_path_services, so they inherit T0 via
+        # t0_baseline and a T1 label on the deployment is the drift ADR-0173 D3 describes:
+        # demoting either below T0 requires an ADR-0030 threat-model update + 2 approvals, and
+        # neither has happened. Their scaled objects run min:1 (= T0 behaviour today); the label
+        # means nothing until the demotion process runs. NOT declared here on purpose — an
+        # explicit T1 entry would silently demote a money-path service, exactly what
+        # money_path_sacred exists to block (check-finops-tiers.py flags it).
         # openbank-product-catalog was WRONGLY declared T1 here (#2800), citing a
         # non-existent issue (#2083), while only Enabler 2 (HTTPScaledObject) existed —
         # no commit ever added a native build (Enabler 1), so the claimed "native
@@ -3212,7 +3226,7 @@ data:
       gate: finops-tier-drift
       enforced: advisory                      # ADR-0057; -> block when the classifier lands
       target_enforce_date: "2026-09-30"   # ADR-0144
-      blocked_on: "the measured-signal classifier (http_request_rate, kafka_consumer_lag, cpu/replica utilisation) has not shipped yet — only 2 services have a declared tier today (notification-service, product-catalog)"
+      blocked_on: "the measured-signal classifier shipped 2026-07-29 (finops-tier-classifier CronJob, daily report in the admin-ui) — the advisory gate now reads its findings; 3 services have a declared tier today (notification-service T2, product-catalog T0, card-issuance T1-held-at-min:1)"
       # Added by issue #2392: the rule carried `enforced`/`target_enforce_date` but never named the
       # script that produces the finding, so nothing tied the advisory CI step to this deadline.
       ci_producer: "openbank-infra/scripts/check-finops-tiers.py"

--- a/openbank-infra/gitops/components/statements/statement-service.yaml
+++ b/openbank-infra/gitops/components/statements/statement-service.yaml
@@ -26,7 +26,7 @@ spec:
       annotations:
         # Rolls the pod when the OPA bundle changes — subPath mounts do NOT hot-reload.
         # Kept in sync by gen-statement-opa-bundle.sh (do not hand-edit).
-        openbank.tech/policy-checksum: "445251103ea59298"
+        openbank.tech/policy-checksum: "48b3f414ae4d0615"
       labels:
         app.kubernetes.io/name: statement-service
         app.kubernetes.io/part-of: statements

--- a/openbank-infra/gitops/components/tpp-registry/tpp-registry-opa-bundle.yaml
+++ b/openbank-infra/gitops/components/tpp-registry/tpp-registry-opa-bundle.yaml
@@ -9,7 +9,7 @@ metadata:
     app.kubernetes.io/name: tpp-registry-service
     app.kubernetes.io/part-of: tpp-registry
   annotations:
-    openbank.tech/policy-checksum: "d6fb50201013c510"
+    openbank.tech/policy-checksum: "7d8ebf68ff4aa9d9"
 data:
   rest.rego: |
     # SPDX-License-Identifier: Apache-2.0
@@ -3084,6 +3084,20 @@ data:
       # t0_baseline and need no explicit entry.
       declared:
         openbank-notification-service: T2     # proven pilot, live in sandbox (ADR-0057 best-first target, #228)
+        # ADR-0173 D3 reconciliation (2026-07-29): card-issuance carries a live HTTPScaledObject
+        # with an openbank.io/finops-tier: T1 label and was missing here. Not money-path, so T1
+        # is declarable on the evidence of the live scaled object + classifier-measured idle —
+        # HELD AT min:1 (warm floor) pending a cold-start SLO re-measurement on the current path,
+        # the same hold product-catalog carries below.
+        openbank-card-issuance-service: T1      # live HTTPScaledObject (payments/card-issuance-http), held at min:1 — see ADR-0173 D3
+        # sdd-service and interest-service ALSO carry T1-labeled HTTPScaledObjects (sdd/ and
+        # interest/ namespaces) — but both are money_path_services, so they inherit T0 via
+        # t0_baseline and a T1 label on the deployment is the drift ADR-0173 D3 describes:
+        # demoting either below T0 requires an ADR-0030 threat-model update + 2 approvals, and
+        # neither has happened. Their scaled objects run min:1 (= T0 behaviour today); the label
+        # means nothing until the demotion process runs. NOT declared here on purpose — an
+        # explicit T1 entry would silently demote a money-path service, exactly what
+        # money_path_sacred exists to block (check-finops-tiers.py flags it).
         # openbank-product-catalog was WRONGLY declared T1 here (#2800), citing a
         # non-existent issue (#2083), while only Enabler 2 (HTTPScaledObject) existed —
         # no commit ever added a native build (Enabler 1), so the claimed "native
@@ -3149,7 +3163,7 @@ data:
       gate: finops-tier-drift
       enforced: advisory                      # ADR-0057; -> block when the classifier lands
       target_enforce_date: "2026-09-30"   # ADR-0144
-      blocked_on: "the measured-signal classifier (http_request_rate, kafka_consumer_lag, cpu/replica utilisation) has not shipped yet — only 2 services have a declared tier today (notification-service, product-catalog)"
+      blocked_on: "the measured-signal classifier shipped 2026-07-29 (finops-tier-classifier CronJob, daily report in the admin-ui) — the advisory gate now reads its findings; 3 services have a declared tier today (notification-service T2, product-catalog T0, card-issuance T1-held-at-min:1)"
       # Added by issue #2392: the rule carried `enforced`/`target_enforce_date` but never named the
       # script that produces the finding, so nothing tied the advisory CI step to this deadline.
       ci_producer: "openbank-infra/scripts/check-finops-tiers.py"

--- a/openbank-infra/gitops/components/tpp-registry/tpp-registry-service.yaml
+++ b/openbank-infra/gitops/components/tpp-registry/tpp-registry-service.yaml
@@ -23,7 +23,7 @@ spec:
       annotations:
         # Rolls the pod when the OPA bundle changes (subPath mounts do not hot-reload).
         # Kept in sync by gen-tpp-registry-opa-bundle.sh (do not hand-edit).
-        openbank.tech/policy-checksum: "d6fb50201013c510"
+        openbank.tech/policy-checksum: "7d8ebf68ff4aa9d9"
     spec:
       securityContext:
         runAsNonRoot: true

--- a/openbank-libs/governance/rules.yaml
+++ b/openbank-libs/governance/rules.yaml
@@ -1645,6 +1645,20 @@ finops_tiers:
   # t0_baseline and need no explicit entry.
   declared:
     openbank-notification-service: T2     # proven pilot, live in sandbox (ADR-0057 best-first target, #228)
+    # ADR-0173 D3 reconciliation (2026-07-29): card-issuance carries a live HTTPScaledObject
+    # with an openbank.io/finops-tier: T1 label and was missing here. Not money-path, so T1
+    # is declarable on the evidence of the live scaled object + classifier-measured idle —
+    # HELD AT min:1 (warm floor) pending a cold-start SLO re-measurement on the current path,
+    # the same hold product-catalog carries below.
+    openbank-card-issuance-service: T1      # live HTTPScaledObject (payments/card-issuance-http), held at min:1 — see ADR-0173 D3
+    # sdd-service and interest-service ALSO carry T1-labeled HTTPScaledObjects (sdd/ and
+    # interest/ namespaces) — but both are money_path_services, so they inherit T0 via
+    # t0_baseline and a T1 label on the deployment is the drift ADR-0173 D3 describes:
+    # demoting either below T0 requires an ADR-0030 threat-model update + 2 approvals, and
+    # neither has happened. Their scaled objects run min:1 (= T0 behaviour today); the label
+    # means nothing until the demotion process runs. NOT declared here on purpose — an
+    # explicit T1 entry would silently demote a money-path service, exactly what
+    # money_path_sacred exists to block (check-finops-tiers.py flags it).
     # openbank-product-catalog was WRONGLY declared T1 here (#2800), citing a
     # non-existent issue (#2083), while only Enabler 2 (HTTPScaledObject) existed —
     # no commit ever added a native build (Enabler 1), so the claimed "native
@@ -1710,7 +1724,7 @@ finops_tiers:
   gate: finops-tier-drift
   enforced: advisory                      # ADR-0057; -> block when the classifier lands
   target_enforce_date: "2026-09-30"   # ADR-0144
-  blocked_on: "the measured-signal classifier (http_request_rate, kafka_consumer_lag, cpu/replica utilisation) has not shipped yet — only 2 services have a declared tier today (notification-service, product-catalog)"
+  blocked_on: "the measured-signal classifier shipped 2026-07-29 (finops-tier-classifier CronJob, daily report in the admin-ui) — the advisory gate now reads its findings; 3 services have a declared tier today (notification-service T2, product-catalog T0, card-issuance T1-held-at-min:1)"
   # Added by issue #2392: the rule carried `enforced`/`target_enforce_date` but never named the
   # script that produces the finding, so nothing tied the advisory CI step to this deadline.
   ci_producer: "openbank-infra/scripts/check-finops-tiers.py"


### PR DESCRIPTION
## Co a proč

ADR-0173 D3: `rules.yaml: finops_tiers.declared` říkal "only 2 services have a declared tier today", ale 3 další služby nesou live HTTPScaledObjects s T1 labels. A `blocked_on` tvrdil, že classifier "has not shipped yet" — shipped 2026-07-29 (#2701).

## Změny

| služba | rozhodnutí | proč |
|---|---|---|
| `openbank-card-issuance-service` | **declared T1** (held at min:1) | NENÍ money-path → T1 deklarovatelné na evidenci (live HTTPScaledObject + classifier-measured idle) |
| `openbank-sdd-service`, `openbank-interest-service` | **NEDECLAROVÁNY** — inherit T0 via `t0_baseline` | JSOU money-path → T1 label na deploymentu JE ten drift; explicitní T1 entry = silent demotion, přesně co `money_path_sacred` blokuje |
| `blocked_on` text | aktualizován | classifier shipped (CronJob, daily report), advisory gate čte jeho findings |

**Process note**: první draft deklaroval všech 5 T1 — `check-finops-tiers.py` chytil sdd+interest jako money-path demotion bez ADR-0030 threat modelu. Gate funguje.

## Ověření

- `check-finops-tiers.py`: **"OK — no declared-side findings"** (3 declared: notification T2, product-catalog T0, card-issuance T1)
- OPA bundles přegenerovány (rules.yaml restamp, 66 files)

Refs ADR-0173 D3, ADR-0057
