### PR TITLE
docs: make --body-file unconditional, because knowing the rule did not work

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -439,13 +439,20 @@ Rationale + what does *not* cover it: `rules.yaml: dependencies.pr_time_cve_gate
   regressions.
 
 ### gh CLI
-- **Never pass a PR/issue body containing backticks via `--body` from zsh — use `--body-file`.**
-  Backticks inside a double-quoted string are command substitution, so zsh *executes* the
-  contents and silently drops them from the text. On #2890 the phrase
-  `` `steps.deps.outputs.changed == 'true'` `` was run as a command and the rendered body read
-  "PRs ()" — valid markdown, no error, nothing in the `gh` output to notice. The failure is
-  invisible unless you re-read the published body. Same trap for `--comment` and `gh release
-  create --notes`. Write the body to a file and pass the path.
+- **Always write a PR/issue body to a file and pass `--body-file`. Never `--body` with an
+  inline string.** Not "when it contains backticks" — *always*, because you decide the flag
+  before you know what the final text will contain. Backticks in a double-quoted string are
+  command substitution, so zsh *executes* them and silently drops them from the text: on #2890
+  `` `steps.deps.outputs.changed == 'true'` `` was run as a command and the published body read
+  "PRs ()" — valid markdown, no error, nothing in `gh`'s output to notice. The failure is
+  invisible unless you re-read the *published* body, which nobody does.
+  This bullet was written after the first occurrence and the same mistake happened **twice more
+  the same day** (#2919's correction comment lost a clause to `command not found:
+  auto-deploy.yml`). Knowing the rule does not help, because the moment of choice is when the
+  text is still an idea. Only the unconditional habit does. Same trap for `--comment`,
+  `gh release create --notes` and `-f body=`; for an edit, `-F body=@file`.
+  If you did use `--body`, re-read what was published (`gh pr view <n> --json body`) — grep it
+  for `()` and for the phrases you meant to include.
 - **`gh` needs a repo context: outside a checkout it fails with `failed to run git: fatal: not
   a git repository`,** which reads like a content or permissions problem rather than a cwd one.
   Pass `-R <owner>/<repo>` explicitly in any script whose working directory is not guaranteed —


### PR DESCRIPTION
Rewrites the `--body-file` bullet in `CLAUDE.md` from a conditional rule into an unconditional one, because the conditional version demonstrably does not work.

## Why

The bullet said *"never pass a body **containing backticks** via `--body`"*. That framing is evaluated at the wrong moment: you choose the flag before you know what the final text will contain.

The evidence is the bullet's own history. It was written on 2026-07-31 in #2894, after the first occurrence — #2890, where the published body rendered as `**Armed only on dependency-touching PRs** ()` because zsh executed the backticked expression and dropped it. The same mistake then happened **twice more the same day**, most recently on #2919, where a correction comment lost a clause to `command not found: auto-deploy.yml`.

The author of the rule broke it, hours after writing it, having just read it. That is not a knowledge problem, so a better-explained conditional would not fix it.

## What changed

- The rule is now **always write the body to a file** — no condition to evaluate.
- Names the other affected flags: `--comment`, `gh release create --notes`, `-f body=`, and `-F body=@file` for edits.
- Adds the recovery step, which matters because the failure is silent: re-read the **published** body (`gh pr view <n> --json body`) and grep it for `()` and for the phrases you meant to include. There is no error, no exit code, and valid markdown either way.

## Verification

- markdown fences balanced (4, even)
- section order unchanged: `Reviewing a diff` → `gh CLI` → `API contract (ADR-0048)`
- the neighbouring `gh` repo-context bullet is untouched
- this PR body was written to a file and passed with `--body-file`

## Release impact

None — `docs` is a hidden type and `CLAUDE.md` is not under any released package path.

Refs #2890, #2919
