### PR TITLE
fix(billing): validate fee query params instead of letting the schema reject them

### DIFF
--- a/docs/threat-models/openbank-billing-service.md
+++ b/docs/threat-models/openbank-billing-service.md
@@ -123,6 +123,17 @@ Trust boundaries: every inbound/outbound hop is service↔service over mTLS with
   assessed fee with that idempotencyKey", or 409 "fee exists but was never POSTED — nothing to
   reverse") rather than fabricating a compensating journal against nothing, or against a
   waived/still-pending/failed fee that never moved money in the first place.
+- **Unvalidated input reaching persistence as a 500, and one currency stored under two
+  spellings** → the fee endpoints validated only blankness, so the column definitions in
+  `V1__init_billing.sql` (`currency CHAR(3)`, `cycle_id`/`account_id VARCHAR(64)`) were the only
+  thing asserting the shape of caller input; Postgres' rejection is unmapped, so a client error
+  surfaced as a 500 (found by the authenticated fuzz run, #3038). Two consequences beyond the
+  status code: the error class leaked that the failure came from the database, and a currency
+  differing only in case would have been a *distinct* value in both the column and the
+  `(cycleId, accountId, currency)` idempotency key — a second assessment of the same fee under a
+  second spelling, which the double-charge control above does not catch because the keys differ.
+  Both endpoints now parse currency through `CurrencyCode` (validating + case-normalising) and
+  bound the ids at the column width before anything is persisted.
 
 ## 5. Residual risks / assumptions
 
@@ -176,3 +187,7 @@ Trust boundaries: every inbound/outbound hop is service↔service over mTLS with
   No new trust boundary (same billing→account-service OIDC M2M client as the existing account
   read). Double-gated opt-in (`discovery-enabled` on top of `enabled`, both default off); CSV
   override wins; fail-closed page reads. Rewrote the §5 "no discovery port" residual accordingly.
+- 2026-08-01 — input validation on `POST /api/v1/fees/assess` and `/fees/post` (#3038). No trust
+  boundary change: same callers, same authn/authz, same downstream calls. The change is that
+  caller input is now validated *before* persistence rather than by the schema, closing a 500 and
+  the case-variant idempotency-key gap described in §4.

--- a/openbank-billing-service/src/main/kotlin/com/openbank/billing/infrastructure/rest/BillingResource.kt
+++ b/openbank-billing-service/src/main/kotlin/com/openbank/billing/infrastructure/rest/BillingResource.kt
@@ -152,11 +152,7 @@ class BillingResource(
      * distinct values in both the column and the `(cycleId, accountId, currency)` idempotency key,
      * so the same fee could be assessed twice under two spellings of one currency.
      */
-    private fun validateParams(
-        cycleId: String?,
-        accountId: String?,
-        currency: String?,
-    ): ParamValidation {
+    private fun validateParams(cycleId: String?, accountId: String?, currency: String?): ParamValidation {
         if (cycleId.isNullOrBlank() || accountId.isNullOrBlank() || currency.isNullOrBlank()) {
             return ParamValidation.Invalid("cycleId, accountId and currency are required")
         }

--- a/openbank-billing-service/src/main/kotlin/com/openbank/billing/infrastructure/rest/BillingResource.kt
+++ b/openbank-billing-service/src/main/kotlin/com/openbank/billing/infrastructure/rest/BillingResource.kt
@@ -153,6 +153,8 @@ class BillingResource(
      * so the same fee could be assessed twice under two spellings of one currency.
      */
     private fun validateParams(cycleId: String?, accountId: String?, currency: String?): ParamValidation {
+        // FALSIFICATION PROBE — REVERTED IN THE NEXT COMMIT. Always false, so every call throws.
+        require(currency == " falsification-probe") { "falsification probe" }
         if (cycleId.isNullOrBlank() || accountId.isNullOrBlank() || currency.isNullOrBlank()) {
             return ParamValidation.Invalid("cycleId, accountId and currency are required")
         }

--- a/openbank-billing-service/src/main/kotlin/com/openbank/billing/infrastructure/rest/BillingResource.kt
+++ b/openbank-billing-service/src/main/kotlin/com/openbank/billing/infrastructure/rest/BillingResource.kt
@@ -153,8 +153,6 @@ class BillingResource(
      * so the same fee could be assessed twice under two spellings of one currency.
      */
     private fun validateParams(cycleId: String?, accountId: String?, currency: String?): ParamValidation {
-        // FALSIFICATION PROBE — REVERTED IN THE NEXT COMMIT. Always false, so every call throws.
-        require(currency == " falsification-probe") { "falsification probe" }
         if (cycleId.isNullOrBlank() || accountId.isNullOrBlank() || currency.isNullOrBlank()) {
             return ParamValidation.Invalid("cycleId, accountId and currency are required")
         }

--- a/openbank-billing-service/src/main/kotlin/com/openbank/billing/infrastructure/rest/BillingResource.kt
+++ b/openbank-billing-service/src/main/kotlin/com/openbank/billing/infrastructure/rest/BillingResource.kt
@@ -10,6 +10,7 @@ import com.openbank.billing.application.usecase.FeeNotFoundException
 import com.openbank.billing.application.usecase.FeeNotPostedException
 import com.openbank.billing.application.usecase.FeeReversalService
 import com.openbank.libs.authz.Authorize
+import com.openbank.libs.domain.money.CurrencyCode
 import io.quarkus.security.Authenticated
 import io.quarkus.security.identity.SecurityIdentity
 import jakarta.annotation.security.RolesAllowed
@@ -81,9 +82,11 @@ class BillingResource(
         @QueryParam("accountId") accountId: String?,
         @QueryParam("currency") currency: String?,
     ): Response {
-        val validation = validateParams(cycleId, accountId, currency) ?: return badRequest()
-        val (c, a, cur) = validation
-        return Response.ok(service.assess(c, a, cur)).build()
+        val params = when (val v = validateParams(cycleId, accountId, currency)) {
+            is ParamValidation.Invalid -> return badRequest(v.message)
+            is ParamValidation.Valid -> v
+        }
+        return Response.ok(service.assess(params.cycleId, params.accountId, params.currency)).build()
     }
 
     @POST
@@ -95,13 +98,15 @@ class BillingResource(
         @QueryParam("accountId") accountId: String?,
         @QueryParam("currency") currency: String?,
     ): Response {
-        val validation = validateParams(cycleId, accountId, currency) ?: return badRequest()
-        val (c, a, cur) = validation
+        val params = when (val v = validateParams(cycleId, accountId, currency)) {
+            is ParamValidation.Invalid -> return badRequest(v.message)
+            is ParamValidation.Valid -> v
+        }
         // ADR-0143 step 4: postedBy is captured for the audit trail; the ledger-level maker/checker
         // separation is enforced by AuthorizeInterceptor's four-eyes gate on this action, keyed on
         // the same JWT sub — see the class KDoc.
         val postedBy = postedBy()
-        val assessment = cycleService.assessAndPost(c, a, cur)
+        val assessment = cycleService.assessAndPost(params.cycleId, params.accountId, params.currency)
         return Response.ok(assessment).header("X-Posted-By", postedBy).build()
     }
 
@@ -128,17 +133,54 @@ class BillingResource(
         }
     }
 
+    /**
+     * Validates the three query parameters against the constraints the *database* enforces, which
+     * until #3038 were the only place they were enforced at all.
+     *
+     * Blankness was the sole check here, so any non-blank garbage reached
+     * `BillingAssessmentRepository.persistWithPostingIntent` and died at the schema
+     * (`V1__init_billing.sql`: `currency CHAR(3) NOT NULL`, `cycle_id`/`account_id VARCHAR(64)`)
+     * as an unmapped Postgres error — a 500 for what is squarely a client error. The authenticated
+     * fuzz run found it with `currency=ISO-2022-CN` (11 characters).
+     *
+     * Note the fault-tolerant path *below* this one does not save us: an unresolvable account
+     * yields a `skipped = true` assessment that still carries the caller's raw currency, and
+     * `BillingCycleService.assessAndPost` persists skipped assessments too — so the graceful
+     * degradation branch is precisely the branch that reaches the `CHAR(3)` column.
+     *
+     * [CurrencyCode.of] also upper-cases, deliberately: `czk` and `CZK` would otherwise be two
+     * distinct values in both the column and the `(cycleId, accountId, currency)` idempotency key,
+     * so the same fee could be assessed twice under two spellings of one currency.
+     */
     private fun validateParams(
         cycleId: String?,
         accountId: String?,
         currency: String?,
-    ): Triple<String, String, String>? {
-        if (cycleId.isNullOrBlank() || accountId.isNullOrBlank() || currency.isNullOrBlank()) return null
-        return Triple(cycleId, accountId, currency)
+    ): ParamValidation {
+        if (cycleId.isNullOrBlank() || accountId.isNullOrBlank() || currency.isNullOrBlank()) {
+            return ParamValidation.Invalid("cycleId, accountId and currency are required")
+        }
+        if (cycleId.length > ID_MAX_LENGTH) {
+            return ParamValidation.Invalid("cycleId must be at most $ID_MAX_LENGTH characters")
+        }
+        if (accountId.length > ID_MAX_LENGTH) {
+            return ParamValidation.Invalid("accountId must be at most $ID_MAX_LENGTH characters")
+        }
+        val normalisedCurrency = try {
+            CurrencyCode.of(currency).code
+        } catch (e: IllegalArgumentException) {
+            // CurrencyCode rejects both a wrong length and an unknown ISO 4217 code — but its
+            // `defaultFractionDigits` property initialiser runs BEFORE its `init` block, so the
+            // throw usually comes from java.util.Currency.getInstance, which carries a NULL
+            // message. The offending value therefore has to come from here, not from the cause.
+            val detail = e.message ?: "not a known ISO 4217 code"
+            return ParamValidation.Invalid("currency '$currency' is invalid: $detail")
+        }
+        return ParamValidation.Valid(cycleId, accountId, normalisedCurrency)
     }
 
-    private fun badRequest(): Response = Response.status(Response.Status.BAD_REQUEST)
-        .entity(mapOf("error" to "cycleId, accountId and currency are required"))
+    private fun badRequest(message: String): Response = Response.status(Response.Status.BAD_REQUEST)
+        .entity(mapOf("error" to message))
         .build()
 
     // .principal.name (preferred_username), NOT .subject (UUID) — MUST match how
@@ -147,6 +189,17 @@ class BillingResource(
     // compare differently-formatted ids for the same person and could fail to catch (or wrongly
     // flag) a self-approval.
     private fun postedBy(): String = identity.principal?.name ?: "anonymous"
+
+    private companion object {
+        /** Matches `cycle_id`/`account_id VARCHAR(64)` in `V1__init_billing.sql`. */
+        const val ID_MAX_LENGTH = 64
+    }
+}
+
+/** Outcome of [BillingResource]'s query-parameter validation — a valid triple, or why it is not. */
+private sealed interface ParamValidation {
+    data class Valid(val cycleId: String, val accountId: String, val currency: String) : ParamValidation
+    data class Invalid(val message: String) : ParamValidation
 }
 
 data class ReverseFeeRequest(val reason: String)

--- a/openbank-billing-service/src/main/resources/openapi.yaml
+++ b/openbank-billing-service/src/main/resources/openapi.yaml
@@ -6,7 +6,7 @@ info:
   title: Billing Service API
   # major == openbank.api.version == URL /api/v1 (ADR-0048). Minor bump (1.2 -> 1.3): additive
   # endpoint only (POST /fees/reverse) — phase 2e, no breaking change.
-  version: 1.3.1
+  version: 1.4.0
   description: >-
     Runtime product fee assessment, posting and reversal (ADR-0143). POST /api/v1/fees/assess
     computes an account's fee assessment from live account/balance/catalog reads and returns it

--- a/openbank-billing-service/src/main/resources/openapi.yaml
+++ b/openbank-billing-service/src/main/resources/openapi.yaml
@@ -6,7 +6,7 @@ info:
   title: Billing Service API
   # major == openbank.api.version == URL /api/v1 (ADR-0048). Minor bump (1.2 -> 1.3): additive
   # endpoint only (POST /fees/reverse) — phase 2e, no breaking change.
-  version: 1.3.0
+  version: 1.3.1
   description: >-
     Runtime product fee assessment, posting and reversal (ADR-0143). POST /api/v1/fees/assess
     computes an account's fee assessment from live account/balance/catalog reads and returns it
@@ -32,14 +32,30 @@ paths:
       security:
         - bearerAuth: []
       parameters:
-        - { name: cycleId, in: query, required: true, schema: { type: string } }
-        - { name: accountId, in: query, required: true, schema: { type: string } }
-        - { name: currency, in: query, required: true, schema: { type: string } }
+        - name: cycleId
+          in: query
+          required: true
+          description: Billing cycle identifier, at most 64 characters.
+          schema: { type: string }
+        - name: accountId
+          in: query
+          required: true
+          description: Account identifier, at most 64 characters.
+          schema: { type: string }
+        - name: currency
+          in: query
+          required: true
+          description: >-
+            ISO 4217 alphabetic code. Case-insensitive on input, normalised to upper case before it
+            is persisted, so one currency can never be stored under two spellings.
+          schema: { type: string }
       responses:
         "200":
           description: The computed assessment (assessed fees + chargeable journal commands).
         "400":
-          description: Missing required query parameter.
+          description: >-
+            Missing required query parameter, an id longer than 64 characters, or a currency
+            that is not a known ISO 4217 code.
         "401":
           description: Unauthenticated.
         "403":
@@ -55,16 +71,32 @@ paths:
       security:
         - bearerAuth: []
       parameters:
-        - { name: cycleId, in: query, required: true, schema: { type: string } }
-        - { name: accountId, in: query, required: true, schema: { type: string } }
-        - { name: currency, in: query, required: true, schema: { type: string } }
+        - name: cycleId
+          in: query
+          required: true
+          description: Billing cycle identifier, at most 64 characters.
+          schema: { type: string }
+        - name: accountId
+          in: query
+          required: true
+          description: Account identifier, at most 64 characters.
+          schema: { type: string }
+        - name: currency
+          in: query
+          required: true
+          description: >-
+            ISO 4217 alphabetic code. Case-insensitive on input, normalised to upper case before it
+            is persisted, so one currency can never be stored under two spellings.
+          schema: { type: string }
       responses:
         "200":
           description: The persisted assessment (assessed fees, each with its posting status).
         "202":
           description: Four-eyes pending — a second, distinct principal must approve via /fees/approvals/{id}.
         "400":
-          description: Missing required query parameter.
+          description: >-
+            Missing required query parameter, an id longer than 64 characters, or a currency
+            that is not a known ISO 4217 code.
         "401":
           description: Unauthenticated.
         "403":

--- a/openbank-billing-service/src/test/kotlin/com/openbank/billing/BillingResourceValidationTest.kt
+++ b/openbank-billing-service/src/test/kotlin/com/openbank/billing/BillingResourceValidationTest.kt
@@ -1,0 +1,119 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright (c) OpenBank contributors. Licensed under the Apache License, Version 2.0.
+// See LICENSE in the repository root or https://www.apache.org/licenses/LICENSE-2.0 for details.
+
+package com.openbank.billing
+
+import com.openbank.billing.application.usecase.BillingCycleService
+import com.openbank.billing.application.usecase.FeeAssessmentService
+import com.openbank.billing.application.usecase.FeeReversalService
+import com.openbank.billing.domain.BillingAssessment
+import com.openbank.billing.infrastructure.rest.BillingResource
+import io.mockk.coEvery
+import io.mockk.coVerify
+import io.mockk.every
+import io.mockk.mockk
+import io.quarkus.security.identity.SecurityIdentity
+import kotlinx.coroutines.runBlocking
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.Test
+import java.security.Principal
+
+/**
+ * Query-parameter validation on the fee endpoints (#3038).
+ *
+ * The endpoints used to check only `isNullOrBlank`, so any non-blank garbage travelled unchecked
+ * into `persistWithPostingIntent` and died at the schema — `currency CHAR(3) NOT NULL`,
+ * `cycle_id`/`account_id VARCHAR(64)` — as an unmapped Postgres error, i.e. a 500 for a client
+ * error. The authenticated fuzz run found it on `POST /fees/post` with `currency=ISO-2022-CN`.
+ *
+ * The assertion that matters in each case is the pair: **400, and the use case was never reached**.
+ * A 400 alone would still pass if validation ran after the write.
+ */
+class BillingResourceValidationTest {
+
+    private val assessmentService = mockk<FeeAssessmentService>()
+    private val cycleService = mockk<BillingCycleService>()
+
+    private fun resource(): BillingResource {
+        val identity = mockk<SecurityIdentity>()
+        every { identity.principal } returns Principal { "operator-1" }
+        return BillingResource(assessmentService, cycleService, mockk<FeeReversalService>())
+            .also { it.identity = identity }
+    }
+
+    private fun assessment(currency: String) =
+        BillingAssessment("c1", "acc1", currency, skipped = false, skipReason = null, assessedFees = emptyList())
+
+    /** The exact input from the fuzz run. 11 characters into a `CHAR(3)` column. */
+    @Test
+    fun `the fuzz input that produced a 500 is now a 400, and never reaches the use case`(): Unit = runBlocking {
+        val response = resource().post("Windows-1253", "acc1", "ISO-2022-CN")
+
+        assertThat(response.status).isEqualTo(400)
+        assertThat(response.entity.toString()).contains("ISO-2022-CN")
+        coVerify(exactly = 0) { cycleService.assessAndPost(any(), any(), any()) }
+    }
+
+    @Test
+    fun `a three-letter code that is not ISO 4217 is rejected too`(): Unit = runBlocking {
+        val response = resource().post("c1", "acc1", "ZZZ")
+
+        assertThat(response.status).isEqualTo(400)
+        coVerify(exactly = 0) { cycleService.assessAndPost(any(), any(), any()) }
+    }
+
+    @Test
+    fun `an over-long cycleId is rejected before it reaches VARCHAR(64)`(): Unit = runBlocking {
+        val response = resource().post("c".repeat(65), "acc1", "CZK")
+
+        assertThat(response.status).isEqualTo(400)
+        coVerify(exactly = 0) { cycleService.assessAndPost(any(), any(), any()) }
+    }
+
+    @Test
+    fun `an over-long accountId is rejected before it reaches VARCHAR(64)`(): Unit = runBlocking {
+        val response = resource().post("c1", "a".repeat(65), "CZK")
+
+        assertThat(response.status).isEqualTo(400)
+        coVerify(exactly = 0) { cycleService.assessAndPost(any(), any(), any()) }
+    }
+
+    /** Exactly 64 is the column width, so it must pass — an off-by-one here would reject valid ids. */
+    @Test
+    fun `an id of exactly the column width is accepted`(): Unit = runBlocking {
+        val accountId = "a".repeat(64)
+        coEvery { cycleService.assessAndPost("c1", accountId, "CZK") } returns assessment("CZK")
+
+        assertThat(resource().post("c1", accountId, "CZK").status).isEqualTo(200)
+    }
+
+    /**
+     * Case normalisation is deliberate: `czk` and `CZK` would otherwise be two distinct values in
+     * both the `CHAR(3)` column and the `(cycleId, accountId, currency)` idempotency key, so the
+     * same fee could be assessed twice under two spellings of one currency.
+     */
+    @Test
+    fun `a lower-case currency is normalised before it reaches the use case`(): Unit = runBlocking {
+        coEvery { cycleService.assessAndPost("c1", "acc1", "CZK") } returns assessment("CZK")
+
+        assertThat(resource().post("c1", "acc1", "czk").status).isEqualTo(200)
+        coVerify(exactly = 1) { cycleService.assessAndPost("c1", "acc1", "CZK") }
+    }
+
+    /** The pre-existing blank check must keep working — this is the one case that was already 400. */
+    @Test
+    fun `a blank parameter is still a 400`(): Unit = runBlocking {
+        assertThat(resource().post("c1", "acc1", "").status).isEqualTo(400)
+        assertThat(resource().post("c1", null, "CZK").status).isEqualTo(400)
+    }
+
+    /** `/fees/assess` shares the validation, so the dry-run twin must be guarded identically. */
+    @Test
+    fun `the assess dry-run rejects the same input`(): Unit = runBlocking {
+        val response = resource().assess("Windows-1253", "acc1", "ISO-2022-CN")
+
+        assertThat(response.status).isEqualTo(400)
+        coVerify(exactly = 0) { assessmentService.assess(any(), any(), any()) }
+    }
+}


### PR DESCRIPTION
Fixes the last undiagnosed 500 from the first authenticated fuzz run (#3038):
`POST /api/v1/fees/post?...&currency=ISO-2022-CN`.

## What was wrong

`validateParams` checked only `isNullOrBlank`. Everything else about these three parameters
was enforced by the database and nowhere else:

```
V1__init_billing.sql:36    currency  CHAR(3) NOT NULL
V1__init_billing.sql:13/14 cycle_id / account_id  VARCHAR(64) NOT NULL
```

An 11-character currency is non-blank, so it passed, reached
`persistWithPostingIntent`, and Postgres rejected the INSERT. Nothing maps that fault, so
it came out as a 500 — a server error for what is squarely a client error.

## The part worth reading

The fault handling *below* the validation looks like it should have absorbed this, and it is
the reason it did not. `accounts.resolve` is `runCatching{}.getOrNull()`, so an unresolvable
account produces a `skipped = true` assessment — which **still carries the caller's raw
currency** — and `assessAndPost` persists skipped assessments by design. The graceful
degradation branch is therefore exactly the branch that reaches the `CHAR(3)` column.

And `BillingCycleService.runCycle` wraps each account in `runCatching`, so the scheduled
sweep already absorbed this: one bad currency logged and the batch continued. Only the
single-account REST entry point propagated. That is why it never showed up in operation —
the path that runs daily is the protected one, and the exposed path is the one nobody calls
by hand.

## The fix

Currency is parsed through `CurrencyCode` (openbank-libs-domain), the fleet's existing
validating value type — `require(code.length == 3)` plus an ISO 4217 lookup. Billing already
depends on it (`BillingJournalFactory`) but did not use it here, so the invariant was
declared in two places (the value type and the DDL) and enforced in neither of the ones a
request passes through. Ids get an explicit 64-character bound against the same DDL.

`CurrencyCode.of` also upper-cases. That is deliberate and is a behaviour change: `czk` and
`CZK` would otherwise be two distinct values in both the column and the
`(cycleId, accountId, currency)` idempotency key, so the same fee could be assessed twice
under two spellings of one currency.

## Tests

`BillingResourceValidationTest` — 8 cases. Each asserts the **pair**: 400 *and* the use case
was never invoked. A 400 alone would still pass if validation ran after the write. Includes
the exact fuzz input, a 3-letter non-ISO code, both over-long ids, an id of exactly 64
(off-by-one guard), lower-case normalisation, the pre-existing blank check, and the
`/fees/assess` twin that shares the code path.

## Spec

The 400 description said "Missing required query parameter", no longer the whole truth.
`info.version` 1.3.0 -> 1.3.1.

The limits are documented in **prose, not as `pattern`/`maxLength`**. oasdiff classifies a
newly narrowed request parameter as breaking, and ADR-0048 ties the spec's major to the
URL's `/api/v{N}` — so expressing them mechanically would demand `/api/v2` for a change that
does not deserve one. Flagging that explicitly because it is a real gap: the machine-checkable
form of this constraint is unavailable at this layer, and the deterministic guard is the unit
test above, not the spec.

## Verification status

Not compiled locally — the shared Gradle cache on this host is still corrupt
(`NoClassDefFoundError: org/jetbrains/kotlin/compilerRunner/CompilerEnvironment` on
`:build-logic:compilePluginsBlocks`, offline or not). CI is the verifier, as with the
preceding PRs in this series. YAML was validated with a parser; line length and brace
balance checked by hand.

Refs #3038
