### PR TITLE
docs(infra): three footguns from routing Grafana behind the edge gate

### DIFF
--- a/openbank-infra/CLAUDE.md
+++ b/openbank-infra/CLAUDE.md
@@ -133,6 +133,37 @@ out of it (they are path-scoped, not less important — several are live-inciden
   workloads), but the reflex stands: verify with
   `kubectl get netpol -n <ns>` / `grep -rl '<workload>-ingress-allow-list' gitops/components/`,
   never with `ls components/<svc>/`.
+- **An allow-list read as a flat set of namespaces has LOST the port dimension, and the flattened
+  answer is the reassuring one.** A NetworkPolicy is a list of rules, each pairing its own `from`
+  with its own `ports`; the same namespace can appear in one rule and be irrelevant to another.
+  `keycloak-ingress-allow-list` names `observability` — on **TCP:9000**, the metrics port, in a rule
+  of its own, while the `:8080` rule lists ~38 other namespaces and not this one. So
+  `jq '.spec.ingress[].from[]'` says "observability is allowed" and Grafana's OIDC token exchange to
+  `keycloak.iam.svc:8080` times out after 20 s anyway (#3145). Dump `ports` WITH `from`, per rule:
+  `kubectl get netpol X -o json | jq -r '.spec.ingress[] | "PORTS=\((.ports//[])|map("\(.protocol//"TCP"):\(.port)")|join(",")) FROM=\([.from[]?|.namespaceSelector.matchLabels["kubernetes.io/metadata.name"]]|join(","))"'`
+  — and prefer an actual connection over any reading of the YAML: a throwaway pod in the caller's
+  namespace `curl`ing the real host:port settles it in one command, where the manifest cannot.
+- **A workload that reaches another namespace from a HELM SUBCHART's config is invisible to
+  `gen-network-policies.py` — it needs a hand-written policy, and nothing will tell you.** The
+  generator reads env URLs off Deployments under `components/`; Grafana's
+  `auth.generic_oauth.token_url` lives in a `grafana.ini` values block inside
+  `apps/kube-prometheus-stack.yaml`, so that edge was never derived and never existed. Same blind
+  spot already forced `networkpolicy-grafana.yaml` and `networkpolicy-rum-gateway.yaml` to be
+  hand-written; policies are additive, so a separate file beside the generated one is the pattern
+  (never edit the generated file). The trap underneath: this had been broken for as long as the
+  config had existed, because Grafana had no Ingress and its SSO was reachable only by port-forward,
+  which nobody had ever completed end-to-end. **Config that no one has exercised is not "working",
+  it is untested** — routing a tool for the first time is exactly when its long-standing config gets
+  its first real test, so expect to find something.
+- **Moving a workload to a sub-path silently breaks every scrape and probe that still asks for a
+  root path.** Grafana's `serve_from_sub_path` answers `/metrics` with a 301 to the sub-path rendered
+  as an ABSOLUTE URL on `root_url`, so the chart-default ServiceMonitor followed it out to the public
+  edge and hit the identity-aware gate's login redirect (ADR-0234). Nothing went red: the
+  ServiceMonitor was healthy, the target was `up`, and it was scraping a login page — the symptom is
+  a metric that stops arriving, and nothing alerts on that. When a sub-path lands, re-point every
+  ServiceMonitor/Probe/readiness URL at it in the same change, and verify by asking for the two paths
+  and comparing (`/metrics` -> 301, `/tools/<x>/metrics` -> 200), never by checking that the target
+  is still `up`.
 - **The generator derives ingress ports from EVERY container's `containerPorts` — a sidecar port
   that only ever serves loopback must be named into `SIDECAR_LOCAL_ONLY_PORT_NAMES`, or it is
   published to the app's whole caller set.** The OPA PDP sidecar is the case that forced the rule:


### PR DESCRIPTION
Refs #3071

Three footguns, all measured on #3145 while diagnosing "the SSO button doesn't work". Each is the same failure class: the cheap way of checking answered the question the reassuring way.

## 1. A flattened allow-list has lost the port dimension

A NetworkPolicy is a list of rules, each pairing its own `from` with its own `ports`. `keycloak-ingress-allow-list` names `observability` — on **TCP:9000**, the metrics port, in a rule of its own, while the `:8080` rule lists ~38 other namespaces and not this one:

```
PORTS=TCP:8080  FROM=accounts,aml,…,tpp-registry   (38 namespaces, no observability)
PORTS=TCP:9000  FROM=observability
```

So `jq '.spec.ingress[].from[]'` reports "observability is allowed" while Grafana's OIDC token exchange to `keycloak.iam.svc:8080` times out after 20 s. The bullet gives the per-rule dump, and the stronger advice: prefer an actual connection from a throwaway pod in the caller's namespace over any reading of the manifest — one command settles what the YAML cannot.

I walked into this one myself during the diagnosis, which is why it is written as "the flattened answer is the reassuring one" rather than "remember to check ports".

## 2. A Helm-subchart edge is invisible to the generator

`gen-network-policies.py` reads env URLs off Deployments under `components/`. Grafana's `auth.generic_oauth.token_url` lives in a `grafana.ini` values block inside `apps/kube-prometheus-stack.yaml`, so that edge was never derived and never existed. The same blind spot already forced `networkpolicy-grafana.yaml` and `networkpolicy-rum-gateway.yaml` to be hand-written.

The part worth keeping is underneath: this had been broken for as long as the config had existed, because Grafana had no Ingress and its SSO was reachable only through a port-forward nobody had ever completed end-to-end. **Config no one has exercised is not "working", it is untested** — routing a tool for the first time is when its long-standing config gets its first real test, so expect to find something.

## 3. A sub-path breaks root-path scrapes, and breaks them green

`serve_from_sub_path` answers `/metrics` with a 301 to the sub-path rendered as an **absolute** URL on `root_url`, so the chart-default ServiceMonitor followed it out to the public edge and into the gate's login redirect. Nothing went red — the ServiceMonitor was healthy, the target was `up`, and it was scraping a login page. The symptom is a metric that stops arriving, and nothing alerts on that.

Verify by asking for both paths and comparing (`/metrics` → 301, `/tools/<x>/metrics` → 200), never by checking the target is still `up`.

## Routing

Per `rules.yaml: knowledge_capture` these are operational footguns → bullets, not rules or an ADR. All three fire only inside `openbank-infra` (NetworkPolicy generation, the GitOps app manifests, the ServiceMonitors), so they go in that tree's `CLAUDE.md` rather than root.

Docs only — no shipped code, no release.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
