### PR TITLE
fix(consent): carry scopes on ConsentRevoked so a revocation can be acted on

### DIFF
--- a/openbank-consent-service/src/main/kotlin/com/openbank/consent/application/usecase/ConsentService.kt
+++ b/openbank-consent-service/src/main/kotlin/com/openbank/consent/application/usecase/ConsentService.kt
@@ -202,6 +202,7 @@ class ConsentService(
                 aggregateId = revoked.id,
                 partyId = revoked.partyId,
                 granteeId = revoked.granteeId,
+                scopes = revoked.scopes,
                 reason = command.reason,
                 occurredAt = clock.instant(),
             ),

--- a/openbank-consent-service/src/main/kotlin/com/openbank/consent/domain/event/ConsentEvents.kt
+++ b/openbank-consent-service/src/main/kotlin/com/openbank/consent/domain/event/ConsentEvents.kt
@@ -25,10 +25,18 @@ data class ConsentGranted(
     override val version = 1L
 }
 
+/**
+ * `scopes` mirrors [ConsentGranted]: a consumer deciding whether a revocation concerns it needs the
+ * same granularity it had when the consent was granted. campaign-service's ConsentEventConsumer
+ * filters on `scopes` for a `MARKETING_COMMS*` prefix (ADR-0200 D2) — without the field its filter
+ * matched nothing, so a revocation never terminated a running journey. Additive and therefore
+ * backward compatible: existing consumers ignore the new field.
+ */
 data class ConsentRevoked(
     override val aggregateId: UUID,
     val partyId: UUID,
     val granteeId: String,
+    val scopes: Set<ConsentScope>,
     val reason: String,
     override val occurredAt: Instant,
 ) : DomainEvent(occurredAt) {


### PR DESCRIPTION
## What was broken

ADR-0200 D2 — revocation terminates a running journey mid-flight — could never happen.

campaign-service's `ConsentEventConsumer` decides whether a revocation concerns it by scope:

```kotlin
val scopes = event.path("scopes").map { it.asText() }
if (scopes.none { it.startsWith("MARKETING_COMMS") }) return
```

`ConsentRevoked` carried `aggregateId`, `partyId`, `granteeId`, `reason`, `occurredAt` — **no
scopes**. On a missing field `path()` returns a `MissingNode`, the list comes out empty, and
`none {}` over an empty list is `true`. The consumer returned before signalling anything, every time.

## Confirmed on the wire

Not inferred from the types. The outbox payload is the domain event serialised flat plus the
envelope, and a real `ConsentGranted` row in the sandbox reads:

```json
{"aggregateId":"3c46be96-…","partyId":"026289e3-…","granteeId":"party-service:marketing-comms",
 "granteeType":"INTERNAL_SERVICE","scopes":["MARKETING_COMMS_EMAIL"],…,"eventType":"ConsentGranted"}
```

`scopes` is there because `ConsentGranted` declares it. `ConsentRevoked` declares none, so none is
published. (No revocation row exists in that outbox to show directly — nobody has ever successfully
revoked a consent in this environment, which is its own finding: see #2911.)

## Why add the field rather than re-filter in campaign

Filtering on `granteeId == "party-service:marketing-comms"` would also work today, since ADR-0205 D3
fixes that grantee. I did not do that because the consumer genuinely wants **scope** granularity —
that is the question it is asking — and any other consumer of a revocation needs the same information
the grant carried. Narrowing the consumer to a grantee constant would make it right by coincidence.

Additive and backward compatible: existing consumers ignore the new field, and the event `version`
stays 1.

## Verification

- `detekt ktlintCheck test` green on consent-service.
- The end-to-end proof is still outstanding and needs two other fixes deployed first (#2916 to make
  M2M revoke reachable at all, #2921 to make enrolment non-empty). I have not yet observed a journey
  terminate; this PR removes one of the three reasons it currently cannot.

Refs #2749, ADR-0200, ADR-0198