### PR TITLE
fix(observability): allow dSYM upload through the GlitchTip ingress

### DIFF
--- a/openbank-infra/gitops/apps/glitchtip.yaml
+++ b/openbank-infra/gitops/apps/glitchtip.yaml
@@ -86,9 +86,13 @@ spec:
               # crashes here). The web UI, Django /admin/ (a superuser password login)
               # and the management REST API have no business on the internet — they're
               # reached in-cluster via port-forward (like Grafana, ArgoCD, et al.).
-              # So the public ingress allow-lists ONLY the per-project ingest verbs;
-              # everything else 404s at the edge. Mirrors the keycloak-admin-block pattern.
+              # So the public ingress allow-lists ONLY the per-project ingest verbs
+              # plus the debug-symbol upload endpoints; everything else 404s at the
+              # edge. Mirrors the keycloak-admin-block pattern.
               nginx.ingress.kubernetes.io/use-regex: "true"
+              # Debug-symbol chunks. sentry-cli sends ~8 MiB chunks and the default
+              # 1m body limit turned every dSYM upload into an nginx 413.
+              nginx.ingress.kubernetes.io/proxy-body-size: 64m
             hosts:
               - host: glitchtip.open-bank.tech
                 paths:
@@ -96,6 +100,25 @@ spec:
                   # security/minidump). project_id is numeric; /api/0/* (management) and
                   # every UI/admin path are intentionally NOT matched → edge 404.
                   - path: /api/[0-9]+/(store|envelope|security|minidump|unreal)/
+                    pathType: ImplementationSpecific
+                  # dSYM upload, and ONLY dSYM upload, out of the /api/0/ management
+                  # surface. Without these two paths `fastlane beta`'s
+                  # upload_debug_symbols was dead code: chunk-upload answers its GET
+                  # with an ABSOLUTE public URL, so sentry-cli posts the chunks back
+                  # through this ingress no matter how it was invoked — a port-forward
+                  # cannot work around it. Every iOS crash therefore arrived with
+                  # <redacted> frames.
+                  #
+                  # Both endpoints require a GlitchTip org auth token (scopes
+                  # project:read/write/releases + org:read), so this exposes an
+                  # authenticated write path, not an open one — and nothing else under
+                  # /api/0/ (users, teams, settings, the Django admin) becomes
+                  # reachable. Keep these regexes anchored to `chunk-upload` and
+                  # `files/(difs|dsyms)`; widening them re-opens the management API.
+                  - path: /api/0/organizations/[^/]+/chunk-upload/
+                    pathType: ImplementationSpecific
+                  # …/files/difs/assemble/ shares this prefix, so it matches too.
+                  - path: /api/0/projects/[^/]+/[^/]+/files/(difs|dsyms)/
                     pathType: ImplementationSpecific
             tls:
               - secretName: glitchtip-tls


### PR DESCRIPTION
## Problém

`upload_debug_symbols` ve `fastlane beta` **nikdy nic nenahrál**. Je non-fatal, takže build nespadne — jen tiše neudělá nic. Následek: každý iOS crash dorazí do GlitchTipu s `<redacted>` framy a je nečitelný.

Veřejný GlitchTip ingress (ADR-0056, attack-surface reduction) pouští jen per-project ingest verby:

```
/api/[0-9]+/(store|envelope|security|minidump|unreal)/
```

sentry-cli ale potřebuje dva endpointy pod `/api/0/`, které tam nejsou → 404 / 400 na edge.

**Port-forward to neobejde** (ověřeno): `chunk-upload` odpoví na GET konfigurací s **absolutní veřejnou URL**, takže sentry-cli pošle chunky zpátky přes ingress bez ohledu na to, jak byl spuštěný. A i kdyby cesta seděla, chunky mají ~8 MiB a výchozí `proxy-body-size: 1m` vrátí nginx `413`.

## Řešení

Allow-listuje **přesně dvě** cesty z celého `/api/0/`:

- `/api/0/organizations/[^/]+/chunk-upload/`
- `/api/0/projects/[^/]+/[^/]+/files/(difs|dsyms)/` — `…/files/difs/assemble/` sdílí tenhle prefix, takže se trefí taky

a zvedá `proxy-body-size` na `64m`.

## Bezpečnostní rozvaha

Oba endpointy vyžadují GlitchTip org auth token (scopes `project:read/write/releases` + `org:read`), takže jde o **autentizovanou zapisovací cestu, ne otevřenou**. Nic dalšího pod `/api/0/` (users, teams, settings, Django `/admin/`) se tím nezpřístupňuje — regexy jsou ukotvené na `chunk-upload` a `files/(difs|dsyms)`. Rozšíření těch regexů by management API otevřelo, proto je to napsané i v komentáři u manifestu.

`proxy-body-size` je anotace celého ingressu, takže 64m platí i pro ingest — u envelope uploadů je to neškodné.

## Ověření po merge

`fastlane beta` na dalším buildu; v logu lane musí projít `upload_debug_symbols` bez 413/400 a crash v GlitchTipu musí mít symbolizované framy.

🤖 Generated with [Claude Code](https://claude.com/claude-code)