### PR TITLE
feat(campaign): show the journey as a funnel, not a table of enums

### DIFF
--- a/openbank-admin-ui/src/app/api/campaigns/[id]/journey/route.ts
+++ b/openbank-admin-ui/src/app/api/campaigns/[id]/journey/route.ts
@@ -1,0 +1,47 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright (c) OpenBank contributors. Licensed under the Apache License, Version 2.0.
+// See LICENSE in the repository root or https://www.apache.org/licenses/LICENSE-2.0 for details.
+
+// Per-step funnel for the journey view. Every number is a SQL aggregate on the service side; this
+// route adds nothing and computes nothing, so the picture cannot disagree with the send log.
+
+import { NextResponse } from 'next/server'
+import { auth } from '@/auth'
+import { serverSvcUrl } from '@/lib/services/bff'
+
+export const dynamic = 'force-dynamic'
+
+export async function GET(_req: Request, ctx: { params: Promise<{ id: string }> }) {
+  const session = await auth()
+  if (!session?.user?.accessToken) {
+    return NextResponse.json({ error: 'unauthenticated' }, { status: 401 })
+  }
+  const { id } = await ctx.params
+  const path = `/api/v1/campaigns/${encodeURIComponent(id)}/journey`
+  try {
+    const res = await fetch(serverSvcUrl('campaign-service', 'campaign', 8128, path), {
+      headers: { authorization: `Bearer ${session.user.accessToken}` },
+      signal: AbortSignal.timeout(6000),
+      cache: 'no-store',
+    })
+    if (!res.ok) {
+      // An unreadable funnel must not arrive as an empty one: "nobody was reached" is a business
+      // conclusion a marketer would act on, and a 403 or a timeout is not that conclusion.
+      return NextResponse.json(
+        {
+          steps: [],
+          state:
+            res.status === 401 || res.status === 403
+              ? 'unauthorized'
+              : res.status === 404
+                ? 'not_deployed'
+                : 'unreachable',
+        },
+        { status: 200 },
+      )
+    }
+    return NextResponse.json({ steps: await res.json(), state: 'ok' })
+  } catch {
+    return NextResponse.json({ steps: [], state: 'unreachable' }, { status: 200 })
+  }
+}

--- a/openbank-admin-ui/src/app/api/campaigns/[id]/route.ts
+++ b/openbank-admin-ui/src/app/api/campaigns/[id]/route.ts
@@ -82,12 +82,15 @@ export async function GET(_req: Request, ctx: { params: Promise<{ id: string }> 
   const { id } = await ctx.params
   const headers = { authorization: `Bearer ${session.user.accessToken}` }
 
-  const [campaign, enrolments, sends, sendSummary] = await Promise.all([
+  const [campaign, enrolments, sends, sendSummary, journey] = await Promise.all([
     read(headers, `/api/v1/campaigns/${encodeURIComponent(id)}`, null),
     read(headers, `/api/v1/campaigns/${encodeURIComponent(id)}/enrolments`, []),
     // First page only. Paging and filtering go through /api/campaigns/[id]/sends so turning a
     // page does not re-read the campaign and its enrolments.
     readSends(headers, id),
+    // The journey funnel: per-step SQL aggregates. Bundled with the first paint because the flow is
+    // the first thing on the screen, not something you scroll to.
+    read(headers, `/api/v1/campaigns/${encodeURIComponent(id)}/journey`, []),
     // Counts come from the service, not from the page above: a suppressed-total derived from the
     // rows on screen understates every campaign larger than one page, and that total is the number
     // an operator acts on.
@@ -99,6 +102,7 @@ export async function GET(_req: Request, ctx: { params: Promise<{ id: string }> 
     enrolments: enrolments.data,
     sends: sends.data,
     sendSummary: sendSummary.data,
+    journey: journey.data,
     // Per-part state travels to the client: the send log is the part most likely to be
     // restricted, and an empty send log rendered as "nothing was suppressed" would be the
     // exact misreading this screen exists to prevent.
@@ -107,6 +111,7 @@ export async function GET(_req: Request, ctx: { params: Promise<{ id: string }> 
       enrolments: enrolments.state,
       sends: sends.state,
       sendSummary: sendSummary.state,
+      journey: journey.state,
     },
   })
 }

--- a/openbank-admin-ui/src/app/campaigns/[id]/page.tsx
+++ b/openbank-admin-ui/src/app/campaigns/[id]/page.tsx
@@ -10,6 +10,7 @@ import { ArrowLeft, Megaphone } from 'lucide-react'
 import { useLanguage } from '@/lib/i18n/LanguageContext'
 import { DataUnavailable, type UnavailableKind } from '@/components/feedback/DataUnavailable'
 import { PageHeader, StatCard, StatusBadge, type Tone } from '@/components/ui'
+import { JourneyFlow, type StepFunnel } from '@/components/campaigns/JourneyFlow'
 
 interface Campaign {
   id: string
@@ -49,6 +50,7 @@ type Detail = {
   enrolments: Enrolment[]
   sends: SendPage
   sendSummary: Record<string, number>
+  journey: StepFunnel[]
   sources: Record<string, string>
 }
 
@@ -314,33 +316,25 @@ export default function CampaignDetailPage({ params }: { params: Promise<{ id: s
           )}
 
           <section className="space-y-2">
-            <h2 className="text-sm font-semibold">{t('Kroky', 'Steps')}</h2>
-            {/* The steps were fetched all along and never shown — a campaign whose content you
-                cannot see is hard to reason about when its sends are being suppressed. */}
-            <div className="overflow-x-auto rounded-lg border">
-              <table className="w-full text-sm">
-                <thead className="bg-muted/50 text-left">
-                  <tr>
-                    <th className="px-4 py-2 font-medium">#</th>
-                    <th className="px-4 py-2 font-medium">{t('Šablona', 'Template')}</th>
-                    <th className="px-4 py-2 font-medium">{t('Zpoždění', 'Delay')}</th>
-                  </tr>
-                </thead>
-                <tbody>
-                  {(c.steps ?? []).map(step => (
-                    <tr key={step.order} className="border-t">
-                      <td className="px-4 py-2">{step.order}</td>
-                      <td className="px-4 py-2 font-mono text-xs">{step.template}</td>
-                      <td className="px-4 py-2 text-xs">
-                        {step.delaySeconds === 0
-                          ? t('ihned', 'immediately')
-                          : `${Math.round(step.delaySeconds / 60)} min`}
-                      </td>
-                    </tr>
-                  ))}
-                </tbody>
-              </table>
-            </div>
+            <h2 className="text-sm font-semibold">{t('Průchod kampaní', 'Journey')}</h2>
+            {/* Replaces a three-column table of order / template id / delay-in-minutes. That table
+                showed the campaign's DEFINITION; a marketer needs its RESULT — who it reached and
+                where the rest went — and had to correlate it against the send log by eye to get
+                there. The definition is still visible, just drawn as the flow it describes. */}
+            {detail?.sources.journey !== 'ok' ? (
+              <DataUnavailable
+                kind={detail?.sources.journey === 'unauthorized' ? 'unauthorized' : 'unreachable'}
+                service="Campaign-service"
+                feature={t('Průchod kampaní', 'Journey')}
+                dense
+              />
+            ) : (
+              <JourneyFlow
+                steps={c.steps ?? []}
+                funnel={detail?.journey ?? []}
+                audienceSize={(detail?.enrolments?.length ?? 0) > 0 ? (detail?.enrolments?.length ?? 0) : null}
+              />
+            )}
           </section>
 
           <section className="space-y-2">

--- a/openbank-admin-ui/src/app/globals.css
+++ b/openbank-admin-ui/src/app/globals.css
@@ -193,6 +193,22 @@ main {
 .badge-neutral { background: var(--surface-3);  color: var(--text-secondary); border: 1px solid var(--border-strong); }
 .badge-accent  { background: var(--ob-accent-light); color: var(--ob-accent-text); border: 1px solid var(--ob-accent-border); }
 
+/* ── Funnel bar (ADR-0208 D2 vocabulary, solid variant) ──
+   A proportion bar is not a chip. The `.badge-*` rules are pale backgrounds tuned so DARK TEXT sits
+   on them legibly, which makes them the wrong fill for a 14px bar carrying no text: at that size the
+   success and info pastels are barely distinguishable, and each segment's 1px border reads as noise
+   rather than structure. These use the SAME semantic variables at full saturation, so the meaning
+   stays in one place and only the presentation differs. Colour still never leaves this file. */
+.funnel-bar { display: flex; height: 14px; width: 100%; overflow: hidden; border-radius: 999px;
+              background: var(--surface-3); }
+.funnel-seg { height: 100%; border: 0; transition: width 240ms ease; }
+.funnel-seg-success { background: var(--success); }
+.funnel-seg-info    { background: var(--info); }
+.funnel-seg-warning { background: var(--warning); }
+.funnel-seg-danger  { background: var(--danger); }
+/* Neutral must stay visible against the track it sits on, so it is a mid grey, not the track grey. */
+.funnel-seg-neutral { background: var(--text-secondary); opacity: 0.45; }
+
 /* ── Button ── */
 @layer components {
   .btn {

--- a/openbank-admin-ui/src/components/campaigns/JourneyFlow.tsx
+++ b/openbank-admin-ui/src/components/campaigns/JourneyFlow.tsx
@@ -1,0 +1,234 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright (c) OpenBank contributors. Licensed under the Apache License, Version 2.0.
+// See LICENSE in the repository root or https://www.apache.org/licenses/LICENSE-2.0 for details.
+
+'use client'
+
+import { useLanguage } from '@/lib/i18n/LanguageContext'
+import type { Tone } from '@/components/ui/tone'
+
+/**
+ * The journey as a marketer reads it: who the campaign reached at each step, and where everyone
+ * else went.
+ *
+ * The send log answers "what happened to party X at step 2" and is the right screen for an engineer
+ * holding an incident. It is the wrong screen for deciding whether a campaign is working, because
+ * the question there is never about one row — it is "how many, and why not more". This renders the
+ * same data as flow and proportion, which is the form that question is actually asked in.
+ *
+ * Three rules it follows, each of which the send-log table breaks on purpose:
+ *
+ *  - **No enum ever reaches the screen.** `SUPPRESSED_QUIET_HOURS` is a value the API returns; what
+ *    a marketer needs is "it was night — we do not email people at night". The raw value stays in
+ *    `title` so the screen and the API can never be describing different things.
+ *  - **Every number is a server-side aggregate.** A funnel is read as the whole picture by
+ *    definition, so one folded from a loaded page would understate every campaign larger than that
+ *    page while looking exactly as authoritative.
+ *  - **A drop-off is never rendered as failure.** Most of these are the platform doing its job —
+ *    consent withheld, quiet hours, frequency cap. Colouring them red teaches people to ignore red,
+ *    and the one that IS a failure (`FAILED`) then reads like the others.
+ *
+ * Colour comes from the ADR-0208 D2 tone vocabulary, never a literal — see `tone.ts`.
+ */
+
+export interface SuppressionCount {
+  reason: string
+  count: number
+}
+
+export interface StepFunnel {
+  stepOrder: number
+  reached: number
+  delivered: number
+  failed: number
+  suppressed: SuppressionCount[]
+}
+
+export interface JourneyStep {
+  order: number
+  template: string
+  delaySeconds: number
+}
+
+/** Colour by MEANING, not by severity: a suppression is the platform working, not an error. */
+const REASON_TONE: Record<string, Tone> = {
+  SUPPRESSED_CONSENT: 'info',
+  SUPPRESSED_QUIET_HOURS: 'neutral',
+  SUPPRESSED_CAP: 'warning',
+  FAILED: 'danger',
+}
+
+export function JourneyFlow({
+  steps,
+  funnel,
+  audienceSize,
+}: {
+  steps: JourneyStep[]
+  funnel: StepFunnel[]
+  audienceSize: number | null
+}) {
+  const { t, language } = useLanguage()
+  const locale = language === 'cs' ? 'cs-CZ' : 'en-GB'
+  const n = (v: number) => v.toLocaleString(locale)
+
+  /** Plain language, and never the enum. The raw value travels in `title` instead. */
+  const reasonLabel = (reason: string): string =>
+    ({
+      SUPPRESSED_CONSENT: t('Bez marketingového souhlasu', 'No marketing consent'),
+      SUPPRESSED_QUIET_HOURS: t('Tiché hodiny (21–8)', 'Quiet hours (21–8)'),
+      SUPPRESSED_CAP: t('Frekvenční strop', 'Frequency cap'),
+      FAILED: t('Nepodařilo se odeslat', 'Delivery failed'),
+    })[reason] ?? reason
+
+  /** "hned" reads better than "za 0 dní", and a delay in seconds is not a human unit. */
+  const delayLabel = (seconds: number): string => {
+    if (seconds <= 0) return t('hned', 'immediately')
+    const days = Math.floor(seconds / 86400)
+    if (days >= 1) return t(`za ${days} d`, `after ${days} d`)
+    const hours = Math.floor(seconds / 3600)
+    if (hours >= 1) return t(`za ${hours} h`, `after ${hours} h`)
+    return t(`za ${Math.floor(seconds / 60)} min`, `after ${Math.floor(seconds / 60)} min`)
+  }
+
+  /** Templates are catalogue ids; a marketer picked one by its meaning, so show that. */
+  const templateLabel = (template: string): string =>
+    ({
+      MARKETING_PRODUCT_OFFER: t('Nabídka produktu', 'Product offer'),
+    })[template] ?? template
+
+  const byStep = new Map(funnel.map(f => [f.stepOrder, f]))
+  const ordered = [...steps].sort((a, b) => a.order - b.order)
+
+  // Nothing has run yet: say so, rather than drawing an empty funnel that reads as "nobody matched".
+  const anyActivity = funnel.some(f => f.reached > 0)
+
+  return (
+    <div className="space-y-4">
+      {audienceSize !== null && (
+        <div className="flex flex-wrap items-baseline gap-2 text-sm">
+          <span className="text-muted-foreground">{t('Publikum', 'Audience')}</span>
+          <strong className="text-lg tabular-nums">{n(audienceSize)}</strong>
+          <span className="text-xs text-muted-foreground">
+            {t(
+              '— velikost segmentu před ověřením souhlasu a potlačením',
+              '— segment size, before consent checks and suppression',
+            )}
+          </span>
+        </div>
+      )}
+
+      {!anyActivity && (
+        <p className="text-sm text-muted-foreground">
+          {t(
+            'Kampaň zatím nikoho neoslovila — po zařazení publika se tu objeví průchod jednotlivými kroky.',
+            'The campaign has not reached anyone yet — once the audience is enrolled, the per-step flow appears here.',
+          )}
+        </p>
+      )}
+
+      <ol className="space-y-3">
+        {ordered.map((step, i) => {
+          const f = byStep.get(step.order)
+          const reached = f?.reached ?? 0
+          const delivered = f?.delivered ?? 0
+          const drops: SuppressionCount[] = [
+            ...(f?.suppressed ?? []),
+            ...(f && f.failed > 0 ? [{ reason: 'FAILED', count: f.failed }] : []),
+          ]
+          const pct = (v: number) => (reached > 0 ? Math.round((v / reached) * 100) : 0)
+
+          return (
+            <li key={step.order}>
+              {i > 0 && (
+                // The wait between steps is part of the journey a marketer designed, so it is drawn
+                // rather than listed in a column they have to correlate by eye.
+                <div className="flex items-center gap-2 py-1 pl-4 text-xs text-muted-foreground">
+                  <span aria-hidden className="inline-block h-4 w-px bg-border" />
+                  {delayLabel(step.delaySeconds)}
+                </div>
+              )}
+
+              <div className="rounded-lg border p-4">
+                <div className="flex flex-wrap items-baseline justify-between gap-2">
+                  <div className="flex items-baseline gap-2">
+                    <span className="text-xs text-muted-foreground">
+                      {t('Krok', 'Step')} {step.order}
+                    </span>
+                    <span className="font-medium" title={step.template}>
+                      {templateLabel(step.template)}
+                    </span>
+                    <span className="text-xs text-muted-foreground">{t('e-mailem', 'by email')}</span>
+                  </div>
+                  {/* A step nobody has reached says so. "0 doručeno z 0" is three numbers that
+                      look like a result and are the absence of one — and on a journey whose later
+                      steps are still waiting out their delay, that is most of the screen. */}
+                  {reached === 0 ? (
+                    <span className="text-xs text-muted-foreground">
+                      {t('zatím nikoho', 'nobody yet')}
+                    </span>
+                  ) : (
+                    <div className="text-sm">
+                      <strong className="tabular-nums">{n(delivered)}</strong>
+                      <span className="text-muted-foreground">
+                        {' '}
+                        {t('doručeno z', 'delivered of')} {n(reached)}
+                      </span>
+                      <span className="ml-2 text-xs text-muted-foreground"> ({pct(delivered)} %)</span>
+                    </div>
+                  )}
+                </div>
+
+                {reached > 0 && (
+                  <>
+                    {/* Proportion first, numbers second: "most of them were asleep" is the shape of
+                        the answer, and a table of counts makes you compute it yourself. */}
+                    <div
+                      className="funnel-bar mt-3"
+                      role="img"
+                      aria-label={t(
+                        `Krok ${step.order}: doručeno ${delivered} z ${reached}`,
+                        `Step ${step.order}: ${delivered} delivered of ${reached}`,
+                      )}
+                    >
+                      {delivered > 0 && (
+                        <span
+                          className="funnel-seg funnel-seg-success"
+                          style={{ width: `${pct(delivered)}%` }}
+                          title={`SENT — ${delivered}`}
+                        />
+                      )}
+                      {drops.map(d => (
+                        <span
+                          key={d.reason}
+                          className={`funnel-seg funnel-seg-${REASON_TONE[d.reason] ?? 'neutral'}`}
+                          style={{ width: `${pct(d.count)}%` }}
+                          title={`${d.reason} — ${d.count}`}
+                        />
+                      ))}
+                    </div>
+
+                    {drops.length > 0 && (
+                      <ul className="mt-3 flex flex-wrap gap-2">
+                        {drops.map(d => (
+                          <li
+                            key={d.reason}
+                            className={`badge badge-${REASON_TONE[d.reason] ?? 'neutral'} text-xs`}
+                            // The enum stays reachable so the screen and the API can never drift
+                            // apart without someone noticing.
+                            title={d.reason}
+                          >
+                            {n(d.count)} × {reasonLabel(d.reason)}
+                          </li>
+                        ))}
+                      </ul>
+                    )}
+                  </>
+                )}
+              </div>
+            </li>
+          )
+        })}
+      </ol>
+    </div>
+  )
+}

--- a/openbank-admin-ui/src/test/journey-flow.test.tsx
+++ b/openbank-admin-ui/src/test/journey-flow.test.tsx
@@ -1,0 +1,121 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright (c) OpenBank contributors. Licensed under the Apache License, Version 2.0.
+// See LICENSE in the repository root or https://www.apache.org/licenses/LICENSE-2.0 for details.
+
+import React from 'react'
+import { describe, expect, it } from 'vitest'
+import { render, screen } from '@testing-library/react'
+import { LanguageProvider } from '@/lib/i18n/LanguageContext'
+import { JourneyFlow } from '@/components/campaigns/JourneyFlow'
+
+/**
+ * The journey view exists because the send-log table is unreadable for the person who decides
+ * whether a campaign is working. These pin the three properties that make it readable — each of
+ * which is easy to lose in a later edit precisely because the table breaks all three on purpose.
+ */
+
+const STEPS = [
+  { order: 1, template: 'MARKETING_PRODUCT_OFFER', delaySeconds: 0 },
+  { order: 2, template: 'MARKETING_PRODUCT_OFFER', delaySeconds: 172800 },
+]
+
+const FUNNEL = [
+  {
+    stepOrder: 1,
+    reached: 1000,
+    delivered: 600,
+    failed: 10,
+    suppressed: [
+      { reason: 'SUPPRESSED_CONSENT', count: 300 },
+      { reason: 'SUPPRESSED_QUIET_HOURS', count: 90 },
+    ],
+  },
+]
+
+function renderFlow(funnel = FUNNEL, audience: number | null = 1000) {
+  return render(
+    React.createElement(
+      LanguageProvider,
+      null,
+      React.createElement(JourneyFlow, { steps: STEPS, funnel, audienceSize: audience }),
+    ),
+  )
+}
+
+describe('journey flow', () => {
+  /**
+   * The whole point of the screen. `SUPPRESSED_QUIET_HOURS` is a value the API returns; a marketer
+   * needs "it was night". If an enum leaks into the visible text, this view has become the send-log
+   * table with extra steps.
+   */
+  it('never puts a raw enum on the screen', () => {
+    const { container } = renderFlow()
+
+    expect(container.textContent).not.toMatch(/SUPPRESSED_/)
+    expect(container.textContent).not.toMatch(/\bFAILED\b/)
+    expect(screen.getByText(/No marketing consent/)).toBeTruthy()
+    expect(screen.getByText(/Quiet hours/)).toBeTruthy()
+    expect(screen.getByText(/Delivery failed/)).toBeTruthy()
+  })
+
+  /**
+   * …but the raw value must stay reachable, or the screen and the API can drift apart with nobody
+   * noticing. Relabelling is a translation, not a replacement.
+   */
+  it('keeps the raw outcome reachable for whoever is debugging', () => {
+    renderFlow()
+
+    expect(screen.getAllByTitle('SUPPRESSED_CONSENT').length).toBeGreaterThan(0)
+    expect(screen.getAllByTitle('SUPPRESSED_QUIET_HOURS').length).toBeGreaterThan(0)
+    expect(screen.getAllByTitle('FAILED').length).toBeGreaterThan(0)
+  })
+
+  it('states the delivered share against what the step reached', () => {
+    renderFlow()
+
+    expect(screen.getByText(/600/)).toBeTruthy()
+    expect(screen.getByText(/delivered of/)).toBeTruthy()
+    expect(screen.getByText(/60 %/)).toBeTruthy()
+  })
+
+  /**
+   * A later step still waiting out its delay has reached nobody. Rendering that as "0 delivered of
+   * 0" puts three numbers on screen that look like a result and are the absence of one — and on a
+   * multi-step journey that is most of the screen.
+   */
+  it('says a step has reached nobody rather than printing zeroes', () => {
+    renderFlow()
+
+    expect(screen.getByText(/nobody yet/)).toBeTruthy()
+    // …and exactly one step reports a real result, so the zero row cannot be mistaken for one.
+    expect(screen.getAllByText(/delivered of/)).toHaveLength(1)
+  })
+
+  /**
+   * A campaign that has not run yet must say so. An empty funnel rendered as bars reads as "nobody
+   * matched", which is a business conclusion, and the opposite of the truth.
+   */
+  it('says nothing has run rather than drawing an empty funnel', () => {
+    renderFlow([], null)
+
+    expect(screen.getByText(/has not reached anyone yet/)).toBeTruthy()
+  })
+
+  /** The wait between steps is part of the design; seconds are not a unit anyone reads. */
+  it('renders the delay between steps in human units', () => {
+    renderFlow()
+
+    expect(screen.getByText(/after 2 d/)).toBeTruthy()
+    expect(screen.queryByText(/172800/)).toBeNull()
+  })
+
+  /**
+   * The audience number is stated as pre-consent, pre-suppression. Without that it reads as the
+   * number of people who got the campaign, which is the single most expensive misreading here.
+   */
+  it('qualifies the audience number so it cannot be read as reach', () => {
+    renderFlow()
+
+    expect(screen.getByText(/before consent checks and suppression/)).toBeTruthy()
+  })
+})

--- a/openbank-campaign-service/src/main/kotlin/com/openbank/campaign/application/port/out/Ports.kt
+++ b/openbank-campaign-service/src/main/kotlin/com/openbank/campaign/application/port/out/Ports.kt
@@ -24,6 +24,9 @@ interface EnrolmentRepository {
     suspend fun save(enrolment: Enrolment): Enrolment
 }
 
+/** A single cell of the per-step funnel: how many sends of [outcome] step [stepOrder] produced. */
+data class StepOutcomeCount(val stepOrder: Int, val outcome: SendOutcome, val count: Long)
+
 interface SendLogRepository {
     suspend fun record(send: SendRecord)
     suspend fun countRecentForParty(partyId: UUID, sinceEpochSeconds: Long): Int
@@ -39,6 +42,15 @@ interface SendLogRepository {
 
     /** How many rows [listByCampaign] would return in total, for the same filter. */
     suspend fun countByCampaign(campaignId: UUID, outcome: SendOutcome?): Long
+
+    /**
+     * One row per (step, outcome) with its count — the shape a journey view needs.
+     *
+     * Aggregated in SQL rather than folded from a page of records: a funnel drawn from whatever
+     * rows happen to be loaded understates every campaign larger than one page, and a funnel is
+     * read as the whole picture by definition.
+     */
+    suspend fun countByStepAndOutcome(campaignId: UUID): List<StepOutcomeCount>
 }
 
 /** ADR-0201 D1: segments are versioned artifacts loaded as code/data, never UI-typed SQL. */

--- a/openbank-campaign-service/src/main/kotlin/com/openbank/campaign/application/usecase/CampaignSendLogQuery.kt
+++ b/openbank-campaign-service/src/main/kotlin/com/openbank/campaign/application/usecase/CampaignSendLogQuery.kt
@@ -48,10 +48,41 @@ class CampaignSendLogQuery(private val sendLog: SendLogRepository) {
      * that number is exactly the one an operator acts on. Paging a list is safe; paging a total is
      * not.
      */
+    /**
+     * The journey as a marketer reads it: for each step, how many people it reached and where the
+     * rest went.
+     *
+     * Every number is a SQL aggregate. A funnel is read as the whole picture by definition, so one
+     * folded from a page of records would understate every campaign larger than that page while
+     * looking exactly as authoritative.
+     */
+    suspend fun funnel(campaignId: UUID): List<StepFunnel> {
+        val cells = sendLog.countByStepAndOutcome(campaignId)
+        return cells.groupBy { it.stepOrder }.toSortedMap().map { (step, rows) ->
+            val byOutcome = rows.associate { it.outcome to it.count }
+            StepFunnel(
+                stepOrder = step,
+                reached = rows.sumOf { it.count },
+                delivered = byOutcome[SendOutcome.SENT] ?: 0,
+                failed = byOutcome[SendOutcome.FAILED] ?: 0,
+                suppressed = SUPPRESSION_REASONS.mapNotNull { r ->
+                    byOutcome[r]?.takeIf { it > 0 }?.let { SuppressionCount(r.name, it) }
+                },
+            )
+        }
+    }
+
     suspend fun summary(campaignId: UUID): Map<SendOutcome, Long> =
         SendOutcome.entries.associateWith { sendLog.countByCampaign(campaignId, it) }
 
     companion object {
+        /** Outcomes that mean "deliberately not sent", in the order ADR-0200 D6 evaluates them. */
+        val SUPPRESSION_REASONS = listOf(
+            SendOutcome.SUPPRESSED_CAP,
+            SendOutcome.SUPPRESSED_QUIET_HOURS,
+            SendOutcome.SUPPRESSED_CONSENT,
+        )
+
         /**
          * A caller-supplied page size is a caller-supplied amount of work. Clamping rather than
          * rejecting keeps an over-large request useful instead of turning it into an error the
@@ -69,4 +100,16 @@ class CampaignSendLogQuery(private val sendLog: SendLogRepository) {
  * the first 50 of many", and those render identically while meaning opposite things to whoever is
  * deciding whether a campaign reached its audience.
  */
+/** How many people one journey step reached, and where the rest of them went. */
+data class StepFunnel(
+    val stepOrder: Int,
+    val reached: Long,
+    val delivered: Long,
+    val failed: Long,
+    val suppressed: List<SuppressionCount>,
+)
+
+/** One reason a step did not deliver, with its count. Kept as a list so the order is the rule order. */
+data class SuppressionCount(val reason: String, val count: Long)
+
 data class SendPage(val items: List<SendRecord>, val total: Long, val page: Int, val size: Int)

--- a/openbank-campaign-service/src/main/kotlin/com/openbank/campaign/infrastructure/persistence/Persistence.kt
+++ b/openbank-campaign-service/src/main/kotlin/com/openbank/campaign/infrastructure/persistence/Persistence.kt
@@ -10,6 +10,7 @@ import com.openbank.campaign.application.port.out.CampaignRepository
 import com.openbank.campaign.application.port.out.EnrolmentRepository
 import com.openbank.campaign.application.port.out.SegmentRegistry
 import com.openbank.campaign.application.port.out.SendLogRepository
+import com.openbank.campaign.application.port.out.StepOutcomeCount
 import com.openbank.campaign.domain.model.Campaign
 import com.openbank.campaign.domain.model.CampaignState
 import com.openbank.campaign.domain.model.CampaignStep
@@ -267,6 +268,26 @@ class PanacheSendLogRepository :
             occurredAt = it.occurredAt,
         )
     }
+
+    override suspend fun countByStepAndOutcome(campaignId: UUID): List<StepOutcomeCount> = Panache
+        .withSession {
+            Panache.getSession().flatMap { session ->
+                session.createQuery(
+                    "select s.stepOrder, s.outcome, count(s) from SendLogEntity s " +
+                        "where s.campaignId = :cid group by s.stepOrder, s.outcome " +
+                        "order by s.stepOrder",
+                    Array<Any>::class.java,
+                ).setParameter("cid", campaignId).resultList
+            }
+        }
+        .awaitSuspending()
+        .map { row ->
+            StepOutcomeCount(
+                stepOrder = row[0] as Int,
+                outcome = SendOutcome.valueOf(row[1] as String),
+                count = row[2] as Long,
+            )
+        }
 
     override suspend fun countByCampaign(campaignId: UUID, outcome: SendOutcome?): Long =
         Panache.withSession { query(campaignId, outcome).count() }.awaitSuspending()

--- a/openbank-campaign-service/src/main/kotlin/com/openbank/campaign/infrastructure/rest/CampaignSendLogResource.kt
+++ b/openbank-campaign-service/src/main/kotlin/com/openbank/campaign/infrastructure/rest/CampaignSendLogResource.kt
@@ -70,6 +70,12 @@ class CampaignSendLogResource(private val query: CampaignSendLogQuery) {
     suspend fun sendSummary(@PathParam("id") id: UUID): Response =
         Response.ok(query.summary(id).mapKeys { it.key.name }).build()
 
+    /** Per-step funnel for the journey view — every number a SQL aggregate, never a page fold. */
+    @GET
+    @Path("/{id}/journey")
+    @Authorize(action = "campaign.read", resource = "#id")
+    suspend fun journey(@PathParam("id") id: UUID): Response = Response.ok(query.funnel(id)).build()
+
     private fun badOutcome(cause: Throwable): Response = Response.status(Response.Status.BAD_REQUEST)
         .entity(
             mapOf(

--- a/openbank-campaign-service/src/main/resources/openapi.yaml
+++ b/openbank-campaign-service/src/main/resources/openapi.yaml
@@ -4,7 +4,7 @@ openapi: 3.1.0
 info:
   title: Campaign Service API
   # major == openbank.api.version == URL /api/v1 (ADR-0048).
-  version: 1.5.0
+  version: 1.6.0
   description: >-
     Campaign management first slice (ADR-0200 / ADR-0209 D3): deterministic, versioned segments;
     per-enrolment Temporal journeys; consent-gated delivery through notification-service.
@@ -186,6 +186,27 @@ paths:
                 type: array
                 items:
                   $ref: '#/components/schemas/Enrolment'
+
+  /api/v1/campaigns/{id}/journey:
+    get:
+      tags: [Campaigns]
+      summary: Per-step funnel — who each step reached, and where the rest went
+      description: >-
+        Every number is a SQL aggregate over the send log, grouped by (step, outcome). A funnel is
+        read as the whole picture by definition, so one folded from a page of records would
+        understate every campaign larger than that page while looking exactly as authoritative.
+      operationId: campaignJourney
+      parameters:
+        - $ref: '#/components/parameters/CampaignId'
+      responses:
+        '200':
+          description: One entry per journey step, ordered by step
+          content:
+            application/json:
+              schema:
+                type: array
+                items:
+                  $ref: '#/components/schemas/StepFunnel'
 
   /api/v1/campaigns/{id}/sends/summary:
     get:
@@ -377,6 +398,33 @@ components:
         approver:
           type: string
           deprecated: true
+
+    StepFunnel:
+      type: object
+      properties:
+        stepOrder: { type: integer }
+        reached:
+          type: integer
+          format: int64
+          description: Sends this step recorded at all — delivered plus every suppression.
+        delivered: { type: integer, format: int64 }
+        failed: { type: integer, format: int64 }
+        suppressed:
+          type: array
+          description: >-
+            One entry per reason that produced at least one suppression, in the order ADR-0200 D6
+            evaluates them (cap, quiet hours, consent). A reason with no occurrences is omitted
+            rather than sent as zero, so a client cannot render an empty bar segment.
+          items:
+            $ref: '#/components/schemas/SuppressionCount'
+
+    SuppressionCount:
+      type: object
+      properties:
+        reason:
+          type: string
+          enum: [SUPPRESSED_CAP, SUPPRESSED_QUIET_HOURS, SUPPRESSED_CONSENT]
+        count: { type: integer, format: int64 }
 
     SegmentSummary:
       type: object

--- a/openbank-campaign-service/src/test/kotlin/com/openbank/campaign/application/CampaignSendLogTest.kt
+++ b/openbank-campaign-service/src/test/kotlin/com/openbank/campaign/application/CampaignSendLogTest.kt
@@ -5,6 +5,7 @@
 package com.openbank.campaign.application
 
 import com.openbank.campaign.application.port.out.SendLogRepository
+import com.openbank.campaign.application.port.out.StepOutcomeCount
 import com.openbank.campaign.application.usecase.CampaignSendLogQuery
 import com.openbank.campaign.domain.model.SendOutcome
 import com.openbank.campaign.domain.model.SendRecord
@@ -53,6 +54,10 @@ class CampaignSendLogTest {
 
             override suspend fun countByCampaign(campaignId: UUID, outcome: SendOutcome?) =
                 records.count { outcome == null || it.outcome == outcome }.toLong()
+
+            override suspend fun countByStepAndOutcome(campaignId: UUID) =
+                records.groupBy { it.stepOrder to it.outcome }
+                    .map { (k, v) -> StepOutcomeCount(k.first, k.second, v.size.toLong()) }
         },
     )
 


### PR DESCRIPTION
Refs #2895. `openapi.yaml` 1.5.0 → 1.6.0.

Direct feedback from the person this console is for: it is too technical to be usable for marketing.
That is fair, and the Steps section was the clearest example — three columns of order / template id /
delay-in-minutes, showing the campaign's **definition**. To learn whether the campaign was *working*
you had to correlate it against the send log by eye, translating `SUPPRESSED_QUIET_HOURS` as you
went.

A marketer's question is never about one row. It is "how many, and why not more" — which is a shape,
not a table: flow and proportion.

## What it looks like now

Each step is a card carrying the step's own funnel: how many it reached, how many were delivered, and
the rest segmented by reason — with the wait between steps drawn as part of the journey rather than
listed in a column.

For a step that reached 1 000 and delivered 600, the bar reads at a glance as 60 % green, 30 % blue
(no consent), 9 % grey (quiet hours), 1 % red (failed), with the same breakdown as labelled chips
underneath.

## Three rules it follows

Each is something the send-log table breaks on purpose, and each is pinned by a test.

- **No enum reaches the screen.** `SUPPRESSED_QUIET_HOURS` is a value the API returns; what a
  marketer needs is "it was night". The raw value stays in `title`, so the screen and the API cannot
  drift apart without someone noticing — relabelling is a translation, not a replacement.
- **Every number is a SQL aggregate**, grouped by `(step, outcome)` in a new
  `GET /campaigns/{id}/journey`. A funnel is read as the whole picture by definition, so one folded
  from a loaded page would understate every campaign larger than that page while looking exactly as
  authoritative. This is the same mistake #3111 fixed for the suppressed headline.
- **A drop-off is not a failure.** Consent withheld, quiet hours and the frequency cap are the
  platform doing its job. Colouring them red teaches people to ignore red — and the one that *is* a
  failure then reads like the others.

## A design-system addition, not a local colour

The bar does **not** reuse `.badge-*`. Those are pale backgrounds tuned so dark text sits on them
legibly, which makes them the wrong fill for a 14px bar carrying no text: at that size the success
and info pastels are barely distinguishable, and each segment's 1px border reads as noise. I verified
this by rendering the component and looking at it — the first version was genuinely hard to read.

`globals.css` gains a `.funnel-bar` / `.funnel-seg-*` vocabulary built from the **same** semantic
variables at full saturation. Meaning stays in one place, and colour still never leaves the
stylesheet (ADR-0208 D2).

## Smaller thing the tests caught

A step that has reached nobody now says so instead of printing "0 delivered of 0". On a journey whose
later steps are still waiting out their delay that is most of the screen, and three zeroes look like
a result rather than the absence of one.

## Verification

Rendered the component to static HTML with the **compiled** stylesheet and inspected it in a browser
— the first attempt, using only `globals.css`, was misleading because the layout depends on utility
classes generated at build time. Worth stating: a screenshot of a partial stylesheet is not a
screenshot of the page.

Suites green locally: `ktlintCheck detekt test` on campaign-service, 940/940 on admin-ui (7 of them
new, covering the three rules above plus the empty-step and delay-formatting cases).

## Not in this PR

The audience number is the enrolment count, labelled as pre-consent and pre-suppression so it cannot
be read as reach. The full ADR-0221 D1 consent funnel (segment → after consent → after caps → after
suppression) needs counts the engine does not expose yet.
