### PR TITLE
test(party): pin the phone-directory hash so a backend-only change fails

### DIFF
--- a/openbank-party-service/src/test/kotlin/com/openbank/party/domain/PhoneDirectoryTest.kt
+++ b/openbank-party-service/src/test/kotlin/com/openbank/party/domain/PhoneDirectoryTest.kt
@@ -15,12 +15,27 @@ import org.junit.jupiter.api.Test
  */
 class PhoneDirectoryTest {
 
+    /**
+     * The same literal openbank-app's `PhoneNumbersTest` pins for this number.
+     *
+     * The two sides hash INDEPENDENTLY and compare the results, so agreeing on "some 64-hex
+     * string" is not agreement: a change to normalisation or to the encoding on either side leaves
+     * both suites green and surfaces to a customer as "your contact isn't on OpenBank" for someone
+     * who is. Pinning the same value on both sides is what turns a one-sided change into a failing
+     * test — before this, only the app pinned it, so a change HERE was the one direction nothing
+     * could catch.
+     *
+     * It is sha256("+420601123456"). Recompute it if it ever fails; copying a new value out of the
+     * failure message would only re-pin the drift.
+     */
+    private val pinned = "f417a9109171fe54f0433ef3af126615f06e2dacb615f11ffb59a4f7cdfd4c10"
+
     @Test
     fun `the same number written four ways hashes identically`() {
         val forms = listOf("+420 601 123 456", "+420601123456", "601 123 456", "00420601123456")
         val hashes = forms.map { PhoneDirectory.hash(it) }.toSet()
         assertThat(hashes).hasSize(1)
-        assertThat(hashes.single()).isNotNull()
+        assertThat(hashes.single()).isEqualTo(pinned)
     }
 
     @Test
@@ -43,7 +58,7 @@ class PhoneDirectoryTest {
 
     @Test
     fun `a hash is lowercase hex sha-256`() {
-        assertThat(PhoneDirectory.hash("+420601123456")).isNotNull().matches("[0-9a-f]{64}")
+        assertThat(PhoneDirectory.hash("+420601123456")).isEqualTo(pinned)
     }
 
     @Test


### PR DESCRIPTION
## The gap

`PhoneDirectory` and openbank-app's `PhoneNumbers` hash **independently** and compare the results, so the two must agree exactly. When they drift, a customer is told *"your contact isn't on OpenBank"* about someone who is — a silent halving of the hit rate, with no error anywhere.

Only the app pinned the expected value. This side asserted:

```kotlin
assertThat(hashes.single()).isNotNull()
assertThat(PhoneDirectory.hash("+420601123456")).isNotNull().matches("[0-9a-f]{64}")
```

— "some 64-hex string", plus that four written forms agree with **each other**. Both stay true after a change to normalisation or encoding *here*. So the one direction the guard existed to catch was the one it could not see.

## The fix

Pins `sha256("+420601123456")` on this side too — the same literal `PhoneNumbersTest` pins.

## Verified by falsification

Changing `CZ_COUNTRY_CODE` to `+421` with the app untouched:

| | before | after |
|---|---|---|
| tests red | **0** | **2** |

Full `:openbank-party-service:test` green (no failing suites), `ktlintCheck` + `detekt` clean.

## Type of change

- [x] test

## Linked issues

Refs #2840.