### PR TITLE
feat(campaign): page and filter the send log instead of reading it whole

### DIFF
--- a/openbank-admin-ui/src/app/api/campaigns/[id]/route.ts
+++ b/openbank-admin-ui/src/app/api/campaigns/[id]/route.ts
@@ -14,6 +14,8 @@ export const dynamic = 'force-dynamic'
 
 type Part = { data: unknown; state: 'ok' | 'unauthorized' | 'not_deployed' | 'unreachable' }
 
+const EMPTY_SENDS = { items: [], total: 0, page: 0, size: 0 }
+
 async function read(headers: HeadersInit, path: string, fallback: unknown): Promise<Part> {
   try {
     const res = await fetch(serverSvcUrl('campaign-service', 'campaign', 8128, path), {
@@ -49,19 +51,31 @@ export async function GET(_req: Request, ctx: { params: Promise<{ id: string }> 
   const { id } = await ctx.params
   const headers = { authorization: `Bearer ${session.user.accessToken}` }
 
-  const [campaign, enrolments, sends] = await Promise.all([
+  const [campaign, enrolments, sends, sendSummary] = await Promise.all([
     read(headers, `/api/v1/campaigns/${encodeURIComponent(id)}`, null),
     read(headers, `/api/v1/campaigns/${encodeURIComponent(id)}/enrolments`, []),
-    read(headers, `/api/v1/campaigns/${encodeURIComponent(id)}/sends`, []),
+    // First page only. Paging and filtering go through /api/campaigns/[id]/sends so turning a
+    // page does not re-read the campaign and its enrolments.
+    read(headers, `/api/v1/campaigns/${encodeURIComponent(id)}/sends?page=0&size=50`, EMPTY_SENDS),
+    // Counts come from the service, not from the page above: a suppressed-total derived from the
+    // rows on screen understates every campaign larger than one page, and that total is the number
+    // an operator acts on.
+    read(headers, `/api/v1/campaigns/${encodeURIComponent(id)}/sends/summary`, {}),
   ])
 
   return NextResponse.json({
     campaign: campaign.data,
     enrolments: enrolments.data,
     sends: sends.data,
+    sendSummary: sendSummary.data,
     // Per-part state travels to the client: the send log is the part most likely to be
     // restricted, and an empty send log rendered as "nothing was suppressed" would be the
     // exact misreading this screen exists to prevent.
-    sources: { campaign: campaign.state, enrolments: enrolments.state, sends: sends.state },
+    sources: {
+      campaign: campaign.state,
+      enrolments: enrolments.state,
+      sends: sends.state,
+      sendSummary: sendSummary.state,
+    },
   })
 }

--- a/openbank-admin-ui/src/app/api/campaigns/[id]/sends/route.ts
+++ b/openbank-admin-ui/src/app/api/campaigns/[id]/sends/route.ts
@@ -1,0 +1,63 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright (c) OpenBank contributors. Licensed under the Apache License, Version 2.0.
+// See LICENSE in the repository root or https://www.apache.org/licenses/LICENSE-2.0 for details.
+
+// Paging and filtering the send log on its own route, separate from the campaign detail bundle.
+// The bundle exists because a campaign, its enrolments and its send log are only meaningful
+// together — but turning a page is not a reason to re-read the other two.
+
+import { NextResponse } from 'next/server'
+import { auth } from '@/auth'
+import { serverSvcUrl } from '@/lib/services/bff'
+
+export const dynamic = 'force-dynamic'
+
+const EMPTY = { items: [], total: 0, page: 0, size: 0 }
+
+export async function GET(req: Request, ctx: { params: Promise<{ id: string }> }) {
+  const session = await auth()
+  if (!session?.user?.accessToken) {
+    return NextResponse.json({ error: 'unauthenticated' }, { status: 401 })
+  }
+  const { id } = await ctx.params
+  const incoming = new URL(req.url).searchParams
+
+  // Forward only the parameters this endpoint defines. Passing the query string through wholesale
+  // would let anything the browser appends reach the service unexamined.
+  const qs = new URLSearchParams()
+  for (const key of ['outcome', 'page', 'size']) {
+    const value = incoming.get(key)
+    if (value) qs.set(key, value)
+  }
+
+  const path = `/api/v1/campaigns/${encodeURIComponent(id)}/sends?${qs.toString()}`
+  try {
+    const res = await fetch(serverSvcUrl('campaign-service', 'campaign', 8128, path), {
+      headers: { authorization: `Bearer ${session.user.accessToken}` },
+      signal: AbortSignal.timeout(6000),
+      cache: 'no-store',
+    })
+    if (!res.ok) {
+      // A refused or failed read must never arrive as an empty page with state 'ok': an empty send
+      // log renders as "nothing was suppressed", which is the exact misreading this screen exists
+      // to prevent.
+      return NextResponse.json(
+        {
+          ...EMPTY,
+          state:
+            res.status === 401 || res.status === 403
+              ? 'unauthorized'
+              : res.status === 400
+                ? 'bad_request'
+                : res.status === 404
+                  ? 'not_deployed'
+                  : 'unreachable',
+        },
+        { status: 200 },
+      )
+    }
+    return NextResponse.json({ ...(await res.json()), state: 'ok' })
+  } catch {
+    return NextResponse.json({ ...EMPTY, state: 'unreachable' }, { status: 200 })
+  }
+}

--- a/openbank-admin-ui/src/app/campaigns/[id]/page.tsx
+++ b/openbank-admin-ui/src/app/campaigns/[id]/page.tsx
@@ -37,12 +37,23 @@ interface Send {
   occurredAt: string
 }
 
+interface SendPage {
+  items: Send[]
+  total: number
+  page: number
+  size: number
+}
+
 type Detail = {
   campaign: Campaign | null
   enrolments: Enrolment[]
-  sends: Send[]
+  sends: SendPage
+  sendSummary: Record<string, number>
   sources: Record<string, string>
 }
+
+/** Outcomes the send-log filter offers, in the order an operator scans them. */
+const OUTCOMES = ['SENT', 'FAILED', 'SUPPRESSED_CONSENT', 'SUPPRESSED_CAP', 'SUPPRESSED_QUIET_HOURS'] as const
 
 /**
  * Outcome colouring, passed explicitly rather than added to the shared tone map (see `tone.ts`:
@@ -89,8 +100,44 @@ export default function CampaignDetailPage({ params }: { params: Promise<{ id: s
   }, [id])
 
   const c = detail?.campaign
-  const sends = detail?.sends ?? []
-  const suppressed = sends.filter(s => s.outcome.startsWith('SUPPRESSED')).length
+
+  // The bundle carries page 0; every later page and every filter change comes from the dedicated
+  // sends route, so turning a page does not re-read the campaign and its enrolments.
+  const [sendOverride, setSendOverride] = useState<SendPage | null>(null)
+  const [sendState, setSendState] = useState<string>('ok')
+  const [outcomeFilter, setOutcomeFilter] = useState<string>('')
+  const [sendsLoading, setSendsLoading] = useState(false)
+
+  const sendPage = sendOverride ?? detail?.sends ?? { items: [], total: 0, page: 0, size: 50 }
+  const sends = sendPage.items
+
+  const loadSends = (page: number, outcome: string) => {
+    setSendsLoading(true)
+    const qs = new URLSearchParams({ page: String(page), size: String(sendPage.size || 50) })
+    if (outcome) qs.set('outcome', outcome)
+    fetch(`/api/campaigns/${encodeURIComponent(id ?? '')}/sends?${qs.toString()}`)
+      .then(r => r.json())
+      .then((d: SendPage & { state: string }) => {
+        setSendState(d.state)
+        // A failed page must not replace a good one with an empty table — that renders as
+        // "nothing was suppressed", the misreading this screen exists to prevent.
+        if (d.state === 'ok') setSendOverride({ items: d.items, total: d.total, page: d.page, size: d.size })
+      })
+      .catch(() => setSendState('unreachable'))
+      .finally(() => setSendsLoading(false))
+  }
+
+  const applyFilter = (outcome: string) => {
+    setOutcomeFilter(outcome)
+    loadSends(0, outcome)
+  }
+  const summary = detail?.sendSummary ?? {}
+
+  // From the server-side summary, never from the loaded page: a headline derived from the rows on
+  // screen understates every campaign larger than one page.
+  const suppressed = Object.entries(summary)
+    .filter(([outcome]) => outcome.startsWith('SUPPRESSED'))
+    .reduce((n, [, count]) => n + count, 0)
 
   const fmtDateTime = (iso: string | null | undefined) =>
     iso
@@ -130,9 +177,9 @@ export default function CampaignDetailPage({ params }: { params: Promise<{ id: s
 
   // Suppressions grouped by reason: "2 suppressed" tells an operator something is off,
   // "2 × quiet hours" tells them whether to act.
-  const byReason = sends
-    .filter(s => s.outcome.startsWith('SUPPRESSED'))
-    .reduce<Record<string, number>>((acc, s) => ({ ...acc, [s.outcome]: (acc[s.outcome] ?? 0) + 1 }), {})
+  const byReason = Object.fromEntries(
+    Object.entries(summary).filter(([outcome, count]) => outcome.startsWith('SUPPRESSED') && count > 0),
+  )
 
   return (
     <div className="space-y-6">
@@ -242,6 +289,34 @@ export default function CampaignDetailPage({ params }: { params: Promise<{ id: s
                 </table>
               </div>
             )}
+
+            {sends.length > 0 && (
+              <div className="flex items-center justify-between text-sm">
+                <span className="text-muted-foreground">
+                  {/* The range and the total together: "1–50" alone cannot distinguish the whole
+                      log from the first slice of a much larger one. */}
+                  {t('Zobrazeno', 'Showing')} {sendPage.page * sendPage.size + 1}–
+                  {sendPage.page * sendPage.size + sends.length} {t('z', 'of')}{' '}
+                  {sendPage.total.toLocaleString(language === 'cs' ? 'cs-CZ' : 'en-GB')}
+                </span>
+                <span className="flex gap-2">
+                  <button
+                    onClick={() => loadSends(sendPage.page - 1, outcomeFilter)}
+                    disabled={sendPage.page === 0 || sendsLoading}
+                    className="rounded-md border px-2 py-1 text-xs disabled:opacity-40"
+                  >
+                    {t('Předchozí', 'Previous')}
+                  </button>
+                  <button
+                    onClick={() => loadSends(sendPage.page + 1, outcomeFilter)}
+                    disabled={(sendPage.page + 1) * sendPage.size >= sendPage.total || sendsLoading}
+                    className="rounded-md border px-2 py-1 text-xs disabled:opacity-40"
+                  >
+                    {t('Další', 'Next')}
+                  </button>
+                </span>
+              </div>
+            )}
           </section>
 
           <section className="space-y-2">
@@ -260,9 +335,36 @@ export default function CampaignDetailPage({ params }: { params: Promise<{ id: s
                 'Quiet hours: 21:00–08:00. Sends in that window are suppressed (ADR-0200 D6).',
               )}
             </p>
-            {detail?.sources.sends !== 'ok' ? (
+            <div className="flex flex-wrap items-center gap-2">
+              <label htmlFor="outcome-filter" className="text-xs text-muted-foreground">
+                {t('Výsledek', 'Outcome')}
+              </label>
+              <select
+                id="outcome-filter"
+                value={outcomeFilter}
+                onChange={e => applyFilter(e.target.value)}
+                className="rounded-md border bg-transparent px-2 py-1 text-sm"
+              >
+                <option value="">{t('Vše', 'All')}</option>
+                {OUTCOMES.map(o => (
+                  <option key={o} value={o}>
+                    {outcomeLabel(o)}
+                    {summary[o] !== undefined ? ` (${summary[o]})` : ''}
+                  </option>
+                ))}
+              </select>
+              {sendsLoading && <span className="text-xs text-muted-foreground">{t('Načítám…', 'Loading…')}</span>}
+            </div>
+
+            {detail?.sources.sends !== 'ok' || sendState !== 'ok' ? (
               <DataUnavailable
-                kind={detail?.sources.sends === 'unauthorized' ? 'unauthorized' : detail?.sources.sends === 'not_deployed' ? 'not_deployed' : 'unreachable'}
+                kind={
+                  detail?.sources.sends === 'unauthorized' || sendState === 'unauthorized'
+                    ? 'unauthorized'
+                    : detail?.sources.sends === 'not_deployed'
+                      ? 'not_deployed'
+                      : 'unreachable'
+                }
                 service="Campaign-service"
                 feature={t('Log odeslání', 'Send log')}
                 dense

--- a/openbank-admin-ui/src/app/campaigns/page.tsx
+++ b/openbank-admin-ui/src/app/campaigns/page.tsx
@@ -31,6 +31,8 @@ export default function CampaignsPage() {
   const [items, setItems] = useState<Campaign[]>([])
   const [unavailable, setUnavailable] = useState<UnavailableKind | null>(null)
   const [loading, setLoading] = useState(true)
+  const [search, setSearch] = useState('')
+  const [stateFilter, setStateFilter] = useState('')
 
   useEffect(() => {
     fetch('/api/campaigns')
@@ -49,6 +51,17 @@ export default function CampaignsPage() {
   const fmtDate = (iso: string | null | undefined) =>
     iso ? new Intl.DateTimeFormat(language === 'cs' ? 'cs-CZ' : 'en-GB', { dateStyle: 'medium' }).format(new Date(iso)) : '—'
 
+  // States present in the data, not a hardcoded list: a state the API starts returning would be
+  // missing from the filter forever, and the rows would look like they had vanished.
+  const states = Array.from(new Set(items.map(c => c.state))).sort()
+
+  const needle = search.trim().toLowerCase()
+  const filtered = items.filter(
+    c =>
+      (!stateFilter || c.state === stateFilter) &&
+      (!needle || c.name.toLowerCase().includes(needle) || (c.goal ?? '').toLowerCase().includes(needle)),
+  )
+
   return (
     <div className="space-y-6">
       <PageHeader
@@ -61,11 +74,53 @@ export default function CampaignsPage() {
 
       {!loading && unavailable && <DataUnavailable kind={unavailable} service="Campaign-service" feature={t('Kampaně', 'Campaigns')} />}
 
+      {/* Filtered in the browser, unlike the send log. A campaign list has one row per campaign,
+          not one per recipient, so it is bounded by how many campaigns a bank runs — the send log
+          is bounded by the audience, which is why that one pages on the server. */}
+      {!loading && !unavailable && items.length > 0 && (
+        <div className="flex flex-wrap items-center gap-3">
+          <input
+            type="search"
+            value={search}
+            onChange={e => setSearch(e.target.value)}
+            placeholder={t('Hledat podle názvu nebo cíle…', 'Search by name or goal…')}
+            aria-label={t('Hledat kampaně', 'Search campaigns')}
+            className="w-72 rounded-md border bg-transparent px-3 py-1.5 text-sm"
+          />
+          <select
+            value={stateFilter}
+            onChange={e => setStateFilter(e.target.value)}
+            aria-label={t('Filtr stavu', 'State filter')}
+            className="rounded-md border bg-transparent px-2 py-1.5 text-sm"
+          >
+            <option value="">{t('Všechny stavy', 'All states')}</option>
+            {states.map(st => (
+              <option key={st} value={st}>
+                {st} ({items.filter(c => c.state === st).length})
+              </option>
+            ))}
+          </select>
+          {filtered.length !== items.length && (
+            <span className="text-xs text-muted-foreground">
+              {t('Zobrazeno', 'Showing')} {filtered.length} {t('z', 'of')} {items.length}
+            </span>
+          )}
+        </div>
+      )}
+
       {!loading && !unavailable && items.length === 0 && (
         <p className="text-sm text-muted-foreground">{t('Zatím žádné kampaně.', 'No campaigns yet.')}</p>
       )}
 
-      {!loading && !unavailable && items.length > 0 && (
+      {!loading && !unavailable && items.length > 0 && filtered.length === 0 && (
+        // Distinct from "no campaigns yet": one is an empty estate, the other is a filter the
+        // user can undo, and rendering the same sentence for both hides the undo.
+        <p className="text-sm text-muted-foreground">
+          {t('Žádná kampaň neodpovídá filtru.', 'No campaign matches the filter.')}
+        </p>
+      )}
+
+      {!loading && !unavailable && filtered.length > 0 && (
         <div className="overflow-x-auto rounded-lg border">
           <table className="w-full text-sm">
             <thead className="bg-muted/50 text-left">
@@ -79,7 +134,7 @@ export default function CampaignsPage() {
               </tr>
             </thead>
             <tbody>
-              {items.map(c => (
+              {filtered.map(c => (
                 <tr key={c.id} className="border-t">
                   <td className="px-4 py-2">
                     <Link href={`/campaigns/${c.id}`} className="font-medium hover:underline">

--- a/openbank-admin-ui/src/test/campaigns-console.test.tsx
+++ b/openbank-admin-ui/src/test/campaigns-console.test.tsx
@@ -38,11 +38,19 @@ const DETAIL = {
     { id: 'e1', partyId: '05a02ef1-381c-40e7-b73f-d6855eead42e', state: 'TERMINATED_CONSENT_REVOKED', currentStep: 0 },
     { id: 'e2', partyId: '026289e3-0b80-452a-be01-e69034838549', state: 'ACTIVE', currentStep: 0 },
   ],
-  sends: [
-    { id: 's1', partyId: '05a02ef1-381c-40e7-b73f-d6855eead42e', stepOrder: 1, outcome: 'SENT', occurredAt: '2026-07-31T18:50:09Z' },
-    { id: 's2', partyId: '026289e3-0b80-452a-be01-e69034838549', stepOrder: 1, outcome: 'SUPPRESSED_CONSENT', occurredAt: '2026-07-31T18:50:09Z' },
-  ],
-  sources: { campaign: 'ok', enrolments: 'ok', sends: 'ok' },
+  sends: {
+    items: [
+      { id: 's1', partyId: '05a02ef1-381c-40e7-b73f-d6855eead42e', stepOrder: 1, outcome: 'SENT', occurredAt: '2026-07-31T18:50:09Z' },
+      { id: 's2', partyId: '026289e3-0b80-452a-be01-e69034838549', stepOrder: 1, outcome: 'SUPPRESSED_CONSENT', occurredAt: '2026-07-31T18:50:09Z' },
+    ],
+    total: 2,
+    page: 0,
+    size: 50,
+  },
+  // Counts come from the service, not from the page above — a suppressed headline derived from the
+  // loaded rows understates every campaign larger than one page.
+  sendSummary: { SENT: 1, SUPPRESSED_CONSENT: 1 },
+  sources: { campaign: 'ok', enrolments: 'ok', sends: 'ok', sendSummary: 'ok' },
 }
 
 function Providers({ children }: { children: React.ReactNode }) {
@@ -117,7 +125,12 @@ describe('campaign console', () => {
   }, 15000)
 
   it('a restricted send log is stated, never rendered as "nothing was suppressed"', async () => {
-    const restricted = { ...DETAIL, sends: [], sources: { campaign: 'ok', enrolments: 'ok', sends: 'unauthorized' } }
+    const restricted = {
+      ...DETAIL,
+      sends: { items: [], total: 0, page: 0, size: 50 },
+      sendSummary: {},
+      sources: { campaign: 'ok', enrolments: 'ok', sends: 'unauthorized', sendSummary: 'unauthorized' },
+    }
     vi.stubGlobal('fetch', mockFetch(LIST, restricted))
     render(
       React.createElement(
@@ -131,5 +144,37 @@ describe('campaign console', () => {
     // "Nothing sent yet" for a log the caller may not read would be a lie with the same shape as
     // the truth — the exact misreading this screen exists to prevent.
     expect(screen.queryByText('Nothing sent or attempted yet.')).toBeNull()
+  }, 15000)
+
+  /**
+   * The send log pages, so anything derived from the rows on screen describes the page, not the
+   * campaign. This pins the two numbers that would otherwise silently mean "so far on this page":
+   * the suppressed headline and the suppression breakdown, both of which an operator acts on.
+   *
+   * Falsification: with the previous page-derived implementation the headline reads 1 and the
+   * breakdown reads "1× Consent withdrawn" against the same fixture.
+   */
+  it('headline counts come from the server summary, not from the loaded page', async () => {
+    const bigCampaign = {
+      ...DETAIL,
+      sends: { ...DETAIL.sends, total: 5000 },
+      sendSummary: { SENT: 1000, SUPPRESSED_CONSENT: 4000 },
+    }
+    vi.stubGlobal('fetch', mockFetch(LIST, bigCampaign))
+    render(
+      React.createElement(
+        Providers,
+        null,
+        React.createElement(CampaignDetailPage, { params: Promise.resolve({ id: CAMPAIGN_ID }) }),
+      ),
+    )
+
+    await waitFor(() => expect(screen.getByText('Suppressed sends')).toBeTruthy(), { timeout: 8000 })
+    expect(screen.getByText('4000')).toBeTruthy()
+    expect(screen.getByText(/4000× Consent withdrawn/)).toBeTruthy()
+
+    // And the range states what fraction is on screen: "1–2" alone cannot distinguish the whole
+    // log from the first slice of a much larger one.
+    expect(screen.getByText(/of\s*5,?000/)).toBeTruthy()
   }, 15000)
 })

--- a/openbank-campaign-service/src/main/kotlin/com/openbank/campaign/application/port/out/Ports.kt
+++ b/openbank-campaign-service/src/main/kotlin/com/openbank/campaign/application/port/out/Ports.kt
@@ -7,6 +7,7 @@ package com.openbank.campaign.application.port.out
 import com.openbank.campaign.domain.model.Campaign
 import com.openbank.campaign.domain.model.Enrolment
 import com.openbank.campaign.domain.model.Segment
+import com.openbank.campaign.domain.model.SendOutcome
 import com.openbank.campaign.domain.model.SendRecord
 import java.util.UUID
 
@@ -27,8 +28,17 @@ interface SendLogRepository {
     suspend fun record(send: SendRecord)
     suspend fun countRecentForParty(partyId: UUID, sinceEpochSeconds: Long): Int
 
-    /** Every recorded send attempt for a campaign, newest first — the operator view of what happened. */
-    suspend fun listByCampaign(campaignId: UUID): List<SendRecord>
+    /**
+     * One page of send attempts for a campaign, newest first — the operator view of what happened.
+     *
+     * Paged at the repository, not in the caller: a campaign's send log has one row per party per
+     * step, so reading it whole to show the first screenful is unbounded work that grows with the
+     * audience. [outcome], when set, filters in SQL for the same reason.
+     */
+    suspend fun listByCampaign(campaignId: UUID, outcome: SendOutcome?, page: Int, size: Int): List<SendRecord>
+
+    /** How many rows [listByCampaign] would return in total, for the same filter. */
+    suspend fun countByCampaign(campaignId: UUID, outcome: SendOutcome?): Long
 }
 
 /** ADR-0201 D1: segments are versioned artifacts loaded as code/data, never UI-typed SQL. */

--- a/openbank-campaign-service/src/main/kotlin/com/openbank/campaign/application/usecase/CampaignSendLogQuery.kt
+++ b/openbank-campaign-service/src/main/kotlin/com/openbank/campaign/application/usecase/CampaignSendLogQuery.kt
@@ -5,6 +5,7 @@
 package com.openbank.campaign.application.usecase
 
 import com.openbank.campaign.application.port.out.SendLogRepository
+import com.openbank.campaign.domain.model.SendOutcome
 import com.openbank.campaign.domain.model.SendRecord
 import jakarta.enterprise.context.ApplicationScoped
 import java.util.UUID
@@ -28,5 +29,44 @@ class CampaignSendLogQuery(private val sendLog: SendLogRepository) {
      * look identical. Filtering this to successful deliveries would answer "who got it" while
      * losing "why didn't they", which is the question operators actually ask.
      */
-    suspend fun listSends(campaignId: UUID): List<SendRecord> = sendLog.listByCampaign(campaignId)
+    suspend fun listSends(campaignId: UUID, outcome: SendOutcome?, page: Int, size: Int): SendPage {
+        val safeSize = size.coerceIn(1, MAX_PAGE_SIZE)
+        val safePage = page.coerceAtLeast(0)
+        return SendPage(
+            items = sendLog.listByCampaign(campaignId, outcome, safePage, safeSize),
+            total = sendLog.countByCampaign(campaignId, outcome),
+            page = safePage,
+            size = safeSize,
+        )
+    }
+
+    /**
+     * How many sends per outcome, across the whole campaign.
+     *
+     * Counted in SQL rather than derived from a page: a "suppressed" headline computed from the
+     * rows currently on screen says "2 suppressed" while a campaign is suppressing thousands, and
+     * that number is exactly the one an operator acts on. Paging a list is safe; paging a total is
+     * not.
+     */
+    suspend fun summary(campaignId: UUID): Map<SendOutcome, Long> =
+        SendOutcome.entries.associateWith { sendLog.countByCampaign(campaignId, it) }
+
+    companion object {
+        /**
+         * A caller-supplied page size is a caller-supplied amount of work. Clamping rather than
+         * rejecting keeps an over-large request useful instead of turning it into an error the
+         * console has to handle, and the ceiling is what stops `?size=1000000` from being the
+         * unbounded read this paging exists to remove.
+         */
+        const val MAX_PAGE_SIZE = 200
+    }
 }
+
+/**
+ * A page of sends plus the total it was cut from.
+ *
+ * `total` is not decoration: without it the console cannot tell "this is everything" from "this is
+ * the first 50 of many", and those render identically while meaning opposite things to whoever is
+ * deciding whether a campaign reached its audience.
+ */
+data class SendPage(val items: List<SendRecord>, val total: Long, val page: Int, val size: Int)

--- a/openbank-campaign-service/src/main/kotlin/com/openbank/campaign/infrastructure/persistence/Persistence.kt
+++ b/openbank-campaign-service/src/main/kotlin/com/openbank/campaign/infrastructure/persistence/Persistence.kt
@@ -23,7 +23,9 @@ import com.openbank.campaign.domain.model.SendRecord
 import com.openbank.libs.domain.identifiers.Ids
 import io.quarkus.hibernate.reactive.panache.Panache
 import io.quarkus.hibernate.reactive.panache.PanacheEntityBase
+import io.quarkus.hibernate.reactive.panache.PanacheQuery
 import io.quarkus.hibernate.reactive.panache.PanacheRepository
+import io.quarkus.panache.common.Page
 import io.smallrye.mutiny.coroutines.awaitSuspending
 import jakarta.enterprise.context.ApplicationScoped
 import jakarta.persistence.Column
@@ -248,8 +250,13 @@ class PanacheSendLogRepository :
         }.awaitSuspending()
     }
 
-    override suspend fun listByCampaign(campaignId: UUID): List<SendRecord> = Panache.withSession {
-        find("campaignId = ?1 order by occurredAt desc", campaignId).list<SendLogEntity>()
+    override suspend fun listByCampaign(
+        campaignId: UUID,
+        outcome: SendOutcome?,
+        page: Int,
+        size: Int,
+    ): List<SendRecord> = Panache.withSession {
+        query(campaignId, outcome).page<SendLogEntity>(Page.of(page, size)).list<SendLogEntity>()
     }.awaitSuspending().map {
         SendRecord(
             id = it.id,
@@ -259,6 +266,19 @@ class PanacheSendLogRepository :
             outcome = SendOutcome.valueOf(it.outcome),
             occurredAt = it.occurredAt,
         )
+    }
+
+    override suspend fun countByCampaign(campaignId: UUID, outcome: SendOutcome?): Long =
+        Panache.withSession { query(campaignId, outcome).count() }.awaitSuspending()
+
+    /**
+     * One place builds the filter so the page and its total can never disagree about what is being
+     * counted — a paging bug that shows up only as a page number that runs past the end.
+     */
+    private fun query(campaignId: UUID, outcome: SendOutcome?): PanacheQuery<SendLogEntity> = if (outcome == null) {
+        find("campaignId = ?1 order by occurredAt desc", campaignId)
+    } else {
+        find("campaignId = ?1 and outcome = ?2 order by occurredAt desc", campaignId, outcome.name)
     }
 
     override suspend fun countRecentForParty(partyId: UUID, sinceEpochSeconds: Long): Int = Panache.withSession {

--- a/openbank-campaign-service/src/main/kotlin/com/openbank/campaign/infrastructure/rest/CampaignSendLogResource.kt
+++ b/openbank-campaign-service/src/main/kotlin/com/openbank/campaign/infrastructure/rest/CampaignSendLogResource.kt
@@ -5,11 +5,14 @@
 package com.openbank.campaign.infrastructure.rest
 
 import com.openbank.campaign.application.usecase.CampaignSendLogQuery
+import com.openbank.campaign.domain.model.SendOutcome
 import com.openbank.libs.authz.Authorize
 import jakarta.enterprise.context.ApplicationScoped
+import jakarta.ws.rs.DefaultValue
 import jakarta.ws.rs.GET
 import jakarta.ws.rs.Path
 import jakarta.ws.rs.PathParam
+import jakarta.ws.rs.QueryParam
 import jakarta.ws.rs.core.Response
 import java.util.UUID
 
@@ -34,5 +37,37 @@ class CampaignSendLogResource(private val query: CampaignSendLogQuery) {
     @GET
     @Path("/{id}/sends")
     @Authorize(action = "campaign.read", resource = "#id")
-    suspend fun sends(@PathParam("id") id: UUID): Response = Response.ok(query.listSends(id)).build()
+    suspend fun sends(
+        @PathParam("id") id: UUID,
+        @QueryParam("outcome") outcome: String?,
+        @QueryParam("page") @DefaultValue("0") page: Int,
+        @QueryParam("size") @DefaultValue("50") size: Int,
+    ): Response {
+        // An unrecognised outcome is a 400, never a silently unfiltered page: answering a filter
+        // the caller did not ask for with every row looks like "no suppressions here".
+        val parsed = outcome?.let {
+            runCatching { SendOutcome.valueOf(it.uppercase()) }.getOrElse { return badOutcome(it) }
+        }
+        return Response.ok(query.listSends(id, parsed, page, size)).build()
+    }
+
+    /**
+     * Counts per outcome for the whole campaign, so the console's headline numbers do not depend on
+     * which page happens to be loaded.
+     */
+    @GET
+    @Path("/{id}/sends/summary")
+    @Authorize(action = "campaign.read", resource = "#id")
+    suspend fun sendSummary(@PathParam("id") id: UUID): Response =
+        Response.ok(query.summary(id).mapKeys { it.key.name }).build()
+
+    private fun badOutcome(cause: Throwable): Response = Response.status(Response.Status.BAD_REQUEST)
+        .entity(
+            mapOf(
+                "error" to "unknown outcome",
+                "allowed" to SendOutcome.entries.map { it.name },
+                "detail" to cause.message,
+            ),
+        )
+        .build()
 }

--- a/openbank-campaign-service/src/main/resources/openapi.yaml
+++ b/openbank-campaign-service/src/main/resources/openapi.yaml
@@ -4,7 +4,7 @@ openapi: 3.1.0
 info:
   title: Campaign Service API
   # major == openbank.api.version == URL /api/v1 (ADR-0048).
-  version: 1.3.0
+  version: 1.4.0
   description: >-
     Campaign management first slice (ADR-0200 / ADR-0209 D3): deterministic, versioned segments;
     per-enrolment Temporal journeys; consent-gated delivery through notification-service.
@@ -178,6 +178,26 @@ paths:
                 items:
                   $ref: '#/components/schemas/Enrolment'
 
+  /api/v1/campaigns/{id}/sends/summary:
+    get:
+      tags: [Campaigns]
+      summary: Counts per outcome for the whole campaign
+      description: >-
+        Counted in SQL, not derived from a page. A "suppressed" headline computed from the rows
+        currently on screen says "2 suppressed" while a campaign is suppressing thousands — and
+        that is the number an operator acts on. Paging a list is safe; paging a total is not.
+      operationId: sendSummary
+      parameters:
+        - $ref: '#/components/parameters/CampaignId'
+      responses:
+        '200':
+          description: Count per outcome, keyed by outcome name
+          content:
+            application/json:
+              schema:
+                type: object
+                additionalProperties: { type: integer, format: int64 }
+
   /api/v1/campaigns/{id}/sends:
     get:
       tags: [Campaigns]
@@ -190,15 +210,34 @@ paths:
       operationId: listSends
       parameters:
         - $ref: '#/components/parameters/CampaignId'
+        - name: outcome
+          in: query
+          required: false
+          description: >-
+            Filter to one outcome. An unrecognised value is a 400, never an unfiltered page —
+            answering a filter the caller did not ask for with every row reads as
+            "no suppressions here".
+          schema:
+            type: string
+            enum: [SENT, FAILED, SUPPRESSED_CONSENT, SUPPRESSED_CAP, SUPPRESSED_QUIET_HOURS]
+        - name: page
+          in: query
+          required: false
+          schema: { type: integer, minimum: 0, default: 0 }
+        - name: size
+          in: query
+          required: false
+          description: Clamped to 1..200. A caller-supplied page size is a caller-supplied amount of work.
+          schema: { type: integer, minimum: 1, maximum: 200, default: 50 }
       responses:
         '200':
-          description: Send records
+          description: One page of send records
           content:
             application/json:
               schema:
-                type: array
-                items:
-                  $ref: '#/components/schemas/SendRecord'
+                $ref: '#/components/schemas/SendPage'
+        '400':
+          description: Unrecognised `outcome`
 
   /api/v1/segments:
     get:
@@ -326,6 +365,23 @@ components:
         version: { type: integer }
         size: { type: integer, description: Parties matched at asOf. }
         asOf: { type: string, format: date-time }
+
+    SendPage:
+      type: object
+      properties:
+        items:
+          type: array
+          items:
+            $ref: '#/components/schemas/SendRecord'
+        total:
+          type: integer
+          format: int64
+          description: >-
+            Rows matching the same filter. Without it a console cannot tell "this is everything"
+            from "this is the first page of many" — they render identically and mean opposite
+            things to whoever is judging whether a campaign reached its audience.
+        page: { type: integer }
+        size: { type: integer }
 
     SendRecord:
       type: object

--- a/openbank-campaign-service/src/test/kotlin/com/openbank/campaign/application/CampaignSendLogTest.kt
+++ b/openbank-campaign-service/src/test/kotlin/com/openbank/campaign/application/CampaignSendLogTest.kt
@@ -45,13 +45,20 @@ class CampaignSendLogTest {
         object : SendLogRepository {
             override suspend fun record(send: SendRecord) = Unit
             override suspend fun countRecentForParty(partyId: UUID, sinceEpochSeconds: Long) = 0
-            override suspend fun listByCampaign(campaignId: UUID) = records
+
+            // Filters and pages the way SQL does, so the test exercises the real contract rather
+            // than a fake that always answers with everything.
+            override suspend fun listByCampaign(campaignId: UUID, outcome: SendOutcome?, page: Int, size: Int) =
+                records.filter { outcome == null || it.outcome == outcome }.drop(page * size).take(size)
+
+            override suspend fun countByCampaign(campaignId: UUID, outcome: SendOutcome?) =
+                records.count { outcome == null || it.outcome == outcome }.toLong()
         },
     )
 
     @Test
     fun `every recorded outcome is surfaced, suppressions included`(): Unit = runBlocking {
-        val sends = query.listSends(campaignId)
+        val sends = query.listSends(campaignId, outcome = null, page = 0, size = 50).items
 
         assertEquals(records.size, sends.size)
         assertEquals(
@@ -68,9 +75,54 @@ class CampaignSendLogTest {
 
     @Test
     fun `the record keeps party and step so a suppression can be attributed`(): Unit = runBlocking {
-        val suppressed = query.listSends(campaignId).first { it.outcome == SendOutcome.SUPPRESSED_CONSENT }
+        val suppressed = query.listSends(campaignId, outcome = null, page = 0, size = 50)
+            .items.first { it.outcome == SendOutcome.SUPPRESSED_CONSENT }
 
         assertEquals(campaignId, suppressed.campaignId)
         assertEquals(1, suppressed.stepOrder)
+    }
+
+    /**
+     * `total` is what lets the console tell "this is everything" from "this is the first page of
+     * many". Those render identically and mean opposite things to whoever is deciding whether a
+     * campaign reached its audience, so the count must survive paging.
+     */
+    @Test
+    fun `a page carries the total it was cut from`(): Unit = runBlocking {
+        val page = query.listSends(campaignId, outcome = null, page = 0, size = 2)
+
+        assertEquals(2, page.items.size)
+        assertEquals(records.size.toLong(), page.total)
+    }
+
+    @Test
+    fun `the total is of the filtered set, not of everything`(): Unit = runBlocking {
+        // A total that ignored the filter would show a page of 1 out of "5 sends", which reads as
+        // four rows the console failed to render.
+        val page = query.listSends(campaignId, SendOutcome.SUPPRESSED_CONSENT, page = 0, size = 50)
+
+        assertEquals(page.items.size.toLong(), page.total)
+        assertEquals(setOf(SendOutcome.SUPPRESSED_CONSENT), page.items.map { it.outcome }.toSet())
+    }
+
+    /**
+     * A caller-supplied page size is a caller-supplied amount of work. Clamping rather than
+     * rejecting keeps an over-large request useful, and the ceiling is the whole reason paging
+     * removes the unbounded read instead of relocating it.
+     */
+    @Test
+    fun `an over-large page size is clamped, not honoured`(): Unit = runBlocking {
+        val page = query.listSends(campaignId, outcome = null, page = 0, size = 1_000_000)
+
+        assertEquals(CampaignSendLogQuery.MAX_PAGE_SIZE, page.size)
+    }
+
+    @Test
+    fun `a negative page or a zero size cannot produce an empty page by accident`(): Unit = runBlocking {
+        val page = query.listSends(campaignId, outcome = null, page = -3, size = 0)
+
+        assertEquals(0, page.page)
+        assertEquals(1, page.size)
+        assertEquals(1, page.items.size)
     }
 }


### PR DESCRIPTION
Refs #2895. **Stacked on #3055** — that PR takes `openapi.yaml` 1.2.0 → 1.3.0, this one takes
1.3.0 → 1.4.0. Splitting the bump avoids two open PRs claiming the same contract version, which the
api-contract gate cannot catch: it classifies against the PR's creation-time base, so whichever
lands second ships new endpoints under an already-taken version (#481 vs #524). This bit on the
first attempt from a direction I was not watching: I guarded the numbering between my own two PRs
and missed that #3037 had already taken 1.2.0 on `main`, so the gate correctly reported
`1.2.0 -> 1.2.0`.

## The actual problem

The task was "filtering and paging in the console". Looking at it, the send log read was unbounded:

```kotlin
override suspend fun listByCampaign(campaignId: UUID): List<SendRecord> = Panache.withSession {
    find("campaignId = ?1 order by occurredAt desc", campaignId).list<SendLogEntity>()
}
```

One row per party per step, all of it loaded, serialised through the BFF and rendered — to show the
first screenful. Filtering in the browser would have made that worse: the same data still crosses
every layer, just hidden on arrival.

## What changed

- `listByCampaign(campaignId, outcome, page, size)` + `countByCampaign`, both filtering in SQL.
- **One private `query()` builds the filter for the page and for the count.** Two copies of a filter
  is a paging bug that surfaces only as a page number running past the end.
- `size` is clamped to 1..200 rather than rejected. A caller-supplied page size is a caller-supplied
  amount of work; clamping keeps an over-large request useful instead of turning it into an error the
  console must handle, and the ceiling is what stops `?size=1000000` from relocating the unbounded
  read rather than removing it.
- `SendPage` carries `total`. Without it the console cannot tell "this is everything" from "this is
  the first 50 of many" — they render identically and mean opposite things to whoever is judging
  whether a campaign reached its audience.
- An unrecognised `outcome` is a 400 listing the allowed values. Answering a filter the caller did
  not ask for with every row reads as "no suppressions here".

## Why there is a summary endpoint

The detail screen's headline "suppressed" number and its by-reason breakdown were computed from the
loaded rows. That was correct only while the whole log was loaded. Once it pages, the same code says
"2 suppressed" for a campaign suppressing thousands — and that number is precisely what an operator
acts on.

`GET /campaigns/{id}/sends/summary` counts per outcome in SQL. **Paging a list is safe; paging a
total is not.**

## Console

- Send log: outcome filter (with counts from the summary), Previous/Next, and a stated range —
  "Showing 1–50 of 5,000". Later pages come from a dedicated `/api/campaigns/[id]/sends` route, so
  turning a page does not re-read the campaign and its enrolments.
- A failed page never replaces a good one with an empty table, and a restricted read never arrives
  as `state: 'ok'` with zero rows — an empty send log renders as "nothing was suppressed", the
  misreading this screen exists to prevent.
- Campaign list: search by name/goal, filter by state. **Filtered in the browser on purpose** — one
  row per campaign, not one per recipient, so it is bounded by how many campaigns a bank runs. The
  state options are derived from the data rather than hardcoded, so a state the API starts returning
  cannot silently go missing from the filter and make rows look like they vanished.
- "No campaigns yet" and "no campaign matches the filter" are different sentences; rendering the same
  one for both hides the undo.

## Tests

Service: total survives paging, the total is of the *filtered* set (a total ignoring the filter shows
"1 of 5", which reads as four rows the console failed to render), an over-large size is clamped, and
a negative page / zero size cannot produce an empty page by accident.

Console: a new test pins that the headline count and the breakdown come from the summary, not the
page. **Falsified before being trusted** — reverting the page to the previous page-derived
implementation makes it fail with `Unable to find an element with the text: 4000`, against the same
fixture.

## Not in scope, deliberately

`EnrolmentRepository.listByCampaign` is unbounded in the same way. Its signature is shared with the
journey path rather than being console-only, so changing it would force paging on a caller that
legitimately wants every row — a different change with a different risk, and not one to smuggle in
here.
