### PR TITLE
fix(ci): give every checkoutless gh job a repo context — four dead escalation paths

### DIFF
--- a/.github/workflows/api-contract-post-merge.yml
+++ b/.github/workflows/api-contract-post-merge.yml
@@ -105,6 +105,11 @@ jobs:
     permissions:
       contents: read
       issues: write
+    # This job has no actions/checkout, so `gh` has nothing to infer the target repo from
+    # and every subcommand dies with `failed to determine base repo: fatal: not a git
+    # repository`. Set it explicitly (same fix, same reason as record-deployment-on-merge.yml).
+    env:
+      GH_REPO: ${{ github.repository }}
     steps:
       - name: Open or refresh the tracking issue
         env:

--- a/.github/workflows/auto-deploy.yml
+++ b/.github/workflows/auto-deploy.yml
@@ -1282,11 +1282,6 @@ jobs:
     if: always() && needs.changes.outputs.any == 'true' && needs.build-push.result == 'success'
     runs-on: ubuntu-latest
     timeout-minutes: 2
-    # This job has no actions/checkout, so `gh` has nothing to infer the target repo from
-    # and every subcommand dies with `failed to determine base repo: fatal: not a git
-    # repository`. Set it explicitly (same fix, same reason as record-deployment-on-merge.yml).
-    env:
-      GH_REPO: ${{ github.repository }}
     steps:
       - name: Report undelivered deploy
         env:

--- a/.github/workflows/auto-deploy.yml
+++ b/.github/workflows/auto-deploy.yml
@@ -1282,6 +1282,11 @@ jobs:
     if: always() && needs.changes.outputs.any == 'true' && needs.build-push.result == 'success'
     runs-on: ubuntu-latest
     timeout-minutes: 2
+    # This job has no actions/checkout, so `gh` has nothing to infer the target repo from
+    # and every subcommand dies with `failed to determine base repo: fatal: not a git
+    # repository`. Set it explicitly (same fix, same reason as record-deployment-on-merge.yml).
+    env:
+      GH_REPO: ${{ github.repository }}
     steps:
       - name: Report undelivered deploy
         env:

--- a/.github/workflows/dependabot-auto-merge.yml
+++ b/.github/workflows/dependabot-auto-merge.yml
@@ -46,6 +46,11 @@ jobs:
       contents: write
       pull-requests: write
 
+    # This job has no actions/checkout, so `gh` has nothing to infer the target repo from
+    # and every subcommand dies with `failed to determine base repo: fatal: not a git
+    # repository`. Set it explicitly (same fix, same reason as record-deployment-on-merge.yml).
+    env:
+      GH_REPO: ${{ github.repository }}
     steps:
       - name: Fetch Dependabot metadata
         id: metadata

--- a/.github/workflows/dependency-submission.yml
+++ b/.github/workflows/dependency-submission.yml
@@ -196,6 +196,11 @@ jobs:
     permissions:
       contents: read
       issues: write
+    # This job has no actions/checkout, so `gh` has nothing to infer the target repo from
+    # and every subcommand dies with `failed to determine base repo: fatal: not a git
+    # repository`. Set it explicitly (same fix, same reason as record-deployment-on-merge.yml).
+    env:
+      GH_REPO: ${{ github.repository }}
     steps:
       - name: Open or refresh the tracking issue
         env:


### PR DESCRIPTION
Follow-up to #2898. That PR fixed one instance; sweeping the rest of `.github/workflows` found **four more, none of which has ever executed**.

## The bug

A job with no `actions/checkout` gives `gh` nothing to infer the target repo from, so every subcommand dies:

```
failed to determine base repo: failed to run git: fatal: not a git repository
```

| workflow | job | calls |
|---|---|---|
| `api-contract-post-merge.yml` | `raise-issue` | `gh issue list` / `create` / `comment` |
| `auto-deploy.yml` | `deploy-signal` | `gh workflow run` |
| `dependabot-auto-merge.yml` | `auto-merge` | `gh pr merge` |
| `dependency-submission.yml` | `raise-issue` | `gh issue list` / `create` / `comment` |

Every one is an escalation or automation path — the code that runs when something has *already* gone wrong. That is why the breakage stayed invisible: these jobs almost never execute, and when they don't execute they don't fail.

## The sharpest one

`dependency-submission.yml`'s `raise-issue` is the **#1449 alarm** — the mechanism this repo points at as the answer to *"a red push-triggered workflow on main is addressed to nobody"*.

It has never fired: no non-PR submission failure in the last 60 runs. So its own breakage was invisible by the same mechanism it exists to defeat. Had the 2026-07-14 three-day `Java heap space` outage happened *after* the alarm was added, it would have failed to raise the issue and the outage would have stayed exactly as quiet.

## Verified, not assumed — in both directions

- `gh issue list`, `gh issue create` and `gh run rerun` were each run from a non-git directory: all fail with the message above; with the repo supplied they reach the API (`HTTP 404` on a bogus id, i.e. resolution worked).
- **The sweep initially flagged five.** `record-deployment-on-merge.yml` already sets `GH_REPO`, so it is fine — and checking for `GH_REPO` as well as `-R` is the only reason it isn't in this diff. Its comment is also where the fix pattern and its rationale come from: *"every run silently records zero services … Pass the repo explicitly so it works API-only."* Someone hit this once and fixed it in one place.
- None of the four has ever run: every occurrence across recent runs is `skipped`, or the job is absent from the run entirely. So there is no counter-evidence that any of them somehow works.

## Choice of fix

Job-level `GH_REPO: ${{ github.repository }}` rather than `-R` on each call — matches the existing precedent in `record-deployment-on-merge.yml` and covers any `gh` call added to these jobs later. #2898's per-call `-R` is equivalent and left alone rather than churned.

## Note on actionlint

`auto-deploy.yml` produces a warning that `openbank-build` is an unknown runner label. **Pre-existing** — 2 occurrences on `main`, 2 on this branch, and no other findings. Not introduced here.

## Verification

- `actionlint` — clean on all four (modulo the pre-existing label warning above)
- `yamllint` under the exact config `ci.yml` builds — clean on branch and on `origin/main`'s copy for all four
- each job re-parsed after editing to confirm `GH_REPO` landed on the job and the step count is unchanged

## Worth doing next, not done here

Nothing stops this recurring. A guard over `.github/workflows` — *a job that invokes `gh` and has no `actions/checkout` must set `GH_REPO` or pass `-R`* — is mechanically checkable and would have caught all five instances at PR time. I'd rather propose it than bundle it: it needs its own falsification pass, including feeding it the `record-deployment-on-merge.yml` shape it must NOT flag.

Refs #2841, #1449
