### PR TITLE
ci(security): two-phase cached build for the CodeQL java-kotlin leg

### DIFF
--- a/.github/workflows/security.yml
+++ b/.github/workflows/security.yml
@@ -165,21 +165,31 @@ jobs:
       # This repo has `org.gradle.caching=true` + a remote HTTP build cache
       # (settings.gradle.kts) fleet-wide; autobuild's `./gradlew testClasses` was
       # intermittently satisfied entirely from the build cache, so javac/kotlinc
-      # never ran, the extractor traced zero compilations, and GitHub recorded the
-      # analysis as "unsuccessful execution, exit code: 0" (0 rules, 0 results) —
-      # the empty result then sits as the default branch's "current" CodeQL state
-      # until the next code-touching main push, showing as a code-scanning
-      # configuration error. --no-build-cache forces a real compile every run.
-      # Wrapped in the heap sampler (#2177 problem 1, #2330). This job is the one that keeps
-      # coming back `cancelled` with no failing step while every other job in the same run
-      # succeeds — the signature of a runner killed rather than a build that failed. It compiles
-      # the whole fleet with `--no-build-cache` at `-Xmx6g` alongside the Kotlin daemon and the
-      # per-task worker JVMs, and nothing has ever recorded what that actually costs. Now it does,
-      # in the job summary, whether or not the run is healthy. Advisory only: the sampler exits
-      # with Gradle's exit code and never its own.
+      # Cache the Gradle build between runs (same setup-gradle as the service CI). The
+      # cold --no-build-cache leg took ~25-30 min of wall time and was the single most
+      # preemption-exposed job in the fleet (killed mid-analysis twice in a row,
+      # run 30666238087, attempt 2 also cancelled). A warm cache cuts the leg to a few
+      # minutes; the two-phase step below keeps the empty-analysis guard that the cold
+      # flag was protecting (a run where every compile resolves FROM-CACHE would trace
+      # zero compilations and record an empty CodeQL analysis).
+      - uses: gradle/actions/setup-gradle@3f131e8634966bd73d06cc69884922b02e6faf92 # v6.2.0
+        if: matrix.language == 'java-kotlin'
+
+      # Two-phase: try the cached build; if NO compile task actually executed (all
+      # FROM-CACHE/UP-TO-DATE — grep anchors on the line end so FROM-CACHE rows don't
+      # count), fall back to the cold compile so the CodeQL trace stays non-empty.
       - name: Build (java-kotlin) for CodeQL tracing
         if: matrix.language == 'java-kotlin'
-        run: .github/scripts/gradle-heap-headroom.sh codeql-java-kotlin -- ./gradlew testClasses --no-build-cache --no-daemon
+        run: |
+          set -euo pipefail
+          .github/scripts/gradle-heap-headroom.sh codeql-java-kotlin -- ./gradlew testClasses --no-daemon 2>&1 | tee "${RUNNER_TEMP:-/tmp}/codeql-build.log"
+          executed=$( { grep -c '> Task :.*:compileKotlin$' "${RUNNER_TEMP:-/tmp}/codeql-build.log" || true; } )
+          if [ "$executed" -eq 0 ]; then
+            echo "::warning::every compile resolved from cache — cold re-run so the CodeQL trace is non-empty"
+            .github/scripts/gradle-heap-headroom.sh codeql-java-kotlin -- ./gradlew testClasses --no-build-cache --no-daemon
+          else
+            echo "compile tasks executed: $executed"
+          fi
 
       - uses: github/codeql-action/analyze@e4fba868fa4b1b91e1fdab776edc8cfbe6e9fb81 # v4
         with:


### PR DESCRIPTION
## Summary

Fixes the recurring real CodeQL (java-kotlin) failure: the leg was spot-killed mid-analysis **twice in a row** on run 30666238087 (attempt 1 auto-retried by `auto-retry-cancelled.yml`, attempt 2 cancelled again — the exact spot-kill signature: 1 cancelled step, 0 failed steps). The root enabler is the ~25-30 min cold `--no-build-cache` full-fleet compile on ubuntu-latest — the largest preemption window in the fleet.

## Type of change

- [ ] feat (new functionality)
- [x] fix (bug fix)
- [ ] refactor (no behavior change)
- [ ] perf (performance)
- [ ] docs
- [x] chore (build / tooling)
- [ ] security (private until disclosed)
- [ ] breaking change

## Linked issues

N/A — CI robustness fix; the failure mode is documented in the commit.

## Changes

- **Diagnosis (verified against run 30666238087):** the 23m42s "real failure" was `The runner has received a shutdown signal / The operation was canceled` at ~24 min — a GitHub-hosted runner preemption, **on attempt 2** (the auto-retry mechanism already worked and was itself preempted). The dependency-verification warnings earlier in the log (hibernate-platform 7.4.5.Final, jackson 2.18.2) are non-fatal and unrelated.
- **Fix:** add `gradle/actions/setup-gradle` (same SHA-pinned v6.2.0 as the service CI) so the build runs **cached**, cutting the leg to a few minutes.
- **Guard preserved:** the original `--no-build-cache` choice protected against a fully-cached run tracing **zero compilations** (an empty CodeQL analysis recorded as a code-scanning configuration error). The step is now two-phase: cached build first; if **no `compileKotlin` task actually executed** (grep anchored at line end so `FROM-CACHE`/`UP-TO-DATE` rows don't count), it falls back to the cold `--no-build-cache` compile.

## Definition of Done

- [ ] Hexagonal layering preserved (domain has zero framework imports). — N/A (CI YAML)
- [ ] Unit tests added/updated. — N/A
- [ ] Integration tests added/updated (if service boundary involved). — N/A
- [ ] Contract tests updated (if public API changed). — N/A
- [x] `./gradlew detekt ktlintCheck koverVerify build` passes. — N/A (no service change); the change itself is exercised by this PR's own CodeQL run
- [x] No new lint warnings.
- [ ] OpenAPI spec regenerated (if REST API changed). — N/A
- [ ] Flyway migration added + rollback note (if DB changed). — N/A
- [ ] Avro schema versioned backward-compatibly (if event changed). — N/A
- [x] Docs updated (README, ADR if architectural). — rationale captured inline in the workflow

## Security checklist

- [x] No secrets, tokens, passwords, or PII in code, config, tests, logs.
- [x] No new `@SuppressWarnings`, `as Any`, `@Suppress("...")` without justification (state it in this PR).
- [x] No new third-party dependency, OR: dependency review attached (license, CVE, source). (setup-gradle is already used SHA-pinned in 3 workflows — same pin)
- [ ] Auth / crypto / payment code changed? → tag `security-review-required`.
- [ ] PII path changed? → tag `gdpr-review-required`.
- [ ] Cardholder data path changed? → tag `pci-review-required`.

## Compliance impact

- [ ] PCI DSS
- [ ] DORA
- [ ] GDPR
- [ ] PSD2 / SCA / RTS
- [ ] AML / 5AMLD
- [ ] CNB reporting
- [x] None

## Rollout / Rollback

- Deployment strategy: merges to main; next Security scan run uses the new step.
- Rollback plan: revert this PR (single-file change).
- Data migration reversible: N/A

## Reviewer notes

- Self-verifying: this PR's own CodeQL run exercises the new cached path (first run populates the cache; a subsequent re-run of the job would show the fast path).
- The remaining hygiene item (deliberately NOT in this PR): `gradle/verification-metadata.xml` misses entries for `hibernate-platform:7.4.5.Final` and `jackson-*:2.18.2` (.module/.pom) — currently warnings, one strictness flip away from fleet-wide failures.