### PR TITLE
feat(libs): settlement quote and withdrawal interest primitives (ADR-0215)

### DIFF
--- a/openbank-libs-domain/src/main/kotlin/com/openbank/libs/lending/Settlement.kt
+++ b/openbank-libs-domain/src/main/kotlin/com/openbank/libs/lending/Settlement.kt
@@ -1,0 +1,129 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright (c) OpenBank contributors. Licensed under the Apache License, Version 2.0.
+// See LICENSE in the repository root or https://www.apache.org/licenses/LICENSE-2.0 for details.
+
+package com.openbank.libs.lending
+
+import com.openbank.libs.domain.money.Money
+import java.math.BigDecimal
+import java.math.RoundingMode
+import java.time.LocalDate
+import java.time.temporal.ChronoUnit
+
+/**
+ * A binding early-repayment quote (ADR-0215 D2). Pure output of the schedule, the
+ * repayment position and the pinned compliance pack — the same inputs always produce
+ * the same number, which is what makes the most litigated figure in consumer credit
+ * examiner-auditable. [compensationCapped] records whether the contractual
+ * compensation had to be cut to the pack's legal cap (ADR-0212).
+ */
+data class SettlementQuote(
+    val asOfDate: LocalDate,
+    val validUntil: LocalDate,
+    val outstandingPrincipal: Money,
+    val accruedInterest: Money,
+    val compensation: Money,
+    val unappliedCredit: Money,
+    val total: Money,
+    val compensationCapped: Boolean,
+)
+
+/**
+ * Pure settlement and withdrawal math (ADR-0215 D2/D4). Day-count is ACT/365 fixed;
+ * money is rounded half-up to the currency's minor unit. No framework, no I/O — the
+ * service supplies the schedule (from [Amortization]), the repayment position and the
+ * pack's legal cap; the function never reads state.
+ */
+object Settlement {
+
+    private const val DAYS_IN_YEAR = 365L
+
+    /**
+     * @param paidThroughInstallment number of the last fully paid installment (0 = none yet)
+     * @param contractualCompensationRate the early-repayment compensation the contract asks
+     *        for, as a fraction of the outstanding principal (e.g. 0.01)
+     * @param legalCompensationCap the pinned pack's cap; null = no compensation permitted
+     * @param unappliedCredit overpayments not yet applied to the balance (subtracted)
+     */
+    fun quote(
+        schedule: RepaymentSchedule,
+        paidThroughInstallment: Int,
+        asOf: LocalDate,
+        contractualCompensationRate: BigDecimal,
+        legalCompensationCap: BigDecimal?,
+        unappliedCredit: Money? = null,
+        quoteValidityDays: Int = 30,
+    ): SettlementQuote {
+        require(paidThroughInstallment >= 0) { "paidThroughInstallment must be >= 0" }
+        val first = schedule.installments.first()
+        require(paidThroughInstallment < schedule.installments.size || !asOf.isAfter(first.dueDate)) {
+            "loan is fully settled by its schedule"
+        }
+
+        val outstanding = if (paidThroughInstallment == 0) {
+            first.openingBalance
+        } else {
+            schedule.balanceAfter(paidThroughInstallment)
+        }
+        val settledAt = if (paidThroughInstallment == 0) {
+            first.dueDate.minusMonths(MONTHS_PER_PERIOD / schedule.periodsPerYear)
+        } else {
+            schedule.installments.first { it.number == paidThroughInstallment }.dueDate
+        }
+
+        val accrued = dayInterest(outstanding, schedule.nominalAnnualRate, settledAt, asOf)
+        val compensation = compensation(outstanding, contractualCompensationRate, legalCompensationCap)
+        val credit = unappliedCredit ?: Money.zero(outstanding.currency.code)
+        val total = outstanding + accrued + compensation.amount - credit
+
+        return SettlementQuote(
+            asOfDate = asOf,
+            validUntil = asOf.plusDays(quoteValidityDays.toLong()),
+            outstandingPrincipal = outstanding,
+            accruedInterest = accrued,
+            compensation = compensation.amount,
+            unappliedCredit = credit,
+            total = total,
+            compensationCapped = compensation.capped,
+        )
+    }
+
+    /**
+     * Statutory day-interest owed on a statutory withdrawal (ADR-0215 D4): the customer
+     * returns the principal and pays interest only for the days the money was actually
+     * drawn — the contract is voided, not enforced.
+     */
+    fun withdrawalInterest(
+        principal: Money,
+        nominalAnnualRate: BigDecimal,
+        disbursedAt: LocalDate,
+        withdrawnAt: LocalDate,
+    ): Money = dayInterest(principal, nominalAnnualRate, disbursedAt, withdrawnAt)
+
+    private const val MONTHS_PER_PERIOD = 12L
+
+    private data class Compensation(val amount: Money, val capped: Boolean)
+
+    private fun compensation(outstanding: Money, contractualRate: BigDecimal, legalCap: BigDecimal?): Compensation {
+        if (legalCap == null || contractualRate <= BigDecimal.ZERO) {
+            return Compensation(Money.zero(outstanding.currency.code), capped = false)
+        }
+        val applied = minOf(contractualRate, legalCap)
+        return Compensation(scale(outstanding.amount * applied, outstanding), capped = applied < contractualRate)
+    }
+
+    private fun dayInterest(principal: Money, annualRate: BigDecimal, from: LocalDate, to: LocalDate): Money {
+        val days = ChronoUnit.DAYS.between(from, to).coerceAtLeast(0)
+        if (days == 0L || principal.isZero()) return Money.zero(principal.currency.code)
+        val raw = principal.amount
+            .multiply(annualRate)
+            .multiply(BigDecimal(days))
+            .divide(BigDecimal(DAYS_IN_YEAR), MC)
+        return scale(raw, principal)
+    }
+
+    private val MC = java.math.MathContext.DECIMAL128
+
+    private fun scale(amount: BigDecimal, like: Money): Money =
+        Money.of(amount.setScale(like.currency.defaultFractionDigits, RoundingMode.HALF_UP), like.currency.code)
+}

--- a/openbank-libs-domain/src/test/kotlin/com/openbank/libs/lending/SettlementTest.kt
+++ b/openbank-libs-domain/src/test/kotlin/com/openbank/libs/lending/SettlementTest.kt
@@ -1,0 +1,151 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright (c) OpenBank contributors. Licensed under the Apache License, Version 2.0.
+// See LICENSE in the repository root or https://www.apache.org/licenses/LICENSE-2.0 for details.
+
+package com.openbank.libs.lending
+
+import com.openbank.libs.domain.money.Money
+import org.assertj.core.api.Assertions.assertThat
+import org.assertj.core.api.Assertions.assertThatThrownBy
+import org.junit.jupiter.api.Test
+import java.math.BigDecimal
+import java.time.LocalDate
+
+/** Covers ADR-0215 D2/D4: deterministic settlement quotes and statutory withdrawal interest. */
+class SettlementTest {
+
+    private fun eur(v: String) = Money.of(v, "EUR")
+
+    private val schedule = Amortization.schedule(
+        principal = eur("12000.00"),
+        nominalAnnualRate = BigDecimal("0.12"),
+        termPeriods = 12,
+        firstDueDate = LocalDate.parse("2026-06-30"),
+    )
+
+    @Test
+    fun `quote after one paid installment reconciles principal, day interest and compensation`() {
+        val quote = Settlement.quote(
+            schedule = schedule,
+            paidThroughInstallment = 1,
+            asOf = LocalDate.parse("2026-07-15"),
+            contractualCompensationRate = BigDecimal("0.01"),
+            legalCompensationCap = BigDecimal("0.01"),
+        )
+
+        assertThat(quote.outstandingPrincipal).isEqualTo(eur("11053.81"))
+        assertThat(quote.accruedInterest).isEqualTo(eur("54.51"))
+        assertThat(quote.compensation).isEqualTo(eur("110.54"))
+        assertThat(quote.total).isEqualTo(eur("11218.86"))
+        assertThat(quote.compensationCapped).isFalse()
+        assertThat(quote.validUntil).isEqualTo(LocalDate.parse("2026-08-14"))
+    }
+
+    @Test
+    fun `quote before any repayment starts from the full principal`() {
+        val quote = Settlement.quote(
+            schedule = schedule,
+            paidThroughInstallment = 0,
+            asOf = LocalDate.parse("2026-06-14"),
+            contractualCompensationRate = BigDecimal("0.01"),
+            legalCompensationCap = BigDecimal("0.01"),
+        )
+
+        assertThat(quote.outstandingPrincipal).isEqualTo(eur("12000.00"))
+        assertThat(quote.accruedInterest).isEqualTo(eur("59.18"))
+    }
+
+    @Test
+    fun `quote on a due date carries zero accrued interest`() {
+        val quote = Settlement.quote(
+            schedule = schedule,
+            paidThroughInstallment = 1,
+            asOf = LocalDate.parse("2026-06-30"),
+            contractualCompensationRate = BigDecimal("0.01"),
+            legalCompensationCap = BigDecimal("0.01"),
+        )
+
+        assertThat(quote.accruedInterest.isZero()).isTrue()
+    }
+
+    @Test
+    fun `compensation above the pack cap is cut to the cap and marked capped`() {
+        val quote = Settlement.quote(
+            schedule = schedule,
+            paidThroughInstallment = 1,
+            asOf = LocalDate.parse("2026-06-30"),
+            contractualCompensationRate = BigDecimal("0.015"),
+            legalCompensationCap = BigDecimal("0.01"),
+        )
+
+        assertThat(quote.compensation).isEqualTo(eur("110.54"))
+        assertThat(quote.compensationCapped).isTrue()
+    }
+
+    @Test
+    fun `null pack cap means no compensation at all`() {
+        val quote = Settlement.quote(
+            schedule = schedule,
+            paidThroughInstallment = 1,
+            asOf = LocalDate.parse("2026-06-30"),
+            contractualCompensationRate = BigDecimal("0.01"),
+            legalCompensationCap = null,
+        )
+
+        assertThat(quote.compensation.isZero()).isTrue()
+    }
+
+    @Test
+    fun `unapplied overpayment reduces the settlement total`() {
+        val quote = Settlement.quote(
+            schedule = schedule,
+            paidThroughInstallment = 1,
+            asOf = LocalDate.parse("2026-06-30"),
+            contractualCompensationRate = BigDecimal.ZERO,
+            legalCompensationCap = null,
+            unappliedCredit = eur("500.00"),
+        )
+
+        assertThat(quote.total).isEqualTo(eur("10553.81"))
+    }
+
+    @Test
+    fun `withdrawal interest is the statutory day interest for the drawn period`() {
+        val interest = Settlement.withdrawalInterest(
+            principal = eur("12000.00"),
+            nominalAnnualRate = BigDecimal("0.12"),
+            disbursedAt = LocalDate.parse("2026-06-01"),
+            withdrawnAt = LocalDate.parse("2026-06-15"),
+        )
+
+        assertThat(interest).isEqualTo(eur("55.23"))
+    }
+
+    @Test
+    fun `same inputs always produce the same quote — the number is reproducible`() {
+        val first = Settlement.quote(schedule, 1, LocalDate.parse("2026-07-15"), BigDecimal("0.01"), BigDecimal("0.01"))
+        val second = Settlement.quote(
+            schedule,
+            1,
+            LocalDate.parse("2026-07-15"),
+            BigDecimal("0.01"),
+            BigDecimal("0.01"),
+        )
+
+        assertThat(first).isEqualTo(second)
+    }
+
+    @Test
+    fun `mixed currencies are refused, never silently converted`() {
+        assertThatThrownBy {
+            Settlement.quote(
+                schedule = schedule,
+                paidThroughInstallment = 1,
+                asOf = LocalDate.parse("2026-06-30"),
+                contractualCompensationRate = BigDecimal.ZERO,
+                legalCompensationCap = null,
+                unappliedCredit = Money.of("10.00", "CZK"),
+            )
+        }.isInstanceOf(IllegalArgumentException::class.java)
+    }
+}


### PR DESCRIPTION
## Summary

Third primitives slice of the credit platform suite: ADR-0215 D2/D4 — the payoff/settlement quote and statutory withdrawal interest as a pure, deterministic function in `openbank-libs-domain`. Completes the pure-domain layer of the credit platform (state machine #2747, decision engine #2747, compliance packs #2753, settlement math here) — everything left is service-side integration.

## Type of change

- [x] feat (new functionality)
- [ ] fix (bug fix)
- [ ] refactor (no behavior change)
- [ ] perf (performance)
- [ ] docs
- [ ] chore (build / tooling)
- [ ] security (private until disclosed)
- [ ] breaking change

## Linked issues

Refs ADR-0215 (suite merged in #2711).

## Changes

**`com.openbank.libs.lending.Settlement`**
- `quote(schedule, paidThroughInstallment, asOf, contractualCompensationRate, legalCompensationCap, unappliedCredit, quoteValidityDays)` → `SettlementQuote` = outstanding principal (from the `Amortization` schedule) + ACT/365 day interest from the last settled due date + early-repayment compensation **cut to the pinned pack's legal cap** (`compensationCapped` flag records the cut, ADR-0212) − unapplied overpayments; validity window on the quote.
- `withdrawalInterest(principal, rate, disbursedAt, withdrawnAt)` — statutory day interest for the drawn period when a contract is voided by withdrawal (ADR-0215 D4): the customer returns principal + day interest only.
- Reproducible by construction (same inputs ⇒ same number — the payoff quote is the most litigated figure in consumer credit); money rounded half-up to the currency minor unit; mixed currencies refused, never silently converted.

## Definition of Done

- [x] Hexagonal layering preserved (domain has zero framework imports).
- [x] Unit tests added/updated. (9 tests with exact expected figures: boundary due-date zero accrual, pre-first-installment quote, cap cut + flag, null cap = no compensation, overpayment credit, withdrawal day interest, reproducibility, currency mismatch refusal)
- [ ] Integration tests added/updated (if service boundary involved). — N/A (pure libs)
- [ ] Contract tests updated (if public API changed). — N/A
- [x] `./gradlew detekt ktlintCheck koverVerify build` passes. (all green for `:openbank-libs-domain`)
- [x] No new lint warnings.
- [ ] OpenAPI spec regenerated (if REST API changed). — N/A
- [ ] Flyway migration added + rollback note (if DB changed). — N/A
- [ ] Avro schema versioned backward-compatibly (if event changed). — N/A
- [x] Docs updated (README, ADR if architectural). — ADR-0215 already merged (#2711)

## Security checklist

- [x] No secrets, tokens, passwords, or PII in code, config, tests, logs.
- [x] No new `@SuppressWarnings`, `as Any`, `@Suppress("...")` without justification (state it in this PR).
- [x] No new third-party dependency, OR: dependency review attached (license, CVE, source).
- [ ] Auth / crypto / payment code changed? → tag `security-review-required`.
- [ ] PII path changed? → tag `gdpr-review-required`.
- [ ] Cardholder data path changed? → tag `pci-review-required`.

## Compliance impact

- [ ] PCI DSS
- [ ] DORA
- [ ] GDPR
- [ ] PSD2 / SCA / RTS
- [ ] AML / 5AMLD
- [x] CNB reporting
- [ ] None

Primitives only — no consumer wired yet. The quote semantics implement CCD2/257/2016 Sb. early-repayment compensation caps (via the pinned pack) and the statutory-withdrawal day interest. Money-path gate applies at service wiring.

## Rollout / Rollback

- Deployment strategy: N/A (library code, no consumers yet)
- Rollback plan: revert this PR
- Data migration reversible: N/A

## Reviewer notes

Design decisions: (1) accrual base for `paidThroughInstallment = 0` is derived as first-due-date minus one period (no extra disbursement-date input needed, period length comes from the schedule's `periodsPerYear`); (2) compensation applied = `min(contractual, pack cap)` with the cap sourced from the pinned pack at call time — the function takes numbers, the service takes the pack (keeps the primitive free of the pack model's evolution); (3) `quoteValidityDays` defaults 30. Follow-ups: CZ reference pack + bootstrap (ADR-0212), then lending-service wiring (money-path PR).