### PR TITLE
docs: record two PR-mechanics footguns hit while shipping the campaign console

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -585,6 +585,16 @@ Rationale + what does *not* cover it: `rules.yaml: dependencies.pr_time_cve_gate
   Pass `-R <owner>/<repo>` explicitly in any script whose working directory is not guaranteed —
   and note a verification command failing this way returns *nothing*, which is easy to misread
   as "the thing I was checking is absent".
+- **`--delete-branch` on a stacked parent CLOSES the child PR, and that is not reversible.**
+  Deleting the base branch makes GitHub close every PR targeting it; a closed PR whose base is gone
+  can be neither reopened nor retargeted — `reopenPullRequest` answers `Could not open the pull
+  request` and `updatePullRequest` answers `Cannot change the base branch of a closed pull request`.
+  The only way back is a rebase onto the new `main` and a **new** PR, losing the number, the review
+  history and the comment thread. The failure is silent at merge time: `gh pr merge` prints nothing
+  about the child and the merge itself succeeds, so it reads as clean from every angle you would
+  normally check. Either retarget each child to `main` *before* merging the parent, or merge without
+  `--delete-branch` and clean up once the whole stack has landed. `--delete-branch` is only safe on a
+  leaf — check `gh pr list --base <branch>` first (#3055 closed #3063, reopened as #3111).
 
 ### API contract (ADR-0048)
 - **Two racing spec PRs can both claim the same `info.version` — and both pass the gate.** The
@@ -595,6 +605,16 @@ Rationale + what does *not* cover it: `rules.yaml: dependencies.pr_time_cve_gate
   when you resolve a merge conflict against `main` — re-check `info.version` against the *current*
   `main` and re-bump; whoever lands second takes the next version. A matching version line merging
   "cleanly" is the trap: git sees identical text, not a taken version.
+- **The same trap fires from an ALREADY-MERGED PR, which is the direction that gets missed.**
+  Anticipating it is not the same as checking for it: the instinct is "am I racing anyone?", and that
+  scans *open* PRs — but the number is just as easily consumed by something that landed while your
+  branch was open and is now invisible in the PR list. Measured on #3055, where the numbering had
+  been guarded carefully between two stacked PRs and the gate still went
+  `1.2.0 -> 1.2.0` because #3037 had merged. Read the version off live `main`, never off your
+  branch's base, and re-read it after every rebase:
+  `git fetch origin main && git show origin/main:<svc>/src/main/resources/openapi.yaml | grep -m1 '^  version:'`.
+  In a stack each PR takes the next number in order — and a child's diff against `main` spans the
+  whole stack, so point its PR base at the parent branch or the gate sees a multi-minor jump.
 
 ## Capturing what we learn
 


### PR DESCRIPTION
Two footguns hit in one afternoon while shipping the campaign console. Both are pure PR mechanics,
both cost real work, and neither is visible from anything you would normally check after the fact.

## `--delete-branch` on a stacked parent closes the child

`gh pr merge <parent> --squash --delete-branch` deletes the base branch of any PR stacked on it, and
GitHub closes those children automatically. That is not recoverable:

```
gh pr reopen 3063         -> Could not open the pull request. (reopenPullRequest)
gh pr edit 3063 --base main -> Cannot change the base branch of a closed pull request.
```

The only way back is rebasing onto the new `main` and opening a **new** PR — losing the number, the
review history and the comment thread. #3063 became #3111 this way.

What makes it worth a bullet rather than a shrug: the merge itself succeeds, `gh pr merge` prints
nothing about the child, and the parent PR reads as a clean squash from every angle. You only find
out by going to look at a PR you had no reason to re-open.

## The racing spec version also fires from an already-merged PR

The existing bullet covers two *open* PRs claiming the same `info.version`. The direction that got
me is a PR that had **already merged** while my branch was open:

```
##[error]api-contract gate: additive API change requires an info.version MINOR bump,
but it moved 1.2.0 -> 1.2.0
```

I had guarded the numbering deliberately between my own two stacked PRs and still shipped this,
because #3037 took 1.2.0 on `main` after my branch was cut. Anticipating the trap is not the same as
checking for it — the instinct is "am I racing anyone?", which scans open PRs, and the number is just
as easily consumed by something already landed and now invisible in the list.

The fix is one command, but it has to be run against live `main` rather than the branch's base, and
re-run after every rebase.

No code changes; documentation only.
