### PR TITLE
fix(ci): fail dependency-review when the diff had no valid basis

### DIFF
--- a/.github/workflows/dependency-review.yml
+++ b/.github/workflows/dependency-review.yml
@@ -112,3 +112,69 @@ jobs:
           # or buildscript configuration is a graph artifact — fix the submission filter in
           # dependency-submission.yml, do not allowlist it. One naming a real *Classpath is a
           # genuine finding: bump the pin.
+
+      # The gate above PROCEEDS on an invalid basis instead of failing (issue #2833, item 4).
+      #
+      # dependency-review compares two SUBMITTED graphs. When one side has no snapshot it
+      # logs a warning, exhausts retry-on-snapshot-warnings, prints
+      # `Retry timeout exceeded. Proceeding...`, and then reports a normal pass/fail computed
+      # from a diff that treated the ENTIRE head graph as additions. Both outcomes are wrong
+      # and neither is distinguishable from a real verdict: a green means "not evaluated",
+      # a red means "every pre-existing dependency, re-flagged".
+      #
+      # #2837 made every main commit submit, so the systemic cause is gone — but a branch
+      # whose merge-base predates that fix, or a submission that failed outright, still lands
+      # here. This step makes that state RED and says why, instead of letting the gate claim
+      # a verdict it did not earn.
+      #
+      # Only armed on dependency-touching PRs: with no Gradle submission in flight there is no
+      # Gradle graph on either side and nothing to assert.
+      #
+      # Deliberately checks the submission RUN, not snapshot queryability. GitHub indexes a
+      # submitted graph some seconds after the API call returns, so asserting the snapshot
+      # itself would flake; asserting the run catches the case that actually caused #2833
+      # (no submission was ever scheduled for that SHA) and accepts the narrow window where a
+      # run has succeeded but is not yet indexed.
+      #
+      # Last step in the job on purpose — nothing runs after it, so failing here costs no
+      # downstream work.
+      - name: Assert the dependency diff had a valid basis
+        if: ${{ success() && steps.deps.outputs.changed == 'true' }}
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          BASE_SHA: ${{ github.event.pull_request.base.sha }}
+          HEAD_SHA: ${{ github.event.pull_request.head.sha }}
+        run: |
+          set -euo pipefail
+          runs_api="repos/${GITHUB_REPOSITORY}/actions/workflows/dependency-submission.yml/runs"
+
+          mb="$(gh api "repos/${GITHUB_REPOSITORY}/compare/${BASE_SHA}...${HEAD_SHA}" \
+                  --jq '.merge_base_commit.sha' 2>/dev/null || true)"
+          if [ -z "${mb}" ]; then
+            echo "::warning title=basis unverified::Could not resolve the merge-base; skipping the basis assertion rather than failing on an API hiccup."
+            exit 0
+          fi
+
+          count() { gh api "${runs_api}?head_sha=$1&status=success" --jq '.total_count' 2>/dev/null || echo ""; }
+          base_runs="$(count "${mb}")"
+          head_runs="$(count "${HEAD_SHA}")"
+          if [ -z "${base_runs}" ] || [ -z "${head_runs}" ]; then
+            echo "::warning title=basis unverified::Could not query dependency-submission runs; skipping the assertion."
+            exit 0
+          fi
+
+          echo "merge-base ${mb}: ${base_runs} successful submission run(s)"
+          echo "head ${HEAD_SHA}: ${head_runs} successful submission run(s)"
+
+          fail=0
+          if [ "${base_runs}" -eq 0 ]; then
+            echo "::error title=Dependency review had no base graph::No successful dependency-submission run exists for the merge-base ${mb}, so the Gradle half of this review compared against nothing and reported the whole head graph as additions. Rebase onto current main — every main commit has carried a snapshot since #2837, so a current merge-base resolves. See issue #2833."
+            fail=1
+          fi
+          if [ "${head_runs}" -eq 0 ]; then
+            echo "::error title=Dependency review had no head graph::No successful dependency-submission run exists for the head ${HEAD_SHA}. Check the Dependency submission workflow for this PR — if it failed, the Gradle half of this review is vacuous. See issue #2833."
+            fail=1
+          fi
+          [ "${fail}" -eq 0 ] || exit 1
+
+          echo "Both sides of the dependency diff had a submitted graph — the verdict above is about this PR's delta."


### PR DESCRIPTION
Closes the last open item of #2833 (item 4).

## The problem

`dependency-review` compares two **submitted** graphs. When one side has no snapshot it warns, exhausts `retry-on-snapshot-warnings`, prints `Retry timeout exceeded. Proceeding...`, and then reports a normal pass/fail computed from a diff that treated the **entire head graph as additions**.

Neither outcome is distinguishable from a real verdict:

- a **green** means "not evaluated"
- a **red** means "every pre-existing dependency, re-flagged" — which is exactly how the seven `allow-ghsas` suppressions removed in #2880 were accreted

#2837 removed the systemic cause (every main commit now submits), but a branch whose merge-base predates that fix, or a submission that failed outright, still lands here. This step makes that state **red** and names both the cause and the remedy.

## Design decisions worth reviewing

**Armed only on dependency-touching PRs** — `if: success() && steps.deps.outputs.changed == 'true'`. With no Gradle submission in flight there is no Gradle graph on either side and nothing to assert.

**Last step in the job**, so a failure costs no downstream work — the placement rule this repo already follows for guards that `setFailed`.

**Checks the submission RUN, not snapshot queryability.** GitHub indexes a submitted graph some seconds after the API call returns, so asserting the snapshot itself would flake. This catches the case that actually caused #2833 — no submission was ever scheduled for that SHA — and knowingly accepts the narrow window where a run succeeded but is not yet indexed. The comment in the workflow states this limitation rather than hiding it.

**API failures warn and pass, they do not fail.** A transient hiccup must not block every PR; only a confirmed missing submission is red.

## Failure path exercised — the part that matters

Per this repo's rule that a gate which has only ever passed is unfalsified, both branches were run against real SHAs **before** committing:

```
merge-base 51364286f (pre-#2837, no submission)  ->  ::error, exit 1
merge-base 73c48273d (post-#2837, submitted)     ->  exit 0
unresolvable SHA                                 ->  ::warning, exit 0
```

The error message it emits:

> No successful dependency-submission run exists for the merge-base `51364286f…`, so the Gradle half of this review compared against nothing and reported the whole head graph as additions. Rebase onto current main — every main commit has carried a snapshot since #2837, so a current merge-base resolves.

**The test was run on the script extracted from the workflow YAML, not a retyped copy.** My first harness used `[ ... ] && { ... }` where the real step uses `if` blocks — under `set -e` those are different programs, and a passing case could have exited 1. Testing the transcription rather than the artifact is the shape of bug this whole issue is about, so it seemed worth not repeating in the fix for it.

## Expected effect on this PR

None visible — this PR touches no manifest, so the step is skipped. That is correct behaviour, not a missing test: the branches were verified directly above. The first manifest-touching PR after merge will exercise it live, and should pass (its merge-base will be a post-#2837 commit).

## Verification

- `actionlint` — clean
- `yamllint` under the exact config `ci.yml` builds — clean on branch and on `origin/main`'s copy
- step order parsed rather than eyeballed: `checkout → Detect dependency-manifest changes → Dependency Review → Assert the dependency diff had a valid basis`

## Release impact

None — `.github/workflows/` is not under any released package path.

Closes #2833
