### PR TITLE
fix(consent): bind consent.revoke's authz resource to granteeId so the M2M rule can fire

### DIFF
--- a/openbank-consent-service/src/main/kotlin/com/openbank/consent/infrastructure/rest/ConsentResource.kt
+++ b/openbank-consent-service/src/main/kotlin/com/openbank/consent/infrastructure/rest/ConsentResource.kt
@@ -138,13 +138,19 @@ class ConsentResource(
     @Operation(summary = "Revoke an ACTIVE consent; transitions to REVOKED and enqueues ConsentRevoked event")
     @DELETE
     @Path("/{id}")
-    // "resource = #id" is unaffected (unscoped human/operator rule). The optional granteeId
-    // query param is for the M2M path (ADR-0206 D2): consent-opa-bundle.yaml's
-    // service-consent-m2m-marketing rule checks it via #granteeId directly (no dotted path
-    // needed here — it's already a top-level parameter), and the use case cross-checks it
-    // against the loaded consent's actual granteeId before revoking, since the OPA decision
-    // can't see the DB row this endpoint hasn't loaded yet.
-    @Authorize(action = "consent.revoke", resource = "#id")
+    // resource = "#granteeId", NOT "#id" (issue #2911). The M2M path (ADR-0206 D2) is gated by
+    // consent-opa-bundle.yaml's service-consent-m2m-marketing rule, which requires
+    // `input.resource.id == "party-service:marketing-comms"`. Binding the resource to the consent
+    // UUID made that comparison unsatisfiable, so the rule's consent.revoke half was dead code and
+    // every M2M revoke 403'd — while consent.grant worked, because create binds
+    // `#request.granteeId`. Measured: grant 201, revoke 403, same principal.
+    //
+    // Human/operator callers are unaffected: they do not pass granteeId, extractResource then
+    // yields no resource at all, and `operator-consent-write` does not inspect one.
+    //
+    // The use case still cross-checks the passed granteeId against the loaded consent's actual
+    // granteeId before revoking, since the OPA decision cannot see the DB row.
+    @Authorize(action = "consent.revoke", resource = "#granteeId")
     suspend fun revoke(
         @PathParam("id") id: UUID,
         @QueryParam("partyId") partyId: UUID,


### PR DESCRIPTION
Closes #2911.

## What was wrong

The ADR-0206 exception letting party-service forward the mobile app's marketing-consent toggle worked
in one direction only. Measured against the sandbox with the shared M2M principal
(`service-account-openbank-services`):

| Operation | `@Authorize` resource | Result |
|-----------|----------------------|--------|
| `consent.grant` | `#request.granteeId` | **201** |
| `consent.revoke` | `#id` | **403** |

`service-consent-m2m-marketing` requires `input.resource.id == "party-service:marketing-comms"`.
Binding the resource to the consent UUID made that comparison unsatisfiable, so the rule's
`consent.revoke` half was unreachable and the caller fell through to deny.

The comment above the annotation already described the intended behaviour — *"the rule checks it via
`#granteeId` directly"* — while the annotation said `#id`. Intent and code disagreed, and the code won.

`consent-service` runs `AUTHZ_ENFORCE=true`, so this was a live denial.

## Impact

Marketing consent could be switched on from the app and never off through the same path. GDPR
Art. 7(3) requires withdrawal to be as easy as granting.

## Fix

`resource = "#granteeId"`.

Human/operator callers are unaffected: they pass no `granteeId`, `extractResource` then returns no
resource at all, and `operator-consent-write` does not inspect one.

## The trade-off, stated rather than buried

`RedisApprovalStore` keys pending approvals by `resourceId`. So this also changes what a
`consent.revoke` approval is keyed by — the grantee rather than the consent.

- Today that is **inert**: `AUTHZ_FOUR_EYES_ENFORCE` defaults to false and the deployment does not
  set it, so no approval is ever created for this action.
- Before four-eyes is enabled for consent-service, it must be addressed — otherwise one approval
  would cover every revoke for that grantee instead of the single consent it was granted for.

The root cause is that one annotation field serves two purposes: the OPA resource *and* the approval
key. Separating them is the durable fix and is deliberately out of scope here — this PR restores a
path that is currently broken, and I would rather name the coupling than quietly widen it.

## Verification

- `detekt ktlintCheck test` green on consent-service.
- Both halves measured live, not inferred: the 201/403 pair above is what identified the rule as
  unreachable, and it is the same pair that should flip after deploy.
- The rego is unchanged, so no OPA bundle regeneration is involved.

## Not fixed here

A guard for the general shape — an `@Authorize` resource expression that no rule can ever match. The
existing `check-no-service-principal-type.sh` catches the principal-type version of this defect class;
this is the resource-binding version and is invisible to it. Noted in #2911.

Refs #2749