### PR TITLE
fix(lending): document the fail-closed input contract of the decision evaluation

### DIFF
--- a/openbank-lending-service/src/main/kotlin/com/openbank/lending/application/usecase/OriginationDecisionService.kt
+++ b/openbank-lending-service/src/main/kotlin/com/openbank/lending/application/usecase/OriginationDecisionService.kt
@@ -44,6 +44,12 @@ data class DecisionOutcome(
  * into ELIGIBILITY, and runs the pure evaluator. The full output contract — outcome,
  * price band, reason codes, matched rules, versions, input snapshot hash — rides back
  * for persistence and `credit.decision.evaluated` evidence (ADR-0214).
+ *
+ * Input completeness is part of the contract, not a convenience: any attribute the
+ * pinned policy needs that the application does not carry (income, residency, age)
+ * makes the evaluator fail closed to REFER (ADR-0213 D2) — never to a silent approve.
+ * The DSTI/DTI pair is computed from the regenerated amortization schedule, so the
+ * affordability number the floor reads is identical to the one the offer discloses.
  */
 @ApplicationScoped
 class OriginationDecisionService(


### PR DESCRIPTION
## Summary

KDoc-only patch: makes the REFER-on-missing-input guarantee (ADR-0213 D2) and the DSTI/DTI provenance explicit in `OriginationDecisionService`. Also a pipeline-flow step: it is a `src/main` change, so the main-push lane publishes a fresh Pact version for lending-service, unblocking the can-i-deploy gate (PENDING_BUILD) for the credit-platform deploy.

## Type of change

- [ ] feat (new functionality)
- [x] fix (bug fix)
- [ ] refactor (no behavior change)
- [ ] perf (performance)
- [ ] docs
- [ ] chore (build / tooling)
- [ ] security (private until disclosed)
- [ ] breaking change

## Linked issues

N/A — documentation + deploy-flow patch.

## Changes

- `OriginationDecisionService` KDoc: the fail-closed input contract (missing attribute ⇒ REFER, never silent approve) and that DSTI/DTI come from the same regenerated amortization schedule the offer discloses.
- version.txt 0.20.0 → 0.20.1 (patch).

## Definition of Done

- [x] No behavior change (documentation only); version bumped per convention.
- [x] `./gradlew detekt ktlintCheck` passes locally on the touched module.

## Compliance impact

- [x] None

## Rollout / Rollback

- Revert.

## Reviewer notes

This PR deliberately touches `src/main` so the main-push `_service-ci` lane publishes a Pact version for lending-service — the can-i-deploy gate (PENDING_BUILD since 11:00, ADR-0092) then clears on the next auto-deploy pass and the credit platform (v0.20.x) can deploy to the sandbox.