### PR TITLE
feat(observability): give the ClickHouse warehouse a BI surface

### DIFF
--- a/openbank-infra/gitops/apps/kube-prometheus-stack.yaml
+++ b/openbank-infra/gitops/apps/kube-prometheus-stack.yaml
@@ -251,6 +251,17 @@ spec:
             # (per-service health as colored hexagons). Latest compatible build
             # resolved by Grafana at startup, like the sentry datasource above.
             - grafana-polystat-panel
+            # ClickHouse datasource for the business warehouse (ADR-0022). The
+            # warehouse has been fed in production for months
+            # (ANALYTICS_SINK_TYPE=clickhouse) and carries a gold layer — daily
+            # event volume, the onboarding funnel, screen feedback — whose own DDL
+            # comment says gold marts are "where Metabase/Superset dashboards
+            # point". No BI tool was ever deployed and Grafana had no ClickHouse
+            # datasource, so the only consumer of the whole warehouse was
+            # admin-ui's customer-360 route. Business reporting ran on Prometheus
+            # instead, which is a 7-day-retention TSDB and cannot answer a
+            # question about last quarter.
+            - grafana-clickhouse-datasource
           # GlitchTip API token, injected from the ESO-managed grafana-glitchtip
           # Secret (components/external-secrets/es-grafana-glitchtip.yaml).
           # optional:true → Grafana stays healthy before the token is in Vault;
@@ -260,6 +271,15 @@ spec:
               secretKeyRef:
                 name: grafana-glitchtip
                 key: token
+                optional: true
+            # ClickHouse `analytics` user password, from the ESO-managed
+            # grafana-clickhouse Secret (components/external-secrets/es-grafana-clickhouse.yaml).
+            # Same optional:true trade as above — Grafana boots before the secret
+            # exists, and only the ClickHouse datasource is unable to query.
+            CLICKHOUSE_PASSWORD:
+              secretKeyRef:
+                name: grafana-clickhouse
+                key: password
                 optional: true
           persistence:
             enabled: false
@@ -354,6 +374,26 @@ spec:
                 orgSlug: openbank
               secureJsonData:
                 authToken: $GLITCHTIP_API_TOKEN
+            # Business warehouse (ADR-0022). NOT part of the trace correlation web
+            # above — this is the analytical plane: months of history at daily
+            # grain, answering "how many accounts did we open last quarter", which
+            # Prometheus structurally cannot (7-day retention, ADR-0088 D3) and
+            # which a counter reset by every pod restart cannot either.
+            - name: ClickHouse
+              type: grafana-clickhouse-datasource
+              uid: clickhouse
+              # HTTP protocol on 8123, matching the single port opened by
+              # components/analytics/clickhouse-grafana-network-policy.yaml. The
+              # native protocol on 9000 stays closed.
+              jsonData:
+                host: clickhouse.analytics.svc
+                port: 8123
+                protocol: http
+                secure: false
+                username: analytics
+                defaultDatabase: openbank_analytics
+              secureJsonData:
+                password: $CLICKHOUSE_PASSWORD
         nodeExporter:
           enabled: true
         # Pin node-exporter straight at the ECR pull-through cache rather than letting

--- a/openbank-infra/gitops/components/analytics/clickhouse-grafana-network-policy.yaml
+++ b/openbank-infra/gitops/components/analytics/clickhouse-grafana-network-policy.yaml
@@ -1,0 +1,46 @@
+# SPDX-License-Identifier: Apache-2.0
+# Copyright (c) OpenBank contributors. Licensed under the Apache License, Version 2.0.
+#
+# Grafana (observability) → ClickHouse HTTP (analytics:8123), for the business-warehouse dashboard
+# over the gold marts (ADR-0022).
+#
+# HAND-MAINTAINED, and in its OWN file on purpose. network-policies.yaml in this directory carries
+# `openbank.io/derived: gen-network-policies` and is rewritten wholesale by
+# openbank-infra/scripts/gen-network-policies.py — an edit there is erased by the next regeneration,
+# and the house rule is that derived artifacts are never hand-edited.
+#
+# The generator cannot derive this edge. It reads cross-namespace callers out of Deployment env URLs
+# in openbank-infra/gitops/components/, which is how `campaign` and `admin-ui` earned their entries
+# in the derived allow-list — both declare CLICKHOUSE_URL on their own Deployments. Grafana has no
+# Deployment in components/: it is rendered by the kube-prometheus-stack Helm chart from
+# apps/kube-prometheus-stack.yaml, and its ClickHouse edge is a Grafana *datasource*, a shape the
+# URL scan does not look at. Same reason temporal-network-policies.yaml is hand-maintained.
+#
+# Additive, not a replacement: NetworkPolicies union, so this grants the observability edge without
+# touching what the generator emits. Enforcement is LIVE (VPC CNI standard mode, ADR-0060) — without
+# this policy the datasource fails with a connection timeout that looks exactly like a wrong
+# password.
+#
+# Port 8123 (HTTP) only. The native protocol on 9000 is deliberately NOT opened: the Grafana
+# ClickHouse datasource speaks either, and the smaller hole is the right default.
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: clickhouse-ingress-grafana
+  namespace: analytics
+  labels:
+    app.kubernetes.io/part-of: analytics
+spec:
+  podSelector:
+    matchLabels:
+      app.kubernetes.io/name: clickhouse
+  policyTypes:
+    - Ingress
+  ingress:
+    - from:
+        - namespaceSelector:
+            matchLabels:
+              kubernetes.io/metadata.name: observability
+      ports:
+        - protocol: TCP
+          port: 8123

--- a/openbank-infra/gitops/components/external-secrets/es-grafana-clickhouse.yaml
+++ b/openbank-infra/gitops/components/external-secrets/es-grafana-clickhouse.yaml
@@ -1,0 +1,27 @@
+# Grafana → ClickHouse `analytics` user password, projected from OpenBao (KV mount openbank/,
+# path analytics-sink, field CLICKHOUSE_PASSWORD — the SAME secret analytics-sink, admin-ui and
+# ClickHouse itself use, so there is one credential to rotate rather than four). Lets the Grafana
+# ClickHouse datasource read the gold marts for the business dashboard (ADR-0022). Never committed
+# in plaintext.
+#
+# Grafana lives in `observability`, so this ExternalSecret targets that namespace — mirroring
+# es-admin-ui-clickhouse.yaml, which does the same for `admin-ui`.
+apiVersion: external-secrets.io/v1beta1
+kind: ExternalSecret
+metadata:
+  name: grafana-clickhouse
+  namespace: observability
+spec:
+  refreshInterval: 1h
+  secretStoreRef:
+    name: vault-kv
+    kind: ClusterSecretStore
+  target:
+    name: grafana-clickhouse
+    creationPolicy: Owner
+    deletionPolicy: Retain
+  data:
+    - secretKey: password
+      remoteRef:
+        key: analytics-sink
+        property: CLICKHOUSE_PASSWORD

--- a/openbank-infra/gitops/components/observability/dashboard-openbank-business-warehouse.yaml
+++ b/openbank-infra/gitops/components/observability/dashboard-openbank-business-warehouse.yaml
@@ -1,0 +1,783 @@
+# Business reporting over the ClickHouse warehouse (ADR-0022).
+#
+# The warehouse has been fed in production for months (analytics-sink runs with
+# ANALYTICS_SINK_TYPE=clickhouse) and already carries a gold layer — gold_daily_event_volume, the
+# onboarding funnel marts, screen feedback. Its own DDL comment says gold marts are "where
+# Metabase/Superset dashboards point, so BI never touches the operational databases". No BI tool was
+# ever deployed, Grafana had no ClickHouse datasource, and the sole consumer of the entire warehouse
+# was admin-ui's customer-360 route. Business reporting therefore ran on Prometheus: 7-day
+# retention, counters that reset on every pod restart, and `sum(counter)` panels that double-count
+# across replicas. This board is the missing analytical plane.
+#
+# Requires the grafana-clickhouse-datasource plugin and the ClickHouse datasource in
+# apps/kube-prometheus-stack.yaml, and the observability->analytics:8123 edge in
+# components/analytics/clickhouse-grafana-network-policy.yaml. Without the NetworkPolicy the panels
+# fail with a connection timeout that looks exactly like a wrong password.
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: dashboard-openbank-business-warehouse
+  namespace: observability
+  labels:
+    grafana_dashboard: '1'
+    app.kubernetes.io/part-of: observability
+data:
+  openbank-business-warehouse.json: |
+    {
+      "id": null,
+      "uid": "openbank-business-warehouse",
+      "title": "OpenBank — Business Reporting (warehouse)",
+      "description": "Business volume, product mix and the onboarding funnel from the ClickHouse warehouse (ADR-0022). Daily grain, 90-day windows — the analytical plane, not the 7-day operational one.",
+      "schemaVersion": 39,
+      "version": 1,
+      "refresh": "5m",
+      "time": {
+        "from": "now-90d",
+        "to": "now"
+      },
+      "timepicker": {},
+      "timezone": "browser",
+      "tags": [
+        "openbank",
+        "business",
+        "warehouse"
+      ],
+      "templating": {
+        "list": [
+          {
+            "current": {
+              "selected": false,
+              "text": "ClickHouse",
+              "value": "clickhouse"
+            },
+            "hide": 0,
+            "includeAll": false,
+            "multi": false,
+            "name": "ds_clickhouse",
+            "options": [],
+            "query": "grafana-clickhouse-datasource",
+            "refresh": 1,
+            "type": "datasource",
+            "label": "Warehouse"
+          }
+        ]
+      },
+      "annotations": {
+        "list": []
+      },
+      "links": [],
+      "panels": [
+        {
+          "id": 1,
+          "type": "text",
+          "title": "How to read this board",
+          "gridPos": {
+            "x": 0,
+            "y": 0,
+            "w": 24,
+            "h": 7
+          },
+          "options": {
+            "mode": "markdown",
+            "content": "**This is the analytical plane, not the operational one.** Every panel reads the ClickHouse warehouse (`openbank_analytics`, ADR-0022), fed from the domain event stream by openbank-analytics-sink. The other OpenBank boards read Prometheus, which holds 7 days and whose counters reset on every pod restart — it cannot answer \"how many accounts did we open last quarter\". This board can, because bronze is the append-only log of record kept for 10 years.\n\n**Freshness first.** The top-left tile is the age of the newest event in the warehouse. If it is hours old, every number below it is stale, and a flat line here means the sink stopped rather than that the business did. Nothing alerts on a table that stops growing — check this tile before reading anything else.\n\n**Grain is a day.** All rollups group by `toDate(occurred_at)`, so today's bar is partial until midnight UTC and always reads low. Compare like-for-like days.\n\nCounts are of *events*, not of reconciled balances. For money that has to foot, use the ledger and the statutory close — this board is for volume, mix and trend."
+          }
+        },
+        {
+          "id": 2,
+          "type": "stat",
+          "title": "Warehouse freshness",
+          "description": "Age of the newest event in bronze. Read this before anything else: a stale warehouse makes every panel below wrong in a way that looks like calm.",
+          "gridPos": {
+            "x": 0,
+            "y": 7,
+            "w": 5,
+            "h": 4
+          },
+          "datasource": {
+            "type": "grafana-clickhouse-datasource",
+            "uid": "clickhouse"
+          },
+          "targets": [
+            {
+              "datasource": {
+                "type": "grafana-clickhouse-datasource",
+                "uid": "clickhouse"
+              },
+              "refId": "A",
+              "editorType": "sql",
+              "format": 2,
+              "rawSql": "SELECT dateDiff('second', max(occurred_at), now()) AS value FROM openbank_analytics.bronze_events"
+            }
+          ],
+          "fieldConfig": {
+            "defaults": {
+              "unit": "s",
+              "decimals": 0,
+              "color": {
+                "mode": "thresholds"
+              },
+              "thresholds": {
+                "mode": "absolute",
+                "steps": [
+                  {
+                    "color": "text",
+                    "value": null
+                  }
+                ]
+              }
+            },
+            "overrides": []
+          },
+          "options": {
+            "reduceOptions": {
+              "calcs": [
+                "lastNotNull"
+              ],
+              "fields": "",
+              "values": false
+            },
+            "textMode": "auto",
+            "colorMode": "value",
+            "graphMode": "area"
+          }
+        },
+        {
+          "id": 3,
+          "type": "stat",
+          "title": "Events (30d)",
+          "description": null,
+          "gridPos": {
+            "x": 5,
+            "y": 7,
+            "w": 5,
+            "h": 4
+          },
+          "datasource": {
+            "type": "grafana-clickhouse-datasource",
+            "uid": "clickhouse"
+          },
+          "targets": [
+            {
+              "datasource": {
+                "type": "grafana-clickhouse-datasource",
+                "uid": "clickhouse"
+              },
+              "refId": "A",
+              "editorType": "sql",
+              "format": 2,
+              "rawSql": "SELECT count() AS value FROM openbank_analytics.bronze_events WHERE occurred_at >= now() - INTERVAL 30 DAY"
+            }
+          ],
+          "fieldConfig": {
+            "defaults": {
+              "unit": "short",
+              "decimals": 0,
+              "color": {
+                "mode": "thresholds"
+              },
+              "thresholds": {
+                "mode": "absolute",
+                "steps": [
+                  {
+                    "color": "text",
+                    "value": null
+                  }
+                ]
+              }
+            },
+            "overrides": []
+          },
+          "options": {
+            "reduceOptions": {
+              "calcs": [
+                "lastNotNull"
+              ],
+              "fields": "",
+              "values": false
+            },
+            "textMode": "auto",
+            "colorMode": "value",
+            "graphMode": "area"
+          }
+        },
+        {
+          "id": 4,
+          "type": "stat",
+          "title": "Accounts opened (30d)",
+          "description": "Distinct account aggregates with an opened-type event. uniqExact, not count(): bronze is at-least-once, so duplicates are expected and a raw count overstates.",
+          "gridPos": {
+            "x": 10,
+            "y": 7,
+            "w": 5,
+            "h": 4
+          },
+          "datasource": {
+            "type": "grafana-clickhouse-datasource",
+            "uid": "clickhouse"
+          },
+          "targets": [
+            {
+              "datasource": {
+                "type": "grafana-clickhouse-datasource",
+                "uid": "clickhouse"
+              },
+              "refId": "A",
+              "editorType": "sql",
+              "format": 2,
+              "rawSql": "SELECT uniqExact(aggregate_id) AS value FROM openbank_analytics.bronze_events WHERE aggregate_type = 'Account' AND event_type LIKE '%Opened%' AND occurred_at >= now() - INTERVAL 30 DAY"
+            }
+          ],
+          "fieldConfig": {
+            "defaults": {
+              "unit": "short",
+              "decimals": 0,
+              "color": {
+                "mode": "thresholds"
+              },
+              "thresholds": {
+                "mode": "absolute",
+                "steps": [
+                  {
+                    "color": "text",
+                    "value": null
+                  }
+                ]
+              }
+            },
+            "overrides": []
+          },
+          "options": {
+            "reduceOptions": {
+              "calcs": [
+                "lastNotNull"
+              ],
+              "fields": "",
+              "values": false
+            },
+            "textMode": "auto",
+            "colorMode": "value",
+            "graphMode": "area"
+          }
+        },
+        {
+          "id": 5,
+          "type": "stat",
+          "title": "Parties onboarded (30d)",
+          "description": null,
+          "gridPos": {
+            "x": 15,
+            "y": 7,
+            "w": 4,
+            "h": 4
+          },
+          "datasource": {
+            "type": "grafana-clickhouse-datasource",
+            "uid": "clickhouse"
+          },
+          "targets": [
+            {
+              "datasource": {
+                "type": "grafana-clickhouse-datasource",
+                "uid": "clickhouse"
+              },
+              "refId": "A",
+              "editorType": "sql",
+              "format": 2,
+              "rawSql": "SELECT uniqExact(aggregate_id) AS value FROM openbank_analytics.bronze_events WHERE aggregate_type = 'Party' AND occurred_at >= now() - INTERVAL 30 DAY"
+            }
+          ],
+          "fieldConfig": {
+            "defaults": {
+              "unit": "short",
+              "decimals": 0,
+              "color": {
+                "mode": "thresholds"
+              },
+              "thresholds": {
+                "mode": "absolute",
+                "steps": [
+                  {
+                    "color": "text",
+                    "value": null
+                  }
+                ]
+              }
+            },
+            "overrides": []
+          },
+          "options": {
+            "reduceOptions": {
+              "calcs": [
+                "lastNotNull"
+              ],
+              "fields": "",
+              "values": false
+            },
+            "textMode": "auto",
+            "colorMode": "value",
+            "graphMode": "area"
+          }
+        },
+        {
+          "id": 6,
+          "type": "stat",
+          "title": "Onboarding sessions (30d)",
+          "description": null,
+          "gridPos": {
+            "x": 19,
+            "y": 7,
+            "w": 5,
+            "h": 4
+          },
+          "datasource": {
+            "type": "grafana-clickhouse-datasource",
+            "uid": "clickhouse"
+          },
+          "targets": [
+            {
+              "datasource": {
+                "type": "grafana-clickhouse-datasource",
+                "uid": "clickhouse"
+              },
+              "refId": "A",
+              "editorType": "sql",
+              "format": 2,
+              "rawSql": "SELECT uniqExact(session_id) AS value FROM openbank_analytics.gold_onboarding_funnel_events WHERE day >= today() - 30"
+            }
+          ],
+          "fieldConfig": {
+            "defaults": {
+              "unit": "short",
+              "decimals": 0,
+              "color": {
+                "mode": "thresholds"
+              },
+              "thresholds": {
+                "mode": "absolute",
+                "steps": [
+                  {
+                    "color": "text",
+                    "value": null
+                  }
+                ]
+              }
+            },
+            "overrides": []
+          },
+          "options": {
+            "reduceOptions": {
+              "calcs": [
+                "lastNotNull"
+              ],
+              "fields": "",
+              "values": false
+            },
+            "textMode": "auto",
+            "colorMode": "value",
+            "graphMode": "area"
+          }
+        },
+        {
+          "id": 7,
+          "type": "timeseries",
+          "title": "Daily event volume by service",
+          "gridPos": {
+            "x": 0,
+            "y": 11,
+            "w": 12,
+            "h": 8
+          },
+          "datasource": {
+            "type": "grafana-clickhouse-datasource",
+            "uid": "clickhouse"
+          },
+          "targets": [
+            {
+              "datasource": {
+                "type": "grafana-clickhouse-datasource",
+                "uid": "clickhouse"
+              },
+              "refId": "A",
+              "editorType": "sql",
+              "format": 1,
+              "rawSql": "SELECT day AS time, source_service, sum(events) AS events FROM openbank_analytics.gold_daily_event_volume WHERE day >= today() - 90 GROUP BY day, source_service ORDER BY day"
+            }
+          ],
+          "fieldConfig": {
+            "defaults": {
+              "unit": "short",
+              "color": {
+                "mode": "palette-classic"
+              },
+              "custom": {
+                "lineWidth": 1,
+                "fillOpacity": 10,
+                "spanNulls": false
+              }
+            },
+            "overrides": []
+          },
+          "options": {
+            "legend": {
+              "displayMode": "list",
+              "placement": "bottom"
+            },
+            "tooltip": {
+              "mode": "multi"
+            }
+          },
+          "description": "From the gold_daily_event_volume mart. 90 days — the window Prometheus cannot offer."
+        },
+        {
+          "id": 8,
+          "type": "timeseries",
+          "title": "Business volume by aggregate type",
+          "gridPos": {
+            "x": 12,
+            "y": 11,
+            "w": 12,
+            "h": 8
+          },
+          "datasource": {
+            "type": "grafana-clickhouse-datasource",
+            "uid": "clickhouse"
+          },
+          "targets": [
+            {
+              "datasource": {
+                "type": "grafana-clickhouse-datasource",
+                "uid": "clickhouse"
+              },
+              "refId": "A",
+              "editorType": "sql",
+              "format": 1,
+              "rawSql": "SELECT day AS time, aggregate_type, sum(events) AS events FROM openbank_analytics.gold_daily_event_volume WHERE day >= today() - 90 GROUP BY day, aggregate_type ORDER BY day"
+            }
+          ],
+          "fieldConfig": {
+            "defaults": {
+              "unit": "short",
+              "color": {
+                "mode": "palette-classic"
+              },
+              "custom": {
+                "lineWidth": 1,
+                "fillOpacity": 10,
+                "spanNulls": false
+              }
+            },
+            "overrides": []
+          },
+          "options": {
+            "legend": {
+              "displayMode": "list",
+              "placement": "bottom"
+            },
+            "tooltip": {
+              "mode": "multi"
+            }
+          },
+          "description": "Product mix over time: which parts of the bank are actually being used."
+        },
+        {
+          "id": 9,
+          "type": "barchart",
+          "title": "Onboarding funnel — sessions by step (30d)",
+          "gridPos": {
+            "x": 0,
+            "y": 19,
+            "w": 12,
+            "h": 8
+          },
+          "datasource": {
+            "type": "grafana-clickhouse-datasource",
+            "uid": "clickhouse"
+          },
+          "targets": [
+            {
+              "datasource": {
+                "type": "grafana-clickhouse-datasource",
+                "uid": "clickhouse"
+              },
+              "refId": "A",
+              "editorType": "sql",
+              "format": 1,
+              "rawSql": "SELECT step, sum(sessions_viewed) AS viewed, sum(sessions_completed) AS completed FROM openbank_analytics.gold_onboarding_funnel_daily WHERE day >= today() - 30 GROUP BY step, step_ordinal ORDER BY step_ordinal"
+            }
+          ],
+          "fieldConfig": {
+            "defaults": {
+              "unit": "short",
+              "color": {
+                "mode": "palette-classic"
+              },
+              "custom": {
+                "lineWidth": 1,
+                "fillOpacity": 10,
+                "spanNulls": false
+              }
+            },
+            "overrides": []
+          },
+          "options": {
+            "legend": {
+              "displayMode": "list",
+              "placement": "bottom"
+            },
+            "tooltip": {
+              "mode": "multi"
+            }
+          },
+          "description": "Viewed vs completed per step. The drop between the two bars is where prospects leave."
+        },
+        {
+          "id": 10,
+          "type": "timeseries",
+          "title": "Framework-agreement signing outcomes",
+          "gridPos": {
+            "x": 12,
+            "y": 19,
+            "w": 12,
+            "h": 8
+          },
+          "datasource": {
+            "type": "grafana-clickhouse-datasource",
+            "uid": "clickhouse"
+          },
+          "targets": [
+            {
+              "datasource": {
+                "type": "grafana-clickhouse-datasource",
+                "uid": "clickhouse"
+              },
+              "refId": "A",
+              "editorType": "sql",
+              "format": 1,
+              "rawSql": "SELECT day AS time, sum(attempts) AS attempts, sum(successes) AS successes, sum(failures) AS failures FROM openbank_analytics.gold_onboarding_sign_outcomes WHERE day >= today() - 90 GROUP BY day ORDER BY day"
+            }
+          ],
+          "fieldConfig": {
+            "defaults": {
+              "unit": "short",
+              "color": {
+                "mode": "palette-classic"
+              },
+              "custom": {
+                "lineWidth": 1,
+                "fillOpacity": 10,
+                "spanNulls": false
+              }
+            },
+            "overrides": []
+          },
+          "options": {
+            "legend": {
+              "displayMode": "list",
+              "placement": "bottom"
+            },
+            "tooltip": {
+              "mode": "multi"
+            }
+          },
+          "description": "The revenue-bearing tail of onboarding: a failed signature is a lost customer."
+        },
+        {
+          "id": 11,
+          "type": "table",
+          "title": "Top signing failure reasons (30d)",
+          "gridPos": {
+            "x": 0,
+            "y": 27,
+            "w": 12,
+            "h": 7
+          },
+          "datasource": {
+            "type": "grafana-clickhouse-datasource",
+            "uid": "clickhouse"
+          },
+          "targets": [
+            {
+              "datasource": {
+                "type": "grafana-clickhouse-datasource",
+                "uid": "clickhouse"
+              },
+              "refId": "A",
+              "editorType": "sql",
+              "format": 2,
+              "rawSql": "SELECT reason, sum(failures) AS failures FROM openbank_analytics.gold_onboarding_sign_fail_reasons WHERE day >= today() - 30 GROUP BY reason ORDER BY failures DESC LIMIT 20"
+            }
+          ],
+          "fieldConfig": {
+            "defaults": {
+              "unit": "short",
+              "color": {
+                "mode": "palette-classic"
+              },
+              "custom": {
+                "lineWidth": 1,
+                "fillOpacity": 10,
+                "spanNulls": false
+              }
+            },
+            "overrides": []
+          },
+          "options": {
+            "showHeader": true
+          },
+          "description": "Ranked machine reasons. Empty is the healthy state."
+        },
+        {
+          "id": 12,
+          "type": "piechart",
+          "title": "KYC method mix (30d)",
+          "gridPos": {
+            "x": 12,
+            "y": 27,
+            "w": 12,
+            "h": 7
+          },
+          "datasource": {
+            "type": "grafana-clickhouse-datasource",
+            "uid": "clickhouse"
+          },
+          "targets": [
+            {
+              "datasource": {
+                "type": "grafana-clickhouse-datasource",
+                "uid": "clickhouse"
+              },
+              "refId": "A",
+              "editorType": "sql",
+              "format": 1,
+              "rawSql": "SELECT kyc_method, sum(sessions) AS sessions FROM openbank_analytics.gold_onboarding_kyc_method_daily WHERE day >= today() - 30 GROUP BY kyc_method ORDER BY sessions DESC"
+            }
+          ],
+          "fieldConfig": {
+            "defaults": {
+              "unit": "short",
+              "color": {
+                "mode": "palette-classic"
+              },
+              "custom": {
+                "lineWidth": 1,
+                "fillOpacity": 10,
+                "spanNulls": false
+              }
+            },
+            "overrides": []
+          },
+          "options": {
+            "legend": {
+              "displayMode": "list",
+              "placement": "bottom"
+            },
+            "tooltip": {
+              "mode": "multi"
+            }
+          },
+          "description": "Which identity path prospects choose."
+        },
+        {
+          "id": 13,
+          "type": "barchart",
+          "title": "Median seconds on step (30d)",
+          "gridPos": {
+            "x": 0,
+            "y": 34,
+            "w": 12,
+            "h": 7
+          },
+          "datasource": {
+            "type": "grafana-clickhouse-datasource",
+            "uid": "clickhouse"
+          },
+          "targets": [
+            {
+              "datasource": {
+                "type": "grafana-clickhouse-datasource",
+                "uid": "clickhouse"
+              },
+              "refId": "A",
+              "editorType": "sql",
+              "format": 1,
+              "rawSql": "SELECT step, quantile(0.5)(seconds_on_step) AS median_seconds FROM openbank_analytics.gold_onboarding_step_durations WHERE day >= today() - 30 GROUP BY step ORDER BY median_seconds DESC"
+            }
+          ],
+          "fieldConfig": {
+            "defaults": {
+              "unit": "s",
+              "color": {
+                "mode": "palette-classic"
+              },
+              "custom": {
+                "lineWidth": 1,
+                "fillOpacity": 10,
+                "spanNulls": false
+              }
+            },
+            "overrides": []
+          },
+          "options": {
+            "legend": {
+              "displayMode": "list",
+              "placement": "bottom"
+            },
+            "tooltip": {
+              "mode": "multi"
+            }
+          },
+          "description": "Where the flow is slow, as opposed to where it leaks."
+        },
+        {
+          "id": 14,
+          "type": "timeseries",
+          "title": "Ingest health — dead-lettered events (30d)",
+          "gridPos": {
+            "x": 12,
+            "y": 34,
+            "w": 12,
+            "h": 7
+          },
+          "datasource": {
+            "type": "grafana-clickhouse-datasource",
+            "uid": "clickhouse"
+          },
+          "targets": [
+            {
+              "datasource": {
+                "type": "grafana-clickhouse-datasource",
+                "uid": "clickhouse"
+              },
+              "refId": "A",
+              "editorType": "sql",
+              "format": 1,
+              "rawSql": "SELECT toDate(failed_at) AS time, count() AS dead_lettered FROM openbank_analytics.dead_letter_events WHERE failed_at >= now() - INTERVAL 30 DAY GROUP BY time ORDER BY time"
+            }
+          ],
+          "fieldConfig": {
+            "defaults": {
+              "unit": "short",
+              "color": {
+                "mode": "palette-classic"
+              },
+              "custom": {
+                "lineWidth": 1,
+                "fillOpacity": 10,
+                "spanNulls": false
+              }
+            },
+            "overrides": []
+          },
+          "options": {
+            "legend": {
+              "displayMode": "list",
+              "placement": "bottom"
+            },
+            "tooltip": {
+              "mode": "multi"
+            }
+          },
+          "description": "Events the sink could not project. Non-zero means this board is missing data — the numbers above are a floor, not a total."
+        }
+      ]
+    }

--- a/openbank-infra/gitops/components/observability/dashboard-openbank-business.yaml
+++ b/openbank-infra/gitops/components/observability/dashboard-openbank-business.yaml
@@ -14,7 +14,10 @@ data:
       "schemaVersion": 39,
       "version": 1,
       "refresh": "30s",
-      "time": { "from": "now-1h", "to": "now" },
+      "time": {
+        "from": "now-1h",
+        "to": "now"
+      },
       "timepicker": {},
       "templating": {
         "list": [
@@ -33,25 +36,42 @@ data:
       "panels": [
         {
           "id": 1,
-          "title": "Accounts Created (cumulative)",
+          "title": "Accounts Created (selected range)",
           "type": "stat",
-          "gridPos": { "x": 0, "y": 0, "w": 4, "h": 4 },
-          "datasource": { "type": "prometheus", "uid": "${datasource}" },
+          "gridPos": {
+            "x": 0,
+            "y": 0,
+            "w": 4,
+            "h": 4
+          },
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${datasource}"
+          },
           "fieldConfig": {
             "defaults": {
               "unit": "short",
-              "color": { "mode": "thresholds" },
+              "color": {
+                "mode": "thresholds"
+              },
               "thresholds": {
                 "mode": "absolute",
                 "steps": [
-                  { "color": "blue", "value": null }
+                  {
+                    "color": "blue",
+                    "value": null
+                  }
                 ]
               }
             },
             "overrides": []
           },
           "options": {
-            "reduceOptions": { "calcs": ["lastNotNull"] },
+            "reduceOptions": {
+              "calcs": [
+                "lastNotNull"
+              ]
+            },
             "orientation": "auto",
             "textMode": "auto",
             "colorMode": "background",
@@ -59,34 +79,52 @@ data:
           },
           "targets": [
             {
-              "expr": "sum(openbank_accounts_created_total)",
+              "expr": "sum(increase(openbank_accounts_created_total[$__range]))",
               "legendFormat": "Accounts",
               "refId": "A",
               "instant": true
             }
-          ]
+          ],
+          "description": "Accounts opened within the dashboard's selected time range. NOT a lifetime total — Prometheus keeps 7 days and counters reset on pod restart. For real historical totals use the Business Reporting (warehouse) board, which reads ClickHouse."
         },
         {
           "id": 2,
           "title": "Parties Created",
           "type": "stat",
-          "gridPos": { "x": 4, "y": 0, "w": 4, "h": 4 },
-          "datasource": { "type": "prometheus", "uid": "${datasource}" },
+          "gridPos": {
+            "x": 4,
+            "y": 0,
+            "w": 4,
+            "h": 4
+          },
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${datasource}"
+          },
           "fieldConfig": {
             "defaults": {
               "unit": "short",
-              "color": { "mode": "thresholds" },
+              "color": {
+                "mode": "thresholds"
+              },
               "thresholds": {
                 "mode": "absolute",
                 "steps": [
-                  { "color": "blue", "value": null }
+                  {
+                    "color": "blue",
+                    "value": null
+                  }
                 ]
               }
             },
             "overrides": []
           },
           "options": {
-            "reduceOptions": { "calcs": ["lastNotNull"] },
+            "reduceOptions": {
+              "calcs": [
+                "lastNotNull"
+              ]
+            },
             "orientation": "auto",
             "textMode": "auto",
             "colorMode": "background",
@@ -94,7 +132,7 @@ data:
           },
           "targets": [
             {
-              "expr": "sum(openbank_parties_created_total)",
+              "expr": "sum(increase(openbank_parties_created_total[$__range]))",
               "legendFormat": "Parties Created",
               "refId": "A",
               "instant": true
@@ -105,23 +143,40 @@ data:
           "id": 3,
           "title": "Parties Verified",
           "type": "stat",
-          "gridPos": { "x": 8, "y": 0, "w": 4, "h": 4 },
-          "datasource": { "type": "prometheus", "uid": "${datasource}" },
+          "gridPos": {
+            "x": 8,
+            "y": 0,
+            "w": 4,
+            "h": 4
+          },
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${datasource}"
+          },
           "fieldConfig": {
             "defaults": {
               "unit": "short",
-              "color": { "mode": "thresholds" },
+              "color": {
+                "mode": "thresholds"
+              },
               "thresholds": {
                 "mode": "absolute",
                 "steps": [
-                  { "color": "green", "value": null }
+                  {
+                    "color": "green",
+                    "value": null
+                  }
                 ]
               }
             },
             "overrides": []
           },
           "options": {
-            "reduceOptions": { "calcs": ["lastNotNull"] },
+            "reduceOptions": {
+              "calcs": [
+                "lastNotNull"
+              ]
+            },
             "orientation": "auto",
             "textMode": "auto",
             "colorMode": "background",
@@ -129,7 +184,7 @@ data:
           },
           "targets": [
             {
-              "expr": "sum(openbank_parties_verified_total)",
+              "expr": "sum(increase(openbank_parties_verified_total[$__range]))",
               "legendFormat": "Parties Verified",
               "refId": "A",
               "instant": true
@@ -140,64 +195,103 @@ data:
           "id": 4,
           "title": "Party Creation vs Verification Trend",
           "type": "timeseries",
-          "gridPos": { "x": 12, "y": 0, "w": 12, "h": 8 },
-          "datasource": { "type": "prometheus", "uid": "${datasource}" },
+          "gridPos": {
+            "x": 12,
+            "y": 0,
+            "w": 12,
+            "h": 8
+          },
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${datasource}"
+          },
           "fieldConfig": {
             "defaults": {
               "unit": "short",
-              "custom": { "lineWidth": 1, "fillOpacity": 10 }
-            },
-            "overrides": []
-          },
-          "options": {
-            "legend": { "displayMode": "table", "placement": "bottom", "calcs": ["lastNotNull"] },
-            "tooltip": { "mode": "multi" }
-          },
-          "targets": [
-            {
-              "expr": "sum(openbank_parties_created_total)",
-              "legendFormat": "created",
-              "refId": "A"
-            },
-            {
-              "expr": "sum(openbank_parties_verified_total)",
-              "legendFormat": "verified",
-              "refId": "B"
-            }
-          ]
-        },
-        {
-          "id": 5,
-          "title": "KYC Funnel: Submitted vs Verdicts",
-          "type": "bargauge",
-          "gridPos": { "x": 0, "y": 8, "w": 12, "h": 8 },
-          "datasource": { "type": "prometheus", "uid": "${datasource}" },
-          "fieldConfig": {
-            "defaults": {
-              "unit": "short",
-              "color": { "mode": "palette-classic" },
-              "thresholds": {
-                "mode": "absolute",
-                "steps": [{ "color": "blue", "value": null }]
+              "custom": {
+                "lineWidth": 1,
+                "fillOpacity": 10
               }
             },
             "overrides": []
           },
           "options": {
-            "reduceOptions": { "calcs": ["lastNotNull"] },
+            "legend": {
+              "displayMode": "table",
+              "placement": "bottom",
+              "calcs": [
+                "lastNotNull"
+              ]
+            },
+            "tooltip": {
+              "mode": "multi"
+            }
+          },
+          "targets": [
+            {
+              "expr": "sum(increase(openbank_parties_created_total[$__range]))",
+              "legendFormat": "created",
+              "refId": "A"
+            },
+            {
+              "expr": "sum(increase(openbank_parties_verified_total[$__range]))",
+              "legendFormat": "verified",
+              "refId": "B"
+            }
+          ],
+          "description": "Rate of party creation vs verification. Plotted as increase() over the dashboard range, not the raw counter: a Micrometer counter resets on pod restart and is per-replica, so the raw form drew a staircase that fell to zero on every deploy."
+        },
+        {
+          "id": 5,
+          "title": "KYC Funnel: Submitted vs Verdicts",
+          "type": "bargauge",
+          "gridPos": {
+            "x": 0,
+            "y": 8,
+            "w": 12,
+            "h": 8
+          },
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${datasource}"
+          },
+          "fieldConfig": {
+            "defaults": {
+              "unit": "short",
+              "color": {
+                "mode": "palette-classic"
+              },
+              "thresholds": {
+                "mode": "absolute",
+                "steps": [
+                  {
+                    "color": "blue",
+                    "value": null
+                  }
+                ]
+              }
+            },
+            "overrides": []
+          },
+          "options": {
+            "reduceOptions": {
+              "calcs": [
+                "lastNotNull"
+              ]
+            },
             "orientation": "horizontal",
             "displayMode": "gradient",
             "text": {}
           },
           "targets": [
             {
-              "expr": "sum(openbank_kyc_submissions_total)",
+              "expr": "sum(increase(openbank_kyc_submissions_total[$__range]))",
               "legendFormat": "submitted",
               "refId": "A",
               "instant": true
             },
             {
-              "expr": "sum by (outcome) (openbank_kyc_verdicts_total)",
+              "expr": "sum by (outcome) (increase(openbank_kyc_verdicts_total[$__range]))",
               "legendFormat": "verdict={{outcome}}",
               "refId": "B",
               "instant": true
@@ -208,34 +302,53 @@ data:
           "id": 6,
           "title": "SCA Challenges: Issued vs Resolved by Outcome",
           "type": "bargauge",
-          "gridPos": { "x": 12, "y": 8, "w": 12, "h": 8 },
-          "datasource": { "type": "prometheus", "uid": "${datasource}" },
+          "gridPos": {
+            "x": 12,
+            "y": 8,
+            "w": 12,
+            "h": 8
+          },
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${datasource}"
+          },
           "fieldConfig": {
             "defaults": {
               "unit": "short",
-              "color": { "mode": "palette-classic" },
+              "color": {
+                "mode": "palette-classic"
+              },
               "thresholds": {
                 "mode": "absolute",
-                "steps": [{ "color": "blue", "value": null }]
+                "steps": [
+                  {
+                    "color": "blue",
+                    "value": null
+                  }
+                ]
               }
             },
             "overrides": []
           },
           "options": {
-            "reduceOptions": { "calcs": ["lastNotNull"] },
+            "reduceOptions": {
+              "calcs": [
+                "lastNotNull"
+              ]
+            },
             "orientation": "horizontal",
             "displayMode": "gradient",
             "text": {}
           },
           "targets": [
             {
-              "expr": "sum(openbank_sca_challenges_total)",
+              "expr": "sum(increase(openbank_sca_challenges_total[$__range]))",
               "legendFormat": "issued",
               "refId": "A",
               "instant": true
             },
             {
-              "expr": "sum by (outcome) (openbank_sca_completions_total)",
+              "expr": "sum by (outcome) (increase(openbank_sca_completions_total[$__range]))",
               "legendFormat": "resolved outcome={{outcome}}",
               "refId": "B",
               "instant": true
@@ -246,18 +359,38 @@ data:
           "id": 7,
           "title": "Ledger Postings Rate by Type",
           "type": "timeseries",
-          "gridPos": { "x": 0, "y": 16, "w": 12, "h": 8 },
-          "datasource": { "type": "prometheus", "uid": "${datasource}" },
+          "gridPos": {
+            "x": 0,
+            "y": 16,
+            "w": 12,
+            "h": 8
+          },
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${datasource}"
+          },
           "fieldConfig": {
             "defaults": {
               "unit": "reqps",
-              "custom": { "lineWidth": 1, "fillOpacity": 10 }
+              "custom": {
+                "lineWidth": 1,
+                "fillOpacity": 10
+              }
             },
             "overrides": []
           },
           "options": {
-            "legend": { "displayMode": "table", "placement": "bottom", "calcs": ["lastNotNull", "mean"] },
-            "tooltip": { "mode": "multi" }
+            "legend": {
+              "displayMode": "table",
+              "placement": "bottom",
+              "calcs": [
+                "lastNotNull",
+                "mean"
+              ]
+            },
+            "tooltip": {
+              "mode": "multi"
+            }
           },
           "targets": [
             {
@@ -271,31 +404,69 @@ data:
           "id": 8,
           "title": "Sanctions Screening Activity",
           "type": "timeseries",
-          "gridPos": { "x": 12, "y": 16, "w": 12, "h": 8 },
-          "datasource": { "type": "prometheus", "uid": "${datasource}" },
+          "gridPos": {
+            "x": 12,
+            "y": 16,
+            "w": 12,
+            "h": 8
+          },
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${datasource}"
+          },
           "fieldConfig": {
             "defaults": {
               "unit": "reqps",
-              "custom": { "lineWidth": 1, "fillOpacity": 10 }
+              "custom": {
+                "lineWidth": 1,
+                "fillOpacity": 10
+              }
             },
             "overrides": [
               {
-                "matcher": { "id": "byName", "options": "hits" },
+                "matcher": {
+                  "id": "byName",
+                  "options": "hits"
+                },
                 "properties": [
-                  { "id": "color", "value": { "fixedColor": "red", "mode": "fixed" } }
+                  {
+                    "id": "color",
+                    "value": {
+                      "fixedColor": "red",
+                      "mode": "fixed"
+                    }
+                  }
                 ]
               },
               {
-                "matcher": { "id": "byName", "options": "screenings" },
+                "matcher": {
+                  "id": "byName",
+                  "options": "screenings"
+                },
                 "properties": [
-                  { "id": "color", "value": { "fixedColor": "blue", "mode": "fixed" } }
+                  {
+                    "id": "color",
+                    "value": {
+                      "fixedColor": "blue",
+                      "mode": "fixed"
+                    }
+                  }
                 ]
               }
             ]
           },
           "options": {
-            "legend": { "displayMode": "table", "placement": "bottom", "calcs": ["lastNotNull", "mean"] },
-            "tooltip": { "mode": "multi" }
+            "legend": {
+              "displayMode": "table",
+              "placement": "bottom",
+              "calcs": [
+                "lastNotNull",
+                "mean"
+              ]
+            },
+            "tooltip": {
+              "mode": "multi"
+            }
           },
           "targets": [
             {


### PR DESCRIPTION
## Summary

The ClickHouse warehouse has been fed in production for months and nothing read it. This gives it a BI surface — a Grafana ClickHouse datasource, the network edge it needs, and a 14-panel business board over the gold marts that already existed — and fixes the existing business dashboard, whose "cumulative" totals were `sum(counter)`.

## Type of change

- [x] feat (new functionality)
- [x] fix (bug fix) — the `sum(counter)` panels, second commit

## Linked issues

Closes #3047
Refs ADR-0022, ADR-0060, ADR-0081

## The gap

`analytics-sink` runs with `ANALYTICS_SINK_TYPE=clickhouse`, so bronze has been filling for months, and the schema already carries a gold layer whose own DDL comment says gold marts are "where Metabase/Superset dashboards point, so BI never touches the operational databases". No BI tool was ever deployed, Grafana had no ClickHouse datasource, and the sole consumer of the entire warehouse was admin-ui's customer-360 route.

So business reporting ran on Prometheus: 7-day retention, counters that reset on every pod restart. It cannot answer "how many accounts did we open last quarter" no matter how the query is written.

## Changes

**Commit 1 — the BI surface**

- `grafana-clickhouse-datasource` plugin + a ClickHouse datasource in the kube-prometheus-stack values. Password from a new ESO `ExternalSecret` projecting the **same** OpenBao field (`analytics-sink/CLICKHOUSE_PASSWORD`) that analytics-sink, admin-ui and ClickHouse itself use — one credential to rotate rather than four. `optional: true`, matching the GlitchTip token: Grafana boots before the secret exists and only this datasource cannot query.
- A hand-maintained NetworkPolicy for `observability -> analytics:8123`, **in its own file**. `components/analytics/network-policies.yaml` carries `openbank.io/derived: gen-network-policies` and is rewritten wholesale, so an edit there is erased on the next run. The generator cannot derive this edge either — it reads cross-namespace callers out of Deployment env URLs under `components/` (which is how campaign and admin-ui earned their entries), and Grafana has no Deployment there: it is rendered by the Helm chart, and its ClickHouse edge is a *datasource*, a shape the URL scan does not look at. Same reason `temporal-network-policies.yaml` is hand-maintained. NetworkPolicies union, so this is additive; `gen-network-policies.py` re-run afterwards produces no diff. Port 8123 (HTTP) only — the native protocol on 9000 stays closed.
- `dashboard-openbank-business-warehouse.yaml`: 14 panels, daily grain, 90-day windows.

**Commit 2 — the counter fix**

`sum(openbank_accounts_created_total)` and eight siblings rewritten as `sum(increase(...[$__range]))`, and the tile retitled from "(cumulative)" to "(selected range)". A counter resets on pod restart and is per-replica, so those numbers dropped on every deploy and inflated on scale-out; "cumulative" was the part that made them convincing. The party trend panel plotted the raw counter and drew a staircase that fell to zero each release.

## Two panels that exist to keep the rest honest

- **Warehouse freshness** is the first tile: age of the newest bronze row. A stale sink makes every number below it wrong in a way that looks like calm, and *nothing alerts on a table that stops growing* — the exact blind spot that hid a dead ČNB feed for the life of fx-service.
- **Dead-lettered events** is the last: events the sink could not project make every count above it a floor, not a total.

The board's header panel says both, in the board.

## Counting discipline

`uniqExact(aggregate_id)`, never `count()`. Bronze is at-least-once by design and tolerates duplicates, so a raw count overstates. Verified on data, not by reading the DDL: seeded three rows with one duplicated aggregate, panel returns **2**.

## Falsification — the queries were run, not eyeballed

There is no promtool-equivalent gate for ClickHouse in this repo, and a dashboard SQL error is invisible until a human opens the panel. So:

- Started ClickHouse 24.8 in Docker, applied all three of the repo's own init SQL files (20 objects created), and executed **all 13** dashboard queries against the real schema: **13/13 pass**.
- Falsified the check itself: a query naming a nonexistent column is rejected (`UNKNOWN_IDENTIFIER`). The 13 passes are therefore a measurement.
- Helm `valuesObject` re-parsed after editing: 3 plugins, 2 `envValueFrom` keys, 5 datasources, ClickHouse `jsonData` as intended.
- All 12 queries on the edited business dashboard re-validated with promtool (`$__range` substituted for a literal window): SUCCESS.
- yamllint with `ci.yml`'s own inline config on all five manifests: clean.

## Definition of Done

- [x] Hexagonal layering preserved (no application code touched).
- [ ] Unit / integration / contract tests — n/a, this is gitops and dashboards; the executable check is the ClickHouse run above.
- [ ] `./gradlew ...` — n/a, no Kotlin or Gradle change.
- [x] No new lint warnings.
- [ ] OpenAPI / Flyway / Avro — n/a.
- [x] Docs updated — both boards document their own limits in-board rather than in a comment.

## Security checklist

- [x] No secrets, tokens, passwords, or PII in code, config, tests, logs — the ClickHouse password is an ESO reference, never a literal.
- [x] No new `@SuppressWarnings` / `@Suppress`.
- [x] New third-party component: the `grafana-clickhouse-datasource` plugin, official Grafana Labs, resolved at Grafana startup exactly like the existing `grafana-sentry-datasource` and `grafana-polystat-panel`.
- [x] No auth / crypto / payment code changed.
- [ ] **PII path — reviewer attention.** No new PII is exposed: the sink masks PII before it reaches bronze, the datasource authenticates as the existing read `analytics` user, and Grafana access is already Keycloak-SSO'd with role mapping. But this does put warehouse data in front of every Grafana Viewer, so the role model deserves a second pair of eyes.
- [x] No cardholder data path changed.

## Compliance impact

- [x] GDPR — see the PII note above; no new personal data reaches the board, the panels are aggregates.
- [x] DORA — business-service monitoring gains an analytical plane with real retention.

## Deployment note

`rules.yaml` and the `.rego` policies are untouched, so no OPA bundle restamp. The dashboards are synced by the `observability-components` Application (`directory.recurse: true`). Grafana rolls to pick up the plugin and the new env var.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
