### PR TITLE
fix(infra): unblock Grafana's OIDC token exchange and its own metrics scrape

### DIFF
--- a/openbank-infra/gitops/apps/kube-prometheus-stack.yaml
+++ b/openbank-infra/gitops/apps/kube-prometheus-stack.yaml
@@ -2,9 +2,13 @@
 # alertmanager (enabled, with the routing tree configured below). Lean FinOps
 # sizing per ADR-0027: single Prometheus replica, 12h retention, gp3 PVC.
 # serviceMonitorSelectorNilUsesHelmValues=false so app ServiceMonitors are
-# picked up regardless of release labels. Grafana has no Ingress — the edge NLB
-# is IP-locked and Grafana keeps the chart-default admin; reach it via
-# `kubectl -n observability port-forward svc/kube-prometheus-stack-grafana 3000:80`.
+# picked up regardless of release labels. Grafana still has no Ingress of its
+# own: it is reached at https://admin.open-bank.tech/tools/grafana, a sub-path of
+# the console served by the admin-ui `admin-ui-tools` Ingress behind an nginx
+# auth_request gate (ADR-0234), so an unauthenticated request is rejected at the
+# edge and never reaches this workload. `openbank-infra/scripts/grafana-local.sh`
+# stays as break-glass (port-forward, local Grafana admin login — SSO does not
+# complete over it, since root_url now carries the public sub-path).
 apiVersion: argoproj.io/v1alpha1
 kind: Application
 metadata:
@@ -260,6 +264,18 @@ spec:
               name_attribute_path: name
               email_attribute_path: email
               role_attribute_path: contains(realm_access.roles[*], 'ROLE_ADMIN') && 'Admin' || (contains(realm_access.roles[*], 'ROLE_OPERATOR') && 'Editor' || 'Viewer')
+          # serve_from_sub_path makes Grafana 301 every root path to the sub-path,
+          # and it renders that redirect as an ABSOLUTE URL on root_url — so the
+          # chart-default `/metrics` scrape was answered with a redirect out to
+          # https://admin.open-bank.tech/tools/grafana/metrics, which Prometheus
+          # followed to the public edge and got the gate's login redirect instead
+          # of metrics. Grafana's own telemetry therefore stopped at the moment
+          # the sub-path landed, with nothing red anywhere: the ServiceMonitor was
+          # healthy, the target was "up", and it was scraping a login page.
+          # Scrape the sub-path directly so no redirect is involved.
+          serviceMonitor:
+            enabled: true
+            path: /tools/grafana/metrics
           # Sentry-protocol datasource plugin so GlitchTip mobile crashes
           # (ADR-0075) sit on the same pane as backend telemetry (ADR-0082).
           plugins:

--- a/openbank-infra/gitops/components/keycloak/networkpolicy-grafana-oidc.yaml
+++ b/openbank-infra/gitops/components/keycloak/networkpolicy-grafana-oidc.yaml
@@ -1,0 +1,56 @@
+# SPDX-License-Identifier: Apache-2.0
+# Copyright (c) OpenBank contributors. Licensed under the Apache License, Version 2.0.
+#
+# Grafana's OIDC back-channel to Keycloak (ADR-0234, ADR-0056).
+#
+# WHAT BROKE. Grafana's `auth.generic_oauth` runs the browser leg against
+# kc.open-bank.tech but the token/userinfo leg in-cluster against
+# `keycloak.iam.svc:8080`. That call was being DROPPED, so every SSO login got
+# as far as Keycloak, came back with a code, and then bounced to the login page
+# after a 20 s timeout:
+#
+#   authn.service level=error msg="Failed to authenticate request"
+#   client=auth.client.generic_oauth error="[auth.oauth.token.exchange]
+#   failed to exchange code to token: Post http://keycloak.iam.svc:8080/…"
+#
+# WHY THE ALLOW-LIST LOOKED CORRECT. `keycloak-ingress-allow-list` (generated,
+# ADR-0081) DOES name `observability` — but on **TCP:9000**, the metrics port,
+# in a rule of its own. The 8080 rule lists ~38 other namespaces and not this
+# one. Reading the policy's namespaces without their per-rule ports therefore
+# says "observability is allowed", and that reads as covered when it is not.
+# Only an actual connection attempt distinguishes the two: a plain pod in
+# `observability` times out on :8080 while :9000 is fine.
+#
+# WHY THE GENERATOR DID NOT CATCH IT. gen-network-policies.py derives edges from
+# the env URLs declared on Deployments under components/. Grafana is a Helm
+# subchart of kube-prometheus-stack and its `token_url` lives in a `grafana.ini`
+# values block, so this edge is invisible to it — the same blind spot that makes
+# networkpolicy-grafana.yaml hand-written. Hence a separate hand-written file
+# rather than an edit to the generated one; NetworkPolicies are additive.
+#
+# WHY IT SURFACED ONLY NOW. Grafana had no Ingress before ADR-0234, so the SSO
+# login was reachable only through a port-forward — and evidently never
+# completed end-to-end. The config had been correct-looking and non-functional
+# for as long as it had existed; routing the tool is simply what finally
+# exercised it.
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: keycloak-allow-grafana-oidc
+  namespace: iam
+  labels:
+    app.kubernetes.io/part-of: iam
+spec:
+  podSelector:
+    matchLabels:
+      app.kubernetes.io/name: keycloak
+  policyTypes:
+    - Ingress
+  ingress:
+    - from:
+        - namespaceSelector:
+            matchLabels:
+              kubernetes.io/metadata.name: observability
+      ports:
+        - protocol: TCP
+          port: 8080


### PR DESCRIPTION
Refs #3071

Two regressions from ADR-0234 (#3072). Both read as green everywhere, which is the interesting part.

## 1. SSO login bounced back to the login page

Reported as "the SSO button doesn't work". It is not a Grafana bug — Grafana's redirect was correct all along:

```
Location: https://kc.open-bank.tech/realms/openbank/protocol/openid-connect/auth
  ?client_id=openbank-grafana&code_challenge_method=S256
  &redirect_uri=https%3A%2F%2Fadmin.open-bank.tech%2Ftools%2Fgrafana%2Flogin%2Fgeneric_oauth…
```

The nginx access log shows the round trip completing and then bouncing:

```
GET /tools/grafana/login/generic_oauth?state=…&session_state=…&iss=https%3A%2F%2Fkc.open-bank.t…
GET /tools/grafana/login  200
```

Grafana's log gives the reason, after a 20 s wait:

```
authn.service level=error msg="Failed to authenticate request" client=auth.client.generic_oauth
error="[auth.oauth.token.exchange] failed to exchange code to token:
Post http://keycloak.iam.svc:8080/realms/openbank/pro…"
```

The browser leg reaches `kc.open-bank.tech`; the token/userinfo leg goes in-cluster to `keycloak.iam.svc:8080`, and that was being dropped.

**Why the allow-list looked correct.** `keycloak-ingress-allow-list` *does* name `observability` — on **TCP:9000**, the metrics port, in a rule of its own. The 8080 rule lists ~38 other namespaces and not this one:

```
PORTS=TCP:8080  FROM=accounts,aml,anacredit,…,tpp-registry     (38 namespaces, no observability)
PORTS=TCP:9000  FROM=observability
```

So dumping the policy's namespaces without their per-rule ports answers "observability is allowed" — the flattened view loses the dimension the bug lives in. Only a connection attempt separates the two: a plain pod in `observability` gets `:9000` fine and times out on `:8080`. With the new policy applied, that same probe returns **200 in 2.07 s**.

**Why the generator could not catch it.** `gen-network-policies.py` derives edges from env URLs on Deployments under `components/`. Grafana is a Helm subchart of kube-prometheus-stack and its `token_url` lives in a `grafana.ini` values block, so this edge is invisible to it — the same blind spot that already makes `networkpolicy-grafana.yaml` hand-written. Hence a separate hand-written file rather than an edit to the generated one; NetworkPolicies are additive.

**Why it surfaced only now.** Grafana had no Ingress before ADR-0234, so its SSO login was reachable only through a port-forward — and evidently never completed end-to-end. The config had been correct-looking and non-functional for as long as it had existed. Routing the tool is simply what finally exercised it.

## 2. Grafana's own metrics scrape broke, silently

Found while reading the access log for #1, not reported:

```
"GET /tools/grafana/metrics HTTP/2.0" 302 138 "http://10.80.76.18:3000/metrics" "Prometheus/3.12.0"
"GET /auth/login?callbackUrl=%2Ftools%2Fgrafana%2Fmetrics…" 200 4672
```

`serve_from_sub_path` makes Grafana 301 every root path to the sub-path, rendered as an **absolute** URL on `root_url`. So the chart-default `/metrics` scrape was answered with a redirect out to the public edge, which Prometheus followed straight into the gate's login redirect.

Nothing went red. The ServiceMonitor was healthy, the target was `up`, and it was scraping a login page — the failure mode is a table that stops growing, and nothing alerts on that. Verified in-cluster: `/metrics` → `301`, `/tools/grafana/metrics` → `200`. Scrape the sub-path directly.

## Also

The file header still told readers Grafana has no Ingress and to reach it by port-forward. Refreshed.

## Verification

`kubectl apply --dry-run=server` accepts both; yamllint clean with the CI config; `gen-network-policies.py` drift gate clean after commit (the new file is hand-written and tracked, so the generator does not fight it).

The NetworkPolicy fix was proven before shipping, not after: the probe that timed out returns 200 with it applied.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
