### PR TITLE
perf(ci): stop the ADR index generator forking ~6800 processes

### DIFF
--- a/docs/adr/gen-index.sh
+++ b/docs/adr/gen-index.sh
@@ -38,16 +38,42 @@ adrs=$(ls [0-9]*.md | sort)
 
 # Title is derived from the H1, and the number from the filename, so neither is
 # duplicated into front-matter where it could drift. See SCHEMA.md.
-h1_title() {
-  grep -m1 '^# ' "$1" | perl -CSD -pe 's/^#\s+//; s/^ADR-\d+\s*[:\x{2014}\x{2013}-]\s+//; s/^\d+\.\s+//'
+# One grep, then pure bash. This used to pipe into `perl -CSD`, and a perl
+# interpreter start per ADR was ~10% of this script's total runtime for three
+# substitutions. The dash class is written as an alternation rather than a bracket
+# expression on purpose: em-dash and en-dash are multi-byte in UTF-8, and inside a
+# bracket expression their bytes can be matched individually under a C locale.
+# Takes the H1 LINE (supplied by fm_extract_many's `!h1`), not a filename — so no
+# grep, and the file is read once for everything. This used to pipe into `perl -CSD`;
+# a perl interpreter start per ADR was ~10% of this script's runtime for three
+# substitutions. The dash class is an alternation rather than a bracket expression on
+# purpose: em-dash and en-dash are multi-byte in UTF-8, and inside a bracket
+# expression their bytes can be matched individually under a C locale.
+h1_title_from() {
+  local t=$1
+  [[ $t =~ ^\#[[:space:]]+(.*)$ ]] && t=${BASH_REMATCH[1]}
+  [[ $t =~ ^ADR-[0-9]+[[:space:]]*(:|—|–|-)[[:space:]]+(.*)$ ]] && t=${BASH_REMATCH[2]}
+  [[ $t =~ ^[0-9]+\.[[:space:]]+(.*)$ ]] && t=${BASH_REMATCH[1]}
+  printf '%s\n' "$t"
 }
 
 # Present an enum to humans: `n-a` -> `N/A`, otherwise capitalise.
+# Called twice per ADR; the old form forked a subshell and a `tr` each time.
+# Bash 3.2 (the macOS default) has no ${var^}, so capitalise with a case.
 pretty() {
   case "$1" in
-    n-a) echo "N/A" ;;
-    *)   echo "$(echo "${1:0:1}" | tr '[:lower:]' '[:upper:]')${1:1}" ;;
+    n-a) printf 'N/A\n'; return ;;
   esac
+  local first=${1:0:1} rest=${1:1}
+  case "$first" in
+    a) first=A ;; b) first=B ;; c) first=C ;; d) first=D ;; e) first=E ;;
+    f) first=F ;; g) first=G ;; h) first=H ;; i) first=I ;; j) first=J ;;
+    k) first=K ;; l) first=L ;; m) first=M ;; n) first=N ;; o) first=O ;;
+    p) first=P ;; q) first=Q ;; r) first=R ;; s) first=S ;; t) first=T ;;
+    u) first=U ;; v) first=V ;; w) first=W ;; x) first=X ;; y) first=Y ;;
+    z) first=Z ;;
+  esac
+  printf '%s%s\n' "$first" "$rest"
 }
 
 # Field separator for the cached table. NOT a tab: tab is IFS whitespace, so bash
@@ -55,27 +81,73 @@ pretty() {
 # shift every later column. \037 (US) is non-whitespace and cannot occur in an ADR.
 SEP=$'\037'
 
-json_escape() { printf '%s' "$1" | sed -e 's/\\/\\\\/g' -e 's/"/\\"/g'; }
+# Backslash first, then quote — reversing the order would double-escape the
+# backslashes this step just introduced.
+json_escape() {
+  local v=${1//\\/\\\\}
+  printf '%s' "${v//\"/\\\"}"
+}
 
 # --- one pass over the fleet, cached as a $SEP-separated table -----------------
 # Bash 3.2 (the macOS default) has no associative arrays, so the cache is one
 # delimited table held in a variable and sliced with awk. ~180 rows -- fine.
+# ONE awk process for the whole fleet (fm_extract_many), then pure bash. This loop
+# used to run fm_extract + grep per ADR and slice the result with forking helpers:
+# ~30 processes per ADR, ~6800 for the fleet, and 62 s of CPU on a check that runs on
+# every PR (issue #3108). Nothing about the parse changed — only how many times the
+# process table is touched.
+#
+# `flush_row` is called when the stream moves to a new file, and once more at the end.
+# Reading the stream with `while read` in the CURRENT shell (a here-string, not a
+# pipe) matters: a pipeline would put the loop in a subshell and TABLE would be
+# discarded at the end of it — the row-building would run, and the table would be
+# empty.
 TABLE=""
-for f in $adrs; do
-  num=${f%%-*}
-  fm="$(fm_extract "$f")" || { echo "ERROR: $f: no valid front-matter block (see SCHEMA.md)" >&2; exit 1; }
-  title=$(h1_title "$f")
-  decision=$(fm_field "$fm" decision-status)
-  delivery=$(fm_field "$fm" delivery-status)
-  date=$(fm_field "$fm" date)
-  summary=$(fm_unquote "$(fm_field "$fm" summary)")
-  tags=$(fm_list "$(fm_field "$fm" tags)" | paste -sd',' -)
-  repos=$(fm_list "$(fm_field "$fm" delivery-repos)" | paste -sd',' -)
-  sup=$(fm_list "$(fm_field "$fm" supersedes)" | paste -sd',' -)
-  supby=$(fm_list "$(fm_field "$fm" superseded-by)" | paste -sd',' -)
-  TABLE="${TABLE}${num}${SEP}${f}${SEP}${title}${SEP}${decision}${SEP}${delivery}${SEP}${date}${SEP}${tags}${SEP}${repos}${SEP}${sup}${SEP}${supby}${SEP}${summary}
+cur=""; c_title=""; c_dec=""; c_del=""; c_date=""; c_sum=""
+c_tags=""; c_repos=""; c_sup=""; c_supby=""; c_status=""
+
+join_list() {  # newline-separated -> comma-separated, no `paste`
+  local out="" line
+  while IFS= read -r line; do
+    [[ -z "$line" ]] && continue
+    out="${out}${out:+,}${line}"
+  done <<< "$1"
+  printf '%s' "$out"
+}
+
+flush_row() {
+  [[ -z "$cur" ]] && return 0
+  if [[ "$c_status" != "ok" ]]; then
+    echo "ERROR: $cur: no valid front-matter block (see SCHEMA.md)" >&2
+    exit 1
+  fi
+  local num=${cur%%-*}
+  TABLE="${TABLE}${num}${SEP}${cur}${SEP}${c_title}${SEP}${c_dec}${SEP}${c_del}${SEP}${c_date}${SEP}${c_tags}${SEP}${c_repos}${SEP}${c_sup}${SEP}${c_supby}${SEP}${c_sum}
 "
-done
+}
+
+while IFS=$'\t' read -r file key value; do
+  [[ -z "$file" ]] && continue
+  if [[ "$file" != "$cur" ]]; then
+    flush_row
+    cur=$file; c_title=""; c_dec=""; c_del=""; c_date=""; c_sum=""
+    c_tags=""; c_repos=""; c_sup=""; c_supby=""; c_status=""
+  fi
+  case "$key" in
+    # First occurrence wins, matching fm_field's `exit` on first match.
+    decision-status)  [[ -z "$c_dec"   ]] && c_dec=$value ;;
+    delivery-status)  [[ -z "$c_del"   ]] && c_del=$value ;;
+    date)             [[ -z "$c_date"  ]] && c_date=$value ;;
+    summary)          [[ -z "$c_sum"   ]] && c_sum=$(fm_unquote "$value") ;;
+    tags)             [[ -z "$c_tags"  ]] && c_tags=$(join_list "$(fm_list "$value")") ;;
+    delivery-repos)   [[ -z "$c_repos" ]] && c_repos=$(join_list "$(fm_list "$value")") ;;
+    supersedes)       [[ -z "$c_sup"   ]] && c_sup=$(join_list "$(fm_list "$value")") ;;
+    superseded-by)    [[ -z "$c_supby" ]] && c_supby=$(join_list "$(fm_list "$value")") ;;
+    '!h1')            c_title=$(h1_title_from "$value") ;;
+    '!status')        c_status=$value ;;
+  esac
+done <<< "$(fm_extract_many $adrs)"
+flush_row
 
 # --- numbering gaps, computed (never hand-typed, so the claim cannot rot) ------
 gaps=$(printf '%s' "$TABLE" | awk -F"$SEP" 'NF{print $1+0}' | sort -n | awk '
@@ -180,7 +252,17 @@ count=$(printf '%s' "$TABLE" | grep -c . || true)
 } > DIGEST.md
 
 # =============================== index.json ==================================
-json_arr() { echo "$1" | tr ',' '\n' | grep -v '^$' | sed 's/.*/"&"/' | paste -sd',' -; }
+# Four processes per call, four calls per ADR, in pure bash instead.
+json_arr() {
+  local out="" e parts=() IFS=','
+  read -ra parts <<< "$1"
+  IFS=$' \t\n'
+  for e in ${parts[@]+"${parts[@]}"}; do   # empty array + set -u = unbound in bash 3.2
+    [[ -z "$e" ]] && continue
+    out="${out}${out:+,}\"${e}\""
+  done
+  printf '%s' "$out"
+}
 {
   echo '{'
   echo '  "_comment": "DERIVED — generated by docs/adr/gen-index.sh from ADR front-matter (docs/adr/SCHEMA.md). Do not hand-edit.",'

--- a/docs/adr/lib-frontmatter.sh
+++ b/docs/adr/lib-frontmatter.sh
@@ -50,64 +50,160 @@
 # READ failure and is surfaced as such, never as a schema verdict.
 # -----------------------------------------------------------------------------
 
+# The line grammar, as ONE awk function shared verbatim by both readers below —
+# the per-file one the validator uses, and the whole-fleet one the generator uses.
+# Whatever a key/value line means, it means the same thing to both. That is the
+# invariant this file exists to hold, and the reason the batch reader is not a second
+# parser. `emit(k, v)` is supplied by each reader.
+FM_AWK_GRAMMAR='
+function fm_line(line,   p, k, v) {
+  # Blank lines and comments inside the block are tolerated but carry nothing.
+  if (line ~ /^[ \t]*$/) return
+  if (line ~ /^[ \t]*#/) return
+  p = index(line, ":")
+  # A key must be flat and left-anchored. Anything else (indentation => nesting,
+  # "- " => a block sequence, no colon => a stray line or a block scalar
+  # continuation) is malformed under this schema and is reported, not guessed at.
+  if (p < 2 || line ~ /^[ \t]/ || line ~ /^-/) { emit("!malformed", line); return }
+  k = substr(line, 1, p - 1)
+  if (k !~ /^[a-z][a-z0-9-]*$/) { emit("!malformed", line); return }
+  v = substr(line, p + 1)
+  sub(/^[ \t]+/, "", v)
+  sub(/[ \t]+$/, "", v)
+  emit(k, v)
+}'
+
 fm_extract() {
-  awk '
+  awk "$FM_AWK_GRAMMAR"'
+    function emit(k, v) { print k "\t" v }
     NR == 1 {
       if ($0 != "---") { exit 3 }   # no front-matter block at all
       next
     }
     $0 == "---" { closed = 1; exit 0 }
-    # Blank lines and comments inside the block are tolerated but carry nothing.
-    /^[ \t]*$/ { next }
-    /^[ \t]*#/ { next }
-    {
-      p = index($0, ":")
-      # A key must be flat and left-anchored. Anything else (indentation => nesting,
-      # "- " => a block sequence, no colon => a stray line or a block scalar
-      # continuation) is malformed under this schema and is reported, not guessed at.
-      if (p < 2 || $0 ~ /^[ \t]/ || $0 ~ /^-/) {
-        print "!malformed\t" $0
-        next
-      }
-      k = substr($0, 1, p - 1)
-      if (k !~ /^[a-z][a-z0-9-]*$/) { print "!malformed\t" $0; next }
-      v = substr($0, p + 1)
-      sub(/^[ \t]+/, "", v)
-      sub(/[ \t]+$/, "", v)
-      print k "\t" v
-    }
+    { fm_line($0) }
     END { if (!closed) exit 4 }     # opening --- but never closed
   ' "$1"
 }
 
-fm_field() {
-  awk -F'\t' -v k="$2" '$1 == k { print $2; exit }' <<< "$1"
+# The whole fleet in ONE awk process. Emits `FILE<TAB>key<TAB>value` in file order,
+# then two synthetic keys per file:
+#   !h1      the first `# ` line, verbatim (the generator derives the title from it)
+#   !status  `ok`, or `3` / `4` — the same conditions fm_extract exits 3 and 4 on.
+# The caller decides what a bad status means, exactly as with fm_extract.
+#
+# WHY THIS EXISTS: gen-index.sh ran fm_extract once per ADR and grepped each file for
+# its H1 — 454 processes for 227 ADRs. Once the helpers below stopped forking, that
+# was ALL that remained of its runtime (9 s + 9 s of 24 s, measured). Same parse, two
+# processes instead of 454.
+#
+# Unlike fm_extract this never exits early: one malformed file must not truncate the
+# other 226. It also reads each file to the end, because the H1 follows the block.
+# No gawk extensions (no ENDFILE) — macOS ships BSD awk.
+fm_extract_many() {
+  awk "$FM_AWK_GRAMMAR"'
+    function emit(k, v) { print FILENAME "\t" k "\t" v }
+    function flush() {
+      if (prev == "") return
+      if (st == "ok" && !closed) st = "4"
+      print prev "\t!h1\t" h1
+      print prev "\t!status\t" st
+    }
+    FNR == 1 {
+      flush()
+      prev = FILENAME; h1 = ""; closed = 0; inblock = 0; st = "ok"
+      if ($0 == "---") { inblock = 1 } else { st = "3" }
+      next
+    }
+    {
+      if (inblock) {
+        if ($0 == "---") { inblock = 0; closed = 1; next }
+        fm_line($0)
+        next
+      }
+      if (h1 == "" && substr($0, 1, 2) == "# ") h1 = $0
+    }
+    END { flush() }
+  ' "$@"
 }
 
-# 0 = present, 1 = genuinely absent, 2 = the blob could not be read. The caller MUST
-# distinguish 1 from 2: only 1 is a statement about the ADR.
+# PURE BASH BELOW THIS LINE — no awk, sed, tr or grep. That is a performance property
+# with a correctness consequence, so it is worth stating plainly.
+#
+# These four are called ~14 times per ADR by gen-index.sh and ~10 times by
+# check-adr-registry.sh, and every one of them used to fork: `fm_list` alone was a
+# four-stage pipeline, so one ADR cost roughly thirty processes. Measured over 40 ADRs,
+# field extraction was 88% of gen-index.sh's runtime; reading every file was most of
+# the rest. They are pure string operations over a blob already in memory — nothing
+# here ever needed a process.
+#
+# The PARSING is still done once, by the shared awk grammar above; these only slice its
+# output. There is still exactly one implementation of the schema.
+#
+# It also removes the SIGPIPE class described above by construction rather than by
+# discipline: with no pipes and no external readers, there is no early-exit consumer to
+# signal a writer, so no caller can be handed a 141 dressed up as a verdict.
+
+fm_field() {
+  local line
+  while IFS= read -r line; do
+    if [[ "${line%%$'\t'*}" == "$2" ]]; then
+      # Only the FIRST tab separates key from value; a value may contain tabs.
+      printf '%s\n' "${line#*$'\t'}"
+      return 0
+    fi
+  done <<< "$1"
+  return 0
+}
+
+# 0 = present, 1 = genuinely absent. The third state — 2, "the blob could not be READ"
+# — is now unreachable BY CONSTRUCTION: there is no scanner left to fail, so a tool
+# failure can no longer be mistaken for a missing key. Callers keep handling 2
+# (check-adr-registry.sh does); it costs nothing and documents a distinction that must
+# never be collapsed if a reader is ever reintroduced here.
 fm_has() {
-  local rc=0
-  awk -F'\t' -v k="$2" '$1 == k { found = 1; exit } END { exit !found }' <<< "$1" || rc=$?
-  if (( rc > 1 )); then
-    echo "::error title=ADR front-matter::fm_has: could not READ front-matter while looking for key '$2' (scanner exited $rc). This is a tool failure, NOT a missing key." >&2
-    return 2
-  fi
-  return "$rc"
+  local line
+  while IFS= read -r line; do
+    [[ "${line%%$'\t'*}" == "$2" ]] && return 0
+  done <<< "$1"
+  return 1
 }
 
 # `[a, b]` -> one element per line. `[]` -> no output. Elements are trimmed; empty
 # elements (a trailing comma, `[ , ]`) are dropped rather than emitted as blanks,
 # so callers can count lines and get the real element count.
 fm_list() {
-  sed -E 's/^\[//; s/\]$//' <<< "$1" \
-    | tr ',' '\n' \
-    | sed -E 's/^[[:space:]]+//; s/[[:space:]]+$//; s/^"//; s/"$//' \
-    | grep -v '^$' || true
+  local v=$1 elem parts=()
+  v=${v#'['}
+  v=${v%']'}
+  local IFS=','
+  # `read -ra`, not `for elem in $v`: unquoted word-splitting also glob-expands, so an
+  # element containing * or ? would silently become a list of filenames.
+  read -ra parts <<< "$v"
+  IFS=$' \t\n'
+  # `${parts[@]+"${parts[@]}"}`, not a bare `"${parts[@]}"`: under `set -u`, bash 3.2
+  # (the macOS default) treats an EMPTY array's expansion as unbound and aborts, and
+  # every `[]` field in the fleet hits that. Worth recording how it was caught, because
+  # it very nearly was not: the abort happened inside a command substitution before
+  # gen-index.sh wrote anything, so the committed artefacts were left untouched — and
+  # the byte-identical check therefore PASSED, comparing the originals against
+  # themselves. A generator that produces nothing looks exactly like one that
+  # reproduces its input. Always check the run reached its last line.
+  for elem in ${parts[@]+"${parts[@]}"}; do
+    elem="${elem#"${elem%%[![:space:]]*}"}"   # ltrim
+    elem="${elem%"${elem##*[![:space:]]}"}"   # rtrim
+    elem=${elem#\"}
+    elem=${elem%\"}
+    [[ -n "$elem" ]] && printf '%s\n' "$elem"
+  done
+  return 0
 }
 
 # One layer of surrounding double quotes, and `\"` back to `"`. Left alone if the
 # value is not quoted, so the caller can tell the difference and reject it.
 fm_unquote() {
-  sed -E 's/^"//; s/"$//; s/\\"/"/g' <<< "$1"
+  local v=$1
+  v=${v#\"}
+  v=${v%\"}
+  printf '%s\n' "${v//\\\"/\"}"
 }


### PR DESCRIPTION
Closes #3108. Refs #3076 — this was the last item on it.

## Why

`docs/adr/gen-index.sh` runs on every PR: `check-adr-registry.sh` check 3 regenerates it and diffs to prove the three committed artefacts are fresh. It cost **~62 s of CPU**, almost none of it work.

Per ADR it ran `fm_extract`, grepped the file for its H1, then sliced the result with helpers that each forked a pipeline — `fm_list` alone was `sed | tr | sed | grep`. Roughly **thirty processes per ADR, ~6800 for 227**. Profiled over 40 ADRs: field extraction was 88% of runtime, `perl` in `h1_title` ~10%, reading the files ~6%.

## Measured

Back to back on the same machine:

| | user | sys | **CPU total** | wall |
|---|---|---|---|---|
| before | 23.2 s | 65.5 s | **88.7 s** | 7m17s |
| after | 3.3 s | 12.0 s | **15.3 s** | 2m43s |

**5.8× on CPU.** The machine was loaded, so wall time is noisy and CPU is the honest number. Note where it went: `sys` fell 65.5 → 12.0 s. That is the process table.

## What changed — nothing about what is parsed

1. **`fm_field` / `fm_has` / `fm_list` / `fm_unquote` are pure bash.** They are string operations over a blob already in memory and never needed a process. This also speeds up `check-adr-registry.sh`, which calls them ~10× per ADR.
2. **The schema grammar moves into one shared awk *function***, used by both the per-file reader the validator needs and the new whole-fleet reader. There is still exactly **one** implementation of the grammar — the invariant `lib-frontmatter.sh` exists to hold, and the reason the batch reader is not a second parser.
3. **`gen-index.sh` reads the fleet in ONE awk pass** (`fm_extract_many`), which also emits each file's H1 — so 227 `fm_extract` calls and 227 `grep`s become two processes. `h1_title`'s `perl -CSD` goes with them.

A side effect worth having: the pure-bash helpers remove the SIGPIPE class documented at the top of `lib-frontmatter.sh` *by construction* rather than by discipline. With no pipes and no external readers, there is no early-exit consumer to signal a writer, so no caller can be handed a 141 dressed up as a schema verdict.

## Verification

A generator that produces nothing looks exactly like one that reproduces its input, so identity alone is not enough:

- **Byte-identical** `README.md`, `DIGEST.md`, `index.json` against the committed copies — **and the run reaches its final line** (`227 ADRs indexed`). That second half is not pedantry: an earlier iteration aborted on `set -u` *before writing anything*, left the artefacts untouched, and the identity check passed by comparing the originals against themselves. It looked like a clean pass.
- **Positive control:** planting a sentinel in one ADR's `summary` changes both `DIGEST.md` and `index.json`. The generator is not inert.
- **Differential test**, old helpers vs new, over every real front-matter value in the fleet plus 22 edge cases — empty lists, trailing commas, `[ , ]`, embedded and unbalanced quotes, glob metacharacters, values containing tabs: **9124 comparisons, 0 differences**.
- **`fm_extract_many` is stream-equivalent** to per-file `fm_extract` across all 227 ADRs (2043 lines, `diff`-clean), and its `!h1` matches `grep -m1 '^# '` for every file.
- **`check-adr-registry.sh` passes** on the shared library and reports the derived artefacts fresh — the real gate, exercising the real oracle.
- `shellcheck -S warning -x` clean on both files.

## One bash 3.2 trap worth naming

Under `set -u`, an **empty** array's `"${a[@]}"` is an unbound variable — and every `[]` field in the fleet hits it. Hence `${a[@]+"${a[@]}"}`. macOS ships bash 3.2, and this library runs on the mixed macOS/Linux pool.
