### PR TITLE
fix(api): stop reporting client errors as 500 — unmapped DateTimeException and catch-all recovers (#3038)

### DIFF
--- a/openbank-clearing-service/src/main/kotlin/com/openbank/clearing/infrastructure/rest/ClearingResource.kt
+++ b/openbank-clearing-service/src/main/kotlin/com/openbank/clearing/infrastructure/rest/ClearingResource.kt
@@ -77,7 +77,6 @@ class ClearingResource(
     @Operation(summary = "Submit payment for clearing")
     fun submit(request: SubmitPaymentRequest): Uni<Response> = submitUseCase.submit(request)
         .map { Response.status(Response.Status.CREATED).entity(it).build() }
-        .onFailure().recoverWithItem { e -> Response.serverError().entity(mapOf("error" to e.message)).build() }
 
     @GET
     @Path("/batches")
@@ -112,7 +111,6 @@ class ClearingResource(
     @Operation(summary = "Settle a clearing batch")
     fun settleBatch(@PathParam("id") id: UUID): Uni<Response> = triggerUseCase.settleBatch(id)
         .map { Response.ok(it).build() }
-        .onFailure().recoverWithItem { e -> Response.serverError().entity(mapOf("error" to e.message)).build() }
 
     @POST
     @Path("/cycle/trigger")
@@ -122,7 +120,6 @@ class ClearingResource(
     fun triggerCycle(@QueryParam("rail") @DefaultValue("SEPA_SCT") rail: String): Uni<Response> =
         triggerUseCase.triggerClearingCycle(PaymentRail.valueOf(rail))
             .map { Response.ok(it).build() }
-            .onFailure().recoverWithItem { e -> Response.serverError().entity(mapOf("error" to e.message)).build() }
 
     @GET
     @Path("/positions/{cycleId}")

--- a/openbank-dispute-service/src/main/kotlin/com/openbank/dispute/infrastructure/rest/ComplaintResource.kt
+++ b/openbank-dispute-service/src/main/kotlin/com/openbank/dispute/infrastructure/rest/ComplaintResource.kt
@@ -44,7 +44,6 @@ class ComplaintResource(
     @RolesAllowed("ROLE_OPERATOR", "ROLE_ADMIN", "ROLE_API")
     fun file(request: FileComplaintRequest): Uni<Response> =
         fileUseCase.file(request).map { Response.status(HTTP_CREATED).entity(it).build() }
-            .onFailure().recoverWithItem { e -> Response.serverError().entity(mapOf("error" to e.message)).build() }
 
     @GET
     @Authorize(action = "complaint.list")

--- a/openbank-dispute-service/src/main/kotlin/com/openbank/dispute/infrastructure/rest/DisputeResource.kt
+++ b/openbank-dispute-service/src/main/kotlin/com/openbank/dispute/infrastructure/rest/DisputeResource.kt
@@ -31,7 +31,6 @@ class DisputeResource(
     @RolesAllowed("ROLE_OPERATOR", "ROLE_ADMIN", "ROLE_API")
     fun open(request: OpenDisputeRequest): Uni<Response> =
         openUseCase.open(request).map { Response.status(201).entity(it).build() }
-            .onFailure().recoverWithItem { e -> Response.serverError().entity(mapOf("error" to e.message)).build() }
 
     @GET
     @Authorize(action = "dispute.list")
@@ -69,7 +68,6 @@ class DisputeResource(
     @Operation(summary = "Update dispute status/resolution")
     fun update(@PathParam("id") id: UUID, request: UpdateDisputeRequest): Uni<Response> =
         updateUseCase.update(id, request).map { Response.ok(it).build() }
-            .onFailure().recoverWithItem { e -> Response.serverError().entity(mapOf("error" to e.message)).build() }
 
     @POST
     @Path("/{id}/evidence")

--- a/openbank-interest-service/src/main/kotlin/com/openbank/interest/infrastructure/rest/InterestResource.kt
+++ b/openbank-interest-service/src/main/kotlin/com/openbank/interest/infrastructure/rest/InterestResource.kt
@@ -77,9 +77,9 @@ class InterestResource(
                 // No rate for this (account/product, currency): a client/config condition, not a 500.
                 Response.status(422).entity(mapOf("error" to e.message)).build()
             }
-            .onFailure().recoverWithItem { e ->
-                Response.serverError().entity(mapOf("error" to e.message)).build()
-            }
+        // The untyped `.onFailure().recoverWithItem { serverError }` that used to sit here is gone
+        // (#3057): it stamped 500 over failures libs-runtime already maps correctly — an
+        // IllegalArgumentException that should be 400, and now DateTimeException too.
     }
 
     @POST
@@ -103,7 +103,6 @@ class InterestResource(
     ): Uni<Response> =
         capitalizeUseCase.capitalize(accountId, productId, toDate?.let { LocalDate.parse(it) } ?: LocalDate.now(clock))
             .map { Response.ok(it).build() }
-            .onFailure().recoverWithItem { e -> Response.serverError().entity(mapOf("error" to e.message)).build() }
 
     @GET
     @Path("/accruals/{accountId}")
@@ -186,5 +185,4 @@ class InterestResource(
     @Authorize(action = "interest.delete", resource = "#id")
     fun deactivateRateConfig(@PathParam("id") id: UUID): Uni<Response> = rateConfigUseCase.deactivateConfig(id)
         .map { Response.ok(it).build() }
-        .onFailure().recoverWithItem { e -> Response.serverError().entity(mapOf("error" to e.message)).build() }
 }

--- a/openbank-interest-service/src/main/kotlin/com/openbank/interest/infrastructure/rest/WithholdingRemittanceResource.kt
+++ b/openbank-interest-service/src/main/kotlin/com/openbank/interest/infrastructure/rest/WithholdingRemittanceResource.kt
@@ -35,7 +35,6 @@ class WithholdingRemittanceResource(private val remitUseCase: RemitWithholdingUs
     fun assemble(@QueryParam("year") year: Int, @QueryParam("month") month: Int): Uni<Response> =
         remitUseCase.assembleRemittance(year, month)
             .map { Response.status(201).entity(it).build() }
-            .onFailure().recoverWithItem { e -> Response.serverError().entity(mapOf("error" to e.message)).build() }
 
     @GET
     @Authorize(action = "interest.list", resource = "")

--- a/openbank-libs-runtime/src/main/kotlin/com/openbank/libs/api/error/CommonExceptionMappers.kt
+++ b/openbank-libs-runtime/src/main/kotlin/com/openbank/libs/api/error/CommonExceptionMappers.kt
@@ -13,6 +13,7 @@ import jakarta.ws.rs.ext.ExceptionMapper
 import jakarta.ws.rs.ext.Provider
 import org.jboss.logging.Logger
 import org.jboss.logging.MDC
+import java.time.DateTimeException
 import java.util.UUID
 
 /**
@@ -47,6 +48,31 @@ class IllegalStateExceptionMapper : ExceptionMapper<IllegalStateException> {
             .entity(apiError(422, "BUSINESS_RULE_VIOLATION", exception.message ?: "Business rule violation"))
             .build()
     }
+}
+
+/**
+ * `DateTimeException` (and its `DateTimeParseException` subclass) → **400**.
+ *
+ * It extends `RuntimeException`, **not** `IllegalArgumentException`, so before this it fell all the
+ * way through to [GenericExceptionMapper] and every unparseable date rendered as a 500. Resources
+ * parse dates straight off the query string —
+ * `date?.let { LocalDate.parse(it) }` — and `?date=` or `?date=null` are non-null strings, so the
+ * `?.let` runs and `parse` throws.
+ *
+ * The first full authenticated-fuzz run hit this on five money-path endpoints (#3038): balance
+ * reconciliation, fx CNB ingest, interest accrue-all / capitalize / accruals. A client sending a bad
+ * date is a client error, and reporting it as 5xx inflates the error budget of those services and
+ * keeps the fuzz lane red forever.
+ *
+ * Safe to map globally, unlike a general "bad input" guess: a `DateTimeException` reaching a
+ * *resource boundary* is always a rejected value, never a server fault. A genuine server-side clock
+ * or zone bug would not surface here as an escaping exception from request handling.
+ */
+@Provider
+class DateTimeExceptionMapper : ExceptionMapper<DateTimeException> {
+    override fun toResponse(exception: DateTimeException): Response = Response.status(400)
+        .entity(apiError(400, ErrorCode.VALIDATION_ERROR.code, exception.message ?: "Invalid date or time value"))
+        .build()
 }
 
 @Provider

--- a/openbank-libs-runtime/src/main/kotlin/com/openbank/libs/api/error/CommonExceptionMappers.kt
+++ b/openbank-libs-runtime/src/main/kotlin/com/openbank/libs/api/error/CommonExceptionMappers.kt
@@ -70,9 +70,16 @@ class IllegalStateExceptionMapper : ExceptionMapper<IllegalStateException> {
  */
 @Provider
 class DateTimeExceptionMapper : ExceptionMapper<DateTimeException> {
-    override fun toResponse(exception: DateTimeException): Response = Response.status(400)
-        .entity(apiError(400, ErrorCode.VALIDATION_ERROR.code, exception.message ?: "Invalid date or time value"))
-        .build()
+    override fun toResponse(exception: DateTimeException): Response =
+        Response.status(ErrorCode.VALIDATION_ERROR.httpStatus)
+            .entity(
+                apiError(
+                    ErrorCode.VALIDATION_ERROR.httpStatus,
+                    ErrorCode.VALIDATION_ERROR.code,
+                    exception.message ?: "Invalid date or time value",
+                ),
+            )
+            .build()
 }
 
 @Provider

--- a/openbank-libs-runtime/src/test/kotlin/com/openbank/libs/api/error/DateTimeExceptionMapperTest.kt
+++ b/openbank-libs-runtime/src/test/kotlin/com/openbank/libs/api/error/DateTimeExceptionMapperTest.kt
@@ -1,0 +1,66 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright (c) OpenBank contributors. Licensed under the Apache License, Version 2.0.
+// See LICENSE in the repository root or https://www.apache.org/licenses/LICENSE-2.0 for details.
+
+package com.openbank.libs.api.error
+
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.Test
+import java.time.DateTimeException
+import java.time.LocalDate
+import java.time.MonthDay
+import java.time.format.DateTimeParseException
+
+/**
+ * The gap this closes is a type-hierarchy detail, so the tests are about the hierarchy.
+ *
+ * `DateTimeParseException` extends `DateTimeException` extends `RuntimeException` — **not**
+ * `IllegalArgumentException`, which is what everyone assumes. So it never matched
+ * [IllegalArgumentExceptionMapper] and fell through to [GenericExceptionMapper] as a 500. The first
+ * full authenticated-fuzz run hit that on five money-path endpoints (#3038) with inputs as ordinary
+ * as `?date=` and `?date=null`.
+ */
+class DateTimeExceptionMapperTest {
+
+    private val mapper = DateTimeExceptionMapper()
+
+    @Test
+    fun `the assumption that made this a 500 — it is NOT an IllegalArgumentException`() {
+        val thrown = runCatching { LocalDate.parse("") }.exceptionOrNull()!!
+
+        assertThat(thrown).isInstanceOf(DateTimeParseException::class.java)
+        assertThat(thrown).isInstanceOf(DateTimeException::class.java)
+        assertThat(thrown).isNotInstanceOf(IllegalArgumentException::class.java)
+    }
+
+    @Test
+    fun `an empty date query parameter maps to 400, not 500`() {
+        val thrown = runCatching { LocalDate.parse("") }.exceptionOrNull() as DateTimeException
+
+        assertThat(mapper.toResponse(thrown).status).isEqualTo(400)
+    }
+
+    @Test
+    fun `the literal string null maps to 400`() {
+        // `?date=null` is a non-null String, so a `date?.let { LocalDate.parse(it) }` runs and throws.
+        val thrown = runCatching { LocalDate.parse("null") }.exceptionOrNull() as DateTimeException
+
+        assertThat(mapper.toResponse(thrown).status).isEqualTo(400)
+    }
+
+    /** `?year=0` produced `Invalid value for MonthOfYear (valid values 1 - 12): 0` as a 500. */
+    @Test
+    fun `an out-of-range temporal value maps to 400`() {
+        val thrown = runCatching { MonthDay.of(0, 1) }.exceptionOrNull() as DateTimeException
+
+        val response = mapper.toResponse(thrown)
+
+        assertThat(response.status).isEqualTo(400)
+        assertThat(response.entity.toString()).contains("MonthOfYear")
+    }
+
+    @Test
+    fun `a message-less exception still yields a usable body`() {
+        assertThat(mapper.toResponse(DateTimeException(null)).status).isEqualTo(400)
+    }
+}


### PR DESCRIPTION
## Summary

Fixes both root causes behind the **non-body** 500s from #3038. Neither is a null body; both make a
**client error look like a server fault**.

## Type of change

- [x] fix (bug fix)

## Linked issues

Refs #3038, #3050, #2365

## A — `DateTimeException` was mapped nowhere in the fleet

`libs-runtime` maps `IllegalArgumentException` → 400, `IllegalStateException` → 422,
`NoSuchElementException` → 404, `Exception` → 500.

**`DateTimeParseException` extends `DateTimeException` extends `RuntimeException` — not
`IllegalArgumentException`**, which is the assumption everyone makes. So it fell straight through to
`GenericExceptionMapper` and rendered 500.

Resources parse dates off the query string:

```kotlin
accrueUseCase.accrueAll(date?.let { LocalDate.parse(it) } ?: LocalDate.now(clock))
```

`?date=` and `?date=null` are both **non-null strings**, so `?.let` runs and `parse` throws. Five
money-path endpoints, on trivially malformed input: balance reconciliation, fx CNB ingest, interest
accrue-all / capitalize / accruals.

**Adds `DateTimeExceptionMapper` → 400.** Safe to map globally, unlike a general "bad input" guess: a
`DateTimeException` escaping request handling at a resource boundary is always a rejected value,
never a server fault.

## B — ten handlers converted *every* failure into 500, defeating the mappers

```kotlin
.onFailure().recoverWithItem { e -> Response.serverError().entity(mapOf("error" to e.message)).build() }
```

Worse than a missing mapper: **the correct mapping already existed and the handler overrode it.**
`InterestService` fails with `IllegalArgumentException("Config not found")` — which `libs-runtime`
renders as **400** — and the catch-all stamped it **500**, printing the message into a server-error
body.

`?year=0` hit both causes at once: a `DateTimeException` from `MonthOfYear`, caught by the catch-all
and relabelled.

Removed all ten — clearing 3, dispute 2, complaint 1, interest 4. **The typed recovers are kept**:
`InterestResource.accrue`'s `onFailure(RateConfigNotFoundException) → 422` sits two lines from one of
the offenders and is exactly the right shape.

## Correction to my own count

The #3038 diagnosis said **nine**. It was **ten**. The grep behind that number required `serverError`
on the same line as `recoverWithItem`, so multi-line forms were invisible to it — the same class of
undercount the issue is about. Corrected here rather than quietly.

## Left alone, deliberately

`ComplaintResource` has three catch-alls mapping every failure to **404** instead of 500. Same
anti-pattern, opposite direction, and arguably worse — a database outage would report "complaint not
found".

But dispute-service was not in the fuzz matrix, so there is **no failing case** for them, and
changing untested behaviour on an evidence-free hunch is how regressions ship. **Flagged for a
reviewer's call**, not fixed.

## Why this matters past the status codes

- **5xx drives alerting and SLOs.** Malformed client input has been eating the error budget of five
  money-path services.
- The fuzz lane will keep reporting these forever while they are 5xx — they cannot be triaged away.
- `{"error":"Config not found"}` with status 500 tells a caller "we broke" when the truth is "you
  asked for something that does not exist".

## Verification

| Check | Result |
|---|---|
| Type hierarchy asserted directly (`DateTimeParseException` is **not** an `IllegalArgumentException`) | ✅ test |
| `?date=`, `?date=null`, `MonthOfYear` out-of-range → 400 | ✅ tests |
| Brace/paren balance per touched file after the removals | ✅ all zero |
| Typed recovers preserved, untyped removed | ✅ verified by reading each site |
| **Compiled** | ❌ — host Gradle cache corrupt; CI is the verifier |

## Definition of Done

- [x] Root cause established from the hierarchy and the source, not inferred from the symptom.
- [x] Unit tests pinned to the hierarchy detail that caused it.
- [x] Own miscount corrected in the open.
- [ ] Not compiled locally.
- [ ] Does not close #3038 — `POST /fees/post` still unexplained and needs its own repro.

## Security checklist

- [x] No secrets, no new dependency, no `@Suppress`.
- [x] Changes error responses on money-path services → `security-review-required`.
- [x] No success-path behaviour changes; only failure statuses move 5xx → 4xx.

## Compliance impact

- [x] DORA — error-rate signals on money-path services currently conflate client and server faults.
- [ ] PCI DSS / GDPR / PSD2 / AML / CNB — not applicable.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
