### PR TITLE
feat(admin-ui): put Alertmanager and Pyrra behind the identity-aware edge gate

### DIFF
--- a/openbank-admin-ui/src/app/api/gate/route.ts
+++ b/openbank-admin-ui/src/app/api/gate/route.ts
@@ -53,6 +53,8 @@ export const dynamic = "force-dynamic"
  */
 const TOOL_PERMISSIONS: Record<string, Permission> = {
   grafana: "system:view",
+  alertmanager: "system:view",
+  pyrra: "system:view",
 }
 
 export async function GET(req: NextRequest): Promise<NextResponse> {

--- a/openbank-admin-ui/src/components/layout/Sidebar.tsx
+++ b/openbank-admin-ui/src/components/layout/Sidebar.tsx
@@ -117,7 +117,9 @@ const platformNav: NavItem[] = [
 // `src/app/api/gate/route.ts` requires for the tool — the gate is what actually
 // enforces it, this only decides whether the operator sees the link.
 const toolsNav: NavItem[] = [
-  { nameCs: 'Grafana',        nameEn: 'Grafana',        href: '/tools/grafana', icon: Activity, permission: 'system:view', external: true },
+  { nameCs: 'Grafana',        nameEn: 'Grafana',        href: '/tools/grafana',      icon: Activity,    permission: 'system:view', external: true },
+  { nameCs: 'Alerty',         nameEn: 'Alertmanager',   href: '/tools/alertmanager', icon: Bell,        permission: 'system:view', external: true },
+  { nameCs: 'SLO (Pyrra)',    nameEn: 'SLO (Pyrra)',    href: '/tools/pyrra',        icon: Scale,       permission: 'system:view', external: true },
 ]
 
 const sysNav: NavItem[] = [

--- a/openbank-admin-ui/src/test/tools-gate.test.ts
+++ b/openbank-admin-ui/src/test/tools-gate.test.ts
@@ -145,15 +145,27 @@ describe('ADR-0234 wiring — the halves of the boundary agree', () => {
     expect(matcher).toMatch(/api\/gate/)
   })
 
-  it('the Sidebar link and the gate require the same permission', () => {
-    // A gate wider than the nav hides access nobody finds; a gate narrower than
-    // the nav renders a link that 403s.
-    const navPerm = sidebarSrc.match(/href: '\/tools\/grafana'.*?permission: '([^']+)'/)?.[1]
-    const gatePerm = routeSrc.match(/grafana:\s*"([^"]+)"/)?.[1]
-    expect(navPerm).toBeDefined()
-    expect(gatePerm).toBeDefined()
+  // Every tool, not just the first one. A gate wider than the nav hides access
+  // nobody can find; a gate narrower than the nav renders a link that 403s. This
+  // loops over the gate's own allow-list rather than naming tools, so adding a
+  // tool without a Sidebar entry fails here instead of shipping.
+  it.each(ingressTools)('the Sidebar link and the gate agree on the permission for %s', tool => {
+    const navPerm = sidebarSrc.match(
+      new RegExp(`href: '/tools/${tool}'[^}]*?permission: '([^']+)'`),
+    )?.[1]
+    const gatePerm = routeSrc.match(new RegExp(`\\b${tool}:\\s*"([^"]+)"`))?.[1]
+    expect(navPerm, `no Sidebar entry for /tools/${tool}`).toBeDefined()
+    expect(gatePerm, `no gate entry for ${tool}`).toBeDefined()
     expect(navPerm).toBe(gatePerm)
     expect(Object.keys(PERMISSIONS)).toContain(gatePerm)
+  })
+
+  it('every Sidebar tool link has a gate entry', () => {
+    // The other direction: a nav link pointing at a /tools path the gate does not
+    // know is a dead link — the gate denies an unknown tool with 403 by design.
+    const navTools = [...sidebarSrc.matchAll(/href: '\/tools\/([A-Za-z0-9_-]+)'/g)].map(m => m[1])
+    expect(navTools.length).toBeGreaterThan(0)
+    expect([...new Set(navTools)].sort()).toEqual([...new Set(ingressTools)].sort())
   })
 
   it('the Ingress does not forward gate response headers into the upstream', () => {

--- a/openbank-infra/gitops/apps/kube-prometheus-stack.yaml
+++ b/openbank-infra/gitops/apps/kube-prometheus-stack.yaml
@@ -40,6 +40,22 @@ spec:
             minAvailable: 1
           alertmanagerSpec:
             replicas: 1
+            # Served as a sub-path of the console behind the identity-aware edge
+            # gate (ADR-0234) — no Ingress of its own, so an unauthenticated
+            # request is still rejected at the edge and never reaches this pod.
+            # Silencing an alert is an operator action that today needs a
+            # port-forward, which is why it effectively never happens.
+            #
+            # routePrefix moves the whole HTTP surface, INCLUDING /api/v2/alerts,
+            # which is how Prometheus delivers alerts. The chart does NOT derive
+            # the Prometheus side from this value — the live CR carries
+            # pathPrefix:"/" hard-coded — so prometheusSpec.alertingEndpoints
+            # below must be set in the same change or every alert silently 404s
+            # on delivery. Same failure shape as the Grafana /metrics scrape in
+            # #3145: nothing goes red, alerts simply stop arriving.
+            routePrefix: /tools/alertmanager
+            # Notification links ("view in Alertmanager") point at the gated URL.
+            externalUrl: https://admin.open-bank.tech/tools/alertmanager
             # Mount the GoAlert integration URL (with its token) from a Secret so the
             # token stays out of git (ADR-0088 D1). Lands at /etc/alertmanager/secrets/
             # goalert-webhook-url/url and is referenced via webhook url_file below.
@@ -145,6 +161,21 @@ spec:
             minAvailable: 1
           prometheusSpec:
             replicas: 1
+            # Alert DELIVERY must follow alertmanagerSpec.routePrefix above. This
+            # list REPLACES the chart's default endpoint rather than amending it,
+            # so every field the default carried has to be repeated — it was
+            # {name: kube-prometheus-stack-alertmanager, namespace: observability,
+            # port: http-web, apiVersion: v2, pathPrefix: "/"} on the live CR, and
+            # only pathPrefix changes here. Verify after deploy with
+            # `curl .../api/v1/alertmanagers` on Prometheus: the discovered URL
+            # must end in /tools/alertmanager/api/v2/alerts and the AM must be
+            # listed as active, NOT merely that the pods are healthy.
+            alertingEndpoints:
+              - name: kube-prometheus-stack-alertmanager
+                namespace: observability
+                port: http-web
+                apiVersion: v2
+                pathPrefix: /tools/alertmanager
             # 12h retention (FinOps per ADR-0027; the 5Gi PVC below is sized for it).
             # GOTCHA (governance-as-code, ADR-0029): for Prometheus >= 3.11 the operator
             # renders this into the Prometheus *config file* (storage.tsdb.retention.time)

--- a/openbank-infra/gitops/components/admin-ui/tools-gate.yaml
+++ b/openbank-infra/gitops/components/admin-ui/tools-gate.yaml
@@ -104,3 +104,119 @@ spec:
                 name: grafana-tools
                 port:
                   number: 80
+---
+# Alertmanager (ADR-0234). Silencing an alert is an operator action that needed a
+# port-forward, so in practice it never happened. Alertmanager serves its whole
+# HTTP surface under `routePrefix: /tools/alertmanager` (set in
+# apps/kube-prometheus-stack.yaml), so the edge passes the prefix through
+# unrewritten — and note that same prefix also moves /api/v2/alerts, which is why
+# prometheusSpec.alertingEndpoints.pathPrefix had to move with it.
+apiVersion: v1
+kind: Service
+metadata:
+  name: alertmanager-tools
+  namespace: admin-ui
+  labels:
+    app.kubernetes.io/name: admin-ui
+    app.kubernetes.io/component: tools-gate
+spec:
+  type: ExternalName
+  externalName: kube-prometheus-stack-alertmanager.observability.svc.cluster.local
+  ports:
+    - name: http
+      port: 9093
+      protocol: TCP
+---
+# Pyrra SLO console (ADR-0234). Read-only, and the natural companion to the SLO
+# dashboard — served under `--route-prefix=/tools/pyrra`.
+apiVersion: v1
+kind: Service
+metadata:
+  name: pyrra-tools
+  namespace: admin-ui
+  labels:
+    app.kubernetes.io/name: admin-ui
+    app.kubernetes.io/component: tools-gate
+spec:
+  type: ExternalName
+  externalName: pyrra-api.observability.svc.cluster.local
+  ports:
+    - name: http
+      port: 9099
+      protocol: TCP
+---
+# ONE INGRESS OBJECT PER TOOL, and that is not accidental: ingress-nginx applies
+# an object's annotations to every location it declares, and the auth-url hard-codes
+# the `?tool=` the gate's allow-list is keyed by. Two tools on one object would
+# both be checked against whichever tool the annotation named — the narrower one
+# would silently gain the wider one's audience. The cost of a tool is therefore
+# one Ingress + one Service + one allow-list entry + one NetworkPolicy.
+apiVersion: networking.k8s.io/v1
+kind: Ingress
+metadata:
+  name: admin-ui-tools-alertmanager
+  namespace: admin-ui
+  labels:
+    app.kubernetes.io/name: admin-ui
+    app.kubernetes.io/component: tools-gate
+  annotations:
+    nginx.ingress.kubernetes.io/ssl-redirect: "true"
+    nginx.ingress.kubernetes.io/auth-url: "http://admin-ui.admin-ui.svc.cluster.local:3000/api/gate?tool=alertmanager"
+    nginx.ingress.kubernetes.io/auth-signin: "https://admin.open-bank.tech/auth/login?callbackUrl=$escaped_request_uri"
+    nginx.ingress.kubernetes.io/configuration-snippet: |
+      more_set_headers "Strict-Transport-Security: max-age=63072000; includeSubDomains; preload";
+      more_set_headers "X-Content-Type-Options: nosniff";
+      more_set_headers "Referrer-Policy: strict-origin-when-cross-origin";
+    nginx.ingress.kubernetes.io/upstream-vhost: "admin.open-bank.tech"
+spec:
+  ingressClassName: nginx
+  tls:
+    - hosts:
+        - admin.open-bank.tech
+      secretName: admin-ui-tls
+  rules:
+    - host: admin.open-bank.tech
+      http:
+        paths:
+          - path: /tools/alertmanager
+            pathType: Prefix
+            backend:
+              service:
+                name: alertmanager-tools
+                port:
+                  number: 9093
+---
+apiVersion: networking.k8s.io/v1
+kind: Ingress
+metadata:
+  name: admin-ui-tools-pyrra
+  namespace: admin-ui
+  labels:
+    app.kubernetes.io/name: admin-ui
+    app.kubernetes.io/component: tools-gate
+  annotations:
+    nginx.ingress.kubernetes.io/ssl-redirect: "true"
+    nginx.ingress.kubernetes.io/auth-url: "http://admin-ui.admin-ui.svc.cluster.local:3000/api/gate?tool=pyrra"
+    nginx.ingress.kubernetes.io/auth-signin: "https://admin.open-bank.tech/auth/login?callbackUrl=$escaped_request_uri"
+    nginx.ingress.kubernetes.io/configuration-snippet: |
+      more_set_headers "Strict-Transport-Security: max-age=63072000; includeSubDomains; preload";
+      more_set_headers "X-Content-Type-Options: nosniff";
+      more_set_headers "Referrer-Policy: strict-origin-when-cross-origin";
+    nginx.ingress.kubernetes.io/upstream-vhost: "admin.open-bank.tech"
+spec:
+  ingressClassName: nginx
+  tls:
+    - hosts:
+        - admin.open-bank.tech
+      secretName: admin-ui-tls
+  rules:
+    - host: admin.open-bank.tech
+      http:
+        paths:
+          - path: /tools/pyrra
+            pathType: Prefix
+            backend:
+              service:
+                name: pyrra-tools
+                port:
+                  number: 9099

--- a/openbank-infra/gitops/components/observability/networkpolicy-tools-gate.yaml
+++ b/openbank-infra/gitops/components/observability/networkpolicy-tools-gate.yaml
@@ -1,0 +1,77 @@
+# SPDX-License-Identifier: Apache-2.0
+# Copyright (c) OpenBank contributors. Licensed under the Apache License, Version 2.0.
+#
+# Edge access for the tools served behind the identity-aware gate (ADR-0234).
+#
+# The gate is an EDGE control and says nothing about the in-cluster path, so each
+# routed workload also needs the ingress-nginx controller admitted to its pod —
+# and nothing else new. Grafana's equivalent lives in networkpolicy-grafana.yaml.
+#
+# HAND-WRITTEN, like the others in this directory. `network-policies.yaml` is
+# emitted by gen-network-policies.py from the declared GitOps edges of
+# Deployments under components/, and it adds ingress-nginx only "where an Ingress
+# backend exists". These Ingresses live in the `admin-ui` namespace and reach
+# here through an ExternalName Service, so the generator cannot see the edge —
+# the same blind spot that already made networkpolicy-grafana.yaml and
+# networkpolicy-grafana-oidc.yaml hand-written.
+#
+# Alertmanager is a chart-managed workload (kube-prometheus-stack) and so is
+# invisible to the generator for a second, independent reason.
+#
+# NOTE ON ALERTMANAGER'S OTHER CALLER: Prometheus delivers alerts to
+# :9093 from inside this namespace, which the same-namespace rule below already
+# covers. Its PATH moved with routePrefix — see prometheusSpec.alertingEndpoints
+# in apps/kube-prometheus-stack.yaml; that is a routing change, not a network one,
+# and it fails as a 404 rather than a timeout.
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: alertmanager-ingress-allow-list
+  namespace: observability
+  labels:
+    app.kubernetes.io/part-of: observability
+spec:
+  podSelector:
+    matchLabels:
+      app.kubernetes.io/name: alertmanager
+  policyTypes:
+    - Ingress
+  ingress:
+    # Same namespace: Prometheus alert delivery, and the operator's reload sidecar.
+    - from:
+        - podSelector: {}
+    # The edge — already gated by nginx before it proxies.
+    - from:
+        - namespaceSelector:
+            matchLabels:
+              kubernetes.io/metadata.name: ingress-nginx
+    - from:
+        - namespaceSelector:
+            matchLabels:
+              kubernetes.io/metadata.name: admin-ui
+---
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: pyrra-api-ingress-allow-list
+  namespace: observability
+  labels:
+    app.kubernetes.io/part-of: observability
+spec:
+  podSelector:
+    matchLabels:
+      app.kubernetes.io/name: pyrra
+      app.kubernetes.io/component: api
+  policyTypes:
+    - Ingress
+  ingress:
+    - from:
+        - podSelector: {}
+    - from:
+        - namespaceSelector:
+            matchLabels:
+              kubernetes.io/metadata.name: ingress-nginx
+    - from:
+        - namespaceSelector:
+            matchLabels:
+              kubernetes.io/metadata.name: admin-ui

--- a/openbank-infra/gitops/components/observability/pyrra.yaml
+++ b/openbank-infra/gitops/components/observability/pyrra.yaml
@@ -196,6 +196,17 @@ spec:
             - api
             - --api-url=http://pyrra-kubernetes.observability.svc:9444
             - --prometheus-url=http://kube-prometheus-stack-prometheus.observability.svc:9090
+            # Served as a sub-path of the console behind the identity-aware edge
+            # gate (ADR-0234); Pyrra keeps no Ingress of its own. --route-prefix
+            # is Pyrra's own flag for exactly this (`pyrra api --help`), so the
+            # edge passes the prefix through unrewritten and Pyrra builds its
+            # asset and API URLs from it.
+            #
+            # --api-url and --prometheus-url are IN-CLUSTER and must stay that
+            # way: they are the server-side legs, and pointing either at the
+            # public host would send them through the gate, which has no session
+            # to present. Only the browser leg goes via admin.open-bank.tech.
+            - --route-prefix=/tools/pyrra
           ports:
             - name: http
               containerPort: 9099


### PR DESCRIPTION
Refs #3071

Two more tools onto the mechanism ADR-0234 proved with Grafana. Neither gets an Ingress of its own, so an unauthenticated request is still rejected at the edge and never reaches the workload.

- **Alertmanager** — the one with real operational value. Silencing an alert needs a terminal and a free local port today, which is why in practice it never happens.
- **Pyrra** — read-only SLO console, belongs next to the SLO dashboard.

Both were picked because their UI carries no machine callers, so no split routing is needed. `reposilite`, `gradle-build-cache`, `ntfy` and `apicurio-registry` are deliberately **not** candidates in this form: their callers authenticate with tokens or DSNs and cannot follow a login redirect — the same reason GlitchTip's ingest host stays ungated.

## The part that would have broken silently

Alertmanager's `routePrefix` moves its **whole** HTTP surface, including `/api/v2/alerts` — the path Prometheus delivers alerts on.

The chart does not derive the Prometheus side from it. Checked, not assumed:

```
$ kubectl get prometheus … -o jsonpath='{.spec.alerting}'
{"alertmanagers":[{… "pathPrefix":"/", "port":"http-web"}]}
```

and `prometheusSpec.alertingEndpoints` is an empty list in the chart's values, which **replaces** the default rather than amending it. So it is spelled out here in full — every field the default carried, with only `pathPrefix` changed.

Without that, every alert would 404 on delivery with nothing red anywhere. Exactly the shape of the Grafana `/metrics` scrape in #3145, where the ServiceMonitor stayed healthy and the target stayed `up` while it was scraping a login page. Verify after deploy with `/api/v1/alertmanagers` on Prometheus — the discovered URL must end in `/tools/alertmanager/api/v2/alerts` and the AM must be listed as active — never by checking that the pods are healthy.

Pyrra needs no such care: `--route-prefix` is its own flag (confirmed against `pyrra api --help` in the running pod), and its `--api-url` / `--prometheus-url` legs are in-cluster and deliberately left alone — pointing either at the public host would send a server-side call through the gate, which has no session to present.

## One Ingress object per tool

Not accidental. ingress-nginx applies an object's annotations to every location it declares, and `auth-url` hard-codes the `?tool=` the gate's allow-list is keyed by. Two tools on one object would both be checked against whichever tool the annotation named, so the narrower one would silently inherit the wider one's audience.

The cost of a tool is therefore: one Ingress + one ExternalName Service + one allow-list entry + one NetworkPolicy. Mechanical on purpose.

## Tests

`tools-gate.test.ts` no longer names `grafana` — it derives its expectations from the gate's own allow-list and now checks **both** directions:

- every gated tool has a Sidebar entry requiring the same permission (a gate wider than the nav hides access nobody can find; narrower renders a link that 403s);
- every Sidebar `/tools/*` link has a gate entry (an unknown tool is denied 403 by design, so a stray link is a dead link).

Verified by deleting the Pyrra nav entry: two assertions go red, and green again on restore.

## Verification

`kubectl apply --dry-run=server` accepts all four manifests against the live API; yamllint clean with the CI config; `tsc --noEmit`, eslint and the gate suite (20 tests) green; `gen-network-policies.py` does not fight the hand-written policy file.

The NetworkPolicies are hand-written for the usual reason — these Ingresses live in the `admin-ui` namespace and reach `observability` through an ExternalName, so the generator cannot see the edge; Alertmanager is additionally chart-managed and invisible to it for a second, independent reason.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
