### PR TITLE
fix(campaign): snake_case column naming + the Temporal namespace the worker polls

### DIFF
--- a/openbank-campaign-service/src/main/resources/application.yaml
+++ b/openbank-campaign-service/src/main/resources/application.yaml
@@ -15,6 +15,13 @@ quarkus:
     password: ${DB_PASSWORD:campaign}
   flyway:
     migrate-at-start: true
+  hibernate-orm:
+    # Flyway schema is snake_case (segment_name, created_by, approved_by, …) but the JPA
+    # entities use camelCase fields with no @Column(name). Without this strategy
+    # Hibernate's default physical naming lowercases the field as-is → `approvedby`, so
+    # every read threw "column ce1_0.approvedby does not exist (42703)" and
+    # GET /api/v1/campaigns was 500. Same fix, same reason, as fx-service.
+    physical-naming-strategy: org.hibernate.boot.model.naming.CamelCaseToUnderscoresNamingStrategy
   # Backs the four-eyes approval store (libs' RedisApprovalStore, produced by
   # ApprovalConfig). Without it the ReactiveRedisDataSource bean is inactive and the
   # app cannot start — the deployed pod died with InactiveBeanException. Overridden

--- a/openbank-infra/gitops/components/campaign/campaign-service.yaml
+++ b/openbank-infra/gitops/components/campaign/campaign-service.yaml
@@ -90,6 +90,13 @@ spec:
               value: "true"
             - name: OPENBANK_TEMPORAL_SERVER_URL
               value: temporal-frontend.temporal.svc.cluster.local:7233
+            # Fleet convention is openbank-<domain>; the application default is the bare
+            # `openbank`, which is not a registered namespace. Leaving it unset does not
+            # fail the boot — readiness is an HTTP probe, not a Temporal one — the worker
+            # just spins on `NOT_FOUND: Namespace openbank is not found` while the pod
+            # reports Healthy. Registered by the temporal-namespace-registration Job.
+            - name: OPENBANK_TEMPORAL_NAMESPACE
+              value: openbank-campaign
             - name: OPENBANK_TEMPORAL_TASK_QUEUE
               value: openbank-campaign
             - name: CAMPAIGN_WORKER_ENABLED

--- a/openbank-infra/gitops/components/temporal/temporal-namespace-registration.yaml
+++ b/openbank-infra/gitops/components/temporal/temporal-namespace-registration.yaml
@@ -89,8 +89,11 @@ spec:
             # openbank-settlement (its own TemporalConfig @WithDefault, like fx/statements —
             # NOT openbank-default; an earlier comment here was wrong. The live worker polls
             # namespace="openbank-settlement", confirmed by NOT_FOUND on go-live — runbook 0006).
+            # campaign → openbank-campaign (ADR-0200 journeys), added on its first rollout:
+            # its Deployment had no OPENBANK_TEMPORAL_NAMESPACE, so the worker defaulted to
+            # the bare `openbank` and hit exactly the NOT_FOUND this Job exists to prevent.
             - name: NAMESPACES
-              value: "openbank-default openbank-payments openbank-fx openbank-statements openbank-settlement openbank-finops openbank-devops openbank-liveness openbank-governance openbank-release openbank-docstruth openbank-authzaudit openbank-flakytest"
+              value: "openbank-default openbank-payments openbank-fx openbank-statements openbank-settlement openbank-finops openbank-devops openbank-liveness openbank-governance openbank-release openbank-docstruth openbank-authzaudit openbank-flakytest openbank-campaign"
             - name: RETENTION
               value: "168h"
           command:


### PR DESCRIPTION
## What

Two defects found by driving the deployed service, after the pod reached 2/2 and
Prometheus reported `up=1`.

### 1. Every API read returns 500

```
GET /api/v1/campaigns -> HTTP 500
ERROR: column ce1_0.approvedby does not exist (42703)
```

The Flyway schema is snake_case (`segment_name`, `created_by`, `approved_by`) but the JPA
entities use camelCase fields with no `@Column(name)`. Without an explicit physical naming
strategy Hibernate lowercases the field as-is → `approvedby`.

`approved_by` is not special — it is just the first column Postgres rejects. `segmentName`,
`createdBy`, `stepsJson`, `currentStep` and the rest are equally unreachable, so no read
path works at all.

fx-service hit this exact bug; its `application.yaml` carries the same one-line fix with a
comment describing the same 42703. This PR adds it to campaign.

### 2. The Temporal worker has no namespace to poll

```
Temporal worker started on task queue 'openbank-campaign'        <- looks fine
NOT_FOUND: Namespace openbank is not found                       <- every poll, forever
```

The Deployment never set `OPENBANK_TEMPORAL_NAMESPACE`, so the application used its default
of the bare `openbank`, which is not a registered namespace — the fleet convention is
`openbank-<domain>`. Sets `openbank-campaign` and registers it in the
`temporal-namespace-registration` Job.

That Job's header already spells out the requirement:

> WHEN A SERVICE ADOPTS TEMPORAL: add its namespace to NAMESPACES below AND to the
> `temporal-platform-ingress` NetworkPolicy — both are required.

campaign was in the NetworkPolicy — which is why the gRPC call reached the frontend at all,
only to be told NOT_FOUND — but not in NAMESPACES.

## Worth noting about the signal quality

At the moment both of these were true, the pod was `2/2 Running`, restart count 0, and the
scrape target was healthy. Readiness is an HTTP probe on the management port; it cannot see
a broken ORM mapping or a worker polling a namespace that does not exist. This is the same
theme as #2872 — the controls were green about something they never examined — and it is
why I checked the API and the worker's actual behaviour rather than stopping at 2/2.

## Verification

- `application.yaml` parsed with a duplicate-key-rejecting loader; the strategy resolves to
  `CamelCaseToUnderscoresNamingStrategy`.
- `yamllint` with the CI config over both touched components: clean.
- `gen-network-policies.py` and `gen-campaign-opa-bundle.sh` re-run: no diff.
- Both symptoms quoted from the live pod, and the namespace absence confirmed directly:
  `temporal operator namespace list` returns 13 namespaces, none of them `openbank`.

Refs #2749