### PR TITLE
fix(ci): the Loki gate's FinOps fix only scoped the cheap half

### DIFF
--- a/.github/scripts/check-loki-rules.py
+++ b/.github/scripts/check-loki-rules.py
@@ -205,11 +205,31 @@ def run_gate() -> int:
     return 1
 
 
-def self_test() -> int:
-    """A gate that has only ever passed is unfalsified. Feed it a file it MUST reject."""
+def self_test(since: str | None = None) -> int:
+    """A gate that has only ever passed is unfalsified. Feed it a file it MUST reject.
+
+    Scoped by --since for the same reason the gate itself is, and measured the same way: the
+    self-test boots Loki TWICE (a case it must pass, a case it must flag), which cost 1m46s on the
+    first main run after it shipped, against 0s for the enforced step it sits in front of. Scoping
+    only the enforced half — as the first version of this did — moved the cheap step and left the
+    expensive one charging every PR in the fleet. Found by reading the step timings CI printed, not
+    from the design.
+
+    Skipping is safe here in a way it usually is not, because RULE_INPUTS already contains
+    everything that could newly break this self-test: the rule ConfigMaps, apps/loki.yaml, and THIS
+    SCRIPT — which is where LOKI_IMAGE lives. So the self-test runs on exactly the changes that
+    could invalidate it, and stays silent on the ones that cannot.
+    """
     if not shutil.which("docker"):
         print("::warning title=Loki rules::docker not available — cannot run the self-test.")
         return 0
+    if since:
+        changed, detail = rule_inputs_changed(since)
+        if not changed:
+            print(f"check-loki-rules --self-test: SKIPPED — {detail}. The gate is unchanged and "
+                  f"was falsified on the PR that last touched it.")
+            return 0
+        print(f"check-loki-rules --self-test: {detail}")
     failures = []
     good = {"good": yaml.safe_dump({"groups": [{
         "name": "selftest.good", "interval": "5m", "rules": [{
@@ -259,30 +279,48 @@ RULE_INPUTS = [
 
 
 def rule_inputs_changed(base_ref: str) -> tuple[bool, str]:
-    """-> (changed, detail). Fails OPEN: an unanswerable git question runs the check."""
+    """-> (changed, detail). Fails OPEN: an unanswerable git question runs the check.
+
+    Counts UNCOMMITTED work as changed, not just the committed diff. `git diff base...HEAD` compares
+    commits, so a developer who edits a rule and runs this before committing would be told "skipped"
+    and could push a broken rule believing it was checked. CI never hits that (its changes are always
+    committed) which is exactly why it would have gone unnoticed — the local experience is the one
+    that misleads.
+    """
+    files: list[str] = []
     try:
-        out = subprocess.run(
+        files += subprocess.run(
             ["git", "diff", "--name-only", f"{base_ref}...HEAD", "--", *RULE_INPUTS],
-            capture_output=True, text=True, cwd=REPO, check=True).stdout
+            capture_output=True, text=True, cwd=REPO, check=True).stdout.splitlines()
     except (subprocess.CalledProcessError, OSError) as ex:
         # Never skip because git was unhappy — that would turn an infrastructure hiccup into a
         # silently unchecked rule set, which is the failure mode this whole file exists to prevent.
         return True, f"could not diff against {base_ref} ({ex}) — running the load test anyway"
-    files = [f for f in out.splitlines() if f.strip()]
-    if not files:
-        return False, f"no rule inputs changed vs {base_ref}"
-    return True, f"{len(files)} rule input(s) changed vs {base_ref}: {', '.join(files[:5])}"
+    try:
+        # Working tree + index + untracked, so a brand-new rule file counts before its first commit.
+        porcelain = subprocess.run(
+            ["git", "status", "--porcelain", "--", *RULE_INPUTS],
+            capture_output=True, text=True, cwd=REPO, check=True).stdout
+        files += [ln[3:].strip() for ln in porcelain.splitlines() if ln[3:].strip()]
+    except (subprocess.CalledProcessError, OSError):
+        return True, "could not read the working tree — running the load test anyway"
+
+    uniq = sorted({f for f in files if f.strip()})
+    if not uniq:
+        return False, f"no rule inputs changed vs {base_ref} (committed or working tree)"
+    return True, f"{len(uniq)} rule input(s) changed vs {base_ref}: {', '.join(uniq[:5])}"
 
 
 def main() -> int:
     ap = argparse.ArgumentParser()
     ap.add_argument("--self-test", action="store_true", help="prove the gate can fail")
     ap.add_argument("--since", metavar="REF",
-                    help="skip the load test when no rule input changed vs REF (e.g. origin/main). "
-                         "Omit to always run.")
+                    help="skip when no rule input changed vs REF (e.g. origin/main). Applies to "
+                         "BOTH the gate and --self-test — each boots Loki, and the self-test boots "
+                         "it twice. Omit to always run.")
     args = ap.parse_args()
     if args.self_test:
-        return self_test()
+        return self_test(args.since)
     if args.since:
         changed, detail = rule_inputs_changed(args.since)
         if not changed:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -416,7 +416,9 @@ jobs:
       # its image, so the only reachable LogQL parser is a real ruler. The self-test runs first and
       # feeds it a file it MUST reject.
       - name: "Loki rule load test self-test"
-        run: python3 .github/scripts/check-loki-rules.py --self-test
+        run: |
+          git fetch origin "${{ github.base_ref || github.ref_name }}:refs/remotes/origin/${{ github.base_ref || github.ref_name }}" --no-tags || true
+          python3 .github/scripts/check-loki-rules.py --self-test --since "origin/${{ github.base_ref || github.ref_name }}"
       # --since scopes the EXPENSIVE half (pull ~100 MB + boot Loki, ~90 s) to PRs that can
       # actually invalidate it. This job is unconditional and required, so an unscoped run charged
       # every PR in the fleet 90 s for a check about files it did not touch. Direct cost is $0


### PR DESCRIPTION
## Summary

#3060 claimed to scope the expensive Loki load test to PRs that can invalidate it. **It scoped the wrong step.**

## The measurement

First main run after #3060 merged:

```
Loki rule load test self-test   07:58:53 -> 08:00:39   1m46s
Loki rule load test (enforced)  08:00:39 -> 08:00:39   0s
```

The enforced step skipped correctly. The **self-test** — which boots Loki *twice*, once for the case it must pass and once for the case it must flag — ran unconditionally. So every PR in the fleet still paid ~1m46s on a required check. The half I moved was the half that cost nothing.

Found by reading what CI printed, not from the design. The design looked right; the step that proved it wrong was the one I had not thought to time.

## Fix 1 — scope the self-test too

`--since` now applies to `--self-test`.

Skipping a self-test is normally the wrong instinct — an unfalsified gate is this repo's recurring scar. It is safe here for a *structural* reason rather than a judgement call: `RULE_INPUTS` already contains everything that could newly break it — the rule ConfigMaps, `apps/loki.yaml`, and **this script**, which is where `LOKI_IMAGE` lives. The self-test therefore runs on exactly the changes that could invalidate it and stays silent on the ones that cannot. It is not "trust me", it is "the input set is the same set".

## Fix 2 — a second defect, found while verifying the first

`rule_inputs_changed()` used `git diff base...HEAD`, which compares **commits**. A developer who edits a rule and runs the gate before committing was told `SKIPPED` and could push a broken rule believing it had been checked.

CI never hits this — its changes are always committed — which is precisely why it would have gone unnoticed. The misleading path is the local one, and it is the one a human actually uses. It now also reads `git status --porcelain` over the same paths, so working-tree and untracked changes count.

## Verification — all four paths

| invocation | result |
|---|---|
| `--self-test --since HEAD` | skips; says the gate is unchanged and was falsified earlier |
| `--self-test --since origin/main` | runs both cases (detects this commit's own edit), both ok |
| `--since HEAD` | skips the load test, names how many rule files are in tree |
| `--since origin/main` | loads the committed rules, ruler accepts 1 group |

actionlint finding **sets** diffed against `origin/main`: unchanged.

## Linked issues

Refs #3062

## Definition of Done

- [x] Hexagonal layering — n/a, CI tooling.
- [x] Tests: the gate's own self-test, still green in both directions when it runs.
- [ ] Integration / contract tests — n/a.
- [ ] `./gradlew ...` — n/a, no Kotlin change.
- [x] No new lint warnings (actionlint sets diffed).
- [ ] OpenAPI / Flyway / Avro — n/a.
- [x] Docs updated — both defects and their reasoning are recorded in the script's docstrings.

## Security checklist

- [x] No secrets, tokens, passwords, or PII in code, config, tests, logs.
- [x] No new `@SuppressWarnings` / `@Suppress`.
- [x] No new third-party dependency.
- [x] No auth / crypto / payment code changed.
- [x] No PII path changed.
- [x] No cardholder data path changed.

## Compliance impact

- [x] None.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
