### PR TITLE
docs(governance): record the CVE gate's base-snapshot fix, scope and empty allowlist

### DIFF
--- a/openbank-infra/gitops/components/accounts/account-opa-bundle.yaml
+++ b/openbank-infra/gitops/components/accounts/account-opa-bundle.yaml
@@ -9,7 +9,7 @@ metadata:
     app.kubernetes.io/name: account-service
     app.kubernetes.io/part-of: accounts
   annotations:
-    openbank.tech/policy-checksum: "df5a50ebe9f48fa0"
+    openbank.tech/policy-checksum: "7d85808d9316893a"
 data:
   rest.rego: |
     # SPDX-License-Identifier: Apache-2.0
@@ -2703,9 +2703,44 @@ data:
           gate keeps reporting green while checking nothing about Gradle -- a silent hole, not a
           visible failure.
         requires:
-          - ".github/workflows/dependency-submission.yml runs on pull_request with the same path filter"
+          - ".github/workflows/dependency-submission.yml runs on pull_request with a manifest path filter"
+          - "its push:[main] trigger is DELIBERATELY UNFILTERED -- see base_snapshot below (#2833)"
           - "dependency-review arms retry-on-snapshot-warnings ONLY on dependency-touching PRs"
           - "dependency-submission failures raise a tracking issue (a stale graph makes the gate vacuous)"
+        base_snapshot: >
+          Snapshots are looked up by EXACT SHA and the compare endpoint is three-dot, so the graph
+          the gate diffs against is the MERGE-BASE of the PR -- an arbitrary main commit. While the
+          push:[main] trigger carried the same manifest path filter as the pull_request one, only
+          ~2% of main commits produced a snapshot (measured: 1 of 50), so the merge-base almost
+          never had one and the action silently fell back to reporting the ENTIRE head graph as
+          additions. That is how the allowlist below was accreted. The push trigger is therefore
+          unfiltered: every main commit submits, so the merge-base always resolves. Ancestry of
+          pull_request.base.sha is NOT a factor -- three-dot compare resolves the merge-base itself.
+        scope: >
+          detachedConfiguration* and the root buildscript `classpath` are EXCLUDED from the
+          submitted graph (dependency-graph-exclude-configurations). `configurations.all {
+          resolutionStrategy { force(...) } }` -- how openbank.dependency-vulnerability-pins applies
+          the fleet patch floors -- cannot reach a detachedConfiguration, so those resolve their own
+          older versions of the same modules and submit coordinates no service can load. Measured:
+          105 of 1389 resolved coordinates came only from a detached configuration and carried 24 of
+          30 findings; filtering both took the graph 1235 -> 1091 and findings 30 -> 3.
+          Test coverage is NOT reduced -- testCompileClasspath / testRuntimeClasspath /
+          integrationTest* are all still submitted.
+          Excluding `classpath` IS a deliberate narrowing: a vulnerable BUILD plugin never ships but
+          does run on CI runners, and this gate is about what ships. Revisit if build-time supply
+          chain becomes an explicit goal.
+        allowlist: >
+          allow-ghsas is DELIBERATELY EMPTY. It held seven suppressions (json-smart 2.5.0,
+          netty-handler 4.2.1, netty-codec-http2 4.1.119), every one silencing a coordinate that
+          only ever existed via a detached/buildscript configuration -- removed at source by the
+          scope filter above instead. An allow-ghsas entry is a PERMANENT FLEET-WIDE suppression: it
+          hides the pre-existing false positive it was added for AND a future PR that genuinely
+          introduces the same GHSA on a real classpath, so each entry buys quiet with a hole.
+          Before adding one, run the extractor's own diagnostic
+          (:ForceDependencyResolutionPlugin_resolveAllDependencies + SimpleDependencyGraphPlugin)
+          and read `resolvedBy` in dependency-resolution.json: a single entry naming a detached or
+          buildscript configuration is a graph artifact -- widen the scope filter, do not allowlist.
+          Entries naming a real *Classpath are a genuine finding -- bump the pin.
         not_covered_by:
           trivy_fs: "Trivy's Java coverage is JAR / pom.xml / gradle.lockfile / *.sbt.lock only; this repo has zero lockfiles, so Trivy fs sees no Gradle dependency"
           codeql: "not a dependency scanner, and not a required check"

--- a/openbank-infra/gitops/components/accounts/account-service.yaml
+++ b/openbank-infra/gitops/components/accounts/account-service.yaml
@@ -37,7 +37,7 @@ spec:
       annotations:
         # Rolls the pod when the OPA bundle changes — subPath mounts do NOT hot-reload.
         # Kept in sync by gen-account-opa-bundle.sh (do not hand-edit).
-        openbank.tech/policy-checksum: "df5a50ebe9f48fa0"
+        openbank.tech/policy-checksum: "7d85808d9316893a"
     spec:
       securityContext:
         runAsNonRoot: true

--- a/openbank-infra/gitops/components/aml/aml-opa-bundle.yaml
+++ b/openbank-infra/gitops/components/aml/aml-opa-bundle.yaml
@@ -9,7 +9,7 @@ metadata:
     app.kubernetes.io/name: aml-service
     app.kubernetes.io/part-of: aml
   annotations:
-    openbank.tech/policy-checksum: "2d14dd777bf66322"
+    openbank.tech/policy-checksum: "541ff369976336d4"
 data:
   rest.rego: |
     # SPDX-License-Identifier: Apache-2.0
@@ -2676,9 +2676,44 @@ data:
           gate keeps reporting green while checking nothing about Gradle -- a silent hole, not a
           visible failure.
         requires:
-          - ".github/workflows/dependency-submission.yml runs on pull_request with the same path filter"
+          - ".github/workflows/dependency-submission.yml runs on pull_request with a manifest path filter"
+          - "its push:[main] trigger is DELIBERATELY UNFILTERED -- see base_snapshot below (#2833)"
           - "dependency-review arms retry-on-snapshot-warnings ONLY on dependency-touching PRs"
           - "dependency-submission failures raise a tracking issue (a stale graph makes the gate vacuous)"
+        base_snapshot: >
+          Snapshots are looked up by EXACT SHA and the compare endpoint is three-dot, so the graph
+          the gate diffs against is the MERGE-BASE of the PR -- an arbitrary main commit. While the
+          push:[main] trigger carried the same manifest path filter as the pull_request one, only
+          ~2% of main commits produced a snapshot (measured: 1 of 50), so the merge-base almost
+          never had one and the action silently fell back to reporting the ENTIRE head graph as
+          additions. That is how the allowlist below was accreted. The push trigger is therefore
+          unfiltered: every main commit submits, so the merge-base always resolves. Ancestry of
+          pull_request.base.sha is NOT a factor -- three-dot compare resolves the merge-base itself.
+        scope: >
+          detachedConfiguration* and the root buildscript `classpath` are EXCLUDED from the
+          submitted graph (dependency-graph-exclude-configurations). `configurations.all {
+          resolutionStrategy { force(...) } }` -- how openbank.dependency-vulnerability-pins applies
+          the fleet patch floors -- cannot reach a detachedConfiguration, so those resolve their own
+          older versions of the same modules and submit coordinates no service can load. Measured:
+          105 of 1389 resolved coordinates came only from a detached configuration and carried 24 of
+          30 findings; filtering both took the graph 1235 -> 1091 and findings 30 -> 3.
+          Test coverage is NOT reduced -- testCompileClasspath / testRuntimeClasspath /
+          integrationTest* are all still submitted.
+          Excluding `classpath` IS a deliberate narrowing: a vulnerable BUILD plugin never ships but
+          does run on CI runners, and this gate is about what ships. Revisit if build-time supply
+          chain becomes an explicit goal.
+        allowlist: >
+          allow-ghsas is DELIBERATELY EMPTY. It held seven suppressions (json-smart 2.5.0,
+          netty-handler 4.2.1, netty-codec-http2 4.1.119), every one silencing a coordinate that
+          only ever existed via a detached/buildscript configuration -- removed at source by the
+          scope filter above instead. An allow-ghsas entry is a PERMANENT FLEET-WIDE suppression: it
+          hides the pre-existing false positive it was added for AND a future PR that genuinely
+          introduces the same GHSA on a real classpath, so each entry buys quiet with a hole.
+          Before adding one, run the extractor's own diagnostic
+          (:ForceDependencyResolutionPlugin_resolveAllDependencies + SimpleDependencyGraphPlugin)
+          and read `resolvedBy` in dependency-resolution.json: a single entry naming a detached or
+          buildscript configuration is a graph artifact -- widen the scope filter, do not allowlist.
+          Entries naming a real *Classpath are a genuine finding -- bump the pin.
         not_covered_by:
           trivy_fs: "Trivy's Java coverage is JAR / pom.xml / gradle.lockfile / *.sbt.lock only; this repo has zero lockfiles, so Trivy fs sees no Gradle dependency"
           codeql: "not a dependency scanner, and not a required check"

--- a/openbank-infra/gitops/components/aml/aml-service.yaml
+++ b/openbank-infra/gitops/components/aml/aml-service.yaml
@@ -22,7 +22,7 @@ spec:
       annotations:
         # Rolls the pod when the OPA bundle changes (subPath mounts do not hot-reload).
         # Kept in sync by gen-aml-opa-bundle.sh (do not hand-edit).
-        openbank.tech/policy-checksum: "2d14dd777bf66322"
+        openbank.tech/policy-checksum: "541ff369976336d4"
     spec:
       securityContext:
         runAsNonRoot: true

--- a/openbank-infra/gitops/components/anacredit/anacredit-opa-bundle.yaml
+++ b/openbank-infra/gitops/components/anacredit/anacredit-opa-bundle.yaml
@@ -9,7 +9,7 @@ metadata:
     app.kubernetes.io/name: anacredit-service
     app.kubernetes.io/part-of: anacredit
   annotations:
-    openbank.tech/policy-checksum: "49fe7413162bf55d"
+    openbank.tech/policy-checksum: "968c5e0e5c84494a"
 data:
   rest.rego: |
     # SPDX-License-Identifier: Apache-2.0
@@ -2646,9 +2646,44 @@ data:
           gate keeps reporting green while checking nothing about Gradle -- a silent hole, not a
           visible failure.
         requires:
-          - ".github/workflows/dependency-submission.yml runs on pull_request with the same path filter"
+          - ".github/workflows/dependency-submission.yml runs on pull_request with a manifest path filter"
+          - "its push:[main] trigger is DELIBERATELY UNFILTERED -- see base_snapshot below (#2833)"
           - "dependency-review arms retry-on-snapshot-warnings ONLY on dependency-touching PRs"
           - "dependency-submission failures raise a tracking issue (a stale graph makes the gate vacuous)"
+        base_snapshot: >
+          Snapshots are looked up by EXACT SHA and the compare endpoint is three-dot, so the graph
+          the gate diffs against is the MERGE-BASE of the PR -- an arbitrary main commit. While the
+          push:[main] trigger carried the same manifest path filter as the pull_request one, only
+          ~2% of main commits produced a snapshot (measured: 1 of 50), so the merge-base almost
+          never had one and the action silently fell back to reporting the ENTIRE head graph as
+          additions. That is how the allowlist below was accreted. The push trigger is therefore
+          unfiltered: every main commit submits, so the merge-base always resolves. Ancestry of
+          pull_request.base.sha is NOT a factor -- three-dot compare resolves the merge-base itself.
+        scope: >
+          detachedConfiguration* and the root buildscript `classpath` are EXCLUDED from the
+          submitted graph (dependency-graph-exclude-configurations). `configurations.all {
+          resolutionStrategy { force(...) } }` -- how openbank.dependency-vulnerability-pins applies
+          the fleet patch floors -- cannot reach a detachedConfiguration, so those resolve their own
+          older versions of the same modules and submit coordinates no service can load. Measured:
+          105 of 1389 resolved coordinates came only from a detached configuration and carried 24 of
+          30 findings; filtering both took the graph 1235 -> 1091 and findings 30 -> 3.
+          Test coverage is NOT reduced -- testCompileClasspath / testRuntimeClasspath /
+          integrationTest* are all still submitted.
+          Excluding `classpath` IS a deliberate narrowing: a vulnerable BUILD plugin never ships but
+          does run on CI runners, and this gate is about what ships. Revisit if build-time supply
+          chain becomes an explicit goal.
+        allowlist: >
+          allow-ghsas is DELIBERATELY EMPTY. It held seven suppressions (json-smart 2.5.0,
+          netty-handler 4.2.1, netty-codec-http2 4.1.119), every one silencing a coordinate that
+          only ever existed via a detached/buildscript configuration -- removed at source by the
+          scope filter above instead. An allow-ghsas entry is a PERMANENT FLEET-WIDE suppression: it
+          hides the pre-existing false positive it was added for AND a future PR that genuinely
+          introduces the same GHSA on a real classpath, so each entry buys quiet with a hole.
+          Before adding one, run the extractor's own diagnostic
+          (:ForceDependencyResolutionPlugin_resolveAllDependencies + SimpleDependencyGraphPlugin)
+          and read `resolvedBy` in dependency-resolution.json: a single entry naming a detached or
+          buildscript configuration is a graph artifact -- widen the scope filter, do not allowlist.
+          Entries naming a real *Classpath are a genuine finding -- bump the pin.
         not_covered_by:
           trivy_fs: "Trivy's Java coverage is JAR / pom.xml / gradle.lockfile / *.sbt.lock only; this repo has zero lockfiles, so Trivy fs sees no Gradle dependency"
           codeql: "not a dependency scanner, and not a required check"

--- a/openbank-infra/gitops/components/anacredit/anacredit-service.yaml
+++ b/openbank-infra/gitops/components/anacredit/anacredit-service.yaml
@@ -32,7 +32,7 @@ spec:
       annotations:
         # Rolls the pods when the OPA bundle changes — subPath mounts do NOT hot-reload.
         # Kept in sync by gen-anacredit-opa-bundle.sh (do not hand-edit).
-        openbank.tech/policy-checksum: "49fe7413162bf55d"
+        openbank.tech/policy-checksum: "968c5e0e5c84494a"
     spec:
       securityContext:
         runAsNonRoot: true

--- a/openbank-infra/gitops/components/ap2/ap2-opa-bundle.yaml
+++ b/openbank-infra/gitops/components/ap2/ap2-opa-bundle.yaml
@@ -9,7 +9,7 @@ metadata:
     app.kubernetes.io/name: mcp-service
     app.kubernetes.io/part-of: platform
   annotations:
-    openbank.tech/policy-checksum: "1e0152b370168318"
+    openbank.tech/policy-checksum: "e802ef1f169a8399"
 data:
   rest.rego: |
     # SPDX-License-Identifier: Apache-2.0
@@ -2614,9 +2614,44 @@ data:
           gate keeps reporting green while checking nothing about Gradle -- a silent hole, not a
           visible failure.
         requires:
-          - ".github/workflows/dependency-submission.yml runs on pull_request with the same path filter"
+          - ".github/workflows/dependency-submission.yml runs on pull_request with a manifest path filter"
+          - "its push:[main] trigger is DELIBERATELY UNFILTERED -- see base_snapshot below (#2833)"
           - "dependency-review arms retry-on-snapshot-warnings ONLY on dependency-touching PRs"
           - "dependency-submission failures raise a tracking issue (a stale graph makes the gate vacuous)"
+        base_snapshot: >
+          Snapshots are looked up by EXACT SHA and the compare endpoint is three-dot, so the graph
+          the gate diffs against is the MERGE-BASE of the PR -- an arbitrary main commit. While the
+          push:[main] trigger carried the same manifest path filter as the pull_request one, only
+          ~2% of main commits produced a snapshot (measured: 1 of 50), so the merge-base almost
+          never had one and the action silently fell back to reporting the ENTIRE head graph as
+          additions. That is how the allowlist below was accreted. The push trigger is therefore
+          unfiltered: every main commit submits, so the merge-base always resolves. Ancestry of
+          pull_request.base.sha is NOT a factor -- three-dot compare resolves the merge-base itself.
+        scope: >
+          detachedConfiguration* and the root buildscript `classpath` are EXCLUDED from the
+          submitted graph (dependency-graph-exclude-configurations). `configurations.all {
+          resolutionStrategy { force(...) } }` -- how openbank.dependency-vulnerability-pins applies
+          the fleet patch floors -- cannot reach a detachedConfiguration, so those resolve their own
+          older versions of the same modules and submit coordinates no service can load. Measured:
+          105 of 1389 resolved coordinates came only from a detached configuration and carried 24 of
+          30 findings; filtering both took the graph 1235 -> 1091 and findings 30 -> 3.
+          Test coverage is NOT reduced -- testCompileClasspath / testRuntimeClasspath /
+          integrationTest* are all still submitted.
+          Excluding `classpath` IS a deliberate narrowing: a vulnerable BUILD plugin never ships but
+          does run on CI runners, and this gate is about what ships. Revisit if build-time supply
+          chain becomes an explicit goal.
+        allowlist: >
+          allow-ghsas is DELIBERATELY EMPTY. It held seven suppressions (json-smart 2.5.0,
+          netty-handler 4.2.1, netty-codec-http2 4.1.119), every one silencing a coordinate that
+          only ever existed via a detached/buildscript configuration -- removed at source by the
+          scope filter above instead. An allow-ghsas entry is a PERMANENT FLEET-WIDE suppression: it
+          hides the pre-existing false positive it was added for AND a future PR that genuinely
+          introduces the same GHSA on a real classpath, so each entry buys quiet with a hole.
+          Before adding one, run the extractor's own diagnostic
+          (:ForceDependencyResolutionPlugin_resolveAllDependencies + SimpleDependencyGraphPlugin)
+          and read `resolvedBy` in dependency-resolution.json: a single entry naming a detached or
+          buildscript configuration is a graph artifact -- widen the scope filter, do not allowlist.
+          Entries naming a real *Classpath are a genuine finding -- bump the pin.
         not_covered_by:
           trivy_fs: "Trivy's Java coverage is JAR / pom.xml / gradle.lockfile / *.sbt.lock only; this repo has zero lockfiles, so Trivy fs sees no Gradle dependency"
           codeql: "not a dependency scanner, and not a required check"

--- a/openbank-infra/gitops/components/ap2/ap2-service.yaml
+++ b/openbank-infra/gitops/components/ap2/ap2-service.yaml
@@ -30,7 +30,7 @@ spec:
       annotations:
         # Roll the pod when the OPA policy bundle changes (subPath mounts don't hot-reload).
         # Kept in sync by gen-ap2-opa-bundle.sh (do not hand-edit).
-        openbank.tech/policy-checksum: "1e0152b370168318"
+        openbank.tech/policy-checksum: "e802ef1f169a8399"
     spec:
       securityContext:
         runAsNonRoot: true

--- a/openbank-infra/gitops/components/audit/audit-opa-bundle.yaml
+++ b/openbank-infra/gitops/components/audit/audit-opa-bundle.yaml
@@ -9,7 +9,7 @@ metadata:
     app.kubernetes.io/name: audit-service
     app.kubernetes.io/part-of: audit
   annotations:
-    openbank.tech/policy-checksum: "0a854ae2cf240354"
+    openbank.tech/policy-checksum: "cb144a8947f3f0f1"
 data:
   rest.rego: |
     # SPDX-License-Identifier: Apache-2.0
@@ -2658,9 +2658,44 @@ data:
           gate keeps reporting green while checking nothing about Gradle -- a silent hole, not a
           visible failure.
         requires:
-          - ".github/workflows/dependency-submission.yml runs on pull_request with the same path filter"
+          - ".github/workflows/dependency-submission.yml runs on pull_request with a manifest path filter"
+          - "its push:[main] trigger is DELIBERATELY UNFILTERED -- see base_snapshot below (#2833)"
           - "dependency-review arms retry-on-snapshot-warnings ONLY on dependency-touching PRs"
           - "dependency-submission failures raise a tracking issue (a stale graph makes the gate vacuous)"
+        base_snapshot: >
+          Snapshots are looked up by EXACT SHA and the compare endpoint is three-dot, so the graph
+          the gate diffs against is the MERGE-BASE of the PR -- an arbitrary main commit. While the
+          push:[main] trigger carried the same manifest path filter as the pull_request one, only
+          ~2% of main commits produced a snapshot (measured: 1 of 50), so the merge-base almost
+          never had one and the action silently fell back to reporting the ENTIRE head graph as
+          additions. That is how the allowlist below was accreted. The push trigger is therefore
+          unfiltered: every main commit submits, so the merge-base always resolves. Ancestry of
+          pull_request.base.sha is NOT a factor -- three-dot compare resolves the merge-base itself.
+        scope: >
+          detachedConfiguration* and the root buildscript `classpath` are EXCLUDED from the
+          submitted graph (dependency-graph-exclude-configurations). `configurations.all {
+          resolutionStrategy { force(...) } }` -- how openbank.dependency-vulnerability-pins applies
+          the fleet patch floors -- cannot reach a detachedConfiguration, so those resolve their own
+          older versions of the same modules and submit coordinates no service can load. Measured:
+          105 of 1389 resolved coordinates came only from a detached configuration and carried 24 of
+          30 findings; filtering both took the graph 1235 -> 1091 and findings 30 -> 3.
+          Test coverage is NOT reduced -- testCompileClasspath / testRuntimeClasspath /
+          integrationTest* are all still submitted.
+          Excluding `classpath` IS a deliberate narrowing: a vulnerable BUILD plugin never ships but
+          does run on CI runners, and this gate is about what ships. Revisit if build-time supply
+          chain becomes an explicit goal.
+        allowlist: >
+          allow-ghsas is DELIBERATELY EMPTY. It held seven suppressions (json-smart 2.5.0,
+          netty-handler 4.2.1, netty-codec-http2 4.1.119), every one silencing a coordinate that
+          only ever existed via a detached/buildscript configuration -- removed at source by the
+          scope filter above instead. An allow-ghsas entry is a PERMANENT FLEET-WIDE suppression: it
+          hides the pre-existing false positive it was added for AND a future PR that genuinely
+          introduces the same GHSA on a real classpath, so each entry buys quiet with a hole.
+          Before adding one, run the extractor's own diagnostic
+          (:ForceDependencyResolutionPlugin_resolveAllDependencies + SimpleDependencyGraphPlugin)
+          and read `resolvedBy` in dependency-resolution.json: a single entry naming a detached or
+          buildscript configuration is a graph artifact -- widen the scope filter, do not allowlist.
+          Entries naming a real *Classpath are a genuine finding -- bump the pin.
         not_covered_by:
           trivy_fs: "Trivy's Java coverage is JAR / pom.xml / gradle.lockfile / *.sbt.lock only; this repo has zero lockfiles, so Trivy fs sees no Gradle dependency"
           codeql: "not a dependency scanner, and not a required check"

--- a/openbank-infra/gitops/components/audit/audit-service.yaml
+++ b/openbank-infra/gitops/components/audit/audit-service.yaml
@@ -22,7 +22,7 @@ spec:
       annotations:
         # Rolls the pod when the OPA bundle changes (subPath mounts do not hot-reload).
         # Kept in sync by gen-audit-opa-bundle.sh (do not hand-edit).
-        openbank.tech/policy-checksum: "0a854ae2cf240354"
+        openbank.tech/policy-checksum: "cb144a8947f3f0f1"
     spec:
       securityContext:
         runAsNonRoot: true

--- a/openbank-infra/gitops/components/balances/balance-opa-bundle.yaml
+++ b/openbank-infra/gitops/components/balances/balance-opa-bundle.yaml
@@ -9,7 +9,7 @@ metadata:
     app.kubernetes.io/name: balance-service
     app.kubernetes.io/part-of: balances
   annotations:
-    openbank.tech/policy-checksum: "78dbae54741d1821"
+    openbank.tech/policy-checksum: "c4a8f5240aa54028"
 data:
   rest.rego: |
     # SPDX-License-Identifier: Apache-2.0
@@ -2747,9 +2747,44 @@ data:
           gate keeps reporting green while checking nothing about Gradle -- a silent hole, not a
           visible failure.
         requires:
-          - ".github/workflows/dependency-submission.yml runs on pull_request with the same path filter"
+          - ".github/workflows/dependency-submission.yml runs on pull_request with a manifest path filter"
+          - "its push:[main] trigger is DELIBERATELY UNFILTERED -- see base_snapshot below (#2833)"
           - "dependency-review arms retry-on-snapshot-warnings ONLY on dependency-touching PRs"
           - "dependency-submission failures raise a tracking issue (a stale graph makes the gate vacuous)"
+        base_snapshot: >
+          Snapshots are looked up by EXACT SHA and the compare endpoint is three-dot, so the graph
+          the gate diffs against is the MERGE-BASE of the PR -- an arbitrary main commit. While the
+          push:[main] trigger carried the same manifest path filter as the pull_request one, only
+          ~2% of main commits produced a snapshot (measured: 1 of 50), so the merge-base almost
+          never had one and the action silently fell back to reporting the ENTIRE head graph as
+          additions. That is how the allowlist below was accreted. The push trigger is therefore
+          unfiltered: every main commit submits, so the merge-base always resolves. Ancestry of
+          pull_request.base.sha is NOT a factor -- three-dot compare resolves the merge-base itself.
+        scope: >
+          detachedConfiguration* and the root buildscript `classpath` are EXCLUDED from the
+          submitted graph (dependency-graph-exclude-configurations). `configurations.all {
+          resolutionStrategy { force(...) } }` -- how openbank.dependency-vulnerability-pins applies
+          the fleet patch floors -- cannot reach a detachedConfiguration, so those resolve their own
+          older versions of the same modules and submit coordinates no service can load. Measured:
+          105 of 1389 resolved coordinates came only from a detached configuration and carried 24 of
+          30 findings; filtering both took the graph 1235 -> 1091 and findings 30 -> 3.
+          Test coverage is NOT reduced -- testCompileClasspath / testRuntimeClasspath /
+          integrationTest* are all still submitted.
+          Excluding `classpath` IS a deliberate narrowing: a vulnerable BUILD plugin never ships but
+          does run on CI runners, and this gate is about what ships. Revisit if build-time supply
+          chain becomes an explicit goal.
+        allowlist: >
+          allow-ghsas is DELIBERATELY EMPTY. It held seven suppressions (json-smart 2.5.0,
+          netty-handler 4.2.1, netty-codec-http2 4.1.119), every one silencing a coordinate that
+          only ever existed via a detached/buildscript configuration -- removed at source by the
+          scope filter above instead. An allow-ghsas entry is a PERMANENT FLEET-WIDE suppression: it
+          hides the pre-existing false positive it was added for AND a future PR that genuinely
+          introduces the same GHSA on a real classpath, so each entry buys quiet with a hole.
+          Before adding one, run the extractor's own diagnostic
+          (:ForceDependencyResolutionPlugin_resolveAllDependencies + SimpleDependencyGraphPlugin)
+          and read `resolvedBy` in dependency-resolution.json: a single entry naming a detached or
+          buildscript configuration is a graph artifact -- widen the scope filter, do not allowlist.
+          Entries naming a real *Classpath are a genuine finding -- bump the pin.
         not_covered_by:
           trivy_fs: "Trivy's Java coverage is JAR / pom.xml / gradle.lockfile / *.sbt.lock only; this repo has zero lockfiles, so Trivy fs sees no Gradle dependency"
           codeql: "not a dependency scanner, and not a required check"

--- a/openbank-infra/gitops/components/balances/balance-service.yaml
+++ b/openbank-infra/gitops/components/balances/balance-service.yaml
@@ -34,7 +34,7 @@ spec:
       annotations:
         # Rolls the pods when the OPA bundle changes — subPath mounts do NOT hot-reload.
         # Kept in sync by gen-balance-opa-bundle.sh (do not hand-edit).
-        openbank.tech/policy-checksum: "78dbae54741d1821"
+        openbank.tech/policy-checksum: "c4a8f5240aa54028"
     spec:
       securityContext:
         runAsNonRoot: true

--- a/openbank-infra/gitops/components/billing/billing-opa-bundle.yaml
+++ b/openbank-infra/gitops/components/billing/billing-opa-bundle.yaml
@@ -9,7 +9,7 @@ metadata:
     app.kubernetes.io/name: billing-service
     app.kubernetes.io/part-of: billing
   annotations:
-    openbank.tech/policy-checksum: "5b8c19245490e6f1"
+    openbank.tech/policy-checksum: "ec56179894498a20"
 data:
   rest.rego: |
     # SPDX-License-Identifier: Apache-2.0
@@ -2652,9 +2652,44 @@ data:
           gate keeps reporting green while checking nothing about Gradle -- a silent hole, not a
           visible failure.
         requires:
-          - ".github/workflows/dependency-submission.yml runs on pull_request with the same path filter"
+          - ".github/workflows/dependency-submission.yml runs on pull_request with a manifest path filter"
+          - "its push:[main] trigger is DELIBERATELY UNFILTERED -- see base_snapshot below (#2833)"
           - "dependency-review arms retry-on-snapshot-warnings ONLY on dependency-touching PRs"
           - "dependency-submission failures raise a tracking issue (a stale graph makes the gate vacuous)"
+        base_snapshot: >
+          Snapshots are looked up by EXACT SHA and the compare endpoint is three-dot, so the graph
+          the gate diffs against is the MERGE-BASE of the PR -- an arbitrary main commit. While the
+          push:[main] trigger carried the same manifest path filter as the pull_request one, only
+          ~2% of main commits produced a snapshot (measured: 1 of 50), so the merge-base almost
+          never had one and the action silently fell back to reporting the ENTIRE head graph as
+          additions. That is how the allowlist below was accreted. The push trigger is therefore
+          unfiltered: every main commit submits, so the merge-base always resolves. Ancestry of
+          pull_request.base.sha is NOT a factor -- three-dot compare resolves the merge-base itself.
+        scope: >
+          detachedConfiguration* and the root buildscript `classpath` are EXCLUDED from the
+          submitted graph (dependency-graph-exclude-configurations). `configurations.all {
+          resolutionStrategy { force(...) } }` -- how openbank.dependency-vulnerability-pins applies
+          the fleet patch floors -- cannot reach a detachedConfiguration, so those resolve their own
+          older versions of the same modules and submit coordinates no service can load. Measured:
+          105 of 1389 resolved coordinates came only from a detached configuration and carried 24 of
+          30 findings; filtering both took the graph 1235 -> 1091 and findings 30 -> 3.
+          Test coverage is NOT reduced -- testCompileClasspath / testRuntimeClasspath /
+          integrationTest* are all still submitted.
+          Excluding `classpath` IS a deliberate narrowing: a vulnerable BUILD plugin never ships but
+          does run on CI runners, and this gate is about what ships. Revisit if build-time supply
+          chain becomes an explicit goal.
+        allowlist: >
+          allow-ghsas is DELIBERATELY EMPTY. It held seven suppressions (json-smart 2.5.0,
+          netty-handler 4.2.1, netty-codec-http2 4.1.119), every one silencing a coordinate that
+          only ever existed via a detached/buildscript configuration -- removed at source by the
+          scope filter above instead. An allow-ghsas entry is a PERMANENT FLEET-WIDE suppression: it
+          hides the pre-existing false positive it was added for AND a future PR that genuinely
+          introduces the same GHSA on a real classpath, so each entry buys quiet with a hole.
+          Before adding one, run the extractor's own diagnostic
+          (:ForceDependencyResolutionPlugin_resolveAllDependencies + SimpleDependencyGraphPlugin)
+          and read `resolvedBy` in dependency-resolution.json: a single entry naming a detached or
+          buildscript configuration is a graph artifact -- widen the scope filter, do not allowlist.
+          Entries naming a real *Classpath are a genuine finding -- bump the pin.
         not_covered_by:
           trivy_fs: "Trivy's Java coverage is JAR / pom.xml / gradle.lockfile / *.sbt.lock only; this repo has zero lockfiles, so Trivy fs sees no Gradle dependency"
           codeql: "not a dependency scanner, and not a required check"

--- a/openbank-infra/gitops/components/billing/billing-service.yaml
+++ b/openbank-infra/gitops/components/billing/billing-service.yaml
@@ -27,7 +27,7 @@ spec:
       annotations:
         # Rolls the pods when the OPA bundle changes — subPath mounts do NOT hot-reload.
         # Kept in sync by gen-billing-opa-bundle.sh (do not hand-edit).
-        openbank.tech/policy-checksum: "5b8c19245490e6f1"
+        openbank.tech/policy-checksum: "ec56179894498a20"
     spec:
       securityContext:
         runAsNonRoot: true

--- a/openbank-infra/gitops/components/campaign/campaign-opa-bundle.yaml
+++ b/openbank-infra/gitops/components/campaign/campaign-opa-bundle.yaml
@@ -9,7 +9,7 @@ metadata:
     app.kubernetes.io/name: campaign-service
     app.kubernetes.io/part-of: campaign
   annotations:
-    openbank.tech/policy-checksum: "36ec39c12807dcf2"
+    openbank.tech/policy-checksum: "0f16a1e24f72c6a9"
 data:
   rest.rego: |
     # SPDX-License-Identifier: Apache-2.0
@@ -2673,9 +2673,44 @@ data:
           gate keeps reporting green while checking nothing about Gradle -- a silent hole, not a
           visible failure.
         requires:
-          - ".github/workflows/dependency-submission.yml runs on pull_request with the same path filter"
+          - ".github/workflows/dependency-submission.yml runs on pull_request with a manifest path filter"
+          - "its push:[main] trigger is DELIBERATELY UNFILTERED -- see base_snapshot below (#2833)"
           - "dependency-review arms retry-on-snapshot-warnings ONLY on dependency-touching PRs"
           - "dependency-submission failures raise a tracking issue (a stale graph makes the gate vacuous)"
+        base_snapshot: >
+          Snapshots are looked up by EXACT SHA and the compare endpoint is three-dot, so the graph
+          the gate diffs against is the MERGE-BASE of the PR -- an arbitrary main commit. While the
+          push:[main] trigger carried the same manifest path filter as the pull_request one, only
+          ~2% of main commits produced a snapshot (measured: 1 of 50), so the merge-base almost
+          never had one and the action silently fell back to reporting the ENTIRE head graph as
+          additions. That is how the allowlist below was accreted. The push trigger is therefore
+          unfiltered: every main commit submits, so the merge-base always resolves. Ancestry of
+          pull_request.base.sha is NOT a factor -- three-dot compare resolves the merge-base itself.
+        scope: >
+          detachedConfiguration* and the root buildscript `classpath` are EXCLUDED from the
+          submitted graph (dependency-graph-exclude-configurations). `configurations.all {
+          resolutionStrategy { force(...) } }` -- how openbank.dependency-vulnerability-pins applies
+          the fleet patch floors -- cannot reach a detachedConfiguration, so those resolve their own
+          older versions of the same modules and submit coordinates no service can load. Measured:
+          105 of 1389 resolved coordinates came only from a detached configuration and carried 24 of
+          30 findings; filtering both took the graph 1235 -> 1091 and findings 30 -> 3.
+          Test coverage is NOT reduced -- testCompileClasspath / testRuntimeClasspath /
+          integrationTest* are all still submitted.
+          Excluding `classpath` IS a deliberate narrowing: a vulnerable BUILD plugin never ships but
+          does run on CI runners, and this gate is about what ships. Revisit if build-time supply
+          chain becomes an explicit goal.
+        allowlist: >
+          allow-ghsas is DELIBERATELY EMPTY. It held seven suppressions (json-smart 2.5.0,
+          netty-handler 4.2.1, netty-codec-http2 4.1.119), every one silencing a coordinate that
+          only ever existed via a detached/buildscript configuration -- removed at source by the
+          scope filter above instead. An allow-ghsas entry is a PERMANENT FLEET-WIDE suppression: it
+          hides the pre-existing false positive it was added for AND a future PR that genuinely
+          introduces the same GHSA on a real classpath, so each entry buys quiet with a hole.
+          Before adding one, run the extractor's own diagnostic
+          (:ForceDependencyResolutionPlugin_resolveAllDependencies + SimpleDependencyGraphPlugin)
+          and read `resolvedBy` in dependency-resolution.json: a single entry naming a detached or
+          buildscript configuration is a graph artifact -- widen the scope filter, do not allowlist.
+          Entries naming a real *Classpath are a genuine finding -- bump the pin.
         not_covered_by:
           trivy_fs: "Trivy's Java coverage is JAR / pom.xml / gradle.lockfile / *.sbt.lock only; this repo has zero lockfiles, so Trivy fs sees no Gradle dependency"
           codeql: "not a dependency scanner, and not a required check"

--- a/openbank-infra/gitops/components/campaign/campaign-service.yaml
+++ b/openbank-infra/gitops/components/campaign/campaign-service.yaml
@@ -25,7 +25,7 @@ spec:
       annotations:
         # Rolls the pod when the OPA bundle changes — subPath mounts do NOT hot-reload.
         # Kept in sync by gen-campaign-opa-bundle.sh (do not hand-edit).
-        openbank.tech/policy-checksum: "36ec39c12807dcf2"
+        openbank.tech/policy-checksum: "0f16a1e24f72c6a9"
       labels:
         app.kubernetes.io/name: campaign-service
         app.kubernetes.io/part-of: campaign

--- a/openbank-infra/gitops/components/consent/consent-opa-bundle.yaml
+++ b/openbank-infra/gitops/components/consent/consent-opa-bundle.yaml
@@ -9,7 +9,7 @@ metadata:
     app.kubernetes.io/name: consent-service
     app.kubernetes.io/part-of: consent
   annotations:
-    openbank.tech/policy-checksum: "cc43ad404832e70e"
+    openbank.tech/policy-checksum: "614d7f7e81754c61"
 data:
   rest.rego: |
     # SPDX-License-Identifier: Apache-2.0
@@ -2722,9 +2722,44 @@ data:
           gate keeps reporting green while checking nothing about Gradle -- a silent hole, not a
           visible failure.
         requires:
-          - ".github/workflows/dependency-submission.yml runs on pull_request with the same path filter"
+          - ".github/workflows/dependency-submission.yml runs on pull_request with a manifest path filter"
+          - "its push:[main] trigger is DELIBERATELY UNFILTERED -- see base_snapshot below (#2833)"
           - "dependency-review arms retry-on-snapshot-warnings ONLY on dependency-touching PRs"
           - "dependency-submission failures raise a tracking issue (a stale graph makes the gate vacuous)"
+        base_snapshot: >
+          Snapshots are looked up by EXACT SHA and the compare endpoint is three-dot, so the graph
+          the gate diffs against is the MERGE-BASE of the PR -- an arbitrary main commit. While the
+          push:[main] trigger carried the same manifest path filter as the pull_request one, only
+          ~2% of main commits produced a snapshot (measured: 1 of 50), so the merge-base almost
+          never had one and the action silently fell back to reporting the ENTIRE head graph as
+          additions. That is how the allowlist below was accreted. The push trigger is therefore
+          unfiltered: every main commit submits, so the merge-base always resolves. Ancestry of
+          pull_request.base.sha is NOT a factor -- three-dot compare resolves the merge-base itself.
+        scope: >
+          detachedConfiguration* and the root buildscript `classpath` are EXCLUDED from the
+          submitted graph (dependency-graph-exclude-configurations). `configurations.all {
+          resolutionStrategy { force(...) } }` -- how openbank.dependency-vulnerability-pins applies
+          the fleet patch floors -- cannot reach a detachedConfiguration, so those resolve their own
+          older versions of the same modules and submit coordinates no service can load. Measured:
+          105 of 1389 resolved coordinates came only from a detached configuration and carried 24 of
+          30 findings; filtering both took the graph 1235 -> 1091 and findings 30 -> 3.
+          Test coverage is NOT reduced -- testCompileClasspath / testRuntimeClasspath /
+          integrationTest* are all still submitted.
+          Excluding `classpath` IS a deliberate narrowing: a vulnerable BUILD plugin never ships but
+          does run on CI runners, and this gate is about what ships. Revisit if build-time supply
+          chain becomes an explicit goal.
+        allowlist: >
+          allow-ghsas is DELIBERATELY EMPTY. It held seven suppressions (json-smart 2.5.0,
+          netty-handler 4.2.1, netty-codec-http2 4.1.119), every one silencing a coordinate that
+          only ever existed via a detached/buildscript configuration -- removed at source by the
+          scope filter above instead. An allow-ghsas entry is a PERMANENT FLEET-WIDE suppression: it
+          hides the pre-existing false positive it was added for AND a future PR that genuinely
+          introduces the same GHSA on a real classpath, so each entry buys quiet with a hole.
+          Before adding one, run the extractor's own diagnostic
+          (:ForceDependencyResolutionPlugin_resolveAllDependencies + SimpleDependencyGraphPlugin)
+          and read `resolvedBy` in dependency-resolution.json: a single entry naming a detached or
+          buildscript configuration is a graph artifact -- widen the scope filter, do not allowlist.
+          Entries naming a real *Classpath are a genuine finding -- bump the pin.
         not_covered_by:
           trivy_fs: "Trivy's Java coverage is JAR / pom.xml / gradle.lockfile / *.sbt.lock only; this repo has zero lockfiles, so Trivy fs sees no Gradle dependency"
           codeql: "not a dependency scanner, and not a required check"

--- a/openbank-infra/gitops/components/consent/consent-service.yaml
+++ b/openbank-infra/gitops/components/consent/consent-service.yaml
@@ -28,7 +28,7 @@ spec:
       annotations:
         # Rolls the pods when the OPA bundle changes — subPath mounts do NOT hot-reload.
         # Kept in sync by gen-consent-opa-bundle.sh (do not hand-edit).
-        openbank.tech/policy-checksum: "cc43ad404832e70e"
+        openbank.tech/policy-checksum: "614d7f7e81754c61"
     spec:
       securityContext:
         runAsNonRoot: true

--- a/openbank-infra/gitops/components/copilot/copilot-opa-bundle.yaml
+++ b/openbank-infra/gitops/components/copilot/copilot-opa-bundle.yaml
@@ -9,7 +9,7 @@ metadata:
     app.kubernetes.io/name: copilot-service
     app.kubernetes.io/part-of: platform
   annotations:
-    openbank.tech/policy-checksum: "b8a699775e2dc059"
+    openbank.tech/policy-checksum: "6f1f58570fc57537"
 data:
   rest.rego: |
     # SPDX-License-Identifier: Apache-2.0
@@ -2738,9 +2738,44 @@ data:
           gate keeps reporting green while checking nothing about Gradle -- a silent hole, not a
           visible failure.
         requires:
-          - ".github/workflows/dependency-submission.yml runs on pull_request with the same path filter"
+          - ".github/workflows/dependency-submission.yml runs on pull_request with a manifest path filter"
+          - "its push:[main] trigger is DELIBERATELY UNFILTERED -- see base_snapshot below (#2833)"
           - "dependency-review arms retry-on-snapshot-warnings ONLY on dependency-touching PRs"
           - "dependency-submission failures raise a tracking issue (a stale graph makes the gate vacuous)"
+        base_snapshot: >
+          Snapshots are looked up by EXACT SHA and the compare endpoint is three-dot, so the graph
+          the gate diffs against is the MERGE-BASE of the PR -- an arbitrary main commit. While the
+          push:[main] trigger carried the same manifest path filter as the pull_request one, only
+          ~2% of main commits produced a snapshot (measured: 1 of 50), so the merge-base almost
+          never had one and the action silently fell back to reporting the ENTIRE head graph as
+          additions. That is how the allowlist below was accreted. The push trigger is therefore
+          unfiltered: every main commit submits, so the merge-base always resolves. Ancestry of
+          pull_request.base.sha is NOT a factor -- three-dot compare resolves the merge-base itself.
+        scope: >
+          detachedConfiguration* and the root buildscript `classpath` are EXCLUDED from the
+          submitted graph (dependency-graph-exclude-configurations). `configurations.all {
+          resolutionStrategy { force(...) } }` -- how openbank.dependency-vulnerability-pins applies
+          the fleet patch floors -- cannot reach a detachedConfiguration, so those resolve their own
+          older versions of the same modules and submit coordinates no service can load. Measured:
+          105 of 1389 resolved coordinates came only from a detached configuration and carried 24 of
+          30 findings; filtering both took the graph 1235 -> 1091 and findings 30 -> 3.
+          Test coverage is NOT reduced -- testCompileClasspath / testRuntimeClasspath /
+          integrationTest* are all still submitted.
+          Excluding `classpath` IS a deliberate narrowing: a vulnerable BUILD plugin never ships but
+          does run on CI runners, and this gate is about what ships. Revisit if build-time supply
+          chain becomes an explicit goal.
+        allowlist: >
+          allow-ghsas is DELIBERATELY EMPTY. It held seven suppressions (json-smart 2.5.0,
+          netty-handler 4.2.1, netty-codec-http2 4.1.119), every one silencing a coordinate that
+          only ever existed via a detached/buildscript configuration -- removed at source by the
+          scope filter above instead. An allow-ghsas entry is a PERMANENT FLEET-WIDE suppression: it
+          hides the pre-existing false positive it was added for AND a future PR that genuinely
+          introduces the same GHSA on a real classpath, so each entry buys quiet with a hole.
+          Before adding one, run the extractor's own diagnostic
+          (:ForceDependencyResolutionPlugin_resolveAllDependencies + SimpleDependencyGraphPlugin)
+          and read `resolvedBy` in dependency-resolution.json: a single entry naming a detached or
+          buildscript configuration is a graph artifact -- widen the scope filter, do not allowlist.
+          Entries naming a real *Classpath are a genuine finding -- bump the pin.
         not_covered_by:
           trivy_fs: "Trivy's Java coverage is JAR / pom.xml / gradle.lockfile / *.sbt.lock only; this repo has zero lockfiles, so Trivy fs sees no Gradle dependency"
           codeql: "not a dependency scanner, and not a required check"

--- a/openbank-infra/gitops/components/copilot/copilot-service.yaml
+++ b/openbank-infra/gitops/components/copilot/copilot-service.yaml
@@ -29,7 +29,7 @@ spec:
       annotations:
         # Rolls the pod when the OPA bundle changes — subPath mounts do NOT hot-reload.
         # Kept in sync by gen-copilot-opa-bundle.sh (do not hand-edit).
-        openbank.tech/policy-checksum: "b8a699775e2dc059"
+        openbank.tech/policy-checksum: "6f1f58570fc57537"
     spec:
       securityContext:
         runAsNonRoot: true

--- a/openbank-infra/gitops/components/customer-edge/customer-edge-opa-bundle.yaml
+++ b/openbank-infra/gitops/components/customer-edge/customer-edge-opa-bundle.yaml
@@ -10,7 +10,7 @@ metadata:
     app.kubernetes.io/name: customer-edge
     app.kubernetes.io/part-of: customer-edge
   annotations:
-    openbank.tech/policy-checksum: "7f3df409fd1c9054"
+    openbank.tech/policy-checksum: "fd428b03c6dbf972"
 data:
   rest.rego: |
     # SPDX-License-Identifier: Apache-2.0
@@ -1837,9 +1837,44 @@ data:
           gate keeps reporting green while checking nothing about Gradle -- a silent hole, not a
           visible failure.
         requires:
-          - ".github/workflows/dependency-submission.yml runs on pull_request with the same path filter"
+          - ".github/workflows/dependency-submission.yml runs on pull_request with a manifest path filter"
+          - "its push:[main] trigger is DELIBERATELY UNFILTERED -- see base_snapshot below (#2833)"
           - "dependency-review arms retry-on-snapshot-warnings ONLY on dependency-touching PRs"
           - "dependency-submission failures raise a tracking issue (a stale graph makes the gate vacuous)"
+        base_snapshot: >
+          Snapshots are looked up by EXACT SHA and the compare endpoint is three-dot, so the graph
+          the gate diffs against is the MERGE-BASE of the PR -- an arbitrary main commit. While the
+          push:[main] trigger carried the same manifest path filter as the pull_request one, only
+          ~2% of main commits produced a snapshot (measured: 1 of 50), so the merge-base almost
+          never had one and the action silently fell back to reporting the ENTIRE head graph as
+          additions. That is how the allowlist below was accreted. The push trigger is therefore
+          unfiltered: every main commit submits, so the merge-base always resolves. Ancestry of
+          pull_request.base.sha is NOT a factor -- three-dot compare resolves the merge-base itself.
+        scope: >
+          detachedConfiguration* and the root buildscript `classpath` are EXCLUDED from the
+          submitted graph (dependency-graph-exclude-configurations). `configurations.all {
+          resolutionStrategy { force(...) } }` -- how openbank.dependency-vulnerability-pins applies
+          the fleet patch floors -- cannot reach a detachedConfiguration, so those resolve their own
+          older versions of the same modules and submit coordinates no service can load. Measured:
+          105 of 1389 resolved coordinates came only from a detached configuration and carried 24 of
+          30 findings; filtering both took the graph 1235 -> 1091 and findings 30 -> 3.
+          Test coverage is NOT reduced -- testCompileClasspath / testRuntimeClasspath /
+          integrationTest* are all still submitted.
+          Excluding `classpath` IS a deliberate narrowing: a vulnerable BUILD plugin never ships but
+          does run on CI runners, and this gate is about what ships. Revisit if build-time supply
+          chain becomes an explicit goal.
+        allowlist: >
+          allow-ghsas is DELIBERATELY EMPTY. It held seven suppressions (json-smart 2.5.0,
+          netty-handler 4.2.1, netty-codec-http2 4.1.119), every one silencing a coordinate that
+          only ever existed via a detached/buildscript configuration -- removed at source by the
+          scope filter above instead. An allow-ghsas entry is a PERMANENT FLEET-WIDE suppression: it
+          hides the pre-existing false positive it was added for AND a future PR that genuinely
+          introduces the same GHSA on a real classpath, so each entry buys quiet with a hole.
+          Before adding one, run the extractor's own diagnostic
+          (:ForceDependencyResolutionPlugin_resolveAllDependencies + SimpleDependencyGraphPlugin)
+          and read `resolvedBy` in dependency-resolution.json: a single entry naming a detached or
+          buildscript configuration is a graph artifact -- widen the scope filter, do not allowlist.
+          Entries naming a real *Classpath are a genuine finding -- bump the pin.
         not_covered_by:
           trivy_fs: "Trivy's Java coverage is JAR / pom.xml / gradle.lockfile / *.sbt.lock only; this repo has zero lockfiles, so Trivy fs sees no Gradle dependency"
           codeql: "not a dependency scanner, and not a required check"

--- a/openbank-infra/gitops/components/customer-edge/customer-edge.yaml
+++ b/openbank-infra/gitops/components/customer-edge/customer-edge.yaml
@@ -65,7 +65,7 @@ spec:
       annotations:
         # Rolls the pod when the OPA bundle changes — subPath mounts do NOT hot-reload.
         # Kept in sync by gen-customer-edge-opa-bundle.sh (do not hand-edit).
-        openbank.tech/policy-checksum: "7f3df409fd1c9054"
+        openbank.tech/policy-checksum: "fd428b03c6dbf972"
     spec:
       # Dedicated SA so EKS Pod Identity can hand the edge (and ONLY the edge) the
       # feedback-screenshots S3 role — ADR-0192, openbank-infra/aws/envs/sandbox-platform/

--- a/openbank-infra/gitops/components/dispute-service/dispute-opa-bundle.yaml
+++ b/openbank-infra/gitops/components/dispute-service/dispute-opa-bundle.yaml
@@ -9,7 +9,7 @@ metadata:
     app.kubernetes.io/name: dispute-service
     app.kubernetes.io/part-of: dispute
   annotations:
-    openbank.tech/policy-checksum: "81bee1d4e5124ac6"
+    openbank.tech/policy-checksum: "b33652f6e297d0dc"
 data:
   rest.rego: |
     # SPDX-License-Identifier: Apache-2.0
@@ -2788,9 +2788,44 @@ data:
           gate keeps reporting green while checking nothing about Gradle -- a silent hole, not a
           visible failure.
         requires:
-          - ".github/workflows/dependency-submission.yml runs on pull_request with the same path filter"
+          - ".github/workflows/dependency-submission.yml runs on pull_request with a manifest path filter"
+          - "its push:[main] trigger is DELIBERATELY UNFILTERED -- see base_snapshot below (#2833)"
           - "dependency-review arms retry-on-snapshot-warnings ONLY on dependency-touching PRs"
           - "dependency-submission failures raise a tracking issue (a stale graph makes the gate vacuous)"
+        base_snapshot: >
+          Snapshots are looked up by EXACT SHA and the compare endpoint is three-dot, so the graph
+          the gate diffs against is the MERGE-BASE of the PR -- an arbitrary main commit. While the
+          push:[main] trigger carried the same manifest path filter as the pull_request one, only
+          ~2% of main commits produced a snapshot (measured: 1 of 50), so the merge-base almost
+          never had one and the action silently fell back to reporting the ENTIRE head graph as
+          additions. That is how the allowlist below was accreted. The push trigger is therefore
+          unfiltered: every main commit submits, so the merge-base always resolves. Ancestry of
+          pull_request.base.sha is NOT a factor -- three-dot compare resolves the merge-base itself.
+        scope: >
+          detachedConfiguration* and the root buildscript `classpath` are EXCLUDED from the
+          submitted graph (dependency-graph-exclude-configurations). `configurations.all {
+          resolutionStrategy { force(...) } }` -- how openbank.dependency-vulnerability-pins applies
+          the fleet patch floors -- cannot reach a detachedConfiguration, so those resolve their own
+          older versions of the same modules and submit coordinates no service can load. Measured:
+          105 of 1389 resolved coordinates came only from a detached configuration and carried 24 of
+          30 findings; filtering both took the graph 1235 -> 1091 and findings 30 -> 3.
+          Test coverage is NOT reduced -- testCompileClasspath / testRuntimeClasspath /
+          integrationTest* are all still submitted.
+          Excluding `classpath` IS a deliberate narrowing: a vulnerable BUILD plugin never ships but
+          does run on CI runners, and this gate is about what ships. Revisit if build-time supply
+          chain becomes an explicit goal.
+        allowlist: >
+          allow-ghsas is DELIBERATELY EMPTY. It held seven suppressions (json-smart 2.5.0,
+          netty-handler 4.2.1, netty-codec-http2 4.1.119), every one silencing a coordinate that
+          only ever existed via a detached/buildscript configuration -- removed at source by the
+          scope filter above instead. An allow-ghsas entry is a PERMANENT FLEET-WIDE suppression: it
+          hides the pre-existing false positive it was added for AND a future PR that genuinely
+          introduces the same GHSA on a real classpath, so each entry buys quiet with a hole.
+          Before adding one, run the extractor's own diagnostic
+          (:ForceDependencyResolutionPlugin_resolveAllDependencies + SimpleDependencyGraphPlugin)
+          and read `resolvedBy` in dependency-resolution.json: a single entry naming a detached or
+          buildscript configuration is a graph artifact -- widen the scope filter, do not allowlist.
+          Entries naming a real *Classpath are a genuine finding -- bump the pin.
         not_covered_by:
           trivy_fs: "Trivy's Java coverage is JAR / pom.xml / gradle.lockfile / *.sbt.lock only; this repo has zero lockfiles, so Trivy fs sees no Gradle dependency"
           codeql: "not a dependency scanner, and not a required check"

--- a/openbank-infra/gitops/components/dispute-service/dispute-service.yaml
+++ b/openbank-infra/gitops/components/dispute-service/dispute-service.yaml
@@ -15,7 +15,7 @@ spec:
       annotations:
         # Rolls the pod when the OPA bundle changes — subPath mounts do NOT hot-reload.
         # Kept in sync by gen-dispute-opa-bundle.sh (do not hand-edit).
-        openbank.tech/policy-checksum: "81bee1d4e5124ac6"
+        openbank.tech/policy-checksum: "b33652f6e297d0dc"
       labels: {app.kubernetes.io/name: dispute-service, app.kubernetes.io/part-of: dispute}
     spec:
       securityContext:

--- a/openbank-infra/gitops/components/document-service/document-service-opa-bundle.yaml
+++ b/openbank-infra/gitops/components/document-service/document-service-opa-bundle.yaml
@@ -10,7 +10,7 @@ metadata:
     app.kubernetes.io/name: document-service
     app.kubernetes.io/part-of: documents
   annotations:
-    openbank.tech/policy-checksum: "7f3df409fd1c9054"
+    openbank.tech/policy-checksum: "fd428b03c6dbf972"
 data:
   rest.rego: |
     # SPDX-License-Identifier: Apache-2.0
@@ -1837,9 +1837,44 @@ data:
           gate keeps reporting green while checking nothing about Gradle -- a silent hole, not a
           visible failure.
         requires:
-          - ".github/workflows/dependency-submission.yml runs on pull_request with the same path filter"
+          - ".github/workflows/dependency-submission.yml runs on pull_request with a manifest path filter"
+          - "its push:[main] trigger is DELIBERATELY UNFILTERED -- see base_snapshot below (#2833)"
           - "dependency-review arms retry-on-snapshot-warnings ONLY on dependency-touching PRs"
           - "dependency-submission failures raise a tracking issue (a stale graph makes the gate vacuous)"
+        base_snapshot: >
+          Snapshots are looked up by EXACT SHA and the compare endpoint is three-dot, so the graph
+          the gate diffs against is the MERGE-BASE of the PR -- an arbitrary main commit. While the
+          push:[main] trigger carried the same manifest path filter as the pull_request one, only
+          ~2% of main commits produced a snapshot (measured: 1 of 50), so the merge-base almost
+          never had one and the action silently fell back to reporting the ENTIRE head graph as
+          additions. That is how the allowlist below was accreted. The push trigger is therefore
+          unfiltered: every main commit submits, so the merge-base always resolves. Ancestry of
+          pull_request.base.sha is NOT a factor -- three-dot compare resolves the merge-base itself.
+        scope: >
+          detachedConfiguration* and the root buildscript `classpath` are EXCLUDED from the
+          submitted graph (dependency-graph-exclude-configurations). `configurations.all {
+          resolutionStrategy { force(...) } }` -- how openbank.dependency-vulnerability-pins applies
+          the fleet patch floors -- cannot reach a detachedConfiguration, so those resolve their own
+          older versions of the same modules and submit coordinates no service can load. Measured:
+          105 of 1389 resolved coordinates came only from a detached configuration and carried 24 of
+          30 findings; filtering both took the graph 1235 -> 1091 and findings 30 -> 3.
+          Test coverage is NOT reduced -- testCompileClasspath / testRuntimeClasspath /
+          integrationTest* are all still submitted.
+          Excluding `classpath` IS a deliberate narrowing: a vulnerable BUILD plugin never ships but
+          does run on CI runners, and this gate is about what ships. Revisit if build-time supply
+          chain becomes an explicit goal.
+        allowlist: >
+          allow-ghsas is DELIBERATELY EMPTY. It held seven suppressions (json-smart 2.5.0,
+          netty-handler 4.2.1, netty-codec-http2 4.1.119), every one silencing a coordinate that
+          only ever existed via a detached/buildscript configuration -- removed at source by the
+          scope filter above instead. An allow-ghsas entry is a PERMANENT FLEET-WIDE suppression: it
+          hides the pre-existing false positive it was added for AND a future PR that genuinely
+          introduces the same GHSA on a real classpath, so each entry buys quiet with a hole.
+          Before adding one, run the extractor's own diagnostic
+          (:ForceDependencyResolutionPlugin_resolveAllDependencies + SimpleDependencyGraphPlugin)
+          and read `resolvedBy` in dependency-resolution.json: a single entry naming a detached or
+          buildscript configuration is a graph artifact -- widen the scope filter, do not allowlist.
+          Entries naming a real *Classpath are a genuine finding -- bump the pin.
         not_covered_by:
           trivy_fs: "Trivy's Java coverage is JAR / pom.xml / gradle.lockfile / *.sbt.lock only; this repo has zero lockfiles, so Trivy fs sees no Gradle dependency"
           codeql: "not a dependency scanner, and not a required check"

--- a/openbank-infra/gitops/components/document-service/document-service-service.yaml
+++ b/openbank-infra/gitops/components/document-service/document-service-service.yaml
@@ -43,7 +43,7 @@ spec:
       annotations:
         # Rolls the pods when the OPA bundle changes — subPath mounts do NOT hot-reload.
         # Kept in sync by gen-document-service-opa-bundle.sh (do not hand-edit).
-        openbank.tech/policy-checksum: "7f3df409fd1c9054"
+        openbank.tech/policy-checksum: "fd428b03c6dbf972"
     spec:
       # ADR-0162 D4 (continued): a dedicated SA (not `default`) is what OpenBao's Kubernetes-auth
       # role `document-service-signing` is bound to — least-privilege, one identity per consumer.

--- a/openbank-infra/gitops/components/fraud-service/fraud-opa-bundle.yaml
+++ b/openbank-infra/gitops/components/fraud-service/fraud-opa-bundle.yaml
@@ -9,7 +9,7 @@ metadata:
     app.kubernetes.io/name: fraud-service
     app.kubernetes.io/part-of: fraud
   annotations:
-    openbank.tech/policy-checksum: "18fd877e785ba365"
+    openbank.tech/policy-checksum: "6608341ccf44f3ba"
 data:
   rest.rego: |
     # SPDX-License-Identifier: Apache-2.0
@@ -2663,9 +2663,44 @@ data:
           gate keeps reporting green while checking nothing about Gradle -- a silent hole, not a
           visible failure.
         requires:
-          - ".github/workflows/dependency-submission.yml runs on pull_request with the same path filter"
+          - ".github/workflows/dependency-submission.yml runs on pull_request with a manifest path filter"
+          - "its push:[main] trigger is DELIBERATELY UNFILTERED -- see base_snapshot below (#2833)"
           - "dependency-review arms retry-on-snapshot-warnings ONLY on dependency-touching PRs"
           - "dependency-submission failures raise a tracking issue (a stale graph makes the gate vacuous)"
+        base_snapshot: >
+          Snapshots are looked up by EXACT SHA and the compare endpoint is three-dot, so the graph
+          the gate diffs against is the MERGE-BASE of the PR -- an arbitrary main commit. While the
+          push:[main] trigger carried the same manifest path filter as the pull_request one, only
+          ~2% of main commits produced a snapshot (measured: 1 of 50), so the merge-base almost
+          never had one and the action silently fell back to reporting the ENTIRE head graph as
+          additions. That is how the allowlist below was accreted. The push trigger is therefore
+          unfiltered: every main commit submits, so the merge-base always resolves. Ancestry of
+          pull_request.base.sha is NOT a factor -- three-dot compare resolves the merge-base itself.
+        scope: >
+          detachedConfiguration* and the root buildscript `classpath` are EXCLUDED from the
+          submitted graph (dependency-graph-exclude-configurations). `configurations.all {
+          resolutionStrategy { force(...) } }` -- how openbank.dependency-vulnerability-pins applies
+          the fleet patch floors -- cannot reach a detachedConfiguration, so those resolve their own
+          older versions of the same modules and submit coordinates no service can load. Measured:
+          105 of 1389 resolved coordinates came only from a detached configuration and carried 24 of
+          30 findings; filtering both took the graph 1235 -> 1091 and findings 30 -> 3.
+          Test coverage is NOT reduced -- testCompileClasspath / testRuntimeClasspath /
+          integrationTest* are all still submitted.
+          Excluding `classpath` IS a deliberate narrowing: a vulnerable BUILD plugin never ships but
+          does run on CI runners, and this gate is about what ships. Revisit if build-time supply
+          chain becomes an explicit goal.
+        allowlist: >
+          allow-ghsas is DELIBERATELY EMPTY. It held seven suppressions (json-smart 2.5.0,
+          netty-handler 4.2.1, netty-codec-http2 4.1.119), every one silencing a coordinate that
+          only ever existed via a detached/buildscript configuration -- removed at source by the
+          scope filter above instead. An allow-ghsas entry is a PERMANENT FLEET-WIDE suppression: it
+          hides the pre-existing false positive it was added for AND a future PR that genuinely
+          introduces the same GHSA on a real classpath, so each entry buys quiet with a hole.
+          Before adding one, run the extractor's own diagnostic
+          (:ForceDependencyResolutionPlugin_resolveAllDependencies + SimpleDependencyGraphPlugin)
+          and read `resolvedBy` in dependency-resolution.json: a single entry naming a detached or
+          buildscript configuration is a graph artifact -- widen the scope filter, do not allowlist.
+          Entries naming a real *Classpath are a genuine finding -- bump the pin.
         not_covered_by:
           trivy_fs: "Trivy's Java coverage is JAR / pom.xml / gradle.lockfile / *.sbt.lock only; this repo has zero lockfiles, so Trivy fs sees no Gradle dependency"
           codeql: "not a dependency scanner, and not a required check"

--- a/openbank-infra/gitops/components/fraud-service/fraud-service.yaml
+++ b/openbank-infra/gitops/components/fraud-service/fraud-service.yaml
@@ -23,7 +23,7 @@ spec:
       annotations:
         # Rolls the pods when the OPA bundle changes — subPath mounts do NOT hot-reload.
         # Kept in sync by gen-fraud-opa-bundle.sh (do not hand-edit).
-        openbank.tech/policy-checksum: "18fd877e785ba365"
+        openbank.tech/policy-checksum: "6608341ccf44f3ba"
     spec:
       securityContext:
         runAsNonRoot: true

--- a/openbank-infra/gitops/components/fx-service/fx-opa-bundle.yaml
+++ b/openbank-infra/gitops/components/fx-service/fx-opa-bundle.yaml
@@ -9,7 +9,7 @@ metadata:
     app.kubernetes.io/name: fx-service
     app.kubernetes.io/part-of: fx
   annotations:
-    openbank.tech/policy-checksum: "d7c6f9020f2856d5"
+    openbank.tech/policy-checksum: "ead4fbfd15ca968e"
 data:
   rest.rego: |
     # SPDX-License-Identifier: Apache-2.0
@@ -2714,9 +2714,44 @@ data:
           gate keeps reporting green while checking nothing about Gradle -- a silent hole, not a
           visible failure.
         requires:
-          - ".github/workflows/dependency-submission.yml runs on pull_request with the same path filter"
+          - ".github/workflows/dependency-submission.yml runs on pull_request with a manifest path filter"
+          - "its push:[main] trigger is DELIBERATELY UNFILTERED -- see base_snapshot below (#2833)"
           - "dependency-review arms retry-on-snapshot-warnings ONLY on dependency-touching PRs"
           - "dependency-submission failures raise a tracking issue (a stale graph makes the gate vacuous)"
+        base_snapshot: >
+          Snapshots are looked up by EXACT SHA and the compare endpoint is three-dot, so the graph
+          the gate diffs against is the MERGE-BASE of the PR -- an arbitrary main commit. While the
+          push:[main] trigger carried the same manifest path filter as the pull_request one, only
+          ~2% of main commits produced a snapshot (measured: 1 of 50), so the merge-base almost
+          never had one and the action silently fell back to reporting the ENTIRE head graph as
+          additions. That is how the allowlist below was accreted. The push trigger is therefore
+          unfiltered: every main commit submits, so the merge-base always resolves. Ancestry of
+          pull_request.base.sha is NOT a factor -- three-dot compare resolves the merge-base itself.
+        scope: >
+          detachedConfiguration* and the root buildscript `classpath` are EXCLUDED from the
+          submitted graph (dependency-graph-exclude-configurations). `configurations.all {
+          resolutionStrategy { force(...) } }` -- how openbank.dependency-vulnerability-pins applies
+          the fleet patch floors -- cannot reach a detachedConfiguration, so those resolve their own
+          older versions of the same modules and submit coordinates no service can load. Measured:
+          105 of 1389 resolved coordinates came only from a detached configuration and carried 24 of
+          30 findings; filtering both took the graph 1235 -> 1091 and findings 30 -> 3.
+          Test coverage is NOT reduced -- testCompileClasspath / testRuntimeClasspath /
+          integrationTest* are all still submitted.
+          Excluding `classpath` IS a deliberate narrowing: a vulnerable BUILD plugin never ships but
+          does run on CI runners, and this gate is about what ships. Revisit if build-time supply
+          chain becomes an explicit goal.
+        allowlist: >
+          allow-ghsas is DELIBERATELY EMPTY. It held seven suppressions (json-smart 2.5.0,
+          netty-handler 4.2.1, netty-codec-http2 4.1.119), every one silencing a coordinate that
+          only ever existed via a detached/buildscript configuration -- removed at source by the
+          scope filter above instead. An allow-ghsas entry is a PERMANENT FLEET-WIDE suppression: it
+          hides the pre-existing false positive it was added for AND a future PR that genuinely
+          introduces the same GHSA on a real classpath, so each entry buys quiet with a hole.
+          Before adding one, run the extractor's own diagnostic
+          (:ForceDependencyResolutionPlugin_resolveAllDependencies + SimpleDependencyGraphPlugin)
+          and read `resolvedBy` in dependency-resolution.json: a single entry naming a detached or
+          buildscript configuration is a graph artifact -- widen the scope filter, do not allowlist.
+          Entries naming a real *Classpath are a genuine finding -- bump the pin.
         not_covered_by:
           trivy_fs: "Trivy's Java coverage is JAR / pom.xml / gradle.lockfile / *.sbt.lock only; this repo has zero lockfiles, so Trivy fs sees no Gradle dependency"
           codeql: "not a dependency scanner, and not a required check"

--- a/openbank-infra/gitops/components/fx-service/fx-service.yaml
+++ b/openbank-infra/gitops/components/fx-service/fx-service.yaml
@@ -22,7 +22,7 @@ spec:
       annotations:
         # Rolls the pods when the OPA bundle changes — subPath mounts do NOT hot-reload.
         # Kept in sync by gen-fx-opa-bundle.sh (do not hand-edit).
-        openbank.tech/policy-checksum: "d7c6f9020f2856d5"
+        openbank.tech/policy-checksum: "ead4fbfd15ca968e"
     spec:
       securityContext:
         runAsNonRoot: true

--- a/openbank-infra/gitops/components/interest-service/interest-opa-bundle.yaml
+++ b/openbank-infra/gitops/components/interest-service/interest-opa-bundle.yaml
@@ -9,7 +9,7 @@ metadata:
     app.kubernetes.io/name: interest-service
     app.kubernetes.io/part-of: interest
   annotations:
-    openbank.tech/policy-checksum: "9ce7d41cafced6f4"
+    openbank.tech/policy-checksum: "8e8e3713923dd002"
 data:
   rest.rego: |
     # SPDX-License-Identifier: Apache-2.0
@@ -2648,9 +2648,44 @@ data:
           gate keeps reporting green while checking nothing about Gradle -- a silent hole, not a
           visible failure.
         requires:
-          - ".github/workflows/dependency-submission.yml runs on pull_request with the same path filter"
+          - ".github/workflows/dependency-submission.yml runs on pull_request with a manifest path filter"
+          - "its push:[main] trigger is DELIBERATELY UNFILTERED -- see base_snapshot below (#2833)"
           - "dependency-review arms retry-on-snapshot-warnings ONLY on dependency-touching PRs"
           - "dependency-submission failures raise a tracking issue (a stale graph makes the gate vacuous)"
+        base_snapshot: >
+          Snapshots are looked up by EXACT SHA and the compare endpoint is three-dot, so the graph
+          the gate diffs against is the MERGE-BASE of the PR -- an arbitrary main commit. While the
+          push:[main] trigger carried the same manifest path filter as the pull_request one, only
+          ~2% of main commits produced a snapshot (measured: 1 of 50), so the merge-base almost
+          never had one and the action silently fell back to reporting the ENTIRE head graph as
+          additions. That is how the allowlist below was accreted. The push trigger is therefore
+          unfiltered: every main commit submits, so the merge-base always resolves. Ancestry of
+          pull_request.base.sha is NOT a factor -- three-dot compare resolves the merge-base itself.
+        scope: >
+          detachedConfiguration* and the root buildscript `classpath` are EXCLUDED from the
+          submitted graph (dependency-graph-exclude-configurations). `configurations.all {
+          resolutionStrategy { force(...) } }` -- how openbank.dependency-vulnerability-pins applies
+          the fleet patch floors -- cannot reach a detachedConfiguration, so those resolve their own
+          older versions of the same modules and submit coordinates no service can load. Measured:
+          105 of 1389 resolved coordinates came only from a detached configuration and carried 24 of
+          30 findings; filtering both took the graph 1235 -> 1091 and findings 30 -> 3.
+          Test coverage is NOT reduced -- testCompileClasspath / testRuntimeClasspath /
+          integrationTest* are all still submitted.
+          Excluding `classpath` IS a deliberate narrowing: a vulnerable BUILD plugin never ships but
+          does run on CI runners, and this gate is about what ships. Revisit if build-time supply
+          chain becomes an explicit goal.
+        allowlist: >
+          allow-ghsas is DELIBERATELY EMPTY. It held seven suppressions (json-smart 2.5.0,
+          netty-handler 4.2.1, netty-codec-http2 4.1.119), every one silencing a coordinate that
+          only ever existed via a detached/buildscript configuration -- removed at source by the
+          scope filter above instead. An allow-ghsas entry is a PERMANENT FLEET-WIDE suppression: it
+          hides the pre-existing false positive it was added for AND a future PR that genuinely
+          introduces the same GHSA on a real classpath, so each entry buys quiet with a hole.
+          Before adding one, run the extractor's own diagnostic
+          (:ForceDependencyResolutionPlugin_resolveAllDependencies + SimpleDependencyGraphPlugin)
+          and read `resolvedBy` in dependency-resolution.json: a single entry naming a detached or
+          buildscript configuration is a graph artifact -- widen the scope filter, do not allowlist.
+          Entries naming a real *Classpath are a genuine finding -- bump the pin.
         not_covered_by:
           trivy_fs: "Trivy's Java coverage is JAR / pom.xml / gradle.lockfile / *.sbt.lock only; this repo has zero lockfiles, so Trivy fs sees no Gradle dependency"
           codeql: "not a dependency scanner, and not a required check"

--- a/openbank-infra/gitops/components/interest-service/interest-service.yaml
+++ b/openbank-infra/gitops/components/interest-service/interest-service.yaml
@@ -16,7 +16,7 @@ spec:
       annotations:
         # Rolls the pods when the OPA bundle changes — subPath mounts do NOT hot-reload.
         # Kept in sync by gen-interest-opa-bundle.sh (do not hand-edit).
-        openbank.tech/policy-checksum: "9ce7d41cafced6f4"
+        openbank.tech/policy-checksum: "8e8e3713923dd002"
     spec:
       securityContext:
         runAsNonRoot: true

--- a/openbank-infra/gitops/components/kyc/kyc-opa-bundle.yaml
+++ b/openbank-infra/gitops/components/kyc/kyc-opa-bundle.yaml
@@ -9,7 +9,7 @@ metadata:
     app.kubernetes.io/name: kyc-service
     app.kubernetes.io/part-of: kyc
   annotations:
-    openbank.tech/policy-checksum: "9b59dd17e380747b"
+    openbank.tech/policy-checksum: "02073b2215cadb2d"
 data:
   rest.rego: |
     # SPDX-License-Identifier: Apache-2.0
@@ -2676,9 +2676,44 @@ data:
           gate keeps reporting green while checking nothing about Gradle -- a silent hole, not a
           visible failure.
         requires:
-          - ".github/workflows/dependency-submission.yml runs on pull_request with the same path filter"
+          - ".github/workflows/dependency-submission.yml runs on pull_request with a manifest path filter"
+          - "its push:[main] trigger is DELIBERATELY UNFILTERED -- see base_snapshot below (#2833)"
           - "dependency-review arms retry-on-snapshot-warnings ONLY on dependency-touching PRs"
           - "dependency-submission failures raise a tracking issue (a stale graph makes the gate vacuous)"
+        base_snapshot: >
+          Snapshots are looked up by EXACT SHA and the compare endpoint is three-dot, so the graph
+          the gate diffs against is the MERGE-BASE of the PR -- an arbitrary main commit. While the
+          push:[main] trigger carried the same manifest path filter as the pull_request one, only
+          ~2% of main commits produced a snapshot (measured: 1 of 50), so the merge-base almost
+          never had one and the action silently fell back to reporting the ENTIRE head graph as
+          additions. That is how the allowlist below was accreted. The push trigger is therefore
+          unfiltered: every main commit submits, so the merge-base always resolves. Ancestry of
+          pull_request.base.sha is NOT a factor -- three-dot compare resolves the merge-base itself.
+        scope: >
+          detachedConfiguration* and the root buildscript `classpath` are EXCLUDED from the
+          submitted graph (dependency-graph-exclude-configurations). `configurations.all {
+          resolutionStrategy { force(...) } }` -- how openbank.dependency-vulnerability-pins applies
+          the fleet patch floors -- cannot reach a detachedConfiguration, so those resolve their own
+          older versions of the same modules and submit coordinates no service can load. Measured:
+          105 of 1389 resolved coordinates came only from a detached configuration and carried 24 of
+          30 findings; filtering both took the graph 1235 -> 1091 and findings 30 -> 3.
+          Test coverage is NOT reduced -- testCompileClasspath / testRuntimeClasspath /
+          integrationTest* are all still submitted.
+          Excluding `classpath` IS a deliberate narrowing: a vulnerable BUILD plugin never ships but
+          does run on CI runners, and this gate is about what ships. Revisit if build-time supply
+          chain becomes an explicit goal.
+        allowlist: >
+          allow-ghsas is DELIBERATELY EMPTY. It held seven suppressions (json-smart 2.5.0,
+          netty-handler 4.2.1, netty-codec-http2 4.1.119), every one silencing a coordinate that
+          only ever existed via a detached/buildscript configuration -- removed at source by the
+          scope filter above instead. An allow-ghsas entry is a PERMANENT FLEET-WIDE suppression: it
+          hides the pre-existing false positive it was added for AND a future PR that genuinely
+          introduces the same GHSA on a real classpath, so each entry buys quiet with a hole.
+          Before adding one, run the extractor's own diagnostic
+          (:ForceDependencyResolutionPlugin_resolveAllDependencies + SimpleDependencyGraphPlugin)
+          and read `resolvedBy` in dependency-resolution.json: a single entry naming a detached or
+          buildscript configuration is a graph artifact -- widen the scope filter, do not allowlist.
+          Entries naming a real *Classpath are a genuine finding -- bump the pin.
         not_covered_by:
           trivy_fs: "Trivy's Java coverage is JAR / pom.xml / gradle.lockfile / *.sbt.lock only; this repo has zero lockfiles, so Trivy fs sees no Gradle dependency"
           codeql: "not a dependency scanner, and not a required check"

--- a/openbank-infra/gitops/components/kyc/kyc-service.yaml
+++ b/openbank-infra/gitops/components/kyc/kyc-service.yaml
@@ -48,7 +48,7 @@ spec:
       annotations:
         # Rolls the pod when the OPA bundle changes (subPath mounts do not hot-reload).
         # Kept in sync by gen-kyc-opa-bundle.sh (do not hand-edit).
-        openbank.tech/policy-checksum: "9b59dd17e380747b"
+        openbank.tech/policy-checksum: "02073b2215cadb2d"
     spec:
       securityContext:
         runAsNonRoot: true

--- a/openbank-infra/gitops/components/ledger/ledger-opa-bundle.yaml
+++ b/openbank-infra/gitops/components/ledger/ledger-opa-bundle.yaml
@@ -9,7 +9,7 @@ metadata:
     app.kubernetes.io/name: ledger-service
     app.kubernetes.io/part-of: ledger
   annotations:
-    openbank.tech/policy-checksum: "5f5a6dc0164b1d13"
+    openbank.tech/policy-checksum: "0868d84324f21a27"
 data:
   rest.rego: |
     # SPDX-License-Identifier: Apache-2.0
@@ -2761,9 +2761,44 @@ data:
           gate keeps reporting green while checking nothing about Gradle -- a silent hole, not a
           visible failure.
         requires:
-          - ".github/workflows/dependency-submission.yml runs on pull_request with the same path filter"
+          - ".github/workflows/dependency-submission.yml runs on pull_request with a manifest path filter"
+          - "its push:[main] trigger is DELIBERATELY UNFILTERED -- see base_snapshot below (#2833)"
           - "dependency-review arms retry-on-snapshot-warnings ONLY on dependency-touching PRs"
           - "dependency-submission failures raise a tracking issue (a stale graph makes the gate vacuous)"
+        base_snapshot: >
+          Snapshots are looked up by EXACT SHA and the compare endpoint is three-dot, so the graph
+          the gate diffs against is the MERGE-BASE of the PR -- an arbitrary main commit. While the
+          push:[main] trigger carried the same manifest path filter as the pull_request one, only
+          ~2% of main commits produced a snapshot (measured: 1 of 50), so the merge-base almost
+          never had one and the action silently fell back to reporting the ENTIRE head graph as
+          additions. That is how the allowlist below was accreted. The push trigger is therefore
+          unfiltered: every main commit submits, so the merge-base always resolves. Ancestry of
+          pull_request.base.sha is NOT a factor -- three-dot compare resolves the merge-base itself.
+        scope: >
+          detachedConfiguration* and the root buildscript `classpath` are EXCLUDED from the
+          submitted graph (dependency-graph-exclude-configurations). `configurations.all {
+          resolutionStrategy { force(...) } }` -- how openbank.dependency-vulnerability-pins applies
+          the fleet patch floors -- cannot reach a detachedConfiguration, so those resolve their own
+          older versions of the same modules and submit coordinates no service can load. Measured:
+          105 of 1389 resolved coordinates came only from a detached configuration and carried 24 of
+          30 findings; filtering both took the graph 1235 -> 1091 and findings 30 -> 3.
+          Test coverage is NOT reduced -- testCompileClasspath / testRuntimeClasspath /
+          integrationTest* are all still submitted.
+          Excluding `classpath` IS a deliberate narrowing: a vulnerable BUILD plugin never ships but
+          does run on CI runners, and this gate is about what ships. Revisit if build-time supply
+          chain becomes an explicit goal.
+        allowlist: >
+          allow-ghsas is DELIBERATELY EMPTY. It held seven suppressions (json-smart 2.5.0,
+          netty-handler 4.2.1, netty-codec-http2 4.1.119), every one silencing a coordinate that
+          only ever existed via a detached/buildscript configuration -- removed at source by the
+          scope filter above instead. An allow-ghsas entry is a PERMANENT FLEET-WIDE suppression: it
+          hides the pre-existing false positive it was added for AND a future PR that genuinely
+          introduces the same GHSA on a real classpath, so each entry buys quiet with a hole.
+          Before adding one, run the extractor's own diagnostic
+          (:ForceDependencyResolutionPlugin_resolveAllDependencies + SimpleDependencyGraphPlugin)
+          and read `resolvedBy` in dependency-resolution.json: a single entry naming a detached or
+          buildscript configuration is a graph artifact -- widen the scope filter, do not allowlist.
+          Entries naming a real *Classpath are a genuine finding -- bump the pin.
         not_covered_by:
           trivy_fs: "Trivy's Java coverage is JAR / pom.xml / gradle.lockfile / *.sbt.lock only; this repo has zero lockfiles, so Trivy fs sees no Gradle dependency"
           codeql: "not a dependency scanner, and not a required check"

--- a/openbank-infra/gitops/components/ledger/ledger-service.yaml
+++ b/openbank-infra/gitops/components/ledger/ledger-service.yaml
@@ -38,7 +38,7 @@ spec:
       annotations:
         # Rolls the pods when the OPA bundle changes — subPath mounts do NOT hot-reload.
         # Kept in sync by gen-ledger-opa-bundle.sh (do not hand-edit).
-        openbank.tech/policy-checksum: "5f5a6dc0164b1d13"
+        openbank.tech/policy-checksum: "0868d84324f21a27"
     spec:
       securityContext:
         runAsNonRoot: true

--- a/openbank-infra/gitops/components/lending/lending-opa-bundle.yaml
+++ b/openbank-infra/gitops/components/lending/lending-opa-bundle.yaml
@@ -9,7 +9,7 @@ metadata:
     app.kubernetes.io/name: lending-service
     app.kubernetes.io/part-of: lending
   annotations:
-    openbank.tech/policy-checksum: "deaf279f4d4422dd"
+    openbank.tech/policy-checksum: "1cb90fd24674d675"
 data:
   rest.rego: |
     # SPDX-License-Identifier: Apache-2.0
@@ -2719,9 +2719,44 @@ data:
           gate keeps reporting green while checking nothing about Gradle -- a silent hole, not a
           visible failure.
         requires:
-          - ".github/workflows/dependency-submission.yml runs on pull_request with the same path filter"
+          - ".github/workflows/dependency-submission.yml runs on pull_request with a manifest path filter"
+          - "its push:[main] trigger is DELIBERATELY UNFILTERED -- see base_snapshot below (#2833)"
           - "dependency-review arms retry-on-snapshot-warnings ONLY on dependency-touching PRs"
           - "dependency-submission failures raise a tracking issue (a stale graph makes the gate vacuous)"
+        base_snapshot: >
+          Snapshots are looked up by EXACT SHA and the compare endpoint is three-dot, so the graph
+          the gate diffs against is the MERGE-BASE of the PR -- an arbitrary main commit. While the
+          push:[main] trigger carried the same manifest path filter as the pull_request one, only
+          ~2% of main commits produced a snapshot (measured: 1 of 50), so the merge-base almost
+          never had one and the action silently fell back to reporting the ENTIRE head graph as
+          additions. That is how the allowlist below was accreted. The push trigger is therefore
+          unfiltered: every main commit submits, so the merge-base always resolves. Ancestry of
+          pull_request.base.sha is NOT a factor -- three-dot compare resolves the merge-base itself.
+        scope: >
+          detachedConfiguration* and the root buildscript `classpath` are EXCLUDED from the
+          submitted graph (dependency-graph-exclude-configurations). `configurations.all {
+          resolutionStrategy { force(...) } }` -- how openbank.dependency-vulnerability-pins applies
+          the fleet patch floors -- cannot reach a detachedConfiguration, so those resolve their own
+          older versions of the same modules and submit coordinates no service can load. Measured:
+          105 of 1389 resolved coordinates came only from a detached configuration and carried 24 of
+          30 findings; filtering both took the graph 1235 -> 1091 and findings 30 -> 3.
+          Test coverage is NOT reduced -- testCompileClasspath / testRuntimeClasspath /
+          integrationTest* are all still submitted.
+          Excluding `classpath` IS a deliberate narrowing: a vulnerable BUILD plugin never ships but
+          does run on CI runners, and this gate is about what ships. Revisit if build-time supply
+          chain becomes an explicit goal.
+        allowlist: >
+          allow-ghsas is DELIBERATELY EMPTY. It held seven suppressions (json-smart 2.5.0,
+          netty-handler 4.2.1, netty-codec-http2 4.1.119), every one silencing a coordinate that
+          only ever existed via a detached/buildscript configuration -- removed at source by the
+          scope filter above instead. An allow-ghsas entry is a PERMANENT FLEET-WIDE suppression: it
+          hides the pre-existing false positive it was added for AND a future PR that genuinely
+          introduces the same GHSA on a real classpath, so each entry buys quiet with a hole.
+          Before adding one, run the extractor's own diagnostic
+          (:ForceDependencyResolutionPlugin_resolveAllDependencies + SimpleDependencyGraphPlugin)
+          and read `resolvedBy` in dependency-resolution.json: a single entry naming a detached or
+          buildscript configuration is a graph artifact -- widen the scope filter, do not allowlist.
+          Entries naming a real *Classpath are a genuine finding -- bump the pin.
         not_covered_by:
           trivy_fs: "Trivy's Java coverage is JAR / pom.xml / gradle.lockfile / *.sbt.lock only; this repo has zero lockfiles, so Trivy fs sees no Gradle dependency"
           codeql: "not a dependency scanner, and not a required check"

--- a/openbank-infra/gitops/components/lending/lending-service.yaml
+++ b/openbank-infra/gitops/components/lending/lending-service.yaml
@@ -34,7 +34,7 @@ spec:
       annotations:
         # Rolls the pods when the OPA bundle changes — subPath mounts do NOT hot-reload.
         # Kept in sync by gen-lending-opa-bundle.sh (do not hand-edit).
-        openbank.tech/policy-checksum: "deaf279f4d4422dd"
+        openbank.tech/policy-checksum: "1cb90fd24674d675"
     spec:
       securityContext:
         runAsNonRoot: true

--- a/openbank-infra/gitops/components/mcp/mcp-opa-bundle.yaml
+++ b/openbank-infra/gitops/components/mcp/mcp-opa-bundle.yaml
@@ -9,7 +9,7 @@ metadata:
     app.kubernetes.io/name: mcp-service
     app.kubernetes.io/part-of: platform
   annotations:
-    openbank.tech/policy-checksum: "1e0152b370168318"
+    openbank.tech/policy-checksum: "e802ef1f169a8399"
 data:
   rest.rego: |
     # SPDX-License-Identifier: Apache-2.0
@@ -2614,9 +2614,44 @@ data:
           gate keeps reporting green while checking nothing about Gradle -- a silent hole, not a
           visible failure.
         requires:
-          - ".github/workflows/dependency-submission.yml runs on pull_request with the same path filter"
+          - ".github/workflows/dependency-submission.yml runs on pull_request with a manifest path filter"
+          - "its push:[main] trigger is DELIBERATELY UNFILTERED -- see base_snapshot below (#2833)"
           - "dependency-review arms retry-on-snapshot-warnings ONLY on dependency-touching PRs"
           - "dependency-submission failures raise a tracking issue (a stale graph makes the gate vacuous)"
+        base_snapshot: >
+          Snapshots are looked up by EXACT SHA and the compare endpoint is three-dot, so the graph
+          the gate diffs against is the MERGE-BASE of the PR -- an arbitrary main commit. While the
+          push:[main] trigger carried the same manifest path filter as the pull_request one, only
+          ~2% of main commits produced a snapshot (measured: 1 of 50), so the merge-base almost
+          never had one and the action silently fell back to reporting the ENTIRE head graph as
+          additions. That is how the allowlist below was accreted. The push trigger is therefore
+          unfiltered: every main commit submits, so the merge-base always resolves. Ancestry of
+          pull_request.base.sha is NOT a factor -- three-dot compare resolves the merge-base itself.
+        scope: >
+          detachedConfiguration* and the root buildscript `classpath` are EXCLUDED from the
+          submitted graph (dependency-graph-exclude-configurations). `configurations.all {
+          resolutionStrategy { force(...) } }` -- how openbank.dependency-vulnerability-pins applies
+          the fleet patch floors -- cannot reach a detachedConfiguration, so those resolve their own
+          older versions of the same modules and submit coordinates no service can load. Measured:
+          105 of 1389 resolved coordinates came only from a detached configuration and carried 24 of
+          30 findings; filtering both took the graph 1235 -> 1091 and findings 30 -> 3.
+          Test coverage is NOT reduced -- testCompileClasspath / testRuntimeClasspath /
+          integrationTest* are all still submitted.
+          Excluding `classpath` IS a deliberate narrowing: a vulnerable BUILD plugin never ships but
+          does run on CI runners, and this gate is about what ships. Revisit if build-time supply
+          chain becomes an explicit goal.
+        allowlist: >
+          allow-ghsas is DELIBERATELY EMPTY. It held seven suppressions (json-smart 2.5.0,
+          netty-handler 4.2.1, netty-codec-http2 4.1.119), every one silencing a coordinate that
+          only ever existed via a detached/buildscript configuration -- removed at source by the
+          scope filter above instead. An allow-ghsas entry is a PERMANENT FLEET-WIDE suppression: it
+          hides the pre-existing false positive it was added for AND a future PR that genuinely
+          introduces the same GHSA on a real classpath, so each entry buys quiet with a hole.
+          Before adding one, run the extractor's own diagnostic
+          (:ForceDependencyResolutionPlugin_resolveAllDependencies + SimpleDependencyGraphPlugin)
+          and read `resolvedBy` in dependency-resolution.json: a single entry naming a detached or
+          buildscript configuration is a graph artifact -- widen the scope filter, do not allowlist.
+          Entries naming a real *Classpath are a genuine finding -- bump the pin.
         not_covered_by:
           trivy_fs: "Trivy's Java coverage is JAR / pom.xml / gradle.lockfile / *.sbt.lock only; this repo has zero lockfiles, so Trivy fs sees no Gradle dependency"
           codeql: "not a dependency scanner, and not a required check"

--- a/openbank-infra/gitops/components/mcp/mcp-service.yaml
+++ b/openbank-infra/gitops/components/mcp/mcp-service.yaml
@@ -29,7 +29,7 @@ spec:
       annotations:
         # Rolls the pod when the OPA bundle changes — subPath mounts do NOT hot-reload.
         # Kept in sync by gen-mcp-opa-bundle.sh (do not hand-edit).
-        openbank.tech/policy-checksum: "1e0152b370168318"
+        openbank.tech/policy-checksum: "e802ef1f169a8399"
     spec:
       securityContext:
         runAsNonRoot: true

--- a/openbank-infra/gitops/components/notifications/notification-service-opa-bundle.yaml
+++ b/openbank-infra/gitops/components/notifications/notification-service-opa-bundle.yaml
@@ -10,7 +10,7 @@ metadata:
     app.kubernetes.io/name: notification-service
     app.kubernetes.io/part-of: notifications
   annotations:
-    openbank.tech/policy-checksum: "7f3df409fd1c9054"
+    openbank.tech/policy-checksum: "fd428b03c6dbf972"
 data:
   rest.rego: |
     # SPDX-License-Identifier: Apache-2.0
@@ -1837,9 +1837,44 @@ data:
           gate keeps reporting green while checking nothing about Gradle -- a silent hole, not a
           visible failure.
         requires:
-          - ".github/workflows/dependency-submission.yml runs on pull_request with the same path filter"
+          - ".github/workflows/dependency-submission.yml runs on pull_request with a manifest path filter"
+          - "its push:[main] trigger is DELIBERATELY UNFILTERED -- see base_snapshot below (#2833)"
           - "dependency-review arms retry-on-snapshot-warnings ONLY on dependency-touching PRs"
           - "dependency-submission failures raise a tracking issue (a stale graph makes the gate vacuous)"
+        base_snapshot: >
+          Snapshots are looked up by EXACT SHA and the compare endpoint is three-dot, so the graph
+          the gate diffs against is the MERGE-BASE of the PR -- an arbitrary main commit. While the
+          push:[main] trigger carried the same manifest path filter as the pull_request one, only
+          ~2% of main commits produced a snapshot (measured: 1 of 50), so the merge-base almost
+          never had one and the action silently fell back to reporting the ENTIRE head graph as
+          additions. That is how the allowlist below was accreted. The push trigger is therefore
+          unfiltered: every main commit submits, so the merge-base always resolves. Ancestry of
+          pull_request.base.sha is NOT a factor -- three-dot compare resolves the merge-base itself.
+        scope: >
+          detachedConfiguration* and the root buildscript `classpath` are EXCLUDED from the
+          submitted graph (dependency-graph-exclude-configurations). `configurations.all {
+          resolutionStrategy { force(...) } }` -- how openbank.dependency-vulnerability-pins applies
+          the fleet patch floors -- cannot reach a detachedConfiguration, so those resolve their own
+          older versions of the same modules and submit coordinates no service can load. Measured:
+          105 of 1389 resolved coordinates came only from a detached configuration and carried 24 of
+          30 findings; filtering both took the graph 1235 -> 1091 and findings 30 -> 3.
+          Test coverage is NOT reduced -- testCompileClasspath / testRuntimeClasspath /
+          integrationTest* are all still submitted.
+          Excluding `classpath` IS a deliberate narrowing: a vulnerable BUILD plugin never ships but
+          does run on CI runners, and this gate is about what ships. Revisit if build-time supply
+          chain becomes an explicit goal.
+        allowlist: >
+          allow-ghsas is DELIBERATELY EMPTY. It held seven suppressions (json-smart 2.5.0,
+          netty-handler 4.2.1, netty-codec-http2 4.1.119), every one silencing a coordinate that
+          only ever existed via a detached/buildscript configuration -- removed at source by the
+          scope filter above instead. An allow-ghsas entry is a PERMANENT FLEET-WIDE suppression: it
+          hides the pre-existing false positive it was added for AND a future PR that genuinely
+          introduces the same GHSA on a real classpath, so each entry buys quiet with a hole.
+          Before adding one, run the extractor's own diagnostic
+          (:ForceDependencyResolutionPlugin_resolveAllDependencies + SimpleDependencyGraphPlugin)
+          and read `resolvedBy` in dependency-resolution.json: a single entry naming a detached or
+          buildscript configuration is a graph artifact -- widen the scope filter, do not allowlist.
+          Entries naming a real *Classpath are a genuine finding -- bump the pin.
         not_covered_by:
           trivy_fs: "Trivy's Java coverage is JAR / pom.xml / gradle.lockfile / *.sbt.lock only; this repo has zero lockfiles, so Trivy fs sees no Gradle dependency"
           codeql: "not a dependency scanner, and not a required check"

--- a/openbank-infra/gitops/components/notifications/notification-service.yaml
+++ b/openbank-infra/gitops/components/notifications/notification-service.yaml
@@ -39,7 +39,7 @@ spec:
       annotations:
         # Rolls the Deployment when the OPA policy bundle changes (subPath mounts don't
         # hot-reload). Kept in sync by gen-notification-opa-bundle.sh.
-        openbank.tech/policy-checksum: "7f3df409fd1c9054"
+        openbank.tech/policy-checksum: "fd428b03c6dbf972"
       labels:
         app.kubernetes.io/name: notification-service
         app.kubernetes.io/part-of: notifications

--- a/openbank-infra/gitops/components/party/party-opa-bundle.yaml
+++ b/openbank-infra/gitops/components/party/party-opa-bundle.yaml
@@ -9,7 +9,7 @@ metadata:
     app.kubernetes.io/name: party-service
     app.kubernetes.io/part-of: party
   annotations:
-    openbank.tech/policy-checksum: "623999d5271a47d5"
+    openbank.tech/policy-checksum: "8e36ddea24566bcb"
 data:
   rest.rego: |
     # SPDX-License-Identifier: Apache-2.0
@@ -2685,9 +2685,44 @@ data:
           gate keeps reporting green while checking nothing about Gradle -- a silent hole, not a
           visible failure.
         requires:
-          - ".github/workflows/dependency-submission.yml runs on pull_request with the same path filter"
+          - ".github/workflows/dependency-submission.yml runs on pull_request with a manifest path filter"
+          - "its push:[main] trigger is DELIBERATELY UNFILTERED -- see base_snapshot below (#2833)"
           - "dependency-review arms retry-on-snapshot-warnings ONLY on dependency-touching PRs"
           - "dependency-submission failures raise a tracking issue (a stale graph makes the gate vacuous)"
+        base_snapshot: >
+          Snapshots are looked up by EXACT SHA and the compare endpoint is three-dot, so the graph
+          the gate diffs against is the MERGE-BASE of the PR -- an arbitrary main commit. While the
+          push:[main] trigger carried the same manifest path filter as the pull_request one, only
+          ~2% of main commits produced a snapshot (measured: 1 of 50), so the merge-base almost
+          never had one and the action silently fell back to reporting the ENTIRE head graph as
+          additions. That is how the allowlist below was accreted. The push trigger is therefore
+          unfiltered: every main commit submits, so the merge-base always resolves. Ancestry of
+          pull_request.base.sha is NOT a factor -- three-dot compare resolves the merge-base itself.
+        scope: >
+          detachedConfiguration* and the root buildscript `classpath` are EXCLUDED from the
+          submitted graph (dependency-graph-exclude-configurations). `configurations.all {
+          resolutionStrategy { force(...) } }` -- how openbank.dependency-vulnerability-pins applies
+          the fleet patch floors -- cannot reach a detachedConfiguration, so those resolve their own
+          older versions of the same modules and submit coordinates no service can load. Measured:
+          105 of 1389 resolved coordinates came only from a detached configuration and carried 24 of
+          30 findings; filtering both took the graph 1235 -> 1091 and findings 30 -> 3.
+          Test coverage is NOT reduced -- testCompileClasspath / testRuntimeClasspath /
+          integrationTest* are all still submitted.
+          Excluding `classpath` IS a deliberate narrowing: a vulnerable BUILD plugin never ships but
+          does run on CI runners, and this gate is about what ships. Revisit if build-time supply
+          chain becomes an explicit goal.
+        allowlist: >
+          allow-ghsas is DELIBERATELY EMPTY. It held seven suppressions (json-smart 2.5.0,
+          netty-handler 4.2.1, netty-codec-http2 4.1.119), every one silencing a coordinate that
+          only ever existed via a detached/buildscript configuration -- removed at source by the
+          scope filter above instead. An allow-ghsas entry is a PERMANENT FLEET-WIDE suppression: it
+          hides the pre-existing false positive it was added for AND a future PR that genuinely
+          introduces the same GHSA on a real classpath, so each entry buys quiet with a hole.
+          Before adding one, run the extractor's own diagnostic
+          (:ForceDependencyResolutionPlugin_resolveAllDependencies + SimpleDependencyGraphPlugin)
+          and read `resolvedBy` in dependency-resolution.json: a single entry naming a detached or
+          buildscript configuration is a graph artifact -- widen the scope filter, do not allowlist.
+          Entries naming a real *Classpath are a genuine finding -- bump the pin.
         not_covered_by:
           trivy_fs: "Trivy's Java coverage is JAR / pom.xml / gradle.lockfile / *.sbt.lock only; this repo has zero lockfiles, so Trivy fs sees no Gradle dependency"
           codeql: "not a dependency scanner, and not a required check"

--- a/openbank-infra/gitops/components/party/party-service.yaml
+++ b/openbank-infra/gitops/components/party/party-service.yaml
@@ -22,7 +22,7 @@ spec:
       annotations:
         # Rolls the pod when the OPA bundle changes — subPath mounts do NOT hot-reload.
         # Kept in sync by gen-party-opa-bundle.sh (do not hand-edit).
-        openbank.tech/policy-checksum: "623999d5271a47d5"
+        openbank.tech/policy-checksum: "8e36ddea24566bcb"
       labels:
         app.kubernetes.io/name: party-service
         app.kubernetes.io/part-of: party

--- a/openbank-infra/gitops/components/payments/card-issuance-opa-bundle.yaml
+++ b/openbank-infra/gitops/components/payments/card-issuance-opa-bundle.yaml
@@ -9,7 +9,7 @@ metadata:
     app.kubernetes.io/name: card-issuance-service
     app.kubernetes.io/part-of: payments
   annotations:
-    openbank.tech/policy-checksum: "5db7e2c207721dc1"
+    openbank.tech/policy-checksum: "d5bbdc1cefeca8b0"
 data:
   rest.rego: |
     # SPDX-License-Identifier: Apache-2.0
@@ -2669,9 +2669,44 @@ data:
           gate keeps reporting green while checking nothing about Gradle -- a silent hole, not a
           visible failure.
         requires:
-          - ".github/workflows/dependency-submission.yml runs on pull_request with the same path filter"
+          - ".github/workflows/dependency-submission.yml runs on pull_request with a manifest path filter"
+          - "its push:[main] trigger is DELIBERATELY UNFILTERED -- see base_snapshot below (#2833)"
           - "dependency-review arms retry-on-snapshot-warnings ONLY on dependency-touching PRs"
           - "dependency-submission failures raise a tracking issue (a stale graph makes the gate vacuous)"
+        base_snapshot: >
+          Snapshots are looked up by EXACT SHA and the compare endpoint is three-dot, so the graph
+          the gate diffs against is the MERGE-BASE of the PR -- an arbitrary main commit. While the
+          push:[main] trigger carried the same manifest path filter as the pull_request one, only
+          ~2% of main commits produced a snapshot (measured: 1 of 50), so the merge-base almost
+          never had one and the action silently fell back to reporting the ENTIRE head graph as
+          additions. That is how the allowlist below was accreted. The push trigger is therefore
+          unfiltered: every main commit submits, so the merge-base always resolves. Ancestry of
+          pull_request.base.sha is NOT a factor -- three-dot compare resolves the merge-base itself.
+        scope: >
+          detachedConfiguration* and the root buildscript `classpath` are EXCLUDED from the
+          submitted graph (dependency-graph-exclude-configurations). `configurations.all {
+          resolutionStrategy { force(...) } }` -- how openbank.dependency-vulnerability-pins applies
+          the fleet patch floors -- cannot reach a detachedConfiguration, so those resolve their own
+          older versions of the same modules and submit coordinates no service can load. Measured:
+          105 of 1389 resolved coordinates came only from a detached configuration and carried 24 of
+          30 findings; filtering both took the graph 1235 -> 1091 and findings 30 -> 3.
+          Test coverage is NOT reduced -- testCompileClasspath / testRuntimeClasspath /
+          integrationTest* are all still submitted.
+          Excluding `classpath` IS a deliberate narrowing: a vulnerable BUILD plugin never ships but
+          does run on CI runners, and this gate is about what ships. Revisit if build-time supply
+          chain becomes an explicit goal.
+        allowlist: >
+          allow-ghsas is DELIBERATELY EMPTY. It held seven suppressions (json-smart 2.5.0,
+          netty-handler 4.2.1, netty-codec-http2 4.1.119), every one silencing a coordinate that
+          only ever existed via a detached/buildscript configuration -- removed at source by the
+          scope filter above instead. An allow-ghsas entry is a PERMANENT FLEET-WIDE suppression: it
+          hides the pre-existing false positive it was added for AND a future PR that genuinely
+          introduces the same GHSA on a real classpath, so each entry buys quiet with a hole.
+          Before adding one, run the extractor's own diagnostic
+          (:ForceDependencyResolutionPlugin_resolveAllDependencies + SimpleDependencyGraphPlugin)
+          and read `resolvedBy` in dependency-resolution.json: a single entry naming a detached or
+          buildscript configuration is a graph artifact -- widen the scope filter, do not allowlist.
+          Entries naming a real *Classpath are a genuine finding -- bump the pin.
         not_covered_by:
           trivy_fs: "Trivy's Java coverage is JAR / pom.xml / gradle.lockfile / *.sbt.lock only; this repo has zero lockfiles, so Trivy fs sees no Gradle dependency"
           codeql: "not a dependency scanner, and not a required check"

--- a/openbank-infra/gitops/components/payments/clearing-opa-bundle.yaml
+++ b/openbank-infra/gitops/components/payments/clearing-opa-bundle.yaml
@@ -9,7 +9,7 @@ metadata:
     app.kubernetes.io/name: clearing-service
     app.kubernetes.io/part-of: payments
   annotations:
-    openbank.tech/policy-checksum: "878c3a860f6e2f71"
+    openbank.tech/policy-checksum: "0ad68da38bb1b73f"
 data:
   rest.rego: |
     # SPDX-License-Identifier: Apache-2.0
@@ -2706,9 +2706,44 @@ data:
           gate keeps reporting green while checking nothing about Gradle -- a silent hole, not a
           visible failure.
         requires:
-          - ".github/workflows/dependency-submission.yml runs on pull_request with the same path filter"
+          - ".github/workflows/dependency-submission.yml runs on pull_request with a manifest path filter"
+          - "its push:[main] trigger is DELIBERATELY UNFILTERED -- see base_snapshot below (#2833)"
           - "dependency-review arms retry-on-snapshot-warnings ONLY on dependency-touching PRs"
           - "dependency-submission failures raise a tracking issue (a stale graph makes the gate vacuous)"
+        base_snapshot: >
+          Snapshots are looked up by EXACT SHA and the compare endpoint is three-dot, so the graph
+          the gate diffs against is the MERGE-BASE of the PR -- an arbitrary main commit. While the
+          push:[main] trigger carried the same manifest path filter as the pull_request one, only
+          ~2% of main commits produced a snapshot (measured: 1 of 50), so the merge-base almost
+          never had one and the action silently fell back to reporting the ENTIRE head graph as
+          additions. That is how the allowlist below was accreted. The push trigger is therefore
+          unfiltered: every main commit submits, so the merge-base always resolves. Ancestry of
+          pull_request.base.sha is NOT a factor -- three-dot compare resolves the merge-base itself.
+        scope: >
+          detachedConfiguration* and the root buildscript `classpath` are EXCLUDED from the
+          submitted graph (dependency-graph-exclude-configurations). `configurations.all {
+          resolutionStrategy { force(...) } }` -- how openbank.dependency-vulnerability-pins applies
+          the fleet patch floors -- cannot reach a detachedConfiguration, so those resolve their own
+          older versions of the same modules and submit coordinates no service can load. Measured:
+          105 of 1389 resolved coordinates came only from a detached configuration and carried 24 of
+          30 findings; filtering both took the graph 1235 -> 1091 and findings 30 -> 3.
+          Test coverage is NOT reduced -- testCompileClasspath / testRuntimeClasspath /
+          integrationTest* are all still submitted.
+          Excluding `classpath` IS a deliberate narrowing: a vulnerable BUILD plugin never ships but
+          does run on CI runners, and this gate is about what ships. Revisit if build-time supply
+          chain becomes an explicit goal.
+        allowlist: >
+          allow-ghsas is DELIBERATELY EMPTY. It held seven suppressions (json-smart 2.5.0,
+          netty-handler 4.2.1, netty-codec-http2 4.1.119), every one silencing a coordinate that
+          only ever existed via a detached/buildscript configuration -- removed at source by the
+          scope filter above instead. An allow-ghsas entry is a PERMANENT FLEET-WIDE suppression: it
+          hides the pre-existing false positive it was added for AND a future PR that genuinely
+          introduces the same GHSA on a real classpath, so each entry buys quiet with a hole.
+          Before adding one, run the extractor's own diagnostic
+          (:ForceDependencyResolutionPlugin_resolveAllDependencies + SimpleDependencyGraphPlugin)
+          and read `resolvedBy` in dependency-resolution.json: a single entry naming a detached or
+          buildscript configuration is a graph artifact -- widen the scope filter, do not allowlist.
+          Entries naming a real *Classpath are a genuine finding -- bump the pin.
         not_covered_by:
           trivy_fs: "Trivy's Java coverage is JAR / pom.xml / gradle.lockfile / *.sbt.lock only; this repo has zero lockfiles, so Trivy fs sees no Gradle dependency"
           codeql: "not a dependency scanner, and not a required check"

--- a/openbank-infra/gitops/components/payments/domestic-payment-opa-bundle.yaml
+++ b/openbank-infra/gitops/components/payments/domestic-payment-opa-bundle.yaml
@@ -9,7 +9,7 @@ metadata:
     app.kubernetes.io/name: domestic-payment
     app.kubernetes.io/part-of: payments
   annotations:
-    openbank.tech/policy-checksum: "e110230c4137075a"
+    openbank.tech/policy-checksum: "78f4877fbd7eb601"
 data:
   rest.rego: |
     # SPDX-License-Identifier: Apache-2.0
@@ -2691,9 +2691,44 @@ data:
           gate keeps reporting green while checking nothing about Gradle -- a silent hole, not a
           visible failure.
         requires:
-          - ".github/workflows/dependency-submission.yml runs on pull_request with the same path filter"
+          - ".github/workflows/dependency-submission.yml runs on pull_request with a manifest path filter"
+          - "its push:[main] trigger is DELIBERATELY UNFILTERED -- see base_snapshot below (#2833)"
           - "dependency-review arms retry-on-snapshot-warnings ONLY on dependency-touching PRs"
           - "dependency-submission failures raise a tracking issue (a stale graph makes the gate vacuous)"
+        base_snapshot: >
+          Snapshots are looked up by EXACT SHA and the compare endpoint is three-dot, so the graph
+          the gate diffs against is the MERGE-BASE of the PR -- an arbitrary main commit. While the
+          push:[main] trigger carried the same manifest path filter as the pull_request one, only
+          ~2% of main commits produced a snapshot (measured: 1 of 50), so the merge-base almost
+          never had one and the action silently fell back to reporting the ENTIRE head graph as
+          additions. That is how the allowlist below was accreted. The push trigger is therefore
+          unfiltered: every main commit submits, so the merge-base always resolves. Ancestry of
+          pull_request.base.sha is NOT a factor -- three-dot compare resolves the merge-base itself.
+        scope: >
+          detachedConfiguration* and the root buildscript `classpath` are EXCLUDED from the
+          submitted graph (dependency-graph-exclude-configurations). `configurations.all {
+          resolutionStrategy { force(...) } }` -- how openbank.dependency-vulnerability-pins applies
+          the fleet patch floors -- cannot reach a detachedConfiguration, so those resolve their own
+          older versions of the same modules and submit coordinates no service can load. Measured:
+          105 of 1389 resolved coordinates came only from a detached configuration and carried 24 of
+          30 findings; filtering both took the graph 1235 -> 1091 and findings 30 -> 3.
+          Test coverage is NOT reduced -- testCompileClasspath / testRuntimeClasspath /
+          integrationTest* are all still submitted.
+          Excluding `classpath` IS a deliberate narrowing: a vulnerable BUILD plugin never ships but
+          does run on CI runners, and this gate is about what ships. Revisit if build-time supply
+          chain becomes an explicit goal.
+        allowlist: >
+          allow-ghsas is DELIBERATELY EMPTY. It held seven suppressions (json-smart 2.5.0,
+          netty-handler 4.2.1, netty-codec-http2 4.1.119), every one silencing a coordinate that
+          only ever existed via a detached/buildscript configuration -- removed at source by the
+          scope filter above instead. An allow-ghsas entry is a PERMANENT FLEET-WIDE suppression: it
+          hides the pre-existing false positive it was added for AND a future PR that genuinely
+          introduces the same GHSA on a real classpath, so each entry buys quiet with a hole.
+          Before adding one, run the extractor's own diagnostic
+          (:ForceDependencyResolutionPlugin_resolveAllDependencies + SimpleDependencyGraphPlugin)
+          and read `resolvedBy` in dependency-resolution.json: a single entry naming a detached or
+          buildscript configuration is a graph artifact -- widen the scope filter, do not allowlist.
+          Entries naming a real *Classpath are a genuine finding -- bump the pin.
         not_covered_by:
           trivy_fs: "Trivy's Java coverage is JAR / pom.xml / gradle.lockfile / *.sbt.lock only; this repo has zero lockfiles, so Trivy fs sees no Gradle dependency"
           codeql: "not a dependency scanner, and not a required check"

--- a/openbank-infra/gitops/components/payments/payments-services.yaml
+++ b/openbank-infra/gitops/components/payments/payments-services.yaml
@@ -42,7 +42,7 @@ spec:
         # Rolls the pods when the OPA bundle changes — subPath mounts do NOT hot-reload.
         # Kept in sync by gen-transaction-opa-bundle.sh via the trailing marker comment
         # (do not hand-edit, do not drop the marker).
-        openbank.tech/policy-checksum: "4738dc9657863425" # transaction-opa-bundle
+        openbank.tech/policy-checksum: "763b4874e18a0604" # transaction-opa-bundle
     spec:
       securityContext:
         runAsNonRoot: true
@@ -375,7 +375,7 @@ spec:
       annotations:
         # Rolls the pods when the OPA bundle changes — subPath mounts do NOT hot-reload.
         # Kept in sync by gen-sepa-payment-opa-bundle.sh (do not hand-edit).
-        openbank.tech/policy-checksum: "76a8d6ffb38e071a"
+        openbank.tech/policy-checksum: "8e3d002658dc364e"
     spec:
       securityContext:
         runAsNonRoot: true
@@ -729,7 +729,7 @@ spec:
         # Rolls the pods when the OPA bundle changes — subPath mounts do NOT hot-reload.
         # Kept in sync by gen-domestic-payment-opa-bundle.sh via the trailing marker
         # comment (do not hand-edit, do not drop the marker).
-        openbank.tech/policy-checksum: "e110230c4137075a" # domestic-payment-opa-bundle
+        openbank.tech/policy-checksum: "78f4877fbd7eb601" # domestic-payment-opa-bundle
     spec:
       securityContext:
         runAsNonRoot: true
@@ -1053,7 +1053,7 @@ spec:
       annotations:
         # Rolls the pods when the OPA bundle changes — subPath mounts do NOT hot-reload.
         # Kept in sync by gen-sepa-instant-opa-bundle.sh (do not hand-edit).
-        openbank.tech/policy-checksum: "0b555cd1840da943"
+        openbank.tech/policy-checksum: "c655b727d7fae5b4"
     spec:
       securityContext:
         runAsNonRoot: true
@@ -1369,7 +1369,7 @@ spec:
         # Rolls the pods when the OPA bundle changes — subPath mounts do NOT hot-reload.
         # Kept in sync by gen-clearing-opa-bundle.sh via the trailing marker comment
         # (do not hand-edit, do not drop the marker).
-        openbank.tech/policy-checksum: "878c3a860f6e2f71" # clearing-opa-bundle
+        openbank.tech/policy-checksum: "0ad68da38bb1b73f" # clearing-opa-bundle
     spec:
       securityContext:
         runAsNonRoot: true
@@ -1658,7 +1658,7 @@ spec:
       annotations:
         # Rolls the pod when the OPA bundle changes (ADR-0034). Value is stamped by
         # gen-standing-order-opa-bundle.sh — do not hand-edit.
-        openbank.tech/policy-checksum: "a490996a0734796c" # standing-order-opa-bundle
+        openbank.tech/policy-checksum: "07296c3222f70124" # standing-order-opa-bundle
     spec:
       securityContext:
         runAsNonRoot: true
@@ -1911,7 +1911,7 @@ spec:
       annotations:
         # Rolls the pods when the OPA bundle changes — subPath mounts do NOT hot-reload.
         # Kept in sync by gen-card-issuance-opa-bundle.sh (do not hand-edit).
-        openbank.tech/policy-checksum: "5db7e2c207721dc1"
+        openbank.tech/policy-checksum: "d5bbdc1cefeca8b0"
     spec:
       securityContext:
         runAsNonRoot: true
@@ -2181,7 +2181,7 @@ spec:
         # Rolls the pods when the OPA bundle changes — subPath mounts do NOT hot-reload.
         # Kept in sync by gen-settlement-opa-bundle.sh via the trailing marker comment
         # (do not hand-edit, do not drop the marker).
-        openbank.tech/policy-checksum: "01d349b06adb1859" # settlement-opa-bundle
+        openbank.tech/policy-checksum: "ae71e4ffc78491e3" # settlement-opa-bundle
     spec:
       securityContext:
         runAsNonRoot: true
@@ -2582,7 +2582,7 @@ spec:
       annotations:
         # Rolls the pods when the OPA bundle changes — subPath mounts do NOT hot-reload.
         # Kept in sync by gen-swift-opa-bundle.sh (do not hand-edit).
-        openbank.tech/policy-checksum: "db5da1d242163b7f"
+        openbank.tech/policy-checksum: "427522265ff3cf1d"
     spec:
       securityContext:
         runAsNonRoot: true
@@ -2896,7 +2896,7 @@ spec:
       annotations:
         # Rolls the pods when the OPA bundle changes — subPath mounts do NOT hot-reload.
         # Kept in sync by gen-vop-opa-bundle.sh (do not hand-edit).
-        openbank.tech/policy-checksum: "d32ef0c644ec0505"
+        openbank.tech/policy-checksum: "51508f0eb17d5612"
     spec:
       securityContext:
         runAsNonRoot: true

--- a/openbank-infra/gitops/components/payments/sepa-instant-opa-bundle.yaml
+++ b/openbank-infra/gitops/components/payments/sepa-instant-opa-bundle.yaml
@@ -9,7 +9,7 @@ metadata:
     app.kubernetes.io/name: sepa-instant
     app.kubernetes.io/part-of: payments
   annotations:
-    openbank.tech/policy-checksum: "0b555cd1840da943"
+    openbank.tech/policy-checksum: "c655b727d7fae5b4"
 data:
   rest.rego: |
     # SPDX-License-Identifier: Apache-2.0
@@ -2664,9 +2664,44 @@ data:
           gate keeps reporting green while checking nothing about Gradle -- a silent hole, not a
           visible failure.
         requires:
-          - ".github/workflows/dependency-submission.yml runs on pull_request with the same path filter"
+          - ".github/workflows/dependency-submission.yml runs on pull_request with a manifest path filter"
+          - "its push:[main] trigger is DELIBERATELY UNFILTERED -- see base_snapshot below (#2833)"
           - "dependency-review arms retry-on-snapshot-warnings ONLY on dependency-touching PRs"
           - "dependency-submission failures raise a tracking issue (a stale graph makes the gate vacuous)"
+        base_snapshot: >
+          Snapshots are looked up by EXACT SHA and the compare endpoint is three-dot, so the graph
+          the gate diffs against is the MERGE-BASE of the PR -- an arbitrary main commit. While the
+          push:[main] trigger carried the same manifest path filter as the pull_request one, only
+          ~2% of main commits produced a snapshot (measured: 1 of 50), so the merge-base almost
+          never had one and the action silently fell back to reporting the ENTIRE head graph as
+          additions. That is how the allowlist below was accreted. The push trigger is therefore
+          unfiltered: every main commit submits, so the merge-base always resolves. Ancestry of
+          pull_request.base.sha is NOT a factor -- three-dot compare resolves the merge-base itself.
+        scope: >
+          detachedConfiguration* and the root buildscript `classpath` are EXCLUDED from the
+          submitted graph (dependency-graph-exclude-configurations). `configurations.all {
+          resolutionStrategy { force(...) } }` -- how openbank.dependency-vulnerability-pins applies
+          the fleet patch floors -- cannot reach a detachedConfiguration, so those resolve their own
+          older versions of the same modules and submit coordinates no service can load. Measured:
+          105 of 1389 resolved coordinates came only from a detached configuration and carried 24 of
+          30 findings; filtering both took the graph 1235 -> 1091 and findings 30 -> 3.
+          Test coverage is NOT reduced -- testCompileClasspath / testRuntimeClasspath /
+          integrationTest* are all still submitted.
+          Excluding `classpath` IS a deliberate narrowing: a vulnerable BUILD plugin never ships but
+          does run on CI runners, and this gate is about what ships. Revisit if build-time supply
+          chain becomes an explicit goal.
+        allowlist: >
+          allow-ghsas is DELIBERATELY EMPTY. It held seven suppressions (json-smart 2.5.0,
+          netty-handler 4.2.1, netty-codec-http2 4.1.119), every one silencing a coordinate that
+          only ever existed via a detached/buildscript configuration -- removed at source by the
+          scope filter above instead. An allow-ghsas entry is a PERMANENT FLEET-WIDE suppression: it
+          hides the pre-existing false positive it was added for AND a future PR that genuinely
+          introduces the same GHSA on a real classpath, so each entry buys quiet with a hole.
+          Before adding one, run the extractor's own diagnostic
+          (:ForceDependencyResolutionPlugin_resolveAllDependencies + SimpleDependencyGraphPlugin)
+          and read `resolvedBy` in dependency-resolution.json: a single entry naming a detached or
+          buildscript configuration is a graph artifact -- widen the scope filter, do not allowlist.
+          Entries naming a real *Classpath are a genuine finding -- bump the pin.
         not_covered_by:
           trivy_fs: "Trivy's Java coverage is JAR / pom.xml / gradle.lockfile / *.sbt.lock only; this repo has zero lockfiles, so Trivy fs sees no Gradle dependency"
           codeql: "not a dependency scanner, and not a required check"

--- a/openbank-infra/gitops/components/payments/sepa-payment-opa-bundle.yaml
+++ b/openbank-infra/gitops/components/payments/sepa-payment-opa-bundle.yaml
@@ -9,7 +9,7 @@ metadata:
     app.kubernetes.io/name: sepa-payment
     app.kubernetes.io/part-of: payments
   annotations:
-    openbank.tech/policy-checksum: "76a8d6ffb38e071a"
+    openbank.tech/policy-checksum: "8e3d002658dc364e"
 data:
   rest.rego: |
     # SPDX-License-Identifier: Apache-2.0
@@ -2685,9 +2685,44 @@ data:
           gate keeps reporting green while checking nothing about Gradle -- a silent hole, not a
           visible failure.
         requires:
-          - ".github/workflows/dependency-submission.yml runs on pull_request with the same path filter"
+          - ".github/workflows/dependency-submission.yml runs on pull_request with a manifest path filter"
+          - "its push:[main] trigger is DELIBERATELY UNFILTERED -- see base_snapshot below (#2833)"
           - "dependency-review arms retry-on-snapshot-warnings ONLY on dependency-touching PRs"
           - "dependency-submission failures raise a tracking issue (a stale graph makes the gate vacuous)"
+        base_snapshot: >
+          Snapshots are looked up by EXACT SHA and the compare endpoint is three-dot, so the graph
+          the gate diffs against is the MERGE-BASE of the PR -- an arbitrary main commit. While the
+          push:[main] trigger carried the same manifest path filter as the pull_request one, only
+          ~2% of main commits produced a snapshot (measured: 1 of 50), so the merge-base almost
+          never had one and the action silently fell back to reporting the ENTIRE head graph as
+          additions. That is how the allowlist below was accreted. The push trigger is therefore
+          unfiltered: every main commit submits, so the merge-base always resolves. Ancestry of
+          pull_request.base.sha is NOT a factor -- three-dot compare resolves the merge-base itself.
+        scope: >
+          detachedConfiguration* and the root buildscript `classpath` are EXCLUDED from the
+          submitted graph (dependency-graph-exclude-configurations). `configurations.all {
+          resolutionStrategy { force(...) } }` -- how openbank.dependency-vulnerability-pins applies
+          the fleet patch floors -- cannot reach a detachedConfiguration, so those resolve their own
+          older versions of the same modules and submit coordinates no service can load. Measured:
+          105 of 1389 resolved coordinates came only from a detached configuration and carried 24 of
+          30 findings; filtering both took the graph 1235 -> 1091 and findings 30 -> 3.
+          Test coverage is NOT reduced -- testCompileClasspath / testRuntimeClasspath /
+          integrationTest* are all still submitted.
+          Excluding `classpath` IS a deliberate narrowing: a vulnerable BUILD plugin never ships but
+          does run on CI runners, and this gate is about what ships. Revisit if build-time supply
+          chain becomes an explicit goal.
+        allowlist: >
+          allow-ghsas is DELIBERATELY EMPTY. It held seven suppressions (json-smart 2.5.0,
+          netty-handler 4.2.1, netty-codec-http2 4.1.119), every one silencing a coordinate that
+          only ever existed via a detached/buildscript configuration -- removed at source by the
+          scope filter above instead. An allow-ghsas entry is a PERMANENT FLEET-WIDE suppression: it
+          hides the pre-existing false positive it was added for AND a future PR that genuinely
+          introduces the same GHSA on a real classpath, so each entry buys quiet with a hole.
+          Before adding one, run the extractor's own diagnostic
+          (:ForceDependencyResolutionPlugin_resolveAllDependencies + SimpleDependencyGraphPlugin)
+          and read `resolvedBy` in dependency-resolution.json: a single entry naming a detached or
+          buildscript configuration is a graph artifact -- widen the scope filter, do not allowlist.
+          Entries naming a real *Classpath are a genuine finding -- bump the pin.
         not_covered_by:
           trivy_fs: "Trivy's Java coverage is JAR / pom.xml / gradle.lockfile / *.sbt.lock only; this repo has zero lockfiles, so Trivy fs sees no Gradle dependency"
           codeql: "not a dependency scanner, and not a required check"

--- a/openbank-infra/gitops/components/payments/settlement-opa-bundle.yaml
+++ b/openbank-infra/gitops/components/payments/settlement-opa-bundle.yaml
@@ -9,7 +9,7 @@ metadata:
     app.kubernetes.io/name: settlement-service
     app.kubernetes.io/part-of: payments
   annotations:
-    openbank.tech/policy-checksum: "01d349b06adb1859"
+    openbank.tech/policy-checksum: "ae71e4ffc78491e3"
 data:
   rest.rego: |
     # SPDX-License-Identifier: Apache-2.0
@@ -2665,9 +2665,44 @@ data:
           gate keeps reporting green while checking nothing about Gradle -- a silent hole, not a
           visible failure.
         requires:
-          - ".github/workflows/dependency-submission.yml runs on pull_request with the same path filter"
+          - ".github/workflows/dependency-submission.yml runs on pull_request with a manifest path filter"
+          - "its push:[main] trigger is DELIBERATELY UNFILTERED -- see base_snapshot below (#2833)"
           - "dependency-review arms retry-on-snapshot-warnings ONLY on dependency-touching PRs"
           - "dependency-submission failures raise a tracking issue (a stale graph makes the gate vacuous)"
+        base_snapshot: >
+          Snapshots are looked up by EXACT SHA and the compare endpoint is three-dot, so the graph
+          the gate diffs against is the MERGE-BASE of the PR -- an arbitrary main commit. While the
+          push:[main] trigger carried the same manifest path filter as the pull_request one, only
+          ~2% of main commits produced a snapshot (measured: 1 of 50), so the merge-base almost
+          never had one and the action silently fell back to reporting the ENTIRE head graph as
+          additions. That is how the allowlist below was accreted. The push trigger is therefore
+          unfiltered: every main commit submits, so the merge-base always resolves. Ancestry of
+          pull_request.base.sha is NOT a factor -- three-dot compare resolves the merge-base itself.
+        scope: >
+          detachedConfiguration* and the root buildscript `classpath` are EXCLUDED from the
+          submitted graph (dependency-graph-exclude-configurations). `configurations.all {
+          resolutionStrategy { force(...) } }` -- how openbank.dependency-vulnerability-pins applies
+          the fleet patch floors -- cannot reach a detachedConfiguration, so those resolve their own
+          older versions of the same modules and submit coordinates no service can load. Measured:
+          105 of 1389 resolved coordinates came only from a detached configuration and carried 24 of
+          30 findings; filtering both took the graph 1235 -> 1091 and findings 30 -> 3.
+          Test coverage is NOT reduced -- testCompileClasspath / testRuntimeClasspath /
+          integrationTest* are all still submitted.
+          Excluding `classpath` IS a deliberate narrowing: a vulnerable BUILD plugin never ships but
+          does run on CI runners, and this gate is about what ships. Revisit if build-time supply
+          chain becomes an explicit goal.
+        allowlist: >
+          allow-ghsas is DELIBERATELY EMPTY. It held seven suppressions (json-smart 2.5.0,
+          netty-handler 4.2.1, netty-codec-http2 4.1.119), every one silencing a coordinate that
+          only ever existed via a detached/buildscript configuration -- removed at source by the
+          scope filter above instead. An allow-ghsas entry is a PERMANENT FLEET-WIDE suppression: it
+          hides the pre-existing false positive it was added for AND a future PR that genuinely
+          introduces the same GHSA on a real classpath, so each entry buys quiet with a hole.
+          Before adding one, run the extractor's own diagnostic
+          (:ForceDependencyResolutionPlugin_resolveAllDependencies + SimpleDependencyGraphPlugin)
+          and read `resolvedBy` in dependency-resolution.json: a single entry naming a detached or
+          buildscript configuration is a graph artifact -- widen the scope filter, do not allowlist.
+          Entries naming a real *Classpath are a genuine finding -- bump the pin.
         not_covered_by:
           trivy_fs: "Trivy's Java coverage is JAR / pom.xml / gradle.lockfile / *.sbt.lock only; this repo has zero lockfiles, so Trivy fs sees no Gradle dependency"
           codeql: "not a dependency scanner, and not a required check"

--- a/openbank-infra/gitops/components/payments/standing-order-opa-bundle.yaml
+++ b/openbank-infra/gitops/components/payments/standing-order-opa-bundle.yaml
@@ -9,7 +9,7 @@ metadata:
     app.kubernetes.io/name: standing-order-service
     app.kubernetes.io/part-of: payments
   annotations:
-    openbank.tech/policy-checksum: "a490996a0734796c"
+    openbank.tech/policy-checksum: "07296c3222f70124"
 data:
   rest.rego: |
     # SPDX-License-Identifier: Apache-2.0
@@ -2650,9 +2650,44 @@ data:
           gate keeps reporting green while checking nothing about Gradle -- a silent hole, not a
           visible failure.
         requires:
-          - ".github/workflows/dependency-submission.yml runs on pull_request with the same path filter"
+          - ".github/workflows/dependency-submission.yml runs on pull_request with a manifest path filter"
+          - "its push:[main] trigger is DELIBERATELY UNFILTERED -- see base_snapshot below (#2833)"
           - "dependency-review arms retry-on-snapshot-warnings ONLY on dependency-touching PRs"
           - "dependency-submission failures raise a tracking issue (a stale graph makes the gate vacuous)"
+        base_snapshot: >
+          Snapshots are looked up by EXACT SHA and the compare endpoint is three-dot, so the graph
+          the gate diffs against is the MERGE-BASE of the PR -- an arbitrary main commit. While the
+          push:[main] trigger carried the same manifest path filter as the pull_request one, only
+          ~2% of main commits produced a snapshot (measured: 1 of 50), so the merge-base almost
+          never had one and the action silently fell back to reporting the ENTIRE head graph as
+          additions. That is how the allowlist below was accreted. The push trigger is therefore
+          unfiltered: every main commit submits, so the merge-base always resolves. Ancestry of
+          pull_request.base.sha is NOT a factor -- three-dot compare resolves the merge-base itself.
+        scope: >
+          detachedConfiguration* and the root buildscript `classpath` are EXCLUDED from the
+          submitted graph (dependency-graph-exclude-configurations). `configurations.all {
+          resolutionStrategy { force(...) } }` -- how openbank.dependency-vulnerability-pins applies
+          the fleet patch floors -- cannot reach a detachedConfiguration, so those resolve their own
+          older versions of the same modules and submit coordinates no service can load. Measured:
+          105 of 1389 resolved coordinates came only from a detached configuration and carried 24 of
+          30 findings; filtering both took the graph 1235 -> 1091 and findings 30 -> 3.
+          Test coverage is NOT reduced -- testCompileClasspath / testRuntimeClasspath /
+          integrationTest* are all still submitted.
+          Excluding `classpath` IS a deliberate narrowing: a vulnerable BUILD plugin never ships but
+          does run on CI runners, and this gate is about what ships. Revisit if build-time supply
+          chain becomes an explicit goal.
+        allowlist: >
+          allow-ghsas is DELIBERATELY EMPTY. It held seven suppressions (json-smart 2.5.0,
+          netty-handler 4.2.1, netty-codec-http2 4.1.119), every one silencing a coordinate that
+          only ever existed via a detached/buildscript configuration -- removed at source by the
+          scope filter above instead. An allow-ghsas entry is a PERMANENT FLEET-WIDE suppression: it
+          hides the pre-existing false positive it was added for AND a future PR that genuinely
+          introduces the same GHSA on a real classpath, so each entry buys quiet with a hole.
+          Before adding one, run the extractor's own diagnostic
+          (:ForceDependencyResolutionPlugin_resolveAllDependencies + SimpleDependencyGraphPlugin)
+          and read `resolvedBy` in dependency-resolution.json: a single entry naming a detached or
+          buildscript configuration is a graph artifact -- widen the scope filter, do not allowlist.
+          Entries naming a real *Classpath are a genuine finding -- bump the pin.
         not_covered_by:
           trivy_fs: "Trivy's Java coverage is JAR / pom.xml / gradle.lockfile / *.sbt.lock only; this repo has zero lockfiles, so Trivy fs sees no Gradle dependency"
           codeql: "not a dependency scanner, and not a required check"

--- a/openbank-infra/gitops/components/payments/swift-opa-bundle.yaml
+++ b/openbank-infra/gitops/components/payments/swift-opa-bundle.yaml
@@ -9,7 +9,7 @@ metadata:
     app.kubernetes.io/name: swift-service
     app.kubernetes.io/part-of: payments
   annotations:
-    openbank.tech/policy-checksum: "db5da1d242163b7f"
+    openbank.tech/policy-checksum: "427522265ff3cf1d"
 data:
   rest.rego: |
     # SPDX-License-Identifier: Apache-2.0
@@ -2668,9 +2668,44 @@ data:
           gate keeps reporting green while checking nothing about Gradle -- a silent hole, not a
           visible failure.
         requires:
-          - ".github/workflows/dependency-submission.yml runs on pull_request with the same path filter"
+          - ".github/workflows/dependency-submission.yml runs on pull_request with a manifest path filter"
+          - "its push:[main] trigger is DELIBERATELY UNFILTERED -- see base_snapshot below (#2833)"
           - "dependency-review arms retry-on-snapshot-warnings ONLY on dependency-touching PRs"
           - "dependency-submission failures raise a tracking issue (a stale graph makes the gate vacuous)"
+        base_snapshot: >
+          Snapshots are looked up by EXACT SHA and the compare endpoint is three-dot, so the graph
+          the gate diffs against is the MERGE-BASE of the PR -- an arbitrary main commit. While the
+          push:[main] trigger carried the same manifest path filter as the pull_request one, only
+          ~2% of main commits produced a snapshot (measured: 1 of 50), so the merge-base almost
+          never had one and the action silently fell back to reporting the ENTIRE head graph as
+          additions. That is how the allowlist below was accreted. The push trigger is therefore
+          unfiltered: every main commit submits, so the merge-base always resolves. Ancestry of
+          pull_request.base.sha is NOT a factor -- three-dot compare resolves the merge-base itself.
+        scope: >
+          detachedConfiguration* and the root buildscript `classpath` are EXCLUDED from the
+          submitted graph (dependency-graph-exclude-configurations). `configurations.all {
+          resolutionStrategy { force(...) } }` -- how openbank.dependency-vulnerability-pins applies
+          the fleet patch floors -- cannot reach a detachedConfiguration, so those resolve their own
+          older versions of the same modules and submit coordinates no service can load. Measured:
+          105 of 1389 resolved coordinates came only from a detached configuration and carried 24 of
+          30 findings; filtering both took the graph 1235 -> 1091 and findings 30 -> 3.
+          Test coverage is NOT reduced -- testCompileClasspath / testRuntimeClasspath /
+          integrationTest* are all still submitted.
+          Excluding `classpath` IS a deliberate narrowing: a vulnerable BUILD plugin never ships but
+          does run on CI runners, and this gate is about what ships. Revisit if build-time supply
+          chain becomes an explicit goal.
+        allowlist: >
+          allow-ghsas is DELIBERATELY EMPTY. It held seven suppressions (json-smart 2.5.0,
+          netty-handler 4.2.1, netty-codec-http2 4.1.119), every one silencing a coordinate that
+          only ever existed via a detached/buildscript configuration -- removed at source by the
+          scope filter above instead. An allow-ghsas entry is a PERMANENT FLEET-WIDE suppression: it
+          hides the pre-existing false positive it was added for AND a future PR that genuinely
+          introduces the same GHSA on a real classpath, so each entry buys quiet with a hole.
+          Before adding one, run the extractor's own diagnostic
+          (:ForceDependencyResolutionPlugin_resolveAllDependencies + SimpleDependencyGraphPlugin)
+          and read `resolvedBy` in dependency-resolution.json: a single entry naming a detached or
+          buildscript configuration is a graph artifact -- widen the scope filter, do not allowlist.
+          Entries naming a real *Classpath are a genuine finding -- bump the pin.
         not_covered_by:
           trivy_fs: "Trivy's Java coverage is JAR / pom.xml / gradle.lockfile / *.sbt.lock only; this repo has zero lockfiles, so Trivy fs sees no Gradle dependency"
           codeql: "not a dependency scanner, and not a required check"

--- a/openbank-infra/gitops/components/payments/transaction-opa-bundle.yaml
+++ b/openbank-infra/gitops/components/payments/transaction-opa-bundle.yaml
@@ -9,7 +9,7 @@ metadata:
     app.kubernetes.io/name: transaction-service
     app.kubernetes.io/part-of: payments
   annotations:
-    openbank.tech/policy-checksum: "4738dc9657863425"
+    openbank.tech/policy-checksum: "763b4874e18a0604"
 data:
   rest.rego: |
     # SPDX-License-Identifier: Apache-2.0
@@ -2721,9 +2721,44 @@ data:
           gate keeps reporting green while checking nothing about Gradle -- a silent hole, not a
           visible failure.
         requires:
-          - ".github/workflows/dependency-submission.yml runs on pull_request with the same path filter"
+          - ".github/workflows/dependency-submission.yml runs on pull_request with a manifest path filter"
+          - "its push:[main] trigger is DELIBERATELY UNFILTERED -- see base_snapshot below (#2833)"
           - "dependency-review arms retry-on-snapshot-warnings ONLY on dependency-touching PRs"
           - "dependency-submission failures raise a tracking issue (a stale graph makes the gate vacuous)"
+        base_snapshot: >
+          Snapshots are looked up by EXACT SHA and the compare endpoint is three-dot, so the graph
+          the gate diffs against is the MERGE-BASE of the PR -- an arbitrary main commit. While the
+          push:[main] trigger carried the same manifest path filter as the pull_request one, only
+          ~2% of main commits produced a snapshot (measured: 1 of 50), so the merge-base almost
+          never had one and the action silently fell back to reporting the ENTIRE head graph as
+          additions. That is how the allowlist below was accreted. The push trigger is therefore
+          unfiltered: every main commit submits, so the merge-base always resolves. Ancestry of
+          pull_request.base.sha is NOT a factor -- three-dot compare resolves the merge-base itself.
+        scope: >
+          detachedConfiguration* and the root buildscript `classpath` are EXCLUDED from the
+          submitted graph (dependency-graph-exclude-configurations). `configurations.all {
+          resolutionStrategy { force(...) } }` -- how openbank.dependency-vulnerability-pins applies
+          the fleet patch floors -- cannot reach a detachedConfiguration, so those resolve their own
+          older versions of the same modules and submit coordinates no service can load. Measured:
+          105 of 1389 resolved coordinates came only from a detached configuration and carried 24 of
+          30 findings; filtering both took the graph 1235 -> 1091 and findings 30 -> 3.
+          Test coverage is NOT reduced -- testCompileClasspath / testRuntimeClasspath /
+          integrationTest* are all still submitted.
+          Excluding `classpath` IS a deliberate narrowing: a vulnerable BUILD plugin never ships but
+          does run on CI runners, and this gate is about what ships. Revisit if build-time supply
+          chain becomes an explicit goal.
+        allowlist: >
+          allow-ghsas is DELIBERATELY EMPTY. It held seven suppressions (json-smart 2.5.0,
+          netty-handler 4.2.1, netty-codec-http2 4.1.119), every one silencing a coordinate that
+          only ever existed via a detached/buildscript configuration -- removed at source by the
+          scope filter above instead. An allow-ghsas entry is a PERMANENT FLEET-WIDE suppression: it
+          hides the pre-existing false positive it was added for AND a future PR that genuinely
+          introduces the same GHSA on a real classpath, so each entry buys quiet with a hole.
+          Before adding one, run the extractor's own diagnostic
+          (:ForceDependencyResolutionPlugin_resolveAllDependencies + SimpleDependencyGraphPlugin)
+          and read `resolvedBy` in dependency-resolution.json: a single entry naming a detached or
+          buildscript configuration is a graph artifact -- widen the scope filter, do not allowlist.
+          Entries naming a real *Classpath are a genuine finding -- bump the pin.
         not_covered_by:
           trivy_fs: "Trivy's Java coverage is JAR / pom.xml / gradle.lockfile / *.sbt.lock only; this repo has zero lockfiles, so Trivy fs sees no Gradle dependency"
           codeql: "not a dependency scanner, and not a required check"

--- a/openbank-infra/gitops/components/payments/vop-opa-bundle.yaml
+++ b/openbank-infra/gitops/components/payments/vop-opa-bundle.yaml
@@ -9,7 +9,7 @@ metadata:
     app.kubernetes.io/name: vop-service
     app.kubernetes.io/part-of: payments
   annotations:
-    openbank.tech/policy-checksum: "d32ef0c644ec0505"
+    openbank.tech/policy-checksum: "51508f0eb17d5612"
 data:
   rest.rego: |
     # SPDX-License-Identifier: Apache-2.0
@@ -2672,9 +2672,44 @@ data:
           gate keeps reporting green while checking nothing about Gradle -- a silent hole, not a
           visible failure.
         requires:
-          - ".github/workflows/dependency-submission.yml runs on pull_request with the same path filter"
+          - ".github/workflows/dependency-submission.yml runs on pull_request with a manifest path filter"
+          - "its push:[main] trigger is DELIBERATELY UNFILTERED -- see base_snapshot below (#2833)"
           - "dependency-review arms retry-on-snapshot-warnings ONLY on dependency-touching PRs"
           - "dependency-submission failures raise a tracking issue (a stale graph makes the gate vacuous)"
+        base_snapshot: >
+          Snapshots are looked up by EXACT SHA and the compare endpoint is three-dot, so the graph
+          the gate diffs against is the MERGE-BASE of the PR -- an arbitrary main commit. While the
+          push:[main] trigger carried the same manifest path filter as the pull_request one, only
+          ~2% of main commits produced a snapshot (measured: 1 of 50), so the merge-base almost
+          never had one and the action silently fell back to reporting the ENTIRE head graph as
+          additions. That is how the allowlist below was accreted. The push trigger is therefore
+          unfiltered: every main commit submits, so the merge-base always resolves. Ancestry of
+          pull_request.base.sha is NOT a factor -- three-dot compare resolves the merge-base itself.
+        scope: >
+          detachedConfiguration* and the root buildscript `classpath` are EXCLUDED from the
+          submitted graph (dependency-graph-exclude-configurations). `configurations.all {
+          resolutionStrategy { force(...) } }` -- how openbank.dependency-vulnerability-pins applies
+          the fleet patch floors -- cannot reach a detachedConfiguration, so those resolve their own
+          older versions of the same modules and submit coordinates no service can load. Measured:
+          105 of 1389 resolved coordinates came only from a detached configuration and carried 24 of
+          30 findings; filtering both took the graph 1235 -> 1091 and findings 30 -> 3.
+          Test coverage is NOT reduced -- testCompileClasspath / testRuntimeClasspath /
+          integrationTest* are all still submitted.
+          Excluding `classpath` IS a deliberate narrowing: a vulnerable BUILD plugin never ships but
+          does run on CI runners, and this gate is about what ships. Revisit if build-time supply
+          chain becomes an explicit goal.
+        allowlist: >
+          allow-ghsas is DELIBERATELY EMPTY. It held seven suppressions (json-smart 2.5.0,
+          netty-handler 4.2.1, netty-codec-http2 4.1.119), every one silencing a coordinate that
+          only ever existed via a detached/buildscript configuration -- removed at source by the
+          scope filter above instead. An allow-ghsas entry is a PERMANENT FLEET-WIDE suppression: it
+          hides the pre-existing false positive it was added for AND a future PR that genuinely
+          introduces the same GHSA on a real classpath, so each entry buys quiet with a hole.
+          Before adding one, run the extractor's own diagnostic
+          (:ForceDependencyResolutionPlugin_resolveAllDependencies + SimpleDependencyGraphPlugin)
+          and read `resolvedBy` in dependency-resolution.json: a single entry naming a detached or
+          buildscript configuration is a graph artifact -- widen the scope filter, do not allowlist.
+          Entries naming a real *Classpath are a genuine finding -- bump the pin.
         not_covered_by:
           trivy_fs: "Trivy's Java coverage is JAR / pom.xml / gradle.lockfile / *.sbt.lock only; this repo has zero lockfiles, so Trivy fs sees no Gradle dependency"
           codeql: "not a dependency scanner, and not a required check"

--- a/openbank-infra/gitops/components/pid/pid-opa-bundle.yaml
+++ b/openbank-infra/gitops/components/pid/pid-opa-bundle.yaml
@@ -9,7 +9,7 @@ metadata:
     app.kubernetes.io/name: pid-service
     app.kubernetes.io/part-of: pid
   annotations:
-    openbank.tech/policy-checksum: "283d9fabb9e5dbeb"
+    openbank.tech/policy-checksum: "0e676ff1e436e111"
 data:
   rest.rego: |
     # SPDX-License-Identifier: Apache-2.0
@@ -2674,9 +2674,44 @@ data:
           gate keeps reporting green while checking nothing about Gradle -- a silent hole, not a
           visible failure.
         requires:
-          - ".github/workflows/dependency-submission.yml runs on pull_request with the same path filter"
+          - ".github/workflows/dependency-submission.yml runs on pull_request with a manifest path filter"
+          - "its push:[main] trigger is DELIBERATELY UNFILTERED -- see base_snapshot below (#2833)"
           - "dependency-review arms retry-on-snapshot-warnings ONLY on dependency-touching PRs"
           - "dependency-submission failures raise a tracking issue (a stale graph makes the gate vacuous)"
+        base_snapshot: >
+          Snapshots are looked up by EXACT SHA and the compare endpoint is three-dot, so the graph
+          the gate diffs against is the MERGE-BASE of the PR -- an arbitrary main commit. While the
+          push:[main] trigger carried the same manifest path filter as the pull_request one, only
+          ~2% of main commits produced a snapshot (measured: 1 of 50), so the merge-base almost
+          never had one and the action silently fell back to reporting the ENTIRE head graph as
+          additions. That is how the allowlist below was accreted. The push trigger is therefore
+          unfiltered: every main commit submits, so the merge-base always resolves. Ancestry of
+          pull_request.base.sha is NOT a factor -- three-dot compare resolves the merge-base itself.
+        scope: >
+          detachedConfiguration* and the root buildscript `classpath` are EXCLUDED from the
+          submitted graph (dependency-graph-exclude-configurations). `configurations.all {
+          resolutionStrategy { force(...) } }` -- how openbank.dependency-vulnerability-pins applies
+          the fleet patch floors -- cannot reach a detachedConfiguration, so those resolve their own
+          older versions of the same modules and submit coordinates no service can load. Measured:
+          105 of 1389 resolved coordinates came only from a detached configuration and carried 24 of
+          30 findings; filtering both took the graph 1235 -> 1091 and findings 30 -> 3.
+          Test coverage is NOT reduced -- testCompileClasspath / testRuntimeClasspath /
+          integrationTest* are all still submitted.
+          Excluding `classpath` IS a deliberate narrowing: a vulnerable BUILD plugin never ships but
+          does run on CI runners, and this gate is about what ships. Revisit if build-time supply
+          chain becomes an explicit goal.
+        allowlist: >
+          allow-ghsas is DELIBERATELY EMPTY. It held seven suppressions (json-smart 2.5.0,
+          netty-handler 4.2.1, netty-codec-http2 4.1.119), every one silencing a coordinate that
+          only ever existed via a detached/buildscript configuration -- removed at source by the
+          scope filter above instead. An allow-ghsas entry is a PERMANENT FLEET-WIDE suppression: it
+          hides the pre-existing false positive it was added for AND a future PR that genuinely
+          introduces the same GHSA on a real classpath, so each entry buys quiet with a hole.
+          Before adding one, run the extractor's own diagnostic
+          (:ForceDependencyResolutionPlugin_resolveAllDependencies + SimpleDependencyGraphPlugin)
+          and read `resolvedBy` in dependency-resolution.json: a single entry naming a detached or
+          buildscript configuration is a graph artifact -- widen the scope filter, do not allowlist.
+          Entries naming a real *Classpath are a genuine finding -- bump the pin.
         not_covered_by:
           trivy_fs: "Trivy's Java coverage is JAR / pom.xml / gradle.lockfile / *.sbt.lock only; this repo has zero lockfiles, so Trivy fs sees no Gradle dependency"
           codeql: "not a dependency scanner, and not a required check"

--- a/openbank-infra/gitops/components/pid/pid-service.yaml
+++ b/openbank-infra/gitops/components/pid/pid-service.yaml
@@ -22,7 +22,7 @@ spec:
       annotations:
         # Rolls the pod when the OPA bundle changes — subPath mounts do NOT hot-reload.
         # Kept in sync by gen-pid-opa-bundle.sh (do not hand-edit).
-        openbank.tech/policy-checksum: "283d9fabb9e5dbeb"
+        openbank.tech/policy-checksum: "0e676ff1e436e111"
     spec:
       securityContext:
         runAsNonRoot: true

--- a/openbank-infra/gitops/components/psd2-service/psd2-opa-bundle.yaml
+++ b/openbank-infra/gitops/components/psd2-service/psd2-opa-bundle.yaml
@@ -9,7 +9,7 @@ metadata:
     app.kubernetes.io/name: psd2-service
     app.kubernetes.io/part-of: psd2
   annotations:
-    openbank.tech/policy-checksum: "5033d961905b4d56"
+    openbank.tech/policy-checksum: "5caa90d5176d0977"
 data:
   rest.rego: |
     # SPDX-License-Identifier: Apache-2.0
@@ -2747,9 +2747,44 @@ data:
           gate keeps reporting green while checking nothing about Gradle -- a silent hole, not a
           visible failure.
         requires:
-          - ".github/workflows/dependency-submission.yml runs on pull_request with the same path filter"
+          - ".github/workflows/dependency-submission.yml runs on pull_request with a manifest path filter"
+          - "its push:[main] trigger is DELIBERATELY UNFILTERED -- see base_snapshot below (#2833)"
           - "dependency-review arms retry-on-snapshot-warnings ONLY on dependency-touching PRs"
           - "dependency-submission failures raise a tracking issue (a stale graph makes the gate vacuous)"
+        base_snapshot: >
+          Snapshots are looked up by EXACT SHA and the compare endpoint is three-dot, so the graph
+          the gate diffs against is the MERGE-BASE of the PR -- an arbitrary main commit. While the
+          push:[main] trigger carried the same manifest path filter as the pull_request one, only
+          ~2% of main commits produced a snapshot (measured: 1 of 50), so the merge-base almost
+          never had one and the action silently fell back to reporting the ENTIRE head graph as
+          additions. That is how the allowlist below was accreted. The push trigger is therefore
+          unfiltered: every main commit submits, so the merge-base always resolves. Ancestry of
+          pull_request.base.sha is NOT a factor -- three-dot compare resolves the merge-base itself.
+        scope: >
+          detachedConfiguration* and the root buildscript `classpath` are EXCLUDED from the
+          submitted graph (dependency-graph-exclude-configurations). `configurations.all {
+          resolutionStrategy { force(...) } }` -- how openbank.dependency-vulnerability-pins applies
+          the fleet patch floors -- cannot reach a detachedConfiguration, so those resolve their own
+          older versions of the same modules and submit coordinates no service can load. Measured:
+          105 of 1389 resolved coordinates came only from a detached configuration and carried 24 of
+          30 findings; filtering both took the graph 1235 -> 1091 and findings 30 -> 3.
+          Test coverage is NOT reduced -- testCompileClasspath / testRuntimeClasspath /
+          integrationTest* are all still submitted.
+          Excluding `classpath` IS a deliberate narrowing: a vulnerable BUILD plugin never ships but
+          does run on CI runners, and this gate is about what ships. Revisit if build-time supply
+          chain becomes an explicit goal.
+        allowlist: >
+          allow-ghsas is DELIBERATELY EMPTY. It held seven suppressions (json-smart 2.5.0,
+          netty-handler 4.2.1, netty-codec-http2 4.1.119), every one silencing a coordinate that
+          only ever existed via a detached/buildscript configuration -- removed at source by the
+          scope filter above instead. An allow-ghsas entry is a PERMANENT FLEET-WIDE suppression: it
+          hides the pre-existing false positive it was added for AND a future PR that genuinely
+          introduces the same GHSA on a real classpath, so each entry buys quiet with a hole.
+          Before adding one, run the extractor's own diagnostic
+          (:ForceDependencyResolutionPlugin_resolveAllDependencies + SimpleDependencyGraphPlugin)
+          and read `resolvedBy` in dependency-resolution.json: a single entry naming a detached or
+          buildscript configuration is a graph artifact -- widen the scope filter, do not allowlist.
+          Entries naming a real *Classpath are a genuine finding -- bump the pin.
         not_covered_by:
           trivy_fs: "Trivy's Java coverage is JAR / pom.xml / gradle.lockfile / *.sbt.lock only; this repo has zero lockfiles, so Trivy fs sees no Gradle dependency"
           codeql: "not a dependency scanner, and not a required check"

--- a/openbank-infra/gitops/components/psd2-service/psd2-service.yaml
+++ b/openbank-infra/gitops/components/psd2-service/psd2-service.yaml
@@ -18,7 +18,7 @@ spec:
       annotations:
         # Rolls the pod when the OPA bundle changes — subPath mounts do NOT hot-reload.
         # Kept in sync by gen-psd2-opa-bundle.sh (do not hand-edit).
-        openbank.tech/policy-checksum: "5033d961905b4d56"
+        openbank.tech/policy-checksum: "5caa90d5176d0977"
       labels: {app.kubernetes.io/name: psd2-service, app.kubernetes.io/part-of: psd2}
     spec:
       securityContext:

--- a/openbank-infra/gitops/components/sanctions-service/sanctions-opa-bundle.yaml
+++ b/openbank-infra/gitops/components/sanctions-service/sanctions-opa-bundle.yaml
@@ -9,7 +9,7 @@ metadata:
     app.kubernetes.io/name: sanctions-service
     app.kubernetes.io/part-of: sanctions
   annotations:
-    openbank.tech/policy-checksum: "f2602df2d6336df2"
+    openbank.tech/policy-checksum: "734682367750a113"
 data:
   rest.rego: |
     # SPDX-License-Identifier: Apache-2.0
@@ -2652,9 +2652,44 @@ data:
           gate keeps reporting green while checking nothing about Gradle -- a silent hole, not a
           visible failure.
         requires:
-          - ".github/workflows/dependency-submission.yml runs on pull_request with the same path filter"
+          - ".github/workflows/dependency-submission.yml runs on pull_request with a manifest path filter"
+          - "its push:[main] trigger is DELIBERATELY UNFILTERED -- see base_snapshot below (#2833)"
           - "dependency-review arms retry-on-snapshot-warnings ONLY on dependency-touching PRs"
           - "dependency-submission failures raise a tracking issue (a stale graph makes the gate vacuous)"
+        base_snapshot: >
+          Snapshots are looked up by EXACT SHA and the compare endpoint is three-dot, so the graph
+          the gate diffs against is the MERGE-BASE of the PR -- an arbitrary main commit. While the
+          push:[main] trigger carried the same manifest path filter as the pull_request one, only
+          ~2% of main commits produced a snapshot (measured: 1 of 50), so the merge-base almost
+          never had one and the action silently fell back to reporting the ENTIRE head graph as
+          additions. That is how the allowlist below was accreted. The push trigger is therefore
+          unfiltered: every main commit submits, so the merge-base always resolves. Ancestry of
+          pull_request.base.sha is NOT a factor -- three-dot compare resolves the merge-base itself.
+        scope: >
+          detachedConfiguration* and the root buildscript `classpath` are EXCLUDED from the
+          submitted graph (dependency-graph-exclude-configurations). `configurations.all {
+          resolutionStrategy { force(...) } }` -- how openbank.dependency-vulnerability-pins applies
+          the fleet patch floors -- cannot reach a detachedConfiguration, so those resolve their own
+          older versions of the same modules and submit coordinates no service can load. Measured:
+          105 of 1389 resolved coordinates came only from a detached configuration and carried 24 of
+          30 findings; filtering both took the graph 1235 -> 1091 and findings 30 -> 3.
+          Test coverage is NOT reduced -- testCompileClasspath / testRuntimeClasspath /
+          integrationTest* are all still submitted.
+          Excluding `classpath` IS a deliberate narrowing: a vulnerable BUILD plugin never ships but
+          does run on CI runners, and this gate is about what ships. Revisit if build-time supply
+          chain becomes an explicit goal.
+        allowlist: >
+          allow-ghsas is DELIBERATELY EMPTY. It held seven suppressions (json-smart 2.5.0,
+          netty-handler 4.2.1, netty-codec-http2 4.1.119), every one silencing a coordinate that
+          only ever existed via a detached/buildscript configuration -- removed at source by the
+          scope filter above instead. An allow-ghsas entry is a PERMANENT FLEET-WIDE suppression: it
+          hides the pre-existing false positive it was added for AND a future PR that genuinely
+          introduces the same GHSA on a real classpath, so each entry buys quiet with a hole.
+          Before adding one, run the extractor's own diagnostic
+          (:ForceDependencyResolutionPlugin_resolveAllDependencies + SimpleDependencyGraphPlugin)
+          and read `resolvedBy` in dependency-resolution.json: a single entry naming a detached or
+          buildscript configuration is a graph artifact -- widen the scope filter, do not allowlist.
+          Entries naming a real *Classpath are a genuine finding -- bump the pin.
         not_covered_by:
           trivy_fs: "Trivy's Java coverage is JAR / pom.xml / gradle.lockfile / *.sbt.lock only; this repo has zero lockfiles, so Trivy fs sees no Gradle dependency"
           codeql: "not a dependency scanner, and not a required check"

--- a/openbank-infra/gitops/components/sanctions-service/sanctions-service.yaml
+++ b/openbank-infra/gitops/components/sanctions-service/sanctions-service.yaml
@@ -49,7 +49,7 @@ spec:
       annotations:
         # Rolls the pods when the OPA bundle changes — subPath mounts do NOT hot-reload.
         # Kept in sync by gen-sanctions-opa-bundle.sh (do not hand-edit).
-        openbank.tech/policy-checksum: "f2602df2d6336df2"
+        openbank.tech/policy-checksum: "734682367750a113"
     spec:
       securityContext:
         runAsNonRoot: true

--- a/openbank-infra/gitops/components/sca/sca-opa-bundle.yaml
+++ b/openbank-infra/gitops/components/sca/sca-opa-bundle.yaml
@@ -9,7 +9,7 @@ metadata:
     app.kubernetes.io/name: sca-service
     app.kubernetes.io/part-of: sca
   annotations:
-    openbank.tech/policy-checksum: "8dc9d5b085b43cb5"
+    openbank.tech/policy-checksum: "a36b273567776b87"
 data:
   rest.rego: |
     # SPDX-License-Identifier: Apache-2.0
@@ -2688,9 +2688,44 @@ data:
           gate keeps reporting green while checking nothing about Gradle -- a silent hole, not a
           visible failure.
         requires:
-          - ".github/workflows/dependency-submission.yml runs on pull_request with the same path filter"
+          - ".github/workflows/dependency-submission.yml runs on pull_request with a manifest path filter"
+          - "its push:[main] trigger is DELIBERATELY UNFILTERED -- see base_snapshot below (#2833)"
           - "dependency-review arms retry-on-snapshot-warnings ONLY on dependency-touching PRs"
           - "dependency-submission failures raise a tracking issue (a stale graph makes the gate vacuous)"
+        base_snapshot: >
+          Snapshots are looked up by EXACT SHA and the compare endpoint is three-dot, so the graph
+          the gate diffs against is the MERGE-BASE of the PR -- an arbitrary main commit. While the
+          push:[main] trigger carried the same manifest path filter as the pull_request one, only
+          ~2% of main commits produced a snapshot (measured: 1 of 50), so the merge-base almost
+          never had one and the action silently fell back to reporting the ENTIRE head graph as
+          additions. That is how the allowlist below was accreted. The push trigger is therefore
+          unfiltered: every main commit submits, so the merge-base always resolves. Ancestry of
+          pull_request.base.sha is NOT a factor -- three-dot compare resolves the merge-base itself.
+        scope: >
+          detachedConfiguration* and the root buildscript `classpath` are EXCLUDED from the
+          submitted graph (dependency-graph-exclude-configurations). `configurations.all {
+          resolutionStrategy { force(...) } }` -- how openbank.dependency-vulnerability-pins applies
+          the fleet patch floors -- cannot reach a detachedConfiguration, so those resolve their own
+          older versions of the same modules and submit coordinates no service can load. Measured:
+          105 of 1389 resolved coordinates came only from a detached configuration and carried 24 of
+          30 findings; filtering both took the graph 1235 -> 1091 and findings 30 -> 3.
+          Test coverage is NOT reduced -- testCompileClasspath / testRuntimeClasspath /
+          integrationTest* are all still submitted.
+          Excluding `classpath` IS a deliberate narrowing: a vulnerable BUILD plugin never ships but
+          does run on CI runners, and this gate is about what ships. Revisit if build-time supply
+          chain becomes an explicit goal.
+        allowlist: >
+          allow-ghsas is DELIBERATELY EMPTY. It held seven suppressions (json-smart 2.5.0,
+          netty-handler 4.2.1, netty-codec-http2 4.1.119), every one silencing a coordinate that
+          only ever existed via a detached/buildscript configuration -- removed at source by the
+          scope filter above instead. An allow-ghsas entry is a PERMANENT FLEET-WIDE suppression: it
+          hides the pre-existing false positive it was added for AND a future PR that genuinely
+          introduces the same GHSA on a real classpath, so each entry buys quiet with a hole.
+          Before adding one, run the extractor's own diagnostic
+          (:ForceDependencyResolutionPlugin_resolveAllDependencies + SimpleDependencyGraphPlugin)
+          and read `resolvedBy` in dependency-resolution.json: a single entry naming a detached or
+          buildscript configuration is a graph artifact -- widen the scope filter, do not allowlist.
+          Entries naming a real *Classpath are a genuine finding -- bump the pin.
         not_covered_by:
           trivy_fs: "Trivy's Java coverage is JAR / pom.xml / gradle.lockfile / *.sbt.lock only; this repo has zero lockfiles, so Trivy fs sees no Gradle dependency"
           codeql: "not a dependency scanner, and not a required check"

--- a/openbank-infra/gitops/components/sca/sca-service.yaml
+++ b/openbank-infra/gitops/components/sca/sca-service.yaml
@@ -28,7 +28,7 @@ spec:
       annotations:
         # Rolls the pods when the OPA bundle changes — subPath mounts do NOT hot-reload.
         # Kept in sync by gen-sca-opa-bundle.sh (do not hand-edit).
-        openbank.tech/policy-checksum: "8dc9d5b085b43cb5"
+        openbank.tech/policy-checksum: "a36b273567776b87"
     spec:
       securityContext:
         runAsNonRoot: true

--- a/openbank-infra/gitops/components/statements/statement-opa-bundle.yaml
+++ b/openbank-infra/gitops/components/statements/statement-opa-bundle.yaml
@@ -9,7 +9,7 @@ metadata:
     app.kubernetes.io/name: statement-service
     app.kubernetes.io/part-of: statements
   annotations:
-    openbank.tech/policy-checksum: "ec277a1075f1b20e"
+    openbank.tech/policy-checksum: "0fb50348e553e472"
 data:
   rest.rego: |
     # SPDX-License-Identifier: Apache-2.0
@@ -2718,9 +2718,44 @@ data:
           gate keeps reporting green while checking nothing about Gradle -- a silent hole, not a
           visible failure.
         requires:
-          - ".github/workflows/dependency-submission.yml runs on pull_request with the same path filter"
+          - ".github/workflows/dependency-submission.yml runs on pull_request with a manifest path filter"
+          - "its push:[main] trigger is DELIBERATELY UNFILTERED -- see base_snapshot below (#2833)"
           - "dependency-review arms retry-on-snapshot-warnings ONLY on dependency-touching PRs"
           - "dependency-submission failures raise a tracking issue (a stale graph makes the gate vacuous)"
+        base_snapshot: >
+          Snapshots are looked up by EXACT SHA and the compare endpoint is three-dot, so the graph
+          the gate diffs against is the MERGE-BASE of the PR -- an arbitrary main commit. While the
+          push:[main] trigger carried the same manifest path filter as the pull_request one, only
+          ~2% of main commits produced a snapshot (measured: 1 of 50), so the merge-base almost
+          never had one and the action silently fell back to reporting the ENTIRE head graph as
+          additions. That is how the allowlist below was accreted. The push trigger is therefore
+          unfiltered: every main commit submits, so the merge-base always resolves. Ancestry of
+          pull_request.base.sha is NOT a factor -- three-dot compare resolves the merge-base itself.
+        scope: >
+          detachedConfiguration* and the root buildscript `classpath` are EXCLUDED from the
+          submitted graph (dependency-graph-exclude-configurations). `configurations.all {
+          resolutionStrategy { force(...) } }` -- how openbank.dependency-vulnerability-pins applies
+          the fleet patch floors -- cannot reach a detachedConfiguration, so those resolve their own
+          older versions of the same modules and submit coordinates no service can load. Measured:
+          105 of 1389 resolved coordinates came only from a detached configuration and carried 24 of
+          30 findings; filtering both took the graph 1235 -> 1091 and findings 30 -> 3.
+          Test coverage is NOT reduced -- testCompileClasspath / testRuntimeClasspath /
+          integrationTest* are all still submitted.
+          Excluding `classpath` IS a deliberate narrowing: a vulnerable BUILD plugin never ships but
+          does run on CI runners, and this gate is about what ships. Revisit if build-time supply
+          chain becomes an explicit goal.
+        allowlist: >
+          allow-ghsas is DELIBERATELY EMPTY. It held seven suppressions (json-smart 2.5.0,
+          netty-handler 4.2.1, netty-codec-http2 4.1.119), every one silencing a coordinate that
+          only ever existed via a detached/buildscript configuration -- removed at source by the
+          scope filter above instead. An allow-ghsas entry is a PERMANENT FLEET-WIDE suppression: it
+          hides the pre-existing false positive it was added for AND a future PR that genuinely
+          introduces the same GHSA on a real classpath, so each entry buys quiet with a hole.
+          Before adding one, run the extractor's own diagnostic
+          (:ForceDependencyResolutionPlugin_resolveAllDependencies + SimpleDependencyGraphPlugin)
+          and read `resolvedBy` in dependency-resolution.json: a single entry naming a detached or
+          buildscript configuration is a graph artifact -- widen the scope filter, do not allowlist.
+          Entries naming a real *Classpath are a genuine finding -- bump the pin.
         not_covered_by:
           trivy_fs: "Trivy's Java coverage is JAR / pom.xml / gradle.lockfile / *.sbt.lock only; this repo has zero lockfiles, so Trivy fs sees no Gradle dependency"
           codeql: "not a dependency scanner, and not a required check"

--- a/openbank-infra/gitops/components/statements/statement-service.yaml
+++ b/openbank-infra/gitops/components/statements/statement-service.yaml
@@ -26,7 +26,7 @@ spec:
       annotations:
         # Rolls the pod when the OPA bundle changes — subPath mounts do NOT hot-reload.
         # Kept in sync by gen-statement-opa-bundle.sh (do not hand-edit).
-        openbank.tech/policy-checksum: "ec277a1075f1b20e"
+        openbank.tech/policy-checksum: "0fb50348e553e472"
       labels:
         app.kubernetes.io/name: statement-service
         app.kubernetes.io/part-of: statements

--- a/openbank-infra/gitops/components/tpp-registry/tpp-registry-opa-bundle.yaml
+++ b/openbank-infra/gitops/components/tpp-registry/tpp-registry-opa-bundle.yaml
@@ -9,7 +9,7 @@ metadata:
     app.kubernetes.io/name: tpp-registry-service
     app.kubernetes.io/part-of: tpp-registry
   annotations:
-    openbank.tech/policy-checksum: "a2860a7a3a9f8b7c"
+    openbank.tech/policy-checksum: "27b2840356229e06"
 data:
   rest.rego: |
     # SPDX-License-Identifier: Apache-2.0
@@ -2655,9 +2655,44 @@ data:
           gate keeps reporting green while checking nothing about Gradle -- a silent hole, not a
           visible failure.
         requires:
-          - ".github/workflows/dependency-submission.yml runs on pull_request with the same path filter"
+          - ".github/workflows/dependency-submission.yml runs on pull_request with a manifest path filter"
+          - "its push:[main] trigger is DELIBERATELY UNFILTERED -- see base_snapshot below (#2833)"
           - "dependency-review arms retry-on-snapshot-warnings ONLY on dependency-touching PRs"
           - "dependency-submission failures raise a tracking issue (a stale graph makes the gate vacuous)"
+        base_snapshot: >
+          Snapshots are looked up by EXACT SHA and the compare endpoint is three-dot, so the graph
+          the gate diffs against is the MERGE-BASE of the PR -- an arbitrary main commit. While the
+          push:[main] trigger carried the same manifest path filter as the pull_request one, only
+          ~2% of main commits produced a snapshot (measured: 1 of 50), so the merge-base almost
+          never had one and the action silently fell back to reporting the ENTIRE head graph as
+          additions. That is how the allowlist below was accreted. The push trigger is therefore
+          unfiltered: every main commit submits, so the merge-base always resolves. Ancestry of
+          pull_request.base.sha is NOT a factor -- three-dot compare resolves the merge-base itself.
+        scope: >
+          detachedConfiguration* and the root buildscript `classpath` are EXCLUDED from the
+          submitted graph (dependency-graph-exclude-configurations). `configurations.all {
+          resolutionStrategy { force(...) } }` -- how openbank.dependency-vulnerability-pins applies
+          the fleet patch floors -- cannot reach a detachedConfiguration, so those resolve their own
+          older versions of the same modules and submit coordinates no service can load. Measured:
+          105 of 1389 resolved coordinates came only from a detached configuration and carried 24 of
+          30 findings; filtering both took the graph 1235 -> 1091 and findings 30 -> 3.
+          Test coverage is NOT reduced -- testCompileClasspath / testRuntimeClasspath /
+          integrationTest* are all still submitted.
+          Excluding `classpath` IS a deliberate narrowing: a vulnerable BUILD plugin never ships but
+          does run on CI runners, and this gate is about what ships. Revisit if build-time supply
+          chain becomes an explicit goal.
+        allowlist: >
+          allow-ghsas is DELIBERATELY EMPTY. It held seven suppressions (json-smart 2.5.0,
+          netty-handler 4.2.1, netty-codec-http2 4.1.119), every one silencing a coordinate that
+          only ever existed via a detached/buildscript configuration -- removed at source by the
+          scope filter above instead. An allow-ghsas entry is a PERMANENT FLEET-WIDE suppression: it
+          hides the pre-existing false positive it was added for AND a future PR that genuinely
+          introduces the same GHSA on a real classpath, so each entry buys quiet with a hole.
+          Before adding one, run the extractor's own diagnostic
+          (:ForceDependencyResolutionPlugin_resolveAllDependencies + SimpleDependencyGraphPlugin)
+          and read `resolvedBy` in dependency-resolution.json: a single entry naming a detached or
+          buildscript configuration is a graph artifact -- widen the scope filter, do not allowlist.
+          Entries naming a real *Classpath are a genuine finding -- bump the pin.
         not_covered_by:
           trivy_fs: "Trivy's Java coverage is JAR / pom.xml / gradle.lockfile / *.sbt.lock only; this repo has zero lockfiles, so Trivy fs sees no Gradle dependency"
           codeql: "not a dependency scanner, and not a required check"

--- a/openbank-infra/gitops/components/tpp-registry/tpp-registry-service.yaml
+++ b/openbank-infra/gitops/components/tpp-registry/tpp-registry-service.yaml
@@ -23,7 +23,7 @@ spec:
       annotations:
         # Rolls the pod when the OPA bundle changes (subPath mounts do not hot-reload).
         # Kept in sync by gen-tpp-registry-opa-bundle.sh (do not hand-edit).
-        openbank.tech/policy-checksum: "a2860a7a3a9f8b7c"
+        openbank.tech/policy-checksum: "27b2840356229e06"
     spec:
       securityContext:
         runAsNonRoot: true

--- a/openbank-libs/governance/rules.yaml
+++ b/openbank-libs/governance/rules.yaml
@@ -1184,9 +1184,44 @@ dependencies:
       gate keeps reporting green while checking nothing about Gradle -- a silent hole, not a
       visible failure.
     requires:
-      - ".github/workflows/dependency-submission.yml runs on pull_request with the same path filter"
+      - ".github/workflows/dependency-submission.yml runs on pull_request with a manifest path filter"
+      - "its push:[main] trigger is DELIBERATELY UNFILTERED -- see base_snapshot below (#2833)"
       - "dependency-review arms retry-on-snapshot-warnings ONLY on dependency-touching PRs"
       - "dependency-submission failures raise a tracking issue (a stale graph makes the gate vacuous)"
+    base_snapshot: >
+      Snapshots are looked up by EXACT SHA and the compare endpoint is three-dot, so the graph
+      the gate diffs against is the MERGE-BASE of the PR -- an arbitrary main commit. While the
+      push:[main] trigger carried the same manifest path filter as the pull_request one, only
+      ~2% of main commits produced a snapshot (measured: 1 of 50), so the merge-base almost
+      never had one and the action silently fell back to reporting the ENTIRE head graph as
+      additions. That is how the allowlist below was accreted. The push trigger is therefore
+      unfiltered: every main commit submits, so the merge-base always resolves. Ancestry of
+      pull_request.base.sha is NOT a factor -- three-dot compare resolves the merge-base itself.
+    scope: >
+      detachedConfiguration* and the root buildscript `classpath` are EXCLUDED from the
+      submitted graph (dependency-graph-exclude-configurations). `configurations.all {
+      resolutionStrategy { force(...) } }` -- how openbank.dependency-vulnerability-pins applies
+      the fleet patch floors -- cannot reach a detachedConfiguration, so those resolve their own
+      older versions of the same modules and submit coordinates no service can load. Measured:
+      105 of 1389 resolved coordinates came only from a detached configuration and carried 24 of
+      30 findings; filtering both took the graph 1235 -> 1091 and findings 30 -> 3.
+      Test coverage is NOT reduced -- testCompileClasspath / testRuntimeClasspath /
+      integrationTest* are all still submitted.
+      Excluding `classpath` IS a deliberate narrowing: a vulnerable BUILD plugin never ships but
+      does run on CI runners, and this gate is about what ships. Revisit if build-time supply
+      chain becomes an explicit goal.
+    allowlist: >
+      allow-ghsas is DELIBERATELY EMPTY. It held seven suppressions (json-smart 2.5.0,
+      netty-handler 4.2.1, netty-codec-http2 4.1.119), every one silencing a coordinate that
+      only ever existed via a detached/buildscript configuration -- removed at source by the
+      scope filter above instead. An allow-ghsas entry is a PERMANENT FLEET-WIDE suppression: it
+      hides the pre-existing false positive it was added for AND a future PR that genuinely
+      introduces the same GHSA on a real classpath, so each entry buys quiet with a hole.
+      Before adding one, run the extractor's own diagnostic
+      (:ForceDependencyResolutionPlugin_resolveAllDependencies + SimpleDependencyGraphPlugin)
+      and read `resolvedBy` in dependency-resolution.json: a single entry naming a detached or
+      buildscript configuration is a graph artifact -- widen the scope filter, do not allowlist.
+      Entries naming a real *Classpath are a genuine finding -- bump the pin.
     not_covered_by:
       trivy_fs: "Trivy's Java coverage is JAR / pom.xml / gradle.lockfile / *.sbt.lock only; this repo has zero lockfiles, so Trivy fs sees no Gradle dependency"
       codeql: "not a dependency scanner, and not a required check"


### PR DESCRIPTION
Closes the documentation half of #2833. `rules.yaml` is the authoritative description of `pr_time_cve_gate`, and three things landed today that it did not describe.

## What is added

**`base_snapshot`** — snapshots are looked up by exact SHA and the compare endpoint is three-dot, so the gate diffs against the PR's **merge-base**. While `push:[main]` carried the same manifest path filter as `pull_request`, only ~2% of main commits produced a snapshot (measured: **1 of 50**), the merge-base almost never had one, and the action silently reported the entire head graph as additions. #2837 unfiltered that trigger.

It also records the **negative** result: ancestry of `pull_request.base.sha` is *not* a factor, because three-dot compare resolves the merge-base itself. That one cost a whole PR ([#2848](https://github.com/JiRaska/open-bank-oss/pull/2848), closed as a no-op) to establish, and without it written down the next person re-derives the same wrong hypothesis.

**`scope`** — `detachedConfiguration*` and the root buildscript `classpath` are excluded from the submitted graph (#2874), with the mechanism: `configurations.all { resolutionStrategy { force(...) } }` cannot reach a `detachedConfiguration`, so those resolve their own older versions and submit coordinates no service can load. Explicitly states that test classpaths are **not** excluded, and that excluding `classpath` **is** a deliberate narrowing — a vulnerable build plugin never ships but does run on CI runners.

**`allowlist`** — `allow-ghsas` is deliberately empty (#2880), with the reason an entry is worse than it looks (a permanent fleet-wide suppression hides the pre-existing false positive *and* a future PR genuinely introducing that GHSA) and the diagnostic to run before ever adding one.

## Also corrected

The first `requires` bullet said the submission workflow "runs on pull_request with **the same** path filter". Since #2837 only the `pull_request` trigger is filtered — the bullet would have read as licence to re-add the filter that caused the bug.

## The 67 gitops files

OPA bundles and their pod-roll annotations, regenerated by the repo's own `gen-*opa-bundle*.sh` (38 of 39 embed `rules.yaml` verbatim and hash it). Not hand-edited.

- regenerated **after** the final `rules.yaml` edit, not before — the ordering that #2457 got wrong
- all 39 generators exited clean
- verified **idempotent**: a second full run changed nothing
- verified the new text is actually present in the regenerated output (38 bundles contain it) — idempotency alone would not catch a generator that silently dropped the change

## Checks on rules.yaml itself

CI never lints `rules.yaml` — the yamllint step's scope is `openbank-infra .github` — and SnakeYAML resolves a duplicate key by keeping the **last** occurrence, silently. So both were checked by hand:

- parsed with a duplicate-key-detecting loader: **no duplicate keys**
- yamllint finding *types* diffed against `origin/main`: identical sets (`braces` 28, `colons` 8, `commas` 9, `comments` 1, `comments-indentation` 17, `document-start` 1). Only `line-length` moved, 1133 → 1161, which is the house style here and disabled in the CI config anyway.

## Merge note

This PR touches every OPA bundle, so it conflicts with any other governance change and has a short shelf life. Merge with `--auto`, and if a competing `rules.yaml` PR lands first the bundles need regenerating again on top.

Refs #2833