### PR TITLE
fix(campaign): start the journey before persisting the enrolment, and keep a bad party local

### DIFF
--- a/openbank-campaign-service/src/main/kotlin/com/openbank/campaign/application/usecase/CampaignService.kt
+++ b/openbank-campaign-service/src/main/kotlin/com/openbank/campaign/application/usecase/CampaignService.kt
@@ -17,8 +17,17 @@ import com.openbank.campaign.domain.model.EnrolmentState
 import com.openbank.campaign.domain.model.SegmentRef
 import com.openbank.libs.domain.identifiers.Ids
 import jakarta.enterprise.context.ApplicationScoped
+import org.jboss.logging.Logger
 import java.time.Instant
 import java.util.UUID
+
+/**
+ * What one `enrol` call actually did. [failed] exists so a partially failed enrolment cannot look
+ * like a small segment: the loop no longer aborts on the first bad party, and a caller that only
+ * ever saw `enrolled` would read "3 started" identically whether the other 40 were out of segment
+ * or blew up (#2953).
+ */
+data class EnrolmentOutcome(val enrolled: Int, val failed: Int)
 
 /**
  * Campaign lifecycle use cases (ADR-0200). State transitions are deterministic domain operations;
@@ -34,6 +43,8 @@ class CampaignService(
     private val segmentEvaluation: SegmentEvaluationPort,
     private val journeys: JourneySignaller,
 ) {
+
+    private val log = Logger.getLogger(CampaignService::class.java)
 
     suspend fun createDraft(
         name: String,
@@ -93,31 +104,54 @@ class CampaignService(
      * Enrols the segment's current membership: evaluates the versioned segment against the silver
      * layer and starts one journey per party. Re-enrolment of the same party is a no-op — the
      * workflow id is the idempotency key (ADR-0200 D1).
+     *
+     * Per party, the journey is started BEFORE the enrolment is persisted, and a failure is
+     * counted rather than thrown. Both are #2953: the reverse order left a committed `ACTIVE`
+     * enrolment with no workflow behind it, which the skip below then treated as already done
+     * forever, and the throw took out every party after the failing one.
      */
-    suspend fun enrol(id: UUID): Int {
+    // TooGenericExceptionCaught: the point is that ANY per-party fault stays local to that party —
+    // a Temporal namespace outage, a DB error, a bad segment row. Narrowing it re-opens the abort.
+    @Suppress("TooGenericExceptionCaught")
+    suspend fun enrol(id: UUID): EnrolmentOutcome {
         val campaign = campaigns.findById(id) ?: throw NoSuchElementException("campaign $id not found")
         check(campaign.state == CampaignState.ACTIVE) { "only an ACTIVE campaign can enrol (state: ${campaign.state})" }
         val segment = segments.load(campaign.segmentRef.name, campaign.segmentRef.version)
             ?: throw NoSuchElementException("segment ${campaign.segmentRef} not found")
         val partyIds = segmentEvaluation.evaluate(segment)
         var started = 0
+        var failed = 0
         for (partyId in partyIds) {
             if (enrolments.findByCampaignAndParty(id, partyId) != null) continue
-            enrolments.save(
-                Enrolment(
-                    id = Ids.newId(),
-                    campaignId = id,
-                    partyId = partyId,
-                    state = EnrolmentState.ACTIVE,
-                    currentStep = 0,
-                    startedAt = Instant.now(),
-                    completedAt = null,
-                ),
-            )
-            journeys.startJourney(id, partyId)
-            started++
+            try {
+                // Start FIRST, persist on success. The workflow id is the idempotency key
+                // (ADR-0200 D1) — `startJourney` swallows WorkflowExecutionAlreadyStarted — so a
+                // crash between these two lines costs a duplicate start that is a no-op, and the
+                // next `enrol` completes the pair. The reverse order costs a party: the row is
+                // already committed, the skip below sees it, and that party is never contacted and
+                // never retried (#2953).
+                journeys.startJourney(id, partyId)
+                enrolments.save(
+                    Enrolment(
+                        id = Ids.newId(),
+                        campaignId = id,
+                        partyId = partyId,
+                        state = EnrolmentState.ACTIVE,
+                        currentStep = 0,
+                        startedAt = Instant.now(),
+                        completedAt = null,
+                    ),
+                )
+                started++
+            } catch (e: Exception) {
+                // Per party, so one bad party is local rather than fatal: the loop used to abort on
+                // the first failure, leaving every party after it unenrolled by a fault that had
+                // nothing to do with them. The count returned is what actually started.
+                failed++
+                log.errorf(e, "campaign.enrol failed campaign=%s party=%s", id, partyId)
+            }
         }
-        return started
+        return EnrolmentOutcome(enrolled = started, failed = failed)
     }
 
     suspend fun listEnrolments(id: UUID): List<Enrolment> = enrolments.listByCampaign(id)

--- a/openbank-campaign-service/src/main/kotlin/com/openbank/campaign/infrastructure/rest/CampaignResource.kt
+++ b/openbank-campaign-service/src/main/kotlin/com/openbank/campaign/infrastructure/rest/CampaignResource.kt
@@ -109,9 +109,10 @@ class CampaignResource(private val service: CampaignService, private val jwt: Js
     @POST
     @Path("/{id}/enrol")
     @Authorize(action = "campaign.enrol", resource = "#id")
-    suspend fun enrol(@PathParam("id") id: UUID): Response =
-        runCatching { Response.ok(mapOf("enrolled" to service.enrol(id))).build() }
-            .getOrElse { Response.status(Response.Status.CONFLICT).entity(mapOf("error" to it.message)).build() }
+    suspend fun enrol(@PathParam("id") id: UUID): Response = runCatching {
+        val outcome = service.enrol(id)
+        Response.ok(mapOf("enrolled" to outcome.enrolled, "failed" to outcome.failed)).build()
+    }.getOrElse { Response.status(Response.Status.CONFLICT).entity(mapOf("error" to it.message)).build() }
 
     @GET
     @Path("/{id}/enrolments")

--- a/openbank-campaign-service/src/main/resources/openapi.yaml
+++ b/openbank-campaign-service/src/main/resources/openapi.yaml
@@ -4,7 +4,7 @@ openapi: 3.1.0
 info:
   title: Campaign Service API
   # major == openbank.api.version == URL /api/v1 (ADR-0048).
-  version: 1.1.0
+  version: 1.2.0
   description: >-
     Campaign management first slice (ADR-0200 / ADR-0209 D3): deterministic, versioned segments;
     per-enrolment Temporal journeys; consent-gated delivery through notification-service.
@@ -142,7 +142,10 @@ paths:
         - $ref: '#/components/parameters/CampaignId'
       responses:
         '200':
-          description: Number of journeys started
+          description: >-
+            What the call actually did. A party whose journey could not be started is counted in
+            `failed` rather than aborting the remaining parties, so `enrolled` alone can no longer
+            be mistaken for the size of the segment.
           content:
             application/json:
               schema:
@@ -150,6 +153,12 @@ paths:
                 properties:
                   enrolled:
                     type: integer
+                    description: Journeys started, each with its enrolment row committed.
+                  failed:
+                    type: integer
+                    description: >-
+                      Parties whose journey start or enrolment write threw. Nothing is persisted
+                      for them, so a later `enrol` retries them.
         '409':
           description: Campaign not ACTIVE
   /api/v1/campaigns/{id}/enrolments:

--- a/openbank-campaign-service/src/test/kotlin/com/openbank/campaign/application/CampaignEnrolmentFailureTest.kt
+++ b/openbank-campaign-service/src/test/kotlin/com/openbank/campaign/application/CampaignEnrolmentFailureTest.kt
@@ -1,0 +1,143 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright (c) OpenBank contributors. Licensed under the Apache License, Version 2.0.
+// See LICENSE in the repository root or https://www.apache.org/licenses/LICENSE-2.0 for details.
+
+package com.openbank.campaign.application
+
+import com.openbank.campaign.application.port.out.CampaignRepository
+import com.openbank.campaign.application.port.out.EnrolmentRepository
+import com.openbank.campaign.application.port.out.JourneySignaller
+import com.openbank.campaign.application.port.out.SegmentEvaluationPort
+import com.openbank.campaign.application.port.out.SegmentRegistry
+import com.openbank.campaign.application.usecase.CampaignService
+import com.openbank.campaign.application.usecase.EnrolmentOutcome
+import com.openbank.campaign.domain.model.Campaign
+import com.openbank.campaign.domain.model.CampaignState
+import com.openbank.campaign.domain.model.CampaignStep
+import com.openbank.campaign.domain.model.Channel
+import com.openbank.campaign.domain.model.Enrolment
+import com.openbank.campaign.domain.model.Segment
+import com.openbank.campaign.domain.model.SegmentRef
+import com.openbank.campaign.domain.model.SegmentRule
+import kotlinx.coroutines.runBlocking
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.Test
+import java.time.Instant
+import java.util.UUID
+
+/**
+ * Regression coverage for #2953 — a failed journey start used to strand its party forever.
+ *
+ * `enrol()` saved the enrolment row and *then* started the Temporal workflow. When the start threw
+ * (the #2749 rollout hit a missing Temporal namespace), the row was already committed with
+ * `state = ACTIVE, currentStep = 0` — identical to a healthy enrolment — and the loop's
+ * "already enrolled, skip" guard meant every later `enrol` call did nothing for that party. A
+ * party in a campaign with no workflow behind it is never contacted and never retried, and the
+ * only recovery was deleting the row by hand.
+ *
+ * Both halves are pinned here, because both were real: the ordering, and the loop aborting on the
+ * first bad party so one failure took out every party after it.
+ */
+class CampaignEnrolmentFailureTest {
+
+    private val campaignId = UUID.randomUUID()
+    private val parties = List(3) { UUID.randomUUID() }
+
+    private val campaign = Campaign(
+        id = campaignId,
+        name = "winback",
+        goal = "reactivate dormant parties",
+        segmentRef = SegmentRef("dormant-parties", 1),
+        steps = listOf(
+            CampaignStep(
+                order = 1,
+                template = "WINBACK_CS",
+                channel = Channel.EMAIL,
+                variables = emptyMap(),
+                delaySeconds = 0,
+            ),
+        ),
+        state = CampaignState.ACTIVE,
+        createdBy = "maker",
+        approvedBy = "checker",
+        createdAt = Instant.parse("2026-07-31T18:00:00Z"),
+        updatedAt = Instant.parse("2026-07-31T18:00:00Z"),
+    )
+
+    private val segment = Segment("dormant-parties", 1, listOf(SegmentRule.PartyStatusIs("ACTIVE")))
+
+    /** Records what was written, so the test can assert on absence as well as presence. */
+    private class RecordingEnrolments : EnrolmentRepository {
+        val saved = mutableListOf<Enrolment>()
+        override suspend fun findByCampaignAndParty(campaignId: UUID, partyId: UUID): Enrolment? =
+            saved.firstOrNull { it.campaignId == campaignId && it.partyId == partyId }
+        override suspend fun listByCampaign(campaignId: UUID): List<Enrolment> =
+            saved.filter { it.campaignId == campaignId }
+        override suspend fun listByParty(partyId: UUID): List<Enrolment> = saved.filter { it.partyId == partyId }
+        override suspend fun save(enrolment: Enrolment): Enrolment = enrolment.also { saved += it }
+    }
+
+    /** Fails for exactly [failFor], the way a missing Temporal namespace fails for every party. */
+    private class FlakyJourneys(private val failFor: Set<UUID>) : JourneySignaller {
+        val started = mutableListOf<UUID>()
+        override fun signalConsentRevoked(campaignId: UUID, partyId: UUID) = Unit
+        override fun startJourney(campaignId: UUID, partyId: UUID) {
+            check(partyId !in failFor) { "Namespace default is not found" }
+            started += partyId
+        }
+    }
+
+    private fun service(enrolments: EnrolmentRepository, journeys: JourneySignaller) = CampaignService(
+        campaigns = object : CampaignRepository {
+            override suspend fun findById(id: UUID): Campaign? = campaign.takeIf { it.id == id }
+            override suspend fun list(): List<Campaign> = listOf(campaign)
+            override suspend fun save(campaign: Campaign): Campaign = campaign
+        },
+        enrolments = enrolments,
+        segments = object : SegmentRegistry {
+            override suspend fun load(name: String, version: Int): Segment? = segment
+            override suspend fun save(segment: Segment): Segment = segment
+            override suspend fun list(): List<Segment> = listOf(segment)
+        },
+        segmentEvaluation = object : SegmentEvaluationPort {
+            override suspend fun evaluate(segment: Segment): List<UUID> = parties
+        },
+        journeys = journeys,
+    )
+
+    @Test
+    fun `a party whose journey start fails is left with no enrolment, so a later enrol retries it`(): Unit =
+        runBlocking {
+            val enrolments = RecordingEnrolments()
+            val outcome = service(enrolments, FlakyJourneys(setOf(parties[0]))).enrol(campaignId)
+
+            assertThat(enrolments.saved.map { it.partyId })
+                .describedAs(
+                    "an enrolment row for a party with no workflow is indistinguishable from a healthy " +
+                        "one and is skipped forever after — persist only once the journey started (#2953)",
+                )
+                .doesNotContain(parties[0])
+            assertThat(outcome.enrolled).isEqualTo(2)
+            assertThat(outcome.failed).isEqualTo(1)
+
+            // The retry: the same call again, with Temporal healthy, must pick that party back up.
+            val healthy = FlakyJourneys(emptySet())
+            val second = service(enrolments, healthy).enrol(campaignId)
+            assertThat(healthy.started).containsExactly(parties[0])
+            assertThat(second.enrolled).isEqualTo(1)
+            assertThat(second.failed).isZero()
+        }
+
+    @Test
+    fun `one failing party does not abort the parties after it`(): Unit = runBlocking {
+        val enrolments = RecordingEnrolments()
+        val journeys = FlakyJourneys(setOf(parties[0]))
+
+        val outcome = service(enrolments, journeys).enrol(campaignId)
+
+        assertThat(journeys.started)
+            .describedAs("the loop used to abort on the first failure, so parties 2 and 3 were never reached")
+            .containsExactly(parties[1], parties[2])
+        assertThat(outcome).isEqualTo(EnrolmentOutcome(enrolled = 2, failed = 1))
+    }
+}


### PR DESCRIPTION
Closes #2953 · Refs #2749, ADR-0200

## The defect

`enrol()` saved the enrolment row and *then* started the Temporal workflow. When the start threw, the row was already committed with `state = ACTIVE, currentStep = 0` — indistinguishable from a healthy enrolment — and the loop's "already enrolled, skip" guard meant every later `enrol` call did nothing for that party. **A party in a campaign with no workflow behind it is never contacted and never retried.** The only recovery was deleting the row by hand, which is what the #2749 rollout needed when the Temporal namespace turned out to be missing.

## The fix — option 1 from the issue

**Start first, persist on success.** The issue asked for the idempotency argument to be confirmed, so: `TemporalJourneySignaller.startJourney` sets the workflow id from `(campaignId, partyId)` and catches `WorkflowExecutionAlreadyStarted` as a debug-level no-op (ADR-0200 D1). A crash between the start and the save therefore costs a duplicate start that does nothing, and the next `enrol` completes the pair. The failure mode becomes a retry instead of a permanent gap.

**One bad party stays local.** The loop aborted on the first failure, so a fault with nothing to do with parties 2..N took them out too. Each party is now attempted independently.

**`failed` is reported, not swallowed.** `enrol` returns `EnrolmentOutcome(enrolled, failed)` and the endpoint returns both. Without it, a partially failed enrolment reads exactly like a small segment — the "component cannot express its own failure" shape.

## Evidence

`CampaignEnrolmentFailureTest` pins both halves, and both were verified fail-first — restoring the old body reddens both cases:

- the failing party has **no** enrolment row, and a second `enrol` with Temporal healthy picks it back up (`healthy.started == [party0]`);
- parties 2 and 3 still start when party 1 blows up.

`ktlintCheck`, `detekt`, `test`, `koverVerify`, `quarkusBuild` green.

## API note

Additive response field ⇒ `openapi.yaml` `info.version` 1.1.0 → **1.2.0** (ADR-0048; major stays 1, URL unchanged). Grepped the tree for consumers of the enrol response — admin-ui and the other services have none, so nothing breaks on the added key.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
