### PR TITLE
fix(campaign): activate answered 415 to every caller that sent no body

### DIFF
--- a/openbank-campaign-service/src/main/kotlin/com/openbank/campaign/infrastructure/rest/CampaignResource.kt
+++ b/openbank-campaign-service/src/main/kotlin/com/openbank/campaign/infrastructure/rest/CampaignResource.kt
@@ -10,10 +10,12 @@ import com.openbank.campaign.domain.model.Channel
 import com.openbank.campaign.domain.model.SegmentRef
 import com.openbank.libs.authz.Authorize
 import jakarta.enterprise.context.ApplicationScoped
+import jakarta.ws.rs.Consumes
 import jakarta.ws.rs.GET
 import jakarta.ws.rs.POST
 import jakarta.ws.rs.Path
 import jakarta.ws.rs.PathParam
+import jakarta.ws.rs.core.MediaType
 import jakarta.ws.rs.core.Response
 import org.eclipse.microprofile.jwt.JsonWebToken
 import java.util.UUID
@@ -107,6 +109,11 @@ class CampaignResource(private val service: CampaignService, private val jwt: Js
      */
     @POST
     @Path("/{id}/activate")
+    // WILDCARD because the body is genuinely optional. A nullable entity parameter still makes
+    // RESTEasy negotiate a media type, so a POST with no body — which is exactly what the console
+    // sends, having nothing to say — was answered 415 instead of reaching the maker/checker check.
+    // Keeping the parameter for old callers is only backwards-compatible if new callers can omit it.
+    @Consumes(MediaType.WILDCARD)
     @Authorize(action = "campaign.activate", resource = "#id")
     suspend fun activate(@PathParam("id") id: UUID, @Suppress("UNUSED_PARAMETER") ignored: ApprovalRequest?): Response =
         runCatching { Response.ok(service.activate(id, jwt.principalName())).build() }


### PR DESCRIPTION
Refs #3133. Found by E2E'ing #3110 against the deployed sandbox pod.

## What was broken

`POST /api/v1/campaigns/{id}/activate` answered **415** to any caller that sent no request body:

```
# no body — exactly what the console's BFF sends, having nothing to say
HTTP 415  {"code":"HTTP_415","message":"HTTP 415 Unsupported Media Type"}

# with content-type and a body
HTTP 409  {"error":"maker/checker: the approver must differ from the creator (ADR-0200 D5)"}
```

So the "Approve and activate" button shipped in #3110 could not work at all.

## Why I introduced it

#3110 moved the approver from the request body to the token, and kept the `ApprovalRequest`
parameter — **nullable** — so an older caller still posting `{"approver": "..."}` would not break
(removing a required body is a breaking contract change). That reasoning was right and the
implementation was not: a nullable entity parameter still makes RESTEasy negotiate a media type, so
the body was optional in Kotlin's type system and mandatory over HTTP. Keeping a parameter for old
callers is only backwards-compatible if *new* callers can omit it.

`@Consumes(MediaType.WILDCARD)` makes it genuinely optional. Verified against the deployed pod: with
no body the request now reaches the maker/checker check instead of being rejected at negotiation.

## Why no test caught it

- the unit tests call `activate(id, null)` directly — a direct call supplies what the HTTP layer
  does not, so it passes against the broken handler;
- `tsc` type-checks the BFF `fetch` and has nothing to say about the response;
- campaign-service has **no REST-level test at all** — no `@QuarkusTest`, no RestAssured.

That last one is the real finding and is filed separately as #3133, with this bug as its evidence.
It is the same shape `CLAUDE.md` already records for `@Scheduled` methods ("the direct call supplies
the very Vert.x context the scheduler does not") and for CDI wiring.

Deliberately no unit test added here: one would have to call the handler directly, which is precisely
the call that cannot observe this. A test that passes against the broken code is worse than none.
