### PR TITLE
feat(ai-platform): give the LLM gateway a budget it can actually enforce

### DIFF
--- a/openbank-infra/gitops/components/ai-platform/litellm-config.yaml
+++ b/openbank-infra/gitops/components/ai-platform/litellm-config.yaml
@@ -15,6 +15,13 @@ data:
         litellm_params:
           model: deepinfra/deepseek-ai/DeepSeek-V3.2
           api_key: os.environ/DEEPINFRA_API_KEY
+          # Per-MODEL daily ceiling. Declarative and in git, unlike the per-key budgets, which
+          # exist only in the database because upstream creates keys through /key/generate.
+          # 20 USD/day sits just under the 25 USD/day fleet figure AiFleetDailySpendHigh alerts on,
+          # so the preventive control bites BEFORE the detective one pages — an alert that fires
+          # only after the money is gone is a receipt, not a guardrail.
+          max_budget: 20
+          budget_duration: 1d
       # agent-service's admin-UI assistant model (#1919). It sends `model-gateway.models[].id`
       # verbatim, so the model_name MUST stay `llama-3.3-70b-versatile` — that is what repointing
       # agent-service at this gateway costs: an endpoint + key change, nothing else. The Groq key
@@ -24,7 +31,16 @@ data:
         litellm_params:
           model: groq/llama-3.3-70b-versatile
           api_key: os.environ/GROQ_API_KEY
+          # Lower ceiling: this route serves only agent-service's admin-UI assistant, a single
+          # interactive surface, where the ops models serve every scheduled agent. A shared ceiling
+          # would let a runaway ops loop starve the interactive one, or vice versa.
+          max_budget: 5
+          budget_duration: 1d
     general_settings:
+      # Virtual keys and every budget below persist here. Injected from the CNPG litellm-db-app
+      # secret (components/ai-platform/postgres.yaml) — see the DATABASE_URL note in litellm.yaml
+      # for why it is deliberately NOT optional.
+      database_url: os.environ/DATABASE_URL
       # Callers authenticate to LiteLLM with this virtual key (projected from OpenBao), NOT with the
       # upstream provider key — so the DeepInfra key lives only here, never in an agent pod (ADR-0175).
       master_key: os.environ/LITELLM_MASTER_KEY

--- a/openbank-infra/gitops/components/ai-platform/litellm.yaml
+++ b/openbank-infra/gitops/components/ai-platform/litellm.yaml
@@ -26,7 +26,7 @@ spec:
         # would leave agent-service's repointed call failing "model not found" with a green,
         # in-sync ArgoCD — the same silent-degradation shape as an `optional: true` secret ref.
         # BUMP THIS whenever litellm-config.yaml changes; that is what rolls the pod.
-        openbank.tech/litellm-config-revision: "2"
+        openbank.tech/litellm-config-revision: "3"
     spec:
       securityContext:
         runAsNonRoot: true
@@ -68,6 +68,32 @@ spec:
                 secretKeyRef:
                   name: litellm-secrets
                   key: LITELLM_MASTER_KEY
+                  optional: true
+            # Postgres (CNPG litellm-db) — the prerequisite for virtual keys, which are the only
+            # mechanism that enforces a spend ceiling per CALLER rather than per model. Also what
+            # makes spend counters survive a restart: without a DB LiteLLM holds them in memory and
+            # every pod restart silently resets the budget window to zero.
+            #
+            # `uri` is the ready-made connection string CNPG puts in the -app secret, so there is no
+            # URL assembled from parts here to drift from the credential.
+            #
+            # NOT optional: unlike the provider keys above, a missing DATABASE_URL must not degrade
+            # quietly. Without it the proxy starts, serves traffic and enforces NOTHING — a budget
+            # that silently does not apply is worse than one that was never claimed, because the
+            # dashboards and the ADR both say the ceiling exists.
+            - name: DATABASE_URL
+              valueFrom:
+                secretKeyRef:
+                  name: litellm-db-app
+                  key: uri
+            # Encrypts virtual-key material at rest in that Postgres. Seeded alongside the master
+            # key; optional so the gateway still boots before the seed script has run, which is the
+            # state a fresh environment starts in.
+            - name: LITELLM_SALT_KEY
+              valueFrom:
+                secretKeyRef:
+                  name: litellm-secrets
+                  key: LITELLM_SALT_KEY
                   optional: true
           securityContext:
             allowPrivilegeEscalation: false

--- a/openbank-infra/gitops/components/ai-platform/postgres.yaml
+++ b/openbank-infra/gitops/components/ai-platform/postgres.yaml
@@ -1,0 +1,55 @@
+# Single-owner Postgres for the LiteLLM gateway (cluster-wide CNPG operator, ADR-0119).
+# Generates the litellm-db-app secret (username/password/uri) + litellm-db-rw Service.
+#
+# WHY LiteLLM NEEDS A DATABASE AT ALL. Virtual keys — the only mechanism that can enforce a spend
+# ceiling per CALLER rather than per model — require a Postgres: upstream is explicit that
+# `DATABASE_URL` is a setup prerequisite for them, and keys are created through /key/generate, not
+# declared in config.yaml. Without it the gateway has exactly one credential (the master key) shared
+# by every agent, so "which agent burned the budget" is unanswerable and "stop THAT agent" is
+# unimplementable. The AiFleetDailySpendHigh alert added alongside is a detective control that fires
+# after the money is spent; this is the preventive one that refuses the call.
+#
+# It is also what makes the spend numbers durable. LiteLLM without a DB keeps its counters in
+# memory, so every pod restart resets them to zero — the same "gauge resets on pod restart" shape
+# this repo has been bitten by before, and the reason a config-only `max_budget` was rejected as the
+# whole answer.
+#
+# NOTE: no S3 WAL/backup here, matching devops-agent's and the other control-plane agents' pattern —
+# that needs an EKS Pod Identity role (aws/.../db-backups.tf, #863). The stakes are deliberately
+# different from a banking DB: this holds spend counters and key metadata, not regulated records.
+# Losing it means budget windows restart and the virtual keys must be re-seeded, which is an
+# operational annoyance, not a retention breach. Backups become worth adding the day a key's spend
+# history is used as evidence rather than as a guardrail.
+apiVersion: postgresql.cnpg.io/v1
+kind: Cluster
+metadata:
+  name: litellm-db
+  namespace: ai-platform
+spec:
+  # DB-layer observability: CNPG's built-in Prometheus exporter on :9187 plus a PodMonitor the
+  # operator owns (selected cluster-wide), so cnpg_* metrics appear with no app change. Note this
+  # is a different scrape path from the fleet PodMonitor, which selects on a `management` port.
+  monitoring:
+    enablePodMonitor: true
+  instances: 1
+  # ECR pull-through rather than ghcr.io (issue #1290). CNPG instance pods are correctly excluded
+  # from the Kyverno ecr-pull-through-rewrite policy — the operator reconciles the running pod's
+  # image against spec.imageName, so a mutating webhook would make the pod permanently drift and be
+  # recreated every ~10s. Setting the ref here avoids that. Same tag as the rest of the fleet's
+  # single-owner clusters, so it resolves through a cache path that is already warm.
+  imageName: 265175468565.dkr.ecr.eu-north-1.amazonaws.com/ghcr/cloudnative-pg/postgresql:18.1
+  storage:
+    storageClass: gp3
+    size: 2Gi
+  resources:
+    requests: {cpu: 100m, memory: 256Mi}
+    limits: {cpu: "1", memory: 512Mi}
+  postgresql:
+    parameters:
+      wal_keep_size: "64MB"
+      # Bound WAL so a checkpoint spike cannot fill the 2Gi volume (#1432).
+      max_wal_size: "512MB"
+  bootstrap:
+    initdb:
+      database: litellm
+      owner: litellm

--- a/openbank-infra/scripts/seed-litellm-virtual-keys.sh
+++ b/openbank-infra/scripts/seed-litellm-virtual-keys.sh
@@ -1,0 +1,123 @@
+#!/usr/bin/env bash
+# Seed one LiteLLM virtual key PER AGENT, each with its own daily budget (ADR-0112 / ADR-0174).
+#
+# WHY THIS IS NOT A KUBERNETES JOB. Creating a key needs the master key, and the OUTPUT is a new
+# credential that has to reach OpenBao and then each agent's namespace. A Job doing that would need
+# both the proxy admin credential and OpenBao write access in one pod — a strictly larger blast
+# radius than an operator running this from their own session, for something done once per
+# environment. Same reasoning as seed-litellm-gateway.sh, which this deliberately mirrors.
+#
+# WHAT IT BUYS. Today every agent authenticates to the gateway with the SAME master key, so:
+#   - "which agent burned the budget" is unanswerable — spend is attributed to one shared key;
+#   - "stop THAT agent" is unimplementable — the only lever revokes the whole fleet;
+#   - the per-model ceilings in litellm-config.yaml are the only enforcement, and they cannot tell
+#     a runaway scheduler from ordinary interactive use of the same model.
+# A per-agent key fixes all three, and LiteLLM refuses the call once the budget is spent — a
+# preventive control, where AiFleetDailySpendHigh is only detective.
+#
+# BUDGETS. Deliberately summing to less than the per-model ceilings in litellm-config.yaml (20 USD
+# for the ops model, 5 for the interactive one), which in turn sit under the 25 USD/day fleet figure
+# AiFleetDailySpendHigh alerts on. Each layer bites before the one outside it, so the alert is the
+# last line rather than the first.
+#
+# RUN:
+#     export AWS_PROFILE=openbank          # kubectl + break-glass access to the sandbox
+#     ./openbank-infra/scripts/seed-litellm-virtual-keys.sh
+#
+# IDEMPOTENT: a key whose alias already exists is left alone and reported, so a re-run does not
+# silently rotate a credential the agents are using. Pass --rotate to replace one on purpose.
+set -euo pipefail
+
+NS_GW="ai-platform"
+
+# alias:daily-budget-usd. The alias is the agent's charter id, so a spend row in LiteLLM joins
+# straight onto agents.yaml and onto the openbank_llm_* series without a mapping table.
+AGENT_BUDGETS=(
+  "devops-agent:3"
+  "control-liveness-sentinel:3"
+  "copilot-service:8"          # customer-facing, interactive, highest legitimate volume
+  "agent-service:5"            # admin-UI assistant; matches the llama route's own ceiling
+)
+
+ROTATE=0
+[[ "${1:-}" == "--rotate" ]] && ROTATE=1
+
+command -v kubectl >/dev/null || { echo "ERROR: kubectl not on PATH." >&2; exit 1; }
+command -v jq      >/dev/null || { echo "ERROR: jq not on PATH." >&2; exit 1; }
+
+echo "[1/4] Reading the master key from the running gateway's own Secret ..."
+# Read it from the cluster rather than from OpenBao: what matters is the key the RUNNING proxy is
+# actually using. If those two have drifted, seeding against OpenBao's copy would mint keys the
+# gateway rejects, and the failure would only show up as agents degrading to their fallback.
+MASTER_KEY="$(kubectl -n "$NS_GW" get secret litellm-secrets \
+  -o jsonpath='{.data.LITELLM_MASTER_KEY}' 2>/dev/null | base64 -d || true)"
+[[ -n "$MASTER_KEY" ]] || {
+  echo "ERROR: litellm-secrets/LITELLM_MASTER_KEY is empty in namespace $NS_GW." >&2
+  echo "       Run ./openbank-infra/scripts/seed-litellm-gateway.sh first." >&2
+  exit 1
+}
+
+echo "[2/4] Port-forwarding to the gateway ..."
+kubectl -n "$NS_GW" port-forward svc/litellm 14001:4000 >/dev/null 2>&1 &
+PF_PID=$!
+trap 'kill "$PF_PID" 2>/dev/null || true' EXIT
+for _ in $(seq 1 30); do
+  curl -sf --max-time 2 http://127.0.0.1:14001/health/liveliness >/dev/null 2>&1 && break
+  sleep 1
+done
+curl -sf --max-time 2 http://127.0.0.1:14001/health/liveliness >/dev/null 2>&1 || {
+  echo "ERROR: gateway did not answer /health/liveliness through the port-forward." >&2
+  exit 1
+}
+
+echo "[3/4] Checking DATABASE_URL is actually in effect ..."
+# Without a database LiteLLM accepts /key/generate calls in some versions and persists nothing, so
+# the script would report success over keys that vanish on the next restart. Ask the proxy.
+if ! curl -sf --max-time 10 http://127.0.0.1:14001/key/list \
+      -H "Authorization: Bearer $MASTER_KEY" >/dev/null 2>&1; then
+  echo "ERROR: /key/list failed — the gateway most likely has no DATABASE_URL." >&2
+  echo "       Virtual keys REQUIRE Postgres (components/ai-platform/postgres.yaml)." >&2
+  exit 1
+fi
+
+EXISTING="$(curl -s --max-time 10 http://127.0.0.1:14001/key/list \
+  -H "Authorization: Bearer $MASTER_KEY" | jq -r '[.keys[]?.key_alias // empty] | join(" ")')"
+
+echo "[4/4] Seeding per-agent keys ..."
+for entry in "${AGENT_BUDGETS[@]}"; do
+  alias="${entry%%:*}"
+  budget="${entry##*:}"
+
+  if [[ " $EXISTING " == *" $alias "* && "$ROTATE" -eq 0 ]]; then
+    echo "      = $alias already has a key (budget unchanged) — skipping. Use --rotate to replace."
+    continue
+  fi
+
+  resp="$(curl -s --max-time 20 -X POST http://127.0.0.1:14001/key/generate \
+    -H "Authorization: Bearer $MASTER_KEY" -H 'Content-Type: application/json' \
+    -d "{\"key_alias\":\"$alias\",\"max_budget\":$budget,\"budget_duration\":\"1d\"}")"
+
+  key="$(echo "$resp" | jq -r '.key // empty')"
+  [[ -n "$key" ]] || {
+    echo "ERROR: /key/generate returned no key for $alias. Response (no secrets): " >&2
+    echo "$resp" | jq -r 'del(.key)' >&2
+    exit 1
+  }
+  # The VALUE is never echoed. Write it to OpenBao yourself, or pipe this into your secret store;
+  # printing a live credential into a terminal scrollback is how it ends up in a paste.
+  echo "      + $alias  budget=${budget} USD/day  key=${key:0:7}… (value not printed)"
+  echo "$alias $key" >> "${SEED_OUT:-/dev/null}"
+done
+
+cat <<'ENDNOTE'
+
+NEXT STEPS (not automated on purpose — each writes a credential):
+  1. Re-run with SEED_OUT=<path> to capture the values, write them into OpenBao under
+     openbank/litellm-keys, and shred the file.
+  2. Point each agent at its own key instead of the shared master key (its *_MODEL_API_KEY /
+     model.api-key entry), then restart it.
+  3. Verify attribution: the openbank_llm_requests_total series should now split by agent once
+     each has its own key, and LiteLLM's /spend/logs attributes spend per key_alias.
+
+Until step 2 lands the agents still share the master key, so these budgets exist but bind nothing.
+ENDNOTE


### PR DESCRIPTION
## Summary

`AiFleetDailySpendHigh` (#3043) is a **detective** control — it fires after the money is gone. This is the **preventive** one: the gateway refuses the call.

## Type of change

- [x] feat (new functionality)

## Linked issues

Refs #3042, ADR-0112, ADR-0119, ADR-0174, ADR-0175

## Three layers, each biting before the one outside it

| layer | ceiling | answers |
|---|---|---|
| per-agent virtual key | 3–8 USD/day | *who* spent it, and stop just them |
| per-model (in git) | 5–20 USD/day | declarative, reviewable |
| fleet alert | 25 USD/day | last line, not first |

## Why Postgres is a hard prerequisite, not a nice-to-have

Virtual keys are the only mechanism that bounds spend per **caller** rather than per model, and upstream is explicit that they require a `DATABASE_URL` — keys are created through `/key/generate`, never declared in `config.yaml`. Without one the gateway has exactly **one** credential shared by every agent, so:

- "which agent burned the budget" is unanswerable,
- "stop *that* agent" revokes the whole fleet.

A database also makes the counters durable. LiteLLM without one keeps spend in memory, so every pod restart silently resets the budget window to zero — the same *"gauge resets on pod restart"* shape this repo has already been bitten by, and the reason a config-only `max_budget` was rejected as the whole answer.

## Changes

- **CNPG `litellm-db`** in `ai-platform`, following devops-agent's single-owner pattern verbatim: 1 instance, gp3, ECR pull-through `imageName` (so the Kyverno rewrite webhook does not fight the operator's own reconcile loop), bounded WAL, PodMonitor on.
- **`DATABASE_URL` deliberately NOT `optional`**, unlike every other secret ref on this Deployment. A missing provider key degrades to a deterministic fallback, which is safe; a missing `DATABASE_URL` would leave the proxy serving traffic and enforcing **nothing** — a budget that silently does not apply is worse than one never claimed, because the dashboard and the ADR both say the ceiling exists. Reads CNPG's ready-made `uri` key, so there is no URL assembled from parts to drift from the credential.
- **Config revision bumped 2 → 3.** LiteLLM parses `--config` once at startup; without the bump the ConfigMap changes and the running proxy keeps its old model list.
- **Per-model budgets in `litellm-config.yaml`** because they *can* be declarative.
- **`seed-litellm-virtual-keys.sh`** for the per-agent keys, which cannot be. It mirrors the existing `seed-litellm-gateway.sh` rather than becoming a Job: a Job would need the proxy admin credential **and** OpenBao write access in one pod — a strictly larger blast radius than an operator running it once per environment. Idempotent (an existing alias is left alone unless `--rotate`), never prints a key value, and checks `/key/list` first so it cannot report success against a gateway with no database.

## No S3 backup, stated rather than omitted

The manifest records the trade: this holds spend counters and key metadata, not regulated records. Losing it restarts budget windows and forces a re-seed — an operational annoyance, not a retention breach. That calculus changes the day spend history is used as *evidence* rather than as a guardrail, and the comment says so.

## Verification — against the real thing, not the docs

- Booted `litellm v1.74.3-stable` (the deployed tag) with **this ConfigMap's** `config.yaml` against a real Postgres: Prisma migrated the schema, `/health/liveliness` alive in 14s.
- `POST /key/generate` returned a working per-agent key with `max_budget=3.0`, `budget_duration=1d`, scoped to one model — so virtual keys function under this exact config, not just in principle.
- `GET /model/info` confirms **both** per-model ceilings loaded from the ConfigMap (`20.0/1d`, `5.0/1d`). A budget that failed to parse would otherwise be silently absent, which is the failure mode that matters here.
- `shellcheck -S warning` on the new script: clean.
- yamllint with `ci.yml`'s own inline config: clean. Duplicate-key guard: 54 files, clean.
- `gen-network-policies.py` re-run: no diff. CNPG pods are deliberately left unselected by the generator (its own header records why), same as every other single-owner DB in the fleet.

## ⚠️ Honest limitation

**Until each agent is repointed from the shared master key to its own virtual key, the per-agent budgets exist but bind nothing.** The per-model ceilings and the durable counters are live immediately; the per-agent layer needs a credential written per agent, which is an operator step. The script's closing note says this too, so it cannot be mistaken for done.

## Definition of Done

- [x] Hexagonal layering — n/a, infra only.
- [ ] Unit / integration / contract tests — n/a; the executable check is the live LiteLLM + Postgres run above.
- [ ] `./gradlew ...` — n/a, no Kotlin change.
- [x] No new lint warnings (yamllint + shellcheck).
- [ ] OpenAPI / Flyway / Avro — n/a. The schema is Prisma's, migrated by LiteLLM itself at startup.
- [x] Docs updated — the reasoning lives in the manifests and the script header.

## Security checklist

- [x] No secrets, tokens, passwords, or PII in code, config, tests, logs. The script never prints a key value and redacts `.key` from an error response; `DATABASE_URL` is a secret ref.
- [x] No new `@SuppressWarnings` / `@Suppress`.
- [x] New component: a CNPG Postgres, same operator and image path already used by ~10 single-owner clusters in this repo.
- [ ] **Auth-adjacent — reviewer attention.** This introduces a credential-issuing surface (`/key/generate` behind the master key) and a database holding key material. `LITELLM_SALT_KEY` encrypts that material at rest. Worth a second pair of eyes on the master-key handling in the script.
- [x] No PII path changed — the database holds spend counters and key metadata, never prompts.
- [x] No cardholder data path changed.

## Compliance impact

- [x] DORA — ICT third-party cost control moves from detective to preventive, with per-caller attribution.
- [x] EU AI Act adjacent — per-agent spend attribution is the record-keeping half of "which system did what".

## Deployment note

`rules.yaml` and the `.rego` policies are untouched, so no OPA bundle restamp. The CNPG cluster provisions before the Deployment can start (`DATABASE_URL` is a required secret ref, so the pod stays Pending until `litellm-db-app` exists — deliberate). LiteLLM migrates its own schema on first boot.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
