### PR TITLE
fix(approvals): a null JSON body on the four-eyes decide endpoint returned 500 (#3029)

### DIFF
--- a/openbank-account-service/src/main/kotlin/com/openbank/account/infrastructure/rest/ApprovalResource.kt
+++ b/openbank-account-service/src/main/kotlin/com/openbank/account/infrastructure/rest/ApprovalResource.kt
@@ -41,7 +41,12 @@ class ApprovalResource(private val approvalStore: ApprovalStore) {
     @RolesAllowed(Roles.OPERATOR, Roles.ADMIN)
     @Authorize(action = "account.approval.decide", resource = "#id")
     @Operation(summary = "Approve or reject a pending four-eyes approval")
-    suspend fun decide(@PathParam("id") id: String, request: DecideApprovalRequest): Response {
+    suspend fun decide(@PathParam("id") id: String, request: DecideApprovalRequest?): Response {
+        // A JSON `null` body deserialises to null even though the Kotlin type is non-nullable, so
+        // the first field access threw NPE and JAX-RS answered 500 on a four-eyes approval endpoint
+        // (#3029, found by the first working run of api-fuzz-authenticated). Same guard the other
+        // resources in this fleet already use; libs-runtime maps IllegalArgumentException to 400.
+        requireNotNull(request) { "request body is required" }
         val decided = approvalStore.decide(id, checkerId(), request.approve)
             ?: throw NotFoundException("no pending approval with id=$id")
         return Response.ok(decided.toResponse()).build()

--- a/openbank-balance-service/src/main/kotlin/com/openbank/balance/infrastructure/rest/ApprovalResource.kt
+++ b/openbank-balance-service/src/main/kotlin/com/openbank/balance/infrastructure/rest/ApprovalResource.kt
@@ -44,7 +44,12 @@ class ApprovalResource(private val approvalStore: ApprovalStore) {
     @RolesAllowed(Roles.OPERATOR, Roles.ADMIN)
     @Authorize(action = "balance.approval.decide", resource = "#id")
     @Operation(summary = "Approve or reject a pending four-eyes approval")
-    suspend fun decide(@PathParam("id") id: String, request: DecideApprovalRequest): Response {
+    suspend fun decide(@PathParam("id") id: String, request: DecideApprovalRequest?): Response {
+        // A JSON `null` body deserialises to null even though the Kotlin type is non-nullable, so
+        // the first field access threw NPE and JAX-RS answered 500 on a four-eyes approval endpoint
+        // (#3029, found by the first working run of api-fuzz-authenticated). Same guard the other
+        // resources in this fleet already use; libs-runtime maps IllegalArgumentException to 400.
+        requireNotNull(request) { "request body is required" }
         val decided = approvalStore.decide(id, checkerId(), request.approve)
             ?: throw NotFoundException("no pending approval with id=$id")
         return Response.ok(decided.toResponse()).build()

--- a/openbank-billing-service/src/main/kotlin/com/openbank/billing/infrastructure/rest/ApprovalResource.kt
+++ b/openbank-billing-service/src/main/kotlin/com/openbank/billing/infrastructure/rest/ApprovalResource.kt
@@ -41,7 +41,12 @@ class ApprovalResource(private val approvalStore: ApprovalStore) {
     @RolesAllowed("ROLE_OPERATOR", "ROLE_ADMIN")
     @Authorize(action = "billing.approval.decide", resource = "#id")
     @Operation(summary = "Approve or reject a pending four-eyes approval for a fee posting")
-    suspend fun decide(@PathParam("id") id: String, request: DecideApprovalRequest): Response {
+    suspend fun decide(@PathParam("id") id: String, request: DecideApprovalRequest?): Response {
+        // A JSON `null` body deserialises to null even though the Kotlin type is non-nullable, so
+        // the first field access threw NPE and JAX-RS answered 500 on a four-eyes approval endpoint
+        // (#3029, found by the first working run of api-fuzz-authenticated). Same guard the other
+        // resources in this fleet already use; libs-runtime maps IllegalArgumentException to 400.
+        requireNotNull(request) { "request body is required" }
         val decided = approvalStore.decide(id, checkerId(), request.approve)
             ?: throw NotFoundException("no pending approval with id=$id")
         return Response.ok(decided.toResponse()).build()

--- a/openbank-clearing-service/src/main/kotlin/com/openbank/clearing/infrastructure/rest/ApprovalResource.kt
+++ b/openbank-clearing-service/src/main/kotlin/com/openbank/clearing/infrastructure/rest/ApprovalResource.kt
@@ -41,7 +41,12 @@ class ApprovalResource(private val approvalStore: ApprovalStore) {
     @RolesAllowed(Roles.PAYMENTS, Roles.ADMIN)
     @Authorize(action = "clearingBatch.approval.decide", resource = "#id")
     @Operation(summary = "Approve or reject a pending four-eyes approval")
-    suspend fun decide(@PathParam("id") id: String, request: DecideApprovalRequest): Response {
+    suspend fun decide(@PathParam("id") id: String, request: DecideApprovalRequest?): Response {
+        // A JSON `null` body deserialises to null even though the Kotlin type is non-nullable, so
+        // the first field access threw NPE and JAX-RS answered 500 on a four-eyes approval endpoint
+        // (#3029, found by the first working run of api-fuzz-authenticated). Same guard the other
+        // resources in this fleet already use; libs-runtime maps IllegalArgumentException to 400.
+        requireNotNull(request) { "request body is required" }
         val decided = approvalStore.decide(id, checkerId(), request.approve)
             ?: throw NotFoundException("no pending approval with id=$id")
         return Response.ok(decided.toResponse()).build()

--- a/openbank-consent-service/src/main/kotlin/com/openbank/consent/infrastructure/rest/ApprovalResource.kt
+++ b/openbank-consent-service/src/main/kotlin/com/openbank/consent/infrastructure/rest/ApprovalResource.kt
@@ -43,7 +43,12 @@ class ApprovalResource(private val approvalStore: ApprovalStore) {
     @RolesAllowed("ROLE_OPERATOR", "ROLE_ADMIN")
     @Authorize(action = "consent.approval.decide", resource = "#id")
     @Operation(summary = "Approve or reject a pending four-eyes approval for a gated consent action")
-    suspend fun decide(@PathParam("id") id: String, request: DecideApprovalRequest): Response {
+    suspend fun decide(@PathParam("id") id: String, request: DecideApprovalRequest?): Response {
+        // A JSON `null` body deserialises to null even though the Kotlin type is non-nullable, so
+        // the first field access threw NPE and JAX-RS answered 500 on a four-eyes approval endpoint
+        // (#3029, found by the first working run of api-fuzz-authenticated). Same guard the other
+        // resources in this fleet already use; libs-runtime maps IllegalArgumentException to 400.
+        requireNotNull(request) { "request body is required" }
         val decided = approvalStore.decide(id, checkerId(), request.approve)
             ?: throw NotFoundException("no pending approval with id=$id")
         return Response.ok(decided.toResponse()).build()

--- a/openbank-consent-service/src/test/kotlin/com/openbank/consent/ApprovalNullBodyTest.kt
+++ b/openbank-consent-service/src/test/kotlin/com/openbank/consent/ApprovalNullBodyTest.kt
@@ -1,0 +1,49 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright (c) OpenBank contributors. Licensed under the Apache License, Version 2.0.
+// See LICENSE in the repository root or https://www.apache.org/licenses/LICENSE-2.0 for details.
+
+package com.openbank.consent
+
+import com.openbank.consent.infrastructure.rest.ApprovalResource
+import com.openbank.libs.approval.ApprovalStore
+import io.mockk.mockk
+import kotlinx.coroutines.runBlocking
+import org.assertj.core.api.Assertions.assertThatThrownBy
+import org.junit.jupiter.api.Test
+
+/**
+ * Regression for #3029: `PATCH /api/v1/consents/approvals/{id}` answered **500** to a JSON `null`
+ * body.
+ *
+ * The parameter was declared non-nullable (`request: DecideApprovalRequest`), but Kotlin's
+ * null-safety is a compile-time property — JAX-RS/Jackson hands a `null` straight through at
+ * runtime, so the first field access threw NPE and the generic mapper turned it into 500 on a
+ * **four-eyes approval endpoint**. The property being violated is the one the authenticated fuzz
+ * lane asserts: no input, however malformed, produces a 5xx (ADR-0080).
+ *
+ * Found by the first ever working run of `api-fuzz-authenticated.yml` — the lane had never started
+ * before, so nothing had ever sent this request. The identical shape existed in all sixteen
+ * `ApprovalResource` copies; this test covers the one with a reproduced failure.
+ *
+ * `requireNotNull` runs before `checkerId()`, so no `SecurityIdentity` is needed here — a null body
+ * is rejected before any identity is resolved, which is also the behaviour you want: an
+ * unparseable request should not reach authorization-adjacent code at all.
+ *
+ * Note on "fail first": this test could not have compiled against the old signature, since it
+ * passes `null` where the parameter was non-nullable. What it locks in is the new contract — a
+ * missing body is a client error, not a server error — so a future change back to a non-nullable
+ * parameter breaks the build rather than silently restoring the 500.
+ */
+class ApprovalNullBodyTest {
+
+    @Test
+    fun `a null request body is a client error, never a 500`(): Unit = runBlocking {
+        val resource = ApprovalResource(mockk<ApprovalStore>(relaxed = true))
+
+        assertThatThrownBy { runBlocking { resource.decide("appr-1", null) } }
+            // libs-runtime's CommonExceptionMappers maps IllegalArgumentException to 400 — the same
+            // guard ConsentResource already uses for its own request bodies.
+            .isInstanceOf(IllegalArgumentException::class.java)
+            .hasMessageContaining("request body is required")
+    }
+}

--- a/openbank-domestic-payment/src/main/kotlin/com/openbank/domestic/infrastructure/rest/ApprovalResource.kt
+++ b/openbank-domestic-payment/src/main/kotlin/com/openbank/domestic/infrastructure/rest/ApprovalResource.kt
@@ -40,7 +40,12 @@ class ApprovalResource(private val approvalStore: ApprovalStore) {
     @RolesAllowed("ROLE_OPERATOR", "ROLE_ADMIN", "ROLE_PAYMENTS")
     @Authorize(action = "domestic-payment.approval.decide", resource = "#id")
     @Operation(summary = "Approve or reject a pending four-eyes approval")
-    suspend fun decide(@PathParam("id") id: String, request: DecideApprovalRequest): Response {
+    suspend fun decide(@PathParam("id") id: String, request: DecideApprovalRequest?): Response {
+        // A JSON `null` body deserialises to null even though the Kotlin type is non-nullable, so
+        // the first field access threw NPE and JAX-RS answered 500 on a four-eyes approval endpoint
+        // (#3029, found by the first working run of api-fuzz-authenticated). Same guard the other
+        // resources in this fleet already use; libs-runtime maps IllegalArgumentException to 400.
+        requireNotNull(request) { "request body is required" }
         val decided = approvalStore.decide(id, checkerId(), request.approve)
             ?: throw NotFoundException("no pending approval with id=$id")
         return Response.ok(decided.toResponse()).build()

--- a/openbank-fx-service/src/main/kotlin/com/openbank/fx/infrastructure/rest/ApprovalResource.kt
+++ b/openbank-fx-service/src/main/kotlin/com/openbank/fx/infrastructure/rest/ApprovalResource.kt
@@ -40,7 +40,12 @@ class ApprovalResource(private val approvalStore: ApprovalStore) {
     @RolesAllowed("ROLE_OPERATOR", "ROLE_ADMIN")
     @Authorize(action = "fx.approval.decide", resource = "#id")
     @Operation(summary = "Approve or reject a pending four-eyes approval for an FX conversion")
-    suspend fun decide(@PathParam("id") id: String, request: DecideApprovalRequest): Response {
+    suspend fun decide(@PathParam("id") id: String, request: DecideApprovalRequest?): Response {
+        // A JSON `null` body deserialises to null even though the Kotlin type is non-nullable, so
+        // the first field access threw NPE and JAX-RS answered 500 on a four-eyes approval endpoint
+        // (#3029, found by the first working run of api-fuzz-authenticated). Same guard the other
+        // resources in this fleet already use; libs-runtime maps IllegalArgumentException to 400.
+        requireNotNull(request) { "request body is required" }
         val decided = approvalStore.decide(id, checkerId(), request.approve)
             ?: throw NotFoundException("no pending approval with id=$id")
         return Response.ok(decided.toResponse()).build()

--- a/openbank-ledger-service/src/main/kotlin/com/openbank/ledger/infrastructure/rest/ApprovalResource.kt
+++ b/openbank-ledger-service/src/main/kotlin/com/openbank/ledger/infrastructure/rest/ApprovalResource.kt
@@ -41,7 +41,12 @@ class ApprovalResource(private val approvalStore: ApprovalStore) {
     @RolesAllowed(Roles.OPERATOR, Roles.ADMIN)
     @Authorize(action = "ledger.approval.decide", resource = "#id")
     @Operation(summary = "Approve or reject a pending four-eyes approval")
-    suspend fun decide(@PathParam("id") id: String, request: DecideApprovalRequest): Response {
+    suspend fun decide(@PathParam("id") id: String, request: DecideApprovalRequest?): Response {
+        // A JSON `null` body deserialises to null even though the Kotlin type is non-nullable, so
+        // the first field access threw NPE and JAX-RS answered 500 on a four-eyes approval endpoint
+        // (#3029, found by the first working run of api-fuzz-authenticated). Same guard the other
+        // resources in this fleet already use; libs-runtime maps IllegalArgumentException to 400.
+        requireNotNull(request) { "request body is required" }
         val decided = approvalStore.decide(id, checkerId(), request.approve)
             ?: throw NotFoundException("no pending approval with id=$id")
         return Response.ok(decided.toResponse()).build()

--- a/openbank-lending-service/src/main/kotlin/com/openbank/lending/infrastructure/rest/ApprovalResource.kt
+++ b/openbank-lending-service/src/main/kotlin/com/openbank/lending/infrastructure/rest/ApprovalResource.kt
@@ -52,7 +52,12 @@ class ApprovalResource(private val approvalStore: ApprovalStore) {
     @RolesAllowed("ROLE_LENDING_OFFICER", "ROLE_ADMIN")
     @Authorize(action = "lending.approval.decide", resource = "#id")
     @Operation(summary = "Approve or reject a pending four-eyes approval")
-    suspend fun decide(@PathParam("id") id: String, request: DecideApprovalRequest): Response {
+    suspend fun decide(@PathParam("id") id: String, request: DecideApprovalRequest?): Response {
+        // A JSON `null` body deserialises to null even though the Kotlin type is non-nullable, so
+        // the first field access threw NPE and JAX-RS answered 500 on a four-eyes approval endpoint
+        // (#3029, found by the first working run of api-fuzz-authenticated). Same guard the other
+        // resources in this fleet already use; libs-runtime maps IllegalArgumentException to 400.
+        requireNotNull(request) { "request body is required" }
         val decided = approvalStore.decide(id, checkerId(), request.approve)
             ?: throw NotFoundException("no pending approval with id=$id")
         return Response.ok(decided.toResponse()).build()

--- a/openbank-notification-service/src/main/kotlin/com/openbank/notification/infrastructure/rest/ApprovalResource.kt
+++ b/openbank-notification-service/src/main/kotlin/com/openbank/notification/infrastructure/rest/ApprovalResource.kt
@@ -46,7 +46,12 @@ class ApprovalResource(private val approvalStore: ApprovalStore) {
     @RolesAllowed("ROLE_OPERATOR", "ROLE_ADMIN")
     @Authorize(action = "opsmessage.approval.decide", resource = "#id")
     @Operation(summary = "Approve or reject a pending four-eyes approval for an operator message")
-    suspend fun decide(@PathParam("id") id: String, request: DecideApprovalRequest): Response {
+    suspend fun decide(@PathParam("id") id: String, request: DecideApprovalRequest?): Response {
+        // A JSON `null` body deserialises to null even though the Kotlin type is non-nullable, so
+        // the first field access threw NPE and JAX-RS answered 500 on a four-eyes approval endpoint
+        // (#3029, found by the first working run of api-fuzz-authenticated). Same guard the other
+        // resources in this fleet already use; libs-runtime maps IllegalArgumentException to 400.
+        requireNotNull(request) { "request body is required" }
         val decided = approvalStore.decide(id, checkerId(), request.approve)
             ?: throw NotFoundException("no pending approval with id=$id")
         return Response.ok(decided.toResponse()).build()

--- a/openbank-party-service/src/main/kotlin/com/openbank/party/infrastructure/rest/ApprovalResource.kt
+++ b/openbank-party-service/src/main/kotlin/com/openbank/party/infrastructure/rest/ApprovalResource.kt
@@ -53,7 +53,12 @@ class ApprovalResource(private val approvalStore: ApprovalStore) {
     @RolesAllowed("ROLE_OPERATOR", "ROLE_ADMIN")
     @Authorize(action = "party.approval.decide", resource = "#id")
     @Operation(summary = "Approve or reject a pending four-eyes approval for a gated party action")
-    suspend fun decide(@PathParam("id") id: String, request: DecideApprovalRequest): Response {
+    suspend fun decide(@PathParam("id") id: String, request: DecideApprovalRequest?): Response {
+        // A JSON `null` body deserialises to null even though the Kotlin type is non-nullable, so
+        // the first field access threw NPE and JAX-RS answered 500 on a four-eyes approval endpoint
+        // (#3029, found by the first working run of api-fuzz-authenticated). Same guard the other
+        // resources in this fleet already use; libs-runtime maps IllegalArgumentException to 400.
+        requireNotNull(request) { "request body is required" }
         val decided = approvalStore.decide(id, checkerId(), request.approve)
             ?: throw NotFoundException("no pending approval with id=$id")
         return Response.ok(decided.toApprovalResponse()).build()

--- a/openbank-sanctions-service/src/main/kotlin/com/openbank/sanctions/infrastructure/rest/ApprovalResource.kt
+++ b/openbank-sanctions-service/src/main/kotlin/com/openbank/sanctions/infrastructure/rest/ApprovalResource.kt
@@ -41,7 +41,12 @@ class ApprovalResource(private val approvalStore: ApprovalStore) {
     @RolesAllowed("ROLE_OPERATOR", "ROLE_ADMIN")
     @Authorize(action = "sanctions.approval.decide", resource = "#id")
     @Operation(summary = "Approve or reject a pending four-eyes approval for a gated sanctions action")
-    suspend fun decide(@PathParam("id") id: String, request: DecideApprovalRequest): Response {
+    suspend fun decide(@PathParam("id") id: String, request: DecideApprovalRequest?): Response {
+        // A JSON `null` body deserialises to null even though the Kotlin type is non-nullable, so
+        // the first field access threw NPE and JAX-RS answered 500 on a four-eyes approval endpoint
+        // (#3029, found by the first working run of api-fuzz-authenticated). Same guard the other
+        // resources in this fleet already use; libs-runtime maps IllegalArgumentException to 400.
+        requireNotNull(request) { "request body is required" }
         val decided = approvalStore.decide(id, checkerId(), request.approve)
             ?: throw NotFoundException("no pending approval with id=$id")
         return Response.ok(decided.toResponse()).build()

--- a/openbank-sepa-instant/src/main/kotlin/com/openbank/sepainstant/infrastructure/rest/ApprovalResource.kt
+++ b/openbank-sepa-instant/src/main/kotlin/com/openbank/sepainstant/infrastructure/rest/ApprovalResource.kt
@@ -40,7 +40,12 @@ class ApprovalResource(private val approvalStore: ApprovalStore) {
     @RolesAllowed("ROLE_OPERATOR", "ROLE_ADMIN", "ROLE_PAYMENTS")
     @Authorize(action = "sctInstPayment.approval.decide", resource = "#id")
     @Operation(summary = "Approve or reject a pending four-eyes approval")
-    suspend fun decide(@PathParam("id") id: String, request: DecideApprovalRequest): Response {
+    suspend fun decide(@PathParam("id") id: String, request: DecideApprovalRequest?): Response {
+        // A JSON `null` body deserialises to null even though the Kotlin type is non-nullable, so
+        // the first field access threw NPE and JAX-RS answered 500 on a four-eyes approval endpoint
+        // (#3029, found by the first working run of api-fuzz-authenticated). Same guard the other
+        // resources in this fleet already use; libs-runtime maps IllegalArgumentException to 400.
+        requireNotNull(request) { "request body is required" }
         val decided = approvalStore.decide(id, checkerId(), request.approve)
             ?: throw NotFoundException("no pending approval with id=$id")
         return Response.ok(decided.toResponse()).build()

--- a/openbank-sepa-payment/src/main/kotlin/com/openbank/sepa/infrastructure/rest/ApprovalResource.kt
+++ b/openbank-sepa-payment/src/main/kotlin/com/openbank/sepa/infrastructure/rest/ApprovalResource.kt
@@ -40,7 +40,12 @@ class ApprovalResource(private val approvalStore: ApprovalStore) {
     @RolesAllowed("ROLE_OPERATOR", "ROLE_ADMIN", "ROLE_PAYMENTS")
     @Authorize(action = "sepaPayment.approval.decide", resource = "#id")
     @Operation(summary = "Approve or reject a pending four-eyes approval")
-    suspend fun decide(@PathParam("id") id: String, request: DecideApprovalRequest): Response {
+    suspend fun decide(@PathParam("id") id: String, request: DecideApprovalRequest?): Response {
+        // A JSON `null` body deserialises to null even though the Kotlin type is non-nullable, so
+        // the first field access threw NPE and JAX-RS answered 500 on a four-eyes approval endpoint
+        // (#3029, found by the first working run of api-fuzz-authenticated). Same guard the other
+        // resources in this fleet already use; libs-runtime maps IllegalArgumentException to 400.
+        requireNotNull(request) { "request body is required" }
         val decided = approvalStore.decide(id, checkerId(), request.approve)
             ?: throw NotFoundException("no pending approval with id=$id")
         return Response.ok(decided.toResponse()).build()

--- a/openbank-swift-service/src/main/kotlin/com/openbank/swift/infrastructure/rest/ApprovalResource.kt
+++ b/openbank-swift-service/src/main/kotlin/com/openbank/swift/infrastructure/rest/ApprovalResource.kt
@@ -51,7 +51,12 @@ class ApprovalResource(private val approvalStore: ApprovalStore) {
     @RolesAllowed("ROLE_OPERATOR", "ROLE_ADMIN", "ROLE_PAYMENTS")
     @Authorize(action = "swift.approval.decide", resource = "#id")
     @Operation(summary = "Approve or reject a pending four-eyes approval")
-    suspend fun decide(@PathParam("id") id: String, request: DecideApprovalRequest): Response {
+    suspend fun decide(@PathParam("id") id: String, request: DecideApprovalRequest?): Response {
+        // A JSON `null` body deserialises to null even though the Kotlin type is non-nullable, so
+        // the first field access threw NPE and JAX-RS answered 500 on a four-eyes approval endpoint
+        // (#3029, found by the first working run of api-fuzz-authenticated). Same guard the other
+        // resources in this fleet already use; libs-runtime maps IllegalArgumentException to 400.
+        requireNotNull(request) { "request body is required" }
         val decided = approvalStore.decide(id, checkerId(), request.approve)
             ?: throw NotFoundException("no pending approval with id=$id")
         return Response.ok(decided.toResponse()).build()

--- a/openbank-transaction-service/src/main/kotlin/com/openbank/transaction/infrastructure/rest/ApprovalResource.kt
+++ b/openbank-transaction-service/src/main/kotlin/com/openbank/transaction/infrastructure/rest/ApprovalResource.kt
@@ -44,7 +44,12 @@ class ApprovalResource(private val approvalStore: ApprovalStore) {
     @RolesAllowed(Roles.OPERATOR, Roles.ADMIN)
     @Authorize(action = "transaction.approval.decide", resource = "#id")
     @Operation(summary = "Approve or reject a pending four-eyes approval")
-    suspend fun decide(@PathParam("id") id: String, request: DecideApprovalRequest): Response {
+    suspend fun decide(@PathParam("id") id: String, request: DecideApprovalRequest?): Response {
+        // A JSON `null` body deserialises to null even though the Kotlin type is non-nullable, so
+        // the first field access threw NPE and JAX-RS answered 500 on a four-eyes approval endpoint
+        // (#3029, found by the first working run of api-fuzz-authenticated). Same guard the other
+        // resources in this fleet already use; libs-runtime maps IllegalArgumentException to 400.
+        requireNotNull(request) { "request body is required" }
         val decided = approvalStore.decide(id, checkerId(), request.approve)
             ?: throw NotFoundException("no pending approval with id=$id")
         return Response.ok(decided.toResponse()).build()


### PR DESCRIPTION
## Summary

`PATCH /api/v1/consents/approvals/{id}` answered **500 Internal Server Error** to a JSON `null`
body. **The same defect exists in all sixteen `ApprovalResource` copies**, eleven of them money-path.
All sixteen are fixed here.

## Type of change

- [x] fix (bug fix)

## Linked issues

Closes #3029 · Refs #3024, #2365, #852

## The bug

```bash
curl -X PATCH -H 'Authorization: Bearer …' -H 'Content-Type: application/json' \
  -d null http://localhost:8106/api/v1/consents/approvals/<uuid>
```

```json
{"traceId":"8701067a-…","status":500,"code":"INTERNAL_ERROR", …}
```

The parameter was `request: DecideApprovalRequest` — **non-nullable**. Kotlin's null-safety is a
compile-time property; JAX-RS/Jackson hands a `null` straight through at runtime, so the first field
access threw NPE and the generic mapper turned it into a 500 — on a **four-eyes approval endpoint**.

## Not one bug — the same bug sixteen times

Measured before fixing: every `ApprovalResource` in the fleet has a **byte-identical** signature and
its own copy of `data class DecideApprovalRequest(val approve: Boolean)`.

```
16 suspend fun decide(@PathParam("id") id: String, request: DecideApprovalRequest): Response {
```

account · balance · billing · clearing · consent · domestic-payment · fx · ledger · lending ·
notification · party · sanctions · sepa-instant · sepa-payment · swift · transaction

Fixing only the one with a reproduced failure would have left fifteen known-vulnerable copies on
four-eyes endpoints, so all sixteen get the identical guard.

## The fix is this repo's own pattern

`ConsentResource` — in the same service — already declares `CreateConsentRequest?`,
`RevokeConsentRequest?`, `ValidateConsentRequest?` and calls `requireNotNull`. So consent-service was
already guarding its request bodies against exactly this, **everywhere except its approval
endpoint**. `libs-runtime`'s `CommonExceptionMappers` maps `IllegalArgumentException` → 400.

`requireNotNull` runs before `checkerId()`, so an unparseable request is rejected before any
`SecurityIdentity` is resolved — which is the behaviour you want regardless.

## How it was found

The **first ever working run** of `api-fuzz-authenticated.yml`, on the branch of #3024 that repairs
that harness. That lane had **0 successful runs in its lifetime**, so nothing had ever sent this
request to any of the sixteen endpoints. 468 cases generated, 1 unique failure.

The property it asserts — *no input, however malformed, produces a 5xx* — is the public-surface
hardening a pentest probes first (ADR-0080), and the `pentest` dimension keeping money-path services
NO-GO in #2365. The lane found a real money-path defect on its first working day.

## On the regression test

It cannot "fail first" in the usual sense: passing `null` would not have **compiled** against the old
signature. What it locks in is the contract — a change back to a non-nullable parameter breaks the
build rather than silently restoring the 500.

## Definition of Done

- [x] Root cause reproduced and confirmed against the source, not inferred from the symptom.
- [x] Blast radius measured (16 copies) before fixing, rather than patching the reported one.
- [x] Fix matches the existing house pattern instead of inventing a new one.
- [x] Regression test in the service where the failure was reproduced.
- [ ] Local `./gradlew` — not run; the build host's shared Gradle cache is corrupting artifacts. CI
      is the verifier. The change is a signature + one guard line per file, but that is a reason to
      read it, not to trust it.

## Security checklist

- [x] No secrets, no new dependency, no `@Suppress`.
- [x] Auth-adjacent code path on money-path services → `security-review-required`.
- [x] No behaviour change for a well-formed body — only a malformed one moves from 500 to 400.

## Compliance impact

- [x] DORA — a four-eyes control endpoint answering 500 to trivially malformed input.
- [ ] PCI DSS / GDPR / PSD2 / AML / CNB — not applicable.

## Note for review

ADR-0227 will collapse these sixteen resources into one contract. Until then a fix like this has to
land in sixteen places, which is itself an argument for that ADR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
