### PR TITLE
docs(infra): mark istio.yaml as the stale template it is (#1914)

### DIFF
--- a/openbank-infra/k8s/base/istio.yaml
+++ b/openbank-infra/k8s/base/istio.yaml
@@ -1,6 +1,18 @@
 # SPDX-License-Identifier: Apache-2.0
 # Copyright (c) OpenBank contributors. Licensed under the Apache License, Version 2.0.
 #
+# STALE TEMPLATE — DO NOT APPLY (tracked in #1914, measured 2026-07-29).
+# This file predates the fleet's per-service namespace layout: it targets a namespace
+# called `openbank` that does not exist (~30 per-service namespaces do), no ArgoCD
+# application references it, and no Istio control plane is installed in the cluster
+# (no istio-system namespace, zero PeerAuthentication objects). Applying it would
+# silently do nothing; treating it as "mTLS is wired" would be a false security claim.
+# The mTLS program is sequenced in issue #1914: capacity first (the default NodePool
+# sits at ~92% of its declared CPU limit), then istiod, a one-namespace pilot, then a
+# per-namespace rollout — with these manifests rewritten against the fleet as it
+# actually is. Until then, east-west traffic is plaintext behind L3/L4 NetworkPolicies,
+# and any threat model claiming mesh mTLS as a mitigating control is aspirational.
+#
 # Istio service mesh wiring for the openbank namespace. Provides:
 #   - mTLS for every east-west call (PeerAuthentication STRICT)
 #   - JWT validation at the mesh edge (RequestAuthentication against Keycloak)


### PR DESCRIPTION
## Co a proč

`openbank-infra/k8s/base/istio.yaml` deklaruje STRICT PeerAuthentication — ale:
- cílí na namespace `openbank`, který **neexistuje** (fleet má ~30 per-service namespaces)
- žádná ArgoCD application ho nereferencuje
- **Istio vůbec není nainstalované** (no istio-system, 0 PeerAuthentication v clusteru — měřeno 2026-07-29)

Aplikovat = tichý no-op. Číst jako "mTLS je wired" = **false security claim** (stejná třída jako #2370's ok-rows-on-dead-evidence).

## Změna

Hlavička souboru nově říká pravdu: STALE TEMPLATE + sekvence programu (#1914: capacity first — default NodePool je na ~92% CPU limitu — istiod, pilot namespace, fleet rollout s rewritten manifests) + interim stav (east-west plaintext za L3/L4 NetworkPolicies, threat modely s "mesh mTLS mitigating control" jsou aspirational).

Full analýza s kapacitní matematikou (sidecar cost, stav nodů) je v issue #1914 comment.

Refs #1914
