### PR TITLE
chore(gitops): lending on Temporal frontend + LENDING_ENFORCE_PACK knob + CZ pack activation script

### DIFF
--- a/openbank-infra/gitops/components/lending/lending-service.yaml
+++ b/openbank-infra/gitops/components/lending/lending-service.yaml
@@ -117,6 +117,20 @@ spec:
             # validated against this Redis in a lower env.
             - name: QUARKUS_REDIS_HOSTS
               value: redis://redis.lending.svc:6379
+            # ADR-0211 D2: Temporal durable origination timers (document SLA, offer
+            # expiry, reflection wait). The temporal-platform-ingress NetworkPolicy
+            # lists the lending namespace, otherwise the worker's onStart gRPC to
+            # temporal-frontend:7233 is DROPPED and the service never boots.
+            - name: OPENBANK_TEMPORAL_ENABLED
+              value: "true"
+            - name: OPENBANK_TEMPORAL_SERVER_URL
+              value: temporal-frontend.temporal.svc.cluster.local:7233
+            # ADR-0212 D2/D4: fail-closed origination guard. STAYS false until the CZ
+            # reference pack is four-eyes-activated in this environment (compliance-
+            # packs/README.md runbook: seed -> activate -> verify /active -> flip).
+            # Flipping early refuses every origination with no pack present.
+            - name: LENDING_ENFORCE_PACK
+              value: "false"
             # OTel traces → Tempo.
             - name: QUARKUS_OTEL_EXPORTER_OTLP_ENDPOINT
               value: "http://tempo.observability.svc:4317"

--- a/openbank-infra/gitops/components/temporal/temporal-network-policies.yaml
+++ b/openbank-infra/gitops/components/temporal/temporal-network-policies.yaml
@@ -65,6 +65,7 @@ spec:
                   - fx
                   - statements
                   - campaign
+                  - lending
                   - finops-agent
                   - devops-agent
                   - control-liveness-sentinel

--- a/openbank-infra/scripts/activate-cz-pack.sh
+++ b/openbank-infra/scripts/activate-cz-pack.sh
@@ -1,0 +1,40 @@
+#!/usr/bin/env bash
+# SPDX-License-Identifier: Apache-2.0
+# ADR-0212 D4 bootstrap, steps 2-3 of the runbook (seed -> ACTIVATE -> verify -> flip):
+# four-eyes-activate the CZ reference pack against a live lending-service, then verify.
+# The flip of LENDING_ENFORCE_PACK stays a separate gitops PR after this script's
+# /active output shows the pack — flipping earlier refuses every origination.
+#
+# Usage:
+#   BASE_URL=https://api.open-bank.tech \
+#   MAKER_TOKEN=<ROLE_COMPLIANCE JWT of principal A> \
+#   CHECKER_TOKEN=<ROLE_COMPLIANCE JWT of principal B, must differ from A> \
+#   openbank-infra/scripts/activate-cz-pack.sh
+set -euo pipefail
+
+BASE_URL="${BASE_URL:?set BASE_URL (e.g. https://api.open-bank.tech)}"
+MAKER_TOKEN="${MAKER_TOKEN:?set MAKER_TOKEN (compliance maker JWT)}"
+CHECKER_TOKEN="${CHECKER_TOKEN:?set CHECKER_TOKEN (compliance checker JWT, must differ from maker)}"
+PACK_FILE="$(git rev-parse --show-toplevel)/openbank-lending-service/src/main/resources/compliance-packs/cz-consumer-credit-v1.json"
+
+echo "==> 1/3 maker proposes the CZ pack"
+proposal=$(curl -fsS -X POST "${BASE_URL}/api/v1/lending/compliance-packs/proposals" \
+  -H "Authorization: Bearer ${MAKER_TOKEN}" \
+  -H "Content-Type: application/json" \
+  --data-binary "@${PACK_FILE}")
+echo "${proposal}" | python3 -m json.tool
+proposal_id=$(echo "${proposal}" | python3 -c 'import json,sys; print(json.load(sys.stdin)["id"])')
+
+echo "==> 2/3 checker approves (must differ from maker — server enforces four-eyes)"
+curl -fsS -X POST "${BASE_URL}/api/v1/lending/compliance-packs/proposals/${proposal_id}/decide" \
+  -H "Authorization: Bearer ${CHECKER_TOKEN}" \
+  -H "Content-Type: application/json" \
+  -d '{"approve": true, "reason": "reviewed against 257/2016 Sb. and CCD2"}' | python3 -m json.tool
+
+echo "==> 3/3 verify the pack is active"
+curl -fsS "${BASE_URL}/api/v1/lending/compliance-packs/active" \
+  -H "Authorization: Bearer ${CHECKER_TOKEN}" | python3 -m json.tool
+
+echo ""
+echo "NEXT (manual): flip LENDING_ENFORCE_PACK=true in openbank-infra/gitops/components/lending/lending-service.yaml"
+echo "as its own one-line PR. Do NOT flip before this script's /active output shows the pack."


### PR DESCRIPTION
## Summary

Ops slice for the credit platform go-live prep (ADR-0211 D2 + ADR-0212 D4 bootstrap): enables the lending Temporal origination timers in the cluster, allowlists the lending namespace on the Temporal frontend NetworkPolicy, declares the `LENDING_ENFORCE_PACK` knob explicitly (stays `false`), and ships the four-eyes CZ pack activation script. **The enforce flag is NOT flipped in this PR** — the flip is a separate one-line PR after the pack is verified active (bootstrap order: seed → activate → verify → flip).

## Type of change

- [ ] feat (new functionality)
- [ ] fix (bug fix)
- [ ] refactor (no behavior change)
- [ ] perf (performance)
- [ ] docs
- [x] chore (build / tooling)
- [ ] security (private until disclosed)
- [ ] breaking change

## Linked issues

N/A — gitops/ops bootstrap step for ADR-0211 D2 and ADR-0212 D4 (architectural decisions live in docs/adr, no tracking issue).

## Changes

- `components/temporal/temporal-network-policies.yaml` — `lending` added to `temporal-platform-ingress`. The comment in the policy itself warns: a worker namespace missing here blocks `onStart()` gRPC to `temporal-frontend:7233` → boot failure (enforcement is live, ADR-0060).
- `components/lending/lending-service.yaml` — `OPENBANK_TEMPORAL_ENABLED=true` + `OPENBANK_TEMPORAL_SERVER_URL` (mirrors fx-service wiring); `LENDING_ENFORCE_PACK=false` declared with the bootstrap warning inline (the silent-default trap: an undeclared knob flips invisibly later).
- `openbank-infra/scripts/activate-cz-pack.sh` — the activation runbook as an executable: maker proposes `cz-consumer-credit-v1.json` → checker (a DIFFERENT principal) approves → `/active` verification, ending with the explicit "flip is the next PR" instruction.

## Definition of Done

- [ ] Service code changes. — none (gitops + script only)
- [x] YAML validity verified (safe_load both files); `gen-network-policies.py` re-run shows no drift; shellcheck clean on the script.
- [x] Docs updated — the activation flow is already documented in `openbank-lending-service/src/main/resources/compliance-packs/README.md` (#2873).

## Security checklist

- [x] No secrets, tokens, passwords, or PII in code, config, tests, logs. (tokens are runtime env inputs to the script, never committed)
- [x] No new third-party dependency.
- [ ] Auth / crypto / payment code changed? → tag `security-review-required`.

## Compliance impact

- [ ] PCI DSS
- [x] DORA
- [ ] GDPR
- [ ] PSD2 / SCA / RTS
- [ ] AML / 5AMLD
- [x] CNB reporting
- [ ] None

Enables durable execution on a money-path service (DORA resilience) and stages the CZ 257/2016 Sb. compliance enforcement bootstrap — without enforcing anything yet (flag stays false, zero behaviour change on deploy).

## Rollout / Rollback

- Deployment strategy: ArgoCD auto-sync. The Temporal enable starts the origination-timers worker (idempotent, no business state). The NetworkPolicy addition is ingress-allowlisting only.
- Rollback plan: revert this PR (worker stops, NP entry removed); no state to unwind — timers hold no business state.
- Data migration reversible: N/A

## Reviewer notes

- **Not done here deliberately:** flipping `LENDING_ENFORCE_PACK` and running `activate-cz-pack.sh` against the sandbox — both need live environment actions AFTER this deploys: (1) run the script with two distinct compliance tokens, (2) verify `/active`, (3) one-line flip PR.
- The generated network policies were re-run (`gen-network-policies.py`) — zero drift, confirming the tree was in sync and no generated file needed hand edits.