### PR TITLE
fix(money-path): a null JSON body returned 500 on 12 handlers (#3038)

### DIFF
--- a/openbank-balance-service/src/main/kotlin/com/openbank/balance/infrastructure/rest/BalanceResource.kt
+++ b/openbank-balance-service/src/main/kotlin/com/openbank/balance/infrastructure/rest/BalanceResource.kt
@@ -101,7 +101,11 @@ class BalanceResource(private val svc: BalanceUseCase, private val accountClient
     @Path("/{accountId}/holds")
     @RolesAllowed(Roles.API, Roles.OPERATOR, Roles.ADMIN)
     @Authorize(action = "balance.hold", resource = "#accountId")
-    suspend fun placeHold(@PathParam("accountId") accountId: UUID, body: PlaceHoldRequest): Response {
+    suspend fun placeHold(@PathParam("accountId") accountId: UUID, body: PlaceHoldRequest?): Response {
+        // A JSON `null` body deserialises to null despite the non-nullable Kotlin type, so the
+        // first field access threw NPE and this answered 500 (#3038). libs-runtime maps
+        // IllegalArgumentException to 400.
+        requireNotNull(body) { "request body is required" }
         val hold = svc.placeHold(
             PlaceHoldCommand(accountId, body.amount, body.currency, body.reason, body.referenceId, body.ttlSeconds),
         )
@@ -119,21 +123,37 @@ class BalanceResource(private val svc: BalanceUseCase, private val accountClient
     @Path("/{accountId}/credit")
     @RolesAllowed(Roles.API, Roles.OPERATOR, Roles.ADMIN)
     @Authorize(action = "balance.credit", resource = "#accountId")
-    suspend fun credit(@PathParam("accountId") accountId: UUID, body: BalanceOperationRequest): Response =
-        Response.ok(svc.credit(CreditAccountCommand(accountId, body.amount, body.currency, body.referenceId))).build()
+    suspend fun credit(@PathParam("accountId") accountId: UUID, body: BalanceOperationRequest?): Response {
+        // A JSON `null` body deserialises to null despite the non-nullable Kotlin type, so the
+        // first field access threw NPE and this answered 500 (#3038). libs-runtime maps
+        // IllegalArgumentException to 400.
+        requireNotNull(body) { "request body is required" }
+        return Response.ok(svc.credit(CreditAccountCommand(accountId, body.amount, body.currency, body.referenceId)))
+            .build()
+    }
 
     @POST
     @Path("/{accountId}/debit")
     @RolesAllowed(Roles.API, Roles.OPERATOR, Roles.ADMIN)
     @Authorize(action = "balance.debit", resource = "#accountId")
-    suspend fun debit(@PathParam("accountId") accountId: UUID, body: BalanceOperationRequest): Response =
-        Response.ok(svc.debit(DebitAccountCommand(accountId, body.amount, body.currency, body.referenceId))).build()
+    suspend fun debit(@PathParam("accountId") accountId: UUID, body: BalanceOperationRequest?): Response {
+        // A JSON `null` body deserialises to null despite the non-nullable Kotlin type, so the
+        // first field access threw NPE and this answered 500 (#3038). libs-runtime maps
+        // IllegalArgumentException to 400.
+        requireNotNull(body) { "request body is required" }
+        return Response.ok(svc.debit(DebitAccountCommand(accountId, body.amount, body.currency, body.referenceId)))
+            .build()
+    }
 
     @POST
     @Path("/{accountId}/initialize")
     @RolesAllowed(Roles.API, Roles.OPERATOR, Roles.ADMIN)
     @Authorize(action = "balance.initialize", resource = "#accountId")
-    suspend fun initialize(@PathParam("accountId") accountId: UUID, body: InitializeRequest): Response {
+    suspend fun initialize(@PathParam("accountId") accountId: UUID, body: InitializeRequest?): Response {
+        // A JSON `null` body deserialises to null despite the non-nullable Kotlin type, so the
+        // first field access threw NPE and this answered 500 (#3038). libs-runtime maps
+        // IllegalArgumentException to 400.
+        requireNotNull(body) { "request body is required" }
         val balance = svc.initializeBalance(
             InitializeBalanceCommand(
                 accountId,

--- a/openbank-fx-service/src/main/kotlin/com/openbank/fx/infrastructure/rest/FxResource.kt
+++ b/openbank-fx-service/src/main/kotlin/com/openbank/fx/infrastructure/rest/FxResource.kt
@@ -74,7 +74,11 @@ class FxResource(private val fxUseCase: FxUseCase, private val cnbIngestion: Cnb
     @RolesAllowed("ROLE_OPERATOR", "ROLE_ADMIN", "ROLE_PAYMENTS")
     @Authorize(action = "fx.convert", resource = "")
     @Operation(summary = "Execute FX conversion")
-    suspend fun convert(req: ConvertRequest, @HeaderParam("Idempotency-Key") key: String): Response {
+    suspend fun convert(req: ConvertRequest?, @HeaderParam("Idempotency-Key") key: String): Response {
+        // A JSON `null` body deserialises to null despite the non-nullable Kotlin type, so the
+        // first field access threw NPE and this answered 500 (#3038). libs-runtime maps
+        // IllegalArgumentException to 400.
+        requireNotNull(req) { "request body is required" }
         require(key.isNotBlank()) { "Idempotency-Key required" }
         val conv = fxUseCase.convert(
             ConvertCommand(

--- a/openbank-interest-service/src/main/kotlin/com/openbank/interest/infrastructure/rest/InterestResource.kt
+++ b/openbank-interest-service/src/main/kotlin/com/openbank/interest/infrastructure/rest/InterestResource.kt
@@ -66,13 +66,21 @@ class InterestResource(
     @Operation(summary = "Accrue interest for an account")
     @RolesAllowed("ROLE_OPERATOR", "ROLE_ADMIN", "ROLE_API")
     @Authorize(action = "interest.create", resource = "")
-    fun accrue(request: AccrualRequest): Uni<Response> = accrueUseCase.accrue(request)
-        .map { Response.status(201).entity(it).build() }
-        .onFailure(RateConfigNotFoundException::class.java).recoverWithItem { e ->
-            // No rate for this (account/product, currency): a client/config condition, not a 500.
-            Response.status(422).entity(mapOf("error" to e.message)).build()
-        }
-        .onFailure().recoverWithItem { e -> Response.serverError().entity(mapOf("error" to e.message)).build() }
+    fun accrue(request: AccrualRequest?): Uni<Response> {
+        // A JSON `null` body deserialises to null despite the non-nullable Kotlin type, so the
+        // first field access threw NPE and this answered 500 (#3038). libs-runtime maps
+        // IllegalArgumentException to 400.
+        requireNotNull(request) { "request body is required" }
+        return accrueUseCase.accrue(request)
+            .map { Response.status(201).entity(it).build() }
+            .onFailure(RateConfigNotFoundException::class.java).recoverWithItem { e ->
+                // No rate for this (account/product, currency): a client/config condition, not a 500.
+                Response.status(422).entity(mapOf("error" to e.message)).build()
+            }
+            .onFailure().recoverWithItem { e ->
+                Response.serverError().entity(mapOf("error" to e.message)).build()
+            }
+    }
 
     @POST
     @Path("/accrue/all")
@@ -134,8 +142,14 @@ class InterestResource(
     @Operation(summary = "Create interest rate configuration")
     @RolesAllowed("ROLE_OPERATOR", "ROLE_ADMIN", "ROLE_API")
     @Authorize(action = "interest.create", resource = "")
-    fun createRateConfig(config: InterestRateConfig): Uni<Response> = rateConfigUseCase.createConfig(config)
-        .map { Response.status(201).entity(it).build() }
+    fun createRateConfig(config: InterestRateConfig?): Uni<Response> {
+        // A JSON `null` body deserialises to null despite the non-nullable Kotlin type, so the
+        // first field access threw NPE and this answered 500 (#3038). libs-runtime maps
+        // IllegalArgumentException to 400.
+        requireNotNull(config) { "request body is required" }
+        return rateConfigUseCase.createConfig(config)
+            .map { Response.status(201).entity(it).build() }
+    }
 
     @GET
     @Path("/rates")

--- a/openbank-sepa-instant/src/main/kotlin/com/openbank/sepainstant/infrastructure/rest/SctInstResource.kt
+++ b/openbank-sepa-instant/src/main/kotlin/com/openbank/sepainstant/infrastructure/rest/SctInstResource.kt
@@ -52,7 +52,11 @@ class SctInstResource @Inject constructor(
     @RolesAllowed("ROLE_OPERATOR", "ROLE_ADMIN", "ROLE_PAYMENTS")
     @Authorize(action = "sctInstPayment.create")
     @Operation(summary = "Submit SCT Inst payment")
-    fun submit(@HeaderParam("Idempotency-Key") idempotencyKey: String?, body: SubmitSctInstRequest): Uni<Response> {
+    fun submit(@HeaderParam("Idempotency-Key") idempotencyKey: String?, body: SubmitSctInstRequest?): Uni<Response> {
+        // A JSON `null` body deserialises to null despite the non-nullable Kotlin type, so the
+        // first field access threw NPE and this answered 500 (#3038). libs-runtime maps
+        // IllegalArgumentException to 400.
+        requireNotNull(body) { "request body is required" }
         val key = idempotencyKey ?: body.idempotencyKey
         val cmd = SubmitSctInstCommand(
             idempotencyKey = key,
@@ -98,8 +102,13 @@ class SctInstResource @Inject constructor(
     @RolesAllowed("ROLE_OPERATOR", "ROLE_ADMIN", "ROLE_PAYMENTS")
     @Authorize(action = "sctInstPayment.recall", resource = "#paymentId")
     @Operation(summary = "Recall a settled SCT Inst payment")
-    fun recall(@PathParam("paymentId") paymentId: UUID, body: RecallRequest): Uni<Response> =
-        recallUseCase.recall(paymentId, body.reason).map { Response.ok(toResponse(it)).build() }
+    fun recall(@PathParam("paymentId") paymentId: UUID, body: RecallRequest?): Uni<Response> {
+        // A JSON `null` body deserialises to null despite the non-nullable Kotlin type, so the
+        // first field access threw NPE and this answered 500 (#3038). libs-runtime maps
+        // IllegalArgumentException to 400.
+        requireNotNull(body) { "request body is required" }
+        return recallUseCase.recall(paymentId, body.reason).map { Response.ok(toResponse(it)).build() }
+    }
 
     private fun toResponse(p: com.openbank.sepainstant.domain.model.SctInstPayment) = SctInstPaymentResponse(
         paymentId = p.paymentId, status = p.status.name,

--- a/openbank-swift-service/src/main/kotlin/com/openbank/swift/infrastructure/rest/SwiftResource.kt
+++ b/openbank-swift-service/src/main/kotlin/com/openbank/swift/infrastructure/rest/SwiftResource.kt
@@ -29,7 +29,13 @@ class SwiftResource(private val useCase: SwiftUseCase) {
     @POST
     @RolesAllowed(Roles.OPERATOR, Roles.PAYMENTS, Roles.ADMIN)
     @Authorize(action = "swift.send", resource = "")
-    suspend fun send(cmd: SendSwiftCommand) = Response.status(201).entity(useCase.send(cmd)).build()
+    suspend fun send(cmd: SendSwiftCommand?): Response {
+        // A JSON `null` body deserialises to null despite the non-nullable Kotlin type, so the
+        // first field access threw NPE and this answered 500 (#3038). libs-runtime maps
+        // IllegalArgumentException to 400.
+        requireNotNull(cmd) { "request body is required" }
+        return Response.status(201).entity(useCase.send(cmd)).build()
+    }
 
     @GET
     @Path("/messages")
@@ -53,12 +59,13 @@ class SwiftResource(private val useCase: SwiftUseCase) {
     @Path("/{id}/ack")
     @RolesAllowed(Roles.OPERATOR, Roles.PAYMENTS, Roles.ADMIN)
     @Authorize(action = "swift.acknowledge", resource = "#id")
-    suspend fun ack(@PathParam("id") id: UUID, body: Map<String, String>) =
-        useCase.acknowledge(id, body["ackRef"] ?: "")
+    suspend fun ack(@PathParam("id") id: UUID, body: Map<String, String>?) =
+        useCase.acknowledge(id, body?.get("ackRef") ?: "")
 
     @POST
     @Path("/{id}/reject")
     @RolesAllowed(Roles.OPERATOR, Roles.PAYMENTS, Roles.ADMIN)
     @Authorize(action = "swift.reject", resource = "#id")
-    suspend fun reject(@PathParam("id") id: UUID, body: Map<String, String>) = useCase.reject(id, body["reason"] ?: "")
+    suspend fun reject(@PathParam("id") id: UUID, body: Map<String, String>?) =
+        useCase.reject(id, body?.get("reason") ?: "")
 }


### PR DESCRIPTION
## Summary

Per-handler fix for the null-body 500s (#3038) — nullable parameter + `requireNotNull`, the same
pattern #3032 applied to the sixteen approval resources. **Twelve handlers across five money-path
services.**

## Type of change

- [x] fix (bug fix)

## Linked issues

Refs #3038, #3032, #2365

## Twelve, not sixteen — and that correction matters

#3038 classified 6 findings as "absent body". Reading the handlers shows **those endpoints take no
body at all**:

| Endpoint | Actual signature |
|---|---|
| `POST /api/v1/balances/reconciliation` | `run(@QueryParam asOf)` |
| `POST /api/v1/fees/post` | `post(@QueryParam …)` |
| `POST /api/v1/fx/cnb/ingest` | `ingest(@QueryParam date)` |
| `POST /api/v1/interest/accrue/all` | `accrueAll(@QueryParam date)` |
| `POST /api/v1/interest/capitalize/{accountId}` | `capitalize(@PathParam, @QueryParam …)` |
| `POST /api/v1/interest/withholding/remittances` | `assemble(@QueryParam year: Int, month: Int)` |

Their 500 is **not** a null-body bug. The likely cause is a non-nullable primitive query parameter
(`year: Int`) with a missing or unconvertible value — a different defect class needing its own
diagnosis. Not fixed here, and I have corrected #3038 rather than leaving it claiming one class.

## What changed

Ten handlers get `requireNotNull(body) { "request body is required" }`:
`balance` credit/debit/placeHold/initialize · `fx` convert · `interest` accrue/createRateConfig ·
`sepa-instant` submit/recall · `swift` send.

**Swift ack/reject are deliberately different.** They take `Map<String, String>?` and use
`body?.get(…) ?: ""`, because those handlers *already* tolerate a missing key via `?: ""` — an empty
JSON object acknowledges with an empty ref today. Making a null body 400 while `{}` stays 200 would
be an arbitrary split; the safe-call keeps one rule. Worth a reviewer's opinion.

## A mistake I made and caught

Eight of the twelve had **expression bodies** (`fun x(…) = …`), which cannot take a guard statement
without converting to a block. My first pass converted `InterestResource.accrue`'s signature and
opening brace but left its chained `.map{}.onFailure{}` continuation **without a closing brace** — a
syntax error.

Caught by checking brace balance per file, not by re-reading the diff — a re-read is exactly what had
just missed it. All five touched files now balance.

## Not verified locally

The build host's shared Gradle cache is corrupting artifacts, so **nothing here has been compiled**.
Twelve hand-edits across five money-path services, eight of them structural conversions.

**Read this one rather than trusting it.** CI is the verifier and I expect at least one round.

## Relationship to the other two PRs

| PR | What | Order |
|---|---|---|
| #3032 | 16 approval handlers, identical signatures | first — smallest, evidenced |
| **this** | 12 remaining body handlers | second |
| #3044 | fleet-wide `libs-runtime` guards | **last, as a net** — by then it should catch nothing, which is the only way to learn it has no false positives |

## Definition of Done

- [x] Each handler read individually; the six non-body endpoints identified and excluded with reasons.
- [x] Brace balance verified per file after the structural conversions.
- [ ] **Not compiled.** No local build.
- [ ] Does not close #3038 — the six query-param 500s remain.

## Security checklist

- [x] No secrets, no new dependency, no `@Suppress`.
- [x] Money-path request handling → `security-review-required`.
- [x] No behaviour change for a well-formed body; only malformed input moves 500 → 400.

## Compliance impact

- [x] DORA — money-path endpoints answering 500 to trivially malformed input.
- [ ] PCI DSS / GDPR / PSD2 / AML / CNB — not applicable.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
