### PR TITLE
feat(edge): resolve the counterparty account on a transaction

### DIFF
--- a/openbank-customer-edge/src/main/kotlin/com/openbank/customeredge/infrastructure/rest/CustomerEdgeResource.kt
+++ b/openbank-customer-edge/src/main/kotlin/com/openbank/customeredge/infrastructure/rest/CustomerEdgeResource.kt
@@ -1360,7 +1360,56 @@ class CustomerEdgeResource(
             return forbidden("Account does not belong to caller")
         }
         val query = buildTransactionsQuery(accountId, limit, cursor)
-        return upstream.get("$transactionServiceUrl/api/v1/transactions$query", customer.partyId.toString())
+        val resp = upstream.get("$transactionServiceUrl/api/v1/transactions$query", customer.partyId.toString())
+        return enrichWithCounterpartyIban(resp, accountId, customer.partyId)
+    }
+
+    /**
+     * Add `counterpartyIban` to each transaction in a page.
+     *
+     * transaction-service keys both sides by ACCOUNT ID and carries no IBAN, so a client reading
+     * the history has no way to address the other side — which is why "repeat this payment" and
+     * "pay the sender back" could not be built on it. Resolving the id here, once, is cheaper and
+     * far less leaky than teaching every client to walk /accounts itself.
+     *
+     * Only the IBAN is taken from the counterparty account — never the owner's name, party or
+     * balance. An IBAN the customer already transacted with is on their statement anyway; the rest
+     * of that account is none of their business.
+     *
+     * The field is ABSENT, not empty, when it cannot be resolved: a counterparty at another bank
+     * has no account here to look up, and an account this caller may not read stays unreadable.
+     * Absent means "we could not say", which the app renders as no repeat button — a wrong IBAN
+     * would address money at a stranger.
+     *
+     * Lookups are memoised per request, so a page of twenty payments to one payee costs one call.
+     */
+    private fun enrichWithCounterpartyIban(resp: Response, accountId: UUID, partyId: UUID): Response {
+        if (resp.status != 200) return resp
+        val body = (resp.entity as? String)?.takeIf { it.isNotBlank() } ?: return resp
+        return runCatching {
+            val root = objectMapper.readTree(body)
+            val items = root.path("data").takeIf { it.isArray } ?: return resp
+            val ibanByAccount = mutableMapOf<String, String?>()
+            items.forEach { item ->
+                val obj = item as? com.fasterxml.jackson.databind.node.ObjectNode ?: return@forEach
+                val source = obj.path("sourceAccountId").asText(null)
+                val target = obj.path("targetAccountId").asText(null)
+                // The side that is NOT the account being read. A transfer between two of the
+                // caller's own accounts still has a counterparty — the other one.
+                val other = when (accountId.toString()) {
+                    target -> source
+                    source -> target
+                    else -> null
+                } ?: return@forEach
+                val iban = ibanByAccount.getOrPut(other) {
+                    runCatching { UUID.fromString(other) }.getOrNull()
+                        ?.let { fetchAccount(it, partyId) }
+                        ?.let { extractTextField(objectMapper, it, "accountNumber") }
+                }
+                if (iban != null) obj.put("counterpartyIban", iban)
+            }
+            Response.ok(root.toString()).build()
+        }.getOrElse { resp }
     }
 
     // Fetch an account from account-service by id (with the M2M token + party header). Returns the raw

--- a/openbank-customer-edge/src/main/resources/openapi.yaml
+++ b/openbank-customer-edge/src/main/resources/openapi.yaml
@@ -3,7 +3,7 @@
 openapi: 3.1.0
 info:
   title: Customer Edge API
-  version: 1.23.0
+  version: 1.24.0
   description: >-
     Customer-facing edge proxy (ADR-0065). Single internet-facing entry point for the
     retail customer app. Validates JWTs from the openbank-customers Keycloak realm,
@@ -1625,6 +1625,15 @@ components:
             How the movement was instructed (ADR-0103) — orthogonal to rail. One of the
             InstructionType enum values (ONE_OFF, STANDING_ORDER, DIRECT_DEBIT, FUTURE_DATED,
             SYSTEM, UNKNOWN). Null on legacy rows not yet stamped.
+        counterpartyIban:
+          type: string
+          description: >
+            IBAN of the other side of this transaction, resolved from its account id. Absent —
+            not empty — when it cannot be resolved: a counterparty at another bank has no account
+            here, and an account the caller may not read stays unreadable. Absent means "we could
+            not say", so a client must not render or pre-fill anything from it. Czech clients
+            should display and pre-fill the BBAN form (prefix-number/bankcode) derived from this;
+            the IBAN is carried because it converts to BBAN without loss and back only with it.
         merchantCategory:
           type: string
           nullable: true


### PR DESCRIPTION
## The gap

`transaction-service` keys both sides by **account id** and carries no account number. A client reading the history therefore cannot address the other side.

That is not theoretical: openbank-app shipped a "repeat this payment" button gated on `counterpartyIban`, and it **could never appear on a real device** — the field is only ever populated in the app's fake data. Same root cause blocks "pay the sender back".

## The fix

`GET /customer/v1/transactions` resolves the counterparty account id — the side that is *not* the account being read — to its account number and adds `counterpartyIban` to each item.

- **Only the account number** is taken from that account. Never the owner's name, party or balance. A number the customer already transacted with is on their statement anyway; the rest of that account is none of their business.
- **Absent, not empty**, when unresolvable: a counterparty at another bank has no account here, and an account this caller may not read stays unreadable. Absent means *"we could not say"* — a client must render that as no repeat button, because a wrong number addresses money at a stranger.
- **Memoised per request**: a page of twenty payments to one payee costs one upstream call, not twenty.
- Non-200 upstream, unparseable body, or any failure mid-enrichment returns the original response untouched — enrichment must never turn a working history into an error.

## A note on IBAN vs BBAN

The value is an IBAN because that is what account-service stores. For a Czech account it converts to the BBAN form (`prefix-number/bankcode`) **without loss**, and that is the direction that matters — BBAN → IBAN needs the check digits computed.

So: IBAN is the wire's canonical form; Czech UIs should **display and pre-fill the BBAN**, which is what a customer here actually reads and dictates. Said in the schema description so no client mistakes the wire form for the display form.

Edge OpenAPI 1.23.0 → 1.24.0.

## Linked issues

N/A — found while fixing the app-side repeat-payment feature; no tracking issue was filed.