### PR TITLE
docs: parallel agents land on the same artifact routinely — check content, not the diff

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -311,6 +311,18 @@ fire from *outside* it, so they stay here:
   (#2984): same inputs, same comparison, same cited defect. Merging it would have put two copies
   of one rule in `Validate manifests`, on every PR, to drift apart later. CI cannot see that;
   only looking at what else landed recently can.
+- **Parallel agents land on the SAME artifact routinely — "what else touched this file today" is
+  as load-bearing a question as "are the checks green".** Three instances on 2026-08-01 alone:
+  `check-probe-port-listener.py` vs `check-probe-port-has-listener.py` (#2984/#3009),
+  `security.yml` (#3103/#3079), `api-fuzz-authenticated.yml` (#3024/#3079). None was visible to
+  CI — #3009 was fully green — and each was found only by comparing CONTENT:
+  `git diff origin/main origin/<branch> -- <file>`, or a shasum of the file on both sides.
+  The three outcomes differ, so measure before deciding: identical content (#3103's `security.yml`
+  matched `main` byte for byte, so merging was a no-op), a true duplicate (#3009, close one),
+  or genuine divergence (#3024 differed by 101 lines — an authoring decision, not a merge).
+  Note the file list `gh pr view --json files` shows is computed against the MERGE-BASE, so after
+  a competing PR squash-merges it still lists the overlap as a diff even when the content already
+  agrees. Read the content, not the diff.
 - **A finding from a CI run goes stale in MINUTES while a parallel agent is active — re-check
   before acting on it.** Three times in one session a ktlint/test failure was already fixed by the
   time the fix was written: the branch had moved (`db25c9ac8` -> `629aff176`,


### PR DESCRIPTION
Extends the "a green PR can still be the wrong one to merge" bullet from #3026, which recorded one instance without the pattern or the method for finding it.

## The pattern

Three collisions on 2026-08-01 alone, all between parallel agents working the same issue independently:

| artifact | PRs |
|---|---|
| `check-probe-port-listener.py` vs `check-probe-port-has-listener.py` | #2984 / #3009 |
| `security.yml` | #3103 / #3079 |
| `api-fuzz-authenticated.yml` | #3024 / #3079 |

**None was visible to CI.** #3009 was fully green on all five required contexts and would have put two copies of one rule into `Validate manifests` — running on every PR in the repo, to drift apart later.

## Why the bullet says *measure*, not *assume*

The three had three different correct answers, and guessing from the file list would have got two of them wrong:

- **#3103's `security.yml` matched `main` byte for byte** — the branch already carried the merged content, so merging was a no-op. I initially read it as a duplicate re-land and was wrong.
- **#3009 was a true duplicate** — same inputs, same comparison, same cited defect. Should be closed.
- **#3024 differs by 101 lines** — the two versions diverged rather than converged. That is an authoring decision, not something to resolve mechanically.

Method that actually discriminates: `git diff origin/main origin/<branch> -- <file>`, or a shasum of the file on both sides.

## The trap that made two of them look wrong

`gh pr view --json files` computes the file list against the **merge-base**. After a competing PR squash-merges, the overlap still shows as a diff even when the content already agrees — because the merge-base predates the squash.

That is exactly what made #3079 look like it re-landed #3103's change. It did not; the content was identical and the merge touched nothing.

## Verification

Each factual claim re-checked against the repo before committing:

```
check-probe-port-listener.py on main (#2984):  1
#3009 would add:  check-probe-port-has-listener.py
#3024 vs main, api-fuzz-authenticated.yml:  101 differing lines
```

Fences balanced (4, even), +12 lines, no deletions, section order unchanged.

## Release impact

None — `docs` is a hidden type and `CLAUDE.md` is not under any released package path.

Refs #3009, #3024, #3079, #3103
