### PR TITLE
feat(observability): make fleet LLM spend and reliability observable in Prometheus

### DIFF
--- a/openbank-agent-service/src/main/kotlin/com/openbank/agent/infrastructure/model/OpenAiCompatibleModelProvider.kt
+++ b/openbank-agent-service/src/main/kotlin/com/openbank/agent/infrastructure/model/OpenAiCompatibleModelProvider.kt
@@ -17,6 +17,8 @@ import com.openbank.agent.domain.model.ModelResponse
 import com.openbank.agent.domain.model.ModelUsage
 import com.openbank.agent.domain.model.StopReason
 import com.openbank.agent.domain.model.ToolInvocation
+import com.openbank.libs.llm.LlmCallMetricsPort
+import com.openbank.libs.observability.DomainMetrics
 import jakarta.enterprise.context.ApplicationScoped
 import jakarta.inject.Inject
 import org.eclipse.microprofile.config.ConfigProvider
@@ -47,6 +49,12 @@ class OpenAiCompatibleModelProvider : ModelProvider {
     @Inject
     lateinit var objectMapper: ObjectMapper
 
+    // Field injection, not a constructor arg: detekt's LongParameterList fires AT
+    // constructorThreshold, and this class is instantiated by Arc, so there is no
+    // constructor to widen anyway. Same shape as LoanStageEventConsumer / VopRateLimitFilter.
+    @Inject
+    lateinit var metrics: DomainMetrics
+
     // Resolved lazily (NOT @ConfigProperty-injected): an un-seeded/empty key would otherwise fail
     // config load at boot (SmallRye SRCFG00040 on an empty String binding) and CrashLoop the pod —
     // and break any @QuarkusTest / fresh env where GROQ_API_KEY isn't set. Empty here just degrades
@@ -66,6 +74,9 @@ class OpenAiCompatibleModelProvider : ModelProvider {
     override suspend fun complete(model: ModelDescriptor, request: ModelRequest): ModelResponse {
         val base = (model.endpoint ?: error("model '${model.id}' has no endpoint (base URL) configured"))
             .trimEnd('/')
+        if (apiKey.isBlank()) {
+            metrics.recordCall(model.id, LlmCallMetricsPort.OUTCOME_NOT_CONFIGURED, 0, 0, 0)
+        }
         require(apiKey.isNotBlank()) {
             "agent.model.openai.api-key is empty — set the backend API key (e.g. GROQ_API_KEY) to use model '${model.id}'"
         }
@@ -79,13 +90,42 @@ class OpenAiCompatibleModelProvider : ModelProvider {
             .POST(HttpRequest.BodyPublishers.ofString(payload))
             .build()
 
-        val resp = http.send(httpRequest, HttpResponse.BodyHandlers.ofString())
+        // Timed around the send AND the parse: `usage` is only known after parsing, and a body that
+        // fails to parse is a failed call from the caller's point of view even though HTTP said 200.
+        val startedAt = System.nanoTime()
+        val resp = try {
+            http.send(httpRequest, HttpResponse.BodyHandlers.ofString())
+        } catch (ex: java.io.IOException) {
+            metrics.recordCall(
+                model.id,
+                LlmCallMetricsPort.OUTCOME_EXCEPTION,
+                0,
+                0,
+                System.nanoTime() - startedAt,
+            )
+            throw ex
+        }
         if (resp.statusCode() !in 200..299) {
             // Body may echo the request on some gateways; do not log it wholesale (prompt PII).
             log.warnf("openai-compat backend %s returned HTTP %d for model %s", base, resp.statusCode(), model.id)
+            metrics.recordCall(
+                model.id,
+                LlmCallMetricsPort.OUTCOME_HTTP_ERROR,
+                0,
+                0,
+                System.nanoTime() - startedAt,
+            )
             error("model backend HTTP ${resp.statusCode()} for '${model.id}'")
         }
-        return parseResponse(model, resp.body())
+        val parsed = parseResponse(model, resp.body())
+        metrics.recordCall(
+            model.id,
+            LlmCallMetricsPort.OUTCOME_SUCCESS,
+            parsed.usage.inputTokens,
+            parsed.usage.outputTokens,
+            System.nanoTime() - startedAt,
+        )
+        return parsed
     }
 
     /** Neutral [ModelRequest] -> OpenAI `/chat/completions` request body. */

--- a/openbank-agent-service/src/main/kotlin/com/openbank/agent/infrastructure/model/OpenAiCompatibleModelProvider.kt
+++ b/openbank-agent-service/src/main/kotlin/com/openbank/agent/infrastructure/model/OpenAiCompatibleModelProvider.kt
@@ -18,7 +18,7 @@ import com.openbank.agent.domain.model.ModelUsage
 import com.openbank.agent.domain.model.StopReason
 import com.openbank.agent.domain.model.ToolInvocation
 import com.openbank.libs.llm.LlmCallMetricsPort
-import com.openbank.libs.observability.DomainMetrics
+import com.openbank.libs.observability.LlmCallMetrics
 import jakarta.enterprise.context.ApplicationScoped
 import jakarta.inject.Inject
 import org.eclipse.microprofile.config.ConfigProvider
@@ -53,7 +53,7 @@ class OpenAiCompatibleModelProvider : ModelProvider {
     // constructorThreshold, and this class is instantiated by Arc, so there is no
     // constructor to widen anyway. Same shape as LoanStageEventConsumer / VopRateLimitFilter.
     @Inject
-    lateinit var metrics: DomainMetrics
+    lateinit var metrics: LlmCallMetrics
 
     // Resolved lazily (NOT @ConfigProperty-injected): an un-seeded/empty key would otherwise fail
     // config load at boot (SmallRye SRCFG00040 on an empty String binding) and CrashLoop the pod —

--- a/openbank-control-liveness-sentinel/src/main/kotlin/com/openbank/liveness/infrastructure/config/LlmGatewayProducer.kt
+++ b/openbank-control-liveness-sentinel/src/main/kotlin/com/openbank/liveness/infrastructure/config/LlmGatewayProducer.kt
@@ -7,6 +7,7 @@ package com.openbank.liveness.infrastructure.config
 
 import com.openbank.libs.llm.LlmGatewayPort
 import com.openbank.libs.llm.OpenAiCompatibleLlmGatewayClient
+import com.openbank.libs.observability.DomainMetrics
 import jakarta.enterprise.context.ApplicationScoped
 import jakarta.enterprise.inject.Produces
 import org.eclipse.microprofile.config.ConfigProvider
@@ -27,7 +28,7 @@ class LlmGatewayProducer {
 
     @Produces
     @ApplicationScoped
-    fun llmGateway(config: LivenessSentinelConfig): LlmGatewayPort {
+    fun llmGateway(config: LivenessSentinelConfig, metrics: DomainMetrics): LlmGatewayPort {
         val apiKey = ConfigProvider.getConfig()
             .getOptionalValue("liveness.model.api-key", String::class.java)
             .orElse("")
@@ -35,6 +36,7 @@ class LlmGatewayProducer {
             baseUrl = config.modelEndpoint(),
             model = config.modelId(),
             apiKey = apiKey,
+            metrics = metrics,
         )
     }
 }

--- a/openbank-control-liveness-sentinel/src/main/kotlin/com/openbank/liveness/infrastructure/config/LlmGatewayProducer.kt
+++ b/openbank-control-liveness-sentinel/src/main/kotlin/com/openbank/liveness/infrastructure/config/LlmGatewayProducer.kt
@@ -7,7 +7,7 @@ package com.openbank.liveness.infrastructure.config
 
 import com.openbank.libs.llm.LlmGatewayPort
 import com.openbank.libs.llm.OpenAiCompatibleLlmGatewayClient
-import com.openbank.libs.observability.DomainMetrics
+import com.openbank.libs.observability.LlmCallMetrics
 import jakarta.enterprise.context.ApplicationScoped
 import jakarta.enterprise.inject.Produces
 import org.eclipse.microprofile.config.ConfigProvider
@@ -28,7 +28,7 @@ class LlmGatewayProducer {
 
     @Produces
     @ApplicationScoped
-    fun llmGateway(config: LivenessSentinelConfig, metrics: DomainMetrics): LlmGatewayPort {
+    fun llmGateway(config: LivenessSentinelConfig, metrics: LlmCallMetrics): LlmGatewayPort {
         val apiKey = ConfigProvider.getConfig()
             .getOptionalValue("liveness.model.api-key", String::class.java)
             .orElse("")

--- a/openbank-copilot-service/src/main/kotlin/com/openbank/copilot/infrastructure/model/OpenAiCompatibleModelProvider.kt
+++ b/openbank-copilot-service/src/main/kotlin/com/openbank/copilot/infrastructure/model/OpenAiCompatibleModelProvider.kt
@@ -18,7 +18,7 @@ import com.openbank.copilot.domain.model.StopReason
 import com.openbank.copilot.domain.model.ToolInvocation
 import com.openbank.copilot.domain.model.ToolSpec
 import com.openbank.libs.llm.LlmCallMetricsPort
-import com.openbank.libs.observability.DomainMetrics
+import com.openbank.libs.observability.LlmCallMetrics
 import jakarta.enterprise.context.ApplicationScoped
 import jakarta.inject.Inject
 import org.eclipse.microprofile.config.ConfigProvider
@@ -55,7 +55,7 @@ class OpenAiCompatibleModelProvider : ModelProvider {
     // Field injection, not a constructor arg: the bean is instantiated by Arc, and detekt's
     // LongParameterList fires AT constructorThreshold rather than above it.
     @Inject
-    lateinit var metrics: DomainMetrics
+    lateinit var metrics: LlmCallMetrics
 
     // Resolved lazily (NOT @ConfigProperty-injected): an un-seeded/empty key would otherwise fail
     // config load at boot (SmallRye SRCFG00040 on an empty String binding) and CrashLoop the pod.

--- a/openbank-copilot-service/src/main/kotlin/com/openbank/copilot/infrastructure/model/OpenAiCompatibleModelProvider.kt
+++ b/openbank-copilot-service/src/main/kotlin/com/openbank/copilot/infrastructure/model/OpenAiCompatibleModelProvider.kt
@@ -17,6 +17,8 @@ import com.openbank.copilot.domain.model.ModelUsage
 import com.openbank.copilot.domain.model.StopReason
 import com.openbank.copilot.domain.model.ToolInvocation
 import com.openbank.copilot.domain.model.ToolSpec
+import com.openbank.libs.llm.LlmCallMetricsPort
+import com.openbank.libs.observability.DomainMetrics
 import jakarta.enterprise.context.ApplicationScoped
 import jakarta.inject.Inject
 import org.eclipse.microprofile.config.ConfigProvider
@@ -50,6 +52,11 @@ class OpenAiCompatibleModelProvider : ModelProvider {
     @Inject
     lateinit var objectMapper: ObjectMapper
 
+    // Field injection, not a constructor arg: the bean is instantiated by Arc, and detekt's
+    // LongParameterList fires AT constructorThreshold rather than above it.
+    @Inject
+    lateinit var metrics: DomainMetrics
+
     // Resolved lazily (NOT @ConfigProperty-injected): an un-seeded/empty key would otherwise fail
     // config load at boot (SmallRye SRCFG00040 on an empty String binding) and CrashLoop the pod.
     // Empty here just degrades the call (require below) until the key is seeded.
@@ -68,6 +75,9 @@ class OpenAiCompatibleModelProvider : ModelProvider {
     override suspend fun complete(model: ModelDescriptor, request: ModelRequest): ModelResponse {
         val base = (model.endpoint ?: error("model '${model.id}' has no endpoint (base URL) configured"))
             .trimEnd('/')
+        if (apiKey.isBlank()) {
+            metrics.recordCall(model.id, LlmCallMetricsPort.OUTCOME_NOT_CONFIGURED, 0, 0, 0)
+        }
         require(apiKey.isNotBlank()) {
             "copilot.model.api-key is empty — set the backend API key to use model '${model.id}'"
         }
@@ -81,13 +91,42 @@ class OpenAiCompatibleModelProvider : ModelProvider {
             .POST(HttpRequest.BodyPublishers.ofString(payload))
             .build()
 
-        val resp = http.send(httpRequest, HttpResponse.BodyHandlers.ofString())
+        // Timed around send AND parse: `usage` is only known after parsing, and a 200 whose body
+        // does not parse is a failed call from the caller's point of view.
+        val startedAt = System.nanoTime()
+        val resp = try {
+            http.send(httpRequest, HttpResponse.BodyHandlers.ofString())
+        } catch (ex: java.io.IOException) {
+            metrics.recordCall(
+                model.id,
+                LlmCallMetricsPort.OUTCOME_EXCEPTION,
+                0,
+                0,
+                System.nanoTime() - startedAt,
+            )
+            throw ex
+        }
         if (resp.statusCode() !in OK_RANGE) {
             // Body may echo the request on some gateways; do not log it wholesale (prompt PII).
             log.warnf("openai-compat backend %s returned HTTP %d for model %s", base, resp.statusCode(), model.id)
+            metrics.recordCall(
+                model.id,
+                LlmCallMetricsPort.OUTCOME_HTTP_ERROR,
+                0,
+                0,
+                System.nanoTime() - startedAt,
+            )
             error("model backend HTTP ${resp.statusCode()} for '${model.id}'")
         }
-        return parseResponse(model, resp.body())
+        val parsed = parseResponse(model, resp.body())
+        metrics.recordCall(
+            model.id,
+            LlmCallMetricsPort.OUTCOME_SUCCESS,
+            parsed.usage.inputTokens,
+            parsed.usage.outputTokens,
+            System.nanoTime() - startedAt,
+        )
+        return parsed
     }
 
     /**

--- a/openbank-devops-agent/src/main/kotlin/com/openbank/devops/infrastructure/config/LlmGatewayProducer.kt
+++ b/openbank-devops-agent/src/main/kotlin/com/openbank/devops/infrastructure/config/LlmGatewayProducer.kt
@@ -7,6 +7,7 @@ package com.openbank.devops.infrastructure.config
 
 import com.openbank.libs.llm.LlmGatewayPort
 import com.openbank.libs.llm.OpenAiCompatibleLlmGatewayClient
+import com.openbank.libs.observability.DomainMetrics
 import jakarta.enterprise.context.ApplicationScoped
 import jakarta.enterprise.inject.Produces
 import org.eclipse.microprofile.config.ConfigProvider
@@ -24,7 +25,7 @@ class LlmGatewayProducer {
 
     @Produces
     @ApplicationScoped
-    fun llmGateway(config: DevOpsConfig): LlmGatewayPort {
+    fun llmGateway(config: DevOpsConfig, metrics: DomainMetrics): LlmGatewayPort {
         val apiKey = ConfigProvider.getConfig()
             .getOptionalValue("devops.model.api-key", String::class.java)
             .orElse("")
@@ -32,6 +33,7 @@ class LlmGatewayProducer {
             baseUrl = config.modelEndpoint(),
             model = config.modelId(),
             apiKey = apiKey,
+            metrics = metrics,
         )
     }
 }

--- a/openbank-devops-agent/src/main/kotlin/com/openbank/devops/infrastructure/config/LlmGatewayProducer.kt
+++ b/openbank-devops-agent/src/main/kotlin/com/openbank/devops/infrastructure/config/LlmGatewayProducer.kt
@@ -7,7 +7,7 @@ package com.openbank.devops.infrastructure.config
 
 import com.openbank.libs.llm.LlmGatewayPort
 import com.openbank.libs.llm.OpenAiCompatibleLlmGatewayClient
-import com.openbank.libs.observability.DomainMetrics
+import com.openbank.libs.observability.LlmCallMetrics
 import jakarta.enterprise.context.ApplicationScoped
 import jakarta.enterprise.inject.Produces
 import org.eclipse.microprofile.config.ConfigProvider
@@ -25,7 +25,7 @@ class LlmGatewayProducer {
 
     @Produces
     @ApplicationScoped
-    fun llmGateway(config: DevOpsConfig, metrics: DomainMetrics): LlmGatewayPort {
+    fun llmGateway(config: DevOpsConfig, metrics: LlmCallMetrics): LlmGatewayPort {
         val apiKey = ConfigProvider.getConfig()
             .getOptionalValue("devops.model.api-key", String::class.java)
             .orElse("")

--- a/openbank-infra/gitops/components/observability/dashboard-openbank-ai.yaml
+++ b/openbank-infra/gitops/components/observability/dashboard-openbank-ai.yaml
@@ -1,0 +1,585 @@
+# AI / LLM cost and reliability dashboard (ADR-0112 / ADR-0174).
+#
+# Every query on this board resolves against series that exist: openbank_llm_requests_total,
+# openbank_llm_tokens_total and openbank_llm_call_duration_seconds are emitted by DomainMetrics
+# from the three code paths that make real /chat/completions calls, and the openbank:llm_* recording
+# rules come from prometheus-rules-ai.yaml in this same directory.
+#
+# The cost panels are DERIVED from a price book, not read from an invoice, and the board says so in
+# its own header panel rather than in a comment nobody opens. The "Unpriced models" panel is the
+# check on the check: a model added to the gateway and forgotten in the price book makes every spend
+# figure here quietly low, and a sum cannot notice that on its own.
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: dashboard-openbank-ai
+  namespace: observability
+  labels:
+    grafana_dashboard: '1'
+    app.kubernetes.io/part-of: observability
+data:
+  openbank-ai.json: |
+    {
+      "id": null,
+      "uid": "openbank-ai",
+      "title": "OpenBank — AI / LLM Cost & Reliability",
+      "description": "Fleet LLM spend, throughput and reliability from client-side token accounting (ADR-0112 / ADR-0174). Cost is derived from a price book, not billed.",
+      "schemaVersion": 39,
+      "version": 1,
+      "refresh": "30s",
+      "time": {
+        "from": "now-24h",
+        "to": "now"
+      },
+      "timepicker": {},
+      "timezone": "browser",
+      "tags": [
+        "openbank",
+        "ai",
+        "finops"
+      ],
+      "templating": {
+        "list": [
+          {
+            "current": {
+              "selected": false,
+              "text": "Prometheus",
+              "value": "prometheus"
+            },
+            "hide": 0,
+            "includeAll": false,
+            "multi": false,
+            "name": "datasource",
+            "options": [],
+            "query": "prometheus",
+            "refresh": 1,
+            "type": "datasource",
+            "label": "Datasource"
+          }
+        ]
+      },
+      "annotations": {
+        "list": []
+      },
+      "links": [],
+      "panels": [
+        {
+          "id": 1,
+          "type": "text",
+          "title": "How to read this board",
+          "gridPos": {
+            "x": 0,
+            "y": 0,
+            "w": 24,
+            "h": 6
+          },
+          "options": {
+            "mode": "markdown",
+            "content": "**What this board can and cannot tell you.**\n\nToken counts are measured **client-side** by `DomainMetrics` on the three code paths that make real `/chat/completions` calls — the shared `LlmGatewayPort` client (devops-agent, control-liveness-sentinel), agent-service and copilot-service. LiteLLM's own Prometheus exporter is an Enterprise feature, so the gateway cannot report this.\n\n**Cost is derived, not billed.** Spend = tokens x the `openbank:llm_price_usd_per_token` price book in `prometheus-rules-ai.yaml`. Rows whose `price_source` is `nearest-sibling` are estimates (DeepInfra publishes no rate for DeepSeek-V3.2; its V3.1 rate is used). The provider invoice is the authority; this is the leading indicator. The **Unpriced models** panel is the check on the check — anything listed there is spend these figures do not include.\n\n`not_configured` is a first-class outcome, not an error: it means a caller skipped the call because no API key was seeded. Six of the eight control-plane agents ship a stub `LlmDiagnosisAdapter` that makes no LLM call at all, so they appear nowhere on this board — absence here is not evidence an agent is healthy."
+          }
+        },
+        {
+          "id": 2,
+          "type": "stat",
+          "title": "LLM spend (24h, derived)",
+          "gridPos": {
+            "x": 0,
+            "y": 6,
+            "w": 5,
+            "h": 5
+          },
+          "datasource": "${datasource}",
+          "targets": [
+            {
+              "datasource": "${datasource}",
+              "expr": "openbank:llm_cost_usd_24h:total",
+              "refId": "A"
+            }
+          ],
+          "fieldConfig": {
+            "defaults": {
+              "unit": "currencyUSD",
+              "color": {
+                "mode": "thresholds"
+              },
+              "thresholds": {
+                "mode": "absolute",
+                "steps": [
+                  {
+                    "color": "text",
+                    "value": null
+                  }
+                ]
+              },
+              "decimals": 2
+            },
+            "overrides": []
+          },
+          "options": {
+            "reduceOptions": {
+              "calcs": [
+                "lastNotNull"
+              ],
+              "fields": "",
+              "values": false
+            },
+            "textMode": "auto",
+            "colorMode": "value",
+            "graphMode": "area"
+          },
+          "description": "Rolling 24h, from the price book. Estimate, not an invoice."
+        },
+        {
+          "id": 3,
+          "type": "stat",
+          "title": "Calls/min",
+          "gridPos": {
+            "x": 5,
+            "y": 6,
+            "w": 5,
+            "h": 5
+          },
+          "datasource": "${datasource}",
+          "targets": [
+            {
+              "datasource": "${datasource}",
+              "expr": "sum(rate(openbank_llm_requests_total{job=\"observability/openbank-services\"}[5m])) * 60",
+              "refId": "A"
+            }
+          ],
+          "fieldConfig": {
+            "defaults": {
+              "unit": "short",
+              "color": {
+                "mode": "thresholds"
+              },
+              "thresholds": {
+                "mode": "absolute",
+                "steps": [
+                  {
+                    "color": "text",
+                    "value": null
+                  }
+                ]
+              },
+              "decimals": 1
+            },
+            "overrides": []
+          },
+          "options": {
+            "reduceOptions": {
+              "calcs": [
+                "lastNotNull"
+              ],
+              "fields": "",
+              "values": false
+            },
+            "textMode": "auto",
+            "colorMode": "value",
+            "graphMode": "area"
+          }
+        },
+        {
+          "id": 4,
+          "type": "stat",
+          "title": "Error rate (15m)",
+          "gridPos": {
+            "x": 10,
+            "y": 6,
+            "w": 5,
+            "h": 5
+          },
+          "datasource": "${datasource}",
+          "targets": [
+            {
+              "datasource": "${datasource}",
+              "expr": "100 * (sum(rate(openbank_llm_requests_total{outcome=~\"http_error|exception\",job=\"observability/openbank-services\"}[15m])) / clamp_min(sum(rate(openbank_llm_requests_total{outcome!=\"not_configured\",job=\"observability/openbank-services\"}[15m])), 0.0000001))",
+              "refId": "A"
+            }
+          ],
+          "fieldConfig": {
+            "defaults": {
+              "unit": "percent",
+              "color": {
+                "mode": "thresholds"
+              },
+              "thresholds": {
+                "mode": "absolute",
+                "steps": [
+                  {
+                    "color": "text",
+                    "value": null
+                  }
+                ]
+              },
+              "decimals": 1
+            },
+            "overrides": []
+          },
+          "options": {
+            "reduceOptions": {
+              "calcs": [
+                "lastNotNull"
+              ],
+              "fields": "",
+              "values": false
+            },
+            "textMode": "auto",
+            "colorMode": "value",
+            "graphMode": "area"
+          },
+          "description": "Excludes not_configured — an unseeded key is a different failure with a different fix."
+        },
+        {
+          "id": 5,
+          "type": "stat",
+          "title": "Skipped: no API key (1h)",
+          "gridPos": {
+            "x": 15,
+            "y": 6,
+            "w": 4,
+            "h": 5
+          },
+          "datasource": "${datasource}",
+          "targets": [
+            {
+              "datasource": "${datasource}",
+              "expr": "sum(increase(openbank_llm_requests_total{outcome=\"not_configured\",job=\"observability/openbank-services\"}[1h]))",
+              "refId": "A"
+            }
+          ],
+          "fieldConfig": {
+            "defaults": {
+              "unit": "short",
+              "color": {
+                "mode": "thresholds"
+              },
+              "thresholds": {
+                "mode": "absolute",
+                "steps": [
+                  {
+                    "color": "text",
+                    "value": null
+                  }
+                ]
+              },
+              "decimals": 0
+            },
+            "overrides": []
+          },
+          "options": {
+            "reduceOptions": {
+              "calcs": [
+                "lastNotNull"
+              ],
+              "fields": "",
+              "values": false
+            },
+            "textMode": "auto",
+            "colorMode": "value",
+            "graphMode": "area"
+          },
+          "description": "Non-zero means an AI feature is silently off, degrading to its deterministic fallback."
+        },
+        {
+          "id": 6,
+          "type": "stat",
+          "title": "Unpriced models",
+          "gridPos": {
+            "x": 19,
+            "y": 6,
+            "w": 5,
+            "h": 5
+          },
+          "datasource": "${datasource}",
+          "targets": [
+            {
+              "datasource": "${datasource}",
+              "expr": "count(openbank:llm_tokens_unpriced_24h > 0) or vector(0)",
+              "refId": "A"
+            }
+          ],
+          "fieldConfig": {
+            "defaults": {
+              "unit": "short",
+              "color": {
+                "mode": "thresholds"
+              },
+              "thresholds": {
+                "mode": "absolute",
+                "steps": [
+                  {
+                    "color": "text",
+                    "value": null
+                  }
+                ]
+              },
+              "decimals": 0
+            },
+            "overrides": []
+          },
+          "options": {
+            "reduceOptions": {
+              "calcs": [
+                "lastNotNull"
+              ],
+              "fields": "",
+              "values": false
+            },
+            "textMode": "auto",
+            "colorMode": "value",
+            "graphMode": "area"
+          },
+          "description": "Models burning tokens with no price-book entry. Non-zero means the spend figures understate reality."
+        },
+        {
+          "id": 7,
+          "type": "timeseries",
+          "title": "Spend by model (24h rolling, derived)",
+          "gridPos": {
+            "x": 0,
+            "y": 11,
+            "w": 12,
+            "h": 8
+          },
+          "datasource": "${datasource}",
+          "targets": [
+            {
+              "datasource": "${datasource}",
+              "expr": "openbank:llm_cost_usd_24h:by_model",
+              "legendFormat": "{{model}} ({{price_source}})",
+              "refId": "A"
+            }
+          ],
+          "fieldConfig": {
+            "defaults": {
+              "unit": "currencyUSD",
+              "color": {
+                "mode": "palette-classic"
+              },
+              "custom": {
+                "lineWidth": 1,
+                "fillOpacity": 10,
+                "spanNulls": false
+              }
+            },
+            "overrides": []
+          },
+          "options": {
+            "legend": {
+              "displayMode": "list",
+              "placement": "bottom"
+            },
+            "tooltip": {
+              "mode": "multi"
+            }
+          },
+          "description": "Legend carries price_source so an estimate is never mistaken for a billed figure."
+        },
+        {
+          "id": 8,
+          "type": "timeseries",
+          "title": "Tokens/s by model and kind",
+          "gridPos": {
+            "x": 12,
+            "y": 11,
+            "w": 12,
+            "h": 8
+          },
+          "datasource": "${datasource}",
+          "targets": [
+            {
+              "datasource": "${datasource}",
+              "expr": "sum by (model, kind) (rate(openbank_llm_tokens_total{job=\"observability/openbank-services\"}[5m]))",
+              "legendFormat": "{{model}} {{kind}}",
+              "refId": "A"
+            }
+          ],
+          "fieldConfig": {
+            "defaults": {
+              "unit": "short",
+              "color": {
+                "mode": "palette-classic"
+              },
+              "custom": {
+                "lineWidth": 1,
+                "fillOpacity": 10,
+                "spanNulls": false
+              }
+            },
+            "overrides": []
+          },
+          "options": {
+            "legend": {
+              "displayMode": "list",
+              "placement": "bottom"
+            },
+            "tooltip": {
+              "mode": "multi"
+            }
+          },
+          "description": "prompt and completion split because every provider prices them differently."
+        },
+        {
+          "id": 9,
+          "type": "timeseries",
+          "title": "Call outcomes",
+          "gridPos": {
+            "x": 0,
+            "y": 19,
+            "w": 12,
+            "h": 8
+          },
+          "datasource": "${datasource}",
+          "targets": [
+            {
+              "datasource": "${datasource}",
+              "expr": "sum by (outcome) (rate(openbank_llm_requests_total{job=\"observability/openbank-services\"}[5m]))",
+              "legendFormat": "{{outcome}}",
+              "refId": "A"
+            }
+          ],
+          "fieldConfig": {
+            "defaults": {
+              "unit": "ops",
+              "color": {
+                "mode": "palette-classic"
+              },
+              "custom": {
+                "lineWidth": 1,
+                "fillOpacity": 10,
+                "spanNulls": false
+              }
+            },
+            "overrides": []
+          },
+          "options": {
+            "legend": {
+              "displayMode": "list",
+              "placement": "bottom"
+            },
+            "tooltip": {
+              "mode": "multi"
+            }
+          }
+        },
+        {
+          "id": 10,
+          "type": "timeseries",
+          "title": "Call latency p50/p95/p99 (successful calls)",
+          "gridPos": {
+            "x": 12,
+            "y": 19,
+            "w": 12,
+            "h": 8
+          },
+          "datasource": "${datasource}",
+          "targets": [
+            {
+              "datasource": "${datasource}",
+              "expr": "histogram_quantile(0.5, sum by (le) (rate(openbank_llm_call_duration_seconds_bucket{outcome=\"success\",job=\"observability/openbank-services\"}[5m])))",
+              "legendFormat": "p50",
+              "refId": "A"
+            },
+            {
+              "datasource": "${datasource}",
+              "expr": "histogram_quantile(0.95, sum by (le) (rate(openbank_llm_call_duration_seconds_bucket{outcome=\"success\",job=\"observability/openbank-services\"}[5m])))",
+              "legendFormat": "p95",
+              "refId": "B"
+            },
+            {
+              "datasource": "${datasource}",
+              "expr": "histogram_quantile(0.99, sum by (le) (rate(openbank_llm_call_duration_seconds_bucket{outcome=\"success\",job=\"observability/openbank-services\"}[5m])))",
+              "legendFormat": "p99",
+              "refId": "C"
+            }
+          ],
+          "fieldConfig": {
+            "defaults": {
+              "unit": "s",
+              "color": {
+                "mode": "palette-classic"
+              },
+              "custom": {
+                "lineWidth": 1,
+                "fillOpacity": 10,
+                "spanNulls": false
+              }
+            },
+            "overrides": []
+          },
+          "options": {
+            "legend": {
+              "displayMode": "list",
+              "placement": "bottom"
+            },
+            "tooltip": {
+              "mode": "multi"
+            }
+          },
+          "description": "Failures are timed too but excluded here — a 60s timeout would swamp the success distribution."
+        },
+        {
+          "id": 11,
+          "type": "table",
+          "title": "Unpriced models (tokens with no price-book entry, 24h)",
+          "gridPos": {
+            "x": 0,
+            "y": 27,
+            "w": 12,
+            "h": 6
+          },
+          "datasource": "${datasource}",
+          "targets": [
+            {
+              "datasource": "${datasource}",
+              "expr": "openbank:llm_tokens_unpriced_24h > 0",
+              "refId": "A",
+              "instant": true,
+              "format": "table"
+            }
+          ],
+          "fieldConfig": {
+            "defaults": {
+              "unit": "short"
+            },
+            "overrides": []
+          },
+          "options": {
+            "showHeader": true
+          },
+          "description": "Empty is the healthy state. Any row: add the model to the price book in prometheus-rules-ai.yaml."
+        },
+        {
+          "id": 12,
+          "type": "table",
+          "title": "Price book in force",
+          "gridPos": {
+            "x": 12,
+            "y": 27,
+            "w": 12,
+            "h": 6
+          },
+          "datasource": "${datasource}",
+          "targets": [
+            {
+              "datasource": "${datasource}",
+              "expr": "openbank:llm_price_usd_per_token",
+              "refId": "A",
+              "instant": true,
+              "format": "table"
+            }
+          ],
+          "fieldConfig": {
+            "defaults": {
+              "unit": "short"
+            },
+            "overrides": []
+          },
+          "options": {
+            "showHeader": true
+          },
+          "description": "USD per token, by model and kind. price_source=nearest-sibling marks an estimate."
+        }
+      ]
+    }

--- a/openbank-infra/gitops/components/observability/prometheus-rules-ai.yaml
+++ b/openbank-infra/gitops/components/observability/prometheus-rules-ai.yaml
@@ -1,0 +1,184 @@
+# AI / LLM cost and reliability rules (ADR-0112, ADR-0174).
+#
+# Why these live here and not in LiteLLM: the gateway is the natural choke point and it does ship a
+# Prometheus exporter, but that exporter is a LiteLLM **Enterprise** feature — verified against
+# upstream docs (docs.litellm.ai/docs/proxy/prometheus, "Enterprise LiteLLM Only") before choosing
+# an approach, not assumed. So the tokens are counted client-side instead, by DomainMetrics on the
+# three code paths that make real /chat/completions calls, and this file turns those counts into
+# spend and into alerts.
+#
+# What this replaces: FinOpsAgentTokenBudgetExceeded in prometheus-rules-finops.yaml was written
+# against langfuse_agent_tokens_total / langfuse_model_cost_per_token / langfuse_agent_daily_budget_usd.
+# Langfuse has never been deployed — it appears nowhere in gitops — so that alert could not fire,
+# and its own annotation said so. An alert that documents its own inertness is still an alert nobody
+# can act on; it is removed in the same PR that adds these.
+apiVersion: monitoring.coreos.com/v1
+kind: PrometheusRule
+metadata:
+  name: openbank-ai-alerts
+  namespace: observability
+  labels:
+    app.kubernetes.io/part-of: observability
+spec:
+  groups:
+    # ── Price book ────────────────────────────────────────────────────────────
+    #
+    # USD per token, as a recording rule rather than a constant in Kotlin, so a provider's rate-card
+    # change is a gitops edit that reloads in place instead of a redeploy of every LLM caller — and
+    # so a wrong price is visible in one file rather than compiled into the fleet.
+    #
+    # `kind` matches the label DomainMetrics emits on openbank_llm_tokens_total, so the join below
+    # is on (model, kind) and prompt/completion are priced separately — every provider charges
+    # different rates for the two, so a combined total cannot be costed at all.
+    #
+    # `price_source` is carried deliberately: it is the difference between a number we can defend
+    # and one we cannot, and it stays visible on the dashboard rather than living in a comment.
+    - name: openbank.ai.price-book
+      interval: 1h
+      rules:
+        # Authoritative: BerriAI/litellm model_prices_and_context_window.json, entry
+        # `groq/llama-3.3-70b-versatile` — $0.59/M input, $0.79/M output.
+        - record: openbank:llm_price_usd_per_token
+          expr: vector(0.00000059)
+          labels:
+            model: llama-3.3-70b-versatile
+            kind: prompt
+            price_source: litellm-map
+        - record: openbank:llm_price_usd_per_token
+          expr: vector(0.00000079)
+          labels:
+            model: llama-3.3-70b-versatile
+            kind: completion
+            price_source: litellm-map
+        # APPROXIMATE. LiteLLM's price map has no `deepinfra/deepseek-ai/DeepSeek-V3.2` entry — the
+        # newest DeepInfra DeepSeek it knows is V3.1 ($0.27/M input, $1.00/M output), used here as
+        # the nearest published sibling. Every panel and alert built on this carries
+        # price_source="nearest-sibling" so the estimate is never mistaken for a billed figure.
+        # Replace with the real rate card when DeepInfra publishes V3.2, or when the invoice
+        # disagrees — the invoice is the authority, this is a leading indicator.
+        - record: openbank:llm_price_usd_per_token
+          expr: vector(0.00000027)
+          labels:
+            model: deepseek-ai/DeepSeek-V3.2
+            kind: prompt
+            price_source: nearest-sibling
+        - record: openbank:llm_price_usd_per_token
+          expr: vector(0.00000100)
+          labels:
+            model: deepseek-ai/DeepSeek-V3.2
+            kind: completion
+            price_source: nearest-sibling
+
+    # ── Derived spend ─────────────────────────────────────────────────────────
+    - name: openbank.ai.spend
+      interval: 5m
+      rules:
+        # Spend per model over 24h. `group_left(price_source)` carries the provenance through, so a
+        # panel can show which figures are estimates without a second query.
+        - record: openbank:llm_cost_usd_24h:by_model
+          expr: |
+            sum by (model, price_source) (
+              increase(openbank_llm_tokens_total[24h])
+              * on (model, kind) group_left (price_source) openbank:llm_price_usd_per_token
+            )
+        # Fleet total. Deliberately re-derived from the same join rather than summing the rule
+        # above, so a model missing from the price book is missing from BOTH and cannot silently
+        # inflate one while deflating the other.
+        - record: openbank:llm_cost_usd_24h:total
+          expr: |
+            sum (
+              increase(openbank_llm_tokens_total[24h])
+              * on (model, kind) group_left () openbank:llm_price_usd_per_token
+            )
+        # Tokens seen for a model with NO price-book entry. This is the metric that makes the price
+        # book falsifiable: add a model to the gateway and forget this file, and the spend figures
+        # stay quietly and wrongly low. `unless on (model)` is the whole point — a plain sum would
+        # not notice.
+        #
+        # No `group_left` here: `unless` is a set operator, not a join, and Prometheus rejects a
+        # grouping modifier on it outright ("no grouping allowed for 'unless' operation"). Written
+        # with one first; promtool caught it, which is the only reason this file is not a rule group
+        # Prometheus silently refuses to load.
+        - record: openbank:llm_tokens_unpriced_24h
+          expr: |
+            sum by (model) (
+              increase(openbank_llm_tokens_total[24h])
+              unless on (model) openbank:llm_price_usd_per_token
+            )
+
+    # ── Alerts ────────────────────────────────────────────────────────────────
+    - name: openbank.ai.alerts
+      interval: 5m
+      rules:
+        # The real replacement for FinOpsAgentTokenBudgetExceeded. Threshold is a plain USD/day
+        # ceiling on the whole fleet rather than a per-agent budget: per-agent budgets need
+        # LiteLLM virtual keys backed by a Postgres, which this gateway does not have yet
+        # (tracked separately). A fleet ceiling is enforceable today and is what actually protects
+        # the card.
+        - alert: AiFleetDailySpendHigh
+          expr: openbank:llm_cost_usd_24h:total > 25
+          for: 15m
+          labels:
+            severity: warning
+            team: platform
+            route: finops-agent
+          annotations:
+            summary: "LLM fleet spend {{ $value | printf \"%.2f\" }} USD/24h exceeds the 25 USD ceiling"
+            description: >-
+              Rolling 24h token spend across every model. Derived from openbank_llm_tokens_total
+              and the openbank:llm_price_usd_per_token price book; figures whose price_source is
+              "nearest-sibling" are estimates, so confirm against the provider invoice before
+              treating the absolute number as billed. Break down by model on the AI dashboard.
+
+        # A model burning tokens that nothing prices. Not a cost alert — a *trust* alert about the
+        # cost figures themselves.
+        - alert: AiSpendUnpriced
+          expr: openbank:llm_tokens_unpriced_24h > 0
+          for: 1h
+          labels:
+            severity: warning
+            team: platform
+          annotations:
+            summary: "Model {{ $labels.model }} has no entry in the LLM price book"
+            description: >-
+              openbank_llm_tokens_total carries tokens for {{ $labels.model }}, but
+              openbank:llm_price_usd_per_token has no (model, kind) pair for it, so every spend
+              figure on the AI dashboard UNDERSTATES the real cost by this model's share. Add the
+              model to the price-book group in prometheus-rules-ai.yaml.
+
+        # Reliability. Deliberately excludes not_configured: a never-seeded agent is a different
+        # problem with a different fix, and folding it in here would make the error rate unusable.
+        - alert: AiCallErrorRateHigh
+          expr: |
+            100 * (
+              sum by (model) (rate(openbank_llm_requests_total{outcome=~"http_error|exception"}[15m]))
+              /
+              sum by (model) (rate(openbank_llm_requests_total{outcome!="not_configured"}[15m]))
+            ) > 20
+          for: 15m
+          labels:
+            severity: warning
+            team: platform
+          annotations:
+            summary: "{{ $value | printf \"%.0f\" }}% of LLM calls to {{ $labels.model }} are failing"
+            description: >-
+              Every caller degrades to a deterministic fallback on a failed LLM call, so this does
+              NOT page — nothing is down. It means the AI features are silently off: the agents
+              still answer, with their non-model path. Check the gateway pod, the provider status
+              and the API key.
+
+        # The gap this whole PR exists to close. An agent whose key was never seeded returns null
+        # forever and logs one warning at startup; nothing else anywhere says so.
+        - alert: AiCallsNotConfigured
+          expr: sum by (model) (increase(openbank_llm_requests_total{outcome="not_configured"}[1h])) > 0
+          for: 30m
+          labels:
+            severity: warning
+            team: platform
+          annotations:
+            summary: "LLM calls for {{ $labels.model }} are being skipped — no API key seeded"
+            description: >-
+              A caller attempted an LLM call and skipped it because its API key is blank, degrading
+              to the deterministic fallback. This is the documented safe mode (an unseeded key must
+              not CrashLoop the pod), but it is not a steady state: the feature is off. Seed the key
+              via ESO/OpenBao.

--- a/openbank-infra/gitops/components/observability/prometheus-rules-finops.yaml
+++ b/openbank-infra/gitops/components/observability/prometheus-rules-finops.yaml
@@ -2,6 +2,18 @@
 # recurring AWS cost incidents documented in the ADR: NAT drain, cross-AZ traffic,
 # Karpenter node churn, EBS attachment failures, and CI runner pool pressure.
 # All alerts route to GoAlert (which triggers the finops-agent Temporal workflow).
+# The openbank.finops.ai-costs group used to live here, holding one alert:
+# FinOpsAgentTokenBudgetExceeded, written against langfuse_agent_tokens_total,
+# langfuse_model_cost_per_token and langfuse_agent_daily_budget_usd. Langfuse has never been
+# deployed — it appears in no manifest anywhere in gitops — so none of those three series has
+# ever existed and the alert could not fire. Its own description said as much ("will be absent
+# until the bridge is deployed"), which is the trap: it read as pending rather than as inert,
+# and the D6 detector looked covered on every dashboard that counts rules.
+#
+# Replaced by prometheus-rules-ai.yaml, which alerts on openbank_llm_* — counted client-side by
+# DomainMetrics on the three code paths that make real /chat/completions calls, because
+# LiteLLM's own Prometheus exporter is an Enterprise feature. AI spend alerting now depends on
+# nothing that is not deployed.
 apiVersion: monitoring.coreos.com/v1
 kind: PrometheusRule
 metadata:
@@ -186,27 +198,3 @@ spec:
             summary: "CI runner pool > 80% utilisation"
             description: "ARC runner pool is at {{ $value | humanizePercentage }} capacity. Scale-up recommended to prevent aio-max-nr exhaustion and job queuing."
             runbook: "https://github.com/JiRaska/open-bank-oss/blob/main/docs/runbooks/0007-arc-runner-scale.md"
-
-    - name: openbank.finops.ai-costs
-      interval: 15m
-      rules:
-        # AI token budget overage — requires Langfuse→Prometheus bridge (ADR-0112 P1).
-        # The bridge exposes langfuse_agent_tokens_total{agent_id, model} counter.
-        # on(agent_id) ensures the budget scalar matches by agent_id to avoid cross-label
-        # vector matching failures when langfuse_agent_daily_budget_usd carries extra labels.
-        - alert: FinOpsAgentTokenBudgetExceeded
-          expr: |
-            (
-              increase(langfuse_agent_tokens_total[24h]) * on(model) group_left()
-              langfuse_model_cost_per_token
-            ) > on(agent_id) langfuse_agent_daily_budget_usd
-          for: 0m
-          labels:
-            severity: warning
-            detector: D6
-            team: platform
-            route: finops-agent
-          annotations:
-            summary: "AI agent {{ $labels.agent_id }} exceeded daily token budget"
-            description: "Agent {{ $labels.agent_id }} used {{ $value }} USD in the last 24h, exceeding its budget. Kill switch available in IAOps console. Requires ADR-0112 P1 Langfuse bridge — alert will be absent until the bridge is deployed."
-            runbook: "https://github.com/JiRaska/open-bank-oss/blob/main/docs/runbooks/0008-ai-token-budget.md"

--- a/openbank-libs-domain/src/main/kotlin/com/openbank/libs/llm/LlmCallMetricsPort.kt
+++ b/openbank-libs-domain/src/main/kotlin/com/openbank/libs/llm/LlmCallMetricsPort.kt
@@ -1,0 +1,74 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright (c) OpenBank contributors. Licensed under the Apache License, Version 2.0.
+// See LICENSE in the repository root or https://www.apache.org/licenses/LICENSE-2.0 for details.
+package com.openbank.libs.llm
+
+/**
+ * What every LLM call in the fleet reports, so the AI spend and reliability are observable in
+ * Prometheus rather than only in a span attribute or a provider's billing page.
+ *
+ * Why a port and not a direct MeterRegistry call at each site: three separate code paths make real
+ * `/chat/completions` calls — the shared [LlmGatewayPort] client (devops-agent,
+ * control-liveness-sentinel), agent-service's `OpenAiCompatibleModelProvider`, and
+ * copilot-service's. They live in different modules with different licences and none of them may
+ * import Micrometer into a domain type. One pure port implemented once in `openbank-libs-runtime`
+ * keeps the metric NAMES and TAGS identical across all three, which is the only reason a fleet-wide
+ * "tokens by model" query can exist at all.
+ *
+ * The gap this closes: LiteLLM's own Prometheus callback is an Enterprise feature, so the gateway
+ * cannot report this for us — measured against the upstream docs before choosing client-side
+ * instrumentation. agent-service did record `openbank.agent.tokens_total`, but as an OpenTelemetry
+ * **span attribute**, which lands in Tempo and is therefore unavailable to a Prometheus alert or a
+ * budget rule.
+ *
+ * Implementations must never throw: a metrics failure may not break an LLM call. The no-op [NONE]
+ * is the default everywhere, so a caller that has not been wired yet is silent rather than broken.
+ */
+interface LlmCallMetricsPort {
+
+    /**
+     * One completed call attempt, successful or not.
+     *
+     * @param model the model id as sent upstream (e.g. `deepseek-ai/DeepSeek-V3.2`) — the same
+     *   string the gateway config uses, so a cost rule can join on it without a mapping table.
+     * @param outcome one of [OUTCOME_SUCCESS], [OUTCOME_HTTP_ERROR], [OUTCOME_EXCEPTION],
+     *   [OUTCOME_NOT_CONFIGURED]. A closed vocabulary: this tag is a Prometheus label and an
+     *   open-ended one (an exception message, a status code) would be a cardinality bomb.
+     * @param promptTokens from the response's `usage.prompt_tokens`; 0 when the provider omits it.
+     * @param completionTokens from `usage.completion_tokens`; 0 when the provider omits it.
+     * @param durationNanos wall-clock for the whole attempt, including a failed one — a timeout is
+     *   the slowest and most interesting case, so timing only successes would hide it.
+     */
+    fun recordCall(
+        model: String,
+        outcome: String,
+        promptTokens: Int,
+        completionTokens: Int,
+        durationNanos: Long,
+    )
+
+    companion object {
+        const val OUTCOME_SUCCESS = "success"
+        const val OUTCOME_HTTP_ERROR = "http_error"
+        const val OUTCOME_EXCEPTION = "exception"
+
+        /**
+         * The call never left the process because no API key was seeded. Distinct from an error on
+         * purpose: it is the fleet's documented degraded mode (an unseeded key returns `null`
+         * rather than CrashLooping the pod), and folding it into `exception` would make a
+         * never-configured agent look like a broken one — and vice versa, which is worse.
+         */
+        const val OUTCOME_NOT_CONFIGURED = "not_configured"
+
+        /** Records nothing. The default for every caller that has not been wired. */
+        val NONE: LlmCallMetricsPort = object : LlmCallMetricsPort {
+            override fun recordCall(
+                model: String,
+                outcome: String,
+                promptTokens: Int,
+                completionTokens: Int,
+                durationNanos: Long,
+            ) = Unit
+        }
+    }
+}

--- a/openbank-libs-domain/src/main/kotlin/com/openbank/libs/llm/LlmCallMetricsPort.kt
+++ b/openbank-libs-domain/src/main/kotlin/com/openbank/libs/llm/LlmCallMetricsPort.kt
@@ -39,13 +39,7 @@ interface LlmCallMetricsPort {
      * @param durationNanos wall-clock for the whole attempt, including a failed one — a timeout is
      *   the slowest and most interesting case, so timing only successes would hide it.
      */
-    fun recordCall(
-        model: String,
-        outcome: String,
-        promptTokens: Int,
-        completionTokens: Int,
-        durationNanos: Long,
-    )
+    fun recordCall(model: String, outcome: String, promptTokens: Int, completionTokens: Int, durationNanos: Long)
 
     companion object {
         const val OUTCOME_SUCCESS = "success"

--- a/openbank-libs-runtime/src/main/kotlin/com/openbank/libs/llm/OpenAiCompatibleLlmGatewayClient.kt
+++ b/openbank-libs-runtime/src/main/kotlin/com/openbank/libs/llm/OpenAiCompatibleLlmGatewayClient.kt
@@ -49,6 +49,10 @@ class OpenAiCompatibleLlmGatewayClient(
     http: HttpClient? = null,
     private val temperature: Double = 0.2,
     private val maxTokens: Int = 700,
+    // Defaults to the no-op so an un-wired caller stays silent rather than broken, and so this
+    // stays a plain constructible class — `DomainMetrics` is the CDI bean that implements it, and
+    // producing one from here would drag Micrometer into every consumer's Arc type closure.
+    private val metrics: LlmCallMetricsPort = LlmCallMetricsPort.NONE,
 ) : LlmGatewayPort {
 
     private val log = Logger.getLogger(OpenAiCompatibleLlmGatewayClient::class.java)
@@ -61,6 +65,10 @@ class OpenAiCompatibleLlmGatewayClient(
     override suspend fun chat(systemPrompt: String, userPrompt: String): String? {
         if (apiKey.isBlank()) {
             log.warn("LLM api-key not seeded — skipping call (degraded to deterministic fallback)")
+            // Recorded, not silent: an agent that has never had a key looks identical to one that
+            // is simply idle unless this series exists, and "the AI features were never switched
+            // on" is exactly the state this repo keeps discovering months late.
+            metrics.recordCall(model, LlmCallMetricsPort.OUTCOME_NOT_CONFIGURED, 0, 0, 0)
             return null
         }
         val url = "${baseUrl.trimEnd('/')}/chat/completions"
@@ -70,6 +78,10 @@ class OpenAiCompatibleLlmGatewayClient(
             temperature = temperature,
             maxTokens = maxTokens,
         )
+        // Nanos, not a Timer.Sample: the metrics port is a pure-domain interface and may not carry a
+        // Micrometer type. Measured around the whole attempt, so a timeout — the slowest and most
+        // interesting case — is timed too rather than being dropped with the exception.
+        val startedAt = System.nanoTime()
         return try {
             val request = HttpRequest.newBuilder(URI.create(url))
                 .timeout(Duration.ofSeconds(REQUEST_TIMEOUT_S))
@@ -83,12 +95,33 @@ class OpenAiCompatibleLlmGatewayClient(
             }
             if (resp.statusCode() !in OK_RANGE) {
                 log.warnf("LLM backend %s returned HTTP %d", baseUrl, resp.statusCode())
+                metrics.recordCall(
+                    model,
+                    LlmCallMetricsPort.OUTCOME_HTTP_ERROR,
+                    0,
+                    0,
+                    System.nanoTime() - startedAt,
+                )
                 return null
             }
-            mapper.readValue(resp.body(), ChatResponse::class.java)
-                .choices.firstOrNull()?.message?.content?.takeIf { it.isNotBlank() }
+            val parsed = mapper.readValue(resp.body(), ChatResponse::class.java)
+            metrics.recordCall(
+                model,
+                LlmCallMetricsPort.OUTCOME_SUCCESS,
+                parsed.usage?.promptTokens ?: 0,
+                parsed.usage?.completionTokens ?: 0,
+                System.nanoTime() - startedAt,
+            )
+            parsed.choices.firstOrNull()?.message?.content?.takeIf { it.isNotBlank() }
         } catch (ex: Exception) {
             log.warnf("LLM call failed: %s", ex.message)
+            metrics.recordCall(
+                model,
+                LlmCallMetricsPort.OUTCOME_EXCEPTION,
+                0,
+                0,
+                System.nanoTime() - startedAt,
+            )
             null
         }
     }
@@ -114,7 +147,21 @@ internal data class ChatRequest(
 internal data class ChatMessage(val role: String, val content: String)
 
 @JsonIgnoreProperties(ignoreUnknown = true)
-internal data class ChatResponse(val choices: List<ChatChoice> = emptyList())
+internal data class ChatResponse(
+    val choices: List<ChatChoice> = emptyList(),
+    // Every OpenAI-compatible backend returns this block on a successful non-streaming call, but
+    // it is nullable because none of them PROMISE to: the client must not start returning null
+    // completions because a provider dropped `usage`. Until now it was parsed away by
+    // @JsonIgnoreProperties, which is why the fleet's token consumption existed only on the
+    // provider's invoice.
+    val usage: ChatUsage? = null,
+)
+
+@JsonIgnoreProperties(ignoreUnknown = true)
+internal data class ChatUsage(
+    @JsonProperty("prompt_tokens") val promptTokens: Int = 0,
+    @JsonProperty("completion_tokens") val completionTokens: Int = 0,
+)
 
 @JsonIgnoreProperties(ignoreUnknown = true)
 internal data class ChatChoice(val message: ChatMessage = ChatMessage("assistant", ""))

--- a/openbank-libs-runtime/src/main/kotlin/com/openbank/libs/observability/DomainMetrics.kt
+++ b/openbank-libs-runtime/src/main/kotlin/com/openbank/libs/observability/DomainMetrics.kt
@@ -4,6 +4,7 @@
 
 package com.openbank.libs.observability
 
+import com.openbank.libs.llm.LlmCallMetricsPort
 import io.micrometer.core.instrument.Counter
 import io.micrometer.core.instrument.DistributionSummary
 import io.micrometer.core.instrument.Gauge
@@ -47,7 +48,7 @@ import java.time.Duration
  * Services that do ship a registry (sepa-payment-service, …) get full instrumentation.
  */
 @ApplicationScoped
-class DomainMetrics {
+class DomainMetrics : LlmCallMetricsPort {
 
     @Inject
     lateinit var registryInstance: Instance<MeterRegistry>
@@ -439,6 +440,61 @@ class DomainMetrics {
                 ref
             }.set(drift)
         }
+    }
+
+    // ── LLM calls (ADR-0174 / ADR-0112) ──────────────────────────────────────
+
+    /**
+     * One completed `/chat/completions` attempt, from any of the three code paths that make real
+     * LLM calls: the shared [com.openbank.libs.llm.OpenAiCompatibleLlmGatewayClient],
+     * agent-service's `OpenAiCompatibleModelProvider` and copilot-service's. Implements
+     * [LlmCallMetricsPort] so the two non-CDI clients can be handed this same bean and every path
+     * emits identical names and tags — otherwise a fleet-wide "tokens by model" query is not
+     * expressible.
+     *
+     * Emits three series:
+     *  - `openbank.llm.requests{model,outcome}` — call volume and reliability;
+     *  - `openbank.llm.tokens{model,kind}` — `prompt` and `completion` separately, because they are
+     *    priced differently by every provider, so a cost rule cannot use a combined total;
+     *  - `openbank.llm.call.duration{model,outcome}` — timed on failures too, since a timeout is
+     *    the slowest and most interesting case.
+     *
+     * **No cost metric here on purpose.** Price per token belongs in a Prometheus recording rule
+     * where it can be corrected without a redeploy of every LLM caller; a constant compiled into
+     * the fleet would be wrong the first time a provider changes its rate card, and silently so.
+     *
+     * Cardinality: `model` is a small closed set from the gateway config and `outcome` is the
+     * closed vocabulary in [LlmCallMetricsPort]. Never pass a prompt, a user id, or a status code.
+     */
+    override fun recordCall(
+        model: String,
+        outcome: String,
+        promptTokens: Int,
+        completionTokens: Int,
+        durationNanos: Long,
+    ) {
+        counter("openbank.llm.requests", "model", model, "outcome", outcome)
+        // Skip zero increments: providers omit `usage` on an error, and a counter that only ever
+        // sees 0 still creates the series — a flat line that reads as "no spend" rather than "no
+        // data", which is the same misreading the business dashboards hit with pinned-at-0 counters.
+        if (promptTokens > 0) {
+            reg()?.let {
+                Counter.builder("openbank.llm.tokens")
+                    .tags("model", model, "kind", "prompt")
+                    .register(it)
+                    .increment(promptTokens.toDouble())
+            }
+        }
+        if (completionTokens > 0) {
+            reg()?.let {
+                Counter.builder("openbank.llm.tokens")
+                    .tags("model", model, "kind", "completion")
+                    .register(it)
+                    .increment(completionTokens.toDouble())
+            }
+        }
+        timer("openbank.llm.call.duration", "model", model, "outcome", outcome)
+            ?.record(Duration.ofNanos(durationNanos))
     }
 
     // ── Helpers ───────────────────────────────────────────────────────────────

--- a/openbank-libs-runtime/src/main/kotlin/com/openbank/libs/observability/DomainMetrics.kt
+++ b/openbank-libs-runtime/src/main/kotlin/com/openbank/libs/observability/DomainMetrics.kt
@@ -4,7 +4,6 @@
 
 package com.openbank.libs.observability
 
-import com.openbank.libs.llm.LlmCallMetricsPort
 import io.micrometer.core.instrument.Counter
 import io.micrometer.core.instrument.DistributionSummary
 import io.micrometer.core.instrument.Gauge
@@ -48,7 +47,7 @@ import java.time.Duration
  * Services that do ship a registry (sepa-payment-service, …) get full instrumentation.
  */
 @ApplicationScoped
-class DomainMetrics : LlmCallMetricsPort {
+class DomainMetrics {
 
     @Inject
     lateinit var registryInstance: Instance<MeterRegistry>
@@ -440,61 +439,6 @@ class DomainMetrics : LlmCallMetricsPort {
                 ref
             }.set(drift)
         }
-    }
-
-    // ── LLM calls (ADR-0174 / ADR-0112) ──────────────────────────────────────
-
-    /**
-     * One completed `/chat/completions` attempt, from any of the three code paths that make real
-     * LLM calls: the shared [com.openbank.libs.llm.OpenAiCompatibleLlmGatewayClient],
-     * agent-service's `OpenAiCompatibleModelProvider` and copilot-service's. Implements
-     * [LlmCallMetricsPort] so the two non-CDI clients can be handed this same bean and every path
-     * emits identical names and tags — otherwise a fleet-wide "tokens by model" query is not
-     * expressible.
-     *
-     * Emits three series:
-     *  - `openbank.llm.requests{model,outcome}` — call volume and reliability;
-     *  - `openbank.llm.tokens{model,kind}` — `prompt` and `completion` separately, because they are
-     *    priced differently by every provider, so a cost rule cannot use a combined total;
-     *  - `openbank.llm.call.duration{model,outcome}` — timed on failures too, since a timeout is
-     *    the slowest and most interesting case.
-     *
-     * **No cost metric here on purpose.** Price per token belongs in a Prometheus recording rule
-     * where it can be corrected without a redeploy of every LLM caller; a constant compiled into
-     * the fleet would be wrong the first time a provider changes its rate card, and silently so.
-     *
-     * Cardinality: `model` is a small closed set from the gateway config and `outcome` is the
-     * closed vocabulary in [LlmCallMetricsPort]. Never pass a prompt, a user id, or a status code.
-     */
-    override fun recordCall(
-        model: String,
-        outcome: String,
-        promptTokens: Int,
-        completionTokens: Int,
-        durationNanos: Long,
-    ) {
-        counter("openbank.llm.requests", "model", model, "outcome", outcome)
-        // Skip zero increments: providers omit `usage` on an error, and a counter that only ever
-        // sees 0 still creates the series — a flat line that reads as "no spend" rather than "no
-        // data", which is the same misreading the business dashboards hit with pinned-at-0 counters.
-        if (promptTokens > 0) {
-            reg()?.let {
-                Counter.builder("openbank.llm.tokens")
-                    .tags("model", model, "kind", "prompt")
-                    .register(it)
-                    .increment(promptTokens.toDouble())
-            }
-        }
-        if (completionTokens > 0) {
-            reg()?.let {
-                Counter.builder("openbank.llm.tokens")
-                    .tags("model", model, "kind", "completion")
-                    .register(it)
-                    .increment(completionTokens.toDouble())
-            }
-        }
-        timer("openbank.llm.call.duration", "model", model, "outcome", outcome)
-            ?.record(Duration.ofNanos(durationNanos))
     }
 
     // ── Helpers ───────────────────────────────────────────────────────────────

--- a/openbank-libs-runtime/src/main/kotlin/com/openbank/libs/observability/LlmCallMetrics.kt
+++ b/openbank-libs-runtime/src/main/kotlin/com/openbank/libs/observability/LlmCallMetrics.kt
@@ -1,0 +1,94 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright (c) OpenBank contributors. Licensed under the Apache License, Version 2.0.
+// See LICENSE in the repository root or https://www.apache.org/licenses/LICENSE-2.0 for details.
+
+package com.openbank.libs.observability
+
+import com.openbank.libs.llm.LlmCallMetricsPort
+import io.micrometer.core.instrument.Counter
+import io.micrometer.core.instrument.MeterRegistry
+import io.micrometer.core.instrument.Timer
+import jakarta.enterprise.context.ApplicationScoped
+import jakarta.enterprise.inject.Instance
+import jakarta.inject.Inject
+import java.time.Duration
+
+/**
+ * Micrometer implementation of [LlmCallMetricsPort] (ADR-0174 / ADR-0112) — the one place the
+ * fleet's LLM call volume, token consumption and latency are recorded.
+ *
+ * **Why its own bean and not another method on [DomainMetrics].** DomainMetrics is the domain-event
+ * façade and it sits exactly at detekt's `TooManyFunctions` ceiling: adding `recordCall` to it took
+ * the class to 30 functions and failed the gate. That ceiling is doing its job here rather than
+ * being an obstacle — LLM calls are infrastructure telemetry, not a banking domain event like
+ * `paymentSubmitted` or `kycVerdict`, and the port they implement is a different contract with a
+ * different set of callers. Suppressing the rule would have kept a wrong grouping.
+ *
+ * Same CDI shape as DomainMetrics, deliberately: `@ApplicationScoped` with an `Instance<MeterRegistry>`
+ * rather than a direct injection, so this bean loads harmlessly in a service that has no
+ * `quarkus-micrometer-*` on its classpath and every method becomes a silent no-op. It is a plain
+ * bean, **not** a `@Produces` — a producer here would drag Micrometer into the Arc type closure of
+ * every consumer of openbank-libs-runtime, including the ones that never make an LLM call.
+ *
+ * Three series, tagged only with closed low-cardinality sets:
+ *  - `openbank.llm.requests{model,outcome}` — call volume and reliability;
+ *  - `openbank.llm.tokens{model,kind}` — `prompt` and `completion` separately, because every
+ *    provider prices them differently, so a combined total cannot be costed at all;
+ *  - `openbank.llm.call.duration{model,outcome}` — timed on failures too, since a timeout is the
+ *    slowest and most interesting case.
+ *
+ * **No cost metric here on purpose.** Price per token lives in the `openbank:llm_price_usd_per_token`
+ * Prometheus recording rules, where a provider's rate-card change is a gitops edit that reloads in
+ * place. A constant compiled into the fleet would be wrong the first time a rate changes, and
+ * silently so.
+ */
+@ApplicationScoped
+class LlmCallMetrics : LlmCallMetricsPort {
+
+    @Inject
+    lateinit var registryInstance: Instance<MeterRegistry>
+
+    private fun reg(): MeterRegistry? = if (registryInstance.isResolvable) registryInstance.get() else null
+
+    override fun recordCall(
+        model: String,
+        outcome: String,
+        promptTokens: Int,
+        completionTokens: Int,
+        durationNanos: Long,
+    ) {
+        val registry = reg() ?: return
+        Counter.builder("openbank.llm.requests")
+            .tags("model", model, "outcome", outcome)
+            .register(registry)
+            .increment()
+        // Skip zero increments: providers omit `usage` on an error, and a counter that only ever
+        // sees 0 still creates the series — a flat line that reads as "no spend" rather than "no
+        // data", which is the same misreading the business dashboards hit with pinned-at-0 counters.
+        recordTokens(registry, model, "prompt", promptTokens)
+        recordTokens(registry, model, "completion", completionTokens)
+        Timer.builder("openbank.llm.call.duration")
+            .tags("model", model, "outcome", outcome)
+            .publishPercentiles(P50, P95, P99)
+            .publishPercentileHistogram()
+            .register(registry)
+            .record(Duration.ofNanos(durationNanos))
+    }
+
+    private fun recordTokens(registry: MeterRegistry, model: String, kind: String, tokens: Int) {
+        if (tokens <= 0) return
+        Counter.builder("openbank.llm.tokens")
+            .tags("model", model, "kind", kind)
+            .register(registry)
+            .increment(tokens.toDouble())
+    }
+
+    private companion object {
+        // Declared as constants, not inline: detekt's MagicNumber fires on the fleet-standard
+        // percentile triple at every call site, and only DomainMetrics escapes it via the
+        // libs-runtime baseline.
+        const val P50 = 0.5
+        const val P95 = 0.95
+        const val P99 = 0.99
+    }
+}

--- a/openbank-libs-runtime/src/test/kotlin/com/openbank/libs/llm/OpenAiCompatibleLlmGatewayClientTest.kt
+++ b/openbank-libs-runtime/src/test/kotlin/com/openbank/libs/llm/OpenAiCompatibleLlmGatewayClientTest.kt
@@ -3,6 +3,7 @@
 // See LICENSE in the repository root or https://www.apache.org/licenses/LICENSE-2.0 for details.
 package com.openbank.libs.llm
 
+import com.openbank.libs.llm.LlmCallMetricsPort
 import com.sun.net.httpserver.HttpExchange
 import com.sun.net.httpserver.HttpServer
 import kotlinx.coroutines.runBlocking
@@ -41,8 +42,39 @@ class OpenAiCompatibleLlmGatewayClientTest {
         return "http://127.0.0.1:${srv.address.port}/v1"
     }
 
-    private fun client(baseUrl: String, apiKey: String = "test-key") =
-        OpenAiCompatibleLlmGatewayClient(baseUrl = baseUrl, model = "test-model", apiKey = apiKey)
+    private fun client(
+        baseUrl: String,
+        apiKey: String = "test-key",
+        metrics: LlmCallMetricsPort = LlmCallMetricsPort.NONE,
+    ) = OpenAiCompatibleLlmGatewayClient(
+        baseUrl = baseUrl,
+        model = "test-model",
+        apiKey = apiKey,
+        metrics = metrics,
+    )
+
+    /** Captures what the client reports, so the assertions can be about the recorded call. */
+    private class RecordingMetrics : LlmCallMetricsPort {
+        data class Call(
+            val model: String,
+            val outcome: String,
+            val promptTokens: Int,
+            val completionTokens: Int,
+            val durationNanos: Long,
+        )
+
+        val calls = mutableListOf<Call>()
+
+        override fun recordCall(
+            model: String,
+            outcome: String,
+            promptTokens: Int,
+            completionTokens: Int,
+            durationNanos: Long,
+        ) {
+            calls += Call(model, outcome, promptTokens, completionTokens, durationNanos)
+        }
+    }
 
     @Test
     fun `a successful completion returns the assistant content and sends the OpenAI wire shape`() {
@@ -87,5 +119,70 @@ class OpenAiCompatibleLlmGatewayClientTest {
         val base = startStub(200, """{"choices":[{"message":{"role":"assistant","content":"   "}}]}""")
         val answer = runBlocking { client(base).chat("s", "u") }
         assertThat(answer).isNull()
+    }
+
+    // ── Token accounting (ADR-0112 / ADR-0174) ───────────────────────────────
+    //
+    // The `usage` block was parsed away by @JsonIgnoreProperties before this, which is the whole
+    // reason the fleet's token consumption existed only on the provider's invoice. These tests are
+    // about that specific regression: it is silent, and a completion still comes back either way.
+
+    @Test
+    fun `usage is parsed and reported as prompt and completion tokens`() {
+        val base = startStub(
+            200,
+            """{"choices":[{"message":{"role":"assistant","content":"ok"}}],""" +
+                """"usage":{"prompt_tokens":321,"completion_tokens":64,"total_tokens":385}}""",
+        )
+        val metrics = RecordingMetrics()
+
+        val answer = runBlocking { client(base, metrics = metrics).chat("s", "u") }
+
+        assertThat(answer).isEqualTo("ok")
+        assertThat(metrics.calls).hasSize(1)
+        val call = metrics.calls.single()
+        assertThat(call.outcome).isEqualTo(LlmCallMetricsPort.OUTCOME_SUCCESS)
+        assertThat(call.model).isEqualTo("test-model")
+        assertThat(call.promptTokens).isEqualTo(321)
+        assertThat(call.completionTokens).isEqualTo(64)
+        assertThat(call.durationNanos).isGreaterThan(0)
+    }
+
+    @Test
+    fun `a provider that omits usage still yields the completion, with zero tokens`() {
+        // Nullable on purpose: no provider PROMISES `usage`, and dropping the completion because
+        // telemetry was missing would trade a working feature for a metric.
+        val base = startStub(200, """{"choices":[{"message":{"role":"assistant","content":"ok"}}]}""")
+        val metrics = RecordingMetrics()
+
+        val answer = runBlocking { client(base, metrics = metrics).chat("s", "u") }
+
+        assertThat(answer).isEqualTo("ok")
+        assertThat(metrics.calls.single().promptTokens).isEqualTo(0)
+        assertThat(metrics.calls.single().completionTokens).isEqualTo(0)
+    }
+
+    @Test
+    fun `a blank api key reports not_configured rather than staying silent`() {
+        val metrics = RecordingMetrics()
+
+        val answer = runBlocking { client("http://127.0.0.1:1/v1", "", metrics).chat("s", "u") }
+
+        assertThat(answer).isNull()
+        // An agent that has never had a key looks identical to an idle one without this series,
+        // and "the AI features were never switched on" is a state this repo keeps finding late.
+        assertThat(metrics.calls.single().outcome)
+            .isEqualTo(LlmCallMetricsPort.OUTCOME_NOT_CONFIGURED)
+    }
+
+    @Test
+    fun `a non-2xx response is reported as http_error and still timed`() {
+        val base = startStub(503, """{"error":"upstream unavailable"}""")
+        val metrics = RecordingMetrics()
+
+        assertThat(runBlocking { client(base, metrics = metrics).chat("s", "u") }).isNull()
+        val call = metrics.calls.single()
+        assertThat(call.outcome).isEqualTo(LlmCallMetricsPort.OUTCOME_HTTP_ERROR)
+        assertThat(call.durationNanos).isGreaterThan(0)
     }
 }

--- a/openbank-libs-runtime/src/test/kotlin/com/openbank/libs/observability/LlmCallMetricsTest.kt
+++ b/openbank-libs-runtime/src/test/kotlin/com/openbank/libs/observability/LlmCallMetricsTest.kt
@@ -1,0 +1,143 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright (c) OpenBank contributors. Licensed under the Apache License, Version 2.0.
+// See LICENSE in the repository root or https://www.apache.org/licenses/LICENSE-2.0 for details.
+
+package com.openbank.libs.observability
+
+import com.openbank.libs.llm.LlmCallMetricsPort
+import io.micrometer.core.instrument.MeterRegistry
+import io.micrometer.core.instrument.simple.SimpleMeterRegistry
+import io.mockk.every
+import io.mockk.mockk
+import jakarta.enterprise.inject.Instance
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.Test
+
+/**
+ * The metric NAMES and TAGS here are a contract with things outside this module:
+ * `prometheus-rules-ai.yaml` alerts on them, `dashboard-openbank-ai.yaml` plots them, and the
+ * `openbank:llm_price_usd_per_token` price book joins on `(model, kind)`. Rename a tag and every
+ * one of those goes quietly empty — a dashboard with no data looks exactly like a fleet making no
+ * LLM calls, which is the misreading this whole feature exists to end.
+ *
+ * promtool can prove those queries PARSE; only this test can prove they will match anything. So the
+ * assertions below deliberately spell the series out rather than referencing constants.
+ */
+class LlmCallMetricsTest {
+
+    private fun withRegistry(reg: MeterRegistry?): LlmCallMetrics {
+        val inst = mockk<Instance<MeterRegistry>>()
+        if (reg == null) {
+            every { inst.isResolvable } returns false
+        } else {
+            every { inst.isResolvable } returns true
+            every { inst.get() } returns reg
+        }
+        return LlmCallMetrics().apply { registryInstance = inst }
+    }
+
+    @Test
+    fun `a successful call emits the three series the rules and dashboard query`() {
+        val reg = SimpleMeterRegistry()
+        withRegistry(reg).recordCall(
+            model = "deepseek-ai/DeepSeek-V3.2",
+            outcome = LlmCallMetricsPort.OUTCOME_SUCCESS,
+            promptTokens = 120,
+            completionTokens = 45,
+            durationNanos = 250_000_000,
+        )
+
+        assertThat(
+            reg.find("openbank.llm.requests")
+                .tag("model", "deepseek-ai/DeepSeek-V3.2").tag("outcome", "success")
+                .counter()!!.count(),
+        ).isEqualTo(1.0)
+
+        // prompt and completion MUST be separate series: every provider prices them differently,
+        // so a combined total cannot be costed at all, and the price book joins on (model, kind).
+        assertThat(
+            reg.find("openbank.llm.tokens")
+                .tag("model", "deepseek-ai/DeepSeek-V3.2").tag("kind", "prompt")
+                .counter()!!.count(),
+        ).isEqualTo(120.0)
+        assertThat(
+            reg.find("openbank.llm.tokens")
+                .tag("model", "deepseek-ai/DeepSeek-V3.2").tag("kind", "completion")
+                .counter()!!.count(),
+        ).isEqualTo(45.0)
+
+        val timer = reg.find("openbank.llm.call.duration")
+            .tag("model", "deepseek-ai/DeepSeek-V3.2").tag("outcome", "success").timer()
+        assertThat(timer).isNotNull
+        assertThat(timer!!.count()).isEqualTo(1L)
+    }
+
+    @Test
+    fun `a failed call is still timed, because a timeout is the most interesting case`() {
+        val reg = SimpleMeterRegistry()
+        withRegistry(reg).recordCall(
+            model = "llama-3.3-70b-versatile",
+            outcome = LlmCallMetricsPort.OUTCOME_EXCEPTION,
+            promptTokens = 0,
+            completionTokens = 0,
+            durationNanos = 60_000_000_000,
+        )
+
+        val timer = reg.find("openbank.llm.call.duration")
+            .tag("model", "llama-3.3-70b-versatile").tag("outcome", "exception").timer()
+        assertThat(timer).isNotNull
+        assertThat(timer!!.count()).isEqualTo(1L)
+        // Timing only successes would have hidden exactly the 60s case this asserts.
+        assertThat(timer.totalTime(java.util.concurrent.TimeUnit.SECONDS)).isGreaterThan(59.0)
+    }
+
+    @Test
+    fun `zero-token calls create no token series at all`() {
+        val reg = SimpleMeterRegistry()
+        withRegistry(reg).recordCall(
+            model = "llama-3.3-70b-versatile",
+            outcome = LlmCallMetricsPort.OUTCOME_HTTP_ERROR,
+            promptTokens = 0,
+            completionTokens = 0,
+            durationNanos = 1_000,
+        )
+
+        // NOT "a counter at 0". Providers omit `usage` on an error, and a series pinned at zero
+        // reads as "no spend" on a dashboard, whereas an absent one reads as "no data" — which is
+        // the truth. This is the same distinction that made the business dashboard's flat lines
+        // convincing for months.
+        assertThat(reg.find("openbank.llm.tokens").counters()).isEmpty()
+        // The request itself is still counted, or the error rate would have no denominator.
+        assertThat(reg.find("openbank.llm.requests").tag("outcome", "http_error").counter())
+            .isNotNull
+    }
+
+    @Test
+    fun `not_configured is its own outcome, not folded into an error`() {
+        val reg = SimpleMeterRegistry()
+        val metrics = withRegistry(reg)
+        metrics.recordCall("m", LlmCallMetricsPort.OUTCOME_NOT_CONFIGURED, 0, 0, 0)
+        metrics.recordCall("m", LlmCallMetricsPort.OUTCOME_EXCEPTION, 0, 0, 5)
+
+        // AiCallErrorRateHigh divides by {outcome!="not_configured"}. If these collapsed into one
+        // outcome, a fleet with no API key seeded would read as 100% broken instead of "switched
+        // off", and the two need different fixes.
+        assertThat(reg.find("openbank.llm.requests").tag("outcome", "not_configured").counter()!!.count())
+            .isEqualTo(1.0)
+        assertThat(reg.find("openbank.llm.requests").tag("outcome", "exception").counter()!!.count())
+            .isEqualTo(1.0)
+    }
+
+    @Test
+    fun `with no MeterRegistry on the classpath every call is a silent no-op`() {
+        // libs-runtime is consumed by services that ship no micrometer. Throwing here would take
+        // down an LLM call over telemetry, which is never an acceptable trade.
+        withRegistry(null).recordCall("m", LlmCallMetricsPort.OUTCOME_SUCCESS, 1, 1, 1)
+    }
+
+    @Test
+    fun `the no-op port records nothing and does not throw`() {
+        // The default handed to any caller not yet wired. It must be inert, not partially wired.
+        LlmCallMetricsPort.NONE.recordCall("m", LlmCallMetricsPort.OUTCOME_SUCCESS, 10, 10, 10)
+    }
+}


### PR DESCRIPTION
## Summary

Fleet LLM spend, throughput and reliability are now real Prometheus series, alerts and a dashboard. Previously nothing reported them, and the one alert that claimed to (`FinOpsAgentTokenBudgetExceeded`) was written against `langfuse_*` series from a Langfuse that has never been deployed — so it could not fire, and said so in its own description, which read as *pending* rather than as *inert*.

## Type of change

- [x] feat (new functionality)

## Linked issues

Closes #3042
Refs ADR-0112, ADR-0174

## Why client-side and not at the gateway

LiteLLM is the natural choke point and does ship a Prometheus exporter — but it is an **Enterprise** feature (docs.litellm.ai/docs/proxy/prometheus, "Enterprise LiteLLM Only"). Checked against upstream docs before choosing an approach rather than assumed. So tokens are counted in the callers.

## What is actually instrumented

ADR-0174 describes one shared LLM seam, but only two services use it. A survey of every `/chat/completions` reference found eleven sites, of which **six are stubs that make no HTTP call at all** (`LlmDiagnosisAdapter` in finops-agent, governance-auditor, docs-truth-agent, flaky-test-hunter, authz-policy-auditor, release-steward — all still on the ADR-0112 P4 TODO). Three code paths make real calls, and all three are instrumented:

- `openbank-libs-runtime` `OpenAiCompatibleLlmGatewayClient` (devops-agent, control-liveness-sentinel)
- `openbank-agent-service` `OpenAiCompatibleModelProvider`
- `openbank-copilot-service` `OpenAiCompatibleModelProvider`

## Changes

- **New pure-domain port** `LlmCallMetricsPort` (openbank-libs-domain) with the closed outcome vocabulary `success | http_error | exception | not_configured`, implemented by the **existing** `DomainMetrics` CDI bean — not a new producer, which would drag Micrometer into every consumer's Arc type closure.
- The shared client takes it as a defaulted constructor arg (`LlmCallMetricsPort.NONE`) so it stays plain-constructible and an un-wired caller is silent rather than broken. The two CDI providers use field injection, because detekt's `LongParameterList` fires *at* `constructorThreshold`, not above it.
- **`usage` is now parsed.** The client discarded the response's `usage` block entirely (`@JsonIgnoreProperties` swallowed it) — which is why token consumption existed only on the provider's invoice. Nullable, so a provider that omits it cannot turn a good completion into a null.
- **`not_configured` is recorded, not silent.** An agent whose key was never seeded returns `null` forever and logs one warning at startup; nothing else anywhere says so.
- **Price book as recording rules**, not a constant in Kotlin: a rate-card change is then a gitops edit that reloads in place. `groq/llama-3.3-70b-versatile` is priced from BerriAI/litellm's own `model_prices_and_context_window.json` ($0.59/M in, $0.79/M out) — fetched, not recalled. DeepInfra publishes no DeepSeek-V3.2 entry there, so its nearest published sibling (V3.1) is used and every rule, alert and panel carries `price_source="nearest-sibling"` — the estimate is labelled in the data, not in a comment.
- **`openbank:llm_tokens_unpriced_24h`** is the check on the check: a model added to the gateway and forgotten in the price book makes every spend figure quietly low, and a plain sum cannot notice.
- Four alerts replace the dead one: `AiFleetDailySpendHigh`, `AiSpendUnpriced`, `AiCallErrorRateHigh` (excludes `not_configured`, a different failure with a different fix) and `AiCallsNotConfigured`. None depends on anything undeployed.
- `dashboard-openbank-ai.yaml`, 12 panels. Its header panel states in the board itself that cost is derived rather than billed, and that the six stub agents appear nowhere — so absence on this board is not evidence an agent is healthy.

## Series added

```
openbank_llm_requests_total{model,outcome}
openbank_llm_tokens_total{model,kind}            # prompt/completion split — priced differently
openbank_llm_call_duration_seconds{model,outcome}
```

Tags are the closed sets `model` and `outcome`/`kind` only — no prompt, user id, or status code.

## Falsification

- **`promtool check rules` initially FAILED.** `openbank:llm_tokens_unpriced_24h` was written `unless on (model) group_left ()`, and Prometheus rejects a grouping modifier on a set operator. Without running it this file would have been a rule group Prometheus silently refuses to load. Fixed; 11 rules SUCCESS.
- The validator was then fed a deliberately broken expression and reported it, so that SUCCESS is a measurement rather than a hope.
- All 13 dashboard PromQL targets extracted and run through promtool: SUCCESS.
- `./gradlew compileKotlin` on all five touched modules: **BUILD SUCCESSFUL**. (The shared `~/.gradle` on this machine has a corrupt instrumented-jar cache that fails `:build-logic:compilePluginsBlocks` on an *unmodified* tree too — verified against a clean worktree — so this ran against an isolated `GRADLE_USER_HOME`.)
- yamllint with `ci.yml`'s own inline config on all three manifests: clean.

## Definition of Done

- [x] Hexagonal layering preserved — the new port is pure domain, the Micrometer implementation stays in `openbank-libs-runtime`.
- [ ] Unit tests added/updated — none in this PR; the change is instrumentation on paths whose existing tests cover behaviour, and the metric contract is asserted by promtool over the rules and dashboard that consume it. Happy to add `DomainMetrics.recordCall` assertions if reviewers prefer.
- [ ] Integration tests — n/a.
- [ ] Contract tests — n/a, no public API change.
- [x] Compiles clean on every touched module.
- [x] No new lint warnings.
- [ ] OpenAPI / Flyway / Avro — n/a.
- [x] Docs updated — the dashboard documents its own limits in-board; the rules files carry the reasoning.

## Security checklist

- [x] No secrets, tokens, passwords, or PII in code, config, tests, logs. Prompts and completions are never recorded — only counts, and the API key handling is untouched.
- [x] No new `@SuppressWarnings` / `@Suppress`.
- [x] No new third-party dependency.
- [x] No auth / crypto / payment code changed.
- [x] No PII path changed. Metric tags are a closed low-cardinality set by construction.
- [x] No cardholder data path changed.

## Compliance impact

- [x] DORA — ICT cost and third-party (LLM provider) monitoring.
- [x] EU AI Act adjacent — per-model call volume and failure rate become evidence rather than assertion.

## Deployment note

`rules.yaml` and the `.rego` policies are untouched, so no OPA bundle restamp. The manifests are synced by the `observability-components` Application (`directory.recurse: true`), so no kustomization registration is needed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
