### PR TITLE
fix(mcp): key an agent session by the token's sub so staff OBO resolves

### DIFF
--- a/openbank-mcp-service/src/main/kotlin/com/openbank/mcp/infrastructure/rest/McpSessionResource.kt
+++ b/openbank-mcp-service/src/main/kotlin/com/openbank/mcp/infrastructure/rest/McpSessionResource.kt
@@ -22,6 +22,7 @@ import jakarta.ws.rs.Produces
 import jakarta.ws.rs.core.MediaType
 import jakarta.ws.rs.core.Response
 import org.eclipse.microprofile.config.inject.ConfigProperty
+import org.eclipse.microprofile.jwt.JsonWebToken
 import org.eclipse.microprofile.openapi.annotations.Operation
 import org.eclipse.microprofile.openapi.annotations.tags.Tag
 import org.jboss.logging.Logger
@@ -67,7 +68,7 @@ class McpSessionResource(
         val now = Instant.now(clock)
         val session = AgentSessionEntity().also {
             it.id = Ids.newId()
-            it.subject = identity.principal.name
+            it.subject = callerSubject()
             it.roleCeiling = ceiling.joinToString(",", prefix = "[", postfix = "]") { r -> "\"$r\"" }
             it.clientId = request.clientId
             it.purpose = request.purpose
@@ -137,7 +138,23 @@ class McpSessionResource(
     // Broken-access-control guard: the role grant admits every operator, but a session row is
     // its owner's alone — reading or revoking another operator's session needs ROLE_ADMIN.
     private fun owns(session: AgentSessionEntity): Boolean =
-        identity.roles.contains("ROLE_ADMIN") || session.subject == identity.principal.name
+        identity.roles.contains("ROLE_ADMIN") || session.subject == callerSubject()
+
+    /**
+     * The identifier a session row is keyed by: the token's `sub`, never `principal.name`.
+     *
+     * [com.openbank.mcp.infrastructure.mcp.CallerContextResolver] validates an OBO token by
+     * comparing the row's subject to `jwt.subject`, so the row MUST hold the same claim. With
+     * `principal.name` it held Quarkus' name claim (`upn`/`preferred_username` — an email in this
+     * realm) while the resolver read the `sub` UUID: never equal, so every staff OBO call fell
+     * through to anonymous with no error anywhere (#2938). `sub` is also the stable choice —
+     * `preferred_username` is mutable in Keycloak and would strand a live session on rename.
+     *
+     * The `principal.name` fallback covers a non-JWT identity (`@TestSecurity`); production always
+     * takes the `sub` branch. Both writers and [owns] read through here so the two can't diverge.
+     */
+    private fun callerSubject(): String =
+        (identity.principal as? JsonWebToken)?.subject ?: identity.principal.name
 
     private fun forbidden(): Response =
         Response.status(Response.Status.FORBIDDEN).entity(mapOf("error" to "not your session")).build()

--- a/openbank-mcp-service/src/main/kotlin/com/openbank/mcp/infrastructure/rest/McpSessionResource.kt
+++ b/openbank-mcp-service/src/main/kotlin/com/openbank/mcp/infrastructure/rest/McpSessionResource.kt
@@ -153,8 +153,7 @@ class McpSessionResource(
      * The `principal.name` fallback covers a non-JWT identity (`@TestSecurity`); production always
      * takes the `sub` branch. Both writers and [owns] read through here so the two can't diverge.
      */
-    private fun callerSubject(): String =
-        (identity.principal as? JsonWebToken)?.subject ?: identity.principal.name
+    private fun callerSubject(): String = (identity.principal as? JsonWebToken)?.subject ?: identity.principal.name
 
     private fun forbidden(): Response =
         Response.status(Response.Status.FORBIDDEN).entity(mapOf("error" to "not your session")).build()

--- a/openbank-mcp-service/src/test/kotlin/com/openbank/mcp/McpEndpointTest.kt
+++ b/openbank-mcp-service/src/test/kotlin/com/openbank/mcp/McpEndpointTest.kt
@@ -156,7 +156,7 @@ class McpEndpointTest {
         )
         val principal = pdp.queries.single().principal
         assertThat(principal.type).isEqualTo("HUMAN")
-        assertThat(principal.id).isEqualTo("jane.operator")
+        assertThat(principal.id).isEqualTo(STAFF_SUB)
         assertThat(principal.roles).containsExactly("ROLE_OPERATOR")
     }
 
@@ -224,7 +224,12 @@ class McpEndpointTest {
     private val staffSessionId = "3f2a9c41-7b5e-4c8d-9e0f-1a2b3c4d5e6f"
 
     private val staffClaims = mapOf(
-        "sub" to "jane.operator",
+        // A realm token's `sub` is a UUID and its name claim is an email — they are NEVER the same
+        // string. The old fixture used "jane.operator" for both, which is exactly why #2938 (row
+        // keyed by the name claim, token validated against `sub`) passed every test while the
+        // staff channel was dead in every environment.
+        "sub" to STAFF_SUB,
+        "preferred_username" to "jane.operator@openbank.local",
         "azp" to "openbank-admin-ui",
         "jti" to staffSessionId,
         "aud" to "openbank-mcp-service",
@@ -237,7 +242,7 @@ class McpEndpointTest {
     private fun fakeSessionRepo() = object : AgentSessionRepository() {
         override suspend fun findActiveByJti(jti: String, asOf: java.time.Instant) = if (jti == staffSessionId) {
             AgentSessionEntity().also {
-                it.subject = "jane.operator"
+                it.subject = STAFF_SUB
                 it.roleCeiling = "[\"ROLE_OPERATOR\"]"
                 it.clientId = "admin-ui"
                 it.jti = staffSessionId
@@ -658,6 +663,9 @@ class McpEndpointTest {
     private companion object {
         const val SECRET = "CZ6508000000192000145399"
         const val TEST_CONSENT_ID = "11111111-1111-1111-1111-111111111111"
+
+        /** A staff `sub` as Keycloak actually mints it — a UUID, never the name claim (#2938). */
+        const val STAFF_SUB = "3a046823-5d47-4de1-9f3f-b1b2a953d2cc"
     }
 
     private class StubReads(private val m: com.fasterxml.jackson.databind.ObjectMapper) :

--- a/openbank-mcp-service/src/test/kotlin/com/openbank/mcp/McpSessionResourceTest.kt
+++ b/openbank-mcp-service/src/test/kotlin/com/openbank/mcp/McpSessionResourceTest.kt
@@ -58,6 +58,60 @@ class McpSessionResourceTest {
         assertThat(saved).isEmpty()
     }
 
+    // #2938: with a real OIDC identity, `principal.name` is the name claim and `sub` is a UUID.
+    // The row must hold `sub` — CallerContextResolver validates an OBO token against exactly that,
+    // so a row keyed by the name claim can never match and every staff call fell through to
+    // anonymous. Asserting on `saved.subject` alone is not enough: the fixture has to make the two
+    // claims DIFFER, or the old code passes too.
+    private fun jwtResource(sub: String, username: String, roles: Set<String>) =
+        McpSessionResource(repo, clock, 15).apply {
+            val token = TestJsonWebToken(mapOf("sub" to sub, "preferred_username" to username))
+            identity = QuarkusSecurityIdentity.builder()
+                .setPrincipal(token)
+                .apply { roles.forEach { addRole(it) } }
+                .build() as SecurityIdentity
+        }
+
+    @Test
+    fun `a session issued from a JWT identity is keyed by sub, not by the name claim`(): Unit = runBlocking {
+        val res = jwtResource(OPERATOR_SUB, "admin@openbank.local", setOf("ROLE_OPERATOR"))
+            .create(CreateSessionRequest(roleCeiling = listOf("ROLE_OPERATOR")))
+        assertThat(res.status).isEqualTo(201)
+        assertThat(saved.single().subject).isEqualTo(OPERATOR_SUB)
+        assertThat(saved.single().subject).isNotEqualTo("admin@openbank.local")
+    }
+
+    @Test
+    fun `ownership of a sub-keyed session is recognised, and a name-keyed row is not theirs`(): Unit = runBlocking {
+        val mine = session(subject = OPERATOR_SUB)
+        val legacy = session(subject = "admin@openbank.local")
+        val repoWithBoth = object : AgentSessionRepository() {
+            override suspend fun findById(id: java.util.UUID) = when (id) {
+                mine.id -> mine
+                legacy.id -> legacy
+                else -> null
+            }
+        }
+        val caller = McpSessionResource(repoWithBoth, clock, 15).apply {
+            identity = QuarkusSecurityIdentity.builder()
+                .setPrincipal(TestJsonWebToken(mapOf("sub" to OPERATOR_SUB, "preferred_username" to "admin@openbank.local")))
+                .addRole("ROLE_OPERATOR")
+                .build() as SecurityIdentity
+        }
+        assertThat(caller.status(mine.id).status).isEqualTo(200)
+        // A row written by the pre-#2938 code holds the name claim: it is not this caller's row.
+        assertThat(caller.status(legacy.id).status).isEqualTo(403)
+    }
+
+    private fun session(subject: String) = AgentSessionEntity().also {
+        it.id = java.util.UUID.randomUUID()
+        it.subject = subject
+        it.roleCeiling = "[\"ROLE_OPERATOR\"]"
+        it.clientId = "admin-ui"
+        it.createdAt = Instant.now(clock)
+        it.expiresAt = Instant.now(clock).plusSeconds(900)
+    }
+
     @Test
     fun `another operator cannot read or revoke a session that is not theirs`(): Unit = runBlocking {
         val foreign = AgentSessionEntity().also {
@@ -103,5 +157,10 @@ class McpSessionResourceTest {
         }
         assertThat(admin.status(foreign.id).status).isEqualTo(200)
         assertThat(admin.revoke(foreign.id).status).isEqualTo(204)
+    }
+
+    private companion object {
+        /** A realm `sub` is a UUID; the name claim is an email. The difference IS the test. */
+        const val OPERATOR_SUB = "3a046823-5d47-4de1-9f3f-b1b2a953d2cc"
     }
 }

--- a/openbank-mcp-service/src/test/kotlin/com/openbank/mcp/McpSessionResourceTest.kt
+++ b/openbank-mcp-service/src/test/kotlin/com/openbank/mcp/McpSessionResourceTest.kt
@@ -94,7 +94,9 @@ class McpSessionResourceTest {
         }
         val caller = McpSessionResource(repoWithBoth, clock, 15).apply {
             identity = QuarkusSecurityIdentity.builder()
-                .setPrincipal(TestJsonWebToken(mapOf("sub" to OPERATOR_SUB, "preferred_username" to "admin@openbank.local")))
+                .setPrincipal(
+                    TestJsonWebToken(mapOf("sub" to OPERATOR_SUB, "preferred_username" to "admin@openbank.local")),
+                )
                 .addRole("ROLE_OPERATOR")
                 .build() as SecurityIdentity
         }

--- a/openbank-mcp-service/src/test/kotlin/com/openbank/mcp/TestJsonWebToken.kt
+++ b/openbank-mcp-service/src/test/kotlin/com/openbank/mcp/TestJsonWebToken.kt
@@ -8,9 +8,15 @@ import org.eclipse.microprofile.jwt.JsonWebToken
  * Minimal POJO [JsonWebToken] for plain-unit tests (mcp tests carry no Quarkus context — see
  * [McpEndpointTest]). Backed by a claim map; `getSubject()` resolves via `getClaim("sub")` per the
  * MP-JWT default, so an empty map models an anonymous / OIDC-disabled call.
+ *
+ * [getName] resolves `preferred_username` BEFORE `sub`, mirroring Quarkus' principal-name
+ * resolution. That asymmetry is load-bearing: with `getName()` returning `sub`, a fixture cannot
+ * express a real token — where the two claims hold different values — and #2938 (a row keyed by
+ * the name claim, validated against `sub`) stays invisible to every test.
  */
 class TestJsonWebToken(private val claims: Map<String, Any?> = emptyMap()) : JsonWebToken {
-    override fun getName(): String = claims["sub"]?.toString() ?: "anonymous"
+    override fun getName(): String =
+        claims["preferred_username"]?.toString() ?: claims["sub"]?.toString() ?: "anonymous"
 
     override fun getClaimNames(): Set<String> = claims.keys
 


### PR DESCRIPTION
## What

`McpSessionResource` wrote `identity.principal.name` into `agent_session.subject`; `CallerContextResolver` validates an OBO token by comparing that row to `jwt.subject`. In production the two are different values — Quarkus resolves the name claim (`upn`/`preferred_username`, an email in this realm) while `sub` is a UUID — so the comparison never held, the resolver returned `null`, and **every staff OBO call degraded to anonymous**.

Both writers and the ownership guard now read through one `callerSubject()` helper, so they cannot diverge again:

```kotlin
private fun callerSubject(): String =
    (identity.principal as? JsonWebToken)?.subject ?: identity.principal.name
```

`sub` is also the right key on its own merit — `preferred_username` is mutable in Keycloak and would strand a live session on a rename. The `principal.name` fallback covers a non-JWT identity (`@TestSecurity`); production always takes the `sub` branch.

Closes #2938.

## Evidence — reproduced on the sandbox before the fix

Full relay chain from [`route.ts`](https://github.com/JiRaska/open-bank-oss/blob/main/openbank-admin-ui/src/app/api/agent/obo-mcp/route.ts) replayed by hand against `sandbox-dde5f188` with `MCP_OBO_ENABLED=true`. Every leg succeeded and the last one still returned the anonymous answer:

| Leg | Result |
|---|---|
| `POST /api/v1/mcp/sessions` | `201`, row `subject: admin@openbank.local` |
| RFC 8693 exchange | `200`, `aud=openbank-mcp-service`, `azp=openbank-admin-ui`, `sid` ✓, roles ✓, TTL 300 s |
| `PATCH /sessions/{id}/bind` | `200`, `jti` persisted |
| `POST /mcp` `tools/list` | `{"tools": []}` — identical to the anonymous control |

Audit line for that exact call: `op=mcp.tools.list result=DENIED actor=unknown actorType=AI_AGENT`.

Worth noting how this hides: an empty tool list is *also* the correct fail-closed answer for a caller with no grants — which is what #2763 says today's rego gives a HUMAN principal until the ADR-0223 matrix lands. Nothing distinguishes "policy denied everything" from "identity was never accepted" except the audit line.

## Why the suite was green

`McpEndpointTest` used `"jane.operator"` for the `sub` claim **and** for the stubbed row's subject. `McpSessionLifecycleIT` uses `@TestSecurity(user = "jane.operator")`, which makes `principal.name` and `sub` the same string by construction. The two identifiers were only ever equal in the fixtures.

Fixed at the fixture level, because that is where the blindness lives:

- `McpEndpointTest.staffClaims` now carries a UUID `sub` **and** a distinct `preferred_username`.
- `TestJsonWebToken.getName()` resolves `preferred_username` before `sub`, mirroring Quarkus' principal-name resolution. Without that, a fixture cannot express a real token at all.
- Two new unit tests in `McpSessionResourceTest`: a session issued from a JWT identity is keyed by `sub` (and explicitly *not* by the name claim), and a row written in the old shape is **not** recognised as the caller's (403).

`McpSessionLifecycleIT` still exercises the fallback branch — `@TestSecurity` supplies a non-JWT principal — so the regression lives in the unit tests, not the IT.

## Verification — fail-first proven

Run in an isolated `GRADLE_USER_HOME` (see the environment note below for why). Three steps, same command each time: `:openbank-mcp-service:test --tests '*McpSessionResourceTest*' --tests '*McpEndpointTest*'`.

**1 — with the fix: green.**

```
com.openbank.mcp.McpEndpointTest:        tests=35  failures=0  errors=0
com.openbank.mcp.McpSessionResourceTest: tests=6   failures=0  errors=0
BUILD SUCCESSFUL
```

**2 — `callerSubject()` reverted to `identity.principal.name` (pre-fix behaviour), tests untouched: red, and red for the right reason.**

```
com.openbank.mcp.McpSessionResourceTest: tests=6  failures=2

FAIL  a session issued from a JWT identity is keyed by sub, not by the name claim
      expected: "3a046823-5d47-4de1-9f3f-b1b2a953d2cc"
      but was:  "admin@openbank.local"

FAIL  ownership of a sub-keyed session is recognised, and a name-keyed row is not theirs
      expected: 200
      but was:  403
```

That is the production confusion exactly: the row keyed by an email, the resolver reading a UUID.

**3 — fix restored: green again.** `BUILD SUCCESSFUL`, 35 + 6 tests, 0 failures.

One prediction of mine was wrong and is worth recording: I expected `McpEndpointTest` to go red in step 2 as well. It does not, and should not — that test never calls `McpSessionResource`; it stubs the repository with `subject = STAFF_SUB` directly, so it covers the *read* side (the resolver) and is unaffected by reverting the *write* side. Its fixture still had to change: with `"jane.operator"` as both `sub` and the name claim it could not tell the two apart, so it could not guard the read side against the same confusion.

## Environment note (not a change in this PR)

The local runs above needed a `GRADLE_USER_HOME` under `/private/tmp` sharing nothing with `~/.gradle`. Against the shared home the build fails before reaching any test:

```
e: .../openbank-libs-domain/.../OpaSidecarPolicyDecisionPoint.kt:7:30 Unresolved reference 'databind'.
```

Reproduced on a pristine `origin/main` worktree with an unmodified tree, so it is not this branch. Files disappear from `~/.gradle` while the machine is idle: the unpacked Gradle 9.6.1 distribution lost its `lib/` (the wrapper keeps the `.ok` marker, so it considers itself installed and never re-unpacks — `rm -rf ~/.gradle/wrapper/dists/gradle-9.6.1-bin/<hash>` fixes that), and a `jackson-databind-2.22.1.jar` I placed into `modules-2` by hand, hashing to exactly the value `verification-metadata.xml` declares, was **gone again within the hour** while the copy in the isolated home survived. No build deletes a valid artifact.

Also unexplained: `maven-settings-3.9.16.jar` and `smallrye-common-os-2.19.0.jar` fail verification locally with checksums (`441f7230…`, `e04ba519…`) matching neither the committed metadata nor what repo1 and the GCS mirror serve — both return exactly the committed hashes, verified by direct download, with `REPOSILITE_MIRROR_URL` unset. Flagging it for whoever owns this machine; nothing here belongs in the repo.

## Not in scope

No schema change: `agent_session.subject` keeps its type, and existing sandbox rows expire within the 15-minute TTL. `AgentSessionResponse.subject` now surfaces the `sub` UUID rather than an email — no UI reads it today (the relay uses only `id`), but a future operator console wanting a display name should add a separate field rather than change this key back.

