### PR TITLE
ci(governance): raise an issue when the spot-kill auto-retry fails

### DIFF
--- a/.github/workflows/auto-retry-cancelled.yml
+++ b/.github/workflows/auto-retry-cancelled.yml
@@ -142,3 +142,92 @@ jobs:
           echo "Re-running ${RUN_URL}: ${killed} job(s) killed mid-step by a runner reclaim (issue #2841)"
           gh run rerun -R "${GITHUB_REPOSITORY}" "${RUN_ID}" --failed
           echo "::notice title=spot-kill auto-retry::Re-ran ${killed} spot-killed job(s) in ${RUN_URL} (attempt 2 of max 2; a second kill stays for a human)"
+
+  # ── The alarm (issue #2901) ───────────────────────────────────────────────────
+  # Why this exists: this workflow failed 208 times without anyone noticing. It is
+  # `workflow_run`-triggered, so there is no PR to show a red check on and no commit status
+  # anyone reads — its red is addressed to nobody, the same blind spot dependency-submission
+  # sat in for three days before it grew a raise-issue job.
+  #
+  # It is the sharp case rather than an ordinary one: the whole POINT of this workflow is to
+  # act unattended, so "nobody is looking" is the design, not an accident. A silent failure is
+  # therefore indistinguishable from a silent success — the spot-killed run just sits there
+  # red, looking like an ordinary build failure, which is exactly the human round-trip #2330
+  # existed to remove.
+  #
+  # The defect behind those 208 (a bare `gh run rerun` with no repo context, #2898) is fixed
+  # and the workflow now succeeds. This job is about the NEXT one: it cannot prevent a
+  # breakage, only make it arrive as an addressed issue instead of two quiet days.
+  #
+  # A separate job, not a step: a guard that fails in place is either skipped or strips the
+  # job of dependents. `retry` has none today, but keeping escalation independent of what the
+  # retry step does next is the pattern CLAUDE.md records.
+  raise-issue:
+    name: Raise issue on retry failure
+    needs: retry
+    if: ${{ failure() }}
+    runs-on: ubuntu-latest
+    timeout-minutes: 5 # API calls only
+    permissions:
+      contents: read
+      issues: write
+    # No actions/checkout, so gh cannot infer the repo from a git remote (#2841).
+    env:
+      GH_REPO: ${{ github.repository }}
+    steps:
+      - name: Open or refresh the tracking issue
+        env:
+          GH_TOKEN: ${{ github.token }}
+          RUN_URL: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
+          TARGET_URL: ${{ github.event.workflow_run.html_url }}
+          TARGET_NAME: ${{ github.event.workflow_run.name }}
+          TARGET_CONCLUSION: ${{ github.event.workflow_run.conclusion }}
+        run: |
+          set -euo pipefail
+          TITLE="Spot-kill auto-retry is failing — reclaimed CI runs are not being re-run"
+          # Body written with a plain redirect + --body-file, NOT `BODY=$(cat <<EOF ...)`.
+          # A heredoc nested inside $( ) mis-parses an apostrophe as an opening quote on
+          # bash 3.2 (still the default /bin/bash on macOS), so that shape cannot be dry-run
+          # locally — a step only its own CI can syntax-check is a step nobody tests before
+          # pushing. Flush-left because `run: |` strips only the common YAML indent.
+          cat > "${RUNNER_TEMP:-/tmp}/issue-body.md" <<EOF
+          \`auto-retry-cancelled.yml\` FAILED, so a CI run killed by a spot reclaim was **not**
+          re-run and is sitting red waiting for a human.
+
+          | | |
+          |---|---|
+          | this run | ${RUN_URL} |
+          | triggering run | ${TARGET_URL} |
+          | triggering workflow | \`${TARGET_NAME}\` |
+          | its conclusion | \`${TARGET_CONCLUSION}\` |
+
+          **Which branch was taken** follows from that conclusion: \`cancelled\` is the
+          whole-run path (full re-run), \`failure\` is the partial-spot-kill path, which
+          re-runs only the failed jobs and only when one of them has a \`cancelled\` step and
+          no \`failed\` step.
+
+          **This is latent, not cosmetic.** The reclaimed run looks like an ordinary build
+          failure from every angle, so the cost is the human round-trip #2330 removed —
+          silently reinstated. Nothing else reports it: a \`workflow_run\` job has no PR to
+          redden and no commit status anyone reads, which is why this job exists (#2901).
+
+          **Check the repo context first.** The 208 failures that preceded this job were all
+          one cause: \`gh run rerun\` with no \`-R\` in a job with no \`actions/checkout\`, so
+          \`gh\` could not resolve the repository and exited 1 (\`failed to determine base
+          repo\`, fixed in #2898). If the log says that, something dropped the \`-R\` or the
+          \`GH_REPO\` env — \`.github/scripts/check-gh-repo-context.py\` should have caught it
+          at PR time, so check that gate too.
+
+          Read the step output from **after the last** \`##[endgroup]\`: GitHub prints the
+          step's own script into the log header, so grepping the whole log matches strings
+          that never executed.
+
+          This issue is refreshed on each further failure; close it once a run is green.
+          EOF
+          existing=$(gh issue list --state open --search "$TITLE in:title" --json number --jq '.[0].number' || true)
+          if [ -n "$existing" ]; then
+            gh issue comment "$existing" --body-file "${RUNNER_TEMP:-/tmp}/issue-body.md"
+          else
+            gh issue create --title "$TITLE" --body-file "${RUNNER_TEMP:-/tmp}/issue-body.md" \
+              --label tech-debt --label "severity:high"
+          fi


### PR DESCRIPTION
Closes #2901.

## Why

`auto-retry-cancelled.yml` failed **208 times** without anyone noticing. It is `workflow_run`-triggered, so there is no PR to redden and no commit status anyone reads — the same blind spot `dependency-submission.yml` sat in for three days before it grew a `raise-issue` job.

It is the sharp case rather than an ordinary one: acting unattended is the *point* of this workflow, so "nobody is looking" is the design, not an accident. A silent failure is indistinguishable from a silent success — the spot-killed run just sits there red, looking like an ordinary build failure, which is exactly the human round-trip #2330 existed to remove.

The defect behind those 208 (#2898) is fixed and the workflow now works: **37 successful retries** in the three hours after it landed, from a lifetime of zero. This job cannot prevent the next breakage, only make it arrive as an addressed issue instead of two quiet days.

## Shape

Follows `dependency-submission.yml`'s `raise-issue` job:

- **separate job** with `needs: retry` and `if: ${{ failure() }}`, not a step — a guard that fails in place is either skipped or strips the job of dependents. `retry` has none today; keeping escalation independent of what it does next is the pattern `CLAUDE.md` records.
- open-or-refresh by title search: comment if an open issue exists, create with `tech-debt` + `severity:high` if not.
- body carries the triggering run, its conclusion, **and which branch of the discriminator that implies** — `cancelled` is the whole-run path, `failure` is the partial-spot-kill path — so a reader knows what happened without opening the log.
- points at the two traps that would otherwise cost the reader an hour: check the repo context first (the 208 were all one cause), and read the log after the last `##[endgroup]`.

## Failure path exercised

Per the acceptance criteria in #2901, and on the script **extracted from the workflow** rather than a retyped copy, with `gh` stubbed and **the stub validated first**:

```
no existing issue   ->  gh issue create --title "…" --label tech-debt --label severity:high
issue #4242 open    ->  gh issue comment 4242 --body-file …   (create NOT called)
rendered body       ->  variables expanded, 0 leftover ${…}, 0 stray escapes,
                        markdown table intact
```

**Also run under `/bin/bash` 3.2.57**, the macOS default. That is the reason the body uses a plain redirect + `--body-file` rather than `BODY=$(cat <<EOF …)`: a heredoc nested in `$( )` mis-parses an apostrophe as an opening quote there, and this body contains one ("step's own script"). It survives. `dependency-submission.yml` documents the same constraint; `fleet-attestation.yml`'s equivalent only survives it because its body happens to have no apostrophe.

## The new guard earned its keep

The `GH_REPO` env is required by #2922's `check-gh-repo-context.py`. I fed it this job with the env removed:

```
- .github/workflows/auto-retry-cancelled.yml: job 'raise-issue', step 'Open or refresh
  the tracking issue' calls gh with no checkout, no GH_REPO and no -R/--repo
```

A guard shipped hours earlier catching a genuinely new job written after it, rather than only its own fixtures.

## Verification

- `actionlint` — clean
- `yamllint` under the exact config `ci.yml` builds — exit 0
- job graph parsed rather than eyeballed: `retry` (unchanged) and `raise-issue` (`needs: retry`, `if: failure()`, `GH_REPO` set)

## Known limit, stated rather than discovered later

The escalation itself can still fail silently — if `gh issue create` errors, that failure lands in the same unread `workflow_run` status this job exists to escape. #2901 raises this explicitly and I have not solved it: a reporting mechanism that needs its own reporting mechanism is the same problem one level up. Bounding it would mean an external signal (a push notification, a scheduled reconciler that checks *"did any auto-retry run fail without a corresponding issue?"*). Worth a follow-up; deliberately not bundled here.

Closes #2901
