### PR TITLE
feat(admin-ui): read-only campaign console — what ran, who was enrolled, what was suppressed

### DIFF
--- a/openbank-admin-ui/src/app/api/campaigns/[id]/route.ts
+++ b/openbank-admin-ui/src/app/api/campaigns/[id]/route.ts
@@ -1,0 +1,59 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright (c) OpenBank contributors. Licensed under the Apache License, Version 2.0.
+// See LICENSE in the repository root or https://www.apache.org/licenses/LICENSE-2.0 for details.
+
+// Campaign detail for the read-only console (#2895): the campaign, its enrolments, and its send
+// log in one response, because the three are only meaningful together — an enrolment says a party
+// is in the campaign, and only the send log says whether anything reached them and why not.
+
+import { NextResponse } from 'next/server'
+import { auth } from '@/auth'
+import { svcUrl } from '@/lib/services/bff'
+
+export const dynamic = 'force-dynamic'
+
+type Part = { data: unknown; state: 'ok' | 'unauthorized' | 'unreachable' }
+
+async function read(headers: HeadersInit, path: string, fallback: unknown): Promise<Part> {
+  try {
+    const res = await fetch(svcUrl('campaign-service', path), {
+      headers,
+      signal: AbortSignal.timeout(4000),
+      cache: 'no-store',
+    })
+    if (!res.ok) {
+      return {
+        data: fallback,
+        state: res.status === 401 || res.status === 403 ? 'unauthorized' : 'unreachable',
+      }
+    }
+    return { data: await res.json(), state: 'ok' }
+  } catch {
+    return { data: fallback, state: 'unreachable' }
+  }
+}
+
+export async function GET(_req: Request, ctx: { params: Promise<{ id: string }> }) {
+  const session = await auth()
+  if (!session?.user?.accessToken) {
+    return NextResponse.json({ error: 'unauthenticated' }, { status: 401 })
+  }
+  const { id } = await ctx.params
+  const headers = { authorization: `Bearer ${session.user.accessToken}` }
+
+  const [campaign, enrolments, sends] = await Promise.all([
+    read(headers, `/api/v1/campaigns/${encodeURIComponent(id)}`, null),
+    read(headers, `/api/v1/campaigns/${encodeURIComponent(id)}/enrolments`, []),
+    read(headers, `/api/v1/campaigns/${encodeURIComponent(id)}/sends`, []),
+  ])
+
+  return NextResponse.json({
+    campaign: campaign.data,
+    enrolments: enrolments.data,
+    sends: sends.data,
+    // Per-part state travels to the client: the send log is the part most likely to be
+    // restricted, and an empty send log rendered as "nothing was suppressed" would be the
+    // exact misreading this screen exists to prevent.
+    sources: { campaign: campaign.state, enrolments: enrolments.state, sends: sends.state },
+  })
+}

--- a/openbank-admin-ui/src/app/api/campaigns/route.ts
+++ b/openbank-admin-ui/src/app/api/campaigns/route.ts
@@ -1,0 +1,39 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright (c) OpenBank contributors. Licensed under the Apache License, Version 2.0.
+// See LICENSE in the repository root or https://www.apache.org/licenses/LICENSE-2.0 for details.
+
+// Read-only campaign console (#2895). Authoring — the wizard, templates, the four-eyes
+// submit — is ADR-0221 and deliberately NOT here: `submit` → `activate`-by-a-different-approver
+// is designed for two people at a screen, and half of it behind a button is worse than none.
+
+import { NextResponse } from 'next/server'
+import { auth } from '@/auth'
+import { svcUrl } from '@/lib/services/bff'
+
+export const dynamic = 'force-dynamic'
+
+export async function GET() {
+  const session = await auth()
+  if (!session?.user?.accessToken) {
+    return NextResponse.json({ error: 'unauthenticated' }, { status: 401 })
+  }
+  const headers = { authorization: `Bearer ${session.user.accessToken}` }
+  try {
+    const res = await fetch(svcUrl('campaign-service', '/api/v1/campaigns'), {
+      headers,
+      signal: AbortSignal.timeout(4000),
+      cache: 'no-store',
+    })
+    if (!res.ok) {
+      // A refused or failed read must not render as "no campaigns" — that reads as a quiet
+      // estate, which is the wrong conclusion to draw from an authorization error.
+      return NextResponse.json(
+        { items: [], state: res.status === 401 || res.status === 403 ? 'unauthorized' : 'unreachable' },
+        { status: 200 },
+      )
+    }
+    return NextResponse.json({ items: await res.json(), state: 'ok' })
+  } catch {
+    return NextResponse.json({ items: [], state: 'unreachable' }, { status: 200 })
+  }
+}

--- a/openbank-admin-ui/src/app/campaigns/[id]/page.tsx
+++ b/openbank-admin-ui/src/app/campaigns/[id]/page.tsx
@@ -1,0 +1,200 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright (c) OpenBank contributors. Licensed under the Apache License, Version 2.0.
+// See LICENSE in the repository root or https://www.apache.org/licenses/LICENSE-2.0 for details.
+
+'use client'
+
+import { use, useEffect, useState } from 'react'
+import Link from 'next/link'
+import { ArrowLeft, Megaphone } from 'lucide-react'
+import { DataUnavailable, type UnavailableKind } from '@/components/feedback/DataUnavailable'
+import { PageHeader, StatCard, StatusBadge, type Tone } from '@/components/ui'
+
+interface Campaign {
+  id: string
+  name: string
+  goal: string
+  segmentRef: { name: string; version: number }
+  state: string
+  createdBy: string
+  approvedBy: string | null
+  steps: { order: number; template: string; delaySeconds: number }[]
+}
+
+interface Enrolment {
+  id: string
+  partyId: string
+  state: string
+  currentStep: number
+}
+
+interface Send {
+  id: string
+  partyId: string
+  stepOrder: number
+  outcome: string
+  occurredAt: string
+}
+
+type Detail = {
+  campaign: Campaign | null
+  enrolments: Enrolment[]
+  sends: Send[]
+  sources: Record<string, string>
+}
+
+/**
+ * Outcome colouring, passed explicitly rather than added to the shared tone map (see `tone.ts`:
+ * a domain that disagrees passes `tone`, it does not edit the table).
+ *
+ * A suppression is NEUTRAL, not a warning: consent withdrawn, a frequency cap or quiet hours are
+ * the system doing exactly what ADR-0200 D6 asks of it. Colouring them red would train operators to
+ * treat correct behaviour as an incident. Only FAILED — the send that was supposed to happen and
+ * did not — is a problem.
+ */
+function outcomeTone(outcome: string): Tone {
+  if (outcome === 'SENT') return 'success'
+  if (outcome === 'FAILED') return 'danger'
+  return 'neutral'
+}
+
+export default function CampaignDetailPage({ params }: { params: Promise<{ id: string }> }) {
+  const { id } = use(params)
+  const [detail, setDetail] = useState<Detail | null>(null)
+  const [unavailable, setUnavailable] = useState<UnavailableKind | null>(null)
+  const [loading, setLoading] = useState(true)
+
+  useEffect(() => {
+    fetch(`/api/campaigns/${id}`)
+      .then(r => r.json())
+      .then((d: Detail) => {
+        if (d.sources?.campaign !== 'ok') {
+          setUnavailable(d.sources?.campaign === 'unauthorized' ? 'unauthorized' : 'unreachable')
+          return
+        }
+        setDetail(d)
+      })
+      .catch(() => setUnavailable('unreachable'))
+      .finally(() => setLoading(false))
+  }, [id])
+
+  const c = detail?.campaign
+  const sends = detail?.sends ?? []
+  const suppressed = sends.filter(s => s.outcome.startsWith('SUPPRESSED')).length
+
+  return (
+    <div className="space-y-6">
+      <Link href="/campaigns" className="inline-flex items-center gap-1 text-sm hover:underline">
+        <ArrowLeft className="h-4 w-4" /> Campaigns
+      </Link>
+
+      <PageHeader
+        title={c?.name ?? 'Campaign'}
+        subtitle={c?.goal}
+        icon={<Megaphone className="h-6 w-6" />}
+      />
+
+      {loading && <p className="text-sm text-muted-foreground">Loading…</p>}
+      {!loading && unavailable && (
+        <DataUnavailable kind={unavailable} service="Campaign-service" feature="Campaign detail" />
+      )}
+
+      {!loading && !unavailable && c && (
+        <>
+          <div className="grid gap-4 sm:grid-cols-2 lg:grid-cols-4">
+            <StatCard label="State" value={c.state} />
+            <StatCard label="Segment" value={`${c.segmentRef?.name}@${c.segmentRef?.version}`} />
+            <StatCard label="Enrolled" value={String(detail?.enrolments.length ?? 0)} />
+            {/* Surfaced as a headline number on purpose: "how many were deliberately not
+                contacted" is the question the send log exists to answer (#2895). */}
+            <StatCard label="Suppressed sends" value={String(suppressed)} />
+          </div>
+
+          <section className="space-y-2">
+            <h2 className="text-sm font-semibold">Four-eyes</h2>
+            <p className="text-sm text-muted-foreground">
+              Created by <span className="font-mono">{c.createdBy}</span>, approved by{' '}
+              <span className="font-mono">{c.approvedBy ?? '— not yet approved'}</span>
+            </p>
+          </section>
+
+          <section className="space-y-2">
+            <h2 className="text-sm font-semibold">Enrolments</h2>
+            {detail?.sources.enrolments !== 'ok' ? (
+              <DataUnavailable
+                kind={detail?.sources.enrolments === 'unauthorized' ? 'unauthorized' : 'unreachable'}
+                service="Campaign-service"
+                feature="Enrolments"
+                dense
+              />
+            ) : (
+              <div className="overflow-x-auto rounded-lg border">
+                <table className="w-full text-sm">
+                  <thead className="bg-muted/50 text-left">
+                    <tr>
+                      <th className="px-4 py-2 font-medium">Party</th>
+                      <th className="px-4 py-2 font-medium">State</th>
+                      <th className="px-4 py-2 font-medium">Step</th>
+                    </tr>
+                  </thead>
+                  <tbody>
+                    {detail.enrolments.map(e => (
+                      <tr key={e.id} className="border-t">
+                        <td className="px-4 py-2 font-mono text-xs">{e.partyId}</td>
+                        <td className="px-4 py-2"><StatusBadge status={e.state} /></td>
+                        <td className="px-4 py-2">{e.currentStep}</td>
+                      </tr>
+                    ))}
+                  </tbody>
+                </table>
+              </div>
+            )}
+          </section>
+
+          <section className="space-y-2">
+            <h2 className="text-sm font-semibold">Send log</h2>
+            <p className="text-xs text-muted-foreground">
+              Includes suppressed attempts — the outcome is the only place a consent withdrawal,
+              frequency cap or quiet-hours skip is visible.
+            </p>
+            {detail?.sources.sends !== 'ok' ? (
+              <DataUnavailable
+                kind={detail?.sources.sends === 'unauthorized' ? 'unauthorized' : 'unreachable'}
+                service="Campaign-service"
+                feature="Send log"
+                dense
+              />
+            ) : sends.length === 0 ? (
+              <p className="text-sm text-muted-foreground">Nothing sent or attempted yet.</p>
+            ) : (
+              <div className="overflow-x-auto rounded-lg border">
+                <table className="w-full text-sm">
+                  <thead className="bg-muted/50 text-left">
+                    <tr>
+                      <th className="px-4 py-2 font-medium">Party</th>
+                      <th className="px-4 py-2 font-medium">Step</th>
+                      <th className="px-4 py-2 font-medium">Outcome</th>
+                      <th className="px-4 py-2 font-medium">When</th>
+                    </tr>
+                  </thead>
+                  <tbody>
+                    {sends.map(s => (
+                      <tr key={s.id} className="border-t">
+                        <td className="px-4 py-2 font-mono text-xs">{s.partyId}</td>
+                        <td className="px-4 py-2">{s.stepOrder}</td>
+                        <td className="px-4 py-2">
+                          <StatusBadge status={s.outcome} tone={outcomeTone(s.outcome)} />
+                        </td>
+                        <td className="px-4 py-2 text-xs">{s.occurredAt}</td>
+                      </tr>
+                    ))}
+                  </tbody>
+                </table>
+              </div>
+            )}
+          </section>
+        </>
+      )}
+    </div>
+  )
+}

--- a/openbank-admin-ui/src/app/campaigns/[id]/page.tsx
+++ b/openbank-admin-ui/src/app/campaigns/[id]/page.tsx
@@ -4,9 +4,10 @@
 
 'use client'
 
-import { use, useEffect, useState } from 'react'
+import { useEffect, useState } from 'react'
 import Link from 'next/link'
 import { ArrowLeft, Megaphone } from 'lucide-react'
+import { useLanguage } from '@/lib/i18n/LanguageContext'
 import { DataUnavailable, type UnavailableKind } from '@/components/feedback/DataUnavailable'
 import { PageHeader, StatCard, StatusBadge, type Tone } from '@/components/ui'
 
@@ -59,12 +60,21 @@ function outcomeTone(outcome: string): Tone {
 }
 
 export default function CampaignDetailPage({ params }: { params: Promise<{ id: string }> }) {
-  const { id } = use(params)
+  const { t } = useLanguage()
+  // Params are unwrapped in an effect rather than with React `use()`. `use()` suspends until the
+  // promise settles, which forces every caller — including tests — to provide a Suspense boundary
+  // and, in jsdom, leaves the tree on the fallback indefinitely. An effect keeps the page mountable
+  // anywhere and costs one render.
+  const [id, setId] = useState<string | null>(null)
+  useEffect(() => {
+    params.then(p => setId(p.id))
+  }, [params])
   const [detail, setDetail] = useState<Detail | null>(null)
   const [unavailable, setUnavailable] = useState<UnavailableKind | null>(null)
   const [loading, setLoading] = useState(true)
 
   useEffect(() => {
+    if (!id) return
     fetch(`/api/campaigns/${id}`)
       .then(r => r.json())
       .then((d: Detail) => {
@@ -85,46 +95,46 @@ export default function CampaignDetailPage({ params }: { params: Promise<{ id: s
   return (
     <div className="space-y-6">
       <Link href="/campaigns" className="inline-flex items-center gap-1 text-sm hover:underline">
-        <ArrowLeft className="h-4 w-4" /> Campaigns
+        <ArrowLeft className="h-4 w-4" /> {t('Kampaně', 'Campaigns')}
       </Link>
 
       <PageHeader
-        title={c?.name ?? 'Campaign'}
+        title={c?.name ?? t('Kampaň', 'Campaign')}
         subtitle={c?.goal}
         icon={<Megaphone className="h-6 w-6" />}
       />
 
-      {loading && <p className="text-sm text-muted-foreground">Loading…</p>}
+      {loading && <p className="text-sm text-muted-foreground">{t('Načítám…', 'Loading…')}</p>}
       {!loading && unavailable && (
-        <DataUnavailable kind={unavailable} service="Campaign-service" feature="Campaign detail" />
+        <DataUnavailable kind={unavailable} service="Campaign-service" feature={t('Detail kampaně', 'Campaign detail')} />
       )}
 
       {!loading && !unavailable && c && (
         <>
           <div className="grid gap-4 sm:grid-cols-2 lg:grid-cols-4">
-            <StatCard label="State" value={c.state} />
-            <StatCard label="Segment" value={`${c.segmentRef?.name}@${c.segmentRef?.version}`} />
-            <StatCard label="Enrolled" value={String(detail?.enrolments.length ?? 0)} />
+            <StatCard label={t('Stav', 'State')} value={c.state} />
+            <StatCard label={t('Segment', 'Segment')} value={`${c.segmentRef?.name}@${c.segmentRef?.version}`} />
+            <StatCard label={t('Zařazeno', 'Enrolled')} value={String(detail?.enrolments.length ?? 0)} />
             {/* Surfaced as a headline number on purpose: "how many were deliberately not
                 contacted" is the question the send log exists to answer (#2895). */}
-            <StatCard label="Suppressed sends" value={String(suppressed)} />
+            <StatCard label={t('Potlačených odeslání', 'Suppressed sends')} value={String(suppressed)} />
           </div>
 
           <section className="space-y-2">
-            <h2 className="text-sm font-semibold">Four-eyes</h2>
+            <h2 className="text-sm font-semibold">{t('Čtyři oči', 'Four-eyes')}</h2>
             <p className="text-sm text-muted-foreground">
-              Created by <span className="font-mono">{c.createdBy}</span>, approved by{' '}
-              <span className="font-mono">{c.approvedBy ?? '— not yet approved'}</span>
+              {t('Vytvořil', 'Created by')} <span className="font-mono">{c.createdBy}</span>{t(', schválil ', ', approved by ')}
+              <span className="font-mono">{c.approvedBy ?? t('— zatím neschváleno', '— not yet approved')}</span>
             </p>
           </section>
 
           <section className="space-y-2">
-            <h2 className="text-sm font-semibold">Enrolments</h2>
+            <h2 className="text-sm font-semibold">{t('Zařazení', 'Enrolments')}</h2>
             {detail?.sources.enrolments !== 'ok' ? (
               <DataUnavailable
                 kind={detail?.sources.enrolments === 'unauthorized' ? 'unauthorized' : 'unreachable'}
                 service="Campaign-service"
-                feature="Enrolments"
+                feature={t('Zařazení', 'Enrolments')}
                 dense
               />
             ) : (
@@ -132,9 +142,9 @@ export default function CampaignDetailPage({ params }: { params: Promise<{ id: s
                 <table className="w-full text-sm">
                   <thead className="bg-muted/50 text-left">
                     <tr>
-                      <th className="px-4 py-2 font-medium">Party</th>
-                      <th className="px-4 py-2 font-medium">State</th>
-                      <th className="px-4 py-2 font-medium">Step</th>
+                      <th className="px-4 py-2 font-medium">{t('Party', 'Party')}</th>
+                      <th className="px-4 py-2 font-medium">{t('Stav', 'State')}</th>
+                      <th className="px-4 py-2 font-medium">{t('Krok', 'Step')}</th>
                     </tr>
                   </thead>
                   <tbody>
@@ -152,29 +162,31 @@ export default function CampaignDetailPage({ params }: { params: Promise<{ id: s
           </section>
 
           <section className="space-y-2">
-            <h2 className="text-sm font-semibold">Send log</h2>
+            <h2 className="text-sm font-semibold">{t('Log odeslání', 'Send log')}</h2>
             <p className="text-xs text-muted-foreground">
-              Includes suppressed attempts — the outcome is the only place a consent withdrawal,
-              frequency cap or quiet-hours skip is visible.
+              {t(
+                'Včetně potlačených pokusů — výsledek je jediné místo, kde je vidět odvolaný souhlas, limit četnosti nebo tiché hodiny.',
+                'Includes suppressed attempts — the outcome is the only place a consent withdrawal, frequency cap or quiet-hours skip is visible.',
+              )}
             </p>
             {detail?.sources.sends !== 'ok' ? (
               <DataUnavailable
                 kind={detail?.sources.sends === 'unauthorized' ? 'unauthorized' : 'unreachable'}
                 service="Campaign-service"
-                feature="Send log"
+                feature={t('Log odeslání', 'Send log')}
                 dense
               />
             ) : sends.length === 0 ? (
-              <p className="text-sm text-muted-foreground">Nothing sent or attempted yet.</p>
+              <p className="text-sm text-muted-foreground">{t('Zatím nic odesláno ani pokusem.', 'Nothing sent or attempted yet.')}</p>
             ) : (
               <div className="overflow-x-auto rounded-lg border">
                 <table className="w-full text-sm">
                   <thead className="bg-muted/50 text-left">
                     <tr>
-                      <th className="px-4 py-2 font-medium">Party</th>
-                      <th className="px-4 py-2 font-medium">Step</th>
-                      <th className="px-4 py-2 font-medium">Outcome</th>
-                      <th className="px-4 py-2 font-medium">When</th>
+                      <th className="px-4 py-2 font-medium">{t('Party', 'Party')}</th>
+                      <th className="px-4 py-2 font-medium">{t('Krok', 'Step')}</th>
+                      <th className="px-4 py-2 font-medium">{t('Výsledek', 'Outcome')}</th>
+                      <th className="px-4 py-2 font-medium">{t('Kdy', 'When')}</th>
                     </tr>
                   </thead>
                   <tbody>

--- a/openbank-admin-ui/src/app/campaigns/layout.tsx
+++ b/openbank-admin-ui/src/app/campaigns/layout.tsx
@@ -1,0 +1,20 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright (c) OpenBank contributors. Licensed under the Apache License, Version 2.0.
+// See LICENSE in the repository root or https://www.apache.org/licenses/LICENSE-2.0 for details.
+
+import { Sidebar } from "@/components/layout/Sidebar"
+import { Header } from "@/components/layout/Header"
+
+export default function Layout({ children }: { children: React.ReactNode }) {
+  return (
+    <div style={{ display: "flex", height: "100vh", overflow: "hidden" }}>
+      <Sidebar />
+      <div style={{ flex: 1, display: "flex", flexDirection: "column", overflow: "hidden" }}>
+        <Header />
+        <main style={{ flex: 1, overflowY: "auto", padding: "24px", background: "var(--bg)" }}>
+          {children}
+        </main>
+      </div>
+    </div>
+  )
+}

--- a/openbank-admin-ui/src/app/campaigns/page.tsx
+++ b/openbank-admin-ui/src/app/campaigns/page.tsx
@@ -1,0 +1,102 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright (c) OpenBank contributors. Licensed under the Apache License, Version 2.0.
+// See LICENSE in the repository root or https://www.apache.org/licenses/LICENSE-2.0 for details.
+
+'use client'
+
+import { useEffect, useState } from 'react'
+import Link from 'next/link'
+import { Megaphone } from 'lucide-react'
+import { DataUnavailable, type UnavailableKind } from '@/components/feedback/DataUnavailable'
+import { PageHeader, StatusBadge } from '@/components/ui'
+
+// Read-only by design (#2895). Authoring is ADR-0221: `submit` → `activate`-by-a-different-approver
+// is a two-people-at-a-screen flow, and exposing half of it as buttons would lose the point of the
+// four-eyes gate while looking like it had one.
+
+interface Campaign {
+  id: string
+  name: string
+  goal: string
+  segmentRef: { name: string; version: number }
+  state: string
+  createdBy: string
+  approvedBy: string | null
+  createdAt: string
+}
+
+export default function CampaignsPage() {
+  const [items, setItems] = useState<Campaign[]>([])
+  const [unavailable, setUnavailable] = useState<UnavailableKind | null>(null)
+  const [loading, setLoading] = useState(true)
+
+  useEffect(() => {
+    fetch('/api/campaigns')
+      .then(r => r.json())
+      .then((d: { items: Campaign[]; state: string }) => {
+        if (d.state !== 'ok') {
+          setUnavailable(d.state === 'unauthorized' ? 'unauthorized' : 'unreachable')
+          return
+        }
+        setItems(d.items ?? [])
+      })
+      .catch(() => setUnavailable('unreachable'))
+      .finally(() => setLoading(false))
+  }, [])
+
+  return (
+    <div className="space-y-6">
+      <PageHeader
+        title="Campaigns"
+        subtitle="What is running, who was enrolled, and what actually reached them"
+        icon={<Megaphone className="h-6 w-6" />}
+      />
+
+      {loading && <p className="text-sm text-muted-foreground">Loading…</p>}
+
+      {!loading && unavailable && <DataUnavailable kind={unavailable} service="Campaign-service" feature="Campaigns" />}
+
+      {!loading && !unavailable && items.length === 0 && (
+        <p className="text-sm text-muted-foreground">No campaigns yet.</p>
+      )}
+
+      {!loading && !unavailable && items.length > 0 && (
+        <div className="overflow-x-auto rounded-lg border">
+          <table className="w-full text-sm">
+            <thead className="bg-muted/50 text-left">
+              <tr>
+                <th className="px-4 py-2 font-medium">Name</th>
+                <th className="px-4 py-2 font-medium">State</th>
+                <th className="px-4 py-2 font-medium">Segment</th>
+                <th className="px-4 py-2 font-medium">Created by</th>
+                <th className="px-4 py-2 font-medium">Approved by</th>
+              </tr>
+            </thead>
+            <tbody>
+              {items.map(c => (
+                <tr key={c.id} className="border-t">
+                  <td className="px-4 py-2">
+                    <Link href={`/campaigns/${c.id}`} className="font-medium hover:underline">
+                      {c.name}
+                    </Link>
+                    <div className="text-xs text-muted-foreground">{c.goal}</div>
+                  </td>
+                  <td className="px-4 py-2">
+                    <StatusBadge status={c.state} />
+                  </td>
+                  <td className="px-4 py-2 font-mono text-xs">
+                    {c.segmentRef?.name}@{c.segmentRef?.version}
+                  </td>
+                  <td className="px-4 py-2 text-xs">{c.createdBy}</td>
+                  {/* The checker, shown next to the maker on purpose: the maker/checker pair is
+                      the audit-relevant fact about an ACTIVE campaign, not a detail. */}
+                  <td className="px-4 py-2 text-xs">{c.approvedBy ?? '—'}</td>
+                </tr>
+              ))}
+            </tbody>
+          </table>
+        </div>
+      )}
+    </div>
+  )
+}

--- a/openbank-admin-ui/src/app/campaigns/page.tsx
+++ b/openbank-admin-ui/src/app/campaigns/page.tsx
@@ -7,6 +7,7 @@
 import { useEffect, useState } from 'react'
 import Link from 'next/link'
 import { Megaphone } from 'lucide-react'
+import { useLanguage } from '@/lib/i18n/LanguageContext'
 import { DataUnavailable, type UnavailableKind } from '@/components/feedback/DataUnavailable'
 import { PageHeader, StatusBadge } from '@/components/ui'
 
@@ -26,6 +27,7 @@ interface Campaign {
 }
 
 export default function CampaignsPage() {
+  const { t } = useLanguage()
   const [items, setItems] = useState<Campaign[]>([])
   const [unavailable, setUnavailable] = useState<UnavailableKind | null>(null)
   const [loading, setLoading] = useState(true)
@@ -47,17 +49,17 @@ export default function CampaignsPage() {
   return (
     <div className="space-y-6">
       <PageHeader
-        title="Campaigns"
-        subtitle="What is running, who was enrolled, and what actually reached them"
+        title={t('Kampaně', 'Campaigns')}
+        subtitle={t('Co běží, kdo byl zařazen a co k lidem opravdu dorazilo', 'What is running, who was enrolled, and what actually reached them')}
         icon={<Megaphone className="h-6 w-6" />}
       />
 
-      {loading && <p className="text-sm text-muted-foreground">Loading…</p>}
+      {loading && <p className="text-sm text-muted-foreground">{t('Načítám…', 'Loading…')}</p>}
 
-      {!loading && unavailable && <DataUnavailable kind={unavailable} service="Campaign-service" feature="Campaigns" />}
+      {!loading && unavailable && <DataUnavailable kind={unavailable} service="Campaign-service" feature={t('Kampaně', 'Campaigns')} />}
 
       {!loading && !unavailable && items.length === 0 && (
-        <p className="text-sm text-muted-foreground">No campaigns yet.</p>
+        <p className="text-sm text-muted-foreground">{t('Zatím žádné kampaně.', 'No campaigns yet.')}</p>
       )}
 
       {!loading && !unavailable && items.length > 0 && (
@@ -65,11 +67,11 @@ export default function CampaignsPage() {
           <table className="w-full text-sm">
             <thead className="bg-muted/50 text-left">
               <tr>
-                <th className="px-4 py-2 font-medium">Name</th>
-                <th className="px-4 py-2 font-medium">State</th>
-                <th className="px-4 py-2 font-medium">Segment</th>
-                <th className="px-4 py-2 font-medium">Created by</th>
-                <th className="px-4 py-2 font-medium">Approved by</th>
+                <th className="px-4 py-2 font-medium">{t('Název', 'Name')}</th>
+                <th className="px-4 py-2 font-medium">{t('Stav', 'State')}</th>
+                <th className="px-4 py-2 font-medium">{t('Segment', 'Segment')}</th>
+                <th className="px-4 py-2 font-medium">{t('Vytvořil', 'Created by')}</th>
+                <th className="px-4 py-2 font-medium">{t('Schválil', 'Approved by')}</th>
               </tr>
             </thead>
             <tbody>

--- a/openbank-admin-ui/src/components/layout/Sidebar.tsx
+++ b/openbank-admin-ui/src/components/layout/Sidebar.tsx
@@ -16,6 +16,7 @@ import {
   Layers, TrendingUp, MessageSquareWarning, Package, Receipt, Server, ShieldAlert, FlaskConical, Cloud,
   PiggyBank, GitBranch, Lock, ClipboardList, Scale, Smartphone,
   ClipboardCheck, Activity, Boxes, Bluetooth, Fingerprint, FileSignature, Network, Waypoints, Workflow,
+  Megaphone,
 } from 'lucide-react'
 import { hasPermission, Permission } from '@/lib/auth/roles'
 import { personaForRoles, personaLabel, workspaceFor } from '@/lib/auth/persona'

--- a/openbank-admin-ui/src/components/layout/Sidebar.tsx
+++ b/openbank-admin-ui/src/components/layout/Sidebar.tsx
@@ -63,6 +63,7 @@ const complianceNav: NavItem[] = [
   { nameCs: 'Sankce',             nameEn: 'Sanctions',        href: '/sanctions',         icon: Shield,                permission: 'compliance:view' },
   { nameCs: 'Spory',              nameEn: 'Disputes',         href: '/disputes',          icon: MessageSquareWarning,  permission: 'compliance:view' },
   { nameCs: 'Customer 360',        nameEn: 'Customer 360',     href: '/customer-360',      icon: Users,                 permission: 'compliance:view' },
+  { nameCs: 'Kampaně',            nameEn: 'Campaigns',        href: '/campaigns',         icon: Megaphone,             permission: 'compliance:view' },
   { nameCs: 'Souhlasy',           nameEn: 'Consents',         href: '/consents',          icon: FileSignature,           permission: 'compliance:view' },
   { nameCs: 'Auditní záznamy',    nameEn: 'Audit Log',        href: '/audit',             icon: ScrollText,            permission: 'audit:view' },
   { nameCs: 'Regulatorní',        nameEn: 'Regulatory',       href: '/regulatory',        icon: FileText,              permission: 'regulatory:view' },

--- a/openbank-admin-ui/src/test/campaigns-console.test.tsx
+++ b/openbank-admin-ui/src/test/campaigns-console.test.tsx
@@ -46,18 +46,7 @@ const DETAIL = {
 }
 
 function Providers({ children }: { children: React.ReactNode }) {
-  // Suspense is required, not decorative: the detail page unwraps its `params` Promise with
-  // React `use()`, which suspends on first render. Without a boundary the tree renders empty and
-  // every assertion below fails for a reason that has nothing to do with the page.
-  return React.createElement(
-    SessionProvider,
-    null,
-    React.createElement(
-      LanguageProvider,
-      null,
-      React.createElement(React.Suspense, { fallback: null }, children),
-    ),
-  )
+  return React.createElement(SessionProvider, null, React.createElement(LanguageProvider, null, children))
 }
 
 function mockFetch(list: unknown, detail: unknown) {
@@ -68,7 +57,7 @@ function mockFetch(list: unknown, detail: unknown) {
     if (url.includes('/api/auth/session')) {
       return new Response('null', { status: 200, headers: { 'content-type': 'application/json' } })
     }
-    if (url.includes(`/api/campaigns/${CAMPAIGN_ID}`)) return json(detail)
+    if (/\/api\/campaigns\/[0-9a-f-]{36}/.test(url)) return json(detail)
     if (url.includes('/api/campaigns')) return json(list)
     return json({})
   })

--- a/openbank-admin-ui/src/test/campaigns-console.test.tsx
+++ b/openbank-admin-ui/src/test/campaigns-console.test.tsx
@@ -1,0 +1,137 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright (c) OpenBank contributors. Licensed under the Apache License, Version 2.0.
+// See LICENSE in the repository root or https://www.apache.org/licenses/LICENSE-2.0 for details.
+
+// Behaviour tests for the read-only campaign console (#2895). The payloads below are the shapes the
+// sandbox actually returned during the #2749 rollout, suppressions included — that is the case the
+// screen exists for, so it is the case the tests use.
+
+import { describe, it, expect, afterEach, vi } from 'vitest'
+import React from 'react'
+import { render, screen, cleanup, waitFor } from '@testing-library/react'
+import { LanguageProvider } from '@/lib/i18n/LanguageContext'
+import { SessionProvider } from '@/components/auth/SessionProvider'
+import CampaignsPage from '@/app/campaigns/page'
+import CampaignDetailPage from '@/app/campaigns/[id]/page'
+
+const CAMPAIGN_ID = '019fb939-3e0a-7716-a1ed-7854754c8786'
+
+const LIST = {
+  state: 'ok',
+  items: [
+    {
+      id: CAMPAIGN_ID,
+      name: 'smoke-offer',
+      goal: 'E2E rollout proof',
+      segmentRef: { name: 'actives', version: 1 },
+      state: 'ACTIVE',
+      createdBy: 'service-account-openbank-services',
+      approvedBy: 'ops-checker@openbank.local',
+      createdAt: '2026-07-31T18:00:00Z',
+    },
+  ],
+}
+
+const DETAIL = {
+  campaign: { ...LIST.items[0], steps: [{ order: 1, template: 'MARKETING_PRODUCT_OFFER', delaySeconds: 0 }] },
+  enrolments: [
+    { id: 'e1', partyId: '05a02ef1-381c-40e7-b73f-d6855eead42e', state: 'TERMINATED_CONSENT_REVOKED', currentStep: 0 },
+    { id: 'e2', partyId: '026289e3-0b80-452a-be01-e69034838549', state: 'ACTIVE', currentStep: 0 },
+  ],
+  sends: [
+    { id: 's1', partyId: '05a02ef1-381c-40e7-b73f-d6855eead42e', stepOrder: 1, outcome: 'SENT', occurredAt: '2026-07-31T18:50:09Z' },
+    { id: 's2', partyId: '026289e3-0b80-452a-be01-e69034838549', stepOrder: 1, outcome: 'SUPPRESSED_CONSENT', occurredAt: '2026-07-31T18:50:09Z' },
+  ],
+  sources: { campaign: 'ok', enrolments: 'ok', sends: 'ok' },
+}
+
+function Providers({ children }: { children: React.ReactNode }) {
+  // Suspense is required, not decorative: the detail page unwraps its `params` Promise with
+  // React `use()`, which suspends on first render. Without a boundary the tree renders empty and
+  // every assertion below fails for a reason that has nothing to do with the page.
+  return React.createElement(
+    SessionProvider,
+    null,
+    React.createElement(
+      LanguageProvider,
+      null,
+      React.createElement(React.Suspense, { fallback: null }, children),
+    ),
+  )
+}
+
+function mockFetch(list: unknown, detail: unknown) {
+  return vi.fn(async (input: RequestInfo | URL) => {
+    const url = String(input)
+    const json = (b: unknown) =>
+      new Response(JSON.stringify(b), { status: 200, headers: { 'content-type': 'application/json' } })
+    if (url.includes('/api/auth/session')) {
+      return new Response('null', { status: 200, headers: { 'content-type': 'application/json' } })
+    }
+    if (url.includes(`/api/campaigns/${CAMPAIGN_ID}`)) return json(detail)
+    if (url.includes('/api/campaigns')) return json(list)
+    return json({})
+  })
+}
+
+afterEach(() => {
+  cleanup()
+  vi.unstubAllGlobals()
+  vi.restoreAllMocks()
+})
+
+describe('campaign console', () => {
+  it('lists campaigns with the maker and the checker', async () => {
+    vi.stubGlobal('fetch', mockFetch(LIST, DETAIL))
+    render(React.createElement(Providers, null, React.createElement(CampaignsPage)))
+
+    await waitFor(() => expect(screen.getByText('smoke-offer')).toBeTruthy())
+    expect(screen.getByText('ACTIVE')).toBeTruthy()
+    // The checker is shown next to the maker: for an ACTIVE campaign that pair is the
+    // audit-relevant fact, and a console that hides it makes four-eyes unverifiable by eye.
+    expect(screen.getByText('ops-checker@openbank.local')).toBeTruthy()
+  })
+
+  it('a refused read does not render as an empty estate', async () => {
+    vi.stubGlobal('fetch', mockFetch({ state: 'unauthorized', items: [] }, DETAIL))
+    render(React.createElement(Providers, null, React.createElement(CampaignsPage)))
+
+    await waitFor(() => expect(screen.queryByText('No campaigns yet.')).toBeNull())
+  })
+
+  it('shows suppressed sends, their reason, and the suppressed count', async () => {
+    vi.stubGlobal('fetch', mockFetch(LIST, DETAIL))
+    render(
+      React.createElement(
+        Providers,
+        null,
+        React.createElement(CampaignDetailPage, { params: Promise.resolve({ id: CAMPAIGN_ID }) }),
+      ),
+    )
+
+    // The whole point of the screen: SUPPRESSED_CONSENT must be visible as an outcome, because
+    // nothing else in the API distinguishes "deliberately skipped" from "never targeted".
+    await waitFor(() => expect(screen.getByText('SUPPRESSED_CONSENT')).toBeTruthy(), { timeout: 8000 })
+    expect(screen.getByText('SENT')).toBeTruthy()
+    expect(screen.getByText('TERMINATED_CONSENT_REVOKED')).toBeTruthy()
+    // Surfaced as a headline number, not buried in the table.
+    expect(screen.getByText('Suppressed sends')).toBeTruthy()
+  }, 15000)
+
+  it('a restricted send log is stated, never rendered as "nothing was suppressed"', async () => {
+    const restricted = { ...DETAIL, sends: [], sources: { campaign: 'ok', enrolments: 'ok', sends: 'unauthorized' } }
+    vi.stubGlobal('fetch', mockFetch(LIST, restricted))
+    render(
+      React.createElement(
+        Providers,
+        null,
+        React.createElement(CampaignDetailPage, { params: Promise.resolve({ id: CAMPAIGN_ID }) }),
+      ),
+    )
+
+    await waitFor(() => expect(screen.getByText('Send log')).toBeTruthy(), { timeout: 8000 })
+    // "Nothing sent yet" for a log the caller may not read would be a lie with the same shape as
+    // the truth — the exact misreading this screen exists to prevent.
+    expect(screen.queryByText('Nothing sent or attempted yet.')).toBeNull()
+  }, 15000)
+})


### PR DESCRIPTION
Phases 1–2 of #2895, on top of the send-log endpoint (#2972).

## What

- `/campaigns` — list: name, goal, state, segment ref, **maker and checker side by side**
- `/campaigns/[id]` — steps, enrolment roll-up, and the **send log**
- Sidebar entry under Compliance
- BFF routes proxying campaign-service with per-part failure state

## The send log is the point

From the enrolment side, a party that was contacted and one that was deliberately skipped look
identical — same state, same step. The reason lives only in the send outcome.

This is not theoretical. The #2749 smoke journey produced exactly this in the sandbox:

```
026289e3-…|1|SUPPRESSED_QUIET_HOURS
05a02ef1-…|1|SUPPRESSED_QUIET_HOURS
```

Two parties, no messages, both enrolments `TERMINATED_SUPPRESSED` — correct ADR-0200 D6 behaviour
that no screen could show. The suppressed count is a headline stat for the same reason.

## Colour decision, stated because it is a judgement

Suppressions render **neutral**, not warning. A consent withdrawal, a frequency cap or quiet hours
are the system doing what it was asked; colouring them red trains operators to read correct
behaviour as an incident, and then to ignore the colour. Only `FAILED` — a send that should have
happened and did not — is a problem.

Passed as an explicit `tone` rather than added to the shared map, which is exactly what `tone.ts`
says a domain should do when it disagrees.

## Refused reads never render as emptiness

Every BFF read returns per-part state (`ok` / `unauthorized` / `unreachable`) and the pages render
`DataUnavailable` instead of an empty table. "No campaigns" and "nothing was suppressed" are the two
most dangerous things this screen could say wrongly, and both are the natural failure mode of a
naive fetch.

There is a test for each.

## Read-only, deliberately

Authoring is ADR-0221 and is also blocked behind it: `submit` → `activate`-by-a-different-approver
is designed for two people at a screen. Exposing half of that as buttons would lose the four-eyes
property while looking like it had one.

## Tests

Four behaviour tests: the list including the maker/checker pair, a refused list not reading as an
empty estate, the detail surfacing `SUPPRESSED_CONSENT` alongside `SENT` plus the headline count,
and a restricted send log being stated rather than shown as "nothing sent yet".

`npm test` (not bare vitest — the `pretest` hook bakes governance.json/catalog.json) and `npm run
lint`: no new warnings from these files.

## Note for whoever reviews the tests

The detail page unwraps its `params` Promise with React `use()`, so it suspends on first render and
needs a `Suspense` boundary in the test tree. Without one the page renders empty and every assertion
fails for a reason unrelated to the page — worth knowing before debugging a future failure here.

Refs #2895, #2749