### PR TITLE
fix(campaign): make the consent-event consumer suspend so revocation can reach the DB

### DIFF
--- a/openbank-campaign-service/src/main/kotlin/com/openbank/campaign/infrastructure/kafka/ConsentEventConsumer.kt
+++ b/openbank-campaign-service/src/main/kotlin/com/openbank/campaign/infrastructure/kafka/ConsentEventConsumer.kt
@@ -8,8 +8,8 @@ import com.fasterxml.jackson.databind.JsonNode
 import com.fasterxml.jackson.databind.ObjectMapper
 import com.openbank.campaign.application.port.out.EnrolmentRepository
 import com.openbank.campaign.application.port.out.JourneySignaller
+import com.openbank.campaign.domain.model.EnrolmentState
 import jakarta.enterprise.context.ApplicationScoped
-import kotlinx.coroutines.runBlocking
 import org.eclipse.microprofile.reactive.messaging.Incoming
 import org.jboss.logging.Logger
 import java.util.UUID
@@ -29,21 +29,32 @@ class ConsentEventConsumer(
 
     private val log = Logger.getLogger(ConsentEventConsumer::class.java)
 
+    /**
+     * `suspend`, NOT a plain method wrapping `runBlocking`.
+     *
+     * SmallRye invokes a plain `@Incoming` method on a Kafka consumer thread, which carries no
+     * Vert.x context, so the first reactive Panache call threw
+     * `InternalStateAssertions.assertUseOnEventLoop` and the message was nacked fail-stop. The
+     * channel then stopped consuming entirely — the readiness check went DOWN while the pod stayed
+     * up, and a revocation could never terminate a journey (ADR-0200 D2). Measured during the
+     * #2749 rollout, after three other defects on this same path had already been fixed.
+     *
+     * Same footgun the fleet documents for `@Scheduled` (#2190/#2191/#2194) — a Kafka consumer is
+     * simply another place with no Vert.x context, and `runBlocking` hides that just as well here.
+     */
     @Incoming("consent-events-in")
-    fun onConsentEvent(payload: String) {
+    suspend fun onConsentEvent(payload: String) {
         val event = mapper.readTree(payload)
         if (event.eventType() != "ConsentRevoked" && event.eventType() != "ConsentExpired") return
         val scopes = event.path("scopes").map { it.asText() }
         if (scopes.none { it.startsWith("MARKETING_COMMS") }) return
         val partyId = runCatching { UUID.fromString(event.path("partyId").asText()) }.getOrNull() ?: return
 
-        runBlocking {
-            // First slice: signal journeys across all ACTIVE campaigns for this party. Campaigns
-            // query enrolments by campaign, so we enumerate via the party's enrolments.
-            enrolments.listByParty(partyId).forEach { enrolment ->
-                if (enrolment.state == com.openbank.campaign.domain.model.EnrolmentState.ACTIVE) {
-                    journeys.signalConsentRevoked(enrolment.campaignId, partyId)
-                }
+        // First slice: signal journeys across all ACTIVE campaigns for this party. Campaigns
+        // query enrolments by campaign, so we enumerate via the party's enrolments.
+        enrolments.listByParty(partyId).forEach { enrolment ->
+            if (enrolment.state == EnrolmentState.ACTIVE) {
+                journeys.signalConsentRevoked(enrolment.campaignId, partyId)
             }
         }
         log.infof("Consent revoked for party %s — signalled live journeys", partyId)


### PR DESCRIPTION
## Symptom

A consent revocation could never terminate a running journey (ADR-0200 D2) — with the
authorization (#2911), the event payload (#2923) and the Temporal converter (#2949) all already
fixed, the consumer threw on its first database call:

```
InternalStateAssertions.assertUseOnEventLoop
  → PanacheEnrolmentRepository.listByParty (Persistence.kt:203)
  → ConsentEventConsumer.onConsentEvent (ConsentEventConsumer.kt:43)
```

Then:

```
SRMSG00200: The method ConsentEventConsumer#onConsentEvent has thrown an exception
SRMSG18203: A message sent to channel `consent-events-in` has been nacked, fail-stop
```

## Cause

`onConsentEvent` was a plain method wrapping `runBlocking`. SmallRye invokes it on a Kafka consumer
thread, which carries no Vert.x context, so reactive Panache refuses to open a session.

This is the footgun the fleet already documents for `@Scheduled` (#2190/#2191/#2194) — a Kafka
consumer is simply another place with no Vert.x context, and `runBlocking` hides it just as well.
The fix is the same one the fleet standardised on: a `suspend fun`.

## Why it was invisible

The nack is fail-stop, so the channel stopped consuming entirely. The only outward sign was
`SmallRye Reactive Messaging - readiness check: DOWN` inside a health payload — on a pod that stayed
`Running`, with no restart and no alert. Every later revocation was simply never processed.

## Context worth recording

This is the **fourth** independent defect on the same revocation path:

| # | What | Effect alone |
|---|------|--------------|
| #2911 | OPA rule could not fire | revoke → 403 |
| #2923 | `ConsentRevoked` carried no `scopes` | consumer filtered the event out |
| #2949 | Temporal could not deserialise Kotlin payloads | journey never advanced |
| this | consumer had no Vert.x context | consumer threw, channel stopped |

Any one of them made ADR-0200 D2 a no-op, and none was visible from a healthy-looking pod. That is
the argument in #2872, made concrete.

## Verification

`detekt ktlintCheck koverVerify build` green. The end-to-end proof needs this deployed; I will report
the enrolment state either way.

Refs #2749, ADR-0200