### PR TITLE
build: fix uber-jar COPY path in three service Dockerfiles

### DIFF
--- a/openbank-campaign-service/Dockerfile
+++ b/openbank-campaign-service/Dockerfile
@@ -1,14 +1,40 @@
 FROM eclipse-temurin:25-jdk@sha256:dfc0093e3dbf43dae57827111c6e374f5b44fac19a9451584b2b336b81474d64 AS build
 WORKDIR /build
+
+# The root settings.gradle.kts is the entry point for every openbank-* module and it
+# `includeBuild("build-logic")` for the `openbank.quarkus-service` convention plugin,
+# so the wrapper, the root build files and build-logic all have to be in the context —
+# not just the service directory.
+COPY gradle /build/gradle
+COPY gradlew build.gradle.kts settings.gradle.kts /build/
+COPY build-logic /build/build-logic
+# ADR-0122 split the shared code into sibling top-level modules; `COPY openbank-libs`
+# alone leaves `project(":openbank-libs-domain")` etc. unresolvable at configuration time.
 COPY openbank-libs /build/openbank-libs
+COPY openbank-libs-domain /build/openbank-libs-domain
+COPY openbank-libs-runtime /build/openbank-libs-runtime
+COPY openbank-libs-temporal /build/openbank-libs-temporal
+COPY openbank-libs-testing /build/openbank-libs-testing
 COPY openbank-campaign-service /build/openbank-campaign-service
-WORKDIR /build/openbank-campaign-service
-RUN chmod +x gradlew && ./gradlew quarkusBuild -Dquarkus.package.jar.type=fast-jar --no-daemon --console=plain
+
+RUN chmod +x gradlew && \
+    ./gradlew :openbank-campaign-service:quarkusBuild \
+      -Dquarkus.package.jar.type=fast-jar \
+      --no-daemon \
+      --console=plain
 
 FROM eclipse-temurin:25-jre-alpine@sha256:28db6fdf60e38945e43d840c0333aeaec66c15943070104f7586fd3c9d1665b0
 WORKDIR /app
 RUN addgroup -S openbank && adduser -S openbank -G openbank
 USER openbank
-COPY --from=build /build/openbank-campaign-service/build/openbank-campaign-service-0.1.0-SNAPSHOT-runner.jar /app/quarkus-run.jar
+
+# fast-jar layout: build/quarkus-app/{lib,app,quarkus,quarkus-run.jar}. There is no
+# top-level <service>-<version>-runner.jar — that is the uber-jar output. Naming it
+# here also hardcoded a version that does not track version.txt.
+COPY --from=build /build/openbank-campaign-service/build/quarkus-app/lib/ /app/lib/
+COPY --from=build /build/openbank-campaign-service/build/quarkus-app/*.jar /app/
+COPY --from=build /build/openbank-campaign-service/build/quarkus-app/app/ /app/app/
+COPY --from=build /build/openbank-campaign-service/build/quarkus-app/quarkus/ /app/quarkus/
+
 EXPOSE 8128
 ENTRYPOINT ["java", "-XX:+UseZGC", "-Djava.util.logging.manager=org.jboss.logmanager.LogManager", "-jar", "/app/quarkus-run.jar"]

--- a/openbank-domestic-payment/Dockerfile
+++ b/openbank-domestic-payment/Dockerfile
@@ -1,14 +1,40 @@
 FROM eclipse-temurin:25-jdk@sha256:dfc0093e3dbf43dae57827111c6e374f5b44fac19a9451584b2b336b81474d64 AS build
 WORKDIR /build
+
+# The root settings.gradle.kts is the entry point for every openbank-* module and it
+# `includeBuild("build-logic")` for the `openbank.quarkus-service` convention plugin,
+# so the wrapper, the root build files and build-logic all have to be in the context —
+# not just the service directory.
+COPY gradle /build/gradle
+COPY gradlew build.gradle.kts settings.gradle.kts /build/
+COPY build-logic /build/build-logic
+# ADR-0122 split the shared code into sibling top-level modules; `COPY openbank-libs`
+# alone leaves `project(":openbank-libs-domain")` etc. unresolvable at configuration time.
 COPY openbank-libs /build/openbank-libs
+COPY openbank-libs-domain /build/openbank-libs-domain
+COPY openbank-libs-runtime /build/openbank-libs-runtime
+COPY openbank-libs-temporal /build/openbank-libs-temporal
+COPY openbank-libs-testing /build/openbank-libs-testing
 COPY openbank-domestic-payment /build/openbank-domestic-payment
-WORKDIR /build/openbank-domestic-payment
-RUN chmod +x gradlew && ./gradlew quarkusBuild -Dquarkus.package.jar.type=fast-jar --no-daemon --console=plain
+
+RUN chmod +x gradlew && \
+    ./gradlew :openbank-domestic-payment:quarkusBuild \
+      -Dquarkus.package.jar.type=fast-jar \
+      --no-daemon \
+      --console=plain
 
 FROM eclipse-temurin:25-jre-alpine@sha256:28db6fdf60e38945e43d840c0333aeaec66c15943070104f7586fd3c9d1665b0
 WORKDIR /app
 RUN addgroup -S openbank && adduser -S openbank -G openbank
 USER openbank
-COPY --from=build /build/openbank-domestic-payment/build/openbank-domestic-payment-0.1.0-SNAPSHOT-runner.jar /app/quarkus-run.jar
+
+# fast-jar layout: build/quarkus-app/{lib,app,quarkus,quarkus-run.jar}. There is no
+# top-level <service>-<version>-runner.jar — that is the uber-jar output. Naming it
+# here also hardcoded a version that does not track version.txt.
+COPY --from=build /build/openbank-domestic-payment/build/quarkus-app/lib/ /app/lib/
+COPY --from=build /build/openbank-domestic-payment/build/quarkus-app/*.jar /app/
+COPY --from=build /build/openbank-domestic-payment/build/quarkus-app/app/ /app/app/
+COPY --from=build /build/openbank-domestic-payment/build/quarkus-app/quarkus/ /app/quarkus/
+
 EXPOSE 8116
 ENTRYPOINT ["java", "-XX:+UseZGC", "-Djava.util.logging.manager=org.jboss.logmanager.LogManager", "-jar", "/app/quarkus-run.jar"]

--- a/openbank-sepa-payment/Dockerfile
+++ b/openbank-sepa-payment/Dockerfile
@@ -1,14 +1,40 @@
 FROM eclipse-temurin:25-jdk@sha256:dfc0093e3dbf43dae57827111c6e374f5b44fac19a9451584b2b336b81474d64 AS build
 WORKDIR /build
+
+# The root settings.gradle.kts is the entry point for every openbank-* module and it
+# `includeBuild("build-logic")` for the `openbank.quarkus-service` convention plugin,
+# so the wrapper, the root build files and build-logic all have to be in the context —
+# not just the service directory.
+COPY gradle /build/gradle
+COPY gradlew build.gradle.kts settings.gradle.kts /build/
+COPY build-logic /build/build-logic
+# ADR-0122 split the shared code into sibling top-level modules; `COPY openbank-libs`
+# alone leaves `project(":openbank-libs-domain")` etc. unresolvable at configuration time.
 COPY openbank-libs /build/openbank-libs
+COPY openbank-libs-domain /build/openbank-libs-domain
+COPY openbank-libs-runtime /build/openbank-libs-runtime
+COPY openbank-libs-temporal /build/openbank-libs-temporal
+COPY openbank-libs-testing /build/openbank-libs-testing
 COPY openbank-sepa-payment /build/openbank-sepa-payment
-WORKDIR /build/openbank-sepa-payment
-RUN chmod +x gradlew && ./gradlew quarkusBuild -Dquarkus.package.jar.type=fast-jar --no-daemon --console=plain
+
+RUN chmod +x gradlew && \
+    ./gradlew :openbank-sepa-payment:quarkusBuild \
+      -Dquarkus.package.jar.type=fast-jar \
+      --no-daemon \
+      --console=plain
 
 FROM eclipse-temurin:25-jre-alpine@sha256:28db6fdf60e38945e43d840c0333aeaec66c15943070104f7586fd3c9d1665b0
 WORKDIR /app
 RUN addgroup -S openbank && adduser -S openbank -G openbank
 USER openbank
-COPY --from=build /build/openbank-sepa-payment/build/openbank-sepa-payment-0.1.0-SNAPSHOT-runner.jar /app/quarkus-run.jar
+
+# fast-jar layout: build/quarkus-app/{lib,app,quarkus,quarkus-run.jar}. There is no
+# top-level <service>-<version>-runner.jar — that is the uber-jar output. Naming it
+# here also hardcoded a version that does not track version.txt.
+COPY --from=build /build/openbank-sepa-payment/build/quarkus-app/lib/ /app/lib/
+COPY --from=build /build/openbank-sepa-payment/build/quarkus-app/*.jar /app/
+COPY --from=build /build/openbank-sepa-payment/build/quarkus-app/app/ /app/app/
+COPY --from=build /build/openbank-sepa-payment/build/quarkus-app/quarkus/ /app/quarkus/
+
 EXPOSE 8115
 ENTRYPOINT ["java", "-XX:+UseZGC", "-Djava.util.logging.manager=org.jboss.logmanager.LogManager", "-jar", "/app/quarkus-run.jar"]


### PR DESCRIPTION
## What

Three service Dockerfiles built with `-Dquarkus.package.jar.type=fast-jar` but then
COPYed the **uber-jar** output path:

```
COPY --from=build /build/openbank-<svc>/build/openbank-<svc>-0.1.0-SNAPSHOT-runner.jar /app/quarkus-run.jar
```

A fast-jar build produces `build/quarkus-app/` (`lib/`, `app/`, `quarkus/`, `quarkus-run.jar`)
and no top-level `-runner.jar`. The hardcoded `-0.1.0-SNAPSHOT-` was a second latent break:
it does not track `version.txt`.

Affected: `openbank-campaign-service`, `openbank-domestic-payment`, `openbank-sepa-payment`.
All three are deployed (live ECR sandbox tags; campaign a `Deployment`, the other two
`Rollout`s in `payments-services.yaml`).

## Why it was still green - and why this is bigger than three files

**Nothing builds a per-service Dockerfile.** `auto-deploy.yml` and `ghcr-publish.yml` both
`cp .github/workflows/Dockerfile.deploy` into a generated context, and
`openbank-infra/scripts/build-push-service.sh:8` documents the choice outright -
*"WHY NOT `docker build -f openbank-<svc>/Dockerfile`"*. All three paths build host-side and
read exactly one thing from the per-service file: the `EXPOSE` line, used to set the container
port. `EXPOSE` is preserved unchanged here.

So the COPY block and build stage are text that has never executed. That was verified, not
assumed - `openbank-ledger-service/Dockerfile`, the file usually cited as the correct shape,
also fails, in 77 s:

```
Included build '/build/build-logic' does not exist.
```

Measured across the fleet:

| gap | Dockerfiles affected |
|---|---|
| no `COPY build-logic` (root `settings.gradle.kts` `includeBuild`s it) | **51 of 51** |
| no `COPY openbank-libs-{domain,runtime,temporal,testing}` (ADR-0122 split) | **51 of 51** |
| uber-jar `-runner.jar` COPY path | 3 of 51 |

This PR fixes all three gaps for the three services, so their build stage is materially closer
to correct rather than merely differently wrong.

## Verification

Built with a real `docker build` at every step rather than by inspection. Each fix was
confirmed by the next error moving forward:

1. `Included build '/build/build-logic' does not exist` -> fixed by `COPY build-logic`
2. `Project with path ':openbank-libs-temporal' could not be found` -> fixed by copying the
   ADR-0122 sibling modules
3. `Dependency verification failed ... hibernate-platform-7.4.5.Final.pom`

**The build is not green, and this PR does not claim it is.** Step 3 is a separate, real bug
that is not about Dockerfiles: `gradle/verification-metadata.xml` has the `.module` artifact for
`hibernate-platform:7.4.5.Final` but not the `.pom`, while `7.4.3.Final` has both. It is a
genuine absence, not cache corruption. Adding that one hash (validated against Maven Central's
published sha1) moved the build forward and immediately exposed six more missing entries in the
next module - all of them `.pom`/`.module` metadata artifacts, never `.jar`.

That is a systematic gap: `verification-metadata.xml` is maintained by warm-cache builds and has
never seen a cold resolve. Any cold-cache build (fresh runner, isolated `GRADLE_USER_HOME`,
CodeQL tracing build) hits it. It is deliberately **not** included here - it is a fleet-wide gate
file with a different blast radius, and it gets its own PR and issue.

## Release impact

Type is `build` (`semver_bump: none`, `changelog: false`). No CI path builds these files, so the
change cannot affect any shipped image; a `fix` would cut three releases whose changelog entries
describe a behaviour change that cannot occur.

## Linked issues

Refs #3016 - the 48 remaining Dockerfiles, which look like the build recipe and structurally
cannot be one. Proposal there is to strip the build stage fleet-wide, keep `EXPOSE` plus the
runtime shape, and document `Dockerfile.deploy` as the real recipe.

Refs #3017 - the cold-cache `verification-metadata.xml` gap that blocks a green build here. Not
fixed in this PR on purpose: it is a fleet-wide gate file with a different blast radius.

Neither is a blocker for this PR. It is a strict improvement to three files that are wrong today,
and it does not depend on either issue landing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
