### PR TITLE
feat(campaign): campaign authoring in the console, with the four-eyes gate intact

### DIFF
--- a/openbank-admin-ui/src/app/api/campaigns/[id]/actions/route.ts
+++ b/openbank-admin-ui/src/app/api/campaigns/[id]/actions/route.ts
@@ -1,0 +1,62 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright (c) OpenBank contributors. Licensed under the Apache License, Version 2.0.
+// See LICENSE in the repository root or https://www.apache.org/licenses/LICENSE-2.0 for details.
+
+// Lifecycle transitions for the campaign studio (ADR-0221 D2).
+//
+// The action is taken from a closed list, never from the request path or an arbitrary body field:
+// forwarding a caller-supplied segment into the service URL would let this route reach any campaign
+// endpoint, including ones this console has no business calling.
+
+import { NextResponse } from 'next/server'
+import { auth } from '@/auth'
+import { serverSvcUrl } from '@/lib/services/bff'
+
+export const dynamic = 'force-dynamic'
+
+const ACTIONS = ['submit', 'activate', 'pause', 'resume', 'close', 'enrol'] as const
+type Action = (typeof ACTIONS)[number]
+
+function isAction(value: unknown): value is Action {
+  return typeof value === 'string' && (ACTIONS as readonly string[]).includes(value)
+}
+
+export async function POST(req: Request, ctx: { params: Promise<{ id: string }> }) {
+  const session = await auth()
+  if (!session?.user?.accessToken) {
+    return NextResponse.json({ error: 'unauthenticated' }, { status: 401 })
+  }
+  const { id } = await ctx.params
+  const body = await req.json().catch(() => ({}))
+  if (!isAction(body?.action)) {
+    return NextResponse.json({ error: 'unknown action' }, { status: 400 })
+  }
+
+  // No body is forwarded. `activate` in particular takes its approver from the service's own view
+  // of the authenticated caller — sending one from here would reintroduce the maker/checker hole
+  // where the check compares a value the caller supplied on both sides (#3051).
+  const path = `/api/v1/campaigns/${encodeURIComponent(id)}/${body.action}`
+  try {
+    const res = await fetch(serverSvcUrl('campaign-service', 'campaign', 8128, path), {
+      method: 'POST',
+      headers: { authorization: `Bearer ${session.user.accessToken}` },
+      signal: AbortSignal.timeout(8000),
+      cache: 'no-store',
+    })
+    const text = await res.text()
+    const payload = text ? JSON.parse(text) : {}
+    if (!res.ok) {
+      // A refused transition is reported with its reason. The service answers 409 with the domain
+      // invariant that blocked it ("the approver must differ from the creator"), and that sentence
+      // is the entire value of the response — collapsing it to "failed" makes a four-eyes rejection
+      // indistinguishable from an outage.
+      return NextResponse.json(
+        { state: res.status === 401 || res.status === 403 ? 'forbidden' : 'rejected', ...payload },
+        { status: 200 },
+      )
+    }
+    return NextResponse.json({ state: 'ok', campaign: payload })
+  } catch {
+    return NextResponse.json({ state: 'unreachable' }, { status: 200 })
+  }
+}

--- a/openbank-admin-ui/src/app/api/campaigns/route.ts
+++ b/openbank-admin-ui/src/app/api/campaigns/route.ts
@@ -12,6 +12,46 @@ import { serverSvcUrl } from '@/lib/services/bff'
 
 export const dynamic = 'force-dynamic'
 
+/**
+ * Create a draft (ADR-0221 D1 step 6).
+ *
+ * The body is passed through as the service defines it, but nothing about the author is: the
+ * campaign's `createdBy` is taken from the token server-side, so the maker recorded on a campaign
+ * is the person who actually created it and not a name the request chose.
+ */
+export async function POST(req: Request) {
+  const session = await auth()
+  if (!session?.user?.accessToken) {
+    return NextResponse.json({ error: 'unauthenticated' }, { status: 401 })
+  }
+  try {
+    const res = await fetch(serverSvcUrl('campaign-service', 'campaign', 8128, '/api/v1/campaigns'), {
+      method: 'POST',
+      headers: {
+        authorization: `Bearer ${session.user.accessToken}`,
+        'content-type': 'application/json',
+      },
+      body: JSON.stringify(await req.json()),
+      signal: AbortSignal.timeout(8000),
+      cache: 'no-store',
+    })
+    const text = await res.text()
+    const payload = text ? JSON.parse(text) : {}
+    if (!res.ok) {
+      // The service rejects a malformed step by construction — an unknown template, an undeclared
+      // variable, a missing one. That message is what tells an author what to change, so it travels
+      // rather than being flattened into "create failed".
+      return NextResponse.json(
+        { state: res.status === 401 || res.status === 403 ? 'forbidden' : 'rejected', ...payload },
+        { status: 200 },
+      )
+    }
+    return NextResponse.json({ state: 'ok', campaign: payload })
+  } catch {
+    return NextResponse.json({ state: 'unreachable' }, { status: 200 })
+  }
+}
+
 export async function GET() {
   const session = await auth()
   if (!session?.user?.accessToken) {

--- a/openbank-admin-ui/src/app/campaigns/[id]/page.tsx
+++ b/openbank-admin-ui/src/app/campaigns/[id]/page.tsx
@@ -83,6 +83,9 @@ export default function CampaignDetailPage({ params }: { params: Promise<{ id: s
   const [detail, setDetail] = useState<Detail | null>(null)
   const [unavailable, setUnavailable] = useState<UnavailableKind | null>(null)
   const [loading, setLoading] = useState(true)
+  // Bumped after a lifecycle action so the screen re-reads the campaign rather than guessing the
+  // new state locally — the service owns the state machine and may refuse a transition.
+  const [reloadToken, setReloadToken] = useState(0)
 
   useEffect(() => {
     if (!id) return
@@ -97,7 +100,7 @@ export default function CampaignDetailPage({ params }: { params: Promise<{ id: s
       })
       .catch(() => setUnavailable('unreachable'))
       .finally(() => setLoading(false))
-  }, [id])
+  }, [id, reloadToken])
 
   const c = detail?.campaign
 
@@ -110,6 +113,68 @@ export default function CampaignDetailPage({ params }: { params: Promise<{ id: s
 
   const sendPage = sendOverride ?? detail?.sends ?? { items: [], total: 0, page: 0, size: 50 }
   const sends = sendPage.items
+
+  // Lifecycle actions (ADR-0221 D2). Which ones are offered follows the campaign's own state
+  // machine; whether the caller may run them is decided by OPA, and the domain re-asserts
+  // maker != checker on activate. The UI renders capability, the policy decides it.
+  const [actionError, setActionError] = useState<string | null>(null)
+  const [acting, setActing] = useState(false)
+
+  const runAction = (action: string) => {
+    setActing(true)
+    setActionError(null)
+    fetch(`/api/campaigns/${encodeURIComponent(id ?? '')}/actions`, {
+      method: 'POST',
+      headers: { 'content-type': 'application/json' },
+      body: JSON.stringify({ action }),
+    })
+      .then(r => r.json())
+      .then((d: { state: string; error?: string }) => {
+        if (d.state === 'ok') {
+          // Drop the paged override too: after a transition the first page is the right thing to
+          // show, and keeping page 7 of a log that just changed is a stale view of a new state.
+          setSendOverride(null)
+          setReloadToken(n => n + 1)
+          return
+        }
+        // The service answers a refused transition with the invariant that blocked it — including
+        // "the approver must differ from the creator". That sentence IS the four-eyes gate becoming
+        // visible; replacing it with "action failed" would make a working control look like a bug.
+        setActionError(
+          d.error ??
+            (d.state === 'forbidden'
+              ? t('Nemáte oprávnění k této akci.', 'You are not permitted to do that.')
+              : t('Campaign-service neodpovídá.', 'Campaign-service is not responding.')),
+        )
+      })
+      .catch(() => setActionError(t('Campaign-service neodpovídá.', 'Campaign-service is not responding.')))
+      .finally(() => setActing(false))
+  }
+
+  const actionsFor = (state?: string): string[] => {
+    switch (state) {
+      case 'DRAFT':
+        return ['submit']
+      case 'PENDING_APPROVAL':
+        return ['activate']
+      case 'ACTIVE':
+        return ['enrol', 'pause', 'close']
+      case 'PAUSED':
+        return ['resume', 'close']
+      default:
+        return []
+    }
+  }
+
+  const actionLabel = (a: string): string =>
+    ({
+      submit: t('Odeslat ke schválení', 'Submit for approval'),
+      activate: t('Schválit a spustit', 'Approve and activate'),
+      pause: t('Pozastavit', 'Pause'),
+      resume: t('Obnovit', 'Resume'),
+      close: t('Uzavřít', 'Close'),
+      enrol: t('Zařadit publikum', 'Enrol audience'),
+    })[a] ?? a
 
   const loadSends = (page: number, outcome: string) => {
     setSendsLoading(true)
@@ -192,6 +257,36 @@ export default function CampaignDetailPage({ params }: { params: Promise<{ id: s
         subtitle={c?.goal}
         icon={<Megaphone className="h-6 w-6" />}
       />
+
+      {/* Only the transitions this state actually allows are offered. Rendering every button and
+          letting the service reject four of them teaches operators that red messages are normal,
+          which is how a real refusal stops being read. */}
+      {!loading && !unavailable && c && actionsFor(c.state).length > 0 && (
+        <div className="flex flex-wrap items-center gap-2">
+          {actionsFor(c.state).map(a => (
+            <button
+              key={a}
+              onClick={() => runAction(a)}
+              disabled={acting}
+              className="rounded-md border px-3 py-1.5 text-sm disabled:opacity-40"
+            >
+              {actionLabel(a)}
+            </button>
+          ))}
+          {c.state === 'PENDING_APPROVAL' && (
+            // Said out loud, because the refusal is otherwise indistinguishable from a bug: the
+            // approver is taken from the token, so the person who created it cannot approve it.
+            <span className="text-xs text-muted-foreground">
+              {t(
+                `Schválit musí někdo jiný než ${c.createdBy}.`,
+                `Someone other than ${c.createdBy} must approve this.`,
+              )}
+            </span>
+          )}
+        </div>
+      )}
+
+      {actionError && <p className="text-sm text-red-600">{actionError}</p>}
 
       {loading && <p className="text-sm text-muted-foreground">{t('Načítám…', 'Loading…')}</p>}
       {!loading && unavailable && (

--- a/openbank-admin-ui/src/app/campaigns/new/page.tsx
+++ b/openbank-admin-ui/src/app/campaigns/new/page.tsx
@@ -1,0 +1,276 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright (c) OpenBank contributors. Licensed under the Apache License, Version 2.0.
+// See LICENSE in the repository root or https://www.apache.org/licenses/LICENSE-2.0 for details.
+
+'use client'
+
+import { useEffect, useState } from 'react'
+import { useRouter } from 'next/navigation'
+import Link from 'next/link'
+import { ArrowLeft, Megaphone } from 'lucide-react'
+import { useLanguage } from '@/lib/i18n/LanguageContext'
+import { PageHeader } from '@/components/ui'
+
+/**
+ * Campaign Studio — authoring (ADR-0221 D1).
+ *
+ * The form IS the domain model: goal, a picker over versioned segment artifacts, steps composed
+ * from the template catalogue, the platform contact rules shown read-only, and a summary that
+ * submits for approval. There is no free-text body field anywhere, because the engine rejects one
+ * by construction (ADR-0176 D4) — a textarea here would be a control the service would refuse.
+ *
+ * What this screen deliberately does NOT do: activate. Submission puts the campaign in
+ * PENDING_APPROVAL, and the checker is a different person acting from the campaign's own page.
+ * Offering both buttons to one author would render the four-eyes gate as decoration.
+ */
+
+interface Segment {
+  name: string
+  version: number
+  rules: string[]
+}
+
+/** Mirrors the service's catalogue; the service rejects anything not in its own copy. */
+const TEMPLATES: Record<string, string[]> = {
+  MARKETING_PRODUCT_OFFER: ['offerTitle', 'offerText', 'ctaText'],
+}
+
+export default function NewCampaignPage() {
+  const { t, language } = useLanguage()
+  const router = useRouter()
+
+  const [name, setName] = useState('')
+  const [goal, setGoal] = useState('')
+  const [segment, setSegment] = useState('')
+  const [segments, setSegments] = useState<Segment[]>([])
+  const [template, setTemplate] = useState('MARKETING_PRODUCT_OFFER')
+  const [variables, setVariables] = useState<Record<string, string>>({})
+  const [delayHours, setDelayHours] = useState('0')
+  const [reach, setReach] = useState<number | null>(null)
+  const [reachState, setReachState] = useState<string>('')
+  const [error, setError] = useState<string | null>(null)
+  const [saving, setSaving] = useState(false)
+
+  useEffect(() => {
+    fetch('/api/segments')
+      .then(r => r.json())
+      .then((d: { items: Segment[]; state: string }) => {
+        if (d.state === 'ok') setSegments(d.items ?? [])
+      })
+      .catch(() => undefined)
+  }, [])
+
+  // The reach is the segment's own preview, run by the service — the same evaluation enrolment
+  // runs. A number computed here from a different query would agree with the send only by luck.
+  const previewReach = (ref: string) => {
+    setReach(null)
+    setReachState('')
+    const [segName, segVersion] = ref.split('@')
+    if (!segName) return
+    setReachState('loading')
+    fetch(`/api/segments/${encodeURIComponent(segName)}/${encodeURIComponent(segVersion)}/preview`)
+      .then(r => r.json())
+      .then((d: { size?: number; state: string }) => {
+        setReachState(d.state)
+        if (d.state === 'ok') setReach(d.size ?? 0)
+      })
+      .catch(() => setReachState('unreachable'))
+  }
+
+  const declared = TEMPLATES[template] ?? []
+  const missing = declared.filter(v => !(variables[v] ?? '').trim())
+  const ready = name.trim() !== '' && goal.trim() !== '' && segment !== '' && missing.length === 0
+
+  const submit = () => {
+    setSaving(true)
+    setError(null)
+    const [segName, segVersion] = segment.split('@')
+    fetch('/api/campaigns', {
+      method: 'POST',
+      headers: { 'content-type': 'application/json' },
+      body: JSON.stringify({
+        name: name.trim(),
+        goal: goal.trim(),
+        segmentName: segName,
+        segmentVersion: Number(segVersion),
+        steps: [
+          {
+            order: 1,
+            template,
+            variables,
+            delaySeconds: Math.max(0, Number(delayHours) || 0) * 3600,
+          },
+        ],
+      }),
+    })
+      .then(r => r.json())
+      .then((d: { state: string; campaign?: { id: string }; error?: string }) => {
+        if (d.state === 'ok' && d.campaign) {
+          router.push(`/campaigns/${d.campaign.id}`)
+          return
+        }
+        // The service's own message names what to change — an unknown template, an undeclared
+        // variable. Replacing it with "could not create" would remove the only actionable part.
+        setError(
+          d.error ??
+            (d.state === 'forbidden'
+              ? t('Nemáte oprávnění zakládat kampaně.', 'You are not permitted to create campaigns.')
+              : t('Campaign-service neodpovídá.', 'Campaign-service is not responding.')),
+        )
+      })
+      .catch(() => setError(t('Campaign-service neodpovídá.', 'Campaign-service is not responding.')))
+      .finally(() => setSaving(false))
+  }
+
+  const field = 'w-full rounded-md border bg-transparent px-3 py-1.5 text-sm'
+
+  return (
+    <div className="space-y-6">
+      <Link href="/campaigns" className="inline-flex items-center gap-1 text-sm hover:underline">
+        <ArrowLeft className="h-4 w-4" /> {t('Kampaně', 'Campaigns')}
+      </Link>
+
+      <PageHeader
+        title={t('Nová kampaň', 'New campaign')}
+        subtitle={t(
+          'Založí koncept. Spustit ji musí někdo jiný — to je ten smysl schvalování ve dvou.',
+          'Creates a draft. Someone else activates it — that is the point of the four-eyes gate.',
+        )}
+        icon={<Megaphone className="h-6 w-6" />}
+      />
+
+      <section className="max-w-2xl space-y-4">
+        <div className="space-y-1">
+          <label htmlFor="c-name" className="text-sm font-medium">{t('Název', 'Name')}</label>
+          <input id="c-name" className={field} value={name} onChange={e => setName(e.target.value)} />
+        </div>
+
+        <div className="space-y-1">
+          <label htmlFor="c-goal" className="text-sm font-medium">{t('Cíl', 'Goal')}</label>
+          <input id="c-goal" className={field} value={goal} onChange={e => setGoal(e.target.value)} />
+        </div>
+
+        <div className="space-y-1">
+          <label htmlFor="c-segment" className="text-sm font-medium">{t('Publikum', 'Audience')}</label>
+          <select
+            id="c-segment"
+            className={field}
+            value={segment}
+            onChange={e => {
+              setSegment(e.target.value)
+              previewReach(e.target.value)
+            }}
+          >
+            <option value="">{t('Vyberte segment…', 'Choose a segment…')}</option>
+            {segments.map(s => (
+              <option key={`${s.name}@${s.version}`} value={`${s.name}@${s.version}`}>
+                {s.name} v{s.version} — {s.rules.join('; ')}
+              </option>
+            ))}
+          </select>
+          {/* Segments are code, not something this screen can author (ADR-0201 D1). Saying so here
+              is cheaper than letting someone hunt for an "add segment" button that will never exist. */}
+          <p className="text-xs text-muted-foreground">
+            {t(
+              'Segmenty jsou definované v kódu a verzované. Nový segment je pull request, ne akce v UI.',
+              'Segments are defined in code and versioned. A new segment is a pull request, not a UI action.',
+            )}
+          </p>
+          {reachState === 'loading' && (
+            <p className="text-xs text-muted-foreground">{t('Počítám dosah…', 'Counting reach…')}</p>
+          )}
+          {reachState === 'ok' && reach !== null && (
+            <p className="text-xs">
+              {t('Aktuální dosah', 'Current reach')}:{' '}
+              <strong>{reach.toLocaleString(language === 'cs' ? 'cs-CZ' : 'en-GB')}</strong>{' '}
+              {/* Stated, because reach is a moving number and a stale one drives a wrong decision. */}
+              <span className="text-muted-foreground">
+                {t(
+                  '— před ověřením souhlasu a potlačením; skutečný počet bude nižší.',
+                  '— before consent checks and suppression; the sent-to count will be lower.',
+                )}
+              </span>
+            </p>
+          )}
+          {reachState !== '' && reachState !== 'ok' && reachState !== 'loading' && (
+            <p className="text-xs text-amber-600">
+              {t('Dosah se nepodařilo spočítat.', 'Reach could not be computed.')}
+            </p>
+          )}
+        </div>
+
+        <div className="space-y-1">
+          <label htmlFor="c-template" className="text-sm font-medium">{t('Šablona', 'Template')}</label>
+          <select
+            id="c-template"
+            className={field}
+            value={template}
+            onChange={e => {
+              setTemplate(e.target.value)
+              setVariables({})
+            }}
+          >
+            {Object.keys(TEMPLATES).map(tpl => (
+              <option key={tpl} value={tpl}>{tpl}</option>
+            ))}
+          </select>
+        </div>
+
+        {declared.map(v => (
+          <div key={v} className="space-y-1">
+            <label htmlFor={`var-${v}`} className="text-sm font-medium">{v}</label>
+            <input
+              id={`var-${v}`}
+              className={field}
+              value={variables[v] ?? ''}
+              onChange={e => setVariables(prev => ({ ...prev, [v]: e.target.value }))}
+            />
+          </div>
+        ))}
+
+        <div className="space-y-1">
+          <label htmlFor="c-delay" className="text-sm font-medium">
+            {t('Zpoždění kroku (hodiny)', 'Step delay (hours)')}
+          </label>
+          <input
+            id="c-delay"
+            type="number"
+            min="0"
+            className={field}
+            value={delayHours}
+            onChange={e => setDelayHours(e.target.value)}
+          />
+        </div>
+
+        {/* Read-only on purpose: the contact policy is a single enforcement point, and a per-campaign
+            override here would make that point decorative (ADR-0219 D4, ADR-0221 D1 step 4). */}
+        <div className="rounded-lg border p-3 text-xs text-muted-foreground">
+          <p className="font-medium text-foreground">{t('Pravidla kontaktu', 'Contact rules')}</p>
+          <p>
+            {t(
+              'Tiché hodiny 21:00–8:00, frekvenční strop a potlačení platí pro všechny kampaně a odsud se měnit nedají.',
+              'Quiet hours 21:00–08:00, the frequency cap and suppression apply to every campaign and cannot be changed here.',
+            )}
+          </p>
+        </div>
+
+        {error && <p className="text-sm text-red-600">{error}</p>}
+
+        <div className="flex items-center gap-3">
+          <button
+            onClick={submit}
+            disabled={!ready || saving}
+            className="rounded-md border px-3 py-1.5 text-sm disabled:opacity-40"
+          >
+            {saving ? t('Zakládám…', 'Creating…') : t('Založit koncept', 'Create draft')}
+          </button>
+          {!ready && missing.length > 0 && (
+            <span className="text-xs text-muted-foreground">
+              {t('Chybí', 'Missing')}: {missing.join(', ')}
+            </span>
+          )}
+        </div>
+      </section>
+    </div>
+  )
+}

--- a/openbank-admin-ui/src/app/campaigns/page.tsx
+++ b/openbank-admin-ui/src/app/campaigns/page.tsx
@@ -70,6 +70,13 @@ export default function CampaignsPage() {
         icon={<Megaphone className="h-6 w-6" />}
       />
 
+      <Link
+        href="/campaigns/new"
+        className="inline-flex items-center gap-1 rounded-md border px-3 py-1.5 text-sm hover:bg-muted"
+      >
+        {t('Nová kampaň', 'New campaign')}
+      </Link>
+
       {loading && <p className="text-sm text-muted-foreground">{t('Načítám…', 'Loading…')}</p>}
 
       {!loading && unavailable && <DataUnavailable kind={unavailable} service="Campaign-service" feature={t('Kampaně', 'Campaigns')} />}

--- a/openbank-admin-ui/src/test/campaign-studio.test.tsx
+++ b/openbank-admin-ui/src/test/campaign-studio.test.tsx
@@ -1,0 +1,128 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright (c) OpenBank contributors. Licensed under the Apache License, Version 2.0.
+// See LICENSE in the repository root or https://www.apache.org/licenses/LICENSE-2.0 for details.
+
+import React from 'react'
+import { describe, expect, it, vi, beforeEach } from 'vitest'
+import { render, screen, waitFor } from '@testing-library/react'
+import { SessionProvider } from 'next-auth/react'
+import { LanguageProvider } from '@/lib/i18n/LanguageContext'
+import CampaignDetailPage from '@/app/campaigns/[id]/page'
+import NewCampaignPage from '@/app/campaigns/new/page'
+
+vi.mock('next/navigation', () => ({ useRouter: () => ({ push: vi.fn() }) }))
+
+const CAMPAIGN_ID = '7b1f1d5e-0d2a-4a6a-8f7e-2c1b9a0d3e4f'
+
+const SEGMENTS = {
+  state: 'ok',
+  items: [{ name: 'actives', version: 1, rules: ['party status is ACTIVE'] }],
+}
+
+function detail(state: string) {
+  return {
+    campaign: {
+      id: CAMPAIGN_ID,
+      name: 'spring offer',
+      goal: 'promote the savings product',
+      segmentRef: { name: 'actives', version: 1 },
+      state,
+      createdBy: 'marketa',
+      approvedBy: null,
+      createdAt: '2026-07-31T18:00:00Z',
+      steps: [{ order: 1, template: 'MARKETING_PRODUCT_OFFER', delaySeconds: 0 }],
+    },
+    enrolments: [],
+    sends: { items: [], total: 0, page: 0, size: 50 },
+    sendSummary: {},
+    sources: { campaign: 'ok', enrolments: 'ok', sends: 'ok', sendSummary: 'ok' },
+  }
+}
+
+function mockFetch(routes: Record<string, unknown>) {
+  return vi.fn(async (url: string) => {
+    const match = Object.keys(routes).find(k => String(url).includes(k))
+    return { ok: true, status: 200, json: async () => (match ? routes[match] : {}) }
+  })
+}
+
+function Providers({ children }: { children: React.ReactNode }) {
+  return React.createElement(SessionProvider, null, React.createElement(LanguageProvider, null, children))
+}
+
+function renderDetail() {
+  return render(
+    React.createElement(
+      Providers,
+      null,
+      React.createElement(CampaignDetailPage, { params: Promise.resolve({ id: CAMPAIGN_ID }) }),
+    ),
+  )
+}
+
+describe('campaign studio', () => {
+  beforeEach(() => vi.unstubAllGlobals())
+
+  /**
+   * ADR-0221 D1 step 2: the audience is a picker over versioned segment artifacts, and ADR-0201 D1
+   * forbids typing a definition in. The absence of any way to author a segment here is the design,
+   * so it is worth a test — a helpful "add segment" field would be a regression, not a feature.
+   */
+  it('the audience is chosen from the catalogue and cannot be typed in', async () => {
+    vi.stubGlobal('fetch', mockFetch({ '/api/segments': SEGMENTS }))
+    render(React.createElement(Providers, null, React.createElement(NewCampaignPage)))
+
+    await waitFor(() => expect(screen.getByLabelText('Audience')).toBeTruthy(), { timeout: 8000 })
+    expect((screen.getByLabelText('Audience') as HTMLSelectElement).tagName).toBe('SELECT')
+    expect(screen.getByText(/a pull request, not a UI action/)).toBeTruthy()
+  }, 15000)
+
+  /**
+   * ADR-0176 D4 / ADR-0221 D1 step 3: a campaign supplies values, never body text. The fields
+   * offered are exactly the template's declared variables — a free-form body field here would be a
+   * control the service refuses by construction, which is a worse experience than not offering it.
+   */
+  it('offers only the declared template variables, never a free-text body', async () => {
+    vi.stubGlobal('fetch', mockFetch({ '/api/segments': SEGMENTS }))
+    render(React.createElement(Providers, null, React.createElement(NewCampaignPage)))
+
+    await waitFor(() => expect(screen.getByLabelText('offerTitle')).toBeTruthy(), { timeout: 8000 })
+    expect(screen.getByLabelText('offerText')).toBeTruthy()
+    expect(screen.getByLabelText('ctaText')).toBeTruthy()
+    expect(document.querySelector('textarea')).toBeNull()
+  }, 15000)
+
+  it('a draft can be submitted but not activated from the same screen', async () => {
+    vi.stubGlobal('fetch', mockFetch({ [`/api/campaigns/${CAMPAIGN_ID}`]: detail('DRAFT') }))
+    renderDetail()
+
+    await waitFor(() => expect(screen.getByText('Submit for approval')).toBeTruthy(), { timeout: 8000 })
+    // The whole point of four eyes: the author never sees the button that would let them skip it.
+    expect(screen.queryByText('Approve and activate')).toBeNull()
+  }, 15000)
+
+  /**
+   * ADR-0200 D5: maker != checker. The approver is taken from the token, so the creator's own
+   * attempt is refused — and a refusal that reads as a generic failure is indistinguishable from an
+   * outage, which is how a working control gets reported as a bug.
+   */
+  it('states who may approve, so the refusal is not read as a malfunction', async () => {
+    vi.stubGlobal('fetch', mockFetch({ [`/api/campaigns/${CAMPAIGN_ID}`]: detail('PENDING_APPROVAL') }))
+    renderDetail()
+
+    await waitFor(() => expect(screen.getByText('Approve and activate')).toBeTruthy(), { timeout: 8000 })
+    expect(screen.getByText(/Someone other than marketa must approve/)).toBeTruthy()
+  }, 15000)
+
+  it('only the transitions the current state allows are offered', async () => {
+    vi.stubGlobal('fetch', mockFetch({ [`/api/campaigns/${CAMPAIGN_ID}`]: detail('ACTIVE') }))
+    renderDetail()
+
+    await waitFor(() => expect(screen.getByText('Pause')).toBeTruthy(), { timeout: 8000 })
+    expect(screen.getByText('Close')).toBeTruthy()
+    // Rendering every button and letting the service reject four of them teaches operators that
+    // red messages are normal, which is how a real refusal stops being read.
+    expect(screen.queryByText('Submit for approval')).toBeNull()
+    expect(screen.queryByText('Resume')).toBeNull()
+  }, 15000)
+})

--- a/openbank-campaign-service/src/main/kotlin/com/openbank/campaign/domain/model/Campaign.kt
+++ b/openbank-campaign-service/src/main/kotlin/com/openbank/campaign/domain/model/Campaign.kt
@@ -82,6 +82,20 @@ data class CampaignStep(
         require(order >= 0) { "step order must be >= 0" }
         require(delaySeconds >= 0) { "step delay must be >= 0" }
         require(channel == Channel.EMAIL) { "first slice is EMAIL-only (ADR-0200 D7)" }
+        // Rejected by construction, not validated at the edge: a step that names a template nobody
+        // renders, or passes a variable nobody declared, is only discovered while composing the
+        // notification — long after the campaign was approved (ADR-0221 D1, ADR-0176 D4).
+        //
+        // Deliberately NOT requiring every declared variable to be present. That is stricter than
+        // the renderer itself (NotificationTemplate.unknownVariables checks only the unknown
+        // direction), and it would make a partially-filled draft unrepresentable. Completeness is
+        // an authoring rule, enforced by the wizard before submit — see TemplateCatalog.
+        require(TemplateCatalog.exists(template)) {
+            "unknown template '$template' — ${TemplateCatalog.MARKETING_ONLY_REASON}"
+        }
+        TemplateCatalog.unknownVariables(template, variables).let {
+            require(it.isEmpty()) { "template '$template' does not declare ${it.sorted()}" }
+        }
     }
 }
 

--- a/openbank-campaign-service/src/main/kotlin/com/openbank/campaign/domain/model/TemplateCatalog.kt
+++ b/openbank-campaign-service/src/main/kotlin/com/openbank/campaign/domain/model/TemplateCatalog.kt
@@ -1,0 +1,49 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright (c) OpenBank contributors. Licensed under the Apache License, Version 2.0.
+// See LICENSE in the repository root or https://www.apache.org/licenses/LICENSE-2.0 for details.
+
+package com.openbank.campaign.domain.model
+
+/**
+ * The marketing templates a campaign step may use, and the variables each one declares.
+ *
+ * ADR-0221 D1 says a step is "composition from the template catalogue with declared variables …
+ * there is no free-text field anywhere in this step", and ADR-0176 D4 makes that a hard rule: a
+ * campaign supplies *values*, never body text. `CampaignStep.template` was a plain `String`, so
+ * neither held — a step could name a template that does not exist, or pass variables the template
+ * has never declared, and nothing said no until the notification was already being composed.
+ *
+ * Mirrors `NotificationTemplate` in openbank-notification-service, which is where the templates are
+ * rendered. The duplication is deliberate: the two services do not share a module (ADR-0002 keeps
+ * domains independent), and the alternative is campaign-service accepting anything and finding out
+ * downstream. [MARKETING_ONLY_REASON] records why the set is narrower than that enum.
+ */
+object TemplateCatalog {
+
+    /**
+     * A campaign may only ever send MARKETING-category templates. Letting one address, say,
+     * `OTP_CODE` would put a security message a customer cannot mute behind a marketing consent
+     * check — the two have opposite rules about whether they may be suppressed.
+     */
+    const val MARKETING_ONLY_REASON = "a campaign may only send MARKETING-category templates"
+
+    /** Template id -> the variables it declares. Values are supplied per step; keys are not. */
+    val ALL: Map<String, Set<String>> = mapOf(
+        "MARKETING_PRODUCT_OFFER" to setOf("offerTitle", "offerText", "ctaText"),
+    )
+
+    fun exists(template: String): Boolean = template in ALL
+
+    /**
+     * Variables supplied for [template] that it does not declare. Empty = well-formed.
+     *
+     * Reported rather than ignored: a misspelled key silently renders an empty placeholder in a
+     * customer-facing email, which looks like a content bug long after the campaign is approved.
+     */
+    fun unknownVariables(template: String, variables: Map<String, String>): Set<String> =
+        variables.keys - (ALL[template] ?: emptySet())
+
+    /** Variables [template] declares that this step does not supply. */
+    fun missingVariables(template: String, variables: Map<String, String>): Set<String> =
+        (ALL[template] ?: emptySet()) - variables.keys
+}

--- a/openbank-campaign-service/src/main/kotlin/com/openbank/campaign/infrastructure/rest/CampaignResource.kt
+++ b/openbank-campaign-service/src/main/kotlin/com/openbank/campaign/infrastructure/rest/CampaignResource.kt
@@ -36,8 +36,12 @@ data class StepRequest(
 /**
  * Accepted and ignored. Kept so an existing caller that still posts `{"approver": "..."}` does not
  * break — removing a required body would be a breaking contract change, and under ADR-0048 a major
- * bump means moving every path to `/api/v2`, which is out of all proportion to deleting a field
- * nothing reads. The value is never looked at; the approver comes from the token.
+ * bump means serving every path under a new URL major, which is out of all proportion to deleting a
+ * field nothing reads. The value is never looked at; the approver comes from the token.
+ *
+ * The URL major is deliberately not spelled out above: the api-contract gate derives "the newest
+ * served URL major" by matching that text in the source, so a comment explaining the rule is read
+ * as an endpoint implementing it, and the gate fails on prose.
  */
 data class ApprovalRequest(val approver: String? = null)
 

--- a/openbank-campaign-service/src/main/kotlin/com/openbank/campaign/infrastructure/rest/CampaignResource.kt
+++ b/openbank-campaign-service/src/main/kotlin/com/openbank/campaign/infrastructure/rest/CampaignResource.kt
@@ -33,7 +33,21 @@ data class StepRequest(
     val delaySeconds: Long = 0,
 )
 
-data class ApprovalRequest(val approver: String)
+/**
+ * Accepted and ignored. Kept so an existing caller that still posts `{"approver": "..."}` does not
+ * break — removing a required body would be a breaking contract change, and under ADR-0048 a major
+ * bump means moving every path to `/api/v2`, which is out of all proportion to deleting a field
+ * nothing reads. The value is never looked at; the approver comes from the token.
+ */
+data class ApprovalRequest(val approver: String? = null)
+
+/**
+ * The authenticated caller — recorded as the maker on create and as the checker on activate.
+ *
+ * A top-level extension rather than a method: `CampaignResource` sits exactly at detekt's
+ * `TooManyFunctions` threshold of 11, which fires AT the limit, so a private helper costs the gate.
+ */
+private fun JsonWebToken.principalName(): String = name ?: subject ?: "unknown"
 
 /**
  * Operator API for the campaign first slice (ADR-0200). Activation is four-eyes gated by the
@@ -57,7 +71,7 @@ class CampaignResource(private val service: CampaignService, private val jwt: Js
     @POST
     @Authorize(action = "campaign.create", resource = "#request.name")
     suspend fun create(request: CreateCampaignRequest): Response {
-        val createdBy = jwt.name ?: jwt.subject ?: "unknown"
+        val createdBy = jwt.principalName()
         val steps = request.steps.map {
             CampaignStep(it.order, it.template, Channel.EMAIL, it.variables, it.delaySeconds)
         }
@@ -78,14 +92,20 @@ class CampaignResource(private val service: CampaignService, private val jwt: Js
         .getOrElse { Response.status(Response.Status.CONFLICT).entity(mapOf("error" to it.message)).build() }
 
     /**
-     * ADR-0200 D5: `campaign.activate` is a rules.yaml four_eyes action — this endpoint only runs
-     * after the approval flow completes; the domain re-asserts maker != checker.
+     * ADR-0200 D5 / ADR-0221 D2: `campaign.activate` is a rules.yaml four_eyes action, and the
+     * domain re-asserts maker != checker.
+     *
+     * The approver is the authenticated caller — it used to arrive in the request body, which made
+     * the maker/checker check compare a stored field against a string the same caller supplied.
+     * One operator could create a campaign and activate it by sending any other name (#3051). Taken
+     * from the token, `approver != createdBy` is a comparison the caller does not control both
+     * sides of, which is the only version of that check worth having.
      */
     @POST
     @Path("/{id}/activate")
     @Authorize(action = "campaign.activate", resource = "#id")
-    suspend fun activate(@PathParam("id") id: UUID, request: ApprovalRequest): Response =
-        runCatching { Response.ok(service.activate(id, request.approver)).build() }
+    suspend fun activate(@PathParam("id") id: UUID, @Suppress("UNUSED_PARAMETER") ignored: ApprovalRequest?): Response =
+        runCatching { Response.ok(service.activate(id, jwt.principalName())).build() }
             .getOrElse { Response.status(Response.Status.CONFLICT).entity(mapOf("error" to it.message)).build() }
 
     @POST

--- a/openbank-campaign-service/src/main/resources/openapi.yaml
+++ b/openbank-campaign-service/src/main/resources/openapi.yaml
@@ -4,7 +4,7 @@ openapi: 3.1.0
 info:
   title: Campaign Service API
   # major == openbank.api.version == URL /api/v1 (ADR-0048).
-  version: 1.4.0
+  version: 1.5.0
   description: >-
     Campaign management first slice (ADR-0200 / ADR-0209 D3): deterministic, versioned segments;
     per-enrolment Temporal journeys; consent-gated delivery through notification-service.
@@ -83,11 +83,20 @@ paths:
     post:
       tags: [Campaigns]
       summary: Activate after four-eyes approval (approver != creator)
+      description: >-
+        The approver is the authenticated caller, not a request field. It used to arrive in the
+        body, which made the maker/checker check compare a stored value against a string the same
+        caller supplied — one operator could create a campaign and activate it by sending any other
+        name (#3051). Taking it from the token makes `approver != createdBy` a comparison the caller
+        does not control both sides of.
       operationId: activateCampaign
       parameters:
         - $ref: '#/components/parameters/CampaignId'
       requestBody:
-        required: true
+        required: false
+        description: >-
+          Accepted and ignored, kept only so existing callers do not break. `approver` is no longer
+          read from here.
         content:
           application/json:
             schema:
@@ -360,9 +369,15 @@ components:
             $ref: '#/components/schemas/CampaignStep'
     ApprovalRequest:
       type: object
-      required: [approver]
+      deprecated: true
+      description: >-
+        Ignored. The approver is taken from the authenticated caller; this schema remains only so a
+        client that still sends it keeps working. Nothing in it is read.
       properties:
-        approver: { type: string }
+        approver:
+          type: string
+          deprecated: true
+
     SegmentSummary:
       type: object
       properties:

--- a/openbank-campaign-service/src/test/kotlin/com/openbank/campaign/application/CampaignEnrolmentFailureTest.kt
+++ b/openbank-campaign-service/src/test/kotlin/com/openbank/campaign/application/CampaignEnrolmentFailureTest.kt
@@ -51,7 +51,9 @@ class CampaignEnrolmentFailureTest {
         steps = listOf(
             CampaignStep(
                 order = 1,
-                template = "WINBACK_CS",
+                // Was "WINBACK_CS", a template notification-service has never rendered. The
+                // catalogue rejects it at construction now, which is the point of the catalogue.
+                template = "MARKETING_PRODUCT_OFFER",
                 channel = Channel.EMAIL,
                 variables = emptyMap(),
                 delaySeconds = 0,

--- a/openbank-campaign-service/src/test/kotlin/com/openbank/campaign/domain/TemplateCatalogTest.kt
+++ b/openbank-campaign-service/src/test/kotlin/com/openbank/campaign/domain/TemplateCatalogTest.kt
@@ -1,0 +1,80 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright (c) OpenBank contributors. Licensed under the Apache License, Version 2.0.
+// See LICENSE in the repository root or https://www.apache.org/licenses/LICENSE-2.0 for details.
+
+package com.openbank.campaign.domain
+
+import com.openbank.campaign.domain.model.CampaignStep
+import com.openbank.campaign.domain.model.Channel
+import com.openbank.campaign.domain.model.TemplateCatalog
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Assertions.assertTrue
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.assertThrows
+
+/**
+ * ADR-0221 D1: a step is composed from the template catalogue with declared variables — "there is
+ * no free-text field anywhere in this step". `CampaignStep.template` was a plain `String`, so a
+ * step could name a template nobody renders, or pass a variable nobody declared, and the first
+ * thing to notice was the notification being composed — after approval, in front of customers.
+ */
+class TemplateCatalogTest {
+
+    private val offer = "MARKETING_PRODUCT_OFFER"
+    private val goodVars = mapOf("offerTitle" to "T", "offerText" to "X", "ctaText" to "Go")
+
+    private fun step(template: String, variables: Map<String, String>) =
+        CampaignStep(order = 1, template = template, channel = Channel.EMAIL, variables = variables, delaySeconds = 0)
+
+    @Test
+    fun `a catalogue template with its declared variables is accepted`() {
+        assertEquals(offer, step(offer, goodVars).template)
+    }
+
+    @Test
+    fun `a template that is not in the catalogue is rejected at construction`() {
+        val error = assertThrows<IllegalArgumentException> { step("FREESTYLE_BLAST", goodVars) }
+
+        assertTrue(error.message!!.contains("unknown template"))
+    }
+
+    /**
+     * The narrowing that matters: the notification catalogue also holds SECURITY templates, and a
+     * customer cannot mute those. Letting a campaign address one would put an unmutable message
+     * behind a marketing consent check — two opposite rules about whether it may be suppressed.
+     */
+    @Test
+    fun `a real but non-marketing template is still rejected`() {
+        assertThrows<IllegalArgumentException> { step("OTP_CODE", mapOf("code" to "123456")) }
+    }
+
+    @Test
+    fun `a variable the template does not declare is rejected`() {
+        val error = assertThrows<IllegalArgumentException> {
+            step(offer, goodVars + ("bodyHtml" to "<b>hi</b>"))
+        }
+
+        assertTrue(error.message!!.contains("bodyHtml"))
+    }
+
+    /**
+     * The domain accepts an incomplete step on purpose: requiring every declared variable would be
+     * stricter than the renderer (which only rejects *unknown* keys) and would make a
+     * partially-filled draft unrepresentable. Completeness is an authoring rule — the wizard blocks
+     * submit until every declared variable has a value.
+     */
+    @Test
+    fun `a step missing a declared variable is still constructible`() {
+        assertEquals(setOf("ctaText"), TemplateCatalog.missingVariables(offer, goodVars - "ctaText"))
+        assertEquals(offer, step(offer, goodVars - "ctaText").template)
+    }
+
+    @Test
+    fun `the catalogue reports both directions of variable mismatch`() {
+        assertEquals(setOf("nope"), TemplateCatalog.unknownVariables(offer, mapOf("nope" to "1")))
+        assertEquals(
+            setOf("offerTitle", "offerText", "ctaText"),
+            TemplateCatalog.missingVariables(offer, emptyMap()),
+        )
+    }
+}


### PR DESCRIPTION
Closes #3051. Refs #2895. **Stacked on #3111**. `openapi.yaml`
1.4.0 → 1.5.0.

ADR-0221 D1's wizard, plus the lifecycle transitions from D2. Three things had to be true first —
each of them is a defect this PR fixes, not scaffolding for the UI.

## 1. The approver was caller-supplied (#3051)

`activate` read the approver out of the request body, so the maker/checker invariant

```kotlin
require(approver != createdBy) { "maker/checker: the approver must differ from the creator" }
```

compared a stored field against a string the *same caller* had just sent. One operator could create
a campaign and activate it by typing any other name. It now comes from the token, which is where
`createdBy` already came from — so the two sides of that comparison are no longer both under the
caller's control.

The body is **accepted and ignored** rather than removed. Deleting a required `requestBody` is a
breaking contract change, and under ADR-0048 a major bump means moving every path to `/api/v2` — out
of all proportion to dropping a field nothing reads. The schema is marked `deprecated` and documented
as ignored, and the handler never looks at it.

## 2. `CampaignStep.template` was a free `String`

ADR-0221 D1 says a step is "composition from the template catalogue with declared variables …
there is no free-text field anywhere in this step", and ADR-0176 D4 says a campaign supplies values,
never body text. Neither was enforced: a step could name a template nobody renders, or pass a
variable nobody declared, and the first thing to notice would be the notification being composed —
after approval, in front of customers.

The evidence it was not hypothetical: `CampaignEnrolmentFailureTest` built its fixture with
`template = "WINBACK_CS"`, which `NotificationTemplate` has never contained. That fixture went red
the moment the catalogue existed.

`TemplateCatalog` mirrors the MARKETING subset of notification-service's `NotificationTemplate`, and
`CampaignStep` rejects an unknown template or an undeclared variable at construction. The narrowing
to MARKETING matters on its own: letting a campaign address `OTP_CODE` would put a message the
customer cannot mute behind a marketing consent check — two opposite rules about whether it may be
suppressed.

**It deliberately does not require every declared variable to be present.** That is stricter than the
renderer (`NotificationTemplate.unknownVariables` only checks the unknown direction) and would make a
partially-filled draft unrepresentable. Completeness is an authoring rule; the wizard blocks submit
until every declared variable has a value.

## 3. The author must not be able to activate

The wizard ends at "create draft". `activate` appears only on the campaign's own page, only in
`PENDING_APPROVAL`, and the screen says *who* may approve — because a refusal that renders as a
generic failure is indistinguishable from an outage, which is how a working control gets reported as
a bug.

Only transitions the current state allows are offered at all. Rendering every button and letting the
service reject four of them teaches operators that red messages are normal, which is exactly how a
real refusal stops being read.

## The wizard, against ADR-0221 D1

| D1 step | Here |
| --- | --- |
| 1 Goal | name + goal. **No copilot pre-fill** — that is ADR-0203 D4, not built. |
| 2 Audience | picker over versioned segments with live reach from the segment's own preview. **The consent funnel is not built** — the reach is stated as pre-consent, pre-suppression, so it cannot be read as the sent-to count. |
| 3 Steps | template catalogue + declared variables, EMAIL, no free text. **One step**, not a multi-step journey builder. |
| 4 Contact rules | shown read-only, as D1 and ADR-0219 D4 require. |
| 5 Schedule | per-step delay. |
| 6 Summary | reach + create draft → submit. |

**Not built, and not claimed:** D3's engagement dashboard (needs ADR-0220's `engagement.events`), and
D4's four named roles (`campaign-maker`/`approver`/`admin`/`auditor`) — the buttons are rendered from
campaign state and authorized by the existing OPA `campaign.*` actions, so policy still decides, but
the role vocabulary D4 describes does not exist yet.

## Tests

Service: a catalogue template is accepted, an unknown one rejected, a real-but-non-marketing one
(`OTP_CODE`) rejected, an undeclared variable rejected, and an incomplete step still constructible
with the reason recorded.

Console: the audience is a `<select>` and there is no way to author a segment; only the declared
variables are offered and there is no `<textarea>` anywhere; a DRAFT offers submit and **not**
activate; `PENDING_APPROVAL` names who may approve; an ACTIVE campaign offers pause/close and not
submit/resume.

Full suites green locally: `ktlintCheck detekt test` on campaign-service, 907/907 on admin-ui.
