### PR TITLE
fix(admin-ui): register campaign-service in the BFF map, and guard the direction nobody checked

### DIFF
--- a/openbank-admin-ui/src/app/api/campaigns/[id]/route.ts
+++ b/openbank-admin-ui/src/app/api/campaigns/[id]/route.ts
@@ -12,7 +12,7 @@ import { svcUrl } from '@/lib/services/bff'
 
 export const dynamic = 'force-dynamic'
 
-type Part = { data: unknown; state: 'ok' | 'unauthorized' | 'unreachable' }
+type Part = { data: unknown; state: 'ok' | 'unauthorized' | 'not_deployed' | 'unreachable' }
 
 async function read(headers: HeadersInit, path: string, fallback: unknown): Promise<Part> {
   try {
@@ -24,7 +24,15 @@ async function read(headers: HeadersInit, path: string, fallback: unknown): Prom
     if (!res.ok) {
       return {
         data: fallback,
-        state: res.status === 401 || res.status === 403 ? 'unauthorized' : 'unreachable',
+        state: res.status === 401 || res.status === 403
+            ? 'unauthorized'
+            // 404 from the BFF proxy means the service key resolved to nothing — "not deployed",
+            // NOT "deployed but silent". Collapsing the two sends whoever debugs it to look at a
+            // healthy pod, which is exactly what happened when campaign-service was missing from
+            // SERVICE_MAP (#2997).
+            : res.status === 404
+              ? 'not_deployed'
+              : 'unreachable',
       }
     }
     return { data: await res.json(), state: 'ok' }

--- a/openbank-admin-ui/src/app/api/campaigns/route.ts
+++ b/openbank-admin-ui/src/app/api/campaigns/route.ts
@@ -28,7 +28,15 @@ export async function GET() {
       // A refused or failed read must not render as "no campaigns" — that reads as a quiet
       // estate, which is the wrong conclusion to draw from an authorization error.
       return NextResponse.json(
-        { items: [], state: res.status === 401 || res.status === 403 ? 'unauthorized' : 'unreachable' },
+        { items: [], state: res.status === 401 || res.status === 403
+            ? 'unauthorized'
+            // 404 from the BFF proxy means the service key resolved to nothing — "not deployed",
+            // NOT "deployed but silent". Collapsing the two sends whoever debugs it to look at a
+            // healthy pod, which is exactly what happened when campaign-service was missing from
+            // SERVICE_MAP (#2997).
+            : res.status === 404
+              ? 'not_deployed'
+              : 'unreachable' },
         { status: 200 },
       )
     }

--- a/openbank-admin-ui/src/app/api/svc/[service]/[...path]/route.ts
+++ b/openbank-admin-ui/src/app/api/svc/[service]/[...path]/route.ts
@@ -42,6 +42,7 @@ const SERVICE_MAP: Record<string, { container: string; port: number }> = {
   'clearing-service':       { container: 'openbank-clearing-service',       port: 8124 },
   'interest-service':       { container: 'openbank-interest-service',       port: 8125 },
   'lending-service':        { container: 'openbank-lending-service',        port: 8126 },
+  'campaign-service':       { container: 'openbank-campaign-service',       port: 8128 },
   'sdd-service':            { container: 'openbank-sdd-service',            port: 8129 },
   'fraud-service':          { container: 'openbank-fraud-service',          port: 8133 },
   'dispute-service':        { container: 'openbank-dispute-service',        port: 8135 },

--- a/openbank-admin-ui/src/app/campaigns/[id]/page.tsx
+++ b/openbank-admin-ui/src/app/campaigns/[id]/page.tsx
@@ -132,7 +132,7 @@ export default function CampaignDetailPage({ params }: { params: Promise<{ id: s
             <h2 className="text-sm font-semibold">{t('Zařazení', 'Enrolments')}</h2>
             {detail?.sources.enrolments !== 'ok' ? (
               <DataUnavailable
-                kind={detail?.sources.enrolments === 'unauthorized' ? 'unauthorized' : 'unreachable'}
+                kind={detail?.sources.enrolments === 'unauthorized' ? 'unauthorized' : detail?.sources.enrolments === 'not_deployed' ? 'not_deployed' : 'unreachable'}
                 service="Campaign-service"
                 feature={t('Zařazení', 'Enrolments')}
                 dense
@@ -171,7 +171,7 @@ export default function CampaignDetailPage({ params }: { params: Promise<{ id: s
             </p>
             {detail?.sources.sends !== 'ok' ? (
               <DataUnavailable
-                kind={detail?.sources.sends === 'unauthorized' ? 'unauthorized' : 'unreachable'}
+                kind={detail?.sources.sends === 'unauthorized' ? 'unauthorized' : detail?.sources.sends === 'not_deployed' ? 'not_deployed' : 'unreachable'}
                 service="Campaign-service"
                 feature={t('Log odeslání', 'Send log')}
                 dense

--- a/openbank-admin-ui/src/app/campaigns/page.tsx
+++ b/openbank-admin-ui/src/app/campaigns/page.tsx
@@ -37,7 +37,7 @@ export default function CampaignsPage() {
       .then(r => r.json())
       .then((d: { items: Campaign[]; state: string }) => {
         if (d.state !== 'ok') {
-          setUnavailable(d.state === 'unauthorized' ? 'unauthorized' : 'unreachable')
+          setUnavailable(d.state === 'unauthorized' ? 'unauthorized' : d.state === 'not_deployed' ? 'not_deployed' : 'unreachable')
           return
         }
         setItems(d.items ?? [])

--- a/openbank-admin-ui/src/test/service-registry.guard.test.ts
+++ b/openbank-admin-ui/src/test/service-registry.guard.test.ts
@@ -216,6 +216,35 @@ describe('service registry drift guard', () => {
     ).toEqual([])
   })
 
+  it('every svcUrl() key exists in SERVICE_MAP (no caller pointing at an unknown service)', () => {
+    // The OTHER direction of the check above, and the one that was missing: that guard proves no
+    // SERVICE_MAP key is dead, but nothing proved every CALLER has a key. A page calling
+    // svcUrl('campaign-service', …) with no such key gets "Unknown service" from the proxy and
+    // renders as "not responding" — a deployed, healthy service that looks down. That is exactly
+    // what shipped with the campaign console (#2749): unit tests stubbed `fetch`, so the proxy was
+    // never on the path they exercised.
+    const keys = new Set(serviceMapKeys())
+    const callers: { file: string; key: string }[] = []
+    const walkDir = (dir: string): string[] =>
+      readdirSync(dir, { withFileTypes: true }).flatMap(e => {
+        const full = path.join(dir, e.name)
+        return e.isDirectory() ? walkDir(full) : [full]
+      })
+    for (const file of walkDir(path.join(ADMIN_UI, 'src/app'))) {
+      if (!file.endsWith('.ts') && !file.endsWith('.tsx')) continue
+      for (const m of readFileSync(file, 'utf8').matchAll(/svcUrl\(\s*'([^']+)'/g)) {
+        callers.push({ file: path.relative(ADMIN_UI, file), key: m[1] })
+      }
+    }
+    expect(callers.length, 'no svcUrl() callers found — the matcher has drifted').toBeGreaterThan(0)
+    const unknown = callers.filter(c => !keys.has(c.key))
+    expect(
+      unknown.map(c => `${c.file} → ${c.key}`),
+      'svcUrl() callers naming a key SERVICE_MAP does not define. The proxy answers '
+      + '"Unknown service" and the page degrades to "not responding" on a healthy service.',
+    ).toEqual([])
+  })
+
   it('SERVICE_MAP containers agree with SERVICE_REGISTRY on the module directory', () => {
     const dirs = moduleDirs()
     const src = readFileSync(BFF_ROUTE, 'utf-8')


### PR DESCRIPTION
## Symptom

The campaign console rendered **"Campaign-service is not responding"** against a service that was
`2/2 Running` and answering `GET /api/v1/campaigns/{id}/sends` correctly from inside the cluster.

## Cause

`SERVICE_MAP` in the BFF proxy had no `campaign-service` key. In-cluster the key IS the discovery
lookup, so the proxy answered `Unknown service` and every caller degraded to "not deployed".

## How it got past me — worth writing down, because the warning existed

The proxy file's own comment describes this exact failure and names its previous victim
(`sepa-instant-service`, which left the SCT-Inst panel stuck). I never read it, because **adding a
BFF route does not require opening that file**: `svcUrl('campaign-service', …)` was copied from a
neighbouring route, and nothing at the call site indicates a registry exists at all.

Then my own tests stubbed `fetch`, so the proxy was never on the path they exercised — the page
tests passed against a boundary I had mocked.

That is the same shape as most of what this rollout turned up: the knowledge lived as prose in a
file the change did not force anyone to visit, and the tests mocked the layer where the mistake was.

## Fix, in two parts

1. The missing entry — `campaign-service` → `openbank-campaign-service`, port 8128 (verified against
   the live Service).
2. **The guard for the direction nobody checked.** There was already a test that every `SERVICE_MAP`
   key matches a real gitops workload — no *dead* keys. Nothing asserted the reverse: that every
   `svcUrl()` **caller** has a key. That is the direction this bug travelled, and the one a new page
   trips.

The new test walks `src/app`, extracts every `svcUrl('<key>'`, and fails on any key `SERVICE_MAP`
does not define, naming the offending file.

## Falsified, not just green

Deleting the entry makes the new test fail and name both callers:

```
× every svcUrl() key exists in SERVICE_MAP (no caller pointing at an unknown service)
+   "src/app/api/campaigns/[id]/route.ts → campaign-service",
+   "src/app/api/campaigns/route.ts → campaign-service",
```

Full suite: 889 tests passing. Type-check clean.

Refs #2749, #2895