### PR TITLE
fix(ci): a fleet-sized concurrency group made auto-deploy discard the whole build

### DIFF
--- a/.github/workflows/auto-deploy.yml
+++ b/.github/workflows/auto-deploy.yml
@@ -103,6 +103,10 @@ jobs:
     outputs:
       services: ${{ steps.detect.outputs.services }}
       any: ${{ steps.detect.outputs.any }}
+      # A BOUNDED stand-in for `services`, for use in a concurrency group. See the step that
+      # computes it, and gitops-pr's `concurrency:` block, for why interpolating the list itself
+      # silently discarded three whole-fleet builds (#3082).
+      services_key: ${{ steps.key.outputs.services_key }}
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
@@ -265,6 +269,44 @@ jobs:
           echo "Services to deploy: $SERVICES_JSON"
           echo "services=$SERVICES_JSON" >> "$GITHUB_OUTPUT"
           echo "any=true" >> "$GITHUB_OUTPUT"
+
+      # Why a digest and not the service list itself (issue #3082).
+      #
+      # gitops-pr's concurrency group used to interpolate `needs.changes.outputs.services`
+      # verbatim. For a change under openbank-libs-* that is every service in the fleet, and the
+      # group name reached ~1436 characters — at which point the job is NEVER INSTANTIATED. Not
+      # skipped: absent. No job, no check-run on the commit, and `needs.gitops-pr.result` reads as
+      # a failure to the Deploy signal job downstream.
+      #
+      # That is the worst possible place to lose it. gitops-pr carries
+      # `if: always() && ... != 'cancelled'` precisely so a partial can-i-deploy failure still
+      # deploys the subset that passed (#846) — and a job that never exists cannot honour its own
+      # `if`. So the whole fleet build was built, pushed, signed, attested and then thrown away,
+      # in exactly the highest-stakes case: a shared-library change.
+      #
+      # Measured over the last 20 auto-deploy runs, the correlation is exact:
+      #   53 services (~1436 chars) -> Gitops PR job never created  (000ba2a5, f994c492, fa61b32c)
+      #   12 services (~322  chars) -> created                      (342cf7d7)
+      #    1 service  (~30   chars) -> created                      (ec841cf5, 91e9b2c5)
+      #
+      # The digest keeps the semantics #1332/#1336 established, which is the whole reason the
+      # service set is in the group at all: the same set maps to the same group (two pushes
+      # touching the same services still serialise, newer wins), disjoint sets map to different
+      # groups (billing and lending no longer cancel each other), and workflow_dispatch still uses
+      # run_id so an ops recovery run is never cancelled by a routine push. `jq -S 'sort'` makes it
+      # order-insensitive, so the same set detected in a different order yields the same key.
+      - id: key
+        name: Derive a bounded concurrency key for the changed-service set
+        env:
+          # Via env, not a `${{ }}` splice into the script body: the value is JSON built from repo
+          # paths, and splicing it directly is the shape script injection takes.
+          SERVICES: ${{ steps.detect.outputs.services }}
+        run: |
+          set -euo pipefail
+          KEY="$(printf '%s' "${SERVICES:-[]}" | jq -S -c 'sort' | sha256sum | cut -c1-12)"
+          echo "services_key=$KEY" >> "$GITHUB_OUTPUT"
+          N="$(printf '%s' "${SERVICES:-[]}" | jq -r 'length')"
+          echo "concurrency key for ${N} service(s): ${KEY}"
 
   # ── 2. Build fast-jars, bake images, push to ECR ─────────────────────────────
   build-push:
@@ -1044,7 +1086,7 @@ jobs:
     concurrency:
       group: >-
         auto-deploy-gitops-pr-${{ github.ref }}-${{
-          github.event_name == 'workflow_dispatch' && github.run_id || needs.changes.outputs.services
+          github.event_name == 'workflow_dispatch' && github.run_id || needs.changes.outputs.services_key
         }}
       cancel-in-progress: true
     # `always()` + explicit build-push check, NOT the default "can-i-deploy must succeed":


### PR DESCRIPTION
## Summary

`gitops-pr`'s concurrency group interpolated the **entire changed-service list**. For a change under `openbank-libs-*` that is every service in the fleet — a group name of ~1436 characters — at which point the job is **never instantiated**. Not skipped: absent.

## What that costs

`gitops-pr` carries `if: always() && … != 'cancelled'` **precisely so a partial `can-i-deploy` failure still deploys the subset that passed** (#846). A job that never exists cannot honour its own `if`. So the whole fleet build was built, pushed, signed, attested — and then discarded. The pipeline reports it accurately:

> `build-push` succeeded … but `gitops-pr` ended **failure** — no manifest PR. **This means the build was thrown away**

The failure mode is worst in exactly the highest-stakes case: a shared-library change.

## Measurement

Last 20 auto-deploy runs. The correlation is exact:

| sha | services | group length | `Gitops PR` job |
|---|---|---|---|
| `000ba2a5` | 53 | ~1436 | **never created** |
| `f994c492` | 53 | ~1436 | **never created** |
| `fa61b32c` | 53 | ~1436 | **never created** |
| `342cf7d7` | 12 | ~322 | created |
| `ec841cf5` | 1 | ~30 | created |
| `91e9b2c5` | 1 | ~30 | created |

Empirical boundary sits between 322 and 1436. I do **not** assert GitHub's exact documented limit — only the measured behaviour. There is no job, and no check-run on the commit; the `if` was provably true (`build-push.result == 'success'`, `can-i-deploy.result` was `failure`, not `cancelled`), so the `if` is not the explanation.

Two of the three losses (`f994c492`, `fa61b32c`) **predate** the current observability work.

## Fix

Key the group on a 12-char digest of the **sorted** service set, computed once in the `changes` job. This preserves the semantics #1332/#1336 established — the only reason the set is in the group at all:

- **same set → same group** (two pushes touching the same services still serialise, newer wins)
- **disjoint → different groups** (billing and lending no longer cancel each other)
- **`workflow_dispatch` → `run_id`** (an ops recovery run is never cancelled by a routine push)

`jq -S 'sort'` makes it order-insensitive. Resulting group name: **50 characters, independent of fleet size.**

## Verification

The step body was **extracted from the workflow with a YAML parse rather than retyped** — a transcription is a different program — and then run:

```
53-service fleet                        -> 421c73a3dadf
the same 53, reversed (different JSON)  -> 421c73a3dadf   order-insensitive ✓
billing alone                           -> 3f436fd7a121
lending alone                           -> 121fb8279bfa   disjoint sets differ ✓
group length                            -> 50 chars (was ~1436)
```

**actionlint caught a real defect mid-fix.** The new step was first placed *before* `detect`, so `steps.detect.outputs.services` was not yet defined and the key would have been computed over an empty string — putting **every** run into one shared group, which is strictly worse than the bug being fixed. Moved after `detect`; finding **sets** re-diffed against `origin/main` and are now identical (4 vs 4, only a line number moved). Diffing sets rather than grepping output is what surfaced it.

`SERVICES` is passed via `env:` rather than spliced into the script body — the value is JSON built from repo paths, and splicing is the shape script injection takes.

## Scope

Does **not** address the second defect in #3082 — `can-i-deploy` racing the pact publish (it asks the broker 2m14s before the relevant build even starts). That one is self-clearing via the 3-hourly reconcile and needs a larger change.

## Linked issues

Refs #3082, #846, #1332, #1336

## Definition of Done

- [x] Hexagonal layering — n/a, CI workflow.
- [x] Tests: the step body extracted and exercised across four cases.
- [ ] Integration / contract tests — n/a.
- [ ] `./gradlew ...` — n/a.
- [x] No new lint warnings (actionlint sets diffed; yamllint clean).
- [ ] OpenAPI / Flyway / Avro — n/a.
- [x] Docs updated — the measurement and the preserved semantics are recorded in the workflow itself.

## Security checklist

- [x] No secrets, tokens, passwords, or PII in code, config, tests, logs.
- [x] No new `@SuppressWarnings` / `@Suppress`.
- [x] No new third-party dependency.
- [x] No auth / crypto / payment code changed.
- [x] No PII path changed.
- [x] No cardholder data path changed.
- [x] Script-injection shape avoided by passing the value through `env:`.

## Compliance impact

- [x] DORA — deployment reliability: fleet-wide changes stop being silently discarded.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
