### PR TITLE
docs: trivy's ignore is repo-wide or nothing, and a check can match its own explanatory comment

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -382,6 +382,18 @@ fire from *outside* it, so they stay here:
   the annotation, because comments are stripped *by design* (#2450). Generalize: a guard over source
   text needs an explicit rule for code-about-code, and stale prose naming a dead identifier is
   invisible to it forever — grep the prose separately after any vocabulary rename.
+- **The same collision runs the other way, and that direction is silent: a check greps a file for the
+  string it wants, and matches the COMMENT that explains why the string is there.** A false positive
+  announces itself; this one reads as a pass. On #3072 a test asserted `middleware.ts` excludes
+  `/api/gate` with a whole-file `toMatch(/api\/gate/)` — the exclusion is explained by a five-line
+  comment directly above it that names the path three times, so deleting the exclusion itself left
+  the test green. Fix: strip comments, then assert against the **construct**, not the file
+  (`config.matcher`, the annotation value, the specific key) — a whole-file grep can never
+  distinguish the thing from the prose about the thing. Same PR, same class, second instance: an
+  Ingress/allow-list agreement check built its tool set with `[a-z0-9-]+`, so a typo'd
+  `?tool=grafanaX` matched on the `grafana` prefix and it reported agreement with a tool the gate
+  does not know. Both were found only by feeding the assertions the exact broken input they exist to
+  reject — a new assertion that has only ever seen the correct file is unfalsified.
 - **An "advisory" gate is usually advisory INSIDE the script, not via `continue-on-error`** — 11 of
   12 here print `::warning` and exit 0 unless passed `--enforce`. A sweep for `continue-on-error:
   true` therefore finds one and silently reports the other eleven as enforced. Check both forms

--- a/openbank-infra/CLAUDE.md
+++ b/openbank-infra/CLAUDE.md
@@ -75,6 +75,19 @@ out of it (they are path-scoped, not less important — several are live-inciden
   admission for that image (admin-ui outage, 2026-07-09). Producers must call the shared
   `openbank-infra/scripts/lib/cosign-attest.sh` (which passes `--platform` and hard-fails), never
   hand-roll `trivy`+`cosign attest` again.
+- **An inline `#trivy:ignore:<ID>` comment does NOT suppress a Kubernetes misconfig finding — the
+  only lever is `.trivyignore`, which is repo-wide.** `Trivy config (IaC) scan` in `security.yml`
+  runs `trivy config … --ignorefile .trivyignore openbank-infra`, and on trivy 0.72 the inline form
+  was measured against all three plausible spellings (`KSV-0108`, `AVD-KSV-0108`, `KSV0108`) above
+  the resource: the finding still reports in every case. So there is no narrow, in-place way to
+  accept one resource — a baseline entry silently exempts every *future* occurrence too. When you
+  add one, say so in the comment and pair it with something that counts the occurrences, so the
+  second one has to be justified rather than inheriting the exemption. `AVD-KSV-0108` (the ADR-0234
+  `grafana-tools` ExternalName Service, an in-cluster target the CVE-2020-8554 check cannot
+  distinguish from an external one) is the worked example: `tools-gate.test.ts` asserts it stays the
+  only `type: ExternalName` in gitops. Verify a baseline edit the same way — re-run with the OLD
+  ignorefile and confirm it still exits 1, or you cannot tell your new line from the scan going
+  quiet for some unrelated reason.
 - **Kyverno verifies at ADMISSION, not continuously — a running pod is NOT evidence its image is
   attested.** An unattested image keeps running; it is denied only on the next reschedule (node
   roll, eviction, scale-up) and then can never restart, one pod at a time. So "the fleet is


### PR DESCRIPTION
Refs #3071

Two footguns measured while building the ADR-0234 edge gate (#3072). Both are the same shape — the thing meant to catch a mistake could not express it — and both were found only by feeding a check the exact broken input it exists to reject.

## 1. `openbank-infra/CLAUDE.md` — trivy's ignore is repo-wide or nothing

`Trivy config (IaC) scan` (`security.yml:300`) runs `trivy config … --ignorefile .trivyignore openbank-infra`. An inline `#trivy:ignore:<ID>` comment above the resource does **not** suppress a Kubernetes misconfig finding: measured on trivy 0.72 against `KSV-0108`, `AVD-KSV-0108` and `KSV0108`, the finding still reports in all three cases.

So there is no narrow, in-place way to accept one resource. A `.trivyignore` entry silently exempts every *future* occurrence too — which is a real cost when the check is something like `AVD-KSV-0108` (Service with `externalName`, i.e. CVE-2020-8554), where the next occurrence might genuinely point outside the cluster.

The bullet says: when you add one, state the blast radius in the comment and pair it with something that counts the occurrences, so the second one has to be justified rather than inheriting the exemption. And verify the edit by re-running with the **old** ignorefile — otherwise you cannot tell your new line from the scan going quiet for an unrelated reason.

## 2. `CLAUDE.md` — the inverse of the #2450 bullet it sits under

The existing bullet covers a guard flagging the prose that explains the bug it hunts. That is a false positive, and a false positive announces itself.

This is the other direction: a check greps a file for the string it wants and matches the **comment explaining why the string is there**. That reads as a pass.

Concretely, on #3072 a test asserted `middleware.ts` excludes `/api/gate` with a whole-file `toMatch(/api\/gate/)`. The exclusion is explained by a five-line comment directly above it that names the path three times — so deleting the exclusion itself left the test green. Fix: strip comments and assert against the *construct* (`config.matcher`), not the file.

Same PR, same class: an agreement check between an Ingress annotation and a route's allow-list built its tool set with `[a-z0-9-]+`, so a typo'd `?tool=grafanaX` matched on the `grafana` prefix and it reported agreement with a tool the gate does not know.

## Routing

Per `rules.yaml: knowledge_capture` — both are operational footguns, so one-line-ish bullets rather than a rule or an ADR. The trivy one fires only inside `openbank-infra` (that is the scan's entire scope), so it goes in that tree's `CLAUDE.md`; the self-matching-check one fires fleet-wide, so it goes in root next to the bullet it inverts.

Docs only — no shipped code, no release.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
