### PR TITLE
fix(notification): disable OIDC discovery in the test profile too

### DIFF
--- a/openbank-notification-service/src/main/resources/application.yaml
+++ b/openbank-notification-service/src/main/resources/application.yaml
@@ -203,10 +203,13 @@ authz:
     # No eager token fetch at test boot: the ADR-0198 D4 consent gate's M2M client
     # (oidc-client, client_credentials) otherwise creates OidcClientImpl eagerly at
     # startup and fails the boot with "OIDC Server is not available" on the CI
-    # runners, which have no Keycloak on localhost:8080. Lazy acquisition matches
-    # account-service's M2M clients in tests.
+    # runners, which have no Keycloak on localhost:8080. Discovery must ALSO be off —
+    # NotificationConsumer is a boot-time Kafka consumer, so its @RestClient injection
+    # creates OidcClientImpl at startup, and discovery is the call that connects.
     oidc-client:
       early-tokens-acquisition: false
+      discovery-enabled: false
+      token-path: /realms/openbank/protocol/openid-connect/token
     mailer:
       mock: true
     # Disable the @Scheduled outbox tick under test so the consumer IT never races


### PR DESCRIPTION
## Problém (dokončení #2746)

#2746 vypnul `early-tokens-acquisition`, ale `Failed to create OidcClientImpl` se vrátilo na notification-service (#2700 build). Mechanismus je hlubší:

`NotificationConsumer` je **boot-time Kafka consumer** → jeho `@Inject @RestClient ConsentServiceClient` vytvoří `OidcClientImpl` **při startupu** (ne až na první request), a `OidcClientImpl` dělá **OIDC discovery** při vytvoření → connection refused na localhost:8080 → boot failure. `early-tokens-acquisition: false` řeší jen eager token fetch, ne discovery.

## Fix

`%test` profil nově:
- `early-tokens-acquisition: false` (z #2746)
- `discovery-enabled: false` — žádný discovery call při vytvoření klienta
- `token-path: /realms/openbank/protocol/openid-connect/token` — explicitní cesta, aby grant fungoval i bez discovery

## Ověření

`:openbank-notification-service:test` — full suite BUILD SUCCESSFUL.
