### PR TITLE
fix(campaign): make the service actually boot — redis, OPA bundle mode, keycloak host

### DIFF
--- a/.github/asvs-l3-baseline.txt
+++ b/.github/asvs-l3-baseline.txt
@@ -198,7 +198,6 @@ V9.1 openbank-infra/gitops/components/document-service/document-service-service.
 V9.1 openbank-infra/gitops/components/release-steward/release-steward.yaml:58: plaintext http:// env value http://litellm.ai-platform.svc:4000
 V9.1 openbank-infra/gitops/components/campaign/campaign-service.yaml:100: plaintext http:// env value http://consent-service.consent.svc:8106
 V9.1 openbank-infra/gitops/components/campaign/campaign-service.yaml:103: plaintext http:// env value http://clickhouse.analytics.svc:8123
-V9.1 openbank-infra/gitops/components/campaign/campaign-service.yaml:105: plaintext http:// env value http://keycloak.platform.svc:8080
 V9.1 openbank-infra/gitops/components/billing/billing-service.yaml:62: plaintext http:// env value http://keda-add-ons-http-interceptor-proxy.keda:8080
 V9.1 openbank-infra/gitops/components/billing/billing-service.yaml:68: plaintext http:// env value http://account-service.accounts.svc:8100
 V9.1 openbank-infra/gitops/components/billing/billing-service.yaml:70: plaintext http:// env value http://balance-service.balances.svc:8103

--- a/openbank-campaign-service/src/main/resources/application.yaml
+++ b/openbank-campaign-service/src/main/resources/application.yaml
@@ -15,6 +15,12 @@ quarkus:
     password: ${DB_PASSWORD:campaign}
   flyway:
     migrate-at-start: true
+  # Backs the four-eyes approval store (libs' RedisApprovalStore, produced by
+  # ApprovalConfig). Without it the ReactiveRedisDataSource bean is inactive and the
+  # app cannot start — the deployed pod died with InactiveBeanException. Overridden
+  # per environment via QUARKUS_REDIS_HOSTS.
+  redis:
+    hosts: redis://localhost:6379
   oidc:
     auth-server-url: ${KEYCLOAK_URL:http://localhost:8080}/realms/openbank
     client-id: openbank-services

--- a/openbank-infra/gitops/components/campaign/campaign-service.yaml
+++ b/openbank-infra/gitops/components/campaign/campaign-service.yaml
@@ -116,8 +116,17 @@ spec:
                 secretKeyRef:
                   name: clickhouse-auth
                   key: password
+            # Keycloak runs in `iam`, not `platform` — the fleet's other 55 references all
+            # say keycloak.iam.svc. The wrong host does not fail the boot (OIDC defers the
+            # discovery to the first request), it just makes every authenticated call fail
+            # later with `Name does not resolve`.
             - name: KEYCLOAK_URL
-              value: http://keycloak.platform.svc:8080
+              value: http://keycloak.iam.svc:8080
+            # Four-eyes approval store (campaign.activate) is Redis-backed via
+            # libs' RedisApprovalStore. Without this the ReactiveRedisDataSource bean is
+            # inactive and the app dies at boot with InactiveBeanException.
+            - name: QUARKUS_REDIS_HOSTS
+              value: redis://redis.campaign.svc:6379
             # ADR-0200 D6 suppression defaults; override per environment here, not in code.
             - name: CAMPAIGN_MAX_SENDS_PER_WEEK
               value: "2"
@@ -179,8 +188,17 @@ spec:
           args:
             - run
             - --server
+            # Bind on the pod network (not 127.0.0.1) so kubelet httpGet probes reach
+            # /health. The image is scratch (no shell), so an exec probe isn't possible.
+            # Reachability is fenced by the NetworkPolicy; OPA serves only policy decisions.
             - --addr=0.0.0.0:8181
             - --log-level=info
+            # `--bundle` is REQUIRED, not decorative: without it OPA loads /bundle as a
+            # plain data directory and merges every YAML into the root data document, so
+            # rules-data.yaml and agents-data.yaml collide and the sidecar dies with
+            # `/bundle/rules-data.yaml: merge error`. In bundle mode the roots declared in
+            # .manifest keep them apart. Mount paths below must match those roots.
+            - --bundle
             - /bundle
           ports:
             - name: opa
@@ -220,18 +238,24 @@ spec:
               mountPath: /bundle/agents.rego
               subPath: agents.rego
               readOnly: true
+            # Data files land under the bundle roots declared in .manifest
+            # (`agents`, `rules`) — NOT flat in /bundle, which is what produced the
+            # merge error above.
             - name: opa-bundle
-              mountPath: /bundle/agents-data.yaml
+              mountPath: /bundle/agents/data.yaml
               subPath: agents-data.yaml
               readOnly: true
             - name: opa-bundle
-              mountPath: /bundle/rules-data.yaml
+              mountPath: /bundle/rules/data.yaml
               subPath: rules-data.yaml
               readOnly: true
             - name: opa-bundle
-              mountPath: /bundle/manifest.json
+              mountPath: /bundle/.manifest
               subPath: manifest.json
               readOnly: true
+            # OPA writes temp files during bundle load — required with readOnlyRootFilesystem.
+            - name: opa-tmp
+              mountPath: /tmp
       volumes:
         - name: tmp
           emptyDir: {}
@@ -243,6 +267,8 @@ spec:
           secret:
             secretName: kafka-cluster-ca-truststore
             optional: false
+        - name: opa-tmp
+          emptyDir: {}
         - name: opa-bundle
           configMap:
             name: campaign-opa-bundle

--- a/openbank-infra/gitops/components/campaign/network-policies.yaml
+++ b/openbank-infra/gitops/components/campaign/network-policies.yaml
@@ -62,3 +62,21 @@ spec:
       ports:
         - protocol: TCP
           port: 8085
+---
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: redis-ingress-allow-list
+  namespace: campaign
+  labels:
+    app.kubernetes.io/part-of: campaign
+    openbank.io/derived: gen-network-policies
+spec:
+  podSelector:
+    matchLabels:
+      app.kubernetes.io/name: redis
+  policyTypes:
+    - Ingress
+  ingress:
+    - from:
+        - podSelector: {}

--- a/openbank-infra/gitops/components/campaign/redis.yaml
+++ b/openbank-infra/gitops/components/campaign/redis.yaml
@@ -1,0 +1,89 @@
+# SPDX-License-Identifier: Apache-2.0
+# Copyright (c) OpenBank contributors. Licensed under the Apache License, Version 2.0.
+#
+# Redis backing the four-eyes approval store for campaign-service: `campaign.activate`
+# records the maker in Redis so the checker can be rejected when the two ids match
+# (ADR-0200). Same shape as the consent/accounts/billing namespaces — every namespace
+# running a service with libs' RedisApprovalStore carries its own instance.
+#
+# Ephemeral on purpose — persistence is disabled (--save "" --appendonly no), so a
+# restart clears in-flight approval records. Acceptable in the sandbox: a pending
+# approval simply has to be re-made. Prod should use an operator-managed HA Redis.
+# Pinned to the image's redis uid 999/gid 1000 to satisfy PSS restricted; /data is a
+# writable emptyDir so the root fs can stay read-only.
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: redis
+  namespace: campaign
+  labels:
+    app.kubernetes.io/name: redis
+    app.kubernetes.io/part-of: campaign
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app.kubernetes.io/name: redis
+  template:
+    metadata:
+      labels:
+        app.kubernetes.io/name: redis
+    spec:
+      securityContext:
+        runAsNonRoot: true
+        runAsUser: 999
+        runAsGroup: 1000
+        fsGroup: 1000
+        seccompProfile:
+          type: RuntimeDefault
+      containers:
+        - name: redis
+          image: docker.io/valkey/valkey:8-alpine
+          args: ["--save", "", "--appendonly", "no"]
+          ports:
+            - name: redis
+              containerPort: 6379
+          securityContext:
+            allowPrivilegeEscalation: false
+            readOnlyRootFilesystem: true
+            capabilities:
+              drop:
+                - ALL
+          volumeMounts:
+            - name: data
+              mountPath: /data
+          readinessProbe:
+            tcpSocket:
+              port: redis
+            initialDelaySeconds: 5
+            periodSeconds: 10
+          livenessProbe:
+            tcpSocket:
+              port: redis
+            initialDelaySeconds: 15
+            periodSeconds: 15
+          resources:
+            requests:
+              cpu: 50m
+              memory: 64Mi
+            limits:
+              cpu: 500m
+              memory: 192Mi
+      volumes:
+        - name: data
+          emptyDir: {}
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: redis
+  namespace: campaign
+  labels:
+    app.kubernetes.io/name: redis
+spec:
+  selector:
+    app.kubernetes.io/name: redis
+  ports:
+    - name: redis
+      port: 6379
+      targetPort: redis

--- a/openbank-infra/gitops/components/keycloak/network-policies.yaml
+++ b/openbank-infra/gitops/components/keycloak/network-policies.yaml
@@ -65,6 +65,9 @@ spec:
               kubernetes.io/metadata.name: billing
         - namespaceSelector:
             matchLabels:
+              kubernetes.io/metadata.name: campaign
+        - namespaceSelector:
+            matchLabels:
               kubernetes.io/metadata.name: consent
         - namespaceSelector:
             matchLabels:


### PR DESCRIPTION
## What

Three independent boot blockers in the campaign component, found by rolling it out
(#2749). Each kills the pod or the sidecar on first start.

| # | Symptom | Cause | Fix |
|---|---------|-------|-----|
| 1 | `InactiveBeanException: ReactiveRedisDataSource` | no `quarkus.redis.hosts`, no Redis in the namespace | config default + Redis workload + `QUARKUS_REDIS_HOSTS` |
| 2 | `/bundle/rules-data.yaml: merge error` | OPA ran in directory mode, data files mounted flat | `--bundle /bundle` + fleet mount layout + `/tmp` emptyDir |
| 3 | `keycloak.platform.svc: Name does not resolve` | wrong namespace | `keycloak.iam.svc` |

## Detail

**1 — Redis.** `ApprovalConfig` produces libs' `RedisApprovalStore` for the four-eyes
`campaign.activate` flow. campaign-service is the only service using that store whose
`application.yaml` never declared `quarkus.redis.hosts`, and the namespace ran no Redis at all,
so the bean is inactive and Quarkus refuses to start. The Redis manifest matches the
consent/accounts/billing shape (ephemeral, PSS-restricted, read-only root fs).

**2 — OPA.** Worth being precise about, because the bundle itself is fine:
`rules-data.yaml`, `agents-data.yaml`, `rest.rego` and `agents.rego` in the campaign ConfigMap are
**bit-identical** (same sha) to the ones the healthy consent sidecar loads. The Deployment passed
`/bundle` as a positional load path rather than `--bundle /bundle`, and mounted the data files flat
(`/bundle/rules-data.yaml`, `/bundle/manifest.json`). In directory mode OPA merges every YAML into
the root data document, so the two data files collide. Bundle mode keeps them apart under the roots
declared in `.manifest`. The `/tmp` emptyDir is required to unpack a bundle with
`readOnlyRootFilesystem: true` — consent carries it, campaign did not.

**3 — Keycloak.** `keycloak.platform.svc` was the only such reference in the tree; the other 55 say
`keycloak.iam.svc`. This one does not fail the boot — OIDC logs a warning and defers discovery to
the first request — so it would have shipped as "healthy" and failed every authenticated call.

## Derived files

`gen-network-policies.py` re-run; both diffs are consequences of the above, not hand edits:

- campaign gains `redis-ingress-allow-list` (new workload).
- the keycloak policy now admits the `campaign` namespace — the generator could only see that edge
  once `KEYCLOAK_URL` named a real service. That diff is itself evidence for fix 3.

`gen-campaign-opa-bundle.sh` re-run: no diff (no rego or `rules.yaml` change), so the
`policy-checksum` annotation is untouched.

## Verification

- `yamllint` with the CI config over both touched components: clean.
- `kubectl apply --dry-run=client` on the changed manifests: accepted.
- `application.yaml` parsed with a duplicate-key-rejecting loader: clean (SmallRye silently keeps
  the last of a repeated key).
- Symptoms 1–3 are quoted from the live sandbox pod logs, not inferred.

## What this says about the component

These are not edge cases — they are the first three seconds of the process. Together they mean the
Deployment had never been run before this rollout, which is worth remembering when a handoff
describes a component as complete because it is merged.

Refs #2749