### PR TITLE
fix(observability): dSYM upload 404s on the missing trailing slash

### DIFF
--- a/openbank-infra/gitops/apps/glitchtip.yaml
+++ b/openbank-infra/gitops/apps/glitchtip.yaml
@@ -129,10 +129,16 @@ spec:
                   # /api/0/ (users, teams, settings, the Django admin) becomes
                   # reachable. Keep these regexes anchored to `chunk-upload` and
                   # `files/(difs|dsyms)`; widening them re-opens the management API.
-                  - path: /api/0/organizations/[^/]+/chunk-upload/
+                  #
+                  # The trailing slash is OPTIONAL, and that is the whole point: sentry-cli asks
+                  # GET .../chunk-upload/ (slash) and is answered with a `url` field that has NO
+                  # trailing slash, so it then POSTs the chunks to .../chunk-upload and nginx 404s
+                  # a path that differs from the allowed one by one character. Build 82 and 83
+                  # both died exactly there, after the GET had already succeeded.
+                  - path: /api/0/organizations/[^/]+/chunk-upload/?
                     pathType: ImplementationSpecific
                   # …/files/difs/assemble/ shares this prefix, so it matches too.
-                  - path: /api/0/projects/[^/]+/[^/]+/files/(difs|dsyms)/
+                  - path: /api/0/projects/[^/]+/[^/]+/files/(difs|dsyms)/?
                     pathType: ImplementationSpecific
             tls:
               - secretName: glitchtip-tls


### PR DESCRIPTION
#3045 allow-listnul obě upload cesty a upload **stejně selhal** — tentokrát ale `404` od nginxu, ne `413`.

Debug log ze sentry-cli ukazuje proč:

```
GET  /api/0/organizations/openbank/chunk-upload/     -> 200  (povoleno)
POST /api/0/organizations/openbank/chunk-upload      -> 404  (nepovoleno)
```

GlitchTip na to GET odpoví konfigurací, jejíž pole `url` **nemá koncové lomítko**, takže sentry-cli pošle chunky na cestu, která se od povolené liší o jeden znak. Buildy 82 i 83 umřely přesně tam — až *poté*, co vyjednávání proběhlo úspěšně.

Ověřeno proti živému hostu:

| požadavek | odpověď |
|---|---|
| `POST …/chunk-upload/` | **403** — dojde do GlitchTipu, chce auth |
| `POST …/chunk-upload` | **404** — zastaveno na edge |

Dělá koncové lomítko volitelné na obou upload cestách. Zbytek `/api/0/` dál 404, regexy zůstávají ukotvené na `chunk-upload` a `files/(difs|dsyms)`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)