### PR TITLE
feat(admin-ui): federated approval inbox — domain maker-checker queues on /approvals (ADR-0227 D2)

### DIFF
--- a/openbank-admin-ui/src/app/api/approvals/pending/route.ts
+++ b/openbank-admin-ui/src/app/api/approvals/pending/route.ts
@@ -15,6 +15,8 @@ import { svcUrl } from '@/lib/services/bff'
 
 export const dynamic = 'force-dynamic'
 
+type SourceState = 'ok' | 'forbidden' | 'unavailable'
+
 type InboxItem = {
   id: string
   domain: 'lending' | 'agent'
@@ -39,16 +41,32 @@ type AgentProposal = {
   proposedAt: string
 }
 
-async function lendingPending(headers: HeadersInit): Promise<InboxItem[]> {
+type SourceResult = { items: InboxItem[]; state: SourceState }
+
+/**
+ * A refused read must never render as an empty queue. lending's list is
+ * @RolesAllowed(LENDING_OFFICER, CREDIT_RISK, ADMIN) while /approvals itself is open to any
+ * authenticated operator, so 403 is the ORDINARY outcome for a supervisor or viewer - and
+ * "no approvals pending" is the most dangerous thing an approvals screen can say wrongly.
+ * The per-source state travels to the client, which shows it.
+ */
+function stateFor(status: number): SourceState {
+  return status === 401 || status === 403 ? 'forbidden' : 'unavailable'
+}
+
+async function lendingPending(headers: HeadersInit): Promise<SourceResult> {
   const res = await fetch(svcUrl('lending-service', '/api/v1/lending/approvals', { limit: '50' }), {
     headers, signal: AbortSignal.timeout(4000), cache: 'no-store',
   })
-  if (!res.ok) return []
+  if (!res.ok) return { items: [], state: stateFor(res.status) }
   const rows = (await res.json()) as LendingApproval[]
-  return rows.map(r => ({
-    id: r.id, domain: 'lending' as const, action: r.action,
-    resourceId: r.resourceId, maker: r.makerId, proposedAt: r.createdAt,
-  }))
+  return {
+    state: 'ok',
+    items: rows.map(r => ({
+      id: r.id, domain: 'lending' as const, action: r.action,
+      resourceId: r.resourceId, maker: r.makerId, proposedAt: r.createdAt,
+    })),
+  }
 }
 
 function agentBase(): string {
@@ -56,16 +74,19 @@ function agentBase(): string {
   return (process.env.AGENT_SERVICE_URL ?? 'http://localhost:8109/mcp').replace(/\/mcp$/, '')
 }
 
-async function agentPending(headers: HeadersInit): Promise<InboxItem[]> {
+async function agentPending(headers: HeadersInit): Promise<SourceResult> {
   const res = await fetch(`${agentBase()}/api/v1/proposals?state=proposed`, {
     headers, signal: AbortSignal.timeout(4000), cache: 'no-store',
   })
-  if (!res.ok) return []
+  if (!res.ok) return { items: [], state: stateFor(res.status) }
   const rows = (await res.json()) as AgentProposal[]
-  return rows.map(r => ({
-    id: r.id, domain: 'agent' as const, action: r.suggestedAction,
-    resourceId: null, maker: r.proposedBy, proposedAt: r.proposedAt,
-  }))
+  return {
+    state: 'ok',
+    items: rows.map(r => ({
+      id: r.id, domain: 'agent' as const, action: r.suggestedAction,
+      resourceId: null, maker: r.proposedBy, proposedAt: r.proposedAt,
+    })),
+  }
 }
 
 export async function GET() {
@@ -74,10 +95,12 @@ export async function GET() {
     return NextResponse.json({ error: 'unauthenticated' }, { status: 401 })
   }
   const headers = { authorization: `Bearer ${session.user.accessToken}` }
+  const unavailable: SourceResult = { items: [], state: 'unavailable' }
   const [lending, agent] = await Promise.all([
-    lendingPending(headers).catch(() => []),
-    agentPending(headers).catch(() => []),
+    lendingPending(headers).catch(() => unavailable),
+    agentPending(headers).catch(() => unavailable),
   ])
-  const items = [...lending, ...agent].sort((a, b) => (a.proposedAt ?? '').localeCompare(b.proposedAt ?? ''))
-  return NextResponse.json({ items })
+  const items = [...lending.items, ...agent.items]
+    .sort((a, b) => (a.proposedAt ?? '').localeCompare(b.proposedAt ?? ''))
+  return NextResponse.json({ items, sources: { lending: lending.state, agent: agent.state } })
 }

--- a/openbank-admin-ui/src/app/api/approvals/pending/route.ts
+++ b/openbank-admin-ui/src/app/api/approvals/pending/route.ts
@@ -1,0 +1,83 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright (c) OpenBank contributors. Licensed under the Apache License, Version 2.0.
+// See LICENSE in the repository root or https://www.apache.org/licenses/LICENSE-2.0 for details.
+
+// ADR-0227 D2 (phase 1): the federated approval inbox read. One BFF route merges each
+// domain's pending queue — lending's maker-checker approvals plus the agent plane's
+// proposals — into one canonical item shape for the /approvals screen. Read-only by
+// design: disposal happens in the governed per-domain decide flows (money-path disposal
+// additionally requires SCA, ADR-0227 D4 — that is the phase-2 design, deliberately NOT a
+// one-click button here).
+
+import { NextResponse } from 'next/server'
+import { auth } from '@/auth'
+import { svcUrl } from '@/lib/services/bff'
+
+export const dynamic = 'force-dynamic'
+
+type InboxItem = {
+  id: string
+  domain: 'lending' | 'agent'
+  action: string
+  resourceId: string | null
+  maker: string | null
+  proposedAt: string | null
+}
+
+type LendingApproval = {
+  id: string
+  action: string
+  resourceId: string | null
+  makerId: string | null
+  createdAt: string | null
+}
+
+type AgentProposal = {
+  id: string
+  suggestedAction: string
+  proposedBy: string
+  proposedAt: string
+}
+
+async function lendingPending(headers: HeadersInit): Promise<InboxItem[]> {
+  const res = await fetch(svcUrl('lending-service', '/api/v1/lending/approvals', { limit: '50' }), {
+    headers, signal: AbortSignal.timeout(4000), cache: 'no-store',
+  })
+  if (!res.ok) return []
+  const rows = (await res.json()) as LendingApproval[]
+  return rows.map(r => ({
+    id: r.id, domain: 'lending' as const, action: r.action,
+    resourceId: r.resourceId, maker: r.makerId, proposedAt: r.createdAt,
+  }))
+}
+
+function agentBase(): string {
+  if (process.env.SERVICES_HOST === 'container') return 'http://openbank-agent-service:8109'
+  return (process.env.AGENT_SERVICE_URL ?? 'http://localhost:8109/mcp').replace(/\/mcp$/, '')
+}
+
+async function agentPending(headers: HeadersInit): Promise<InboxItem[]> {
+  const res = await fetch(`${agentBase()}/api/v1/proposals?state=proposed`, {
+    headers, signal: AbortSignal.timeout(4000), cache: 'no-store',
+  })
+  if (!res.ok) return []
+  const rows = (await res.json()) as AgentProposal[]
+  return rows.map(r => ({
+    id: r.id, domain: 'agent' as const, action: r.suggestedAction,
+    resourceId: null, maker: r.proposedBy, proposedAt: r.proposedAt,
+  }))
+}
+
+export async function GET() {
+  const session = await auth()
+  if (!session?.user?.accessToken) {
+    return NextResponse.json({ error: 'unauthenticated' }, { status: 401 })
+  }
+  const headers = { authorization: `Bearer ${session.user.accessToken}` }
+  const [lending, agent] = await Promise.all([
+    lendingPending(headers).catch(() => []),
+    agentPending(headers).catch(() => []),
+  ])
+  const items = [...lending, ...agent].sort((a, b) => (a.proposedAt ?? '').localeCompare(b.proposedAt ?? ''))
+  return NextResponse.json({ items })
+}

--- a/openbank-admin-ui/src/app/approvals/page.tsx
+++ b/openbank-admin-ui/src/app/approvals/page.tsx
@@ -29,6 +29,15 @@ interface Proposal {
   modelId: string | null
 }
 
+interface InboxItem {
+  id: string
+  domain: 'lending' | 'agent'
+  action: string
+  resourceId: string | null
+  maker: string | null
+  proposedAt: string | null
+}
+
 const STATE_META: Record<string, { color: string; bg: string; border: string; Icon: React.ElementType; cs: string; en: string }> = {
   PROPOSED: { color: '#d97706', bg: '#fffbeb', border: '#fcd34d', Icon: Clock, cs: 'Čeká na rozhodnutí', en: 'Pending' },
   APPROVED: { color: '#059669', bg: '#ecfdf5', border: '#6ee7b7', Icon: CheckCircle2, cs: 'Schváleno', en: 'Approved' },
@@ -41,6 +50,7 @@ export default function ApprovalsPage() {
   const decidedBy = session?.user?.email || session?.user?.name || 'operator'
 
   const [rows, setRows] = useState<Proposal[]>([])
+  const [domainItems, setDomainItems] = useState<InboxItem[]>([])
   const [loading, setLoading] = useState(true)
   const [busyId, setBusyId] = useState<string | null>(null)
   const [reasons, setReasons] = useState<Record<string, string>>({})
@@ -49,9 +59,16 @@ export default function ApprovalsPage() {
   const load = useCallback(async () => {
     setLoading(true)
     try {
-      const res = await fetch('/api/agent/proposals?state=all', { cache: 'no-store' })
-      const data = await res.json()
+      const [proposalsRes, inboxRes] = await Promise.all([
+        fetch('/api/agent/proposals?state=all', { cache: 'no-store' }),
+        fetch('/api/approvals/pending', { cache: 'no-store' }),
+      ])
+      const data = await proposalsRes.json()
       setRows(Array.isArray(data) ? data : [])
+      if (inboxRes.ok) {
+        const inbox = await inboxRes.json()
+        setDomainItems(Array.isArray(inbox.items) ? inbox.items : [])
+      }
       setError(null)
     } catch {
       setError('unreachable')
@@ -117,8 +134,42 @@ export default function ApprovalsPage() {
         </div>
       )}
 
+      {/* ADR-0227 D2/D4: domain maker-checker queues, federated. Read-only here — disposal
+          belongs to the governed per-domain flows (money-path adds SCA). */}
       <div style={{ fontSize: 12, fontWeight: 700, textTransform: 'uppercase', letterSpacing: '0.05em', color: 'var(--text-secondary)', margin: '4px 0 10px' }}>
-        {t('Čeká na rozhodnutí', 'Pending')} ({pending.length})
+        {t('Doménová schvalování (money-path)', 'Domain approvals (money-path)')} ({domainItems.filter(i => i.domain !== 'agent').length})
+      </div>
+      {!loading && domainItems.filter(i => i.domain !== 'agent').length === 0 && (
+        <div className="card" style={{ padding: 16, marginBottom: 16, color: 'var(--text-secondary)', fontSize: 13 }}>
+          {t('Žádná doménová schvalování nečekají.', 'No domain approvals pending.')}
+        </div>
+      )}
+      <div style={{ display: 'grid', gap: 10, marginBottom: 24 }}>
+        {domainItems.filter(i => i.domain !== 'agent').map(item => (
+          <div key={`${item.domain}:${item.id}`} className="card" style={{ padding: 14, display: 'flex', alignItems: 'center', gap: 12 }}>
+            <span style={{
+              fontSize: 10, fontWeight: 800, padding: '2px 8px', borderRadius: 10, textTransform: 'uppercase',
+              color: '#1d4ed8', background: '#eff6ff', border: '1px solid #bfdbfe', flexShrink: 0,
+            }}>
+              {item.domain}
+            </span>
+            <div style={{ flex: 1, minWidth: 0 }}>
+              <div style={{ fontSize: 13, fontWeight: 700, color: 'var(--text-primary)', fontFamily: 'var(--font-mono)' }}>{item.action}</div>
+              <div style={{ fontSize: 11, color: 'var(--text-tertiary)', marginTop: 2 }}>
+                {item.resourceId && <span style={{ fontFamily: 'var(--font-mono)' }}>{item.resourceId} · </span>}
+                {item.maker && <span>{t('navrhl', 'by')} {item.maker}</span>}
+                {item.proposedAt && <span> · {new Date(item.proposedAt).toLocaleString()}</span>}
+              </div>
+            </div>
+            <span style={{ fontSize: 10, fontWeight: 700, color: '#d97706', background: '#fffbeb', border: '1px solid #fcd34d', padding: '2px 7px', borderRadius: 20, textTransform: 'uppercase', flexShrink: 0 }}>
+              {t('Čeká', 'Pending')}
+            </span>
+          </div>
+        ))}
+      </div>
+
+      <div style={{ fontSize: 12, fontWeight: 700, textTransform: 'uppercase', letterSpacing: '0.05em', color: 'var(--text-secondary)', margin: '4px 0 10px' }}>
+        {t('Čeká na rozhodnutí (AI agent)', 'Pending (AI agent)')} ({pending.length})
       </div>
       {!loading && pending.length === 0 && (
         <div className="card" style={{ padding: 20, color: 'var(--text-secondary)', fontSize: 13 }}>

--- a/openbank-admin-ui/src/app/approvals/page.tsx
+++ b/openbank-admin-ui/src/app/approvals/page.tsx
@@ -51,6 +51,7 @@ export default function ApprovalsPage() {
 
   const [rows, setRows] = useState<Proposal[]>([])
   const [domainItems, setDomainItems] = useState<InboxItem[]>([])
+  const [domainSources, setDomainSources] = useState<Record<string, string>>({})
   const [loading, setLoading] = useState(true)
   const [busyId, setBusyId] = useState<string | null>(null)
   const [reasons, setReasons] = useState<Record<string, string>>({})
@@ -68,6 +69,7 @@ export default function ApprovalsPage() {
       if (inboxRes.ok) {
         const inbox = await inboxRes.json()
         setDomainItems(Array.isArray(inbox.items) ? inbox.items : [])
+        setDomainSources(inbox.sources ?? {})
       }
       setError(null)
     } catch {
@@ -103,6 +105,12 @@ export default function ApprovalsPage() {
 
   const pending = useMemo(() => rows.filter(r => r.state === 'PROPOSED'), [rows])
   const decided = useMemo(() => rows.filter(r => r.state !== 'PROPOSED'), [rows])
+  // Sources that answered anything other than 200 — a 403 here is ordinary (lending's list is
+  // desk-role gated while this page is not), and it must never look like an empty queue.
+  const degradedSources = useMemo(
+    () => Object.entries(domainSources).filter(([, v]) => v !== 'ok').map(([k]) => k),
+    [domainSources],
+  )
 
   return (
     <div>
@@ -139,7 +147,18 @@ export default function ApprovalsPage() {
       <div style={{ fontSize: 12, fontWeight: 700, textTransform: 'uppercase', letterSpacing: '0.05em', color: 'var(--text-secondary)', margin: '4px 0 10px' }}>
         {t('Doménová schvalování (money-path)', 'Domain approvals (money-path)')} ({domainItems.filter(i => i.domain !== 'agent').length})
       </div>
-      {!loading && domainItems.filter(i => i.domain !== 'agent').length === 0 && (
+      {degradedSources.length > 0 && (
+        <div className="card" style={{
+          padding: 14, marginBottom: 16, fontSize: 13,
+          color: '#92400e', background: '#fffbeb', border: '1px solid #fcd34d',
+        }}>
+          {t(
+            `Fronta není úplná — nepodařilo se načíst: ${degradedSources.join(', ')}. Prázdný seznam neznamená, že nic nečeká.`,
+            `This queue is incomplete — could not read: ${degradedSources.join(', ')}. An empty list does not mean nothing is pending.`,
+          )}
+        </div>
+      )}
+      {!loading && degradedSources.length === 0 && domainItems.filter(i => i.domain !== 'agent').length === 0 && (
         <div className="card" style={{ padding: 16, marginBottom: 16, color: 'var(--text-secondary)', fontSize: 13 }}>
           {t('Žádná doménová schvalování nečekají.', 'No domain approvals pending.')}
         </div>

--- a/openbank-admin-ui/src/test/approvals-inbox.test.ts
+++ b/openbank-admin-ui/src/test/approvals-inbox.test.ts
@@ -69,4 +69,38 @@ describe('federated approvals inbox (ADR-0227 D2)', () => {
     expect(body.items).toHaveLength(1)
     expect(body.items[0].domain).toBe('agent')
   })
+
+
+  it('reports a refused source instead of an empty queue — 403 is ordinary for a non-desk role', async () => {
+    const mock = vi.fn().mockImplementation((url: string) =>
+      Promise.resolve(
+        String(url).includes('lending')
+          ? new Response('{}', { status: 403 })
+          : new Response(JSON.stringify([]), { status: 200 }),
+      ),
+    )
+    vi.stubGlobal('fetch', mock)
+
+    const res = await (await route()).GET()
+    const body = await res.json()
+
+    expect(res.status).toBe(200)
+    expect(body.items).toEqual([])
+    expect(body.sources.lending).toBe('forbidden')
+    expect(body.sources.agent).toBe('ok')
+  })
+
+  it('marks an unreachable source unavailable, distinct from refused', async () => {
+    const mock = vi.fn().mockImplementation((url: string) =>
+      String(url).includes('lending')
+        ? Promise.reject(new Error('ECONNREFUSED'))
+        : Promise.resolve(new Response('{}', { status: 500 })),
+    )
+    vi.stubGlobal('fetch', mock)
+
+    const body = await (await (await route()).GET()).json()
+
+    expect(body.sources.lending).toBe('unavailable')
+    expect(body.sources.agent).toBe('unavailable')
+  })
 })

--- a/openbank-admin-ui/src/test/approvals-inbox.test.ts
+++ b/openbank-admin-ui/src/test/approvals-inbox.test.ts
@@ -1,0 +1,72 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright (c) OpenBank contributors. Licensed under the Apache License, Version 2.0.
+// See LICENSE in the repository root or https://www.apache.org/licenses/LICENSE-2.0 for details.
+
+// Integration tests for the federated approval inbox read (/api/approvals/pending, ADR-0227 D2).
+
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+
+vi.mock('@/auth', () => ({
+  auth: vi.fn(),
+}))
+
+import { auth } from '@/auth'
+
+const SESSION = { user: { accessToken: 'operator-token', roles: ['ROLE_ADMIN'] } }
+
+async function route(): Promise<typeof import('@/app/api/approvals/pending/route')> {
+  return import('@/app/api/approvals/pending/route')
+}
+
+describe('federated approvals inbox (ADR-0227 D2)', () => {
+  beforeEach(() => {
+    vi.resetModules()
+    vi.mocked(auth).mockResolvedValue(SESSION as never)
+  })
+  afterEach(() => {
+    vi.restoreAllMocks()
+  })
+
+  it('401s without a session', async () => {
+    vi.mocked(auth).mockResolvedValue(null as never)
+    const res = await (await route()).GET()
+    expect(res.status).toBe(401)
+  })
+
+  it('merges lending and agent queues into canonical items, sorted by proposedAt', async () => {
+    const mock = vi.fn().mockImplementation((url: string) => {
+      if (url.includes('lending')) {
+        return Promise.resolve(new Response(JSON.stringify([
+          { id: 'L-2', action: 'lending.disburse', resourceId: 'loan-2', makerId: 'officer.b', createdAt: '2026-07-30T10:00:00Z' },
+          { id: 'L-1', action: 'lending.writeoff', resourceId: 'loan-1', makerId: 'officer.a', createdAt: '2026-07-29T09:00:00Z' },
+        ]), { status: 200 }))
+      }
+      return Promise.resolve(new Response(JSON.stringify([
+        { id: 'P-1', suggestedAction: 'agent.research', proposedBy: 'ui-assistant', proposedAt: '2026-07-30T08:00:00Z' },
+      ]), { status: 200 }))
+    })
+    vi.stubGlobal('fetch', mock)
+
+    const res = await (await route()).GET()
+    const body = await res.json()
+    expect(body.items.map((i: { id: string }) => i.id)).toEqual(['L-1', 'P-1', 'L-2'])
+    expect(body.items[0]).toMatchObject({ domain: 'lending', action: 'lending.writeoff', maker: 'officer.a' })
+    expect(body.items[1]).toMatchObject({ domain: 'agent', action: 'agent.research' })
+  })
+
+  it('degrades to the working half when one queue is down', async () => {
+    const mock = vi.fn().mockImplementation((url: string) => {
+      if (url.includes('lending')) return Promise.reject(new Error('lending down'))
+      return Promise.resolve(new Response(JSON.stringify([
+        { id: 'P-1', suggestedAction: 'agent.research', proposedBy: 'ui-assistant', proposedAt: '2026-07-30T08:00:00Z' },
+      ]), { status: 200 }))
+    })
+    vi.stubGlobal('fetch', mock)
+
+    const res = await (await route()).GET()
+    const body = await res.json()
+    expect(res.status).toBe(200)
+    expect(body.items).toHaveLength(1)
+    expect(body.items[0].domain).toBe('agent')
+  })
+})


### PR DESCRIPTION
## Summary

The second half of **ADR-0227**'s first phase (backend source in #2791): a supervisor finally answers "what is waiting on me?" in ONE place.

- New BFF route `GET /api/approvals/pending` — federates lending's four-eyes queue (`GET /api/v1/lending/approvals`) with the agent plane's proposals into canonical `{id, domain, action, resourceId, maker, proposedAt}` items, oldest first. Session-gated; each source degrades independently.
- `/approvals` page gains a **"Doménová schvalování (money-path)"** section above the agent queue — domain badge, action, resource, maker, timestamp.
- **Read-only by design**: disposal stays in the governed per-domain decide flows; money-path disposal additionally requires SCA (ADR-0227 D4) — deliberately NOT a one-click button here. That is the phase-2 design.
- Note: #2791's `ApprovalResponse` gained `makerId`+`createdAt` in a follow-up commit there, so the inbox shows who asked and when.

**Tests (3):** 401, merge+sort with canonical mapping, per-source degradation. Full suite **826/826**, lint 0 errors, tsc clean. Version 0.70.0 (feat → minor, both files).

## Type of change

- [x] feat

## Linked issues

Refs #2750

## Definition of Done

- [x] vitest 826/826, lint 0 errors, tsc --noEmit clean
- [x] version.txt == package.json (0.70.0)
- [x] No disposal path added (ADR-0227 D4 SCA discipline)
- [x] Commit signed (-s -S), conventional format