### PR TITLE
ci(gitops): make the SBOM-attestation gate binding on the deploy, not a race against it

### DIFF
--- a/.github/workflows/auto-deploy.yml
+++ b/.github/workflows/auto-deploy.yml
@@ -608,6 +608,39 @@ jobs:
             exit 1
           }
 
+      # Fleet SBOM attestation — the gate that binds the deploy (issue #2947).
+      #
+      # `fleet-attestation.yml` runs exactly this check on gitops PRs, and it is not one of the
+      # five required contexts — it cannot be, being `paths:`-filtered, since GitHub holds a
+      # path-filtered required context as permanently "Expected". So the auto-deploy snapshot PR
+      # auto-merged without waiting for it: measured, 8 of the last 10 merged 24-65 s BEFORE the
+      # gate finished. All eight passed, which is luck about timing rather than a property of the
+      # process.
+      #
+      # What that risks is not a red deploy. Kyverno verifies at ADMISSION, not continuously, so
+      # an unattested image whose pods are already running keeps running, and is denied the next
+      # time anything reschedules it — a deploy that looks fine for days and then cannot come
+      # back. That is the admin-ui outage of 2026-07-09.
+      #
+      # HERE rather than in `Validate manifests`: this is the earliest point at which the answer
+      # can be known, and the PR then cannot exist for an unattested fleet at all. It also needs
+      # no new permission — this job already holds `id-token: write` and an ECR login for the
+      # push and the attestation above — whereas the required-check placement would have put
+      # `id-token: write` on a job that runs on every PR in the repo.
+      #
+      # AFTER the attestation step, never racing it: #1226 is exactly what a cancellation between
+      # `Docker push` and `Attest image SBOMs` costs. The images built by THIS run are already
+      # proven by that step (it binds the verify to the serialNumber trivy minted per image); what
+      # this adds is every OTHER image the fleet still declares, which is where a latent gap
+      # actually hides. A failure here fails `build-push`, and `gitops-pr` needs it — so no
+      # manifest PR is opened.
+      #
+      # The daily schedule on `fleet-attestation.yml` stays, and is not made redundant: a latent
+      # gap can appear with no deploy at all (a registry lifecycle rule, a hand-pushed image).
+      - name: Fleet SBOM attestation gate (issue #2947)
+        timeout-minutes: 20  # measured max 198s on the same check in fleet-attestation.yml
+        run: bash .github/scripts/check-fleet-attestations.sh
+
       - name: Collect image tags
         id: collect
         run: |


### PR DESCRIPTION
Closes #2947 · Refs #1226, #1228

**Revised to option 3** after review feedback — the earlier version put the binding copy in `Validate manifests` and needed `id-token: write` on a job that runs on every PR in the repo. This version adds no permission anywhere. Diff is now a single file, 33 added lines, all in `auto-deploy.yml`.

## The problem

`fleet-attestation.yml` already runs exactly the right gate on gitops PRs. It is simply not one of the five required contexts, and it cannot be: it is `paths:`-filtered, and GitHub holds a path-filtered required context as permanently "Expected". So auto-deploy snapshot PRs auto-merged without waiting for it — **8 of the last 10 merged 24–65 s before the gate finished**. All eight passed, which is luck about timing rather than a property of the process.

What that risks is not a red deploy. Kyverno verifies at **admission**, not continuously, so an unattested image whose pods are already running keeps running — and is denied the next time anything reschedules it. A deploy that looks fine for days and then cannot come back is the admin-ui outage of 2026-07-09.

## Where it goes and why

Inside `auto-deploy.yml`'s `build-push` job, immediately **after** `Attest image SBOMs` and before `Collect image tags`. The manifest PR then cannot exist for an unattested fleet at all — `gitops-pr` has `needs: [changes, build-push, can-i-deploy]`, so a failure here opens no PR.

- **After the attestation, never racing it.** #1226 is precisely what a cancellation between `Docker push` and `Attest image SBOMs` costs, and the issue flags this as the care option 3 needs.
- **No new permission.** `build-push` already carries `id-token: write` plus an ECR login, for the push and the attestation it performs anyway.
- **What each half covers.** The images *this run* built are already proven by the attestation step, which binds its verify to the CycloneDX `serialNumber` trivy mints per image (the #1197 hardening — `cosign attest` appends, so a bare `verify-attestation` would pass on an earlier envelope). What this step adds is every **other** image the fleet still declares, which is where a latent gap actually hides.
- **The daily schedule stays and is not redundant.** A latent gap can appear with no deploy at all — a registry lifecycle rule, a hand-pushed image — and no deploy-time gate can see that.

## Falsified before shipping

The issue asked for this explicitly, and it is the repo's own rule about unfalsified gates:

| case | result |
|---|---|
| stubbed cosign reports one image unattested | `FLEET ATTESTATION GATE: FAIL — 1 of 59 declared image(s) not deployable`, **exit 1**, image named |
| stubbed cosign reports all attested | `58 attested / 0 unattested`, **exit 0** |

The stub itself was validated against a known positive first — it must exit 1 for the target image and 0 for the others. A silently-passing stub would either have run the real cosign or proved nothing.

`actionlint` finding count on `auto-deploy.yml` is unchanged from `origin/main` (1, the pre-existing custom `openbank-build` runner label); `yamllint` clean.

## Trade-off accepted with this placement

A hand-written gitops PR that bumps an image tag without going through `auto-deploy.yml` is not covered at merge time — only by the daily `fleet-attestation.yml` run and by the path-filtered PR run, whose verdict stays advisory. Option 1 would have covered that path too, at the cost of the `id-token` grant on the universal required job. That is the deliberate call here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
