### PR TITLE
build: copy gradle.properties into the three service Dockerfile build contexts

### DIFF
--- a/openbank-campaign-service/Dockerfile
+++ b/openbank-campaign-service/Dockerfile
@@ -4,9 +4,11 @@ WORKDIR /build
 # The root settings.gradle.kts is the entry point for every openbank-* module and it
 # `includeBuild("build-logic")` for the `openbank.quarkus-service` convention plugin,
 # so the wrapper, the root build files and build-logic all have to be in the context —
-# not just the service directory.
+# not just the service directory. gradle.properties matters too: it carries
+# org.gradle.dependency.verification=lenient, so omitting it silently builds the
+# image under Gradle's default STRICT verification - different rules than the repo.
 COPY gradle /build/gradle
-COPY gradlew build.gradle.kts settings.gradle.kts /build/
+COPY gradlew gradle.properties build.gradle.kts settings.gradle.kts /build/
 COPY build-logic /build/build-logic
 # ADR-0122 split the shared code into sibling top-level modules; `COPY openbank-libs`
 # alone leaves `project(":openbank-libs-domain")` etc. unresolvable at configuration time.

--- a/openbank-domestic-payment/Dockerfile
+++ b/openbank-domestic-payment/Dockerfile
@@ -4,9 +4,11 @@ WORKDIR /build
 # The root settings.gradle.kts is the entry point for every openbank-* module and it
 # `includeBuild("build-logic")` for the `openbank.quarkus-service` convention plugin,
 # so the wrapper, the root build files and build-logic all have to be in the context —
-# not just the service directory.
+# not just the service directory. gradle.properties matters too: it carries
+# org.gradle.dependency.verification=lenient, so omitting it silently builds the
+# image under Gradle's default STRICT verification - different rules than the repo.
 COPY gradle /build/gradle
-COPY gradlew build.gradle.kts settings.gradle.kts /build/
+COPY gradlew gradle.properties build.gradle.kts settings.gradle.kts /build/
 COPY build-logic /build/build-logic
 # ADR-0122 split the shared code into sibling top-level modules; `COPY openbank-libs`
 # alone leaves `project(":openbank-libs-domain")` etc. unresolvable at configuration time.

--- a/openbank-sepa-payment/Dockerfile
+++ b/openbank-sepa-payment/Dockerfile
@@ -4,9 +4,11 @@ WORKDIR /build
 # The root settings.gradle.kts is the entry point for every openbank-* module and it
 # `includeBuild("build-logic")` for the `openbank.quarkus-service` convention plugin,
 # so the wrapper, the root build files and build-logic all have to be in the context —
-# not just the service directory.
+# not just the service directory. gradle.properties matters too: it carries
+# org.gradle.dependency.verification=lenient, so omitting it silently builds the
+# image under Gradle's default STRICT verification - different rules than the repo.
 COPY gradle /build/gradle
-COPY gradlew build.gradle.kts settings.gradle.kts /build/
+COPY gradlew gradle.properties build.gradle.kts settings.gradle.kts /build/
 COPY build-logic /build/build-logic
 # ADR-0122 split the shared code into sibling top-level modules; `COPY openbank-libs`
 # alone leaves `project(":openbank-libs-domain")` etc. unresolvable at configuration time.


### PR DESCRIPTION
## What

Adds `gradle.properties` to the build context of the three service Dockerfiles fixed in #3015.

```diff
-COPY gradlew build.gradle.kts settings.gradle.kts /build/
+COPY gradlew gradle.properties build.gradle.kts settings.gradle.kts /build/
```

Follow-up to #3015, which merged before this was found.

## Why

The repository sets `org.gradle.dependency.verification=lenient` in `gradle.properties` —
deliberately, while the metadata soaks, flipping to strict at the ADR-0144 graduation date. A build
context that omits the file therefore runs under Gradle's **default**, which is strict.

So a container build enforced a rule the rest of the repo does not, and the two disagreed about
whether a missing `verification-metadata.xml` entry is a warning or a hard failure.

## How it surfaced

This is the discrepancy behind #3017. A docker build failed hard:

```
Dependency verification failed ... hibernate-platform-7.4.5.Final.pom
```

while the *identical* cold-cache build on the host passed — because the host honoured `lenient` and
the container never saw the file. The two builds were not testing the same thing, and the
difference was invisible until the mismatch was chased down.

Worth stating plainly: this cuts both ways. It means the container was **stricter** than CI, so the
gap in #3017 is real but does not fail builds today — it will the moment verification graduates to
strict. It also means a container build could not be used as evidence about the repo's actual
verification behaviour, which is how one measurement in #3017 was initially misread.

## Scope

Only the three Dockerfiles that #3015 touched. The other 48 have the same omission, but they also
cannot build at all (#3016), so fixing this there in isolation would be meaningless — it is folded
into the proposal in that issue.

Type is `build`: no CI path builds these files (`auto-deploy.yml`, `ghcr-publish.yml` and
`build-push-service.sh` all generate their own context from `Dockerfile.deploy`), so this cannot
affect a shipped image.

## Linked issues

Refs #3016
