### PR TITLE
feat(ci): point api-fuzz at the money-path services (#2365)

### DIFF
--- a/.github/workflows/api-fuzz.yml
+++ b/.github/workflows/api-fuzz.yml
@@ -16,6 +16,18 @@
 # fuzz traffic and shows up here). Authenticated fuzzing (Keycloak dev-service
 # + token) is the tracked follow-up.
 #
+# SCOPE (2026-08-01, #2365): the money-path services are now in. Before this, the default list
+# was five services of which only consent-service was money-path — so eighteen of the twenty
+# money-path services had never been adversarially tested by anything in this repo, and the
+# `pentest` attestation was blocked on an event that could not happen. This is the cheapest way
+# to unblock it: the harness already worked, it was just pointed elsewhere.
+#
+# Sequential-loop -> MATRIX, because the scope change forces it: 23 services through one 45-minute
+# job (postgres + gradle + quarkusDev boot + fuzz, each) does not fit. One runner per service is
+# also strictly better than the loop was — `fail-fast: false` means a service that cannot boot
+# reports itself instead of consuming the budget of everything after it in the list, which the
+# shared `OVERALL=1` used to hide.
+#
 # Batch lane (openbank-batch): weekly + manual, never a PR gate (ADR-0053).
 name: API fuzz
 
@@ -26,10 +38,9 @@ on:
   workflow_dispatch:
     inputs:
       services:
-        description: "Space-separated service modules to fuzz"
+        description: "Space-separated service modules to fuzz (blank = derived money-path + legacy set)"
         required: false
-        # Fleet: self-contained services (no complex DB state). Authenticated fuzzing (Keycloak) tracked in #852.
-        default: "openbank-dispute-service openbank-party-service openbank-kyc-service openbank-notification-service openbank-consent-service"
+        default: ""
       max_examples:
         description: "Hypothesis examples per endpoint"
         required: false
@@ -43,15 +54,74 @@ concurrency:
   cancel-in-progress: true
 
 jobs:
+  prepare:
+    name: derive fuzz scope
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    outputs:
+      services: ${{ steps.derive.outputs.services }}
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+
+      # Scope is DERIVED from rules.yaml money_path_services plus the legacy set, never hand-kept:
+      # a service that becomes money-path is fuzzed the day rules.yaml says so. A service that
+      # cannot be fuzzed is EXCLUDED OUT LOUD with its reason — a silently shortened list reads as
+      # "covered" when it is not, which is the failure this whole issue is about.
+      - name: Derive service list
+        id: derive
+        env:
+          OVERRIDE: ${{ github.event.inputs.services }}
+        run: |
+          python3 - <<'PY'
+          import json, os, pathlib, re, yaml
+
+          override = (os.environ.get("OVERRIDE") or "").split()
+          legacy = [
+              "openbank-dispute-service", "openbank-party-service", "openbank-kyc-service",
+              "openbank-notification-service", "openbank-consent-service",
+          ]
+          money = yaml.safe_load(open("openbank-libs/governance/rules.yaml"))["money_path_services"]
+          candidates = override or list(dict.fromkeys(money + legacy))
+
+          keep, skipped = [], []
+          for svc in candidates:
+              app = pathlib.Path(svc) / "src/main/resources/application.yaml"
+              spec = pathlib.Path(svc) / "src/main/resources/openapi.yaml"
+              if not app.is_file() or not spec.is_file():
+                  skipped.append((svc, "no application.yaml or openapi.yaml")); continue
+              raw = app.read_text()
+              port = re.search(r"^  http:\n(?:.*\n)?\s*port:\s*(\d+)", raw, re.M)
+              db = re.search(r"jdbc:postgresql://[^/]+/([A-Za-z0-9_]+)", raw)
+              if not port:
+                  skipped.append((svc, "no derivable quarkus.http.port")); continue
+              if not db:
+                  skipped.append((svc, "no jdbc:postgresql URL — the harness cannot provision its DB")); continue
+              keep.append(svc)
+
+          for svc, why in skipped:
+              print(f"::warning::api-fuzz: {svc} EXCLUDED — {why}")
+          print(f"fuzzing {len(keep)} service(s); {len(skipped)} excluded")
+          with open(os.environ["GITHUB_OUTPUT"], "a") as fh:
+              fh.write("services=" + json.dumps(keep) + "\n")
+          PY
+
   fuzz:
-    name: schemathesis
+    name: "schemathesis (${{ matrix.service }})"
+    needs: prepare
     runs-on: ubuntu-latest  # public repo => hosted runners free+unlimited (FinOps: hosted-first)
-    timeout-minutes: 45
+    timeout-minutes: 30
+    strategy:
+      # One service must not mask another. The old sequential loop shared a single OVERALL=1, so a
+      # boot failure early in the list hid every result after it.
+      fail-fast: false
+      max-parallel: 8
+      matrix:
+        service: ${{ fromJson(needs.prepare.outputs.services) }}
     env:
       GRADLE_OPTS: "-Dorg.gradle.jvmargs=-Xmx3g -Dfile.encoding=UTF-8"
       # Throwaway credentials for the job-local postgres container only.
       POSTGRES_PASSWORD: "fuzz-ci-throwaway"
-      SERVICES: ${{ github.event.inputs.services || 'openbank-dispute-service openbank-party-service openbank-kyc-service openbank-notification-service openbank-consent-service' }}
+      SERVICES: ${{ matrix.service }}
       MAX_EXAMPLES: ${{ github.event.inputs.max_examples || '75' }}
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
@@ -190,6 +260,6 @@ jobs:
         if: always()
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
-          name: api-fuzz-reports
+          name: api-fuzz-reports-${{ matrix.service }}
           path: fuzz-reports/
           retention-days: 30


### PR DESCRIPTION
## Summary

Points `api-fuzz.yml` at the money-path services. Before this, the fuzz list was five services of
which **exactly one — `consent-service` — was money-path**. So eighteen of the twenty money-path
services had never been adversarially tested by anything in this repo, and their `pentest`
attestation (#2365) was blocked on an event that could not happen.

The harness already worked and had run six times. It was pointed elsewhere.

## Type of change

- [x] feat (new functionality) — CI scope, no service code

## Linked issues

Refs #2365, Refs #852

## Measured before changing anything

**19 of the 20 money-path services are fuzzable as-is** — each has an `openapi.yaml`, a derivable
`quarkus.http.port`, a `jdbc:postgresql` URL the harness can provision from, and a `%dev` profile
with OIDC off.

`openbank-settlement-service` is the one exception (no JDBC URL) and is **excluded out loud with its
reason**, printed as a `::warning::`. A silently shortened list reads as "covered" when it is not,
which is the exact failure class #2365 is about.

## Scope is derived, not hand-kept

The list comes from `rules.yaml: money_path_services` plus the legacy set, so a service that becomes
money-path is fuzzed the day `rules.yaml` says so. There is no second list to keep in step.

## Sequential loop → matrix

Forced by the scope change: 23 services through one 45-minute job — postgres container, Gradle
build, `quarkusDev` boot and fuzz for *each* — does not fit.

It is also strictly better than the loop was. The old shared `OVERALL=1` meant a service that failed
to boot early **consumed the time budget of everything after it and hid their results**. Now:
`fail-fast: false`, `max-parallel: 8`, per-service artifact names so 23 uploads do not collide, and
a 30-minute per-service timeout.

## Verified by running the derive step extracted from the workflow

Not a retyped copy — parsed out of the YAML and executed:

| Case | Result |
|---|---|
| Derived scope (no override) | 23 services, **19 money-path**, settlement excluded with a warning |
| Dispatch override with an unknown module | keeps the valid one, drops the unknown **with its reason** |
| `actionlint` finding sets vs `main` | **identical** — no new lint introduced (the one `SC2034` is pre-existing, in a readiness loop this change does not touch) |

## Expect the first run to be informative, not green

These eighteen services have never been booted this way, so some will fail readiness in dev mode —
missing Redis, an unlazy client, whatever. **That is the point.** It is a scheduled workflow and
never a PR gate (ADR-0053), so a red service is a finding, not a blocked merge, and each one now
reports independently instead of hiding behind the first failure.

## What this does and does not settle

It unblocks the `pentest` key for the services it covers. It does **not** decide whether an automated
DAST/fuzz run is sufficient evidence for that attestation — precedent has already answered yes twice
(`by: ci-zap-baseline`, `by: ci-schemathesis` in `attestations.yaml`), and that should be made
explicit rather than left set by accident. See the triage comment on #2365.

Related and still open: `api-fuzz-authenticated.yml` has **0 runs, ever** — the authenticated
surface, where the money-path endpoints actually live, has never been fuzzed anywhere (#852).

## Definition of Done

- [x] Scope derived from `rules.yaml`, exclusions printed rather than silent.
- [x] Derive step tested as extracted from the workflow, both the derived and override paths.
- [x] `actionlint` finding sets compared against `main` rather than read in isolation.
- [ ] Unit tests / OpenAPI / Flyway — not applicable; CI only, no service code touched.

## Security checklist

- [x] No secrets — the postgres password is a job-local throwaway, unchanged from before.
- [x] No new dependency; schemathesis stays hash-locked via the existing requirements file.
- [x] Permissions still `contents: read`.

## Compliance impact

- [ ] None directly. It supplies evidence toward the `pentest` attestation that keeps money-path
      services NO-GO in the prod-readiness matrix (#2365).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
