### PR TITLE
fix(ci): ask the pact broker about the commit being deployed, not the last one

### DIFF
--- a/.github/scripts/resolve-can-i-deploy-selector.sh
+++ b/.github/scripts/resolve-can-i-deploy-selector.sh
@@ -1,0 +1,96 @@
+#!/usr/bin/env bash
+# SPDX-License-Identifier: Apache-2.0
+# Copyright (c) OpenBank contributors. Licensed under the Apache License, Version 2.0.
+# See LICENSE in the repository root or https://www.apache.org/licenses/LICENSE-2.0 for details.
+#
+# ---------------------------------------------------------------------------------------
+# Decide WHICH VERSION can-i-deploy should ask the broker about (issue #3082, defect 1).
+#
+# THE PROBLEM THIS SOLVES
+# auto-deploy asks `can-i-deploy --pacticipant <svc> --latest main`, and `can-i-deploy`
+# has `needs: [changes, build-push]` — auto-deploy's OWN image build, NOT services-ci,
+# which is the workflow that publishes pact versions. Both are triggered by the same push
+# and run concurrently, so the gate routinely asks about a commit whose pacts are still
+# being built. Measured on run 30690770972: it asked about account-service at 08:36:49,
+# and that service's build did not START until 08:39:03.
+#
+# `--latest main` then resolves to the PREVIOUS main build's version, and the answer is
+# about a different commit than the one being deployed. That has two outcomes, and the
+# quieter one is the dangerous one:
+#
+#   * the older version was NOT verified  → red, labelled PENDING_BUILD. Noisy, honest,
+#     self-clearing. This is the half that shows up in the failure rate.
+#   * the older version WAS verified      → GREEN, and auto-deploy ships an image built
+#     from $GITHUB_SHA whose contracts were never verified at all. Nothing anywhere says
+#     so. A contract gate that answers about the wrong version is not a gate.
+#
+# The broker says this itself, on every single run:
+#   WARN: It is recommended to specify the version number (rather than the tag or branch)
+#   of the pacticipant you wish to deploy to avoid race conditions. Without a version
+#   number, this result will not be reliable.
+#
+# WHY NOT JUST ALWAYS PASS --version $GITHUB_SHA
+# Because the existing `--latest main` is not an oversight — auto-deploy.yml records the
+# reason: path-scoped CI skips most services on any given commit, so for those the broker
+# legitimately has no version for $GITHUB_SHA and `--version` errors with "No pacts or
+# verifications". Switching unconditionally would break the common case to fix the rare
+# one. So the selector is chosen from a PROBE of whether this commit's version actually
+# exists, and falls back to today's exact behaviour whenever it does not.
+#
+# WHY A SEPARATE SCRIPT
+# Same reason as classify-can-i-deploy-block.sh next door: inline in the workflow this is
+# unreachable by any test, and a gate whose version-selection logic is untested is a gate
+# that can silently start asking about the wrong thing. Here it is a pure function of
+# (probe result, sha) with no network of its own, so the unit test can drive every branch.
+#
+# Usage:
+#   PACT_VERSION_PRESENT=yes|no|unknown resolve-can-i-deploy-selector.sh <service> <sha>
+#
+#   PACT_VERSION_PRESENT — the caller's probe of
+#     GET <broker>/pacticipants/<svc>/versions/<sha>, same vocabulary the classifier uses:
+#       yes     → 200, a version exists for THIS commit
+#       no      → 404, this commit's build has published nothing yet
+#       unknown → the probe itself failed (broker unreachable / non-2xx-non-404)
+#
+# Prints one TAB-separated line: <selector args>\t<human reason>
+# The selector is emitted as the literal CLI arguments, so the caller does no string
+# surgery on it — a caller that has to re-split the answer is a caller that can get it
+# wrong.
+#
+# Always exits 0 — this chooses a question, it does not answer one.
+set -uo pipefail
+
+SVC="${1:-}"
+SHA="${2:-}"
+if [ -z "$SVC" ] || [ -z "$SHA" ]; then
+  echo "usage: PACT_VERSION_PRESENT=yes|no|unknown $0 <service> <sha>" >&2
+  exit 2
+fi
+
+PRESENT="${PACT_VERSION_PRESENT:-unknown}"
+
+emit() { printf '%s\t%s\n' "$1" "$2"; }
+
+case "$PRESENT" in
+  yes)
+    # The precise question, and the one the broker's own warning asks for: can THIS commit
+    # of this service go to sandbox? No race window, and a green here cannot be borrowed
+    # from an older build.
+    emit "--version ${SHA}" \
+      "this commit's pact version is in the broker — asking about it exactly, so the verdict cannot be inherited from an earlier build"
+    ;;
+  no)
+    # Today's behaviour, deliberately unchanged. `--version` would error "No pacts or
+    # verifications" for a service path-scoped CI skipped on this commit, which is most of
+    # the fleet on most commits. The block classifier downstream then labels this
+    # PENDING_BUILD from the same probe result, and the reconcile tick re-drives it.
+    emit "--latest main" \
+      "no pact version for this commit — falling back to latest/main (ADR-0092); the block classifier will label this PENDING_BUILD"
+    ;;
+  *)
+    # Probe failed. Fall back rather than invent precision: an unreachable broker must not
+    # silently change which question the gate asks.
+    emit "--latest main" \
+      "broker probe inconclusive — falling back to latest/main rather than assuming a version that may not exist"
+    ;;
+esac

--- a/.github/scripts/test-resolve-can-i-deploy-selector.sh
+++ b/.github/scripts/test-resolve-can-i-deploy-selector.sh
@@ -1,0 +1,96 @@
+#!/usr/bin/env bash
+# SPDX-License-Identifier: Apache-2.0
+# Copyright (c) OpenBank contributors. Licensed under the Apache License, Version 2.0.
+# See LICENSE in the repository root or https://www.apache.org/licenses/LICENSE-2.0 for details.
+#
+# Unit test for resolve-can-i-deploy-selector.sh (issue #3082, defect 1). Pure bash, no
+# network, no Gradle — same shape as test-classify-can-i-deploy-block.sh next door.
+#
+# The case that matters is #2. Before this selector existed, a service whose pact for the
+# deployed commit WAS already in the broker was still asked about as `--latest main`, so a
+# green could be inherited from an earlier build while the image being shipped came from a
+# commit nobody had verified. That is a false GREEN on a contract gate, and it is silent —
+# there is no red anywhere to notice. If someone "simplifies" this script back to always
+# returning `--latest main`, case 2 is what goes red.
+set -uo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+RESOLVE="${SCRIPT_DIR}/resolve-can-i-deploy-selector.sh"
+SHA="0e32873f8c52d37e1b6530e5bd5e94275e5cefae"
+
+fails=0
+check() {
+  local name="$1" want="$2" present="$3"
+  local got
+  got="$(PACT_VERSION_PRESENT="$present" bash "$RESOLVE" openbank-demo-service "$SHA" | cut -f1)"
+  if [ "$got" = "$want" ]; then
+    echo "  ok   ${name} → ${got}"
+  else
+    echo "  FAIL ${name}: want '${want}', got '${got}'"
+    fails=$((fails + 1))
+  fi
+}
+
+echo "resolve-can-i-deploy-selector.sh"
+
+# 1. The common case: path-scoped CI skipped this service on this commit, so the broker has
+#    no version for it. Must keep today's behaviour exactly — `--version` would error here.
+check "no version for this commit → latest/main" "--latest main" no
+
+# 2. THE POINT OF THE FILE. This commit's version IS published, so ask about it precisely.
+#    Returning `--latest main` here is the false-green path: the verdict would be about a
+#    different, older version than the image being deployed.
+check "version present → ask about THIS commit" "--version ${SHA}" yes
+
+# 3. Broker probe failed. Must fall back, not invent precision — asking `--version` for a
+#    version that may not exist would turn an unreachable broker into a fleet-wide block.
+check "probe inconclusive → latest/main" "--latest main" unknown
+
+# 4. Unset variable behaves as `unknown`, not as `yes`. A caller that forgets to export the
+#    probe must not silently get the precise-but-possibly-wrong question.
+got_unset="$(unset PACT_VERSION_PRESENT; bash "$RESOLVE" openbank-demo-service "$SHA" | cut -f1)"
+if [ "$got_unset" = "--latest main" ]; then
+  echo "  ok   unset probe → latest/main"
+else
+  echo "  FAIL unset probe: want '--latest main', got '${got_unset}'"
+  fails=$((fails + 1))
+fi
+
+# 5. Every branch must emit a non-empty human reason — the workflow prints it, and a blank
+#    reason is how a decision becomes unexplainable after the fact.
+for p in yes no unknown; do
+  reason="$(PACT_VERSION_PRESENT="$p" bash "$RESOLVE" openbank-demo-service "$SHA" | cut -f2)"
+  if [ -n "$reason" ]; then
+    echo "  ok   reason present for present=${p}"
+  else
+    echo "  FAIL reason missing for present=${p}"
+    fails=$((fails + 1))
+  fi
+done
+
+# 6. The selector must be usable as literal CLI args without re-splitting by the caller.
+#    Two words for `--latest main`, two for `--version <sha>` — a caller doing `${SEL[@]}`
+#    after `read -ra` gets exactly what the broker CLI expects.
+sel="$(PACT_VERSION_PRESENT=yes bash "$RESOLVE" openbank-demo-service "$SHA" | cut -f1)"
+read -ra sel_arr <<< "$sel"
+if [ "${#sel_arr[@]}" -eq 2 ] && [ "${sel_arr[0]}" = "--version" ] && [ "${sel_arr[1]}" = "$SHA" ]; then
+  echo "  ok   selector splits into exactly the two CLI args"
+else
+  echo "  FAIL selector split: got ${#sel_arr[@]} arg(s): ${sel_arr[*]}"
+  fails=$((fails + 1))
+fi
+
+# 7. Missing arguments are a usage error, not a silent default. Defaulting here would send
+#    the gate a question about an empty version.
+if bash "$RESOLVE" openbank-demo-service >/dev/null 2>&1; then
+  echo "  FAIL missing-sha-arg: expected non-zero exit"
+  fails=$((fails + 1))
+else
+  echo "  ok   missing-sha-arg → non-zero exit"
+fi
+
+if [ "$fails" -ne 0 ]; then
+  echo "FAILED: ${fails} case(s)"
+  exit 1
+fi
+echo "all cases behaved as declared"

--- a/.github/workflows/auto-deploy.yml
+++ b/.github/workflows/auto-deploy.yml
@@ -818,6 +818,13 @@ jobs:
             || echo "::warning::could not ensure sandbox environment (may already exist — continuing)"
           rc=0
           deployable_list=()
+          # Bounded head start for the pact-publish race (#3082, defect 1). Total across ALL
+          # services and a per-service cap, so a fleet-sized push cannot turn this job into a
+          # 45-minute wait — it is a head start, not a synchronisation primitive. Both are
+          # env-overridable so an operator can widen or disable it without a code change;
+          # setting the budget to 0 restores the pre-#3082 behaviour exactly.
+          PACT_WAIT_BUDGET="${PACT_WAIT_BUDGET_SECONDS:-180}"
+          PACT_WAIT_PER_SVC="${PACT_WAIT_PER_SERVICE_SECONDS:-60}"
           # Per-service block classification (#2549): PENDING_BUILD / UNVERIFIED /
           # REGRESSION / UNKNOWN, plus the human reason. Read below by the left-behind
           # summary and by the scheduled-tick silencing rule.
@@ -879,16 +886,66 @@ jobs:
               deployable_list+=("$svc")
               continue
             fi
-            # --latest main: ask "can the latest version tagged 'main' go to sandbox?"
-            # _service-ci.yml publishes every version with tags:[$branch] so the broker
-            # index has a 'main'-tagged entry for each service's last main-branch build.
-            # --version $SHA would error ("No pacts or verifications") when path-scoped CI
-            # skipped this service on the triggering commit (ADR-0092).
-            # record-deployment (gitops-pr job) still pins the exact $GITHUB_SHA so the
-            # broker tracks what is actually deployed.
-            echo "==> can-i-deploy ${svc} (latest/main) → environment sandbox"
+            # WHICH VERSION do we ask about? (issue #3082, defect 1)
+            #
+            # `--latest main` alone asks about the last main-tagged build, which on a push is
+            # very often NOT the commit being deployed: this job needs [changes, build-push],
+            # i.e. auto-deploy's own image build — never services-ci, which is what publishes
+            # pact versions. The two race. Measured on run 30690770972: the gate asked about
+            # account-service at 08:36:49 and that service's build did not START until
+            # 08:39:03. The loud half of that is a PENDING_BUILD red. The quiet half is worse —
+            # if the older main version happens to be verified, the gate goes GREEN and
+            # auto-deploy ships an image built from $GITHUB_SHA whose contracts were never
+            # verified. The broker warns about exactly this on every run ("specify the version
+            # number ... without a version number, this result will not be reliable").
+            #
+            # So: wait briefly for THIS commit's version, then ask about it precisely; and if
+            # it is genuinely absent, fall back to today's exact behaviour. `--version $SHA`
+            # cannot be the unconditional answer — path-scoped CI skips most services on most
+            # commits, and for those the broker rightly has no version for this sha and
+            # `--version` errors with "No pacts or verifications" (ADR-0092). The selector is
+            # chosen by resolve-can-i-deploy-selector.sh, which is unit-tested precisely so
+            # this cannot silently regress to always asking the vaguer question.
+            #
+            # The wait is bounded and only happens on `push`, where the changed set really is
+            # being built right now. On schedule/dispatch the fleet was built at other commits,
+            # so waiting would burn the budget for nothing. It is a best-effort head start, NOT
+            # a synchronisation primitive: the fleet build serialises at ~45 min/service on one
+            # runner, so a 53-service push will still leave most services PENDING_BUILD for the
+            # reconcile tick. It converts the common 1-3 service push from a coin flip into a
+            # correct answer, and never makes any case worse than it is today.
+            vpresent=unknown
+            probe_version() {
+              local code
+              code="$(curl -s -o /dev/null -w '%{http_code}' \
+                -u "${PACT_BROKER_USERNAME}:${PACT_BROKER_PASSWORD}" \
+                "${PACT_BROKER_URL}/pacticipants/${svc}/versions/${GITHUB_SHA}" || echo 000)"
+              case "$code" in
+                200) echo yes ;;
+                404) echo no ;;
+                *)   echo unknown ;;
+              esac
+            }
+            vpresent="$(probe_version)"
+            if [ "$vpresent" = "no" ] && [ "${{ github.event_name }}" = "push" ] \
+               && [ "$PACT_WAIT_BUDGET" -gt 0 ]; then
+              waited=0
+              while [ "$waited" -lt "$PACT_WAIT_PER_SVC" ] && [ "$PACT_WAIT_BUDGET" -gt 0 ]; do
+                sleep 10
+                waited=$((waited + 10))
+                PACT_WAIT_BUDGET=$((PACT_WAIT_BUDGET - 10))
+                vpresent="$(probe_version)"
+                [ "$vpresent" = "no" ] || break
+              done
+              [ "$waited" -gt 0 ] && echo "  … waited ${waited}s for ${svc}'s pact version (budget left: ${PACT_WAIT_BUDGET}s) → ${vpresent}" || true
+            fi
+            sel_line="$(PACT_VERSION_PRESENT="$vpresent" \
+              bash .github/scripts/resolve-can-i-deploy-selector.sh "$svc" "$GITHUB_SHA")"
+            read -ra CID_SELECTOR <<< "$(printf '%s' "$sel_line" | cut -f1)"
+            echo "==> can-i-deploy ${svc} (${CID_SELECTOR[*]}) → environment sandbox"
+            echo "    $(printf '%s' "$sel_line" | cut -f2)"
             cid_out=$("$CLI" can-i-deploy \
-                 --pacticipant "$svc" --latest main \
+                 --pacticipant "$svc" "${CID_SELECTOR[@]}" \
                  --to-environment sandbox \
                  --broker-base-url "$PACT_BROKER_URL" \
                  --broker-username "$PACT_BROKER_USERNAME" \
@@ -926,14 +983,11 @@ jobs:
                 # distinguish a queue delay from a regression (issue #2549). Probe the
                 # broker for a version of THIS commit, then classify (the classifier is
                 # unit-tested — .github/scripts/test-classify-can-i-deploy-block.sh).
-                vcode="$(curl -s -o /dev/null -w '%{http_code}' \
-                  -u "${PACT_BROKER_USERNAME}:${PACT_BROKER_PASSWORD}" \
-                  "${PACT_BROKER_URL}/pacticipants/${svc}/versions/${GITHUB_SHA}" || echo 000)"
-                case "$vcode" in
-                  404) present=no ;;
-                  2??) present=yes ;;
-                  *)   present=unknown ;;
-                esac
+                # Reuse the probe taken before the can-i-deploy call rather than re-asking.
+                # Not just to save a request: if the version landed between the two calls the
+                # selector and this label would describe different worlds, and the summary
+                # would explain a block that was decided on other evidence.
+                present="$vpresent"
                 cls_line="$(PACT_VERSION_PRESENT="$present" \
                   bash .github/scripts/classify-can-i-deploy-block.sh "$svc" <<< "$cid_out")"
                 cls="$(cut -f1 <<< "$cls_line")"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -877,6 +877,17 @@ jobs:
       - name: "can-i-deploy block classifier unit test"
         run: bash .github/scripts/test-classify-can-i-deploy-block.sh
 
+      # can-i-deploy version-selector unit test (issue #3082, defect 1). The classifier above
+      # labels WHY a block happened; this one decides WHICH VERSION the gate asks about in the
+      # first place — and getting that wrong is quieter than any block. `--latest main` on a
+      # push routinely resolves to the PREVIOUS build, so a green can be inherited from a
+      # commit that is not the one being deployed: a contract gate answering about the wrong
+      # version. The load-bearing case is "version present → --version <sha>"; if someone
+      # simplifies the selector back to always returning `--latest main`, that case is what
+      # goes red.
+      - name: "can-i-deploy version selector unit test"
+        run: bash .github/scripts/test-resolve-can-i-deploy-selector.sh
+
       # co-deploy set derivation unit test (issue #1985). The classifier above says WHAT KIND
       # of block a service has; this one says whether the block can be resolved by deploying
       # that service at all. Two services that name each other never converge one at a time,


### PR DESCRIPTION
## Summary

Defect 1 from #3082. `can-i-deploy` asks the broker about **the wrong commit**, and the quiet consequence is a false green on a contract gate.

## The race

`can-i-deploy` has `needs: [changes, build-push]` — auto-deploy's *own* image build, never `services-ci`, which is what publishes pact versions. Both fire from the same push and race.

Measured on run `30690770972`:

```
gate asked about account-service   08:36:49
account-service build STARTED      08:39:03   (+2m14s)
```

So `--latest main` routinely resolves to the **previous** main build.

| older version | outcome |
|---|---|
| not verified | red, `PENDING_BUILD` — loud, honest, self-clearing. This is the half in the failure rate. |
| **verified** | **GREEN** — auto-deploy ships an image built from `$GITHUB_SHA` whose contracts were never verified. Nothing reports it. |

A contract gate that answers about the wrong version is not a gate. The broker has been warning about exactly this in every single log line:

> `WARN: It is recommended to specify the version number (rather than the tag or branch) of the pacticipant you wish to deploy to avoid race conditions. Without a version number, this result will not be reliable.`

## Why `--version $GITHUB_SHA` cannot simply replace it

The existing comment in the workflow is right: path-scoped CI skips most services on most commits, so for those the broker legitimately has **no** version for this sha and `--version` errors "No pacts or verifications" (ADR-0092). Switching unconditionally would break the common case to fix the rare one.

So the question is **chosen**, not fixed:

| probe of `/pacticipants/<svc>/versions/<sha>` | selector | why |
|---|---|---|
| present | `--version $GITHUB_SHA` | the precise question; a green cannot be inherited |
| absent | `--latest main` | today's exact behaviour; classifier labels `PENDING_BUILD` |
| probe failed | `--latest main` | fall back rather than invent precision |

`resolve-can-i-deploy-selector.sh` owns that choice as a pure function with no network — same reason `classify-can-i-deploy-block.sh` next door exists: inline in the workflow it is unreachable by any test, and version-selection logic that can silently start asking the vaguer question is exactly what this fixes.

## Plus a bounded head start

Before asking, the gate polls for this commit's version: **60s per service, 180s total**, both env-overridable, and **only on `push`** — on schedule/dispatch the fleet was built at other commits, so waiting would burn the budget for nothing. `PACT_WAIT_BUDGET_SECONDS=0` restores the previous behaviour exactly.

**Deliberately a head start, not a synchronisation primitive.** The fleet build serialises at ~45 min/service on one runner, so a 53-service push will still leave most services `PENDING_BUILD` for the reconcile tick — that stays self-clearing and is unchanged. What this fixes is the ordinary 1–3 service push, which goes from a coin flip to a correct answer. It never makes any case worse than today.

## Probe reuse

The downstream block classifier now reuses this probe instead of taking its own. Beyond saving a request: if the version landed between the two calls, the selector and the block label would describe **different worlds**, and the summary would explain a block that was decided on other evidence.

## Verification

The **real step body** was extracted from the workflow with a YAML parse — not retyped, because a transcription is a different program — and run against stubbed `curl`/CLI. The stubs were validated against known-positives *first*, or a silent passthrough would have hit the real broker:

```
version present immediately (push)      -> --version deadbeefcafe
absent, appears after one probe (push)  -> waited 10s, then --version deadbeefcafe
absent throughout (push)                -> waited 30s, budget spent, --latest main
absent, schedule                        -> no wait at all, --latest main
```

The CLI's own argv was asserted each time, not just the printed line.

`resolve-can-i-deploy-selector.sh` ships 9 unit-test cases, wired into `Validate manifests`. The load-bearing one is **"version present → `--version <sha>`"**: injecting the obvious simplification (always return `--latest main`) turns it red — that is the false-green path this change exists to close, and it was verified by injecting it.

Both existing suites still pass. shellcheck clean. actionlint and yamllint finding **sets** diffed against `origin/main` — unchanged.

## Linked issues

Closes #3082
Refs #2549, ADR-0092

## Definition of Done

- [x] Hexagonal layering — n/a, CI.
- [x] Tests: 9 new cases, falsified by injecting the regression they guard.
- [ ] Integration / contract tests — n/a.
- [ ] `./gradlew ...` — n/a.
- [x] No new lint warnings (finding sets diffed).
- [ ] OpenAPI / Flyway / Avro — n/a.
- [x] Docs updated — the reasoning is in the script header and the workflow comment.

## Security checklist

- [x] No secrets, tokens, passwords, or PII in code, config, tests, logs. Broker credentials stay in the existing env refs; the stub harness is local-only and not committed.
- [x] No new `@SuppressWarnings` / `@Suppress`.
- [x] No new third-party dependency.
- [ ] **Contract-gate change — reviewer attention.** This alters which question a deploy gate asks. The fallback is byte-identical to today's behaviour, and the new path is strictly more precise, but a second pair of eyes on the selector's three branches is worth it.
- [x] No PII path changed.
- [x] No cardholder data path changed.

## Compliance impact

- [x] DORA — deployment/contract assurance: the gate can no longer pass on evidence from a different build.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
