### PR TITLE
feat(infra): enable the staff OBO MCP channel in the sandbox (ADR-0224)

### DIFF
--- a/.github/asvs-l3-baseline.txt
+++ b/.github/asvs-l3-baseline.txt
@@ -151,6 +151,7 @@ V9.1 openbank-infra/gitops/components/balances/balance-service.yaml:121: plainte
 V9.1 openbank-infra/gitops/components/admin-ui/tier-classifier.yaml:108: plaintext http:// env value http://kube-prometheus-stack-prometheus.observability.svc:90
 V9.1 openbank-infra/gitops/components/admin-ui/admin-ui.yaml:85: plaintext http:// env value http://agent-service.platform.svc:8109/mcp
 V9.1 openbank-infra/gitops/components/admin-ui/admin-ui.yaml:91: plaintext http:// env value http://product-catalog.accounts.svc:8104
+V9.1 openbank-infra/gitops/components/admin-ui/admin-ui.yaml:92: plaintext http:// env value http://mcp-service.platform.svc:8150/mcp
 V9.1 openbank-infra/gitops/components/admin-ui/admin-ui.yaml:116: plaintext http:// env value http://security-scanner-service.security-scanner.svc:8120
 V9.1 openbank-infra/gitops/components/admin-ui/admin-ui.yaml:121: plaintext http:// env value http://tempo.observability.svc:3100
 V9.1 openbank-infra/gitops/components/admin-ui/admin-ui.yaml:127: plaintext http:// env value http://clickhouse.analytics.svc:8123

--- a/openbank-infra/gitops/components/admin-ui/admin-ui.yaml
+++ b/openbank-infra/gitops/components/admin-ui/admin-ui.yaml
@@ -83,6 +83,13 @@ spec:
             # at the in-cluster Service (agent-service lives in the platform ns).
             - name: AGENT_SERVICE_URL
               value: http://agent-service.platform.svc:8109/mcp
+            # ADR-0224 D4/D2: the staff OBO MCP channel (/api/agent/obo-mcp). The route
+            # 404s unless enabled; enabling requires the whole chain in place —
+            # realm permission (#2762), session store (#2843) and this flow (#2850).
+            - name: OBO_MCP_ENABLED
+              value: "true"
+            - name: MCP_SERVICE_URL
+              value: http://mcp-service.platform.svc:8150/mcp
             # Fees vertical (ADR-0051): the BFF /api/product-catalog/fees route
             # proxies the bank-wide fee schedule from product-catalog's in-cluster
             # Service rather than a hardcoded web-tier list. product-catalog is

--- a/openbank-infra/gitops/components/mcp/mcp-service.yaml
+++ b/openbank-infra/gitops/components/mcp/mcp-service.yaml
@@ -66,6 +66,11 @@ spec:
                 secretKeyRef:
                   name: mcp-db-app
                   key: password
+            # ADR-0224: admit staff OBO tokens at the resolver. Flip ONLY with the full
+            # chain live: realm permission (#2762), this service's session store (#2843),
+            # and the admin-ui OBO_MCP_ENABLED relay (#2850).
+            - name: MCP_OBO_ENABLED
+              value: "true"
             # ADR-0034 PDP: the OPA sidecar in this pod (localhost:8181), serving
             # data.openbank.rest.allow (mcp-opa-bundle ConfigMap). A PDP connectivity error
             # still fails CLOSED in McpEndpoint (money-adjacent surface — never fail-open).


### PR DESCRIPTION
## Summary

**DRAFT — merge ONLY after #2843 and #2850 land** (stacked on #2843's branch; the diff collapses to the two flag commits once it merges).

Flips the full ADR-0224 chain live in the sandbox:

- **`mcp-service`: `MCP_OBO_ENABLED=true`** — the resolver admits staff OBO tokens (live-validated against the session store).
- **`admin-ui`: `OBO_MCP_ENABLED=true`** — the `/api/agent/obo-mcp` relay route goes live (404s without it) + explicit `MCP_SERVICE_URL` on the app's real **8150** port.

Dependency chain (all must be live or the channel fails closed by design):
1. Realm permission — #2762 (merged)
2. Session store — #2843 (this PR's base)
3. BFF session flow — #2850 (merged or merging before this)
4. These two flags — this PR.

Rollback: revert → both flags return to off (resolver stops admitting staff tokens; the route 404s). No data migration affected (agent_session rows are harmless when the channel is off).

## Type of change

- [x] feat (gitops feature flags)

## Linked issues

Refs #2750

## Definition of Done

- [x] Stacked on #2843 (do not merge before it + #2850)
- [x] Both flags documented inline with the dependency chain
- [x] Commit signed (-s -S), conventional format