### PR TITLE
fix(campaign): give SegmentRule a persistence format it can be read back from

### DIFF
--- a/openbank-campaign-service/src/main/kotlin/com/openbank/campaign/infrastructure/persistence/Persistence.kt
+++ b/openbank-campaign-service/src/main/kotlin/com/openbank/campaign/infrastructure/persistence/Persistence.kt
@@ -17,7 +17,6 @@ import com.openbank.campaign.domain.model.Enrolment
 import com.openbank.campaign.domain.model.EnrolmentState
 import com.openbank.campaign.domain.model.Segment
 import com.openbank.campaign.domain.model.SegmentRef
-import com.openbank.campaign.domain.model.SegmentRule
 import com.openbank.campaign.domain.model.SendOutcome
 import com.openbank.campaign.domain.model.SendRecord
 import com.openbank.libs.domain.identifiers.Ids
@@ -265,7 +264,7 @@ class PanacheSegmentRegistry(private val mapper: ObjectMapper) :
 
     override suspend fun load(name: String, version: Int): Segment? =
         Panache.withSession { find("name = ?1 and version = ?2", name, version).firstResult<SegmentEntity>() }
-            .awaitSuspending()?.let { Segment(it.name, it.version, mapper.readValue<List<SegmentRule>>(it.rulesJson)) }
+            .awaitSuspending()?.let { Segment(it.name, it.version, SegmentRuleSerde.read(mapper, it.rulesJson)) }
 
     override suspend fun save(segment: Segment): Segment {
         Panache.withTransaction {
@@ -274,7 +273,7 @@ class PanacheSegmentRegistry(private val mapper: ObjectMapper) :
                     id = Ids.newId()
                     name = segment.name
                     version = segment.version
-                    rulesJson = mapper.writeValueAsString(segment.rules)
+                    rulesJson = SegmentRuleSerde.write(mapper, segment.rules)
                     createdAt = Instant.now()
                 },
             )
@@ -283,5 +282,5 @@ class PanacheSegmentRegistry(private val mapper: ObjectMapper) :
     }
 
     override suspend fun list(): List<Segment> = Panache.withSession { listAll() }.awaitSuspending()
-        .map { Segment(it.name, it.version, mapper.readValue<List<SegmentRule>>(it.rulesJson)) }
+        .map { Segment(it.name, it.version, SegmentRuleSerde.read(mapper, it.rulesJson)) }
 }

--- a/openbank-campaign-service/src/main/kotlin/com/openbank/campaign/infrastructure/persistence/SegmentRuleSerde.kt
+++ b/openbank-campaign-service/src/main/kotlin/com/openbank/campaign/infrastructure/persistence/SegmentRuleSerde.kt
@@ -1,0 +1,83 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright (c) OpenBank contributors. Licensed under the Apache License, Version 2.0.
+// See LICENSE in the repository root or https://www.apache.org/licenses/LICENSE-2.0 for details.
+
+package com.openbank.campaign.infrastructure.persistence
+
+import com.fasterxml.jackson.databind.JsonNode
+import com.fasterxml.jackson.databind.ObjectMapper
+import com.fasterxml.jackson.databind.node.ArrayNode
+import com.openbank.campaign.domain.model.SegmentRule
+
+/**
+ * Persistence format for [SegmentRule], owned by the adapter rather than the domain (ADR-0002).
+ *
+ * `SegmentRule` is a sealed hierarchy, and Jackson cannot deserialise one without type information:
+ * reading a stored segment threw
+ *
+ *     Cannot construct instance of `SegmentRule` (no Creators, like default constructor, exist):
+ *     abstract types either need to be mapped to concrete types, have custom deserializer, or
+ *     contain additional type information
+ *
+ * The usual fix is `@JsonTypeInfo`/`@JsonSubTypes` on the sealed class, but the domain layer carries
+ * zero framework imports, so annotating it there is not available. A Jackson mixin would work and
+ * keep the domain clean; this does the same job without the indirection, and — the reason it is
+ * preferred here — it fails loudly and specifically on a rule name it does not recognise, instead of
+ * yielding a half-built object. The mapping is deliberately explicit: adding a `SegmentRule` without
+ * touching this file is a compile error on the `when`, not a silent runtime gap.
+ *
+ * Format: `[{"type":"PartyStatusIs","status":"ACTIVE"}, {"type":"TenureAtLeastDays","minDays":30}]`
+ */
+object SegmentRuleSerde {
+
+    private const val TYPE = "type"
+
+    fun write(mapper: ObjectMapper, rules: List<SegmentRule>): String {
+        val array = mapper.createArrayNode()
+        rules.forEach { rule ->
+            val node = array.addObject()
+            when (rule) {
+                is SegmentRule.PartyStatusIs -> {
+                    node.put(TYPE, "PartyStatusIs")
+                    node.put("status", rule.status)
+                }
+
+                is SegmentRule.TenureAtLeastDays -> {
+                    node.put(TYPE, "TenureAtLeastDays")
+                    node.put("minDays", rule.minDays)
+                }
+
+                // Unsupported rules are rejected by Segment's constructor, so a persisted segment can
+                // never contain one. Writing them anyway would put a rule in the database that can
+                // never be loaded back (issue #2891).
+                is SegmentRule.HasAccount,
+                is SegmentRule.HasActiveConsentScope,
+                -> throw IllegalArgumentException(
+                    "rule ${rule::class.simpleName} cannot be persisted: ${rule.unsupportedReason}",
+                )
+            }
+        }
+        return mapper.writeValueAsString(array)
+    }
+
+    fun read(mapper: ObjectMapper, json: String): List<SegmentRule> {
+        val array = mapper.readTree(json) as? ArrayNode
+            ?: throw IllegalArgumentException(
+                "segment rules must be a JSON array, got: ${json.take(ERROR_SNIPPET_LENGTH)}",
+            )
+        return array.map { node ->
+            when (val type = node[TYPE]?.asText()) {
+                "PartyStatusIs" -> SegmentRule.PartyStatusIs(field(node, "status", type).asText())
+                "TenureAtLeastDays" -> SegmentRule.TenureAtLeastDays(field(node, "minDays", type).asLong())
+                else -> throw IllegalArgumentException(
+                    "unknown segment rule type: ${type ?: "<missing `type`>"}",
+                )
+            }
+        }
+    }
+
+    private fun field(node: JsonNode, name: String, ruleType: String): JsonNode =
+        node[name] ?: throw IllegalArgumentException("$ruleType requires `$name`")
+
+    private const val ERROR_SNIPPET_LENGTH = 80
+}

--- a/openbank-campaign-service/src/test/kotlin/com/openbank/campaign/infrastructure/SegmentRuleSerdeTest.kt
+++ b/openbank-campaign-service/src/test/kotlin/com/openbank/campaign/infrastructure/SegmentRuleSerdeTest.kt
@@ -1,0 +1,86 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright (c) OpenBank contributors. Licensed under the Apache License, Version 2.0.
+// See LICENSE in the repository root or https://www.apache.org/licenses/LICENSE-2.0 for details.
+
+package com.openbank.campaign.infrastructure
+
+import com.fasterxml.jackson.databind.ObjectMapper
+import com.openbank.campaign.domain.model.SegmentRule
+import com.openbank.campaign.infrastructure.persistence.SegmentRuleSerde
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Assertions.assertTrue
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.assertThrows
+
+/**
+ * The round-trip nobody had: reading a stored segment used to throw
+ * `Cannot construct instance of SegmentRule (no Creators...)`, because Jackson cannot deserialise a
+ * sealed hierarchy without type information. That surfaced only when a real segment row existed —
+ * the first `POST /api/v1/campaigns` of the #2749 rollout, which loads the segment.
+ */
+class SegmentRuleSerdeTest {
+
+    private val mapper = ObjectMapper()
+
+    @Test
+    fun `rules survive a write-read round trip`() {
+        val rules = listOf(
+            SegmentRule.PartyStatusIs("ACTIVE"),
+            SegmentRule.TenureAtLeastDays(30),
+        )
+
+        val restored = SegmentRuleSerde.read(mapper, SegmentRuleSerde.write(mapper, rules))
+
+        assertEquals(rules, restored)
+    }
+
+    @Test
+    fun `the persisted shape carries a discriminator`() {
+        val json = SegmentRuleSerde.write(mapper, listOf(SegmentRule.PartyStatusIs("ACTIVE")))
+        assertTrue(json.contains("\"type\":\"PartyStatusIs\""), "actual: $json")
+        assertTrue(json.contains("\"status\":\"ACTIVE\""), "actual: $json")
+    }
+
+    @Test
+    fun `an unknown rule type fails loudly rather than yielding a half-built rule`() {
+        val e = assertThrows<IllegalArgumentException> {
+            SegmentRuleSerde.read(mapper, """[{"type":"WasDeletedInV3","status":"ACTIVE"}]""")
+        }
+        assertTrue(e.message!!.contains("WasDeletedInV3"), "actual: ${e.message}")
+    }
+
+    @Test
+    fun `a rule missing its discriminator is rejected`() {
+        val e = assertThrows<IllegalArgumentException> {
+            SegmentRuleSerde.read(mapper, """[{"status":"ACTIVE"}]""")
+        }
+        assertTrue(e.message!!.contains("missing"), "actual: ${e.message}")
+    }
+
+    @Test
+    fun `a rule missing a required field is rejected`() {
+        val e = assertThrows<IllegalArgumentException> {
+            SegmentRuleSerde.read(mapper, """[{"type":"PartyStatusIs"}]""")
+        }
+        assertTrue(e.message!!.contains("status"), "actual: ${e.message}")
+    }
+
+    /**
+     * Unsupported rules cannot reach the database: `Segment` rejects them at construction, and
+     * writing one anyway would store a rule that can never be read back (#2891).
+     */
+    @Test
+    fun `an unsupported rule cannot be persisted`() {
+        val e = assertThrows<IllegalArgumentException> {
+            SegmentRuleSerde.write(mapper, listOf(SegmentRule.HasAccount))
+        }
+        assertTrue(e.message!!.contains("HasAccount"), "actual: ${e.message}")
+    }
+
+    @Test
+    fun `a non-array document is rejected`() {
+        assertThrows<IllegalArgumentException> {
+            SegmentRuleSerde.read(mapper, """{"type":"PartyStatusIs","status":"ACTIVE"}""")
+        }
+    }
+}


### PR DESCRIPTION
## Symptom

`POST /api/v1/campaigns` → 500. `createDraft` loads the segment before it builds anything, and the
load threw:

```
Cannot construct instance of `SegmentRule` (no Creators, like default constructor, exist):
abstract types either need to be mapped to concrete types, have custom deserializer,
or contain additional type information
```

## Cause

`SegmentRule` is a sealed hierarchy, and `PanacheSegmentRegistry` called
`mapper.readValue<List<SegmentRule>>` on it. Jackson cannot deserialise that without type
information, and the write side (`writeValueAsString`) emitted none.

So `save` produced a document `load` could never parse — the registry could not round-trip its own
output. Nothing caught it: no test exercises the registry, and the table stayed empty until the first
real segment existed, which was this rollout.

## Fix

An explicit, adapter-owned serde (`SegmentRuleSerde`) with a `type` discriminator.

The conventional fix would be `@JsonTypeInfo`/`@JsonSubTypes` on the sealed class, but the domain
layer carries zero framework imports (ADR-0002), so that is not available. A Jackson mixin
registered in infrastructure would also work and is the other reasonable choice — I went with the
explicit mapping because:

- it **fails loudly and specifically** on a rule name it does not recognise, rather than producing a
  half-built object;
- adding a `SegmentRule` becomes a **compile error** on the `when`, not a silent runtime gap;
- it introduces no fleet-new Jackson wiring — there is currently no `ObjectMapperCustomizer`,
  `addMixIn` or `@JsonSubTypes` anywhere in the repo, so either choice would have been a new pattern,
  and this one has no framework magic to understand.

Unsupported rules (`HasAccount`, `HasActiveConsentScope`) are refused on write: `Segment` already
rejects them at construction, and persisting one would store a rule that can never be read back
(#2891).

## Tests

Seven, covering what was missing rather than what already worked: the round trip, the discriminator
in the stored shape, an unknown rule type, a missing discriminator, a missing required field, a
non-array document, and the refusal to persist an unsupported rule.

## Verification

Full gate green: `detekt ktlintCheck koverVerify build`. Test counts read from the JUnit XML rather
than the console — 20 tests, 0 failures, across `SegmentEvaluationTest` (7),
`SegmentRuleSerdeTest` (7) and `CampaignStateMachineTest` (6) — after a `--rerun-tasks` run, since a
15-second "BUILD SUCCESSFUL" on UP-TO-DATE tasks proves nothing about whether the new tests executed.

detekt caught two real things on the way (`ThrowsCount`, `MagicNumber`); both are fixed in the code
rather than baselined.

## Context

Eleventh defect found by driving the #2749 rollout, and the third in the read path alone: column
naming (#2881), jsonb array mapping (#2902), and now sealed-class serialisation. Each was hidden by
the one in front of it, and all three needed a real row to surface.

Refs #2749, #2891