### PR TITLE
feat(directory): pay-to-phone lookup, opt-in and honest about what hashing buys

### DIFF
--- a/openbank-customer-edge/src/main/kotlin/com/openbank/customeredge/infrastructure/rest/CustomerEdgeResource.kt
+++ b/openbank-customer-edge/src/main/kotlin/com/openbank/customeredge/infrastructure/rest/CustomerEdgeResource.kt
@@ -1278,6 +1278,66 @@ class CustomerEdgeResource(
         )
     }
 
+    /**
+     * Pay-to-phone directory lookup. The app sends SHA-256 hashes of phone numbers from the
+     * customer's own address book and gets back the subset belonging to parties who opted into
+     * being discoverable.
+     *
+     * What this route deliberately does NOT do:
+     *   · it never sees a plaintext phone number (the app hashes before sending), so numbers stay
+     *     out of this service's access logs;
+     *   · it answers only about numbers the caller already had — it cannot be walked to enumerate
+     *     customers, and a party who has not opted in is invisible whatever is asked;
+     *   · it returns a party id and a name, never an account, an email or an address. The payment
+     *     rail resolves the account from the party id server-side, so knowing someone banks here
+     *     does not hand out their account number.
+     *
+     * The hashing is honest about its limits: it keeps plaintext off the wire and out of logs, it
+     * is NOT a privacy guarantee against OpenBank, which holds the numbers anyway. The opt-in is
+     * the control that matters.
+     */
+    @POST
+    @Path("/directory/lookup")
+    @Authorize(action = "customer.directory.lookup")
+    @Blocking
+    fun directoryLookup(body: String): Response {
+        val customer = customer()
+        val parsed = runCatching { objectMapper.readTree(body) }.getOrNull()
+            ?: return badRequest("body must be JSON")
+        val hashes = parsed.path("phoneHashes").takeIf { it.isArray }?.mapNotNull { it.asText(null) }
+            ?: return badRequest("phoneHashes (array of hex sha-256) is required")
+        if (hashes.isEmpty()) return Response.ok(mapOf("matches" to emptyList<Any>())).build()
+        val out = objectMapper.createObjectNode()
+        out.set<com.fasterxml.jackson.databind.JsonNode>(
+            "phoneHashes",
+            objectMapper.valueToTree(hashes.take(MAX_DIRECTORY_HASHES)),
+        )
+        return upstream.post(
+            "$partyServiceUrl/api/v1/parties/directory/lookup",
+            customer.partyId.toString(),
+            out.toString(),
+        )
+    }
+
+    /**
+     * Turn the caller's own pay-to-phone findability on or off. Party-scoped by the JWT party, so
+     * a customer can only ever change their own — the id is never taken from the body.
+     */
+    @PUT
+    @Path("/directory/discoverable")
+    @Authorize(action = "customer.directory.update")
+    @Blocking
+    fun setDiscoverable(body: String): Response {
+        val customer = customer()
+        val discoverable = extractBooleanField(objectMapper, body, "discoverable")
+            ?: return badRequest("discoverable (boolean) is required")
+        return upstream.put(
+            "$partyServiceUrl/api/v1/parties/${customer.partyId}/discoverable",
+            customer.partyId.toString(),
+            """{"discoverable":$discoverable}""",
+        )
+    }
+
     // --- Transactions ---
 
     /**
@@ -3284,6 +3344,9 @@ class CustomerEdgeResource(
 
         private const val BAD_REQUEST_STATUS = 400
         private const val FORBIDDEN_STATUS = 403
+
+        /** Upper bound on address-book hashes forwarded in one directory lookup. */
+        internal const val MAX_DIRECTORY_HASHES = 500
 
         internal const val CARD_TYPE_VIRTUAL = "VIRTUAL"
         internal const val CARD_TYPE_SINGLE_USE = "SINGLE_USE"

--- a/openbank-customer-edge/src/main/resources/openapi.yaml
+++ b/openbank-customer-edge/src/main/resources/openapi.yaml
@@ -3,7 +3,7 @@
 openapi: 3.1.0
 info:
   title: Customer Edge API
-  version: 1.22.0
+  version: 1.23.0
   description: >-
     Customer-facing edge proxy (ADR-0065). Single internet-facing entry point for the
     retail customer app. Validates JWTs from the openbank-customers Keycloak realm,
@@ -151,6 +151,58 @@ paths:
                 type: array
                 items:
                   $ref: '#/components/schemas/AccessLogEntry'
+
+  /directory/lookup:
+    post:
+      tags: [Directory]
+      summary: Match address-book phone hashes against parties who opted into pay-to-phone
+      description: >
+        Takes SHA-256 hashes of phone numbers the caller already holds and returns the subset
+        belonging to parties who opted into being discoverable. Never accepts or returns a
+        plaintext phone number, and returns no account, email or address — the payment rail
+        resolves the account from the party id server-side. Hashing keeps numbers out of logs;
+        it is not a privacy guarantee against the bank, which holds the numbers regardless.
+      operationId: directoryLookup
+      security:
+        - customerOidc: [accounts:read]
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/DirectoryLookupRequest'
+      responses:
+        '200':
+          description: The hashes that matched a discoverable party
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/DirectoryLookupResponse'
+        '400':
+          description: phoneHashes missing or not an array
+
+  /directory/discoverable:
+    put:
+      tags: [Directory]
+      summary: Turn the caller's own pay-to-phone findability on or off
+      operationId: setDiscoverable
+      security:
+        - customerOidc: [accounts:read]
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/DiscoverableRequest'
+      responses:
+        '200':
+          description: The stored setting
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/DiscoverableRequest'
+        '400':
+          description: discoverable missing or not a boolean
 
   /accounts:
     get:
@@ -1398,6 +1450,39 @@ components:
           type: integer
           nullable: true
 
+    DirectoryLookupRequest:
+      type: object
+      properties:
+        phoneHashes:
+          type: array
+          description: Lowercase hex SHA-256 of each phone number in E.164 form.
+          items:
+            type: string
+    DirectoryLookupResponse:
+      type: object
+      properties:
+        matches:
+          type: array
+          items:
+            $ref: '#/components/schemas/DirectoryMatch'
+    DirectoryMatch:
+      type: object
+      description: >
+        A hash that belongs to a discoverable party. Carries the party id and legal name only —
+        nothing else about the payee is the caller's to learn from a lookup.
+      properties:
+        phoneHash:
+          type: string
+        partyId:
+          type: string
+          format: uuid
+        legalName:
+          type: string
+    DiscoverableRequest:
+      type: object
+      properties:
+        discoverable:
+          type: boolean
     AccessLogEntry:
       type: object
       description: One audit event whose aggregate is the caller's party (metadata only,

--- a/openbank-party-service/src/main/kotlin/com/openbank/party/application/port/in/PartyPort.kt
+++ b/openbank-party-service/src/main/kotlin/com/openbank/party/application/port/in/PartyPort.kt
@@ -106,6 +106,16 @@ interface PartyUseCase {
     suspend fun getParty(id: UUID): Party
     suspend fun updateParty(cmd: UpdatePartyCommand): Party
 
+    /**
+     * Pay-to-phone directory lookup. Answers ONLY about parties that opted into being
+     * discoverable, and only for hashes the caller already supplied — it cannot be used to
+     * enumerate customers. Hashes that do not match are not recorded anywhere.
+     */
+    suspend fun lookupByPhoneHashes(hashes: Collection<String>): List<PhoneDirectoryMatch>
+
+    /** Turn pay-to-phone findability on or off for one party (revocable, opt-in). */
+    suspend fun updateDiscoverable(partyId: UUID, discoverable: Boolean): Boolean
+
     /** Post-onboarding marketing-consent toggle (mobile app Profile screen, revocable). */
     suspend fun updateMarketingConsent(cmd: UpdateMarketingConsentCommand): Party
     suspend fun addDocument(cmd: AddDocumentCommand): PartyDocument
@@ -167,3 +177,11 @@ interface PartyUseCase {
      */
     suspend fun getPartyKeycloakSub(id: UUID): String?
 }
+
+/**
+ * One directory hit. Carries the party id and the LEGAL NAME only — the caller already knows the
+ * phone number they asked about, and nothing else about the payee is theirs to learn from a
+ * lookup. In particular no account, no email and no address: the payment rail resolves the
+ * account from the party id server-side.
+ */
+data class PhoneDirectoryMatch(val phoneHash: String, val partyId: UUID, val legalName: String)

--- a/openbank-party-service/src/main/kotlin/com/openbank/party/application/port/out/PartyPorts.kt
+++ b/openbank-party-service/src/main/kotlin/com/openbank/party/application/port/out/PartyPorts.kt
@@ -20,6 +20,12 @@ interface PartyRepository {
 
     suspend fun findByEmail(email: String): Party?
 
+    /** Pay-to-phone: parties that opted in AND whose phone hash is in [hashes]. */
+    suspend fun findDiscoverableByPhoneHashes(hashes: Collection<String>): List<Party>
+
+    /** Toggle pay-to-phone findability. Returns false when no such party exists. */
+    suspend fun updateDiscoverable(partyId: UUID, discoverable: Boolean, at: Instant): Boolean
+
     suspend fun update(party: Party): Party
 
     suspend fun listAll(page: Int, size: Int): List<Party>

--- a/openbank-party-service/src/main/kotlin/com/openbank/party/application/usecase/PartyService.kt
+++ b/openbank-party-service/src/main/kotlin/com/openbank/party/application/usecase/PartyService.kt
@@ -116,6 +116,32 @@ class PartyService : PartyUseCase {
      * D1's auto-activate path); the persisted row catches up asynchronously over Kafka, typically
      * within milliseconds.
      */
+    /**
+     * Pay-to-phone lookup. The caller sends hashes it computed from numbers it already holds; this
+     * returns the subset that belongs to a party who opted in. Nothing about a MISS is recorded —
+     * no log line, no table — because the set of numbers a customer knows is itself personal data
+     * and the bank has no business accumulating it.
+     *
+     * [MAX_DIRECTORY_LOOKUP] bounds a single call. It is not a privacy control on its own (a
+     * caller can page), it is what stops one request from turning into an unbounded IN-list; the
+     * privacy control is [Party.discoverable].
+     */
+    override suspend fun lookupByPhoneHashes(hashes: Collection<String>): List<PhoneDirectoryMatch> {
+        val clean = hashes.asSequence()
+            .map { it.trim().lowercase() }
+            .filter { it.length == SHA256_HEX_LENGTH && it.all { c -> c.isDigit() || c in 'a'..'f' } }
+            .distinct()
+            .take(MAX_DIRECTORY_LOOKUP)
+            .toList()
+        if (clean.isEmpty()) return emptyList()
+        return partyRepo.findDiscoverableByPhoneHashes(clean).mapNotNull { p ->
+            p.phone?.let { PhoneDirectory.hash(it) }?.let { h -> PhoneDirectoryMatch(h, p.id, p.legalName) }
+        }
+    }
+
+    override suspend fun updateDiscoverable(partyId: UUID, discoverable: Boolean): Boolean =
+        partyRepo.updateDiscoverable(partyId, discoverable, Instant.now(clock))
+
     override suspend fun updateMarketingConsent(cmd: UpdateMarketingConsentCommand): Party {
         val party = partyRepo.findById(cmd.id) ?: throw PartyNotFoundException(cmd.id)
         if (cmd.marketingConsent) {
@@ -431,3 +457,9 @@ class PartyService : PartyUseCase {
 
     override suspend fun getPartyKeycloakSub(id: UUID): String? = partyRepo.findById(id)?.keycloakSub
 }
+
+/** SHA-256 rendered as lowercase hex. */
+private const val SHA256_HEX_LENGTH = 64
+
+/** Upper bound on hashes accepted in one directory lookup — a request-shape guard, not a privacy one. */
+private const val MAX_DIRECTORY_LOOKUP = 500

--- a/openbank-party-service/src/main/kotlin/com/openbank/party/domain/model/Party.kt
+++ b/openbank-party-service/src/main/kotlin/com/openbank/party/domain/model/Party.kt
@@ -29,6 +29,8 @@ data class Party(
     val registrationNumber: String?,
     val email: String,
     val phone: String?,
+    /** Pay-to-phone findability. Opt-in — see [PhoneDirectory]. */
+    val discoverable: Boolean = false,
     val address: Address?,
     val kycStatus: KycStatus,
     val createdAt: Instant,

--- a/openbank-party-service/src/main/kotlin/com/openbank/party/domain/model/PhoneDirectory.kt
+++ b/openbank-party-service/src/main/kotlin/com/openbank/party/domain/model/PhoneDirectory.kt
@@ -1,0 +1,60 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright (c) OpenBank contributors. Licensed under the Apache License, Version 2.0.
+// See LICENSE in the repository root or https://www.apache.org/licenses/LICENSE-2.0 for details.
+
+package com.openbank.party.domain.model
+
+import java.security.MessageDigest
+
+/**
+ * Phone-number matching for pay-to-phone.
+ *
+ * **What the hash is for, and what it is not.** Hashing keeps plaintext phone numbers out of
+ * request bodies, access logs and this service's indexes — that is a real and worthwhile
+ * reduction in where a number can leak from. It is NOT a privacy guarantee against OpenBank:
+ * the phone-number space is small enough to enumerate, and this service holds both the numbers
+ * and the hashes anyway. Anyone reading `phone_hash` should read it as "not stored in the clear",
+ * never as "we cannot tell whose number this is".
+ *
+ * The protections that actually bound this feature are elsewhere: a party is only matchable
+ * after opting in ([Party.discoverable]), a lookup only ever answers about numbers the caller
+ * already had, and non-matching hashes are never persisted.
+ */
+object PhoneDirectory {
+
+    private const val CZ_COUNTRY_CODE = "+420"
+    private const val CZ_NATIONAL_DIGITS = 9
+    private const val MIN_E164_DIGITS = 8
+    private const val MAX_E164_DIGITS = 15
+
+    /**
+     * Canonical E.164 for [raw], or null when it cannot be trusted.
+     *
+     * A bare 9-digit national number is assumed Czech — the only country this bank operates in.
+     * Anything that does not land on a plausible E.164 returns null rather than a guess: an
+     * unmatched number costs a convenience, a WRONGLY matched one addresses a payment to a
+     * stranger.
+     */
+    fun normalise(raw: String?): String? {
+        val trimmed = raw?.trim()?.takeIf { it.isNotEmpty() } ?: return null
+        val digits = trimmed.filter { it.isDigit() }
+        if (digits.isEmpty()) return null
+        return when {
+            !trimmed.startsWith("+") && digits.length == CZ_NATIONAL_DIGITS && !digits.startsWith("0") ->
+                "$CZ_COUNTRY_CODE$digits"
+            trimmed.startsWith("+") && digits.length in MIN_E164_DIGITS..MAX_E164_DIGITS -> "+$digits"
+            // "00420…" — the other way people write an international prefix.
+            digits.startsWith("00") && digits.length - 2 in MIN_E164_DIGITS..MAX_E164_DIGITS ->
+                "+${digits.removePrefix("00")}"
+            else -> null
+        }
+    }
+
+    /** Lowercase hex SHA-256 of the E.164 form of [raw]; null when [raw] does not normalise. */
+    fun hash(raw: String?): String? {
+        val e164 = normalise(raw) ?: return null
+        return MessageDigest.getInstance("SHA-256")
+            .digest(e164.toByteArray(Charsets.UTF_8))
+            .joinToString("") { "%02x".format(it) }
+    }
+}

--- a/openbank-party-service/src/main/kotlin/com/openbank/party/infrastructure/persistence/entity/PartyEntity.kt
+++ b/openbank-party-service/src/main/kotlin/com/openbank/party/infrastructure/persistence/entity/PartyEntity.kt
@@ -45,6 +45,18 @@ class PartyEntity : PanacheEntity() {
     @Column(name = "phone")
     var phone: String? = null
 
+    /**
+     * Whether this party may be FOUND by someone who knows their phone number (pay-to-phone).
+     * Opt-in: false until the customer turns it on. See [PhoneDirectory] for what the hash does
+     * and does not protect.
+     */
+    @Column(name = "discoverable", nullable = false)
+    var discoverable: Boolean = false
+
+    /** SHA-256 of the E.164 [phone]; kept in step with [phone] on every write. */
+    @Column(name = "phone_hash")
+    var phoneHash: String? = null
+
     @Column(name = "address_line1")
     var addressLine1: String? = null
 

--- a/openbank-party-service/src/main/kotlin/com/openbank/party/infrastructure/persistence/repository/PartyRepositoryImpl.kt
+++ b/openbank-party-service/src/main/kotlin/com/openbank/party/infrastructure/persistence/repository/PartyRepositoryImpl.kt
@@ -108,6 +108,10 @@ class PartyRepositoryImpl :
                 it.status = party.status.name
                 it.email = party.email
                 it.phone = party.phone
+                // The hash is derived state, never supplied by a caller — recomputing it here is
+                // what keeps it from drifting out of step with the number it indexes.
+                it.phoneHash = PhoneDirectory.hash(party.phone)
+                it.discoverable = party.discoverable
                 it.tradingName = party.tradingName
                 it.kycStatus = party.kycStatus.name
                 it.amlStatus = party.amlStatus.name
@@ -124,6 +128,24 @@ class PartyRepositoryImpl :
             }
         }.replaceWith(party)
     }.awaitSuspending()
+
+    /**
+     * Discoverable parties whose phone hash is in [hashes]. Non-discoverable rows are excluded in
+     * the query, not filtered afterwards: a party that has not opted in must never leave this
+     * method, however the caller behaves.
+     */
+    override suspend fun findDiscoverableByPhoneHashes(hashes: Collection<String>): List<Party> {
+        if (hashes.isEmpty()) return emptyList()
+        return Panache.withSession {
+            find("discoverable = true and phoneHash in ?1", hashes.toList()).list()
+        }.awaitSuspending().map { it.toDomain() }
+    }
+
+    /** Scoped UPDATE of the opt-in flag alone — no read-modify-write of the whole aggregate. */
+    override suspend fun updateDiscoverable(partyId: UUID, discoverable: Boolean, at: Instant): Boolean =
+        Panache.withTransaction {
+            update("discoverable = ?1, updatedAt = ?2 where partyId = ?3", discoverable, at, partyId)
+        }.awaitSuspending() > 0
 
     override suspend fun findByKeycloakSub(sub: String): Party? =
         Panache.withSession { find("keycloakSub", sub).firstResult() }.awaitSuspending()?.toDomain()
@@ -152,6 +174,8 @@ class PartyRepositoryImpl :
         it.registrationNumber = registrationNumber
         it.email = email
         it.phone = phone
+        it.phoneHash = PhoneDirectory.hash(phone)
+        it.discoverable = discoverable
         it.kycStatus = kycStatus.name
         it.amlStatus = amlStatus.name
         it.addressLine1 = address?.line1
@@ -175,7 +199,7 @@ class PartyRepositoryImpl :
         id = partyId, partyType = PartyType.valueOf(partyType), status = PartyStatus.valueOf(status),
         legalName = legalName, tradingName = tradingName, dateOfBirth = dateOfBirth,
         nationality = nationality, taxId = taxId, registrationNumber = registrationNumber,
-        email = email, phone = phone, kycStatus = KycStatus.valueOf(kycStatus),
+        email = email, phone = phone, discoverable = discoverable, kycStatus = KycStatus.valueOf(kycStatus),
         address = if (addressLine1 !=
             null
         ) {

--- a/openbank-party-service/src/main/kotlin/com/openbank/party/infrastructure/rest/PartyResource.kt
+++ b/openbank-party-service/src/main/kotlin/com/openbank/party/infrastructure/rest/PartyResource.kt
@@ -130,6 +130,33 @@ class PartyResource {
         return Response.created(URI.create("/api/v1/parties/${party.id}")).entity(party.toResponse()).build()
     }
 
+    /**
+     * Pay-to-phone directory lookup (ROLE_API — the customer edge, never a browser).
+     *
+     * POST, not GET: the request body is a list of phone-number hashes derived from the caller's
+     * address book, and those have no business sitting in a URL, an access log or a proxy cache.
+     * Only parties who opted into being discoverable can come back, and a hash that matches
+     * nothing is not recorded anywhere.
+     */
+    @POST
+    @Path("/directory/lookup")
+    @RolesAllowed("ROLE_API")
+    @Operation(summary = "Match phone-number hashes against parties who opted into being discoverable")
+    suspend fun lookupDirectory(req: DirectoryLookupRequest): Response =
+        Response.ok(mapOf("matches" to partyUseCase.lookupByPhoneHashes(req.phoneHashes))).build()
+
+    /** Turn this party's pay-to-phone findability on or off. Revocable at any time. */
+    @PUT
+    @Path("/{id}/discoverable")
+    @RolesAllowed("ROLE_API", "ROLE_OPERATOR", "ROLE_ADMIN")
+    @Operation(summary = "Opt a party in or out of pay-to-phone discoverability")
+    suspend fun setDiscoverable(@PathParam("id") id: UUID, req: DiscoverableRequest): Response =
+        if (partyUseCase.updateDiscoverable(id, req.discoverable)) {
+            Response.ok(mapOf("discoverable" to req.discoverable)).build()
+        } else {
+            Response.status(Response.Status.NOT_FOUND).build()
+        }
+
     @GET
     @Path("/{id}")
     @RolesAllowed("ROLE_VIEWER", "ROLE_OPERATOR", "ROLE_ADMIN", "ROLE_KYC", "ROLE_API")
@@ -647,3 +674,8 @@ private const val GDPR_EXPORT_SCOPE =
     "party-service direct PII and identity-document metadata. KYC PII (kyc-service) and " +
         "card PII (card-issuance-service) are held by those services; aggregating them into this " +
         "subject-access response is a tracked follow-up (ADR-0118 §6)."
+
+/** Address-book hashes to match. See PhoneDirectory for what the hashing does and does not buy. */
+data class DirectoryLookupRequest(val phoneHashes: List<String> = emptyList())
+
+data class DiscoverableRequest(val discoverable: Boolean = false)

--- a/openbank-party-service/src/main/resources/db/migration/V17__party_phone_directory.sql
+++ b/openbank-party-service/src/main/resources/db/migration/V17__party_phone_directory.sql
@@ -1,0 +1,43 @@
+-- Phone directory (pay-to-phone). Two columns, both opt-in by construction:
+--
+--   discoverable — whether this party may be FOUND by someone who knows their phone number.
+--     Defaults to FALSE for every existing and future row. Findability has to be a decision the
+--     customer makes: a bank that answers "yes, that number banks with us" for anyone who guesses
+--     a number is leaking the existence of a customer relationship.
+--
+--   phone_hash — SHA-256 of the E.164 phone number, so the lookup never carries or compares a
+--     plaintext number. This keeps plaintext out of request bodies, logs and indexes; it is NOT a
+--     privacy guarantee against this service, which holds both the numbers and the hashes and
+--     could brute-force the (small) phone-number space regardless. Said plainly here so nobody
+--     reads the column name as stronger than it is.
+--
+-- The partial index only covers discoverable rows: a non-discoverable party must never be
+-- matchable, and keeping them out of the index makes that cheap as well as correct.
+ALTER TABLE parties ADD COLUMN discoverable BOOLEAN NOT NULL DEFAULT FALSE;
+ALTER TABLE parties ADD COLUMN phone_hash CHAR(64);
+
+-- Backfill for rows that already have a phone. normalise: drop everything but digits and a
+-- leading +, then assume the Czech country code for a bare 9-digit national number. Rows whose
+-- phone does not normalise to something plausible are left NULL — an unmatched row is a missed
+-- convenience, a WRONGLY matched one is a payment to a stranger.
+UPDATE parties
+SET phone_hash = encode(
+        sha256(
+            convert_to(
+                CASE
+                    WHEN regexp_replace(phone, '[^0-9]', '', 'g') ~ '^[1-9][0-9]{8}$'
+                        THEN '+420' || regexp_replace(phone, '[^0-9]', '', 'g')
+                    WHEN phone LIKE '+%' AND length(regexp_replace(phone, '[^0-9]', '', 'g')) BETWEEN 8 AND 15
+                        THEN '+' || regexp_replace(phone, '[^0-9]', '', 'g')
+                    ELSE NULL
+                END,
+                'UTF8'
+            )
+        ),
+        'hex'
+    )
+WHERE phone IS NOT NULL;
+
+CREATE INDEX idx_parties_phone_hash_discoverable
+    ON parties (phone_hash)
+    WHERE discoverable AND phone_hash IS NOT NULL;

--- a/openbank-party-service/src/main/resources/openapi.yaml
+++ b/openbank-party-service/src/main/resources/openapi.yaml
@@ -6,7 +6,7 @@ info:
   # major == openbank.api.version == URL /api/v1 (ADR-0048). Minor bump (1.8 -> 1.9): additive
   # only — a new PATCH /api/v1/parties/approvals/{id} endpoint and an additional 202 response
   # on POST /{id}/merge (ADR-0155 four-eyes). No existing response or schema changed.
-  version: 1.13.0
+  version: 1.14.0
   description: Legal entity and individual party management with document storage.
   license:
     name: Apache-2.0
@@ -249,6 +249,53 @@ paths:
       responses:
         '200':
           description: Updated
+        '404':
+          $ref: '#/components/responses/NotFound'
+
+  /api/v1/parties/directory/lookup:
+    post:
+      tags: [Parties]
+      summary: Match phone-number hashes against parties who opted into pay-to-phone discoverability
+      description: >
+        Answers only about parties whose `discoverable` flag is set, and only for hashes the
+        caller supplied — it cannot be walked to enumerate customers. Hashes that match nothing
+        are not recorded. The hashing keeps plaintext numbers out of bodies and logs; it is not a
+        privacy guarantee against this service, which holds the numbers as well.
+      operationId: lookupDirectory
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/DirectoryLookupRequest'
+      responses:
+        '200':
+          description: The hashes that matched a discoverable party
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/DirectoryLookupResponse'
+
+  /api/v1/parties/{id}/discoverable:
+    put:
+      tags: [Parties]
+      summary: Opt a party in or out of pay-to-phone discoverability
+      operationId: setDiscoverable
+      parameters:
+        - $ref: '#/components/parameters/partyId'
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/DiscoverableRequest'
+      responses:
+        '200':
+          description: The stored setting
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/DiscoverableRequest'
         '404':
           $ref: '#/components/responses/NotFound'
 
@@ -608,6 +655,39 @@ components:
             The ledger approval that authorised the balance sweep, linking the ADJUSTMENT journal
             entries to this identity retirement.
 
+    DirectoryLookupRequest:
+      type: object
+      properties:
+        phoneHashes:
+          type: array
+          description: Lowercase hex SHA-256 of each phone number in E.164 form.
+          items:
+            type: string
+    DirectoryLookupResponse:
+      type: object
+      properties:
+        matches:
+          type: array
+          items:
+            $ref: '#/components/schemas/PhoneDirectoryMatch'
+    PhoneDirectoryMatch:
+      type: object
+      description: >
+        A hash belonging to a discoverable party. Party id and legal name only — no account,
+        email or address; the payment rail resolves the account from the party id.
+      properties:
+        phoneHash:
+          type: string
+        partyId:
+          type: string
+          format: uuid
+        legalName:
+          type: string
+    DiscoverableRequest:
+      type: object
+      properties:
+        discoverable:
+          type: boolean
     UpdateConsentRequest:
       type: object
       required: [marketingConsent]

--- a/openbank-party-service/src/test/kotlin/com/openbank/party/domain/PhoneDirectoryTest.kt
+++ b/openbank-party-service/src/test/kotlin/com/openbank/party/domain/PhoneDirectoryTest.kt
@@ -1,0 +1,53 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright (c) OpenBank contributors. Licensed under the Apache License, Version 2.0.
+// See LICENSE in the repository root or https://www.apache.org/licenses/LICENSE-2.0 for details.
+
+package com.openbank.party.domain
+
+import com.openbank.party.domain.model.PhoneDirectory
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.Test
+
+/**
+ * The normaliser decides who a pay-to-phone payment can be addressed to, so its failure mode
+ * matters more than its hit rate: an unrecognised number costs a convenience, a number
+ * normalised to the WRONG canonical form addresses money at a stranger.
+ */
+class PhoneDirectoryTest {
+
+    @Test
+    fun `the same number written four ways hashes identically`() {
+        val forms = listOf("+420 601 123 456", "+420601123456", "601 123 456", "00420601123456")
+        val hashes = forms.map { PhoneDirectory.hash(it) }.toSet()
+        assertThat(hashes).hasSize(1)
+        assertThat(hashes.single()).isNotNull()
+    }
+
+    @Test
+    fun `a bare nine-digit number is treated as Czech`() {
+        assertThat(PhoneDirectory.normalise("601123456")).isEqualTo("+420601123456")
+    }
+
+    @Test
+    fun `an explicit country code is never overwritten with the Czech one`() {
+        assertThat(PhoneDirectory.normalise("+44 20 7946 0958")).isEqualTo("+442079460958")
+    }
+
+    @Test
+    fun `numbers that cannot be trusted normalise to null rather than a guess`() {
+        // Too short, alphabetic, empty, a national number starting with a trunk prefix rather
+        // than a subscriber digit, and an over-long E.164.
+        val rejected = listOf(null, "", "   ", "12345", "0601123456", "not a phone", "+1234567890123456")
+        assertThat(rejected.map { PhoneDirectory.normalise(it) }).containsOnlyNulls()
+    }
+
+    @Test
+    fun `a hash is lowercase hex sha-256`() {
+        assertThat(PhoneDirectory.hash("+420601123456")).isNotNull().matches("[0-9a-f]{64}")
+    }
+
+    @Test
+    fun `different numbers do not collide`() {
+        assertThat(PhoneDirectory.hash("+420601123456")).isNotEqualTo(PhoneDirectory.hash("+420601123457"))
+    }
+}


### PR DESCRIPTION
Backend for pay-to-phone in the mobile app: pay someone by phone number, and show which contacts bank here — without the bank quietly accumulating address books.

## party-service

- **`discoverable`** — default `FALSE` for every existing and future row. A party is invisible to the directory until they turn it on. Findability has to be the customer's decision: a bank that answers *"yes, that number banks with us"* to anyone who guesses a number is leaking the existence of a customer relationship.
- **`phone_hash`** — SHA-256 of the E.164 number, kept in step with `phone` on every write and backfilled for existing rows. The partial index covers **only discoverable rows**, so a party who has not opted in cannot be matched even by accident.
- `POST /parties/directory/lookup` (ROLE_API), `PUT /parties/{id}/discoverable`.

## customer-edge

- `POST /customer/v1/directory/lookup`, `PUT /customer/v1/directory/discoverable` — both party-scoped from the JWT, so a customer can only ever change their own setting.
- A match returns **a party id and a legal name, nothing else**. No account, no email, no address: knowing that someone banks here must not hand out their account number. The payment rail resolves the account from the party id server-side.

## What the hashing is, and what it isn't

It keeps plaintext phone numbers out of request bodies, access logs and indexes — a real reduction in where a number can leak from.

It is **not** a privacy guarantee against OpenBank. The phone-number space is small enough to enumerate, and party-service holds both the numbers and the hashes anyway. The SQL and the Kotlin both say so in as many words, so nobody later reads `phone_hash` as "we cannot tell whose number this is".

The controls that actually bound this feature are: the opt-in, answering only about hashes the caller already supplied (so it cannot be walked to enumerate customers), and never persisting a miss — the set of numbers a customer knows is itself personal data.

## Normalisation

`PhoneDirectory.normalise` returns `null` rather than a guess for anything that does not land on a plausible E.164. An unrecognised number costs a convenience; a wrongly normalised one addresses money at a stranger.

6 tests: the four ways one number gets written all hash alike, a bare 9-digit number defaults to CZ, an explicit country code is never overwritten, and the rejects stay rejected.

Edge OpenAPI 1.22.0 → 1.23.0.

## Linked issues

N/A — backend for the app-side pay-to-phone feature requested directly; no tracking issue was filed.