### PR TITLE
fix(ci): make the customer-app dossier check actually enforce, and refresh it

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -460,12 +460,21 @@ jobs:
         working-directory: openbank-admin-ui
         run: npm ci --no-audit --no-fund
 
-      # Diff the derived block in enforce mode: --enforce makes node exit 1 on drift,
-      # which propagates via pipefail and turns the step red. Do NOT add `|| true`.
+      # Diff the derived block in enforce mode: --enforce makes node exit 1 on drift, and the
+      # step must go red. Do NOT add `|| true`.
+      #
+      # `shell: bash` and the explicit `set -o pipefail` are load-bearing, not decoration. A `run:`
+      # step with no `shell:` key runs under `bash -e {0}` — WITHOUT pipefail — so `node … | tee`
+      # exits with tee's status and the step passed while printing the drift it had just detected.
+      # Measured: `bash -e -c 'false | tee /dev/null'` exits 0; the same under `-o pipefail` aborts.
+      # This step carried a comment claiming pipefail propagation for as long as it has existed, so
+      # the check was documented as enforcing, believed to be enforcing, and was not (#3053).
       - name: Regenerate & diff derived block
         if: env.APP_RO_TOKEN != ''
         working-directory: openbank-admin-ui
+        shell: bash
         run: |
+          set -euo pipefail
           node scripts/generate-app-status.mjs \
             --app-repo "${GITHUB_WORKSPACE}/.app-src" \
             --against app-status.json \

--- a/openbank-admin-ui/app-status.json
+++ b/openbank-admin-ui/app-status.json
@@ -9,10 +9,10 @@
     "owner": "customer-app team",
     "repo": "JiRaska/openbank-app"
   },
-  "asOf": "2026-06-08",
+  "asOf": "2026-07-29",
   "appRepo": "JiRaska/openbank-app",
   "derived": {
-    "version": "0.4.0",
+    "version": "0.11.0",
     "useFakeData": false,
     "edgeBaseUrl": "https://customer.open-bank.tech",
     "keycloakIssuer": "https://kc.open-bank.tech/realms/openbank-customers",
@@ -136,8 +136,8 @@
         "ADR-0066"
       ],
       "gap": {
-        "cs": "Kompletní Authorization Code + PKCE flow ve sdíleném AuthService (commonMain, unit-testováno): S256 challenge, state proti CSRF, OIDC nonce, výměna kódu, persistnce tokenů s expirací, proaktivní refresh (refresh_token) a RP-initiated logout. Platformy dodávají jen systémový prohlížeč (ASWebAuthenticationSession / Custom Tabs + redirect Activity). Zbývá: ověření na fyzickém zařízení (deeplink round-trip).",
-        "en": "Complete Authorization Code + PKCE flow in the shared AuthService (commonMain, unit-tested): S256 challenge, CSRF state, OIDC nonce, code exchange, token persistence with expiry, proactive refresh (refresh_token) and RP-initiated logout. Platforms contribute only the system browser (ASWebAuthenticationSession / Custom Tabs + redirect Activity). Remaining: on-device verification of the deeplink round-trip."
+        "cs": "Kompletní Authorization Code + PKCE flow ve sdíleném AuthService (commonMain, unit-testováno): S256 challenge, state proti CSRF, OIDC nonce, výměna kódu, persistnce tokenů s expirací, proaktivní refresh (refresh_token) a RP-initiated logout. P0 zpevnění je PŘIPRAVENÉ, ale ZATÍM NEAKTIVNÍ: claimed HTTPS app/universal link (https://open-bank.tech/app/oauth/callback) má hotové AASA i assetlinks.json, ale realm ho ještě neregistruje (open-bank-oss #2814 je otevřený) — živý authorize endpoint na něj vrací 400 invalid redirect_uri, takže app zatím používá privátní scheme. Přepnout až po merge #2814 a nasazení realmu.",
+        "en": "Complete Authorization Code + PKCE flow in the shared AuthService (commonMain, unit-tested): S256 challenge, CSRF state, OIDC nonce, code exchange, token persistence with expiry, proactive refresh (refresh_token) and RP-initiated logout. The P0 hardening is BUILT but NOT YET ACTIVE: the claimed HTTPS app/universal link (https://open-bank.tech/app/oauth/callback) has its AASA and assetlinks.json served, but the realm does not register it yet (open-bank-oss #2814 is still open) — the live authorize endpoint answers it with 400 invalid redirect_uri, so the app still uses the private scheme. Flip it once #2814 merges and the realm is deployed."
       },
       "derivedStatus": "live"
     },
@@ -155,8 +155,8 @@
         "ADR-0073"
       ],
       "gap": {
-        "cs": "Android: tokeny šifrované AES-256-GCM klíčem v AndroidKeyStore (StrongBox fallback) — už ne in-memory. iOS: tokeny v Keychain (WhenUnlockedThisDeviceOnly). Zbývající mezera: iOS PIN může degradovat na nešifrovaný NSUserDefaults, když selže Keychain bridge (zpevnění ADR-0073).",
-        "en": "Android: tokens encrypted with an AES-256-GCM key in AndroidKeyStore (StrongBox fallback) — no longer in-memory. iOS: tokens in the Keychain (WhenUnlockedThisDeviceOnly). Residual gap: the iOS PIN can degrade to unencrypted NSUserDefaults if the Keychain bridge fails (hardening tracked by ADR-0073)."
+        "cs": "Android: tokeny šifrované AES-256-GCM klíčem v AndroidKeyStore (StrongBox fallback). iOS: tokeny v Keychain (WhenUnlockedThisDeviceOnly) — P0 zpevnění: plaintext NSUserDefaults fallback pro tokeny i PIN odstraněn, úložiště je fail-closed (chyba Keychainu = konec relace, ne degradace), staré plaintext kopie se při prvním spuštění mažou.",
+        "en": "Android: tokens encrypted with an AES-256-GCM key in AndroidKeyStore (StrongBox fallback). iOS: tokens in the Keychain (WhenUnlockedThisDeviceOnly) — P0 hardening: the plaintext NSUserDefaults fallback for tokens and the PIN is removed, the store is fail-closed (Keychain failure = session ends, no downgrade), legacy plaintext copies are wiped on first launch."
       },
       "derivedStatus": "live"
     },
@@ -174,8 +174,8 @@
         "ADR-0021"
       ],
       "gap": {
-        "cs": "iOS: Secure Enclave (P-256, gated biometrikou). Android: P-256 v AndroidKeyStore (StrongBox/TEE), ECDSA podpis, export X.509 SPKI — už ne stub. Zbývá: per-signature biometrika (zatím per-key-creation, F2).",
-        "en": "iOS: Secure Enclave (P-256, biometric-gated). Android: P-256 in AndroidKeyStore (StrongBox/TEE), ECDSA signing, X.509 SPKI export — no longer a stub. Remaining: per-signature biometrics (currently per-key-creation, F2)."
+        "cs": "iOS: Secure Enclave (P-256, gated biometrikou). Android: P-256 v AndroidKeyStore (StrongBox/TEE), ECDSA podpis, export X.509 SPKI. P0 zpevnění: per-signature biometrika na obou platformách — Android klíč má setUserAuthenticationRequired s nulovým oknem, každý podpis vyžaduje čerstvý BiometricPrompt nad částkou/měnou/příjemcem (dynamic linking, RTS Art. 5); staré klíče bez auth požadavku jsou vyřazeny (v2 alias, jednorázová re-enrolace).",
+        "en": "iOS: Secure Enclave (P-256, biometric-gated). Android: P-256 in AndroidKeyStore (StrongBox/TEE), ECDSA signing, X.509 SPKI export. P0 hardening: per-signature biometrics on both platforms — the Android key requires user authentication with a zero validity window, every signature passes a fresh BiometricPrompt over amount/currency/payee (dynamic linking, RTS Art. 5); legacy keys without the auth requirement are retired (v2 alias, one-time re-enrolment)."
       },
       "derivedStatus": "live"
     },
@@ -257,6 +257,100 @@
       }
     },
     {
+      "id": "contract-gates",
+      "title": {
+        "cs": "Kontraktové brány edge ↔ app",
+        "en": "Edge ↔ app contract gates"
+      },
+      "lens": [
+        "technology",
+        "governance"
+      ],
+      "status": "live",
+      "adr": [
+        "ADR-0074"
+      ],
+      "gap": {
+        "cs": "Snapshot edge OpenAPI je 1.21.0 (35 schémat, 48 cest); EdgeContractTest kryje 14 DTO, EdgeRouteCoverageTest drží ratchet nad všemi 77 app-volánými routami (36 covered, 41 známých gapů — seznam se jen zmenšuje). PR gate (edge-contract-gate.yml) blokuje merge při driftu proti živému OpenAPI. Test odhalil reálný drift: phantom pole TxDto odstraněna, schémata Balance/Pagination opravena v open-bank-oss. Zbývá: dospecifikovat 41 rout na backendu a vygenerovat klienta z OpenAPI.",
+        "en": "The edge OpenAPI snapshot is 1.21.0 (35 schemas, 48 paths); EdgeContractTest covers 14 DTOs, EdgeRouteCoverageTest holds a ratchet over all 77 app-called routes (36 covered, 41 known gaps — the list only shrinks). A PR gate (edge-contract-gate.yml) blocks merges on drift against the live OpenAPI. The test caught real drift: phantom TxDto fields removed, Balance/Pagination schemas fixed in open-bank-oss. Remaining: spec the 41 routes on the backend and generate the client from OpenAPI."
+      }
+    },
+    {
+      "id": "fail-closed-reads",
+      "title": {
+        "cs": "Fail-closed čtení dat (DataResult)",
+        "en": "Fail-closed data reads (DataResult)"
+      },
+      "lens": [
+        "technology",
+        "governance"
+      ],
+      "status": "partial",
+      "adr": [
+        "ADR-0074"
+      ],
+      "gap": {
+        "cs": "Loans/Cards/SDD/StandingOrder/Consents/Disputes list API vracejí DataResult (Ok / Failed: UNAUTHORIZED/NETWORK/SERVER) místo spolknutí chyby do prázdného seznamu — „nemáte půjčky“ ≠ „banka je nedostupná“; každá obrazovka má poctivý error stav. Hard-401 hlásí API vrstva přes SessionGuard → forced re-auth. Zbývá: rozšířit DataResult na zbylé čtecí API (pockets, fees, instant payments, documents, notifications) a odstranit ~15 zbývajících error-swallow míst.",
+        "en": "Loans/Cards/SDD/StandingOrder/Consents/Disputes list APIs return DataResult (Ok / Failed: UNAUTHORIZED/NETWORK/SERVER) instead of swallowing errors into empty lists — \"no loans\" ≠ \"bank unreachable\"; every screen has an honest error state. Hard 401s are reported by the API layer via SessionGuard → forced re-auth. Remaining: extend DataResult to the other read APIs (pockets, fees, instant payments, documents, notifications) and remove the ~15 remaining error-swallow sites."
+      }
+    },
+    {
+      "id": "native-tests",
+      "title": {
+        "cs": "Nativní testy iOS v CI",
+        "en": "Native iOS tests in CI"
+      },
+      "lens": [
+        "technology"
+      ],
+      "status": "live",
+      "adr": [
+        "ADR-0075"
+      ],
+      "gap": {
+        "cs": "iOS unit testy se linkují a běží na simulátoru: :shared:downloadSentryCocoa stáhne verzově párovaný Sentry.xcframework (8.58.2 = SPM v project.yml) a test link dostane jeho slice + Swift back-compat lib dir. iosSimulatorArm64Test pro :shared i :composeApp je krok v app-build.yml (runner potřebuje dostupný iPhone simulátor).",
+        "en": "iOS unit tests link and run on the simulator: :shared:downloadSentryCocoa fetches the version-matched Sentry.xcframework (8.58.2 = the SPM pin in project.yml) and the test link gets its slice + the Swift back-compat lib dir. iosSimulatorArm64Test for :shared and :composeApp is a step in app-build.yml (the runner needs an available iPhone simulator)."
+      }
+    },
+    {
+      "id": "security-pipeline",
+      "title": {
+        "cs": "Bezpečnostní CI pipeline",
+        "en": "Security CI pipeline"
+      },
+      "lens": [
+        "security",
+        "governance"
+      ],
+      "status": "live",
+      "adr": [
+        "ADR-0066"
+      ],
+      "gap": {
+        "cs": "app-security.yml: dependency CVE gate (High+ blokuje merge), gitleaks secret scan (PR + týdenní full-history), explicitní pinning/auth/contract unit gate. MoneyPathChaosTest hlídá money-path invarianty (idempotence, žádné tiché retry). Zbývá P2: MobSF/MASTG binární scan store artefaktů a MITM pinning test přes proxy.",
+        "en": "app-security.yml: dependency CVE gate (High+ blocks merges), gitleaks secret scan (per-PR + weekly full-history), explicit pinning/auth/contract unit gate. MoneyPathChaosTest guards money-path invariants (idempotency, no silent retries). Remaining P2: MobSF/MASTG binary scanning of store artifacts and a MITM pinning test via proxy."
+      }
+    },
+    {
+      "id": "accessibility",
+      "title": {
+        "cs": "Přístupnost (WCAG 2.2 AA)",
+        "en": "Accessibility (WCAG 2.2 AA)"
+      },
+      "lens": [
+        "technology",
+        "governance"
+      ],
+      "status": "partial",
+      "adr": [
+        "ADR-0074"
+      ],
+      "gap": {
+        "cs": "Zahájeno u kritických flow: PIN klávesnice (číslice/delete/biometrika s contentDescription + Button rolí), stav PIN teček („N z 6 číslic“), hold-to-confirm tlačítko s semantics. Zbývá: program přes všech 42 obrazovek — TalkBack/VoiceOver průchod kritickými cestami, Dynamic Type, kontrasty, focus order, touch targets — cíl WCAG 2.2 AA.",
+        "en": "Started with the critical flows: the PIN pad (digits/delete/biometrics with contentDescription + Button role), the PIN dots state (\"N of 6 digits\"), the hold-to-confirm button semantics. Remaining: a program across all 42 screens — TalkBack/VoiceOver walkthroughs of critical paths, Dynamic Type, contrast, focus order, touch targets — targeting WCAG 2.2 AA."
+      }
+    },
+    {
       "id": "dossier",
       "title": {
         "cs": "Living dossier (plán vs realita)",
@@ -276,10 +370,10 @@
     }
   ],
   "summary": {
-    "total": 13,
+    "total": 18,
     "byStatus": {
-      "live": 10,
-      "partial": 2,
+      "live": 13,
+      "partial": 4,
       "planned": 1
     },
     "decisionMissing": []


### PR DESCRIPTION
Closes #3053.

The issue was filed as "advisory over a generated artifact". Looking at the workflow, it is worse
than that: the check **is** written to enforce, and does not.

## The step passed while printing its own failure

```yaml
# Diff the derived block in enforce mode: --enforce makes node exit 1 on drift,
# which propagates via pipefail and turns the step red. Do NOT add `|| true`.
- name: Regenerate & diff derived block
  run: |
    node scripts/generate-app-status.mjs … --enforce --check | tee "${RUNNER_TEMP:-/tmp}/app-status-check.txt"
```

It does not propagate. A `run:` step with no `shell:` key runs under `bash -e {0}` — **without**
pipefail. GitHub only adds `-o pipefail` when you write `shell: bash` explicitly. So the pipeline
exits with `tee`'s status and the step is green.

Measured rather than taken from docs:

```
bash -e           -c 'false | tee /dev/null'   -> exit 0    (step green)
bash -eo pipefail -c 'false | tee /dev/null'   -> aborts     (step red)
```

That explains the shape of the bug exactly: every affected PR got a red-looking drift comment, and a
green check. The comment came from the output; the status came from `tee`.

An advisory check over a *generated* artifact is already the contradiction `CLAUDE.md` records —
there is no judgement left to exercise, so advisory only makes the drift mergeable. One that merely
*looks* enforcing is worse, because the workflow says otherwise and nobody re-reads a step whose
comment already claims the thing you would go there to check.

Fixed with `shell: bash` plus an explicit `set -euo pipefail`, with the reason recorded in place so
neither gets tidied away as redundant.

## And the artifact itself

Regenerated against `openbank-app` at its current default branch:

| | committed | actual |
| --- | --- | --- |
| `derived.version` | 0.4.0 | **0.11.0** |
| capabilities | 13 | **18** (live 13, partial 4, planned 1) |

So the console's customer-app dossier (ADR-0074) — a page whose entire purpose is to state what the
customer app can currently do — was understating it by seven minor versions.

Note the issue quoted 0.9.7 from this morning's CI run; the app moved again since, which is the
point: this artifact drifts continuously and only a working gate keeps it honest.

I regenerated from a clean worktree of `origin/main` rather than from the local checkout, which was
stale at 0.9.1 — regenerating from that would have swapped one wrong number for another.

## Falsification

- version put back to `0.4.0` → generator exits **1**, and the piped step **dies** under pipefail
  (the "STEP WOULD BE GREEN" marker after the pipe never prints);
- regenerated file → generator exits **0**, check reports `✓ derived block matches`.

## Consequence worth stating

With the step actually enforcing, an admin-ui PR will go red whenever `openbank-app` has moved and no
publish PR has landed yet. That is the designed flow — the drift comment already tells you
`openbank-app` CI opens the publish PR — but it has never actually been exercised, because until now
the check could not go red.
