### PR TITLE
ci(security): stop a Dockerfile-only PR starting the java-kotlin CodeQL leg

### DIFF
--- a/.github/workflows/security.yml
+++ b/.github/workflows/security.yml
@@ -56,9 +56,15 @@ jobs:
           # (and Trivy on every PR) still cover them.
           # Per LANGUAGE, because the analysis is per language: a PR that changes only
           # .ts has nothing for the java-kotlin leg to look at, and vice versa.
-          JAVA_RE='(\.(java|kt|kts)$|(^|/)(build|settings)\.gradle|gradle/|(^|/)Dockerfile)'
+          # No Dockerfile here: the java-kotlin extractor cannot read one, so a
+          # Dockerfile-only PR could only ever start a leg with nothing to trace. That is
+          # no longer RED — #3103's fallback forces a real recompile rather than
+          # finalising an empty database — but it is now the expensive shape instead: a
+          # ~30-module `--rerun-tasks` rebuild, 25-30 min, to analyse a diff containing no
+          # Java. Dockerfile stays in the SBOM regex below, which is a separate question
+          # (a base-image bump genuinely does change the dependency graph).
+          JAVA_RE='(\.(java|kt|kts)$|(^|/)(build|settings)\.gradle|gradle/)'
           JS_RE='(\.(js|jsx|ts|tsx|mjs|cjs)$|(^|/)package(-lock)?\.json$)'
-          CODE_RE="($JAVA_RE|$JS_RE)"
           # NOTE: .github/workflows/ is deliberately NOT in either pattern. A workflow-only
           # PR changes no analysable source, so every compile resolves from cache, CodeQL
           # traces nothing, and `analyze` dies with "could not process any code written in


### PR DESCRIPTION
Closes #3078.

## What was already fixed, and by whom

I filed #3078 after hitting it on #3077, and while I was writing the fix [#3103](https://github.com/JiRaska/open-bank-oss/pull/3103) landed with the same diagnosis and both structural halves:

- the trigger is now per-language, so a workflow-only PR no longer starts the java-kotlin leg;
- the cold re-run uses `--rerun-tasks` (not just `--no-build-cache`, which disables the build cache but not Gradle's up-to-date check) and **fails loudly** if it still traces nothing.

I dropped my duplicate of both. This is the one path they left behind.

## The remaining gap

`JAVA_RE` still contains `(^|/)Dockerfile`. The java-kotlin extractor cannot read a Dockerfile, so a Dockerfile-only PR starts a leg with nothing new to trace.

That is no longer *red* — #3103 made sure of it — it is *expensive* instead. Phase 1 compiles nothing, the guard fires correctly, and the fallback force-rebuilds ~30 modules with `--rerun-tasks`: **25–30 min to analyse a diff containing no Java.**

Not hypothetical, and not rare. Dependabot base-image bumps are exactly this shape — #2686 and #2687 are both `Bump …/ubi9-…` and both sat >56 h.

`Dockerfile` stays in the SBOM regex, which is where a base-image bump belongs: that check is about the dependency graph, not about semantic analysis of source CodeQL never sees.

## Also

Drops `CODE_RE`, dead since #3103 split the pattern per language — assigned, never read. `shellcheck` has been reporting it as unused on `main` ever since (`SC2034`), so leaving it means carrying a permanent finding in a block this PR is editing anyway. The actionlint finding set is otherwise identical to `main`'s.

## Verification

The `detect-deps` step was **extracted from the workflow** and driven against a stubbed `git` — not retyped, since a transcription is a different program. `main`'s version was run beside this one on the same fixtures. Exactly one case moves:

| case | main | this branch |
|---|---|---|
| Dockerfile-only | java-kotlin | **(none)** |
| Kotlin | java-kotlin | java-kotlin |
| workflow-only | (none) | (none) |
| TypeScript | javascript-typescript | javascript-typescript |
| gradle catalog | java-kotlin | java-kotlin |
| docs-only | (none) | (none) |

The rows that do *not* move are the point: a change that made everything skip would satisfy the first row too.
