### PR TITLE
fix(infra): grant the ESO cert reader access to the campaign-service keystore

### DIFF
--- a/openbank-infra/gitops/components/payments/kafka-scheme-accepted-acl.yaml
+++ b/openbank-infra/gitops/components/payments/kafka-scheme-accepted-acl.yaml
@@ -382,6 +382,7 @@ rules:
       - document-service                # ADR-0161/0162: document lifecycle events, ns documents (first ESO client there)
       - customer-edge                   # ADR-0086 audit trail + ADR-0072 resume, ns customer-edge (first ESO Kafka client there); missed by the #2665 sweep
       - analytics-sink                  # ADR-0022/0069: analytics bronze consumer (party/kyc/consent/sca/documents/onboarding-funnel), ns analytics (first ESO client there)
+      - campaign-service                # ADR-0200: campaign journey delivery requests, ns campaign (first ESO client there); missing entry blocked the whole sandbox rollout at sync-wave -1 (#2749)
       - openbank-cluster-cluster-ca-cert
 ---
 apiVersion: rbac.authorization.k8s.io/v1


### PR DESCRIPTION
## What

Adds `campaign-service` to the `resourceNames` allow-list of the
`eso-kafka-cert-reader` Role in `messaging`
(`openbank-infra/gitops/components/payments/kafka-scheme-accepted-acl.yaml`).

One additive line, least privilege — `get` on one more named secret. No new verb,
no list/watch, CA signing-key secrets still out of scope.

## Why

The campaign GitOps component (#2838) ships its own KafkaUser and kafka-mTLS
ExternalSecrets, but the cross-namespace reader's allow-list lives in the payments
component and was not updated. Measured on the live sandbox during the #2749 rollout:

```
secrets "campaign-service" is forbidden: User "system:serviceaccount:messaging:eso-kafka-cert-reader" cannot get resource "secrets" in API group "" in the namespace "messaging"
```

`KafkaUser campaign-service` is Ready and the Strimzi-minted secret exists in
`messaging` — only the RBAC entry is missing. Since the cert ExternalSecrets sync at
sync-wave -2/-1 and ArgoCD blocks on `SecretSynced`, the campaign Application never
progresses past that wave: CNPG `campaign-db` is not created and the pod never starts.
App state before this fix: `OutOfSync / Degraded`, sync retry #3.

## Note on the shape of the gap

Same class as the `customer-edge` entry ("missed by the #2665 sweep"): the allow-list
is a hand-kept coverage set maintained separately from the components it covers, so a
new namespace's first ESO Kafka client is silently denied and the failure surfaces only
at rollout time. Worth a follow-up that derives the list from the `KafkaUser` manifests
in `gitops/components/*` — filed as a note on #2749 rather than expanding this PR.

## Verification

- `yamllint` with the CI config (`line-length` disabled): clean.
- Reproduction and root cause read from the live `external-secrets` controller log,
  not inferred — the exact denial is quoted above.
- Post-merge check: ArgoCD reconciles the Role, the ExternalSecret goes `SecretSynced`,
  and the campaign sync proceeds to the CNPG wave.

Refs #2749