### PR TITLE
fix(ci): submit a dependency graph for every main commit, not just manifest-touching ones

### DIFF
--- a/.github/workflows/dependency-submission.yml
+++ b/.github/workflows/dependency-submission.yml
@@ -14,26 +14,38 @@
 # context — the worst of both worlds (silent Dependabot, noisy unopinionated Scorecard).
 #
 # This wires `gradle/actions/setup-gradle`'s built-in dependency-graph extractor so the graph
-# gets submitted from a real build on every relevant main push. Once populated, Dependabot
+# gets submitted from a real build on every main push. Once populated, Dependabot
 # alerts become the authoritative, actionable, per-service view (exact vulnerable version +
 # suggested fix), and Scorecard's Vulnerabilities check should stop flying blind.
 name: Dependency submission
 
 on:
+  # DELIBERATELY UNFILTERED (issue #2833). This trigger used to carry the same
+  # manifest `paths:` filter as the pull_request one below. That filter is correct for
+  # a PR head and wrong for a main commit, because dependency-review looks snapshots up
+  # by EXACT SHA and the two sides are selected by different rules: a PR only reaches
+  # the gate with a manifest change (so its head is always snapshot-bearing), but its
+  # `pull_request.base.sha` is an arbitrary main commit. Measured 2026-07-31: 1 of the
+  # last 50 main commits touched any filtered path, so ~98% of base SHAs could never
+  # have a snapshot, and dependency-review silently fell back to diffing the ENTIRE head
+  # graph as additions — 1235 packages, 30 of them carrying advisories, none of which
+  # the PR introduced. That is how the netty/protobuf entries in dependency-review.yml's
+  # allow-ghsas were accreted: pre-existing findings surfaced as if new, each silenced by
+  # a permanent fleet-wide suppression.
+  #
+  # The cost of dropping the filter is a ~11 min run on every main push, which is $0 —
+  # public repo, hosted runners, free and unlimited. Do not "optimize" it back: a
+  # docs-only main commit produces a graph identical to its parent's, but exact-SHA
+  # lookup means an identical graph and a MISSING graph are not the same thing.
   push:
     branches: [main]
-    paths:
-      - "**/build.gradle.kts"
-      - "openbank-libs/gradle/libs.versions.toml"
-      - "settings.gradle.kts"
-      - "gradle/wrapper/**"
   # PRs too, so dependency-review.yml has a head-SHA graph to diff against main's
   # (issue #1419): without a per-PR submission the Gradle graph is main-only, and
   # dependency-review — which only ever compares submitted graphs — silently had
   # nothing to say about the fleet's primary language. This is the integration
-  # documented by gradle/actions (docs/dependency-submission.md). Same path filter
-  # as the push trigger: only a PR that can change resolution pays the ~11 min, which
-  # is 3 of the last 40 PRs.
+  # documented by gradle/actions (docs/dependency-submission.md). The path filter is
+  # kept HERE and only here: a PR that changes no manifest cannot change resolution, so
+  # its head needs no snapshot of its own — the gate has nothing to diff either way.
   pull_request:
     branches: [main]
     paths:
@@ -50,9 +62,26 @@ on:
 permissions:
   contents: read
 
+# Keyed per-SHA on push, per-ref everywhere else — and push runs are never cancelled.
+#
+# This is load-bearing for the unfiltered push trigger above, not a style preference.
+# The old rule grouped every main push under `refs/heads/main` with
+# `cancel-in-progress: true`, so a second merge killed the first merge's submission.
+# Measured 2026-07-31: 70 of the last 80 main commits landed within 11 minutes of the
+# previous one (tightest gaps: 2 seconds), i.e. under the old rule dropping the paths
+# filter would still have produced a snapshot for roughly 9 commits in 80 — the fix
+# would have looked applied while leaving the gap almost entirely open.
+#
+# Cancelling is still right for a PR: only the head SHA is ever compared, so a
+# superseded push has nothing to contribute. On main every commit is a potential
+# `pull_request.base.sha` for some future PR, so every one has to finish.
+#
+# Cost: a merge burst (a release-please batch drain) starts one ~11 min job per commit
+# in parallel. $0 on hosted runners for a public repo; the exposure is queue depth, and
+# a queued snapshot arriving late still beats a cancelled one never arriving.
 concurrency:
-  group: dependency-submission-${{ github.ref }}
-  cancel-in-progress: true
+  group: dependency-submission-${{ github.event_name == 'push' && github.sha || github.ref }}
+  cancel-in-progress: ${{ github.event_name != 'push' }}
 
 jobs:
   submit:


### PR DESCRIPTION
Implements suggested fix 2 from #2833. Two changes to `dependency-submission.yml`, both load-bearing.

## 1. Drop the `paths:` filter from the `push: [main]` trigger

`dependency-review` looks snapshots up by **exact SHA**, and the two sides of its diff were selected by different rules:

- **head SHA** — a PR only reaches the gate with a manifest change, so it is always snapshot-bearing.
- **base SHA** — `pull_request.base.sha` is an arbitrary main commit, snapshot-bearing only if *that exact commit* also touched a manifest.

**1 of the last 50 main commits** touches any filtered path, so ~98% of base SHAs could never have a snapshot. The action then falls back to diffing the entire head graph as additions.

Verified directly against the compare API the action calls, same head `33334a2db`:

| base | entries | added | with vulnerabilities |
|---|---|---|---|
| `add0b5e83` — the real `base.sha`, no snapshot | 1235 | 1235 | 30 |
| `main` — what a `base-ref` fix would resolve to | 1235 | 1235 | 30 |
| `98fc64c9c` — snapshot-bearing, 33 commits earlier | **29** | 29 | 2 |

The `98fc64c9c` row is a valid control: it is an ancestor of `add0b5e83` and **none of the 33 commits between them touches a manifest**, so nothing in the gap could have changed resolution. That 29-package delta is #2751's own.

The `main` row is why the cheaper option was rejected — `base-ref` resolves the ref to a tip SHA and then does the same exact-SHA lookup. No "latest snapshot at or before" fallback exists.

The `pull_request` filter is **kept**: a PR changing no manifest cannot change resolution, so its head needs no snapshot of its own.

## 2. Concurrency had to change with it

Not a style preference — without this, change 1 barely works.

The old rule grouped every main push under `refs/heads/main` with `cancel-in-progress: true`, so a second merge killed the first merge's submission. **70 of the last 80 main commits landed within 11 minutes of the previous one**, tightest gaps 2 seconds. Under the old rule, dropping the paths filter would still have produced a snapshot for roughly **9 commits in 80** — a fix that looks applied while leaving the gap almost entirely open.

Now:

```yaml
group: dependency-submission-${{ github.event_name == 'push' && github.sha || github.ref }}
cancel-in-progress: ${{ github.event_name != 'push' }}
```

Push runs are keyed per SHA and never cancelled — on main, every commit is a potential `base.sha` for some future PR, so every one has to finish. PR runs keep the old per-ref cancelling behaviour, which is correct there because only the head SHA is ever compared.

## Why this matters beyond flakiness

The `allow-ghsas` list in `dependency-review.yml` has been accreting **permanent fleet-wide suppressions bought to silence non-delta findings**. The rationale block says so outright about the netty entries — *"pre-existing, not introduced by the Quarkus 3.38 bump this gate flagged it on"*. Each such entry also hides a future PR that genuinely introduces that GHSA. That is the actual coverage loss this fixes the input to.

## Cost

**$0.** Public repo, hosted runners, free and unlimited — the workflow already runs `ubuntu-latest` for exactly this reason. The exposure is queue depth: a release-please batch drain starts one ~11 min job per commit in parallel. A queued snapshot arriving late still beats a cancelled one never arriving.

## Verification

- `actionlint .github/workflows/dependency-submission.yml` — clean
- `yamllint` under the exact config `ci.yml` builds — clean on branch **and** on `origin/main`'s copy (no new findings). Confirmed the linter can speak about this file (117 findings under default config), so the clean run is not a silent no-op.
- Parsed the result to confirm the structure is what was intended, rather than eyeballing the diff: `push` keys are now `['branches']` only, `pull_request` keys remain `['branches', 'paths']`.

## Does NOT close #2833

Deliberately `Refs`, not `Closes`. Two items from that issue remain open:

- **Item 3** — the mismatch still proceeds silently. A run logging `(0) and (1) do not match` produces an untrustworthy diff and reports a normal verdict.
- **Item 4** — the submitted graph still records pre-resolution coordinates that `resolutionStrategy` pins away (`grpc-protobuf:1.54.1 -> 1.81.0`, `protobuf-java:3.21.7` absent entirely, `netty:4.1.119 -> 4.1.136`). Measured on #2751: a correct base cuts findings from ~30 to ~2, **not to 0**.

So `allow-ghsas` pressure drops by an order of magnitude but does not reach zero. The follow-up to re-review and prune that list is still worth doing once this lands.

## Release impact

None. `.github/workflows/` is not under any released package path, so release-please cuts nothing despite the `fix` type.

Refs #2833
