### PR TITLE
ci(governance): gate that a checkoutless gh job declares its repo

### DIFF
--- a/.github/scripts/check-gh-repo-context.py
+++ b/.github/scripts/check-gh-repo-context.py
@@ -1,0 +1,289 @@
+#!/usr/bin/env python3
+# SPDX-License-Identifier: Apache-2.0
+# Copyright (c) OpenBank contributors. Licensed under the Apache License, Version 2.0.
+# See LICENSE in the repository root or https://www.apache.org/licenses/LICENSE-2.0 for details.
+"""A workflow job that calls `gh` without a checkout must be told which repo it means.
+
+WHY THIS EXISTS
+`gh` infers the target repository from the git remote of the working directory. A job with
+no `actions/checkout` has no working copy, so every subcommand dies with:
+
+    failed to determine base repo: failed to run git: fatal: not a git repository
+
+That is a one-line failure with an enormous blast radius, because the jobs shaped like this
+are almost always ESCALATION paths — the code that runs only when something has already gone
+wrong. They rarely execute, so they rarely fail, so nobody learns they are broken.
+
+Measured 2026-07-31: four such jobs existed. Three had NEVER executed
+(`api-contract-post-merge.yml:raise-issue`, `dependabot-auto-merge.yml:auto-merge`,
+`dependency-submission.yml:raise-issue`), and the fourth — `auto-retry-cancelled.yml` — had
+executed repeatedly and failed every single time since the day it was written, so the
+spot-kill auto-retry from #2330 had never once re-run anything (#2898). The sharpest is the
+#1449 alarm itself: the mechanism this repo points at as the answer to "a red push-triggered
+workflow is addressed to nobody" could not have raised its issue.
+
+(A fifth, `auto-deploy.yml:deploy-signal`, was flagged by the first draft of this guard and
+is NOT broken — it only quotes `gh workflow run` inside a notice body. See strip_noncode.)
+
+WHAT COUNTS AS SATISFIED
+Either is fine, and both are in use here:
+  * `GH_REPO` in the workflow env, the job env, or the step env  (record-deployment-on-merge)
+  * `-R` / `--repo` on every flagged invocation                  (auto-retry-cancelled)
+
+WHAT IS FLAGGED
+`gh <subcommand>` for subcommands that resolve a repository: issue, pr, run, release,
+workflow, label, repo, api. `gh api` is flagged ONLY when the path uses gh's `{owner}` /
+`{repo}` placeholders — `gh api repos/OWNER/NAME/...` with a literal path needs no resolution
+and is deliberately not flagged, because that form is common and correct here.
+
+Shell comments are stripped before matching, so a line explaining `gh issue create` does not
+trip the guard. That is the code-about-code rule this repo learned the hard way (#2450).
+
+Usage:
+    python3 .github/scripts/check-gh-repo-context.py            # check .github/workflows
+    python3 .github/scripts/check-gh-repo-context.py --self-test
+"""
+from __future__ import annotations
+
+import re
+import sys
+from pathlib import Path
+
+try:
+    import yaml
+except ImportError:  # pragma: no cover
+    print("PyYAML is required", file=sys.stderr)
+    raise SystemExit(2)
+
+WORKFLOWS = Path(".github/workflows")
+
+# Subcommands that need gh to know which repo it is talking about.
+RESOLVING = ("issue", "pr", "run", "release", "workflow", "label", "repo")
+_GH_SUB = re.compile(r"(?<![\w/-])gh\s+(" + "|".join(RESOLVING) + r")\b")
+_GH_API_PLACEHOLDER = re.compile(r"(?<![\w/-])gh\s+api\b[^\n]*\{(?:owner|repo)\}")
+_HAS_REPO_FLAG = re.compile(r"\s(?:-R|--repo)[\s=]")
+
+
+_ESCAPED_SPAN = re.compile(r"\\`[^`]*\\`")
+
+
+def strip_noncode(script: str) -> str:
+    """Remove text that mentions gh without running it.
+
+    Two forms, both real and both found while building this guard:
+
+    * whole-line shell comments — only lines whose first non-space character is `#`, so a
+      `#` inside a URL or a string is left alone (the code-about-code rule from #2450);
+    * markdown code spans written with ESCAPED backticks, `\\`gh workflow run ...\\``. Inside a
+      double-quoted shell string an escaped backtick is a literal character, never command
+      substitution, so this is unambiguously prose. `auto-deploy.yml`'s `deploy-signal` job
+      builds a notice body containing exactly that and has no gh call at all — the first draft
+      of this guard flagged it, and the PR it shipped alongside briefly claimed that job was
+      broken. Un-escaped backticks are NOT stripped: those ARE command substitution.
+    """
+    lines = []
+    for line in script.split("\n"):
+        if line.lstrip().startswith("#"):
+            continue
+        lines.append(_ESCAPED_SPAN.sub("", line))
+    return "\n".join(lines)
+
+
+def offending_lines(script: str) -> list[str]:
+    """Lines invoking a repo-resolving gh subcommand without -R/--repo."""
+    out = []
+    for line in strip_noncode(script).split("\n"):
+        if not (_GH_SUB.search(line) or _GH_API_PLACEHOLDER.search(line)):
+            continue
+        if _HAS_REPO_FLAG.search(line):
+            continue
+        out.append(line.strip())
+    return out
+
+
+def check_workflow(path: Path, text: str) -> list[str]:
+    try:
+        doc = yaml.safe_load(text)
+    except yaml.YAMLError as exc:
+        return [f"{path}: unparseable YAML ({exc.__class__.__name__})"]
+    if not isinstance(doc, dict) or not isinstance(doc.get("jobs"), dict):
+        return []
+
+    wf_env = doc.get("env") or {}
+    findings = []
+    for job_name, job in doc["jobs"].items():
+        if not isinstance(job, dict):
+            continue
+        steps = job.get("steps") or []
+        if not isinstance(steps, list):
+            continue
+        if any(
+            isinstance(s, dict) and "actions/checkout" in str(s.get("uses", ""))
+            for s in steps
+        ):
+            continue  # has a working copy; gh can infer the repo
+
+        job_env = job.get("env") or {}
+        for step in steps:
+            if not isinstance(step, dict):
+                continue
+            script = step.get("run")
+            if not isinstance(script, str):
+                continue
+            bad = offending_lines(script)
+            if not bad:
+                continue
+            step_env = step.get("env") or {}
+            if "GH_REPO" in {**wf_env, **job_env, **step_env}:
+                continue
+            step_name = step.get("name", "<unnamed step>")
+            findings.append(
+                f"{path}: job '{job_name}', step '{step_name}' calls gh with no checkout, "
+                f"no GH_REPO and no -R/--repo:\n      {bad[0]}"
+            )
+    return findings
+
+
+# --------------------------------------------------------------------------------------
+# Self-test. A guard that has only ever passed is unfalsified, so the negative cases below
+# are the point: each is a shape that MUST NOT be flagged, and every one of them is real.
+# --------------------------------------------------------------------------------------
+_MUST_FLAG = {
+    "bare gh issue, no checkout": """
+jobs:
+  raise-issue:
+    steps:
+      - name: Open issue
+        run: gh issue create --title x --body y
+""",
+    "gh api with {owner}/{repo} placeholders": """
+jobs:
+  probe:
+    steps:
+      - run: gh api repos/{owner}/{repo}/actions/runs
+""",
+    "GH_REPO on a different job does not help": """
+jobs:
+  ok:
+    env:
+      GH_REPO: a/b
+    steps:
+      - run: gh pr merge 1
+  broken:
+    steps:
+      - run: gh pr merge 2
+""",
+}
+
+_MUST_NOT_FLAG = {
+    "job has a checkout": """
+jobs:
+  build:
+    steps:
+      - uses: actions/checkout@v4
+      - run: gh pr merge 1
+""",
+    "GH_REPO in job env (record-deployment-on-merge shape)": """
+jobs:
+  record:
+    env:
+      GH_REPO: ${{ github.repository }}
+    steps:
+      - run: gh pr diff 1
+""",
+    "GH_REPO in step env": """
+jobs:
+  j:
+    steps:
+      - env:
+          GH_REPO: ${{ github.repository }}
+        run: gh issue list
+""",
+    "-R on the call (auto-retry-cancelled shape)": """
+jobs:
+  retry:
+    steps:
+      - run: gh run rerun -R "${GITHUB_REPOSITORY}" "${RUN_ID}" --failed
+""",
+    "gh api with a literal repos/ path needs no resolution": """
+jobs:
+  j:
+    steps:
+      - run: gh api repos/JiRaska/open-bank-oss/actions/runs --jq '.total_count'
+""",
+    "a comment mentioning gh issue create is not code": """
+jobs:
+  j:
+    steps:
+      - run: |
+          # gh issue create would need a repo here
+          echo hello
+""",
+    "no gh at all": """
+jobs:
+  j:
+    steps:
+      - run: echo hello
+""",
+    "escaped-backtick prose in a heredoc (auto-deploy deploy-signal shape)": r"""
+jobs:
+  deploy-signal:
+    steps:
+      - run: |
+          printf '%s\n' \
+            "re-dispatch to recover (\`gh workflow run auto-deploy.yml -f services=<svc>\`), or" \
+            "wait for the reconcile tick"
+""",
+}
+
+
+def self_test() -> int:
+    failures = 0
+    for label, text in _MUST_FLAG.items():
+        if not check_workflow(Path("<test>"), text):
+            print(f"SELF-TEST FAIL: should have flagged — {label}")
+            failures += 1
+    for label, text in _MUST_NOT_FLAG.items():
+        found = check_workflow(Path("<test>"), text)
+        if found:
+            print(f"SELF-TEST FAIL: false positive — {label}\n  {found[0]}")
+            failures += 1
+    total = len(_MUST_FLAG) + len(_MUST_NOT_FLAG)
+    if failures:
+        print(f"self-test: {failures} of {total} cases failed")
+        return 1
+    print(f"self-test: {total}/{total} cases pass "
+          f"({len(_MUST_FLAG)} must-flag, {len(_MUST_NOT_FLAG)} must-not-flag)")
+    return 0
+
+
+def main() -> int:
+    if "--self-test" in sys.argv:
+        return self_test()
+
+    if not WORKFLOWS.is_dir():
+        print(f"{WORKFLOWS} not found — run from the repository root", file=sys.stderr)
+        return 2
+
+    findings = []
+    files = sorted(WORKFLOWS.glob("*.yml")) + sorted(WORKFLOWS.glob("*.yaml"))
+    for path in files:
+        findings.extend(check_workflow(path, path.read_text(encoding="utf-8")))
+
+    if findings:
+        print("gh invocations with no repo context:\n")
+        for f in findings:
+            print(f"  - {f}")
+        print(
+            "\nA job with no actions/checkout cannot infer the repo, so gh exits 1 with\n"
+            "'failed to determine base repo'. Set GH_REPO: ${{ github.repository }} on the\n"
+            "job, or pass -R to the call. See .github/scripts/check-gh-repo-context.py."
+        )
+        return 1
+
+    print(f"gh repo context: OK ({len(files)} workflows checked)")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/.github/workflows/api-contract-post-merge.yml
+++ b/.github/workflows/api-contract-post-merge.yml
@@ -105,6 +105,11 @@ jobs:
     permissions:
       contents: read
       issues: write
+    # This job has no actions/checkout, so `gh` has nothing to infer the target repo from
+    # and every subcommand dies with `failed to determine base repo: fatal: not a git
+    # repository`. Set it explicitly (same fix, same reason as record-deployment-on-merge.yml).
+    env:
+      GH_REPO: ${{ github.repository }}
     steps:
       - name: Open or refresh the tracking issue
         env:

--- a/.github/workflows/auto-deploy.yml
+++ b/.github/workflows/auto-deploy.yml
@@ -1282,11 +1282,6 @@ jobs:
     if: always() && needs.changes.outputs.any == 'true' && needs.build-push.result == 'success'
     runs-on: ubuntu-latest
     timeout-minutes: 2
-    # This job has no actions/checkout, so `gh` has nothing to infer the target repo from
-    # and every subcommand dies with `failed to determine base repo: fatal: not a git
-    # repository`. Set it explicitly (same fix, same reason as record-deployment-on-merge.yml).
-    env:
-      GH_REPO: ${{ github.repository }}
     steps:
       - name: Report undelivered deploy
         env:

--- a/.github/workflows/auto-deploy.yml
+++ b/.github/workflows/auto-deploy.yml
@@ -1282,6 +1282,11 @@ jobs:
     if: always() && needs.changes.outputs.any == 'true' && needs.build-push.result == 'success'
     runs-on: ubuntu-latest
     timeout-minutes: 2
+    # This job has no actions/checkout, so `gh` has nothing to infer the target repo from
+    # and every subcommand dies with `failed to determine base repo: fatal: not a git
+    # repository`. Set it explicitly (same fix, same reason as record-deployment-on-merge.yml).
+    env:
+      GH_REPO: ${{ github.repository }}
     steps:
       - name: Report undelivered deploy
         env:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -423,6 +423,21 @@ jobs:
       - name: "License header consistency (issue #2280, enforced)"
         run: python3 .github/scripts/check-license-headers.py
 
+      # issue #2841 / #1449. `gh` infers the target repo from the working directory's git
+      # remote, so a job with no actions/checkout dies on every subcommand with
+      # "failed to determine base repo". The jobs shaped that way here are escalation paths —
+      # they run only when something has already broken — so they almost never execute, and a
+      # path that never executes never reveals that it cannot. Measured 2026-07-31: four such
+      # jobs, three of which had NEVER run, and the fourth (auto-retry-cancelled) had failed on
+      # this exact line every time since it was written, so the #2330 spot-kill retry had never
+      # re-run anything. One of the three was the #1449 alarm itself.
+      # Its --self-test carries the false positive that the first draft produced (prose in an
+      # escaped-backtick code span) as a must-NOT-flag case, alongside the must-flag ones.
+      - name: "gh repo context self-test (issue #2841)"
+        run: python3 .github/scripts/check-gh-repo-context.py --self-test
+      - name: "gh repo context in checkoutless jobs (issue #2841, enforced)"
+        run: python3 .github/scripts/check-gh-repo-context.py
+
 
       # issue #2255. docs/runbooks/svc-*.md are GENERATED from governance.yaml + the gitops
       # manifests, and nothing checked them, so 25 of 30 had silently gone stale: they told

--- a/.github/workflows/dependabot-auto-merge.yml
+++ b/.github/workflows/dependabot-auto-merge.yml
@@ -46,6 +46,11 @@ jobs:
       contents: write
       pull-requests: write
 
+    # This job has no actions/checkout, so `gh` has nothing to infer the target repo from
+    # and every subcommand dies with `failed to determine base repo: fatal: not a git
+    # repository`. Set it explicitly (same fix, same reason as record-deployment-on-merge.yml).
+    env:
+      GH_REPO: ${{ github.repository }}
     steps:
       - name: Fetch Dependabot metadata
         id: metadata

--- a/.github/workflows/dependency-submission.yml
+++ b/.github/workflows/dependency-submission.yml
@@ -196,6 +196,11 @@ jobs:
     permissions:
       contents: read
       issues: write
+    # This job has no actions/checkout, so `gh` has nothing to infer the target repo from
+    # and every subcommand dies with `failed to determine base repo: fatal: not a git
+    # repository`. Set it explicitly (same fix, same reason as record-deployment-on-merge.yml).
+    env:
+      GH_REPO: ${{ github.repository }}
     steps:
       - name: Open or refresh the tracking issue
         env:


### PR DESCRIPTION
**Stacked on #2919** — includes its commits so the guard is green. Merge #2919 first; the shared commits drop out of this diff as it lands.

Encodes the rule #2919 fixed by hand, so it cannot come back.

## The rule

`gh` infers the target repo from the working directory's git remote. A job with no `actions/checkout` dies on every subcommand with `failed to determine base repo`. Satisfied by either:

- `GH_REPO` in workflow / job / step env — the `record-deployment-on-merge.yml` pattern
- `-R` / `--repo` on the call — the `auto-retry-cancelled.yml` pattern (#2898)

Both are already in use, so this ratifies existing practice rather than inventing a convention.

`gh api` is flagged **only** when the path uses gh's `{owner}`/`{repo}` placeholders. A literal `repos/OWNER/NAME/...` path needs no resolution and is common here.

## Why a guard rather than just the fix

The shape hides unusually well. These jobs are **escalation paths** — they run only when something has already broken. A path that never executes never reveals that it cannot execute.

That is precisely how the **#1449 alarm** — this repo's own answer to *"a red push-triggered workflow is addressed to nobody"* — sat unable to raise its issue, undetected, for its entire life.

## Falsification — the part that matters

**1. Self-test**: 3 must-flag + 8 must-not-flag cases, wired as its own CI step per the `check-license-headers` convention.

```
self-test: 11/11 cases pass (3 must-flag, 8 must-not-flag)
```

**2. Run against `origin/main` before the parent's fixes** — it reports exactly the three genuinely broken jobs:

```
- api-contract-post-merge.yml   job 'raise-issue'
- dependabot-auto-merge.yml     job 'auto-merge'
- dependency-submission.yml     job 'raise-issue'
```

Against this branch: `gh repo context: OK (51 workflows checked)`. So it detects the real defect, not merely its own fixtures.

**3. It produced a false positive and that is now a test case.** The first draft flagged `auto-deploy.yml:deploy-signal`, and I initially believed it — #2919 originally "fixed" that job too. It has no `gh` call at all; the match was prose inside the notice body it builds:

```
"re-dispatch to recover (\`gh workflow run auto-deploy.yml -f services=<svc>\`), or" \
```

An escaped-backtick markdown code span inside a double-quoted string — unambiguously text, since `\`` in a double-quoted shell string is a literal character and never command substitution. `strip_noncode` now removes those spans, the shape is a must-not-flag case, and **a commit on the parent branch reverts the unnecessary edit**.

Worth being explicit about why I reverted rather than left it: setting `GH_REPO` on that job would have been harmless. That is exactly what makes it worth removing — a workflow carrying an env var "because a check said so" is how a false positive becomes permanent undocumented cargo.

Whole-line shell comments are stripped for the same reason (#2450): a comment explaining a `gh` command must not trip a guard over source text.

## Placement

Registered in the unconditional `Validate manifests` job (`ci.yml`, job `validate`), not a new paths-filtered workflow — a path-filtered workflow can never be a required status check, so its red would be advisory.

## Verification

- `actionlint` — clean; the one `SC2086` it reports on `ci.yml` is pre-existing (1 occurrence on `main`, 1 here)
- `yamllint` under the exact config `ci.yml` builds — exit 0 on the branch (3 pre-existing `comments` warnings, non-failing)
- confirmed by parsing that both steps landed in the job whose `name` is literally `Validate manifests`

## Known limits, stated rather than discovered later

- Comment stripping is whole-line only, so a `gh` call appended after code on a line with a trailing comment is still matched. Conservative in the safe direction.
- Only `run:` steps are inspected. A composite action that shells out to `gh` is invisible to this guard.
- Detection is per-line, so a `gh` call split across a line continuation with `-R` on the next line would be flagged. No such call exists today; it would be a trivially-fixed false positive rather than a miss.

Refs #2841, #1449
