### PR TITLE
docs(infra): correct the claim that nothing syncs gitops/apps — the root app-of-apps does

### DIFF
--- a/docs/adr/0234-identity-aware-edge-gate-for-internal-tool-uis.md
+++ b/docs/adr/0234-identity-aware-edge-gate-for-internal-tool-uis.md
@@ -93,8 +93,10 @@ Four parts:
    Its precondition for Enforce is "every Ingress in the namespace already carries
    one of the two annotations", which is true in git and false in the cluster: the
    policy auto-syncs from `components/kyverno`, while the annotations live in
-   `gitops/apps/{glitchtip,rum-gateway}.yaml`, which nothing syncs — those
-   Application objects reach the cluster only by a manual `kubectl apply`. Both are
+   `gitops/apps/{glitchtip,rum-gateway}.yaml`, which at the time had not been
+   merged. (This paragraph originally said nothing syncs `gitops/apps/`; that was
+   wrong — the root app-of-apps does, with prune and selfHeal. The ordering hazard
+   was real, the stated cause was not.) Both are
    `prune: true, selfHeal: true`, so Enforce would reject ArgoCD's own re-apply of
    two Ingresses that are correct in git and take GlitchTip ingest and the RUM
    gateway to SyncFailed. Verified against the sandbox on 2026-08-01: both live

--- a/openbank-infra/gitops/apps/glitchtip.yaml
+++ b/openbank-infra/gitops/apps/glitchtip.yaml
@@ -22,8 +22,9 @@
 # SECRETS: SECRET_KEY + DATABASE_URL come from Vault via ESO
 # (components/external-secrets/es-glitchtip.yaml -> Secret `glitchtip-secrets`).
 # Git holds only the reference. Postgres is external/managed (chart default); the
-# bundled Valkey is a transient cache (no persistence needed). No app-of-apps yet
-# syncs gitops/apps, so this is applied with `kubectl apply` (same as tempo/loki).
+# bundled Valkey is a transient cache (no persistence needed). The root
+# app-of-apps syncs gitops/apps (prune+selfHeal), so a merge to main is the
+# deploy — a hand `kubectl apply` of an unmerged change is reverted (#3156).
 apiVersion: argoproj.io/v1alpha1
 kind: Application
 metadata:

--- a/openbank-infra/gitops/apps/loki.yaml
+++ b/openbank-infra/gitops/apps/loki.yaml
@@ -20,8 +20,11 @@
 # this Loki with `trace_id`/`span_id`/`correlationId` lifted into structured
 # metadata.
 #
-# Codified into GitOps (ADR-0027). No root app-of-apps syncs gitops/apps yet, so
-# applied with `kubectl apply` until that is wired (separate follow-up).
+# Codified into GitOps (ADR-0027). The root app-of-apps (`root`, ArgoCD
+# Application over openbank-infra/gitops/apps, prune+selfHeal) syncs this file,
+# so a merge to main IS the deploy. A `kubectl apply` of an UNMERGED change here
+# is reverted within seconds — verified 2026-08-01, three applies in a row
+# reported `configured` and the live object never changed (#3156).
 apiVersion: argoproj.io/v1alpha1
 kind: Application
 metadata:

--- a/openbank-infra/gitops/components/kyverno/tool-ingress-gate-policy.yaml
+++ b/openbank-infra/gitops/components/kyverno/tool-ingress-gate-policy.yaml
@@ -27,8 +27,10 @@
 # policy first shipped (#3072) that was true in git and FALSE in the cluster, and
 # merging did not close the gap: this policy auto-syncs (`kyverno-policies`
 # watches components/kyverno with prune+selfHeal), while the two declarations
-# live in `gitops/apps/{glitchtip,rum-gateway}.yaml`, which NOTHING syncs — those
-# Application objects reach the cluster only via a manual `kubectl apply`. Both
+# live in `gitops/apps/{glitchtip,rum-gateway}.yaml`, which had not been merged
+# yet. (An earlier revision of this comment said NOTHING syncs that directory.
+# That was wrong — the root app-of-apps does, prune+selfHeal. The ordering hazard
+# was real; the stated cause was not.) Both
 # of those Applications are themselves prune+selfHeal, so Enforce would have
 # rejected ArgoCD's own re-apply of two Ingresses that were correct in git,
 # taking GlitchTip ingest and the RUM gateway to SyncFailed. ADR-0030's SBOM


### PR DESCRIPTION
Refs #3071

## What was wrong

Applying an unmerged change to an ArgoCD `Application` by hand kept silently reverting. The cause:

```
$ kubectl -n argocd get app root
path=openbank-infra/gitops/apps  auto={"prune":true,"selfHeal":true}
```

**There IS a root app-of-apps over `gitops/apps`, with prune and selfHeal.** The comments in `apps/loki.yaml` and `apps/glitchtip.yaml` saying none exists yet are stale, and I repeated the claim in ADR-0234 and in the tool-Ingress policy header — from where it reached #3072's post-merge runbook and several PR bodies.

## Why the mistake was invisible

Every manual `kubectl apply` I ran earlier in this line of work *appeared* to succeed — because those changes were **already merged**. `root` would have applied them anyway, so the command looked like the cause of an effect it did not produce.

Only applying something **not** in git shows the truth: three applies in a row reported `configured` and the live object never changed (2026-08-01, #3156). That is the general shape worth remembering — a redundant step looks load-bearing for exactly as long as you only ever run it alongside the thing that actually works.

## Consequences, written down where the wrong claim was

- a merge to main **is** the deploy for `gitops/apps`; the "run `kubectl apply -f gitops/apps/…` after merge" steps were unnecessary;
- an unmerged change applied by hand is reverted within seconds, so there is **no out-of-git interim mitigation** for anything in that directory — which is what made the #3156 security fix merge-or-nothing.

## What is deliberately preserved

The ADR-0234 paragraph and the `tool-ingress-gate-policy.yaml` header keep their original point — the Audit-not-Enforce ordering hazard was real, and Enforce would genuinely have taken GlitchTip ingest and the RUM gateway to SyncFailed. Only the *stated cause* was wrong: the declarations were absent because those two manifests had not been merged yet, not because nothing syncs them.

Both corrections say so in place rather than quietly rewriting the text, so a reader who saw the earlier version is not left wondering which one to believe.

## Verification

yamllint clean with the CI config; ADR derived files regenerate with no diff (the change is body prose, not front-matter).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
