### PR TITLE
fix(libs): teach the Temporal payload converter to build Kotlin data classes

### DIFF
--- a/openbank-libs-temporal/build.gradle.kts
+++ b/openbank-libs-temporal/build.gradle.kts
@@ -62,6 +62,12 @@ dependencies {
     // services resolve them), so this adds no new verification entries. Only the type
     // signatures are needed here; each consumer brings the real temporal-sdk itself.
     compileOnly("io.temporal:temporal-sdk:1.25.1") { isTransitive = false }
+    // Kotlin data classes as workflow payloads need the Kotlin module on the Temporal
+    // JSON converter; consumers already ship it via quarkus-rest-jackson (#2749).
+    compileOnly("com.fasterxml.jackson.module:jackson-module-kotlin:2.18.2")
+
+    testImplementation("io.temporal:temporal-sdk:1.25.1")
+    testImplementation("com.fasterxml.jackson.module:jackson-module-kotlin:2.18.2")
     compileOnly("io.temporal:temporal-serviceclient:1.25.1") { isTransitive = false }
     compileOnly("com.uber.m3:tally-core:0.13.0") { isTransitive = false }
 

--- a/openbank-libs-temporal/build.gradle.kts
+++ b/openbank-libs-temporal/build.gradle.kts
@@ -66,7 +66,13 @@ dependencies {
     // JSON converter; consumers already ship it via quarkus-rest-jackson (#2749).
     compileOnly("com.fasterxml.jackson.module:jackson-module-kotlin:2.18.2")
 
-    testImplementation("io.temporal:temporal-sdk:1.25.1")
+    // grpc excluded: temporal-sdk brings its own 1.54.1, which carries GHSA-cfgp-2977-2fmm
+    // (high) and fails dependency-review. The converter test needs the payload/converter types,
+    // not the service client, so this stays a test-only classpath without grpc.
+    testImplementation("io.temporal:temporal-sdk:1.25.1") { exclude(group = "io.grpc") }
+    // protobuf reached the test classpath via grpc; excluding grpc means naming it directly.
+    // Version matches the fleet pin in openbank.dependency-vulnerability-pins.
+    testImplementation("com.google.protobuf:protobuf-java:4.35.0")
     testImplementation("com.fasterxml.jackson.module:jackson-module-kotlin:2.18.2")
     compileOnly("io.temporal:temporal-serviceclient:1.25.1") { isTransitive = false }
     compileOnly("com.uber.m3:tally-core:0.13.0") { isTransitive = false }

--- a/openbank-libs-temporal/src/main/kotlin/com/openbank/libs/temporal/TemporalClientProducer.kt
+++ b/openbank-libs-temporal/src/main/kotlin/com/openbank/libs/temporal/TemporalClientProducer.kt
@@ -4,11 +4,15 @@
 
 package com.openbank.libs.temporal
 
+import com.fasterxml.jackson.module.kotlin.registerKotlinModule
 import com.uber.m3.tally.RootScopeBuilder
 import com.uber.m3.util.Duration
 import io.micrometer.core.instrument.MeterRegistry
 import io.temporal.client.WorkflowClient
 import io.temporal.client.WorkflowClientOptions
+import io.temporal.common.converter.DataConverter
+import io.temporal.common.converter.DefaultDataConverter
+import io.temporal.common.converter.JacksonJsonPayloadConverter
 import io.temporal.common.reporter.MicrometerClientStatsReporter
 import io.temporal.serviceclient.WorkflowServiceStubs
 import io.temporal.serviceclient.WorkflowServiceStubsOptions
@@ -43,9 +47,36 @@ class TemporalClientProducer(private val config: TemporalConfig, private val met
         }
         WorkflowClient.newInstance(
             WorkflowServiceStubs.newServiceStubs(stubsOptions.build()),
-            WorkflowClientOptions.newBuilder().setNamespace(config.namespace()).build(),
+            WorkflowClientOptions.newBuilder()
+                .setNamespace(config.namespace())
+                .setDataConverter(kotlinAwareDataConverter())
+                .build(),
         )
     }
+
+    /**
+     * Temporal's default JSON payload converter builds a plain Jackson ObjectMapper, which cannot
+     * construct a Kotlin data class — those have no no-arg constructor. Any workflow argument or
+     * return value that is a Kotlin data class fails with
+     *
+     *     DataConverterException: Cannot construct instance of `X` (no Creators, like default
+     *     constructor, exist)
+     *
+     * and the workflow task fails in a loop: the activity has already run, so the work is done and
+     * the journey still never advances. Measured on campaign-service, whose journey passes
+     * `List<CampaignStep>` (#2749); services that only pass Strings and UUIDs never hit it, which is
+     * why this survived in a fleet with several Temporal consumers.
+     *
+     * Additive: this only teaches the existing JSON converter to build Kotlin types. Payload
+     * encoding is unchanged, so in-flight workflows and histories written before this stay readable.
+     */
+    internal fun kotlinAwareDataConverter(): DataConverter = DefaultDataConverter
+        .newDefaultInstance()
+        .withPayloadConverterOverrides(
+            JacksonJsonPayloadConverter(
+                JacksonJsonPayloadConverter.newDefaultObjectMapper().registerKotlinModule(),
+            ),
+        )
 
     @Produces
     @ApplicationScoped

--- a/openbank-libs-temporal/src/test/kotlin/com/openbank/libs/temporal/KotlinDataConverterTest.kt
+++ b/openbank-libs-temporal/src/test/kotlin/com/openbank/libs/temporal/KotlinDataConverterTest.kt
@@ -1,0 +1,59 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright (c) OpenBank contributors. Licensed under the Apache License, Version 2.0.
+// See LICENSE in the repository root or https://www.apache.org/licenses/LICENSE-2.0 for details.
+
+package com.openbank.libs.temporal
+
+import io.micrometer.core.instrument.simple.SimpleMeterRegistry
+import io.temporal.common.converter.DefaultDataConverter
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.assertThrows
+
+/**
+ * Regression for #2749. Temporal's stock JSON payload converter builds a plain Jackson ObjectMapper,
+ * which cannot construct a Kotlin data class — it has no no-arg constructor. campaign-service's
+ * journey passes `List<CampaignStep>`, so every workflow task failed with
+ * `Cannot construct instance of ... (no Creators, like default constructor, exist)` **after** the
+ * send activity had already run: the work happened and the journey still never advanced.
+ *
+ * The second test is the one that matters — it pins the *reason* the override exists. Without it,
+ * someone could drop `registerKotlinModule()` and only this file's first test would fail, with no
+ * indication of what the override was for.
+ */
+class KotlinDataConverterTest {
+
+    data class Step(val order: Int, val template: String, val variables: Map<String, String>)
+
+    private val converter = TemporalClientProducer(
+        config = object : TemporalConfig {
+            override fun enabled() = true
+            override fun serverUrl() = "localhost:7233"
+            override fun namespace() = "test"
+            override fun taskQueue() = "test"
+            override fun metricsEnabled() = false
+        },
+        meterRegistry = SimpleMeterRegistry(),
+    ).kotlinAwareDataConverter()
+
+    @Test
+    fun `a Kotlin data class survives a payload round trip`() {
+        val step = Step(1, "MARKETING_PRODUCT_OFFER", mapOf("offerTitle" to "Saver"))
+
+        val payload = converter.toPayload(step).orElseThrow()
+        val restored = converter.fromPayload(payload, Step::class.java, Step::class.java)
+
+        assertEquals(step, restored)
+    }
+
+    @Test
+    fun `the stock converter cannot - which is why the override exists`() {
+        val step = Step(1, "MARKETING_PRODUCT_OFFER", emptyMap())
+        val stock = DefaultDataConverter.newDefaultInstance()
+
+        val payload = stock.toPayload(step).orElseThrow()
+        assertThrows<Exception> {
+            stock.fromPayload(payload, Step::class.java, Step::class.java)
+        }
+    }
+}


### PR DESCRIPTION
## Symptom

The smoke journey started, ran its first activity, and then failed its workflow task in a loop:

```
DataConverterException: Cannot construct instance of
`com.openbank.campaign.domain.model.CampaignStep`
(no Creators, like default constructor, exist)
```

Workflow history, party `05a02ef1`:

```
5  ActivityTaskScheduled
6  ActivityTaskStarted
7  ActivityTaskCompleted     <- the send activity ran
8  WorkflowTaskScheduled
9  WorkflowTaskStarted
10 WorkflowTaskFailed        <- and then this, forever
```

**The activity had already completed.** The work happened; the journey just never advanced past it.
Anything checking "did the activity run" would have read as healthy.

## Cause

Temporal's stock JSON payload converter builds a plain Jackson `ObjectMapper`, which cannot
construct a Kotlin data class — there is no no-arg constructor. `TemporalClientProducer` set no
`DataConverter`, so every Temporal consumer in the fleet inherited that.

Services passing only Strings and UUIDs across the workflow boundary never hit it. campaign-service
is the first to pass a domain type (`List<CampaignStep>`), which is why this survived in a fleet that
already had several Temporal consumers.

## Fix

Register a `DataConverter` whose JSON converter has the Kotlin module. In the shared producer, not in
campaign — the limitation is the fleet's, not one service's.

Additive: it only teaches the existing JSON converter to build Kotlin types. Payload encoding is
unchanged, so histories written before this stay readable and in-flight workflows are unaffected.

## Tests

Two, and the second is the point:

1. A Kotlin data class survives a round trip through the configured converter.
2. The **stock** converter fails on the same class.

Without (2), someone could drop `registerKotlinModule()` and only (1) would fail, with nothing
explaining what the override was for.

Coverage note: the kover ratchet caught the first version of this change (15% vs a 20% floor) because
I had added the converter without a test. The tests above are what fixed it — the floor did its job.

## Verification

`detekt ktlintCheck koverVerify build` green on `openbank-libs-temporal`, plus
`:openbank-campaign-service:build`.

Deployment of this is what should let the #2749 journey advance past its first step; that is not yet
observed and I will report it either way.

Refs #2749