### PR TITLE
security(account): a delegation grant only counts when its issuer owns the account

### DIFF
--- a/docs/threat-models/openbank-account-service.md
+++ b/docs/threat-models/openbank-account-service.md
@@ -246,10 +246,17 @@ not change any existing request's outcome until explicitly flipped.
   `account_delegation_projection` fed by `DelegationEventConsumer` from
   `openbank.delegation.events`, and `AuthorizationService.isAuthorized` gains a third disjunct —
   owner OR legacy `AccountAuthorization` OR an ACTIVE in-window delegation grant. **Risk class =
-  elevation of privilege / confused deputy.** Key properties: enforcement is local-only (no
-  synchronous call to delegation-service on the request path — guarded by
-  `NoDelegationRestClientTest`); the guard is additive (delegation can only ADD access, never
-  remove the owner's); per-transaction ceilings and currency match are enforced for
+  elevation of privilege / confused deputy.** Key properties: **a grant only counts when the party
+  who ISSUED it owns the account** — the projection carries `grantor_party_id` and the guard
+  compares it to `account.partyId` on every call. Without that the disjunct made a projection row
+  authority in itself: matching on (accountId, granteePartyId) alone meant a grant naming somebody
+  else's account was enforced against that account, so two colluding parties could mint payment
+  rights over a stranger's money using nothing but their own valid SCA. delegation-service also
+  verifies ownership at offer time; this is the half that re-evaluates per request rather than
+  trusting a verdict reached once, and it is the last check before the money path. Further:
+  enforcement is local-only (no synchronous call to delegation-service on the request path —
+  guarded by `NoDelegationRestClientTest`); the guard is additive (delegation can only ADD access,
+  never remove the owner's); per-transaction ceilings and currency match are enforced for
   PAYMENT_ONLY; a missed close event would leave access open, so consumer failures dead-letter
   instead of being swallowed (the worst drift direction is a REVOKED grant staying enforceable —
   the DLQ preserves the close for replay); projection rows key on the grant id, so redelivered

--- a/openbank-account-service/src/main/kotlin/com/openbank/account/application/usecase/AuthorizationService.kt
+++ b/openbank-account-service/src/main/kotlin/com/openbank/account/application/usecase/AuthorizationService.kt
@@ -69,7 +69,7 @@ class AuthorizationService(
         if (account.partyId == partyId) return true
         val active = authorizationRepository.findActiveByAccountAndParty(accountId, partyId)
         if (active.any { it.role == role || it.role == AuthorizationRole.FULL_ACCESS }) return true
-        return hasDelegatedAccess(accountId, partyId, role)
+        return hasDelegatedAccess(accountId, partyId, role, account.partyId)
     }
 
     override suspend fun isAuthorizedForAmount(
@@ -82,10 +82,10 @@ class AuthorizationService(
         if (account.partyId == partyId) return true
         val active = authorizationRepository.findActiveByAccountAndParty(accountId, partyId)
         if (active.any { it.role == role || it.role == AuthorizationRole.FULL_ACCESS }) return true
-        if (amount == null) return hasDelegatedAccess(accountId, partyId, role)
+        if (amount == null) return hasDelegatedAccess(accountId, partyId, role, account.partyId)
         val now = OffsetDateTime.now(clock)
         return delegationProjectionRepository.findActiveByAccountAndParty(accountId, partyId)
-            .filter { it.isActiveOn(now) && it.satisfies(role) }
+            .filter { it.issuedBy(account.partyId) && it.isActiveOn(now) && it.satisfies(role) }
             .any { it.withinPerTransactionLimit(amount.amount, amount.currency.code) }
     }
 
@@ -94,10 +94,24 @@ class AuthorizationService(
      * grant from the local event-fed projection. Runs after ownership and the legacy
      * AccountAuthorization table so the 99% path (owner) and the existing grants keep
      * their exact behavior; delegation only ever ADDS access, never removes it.
+     *
+     * [ownerPartyId] is the account's own owner, and a grant only counts when the party who
+     * ISSUED it is that owner. Without this the disjunct made a grant row authority in itself:
+     * the projection matched on (accountId, granteePartyId) alone, so a grant naming somebody
+     * else's account was enforced against that account — two colluding parties could mint
+     * payment rights over a stranger's money using nothing but their own valid SCA. The
+     * offer-time ownership gate in delegation-service closes the same hole from the other end;
+     * this check is the one that re-evaluates on every request instead of trusting a verdict
+     * reached once, and it is the last line before the money path.
      */
-    private suspend fun hasDelegatedAccess(accountId: UUID, partyId: UUID, role: AuthorizationRole): Boolean {
+    private suspend fun hasDelegatedAccess(
+        accountId: UUID,
+        partyId: UUID,
+        role: AuthorizationRole,
+        ownerPartyId: UUID,
+    ): Boolean {
         val now = OffsetDateTime.now(clock)
         return delegationProjectionRepository.findActiveByAccountAndParty(accountId, partyId)
-            .any { it.isActiveOn(now) && it.satisfies(role) }
+            .any { it.issuedBy(ownerPartyId) && it.isActiveOn(now) && it.satisfies(role) }
     }
 }

--- a/openbank-account-service/src/main/kotlin/com/openbank/account/domain/model/DelegatedAccessGrant.kt
+++ b/openbank-account-service/src/main/kotlin/com/openbank/account/domain/model/DelegatedAccessGrant.kt
@@ -19,6 +19,17 @@ import java.util.UUID
 data class DelegatedAccessGrant(
     val id: UUID,
     val accountId: UUID,
+    /**
+     * The party that issued the grant. Carried so the guard can ask the question this projection
+     * could not: does the grantor actually OWN the account?
+     *
+     * Without it a grant row is authority in itself — the guard matched on
+     * (accountId, granteePartyId) alone, so a grant naming a stranger's account produced real,
+     * enforced access to that account. delegation-service now verifies ownership at offer time
+     * too; this is the enforcing side, and it is the one that re-reads the truth on every call
+     * rather than trusting a check that passed once.
+     */
+    val grantorPartyId: UUID,
     val granteePartyId: UUID,
     val capabilities: Set<String>,
     val perTransactionLimitAmount: java.math.BigDecimal? = null,
@@ -27,6 +38,9 @@ data class DelegatedAccessGrant(
     val validTo: OffsetDateTime? = null,
     val active: Boolean = true,
 ) {
+    /** The grant only speaks for the account if the party who issued it owns the account. */
+    fun issuedBy(ownerPartyId: UUID): Boolean = grantorPartyId == ownerPartyId
+
     fun isActiveOn(now: OffsetDateTime): Boolean = active &&
         !now.isBefore(validFrom) &&
         (validTo == null || now.isBefore(validTo))

--- a/openbank-account-service/src/main/kotlin/com/openbank/account/infrastructure/kafka/DelegationEventConsumer.kt
+++ b/openbank-account-service/src/main/kotlin/com/openbank/account/infrastructure/kafka/DelegationEventConsumer.kt
@@ -17,6 +17,7 @@ import java.util.UUID
 private data class DelegationEvent(
     val type: String,
     val grantId: UUID,
+    val grantorPartyId: UUID,
     val granteePartyId: UUID,
     val resourceType: String,
     val resourceId: UUID?,
@@ -59,6 +60,9 @@ class DelegationEventConsumer(
         val node = runCatching { objectMapper.readTree(payload) }.getOrNull() ?: return null
         val grantId = runCatching { UUID.fromString(node.path("aggregateId").asText()) }.getOrNull() ?: return null
         val grantee = runCatching { UUID.fromString(node.path("granteePartyId").asText()) }.getOrNull() ?: return null
+        // A grant with no readable grantor cannot be checked against the account owner, so it is
+        // a poison pill rather than a row to project optimistically.
+        val grantor = runCatching { UUID.fromString(node.path("grantorPartyId").asText()) }.getOrNull() ?: return null
         val resourceId = node.path("resourceId").asText(null)
             ?.let { runCatching { UUID.fromString(it) }.getOrNull() }
         val caps = node.path("capabilities").takeIf { it.isArray }
@@ -66,6 +70,7 @@ class DelegationEventConsumer(
         return DelegationEvent(
             type = node.path("eventType").asText(""),
             grantId = grantId,
+            grantorPartyId = grantor,
             granteePartyId = grantee,
             resourceType = node.path("resourceType").asText(""),
             resourceId = resourceId,
@@ -95,6 +100,7 @@ class DelegationEventConsumer(
             DelegatedAccessGrant(
                 id = event.grantId,
                 accountId = accountId,
+                grantorPartyId = event.grantorPartyId,
                 granteePartyId = event.granteePartyId,
                 capabilities = event.capabilities,
                 perTransactionLimitAmount = event.perTxLimitAmount,

--- a/openbank-account-service/src/main/kotlin/com/openbank/account/infrastructure/persistence/entity/DelegationProjectionEntity.kt
+++ b/openbank-account-service/src/main/kotlin/com/openbank/account/infrastructure/persistence/entity/DelegationProjectionEntity.kt
@@ -29,6 +29,9 @@ class DelegationProjectionEntity : PanacheEntityBase() {
     @Column(name = "account_id", nullable = false)
     lateinit var accountId: UUID
 
+    @Column(name = "grantor_party_id", nullable = false)
+    lateinit var grantorPartyId: UUID
+
     @Column(name = "grantee_party_id", nullable = false)
     lateinit var granteePartyId: UUID
 
@@ -58,6 +61,7 @@ class DelegationProjectionEntity : PanacheEntityBase() {
     fun toDomain(): DelegatedAccessGrant = DelegatedAccessGrant(
         id = id,
         accountId = accountId,
+        grantorPartyId = grantorPartyId,
         granteePartyId = granteePartyId,
         capabilities = capabilities.toSet(),
         perTransactionLimitAmount = perTxLimitAmount,
@@ -72,6 +76,7 @@ class DelegationProjectionEntity : PanacheEntityBase() {
             DelegationProjectionEntity().apply {
                 id = g.id
                 accountId = g.accountId
+                grantorPartyId = g.grantorPartyId
                 granteePartyId = g.granteePartyId
                 capabilities = g.capabilities.toMutableSet()
                 perTxLimitAmount = g.perTransactionLimitAmount

--- a/openbank-account-service/src/main/resources/db/migration/V16__delegation_projection.sql
+++ b/openbank-account-service/src/main/resources/db/migration/V16__delegation_projection.sql
@@ -5,6 +5,10 @@
 CREATE TABLE account_delegation_projection (
     id                      UUID PRIMARY KEY,
     account_id              UUID NOT NULL,
+    -- The grantor is not decoration: the guard compares it to the account's owner, because a
+    -- projection row keyed only on (account_id, grantee_party_id) is authority in itself and a
+    -- grant naming a stranger's account would therefore be enforced against that account.
+    grantor_party_id        UUID NOT NULL,
     grantee_party_id        UUID NOT NULL,
     per_tx_limit_amount     NUMERIC(20, 6),
     per_tx_limit_currency   CHAR(3),

--- a/openbank-account-service/src/test/kotlin/com/openbank/account/application/usecase/AuthorizationServiceDelegationTest.kt
+++ b/openbank-account-service/src/test/kotlin/com/openbank/account/application/usecase/AuthorizationServiceDelegationTest.kt
@@ -53,9 +53,11 @@ class AuthorizationServiceDelegationTest {
         capabilities: Set<String>,
         validTo: OffsetDateTime? = now.plusDays(30),
         perTxAmount: String? = null,
+        grantorPartyId: UUID = owner,
     ) = DelegatedAccessGrant(
         id = UUID.randomUUID(),
         accountId = accountId,
+        grantorPartyId = grantorPartyId,
         granteePartyId = delegate,
         capabilities = capabilities,
         perTransactionLimitAmount = perTxAmount?.toBigDecimal(),
@@ -140,6 +142,69 @@ class AuthorizationServiceDelegationTest {
             ),
         ).isFalse()
     }
+
+    // --- the grant must have been issued by the account's OWNER -------------------------------
+    // Before this, the guard matched on (accountId, granteePartyId) alone, so a projection row is
+    // authority in itself: a grant naming somebody else's account was enforced against that
+    // account. Two colluding parties could therefore mint payment rights over a stranger's money
+    // with nothing but their own valid SCA.
+
+    @Test
+    fun `a grant issued by someone who does not own the account is denied`(): Unit = runBlocking {
+        val stranger = UUID.randomUUID()
+        coEvery { projectionRepository.findActiveByAccountAndParty(accountId, delegate) } returns
+            listOf(grant(setOf("ACCOUNT_READ_BALANCES"), grantorPartyId = stranger))
+
+        assertThat(service.isAuthorized(accountId, delegate, AuthorizationRole.READ_ONLY)).isFalse()
+    }
+
+    @Test
+    fun `a payment grant issued by a non-owner is denied on the amount path too`(): Unit = runBlocking {
+        val stranger = UUID.randomUUID()
+        coEvery { projectionRepository.findActiveByAccountAndParty(accountId, delegate) } returns
+            listOf(grant(setOf("ACCOUNT_INITIATE_PAYMENT"), perTxAmount = "5000", grantorPartyId = stranger))
+
+        // The amount path is a separate branch of the guard and was separately vulnerable — this
+        // is the one that reaches the money.
+        assertThat(
+            service.isAuthorizedForAmount(
+                accountId,
+                delegate,
+                AuthorizationRole.PAYMENT_ONLY,
+                Money.of("100".toBigDecimal(), "CZK"),
+            ),
+        ).isFalse()
+    }
+
+    @Test
+    fun `a grant from the owner still passes, on both paths`(): Unit = runBlocking {
+        coEvery { projectionRepository.findActiveByAccountAndParty(accountId, delegate) } returns
+            listOf(grant(setOf("ACCOUNT_INITIATE_PAYMENT"), perTxAmount = "5000"))
+
+        assertThat(service.isAuthorized(accountId, delegate, AuthorizationRole.PAYMENT_ONLY)).isTrue()
+        assertThat(
+            service.isAuthorizedForAmount(
+                accountId,
+                delegate,
+                AuthorizationRole.PAYMENT_ONLY,
+                Money.of("100".toBigDecimal(), "CZK"),
+            ),
+        ).isTrue()
+    }
+
+    @Test
+    fun `a valid grant next to a forged one still passes, and the forged one is not what carried it`(): Unit =
+        runBlocking {
+            val stranger = UUID.randomUUID()
+            coEvery { projectionRepository.findActiveByAccountAndParty(accountId, delegate) } returns listOf(
+                grant(setOf("ACCOUNT_INITIATE_PAYMENT"), grantorPartyId = stranger),
+                grant(setOf("ACCOUNT_READ_BALANCES")),
+            )
+
+            assertThat(service.isAuthorized(accountId, delegate, AuthorizationRole.READ_ONLY)).isTrue()
+            // The forged row is the only one carrying a payment capability.
+            assertThat(service.isAuthorized(accountId, delegate, AuthorizationRole.PAYMENT_ONLY)).isFalse()
+        }
 
     @Test
     fun `no grant at all denies`(): Unit = runBlocking {

--- a/openbank-account-service/src/test/kotlin/com/openbank/account/infrastructure/kafka/DelegationEventConsumerTest.kt
+++ b/openbank-account-service/src/test/kotlin/com/openbank/account/infrastructure/kafka/DelegationEventConsumerTest.kt
@@ -26,6 +26,7 @@ class DelegationEventConsumerTest {
 
     private val grantId: UUID = UUID.randomUUID()
     private val accountId: UUID = UUID.randomUUID()
+    private val grantor: UUID = UUID.randomUUID()
     private val grantee: UUID = UUID.randomUUID()
 
     @BeforeEach
@@ -38,7 +39,7 @@ class DelegationEventConsumerTest {
             mapOf(
                 "eventType" to type,
                 "aggregateId" to grantId,
-                "grantorPartyId" to UUID.randomUUID(),
+                "grantorPartyId" to grantor,
                 "granteePartyId" to grantee,
                 "resourceType" to resourceType,
                 "resourceId" to resourceId,
@@ -58,12 +59,35 @@ class DelegationEventConsumerTest {
                 match<DelegatedAccessGrant> {
                     it.id == grantId &&
                         it.accountId == accountId &&
+                        // Without the grantor the guard cannot ask whether the issuer owns the
+                        // account, and a projection row becomes authority in itself.
+                        it.grantorPartyId == grantor &&
                         it.active &&
                         "ACCOUNT_READ_BALANCES" in it.capabilities &&
                         it.perTransactionLimitAmount?.compareTo("5000.00".toBigDecimal()) == 0
                 },
             )
         }
+    }
+
+    @Test
+    fun `an event with no readable grantor is a poison pill, not an optimistic row`(): Unit = runBlocking {
+        val noGrantor = objectMapper.writeValueAsString(
+            mapOf(
+                "eventType" to "DelegationActivated",
+                "aggregateId" to grantId,
+                "granteePartyId" to grantee,
+                "resourceType" to "ACCOUNT",
+                "resourceId" to accountId,
+                "capabilities" to listOf("ACCOUNT_INITIATE_PAYMENT"),
+                "occurredAt" to "2026-08-01T12:00:00Z",
+            ),
+        )
+
+        consumer.consume(noGrantor)
+
+        // Projecting it would create a row the ownership check can never evaluate.
+        coVerify(exactly = 0) { repository.upsertActive(any()) }
     }
 
     @Test

--- a/openbank-account-service/src/test/kotlin/com/openbank/account/integration/DelegationProjectionIT.kt
+++ b/openbank-account-service/src/test/kotlin/com/openbank/account/integration/DelegationProjectionIT.kt
@@ -45,6 +45,8 @@ class DelegationProjectionIT {
     private val ownerParty: UUID = UUID.randomUUID()
     private val delegateParty: UUID = UUID.randomUUID()
     private val grantId: UUID = UUID.randomUUID()
+    private val forgedGrantId: UUID = UUID.randomUUID()
+    private val strangerParty: UUID = UUID.randomUUID()
 
     @Test
     @TestSecurity(user = "00000000-0000-0000-0000-000000000099", roles = ["ROLE_OPERATOR"])
@@ -61,6 +63,44 @@ class DelegationProjectionIT {
 
         source.send(delegationEvent("DelegationRevoked", accountId))
         assertThat(awaitAuthorized(accountId, expected = false)).isTrue()
+    }
+
+    /**
+     * End-to-end proof of the ownership half of the guard: a grant issued by a party who does not
+     * own the account must not open anything, even though the projection row is real, ACTIVE and
+     * in-window. Before the grantor was carried, the guard matched on
+     * (accountId, granteePartyId) alone and this event granted payment rights over the account.
+     *
+     * Ordering is what makes the assertion safe: both events go to the same channel, so once the
+     * READ_ONLY check flips, the forged event has certainly been consumed too. PAYMENT_ONLY can
+     * then only be satisfied by the forged row — and it is not.
+     */
+    @Test
+    @TestSecurity(user = "00000000-0000-0000-0000-000000000099", roles = ["ROLE_OPERATOR"])
+    fun `a grant issued by a non-owner never opens access`(): Unit = runBlocking {
+        val accountId = openAccount()
+        val source: io.smallrye.reactive.messaging.memory.InMemorySource<String> =
+            connector.source("delegation-events-in")
+        source.runOnVertxContext(true)
+
+        source.send(
+            delegationEvent(
+                "DelegationActivated",
+                accountId,
+                grantId = forgedGrantId,
+                grantorPartyId = strangerParty,
+                capabilities = """"ACCOUNT_READ_BALANCES", "ACCOUNT_INITIATE_PAYMENT"""",
+            ),
+        )
+        source.send(delegationEvent("DelegationActivated", accountId))
+
+        assertThat(awaitAuthorized(accountId, expected = true))
+            .describedAs("the owner's own grant must open READ_ONLY — otherwise this test proves nothing")
+            .isTrue()
+
+        assertThat(authorized(accountId, role = "PAYMENT_ONLY"))
+            .describedAs("only the forged grant carries a payment capability, and its issuer does not own the account")
+            .isFalse()
     }
 
     private fun openAccount(): String {
@@ -86,31 +126,38 @@ class DelegationProjectionIT {
         return response.extract().path("id")
     }
 
+    private fun authorized(accountId: String, role: String = "READ_ONLY"): Boolean = (
+        Given { this } When {
+            get("/api/v1/accounts/$accountId/authorizations/check?partyId=$delegateParty&role=$role")
+        } Then {
+            statusCode(200)
+        }
+        ).extract().path("authorized")
+
     private suspend fun awaitAuthorized(accountId: String, expected: Boolean): Boolean {
         repeat(40) {
-            val authorized: Boolean = (
-                Given { this } When {
-                    get("/api/v1/accounts/$accountId/authorizations/check?partyId=$delegateParty&role=READ_ONLY")
-                } Then {
-                    statusCode(200)
-                }
-                ).extract().path("authorized")
-            if (authorized == expected) return true
+            if (authorized(accountId) == expected) return true
             delay(250)
         }
         return false
     }
 
-    private fun delegationEvent(type: String, accountId: String): String =
+    private fun delegationEvent(
+        type: String,
+        accountId: String,
+        grantId: UUID = this.grantId,
+        grantorPartyId: UUID = ownerParty,
+        capabilities: String = """"ACCOUNT_READ_BALANCES"""",
+    ): String =
         """
         {
           "eventType": "$type",
           "aggregateId": "$grantId",
-          "grantorPartyId": "$ownerParty",
+          "grantorPartyId": "$grantorPartyId",
           "granteePartyId": "$delegateParty",
           "resourceType": "ACCOUNT",
           "resourceId": "$accountId",
-          "capabilities": ["ACCOUNT_READ_BALANCES"],
+          "capabilities": [$capabilities],
           "validFrom": "2026-01-01T00:00:00Z",
           "occurredAt": "2026-08-01T12:00:00Z"
         }


### PR DESCRIPTION
## What

The projection half of the account-takeover chain found reviewing #2971. Targets `feat/account-delegation-projection` so #3058 absorbs it before merging.

**Do not merge without a second reviewer** — money-path service, threat model updated in this PR.

## The hole

`AuthorizationService`'s third disjunct asked *"is there an ACTIVE, in-window grant for (accountId, granteePartyId)?"*. The projection carried no grantor, so a grant row was **authority in itself**: a grant naming somebody else's account was enforced against that account.

Full chain, with the delegation-service side ([#3164](https://github.com/JiRaska/open-bank-oss/pull/3164)):

1. delegation-service verified both parties exist and are KYC'd. It never verified the grantor owns the resource.
2. This projection had no grantor to compare against even if it had wanted to.

So two colluding, fully-legitimate parties could mint `ACCOUNT_INITIATE_PAYMENT` over a **stranger's account** using nothing but their own valid SCA — and then pay from it. Every layer said yes.

`docs/threat-models/openbank-account-service.md` named *"elevation of privilege / confused deputy"* as the risk class of this very feature while the check that prevents it did not exist.

## The fix

- `DelegatedAccessGrant` gains `grantorPartyId`; `issuedBy(ownerPartyId)` is the question.
- The guard compares it to `account.partyId` on **both** paths — `isAuthorized` and `isAuthorizedForAmount`. The amount path is a separate branch and was separately vulnerable; it is the one that reaches the money.
- `DelegationEventConsumer` parses and stores it. The event has carried `grantorPartyId` since the first slice — the projection simply dropped it.
- An event with no readable grantor is a **poison pill**, not a row projected optimistically: a row whose ownership can never be evaluated is worse than no row.

### Why here as well as in delegation-service

#3164 adds an offer-time ownership gate. That runs **once**, at grant time, against a service that can be unavailable or wrong. This one re-evaluates **per request**, against the account this service owns, and it is the last thing between a grant and a payment. Neither makes the other redundant.

## Tests

- forged grantor denied on `isAuthorized`
- forged grantor denied on `isAuthorizedForAmount` (the money branch)
- owner-issued grant still passes on both paths
- a valid grant and a forged one side by side: READ_ONLY passes (from the valid row), PAYMENT_ONLY does not (only the forged row carries it)
- consumer poison-pill path: no `upsertActive` when the grantor is unreadable
- consumer projects the grantor it was sent
- **`DelegationProjectionIT`**: end-to-end through the real consumer, real Postgres and the real `/authorizations/check` endpoint. Ordering on the shared channel is what makes the negative assertion safe — once the owner's grant flips READ_ONLY, the forged event has certainly been consumed too.

## Migration

`V16` is **edited**, not superseded. It exists only on this unmerged branch and has never been applied; the child PR #3143 already occupies `V17`, so a `V18` here would make Flyway refuse the child's migration as out of order. #3143 needs a rebase after this lands either way.

## Verification

- `:openbank-account-service:compileKotlin compileTestKotlin detekt` locally.
- ktlint clean on all six changed Kotlin files (standalone 1.8.0 against the repo `.editorconfig`); the pre-existing findings elsewhere in the service are identical on the base branch — verified by linting the base version of the same file.

Refs #2990
