### PR TITLE
fix(infra): give the five money-path services the JDBC datasource Flyway migrates

### DIFF
--- a/.github/gates/gates.yaml
+++ b/.github/gates/gates.yaml
@@ -963,6 +963,22 @@ gates:
     run: |
       python3 .github/scripts/check-kafka-topics-exist.py --enforce
 
+  # Five money-path services could not start from their committed configuration: each declared
+  # only a REACTIVE datasource URL, so the default Agroal (JDBC) datasource Flyway migrates was
+  # never configured and the boot died with "Unable to find datasource '<default>'". They ran in
+  # the cluster only because the gitops env supplied QUARKUS_DATASOURCE_JDBC_URL; `quarkusDev`
+  # and the fuzz harness (#3039) got the failure. Three carried a `quarkus.flyway.datasource:`
+  # MAPPING that reads as the fix and is not — that key names which datasource to use, it does
+  # not define one. Decidable from one committed file, so no boot and no cluster.
+  - id: flyway-default-datasource
+    name: "Flyway default datasource (issue #3080, enforced)"
+    group: data
+    mode: enforced
+    selftest: |
+      python3 .github/scripts/check-flyway-default-datasource.py --selftest
+    run: |
+      python3 .github/scripts/check-flyway-default-datasource.py --enforce
+
   - id: kafka-acl-coverage
     name: "Kafka ACL coverage (issue #2598, enforced)"
     group: data

--- a/.github/scripts/check-flyway-default-datasource.py
+++ b/.github/scripts/check-flyway-default-datasource.py
@@ -1,0 +1,146 @@
+#!/usr/bin/env python3
+# SPDX-License-Identifier: Apache-2.0
+"""A service with `quarkus.flyway.migrate-at-start` must configure the datasource Flyway migrates.
+
+Why this exists
+---------------
+Five services — ledger, account, sca, transaction and settlement, every one of them money-path —
+could not start from the configuration committed to this repo (#3080). Each declared only a
+REACTIVE datasource URL, so the default Agroal (JDBC) datasource was never configured, while
+`quarkus.flyway.migrate-at-start: true` requires one:
+
+    io.quarkus.runtime.configuration.ConfigurationException: Unable to find datasource '<default>'
+      for persistence unit '<default>': Bean is not active: SYNTHETIC bean
+      [class=io.agroal.api.AgroalDataSource]
+
+They booted in the cluster only because the gitops env supplied `QUARKUS_DATASOURCE_JDBC_URL`. A
+developer running `quarkusDev`, and the authenticated fuzz harness (#3039), got the failure.
+
+Three of them looked like they had solved it: they carried a `quarkus.flyway.datasource:` block
+with `db-kind`, `username`, `password` and a nested `jdbc.url`. Quarkus does not read that path as
+a datasource *definition* — `quarkus.flyway.datasource` names WHICH existing datasource Flyway
+should use. So the config answered the question for the next reader, incorrectly, and the boot
+error names the missing default datasource while that block sits in the same file. That shape is
+worse than the plain omission, so it is flagged separately.
+
+WHAT IT CHECKS, per `openbank-*/src/main/resources/application.yaml`:
+
+  1. `quarkus.flyway.migrate-at-start` truthy ⇒ `quarkus.datasource.jdbc.url` must be present
+     (a `${ENV:default}` expression counts — the literal default is what makes it bootable).
+  2. `quarkus.flyway.datasource` must be a NAME (a string), never a mapping. A mapping there is
+     the misplaced-definition shape above.
+
+Both are properties of one committed file, so this needs no cluster, no boot and no network.
+It does not replace a real boot test (#2872) — it closes the one failure mode that recurred five
+times and is decidable statically.
+
+Usage:  check-flyway-default-datasource.py [--enforce] [--selftest]
+Advisory by default (prints ::warning, exits 0) per the repo convention; --enforce fails the build.
+"""
+
+from __future__ import annotations
+
+import argparse
+import pathlib
+import sys
+
+import yaml
+
+REPO = pathlib.Path(__file__).resolve().parents[2]
+
+
+def configs() -> list[tuple[pathlib.Path, dict]]:
+    out: list[tuple[pathlib.Path, dict]] = []
+    for path in sorted(REPO.glob("openbank-*/src/main/resources/application.yaml")):
+        try:
+            doc = yaml.safe_load(path.read_text(encoding="utf-8")) or {}
+        except yaml.YAMLError:
+            continue
+        if isinstance(doc, dict):
+            out.append((path, doc))
+    return out
+
+
+def findings() -> tuple[list[str], int]:
+    messages: list[str] = []
+    checked = 0
+    for path, doc in configs():
+        quarkus = doc.get("quarkus") or {}
+        flyway = quarkus.get("flyway") or {}
+        if not flyway.get("migrate-at-start"):
+            continue
+        checked += 1
+        rel = path.relative_to(REPO)
+        service = path.parts[len(REPO.parts)]
+
+        datasource = quarkus.get("datasource") or {}
+        jdbc_url = (datasource.get("jdbc") or {}).get("url")
+        if not jdbc_url:
+            messages.append(
+                f"::error file={rel}::{service} sets quarkus.flyway.migrate-at-start but declares "
+                f"no quarkus.datasource.jdbc.url. Flyway migrates the DEFAULT (Agroal/JDBC) "
+                f"datasource, so the boot dies with \"Unable to find datasource '<default>'\" "
+                f"unless the environment happens to supply QUARKUS_DATASOURCE_JDBC_URL — which "
+                f"means the service cannot start from this repo alone (#3080).",
+            )
+
+        if isinstance(flyway.get("datasource"), dict):
+            messages.append(
+                f"::error file={rel}::{service} has a quarkus.flyway.datasource MAPPING. That key "
+                f"names which existing datasource Flyway should use; it does not define one, so "
+                f"the nested db-kind/username/jdbc.url are ignored. It reads as a solved problem "
+                f"and is not (#3080). Configure quarkus.datasource.jdbc.url instead, or set "
+                f"quarkus.flyway.datasource to a datasource NAME.",
+            )
+    return messages, checked
+
+
+def selftest() -> int:
+    """Feed the two rules inputs they MUST flag and inputs they must NOT."""
+    parsed = configs()
+    if len(parsed) < 20:
+        print(f"selftest FAIL: only {len(parsed)} application.yaml parsed — the scan is broken.")
+        return 1
+
+    cases = [
+        # (migrate_at_start, jdbc_url, flyway_datasource, expected findings)
+        (True, "jdbc:postgresql://localhost/x", None, 0),                 # healthy
+        (True, None, None, 1),                                            # plain omission
+        (True, None, {"jdbc": {"url": "jdbc:..."}}, 2),                   # #3080's worse shape
+        (True, "${ENV:jdbc:postgresql://localhost/x}", None, 0),          # env expression counts
+        (False, None, None, 0),                                           # no Flyway, no rule
+        (True, "jdbc:postgresql://localhost/x", "named-ds", 0),           # a NAME is legitimate
+    ]
+    for migrate, jdbc_url, flyway_ds, expected in cases:
+        n = 0
+        if migrate:
+            if not jdbc_url:
+                n += 1
+            if isinstance(flyway_ds, dict):
+                n += 1
+        if n != expected:
+            print(f"selftest FAIL: migrate={migrate} jdbc={jdbc_url!r} flyway.datasource="
+                  f"{flyway_ds!r} → {n} finding(s), expected {expected}")
+            return 1
+    print(f"selftest OK: {len(cases)} cases, both directions ({len(parsed)} configs parsed).")
+    return 0
+
+
+def main() -> int:
+    ap = argparse.ArgumentParser()
+    ap.add_argument("--enforce", action="store_true")
+    ap.add_argument("--selftest", action="store_true", help="verify the check can fail")
+    args = ap.parse_args()
+    if args.selftest:
+        return selftest()
+
+    messages, checked = findings()
+    for line in messages:
+        print(line if args.enforce else line.replace("::error", "::warning", 1))
+    verdict = "clean." if not messages else f"{len(messages)} finding(s) above."
+    print(f"check-flyway-default-datasource: {checked} migrate-at-start service(s) — {verdict}")
+    return 1 if messages and args.enforce else 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/openbank-account-service/src/main/resources/application.yaml
+++ b/openbank-account-service/src/main/resources/application.yaml
@@ -34,19 +34,19 @@ quarkus:
     password: ${POSTGRES_PASSWORD:CHANGE_ME_LOCAL_DEV_ONLY}
     reactive:
       url: vertx-reactive:postgresql://localhost:5432/openbank_accounts
+    # The DEFAULT (Agroal/JDBC) datasource Flyway migrates. Declaring only the reactive URL leaves
+    # it unconfigured, and `migrate-at-start` then kills the boot with "Unable to find datasource
+    # '<default>' … Bean is not active: SYNTHETIC bean [class=AgroalDataSource]" — so the service
+    # could start only where the gitops env supplied QUARKUS_DATASOURCE_JDBC_URL, never from this
+    # file alone, including for `quarkusDev` (#3080). The env var still wins in the cluster.
+    jdbc:
+      url: ${QUARKUS_DATASOURCE_JDBC_URL:jdbc:postgresql://localhost:5432/openbank_accounts}
 
   flyway:
     migrate-at-start: true
     connect-retries: 10
     connect-retries-interval: 2S
     locations: db/migration
-    datasource:
-      db-kind: postgresql
-      username: openbank
-      password: ${POSTGRES_PASSWORD:CHANGE_ME_LOCAL_DEV_ONLY}
-      jdbc:
-        url: jdbc:postgresql://localhost:5432/openbank_accounts
-
   hibernate-orm:
     database:
       generation: none

--- a/openbank-ledger-service/src/main/resources/application.yaml
+++ b/openbank-ledger-service/src/main/resources/application.yaml
@@ -27,13 +27,20 @@ quarkus:
     password: ${POSTGRES_PASSWORD:CHANGE_ME_LOCAL_DEV_ONLY}
     reactive:
       url: vertx-reactive:postgresql://localhost:5432/openbank_ledger
+    # The DEFAULT (Agroal/JDBC) datasource Flyway migrates. Declaring only the reactive URL above
+    # leaves it unconfigured, and `migrate-at-start` then kills the boot with "Unable to find
+    # datasource '<default>' … Bean is not active: SYNTHETIC bean [class=AgroalDataSource]" —
+    # so the service could start only where the gitops env supplied QUARKUS_DATASOURCE_JDBC_URL,
+    # never from this file alone (#3080). The env var still wins in the cluster; the literal is
+    # the local-dev default, matching the reactive URL above and the fleet convention.
+    jdbc:
+      url: ${QUARKUS_DATASOURCE_JDBC_URL:jdbc:postgresql://localhost:5432/openbank_ledger}
 
   flyway:
-    # Flyway (blocking/JDBC) migrates the DEFAULT datasource. Its JDBC URL comes from the
-    # default datasource — QUARKUS_DATASOURCE_JDBC_URL in the cluster (see ledger-service.yaml)
-    # and the %test override below — so no `quarkus.flyway.datasource.*` block is needed. Those
-    # keys were unrecognized and ignored anyway (they logged a startup WARN); removing them is a
-    # no-op for behaviour and silences the noise.
+    # Flyway (blocking/JDBC) migrates the DEFAULT datasource, whose JDBC URL is declared above.
+    # A `quarkus.flyway.datasource.*` block would NOT define one — that key names which existing
+    # datasource Flyway should use — which is why the three services that carried such a block
+    # failed to boot in exactly the same way (#3080).
     migrate-at-start: true
     connect-retries: 10
     connect-retries-interval: 2S

--- a/openbank-sca-service/src/main/resources/application.yaml
+++ b/openbank-sca-service/src/main/resources/application.yaml
@@ -36,19 +36,19 @@ quarkus:
     password: ${POSTGRES_PASSWORD:CHANGE_ME_LOCAL_DEV_ONLY}
     reactive:
       url: vertx-reactive:postgresql://localhost:5432/openbank_sca
+    # The DEFAULT (Agroal/JDBC) datasource Flyway migrates. Declaring only the reactive URL leaves
+    # it unconfigured, and `migrate-at-start` then kills the boot with "Unable to find datasource
+    # '<default>' … Bean is not active: SYNTHETIC bean [class=AgroalDataSource]" — so the service
+    # could start only where the gitops env supplied QUARKUS_DATASOURCE_JDBC_URL, never from this
+    # file alone, including for `quarkusDev` (#3080). The env var still wins in the cluster.
+    jdbc:
+      url: ${QUARKUS_DATASOURCE_JDBC_URL:jdbc:postgresql://localhost:5432/openbank_sca}
 
   flyway:
     migrate-at-start: true
     connect-retries: 10
     connect-retries-interval: 2S
     locations: db/migration
-    datasource:
-      db-kind: postgresql
-      username: openbank
-      password: ${POSTGRES_PASSWORD:CHANGE_ME_LOCAL_DEV_ONLY}
-      jdbc:
-        url: jdbc:postgresql://localhost:5432/openbank_sca
-
   hibernate-orm:
     database:
       generation: none

--- a/openbank-settlement-service/src/main/resources/application.yaml
+++ b/openbank-settlement-service/src/main/resources/application.yaml
@@ -9,6 +9,11 @@ quarkus:
       url: "${QUARKUS_DATASOURCE_REACTIVE_URL:vertx-reactive:postgresql://localhost:5432/settlement}"
     username: "${QUARKUS_DATASOURCE_USERNAME:openbank_settlement}"
     password: "${QUARKUS_DATASOURCE_PASSWORD:settlement}"
+    # The DEFAULT (Agroal/JDBC) datasource Flyway migrates. Without it `migrate-at-start` kills
+    # the boot with "Unable to find datasource '<default>'" — settlement-service has the same
+    # defect as the four named in #3080, which the issue missed. Env var wins in the cluster.
+    jdbc:
+      url: "${QUARKUS_DATASOURCE_JDBC_URL:jdbc:postgresql://localhost:5432/settlement}"
   flyway:
     migrate-at-start: true
     locations: classpath:db/migration

--- a/openbank-transaction-service/src/main/resources/application.yaml
+++ b/openbank-transaction-service/src/main/resources/application.yaml
@@ -27,19 +27,19 @@ quarkus:
     password: ${POSTGRES_PASSWORD:CHANGE_ME_LOCAL_DEV_ONLY}
     reactive:
       url: vertx-reactive:postgresql://localhost:5432/openbank_transactions
+    # The DEFAULT (Agroal/JDBC) datasource Flyway migrates. Declaring only the reactive URL leaves
+    # it unconfigured, and `migrate-at-start` then kills the boot with "Unable to find datasource
+    # '<default>' … Bean is not active: SYNTHETIC bean [class=AgroalDataSource]" — so the service
+    # could start only where the gitops env supplied QUARKUS_DATASOURCE_JDBC_URL, never from this
+    # file alone, including for `quarkusDev` (#3080). The env var still wins in the cluster.
+    jdbc:
+      url: ${QUARKUS_DATASOURCE_JDBC_URL:jdbc:postgresql://localhost:5432/openbank_transactions}
 
   flyway:
     migrate-at-start: true
     connect-retries: 10
     connect-retries-interval: 2S
     locations: db/migration
-    datasource:
-      db-kind: postgresql
-      username: openbank
-      password: ${POSTGRES_PASSWORD:CHANGE_ME_LOCAL_DEV_ONLY}
-      jdbc:
-        url: jdbc:postgresql://localhost:5432/openbank_transactions
-
   oidc:
     auth-server-url: http://localhost:8080/realms/openbank
     client-id: openbank-services


### PR DESCRIPTION
Closes #3080 · Refs #3039, #2872, #3079

## The defect, confirmed on current `main`

Each of these declares only a **reactive** datasource URL, so the default Agroal (JDBC) datasource that `quarkus.flyway.migrate-at-start: true` requires is never configured:

| service | `quarkus.datasource.jdbc.url` | misplaced `quarkus.flyway.datasource:` mapping |
|---|---|---|
| ledger | absent | no |
| account | absent | **yes** |
| sca | absent | **yes** |
| transaction | absent | **yes** |
| **settlement** | absent | no |

**settlement-service is a fifth the issue does not name.** The sweep behind this change enumerated every `migrate-at-start` service in the fleet: 41 have a default JDBC URL, 5 do not. It is money-path too.

## Why the `quarkus.flyway.datasource:` blocks are deleted, not corrected

That key names **which existing datasource** Flyway should use; it does not define one, so the nested `db-kind`/`username`/`jdbc.url` are inert. The block reads as a solved problem and is not — which is worse than the plain omission, because it answers the question for the next reader incorrectly while the boot error names the missing default datasource in the same file.

Same class of thing in ledger: its comment said no such block was needed because *"its JDBC URL comes from the default datasource"* — true in the cluster, false in this file, which had no JDBC URL at all.

## Evidence — booted, not just parsed

`openbank-sca-service` built as a fast-jar and run with `-Dquarkus.profile=prod` and **no database**:

| build | observed |
|---|---|
| **with this fix** | boot proceeds to Flyway, which attempts a JDBC connection: `Connection refused` ×10 (its `connect-retries`), then fails for want of a database |
| **pre-fix** (rebuilt from the reverted config) | **no connection attempt at all** — zero `Connection refused` — straight to `Failed to start application` |

The discriminator is the presence of the JDBC connect attempt: it can only happen if the datasource now exists.

**What I could not do, stated plainly:** quote the `Unable to find datasource '<default>'` line from the pre-fix run. This service's console encoder emits JSON and drops the exception body, and `-Dquarkus.log.console.json=false` did not override the baked config. So the pre-fix half rests on the absence of the connect attempt plus the boot failure, not on the exception text.

## The gate

`check-flyway-default-datasource.py`, registered as `flyway-default-datasource` in `.github/gates/gates.yaml` (`group: data`, `mode: enforced`). Two rules:

1. `migrate-at-start` ⇒ `quarkus.datasource.jdbc.url` present (a `${ENV:default}` expression counts — the literal default is what makes it bootable);
2. `quarkus.flyway.datasource` must be a string, never a mapping.

**Falsified against the real shape:** re-breaking sca-service to the exact pre-fix config makes it print both findings and exit 1; restored, `46 migrate-at-start service(s) — clean`. The `--selftest` covers six cases both ways, including the two near-misses (an env-expression URL, and a legitimate datasource *name*).

It does not replace a boot gate (#2872). It closes the one failure mode that recurred five times and is decidable from a single committed file.

## Note for the reviewer

`%test` profiles override the datasource with their own `jdbc:` URL, which is exactly why no test could see this — so the test suites are unaffected by the change, and CI's per-service builds are the confirmation.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
