### PR TITLE
feat(campaign): expose the send log so suppressions are visible outside psql

### DIFF
--- a/openbank-campaign-service/src/main/kotlin/com/openbank/campaign/application/port/out/Ports.kt
+++ b/openbank-campaign-service/src/main/kotlin/com/openbank/campaign/application/port/out/Ports.kt
@@ -26,6 +26,9 @@ interface EnrolmentRepository {
 interface SendLogRepository {
     suspend fun record(send: SendRecord)
     suspend fun countRecentForParty(partyId: UUID, sinceEpochSeconds: Long): Int
+
+    /** Every recorded send attempt for a campaign, newest first — the operator view of what happened. */
+    suspend fun listByCampaign(campaignId: UUID): List<SendRecord>
 }
 
 /** ADR-0201 D1: segments are versioned artifacts loaded as code/data, never UI-typed SQL. */

--- a/openbank-campaign-service/src/main/kotlin/com/openbank/campaign/application/usecase/CampaignSendLogQuery.kt
+++ b/openbank-campaign-service/src/main/kotlin/com/openbank/campaign/application/usecase/CampaignSendLogQuery.kt
@@ -1,0 +1,32 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright (c) OpenBank contributors. Licensed under the Apache License, Version 2.0.
+// See LICENSE in the repository root or https://www.apache.org/licenses/LICENSE-2.0 for details.
+
+package com.openbank.campaign.application.usecase
+
+import com.openbank.campaign.application.port.out.SendLogRepository
+import com.openbank.campaign.domain.model.SendRecord
+import jakarta.enterprise.context.ApplicationScoped
+import java.util.UUID
+
+/**
+ * Read-only view of what a campaign actually did, for the operator console (#2895).
+ *
+ * Separate from [CampaignService] on purpose: that class owns the campaign lifecycle — create,
+ * submit, activate, enrol — and this one only answers questions. Keeping the query here also keeps
+ * both classes under the detekt function-count threshold without raising it, which is the honest
+ * reading of that rule rather than a workaround.
+ */
+@ApplicationScoped
+class CampaignSendLogQuery(private val sendLog: SendLogRepository) {
+
+    /**
+     * Every send attempt for this campaign, newest first — **including suppressed ones**.
+     *
+     * The outcome is the whole point: from the enrolment side a party that was contacted and one
+     * that was deliberately skipped (consent withdrawn, frequency cap, quiet hours — ADR-0200 D6)
+     * look identical. Filtering this to successful deliveries would answer "who got it" while
+     * losing "why didn't they", which is the question operators actually ask.
+     */
+    suspend fun listSends(campaignId: UUID): List<SendRecord> = sendLog.listByCampaign(campaignId)
+}

--- a/openbank-campaign-service/src/main/kotlin/com/openbank/campaign/infrastructure/persistence/Persistence.kt
+++ b/openbank-campaign-service/src/main/kotlin/com/openbank/campaign/infrastructure/persistence/Persistence.kt
@@ -247,6 +247,19 @@ class PanacheSendLogRepository :
         }.awaitSuspending()
     }
 
+    override suspend fun listByCampaign(campaignId: UUID): List<SendRecord> = Panache.withSession {
+        find("campaignId = ?1 order by occurredAt desc", campaignId).list<SendLogEntity>()
+    }.awaitSuspending().map {
+        SendRecord(
+            id = it.id,
+            campaignId = it.campaignId,
+            partyId = it.partyId,
+            stepOrder = it.stepOrder,
+            outcome = SendOutcome.valueOf(it.outcome),
+            occurredAt = it.occurredAt,
+        )
+    }
+
     override suspend fun countRecentForParty(partyId: UUID, sinceEpochSeconds: Long): Int = Panache.withSession {
         count(
             "partyId = ?1 and outcome = ?2 and occurredAt >= ?3",

--- a/openbank-campaign-service/src/main/kotlin/com/openbank/campaign/infrastructure/rest/CampaignSendLogResource.kt
+++ b/openbank-campaign-service/src/main/kotlin/com/openbank/campaign/infrastructure/rest/CampaignSendLogResource.kt
@@ -1,0 +1,38 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright (c) OpenBank contributors. Licensed under the Apache License, Version 2.0.
+// See LICENSE in the repository root or https://www.apache.org/licenses/LICENSE-2.0 for details.
+
+package com.openbank.campaign.infrastructure.rest
+
+import com.openbank.campaign.application.usecase.CampaignSendLogQuery
+import com.openbank.libs.authz.Authorize
+import jakarta.enterprise.context.ApplicationScoped
+import jakarta.ws.rs.GET
+import jakarta.ws.rs.Path
+import jakarta.ws.rs.PathParam
+import jakarta.ws.rs.core.Response
+import java.util.UUID
+
+/**
+ * The send log endpoint, split out of [CampaignResource] so the lifecycle API and the operator's
+ * read view stay separate concerns (and both stay under the detekt function-count threshold).
+ */
+@Path("/api/v1/campaigns")
+@ApplicationScoped
+class CampaignSendLogResource(private val query: CampaignSendLogQuery) {
+
+    /**
+     * What happened per party per step, newest first.
+     *
+     * `outcome` is why this exists. A suppressed send — consent withdrawn, frequency cap, quiet
+     * hours (ADR-0200 D6) — is invisible everywhere else: the enrolment reads the same whether the
+     * party was contacted or deliberately skipped. Without this, "why did this customer get
+     * nothing?" is only answerable with a psql session (#2895).
+     *
+     * Party identifiers only; the send log holds no contact details, so this exposes none.
+     */
+    @GET
+    @Path("/{id}/sends")
+    @Authorize(action = "campaign.read", resource = "#id")
+    suspend fun sends(@PathParam("id") id: UUID): Response = Response.ok(query.listSends(id)).build()
+}

--- a/openbank-campaign-service/src/main/resources/openapi.yaml
+++ b/openbank-campaign-service/src/main/resources/openapi.yaml
@@ -4,7 +4,7 @@ openapi: 3.1.0
 info:
   title: Campaign Service API
   # major == openbank.api.version == URL /api/v1 (ADR-0048).
-  version: 1.0.0
+  version: 1.1.0
   description: >-
     Campaign management first slice (ADR-0200 / ADR-0209 D3): deterministic, versioned segments;
     per-enrolment Temporal journeys; consent-gated delivery through notification-service.
@@ -169,6 +169,28 @@ paths:
                 items:
                   $ref: '#/components/schemas/Enrolment'
 
+  /api/v1/campaigns/{id}/sends:
+    get:
+      tags: [Campaigns]
+      summary: Send log of a campaign — what happened per party per step, newest first
+      description: >-
+        Includes suppressed attempts. `outcome` is the only place a suppression is visible: an
+        enrolment looks identical whether the party was contacted or deliberately skipped
+        (consent withdrawn, frequency cap, quiet hours — ADR-0200 D6).
+        Party identifiers only; no contact details.
+      operationId: listSends
+      parameters:
+        - $ref: '#/components/parameters/CampaignId'
+      responses:
+        '200':
+          description: Send records
+          content:
+            application/json:
+              schema:
+                type: array
+                items:
+                  $ref: '#/components/schemas/SendRecord'
+
 components:
   parameters:
     CampaignId:
@@ -232,6 +254,18 @@ components:
       required: [approver]
       properties:
         approver: { type: string }
+    SendRecord:
+      type: object
+      properties:
+        id: { type: string, format: uuid }
+        campaignId: { type: string, format: uuid }
+        partyId: { type: string, format: uuid }
+        stepOrder: { type: integer }
+        outcome:
+          type: string
+          enum: [SENT, SUPPRESSED_CAP, SUPPRESSED_QUIET_HOURS, SUPPRESSED_CONSENT, FAILED]
+        occurredAt: { type: string, format: date-time }
+
     Enrolment:
       type: object
       properties:

--- a/openbank-campaign-service/src/test/kotlin/com/openbank/campaign/application/CampaignSendLogTest.kt
+++ b/openbank-campaign-service/src/test/kotlin/com/openbank/campaign/application/CampaignSendLogTest.kt
@@ -1,0 +1,76 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright (c) OpenBank contributors. Licensed under the Apache License, Version 2.0.
+// See LICENSE in the repository root or https://www.apache.org/licenses/LICENSE-2.0 for details.
+
+package com.openbank.campaign.application
+
+import com.openbank.campaign.application.port.out.SendLogRepository
+import com.openbank.campaign.application.usecase.CampaignSendLogQuery
+import com.openbank.campaign.domain.model.SendOutcome
+import com.openbank.campaign.domain.model.SendRecord
+import kotlinx.coroutines.runBlocking
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Test
+import java.time.Instant
+import java.util.UUID
+
+/**
+ * The send log is the only place a suppression is observable (#2895): an enrolment reads the same
+ * whether the party was contacted or deliberately skipped. These pin that `listSends` surfaces the
+ * suppressed outcomes rather than filtering to successful deliveries — a "sends" list that quietly
+ * showed only `SENT` would answer "who got it" while losing "why didn't they".
+ */
+class CampaignSendLogTest {
+
+    private val campaignId = UUID.randomUUID()
+
+    private val records = listOf(
+        record(SendOutcome.SENT, 1),
+        record(SendOutcome.SUPPRESSED_CONSENT, 1),
+        record(SendOutcome.SUPPRESSED_CAP, 2),
+        record(SendOutcome.SUPPRESSED_QUIET_HOURS, 2),
+        record(SendOutcome.FAILED, 3),
+    )
+
+    private fun record(outcome: SendOutcome, step: Int) = SendRecord(
+        id = UUID.randomUUID(),
+        campaignId = campaignId,
+        partyId = UUID.randomUUID(),
+        stepOrder = step,
+        outcome = outcome,
+        occurredAt = Instant.parse("2026-07-31T18:00:00Z"),
+    )
+
+    private val query = CampaignSendLogQuery(
+        object : SendLogRepository {
+            override suspend fun record(send: SendRecord) = Unit
+            override suspend fun countRecentForParty(partyId: UUID, sinceEpochSeconds: Long) = 0
+            override suspend fun listByCampaign(campaignId: UUID) = records
+        },
+    )
+
+    @Test
+    fun `every recorded outcome is surfaced, suppressions included`(): Unit = runBlocking {
+        val sends = query.listSends(campaignId)
+
+        assertEquals(records.size, sends.size)
+        assertEquals(
+            setOf(
+                SendOutcome.SENT,
+                SendOutcome.SUPPRESSED_CONSENT,
+                SendOutcome.SUPPRESSED_CAP,
+                SendOutcome.SUPPRESSED_QUIET_HOURS,
+                SendOutcome.FAILED,
+            ),
+            sends.map { it.outcome }.toSet(),
+        )
+    }
+
+    @Test
+    fun `the record keeps party and step so a suppression can be attributed`(): Unit = runBlocking {
+        val suppressed = query.listSends(campaignId).first { it.outcome == SendOutcome.SUPPRESSED_CONSENT }
+
+        assertEquals(campaignId, suppressed.campaignId)
+        assertEquals(1, suppressed.stepOrder)
+    }
+}


### PR DESCRIPTION
Phase 0 of #2895 — the one backend piece the read-only campaign console needs.

## What

`GET /api/v1/campaigns/{id}/sends` — what happened per party per step, newest first, **including
suppressed attempts**.

Everything else the console needs already exists (`GET /campaigns`, `/{id}`, `/{id}/enrolments`).

## Why this endpoint specifically

`outcome` is the point. From the enrolment side, a party that was contacted and one that was
deliberately skipped look identical — same state, same step. The suppression reason lives only in
`send_log`, which had no REST surface, so "why did this customer get nothing?" was answerable only
with a database session.

That is not hypothetical. Running the #2749 smoke journey tonight produced exactly this:

```
026289e3-…|1|SUPPRESSED_QUIET_HOURS
05a02ef1-…|1|SUPPRESSED_QUIET_HOURS
```

Two parties, no messages sent, both enrolments `TERMINATED_SUPPRESSED` — correct ADR-0200 D6
behaviour, and completely invisible through the existing API.

## Why new classes rather than two more methods

`CampaignService` and `CampaignResource` were both already at detekt's function-count threshold (11,
and the rule fires *at* it). Raising the threshold would have been the workaround; splitting is what
the rule was pointing at. `CampaignSendLogQuery` / `CampaignSendLogResource` also keep a read-only
operator query separate from the campaign lifecycle, which is a real distinction rather than a
packaging trick.

## Privacy

Party identifiers only. The send log stores no contact details, so this exposes none. Worth keeping
in mind for the UI: any view of it is a view of who was marketed to (noted in #2895).

## Contract

Additive endpoint → `openapi.yaml` 1.0.0 → 1.1.0 on the API-contract axis (ADR-0048), with the
`SendRecord` schema and its full outcome enum.

## Tests

Two, aimed at the failure that would matter: that `listSends` surfaces the **suppressed** outcomes
rather than filtering to successful deliveries, and that a suppression stays attributable to a party
and step. A "sends" list quietly showing only `SENT` would answer "who got it" while losing "why
didn't they" — and would still look like a working endpoint.

Full gate green: `detekt ktlintCheck koverVerify build`.

Refs #2895, #2749