### PR TITLE
ci: gate that self-hosted Gradle jobs isolate GRADLE_USER_HOME

### DIFF
--- a/.github/scripts/check-gradle-user-home-isolation.py
+++ b/.github/scripts/check-gradle-user-home-isolation.py
@@ -1,0 +1,280 @@
+#!/usr/bin/env python3
+# SPDX-License-Identifier: Apache-2.0
+# Copyright (c) OpenBank contributors. Licensed under the Apache License, Version 2.0.
+# See LICENSE in the repository root or https://www.apache.org/licenses/LICENSE-2.0 for details.
+"""A Gradle job that can land on a self-hosted runner must set its own GRADLE_USER_HOME.
+
+WHY THIS EXISTS
+The self-hosted Mac runners are also developer workstations. A job that leaves
+GRADLE_USER_HOME unset resolves it to `~/.gradle` — the human's cache — and then
+`gradle/actions/setup-gradle` does two things to it:
+
+  * writes its init scripts into `~/.gradle/init.d`, where they apply to EVERY
+    interactive build on that machine; and
+  * runs `cache-cleanup: on-success` — the action's DEFAULT — as a post-job step:
+    "remove any stale/unused entries from the Gradle User Home". On a shared home
+    that deletes entries the CI build did not use, and truncates files a concurrent
+    local build is reading.
+
+Measured 2026-08-01 on the openbank-app runner, which had five such jobs: local builds
+in THIS repo failed `Dependency verification failed` for artifacts whose cached bytes
+matched `verification-metadata.xml` and Maven Central exactly, and `modules-2/metadata-*`
+lost its binary caches mid-build. The failure is indistinguishable from cache corruption
+and cost two sessions of misdiagnosis, because the damaging job is in a different repo.
+
+`_service-ci.yml` already resolves a per-service home for the self-hosted lanes; this
+guard is what keeps the next Gradle job from forgetting.
+
+WHAT COUNTS AS SATISFIED — any of:
+  * `GRADLE_USER_HOME` in the workflow-level `env:`
+  * `GRADLE_USER_HOME` in the job-level `env:`
+  * a step that writes `GRADLE_USER_HOME=... >> $GITHUB_ENV` BEFORE the first step that
+    uses Gradle (the `_service-ci.yml` shape — a reusable workflow cannot reference the
+    `env` context in a job-level `env:` block, so it must be resolved in a step).
+
+WHAT IS FLAGGED
+A job that uses Gradle (`gradle/actions/setup-gradle`, or `gradlew` in a `run:` body) AND
+whose `runs-on` is not exclusively GitHub-hosted labels. An expression-valued `runs-on` is
+resolved to the string literals inside it, so the `_service-ci.yml` shape
+(`... && 'openbank-build' || 'ubuntu-latest'`) is treated as possibly self-hosted.
+
+Shell comments are stripped before matching, so prose mentioning `./gradlew` in a comment
+does not make a job "a Gradle job" (#2450, the code-about-code rule).
+
+Usage:
+    python3 .github/scripts/check-gradle-user-home-isolation.py
+    python3 .github/scripts/check-gradle-user-home-isolation.py --self-test
+"""
+from __future__ import annotations
+
+import re
+import sys
+from pathlib import Path
+
+try:
+    import yaml
+except ImportError:  # pragma: no cover
+    print("PyYAML is required", file=sys.stderr)
+    raise SystemExit(2)
+
+WORKFLOWS = Path(".github/workflows")
+
+VAR = "GRADLE_USER_HOME"
+
+# GitHub-hosted runner images. Anything else — a bare custom label, or a label produced by
+# an expression — is treated as possibly self-hosted.
+HOSTED = re.compile(r"^(ubuntu|macos|windows)-[0-9a-z.\-]+$")
+
+GRADLE_ACTION = "gradle/actions/setup-gradle"
+GRADLEW = re.compile(r"(?<![\w./-])\.?/?gradlew\b")
+GITHUB_ENV_WRITE = re.compile(rf"{VAR}=.*>>\s*\"?\$?\{{?GITHUB_ENV", re.MULTILINE)
+
+
+def strip_shell_comments(text: str) -> str:
+    """Drop `#` comments so prose about Gradle is not read as a Gradle invocation."""
+    out = []
+    for line in text.splitlines():
+        stripped = line.lstrip()
+        if stripped.startswith("#"):
+            continue
+        out.append(re.sub(r"(?<!\S)#(?!\{).*$", "", line))
+    return "\n".join(out)
+
+
+def runner_may_be_self_hosted(runs_on) -> bool:
+    if runs_on is None:
+        return False
+    labels: list[str] = []
+    if isinstance(runs_on, str):
+        if "${{" in runs_on:
+            # Resolve an expression to the literals it can evaluate to.
+            labels = re.findall(r"'([^']+)'", runs_on) or ["<expression>"]
+        else:
+            labels = [runs_on]
+    elif isinstance(runs_on, list):
+        labels = [str(x) for x in runs_on]
+    elif isinstance(runs_on, dict):  # `group:` / `labels:` form
+        raw = runs_on.get("labels") or runs_on.get("group") or ""
+        labels = raw if isinstance(raw, list) else [str(raw)]
+    return any(not HOSTED.match(label.strip()) for label in labels if label)
+
+
+def step_uses_gradle(step: dict) -> bool:
+    if GRADLE_ACTION in str(step.get("uses") or ""):
+        return True
+    return bool(GRADLEW.search(strip_shell_comments(str(step.get("run") or ""))))
+
+
+def step_sets_home(step: dict) -> bool:
+    if VAR in (step.get("env") or {}):
+        return True
+    return bool(GITHUB_ENV_WRITE.search(strip_shell_comments(str(step.get("run") or ""))))
+
+
+def check_workflow(path: Path, text: str) -> list[str]:
+    try:
+        doc = yaml.safe_load(text) or {}
+    except yaml.YAMLError as exc:
+        return [f"{path}: unparseable YAML: {exc}"]
+
+    workflow_env = doc.get("env") or {}
+    findings = []
+    for name, job in (doc.get("jobs") or {}).items():
+        if not isinstance(job, dict):
+            continue
+        steps = [s for s in (job.get("steps") or []) if isinstance(s, dict)]
+        gradle_at = next((i for i, s in enumerate(steps) if step_uses_gradle(s)), None)
+        if gradle_at is None:
+            continue
+        if not runner_may_be_self_hosted(job.get("runs-on")):
+            continue
+        if VAR in workflow_env or VAR in (job.get("env") or {}):
+            continue
+        # A step may resolve the home into $GITHUB_ENV — but only if it runs FIRST.
+        if any(step_sets_home(s) for s in steps[:gradle_at]):
+            continue
+        late = any(step_sets_home(s) for s in steps[gradle_at:])
+        why = (
+            f"sets {VAR} only AFTER the first Gradle step — setup-gradle has already "
+            f"written to the shared home by then"
+            if late
+            else f"no {VAR}"
+        )
+        findings.append(f"{path}:{name} — {why}")
+    return findings
+
+
+_MUST_FLAG = {
+    "self-hosted gradle job with no GRADLE_USER_HOME": """
+jobs:
+  build:
+    runs-on: [self-hosted, openbank-build]
+    steps:
+      - uses: gradle/actions/setup-gradle@v6
+      - run: ./gradlew build
+""",
+    "custom label via an expression (the _service-ci shape)": """
+jobs:
+  build:
+    runs-on: ${{ github.ref == 'refs/heads/main' && 'openbank-build' || 'ubuntu-latest' }}
+    steps:
+      - run: ./gradlew build
+""",
+    "home exported only after setup-gradle ran": """
+jobs:
+  gate:
+    runs-on: [self-hosted, openbank-build]
+    steps:
+      - uses: gradle/actions/setup-gradle@v6
+      - run: |
+          echo "GRADLE_USER_HOME=$HOME/.gradle-ci" >> "$GITHUB_ENV"
+          ./gradlew test
+""",
+}
+
+_MUST_NOT_FLAG = {
+    "GitHub-hosted runner needs no isolation": """
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - run: ./gradlew build
+""",
+    "job-level env (the app-build shape)": """
+jobs:
+  build:
+    runs-on: [self-hosted, openbank-build]
+    env:
+      GRADLE_USER_HOME: ${{ github.workspace }}/../_gradle-ci
+    steps:
+      - run: ./gradlew build
+""",
+    "resolved into $GITHUB_ENV before the first Gradle step (_service-ci shape)": """
+jobs:
+  build:
+    runs-on: ${{ github.ref == 'refs/heads/main' && 'openbank-build' || 'ubuntu-latest' }}
+    steps:
+      - name: Resolve GRADLE_USER_HOME
+        run: echo "GRADLE_USER_HOME=${{ github.workspace }}/../.gradle-svc/svc" >> "$GITHUB_ENV"
+      - uses: gradle/actions/setup-gradle@v6
+      - run: ./gradlew build
+""",
+    "workflow-level env": """
+env:
+  GRADLE_USER_HOME: /tmp/gradle-ci
+jobs:
+  build:
+    runs-on: [self-hosted, openbank-build]
+    steps:
+      - run: ./gradlew build
+""",
+    "a comment mentioning gradlew is not a Gradle job": """
+jobs:
+  notes:
+    runs-on: [self-hosted, openbank-build]
+    steps:
+      - run: |
+          # ./gradlew build runs in the sibling job
+          echo hello
+""",
+    "no Gradle at all": """
+jobs:
+  j:
+    runs-on: [self-hosted, openbank-build]
+    steps:
+      - run: echo hello
+""",
+}
+
+
+def self_test() -> int:
+    failures = 0
+    for label, text in _MUST_FLAG.items():
+        if not check_workflow(Path("<test>"), text):
+            print(f"SELF-TEST FAIL: should have flagged — {label}")
+            failures += 1
+    for label, text in _MUST_NOT_FLAG.items():
+        found = check_workflow(Path("<test>"), text)
+        if found:
+            print(f"SELF-TEST FAIL: false positive — {label}\n  {found[0]}")
+            failures += 1
+    total = len(_MUST_FLAG) + len(_MUST_NOT_FLAG)
+    if failures:
+        print(f"self-test: {failures} of {total} cases failed")
+        return 1
+    print(f"self-test: {total}/{total} cases pass "
+          f"({len(_MUST_FLAG)} must-flag, {len(_MUST_NOT_FLAG)} must-not-flag)")
+    return 0
+
+
+def main() -> int:
+    if "--self-test" in sys.argv:
+        return self_test()
+
+    if not WORKFLOWS.is_dir():
+        print(f"{WORKFLOWS} not found — run from the repository root", file=sys.stderr)
+        return 2
+
+    findings = []
+    for path in sorted(WORKFLOWS.glob("*.yml")) + sorted(WORKFLOWS.glob("*.yaml")):
+        findings.extend(check_workflow(path, path.read_text()))
+
+    if findings:
+        print("Gradle jobs that can run self-hosted without an isolated GRADLE_USER_HOME:")
+        for f in findings:
+            print(f"  - {f}")
+        print(
+            "\nSet a per-job home so CI cannot prune the workstation's ~/.gradle:\n"
+            "    env:\n"
+            "      GRADLE_USER_HOME: ${{ github.workspace }}/../.gradle-svc/<name>\n"
+            "or resolve it into $GITHUB_ENV in a step BEFORE the first Gradle step\n"
+            "(see .github/workflows/_service-ci.yml)."
+        )
+        return 1
+
+    print("OK: every self-hosted Gradle job isolates GRADLE_USER_HOME.")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -439,6 +439,21 @@ jobs:
         run: python3 .github/scripts/check-gh-repo-context.py
 
 
+      # The self-hosted Mac runners are also developer workstations, and setup-gradle's
+      # DEFAULT post-job step (`cache-cleanup: on-success`) prunes "unused" entries from
+      # whatever GRADLE_USER_HOME it was given. Pointed at the human's ~/.gradle it deletes
+      # artifacts local builds depend on and truncates files a concurrent local build is
+      # reading — which surfaces as `Dependency verification failed` for artifacts whose
+      # bytes match verification-metadata.xml exactly, i.e. as cache corruption that no
+      # amount of cache repair fixes. Measured 2026-08-01 from the openbank-app runner,
+      # which had five such jobs. _service-ci.yml already resolves a per-service home for
+      # the self-hosted lanes; this gate is what keeps the next Gradle job from forgetting.
+      - name: "Gradle home isolation self-test"
+        run: python3 .github/scripts/check-gradle-user-home-isolation.py --self-test
+      - name: "Gradle home isolation on self-hosted runners (enforced)"
+        run: python3 .github/scripts/check-gradle-user-home-isolation.py
+
+
       # issue #2255. docs/runbooks/svc-*.md are GENERATED from governance.yaml + the gitops
       # manifests, and nothing checked them, so 25 of 30 had silently gone stale: they told
       # an on-call engineer "DR is not achievable today — no backup configured" for services

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -445,6 +445,20 @@ fire from *outside* it, so they stay here:
   open, and `strict_required_status_checks_policy` (require branches up to date) is the only
   remaining lever that works on a personal account.
 
+### Self-hosted runners share the machine with a human
+- **A CI job that leaves `GRADLE_USER_HOME` unset does not merely *share* the workstation's
+  `~/.gradle` — it PRUNES it.** `gradle/actions/setup-gradle` runs `cache-cleanup: on-success` by
+  default: "remove any stale/unused entries from the Gradle User Home", where *unused* means
+  "unused by this one CI build". Pointed at a developer's home it deletes artifacts local builds
+  depend on and truncates files a concurrent local build is reading, so the local build reports
+  `Dependency verification failed … expected X but was Y` for an artifact whose cached bytes match
+  `verification-metadata.xml` and Maven Central **exactly**. That reads as cache corruption, and no
+  amount of cache repair fixes it because the damage recurs on the next CI job — the diagnosis only
+  closes when you notice the failures track the runner being busy. Every Gradle job that can land on
+  a self-hosted runner needs its own home; `_service-ci.yml` resolves one per service in a step
+  (a `workflow_call` job cannot reference the `env` context in a job-level `env:` block).
+  `.github/scripts/check-gradle-user-home-isolation.py` enforces it in `Validate manifests`.
+
 ### Dependency graph & PR-time CVE gating
 Rationale + what does *not* cover it: `rules.yaml: dependencies.pr_time_cve_gate` (authoritative).
 - **`dependency-submission.yml` MUST keep its `pull_request` trigger.** `dependency-review` only


### PR DESCRIPTION
Closes #3003.

## Problem

The self-hosted Mac runners are also developer workstations. A Gradle job that leaves `GRADLE_USER_HOME` unset resolves it to the human's `~/.gradle`, and `gradle/actions/setup-gradle` then runs `cache-cleanup: on-success` — the action's **default** — as a post-job step: *"remove any stale/unused entries from the Gradle User Home"*, where *unused* means unused by that one CI build.

The home is therefore not shared, it is **pruned**: local builds lose artifacts they depend on, and a file a concurrent local build is reading gets truncated under it. The symptom is

```
Dependency verification failed ... expected a sha256 checksum of <X> but was <Y>
```

for an artifact whose cached bytes match `gradle/verification-metadata.xml` and Maven Central **exactly** — indistinguishable from cache corruption, and unfixable by cache repair since the next CI job redoes it.

Measured 2026-08-01: five `openbank-app` jobs were in that state and were breaking local builds of this repo (JiRaska/openbank-app#322). `_service-ci.yml` already resolves a per-service home for the self-hosted lanes, so **nothing here is broken today** — this is the gate that keeps the next Gradle job from forgetting.

## Change

- `.github/scripts/check-gradle-user-home-isolation.py` — flags a job that uses Gradle (`setup-gradle`, or `gradlew` in a `run:` body) whose `runs-on` is not exclusively GitHub-hosted labels, unless the home comes from the workflow `env`, the job `env`, or a step writing `$GITHUB_ENV` **before** the first Gradle step. An expression-valued `runs-on` resolves to the string literals inside it, so the `_service-ci.yml` shape counts as possibly self-hosted. Shell comments are stripped first, per the code-about-code rule (#2450).
- Wired into `Validate manifests` (unconditional, required), self-test step alongside it.
- One `CLAUDE.md` bullet under a new "Self-hosted runners share the machine with a human" heading.

Deliberately **not** added to `rules.yaml`: no comparable workflow-shape guard (`check-gh-repo-context`, `check-podmonitor-namespace-coverage`) is registered there, and an edit would restamp every OPA bundle for a rule that has no runtime meaning.

## Verification

- `--self-test`: 9/9 (3 must-flag, 6 must-not-flag), both directions including the comment case.
- Against the **real** workflow, not just fixtures: deleting `_service-ci.yml`'s `Resolve GRADLE_USER_HOME` step makes it exit 1 naming `_service-ci.yml:build`; restored, exit 0.
- `yamllint` finding set on `ci.yml` under the CI job's own config is byte-identical to `origin/main`.
- `python3 -m unittest discover -s .github/scripts -p '*_test.py'` — 8 tests, OK.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
