### PR TITLE
feat(observability): wire the Loki ruler up and give it the alerts only a log can carry

### DIFF
--- a/.github/scripts/check-loki-rules.py
+++ b/.github/scripts/check-loki-rules.py
@@ -1,0 +1,249 @@
+#!/usr/bin/env python3
+# SPDX-License-Identifier: Apache-2.0
+"""
+Load every committed Loki rule ConfigMap into a real Loki ruler and assert it accepts them.
+
+WHY THIS IS NOT OPTIONAL, and why structural YAML validation would not do.
+
+Loki's ruler lists rule groups per tenant as one operation. When ANY file in the tenant directory
+fails to parse, that operation fails wholesale:
+
+    msg="unable to list rules" err="failed to list rule groups for user fake: ...
+    error parsing /rules/fake/broken.yaml: could not parse expression for alert '...'"
+
+and `/prometheus/api/v1/rules` then returns an EMPTY group list. Measured, not assumed: with four
+valid rules loaded and healthy, adding one file with a single unbalanced parenthesis dropped the
+loaded groups from four to zero. So a typo in a new alert does not disable that alert — it disables
+every log-based alert in the estate, silently, with the ruler still running and Loki still ready.
+
+That is the worst possible blast radius for the cheapest possible mistake, and nothing else in this
+repo would catch it: `yamllint` sees valid YAML, ArgoCD syncs a valid ConfigMap, the sidecar copies
+a valid file, and the pod stays Running. The only signal is one ERROR line in the ruler's own log —
+which is exactly the class of failure these rules exist to catch, so relying on it would be circular.
+
+Structural validation cannot substitute: the failure is in the LogQL *expression*, and only a LogQL
+parser can judge it. Loki ships no `lokitool` in its container image (verified against
+grafana/loki:3.6.7 — `usr/bin/loki` is the only binary), so the parser we can reach is the ruler
+itself.
+
+Usage:
+    check-loki-rules.py                 # gate (exit 1 when the ruler rejects anything)
+    check-loki-rules.py --self-test     # prove the gate can fail
+
+Requires docker. Without it the check SKIPS with a warning and exit 0 — deliberately, so this
+cannot become a hard dependency that blocks unrelated work on a machine without docker; the CI job
+that runs it does have docker.
+"""
+from __future__ import annotations
+
+import argparse
+import json
+import shutil
+import subprocess
+import sys
+import tempfile
+import time
+import urllib.error
+import urllib.request
+from pathlib import Path
+
+try:
+    import yaml
+except ImportError:
+    sys.stderr.write("PyYAML required: pip install pyyaml\n")
+    sys.exit(2)
+
+REPO = Path(__file__).resolve().parents[2]
+COMPONENTS = REPO / "openbank-infra" / "gitops" / "components"
+LOKI_IMAGE = "grafana/loki:3.6.7"
+PORT = 13199
+CONTAINER = "openbank-loki-rule-check"
+
+# Minimal single-binary config whose ruler section mirrors apps/loki.yaml's: local rule storage in
+# /rules, single-tenant (auth_enabled: false, so the tenant directory is `fake`). Storage is
+# filesystem rather than S3 because this only exercises the RULE PARSER, and an S3 dependency would
+# make the gate fail for reasons that have nothing to do with the rules.
+LOKI_CONFIG = """
+auth_enabled: false
+server:
+  http_listen_port: 3100
+common:
+  path_prefix: /loki
+  replication_factor: 1
+  ring:
+    kvstore:
+      store: inmemory
+  storage:
+    filesystem:
+      chunks_directory: /loki/chunks
+      rules_directory: /loki/rules-tmp
+schema_config:
+  configs:
+    - from: "2024-04-01"
+      store: tsdb
+      object_store: filesystem
+      schema: v13
+      index:
+        prefix: index_
+        period: 24h
+ruler:
+  enable_api: true
+  storage:
+    type: local
+    local:
+      directory: /rules
+  rule_path: /tmp/loki-rules
+  ring:
+    kvstore:
+      store: inmemory
+"""
+
+
+def rule_configmaps(root: Path) -> dict[str, str]:
+    """{filename: rule-file body} for every ConfigMap labelled loki_rule.
+
+    Derived from the label the Loki sidecar actually selects on, not from a hand-kept path list —
+    a rules ConfigMap added in a new directory is in scope automatically. The label IS the contract.
+    """
+    out: dict[str, str] = {}
+    for f in sorted(root.rglob("*.yaml")):
+        text = f.read_text(encoding="utf-8", errors="ignore")
+        if "loki_rule" not in text:
+            continue
+        for doc in yaml.safe_load_all(text):
+            if not isinstance(doc, dict) or doc.get("kind") != "ConfigMap":
+                continue
+            if "loki_rule" not in (doc.get("metadata", {}).get("labels") or {}):
+                continue
+            for key, body in (doc.get("data") or {}).items():
+                out[f"{doc['metadata']['name']}__{key}"] = body
+    return out
+
+
+def _get(url: str, timeout: float = 5.0) -> str | None:
+    try:
+        with urllib.request.urlopen(url, timeout=timeout) as r:
+            return r.read().decode()
+    except (urllib.error.URLError, OSError):
+        return None
+
+
+def load_into_ruler(bodies: dict[str, str], quiet: bool = False) -> tuple[bool, str]:
+    """-> (accepted, detail). accepted is False when the ruler lists fewer groups than we gave it."""
+    tmp = Path(tempfile.mkdtemp())
+    rules_dir = tmp / "rules" / "fake"
+    rules_dir.mkdir(parents=True)
+    (tmp / "config.yaml").write_text(LOKI_CONFIG)
+    expected_groups = 0
+    for name, body in bodies.items():
+        (rules_dir / f"{name}.yaml").write_text(body)
+        doc = yaml.safe_load(body) or {}
+        expected_groups += len(doc.get("groups") or [])
+
+    subprocess.run(["docker", "rm", "-f", CONTAINER], capture_output=True)
+    run = subprocess.run(
+        ["docker", "run", "-d", "--name", CONTAINER, "-p", f"{PORT}:3100",
+         "-v", f"{tmp / 'config.yaml'}:/etc/loki/local-config.yaml",
+         "-v", f"{tmp / 'rules'}:/rules", LOKI_IMAGE,
+         "-config.file=/etc/loki/local-config.yaml"],
+        capture_output=True, text=True)
+    if run.returncode != 0:
+        return False, f"could not start {LOKI_IMAGE}: {run.stderr.strip()[:300]}"
+    try:
+        deadline = time.monotonic() + 120
+        while time.monotonic() < deadline:
+            if (_get(f"http://localhost:{PORT}/ready") or "").strip().startswith("ready"):
+                break
+            time.sleep(2)
+        else:
+            return False, "Loki never became ready within 120s"
+
+        # The ruler lists lazily; poll until it reports the expected count or we run out of patience.
+        deadline = time.monotonic() + 60
+        loaded: list[str] = []
+        while time.monotonic() < deadline:
+            raw = _get(f"http://localhost:{PORT}/prometheus/api/v1/rules")
+            if raw:
+                groups = (json.loads(raw).get("data") or {}).get("groups") or []
+                loaded = [g["name"] for g in groups]
+                if len(loaded) >= expected_groups:
+                    break
+            time.sleep(2)
+
+        if len(loaded) < expected_groups:
+            logs = subprocess.run(["docker", "logs", CONTAINER], capture_output=True, text=True)
+            err = [ln for ln in (logs.stderr + logs.stdout).splitlines()
+                   if "unable to list rules" in ln or "error parsing" in ln]
+            return False, (
+                f"ruler loaded {len(loaded)} group(s), expected {expected_groups}. "
+                f"A SINGLE unparseable file empties the whole list, so the broken rule may not be "
+                f"the one you just added. Ruler said: "
+                + (err[-1][:600] if err else "(no parse error logged)"))
+        if not quiet:
+            print(f"  ruler accepted {len(loaded)} group(s): {', '.join(sorted(loaded))}")
+        return True, ""
+    finally:
+        subprocess.run(["docker", "rm", "-f", CONTAINER], capture_output=True)
+
+
+def run_gate() -> int:
+    if not shutil.which("docker"):
+        print("::warning title=Loki rules::docker not available — skipping the Loki rule load test. "
+              "The CI job that gates this does have docker.")
+        return 0
+    bodies = rule_configmaps(COMPONENTS)
+    if not bodies:
+        print("check-loki-rules: no ConfigMaps labelled loki_rule found — nothing to check.")
+        return 0
+    print(f"check-loki-rules: loading {len(bodies)} rule file(s) into {LOKI_IMAGE}")
+    ok, detail = load_into_ruler(bodies)
+    if ok:
+        print("check-loki-rules: every committed Loki rule file parses.")
+        return 0
+    print(f"::error title=Loki rules::{detail}")
+    return 1
+
+
+def self_test() -> int:
+    """A gate that has only ever passed is unfalsified. Feed it a file it MUST reject."""
+    if not shutil.which("docker"):
+        print("::warning title=Loki rules::docker not available — cannot run the self-test.")
+        return 0
+    failures = []
+    good = {"good": yaml.safe_dump({"groups": [{
+        "name": "selftest.good", "interval": "5m", "rules": [{
+            "alert": "SelfTestGood",
+            "expr": 'sum by (namespace) (count_over_time({namespace=~".+"} |= "x" [15m])) > 0',
+            "labels": {"severity": "warning"}}]}]})}
+    # Unbalanced parenthesis: valid YAML, invalid LogQL — the exact shape yamllint cannot see.
+    bad = dict(good, bad='groups:\n  - name: selftest.bad\n    rules:\n      - alert: SelfTestBad\n'
+                         '        expr: sum by (namespace ( count_over_time({namespace=~".+"} |= "x" [15m])\n')
+
+    print("self-test: the case the gate MUST pass")
+    ok, detail = load_into_ruler(good)
+    print(f"  {'ok  ' if ok else 'FAIL'} a valid rule file is accepted" + ("" if ok else f" — {detail}"))
+    if not ok:
+        failures.append("valid rule rejected")
+
+    print("self-test: the case the gate MUST flag")
+    ok, _ = load_into_ruler(bad, quiet=True)
+    print(f"  {'ok  ' if not ok else 'FAIL'} a file with unparseable LogQL is rejected")
+    if ok:
+        failures.append("broken rule accepted")
+
+    if failures:
+        print(f"\n::error::check-loki-rules --self-test: {', '.join(failures)}")
+        return 1
+    print("\nself-test passed: the gate accepts valid LogQL and rejects a broken file.")
+    return 0
+
+
+def main() -> int:
+    ap = argparse.ArgumentParser()
+    ap.add_argument("--self-test", action="store_true", help="prove the gate can fail")
+    args = ap.parse_args()
+    return self_test() if args.self_test else run_gate()
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/.github/scripts/check-loki-rules.py
+++ b/.github/scripts/check-loki-rules.py
@@ -27,8 +27,9 @@ grafana/loki:3.6.7 — `usr/bin/loki` is the only binary), so the parser we can 
 itself.
 
 Usage:
-    check-loki-rules.py                 # gate (exit 1 when the ruler rejects anything)
-    check-loki-rules.py --self-test     # prove the gate can fail
+    check-loki-rules.py                       # always run the load test
+    check-loki-rules.py --since origin/main   # run it only when a rule input changed (CI)
+    check-loki-rules.py --self-test           # prove the gate can fail
 
 Requires docker. Without it the check SKIPS with a warning and exit 0 — deliberately, so this
 cannot become a hard dependency that blocks unrelated work on a machine without docker; the CI job
@@ -238,11 +239,60 @@ def self_test() -> int:
     return 0
 
 
+# What this gate costs, stated rather than assumed (the house rule is to quantify FinOps with a
+# denominator). Booting a real Loki means pulling ~100 MB and waiting ~25 s for readiness, so a full
+# run adds roughly 90 s. It lives in `Validate manifests`, which is UNCONDITIONAL and required — so
+# without scoping, every PR in the fleet pays that, including the overwhelming majority that touch
+# no rule at all. Direct dollar cost is $0 (public repo, GitHub-hosted runners are free), but 90 s
+# on a required check is 90 s every contributor waits, on every PR, forever.
+#
+# So the expensive part is scoped to the PRs that can actually invalidate it, and the STEP still
+# runs unconditionally and PRINTS what it decided. That distinction matters: a path-filtered
+# workflow can never be a required check (a required context that never reports blocks every PR
+# that misses its paths), and a step that silently no-ops reads exactly like a step that passed.
+# This one says which it did.
+RULE_INPUTS = [
+    "openbank-infra/gitops/components",       # where loki_rule ConfigMaps live
+    "openbank-infra/gitops/apps/loki.yaml",   # the ruler config the rules load under
+    ".github/scripts/check-loki-rules.py",    # the gate itself
+]
+
+
+def rule_inputs_changed(base_ref: str) -> tuple[bool, str]:
+    """-> (changed, detail). Fails OPEN: an unanswerable git question runs the check."""
+    try:
+        out = subprocess.run(
+            ["git", "diff", "--name-only", f"{base_ref}...HEAD", "--", *RULE_INPUTS],
+            capture_output=True, text=True, cwd=REPO, check=True).stdout
+    except (subprocess.CalledProcessError, OSError) as ex:
+        # Never skip because git was unhappy — that would turn an infrastructure hiccup into a
+        # silently unchecked rule set, which is the failure mode this whole file exists to prevent.
+        return True, f"could not diff against {base_ref} ({ex}) — running the load test anyway"
+    files = [f for f in out.splitlines() if f.strip()]
+    if not files:
+        return False, f"no rule inputs changed vs {base_ref}"
+    return True, f"{len(files)} rule input(s) changed vs {base_ref}: {', '.join(files[:5])}"
+
+
 def main() -> int:
     ap = argparse.ArgumentParser()
     ap.add_argument("--self-test", action="store_true", help="prove the gate can fail")
+    ap.add_argument("--since", metavar="REF",
+                    help="skip the load test when no rule input changed vs REF (e.g. origin/main). "
+                         "Omit to always run.")
     args = ap.parse_args()
-    return self_test() if args.self_test else run_gate()
+    if args.self_test:
+        return self_test()
+    if args.since:
+        changed, detail = rule_inputs_changed(args.since)
+        if not changed:
+            n = len(rule_configmaps(COMPONENTS))
+            print(f"check-loki-rules: SKIPPED the Loki load test — {detail}. "
+                  f"{n} rule file(s) in tree, unchanged by this PR, and validated on the PR that "
+                  f"last touched them.")
+            return 0
+        print(f"check-loki-rules: {detail}")
+    return run_gate()
 
 
 if __name__ == "__main__":

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -405,6 +405,21 @@ jobs:
       - name: "PodMonitor namespace coverage (issue #2255, enforced)"
         run: python3 .github/scripts/check-podmonitor-namespace-coverage.py
 
+      # Loki's ruler lists rule groups per tenant as ONE operation, so a single unparseable file
+      # fails the whole listing and /prometheus/api/v1/rules returns an EMPTY group list. Measured:
+      # four valid, healthy rules plus one file with an unbalanced parenthesis took the loaded
+      # groups from four to zero. A typo in a new alert therefore disables EVERY log-based alert in
+      # the estate, silently — the ruler keeps running, Loki stays ready, the ConfigMap is valid
+      # YAML, and ArgoCD syncs it green. The only signal is one ERROR line in the ruler's own log,
+      # which is the very class of failure these rules exist to catch, so relying on it is circular.
+      # yamllint cannot help: the defect is in the LogQL expression, and Loki ships no lokitool in
+      # its image, so the only reachable LogQL parser is a real ruler. The self-test runs first and
+      # feeds it a file it MUST reject.
+      - name: "Loki rule load test self-test"
+        run: python3 .github/scripts/check-loki-rules.py --self-test
+      - name: "Loki rule load test (enforced)"
+        run: python3 .github/scripts/check-loki-rules.py
+
       # issue #2280. This repo is a MULTI-LICENSE tree: Apache-2.0 at the root (ADR-0123) with an
       # AGPL-3.0-only open-core subset (ADR-0136, extended by ADR-0181 and ADR-0193). NOTHING
       # compared the per-file SPDX headers against that declaration — no reuse-tool, no licensee,

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -417,8 +417,16 @@ jobs:
       # feeds it a file it MUST reject.
       - name: "Loki rule load test self-test"
         run: python3 .github/scripts/check-loki-rules.py --self-test
+      # --since scopes the EXPENSIVE half (pull ~100 MB + boot Loki, ~90 s) to PRs that can
+      # actually invalidate it. This job is unconditional and required, so an unscoped run charged
+      # every PR in the fleet 90 s for a check about files it did not touch. Direct cost is $0
+      # (public repo, GitHub-hosted runners), but 90 s on a required check is 90 s every
+      # contributor waits on every PR. The STEP still runs unconditionally and prints whether it
+      # loaded or skipped and why — a step that silently no-ops reads exactly like one that passed.
       - name: "Loki rule load test (enforced)"
-        run: python3 .github/scripts/check-loki-rules.py
+        run: |
+          git fetch origin "${{ github.base_ref || github.ref_name }}:refs/remotes/origin/${{ github.base_ref || github.ref_name }}" --no-tags || true
+          python3 .github/scripts/check-loki-rules.py --since "origin/${{ github.base_ref || github.ref_name }}"
 
       # issue #2280. This repo is a MULTI-LICENSE tree: Apache-2.0 at the root (ADR-0123) with an
       # AGPL-3.0-only open-core subset (ADR-0136, extended by ADR-0181 and ADR-0193). NOTHING

--- a/openbank-infra/gitops/apps/loki.yaml
+++ b/openbank-infra/gitops/apps/loki.yaml
@@ -100,8 +100,33 @@ spec:
           compactor:
             retention_enabled: true
             delete_request_store: s3
+          # RULER (log-based alerting). enable_api alone was all this had, and it delivered
+          # nothing: there was no alertmanager_url, so a firing rule had nowhere to go, and there
+          # were no rules at all — the whole feature was configured-looking and inert. Meanwhile
+          # several of this repo's most expensive incidents left their ONLY evidence in a log line
+          # (HR000068 schedulers that had never run, SRCFG00040 at boot, the persist-vs-merge
+          # duplicate-key 500s, fx-service's "skipping its revaluation leg"), and no metric existed
+          # for any of them.
           ruler:
             enable_api: true
+            # Rules come from ConfigMaps in git via the chart's k8s-sidecar (see sidecar.rules
+            # below), so the ruler reads them off local disk. This deliberately does NOT use the
+            # S3 `ruler` bucket configured above: S3 ruler storage is written through the ruler
+            # API, which would make the rules a mutable runtime object rather than a reviewed
+            # artifact — the exact "derived data hand-edited in place" shape the house rules forbid.
+            storage:
+              type: local
+              local:
+                directory: /rules
+            # Loki is single-tenant here (auth_enabled: false), so the sidecar's folder must be the
+            # "fake" tenant directory the ruler looks in.
+            rule_path: /tmp/loki-rules
+            ring:
+              kvstore:
+                store: inmemory
+            # The missing half. Without this a rule evaluates, fires, and is delivered nowhere.
+            alertmanager_url: http://kube-prometheus-stack-alertmanager.observability.svc:9093
+            enable_alertmanager_v2: true
           # Single-binary needs the embedded query scheduler off.
           querier:
             max_concurrent: 2
@@ -156,6 +181,14 @@ spec:
         sidecar:
           image:
             repository: kiwigrid/k8s-sidecar
+          # Watch for ConfigMaps labelled loki_rule=1 and drop them into the ruler's local
+          # directory, so a log-based alert is a reviewed file in git like every PrometheusRule.
+          rules:
+            enabled: true
+            label: loki_rule
+            labelValue: "1"
+            searchNamespace: observability
+            folder: /rules/fake
   destination:
     server: https://kubernetes.default.svc
     namespace: observability

--- a/openbank-infra/gitops/components/observability/loki-rules-silent-failures.yaml
+++ b/openbank-infra/gitops/components/observability/loki-rules-silent-failures.yaml
@@ -1,0 +1,122 @@
+# Log-based alerting (Loki ruler) — the failures that only ever appear in a log line.
+#
+# Delivered as a ConfigMap labelled loki_rule=1; the Loki chart's k8s-sidecar drops it into the
+# ruler's local rules directory (see sidecar.rules in apps/loki.yaml). A rule here is a reviewed
+# file in git, exactly like a PrometheusRule — never pushed through the ruler API.
+#
+# WHY THESE FOUR. Each one is a failure this repo has already paid for, whose ONLY evidence anywhere
+# was a log line, and for which no metric exists or could easily exist:
+#
+#   HR000068                        five @Scheduled methods, three money-path, had NEVER run. A
+#                                   plain @Scheduled method carries no Vert.x context, so
+#                                   runBlocking around reactive Panache throws before the per-item
+#                                   try/catch. The job aborts having done nothing — no failed
+#                                   counter increments, because nothing got far enough to count.
+#   SRCFG00040                       a missing @ConfigProperty value throws at boot. The pod
+#                                   crashloops, which IS visible — but the reason is not, and
+#                                   "which config key" is the entire diagnosis.
+#   duplicate key ... _pkey          Panache persist() on an application-assigned @Id is INSERT-only,
+#                                   so every lifecycle transition 500s (ADR-0126 D3, #1521).
+#                                   Invisible to unit tests that mock the repository.
+#   skipping its revaluation leg     fx-service's FxRevaluationService found no valid rate, logged
+#                                   this, and returned posted=false — a successful-looking run of a
+#                                   job that revalued nothing, for the entire life of the service.
+#                                   The only other evidence was a table that stopped growing, and
+#                                   nothing alerts on a table not growing.
+#
+# All four are `warning`, none pages. They mean "a thing you believe is running is not", which is
+# urgent to know and not urgent at 03:00 — and alert fatigue is already this estate's documented
+# root cause, so a new rule that pages is a regression even when it is correct.
+#
+# Retention is 7d (ADR-0088 D3), so these windows must stay well inside it.
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: loki-rules-silent-failures
+  namespace: observability
+  labels:
+    loki_rule: "1"
+    app.kubernetes.io/part-of: observability
+data:
+  silent-failures.yaml: |
+    groups:
+      - name: openbank.logs.silent-failures
+        interval: 5m
+        rules:
+          # A scheduler that aborts on the missing Vert.x context. `HR000068` is Hibernate
+          # Reactive's own code, so this matches the exception rather than our prose about it —
+          # prose gets reworded, an exception code does not.
+          - alert: SchedulerMissingVertxContext
+            expr: |
+              sum by (namespace, app) (
+                count_over_time({namespace=~".+"} |= "HR000068" [15m])
+              ) > 0
+            for: 5m
+            labels:
+              severity: warning
+              team: platform
+            annotations:
+              summary: "{{ $labels.app }} in {{ $labels.namespace }} logged HR000068 — a scheduled job aborted"
+              description: >-
+                A @Scheduled method reached reactive Panache with no Vert.x context and threw before
+                doing any work. The job did NOT run, and no failure counter incremented because
+                nothing got far enough to count. Make the method a `suspend fun` — never
+                runBlocking, never VertxContextSupport (rules.yaml: scheduled_methods).
+
+          # A missing config value at boot. The crashloop is visible in kube-state-metrics; WHICH
+          # key is missing is only ever in this line, and it is the whole diagnosis.
+          - alert: ConfigPropertyMissingAtBoot
+            expr: |
+              sum by (namespace, app) (
+                count_over_time({namespace=~".+"} |= "SRCFG00040" [15m])
+              ) > 0
+            for: 5m
+            labels:
+              severity: warning
+              team: platform
+            annotations:
+              summary: "{{ $labels.app }} in {{ $labels.namespace }} failed config load (SRCFG00040)"
+              description: >-
+                A @ConfigProperty has no value and no default, so the pod cannot start. Optional
+                fields must be Optional<String> with a defaultValue. The failing key is named in
+                the log line this alert matched.
+
+          # persist() on an application-assigned @Id. Every lifecycle transition 500s, and a
+          # repository-mocking unit test cannot see it.
+          - alert: PanacheAssignedIdInsertOnly
+            expr: |
+              sum by (namespace, app) (
+                count_over_time({namespace=~".+"} |= "duplicate key value violates" [15m])
+              ) > 0
+            for: 5m
+            labels:
+              severity: warning
+              team: platform
+            annotations:
+              summary: "{{ $labels.app }} in {{ $labels.namespace }} hit a duplicate-key violation on flush"
+              description: >-
+                Usually Panache persist() on an aggregate whose @Id is set by the application:
+                Hibernate schedules an INSERT and never an UPDATE, so every update fails at flush
+                (ADR-0126 D3, #1521). Use Panache.getSession().flatMap { it.merge(entity) }. Not
+                always this cause — a genuine unique-constraint clash looks the same — so read the
+                constraint name in the line.
+
+          # A job that completed successfully having done nothing. The hardest class to alert on,
+          # because every metric it touches reports a healthy run.
+          - alert: FxRevaluationSkippedAllLegs
+            expr: |
+              sum by (namespace) (
+                count_over_time({namespace="fx"} |= "skipping its revaluation leg" [1h])
+              ) > 0
+            for: 15m
+            labels:
+              severity: warning
+              team: platform
+            annotations:
+              summary: "fx-service revalued nothing — no valid rate available"
+              description: >-
+                FxRevaluationService found no usable rate and returned posted=false. The run looks
+                successful from every angle: no exception, no failed counter, a green job. The only
+                other evidence is a table that stops growing, and nothing alerts on that. Check the
+                ČNB feed first (check-external-feeds.py probes the URL's payload SHAPE, not its
+                status code — a 404 HTML page is a perfectly valid HTTP response).


### PR DESCRIPTION
## Summary

The Loki ruler had `enable_api: true` and nothing else — no `alertmanager_url`, so a firing rule had nowhere to deliver, and no rules anywhere in the repo. The feature was configured-looking and completely inert. This wires it up, adds the four alerts only a log line can carry, and adds a gate that turned out to matter more than the rules.

## Type of change

- [x] feat (new functionality)

## Linked issues

Closes #3062
Refs ADR-0088, #2148, #2187, #1521

## Why these four rules

Each is a failure this estate has already paid for, whose only evidence anywhere was a log line, and for which no metric exists or could easily exist:

| match | what it means |
|---|---|
| `HR000068` | Five `@Scheduled` methods, three money-path, had **never run**. The throw lands before the per-item try/catch, so nothing counted a failure — the job simply did nothing, forever. |
| `SRCFG00040` | A missing `@ConfigProperty` kills the pod at boot. The crashloop is visible; *which key* is only in the log, and that is the whole diagnosis. |
| `duplicate key ... _pkey` | Panache `persist()` on an application-assigned `@Id` is INSERT-only, so every lifecycle transition 500s (ADR-0126 D3). Invisible to a repository-mocking unit test. |
| `skipping its revaluation leg` | fx-service found no valid rate and returned `posted=false` — a successful-looking run of a job that revalued nothing, for the service's entire life. The only other evidence was a table that stopped growing, and nothing alerts on that. |

All four are `warning`; **none pages**. They mean "something you believe is running is not" — urgent to know, not urgent at 03:00. Alert fatigue is already this estate's documented root cause, so a new rule that pages is a regression even when correct.

## Delivery

Rules are ConfigMaps labelled `loki_rule=1`, picked up by the chart's k8s-sidecar into the ruler's **local** directory. Deliberately *not* the S3 `ruler` bucket already configured: S3 ruler storage is written through the ruler API, which would make the rules a mutable runtime object instead of a reviewed artifact — the "derived data edited in place" shape the house rules forbid.

## ⚠️ The new gate, and why falsifying this mattered more than the rules

Loki's ruler lists rule groups per tenant as **one operation**. When any file fails to parse, the whole listing fails and `/prometheus/api/v1/rules` returns an **empty** group list.

Measured, not assumed: with the four rules above loaded and `health=ok`, adding a single file with one unbalanced parenthesis took the loaded groups from **four to zero**.

So a typo in a new alert does not disable that alert — **it disables every log-based alert in the estate**, silently, while the ruler keeps running, Loki stays ready, the ConfigMap is valid YAML and ArgoCD syncs it green. The only signal is an ERROR line in the ruler's own log, which is precisely the class of failure these rules exist to catch, so relying on it would be circular.

`check-loki-rules.py` loads every committed `loki_rule` ConfigMap into a real Loki and asserts the ruler accepts them:

- Structural validation cannot substitute — the defect is in the **LogQL expression**.
- Loki ships no `lokitool` in its image (verified against `grafana/loki:3.6.7`: `usr/bin/loki` is the only binary), so the only reachable LogQL parser is a real ruler.
- Its scope is derived from the `loki_rule` label the sidecar itself selects on, not a path list, so a rules ConfigMap added in a new directory is in scope automatically.
- Skips with a warning where docker is absent; the CI job that gates it has docker.
- Wired into `Validate manifests` in `ci.yml`, self-test first — the unconditional job, not a path-filtered workflow that could never be a required check.

## Falsification

- Ran a real Loki 3.6.7 with this exact ruler config and the rules mounted: all four groups load and reach `health=ok` with no `lastError`.
- The four-to-zero blast-radius result above is from that run, not from reasoning.
- `check-loki-rules.py --self-test`: accepts a valid file, rejects an unparseable one. Both directions, so the gate's green is a measurement.
- actionlint finding **sets** diffed against `origin/main`: 2 vs 2, no new findings. (Post-filtering actionlint output has previously hidden a YAML error introduced in the same change — this repo has that scar, so sets are diffed rather than output grepped.)
- yamllint with `ci.yml`'s own inline config: the 3 warnings on `ci.yml` are present on unmodified `main` too.

## Definition of Done

- [x] Hexagonal layering — n/a, infra + CI tooling.
- [x] Tests: the gate's own self-test, both directions.
- [ ] Integration / contract tests — n/a.
- [ ] `./gradlew ...` — n/a, no Kotlin change.
- [x] No new lint warnings (finding sets diffed against main).
- [ ] OpenAPI / Flyway / Avro — n/a.
- [x] Docs updated — the ConfigMap records why each rule exists; the gate's docstring records the blast radius that justifies it.

## Security checklist

- [x] No secrets, tokens, passwords, or PII in code, config, tests, logs. The alert annotations quote exception codes and fixed strings, never log content — a `{{ $labels }}` expansion of a matched line could carry PII, so the rules deliberately alert on counts only.
- [x] No new `@SuppressWarnings` / `@Suppress`.
- [x] No new third-party dependency at runtime; the gate pulls the same `grafana/loki` image already deployed.
- [x] No auth / crypto / payment code changed.
- [x] No PII path changed — see the annotation note above.
- [x] No cardholder data path changed.

## Compliance impact

- [x] DORA — ICT incident detection: four documented silent-failure classes move from undetectable to alerted.

## Deployment note

`rules.yaml` and the `.rego` policies are untouched, so no OPA bundle restamp. Loki restarts to pick up the ruler config; the sidecar then mounts the rules. Retention is 7d (ADR-0088 D3), so all rule windows (15m–1h) sit well inside it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

