### PR TITLE
test(ci): diverged-base probe — isolates the merge-base fix from the snapshot fix (#2833)

### DIFF
--- a/openbank-security-scanner/build.gradle.kts
+++ b/openbank-security-scanner/build.gradle.kts
@@ -2,6 +2,11 @@
 // Copyright (c) OpenBank contributors. Licensed under the Apache License, Version 2.0.
 // See LICENSE in the repository root or https://www.apache.org/licenses/LICENSE-2.0 for details.
 
+// CI probe (#2833/#2848): comment-only, so the resolved graph is bit-identical to this
+// branch's parent. Cut from an OLDER main commit on purpose, so that pull_request.base.sha
+// (main's tip at PR-creation time) differs from the merge-base — the only state in which
+// the merge-base fix is distinguishable from the snapshot fix.
+
 plugins {
     id("openbank.quarkus-service")
 }


### PR DESCRIPTION
**Draft, to be CLOSED not merged.** Stage 2 of verifying #2848. Measures the BEFORE state deliberately, with #2848 still unmerged.

## Why #2854 could not do this

Probe #2854 was cut from main's tip, so `base.sha == merge-base` and only #2837's half was under test. I tried to force divergence by pushing an empty commit — **it did not work**: `pull_request.base.sha` stayed at `73c48273d` across the `synchronize` event.

That confirms the frozen-`base.sha` behaviour this repo already documents (#481 × #524, and the comment in `dependency-review.yml`'s detect step). `base.sha` is fixed at PR creation and does **not** track the base branch afterwards. So for a freshly-cut branch it equals the merge-base permanently, and no amount of pushing changes that.

Divergence has to be built in at creation time: branch from an **older** commit, open the PR **now**.

## Setup

- branch point / merge-base: `d9553237c` — post-#2837, snapshot completed
- `base.sha`: main's tip at PR creation — also post-#2837, also snapshot-bearing
- change: comment-only in `openbank-security-scanner/build.gradle.kts`, so the resolved graph is bit-identical to the branch point

Both candidate bases carry a snapshot, which is what makes this clean: **ancestry is the only remaining variable.**

| base | snapshot | ancestor | expected |
|---|---|---|---|
| `base.sha` (main tip) | yes | **no** | **1235** |
| merge-base `d9553237c` | yes | **yes** | **0** |

## Expected result of THIS run (#2848 unmerged)

**1235 added packages.** If it reports 0, then ancestry does not matter in practice and #2848 is unnecessary — which would be a useful negative result, not a failure.

Reading the log: the signal is the added-package count and whether `Retry timeout exceeded` appears. The `base SHA (0)` warning is transient polling noise and should NOT be used to judge this — see the [analysis on #2854](https://github.com/JiRaska/open-bank-oss/pull/2854#issuecomment-5143158796).

After #2848 merges, the same probe re-run must flip to 0.

Refs #2833