### PR TITLE
fix(analytics): grant the sink Read on the topics it actually subscribes to, and gate the pair

### DIFF
--- a/.github/scripts/check-kafka-acl-coverage.py
+++ b/.github/scripts/check-kafka-acl-coverage.py
@@ -1,0 +1,257 @@
+#!/usr/bin/env python3
+# SPDX-License-Identifier: Apache-2.0
+"""Every topic a service reads or writes must be covered by its own KafkaUser ACLs.
+
+Why this exists
+---------------
+`check-kafka-topics-exist.py` (#2598) closed one half of a two-list problem: a service must not
+name a topic that does not exist. This closes the other half — a service must not name a topic
+its Kafka principal is not allowed to touch.
+
+The two lists live in different trees and were kept in step by hand:
+
+    openbank-<svc>/src/main/resources/application.yaml   mp.messaging.{incoming,outgoing}.*.topic(s)
+    openbank-infra/gitops/**/KafkaUser                   spec.authorization.acls
+
+`analytics-sink` is the proof that hand-keeping does not hold. #2629 corrected its SUBSCRIPTION
+from the never-existing `openbank.account.events` / `openbank.transaction.events` to the real
+`openbank.accounts.account.created` / `openbank.transactions.transaction.initiated` — and left the
+ACL list on the dead names. So after the fix the sink was subscribed to the right topics with no
+Read on either of them (#2598).
+
+The broker runs `allow.everyone.if.no.acl.found=false`, and a denial here is as quiet as the
+missing topic was: the consumer retries, the pod stays ready, the group stays joined, lag reads
+zero, and every dashboard agrees the topic simply has no traffic.
+
+WHAT IT CHECKS
+--------------
+For each `openbank-*/src/main/resources/application.yaml`, each literal `openbank.*` topic under
+an `mp.messaging.incoming.*` channel needs `Read`, and each under `mp.messaging.outgoing.*` needs
+`Write`, from a KafkaUser whose name matches the service. `patternType: prefix` rules are honoured.
+
+WHAT IT DELIBERATELY DOES NOT CHECK
+-----------------------------------
+Topics a service names in code rather than in `application.yaml` (a dispatcher that derives the
+topic at runtime), and services with no KafkaUser at all — reported as `no KafkaUser` notices
+rather than failures, because "this service does not use the mTLS listener" is a legitimate state
+and this check cannot tell it apart from a missing user.
+
+Usage:  check-kafka-acl-coverage.py [--enforce] [--selftest]
+Advisory by default (prints ::warning, exits 0) per the repo convention; --enforce fails the build.
+"""
+
+from __future__ import annotations
+
+import argparse
+import pathlib
+import sys
+
+import yaml
+
+REPO = pathlib.Path(__file__).resolve().parents[2]
+GITOPS = REPO / "openbank-infra" / "gitops"
+
+# Coverage gaps that exist TODAY and are not fixed by this change, each with the reason it is a
+# separate piece of work. The list may only SHRINK: an entry that is no longer a gap is itself
+# reported, so a temporary exception cannot quietly become permanent (same idiom as the pact
+# gate's KNOWN_UNCOVERED and scheduled_methods' allowlists).
+#
+# These were found by this check on its first run and are NOT drive-by-fixable: granting a
+# principal a new topic permission is a live-broker change whose blast radius wants its own
+# review, and several of them may instead mean the service publishes over a different principal.
+# Tracked in #2598's follow-up.
+KNOWN_GAPS: dict[str, str] = {
+    "openbank-audit-service#openbank.cards.events#Read":
+        "audit subscribes to six payment/card/lending topics its KafkaUser predates; needs a "
+        "broker-side grant reviewed as one change (#2598 follow-up).",
+    "openbank-audit-service#openbank.domestic.payment.events#Read":
+        "same audit grant batch (#2598 follow-up).",
+    "openbank-audit-service#openbank.lending.events#Read":
+        "same audit grant batch (#2598 follow-up).",
+    "openbank-audit-service#openbank.payments.swift.event#Read":
+        "same audit grant batch (#2598 follow-up).",
+    "openbank-audit-service#openbank.sepa.instant.events#Read":
+        "same audit grant batch (#2598 follow-up).",
+    "openbank-audit-service#openbank.sepa.payment.events#Read":
+        "same audit grant batch (#2598 follow-up).",
+    "openbank-card-issuance-service#openbank.cards.events#Write":
+        "producer grant missing; card-issuance's KafkaUser carries only the party.events Read it "
+        "was created for (#2598 follow-up).",
+    "openbank-domestic-payment#openbank.domestic.payment.events#Write":
+        "producer grant missing; the KafkaUser carries only payment.scheme-accepted (#2598 "
+        "follow-up).",
+    "openbank-sepa-payment#openbank.sepa.payment.events#Write":
+        "producer grant missing; the KafkaUser carries only payment.scheme-accepted (#2598 "
+        "follow-up).",
+    "openbank-transaction-service#openbank.transactions.transaction.initiated#Write":
+        "producer grant missing; the KafkaUser carries only payment.scheme-accepted (#2598 "
+        "follow-up).",
+    "openbank-interest-service#openbank.interest.accrual.event#Read":
+        "self-consumed topic with no KafkaUser grant (#2598 follow-up).",
+    "openbank-sdd-service#openbank.sdd.event#Read":
+        "self-consumed topic with no KafkaUser grant (#2598 follow-up).",
+}
+
+
+def _walk(node: object, path: list[str], out: list[tuple[list[str], object]]) -> None:
+    if isinstance(node, dict):
+        for key, value in node.items():
+            _walk(value, path + [str(key)], out)
+    elif isinstance(node, list):
+        for value in node:
+            _walk(value, path, out)
+    else:
+        out.append((path, node))
+
+
+def required(app_yaml: pathlib.Path) -> set[tuple[str, str]]:
+    """{(topic, "Read"|"Write")} for one service, from its channel config.
+
+    The direction comes from the channel's own key (`incoming` vs `outgoing`), which is what makes
+    the operation checkable at all — a bare topic name says nothing about which way it flows.
+    """
+    try:
+        doc = yaml.safe_load(app_yaml.read_text(encoding="utf-8"))
+    except yaml.YAMLError:
+        return set()
+    flat: list[tuple[list[str], object]] = []
+    _walk(doc, [], flat)
+    out: set[tuple[str, str]] = set()
+    for path, value in flat:
+        if not path or path[-1] not in ("topic", "topics") or not isinstance(value, str):
+            continue
+        if "incoming" in path:
+            operation = "Read"
+        elif "outgoing" in path:
+            operation = "Write"
+        else:
+            continue
+        for name in value.split(","):
+            name = name.strip().strip("\"'")
+            if name.startswith("openbank.") and "$" not in name and "{" not in name:
+                out.add((name, operation))
+    return out
+
+
+def kafka_users() -> dict[str, list[tuple[str, str, set[str]]]]:
+    """{user: [(topic-or-prefix, patternType, {operations})]} across every KafkaUser CR."""
+    users: dict[str, list[tuple[str, str, set[str]]]] = {}
+    for path in GITOPS.rglob("*.yaml"):
+        try:
+            docs = list(yaml.safe_load_all(path.read_text(encoding="utf-8")))
+        except (yaml.YAMLError, UnicodeDecodeError):
+            continue
+        for doc in docs:
+            if not isinstance(doc, dict) or doc.get("kind") != "KafkaUser":
+                continue
+            name = (doc.get("metadata") or {}).get("name")
+            if not name:
+                continue
+            acls = ((doc.get("spec") or {}).get("authorization") or {}).get("acls") or []
+            for acl in acls:
+                if not isinstance(acl, dict):
+                    continue
+                resource = acl.get("resource") or {}
+                if resource.get("type") != "topic" or not resource.get("name"):
+                    continue
+                users.setdefault(name, []).append(
+                    (resource["name"], resource.get("patternType", "literal"), set(acl.get("operations") or [])),
+                )
+    return users
+
+
+def covers(topic: str, operation: str, rules: list[tuple[str, str, set[str]]]) -> bool:
+    for name, pattern, operations in rules:
+        matched = topic.startswith(name) if pattern == "prefix" else topic == name
+        if matched and operation in operations:
+            return True
+    return False
+
+
+def selftest() -> int:
+    """Feed `covers` inputs it MUST flag and inputs it must NOT.
+
+    Once the fleet is clean the flagging branch never executes again, and a gate that has only
+    ever passed is unfalsified — so this runs on every CI invocation.
+    """
+    rules = [
+        ("openbank.party.events", "literal", {"Read", "Describe"}),
+        ("openbank.payments.swift.", "prefix", {"Write", "Describe"}),
+    ]
+    cases = [
+        ("openbank.party.events", "Read", True),
+        ("openbank.party.events", "Write", False),        # right topic, wrong operation
+        ("openbank.parties.events", "Read", False),        # the #2598 shape: near-miss name
+        ("openbank.payments.swift.event", "Write", True),  # prefix rule
+        ("openbank.payments.swift.event", "Read", False),
+    ]
+    for topic, operation, expected in cases:
+        if covers(topic, operation, rules) != expected:
+            verb = "missed" if expected else "wrongly flagged"
+            print(f"selftest FAIL: {verb} {topic!r} {operation}")
+            return 1
+    if not kafka_users():
+        print("selftest FAIL: no KafkaUser CRs found — the scan itself is broken.")
+        return 1
+    print(f"selftest OK: {len(cases)} cases, both directions (flags the near-miss, spares the prefix match).")
+    return 0
+
+
+def main() -> int:
+    ap = argparse.ArgumentParser()
+    ap.add_argument("--enforce", action="store_true")
+    ap.add_argument("--selftest", action="store_true", help="verify the check can fail")
+    args = ap.parse_args()
+    if args.selftest:
+        return selftest()
+
+    users = kafka_users()
+    findings: list[str] = []
+    used_gaps: set[str] = set()
+    checked = 0
+
+    for app_yaml in sorted(REPO.glob("openbank-*/src/main/resources/application.yaml")):
+        service = app_yaml.parts[len(REPO.parts)]
+        wanted = required(app_yaml)
+        if not wanted:
+            continue
+        short = service.removeprefix("openbank-")
+        candidates = [u for u in users if u in (short, short.removesuffix("-service"))]
+        if not candidates:
+            print(f"::notice::{service} references {len(wanted)} topic(s) but has no KafkaUser — "
+                  f"not checkable here (it may not use the mTLS listener).")
+            continue
+        rules = [rule for user in candidates for rule in users[user]]
+        for topic, operation in sorted(wanted):
+            checked += 1
+            if covers(topic, operation, rules):
+                continue
+            key = f"{service}#{topic}#{operation}"
+            if key in KNOWN_GAPS:
+                used_gaps.add(key)
+                print(f"::notice::known gap {key}: {KNOWN_GAPS[key]}")
+                continue
+            findings.append(
+                f"::error file={app_yaml.relative_to(REPO)}::{service} uses {topic} "
+                f"({'consumes' if operation == 'Read' else 'produces'}) but its KafkaUser "
+                f"({'/'.join(candidates)}) has no {operation} ACL covering it. The broker runs "
+                f"allow.everyone.if.no.acl.found=false, so this is denied at runtime — silently, "
+                f"as a retry loop rather than a red pod (#2598).",
+            )
+
+    for key in sorted(set(KNOWN_GAPS) - used_gaps):
+        findings.append(
+            f"::error::stale KNOWN_GAPS entry {key} — that topic/operation is now covered (or no "
+            f"longer referenced). Remove it, so the list can only shrink.",
+        )
+
+    for line in findings:
+        print(line if args.enforce else line.replace("::error", "::warning", 1))
+    verdict = "clean." if not findings else f"{len(findings)} finding(s) above."
+    print(f"check-kafka-acl-coverage: {checked} (topic, operation) pair(s) checked across "
+          f"{len(users)} KafkaUser(s), {len(KNOWN_GAPS)} known gap(s) — {verdict}")
+    return 1 if findings and args.enforce else 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -682,6 +682,17 @@ jobs:
       - name: "Kafka topic existence (issue #2598, enforced)"
         run: python3 .github/scripts/check-kafka-topics-exist.py --enforce
 
+      # The other half of the same two-list problem (#2598). Correcting analytics-sink's SUBSCRIPTION
+      # to the real topic names left its KafkaUser ACLs on the dead ones, so the sink asked for
+      # topics its own principal had no Read on — and a denial is as quiet as the missing topic was:
+      # a retry loop, never a red pod. Enforced, with the pre-existing gaps enumerated in the
+      # script's KNOWN_GAPS (shrink-only, stale entries reported) rather than left as a warning
+      # nobody reads.
+      - name: "Kafka ACL coverage self-test (issue #2598)"
+        run: python3 .github/scripts/check-kafka-acl-coverage.py --selftest
+      - name: "Kafka ACL coverage (issue #2598, enforced)"
+        run: python3 .github/scripts/check-kafka-acl-coverage.py --enforce
+
       # issue #2370. The admin-ui compliance matrix is a hardcoded literal and nothing verified any
       # of its rows. 16 of 39 `ok` rows cited a database column that exists only in a Flyway
       # migration — evidence of a schema, not of a control, on AML/KYC/FATCA rows (SAR filing, MLRO

--- a/openbank-infra/gitops/components/analytics/kafka-analytics-sink-mtls.yaml
+++ b/openbank-infra/gitops/components/analytics/kafka-analytics-sink-mtls.yaml
@@ -27,10 +27,17 @@ spec:
     acls:
       # Read-only consumer across the analytics ingest topics (analytics-sink application.yaml
       # `topics:` list). Describe is required alongside Read for metadata/offset fetch.
-      - resource: { type: topic, name: openbank.account.events, patternType: literal }
+      #
+      # These two carried the dead names `openbank.account.events` / `openbank.transaction.events`
+      # (issue #2598). #2629 corrected the SUBSCRIPTION to the real topics but left this list
+      # behind, so the sink asked for topics its own principal had no Read on — the second half of
+      # the same drift, and just as quiet: an authorization failure here is a retry loop in the
+      # consumer, never a red pod. `check-kafka-acl-coverage.py` now derives this list from the
+      # service's own channel config so the two cannot disagree again.
+      - resource: { type: topic, name: openbank.accounts.account.created, patternType: literal }
         operations: [Read, Describe]
         host: "*"
-      - resource: { type: topic, name: openbank.transaction.events, patternType: literal }
+      - resource: { type: topic, name: openbank.transactions.transaction.initiated, patternType: literal }
         operations: [Read, Describe]
         host: "*"
       - resource: { type: topic, name: openbank.balance.events, patternType: literal }


### PR DESCRIPTION
Refs #2598 — this is **ask 3**, "establish why ACCOUNT_OPENED, CONSENT and TRANSACTION events are absent". Asks 1 and 2 shipped in #2630.

## What was still wrong

#2629 corrected analytics-sink's **subscription** from the never-existing `openbank.account.events` / `openbank.transaction.events` to the real `openbank.accounts.account.created` / `openbank.transactions.transaction.initiated`. It left the **KafkaUser ACLs** on the dead names:

```yaml
# before — components/analytics/kafka-analytics-sink-mtls.yaml
- resource: { type: topic, name: openbank.account.events, ... }      # never existed
- resource: { type: topic, name: openbank.transaction.events, ... }  # never existed
```

So after the topic fix the sink was subscribed to the right topics with **no Read on either of them**. The broker runs `allow.everyone.if.no.acl.found=false`, and a denial is as quiet as the missing topic was: a retry loop in the consumer, pod ready, group joined, lag flat. That is why the reported symptom — zero ACCOUNT rows carrying `partyId`, zero TRANSACTION rows — outlived the name correction.

CONSENT is a separate story: its ACL is and was correct, so its absence is about production, not authorization. Not claimed as resolved here.

## The generalisation

Two hand-kept lists, in different trees, with nothing making them agree:

| list | lives in |
|---|---|
| what the service subscribes/publishes to | `openbank-<svc>/src/main/resources/application.yaml` |
| what its principal may touch | `openbank-infra/gitops/**` `KafkaUser.spec.authorization.acls` |

`check-kafka-acl-coverage.py` derives the second from the first: every `openbank.*` topic under an `mp.messaging.incoming.*` channel needs `Read`, every one under `outgoing.*` needs `Write`, honouring `patternType: prefix`. This is the sibling of `check-kafka-topics-exist.py` from the same issue — that one asks "does the name exist", this one asks "may you touch it".

**Validated both directions.** Reverting just the ACL edit makes it print two `::error` lines naming exactly those topics; with the fix it reports `85 (topic, operation) pair(s) checked across 35 KafkaUser(s) — clean.` The `--selftest` (run on every CI invocation, like its sibling) feeds it a near-miss name it must flag and a prefix match it must not, so the flagging branch keeps executing after the fleet goes clean.

## The twelve gaps it found — deliberately not fixed here

| service | topic | op |
|---|---|---|
| audit-service | cards / domestic.payment / lending / swift / sepa.instant / sepa.payment events | Read ×6 |
| card-issuance, domestic-payment, sepa-payment, transaction-service | their own outgoing topic | Write ×4 |
| interest-service, sdd-service | self-consumed topic | Read ×2 |

They are enumerated in `KNOWN_GAPS` with reasons. Granting a principal a new topic permission is a live-broker change whose blast radius wants its own review, and several may instead mean the service publishes under a different principal than its name suggests — I could not settle that from the repo alone, and guessing would be the wrong kind of confident. The list may only **shrink**: a stale entry is itself a finding, so this cannot quietly become permanent.

Worth a follow-up issue to drain it; I did not want to bundle a fleet-wide broker permission change into a fix for one sink.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
