### PR TITLE
fix(admin-ui): server routes cannot fetch a relative URL — the real cause of "not responding"

### DIFF
--- a/openbank-admin-ui/src/app/api/approvals/pending/route.ts
+++ b/openbank-admin-ui/src/app/api/approvals/pending/route.ts
@@ -11,7 +11,7 @@
 
 import { NextResponse } from 'next/server'
 import { auth } from '@/auth'
-import { svcUrl } from '@/lib/services/bff'
+import { serverSvcUrl } from '@/lib/services/bff'
 
 export const dynamic = 'force-dynamic'
 
@@ -55,7 +55,7 @@ function stateFor(status: number): SourceState {
 }
 
 async function lendingPending(headers: HeadersInit): Promise<SourceResult> {
-  const res = await fetch(svcUrl('lending-service', '/api/v1/lending/approvals', { limit: '50' }), {
+  const res = await fetch(serverSvcUrl('lending-service', 'lending', 8126, '/api/v1/lending/approvals', { limit: '50' }), {
     headers, signal: AbortSignal.timeout(4000), cache: 'no-store',
   })
   if (!res.ok) return { items: [], state: stateFor(res.status) }

--- a/openbank-admin-ui/src/app/api/campaigns/[id]/route.ts
+++ b/openbank-admin-ui/src/app/api/campaigns/[id]/route.ts
@@ -8,7 +8,7 @@
 
 import { NextResponse } from 'next/server'
 import { auth } from '@/auth'
-import { svcUrl } from '@/lib/services/bff'
+import { serverSvcUrl } from '@/lib/services/bff'
 
 export const dynamic = 'force-dynamic'
 
@@ -16,7 +16,7 @@ type Part = { data: unknown; state: 'ok' | 'unauthorized' | 'not_deployed' | 'un
 
 async function read(headers: HeadersInit, path: string, fallback: unknown): Promise<Part> {
   try {
-    const res = await fetch(svcUrl('campaign-service', path), {
+    const res = await fetch(serverSvcUrl('campaign-service', 'campaign', 8128, path), {
       headers,
       signal: AbortSignal.timeout(4000),
       cache: 'no-store',

--- a/openbank-admin-ui/src/app/api/campaigns/route.ts
+++ b/openbank-admin-ui/src/app/api/campaigns/route.ts
@@ -8,7 +8,7 @@
 
 import { NextResponse } from 'next/server'
 import { auth } from '@/auth'
-import { svcUrl } from '@/lib/services/bff'
+import { serverSvcUrl } from '@/lib/services/bff'
 
 export const dynamic = 'force-dynamic'
 
@@ -19,7 +19,7 @@ export async function GET() {
   }
   const headers = { authorization: `Bearer ${session.user.accessToken}` }
   try {
-    const res = await fetch(svcUrl('campaign-service', '/api/v1/campaigns'), {
+    const res = await fetch(serverSvcUrl('campaign-service', 'campaign', 8128, '/api/v1/campaigns'), {
       headers,
       signal: AbortSignal.timeout(4000),
       cache: 'no-store',

--- a/openbank-admin-ui/src/app/api/entities/resolve/route.ts
+++ b/openbank-admin-ui/src/app/api/entities/resolve/route.ts
@@ -13,7 +13,7 @@
 
 import { NextRequest, NextResponse } from 'next/server'
 import { auth } from '@/auth'
-import { svcUrl } from '@/lib/services/bff'
+import { serverSvcUrl } from '@/lib/services/bff'
 import { hasIbanShape, isValidIban, normalizeIban } from '@/lib/validation/iban'
 
 export const dynamic = 'force-dynamic'
@@ -41,7 +41,7 @@ type AccountView = {
 }
 
 async function resolveParties(q: string, headers: HeadersInit): Promise<EntityRef[]> {
-  const res = await fetch(svcUrl('party-service', '/api/v1/parties/search', { q, limit: String(MAX_RESULTS) }), {
+  const res = await fetch(serverSvcUrl('party-service', 'party', 8111, '/api/v1/parties/search', { q, limit: String(MAX_RESULTS) }), {
     headers,
     signal: AbortSignal.timeout(4000),
     cache: 'no-store',
@@ -59,7 +59,7 @@ async function resolveParties(q: string, headers: HeadersInit): Promise<EntityRe
 
 async function resolveAccountByIban(q: string, headers: HeadersInit): Promise<EntityRef[]> {
   if (!hasIbanShape(q) || !isValidIban(q)) return []
-  const res = await fetch(svcUrl('account-service', `/api/v1/accounts/iban/${normalizeIban(q)}`), {
+  const res = await fetch(serverSvcUrl('account-service', 'accounts', 8100, `/api/v1/accounts/iban/${normalizeIban(q)}`), {
     headers,
     signal: AbortSignal.timeout(4000),
     cache: 'no-store',

--- a/openbank-admin-ui/src/lib/services/bff.ts
+++ b/openbank-admin-ui/src/lib/services/bff.ts
@@ -38,6 +38,33 @@ export function svcUrl(
 /** The monorepo folder / release-please component for a service, e.g.
  *  `account-service` → `openbank-account-service`. Used by the docs BFF
  *  (/api/docs/...) to locate per-service CHANGELOG / release tags. */
+/**
+ * Absolute upstream URL for a cluster service, for use in SERVER code (route handlers).
+ *
+ * [svcUrl] returns a same-origin *relative* path, which is right for the browser and wrong here:
+ * Node's `fetch` rejects a relative URL outright with `Failed to parse URL from /api/svc/…`. That
+ * throw is easy to swallow in a `catch` and surface as "the service did not answer", which is how
+ * the campaign console reported a healthy service as down (#2749).
+ *
+ * In-cluster we address the Service DNS directly — the proxy exists to give the *browser* a
+ * same-origin path, and server code has no such constraint. Off-cluster we fall back to the same
+ * localhost convention the proxy uses for local dev.
+ */
+export function serverSvcUrl(
+  k8sName: string,
+  namespace: string,
+  port: number,
+  path: string,
+  query?: Record<string, string>,
+): string {
+  const p = path.startsWith('/') ? path : `/${path}`
+  const qs = query && Object.keys(query).length ? `?${new URLSearchParams(query).toString()}` : ''
+  const host = process.env.KUBERNETES_SERVICE_HOST
+    ? `${k8sName}.${namespace}.svc:${port}`
+    : `${process.env.SERVICES_HOST ?? 'localhost'}:${port}`
+  return `http://${host}${p}${qs}`
+}
+
 export function componentFolder(k8sName: string): string {
   return k8sName.startsWith('openbank-') ? k8sName : `openbank-${k8sName}`
 }

--- a/openbank-admin-ui/src/test/service-registry.guard.test.ts
+++ b/openbank-admin-ui/src/test/service-registry.guard.test.ts
@@ -313,6 +313,35 @@ describe('service registry drift guard', () => {
     ).toEqual([])
   })
 
+  it('no server route calls svcUrl() — a relative URL cannot be fetched server-side', () => {
+    // svcUrl() returns a same-origin RELATIVE path. That is correct for the browser and fatal in a
+    // route handler: Node's fetch answers `Failed to parse URL from /api/svc/…`, which lands in a
+    // catch and surfaces as "the service did not answer" — a healthy service reported as down. It
+    // cost the campaign console three wrong diagnoses before the throw was read (#2749).
+    //
+    // Server code addresses the Service DNS directly via serverSvcUrl(); the proxy exists to give
+    // the BROWSER a same-origin path, which server code does not need.
+    const offenders: string[] = []
+    const walkDir = (dir: string): string[] =>
+      readdirSync(dir, { withFileTypes: true }).flatMap(e => {
+        const full = path.join(dir, e.name)
+        return e.isDirectory() ? walkDir(full) : [full]
+      })
+    for (const file of walkDir(path.join(ADMIN_UI, 'src/app'))) {
+      // Route handlers only: a page.tsx marked 'use client' runs in the browser, where svcUrl is right.
+      if (!/route\.tsx?$/.test(file)) continue
+      const src = readFileSync(file, 'utf8')
+      if (/\bsvcUrl\s*\(/.test(src) && !/\bserverSvcUrl\s*\(/.test(src.match(/\bsvcUrl\s*\(/) ? src : '')) {
+        if (/[^r]\bsvcUrl\s*\(/.test(src)) offenders.push(path.relative(ADMIN_UI, file))
+      }
+    }
+    expect(
+      offenders,
+      'route handlers calling svcUrl(). Node fetch rejects the relative URL it returns; use '
+      + 'serverSvcUrl(name, namespace, port, path) instead.',
+    ).toEqual([])
+  })
+
   it('SERVICE_MAP containers agree with SERVICE_REGISTRY on the module directory', () => {
     const dirs = moduleDirs()
     const src = readFileSync(BFF_ROUTE, 'utf-8')


### PR DESCRIPTION
## The actual cause, measured

From inside the admin-ui pod:

```
node -e "fetch('/api/svc/campaign-service/api/v1/campaigns')"
TypeError: Failed to parse URL from /api/svc/campaign-service/api/v1/campaigns
```

`svcUrl()` returns a same-origin **relative** path — right for the browser, fatal in a route
handler. Node's `fetch` rejects it, the throw lands in the route's `catch`, and the console reports
*"the service is deployed but did not answer"* for a healthy `2/2` service.

## Two earlier fixes, two wrong diagnoses

I claimed the cause twice with more confidence than I had earned:

- **#2997** added the missing `SERVICE_MAP` key. In-cluster that map is unused.
- **#3018** added `campaign` to `OPENBANK_NAMESPACES` and its discovery RoleBinding. Genuinely
  missing — but never reached, because the fetch died before resolution.

Both closed real gaps and both keep their guards. Neither was this bug. What I should have done
first, and did only now, was read the throw instead of reasoning about the layers.

## Fix

`serverSvcUrl(name, namespace, port, path)` addresses the Service DNS directly. The proxy exists to
give the **browser** a same-origin path; server code has no such constraint.

## The guard found two more, both already in production

| Route | Screen |
|-------|--------|
| `api/approvals/pending/route.ts` | the ADR-0227 approval inbox |
| `api/entities/resolve/route.ts` | party + account lookup |

Both have been failing this way silently, presented to operators as "unavailable". An approvals
inbox that cannot read its queue is the most dangerous version of this: *"no approvals pending"* is
exactly what that screen must never say wrongly, and its own source comment says so.

Migrated as well, with namespace and port verified against the live cluster.

## Guard

Route handlers may not call `svcUrl()`. Falsified — it fails naming both pre-existing offenders,
which is how they were found rather than by reading every route.

Full suite: 891 passing.

Refs #2749, #2895