### PR TITLE
docs: a PR born conflicted gets no merge ref, so no CI ever runs

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -442,6 +442,18 @@ fire from *outside* it, so they stay here:
   fast echo — what `adr-registry` already did, and what `agent-charter-registry` and `eu-ai-act` now
   do too. Corollary: reaching for the ruleset is usually the wrong instinct here, since the in-repo
   fix ships in the same PR as the gate and needs no GitHub-side config change.
+- **A PR that is conflicted AT CREATION never gets `refs/pull/<n>/merge`, so NO `pull_request`
+  workflow is ever created — and zero checks renders as "waiting", never as broken.** Not skipped:
+  absent. Nothing reports, the required contexts can never be satisfied, and there is no run to
+  re-run, so the PR is unmergeable forever and eventually gets closed by whoever supersedes it.
+  `DIRTY` alone is NOT the predictor and that is what makes it hard to see — a PR that became
+  conflicted *later* keeps the merge ref it was born with along with its full check set (#3058:
+  DIRTY, 13 runs). Measured 2026-08-01: four admin-ui deploy PRs with 0 runs, three closed having
+  deployed nothing, while every one that merged had 18. The fix on an affected PR is any new head —
+  merging `main` in took #3183 from `merge ref 0 / 0 runs` to `1 / 12`, and it then merged. Root
+  cause class: a bot that checks out `github.sha` and branches from it while `main` moves under it
+  (#3194). Probe with `git ls-remote origin refs/pull/<n>/merge` and a run count per head SHA —
+  a PR list, a check list and `gh pr view` all look normal.
 - **`/actions/runs/<id>/jobs` returns the LATEST attempt — anything reacting to `workflow_run`
   must query `/actions/runs/<id>/attempts/<n>/jobs`.** The unscoped endpoint silently answers
   about a *different* run than the event fired for, so a guard that inspects job or step


### PR DESCRIPTION
The operational half of #3194 — that issue proposes the fix in `admin-ui-deploy.yml`; this bullet is for whoever next meets a PR that looks like it is merely waiting.

## What it records

A PR that is conflicted **at creation** never gets `refs/pull/<n>/merge`. GitHub cannot compute the merge commit, `pull_request` workflows run against that ref, so no run is ever created — not skipped, absent. The required contexts can never be satisfied and there is no run to re-run.

The reason it is worth a bullet rather than a comment on one PR: **zero checks renders as "waiting", never as broken.** A PR list, a check list and `gh pr view` all look normal.

## The part that makes it hard to spot

`DIRTY` is not the predictor. Verified against the live queue:

```
#3058   DIRTY   merge ref 1   13 runs    <- became conflicted later
#3183   DIRTY   merge ref 0    0 runs    <- born conflicted
```

A PR that became conflicted after the fact keeps the merge ref it was born with, along with its full check set. Only conflicted-at-creation produces the dead state.

## Measured

Four admin-ui deploy PRs in one day with zero runs; three closed having deployed nothing:

```
#3138 CLOSED   #3154 CLOSED   #3162 CLOSED   #3183 recovered
```

Every deploy PR that merged the same day had 18 runs.

Recovery is any new head — merging `main` into #3183 moved it from `merge ref 0 / 0 runs` to `1 / 12`, and it merged normally after that.

## Probe

```bash
git ls-remote origin refs/pull/<n>/merge
gh api "repos/<owner>/<repo>/actions/runs?head_sha=<sha>" --jq '.workflow_runs|length'
```

## Verification

Every claim re-checked against the API before committing — #3058's state and run count, #3183 merged, the three closed PRs. Fences balanced (4, even), +12/-0.

## Release impact

None — `docs` is a hidden type and `CLAUDE.md` is under no released package path.

Refs #3194
