### PR TITLE
fix(ci): diff dependency-review against the merge-base, not pull_request.base.sha

### DIFF
--- a/.github/workflows/dependency-review.yml
+++ b/.github/workflows/dependency-review.yml
@@ -60,11 +60,64 @@ jobs:
             echo "No dependency manifest touched — no Gradle submission runs for this PR, so nothing to wait for."
           fi
 
+      # Diff against the MERGE-BASE, not `pull_request.base.sha` (issue #2833).
+      #
+      # A correct delta needs the base to satisfy BOTH conditions: carry a submitted
+      # snapshot, and be an ancestor of the head. `base.sha` is the tip of the base
+      # branch, so for any PR that is not freshly rebased it is neither — and when the
+      # basis is invalid the action silently falls back to reporting the ENTIRE head
+      # graph as additions, re-flagging every pre-existing transitive as if this PR
+      # introduced it.
+      #
+      # Measured 2026-07-31 against head 33334a2db (PR #2751), same head throughout:
+      #   base 98fc64c9c  snapshot=yes  ancestor=yes  ->    29 entries (the true delta)
+      #   base 27e83b42c  snapshot=yes  ancestor=NO   ->  1235 entries (whole graph)
+      #   base add0b5e83  snapshot=NO   ancestor=NO   ->  1235 entries  <- the real base.sha
+      # Ancestry alone is enough to break it: row 2 has a perfectly good snapshot.
+      #
+      # #2837 fixed the snapshot half by submitting a graph for every main commit, which
+      # is what makes the merge-base reliably snapshot-bearing from now on. This step is
+      # the other half. NOTE this is NOT the `base-ref: main` that was tried and rejected
+      # in #2833 — `main` resolves to a tip (not an ancestor); a merge-base is an ancestor
+      # by construction.
+      #
+      # Resolved via the compare API rather than `git merge-base`: actions/checkout is
+      # shallow here, and deepening until the merge-base appears is unbounded. Verified
+      # the API agrees with git on a real pair — `.merge_base_commit.sha` for
+      # add0b5e83...33334a2db returns 51364286f, identical to `git merge-base`.
+      - name: Resolve the merge-base to diff against
+        id: mb
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          BASE_SHA: ${{ github.event.pull_request.base.sha }}
+          HEAD_SHA: ${{ github.event.pull_request.head.sha }}
+        run: |
+          set -euo pipefail
+          # Fall back to base.sha rather than failing the gate: a resolution hiccup should
+          # degrade to today's (noisier) behaviour, not block every PR. The warning is the
+          # signal that the diff is untrustworthy — silence here would be the #2833 bug
+          # reintroduced one level up.
+          if mb="$(gh api "repos/${GITHUB_REPOSITORY}/compare/${BASE_SHA}...${HEAD_SHA}" \
+                    --jq '.merge_base_commit.sha' 2>/dev/null)" && [ -n "${mb}" ]; then
+            echo "Merge-base of ${BASE_SHA} and ${HEAD_SHA}: ${mb}"
+          else
+            mb="${BASE_SHA}"
+            echo "::warning title=merge-base unresolved::Could not resolve the merge-base; falling back to pull_request.base.sha (${BASE_SHA}). The dependency diff may report pre-existing packages as additions."
+          fi
+          echo "sha=${mb}" >> "$GITHUB_OUTPUT"
+
       - name: Dependency Review
         uses: actions/dependency-review-action@a1d282b36b6f3519aa1f3fc636f609c47dddb294 # v5.0.0
         with:
           fail-on-severity: high
           comment-summary-in-pr: always
+          # Both refs pinned explicitly so they are a coherent pair. head-ref is set to the
+          # value the action already defaults to on `pull_request` — the PR head SHA, which
+          # is what the Gradle snapshot is keyed on (the failing run's log named exactly
+          # this SHA: "No snapshots were found for the head SHA 33334a2db..."), so this is
+          # a no-op made visible rather than a behaviour change.
+          base-ref: ${{ steps.mb.outputs.sha }}
+          head-ref: ${{ github.event.pull_request.head.sha }}
           # This action only ever diffs SUBMITTED dependency graphs. Gradle — the fleet's
           # primary language — is not natively parsed by GitHub, so until
           # dependency-submission.yml also ran on pull_request (#1419) the Gradle half of


### PR DESCRIPTION
Second half of the fix for #2833. #2837 (merged) was the first half; on its own it is **necessary but not sufficient**.

## The two conditions

A correct dependency delta needs the base to **carry a submitted snapshot** *and* **be an ancestor of the head**. The original diagnosis in #2833 only recognised the first, and I overstated #2837's completeness on that basis — [corrected here](https://github.com/JiRaska/open-bank-oss/issues/2833#issuecomment-5142890751).

Measured against head `33334a2db` (PR #2751), same head throughout:

| base | snapshot | ancestor | entries |
|---|---|---|---|
| `98fc64c9c` | yes | **yes** | **29** — the true delta |
| `27e83b42c` | yes | no | 1235 — whole graph |
| `add0b5e83` — the real `base.sha` | no | no | 1235 — whole graph |
| `51364286f` — the merge-base | no | yes | 1235 — whole graph |

**Row 2 is the point.** Ancestry alone breaks it, with a perfectly good snapshot present. When the basis is invalid the action silently falls back to reporting the entire head graph as additions, re-flagging every pre-existing transitive as if this PR introduced it — which is how the `netty` and `protobuf` entries in `allow-ghsas` were accreted as permanent fleet-wide suppressions.

`pull_request.base.sha` is the tip of the base branch, so for any PR that is not freshly rebased it is not an ancestor of the head. That is the common case, not an edge case.

## Not the `base-ref` that was already rejected

#2833 tested `base-ref: main` and ruled it out. This is different: `main` resolves to a *tip*, which is not an ancestor of an unrebased head — so it failed for the same reason `base.sha` does. A **merge-base is an ancestor by construction**. The earlier negative result does not transfer.

The two halves compose: #2837 is what makes the merge-base reliably snapshot-bearing from here on.

## Implementation notes

Resolved through the compare API rather than `git merge-base`, because `actions/checkout` is shallow in this job and deepening until the merge-base appears is unbounded. Verified the API agrees with git on a real pair — `.merge_base_commit.sha` for `add0b5e83...33334a2db` returns `51364286f`, byte-identical to `git merge-base`.

`head-ref` is pinned to the value the action already defaults to on `pull_request` — the PR head SHA, which is what the Gradle snapshot is keyed on (the failing run's log named exactly that SHA: `No snapshots were found for the head SHA 33334a2db...`). It makes the pair explicit; it is not a behaviour change.

## Verification

- **Both branches of the new step exercised, not just the happy one.** A real SHA pair resolves and writes the merge-base to `GITHUB_OUTPUT`; an unresolvable base emits the `::warning` and falls back to `base.sha` **without failing the step** (exit 0 confirmed). Failing closed would block every PR on a transient API hiccup; staying silent would reintroduce the #2833 bug one level up — so it warns.
- `actionlint` — clean.
- `yamllint` under the exact config `ci.yml` builds — clean on branch **and** on `origin/main`'s copy. Probe validated: 99 findings under default config, so the clean run is not a silent no-op.
- Parsed the result rather than eyeballing the diff: step order is `checkout → Detect dependency-manifest changes → Resolve the merge-base → Dependency Review`, with `base-ref: ${{ steps.mb.outputs.sha }}`.

## What is NOT yet verified — read before merging

**This PR touches no dependency manifest, so the gate passes trivially on it and proves nothing about the change.** Green here means "not exercised" — exactly the vacuous-green shape #2833 is about.

End-to-end proof needs a manifest-touching PR whose **merge-base is a post-#2837 main commit**. No such PR exists yet, and the two obvious candidates are both ruled out:

- **#2751 is already MERGED** (its branch is deleted), so it can no longer be rebased. An earlier revision of this description named it as the verification candidate; that is no longer possible.
- **#2843** does touch a manifest (`openbank-mcp-service/build.gradle.kts`) and its head has a snapshot, but its merge-base `6a9b9f7c5` landed at 12:14:18Z — **four minutes before** #2837 merged at 12:18:17Z — so it has no snapshot. Measured, both ways: `base.sha...head` = 1235 entries, `merge-base...head` = 1235 entries. The merge-base half cannot help while the snapshot half is missing for that commit.

So the next manifest-touching PR branched from current `main` is the real test. What it must show: a small delta (tens of entries) instead of ~1235. If it still reports the whole graph, this change did not do what it claims.

### Evidence that the precondition now holds

All 6 main commits since #2837 have a `dependency-submission` run, and **none of them touches a manifest** — under the old filter every one would have had zero:

```
2b3cbe66a  completed/success   manifest=0
bebbf84ae  in_progress         manifest=0
57d293801  in_progress         manifest=0
9d84e02b8  in_progress         manifest=0
b325aee34  in_progress         manifest=0
7915cdf73  in_progress         manifest=0
```

Five running concurrently with none cancelling another also validates #2837's per-SHA concurrency change — under the old shared-group rule with `cancel-in-progress`, four of those five would have been killed.

## Still open on #2833

Items 4 and 5 are untouched here: the mismatch still proceeds silently, and the submitted graph still records pre-resolution coordinates that `resolutionStrategy` pins away. Measured on #2751, a correct base cuts findings from ~30 to ~2, **not to 0**.

## Release impact

None. `.github/workflows/` is not under any released package path.

Refs #2833

