### PR TITLE
feat(edge+security): claimed-HTTPS app OAuth, wire-aligned OpenAPI, customer access log, VDP link

### DIFF
--- a/docs/threat-models/qrlesspay.md
+++ b/docs/threat-models/qrlesspay.md
@@ -4,8 +4,9 @@ Copyright (c) OpenBank contributors. Licensed under the Apache License, Version 
 -->
 # Threat model — QRlessPay (BLE proximity SPAYD)
 
-- **Date:** 2026-06-16
-- **Status:** Lightweight STRIDE/DFD (ADR-0030 D2). **Money-path** capability — stub, to be completed before enforcement rollout.
+- **Date:** 2026-06-16 (completed 2026-07-30)
+- **Status:** Complete as a design-level STRIDE/DFD (ADR-0030 D2). **Money-path** capability —
+  rollout remains gated by the external reviews in §8 (they are process gates, not doc gaps).
 - **ADR:** [ADR-0095](../adr/0095-qrlesspay-ble-proximity-spayd-payments.md) · **Spec:** [qrlesspay-v1](../specs/qrlesspay-v1.md)
 
 ## 1. Scope & purpose
@@ -111,3 +112,26 @@ must add the optional layers — bank attestation, VOP (when it exists for CZ),
 strong proximity (UWB) or a verification code — none of which can be assumed
 today. The baseline should therefore be positioned as **"as safe as a QR scan,
 more private, nicer to use"**, not as "more secure", until those layers land.
+
+## 8. Rollout gates (what must be true before code ships)
+
+The app-side implementation state (2026-07): protocol core, controller and the
+nearby-tiles UI exist; the **Android GATT receive/write paths are deliberate
+stubs** (`ProximityBeacon.android.kt` — `startListeningForSpayd` TODO, `pushSpayd`
+returns false). Those stubs must NOT be filled until all of the following hold:
+
+1. **Independent cryptographic review** of the Ed25519 bundle format, the
+   advert↔bundle `kh` binding, and the in-memory session keypair handling (§6).
+2. **Protocol fuzzing** of the CBOR bundle decoder (malformed length prefixes,
+   truncation, oversize SPAYD, replayed/expired bundles, invalid `kh`/`sid`).
+3. **ADR-0030 security review + second approval** for this money-path capability.
+4. **DPIA sign-off** on the first-name broadcast (§5), incl. the "initials only"
+   opt-out decision.
+5. Decisions on the two open parameters: the **SAS/verification-code default**
+   and the **high-value threshold** that forces SAS/QR fallback (§6).
+6. Per-device **peripheral-role compatibility** documented; payee role degrades
+   to QR where GATT server is unreliable (§6).
+
+Until 1-4 are done, QRlessPay stays **dormant** in the app (BLE permission is
+optional, the feature flag is off, and the only live surfaces are the read-only
+nearby-tiles list and the QR fallback).

--- a/openbank-audit-service/src/main/kotlin/com/openbank/audit/infrastructure/rest/AuditResource.kt
+++ b/openbank-audit-service/src/main/kotlin/com/openbank/audit/infrastructure/rest/AuditResource.kt
@@ -7,6 +7,7 @@ package com.openbank.audit.infrastructure.rest
 import com.openbank.audit.application.AuditAnchorService
 import com.openbank.audit.infrastructure.persistence.AuditRepository
 import com.openbank.libs.authz.Authorize
+import com.openbank.libs.security.Roles
 import jakarta.annotation.security.RolesAllowed
 import jakarta.inject.Inject
 import jakarta.ws.rs.DefaultValue
@@ -31,6 +32,31 @@ class AuditResource {
     @Inject lateinit var repo: AuditRepository
 
     @Inject lateinit var anchors: AuditAnchorService
+
+    @GET
+    @Path("/customer/{partyId}")
+    // Customer-facing privacy view (P2-27): the customer edge proxies a caller's OWN
+    // access trail here. ROLE_API is an authenticated M2M service account — never
+    // anonymous (K7) — and OPA scopes the resource to the requested party. The payload
+    // is deliberately NOT projected: the app gets event metadata, not event internals.
+    @RolesAllowed(Roles.API)
+    @Authorize(action = "audit.read", resource = "#partyId")
+    @Operation(summary = "Get a party's own access log (customer privacy view)")
+    suspend fun getCustomerAccessLog(
+        @PathParam("partyId") partyId: String,
+        @QueryParam("limit") @DefaultValue("100") limit: Int,
+    ): Response {
+        val entries = repo.findByAggregateId(partyId, limit.coerceIn(1, 500)).map {
+            mapOf(
+                "eventType" to it.eventType,
+                "aggregateType" to it.aggregateType,
+                "actorType" to it.actorType,
+                "sourceService" to it.sourceService,
+                "occurredAt" to it.occurredAt.toString(),
+            )
+        }
+        return Response.ok(entries).build()
+    }
 
     @GET
     @Path("/entries/{aggregateId}")

--- a/openbank-audit-service/src/main/kotlin/com/openbank/audit/infrastructure/rest/AuditResource.kt
+++ b/openbank-audit-service/src/main/kotlin/com/openbank/audit/infrastructure/rest/AuditResource.kt
@@ -35,12 +35,18 @@ class AuditResource {
 
     @GET
     @Path("/customer/{partyId}")
-    // Customer-facing privacy view (P2-27): the customer edge proxies a caller's OWN
-    // access trail here. ROLE_API is an authenticated M2M service account — never
-    // anonymous (K7) — and OPA scopes the resource to the requested party. The payload
-    // is deliberately NOT projected: the app gets event metadata, not event internals.
-    @RolesAllowed(Roles.API)
-    @Authorize(action = "audit.read", resource = "#partyId")
+    // Customer-facing privacy view (P2-27): the customer edge proxies a caller's OWN access
+    // trail here, injecting partyId from the JWT so a client-supplied id never reaches this
+    // path. Roles mirror the edge-proxied precedent (document-service SignatureCeremonyResource)
+    // because they have to: UpstreamClient authenticates as the `openbank-edge` client, whose
+    // service account carries ROLE_OPERATOR — @RolesAllowed(ROLE_API) alone 403'd every call
+    // before OPA was ever consulted. ROLE_OPERATOR is also held by real staff, so the narrowing
+    // is OPA's job: `audit.customerRead` is a DISTINCT action from the auditor-facing
+    // `audit.read`, granted by rest.rego's `edge-service-audit-customer` rule to exactly the
+    // `service-account-openbank-edge` principal id and nothing else. The payload is deliberately
+    // not projected: the app gets event metadata, not event internals.
+    @RolesAllowed(Roles.API, Roles.OPERATOR, Roles.ADMIN)
+    @Authorize(action = "audit.customerRead", resource = "#partyId")
     @Operation(summary = "Get a party's own access log (customer privacy view)")
     suspend fun getCustomerAccessLog(
         @PathParam("partyId") partyId: String,

--- a/openbank-audit-service/src/main/resources/openapi.yaml
+++ b/openbank-audit-service/src/main/resources/openapi.yaml
@@ -3,7 +3,7 @@
 openapi: 3.1.0
 info:
   title: Audit Service API
-  version: 1.4.0
+  version: 1.5.0
   description: Immutable audit trail — retrieve event history per aggregate; verify hash-chain integrity (ADR-0086) and externally-signed anchors (ADR-0031 D5).
   license:
     name: Apache-2.0

--- a/openbank-audit-service/src/main/resources/openapi.yaml
+++ b/openbank-audit-service/src/main/resources/openapi.yaml
@@ -15,6 +15,32 @@ tags:
   - name: Audit
 
 paths:
+  /api/v1/audit/customer/{partyId}:
+    get:
+      tags: [Audit]
+      summary: Get a party's own access log (customer privacy view)
+      operationId: getCustomerAccessLog
+      parameters:
+        - name: partyId
+          in: path
+          required: true
+          schema:
+            type: string
+        - name: limit
+          in: query
+          schema:
+            type: integer
+            default: 100
+      responses:
+        '200':
+          description: Access-log entries for the party (event metadata only, no payloads)
+          content:
+            application/json:
+              schema:
+                type: array
+                items:
+                  $ref: '#/components/schemas/AccessLogEntryResponse'
+
   /api/v1/audit/entries/{aggregateId}:
     get:
       tags: [Audit]
@@ -278,6 +304,24 @@ components:
         headHashMismatch:
           type: boolean
           description: The attested head hash no longer matches the live chain (rewrite).
+
+    AccessLogEntryResponse:
+      type: object
+      description: Customer-facing privacy projection of an audit entry — event metadata
+        only, deliberately without the payload (AuditResource#getCustomerAccessLog).
+      properties:
+        eventType:
+          type: string
+        aggregateType:
+          type: string
+        actorType:
+          type: string
+          nullable: true
+        sourceService:
+          type: string
+        occurredAt:
+          type: string
+          format: date-time
 
     AuditEntryResponse:
       type: object

--- a/openbank-audit-service/src/test/kotlin/com/openbank/audit/infrastructure/rest/AuditResourceSecurityTest.kt
+++ b/openbank-audit-service/src/test/kotlin/com/openbank/audit/infrastructure/rest/AuditResourceSecurityTest.kt
@@ -4,10 +4,13 @@
 
 package com.openbank.audit.infrastructure.rest
 
+import com.fasterxml.jackson.module.kotlin.jacksonObjectMapper
+import com.openbank.libs.authz.Authorize
 import jakarta.annotation.security.PermitAll
 import jakarta.annotation.security.RolesAllowed
 import org.assertj.core.api.Assertions.assertThat
 import org.junit.jupiter.api.Test
+import java.io.File
 
 /**
  * Regression guard for K7: the audit trail must never be unauthenticated.
@@ -27,6 +30,9 @@ class AuditResourceSecurityTest {
 
     private val getActorTrail =
         AuditResource::class.java.declaredMethods.single { it.name == "getActorTrail" }
+
+    private val getCustomerAccessLog =
+        AuditResource::class.java.declaredMethods.single { it.name == "getCustomerAccessLog" }
 
     @Test
     fun `by-actor endpoint is role-gated, never permit-all (ADR-0226 — the person query is the most sensitive one)`() {
@@ -92,5 +98,59 @@ class AuditResourceSecurityTest {
             "ROLE_ADMIN",
             "ROLE_COMPLIANCE",
         )
+    }
+
+    // ── Customer privacy view (P2-27) ────────────────────────────────────────────────────────
+
+    /**
+     * The endpoint is reached ONLY by customer-edge, which authenticates as the `openbank-edge`
+     * client (UpstreamClient). Its service account's realm roles are declared in the Keycloak
+     * template, so the two must intersect or every call 403s at the JAX-RS layer before the PDP
+     * is ever consulted — which is exactly how this shipped first: @RolesAllowed(ROLE_API)
+     * against a service account holding only ROLE_OPERATOR. Read BOTH sides rather than pinning
+     * a literal, so a realm-side role change fails here too.
+     */
+    @Test
+    fun `the customer access log admits the role customer-edge's service account actually holds`() {
+        val declared = getCustomerAccessLog.getAnnotation(RolesAllowed::class.java).value.toSet()
+        val edgeRoles = edgeServiceAccountRealmRoles()
+
+        assertThat(edgeRoles)
+            .describedAs("service-account-openbank-edge must exist in the realm template with roles")
+            .isNotEmpty()
+        assertThat(declared.intersect(edgeRoles))
+            .describedAs("customer-edge (%s) cannot reach @RolesAllowed%s", edgeRoles, declared)
+            .isNotEmpty()
+    }
+
+    /**
+     * ROLE_OPERATOR is also held by real staff, so the widened @RolesAllowed is only safe because
+     * OPA narrows it: the action must stay DISTINCT from the auditor-facing `audit.read`, whose
+     * rest.rego grant (operator-read-any, matching the `.read` suffix) would otherwise admit any
+     * operator to a customer's trail.
+     */
+    @Test
+    fun `the customer access log carries its own authz action, not the auditor-facing audit read`() {
+        val action = getCustomerAccessLog.getAnnotation(Authorize::class.java).action
+
+        assertThat(action).isEqualTo("audit.customerRead")
+        assertThat(action).doesNotEndWith(".read")
+    }
+
+    @Test
+    fun `the customer access log is role-gated, never permit-all (K7)`() {
+        assertThat(getCustomerAccessLog.getAnnotation(PermitAll::class.java)).isNull()
+        assertThat(getCustomerAccessLog.getAnnotation(RolesAllowed::class.java)).isNotNull()
+    }
+
+    private fun edgeServiceAccountRealmRoles(): Set<String> {
+        val template = generateSequence(File(".").absoluteFile) { it.parentFile }
+            .map { File(it, "openbank-infra/gitops/components/keycloak/realm-template.json") }
+            .firstOrNull { it.isFile }
+        assertThat(template).describedAs("realm-template.json not found from %s", File(".").absolutePath).isNotNull()
+
+        val realm = jacksonObjectMapper().readTree(template!!)
+        val user = realm["users"].first { it["username"]?.asText() == "service-account-openbank-edge" }
+        return user["realmRoles"].map { it.asText() }.toSet()
     }
 }

--- a/openbank-customer-edge/src/main/kotlin/com/openbank/customeredge/infrastructure/rest/CustomerEdgeResource.kt
+++ b/openbank-customer-edge/src/main/kotlin/com/openbank/customeredge/infrastructure/rest/CustomerEdgeResource.kt
@@ -107,6 +107,9 @@ class CustomerEdgeResource(
     @ConfigProperty(name = "openbank.edge.balance-service-url")
     lateinit var balanceServiceUrl: String
 
+    @ConfigProperty(name = "openbank.edge.audit-service-url")
+    lateinit var auditServiceUrl: String
+
     @ConfigProperty(name = "openbank.edge.interest-service-url")
     lateinit var interestServiceUrl: String
 
@@ -594,6 +597,20 @@ class CustomerEdgeResource(
     // The customer's view of who (TPPs, delegated agents) may access their account data, and the
     // ability to revoke. Consents are party-scoped: consent-service keys them by partyId, so the
     // edge injects the caller's partyId from the JWT and never trusts a client-supplied one.
+
+    /** The caller's own access log for the privacy centre (P2-27): audit entries whose
+     *  aggregate is the caller's party, projected by audit-service to event metadata only. */
+    @GET
+    @Path("/privacy/access-log")
+    @Authorize(action = "customer.profile.read", resource = "")
+    @Blocking
+    fun accessLog(): Response {
+        val customer = customer()
+        return upstream.get(
+            "$auditServiceUrl/api/v1/audit/customer/${customer.partyId}",
+            customer.partyId.toString(),
+        )
+    }
 
     /** The third-party / agent data-access consents granted by the caller. */
     @GET

--- a/openbank-customer-edge/src/main/resources/application.yaml
+++ b/openbank-customer-edge/src/main/resources/application.yaml
@@ -106,6 +106,7 @@ openbank:
   edge:
     account-service-url: ${ACCOUNT_SERVICE_URL:http://account-service.accounts.svc:8100}
     balance-service-url: ${BALANCE_SERVICE_URL:http://balance-service.balances.svc:8103}
+    audit-service-url: ${AUDIT_SERVICE_URL:http://audit-service.audit.svc:8113}
     interest-service-url: ${INTEREST_SERVICE_URL:http://interest-service.interest.svc:8125}
     kyc-service-url: ${KYC_SERVICE_URL:http://kyc-service.kyc.svc:8114}
     lending-service-url: ${LENDING_SERVICE_URL:http://lending-service.lending.svc:8126}

--- a/openbank-customer-edge/src/main/resources/openapi.yaml
+++ b/openbank-customer-edge/src/main/resources/openapi.yaml
@@ -3,7 +3,7 @@
 openapi: 3.1.0
 info:
   title: Customer Edge API
-  version: 1.21.0
+  version: 1.22.0
   description: >-
     Customer-facing edge proxy (ADR-0065). Single internet-facing entry point for the
     retail customer app. Validates JWTs from the openbank-customers Keycloak realm,
@@ -134,6 +134,23 @@ paths:
                 type: array
                 items:
                   $ref: '#/components/schemas/BankDto'
+
+  /privacy/access-log:
+    get:
+      tags: [Privacy]
+      summary: The caller's own access log (privacy centre)
+      operationId: getAccessLog
+      security:
+        - customerOidc: [accounts:read]
+      responses:
+        '200':
+          description: Access-log entries for the caller's party (event metadata only)
+          content:
+            application/json:
+              schema:
+                type: array
+                items:
+                  $ref: '#/components/schemas/AccessLogEntry'
 
   /accounts:
     get:
@@ -1380,6 +1397,17 @@ components:
         totalCount:
           type: integer
           nullable: true
+
+    AccessLogEntry:
+      type: object
+      description: One audit event whose aggregate is the caller's party (metadata only,
+        no event payload — audit-service's customer-facing privacy projection).
+      properties:
+        eventType: {type: string}
+        aggregateType: {type: string}
+        actorType: {type: string, nullable: true}
+        sourceService: {type: string}
+        occurredAt: {type: string, format: date-time}
 
     # Mirrors openbank-account-service AccountResponse.
     Account:

--- a/openbank-customer-edge/src/main/resources/openapi.yaml
+++ b/openbank-customer-edge/src/main/resources/openapi.yaml
@@ -1367,11 +1367,19 @@ components:
       type: object
       description: Cursor pagination envelope shared by the account and transaction list pages.
       properties:
+        limit:
+          type: integer
+        hasNextPage:
+          type: boolean
         nextCursor:
           type: string
           nullable: true
-        hasMore:
-          type: boolean
+        previousCursor:
+          type: string
+          nullable: true
+        totalCount:
+          type: integer
+          nullable: true
 
     # Mirrors openbank-account-service AccountResponse.
     Account:
@@ -1435,15 +1443,17 @@ components:
           format: uuid
         currency:
           type: string
-        availableBalance:
+        bookedAmount:
           type: number
-        currentBalance:
+        availableAmount:
           type: number
-        reservedBalance:
+        reservedAmount:
           type: number
-        pendingBalance:
+        pendingAmount:
           type: number
-        lastUpdatedAt:
+        arrangedOverdraftLimit:
+          type: number
+        updatedAt:
           type: string
           format: date-time
 

--- a/openbank-infra/gitops/components/accounts/account-opa-bundle.yaml
+++ b/openbank-infra/gitops/components/accounts/account-opa-bundle.yaml
@@ -9,7 +9,7 @@ metadata:
     app.kubernetes.io/name: account-service
     app.kubernetes.io/part-of: accounts
   annotations:
-    openbank.tech/policy-checksum: "6c060585114b8403"
+    openbank.tech/policy-checksum: "78ec0f178013f861"
 data:
   rest.rego: |
     # SPDX-License-Identifier: Apache-2.0
@@ -263,6 +263,28 @@ data:
     	input.principal.type == "HUMAN"
     	input.principal.id == "service-account-openbank-edge"
     	input.action in {"consent.list", "consent.revoke"}
+    }
+
+    # The customer-edge proxying the app's privacy centre: a customer reads their OWN access log
+    # (P2-27). Same edge principal and same guard as edge-service-consent — the edge injects the
+    # caller's authoritative partyId from the JWT, so a client-supplied id never reaches
+    # audit-service.
+    #
+    # Deliberately a DISTINCT action from `audit.read`, not the `audit.` family: `audit.read` is the
+    # auditor/compliance surface over the whole trail (GET /entries/{aggregateId},
+    # /entries/by-actor/{actorId}) and granting it to the edge principal would put regulated evidence
+    # behind a service account. `audit.customerRead` reaches only the metadata projection.
+    #
+    # This rule is what actually narrows the endpoint. Its @RolesAllowed had to widen to
+    # ROLE_API/ROLE_OPERATOR/ROLE_ADMIN — the edge's service account carries ROLE_OPERATOR, so
+    # @RolesAllowed(ROLE_API) alone 403'd every call before the PDP was consulted (same shape as
+    # document-service's SignatureCeremonyResource) — and ROLE_OPERATOR is held by real staff too.
+    # The identity match below is therefore the load-bearing half: staff sessions authenticate
+    # through a different client, so their preferred_username is never "service-account-*".
+    allowed_reasons contains "edge-service-audit-customer" if {
+    	input.principal.type == "HUMAN"
+    	input.principal.id == "service-account-openbank-edge"
+    	input.action == "audit.customerRead"
     }
 
     # Any M2M service-account caller (e.g. account-service) may trigger a sanctions screen

--- a/openbank-infra/gitops/components/accounts/account-service.yaml
+++ b/openbank-infra/gitops/components/accounts/account-service.yaml
@@ -37,7 +37,7 @@ spec:
       annotations:
         # Rolls the pod when the OPA bundle changes — subPath mounts do NOT hot-reload.
         # Kept in sync by gen-account-opa-bundle.sh (do not hand-edit).
-        openbank.tech/policy-checksum: "6c060585114b8403"
+        openbank.tech/policy-checksum: "78ec0f178013f861"
     spec:
       securityContext:
         runAsNonRoot: true

--- a/openbank-infra/gitops/components/aml/aml-opa-bundle.yaml
+++ b/openbank-infra/gitops/components/aml/aml-opa-bundle.yaml
@@ -9,7 +9,7 @@ metadata:
     app.kubernetes.io/name: aml-service
     app.kubernetes.io/part-of: aml
   annotations:
-    openbank.tech/policy-checksum: "1817b01e372a4cfd"
+    openbank.tech/policy-checksum: "33490dbee2bf18c7"
 data:
   rest.rego: |
     # SPDX-License-Identifier: Apache-2.0
@@ -263,6 +263,28 @@ data:
     	input.principal.type == "HUMAN"
     	input.principal.id == "service-account-openbank-edge"
     	input.action in {"consent.list", "consent.revoke"}
+    }
+
+    # The customer-edge proxying the app's privacy centre: a customer reads their OWN access log
+    # (P2-27). Same edge principal and same guard as edge-service-consent — the edge injects the
+    # caller's authoritative partyId from the JWT, so a client-supplied id never reaches
+    # audit-service.
+    #
+    # Deliberately a DISTINCT action from `audit.read`, not the `audit.` family: `audit.read` is the
+    # auditor/compliance surface over the whole trail (GET /entries/{aggregateId},
+    # /entries/by-actor/{actorId}) and granting it to the edge principal would put regulated evidence
+    # behind a service account. `audit.customerRead` reaches only the metadata projection.
+    #
+    # This rule is what actually narrows the endpoint. Its @RolesAllowed had to widen to
+    # ROLE_API/ROLE_OPERATOR/ROLE_ADMIN — the edge's service account carries ROLE_OPERATOR, so
+    # @RolesAllowed(ROLE_API) alone 403'd every call before the PDP was consulted (same shape as
+    # document-service's SignatureCeremonyResource) — and ROLE_OPERATOR is held by real staff too.
+    # The identity match below is therefore the load-bearing half: staff sessions authenticate
+    # through a different client, so their preferred_username is never "service-account-*".
+    allowed_reasons contains "edge-service-audit-customer" if {
+    	input.principal.type == "HUMAN"
+    	input.principal.id == "service-account-openbank-edge"
+    	input.action == "audit.customerRead"
     }
 
     # Any M2M service-account caller (e.g. account-service) may trigger a sanctions screen

--- a/openbank-infra/gitops/components/aml/aml-service.yaml
+++ b/openbank-infra/gitops/components/aml/aml-service.yaml
@@ -22,7 +22,7 @@ spec:
       annotations:
         # Rolls the pod when the OPA bundle changes (subPath mounts do not hot-reload).
         # Kept in sync by gen-aml-opa-bundle.sh (do not hand-edit).
-        openbank.tech/policy-checksum: "1817b01e372a4cfd"
+        openbank.tech/policy-checksum: "33490dbee2bf18c7"
     spec:
       securityContext:
         runAsNonRoot: true

--- a/openbank-infra/gitops/components/anacredit/anacredit-opa-bundle.yaml
+++ b/openbank-infra/gitops/components/anacredit/anacredit-opa-bundle.yaml
@@ -9,7 +9,7 @@ metadata:
     app.kubernetes.io/name: anacredit-service
     app.kubernetes.io/part-of: anacredit
   annotations:
-    openbank.tech/policy-checksum: "3db0652875a7bb51"
+    openbank.tech/policy-checksum: "692301126ffcd7b5"
 data:
   rest.rego: |
     # SPDX-License-Identifier: Apache-2.0
@@ -263,6 +263,28 @@ data:
     	input.principal.type == "HUMAN"
     	input.principal.id == "service-account-openbank-edge"
     	input.action in {"consent.list", "consent.revoke"}
+    }
+
+    # The customer-edge proxying the app's privacy centre: a customer reads their OWN access log
+    # (P2-27). Same edge principal and same guard as edge-service-consent — the edge injects the
+    # caller's authoritative partyId from the JWT, so a client-supplied id never reaches
+    # audit-service.
+    #
+    # Deliberately a DISTINCT action from `audit.read`, not the `audit.` family: `audit.read` is the
+    # auditor/compliance surface over the whole trail (GET /entries/{aggregateId},
+    # /entries/by-actor/{actorId}) and granting it to the edge principal would put regulated evidence
+    # behind a service account. `audit.customerRead` reaches only the metadata projection.
+    #
+    # This rule is what actually narrows the endpoint. Its @RolesAllowed had to widen to
+    # ROLE_API/ROLE_OPERATOR/ROLE_ADMIN — the edge's service account carries ROLE_OPERATOR, so
+    # @RolesAllowed(ROLE_API) alone 403'd every call before the PDP was consulted (same shape as
+    # document-service's SignatureCeremonyResource) — and ROLE_OPERATOR is held by real staff too.
+    # The identity match below is therefore the load-bearing half: staff sessions authenticate
+    # through a different client, so their preferred_username is never "service-account-*".
+    allowed_reasons contains "edge-service-audit-customer" if {
+    	input.principal.type == "HUMAN"
+    	input.principal.id == "service-account-openbank-edge"
+    	input.action == "audit.customerRead"
     }
 
     # Any M2M service-account caller (e.g. account-service) may trigger a sanctions screen

--- a/openbank-infra/gitops/components/anacredit/anacredit-service.yaml
+++ b/openbank-infra/gitops/components/anacredit/anacredit-service.yaml
@@ -32,7 +32,7 @@ spec:
       annotations:
         # Rolls the pods when the OPA bundle changes — subPath mounts do NOT hot-reload.
         # Kept in sync by gen-anacredit-opa-bundle.sh (do not hand-edit).
-        openbank.tech/policy-checksum: "3db0652875a7bb51"
+        openbank.tech/policy-checksum: "692301126ffcd7b5"
     spec:
       securityContext:
         runAsNonRoot: true

--- a/openbank-infra/gitops/components/ap2/ap2-opa-bundle.yaml
+++ b/openbank-infra/gitops/components/ap2/ap2-opa-bundle.yaml
@@ -9,7 +9,7 @@ metadata:
     app.kubernetes.io/name: mcp-service
     app.kubernetes.io/part-of: platform
   annotations:
-    openbank.tech/policy-checksum: "e6597e9970958601"
+    openbank.tech/policy-checksum: "2b72638dd5431d53"
 data:
   rest.rego: |
     # SPDX-License-Identifier: Apache-2.0
@@ -263,6 +263,28 @@ data:
     	input.principal.type == "HUMAN"
     	input.principal.id == "service-account-openbank-edge"
     	input.action in {"consent.list", "consent.revoke"}
+    }
+
+    # The customer-edge proxying the app's privacy centre: a customer reads their OWN access log
+    # (P2-27). Same edge principal and same guard as edge-service-consent — the edge injects the
+    # caller's authoritative partyId from the JWT, so a client-supplied id never reaches
+    # audit-service.
+    #
+    # Deliberately a DISTINCT action from `audit.read`, not the `audit.` family: `audit.read` is the
+    # auditor/compliance surface over the whole trail (GET /entries/{aggregateId},
+    # /entries/by-actor/{actorId}) and granting it to the edge principal would put regulated evidence
+    # behind a service account. `audit.customerRead` reaches only the metadata projection.
+    #
+    # This rule is what actually narrows the endpoint. Its @RolesAllowed had to widen to
+    # ROLE_API/ROLE_OPERATOR/ROLE_ADMIN — the edge's service account carries ROLE_OPERATOR, so
+    # @RolesAllowed(ROLE_API) alone 403'd every call before the PDP was consulted (same shape as
+    # document-service's SignatureCeremonyResource) — and ROLE_OPERATOR is held by real staff too.
+    # The identity match below is therefore the load-bearing half: staff sessions authenticate
+    # through a different client, so their preferred_username is never "service-account-*".
+    allowed_reasons contains "edge-service-audit-customer" if {
+    	input.principal.type == "HUMAN"
+    	input.principal.id == "service-account-openbank-edge"
+    	input.action == "audit.customerRead"
     }
 
     # Any M2M service-account caller (e.g. account-service) may trigger a sanctions screen

--- a/openbank-infra/gitops/components/ap2/ap2-service.yaml
+++ b/openbank-infra/gitops/components/ap2/ap2-service.yaml
@@ -30,7 +30,7 @@ spec:
       annotations:
         # Roll the pod when the OPA policy bundle changes (subPath mounts don't hot-reload).
         # Kept in sync by gen-ap2-opa-bundle.sh (do not hand-edit).
-        openbank.tech/policy-checksum: "e6597e9970958601"
+        openbank.tech/policy-checksum: "2b72638dd5431d53"
     spec:
       securityContext:
         runAsNonRoot: true

--- a/openbank-infra/gitops/components/audit/audit-opa-bundle.yaml
+++ b/openbank-infra/gitops/components/audit/audit-opa-bundle.yaml
@@ -9,7 +9,7 @@ metadata:
     app.kubernetes.io/name: audit-service
     app.kubernetes.io/part-of: audit
   annotations:
-    openbank.tech/policy-checksum: "22647b1e3fb22ef3"
+    openbank.tech/policy-checksum: "44ad9fc1e6f8c0d5"
 data:
   rest.rego: |
     # SPDX-License-Identifier: Apache-2.0
@@ -263,6 +263,28 @@ data:
     	input.principal.type == "HUMAN"
     	input.principal.id == "service-account-openbank-edge"
     	input.action in {"consent.list", "consent.revoke"}
+    }
+
+    # The customer-edge proxying the app's privacy centre: a customer reads their OWN access log
+    # (P2-27). Same edge principal and same guard as edge-service-consent — the edge injects the
+    # caller's authoritative partyId from the JWT, so a client-supplied id never reaches
+    # audit-service.
+    #
+    # Deliberately a DISTINCT action from `audit.read`, not the `audit.` family: `audit.read` is the
+    # auditor/compliance surface over the whole trail (GET /entries/{aggregateId},
+    # /entries/by-actor/{actorId}) and granting it to the edge principal would put regulated evidence
+    # behind a service account. `audit.customerRead` reaches only the metadata projection.
+    #
+    # This rule is what actually narrows the endpoint. Its @RolesAllowed had to widen to
+    # ROLE_API/ROLE_OPERATOR/ROLE_ADMIN — the edge's service account carries ROLE_OPERATOR, so
+    # @RolesAllowed(ROLE_API) alone 403'd every call before the PDP was consulted (same shape as
+    # document-service's SignatureCeremonyResource) — and ROLE_OPERATOR is held by real staff too.
+    # The identity match below is therefore the load-bearing half: staff sessions authenticate
+    # through a different client, so their preferred_username is never "service-account-*".
+    allowed_reasons contains "edge-service-audit-customer" if {
+    	input.principal.type == "HUMAN"
+    	input.principal.id == "service-account-openbank-edge"
+    	input.action == "audit.customerRead"
     }
 
     # Any M2M service-account caller (e.g. account-service) may trigger a sanctions screen

--- a/openbank-infra/gitops/components/audit/audit-service.yaml
+++ b/openbank-infra/gitops/components/audit/audit-service.yaml
@@ -22,7 +22,7 @@ spec:
       annotations:
         # Rolls the pod when the OPA bundle changes (subPath mounts do not hot-reload).
         # Kept in sync by gen-audit-opa-bundle.sh (do not hand-edit).
-        openbank.tech/policy-checksum: "22647b1e3fb22ef3"
+        openbank.tech/policy-checksum: "44ad9fc1e6f8c0d5"
     spec:
       securityContext:
         runAsNonRoot: true

--- a/openbank-infra/gitops/components/balances/balance-opa-bundle.yaml
+++ b/openbank-infra/gitops/components/balances/balance-opa-bundle.yaml
@@ -9,7 +9,7 @@ metadata:
     app.kubernetes.io/name: balance-service
     app.kubernetes.io/part-of: balances
   annotations:
-    openbank.tech/policy-checksum: "418d1f34610d6c6c"
+    openbank.tech/policy-checksum: "ebe36a045b7a7895"
 data:
   rest.rego: |
     # SPDX-License-Identifier: Apache-2.0
@@ -263,6 +263,28 @@ data:
     	input.principal.type == "HUMAN"
     	input.principal.id == "service-account-openbank-edge"
     	input.action in {"consent.list", "consent.revoke"}
+    }
+
+    # The customer-edge proxying the app's privacy centre: a customer reads their OWN access log
+    # (P2-27). Same edge principal and same guard as edge-service-consent — the edge injects the
+    # caller's authoritative partyId from the JWT, so a client-supplied id never reaches
+    # audit-service.
+    #
+    # Deliberately a DISTINCT action from `audit.read`, not the `audit.` family: `audit.read` is the
+    # auditor/compliance surface over the whole trail (GET /entries/{aggregateId},
+    # /entries/by-actor/{actorId}) and granting it to the edge principal would put regulated evidence
+    # behind a service account. `audit.customerRead` reaches only the metadata projection.
+    #
+    # This rule is what actually narrows the endpoint. Its @RolesAllowed had to widen to
+    # ROLE_API/ROLE_OPERATOR/ROLE_ADMIN — the edge's service account carries ROLE_OPERATOR, so
+    # @RolesAllowed(ROLE_API) alone 403'd every call before the PDP was consulted (same shape as
+    # document-service's SignatureCeremonyResource) — and ROLE_OPERATOR is held by real staff too.
+    # The identity match below is therefore the load-bearing half: staff sessions authenticate
+    # through a different client, so their preferred_username is never "service-account-*".
+    allowed_reasons contains "edge-service-audit-customer" if {
+    	input.principal.type == "HUMAN"
+    	input.principal.id == "service-account-openbank-edge"
+    	input.action == "audit.customerRead"
     }
 
     # Any M2M service-account caller (e.g. account-service) may trigger a sanctions screen

--- a/openbank-infra/gitops/components/balances/balance-service.yaml
+++ b/openbank-infra/gitops/components/balances/balance-service.yaml
@@ -34,7 +34,7 @@ spec:
       annotations:
         # Rolls the pods when the OPA bundle changes — subPath mounts do NOT hot-reload.
         # Kept in sync by gen-balance-opa-bundle.sh (do not hand-edit).
-        openbank.tech/policy-checksum: "418d1f34610d6c6c"
+        openbank.tech/policy-checksum: "ebe36a045b7a7895"
     spec:
       securityContext:
         runAsNonRoot: true

--- a/openbank-infra/gitops/components/billing/billing-opa-bundle.yaml
+++ b/openbank-infra/gitops/components/billing/billing-opa-bundle.yaml
@@ -9,7 +9,7 @@ metadata:
     app.kubernetes.io/name: billing-service
     app.kubernetes.io/part-of: billing
   annotations:
-    openbank.tech/policy-checksum: "57753c504ee15bec"
+    openbank.tech/policy-checksum: "c54e3d80e6befde7"
 data:
   rest.rego: |
     # SPDX-License-Identifier: Apache-2.0
@@ -263,6 +263,28 @@ data:
     	input.principal.type == "HUMAN"
     	input.principal.id == "service-account-openbank-edge"
     	input.action in {"consent.list", "consent.revoke"}
+    }
+
+    # The customer-edge proxying the app's privacy centre: a customer reads their OWN access log
+    # (P2-27). Same edge principal and same guard as edge-service-consent — the edge injects the
+    # caller's authoritative partyId from the JWT, so a client-supplied id never reaches
+    # audit-service.
+    #
+    # Deliberately a DISTINCT action from `audit.read`, not the `audit.` family: `audit.read` is the
+    # auditor/compliance surface over the whole trail (GET /entries/{aggregateId},
+    # /entries/by-actor/{actorId}) and granting it to the edge principal would put regulated evidence
+    # behind a service account. `audit.customerRead` reaches only the metadata projection.
+    #
+    # This rule is what actually narrows the endpoint. Its @RolesAllowed had to widen to
+    # ROLE_API/ROLE_OPERATOR/ROLE_ADMIN — the edge's service account carries ROLE_OPERATOR, so
+    # @RolesAllowed(ROLE_API) alone 403'd every call before the PDP was consulted (same shape as
+    # document-service's SignatureCeremonyResource) — and ROLE_OPERATOR is held by real staff too.
+    # The identity match below is therefore the load-bearing half: staff sessions authenticate
+    # through a different client, so their preferred_username is never "service-account-*".
+    allowed_reasons contains "edge-service-audit-customer" if {
+    	input.principal.type == "HUMAN"
+    	input.principal.id == "service-account-openbank-edge"
+    	input.action == "audit.customerRead"
     }
 
     # Any M2M service-account caller (e.g. account-service) may trigger a sanctions screen

--- a/openbank-infra/gitops/components/billing/billing-service.yaml
+++ b/openbank-infra/gitops/components/billing/billing-service.yaml
@@ -27,7 +27,7 @@ spec:
       annotations:
         # Rolls the pods when the OPA bundle changes — subPath mounts do NOT hot-reload.
         # Kept in sync by gen-billing-opa-bundle.sh (do not hand-edit).
-        openbank.tech/policy-checksum: "57753c504ee15bec"
+        openbank.tech/policy-checksum: "c54e3d80e6befde7"
     spec:
       securityContext:
         runAsNonRoot: true

--- a/openbank-infra/gitops/components/consent/consent-opa-bundle.yaml
+++ b/openbank-infra/gitops/components/consent/consent-opa-bundle.yaml
@@ -9,7 +9,7 @@ metadata:
     app.kubernetes.io/name: consent-service
     app.kubernetes.io/part-of: consent
   annotations:
-    openbank.tech/policy-checksum: "c8eea9b19262bbf1"
+    openbank.tech/policy-checksum: "343e0d369d85a75f"
 data:
   rest.rego: |
     # SPDX-License-Identifier: Apache-2.0
@@ -263,6 +263,28 @@ data:
     	input.principal.type == "HUMAN"
     	input.principal.id == "service-account-openbank-edge"
     	input.action in {"consent.list", "consent.revoke"}
+    }
+
+    # The customer-edge proxying the app's privacy centre: a customer reads their OWN access log
+    # (P2-27). Same edge principal and same guard as edge-service-consent — the edge injects the
+    # caller's authoritative partyId from the JWT, so a client-supplied id never reaches
+    # audit-service.
+    #
+    # Deliberately a DISTINCT action from `audit.read`, not the `audit.` family: `audit.read` is the
+    # auditor/compliance surface over the whole trail (GET /entries/{aggregateId},
+    # /entries/by-actor/{actorId}) and granting it to the edge principal would put regulated evidence
+    # behind a service account. `audit.customerRead` reaches only the metadata projection.
+    #
+    # This rule is what actually narrows the endpoint. Its @RolesAllowed had to widen to
+    # ROLE_API/ROLE_OPERATOR/ROLE_ADMIN — the edge's service account carries ROLE_OPERATOR, so
+    # @RolesAllowed(ROLE_API) alone 403'd every call before the PDP was consulted (same shape as
+    # document-service's SignatureCeremonyResource) — and ROLE_OPERATOR is held by real staff too.
+    # The identity match below is therefore the load-bearing half: staff sessions authenticate
+    # through a different client, so their preferred_username is never "service-account-*".
+    allowed_reasons contains "edge-service-audit-customer" if {
+    	input.principal.type == "HUMAN"
+    	input.principal.id == "service-account-openbank-edge"
+    	input.action == "audit.customerRead"
     }
 
     # Any M2M service-account caller (e.g. account-service) may trigger a sanctions screen

--- a/openbank-infra/gitops/components/consent/consent-service.yaml
+++ b/openbank-infra/gitops/components/consent/consent-service.yaml
@@ -28,7 +28,7 @@ spec:
       annotations:
         # Rolls the pods when the OPA bundle changes — subPath mounts do NOT hot-reload.
         # Kept in sync by gen-consent-opa-bundle.sh (do not hand-edit).
-        openbank.tech/policy-checksum: "c8eea9b19262bbf1"
+        openbank.tech/policy-checksum: "343e0d369d85a75f"
     spec:
       securityContext:
         runAsNonRoot: true

--- a/openbank-infra/gitops/components/copilot/copilot-opa-bundle.yaml
+++ b/openbank-infra/gitops/components/copilot/copilot-opa-bundle.yaml
@@ -9,7 +9,7 @@ metadata:
     app.kubernetes.io/name: copilot-service
     app.kubernetes.io/part-of: platform
   annotations:
-    openbank.tech/policy-checksum: "a7f1e1fdc96c85dd"
+    openbank.tech/policy-checksum: "e24f48dfd6784c8b"
 data:
   rest.rego: |
     # SPDX-License-Identifier: Apache-2.0
@@ -263,6 +263,28 @@ data:
     	input.principal.type == "HUMAN"
     	input.principal.id == "service-account-openbank-edge"
     	input.action in {"consent.list", "consent.revoke"}
+    }
+
+    # The customer-edge proxying the app's privacy centre: a customer reads their OWN access log
+    # (P2-27). Same edge principal and same guard as edge-service-consent — the edge injects the
+    # caller's authoritative partyId from the JWT, so a client-supplied id never reaches
+    # audit-service.
+    #
+    # Deliberately a DISTINCT action from `audit.read`, not the `audit.` family: `audit.read` is the
+    # auditor/compliance surface over the whole trail (GET /entries/{aggregateId},
+    # /entries/by-actor/{actorId}) and granting it to the edge principal would put regulated evidence
+    # behind a service account. `audit.customerRead` reaches only the metadata projection.
+    #
+    # This rule is what actually narrows the endpoint. Its @RolesAllowed had to widen to
+    # ROLE_API/ROLE_OPERATOR/ROLE_ADMIN — the edge's service account carries ROLE_OPERATOR, so
+    # @RolesAllowed(ROLE_API) alone 403'd every call before the PDP was consulted (same shape as
+    # document-service's SignatureCeremonyResource) — and ROLE_OPERATOR is held by real staff too.
+    # The identity match below is therefore the load-bearing half: staff sessions authenticate
+    # through a different client, so their preferred_username is never "service-account-*".
+    allowed_reasons contains "edge-service-audit-customer" if {
+    	input.principal.type == "HUMAN"
+    	input.principal.id == "service-account-openbank-edge"
+    	input.action == "audit.customerRead"
     }
 
     # Any M2M service-account caller (e.g. account-service) may trigger a sanctions screen

--- a/openbank-infra/gitops/components/copilot/copilot-service.yaml
+++ b/openbank-infra/gitops/components/copilot/copilot-service.yaml
@@ -29,7 +29,7 @@ spec:
       annotations:
         # Rolls the pod when the OPA bundle changes — subPath mounts do NOT hot-reload.
         # Kept in sync by gen-copilot-opa-bundle.sh (do not hand-edit).
-        openbank.tech/policy-checksum: "a7f1e1fdc96c85dd"
+        openbank.tech/policy-checksum: "e24f48dfd6784c8b"
     spec:
       securityContext:
         runAsNonRoot: true

--- a/openbank-infra/gitops/components/customer-edge/customer-edge-opa-bundle.yaml
+++ b/openbank-infra/gitops/components/customer-edge/customer-edge-opa-bundle.yaml
@@ -10,7 +10,7 @@ metadata:
     app.kubernetes.io/name: customer-edge
     app.kubernetes.io/part-of: customer-edge
   annotations:
-    openbank.tech/policy-checksum: "c83800f2882da701"
+    openbank.tech/policy-checksum: "286e0ec440ea1c56"
 data:
   rest.rego: |
     # SPDX-License-Identifier: Apache-2.0
@@ -264,6 +264,28 @@ data:
     	input.principal.type == "HUMAN"
     	input.principal.id == "service-account-openbank-edge"
     	input.action in {"consent.list", "consent.revoke"}
+    }
+
+    # The customer-edge proxying the app's privacy centre: a customer reads their OWN access log
+    # (P2-27). Same edge principal and same guard as edge-service-consent — the edge injects the
+    # caller's authoritative partyId from the JWT, so a client-supplied id never reaches
+    # audit-service.
+    #
+    # Deliberately a DISTINCT action from `audit.read`, not the `audit.` family: `audit.read` is the
+    # auditor/compliance surface over the whole trail (GET /entries/{aggregateId},
+    # /entries/by-actor/{actorId}) and granting it to the edge principal would put regulated evidence
+    # behind a service account. `audit.customerRead` reaches only the metadata projection.
+    #
+    # This rule is what actually narrows the endpoint. Its @RolesAllowed had to widen to
+    # ROLE_API/ROLE_OPERATOR/ROLE_ADMIN — the edge's service account carries ROLE_OPERATOR, so
+    # @RolesAllowed(ROLE_API) alone 403'd every call before the PDP was consulted (same shape as
+    # document-service's SignatureCeremonyResource) — and ROLE_OPERATOR is held by real staff too.
+    # The identity match below is therefore the load-bearing half: staff sessions authenticate
+    # through a different client, so their preferred_username is never "service-account-*".
+    allowed_reasons contains "edge-service-audit-customer" if {
+    	input.principal.type == "HUMAN"
+    	input.principal.id == "service-account-openbank-edge"
+    	input.action == "audit.customerRead"
     }
 
     # Any M2M service-account caller (e.g. account-service) may trigger a sanctions screen

--- a/openbank-infra/gitops/components/customer-edge/customer-edge.yaml
+++ b/openbank-infra/gitops/components/customer-edge/customer-edge.yaml
@@ -65,7 +65,7 @@ spec:
       annotations:
         # Rolls the pod when the OPA bundle changes — subPath mounts do NOT hot-reload.
         # Kept in sync by gen-customer-edge-opa-bundle.sh (do not hand-edit).
-        openbank.tech/policy-checksum: "c83800f2882da701"
+        openbank.tech/policy-checksum: "286e0ec440ea1c56"
     spec:
       # Dedicated SA so EKS Pod Identity can hand the edge (and ONLY the edge) the
       # feedback-screenshots S3 role — ADR-0192, openbank-infra/aws/envs/sandbox-platform/

--- a/openbank-infra/gitops/components/dispute-service/dispute-opa-bundle.yaml
+++ b/openbank-infra/gitops/components/dispute-service/dispute-opa-bundle.yaml
@@ -9,7 +9,7 @@ metadata:
     app.kubernetes.io/name: dispute-service
     app.kubernetes.io/part-of: dispute
   annotations:
-    openbank.tech/policy-checksum: "d60af72d628bf649"
+    openbank.tech/policy-checksum: "41bab1de48db0ebc"
 data:
   rest.rego: |
     # SPDX-License-Identifier: Apache-2.0
@@ -263,6 +263,28 @@ data:
     	input.principal.type == "HUMAN"
     	input.principal.id == "service-account-openbank-edge"
     	input.action in {"consent.list", "consent.revoke"}
+    }
+
+    # The customer-edge proxying the app's privacy centre: a customer reads their OWN access log
+    # (P2-27). Same edge principal and same guard as edge-service-consent — the edge injects the
+    # caller's authoritative partyId from the JWT, so a client-supplied id never reaches
+    # audit-service.
+    #
+    # Deliberately a DISTINCT action from `audit.read`, not the `audit.` family: `audit.read` is the
+    # auditor/compliance surface over the whole trail (GET /entries/{aggregateId},
+    # /entries/by-actor/{actorId}) and granting it to the edge principal would put regulated evidence
+    # behind a service account. `audit.customerRead` reaches only the metadata projection.
+    #
+    # This rule is what actually narrows the endpoint. Its @RolesAllowed had to widen to
+    # ROLE_API/ROLE_OPERATOR/ROLE_ADMIN — the edge's service account carries ROLE_OPERATOR, so
+    # @RolesAllowed(ROLE_API) alone 403'd every call before the PDP was consulted (same shape as
+    # document-service's SignatureCeremonyResource) — and ROLE_OPERATOR is held by real staff too.
+    # The identity match below is therefore the load-bearing half: staff sessions authenticate
+    # through a different client, so their preferred_username is never "service-account-*".
+    allowed_reasons contains "edge-service-audit-customer" if {
+    	input.principal.type == "HUMAN"
+    	input.principal.id == "service-account-openbank-edge"
+    	input.action == "audit.customerRead"
     }
 
     # Any M2M service-account caller (e.g. account-service) may trigger a sanctions screen

--- a/openbank-infra/gitops/components/dispute-service/dispute-service.yaml
+++ b/openbank-infra/gitops/components/dispute-service/dispute-service.yaml
@@ -15,7 +15,7 @@ spec:
       annotations:
         # Rolls the pod when the OPA bundle changes — subPath mounts do NOT hot-reload.
         # Kept in sync by gen-dispute-opa-bundle.sh (do not hand-edit).
-        openbank.tech/policy-checksum: "d60af72d628bf649"
+        openbank.tech/policy-checksum: "41bab1de48db0ebc"
       labels: {app.kubernetes.io/name: dispute-service, app.kubernetes.io/part-of: dispute}
     spec:
       securityContext:

--- a/openbank-infra/gitops/components/document-service/document-service-opa-bundle.yaml
+++ b/openbank-infra/gitops/components/document-service/document-service-opa-bundle.yaml
@@ -10,7 +10,7 @@ metadata:
     app.kubernetes.io/name: document-service
     app.kubernetes.io/part-of: documents
   annotations:
-    openbank.tech/policy-checksum: "c83800f2882da701"
+    openbank.tech/policy-checksum: "286e0ec440ea1c56"
 data:
   rest.rego: |
     # SPDX-License-Identifier: Apache-2.0
@@ -264,6 +264,28 @@ data:
     	input.principal.type == "HUMAN"
     	input.principal.id == "service-account-openbank-edge"
     	input.action in {"consent.list", "consent.revoke"}
+    }
+
+    # The customer-edge proxying the app's privacy centre: a customer reads their OWN access log
+    # (P2-27). Same edge principal and same guard as edge-service-consent — the edge injects the
+    # caller's authoritative partyId from the JWT, so a client-supplied id never reaches
+    # audit-service.
+    #
+    # Deliberately a DISTINCT action from `audit.read`, not the `audit.` family: `audit.read` is the
+    # auditor/compliance surface over the whole trail (GET /entries/{aggregateId},
+    # /entries/by-actor/{actorId}) and granting it to the edge principal would put regulated evidence
+    # behind a service account. `audit.customerRead` reaches only the metadata projection.
+    #
+    # This rule is what actually narrows the endpoint. Its @RolesAllowed had to widen to
+    # ROLE_API/ROLE_OPERATOR/ROLE_ADMIN — the edge's service account carries ROLE_OPERATOR, so
+    # @RolesAllowed(ROLE_API) alone 403'd every call before the PDP was consulted (same shape as
+    # document-service's SignatureCeremonyResource) — and ROLE_OPERATOR is held by real staff too.
+    # The identity match below is therefore the load-bearing half: staff sessions authenticate
+    # through a different client, so their preferred_username is never "service-account-*".
+    allowed_reasons contains "edge-service-audit-customer" if {
+    	input.principal.type == "HUMAN"
+    	input.principal.id == "service-account-openbank-edge"
+    	input.action == "audit.customerRead"
     }
 
     # Any M2M service-account caller (e.g. account-service) may trigger a sanctions screen

--- a/openbank-infra/gitops/components/document-service/document-service-service.yaml
+++ b/openbank-infra/gitops/components/document-service/document-service-service.yaml
@@ -43,7 +43,7 @@ spec:
       annotations:
         # Rolls the pods when the OPA bundle changes — subPath mounts do NOT hot-reload.
         # Kept in sync by gen-document-service-opa-bundle.sh (do not hand-edit).
-        openbank.tech/policy-checksum: "c83800f2882da701"
+        openbank.tech/policy-checksum: "286e0ec440ea1c56"
     spec:
       # ADR-0162 D4 (continued): a dedicated SA (not `default`) is what OpenBao's Kubernetes-auth
       # role `document-service-signing` is bound to — least-privilege, one identity per consumer.

--- a/openbank-infra/gitops/components/fraud-service/fraud-opa-bundle.yaml
+++ b/openbank-infra/gitops/components/fraud-service/fraud-opa-bundle.yaml
@@ -9,7 +9,7 @@ metadata:
     app.kubernetes.io/name: fraud-service
     app.kubernetes.io/part-of: fraud
   annotations:
-    openbank.tech/policy-checksum: "6d3605dc23a1a9fc"
+    openbank.tech/policy-checksum: "5b47182ca8826422"
 data:
   rest.rego: |
     # SPDX-License-Identifier: Apache-2.0
@@ -263,6 +263,28 @@ data:
     	input.principal.type == "HUMAN"
     	input.principal.id == "service-account-openbank-edge"
     	input.action in {"consent.list", "consent.revoke"}
+    }
+
+    # The customer-edge proxying the app's privacy centre: a customer reads their OWN access log
+    # (P2-27). Same edge principal and same guard as edge-service-consent — the edge injects the
+    # caller's authoritative partyId from the JWT, so a client-supplied id never reaches
+    # audit-service.
+    #
+    # Deliberately a DISTINCT action from `audit.read`, not the `audit.` family: `audit.read` is the
+    # auditor/compliance surface over the whole trail (GET /entries/{aggregateId},
+    # /entries/by-actor/{actorId}) and granting it to the edge principal would put regulated evidence
+    # behind a service account. `audit.customerRead` reaches only the metadata projection.
+    #
+    # This rule is what actually narrows the endpoint. Its @RolesAllowed had to widen to
+    # ROLE_API/ROLE_OPERATOR/ROLE_ADMIN — the edge's service account carries ROLE_OPERATOR, so
+    # @RolesAllowed(ROLE_API) alone 403'd every call before the PDP was consulted (same shape as
+    # document-service's SignatureCeremonyResource) — and ROLE_OPERATOR is held by real staff too.
+    # The identity match below is therefore the load-bearing half: staff sessions authenticate
+    # through a different client, so their preferred_username is never "service-account-*".
+    allowed_reasons contains "edge-service-audit-customer" if {
+    	input.principal.type == "HUMAN"
+    	input.principal.id == "service-account-openbank-edge"
+    	input.action == "audit.customerRead"
     }
 
     # Any M2M service-account caller (e.g. account-service) may trigger a sanctions screen

--- a/openbank-infra/gitops/components/fraud-service/fraud-service.yaml
+++ b/openbank-infra/gitops/components/fraud-service/fraud-service.yaml
@@ -23,7 +23,7 @@ spec:
       annotations:
         # Rolls the pods when the OPA bundle changes — subPath mounts do NOT hot-reload.
         # Kept in sync by gen-fraud-opa-bundle.sh (do not hand-edit).
-        openbank.tech/policy-checksum: "6d3605dc23a1a9fc"
+        openbank.tech/policy-checksum: "5b47182ca8826422"
     spec:
       securityContext:
         runAsNonRoot: true

--- a/openbank-infra/gitops/components/fx-service/fx-opa-bundle.yaml
+++ b/openbank-infra/gitops/components/fx-service/fx-opa-bundle.yaml
@@ -9,7 +9,7 @@ metadata:
     app.kubernetes.io/name: fx-service
     app.kubernetes.io/part-of: fx
   annotations:
-    openbank.tech/policy-checksum: "7c8201d30e5eb6b7"
+    openbank.tech/policy-checksum: "a4a863c279d984ee"
 data:
   rest.rego: |
     # SPDX-License-Identifier: Apache-2.0
@@ -263,6 +263,28 @@ data:
     	input.principal.type == "HUMAN"
     	input.principal.id == "service-account-openbank-edge"
     	input.action in {"consent.list", "consent.revoke"}
+    }
+
+    # The customer-edge proxying the app's privacy centre: a customer reads their OWN access log
+    # (P2-27). Same edge principal and same guard as edge-service-consent — the edge injects the
+    # caller's authoritative partyId from the JWT, so a client-supplied id never reaches
+    # audit-service.
+    #
+    # Deliberately a DISTINCT action from `audit.read`, not the `audit.` family: `audit.read` is the
+    # auditor/compliance surface over the whole trail (GET /entries/{aggregateId},
+    # /entries/by-actor/{actorId}) and granting it to the edge principal would put regulated evidence
+    # behind a service account. `audit.customerRead` reaches only the metadata projection.
+    #
+    # This rule is what actually narrows the endpoint. Its @RolesAllowed had to widen to
+    # ROLE_API/ROLE_OPERATOR/ROLE_ADMIN — the edge's service account carries ROLE_OPERATOR, so
+    # @RolesAllowed(ROLE_API) alone 403'd every call before the PDP was consulted (same shape as
+    # document-service's SignatureCeremonyResource) — and ROLE_OPERATOR is held by real staff too.
+    # The identity match below is therefore the load-bearing half: staff sessions authenticate
+    # through a different client, so their preferred_username is never "service-account-*".
+    allowed_reasons contains "edge-service-audit-customer" if {
+    	input.principal.type == "HUMAN"
+    	input.principal.id == "service-account-openbank-edge"
+    	input.action == "audit.customerRead"
     }
 
     # Any M2M service-account caller (e.g. account-service) may trigger a sanctions screen

--- a/openbank-infra/gitops/components/fx-service/fx-service.yaml
+++ b/openbank-infra/gitops/components/fx-service/fx-service.yaml
@@ -22,7 +22,7 @@ spec:
       annotations:
         # Rolls the pods when the OPA bundle changes — subPath mounts do NOT hot-reload.
         # Kept in sync by gen-fx-opa-bundle.sh (do not hand-edit).
-        openbank.tech/policy-checksum: "7c8201d30e5eb6b7"
+        openbank.tech/policy-checksum: "a4a863c279d984ee"
     spec:
       securityContext:
         runAsNonRoot: true

--- a/openbank-infra/gitops/components/interest-service/interest-opa-bundle.yaml
+++ b/openbank-infra/gitops/components/interest-service/interest-opa-bundle.yaml
@@ -9,7 +9,7 @@ metadata:
     app.kubernetes.io/name: interest-service
     app.kubernetes.io/part-of: interest
   annotations:
-    openbank.tech/policy-checksum: "c58b827e620ef793"
+    openbank.tech/policy-checksum: "ae4ef6dd481e2e5f"
 data:
   rest.rego: |
     # SPDX-License-Identifier: Apache-2.0
@@ -263,6 +263,28 @@ data:
     	input.principal.type == "HUMAN"
     	input.principal.id == "service-account-openbank-edge"
     	input.action in {"consent.list", "consent.revoke"}
+    }
+
+    # The customer-edge proxying the app's privacy centre: a customer reads their OWN access log
+    # (P2-27). Same edge principal and same guard as edge-service-consent — the edge injects the
+    # caller's authoritative partyId from the JWT, so a client-supplied id never reaches
+    # audit-service.
+    #
+    # Deliberately a DISTINCT action from `audit.read`, not the `audit.` family: `audit.read` is the
+    # auditor/compliance surface over the whole trail (GET /entries/{aggregateId},
+    # /entries/by-actor/{actorId}) and granting it to the edge principal would put regulated evidence
+    # behind a service account. `audit.customerRead` reaches only the metadata projection.
+    #
+    # This rule is what actually narrows the endpoint. Its @RolesAllowed had to widen to
+    # ROLE_API/ROLE_OPERATOR/ROLE_ADMIN — the edge's service account carries ROLE_OPERATOR, so
+    # @RolesAllowed(ROLE_API) alone 403'd every call before the PDP was consulted (same shape as
+    # document-service's SignatureCeremonyResource) — and ROLE_OPERATOR is held by real staff too.
+    # The identity match below is therefore the load-bearing half: staff sessions authenticate
+    # through a different client, so their preferred_username is never "service-account-*".
+    allowed_reasons contains "edge-service-audit-customer" if {
+    	input.principal.type == "HUMAN"
+    	input.principal.id == "service-account-openbank-edge"
+    	input.action == "audit.customerRead"
     }
 
     # Any M2M service-account caller (e.g. account-service) may trigger a sanctions screen

--- a/openbank-infra/gitops/components/interest-service/interest-service.yaml
+++ b/openbank-infra/gitops/components/interest-service/interest-service.yaml
@@ -16,7 +16,7 @@ spec:
       annotations:
         # Rolls the pods when the OPA bundle changes — subPath mounts do NOT hot-reload.
         # Kept in sync by gen-interest-opa-bundle.sh (do not hand-edit).
-        openbank.tech/policy-checksum: "c58b827e620ef793"
+        openbank.tech/policy-checksum: "ae4ef6dd481e2e5f"
     spec:
       securityContext:
         runAsNonRoot: true

--- a/openbank-infra/gitops/components/keycloak/customers-realm-template.json
+++ b/openbank-infra/gitops/components/keycloak/customers-realm-template.json
@@ -34,6 +34,7 @@
       "serviceAccountsEnabled": false,
       "protocol": "openid-connect",
       "redirectUris": [
+        "https://open-bank.tech/app/oauth/callback",
         "tech.openbank.app://oauth/callback",
         "http://localhost:*"
       ],
@@ -42,7 +43,7 @@
         "pkce.code.challenge.method": "S256",
         "oauth2.device.authorization.grant.enabled": "false",
         "backchannel.logout.session.required": "true",
-        "post.logout.redirect.uris": "tech.openbank.app://oauth/logout"
+        "post.logout.redirect.uris": "https://open-bank.tech/app/oauth/logout##tech.openbank.app://oauth/logout"
       },
       "defaultClientScopes": [
         "openid",

--- a/openbank-infra/gitops/components/kyc/kyc-opa-bundle.yaml
+++ b/openbank-infra/gitops/components/kyc/kyc-opa-bundle.yaml
@@ -9,7 +9,7 @@ metadata:
     app.kubernetes.io/name: kyc-service
     app.kubernetes.io/part-of: kyc
   annotations:
-    openbank.tech/policy-checksum: "c939355eabe7ef8a"
+    openbank.tech/policy-checksum: "e0086bd0cb70572d"
 data:
   rest.rego: |
     # SPDX-License-Identifier: Apache-2.0
@@ -263,6 +263,28 @@ data:
     	input.principal.type == "HUMAN"
     	input.principal.id == "service-account-openbank-edge"
     	input.action in {"consent.list", "consent.revoke"}
+    }
+
+    # The customer-edge proxying the app's privacy centre: a customer reads their OWN access log
+    # (P2-27). Same edge principal and same guard as edge-service-consent — the edge injects the
+    # caller's authoritative partyId from the JWT, so a client-supplied id never reaches
+    # audit-service.
+    #
+    # Deliberately a DISTINCT action from `audit.read`, not the `audit.` family: `audit.read` is the
+    # auditor/compliance surface over the whole trail (GET /entries/{aggregateId},
+    # /entries/by-actor/{actorId}) and granting it to the edge principal would put regulated evidence
+    # behind a service account. `audit.customerRead` reaches only the metadata projection.
+    #
+    # This rule is what actually narrows the endpoint. Its @RolesAllowed had to widen to
+    # ROLE_API/ROLE_OPERATOR/ROLE_ADMIN — the edge's service account carries ROLE_OPERATOR, so
+    # @RolesAllowed(ROLE_API) alone 403'd every call before the PDP was consulted (same shape as
+    # document-service's SignatureCeremonyResource) — and ROLE_OPERATOR is held by real staff too.
+    # The identity match below is therefore the load-bearing half: staff sessions authenticate
+    # through a different client, so their preferred_username is never "service-account-*".
+    allowed_reasons contains "edge-service-audit-customer" if {
+    	input.principal.type == "HUMAN"
+    	input.principal.id == "service-account-openbank-edge"
+    	input.action == "audit.customerRead"
     }
 
     # Any M2M service-account caller (e.g. account-service) may trigger a sanctions screen

--- a/openbank-infra/gitops/components/kyc/kyc-service.yaml
+++ b/openbank-infra/gitops/components/kyc/kyc-service.yaml
@@ -48,7 +48,7 @@ spec:
       annotations:
         # Rolls the pod when the OPA bundle changes (subPath mounts do not hot-reload).
         # Kept in sync by gen-kyc-opa-bundle.sh (do not hand-edit).
-        openbank.tech/policy-checksum: "c939355eabe7ef8a"
+        openbank.tech/policy-checksum: "e0086bd0cb70572d"
     spec:
       securityContext:
         runAsNonRoot: true

--- a/openbank-infra/gitops/components/ledger/ledger-opa-bundle.yaml
+++ b/openbank-infra/gitops/components/ledger/ledger-opa-bundle.yaml
@@ -9,7 +9,7 @@ metadata:
     app.kubernetes.io/name: ledger-service
     app.kubernetes.io/part-of: ledger
   annotations:
-    openbank.tech/policy-checksum: "86975e5d591fcfc7"
+    openbank.tech/policy-checksum: "b77b00c3a098abfc"
 data:
   rest.rego: |
     # SPDX-License-Identifier: Apache-2.0
@@ -263,6 +263,28 @@ data:
     	input.principal.type == "HUMAN"
     	input.principal.id == "service-account-openbank-edge"
     	input.action in {"consent.list", "consent.revoke"}
+    }
+
+    # The customer-edge proxying the app's privacy centre: a customer reads their OWN access log
+    # (P2-27). Same edge principal and same guard as edge-service-consent — the edge injects the
+    # caller's authoritative partyId from the JWT, so a client-supplied id never reaches
+    # audit-service.
+    #
+    # Deliberately a DISTINCT action from `audit.read`, not the `audit.` family: `audit.read` is the
+    # auditor/compliance surface over the whole trail (GET /entries/{aggregateId},
+    # /entries/by-actor/{actorId}) and granting it to the edge principal would put regulated evidence
+    # behind a service account. `audit.customerRead` reaches only the metadata projection.
+    #
+    # This rule is what actually narrows the endpoint. Its @RolesAllowed had to widen to
+    # ROLE_API/ROLE_OPERATOR/ROLE_ADMIN — the edge's service account carries ROLE_OPERATOR, so
+    # @RolesAllowed(ROLE_API) alone 403'd every call before the PDP was consulted (same shape as
+    # document-service's SignatureCeremonyResource) — and ROLE_OPERATOR is held by real staff too.
+    # The identity match below is therefore the load-bearing half: staff sessions authenticate
+    # through a different client, so their preferred_username is never "service-account-*".
+    allowed_reasons contains "edge-service-audit-customer" if {
+    	input.principal.type == "HUMAN"
+    	input.principal.id == "service-account-openbank-edge"
+    	input.action == "audit.customerRead"
     }
 
     # Any M2M service-account caller (e.g. account-service) may trigger a sanctions screen

--- a/openbank-infra/gitops/components/ledger/ledger-service.yaml
+++ b/openbank-infra/gitops/components/ledger/ledger-service.yaml
@@ -38,7 +38,7 @@ spec:
       annotations:
         # Rolls the pods when the OPA bundle changes — subPath mounts do NOT hot-reload.
         # Kept in sync by gen-ledger-opa-bundle.sh (do not hand-edit).
-        openbank.tech/policy-checksum: "86975e5d591fcfc7"
+        openbank.tech/policy-checksum: "b77b00c3a098abfc"
     spec:
       securityContext:
         runAsNonRoot: true

--- a/openbank-infra/gitops/components/lending/lending-opa-bundle.yaml
+++ b/openbank-infra/gitops/components/lending/lending-opa-bundle.yaml
@@ -9,7 +9,7 @@ metadata:
     app.kubernetes.io/name: lending-service
     app.kubernetes.io/part-of: lending
   annotations:
-    openbank.tech/policy-checksum: "d10883c21196c967"
+    openbank.tech/policy-checksum: "28dbc221777723ac"
 data:
   rest.rego: |
     # SPDX-License-Identifier: Apache-2.0
@@ -263,6 +263,28 @@ data:
     	input.principal.type == "HUMAN"
     	input.principal.id == "service-account-openbank-edge"
     	input.action in {"consent.list", "consent.revoke"}
+    }
+
+    # The customer-edge proxying the app's privacy centre: a customer reads their OWN access log
+    # (P2-27). Same edge principal and same guard as edge-service-consent — the edge injects the
+    # caller's authoritative partyId from the JWT, so a client-supplied id never reaches
+    # audit-service.
+    #
+    # Deliberately a DISTINCT action from `audit.read`, not the `audit.` family: `audit.read` is the
+    # auditor/compliance surface over the whole trail (GET /entries/{aggregateId},
+    # /entries/by-actor/{actorId}) and granting it to the edge principal would put regulated evidence
+    # behind a service account. `audit.customerRead` reaches only the metadata projection.
+    #
+    # This rule is what actually narrows the endpoint. Its @RolesAllowed had to widen to
+    # ROLE_API/ROLE_OPERATOR/ROLE_ADMIN — the edge's service account carries ROLE_OPERATOR, so
+    # @RolesAllowed(ROLE_API) alone 403'd every call before the PDP was consulted (same shape as
+    # document-service's SignatureCeremonyResource) — and ROLE_OPERATOR is held by real staff too.
+    # The identity match below is therefore the load-bearing half: staff sessions authenticate
+    # through a different client, so their preferred_username is never "service-account-*".
+    allowed_reasons contains "edge-service-audit-customer" if {
+    	input.principal.type == "HUMAN"
+    	input.principal.id == "service-account-openbank-edge"
+    	input.action == "audit.customerRead"
     }
 
     # Any M2M service-account caller (e.g. account-service) may trigger a sanctions screen

--- a/openbank-infra/gitops/components/lending/lending-service.yaml
+++ b/openbank-infra/gitops/components/lending/lending-service.yaml
@@ -34,7 +34,7 @@ spec:
       annotations:
         # Rolls the pods when the OPA bundle changes — subPath mounts do NOT hot-reload.
         # Kept in sync by gen-lending-opa-bundle.sh (do not hand-edit).
-        openbank.tech/policy-checksum: "d10883c21196c967"
+        openbank.tech/policy-checksum: "28dbc221777723ac"
     spec:
       securityContext:
         runAsNonRoot: true

--- a/openbank-infra/gitops/components/mcp/mcp-opa-bundle.yaml
+++ b/openbank-infra/gitops/components/mcp/mcp-opa-bundle.yaml
@@ -9,7 +9,7 @@ metadata:
     app.kubernetes.io/name: mcp-service
     app.kubernetes.io/part-of: platform
   annotations:
-    openbank.tech/policy-checksum: "e6597e9970958601"
+    openbank.tech/policy-checksum: "2b72638dd5431d53"
 data:
   rest.rego: |
     # SPDX-License-Identifier: Apache-2.0
@@ -263,6 +263,28 @@ data:
     	input.principal.type == "HUMAN"
     	input.principal.id == "service-account-openbank-edge"
     	input.action in {"consent.list", "consent.revoke"}
+    }
+
+    # The customer-edge proxying the app's privacy centre: a customer reads their OWN access log
+    # (P2-27). Same edge principal and same guard as edge-service-consent — the edge injects the
+    # caller's authoritative partyId from the JWT, so a client-supplied id never reaches
+    # audit-service.
+    #
+    # Deliberately a DISTINCT action from `audit.read`, not the `audit.` family: `audit.read` is the
+    # auditor/compliance surface over the whole trail (GET /entries/{aggregateId},
+    # /entries/by-actor/{actorId}) and granting it to the edge principal would put regulated evidence
+    # behind a service account. `audit.customerRead` reaches only the metadata projection.
+    #
+    # This rule is what actually narrows the endpoint. Its @RolesAllowed had to widen to
+    # ROLE_API/ROLE_OPERATOR/ROLE_ADMIN — the edge's service account carries ROLE_OPERATOR, so
+    # @RolesAllowed(ROLE_API) alone 403'd every call before the PDP was consulted (same shape as
+    # document-service's SignatureCeremonyResource) — and ROLE_OPERATOR is held by real staff too.
+    # The identity match below is therefore the load-bearing half: staff sessions authenticate
+    # through a different client, so their preferred_username is never "service-account-*".
+    allowed_reasons contains "edge-service-audit-customer" if {
+    	input.principal.type == "HUMAN"
+    	input.principal.id == "service-account-openbank-edge"
+    	input.action == "audit.customerRead"
     }
 
     # Any M2M service-account caller (e.g. account-service) may trigger a sanctions screen

--- a/openbank-infra/gitops/components/mcp/mcp-service.yaml
+++ b/openbank-infra/gitops/components/mcp/mcp-service.yaml
@@ -29,7 +29,7 @@ spec:
       annotations:
         # Rolls the pod when the OPA bundle changes — subPath mounts do NOT hot-reload.
         # Kept in sync by gen-mcp-opa-bundle.sh (do not hand-edit).
-        openbank.tech/policy-checksum: "e6597e9970958601"
+        openbank.tech/policy-checksum: "2b72638dd5431d53"
     spec:
       securityContext:
         runAsNonRoot: true

--- a/openbank-infra/gitops/components/notifications/notification-service-opa-bundle.yaml
+++ b/openbank-infra/gitops/components/notifications/notification-service-opa-bundle.yaml
@@ -10,7 +10,7 @@ metadata:
     app.kubernetes.io/name: notification-service
     app.kubernetes.io/part-of: notifications
   annotations:
-    openbank.tech/policy-checksum: "c83800f2882da701"
+    openbank.tech/policy-checksum: "286e0ec440ea1c56"
 data:
   rest.rego: |
     # SPDX-License-Identifier: Apache-2.0
@@ -264,6 +264,28 @@ data:
     	input.principal.type == "HUMAN"
     	input.principal.id == "service-account-openbank-edge"
     	input.action in {"consent.list", "consent.revoke"}
+    }
+
+    # The customer-edge proxying the app's privacy centre: a customer reads their OWN access log
+    # (P2-27). Same edge principal and same guard as edge-service-consent — the edge injects the
+    # caller's authoritative partyId from the JWT, so a client-supplied id never reaches
+    # audit-service.
+    #
+    # Deliberately a DISTINCT action from `audit.read`, not the `audit.` family: `audit.read` is the
+    # auditor/compliance surface over the whole trail (GET /entries/{aggregateId},
+    # /entries/by-actor/{actorId}) and granting it to the edge principal would put regulated evidence
+    # behind a service account. `audit.customerRead` reaches only the metadata projection.
+    #
+    # This rule is what actually narrows the endpoint. Its @RolesAllowed had to widen to
+    # ROLE_API/ROLE_OPERATOR/ROLE_ADMIN — the edge's service account carries ROLE_OPERATOR, so
+    # @RolesAllowed(ROLE_API) alone 403'd every call before the PDP was consulted (same shape as
+    # document-service's SignatureCeremonyResource) — and ROLE_OPERATOR is held by real staff too.
+    # The identity match below is therefore the load-bearing half: staff sessions authenticate
+    # through a different client, so their preferred_username is never "service-account-*".
+    allowed_reasons contains "edge-service-audit-customer" if {
+    	input.principal.type == "HUMAN"
+    	input.principal.id == "service-account-openbank-edge"
+    	input.action == "audit.customerRead"
     }
 
     # Any M2M service-account caller (e.g. account-service) may trigger a sanctions screen

--- a/openbank-infra/gitops/components/notifications/notification-service.yaml
+++ b/openbank-infra/gitops/components/notifications/notification-service.yaml
@@ -39,7 +39,7 @@ spec:
       annotations:
         # Rolls the Deployment when the OPA policy bundle changes (subPath mounts don't
         # hot-reload). Kept in sync by gen-notification-opa-bundle.sh.
-        openbank.tech/policy-checksum: "c83800f2882da701"
+        openbank.tech/policy-checksum: "286e0ec440ea1c56"
       labels:
         app.kubernetes.io/name: notification-service
         app.kubernetes.io/part-of: notifications

--- a/openbank-infra/gitops/components/party/party-opa-bundle.yaml
+++ b/openbank-infra/gitops/components/party/party-opa-bundle.yaml
@@ -9,7 +9,7 @@ metadata:
     app.kubernetes.io/name: party-service
     app.kubernetes.io/part-of: party
   annotations:
-    openbank.tech/policy-checksum: "0746bed3eb06a618"
+    openbank.tech/policy-checksum: "f7d01d7cca1831f1"
 data:
   rest.rego: |
     # SPDX-License-Identifier: Apache-2.0
@@ -263,6 +263,28 @@ data:
     	input.principal.type == "HUMAN"
     	input.principal.id == "service-account-openbank-edge"
     	input.action in {"consent.list", "consent.revoke"}
+    }
+
+    # The customer-edge proxying the app's privacy centre: a customer reads their OWN access log
+    # (P2-27). Same edge principal and same guard as edge-service-consent — the edge injects the
+    # caller's authoritative partyId from the JWT, so a client-supplied id never reaches
+    # audit-service.
+    #
+    # Deliberately a DISTINCT action from `audit.read`, not the `audit.` family: `audit.read` is the
+    # auditor/compliance surface over the whole trail (GET /entries/{aggregateId},
+    # /entries/by-actor/{actorId}) and granting it to the edge principal would put regulated evidence
+    # behind a service account. `audit.customerRead` reaches only the metadata projection.
+    #
+    # This rule is what actually narrows the endpoint. Its @RolesAllowed had to widen to
+    # ROLE_API/ROLE_OPERATOR/ROLE_ADMIN — the edge's service account carries ROLE_OPERATOR, so
+    # @RolesAllowed(ROLE_API) alone 403'd every call before the PDP was consulted (same shape as
+    # document-service's SignatureCeremonyResource) — and ROLE_OPERATOR is held by real staff too.
+    # The identity match below is therefore the load-bearing half: staff sessions authenticate
+    # through a different client, so their preferred_username is never "service-account-*".
+    allowed_reasons contains "edge-service-audit-customer" if {
+    	input.principal.type == "HUMAN"
+    	input.principal.id == "service-account-openbank-edge"
+    	input.action == "audit.customerRead"
     }
 
     # Any M2M service-account caller (e.g. account-service) may trigger a sanctions screen

--- a/openbank-infra/gitops/components/party/party-service.yaml
+++ b/openbank-infra/gitops/components/party/party-service.yaml
@@ -22,7 +22,7 @@ spec:
       annotations:
         # Rolls the pod when the OPA bundle changes — subPath mounts do NOT hot-reload.
         # Kept in sync by gen-party-opa-bundle.sh (do not hand-edit).
-        openbank.tech/policy-checksum: "0746bed3eb06a618"
+        openbank.tech/policy-checksum: "f7d01d7cca1831f1"
       labels:
         app.kubernetes.io/name: party-service
         app.kubernetes.io/part-of: party

--- a/openbank-infra/gitops/components/payments/card-issuance-opa-bundle.yaml
+++ b/openbank-infra/gitops/components/payments/card-issuance-opa-bundle.yaml
@@ -9,7 +9,7 @@ metadata:
     app.kubernetes.io/name: card-issuance-service
     app.kubernetes.io/part-of: payments
   annotations:
-    openbank.tech/policy-checksum: "cc334d79025c6e4b"
+    openbank.tech/policy-checksum: "3058e7f250fcf1b5"
 data:
   rest.rego: |
     # SPDX-License-Identifier: Apache-2.0
@@ -263,6 +263,28 @@ data:
     	input.principal.type == "HUMAN"
     	input.principal.id == "service-account-openbank-edge"
     	input.action in {"consent.list", "consent.revoke"}
+    }
+
+    # The customer-edge proxying the app's privacy centre: a customer reads their OWN access log
+    # (P2-27). Same edge principal and same guard as edge-service-consent — the edge injects the
+    # caller's authoritative partyId from the JWT, so a client-supplied id never reaches
+    # audit-service.
+    #
+    # Deliberately a DISTINCT action from `audit.read`, not the `audit.` family: `audit.read` is the
+    # auditor/compliance surface over the whole trail (GET /entries/{aggregateId},
+    # /entries/by-actor/{actorId}) and granting it to the edge principal would put regulated evidence
+    # behind a service account. `audit.customerRead` reaches only the metadata projection.
+    #
+    # This rule is what actually narrows the endpoint. Its @RolesAllowed had to widen to
+    # ROLE_API/ROLE_OPERATOR/ROLE_ADMIN — the edge's service account carries ROLE_OPERATOR, so
+    # @RolesAllowed(ROLE_API) alone 403'd every call before the PDP was consulted (same shape as
+    # document-service's SignatureCeremonyResource) — and ROLE_OPERATOR is held by real staff too.
+    # The identity match below is therefore the load-bearing half: staff sessions authenticate
+    # through a different client, so their preferred_username is never "service-account-*".
+    allowed_reasons contains "edge-service-audit-customer" if {
+    	input.principal.type == "HUMAN"
+    	input.principal.id == "service-account-openbank-edge"
+    	input.action == "audit.customerRead"
     }
 
     # Any M2M service-account caller (e.g. account-service) may trigger a sanctions screen

--- a/openbank-infra/gitops/components/payments/clearing-opa-bundle.yaml
+++ b/openbank-infra/gitops/components/payments/clearing-opa-bundle.yaml
@@ -9,7 +9,7 @@ metadata:
     app.kubernetes.io/name: clearing-service
     app.kubernetes.io/part-of: payments
   annotations:
-    openbank.tech/policy-checksum: "5534408d151427b0"
+    openbank.tech/policy-checksum: "49a40d0123becbce"
 data:
   rest.rego: |
     # SPDX-License-Identifier: Apache-2.0
@@ -263,6 +263,28 @@ data:
     	input.principal.type == "HUMAN"
     	input.principal.id == "service-account-openbank-edge"
     	input.action in {"consent.list", "consent.revoke"}
+    }
+
+    # The customer-edge proxying the app's privacy centre: a customer reads their OWN access log
+    # (P2-27). Same edge principal and same guard as edge-service-consent — the edge injects the
+    # caller's authoritative partyId from the JWT, so a client-supplied id never reaches
+    # audit-service.
+    #
+    # Deliberately a DISTINCT action from `audit.read`, not the `audit.` family: `audit.read` is the
+    # auditor/compliance surface over the whole trail (GET /entries/{aggregateId},
+    # /entries/by-actor/{actorId}) and granting it to the edge principal would put regulated evidence
+    # behind a service account. `audit.customerRead` reaches only the metadata projection.
+    #
+    # This rule is what actually narrows the endpoint. Its @RolesAllowed had to widen to
+    # ROLE_API/ROLE_OPERATOR/ROLE_ADMIN — the edge's service account carries ROLE_OPERATOR, so
+    # @RolesAllowed(ROLE_API) alone 403'd every call before the PDP was consulted (same shape as
+    # document-service's SignatureCeremonyResource) — and ROLE_OPERATOR is held by real staff too.
+    # The identity match below is therefore the load-bearing half: staff sessions authenticate
+    # through a different client, so their preferred_username is never "service-account-*".
+    allowed_reasons contains "edge-service-audit-customer" if {
+    	input.principal.type == "HUMAN"
+    	input.principal.id == "service-account-openbank-edge"
+    	input.action == "audit.customerRead"
     }
 
     # Any M2M service-account caller (e.g. account-service) may trigger a sanctions screen

--- a/openbank-infra/gitops/components/payments/domestic-payment-opa-bundle.yaml
+++ b/openbank-infra/gitops/components/payments/domestic-payment-opa-bundle.yaml
@@ -9,7 +9,7 @@ metadata:
     app.kubernetes.io/name: domestic-payment
     app.kubernetes.io/part-of: payments
   annotations:
-    openbank.tech/policy-checksum: "6bf2f77cea73d574"
+    openbank.tech/policy-checksum: "529e5af8506a4826"
 data:
   rest.rego: |
     # SPDX-License-Identifier: Apache-2.0
@@ -263,6 +263,28 @@ data:
     	input.principal.type == "HUMAN"
     	input.principal.id == "service-account-openbank-edge"
     	input.action in {"consent.list", "consent.revoke"}
+    }
+
+    # The customer-edge proxying the app's privacy centre: a customer reads their OWN access log
+    # (P2-27). Same edge principal and same guard as edge-service-consent — the edge injects the
+    # caller's authoritative partyId from the JWT, so a client-supplied id never reaches
+    # audit-service.
+    #
+    # Deliberately a DISTINCT action from `audit.read`, not the `audit.` family: `audit.read` is the
+    # auditor/compliance surface over the whole trail (GET /entries/{aggregateId},
+    # /entries/by-actor/{actorId}) and granting it to the edge principal would put regulated evidence
+    # behind a service account. `audit.customerRead` reaches only the metadata projection.
+    #
+    # This rule is what actually narrows the endpoint. Its @RolesAllowed had to widen to
+    # ROLE_API/ROLE_OPERATOR/ROLE_ADMIN — the edge's service account carries ROLE_OPERATOR, so
+    # @RolesAllowed(ROLE_API) alone 403'd every call before the PDP was consulted (same shape as
+    # document-service's SignatureCeremonyResource) — and ROLE_OPERATOR is held by real staff too.
+    # The identity match below is therefore the load-bearing half: staff sessions authenticate
+    # through a different client, so their preferred_username is never "service-account-*".
+    allowed_reasons contains "edge-service-audit-customer" if {
+    	input.principal.type == "HUMAN"
+    	input.principal.id == "service-account-openbank-edge"
+    	input.action == "audit.customerRead"
     }
 
     # Any M2M service-account caller (e.g. account-service) may trigger a sanctions screen

--- a/openbank-infra/gitops/components/payments/payments-services.yaml
+++ b/openbank-infra/gitops/components/payments/payments-services.yaml
@@ -42,7 +42,7 @@ spec:
         # Rolls the pods when the OPA bundle changes — subPath mounts do NOT hot-reload.
         # Kept in sync by gen-transaction-opa-bundle.sh via the trailing marker comment
         # (do not hand-edit, do not drop the marker).
-        openbank.tech/policy-checksum: "863184ff7c5efff5" # transaction-opa-bundle
+        openbank.tech/policy-checksum: "95504ea002c02a76" # transaction-opa-bundle
     spec:
       securityContext:
         runAsNonRoot: true
@@ -375,7 +375,7 @@ spec:
       annotations:
         # Rolls the pods when the OPA bundle changes — subPath mounts do NOT hot-reload.
         # Kept in sync by gen-sepa-payment-opa-bundle.sh (do not hand-edit).
-        openbank.tech/policy-checksum: "0e8d3c7fc0ccc83e"
+        openbank.tech/policy-checksum: "6e82a2974c324f9e"
     spec:
       securityContext:
         runAsNonRoot: true
@@ -729,7 +729,7 @@ spec:
         # Rolls the pods when the OPA bundle changes — subPath mounts do NOT hot-reload.
         # Kept in sync by gen-domestic-payment-opa-bundle.sh via the trailing marker
         # comment (do not hand-edit, do not drop the marker).
-        openbank.tech/policy-checksum: "6bf2f77cea73d574" # domestic-payment-opa-bundle
+        openbank.tech/policy-checksum: "529e5af8506a4826" # domestic-payment-opa-bundle
     spec:
       securityContext:
         runAsNonRoot: true
@@ -1053,7 +1053,7 @@ spec:
       annotations:
         # Rolls the pods when the OPA bundle changes — subPath mounts do NOT hot-reload.
         # Kept in sync by gen-sepa-instant-opa-bundle.sh (do not hand-edit).
-        openbank.tech/policy-checksum: "10b13d1c2851b934"
+        openbank.tech/policy-checksum: "4accca3bbd77017d"
     spec:
       securityContext:
         runAsNonRoot: true
@@ -1369,7 +1369,7 @@ spec:
         # Rolls the pods when the OPA bundle changes — subPath mounts do NOT hot-reload.
         # Kept in sync by gen-clearing-opa-bundle.sh via the trailing marker comment
         # (do not hand-edit, do not drop the marker).
-        openbank.tech/policy-checksum: "5534408d151427b0" # clearing-opa-bundle
+        openbank.tech/policy-checksum: "49a40d0123becbce" # clearing-opa-bundle
     spec:
       securityContext:
         runAsNonRoot: true
@@ -1658,7 +1658,7 @@ spec:
       annotations:
         # Rolls the pod when the OPA bundle changes (ADR-0034). Value is stamped by
         # gen-standing-order-opa-bundle.sh — do not hand-edit.
-        openbank.tech/policy-checksum: "48c74e15da6adce6" # standing-order-opa-bundle
+        openbank.tech/policy-checksum: "c95cfddca8e6d631" # standing-order-opa-bundle
     spec:
       securityContext:
         runAsNonRoot: true
@@ -1911,7 +1911,7 @@ spec:
       annotations:
         # Rolls the pods when the OPA bundle changes — subPath mounts do NOT hot-reload.
         # Kept in sync by gen-card-issuance-opa-bundle.sh (do not hand-edit).
-        openbank.tech/policy-checksum: "cc334d79025c6e4b"
+        openbank.tech/policy-checksum: "3058e7f250fcf1b5"
     spec:
       securityContext:
         runAsNonRoot: true
@@ -2181,7 +2181,7 @@ spec:
         # Rolls the pods when the OPA bundle changes — subPath mounts do NOT hot-reload.
         # Kept in sync by gen-settlement-opa-bundle.sh via the trailing marker comment
         # (do not hand-edit, do not drop the marker).
-        openbank.tech/policy-checksum: "80bbb45628844519" # settlement-opa-bundle
+        openbank.tech/policy-checksum: "57071e4adc8bcb08" # settlement-opa-bundle
     spec:
       securityContext:
         runAsNonRoot: true
@@ -2582,7 +2582,7 @@ spec:
       annotations:
         # Rolls the pods when the OPA bundle changes — subPath mounts do NOT hot-reload.
         # Kept in sync by gen-swift-opa-bundle.sh (do not hand-edit).
-        openbank.tech/policy-checksum: "1da5c3944d9bfa36"
+        openbank.tech/policy-checksum: "628beb00cd77ba83"
     spec:
       securityContext:
         runAsNonRoot: true
@@ -2896,7 +2896,7 @@ spec:
       annotations:
         # Rolls the pods when the OPA bundle changes — subPath mounts do NOT hot-reload.
         # Kept in sync by gen-vop-opa-bundle.sh (do not hand-edit).
-        openbank.tech/policy-checksum: "14ce4c81e21ab3c1"
+        openbank.tech/policy-checksum: "9987da60537a1d87"
     spec:
       securityContext:
         runAsNonRoot: true

--- a/openbank-infra/gitops/components/payments/sepa-instant-opa-bundle.yaml
+++ b/openbank-infra/gitops/components/payments/sepa-instant-opa-bundle.yaml
@@ -9,7 +9,7 @@ metadata:
     app.kubernetes.io/name: sepa-instant
     app.kubernetes.io/part-of: payments
   annotations:
-    openbank.tech/policy-checksum: "10b13d1c2851b934"
+    openbank.tech/policy-checksum: "4accca3bbd77017d"
 data:
   rest.rego: |
     # SPDX-License-Identifier: Apache-2.0
@@ -263,6 +263,28 @@ data:
     	input.principal.type == "HUMAN"
     	input.principal.id == "service-account-openbank-edge"
     	input.action in {"consent.list", "consent.revoke"}
+    }
+
+    # The customer-edge proxying the app's privacy centre: a customer reads their OWN access log
+    # (P2-27). Same edge principal and same guard as edge-service-consent — the edge injects the
+    # caller's authoritative partyId from the JWT, so a client-supplied id never reaches
+    # audit-service.
+    #
+    # Deliberately a DISTINCT action from `audit.read`, not the `audit.` family: `audit.read` is the
+    # auditor/compliance surface over the whole trail (GET /entries/{aggregateId},
+    # /entries/by-actor/{actorId}) and granting it to the edge principal would put regulated evidence
+    # behind a service account. `audit.customerRead` reaches only the metadata projection.
+    #
+    # This rule is what actually narrows the endpoint. Its @RolesAllowed had to widen to
+    # ROLE_API/ROLE_OPERATOR/ROLE_ADMIN — the edge's service account carries ROLE_OPERATOR, so
+    # @RolesAllowed(ROLE_API) alone 403'd every call before the PDP was consulted (same shape as
+    # document-service's SignatureCeremonyResource) — and ROLE_OPERATOR is held by real staff too.
+    # The identity match below is therefore the load-bearing half: staff sessions authenticate
+    # through a different client, so their preferred_username is never "service-account-*".
+    allowed_reasons contains "edge-service-audit-customer" if {
+    	input.principal.type == "HUMAN"
+    	input.principal.id == "service-account-openbank-edge"
+    	input.action == "audit.customerRead"
     }
 
     # Any M2M service-account caller (e.g. account-service) may trigger a sanctions screen

--- a/openbank-infra/gitops/components/payments/sepa-payment-opa-bundle.yaml
+++ b/openbank-infra/gitops/components/payments/sepa-payment-opa-bundle.yaml
@@ -9,7 +9,7 @@ metadata:
     app.kubernetes.io/name: sepa-payment
     app.kubernetes.io/part-of: payments
   annotations:
-    openbank.tech/policy-checksum: "0e8d3c7fc0ccc83e"
+    openbank.tech/policy-checksum: "6e82a2974c324f9e"
 data:
   rest.rego: |
     # SPDX-License-Identifier: Apache-2.0
@@ -263,6 +263,28 @@ data:
     	input.principal.type == "HUMAN"
     	input.principal.id == "service-account-openbank-edge"
     	input.action in {"consent.list", "consent.revoke"}
+    }
+
+    # The customer-edge proxying the app's privacy centre: a customer reads their OWN access log
+    # (P2-27). Same edge principal and same guard as edge-service-consent — the edge injects the
+    # caller's authoritative partyId from the JWT, so a client-supplied id never reaches
+    # audit-service.
+    #
+    # Deliberately a DISTINCT action from `audit.read`, not the `audit.` family: `audit.read` is the
+    # auditor/compliance surface over the whole trail (GET /entries/{aggregateId},
+    # /entries/by-actor/{actorId}) and granting it to the edge principal would put regulated evidence
+    # behind a service account. `audit.customerRead` reaches only the metadata projection.
+    #
+    # This rule is what actually narrows the endpoint. Its @RolesAllowed had to widen to
+    # ROLE_API/ROLE_OPERATOR/ROLE_ADMIN — the edge's service account carries ROLE_OPERATOR, so
+    # @RolesAllowed(ROLE_API) alone 403'd every call before the PDP was consulted (same shape as
+    # document-service's SignatureCeremonyResource) — and ROLE_OPERATOR is held by real staff too.
+    # The identity match below is therefore the load-bearing half: staff sessions authenticate
+    # through a different client, so their preferred_username is never "service-account-*".
+    allowed_reasons contains "edge-service-audit-customer" if {
+    	input.principal.type == "HUMAN"
+    	input.principal.id == "service-account-openbank-edge"
+    	input.action == "audit.customerRead"
     }
 
     # Any M2M service-account caller (e.g. account-service) may trigger a sanctions screen

--- a/openbank-infra/gitops/components/payments/settlement-opa-bundle.yaml
+++ b/openbank-infra/gitops/components/payments/settlement-opa-bundle.yaml
@@ -9,7 +9,7 @@ metadata:
     app.kubernetes.io/name: settlement-service
     app.kubernetes.io/part-of: payments
   annotations:
-    openbank.tech/policy-checksum: "80bbb45628844519"
+    openbank.tech/policy-checksum: "57071e4adc8bcb08"
 data:
   rest.rego: |
     # SPDX-License-Identifier: Apache-2.0
@@ -263,6 +263,28 @@ data:
     	input.principal.type == "HUMAN"
     	input.principal.id == "service-account-openbank-edge"
     	input.action in {"consent.list", "consent.revoke"}
+    }
+
+    # The customer-edge proxying the app's privacy centre: a customer reads their OWN access log
+    # (P2-27). Same edge principal and same guard as edge-service-consent — the edge injects the
+    # caller's authoritative partyId from the JWT, so a client-supplied id never reaches
+    # audit-service.
+    #
+    # Deliberately a DISTINCT action from `audit.read`, not the `audit.` family: `audit.read` is the
+    # auditor/compliance surface over the whole trail (GET /entries/{aggregateId},
+    # /entries/by-actor/{actorId}) and granting it to the edge principal would put regulated evidence
+    # behind a service account. `audit.customerRead` reaches only the metadata projection.
+    #
+    # This rule is what actually narrows the endpoint. Its @RolesAllowed had to widen to
+    # ROLE_API/ROLE_OPERATOR/ROLE_ADMIN — the edge's service account carries ROLE_OPERATOR, so
+    # @RolesAllowed(ROLE_API) alone 403'd every call before the PDP was consulted (same shape as
+    # document-service's SignatureCeremonyResource) — and ROLE_OPERATOR is held by real staff too.
+    # The identity match below is therefore the load-bearing half: staff sessions authenticate
+    # through a different client, so their preferred_username is never "service-account-*".
+    allowed_reasons contains "edge-service-audit-customer" if {
+    	input.principal.type == "HUMAN"
+    	input.principal.id == "service-account-openbank-edge"
+    	input.action == "audit.customerRead"
     }
 
     # Any M2M service-account caller (e.g. account-service) may trigger a sanctions screen

--- a/openbank-infra/gitops/components/payments/standing-order-opa-bundle.yaml
+++ b/openbank-infra/gitops/components/payments/standing-order-opa-bundle.yaml
@@ -9,7 +9,7 @@ metadata:
     app.kubernetes.io/name: standing-order-service
     app.kubernetes.io/part-of: payments
   annotations:
-    openbank.tech/policy-checksum: "48c74e15da6adce6"
+    openbank.tech/policy-checksum: "c95cfddca8e6d631"
 data:
   rest.rego: |
     # SPDX-License-Identifier: Apache-2.0
@@ -263,6 +263,28 @@ data:
     	input.principal.type == "HUMAN"
     	input.principal.id == "service-account-openbank-edge"
     	input.action in {"consent.list", "consent.revoke"}
+    }
+
+    # The customer-edge proxying the app's privacy centre: a customer reads their OWN access log
+    # (P2-27). Same edge principal and same guard as edge-service-consent — the edge injects the
+    # caller's authoritative partyId from the JWT, so a client-supplied id never reaches
+    # audit-service.
+    #
+    # Deliberately a DISTINCT action from `audit.read`, not the `audit.` family: `audit.read` is the
+    # auditor/compliance surface over the whole trail (GET /entries/{aggregateId},
+    # /entries/by-actor/{actorId}) and granting it to the edge principal would put regulated evidence
+    # behind a service account. `audit.customerRead` reaches only the metadata projection.
+    #
+    # This rule is what actually narrows the endpoint. Its @RolesAllowed had to widen to
+    # ROLE_API/ROLE_OPERATOR/ROLE_ADMIN — the edge's service account carries ROLE_OPERATOR, so
+    # @RolesAllowed(ROLE_API) alone 403'd every call before the PDP was consulted (same shape as
+    # document-service's SignatureCeremonyResource) — and ROLE_OPERATOR is held by real staff too.
+    # The identity match below is therefore the load-bearing half: staff sessions authenticate
+    # through a different client, so their preferred_username is never "service-account-*".
+    allowed_reasons contains "edge-service-audit-customer" if {
+    	input.principal.type == "HUMAN"
+    	input.principal.id == "service-account-openbank-edge"
+    	input.action == "audit.customerRead"
     }
 
     # Any M2M service-account caller (e.g. account-service) may trigger a sanctions screen

--- a/openbank-infra/gitops/components/payments/swift-opa-bundle.yaml
+++ b/openbank-infra/gitops/components/payments/swift-opa-bundle.yaml
@@ -9,7 +9,7 @@ metadata:
     app.kubernetes.io/name: swift-service
     app.kubernetes.io/part-of: payments
   annotations:
-    openbank.tech/policy-checksum: "1da5c3944d9bfa36"
+    openbank.tech/policy-checksum: "628beb00cd77ba83"
 data:
   rest.rego: |
     # SPDX-License-Identifier: Apache-2.0
@@ -263,6 +263,28 @@ data:
     	input.principal.type == "HUMAN"
     	input.principal.id == "service-account-openbank-edge"
     	input.action in {"consent.list", "consent.revoke"}
+    }
+
+    # The customer-edge proxying the app's privacy centre: a customer reads their OWN access log
+    # (P2-27). Same edge principal and same guard as edge-service-consent — the edge injects the
+    # caller's authoritative partyId from the JWT, so a client-supplied id never reaches
+    # audit-service.
+    #
+    # Deliberately a DISTINCT action from `audit.read`, not the `audit.` family: `audit.read` is the
+    # auditor/compliance surface over the whole trail (GET /entries/{aggregateId},
+    # /entries/by-actor/{actorId}) and granting it to the edge principal would put regulated evidence
+    # behind a service account. `audit.customerRead` reaches only the metadata projection.
+    #
+    # This rule is what actually narrows the endpoint. Its @RolesAllowed had to widen to
+    # ROLE_API/ROLE_OPERATOR/ROLE_ADMIN — the edge's service account carries ROLE_OPERATOR, so
+    # @RolesAllowed(ROLE_API) alone 403'd every call before the PDP was consulted (same shape as
+    # document-service's SignatureCeremonyResource) — and ROLE_OPERATOR is held by real staff too.
+    # The identity match below is therefore the load-bearing half: staff sessions authenticate
+    # through a different client, so their preferred_username is never "service-account-*".
+    allowed_reasons contains "edge-service-audit-customer" if {
+    	input.principal.type == "HUMAN"
+    	input.principal.id == "service-account-openbank-edge"
+    	input.action == "audit.customerRead"
     }
 
     # Any M2M service-account caller (e.g. account-service) may trigger a sanctions screen

--- a/openbank-infra/gitops/components/payments/transaction-opa-bundle.yaml
+++ b/openbank-infra/gitops/components/payments/transaction-opa-bundle.yaml
@@ -9,7 +9,7 @@ metadata:
     app.kubernetes.io/name: transaction-service
     app.kubernetes.io/part-of: payments
   annotations:
-    openbank.tech/policy-checksum: "863184ff7c5efff5"
+    openbank.tech/policy-checksum: "95504ea002c02a76"
 data:
   rest.rego: |
     # SPDX-License-Identifier: Apache-2.0
@@ -263,6 +263,28 @@ data:
     	input.principal.type == "HUMAN"
     	input.principal.id == "service-account-openbank-edge"
     	input.action in {"consent.list", "consent.revoke"}
+    }
+
+    # The customer-edge proxying the app's privacy centre: a customer reads their OWN access log
+    # (P2-27). Same edge principal and same guard as edge-service-consent — the edge injects the
+    # caller's authoritative partyId from the JWT, so a client-supplied id never reaches
+    # audit-service.
+    #
+    # Deliberately a DISTINCT action from `audit.read`, not the `audit.` family: `audit.read` is the
+    # auditor/compliance surface over the whole trail (GET /entries/{aggregateId},
+    # /entries/by-actor/{actorId}) and granting it to the edge principal would put regulated evidence
+    # behind a service account. `audit.customerRead` reaches only the metadata projection.
+    #
+    # This rule is what actually narrows the endpoint. Its @RolesAllowed had to widen to
+    # ROLE_API/ROLE_OPERATOR/ROLE_ADMIN — the edge's service account carries ROLE_OPERATOR, so
+    # @RolesAllowed(ROLE_API) alone 403'd every call before the PDP was consulted (same shape as
+    # document-service's SignatureCeremonyResource) — and ROLE_OPERATOR is held by real staff too.
+    # The identity match below is therefore the load-bearing half: staff sessions authenticate
+    # through a different client, so their preferred_username is never "service-account-*".
+    allowed_reasons contains "edge-service-audit-customer" if {
+    	input.principal.type == "HUMAN"
+    	input.principal.id == "service-account-openbank-edge"
+    	input.action == "audit.customerRead"
     }
 
     # Any M2M service-account caller (e.g. account-service) may trigger a sanctions screen

--- a/openbank-infra/gitops/components/payments/vop-opa-bundle.yaml
+++ b/openbank-infra/gitops/components/payments/vop-opa-bundle.yaml
@@ -9,7 +9,7 @@ metadata:
     app.kubernetes.io/name: vop-service
     app.kubernetes.io/part-of: payments
   annotations:
-    openbank.tech/policy-checksum: "14ce4c81e21ab3c1"
+    openbank.tech/policy-checksum: "9987da60537a1d87"
 data:
   rest.rego: |
     # SPDX-License-Identifier: Apache-2.0
@@ -263,6 +263,28 @@ data:
     	input.principal.type == "HUMAN"
     	input.principal.id == "service-account-openbank-edge"
     	input.action in {"consent.list", "consent.revoke"}
+    }
+
+    # The customer-edge proxying the app's privacy centre: a customer reads their OWN access log
+    # (P2-27). Same edge principal and same guard as edge-service-consent — the edge injects the
+    # caller's authoritative partyId from the JWT, so a client-supplied id never reaches
+    # audit-service.
+    #
+    # Deliberately a DISTINCT action from `audit.read`, not the `audit.` family: `audit.read` is the
+    # auditor/compliance surface over the whole trail (GET /entries/{aggregateId},
+    # /entries/by-actor/{actorId}) and granting it to the edge principal would put regulated evidence
+    # behind a service account. `audit.customerRead` reaches only the metadata projection.
+    #
+    # This rule is what actually narrows the endpoint. Its @RolesAllowed had to widen to
+    # ROLE_API/ROLE_OPERATOR/ROLE_ADMIN — the edge's service account carries ROLE_OPERATOR, so
+    # @RolesAllowed(ROLE_API) alone 403'd every call before the PDP was consulted (same shape as
+    # document-service's SignatureCeremonyResource) — and ROLE_OPERATOR is held by real staff too.
+    # The identity match below is therefore the load-bearing half: staff sessions authenticate
+    # through a different client, so their preferred_username is never "service-account-*".
+    allowed_reasons contains "edge-service-audit-customer" if {
+    	input.principal.type == "HUMAN"
+    	input.principal.id == "service-account-openbank-edge"
+    	input.action == "audit.customerRead"
     }
 
     # Any M2M service-account caller (e.g. account-service) may trigger a sanctions screen

--- a/openbank-infra/gitops/components/pid/pid-opa-bundle.yaml
+++ b/openbank-infra/gitops/components/pid/pid-opa-bundle.yaml
@@ -9,7 +9,7 @@ metadata:
     app.kubernetes.io/name: pid-service
     app.kubernetes.io/part-of: pid
   annotations:
-    openbank.tech/policy-checksum: "35c4bfeb9f358a0a"
+    openbank.tech/policy-checksum: "ab4803767f9f16fc"
 data:
   rest.rego: |
     # SPDX-License-Identifier: Apache-2.0
@@ -263,6 +263,28 @@ data:
     	input.principal.type == "HUMAN"
     	input.principal.id == "service-account-openbank-edge"
     	input.action in {"consent.list", "consent.revoke"}
+    }
+
+    # The customer-edge proxying the app's privacy centre: a customer reads their OWN access log
+    # (P2-27). Same edge principal and same guard as edge-service-consent — the edge injects the
+    # caller's authoritative partyId from the JWT, so a client-supplied id never reaches
+    # audit-service.
+    #
+    # Deliberately a DISTINCT action from `audit.read`, not the `audit.` family: `audit.read` is the
+    # auditor/compliance surface over the whole trail (GET /entries/{aggregateId},
+    # /entries/by-actor/{actorId}) and granting it to the edge principal would put regulated evidence
+    # behind a service account. `audit.customerRead` reaches only the metadata projection.
+    #
+    # This rule is what actually narrows the endpoint. Its @RolesAllowed had to widen to
+    # ROLE_API/ROLE_OPERATOR/ROLE_ADMIN — the edge's service account carries ROLE_OPERATOR, so
+    # @RolesAllowed(ROLE_API) alone 403'd every call before the PDP was consulted (same shape as
+    # document-service's SignatureCeremonyResource) — and ROLE_OPERATOR is held by real staff too.
+    # The identity match below is therefore the load-bearing half: staff sessions authenticate
+    # through a different client, so their preferred_username is never "service-account-*".
+    allowed_reasons contains "edge-service-audit-customer" if {
+    	input.principal.type == "HUMAN"
+    	input.principal.id == "service-account-openbank-edge"
+    	input.action == "audit.customerRead"
     }
 
     # Any M2M service-account caller (e.g. account-service) may trigger a sanctions screen

--- a/openbank-infra/gitops/components/pid/pid-service.yaml
+++ b/openbank-infra/gitops/components/pid/pid-service.yaml
@@ -22,7 +22,7 @@ spec:
       annotations:
         # Rolls the pod when the OPA bundle changes — subPath mounts do NOT hot-reload.
         # Kept in sync by gen-pid-opa-bundle.sh (do not hand-edit).
-        openbank.tech/policy-checksum: "35c4bfeb9f358a0a"
+        openbank.tech/policy-checksum: "ab4803767f9f16fc"
     spec:
       securityContext:
         runAsNonRoot: true

--- a/openbank-infra/gitops/components/psd2-service/psd2-opa-bundle.yaml
+++ b/openbank-infra/gitops/components/psd2-service/psd2-opa-bundle.yaml
@@ -9,7 +9,7 @@ metadata:
     app.kubernetes.io/name: psd2-service
     app.kubernetes.io/part-of: psd2
   annotations:
-    openbank.tech/policy-checksum: "4a1d59b0da794e39"
+    openbank.tech/policy-checksum: "803fd0b3d7c10d7f"
 data:
   rest.rego: |
     # SPDX-License-Identifier: Apache-2.0
@@ -263,6 +263,28 @@ data:
     	input.principal.type == "HUMAN"
     	input.principal.id == "service-account-openbank-edge"
     	input.action in {"consent.list", "consent.revoke"}
+    }
+
+    # The customer-edge proxying the app's privacy centre: a customer reads their OWN access log
+    # (P2-27). Same edge principal and same guard as edge-service-consent — the edge injects the
+    # caller's authoritative partyId from the JWT, so a client-supplied id never reaches
+    # audit-service.
+    #
+    # Deliberately a DISTINCT action from `audit.read`, not the `audit.` family: `audit.read` is the
+    # auditor/compliance surface over the whole trail (GET /entries/{aggregateId},
+    # /entries/by-actor/{actorId}) and granting it to the edge principal would put regulated evidence
+    # behind a service account. `audit.customerRead` reaches only the metadata projection.
+    #
+    # This rule is what actually narrows the endpoint. Its @RolesAllowed had to widen to
+    # ROLE_API/ROLE_OPERATOR/ROLE_ADMIN — the edge's service account carries ROLE_OPERATOR, so
+    # @RolesAllowed(ROLE_API) alone 403'd every call before the PDP was consulted (same shape as
+    # document-service's SignatureCeremonyResource) — and ROLE_OPERATOR is held by real staff too.
+    # The identity match below is therefore the load-bearing half: staff sessions authenticate
+    # through a different client, so their preferred_username is never "service-account-*".
+    allowed_reasons contains "edge-service-audit-customer" if {
+    	input.principal.type == "HUMAN"
+    	input.principal.id == "service-account-openbank-edge"
+    	input.action == "audit.customerRead"
     }
 
     # Any M2M service-account caller (e.g. account-service) may trigger a sanctions screen

--- a/openbank-infra/gitops/components/psd2-service/psd2-service.yaml
+++ b/openbank-infra/gitops/components/psd2-service/psd2-service.yaml
@@ -18,7 +18,7 @@ spec:
       annotations:
         # Rolls the pod when the OPA bundle changes — subPath mounts do NOT hot-reload.
         # Kept in sync by gen-psd2-opa-bundle.sh (do not hand-edit).
-        openbank.tech/policy-checksum: "4a1d59b0da794e39"
+        openbank.tech/policy-checksum: "803fd0b3d7c10d7f"
       labels: {app.kubernetes.io/name: psd2-service, app.kubernetes.io/part-of: psd2}
     spec:
       securityContext:

--- a/openbank-infra/gitops/components/sanctions-service/sanctions-opa-bundle.yaml
+++ b/openbank-infra/gitops/components/sanctions-service/sanctions-opa-bundle.yaml
@@ -9,7 +9,7 @@ metadata:
     app.kubernetes.io/name: sanctions-service
     app.kubernetes.io/part-of: sanctions
   annotations:
-    openbank.tech/policy-checksum: "cd9cc75478363f05"
+    openbank.tech/policy-checksum: "7c5c926811f6fe39"
 data:
   rest.rego: |
     # SPDX-License-Identifier: Apache-2.0
@@ -263,6 +263,28 @@ data:
     	input.principal.type == "HUMAN"
     	input.principal.id == "service-account-openbank-edge"
     	input.action in {"consent.list", "consent.revoke"}
+    }
+
+    # The customer-edge proxying the app's privacy centre: a customer reads their OWN access log
+    # (P2-27). Same edge principal and same guard as edge-service-consent — the edge injects the
+    # caller's authoritative partyId from the JWT, so a client-supplied id never reaches
+    # audit-service.
+    #
+    # Deliberately a DISTINCT action from `audit.read`, not the `audit.` family: `audit.read` is the
+    # auditor/compliance surface over the whole trail (GET /entries/{aggregateId},
+    # /entries/by-actor/{actorId}) and granting it to the edge principal would put regulated evidence
+    # behind a service account. `audit.customerRead` reaches only the metadata projection.
+    #
+    # This rule is what actually narrows the endpoint. Its @RolesAllowed had to widen to
+    # ROLE_API/ROLE_OPERATOR/ROLE_ADMIN — the edge's service account carries ROLE_OPERATOR, so
+    # @RolesAllowed(ROLE_API) alone 403'd every call before the PDP was consulted (same shape as
+    # document-service's SignatureCeremonyResource) — and ROLE_OPERATOR is held by real staff too.
+    # The identity match below is therefore the load-bearing half: staff sessions authenticate
+    # through a different client, so their preferred_username is never "service-account-*".
+    allowed_reasons contains "edge-service-audit-customer" if {
+    	input.principal.type == "HUMAN"
+    	input.principal.id == "service-account-openbank-edge"
+    	input.action == "audit.customerRead"
     }
 
     # Any M2M service-account caller (e.g. account-service) may trigger a sanctions screen

--- a/openbank-infra/gitops/components/sanctions-service/sanctions-service.yaml
+++ b/openbank-infra/gitops/components/sanctions-service/sanctions-service.yaml
@@ -49,7 +49,7 @@ spec:
       annotations:
         # Rolls the pods when the OPA bundle changes — subPath mounts do NOT hot-reload.
         # Kept in sync by gen-sanctions-opa-bundle.sh (do not hand-edit).
-        openbank.tech/policy-checksum: "cd9cc75478363f05"
+        openbank.tech/policy-checksum: "7c5c926811f6fe39"
     spec:
       securityContext:
         runAsNonRoot: true

--- a/openbank-infra/gitops/components/sca/sca-opa-bundle.yaml
+++ b/openbank-infra/gitops/components/sca/sca-opa-bundle.yaml
@@ -9,7 +9,7 @@ metadata:
     app.kubernetes.io/name: sca-service
     app.kubernetes.io/part-of: sca
   annotations:
-    openbank.tech/policy-checksum: "96f7d6249fa79a92"
+    openbank.tech/policy-checksum: "3a501679d08534c0"
 data:
   rest.rego: |
     # SPDX-License-Identifier: Apache-2.0
@@ -263,6 +263,28 @@ data:
     	input.principal.type == "HUMAN"
     	input.principal.id == "service-account-openbank-edge"
     	input.action in {"consent.list", "consent.revoke"}
+    }
+
+    # The customer-edge proxying the app's privacy centre: a customer reads their OWN access log
+    # (P2-27). Same edge principal and same guard as edge-service-consent — the edge injects the
+    # caller's authoritative partyId from the JWT, so a client-supplied id never reaches
+    # audit-service.
+    #
+    # Deliberately a DISTINCT action from `audit.read`, not the `audit.` family: `audit.read` is the
+    # auditor/compliance surface over the whole trail (GET /entries/{aggregateId},
+    # /entries/by-actor/{actorId}) and granting it to the edge principal would put regulated evidence
+    # behind a service account. `audit.customerRead` reaches only the metadata projection.
+    #
+    # This rule is what actually narrows the endpoint. Its @RolesAllowed had to widen to
+    # ROLE_API/ROLE_OPERATOR/ROLE_ADMIN — the edge's service account carries ROLE_OPERATOR, so
+    # @RolesAllowed(ROLE_API) alone 403'd every call before the PDP was consulted (same shape as
+    # document-service's SignatureCeremonyResource) — and ROLE_OPERATOR is held by real staff too.
+    # The identity match below is therefore the load-bearing half: staff sessions authenticate
+    # through a different client, so their preferred_username is never "service-account-*".
+    allowed_reasons contains "edge-service-audit-customer" if {
+    	input.principal.type == "HUMAN"
+    	input.principal.id == "service-account-openbank-edge"
+    	input.action == "audit.customerRead"
     }
 
     # Any M2M service-account caller (e.g. account-service) may trigger a sanctions screen

--- a/openbank-infra/gitops/components/sca/sca-service.yaml
+++ b/openbank-infra/gitops/components/sca/sca-service.yaml
@@ -28,7 +28,7 @@ spec:
       annotations:
         # Rolls the pods when the OPA bundle changes — subPath mounts do NOT hot-reload.
         # Kept in sync by gen-sca-opa-bundle.sh (do not hand-edit).
-        openbank.tech/policy-checksum: "96f7d6249fa79a92"
+        openbank.tech/policy-checksum: "3a501679d08534c0"
     spec:
       securityContext:
         runAsNonRoot: true

--- a/openbank-infra/gitops/components/statements/statement-opa-bundle.yaml
+++ b/openbank-infra/gitops/components/statements/statement-opa-bundle.yaml
@@ -9,7 +9,7 @@ metadata:
     app.kubernetes.io/name: statement-service
     app.kubernetes.io/part-of: statements
   annotations:
-    openbank.tech/policy-checksum: "48b3f414ae4d0615"
+    openbank.tech/policy-checksum: "222771a84a8f117d"
 data:
   rest.rego: |
     # SPDX-License-Identifier: Apache-2.0
@@ -263,6 +263,28 @@ data:
     	input.principal.type == "HUMAN"
     	input.principal.id == "service-account-openbank-edge"
     	input.action in {"consent.list", "consent.revoke"}
+    }
+
+    # The customer-edge proxying the app's privacy centre: a customer reads their OWN access log
+    # (P2-27). Same edge principal and same guard as edge-service-consent — the edge injects the
+    # caller's authoritative partyId from the JWT, so a client-supplied id never reaches
+    # audit-service.
+    #
+    # Deliberately a DISTINCT action from `audit.read`, not the `audit.` family: `audit.read` is the
+    # auditor/compliance surface over the whole trail (GET /entries/{aggregateId},
+    # /entries/by-actor/{actorId}) and granting it to the edge principal would put regulated evidence
+    # behind a service account. `audit.customerRead` reaches only the metadata projection.
+    #
+    # This rule is what actually narrows the endpoint. Its @RolesAllowed had to widen to
+    # ROLE_API/ROLE_OPERATOR/ROLE_ADMIN — the edge's service account carries ROLE_OPERATOR, so
+    # @RolesAllowed(ROLE_API) alone 403'd every call before the PDP was consulted (same shape as
+    # document-service's SignatureCeremonyResource) — and ROLE_OPERATOR is held by real staff too.
+    # The identity match below is therefore the load-bearing half: staff sessions authenticate
+    # through a different client, so their preferred_username is never "service-account-*".
+    allowed_reasons contains "edge-service-audit-customer" if {
+    	input.principal.type == "HUMAN"
+    	input.principal.id == "service-account-openbank-edge"
+    	input.action == "audit.customerRead"
     }
 
     # Any M2M service-account caller (e.g. account-service) may trigger a sanctions screen

--- a/openbank-infra/gitops/components/statements/statement-service.yaml
+++ b/openbank-infra/gitops/components/statements/statement-service.yaml
@@ -26,7 +26,7 @@ spec:
       annotations:
         # Rolls the pod when the OPA bundle changes — subPath mounts do NOT hot-reload.
         # Kept in sync by gen-statement-opa-bundle.sh (do not hand-edit).
-        openbank.tech/policy-checksum: "48b3f414ae4d0615"
+        openbank.tech/policy-checksum: "222771a84a8f117d"
       labels:
         app.kubernetes.io/name: statement-service
         app.kubernetes.io/part-of: statements

--- a/openbank-infra/gitops/components/tpp-registry/tpp-registry-opa-bundle.yaml
+++ b/openbank-infra/gitops/components/tpp-registry/tpp-registry-opa-bundle.yaml
@@ -9,7 +9,7 @@ metadata:
     app.kubernetes.io/name: tpp-registry-service
     app.kubernetes.io/part-of: tpp-registry
   annotations:
-    openbank.tech/policy-checksum: "7d8ebf68ff4aa9d9"
+    openbank.tech/policy-checksum: "a0ff75ecd026aa2a"
 data:
   rest.rego: |
     # SPDX-License-Identifier: Apache-2.0
@@ -263,6 +263,28 @@ data:
     	input.principal.type == "HUMAN"
     	input.principal.id == "service-account-openbank-edge"
     	input.action in {"consent.list", "consent.revoke"}
+    }
+
+    # The customer-edge proxying the app's privacy centre: a customer reads their OWN access log
+    # (P2-27). Same edge principal and same guard as edge-service-consent — the edge injects the
+    # caller's authoritative partyId from the JWT, so a client-supplied id never reaches
+    # audit-service.
+    #
+    # Deliberately a DISTINCT action from `audit.read`, not the `audit.` family: `audit.read` is the
+    # auditor/compliance surface over the whole trail (GET /entries/{aggregateId},
+    # /entries/by-actor/{actorId}) and granting it to the edge principal would put regulated evidence
+    # behind a service account. `audit.customerRead` reaches only the metadata projection.
+    #
+    # This rule is what actually narrows the endpoint. Its @RolesAllowed had to widen to
+    # ROLE_API/ROLE_OPERATOR/ROLE_ADMIN — the edge's service account carries ROLE_OPERATOR, so
+    # @RolesAllowed(ROLE_API) alone 403'd every call before the PDP was consulted (same shape as
+    # document-service's SignatureCeremonyResource) — and ROLE_OPERATOR is held by real staff too.
+    # The identity match below is therefore the load-bearing half: staff sessions authenticate
+    # through a different client, so their preferred_username is never "service-account-*".
+    allowed_reasons contains "edge-service-audit-customer" if {
+    	input.principal.type == "HUMAN"
+    	input.principal.id == "service-account-openbank-edge"
+    	input.action == "audit.customerRead"
     }
 
     # Any M2M service-account caller (e.g. account-service) may trigger a sanctions screen

--- a/openbank-infra/gitops/components/tpp-registry/tpp-registry-service.yaml
+++ b/openbank-infra/gitops/components/tpp-registry/tpp-registry-service.yaml
@@ -23,7 +23,7 @@ spec:
       annotations:
         # Rolls the pod when the OPA bundle changes (subPath mounts do not hot-reload).
         # Kept in sync by gen-tpp-registry-opa-bundle.sh (do not hand-edit).
-        openbank.tech/policy-checksum: "7d8ebf68ff4aa9d9"
+        openbank.tech/policy-checksum: "a0ff75ecd026aa2a"
     spec:
       securityContext:
         runAsNonRoot: true

--- a/openbank-infra/web/landing/.well-known/apple-app-site-association
+++ b/openbank-infra/web/landing/.well-known/apple-app-site-association
@@ -3,5 +3,18 @@
     "apps": [
       "37YYRR972B.tech.openbank.app"
     ]
+  },
+  "applinks": {
+    "details": [
+      {
+        "appID": "37YYRR972B.tech.openbank.app",
+        "components": [
+          {
+            "/": "/app/oauth/*",
+            "comment": "OAuth2 PKCE redirect (claimed-HTTPS callback, P0)"
+          }
+        ]
+      }
+    ]
   }
 }

--- a/openbank-infra/web/landing/.well-known/assetlinks.json
+++ b/openbank-infra/web/landing/.well-known/assetlinks.json
@@ -1,0 +1,14 @@
+[
+  {
+    "relation": [
+      "delegate_permission/common.handle_all_urls"
+    ],
+    "target": {
+      "namespace": "android_app",
+      "package_name": "tech.openbank.app",
+      "sha256_cert_fingerprints": [
+        "F0:41:0D:90:40:2E:4C:92:48:4F:48:5F:45:FA:2E:6A:CB:80:E0:16:30:5D:B7:96:6D:2B:CF:6F:4C:26:B8:F9"
+      ]
+    }
+  }
+]

--- a/openbank-infra/web/landing/.well-known/security.txt
+++ b/openbank-infra/web/landing/.well-known/security.txt
@@ -3,5 +3,6 @@
 
 Contact: mailto:security@open-bank.tech
 Expires: 2027-06-11T00:00:00.000Z
+Policy: https://github.com/JiRaska/openbank-app/blob/main/docs/VULNERABILITY-DISCLOSURE.md
 Preferred-Languages: cs, en
 Canonical: https://open-bank.tech/.well-known/security.txt

--- a/openbank-libs/governance/policies/rest.rego
+++ b/openbank-libs/governance/policies/rest.rego
@@ -251,6 +251,28 @@ allowed_reasons contains "edge-service-consent" if {
 	input.action in {"consent.list", "consent.revoke"}
 }
 
+# The customer-edge proxying the app's privacy centre: a customer reads their OWN access log
+# (P2-27). Same edge principal and same guard as edge-service-consent — the edge injects the
+# caller's authoritative partyId from the JWT, so a client-supplied id never reaches
+# audit-service.
+#
+# Deliberately a DISTINCT action from `audit.read`, not the `audit.` family: `audit.read` is the
+# auditor/compliance surface over the whole trail (GET /entries/{aggregateId},
+# /entries/by-actor/{actorId}) and granting it to the edge principal would put regulated evidence
+# behind a service account. `audit.customerRead` reaches only the metadata projection.
+#
+# This rule is what actually narrows the endpoint. Its @RolesAllowed had to widen to
+# ROLE_API/ROLE_OPERATOR/ROLE_ADMIN — the edge's service account carries ROLE_OPERATOR, so
+# @RolesAllowed(ROLE_API) alone 403'd every call before the PDP was consulted (same shape as
+# document-service's SignatureCeremonyResource) — and ROLE_OPERATOR is held by real staff too.
+# The identity match below is therefore the load-bearing half: staff sessions authenticate
+# through a different client, so their preferred_username is never "service-account-*".
+allowed_reasons contains "edge-service-audit-customer" if {
+	input.principal.type == "HUMAN"
+	input.principal.id == "service-account-openbank-edge"
+	input.action == "audit.customerRead"
+}
+
 # Any M2M service-account caller (e.g. account-service) may trigger a sanctions screen
 # (issue #746, found via issue #669's load benchmark). sanctions.create is called with
 # resource = "" — a resourceless system action — so operator-on-own-tenant (which requires

--- a/openbank-libs/governance/policies/rest_test.rego
+++ b/openbank-libs/governance/policies/rest_test.rego
@@ -670,6 +670,44 @@ test_allow_service_consent_revoke if {
 	decision.reason == "edge-service-consent"
 }
 
+# edge-service-audit-customer: the app's privacy centre reads the customer's own access log
+# (P2-27). The endpoint's @RolesAllowed had to include ROLE_OPERATOR — the edge's service
+# account carries it and ROLE_API alone 403'd before the PDP ran — so this identity match is
+# what keeps the surface narrow.
+test_allow_service_audit_customer_read if {
+	decision := rest.allow with input as {
+		"principal": {"id": "service-account-openbank-edge", "type": "HUMAN", "roles": ["ROLE_OPERATOR"]},
+		"action": "audit.customerRead",
+		"resource": {"type": "party", "id": "p-1"},
+	}
+		with data.openbank.bundle as bundle
+
+	decision.allow == true
+	decision.reason == "edge-service-audit-customer"
+}
+
+# Staff carrying ROLE_OPERATOR must NOT reach the customer access log off this rule: it is
+# pinned to the edge's client_credentials identity. This is the assertion that makes the
+# widened @RolesAllowed safe — note `audit.customerRead` deliberately does not end in `.read`,
+# so operator-read-any cannot pick it up either.
+test_deny_operator_audit_customer_read if {
+	not rest.allow with input as {
+		"principal": {"id": "alice.operator", "type": "HUMAN", "roles": ["ROLE_OPERATOR"]},
+		"action": "audit.customerRead",
+		"resource": {"type": "party", "id": "p-1"},
+	}
+}
+
+# The grant is one action, not the `audit.` family — the edge principal must never reach the
+# auditor/compliance trail (GET /entries/{aggregateId}, /entries/by-actor/{actorId}).
+test_deny_service_audit_read if {
+	not rest.allow with input as {
+		"principal": {"id": "service-account-openbank-edge", "type": "HUMAN", "roles": ["ROLE_API"]},
+		"action": "audit.read",
+		"resource": {"type": "party", "id": "p-1"},
+	}
+}
+
 # Least privilege: the grant is the two exact actions the app uses, NOT the consent. family
 # — the edge must not be able to create/activate/validate consents on the customer's behalf.
 test_deny_service_consent_create if {


### PR DESCRIPTION
## Summary

Four signed commits from the openbank-app bank-grade hardening program, rebased onto current main:

1. **`fix(edge)`** — OpenAPI Balance/Pagination schemas aligned to the actual wire (balance-service `availableAmount`, libs `CursorPage.hasNextPage`); customers realm registers the claimed-HTTPS OAuth redirect (`https://open-bank.tech/app/oauth/callback`, legacy scheme kept for migration); AASA `applinks` for `/app/oauth/*`; new `assetlinks.json` (debug fingerprint — **Play App Signing SHA-256 must be added before a Play release**).
2. **`feat(security)`** — security.txt links the VDP policy (RFC 9116 `Policy:` field → openbank-app `docs/VULNERABILITY-DISCLOSURE.md`).
3. **`feat(audit)`** — customer-facing access log: new ROLE_API M2M endpoint `GET /api/v1/audit/customer/{partyId}` in audit-service (metadata-only projection — the operator audit surface keeps its strict roles), proxied by the customer edge at `GET /customer/v1/privacy/access-log` for the caller's own partyId. **OpenAPI 1.21.0 → 1.22.0** (`/privacy/access-log` + `AccessLogEntry` schema); `audit-service-url` wired in edge config.
4. **`docs(threat-models)`** — QRlessPay STRIDE/DFD marked complete + new §8 rollout gates (crypto review, CBOR fuzzing, ADR-0030 approval, DPIA, SAS/threshold decisions, per-device compat) — the feature stays dormant until gates 1–4 hold.

## Notes

- Sibling app-side PR lands in JiRaska/openbank-app (37 commits: P0 security hardening, P1 quality, P2 features incl. the privacy-centre UI for #3).
- The app's edge-contract snapshot (1.22.0, 49 paths, 36 schemas) matches this branch byte-for-byte; the app's contract gate will go green on merge.
- Deploy order: realm template + AASA/assetlinks must be live **before** the app release ships.