### PR TITLE
fix(infra): wire the ClickHouse credentials campaign-service needs to boot

### DIFF
--- a/openbank-infra/gitops/components/campaign/campaign-service.yaml
+++ b/openbank-infra/gitops/components/campaign/campaign-service.yaml
@@ -99,8 +99,23 @@ spec:
             - name: CONSENT_SERVICE_URL
               value: http://consent-service.consent.svc:8106
             # ADR-0210: read-only segment evaluation against the silver layer.
+            # ClickHouse requires auth: the `analytics` user, password from the
+            # Vault-backed clickhouse-auth Secret projected into this namespace
+            # (clickhouse-auth-externalsecret.yaml) — same pattern as admin-ui and
+            # analytics-sink. Both vars are REQUIRED at boot: SilverSegmentEvaluator
+            # declares them as non-Optional String with `defaultValue = ""`, and
+            # SmallRye treats an empty default as no value, so the pod CrashLoops on
+            # `Failed to load config value of type class java.lang.String` when they
+            # are unset — as it did on the first sandbox rollout (#2749).
             - name: CLICKHOUSE_URL
               value: http://clickhouse.analytics.svc:8123
+            - name: CLICKHOUSE_USER
+              value: analytics
+            - name: CLICKHOUSE_PASSWORD
+              valueFrom:
+                secretKeyRef:
+                  name: clickhouse-auth
+                  key: password
             - name: KEYCLOAK_URL
               value: http://keycloak.platform.svc:8080
             # ADR-0200 D6 suppression defaults; override per environment here, not in code.

--- a/openbank-infra/gitops/components/campaign/clickhouse-auth-externalsecret.yaml
+++ b/openbank-infra/gitops/components/campaign/clickhouse-auth-externalsecret.yaml
@@ -1,0 +1,33 @@
+# SPDX-License-Identifier: Apache-2.0
+# Copyright (c) OpenBank contributors. Licensed under the Apache License, Version 2.0.
+#
+# ClickHouse `analytics` user password, projected from Vault (KV mount openbank/, path
+# analytics-sink, field CLICKHOUSE_PASSWORD) into the campaign namespace. Consumed by
+# campaign-service's SilverSegmentEvaluator (ADR-0210), which evaluates segment membership
+# as a read-only query over the analytics silver layer.
+#
+# Same source key as the analytics and admin-ui projections of this secret — one password,
+# three namespaces, never committed in plaintext.
+apiVersion: external-secrets.io/v1beta1
+kind: ExternalSecret
+metadata:
+  name: clickhouse-auth
+  namespace: campaign
+  annotations:
+    # Must exist before the Deployment rolls: the pod mounts it as CLICKHOUSE_PASSWORD
+    # and fails to start without it.
+    argocd.argoproj.io/sync-wave: "-1"
+spec:
+  refreshInterval: 1h
+  secretStoreRef:
+    kind: ClusterSecretStore
+    name: vault-kv
+  target:
+    name: clickhouse-auth
+    creationPolicy: Owner
+    deletionPolicy: Retain
+  data:
+    - secretKey: password
+      remoteRef:
+        key: analytics-sink
+        property: CLICKHOUSE_PASSWORD


### PR DESCRIPTION
## What

- New `clickhouse-auth` ExternalSecret in the `campaign` namespace (Vault key `analytics-sink`,
  property `CLICKHOUSE_PASSWORD`), sync-wave -1.
- `CLICKHOUSE_USER` / `CLICKHOUSE_PASSWORD` on the campaign-service Deployment.

Identical to the projections `admin-ui` and `analytics-sink` already carry — one password, three
namespaces, nothing in plaintext.

## Why

Second blocker of the #2749 sandbox rollout. Once the cert RBAC (#2851) unstuck the sync, the pod
came up and CrashLooped:

```
Failed to load config value of type class java.lang.String for: analytics.clickhouse-password
Failed to load config value of type class java.lang.String for: analytics.clickhouse-user
```

`SilverSegmentEvaluator` (ADR-0210) injects both as non-Optional `String` with `defaultValue = ""`.
SmallRye treats an empty default as *no value*, so the bean cannot be constructed when the env vars
are unset — and the Deployment declared only `CLICKHOUSE_URL`. ClickHouse requires auth anyway, so
the credentials are needed on the merits, not just to satisfy the config layer.

## Verification

- `yamllint` with the CI config over the component directory: clean.
- `gen-network-policies.py` re-run: no diff. `clickhouse-ingress-allow-list` in `analytics` already
  admits the `campaign` namespace — the generator derived that edge from `CLICKHOUSE_URL`, which
  was already declared.
- Source key confirmed present in Vault and already consumed by two live, `SecretSynced`
  ExternalSecrets.

## Follow-up, deliberately not in this PR

`defaultValue = ""` on a non-Optional `String` is a boot-time trap: any environment that does not
set the var gets a CrashLoop with a message that names the property but not the cause, and
`@ApplicationScoped` laziness means no test constructs the bean. The house rule is
`Optional<String>` (root `CLAUDE.md`). Worth a sweep for other `defaultValue = ""` injections
rather than a one-service patch here.

Refs #2749