### PR TITLE
fix(keycloak): give app tokens the openbank-rum audience so mobile RUM can ingest

### DIFF
--- a/openbank-infra/gitops/components/keycloak/customers-realm-template.json
+++ b/openbank-infra/gitops/components/keycloak/customers-realm-template.json
@@ -112,6 +112,18 @@
             "id.token.claim": "false",
             "access.token.claim": "true"
           }
+        },
+        {
+          "comment": "Adds openbank-rum to the JWT aud claim. The mobile-RUM ingest gateway (ADR-0088 §D4, rum.open-bank.tech) is an OTel collector whose OIDC authenticator requires audience=openbank-rum, and openbank-rum is not a Keycloak client — it is a resource name — so it needs a CUSTOM audience, not a client one. Without this the app's session token carries only openbank-edge and every OTLP export is rejected 401: mobile RUM produced literally zero spans from the day it was switched on, and a crash's trace_id pointed at a trace that did not exist. id.token.claim=false keeps the ID token lean.",
+          "name": "openbank-rum-audience",
+          "protocol": "openid-connect",
+          "protocolMapper": "oidc-audience-mapper",
+          "consentRequired": false,
+          "config": {
+            "included.custom.audience": "openbank-rum",
+            "id.token.claim": "false",
+            "access.token.claim": "true"
+          }
         }
       ]
     },


### PR DESCRIPTION
## What

Mobile RUM (ADR-0088 §D4) has produced **zero spans since it was switched on**. Every OTLP export from the app answers 401, in every session, for every user:

```
POST https://rum.open-bank.tech/v1/traces -> 401 unauthorized  (response 129 B)
```

Found while debugging an unrelated iOS crash — the crash report's `trace_id` pointed at a Tempo trace that did not exist.

## Root cause

The `rum-gateway` collector requires a specific audience:

```yaml
# cm/rum-gateway, ns observability
extensions:
  oidc:
    audience: openbank-rum
    issuer_url: https://kc.open-bank.tech/realms/openbank-customers
```

The `openbank-app` client carried exactly one audience mapper, for `openbank-edge`. And `openbank-rum` is **not a Keycloak client** — it is a resource name, confirmed against the live realm's client list — so `included.client.audience` cannot produce it. It needs `included.custom.audience`.

So the token could never satisfy the gateway. Not a flake, not intermittent: a permanent misconfiguration that made the whole mobile-RUM pipeline inert from day one.

## Cost

Beyond the empty dashboards, this broke the crash → backend-trace pivot the ADR is built around. A crash report carries a `trace_id`, that trace was never ingested, and the lookup silently resolved to nothing — which reads exactly like "the trace expired" rather than "RUM is down".

## Also applied live

A realm import only runs on realm creation, so this file alone would not have fixed the running sandbox. The same mapper was added to the live `openbank-customers` realm with `kcadm` (mapper id `fe377e26-5b16-4ae9-b2bf-91f32872b3ef`). It is additive — services check membership in `aud`, not equality — and takes effect on newly issued tokens, not on ones clients already hold.

## Linked issues

N/A — the defect, its root cause and the live remediation are recorded above and in the commit message.

🤖 Generated with [Claude Code](https://claude.com/claude-code)