### PR TITLE
ci(governance): aggregate the release PRs and stop building bump-only diffs

### DIFF
--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -1,9 +1,13 @@
 name: Release Please
 
 # Per-service RELEASE-axis automation (ADR-0029 Layer B, refined by ADR-0048).
-# On every push to main, release-please reads merged Conventional Commits, opens/maintains
-# one Release PR per changed component, and — when a Release PR is merged — bumps version.txt,
-# writes the per-service CHANGELOG, and cuts the tagged GitHub Release <component>-v<version>.
+# On every push to main, release-please reads merged Conventional Commits and opens/maintains
+# ONE aggregated Release PR covering every component with pending changes — when it is merged
+# it bumps each version.txt, writes each per-service CHANGELOG, and cuts one tagged GitHub
+# Release <component>-v<version> per component. Versioning is still entirely per-component;
+# only the PR is shared (release-please-config.json: separate-pull-requests: false). The steps
+# below still loop over "release PRs" plural because the filter is by label/title prefix and
+# must keep working while an old per-component PR is still open.
 #
 # Scope: the RELEASE axis only (version.txt == quarkus.application.version == git tag). The API
 # contract version (openapi.yaml:info.version) is a SEPARATE axis governed by ADR-0048 / oasdiff

--- a/.github/workflows/services-ci.yml
+++ b/.github/workflows/services-ci.yml
@@ -222,7 +222,19 @@ jobs:
             # explicitly (#376); this brings services-ci.yml's PR-path trigger in
             # line with it, plus openbank-libs-testing (auto-deploy correctly omits
             # it — it's test-only, never shipped in a runtime image).
-            FILES_CODE=$(grep -vE '^openbank-libs/governance/' <<< "$FILES" || true)
+            # Release-bookkeeping paths are inert here for the SAME reason the push path
+            # above already treats them as inert (the `RELEVANT` filter): version.txt,
+            # CHANGELOG.md and the release-please manifest cannot alter any module's
+            # compile inputs or any pact. Without this the PR lane fanned out per-module
+            # on `^<module>/`, so every release-please PR built the service it bumps —
+            # 194 of them in the week of 2026-07-25, each a build of a two-line diff whose
+            # post-merge push is then skipped as inert anyway. It also makes the single
+            # aggregated Release PR (separate-pull-requests: false) build NOTHING rather
+            # than full-fleet, which is what makes the aggregation affordable.
+            # The version bump is not unchecked: check-app-version-override.sh holds the
+            # quarkus.application.version invariant and check-admin-ui-version-sync.sh the
+            # package.json one, both unconditionally in the gate job.
+            FILES_CODE=$(grep -vE '^openbank-libs/governance/|(/version\.txt$)|(/CHANGELOG\.md$)|(^\.release-please-manifest\.json$)|(^release-please-config\.json$)' <<< "$FILES" || true)
             if grep -qE '^(openbank-libs/|openbank-libs-domain/|openbank-libs-runtime/|openbank-libs-testing/|gradle/|settings\.gradle\.kts|build\.gradle\.kts|gradle\.properties|build-logic/)' <<< "$FILES_CODE"; then
               echo "Decision: code-global change -> build all modules."
               CHANGED="$ALL"

--- a/openbank-libs/governance/RELEASE.md
+++ b/openbank-libs/governance/RELEASE.md
@@ -22,10 +22,17 @@ release version must *not* drag the API version with it.
 ## The release-axis rule in one paragraph
 
 Every module that ships is a **released component iff it has a `version.txt`** (today: 23 services).
-You write a Conventional Commit; you bump nothing by hand. On merge to `main`, release-please opens a
-**Release PR per changed component** proposing the next SemVer (from commit types) and the assembled
-release notes. When **you merge that Release PR**, release-please bumps `version.txt`, writes the
-per-service `CHANGELOG.md`, and cuts the tagged GitHub Release `<component>-v<version>`.
+You write a Conventional Commit; you bump nothing by hand. On merge to `main`, release-please opens
+**one aggregated Release PR** (`chore(main): release main`) holding every component with pending
+changes, each proposing its own next SemVer (from commit types) and its own assembled release notes.
+When **you merge that Release PR**, release-please bumps each `version.txt`, writes each per-service
+`CHANGELOG.md`, and cuts one tagged GitHub Release `<component>-v<version>` per component.
+
+Versioning stays fully per-component — only the *pull request* is shared. It was per-PR until
+2026-08-01 (`separate-pull-requests: true`), which produced 194 release PRs in one week, 26% of every
+PR merged, each carrying the full required-check set. Aggregating also removes a whole conflict class:
+parallel release PRs all edit `.release-please-manifest.json`, and the bot will not rebase a conflict
+another component caused, so they had to be drained by hand.
 
 ## Commit type → release bump (must match [`rules.yaml: commits`](./rules.yaml))
 
@@ -126,8 +133,14 @@ release" — that conflates the two axes ADR-0048 split.
   `released_unit_marker` in `rules.yaml` is `version.txt` — keep that true.
 - **Baseline:** `last-release-sha` pins the point release-please treats as "already released", so the
   first Release PR only contains commits merged *after* Layer B landed.
-- **CI on Release PRs:** the action uses the default `GITHUB_TOKEN`; PRs it opens do not themselves
-  re-trigger other workflows. Per-service CI runs on the feature PRs that feed the release.
+- **CI on Release PRs:** they run the FULL required-check set — 29 checks on #3069, measured
+  2026-08-01. The older claim here ("the action uses the default `GITHUB_TOKEN`; PRs it opens do not
+  themselves re-trigger other workflows") stopped being true when the workflow moved to a GitHub App
+  token for commit signing (#1276): an App token does re-trigger workflows. Since 2026-08-01 the
+  service build is no longer among them — `services-ci.yml`'s PR path treats `version.txt` /
+  `CHANGELOG.md` / the release manifest as inert, exactly as its push path already did, so a bump-only
+  diff builds nothing. Per-service CI still runs on the feature PRs that feed the release, which is
+  where a compile failure would actually come from.
 
 ## Skills
 

--- a/release-please-config.json
+++ b/release-please-config.json
@@ -1,7 +1,8 @@
 {
   "$schema": "https://raw.githubusercontent.com/googleapis/release-please/main/schemas/config.json",
   "release-type": "simple",
-  "separate-pull-requests": true,
+  "separate-pull-requests": false,
+  "group-pull-request-title-pattern": "chore(main): release ${branch}",
   "include-component-in-tag": true,
   "last-release-sha": "af9c9cbbc02ba0a8fc5f655f5871ea00d4a66b7f",
   "changelog-sections": [


### PR DESCRIPTION
Refs #3076 (item 3).

## Why

release-please opens one PR per component across 54 packages. In the week of 2026-07-25 that was **194 merged PRs — 26% of every PR merged in the repo**, 675 h of aggregate open-PR time, and **29 checks each** (counted on #3069). Every one is the same two-line diff.

It also creates a conflict class: parallel release PRs all edit `.release-please-manifest.json`, and the bot will not rebase a conflict another component caused, so they get drained by hand.

## What changed

**`separate-pull-requests: false`** — one Release PR, titled `chore(main): release main`.

Versioning granularity is untouched. Each component still proposes its own SemVer from its own commits, writes its own `CHANGELOG.md`, and cuts its own `<component>-v<version>` tag; `include-component-in-tag` is unchanged. Only the *pull request* is shared. Merging it produces exactly the releases the 28 separate PRs would have.

**`services-ci.yml` PR path: `version.txt` / `CHANGELOG.md` / the release manifest are inert.** This mirrors the push path's existing `RELEVANT` filter one-for-one.

This is the load-bearing half. The PR path fans out per-module on `^<module>/`, so without it the single aggregated PR would build all 54 modules — strictly worse than today. With it, a bump-only diff builds nothing. It also removes a cost that exists *today*: #3069 ran `build (openbank-devops-agent)` to compile a version string, and its post-merge push is then skipped as inert anyway.

The bump is not left unverified — `check-app-version-override.sh` holds the `quarkus.application.version` invariant and `check-admin-ui-version-sync.sh` the `package.json` one, both unconditional in the gate job.

## Compatibility

The three loops in `release-please.yml` that re-sign, arm auto-merge, and verify signatures all filter by the `autorelease: pending` label **or** the `chore(main): release` title prefix. `group-pull-request-title-pattern` keeps that prefix, so all three keep matching. They stay plural deliberately: an old per-component PR may still be open when this lands.

Side benefit for the re-sign loop — it pages `pulls.list` at `per_page: 100` and then walks each PR's commits. One PR instead of 28 removes both the truncation risk and 27 round-trips.

## Doc correction

`RELEASE.md` claimed release PRs "do not themselves re-trigger other workflows". That was true under the default `GITHUB_TOKEN` and stopped being true when the workflow moved to a GitHub App token for commit signing (#1276) — an App token does re-trigger. The 29 checks on #3069 are the measurement. Both the file and `release-please.yml`'s header now describe the aggregated shape.

## Verification

- `actionlint` finding **sets** diffed against `origin/main` rather than counted: 6 before, 6 after, and the one apparent difference is `SC2086:info` moving line 218 → 230 because this adds 12 comment lines. No new finding.
- `yamllint` clean under the repo's own config; `release-please-config.json` parses.
- Behaviour of `separate-pull-requests: false` is not verifiable pre-merge — release-please only acts on a push to `main`. The first post-merge run is the test: expect one PR titled `chore(main): release main`, and on merging it one `<component>-v<version>` tag per component. If it misbehaves, reverting this file restores the previous shape with no state to unwind.
