### PR TITLE
feat(governance): role→action matrix as data + shadow matrix-allows reason (ADR-0223 phase 1)

### DIFF
--- a/openbank-infra/gitops/components/accounts/account-opa-bundle.yaml
+++ b/openbank-infra/gitops/components/accounts/account-opa-bundle.yaml
@@ -9,7 +9,7 @@ metadata:
     app.kubernetes.io/name: account-service
     app.kubernetes.io/part-of: accounts
   annotations:
-    openbank.tech/policy-checksum: "8c41fb8571249943"
+    openbank.tech/policy-checksum: "f521c1fbe717ea57"
 data:
   rest.rego: |
     # SPDX-License-Identifier: Apache-2.0
@@ -145,6 +145,21 @@ data:
     	input.principal.id == input.resource.id
     	some verb in {"list", "read"}
     	endswith(input.action, sprintf(".%v", [verb]))
+    }
+
+    # ---------------------------------------------------------------------------------------
+    # ADR-0223 D2 phase 1 (shadow): the role->action matrix as data (rules.yaml: authz.
+    # role_action_matrix), granting ALONGSIDE the legacy reasons. The seed is derived as a
+    # strict subset of today's effective grants (operator-read-any's and compliance-read-any's
+    # read verbs, verbatim), so this rule changes no decision; what it changes is the
+    # decision_reason mix, which the D2(b) retirement triage reads to find where the matrix
+    # already carries the call. A role absent from the matrix yields an undefined lookup and
+    # the rule simply does not fire — fail-closed by construction.
+    # ---------------------------------------------------------------------------------------
+    allowed_reasons contains "matrix-allows" if {
+    	input.principal.type == "HUMAN"
+    	some role in input.principal.roles
+    	input.action in data.rules.authz.role_action_matrix[role].grant
     }
 
     # Operators and admins may list or read any resource on behalf of any party (support-desk
@@ -3504,5 +3519,95 @@ data:
           form: "a runnable skill that encodes the steps so they aren't re-derived each time"
       not_a_home:
         - "assistant session/local memory — does not travel to other agents or contributors, and may be stale"
+
+    # ADR-0223 D2 (phase 1, shadow): the role→action matrix as data. Seeded as the EXACT read
+    # half of today's operator-read-any (ROLE_OPERATOR/ROLE_ADMIN: every .list/.read) and
+    # compliance-read-any (ROLE_COMPLIANCE: every .read) — the action inventory is derived from
+    # the fleet-wide @Authorize coverage report (openbank-infra/scripts/authz-coverage-report.py),
+    # making this a provable subset of today's effective grants: rest.rego's matrix-allows reason
+    # grants nothing new, and decision_reason telemetry shows where the matrix already carries
+    # the call. Write grants (operator-<domain>-write etc.) join in phase 1.5 after the D2(b)
+    # triage; the retirement of operator-read-any itself is D2(c), a separate PR.
+    authz:
+      role_action_matrix:
+        ROLE_OPERATOR:
+          grant:
+            - account.list
+            - account.read
+            - anacredit.list
+            - anacredit.read
+            - audit.read
+            - card.list
+            - card.read
+            - device.list
+            - dispatch.read
+            - fx.list
+            - fx.read
+            - interest.list
+            - interest.read
+            - ledger.list
+            - ledger.read
+            - lending.list
+            - lending.read
+            - notification.list
+            - notification.read
+            - sanctions.list
+            - sanctions.read
+            - sdd.list
+            - sdd.read
+            - statement.list
+            - statement.read
+            - swift.list
+            - swift.read
+            - transaction.list
+            - transaction.read
+        ROLE_ADMIN:
+          grant:
+            - account.list
+            - account.read
+            - anacredit.list
+            - anacredit.read
+            - audit.read
+            - card.list
+            - card.read
+            - device.list
+            - dispatch.read
+            - fx.list
+            - fx.read
+            - interest.list
+            - interest.read
+            - ledger.list
+            - ledger.read
+            - lending.list
+            - lending.read
+            - notification.list
+            - notification.read
+            - sanctions.list
+            - sanctions.read
+            - sdd.list
+            - sdd.read
+            - statement.list
+            - statement.read
+            - swift.list
+            - swift.read
+            - transaction.list
+            - transaction.read
+        ROLE_COMPLIANCE:
+          grant:
+            - account.read
+            - anacredit.read
+            - audit.read
+            - card.read
+            - dispatch.read
+            - fx.read
+            - interest.read
+            - ledger.read
+            - lending.read
+            - notification.read
+            - sanctions.read
+            - sdd.read
+            - statement.read
+            - swift.read
+            - transaction.read
   manifest.json: |
     {"roots": ["openbank/agents", "openbank/copilot", "openbank/rest", "agents", "rules"]}

--- a/openbank-infra/gitops/components/accounts/account-service.yaml
+++ b/openbank-infra/gitops/components/accounts/account-service.yaml
@@ -37,7 +37,7 @@ spec:
       annotations:
         # Rolls the pod when the OPA bundle changes — subPath mounts do NOT hot-reload.
         # Kept in sync by gen-account-opa-bundle.sh (do not hand-edit).
-        openbank.tech/policy-checksum: "8c41fb8571249943"
+        openbank.tech/policy-checksum: "f521c1fbe717ea57"
     spec:
       securityContext:
         runAsNonRoot: true
@@ -106,13 +106,6 @@ spec:
             # user tokens validate here without the edge cert.
             - name: QUARKUS_OIDC_AUTH_SERVER_URL
               value: http://keycloak.iam.svc:8080/realms/openbank
-            # ADR-0083 T1 re-entry: product-catalog reads route through the KEDA HTTP
-            # interceptor (dispatches on Host) so a scaled-to-zero pod wakes instead of
-            # refusing the connection (#668's fail-open hid exactly that refusal).
-            - name: PRODUCT_CATALOG_SERVICE_URL
-              value: http://keda-add-ons-http-interceptor-proxy.keda:8080
-            - name: PRODUCT_CATALOG_API_HOST_OVERRIDE
-              value: product-catalog.accounts.svc
             - name: OIDC_CLIENT_SECRET
               valueFrom:
                 secretKeyRef:

--- a/openbank-infra/gitops/components/aml/aml-opa-bundle.yaml
+++ b/openbank-infra/gitops/components/aml/aml-opa-bundle.yaml
@@ -9,7 +9,7 @@ metadata:
     app.kubernetes.io/name: aml-service
     app.kubernetes.io/part-of: aml
   annotations:
-    openbank.tech/policy-checksum: "6c5e4bcd20f6fb39"
+    openbank.tech/policy-checksum: "b07cf27112d6d227"
 data:
   rest.rego: |
     # SPDX-License-Identifier: Apache-2.0
@@ -145,6 +145,21 @@ data:
     	input.principal.id == input.resource.id
     	some verb in {"list", "read"}
     	endswith(input.action, sprintf(".%v", [verb]))
+    }
+
+    # ---------------------------------------------------------------------------------------
+    # ADR-0223 D2 phase 1 (shadow): the role->action matrix as data (rules.yaml: authz.
+    # role_action_matrix), granting ALONGSIDE the legacy reasons. The seed is derived as a
+    # strict subset of today's effective grants (operator-read-any's and compliance-read-any's
+    # read verbs, verbatim), so this rule changes no decision; what it changes is the
+    # decision_reason mix, which the D2(b) retirement triage reads to find where the matrix
+    # already carries the call. A role absent from the matrix yields an undefined lookup and
+    # the rule simply does not fire — fail-closed by construction.
+    # ---------------------------------------------------------------------------------------
+    allowed_reasons contains "matrix-allows" if {
+    	input.principal.type == "HUMAN"
+    	some role in input.principal.roles
+    	input.action in data.rules.authz.role_action_matrix[role].grant
     }
 
     # Operators and admins may list or read any resource on behalf of any party (support-desk
@@ -3477,5 +3492,95 @@ data:
           form: "a runnable skill that encodes the steps so they aren't re-derived each time"
       not_a_home:
         - "assistant session/local memory — does not travel to other agents or contributors, and may be stale"
+
+    # ADR-0223 D2 (phase 1, shadow): the role→action matrix as data. Seeded as the EXACT read
+    # half of today's operator-read-any (ROLE_OPERATOR/ROLE_ADMIN: every .list/.read) and
+    # compliance-read-any (ROLE_COMPLIANCE: every .read) — the action inventory is derived from
+    # the fleet-wide @Authorize coverage report (openbank-infra/scripts/authz-coverage-report.py),
+    # making this a provable subset of today's effective grants: rest.rego's matrix-allows reason
+    # grants nothing new, and decision_reason telemetry shows where the matrix already carries
+    # the call. Write grants (operator-<domain>-write etc.) join in phase 1.5 after the D2(b)
+    # triage; the retirement of operator-read-any itself is D2(c), a separate PR.
+    authz:
+      role_action_matrix:
+        ROLE_OPERATOR:
+          grant:
+            - account.list
+            - account.read
+            - anacredit.list
+            - anacredit.read
+            - audit.read
+            - card.list
+            - card.read
+            - device.list
+            - dispatch.read
+            - fx.list
+            - fx.read
+            - interest.list
+            - interest.read
+            - ledger.list
+            - ledger.read
+            - lending.list
+            - lending.read
+            - notification.list
+            - notification.read
+            - sanctions.list
+            - sanctions.read
+            - sdd.list
+            - sdd.read
+            - statement.list
+            - statement.read
+            - swift.list
+            - swift.read
+            - transaction.list
+            - transaction.read
+        ROLE_ADMIN:
+          grant:
+            - account.list
+            - account.read
+            - anacredit.list
+            - anacredit.read
+            - audit.read
+            - card.list
+            - card.read
+            - device.list
+            - dispatch.read
+            - fx.list
+            - fx.read
+            - interest.list
+            - interest.read
+            - ledger.list
+            - ledger.read
+            - lending.list
+            - lending.read
+            - notification.list
+            - notification.read
+            - sanctions.list
+            - sanctions.read
+            - sdd.list
+            - sdd.read
+            - statement.list
+            - statement.read
+            - swift.list
+            - swift.read
+            - transaction.list
+            - transaction.read
+        ROLE_COMPLIANCE:
+          grant:
+            - account.read
+            - anacredit.read
+            - audit.read
+            - card.read
+            - dispatch.read
+            - fx.read
+            - interest.read
+            - ledger.read
+            - lending.read
+            - notification.read
+            - sanctions.read
+            - sdd.read
+            - statement.read
+            - swift.read
+            - transaction.read
   manifest.json: |
     {"roots": ["openbank/agents", "openbank/copilot", "openbank/rest", "agents", "rules"]}

--- a/openbank-infra/gitops/components/aml/aml-service.yaml
+++ b/openbank-infra/gitops/components/aml/aml-service.yaml
@@ -22,7 +22,7 @@ spec:
       annotations:
         # Rolls the pod when the OPA bundle changes (subPath mounts do not hot-reload).
         # Kept in sync by gen-aml-opa-bundle.sh (do not hand-edit).
-        openbank.tech/policy-checksum: "6c5e4bcd20f6fb39"
+        openbank.tech/policy-checksum: "b07cf27112d6d227"
     spec:
       securityContext:
         runAsNonRoot: true

--- a/openbank-infra/gitops/components/anacredit/anacredit-opa-bundle.yaml
+++ b/openbank-infra/gitops/components/anacredit/anacredit-opa-bundle.yaml
@@ -9,7 +9,7 @@ metadata:
     app.kubernetes.io/name: anacredit-service
     app.kubernetes.io/part-of: anacredit
   annotations:
-    openbank.tech/policy-checksum: "c70ad46020a41dbe"
+    openbank.tech/policy-checksum: "e8cc62aba3dcdd39"
 data:
   rest.rego: |
     # SPDX-License-Identifier: Apache-2.0
@@ -145,6 +145,21 @@ data:
     	input.principal.id == input.resource.id
     	some verb in {"list", "read"}
     	endswith(input.action, sprintf(".%v", [verb]))
+    }
+
+    # ---------------------------------------------------------------------------------------
+    # ADR-0223 D2 phase 1 (shadow): the role->action matrix as data (rules.yaml: authz.
+    # role_action_matrix), granting ALONGSIDE the legacy reasons. The seed is derived as a
+    # strict subset of today's effective grants (operator-read-any's and compliance-read-any's
+    # read verbs, verbatim), so this rule changes no decision; what it changes is the
+    # decision_reason mix, which the D2(b) retirement triage reads to find where the matrix
+    # already carries the call. A role absent from the matrix yields an undefined lookup and
+    # the rule simply does not fire — fail-closed by construction.
+    # ---------------------------------------------------------------------------------------
+    allowed_reasons contains "matrix-allows" if {
+    	input.principal.type == "HUMAN"
+    	some role in input.principal.roles
+    	input.action in data.rules.authz.role_action_matrix[role].grant
     }
 
     # Operators and admins may list or read any resource on behalf of any party (support-desk
@@ -3447,5 +3462,95 @@ data:
           form: "a runnable skill that encodes the steps so they aren't re-derived each time"
       not_a_home:
         - "assistant session/local memory — does not travel to other agents or contributors, and may be stale"
+
+    # ADR-0223 D2 (phase 1, shadow): the role→action matrix as data. Seeded as the EXACT read
+    # half of today's operator-read-any (ROLE_OPERATOR/ROLE_ADMIN: every .list/.read) and
+    # compliance-read-any (ROLE_COMPLIANCE: every .read) — the action inventory is derived from
+    # the fleet-wide @Authorize coverage report (openbank-infra/scripts/authz-coverage-report.py),
+    # making this a provable subset of today's effective grants: rest.rego's matrix-allows reason
+    # grants nothing new, and decision_reason telemetry shows where the matrix already carries
+    # the call. Write grants (operator-<domain>-write etc.) join in phase 1.5 after the D2(b)
+    # triage; the retirement of operator-read-any itself is D2(c), a separate PR.
+    authz:
+      role_action_matrix:
+        ROLE_OPERATOR:
+          grant:
+            - account.list
+            - account.read
+            - anacredit.list
+            - anacredit.read
+            - audit.read
+            - card.list
+            - card.read
+            - device.list
+            - dispatch.read
+            - fx.list
+            - fx.read
+            - interest.list
+            - interest.read
+            - ledger.list
+            - ledger.read
+            - lending.list
+            - lending.read
+            - notification.list
+            - notification.read
+            - sanctions.list
+            - sanctions.read
+            - sdd.list
+            - sdd.read
+            - statement.list
+            - statement.read
+            - swift.list
+            - swift.read
+            - transaction.list
+            - transaction.read
+        ROLE_ADMIN:
+          grant:
+            - account.list
+            - account.read
+            - anacredit.list
+            - anacredit.read
+            - audit.read
+            - card.list
+            - card.read
+            - device.list
+            - dispatch.read
+            - fx.list
+            - fx.read
+            - interest.list
+            - interest.read
+            - ledger.list
+            - ledger.read
+            - lending.list
+            - lending.read
+            - notification.list
+            - notification.read
+            - sanctions.list
+            - sanctions.read
+            - sdd.list
+            - sdd.read
+            - statement.list
+            - statement.read
+            - swift.list
+            - swift.read
+            - transaction.list
+            - transaction.read
+        ROLE_COMPLIANCE:
+          grant:
+            - account.read
+            - anacredit.read
+            - audit.read
+            - card.read
+            - dispatch.read
+            - fx.read
+            - interest.read
+            - ledger.read
+            - lending.read
+            - notification.read
+            - sanctions.read
+            - sdd.read
+            - statement.read
+            - swift.read
+            - transaction.read
   manifest.json: |
     {"roots": ["openbank/agents", "openbank/copilot", "openbank/rest", "agents", "rules"]}

--- a/openbank-infra/gitops/components/anacredit/anacredit-service.yaml
+++ b/openbank-infra/gitops/components/anacredit/anacredit-service.yaml
@@ -32,7 +32,7 @@ spec:
       annotations:
         # Rolls the pods when the OPA bundle changes — subPath mounts do NOT hot-reload.
         # Kept in sync by gen-anacredit-opa-bundle.sh (do not hand-edit).
-        openbank.tech/policy-checksum: "c70ad46020a41dbe"
+        openbank.tech/policy-checksum: "e8cc62aba3dcdd39"
     spec:
       securityContext:
         runAsNonRoot: true

--- a/openbank-infra/gitops/components/ap2/ap2-opa-bundle.yaml
+++ b/openbank-infra/gitops/components/ap2/ap2-opa-bundle.yaml
@@ -9,7 +9,7 @@ metadata:
     app.kubernetes.io/name: mcp-service
     app.kubernetes.io/part-of: platform
   annotations:
-    openbank.tech/policy-checksum: "44ce78c4ebb1cafa"
+    openbank.tech/policy-checksum: "7d2bfb2623287e86"
 data:
   rest.rego: |
     # SPDX-License-Identifier: Apache-2.0
@@ -145,6 +145,21 @@ data:
     	input.principal.id == input.resource.id
     	some verb in {"list", "read"}
     	endswith(input.action, sprintf(".%v", [verb]))
+    }
+
+    # ---------------------------------------------------------------------------------------
+    # ADR-0223 D2 phase 1 (shadow): the role->action matrix as data (rules.yaml: authz.
+    # role_action_matrix), granting ALONGSIDE the legacy reasons. The seed is derived as a
+    # strict subset of today's effective grants (operator-read-any's and compliance-read-any's
+    # read verbs, verbatim), so this rule changes no decision; what it changes is the
+    # decision_reason mix, which the D2(b) retirement triage reads to find where the matrix
+    # already carries the call. A role absent from the matrix yields an undefined lookup and
+    # the rule simply does not fire — fail-closed by construction.
+    # ---------------------------------------------------------------------------------------
+    allowed_reasons contains "matrix-allows" if {
+    	input.principal.type == "HUMAN"
+    	some role in input.principal.roles
+    	input.action in data.rules.authz.role_action_matrix[role].grant
     }
 
     # Operators and admins may list or read any resource on behalf of any party (support-desk
@@ -3415,5 +3430,95 @@ data:
           form: "a runnable skill that encodes the steps so they aren't re-derived each time"
       not_a_home:
         - "assistant session/local memory — does not travel to other agents or contributors, and may be stale"
+
+    # ADR-0223 D2 (phase 1, shadow): the role→action matrix as data. Seeded as the EXACT read
+    # half of today's operator-read-any (ROLE_OPERATOR/ROLE_ADMIN: every .list/.read) and
+    # compliance-read-any (ROLE_COMPLIANCE: every .read) — the action inventory is derived from
+    # the fleet-wide @Authorize coverage report (openbank-infra/scripts/authz-coverage-report.py),
+    # making this a provable subset of today's effective grants: rest.rego's matrix-allows reason
+    # grants nothing new, and decision_reason telemetry shows where the matrix already carries
+    # the call. Write grants (operator-<domain>-write etc.) join in phase 1.5 after the D2(b)
+    # triage; the retirement of operator-read-any itself is D2(c), a separate PR.
+    authz:
+      role_action_matrix:
+        ROLE_OPERATOR:
+          grant:
+            - account.list
+            - account.read
+            - anacredit.list
+            - anacredit.read
+            - audit.read
+            - card.list
+            - card.read
+            - device.list
+            - dispatch.read
+            - fx.list
+            - fx.read
+            - interest.list
+            - interest.read
+            - ledger.list
+            - ledger.read
+            - lending.list
+            - lending.read
+            - notification.list
+            - notification.read
+            - sanctions.list
+            - sanctions.read
+            - sdd.list
+            - sdd.read
+            - statement.list
+            - statement.read
+            - swift.list
+            - swift.read
+            - transaction.list
+            - transaction.read
+        ROLE_ADMIN:
+          grant:
+            - account.list
+            - account.read
+            - anacredit.list
+            - anacredit.read
+            - audit.read
+            - card.list
+            - card.read
+            - device.list
+            - dispatch.read
+            - fx.list
+            - fx.read
+            - interest.list
+            - interest.read
+            - ledger.list
+            - ledger.read
+            - lending.list
+            - lending.read
+            - notification.list
+            - notification.read
+            - sanctions.list
+            - sanctions.read
+            - sdd.list
+            - sdd.read
+            - statement.list
+            - statement.read
+            - swift.list
+            - swift.read
+            - transaction.list
+            - transaction.read
+        ROLE_COMPLIANCE:
+          grant:
+            - account.read
+            - anacredit.read
+            - audit.read
+            - card.read
+            - dispatch.read
+            - fx.read
+            - interest.read
+            - ledger.read
+            - lending.read
+            - notification.read
+            - sanctions.read
+            - sdd.read
+            - statement.read
+            - swift.read
+            - transaction.read
   manifest.json: |
     {"roots": ["openbank/agents", "openbank/copilot", "openbank/rest", "agents", "rules"]}

--- a/openbank-infra/gitops/components/ap2/ap2-service.yaml
+++ b/openbank-infra/gitops/components/ap2/ap2-service.yaml
@@ -30,7 +30,7 @@ spec:
       annotations:
         # Roll the pod when the OPA policy bundle changes (subPath mounts don't hot-reload).
         # Kept in sync by gen-ap2-opa-bundle.sh (do not hand-edit).
-        openbank.tech/policy-checksum: "44ce78c4ebb1cafa"
+        openbank.tech/policy-checksum: "7d2bfb2623287e86"
     spec:
       securityContext:
         runAsNonRoot: true

--- a/openbank-infra/gitops/components/audit/audit-opa-bundle.yaml
+++ b/openbank-infra/gitops/components/audit/audit-opa-bundle.yaml
@@ -9,7 +9,7 @@ metadata:
     app.kubernetes.io/name: audit-service
     app.kubernetes.io/part-of: audit
   annotations:
-    openbank.tech/policy-checksum: "f993698b4ea07b98"
+    openbank.tech/policy-checksum: "2fb1a7f94ee4de6c"
 data:
   rest.rego: |
     # SPDX-License-Identifier: Apache-2.0
@@ -145,6 +145,21 @@ data:
     	input.principal.id == input.resource.id
     	some verb in {"list", "read"}
     	endswith(input.action, sprintf(".%v", [verb]))
+    }
+
+    # ---------------------------------------------------------------------------------------
+    # ADR-0223 D2 phase 1 (shadow): the role->action matrix as data (rules.yaml: authz.
+    # role_action_matrix), granting ALONGSIDE the legacy reasons. The seed is derived as a
+    # strict subset of today's effective grants (operator-read-any's and compliance-read-any's
+    # read verbs, verbatim), so this rule changes no decision; what it changes is the
+    # decision_reason mix, which the D2(b) retirement triage reads to find where the matrix
+    # already carries the call. A role absent from the matrix yields an undefined lookup and
+    # the rule simply does not fire — fail-closed by construction.
+    # ---------------------------------------------------------------------------------------
+    allowed_reasons contains "matrix-allows" if {
+    	input.principal.type == "HUMAN"
+    	some role in input.principal.roles
+    	input.action in data.rules.authz.role_action_matrix[role].grant
     }
 
     # Operators and admins may list or read any resource on behalf of any party (support-desk
@@ -3459,5 +3474,95 @@ data:
           form: "a runnable skill that encodes the steps so they aren't re-derived each time"
       not_a_home:
         - "assistant session/local memory — does not travel to other agents or contributors, and may be stale"
+
+    # ADR-0223 D2 (phase 1, shadow): the role→action matrix as data. Seeded as the EXACT read
+    # half of today's operator-read-any (ROLE_OPERATOR/ROLE_ADMIN: every .list/.read) and
+    # compliance-read-any (ROLE_COMPLIANCE: every .read) — the action inventory is derived from
+    # the fleet-wide @Authorize coverage report (openbank-infra/scripts/authz-coverage-report.py),
+    # making this a provable subset of today's effective grants: rest.rego's matrix-allows reason
+    # grants nothing new, and decision_reason telemetry shows where the matrix already carries
+    # the call. Write grants (operator-<domain>-write etc.) join in phase 1.5 after the D2(b)
+    # triage; the retirement of operator-read-any itself is D2(c), a separate PR.
+    authz:
+      role_action_matrix:
+        ROLE_OPERATOR:
+          grant:
+            - account.list
+            - account.read
+            - anacredit.list
+            - anacredit.read
+            - audit.read
+            - card.list
+            - card.read
+            - device.list
+            - dispatch.read
+            - fx.list
+            - fx.read
+            - interest.list
+            - interest.read
+            - ledger.list
+            - ledger.read
+            - lending.list
+            - lending.read
+            - notification.list
+            - notification.read
+            - sanctions.list
+            - sanctions.read
+            - sdd.list
+            - sdd.read
+            - statement.list
+            - statement.read
+            - swift.list
+            - swift.read
+            - transaction.list
+            - transaction.read
+        ROLE_ADMIN:
+          grant:
+            - account.list
+            - account.read
+            - anacredit.list
+            - anacredit.read
+            - audit.read
+            - card.list
+            - card.read
+            - device.list
+            - dispatch.read
+            - fx.list
+            - fx.read
+            - interest.list
+            - interest.read
+            - ledger.list
+            - ledger.read
+            - lending.list
+            - lending.read
+            - notification.list
+            - notification.read
+            - sanctions.list
+            - sanctions.read
+            - sdd.list
+            - sdd.read
+            - statement.list
+            - statement.read
+            - swift.list
+            - swift.read
+            - transaction.list
+            - transaction.read
+        ROLE_COMPLIANCE:
+          grant:
+            - account.read
+            - anacredit.read
+            - audit.read
+            - card.read
+            - dispatch.read
+            - fx.read
+            - interest.read
+            - ledger.read
+            - lending.read
+            - notification.read
+            - sanctions.read
+            - sdd.read
+            - statement.read
+            - swift.read
+            - transaction.read
   manifest.json: |
     {"roots": ["openbank/agents", "openbank/copilot", "openbank/rest", "agents", "rules"]}

--- a/openbank-infra/gitops/components/audit/audit-service.yaml
+++ b/openbank-infra/gitops/components/audit/audit-service.yaml
@@ -22,7 +22,7 @@ spec:
       annotations:
         # Rolls the pod when the OPA bundle changes (subPath mounts do not hot-reload).
         # Kept in sync by gen-audit-opa-bundle.sh (do not hand-edit).
-        openbank.tech/policy-checksum: "f993698b4ea07b98"
+        openbank.tech/policy-checksum: "2fb1a7f94ee4de6c"
     spec:
       securityContext:
         runAsNonRoot: true

--- a/openbank-infra/gitops/components/balances/balance-opa-bundle.yaml
+++ b/openbank-infra/gitops/components/balances/balance-opa-bundle.yaml
@@ -9,7 +9,7 @@ metadata:
     app.kubernetes.io/name: balance-service
     app.kubernetes.io/part-of: balances
   annotations:
-    openbank.tech/policy-checksum: "4fcc7ce365ba1142"
+    openbank.tech/policy-checksum: "b8402b1bbfc12b22"
 data:
   rest.rego: |
     # SPDX-License-Identifier: Apache-2.0
@@ -145,6 +145,21 @@ data:
     	input.principal.id == input.resource.id
     	some verb in {"list", "read"}
     	endswith(input.action, sprintf(".%v", [verb]))
+    }
+
+    # ---------------------------------------------------------------------------------------
+    # ADR-0223 D2 phase 1 (shadow): the role->action matrix as data (rules.yaml: authz.
+    # role_action_matrix), granting ALONGSIDE the legacy reasons. The seed is derived as a
+    # strict subset of today's effective grants (operator-read-any's and compliance-read-any's
+    # read verbs, verbatim), so this rule changes no decision; what it changes is the
+    # decision_reason mix, which the D2(b) retirement triage reads to find where the matrix
+    # already carries the call. A role absent from the matrix yields an undefined lookup and
+    # the rule simply does not fire — fail-closed by construction.
+    # ---------------------------------------------------------------------------------------
+    allowed_reasons contains "matrix-allows" if {
+    	input.principal.type == "HUMAN"
+    	some role in input.principal.roles
+    	input.action in data.rules.authz.role_action_matrix[role].grant
     }
 
     # Operators and admins may list or read any resource on behalf of any party (support-desk
@@ -3548,5 +3563,95 @@ data:
           form: "a runnable skill that encodes the steps so they aren't re-derived each time"
       not_a_home:
         - "assistant session/local memory — does not travel to other agents or contributors, and may be stale"
+
+    # ADR-0223 D2 (phase 1, shadow): the role→action matrix as data. Seeded as the EXACT read
+    # half of today's operator-read-any (ROLE_OPERATOR/ROLE_ADMIN: every .list/.read) and
+    # compliance-read-any (ROLE_COMPLIANCE: every .read) — the action inventory is derived from
+    # the fleet-wide @Authorize coverage report (openbank-infra/scripts/authz-coverage-report.py),
+    # making this a provable subset of today's effective grants: rest.rego's matrix-allows reason
+    # grants nothing new, and decision_reason telemetry shows where the matrix already carries
+    # the call. Write grants (operator-<domain>-write etc.) join in phase 1.5 after the D2(b)
+    # triage; the retirement of operator-read-any itself is D2(c), a separate PR.
+    authz:
+      role_action_matrix:
+        ROLE_OPERATOR:
+          grant:
+            - account.list
+            - account.read
+            - anacredit.list
+            - anacredit.read
+            - audit.read
+            - card.list
+            - card.read
+            - device.list
+            - dispatch.read
+            - fx.list
+            - fx.read
+            - interest.list
+            - interest.read
+            - ledger.list
+            - ledger.read
+            - lending.list
+            - lending.read
+            - notification.list
+            - notification.read
+            - sanctions.list
+            - sanctions.read
+            - sdd.list
+            - sdd.read
+            - statement.list
+            - statement.read
+            - swift.list
+            - swift.read
+            - transaction.list
+            - transaction.read
+        ROLE_ADMIN:
+          grant:
+            - account.list
+            - account.read
+            - anacredit.list
+            - anacredit.read
+            - audit.read
+            - card.list
+            - card.read
+            - device.list
+            - dispatch.read
+            - fx.list
+            - fx.read
+            - interest.list
+            - interest.read
+            - ledger.list
+            - ledger.read
+            - lending.list
+            - lending.read
+            - notification.list
+            - notification.read
+            - sanctions.list
+            - sanctions.read
+            - sdd.list
+            - sdd.read
+            - statement.list
+            - statement.read
+            - swift.list
+            - swift.read
+            - transaction.list
+            - transaction.read
+        ROLE_COMPLIANCE:
+          grant:
+            - account.read
+            - anacredit.read
+            - audit.read
+            - card.read
+            - dispatch.read
+            - fx.read
+            - interest.read
+            - ledger.read
+            - lending.read
+            - notification.read
+            - sanctions.read
+            - sdd.read
+            - statement.read
+            - swift.read
+            - transaction.read
   manifest.json: |
     {"roots": ["openbank/agents", "openbank/copilot", "openbank/rest", "agents", "rules"]}

--- a/openbank-infra/gitops/components/balances/balance-service.yaml
+++ b/openbank-infra/gitops/components/balances/balance-service.yaml
@@ -34,7 +34,7 @@ spec:
       annotations:
         # Rolls the pods when the OPA bundle changes — subPath mounts do NOT hot-reload.
         # Kept in sync by gen-balance-opa-bundle.sh (do not hand-edit).
-        openbank.tech/policy-checksum: "4fcc7ce365ba1142"
+        openbank.tech/policy-checksum: "b8402b1bbfc12b22"
     spec:
       securityContext:
         runAsNonRoot: true

--- a/openbank-infra/gitops/components/billing/billing-opa-bundle.yaml
+++ b/openbank-infra/gitops/components/billing/billing-opa-bundle.yaml
@@ -9,7 +9,7 @@ metadata:
     app.kubernetes.io/name: billing-service
     app.kubernetes.io/part-of: billing
   annotations:
-    openbank.tech/policy-checksum: "1ccf68097d4a92bb"
+    openbank.tech/policy-checksum: "dbe4c06091e8501c"
 data:
   rest.rego: |
     # SPDX-License-Identifier: Apache-2.0
@@ -145,6 +145,21 @@ data:
     	input.principal.id == input.resource.id
     	some verb in {"list", "read"}
     	endswith(input.action, sprintf(".%v", [verb]))
+    }
+
+    # ---------------------------------------------------------------------------------------
+    # ADR-0223 D2 phase 1 (shadow): the role->action matrix as data (rules.yaml: authz.
+    # role_action_matrix), granting ALONGSIDE the legacy reasons. The seed is derived as a
+    # strict subset of today's effective grants (operator-read-any's and compliance-read-any's
+    # read verbs, verbatim), so this rule changes no decision; what it changes is the
+    # decision_reason mix, which the D2(b) retirement triage reads to find where the matrix
+    # already carries the call. A role absent from the matrix yields an undefined lookup and
+    # the rule simply does not fire — fail-closed by construction.
+    # ---------------------------------------------------------------------------------------
+    allowed_reasons contains "matrix-allows" if {
+    	input.principal.type == "HUMAN"
+    	some role in input.principal.roles
+    	input.action in data.rules.authz.role_action_matrix[role].grant
     }
 
     # Operators and admins may list or read any resource on behalf of any party (support-desk
@@ -3453,5 +3468,95 @@ data:
           form: "a runnable skill that encodes the steps so they aren't re-derived each time"
       not_a_home:
         - "assistant session/local memory — does not travel to other agents or contributors, and may be stale"
+
+    # ADR-0223 D2 (phase 1, shadow): the role→action matrix as data. Seeded as the EXACT read
+    # half of today's operator-read-any (ROLE_OPERATOR/ROLE_ADMIN: every .list/.read) and
+    # compliance-read-any (ROLE_COMPLIANCE: every .read) — the action inventory is derived from
+    # the fleet-wide @Authorize coverage report (openbank-infra/scripts/authz-coverage-report.py),
+    # making this a provable subset of today's effective grants: rest.rego's matrix-allows reason
+    # grants nothing new, and decision_reason telemetry shows where the matrix already carries
+    # the call. Write grants (operator-<domain>-write etc.) join in phase 1.5 after the D2(b)
+    # triage; the retirement of operator-read-any itself is D2(c), a separate PR.
+    authz:
+      role_action_matrix:
+        ROLE_OPERATOR:
+          grant:
+            - account.list
+            - account.read
+            - anacredit.list
+            - anacredit.read
+            - audit.read
+            - card.list
+            - card.read
+            - device.list
+            - dispatch.read
+            - fx.list
+            - fx.read
+            - interest.list
+            - interest.read
+            - ledger.list
+            - ledger.read
+            - lending.list
+            - lending.read
+            - notification.list
+            - notification.read
+            - sanctions.list
+            - sanctions.read
+            - sdd.list
+            - sdd.read
+            - statement.list
+            - statement.read
+            - swift.list
+            - swift.read
+            - transaction.list
+            - transaction.read
+        ROLE_ADMIN:
+          grant:
+            - account.list
+            - account.read
+            - anacredit.list
+            - anacredit.read
+            - audit.read
+            - card.list
+            - card.read
+            - device.list
+            - dispatch.read
+            - fx.list
+            - fx.read
+            - interest.list
+            - interest.read
+            - ledger.list
+            - ledger.read
+            - lending.list
+            - lending.read
+            - notification.list
+            - notification.read
+            - sanctions.list
+            - sanctions.read
+            - sdd.list
+            - sdd.read
+            - statement.list
+            - statement.read
+            - swift.list
+            - swift.read
+            - transaction.list
+            - transaction.read
+        ROLE_COMPLIANCE:
+          grant:
+            - account.read
+            - anacredit.read
+            - audit.read
+            - card.read
+            - dispatch.read
+            - fx.read
+            - interest.read
+            - ledger.read
+            - lending.read
+            - notification.read
+            - sanctions.read
+            - sdd.read
+            - statement.read
+            - swift.read
+            - transaction.read
   manifest.json: |
     {"roots": ["openbank/agents", "openbank/copilot", "openbank/rest", "agents", "rules"]}

--- a/openbank-infra/gitops/components/billing/billing-service.yaml
+++ b/openbank-infra/gitops/components/billing/billing-service.yaml
@@ -27,7 +27,7 @@ spec:
       annotations:
         # Rolls the pods when the OPA bundle changes — subPath mounts do NOT hot-reload.
         # Kept in sync by gen-billing-opa-bundle.sh (do not hand-edit).
-        openbank.tech/policy-checksum: "1ccf68097d4a92bb"
+        openbank.tech/policy-checksum: "dbe4c06091e8501c"
     spec:
       securityContext:
         runAsNonRoot: true
@@ -59,11 +59,7 @@ spec:
                   key: OIDC_CLIENT_SECRET
                   optional: true
             - name: PRODUCT_CATALOG_SERVICE_URL
-              value: http://keda-add-ons-http-interceptor-proxy.keda:8080
-            # ADR-0083 T1 re-entry: the interceptor dispatches on Host; fee reads must wake
-            # a scaled-to-zero catalog, not fail into a no-fees assessment (money path).
-            - name: PRODUCT_CATALOG_HOST_OVERRIDE
-              value: product-catalog.accounts.svc
+              value: http://product-catalog.accounts.svc:8104
             - name: ACCOUNT_SERVICE_URL
               value: http://account-service.accounts.svc:8100
             - name: BALANCE_SERVICE_URL

--- a/openbank-infra/gitops/components/consent/consent-opa-bundle.yaml
+++ b/openbank-infra/gitops/components/consent/consent-opa-bundle.yaml
@@ -9,7 +9,7 @@ metadata:
     app.kubernetes.io/name: consent-service
     app.kubernetes.io/part-of: consent
   annotations:
-    openbank.tech/policy-checksum: "16447b0592612b6c"
+    openbank.tech/policy-checksum: "b7ea87fb62f61de7"
 data:
   rest.rego: |
     # SPDX-License-Identifier: Apache-2.0
@@ -145,6 +145,21 @@ data:
     	input.principal.id == input.resource.id
     	some verb in {"list", "read"}
     	endswith(input.action, sprintf(".%v", [verb]))
+    }
+
+    # ---------------------------------------------------------------------------------------
+    # ADR-0223 D2 phase 1 (shadow): the role->action matrix as data (rules.yaml: authz.
+    # role_action_matrix), granting ALONGSIDE the legacy reasons. The seed is derived as a
+    # strict subset of today's effective grants (operator-read-any's and compliance-read-any's
+    # read verbs, verbatim), so this rule changes no decision; what it changes is the
+    # decision_reason mix, which the D2(b) retirement triage reads to find where the matrix
+    # already carries the call. A role absent from the matrix yields an undefined lookup and
+    # the rule simply does not fire — fail-closed by construction.
+    # ---------------------------------------------------------------------------------------
+    allowed_reasons contains "matrix-allows" if {
+    	input.principal.type == "HUMAN"
+    	some role in input.principal.roles
+    	input.action in data.rules.authz.role_action_matrix[role].grant
     }
 
     # Operators and admins may list or read any resource on behalf of any party (support-desk
@@ -3523,5 +3538,95 @@ data:
           form: "a runnable skill that encodes the steps so they aren't re-derived each time"
       not_a_home:
         - "assistant session/local memory — does not travel to other agents or contributors, and may be stale"
+
+    # ADR-0223 D2 (phase 1, shadow): the role→action matrix as data. Seeded as the EXACT read
+    # half of today's operator-read-any (ROLE_OPERATOR/ROLE_ADMIN: every .list/.read) and
+    # compliance-read-any (ROLE_COMPLIANCE: every .read) — the action inventory is derived from
+    # the fleet-wide @Authorize coverage report (openbank-infra/scripts/authz-coverage-report.py),
+    # making this a provable subset of today's effective grants: rest.rego's matrix-allows reason
+    # grants nothing new, and decision_reason telemetry shows where the matrix already carries
+    # the call. Write grants (operator-<domain>-write etc.) join in phase 1.5 after the D2(b)
+    # triage; the retirement of operator-read-any itself is D2(c), a separate PR.
+    authz:
+      role_action_matrix:
+        ROLE_OPERATOR:
+          grant:
+            - account.list
+            - account.read
+            - anacredit.list
+            - anacredit.read
+            - audit.read
+            - card.list
+            - card.read
+            - device.list
+            - dispatch.read
+            - fx.list
+            - fx.read
+            - interest.list
+            - interest.read
+            - ledger.list
+            - ledger.read
+            - lending.list
+            - lending.read
+            - notification.list
+            - notification.read
+            - sanctions.list
+            - sanctions.read
+            - sdd.list
+            - sdd.read
+            - statement.list
+            - statement.read
+            - swift.list
+            - swift.read
+            - transaction.list
+            - transaction.read
+        ROLE_ADMIN:
+          grant:
+            - account.list
+            - account.read
+            - anacredit.list
+            - anacredit.read
+            - audit.read
+            - card.list
+            - card.read
+            - device.list
+            - dispatch.read
+            - fx.list
+            - fx.read
+            - interest.list
+            - interest.read
+            - ledger.list
+            - ledger.read
+            - lending.list
+            - lending.read
+            - notification.list
+            - notification.read
+            - sanctions.list
+            - sanctions.read
+            - sdd.list
+            - sdd.read
+            - statement.list
+            - statement.read
+            - swift.list
+            - swift.read
+            - transaction.list
+            - transaction.read
+        ROLE_COMPLIANCE:
+          grant:
+            - account.read
+            - anacredit.read
+            - audit.read
+            - card.read
+            - dispatch.read
+            - fx.read
+            - interest.read
+            - ledger.read
+            - lending.read
+            - notification.read
+            - sanctions.read
+            - sdd.read
+            - statement.read
+            - swift.read
+            - transaction.read
   manifest.json: |
     {"roots": ["openbank/agents", "openbank/copilot", "openbank/rest", "agents", "rules"]}

--- a/openbank-infra/gitops/components/consent/consent-service.yaml
+++ b/openbank-infra/gitops/components/consent/consent-service.yaml
@@ -28,7 +28,7 @@ spec:
       annotations:
         # Rolls the pods when the OPA bundle changes — subPath mounts do NOT hot-reload.
         # Kept in sync by gen-consent-opa-bundle.sh (do not hand-edit).
-        openbank.tech/policy-checksum: "16447b0592612b6c"
+        openbank.tech/policy-checksum: "b7ea87fb62f61de7"
     spec:
       securityContext:
         runAsNonRoot: true

--- a/openbank-infra/gitops/components/copilot/copilot-opa-bundle.yaml
+++ b/openbank-infra/gitops/components/copilot/copilot-opa-bundle.yaml
@@ -9,7 +9,7 @@ metadata:
     app.kubernetes.io/name: copilot-service
     app.kubernetes.io/part-of: platform
   annotations:
-    openbank.tech/policy-checksum: "c28933ffa1a838a1"
+    openbank.tech/policy-checksum: "2f670618249ac082"
 data:
   rest.rego: |
     # SPDX-License-Identifier: Apache-2.0
@@ -145,6 +145,21 @@ data:
     	input.principal.id == input.resource.id
     	some verb in {"list", "read"}
     	endswith(input.action, sprintf(".%v", [verb]))
+    }
+
+    # ---------------------------------------------------------------------------------------
+    # ADR-0223 D2 phase 1 (shadow): the role->action matrix as data (rules.yaml: authz.
+    # role_action_matrix), granting ALONGSIDE the legacy reasons. The seed is derived as a
+    # strict subset of today's effective grants (operator-read-any's and compliance-read-any's
+    # read verbs, verbatim), so this rule changes no decision; what it changes is the
+    # decision_reason mix, which the D2(b) retirement triage reads to find where the matrix
+    # already carries the call. A role absent from the matrix yields an undefined lookup and
+    # the rule simply does not fire — fail-closed by construction.
+    # ---------------------------------------------------------------------------------------
+    allowed_reasons contains "matrix-allows" if {
+    	input.principal.type == "HUMAN"
+    	some role in input.principal.roles
+    	input.action in data.rules.authz.role_action_matrix[role].grant
     }
 
     # Operators and admins may list or read any resource on behalf of any party (support-desk
@@ -3539,5 +3554,95 @@ data:
           form: "a runnable skill that encodes the steps so they aren't re-derived each time"
       not_a_home:
         - "assistant session/local memory — does not travel to other agents or contributors, and may be stale"
+
+    # ADR-0223 D2 (phase 1, shadow): the role→action matrix as data. Seeded as the EXACT read
+    # half of today's operator-read-any (ROLE_OPERATOR/ROLE_ADMIN: every .list/.read) and
+    # compliance-read-any (ROLE_COMPLIANCE: every .read) — the action inventory is derived from
+    # the fleet-wide @Authorize coverage report (openbank-infra/scripts/authz-coverage-report.py),
+    # making this a provable subset of today's effective grants: rest.rego's matrix-allows reason
+    # grants nothing new, and decision_reason telemetry shows where the matrix already carries
+    # the call. Write grants (operator-<domain>-write etc.) join in phase 1.5 after the D2(b)
+    # triage; the retirement of operator-read-any itself is D2(c), a separate PR.
+    authz:
+      role_action_matrix:
+        ROLE_OPERATOR:
+          grant:
+            - account.list
+            - account.read
+            - anacredit.list
+            - anacredit.read
+            - audit.read
+            - card.list
+            - card.read
+            - device.list
+            - dispatch.read
+            - fx.list
+            - fx.read
+            - interest.list
+            - interest.read
+            - ledger.list
+            - ledger.read
+            - lending.list
+            - lending.read
+            - notification.list
+            - notification.read
+            - sanctions.list
+            - sanctions.read
+            - sdd.list
+            - sdd.read
+            - statement.list
+            - statement.read
+            - swift.list
+            - swift.read
+            - transaction.list
+            - transaction.read
+        ROLE_ADMIN:
+          grant:
+            - account.list
+            - account.read
+            - anacredit.list
+            - anacredit.read
+            - audit.read
+            - card.list
+            - card.read
+            - device.list
+            - dispatch.read
+            - fx.list
+            - fx.read
+            - interest.list
+            - interest.read
+            - ledger.list
+            - ledger.read
+            - lending.list
+            - lending.read
+            - notification.list
+            - notification.read
+            - sanctions.list
+            - sanctions.read
+            - sdd.list
+            - sdd.read
+            - statement.list
+            - statement.read
+            - swift.list
+            - swift.read
+            - transaction.list
+            - transaction.read
+        ROLE_COMPLIANCE:
+          grant:
+            - account.read
+            - anacredit.read
+            - audit.read
+            - card.read
+            - dispatch.read
+            - fx.read
+            - interest.read
+            - ledger.read
+            - lending.read
+            - notification.read
+            - sanctions.read
+            - sdd.read
+            - statement.read
+            - swift.read
+            - transaction.read
   manifest.json: |
     {"roots": ["openbank/agents", "openbank/copilot", "openbank/rest", "agents", "rules"]}

--- a/openbank-infra/gitops/components/copilot/copilot-service.yaml
+++ b/openbank-infra/gitops/components/copilot/copilot-service.yaml
@@ -29,7 +29,7 @@ spec:
       annotations:
         # Rolls the pod when the OPA bundle changes — subPath mounts do NOT hot-reload.
         # Kept in sync by gen-copilot-opa-bundle.sh (do not hand-edit).
-        openbank.tech/policy-checksum: "c28933ffa1a838a1"
+        openbank.tech/policy-checksum: "2f670618249ac082"
     spec:
       securityContext:
         runAsNonRoot: true

--- a/openbank-infra/gitops/components/customer-edge/customer-edge-opa-bundle.yaml
+++ b/openbank-infra/gitops/components/customer-edge/customer-edge-opa-bundle.yaml
@@ -10,7 +10,7 @@ metadata:
     app.kubernetes.io/name: customer-edge
     app.kubernetes.io/part-of: customer-edge
   annotations:
-    openbank.tech/policy-checksum: "3ea4c49faa98e1e8"
+    openbank.tech/policy-checksum: "03182587fbf1f696"
 data:
   rest.rego: |
     # SPDX-License-Identifier: Apache-2.0
@@ -146,6 +146,21 @@ data:
     	input.principal.id == input.resource.id
     	some verb in {"list", "read"}
     	endswith(input.action, sprintf(".%v", [verb]))
+    }
+
+    # ---------------------------------------------------------------------------------------
+    # ADR-0223 D2 phase 1 (shadow): the role->action matrix as data (rules.yaml: authz.
+    # role_action_matrix), granting ALONGSIDE the legacy reasons. The seed is derived as a
+    # strict subset of today's effective grants (operator-read-any's and compliance-read-any's
+    # read verbs, verbatim), so this rule changes no decision; what it changes is the
+    # decision_reason mix, which the D2(b) retirement triage reads to find where the matrix
+    # already carries the call. A role absent from the matrix yields an undefined lookup and
+    # the rule simply does not fire — fail-closed by construction.
+    # ---------------------------------------------------------------------------------------
+    allowed_reasons contains "matrix-allows" if {
+    	input.principal.type == "HUMAN"
+    	some role in input.principal.roles
+    	input.action in data.rules.authz.role_action_matrix[role].grant
     }
 
     # Operators and admins may list or read any resource on behalf of any party (support-desk
@@ -2638,6 +2653,96 @@ data:
           form: "a runnable skill that encodes the steps so they aren't re-derived each time"
       not_a_home:
         - "assistant session/local memory — does not travel to other agents or contributors, and may be stale"
+
+    # ADR-0223 D2 (phase 1, shadow): the role→action matrix as data. Seeded as the EXACT read
+    # half of today's operator-read-any (ROLE_OPERATOR/ROLE_ADMIN: every .list/.read) and
+    # compliance-read-any (ROLE_COMPLIANCE: every .read) — the action inventory is derived from
+    # the fleet-wide @Authorize coverage report (openbank-infra/scripts/authz-coverage-report.py),
+    # making this a provable subset of today's effective grants: rest.rego's matrix-allows reason
+    # grants nothing new, and decision_reason telemetry shows where the matrix already carries
+    # the call. Write grants (operator-<domain>-write etc.) join in phase 1.5 after the D2(b)
+    # triage; the retirement of operator-read-any itself is D2(c), a separate PR.
+    authz:
+      role_action_matrix:
+        ROLE_OPERATOR:
+          grant:
+            - account.list
+            - account.read
+            - anacredit.list
+            - anacredit.read
+            - audit.read
+            - card.list
+            - card.read
+            - device.list
+            - dispatch.read
+            - fx.list
+            - fx.read
+            - interest.list
+            - interest.read
+            - ledger.list
+            - ledger.read
+            - lending.list
+            - lending.read
+            - notification.list
+            - notification.read
+            - sanctions.list
+            - sanctions.read
+            - sdd.list
+            - sdd.read
+            - statement.list
+            - statement.read
+            - swift.list
+            - swift.read
+            - transaction.list
+            - transaction.read
+        ROLE_ADMIN:
+          grant:
+            - account.list
+            - account.read
+            - anacredit.list
+            - anacredit.read
+            - audit.read
+            - card.list
+            - card.read
+            - device.list
+            - dispatch.read
+            - fx.list
+            - fx.read
+            - interest.list
+            - interest.read
+            - ledger.list
+            - ledger.read
+            - lending.list
+            - lending.read
+            - notification.list
+            - notification.read
+            - sanctions.list
+            - sanctions.read
+            - sdd.list
+            - sdd.read
+            - statement.list
+            - statement.read
+            - swift.list
+            - swift.read
+            - transaction.list
+            - transaction.read
+        ROLE_COMPLIANCE:
+          grant:
+            - account.read
+            - anacredit.read
+            - audit.read
+            - card.read
+            - dispatch.read
+            - fx.read
+            - interest.read
+            - ledger.read
+            - lending.read
+            - notification.read
+            - sanctions.read
+            - sdd.read
+            - statement.read
+            - swift.read
+            - transaction.read
   agents-data.yaml: |
     # SPDX-License-Identifier: Apache-2.0
     # Copyright (c) OpenBank contributors. Licensed under the Apache License, Version 2.0.

--- a/openbank-infra/gitops/components/customer-edge/customer-edge.yaml
+++ b/openbank-infra/gitops/components/customer-edge/customer-edge.yaml
@@ -65,7 +65,7 @@ spec:
       annotations:
         # Rolls the pod when the OPA bundle changes — subPath mounts do NOT hot-reload.
         # Kept in sync by gen-customer-edge-opa-bundle.sh (do not hand-edit).
-        openbank.tech/policy-checksum: "3ea4c49faa98e1e8"
+        openbank.tech/policy-checksum: "03182587fbf1f696"
     spec:
       # Dedicated SA so EKS Pod Identity can hand the edge (and ONLY the edge) the
       # feedback-screenshots S3 role — ADR-0192, openbank-infra/aws/envs/sandbox-platform/
@@ -81,7 +81,7 @@ spec:
           type: RuntimeDefault
       containers:
         - name: customer-edge
-          image: 265175468565.dkr.ecr.eu-north-1.amazonaws.com/openbank-customer-edge:sandbox-b0753164
+          image: 265175468565.dkr.ecr.eu-north-1.amazonaws.com/openbank-customer-edge:sandbox-e8458d94
           imagePullPolicy: IfNotPresent
           ports:
             - name: http

--- a/openbank-infra/gitops/components/dispute-service/dispute-opa-bundle.yaml
+++ b/openbank-infra/gitops/components/dispute-service/dispute-opa-bundle.yaml
@@ -9,7 +9,7 @@ metadata:
     app.kubernetes.io/name: dispute-service
     app.kubernetes.io/part-of: dispute
   annotations:
-    openbank.tech/policy-checksum: "7816886ae5bf71ea"
+    openbank.tech/policy-checksum: "b3ed138cac9189cf"
 data:
   rest.rego: |
     # SPDX-License-Identifier: Apache-2.0
@@ -145,6 +145,21 @@ data:
     	input.principal.id == input.resource.id
     	some verb in {"list", "read"}
     	endswith(input.action, sprintf(".%v", [verb]))
+    }
+
+    # ---------------------------------------------------------------------------------------
+    # ADR-0223 D2 phase 1 (shadow): the role->action matrix as data (rules.yaml: authz.
+    # role_action_matrix), granting ALONGSIDE the legacy reasons. The seed is derived as a
+    # strict subset of today's effective grants (operator-read-any's and compliance-read-any's
+    # read verbs, verbatim), so this rule changes no decision; what it changes is the
+    # decision_reason mix, which the D2(b) retirement triage reads to find where the matrix
+    # already carries the call. A role absent from the matrix yields an undefined lookup and
+    # the rule simply does not fire — fail-closed by construction.
+    # ---------------------------------------------------------------------------------------
+    allowed_reasons contains "matrix-allows" if {
+    	input.principal.type == "HUMAN"
+    	some role in input.principal.roles
+    	input.action in data.rules.authz.role_action_matrix[role].grant
     }
 
     # Operators and admins may list or read any resource on behalf of any party (support-desk
@@ -3589,5 +3604,95 @@ data:
           form: "a runnable skill that encodes the steps so they aren't re-derived each time"
       not_a_home:
         - "assistant session/local memory — does not travel to other agents or contributors, and may be stale"
+
+    # ADR-0223 D2 (phase 1, shadow): the role→action matrix as data. Seeded as the EXACT read
+    # half of today's operator-read-any (ROLE_OPERATOR/ROLE_ADMIN: every .list/.read) and
+    # compliance-read-any (ROLE_COMPLIANCE: every .read) — the action inventory is derived from
+    # the fleet-wide @Authorize coverage report (openbank-infra/scripts/authz-coverage-report.py),
+    # making this a provable subset of today's effective grants: rest.rego's matrix-allows reason
+    # grants nothing new, and decision_reason telemetry shows where the matrix already carries
+    # the call. Write grants (operator-<domain>-write etc.) join in phase 1.5 after the D2(b)
+    # triage; the retirement of operator-read-any itself is D2(c), a separate PR.
+    authz:
+      role_action_matrix:
+        ROLE_OPERATOR:
+          grant:
+            - account.list
+            - account.read
+            - anacredit.list
+            - anacredit.read
+            - audit.read
+            - card.list
+            - card.read
+            - device.list
+            - dispatch.read
+            - fx.list
+            - fx.read
+            - interest.list
+            - interest.read
+            - ledger.list
+            - ledger.read
+            - lending.list
+            - lending.read
+            - notification.list
+            - notification.read
+            - sanctions.list
+            - sanctions.read
+            - sdd.list
+            - sdd.read
+            - statement.list
+            - statement.read
+            - swift.list
+            - swift.read
+            - transaction.list
+            - transaction.read
+        ROLE_ADMIN:
+          grant:
+            - account.list
+            - account.read
+            - anacredit.list
+            - anacredit.read
+            - audit.read
+            - card.list
+            - card.read
+            - device.list
+            - dispatch.read
+            - fx.list
+            - fx.read
+            - interest.list
+            - interest.read
+            - ledger.list
+            - ledger.read
+            - lending.list
+            - lending.read
+            - notification.list
+            - notification.read
+            - sanctions.list
+            - sanctions.read
+            - sdd.list
+            - sdd.read
+            - statement.list
+            - statement.read
+            - swift.list
+            - swift.read
+            - transaction.list
+            - transaction.read
+        ROLE_COMPLIANCE:
+          grant:
+            - account.read
+            - anacredit.read
+            - audit.read
+            - card.read
+            - dispatch.read
+            - fx.read
+            - interest.read
+            - ledger.read
+            - lending.read
+            - notification.read
+            - sanctions.read
+            - sdd.read
+            - statement.read
+            - swift.read
+            - transaction.read
   manifest.json: |
     {"roots": ["openbank/agents", "openbank/copilot", "openbank/rest", "agents", "rules"]}

--- a/openbank-infra/gitops/components/dispute-service/dispute-service.yaml
+++ b/openbank-infra/gitops/components/dispute-service/dispute-service.yaml
@@ -15,7 +15,7 @@ spec:
       annotations:
         # Rolls the pod when the OPA bundle changes — subPath mounts do NOT hot-reload.
         # Kept in sync by gen-dispute-opa-bundle.sh (do not hand-edit).
-        openbank.tech/policy-checksum: "7816886ae5bf71ea"
+        openbank.tech/policy-checksum: "b3ed138cac9189cf"
       labels: {app.kubernetes.io/name: dispute-service, app.kubernetes.io/part-of: dispute}
     spec:
       securityContext:

--- a/openbank-infra/gitops/components/document-service/document-service-opa-bundle.yaml
+++ b/openbank-infra/gitops/components/document-service/document-service-opa-bundle.yaml
@@ -10,7 +10,7 @@ metadata:
     app.kubernetes.io/name: document-service
     app.kubernetes.io/part-of: documents
   annotations:
-    openbank.tech/policy-checksum: "3ea4c49faa98e1e8"
+    openbank.tech/policy-checksum: "03182587fbf1f696"
 data:
   rest.rego: |
     # SPDX-License-Identifier: Apache-2.0
@@ -146,6 +146,21 @@ data:
     	input.principal.id == input.resource.id
     	some verb in {"list", "read"}
     	endswith(input.action, sprintf(".%v", [verb]))
+    }
+
+    # ---------------------------------------------------------------------------------------
+    # ADR-0223 D2 phase 1 (shadow): the role->action matrix as data (rules.yaml: authz.
+    # role_action_matrix), granting ALONGSIDE the legacy reasons. The seed is derived as a
+    # strict subset of today's effective grants (operator-read-any's and compliance-read-any's
+    # read verbs, verbatim), so this rule changes no decision; what it changes is the
+    # decision_reason mix, which the D2(b) retirement triage reads to find where the matrix
+    # already carries the call. A role absent from the matrix yields an undefined lookup and
+    # the rule simply does not fire — fail-closed by construction.
+    # ---------------------------------------------------------------------------------------
+    allowed_reasons contains "matrix-allows" if {
+    	input.principal.type == "HUMAN"
+    	some role in input.principal.roles
+    	input.action in data.rules.authz.role_action_matrix[role].grant
     }
 
     # Operators and admins may list or read any resource on behalf of any party (support-desk
@@ -2638,6 +2653,96 @@ data:
           form: "a runnable skill that encodes the steps so they aren't re-derived each time"
       not_a_home:
         - "assistant session/local memory — does not travel to other agents or contributors, and may be stale"
+
+    # ADR-0223 D2 (phase 1, shadow): the role→action matrix as data. Seeded as the EXACT read
+    # half of today's operator-read-any (ROLE_OPERATOR/ROLE_ADMIN: every .list/.read) and
+    # compliance-read-any (ROLE_COMPLIANCE: every .read) — the action inventory is derived from
+    # the fleet-wide @Authorize coverage report (openbank-infra/scripts/authz-coverage-report.py),
+    # making this a provable subset of today's effective grants: rest.rego's matrix-allows reason
+    # grants nothing new, and decision_reason telemetry shows where the matrix already carries
+    # the call. Write grants (operator-<domain>-write etc.) join in phase 1.5 after the D2(b)
+    # triage; the retirement of operator-read-any itself is D2(c), a separate PR.
+    authz:
+      role_action_matrix:
+        ROLE_OPERATOR:
+          grant:
+            - account.list
+            - account.read
+            - anacredit.list
+            - anacredit.read
+            - audit.read
+            - card.list
+            - card.read
+            - device.list
+            - dispatch.read
+            - fx.list
+            - fx.read
+            - interest.list
+            - interest.read
+            - ledger.list
+            - ledger.read
+            - lending.list
+            - lending.read
+            - notification.list
+            - notification.read
+            - sanctions.list
+            - sanctions.read
+            - sdd.list
+            - sdd.read
+            - statement.list
+            - statement.read
+            - swift.list
+            - swift.read
+            - transaction.list
+            - transaction.read
+        ROLE_ADMIN:
+          grant:
+            - account.list
+            - account.read
+            - anacredit.list
+            - anacredit.read
+            - audit.read
+            - card.list
+            - card.read
+            - device.list
+            - dispatch.read
+            - fx.list
+            - fx.read
+            - interest.list
+            - interest.read
+            - ledger.list
+            - ledger.read
+            - lending.list
+            - lending.read
+            - notification.list
+            - notification.read
+            - sanctions.list
+            - sanctions.read
+            - sdd.list
+            - sdd.read
+            - statement.list
+            - statement.read
+            - swift.list
+            - swift.read
+            - transaction.list
+            - transaction.read
+        ROLE_COMPLIANCE:
+          grant:
+            - account.read
+            - anacredit.read
+            - audit.read
+            - card.read
+            - dispatch.read
+            - fx.read
+            - interest.read
+            - ledger.read
+            - lending.read
+            - notification.read
+            - sanctions.read
+            - sdd.read
+            - statement.read
+            - swift.read
+            - transaction.read
   agents-data.yaml: |
     # SPDX-License-Identifier: Apache-2.0
     # Copyright (c) OpenBank contributors. Licensed under the Apache License, Version 2.0.

--- a/openbank-infra/gitops/components/document-service/document-service-service.yaml
+++ b/openbank-infra/gitops/components/document-service/document-service-service.yaml
@@ -43,7 +43,7 @@ spec:
       annotations:
         # Rolls the pods when the OPA bundle changes — subPath mounts do NOT hot-reload.
         # Kept in sync by gen-document-service-opa-bundle.sh (do not hand-edit).
-        openbank.tech/policy-checksum: "3ea4c49faa98e1e8"
+        openbank.tech/policy-checksum: "03182587fbf1f696"
     spec:
       # ADR-0162 D4 (continued): a dedicated SA (not `default`) is what OpenBao's Kubernetes-auth
       # role `document-service-signing` is bound to — least-privilege, one identity per consumer.
@@ -57,7 +57,7 @@ spec:
           type: RuntimeDefault
       containers:
         - name: document-service
-          image: 265175468565.dkr.ecr.eu-north-1.amazonaws.com/openbank-document-service:sandbox-f603f4d7
+          image: 265175468565.dkr.ecr.eu-north-1.amazonaws.com/openbank-document-service:sandbox-e8458d94
           imagePullPolicy: IfNotPresent
           ports:
             - name: http
@@ -88,14 +88,9 @@ spec:
             # product-catalog REST client base URL (application.yaml:
             # quarkus.rest-client.product-catalog-api.url) — ADR-0162 D7: AccountCreatedConsumer's
             # ProductCatalogAdapter looks up documentTemplateCode for the account's product on
-            # every account.created event. Routed via the KEDA HTTP interceptor (ADR-0083 T1
-            # re-entry): the interceptor dispatches on Host, so a scaled-to-zero product-catalog
-            # wakes instead of this adapter reading "no template -> no onboarding document"
-            # (the silent onboarding breakage, 2026-06-24..2026-07-17).
+            # every account.created event. Same in-cluster address billing-service already uses.
             - name: PRODUCT_CATALOG_SERVICE_URL
-              value: http://keda-add-ons-http-interceptor-proxy.keda:8080
-            - name: PRODUCT_CATALOG_API_HOST_OVERRIDE
-              value: product-catalog.accounts.svc
+              value: http://product-catalog.accounts.svc:8104
             # party-service / account-service REST client base URLs (application.yaml:
             # quarkus.rest-client.party-service-api / account-service-api) — fill the
             # RAMCOVA_SMLOUVA template's {{party.*}}/{{account.*}}/{{product.*}} clauses at sign

--- a/openbank-infra/gitops/components/fraud-service/fraud-opa-bundle.yaml
+++ b/openbank-infra/gitops/components/fraud-service/fraud-opa-bundle.yaml
@@ -9,7 +9,7 @@ metadata:
     app.kubernetes.io/name: fraud-service
     app.kubernetes.io/part-of: fraud
   annotations:
-    openbank.tech/policy-checksum: "a5b15d7c936fbdd7"
+    openbank.tech/policy-checksum: "158fc1f5ff1ecfc4"
 data:
   rest.rego: |
     # SPDX-License-Identifier: Apache-2.0
@@ -145,6 +145,21 @@ data:
     	input.principal.id == input.resource.id
     	some verb in {"list", "read"}
     	endswith(input.action, sprintf(".%v", [verb]))
+    }
+
+    # ---------------------------------------------------------------------------------------
+    # ADR-0223 D2 phase 1 (shadow): the role->action matrix as data (rules.yaml: authz.
+    # role_action_matrix), granting ALONGSIDE the legacy reasons. The seed is derived as a
+    # strict subset of today's effective grants (operator-read-any's and compliance-read-any's
+    # read verbs, verbatim), so this rule changes no decision; what it changes is the
+    # decision_reason mix, which the D2(b) retirement triage reads to find where the matrix
+    # already carries the call. A role absent from the matrix yields an undefined lookup and
+    # the rule simply does not fire — fail-closed by construction.
+    # ---------------------------------------------------------------------------------------
+    allowed_reasons contains "matrix-allows" if {
+    	input.principal.type == "HUMAN"
+    	some role in input.principal.roles
+    	input.action in data.rules.authz.role_action_matrix[role].grant
     }
 
     # Operators and admins may list or read any resource on behalf of any party (support-desk
@@ -3464,5 +3479,95 @@ data:
           form: "a runnable skill that encodes the steps so they aren't re-derived each time"
       not_a_home:
         - "assistant session/local memory — does not travel to other agents or contributors, and may be stale"
+
+    # ADR-0223 D2 (phase 1, shadow): the role→action matrix as data. Seeded as the EXACT read
+    # half of today's operator-read-any (ROLE_OPERATOR/ROLE_ADMIN: every .list/.read) and
+    # compliance-read-any (ROLE_COMPLIANCE: every .read) — the action inventory is derived from
+    # the fleet-wide @Authorize coverage report (openbank-infra/scripts/authz-coverage-report.py),
+    # making this a provable subset of today's effective grants: rest.rego's matrix-allows reason
+    # grants nothing new, and decision_reason telemetry shows where the matrix already carries
+    # the call. Write grants (operator-<domain>-write etc.) join in phase 1.5 after the D2(b)
+    # triage; the retirement of operator-read-any itself is D2(c), a separate PR.
+    authz:
+      role_action_matrix:
+        ROLE_OPERATOR:
+          grant:
+            - account.list
+            - account.read
+            - anacredit.list
+            - anacredit.read
+            - audit.read
+            - card.list
+            - card.read
+            - device.list
+            - dispatch.read
+            - fx.list
+            - fx.read
+            - interest.list
+            - interest.read
+            - ledger.list
+            - ledger.read
+            - lending.list
+            - lending.read
+            - notification.list
+            - notification.read
+            - sanctions.list
+            - sanctions.read
+            - sdd.list
+            - sdd.read
+            - statement.list
+            - statement.read
+            - swift.list
+            - swift.read
+            - transaction.list
+            - transaction.read
+        ROLE_ADMIN:
+          grant:
+            - account.list
+            - account.read
+            - anacredit.list
+            - anacredit.read
+            - audit.read
+            - card.list
+            - card.read
+            - device.list
+            - dispatch.read
+            - fx.list
+            - fx.read
+            - interest.list
+            - interest.read
+            - ledger.list
+            - ledger.read
+            - lending.list
+            - lending.read
+            - notification.list
+            - notification.read
+            - sanctions.list
+            - sanctions.read
+            - sdd.list
+            - sdd.read
+            - statement.list
+            - statement.read
+            - swift.list
+            - swift.read
+            - transaction.list
+            - transaction.read
+        ROLE_COMPLIANCE:
+          grant:
+            - account.read
+            - anacredit.read
+            - audit.read
+            - card.read
+            - dispatch.read
+            - fx.read
+            - interest.read
+            - ledger.read
+            - lending.read
+            - notification.read
+            - sanctions.read
+            - sdd.read
+            - statement.read
+            - swift.read
+            - transaction.read
   manifest.json: |
     {"roots": ["openbank/agents", "openbank/copilot", "openbank/rest", "agents", "rules"]}

--- a/openbank-infra/gitops/components/fraud-service/fraud-service.yaml
+++ b/openbank-infra/gitops/components/fraud-service/fraud-service.yaml
@@ -23,7 +23,7 @@ spec:
       annotations:
         # Rolls the pods when the OPA bundle changes — subPath mounts do NOT hot-reload.
         # Kept in sync by gen-fraud-opa-bundle.sh (do not hand-edit).
-        openbank.tech/policy-checksum: "a5b15d7c936fbdd7"
+        openbank.tech/policy-checksum: "158fc1f5ff1ecfc4"
     spec:
       securityContext:
         runAsNonRoot: true

--- a/openbank-infra/gitops/components/fx-service/fx-opa-bundle.yaml
+++ b/openbank-infra/gitops/components/fx-service/fx-opa-bundle.yaml
@@ -9,7 +9,7 @@ metadata:
     app.kubernetes.io/name: fx-service
     app.kubernetes.io/part-of: fx
   annotations:
-    openbank.tech/policy-checksum: "a1a6e474300f3d85"
+    openbank.tech/policy-checksum: "42d42773cdf875d9"
 data:
   rest.rego: |
     # SPDX-License-Identifier: Apache-2.0
@@ -145,6 +145,21 @@ data:
     	input.principal.id == input.resource.id
     	some verb in {"list", "read"}
     	endswith(input.action, sprintf(".%v", [verb]))
+    }
+
+    # ---------------------------------------------------------------------------------------
+    # ADR-0223 D2 phase 1 (shadow): the role->action matrix as data (rules.yaml: authz.
+    # role_action_matrix), granting ALONGSIDE the legacy reasons. The seed is derived as a
+    # strict subset of today's effective grants (operator-read-any's and compliance-read-any's
+    # read verbs, verbatim), so this rule changes no decision; what it changes is the
+    # decision_reason mix, which the D2(b) retirement triage reads to find where the matrix
+    # already carries the call. A role absent from the matrix yields an undefined lookup and
+    # the rule simply does not fire — fail-closed by construction.
+    # ---------------------------------------------------------------------------------------
+    allowed_reasons contains "matrix-allows" if {
+    	input.principal.type == "HUMAN"
+    	some role in input.principal.roles
+    	input.action in data.rules.authz.role_action_matrix[role].grant
     }
 
     # Operators and admins may list or read any resource on behalf of any party (support-desk
@@ -3515,5 +3530,95 @@ data:
           form: "a runnable skill that encodes the steps so they aren't re-derived each time"
       not_a_home:
         - "assistant session/local memory — does not travel to other agents or contributors, and may be stale"
+
+    # ADR-0223 D2 (phase 1, shadow): the role→action matrix as data. Seeded as the EXACT read
+    # half of today's operator-read-any (ROLE_OPERATOR/ROLE_ADMIN: every .list/.read) and
+    # compliance-read-any (ROLE_COMPLIANCE: every .read) — the action inventory is derived from
+    # the fleet-wide @Authorize coverage report (openbank-infra/scripts/authz-coverage-report.py),
+    # making this a provable subset of today's effective grants: rest.rego's matrix-allows reason
+    # grants nothing new, and decision_reason telemetry shows where the matrix already carries
+    # the call. Write grants (operator-<domain>-write etc.) join in phase 1.5 after the D2(b)
+    # triage; the retirement of operator-read-any itself is D2(c), a separate PR.
+    authz:
+      role_action_matrix:
+        ROLE_OPERATOR:
+          grant:
+            - account.list
+            - account.read
+            - anacredit.list
+            - anacredit.read
+            - audit.read
+            - card.list
+            - card.read
+            - device.list
+            - dispatch.read
+            - fx.list
+            - fx.read
+            - interest.list
+            - interest.read
+            - ledger.list
+            - ledger.read
+            - lending.list
+            - lending.read
+            - notification.list
+            - notification.read
+            - sanctions.list
+            - sanctions.read
+            - sdd.list
+            - sdd.read
+            - statement.list
+            - statement.read
+            - swift.list
+            - swift.read
+            - transaction.list
+            - transaction.read
+        ROLE_ADMIN:
+          grant:
+            - account.list
+            - account.read
+            - anacredit.list
+            - anacredit.read
+            - audit.read
+            - card.list
+            - card.read
+            - device.list
+            - dispatch.read
+            - fx.list
+            - fx.read
+            - interest.list
+            - interest.read
+            - ledger.list
+            - ledger.read
+            - lending.list
+            - lending.read
+            - notification.list
+            - notification.read
+            - sanctions.list
+            - sanctions.read
+            - sdd.list
+            - sdd.read
+            - statement.list
+            - statement.read
+            - swift.list
+            - swift.read
+            - transaction.list
+            - transaction.read
+        ROLE_COMPLIANCE:
+          grant:
+            - account.read
+            - anacredit.read
+            - audit.read
+            - card.read
+            - dispatch.read
+            - fx.read
+            - interest.read
+            - ledger.read
+            - lending.read
+            - notification.read
+            - sanctions.read
+            - sdd.read
+            - statement.read
+            - swift.read
+            - transaction.read
   manifest.json: |
     {"roots": ["openbank/agents", "openbank/copilot", "openbank/rest", "agents", "rules"]}

--- a/openbank-infra/gitops/components/fx-service/fx-service.yaml
+++ b/openbank-infra/gitops/components/fx-service/fx-service.yaml
@@ -22,7 +22,7 @@ spec:
       annotations:
         # Rolls the pods when the OPA bundle changes — subPath mounts do NOT hot-reload.
         # Kept in sync by gen-fx-opa-bundle.sh (do not hand-edit).
-        openbank.tech/policy-checksum: "a1a6e474300f3d85"
+        openbank.tech/policy-checksum: "42d42773cdf875d9"
     spec:
       securityContext:
         runAsNonRoot: true

--- a/openbank-infra/gitops/components/interest-service/interest-opa-bundle.yaml
+++ b/openbank-infra/gitops/components/interest-service/interest-opa-bundle.yaml
@@ -9,7 +9,7 @@ metadata:
     app.kubernetes.io/name: interest-service
     app.kubernetes.io/part-of: interest
   annotations:
-    openbank.tech/policy-checksum: "d09fcdeecf39c07d"
+    openbank.tech/policy-checksum: "7273631754ef34f5"
 data:
   rest.rego: |
     # SPDX-License-Identifier: Apache-2.0
@@ -145,6 +145,21 @@ data:
     	input.principal.id == input.resource.id
     	some verb in {"list", "read"}
     	endswith(input.action, sprintf(".%v", [verb]))
+    }
+
+    # ---------------------------------------------------------------------------------------
+    # ADR-0223 D2 phase 1 (shadow): the role->action matrix as data (rules.yaml: authz.
+    # role_action_matrix), granting ALONGSIDE the legacy reasons. The seed is derived as a
+    # strict subset of today's effective grants (operator-read-any's and compliance-read-any's
+    # read verbs, verbatim), so this rule changes no decision; what it changes is the
+    # decision_reason mix, which the D2(b) retirement triage reads to find where the matrix
+    # already carries the call. A role absent from the matrix yields an undefined lookup and
+    # the rule simply does not fire — fail-closed by construction.
+    # ---------------------------------------------------------------------------------------
+    allowed_reasons contains "matrix-allows" if {
+    	input.principal.type == "HUMAN"
+    	some role in input.principal.roles
+    	input.action in data.rules.authz.role_action_matrix[role].grant
     }
 
     # Operators and admins may list or read any resource on behalf of any party (support-desk
@@ -3449,5 +3464,95 @@ data:
           form: "a runnable skill that encodes the steps so they aren't re-derived each time"
       not_a_home:
         - "assistant session/local memory — does not travel to other agents or contributors, and may be stale"
+
+    # ADR-0223 D2 (phase 1, shadow): the role→action matrix as data. Seeded as the EXACT read
+    # half of today's operator-read-any (ROLE_OPERATOR/ROLE_ADMIN: every .list/.read) and
+    # compliance-read-any (ROLE_COMPLIANCE: every .read) — the action inventory is derived from
+    # the fleet-wide @Authorize coverage report (openbank-infra/scripts/authz-coverage-report.py),
+    # making this a provable subset of today's effective grants: rest.rego's matrix-allows reason
+    # grants nothing new, and decision_reason telemetry shows where the matrix already carries
+    # the call. Write grants (operator-<domain>-write etc.) join in phase 1.5 after the D2(b)
+    # triage; the retirement of operator-read-any itself is D2(c), a separate PR.
+    authz:
+      role_action_matrix:
+        ROLE_OPERATOR:
+          grant:
+            - account.list
+            - account.read
+            - anacredit.list
+            - anacredit.read
+            - audit.read
+            - card.list
+            - card.read
+            - device.list
+            - dispatch.read
+            - fx.list
+            - fx.read
+            - interest.list
+            - interest.read
+            - ledger.list
+            - ledger.read
+            - lending.list
+            - lending.read
+            - notification.list
+            - notification.read
+            - sanctions.list
+            - sanctions.read
+            - sdd.list
+            - sdd.read
+            - statement.list
+            - statement.read
+            - swift.list
+            - swift.read
+            - transaction.list
+            - transaction.read
+        ROLE_ADMIN:
+          grant:
+            - account.list
+            - account.read
+            - anacredit.list
+            - anacredit.read
+            - audit.read
+            - card.list
+            - card.read
+            - device.list
+            - dispatch.read
+            - fx.list
+            - fx.read
+            - interest.list
+            - interest.read
+            - ledger.list
+            - ledger.read
+            - lending.list
+            - lending.read
+            - notification.list
+            - notification.read
+            - sanctions.list
+            - sanctions.read
+            - sdd.list
+            - sdd.read
+            - statement.list
+            - statement.read
+            - swift.list
+            - swift.read
+            - transaction.list
+            - transaction.read
+        ROLE_COMPLIANCE:
+          grant:
+            - account.read
+            - anacredit.read
+            - audit.read
+            - card.read
+            - dispatch.read
+            - fx.read
+            - interest.read
+            - ledger.read
+            - lending.read
+            - notification.read
+            - sanctions.read
+            - sdd.read
+            - statement.read
+            - swift.read
+            - transaction.read
   manifest.json: |
     {"roots": ["openbank/agents", "openbank/copilot", "openbank/rest", "agents", "rules"]}

--- a/openbank-infra/gitops/components/interest-service/interest-service.yaml
+++ b/openbank-infra/gitops/components/interest-service/interest-service.yaml
@@ -16,7 +16,7 @@ spec:
       annotations:
         # Rolls the pods when the OPA bundle changes — subPath mounts do NOT hot-reload.
         # Kept in sync by gen-interest-opa-bundle.sh (do not hand-edit).
-        openbank.tech/policy-checksum: "d09fcdeecf39c07d"
+        openbank.tech/policy-checksum: "7273631754ef34f5"
     spec:
       securityContext:
         runAsNonRoot: true

--- a/openbank-infra/gitops/components/kyc/kyc-opa-bundle.yaml
+++ b/openbank-infra/gitops/components/kyc/kyc-opa-bundle.yaml
@@ -9,7 +9,7 @@ metadata:
     app.kubernetes.io/name: kyc-service
     app.kubernetes.io/part-of: kyc
   annotations:
-    openbank.tech/policy-checksum: "e7d86c6a969d6aaa"
+    openbank.tech/policy-checksum: "27a3b1c8d3cf64f3"
 data:
   rest.rego: |
     # SPDX-License-Identifier: Apache-2.0
@@ -145,6 +145,21 @@ data:
     	input.principal.id == input.resource.id
     	some verb in {"list", "read"}
     	endswith(input.action, sprintf(".%v", [verb]))
+    }
+
+    # ---------------------------------------------------------------------------------------
+    # ADR-0223 D2 phase 1 (shadow): the role->action matrix as data (rules.yaml: authz.
+    # role_action_matrix), granting ALONGSIDE the legacy reasons. The seed is derived as a
+    # strict subset of today's effective grants (operator-read-any's and compliance-read-any's
+    # read verbs, verbatim), so this rule changes no decision; what it changes is the
+    # decision_reason mix, which the D2(b) retirement triage reads to find where the matrix
+    # already carries the call. A role absent from the matrix yields an undefined lookup and
+    # the rule simply does not fire — fail-closed by construction.
+    # ---------------------------------------------------------------------------------------
+    allowed_reasons contains "matrix-allows" if {
+    	input.principal.type == "HUMAN"
+    	some role in input.principal.roles
+    	input.action in data.rules.authz.role_action_matrix[role].grant
     }
 
     # Operators and admins may list or read any resource on behalf of any party (support-desk
@@ -3477,5 +3492,95 @@ data:
           form: "a runnable skill that encodes the steps so they aren't re-derived each time"
       not_a_home:
         - "assistant session/local memory — does not travel to other agents or contributors, and may be stale"
+
+    # ADR-0223 D2 (phase 1, shadow): the role→action matrix as data. Seeded as the EXACT read
+    # half of today's operator-read-any (ROLE_OPERATOR/ROLE_ADMIN: every .list/.read) and
+    # compliance-read-any (ROLE_COMPLIANCE: every .read) — the action inventory is derived from
+    # the fleet-wide @Authorize coverage report (openbank-infra/scripts/authz-coverage-report.py),
+    # making this a provable subset of today's effective grants: rest.rego's matrix-allows reason
+    # grants nothing new, and decision_reason telemetry shows where the matrix already carries
+    # the call. Write grants (operator-<domain>-write etc.) join in phase 1.5 after the D2(b)
+    # triage; the retirement of operator-read-any itself is D2(c), a separate PR.
+    authz:
+      role_action_matrix:
+        ROLE_OPERATOR:
+          grant:
+            - account.list
+            - account.read
+            - anacredit.list
+            - anacredit.read
+            - audit.read
+            - card.list
+            - card.read
+            - device.list
+            - dispatch.read
+            - fx.list
+            - fx.read
+            - interest.list
+            - interest.read
+            - ledger.list
+            - ledger.read
+            - lending.list
+            - lending.read
+            - notification.list
+            - notification.read
+            - sanctions.list
+            - sanctions.read
+            - sdd.list
+            - sdd.read
+            - statement.list
+            - statement.read
+            - swift.list
+            - swift.read
+            - transaction.list
+            - transaction.read
+        ROLE_ADMIN:
+          grant:
+            - account.list
+            - account.read
+            - anacredit.list
+            - anacredit.read
+            - audit.read
+            - card.list
+            - card.read
+            - device.list
+            - dispatch.read
+            - fx.list
+            - fx.read
+            - interest.list
+            - interest.read
+            - ledger.list
+            - ledger.read
+            - lending.list
+            - lending.read
+            - notification.list
+            - notification.read
+            - sanctions.list
+            - sanctions.read
+            - sdd.list
+            - sdd.read
+            - statement.list
+            - statement.read
+            - swift.list
+            - swift.read
+            - transaction.list
+            - transaction.read
+        ROLE_COMPLIANCE:
+          grant:
+            - account.read
+            - anacredit.read
+            - audit.read
+            - card.read
+            - dispatch.read
+            - fx.read
+            - interest.read
+            - ledger.read
+            - lending.read
+            - notification.read
+            - sanctions.read
+            - sdd.read
+            - statement.read
+            - swift.read
+            - transaction.read
   manifest.json: |
     {"roots": ["openbank/agents", "openbank/copilot", "openbank/rest", "agents", "rules"]}

--- a/openbank-infra/gitops/components/kyc/kyc-service.yaml
+++ b/openbank-infra/gitops/components/kyc/kyc-service.yaml
@@ -48,7 +48,7 @@ spec:
       annotations:
         # Rolls the pod when the OPA bundle changes (subPath mounts do not hot-reload).
         # Kept in sync by gen-kyc-opa-bundle.sh (do not hand-edit).
-        openbank.tech/policy-checksum: "e7d86c6a969d6aaa"
+        openbank.tech/policy-checksum: "27a3b1c8d3cf64f3"
     spec:
       securityContext:
         runAsNonRoot: true

--- a/openbank-infra/gitops/components/ledger/ledger-opa-bundle.yaml
+++ b/openbank-infra/gitops/components/ledger/ledger-opa-bundle.yaml
@@ -9,7 +9,7 @@ metadata:
     app.kubernetes.io/name: ledger-service
     app.kubernetes.io/part-of: ledger
   annotations:
-    openbank.tech/policy-checksum: "05fc06809676bf6a"
+    openbank.tech/policy-checksum: "ba68b384b7540dd4"
 data:
   rest.rego: |
     # SPDX-License-Identifier: Apache-2.0
@@ -145,6 +145,21 @@ data:
     	input.principal.id == input.resource.id
     	some verb in {"list", "read"}
     	endswith(input.action, sprintf(".%v", [verb]))
+    }
+
+    # ---------------------------------------------------------------------------------------
+    # ADR-0223 D2 phase 1 (shadow): the role->action matrix as data (rules.yaml: authz.
+    # role_action_matrix), granting ALONGSIDE the legacy reasons. The seed is derived as a
+    # strict subset of today's effective grants (operator-read-any's and compliance-read-any's
+    # read verbs, verbatim), so this rule changes no decision; what it changes is the
+    # decision_reason mix, which the D2(b) retirement triage reads to find where the matrix
+    # already carries the call. A role absent from the matrix yields an undefined lookup and
+    # the rule simply does not fire — fail-closed by construction.
+    # ---------------------------------------------------------------------------------------
+    allowed_reasons contains "matrix-allows" if {
+    	input.principal.type == "HUMAN"
+    	some role in input.principal.roles
+    	input.action in data.rules.authz.role_action_matrix[role].grant
     }
 
     # Operators and admins may list or read any resource on behalf of any party (support-desk
@@ -3562,5 +3577,95 @@ data:
           form: "a runnable skill that encodes the steps so they aren't re-derived each time"
       not_a_home:
         - "assistant session/local memory — does not travel to other agents or contributors, and may be stale"
+
+    # ADR-0223 D2 (phase 1, shadow): the role→action matrix as data. Seeded as the EXACT read
+    # half of today's operator-read-any (ROLE_OPERATOR/ROLE_ADMIN: every .list/.read) and
+    # compliance-read-any (ROLE_COMPLIANCE: every .read) — the action inventory is derived from
+    # the fleet-wide @Authorize coverage report (openbank-infra/scripts/authz-coverage-report.py),
+    # making this a provable subset of today's effective grants: rest.rego's matrix-allows reason
+    # grants nothing new, and decision_reason telemetry shows where the matrix already carries
+    # the call. Write grants (operator-<domain>-write etc.) join in phase 1.5 after the D2(b)
+    # triage; the retirement of operator-read-any itself is D2(c), a separate PR.
+    authz:
+      role_action_matrix:
+        ROLE_OPERATOR:
+          grant:
+            - account.list
+            - account.read
+            - anacredit.list
+            - anacredit.read
+            - audit.read
+            - card.list
+            - card.read
+            - device.list
+            - dispatch.read
+            - fx.list
+            - fx.read
+            - interest.list
+            - interest.read
+            - ledger.list
+            - ledger.read
+            - lending.list
+            - lending.read
+            - notification.list
+            - notification.read
+            - sanctions.list
+            - sanctions.read
+            - sdd.list
+            - sdd.read
+            - statement.list
+            - statement.read
+            - swift.list
+            - swift.read
+            - transaction.list
+            - transaction.read
+        ROLE_ADMIN:
+          grant:
+            - account.list
+            - account.read
+            - anacredit.list
+            - anacredit.read
+            - audit.read
+            - card.list
+            - card.read
+            - device.list
+            - dispatch.read
+            - fx.list
+            - fx.read
+            - interest.list
+            - interest.read
+            - ledger.list
+            - ledger.read
+            - lending.list
+            - lending.read
+            - notification.list
+            - notification.read
+            - sanctions.list
+            - sanctions.read
+            - sdd.list
+            - sdd.read
+            - statement.list
+            - statement.read
+            - swift.list
+            - swift.read
+            - transaction.list
+            - transaction.read
+        ROLE_COMPLIANCE:
+          grant:
+            - account.read
+            - anacredit.read
+            - audit.read
+            - card.read
+            - dispatch.read
+            - fx.read
+            - interest.read
+            - ledger.read
+            - lending.read
+            - notification.read
+            - sanctions.read
+            - sdd.read
+            - statement.read
+            - swift.read
+            - transaction.read
   manifest.json: |
     {"roots": ["openbank/agents", "openbank/copilot", "openbank/rest", "agents", "rules"]}

--- a/openbank-infra/gitops/components/ledger/ledger-service.yaml
+++ b/openbank-infra/gitops/components/ledger/ledger-service.yaml
@@ -38,7 +38,7 @@ spec:
       annotations:
         # Rolls the pods when the OPA bundle changes — subPath mounts do NOT hot-reload.
         # Kept in sync by gen-ledger-opa-bundle.sh (do not hand-edit).
-        openbank.tech/policy-checksum: "05fc06809676bf6a"
+        openbank.tech/policy-checksum: "ba68b384b7540dd4"
     spec:
       securityContext:
         runAsNonRoot: true

--- a/openbank-infra/gitops/components/lending/lending-opa-bundle.yaml
+++ b/openbank-infra/gitops/components/lending/lending-opa-bundle.yaml
@@ -9,7 +9,7 @@ metadata:
     app.kubernetes.io/name: lending-service
     app.kubernetes.io/part-of: lending
   annotations:
-    openbank.tech/policy-checksum: "dbdcb49d84b8358b"
+    openbank.tech/policy-checksum: "6f107d051c8280e8"
 data:
   rest.rego: |
     # SPDX-License-Identifier: Apache-2.0
@@ -145,6 +145,21 @@ data:
     	input.principal.id == input.resource.id
     	some verb in {"list", "read"}
     	endswith(input.action, sprintf(".%v", [verb]))
+    }
+
+    # ---------------------------------------------------------------------------------------
+    # ADR-0223 D2 phase 1 (shadow): the role->action matrix as data (rules.yaml: authz.
+    # role_action_matrix), granting ALONGSIDE the legacy reasons. The seed is derived as a
+    # strict subset of today's effective grants (operator-read-any's and compliance-read-any's
+    # read verbs, verbatim), so this rule changes no decision; what it changes is the
+    # decision_reason mix, which the D2(b) retirement triage reads to find where the matrix
+    # already carries the call. A role absent from the matrix yields an undefined lookup and
+    # the rule simply does not fire — fail-closed by construction.
+    # ---------------------------------------------------------------------------------------
+    allowed_reasons contains "matrix-allows" if {
+    	input.principal.type == "HUMAN"
+    	some role in input.principal.roles
+    	input.action in data.rules.authz.role_action_matrix[role].grant
     }
 
     # Operators and admins may list or read any resource on behalf of any party (support-desk
@@ -3520,5 +3535,95 @@ data:
           form: "a runnable skill that encodes the steps so they aren't re-derived each time"
       not_a_home:
         - "assistant session/local memory — does not travel to other agents or contributors, and may be stale"
+
+    # ADR-0223 D2 (phase 1, shadow): the role→action matrix as data. Seeded as the EXACT read
+    # half of today's operator-read-any (ROLE_OPERATOR/ROLE_ADMIN: every .list/.read) and
+    # compliance-read-any (ROLE_COMPLIANCE: every .read) — the action inventory is derived from
+    # the fleet-wide @Authorize coverage report (openbank-infra/scripts/authz-coverage-report.py),
+    # making this a provable subset of today's effective grants: rest.rego's matrix-allows reason
+    # grants nothing new, and decision_reason telemetry shows where the matrix already carries
+    # the call. Write grants (operator-<domain>-write etc.) join in phase 1.5 after the D2(b)
+    # triage; the retirement of operator-read-any itself is D2(c), a separate PR.
+    authz:
+      role_action_matrix:
+        ROLE_OPERATOR:
+          grant:
+            - account.list
+            - account.read
+            - anacredit.list
+            - anacredit.read
+            - audit.read
+            - card.list
+            - card.read
+            - device.list
+            - dispatch.read
+            - fx.list
+            - fx.read
+            - interest.list
+            - interest.read
+            - ledger.list
+            - ledger.read
+            - lending.list
+            - lending.read
+            - notification.list
+            - notification.read
+            - sanctions.list
+            - sanctions.read
+            - sdd.list
+            - sdd.read
+            - statement.list
+            - statement.read
+            - swift.list
+            - swift.read
+            - transaction.list
+            - transaction.read
+        ROLE_ADMIN:
+          grant:
+            - account.list
+            - account.read
+            - anacredit.list
+            - anacredit.read
+            - audit.read
+            - card.list
+            - card.read
+            - device.list
+            - dispatch.read
+            - fx.list
+            - fx.read
+            - interest.list
+            - interest.read
+            - ledger.list
+            - ledger.read
+            - lending.list
+            - lending.read
+            - notification.list
+            - notification.read
+            - sanctions.list
+            - sanctions.read
+            - sdd.list
+            - sdd.read
+            - statement.list
+            - statement.read
+            - swift.list
+            - swift.read
+            - transaction.list
+            - transaction.read
+        ROLE_COMPLIANCE:
+          grant:
+            - account.read
+            - anacredit.read
+            - audit.read
+            - card.read
+            - dispatch.read
+            - fx.read
+            - interest.read
+            - ledger.read
+            - lending.read
+            - notification.read
+            - sanctions.read
+            - sdd.read
+            - statement.read
+            - swift.read
+            - transaction.read
   manifest.json: |
     {"roots": ["openbank/agents", "openbank/copilot", "openbank/rest", "agents", "rules"]}

--- a/openbank-infra/gitops/components/lending/lending-service.yaml
+++ b/openbank-infra/gitops/components/lending/lending-service.yaml
@@ -34,7 +34,7 @@ spec:
       annotations:
         # Rolls the pods when the OPA bundle changes — subPath mounts do NOT hot-reload.
         # Kept in sync by gen-lending-opa-bundle.sh (do not hand-edit).
-        openbank.tech/policy-checksum: "dbdcb49d84b8358b"
+        openbank.tech/policy-checksum: "6f107d051c8280e8"
     spec:
       securityContext:
         runAsNonRoot: true

--- a/openbank-infra/gitops/components/mcp/mcp-opa-bundle.yaml
+++ b/openbank-infra/gitops/components/mcp/mcp-opa-bundle.yaml
@@ -9,7 +9,7 @@ metadata:
     app.kubernetes.io/name: mcp-service
     app.kubernetes.io/part-of: platform
   annotations:
-    openbank.tech/policy-checksum: "44ce78c4ebb1cafa"
+    openbank.tech/policy-checksum: "7d2bfb2623287e86"
 data:
   rest.rego: |
     # SPDX-License-Identifier: Apache-2.0
@@ -145,6 +145,21 @@ data:
     	input.principal.id == input.resource.id
     	some verb in {"list", "read"}
     	endswith(input.action, sprintf(".%v", [verb]))
+    }
+
+    # ---------------------------------------------------------------------------------------
+    # ADR-0223 D2 phase 1 (shadow): the role->action matrix as data (rules.yaml: authz.
+    # role_action_matrix), granting ALONGSIDE the legacy reasons. The seed is derived as a
+    # strict subset of today's effective grants (operator-read-any's and compliance-read-any's
+    # read verbs, verbatim), so this rule changes no decision; what it changes is the
+    # decision_reason mix, which the D2(b) retirement triage reads to find where the matrix
+    # already carries the call. A role absent from the matrix yields an undefined lookup and
+    # the rule simply does not fire — fail-closed by construction.
+    # ---------------------------------------------------------------------------------------
+    allowed_reasons contains "matrix-allows" if {
+    	input.principal.type == "HUMAN"
+    	some role in input.principal.roles
+    	input.action in data.rules.authz.role_action_matrix[role].grant
     }
 
     # Operators and admins may list or read any resource on behalf of any party (support-desk
@@ -3415,5 +3430,95 @@ data:
           form: "a runnable skill that encodes the steps so they aren't re-derived each time"
       not_a_home:
         - "assistant session/local memory — does not travel to other agents or contributors, and may be stale"
+
+    # ADR-0223 D2 (phase 1, shadow): the role→action matrix as data. Seeded as the EXACT read
+    # half of today's operator-read-any (ROLE_OPERATOR/ROLE_ADMIN: every .list/.read) and
+    # compliance-read-any (ROLE_COMPLIANCE: every .read) — the action inventory is derived from
+    # the fleet-wide @Authorize coverage report (openbank-infra/scripts/authz-coverage-report.py),
+    # making this a provable subset of today's effective grants: rest.rego's matrix-allows reason
+    # grants nothing new, and decision_reason telemetry shows where the matrix already carries
+    # the call. Write grants (operator-<domain>-write etc.) join in phase 1.5 after the D2(b)
+    # triage; the retirement of operator-read-any itself is D2(c), a separate PR.
+    authz:
+      role_action_matrix:
+        ROLE_OPERATOR:
+          grant:
+            - account.list
+            - account.read
+            - anacredit.list
+            - anacredit.read
+            - audit.read
+            - card.list
+            - card.read
+            - device.list
+            - dispatch.read
+            - fx.list
+            - fx.read
+            - interest.list
+            - interest.read
+            - ledger.list
+            - ledger.read
+            - lending.list
+            - lending.read
+            - notification.list
+            - notification.read
+            - sanctions.list
+            - sanctions.read
+            - sdd.list
+            - sdd.read
+            - statement.list
+            - statement.read
+            - swift.list
+            - swift.read
+            - transaction.list
+            - transaction.read
+        ROLE_ADMIN:
+          grant:
+            - account.list
+            - account.read
+            - anacredit.list
+            - anacredit.read
+            - audit.read
+            - card.list
+            - card.read
+            - device.list
+            - dispatch.read
+            - fx.list
+            - fx.read
+            - interest.list
+            - interest.read
+            - ledger.list
+            - ledger.read
+            - lending.list
+            - lending.read
+            - notification.list
+            - notification.read
+            - sanctions.list
+            - sanctions.read
+            - sdd.list
+            - sdd.read
+            - statement.list
+            - statement.read
+            - swift.list
+            - swift.read
+            - transaction.list
+            - transaction.read
+        ROLE_COMPLIANCE:
+          grant:
+            - account.read
+            - anacredit.read
+            - audit.read
+            - card.read
+            - dispatch.read
+            - fx.read
+            - interest.read
+            - ledger.read
+            - lending.read
+            - notification.read
+            - sanctions.read
+            - sdd.read
+            - statement.read
+            - swift.read
+            - transaction.read
   manifest.json: |
     {"roots": ["openbank/agents", "openbank/copilot", "openbank/rest", "agents", "rules"]}

--- a/openbank-infra/gitops/components/mcp/mcp-service.yaml
+++ b/openbank-infra/gitops/components/mcp/mcp-service.yaml
@@ -29,7 +29,7 @@ spec:
       annotations:
         # Rolls the pod when the OPA bundle changes — subPath mounts do NOT hot-reload.
         # Kept in sync by gen-mcp-opa-bundle.sh (do not hand-edit).
-        openbank.tech/policy-checksum: "44ce78c4ebb1cafa"
+        openbank.tech/policy-checksum: "7d2bfb2623287e86"
     spec:
       securityContext:
         runAsNonRoot: true
@@ -40,7 +40,7 @@ spec:
           type: RuntimeDefault
       containers:
         - name: mcp-service
-          image: 265175468565.dkr.ecr.eu-north-1.amazonaws.com/openbank-mcp-service:sandbox-64c2d5e7
+          image: 265175468565.dkr.ecr.eu-north-1.amazonaws.com/openbank-mcp-service:sandbox-e8458d94
           imagePullPolicy: IfNotPresent
           ports:
             - name: http

--- a/openbank-infra/gitops/components/notifications/notification-service-opa-bundle.yaml
+++ b/openbank-infra/gitops/components/notifications/notification-service-opa-bundle.yaml
@@ -10,7 +10,7 @@ metadata:
     app.kubernetes.io/name: notification-service
     app.kubernetes.io/part-of: notifications
   annotations:
-    openbank.tech/policy-checksum: "3ea4c49faa98e1e8"
+    openbank.tech/policy-checksum: "03182587fbf1f696"
 data:
   rest.rego: |
     # SPDX-License-Identifier: Apache-2.0
@@ -146,6 +146,21 @@ data:
     	input.principal.id == input.resource.id
     	some verb in {"list", "read"}
     	endswith(input.action, sprintf(".%v", [verb]))
+    }
+
+    # ---------------------------------------------------------------------------------------
+    # ADR-0223 D2 phase 1 (shadow): the role->action matrix as data (rules.yaml: authz.
+    # role_action_matrix), granting ALONGSIDE the legacy reasons. The seed is derived as a
+    # strict subset of today's effective grants (operator-read-any's and compliance-read-any's
+    # read verbs, verbatim), so this rule changes no decision; what it changes is the
+    # decision_reason mix, which the D2(b) retirement triage reads to find where the matrix
+    # already carries the call. A role absent from the matrix yields an undefined lookup and
+    # the rule simply does not fire — fail-closed by construction.
+    # ---------------------------------------------------------------------------------------
+    allowed_reasons contains "matrix-allows" if {
+    	input.principal.type == "HUMAN"
+    	some role in input.principal.roles
+    	input.action in data.rules.authz.role_action_matrix[role].grant
     }
 
     # Operators and admins may list or read any resource on behalf of any party (support-desk
@@ -2638,6 +2653,96 @@ data:
           form: "a runnable skill that encodes the steps so they aren't re-derived each time"
       not_a_home:
         - "assistant session/local memory — does not travel to other agents or contributors, and may be stale"
+
+    # ADR-0223 D2 (phase 1, shadow): the role→action matrix as data. Seeded as the EXACT read
+    # half of today's operator-read-any (ROLE_OPERATOR/ROLE_ADMIN: every .list/.read) and
+    # compliance-read-any (ROLE_COMPLIANCE: every .read) — the action inventory is derived from
+    # the fleet-wide @Authorize coverage report (openbank-infra/scripts/authz-coverage-report.py),
+    # making this a provable subset of today's effective grants: rest.rego's matrix-allows reason
+    # grants nothing new, and decision_reason telemetry shows where the matrix already carries
+    # the call. Write grants (operator-<domain>-write etc.) join in phase 1.5 after the D2(b)
+    # triage; the retirement of operator-read-any itself is D2(c), a separate PR.
+    authz:
+      role_action_matrix:
+        ROLE_OPERATOR:
+          grant:
+            - account.list
+            - account.read
+            - anacredit.list
+            - anacredit.read
+            - audit.read
+            - card.list
+            - card.read
+            - device.list
+            - dispatch.read
+            - fx.list
+            - fx.read
+            - interest.list
+            - interest.read
+            - ledger.list
+            - ledger.read
+            - lending.list
+            - lending.read
+            - notification.list
+            - notification.read
+            - sanctions.list
+            - sanctions.read
+            - sdd.list
+            - sdd.read
+            - statement.list
+            - statement.read
+            - swift.list
+            - swift.read
+            - transaction.list
+            - transaction.read
+        ROLE_ADMIN:
+          grant:
+            - account.list
+            - account.read
+            - anacredit.list
+            - anacredit.read
+            - audit.read
+            - card.list
+            - card.read
+            - device.list
+            - dispatch.read
+            - fx.list
+            - fx.read
+            - interest.list
+            - interest.read
+            - ledger.list
+            - ledger.read
+            - lending.list
+            - lending.read
+            - notification.list
+            - notification.read
+            - sanctions.list
+            - sanctions.read
+            - sdd.list
+            - sdd.read
+            - statement.list
+            - statement.read
+            - swift.list
+            - swift.read
+            - transaction.list
+            - transaction.read
+        ROLE_COMPLIANCE:
+          grant:
+            - account.read
+            - anacredit.read
+            - audit.read
+            - card.read
+            - dispatch.read
+            - fx.read
+            - interest.read
+            - ledger.read
+            - lending.read
+            - notification.read
+            - sanctions.read
+            - sdd.read
+            - statement.read
+            - swift.read
+            - transaction.read
   agents-data.yaml: |
     # SPDX-License-Identifier: Apache-2.0
     # Copyright (c) OpenBank contributors. Licensed under the Apache License, Version 2.0.

--- a/openbank-infra/gitops/components/notifications/notification-service.yaml
+++ b/openbank-infra/gitops/components/notifications/notification-service.yaml
@@ -39,7 +39,7 @@ spec:
       annotations:
         # Rolls the Deployment when the OPA policy bundle changes (subPath mounts don't
         # hot-reload). Kept in sync by gen-notification-opa-bundle.sh.
-        openbank.tech/policy-checksum: "3ea4c49faa98e1e8"
+        openbank.tech/policy-checksum: "03182587fbf1f696"
       labels:
         app.kubernetes.io/name: notification-service
         app.kubernetes.io/part-of: notifications

--- a/openbank-infra/gitops/components/party/party-opa-bundle.yaml
+++ b/openbank-infra/gitops/components/party/party-opa-bundle.yaml
@@ -9,7 +9,7 @@ metadata:
     app.kubernetes.io/name: party-service
     app.kubernetes.io/part-of: party
   annotations:
-    openbank.tech/policy-checksum: "058321ede6ffd39d"
+    openbank.tech/policy-checksum: "79a20a9bead05984"
 data:
   rest.rego: |
     # SPDX-License-Identifier: Apache-2.0
@@ -145,6 +145,21 @@ data:
     	input.principal.id == input.resource.id
     	some verb in {"list", "read"}
     	endswith(input.action, sprintf(".%v", [verb]))
+    }
+
+    # ---------------------------------------------------------------------------------------
+    # ADR-0223 D2 phase 1 (shadow): the role->action matrix as data (rules.yaml: authz.
+    # role_action_matrix), granting ALONGSIDE the legacy reasons. The seed is derived as a
+    # strict subset of today's effective grants (operator-read-any's and compliance-read-any's
+    # read verbs, verbatim), so this rule changes no decision; what it changes is the
+    # decision_reason mix, which the D2(b) retirement triage reads to find where the matrix
+    # already carries the call. A role absent from the matrix yields an undefined lookup and
+    # the rule simply does not fire — fail-closed by construction.
+    # ---------------------------------------------------------------------------------------
+    allowed_reasons contains "matrix-allows" if {
+    	input.principal.type == "HUMAN"
+    	some role in input.principal.roles
+    	input.action in data.rules.authz.role_action_matrix[role].grant
     }
 
     # Operators and admins may list or read any resource on behalf of any party (support-desk
@@ -3486,5 +3501,95 @@ data:
           form: "a runnable skill that encodes the steps so they aren't re-derived each time"
       not_a_home:
         - "assistant session/local memory — does not travel to other agents or contributors, and may be stale"
+
+    # ADR-0223 D2 (phase 1, shadow): the role→action matrix as data. Seeded as the EXACT read
+    # half of today's operator-read-any (ROLE_OPERATOR/ROLE_ADMIN: every .list/.read) and
+    # compliance-read-any (ROLE_COMPLIANCE: every .read) — the action inventory is derived from
+    # the fleet-wide @Authorize coverage report (openbank-infra/scripts/authz-coverage-report.py),
+    # making this a provable subset of today's effective grants: rest.rego's matrix-allows reason
+    # grants nothing new, and decision_reason telemetry shows where the matrix already carries
+    # the call. Write grants (operator-<domain>-write etc.) join in phase 1.5 after the D2(b)
+    # triage; the retirement of operator-read-any itself is D2(c), a separate PR.
+    authz:
+      role_action_matrix:
+        ROLE_OPERATOR:
+          grant:
+            - account.list
+            - account.read
+            - anacredit.list
+            - anacredit.read
+            - audit.read
+            - card.list
+            - card.read
+            - device.list
+            - dispatch.read
+            - fx.list
+            - fx.read
+            - interest.list
+            - interest.read
+            - ledger.list
+            - ledger.read
+            - lending.list
+            - lending.read
+            - notification.list
+            - notification.read
+            - sanctions.list
+            - sanctions.read
+            - sdd.list
+            - sdd.read
+            - statement.list
+            - statement.read
+            - swift.list
+            - swift.read
+            - transaction.list
+            - transaction.read
+        ROLE_ADMIN:
+          grant:
+            - account.list
+            - account.read
+            - anacredit.list
+            - anacredit.read
+            - audit.read
+            - card.list
+            - card.read
+            - device.list
+            - dispatch.read
+            - fx.list
+            - fx.read
+            - interest.list
+            - interest.read
+            - ledger.list
+            - ledger.read
+            - lending.list
+            - lending.read
+            - notification.list
+            - notification.read
+            - sanctions.list
+            - sanctions.read
+            - sdd.list
+            - sdd.read
+            - statement.list
+            - statement.read
+            - swift.list
+            - swift.read
+            - transaction.list
+            - transaction.read
+        ROLE_COMPLIANCE:
+          grant:
+            - account.read
+            - anacredit.read
+            - audit.read
+            - card.read
+            - dispatch.read
+            - fx.read
+            - interest.read
+            - ledger.read
+            - lending.read
+            - notification.read
+            - sanctions.read
+            - sdd.read
+            - statement.read
+            - swift.read
+            - transaction.read
   manifest.json: |
     {"roots": ["openbank/agents", "openbank/copilot", "openbank/rest", "agents", "rules"]}

--- a/openbank-infra/gitops/components/party/party-service.yaml
+++ b/openbank-infra/gitops/components/party/party-service.yaml
@@ -22,7 +22,7 @@ spec:
       annotations:
         # Rolls the pod when the OPA bundle changes — subPath mounts do NOT hot-reload.
         # Kept in sync by gen-party-opa-bundle.sh (do not hand-edit).
-        openbank.tech/policy-checksum: "058321ede6ffd39d"
+        openbank.tech/policy-checksum: "79a20a9bead05984"
       labels:
         app.kubernetes.io/name: party-service
         app.kubernetes.io/part-of: party
@@ -36,7 +36,7 @@ spec:
           type: RuntimeDefault
       containers:
         - name: party-service
-          image: 265175468565.dkr.ecr.eu-north-1.amazonaws.com/openbank-party-service:sandbox-b6fd3153
+          image: 265175468565.dkr.ecr.eu-north-1.amazonaws.com/openbank-party-service:sandbox-e8458d94
           imagePullPolicy: IfNotPresent
           ports:
             - name: http

--- a/openbank-infra/gitops/components/payments/card-issuance-opa-bundle.yaml
+++ b/openbank-infra/gitops/components/payments/card-issuance-opa-bundle.yaml
@@ -9,7 +9,7 @@ metadata:
     app.kubernetes.io/name: card-issuance-service
     app.kubernetes.io/part-of: payments
   annotations:
-    openbank.tech/policy-checksum: "c05a223835cae451"
+    openbank.tech/policy-checksum: "b7fe840230db2033"
 data:
   rest.rego: |
     # SPDX-License-Identifier: Apache-2.0
@@ -145,6 +145,21 @@ data:
     	input.principal.id == input.resource.id
     	some verb in {"list", "read"}
     	endswith(input.action, sprintf(".%v", [verb]))
+    }
+
+    # ---------------------------------------------------------------------------------------
+    # ADR-0223 D2 phase 1 (shadow): the role->action matrix as data (rules.yaml: authz.
+    # role_action_matrix), granting ALONGSIDE the legacy reasons. The seed is derived as a
+    # strict subset of today's effective grants (operator-read-any's and compliance-read-any's
+    # read verbs, verbatim), so this rule changes no decision; what it changes is the
+    # decision_reason mix, which the D2(b) retirement triage reads to find where the matrix
+    # already carries the call. A role absent from the matrix yields an undefined lookup and
+    # the rule simply does not fire — fail-closed by construction.
+    # ---------------------------------------------------------------------------------------
+    allowed_reasons contains "matrix-allows" if {
+    	input.principal.type == "HUMAN"
+    	some role in input.principal.roles
+    	input.action in data.rules.authz.role_action_matrix[role].grant
     }
 
     # Operators and admins may list or read any resource on behalf of any party (support-desk
@@ -3470,5 +3485,95 @@ data:
           form: "a runnable skill that encodes the steps so they aren't re-derived each time"
       not_a_home:
         - "assistant session/local memory — does not travel to other agents or contributors, and may be stale"
+
+    # ADR-0223 D2 (phase 1, shadow): the role→action matrix as data. Seeded as the EXACT read
+    # half of today's operator-read-any (ROLE_OPERATOR/ROLE_ADMIN: every .list/.read) and
+    # compliance-read-any (ROLE_COMPLIANCE: every .read) — the action inventory is derived from
+    # the fleet-wide @Authorize coverage report (openbank-infra/scripts/authz-coverage-report.py),
+    # making this a provable subset of today's effective grants: rest.rego's matrix-allows reason
+    # grants nothing new, and decision_reason telemetry shows where the matrix already carries
+    # the call. Write grants (operator-<domain>-write etc.) join in phase 1.5 after the D2(b)
+    # triage; the retirement of operator-read-any itself is D2(c), a separate PR.
+    authz:
+      role_action_matrix:
+        ROLE_OPERATOR:
+          grant:
+            - account.list
+            - account.read
+            - anacredit.list
+            - anacredit.read
+            - audit.read
+            - card.list
+            - card.read
+            - device.list
+            - dispatch.read
+            - fx.list
+            - fx.read
+            - interest.list
+            - interest.read
+            - ledger.list
+            - ledger.read
+            - lending.list
+            - lending.read
+            - notification.list
+            - notification.read
+            - sanctions.list
+            - sanctions.read
+            - sdd.list
+            - sdd.read
+            - statement.list
+            - statement.read
+            - swift.list
+            - swift.read
+            - transaction.list
+            - transaction.read
+        ROLE_ADMIN:
+          grant:
+            - account.list
+            - account.read
+            - anacredit.list
+            - anacredit.read
+            - audit.read
+            - card.list
+            - card.read
+            - device.list
+            - dispatch.read
+            - fx.list
+            - fx.read
+            - interest.list
+            - interest.read
+            - ledger.list
+            - ledger.read
+            - lending.list
+            - lending.read
+            - notification.list
+            - notification.read
+            - sanctions.list
+            - sanctions.read
+            - sdd.list
+            - sdd.read
+            - statement.list
+            - statement.read
+            - swift.list
+            - swift.read
+            - transaction.list
+            - transaction.read
+        ROLE_COMPLIANCE:
+          grant:
+            - account.read
+            - anacredit.read
+            - audit.read
+            - card.read
+            - dispatch.read
+            - fx.read
+            - interest.read
+            - ledger.read
+            - lending.read
+            - notification.read
+            - sanctions.read
+            - sdd.read
+            - statement.read
+            - swift.read
+            - transaction.read
   manifest.json: |
     {"roots": ["openbank/agents", "openbank/copilot", "openbank/rest", "agents", "rules"]}

--- a/openbank-infra/gitops/components/payments/clearing-opa-bundle.yaml
+++ b/openbank-infra/gitops/components/payments/clearing-opa-bundle.yaml
@@ -9,7 +9,7 @@ metadata:
     app.kubernetes.io/name: clearing-service
     app.kubernetes.io/part-of: payments
   annotations:
-    openbank.tech/policy-checksum: "5a09b6f58b416ab1"
+    openbank.tech/policy-checksum: "af5a19e8d5a8e76c"
 data:
   rest.rego: |
     # SPDX-License-Identifier: Apache-2.0
@@ -145,6 +145,21 @@ data:
     	input.principal.id == input.resource.id
     	some verb in {"list", "read"}
     	endswith(input.action, sprintf(".%v", [verb]))
+    }
+
+    # ---------------------------------------------------------------------------------------
+    # ADR-0223 D2 phase 1 (shadow): the role->action matrix as data (rules.yaml: authz.
+    # role_action_matrix), granting ALONGSIDE the legacy reasons. The seed is derived as a
+    # strict subset of today's effective grants (operator-read-any's and compliance-read-any's
+    # read verbs, verbatim), so this rule changes no decision; what it changes is the
+    # decision_reason mix, which the D2(b) retirement triage reads to find where the matrix
+    # already carries the call. A role absent from the matrix yields an undefined lookup and
+    # the rule simply does not fire — fail-closed by construction.
+    # ---------------------------------------------------------------------------------------
+    allowed_reasons contains "matrix-allows" if {
+    	input.principal.type == "HUMAN"
+    	some role in input.principal.roles
+    	input.action in data.rules.authz.role_action_matrix[role].grant
     }
 
     # Operators and admins may list or read any resource on behalf of any party (support-desk
@@ -3507,5 +3522,95 @@ data:
           form: "a runnable skill that encodes the steps so they aren't re-derived each time"
       not_a_home:
         - "assistant session/local memory — does not travel to other agents or contributors, and may be stale"
+
+    # ADR-0223 D2 (phase 1, shadow): the role→action matrix as data. Seeded as the EXACT read
+    # half of today's operator-read-any (ROLE_OPERATOR/ROLE_ADMIN: every .list/.read) and
+    # compliance-read-any (ROLE_COMPLIANCE: every .read) — the action inventory is derived from
+    # the fleet-wide @Authorize coverage report (openbank-infra/scripts/authz-coverage-report.py),
+    # making this a provable subset of today's effective grants: rest.rego's matrix-allows reason
+    # grants nothing new, and decision_reason telemetry shows where the matrix already carries
+    # the call. Write grants (operator-<domain>-write etc.) join in phase 1.5 after the D2(b)
+    # triage; the retirement of operator-read-any itself is D2(c), a separate PR.
+    authz:
+      role_action_matrix:
+        ROLE_OPERATOR:
+          grant:
+            - account.list
+            - account.read
+            - anacredit.list
+            - anacredit.read
+            - audit.read
+            - card.list
+            - card.read
+            - device.list
+            - dispatch.read
+            - fx.list
+            - fx.read
+            - interest.list
+            - interest.read
+            - ledger.list
+            - ledger.read
+            - lending.list
+            - lending.read
+            - notification.list
+            - notification.read
+            - sanctions.list
+            - sanctions.read
+            - sdd.list
+            - sdd.read
+            - statement.list
+            - statement.read
+            - swift.list
+            - swift.read
+            - transaction.list
+            - transaction.read
+        ROLE_ADMIN:
+          grant:
+            - account.list
+            - account.read
+            - anacredit.list
+            - anacredit.read
+            - audit.read
+            - card.list
+            - card.read
+            - device.list
+            - dispatch.read
+            - fx.list
+            - fx.read
+            - interest.list
+            - interest.read
+            - ledger.list
+            - ledger.read
+            - lending.list
+            - lending.read
+            - notification.list
+            - notification.read
+            - sanctions.list
+            - sanctions.read
+            - sdd.list
+            - sdd.read
+            - statement.list
+            - statement.read
+            - swift.list
+            - swift.read
+            - transaction.list
+            - transaction.read
+        ROLE_COMPLIANCE:
+          grant:
+            - account.read
+            - anacredit.read
+            - audit.read
+            - card.read
+            - dispatch.read
+            - fx.read
+            - interest.read
+            - ledger.read
+            - lending.read
+            - notification.read
+            - sanctions.read
+            - sdd.read
+            - statement.read
+            - swift.read
+            - transaction.read
   manifest.json: |
     {"roots": ["openbank/agents", "openbank/copilot", "openbank/rest", "agents", "rules"]}

--- a/openbank-infra/gitops/components/payments/domestic-payment-opa-bundle.yaml
+++ b/openbank-infra/gitops/components/payments/domestic-payment-opa-bundle.yaml
@@ -9,7 +9,7 @@ metadata:
     app.kubernetes.io/name: domestic-payment
     app.kubernetes.io/part-of: payments
   annotations:
-    openbank.tech/policy-checksum: "d0599b19c748adfb"
+    openbank.tech/policy-checksum: "6b83bb4020b7d37a"
 data:
   rest.rego: |
     # SPDX-License-Identifier: Apache-2.0
@@ -145,6 +145,21 @@ data:
     	input.principal.id == input.resource.id
     	some verb in {"list", "read"}
     	endswith(input.action, sprintf(".%v", [verb]))
+    }
+
+    # ---------------------------------------------------------------------------------------
+    # ADR-0223 D2 phase 1 (shadow): the role->action matrix as data (rules.yaml: authz.
+    # role_action_matrix), granting ALONGSIDE the legacy reasons. The seed is derived as a
+    # strict subset of today's effective grants (operator-read-any's and compliance-read-any's
+    # read verbs, verbatim), so this rule changes no decision; what it changes is the
+    # decision_reason mix, which the D2(b) retirement triage reads to find where the matrix
+    # already carries the call. A role absent from the matrix yields an undefined lookup and
+    # the rule simply does not fire — fail-closed by construction.
+    # ---------------------------------------------------------------------------------------
+    allowed_reasons contains "matrix-allows" if {
+    	input.principal.type == "HUMAN"
+    	some role in input.principal.roles
+    	input.action in data.rules.authz.role_action_matrix[role].grant
     }
 
     # Operators and admins may list or read any resource on behalf of any party (support-desk
@@ -3492,5 +3507,95 @@ data:
           form: "a runnable skill that encodes the steps so they aren't re-derived each time"
       not_a_home:
         - "assistant session/local memory — does not travel to other agents or contributors, and may be stale"
+
+    # ADR-0223 D2 (phase 1, shadow): the role→action matrix as data. Seeded as the EXACT read
+    # half of today's operator-read-any (ROLE_OPERATOR/ROLE_ADMIN: every .list/.read) and
+    # compliance-read-any (ROLE_COMPLIANCE: every .read) — the action inventory is derived from
+    # the fleet-wide @Authorize coverage report (openbank-infra/scripts/authz-coverage-report.py),
+    # making this a provable subset of today's effective grants: rest.rego's matrix-allows reason
+    # grants nothing new, and decision_reason telemetry shows where the matrix already carries
+    # the call. Write grants (operator-<domain>-write etc.) join in phase 1.5 after the D2(b)
+    # triage; the retirement of operator-read-any itself is D2(c), a separate PR.
+    authz:
+      role_action_matrix:
+        ROLE_OPERATOR:
+          grant:
+            - account.list
+            - account.read
+            - anacredit.list
+            - anacredit.read
+            - audit.read
+            - card.list
+            - card.read
+            - device.list
+            - dispatch.read
+            - fx.list
+            - fx.read
+            - interest.list
+            - interest.read
+            - ledger.list
+            - ledger.read
+            - lending.list
+            - lending.read
+            - notification.list
+            - notification.read
+            - sanctions.list
+            - sanctions.read
+            - sdd.list
+            - sdd.read
+            - statement.list
+            - statement.read
+            - swift.list
+            - swift.read
+            - transaction.list
+            - transaction.read
+        ROLE_ADMIN:
+          grant:
+            - account.list
+            - account.read
+            - anacredit.list
+            - anacredit.read
+            - audit.read
+            - card.list
+            - card.read
+            - device.list
+            - dispatch.read
+            - fx.list
+            - fx.read
+            - interest.list
+            - interest.read
+            - ledger.list
+            - ledger.read
+            - lending.list
+            - lending.read
+            - notification.list
+            - notification.read
+            - sanctions.list
+            - sanctions.read
+            - sdd.list
+            - sdd.read
+            - statement.list
+            - statement.read
+            - swift.list
+            - swift.read
+            - transaction.list
+            - transaction.read
+        ROLE_COMPLIANCE:
+          grant:
+            - account.read
+            - anacredit.read
+            - audit.read
+            - card.read
+            - dispatch.read
+            - fx.read
+            - interest.read
+            - ledger.read
+            - lending.read
+            - notification.read
+            - sanctions.read
+            - sdd.read
+            - statement.read
+            - swift.read
+            - transaction.read
   manifest.json: |
     {"roots": ["openbank/agents", "openbank/copilot", "openbank/rest", "agents", "rules"]}

--- a/openbank-infra/gitops/components/payments/payments-services.yaml
+++ b/openbank-infra/gitops/components/payments/payments-services.yaml
@@ -42,7 +42,7 @@ spec:
         # Rolls the pods when the OPA bundle changes — subPath mounts do NOT hot-reload.
         # Kept in sync by gen-transaction-opa-bundle.sh via the trailing marker comment
         # (do not hand-edit, do not drop the marker).
-        openbank.tech/policy-checksum: "8098b5ab53f5b824" # transaction-opa-bundle
+        openbank.tech/policy-checksum: "62695986a96add53" # transaction-opa-bundle
     spec:
       securityContext:
         runAsNonRoot: true
@@ -375,7 +375,7 @@ spec:
       annotations:
         # Rolls the pods when the OPA bundle changes — subPath mounts do NOT hot-reload.
         # Kept in sync by gen-sepa-payment-opa-bundle.sh (do not hand-edit).
-        openbank.tech/policy-checksum: "706d015af313796e"
+        openbank.tech/policy-checksum: "aa8f021d73df1b81"
     spec:
       securityContext:
         runAsNonRoot: true
@@ -729,7 +729,7 @@ spec:
         # Rolls the pods when the OPA bundle changes — subPath mounts do NOT hot-reload.
         # Kept in sync by gen-domestic-payment-opa-bundle.sh via the trailing marker
         # comment (do not hand-edit, do not drop the marker).
-        openbank.tech/policy-checksum: "d0599b19c748adfb" # domestic-payment-opa-bundle
+        openbank.tech/policy-checksum: "6b83bb4020b7d37a" # domestic-payment-opa-bundle
     spec:
       securityContext:
         runAsNonRoot: true
@@ -1053,7 +1053,7 @@ spec:
       annotations:
         # Rolls the pods when the OPA bundle changes — subPath mounts do NOT hot-reload.
         # Kept in sync by gen-sepa-instant-opa-bundle.sh (do not hand-edit).
-        openbank.tech/policy-checksum: "907e4bd0e0a7d5b3"
+        openbank.tech/policy-checksum: "00be421cd83b7a99"
     spec:
       securityContext:
         runAsNonRoot: true
@@ -1369,7 +1369,7 @@ spec:
         # Rolls the pods when the OPA bundle changes — subPath mounts do NOT hot-reload.
         # Kept in sync by gen-clearing-opa-bundle.sh via the trailing marker comment
         # (do not hand-edit, do not drop the marker).
-        openbank.tech/policy-checksum: "5a09b6f58b416ab1" # clearing-opa-bundle
+        openbank.tech/policy-checksum: "af5a19e8d5a8e76c" # clearing-opa-bundle
     spec:
       securityContext:
         runAsNonRoot: true
@@ -1658,7 +1658,7 @@ spec:
       annotations:
         # Rolls the pod when the OPA bundle changes (ADR-0034). Value is stamped by
         # gen-standing-order-opa-bundle.sh — do not hand-edit.
-        openbank.tech/policy-checksum: "2dcf6eb27bae36d1" # standing-order-opa-bundle
+        openbank.tech/policy-checksum: "b024c4d7ee92703f" # standing-order-opa-bundle
     spec:
       securityContext:
         runAsNonRoot: true
@@ -1911,7 +1911,7 @@ spec:
       annotations:
         # Rolls the pods when the OPA bundle changes — subPath mounts do NOT hot-reload.
         # Kept in sync by gen-card-issuance-opa-bundle.sh (do not hand-edit).
-        openbank.tech/policy-checksum: "c05a223835cae451"
+        openbank.tech/policy-checksum: "b7fe840230db2033"
     spec:
       securityContext:
         runAsNonRoot: true
@@ -1990,10 +1990,7 @@ spec:
                   name: card-issuance-pan-key
                   key: CARD_PAN_ENCRYPTION_KEY
             - name: PRODUCT_CATALOG_SERVICE_URL
-              value: http://keda-add-ons-http-interceptor-proxy.keda:8080
-            # ADR-0083 T1 re-entry: the interceptor dispatches on Host (see account-service).
-            - name: PRODUCT_CATALOG_API_HOST_OVERRIDE
-              value: product-catalog.accounts.svc
+              value: http://product-catalog.accounts.svc:8104
             - name: QUARKUS_OTEL_EXPORTER_OTLP_ENDPOINT
               value: "http://tempo.observability.svc:4317"
             - name: OTEL_TRACES_SAMPLER_ARG
@@ -2181,7 +2178,7 @@ spec:
         # Rolls the pods when the OPA bundle changes — subPath mounts do NOT hot-reload.
         # Kept in sync by gen-settlement-opa-bundle.sh via the trailing marker comment
         # (do not hand-edit, do not drop the marker).
-        openbank.tech/policy-checksum: "3d33b06574266a69" # settlement-opa-bundle
+        openbank.tech/policy-checksum: "01e51d5ea989394a" # settlement-opa-bundle
     spec:
       securityContext:
         runAsNonRoot: true
@@ -2582,7 +2579,7 @@ spec:
       annotations:
         # Rolls the pods when the OPA bundle changes — subPath mounts do NOT hot-reload.
         # Kept in sync by gen-swift-opa-bundle.sh (do not hand-edit).
-        openbank.tech/policy-checksum: "a270cf688f9126b9"
+        openbank.tech/policy-checksum: "f1ac792f1156c219"
     spec:
       securityContext:
         runAsNonRoot: true
@@ -2896,7 +2893,7 @@ spec:
       annotations:
         # Rolls the pods when the OPA bundle changes — subPath mounts do NOT hot-reload.
         # Kept in sync by gen-vop-opa-bundle.sh (do not hand-edit).
-        openbank.tech/policy-checksum: "bc00341a31edd0f0"
+        openbank.tech/policy-checksum: "5965534d2aa3f631"
     spec:
       securityContext:
         runAsNonRoot: true

--- a/openbank-infra/gitops/components/payments/sepa-instant-opa-bundle.yaml
+++ b/openbank-infra/gitops/components/payments/sepa-instant-opa-bundle.yaml
@@ -9,7 +9,7 @@ metadata:
     app.kubernetes.io/name: sepa-instant
     app.kubernetes.io/part-of: payments
   annotations:
-    openbank.tech/policy-checksum: "907e4bd0e0a7d5b3"
+    openbank.tech/policy-checksum: "00be421cd83b7a99"
 data:
   rest.rego: |
     # SPDX-License-Identifier: Apache-2.0
@@ -145,6 +145,21 @@ data:
     	input.principal.id == input.resource.id
     	some verb in {"list", "read"}
     	endswith(input.action, sprintf(".%v", [verb]))
+    }
+
+    # ---------------------------------------------------------------------------------------
+    # ADR-0223 D2 phase 1 (shadow): the role->action matrix as data (rules.yaml: authz.
+    # role_action_matrix), granting ALONGSIDE the legacy reasons. The seed is derived as a
+    # strict subset of today's effective grants (operator-read-any's and compliance-read-any's
+    # read verbs, verbatim), so this rule changes no decision; what it changes is the
+    # decision_reason mix, which the D2(b) retirement triage reads to find where the matrix
+    # already carries the call. A role absent from the matrix yields an undefined lookup and
+    # the rule simply does not fire — fail-closed by construction.
+    # ---------------------------------------------------------------------------------------
+    allowed_reasons contains "matrix-allows" if {
+    	input.principal.type == "HUMAN"
+    	some role in input.principal.roles
+    	input.action in data.rules.authz.role_action_matrix[role].grant
     }
 
     # Operators and admins may list or read any resource on behalf of any party (support-desk
@@ -3465,5 +3480,95 @@ data:
           form: "a runnable skill that encodes the steps so they aren't re-derived each time"
       not_a_home:
         - "assistant session/local memory — does not travel to other agents or contributors, and may be stale"
+
+    # ADR-0223 D2 (phase 1, shadow): the role→action matrix as data. Seeded as the EXACT read
+    # half of today's operator-read-any (ROLE_OPERATOR/ROLE_ADMIN: every .list/.read) and
+    # compliance-read-any (ROLE_COMPLIANCE: every .read) — the action inventory is derived from
+    # the fleet-wide @Authorize coverage report (openbank-infra/scripts/authz-coverage-report.py),
+    # making this a provable subset of today's effective grants: rest.rego's matrix-allows reason
+    # grants nothing new, and decision_reason telemetry shows where the matrix already carries
+    # the call. Write grants (operator-<domain>-write etc.) join in phase 1.5 after the D2(b)
+    # triage; the retirement of operator-read-any itself is D2(c), a separate PR.
+    authz:
+      role_action_matrix:
+        ROLE_OPERATOR:
+          grant:
+            - account.list
+            - account.read
+            - anacredit.list
+            - anacredit.read
+            - audit.read
+            - card.list
+            - card.read
+            - device.list
+            - dispatch.read
+            - fx.list
+            - fx.read
+            - interest.list
+            - interest.read
+            - ledger.list
+            - ledger.read
+            - lending.list
+            - lending.read
+            - notification.list
+            - notification.read
+            - sanctions.list
+            - sanctions.read
+            - sdd.list
+            - sdd.read
+            - statement.list
+            - statement.read
+            - swift.list
+            - swift.read
+            - transaction.list
+            - transaction.read
+        ROLE_ADMIN:
+          grant:
+            - account.list
+            - account.read
+            - anacredit.list
+            - anacredit.read
+            - audit.read
+            - card.list
+            - card.read
+            - device.list
+            - dispatch.read
+            - fx.list
+            - fx.read
+            - interest.list
+            - interest.read
+            - ledger.list
+            - ledger.read
+            - lending.list
+            - lending.read
+            - notification.list
+            - notification.read
+            - sanctions.list
+            - sanctions.read
+            - sdd.list
+            - sdd.read
+            - statement.list
+            - statement.read
+            - swift.list
+            - swift.read
+            - transaction.list
+            - transaction.read
+        ROLE_COMPLIANCE:
+          grant:
+            - account.read
+            - anacredit.read
+            - audit.read
+            - card.read
+            - dispatch.read
+            - fx.read
+            - interest.read
+            - ledger.read
+            - lending.read
+            - notification.read
+            - sanctions.read
+            - sdd.read
+            - statement.read
+            - swift.read
+            - transaction.read
   manifest.json: |
     {"roots": ["openbank/agents", "openbank/copilot", "openbank/rest", "agents", "rules"]}

--- a/openbank-infra/gitops/components/payments/sepa-payment-opa-bundle.yaml
+++ b/openbank-infra/gitops/components/payments/sepa-payment-opa-bundle.yaml
@@ -9,7 +9,7 @@ metadata:
     app.kubernetes.io/name: sepa-payment
     app.kubernetes.io/part-of: payments
   annotations:
-    openbank.tech/policy-checksum: "706d015af313796e"
+    openbank.tech/policy-checksum: "aa8f021d73df1b81"
 data:
   rest.rego: |
     # SPDX-License-Identifier: Apache-2.0
@@ -145,6 +145,21 @@ data:
     	input.principal.id == input.resource.id
     	some verb in {"list", "read"}
     	endswith(input.action, sprintf(".%v", [verb]))
+    }
+
+    # ---------------------------------------------------------------------------------------
+    # ADR-0223 D2 phase 1 (shadow): the role->action matrix as data (rules.yaml: authz.
+    # role_action_matrix), granting ALONGSIDE the legacy reasons. The seed is derived as a
+    # strict subset of today's effective grants (operator-read-any's and compliance-read-any's
+    # read verbs, verbatim), so this rule changes no decision; what it changes is the
+    # decision_reason mix, which the D2(b) retirement triage reads to find where the matrix
+    # already carries the call. A role absent from the matrix yields an undefined lookup and
+    # the rule simply does not fire — fail-closed by construction.
+    # ---------------------------------------------------------------------------------------
+    allowed_reasons contains "matrix-allows" if {
+    	input.principal.type == "HUMAN"
+    	some role in input.principal.roles
+    	input.action in data.rules.authz.role_action_matrix[role].grant
     }
 
     # Operators and admins may list or read any resource on behalf of any party (support-desk
@@ -3486,5 +3501,95 @@ data:
           form: "a runnable skill that encodes the steps so they aren't re-derived each time"
       not_a_home:
         - "assistant session/local memory — does not travel to other agents or contributors, and may be stale"
+
+    # ADR-0223 D2 (phase 1, shadow): the role→action matrix as data. Seeded as the EXACT read
+    # half of today's operator-read-any (ROLE_OPERATOR/ROLE_ADMIN: every .list/.read) and
+    # compliance-read-any (ROLE_COMPLIANCE: every .read) — the action inventory is derived from
+    # the fleet-wide @Authorize coverage report (openbank-infra/scripts/authz-coverage-report.py),
+    # making this a provable subset of today's effective grants: rest.rego's matrix-allows reason
+    # grants nothing new, and decision_reason telemetry shows where the matrix already carries
+    # the call. Write grants (operator-<domain>-write etc.) join in phase 1.5 after the D2(b)
+    # triage; the retirement of operator-read-any itself is D2(c), a separate PR.
+    authz:
+      role_action_matrix:
+        ROLE_OPERATOR:
+          grant:
+            - account.list
+            - account.read
+            - anacredit.list
+            - anacredit.read
+            - audit.read
+            - card.list
+            - card.read
+            - device.list
+            - dispatch.read
+            - fx.list
+            - fx.read
+            - interest.list
+            - interest.read
+            - ledger.list
+            - ledger.read
+            - lending.list
+            - lending.read
+            - notification.list
+            - notification.read
+            - sanctions.list
+            - sanctions.read
+            - sdd.list
+            - sdd.read
+            - statement.list
+            - statement.read
+            - swift.list
+            - swift.read
+            - transaction.list
+            - transaction.read
+        ROLE_ADMIN:
+          grant:
+            - account.list
+            - account.read
+            - anacredit.list
+            - anacredit.read
+            - audit.read
+            - card.list
+            - card.read
+            - device.list
+            - dispatch.read
+            - fx.list
+            - fx.read
+            - interest.list
+            - interest.read
+            - ledger.list
+            - ledger.read
+            - lending.list
+            - lending.read
+            - notification.list
+            - notification.read
+            - sanctions.list
+            - sanctions.read
+            - sdd.list
+            - sdd.read
+            - statement.list
+            - statement.read
+            - swift.list
+            - swift.read
+            - transaction.list
+            - transaction.read
+        ROLE_COMPLIANCE:
+          grant:
+            - account.read
+            - anacredit.read
+            - audit.read
+            - card.read
+            - dispatch.read
+            - fx.read
+            - interest.read
+            - ledger.read
+            - lending.read
+            - notification.read
+            - sanctions.read
+            - sdd.read
+            - statement.read
+            - swift.read
+            - transaction.read
   manifest.json: |
     {"roots": ["openbank/agents", "openbank/copilot", "openbank/rest", "agents", "rules"]}

--- a/openbank-infra/gitops/components/payments/settlement-opa-bundle.yaml
+++ b/openbank-infra/gitops/components/payments/settlement-opa-bundle.yaml
@@ -9,7 +9,7 @@ metadata:
     app.kubernetes.io/name: settlement-service
     app.kubernetes.io/part-of: payments
   annotations:
-    openbank.tech/policy-checksum: "3d33b06574266a69"
+    openbank.tech/policy-checksum: "01e51d5ea989394a"
 data:
   rest.rego: |
     # SPDX-License-Identifier: Apache-2.0
@@ -145,6 +145,21 @@ data:
     	input.principal.id == input.resource.id
     	some verb in {"list", "read"}
     	endswith(input.action, sprintf(".%v", [verb]))
+    }
+
+    # ---------------------------------------------------------------------------------------
+    # ADR-0223 D2 phase 1 (shadow): the role->action matrix as data (rules.yaml: authz.
+    # role_action_matrix), granting ALONGSIDE the legacy reasons. The seed is derived as a
+    # strict subset of today's effective grants (operator-read-any's and compliance-read-any's
+    # read verbs, verbatim), so this rule changes no decision; what it changes is the
+    # decision_reason mix, which the D2(b) retirement triage reads to find where the matrix
+    # already carries the call. A role absent from the matrix yields an undefined lookup and
+    # the rule simply does not fire — fail-closed by construction.
+    # ---------------------------------------------------------------------------------------
+    allowed_reasons contains "matrix-allows" if {
+    	input.principal.type == "HUMAN"
+    	some role in input.principal.roles
+    	input.action in data.rules.authz.role_action_matrix[role].grant
     }
 
     # Operators and admins may list or read any resource on behalf of any party (support-desk
@@ -3466,5 +3481,95 @@ data:
           form: "a runnable skill that encodes the steps so they aren't re-derived each time"
       not_a_home:
         - "assistant session/local memory — does not travel to other agents or contributors, and may be stale"
+
+    # ADR-0223 D2 (phase 1, shadow): the role→action matrix as data. Seeded as the EXACT read
+    # half of today's operator-read-any (ROLE_OPERATOR/ROLE_ADMIN: every .list/.read) and
+    # compliance-read-any (ROLE_COMPLIANCE: every .read) — the action inventory is derived from
+    # the fleet-wide @Authorize coverage report (openbank-infra/scripts/authz-coverage-report.py),
+    # making this a provable subset of today's effective grants: rest.rego's matrix-allows reason
+    # grants nothing new, and decision_reason telemetry shows where the matrix already carries
+    # the call. Write grants (operator-<domain>-write etc.) join in phase 1.5 after the D2(b)
+    # triage; the retirement of operator-read-any itself is D2(c), a separate PR.
+    authz:
+      role_action_matrix:
+        ROLE_OPERATOR:
+          grant:
+            - account.list
+            - account.read
+            - anacredit.list
+            - anacredit.read
+            - audit.read
+            - card.list
+            - card.read
+            - device.list
+            - dispatch.read
+            - fx.list
+            - fx.read
+            - interest.list
+            - interest.read
+            - ledger.list
+            - ledger.read
+            - lending.list
+            - lending.read
+            - notification.list
+            - notification.read
+            - sanctions.list
+            - sanctions.read
+            - sdd.list
+            - sdd.read
+            - statement.list
+            - statement.read
+            - swift.list
+            - swift.read
+            - transaction.list
+            - transaction.read
+        ROLE_ADMIN:
+          grant:
+            - account.list
+            - account.read
+            - anacredit.list
+            - anacredit.read
+            - audit.read
+            - card.list
+            - card.read
+            - device.list
+            - dispatch.read
+            - fx.list
+            - fx.read
+            - interest.list
+            - interest.read
+            - ledger.list
+            - ledger.read
+            - lending.list
+            - lending.read
+            - notification.list
+            - notification.read
+            - sanctions.list
+            - sanctions.read
+            - sdd.list
+            - sdd.read
+            - statement.list
+            - statement.read
+            - swift.list
+            - swift.read
+            - transaction.list
+            - transaction.read
+        ROLE_COMPLIANCE:
+          grant:
+            - account.read
+            - anacredit.read
+            - audit.read
+            - card.read
+            - dispatch.read
+            - fx.read
+            - interest.read
+            - ledger.read
+            - lending.read
+            - notification.read
+            - sanctions.read
+            - sdd.read
+            - statement.read
+            - swift.read
+            - transaction.read
   manifest.json: |
     {"roots": ["openbank/agents", "openbank/copilot", "openbank/rest", "agents", "rules"]}

--- a/openbank-infra/gitops/components/payments/standing-order-opa-bundle.yaml
+++ b/openbank-infra/gitops/components/payments/standing-order-opa-bundle.yaml
@@ -9,7 +9,7 @@ metadata:
     app.kubernetes.io/name: standing-order-service
     app.kubernetes.io/part-of: payments
   annotations:
-    openbank.tech/policy-checksum: "2dcf6eb27bae36d1"
+    openbank.tech/policy-checksum: "b024c4d7ee92703f"
 data:
   rest.rego: |
     # SPDX-License-Identifier: Apache-2.0
@@ -145,6 +145,21 @@ data:
     	input.principal.id == input.resource.id
     	some verb in {"list", "read"}
     	endswith(input.action, sprintf(".%v", [verb]))
+    }
+
+    # ---------------------------------------------------------------------------------------
+    # ADR-0223 D2 phase 1 (shadow): the role->action matrix as data (rules.yaml: authz.
+    # role_action_matrix), granting ALONGSIDE the legacy reasons. The seed is derived as a
+    # strict subset of today's effective grants (operator-read-any's and compliance-read-any's
+    # read verbs, verbatim), so this rule changes no decision; what it changes is the
+    # decision_reason mix, which the D2(b) retirement triage reads to find where the matrix
+    # already carries the call. A role absent from the matrix yields an undefined lookup and
+    # the rule simply does not fire — fail-closed by construction.
+    # ---------------------------------------------------------------------------------------
+    allowed_reasons contains "matrix-allows" if {
+    	input.principal.type == "HUMAN"
+    	some role in input.principal.roles
+    	input.action in data.rules.authz.role_action_matrix[role].grant
     }
 
     # Operators and admins may list or read any resource on behalf of any party (support-desk
@@ -3451,5 +3466,95 @@ data:
           form: "a runnable skill that encodes the steps so they aren't re-derived each time"
       not_a_home:
         - "assistant session/local memory — does not travel to other agents or contributors, and may be stale"
+
+    # ADR-0223 D2 (phase 1, shadow): the role→action matrix as data. Seeded as the EXACT read
+    # half of today's operator-read-any (ROLE_OPERATOR/ROLE_ADMIN: every .list/.read) and
+    # compliance-read-any (ROLE_COMPLIANCE: every .read) — the action inventory is derived from
+    # the fleet-wide @Authorize coverage report (openbank-infra/scripts/authz-coverage-report.py),
+    # making this a provable subset of today's effective grants: rest.rego's matrix-allows reason
+    # grants nothing new, and decision_reason telemetry shows where the matrix already carries
+    # the call. Write grants (operator-<domain>-write etc.) join in phase 1.5 after the D2(b)
+    # triage; the retirement of operator-read-any itself is D2(c), a separate PR.
+    authz:
+      role_action_matrix:
+        ROLE_OPERATOR:
+          grant:
+            - account.list
+            - account.read
+            - anacredit.list
+            - anacredit.read
+            - audit.read
+            - card.list
+            - card.read
+            - device.list
+            - dispatch.read
+            - fx.list
+            - fx.read
+            - interest.list
+            - interest.read
+            - ledger.list
+            - ledger.read
+            - lending.list
+            - lending.read
+            - notification.list
+            - notification.read
+            - sanctions.list
+            - sanctions.read
+            - sdd.list
+            - sdd.read
+            - statement.list
+            - statement.read
+            - swift.list
+            - swift.read
+            - transaction.list
+            - transaction.read
+        ROLE_ADMIN:
+          grant:
+            - account.list
+            - account.read
+            - anacredit.list
+            - anacredit.read
+            - audit.read
+            - card.list
+            - card.read
+            - device.list
+            - dispatch.read
+            - fx.list
+            - fx.read
+            - interest.list
+            - interest.read
+            - ledger.list
+            - ledger.read
+            - lending.list
+            - lending.read
+            - notification.list
+            - notification.read
+            - sanctions.list
+            - sanctions.read
+            - sdd.list
+            - sdd.read
+            - statement.list
+            - statement.read
+            - swift.list
+            - swift.read
+            - transaction.list
+            - transaction.read
+        ROLE_COMPLIANCE:
+          grant:
+            - account.read
+            - anacredit.read
+            - audit.read
+            - card.read
+            - dispatch.read
+            - fx.read
+            - interest.read
+            - ledger.read
+            - lending.read
+            - notification.read
+            - sanctions.read
+            - sdd.read
+            - statement.read
+            - swift.read
+            - transaction.read
   manifest.json: |
     {"roots": ["openbank/agents", "openbank/copilot", "openbank/rest", "agents", "rules"]}

--- a/openbank-infra/gitops/components/payments/swift-opa-bundle.yaml
+++ b/openbank-infra/gitops/components/payments/swift-opa-bundle.yaml
@@ -9,7 +9,7 @@ metadata:
     app.kubernetes.io/name: swift-service
     app.kubernetes.io/part-of: payments
   annotations:
-    openbank.tech/policy-checksum: "a270cf688f9126b9"
+    openbank.tech/policy-checksum: "f1ac792f1156c219"
 data:
   rest.rego: |
     # SPDX-License-Identifier: Apache-2.0
@@ -145,6 +145,21 @@ data:
     	input.principal.id == input.resource.id
     	some verb in {"list", "read"}
     	endswith(input.action, sprintf(".%v", [verb]))
+    }
+
+    # ---------------------------------------------------------------------------------------
+    # ADR-0223 D2 phase 1 (shadow): the role->action matrix as data (rules.yaml: authz.
+    # role_action_matrix), granting ALONGSIDE the legacy reasons. The seed is derived as a
+    # strict subset of today's effective grants (operator-read-any's and compliance-read-any's
+    # read verbs, verbatim), so this rule changes no decision; what it changes is the
+    # decision_reason mix, which the D2(b) retirement triage reads to find where the matrix
+    # already carries the call. A role absent from the matrix yields an undefined lookup and
+    # the rule simply does not fire — fail-closed by construction.
+    # ---------------------------------------------------------------------------------------
+    allowed_reasons contains "matrix-allows" if {
+    	input.principal.type == "HUMAN"
+    	some role in input.principal.roles
+    	input.action in data.rules.authz.role_action_matrix[role].grant
     }
 
     # Operators and admins may list or read any resource on behalf of any party (support-desk
@@ -3469,5 +3484,95 @@ data:
           form: "a runnable skill that encodes the steps so they aren't re-derived each time"
       not_a_home:
         - "assistant session/local memory — does not travel to other agents or contributors, and may be stale"
+
+    # ADR-0223 D2 (phase 1, shadow): the role→action matrix as data. Seeded as the EXACT read
+    # half of today's operator-read-any (ROLE_OPERATOR/ROLE_ADMIN: every .list/.read) and
+    # compliance-read-any (ROLE_COMPLIANCE: every .read) — the action inventory is derived from
+    # the fleet-wide @Authorize coverage report (openbank-infra/scripts/authz-coverage-report.py),
+    # making this a provable subset of today's effective grants: rest.rego's matrix-allows reason
+    # grants nothing new, and decision_reason telemetry shows where the matrix already carries
+    # the call. Write grants (operator-<domain>-write etc.) join in phase 1.5 after the D2(b)
+    # triage; the retirement of operator-read-any itself is D2(c), a separate PR.
+    authz:
+      role_action_matrix:
+        ROLE_OPERATOR:
+          grant:
+            - account.list
+            - account.read
+            - anacredit.list
+            - anacredit.read
+            - audit.read
+            - card.list
+            - card.read
+            - device.list
+            - dispatch.read
+            - fx.list
+            - fx.read
+            - interest.list
+            - interest.read
+            - ledger.list
+            - ledger.read
+            - lending.list
+            - lending.read
+            - notification.list
+            - notification.read
+            - sanctions.list
+            - sanctions.read
+            - sdd.list
+            - sdd.read
+            - statement.list
+            - statement.read
+            - swift.list
+            - swift.read
+            - transaction.list
+            - transaction.read
+        ROLE_ADMIN:
+          grant:
+            - account.list
+            - account.read
+            - anacredit.list
+            - anacredit.read
+            - audit.read
+            - card.list
+            - card.read
+            - device.list
+            - dispatch.read
+            - fx.list
+            - fx.read
+            - interest.list
+            - interest.read
+            - ledger.list
+            - ledger.read
+            - lending.list
+            - lending.read
+            - notification.list
+            - notification.read
+            - sanctions.list
+            - sanctions.read
+            - sdd.list
+            - sdd.read
+            - statement.list
+            - statement.read
+            - swift.list
+            - swift.read
+            - transaction.list
+            - transaction.read
+        ROLE_COMPLIANCE:
+          grant:
+            - account.read
+            - anacredit.read
+            - audit.read
+            - card.read
+            - dispatch.read
+            - fx.read
+            - interest.read
+            - ledger.read
+            - lending.read
+            - notification.read
+            - sanctions.read
+            - sdd.read
+            - statement.read
+            - swift.read
+            - transaction.read
   manifest.json: |
     {"roots": ["openbank/agents", "openbank/copilot", "openbank/rest", "agents", "rules"]}

--- a/openbank-infra/gitops/components/payments/transaction-opa-bundle.yaml
+++ b/openbank-infra/gitops/components/payments/transaction-opa-bundle.yaml
@@ -9,7 +9,7 @@ metadata:
     app.kubernetes.io/name: transaction-service
     app.kubernetes.io/part-of: payments
   annotations:
-    openbank.tech/policy-checksum: "8098b5ab53f5b824"
+    openbank.tech/policy-checksum: "62695986a96add53"
 data:
   rest.rego: |
     # SPDX-License-Identifier: Apache-2.0
@@ -145,6 +145,21 @@ data:
     	input.principal.id == input.resource.id
     	some verb in {"list", "read"}
     	endswith(input.action, sprintf(".%v", [verb]))
+    }
+
+    # ---------------------------------------------------------------------------------------
+    # ADR-0223 D2 phase 1 (shadow): the role->action matrix as data (rules.yaml: authz.
+    # role_action_matrix), granting ALONGSIDE the legacy reasons. The seed is derived as a
+    # strict subset of today's effective grants (operator-read-any's and compliance-read-any's
+    # read verbs, verbatim), so this rule changes no decision; what it changes is the
+    # decision_reason mix, which the D2(b) retirement triage reads to find where the matrix
+    # already carries the call. A role absent from the matrix yields an undefined lookup and
+    # the rule simply does not fire — fail-closed by construction.
+    # ---------------------------------------------------------------------------------------
+    allowed_reasons contains "matrix-allows" if {
+    	input.principal.type == "HUMAN"
+    	some role in input.principal.roles
+    	input.action in data.rules.authz.role_action_matrix[role].grant
     }
 
     # Operators and admins may list or read any resource on behalf of any party (support-desk
@@ -3522,5 +3537,95 @@ data:
           form: "a runnable skill that encodes the steps so they aren't re-derived each time"
       not_a_home:
         - "assistant session/local memory — does not travel to other agents or contributors, and may be stale"
+
+    # ADR-0223 D2 (phase 1, shadow): the role→action matrix as data. Seeded as the EXACT read
+    # half of today's operator-read-any (ROLE_OPERATOR/ROLE_ADMIN: every .list/.read) and
+    # compliance-read-any (ROLE_COMPLIANCE: every .read) — the action inventory is derived from
+    # the fleet-wide @Authorize coverage report (openbank-infra/scripts/authz-coverage-report.py),
+    # making this a provable subset of today's effective grants: rest.rego's matrix-allows reason
+    # grants nothing new, and decision_reason telemetry shows where the matrix already carries
+    # the call. Write grants (operator-<domain>-write etc.) join in phase 1.5 after the D2(b)
+    # triage; the retirement of operator-read-any itself is D2(c), a separate PR.
+    authz:
+      role_action_matrix:
+        ROLE_OPERATOR:
+          grant:
+            - account.list
+            - account.read
+            - anacredit.list
+            - anacredit.read
+            - audit.read
+            - card.list
+            - card.read
+            - device.list
+            - dispatch.read
+            - fx.list
+            - fx.read
+            - interest.list
+            - interest.read
+            - ledger.list
+            - ledger.read
+            - lending.list
+            - lending.read
+            - notification.list
+            - notification.read
+            - sanctions.list
+            - sanctions.read
+            - sdd.list
+            - sdd.read
+            - statement.list
+            - statement.read
+            - swift.list
+            - swift.read
+            - transaction.list
+            - transaction.read
+        ROLE_ADMIN:
+          grant:
+            - account.list
+            - account.read
+            - anacredit.list
+            - anacredit.read
+            - audit.read
+            - card.list
+            - card.read
+            - device.list
+            - dispatch.read
+            - fx.list
+            - fx.read
+            - interest.list
+            - interest.read
+            - ledger.list
+            - ledger.read
+            - lending.list
+            - lending.read
+            - notification.list
+            - notification.read
+            - sanctions.list
+            - sanctions.read
+            - sdd.list
+            - sdd.read
+            - statement.list
+            - statement.read
+            - swift.list
+            - swift.read
+            - transaction.list
+            - transaction.read
+        ROLE_COMPLIANCE:
+          grant:
+            - account.read
+            - anacredit.read
+            - audit.read
+            - card.read
+            - dispatch.read
+            - fx.read
+            - interest.read
+            - ledger.read
+            - lending.read
+            - notification.read
+            - sanctions.read
+            - sdd.read
+            - statement.read
+            - swift.read
+            - transaction.read
   manifest.json: |
     {"roots": ["openbank/agents", "openbank/copilot", "openbank/rest", "agents", "rules"]}

--- a/openbank-infra/gitops/components/payments/vop-opa-bundle.yaml
+++ b/openbank-infra/gitops/components/payments/vop-opa-bundle.yaml
@@ -9,7 +9,7 @@ metadata:
     app.kubernetes.io/name: vop-service
     app.kubernetes.io/part-of: payments
   annotations:
-    openbank.tech/policy-checksum: "bc00341a31edd0f0"
+    openbank.tech/policy-checksum: "5965534d2aa3f631"
 data:
   rest.rego: |
     # SPDX-License-Identifier: Apache-2.0
@@ -145,6 +145,21 @@ data:
     	input.principal.id == input.resource.id
     	some verb in {"list", "read"}
     	endswith(input.action, sprintf(".%v", [verb]))
+    }
+
+    # ---------------------------------------------------------------------------------------
+    # ADR-0223 D2 phase 1 (shadow): the role->action matrix as data (rules.yaml: authz.
+    # role_action_matrix), granting ALONGSIDE the legacy reasons. The seed is derived as a
+    # strict subset of today's effective grants (operator-read-any's and compliance-read-any's
+    # read verbs, verbatim), so this rule changes no decision; what it changes is the
+    # decision_reason mix, which the D2(b) retirement triage reads to find where the matrix
+    # already carries the call. A role absent from the matrix yields an undefined lookup and
+    # the rule simply does not fire — fail-closed by construction.
+    # ---------------------------------------------------------------------------------------
+    allowed_reasons contains "matrix-allows" if {
+    	input.principal.type == "HUMAN"
+    	some role in input.principal.roles
+    	input.action in data.rules.authz.role_action_matrix[role].grant
     }
 
     # Operators and admins may list or read any resource on behalf of any party (support-desk
@@ -3473,5 +3488,95 @@ data:
           form: "a runnable skill that encodes the steps so they aren't re-derived each time"
       not_a_home:
         - "assistant session/local memory — does not travel to other agents or contributors, and may be stale"
+
+    # ADR-0223 D2 (phase 1, shadow): the role→action matrix as data. Seeded as the EXACT read
+    # half of today's operator-read-any (ROLE_OPERATOR/ROLE_ADMIN: every .list/.read) and
+    # compliance-read-any (ROLE_COMPLIANCE: every .read) — the action inventory is derived from
+    # the fleet-wide @Authorize coverage report (openbank-infra/scripts/authz-coverage-report.py),
+    # making this a provable subset of today's effective grants: rest.rego's matrix-allows reason
+    # grants nothing new, and decision_reason telemetry shows where the matrix already carries
+    # the call. Write grants (operator-<domain>-write etc.) join in phase 1.5 after the D2(b)
+    # triage; the retirement of operator-read-any itself is D2(c), a separate PR.
+    authz:
+      role_action_matrix:
+        ROLE_OPERATOR:
+          grant:
+            - account.list
+            - account.read
+            - anacredit.list
+            - anacredit.read
+            - audit.read
+            - card.list
+            - card.read
+            - device.list
+            - dispatch.read
+            - fx.list
+            - fx.read
+            - interest.list
+            - interest.read
+            - ledger.list
+            - ledger.read
+            - lending.list
+            - lending.read
+            - notification.list
+            - notification.read
+            - sanctions.list
+            - sanctions.read
+            - sdd.list
+            - sdd.read
+            - statement.list
+            - statement.read
+            - swift.list
+            - swift.read
+            - transaction.list
+            - transaction.read
+        ROLE_ADMIN:
+          grant:
+            - account.list
+            - account.read
+            - anacredit.list
+            - anacredit.read
+            - audit.read
+            - card.list
+            - card.read
+            - device.list
+            - dispatch.read
+            - fx.list
+            - fx.read
+            - interest.list
+            - interest.read
+            - ledger.list
+            - ledger.read
+            - lending.list
+            - lending.read
+            - notification.list
+            - notification.read
+            - sanctions.list
+            - sanctions.read
+            - sdd.list
+            - sdd.read
+            - statement.list
+            - statement.read
+            - swift.list
+            - swift.read
+            - transaction.list
+            - transaction.read
+        ROLE_COMPLIANCE:
+          grant:
+            - account.read
+            - anacredit.read
+            - audit.read
+            - card.read
+            - dispatch.read
+            - fx.read
+            - interest.read
+            - ledger.read
+            - lending.read
+            - notification.read
+            - sanctions.read
+            - sdd.read
+            - statement.read
+            - swift.read
+            - transaction.read
   manifest.json: |
     {"roots": ["openbank/agents", "openbank/copilot", "openbank/rest", "agents", "rules"]}

--- a/openbank-infra/gitops/components/pid/pid-opa-bundle.yaml
+++ b/openbank-infra/gitops/components/pid/pid-opa-bundle.yaml
@@ -9,7 +9,7 @@ metadata:
     app.kubernetes.io/name: pid-service
     app.kubernetes.io/part-of: pid
   annotations:
-    openbank.tech/policy-checksum: "2864f8d1beb89959"
+    openbank.tech/policy-checksum: "e1feb36d958dbec2"
 data:
   rest.rego: |
     # SPDX-License-Identifier: Apache-2.0
@@ -145,6 +145,21 @@ data:
     	input.principal.id == input.resource.id
     	some verb in {"list", "read"}
     	endswith(input.action, sprintf(".%v", [verb]))
+    }
+
+    # ---------------------------------------------------------------------------------------
+    # ADR-0223 D2 phase 1 (shadow): the role->action matrix as data (rules.yaml: authz.
+    # role_action_matrix), granting ALONGSIDE the legacy reasons. The seed is derived as a
+    # strict subset of today's effective grants (operator-read-any's and compliance-read-any's
+    # read verbs, verbatim), so this rule changes no decision; what it changes is the
+    # decision_reason mix, which the D2(b) retirement triage reads to find where the matrix
+    # already carries the call. A role absent from the matrix yields an undefined lookup and
+    # the rule simply does not fire — fail-closed by construction.
+    # ---------------------------------------------------------------------------------------
+    allowed_reasons contains "matrix-allows" if {
+    	input.principal.type == "HUMAN"
+    	some role in input.principal.roles
+    	input.action in data.rules.authz.role_action_matrix[role].grant
     }
 
     # Operators and admins may list or read any resource on behalf of any party (support-desk
@@ -3475,5 +3490,95 @@ data:
           form: "a runnable skill that encodes the steps so they aren't re-derived each time"
       not_a_home:
         - "assistant session/local memory — does not travel to other agents or contributors, and may be stale"
+
+    # ADR-0223 D2 (phase 1, shadow): the role→action matrix as data. Seeded as the EXACT read
+    # half of today's operator-read-any (ROLE_OPERATOR/ROLE_ADMIN: every .list/.read) and
+    # compliance-read-any (ROLE_COMPLIANCE: every .read) — the action inventory is derived from
+    # the fleet-wide @Authorize coverage report (openbank-infra/scripts/authz-coverage-report.py),
+    # making this a provable subset of today's effective grants: rest.rego's matrix-allows reason
+    # grants nothing new, and decision_reason telemetry shows where the matrix already carries
+    # the call. Write grants (operator-<domain>-write etc.) join in phase 1.5 after the D2(b)
+    # triage; the retirement of operator-read-any itself is D2(c), a separate PR.
+    authz:
+      role_action_matrix:
+        ROLE_OPERATOR:
+          grant:
+            - account.list
+            - account.read
+            - anacredit.list
+            - anacredit.read
+            - audit.read
+            - card.list
+            - card.read
+            - device.list
+            - dispatch.read
+            - fx.list
+            - fx.read
+            - interest.list
+            - interest.read
+            - ledger.list
+            - ledger.read
+            - lending.list
+            - lending.read
+            - notification.list
+            - notification.read
+            - sanctions.list
+            - sanctions.read
+            - sdd.list
+            - sdd.read
+            - statement.list
+            - statement.read
+            - swift.list
+            - swift.read
+            - transaction.list
+            - transaction.read
+        ROLE_ADMIN:
+          grant:
+            - account.list
+            - account.read
+            - anacredit.list
+            - anacredit.read
+            - audit.read
+            - card.list
+            - card.read
+            - device.list
+            - dispatch.read
+            - fx.list
+            - fx.read
+            - interest.list
+            - interest.read
+            - ledger.list
+            - ledger.read
+            - lending.list
+            - lending.read
+            - notification.list
+            - notification.read
+            - sanctions.list
+            - sanctions.read
+            - sdd.list
+            - sdd.read
+            - statement.list
+            - statement.read
+            - swift.list
+            - swift.read
+            - transaction.list
+            - transaction.read
+        ROLE_COMPLIANCE:
+          grant:
+            - account.read
+            - anacredit.read
+            - audit.read
+            - card.read
+            - dispatch.read
+            - fx.read
+            - interest.read
+            - ledger.read
+            - lending.read
+            - notification.read
+            - sanctions.read
+            - sdd.read
+            - statement.read
+            - swift.read
+            - transaction.read
   manifest.json: |
     {"roots": ["openbank/agents", "openbank/copilot", "openbank/rest", "agents", "rules"]}

--- a/openbank-infra/gitops/components/pid/pid-service.yaml
+++ b/openbank-infra/gitops/components/pid/pid-service.yaml
@@ -22,7 +22,7 @@ spec:
       annotations:
         # Rolls the pod when the OPA bundle changes — subPath mounts do NOT hot-reload.
         # Kept in sync by gen-pid-opa-bundle.sh (do not hand-edit).
-        openbank.tech/policy-checksum: "2864f8d1beb89959"
+        openbank.tech/policy-checksum: "e1feb36d958dbec2"
     spec:
       securityContext:
         runAsNonRoot: true

--- a/openbank-infra/gitops/components/psd2-service/psd2-opa-bundle.yaml
+++ b/openbank-infra/gitops/components/psd2-service/psd2-opa-bundle.yaml
@@ -9,7 +9,7 @@ metadata:
     app.kubernetes.io/name: psd2-service
     app.kubernetes.io/part-of: psd2
   annotations:
-    openbank.tech/policy-checksum: "952baed324dea0a8"
+    openbank.tech/policy-checksum: "697004d2818af3c2"
 data:
   rest.rego: |
     # SPDX-License-Identifier: Apache-2.0
@@ -145,6 +145,21 @@ data:
     	input.principal.id == input.resource.id
     	some verb in {"list", "read"}
     	endswith(input.action, sprintf(".%v", [verb]))
+    }
+
+    # ---------------------------------------------------------------------------------------
+    # ADR-0223 D2 phase 1 (shadow): the role->action matrix as data (rules.yaml: authz.
+    # role_action_matrix), granting ALONGSIDE the legacy reasons. The seed is derived as a
+    # strict subset of today's effective grants (operator-read-any's and compliance-read-any's
+    # read verbs, verbatim), so this rule changes no decision; what it changes is the
+    # decision_reason mix, which the D2(b) retirement triage reads to find where the matrix
+    # already carries the call. A role absent from the matrix yields an undefined lookup and
+    # the rule simply does not fire — fail-closed by construction.
+    # ---------------------------------------------------------------------------------------
+    allowed_reasons contains "matrix-allows" if {
+    	input.principal.type == "HUMAN"
+    	some role in input.principal.roles
+    	input.action in data.rules.authz.role_action_matrix[role].grant
     }
 
     # Operators and admins may list or read any resource on behalf of any party (support-desk
@@ -3548,5 +3563,95 @@ data:
           form: "a runnable skill that encodes the steps so they aren't re-derived each time"
       not_a_home:
         - "assistant session/local memory — does not travel to other agents or contributors, and may be stale"
+
+    # ADR-0223 D2 (phase 1, shadow): the role→action matrix as data. Seeded as the EXACT read
+    # half of today's operator-read-any (ROLE_OPERATOR/ROLE_ADMIN: every .list/.read) and
+    # compliance-read-any (ROLE_COMPLIANCE: every .read) — the action inventory is derived from
+    # the fleet-wide @Authorize coverage report (openbank-infra/scripts/authz-coverage-report.py),
+    # making this a provable subset of today's effective grants: rest.rego's matrix-allows reason
+    # grants nothing new, and decision_reason telemetry shows where the matrix already carries
+    # the call. Write grants (operator-<domain>-write etc.) join in phase 1.5 after the D2(b)
+    # triage; the retirement of operator-read-any itself is D2(c), a separate PR.
+    authz:
+      role_action_matrix:
+        ROLE_OPERATOR:
+          grant:
+            - account.list
+            - account.read
+            - anacredit.list
+            - anacredit.read
+            - audit.read
+            - card.list
+            - card.read
+            - device.list
+            - dispatch.read
+            - fx.list
+            - fx.read
+            - interest.list
+            - interest.read
+            - ledger.list
+            - ledger.read
+            - lending.list
+            - lending.read
+            - notification.list
+            - notification.read
+            - sanctions.list
+            - sanctions.read
+            - sdd.list
+            - sdd.read
+            - statement.list
+            - statement.read
+            - swift.list
+            - swift.read
+            - transaction.list
+            - transaction.read
+        ROLE_ADMIN:
+          grant:
+            - account.list
+            - account.read
+            - anacredit.list
+            - anacredit.read
+            - audit.read
+            - card.list
+            - card.read
+            - device.list
+            - dispatch.read
+            - fx.list
+            - fx.read
+            - interest.list
+            - interest.read
+            - ledger.list
+            - ledger.read
+            - lending.list
+            - lending.read
+            - notification.list
+            - notification.read
+            - sanctions.list
+            - sanctions.read
+            - sdd.list
+            - sdd.read
+            - statement.list
+            - statement.read
+            - swift.list
+            - swift.read
+            - transaction.list
+            - transaction.read
+        ROLE_COMPLIANCE:
+          grant:
+            - account.read
+            - anacredit.read
+            - audit.read
+            - card.read
+            - dispatch.read
+            - fx.read
+            - interest.read
+            - ledger.read
+            - lending.read
+            - notification.read
+            - sanctions.read
+            - sdd.read
+            - statement.read
+            - swift.read
+            - transaction.read
   manifest.json: |
     {"roots": ["openbank/agents", "openbank/copilot", "openbank/rest", "agents", "rules"]}

--- a/openbank-infra/gitops/components/psd2-service/psd2-service.yaml
+++ b/openbank-infra/gitops/components/psd2-service/psd2-service.yaml
@@ -18,7 +18,7 @@ spec:
       annotations:
         # Rolls the pod when the OPA bundle changes — subPath mounts do NOT hot-reload.
         # Kept in sync by gen-psd2-opa-bundle.sh (do not hand-edit).
-        openbank.tech/policy-checksum: "952baed324dea0a8"
+        openbank.tech/policy-checksum: "697004d2818af3c2"
       labels: {app.kubernetes.io/name: psd2-service, app.kubernetes.io/part-of: psd2}
     spec:
       securityContext:

--- a/openbank-infra/gitops/components/sanctions-service/sanctions-opa-bundle.yaml
+++ b/openbank-infra/gitops/components/sanctions-service/sanctions-opa-bundle.yaml
@@ -9,7 +9,7 @@ metadata:
     app.kubernetes.io/name: sanctions-service
     app.kubernetes.io/part-of: sanctions
   annotations:
-    openbank.tech/policy-checksum: "a8338376f7fca3fa"
+    openbank.tech/policy-checksum: "dcf89dde886de7d6"
 data:
   rest.rego: |
     # SPDX-License-Identifier: Apache-2.0
@@ -145,6 +145,21 @@ data:
     	input.principal.id == input.resource.id
     	some verb in {"list", "read"}
     	endswith(input.action, sprintf(".%v", [verb]))
+    }
+
+    # ---------------------------------------------------------------------------------------
+    # ADR-0223 D2 phase 1 (shadow): the role->action matrix as data (rules.yaml: authz.
+    # role_action_matrix), granting ALONGSIDE the legacy reasons. The seed is derived as a
+    # strict subset of today's effective grants (operator-read-any's and compliance-read-any's
+    # read verbs, verbatim), so this rule changes no decision; what it changes is the
+    # decision_reason mix, which the D2(b) retirement triage reads to find where the matrix
+    # already carries the call. A role absent from the matrix yields an undefined lookup and
+    # the rule simply does not fire — fail-closed by construction.
+    # ---------------------------------------------------------------------------------------
+    allowed_reasons contains "matrix-allows" if {
+    	input.principal.type == "HUMAN"
+    	some role in input.principal.roles
+    	input.action in data.rules.authz.role_action_matrix[role].grant
     }
 
     # Operators and admins may list or read any resource on behalf of any party (support-desk
@@ -3453,5 +3468,95 @@ data:
           form: "a runnable skill that encodes the steps so they aren't re-derived each time"
       not_a_home:
         - "assistant session/local memory — does not travel to other agents or contributors, and may be stale"
+
+    # ADR-0223 D2 (phase 1, shadow): the role→action matrix as data. Seeded as the EXACT read
+    # half of today's operator-read-any (ROLE_OPERATOR/ROLE_ADMIN: every .list/.read) and
+    # compliance-read-any (ROLE_COMPLIANCE: every .read) — the action inventory is derived from
+    # the fleet-wide @Authorize coverage report (openbank-infra/scripts/authz-coverage-report.py),
+    # making this a provable subset of today's effective grants: rest.rego's matrix-allows reason
+    # grants nothing new, and decision_reason telemetry shows where the matrix already carries
+    # the call. Write grants (operator-<domain>-write etc.) join in phase 1.5 after the D2(b)
+    # triage; the retirement of operator-read-any itself is D2(c), a separate PR.
+    authz:
+      role_action_matrix:
+        ROLE_OPERATOR:
+          grant:
+            - account.list
+            - account.read
+            - anacredit.list
+            - anacredit.read
+            - audit.read
+            - card.list
+            - card.read
+            - device.list
+            - dispatch.read
+            - fx.list
+            - fx.read
+            - interest.list
+            - interest.read
+            - ledger.list
+            - ledger.read
+            - lending.list
+            - lending.read
+            - notification.list
+            - notification.read
+            - sanctions.list
+            - sanctions.read
+            - sdd.list
+            - sdd.read
+            - statement.list
+            - statement.read
+            - swift.list
+            - swift.read
+            - transaction.list
+            - transaction.read
+        ROLE_ADMIN:
+          grant:
+            - account.list
+            - account.read
+            - anacredit.list
+            - anacredit.read
+            - audit.read
+            - card.list
+            - card.read
+            - device.list
+            - dispatch.read
+            - fx.list
+            - fx.read
+            - interest.list
+            - interest.read
+            - ledger.list
+            - ledger.read
+            - lending.list
+            - lending.read
+            - notification.list
+            - notification.read
+            - sanctions.list
+            - sanctions.read
+            - sdd.list
+            - sdd.read
+            - statement.list
+            - statement.read
+            - swift.list
+            - swift.read
+            - transaction.list
+            - transaction.read
+        ROLE_COMPLIANCE:
+          grant:
+            - account.read
+            - anacredit.read
+            - audit.read
+            - card.read
+            - dispatch.read
+            - fx.read
+            - interest.read
+            - ledger.read
+            - lending.read
+            - notification.read
+            - sanctions.read
+            - sdd.read
+            - statement.read
+            - swift.read
+            - transaction.read
   manifest.json: |
     {"roots": ["openbank/agents", "openbank/copilot", "openbank/rest", "agents", "rules"]}

--- a/openbank-infra/gitops/components/sanctions-service/sanctions-service.yaml
+++ b/openbank-infra/gitops/components/sanctions-service/sanctions-service.yaml
@@ -49,7 +49,7 @@ spec:
       annotations:
         # Rolls the pods when the OPA bundle changes — subPath mounts do NOT hot-reload.
         # Kept in sync by gen-sanctions-opa-bundle.sh (do not hand-edit).
-        openbank.tech/policy-checksum: "a8338376f7fca3fa"
+        openbank.tech/policy-checksum: "dcf89dde886de7d6"
     spec:
       securityContext:
         runAsNonRoot: true

--- a/openbank-infra/gitops/components/sca/sca-opa-bundle.yaml
+++ b/openbank-infra/gitops/components/sca/sca-opa-bundle.yaml
@@ -9,7 +9,7 @@ metadata:
     app.kubernetes.io/name: sca-service
     app.kubernetes.io/part-of: sca
   annotations:
-    openbank.tech/policy-checksum: "d0061cf496f6bea0"
+    openbank.tech/policy-checksum: "47f01a892e59d08b"
 data:
   rest.rego: |
     # SPDX-License-Identifier: Apache-2.0
@@ -145,6 +145,21 @@ data:
     	input.principal.id == input.resource.id
     	some verb in {"list", "read"}
     	endswith(input.action, sprintf(".%v", [verb]))
+    }
+
+    # ---------------------------------------------------------------------------------------
+    # ADR-0223 D2 phase 1 (shadow): the role->action matrix as data (rules.yaml: authz.
+    # role_action_matrix), granting ALONGSIDE the legacy reasons. The seed is derived as a
+    # strict subset of today's effective grants (operator-read-any's and compliance-read-any's
+    # read verbs, verbatim), so this rule changes no decision; what it changes is the
+    # decision_reason mix, which the D2(b) retirement triage reads to find where the matrix
+    # already carries the call. A role absent from the matrix yields an undefined lookup and
+    # the rule simply does not fire — fail-closed by construction.
+    # ---------------------------------------------------------------------------------------
+    allowed_reasons contains "matrix-allows" if {
+    	input.principal.type == "HUMAN"
+    	some role in input.principal.roles
+    	input.action in data.rules.authz.role_action_matrix[role].grant
     }
 
     # Operators and admins may list or read any resource on behalf of any party (support-desk
@@ -3489,5 +3504,95 @@ data:
           form: "a runnable skill that encodes the steps so they aren't re-derived each time"
       not_a_home:
         - "assistant session/local memory — does not travel to other agents or contributors, and may be stale"
+
+    # ADR-0223 D2 (phase 1, shadow): the role→action matrix as data. Seeded as the EXACT read
+    # half of today's operator-read-any (ROLE_OPERATOR/ROLE_ADMIN: every .list/.read) and
+    # compliance-read-any (ROLE_COMPLIANCE: every .read) — the action inventory is derived from
+    # the fleet-wide @Authorize coverage report (openbank-infra/scripts/authz-coverage-report.py),
+    # making this a provable subset of today's effective grants: rest.rego's matrix-allows reason
+    # grants nothing new, and decision_reason telemetry shows where the matrix already carries
+    # the call. Write grants (operator-<domain>-write etc.) join in phase 1.5 after the D2(b)
+    # triage; the retirement of operator-read-any itself is D2(c), a separate PR.
+    authz:
+      role_action_matrix:
+        ROLE_OPERATOR:
+          grant:
+            - account.list
+            - account.read
+            - anacredit.list
+            - anacredit.read
+            - audit.read
+            - card.list
+            - card.read
+            - device.list
+            - dispatch.read
+            - fx.list
+            - fx.read
+            - interest.list
+            - interest.read
+            - ledger.list
+            - ledger.read
+            - lending.list
+            - lending.read
+            - notification.list
+            - notification.read
+            - sanctions.list
+            - sanctions.read
+            - sdd.list
+            - sdd.read
+            - statement.list
+            - statement.read
+            - swift.list
+            - swift.read
+            - transaction.list
+            - transaction.read
+        ROLE_ADMIN:
+          grant:
+            - account.list
+            - account.read
+            - anacredit.list
+            - anacredit.read
+            - audit.read
+            - card.list
+            - card.read
+            - device.list
+            - dispatch.read
+            - fx.list
+            - fx.read
+            - interest.list
+            - interest.read
+            - ledger.list
+            - ledger.read
+            - lending.list
+            - lending.read
+            - notification.list
+            - notification.read
+            - sanctions.list
+            - sanctions.read
+            - sdd.list
+            - sdd.read
+            - statement.list
+            - statement.read
+            - swift.list
+            - swift.read
+            - transaction.list
+            - transaction.read
+        ROLE_COMPLIANCE:
+          grant:
+            - account.read
+            - anacredit.read
+            - audit.read
+            - card.read
+            - dispatch.read
+            - fx.read
+            - interest.read
+            - ledger.read
+            - lending.read
+            - notification.read
+            - sanctions.read
+            - sdd.read
+            - statement.read
+            - swift.read
+            - transaction.read
   manifest.json: |
     {"roots": ["openbank/agents", "openbank/copilot", "openbank/rest", "agents", "rules"]}

--- a/openbank-infra/gitops/components/sca/sca-service.yaml
+++ b/openbank-infra/gitops/components/sca/sca-service.yaml
@@ -28,7 +28,7 @@ spec:
       annotations:
         # Rolls the pods when the OPA bundle changes — subPath mounts do NOT hot-reload.
         # Kept in sync by gen-sca-opa-bundle.sh (do not hand-edit).
-        openbank.tech/policy-checksum: "d0061cf496f6bea0"
+        openbank.tech/policy-checksum: "47f01a892e59d08b"
     spec:
       securityContext:
         runAsNonRoot: true

--- a/openbank-infra/gitops/components/statements/statement-opa-bundle.yaml
+++ b/openbank-infra/gitops/components/statements/statement-opa-bundle.yaml
@@ -9,7 +9,7 @@ metadata:
     app.kubernetes.io/name: statement-service
     app.kubernetes.io/part-of: statements
   annotations:
-    openbank.tech/policy-checksum: "8de6229901d4eb37"
+    openbank.tech/policy-checksum: "0a7859b4aed42d43"
 data:
   rest.rego: |
     # SPDX-License-Identifier: Apache-2.0
@@ -145,6 +145,21 @@ data:
     	input.principal.id == input.resource.id
     	some verb in {"list", "read"}
     	endswith(input.action, sprintf(".%v", [verb]))
+    }
+
+    # ---------------------------------------------------------------------------------------
+    # ADR-0223 D2 phase 1 (shadow): the role->action matrix as data (rules.yaml: authz.
+    # role_action_matrix), granting ALONGSIDE the legacy reasons. The seed is derived as a
+    # strict subset of today's effective grants (operator-read-any's and compliance-read-any's
+    # read verbs, verbatim), so this rule changes no decision; what it changes is the
+    # decision_reason mix, which the D2(b) retirement triage reads to find where the matrix
+    # already carries the call. A role absent from the matrix yields an undefined lookup and
+    # the rule simply does not fire — fail-closed by construction.
+    # ---------------------------------------------------------------------------------------
+    allowed_reasons contains "matrix-allows" if {
+    	input.principal.type == "HUMAN"
+    	some role in input.principal.roles
+    	input.action in data.rules.authz.role_action_matrix[role].grant
     }
 
     # Operators and admins may list or read any resource on behalf of any party (support-desk
@@ -3519,5 +3534,95 @@ data:
           form: "a runnable skill that encodes the steps so they aren't re-derived each time"
       not_a_home:
         - "assistant session/local memory — does not travel to other agents or contributors, and may be stale"
+
+    # ADR-0223 D2 (phase 1, shadow): the role→action matrix as data. Seeded as the EXACT read
+    # half of today's operator-read-any (ROLE_OPERATOR/ROLE_ADMIN: every .list/.read) and
+    # compliance-read-any (ROLE_COMPLIANCE: every .read) — the action inventory is derived from
+    # the fleet-wide @Authorize coverage report (openbank-infra/scripts/authz-coverage-report.py),
+    # making this a provable subset of today's effective grants: rest.rego's matrix-allows reason
+    # grants nothing new, and decision_reason telemetry shows where the matrix already carries
+    # the call. Write grants (operator-<domain>-write etc.) join in phase 1.5 after the D2(b)
+    # triage; the retirement of operator-read-any itself is D2(c), a separate PR.
+    authz:
+      role_action_matrix:
+        ROLE_OPERATOR:
+          grant:
+            - account.list
+            - account.read
+            - anacredit.list
+            - anacredit.read
+            - audit.read
+            - card.list
+            - card.read
+            - device.list
+            - dispatch.read
+            - fx.list
+            - fx.read
+            - interest.list
+            - interest.read
+            - ledger.list
+            - ledger.read
+            - lending.list
+            - lending.read
+            - notification.list
+            - notification.read
+            - sanctions.list
+            - sanctions.read
+            - sdd.list
+            - sdd.read
+            - statement.list
+            - statement.read
+            - swift.list
+            - swift.read
+            - transaction.list
+            - transaction.read
+        ROLE_ADMIN:
+          grant:
+            - account.list
+            - account.read
+            - anacredit.list
+            - anacredit.read
+            - audit.read
+            - card.list
+            - card.read
+            - device.list
+            - dispatch.read
+            - fx.list
+            - fx.read
+            - interest.list
+            - interest.read
+            - ledger.list
+            - ledger.read
+            - lending.list
+            - lending.read
+            - notification.list
+            - notification.read
+            - sanctions.list
+            - sanctions.read
+            - sdd.list
+            - sdd.read
+            - statement.list
+            - statement.read
+            - swift.list
+            - swift.read
+            - transaction.list
+            - transaction.read
+        ROLE_COMPLIANCE:
+          grant:
+            - account.read
+            - anacredit.read
+            - audit.read
+            - card.read
+            - dispatch.read
+            - fx.read
+            - interest.read
+            - ledger.read
+            - lending.read
+            - notification.read
+            - sanctions.read
+            - sdd.read
+            - statement.read
+            - swift.read
+            - transaction.read
   manifest.json: |
     {"roots": ["openbank/agents", "openbank/copilot", "openbank/rest", "agents", "rules"]}

--- a/openbank-infra/gitops/components/statements/statement-service.yaml
+++ b/openbank-infra/gitops/components/statements/statement-service.yaml
@@ -26,7 +26,7 @@ spec:
       annotations:
         # Rolls the pod when the OPA bundle changes — subPath mounts do NOT hot-reload.
         # Kept in sync by gen-statement-opa-bundle.sh (do not hand-edit).
-        openbank.tech/policy-checksum: "8de6229901d4eb37"
+        openbank.tech/policy-checksum: "0a7859b4aed42d43"
       labels:
         app.kubernetes.io/name: statement-service
         app.kubernetes.io/part-of: statements

--- a/openbank-infra/gitops/components/tpp-registry/tpp-registry-opa-bundle.yaml
+++ b/openbank-infra/gitops/components/tpp-registry/tpp-registry-opa-bundle.yaml
@@ -9,7 +9,7 @@ metadata:
     app.kubernetes.io/name: tpp-registry-service
     app.kubernetes.io/part-of: tpp-registry
   annotations:
-    openbank.tech/policy-checksum: "dcde487a098693c1"
+    openbank.tech/policy-checksum: "9be6f488da1f7f58"
 data:
   rest.rego: |
     # SPDX-License-Identifier: Apache-2.0
@@ -145,6 +145,21 @@ data:
     	input.principal.id == input.resource.id
     	some verb in {"list", "read"}
     	endswith(input.action, sprintf(".%v", [verb]))
+    }
+
+    # ---------------------------------------------------------------------------------------
+    # ADR-0223 D2 phase 1 (shadow): the role->action matrix as data (rules.yaml: authz.
+    # role_action_matrix), granting ALONGSIDE the legacy reasons. The seed is derived as a
+    # strict subset of today's effective grants (operator-read-any's and compliance-read-any's
+    # read verbs, verbatim), so this rule changes no decision; what it changes is the
+    # decision_reason mix, which the D2(b) retirement triage reads to find where the matrix
+    # already carries the call. A role absent from the matrix yields an undefined lookup and
+    # the rule simply does not fire — fail-closed by construction.
+    # ---------------------------------------------------------------------------------------
+    allowed_reasons contains "matrix-allows" if {
+    	input.principal.type == "HUMAN"
+    	some role in input.principal.roles
+    	input.action in data.rules.authz.role_action_matrix[role].grant
     }
 
     # Operators and admins may list or read any resource on behalf of any party (support-desk
@@ -3456,5 +3471,95 @@ data:
           form: "a runnable skill that encodes the steps so they aren't re-derived each time"
       not_a_home:
         - "assistant session/local memory — does not travel to other agents or contributors, and may be stale"
+
+    # ADR-0223 D2 (phase 1, shadow): the role→action matrix as data. Seeded as the EXACT read
+    # half of today's operator-read-any (ROLE_OPERATOR/ROLE_ADMIN: every .list/.read) and
+    # compliance-read-any (ROLE_COMPLIANCE: every .read) — the action inventory is derived from
+    # the fleet-wide @Authorize coverage report (openbank-infra/scripts/authz-coverage-report.py),
+    # making this a provable subset of today's effective grants: rest.rego's matrix-allows reason
+    # grants nothing new, and decision_reason telemetry shows where the matrix already carries
+    # the call. Write grants (operator-<domain>-write etc.) join in phase 1.5 after the D2(b)
+    # triage; the retirement of operator-read-any itself is D2(c), a separate PR.
+    authz:
+      role_action_matrix:
+        ROLE_OPERATOR:
+          grant:
+            - account.list
+            - account.read
+            - anacredit.list
+            - anacredit.read
+            - audit.read
+            - card.list
+            - card.read
+            - device.list
+            - dispatch.read
+            - fx.list
+            - fx.read
+            - interest.list
+            - interest.read
+            - ledger.list
+            - ledger.read
+            - lending.list
+            - lending.read
+            - notification.list
+            - notification.read
+            - sanctions.list
+            - sanctions.read
+            - sdd.list
+            - sdd.read
+            - statement.list
+            - statement.read
+            - swift.list
+            - swift.read
+            - transaction.list
+            - transaction.read
+        ROLE_ADMIN:
+          grant:
+            - account.list
+            - account.read
+            - anacredit.list
+            - anacredit.read
+            - audit.read
+            - card.list
+            - card.read
+            - device.list
+            - dispatch.read
+            - fx.list
+            - fx.read
+            - interest.list
+            - interest.read
+            - ledger.list
+            - ledger.read
+            - lending.list
+            - lending.read
+            - notification.list
+            - notification.read
+            - sanctions.list
+            - sanctions.read
+            - sdd.list
+            - sdd.read
+            - statement.list
+            - statement.read
+            - swift.list
+            - swift.read
+            - transaction.list
+            - transaction.read
+        ROLE_COMPLIANCE:
+          grant:
+            - account.read
+            - anacredit.read
+            - audit.read
+            - card.read
+            - dispatch.read
+            - fx.read
+            - interest.read
+            - ledger.read
+            - lending.read
+            - notification.read
+            - sanctions.read
+            - sdd.read
+            - statement.read
+            - swift.read
+            - transaction.read
   manifest.json: |
     {"roots": ["openbank/agents", "openbank/copilot", "openbank/rest", "agents", "rules"]}

--- a/openbank-infra/gitops/components/tpp-registry/tpp-registry-service.yaml
+++ b/openbank-infra/gitops/components/tpp-registry/tpp-registry-service.yaml
@@ -23,7 +23,7 @@ spec:
       annotations:
         # Rolls the pod when the OPA bundle changes (subPath mounts do not hot-reload).
         # Kept in sync by gen-tpp-registry-opa-bundle.sh (do not hand-edit).
-        openbank.tech/policy-checksum: "dcde487a098693c1"
+        openbank.tech/policy-checksum: "9be6f488da1f7f58"
     spec:
       securityContext:
         runAsNonRoot: true

--- a/openbank-libs/governance/policies/rest.rego
+++ b/openbank-libs/governance/policies/rest.rego
@@ -133,6 +133,21 @@ allowed_reasons contains "party-self-service" if {
 	endswith(input.action, sprintf(".%v", [verb]))
 }
 
+# ---------------------------------------------------------------------------------------
+# ADR-0223 D2 phase 1 (shadow): the role->action matrix as data (rules.yaml: authz.
+# role_action_matrix), granting ALONGSIDE the legacy reasons. The seed is derived as a
+# strict subset of today's effective grants (operator-read-any's and compliance-read-any's
+# read verbs, verbatim), so this rule changes no decision; what it changes is the
+# decision_reason mix, which the D2(b) retirement triage reads to find where the matrix
+# already carries the call. A role absent from the matrix yields an undefined lookup and
+# the rule simply does not fire — fail-closed by construction.
+# ---------------------------------------------------------------------------------------
+allowed_reasons contains "matrix-allows" if {
+	input.principal.type == "HUMAN"
+	some role in input.principal.roles
+	input.action in data.rules.authz.role_action_matrix[role].grant
+}
+
 # Operators and admins may list or read any resource on behalf of any party (support-desk
 # and onboarding cockpit paths, ADR-0068).
 allowed_reasons contains "operator-read-any" if {

--- a/openbank-libs/governance/policies/rest_test.rego
+++ b/openbank-libs/governance/policies/rest_test.rego
@@ -1172,3 +1172,48 @@ test_allow_when_the_register_key_is_absent if {
 
 	decision.allow == true
 }
+
+# ADR-0223 D2 phase 1 (shadow): the matrix grants a seeded read for a staff role — and the
+# reason surfaces, so the retirement triage can count matrix-carried calls.
+test_matrix_allows_grants_a_seeded_read if {
+	decision := rest.allow with input as {
+		"principal": {"id": "op-1", "type": "HUMAN", "roles": ["ROLE_OPERATOR"]},
+		"action": "account.read",
+	}
+		with data.openbank.bundle as bundle
+		with data.rules.authz as {"role_action_matrix": {"ROLE_OPERATOR": {"grant": ["account.read"]}}}
+
+	decision.allow == true
+	"matrix-allows" in rest.allowed_reasons with input as {
+		"principal": {"id": "op-1", "type": "HUMAN", "roles": ["ROLE_OPERATOR"]},
+		"action": "account.read",
+	}
+		with data.rules.authz as {"role_action_matrix": {"ROLE_OPERATOR": {"grant": ["account.read"]}}}
+}
+
+# An action outside the seed is NOT granted by the matrix (and by nothing else here) —
+# the matrix is an exact-action gate, not a prefix one.
+test_matrix_allows_does_not_grant_an_unseeded_action if {
+	not rest.allow with input as {
+		"principal": {"id": "op-1", "type": "HUMAN", "roles": ["ROLE_OPERATOR"]},
+		"action": "account.freeze",
+	}
+		with data.openbank.bundle as bundle
+		with data.rules.authz as {"role_action_matrix": {"ROLE_OPERATOR": {"grant": ["account.read"]}}}
+}
+
+# A role absent from the matrix: the lookup is undefined, the rule does not fire, and a
+# bundle whose rules.yaml predates the key sees no behaviour change.
+test_matrix_allows_absent_role_and_absent_key_are_silent if {
+	not rest.allowed_reasons["matrix-allows"] with input as {
+		"principal": {"id": "op-1", "type": "HUMAN", "roles": ["ROLE_NOPE"]},
+		"action": "account.read",
+	}
+		with data.rules.authz as {"role_action_matrix": {"ROLE_OPERATOR": {"grant": ["account.read"]}}}
+
+	not rest.allowed_reasons["matrix-allows"] with input as {
+		"principal": {"id": "op-1", "type": "HUMAN", "roles": ["ROLE_OPERATOR"]},
+		"action": "account.read",
+	}
+		with data.rules as {}
+}

--- a/openbank-libs/governance/rules.yaml
+++ b/openbank-libs/governance/rules.yaml
@@ -1995,3 +1995,93 @@ knowledge_capture:
       form: "a runnable skill that encodes the steps so they aren't re-derived each time"
   not_a_home:
     - "assistant session/local memory — does not travel to other agents or contributors, and may be stale"
+
+# ADR-0223 D2 (phase 1, shadow): the role→action matrix as data. Seeded as the EXACT read
+# half of today's operator-read-any (ROLE_OPERATOR/ROLE_ADMIN: every .list/.read) and
+# compliance-read-any (ROLE_COMPLIANCE: every .read) — the action inventory is derived from
+# the fleet-wide @Authorize coverage report (openbank-infra/scripts/authz-coverage-report.py),
+# making this a provable subset of today's effective grants: rest.rego's matrix-allows reason
+# grants nothing new, and decision_reason telemetry shows where the matrix already carries
+# the call. Write grants (operator-<domain>-write etc.) join in phase 1.5 after the D2(b)
+# triage; the retirement of operator-read-any itself is D2(c), a separate PR.
+authz:
+  role_action_matrix:
+    ROLE_OPERATOR:
+      grant:
+        - account.list
+        - account.read
+        - anacredit.list
+        - anacredit.read
+        - audit.read
+        - card.list
+        - card.read
+        - device.list
+        - dispatch.read
+        - fx.list
+        - fx.read
+        - interest.list
+        - interest.read
+        - ledger.list
+        - ledger.read
+        - lending.list
+        - lending.read
+        - notification.list
+        - notification.read
+        - sanctions.list
+        - sanctions.read
+        - sdd.list
+        - sdd.read
+        - statement.list
+        - statement.read
+        - swift.list
+        - swift.read
+        - transaction.list
+        - transaction.read
+    ROLE_ADMIN:
+      grant:
+        - account.list
+        - account.read
+        - anacredit.list
+        - anacredit.read
+        - audit.read
+        - card.list
+        - card.read
+        - device.list
+        - dispatch.read
+        - fx.list
+        - fx.read
+        - interest.list
+        - interest.read
+        - ledger.list
+        - ledger.read
+        - lending.list
+        - lending.read
+        - notification.list
+        - notification.read
+        - sanctions.list
+        - sanctions.read
+        - sdd.list
+        - sdd.read
+        - statement.list
+        - statement.read
+        - swift.list
+        - swift.read
+        - transaction.list
+        - transaction.read
+    ROLE_COMPLIANCE:
+      grant:
+        - account.read
+        - anacredit.read
+        - audit.read
+        - card.read
+        - dispatch.read
+        - fx.read
+        - interest.read
+        - ledger.read
+        - lending.read
+        - notification.read
+        - sanctions.read
+        - sdd.read
+        - statement.read
+        - swift.read
+        - transaction.read


### PR DESCRIPTION
## Summary

**ADR-0223 D2 phase 1** — the role→action authorization matrix lands as data, in shadow mode (grants nothing new):

- **`rules.yaml: authz.role_action_matrix`** — seeded as the EXACT read half of today's grants (OPERATOR/ADMIN: 29 fleet `.list`/`.read` actions; COMPLIANCE: 15 `.read`), derived from the `authz-coverage-report.py` inventory — a provable subset of current effective grants.
- **`rest.rego: matrix-allows`** — an ADDITIVE reason granting per the matrix. Because the seed is a strict subset, **no decision changes today**; what changes is the `decision_reason` mix, which the D2(b) `operator-read-any` retirement triage will read (SQL over decision reasons, by design).
- **3 policy tests** (grant seeded / deny unseeded / absent role+key silent). `opa test` **160/160**.
- Fleet OPA bundles regenerated (68 files) on the post-#2751 base.

Phases after this (separate PRs): D2(b) triage of what operator-read-any admits beyond the matrix → D2(c) retirement → D4 four-eyes flips → D5 UI matrix codegen (ADR-0229 D1).

## Type of change

- [x] feat (governance, shadow/no-op today)

## Linked issues

Refs #2750

## Definition of Done

- [x] opa test 160/160
- [x] Matrix seed derived (not hand-written) from the coverage inventory
- [x] Fleet bundles regenerated via the generator (no hand edits), rebased over #2751's regen
- [x] Commit signed (-s -S), conventional format