### PR TITLE
fix(ai-platform): stop the litellm crashloop my #3065 caused

### DIFF
--- a/openbank-infra/gitops/components/ai-platform/litellm.yaml
+++ b/openbank-infra/gitops/components/ai-platform/litellm.yaml
@@ -26,7 +26,7 @@ spec:
         # would leave agent-service's repointed call failing "model not found" with a green,
         # in-sync ArgoCD — the same silent-degradation shape as an `optional: true` secret ref.
         # BUMP THIS whenever litellm-config.yaml changes; that is what rolls the pod.
-        openbank.tech/litellm-config-revision: "3"
+        openbank.tech/litellm-config-revision: "4"
     spec:
       securityContext:
         runAsNonRoot: true
@@ -69,32 +69,21 @@ spec:
                   name: litellm-secrets
                   key: LITELLM_MASTER_KEY
                   optional: true
-            # Postgres (CNPG litellm-db) — the prerequisite for virtual keys, which are the only
-            # mechanism that enforces a spend ceiling per CALLER rather than per model. Also what
-            # makes spend counters survive a restart: without a DB LiteLLM holds them in memory and
-            # every pod restart silently resets the budget window to zero.
-            #
-            # `uri` is the ready-made connection string CNPG puts in the -app secret, so there is no
-            # URL assembled from parts here to drift from the credential.
-            #
-            # NOT optional: unlike the provider keys above, a missing DATABASE_URL must not degrade
-            # quietly. Without it the proxy starts, serves traffic and enforces NOTHING — a budget
-            # that silently does not apply is worse than one that was never claimed, because the
-            # dashboards and the ADR both say the ceiling exists.
-            - name: DATABASE_URL
-              valueFrom:
-                secretKeyRef:
-                  name: litellm-db-app
-                  key: uri
-            # Encrypts virtual-key material at rest in that Postgres. Seeded alongside the master
-            # key; optional so the gateway still boots before the seed script has run, which is the
-            # state a fresh environment starts in.
-            - name: LITELLM_SALT_KEY
-              valueFrom:
-                secretKeyRef:
-                  name: litellm-secrets
-                  key: LITELLM_SALT_KEY
-                  optional: true
+            # DATABASE_URL / LITELLM_SALT_KEY are DELIBERATELY NOT SET YET (#3065 -> this PR).
+            # Wiring them made the new ReplicaSet CrashLoopBackOff for 12h / 180 restarts while the
+            # old one kept serving — nothing went red, the Service still answered, ArgoCD said
+            # Synced. Three separate causes, each only visible after the previous one was fixed:
+            #   1. this pod is Egress-deny-by-default and 5432 was not on the allow-list
+            #      (fixed in networkpolicy-litellm-egress.yaml, verified TCP_5432_OPEN);
+            #   2. no writable HOME, so Prisma could not create /.cache/prisma-python/binaries
+            #      under uid 1000 — the local docker check missed this because that container ran
+            #      as root;
+            #   3. even past that, the image DOWNLOADS the Prisma CLI and a node runtime at every
+            #      start and is OOMKilled at the 512Mi limit.
+            # (3) is the one that makes this more than a config tweak: it puts an internet download
+            # on the boot path of the very pod that exists to BE the egress choke point (ADR-0175).
+            # That trade needs its own reviewed change, so the DB stays provisioned and unused
+            # rather than half-wired. postgres.yaml and seed-litellm-virtual-keys.sh are kept as-is.
           securityContext:
             allowPrivilegeEscalation: false
             readOnlyRootFilesystem: false

--- a/openbank-infra/gitops/components/ai-platform/networkpolicy-litellm-egress.yaml
+++ b/openbank-infra/gitops/components/ai-platform/networkpolicy-litellm-egress.yaml
@@ -38,3 +38,21 @@ spec:
       ports:
         - protocol: TCP
           port: 443
+    # Its own Postgres (CNPG litellm-db, #3065). MISSING THIS CRASHLOOPED THE GATEWAY: #3065 gave
+    # LiteLLM a DATABASE_URL — the prerequisite for virtual keys and for spend counters that survive
+    # a restart — but this policy is Egress-DENY-by-default for the litellm pod, and 5432 was not on
+    # it. Prisma could not reach the database, so startup failed with "Not connected to the query
+    # engine" and the new ReplicaSet sat in CrashLoopBackOff for 12h / 180 restarts while the old one
+    # kept serving. Nothing went red: the Deployment was simply stuck, the Service still answered
+    # from the old pod, and ArgoCD reported Synced.
+    #
+    # Scoped to the CNPG pods of THIS cluster by label, not to the whole namespace — the choke point
+    # ADR-0175 §4 establishes is about what may leave the cluster, and a same-namespace database
+    # edge does not widen that, but there is no reason to grant more than the one peer it needs.
+    - to:
+        - podSelector:
+            matchLabels:
+              cnpg.io/cluster: litellm-db
+      ports:
+        - protocol: TCP
+          port: 5432


### PR DESCRIPTION
## Summary

#3065 (mine) gave LiteLLM a `DATABASE_URL`. **The new ReplicaSet has never started** — 180 restarts over 12h — while the old one kept serving. This fixes the one clear bug and unwires the rest.

## Nothing went red

The Service still answered from the old pod, ArgoCD reported **Synced**, and the Deployment was simply stuck. Found by looking at the cluster while setting up something else, not by any alert.

## Three causes, each only visible once the previous was fixed

1. **Egress deny.** The litellm pod is Egress-deny-by-default (`networkpolicy-litellm-egress.yaml`, ADR-0175 §4) and 5432 was not on the allow-list, so Prisma could not reach the database at all.
2. **No writable HOME.** Prisma tries to create `/.cache/prisma-python/binaries`; the pod runs as uid 1000 with a non-writable `/`. **The pre-merge check missed this because the local docker container ran as root** — the security context is exactly the difference.
3. **OOMKilled at 512Mi.** Even past (2), the image *downloads* the Prisma CLI and a node runtime on every start and is killed (exit 137).

## What this PR does

**Fixes (1).** An egress rule to the CNPG pods on 5432, scoped by `cnpg.io/cluster: litellm-db` rather than to the namespace — a same-namespace database edge does not widen the ADR-0175 choke point, but there is no reason to grant more than the one peer it needs.

*Verified live:* a probe pod carrying the litellm label reported `TCP_5432_OPEN` after applying it, where it was blocked before.

**Defers the rest.** `DATABASE_URL` and `LITELLM_SALT_KEY` come back out, config revision 3 → 4 to roll the pod. Cause (3) is why: it puts an internet download on the boot path of the very pod that exists to *be* the egress choke point, and needs a materially larger memory limit besides. That trade deserves its own reviewed change, not a hot-patch to clear a crashloop.

## Nothing else is removed

`postgres.yaml` stays (the cluster is healthy and will be needed) and `seed-litellm-virtual-keys.sh` stays. Only the *wiring* is deferred — and the per-agent budgets it would have enabled were already documented in #3065 as inert until each agent is repointed off the shared master key, so **no working capability is lost**.

## Live-diagnosis note

`kubectl set env` / `set resources` were used to isolate causes 2 and 3, and were reverted. The ai-platform Application has `selfHeal`, so hand-patches there are diagnostics only and never a fix — the 512Mi still visible on the pod after `set resources` is ArgoCD having already reverted it, which is also how I confirmed the OOM was at the manifest's limit.

## Linked issues

Refs #3065, ADR-0175

## Definition of Done

- [x] Hexagonal layering — n/a, infra.
- [ ] Tests — n/a; the executable check is the live `TCP_5432_OPEN` probe.
- [x] No new lint warnings (yamllint clean; `gen-network-policies.py` re-run, no diff — this file is deliberately named `networkpolicy-*` so the generator never owns it).
- [x] Docs updated — both manifests carry the reasoning.

## Security checklist

- [x] No secrets, tokens, passwords, or PII.
- [x] The egress hole added is the narrowest that works: one port, one pod-label peer, same namespace. The 0.0.0.0/0:443 provider hole is untouched.
- [x] No auth / crypto / payment code changed. No PII or cardholder path changed.

## Compliance impact

- [x] DORA — restores the gateway Deployment to a state that can actually roll.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
