### PR TITLE
fix(ci): make the CodeQL cold re-run actually recompile, and fail loudly if it does not

### DIFF
--- a/.github/workflows/security.yml
+++ b/.github/workflows/security.yml
@@ -37,6 +37,7 @@ jobs:
     outputs:
       run_sbom: ${{ steps.f.outputs.run_sbom }}
       run_codeql: ${{ steps.f.outputs.run_codeql }}
+      codeql_matrix: ${{ steps.f.outputs.codeql_matrix }}
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
@@ -53,10 +54,42 @@ jobs:
           # ~14 min java-kotlin autobuild is pure waste there. CodeQL is NOT a required
           # check, so skipping it on such PRs is safe — the weekly + main-push full scan
           # (and Trivy on every PR) still cover them.
-          CODE_RE='(\.(java|kt|kts)$|(^|/)(build|settings)\.gradle|gradle/|\.(js|jsx|ts|tsx|mjs|cjs)$|(^|/)package(-lock)?\.json$|(^|/)Dockerfile|\.github/workflows/)'
+          # Per LANGUAGE, because the analysis is per language: a PR that changes only
+          # .ts has nothing for the java-kotlin leg to look at, and vice versa.
+          JAVA_RE='(\.(java|kt|kts)$|(^|/)(build|settings)\.gradle|gradle/|(^|/)Dockerfile)'
+          JS_RE='(\.(js|jsx|ts|tsx|mjs|cjs)$|(^|/)package(-lock)?\.json$)'
+          CODE_RE="($JAVA_RE|$JS_RE)"
+          # NOTE: .github/workflows/ is deliberately NOT in either pattern. A workflow-only
+          # PR changes no analysable source, so every compile resolves from cache, CodeQL
+          # traces nothing, and `analyze` dies with "could not process any code written in
+          # Java/Kotlin" (issue seen on PR #3079). Including workflows bought no coverage —
+          # it bought a guaranteed red on exactly the PRs that change no code.
+
+          # Emits codeql_matrix as a JSON array of matrix entries; '[]' means skip the job.
+          emit_matrix() {
+            local java="$1" js="$2" out="["
+            if [ "$java" = "true" ]; then
+              out="$out{\"language\":\"java-kotlin\",\"build-mode\":\"manual\"}"
+              if [ "$js" = "true" ]; then out="$out,"; fi
+            fi
+            if [ "$js" = "true" ]; then
+              out="$out{\"language\":\"javascript-typescript\",\"build-mode\":\"none\"}"
+            fi
+            out="$out]"
+            echo "codeql_matrix=$out" >> "$GITHUB_OUTPUT"
+            echo "codeql matrix: $out"
+          }
+          # Same reason: a bare `grep -q ... && VAR=true` is fatal under errexit when it
+          # does not match, which is the common case. classify() never fails.
+          classify() {
+            J=false; S=false
+            if printf '%s\n' "$1" | grep -qE "$JAVA_RE"; then J=true; fi
+            if printf '%s\n' "$1" | grep -qE "$JS_RE"; then S=true; fi
+          }
           # schedule / manual: always run the full audit.
           if [ "$EVENT" = "schedule" ] || [ "$EVENT" = "workflow_dispatch" ]; then
-            echo "run_sbom=true" >> "$GITHUB_OUTPUT"; echo "run_codeql=true" >> "$GITHUB_OUTPUT"; exit 0
+            echo "run_sbom=true" >> "$GITHUB_OUTPUT"; echo "run_codeql=true" >> "$GITHUB_OUTPUT"
+            emit_matrix true true; exit 0
           fi
           # PRs never run the SBOM jobs (too heavy for the PR gate). CodeQL runs only
           # when code actually changed — diff against the merge-base with the target
@@ -64,16 +97,25 @@ jobs:
           if [ "$EVENT" = "pull_request" ]; then
             git fetch --no-tags --depth=1 origin "$BASE_REF" >/dev/null 2>&1 || true
             BASE="$(git merge-base "origin/$BASE_REF" HEAD 2>/dev/null || true)"
-            if [ -n "$BASE" ] && ! git diff --name-only "$BASE" HEAD | grep -qE "$CODE_RE"; then
-              echo "run_codeql=false" >> "$GITHUB_OUTPUT"
+            if [ -z "$BASE" ]; then
+              # Cannot diff — default to running everything rather than skipping silently.
+              echo "run_codeql=true" >> "$GITHUB_OUTPUT"; emit_matrix true true
             else
-              echo "run_codeql=true" >> "$GITHUB_OUTPUT"   # default to running when unsure
+              CHANGED="$(git diff --name-only "$BASE" HEAD)"
+              classify "$CHANGED"
+              if [ "$J" = "false" ] && [ "$S" = "false" ]; then
+                echo "run_codeql=false" >> "$GITHUB_OUTPUT"
+              else
+                echo "run_codeql=true" >> "$GITHUB_OUTPUT"
+              fi
+              emit_matrix "$J" "$S"
             fi
             echo "run_sbom=false" >> "$GITHUB_OUTPUT"; exit 0
           fi
           # First push of a branch has an all-zero "before" → cannot diff, run to be safe.
           if [ -z "$BEFORE" ] || [ "$BEFORE" = "0000000000000000000000000000000000000000" ]; then
-            echo "run_sbom=true" >> "$GITHUB_OUTPUT"; echo "run_codeql=true" >> "$GITHUB_OUTPUT"; exit 0
+            echo "run_sbom=true" >> "$GITHUB_OUTPUT"; echo "run_codeql=true" >> "$GITHUB_OUTPUT"
+            emit_matrix true true; exit 0
           fi
           CHANGED="$(git diff --name-only "$BEFORE" "$SHA")"
           # Dependency-affecting paths: Gradle build/version files, lockfiles, Dockerfiles.
@@ -82,11 +124,13 @@ jobs:
           else
             echo "run_sbom=false" >> "$GITHUB_OUTPUT"
           fi
-          if echo "$CHANGED" | grep -qE "$CODE_RE"; then
+          classify "$CHANGED"
+          if [ "$J" = "true" ] || [ "$S" = "true" ]; then
             echo "run_codeql=true" >> "$GITHUB_OUTPUT"
           else
             echo "run_codeql=false" >> "$GITHUB_OUTPUT"
           fi
+          emit_matrix "$J" "$S"
 
   # ---------------------------------------------------------------------------
   # CodeQL (semantic analysis)
@@ -103,7 +147,7 @@ jobs:
     # support linux/arm64, so it could not run on the arm64 sandbox runner anyway.)
     # Skip on gitops/docs-only PRs (run_codeql=false) — CodeQL isn't a required check
     # there, and the java-kotlin autobuild is the ~14 min tax that strands deploy PRs.
-    if: github.event.repository.private == false && needs.detect-deps.outputs.run_codeql != 'false'
+    if: github.event.repository.private == false && needs.detect-deps.outputs.codeql_matrix != '[]'
     # Standard github/codeql-action usage targets ubuntu-latest; no self-hosted-specific
     # dependency here (setup-java/setup-node are already used to work around the Hetzner
     # pool lacking those toolchains). Public repo = free GitHub-hosted minutes.
@@ -124,11 +168,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        include:
-          - language: java-kotlin
-            build-mode: manual
-          - language: javascript-typescript
-            build-mode: none
+        include: ${{ fromJSON(needs.detect-deps.outputs.codeql_matrix) }}
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
       - uses: actions/setup-java@03ad4de0992f5dab5e18fcb136590ce7c4a0ac95 # v5.6.0

--- a/.github/workflows/security.yml
+++ b/.github/workflows/security.yml
@@ -186,7 +186,20 @@ jobs:
           executed=$( { grep -c '> Task :.*:compileKotlin$' "${RUNNER_TEMP:-/tmp}/codeql-build.log" || true; } )
           if [ "$executed" -eq 0 ]; then
             echo "::warning::every compile resolved from cache — cold re-run so the CodeQL trace is non-empty"
-            .github/scripts/gradle-heap-headroom.sh codeql-java-kotlin -- ./gradlew testClasses --no-build-cache --no-daemon
+            # --rerun-tasks, not just --no-build-cache: the latter bypasses the build CACHE but
+            # not Gradle's UP-TO-DATE checks, and after the first run every compileKotlin output
+            # is already in build/. Measured on run 30692843630, where the fallback still produced
+            # `60 UP-TO-DATE, 60 FROM-CACHE, 0 executed` and CodeQL then failed with
+            # "could not process any code written in Java/Kotlin".
+            .github/scripts/gradle-heap-headroom.sh codeql-java-kotlin -- \
+              ./gradlew testClasses --no-build-cache --rerun-tasks --no-daemon \
+              2>&1 | tee "${RUNNER_TEMP:-/tmp}/codeql-build-cold.log"
+            cold=$( { grep -c '> Task :.*:compileKotlin$' "${RUNNER_TEMP:-/tmp}/codeql-build-cold.log" || true; } )
+            if [ "$cold" -eq 0 ]; then
+              echo "::error::cold re-run still compiled nothing — CodeQL would report no source code"
+              exit 1
+            fi
+            echo "cold re-run compiled: $cold"
           else
             echo "compile tasks executed: $executed"
           fi

--- a/.github/workflows/security.yml
+++ b/.github/workflows/security.yml
@@ -95,10 +95,18 @@ jobs:
           # when code actually changed — diff against the merge-base with the target
           # branch (not the frozen base.sha, which drifts once a competing PR merges).
           if [ "$EVENT" = "pull_request" ]; then
-            git fetch --no-tags --depth=1 origin "$BASE_REF" >/dev/null 2>&1 || true
+            # NOT --depth=1: a shallow base ref has no ancestry, so `git merge-base` finds
+            # nothing and BASE comes back empty — which silently falls through to "run
+            # everything". Measured on PR #3079 (both languages) vs #3103 ([]) with identical
+            # code: the only difference was how far the branch had drifted from main. An
+            # explicit refspec also guarantees refs/remotes/origin/<base> exists at all.
+            git fetch --no-tags origin "+refs/heads/$BASE_REF:refs/remotes/origin/$BASE_REF" >/dev/null 2>&1 || true
             BASE="$(git merge-base "origin/$BASE_REF" HEAD 2>/dev/null || true)"
             if [ -z "$BASE" ]; then
-              # Cannot diff — default to running everything rather than skipping silently.
+              # Cannot diff — run everything rather than skip silently. Say so out loud: a
+              # quiet fallback to "run everything" is indistinguishable from "scoping decided
+              # to run everything", so the scoping can stop working and nothing reports it.
+              echo "::warning::merge-base against $BASE_REF could not be resolved — running CodeQL for ALL languages (scoping did not engage)"
               echo "run_codeql=true" >> "$GITHUB_OUTPUT"; emit_matrix true true
             else
               CHANGED="$(git diff --name-only "$BASE" HEAD)"


### PR DESCRIPTION
`CodeQL (java-kotlin, manual)` fails on any PR that touches no Java/Kotlin — it went red on
[#3079](https://github.com/JiRaska/open-bank-oss/pull/3079), which changes two workflow YAMLs and
nothing else.

```
CodeQL could not process any code written in Java/Kotlin.
```

## Two commits, two different problems

**1. Scope CodeQL to the languages the PR changed** (the cost fix, and the one that makes the red
go away).

The `run_codeql` flag was all-or-nothing and listed `.github/workflows/` as a code path. So a
workflow-only PR ran **both** legs: no new coverage, and a guaranteed red on the java-kotlin one,
because there is nothing for the tracer to see. Detection is now per language and the job consumes
a derived matrix — `[]` skips the job outright. Workflows are in neither pattern.

Cheaper than the alternative (forcing a cold recompile so the tracer has something to look at):
this saves the entire job on doc/CI-only PRs, which are frequent here, instead of adding a full
fleet compile to them.

**2. Fix the cold re-run so it actually recompiles** (a latent bug, still reachable).

The step already detects "everything came from cache" and re-runs. **The detection is correct** —
I checked before assuming otherwise: of 123 `compileKotlin` lines in run 30692843630, zero were
bare (executed); all were `FROM-CACHE`/`UP-TO-DATE`/`NO-SOURCE`. The `472 actionable tasks: 294
executed` line is misleading — those are jars and resources, not compilation.

The **remedy** is what fails: `--no-build-cache` bypasses the build *cache* but not Gradle's
UP-TO-DATE checks, and after the first run every compile output is already in `build/`. That
fallback produced `60 UP-TO-DATE, 60 FROM-CACHE, 0 executed` and CodeQL failed anyway.
`--rerun-tasks` is what forces re-execution, and the step now asserts the re-run compiled
something instead of exiting 0 regardless.

Commit 1 makes commit 2 unreachable for workflow-only PRs, but not for the case it was written
for — a code PR whose compiles all restore from cache, e.g. on a re-run.

## Safety of skipping

Not a required status check: `main-protection` requires `all-green`, `Validate manifests`,
`Gitleaks`, `issue-hygiene`, `OPA policy gate`. Verified via the rulesets API, not assumed. No job
`needs:` the codeql job either, so a skip cannot strand a dependent. Weekly and main-push scans are
unchanged.

## Verification

GitHub's default shell is `bash -e {0}`, so `grep -q … && VAR=true` **terminates the step** when it
does not match — the common case here, and it would have left `codeql_matrix` unset while the job's
`if:` still evaluated to true. Every branch is a full `if/fi` for that reason.

The two emitted shell functions were extracted **from the workflow file** (not retyped) and run
against nine file-list fixtures:

```
  workflow YAML only  -> []                                      OK
  docs only           -> []                                      OK
  kotlin only         -> [java-kotlin]                            OK
  gradle only         -> [java-kotlin]                            OK
  typescript only     -> [javascript-typescript]                  OK
  package-lock only   -> [javascript-typescript]                  OK
  both                -> [java-kotlin, javascript-typescript]     OK
  Dockerfile          -> [java-kotlin]                            OK
  THIS PR (yaml only) -> []                                       OK
```

Known-negatives included on purpose — a classifier that only ever returns "run everything" would
pass a positives-only suite. The emitted JSON was also parsed to confirm it is valid input for
`fromJSON`.

Consequence for this PR itself: it changes only `security.yml`, so its own CodeQL job should now
**skip** rather than run and fail. That is the visible proof the change works.

Refs #3079
