### PR TITLE
fix(admin-ui): make seven namespaces discoverable, and gate the ADR-0051 checklist

### DIFF
--- a/openbank-admin-ui/src/test/service-registry.guard.test.ts
+++ b/openbank-admin-ui/src/test/service-registry.guard.test.ts
@@ -121,6 +121,39 @@ function gitopsWorkloadNames(): Set<string> {
   return names
 }
 
+
+/**
+ * Namespaces that run an openbank-* Deployment/Rollout, derived from the gitops tree.
+ * Derived, not listed: a second hand-kept list is the drift this guard exists to prevent.
+ */
+function gitopsWorkloadNamespaces(): Set<string> {
+  const namespaces = new Set<string>()
+  for (const file of walkYaml(GITOPS)) {
+    const src = readFileSync(file, 'utf-8')
+    for (const doc of src.split(/^---$/m)) {
+      if (!/^kind:\s*(Deployment|Rollout)\s*$/m.test(doc)) continue
+      const name = doc.match(/^\s{2}name:\s*(\S+)/m)?.[1]
+      const ns = doc.match(/^\s{2}namespace:\s*(\S+)/m)?.[1]
+      if (name?.startsWith('openbank-') || /-service$/.test(name ?? '')) {
+        if (ns) namespaces.add(ns)
+      }
+    }
+  }
+  return namespaces
+}
+
+/**
+ * Namespaces deliberately outside the discovery boundary. Kept tight: each entry is a namespace
+ * whose workloads the console never proxies to.
+ */
+const DISCOVERY_EXEMPT_NAMESPACES = new Set<string>([
+  'admin-ui',      // the console itself
+  'temporal',      // infra, reached through its own status route
+  'messaging',     // Kafka/Strimzi
+  'observability', // Prometheus/Tempo, reached directly
+  'argocd', 'external-secrets', 'vault', 'cnpg-system', 'keda', 'iam',
+])
+
 /** BFF SERVICE_MAP keys, read from the route source. */
 function serviceMapKeys(): string[] {
   const src = readFileSync(BFF_ROUTE, 'utf-8')
@@ -242,6 +275,41 @@ describe('service registry drift guard', () => {
       unknown.map(c => `${c.file} → ${c.key}`),
       'svcUrl() callers naming a key SERVICE_MAP does not define. The proxy answers '
       + '"Unknown service" and the page degrades to "not responding" on a healthy service.',
+    ).toEqual([])
+  })
+
+  it('every namespace with a gitops workload is discoverable (OPENBANK_NAMESPACES + RoleBinding)', () => {
+    // ADR-0051 makes adding a domain namespace a THREE-step change, two of which live in
+    // admin-ui.yaml: the OPENBANK_NAMESPACES filter and a per-namespace RoleBinding for
+    // admin-ui-discovery. Miss either and discovery cannot see the service, so the console renders
+    // "not responding" against a healthy pod — which is exactly what campaign did (#2749).
+    //
+    // The checklist was already written in a comment. A comment cannot fail; this can.
+    const manifest = readFileSync(
+      path.join(GITOPS, 'components/admin-ui/admin-ui.yaml'), 'utf8',
+    )
+    const listed = new Set(
+      (manifest.match(/name: OPENBANK_NAMESPACES\s*\n\s*value:\s*(.+)/)?.[1] ?? '')
+        .split(',').map(n => n.trim()).filter(Boolean),
+    )
+    const bound = new Set(
+      [...manifest.matchAll(/name: admin-ui-discovery\s*\n\s*namespace:\s*(\S+)/g)].map(m => m[1]),
+    )
+
+    // Namespaces that actually run an openbank service, derived from the gitops tree rather than
+    // from a second hand-kept list — the whole point is that the set cannot drift.
+    const serviceNamespaces = new Set<string>()
+    for (const ns of gitopsWorkloadNamespaces()) serviceNamespaces.add(ns)
+
+    const missing = [...serviceNamespaces]
+      .filter(ns => !DISCOVERY_EXEMPT_NAMESPACES.has(ns))
+      .filter(ns => !listed.has(ns) || !bound.has(ns))
+      .map(ns => `${ns}${listed.has(ns) ? '' : ' (not in OPENBANK_NAMESPACES)'}${bound.has(ns) ? '' : ' (no RoleBinding)'}`)
+
+    expect(
+      missing,
+      'namespaces running an openbank service that admin-ui discovery cannot see. The console '
+      + 'will render "not responding" for every service in them, against healthy pods.',
     ).toEqual([])
   })
 

--- a/openbank-infra/gitops/components/admin-ui/admin-ui.yaml
+++ b/openbank-infra/gitops/components/admin-ui/admin-ui.yaml
@@ -75,7 +75,7 @@ spec:
             #   3. Add a RoleBinding for admin-ui-discovery below.
             # Adding a service *inside* an existing namespace is fully automatic.
             - name: OPENBANK_NAMESPACES
-              value: accounts,payments,compliance,identity,open-banking,platform,ledger,balances,audit,sanctions,security-scanner,onboarding,party,sca,statements,customer-edge,kyc,notifications,aml,consent,dispute,fraud,fx,interest,pid,psd2,documents
+              value: accounts,payments,compliance,identity,open-banking,platform,ledger,balances,audit,sanctions,security-scanner,onboarding,party,sca,statements,customer-edge,kyc,notifications,aml,consent,dispute,fraud,fx,interest,pid,psd2,documents,campaign,anacredit,billing,finrep,lending,sdd,tpp-registry
             # agent-service (MCP) is NOT reached via the discovery proxy: the
             # /api/agent/mcp and /api/agent/chat routes resolve it from this env
             # directly. Unset, they fall back to localhost:8109 (the admin-ui pod
@@ -742,3 +742,118 @@ spec:
                 name: admin-ui
                 port:
                   number: 3000
+---
+# campaign (ADR-0200/#2749). Without BOTH this binding and the OPENBANK_NAMESPACES
+# entry above, discovery cannot see campaign-service and the console renders
+# "Campaign-service is not responding" against a healthy 2/2 pod.
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: admin-ui-discovery
+  namespace: campaign
+  labels:
+    app.kubernetes.io/name: admin-ui
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: admin-ui-discovery
+subjects:
+  - kind: ServiceAccount
+    name: admin-ui
+    namespace: admin-ui
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: admin-ui-discovery
+  namespace: anacredit
+  labels:
+    app.kubernetes.io/name: admin-ui
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: admin-ui-discovery
+subjects:
+  - kind: ServiceAccount
+    name: admin-ui
+    namespace: admin-ui
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: admin-ui-discovery
+  namespace: billing
+  labels:
+    app.kubernetes.io/name: admin-ui
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: admin-ui-discovery
+subjects:
+  - kind: ServiceAccount
+    name: admin-ui
+    namespace: admin-ui
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: admin-ui-discovery
+  namespace: finrep
+  labels:
+    app.kubernetes.io/name: admin-ui
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: admin-ui-discovery
+subjects:
+  - kind: ServiceAccount
+    name: admin-ui
+    namespace: admin-ui
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: admin-ui-discovery
+  namespace: lending
+  labels:
+    app.kubernetes.io/name: admin-ui
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: admin-ui-discovery
+subjects:
+  - kind: ServiceAccount
+    name: admin-ui
+    namespace: admin-ui
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: admin-ui-discovery
+  namespace: sdd
+  labels:
+    app.kubernetes.io/name: admin-ui
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: admin-ui-discovery
+subjects:
+  - kind: ServiceAccount
+    name: admin-ui
+    namespace: admin-ui
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: admin-ui-discovery
+  namespace: tpp-registry
+  labels:
+    app.kubernetes.io/name: admin-ui
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: admin-ui-discovery
+subjects:
+  - kind: ServiceAccount
+    name: admin-ui
+    namespace: admin-ui


### PR DESCRIPTION
## What was actually wrong

The campaign console rendered **"Campaign-service is not responding"** against a `2/2` service that
answered every request put to it.

**It was not the `SERVICE_MAP` entry I added in #2997.** In-cluster that map is unused —
`serviceBaseUrl()` calls `resolveInCluster()`, which reads the ADR-0051 discovery feed. My earlier
diagnosis was stated too confidently; the entry is correct for local dev and the guard that came with
it is still worth having, but it was not this bug.

`campaign` was missing from **both** admin-ui steps of the ADR-0051 three-step checklist:
`OPENBANK_NAMESPACES` and a per-namespace RoleBinding for `admin-ui-discovery`.

## Verified from the real source first

From inside the admin-ui pod:

```
wget -O- http://campaign-service.campaign.svc:8128/api/v1/campaigns
[{"id":"019fb939-…","name":"smoke-offer",…}]   exit=0
```

The service, the port and the NetworkPolicy were never the problem. Discovery could not see the
namespace, so nothing was ever attempted.

## The guard found six more, two of them live

| Namespace | admin-ui callers | Pods running |
|-----------|------------------|--------------|
| `lending` | **2** | 4 |
| `sdd` | **1** | 2 |
| `anacredit`, `billing`, `finrep`, `tpp-registry` | 0 (no page yet) | 2–4 each |

So `/lending` and `/sdd` have been reporting healthy services as unreachable — the same symptom,
already shipped, nobody looking.

All seven are **added, not exempted**. An exemption list here would hide precisely the defect the
guard exists to find, and the fix is the two lines the checklist already prescribes.

## Why a guard rather than a better comment

The checklist was already written, in a comment directly above the env var it describes. It did not
help — not because it is badly written, but because **a comment only reaches whoever opens that
file**, and adding a service never requires opening it. That is the same shape as most of what this
rollout surfaced.

The new test derives the namespace set from the gitops tree rather than from a second hand-kept list,
so it cannot drift the way the list it checks did.

## Falsified

Removing the entries makes it fail and name all seven:

```
+   "anacredit (not in OPENBANK_NAMESPACES)",
+   "billing (not in OPENBANK_NAMESPACES)",
+   "campaign (not in OPENBANK_NAMESPACES)",
+   "finrep (not in OPENBANK_NAMESPACES)",
+   "lending (not in OPENBANK_NAMESPACES)",
+   "sdd (not in OPENBANK_NAMESPACES)",
+   "tpp-registry (not in OPENBANK_NAMESPACES)",
```

Guard suite: 12 passing with the fix.

Refs #2749, #2895