### PR TITLE
fix(ci): keep detached and buildscript configurations out of the dependency graph

### DIFF
--- a/.github/workflows/dependency-submission.yml
+++ b/.github/workflows/dependency-submission.yml
@@ -127,6 +127,42 @@ jobs:
         with:
           cache-read-only: ${{ github.ref != 'refs/heads/main' }}
           dependency-graph: generate-and-submit
+          # Keep detached and buildscript configurations OUT of the submitted graph (#2833).
+          #
+          # `configurations.all { resolutionStrategy { force(...) } }` — how
+          # openbank.dependency-vulnerability-pins applies the fleet-wide patch floors — does
+          # NOT reach configurations created via `detachedConfiguration(...)`. Those therefore
+          # resolve their own, older versions of the same modules, and every one of them lands
+          # in the submitted graph as a distinct coordinate that no service can ever load.
+          #
+          # Measured 2026-07-31 with the extractor's own `resolvedBy` report
+          # (`:ForceDependencyResolutionPlugin_resolveAllDependencies` + SimpleDependencyGraphPlugin):
+          #
+          #   io.netty:netty-codec-http:4.1.110  resolvedBy=1     path=:  detachedConfiguration11
+          #   io.netty:netty-codec-http:4.1.119  resolvedBy=1     path=:  detachedConfiguration11
+          #   io.netty:netty-codec-http:4.1.133  resolvedBy=1     path=:  detachedConfiguration11
+          #   io.netty:netty-codec-http:4.1.136  resolvedBy=1147  compile/runtimeClasspath × 56 projects
+          #
+          # 105 of 1389 resolved coordinates came exclusively from a detached configuration
+          # (104 from `detachedConfiguration11` alone), and they carried 24 of the 30
+          # vulnerability findings. `classpath` — the root project's BUILDSCRIPT classpath —
+          # accounted for 3 more. Filtering both takes the gate from 30 findings to 3, all
+          # `moderate`, i.e. below `fail-on-severity: high`.
+          #
+          # This does NOT narrow test coverage: testCompileClasspath, testRuntimeClasspath and
+          # integrationTest* are all still submitted. The surviving
+          # hibernate-reactive-core:3.4.2 finding is reported partly BECAUSE of its
+          # integration-test classpaths — that is the check that this filter is not too broad.
+          #
+          # Excluding `classpath` IS a deliberate scope reduction, unlike the detached case: a
+          # vulnerable build plugin never ships but does run on CI runners. Accepted because
+          # the buildscript graph is not what `block_on_cve_severity` is about; revisit if
+          # build-time supply-chain becomes an explicit goal.
+          #
+          # The regex is name-shaped, not identity-shaped, on purpose: Gradle renumbers
+          # `detachedConfiguration<N>` freely between builds and versions, so pinning to
+          # `detachedConfiguration11` would silently stop matching.
+          dependency-graph-exclude-configurations: '^(detachedConfiguration.*|classpath)$'
 
       # assemble resolves runtimeClasspath (what actually ships); testClasses additionally
       # resolves testCompileClasspath/testRuntimeClasspath — together the full graph the


### PR DESCRIPTION
Resolves item 5 of #2833 — the residual false positives that a correct base snapshot (#2837) does **not** eliminate.

## Root cause, measured

Ran the extractor's own diagnostic (`:ForceDependencyResolutionPlugin_resolveAllDependencies` with `SimpleDependencyGraphPlugin`) and read `resolvedBy` for every coordinate:

```
io.netty:netty-codec-http:4.1.110  resolvedBy=1     path=:  detachedConfiguration11
io.netty:netty-codec-http:4.1.119  resolvedBy=1     path=:  detachedConfiguration11
io.netty:netty-codec-http:4.1.133  resolvedBy=1     path=:  detachedConfiguration11
io.netty:netty-codec-http:4.1.136  resolvedBy=1147  compile/runtimeClasspath × 56 projects
```

Same shape for `protobuf-java` (3.21.7, 4.26.1 detached; 4.35.0 real) and `grpc-protobuf` (1.54.1, 1.72.0 detached; 1.81.0 real).

**`configurations.all { resolutionStrategy { force(...) } }` does not reach `detachedConfiguration(...)`.** The fleet pins in `openbank.dependency-vulnerability-pins` are fine; detached configurations are simply outside their reach, so they resolve their own older versions and every one is submitted as a coordinate no service can load.

**105 of 1389** resolved coordinates came exclusively from a detached configuration — 104 from `detachedConfiguration11` alone — carrying **24 of the 30** vulnerability findings. The root project's buildscript `classpath` accounted for 3 more.

## Impact

| | count |
|---|---|
| vulnerable entries today | 30 |
| removed by this filter | **27** |
| remaining | **3** |

Survivors, all genuinely resolved on real classpaths and all **moderate** (below `fail-on-severity: high`):

```
io.opentelemetry:opentelemetry-api:1.57.0             :openbank-libs-runtime, :openbank-libs-testing
org.hibernate.reactive:hibernate-reactive-core:3.2.11 :openbank-libs-runtime compileClasspath
org.hibernate.reactive:hibernate-reactive-core:3.4.2  46 services, compile + integrationTest classpaths
```

## Not too broad — the check

Test coverage is **not** narrowed. `testCompileClasspath`, `testRuntimeClasspath` and `integrationTest*` are all still submitted, and the surviving `hibernate-reactive-core:3.4.2` finding is reported partly *because* of its integration-test classpaths — that is the evidence.

The regex was validated against known-negatives that merely contain "Classpath":

```
must match:     detachedConfiguration11 ✓  detachedConfiguration7 ✓  classpath ✓
must NOT match: runtimeClasspath ✗  compileClasspath ✗  testRuntimeClasspath ✗
                integrationTestCompileClasspath ✗  annotationProcessor ✗
                quarkusTestBaseRuntimeClasspathConfiguration ✗
```

It is name-shaped rather than identity-shaped on purpose: Gradle renumbers `detachedConfiguration<N>` freely, so pinning to `detachedConfiguration11` would silently stop matching.

## One deliberate scope reduction

Excluding `classpath` — the root buildscript classpath — is a real narrowing, unlike the detached case: a vulnerable build plugin never ships, but it does run on CI runners. Accepted here because that is not what `block_on_cve_severity` is about. If build-time supply chain becomes an explicit goal it should be revisited, and `rules.yaml: dependencies.pr_time_cve_gate` should record the decision (kept out of this PR — editing `rules.yaml` restamps ~65 OPA bundles and belongs in its own change).

## What this does NOT do

**`allow-ghsas` is untouched.** All three current suppressions are for coordinates this filter removes:

| GHSAs | coordinate |
|---|---|
| `GHSA-pq2g-wx69-c263` | `net.minidev:json-smart:2.5.0` |
| `GHSA-3qp7-7mw8-wx86`, `-x4gw-5cx5-pgmh`, `-c653-97m9-rcg9` | `io.netty:netty-handler:4.2.1.Final` |
| `GHSA-prj3-ccx8-p6x4`, `-w9fj-cfpg-grvv`, `-f6hv-jmp6-3vwv` | `io.netty:netty-codec-http2:4.1.119.Final` |

So the list can be **emptied** — a coverage gain, since each entry currently also suppresses a future PR genuinely introducing that GHSA. But that must follow a *confirmed* submission, not ship blind alongside the filter: this PR touches no manifest, so its own `dependency-review` run cannot exercise the change. Sequencing is deliberate — land this, confirm the next main submission drops the detached coordinates, then empty the allowlist.

## Verification

- `actionlint` — clean
- `yamllint` under the exact config `ci.yml` builds — clean on branch and on `origin/main`'s copy; probe validated (140 findings under default config, so the clean run is not a no-op)
- input name confirmed against `setup-gradle`'s `action.yml` at the pinned SHA `3f131e86` — `dependency-graph-exclude-configurations` exists there (it is a different action from `dependency-submission`, so the name was checked rather than assumed)

## Release impact

None — `.github/workflows/` is not under any released package path.

Refs #2833