### PR TITLE
docs: a job log contains the step's own script, so grepping it matches dead strings

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -356,6 +356,18 @@ fire from *outside* it, so they stay here:
   script against a fixture that had been re-run by hand: it reported "no spot-kill signature"
   for a run whose attempt 1 was unambiguously spot-killed. If the job's `if:` already pins
   `run_attempt`, pin the query to match.
+- **A job log CONTAINS the step's own `run:` script, so grepping it matches strings that never
+  executed.** GitHub prints the script into the log header, which means every `echo "…"` in it
+  appears whether or not that branch ran — a naive `grep 'treating it as a real failure'` reports
+  a hit on *every* run of the step, forever. Read only the output after the **LAST**
+  `##[endgroup]` (there are several; the last one closes the `Run …` block):
+  `awk '/##\[endgroup\]/{n=NR} {a[NR]=$0} END{for(i=n+1;i<=NR;i++) print a[i]}'`.
+  Validated on a real pair: the naive grep reports 1 hit on a run where the clean pipeline
+  reports 0, and the 0 is right. Cost two wrong conclusions on 2026-07-31, the second from a
+  monitor built minutes after diagnosing the first — the fix is easy, noticing is not, because
+  a false positive here looks exactly like the success you were hoping for. Prefer structured
+  data outright where it exists: step conclusions from
+  `gh api .../actions/jobs/<id> --jq '.steps[]'` cannot be spoofed by the script listing.
 - **Test the script EXTRACTED from the workflow, not a retyped copy of it.** A transcription is
   a different program: the first harness for #2890 used `[ … ] && { … }` where the real step
   used `if` blocks, and under `set -e` those differ on exactly the passing case. Parse the YAML


### PR DESCRIPTION
Companion to #2927. Same family of trap — a verification step that reports success because it cannot express the failure.

## The trap

GitHub prints the step's own `run:` script into the log header. So every `echo "…"` in a step appears in its log **whether or not that branch executed**. A naive grep for one of those strings reports a hit on *every* run of the step, permanently.

It is worse than an ordinary false positive because the hit looks exactly like the outcome you were hoping to see. On 2026-07-31 it produced two wrong conclusions:

1. A manual check reported that the spot-kill guard had "correctly declined to retry a real failure" — the run had actually died on a missing `-R` and never reached that branch.
2. A monitor built **minutes after diagnosing the first** reused the same naive grep and reported the same false hit again.

The second is the reason this is worth a bullet rather than a comment: the fix is trivial, noticing is not.

## The fix, as recorded

Read only the output after the **LAST** `##[endgroup]` — there are several, and the last one closes the `Run …` block:

```
awk '/##\[endgroup\]/{n=NR} {a[NR]=$0} END{for(i=n+1;i<=NR;i++) print a[i]}'
```

Also records the better habit: prefer structured data where it exists. Step conclusions from `gh api .../actions/jobs/<id> --jq '.steps[]'` cannot be spoofed by the script listing at all.

## Validation

The discriminator was checked against a real log where the two disagree — job from run `30644273088`:

```
naive grep:                1 hit
documented awk pipeline:   0 hits      <- correct; that run failed on a different error
```

**The awk command was extracted from the committed markdown and run**, not pasted from my session — so the documented form is the tested form. That distinction has already mattered twice today (#2890's harness used `[ … ] && { … }` where the real step used `if` blocks, which differ under `set -e`).

## Placement

`CLAUDE.md` → `CI gates — exercise the failure path before trusting the green`, directly after the `/attempts/<n>/jobs` bullet. Both are "the API or log answered about something other than what you asked".

## Verification

- markdown fences balanced (4, even)
- +12 lines, no deletions — nothing existing reworded
- does not touch the `gh CLI` section, so no overlap with #2927

## Release impact

None — `docs` is a hidden type and `CLAUDE.md` is not under any released package path.

Refs #2892, #2898
