### PR TITLE
docs(adr): harden 0219/0220/0222 after independent post-merge review

### DIFF
--- a/docs/adr/0219-platform-contact-policy-gate-contact-classes-durable-counters-suppression.md
+++ b/docs/adr/0219-platform-contact-policy-gate-contact-classes-durable-counters-suppression.md
@@ -64,7 +64,14 @@ rendering personalised promotional content on a customer-initiated surface (ADR-
 a *separate, higher* impression budget (default 1 promotional surface/day), never against the send cap;
 budget exhaustion degrades the surface to default content, never blocks app functionality. (3)
 **SERVICE_EXEMPT** — transactional/security/service content and non-personalised default surfaces:
-never counted, never gated, exactly as ADR-0198 D4 leaves the SECURITY category untouched.
+never counted, never gated, exactly as ADR-0198 D4 leaves the SECURITY category untouched. All
+windows are **rolling** (per-party rolling 7 days for the send cap, rolling 24 hours for the
+impression budget) — never calendar days: a midnight boundary must not reset protection, and the
+semantics are decided here, not rediscovered in code review. Where several campaigns or NBA items are
+simultaneously eligible for one slot or one cap unit, the winner is chosen by a single **deterministic
+arbitration order** — SERVICE_EXEMPT first, then a non-expired standing decision (ADR-0220 D4), then
+NBA-ranked content, then plain campaign steps, ties broken by the item's priority field and id — so
+the tie-break is a reviewed decision, not an accident of iteration order.
 
 **D2 — Counters are cache-backed but log-derived.** Cap and budget counters live in Valkey for
 latency, but every gate decision that results in a counted contact is reflected in the sender's
@@ -72,7 +79,13 @@ outbox-published event (notification send records, ADR-0220's `engagement.events
 detected flush, the gate **rebuilds counters by replaying the trailing cap window of those events
 before reopening** — and fails closed while rebuilding. A silent cache reset can therefore never
 produce a contact burst: the anti-spam control is derivable from the log we already keep, not
-dependent on cache survival.
+dependent on cache survival. Two integrity rules make the rebuild sound: (a) the **rebuild window is
+bounded by topic retention** — the maximum configurable cap window must never exceed the send/
+impression topics' `retention.ms` (a 30-day window over a 7-day topic would rebuild a partial history
+and reopen under-counted, re-creating the burst this section exists to kill); this is asserted by a
+CI check comparing the configured maximum against topic retention, and the gate fails closed on
+violation; (b) replay uses the events' business timestamps (`occurred_at`), never ingestion time, so
+a delayed event cannot escape its true window.
 
 **D3 — A suppression list with reason codes, distinct from consent.** A platform-level do-not-contact
 entry carries `(partyId, scope|topic|ALL, reasonCode, source)` — reason codes: customer opt-out,
@@ -83,11 +96,17 @@ the bank must not contact about a specific topic today.
 
 **D4 — Mandatory call sites, CI-enforced.** The gate is invoked by: notification-service (the ADR-0198
 D4 choke point — its consent call becomes this gate call), campaign journeys (ADR-0200 D2's per-step
-check), finance-coach and any agent-proposed contact (ADR-0203/0214 — an agent's output becomes a
+check), finance-coach and any agent-proposed contact (ADR-0203/0222 — an agent's output becomes a
 customer touch only through this gate), engagement surfaces (ADR-0220), and RM-initiated sends (ADR-0222).
 Adherence is enforced by a **contract test in `openbank-libs`** that fails a service build when a
-marketing-class touch path bypasses the gate — the same governance-as-code style as the fleet's other
-cross-cutting invariants, because gap 1 showed "every sender checks" is a convention, not a control.
+marketing-class touch path bypasses the gate. The detection mechanism is stated explicitly, because a
+text-match guard produces vacuous greens: a **compile-time wiring assertion** — every service that
+declares a marketing-class capability (a notification category, a surface slot, a campaign step type,
+an agent tool that originates contact) must inject the `ContactPolicyGate` port via the shared
+convention plugin, and a detekt/AST rule (not a grep) fails the build when a marketing-class call site
+references the delivery/surface layer without the gate in its call graph. The same governance-as-code
+style as the fleet's other cross-cutting invariants, because gap 1 showed "every sender checks" is a
+convention, not a control.
 
 **D5 — The gate stays a library, not a service.** An in-process component over consent-service (live
 per-call validation, per ADR-0195's rule that a cached consent survives its own revocation) and the

--- a/docs/adr/0220-in-app-engagement-surfaces-gamification-and-pre-approved-offers.md
+++ b/docs/adr/0220-in-app-engagement-surfaces-gamification-and-pre-approved-offers.md
@@ -55,9 +55,16 @@ contact-policy gate.
 the customer edge; resolution runs ContactPolicyGate (ADR-0219 — `MARKETING_COMMS_INAPP` consent plus
 the PROMOTIONAL_IMPRESSION budget) → deterministic eligibility → ADR-0201 NBA ranking → a **typed
 payload** (`banner | card | story | carousel | offer`) whose content references the ADR-0176-style
-catalogue, never free-form markup. The KMP client owns theme, accessibility (ADR-0149) and motion.
-Service outage or gate timeout ⇒ the app renders bundled default content (SERVICE_EXEMPT) —
-engagement never blocks banking.
+catalogue, never free-form markup. **Eligibility is pre-computed, not queried per render**: an
+eligibility snapshot per party (product holdings, adverse-state flags, segment membership) is
+materialised event-driven into the service's own store (Valkey/Postgres) from the same domain events
+that feed the ADR-0210 silver layer — ClickHouse is used for backfill, audit and the ADR-0221 funnel,
+never for a point query on the app-open hot path. **Adverse-state changes invalidate near-real-time**:
+fraud-hold, arrears, dispute-opened and erasure events evict the party's snapshot immediately (the
+same event-driven invalidation ADR-0219 uses for consent), because a vulnerable-customer exclusion
+that lags by a snapshot interval is a compliance defect, not a freshness metric. The KMP client owns
+theme, accessibility (ADR-0149) and motion. Service outage or gate timeout ⇒ the app renders bundled
+default content (SERVICE_EXEMPT) — engagement never blocks banking.
 
 **D2 — The feedback loop is the product.** The app posts `impression | click | dismiss | conversion`
 to the service, which publishes `engagement.events` via outbox. This stream feeds the analytics
@@ -81,7 +88,9 @@ domain rules, not stated as content policy:
 5. **Vulnerable customers are excluded from targeting** (arrears/collections contact, an open
    dispute, a fraud hold — the ADR-0200 D6 adverse-state set): excluded from challenge *targeting*
    and promotional surfaces at the eligibility stage, while remaining free to use the hub on their
-   own initiative.
+   own initiative. The exclusion reads the D1 eligibility snapshot with its near-real-time
+   invalidation — an adverse-state change takes effect at event speed, not at the next materialisation
+   interval.
 
 **D4 — Pre-approved offers are standing decisions, rendered — never invented, never ranked.** A
 scheduled batch asks ADR-0142's engine for standing decisions per eligible party (amount, price,

--- a/docs/adr/0222-offer-explanation-and-relationship-manager-agents.md
+++ b/docs/adr/0222-offer-explanation-and-relationship-manager-agents.md
@@ -57,7 +57,10 @@ ADR-0198 revocation paths). Hard invariants: the tool answers **only** from the 
 "I can't verify that, here's how to reach a human"); it never quotes amounts, rates or terms beyond
 what the record carries; it never collects data beyond the session. An `ml-systems.yaml` entry is
 generated in the same PR (ADR-0203 D7's registry rule), with the ADR-0201 Art. 22 analysis carried
-as its basis.
+as its basis — and the ADR-0148 evals gate gains a **named eval suite for the no-re-derivation
+invariant** (adversarial prompts asking for terms, amounts or reasons absent from the record must
+produce the no-record fallback, never a completion), because this tool's entire safety case is that
+single behaviour and a generic gate does not prove it.
 
 **D2 — `rm-copilot` as a new business-plane agent.** Read-only over the ADR-0210 360 query,
 interaction history and open cases; per client or per meeting it produces a briefing (holdings,
@@ -66,7 +69,12 @@ what the targeting engine already respects) and drafts follow-up communications.
 **only** through ADR-0176's operator-initiated path — template catalogue, four-eyes where required,
 and the ADR-0219 gate on send — never from a personal mail client or a new send capability in the
 agent. `requires_human: every output`; no write/execute tools; charter under `docs/agents/` with
-id-parity per the charter-registry gate.
+id-parity per the charter-registry gate. On cost, stated plainly rather than inherited silently:
+ADR-0203 flags that the model gateway is not yet deployed and per-agent token accounting does not
+exist — `rm-copilot` therefore ships **after** the gateway (ADR-0203 D8's gate, restated), and its
+deployment shape is decided at implementation time against the measured marginal cost of a new
+agent service versus colocating on an existing business-plane deployment; the charter, tools and
+constraints in this ADR are invariant under either shape.
 
 **D3 — Neither agent relaxes a boundary.** The explanation tool changes nothing about what may be
 decided (ADR-0201 D5) or shown (ADR-0220 D4); the RM agent changes nothing about how customers are


### PR DESCRIPTION
## Summary

Amends the freshly-merged ADR-0219/0220/0222 with the findings of an independent post-merge architecture review. No scope change — the amendments close three underspecified mechanisms the review flagged as critical (counter-rebuild retention bound, gate-detection mechanism, hot-path eligibility) and five smaller gaps.

## Type of change

- [x] docs

## Linked issues

N/A — hardening amendments to ADR-0219/0220/0222 (merged as #2714), driven by the post-merge review recorded below.

## Changes

- **ADR-0219 D1** — windows are rolling (7d send cap / 24h impression budget), never calendar-day; deterministic cross-campaign/cross-surface arbitration order decided (service-exempt → standing decision → NBA-ranked → campaign steps, priority+id tie-break) instead of an unreviewed code tie-break.
- **ADR-0219 D2** — the rebuild window is CI-asserted against topic `retention.ms` (a >retention cap window would rebuild partial history and reopen under-counted — the exact burst D2 exists to kill); replay uses business timestamps, not ingestion time.
- **ADR-0219 D4** — the bypass-detection mechanism is specified: compile-time wiring assertion via the convention plugin + a detekt/AST rule (explicitly *not* a text-match guard, which produces vacuous greens).
- **ADR-0220 D1** — eligibility is pre-computed into an event-driven per-party snapshot (Valkey/Postgres); ClickHouse serves backfill/audit/funnel only, never point queries on the app-open hot path. Adverse-state events (fraud hold, arrears, dispute, erasure) invalidate the snapshot near-real-time — the vulnerable-customer exclusion now works at event speed.
- **ADR-0222 D1** — a named adversarial eval suite for `explain_offer`'s no-re-derivation invariant (prompts requesting absent terms/reasons must yield the human fallback), registered with the ADR-0148 evals gate.
- **ADR-0222 D2** — rm-copilot's token cost and deployment shape stated against ADR-0203's unpriced-gateway concern (ships after the gateway; shape decided on measured marginal cost) instead of silently inherited.

## Definition of Done

- [x] Docs updated (README, ADR if architectural). — this PR is the docs change
- [x] `./gradlew detekt ktlintCheck koverVerify build` passes. — N/A: docs/adr only

## Security checklist

- [x] No secrets, tokens, passwords, or PII in code, config, tests, logs.

## Compliance impact

- [x] GDPR — the adverse-state invalidation is a compliance-grade freshness requirement for the vulnerable-customer exclusion; the retention-bound rebuild keeps the anti-spam control actually demonstrable.

## Rollout / Rollback

- Deployment strategy: N/A (docs only)
- Rollback plan: revert the merge commit
- Data migration reversible: N/A

## Reviewer notes

Review verdicts before these amendments: 0221 SOUND; 0219/0220/0222 SOUND-WITH-GAPS. Strong points the review confirmed (kept unchanged): event-sourced counters as the compliance-correct pattern, extension-not-new-agent for explain_offer, refusing to fake pre-approved offers before ADR-0142 exists. Remaining follow-ups deliberately not in this PR: experimentation holdout methodology, real-time event-triggered moments, bandit-based variant selection, cost-per-touch accounting — candidates for future ADRs once the base capability ships.