### PR TITLE
feat(libs): origination state machine + credit policy evaluator primitives (ADR-0211/0213)

### DIFF
--- a/openbank-libs-domain/src/main/kotlin/com/openbank/libs/decision/PolicyDecision.kt
+++ b/openbank-libs-domain/src/main/kotlin/com/openbank/libs/decision/PolicyDecision.kt
@@ -1,0 +1,42 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright (c) OpenBank contributors. Licensed under the Apache License, Version 2.0.
+// See LICENSE in the repository root or https://www.apache.org/licenses/LICENSE-2.0 for details.
+
+package com.openbank.libs.decision
+
+/** Machine-readable reason codes — the adverse-action contract (ADR-0213 D1/D2, ADR-0142). */
+enum class PolicyReasonCode {
+    INPUT_MISSING,
+    RULE_NOT_EVALUABLE,
+    POLICY_TABLE_MISSING,
+    EXCLUSION_MATCHED,
+    ELIGIBILITY_FAILED,
+    AFFORDABILITY_FAILED,
+    PRICING_BAND_UNMATCHED,
+}
+
+/** A single machine-readable reason; [ruleId] links it to the exact rule that fired. */
+data class DecisionReason(val code: PolicyReasonCode, val ruleId: String? = null, val detail: String = "")
+
+/** The evidentiary metadata of one evaluation (ADR-0214): versions, matched rules, input hash. */
+data class PolicyEvaluation(
+    val policyVersions: Map<PolicyTableKind, Int>,
+    val matchedRuleIds: List<String>,
+    val reasons: List<DecisionReason>,
+    val inputSnapshotHash: String,
+)
+
+/**
+ * The decision output contract (ADR-0213 D1): never a bare score — always an outcome
+ * plus reasons, matched rule ids, policy versions and the input snapshot hash, so a
+ * historic decision replays deterministically against its pinned policy.
+ */
+sealed interface PolicyDecision {
+    val evaluation: PolicyEvaluation
+
+    data class Approve(val priceBand: String, override val evaluation: PolicyEvaluation) : PolicyDecision
+
+    data class Refer(override val evaluation: PolicyEvaluation) : PolicyDecision
+
+    data class Decline(override val evaluation: PolicyEvaluation) : PolicyDecision
+}

--- a/openbank-libs-domain/src/main/kotlin/com/openbank/libs/decision/PolicyEvaluator.kt
+++ b/openbank-libs-domain/src/main/kotlin/com/openbank/libs/decision/PolicyEvaluator.kt
@@ -1,0 +1,180 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright (c) OpenBank contributors. Licensed under the Apache License, Version 2.0.
+// See LICENSE in the repository root or https://www.apache.org/licenses/LICENSE-2.0 for details.
+
+package com.openbank.libs.decision
+
+import java.security.MessageDigest
+import java.time.LocalDate
+
+/** The application as the evaluator sees it: typed facts plus the decision date. */
+data class PolicyApplication(val attributes: Map<PolicyAttribute, PolicyValue>, val asOf: LocalDate)
+
+/**
+ * Pure, deterministic credit policy evaluator (ADR-0213). Zero framework imports,
+ * zero I/O — policy tables arrive compiled in memory (ADR-0218 D3) and evaluation is
+ * O(rules). Table order is fixed: EXCLUSION (first match declines) → ELIGIBILITY and
+ * AFFORDABILITY (all rules must pass) → PRICING_BAND (first matching band, never
+ * flips a decline). Everything fail-closed: a missing input, an unevaluable rule or
+ * a missing/expired table yields REFER — the only path to APPROVE is every hard rule
+ * evaluated and passed.
+ */
+object PolicyEvaluator {
+
+    fun evaluate(application: PolicyApplication, bundle: PolicyBundle): PolicyDecision {
+        val hash = inputSnapshotHash(application.attributes)
+        val matched = mutableListOf<String>()
+        val versions = mutableMapOf<PolicyTableKind, Int>()
+        var band: String? = null
+
+        for (kind in PolicyTableKind.entries) {
+            val table = bundle.active(kind, application.asOf)
+                ?: return refer(
+                    versions,
+                    matched,
+                    hash,
+                    DecisionReason(PolicyReasonCode.POLICY_TABLE_MISSING, detail = kind.name),
+                )
+            versions[kind] = table.version
+            when (val outcome = evaluateTable(kind, table, application, matched)) {
+                is TableOutcome.Referred -> return refer(versions, matched, hash, outcome.reason)
+                is TableOutcome.Declined ->
+                    return PolicyDecision.Decline(
+                        PolicyEvaluation(versions.toMap(), matched.toList(), outcome.reasons, hash),
+                    )
+                is TableOutcome.Passed -> if (outcome.band != null) band = outcome.band
+            }
+        }
+
+        return band?.let {
+            PolicyDecision.Approve(
+                priceBand = it,
+                evaluation = PolicyEvaluation(versions.toMap(), matched.toList(), emptyList(), hash),
+            )
+        } ?: refer(versions, matched, hash, DecisionReason(PolicyReasonCode.PRICING_BAND_UNMATCHED))
+    }
+
+    /** Deterministic SHA-256 over the canonical attribute rendering (ADR-0214 D2). */
+    fun inputSnapshotHash(attributes: Map<PolicyAttribute, PolicyValue>): String {
+        val canonical = attributes.entries
+            .sortedBy { it.key.name }
+            .joinToString("|") { "${it.key.name}=${it.value.render()}" }
+        return MessageDigest.getInstance("SHA-256")
+            .digest(canonical.toByteArray(Charsets.UTF_8))
+            .joinToString("") { "%02x".format(it) }
+    }
+
+    private sealed interface TableOutcome {
+        data class Passed(val band: String? = null) : TableOutcome
+
+        data class Referred(val reason: DecisionReason) : TableOutcome
+
+        data class Declined(val reasons: List<DecisionReason>) : TableOutcome
+    }
+
+    private fun evaluateTable(
+        kind: PolicyTableKind,
+        table: PolicyTable,
+        application: PolicyApplication,
+        matched: MutableList<String>,
+    ): TableOutcome {
+        val failures = mutableListOf<DecisionReason>()
+        for (rule in table.rules) {
+            when (val outcome = evaluateRule(rule, application.attributes[rule.attribute])) {
+                is RuleOutcome.NotEvaluable -> return TableOutcome.Referred(outcome.reason)
+                is RuleOutcome.Matched -> {
+                    matched += rule.id
+                    when (kind) {
+                        PolicyTableKind.EXCLUSION ->
+                            return TableOutcome.Declined(
+                                listOf(DecisionReason(PolicyReasonCode.EXCLUSION_MATCHED, rule.id, rule.detail)),
+                            )
+                        PolicyTableKind.PRICING_BAND -> return TableOutcome.Passed(band = rule.band)
+                        else -> Unit
+                    }
+                }
+                is RuleOutcome.NotMatched ->
+                    if (kind == PolicyTableKind.ELIGIBILITY || kind == PolicyTableKind.AFFORDABILITY) {
+                        failures += DecisionReason(
+                            if (kind == PolicyTableKind.ELIGIBILITY) {
+                                PolicyReasonCode.ELIGIBILITY_FAILED
+                            } else {
+                                PolicyReasonCode.AFFORDABILITY_FAILED
+                            },
+                            rule.id,
+                            rule.detail,
+                        )
+                    }
+            }
+        }
+        return if (failures.isNotEmpty()) TableOutcome.Declined(failures) else TableOutcome.Passed()
+    }
+
+    private sealed interface RuleOutcome {
+        data object Matched : RuleOutcome
+
+        data object NotMatched : RuleOutcome
+
+        data class NotEvaluable(val reason: DecisionReason) : RuleOutcome
+    }
+
+    private fun evaluateRule(rule: PolicyRule, value: PolicyValue?): RuleOutcome {
+        if (value == null) {
+            return RuleOutcome.NotEvaluable(
+                DecisionReason(PolicyReasonCode.INPUT_MISSING, rule.id, rule.attribute.name),
+            )
+        }
+        return when (rule.operator) {
+            PolicyOperator.IN, PolicyOperator.NOT_IN -> evaluateMembership(rule, value)
+            else -> evaluateComparison(rule, value)
+        }
+    }
+
+    private fun evaluateMembership(rule: PolicyRule, value: PolicyValue): RuleOutcome {
+        if (value !is PolicyValue.Text || rule.values.isEmpty()) return notEvaluable(rule)
+        val member = rule.values.any { it.equals(value.value, ignoreCase = true) }
+        val matched = if (rule.operator == PolicyOperator.IN) member else !member
+        return if (matched) RuleOutcome.Matched else RuleOutcome.NotMatched
+    }
+
+    private fun evaluateComparison(rule: PolicyRule, value: PolicyValue): RuleOutcome = when (value) {
+        is PolicyValue.Numeric -> evaluateNumeric(rule, value.value)
+        is PolicyValue.Text -> evaluateText(rule, value.value)
+    }
+
+    private fun evaluateNumeric(rule: PolicyRule, actual: java.math.BigDecimal): RuleOutcome {
+        val threshold = rule.threshold ?: return notEvaluable(rule)
+        val matched = when (rule.operator) {
+            PolicyOperator.GT -> actual > threshold
+            PolicyOperator.GTE -> actual >= threshold
+            PolicyOperator.LT -> actual < threshold
+            PolicyOperator.LTE -> actual <= threshold
+            PolicyOperator.EQ -> actual.compareTo(threshold) == 0
+            PolicyOperator.NEQ -> actual.compareTo(threshold) != 0
+            else -> return notEvaluable(rule)
+        }
+        return if (matched) RuleOutcome.Matched else RuleOutcome.NotMatched
+    }
+
+    private fun evaluateText(rule: PolicyRule, actual: String): RuleOutcome {
+        val expected = rule.values.singleOrNull() ?: return notEvaluable(rule)
+        val equal = actual.equals(expected, ignoreCase = true)
+        val matched = when (rule.operator) {
+            PolicyOperator.EQ -> equal
+            PolicyOperator.NEQ -> !equal
+            else -> return notEvaluable(rule)
+        }
+        return if (matched) RuleOutcome.Matched else RuleOutcome.NotMatched
+    }
+
+    private fun notEvaluable(rule: PolicyRule): RuleOutcome.NotEvaluable =
+        RuleOutcome.NotEvaluable(DecisionReason(PolicyReasonCode.RULE_NOT_EVALUABLE, rule.id, rule.attribute.name))
+
+    private fun refer(
+        versions: Map<PolicyTableKind, Int>,
+        matched: List<String>,
+        hash: String,
+        reason: DecisionReason,
+    ): PolicyDecision.Refer =
+        PolicyDecision.Refer(PolicyEvaluation(versions.toMap(), matched.toList(), listOf(reason), hash))
+}

--- a/openbank-libs-domain/src/main/kotlin/com/openbank/libs/decision/PolicyTable.kt
+++ b/openbank-libs-domain/src/main/kotlin/com/openbank/libs/decision/PolicyTable.kt
@@ -1,0 +1,48 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright (c) OpenBank contributors. Licensed under the Apache License, Version 2.0.
+// See LICENSE in the repository root or https://www.apache.org/licenses/LICENSE-2.0 for details.
+
+package com.openbank.libs.decision
+
+import java.math.BigDecimal
+import java.time.LocalDate
+
+/** Table kinds evaluated in this fixed order (ADR-0213 D2). */
+enum class PolicyTableKind { EXCLUSION, ELIGIBILITY, AFFORDABILITY, PRICING_BAND }
+
+/**
+ * One versioned, effective-dated rule inside a [PolicyTable]. Numeric operators use
+ * [threshold]; text operators use [values]. In a PRICING_BAND table a matching rule
+ * must carry [band] — the assigned price band, never a decline/approve flip.
+ */
+data class PolicyRule(
+    val id: String,
+    val attribute: PolicyAttribute,
+    val operator: PolicyOperator,
+    val threshold: BigDecimal? = null,
+    val values: Set<String> = emptySet(),
+    val band: String? = null,
+    val detail: String = "",
+)
+
+/**
+ * A versioned, effective-dated decision table. Activation is four-eyes and recorded
+ * (ADR-0213 D4); the service pins [version] on every evaluation it persists.
+ */
+data class PolicyTable(
+    val kind: PolicyTableKind,
+    val name: String,
+    val version: Int,
+    val effectiveFrom: LocalDate,
+    val rules: List<PolicyRule>,
+    val effectiveTo: LocalDate? = null,
+) {
+    fun isActive(asOf: LocalDate): Boolean =
+        !asOf.isBefore(effectiveFrom) && (effectiveTo == null || asOf.isBefore(effectiveTo))
+}
+
+/** The full policy set evaluated as one unit; every table kind must resolve to an active table. */
+data class PolicyBundle(val tables: List<PolicyTable>) {
+    fun active(kind: PolicyTableKind, asOf: LocalDate): PolicyTable? =
+        tables.filter { it.kind == kind && it.isActive(asOf) }.maxByOrNull { it.version }
+}

--- a/openbank-libs-domain/src/main/kotlin/com/openbank/libs/decision/PolicyVocabulary.kt
+++ b/openbank-libs-domain/src/main/kotlin/com/openbank/libs/decision/PolicyVocabulary.kt
@@ -1,0 +1,46 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright (c) OpenBank contributors. Licensed under the Apache License, Version 2.0.
+// See LICENSE in the repository root or https://www.apache.org/licenses/LICENSE-2.0 for details.
+
+package com.openbank.libs.decision
+
+import java.math.BigDecimal
+
+/**
+ * Closed attribute vocabulary for credit policy rules (ADR-0213 D1). Deliberately
+ * finite — a policy that needs an attribute not listed here extends the vocabulary in
+ * code (a reviewed change), it does not smuggle it in as free text. Bureau and
+ * external scoring inputs arrive only via the ADR-0028 D4 port; their absence makes
+ * the dependent rule fail closed to REFER, never to APPROVE.
+ */
+enum class PolicyAttribute {
+    VERIFIED_INCOME_MONTHLY,
+    EXISTING_DEBT_SERVICE_MONTHLY,
+    DTI,
+    DSTI,
+    AGE_YEARS,
+    EMPLOYMENT_TENURE_MONTHS,
+    REQUESTED_AMOUNT,
+    TERM_MONTHS,
+    BUREAU_SCORE_BAND,
+    RESIDENCY,
+    CUSTOMER_TYPE,
+    PRODUCT_TYPE,
+    JURISDICTION,
+    CHANNEL,
+}
+
+/** Closed operator vocabulary (ADR-0138 comparison set + set membership). */
+enum class PolicyOperator { GT, GTE, LT, LTE, EQ, NEQ, IN, NOT_IN }
+
+/** A typed input fact supplied by the caller; the evaluator persists nothing. */
+sealed interface PolicyValue {
+    data class Numeric(val value: BigDecimal) : PolicyValue
+
+    data class Text(val value: String) : PolicyValue
+
+    fun render(): String = when (this) {
+        is Numeric -> value.stripTrailingZeros().toPlainString()
+        is Text -> value
+    }
+}

--- a/openbank-libs-domain/src/main/kotlin/com/openbank/libs/lending/origination/LegacyOriginationMigration.kt
+++ b/openbank-libs-domain/src/main/kotlin/com/openbank/libs/lending/origination/LegacyOriginationMigration.kt
@@ -1,0 +1,30 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright (c) OpenBank contributors. Licensed under the Apache License, Version 2.0.
+// See LICENSE in the repository root or https://www.apache.org/licenses/LICENSE-2.0 for details.
+
+package com.openbank.libs.lending.origination
+
+/**
+ * Pure mapping of the pre-ADR-0211 `ApplicationStatus` rows (`PROPOSED / APPROVED /
+ * REJECTED / DISBURSED`, lending-service v0.11.5) onto the canonical origination
+ * graph — the ADR-0211 D7 cutover table as a pure, testable function. The service
+ * runs it inside a Flyway data migration; `null` means "no lawful mapping — migrate
+ * manually", so a corrupt legacy row fails the migration loudly instead of guessing.
+ */
+object LegacyOriginationMigration {
+
+    /**
+     * @param legacyStatus the pre-ADR-0211 status string as persisted
+     * @param wasSubmitted whether the legacy row carries a submission timestamp
+     *        (distinguishes PROPOSED → DRAFT from PROPOSED → SUBMITTED per D7)
+     */
+    fun mapLegacyStatus(legacyStatus: String, wasSubmitted: Boolean): OriginationState? = when (legacyStatus) {
+        "PROPOSED" -> if (wasSubmitted) OriginationState.SUBMITTED else OriginationState.DRAFT
+        "APPROVED" -> OriginationState.OFFERED
+        "REJECTED" -> OriginationState.DECLINED
+        "DISBURSED" -> OriginationState.DISBURSED
+        else -> null
+    }
+
+    val MAPPABLE_LEGACY_STATUSES: Set<String> = setOf("PROPOSED", "APPROVED", "REJECTED", "DISBURSED")
+}

--- a/openbank-libs-domain/src/main/kotlin/com/openbank/libs/lending/origination/OriginationState.kt
+++ b/openbank-libs-domain/src/main/kotlin/com/openbank/libs/lending/origination/OriginationState.kt
@@ -1,0 +1,48 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright (c) OpenBank contributors. Licensed under the Apache License, Version 2.0.
+// See LICENSE in the repository root or https://www.apache.org/licenses/LICENSE-2.0 for details.
+
+package com.openbank.libs.lending.origination
+
+/**
+ * Canonical loan-origination lifecycle states (ADR-0211 D1).
+ *
+ * The transition *graph* over these states is fixed in code and identical for every
+ * jurisdiction; a jurisdiction compliance pack (ADR-0212) may only mark optional
+ * states as mandatory (e.g. [REFLECTION_PERIOD] for products whose national law
+ * grants a pre-contractual reflection wait). The statutory CCD2 withdrawal window
+ * is deliberately NOT a state here: it runs post-disbursement as an exit path on the
+ * live loan (ADR-0215), not as an origination gate.
+ */
+enum class OriginationState {
+    DRAFT,
+    SUBMITTED,
+    KYC_PENDING,
+    DOCS_REQUIRED,
+    ASSESSMENT,
+    DECISION_PENDING,
+    FOUR_EYES,
+    OFFERED,
+    AWAITING_SIGNATURE,
+    SIGNED,
+    REFLECTION_PERIOD,
+    READY_TO_DISBURSE,
+    DISBURSED,
+
+    /** Customer abandoned the application before disbursement. */
+    WITHDRAWN,
+
+    /** Decision engine or four-eyes declined the application. */
+    DECLINED,
+
+    /** Offer / document / KYC validity elapsed (time-driven). */
+    EXPIRED,
+    ;
+
+    val isTerminal: Boolean
+        get() = this in TERMINAL
+
+    companion object {
+        val TERMINAL: Set<OriginationState> = setOf(DISBURSED, WITHDRAWN, DECLINED, EXPIRED)
+    }
+}

--- a/openbank-libs-domain/src/main/kotlin/com/openbank/libs/lending/origination/OriginationStateMachine.kt
+++ b/openbank-libs-domain/src/main/kotlin/com/openbank/libs/lending/origination/OriginationStateMachine.kt
@@ -1,0 +1,86 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright (c) OpenBank contributors. Licensed under the Apache License, Version 2.0.
+// See LICENSE in the repository root or https://www.apache.org/licenses/LICENSE-2.0 for details.
+
+package com.openbank.libs.lending.origination
+
+import java.time.Instant
+
+/** Who commands a transition — machine transitions carry [SYSTEM], human ones [HUMAN] (ADR-0211 D3). */
+enum class OriginationActorKind { HUMAN, SYSTEM }
+
+/** A requested origination transition with its evidentiary payload (ADR-0214). */
+data class OriginationTransition(
+    val applicationId: String,
+    val from: OriginationState,
+    val to: OriginationState,
+    val actor: String,
+    val actorKind: OriginationActorKind,
+    val reason: String,
+    val occurredAt: Instant,
+    val packVersion: String? = null,
+    val metadata: Map<String, String> = emptyMap(),
+)
+
+/** Result of applying a transition through the state machine. */
+sealed interface OriginationTransitionResult {
+    data class Applied(val newState: OriginationState) : OriginationTransitionResult
+
+    data class Rejected(val reason: String) : OriginationTransitionResult
+}
+
+/**
+ * Pure transition engine for loan origination (ADR-0211 D1/D3). Deterministic: the
+ * outcome depends only on the policy and the transition. Persistence, Temporal wiring
+ * and audit emission are the service's concern; this machine only decides whether a
+ * commanded transition is lawful.
+ *
+ * Guards enforced here (before policy-level [OriginationGuard] hooks): non-blank actor
+ * and reason, no transitions out of terminal states, and system actors never taking
+ * human-only edges (four-eyes approval/decline, signature).
+ */
+class OriginationStateMachine(
+    private val policy: OriginationTransitionPolicy = OriginationTransitionPolicy.standard(),
+) {
+    fun guard(transition: OriginationTransition): OriginationTransitionResult {
+        if (transition.from.isTerminal) {
+            return OriginationTransitionResult.Rejected(
+                "State ${transition.from} is terminal — no outgoing transitions",
+            )
+        }
+        if (!policy.isAllowed(transition.from, transition.to)) {
+            return OriginationTransitionResult.Rejected(
+                "Transition from ${transition.from} to ${transition.to} is not allowed",
+            )
+        }
+        if (transition.actor.isBlank()) {
+            return OriginationTransitionResult.Rejected("Actor must not be blank")
+        }
+        if (transition.reason.isBlank()) {
+            return OriginationTransitionResult.Rejected("Reason must not be blank")
+        }
+        if (transition.actorKind == OriginationActorKind.SYSTEM && transition.to in HUMAN_ONLY_TARGETS) {
+            return OriginationTransitionResult.Rejected(
+                "Transition to ${transition.to} requires a human actor (four-eyes / signature)",
+            )
+        }
+        val failure = policy.guardsFor(OriginationTransitionKey(transition.from, transition.to))
+            .asSequence()
+            .mapNotNull { it.evaluate(transition) }
+            .firstOrNull()
+        return if (failure == null) {
+            OriginationTransitionResult.Applied(transition.to)
+        } else {
+            OriginationTransitionResult.Rejected(failure.reason)
+        }
+    }
+
+    fun apply(transition: OriginationTransition): OriginationTransitionResult = guard(transition)
+
+    companion object {
+        private val HUMAN_ONLY_TARGETS: Set<OriginationState> = setOf(
+            OriginationState.OFFERED,
+            OriginationState.SIGNED,
+        )
+    }
+}

--- a/openbank-libs-domain/src/main/kotlin/com/openbank/libs/lending/origination/OriginationTransitionPolicy.kt
+++ b/openbank-libs-domain/src/main/kotlin/com/openbank/libs/lending/origination/OriginationTransitionPolicy.kt
@@ -1,0 +1,79 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright (c) OpenBank contributors. Licensed under the Apache License, Version 2.0.
+// See LICENSE in the repository root or https://www.apache.org/licenses/LICENSE-2.0 for details.
+
+package com.openbank.libs.lending.origination
+
+import com.openbank.libs.lending.origination.OriginationState.ASSESSMENT
+import com.openbank.libs.lending.origination.OriginationState.AWAITING_SIGNATURE
+import com.openbank.libs.lending.origination.OriginationState.DECISION_PENDING
+import com.openbank.libs.lending.origination.OriginationState.DECLINED
+import com.openbank.libs.lending.origination.OriginationState.DISBURSED
+import com.openbank.libs.lending.origination.OriginationState.DOCS_REQUIRED
+import com.openbank.libs.lending.origination.OriginationState.DRAFT
+import com.openbank.libs.lending.origination.OriginationState.EXPIRED
+import com.openbank.libs.lending.origination.OriginationState.FOUR_EYES
+import com.openbank.libs.lending.origination.OriginationState.KYC_PENDING
+import com.openbank.libs.lending.origination.OriginationState.OFFERED
+import com.openbank.libs.lending.origination.OriginationState.READY_TO_DISBURSE
+import com.openbank.libs.lending.origination.OriginationState.REFLECTION_PERIOD
+import com.openbank.libs.lending.origination.OriginationState.SIGNED
+import com.openbank.libs.lending.origination.OriginationState.SUBMITTED
+import com.openbank.libs.lending.origination.OriginationState.WITHDRAWN
+
+/**
+ * Explicit, deterministic transition policy for loan origination (ADR-0211 D1), in the
+ * ADR-0045 [com.openbank.libs.domain.case.CaseTransitionPolicy] pattern: the allowed
+ * targets are data, validation is a pure function, and service-level concerns (maker !=
+ * checker, pack-mandated waits) attach as [OriginationGuard] hooks keyed by transition.
+ *
+ * The graph is fixed in code for every jurisdiction — a compliance pack (ADR-0212)
+ * parameterises *which optional states are mandatory* and *how long waits last*, never
+ * the shape of the graph itself.
+ */
+data class OriginationTransitionPolicy(
+    val allowedTransitions: Map<OriginationState, Set<OriginationState>>,
+    val guards: Map<OriginationTransitionKey, List<OriginationGuard>> = emptyMap(),
+) {
+    fun isAllowed(from: OriginationState, to: OriginationState): Boolean =
+        allowedTransitions[from].orEmpty().contains(to)
+
+    fun allowedTargets(from: OriginationState): Set<OriginationState> = allowedTransitions[from].orEmpty()
+
+    fun guardsFor(key: OriginationTransitionKey): List<OriginationGuard> = guards[key].orEmpty()
+
+    companion object {
+        /**
+         * The canonical origination graph (ADR-0211 D1). Terminal states have no
+         * outgoing transitions. [REFLECTION_PERIOD] is reachable but skippable — the
+         * pinned pack decides, per application, which edge is taken.
+         */
+        fun standard(): OriginationTransitionPolicy = OriginationTransitionPolicy(
+            allowedTransitions = mapOf(
+                DRAFT to setOf(SUBMITTED, WITHDRAWN),
+                SUBMITTED to setOf(KYC_PENDING, WITHDRAWN, EXPIRED),
+                KYC_PENDING to setOf(DOCS_REQUIRED, ASSESSMENT, WITHDRAWN, EXPIRED),
+                DOCS_REQUIRED to setOf(ASSESSMENT, WITHDRAWN, EXPIRED),
+                ASSESSMENT to setOf(DECISION_PENDING, DOCS_REQUIRED, WITHDRAWN, EXPIRED),
+                DECISION_PENDING to setOf(FOUR_EYES, DECLINED, WITHDRAWN, EXPIRED),
+                FOUR_EYES to setOf(OFFERED, DECLINED, WITHDRAWN, EXPIRED),
+                OFFERED to setOf(AWAITING_SIGNATURE, WITHDRAWN, EXPIRED),
+                AWAITING_SIGNATURE to setOf(SIGNED, WITHDRAWN, EXPIRED),
+                SIGNED to setOf(REFLECTION_PERIOD, READY_TO_DISBURSE, EXPIRED),
+                REFLECTION_PERIOD to setOf(READY_TO_DISBURSE, EXPIRED),
+                READY_TO_DISBURSE to setOf(DISBURSED, EXPIRED),
+            ),
+        )
+    }
+}
+
+/** Stable key used to attach policy guards to a specific origination transition. */
+data class OriginationTransitionKey(val from: OriginationState, val to: OriginationState)
+
+/** Optional transition guard hook for service-level validation (maker != checker, pack waits, …). */
+fun interface OriginationGuard {
+    fun evaluate(transition: OriginationTransition): OriginationGuardFailure?
+}
+
+/** Describes why a transition was rejected by a guard. */
+data class OriginationGuardFailure(val reason: String)

--- a/openbank-libs-domain/src/test/kotlin/com/openbank/libs/decision/PolicyEvaluatorTest.kt
+++ b/openbank-libs-domain/src/test/kotlin/com/openbank/libs/decision/PolicyEvaluatorTest.kt
@@ -1,0 +1,256 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright (c) OpenBank contributors. Licensed under the Apache License, Version 2.0.
+// See LICENSE in the repository root or https://www.apache.org/licenses/LICENSE-2.0 for details.
+
+package com.openbank.libs.decision
+
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.Test
+import java.math.BigDecimal
+import java.time.LocalDate
+
+/** Covers ADR-0213: table order, fail-closed semantics, reason codes, versions and the input hash. */
+class PolicyEvaluatorTest {
+
+    private val asOf: LocalDate = LocalDate.parse("2026-07-29")
+
+    private fun exclusionTable(effectiveFrom: LocalDate = LocalDate.parse("2026-01-01")) = PolicyTable(
+        kind = PolicyTableKind.EXCLUSION,
+        name = "exclusion",
+        version = 1,
+        effectiveFrom = effectiveFrom,
+        rules = listOf(
+            PolicyRule(
+                id = "ex-bureau-f",
+                attribute = PolicyAttribute.BUREAU_SCORE_BAND,
+                operator = PolicyOperator.EQ,
+                values = setOf("F"),
+                detail = "bureau band F is an automatic exclusion",
+            ),
+            PolicyRule(
+                id = "ex-jurisdiction",
+                attribute = PolicyAttribute.JURISDICTION,
+                operator = PolicyOperator.NOT_IN,
+                values = setOf("CZ", "DE", "SK"),
+                detail = "unsupported jurisdiction",
+            ),
+        ),
+    )
+
+    private fun eligibilityTable() = PolicyTable(
+        kind = PolicyTableKind.ELIGIBILITY,
+        name = "eligibility",
+        version = 3,
+        effectiveFrom = LocalDate.parse("2026-01-01"),
+        rules = listOf(
+            PolicyRule("el-age", PolicyAttribute.AGE_YEARS, PolicyOperator.GTE, threshold = BigDecimal("18")),
+            PolicyRule("el-residency", PolicyAttribute.RESIDENCY, PolicyOperator.IN, values = setOf("CZ", "DE", "SK")),
+        ),
+    )
+
+    private fun affordabilityTable() = PolicyTable(
+        kind = PolicyTableKind.AFFORDABILITY,
+        name = "affordability",
+        version = 2,
+        effectiveFrom = LocalDate.parse("2026-01-01"),
+        rules = listOf(
+            PolicyRule("af-dsti", PolicyAttribute.DSTI, PolicyOperator.LTE, threshold = BigDecimal("0.45")),
+            PolicyRule("af-dti", PolicyAttribute.DTI, PolicyOperator.LTE, threshold = BigDecimal("8")),
+        ),
+    )
+
+    private fun pricingTable() = PolicyTable(
+        kind = PolicyTableKind.PRICING_BAND,
+        name = "pricing",
+        version = 5,
+        effectiveFrom = LocalDate.parse("2026-01-01"),
+        rules = listOf(
+            PolicyRule(
+                "pr-a",
+                PolicyAttribute.BUREAU_SCORE_BAND,
+                PolicyOperator.EQ,
+                values = setOf("A"),
+                band = "PRIME",
+            ),
+            PolicyRule(
+                "pr-b",
+                PolicyAttribute.BUREAU_SCORE_BAND,
+                PolicyOperator.EQ,
+                values = setOf("B"),
+                band = "STANDARD",
+            ),
+            PolicyRule(
+                "pr-c",
+                PolicyAttribute.BUREAU_SCORE_BAND,
+                PolicyOperator.EQ,
+                values = setOf("C"),
+                band = "SUBPRIME",
+            ),
+        ),
+    )
+
+    private fun bundle() =
+        PolicyBundle(listOf(exclusionTable(), eligibilityTable(), affordabilityTable(), pricingTable()))
+
+    private fun application(
+        band: String = "A",
+        age: String = "35",
+        dsti: String = "0.30",
+        dti: String = "4",
+        residency: String = "CZ",
+        jurisdiction: String = "CZ",
+    ) = PolicyApplication(
+        attributes = mapOf(
+            PolicyAttribute.BUREAU_SCORE_BAND to PolicyValue.Text(band),
+            PolicyAttribute.AGE_YEARS to PolicyValue.Numeric(BigDecimal(age)),
+            PolicyAttribute.DSTI to PolicyValue.Numeric(BigDecimal(dsti)),
+            PolicyAttribute.DTI to PolicyValue.Numeric(BigDecimal(dti)),
+            PolicyAttribute.RESIDENCY to PolicyValue.Text(residency),
+            PolicyAttribute.JURISDICTION to PolicyValue.Text(jurisdiction),
+        ),
+        asOf = asOf,
+    )
+
+    @Test
+    fun `all rules pass yields Approve with band, versions, matched rules and input hash`() {
+        val decision = PolicyEvaluator.evaluate(application(), bundle())
+
+        assertThat(decision).isInstanceOf(PolicyDecision.Approve::class.java)
+        decision as PolicyDecision.Approve
+        assertThat(decision.priceBand).isEqualTo("PRIME")
+        assertThat(decision.evaluation.policyVersions).containsEntry(PolicyTableKind.ELIGIBILITY, 3)
+            .containsEntry(PolicyTableKind.AFFORDABILITY, 2)
+            .containsEntry(PolicyTableKind.PRICING_BAND, 5)
+        assertThat(decision.evaluation.matchedRuleIds).contains("pr-a")
+        assertThat(decision.evaluation.reasons).isEmpty()
+        assertThat(decision.evaluation.inputSnapshotHash).hasSize(64)
+    }
+
+    @Test
+    fun `exclusion match declines with the firing rule id`() {
+        val decision = PolicyEvaluator.evaluate(application(band = "F"), bundle())
+
+        assertThat(decision).isInstanceOf(PolicyDecision.Decline::class.java)
+        assertThat(decision.evaluation.reasons.single().code).isEqualTo(PolicyReasonCode.EXCLUSION_MATCHED)
+        assertThat(decision.evaluation.reasons.single().ruleId).isEqualTo("ex-bureau-f")
+    }
+
+    @Test
+    fun `unsupported jurisdiction declines via NOT_IN exclusion`() {
+        val decision = PolicyEvaluator.evaluate(application(jurisdiction = "US"), bundle())
+
+        assertThat(decision).isInstanceOf(PolicyDecision.Decline::class.java)
+        assertThat(decision.evaluation.reasons.single().ruleId).isEqualTo("ex-jurisdiction")
+    }
+
+    @Test
+    fun `eligibility failure declines and never reaches pricing (pricing cannot flip a decline)`() {
+        val decision = PolicyEvaluator.evaluate(application(age = "17", band = "A"), bundle())
+
+        assertThat(decision).isInstanceOf(PolicyDecision.Decline::class.java)
+        assertThat(decision.evaluation.reasons.map { it.code })
+            .containsExactly(PolicyReasonCode.ELIGIBILITY_FAILED)
+        assertThat(decision.evaluation.matchedRuleIds).doesNotContain("pr-a")
+    }
+
+    @Test
+    fun `affordability failure declines with all failed rules`() {
+        val decision = PolicyEvaluator.evaluate(application(dsti = "0.60", dti = "12"), bundle())
+
+        assertThat(decision).isInstanceOf(PolicyDecision.Decline::class.java)
+        assertThat(decision.evaluation.reasons.map { it.ruleId }).containsExactly("af-dsti", "af-dti")
+    }
+
+    @Test
+    fun `missing input fails closed to REFER, never to APPROVE`() {
+        val incomplete = application().copy(
+            attributes = application().attributes - PolicyAttribute.DSTI,
+        )
+        val decision = PolicyEvaluator.evaluate(incomplete, bundle())
+
+        assertThat(decision).isInstanceOf(PolicyDecision.Refer::class.java)
+        assertThat(decision.evaluation.reasons.single().code).isEqualTo(PolicyReasonCode.INPUT_MISSING)
+        assertThat(decision.evaluation.reasons.single().ruleId).isEqualTo("af-dsti")
+    }
+
+    @Test
+    fun `missing policy table fails closed to REFER`() {
+        val noExclusion = PolicyBundle(listOf(eligibilityTable(), affordabilityTable(), pricingTable()))
+        val decision = PolicyEvaluator.evaluate(application(), noExclusion)
+
+        assertThat(decision).isInstanceOf(PolicyDecision.Refer::class.java)
+        assertThat(decision.evaluation.reasons.single().code).isEqualTo(PolicyReasonCode.POLICY_TABLE_MISSING)
+        assertThat(decision.evaluation.reasons.single().detail).isEqualTo("EXCLUSION")
+    }
+
+    @Test
+    fun `not-yet-effective table version is not active and fails closed`() {
+        val future = PolicyBundle(
+            listOf(
+                exclusionTable(effectiveFrom = LocalDate.parse("2027-01-01")),
+                eligibilityTable(),
+                affordabilityTable(),
+                pricingTable(),
+            ),
+        )
+        val decision = PolicyEvaluator.evaluate(application(), future)
+
+        assertThat(decision).isInstanceOf(PolicyDecision.Refer::class.java)
+        assertThat(decision.evaluation.reasons.single().code).isEqualTo(PolicyReasonCode.POLICY_TABLE_MISSING)
+    }
+
+    @Test
+    fun `newer effective version wins within one kind`() {
+        val v1 = pricingTable().copy(version = 1, rules = emptyList())
+        val v2 = pricingTable().copy(version = 9)
+        val bundle = PolicyBundle(listOf(exclusionTable(), eligibilityTable(), affordabilityTable(), v1, v2))
+        val decision = PolicyEvaluator.evaluate(application(), bundle)
+
+        assertThat(decision.evaluation.policyVersions[PolicyTableKind.PRICING_BAND]).isEqualTo(9)
+    }
+
+    @Test
+    fun `unmatched pricing band refers — approval always carries a price`() {
+        val decision = PolicyEvaluator.evaluate(application(band = "D"), bundle())
+
+        assertThat(decision).isInstanceOf(PolicyDecision.Refer::class.java)
+        assertThat(decision.evaluation.reasons.single().code).isEqualTo(PolicyReasonCode.PRICING_BAND_UNMATCHED)
+    }
+
+    @Test
+    fun `type-mismatched rule is REFER not a guessed decision`() {
+        val broken = pricingTable().copy(
+            rules = listOf(
+                PolicyRule(
+                    "pr-broken",
+                    PolicyAttribute.BUREAU_SCORE_BAND,
+                    PolicyOperator.GT,
+                    threshold = BigDecimal("1"),
+                ),
+            ),
+        )
+        val bundle = PolicyBundle(listOf(exclusionTable(), eligibilityTable(), affordabilityTable(), broken))
+        val decision = PolicyEvaluator.evaluate(application(), bundle)
+
+        assertThat(decision).isInstanceOf(PolicyDecision.Refer::class.java)
+        assertThat(decision.evaluation.reasons.single().code).isEqualTo(PolicyReasonCode.RULE_NOT_EVALUABLE)
+    }
+
+    @Test
+    fun `input snapshot hash is deterministic and input-sensitive`() {
+        val first = PolicyEvaluator.inputSnapshotHash(application().attributes)
+        val same = PolicyEvaluator.inputSnapshotHash(application().attributes)
+        val different = PolicyEvaluator.inputSnapshotHash(application(age = "36").attributes)
+
+        assertThat(first).isEqualTo(same)
+        assertThat(first).isNotEqualTo(different)
+    }
+
+    @Test
+    fun `membership operators work on text values`() {
+        val decision = PolicyEvaluator.evaluate(application(residency = "FR"), bundle())
+
+        assertThat(decision).isInstanceOf(PolicyDecision.Decline::class.java)
+        assertThat(decision.evaluation.reasons.map { it.code }).contains(PolicyReasonCode.ELIGIBILITY_FAILED)
+    }
+}

--- a/openbank-libs-domain/src/test/kotlin/com/openbank/libs/lending/origination/OriginationStateMachineTest.kt
+++ b/openbank-libs-domain/src/test/kotlin/com/openbank/libs/lending/origination/OriginationStateMachineTest.kt
@@ -1,0 +1,199 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright (c) OpenBank contributors. Licensed under the Apache License, Version 2.0.
+// See LICENSE in the repository root or https://www.apache.org/licenses/LICENSE-2.0 for details.
+
+package com.openbank.libs.lending.origination
+
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.Test
+import java.time.Instant
+
+/** Covers the canonical origination graph, guards and the ADR-0211 D7 legacy mapping. */
+class OriginationStateMachineTest {
+
+    private val machine = OriginationStateMachine()
+    private val now: Instant = Instant.parse("2026-07-29T12:00:00Z")
+
+    private fun transition(
+        from: OriginationState,
+        to: OriginationState,
+        actor: String = "officer-1",
+        actorKind: OriginationActorKind = OriginationActorKind.HUMAN,
+        reason: String = "valid business reason",
+    ) = OriginationTransition(
+        applicationId = "app-1",
+        from = from,
+        to = to,
+        actor = actor,
+        actorKind = actorKind,
+        reason = reason,
+        occurredAt = now,
+        packVersion = "CZ-2026.1",
+    )
+
+    @Test
+    fun `happy path walks the full canonical graph to DISBURSED`() {
+        val path = listOf(
+            OriginationState.DRAFT to OriginationState.SUBMITTED,
+            OriginationState.SUBMITTED to OriginationState.KYC_PENDING,
+            OriginationState.KYC_PENDING to OriginationState.DOCS_REQUIRED,
+            OriginationState.DOCS_REQUIRED to OriginationState.ASSESSMENT,
+            OriginationState.ASSESSMENT to OriginationState.DECISION_PENDING,
+            OriginationState.DECISION_PENDING to OriginationState.FOUR_EYES,
+            OriginationState.FOUR_EYES to OriginationState.OFFERED,
+            OriginationState.OFFERED to OriginationState.AWAITING_SIGNATURE,
+            OriginationState.AWAITING_SIGNATURE to OriginationState.SIGNED,
+            OriginationState.SIGNED to OriginationState.READY_TO_DISBURSE,
+            OriginationState.READY_TO_DISBURSE to OriginationState.DISBURSED,
+        )
+        path.forEach { (from, to) ->
+            assertThat(machine.apply(transition(from, to)))
+                .isEqualTo(OriginationTransitionResult.Applied(to))
+        }
+    }
+
+    @Test
+    fun `reflection period is a reachable but skippable edge`() {
+        assertThat(machine.apply(transition(OriginationState.SIGNED, OriginationState.REFLECTION_PERIOD)))
+            .isEqualTo(OriginationTransitionResult.Applied(OriginationState.REFLECTION_PERIOD))
+        assertThat(machine.apply(transition(OriginationState.REFLECTION_PERIOD, OriginationState.READY_TO_DISBURSE)))
+            .isEqualTo(OriginationTransitionResult.Applied(OriginationState.READY_TO_DISBURSE))
+        assertThat(machine.apply(transition(OriginationState.SIGNED, OriginationState.READY_TO_DISBURSE)))
+            .isEqualTo(OriginationTransitionResult.Applied(OriginationState.READY_TO_DISBURSE))
+    }
+
+    @Test
+    fun `forbidden shortcut DRAFT to DISBURSED is rejected`() {
+        val result = machine.apply(transition(OriginationState.DRAFT, OriginationState.DISBURSED))
+        assertThat(result).isInstanceOf(OriginationTransitionResult.Rejected::class.java)
+        assertThat((result as OriginationTransitionResult.Rejected).reason).contains("not allowed")
+    }
+
+    @Test
+    fun `terminal states have no outgoing transitions`() {
+        OriginationState.TERMINAL.forEach { terminal ->
+            val result = machine.apply(transition(terminal, OriginationState.SUBMITTED))
+            assertThat(result).isInstanceOf(OriginationTransitionResult.Rejected::class.java)
+            assertThat((result as OriginationTransitionResult.Rejected).reason).contains("terminal")
+        }
+    }
+
+    @Test
+    fun `customer exit and time-driven exits are reachable from pre-disbursement states`() {
+        assertThat(machine.apply(transition(OriginationState.ASSESSMENT, OriginationState.WITHDRAWN)))
+            .isEqualTo(OriginationTransitionResult.Applied(OriginationState.WITHDRAWN))
+        assertThat(machine.apply(transition(OriginationState.OFFERED, OriginationState.EXPIRED)))
+            .isEqualTo(OriginationTransitionResult.Applied(OriginationState.EXPIRED))
+    }
+
+    @Test
+    fun `system actor cannot take human-only edges (offer, signature)`() {
+        val offered = machine.apply(
+            transition(
+                OriginationState.FOUR_EYES,
+                OriginationState.OFFERED,
+                actorKind = OriginationActorKind.SYSTEM,
+                actor = "temporal-worker",
+            ),
+        )
+        assertThat(offered).isInstanceOf(OriginationTransitionResult.Rejected::class.java)
+
+        val signed = machine.apply(
+            transition(
+                OriginationState.AWAITING_SIGNATURE,
+                OriginationState.SIGNED,
+                actorKind = OriginationActorKind.SYSTEM,
+                actor = "temporal-worker",
+            ),
+        )
+        assertThat(signed).isInstanceOf(OriginationTransitionResult.Rejected::class.java)
+    }
+
+    @Test
+    fun `system actor can take machine edges (timer expiry)`() {
+        val result = machine.apply(
+            transition(
+                OriginationState.OFFERED,
+                OriginationState.EXPIRED,
+                actorKind = OriginationActorKind.SYSTEM,
+                actor = "temporal-worker",
+            ),
+        )
+        assertThat(result).isEqualTo(OriginationTransitionResult.Applied(OriginationState.EXPIRED))
+    }
+
+    @Test
+    fun `blank actor or reason is rejected`() {
+        assertThat(machine.apply(transition(OriginationState.DRAFT, OriginationState.SUBMITTED, actor = " ")))
+            .isInstanceOf(OriginationTransitionResult.Rejected::class.java)
+        assertThat(machine.apply(transition(OriginationState.DRAFT, OriginationState.SUBMITTED, reason = "")))
+            .isInstanceOf(OriginationTransitionResult.Rejected::class.java)
+    }
+
+    @Test
+    fun `policy guard hook rejects maker-equals-checker`() {
+        val makerCheckerGuard = OriginationGuard { t ->
+            if (t.to == OriginationState.OFFERED && t.metadata["maker"] == t.actor) {
+                OriginationGuardFailure("maker must differ from checker")
+            } else {
+                null
+            }
+        }
+        val guarded = OriginationStateMachine(
+            OriginationTransitionPolicy(
+                allowedTransitions = OriginationTransitionPolicy.standard().allowedTransitions,
+                guards = mapOf(
+                    OriginationTransitionKey(OriginationState.FOUR_EYES, OriginationState.OFFERED) to
+                        listOf(makerCheckerGuard),
+                ),
+            ),
+        )
+        val selfApproval = transition(OriginationState.FOUR_EYES, OriginationState.OFFERED, actor = "officer-1")
+            .copy(metadata = mapOf("maker" to "officer-1"))
+        assertThat(guarded.apply(selfApproval))
+            .isEqualTo(OriginationTransitionResult.Rejected("maker must differ from checker"))
+
+        val fourEyes = transition(OriginationState.FOUR_EYES, OriginationState.OFFERED, actor = "officer-2")
+            .copy(metadata = mapOf("maker" to "officer-1"))
+        assertThat(guarded.apply(fourEyes))
+            .isEqualTo(OriginationTransitionResult.Applied(OriginationState.OFFERED))
+    }
+
+    @Test
+    fun `legacy v0_11_5 statuses map onto the canonical graph (ADR-0211 D7)`() {
+        assertThat(LegacyOriginationMigration.mapLegacyStatus("PROPOSED", wasSubmitted = false))
+            .isEqualTo(OriginationState.DRAFT)
+        assertThat(LegacyOriginationMigration.mapLegacyStatus("PROPOSED", wasSubmitted = true))
+            .isEqualTo(OriginationState.SUBMITTED)
+        assertThat(LegacyOriginationMigration.mapLegacyStatus("APPROVED", wasSubmitted = true))
+            .isEqualTo(OriginationState.OFFERED)
+        assertThat(LegacyOriginationMigration.mapLegacyStatus("REJECTED", wasSubmitted = true))
+            .isEqualTo(OriginationState.DECLINED)
+        assertThat(LegacyOriginationMigration.mapLegacyStatus("DISBURSED", wasSubmitted = true))
+            .isEqualTo(OriginationState.DISBURSED)
+        assertThat(LegacyOriginationMigration.mapLegacyStatus("CORRUPT", wasSubmitted = true)).isNull()
+    }
+
+    @Test
+    fun `every non-terminal state can reach a terminal state`() {
+        OriginationState.entries.filter { !it.isTerminal }.forEach { state ->
+            val reachable = reachableFrom(state)
+            assertThat(reachable.intersect(OriginationState.TERMINAL))
+                .`as`("state %s must reach a terminal state", state)
+                .isNotEmpty()
+        }
+    }
+
+    private fun reachableFrom(start: OriginationState): Set<OriginationState> {
+        val policy = OriginationTransitionPolicy.standard()
+        val seen = mutableSetOf(start)
+        val queue = ArrayDeque(listOf(start))
+        while (queue.isNotEmpty()) {
+            val current = queue.removeFirst()
+            policy.allowedTargets(current).forEach { next ->
+                if (seen.add(next)) queue.addLast(next)
+            }
+        }
+        return seen
+    }
+}


### PR DESCRIPTION
## Summary

First implementation slice of the credit platform suite (ADR-0211…0218): the two pure primitives everything else builds on — the canonical origination transition policy (ADR-0211 D1/D3/D7) and the deterministic credit policy evaluator (ADR-0213) — as zero-framework, fully unit-tested domain code in `openbank-libs-domain`.

## Type of change

- [x] feat (new functionality)
- [ ] fix (bug fix)
- [ ] refactor (no behavior change)
- [ ] perf (performance)
- [ ] docs
- [ ] chore (build / tooling)
- [ ] security (private until disclosed)
- [ ] breaking change

## Linked issues

Refs ADR-0211, ADR-0213 (implemented from the accepted-for-review suite merged in #2711).

## Changes

**ADR-0211 — `com.openbank.libs.lending.origination`**
- `OriginationState` — canonical lifecycle (DRAFT → … → DISBURSED + WITHDRAWN/DECLINED/EXPIRED exits); REFLECTION_PERIOD reachable-but-skippable (pack decides); withdrawal deliberately post-disbursement (ADR-0215).
- `OriginationTransitionPolicy` — the graph as data + `OriginationGuard` hooks keyed by transition (maker≠checker and pack waits attach service-side), ADR-0045 pattern.
- `OriginationStateMachine` — deterministic guard/apply: terminal-state guard, human-only edges (OFFERED, SIGNED) refuse SYSTEM actors, non-blank actor/reason.
- `LegacyOriginationMigration` — D7 mapping of v0.11.5 statuses (PROPOSED→DRAFT/SUBMITTED, APPROVED→OFFERED, REJECTED→DECLINED, DISBURSED→DISBURSED; unknown → null, fail loud).

**ADR-0213 — `com.openbank.libs.decision`**
- Closed vocabulary: `PolicyAttribute` (14 attrs), `PolicyOperator` (comparisons + IN/NOT_IN), `PolicyValue` (typed Numeric/Text).
- `PolicyTable`/`PolicyBundle` — versioned, effective-dated tables; kinds evaluate in fixed order EXCLUSION (first match declines) → ELIGIBILITY/AFFORDABILITY (all-pass, collects every failed rule) → PRICING_BAND (first match, never flips a decline).
- `PolicyEvaluator` — pure O(rules) object; fail-closed: missing input / unevaluable rule / missing or not-yet-effective table ⇒ REFER; approve always carries a price band. Output contract: outcome + reason codes + matched rule ids + policy versions + SHA-256 input snapshot hash (the ADR-0214 evidence shape).

## Definition of Done

- [x] Hexagonal layering preserved (domain has zero framework imports).
- [x] Unit tests added/updated. (24 tests: full happy-path walk, terminal-state guard, actor-kind guard, guard hooks, legacy mapping, all fail-closed paths, table ordering, version selection, hash determinism)
- [ ] Integration tests added/updated (if service boundary involved). — N/A (pure libs, no service boundary)
- [ ] Contract tests updated (if public API changed). — N/A
- [x] `./gradlew detekt ktlintCheck koverVerify build` passes. (`:openbank-libs-domain:test :ktlintCheck :detekt :koverVerify :build` all green)
- [x] No new lint warnings.
- [ ] OpenAPI spec regenerated (if REST API changed). — N/A
- [ ] Flyway migration added + rollback note (if DB changed). — N/A
- [ ] Avro schema versioned backward-compatibly (if event changed). — N/A
- [x] Docs updated (README, ADR if architectural). — ADRs 0211/0213 already merged (#2711); Delivery-Status bump follows with the service wiring.

## Security checklist

- [x] No secrets, tokens, passwords, or PII in code, config, tests, logs.
- [x] No new `@SuppressWarnings`, `as Any`, `@Suppress("...")` without justification (state it in this PR).
- [x] No new third-party dependency, OR: dependency review attached (license, CVE, source).
- [ ] Auth / crypto / payment code changed? → tag `security-review-required`.
- [ ] PII path changed? → tag `gdpr-review-required`.
- [ ] Cardholder data path changed? → tag `pci-review-required`.

## Compliance impact

- [ ] PCI DSS
- [ ] DORA
- [x] GDPR
- [ ] PSD2 / SCA / RTS
- [ ] AML / 5AMLD
- [x] CNB reporting
- [ ] None

Primitives only — no runtime behaviour change anywhere (no consumer wired yet). The evaluator's reason-code + input-hash contract is the GDPR Art. 22 / adverse-action foundation; the state machine's guards are the EBA/GL/2020/06 four-eyes mechanics. Money-path gate applies when lending-service wires these in (follow-up PRs).

## Rollout / Rollback

- Deployment strategy: N/A (library code, no consumers yet)
- Rollback plan: revert this PR
- Data migration reversible: N/A

## Reviewer notes

Design decisions worth a look: (1) human-only edges (OFFERED/SIGNED) are enforced in the machine, pack-mandated waits stay service-side guards; (2) all four table kinds are mandatory per bundle — a missing PRICING_BAND table REFERs, because a price-less approval is not a lawful decision; (3) PRICING_BAND first-match returns immediately, so band rule order is significant by design. Follow-ups (next PRs): pack loader + compile-at-activation (ADR-0212/0218), lending-service wiring of the state machine.