### PR TITLE
docs: a zsh `for x in $VAR` loop runs once, so the sweep reports the estate clean

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -385,6 +385,17 @@ fire from *outside* it, so they stay here:
   a false positive here looks exactly like the success you were hoping for. Prefer structured
   data outright where it exists: step conclusions from
   `gh api .../actions/jobs/<id> --jq '.steps[]'` cannot be spoofed by the script listing.
+- **Validate the PROBE, not the command inside it — in zsh a `for x in $VAR` loop runs ONCE.**
+  zsh does not word-split an unquoted parameter (bash does), so a sweep written as
+  `LIST="a b c"; for b in $LIST; do git show-ref --verify --quiet "refs/heads/$b" …` tests one
+  ref literally named `a b c`, finds nothing, and reports the estate clean. Measured
+  2026-07-31 on a leftover-branch sweep: it printed `0 of 17` while five refs were sitting
+  there. Use `${=VAR}`, a real array `VAR=(a b c)`, or `while read` from a heredoc — the last
+  is safest since it also survives names with spaces.
+  The transferable half is the failure of the check on the check: `git show-ref` *was* validated
+  against a known-positive and passed, because the bug was in the LOOP, not the command. A
+  component test is not a probe test. Feed the whole construct a case it must flag — here, a
+  branch you know exists — and only then trust its silence.
 - **Test the script EXTRACTED from the workflow, not a retyped copy of it.** A transcription is
   a different program: the first harness for #2890 used `[ … ] && { … }` where the real step
   used `if` blocks, and under `set -e` those differ on exactly the passing case. Parse the YAML


### PR DESCRIPTION
Third bullet today in the same family (#2894, #2928), and the one with the most transferable half.

## The trap

zsh does **not** word-split an unquoted parameter the way bash does. So a sweep written the obvious way:

```
LIST="branch-a branch-b branch-c"
for b in $LIST; do git show-ref --verify --quiet "refs/heads/$b" && echo "$b"; done
```

runs **once**, testing a single ref literally named `branch-a branch-b branch-c`. It finds nothing and reports the estate clean.

Measured 2026-07-31 on a leftover-branch sweep: it printed `0 of 17` while five refs were sitting there. It only looked wrong because the number was implausible — several worktrees had been created with `-b`, so some refs *had* to remain.

## The transferable half

`git show-ref` **was** validated against a known-positive, and it passed. The bug was in the **loop**, not the command it wrapped.

A component test is not a probe test. Feed the whole construct a case it must flag — here, a branch known to exist — before trusting its silence.

That is what separates this from the two earlier bullets today: I did the validation step, just one layer too deep.

## The fixes, verified before writing them down

```
${=VAR}                for x in ${=V}     -> 3 iterations
real array             V=(a b c)          -> 3 iterations
while read + heredoc                      -> 3 iterations
```

All three run in zsh; `bash -c 'for x in $V'` gives 3 for comparison, confirming the difference is zsh-specific and not a mistake in the demo. `while read` is recommended as the default because it also survives names containing spaces.

Writing an untested fix into a bullet about untested probes seemed like a good way to earn a sequel.

## Placement

`CLAUDE.md` → `CI gates — exercise the failure path before trusting the green`, immediately before the extracted-script bullet. Same mistake in a different shape: verifying a stand-in instead of the artifact.

## Verification

- markdown fences balanced (4, even)
- +11 lines, no deletions
- section order unchanged
- body passed with `--body-file` per the rule merged in #2927

Refs #2892
