### PR TITLE
fix(campaign): open the management interface the probes and scrape target

### DIFF
--- a/openbank-campaign-service/src/main/resources/application.yaml
+++ b/openbank-campaign-service/src/main/resources/application.yaml
@@ -24,8 +24,25 @@ quarkus:
   oidc:
     auth-server-url: ${KEYCLOAK_URL:http://localhost:8080}/realms/openbank
     client-id: openbank-services
+  # Health probes and the Prometheus scrape live on the management interface, not the
+  # application port — the Deployment probes /q/health/{live,ready} on 8085 and the
+  # PodMonitor scrapes the same port. Without this block nothing listens there, so the
+  # pod never goes ready and the liveness probe restarts it forever.
+  management:
+    enabled: true
+    port: 8085
+    host: 0.0.0.0
+    root-path: /q
   log:
     level: INFO
+
+"%test":
+  quarkus:
+    # Tests bind a random application port (http.test-port: 0); the management
+    # interface has no such randomisation, so leaving it on makes two concurrent
+    # test JVMs fight over 8085.
+    management:
+      enabled: false
 
 openbank:
   temporal:


### PR DESCRIPTION
## What

Enables the Quarkus management interface on 8085 in campaign-service's `application.yaml`,
with a `"%test"` override disabling it.

## Why

The Deployment probes `/q/health/live` and `/q/health/ready` on port 8085, and the PodMonitor
scrapes the same port — but `application.yaml` declared only `quarkus.http.port: 8128` and no
`quarkus.management` block, so nothing ever listened there:

```
Readiness probe failed: dial tcp 10.80.180.14:8085: connect: connection refused
Liveness probe failed:  dial tcp 10.80.180.14:8085: connect: connection refused
```

The pod sits at 1/2 and the liveness failure restarts it indefinitely. The application itself is
fine — from the same pod's log, in order: Flyway validated 1 migration, Kafka producer and consumer
connected over mTLS, `Temporal worker started on task queue 'openbank-campaign'`, OPA sidecar
`ready=true`. The only thing missing is the port the platform watches.

## The `%test` override

Tests randomise the application port (`http.test-port: 0`); the management interface has no
equivalent, so leaving it enabled makes two concurrent test JVMs contend on 8085. consent-service
carries the same pair — this PR mirrors it.

## Verification

- `application.yaml` parsed with a duplicate-key-rejecting loader: clean, and the parsed values are
  the intended ones (`{enabled: True, port: 8085, host: 0.0.0.0, root-path: /q}`, test override
  `{enabled: False}`). SmallRye silently keeps the last of a repeated key, so this is worth checking
  rather than eyeballing.
- Probe failures quoted from the live pod.

## Context

Fifth defect found by actually rolling this component out (#2749), after the ESO cert RBAC (#2851),
the ClickHouse credentials (#2858), and the redis/OPA/keycloak trio (#2865). Each one is a
first-seconds-of-the-process failure. Worth asking separately whether anything could have caught
this class before a rollout — a probe port with no listener is mechanically checkable from the
Deployment plus the service config, and nothing in CI compares them.

Refs #2749