### PR TITLE
fix(notification): disable eager OIDC token acquisition in the test profile

### DIFF
--- a/openbank-notification-service/src/main/resources/application.yaml
+++ b/openbank-notification-service/src/main/resources/application.yaml
@@ -200,6 +200,13 @@ authz:
       enabled: false
     oidc:
       enabled: false
+    # No eager token fetch at test boot: the ADR-0198 D4 consent gate's M2M client
+    # (oidc-client, client_credentials) otherwise creates OidcClientImpl eagerly at
+    # startup and fails the boot with "OIDC Server is not available" on the CI
+    # runners, which have no Keycloak on localhost:8080. Lazy acquisition matches
+    # account-service's M2M clients in tests.
+    oidc-client:
+      early-tokens-acquisition: false
     mailer:
       mock: true
     # Disable the @Scheduled outbox tick under test so the consumer IT never races


### PR DESCRIPTION
## Problém (způsobeno mojí A9 změnou)

Consent gate (#2660/#2692) přidal `quarkus.oidc-client` (client_credentials) do notification-service. Default `early-tokens-acquisition: true` → app fetchuje tokeny **při bootu** → CI test booty failují `Failed to create OidcClientImpl — OIDC Server is not available` (na ARC runneru není Keycloak na localhost:8080). Blokuje #2700 (quarkus bump) build na notification-service.

## Fix

`quarkus.oidc-client.early-tokens-acquisition: false` v `%test` profilu — lazy acquisition. Stejný pattern používají agent-service testy (`"quarkus.oidc-client.early-tokens-acquisition" to "false"` v getConfigOverrides). account-service má identickou oidc-client konfiguraci a jeho test booty prochází toutéž cestou.

## Ověření

`:openbank-notification-service:test` — full suite BUILD SUCCESSFUL s tímto profilem.
