### PR TITLE
fix(campaign): send ClickHouse query parameters the only way ClickHouse accepts them

### DIFF
--- a/openbank-campaign-service/src/main/kotlin/com/openbank/campaign/infrastructure/segment/SilverSegmentEvaluator.kt
+++ b/openbank-campaign-service/src/main/kotlin/com/openbank/campaign/infrastructure/segment/SilverSegmentEvaluator.kt
@@ -10,9 +10,11 @@ import jakarta.enterprise.context.ApplicationScoped
 import org.eclipse.microprofile.config.inject.ConfigProperty
 import org.jboss.logging.Logger
 import java.net.URI
+import java.net.URLEncoder
 import java.net.http.HttpClient
 import java.net.http.HttpRequest
 import java.net.http.HttpResponse
+import java.nio.charset.StandardCharsets
 import java.util.UUID
 
 /**
@@ -44,29 +46,36 @@ class SilverSegmentEvaluator(
             append(" WHERE ").append(where)
             append(" FORMAT JSONEachRow")
         }
-        val requestBuilder = HttpRequest.newBuilder(URI.create(clickHouseUrl))
+        // Bind values travel as `?param_<name>=` on the URL — ClickHouse's only supported form for
+        // query parameters over HTTP. They used to be sent as `X-ClickHouse-Parameter-<name>`
+        // headers, which ClickHouse ignores entirely, so every evaluation died with
+        // `Code: 456 ... Substitution 'p0_status' is not set` (#2749). Still parameters, not
+        // interpolation: the values are URL-encoded here and substituted by ClickHouse, so a rule
+        // value cannot become SQL.
+        val query = params.entries.joinToString("&") { (k, v) ->
+            "param_$k=" + URLEncoder.encode(v.toString(), StandardCharsets.UTF_8)
+        }
+        val uri = URI.create(if (query.isEmpty()) clickHouseUrl else "$clickHouseUrl?$query")
+        val requestBuilder = HttpRequest.newBuilder(uri)
             .POST(HttpRequest.BodyPublishers.ofString(sql))
             .header("Content-Type", "text/plain")
         if (clickHouseUser.isNotBlank()) requestBuilder.header("X-ClickHouse-User", clickHouseUser)
         if (clickHousePassword.isNotBlank()) requestBuilder.header("X-ClickHouse-Key", clickHousePassword)
-        params.forEach { (k, v) -> requestBuilder.header("X-ClickHouse-Parameter-$k", v.toString()) }
 
         val response = http.send(requestBuilder.build(), HttpResponse.BodyHandlers.ofString())
         if (response.statusCode() != HTTP_OK) {
             log.errorf("ClickHouse segment evaluation failed (%d): %s", response.statusCode(), response.body())
-            // A REJECTED QUERY IS A BUG, NOT AN EMPTY COHORT. ClickHouse answers 4xx for SQL it
-            // cannot execute; returning emptyList() there reports "nobody matched" for a query that
-            // never ran, which is exactly how a DSL naming non-existent columns survived to
-            // production (#2891). Surface it so enrol() fails loudly instead.
-            if (response.statusCode() in HTTP_CLIENT_ERROR_RANGE) {
-                throw IllegalStateException(
-                    "segment ${segment.name}@${segment.version} could not be evaluated: " +
-                        "ClickHouse rejected the query (${response.statusCode()}) — ${response.body().trim()}",
-                )
-            }
-            // Fail closed only for an unavailable analytics layer (5xx): an outage means an empty
-            // cohort, never a guessed one.
-            return emptyList()
+            // ANY non-200 throws. An earlier version of this only threw on 4xx, reasoning that a
+            // rejected query is a bug while a 5xx is an outage worth failing closed on. That split
+            // does not survive contact with ClickHouse: it answers **500** for SQL it cannot
+            // execute, so the exact defect the split existed to surface — an unbound parameter,
+            // `Code: 456 ... Substitution is not set` — came back as 5xx and was swallowed into an
+            // empty cohort anyway. "Nobody matched" and "the query never ran" must not look alike,
+            // and no status-code split can tell them apart here.
+            throw IllegalStateException(
+                "segment ${segment.name}@${segment.version} could not be evaluated: " +
+                    "ClickHouse returned ${response.statusCode()} — ${response.body().trim()}",
+            )
         }
         return response.body().lineSequence()
             .filter { it.isNotBlank() }
@@ -80,7 +89,6 @@ class SilverSegmentEvaluator(
 
     companion object {
         private const val HTTP_OK = 200
-        private val HTTP_CLIENT_ERROR_RANGE = 400..499
         private val AGGREGATE_ID = Regex("\"aggregate_id\"\\s*:\\s*\"([0-9a-fA-F-]{36})\"")
     }
 }


### PR DESCRIPTION
## Symptom

The smoke campaign reached `ACTIVE`, and `enrol` answered `{"enrolled":0}` for a segment whose rule
matches two parties. The API said 200; the service log said otherwise:

```
ClickHouse segment evaluation failed (500): Code: 456.
DB::Exception: Substitution `p0_status` is not set. (UNKNOWN_QUERY_PARAMETER)
```

## Cause

Bind values were sent as `X-ClickHouse-Parameter-<name>` request headers. ClickHouse has no such
header. Query parameters arrive as `?param_<name>=` on the URL; anything else is ignored, leaving
`{p0_status:String}` unbound.

Measured side by side against the sandbox, same SQL, same credentials:

| Parameter transport | Result |
|---------------------|--------|
| `X-ClickHouse-Parameter-p0_status` header | **500**, `Code: 456 ... Substitution is not set` |
| `?param_p0_status=ACTIVE` | **200**, 2 rows |

Values are URL-encoded and still substituted by ClickHouse, so this remains parameterised — a rule
value cannot become SQL.

## This also corrects my own #2896

That PR made the evaluator throw on 4xx and keep failing closed on 5xx, on the reasoning that a
rejected query is a bug while a 5xx is an outage where an empty cohort is the safe answer. Its
description said this would stop a broken query from looking like an empty cohort.

It does not, because **ClickHouse answers 500 for SQL it cannot execute**. This unbound-parameter
error is a 500, so it landed on the silent path and became `enrolled: 0` — precisely the failure mode
#2896 claimed to have closed. I only found out because I compared the two transports by hand rather
than trusting the 200 the API returned.

Any non-200 now throws. There is no status-code split that separates "the query never ran" from "the
analytics layer is down" here, and of the two ways to be wrong, failing loudly is the one that gets
noticed.

## Verification

- Both transports executed against the sandbox ClickHouse; the table above is measured output.
- Full gate green: `detekt ktlintCheck koverVerify build`.
- The end-to-end proof is still pending deploy — this PR is what unblocks `enrolled >= 1` in #2749.

Refs #2749, #2891