### PR TITLE
docs: note that a comment-only build.gradle.kts edit costs a full fleet resolution

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -400,6 +400,12 @@ Rationale + what does *not* cover it: `rules.yaml: dependencies.pr_time_cve_gate
   `No snapshots were found for the head SHA`) — armed unconditionally it burnt >11 min on PRs
   touching no manifest. Arm it only on dependency-touching PRs, and size the window from the
   measured ~24 min end-to-end, not the 734 s resolve (the documented 600 s cannot work here).
+- **Touching ANY `build.gradle.kts` — even to add a comment — costs a ~11 min fleet resolution.**
+  Both `dependency-submission.yml` and `dependency-review.yml` filter on `**/build.gradle.kts`,
+  and a path filter cannot inspect intent: a comment-only edit changes no dependency yet arms the
+  whole submit-and-wait path. So a drive-by comment in a service's build file is not free, and
+  batching a real manifest change with unrelated formatting costs nothing extra — but doing the
+  reverse (splitting a comment tweak into its own PR) buys an 11 min job for zero information.
 - **A red push-triggered workflow on `main` is addressed to nobody.** `dependency-submission` died
   of `Java heap space` for three days, red every run, while Dependabot and the gate quietly read the
   stale graph — neither goes red when it is stale. Anything whose *output* others depend on needs an


### PR DESCRIPTION
Salvages the one reusable fact from probe #2854 before it was closed, into the place it belongs rather than buried in one service's build file.

## The bullet

Added to `CLAUDE.md` → **Dependency graph & PR-time CVE gating**, directly after the existing `retry-on-snapshot-warnings` bullet — the two are complements:

- existing bullet: the retry firing on PRs that touch **no** manifest
- new bullet: the cost of touching a manifest **trivially**

## Why it is worth a line

Both `dependency-submission.yml` and `dependency-review.yml` filter on `**/build.gradle.kts`, and a path filter cannot inspect intent. A comment-only edit changes no dependency, yet arms the full submit-and-wait path — ~11 min.

Measured while building the #2833 probes: a comment-only touch to `openbank-simulation/build.gradle.kts` triggered a full fleet submission plus a `dependency-review` that waited on it. That was the point there (it made the expected delta unambiguously 0, which is what let the probe falsify anything), but as a drive-by it is a trap.

The practical consequence is stated in the bullet: batching a real manifest change with unrelated formatting costs nothing extra, while splitting a comment tweak into its own PR buys an 11 min job for zero information.

## Placement

Root `CLAUDE.md` rather than a scoped `<dir>/CLAUDE.md`, because it fires from anywhere in the fleet — any service's build file, and the two workflows that react are repo-level.

## Release impact

None — `docs` is a hidden type and `CLAUDE.md` is not under any released package path.

Refs #2833