### PR TITLE
security(admin-ui): hold the public demo account to least privilege in each tool, and deny it Alertmanager

### DIFF
--- a/openbank-admin-ui/src/app/api/gate/route.ts
+++ b/openbank-admin-ui/src/app/api/gate/route.ts
@@ -57,6 +57,43 @@ const TOOL_PERMISSIONS: Record<string, Permission> = {
   pyrra: "system:view",
 }
 
+/**
+ * PER-TOOL deny-list: roles refused for a specific tool, whatever else they carry.
+ *
+ * `demo@openbank.local` is a PUBLIC account — its credentials are handed out —
+ * and in the sandbox realm it holds ROLE_ADMIN, ROLE_OPERATOR, ROLE_COMPLIANCE,
+ * ROLE_AUDITOR, ROLE_PAYMENTS and ROLE_VIEWER alongside ROLE_DEMO, so that it can
+ * show every console page. Those roles were harmless while the tools had no route;
+ * ADR-0234 gave them one, and the permission check alone then admits the public
+ * account everywhere.
+ *
+ * The demo account is DELIBERATELY still admitted to Grafana and Pyrra, because a
+ * greyed-out console is a worse outcome than a read-only one — the point of the
+ * account is that a visitor sees a working platform. It is held to the least
+ * privilege each tool can express instead:
+ *
+ *   - Grafana: `role_attribute_path` (kube-prometheus-stack) tests ROLE_DEMO FIRST
+ *     and maps it to Viewer. Viewer sees dashboards; it does not get Explore, which
+ *     is what would otherwise expose the raw Prometheus/Loki/Tempo streams.
+ *   - Pyrra: read-only by construction — there is nothing to restrict.
+ *   - Alertmanager: DENIED, and it is the exception because it has no role model at
+ *     all. Its UI is its API: anything that can load the page can silence or expire
+ *     an alert on the whole platform. There is no read-only Alertmanager to offer,
+ *     so the choice is "can mute production alerting" or "not admitted", and for a
+ *     public account that is not a close call.
+ *
+ * Keyed by tool rather than global so that adding a tool forces the question
+ * "what is the least privilege this one can express?" instead of inheriting an
+ * answer. The Sidebar renders a denied tool as a disabled entry with the
+ * demo-account tooltip, so it reads as deliberate rather than broken.
+ *
+ * 403 rather than 401 — re-authenticating cannot help, and a 401 would loop the
+ * user through login.
+ */
+const TOOL_DENIED_ROLES: Record<string, readonly string[]> = {
+  alertmanager: ["ROLE_DEMO"],
+}
+
 export async function GET(req: NextRequest): Promise<NextResponse> {
   const tool = req.nextUrl.searchParams.get("tool") ?? ""
   const required = TOOL_PERMISSIONS[tool]
@@ -84,6 +121,14 @@ export async function GET(req: NextRequest): Promise<NextResponse> {
   }
 
   const roles: string[] = user.roles ?? []
+
+  // Deny BEFORE the permission check: the denied roles are carried alongside the
+  // ones that would pass it, so checking permission first would admit them.
+  const denied = TOOL_DENIED_ROLES[tool] ?? []
+  if (roles.some(r => denied.includes(r))) {
+    return new NextResponse(null, { status: 403, headers: { "Cache-Control": "no-store" } })
+  }
+
   if (!hasPermission(roles, required)) {
     return new NextResponse(null, { status: 403, headers: { "Cache-Control": "no-store" } })
   }

--- a/openbank-admin-ui/src/components/layout/Sidebar.tsx
+++ b/openbank-admin-ui/src/components/layout/Sidebar.tsx
@@ -29,7 +29,12 @@ import { useLanguage } from '@/lib/i18n/LanguageContext'
 // client-side navigation into the App Router and 404, because no page.tsx backs
 // the path. Same origin, so the session cookie still rides along and the edge
 // gate can read it.
-type NavItem = { nameCs: string; nameEn: string; href: string; icon: React.ElementType; permission?: Permission; lockedPermission?: Permission; badge?: string; external?: boolean }
+// `deniedRole` mirrors the per-tool deny-list in src/app/api/gate/route.ts. The
+// gate is what ENFORCES it; this only decides how the entry renders, so a denied
+// tool shows as a disabled item with the demo-account tooltip instead of a live
+// link that 403s. A link that visibly fails reads as a broken platform, which for
+// the public demo account is the outcome worth avoiding.
+type NavItem = { nameCs: string; nameEn: string; href: string; icon: React.ElementType; permission?: Permission; lockedPermission?: Permission; deniedRole?: string; badge?: string; external?: boolean }
 
 const coreNav: NavItem[] = [
   { nameCs: 'Přehled',      nameEn: 'Dashboard',    href: '/dashboard',    icon: LayoutDashboard },
@@ -118,7 +123,9 @@ const platformNav: NavItem[] = [
 // enforces it, this only decides whether the operator sees the link.
 const toolsNav: NavItem[] = [
   { nameCs: 'Grafana',        nameEn: 'Grafana',        href: '/tools/grafana',      icon: Activity,    permission: 'system:view', external: true },
-  { nameCs: 'Alerty',         nameEn: 'Alertmanager',   href: '/tools/alertmanager', icon: Bell,        permission: 'system:view', external: true },
+  // Denied to the public demo account: Alertmanager has no role model, so anything
+  // that can load its UI can silence alerts platform-wide (gate route.ts).
+  { nameCs: 'Alerty',         nameEn: 'Alertmanager',   href: '/tools/alertmanager', icon: Bell,        permission: 'system:view', external: true, deniedRole: 'ROLE_DEMO' },
   { nameCs: 'SLO (Pyrra)',    nameEn: 'SLO (Pyrra)',    href: '/tools/pyrra',        icon: Scale,       permission: 'system:view', external: true },
 ]
 
@@ -147,7 +154,9 @@ export function Sidebar() {
   const { t, language } = useLanguage()
   const roles: string[] = session?.user?.roles ?? []
   const filter = (items: NavItem[]) => items.filter(i => !i.permission || hasPermission(roles, i.permission))
-  const isLocked = (item: NavItem) => !!item.lockedPermission && !hasPermission(roles, item.lockedPermission)
+  const isLocked = (item: NavItem) =>
+    (!!item.lockedPermission && !hasPermission(roles, item.lockedPermission)) ||
+    (!!item.deniedRole && roles.includes(item.deniedRole))
 
   // ADR-0229 D4 (first cut): the persona's quick links pinned at the top — the full menu below
   // is untouched. Each link inherits its permission from the same destination's nav entry.
@@ -231,7 +240,7 @@ export function Sidebar() {
         <SectionLabel>{t('Dokumentace', 'Documentation')}</SectionLabel>
         <NavSection items={filter(docsNav)} pathname={pathname} />
         <SectionLabel>{t('Nástroje', 'Tools')}</SectionLabel>
-        <NavSection items={filter(toolsNav)} pathname={pathname} />
+        <NavSection items={filter(toolsNav)} pathname={pathname} isLocked={isLocked} />
         <SectionLabel>{t('Systém', 'System')}</SectionLabel>
         <NavSection items={filter(sysNav)} pathname={pathname} isLocked={isLocked} />
       </nav>

--- a/openbank-admin-ui/src/test/tools-gate.test.ts
+++ b/openbank-admin-ui/src/test/tools-gate.test.ts
@@ -75,6 +75,26 @@ describe('GET /api/gate — nginx auth_request contract', () => {
     expect((await (await route()).GET(req('?tool=grafana'))).status).toBe(403)
   })
 
+  it('403s the public demo account on alertmanager despite ROLE_ADMIN', async () => {
+    // Alertmanager has no role model: its UI is its API, so anything that can load
+    // the page can silence or expire alerts platform-wide. There is no read-only
+    // Alertmanager to offer a public account, so it is denied outright.
+    vi.mocked(auth).mockResolvedValue(session(['ROLE_ADMIN', 'ROLE_OPERATOR', 'ROLE_DEMO']))
+    expect((await (await route()).GET(req('?tool=alertmanager'))).status).toBe(403)
+  })
+
+  it.each(['grafana', 'pyrra'])(
+    'still ADMITS the demo account to %s — a greyed-out console is the worse outcome',
+    async tool => {
+      // Deliberate: the demo exists so a visitor sees a working platform. It is held
+      // to least privilege INSIDE each tool instead — Grafana pins ROLE_DEMO to
+      // Viewer (no Explore, so no raw Loki/Tempo), Pyrra is read-only by construction.
+      // If this ever flips to 403, the demo silently starts looking broken.
+      vi.mocked(auth).mockResolvedValue(session(['ROLE_ADMIN', 'ROLE_OPERATOR', 'ROLE_DEMO']))
+      expect((await (await route()).GET(req(`?tool=${tool}`))).status).toBe(204)
+    },
+  )
+
   it('403s an unknown tool even for an admin', async () => {
     // The allow-list is what makes an Ingress path added without a gate entry
     // fail closed. If this ever returns 204 the allow-list is decorative.
@@ -166,6 +186,18 @@ describe('ADR-0234 wiring — the halves of the boundary agree', () => {
     const navTools = [...sidebarSrc.matchAll(/href: '\/tools\/([A-Za-z0-9_-]+)'/g)].map(m => m[1])
     expect(navTools.length).toBeGreaterThan(0)
     expect([...new Set(navTools)].sort()).toEqual([...new Set(ingressTools)].sort())
+  })
+
+  it('Grafana pins ROLE_DEMO to Viewer, and tests it BEFORE the admin role', () => {
+    // jmespath `||` short-circuits, so order IS the mechanism: placed after the
+    // ROLE_ADMIN test this never fires and the public account lands as a Grafana
+    // Admin with Explore over Prometheus, Loki and Tempo.
+    const kps = readFileSync('../openbank-infra/gitops/apps/kube-prometheus-stack.yaml', 'utf8')
+    const expr = kps.match(/role_attribute_path: (.*)/)?.[1]
+    expect(expr, 'role_attribute_path not found').toBeDefined()
+    expect(expr).toMatch(/ROLE_DEMO/)
+    expect(expr!.indexOf('ROLE_DEMO')).toBeLessThan(expr!.indexOf('ROLE_ADMIN'))
+    expect(expr).toMatch(/ROLE_DEMO'\)\s*&&\s*'Viewer'/)
   })
 
   it('the Ingress does not forward gate response headers into the upstream', () => {

--- a/openbank-infra/gitops/apps/kube-prometheus-stack.yaml
+++ b/openbank-infra/gitops/apps/kube-prometheus-stack.yaml
@@ -294,7 +294,18 @@ spec:
               login_attribute_path: preferred_username
               name_attribute_path: name
               email_attribute_path: email
-              role_attribute_path: contains(realm_access.roles[*], 'ROLE_ADMIN') && 'Admin' || (contains(realm_access.roles[*], 'ROLE_OPERATOR') && 'Editor' || 'Viewer')
+              # ROLE_DEMO is checked FIRST and pins the public demo account to
+              # Viewer. demo@openbank.local's credentials are handed out, and in
+              # the sandbox realm it carries ROLE_ADMIN + ROLE_OPERATOR so that it
+              # can show every console page — which would otherwise make it a
+              # Grafana ADMIN the moment ADR-0234 gave Grafana a route, granting
+              # Explore against Prometheus, Loki and Tempo, i.e. the raw log
+              # stream. jmespath `||` short-circuits, so order is the whole
+              # mechanism here: put ROLE_DEMO after the ADMIN test and it never
+              # fires. The gate (`/api/gate`) already refuses ROLE_DEMO outright;
+              # this is the second, independent layer, so widening the gate later
+              # cannot silently promote the public account.
+              role_attribute_path: contains(realm_access.roles[*], 'ROLE_DEMO') && 'Viewer' || (contains(realm_access.roles[*], 'ROLE_ADMIN') && 'Admin' || (contains(realm_access.roles[*], 'ROLE_OPERATOR') && 'Editor' || 'Viewer'))
           # serve_from_sub_path makes Grafana 301 every root path to the sub-path,
           # and it renders that redirect as an ABSOLUTE URL on root_url — so the
           # chart-default `/metrics` scrape was answered with a redirect out to


### PR DESCRIPTION
Refs #3071

**Design changed after review feedback: the demo account is no longer denied outright.** It stays admitted to Grafana and Pyrra and is held to the least privilege each tool can express; only Alertmanager is denied, because it has no privilege level to hold it to.

## The exposure

`demo@openbank.local` is a **public** account — its credentials are handed out — and in the sandbox realm it carries:

```
ROLE_OPERATOR ROLE_AUDITOR ROLE_COMPLIANCE ROLE_ADMIN ROLE_DEMO ROLE_PAYMENTS ROLE_VIEWER
```

Those grants exist so the demo can show every console page, and they were harmless while the tools had no route. **ADR-0234 gave them one.** The gate's permission check alone (`system:view` = ADMIN or OPERATOR) then admits the public account to all three — and Grafana maps `ROLE_ADMIN` → Admin, which grants Explore against Prometheus, **Loki** and Tempo, i.e. the raw log stream.

This is a regression I introduced by routing the tools: the roles were already there, the reachability is new.

## What this does instead

| tool | demo | why |
|---|---|---|
| Grafana | **admitted as Viewer** | Viewer sees dashboards but not Explore, so no raw Loki/Tempo |
| Pyrra | **admitted** | read-only by construction — nothing to restrict |
| Alertmanager | **denied** | no role model at all |

Alertmanager is the exception because its UI *is* its API: anything that can load the page can silence or expire an alert platform-wide. There is no read-only Alertmanager to offer, so the choice is "can mute production alerting" or "not admitted" — and for a public account that is not close.

A greyed-out console is a worse outcome than a read-only one — the point of the demo account is that a visitor sees a working platform — so the Sidebar renders a denied tool as a **disabled entry with the demo-account tooltip**, not a live link that 403s. A visibly failing link reads as a broken product.

## Mechanism

**The deny-list is keyed by tool, not global.** Adding a tool then forces the question "what is the least privilege *this one* can express?" instead of silently inheriting an answer. It runs *before* the permission check, because the denied role travels alongside the roles that would pass.

**Grafana's `role_attribute_path` tests `ROLE_DEMO` first.** jmespath `||` short-circuits, so the ORDER is the entire mechanism — placed after the ADMIN test it would never fire. This is the second, independent layer: it holds even if the gate list is later widened.

## Verification

Falsified in both directions, not just run:

- adding `grafana` to the deny-list reddens the *"still admits the demo account"* assertion — so the allow is asserted, not assumed;
- removing the `ROLE_DEMO` branch from `role_attribute_path` reddens the ordering assertion.

24 tests pass; eslint clean. `tsc --noEmit` is extremely slow in this worktree and had not finished at push time — the changes are a `Record` type, one optional field and a boolean expression, and the suite compiles the route and Sidebar through the vitest transform, so the risk is low; I am watching CI's type-check rather than claiming a local pass.

## A correction that belongs here

Applying the Grafana half as an interim mitigation kept silently reverting, and the cause invalidates something I have repeated:

```
$ kubectl -n argocd get app root
path=openbank-infra/gitops/apps  auto={"prune":true,"selfHeal":true}
```

**There IS an app-of-apps syncing `gitops/apps/`.** The comments in `apps/glitchtip.yaml` and `apps/loki.yaml` saying no app-of-apps exists yet are stale, and I repeated the claim in ADR-0234, in the `tool-ingress-gate-policy.yaml` header, in #3072's post-merge runbook and in several PR bodies. The manual applies I ran earlier only appeared to work because those changes were already merged — `root` would have synced them anyway.

Consequences: the "run `kubectl apply -f gitops/apps/…` after merge" steps are unnecessary; an unmerged change applied by hand is reverted within seconds; and therefore **no interim mitigation outside git is available here — merging is the mitigation**. Follow-up sweep to come, kept out of this PR to keep it focused.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
