### PR TITLE
fix(campaign): store the JSON documents as text so reads stop throwing

### DIFF
--- a/openbank-campaign-service/src/main/kotlin/com/openbank/campaign/infrastructure/persistence/Persistence.kt
+++ b/openbank-campaign-service/src/main/kotlin/com/openbank/campaign/infrastructure/persistence/Persistence.kt
@@ -52,7 +52,9 @@ class CampaignEntity : PanacheEntityBase() {
     @Column(nullable = false)
     var segmentVersion: Int = 1
 
-    @Column(nullable = false, columnDefinition = "jsonb")
+    // text, not jsonb (V2): under Hibernate Reactive the Vert.x PG client returns a JsonArray for a
+    // jsonb array column, which cannot be cast to String — every read threw ClassCastException.
+    @Column(nullable = false, columnDefinition = "text")
     lateinit var stepsJson: String
 
     @Column(nullable = false)
@@ -131,7 +133,8 @@ class SegmentEntity : PanacheEntityBase() {
     @Column(nullable = false)
     var version: Int = 1
 
-    @Column(nullable = false, columnDefinition = "jsonb")
+    // text, not jsonb — see the note on CampaignEntity.stepsJson and migration V2.
+    @Column(nullable = false, columnDefinition = "text")
     lateinit var rulesJson: String
 
     @Column(nullable = false)

--- a/openbank-campaign-service/src/main/resources/db/migration/V2__json_columns_as_text.sql
+++ b/openbank-campaign-service/src/main/resources/db/migration/V2__json_columns_as_text.sql
@@ -1,0 +1,34 @@
+-- SPDX-License-Identifier: Apache-2.0
+-- Copyright (c) OpenBank contributors. Licensed under the Apache License, Version 2.0.
+--
+-- Store the two JSON documents as text rather than jsonb.
+--
+-- WHY: the entities map these columns to a Kotlin String, and under Hibernate Reactive the Vert.x
+-- PG client hands back a typed io.vertx.core.json.JsonArray for a jsonb column holding an array.
+-- Hibernate cannot cast that to String, so EVERY read of a campaign or a segment failed with
+--
+--     java.lang.ClassCastException: Invalid String value type class io.vertx.core.json.JsonArray
+--
+-- which made POST /api/v1/campaigns a 500 (it loads the segment first) and would have done the same
+-- to every campaign read. A jsonb column holding an OBJECT is unaffected — product-catalog's `doc`
+-- maps jsonb to String on the same stack and reads fine — so this is specific to arrays.
+--
+-- WHY TEXT AND NOT A JSON TYPE MAPPING: both columns are only ever round-tripped whole, as strings
+-- (`mapper.writeValueAsString` on write, `mapper.readValue` on read). Nothing queries them with JSON
+-- operators and nothing indexes them, so jsonb bought validation we never used at the cost of a type
+-- the driver returns as something the entity cannot accept. text removes the ambiguity entirely
+-- instead of relying on driver-specific conversion behaviour.
+--
+-- Note the cast direction is lossless: jsonb -> text always succeeds. Existing rows keep their
+-- content, normalised by jsonb's own formatting (key order, whitespace), which the JSON parser on
+-- the read side does not care about.
+--
+-- ROLLBACK:
+--   ALTER TABLE campaigns ALTER COLUMN steps_json TYPE jsonb USING steps_json::jsonb;
+--   ALTER TABLE segments  ALTER COLUMN rules_json TYPE jsonb USING rules_json::jsonb;
+-- Safe as long as every stored value is valid JSON, which it is — it is written by Jackson. Rolling
+-- back reinstates the read failure above, so it is only useful together with reverting the entity
+-- change.
+
+ALTER TABLE campaigns ALTER COLUMN steps_json TYPE text USING steps_json::text;
+ALTER TABLE segments ALTER COLUMN rules_json TYPE text USING rules_json::text;


### PR DESCRIPTION
## Symptom

`POST /api/v1/campaigns` returned 500, and so would any read of an existing campaign:

```
java.lang.ClassCastException: Invalid String value type class io.vertx.core.json.JsonArray
```

## Cause

Both entities map their JSON column to a Kotlin `String`, but under Hibernate Reactive the Vert.x PG
client returns a typed `io.vertx.core.json.JsonArray` for a `jsonb` column holding an array.
Hibernate cannot cast that to `String`.

It affects `segments.rules_json` — loaded by `createDraft`, which is why campaign *creation* failed —
and `campaigns.steps_json` equally.

**Scoped to arrays, not to jsonb in general.** product-catalog maps a jsonb *object* to `String` on
the same reactive stack and reads fine (verified live: `GET /api/v1/products` → 200 with rows). That
contrast is what narrowed the diagnosis.

## Why an empty table hid it

`GET /api/v1/campaigns` answered `200 []` throughout the rollout, because with no rows the mapping
never ran. I had taken that 200 as "the read path works" after fixing the column naming in #2881; it
was true only of an empty table. The first real row disproved it.

## Fix

V2 migrates both columns to `text`; the entities follow.

Both documents are only ever round-tripped whole as strings (`writeValueAsString` on write,
`readValue` on read). Nothing queries them with JSON operators and nothing indexes them, so `jsonb`
was buying validation we never used at the cost of a driver type the entity cannot accept. `text`
removes the ambiguity rather than depending on driver-specific conversion behaviour.

The migration carries a rollback note. `jsonb -> text` is lossless; rolling back reinstates the read
failure, so it is only meaningful together with reverting the entity change.

## Verification

- **Migration executed against the sandbox database inside a transaction that was rolled back**: both
  `ALTER`s succeed, `information_schema` reports both columns as `text`, and after `ROLLBACK` they
  are `jsonb` again — schema untouched.
- Full gate green: `detekt ktlintCheck koverVerify build`.

## Related, unverified

sanctions-service maps four jsonb *array* columns to `String` on the same reactive stack
(`aliases`, `identifiers`, `matches`, `checked_lists`) and holds 161 rows. Its recent logs show no
such exception, but that only means the path has not been exercised lately — it is not evidence of
health. Worth checking separately; I have not, and am not claiming it is broken.

Refs #2749