### PR TITLE
fix(edge): let a customer issue a virtual card again after the old one dies

### DIFF
--- a/openbank-customer-edge/src/main/kotlin/com/openbank/customeredge/infrastructure/rest/CustomerEdgeResource.kt
+++ b/openbank-customer-edge/src/main/kotlin/com/openbank/customeredge/infrastructure/rest/CustomerEdgeResource.kt
@@ -2788,6 +2788,33 @@ class CustomerEdgeResource(
     }
 
     /**
+     * How many VIRTUAL cards on [accountId] have reached a terminal state. This is the generation
+     * counter in the virtual-card idempotency key — see [issueCard] for why the key cannot simply
+     * be constant.
+     *
+     * Counting DEAD cards rather than all cards is the whole trick: the number is unchanged by a
+     * successful issue, so a retry after a dropped response still replays instead of minting a
+     * duplicate, and it only moves when a card is blocked or cancelled — which is exactly when a
+     * fresh card must become mintable.
+     *
+     * On an upstream failure this returns 0, i.e. the previous constant-key behaviour: replaying an
+     * existing card is a safe answer to "I could not tell", whereas guessing high would mint a card
+     * the customer did not ask for.
+     */
+    private fun terminalVirtualCardCount(partyId: UUID, accountId: UUID): Int {
+        val resp = upstream.get("$cardIssuanceServiceUrl/api/v1/cards/party/$partyId", partyId.toString())
+        if (resp.status != 200) return 0
+        val body = (resp.entity as? String)?.takeIf { it.isNotBlank() } ?: return 0
+        return runCatching {
+            objectMapper.readTree(body).count { card ->
+                card.path("accountId").asText() == accountId.toString() &&
+                    card.path("cardType").asText().uppercase() == CARD_TYPE_VIRTUAL &&
+                    card.path("status").asText().uppercase() in TERMINAL_CARD_STATUSES
+            }
+        }.getOrDefault(0)
+    }
+
+    /**
      * Issue a VIRTUAL or SINGLE_USE card on one of the caller's OWN accounts (self-service, #4b). The
      * app sends { "accountId": "...", "cardType": "VIRTUAL"|"SINGLE_USE" }; the edge forces the
      * partyId from the JWT, verifies the account belongs to the caller, and resolves the cardholder
@@ -2849,10 +2876,19 @@ class CustomerEdgeResource(
         //    would make the SECOND one impossible (it would replay the first forever). Honour a
         //    client-supplied Idempotency-Key so a genuine network retry still de-duplicates, and
         //    generate one otherwise.
+        //
+        // The VIRTUAL key carries a generation suffix because a FULLY constant key does not just
+        // de-duplicate retries — it permanently caps the account at one virtual card ever. Once
+        // that card is blocked or cancelled, card-issuance's `findByIdempotencyKey(...)?.let {
+        // return it }` keeps replaying the DEAD row: the customer taps "issue", gets 200 and a
+        // card that cannot pay, and no amount of retrying can ever produce a live one. (The
+        // `idempotency_key` column is NOT NULL UNIQUE, so the key has to move for a new row to
+        // exist at all.) The suffix counts TERMINAL cards, which a successful issue leaves
+        // unchanged — retry de-duplication survives, the dead end does not.
         val key = if (cardType == CARD_TYPE_SINGLE_USE) {
             idempotencyKey?.takeIf { it.isNotBlank() } ?: Ids.randomId().toString()
         } else {
-            "vcard-${customer.partyId}-$acct"
+            "vcard-${customer.partyId}-$acct-r${terminalVirtualCardCount(customer.partyId, acct)}"
         }
         val resp = upstream.post(
             "$cardIssuanceServiceUrl/api/v1/cards",
@@ -3287,6 +3323,11 @@ class CustomerEdgeResource(
 
         internal const val CARD_TYPE_VIRTUAL = "VIRTUAL"
         internal const val CARD_TYPE_SINGLE_USE = "SINGLE_USE"
+
+        // Card states from which there is no way back — the card will never transact again,
+        // whatever the customer does. SUSPENDED is deliberately absent: a frozen card is alive
+        // and must NOT free up a new virtual-card generation.
+        internal val TERMINAL_CARD_STATUSES = setOf("BLOCKED", "CANCELLED", "EXPIRED")
 
         /** The only card types a customer may mint themselves — plastic stays an operator flow. */
         internal val SELF_SERVICE_CARD_TYPES = setOf(CARD_TYPE_VIRTUAL, CARD_TYPE_SINGLE_USE)

--- a/openbank-customer-edge/src/test/kotlin/com/openbank/customeredge/CustomerEdgeCardsTest.kt
+++ b/openbank-customer-edge/src/test/kotlin/com/openbank/customeredge/CustomerEdgeCardsTest.kt
@@ -277,7 +277,16 @@ class CustomerEdgeCardsTest {
             Response.ok("""{"id":"$productId","code":"CURRENT_CZK"}""").build()
         every { upstream.get(match { it.contains("/parties/$caller") }, any()) } returns
             Response.ok("""{"legalName":"Jan Novak"}""").build()
+        // The virtual-card idempotency key carries a generation counted from the party's TERMINAL
+        // cards, so issuing reads the card list. Default: nothing issued yet.
+        stubPartyCards(upstream, caller, "[]")
         approvedSca(upstream)
+    }
+
+    /** Stub `GET /api/v1/cards/party/{partyId}` with a raw card-list JSON array. */
+    private fun stubPartyCards(upstream: UpstreamClient, caller: UUID, json: String) {
+        every { upstream.get(match { it.endsWith("/api/v1/cards/party/$caller") }, any()) } returns
+            Response.ok(json).build()
     }
 
     @Test
@@ -324,7 +333,7 @@ class CustomerEdgeCardsTest {
     }
 
     @Test
-    fun `a VIRTUAL issue keeps the stable per-account idempotency key`() {
+    fun `a VIRTUAL issue keeps a per-account idempotency key stable across retries`() {
         val caller = UUID.randomUUID()
         val acct = UUID.randomUUID()
         val upstream = mockk<UpstreamClient>()
@@ -338,7 +347,60 @@ class CustomerEdgeCardsTest {
             "client-supplied",
             UUID.randomUUID().toString(),
         )
-        assertThat(key.captured).isEqualTo("vcard-$caller-$acct")
+        assertThat(key.captured).isEqualTo("vcard-$caller-$acct-r0")
+    }
+
+    /**
+     * The regression that made the app's "issue a virtual card" button a dead end: with a fully
+     * constant key, card-issuance replayed the row it already had — so once that card was blocked,
+     * every later issue returned the DEAD card and the account could never hold a live virtual card
+     * again. The generation suffix has to move when a card reaches a terminal state.
+     */
+    @Test
+    fun `a VIRTUAL issue after the previous card was blocked uses a fresh key`() {
+        val caller = UUID.randomUUID()
+        val acct = UUID.randomUUID()
+        val upstream = mockk<UpstreamClient>()
+        stubIssue(upstream, caller, acct, UUID.randomUUID())
+        stubPartyCards(
+            upstream,
+            caller,
+            """[{"id":"${UUID.randomUUID()}","accountId":"$acct","cardType":"VIRTUAL","status":"BLOCKED"}]""",
+        )
+        val key = slot<String>()
+        every {
+            upstream.post(match { it.endsWith("/api/v1/cards") }, any(), any(), capture(key))
+        } returns Response.status(201).entity("{}").build()
+        resourceFor(upstream, caller).issueCard(
+            """{"accountId":"$acct","cardType":"VIRTUAL"}""",
+            null,
+            UUID.randomUUID().toString(),
+        )
+        assertThat(key.captured).isEqualTo("vcard-$caller-$acct-r1")
+    }
+
+    /** A FROZEN card is alive — freezing must not hand out a new virtual-card generation. */
+    @Test
+    fun `a suspended card does not free up a new virtual-card generation`() {
+        val caller = UUID.randomUUID()
+        val acct = UUID.randomUUID()
+        val upstream = mockk<UpstreamClient>()
+        stubIssue(upstream, caller, acct, UUID.randomUUID())
+        stubPartyCards(
+            upstream,
+            caller,
+            """[{"id":"${UUID.randomUUID()}","accountId":"$acct","cardType":"VIRTUAL","status":"SUSPENDED"}]""",
+        )
+        val key = slot<String>()
+        every {
+            upstream.post(match { it.endsWith("/api/v1/cards") }, any(), any(), capture(key))
+        } returns Response.status(201).entity("{}").build()
+        resourceFor(upstream, caller).issueCard(
+            """{"accountId":"$acct","cardType":"VIRTUAL"}""",
+            null,
+            UUID.randomUUID().toString(),
+        )
+        assertThat(key.captured).isEqualTo("vcard-$caller-$acct-r0")
     }
 
     @Test


### PR DESCRIPTION
## The bug

The virtual-card idempotency key is fully constant:

```kotlin
"vcard-${customer.partyId}-$acct"
```

and `CardService.issueCard` opens with

```kotlin
repo.findByIdempotencyKey(cmd.idempotencyKey)?.let { return it }
```

over a `NOT NULL UNIQUE` column.

That does not merely de-duplicate retries — **it caps the account at one virtual card for its entire lifetime.** Once that card reaches a terminal state, every later issue replays the dead row: the customer taps "issue", the edge answers 201 with a card that cannot pay, the app shows success, and no retry can ever produce a live card.

Found from the openbank-app side: an emergency action blocked every card, the Cards screen then says *"This card is permanently blocked. Issue a new one with the + button"* — and that button was unreachable by construction.

## The fix

The key carries a generation suffix counting the account's **terminal** virtual cards:

```kotlin
"vcard-${customer.partyId}-$acct-r${terminalVirtualCardCount(customer.partyId, acct)}"
```

Counting dead cards rather than all cards is what keeps both properties:

- a successful issue leaves the count unchanged → a retry after a dropped response still replays, no duplicate minted;
- the count moves only when a card is blocked or cancelled → exactly when a fresh card must become mintable.

`SUSPENDED` is deliberately not terminal — a frozen card is alive and must not hand out a new generation.

An upstream failure counting the cards falls back to generation 0 (the previous behaviour): replaying an existing card is a safe answer to "I could not tell", where guessing high would mint a card nobody asked for.

## Tests

`CustomerEdgeCardsTest` — 23 pass. Existing stable-key test updated to `-r0`; two added:

- a VIRTUAL issue after the previous card was blocked uses a fresh key (`-r1`)
- a suspended card does not free up a new virtual-card generation (stays `-r0`)

## Linked issues

N/A — found from the openbank-app side while reproducing a customer report (emergency freeze blocked every card, and the "issue a new one" the UI then suggests was unreachable by construction). No tracking issue was filed; the report and the root cause are in the description above.
