### PR TITLE
feat(infra): keycloak OBO audience client + admin-ui token-exchange permission (ADR-0224 D1)

### DIFF
--- a/openbank-infra/gitops/components/keycloak/realm-template.json
+++ b/openbank-infra/gitops/components/keycloak/realm-template.json
@@ -82,7 +82,15 @@
         "name": "ROLE_DEMO",
         "description": "Demo/guided-tour badge shown by the admin-UI (src/lib/auth/roles.ts). Existed in the live sandbox realm and in the docker dev realm but was missing here, so a cold-started cluster would not have it — added by the #2442 drift reconciliation"
       }
-    ]
+    ],
+    "client": {
+      "openbank-mcp-service": [
+        {
+          "name": "mcp-caller",
+          "description": "May call MCP tools via an OBO-exchanged token (ADR-0224). Assignment to staff is operational, not realm-managed"
+        }
+      ]
+    }
   },
   "clients": [
     {
@@ -100,7 +108,9 @@
       "webOrigins": [
         "https://__ADMIN_HOST__"
       ],
-      "attributes": {},
+      "attributes": {
+        "standard.token.exchange.enabled": "true"
+      },
       "defaultClientScopes": [
         "openid",
         "profile",
@@ -108,6 +118,55 @@
         "roles"
       ],
       "secret": "__ADMINUI_CLIENT_SECRET__"
+    },
+    {
+      "clientId": "openbank-mcp-service",
+      "name": "OpenBank MCP Service (OBO audience)",
+      "description": "Audience target for RFC 8693 OBO-exchanged staff tokens (ADR-0224). Token-exchange scope permission granted to openbank-admin-ui only (verified on Keycloak 26.6.3)",
+      "enabled": true,
+      "publicClient": false,
+      "standardFlowEnabled": false,
+      "directAccessGrantsEnabled": false,
+      "serviceAccountsEnabled": true,
+      "protocol": "openid-connect",
+      "bearerOnly": false,
+      "defaultClientScopes": [
+        "openid",
+        "profile",
+        "email",
+        "roles"
+      ],
+      "secret": "__MCP_OBO_CLIENT_SECRET__",
+      "authorizationSettings": {
+        "allowRemoteResourceManagement": false,
+        "policyEnforcementMode": "ENFORCING",
+        "scopes": [
+          {
+            "name": "token-exchange"
+          }
+        ],
+        "policies": [
+          {
+            "type": "client",
+            "logic": "POSITIVE",
+            "decisionStrategy": "UNANIMOUS",
+            "name": "requester-openbank-admin-ui",
+            "config": {
+              "clients": "[\"openbank-admin-ui\"]"
+            }
+          },
+          {
+            "type": "scope",
+            "logic": "POSITIVE",
+            "decisionStrategy": "UNANIMOUS",
+            "name": "token-exchange.openbank-mcp-service",
+            "config": {
+              "scopes": "[\"token-exchange\"]",
+              "applyPolicies": "[\"requester-openbank-admin-ui\"]"
+            }
+          }
+        ]
+      }
     },
     {
       "clientId": "openbank-services",

--- a/openbank-infra/scripts/check_realm_role_parity_test.py
+++ b/openbank-infra/scripts/check_realm_role_parity_test.py
@@ -28,7 +28,12 @@ BUILTINS = ["offline_access", "uma_authorization", "default-roles-openbank"]
 
 def declared_roles() -> list:
     doc = json.loads(TEMPLATE.read_text())
-    return sorted(r["name"] for r in doc["roles"]["realm"])
+    names = [r["name"] for r in doc["roles"]["realm"]]
+    # The detector flattens client roles into the same name set as realm roles — the synthetic
+    # live snapshot must do the same, or any client-role addition reads as declared-not-live.
+    for client_roles in (doc["roles"].get("client", {}) or {}).values():
+        names += [r["name"] for r in client_roles or []]
+    return sorted(names)
 
 
 def run(live_roles, realm="openbank", extra=()):


### PR DESCRIPTION
## Summary

First slice of **ADR-0224** (PR #2752) — the identity-plane foundation for the human-operator MCP channel, **verified end-to-end against a local Keycloak 26.6.3** (same version as the sandbox `openbank-keycloak:26.6.3-optimized`):

- New client **`openbank-mcp-service`** — audience target with the `token-exchange` scope permission granted to `openbank-admin-ui` **only** (client policy + scope permission in `authorizationSettings`).
- **`openbank-admin-ui`** gains `standard.token.exchange.enabled=true` (KC 26 requires it on the requesting client).
- Client role **`mcp-caller`** on the audience client (realm-level `roles.client`) — gates staff MCP access; assignment is operational.
- New secret placeholder `__MCP_OBO_CLIENT_SECRET__` (same provisioning pattern as the existing placeholders).

## Local verification transcript (docker `quay.io/keycloak/keycloak:26.6.3`, template imported 0 errors)

```
POST .../token (grant_type=token-exchange, client=openbank-admin-ui, audience=openbank-mcp-service)
→ EXCHANGE OK
  aud: openbank-mcp-service          (audience-restricted, ADR-0224 D1)
  azp: openbank-admin-ui             (actor identification; `act` chain fallback for phase 2)
  realm roles: [ROLE_OPERATOR]       (subject's roles carried)
  mcp roles:   [mcp-caller]          (audience resolution + MCP access gate)
  sid present: true                  (session binding, ADR-0226 correlation)
  ttl: 300 s                         (minutes, per ADR)
```

Negative path also observed during setup: a requester **without** the permission gets `access_denied` — the permission is what admits, not the client capability alone.

Iteration notes (why the config looks exactly like this): realm-JSON policy shape (`config` maps, not first-class fields), `type: "scope"` (not `scope-permission`), the `token-exchange` authorization scope must be declared, and KC user-profile requires firstName/lastName on the test user. Description capped at 255 chars (DB limit).

NOT in this slice (next PRs, per tracker #2750): mcp-service resolver accepting HUMAN OBO tokens behind `mcp.obo.enabled=false`; session issuance + live validation; the BFF embedded-console exchange call.

⚠️ Stacking note: `docs/adr-channel-authz-mcp` (#2752) is merged INTO this branch so the ADR-reference gate passes independently; the ADR files drop out of the diff once #2752 lands on main.

## Type of change

- [x] feat (gitops / identity config)

## Linked issues

Refs #2750

## Definition of Done

- [x] Template imports into a clean Keycloak 26.6.3 with 0 errors (was 4 iteration cycles to get here — the exact failure modes are documented above for the reviewer)
- [x] Exchange happy path + deny path verified locally
- [x] Minimal diff (61+/2−), no formatting churn on the rest of the file
- [x] No service code changed → no version bump; no openapi change
- [x] Commit signed (-s -S), conventional format