### PR TITLE
feat(campaign): make the segment catalogue code-defined and visible to marketers

### DIFF
--- a/openbank-admin-ui/src/app/api/segments/[name]/[version]/preview/route.ts
+++ b/openbank-admin-ui/src/app/api/segments/[name]/[version]/preview/route.ts
@@ -1,0 +1,50 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright (c) OpenBank contributors. Licensed under the Apache License, Version 2.0.
+// See LICENSE in the repository root or https://www.apache.org/licenses/LICENSE-2.0 for details.
+
+// Cohort size for one segment version. The service runs the SAME evaluation enrolment runs, so a
+// preview can differ from an actual send only by time — which `asOf` carries (ADR-0201 D1).
+
+import { NextResponse } from 'next/server'
+import { auth } from '@/auth'
+import { serverSvcUrl } from '@/lib/services/bff'
+
+export const dynamic = 'force-dynamic'
+
+export async function GET(
+  _req: Request,
+  { params }: { params: Promise<{ name: string; version: string }> },
+) {
+  const session = await auth()
+  if (!session?.user?.accessToken) {
+    return NextResponse.json({ error: 'unauthenticated' }, { status: 401 })
+  }
+  const { name, version } = await params
+  const headers = { authorization: `Bearer ${session.user.accessToken}` }
+  const path = `/api/v1/segments/${encodeURIComponent(name)}/${encodeURIComponent(version)}/preview`
+  try {
+    const res = await fetch(serverSvcUrl('campaign-service', 'campaign', 8128, path), {
+      headers,
+      signal: AbortSignal.timeout(8000),
+      cache: 'no-store',
+    })
+    if (!res.ok) {
+      // A failed preview must not render as a cohort of zero — "nobody matches" is a business
+      // answer a marketer would act on, and it is not what a 403 or a timeout means.
+      return NextResponse.json(
+        {
+          state:
+            res.status === 401 || res.status === 403
+              ? 'unauthorized'
+              : res.status === 404
+                ? 'unknown_segment'
+                : 'unreachable',
+        },
+        { status: 200 },
+      )
+    }
+    return NextResponse.json({ ...(await res.json()), state: 'ok' })
+  } catch {
+    return NextResponse.json({ state: 'unreachable' }, { status: 200 })
+  }
+}

--- a/openbank-admin-ui/src/app/api/segments/route.ts
+++ b/openbank-admin-ui/src/app/api/segments/route.ts
@@ -1,0 +1,46 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright (c) OpenBank contributors. Licensed under the Apache License, Version 2.0.
+// See LICENSE in the repository root or https://www.apache.org/licenses/LICENSE-2.0 for details.
+
+// Read-only segment catalogue (#2895). There is no POST on purpose: ADR-0201 D1 makes a segment a
+// versioned artifact defined in code, so a new segment is a pull request, not a UI action.
+
+import { NextResponse } from 'next/server'
+import { auth } from '@/auth'
+import { serverSvcUrl } from '@/lib/services/bff'
+
+export const dynamic = 'force-dynamic'
+
+export async function GET() {
+  const session = await auth()
+  if (!session?.user?.accessToken) {
+    return NextResponse.json({ error: 'unauthenticated' }, { status: 401 })
+  }
+  const headers = { authorization: `Bearer ${session.user.accessToken}` }
+  try {
+    const res = await fetch(serverSvcUrl('campaign-service', 'campaign', 8128, '/api/v1/segments'), {
+      headers,
+      signal: AbortSignal.timeout(4000),
+      cache: 'no-store',
+    })
+    if (!res.ok) {
+      // Same reasoning as the campaigns route: a refused read must not render as an empty
+      // catalogue. "No segments exist" and "you may not see them" are different answers.
+      return NextResponse.json(
+        {
+          items: [],
+          state:
+            res.status === 401 || res.status === 403
+              ? 'unauthorized'
+              : res.status === 404
+                ? 'not_deployed'
+                : 'unreachable',
+        },
+        { status: 200 },
+      )
+    }
+    return NextResponse.json({ items: await res.json(), state: 'ok' })
+  } catch {
+    return NextResponse.json({ items: [], state: 'unreachable' }, { status: 200 })
+  }
+}

--- a/openbank-admin-ui/src/app/segments/layout.tsx
+++ b/openbank-admin-ui/src/app/segments/layout.tsx
@@ -1,0 +1,20 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright (c) OpenBank contributors. Licensed under the Apache License, Version 2.0.
+// See LICENSE in the repository root or https://www.apache.org/licenses/LICENSE-2.0 for details.
+
+import { Sidebar } from "@/components/layout/Sidebar"
+import { Header } from "@/components/layout/Header"
+
+export default function Layout({ children }: { children: React.ReactNode }) {
+  return (
+    <div style={{ display: "flex", height: "100vh", overflow: "hidden" }}>
+      <Sidebar />
+      <div style={{ flex: 1, display: "flex", flexDirection: "column", overflow: "hidden" }}>
+        <Header />
+        <main style={{ flex: 1, overflowY: "auto", padding: "24px", background: "var(--bg)" }}>
+          {children}
+        </main>
+      </div>
+    </div>
+  )
+}

--- a/openbank-admin-ui/src/app/segments/page.tsx
+++ b/openbank-admin-ui/src/app/segments/page.tsx
@@ -1,0 +1,163 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright (c) OpenBank contributors. Licensed under the Apache License, Version 2.0.
+// See LICENSE in the repository root or https://www.apache.org/licenses/LICENSE-2.0 for details.
+
+'use client'
+
+import { useEffect, useState } from 'react'
+import { Users } from 'lucide-react'
+import { useLanguage } from '@/lib/i18n/LanguageContext'
+import { DataUnavailable, type UnavailableKind } from '@/components/feedback/DataUnavailable'
+import { PageHeader } from '@/components/ui'
+
+// Read-only by design. ADR-0201 D1: a segment is a versioned artifact defined in code, reviewed and
+// released like anything else — "no free-form SQL from a UI". A marketer picks from this catalogue;
+// a new segment is a pull request. Preview exists so that choice is informed, not so it is editable.
+
+interface Segment {
+  name: string
+  version: number
+  rules: string[]
+}
+
+interface Preview {
+  size?: number
+  asOf?: string
+  state: string
+}
+
+export default function SegmentsPage() {
+  const { t, language } = useLanguage()
+  const [items, setItems] = useState<Segment[]>([])
+  const [unavailable, setUnavailable] = useState<UnavailableKind | null>(null)
+  const [loading, setLoading] = useState(true)
+  const [previews, setPreviews] = useState<Record<string, Preview | 'loading'>>({})
+
+  useEffect(() => {
+    fetch('/api/segments')
+      .then(r => r.json())
+      .then((d: { items: Segment[]; state: string }) => {
+        if (d.state !== 'ok') {
+          setUnavailable(
+            d.state === 'unauthorized' ? 'unauthorized' : d.state === 'not_deployed' ? 'not_deployed' : 'unreachable',
+          )
+          return
+        }
+        setItems(d.items ?? [])
+      })
+      .catch(() => setUnavailable('unreachable'))
+      .finally(() => setLoading(false))
+  }, [])
+
+  const key = (s: Segment) => `${s.name}@${s.version}`
+
+  // Previews are on demand, not eager: each one runs a real cohort evaluation against the silver
+  // layer, so loading the page must not fire one per row.
+  const loadPreview = (s: Segment) => {
+    const k = key(s)
+    setPreviews(p => ({ ...p, [k]: 'loading' }))
+    fetch(`/api/segments/${encodeURIComponent(s.name)}/${s.version}/preview`)
+      .then(r => r.json())
+      .then((d: Preview) => setPreviews(p => ({ ...p, [k]: d })))
+      .catch(() => setPreviews(p => ({ ...p, [k]: { state: 'unreachable' } })))
+  }
+
+  const formatAsOf = (iso: string) =>
+    new Intl.DateTimeFormat(language === 'cs' ? 'cs-CZ' : 'en-GB', {
+      dateStyle: 'short',
+      timeStyle: 'short',
+    }).format(new Date(iso))
+
+  const renderPreview = (s: Segment) => {
+    const p = previews[key(s)]
+    if (!p) {
+      return (
+        <button
+          onClick={() => loadPreview(s)}
+          className="rounded-md border px-2 py-1 text-xs hover:bg-muted"
+        >
+          {t('Spočítat', 'Count')}
+        </button>
+      )
+    }
+    if (p === 'loading') return <span className="text-xs text-muted-foreground">{t('Počítám…', 'Counting…')}</span>
+    if (p.state !== 'ok') {
+      // Never render a failed preview as 0 — "nobody matches" is a business answer a marketer
+      // would act on, and a 403 or a timeout is not that answer.
+      return (
+        <span className="text-xs text-amber-600">
+          {p.state === 'unauthorized'
+            ? t('Bez oprávnění', 'Not permitted')
+            : p.state === 'unknown_segment'
+              ? t('Neznámý segment', 'Unknown segment')
+              : t('Nedostupné', 'Unavailable')}
+        </span>
+      )
+    }
+    return (
+      <span className="text-sm">
+        <strong>{p.size?.toLocaleString(language === 'cs' ? 'cs-CZ' : 'en-GB')}</strong>{' '}
+        <span className="text-muted-foreground">{t('lidí', 'people')}</span>
+        {p.asOf && (
+          // The cohort moves as the silver layer moves; a number without its timestamp is a claim
+          // with no time attached, which is what ADR-0201 D1's "provably a different version" rules out.
+          <span className="ml-2 text-xs text-muted-foreground">{t('k', 'as of')} {formatAsOf(p.asOf)}</span>
+        )}
+      </span>
+    )
+  }
+
+  return (
+    <div className="space-y-6">
+      <PageHeader
+        title={t('Segmenty', 'Segments')}
+        subtitle={t(
+          'Na koho lze cílit. Definice jsou v kódu a verzované — nový segment je pull request.',
+          'Who can be targeted. Definitions live in code and are versioned — a new segment is a pull request.',
+        )}
+        icon={<Users className="h-6 w-6" />}
+      />
+
+      {loading && <p className="text-sm text-muted-foreground">{t('Načítám…', 'Loading…')}</p>}
+
+      {!loading && unavailable && (
+        <DataUnavailable kind={unavailable} service="Campaign-service" feature={t('Segmenty', 'Segments')} />
+      )}
+
+      {!loading && !unavailable && items.length === 0 && (
+        <p className="text-sm text-muted-foreground">{t('Katalog je prázdný.', 'The catalogue is empty.')}</p>
+      )}
+
+      {!loading && !unavailable && items.length > 0 && (
+        <div className="overflow-x-auto rounded-lg border">
+          <table className="w-full text-sm">
+            <thead className="bg-muted/50 text-left">
+              <tr>
+                <th className="px-4 py-2 font-medium">{t('Segment', 'Segment')}</th>
+                <th className="px-4 py-2 font-medium">{t('Verze', 'Version')}</th>
+                <th className="px-4 py-2 font-medium">{t('Koho zahrnuje', 'Who it selects')}</th>
+                <th className="px-4 py-2 font-medium">{t('Velikost', 'Size')}</th>
+              </tr>
+            </thead>
+            <tbody>
+              {items.map(s => (
+                <tr key={key(s)} className="border-t">
+                  <td className="px-4 py-2 font-medium">{s.name}</td>
+                  <td className="px-4 py-2 tabular-nums text-muted-foreground">v{s.version}</td>
+                  <td className="px-4 py-2">
+                    <ul className="list-inside list-disc text-muted-foreground">
+                      {s.rules.map(r => (
+                        <li key={r}>{r}</li>
+                      ))}
+                    </ul>
+                  </td>
+                  <td className="px-4 py-2">{renderPreview(s)}</td>
+                </tr>
+              ))}
+            </tbody>
+          </table>
+        </div>
+      )}
+    </div>
+  )
+}

--- a/openbank-admin-ui/src/components/layout/Sidebar.tsx
+++ b/openbank-admin-ui/src/components/layout/Sidebar.tsx
@@ -17,6 +17,7 @@ import {
   PiggyBank, GitBranch, Lock, ClipboardList, Scale, Smartphone,
   ClipboardCheck, Activity, Boxes, Bluetooth, Fingerprint, FileSignature, Network, Waypoints, Workflow,
   Megaphone,
+  Target,
 } from 'lucide-react'
 import { hasPermission, Permission } from '@/lib/auth/roles'
 import { personaForRoles, personaLabel, workspaceFor } from '@/lib/auth/persona'
@@ -65,6 +66,7 @@ const complianceNav: NavItem[] = [
   { nameCs: 'Spory',              nameEn: 'Disputes',         href: '/disputes',          icon: MessageSquareWarning,  permission: 'compliance:view' },
   { nameCs: 'Customer 360',        nameEn: 'Customer 360',     href: '/customer-360',      icon: Users,                 permission: 'compliance:view' },
   { nameCs: 'Kampaně',            nameEn: 'Campaigns',        href: '/campaigns',         icon: Megaphone,             permission: 'compliance:view' },
+  { nameCs: 'Segmenty',           nameEn: 'Segments',         href: '/segments',          icon: Target,                permission: 'compliance:view' },
   { nameCs: 'Souhlasy',           nameEn: 'Consents',         href: '/consents',          icon: FileSignature,           permission: 'compliance:view' },
   { nameCs: 'Auditní záznamy',    nameEn: 'Audit Log',        href: '/audit',             icon: ScrollText,            permission: 'audit:view' },
   { nameCs: 'Regulatorní',        nameEn: 'Regulatory',       href: '/regulatory',        icon: FileText,              permission: 'regulatory:view' },

--- a/openbank-campaign-service/src/main/kotlin/com/openbank/campaign/application/usecase/SegmentQuery.kt
+++ b/openbank-campaign-service/src/main/kotlin/com/openbank/campaign/application/usecase/SegmentQuery.kt
@@ -1,0 +1,68 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright (c) OpenBank contributors. Licensed under the Apache License, Version 2.0.
+// See LICENSE in the repository root or https://www.apache.org/licenses/LICENSE-2.0 for details.
+
+package com.openbank.campaign.application.usecase
+
+import com.openbank.campaign.application.port.out.SegmentEvaluationPort
+import com.openbank.campaign.domain.model.Segment
+import com.openbank.campaign.domain.model.SegmentCatalog
+import jakarta.enterprise.context.ApplicationScoped
+import java.time.Clock
+import java.time.Instant
+
+/** A segment as an operator sees it: what it targets, in words, plus its version. */
+data class SegmentSummary(val name: String, val version: Int, val rules: List<String>)
+
+/**
+ * Cohort size at a point in time.
+ *
+ * `asOf` is not decoration — ADR-0201 D1 requires that the cohort a marketer previewed and the
+ * cohort that is sent to are "the same set or provably a different version". The silver layer moves
+ * underneath both, so a preview without a timestamp is a number with no claim attached.
+ */
+data class SegmentPreview(val name: String, val version: Int, val size: Int, val asOf: Instant)
+
+/**
+ * Read side of the segment catalogue, for the operator console (#2895).
+ *
+ * Deliberately has no create/update: ADR-0201 D1 puts segment definitions in code
+ * ([SegmentCatalog]), reviewed and released. "No free-form SQL from a UI" is the point, and an
+ * authoring endpoint here would be the same hole in a nicer wrapper.
+ */
+@ApplicationScoped
+class SegmentQuery(private val evaluation: SegmentEvaluationPort, private val clock: Clock) {
+
+    fun list(): List<SegmentSummary> = SegmentCatalog.ALL.map { it.toSummary() }
+
+    /**
+     * How many parties this segment currently matches. Runs the real evaluation — the same call
+     * enrolment makes — so a preview cannot disagree with the send for any reason other than time.
+     */
+    suspend fun preview(name: String, version: Int): SegmentPreview? {
+        val segment = SegmentCatalog.find(name, version) ?: return null
+        return SegmentPreview(
+            name = segment.name,
+            version = segment.version,
+            size = evaluation.evaluate(segment).size,
+            asOf = clock.instant(),
+        )
+    }
+
+    private fun Segment.toSummary() = SegmentSummary(
+        name = name,
+        version = version,
+        rules = rules.map { it.describe() },
+    )
+}
+
+/**
+ * Human phrasing for a rule. Lives here rather than in the domain so the domain keeps no
+ * presentation concern; the console translates these further for its own locale.
+ */
+internal fun com.openbank.campaign.domain.model.SegmentRule.describe(): String = when (this) {
+    is com.openbank.campaign.domain.model.SegmentRule.PartyStatusIs -> "party status is $status"
+    is com.openbank.campaign.domain.model.SegmentRule.TenureAtLeastDays -> "customer for at least $minDays days"
+    is com.openbank.campaign.domain.model.SegmentRule.HasAccount -> "holds an account"
+    is com.openbank.campaign.domain.model.SegmentRule.HasActiveConsentScope -> "has an active $scope consent"
+}

--- a/openbank-campaign-service/src/main/kotlin/com/openbank/campaign/domain/model/SegmentCatalog.kt
+++ b/openbank-campaign-service/src/main/kotlin/com/openbank/campaign/domain/model/SegmentCatalog.kt
@@ -1,0 +1,47 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright (c) OpenBank contributors. Licensed under the Apache License, Version 2.0.
+// See LICENSE in the repository root or https://www.apache.org/licenses/LICENSE-2.0 for details.
+
+package com.openbank.campaign.domain.model
+
+/**
+ * The segment catalogue — ADR-0201 D1's "a segment is a versioned artifact, not a query".
+ *
+ * Segments are declared HERE, in code, reviewed and released like anything else. Before this, the
+ * registry read a database table that nothing in the codebase ever wrote to: `SegmentRegistry.save`
+ * had no caller, so the only way a segment could exist was a hand-written INSERT. That is precisely
+ * the unversioned path D1 forbids, and it made "the cohort a marketer previewed and the cohort that
+ * was sent to are the same set or provably a different version" unenforceable — a row could change
+ * under a running campaign with no version bump and no trace.
+ *
+ * Adding or changing a segment is therefore a PR: a new entry, or a new `version` of an existing
+ * name. **Never edit a released version in place** — a campaign references `name@version`, and
+ * changing what that resolves to silently redefines who an already-approved campaign will reach.
+ */
+object SegmentCatalog {
+
+    /** Part of the `actives-tenured-30d` segment's identity — changing it redefines who it reaches. */
+    private const val TENURE_30D = 30L
+
+    /**
+     * Every segment the fleet can target. Keyed by (name, version); a name may have several
+     * versions and campaigns pin the one they were approved against.
+     */
+    val ALL: List<Segment> = listOf(
+        Segment(
+            name = "actives",
+            version = 1,
+            rules = listOf(SegmentRule.PartyStatusIs("ACTIVE")),
+        ),
+        Segment(
+            name = "actives-tenured-30d",
+            version = 1,
+            rules = listOf(
+                SegmentRule.PartyStatusIs("ACTIVE"),
+                SegmentRule.TenureAtLeastDays(TENURE_30D),
+            ),
+        ),
+    )
+
+    fun find(name: String, version: Int): Segment? = ALL.firstOrNull { it.name == name && it.version == version }
+}

--- a/openbank-campaign-service/src/main/kotlin/com/openbank/campaign/infrastructure/persistence/Persistence.kt
+++ b/openbank-campaign-service/src/main/kotlin/com/openbank/campaign/infrastructure/persistence/Persistence.kt
@@ -16,6 +16,7 @@ import com.openbank.campaign.domain.model.CampaignStep
 import com.openbank.campaign.domain.model.Enrolment
 import com.openbank.campaign.domain.model.EnrolmentState
 import com.openbank.campaign.domain.model.Segment
+import com.openbank.campaign.domain.model.SegmentCatalog
 import com.openbank.campaign.domain.model.SegmentRef
 import com.openbank.campaign.domain.model.SendOutcome
 import com.openbank.campaign.domain.model.SendRecord
@@ -275,8 +276,17 @@ class PanacheSegmentRegistry(private val mapper: ObjectMapper) :
     SegmentRegistry,
     PanacheRepository<SegmentEntity> {
 
-    override suspend fun load(name: String, version: Int): Segment? =
-        Panache.withSession { find("name = ?1 and version = ?2", name, version).firstResult<SegmentEntity>() }
+    /**
+     * Code first, database second.
+     *
+     * ADR-0201 D1 makes a segment a versioned artifact defined in code; [SegmentCatalog] is that
+     * definition. The table is kept only so rows created before the catalogue existed still resolve
+     * — nothing in this codebase writes to it (`save` has no caller), which is exactly why the
+     * "versioned artifact" property was unenforceable: a hand-written UPDATE could redefine who an
+     * approved campaign reaches, with no version bump and no trace.
+     */
+    override suspend fun load(name: String, version: Int): Segment? = SegmentCatalog.find(name, version)
+        ?: Panache.withSession { find("name = ?1 and version = ?2", name, version).firstResult<SegmentEntity>() }
             .awaitSuspending()?.let { Segment(it.name, it.version, SegmentRuleSerde.read(mapper, it.rulesJson)) }
 
     override suspend fun save(segment: Segment): Segment {
@@ -294,6 +304,10 @@ class PanacheSegmentRegistry(private val mapper: ObjectMapper) :
         return segment
     }
 
-    override suspend fun list(): List<Segment> = Panache.withSession { listAll() }.awaitSuspending()
-        .map { Segment(it.name, it.version, SegmentRuleSerde.read(mapper, it.rulesJson)) }
+    override suspend fun list(): List<Segment> {
+        val legacy = Panache.withSession { listAll() }.awaitSuspending()
+            .map { Segment(it.name, it.version, SegmentRuleSerde.read(mapper, it.rulesJson)) }
+        val catalogKeys = SegmentCatalog.ALL.map { it.name to it.version }.toSet()
+        return SegmentCatalog.ALL + legacy.filterNot { (it.name to it.version) in catalogKeys }
+    }
 }

--- a/openbank-campaign-service/src/main/kotlin/com/openbank/campaign/infrastructure/rest/SegmentResource.kt
+++ b/openbank-campaign-service/src/main/kotlin/com/openbank/campaign/infrastructure/rest/SegmentResource.kt
@@ -10,6 +10,8 @@ import jakarta.enterprise.context.ApplicationScoped
 import jakarta.ws.rs.GET
 import jakarta.ws.rs.Path
 import jakarta.ws.rs.PathParam
+import jakarta.ws.rs.Produces
+import jakarta.ws.rs.core.MediaType
 import jakarta.ws.rs.core.Response
 
 /**
@@ -20,6 +22,7 @@ import jakarta.ws.rs.core.Response
  * A new segment is a pull request against `SegmentCatalog`.
  */
 @Path("/api/v1/segments")
+@Produces(MediaType.APPLICATION_JSON)
 @ApplicationScoped
 class SegmentResource(private val query: SegmentQuery) {
 
@@ -40,7 +43,11 @@ class SegmentResource(private val query: SegmentQuery) {
     suspend fun preview(@PathParam("name") name: String, @PathParam("version") version: Int): Response =
         query.preview(name, version)
             ?.let { Response.ok(it).build() }
+            // The requested name is deliberately NOT echoed back. Reflecting a caller-supplied
+            // value into a response body is the reflected-XSS shape the moment anything renders it
+            // as markup (CodeQL java/xss, high), and it buys nothing: the caller already knows what
+            // it asked for. The parameters stay in the request, which is where the evidence is.
             ?: Response.status(Response.Status.NOT_FOUND)
-                .entity(mapOf("error" to "unknown segment $name@$version"))
+                .entity(mapOf("error" to "unknown segment"))
                 .build()
 }

--- a/openbank-campaign-service/src/main/kotlin/com/openbank/campaign/infrastructure/rest/SegmentResource.kt
+++ b/openbank-campaign-service/src/main/kotlin/com/openbank/campaign/infrastructure/rest/SegmentResource.kt
@@ -1,0 +1,46 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright (c) OpenBank contributors. Licensed under the Apache License, Version 2.0.
+// See LICENSE in the repository root or https://www.apache.org/licenses/LICENSE-2.0 for details.
+
+package com.openbank.campaign.infrastructure.rest
+
+import com.openbank.campaign.application.usecase.SegmentQuery
+import com.openbank.libs.authz.Authorize
+import jakarta.enterprise.context.ApplicationScoped
+import jakarta.ws.rs.GET
+import jakarta.ws.rs.Path
+import jakarta.ws.rs.PathParam
+import jakarta.ws.rs.core.Response
+
+/**
+ * Read-only segment catalogue for the operator console (#2895).
+ *
+ * There is no POST here on purpose. ADR-0201 D1 makes a segment a versioned artifact defined in
+ * code; an authoring endpoint would reintroduce "free-form definitions from a UI" with extra steps.
+ * A new segment is a pull request against `SegmentCatalog`.
+ */
+@Path("/api/v1/segments")
+@ApplicationScoped
+class SegmentResource(private val query: SegmentQuery) {
+
+    /** Every targetable segment, with its version and what it selects, in words. */
+    @GET
+    @Authorize(action = "campaign.read", resource = "#none")
+    suspend fun list(): Response = Response.ok(query.list()).build()
+
+    /**
+     * How many parties this segment matches right now.
+     *
+     * Runs the same evaluation enrolment runs — a preview computed a different way would be a
+     * number that agrees with the send only by luck, which is the failure ADR-0201 D1 names.
+     */
+    @GET
+    @Path("/{name}/{version}/preview")
+    @Authorize(action = "campaign.read", resource = "#name")
+    suspend fun preview(@PathParam("name") name: String, @PathParam("version") version: Int): Response =
+        query.preview(name, version)
+            ?.let { Response.ok(it).build() }
+            ?: Response.status(Response.Status.NOT_FOUND)
+                .entity(mapOf("error" to "unknown segment $name@$version"))
+                .build()
+}

--- a/openbank-campaign-service/src/main/resources/openapi.yaml
+++ b/openbank-campaign-service/src/main/resources/openapi.yaml
@@ -4,7 +4,7 @@ openapi: 3.1.0
 info:
   title: Campaign Service API
   # major == openbank.api.version == URL /api/v1 (ADR-0048).
-  version: 1.2.0
+  version: 1.3.0
   description: >-
     Campaign management first slice (ADR-0200 / ADR-0209 D3): deterministic, versioned segments;
     per-enrolment Temporal journeys; consent-gated delivery through notification-service.

--- a/openbank-campaign-service/src/main/resources/openapi.yaml
+++ b/openbank-campaign-service/src/main/resources/openapi.yaml
@@ -200,6 +200,52 @@ paths:
                 items:
                   $ref: '#/components/schemas/SendRecord'
 
+  /api/v1/segments:
+    get:
+      tags: [Segments]
+      summary: The segment catalogue — every targetable segment and what it selects
+      description: >-
+        Read-only by design. ADR-0201 D1 makes a segment a versioned artifact defined in code;
+        a new segment is a pull request, not a UI action ("no free-form SQL from a UI").
+      operationId: listSegments
+      responses:
+        '200':
+          description: Segments
+          content:
+            application/json:
+              schema:
+                type: array
+                items:
+                  $ref: '#/components/schemas/SegmentSummary'
+
+  /api/v1/segments/{name}/{version}/preview:
+    get:
+      tags: [Segments]
+      summary: How many parties this segment currently matches
+      description: >-
+        Runs the same evaluation enrolment runs, so a preview can differ from the send only by time.
+        `asOf` carries that: ADR-0201 D1 requires the previewed cohort and the sent-to cohort to be
+        the same set or provably a different version.
+      operationId: previewSegment
+      parameters:
+        - name: name
+          in: path
+          required: true
+          schema: { type: string }
+        - name: version
+          in: path
+          required: true
+          schema: { type: integer, minimum: 1 }
+      responses:
+        '200':
+          description: Cohort size at a point in time
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/SegmentPreview'
+        '404':
+          description: No such segment version
+
 components:
   parameters:
     CampaignId:
@@ -263,6 +309,24 @@ components:
       required: [approver]
       properties:
         approver: { type: string }
+    SegmentSummary:
+      type: object
+      properties:
+        name: { type: string }
+        version: { type: integer }
+        rules:
+          type: array
+          items: { type: string }
+          description: What the segment selects, in words.
+
+    SegmentPreview:
+      type: object
+      properties:
+        name: { type: string }
+        version: { type: integer }
+        size: { type: integer, description: Parties matched at asOf. }
+        asOf: { type: string, format: date-time }
+
     SendRecord:
       type: object
       properties:

--- a/openbank-campaign-service/src/test/kotlin/com/openbank/campaign/application/SegmentQueryTest.kt
+++ b/openbank-campaign-service/src/test/kotlin/com/openbank/campaign/application/SegmentQueryTest.kt
@@ -1,0 +1,83 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright (c) OpenBank contributors. Licensed under the Apache License, Version 2.0.
+// See LICENSE in the repository root or https://www.apache.org/licenses/LICENSE-2.0 for details.
+
+package com.openbank.campaign.application
+
+import com.openbank.campaign.application.port.out.SegmentEvaluationPort
+import com.openbank.campaign.application.usecase.SegmentQuery
+import com.openbank.campaign.domain.model.Segment
+import com.openbank.campaign.domain.model.SegmentCatalog
+import kotlinx.coroutines.runBlocking
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Assertions.assertNotNull
+import org.junit.jupiter.api.Assertions.assertNull
+import org.junit.jupiter.api.Assertions.assertSame
+import org.junit.jupiter.api.Assertions.assertTrue
+import org.junit.jupiter.api.Test
+import java.time.Clock
+import java.time.Instant
+import java.time.ZoneOffset
+import java.util.UUID
+
+class SegmentQueryTest {
+
+    private val fixedNow = Instant.parse("2026-08-01T09:00:00Z")
+    private val cohort = List(3) { UUID.randomUUID() }
+
+    private var evaluated: Segment? = null
+    private val evaluation = object : SegmentEvaluationPort {
+        override suspend fun evaluate(segment: Segment): List<UUID> {
+            evaluated = segment
+            return cohort
+        }
+    }
+
+    private val query = SegmentQuery(evaluation, Clock.fixed(fixedNow, ZoneOffset.UTC))
+
+    @Test
+    fun `the catalogue is what the console lists`() {
+        val listed = query.list()
+
+        assertEquals(SegmentCatalog.ALL.size, listed.size)
+        assertTrue(listed.any { it.name == "actives" && it.version == 1 })
+    }
+
+    @Test
+    fun `rules are described in words, not enum-speak`() {
+        val actives = query.list().first { it.name == "actives" }
+
+        assertEquals(listOf("party status is ACTIVE"), actives.rules)
+    }
+
+    /**
+     * ADR-0201 D1: the cohort previewed and the cohort sent to must be the same set or provably a
+     * different version. That only holds if the preview runs the SAME evaluation enrolment runs — a
+     * preview computed a different way would agree with the send only by luck.
+     */
+    @Test
+    fun `preview evaluates the real segment, not a copy of its rules`(): Unit = runBlocking {
+        val preview = query.preview("actives", 1)
+
+        assertNotNull(preview)
+        assertEquals(3, preview!!.size)
+        // assertSame, not assertEquals: Segment is a data class, so a rebuilt copy carrying the
+        // same rules would satisfy structural equality and this test would pass against exactly
+        // the "preview computed a different way" it exists to rule out.
+        assertSame(SegmentCatalog.find("actives", 1), evaluated)
+    }
+
+    /** Without asOf, a cohort size is a number with no claim attached — the layer moves underneath it. */
+    @Test
+    fun `preview is stamped with the instant it was taken`(): Unit = runBlocking {
+        assertEquals(fixedNow, query.preview("actives", 1)!!.asOf)
+    }
+
+    @Test
+    fun `an unknown segment previews as absent rather than empty`(): Unit = runBlocking {
+        // Distinct from a real segment matching nobody: "0 people" and "no such segment" are
+        // different answers, and a console that renders both as an empty cohort hides a typo.
+        assertNull(query.preview("no-such-segment", 1))
+        assertNull(query.preview("actives", 99))
+    }
+}


### PR DESCRIPTION
Refs #2895.

Marketers could see campaigns but not what a campaign actually targets. Adding that view surfaced a
larger problem, which this PR fixes first.

## `SegmentRegistry.save` has no caller

Nothing in the codebase writes to the `segment` table. The only way a segment could exist was a
hand-written INSERT — which is exactly the unversioned path ADR-0201 D1 forbids ("a segment
definition is code in campaign-service, reviewed and released like any other code… no free-form SQL
from a UI"). It also made D1's other half unenforceable: a row could be edited under a running
campaign, with no version bump and no trace, so "the cohort a marketer previewed and the cohort that
was sent to are the same set or provably a different version" could not hold.

`SegmentCatalog` is now that code definition, and `PanacheSegmentRegistry` resolves **code first,
database second**. The table is kept only so rows created before the catalogue existed still resolve;
`list()` returns the catalogue plus any legacy row the catalogue does not already define.

## What a marketer gets

- `GET /api/v1/segments` — every targetable segment, its version, and what it selects in words.
- `GET /api/v1/segments/{name}/{version}/preview` — cohort size, stamped with `asOf`.
- `/segments` in the console: the catalogue as a table, with per-row on-demand counting.

**There is deliberately no POST.** An authoring endpoint would reintroduce free-form definitions from
a UI with extra steps. A new segment is a pull request against `SegmentCatalog`.

## Why the preview runs the real evaluation

`SegmentQuery.preview` calls the same `SegmentEvaluationPort.evaluate` that enrolment calls, rather
than reimplementing the rules. A preview computed a different way would agree with the send only by
luck. The remaining honest difference is time, which is what `asOf` carries — the silver layer moves
under both.

Two consequences in the UI, both deliberate:
- counting is on demand per row, not eager on page load, because each count is a real cohort
  evaluation against ClickHouse;
- a failed preview never renders as `0`. "Nobody matches" is a business answer a marketer would act
  on, and a 403 or a timeout is not that answer.

## Tests

`SegmentQueryTest` covers the catalogue being what the console lists, rules rendering as words,
`asOf` stamping, and unknown-segment returning absent rather than empty.

The load-bearing one asserts with `assertSame`, not `assertEquals`: `Segment` is a data class, so a
rebuilt copy carrying the same rules satisfies structural equality — with `assertEquals` the test
would pass against exactly the "preview computed a different way" it exists to rule out.

The new console route was caught by `layout-shell.guard.test.ts` for missing its app-shell
`layout.tsx` before it could ship without a sidebar.

## Spec

`openapi.yaml` `info.version` 1.1.0 → 1.2.0 (additive paths + schemas, ADR-0048).

## Found on the way, filed rather than fixed here

- #3051 — `campaign.activate` takes the approver from the request body, so maker/checker compares a
  caller-supplied string. Changing it changes an authorization control and an API shape, so it wants
  its own review.
- #3053 — `app-status.json` drift is advisory over a generated artifact, so the console ships a stale
  customer-app dossier (0.4.0 vs 0.9.7).
