### PR TITLE
test(ci): end-to-end probe for the dependency-review merge-base fix (#2833)

### DIFF
--- a/openbank-simulation/build.gradle.kts
+++ b/openbank-simulation/build.gradle.kts
@@ -16,6 +16,12 @@
 // rung. It exercises the domain + application semantics faithfully (built on the real
 // `openbank-libs` primitives — Money, SagaStateMachine); it cannot catch JVM-threading
 // or OS-level non-determinism (that is the deferred Antithesis option).
+//
+// CI note: editing ANY `build.gradle.kts` — including a comment like this one, which
+// changes no dependency at all — matches the `**/build.gradle.kts` path filter in
+// dependency-submission.yml and dependency-review.yml, so it triggers a full ~11 min
+// fleet dependency resolution. That is deliberate (the filter cannot inspect intent),
+// but it means a comment-only touch here is not free. See issue #2833.
 
 plugins {
     alias(libs.plugins.kotlin.jvm)


### PR DESCRIPTION
**Draft, and intended to be CLOSED rather than merged** unless the comment it adds is judged worth keeping on its own. This exists to falsify #2848, which I have so far only verified in pieces.

## Why a probe was needed

Every earlier verification attempt failed for a different reason:

- **#2751** — already MERGED, branch deleted, cannot be rebased.
- **#2843** — touches a manifest and its head has a snapshot, but its merge-base `6a9b9f7c5` landed at 12:14:18Z, **four minutes before** #2837 merged at 12:18:17Z, so that commit has no snapshot. Measured both ways: `base.sha...head` = 1235, `merge-base...head` = 1235.
- **#2848 itself** — touches no manifest, so the gate passes trivially and proves nothing.

## Why this one is decisive

The change is **comment-only**, so the resolved dependency graph is bit-identical to its parent's. That removes the judgement call that made every other candidate weak:

| behaviour | expected entries |
|---|---|
| correct | **0** — nothing changed |
| broken | **1235** — whole head graph reported as additions |

No middle ground to argue about.

Branch point (the expected merge-base): `73c48273d`, a post-#2837 main commit, so it carries a snapshot.

## What each stage tests

1. **Now, with #2848 unmerged and `base.sha == merge-base`** — this exercises the #2837 half only. Expect 0 entries. If it reports 1235, then #2837 did not deliver what it claims and #2848 rests on a false premise.
2. **After main advances and this branch is pushed again**, `base.sha` moves to the new main tip while the merge-base stays at the branch point — they diverge. That is the state that isolates #2848: without it 1235, with it 0.

Stage 2 is the one that actually tests the merge-base change. Stage 1 is a precondition check.

## Cost

One ~11 min fleet resolution, $0 on hosted runners. Worth stating plainly: the comment this PR adds documents exactly that cost, which is the one genuinely reusable thing here.

Refs #2833