### PR TITLE
fix(fx): price a pair from its reverse quote instead of answering 404

### DIFF
--- a/openbank-fx-service/src/main/kotlin/com/openbank/fx/application/usecase/FxService.kt
+++ b/openbank-fx-service/src/main/kotlin/com/openbank/fx/application/usecase/FxService.kt
@@ -67,7 +67,23 @@ class FxService(
     }
 
     override suspend fun getRate(query: GetRateQuery) =
-        rateRepo.findLatest(query.baseCurrency, query.quoteCurrency, query.rateType)
+        resolveRate(query.baseCurrency, query.quoteCurrency, query.rateType)
+
+    /**
+     * The quote for base/quote, falling back to the inverse of quote/base when only that
+     * direction is stored.
+     *
+     * The ČNB fixing — the only live source ingested here — publishes FOREIGN→CZK exclusively, so
+     * every stored pair is `X/CZK`. Without this fallback `CZK/EUR` has no answer, which is not a
+     * transient failure: it is every customer-initiated CZK→foreign exchange, permanently. The
+     * customer edge turns the resulting null into `fx_rate_unavailable` + HTTP 502, so the app
+     * reports a gateway error for what is really a missing derivation.
+     *
+     * Inversion swaps bid and ask — see [FxRate.inverted].
+     */
+    private suspend fun resolveRate(base: String, quote: String, type: RateType): FxRate? =
+        rateRepo.findLatest(base, quote, type)
+            ?: rateRepo.findLatest(quote, base, type)?.inverted()
 
     override suspend fun getAllRates() = rateRepo.findAll()
 
@@ -83,7 +99,9 @@ class FxService(
 
     override suspend fun convert(cmd: ConvertCommand): FxConversion {
         convRepo.findByIdempotencyKey(cmd.idempotencyKey)?.let { return it }
-        val rate = rateRepo.findLatest(cmd.fromCurrency, cmd.toCurrency, RateType.SPOT)
+        // Same resolution as the read path: a conversion must not be refused for a pair the bank
+        // can price perfectly well from the other side.
+        val rate = resolveRate(cmd.fromCurrency, cmd.toCurrency, RateType.SPOT)
             ?: error("No FX rate available for ${cmd.fromCurrency}/${cmd.toCurrency}")
         require(rate.isValid(Instant.now(clock))) { "FX rate expired for ${cmd.fromCurrency}/${cmd.toCurrency}" }
 

--- a/openbank-fx-service/src/main/kotlin/com/openbank/fx/domain/model/FxRate.kt
+++ b/openbank-fx-service/src/main/kotlin/com/openbank/fx/domain/model/FxRate.kt
@@ -28,6 +28,36 @@ data class FxRate(
     val midRate: BigDecimal get() = (bidRate + askRate).divide(BigDecimal.TWO)
     val spread: BigDecimal get() = askRate - bidRate
     fun isValid(at: Instant = Instant.EPOCH) = at.isAfter(validFrom) && at.isBefore(validTo)
+
+    /**
+     * The same quote read from the other side: CZK/EUR out of EUR/CZK.
+     *
+     * Needed because the ČNB fixing — the only live source this platform ingests — publishes
+     * FOREIGN→CZK exclusively. Every stored pair is therefore `X/CZK`, and a customer selling
+     * CZK to buy EUR asks for a pair that has never existed and never will. There is no amount
+     * of retrying that fixes that.
+     *
+     * **The sides swap, and that is the whole point.** The bank BUYS the base at [bidRate] and
+     * SELLS it at [askRate]; in the inverted pair those roles trade places, so
+     * `inverted().bidRate = 1 / askRate` and `inverted().askRate = 1 / bidRate`. Taking a naive
+     * `1 / bidRate` for both would quote the customer the wrong side of the spread on every
+     * CZK→foreign exchange — a systematic loss, in the customer's favour on one leg and the
+     * bank's on the other, which is exactly the kind of error that does not announce itself.
+     *
+     * [id] is carried over unchanged: this is a view of the SAME quote, not a new one, and
+     * FxConversion.rateId must keep pointing at the row the price came from.
+     */
+    fun inverted(): FxRate = copy(
+        baseCurrency = quoteCurrency,
+        quoteCurrency = baseCurrency,
+        bidRate = BigDecimal.ONE.divide(askRate, INVERSE_SCALE, RoundingMode.HALF_UP),
+        askRate = BigDecimal.ONE.divide(bidRate, INVERSE_SCALE, RoundingMode.HALF_UP),
+    )
+
+    private companion object {
+        /** Matches the numeric(18,8) the rates are stored at, so a round trip does not drift. */
+        const val INVERSE_SCALE = 8
+    }
 }
 
 data class FxConversion(

--- a/openbank-fx-service/src/test/kotlin/com/openbank/fx/application/usecase/FxServiceTest.kt
+++ b/openbank-fx-service/src/test/kotlin/com/openbank/fx/application/usecase/FxServiceTest.kt
@@ -107,13 +107,59 @@ class FxServiceTest {
     }
 
     @Test
-    fun `convert throws error when no FX rate available`() = runBlocking<Unit> {
+    fun `convert throws error when no FX rate available in either direction`() = runBlocking<Unit> {
         val command = convertCommand()
-        coEvery { rateRepo.findLatest(command.fromCurrency, command.toCurrency, RateType.SPOT) } returns null
+        // Both directions must be absent now: a pair quoted the other way round is priceable.
+        coEvery { rateRepo.findLatest(any(), any(), RateType.SPOT) } returns null
 
         val ex = assertThrows<IllegalStateException> { runBlocking { service.convert(command) } }
 
         assertThat(ex).hasMessage("No FX rate available for EUR/CZK")
+    }
+
+    // --- pricing from the reverse quote ------------------------------------------------------
+    // The ČNB fixing publishes FOREIGN→CZK only, so every stored pair is X/CZK. Before this,
+    // CZK→EUR had no answer at all: not a transient failure but every customer-initiated
+    // CZK→foreign exchange, permanently, surfacing in the app as HTTP 502.
+
+    @Test
+    fun `getRate answers from the reverse quote when only that direction is stored`() = runBlocking<Unit> {
+        coEvery { rateRepo.findLatest("CZK", "EUR", RateType.SPOT) } returns null
+        coEvery { rateRepo.findLatest("EUR", "CZK", RateType.SPOT) } returns fxRate()
+
+        val rate = service.getRate(GetRateQuery("CZK", "EUR", RateType.SPOT))
+
+        assertThat(rate).isNotNull
+        assertThat(rate!!.baseCurrency).isEqualTo("CZK")
+        assertThat(rate.quoteCurrency).isEqualTo("EUR")
+        // 1/25.10 (the ask side), not 1/24.90.
+        assertThat(rate.bidRate).isEqualByComparingTo("0.03984064")
+    }
+
+    @Test
+    fun `a directly stored pair is never overridden by an inverse`() = runBlocking<Unit> {
+        coEvery { rateRepo.findLatest("EUR", "CZK", RateType.SPOT) } returns fxRate()
+
+        val rate = service.getRate(GetRateQuery("EUR", "CZK", RateType.SPOT))
+
+        assertThat(rate!!.bidRate).isEqualByComparingTo("24.90")
+        coVerify(exactly = 0) { rateRepo.findLatest("CZK", "EUR", RateType.SPOT) }
+    }
+
+    @Test
+    fun `convert prices a reverse-quoted pair instead of refusing it`() = runBlocking<Unit> {
+        val command = convertCommand().copy(fromCurrency = "CZK", toCurrency = "EUR")
+        coEvery { rateRepo.findLatest("CZK", "EUR", RateType.SPOT) } returns null
+        coEvery { rateRepo.findLatest("EUR", "CZK", RateType.SPOT) } returns fxRate()
+        coEvery { convRepo.saveWithOutbox(any(), any()) } answers { firstArg() }
+        clear()
+
+        val conv = service.convert(command)
+
+        // convert() charges the ASK side, and after inversion the ask is 1/24.90 — the customer
+        // buying EUR pays the bank's selling price, exactly as they would on a directly quoted
+        // pair. (The inverted BID, 1/25.10, is what a customer SELLING EUR would receive.)
+        assertThat(conv.appliedRate).isEqualByComparingTo("0.04016064")
     }
 
     @Test

--- a/openbank-fx-service/src/test/kotlin/com/openbank/fx/domain/model/FxRateTest.kt
+++ b/openbank-fx-service/src/test/kotlin/com/openbank/fx/domain/model/FxRateTest.kt
@@ -36,6 +36,65 @@ class FxRateTest {
         assertThat(rate.spread).isEqualByComparingTo("0.04")
     }
 
+    // --- inverting a pair (the ČNB fixing only ever publishes FOREIGN→CZK) -------------------
+
+    @Test
+    fun `inverting swaps the pair`() {
+        val inverted = fxRate().inverted()
+
+        assertThat(inverted.baseCurrency).isEqualTo("CZK")
+        assertThat(inverted.quoteCurrency).isEqualTo("EUR")
+    }
+
+    @Test
+    fun `inverting swaps bid and ask, not just the numbers`() {
+        // EUR/CZK: the bank buys EUR at 24.00, sells it at 25.00. Inverted, the customer selling
+        // CZK to buy EUR must get 1/25.00 — the ASK side — not 1/24.00.
+        val inverted = fxRate(bid = "24.00", ask = "25.00").inverted()
+
+        assertThat(inverted.bidRate).isEqualByComparingTo("0.04")
+        assertThat(inverted.askRate).isEqualByComparingTo("0.04166667")
+        assertThat(inverted.bidRate).isLessThan(inverted.askRate)
+    }
+
+    @Test
+    fun `a naive one-over-bid would quote the wrong side`() {
+        // Guards the mistake this method exists to prevent: 1/bid on both sides hands the
+        // customer the bank's buying price on a sell, on every CZK→foreign exchange.
+        val rate = fxRate(bid = "24.00", ask = "25.00")
+
+        assertThat(rate.inverted().bidRate).isNotEqualByComparingTo(
+            BigDecimal.ONE.divide(rate.bidRate, 8, java.math.RoundingMode.HALF_UP),
+        )
+    }
+
+    @Test
+    fun `inverting twice returns to the original pair and ordering`() {
+        val original = fxRate(bid = "24.00", ask = "25.00")
+        val round = original.inverted().inverted()
+
+        assertThat(round.baseCurrency).isEqualTo(original.baseCurrency)
+        assertThat(round.quoteCurrency).isEqualTo(original.quoteCurrency)
+        assertThat(round.bidRate).isLessThan(round.askRate)
+    }
+
+    @Test
+    fun `the inverted quote keeps the id of the row it was derived from`() {
+        // FxConversion.rateId must still point at the stored quote the price came from.
+        val original = fxRate()
+
+        assertThat(original.inverted().id).isEqualTo(original.id)
+    }
+
+    @Test
+    fun `validity window is unchanged by inverting`() {
+        val original = fxRate()
+        val inverted = original.inverted()
+
+        assertThat(inverted.validFrom).isEqualTo(original.validFrom)
+        assertThat(inverted.validTo).isEqualTo(original.validTo)
+    }
+
     private fun fxRate(
         bid: String = "1.00",
         ask: String = "1.01",


### PR DESCRIPTION
## The 502 in the app's currency exchange

Both exchange screens have failed with `HTTP 502` across three releases. It is not a flake, and it was never a client bug — three client-side fixes could not have worked.

**Root cause, from production data.** The ČNB fixing is the only live rate source ingested, and it publishes FOREIGN→CZK exclusively. The sandbox `fx_rates` table holds exactly six currently-valid pairs:

```
CHF/CZK  EUR/CZK  GBP/CZK  HUF/CZK  PLN/CZK  USD/CZK
```

`grep -rn 'invert|inverse|reciprocal' openbank-fx-service/src/main` → **no matches**. So `GET /api/v1/fx/rates/CZK/EUR` could never be answered. The chain:

`POST /pockets/CZK/exchange` → `planExchange` → `fxBidRate(CZK, EUR)` → 404 → `null` → `SweepPlan.Rejected(BAD_GATEWAY, "fx_rate_unavailable")` → **502**

A customer selling CZK — which is every customer, CZK being the primary currency — was asking for a pair that has never existed and never would.

## The fix

`FxRate.inverted()`, plus a `resolveRate` fallback used by **both** `getRate` and `convert`.

**The sides swap, and that is the whole point.** The bank buys the base at `bidRate` and sells it at `askRate`; inverting trades those roles:

```kotlin
bidRate = 1 / askRate
askRate = 1 / bidRate
```

A naive `1 / bidRate` on both sides would quote the customer the wrong side of the spread on every CZK→foreign exchange — a systematic mispricing, in the customer's favour on one leg and the bank's on the other, which is exactly the kind of error that does not announce itself. `a naive one-over-bid would quote the wrong side` exists to fail if anyone simplifies it back.

Other properties held: a directly stored pair always wins (the inverse is only a fallback, and there is a test that the direct pair is never overridden); the derived quote keeps the `id` of the row it came from, so `FxConversion.rateId` still points at the row the price came from; the validity window is unchanged.

## Verification

- `FxRateTest` 9/9, `FxServiceTest` 19/19, `:openbank-fx-service:detekt` — BUILD SUCCESSFUL locally.
- The six-pair list above was read from the live sandbox `fx` database, not inferred.

## Second defect, tracked separately

customer-edge returns `{"error":"fx_rate_unavailable"}` in the body and the app *parses it into a `code` field* — then renders `message`, i.e. `"HTTP 502"`. The diagnosis was in the response the whole time and the UI threw it away. Fixed on the app side (openbank-app), not here.

Refs #2314
