### PR TITLE
fix(campaign): evaluate segments against the silver layer that exists

### DIFF
--- a/openbank-campaign-service/src/main/kotlin/com/openbank/campaign/domain/model/Segment.kt
+++ b/openbank-campaign-service/src/main/kotlin/com/openbank/campaign/domain/model/Segment.kt
@@ -8,12 +8,25 @@ package com.openbank.campaign.domain.model
  * Deterministic, rule-based segment (ADR-0201 D1/D2): a versioned artifact evaluated against the
  * ADR-0210 silver layer. Rules are a closed DSL — the only SQL in the system is generated here, from
  * typed rules, never accepted from a UI.
+ *
+ * The silver layer is an EVENT LOG reduced to the latest row per `(aggregate_type, aggregate_id)`,
+ * with the domain attributes inside the `payload` JSON — it is not a per-party attribute table.
+ * Rules therefore read `payload`, and a rule needing data the layer does not carry is rejected at
+ * construction time rather than rendered into SQL that cannot run (issue #2891).
  */
 data class Segment(val name: String, val version: Int, val rules: List<SegmentRule>) {
     init {
         require(name.matches(Regex("[a-z0-9][a-z0-9-]*"))) { "segment name must be kebab-case" }
         require(version >= 1) { "segment version must be >= 1" }
         require(rules.isNotEmpty()) { "a segment must have at least one rule" }
+        // Fail where the segment is DEFINED, not at enrolment. An unsupported rule used to render
+        // SQL that ClickHouse rejected, which the fail-closed evaluator turned into an empty cohort
+        // — indistinguishable from "nobody matched" (#2891).
+        rules.forEach { rule ->
+            require(rule.unsupportedReason == null) {
+                "segment rule ${rule::class.simpleName} cannot be evaluated: ${rule.unsupportedReason}"
+            }
+        }
     }
 
     /**
@@ -31,36 +44,75 @@ data class Segment(val name: String, val version: Int, val rules: List<SegmentRu
 sealed class SegmentRule {
     abstract fun toSql(paramPrefix: String, params: MutableMap<String, Any>): String
 
-    /** Party lifecycle state as projected in silver (ACTIVE, PENDING_KYC, SUSPENDED, CLOSED). */
+    /**
+     * Why this rule cannot run against today's silver layer, or null when it can. A non-null value
+     * makes [Segment] reject the rule up front; see each rule for what would have to exist first.
+     */
+    open val unsupportedReason: String? = null
+
+    /**
+     * Party lifecycle state as carried in the latest PARTY event's payload
+     * (ACTIVE, PENDING_KYC, SUSPENDED, CLOSED).
+     */
     data class PartyStatusIs(val status: String) : SegmentRule() {
         override fun toSql(paramPrefix: String, params: MutableMap<String, Any>): String {
             params["${paramPrefix}_status"] = status
-            return "(aggregate_type = 'PARTY' AND jsonExtractString(state, 'status') = {${paramPrefix}_status:String})"
+            return "(aggregate_type = 'PARTY' AND " +
+                "JSONExtractString(payload, 'status') = {${paramPrefix}_status:String})"
         }
     }
 
-    /** Tenure: the party's oldest event is at least [minDays] days old. */
+    /**
+     * Tenure: the party's oldest event is at least [minDays] days old.
+     *
+     * silver_current_state holds only the LATEST event per aggregate, so first-seen has to come from
+     * the bronze log it reduces. The subquery selects `aggregate_id` only — no payload parsing — so
+     * it stays on the (aggregate_type, aggregate_id) key.
+     */
     data class TenureAtLeastDays(val minDays: Long) : SegmentRule() {
         init {
             require(minDays >= 0) { "minDays must be >= 0" }
         }
+
         override fun toSql(paramPrefix: String, params: MutableMap<String, Any>): String {
             params["${paramPrefix}_days"] = minDays
-            return "(aggregate_type = 'PARTY' AND first_seen <= now64(3) - INTERVAL {${paramPrefix}_days:UInt32} DAY)"
+            return "(aggregate_type = 'PARTY' AND aggregate_id IN (" +
+                "SELECT aggregate_id FROM openbank_analytics.bronze_events " +
+                "WHERE aggregate_type = 'PARTY' GROUP BY aggregate_id " +
+                "HAVING min(occurred_at) <= now64(3) - INTERVAL {${paramPrefix}_days:UInt32} DAY))"
         }
     }
 
-    /** Holds at least one account (any product holding visible in silver). */
+    /**
+     * Holds at least one account.
+     *
+     * UNSUPPORTED: no ACCOUNT event in analytics carries a partyId (0 of 59 bronze rows, measured
+     * 2026-07-31), so the party↔account link does not exist in this layer at all. Supporting this
+     * needs account events to carry the owning party — not a cleverer query.
+     */
     data object HasAccount : SegmentRule() {
+        override val unsupportedReason: String =
+            "ACCOUNT events in the analytics layer carry no partyId, so account ownership " +
+                "cannot be resolved (issue #2891)"
+
         override fun toSql(paramPrefix: String, params: MutableMap<String, Any>): String =
-            "(aggregate_type = 'PARTY' AND has_account = 1)"
+            throw UnsupportedOperationException(unsupportedReason)
     }
 
-    /** An ACTIVE consent carrying [scope] exists (evaluated against consent projections). */
+    /**
+     * An ACTIVE consent carrying [scope] exists.
+     *
+     * UNSUPPORTED: consent events are not ingested into analytics at all — neither silver nor bronze
+     * holds a CONSENT aggregate. This rule was only ever a cohort-narrowing optimisation: the binding
+     * consent check is the live per-send call in LiveConsentCheckAdapter (ADR-0198), which is
+     * unaffected. A campaign without this rule is not less consent-gated.
+     */
     data class HasActiveConsentScope(val scope: String) : SegmentRule() {
-        override fun toSql(paramPrefix: String, params: MutableMap<String, Any>): String {
-            params["${paramPrefix}_scope"] = scope
-            return "(aggregate_type = 'PARTY' AND has(consent_scopes, {${paramPrefix}_scope:String}))"
-        }
+        override val unsupportedReason: String =
+            "consent events are not ingested into the analytics layer, so consent scopes cannot be " +
+                "resolved there; per-send consent is still enforced live (issue #2891)"
+
+        override fun toSql(paramPrefix: String, params: MutableMap<String, Any>): String =
+            throw UnsupportedOperationException(unsupportedReason)
     }
 }

--- a/openbank-campaign-service/src/main/kotlin/com/openbank/campaign/infrastructure/segment/SilverSegmentEvaluator.kt
+++ b/openbank-campaign-service/src/main/kotlin/com/openbank/campaign/infrastructure/segment/SilverSegmentEvaluator.kt
@@ -53,8 +53,19 @@ class SilverSegmentEvaluator(
 
         val response = http.send(requestBuilder.build(), HttpResponse.BodyHandlers.ofString())
         if (response.statusCode() != HTTP_OK) {
-            // Fail closed: an unreachable analytics layer means an empty cohort, never a guessed one.
             log.errorf("ClickHouse segment evaluation failed (%d): %s", response.statusCode(), response.body())
+            // A REJECTED QUERY IS A BUG, NOT AN EMPTY COHORT. ClickHouse answers 4xx for SQL it
+            // cannot execute; returning emptyList() there reports "nobody matched" for a query that
+            // never ran, which is exactly how a DSL naming non-existent columns survived to
+            // production (#2891). Surface it so enrol() fails loudly instead.
+            if (response.statusCode() in HTTP_CLIENT_ERROR_RANGE) {
+                throw IllegalStateException(
+                    "segment ${segment.name}@${segment.version} could not be evaluated: " +
+                        "ClickHouse rejected the query (${response.statusCode()}) — ${response.body().trim()}",
+                )
+            }
+            // Fail closed only for an unavailable analytics layer (5xx): an outage means an empty
+            // cohort, never a guessed one.
             return emptyList()
         }
         return response.body().lineSequence()
@@ -69,6 +80,7 @@ class SilverSegmentEvaluator(
 
     companion object {
         private const val HTTP_OK = 200
+        private val HTTP_CLIENT_ERROR_RANGE = 400..499
         private val AGGREGATE_ID = Regex("\"aggregate_id\"\\s*:\\s*\"([0-9a-fA-F-]{36})\"")
     }
 }

--- a/openbank-campaign-service/src/test/kotlin/com/openbank/campaign/domain/SegmentEvaluationTest.kt
+++ b/openbank-campaign-service/src/test/kotlin/com/openbank/campaign/domain/SegmentEvaluationTest.kt
@@ -10,6 +10,7 @@ import org.junit.jupiter.api.Assertions.assertEquals
 import org.junit.jupiter.api.Assertions.assertFalse
 import org.junit.jupiter.api.Assertions.assertTrue
 import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.assertThrows
 
 class SegmentEvaluationTest {
 
@@ -34,16 +35,88 @@ class SegmentEvaluationTest {
         assertFalse(where.contains("'ACTIVE'"), "rule values must travel as bind parameters, never as literals")
     }
 
+    /**
+     * Regression for #2891. The DSL used to read `state`, `first_seen`, `has_account` and
+     * `consent_scopes` — none of which exist in silver_current_state, whose columns are the event
+     * envelope plus a `payload` JSON.
+     *
+     * This asserts the query TEXT, which is all the unit layer can do, and that is explicitly not
+     * enough: the same limitation is why #2891 shipped. It cannot catch a valid-looking query that
+     * ClickHouse refuses — proven while writing this fix, when the rewritten rule still used
+     * `jsonExtractString` and ClickHouse answered `Function with name 'jsonExtractString' does not
+     * exist` (it is `JSONExtractString`). A test asserting the lowercase spelling would have been
+     * green against a query that cannot run. Both rules were therefore executed against the sandbox
+     * ClickHouse by hand before merge. An automated executable check does not exist yet — tracked in
+     * #2891.
+     */
+    @Test
+    fun `rules only reference columns the silver layer actually has`() {
+        val silverColumns = setOf(
+            "aggregate_type", "aggregate_id", "event_id", "aggregate_version",
+            "event_type", "occurred_at", "source_service", "schema_version", "payload",
+        )
+        val vanished = setOf("state", "first_seen", "has_account", "consent_scopes")
+
+        val (where, _) = Segment(
+            "supported-rules",
+            1,
+            listOf(SegmentRule.PartyStatusIs("ACTIVE"), SegmentRule.TenureAtLeastDays(0)),
+        ).toWhereClause()
+
+        vanished.forEach { column ->
+            assertFalse(
+                Regex("(?<![a-z_])$column(?![a-z_])").containsMatchIn(where),
+                "rule SQL references `$column`, which silver_current_state does not have (#2891)",
+            )
+        }
+        assertTrue(silverColumns.any { where.contains(it) }, "rule SQL must read a real silver column")
+    }
+
+    @Test
+    fun `party status reads the payload JSON, not a status column`() {
+        val (where, _) = Segment("actives", 1, listOf(SegmentRule.PartyStatusIs("ACTIVE"))).toWhereClause()
+        assertTrue(where.contains("JSONExtractString(payload, 'status')"), "actual: $where")
+    }
+
+    /**
+     * silver_current_state keeps only the latest event per aggregate, so tenure has to reach into
+     * the bronze log for the party's first-seen timestamp.
+     */
+    @Test
+    fun `tenure derives first-seen from bronze, which silver cannot answer`() {
+        val (where, _) = Segment("tenured", 1, listOf(SegmentRule.TenureAtLeastDays(30))).toWhereClause()
+        assertTrue(where.contains("bronze_events"), "actual: $where")
+        assertTrue(where.contains("min(occurred_at)"), "actual: $where")
+    }
+
+    /**
+     * The two rules whose data does not exist anywhere in analytics are rejected where the segment is
+     * DEFINED. Rendering them into SQL that ClickHouse refuses is what made #2891 look like an empty
+     * cohort instead of a broken query.
+     */
+    @Test
+    fun `rules whose data the analytics layer does not carry are rejected at construction`() {
+        val noAccountLink = assertThrows<IllegalArgumentException> {
+            Segment("has-account", 1, listOf(SegmentRule.HasAccount))
+        }
+        assertTrue(noAccountLink.message!!.contains("partyId"), "actual: ${noAccountLink.message}")
+
+        val noConsentEvents = assertThrows<IllegalArgumentException> {
+            Segment("consented", 1, listOf(SegmentRule.HasActiveConsentScope("MARKETING_COMMS_EMAIL")))
+        }
+        assertTrue(noConsentEvents.message!!.contains("consent events"), "actual: ${noConsentEvents.message}")
+    }
+
     @Test
     fun `segment names are kebab-case`() {
-        org.junit.jupiter.api.assertThrows<IllegalArgumentException> {
-            Segment("Saver High Balance", 1, listOf(SegmentRule.HasAccount))
+        assertThrows<IllegalArgumentException> {
+            Segment("Saver High Balance", 1, listOf(SegmentRule.PartyStatusIs("ACTIVE")))
         }
     }
 
     @Test
     fun `a segment requires at least one rule`() {
-        org.junit.jupiter.api.assertThrows<IllegalArgumentException> {
+        assertThrows<IllegalArgumentException> {
             Segment("empty", 1, emptyList())
         }
     }


### PR DESCRIPTION
Closes #2891.

## What was wrong

The segment DSL generated SQL over `state`, `first_seen`, `has_account` and `consent_scopes`.
`silver_current_state` has none of those columns — it is the event log reduced to the latest row per
`(aggregate_type, aggregate_id)`, with the domain attributes inside a `payload` JSON.

Every evaluation failed, and because `SilverSegmentEvaluator` is fail-closed the failure surfaced as
an **empty cohort**: `enrol()` returned `enrolled: 0` for every campaign and every segment, which
reads as "nobody matched" rather than "the query never ran". That is what blocked the #2749 rollout.

## The rewrite

Two rules the layer can answer:

| Rule | Now renders |
|------|-------------|
| `PartyStatusIs` | `JSONExtractString(payload, 'status')` |
| `TenureAtLeastDays` | `min(occurred_at)` per party from `bronze_events` — silver keeps only the newest event per aggregate, so first-seen has to come from the log it reduces |

Two rules the layer cannot answer are now rejected **where the segment is defined**, instead of
rendering SQL ClickHouse refuses:

| Rule | Why |
|------|-----|
| `HasAccount` | No ACCOUNT event carries a `partyId` (0 of 59 bronze rows) — party↔account ownership is absent from analytics entirely |
| `HasActiveConsentScope` | No CONSENT aggregate is ingested, in silver or bronze |

**Dropping `HasActiveConsentScope` does not weaken the consent gate.** It was a cohort narrowing; the
binding check is the live per-send call in `LiveConsentCheckAdapter` (ADR-0198). A campaign without
it is not less consent-gated, the cohort is just not pre-filtered.

## The evaluator no longer launders a broken query into an empty cohort

A 4xx from ClickHouse means SQL it cannot execute — a bug — and now throws. 5xx and unreachability
stay fail-closed, where an empty cohort genuinely is the safe answer. Without this split, the next
schema drift is silent in exactly the same way.

## Verification

**Executed against the sandbox ClickHouse**, not just asserted as strings:

```
PartyStatusIs('ACTIVE')                        -> 2 parties
PartyStatusIs('ACTIVE') AND TenureAtLeastDays(0) -> the same 2 parties
```

**The new tests fail against the old implementation** — 4 of them, with the 3 pre-existing tests
still passing:

```
tenure derives first-seen from bronze, which silver cannot answer() FAILED
party status reads the payload JSON, not a status column() FAILED
rules whose data the analytics layer does not carry are rejected at construction() FAILED
rules only reference columns the silver layer actually has() FAILED
```

Full gate green on the fixed code: `detekt ktlintCheck koverVerify build`, plus a `--rerun-tasks`
test run to confirm the suite actually re-executed rather than reporting an UP-TO-DATE green.

## Worth reading before trusting the unit tests

While writing this, the rewritten rule still said `jsonExtractString`. ClickHouse answered
`Function with name 'jsonExtractString' does not exist. Maybe you meant: ['JSONExtractString', ...]`.
**That lowercase spelling was in the original code too**, so correcting only the column names would
have left the query exactly as unrunnable, for a second reason.

A unit test asserting the query text would have been green either way. That is the same limitation
that let #2891 ship, so I ran both rules against the real database by hand. An automated executable
check still does not exist — I did not leave a KDoc claiming otherwise, and #2891 carries the
suggestion (run each rule's rendered SQL against a real schema in CI).

## Scope

Segment evaluation only. The #2749 smoke journey is still unproven — this unblocks it but does not
demonstrate it.

Refs #2749