### PR TITLE
fix(observability): scrape the eight control-plane agents, and derive the gate's scope from the scrape contract

### DIFF
--- a/.github/scripts/check-podmonitor-namespace-coverage.py
+++ b/.github/scripts/check-podmonitor-namespace-coverage.py
@@ -51,11 +51,20 @@ PODMON_REL = Path(
 # openbank-infra/scripts/prod_readiness_collector_test.py and the fixtures in --self-test below.
 sys.path.insert(0, str(REPO / "openbank-infra" / "scripts"))
 from gitops_facts import (  # noqa: E402
+    management_port_workloads,
+    management_scraped_namespaces,
     module_dir,
     money_path_services,
     podmonitor_namespaces,
     workload_namespaces,
 )
+
+# Namespaces that declare a `management` port but are deliberately not scraped. An entry needs a
+# reason, and the gate fails on a stale declaration in EITHER direction — an entry for a namespace
+# that is now scraped, or one whose workload is gone. That asymmetry is the point: a new gap is red
+# by default and only a human writing down why can make it green, which is the opposite of the
+# hand-kept matchNames list this check exists to police.
+NOT_SCRAPED: dict[str, str] = {}
 
 
 def audit(repo: Path) -> tuple[dict[str, list[str]], list[str], int]:
@@ -93,14 +102,36 @@ def audit(repo: Path) -> tuple[dict[str, list[str]], list[str], int]:
     return missing, no_workload, ok
 
 
+def audit_fleet(
+    gitops: Path, not_scraped: dict[str, str] | None = None
+) -> tuple[dict[str, set[str]], list[str], int]:
+    """-> ({namespace: workloads} unscraped, [stale NOT_SCRAPED keys], covered_count)
+
+    The population is every workload declaring a `management` container port, NOT the
+    `openbank-*-service` module list [audit] iterates. Those are different questions and they had
+    different answers: the module list covered 32 namespaces while 36 carried a `management`-port
+    workload, and the four-namespace difference was the entire control-plane agent fleet.
+    """
+    declared = NOT_SCRAPED if not_scraped is None else not_scraped
+    workloads = management_port_workloads(gitops)
+    scraped = management_scraped_namespaces(gitops)
+    everywhere = "*" in scraped
+    unscraped = {
+        ns: names
+        for ns, names in workloads.items()
+        if not everywhere and ns not in scraped and ns not in declared
+    }
+    stale = [ns for ns in declared if ns not in workloads or everywhere or ns in scraped]
+    covered = sum(1 for ns in workloads if everywhere or ns in scraped)
+    return unscraped, sorted(stale), covered
+
+
 def run_gate(repo: Path, quiet: bool = False) -> int:
     missing, no_workload, ok = audit(repo)
     say = (lambda *a: None) if quiet else print
     say(f"PodMonitor namespace coverage: {ok} scraped, {len(missing)} missing, {len(no_workload)} not deployed")
     for short in no_workload:
         say(f"  note: {short} has no Deployment/Rollout in gitops (not deployed yet)")
-    if not missing:
-        return 0
     for short, gaps in sorted(missing.items()):
         for ns in gaps:
             say(
@@ -109,7 +140,27 @@ def run_gate(repo: Path, quiet: bool = False) -> int:
                 f"never reach Prometheus and any PrometheusRule over them cannot fire. "
                 f"Add '{ns}' to {PODMON_REL}."
             )
-    return 1
+
+    gitops = repo / "openbank-infra" / "gitops"
+    unscraped, stale, covered = audit_fleet(gitops)
+    say(
+        f"management-port scrape coverage: {covered} namespaces scraped, "
+        f"{len(unscraped)} unscraped, {len(NOT_SCRAPED)} declared not-scraped"
+    )
+    for ns, names in sorted(unscraped.items()):
+        say(
+            f"::error file={PODMON_REL}::namespace '{ns}' runs "
+            f"{', '.join(sorted(names))}, which declare a `management` container port, but no "
+            f"PodMonitor/ServiceMonitor scrapes that port there — /q/metrics never reaches "
+            f"Prometheus. Add '{ns}' to {PODMON_REL}, or declare it in NOT_SCRAPED in "
+            f"{Path(__file__).name} with a reason."
+        )
+    for ns in stale:
+        say(
+            f"::error file={Path(__file__).name}::NOT_SCRAPED declares '{ns}', but it is now "
+            f"scraped or has no `management`-port workload — remove the stale entry."
+        )
+    return 1 if (missing or unscraped or stale) else 0
 
 
 # ---------------------------------------------------------------------------
@@ -141,6 +192,30 @@ spec:
       containers:
         - name: {short}-service
           image: openbank-{short}-service:1.0.0
+          ports:
+            - name: http
+              containerPort: 8080
+            - name: management
+              containerPort: 9000
+"""
+
+# The same workload WITHOUT a management port. The scrape contract is the port, not the pod: a
+# workload that never exposes /q/metrics is not a coverage gap, and a fleet check that flagged it
+# would produce permanent noise for admin-ui, external-dns, reposilite and the registry caches.
+SELF_TEST_WORKLOAD_NO_MGMT = """apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: {short}-service
+  namespace: {ns}
+spec:
+  template:
+    spec:
+      containers:
+        - name: {short}-service
+          image: openbank-{short}-service:1.0.0
+          ports:
+            - name: http
+              containerPort: 8080
 """
 
 # A NetworkPolicy that only *mentions* the service. If the resolver ever counted a mere
@@ -160,15 +235,25 @@ spec:
 """
 
 
-def build_fixture(root: Path, workloads: list[tuple[str, str]], kustomize_ns: str | None = None):
+def build_fixture(
+    root: Path,
+    workloads: list[tuple[str, str]],
+    kustomize_ns: str | None = None,
+    no_mgmt_port: set[str] | None = None,
+):
     comp = root / "openbank-infra" / "gitops" / "components" / "fixture"
     comp.mkdir(parents=True)
     (root / PODMON_REL).parent.mkdir(parents=True, exist_ok=True)
     (root / PODMON_REL).write_text(SELF_TEST_PODMON)
     for short, ns in workloads:
         (root / f"openbank-{short}-service").mkdir(exist_ok=True)
-        body = SELF_TEST_WORKLOAD.format(short=short, ns=ns) if ns else (
-            SELF_TEST_WORKLOAD.format(short=short, ns="PLACEHOLDER").replace(
+        template = (
+            SELF_TEST_WORKLOAD_NO_MGMT
+            if short in (no_mgmt_port or set())
+            else SELF_TEST_WORKLOAD
+        )
+        body = template.format(short=short, ns=ns) if ns else (
+            template.format(short=short, ns="PLACEHOLDER").replace(
                 "  namespace: PLACEHOLDER\n", ""
             )
         )
@@ -222,6 +307,81 @@ def self_test() -> int:
         [("ledgerish", "")],
         "payments",
         0,
+    )
+
+    # The fleet pass. Its population is the `management` port, so these cases must not be
+    # expressible through the module-name path above — a fixture module that is NOT named
+    # openbank-<short>-service is invisible to audit() and visible to audit_fleet(), which is
+    # exactly the eight-agent blind spot that made the original gate print `0 missing`.
+    def fleet_case(
+        name: str,
+        workloads,
+        want_rc: int,
+        want_in_output: str = "",
+        not_scraped: dict[str, str] | None = None,
+        no_mgmt_port: set[str] | None = None,
+    ):
+        tmp = Path(tempfile.mkdtemp())
+        try:
+            build_fixture(tmp, workloads, None, no_mgmt_port)
+            unscraped, stale, _covered = audit_fleet(
+                tmp / "openbank-infra" / "gitops", not_scraped or {}
+            )
+            rc = 1 if (unscraped or stale) else 0
+            rendered = "; ".join(
+                f"{ns}->{','.join(sorted(w))}" for ns, w in sorted(unscraped.items())
+            ) + ("" if not stale else f" stale:{','.join(stale)}")
+            bad = []
+            if rc != want_rc:
+                bad.append(f"exit {rc}, wanted {want_rc}")
+            if want_in_output and want_in_output not in rendered:
+                bad.append(f"output {rendered!r} lacks {want_in_output!r}")
+            print(f"  {'ok  ' if not bad else 'FAIL'} {name}" + (f" — {'; '.join(bad)}" if bad else ""))
+            if bad:
+                failures.append(name)
+        finally:
+            shutil.rmtree(tmp, ignore_errors=True)
+
+    print("self-test: fleet pass — cases the gate MUST flag")
+    fleet_case(
+        "management-port workload in an unscraped namespace",
+        [("agentish", "devops-agent")],
+        1,
+        "devops-agent->agentish-service",
+    )
+    fleet_case(
+        "a covered namespace does not mask an uncovered one",
+        [("ledgerish", "ledger"), ("agentish", "devops-agent")],
+        1,
+        "devops-agent->agentish-service",
+    )
+    fleet_case(
+        "NOT_SCRAPED entry for a namespace that IS scraped is stale",
+        [("ledgerish", "ledger")],
+        1,
+        "stale:ledger",
+        not_scraped={"ledger": "reason"},
+    )
+    fleet_case(
+        "NOT_SCRAPED entry for a namespace with no management-port workload is stale",
+        [("ledgerish", "ledger")],
+        1,
+        "stale:ghost",
+        not_scraped={"ghost": "reason"},
+    )
+    print("self-test: fleet pass — cases the gate MUST pass")
+    fleet_case("management-port workload in a scraped namespace", [("ledgerish", "ledger")], 0)
+    fleet_case(
+        "workload with NO management port in an unscraped namespace",
+        [("portless", "developer-portal")],
+        0,
+        no_mgmt_port={"portless"},
+    )
+    fleet_case(
+        "declared NOT_SCRAPED gap",
+        [("agentish", "devops-agent")],
+        0,
+        not_scraped={"devops-agent": "reason"},
     )
 
     if failures:

--- a/openbank-infra/gitops/components/observability/podmonitor-openbank-services.yaml
+++ b/openbank-infra/gitops/components/observability/podmonitor-openbank-services.yaml
@@ -21,6 +21,23 @@
 # collector's C8 scorer read this file as a plain substring, so the false claim scored
 # sdd as scraped. Coverage is now asserted from the workload manifests by
 # .github/scripts/check-podmonitor-namespace-coverage.py — do not hand-audit it.
+#
+# Third sweep: added authz-policy-auditor, control-liveness-sentinel, devops-agent,
+# docs-truth-agent, finops-agent, flaky-test-hunter, governance-auditor, release-steward —
+# the entire control-plane agent fleet, none of which had ever been scraped. All eight are
+# ordinary Quarkus apps (management port 8085, root-path /q, micrometer-registry-prometheus)
+# carrying app.kubernetes.io/name, so they were one line each away from working the whole time.
+#
+# The gate above did not catch it, and its green was the reason nobody looked: it iterated
+# `openbank-*-service` plus the money-path list, so the agents — openbank-devops-agent,
+# openbank-governance-auditor and friends, none of which carry the `-service` suffix — were
+# never in its population. It printed `41 scraped, 0 missing` while eight namespaces went
+# unscraped. That is this repo's recurring shape: a gate whose SCOPE is a hand-kept list of the
+# thing it checks reads as passing when the list is short, never as unchecked. The check now
+# ALSO derives its population from the scrape contract itself — every workload declaring a
+# `management` container port — and cross-references every Pod/ServiceMonitor that scrapes that
+# port, so `iam` (its own keycloak PodMonitor) is correctly not a gap. Deliberate exclusions go
+# in NOT_SCRAPED with a reason, and a stale entry there fails in either direction.
 apiVersion: monitoring.coreos.com/v1
 kind: PodMonitor
 metadata:
@@ -40,16 +57,23 @@ spec:
       - anacredit
       - analytics
       - audit
+      - authz-policy-auditor
       - balances
       - billing
       - campaign
       - consent
+      - control-liveness-sentinel
       - customer-edge
+      - devops-agent
       - dispute
+      - docs-truth-agent
       - documents
+      - finops-agent
       - finrep
+      - flaky-test-hunter
       - fraud
       - fx
+      - governance-auditor
       - interest
       - kyc
       - ledger
@@ -61,6 +85,7 @@ spec:
       - pid
       - platform
       - psd2
+      - release-steward
       - sanctions
       - sca
       - sdd

--- a/openbank-infra/scripts/gitops_facts.py
+++ b/openbank-infra/scripts/gitops_facts.py
@@ -36,6 +36,8 @@ __all__ = [
     "service_namespace",
     "workload_namespaces",
     "podmonitor_namespaces",
+    "management_port_workloads",
+    "management_scraped_namespaces",
     "declared_datastore",
     "is_stateless",
 ]
@@ -219,6 +221,89 @@ def podmonitor_namespaces(gitops: Path) -> set[str]:
             out.add(m.group(2))
         elif line.strip():
             break  # dedented back out of the list
+    return out
+
+
+def management_port_workloads(gitops: Path) -> dict[str, set[str]]:
+    """{namespace: {workload names}} for every workload declaring a container port `management`.
+
+    This is the SCRAPE CONTRACT, read off the workloads themselves. The fleet PodMonitor scrapes
+    `port: management, path: /q/metrics`, so a workload that declares that port is asking to be
+    scraped, and a workload that does not cannot be scraped no matter which namespace it sits in.
+    Deriving the population this way is the whole point: [workload_namespaces] answers "where does
+    module X run", which can only ever enumerate namespaces for modules someone already listed.
+
+    That difference is not academic. The caller that used to drive the coverage gate iterated
+    `repo.glob("openbank-*-service")` plus the money-path list, so the eight control-plane agent
+    workloads — devops-agent, finops-agent, governance-auditor, docs-truth-agent,
+    authz-policy-auditor, flaky-test-hunter, control-liveness-sentinel, release-steward — were
+    never in its population at all. All eight declare a `management` port, none was in
+    `matchNames`, and the gate printed `0 missing` about a fleet it had never looked at. A gate
+    whose scope is a hand-kept list of the thing it checks reads as passing when the list is
+    short, never as unchecked (CLAUDE.md).
+    """
+    out: dict[str, set[str]] = {}
+    for f in sorted(gitops.rglob("*.yaml")):
+        text = read(f)
+        if "name: management" not in text:
+            continue
+        for doc in text.split("\n---"):
+            kind = re.search(r"^kind:\s*(\S+)", doc, re.M)
+            if not kind or kind.group(1) not in ("Deployment", "Rollout", "StatefulSet"):
+                continue
+            # The port entry itself, not a mere mention: `- name: management` inside `ports:`.
+            if not re.search(r"^\s+-\s+name:\s*management\s*$", doc, re.M):
+                continue
+            name = re.search(r"^\s{2}name:\s*(\S+)", doc, re.M)
+            explicit = re.search(r"^\s{2}namespace:\s*(\S+)", doc, re.M)
+            ns = explicit.group(1) if explicit else _nearest_kustomize_namespace(f, gitops)
+            if ns:
+                out.setdefault(ns, set()).add(name.group(1) if name else f.name)
+    return out
+
+
+def management_scraped_namespaces(gitops: Path) -> dict[str, set[str]]:
+    """{namespace: {monitor names}} for every Pod/ServiceMonitor scraping `port: management`.
+
+    The fleet PodMonitor is not the only one — `iam` (keycloak) has its own, and billing,
+    document-service and statement-service each carry a per-service ServiceMonitor on the same
+    port. A gate that only reads the fleet PodMonitor would report keycloak as an uncovered gap
+    and get argued down, which is how a real gap ends up excluded next to a false one.
+
+    Only endpoints on the `management` port count. A monitor scraping `redis-metrics` or
+    `tcp-prometheus` in a namespace says nothing about whether that namespace's Quarkus
+    `/q/metrics` reaches Prometheus.
+    """
+    out: dict[str, set[str]] = {}
+    for f in sorted(gitops.rglob("*.yaml")):
+        text = read(f)
+        if "Monitor" not in text:
+            continue
+        for doc in text.split("\n---"):
+            kind = re.search(r"^kind:\s*(\S+)", doc, re.M)
+            if not kind or kind.group(1) not in ("PodMonitor", "ServiceMonitor"):
+                continue
+            if not re.search(r"^\s+-\s+port:\s*management\s*$", doc, re.M):
+                continue
+            name_m = re.search(r"^\s{2}name:\s*(\S+)", doc, re.M)
+            name = name_m.group(1) if name_m else f.name
+            own = re.search(r"^\s{2}namespace:\s*(\S+)", doc, re.M)
+            own_ns = own.group(1) if own else _nearest_kustomize_namespace(f, gitops)
+            targets: set[str] = set()
+            if re.search(r"^\s+any:\s*true\s*$", doc, re.M):
+                targets.add("*")
+            elif "matchNames:" in doc:
+                for line in doc.split("matchNames:", 1)[1].splitlines():
+                    m = re.match(r"^(\s+)-\s+(\S+)\s*$", line)
+                    if m:
+                        targets.add(m.group(2))
+                    elif line.strip():
+                        break
+            elif own_ns:
+                # No namespaceSelector: the operator defaults to the monitor's own namespace.
+                targets.add(own_ns)
+            for t in targets:
+                out.setdefault(t, set()).add(name)
     return out
 
 


### PR DESCRIPTION
## Summary

The fleet PodMonitor never scraped the eight control-plane agent namespaces, and the gate that exists to catch exactly that printed `41 scraped, 0 missing`. This adds the namespaces and re-derives the gate's population from the scrape contract instead of a module-name glob.

## Type of change

- [x] fix (bug fix)

## Linked issues

Closes #3034
Refs #2255, #2364

## Changes

- `podmonitor-openbank-services.yaml`: add `authz-policy-auditor`, `control-liveness-sentinel`, `devops-agent`, `docs-truth-agent`, `finops-agent`, `flaky-test-hunter`, `governance-auditor`, `release-steward` to `namespaceSelector.matchNames` (32 -> 40 entries).
- `gitops_facts.py`: two new derivations.
  - `management_port_workloads(gitops)` — every Deployment/Rollout/StatefulSet declaring a `management` container port. Port-derived, not name-derived, which is what puts the agents in scope.
  - `management_scraped_namespaces(gitops)` — every Pod/ServiceMonitor with an endpoint on the `management` port, and the namespaces it targets (`matchNames`, `any: true`, or its own namespace by operator default). Endpoints on other ports (`redis-metrics`, `tcp-prometheus`) deliberately do not count.
- `check-podmonitor-namespace-coverage.py`: new `audit_fleet` pass over that population, an empty `NOT_SCRAPED` exclusion map that fails on a stale entry in either direction, and seven new self-test cases.

## Why the old gate was green

Its population was `repo.glob("openbank-*-service")` plus the money-path list. The agent modules carry no `-service` suffix, so they were never in scope. Third occurrence of the shape from #2255 and #2364: a gate whose scope is a hand-kept list of the thing it checks reads as passing when the list is short, never as unchecked.

## Why this was a one-line fix per namespace

All eight agents are Quarkus apps on management port 8085 with `root-path: /q` and `micrometer-registry-prometheus`, all carry `app.kubernetes.io/name` (the PodMonitor's `Exists` selector), and all eight already allow ingress from `observability` on 8085 in their own NetworkPolicy. Verified per namespace before writing the fix — nothing but `matchNames` was blocking the scrape.

## Falsification

Per CLAUDE.md, a gate that has only ever passed is unfalsified. What was actually run:

- `--self-test` gains seven fleet cases. MUST flag: an unscraped management-port workload; a covered namespace not masking an uncovered one; a `NOT_SCRAPED` entry for a namespace that is now scraped; a `NOT_SCRAPED` entry whose workload is gone. MUST pass: a scraped namespace; a workload with **no** management port in an unscraped namespace; a declared exclusion. The fixture gained a management port plus a no-management-port variant so both paths are exercised. 12/12 cases ok.
- Against the real tree **before** the `matchNames` edit the gate exits 1 and names exactly the eight agent namespaces, with `iam` correctly absent from the findings (its keycloak PodMonitor is picked up). **After** the edit: `36 namespaces scraped, 0 unscraped`.
- `openbank-infra/scripts/prod_readiness_collector_test.py` — 29 tests, OK.
- yamllint using `ci.yml`'s own inline config (`line-length: disable`, `indent-sequences: whatever`) — clean. The stock default config reports pre-existing long comment lines on this file and is not what CI runs.

## Definition of Done

- [x] Hexagonal layering preserved (no application code touched).
- [ ] Unit tests added/updated — n/a, the gate's own self-test is the test and it grew seven cases.
- [ ] Integration tests added/updated — n/a.
- [ ] Contract tests updated — n/a, no public API change.
- [ ] `./gradlew detekt ktlintCheck koverVerify build` — n/a, no Kotlin/Gradle change in this PR.
- [x] No new lint warnings.
- [ ] OpenAPI spec regenerated — n/a.
- [ ] Flyway migration — n/a.
- [ ] Avro schema — n/a.
- [x] Docs updated — the PodMonitor header records the third drift and why the old gate could not see it.

## Security checklist

- [x] No secrets, tokens, passwords, or PII in code, config, tests, logs.
- [x] No new `@SuppressWarnings` / `@Suppress`.
- [x] No new third-party dependency.
- [x] No auth / crypto / payment code changed.
- [x] No PII path changed.
- [x] No cardholder data path changed.

## Compliance impact

- [x] DORA — ICT monitoring coverage: eight control-plane workloads move from unmonitored to monitored.

## Deployment note

`rules.yaml` and the `.rego` policies are untouched, so no OPA bundle restamp is needed. The PodMonitor is synced by the `observability-components` Application; the eight new targets appear on the next reconcile without a pod roll.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
