### PR TITLE
fix(ci): make the fuzz harness able to boot reactive-only services, and report why when it cannot

### DIFF
--- a/.github/workflows/api-fuzz-authenticated.yml
+++ b/.github/workflows/api-fuzz-authenticated.yml
@@ -83,7 +83,7 @@ jobs:
       - name: Start Keycloak (throwaway realm)
         run: |
           set -euo pipefail
-          docker run -d --name fuzz-keycloak -p 8080:8080 \
+          docker run -d --name fuzz-keycloak -p 8543:8080 \
             -e KC_BOOTSTRAP_ADMIN_USERNAME=admin \
             -e KC_BOOTSTRAP_ADMIN_PASSWORD=admin \
             -v "$PWD/.github/workflows/keycloak:/opt/keycloak/data/import:ro" \
@@ -93,7 +93,7 @@ jobs:
           KC_UP=0
           for i in $(seq 1 60); do
             code="$(curl -s -o /dev/null -w '%{http_code}' \
-              http://localhost:8080/realms/openbank/.well-known/openid-configuration || true)"
+              http://localhost:8543/realms/openbank/.well-known/openid-configuration || true)"
             if [ "$code" = "200" ]; then KC_UP=1; break; fi
             sleep 3
           done
@@ -130,8 +130,9 @@ jobs:
           echo "==> [${svc}] starting quarkusDev with OIDC on"
           ./gradlew ":${svc}:quarkusDev" \
             -Dquarkus.console.basic=true --console=plain --quiet \
+            -Dquarkus.datasource.jdbc.url="jdbc:postgresql://localhost:5432/${DB}" \
             -Dquarkus.oidc.enabled=true \
-            -Dquarkus.oidc.auth-server-url=http://localhost:8080/realms/openbank \
+            -Dquarkus.oidc.auth-server-url=http://localhost:8543/realms/openbank \
             -Dquarkus.oidc.client-id=openbank-services \
             -Dquarkus.oidc.credentials.secret="${OIDC_CLIENT_SECRET}" \
             > "fuzz-reports/${svc}-boot.log" 2>&1 &
@@ -144,12 +145,23 @@ jobs:
             sleep 2
           done
           if [ "$UP" != "1" ]; then
-            echo "::error::[${svc}] failed to boot"; tail -60 "fuzz-reports/${svc}-boot.log"; exit 1
+            echo "::error::[${svc}] failed to boot"
+            # A blind `tail` puts the root cause above the window — every ERROR and every
+            # `Caused by:` is what actually identifies it (issue #3039: six of seven services
+            # were "not determined" purely because of this).
+            echo "--- boot failure: ERROR lines and cause chain ---"
+            sed -E 's/\x1b\[[0-9;]*m//g' "fuzz-reports/${svc}-boot.log" \
+              | grep -E ' ERROR |Caused by:|Failed to start|Port already bound' \
+              | grep -v 'ht.wire' | tail -40
+            echo "--- last 40 lines ---"
+            tail -40 "fuzz-reports/${svc}-boot.log"
+            echo "(full log in the api-fuzz-auth-reports-${svc} artifact)"
+            exit 1
           fi
 
           # client_credentials token for the confidential service client.
           TOKEN="$(curl -s -X POST \
-            http://localhost:8080/realms/openbank/protocol/openid-connect/token \
+            http://localhost:8543/realms/openbank/protocol/openid-connect/token \
             -d grant_type=client_credentials \
             -d client_id=openbank-services \
             -d client_secret="${OIDC_CLIENT_SECRET}" | jq -r '.access_token')"

--- a/.github/workflows/api-fuzz.yml
+++ b/.github/workflows/api-fuzz.yml
@@ -91,11 +91,13 @@ jobs:
                   skipped.append((svc, "no application.yaml or openapi.yaml")); continue
               raw = app.read_text()
               port = re.search(r"^  http:\n(?:.*\n)?\s*port:\s*(\d+)", raw, re.M)
-              db = re.search(r"jdbc:postgresql://[^/]+/([A-Za-z0-9_]+)", raw)
+              # Reactive-only services carry no jdbc: URL (their Agroal datasource is
+              # supplied at boot below). The DB name is in the reactive URL all the same.
+              db = re.search(r"(?:jdbc:)?(?:vertx-reactive:)?postgresql://[^/]+/([A-Za-z0-9_]+)", raw)
               if not port:
                   skipped.append((svc, "no derivable quarkus.http.port")); continue
               if not db:
-                  skipped.append((svc, "no jdbc:postgresql URL — the harness cannot provision its DB")); continue
+                  skipped.append((svc, "no postgresql:// URL — the harness cannot provision its DB")); continue
               keep.append(svc)
 
           for svc, why in skipped:
@@ -176,7 +178,7 @@ jobs:
             # Derive the HTTP port and database name from the service's own
             # config — no per-service table to rot.
             PORT="$(grep -m1 -A3 '^  http:' "$APP_YAML" | grep -m1 'port:' | grep -oE '[0-9]+')"
-            DB="$(grep -m1 'jdbc:postgresql://' "$APP_YAML" | sed -E 's|.*/([A-Za-z0-9_]+).*|\1|')"
+            DB="$(grep -m1 -E 'postgresql://' "$APP_YAML" | sed -E 's|.*/([A-Za-z0-9_]+).*|\1|')"
             DBUSER="$(grep -m1 '^    username:' "$APP_YAML" | awk '{print $2}')"
             echo "==> [${svc}] port=${PORT} db=${DB} user=${DBUSER}"
 
@@ -207,6 +209,7 @@ jobs:
             # (the transactional outbox keeps brokers out of the request path).
             echo "==> [${svc}] starting quarkusDev"
             ./gradlew ":${svc}:quarkusDev" \
+              -Dquarkus.datasource.jdbc.url="jdbc:postgresql://localhost:5432/${DB}" \
               -Dquarkus.console.basic=true \
               --console=plain --quiet \
               > "fuzz-reports/${svc}-boot.log" 2>&1 &

--- a/.github/workflows/security.yml
+++ b/.github/workflows/security.yml
@@ -37,6 +37,7 @@ jobs:
     outputs:
       run_sbom: ${{ steps.f.outputs.run_sbom }}
       run_codeql: ${{ steps.f.outputs.run_codeql }}
+      codeql_matrix: ${{ steps.f.outputs.codeql_matrix }}
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
@@ -53,10 +54,42 @@ jobs:
           # ~14 min java-kotlin autobuild is pure waste there. CodeQL is NOT a required
           # check, so skipping it on such PRs is safe — the weekly + main-push full scan
           # (and Trivy on every PR) still cover them.
-          CODE_RE='(\.(java|kt|kts)$|(^|/)(build|settings)\.gradle|gradle/|\.(js|jsx|ts|tsx|mjs|cjs)$|(^|/)package(-lock)?\.json$|(^|/)Dockerfile|\.github/workflows/)'
+          # Per LANGUAGE, because the analysis is per language: a PR that changes only
+          # .ts has nothing for the java-kotlin leg to look at, and vice versa.
+          JAVA_RE='(\.(java|kt|kts)$|(^|/)(build|settings)\.gradle|gradle/|(^|/)Dockerfile)'
+          JS_RE='(\.(js|jsx|ts|tsx|mjs|cjs)$|(^|/)package(-lock)?\.json$)'
+          CODE_RE="($JAVA_RE|$JS_RE)"
+          # NOTE: .github/workflows/ is deliberately NOT in either pattern. A workflow-only
+          # PR changes no analysable source, so every compile resolves from cache, CodeQL
+          # traces nothing, and `analyze` dies with "could not process any code written in
+          # Java/Kotlin" (issue seen on PR #3079). Including workflows bought no coverage —
+          # it bought a guaranteed red on exactly the PRs that change no code.
+
+          # Emits codeql_matrix as a JSON array of matrix entries; '[]' means skip the job.
+          emit_matrix() {
+            local java="$1" js="$2" out="["
+            if [ "$java" = "true" ]; then
+              out="$out{\"language\":\"java-kotlin\",\"build-mode\":\"manual\"}"
+              if [ "$js" = "true" ]; then out="$out,"; fi
+            fi
+            if [ "$js" = "true" ]; then
+              out="$out{\"language\":\"javascript-typescript\",\"build-mode\":\"none\"}"
+            fi
+            out="$out]"
+            echo "codeql_matrix=$out" >> "$GITHUB_OUTPUT"
+            echo "codeql matrix: $out"
+          }
+          # Same reason: a bare `grep -q ... && VAR=true` is fatal under errexit when it
+          # does not match, which is the common case. classify() never fails.
+          classify() {
+            J=false; S=false
+            if printf '%s\n' "$1" | grep -qE "$JAVA_RE"; then J=true; fi
+            if printf '%s\n' "$1" | grep -qE "$JS_RE"; then S=true; fi
+          }
           # schedule / manual: always run the full audit.
           if [ "$EVENT" = "schedule" ] || [ "$EVENT" = "workflow_dispatch" ]; then
-            echo "run_sbom=true" >> "$GITHUB_OUTPUT"; echo "run_codeql=true" >> "$GITHUB_OUTPUT"; exit 0
+            echo "run_sbom=true" >> "$GITHUB_OUTPUT"; echo "run_codeql=true" >> "$GITHUB_OUTPUT"
+            emit_matrix true true; exit 0
           fi
           # PRs never run the SBOM jobs (too heavy for the PR gate). CodeQL runs only
           # when code actually changed — diff against the merge-base with the target
@@ -64,16 +97,25 @@ jobs:
           if [ "$EVENT" = "pull_request" ]; then
             git fetch --no-tags --depth=1 origin "$BASE_REF" >/dev/null 2>&1 || true
             BASE="$(git merge-base "origin/$BASE_REF" HEAD 2>/dev/null || true)"
-            if [ -n "$BASE" ] && ! git diff --name-only "$BASE" HEAD | grep -qE "$CODE_RE"; then
-              echo "run_codeql=false" >> "$GITHUB_OUTPUT"
+            if [ -z "$BASE" ]; then
+              # Cannot diff — default to running everything rather than skipping silently.
+              echo "run_codeql=true" >> "$GITHUB_OUTPUT"; emit_matrix true true
             else
-              echo "run_codeql=true" >> "$GITHUB_OUTPUT"   # default to running when unsure
+              CHANGED="$(git diff --name-only "$BASE" HEAD)"
+              classify "$CHANGED"
+              if [ "$J" = "false" ] && [ "$S" = "false" ]; then
+                echo "run_codeql=false" >> "$GITHUB_OUTPUT"
+              else
+                echo "run_codeql=true" >> "$GITHUB_OUTPUT"
+              fi
+              emit_matrix "$J" "$S"
             fi
             echo "run_sbom=false" >> "$GITHUB_OUTPUT"; exit 0
           fi
           # First push of a branch has an all-zero "before" → cannot diff, run to be safe.
           if [ -z "$BEFORE" ] || [ "$BEFORE" = "0000000000000000000000000000000000000000" ]; then
-            echo "run_sbom=true" >> "$GITHUB_OUTPUT"; echo "run_codeql=true" >> "$GITHUB_OUTPUT"; exit 0
+            echo "run_sbom=true" >> "$GITHUB_OUTPUT"; echo "run_codeql=true" >> "$GITHUB_OUTPUT"
+            emit_matrix true true; exit 0
           fi
           CHANGED="$(git diff --name-only "$BEFORE" "$SHA")"
           # Dependency-affecting paths: Gradle build/version files, lockfiles, Dockerfiles.
@@ -82,11 +124,13 @@ jobs:
           else
             echo "run_sbom=false" >> "$GITHUB_OUTPUT"
           fi
-          if echo "$CHANGED" | grep -qE "$CODE_RE"; then
+          classify "$CHANGED"
+          if [ "$J" = "true" ] || [ "$S" = "true" ]; then
             echo "run_codeql=true" >> "$GITHUB_OUTPUT"
           else
             echo "run_codeql=false" >> "$GITHUB_OUTPUT"
           fi
+          emit_matrix "$J" "$S"
 
   # ---------------------------------------------------------------------------
   # CodeQL (semantic analysis)
@@ -103,7 +147,7 @@ jobs:
     # support linux/arm64, so it could not run on the arm64 sandbox runner anyway.)
     # Skip on gitops/docs-only PRs (run_codeql=false) — CodeQL isn't a required check
     # there, and the java-kotlin autobuild is the ~14 min tax that strands deploy PRs.
-    if: github.event.repository.private == false && needs.detect-deps.outputs.run_codeql != 'false'
+    if: github.event.repository.private == false && needs.detect-deps.outputs.codeql_matrix != '[]'
     # Standard github/codeql-action usage targets ubuntu-latest; no self-hosted-specific
     # dependency here (setup-java/setup-node are already used to work around the Hetzner
     # pool lacking those toolchains). Public repo = free GitHub-hosted minutes.
@@ -124,11 +168,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        include:
-          - language: java-kotlin
-            build-mode: manual
-          - language: javascript-typescript
-            build-mode: none
+        include: ${{ fromJSON(needs.detect-deps.outputs.codeql_matrix) }}
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
       - uses: actions/setup-java@03ad4de0992f5dab5e18fcb136590ce7c4a0ac95 # v5.6.0

--- a/.github/workflows/security.yml
+++ b/.github/workflows/security.yml
@@ -186,7 +186,20 @@ jobs:
           executed=$( { grep -c '> Task :.*:compileKotlin$' "${RUNNER_TEMP:-/tmp}/codeql-build.log" || true; } )
           if [ "$executed" -eq 0 ]; then
             echo "::warning::every compile resolved from cache — cold re-run so the CodeQL trace is non-empty"
-            .github/scripts/gradle-heap-headroom.sh codeql-java-kotlin -- ./gradlew testClasses --no-build-cache --no-daemon
+            # --rerun-tasks, not just --no-build-cache: the latter bypasses the build CACHE but
+            # not Gradle's UP-TO-DATE checks, and after the first run every compileKotlin output
+            # is already in build/. Measured on run 30692843630, where the fallback still produced
+            # `60 UP-TO-DATE, 60 FROM-CACHE, 0 executed` and CodeQL then failed with
+            # "could not process any code written in Java/Kotlin".
+            .github/scripts/gradle-heap-headroom.sh codeql-java-kotlin -- \
+              ./gradlew testClasses --no-build-cache --rerun-tasks --no-daemon \
+              2>&1 | tee "${RUNNER_TEMP:-/tmp}/codeql-build-cold.log"
+            cold=$( { grep -c '> Task :.*:compileKotlin$' "${RUNNER_TEMP:-/tmp}/codeql-build-cold.log" || true; } )
+            if [ "$cold" -eq 0 ]; then
+              echo "::error::cold re-run still compiled nothing — CodeQL would report no source code"
+              exit 1
+            fi
+            echo "cold re-run compiled: $cold"
           else
             echo "compile tasks executed: $executed"
           fi

--- a/.github/workflows/security.yml
+++ b/.github/workflows/security.yml
@@ -95,10 +95,18 @@ jobs:
           # when code actually changed — diff against the merge-base with the target
           # branch (not the frozen base.sha, which drifts once a competing PR merges).
           if [ "$EVENT" = "pull_request" ]; then
-            git fetch --no-tags --depth=1 origin "$BASE_REF" >/dev/null 2>&1 || true
+            # NOT --depth=1: a shallow base ref has no ancestry, so `git merge-base` finds
+            # nothing and BASE comes back empty — which silently falls through to "run
+            # everything". Measured on PR #3079 (both languages) vs #3103 ([]) with identical
+            # code: the only difference was how far the branch had drifted from main. An
+            # explicit refspec also guarantees refs/remotes/origin/<base> exists at all.
+            git fetch --no-tags origin "+refs/heads/$BASE_REF:refs/remotes/origin/$BASE_REF" >/dev/null 2>&1 || true
             BASE="$(git merge-base "origin/$BASE_REF" HEAD 2>/dev/null || true)"
             if [ -z "$BASE" ]; then
-              # Cannot diff — default to running everything rather than skipping silently.
+              # Cannot diff — run everything rather than skip silently. Say so out loud: a
+              # quiet fallback to "run everything" is indistinguishable from "scoping decided
+              # to run everything", so the scoping can stop working and nothing reports it.
+              echo "::warning::merge-base against $BASE_REF could not be resolved — running CodeQL for ALL languages (scoping did not engage)"
               echo "run_codeql=true" >> "$GITHUB_OUTPUT"; emit_matrix true true
             else
               CHANGED="$(git diff --name-only "$BASE" HEAD)"


### PR DESCRIPTION
Triages all seven boot failures in #3039 and fixes the four that are harness gaps.

**No re-run was needed.** The full boot logs were already uploaded as
`api-fuzz-auth-reports-<svc>` artifacts from run 30687065400 — only the *echoed* tail was too
short to see the cause. Each log is ~30k lines of dev-mode DEBUG; the root cause sits thousands
of lines above a 60-line window.

## The seven, with causes

| Service | Real cause | Class |
|---|---|---|
| ledger, account, sca, transaction | `Unable to find datasource '<default>' … Bean is not active [AgroalDataSource]` | harness gap — fixed here |
| sepa-payment | `Schema validation: missing table [object_store_blobs]` | service defect |
| lending | `wrong column type … [currency] in table [collateral]` | service defect |
| domestic-payment | `wrong column type … [reject_detail] in table [domestic_payments]` | service defect |

## Correction to the issue

#3039 records `Port already bound: 8080` as account-service's one *established* cause. It is in
**all seven** logs, and in every one of them it is a **consequence**: the frame above it is
`VertxHttpRecorder.startServerAfterFailedStart`. Quarkus raises a fallback error-page server on
its default port *after* a failed start, and Keycloak holds 8080. So the one cause the issue was
confident about is the one artifact that says nothing about why any service failed.

Moving Keycloak to 8543 removes it from every log, which is worth more than the port itself.

## Why the four could not boot

They declare only a reactive datasource URL, so the default Agroal (JDBC) datasource is never
configured — while `flyway.migrate-at-start: true` needs one. Production is fine because the
gitops env supplies `QUARKUS_DATASOURCE_JDBC_URL`; the harness never did. One flag fixes it.

Three of the four additionally carry a `quarkus.flyway.datasource:` block with `db-kind`,
`username` and `jdbc.url` nested under it. That is not a datasource *definition* path, and the
boot error proves Quarkus ignored it — it says the default datasource is absent while that block
sits right there in the file. **These four services cannot boot from their committed
configuration alone**; that is a service-level defect worth its own issue and is exactly the class
#2872 exists for. Not fixed here — this PR keeps to the harness.

## Verification of the scope change

The DB-name regex now accepts any `postgresql://` URL. Checked against all 54 service configs
rather than assumed: 0 services lose derivation, 1 gains it (`settlement`), and exactly 1 value
changes — ledger, `openbank_ledger_it` -> `openbank_ledger`. The old pattern's first match in
ledger's file is an **integration-test** profile, so the unauthenticated lane had been
provisioning ledger's IT database. That is a fix, but it is a behaviour change and belongs in the
open.

I also stated mid-investigation that the unauthenticated lane was silently skipping those four
services. That was wrong — it derived a DB name for them from an IT-profile `jdbc:` URL, so they
were in scope and failed at boot. Only `settlement` was actually skipped.

## Not fixed here

The three schema-validation failures are real entity/DDL drift. `object_store_blobs` is an
`@Entity` in `openbank-libs-runtime` (`PostgresBlobStore`) and only `openbank-document-service`
has a migration creating it — sepa-payment reaches it through the ordinary
`implementation(project(":openbank-libs-runtime"))` that 47 modules share. Whether the other 46
are equally exposed is **not** answerable from these logs: validation aborts at the first
mismatch, so lending and domestic-payment stopped before they would have reached it. Settling
that needs a per-service boot, which is #2872.

Refs #3039, #3024, #2872
