### PR TITLE
fix(fx): point the ČNB fixing ingestion at the URL that actually serves it

### DIFF
--- a/.github/scripts/check-external-feeds.py
+++ b/.github/scripts/check-external-feeds.py
@@ -1,0 +1,399 @@
+#!/usr/bin/env python3
+# SPDX-License-Identifier: Apache-2.0
+# Copyright (c) OpenBank contributors. Licensed under the Apache License, Version 2.0.
+#
+# External public-feed watch: catch a dead third-party data feed before a money-path job
+# silently stops producing (issue #2204).
+#
+# WHY THIS EXISTS
+#   `openbank-fx-service` ingests the statutory ČNB daily fixing from a public text feed. On
+#   2026-07-31 that feed's configured URL was a 404 — one path segment short — and had been for
+#   the whole life of the service. ČNB serves the 404 as a 58 KB HTML page, `CnbFixingParser`
+#   rejects it, and `CnbRateIngestionScheduler`'s catch swallows the exception into a single
+#   ERROR line. So:
+#
+#     * every layer was green. The scheduler fired (after #2187 fixed HR000068), the rest-client
+#       resolved, the circuit breaker never opened — a 404 is a perfectly good HTTP response.
+#     * the ONLY evidence was an absence: `fx_rates` stopped gaining `source = CNB` rows. Nothing
+#       alerts on a table not growing.
+#     * downstream, `FxRevaluationService` reads `findLatestBySource(... validTo > now)`, gets
+#       `null`, logs "No ČNB rate for EUR/CZK — skipping its revaluation leg", and returns
+#       `posted = false`. A successful-looking run of a job that revalued nothing.
+#
+#   A URL in a config file is not covered by any test in this repo, by construction: a unit test
+#   stubs the client, an IT serves a local fixture, and a consumer pact answers whatever path it
+#   is asked for (the #2283 lesson — only the real provider can falsify a path). The upstream here
+#   is a foreign government feed with no pact and no contract; the only thing that can falsify its
+#   URL is fetching it.
+#
+# WHAT IT CHECKS
+#   1. DRIFT, both directions, offline — this half is PR-BLOCKING.
+#        Every external `http(s)://` URL in a scanned `application.yaml` must be either
+#        (a) declared in FEEDS, so it is probed, or
+#        (b) declared in NOT_PROBED with a reason it cannot be.
+#        A new external dependency added without either is a feed this watch would silently know
+#        nothing about while still passing. This is the repo's derived-scope rule: a gate whose
+#        coverage set is maintained separately from the artifacts it covers reads as *passing*
+#        when the set is short, never as *unchecked*.
+#
+#        FEEDS holds NO copy of the URL. It names the YAML path (`quarkus.rest-client.cnb-feed.url`)
+#        and the probe reads the value out of the committed file. A second copy would move together
+#        with the first and the probe would keep passing against a URL the service does not use —
+#        the same vacuous shape as deriving both halves of a pact from one annotation.
+#
+#   2. LIVENESS, online — this half NEVER blocks a PR; it escalates to an issue.
+#        Fetch each declared feed and assert its SHAPE, not merely its status code. A 200 proves
+#        a server answered; it does not prove the answer is the feed. ČNB's own 404 page is a
+#        200-shaped HTML document to anything that only reads the status line, and several CDNs
+#        return 200 + an interstitial. So each feed declares a matcher that the real payload must
+#        satisfy, and `--self-test` runs every matcher against a payload it MUST accept and
+#        payloads it MUST reject (including that HTML error page). A matcher that has only ever
+#        returned "fine" is indistinguishable from one that always does.
+#
+# EXIT CODES
+#   0  no drift, every declared feed live and correctly shaped
+#   1  DRIFT — an undeclared external URL, a declared feed whose YAML path no longer resolves, or
+#      a stale NOT_PROBED entry. Offline, deterministic, and a PR must not merge over it.
+#   2  a declared feed is DEAD or misshapen — actionable, but a property of the internet at this
+#      moment, so it escalates rather than blocking a merge.
+#   3  the probe itself could not run (no network, PyYAML missing). NEVER conflate with 0: a
+#      fetch that fails is not evidence the feed is fine, and this script exists precisely because
+#      a broken thing's silence read as health for 46 days.
+#
+# Run:  python3 .github/scripts/check-external-feeds.py [--root .] [--self-test] [--offline]
+
+import argparse
+import pathlib
+import re
+import sys
+import urllib.error
+import urllib.request
+
+try:
+    import yaml
+except ImportError:  # pragma: no cover - reported as exit 3 by main()
+    yaml = None
+
+TIMEOUT_SECONDS = 25
+USER_AGENT = "openbank-external-feed-watch/1.0 (+https://github.com/JiRaska/open-bank-oss)"
+
+# ---------------------------------------------------------------------------------------------
+# Shape matchers. Each returns None when the payload IS the expected feed, or a short reason why
+# it is not. They must reject an HTML error page — that is the failure this whole script is about.
+# ---------------------------------------------------------------------------------------------
+
+
+def _looks_like_html(text):
+    head = text.lstrip()[:200].lower()
+    return head.startswith("<!doctype html") or head.startswith("<html") or "<head>" in head
+
+
+def shape_cnb_fixing(text):
+    """The ČNB daily central-bank fixing text feed.
+
+    Line 1 is `DD.MM.YYYY #seq`; the rest are `country|currency|amount|code|rate`. Asserting the
+    header AND a plausible number of rate lines is what separates the feed from a 200-with-nothing
+    and from the HTML 404 page ČNB actually serves for a wrong path.
+    """
+    if _looks_like_html(text):
+        return "payload is an HTML page, not the fixing text feed"
+    lines = [ln.strip() for ln in text.splitlines() if ln.strip()]
+    if not lines:
+        return "payload is empty"
+    if not re.match(r"^\d{2}\.\d{2}\.\d{4}\s+#\d+$", lines[0]):
+        return f"first line is not a `DD.MM.YYYY #seq` header: {lines[0][:60]!r}"
+    rates = [ln for ln in lines[1:] if len(ln.split("|")) == 5 and ln.split("|")[2].strip().isdigit()]
+    if len(rates) < 5:
+        return f"only {len(rates)} parseable rate line(s) — the feed normally carries ~30"
+    return None
+
+
+def shape_xml_document(text):
+    """Any XML payload with at least one element — used for registry-style feeds."""
+    if _looks_like_html(text):
+        return "payload is an HTML page, not XML"
+    stripped = text.lstrip()
+    if not stripped.startswith("<?xml") and not stripped.startswith("<"):
+        return f"payload does not begin as XML: {stripped[:60]!r}"
+    if not re.search(r"<[A-Za-z_][\w.:-]*[\s/>]", stripped):
+        return "payload contains no XML element"
+    return None
+
+
+SHAPES = {
+    "cnb_fixing": shape_cnb_fixing,
+    "xml_document": shape_xml_document,
+}
+
+# ---------------------------------------------------------------------------------------------
+# Declared feeds. `yaml_path` is the dotted key whose VALUE is the URL — never the URL itself.
+# ---------------------------------------------------------------------------------------------
+
+FEEDS = [
+    {
+        "name": "cnb-daily-fixing",
+        "file": "openbank-fx-service/src/main/resources/application.yaml",
+        "yaml_path": "quarkus.rest-client.cnb-feed.url",
+        "shape": "cnb_fixing",
+        "why": (
+            "The statutory ČNB fixing. `FxRevaluationService` marks every foreign position to it "
+            "(ADR-0046); with no rate the revaluation skips the leg and posts nothing."
+        ),
+    },
+    {
+        "name": "cnb-bank-registry",
+        "file": "openbank-customer-edge/src/main/resources/application.yaml",
+        "yaml_path": "openbank.edge.cnb-banks-url",
+        "shape": "xml_document",
+        "why": (
+            "Czech bank-code registry behind IBAN/account validation in customer-edge. "
+            "`CnbBanksClient` falls back to an embedded /banks.json, so a dead URL degrades to a "
+            "frozen list rather than an outage — which is exactly why nothing notices it."
+        ),
+    },
+]
+
+# External URLs that exist in a scanned YAML but cannot be probed by an unauthenticated CI job.
+# Each needs a reason. This list is the thing a human has to justify, not the coverage.
+NOT_PROBED = [
+    ("https://api.github.com", "authenticated API, not a data feed; failure is loud at call time"),
+    ("https://api.groq.com/openai/v1", "authenticated LLM gateway (ADR-0139); needs a key"),
+    ("https://api.deepinfra.com/v1/openai", "authenticated LLM gateway; needs a key"),
+    ("https://integrate.api.nvidia.com/v1", "authenticated LLM gateway; needs a key"),
+    ("https://s3.eu-central-1.amazonaws.com", "AWS endpoint, reached with SigV4 credentials"),
+    ("https://kc.open-bank.tech/realms/openbank-customers", "our own Keycloak realm, covered by its own probes"),
+    ("https://pid.open-bank.tech", "our own PID issuer, covered by its own probes"),
+]
+
+URL_IN_TEXT = re.compile(r"https?://[^\s\"'}\)>,]+")
+_LOOPBACK = re.compile(r"^https?://(localhost|127\.0\.0\.1|0\.0\.0\.0)(:\d+)?(/|$)")
+_PLAINTEXT = re.compile(r"^http://(?P<host>[^/:]+)(?P<port>:\d+)?")
+
+
+def is_internal(url):
+    """True for a URL that is in-cluster by construction, so not a third-party feed.
+
+    Deliberately narrow, because a false "internal" is a feed this watch never looks at. A
+    plaintext `http://` URL qualifies only when something else also marks it as cluster-local:
+    a loopback host, a dotless service name, an explicit port (every k8s service URL in this
+    tree carries one; a public feed uses the default 443), or an explicit `.svc`/`.cluster.local`
+    suffix. Anything over `https://` is treated as external without exception — a banking
+    service does not fetch a third-party feed in plaintext, so `https` is the honest tell.
+    """
+    if _LOOPBACK.match(url):
+        return True
+    m = _PLAINTEXT.match(url)
+    if not m:
+        return False  # https:// — external by definition
+    host, port = m.group("host"), m.group("port")
+    return "." not in host or bool(port) or host.endswith((".svc", ".cluster.local"))
+
+
+def scanned_yamls(root):
+    return sorted(pathlib.Path(root).glob("openbank-*/src/main/resources/application.yaml"))
+
+
+def external_urls_in(path):
+    """Every third-party URL literal in a YAML, ignoring comments and internal hosts."""
+    found = []
+    for lineno, line in enumerate(path.read_text(encoding="utf-8").splitlines(), 1):
+        if line.lstrip().startswith("#"):
+            continue
+        for url in URL_IN_TEXT.findall(line):
+            url = url.rstrip("},")
+            if is_internal(url):
+                continue
+            found.append((lineno, url))
+    return found
+
+
+def resolve_yaml_path(doc, dotted):
+    node = doc
+    for part in dotted.split("."):
+        if not isinstance(node, dict) or part not in node:
+            return None
+        node = node[part]
+    return node if isinstance(node, str) else None
+
+
+def strip_config_default(value):
+    """`${CNB_FEED_URL:https://…}` -> the default. A plain URL passes through unchanged."""
+    m = re.fullmatch(r"\$\{[A-Za-z_][A-Za-z0-9_]*:(.*)\}", value.strip())
+    return (m.group(1) if m else value).strip()
+
+
+def load_feed_urls(root, problems):
+    """Read each declared feed's URL out of its committed YAML. Never from a table."""
+    resolved = []
+    for feed in FEEDS:
+        path = pathlib.Path(root) / feed["file"]
+        if not path.exists():
+            problems.append(f"DRIFT {feed['name']}: {feed['file']} does not exist")
+            continue
+        doc = yaml.safe_load(path.read_text(encoding="utf-8")) or {}
+        raw = resolve_yaml_path(doc, feed["yaml_path"])
+        if raw is None:
+            problems.append(
+                f"DRIFT {feed['name']}: `{feed['yaml_path']}` no longer resolves in {feed['file']} "
+                f"— the probe would test nothing",
+            )
+            continue
+        url = strip_config_default(raw)
+        if is_internal(url):
+            problems.append(f"DRIFT {feed['name']}: `{feed['yaml_path']}` is not an external URL: {url}")
+            continue
+        resolved.append({**feed, "url": url})
+    return resolved
+
+
+def check_drift(root, resolved):
+    """Every external URL in every scanned YAML is declared, and every declaration is live."""
+    problems = []
+    probed = {f["url"] for f in resolved}
+    excused = {u for u, _ in NOT_PROBED}
+    seen_excused = set()
+
+    for path in scanned_yamls(root):
+        for lineno, url in external_urls_in(path):
+            if url in probed:
+                continue
+            match = next((e for e in excused if url.startswith(e)), None)
+            if match:
+                seen_excused.add(match)
+                continue
+            problems.append(
+                f"DRIFT undeclared external URL {path}:{lineno} -> {url}\n"
+                f"       Declare it in FEEDS (with a shape matcher) or in NOT_PROBED (with a reason).",
+            )
+
+    for url, reason in NOT_PROBED:
+        if url not in seen_excused:
+            problems.append(
+                f"DRIFT stale NOT_PROBED entry: {url} ({reason}) is no longer in any scanned YAML",
+            )
+    return problems
+
+
+def fetch(url):
+    req = urllib.request.Request(url, headers={"User-Agent": USER_AGENT})
+    with urllib.request.urlopen(req, timeout=TIMEOUT_SECONDS) as resp:  # noqa: S310 - fixed https feeds
+        return resp.status, resp.read().decode("utf-8", errors="replace")
+
+
+def check_liveness(resolved):
+    """Fetch and shape-check. Returns (dead, unreachable) — kept apart on purpose."""
+    dead, unreachable = [], []
+    for feed in resolved:
+        try:
+            status, body = fetch(feed["url"])
+        except urllib.error.HTTPError as exc:
+            dead.append(f"DEAD {feed['name']}: HTTP {exc.code} for {feed['url']}\n       {feed['why']}")
+            continue
+        except (urllib.error.URLError, OSError, TimeoutError) as exc:
+            unreachable.append(f"UNREACHABLE {feed['name']}: {exc} ({feed['url']})")
+            continue
+        if status != 200:
+            dead.append(f"DEAD {feed['name']}: HTTP {status} for {feed['url']}\n       {feed['why']}")
+            continue
+        reason = SHAPES[feed["shape"]](body)
+        if reason:
+            dead.append(
+                f"DEAD {feed['name']}: HTTP 200 but the payload is not the feed — {reason}\n"
+                f"       {feed['url']}\n       {feed['why']}",
+            )
+        else:
+            print(f"OK   {feed['name']}: {feed['url']}")
+    return dead, unreachable
+
+
+CNB_GOOD = "31.07.2026 #146\nzemě|měna|množství|kód|kurz\nEMU|euro|1|EUR|24,915\n" + "".join(
+    f"Země{i}|měna|1|C{i:02d}|1,0{i}\n" for i in range(9)
+)
+CNB_404_HTML = '<!DOCTYPE html>\n<html lang="cs">\n<head>\n<title>Stránka nenalezena</title>\n</head>\n'
+
+
+def self_test():
+    """Exercise every matcher against a payload it MUST accept and payloads it MUST reject.
+
+    The rejection cases are the point. A shape matcher is only trustworthy if it has been shown
+    to fire — and the single most important input here is the exact HTML error page that started
+    this whole issue by being accepted as a successful fetch for 46 days.
+    """
+    cases = [
+        ("cnb_fixing accepts the real feed", shape_cnb_fixing, CNB_GOOD, True),
+        ("cnb_fixing rejects the ČNB 404 HTML page", shape_cnb_fixing, CNB_404_HTML, False),
+        ("cnb_fixing rejects an empty 200", shape_cnb_fixing, "   \n\n", False),
+        ("cnb_fixing rejects a header with no rate lines", shape_cnb_fixing, "31.07.2026 #146\n", False),
+        (
+            "cnb_fixing rejects a plausible-but-wrong header",
+            shape_cnb_fixing,
+            "2026-07-31 #146\nEMU|euro|1|EUR|24,915\n",
+            False,
+        ),
+        ("xml_document accepts XML", shape_xml_document, '<?xml version="1.0"?><banks><bank/></banks>', True),
+        ("xml_document rejects an HTML error page", shape_xml_document, CNB_404_HTML, False),
+        ("xml_document rejects plain text", shape_xml_document, "Not Found", False),
+    ]
+    failures = 0
+    for name, matcher, payload, should_pass in cases:
+        reason = matcher(payload)
+        ok = (reason is None) == should_pass
+        print(f"{'pass' if ok else 'FAIL'}  {name}" + ("" if ok else f"  (got {reason!r})"))
+        failures += 0 if ok else 1
+
+    # The config-default unwrapper is load-bearing: get it wrong and every probe fetches the
+    # literal string "${CNB_FEED_URL:https://…}" and fails for the wrong reason.
+    for raw, want in [
+        ("${CNB_FEED_URL:https://x.test/a.txt}", "https://x.test/a.txt"),
+        ("https://x.test/a.txt", "https://x.test/a.txt"),
+    ]:
+        got = strip_config_default(raw)
+        ok = got == want
+        print(f"{'pass' if ok else 'FAIL'}  strip_config_default({raw!r})" + ("" if ok else f" -> {got!r}"))
+        failures += 0 if ok else 1
+
+    print(f"\nself-test: {len(cases) + 2 - failures} passed, {failures} failed")
+    return 0 if failures == 0 else 3
+
+
+def main():
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--root", default=".")
+    parser.add_argument("--self-test", action="store_true", help="exercise the shape matchers and exit")
+    parser.add_argument("--offline", action="store_true", help="run the drift half only (no network)")
+    args = parser.parse_args()
+
+    if args.self_test:
+        return self_test()
+
+    if yaml is None:
+        print("::error::PyYAML is not installed — the probe could not run. This is NOT a pass.")
+        return 3
+
+    problems = []
+    resolved = load_feed_urls(args.root, problems)
+    problems += check_drift(args.root, resolved)
+
+    if problems:
+        print("\n".join(problems))
+        print(f"\n{len(problems)} drift problem(s). This half is offline and deterministic.")
+        return 1
+    print(f"drift: OK — {len(resolved)} declared feed(s), every external URL accounted for.")
+
+    if args.offline:
+        return 0
+
+    dead, unreachable = check_liveness(resolved)
+    if unreachable:
+        print("\n".join(unreachable))
+        print("\nThe probe could not reach a feed. That is NOT a verdict about the feed.")
+        return 3
+    if dead:
+        print("\n".join(dead))
+        print(f"\n{len(dead)} declared feed(s) are dead or misshapen.")
+        return 2
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1172,6 +1172,27 @@ jobs:
       - name: "EU AI Act inventory drift (ADR-0148 rule #7, enforced)"
         run: bash .github/scripts/check-eu-ai-act.sh
 
+      # External public-feed declaration drift (issue #2204).
+      #
+      # `--offline` on purpose: this is the DRIFT half only — every third-party URL in an
+      # `openbank-*/src/main/resources/application.yaml` is either declared in the watch's FEEDS
+      # (so it gets probed daily) or in NOT_PROBED with a reason. No network, deterministic, ~1 s.
+      # The liveness half lives in the `external-feed-watch` workflow and never gates a merge: a
+      # third party having a bad day must not wedge the repo.
+      #
+      # The binding copy is HERE for the reason spelled out above: `external-feed-watch` is
+      # path-filtered and therefore un-requireable, so its verdict is advisory in practice. What
+      # this step actually buys is that adding a new external dependency to a service's config
+      # cannot silently create a feed nothing ever fetches — which is exactly how the ČNB fixing
+      # URL stayed a 404 for the whole life of openbank-fx-service.
+      #
+      # Self-test first: the matchers are what separate "a server answered 200" from "the answer
+      # is the feed", and one that has only ever passed is unfalsified.
+      - name: "external feed declaration drift (issue #2204, enforced)"
+        run: |
+          python3 .github/scripts/check-external-feeds.py --self-test
+          python3 .github/scripts/check-external-feeds.py --root . --offline
+
   # ---------------------------------------------------------------------------
   # Customer-app dossier content check (ADR-0074 invariant 5).
   #

--- a/.github/workflows/external-feed-watch.yml
+++ b/.github/workflows/external-feed-watch.yml
@@ -1,0 +1,150 @@
+# -----------------------------------------------------------------------------
+# External public-feed watch (issue #2204).
+#
+# WHY THIS EXISTS
+#   `openbank-fx-service`'s ČNB fixing URL was a 404 for the whole life of the
+#   service — one path segment short — and no layer of the stack could say so. A
+#   404 is a valid HTTP response, so the rest-client succeeded, the circuit
+#   breaker stayed closed, and the scheduler's catch turned the parse failure
+#   into one ERROR line. The only evidence was a table that stopped growing.
+#
+#   No test in this repo can catch that by construction: a unit test stubs the
+#   client, an IT serves a local fixture, and a consumer pact answers whatever
+#   path it is asked for (#2283). The upstream is a foreign government feed with
+#   no pact. Fetching it is the only thing that falsifies its URL.
+#
+# TWO HALVES, DELIBERATELY DIFFERENT LANES
+#   DRIFT is a property of the committed files, needs no network, and is exact —
+#   so it runs on PRs that touch a scanned file and BLOCKS. That is what stops a
+#   newly added external dependency from becoming a feed this watch knows
+#   nothing about while still reporting green.
+#
+#   LIVENESS is a property of the internet at this moment. It never blocks a
+#   merge: a third-party outage must not wedge the repo. It escalates instead —
+#   a red scheduled run is addressed to nobody, so a dead feed posts on #2204.
+#
+# WHY IT IS NOT A REQUIRED CHECK
+#   `paths:`-filtered workflows cannot be required contexts (a required context
+#   that never reports blocks every PR touching none of its paths). The binding
+#   copy of the DRIFT half therefore belongs in `Validate manifests` in ci.yml,
+#   the same shape adr-registry and eu-ai-act use; this workflow is the fast
+#   echo plus the scheduled liveness lane.
+# -----------------------------------------------------------------------------
+name: External feed watch
+
+on:
+  schedule:
+    # 05:10 UTC daily. Daily is the right cadence: the ČNB fixing is a daily
+    # publication, so a dead feed costs at most one missed business day before
+    # this says so — against the 46 days it went unnoticed the first time.
+    - cron: "10 5 * * *"
+  pull_request:
+    paths:
+      - "openbank-*/src/main/resources/application.yaml"
+      - ".github/scripts/check-external-feeds.py"
+      - ".github/workflows/external-feed-watch.yml"
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+concurrency:
+  group: external-feed-watch-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  watch:
+    name: external-feed-watch
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    permissions:
+      contents: read
+      issues: write
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+
+      - name: Install PyYAML
+        run: python3 -m pip install --quiet pyyaml
+
+      # The shape matchers decide whether a 200 is really the feed. A matcher
+      # that has only ever returned "fine" is indistinguishable from one that
+      # always does, so it is exercised against payloads it MUST reject —
+      # including the exact ČNB HTML error page that read as success for 46
+      # days. This step failing voids every verdict below it.
+      - name: Self-test the shape matchers
+        run: python3 .github/scripts/check-external-feeds.py --self-test
+
+      # PR lane: drift only. No network, so nothing here can go red because a
+      # third party is having a bad day.
+      - name: Check declaration drift (blocking)
+        if: ${{ github.event_name == 'pull_request' }}
+        run: python3 .github/scripts/check-external-feeds.py --root . --offline
+
+      - name: Probe the declared feeds
+        id: probe
+        if: ${{ github.event_name != 'pull_request' }}
+        run: |
+          set +e
+          python3 .github/scripts/check-external-feeds.py --root . | tee /tmp/feeds.txt
+          code=${PIPESTATUS[0]}
+          set -e
+          echo "code=$code" >> "$GITHUB_OUTPUT"
+          case "$code" in
+            0) echo "Every declared feed is live and correctly shaped." ;;
+            1) echo "::error::Declaration drift on the default branch — reconcile the script with the YAMLs."
+               exit 1 ;;
+            2) echo "::warning::A declared external feed is dead or misshapen — escalating to #2204." ;;
+            *) echo "::error::The feed probe could not run. This is NOT a 'feeds are fine' verdict."
+               exit "$code" ;;
+          esac
+
+      - name: Escalate a dead feed on its issue
+        if: ${{ github.event_name != 'pull_request' && steps.probe.outputs.code == '2' }}
+        uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9.0.0
+        with:
+          script: |
+            const fs = require('fs')
+            const report = fs.readFileSync('/tmp/feeds.txt', 'utf8')
+            const MARKER = '<!-- external-feed-watch -->'
+            const issue_number = 2204
+            const body = [
+              MARKER,
+              '## External feed watch — a declared feed is dead or misshapen',
+              '',
+              'The daily probe fetched each declared third-party feed and checked its',
+              'payload shape, not just its status code. Something is not answering with',
+              'the feed:',
+              '',
+              '```',
+              report.trim(),
+              '```',
+              '',
+              'A dead feed here is silent in the service: the rest-client succeeds, the',
+              'circuit breaker stays closed, and the scheduler logs one ERROR line. Fix',
+              'the URL in the service\'s `application.yaml` (the probe reads it from',
+              'there, so the fix and the check can never disagree).',
+              '',
+              `_Automated: \`${context.workflow}\` run ${context.runId}._`,
+            ].join('\n')
+
+            let issue
+            try {
+              issue = (await github.rest.issues.get({ ...context.repo, issue_number })).data
+            } catch (e) {
+              core.setFailed(`issue #${issue_number}: ${e.message}`)
+              return
+            }
+            if (issue.state !== 'open') {
+              await github.rest.issues.update({ ...context.repo, issue_number, state: 'open' })
+            }
+            // Refresh a previous report rather than stacking one comment per day —
+            // a watch that spams its own issue trains people to filter it.
+            const comments = await github.paginate(github.rest.issues.listComments, {
+              ...context.repo, issue_number, per_page: 100,
+            })
+            const prior = comments.find(c => c.body && c.body.includes(MARKER))
+            if (prior) {
+              await github.rest.issues.updateComment({ ...context.repo, comment_id: prior.id, body })
+            } else {
+              await github.rest.issues.createComment({ ...context.repo, issue_number, body })
+            }

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -296,6 +296,23 @@ fire from *outside* it, so they stay here:
   does not match reality" — there is no judgement left to exercise, so advisory just makes the drift
   mergeable. `eu-ai-act-registry` went red twice on #2156 and the PR merged anyway, leaving the EU AI
   Act inventory omitting an AI system until it was regenerated (#2216).
+- **A third-party URL in `application.yaml` is unfalsifiable by every test layer this repo has —
+  only fetching it can be wrong out loud.** A unit test stubs the client, an IT serves a local
+  fixture, and a consumer pact answers whatever path it is asked for (the #2283 asymmetry). So
+  `openbank-fx-service`'s ČNB fixing URL was a 404 — one path segment short, `kurzy-devizoveho-trhu`
+  appears TWICE — for the entire life of the service, and every layer stayed green: a 404 IS a valid
+  HTTP response, so the rest-client succeeded and the circuit breaker never opened; ČNB serves it as
+  a 58 KB HTML page, the parser rejected that, and the scheduler's `catch` swallowed it into one
+  ERROR line. Downstream, `FxRevaluationService` found no valid rate, logged "skipping its
+  revaluation leg" and returned `posted = false` — a successful-looking run of a job that revalued
+  nothing. The only evidence anywhere was a table that stopped growing, and **nothing alerts on a
+  table not growing**. Two transferable rules. (a) **Probe the payload's SHAPE, never the status
+  code** — a 200 proves a server answered, not that the answer is the feed. (b) **The probe must
+  read the URL out of the committed config, never keep its own copy** — a second copy moves with the
+  first and keeps passing against a URL the service does not use. `check-external-feeds.py` +
+  `external-feed-watch.yml` do both (drift half enforced in `Validate manifests`, liveness half
+  daily and escalating, never merge-blocking). Its first run found a *second* dead ČNB URL,
+  customer-edge's bank registry, silently masked by an embedded fallback (#2204).
 - **The gate that never existed beats the unfalsified one: check whether anything reads the artifact
   at all before assuming a green covers it.** This repo is a MULTI-LICENSE tree — Apache-2.0 at the
   root, an AGPL-3.0-only open-core subset (ADR-0136 + ADR-0181/0193) — and *nothing* compared the

--- a/openbank-fx-service/src/main/resources/application.yaml
+++ b/openbank-fx-service/src/main/resources/application.yaml
@@ -69,7 +69,15 @@ quarkus:
     hosts: redis://localhost:6379
   rest-client:
     cnb-feed:
-      url: ${CNB_FEED_URL:https://www.cnb.cz/cs/financni-trhy/devizovy-trh/kurzy-devizoveho-trhu/kurzy/denni_kurz.txt}
+      # The path segment `kurzy-devizoveho-trhu` appears TWICE — section, then page. A single
+      # occurrence is a 404 that ČNB serves as a 58 KB HTML error page, which the parser rejects
+      # with `Unparseable ČNB fixing date header`, which `CnbRateIngestionScheduler`'s catch
+      # swallows into one ERROR line. That is exactly how the previous value shipped and how the
+      # daily fixing went un-ingested for 46 days after the #2187 Vert.x fix made the job actually
+      # run (#2204). `check-external-feeds.py` now probes this URL daily so a dead feed cannot be
+      # silent again. Verify by hand with:
+      #   curl -sSo /dev/null -w '%{http_code}\n' "<url>"     # must be 200, not 404
+      url: ${CNB_FEED_URL:https://www.cnb.cz/cs/financni-trhy/devizovy-trh/kurzy-devizoveho-trhu/kurzy-devizoveho-trhu/denni_kurz.txt}
       scope: jakarta.inject.Singleton
     sanctions-service:
       url: ${SANCTIONS_SERVICE_URL:http://localhost:8123}


### PR DESCRIPTION
## What

`openbank-fx-service`'s ČNB fixing URL was a **404** and had been for the whole life of the service. The path segment `kurzy-devizoveho-trhu` appears **twice** in ČNB's URL (section, then page); the config carried it once.

Measured from the `fx` namespace on the sandbox:

```
== 404  .../kurzy-devizoveho-trhu/kurzy/denni_kurz.txt              <- configured
== 200  .../kurzy-devizoveho-trhu/kurzy-devizoveho-trhu/denni_kurz.txt   "31.07.2026 #146"
```

`?date=DD.MM.YYYY` works on the correct URL too, so the historical backfill path in `POST /api/v1/fx/cnb/ingest` is mechanically available.

## Why nothing reported it

Every layer was green, and each for a defensible reason:

| layer | what it saw |
|---|---|
| rest-client + `@CircuitBreaker` | a 404 is a valid HTTP response — success |
| `CnbFixingParser` | rejected the 58 KB HTML error page ČNB serves |
| `CnbRateIngestionScheduler` | caught it, logged **one** ERROR line, returned |
| `FxRevaluationService` | no valid `source = CNB` rate, "skipping its revaluation leg", `posted = false` |

The last row is the one that matters: a successful-looking run of a job that revalued nothing. The only evidence anywhere was `fx_rates` not growing, and nothing alerts on a table not growing.

So #2191 made the job *run* (the #2187 `HR000068` fix — the deployed image is `sandbox-398a0433`, which **is** that commit), and it has failed silently every day since. On the sandbox the newest rate of any source is `2026-06-15` (46 days stale) and `source = CNB` has 3 rows, all seeded at the same `created_at` as the synthetic `INTERNAL` seed.

## The gate

A third-party URL in `application.yaml` is unfalsifiable by every test layer this repo has: a unit test stubs the client, an IT serves a local fixture, and a consumer pact answers whatever path it is asked for (#2283). The upstream is a foreign government feed with no pact. Fetching it is the only thing that can be wrong out loud.

`check-external-feeds.py` has two halves in **deliberately different lanes**:

- **DRIFT** — offline, deterministic, **enforced in `Validate manifests`**. Every third-party URL in an `openbank-*/src/main/resources/application.yaml` is either declared in `FEEDS` (probed) or in `NOT_PROBED` (with a reason). The declaration holds **no copy of the URL**: it names the YAML path and the probe reads the value out of the committed file, so the fix and the check cannot drift apart — the vacuity that made `ProductCatalogPactConsumerTest` unable to fail.
- **LIVENESS** — daily, fetches each feed and asserts the payload's **shape**, not its status code. Never blocks a merge; a third party having a bad day must not wedge the repo. A dead feed escalates onto #2204 (refreshing one comment, not stacking one per day).

Exit codes keep `2` (dead feed) and `3` (probe could not run) apart from `0`, because this whole issue is what happens when a broken thing's silence reads as health.

## Falsification

Not trusting a green — each half was run against a case it MUST flag:

- `--self-test`: 10/10, including `cnb_fixing` rejecting the exact ČNB 404 HTML page, an empty 200, a header with no rate lines, and a plausible-but-wrong `YYYY-MM-DD` header.
- drift, undeclared URL: added a bogus `https://…` to the fx YAML → flagged with file:line.
- drift, broken declaration: typo'd `yaml_path` → `no longer resolves … the probe would test nothing`.
- liveness, real internet: `cnb-daily-fixing` **OK**, `cnb-bank-registry` **DEAD (404)**, exit 2.

The first pass at the internal-host rule classified 15 in-cluster `http://svc.ns:port` URLs as third-party feeds; `is_internal` is now narrow and documented, and `https://` is external without exception.

## What this found on the way

**A second dead ČNB URL.** `openbank-customer-edge`'s bank registry `https://apl.cnb.cz/apljerrpp/jerr_banky.xml` is also a 404. `CnbBanksClient` falls back to an embedded `/banks.json`, so it degrades to a **frozen bank list** rather than an outage — which is exactly why nobody noticed. Declared and reported here, **not fixed**: the replacement endpoint needs deciding, not guessing. Filed separately.

## Not done here

- `rules.yaml` is untouched on purpose. Editing it restamps every service's OPA bundle (~44–65 files) and gives this PR a shelf life measured in hours; the rule is enforced in a required check either way. Say the word and it goes in a follow-up.
- The rate **backfill** (`POST /api/v1/fx/cnb/ingest?date=…` per business day) is sequenced *after* this merges and deploys — backfilling against a 404 would do nothing.

Refs #2204, #2187, #2191, #2283.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
