### PR TITLE
docs: in a multi-step job the last-endgroup trick is not enough — use substitution

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -426,6 +426,13 @@ fire from *outside* it, so they stay here:
   a false positive here looks exactly like the success you were hoping for. Prefer structured
   data outright where it exists: step conclusions from
   `gh api .../actions/jobs/<id> --jq '.steps[]'` cannot be spoofed by the script listing.
+  In a MULTI-STEP job the last-`##[endgroup]` trick is not enough — it lands you after the final
+  step, not inside the one that failed. There the discriminator is **substitution**: real output
+  has the variable expanded, the echoed script still has the literal. `grep 'failed to boot'`
+  matched an `echo "::error::[${svc}] failed to boot"` that never ran; `grep 'failed to boot' |
+  grep -v '\${'` found the one line that did. Took three attempts on #3024 *after* the bullet
+  above was already written, so treat "my grep found it" as a hypothesis until the match shows a
+  value the script could not have contained.
 - **Validate the PROBE, not the command inside it — in zsh a `for x in $VAR` loop runs ONCE.**
   zsh does not word-split an unquoted parameter (bash does), so a sweep written as
   `LIST="a b c"; for b in $LIST; do git show-ref --verify --quiet "refs/heads/$b" …` tests one


### PR DESCRIPTION
Extends the bullet added earlier today in #2928, because that one turned out to be insufficient — and insufficient in a way I only found by falling into the gap it left.

## The gap

#2928 says: read a job log only after the **last** `##[endgroup]`, because GitHub prints the step's own `run:` script into the log header and a naive grep matches strings that never executed.

That works for a single-step job. In a **multi-step** job the last `##[endgroup]` lands you after the *final* step — so the echoed script of the step that actually failed is still in range, and the naive grep matches it again.

## The discriminator that does work

**Substitution.** Real output has the variable expanded; the echoed script still carries the literal.

On #3024:

```
grep 'failed to boot'                     -> 2 hits   (one is echo "::error::[${svc}] failed to boot")
grep 'failed to boot' | grep -v '${'      -> 1 hit    (the one that ran)
```

Verified against the real log from that run — the unfiltered count is higher, and the filtered one is correct.

## Why it is worth a second bullet rather than editing the first

It took **three attempts** to notice, *after* the earlier bullet existed, by the person who wrote it. The first bullet is not wrong; it is just scoped to a case narrower than the one that keeps occurring.

So the rule is now stated as a posture rather than a recipe: treat *"my grep found it"* as a hypothesis until the match shows a value the script could not have contained.

## Placement

Appended to the existing log-header bullet in `CI gates — exercise the failure path before trusting the green`, so the two read as one lesson rather than competing advice.

## Verification

- markdown fences balanced (4, even)
- +7 lines, no deletions
- the discriminator itself re-run against the real log before committing, not recalled from the session

## Release impact

None — `docs` is a hidden type and `CLAUDE.md` is not under any released package path.

Refs #3024, #2928
