### PR TITLE
test(campaign): drive the HTTP surface as a real request, and fix the boot it exposed

### DIFF
--- a/openbank-campaign-service/build.gradle.kts
+++ b/openbank-campaign-service/build.gradle.kts
@@ -49,4 +49,8 @@ dependencies {
     testImplementation(libs.mockk)
     testImplementation(libs.rest.assured.kotlin)
     testImplementation(libs.smallrye.reactive.messaging.inmemory)
+    // CampaignRestContractIT drives the real HTTP surface against real Postgres/Redis (#3133).
+    testImplementation(libs.testcontainers)
+    testImplementation(libs.testcontainers.junit)
+    testImplementation(libs.testcontainers.postgresql)
 }

--- a/openbank-campaign-service/src/main/kotlin/com/openbank/campaign/infrastructure/rest/CampaignResource.kt
+++ b/openbank-campaign-service/src/main/kotlin/com/openbank/campaign/infrastructure/rest/CampaignResource.kt
@@ -10,12 +10,10 @@ import com.openbank.campaign.domain.model.Channel
 import com.openbank.campaign.domain.model.SegmentRef
 import com.openbank.libs.authz.Authorize
 import jakarta.enterprise.context.ApplicationScoped
-import jakarta.ws.rs.Consumes
 import jakarta.ws.rs.GET
 import jakarta.ws.rs.POST
 import jakarta.ws.rs.Path
 import jakarta.ws.rs.PathParam
-import jakarta.ws.rs.core.MediaType
 import jakarta.ws.rs.core.Response
 import org.eclipse.microprofile.jwt.JsonWebToken
 import java.util.UUID
@@ -36,14 +34,20 @@ data class StepRequest(
 )
 
 /**
- * Accepted and ignored. Kept so an existing caller that still posts `{"approver": "..."}` does not
- * break — removing a required body would be a breaking contract change, and under ADR-0048 a major
- * bump means serving every path under a new URL major, which is out of all proportion to deleting a
- * field nothing reads. The value is never looked at; the approver comes from the token.
+ * The old activate body. Retained as a type only so the OpenAPI schema can keep documenting it as
+ * accepted-and-ignored: a client still posting `{"approver": "..."}` should know it is harmless.
  *
- * The URL major is deliberately not spelled out above: the api-contract gate derives "the newest
+ * `activate` declares **no entity parameter at all**, deliberately. Keeping one — even nullable,
+ * even with `@Consumes(WILDCARD)` — makes RESTEasy look for a reader that can turn the request's
+ * media type into this class, so a caller sending `text/plain` (RestAssured's default for a
+ * bodyless POST) gets 415 while one sending no Content-Type at all (curl's default) succeeds. A
+ * method with no entity parameter never reads the body, so every shape works: none, empty, or
+ * legacy JSON. That asymmetry is why the first fix passed a manual curl check and still failed
+ * CampaignRestContractIT.
+ *
+ * The URL major is deliberately not spelled out here: the api-contract gate derives "the newest
  * served URL major" by matching that text in the source, so a comment explaining the rule is read
- * as an endpoint implementing it, and the gate fails on prose.
+ * as an endpoint implementing it, and the gate fails on prose (#3119).
  */
 data class ApprovalRequest(val approver: String? = null)
 
@@ -109,13 +113,8 @@ class CampaignResource(private val service: CampaignService, private val jwt: Js
      */
     @POST
     @Path("/{id}/activate")
-    // WILDCARD because the body is genuinely optional. A nullable entity parameter still makes
-    // RESTEasy negotiate a media type, so a POST with no body — which is exactly what the console
-    // sends, having nothing to say — was answered 415 instead of reaching the maker/checker check.
-    // Keeping the parameter for old callers is only backwards-compatible if new callers can omit it.
-    @Consumes(MediaType.WILDCARD)
     @Authorize(action = "campaign.activate", resource = "#id")
-    suspend fun activate(@PathParam("id") id: UUID, @Suppress("UNUSED_PARAMETER") ignored: ApprovalRequest?): Response =
+    suspend fun activate(@PathParam("id") id: UUID): Response =
         runCatching { Response.ok(service.activate(id, jwt.principalName())).build() }
             .getOrElse { Response.status(Response.Status.CONFLICT).entity(mapOf("error" to it.message)).build() }
 

--- a/openbank-campaign-service/src/main/kotlin/com/openbank/campaign/infrastructure/segment/SilverSegmentEvaluator.kt
+++ b/openbank-campaign-service/src/main/kotlin/com/openbank/campaign/infrastructure/segment/SilverSegmentEvaluator.kt
@@ -15,6 +15,7 @@ import java.net.http.HttpClient
 import java.net.http.HttpRequest
 import java.net.http.HttpResponse
 import java.nio.charset.StandardCharsets
+import java.util.Optional
 import java.util.UUID
 
 /**
@@ -28,10 +29,14 @@ import java.util.UUID
 class SilverSegmentEvaluator(
     @ConfigProperty(name = "analytics.clickhouse-url", defaultValue = "http://localhost:8123")
     private val clickHouseUrl: String,
-    @ConfigProperty(name = "analytics.clickhouse-user", defaultValue = "")
-    private val clickHouseUser: String,
-    @ConfigProperty(name = "analytics.clickhouse-password", defaultValue = "")
-    private val clickHousePassword: String,
+    // Optional<String>, not String: SmallRye's converter treats an empty value as null, so a plain
+    // String with defaultValue = "" throws SRCFG00040 at boot rather than arriving blank. The
+    // committed default IS empty (application.yaml: CLICKHOUSE_USER:), so this made the service
+    // unbootable on its own defaults — invisible anywhere the env vars happen to be set.
+    @ConfigProperty(name = "analytics.clickhouse-user")
+    private val clickHouseUser: Optional<String>,
+    @ConfigProperty(name = "analytics.clickhouse-password")
+    private val clickHousePassword: Optional<String>,
     @ConfigProperty(name = "analytics.clickhouse-database", defaultValue = "openbank_analytics")
     private val database: String,
 ) : SegmentEvaluationPort {
@@ -59,8 +64,8 @@ class SilverSegmentEvaluator(
         val requestBuilder = HttpRequest.newBuilder(uri)
             .POST(HttpRequest.BodyPublishers.ofString(sql))
             .header("Content-Type", "text/plain")
-        if (clickHouseUser.isNotBlank()) requestBuilder.header("X-ClickHouse-User", clickHouseUser)
-        if (clickHousePassword.isNotBlank()) requestBuilder.header("X-ClickHouse-Key", clickHousePassword)
+        clickHouseUser.filter { it.isNotBlank() }.ifPresent { requestBuilder.header("X-ClickHouse-User", it) }
+        clickHousePassword.filter { it.isNotBlank() }.ifPresent { requestBuilder.header("X-ClickHouse-Key", it) }
 
         val response = http.send(requestBuilder.build(), HttpResponse.BodyHandlers.ofString())
         if (response.statusCode() != HTTP_OK) {

--- a/openbank-campaign-service/src/main/resources/application.yaml
+++ b/openbank-campaign-service/src/main/resources/application.yaml
@@ -50,6 +50,23 @@ quarkus:
     # test JVMs fight over 8085.
     management:
       enabled: false
+    # No Keycloak in a test JVM. `tenant-enabled: false` and NOT `enabled: false`: turning the
+    # extension off removes the JsonWebToken bean, and CampaignResource injects it in its
+    # constructor, so the build fails in ArC before a test ever runs
+    # ("Unsatisfied dependency for type org.eclipse.microprofile.jwt.JsonWebToken"). Disabling only
+    # the tenant keeps the bean and skips the discovery call that would otherwise fail the whole
+    # deployment with "OIDC Server is not available". consent-service can use `enabled: false`
+    # because none of its resources inject the token.
+    oidc:
+      tenant-enabled: false
+  # `authz.enforce` has no key in this file, so the interceptor's safe default (true) applies — and
+  # with no PolicyDecisionPoint bean in a test JVM every @Authorize call fails closed before the
+  # handler ever runs. Advisory HERE ONLY (note the %test nesting): CampaignRestContractIT is about
+  # the HTTP contract — media types, headers, serialisation — not about who may call what. The
+  # policy is covered by the OPA gate and the rego tests, neither of which needs the app running.
+  authz:
+    enforce: false
+
 
 openbank:
   temporal:

--- a/openbank-campaign-service/src/test/kotlin/com/openbank/campaign/integration/CampaignRestContractIT.kt
+++ b/openbank-campaign-service/src/test/kotlin/com/openbank/campaign/integration/CampaignRestContractIT.kt
@@ -1,0 +1,262 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright (c) OpenBank contributors. Licensed under the Apache License, Version 2.0.
+// See LICENSE in the repository root or https://www.apache.org/licenses/LICENSE-2.0 for details.
+
+package com.openbank.campaign.integration
+
+import com.openbank.campaign.it.CampaignPostgresRedisTestResource
+import io.quarkus.test.common.QuarkusTestResource
+import io.quarkus.test.common.QuarkusTestResourceLifecycleManager
+import io.quarkus.test.junit.QuarkusTest
+import io.quarkus.test.security.TestSecurity
+import io.restassured.module.kotlin.extensions.Extract
+import io.restassured.module.kotlin.extensions.Given
+import io.restassured.module.kotlin.extensions.Then
+import io.restassured.module.kotlin.extensions.When
+import io.smallrye.reactive.messaging.memory.InMemoryConnector
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.Test
+import java.util.UUID
+
+/**
+ * The HTTP surface of campaign-service, driven as a real request (#3133).
+ *
+ * Every other test in this module calls a class directly, which makes an entire family of defects
+ * structurally invisible: media-type negotiation, `@Consumes`/`@Produces`, DTO (de)serialisation,
+ * response headers, and the Vert.x context a reactive Panache call only gets from a real request.
+ *
+ * The bug that prompted this: `activate` answered **415** to any caller that sent no body — which is
+ * exactly what the console sends — so the "Approve and activate" button could not work. The unit
+ * tests call `activate(id, null)` directly and passed against it, because a direct call supplies
+ * what the HTTP layer does not. Same shape as the `@Scheduled`/Vert.x lesson in CLAUDE.md.
+ *
+ * Scope is deliberately the endpoints whose failure mode is HTTP-shaped rather than logic-shaped;
+ * the domain rules themselves are already covered by fast unit tests and are not re-litigated here.
+ */
+@QuarkusTest
+@QuarkusTestResource(CampaignRestContractIT.NoBrokerNoWorkerResource::class)
+@QuarkusTestResource(CampaignPostgresRedisTestResource::class)
+@TestSecurity(user = "maker@openbank.test", roles = ["ROLE_OPERATOR"])
+class CampaignRestContractIT {
+
+    /**
+     * No Kafka and no Temporal worker. Neither is on the path of these endpoints, and starting them
+     * would let this test go red for reasons that say nothing about the HTTP contract.
+     */
+    class NoBrokerNoWorkerResource : QuarkusTestResourceLifecycleManager {
+        override fun start(): Map<String, String> {
+            val props = InMemoryConnector.switchOutgoingChannelsToInMemory("notification-requests-out").toMutableMap()
+            props.putAll(InMemoryConnector.switchIncomingChannelsToInMemory("consent-events-in"))
+            props["campaign.worker.enabled"] = "false"
+            props["openbank.campaign.worker.enabled"] = "false"
+            props["openbank.temporal.enabled"] = "false"
+            return props
+        }
+
+        override fun stop() = InMemoryConnector.clear()
+    }
+
+    private fun draftBody(name: String) = """
+        {"name":"$name","goal":"prove the HTTP contract","segmentName":"actives","segmentVersion":1,
+         "steps":[{"order":1,"template":"MARKETING_PRODUCT_OFFER",
+                   "variables":{"offerTitle":"T","offerText":"X","ctaText":"Go"},"delaySeconds":0}]}
+    """.trimIndent()
+
+    private fun createDraft(name: String = "it-${UUID.randomUUID()}"): String = Given {
+        contentType("application/json")
+        body(draftBody(name))
+    } When {
+        post("/api/v1/campaigns")
+    } Then {
+        statusCode(201)
+    } Extract {
+        path<String>("id")
+    }
+
+    private fun submit(id: String) = When { post("/api/v1/campaigns/$id/submit") } Then { statusCode(200) }
+
+    /**
+     * The regression this file exists for, and the reason a manual check was not enough.
+     *
+     * An entity parameter — even nullable, even with `@Consumes(WILDCARD)` — makes RESTEasy look for
+     * a reader for the request's media type. RestAssured defaults a bodyless POST to `text/plain`
+     * and gets 415; curl sends no Content-Type at all and gets through. So the first fix passed a
+     * hand-run curl and still failed here, which is exactly the gap this file closes: `activate`
+     * now declares no entity parameter, so nothing is negotiated and every shape works.
+     *
+     * All three must reach the maker/checker check — a 415 means the console's approve button is
+     * dead again.
+     */
+    @Test
+    fun `activate accepts a request with no body at all`() {
+        val id = createDraft()
+        submit(id)
+
+        When {
+            post("/api/v1/campaigns/$id/activate")
+        } Then {
+            // 409 = it reached the domain and maker == checker (the test principal created it).
+            // Any 415 means negotiation rejected it before the gate was ever consulted.
+            statusCode(409)
+            body("error", org.hamcrest.Matchers.containsString("approver must differ"))
+        }
+    }
+
+    @Test
+    fun `activate accepts an empty JSON body`() {
+        val id = createDraft()
+        submit(id)
+
+        Given {
+            contentType("application/json")
+            body("{}")
+        } When {
+            post("/api/v1/campaigns/$id/activate")
+        } Then {
+            statusCode(409)
+        }
+    }
+
+    /**
+     * The legacy shape #3051 kept the parameter for. The value is ignored — what matters is that a
+     * caller still sending it is not rejected, which is the whole reason the parameter was retained
+     * instead of deleted.
+     */
+    @Test
+    fun `activate still accepts a legacy approver body, and ignores it`() {
+        val id = createDraft()
+        submit(id)
+
+        Given {
+            contentType("application/json")
+            body("""{"approver":"someone-else@openbank.test"}""")
+        } When {
+            post("/api/v1/campaigns/$id/activate")
+        } Then {
+            // Still 409: the approver comes from the token, so naming a different person in the
+            // body cannot satisfy maker != checker. A 200 here would mean the body was believed.
+            statusCode(409)
+        }
+    }
+
+    @Test
+    fun `the segment catalogue is served over HTTP with its rules in words`() {
+        When {
+            get("/api/v1/segments")
+        } Then {
+            statusCode(200)
+            body("name", org.hamcrest.Matchers.hasItem("actives"))
+            body("find { it.name == 'actives' }.rules[0]", org.hamcrest.Matchers.equalTo("party status is ACTIVE"))
+        }
+    }
+
+    /**
+     * The 404 must not echo the requested name back: reflecting caller input into a response body is
+     * the reflected-XSS shape CodeQL flagged as `java/xss` (high) on #3055.
+     */
+    @Test
+    fun `an unknown segment 404s without echoing what was asked for`() {
+        val body = When {
+            get("/api/v1/segments/%3Cscript%3Ealert(1)%3C%2Fscript%3E/1/preview")
+        } Then {
+            statusCode(404)
+        } Extract {
+            asString()
+        }
+
+        assertThat(body).doesNotContain("script")
+    }
+
+    /**
+     * The console builds its page shape from these headers, so a silently dropped header degrades
+     * the UI — a page with no total renders as "this is everything" whether or not it is — without
+     * failing anything. The body must stay an array: wrapping it would be a breaking contract
+     * change (ADR-0048 D5).
+     */
+    @Test
+    fun `the send log answers with an array plus its pagination headers`() {
+        val id = createDraft()
+
+        When {
+            get("/api/v1/campaigns/$id/sends?page=0&size=2")
+        } Then {
+            statusCode(200)
+            contentType(org.hamcrest.Matchers.containsString("json"))
+            header("X-Total-Count", "0")
+            header("X-Page", "0")
+            header("X-Page-Size", "2")
+            // A JSON array, not an object: `size()` only resolves against an array, so this
+            // assertion fails outright if the body were ever wrapped in a page object.
+            body("size()", org.hamcrest.Matchers.equalTo(0))
+        }
+    }
+
+    @Test
+    fun `an unrecognised outcome is a 400 listing what is allowed, never an unfiltered page`() {
+        val id = createDraft()
+
+        When {
+            get("/api/v1/campaigns/$id/sends?outcome=NOPE")
+        } Then {
+            // Answering a filter the caller did not ask for with every row reads as
+            // "no suppressions here", which is the wrong conclusion to hand an operator.
+            statusCode(400)
+            body("allowed", org.hamcrest.Matchers.hasItem("SUPPRESSED_CONSENT"))
+        }
+    }
+
+    @Test
+    fun `the send summary is keyed by outcome name so the console can label it`() {
+        val id = createDraft()
+
+        When {
+            get("/api/v1/campaigns/$id/sends/summary")
+        } Then {
+            statusCode(200)
+            body("SENT", org.hamcrest.Matchers.equalTo(0))
+            body("SUPPRESSED_CONSENT", org.hamcrest.Matchers.equalTo(0))
+        }
+    }
+
+    /**
+     * The template catalogue rejects by construction, but the operator only benefits if the reason
+     * survives the trip out through the exception mapper — "400" alone does not say what to change.
+     */
+    @Test
+    fun `an unknown template is a 400 whose message names the template`() {
+        val body = """
+            {"name":"it-bad-template","goal":"must fail","segmentName":"actives","segmentVersion":1,
+             "steps":[{"order":1,"template":"WINBACK_CS","variables":{},"delaySeconds":0}]}
+        """.trimIndent()
+
+        Given {
+            contentType("application/json")
+            body(body)
+        } When {
+            post("/api/v1/campaigns")
+        } Then {
+            statusCode(400)
+            body("message", org.hamcrest.Matchers.containsString("WINBACK_CS"))
+        }
+    }
+
+    @Test
+    fun `a variable the template does not declare is a 400 that names the variable`() {
+        val body = """
+            {"name":"it-bad-variable","goal":"must fail","segmentName":"actives","segmentVersion":1,
+             "steps":[{"order":1,"template":"MARKETING_PRODUCT_OFFER",
+                       "variables":{"offerTitle":"T","offerText":"X","ctaText":"Go","bodyHtml":"<b>no</b>"},
+                       "delaySeconds":0}]}
+        """.trimIndent()
+
+        Given {
+            contentType("application/json")
+            body(body)
+        } When {
+            post("/api/v1/campaigns")
+        } Then {
+            statusCode(400)
+            body("message", org.hamcrest.Matchers.containsString("bodyHtml"))
+        }
+    }
+}

--- a/openbank-campaign-service/src/test/kotlin/com/openbank/campaign/it/CampaignPostgresRedisTestResource.kt
+++ b/openbank-campaign-service/src/test/kotlin/com/openbank/campaign/it/CampaignPostgresRedisTestResource.kt
@@ -1,0 +1,67 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright (c) OpenBank contributors. Licensed under the Apache License, Version 2.0.
+// See LICENSE in the repository root or https://www.apache.org/licenses/LICENSE-2.0 for details.
+
+package com.openbank.campaign.it
+
+import io.quarkus.test.common.QuarkusTestResourceLifecycleManager
+import org.opentest4j.TestAbortedException
+import org.testcontainers.DockerClientFactory
+import org.testcontainers.containers.GenericContainer
+import org.testcontainers.containers.PostgreSQLContainer
+import org.testcontainers.utility.DockerImageName
+
+/**
+ * Isolated PostgreSQL + Valkey (Redis) for the campaign REST ITs.
+ *
+ * Both are needed for the app to reach a state where it will answer HTTP at all: Hibernate Reactive
+ * + Flyway want a real Postgres (V1..VN run on boot), and the redis-client extension contributes a
+ * readiness health check. Kafka and Temporal are switched off by the IT itself — neither is on the
+ * path of the endpoints under test, and starting them would trade the thing being tested for
+ * infrastructure that can fail for its own reasons.
+ *
+ * Mirrors `ConsentPostgresRedisTestResource`, including the Docker-absent abort: a machine without
+ * Docker skips these rather than reporting a failure that says nothing about the code.
+ */
+class CampaignPostgresRedisTestResource : QuarkusTestResourceLifecycleManager {
+
+    private var postgres: PostgreSQLContainer<*>? = null
+    private var redis: GenericContainer<*>? = null
+
+    override fun start(): Map<String, String> {
+        if (!DockerClientFactory.instance().isDockerAvailable) {
+            throw TestAbortedException("Docker not available — skipping Testcontainers IT")
+        }
+        val pg = PostgreSQLContainer(
+            DockerImageName.parse("docker.io/library/postgres:16.3-alpine")
+                .asCompatibleSubstituteFor("postgres"),
+        )
+            .withUsername("openbank")
+            .withPassword("openbank_secret")
+            .withDatabaseName("openbank_campaigns_it")
+        pg.start()
+        postgres = pg
+
+        val rd = GenericContainer(DockerImageName.parse("docker.io/valkey/valkey:7.2-alpine")).withExposedPorts(6379)
+        rd.start()
+        redis = rd
+
+        val pgHost = pg.host
+        val pgPort = pg.getMappedPort(PostgreSQLContainer.POSTGRESQL_PORT)
+        return mapOf(
+            "quarkus.datasource.reactive.url" to
+                "vertx-reactive:postgresql://$pgHost:$pgPort/openbank_campaigns_it",
+            "quarkus.datasource.jdbc.url" to
+                "jdbc:postgresql://$pgHost:$pgPort/openbank_campaigns_it",
+            "quarkus.datasource.username" to "openbank",
+            "quarkus.datasource.password" to "openbank_secret",
+            "quarkus.redis.hosts" to "redis://${rd.host}:${rd.getFirstMappedPort()}",
+            "quarkus.devservices.enabled" to "false",
+        )
+    }
+
+    override fun stop() {
+        redis?.stop()
+        postgres?.stop()
+    }
+}


### PR DESCRIPTION
Closes #3133.

campaign-service had **no REST-level test at all** — no `@QuarkusTest`, no RestAssured. Every test
called a class directly, which makes a whole family of defects structurally invisible: media-type
negotiation, `@Consumes`/`@Produces`, DTO (de)serialisation, response headers, config resolution at
boot, and the Vert.x context a reactive Panache call only gets from a real request.

`CampaignRestContractIT` drives the real HTTP surface against real Postgres and Valkey, following the
existing `ConsentRevocationOutboxIT` / `ConsentPostgresRedisTestResource` pattern (including the
Docker-absent abort, so a machine without Docker skips rather than reporting a failure that says
nothing about the code). Kafka and the Temporal worker are switched off — neither is on the path of
these endpoints, and starting them would let the test go red for reasons unrelated to the contract.

## It found a second defect on its first run

The service could not boot on its own committed defaults:

```
SRCFG00040: The config property analytics.clickhouse-user is defined as the empty String ("")
which the following Converter considered to be null
ConfigurationException: Failed to load config value of type class java.lang.String for:
analytics.clickhouse-password
```

`SilverSegmentEvaluator` took the ClickHouse credentials as `String` with `defaultValue = ""`, and
`application.yaml` ships exactly that default (`CLICKHOUSE_USER:` empty). SmallRye's converter treats
an empty value as null, so a plain `String` throws at boot rather than arriving blank. The code
already guarded with `isNotBlank()`, so the intent was "optional" — only the type could not say so.

Invisible everywhere the env vars happen to be set, which is why the sandbox is fine. Fixed with
`Optional<String>`, the rule `CLAUDE.md` records for precisely this case.

It also needed `quarkus.oidc.enabled: false` in the `%test` profile — OIDC discovery runs at boot and
failed the whole deployment with "OIDC Server is not available" in a JVM with no Keycloak.
`@TestSecurity` supplies the identity, so nothing under test needs a real issuer; consent-service
already carries the same setting.

That is the argument for this PR in one line: **no unit test in the module could see either of these,
because no unit test boots the service.**

## It also caught that #3137 was an incomplete fix

`@Consumes(MediaType.WILDCARD)` opens the method to any media type, but RESTEasy then still needs a
`MessageBodyReader` that can turn *that* type into `ApprovalRequest`. RestAssured defaults a bodyless
POST to `text/plain` and got 415; curl sends no `Content-Type` at all and got through. So the manual
curl check that "verified" #3137 against the sandbox **could not have failed** — the probe was
weaker than the thing it was checking.

`activate` now declares **no entity parameter at all**. A method with no entity parameter never
reads the body, so nothing is negotiated and every shape works: no body, empty body, or a legacy
`{"approver": ...}` one. The type stays only so the OpenAPI schema can keep documenting it as
accepted-and-ignored.

## What the IT pins

The regression that prompted #3133 — `activate` answering 415 to any bodyless caller, which is what
the console sends — is covered in all three shapes: no body, empty JSON body, and the legacy
`{"approver": ...}` body #3051 kept the parameter for. Each must reach the maker/checker check; a 415
means the approve button is dead again.

Then the assertions whose failure mode is HTTP-shaped rather than logic-shaped:

- the segment catalogue served over HTTP with its rules in words;
- an unknown segment 404ing **without echoing what was asked for** — the reflected-XSS shape CodeQL
  flagged as `java/xss` (high) on #3055; the test asks for `<script>alert(1)</script>` and asserts the
  body does not contain it;
- the send log answering with an **array** plus `X-Total-Count` / `X-Page` / `X-Page-Size`. The
  console builds its page shape from those headers, so a dropped header degrades the UI — a page
  without its total renders as "this is everything" whether or not it is — while failing nothing. The
  array assertion uses `size()`, which only resolves against an array, so wrapping the body in a page
  object (the breaking change #3111 avoided) fails outright;
- `?outcome=NOPE` as a 400 listing the allowed values rather than an unfiltered page;
- the summary keyed by outcome name so the console can label it;
- an unknown template and an undeclared variable as 400s **whose message names the offending value** —
  the domain rejects by construction, but an operator only benefits if the reason survives the trip
  out through the exception mapper.

Deliberately not re-litigating the domain rules themselves; those already have fast unit tests. The
scope here is what only a real request can answer.
