### PR TITLE
fix(ci): pass -R to gh run rerun — the auto-retry had never once succeeded

### DIFF
--- a/.github/workflows/auto-retry-cancelled.yml
+++ b/.github/workflows/auto-retry-cancelled.yml
@@ -45,6 +45,18 @@
 # dying — indistinguishable from the outside, so we accept one wasted retry on a manually
 # cancelled run over a more clever heuristic that can misfire.
 #
+# `-R` ON EVERY `gh run rerun` IS LOAD-BEARING (issue #2841 follow-up)
+# This job has no `actions/checkout`, so there is no git repository for `gh` to infer the
+# target repo from, and a bare `gh run rerun <id>` dies with
+#   failed to determine base repo: failed to run git: fatal: not a git repository
+# That is not a new hazard: it is how this workflow behaved from the day it was written, so
+# the auto-retry from #2330 had NEVER once succeeded — every invocation exited 1. Nothing
+# caught it because a `workflow_run` job's red is addressed to nobody (the same blind spot
+# `dependency-submission` hit for three days, which is why that one raises an issue now).
+# Verified from a non-git directory: without `-R` the command cannot resolve the repo; with
+# it, the call reaches the API. Do not drop the flag, and do not "fix" this by adding a
+# checkout — cloning the repo to make one API call is pure waste.
+#
 # WATCH LIST
 # Only the lanes that run on the spot pool and hurt when killed mid-flight: the PR services CI
 # and the two slow security lanes. Do NOT add auto-deploy here — it has its own reconcile tick.
@@ -84,7 +96,7 @@ jobs:
             # LOOP SAFETY above describes. `--failed` is a no-op against `cancelled`, so this
             # is always the full re-run.
             echo "Re-running cancelled run ${RUN_URL} (issue #2330)"
-            gh run rerun "${RUN_ID}"
+            gh run rerun -R "${GITHUB_REPOSITORY}" "${RUN_ID}"
             echo "::notice title=spot-kill auto-retry::Re-ran cancelled run ${RUN_URL} (attempt 2 of max 2; a second kill stays for a human)"
             exit 0
           fi
@@ -114,5 +126,5 @@ jobs:
           fi
 
           echo "Re-running ${RUN_URL}: ${killed} job(s) killed mid-step by a runner reclaim (issue #2841)"
-          gh run rerun "${RUN_ID}" --failed
+          gh run rerun -R "${GITHUB_REPOSITORY}" "${RUN_ID}" --failed
           echo "::notice title=spot-kill auto-retry::Re-ran ${killed} spot-killed job(s) in ${RUN_URL} (attempt 2 of max 2; a second kill stays for a human)"

--- a/.github/workflows/auto-retry-cancelled.yml
+++ b/.github/workflows/auto-retry-cancelled.yml
@@ -30,10 +30,24 @@
 #
 # A run-level `failure` is NOT retried on its own — that is the normal outcome of a broken
 # build, and blanket-retrying it would burn runner time and turn a deterministic red into a
-# flaky-looking one. It is retried only when a failed job carries the spot-kill SIGNATURE:
-# at least one `cancelled` step and NO `failed` step. A genuine build failure has a `failure`
-# step followed by `skipped` ones, never a `cancelled` one. Read from the jobs API, so no log
-# download is needed.
+# flaky-looking one. The run is retried when AT LEAST ONE failed job carries the spot-kill
+# SIGNATURE: at least one `cancelled` step and NO `failed` step. A genuine build failure has a
+# `failure` step followed by `skipped` ones, never a `cancelled` one. Read from the jobs API,
+# so no log download is needed.
+#
+# MIXED RUNS ARE THE NORMAL CASE, and the rule above is a per-RUN decision, not a per-JOB
+# filter. `gh run rerun --failed` re-runs every failed job, so a run containing both a
+# spot-killed job and a genuinely broken one re-runs both. That is accepted: the reclaimed job
+# needs the retry, the broken one fails again for the same reason, and `run_attempt == 1`
+# bounds the whole thing to a single extra attempt.
+#
+# Do not read the rule as "only spot-killed jobs are re-run" — it isn't, and the very first
+# live firing was already a mixed run. Services CI 30630120640 (main, 63 jobs) had three
+# failed jobs: `build (openbank-product-catalog)` killed by a reclaim (1 cancelled step, 0
+# failed), `build (openbank-mcp-service)` genuinely broken (0 cancelled, 1 failed), and
+# `all-green` failing downstream of them. The signature matched on one job and the whole set
+# was re-run. If per-job precision is ever wanted, it needs `gh run rerun --job <id>` per
+# killed job, which is a different and larger change.
 #
 # LOOP SAFETY
 # github.event.workflow_run.run_attempt is 1 for the original run and 2 for the first rerun,


### PR DESCRIPTION
Found by watching for the first live firing of #2892. It fired — and exposed that **the auto-retry from #2330 has never once succeeded.**

## The bug

The job has no `actions/checkout`, so `gh` has no git repository to infer the target repo from:

```
Re-running cancelled run https://github.com/JiRaska/open-bank-oss/actions/runs/30640099943
failed to determine base repo: failed to run git: fatal: not a git repository
##[error]Process completed with exit code 1
```

Every invocation of `gh run rerun` exited 1 at the first line that mattered.

## Not a regression from #2892

Run [30640432089](https://github.com/JiRaska/open-bank-oss/actions/runs/30640432089) at **14:52Z** — five minutes *before* #2892 merged at 14:57Z, on the old workflow — failed on the same line with the same message. The bug is as old as the workflow.

Nothing caught it because **a `workflow_run` job's red is addressed to nobody** — the same blind spot `dependency-submission` hit for three days, which is why that one raises a tracking issue now. This workflow still has no escalation path. Not fixed here; see below.

## It corrects the record in #2841

That issue said the mechanism *"fired on the harmless case and missed the one it was built for"*. The first half was wrong. The three concurrency-superseded `cancelled` runs I cited as *having been retried* were themselves exiting 1. It never fired at all — on either conclusion.

The #2841 fix (retry on a partial spot kill) was still correct and necessary; it just landed on top of a mechanism that could not execute its own final step.

## The fix

`-R "${GITHUB_REPOSITORY}"` on both `gh run rerun` calls. Verified from a non-git directory that this is precisely what resolves it:

```
gh run rerun 999999999                          ->  failed to determine base repo
gh run rerun 999999999 -R JiRaska/open-bank-oss ->  HTTP 404 (reached the API)
```

`gh api` calls in the same step are unaffected — they pass a full `repos/{owner}/{repo}/…` path and need no base-repo resolution.

Deliberately **not** fixed by adding a checkout: cloning the repo to make one API call is pure waste, and the comment in the file now says so, so the next person does not "helpfully" add one.

## Test

All three branches re-run against real SHAs, with a stub that **fails when `-R` is absent** — so the test cannot pass against the unfixed script. The stub was validated first by feeding it a bare rerun and watching it exit 1:

```
validation:        gh run rerun 1              ->  STUB: CHYBI -R (ROZBITE), exit 1
cancelled branch   ->  gh run rerun -R … <id>            ✓
spot-kill branch   ->  gh run rerun -R … <id> --failed   ✓
genuine failure    ->  does not re-run                   ✓
```

## Awkward but worth saying

This is the exact footgun I added to `CLAUDE.md` in #2894 a few minutes earlier:

> **`gh` needs a repo context: outside a checkout it fails with `failed to run git: fatal: not a git repository`** … Pass `-R <owner>/<repo>` explicitly in any script whose working directory is not guaranteed.

I wrote that bullet and then shipped #2892 without applying it, because I restructured an existing call instead of checking whether the original had ever succeeded. "A gate that has only ever passed is unfalsified" has a mirror image: **a step that has only ever gone red is equally unexamined** — I read its red as "did not apply here" rather than "never worked".

## Follow-up not in this PR

`auto-retry-cancelled.yml` still has no escalation path, so the next time it breaks it will again fail silently for as long as nobody looks. `dependency-submission.yml` solved this by raising/refreshing an issue on failure. Worth doing the same here — happy to open it as a separate change.

Refs #2841
