### PR TITLE
feat(libs): jurisdictional compliance packs — parser, compiler, four-eyes registry (ADR-0212)

### DIFF
--- a/openbank-libs-domain/src/main/kotlin/com/openbank/libs/lending/compliance/CompiledCompliancePack.kt
+++ b/openbank-libs-domain/src/main/kotlin/com/openbank/libs/lending/compliance/CompiledCompliancePack.kt
@@ -1,0 +1,143 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright (c) OpenBank contributors. Licensed under the Apache License, Version 2.0.
+// See LICENSE in the repository root or https://www.apache.org/licenses/LICENSE-2.0 for details.
+
+package com.openbank.libs.lending.compliance
+
+import com.openbank.libs.lending.origination.OriginationState
+import java.math.BigDecimal
+import java.security.MessageDigest
+
+/** Compile-time pack validation failed — activation is refused (fail-closed). */
+class CompliancePackValidationException(message: String) : IllegalArgumentException(message)
+
+/** The activation-ready, immutable form of a [CompliancePack] (ADR-0218 D3
+ * compile-at-activation): validated once, then served from memory for the pack's
+ * whole lifetime — origination never re-parses or re-validates per request.
+ * [contentHash] pins the exact canonical content into the evidence chain
+ * (ADR-0214): what the contract was originated under is provable, not asserted.
+ */
+data class CompiledCompliancePack(
+    val pack: CompliancePack,
+    val contentHash: String,
+    val disclosureById: Map<String, PackDisclosure>,
+) {
+    val key: PackKey get() = PackKey(pack.jurisdiction, pack.productType)
+}
+
+/** Lookup key packs are activated and resolved under. */
+data class PackKey(val jurisdiction: String, val productType: PackProductType)
+
+/**
+ * Validates a parsed pack and compiles it into its immutable runtime form. Every
+ * rule here is fail-closed: a pack that violates one is never activated, so an
+ * unlawful configuration cannot reach origination even with a signed four-eyes
+ * approval — the human gate and the machine gate are independent (ADR-0212 D2/D4).
+ */
+object CompliancePackCompiler {
+
+    private const val MAX_DPD_THRESHOLD = 180
+
+    /** Origination states a pack may mark mandatory — the graph's optional states only. */
+    private val PARAMETERISABLE_STEPS: Set<OriginationState> = setOf(
+        OriginationState.DOCS_REQUIRED,
+        OriginationState.REFLECTION_PERIOD,
+    )
+
+    fun compile(pack: CompliancePack): CompiledCompliancePack {
+        validateShape(pack)
+        validateDisclosures(pack)
+        validateMandatoryChecks(pack)
+        return CompiledCompliancePack(
+            pack = pack,
+            contentHash = contentHash(pack),
+            disclosureById = pack.disclosures.associateBy { it.id },
+        )
+    }
+
+    private fun validateShape(pack: CompliancePack) {
+        if (pack.jurisdiction.isBlank()) fail("jurisdiction must not be blank")
+        if (pack.version < 1) fail("version must be >= 1")
+        if (pack.effectiveTo != null && !pack.effectiveTo.isAfter(pack.effectiveFrom)) {
+            fail("effectiveTo must be after effectiveFrom")
+        }
+        val badSteps = pack.requiredSteps - PARAMETERISABLE_STEPS
+        if (badSteps.isNotEmpty()) {
+            fail("requiredSteps may only contain optional states $PARAMETERISABLE_STEPS, got $badSteps")
+        }
+        if (pack.requiredSteps.contains(OriginationState.REFLECTION_PERIOD) && pack.reflectionPeriodDays == null) {
+            fail("REFLECTION_PERIOD is mandatory but reflectionPeriodDays is not set")
+        }
+        if (pack.coolingOffDays < 0) fail("coolingOffDays must be >= 0")
+        validateFinancials(pack)
+    }
+
+    private fun validateFinancials(pack: CompliancePack) {
+        pack.earlyRepaymentCompensationCap?.let { cap ->
+            if (cap < BigDecimal.ZERO || cap > BigDecimal.ONE) {
+                fail("earlyRepaymentCompensationCap must be in [0, 1]")
+            }
+        }
+        if (pack.terminationRules.noticePeriodDays < 0) {
+            fail("terminationRules.noticePeriodDays must be >= 0")
+        }
+        if (pack.terminationRules.defaultDpdThreshold !in 1..MAX_DPD_THRESHOLD) {
+            fail("terminationRules.defaultDpdThreshold must be in 1..$MAX_DPD_THRESHOLD (CRR Art. 178 bounds)")
+        }
+    }
+
+    private fun validateDisclosures(pack: CompliancePack) {
+        if (pack.disclosures.map { it.id }.toSet().size != pack.disclosures.size) {
+            fail("duplicate disclosure id")
+        }
+        pack.disclosures.forEach { disclosure ->
+            if (disclosure.templateKey.isBlank()) {
+                fail("disclosure '${disclosure.id}': templateKey must not be blank")
+            }
+            if (disclosure.languages.isEmpty()) {
+                fail("disclosure '${disclosure.id}': at least one language required")
+            }
+        }
+    }
+
+    private fun validateMandatoryChecks(pack: CompliancePack) {
+        val ids = pack.mandatoryChecks.map { it.id }
+        if (ids.toSet().size != ids.size) fail("duplicate mandatoryChecks rule id")
+    }
+
+    private fun fail(message: String): Nothing = throw CompliancePackValidationException(message)
+
+    /** Canonical content rendering → SHA-256; stable across JVMs and map orderings. */
+    private fun contentHash(pack: CompliancePack): String {
+        val canonical = buildString {
+            append(pack.jurisdiction).append('|')
+            append(pack.productType.name).append('|')
+            append(pack.version).append('|')
+            append(pack.effectiveFrom).append('|')
+            append(pack.effectiveTo ?: "-").append('|')
+            append(pack.requiredSteps.map { it.name }.sorted().joinToString(",")).append('|')
+            append(pack.coolingOffDays).append('|')
+            append(pack.reflectionPeriodDays ?: "-").append('|')
+            append(pack.aprDisclosure.label).append('|').append(pack.aprDisclosure.locale).append('|')
+            append(pack.earlyRepaymentCompensationCap?.toPlainString() ?: "-").append('|')
+            append(pack.terminationRules.noticePeriodDays).append('|')
+            append(pack.terminationRules.permittedGrounds.map { it.name }.sorted().joinToString(",")).append('|')
+            append(pack.terminationRules.defaultDpdThreshold).append('|')
+            pack.disclosures.sortedBy { it.id }.forEach { d ->
+                append(d.id).append(':').append(d.templateKey).append(':')
+                    .append(d.languages.sorted().joinToString(",")).append(':')
+                    .append(d.requiresAcknowledgement).append(':').append(d.stage.name).append(';')
+            }
+            append('|')
+            pack.mandatoryChecks.sortedBy { it.id }.forEach { r ->
+                append(r.id).append(':').append(r.attribute.name).append(':').append(r.operator.name).append(':')
+                    .append(r.threshold?.toPlainString() ?: "-").append(':')
+                    .append(r.values.sorted().joinToString(",")).append(':')
+                    .append(r.band ?: "-").append(';')
+            }
+        }
+        return MessageDigest.getInstance("SHA-256")
+            .digest(canonical.toByteArray(Charsets.UTF_8))
+            .joinToString("") { "%02x".format(it) }
+    }
+}

--- a/openbank-libs-domain/src/main/kotlin/com/openbank/libs/lending/compliance/CompliancePack.kt
+++ b/openbank-libs-domain/src/main/kotlin/com/openbank/libs/lending/compliance/CompliancePack.kt
@@ -1,0 +1,68 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright (c) OpenBank contributors. Licensed under the Apache License, Version 2.0.
+// See LICENSE in the repository root or https://www.apache.org/licenses/LICENSE-2.0 for details.
+
+package com.openbank.libs.lending.compliance
+
+import com.openbank.libs.decision.PolicyRule
+import com.openbank.libs.lending.origination.OriginationState
+import java.math.BigDecimal
+import java.time.LocalDate
+
+/**
+ * Jurisdictional credit compliance pack (ADR-0212 D1): the legal duties of one
+ * (jurisdiction, productType) pair as versioned, effective-dated, declarative data.
+ * Authored as reviewed JSON/YAML in the repo, activated at runtime four-eyes
+ * (ADR-0212 D4) — adding a jurisdiction is data, not a service release.
+ */
+data class CompliancePack(
+    val jurisdiction: String,
+    val productType: PackProductType,
+    val version: Int,
+    val effectiveFrom: LocalDate,
+    val effectiveTo: LocalDate? = null,
+    val requiredSteps: Set<OriginationState> = emptySet(),
+    val coolingOffDays: Int,
+    val reflectionPeriodDays: Int? = null,
+    val aprDisclosure: AprDisclosure,
+    val earlyRepaymentCompensationCap: BigDecimal? = null,
+    val terminationRules: TerminationRules,
+    val disclosures: List<PackDisclosure> = emptyList(),
+    val mandatoryChecks: List<PolicyRule> = emptyList(),
+) {
+    fun isEffectiveOn(asOf: LocalDate): Boolean =
+        !asOf.isBefore(effectiveFrom) && (effectiveTo == null || asOf.isBefore(effectiveTo))
+}
+
+enum class PackProductType { CONSUMER_CREDIT, MORTGAGE, OVERDRAFT, SME_CREDIT }
+
+/**
+ * The pricing-disclosure label and locale, never the math: the APRC formula is the
+ * single harmonised CCD2 Annex I computation in libs; RPSN / effektiver Jahreszins /
+ * APR are national-language disclosures of the same number (ADR-0212 D1).
+ */
+data class AprDisclosure(val label: String, val locale: String)
+
+enum class TerminationGround { DEFAULT_DPD, MATERIAL_BREACH, INSOLVENCY, FRAUD, OTHER_STATUTORY }
+
+/**
+ * Bank-initiated termination parameters (ADR-0215). [defaultDpdThreshold] defaults to
+ * the ČNB 90-day election; CRR Art. 178 permits a 180-day national discretion for some
+ * retail/PSE classes, so the threshold is data, not a constant.
+ */
+data class TerminationRules(
+    val noticePeriodDays: Int,
+    val permittedGrounds: Set<TerminationGround>,
+    val defaultDpdThreshold: Int = 90,
+)
+
+enum class DisclosureStage { PRE_CONTRACTUAL, CONTRACTUAL, PRE_TERMINATION }
+
+/** One mandatory document the pack requires (SECCI, contract, termination notice, …). */
+data class PackDisclosure(
+    val id: String,
+    val templateKey: String,
+    val languages: Set<String>,
+    val requiresAcknowledgement: Boolean,
+    val stage: DisclosureStage,
+)

--- a/openbank-libs-domain/src/main/kotlin/com/openbank/libs/lending/compliance/CompliancePackEvaluator.kt
+++ b/openbank-libs-domain/src/main/kotlin/com/openbank/libs/lending/compliance/CompliancePackEvaluator.kt
@@ -1,0 +1,36 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright (c) OpenBank contributors. Licensed under the Apache License, Version 2.0.
+// See LICENSE in the repository root or https://www.apache.org/licenses/LICENSE-2.0 for details.
+
+package com.openbank.libs.lending.compliance
+
+import com.openbank.libs.decision.PolicyRule
+import com.openbank.libs.lending.origination.OriginationState
+
+/**
+ * Pure read-side queries over a compiled pack (ADR-0212 D5): given the pack, what
+ * steps, disclosures and limits apply. The evaluator never decides legality on its
+ * own — it exposes what the pinned pack declares, so the origination state machine,
+ * the policy engine (ADR-0213) and the termination lifecycle (ADR-0215) all read one
+ * source of legal truth.
+ */
+object CompliancePackEvaluator {
+
+    /** States the origination graph may skip by default but this pack makes mandatory. */
+    fun mandatorySteps(pack: CompiledCompliancePack): Set<OriginationState> = pack.pack.requiredSteps
+
+    fun disclosuresFor(pack: CompiledCompliancePack, stage: DisclosureStage): List<PackDisclosure> =
+        pack.pack.disclosures.filter { it.stage == stage }
+
+    /**
+     * Jurisdiction-mandated credit checks as ADR-0213 eligibility rules: the service
+     * appends them to the ELIGIBILITY table at evaluation time, so a statutory floor
+     * (e.g. DSTI cap from the local act) is enforced by the same fail-closed engine
+     * as commercial policy — never bypassed, never silently absent.
+     */
+    fun mandatoryEligibilityRules(pack: CompiledCompliancePack): List<PolicyRule> = pack.pack.mandatoryChecks
+
+    fun coolingOffDays(pack: CompiledCompliancePack): Int = pack.pack.coolingOffDays
+
+    fun terminationRules(pack: CompiledCompliancePack): TerminationRules = pack.pack.terminationRules
+}

--- a/openbank-libs-domain/src/main/kotlin/com/openbank/libs/lending/compliance/CompliancePackParser.kt
+++ b/openbank-libs-domain/src/main/kotlin/com/openbank/libs/lending/compliance/CompliancePackParser.kt
@@ -1,0 +1,184 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright (c) OpenBank contributors. Licensed under the Apache License, Version 2.0.
+// See LICENSE in the repository root or https://www.apache.org/licenses/LICENSE-2.0 for details.
+
+package com.openbank.libs.lending.compliance
+
+import com.fasterxml.jackson.databind.ObjectMapper
+import com.fasterxml.jackson.module.kotlin.readValue
+import com.fasterxml.jackson.module.kotlin.registerKotlinModule
+import com.openbank.libs.decision.PolicyAttribute
+import com.openbank.libs.decision.PolicyOperator
+import com.openbank.libs.decision.PolicyRule
+import com.openbank.libs.lending.origination.OriginationState
+import java.math.BigDecimal
+import java.time.LocalDate
+
+/** Strict pack decoding failed — the pack is rejected whole, never coerced (ADR-0212 D2). */
+class CompliancePackParseException(message: String) : IllegalArgumentException(message)
+
+/**
+ * Strict, fail-closed decoder for compliance packs. The schema is closed: an unknown
+ * key, an unknown enum value, a wrong type or a missing mandatory field rejects the
+ * whole pack — the bank never originates under a rule set it could not fully read.
+ * Format-agnostic: [fromMap] does the decoding; [fromJson] is the JSON convenience
+ * (a YAML front-end needs no change here, only a YAML→Map step at the caller).
+ */
+object CompliancePackParser {
+
+    private val mapper: ObjectMapper = ObjectMapper().registerKotlinModule()
+
+    fun fromJson(json: String): CompliancePack = fromMap(mapper.readValue(json))
+
+    fun fromMap(raw: Map<String, Any?>): CompliancePack {
+        val node = Node(raw, "pack")
+        node.require(MANDATORY_KEYS)
+        node.rejectUnknown(ALL_KEYS)
+        return CompliancePack(
+            jurisdiction = node.textOf("jurisdiction"),
+            productType = node.enumValue("productType", PackProductType.entries),
+            version = node.int("version"),
+            effectiveFrom = node.date("effectiveFrom"),
+            effectiveTo = node.optDate("effectiveTo"),
+            requiredSteps = node.strList("requiredSteps").map { step ->
+                OriginationState.entries.firstOrNull { it.name == step }
+                    ?: throw CompliancePackParseException("requiredSteps: unknown origination state '$step'")
+            }.toSet(),
+            coolingOffDays = node.int("coolingOffDays"),
+            reflectionPeriodDays = node.optInt("reflectionPeriodDays"),
+            aprDisclosure = aprDisclosure(node),
+            earlyRepaymentCompensationCap = node.optDecimal("earlyRepaymentCompensationCap"),
+            terminationRules = terminationRules(node),
+            disclosures = node.objList("disclosures").mapIndexed { i, d -> disclosure(Node(d, "disclosures[$i]")) },
+            mandatoryChecks = node.objList("mandatoryChecks").mapIndexed { i, r ->
+                policyRule(Node(r, "mandatoryChecks[$i]"))
+            },
+        )
+    }
+
+    private val MANDATORY_KEYS = setOf(
+        "jurisdiction",
+        "productType",
+        "version",
+        "effectiveFrom",
+        "coolingOffDays",
+        "aprDisclosure",
+        "terminationRules",
+    )
+
+    private val ALL_KEYS = MANDATORY_KEYS + setOf(
+        "effectiveTo",
+        "requiredSteps",
+        "reflectionPeriodDays",
+        "earlyRepaymentCompensationCap",
+        "disclosures",
+        "mandatoryChecks",
+    )
+
+    private fun aprDisclosure(parent: Node): AprDisclosure {
+        val node = parent.obj("aprDisclosure")
+        node.rejectUnknown(setOf("label", "locale"))
+        node.require(setOf("label", "locale"))
+        return AprDisclosure(label = node.textOf("label"), locale = node.textOf("locale"))
+    }
+
+    private fun terminationRules(parent: Node): TerminationRules {
+        val node = parent.obj("terminationRules")
+        node.rejectUnknown(setOf("noticePeriodDays", "permittedGrounds", "defaultDpdThreshold"))
+        node.require(setOf("noticePeriodDays", "permittedGrounds"))
+        return TerminationRules(
+            noticePeriodDays = node.int("noticePeriodDays"),
+            permittedGrounds = node.strList("permittedGrounds").map { ground ->
+                TerminationGround.entries.firstOrNull { it.name == ground }
+                    ?: throw CompliancePackParseException("terminationRules.permittedGrounds: unknown ground '$ground'")
+            }.toSet(),
+            defaultDpdThreshold = node.optInt("defaultDpdThreshold") ?: 90,
+        )
+    }
+
+    private fun disclosure(node: Node): PackDisclosure {
+        node.rejectUnknown(setOf("id", "templateKey", "languages", "requiresAcknowledgement", "stage"))
+        node.require(setOf("id", "templateKey", "languages", "stage"))
+        return PackDisclosure(
+            id = node.textOf("id"),
+            templateKey = node.textOf("templateKey"),
+            languages = node.strList("languages").toSet(),
+            requiresAcknowledgement = node.bool("requiresAcknowledgement", defaultValue = false),
+            stage = node.enumValue("stage", DisclosureStage.entries),
+        )
+    }
+
+    private fun policyRule(node: Node): PolicyRule {
+        node.rejectUnknown(setOf("id", "attribute", "operator", "threshold", "values", "band", "detail"))
+        node.require(setOf("id", "attribute", "operator"))
+        return PolicyRule(
+            id = node.textOf("id"),
+            attribute = node.enumValue("attribute", PolicyAttribute.entries),
+            operator = node.enumValue("operator", PolicyOperator.entries),
+            threshold = node.optDecimal("threshold"),
+            values = node.strList("values").toSet(),
+            band = node.optText("band"),
+            detail = node.optText("detail") ?: "",
+        )
+    }
+}
+
+/** Typed accessor over one decoded JSON object; every misuse fails closed with [CompliancePackParseException]. */
+private class Node(val raw: Map<String, Any?>, val where: String) {
+    fun require(keys: Set<String>) {
+        keys.forEach { key ->
+            if (raw[key] == null) throw CompliancePackParseException("$where: missing mandatory key '$key'")
+        }
+    }
+
+    fun rejectUnknown(known: Set<String>) {
+        (raw.keys - known).forEach { key ->
+            throw CompliancePackParseException("$where: unknown key '$key' (closed schema)")
+        }
+    }
+
+    fun obj(key: String): Node =
+        (raw[key] as? Map<*, *>)?.let { Node(it.entries.associate { e -> e.key.toString() to e.value }, key) }
+            ?: throw CompliancePackParseException("$where: '$key' must be an object")
+
+    @Suppress("UNCHECKED_CAST")
+    fun objList(key: String): List<Map<String, Any?>> = (raw[key] as? List<Map<String, Any?>>) ?: emptyList()
+
+    @Suppress("UNCHECKED_CAST")
+    fun strList(key: String): List<String> = (raw[key] as? List<String>) ?: emptyList()
+
+    fun <T : Enum<T>> enumValue(key: String, entries: List<T>): T {
+        val value = textOf(key)
+        return entries.firstOrNull { it.name == value }
+            ?: throw CompliancePackParseException(
+                "$where: '$key': unknown value '$value' (allowed: ${entries.joinToString()})",
+            )
+    }
+}
+
+private fun Node.textOf(key: String): String =
+    raw[key] as? String ?: throw CompliancePackParseException("$where: '$key' must be a string")
+
+private fun Node.optText(key: String): String? = raw[key] as? String
+
+private fun Node.int(key: String): Int =
+    (raw[key] as? Number)?.toInt() ?: throw CompliancePackParseException("$where: '$key' must be a number")
+
+private fun Node.optInt(key: String): Int? = (raw[key] as? Number)?.toInt()
+
+private fun Node.bool(key: String, defaultValue: Boolean): Boolean = (raw[key] as? Boolean) ?: defaultValue
+
+private fun Node.optDecimal(key: String): BigDecimal? = when (val v = raw[key]) {
+    is Number -> BigDecimal(v.toString())
+    is String -> v.toBigDecimalOrNull()
+        ?: throw CompliancePackParseException("$where: '$key' must be a decimal number")
+    else -> null
+}
+
+private fun Node.date(key: String): LocalDate = try {
+    LocalDate.parse(textOf(key))
+} catch (e: java.time.format.DateTimeParseException) {
+    throw CompliancePackParseException("$where: '$key' must be an ISO date: ${e.message}")
+}
+
+private fun Node.optDate(key: String): LocalDate? = raw[key]?.let { date(key) }

--- a/openbank-libs-domain/src/main/kotlin/com/openbank/libs/lending/compliance/CompliancePackRegistry.kt
+++ b/openbank-libs-domain/src/main/kotlin/com/openbank/libs/lending/compliance/CompliancePackRegistry.kt
@@ -1,0 +1,75 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright (c) OpenBank contributors. Licensed under the Apache License, Version 2.0.
+// See LICENSE in the repository root or https://www.apache.org/licenses/LICENSE-2.0 for details.
+
+package com.openbank.libs.lending.compliance
+
+import com.openbank.libs.governance.Proposal
+import com.openbank.libs.governance.ProposalState
+import java.time.LocalDate
+import java.util.concurrent.atomic.AtomicReference
+
+/** Four-eyes or registry invariant violated — the activation/lookup is refused. */
+class PackActivationException(message: String) : IllegalStateException(message)
+
+/**
+ * In-memory registry of compiled compliance packs (ADR-0212 D4, ADR-0218 D3).
+ * Activation is runtime four-eyes: the only way in is an APPROVED
+ * [Proposal] whose maker and checker differ (the segregation-of-duties rule is
+ * enforced by the MakerChecker state machine on the way in, and re-asserted here).
+ * No Flyway migration, no service release per pack.
+ *
+ * The registry is an [AtomicReference] over an immutable map: activation swaps one
+ * reference, readers never block, and a lookup resolves the pack version effective
+ * at the requested date — in-flight applications keep their pinned version
+ * (ADR-0212 D3), a new version never rewrites history.
+ */
+class CompliancePackRegistry {
+
+    private val active: AtomicReference<Map<PackKey, List<CompiledCompliancePack>>> =
+        AtomicReference(emptyMap())
+
+    /**
+     * Activates the pack carried by an APPROVED four-eyes [proposal]. Rejects:
+     * a non-approved proposal, maker == checker (belt-and-braces behind MakerChecker),
+     * and re-activation of the exact same (key, version) — a version, once activated,
+     * is immutable history.
+     */
+    fun activate(proposal: Proposal<CompiledCompliancePack>): CompiledCompliancePack {
+        if (proposal.state != ProposalState.APPROVED && proposal.state != ProposalState.EXECUTED) {
+            fail("pack activation requires an APPROVED four-eyes proposal, got ${proposal.state}")
+        }
+        if (proposal.decidedBy == null || proposal.decidedBy == proposal.proposedBy) {
+            fail("maker and checker must differ (four-eyes)")
+        }
+        val compiled = proposal.action
+        val key = compiled.key
+        active.getAndUpdate { current ->
+            val versions = current[key].orEmpty()
+            if (versions.any { it.pack.version == compiled.pack.version }) {
+                fail("pack ${key.jurisdiction}/${key.productType} v${compiled.pack.version} is already activated")
+            }
+            current + (key to (versions + compiled).sortedBy { it.pack.version })
+        }
+        return compiled
+    }
+
+    private fun fail(message: String): Nothing = throw PackActivationException(message)
+
+    /**
+     * The pack version effective at [asOf] for (jurisdiction, productType), or null —
+     * fail-closed: the service rejects origination when this returns null
+     * (ADR-0212 D2: no active pack, no origination).
+     */
+    fun activePack(key: PackKey, asOf: LocalDate): CompiledCompliancePack? = active.get()[key].orEmpty()
+        .filter { it.pack.isEffectiveOn(asOf) }
+        .maxByOrNull { it.pack.version }
+
+    /** Convenience overload for call sites that have the raw pair. */
+    fun activePack(jurisdiction: String, productType: PackProductType, asOf: LocalDate): CompiledCompliancePack? =
+        activePack(PackKey(jurisdiction, productType), asOf)
+
+    /** All packs effective at [asOf] — for the admin surface and bootstrap checks. */
+    fun allActive(asOf: LocalDate): List<CompiledCompliancePack> =
+        active.get().values.flatten().filter { it.pack.isEffectiveOn(asOf) }
+}

--- a/openbank-libs-domain/src/test/kotlin/com/openbank/libs/lending/compliance/CompliancePackParserTest.kt
+++ b/openbank-libs-domain/src/test/kotlin/com/openbank/libs/lending/compliance/CompliancePackParserTest.kt
@@ -1,0 +1,184 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright (c) OpenBank contributors. Licensed under the Apache License, Version 2.0.
+// See LICENSE in the repository root or https://www.apache.org/licenses/LICENSE-2.0 for details.
+
+package com.openbank.libs.lending.compliance
+
+import org.assertj.core.api.Assertions.assertThat
+import org.assertj.core.api.Assertions.assertThatThrownBy
+import org.junit.jupiter.api.Test
+import java.math.BigDecimal
+import java.time.LocalDate
+
+/** Covers ADR-0212 D2: strict fail-closed parsing and compile-time validation. */
+class CompliancePackParserTest {
+
+    private val czPackJson = """
+        {
+          "jurisdiction": "CZ",
+          "productType": "CONSUMER_CREDIT",
+          "version": 1,
+          "effectiveFrom": "2026-08-01",
+          "coolingOffDays": 14,
+          "aprDisclosure": { "label": "RPSN", "locale": "cs-CZ" },
+          "earlyRepaymentCompensationCap": "0.01",
+          "requiredSteps": ["DOCS_REQUIRED"],
+          "terminationRules": {
+            "noticePeriodDays": 30,
+            "permittedGrounds": ["DEFAULT_DPD", "MATERIAL_BREACH"],
+            "defaultDpdThreshold": 90
+          },
+          "disclosures": [
+            {
+              "id": "secci",
+              "templateKey": "cz/secci-v1",
+              "languages": ["cs", "en"],
+              "requiresAcknowledgement": true,
+              "stage": "PRE_CONTRACTUAL"
+            }
+          ],
+          "mandatoryChecks": [
+            {
+              "id": "cz-dsti-cap",
+              "attribute": "DSTI",
+              "operator": "LTE",
+              "threshold": 0.45,
+              "detail": "statutory DSTI cap"
+            }
+          ]
+        }
+    """.trimIndent()
+
+    @Test
+    fun `valid CZ pack parses with all fields`() {
+        val pack = CompliancePackParser.fromJson(czPackJson)
+
+        assertThat(pack.jurisdiction).isEqualTo("CZ")
+        assertThat(pack.productType).isEqualTo(PackProductType.CONSUMER_CREDIT)
+        assertThat(pack.coolingOffDays).isEqualTo(14)
+        assertThat(pack.aprDisclosure).isEqualTo(AprDisclosure("RPSN", "cs-CZ"))
+        assertThat(pack.earlyRepaymentCompensationCap).isEqualByComparingTo(BigDecimal("0.01"))
+        assertThat(pack.terminationRules.defaultDpdThreshold).isEqualTo(90)
+        assertThat(pack.disclosures.single().requiresAcknowledgement).isTrue()
+        assertThat(pack.mandatoryChecks.single().threshold).isEqualByComparingTo(BigDecimal("0.45"))
+    }
+
+    @Test
+    fun `unknown key rejects the whole pack (closed schema)`() {
+        val json = czPackJson.replace("\"coolingOffDays\": 14,", "\"coolingOffDays\": 14, \"surprise\": true,")
+
+        assertThatThrownBy { CompliancePackParser.fromJson(json) }
+            .isInstanceOf(CompliancePackParseException::class.java)
+            .hasMessageContaining("unknown key 'surprise'")
+    }
+
+    @Test
+    fun `unknown enum value rejects with the allowed set in the message`() {
+        val json = czPackJson.replace("\"CONSUMER_CREDIT\"", "\"PAYDAY_LOAN\"")
+
+        assertThatThrownBy { CompliancePackParser.fromJson(json) }
+            .isInstanceOf(CompliancePackParseException::class.java)
+            .hasMessageContaining("PAYDAY_LOAN")
+    }
+
+    @Test
+    fun `missing mandatory key rejects`() {
+        val json = czPackJson.replace("\"coolingOffDays\": 14,", "")
+
+        assertThatThrownBy { CompliancePackParser.fromJson(json) }
+            .isInstanceOf(CompliancePackParseException::class.java)
+            .hasMessageContaining("coolingOffDays")
+    }
+
+    @Test
+    fun `unknown origination state in requiredSteps rejects`() {
+        val json = czPackJson.replace("\"DOCS_REQUIRED\"", "\"NOT_A_STATE\"")
+
+        assertThatThrownBy { CompliancePackParser.fromJson(json) }
+            .isInstanceOf(CompliancePackParseException::class.java)
+            .hasMessageContaining("NOT_A_STATE")
+    }
+
+    @Test
+    fun `unknown policy attribute in mandatoryChecks rejects`() {
+        val json = czPackJson.replace("\"DSTI\"", "\"CREDIT_SCORE_VIBE\"")
+
+        assertThatThrownBy { CompliancePackParser.fromJson(json) }
+            .isInstanceOf(CompliancePackParseException::class.java)
+            .hasMessageContaining("CREDIT_SCORE_VIBE")
+    }
+
+    @Test
+    fun `compiler rejects mandatory REFLECTION_PERIOD without its duration`() {
+        val pack = CompliancePackParser.fromJson(
+            czPackJson.replace(
+                "\"requiredSteps\": [\"DOCS_REQUIRED\"]",
+                "\"requiredSteps\": [\"REFLECTION_PERIOD\"]",
+            ),
+        )
+
+        assertThatThrownBy { CompliancePackCompiler.compile(pack) }
+            .isInstanceOf(CompliancePackValidationException::class.java)
+            .hasMessageContaining("reflectionPeriodDays")
+    }
+
+    @Test
+    fun `compiler rejects compensation cap outside zero to one`() {
+        val pack = CompliancePackParser.fromJson(czPackJson.replace("\"0.01\"", "1.5"))
+
+        assertThatThrownBy { CompliancePackCompiler.compile(pack) }
+            .isInstanceOf(CompliancePackValidationException::class.java)
+            .hasMessageContaining("[0, 1]")
+    }
+
+    @Test
+    fun `compiler rejects duplicate disclosure ids`() {
+        val pack = CompliancePackParser.fromJson(czPackJson).copy(
+            disclosures = listOf(
+                PackDisclosure("secci", "cz/secci-v1", setOf("cs"), true, DisclosureStage.PRE_CONTRACTUAL),
+                PackDisclosure("secci", "cz/other-v1", setOf("cs"), false, DisclosureStage.CONTRACTUAL),
+            ),
+        )
+
+        assertThatThrownBy { CompliancePackCompiler.compile(pack) }
+            .isInstanceOf(CompliancePackValidationException::class.java)
+            .hasMessageContaining("duplicate disclosure id")
+    }
+
+    @Test
+    fun `compiler rejects DPD threshold beyond CRR bounds`() {
+        val json = czPackJson.replace("\"defaultDpdThreshold\": 90", "\"defaultDpdThreshold\": 400")
+
+        assertThatThrownBy { CompliancePackCompiler.compile(CompliancePackParser.fromJson(json)) }
+            .isInstanceOf(CompliancePackValidationException::class.java)
+            .hasMessageContaining("1..180")
+    }
+
+    @Test
+    fun `compiled pack carries a deterministic content hash and disclosure lookup`() {
+        val first = CompliancePackCompiler.compile(CompliancePackParser.fromJson(czPackJson))
+        val second = CompliancePackCompiler.compile(CompliancePackParser.fromJson(czPackJson))
+
+        assertThat(first.contentHash).isEqualTo(second.contentHash).hasSize(64)
+        assertThat(first.disclosureById["secci"]?.templateKey).isEqualTo("cz/secci-v1")
+    }
+
+    @Test
+    fun `content hash changes with pack content`() {
+        val base = CompliancePackCompiler.compile(CompliancePackParser.fromJson(czPackJson))
+        val other = CompliancePackCompiler.compile(
+            CompliancePackParser.fromJson(czPackJson.replace("\"coolingOffDays\": 14", "\"coolingOffDays\": 15")),
+        )
+
+        assertThat(base.contentHash).isNotEqualTo(other.contentHash)
+    }
+
+    @Test
+    fun `effectiveness window honours effectiveFrom and effectiveTo`() {
+        val pack = CompliancePackParser.fromJson(czPackJson).copy(effectiveTo = LocalDate.parse("2027-01-01"))
+
+        assertThat(pack.isEffectiveOn(LocalDate.parse("2026-07-31"))).isFalse()
+        assertThat(pack.isEffectiveOn(LocalDate.parse("2026-08-01"))).isTrue()
+        assertThat(pack.isEffectiveOn(LocalDate.parse("2027-01-01"))).isFalse()
+    }
+}

--- a/openbank-libs-domain/src/test/kotlin/com/openbank/libs/lending/compliance/CompliancePackRegistryTest.kt
+++ b/openbank-libs-domain/src/test/kotlin/com/openbank/libs/lending/compliance/CompliancePackRegistryTest.kt
@@ -1,0 +1,145 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright (c) OpenBank contributors. Licensed under the Apache License, Version 2.0.
+// See LICENSE in the repository root or https://www.apache.org/licenses/LICENSE-2.0 for details.
+
+package com.openbank.libs.lending.compliance
+
+import com.openbank.libs.governance.MakerCheckerViolation
+import com.openbank.libs.governance.Proposal
+import com.openbank.libs.lending.origination.OriginationState
+import org.assertj.core.api.Assertions.assertThat
+import org.assertj.core.api.Assertions.assertThatThrownBy
+import org.junit.jupiter.api.Test
+import java.time.Instant
+import java.time.LocalDate
+
+/** Covers ADR-0212 D3/D4: four-eyes activation, immutable versions, effective-dated lookup. */
+class CompliancePackRegistryTest {
+
+    private val now: Instant = Instant.parse("2026-07-29T12:00:00Z")
+
+    private fun pack(version: Int, effectiveFrom: String = "2026-08-01"): CompiledCompliancePack =
+        CompliancePackCompiler.compile(
+            CompliancePack(
+                jurisdiction = "CZ",
+                productType = PackProductType.CONSUMER_CREDIT,
+                version = version,
+                effectiveFrom = LocalDate.parse(effectiveFrom),
+                coolingOffDays = 14,
+                aprDisclosure = AprDisclosure("RPSN", "cs-CZ"),
+                terminationRules = TerminationRules(
+                    noticePeriodDays = 30,
+                    permittedGrounds = setOf(TerminationGround.DEFAULT_DPD),
+                ),
+            ),
+        )
+
+    private fun approvedProposal(
+        compiled: CompiledCompliancePack,
+        maker: String = "compliance-officer-1",
+        checker: String = "compliance-officer-2",
+    ): Proposal<CompiledCompliancePack> = Proposal(
+        id = "prop-${compiled.pack.version}",
+        action = compiled,
+        proposedBy = maker,
+        proposedAt = now,
+    ).approve(checker, now.plusSeconds(60), "reviewed against legal opinion")
+
+    @Test
+    fun `approved four-eyes proposal activates the pack`() {
+        val registry = CompliancePackRegistry()
+        registry.activate(approvedProposal(pack(1)))
+
+        val active = registry.activePack("CZ", PackProductType.CONSUMER_CREDIT, LocalDate.parse("2026-08-15"))
+        assertThat(active).isNotNull
+        assertThat(active!!.pack.version).isEqualTo(1)
+    }
+
+    @Test
+    fun `pending proposal cannot activate`() {
+        val registry = CompliancePackRegistry()
+        val pending = Proposal(id = "p1", action = pack(1), proposedBy = "maker-1", proposedAt = now)
+
+        assertThatThrownBy { registry.activate(pending) }
+            .isInstanceOf(PackActivationException::class.java)
+            .hasMessageContaining("APPROVED")
+    }
+
+    @Test
+    fun `maker-checker state machine refuses self-approval before the registry is consulted`() {
+        val pending = Proposal(id = "p2", action = pack(1), proposedBy = "same-person", proposedAt = now)
+
+        assertThatThrownBy { pending.approve("same-person", now) }
+            .isInstanceOf(MakerCheckerViolation::class.java)
+    }
+
+    @Test
+    fun `re-activating the same version is refused — activated versions are immutable history`() {
+        val registry = CompliancePackRegistry()
+        registry.activate(approvedProposal(pack(1)))
+
+        assertThatThrownBy { registry.activate(approvedProposal(pack(1))) }
+            .isInstanceOf(PackActivationException::class.java)
+            .hasMessageContaining("already activated")
+    }
+
+    @Test
+    fun `lookup resolves the version effective at the date — in-flight pins are stable`() {
+        val registry = CompliancePackRegistry()
+        registry.activate(approvedProposal(pack(1, effectiveFrom = "2026-08-01")))
+        registry.activate(approvedProposal(pack(2, effectiveFrom = "2026-09-01")))
+
+        val before = registry.activePack("CZ", PackProductType.CONSUMER_CREDIT, LocalDate.parse("2026-08-15"))
+        val after = registry.activePack("CZ", PackProductType.CONSUMER_CREDIT, LocalDate.parse("2026-09-15"))
+        val tooEarly = registry.activePack("CZ", PackProductType.CONSUMER_CREDIT, LocalDate.parse("2026-07-15"))
+
+        assertThat(before!!.pack.version).isEqualTo(1)
+        assertThat(after!!.pack.version).isEqualTo(2)
+        assertThat(tooEarly).isNull()
+    }
+
+    @Test
+    fun `no active pack returns null — the service fails closed`() {
+        val registry = CompliancePackRegistry()
+
+        assertThat(registry.activePack("DE", PackProductType.CONSUMER_CREDIT, LocalDate.parse("2026-08-15")))
+            .isNull()
+        assertThat(registry.allActive(LocalDate.parse("2026-08-15"))).isEmpty()
+    }
+
+    @Test
+    fun `evaluator exposes mandatory steps, disclosures and mandatory checks from the pinned pack`() {
+        val compiled = CompliancePackCompiler.compile(
+            CompliancePackParser.fromJson(
+                """
+                {
+                  "jurisdiction": "CZ",
+                  "productType": "CONSUMER_CREDIT",
+                  "version": 1,
+                  "effectiveFrom": "2026-08-01",
+                  "coolingOffDays": 14,
+                  "aprDisclosure": { "label": "RPSN", "locale": "cs-CZ" },
+                  "requiredSteps": ["DOCS_REQUIRED"],
+                  "terminationRules": { "noticePeriodDays": 30, "permittedGrounds": ["DEFAULT_DPD"] },
+                  "disclosures": [
+                    { "id": "secci", "templateKey": "cz/secci-v1", "languages": ["cs"], "stage": "PRE_CONTRACTUAL" },
+                    { "id": "contract", "templateKey": "cz/contract-v1", "languages": ["cs"], "stage": "CONTRACTUAL" }
+                  ],
+                  "mandatoryChecks": [
+                    { "id": "cz-dsti-cap", "attribute": "DSTI", "operator": "LTE", "threshold": 0.45 }
+                  ]
+                }
+                """.trimIndent(),
+            ),
+        )
+
+        assertThat(CompliancePackEvaluator.mandatorySteps(compiled))
+            .containsExactly(OriginationState.DOCS_REQUIRED)
+        assertThat(CompliancePackEvaluator.disclosuresFor(compiled, DisclosureStage.PRE_CONTRACTUAL).map { it.id })
+            .containsExactly("secci")
+        assertThat(CompliancePackEvaluator.mandatoryEligibilityRules(compiled).map { it.id })
+            .containsExactly("cz-dsti-cap")
+        assertThat(CompliancePackEvaluator.coolingOffDays(compiled)).isEqualTo(14)
+        assertThat(CompliancePackEvaluator.terminationRules(compiled).defaultDpdThreshold).isEqualTo(90)
+    }
+}


### PR DESCRIPTION
## Summary

Second implementation slice of the credit platform suite: ADR-0212 jurisdictional compliance packs as pure primitives in `openbank-libs-domain` — the closed pack schema, a strict fail-closed parser, compile-at-activation into immutable in-memory form (ADR-0218 D3), and a four-eyes activation registry. Follows #2747 (ADR-0211/0213 primitives).

## Type of change

- [x] feat (new functionality)
- [ ] fix (bug fix)
- [ ] refactor (no behavior change)
- [ ] perf (performance)
- [ ] docs
- [ ] chore (build / tooling)
- [ ] security (private until disclosed)
- [ ] breaking change

## Linked issues

Refs ADR-0212 (suite merged in #2711).

## Changes

**`com.openbank.libs.lending.compliance`**
- `CompliancePack` — closed schema per ADR-0212 D1: `requiredSteps` (only the graph's optional states), `coolingOffDays`, `reflectionPeriodDays`, `aprDisclosure` (label + locale, **never the math** — single APRC formula), `earlyRepaymentCompensationCap` ∈ [0,1], `terminationRules` (notice, grounds, CRR-178 DPD threshold 1..180), `disclosures`, `mandatoryChecks` as ADR-0213 `PolicyRule`s.
- `CompliancePackParser` — strict decoder (`fromMap` + `fromJson`): unknown key / unknown enum / wrong type / missing mandatory field rejects the **whole** pack; mandatoryChecks decode validated against the closed `PolicyAttribute`/`PolicyOperator` vocabulary.
- `CompliancePackCompiler` + `CompiledCompliancePack` — compile-at-activation: ~15 fail-closed invariants (REFLECTION_PERIOD requires duration, cap bounds, DPD bounds, duplicate disclosure/rule ids, blank template keys, empty languages), then immutable + canonical **SHA-256 content hash** for ADR-0214 evidence pinning.
- `CompliancePackRegistry` — the only way in is an APPROVED `Proposal` from the existing MakerChecker state machine (maker ≠ checker re-asserted registry-side); activated versions are **immutable history** (re-activation refused); `AtomicReference` swap, lock-free readers; `activePack(key, asOf)` resolves the version effective at the date and **returns null = fail closed** (no pack, no origination); no Flyway, no service release per pack (ADR-0212 D4).
- `CompliancePackEvaluator` — D5 read-side queries: mandatory steps, disclosures by stage, mandatory eligibility rules for the ADR-0213 bundle, cooling-off, termination rules.

## Definition of Done

- [x] Hexagonal layering preserved (domain has zero framework imports).
- [x] Unit tests added/updated. (19 tests: full parse, every fail-closed path, compiler invariants, hash determinism, four-eyes activation, version immutability, effective-dating, evaluator queries)
- [ ] Integration tests added/updated (if service boundary involved). — N/A (pure libs)
- [ ] Contract tests updated (if public API changed). — N/A
- [x] `./gradlew detekt ktlintCheck koverVerify build` passes. (all green for `:openbank-libs-domain`)
- [x] No new lint warnings.
- [ ] OpenAPI spec regenerated (if REST API changed). — N/A
- [ ] Flyway migration added + rollback note (if DB changed). — N/A
- [ ] Avro schema versioned backward-compatibly (if event changed). — N/A
- [x] Docs updated (README, ADR if architectural). — ADR-0212 already merged (#2711)

## Security checklist

- [x] No secrets, tokens, passwords, or PII in code, config, tests, logs.
- [x] No new `@SuppressWarnings`, `as Any`, `@Suppress("...")` without justification (state it in this PR). (two `@Suppress("UNCHECKED_CAST")` on the JSON decode casts — Jackson `readValue<Map>` boundary, values are re-validated per key immediately after)
- [x] No new third-party dependency, OR: dependency review attached (license, CVE, source). (uses existing `jackson-module-kotlin` already an api dep of libs-domain)
- [ ] Auth / crypto / payment code changed? → tag `security-review-required`.
- [ ] PII path changed? → tag `gdpr-review-required`.
- [ ] Cardholder data path changed? → tag `pci-review-required`.

## Compliance impact

- [ ] PCI DSS
- [ ] DORA
- [ ] GDPR
- [ ] PSD2 / SCA / RTS
- [ ] AML / 5AMLD
- [x] CNB reporting
- [ ] None

Primitives only — no consumer wired yet. The pack is the CZ consumer-credit law (257/2016 Sb.) / CCD2 execution surface; four-eyes activation + fail-closed validation are the compliance controls. Money-path gate applies at service wiring.

## Rollout / Rollback

- Deployment strategy: N/A (library code, no consumers yet)
- Rollback plan: revert this PR
- Data migration reversible: N/A

## Reviewer notes

Design decisions: (1) activation accepts `ProposalState.APPROVED` **or** `EXECUTED` — services that persist proposals through the foureyes port mark executed after applying; (2) `optDecimal` accepts both JSON numbers and numeric strings — pack authoring reality is YAML/JSON where `0.01` often lands quoted, and a strict-Number parser would reject valid packs for a formatting accident (the value is still validated for range at compile time); (3) `requiredSteps` is restricted to the origination graph's two genuinely optional states (DOCS_REQUIRED, REFLECTION_PERIOD) — everything else would be a graph change, not data. Follow-ups: CZ reference pack JSON + bootstrap flag (ADR-0212 D4 bootstrap), lending-service wiring.