### PR TITLE
feat(admin-ui): a four-eyes console for credit compliance pack activation

### DIFF
--- a/openbank-admin-ui/src/app/lending/compliance-packs/page.tsx
+++ b/openbank-admin-ui/src/app/lending/compliance-packs/page.tsx
@@ -1,0 +1,339 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright (c) OpenBank contributors. Licensed under the Apache License, Version 2.0.
+// See LICENSE in the repository root or https://www.apache.org/licenses/LICENSE-2.0 for details.
+
+// ADR-0212 D4 — the four-eyes activation console for jurisdictional credit compliance packs.
+//
+// Why this screen exists: activating a pack was reachable only by hand-driving
+// POST /compliance-packs/proposals and .../decide with two separately-minted operator tokens.
+// A control that needs a shell is a control nobody exercises — and
+// `openbank.lending.compliance.enforce-pack` must stay false until a pack is active, because with
+// enforcement on and no active pack every origination is REFUSED. The gate and the only way
+// through it belong in the same place.
+//
+// Maker != checker is NOT enforced here. The service raises MakerCheckerViolation (422) when one
+// principal tries both halves, and this page renders that refusal verbatim. A client-side copy of
+// the rule would only hide the real control behind a weaker one.
+
+'use client'
+
+import { useCallback, useEffect, useMemo, useState } from 'react'
+import { useSession } from 'next-auth/react'
+import { CheckCircle2, XCircle, Clock, RefreshCw, ShieldCheck, ScrollText, AlertTriangle } from 'lucide-react'
+import { useLanguage } from '@/lib/i18n/LanguageContext'
+import { svcUrl } from '@/lib/services/bff'
+
+/** Mirrors lending-service `PackActivationView`. `listActive()` synthesises id = all-zero UUID for
+ *  every row (it projects the in-memory registry, not a workflow row) — never key a list on it. */
+type PackActivationView = {
+  id: string
+  jurisdiction: string
+  productType: string
+  packVersion: number
+  effectiveFrom: string
+  contentHash: string
+  state: string
+  proposedBy: string
+  decidedBy: string | null
+  decidedAt: string | null
+}
+
+/** A read that was REFUSED must never render as "nothing pending" — same reasoning as /approvals
+ *  (ADR-0227 D2): an approvals screen wrongly saying "nothing to do" is its worst failure. */
+type SourceState = 'ok' | 'forbidden' | 'unavailable'
+
+function stateFor(status: number): SourceState {
+  return status === 401 || status === 403 ? 'forbidden' : 'unavailable'
+}
+
+const PACKS_BASE = '/api/v1/lending/compliance-packs'
+const cell = { padding: '10px 14px' } as const
+const th = { padding: '10px 14px', fontSize: 11, color: 'var(--text-tertiary)' } as const
+
+export default function CompliancePacksPage() {
+  const { t } = useLanguage()
+  const { data: session } = useSession()
+  const actor = session?.user?.email || session?.user?.name || null
+
+  const [active, setActive] = useState<PackActivationView[]>([])
+  const [pending, setPending] = useState<PackActivationView[]>([])
+  const [sources, setSources] = useState<Record<string, SourceState>>({})
+  const [loading, setLoading] = useState(true)
+  const [busyId, setBusyId] = useState<string | null>(null)
+  const [error, setError] = useState<string | null>(null)
+  const [notice, setNotice] = useState<string | null>(null)
+  const [reasons, setReasons] = useState<Record<string, string>>({})
+  const [packJson, setPackJson] = useState('')
+
+  const load = useCallback(async () => {
+    setLoading(true)
+    try {
+      const [activeRes, pendingRes] = await Promise.all([
+        fetch(svcUrl('lending-service', `${PACKS_BASE}/active`), { cache: 'no-store' }),
+        fetch(svcUrl('lending-service', `${PACKS_BASE}/proposals/pending`), { cache: 'no-store' }),
+      ])
+      const next: Record<string, SourceState> = {}
+      if (activeRes.ok) {
+        const rows = await activeRes.json()
+        setActive(Array.isArray(rows) ? rows : [])
+        next.active = 'ok'
+      } else {
+        setActive([])
+        next.active = stateFor(activeRes.status)
+      }
+      if (pendingRes.ok) {
+        const rows = await pendingRes.json()
+        setPending(Array.isArray(rows) ? rows : [])
+        next.pending = 'ok'
+      } else {
+        setPending([])
+        next.pending = stateFor(pendingRes.status)
+      }
+      setSources(next)
+      setError(null)
+    } catch {
+      setActive([])
+      setPending([])
+      setSources({ active: 'unavailable', pending: 'unavailable' })
+      setError(t('lending-service je nedostupný.', 'lending-service is unreachable.'))
+    } finally {
+      setLoading(false)
+    }
+  }, [t])
+
+  useEffect(() => { void load() }, [load])
+
+  /** Surface the service's own message. A 422 here is the maker-checker refusal — the single most
+   *  important thing this screen can say. Never flatten it to a generic "failed". */
+  const failWith = async (res: Response, fallback: string) => {
+    const body = await res.json().catch(() => ({} as { error?: string }))
+    setError(body?.error || `${fallback} (HTTP ${res.status})`)
+  }
+
+  const propose = async () => {
+    let parsed: unknown
+    try {
+      parsed = JSON.parse(packJson)
+    } catch {
+      setError(t('Pack není platný JSON.', 'Pack is not valid JSON.'))
+      return
+    }
+    setBusyId('propose')
+    setNotice(null)
+    try {
+      const res = await fetch(svcUrl('lending-service', `${PACKS_BASE}/proposals`), {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify(parsed),
+      })
+      if (!res.ok) {
+        await failWith(res, t('Návrh se nezdařil', 'Proposal failed'))
+        return
+      }
+      setError(null)
+      setPackJson('')
+      setNotice(t(
+        'Návrh zapsán. Aktivuje ho AŽ jiný compliance principál — ne vy.',
+        'Proposal recorded. It activates only once a DIFFERENT compliance principal decides it — not you.',
+      ))
+      await load()
+    } catch {
+      setError(t('lending-service je nedostupný.', 'lending-service is unreachable.'))
+    } finally {
+      setBusyId(null)
+    }
+  }
+
+  const decide = async (id: string, approve: boolean) => {
+    setBusyId(id)
+    setNotice(null)
+    try {
+      const res = await fetch(svcUrl('lending-service', `${PACKS_BASE}/proposals/${id}/decide`), {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ approve, reason: reasons[id] || null }),
+      })
+      if (!res.ok) {
+        await failWith(res, t('Rozhodnutí se nezdařilo', 'Decision failed'))
+        return
+      }
+      setError(null)
+      setNotice(approve
+        ? t('Pack aktivován. Guard ho používá okamžitě, bez restartu služby.',
+            'Pack activated. The origination guard uses it immediately — no service restart.')
+        : t('Návrh zamítnut.', 'Proposal rejected.'))
+      await load()
+    } catch {
+      setError(t('lending-service je nedostupný.', 'lending-service is unreachable.'))
+    } finally {
+      setBusyId(null)
+    }
+  }
+
+  const degraded = useMemo(
+    () => Object.entries(sources).filter(([, v]) => v !== 'ok').map(([k]) => k),
+    [sources],
+  )
+
+  return (
+    <div>
+      <div className="page-header">
+        <div>
+          <div className="breadcrumb">
+            <span>OpenBank</span><span className="breadcrumb-sep">/</span>
+            <span>{t('Úvěry', 'Lending')}</span><span className="breadcrumb-sep">/</span>
+            <span className="breadcrumb-current">{t('Compliance packy', 'Compliance packs')}</span>
+          </div>
+          <h1 className="page-title" style={{ display: 'flex', alignItems: 'center', gap: 8 }}>
+            <ShieldCheck size={18} style={{ color: 'var(--accent)' }} />
+            {t('Aktivace compliance packů', 'Compliance pack activation')}
+          </h1>
+          <p className="page-subtitle">
+            {t(
+              'Jurisdikční úvěrové compliance packy (ADR-0212 D4). Maker navrhne, JINÝ compliance principál rozhodne. Aktivovaný pack platí okamžitě — bez release služby.',
+              'Jurisdictional credit compliance packs (ADR-0212 D4). A maker proposes, a DIFFERENT compliance principal decides. An activated pack takes effect immediately — no service release.',
+            )}
+          </p>
+          {actor && (
+            <p className="page-subtitle" data-testid="acting-as">
+              {t('Jednáte jako', 'Acting as')}: <strong>{actor}</strong>
+            </p>
+          )}
+        </div>
+        <button onClick={() => void load()} disabled={loading} className="btn btn-secondary" style={{ display: 'flex', alignItems: 'center', gap: 6, fontSize: 12 }}>
+          <RefreshCw size={14} className={loading ? 'animate-spin' : ''} /> {t('Obnovit', 'Refresh')}
+        </button>
+      </div>
+
+      {degraded.length > 0 && (
+        <div className="card" data-testid="degraded" style={{ padding: 12, marginBottom: 16, borderLeft: '3px solid var(--warning)', fontSize: 13, display: 'flex', alignItems: 'center', gap: 6 }}>
+          <AlertTriangle size={14} />
+          {t(
+            `Nepřečteno (403 / nedostupné): ${degraded.join(', ')} — prázdný seznam NEZNAMENÁ, že nic nečeká.`,
+            `Not read (403 / unavailable): ${degraded.join(', ')} — an empty list does NOT mean nothing is pending.`,
+          )}
+        </div>
+      )}
+      {error && (
+        <div className="card" data-testid="error" style={{ padding: 12, marginBottom: 16, borderLeft: '3px solid var(--danger)', color: 'var(--danger)', fontSize: 13 }}>
+          {error}
+        </div>
+      )}
+      {notice && (
+        <div className="card" data-testid="notice" style={{ padding: 12, marginBottom: 16, borderLeft: '3px solid var(--success)', fontSize: 13 }}>
+          {notice}
+        </div>
+      )}
+
+      <div className="section-title" style={{ display: 'flex', alignItems: 'center', gap: 6 }}>
+        <CheckCircle2 size={15} /> {t('Aktivní packy', 'Active packs')} ({active.length})
+      </div>
+      <div className="card" style={{ padding: 0, overflow: 'hidden', marginBottom: 24 }}>
+        <table style={{ width: '100%', borderCollapse: 'collapse', fontSize: 13 }}>
+          <thead>
+            <tr style={{ background: 'var(--surface-2)', textAlign: 'left' }}>
+              <th style={th}>{t('Jurisdikce', 'Jurisdiction')}</th>
+              <th style={th}>{t('Produkt', 'Product')}</th>
+              <th style={th}>{t('Verze', 'Version')}</th>
+              <th style={th}>{t('Účinnost od', 'Effective from')}</th>
+              <th style={th}>{t('Otisk obsahu', 'Content hash')}</th>
+            </tr>
+          </thead>
+          <tbody>
+            {active.map(p => (
+              <tr key={`${p.jurisdiction}-${p.productType}-${p.packVersion}`} style={{ borderTop: '1px solid var(--border)' }}>
+                <td style={cell}>{p.jurisdiction}</td>
+                <td style={cell}>{p.productType}</td>
+                <td style={cell}>v{p.packVersion}</td>
+                <td style={cell}>{p.effectiveFrom}</td>
+                <td style={{ ...cell, fontSize: 11 }} className="mono">{p.contentHash.slice(0, 16)}…</td>
+              </tr>
+            ))}
+            {active.length === 0 && (
+              <tr><td colSpan={5} data-testid="no-active" style={{ padding: 20, textAlign: 'center', color: 'var(--text-tertiary)', fontSize: 13 }}>
+                {sources.active === 'ok'
+                  ? t(
+                      'Žádný aktivní pack. Dokud je tu prázdno, nesmí se zapnout LENDING_ENFORCE_PACK — s vynucením a bez packu je každá žádost ODMÍTNUTA.',
+                      'No active pack. While this is empty, LENDING_ENFORCE_PACK must not be turned on — with enforcement on and no pack, every application is REFUSED.',
+                    )
+                  : t('Nenačteno.', 'Not loaded.')}
+              </td></tr>
+            )}
+          </tbody>
+        </table>
+      </div>
+
+      <div className="section-title" style={{ display: 'flex', alignItems: 'center', gap: 6 }}>
+        <Clock size={15} /> {t('Čeká na druhý pár očí', 'Awaiting a checker')} ({pending.length})
+      </div>
+      <div className="card" style={{ padding: 0, overflow: 'hidden', marginBottom: 24 }}>
+        {pending.map(p => (
+          <div
+            key={p.id}
+            data-testid={`proposal-${p.id}`}
+            style={{ display: 'flex', gap: 12, alignItems: 'center', justifyContent: 'space-between', padding: '12px 14px', borderTop: '1px solid var(--border)', flexWrap: 'wrap' }}
+          >
+            <div style={{ fontSize: 13 }}>
+              <div>
+                {p.jurisdiction} / {p.productType} · <strong>v{p.packVersion}</strong> ·{' '}
+                {t('účinnost od', 'effective from')} {p.effectiveFrom}
+              </div>
+              <div style={{ color: 'var(--text-tertiary)', fontSize: 12 }}>
+                {t('Navrhl', 'Proposed by')}: {p.proposedBy} · <span className="mono">{p.contentHash.slice(0, 16)}…</span>
+              </div>
+            </div>
+            <div style={{ display: 'flex', gap: 8, alignItems: 'center' }}>
+              <input
+                className="input"
+                type="text"
+                aria-label={t('Důvod rozhodnutí', 'Decision reason')}
+                placeholder={t('Důvod (volitelný)', 'Reason (optional)')}
+                value={reasons[p.id] ?? ''}
+                onChange={e => setReasons(r => ({ ...r, [p.id]: e.target.value }))}
+                style={{ fontSize: 12 }}
+              />
+              <button className="btn btn-primary" disabled={busyId === p.id} onClick={() => void decide(p.id, true)} style={{ fontSize: 12 }}>
+                {t('Schválit', 'Approve')}
+              </button>
+              <button className="btn btn-secondary" disabled={busyId === p.id} onClick={() => void decide(p.id, false)} style={{ fontSize: 12 }}>
+                {t('Zamítnout', 'Reject')}
+              </button>
+            </div>
+          </div>
+        ))}
+        {pending.length === 0 && (
+          <div data-testid="no-pending" style={{ padding: 20, textAlign: 'center', color: 'var(--text-tertiary)', fontSize: 13 }}>
+            {sources.pending === 'ok' ? t('Nic nečeká.', 'Nothing pending.') : t('Nenačteno.', 'Not loaded.')}
+          </div>
+        )}
+      </div>
+
+      <div className="section-title" style={{ display: 'flex', alignItems: 'center', gap: 6 }}>
+        <ScrollText size={15} /> {t('Navrhnout pack (maker)', 'Propose a pack (maker)')}
+      </div>
+      <div className="card" style={{ padding: 14 }}>
+        <p style={{ fontSize: 12, color: 'var(--text-tertiary)', marginTop: 0 }}>
+          {t(
+            'Vložte JSON packu — referenční CZ pack je openbank-lending-service/src/main/resources/compliance-packs/cz-consumer-credit-v1.json. Váš návrh nemá žádný efekt, dokud ho neschválí někdo jiný.',
+            'Paste the pack JSON — the CZ reference pack is openbank-lending-service/src/main/resources/compliance-packs/cz-consumer-credit-v1.json. Your proposal has no effect until someone else approves it.',
+          )}
+        </p>
+        <textarea
+          aria-label={t('JSON packu', 'Pack JSON')}
+          rows={10}
+          value={packJson}
+          onChange={e => setPackJson(e.target.value)}
+          style={{ width: '100%', fontFamily: 'monospace', fontSize: 12, padding: 8, borderRadius: 6, border: '1px solid var(--border)', background: 'var(--surface)', color: 'var(--text)' }}
+        />
+        <button
+          className="btn btn-primary"
+          style={{ marginTop: 8, fontSize: 12 }}
+          disabled={busyId === 'propose' || packJson.trim().length === 0}
+          onClick={() => void propose()}
+        >
+          {t('Navrhnout', 'Propose')}
+        </button>
+      </div>
+    </div>
+  )
+}

--- a/openbank-admin-ui/src/app/lending/compliance-packs/page.tsx
+++ b/openbank-admin-ui/src/app/lending/compliance-packs/page.tsx
@@ -19,7 +19,7 @@
 
 import { useCallback, useEffect, useMemo, useState } from 'react'
 import { useSession } from 'next-auth/react'
-import { CheckCircle2, XCircle, Clock, RefreshCw, ShieldCheck, ScrollText, AlertTriangle } from 'lucide-react'
+import { CheckCircle2, Clock, RefreshCw, ShieldCheck, ScrollText, AlertTriangle } from 'lucide-react'
 import { useLanguage } from '@/lib/i18n/LanguageContext'
 import { svcUrl } from '@/lib/services/bff'
 

--- a/openbank-admin-ui/src/components/layout/Sidebar.tsx
+++ b/openbank-admin-ui/src/components/layout/Sidebar.tsx
@@ -79,6 +79,10 @@ const complianceNav: NavItem[] = [
   { nameCs: 'Kampaně',            nameEn: 'Campaigns',        href: '/campaigns',         icon: Megaphone,             permission: 'compliance:view' },
   { nameCs: 'Segmenty',           nameEn: 'Segments',         href: '/segments',          icon: Target,                permission: 'compliance:view' },
   { nameCs: 'Souhlasy',           nameEn: 'Consents',         href: '/consents',          icon: FileSignature,           permission: 'compliance:view' },
+  // ADR-0212 D4: four-eyes activation of the jurisdictional credit compliance packs. Filed under
+  // compliance, not lending, because the backing endpoints are ROLE_COMPLIANCE/ROLE_ADMIN — a
+  // lending officer cannot propose or decide one.
+  { nameCs: 'Úvěrové compliance packy', nameEn: 'Credit Compliance Packs', href: '/lending/compliance-packs', icon: ShieldCheck, permission: 'compliance:view' },
   { nameCs: 'Auditní záznamy',    nameEn: 'Audit Log',        href: '/audit',             icon: ScrollText,            permission: 'audit:view' },
   { nameCs: 'Regulatorní',        nameEn: 'Regulatory',       href: '/regulatory',        icon: FileText,              permission: 'regulatory:view' },
 ]

--- a/openbank-admin-ui/src/test/compliance-packs-console.test.tsx
+++ b/openbank-admin-ui/src/test/compliance-packs-console.test.tsx
@@ -1,0 +1,151 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright (c) OpenBank contributors. Licensed under the Apache License, Version 2.0.
+// See LICENSE in the repository root or https://www.apache.org/licenses/LICENSE-2.0 for details.
+
+// Behaviour tests for the ADR-0212 D4 compliance-pack activation console.
+//
+// Every case here is one the naive implementation gets WRONG, and each was run against a
+// deliberately-broken version first:
+//  - a 403 on the pending list rendering as "Nothing pending" (the worst thing an approvals
+//    screen can say),
+//  - the 422 maker-checker refusal flattened to a generic "Decision failed", which hides the
+//    single fact the operator needs (the SAME person cannot do both halves),
+//  - an empty active list rendered as unremarkable, when it is precisely the state in which
+//    LENDING_ENFORCE_PACK must not be flipped.
+
+import { describe, it, expect, afterEach, vi } from 'vitest'
+import React from 'react'
+import { render, screen, cleanup, waitFor, fireEvent } from '@testing-library/react'
+import { LanguageProvider } from '@/lib/i18n/LanguageContext'
+import { SessionProvider } from '@/components/auth/SessionProvider'
+import CompliancePacksPage from '@/app/lending/compliance-packs/page'
+
+const PROPOSAL_ID = '019fb939-3e0a-7716-a1ed-7854754c8786'
+
+const PENDING = [{
+  id: PROPOSAL_ID,
+  jurisdiction: 'CZ',
+  productType: 'CONSUMER_CREDIT',
+  packVersion: 1,
+  effectiveFrom: '2026-01-01',
+  contentHash: 'b7c4d1e9a0f35286bb1122334455667788990011223344556677889900aabbcc',
+  state: 'PROPOSED',
+  proposedBy: 'maker@openbank.local',
+  decidedBy: null,
+  decidedAt: null,
+}]
+
+const ACTIVE = [{ ...PENDING[0], id: '00000000-0000-0000-0000-000000000000', state: 'EXECUTED', proposedBy: '-' }]
+
+function Providers({ children }: { children: React.ReactNode }) {
+  return React.createElement(SessionProvider, null, React.createElement(LanguageProvider, null, children))
+}
+
+type Case = { active?: { status: number; body: unknown }; pending?: { status: number; body: unknown }; decide?: { status: number; body: unknown } }
+
+function mockFetch(c: Case) {
+  const json = (status: number, b: unknown) =>
+    new Response(JSON.stringify(b), { status, headers: { 'content-type': 'application/json' } })
+  return vi.fn(async (input: RequestInfo | URL) => {
+    const url = String(input)
+    if (url.includes('/api/auth/session')) {
+      return new Response('null', { status: 200, headers: { 'content-type': 'application/json' } })
+    }
+    if (url.includes('/decide')) {
+      const d = c.decide ?? { status: 200, body: {} }
+      return json(d.status, d.body)
+    }
+    if (url.includes('/proposals/pending')) {
+      const p = c.pending ?? { status: 200, body: [] }
+      return json(p.status, p.body)
+    }
+    if (url.includes('/compliance-packs/active')) {
+      const a = c.active ?? { status: 200, body: [] }
+      return json(a.status, a.body)
+    }
+    if (url.includes('/proposals')) return json(201, PENDING[0])
+    return json(200, {})
+  })
+}
+
+afterEach(() => {
+  cleanup()
+  vi.unstubAllGlobals()
+  vi.restoreAllMocks()
+})
+
+describe('compliance pack activation console', () => {
+  it('lists the active pack with its jurisdiction, product and content hash', async () => {
+    vi.stubGlobal('fetch', mockFetch({ active: { status: 200, body: ACTIVE } }))
+    render(React.createElement(Providers, null, React.createElement(CompliancePacksPage)))
+
+    await waitFor(() => expect(screen.getByText('CONSUMER_CREDIT')).toBeTruthy())
+    expect(screen.getByText('CZ')).toBeTruthy()
+    // The hash is what ties an activated pack to a reviewable document. A console that shows
+    // "CZ v1 active" without it cannot answer "active *as of which text*".
+    expect(screen.getAllByText(/b7c4d1e9a0f35286/).length).toBeGreaterThan(0)
+  })
+
+  it('an empty active list states the enforce-pack consequence, not just "none"', async () => {
+    vi.stubGlobal('fetch', mockFetch({}))
+    render(React.createElement(Providers, null, React.createElement(CompliancePacksPage)))
+
+    await waitFor(() => expect(screen.getByTestId('no-active')).toBeTruthy())
+    // With enforcement on and no pack, origination is refused fleet-wide. That is the whole
+    // reason this screen exists before the flag flip, so it has to be said on the screen.
+    expect(screen.getByTestId('no-active').textContent).toMatch(/LENDING_ENFORCE_PACK/)
+  })
+
+  it('a refused pending read never renders as "nothing pending"', async () => {
+    vi.stubGlobal('fetch', mockFetch({ pending: { status: 403, body: { error: 'forbidden' } } }))
+    render(React.createElement(Providers, null, React.createElement(CompliancePacksPage)))
+
+    await waitFor(() => expect(screen.getByTestId('degraded')).toBeTruthy())
+    expect(screen.queryByText('Nothing pending.')).toBeNull()
+    expect(screen.getByTestId('degraded').textContent).toMatch(/pending/)
+  })
+
+  it('renders the maker-checker refusal verbatim instead of a generic failure', async () => {
+    vi.stubGlobal('fetch', mockFetch({
+      pending: { status: 200, body: PENDING },
+      // What lending-service returns on MakerCheckerViolation (422) — the checker is the maker.
+      decide: { status: 422, body: { error: 'Checker maker@openbank.local must differ from maker maker@openbank.local' } },
+    }))
+    render(React.createElement(Providers, null, React.createElement(CompliancePacksPage)))
+
+    await waitFor(() => expect(screen.getByTestId(`proposal-${PROPOSAL_ID}`)).toBeTruthy())
+    fireEvent.click(screen.getByText('Approve'))
+
+    await waitFor(() => expect(screen.getByTestId('error')).toBeTruthy())
+    expect(screen.getByTestId('error').textContent).toMatch(/must differ from maker/)
+  })
+
+  it('approving posts approve=true to the proposal decide route', async () => {
+    const f = mockFetch({ pending: { status: 200, body: PENDING } })
+    vi.stubGlobal('fetch', f)
+    render(React.createElement(Providers, null, React.createElement(CompliancePacksPage)))
+
+    await waitFor(() => expect(screen.getByTestId(`proposal-${PROPOSAL_ID}`)).toBeTruthy())
+    fireEvent.click(screen.getByText('Approve'))
+
+    await waitFor(() => {
+      const call = f.mock.calls.find(([u]) => String(u).includes('/decide'))
+      expect(call).toBeTruthy()
+      expect(String(call?.[0])).toContain(`/proposals/${PROPOSAL_ID}/decide`)
+      expect(JSON.parse(String((call?.[1] as RequestInit)?.body))).toMatchObject({ approve: true })
+    })
+  })
+
+  it('refuses to propose a pack that is not valid JSON, without calling the service', async () => {
+    const f = mockFetch({})
+    vi.stubGlobal('fetch', f)
+    render(React.createElement(Providers, null, React.createElement(CompliancePacksPage)))
+
+    await waitFor(() => expect(screen.getByTestId('no-active')).toBeTruthy())
+    fireEvent.change(screen.getByLabelText('Pack JSON'), { target: { value: '{ not json' } })
+    fireEvent.click(screen.getByText('Propose'))
+
+    await waitFor(() => expect(screen.getByTestId('error').textContent).toMatch(/not valid JSON/))
+    expect(f.mock.calls.some(([u, i]) => String(u).includes('/proposals') && (i as RequestInit)?.method === 'POST')).toBe(false)
+  })
+})


### PR DESCRIPTION
## What

A four-eyes activation console for the ADR-0212 jurisdictional credit compliance packs, at
`/lending/compliance-packs` (sidebar: Compliance → *Credit Compliance Packs*, `compliance:view`).

It shows the **active packs**, the **proposals awaiting a checker** (approve / reject with a
reason), and a **maker form** that takes pack JSON.

## Why

ADR-0212 D4 made pack activation a maker-checker control, but the only way to exercise it was
hand-driving `POST /api/v1/lending/compliance-packs/proposals` and `.../decide` with two
separately-minted operator tokens. A control that needs a shell is a control nobody runs.

That matters right now: `openbank.lending.compliance.enforce-pack` cannot be turned on until a pack
is active, because with enforcement on and no active pack **every origination is refused**. The gate
and the only route through it should not live in different places.

## Three things it deliberately does not do

- **It does not re-implement `maker != checker`.** lending-service raises `MakerCheckerViolation`
  (422) and the page renders that message verbatim. A client-side copy of the rule would put a
  weaker check in front of the real one.
- **It does not render a refused read as an empty queue.** A 403 on the pending list is the ordinary
  outcome for a non-compliance operator, and "nothing pending" is the most dangerous thing an
  approvals screen can say wrongly — same reasoning as ADR-0227 D2's `/approvals`.
- **It does not treat an empty active list as unremarkable.** That is precisely the state in which
  `LENDING_ENFORCE_PACK` must not be flipped, so the screen says so in place.

Each of the three is a test.

## Falsification

The suite was run against a deliberately broken page before it was trusted:

- flattening the 422 to a generic `Decision failed` → `renders the maker-checker refusal verbatim` red
- forcing the pending source to `'ok'` regardless of status → `a refused pending read never renders as "nothing pending"` red

`2 failed | 4 passed`, then green again on restore.

## Verification

- `npm test` — 62 files, **942 tests passed** (includes the 6 new ones)
- `npx tsc --noEmit` — clean
- `npm run lint` — 0 errors (the one warning on the new file is the fleet-wide
  `set-state-in-effect` pattern every console page already uses, incl. `/lending`)

No API, DB, event or config change; admin-ui only.

Refs #3168
