### PR TITLE
feat(lending): customer self-service loan application intake (ADR-0211)

### DIFF
--- a/docs/threat-models/openbank-customer-edge.md
+++ b/docs/threat-models/openbank-customer-edge.md
@@ -145,3 +145,15 @@ Trust boundaries:
 | OPA per-resource ownership policies | 🔲 Phase 2 |
 | M2M secret rotation SLA | 🔲 Pre-GA |
 | Mobile certificate pinning | 🔲 ADR-0064 Phase F2 |
+
+## 6. Change log
+
+- **2026-08-01** — ADR-0211 customer intake. `POST /customer/v1/loan-applications` forwards a loan
+  application to lending-service. The party travels as `X-Customer-Party-Id`, derived from the
+  customer JWT here — the app supplies only amount and term, so a customer can only apply for
+  themselves. Deliberately NOT fail-soft (unlike the `/loans` read, which degrades to `[]`): for a
+  write, a synthesised success would tell the customer an application was filed when none was, so
+  the upstream status and reason pass through. The endpoint is inert until lending-service's own
+  `lending.intake.enabled` is turned on, and lending refuses any caller that is not this service's
+  configured principal — see §9 of the `openbank-lending-service` threat model for why the role gate
+  cannot be that control.

--- a/docs/threat-models/openbank-lending-service.md
+++ b/docs/threat-models/openbank-lending-service.md
@@ -250,7 +250,48 @@ two authenticated principals to alter.
 CZ reference pack is seeded and activated — the guard cannot protect origination while off.
 Tracked as the named bootstrap follow-up (ADR-0212 D4).
 
-## 9. Change log
+## 9. Customer self-service origination intake (ADR-0211) — STRIDE supplement
+
+`CustomerIntakeResource` (`POST /api/v1/lending/intake/applications`) is the first path by which a
+request originating **outside the bank's staff** reaches the loan book. Until it existed, every
+origination entry point was a desk endpoint, and the whole §4 posture assumed an authenticated
+employee behind every write. That assumption no longer holds, so this supplement states what does.
+
+**What it is not.** It is the MAKER leg only. The created application enters the ordinary
+origination graph and still requires a human checker (`lending.approve`, four-eyes) before a
+disbursement moves any money. A customer cannot originate cash by calling this endpoint, and the
+§7 controls are untouched.
+
+**Why `@RolesAllowed` cannot be the control here.** customer-edge's M2M identity carries
+`ROLE_OPERATOR` and nothing else, and `AuthorizeInterceptor` classifies a client_credentials JWT as
+`HUMAN` — so neither the JAX-RS role gate nor the lending rego extension (whose
+`operator-lending-write` rule admits any `lending.*` action for `ROLE_OPERATOR`) can distinguish the
+edge from a real person at a desk. The control is therefore a named-principal check in the handler
+against `lending.intake.caller-principal`, which refuses every call when unset.
+
+| STRIDE | Threat | Mitigation |
+|---|---|---|
+| **S**poofing | An operator (or any `ROLE_OPERATOR` holder) files an application in a customer's name | Handler compares `SecurityIdentity.principal.name` to `lending.intake.caller-principal` and refuses on mismatch; an unset value refuses everything rather than admitting any operator. Covered by `CustomerIntakeResourceTest` (the test suite goes red when the check is removed). |
+| **S**poofing | A customer applies on behalf of another party | The party id comes only from `X-Customer-Party-Id`, which customer-edge derives from the customer JWT's `party_id`/`sub`; the request body has no party field at all, and the nil UUID is refused. |
+| **T**ampering | An applicant prices their own loan, or picks the compliance regime that judges them | `nominalAnnualRate`, `jurisdiction`, `productType` and `currency` are server configuration, absent from the request schema. An unpriced product refuses (403) rather than defaulting a rate. |
+| **T**ampering | An applicant bypasses the ADR-0212 pack guard by declaring a jurisdiction with no active pack | Same as above — jurisdiction is not caller-supplied, so the (jurisdiction, productType) key the guard resolves is fixed by configuration. |
+| **R**epudiation | "Did the customer really ask for this?" | The maker is recorded as `customer:<partyId>`, namespaced so it can never be mistaken for a desk principal in the ADR-0214 evidence trail nor satisfy a checker leg; customer-edge emits `LOAN_APPLICATION_SUBMITTED` to the audit stream with the upstream status. |
+| **D**oS | An app floods intake, filling the application table and the operator queue | Bounded by customer-edge's `RateLimitFilter` on the customer-facing side and by the amount/term bounds here; the feature defaults OFF (`lending.intake.enabled=false`), so the exposure exists only once deliberately enabled. Per-party application-rate limiting is a gap — see below. |
+| **E**oP | Self-service intake becomes a route to disbursement | It is not: intake creates an application, never a `Loan`; `lending.disburse` remains a separate four-eyes desk action. |
+
+**Residual risks / gaps (not closed by this change):**
+
+- **No per-party intake rate limit in lending-service.** The only throttle is customer-edge's
+  generic filter. A compromised edge, or a second future caller, could enqueue applications faster
+  than the desk can dispose of them. Bounded in practice by the feature defaulting off.
+- **No SCA on submission.** ADR-0211 puts SCA on the *signature*, not the application, so this is
+  by design — but it means an attacker holding a live customer session can file an application in
+  that customer's name. The consequence is an entry in the operator queue, not money movement.
+- **The rego rule is documentation, not enforcement.** `edge-customer-intake` names the intended
+  caller, but `operator-lending-write` already grants the same action more broadly; the rule only
+  becomes load-bearing if that blanket operator grant is narrowed.
+
+## 10. Change log
 
 - **2026-07-31** — Termination and early-exit lifecycle (ADR-0215): termination
   sub-lifecycle states + guard, settlement quote (expired quote refused), statutory
@@ -346,3 +387,12 @@ Tracked as the named bootstrap follow-up (ADR-0212 D4).
   staleness bound, haircut calibration is a placeholder). No DB schema change (reads the existing
   `collateral` table); no new endpoint; rollback = revert the commit (LGD reverts to the flat
   placeholder for every loan, identical to before this increment).
+- **2026-08-01** — ADR-0211 customer self-service intake. `CustomerIntakeResource`
+  (`POST /api/v1/lending/intake/applications`) is the first entry point on this service reachable
+  from outside the bank's staff, so §4's "an employee is behind every write" assumption no longer
+  holds unqualified — new §9 states what replaces it. The control is a named-principal check in the
+  handler, NOT `@RolesAllowed` and NOT rego: customer-edge's M2M token carries `ROLE_OPERATOR` and
+  the interceptor classifies it as `HUMAN`, so neither layer can tell the edge from a person.
+  Default OFF (`lending.intake.enabled=false`) and refuses everything while
+  `lending.intake.caller-principal` is unset. No DB schema change; maker leg only, so the four-eyes
+  disbursement control is untouched; rollback = revert the commit or leave the flag false.

--- a/openbank-customer-edge/src/main/kotlin/com/openbank/customeredge/infrastructure/rest/CustomerEdgeResource.kt
+++ b/openbank-customer-edge/src/main/kotlin/com/openbank/customeredge/infrastructure/rest/CustomerEdgeResource.kt
@@ -442,6 +442,49 @@ class CustomerEdgeResource(
     }
 
     /**
+     * Apply for a loan from the customer app (ADR-0211's "Customer intake" row: customer edge,
+     * ADR-0065). Until this existed the app could only READ loans — `LendingResource.applyForLoan`
+     * is a desk endpoint (`ROLE_LENDING_OFFICER`/`ROLE_CREDIT_RISK`/…), so there was no route by
+     * which a customer could apply at all.
+     *
+     * The party is taken from the JWT and travels as [UpstreamClient.PARTY_HEADER]; the body carries
+     * only what the applicant may legitimately choose (amount, term). Price, jurisdiction and
+     * product type are lending-side configuration — see `CustomerIntakeResource`.
+     *
+     * Deliberately NOT fail-soft. `listLoans` above degrades to `[]` because an empty list is an
+     * honest answer for an unavailable read; for a WRITE, a synthesised success would tell the
+     * customer their application was filed when nothing was. The upstream status and body pass
+     * through, so a 400 (amount out of bounds) reaches the app as a 400 with its reason.
+     */
+    @POST
+    @Path("/loan-applications")
+    @Authorize(action = "customer.profile.write", resource = "")
+    @Blocking
+    fun applyForLoan(request: Map<String, Any?>): Response {
+        val customer = customer()
+        val body = objectMapper.writeValueAsString(
+            mapOf("amount" to request["amount"], "termMonths" to request["termMonths"]),
+        )
+        val resp = upstream.post(
+            "$lendingServiceUrl/api/v1/lending/intake/applications",
+            customer.partyId.toString(),
+            body,
+        )
+        audit.emit(
+            eventType = "LOAN_APPLICATION_SUBMITTED",
+            partyId = customer.partyId.toString(),
+            operation = "loanApplications.create",
+            result = if (resp.statusInfo.family == Response.Status.Family.SUCCESSFUL) "SUCCESS" else "FAILURE",
+            resourceId = extractTextField(objectMapper, (resp.entity as? String).orEmpty(), "id"),
+            details = mapOf("upstreamStatus" to resp.status.toString()),
+        )
+        return Response.status(resp.status)
+            .entity(resp.entity ?: "{}")
+            .type(MediaType.APPLICATION_JSON)
+            .build()
+    }
+
+    /**
      * The repayment schedule for one of the caller's OWN loans. Ownership enforced HERE: the loan is
      * fetched and its partyId compared to the caller (403 otherwise) — lending-service scopes by loan
      * id only. Projects each installment to {number, dueDate, payment, principal, interest, paid}.

--- a/openbank-customer-edge/src/main/resources/openapi.yaml
+++ b/openbank-customer-edge/src/main/resources/openapi.yaml
@@ -3,7 +3,7 @@
 openapi: 3.1.0
 info:
   title: Customer Edge API
-  version: 1.24.0
+  version: 1.25.0
   description: >-
     Customer-facing edge proxy (ADR-0065). Single internet-facing entry point for the
     retail customer app. Validates JWTs from the openbank-customers Keycloak realm,
@@ -33,6 +33,7 @@ tags:
   - name: Preferences
   - name: Feedback
   - name: Cards
+  - name: Lending
 
 paths:
   /feedback:
@@ -503,6 +504,39 @@ paths:
           description: Invalid currency code or instant format
         '502':
           description: Malformed upstream history
+
+  /loan-applications:
+    post:
+      tags: [Lending]
+      summary: Apply for a loan (ADR-0211 customer intake)
+      description: >-
+        Submits a loan application for the caller. The party is taken from the JWT and travels to
+        lending-service as X-Customer-Party-Id — never from the body — so a customer can only apply
+        for themselves. Price, jurisdiction and product type are lending-side configuration, so the
+        applicant cannot price their own loan nor choose which compliance pack judges them.
+        Deliberately not fail-soft: the upstream status and reason pass through, because a
+        synthesised success would tell the customer an application was filed when none was.
+        This is the maker leg only — a human four-eyes decision still gates any disbursement.
+      operationId: applyForLoan
+      security:
+        - customerOidc: []
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              type: object
+              required: [amount, termMonths]
+              properties:
+                amount: {type: number, example: 250000}
+                termMonths: {type: integer, example: 48}
+      responses:
+        '201':
+          description: Application accepted into the origination graph
+        '400':
+          description: Amount or term outside the configured product bounds
+        '403':
+          description: Self-service intake is disabled, unpriced, or the caller is not permitted
 
   /domestic-payments:
     post:

--- a/openbank-infra/gitops/components/lending/gen-lending-opa-bundle.sh
+++ b/openbank-infra/gitops/components/lending/gen-lending-opa-bundle.sh
@@ -18,6 +18,7 @@ LENDING_REST_EXT=$(cat << 'REGO'
 # Actions gated (LendingResource):
 #   lending.create              — submit a loan application (maker)
 #   lending.approve             — approve/reject an application (checker; four-eyes in the handler)
+#   lending.intake              — customer self-service application via customer-edge (ADR-0211)
 #   lending.read                — get application/loan/schedule/collateral/IFRS-9 snapshot (#id)
 #   lending.list                — list a party's applications/loans
 #   lending.disburse            — disburse an approved application (books the loan)
@@ -108,12 +109,31 @@ allowed_reasons contains "compliance-lending-desk" if {
 	}
 }
 
-# NO SERVICE (M2M) rule on purpose: no in-repo service calls lending's @Authorize
-# endpoints today (verified — the only cross-namespace ingress is the admin-ui BFF's
-# unauthenticated /api/v1/info discovery and the observability/security-scanner
-# management-port probes; ledger posting is an OUTBOUND call from lending). A blanket
-# SERVICE allow would open every endpoint to any M2M client. If a future caller lands
-# (e.g. anacredit moving from Kafka to REST), add a named, action-scoped rule here.
+# customer-edge submits customer self-service loan applications (ADR-0211's "Customer
+# intake" row; CustomerIntakeResource). This is the named, action-scoped M2M rule the note
+# below anticipated — the first in-repo service to call a lending @Authorize endpoint.
+#
+# Identified by principal.id, NOT by principal.type: AuthorizeInterceptor classifies a
+# client_credentials JWT as HUMAN, so `input.principal.type == "SERVICE"` can never fire
+# (issue #266), and edge's only role is ROLE_OPERATOR, which real staff also carry.
+#
+# This rule is NOT the control. `operator-lending-write` above already admits any
+# lending.* action for a ROLE_OPERATOR principal, so rego cannot be what stops a person
+# at a desk from filing an application in a customer's name — CustomerIntakeResource
+# checks the principal name against `lending.intake.caller-principal` in Kotlin and
+# refuses when it is unset. This rule states the intent, and narrows the day the blanket
+# operator grant is tightened.
+allowed_reasons contains "edge-customer-intake" if {
+	input.principal.id == "service-account-openbank-edge"
+	input.action == "lending.intake"
+}
+
+# NO BLANKET SERVICE (M2M) rule on purpose: the only in-repo M2M caller is the one named
+# above (the admin-ui BFF reaches only the unauthenticated /api/v1/info discovery, the
+# observability/security scanners use the management port, and ledger posting is an
+# OUTBOUND call from lending). A blanket SERVICE allow would open every endpoint to any
+# M2M client. If a future caller lands (e.g. anacredit moving from Kafka to REST), add
+# another named, action-scoped rule here.
 REGO
 )
 

--- a/openbank-infra/gitops/components/lending/lending-opa-bundle.yaml
+++ b/openbank-infra/gitops/components/lending/lending-opa-bundle.yaml
@@ -9,7 +9,7 @@ metadata:
     app.kubernetes.io/name: lending-service
     app.kubernetes.io/part-of: lending
   annotations:
-    openbank.tech/policy-checksum: "903fddf8a5bd38d7"
+    openbank.tech/policy-checksum: "9449007dc499f6d0"
 data:
   rest.rego: |
     # SPDX-License-Identifier: Apache-2.0
@@ -506,6 +506,7 @@ data:
     # Actions gated (LendingResource):
     #   lending.create              — submit a loan application (maker)
     #   lending.approve             — approve/reject an application (checker; four-eyes in the handler)
+    #   lending.intake              — customer self-service application via customer-edge (ADR-0211)
     #   lending.read                — get application/loan/schedule/collateral/IFRS-9 snapshot (#id)
     #   lending.list                — list a party's applications/loans
     #   lending.disburse            — disburse an approved application (books the loan)
@@ -596,12 +597,31 @@ data:
     	}
     }
 
-    # NO SERVICE (M2M) rule on purpose: no in-repo service calls lending's @Authorize
-    # endpoints today (verified — the only cross-namespace ingress is the admin-ui BFF's
-    # unauthenticated /api/v1/info discovery and the observability/security-scanner
-    # management-port probes; ledger posting is an OUTBOUND call from lending). A blanket
-    # SERVICE allow would open every endpoint to any M2M client. If a future caller lands
-    # (e.g. anacredit moving from Kafka to REST), add a named, action-scoped rule here.
+    # customer-edge submits customer self-service loan applications (ADR-0211's "Customer
+    # intake" row; CustomerIntakeResource). This is the named, action-scoped M2M rule the note
+    # below anticipated — the first in-repo service to call a lending @Authorize endpoint.
+    #
+    # Identified by principal.id, NOT by principal.type: AuthorizeInterceptor classifies a
+    # client_credentials JWT as HUMAN, so `input.principal.type == "SERVICE"` can never fire
+    # (issue #266), and edge's only role is ROLE_OPERATOR, which real staff also carry.
+    #
+    # This rule is NOT the control. `operator-lending-write` above already admits any
+    # lending.* action for a ROLE_OPERATOR principal, so rego cannot be what stops a person
+    # at a desk from filing an application in a customer's name — CustomerIntakeResource
+    # checks the principal name against `lending.intake.caller-principal` in Kotlin and
+    # refuses when it is unset. This rule states the intent, and narrows the day the blanket
+    # operator grant is tightened.
+    allowed_reasons contains "edge-customer-intake" if {
+    	input.principal.id == "service-account-openbank-edge"
+    	input.action == "lending.intake"
+    }
+
+    # NO BLANKET SERVICE (M2M) rule on purpose: the only in-repo M2M caller is the one named
+    # above (the admin-ui BFF reaches only the unauthenticated /api/v1/info discovery, the
+    # observability/security scanners use the management port, and ledger posting is an
+    # OUTBOUND call from lending). A blanket SERVICE allow would open every endpoint to any
+    # M2M client. If a future caller lands (e.g. anacredit moving from Kafka to REST), add
+    # another named, action-scoped rule here.
   agents.rego: |
     # SPDX-License-Identifier: Apache-2.0
     # Copyright (c) OpenBank contributors. Licensed under the Apache License, Version 2.0.
@@ -2929,27 +2949,6 @@ data:
             analytics-sink deliberately DROPS hibernate-reactive-panache, reactive-pg-client and
             jdbc-postgresql (build.gradle.kts) — it has no OLTP datasource to reach. The
             reconciliation reads the warehouse and the WORM archive over blocking clients.
-
-      no_reactive_from_nonsuspend_scheduled_body: true
-      # The SAME defect without the `runBlocking` spelling — and keying the first version of this
-      # gate on that spelling is precisely how it walked past. #2913:
-      # ConsentExpirationJob.sweepExpiredConsents() built a Uni and `subscribe()`d it, with no
-      # `runBlocking` anywhere. `subscribe()` reads as "hand this off, it runs elsewhere" and does
-      # not: the subscription starts on the CALLER's thread, which is the contextless
-      # executor-thread. The hourly consent-expiration sweep had therefore never once succeeded
-      # (GDPR Art. 17 / PSD2 RTS Art. 10 — expired consents stayed ACTIVE and the ConsentExpired
-      # event never reached a single consumer), and the sweep for that shape found two more:
-      # notification-service's device-token sweep (ADR-0135) and its dead-letter janitor
-      # (ADR-0050 N5). Neither had ever purged a row.
-      #
-      # RULE: a @Scheduled method that starts reactive work must be `suspend` — or declared to
-      # return `Uni<…>`, the other shape Quarkus dispatches on a proper (duplicated) Vert.x context,
-      # which four services already use. The gate checks that PROPERTY rather than one forbidden
-      # identifier, so the next spelling is covered too.
-      #
-      # Same exception idiom as runblocking_allowlist above, and a stale entry is a violation in
-      # either direction.
-      nonsuspend_reactive_allowlist: []
       ci_producer: ".github/scripts/check-no-runblocking-in-scheduled.py"
 
       # The structural reason the HR000068 class was invisible (#2204). `quarkus.scheduler.enabled:

--- a/openbank-infra/gitops/components/lending/lending-opa-bundle.yaml
+++ b/openbank-infra/gitops/components/lending/lending-opa-bundle.yaml
@@ -9,7 +9,7 @@ metadata:
     app.kubernetes.io/name: lending-service
     app.kubernetes.io/part-of: lending
   annotations:
-    openbank.tech/policy-checksum: "9449007dc499f6d0"
+    openbank.tech/policy-checksum: "e6e468f8de3e49b3"
 data:
   rest.rego: |
     # SPDX-License-Identifier: Apache-2.0
@@ -2949,6 +2949,27 @@ data:
             analytics-sink deliberately DROPS hibernate-reactive-panache, reactive-pg-client and
             jdbc-postgresql (build.gradle.kts) — it has no OLTP datasource to reach. The
             reconciliation reads the warehouse and the WORM archive over blocking clients.
+
+      no_reactive_from_nonsuspend_scheduled_body: true
+      # The SAME defect without the `runBlocking` spelling — and keying the first version of this
+      # gate on that spelling is precisely how it walked past. #2913:
+      # ConsentExpirationJob.sweepExpiredConsents() built a Uni and `subscribe()`d it, with no
+      # `runBlocking` anywhere. `subscribe()` reads as "hand this off, it runs elsewhere" and does
+      # not: the subscription starts on the CALLER's thread, which is the contextless
+      # executor-thread. The hourly consent-expiration sweep had therefore never once succeeded
+      # (GDPR Art. 17 / PSD2 RTS Art. 10 — expired consents stayed ACTIVE and the ConsentExpired
+      # event never reached a single consumer), and the sweep for that shape found two more:
+      # notification-service's device-token sweep (ADR-0135) and its dead-letter janitor
+      # (ADR-0050 N5). Neither had ever purged a row.
+      #
+      # RULE: a @Scheduled method that starts reactive work must be `suspend` — or declared to
+      # return `Uni<…>`, the other shape Quarkus dispatches on a proper (duplicated) Vert.x context,
+      # which four services already use. The gate checks that PROPERTY rather than one forbidden
+      # identifier, so the next spelling is covered too.
+      #
+      # Same exception idiom as runblocking_allowlist above, and a stale entry is a violation in
+      # either direction.
+      nonsuspend_reactive_allowlist: []
       ci_producer: ".github/scripts/check-no-runblocking-in-scheduled.py"
 
       # The structural reason the HR000068 class was invisible (#2204). `quarkus.scheduler.enabled:

--- a/openbank-infra/gitops/components/lending/lending-service.yaml
+++ b/openbank-infra/gitops/components/lending/lending-service.yaml
@@ -34,7 +34,7 @@ spec:
       annotations:
         # Rolls the pods when the OPA bundle changes — subPath mounts do NOT hot-reload.
         # Kept in sync by gen-lending-opa-bundle.sh (do not hand-edit).
-        openbank.tech/policy-checksum: "903fddf8a5bd38d7"
+        openbank.tech/policy-checksum: "e6e468f8de3e49b3"
     spec:
       securityContext:
         runAsNonRoot: true

--- a/openbank-lending-service/src/main/kotlin/com/openbank/lending/infrastructure/intake/CustomerIntakeConfig.kt
+++ b/openbank-lending-service/src/main/kotlin/com/openbank/lending/infrastructure/intake/CustomerIntakeConfig.kt
@@ -1,0 +1,47 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright (c) OpenBank contributors. Licensed under the Apache License, Version 2.0.
+// See LICENSE in the repository root or https://www.apache.org/licenses/LICENSE-2.0 for details.
+
+package com.openbank.lending.infrastructure.intake
+
+import jakarta.enterprise.context.ApplicationScoped
+import org.eclipse.microprofile.config.inject.ConfigProperty
+import java.math.BigDecimal
+import java.util.Optional
+
+/**
+ * Customer self-service origination intake (ADR-0211: "Customer intake + signature | customer edge
+ * (ADR-0065) + SCA (ADR-0021)"). Every value here is a REFUSAL boundary, not a preference — the
+ * request body carries no price, no jurisdiction and no product, because a customer-supplied
+ * nominal rate or jurisdiction would let the applicant choose which compliance pack judges them.
+ *
+ * Default OFF. When on, [callerPrincipal] must name the one M2M identity permitted to submit on a
+ * customer's behalf; an empty value refuses every call rather than admitting any operator (see
+ * [CustomerIntakeResource] for why that check cannot live in rego alone).
+ */
+@ApplicationScoped
+@Suppress("LongParameterList")
+class CustomerIntakeConfig(
+    @param:ConfigProperty(name = "lending.intake.enabled", defaultValue = "false")
+    val enabled: Boolean = false,
+    /** The ONLY principal allowed to submit on a customer's behalf. Blank ⇒ refuse everything. */
+    @param:ConfigProperty(name = "lending.intake.caller-principal")
+    val callerPrincipal: Optional<String> = Optional.empty(),
+    @param:ConfigProperty(name = "lending.intake.jurisdiction", defaultValue = "CZ")
+    val jurisdiction: String = "CZ",
+    @param:ConfigProperty(name = "lending.intake.product-type", defaultValue = "CONSUMER_CREDIT")
+    val productType: String = "CONSUMER_CREDIT",
+    @param:ConfigProperty(name = "lending.intake.currency", defaultValue = "CZK")
+    val currency: String = "CZK",
+    /** Offered nominal annual rate. No default: an unpriced product must refuse, never guess. */
+    @param:ConfigProperty(name = "lending.intake.nominal-annual-rate")
+    val nominalAnnualRate: Optional<BigDecimal> = Optional.empty(),
+    @param:ConfigProperty(name = "lending.intake.min-amount", defaultValue = "5000")
+    val minAmount: BigDecimal = BigDecimal("5000"),
+    @param:ConfigProperty(name = "lending.intake.max-amount", defaultValue = "1000000")
+    val maxAmount: BigDecimal = BigDecimal("1000000"),
+    @param:ConfigProperty(name = "lending.intake.min-term-months", defaultValue = "6")
+    val minTermMonths: Int = 6,
+    @param:ConfigProperty(name = "lending.intake.max-term-months", defaultValue = "120")
+    val maxTermMonths: Int = 120,
+)

--- a/openbank-lending-service/src/main/kotlin/com/openbank/lending/infrastructure/rest/CustomerIntakeResource.kt
+++ b/openbank-lending-service/src/main/kotlin/com/openbank/lending/infrastructure/rest/CustomerIntakeResource.kt
@@ -1,0 +1,160 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright (c) OpenBank contributors. Licensed under the Apache License, Version 2.0.
+// See LICENSE in the repository root or https://www.apache.org/licenses/LICENSE-2.0 for details.
+
+package com.openbank.lending.infrastructure.rest
+
+import com.openbank.lending.application.port.`in`.ApplyForLoanUseCase
+import com.openbank.lending.domain.model.LoanApplicationRequest
+import com.openbank.lending.infrastructure.intake.CustomerIntakeConfig
+import com.openbank.libs.authz.Authorize
+import com.openbank.libs.domain.money.CurrencyCode
+import com.openbank.libs.domain.money.Money
+import io.quarkus.security.identity.SecurityIdentity
+import io.smallrye.mutiny.Uni
+import jakarta.annotation.security.RolesAllowed
+import jakarta.ws.rs.Consumes
+import jakarta.ws.rs.HeaderParam
+import jakarta.ws.rs.POST
+import jakarta.ws.rs.Path
+import jakarta.ws.rs.Produces
+import jakarta.ws.rs.core.MediaType
+import jakarta.ws.rs.core.Response
+import org.eclipse.microprofile.openapi.annotations.Operation
+import org.eclipse.microprofile.openapi.annotations.tags.Tag
+import java.math.BigDecimal
+import java.time.Clock
+import java.time.LocalDate
+import java.util.UUID
+
+/**
+ * Customer self-service origination intake (ADR-0211's "Customer intake" row: customer edge,
+ * ADR-0065). This is the missing half of the origination path — `LendingResource.applyForLoan` is a
+ * DESK endpoint (`ROLE_LENDING_OFFICER`/`ROLE_CREDIT_RISK`/`ROLE_COMPLIANCE`/`ROLE_ADMIN`), so a
+ * customer app had no route by which to apply at all.
+ *
+ * ## Why the caller check is in Kotlin and not only in rego
+ *
+ * customer-edge's M2M identity carries `ROLE_OPERATOR` and NOTHING else, and `AuthorizeInterceptor`
+ * classifies a client_credentials JWT as `HUMAN` — so lending's `operator-lending-write` rego rule
+ * already admits any `lending.*` action for it. Gating this endpoint on `ROLE_OPERATOR` alone would
+ * therefore let *any* operator — a real person at a desk — submit an application in a customer's
+ * name, with the party id supplied in a header. The named-principal check below is the actual
+ * control; the rego rule added alongside is defence in depth, and neither is load-bearing alone.
+ *
+ * ## What is NOT trusted from the request
+ *
+ * The party id comes from `X-Customer-Party-Id` (set by the edge from the customer JWT, never by the
+ * app), and the price, jurisdiction and product type come from configuration. A customer-supplied
+ * jurisdiction would let the applicant choose which ADR-0212 compliance pack judges them; a
+ * customer-supplied rate would let them price their own loan.
+ *
+ * This endpoint is the MAKER leg only. The application lands in the ordinary origination graph and
+ * still needs a human checker (`lending.approve`, four-eyes) before anything is disbursed — a
+ * customer cannot originate money by calling it.
+ */
+@Path("/api/v1/lending/intake")
+@Produces(MediaType.APPLICATION_JSON)
+@Consumes(MediaType.APPLICATION_JSON)
+@Tag(name = "Lending", description = "Customer self-service origination intake")
+@RolesAllowed("ROLE_OPERATOR", "ROLE_ADMIN")
+class CustomerIntakeResource(
+    private val apply: ApplyForLoanUseCase,
+    private val config: CustomerIntakeConfig,
+    private val identity: SecurityIdentity,
+    private val clock: Clock,
+) {
+    @POST
+    @Path("/applications")
+    @Authorize(action = "lending.intake", resource = "")
+    @Operation(summary = "Submit a loan application on behalf of an authenticated customer (edge only)")
+    fun submit(@HeaderParam(PARTY_HEADER) partyHeader: String?, request: CustomerIntakeRequest): Uni<Response> {
+        val refusal = refuse(partyHeader, request)
+        if (refusal != null) return Uni.createFrom().item(refusal)
+
+        val partyId = UUID.fromString(partyHeader)
+        val application = LoanApplicationRequest(
+            partyId = partyId,
+            requestedAmount = Money(request.amount, CurrencyCode.of(config.currency)),
+            nominalAnnualRate = config.nominalAnnualRate.get(),
+            termPeriods = request.termMonths,
+            firstDueDate = firstDueDate(),
+            jurisdiction = config.jurisdiction,
+            productType = config.productType,
+        )
+        return apply.apply(application, "$CUSTOMER_ACTOR_PREFIX$partyId")
+            .map { Response.status(HTTP_CREATED).entity(it).build() }
+            .onFailure().recoverWithItem { e -> error(HTTP_UNPROCESSABLE, e.message ?: "intake refused") }
+    }
+
+    /**
+     * Every guard, in one place and fail-closed: a `null` return is the ONLY way through. Written as
+     * a refusal function rather than a chain of early returns inside [submit] so that adding a
+     * transport concern later cannot accidentally land above a check.
+     */
+    @Suppress("ReturnCount")
+    private fun refuse(partyHeader: String?, request: CustomerIntakeRequest): Response? {
+        if (!config.enabled) return error(HTTP_FORBIDDEN, "customer self-service intake is disabled")
+
+        val permitted = config.callerPrincipal.orElse("")
+        // Blank config refuses everything. The alternative — "unset means allow any operator" — is
+        // exactly the over-grant this endpoint exists to avoid, and it would arrive by omission.
+        if (permitted.isBlank() || identity.principal?.name != permitted) {
+            return error(HTTP_FORBIDDEN, "caller is not the customer-edge intake principal")
+        }
+        val partyId = partyHeader?.let { runCatching { UUID.fromString(it) }.getOrNull() }
+            ?: return error(HTTP_BAD_REQUEST, "$PARTY_HEADER is missing or not a UUID")
+        if (partyId == ZERO_UUID) return error(HTTP_BAD_REQUEST, "$PARTY_HEADER is the nil UUID")
+
+        if (config.nominalAnnualRate.isEmpty) {
+            return error(HTTP_FORBIDDEN, "self-service product has no configured price")
+        }
+        if (request.amount < config.minAmount || request.amount > config.maxAmount) {
+            return error(HTTP_BAD_REQUEST, "amount outside [${config.minAmount}, ${config.maxAmount}]")
+        }
+        // Money's init rejects an over-scaled amount by THROWING, which a client sees as a 500. An
+        // app sending 50000.123 CZK is making an ordinary mistake and deserves an ordinary 400.
+        val currency = runCatching { CurrencyCode.of(config.currency) }.getOrNull()
+            ?: return error(HTTP_FORBIDDEN, "self-service product currency is not a valid ISO code")
+        if (request.amount.scale() > currency.defaultFractionDigits) {
+            return error(
+                HTTP_BAD_REQUEST,
+                "amount has more than ${currency.defaultFractionDigits} decimal places for ${currency.code}",
+            )
+        }
+        if (request.termMonths < config.minTermMonths || request.termMonths > config.maxTermMonths) {
+            return error(
+                HTTP_BAD_REQUEST,
+                "termMonths outside [${config.minTermMonths}, ${config.maxTermMonths}]",
+            )
+        }
+        return null
+    }
+
+    /** First day of the month after next — a full month of runway before instalment one. */
+    private fun firstDueDate(): LocalDate = LocalDate.now(clock).withDayOfMonth(1).plusMonths(2)
+
+    private fun error(status: Int, message: String): Response =
+        Response.status(status).entity(mapOf("error" to message)).build()
+
+    companion object {
+        const val PARTY_HEADER = "X-Customer-Party-Id"
+
+        /** Actor recorded on the application. Namespaced so a customer maker can never be mistaken
+         *  for a desk principal in the ADR-0214 evidence trail, nor satisfy a checker leg. */
+        const val CUSTOMER_ACTOR_PREFIX = "customer:"
+
+        private val ZERO_UUID = UUID(0, 0)
+        private const val HTTP_CREATED = 201
+        private const val HTTP_BAD_REQUEST = 400
+        private const val HTTP_FORBIDDEN = 403
+        private const val HTTP_UNPROCESSABLE = 422
+    }
+}
+
+/**
+ * What the customer app may say. Note what is ABSENT: party id, rate, jurisdiction, product type —
+ * see the class KDoc. Nothing else is accepted: a field the service takes and then silently drops
+ * reads to the client as an honoured request, which is worse than a 400.
+ */
+data class CustomerIntakeRequest(val amount: BigDecimal, val termMonths: Int)

--- a/openbank-lending-service/src/main/resources/application.yaml
+++ b/openbank-lending-service/src/main/resources/application.yaml
@@ -143,6 +143,22 @@ lending:
     # after the CZ reference pack is seeded and four-eyes-activated — with enforcement on and no
     # active pack for the request's (jurisdiction, productType), origination is REFUSED.
     enforce-pack: ${LENDING_ENFORCE_PACK:false}
+  # Customer self-service origination intake (ADR-0211 "Customer intake" row; CustomerIntakeResource).
+  # Default OFF. `caller-principal` is the ONLY identity permitted to submit on a customer's behalf —
+  # left blank, EVERY call is refused, deliberately: customer-edge's M2M token carries ROLE_OPERATOR
+  # and nothing else, so "unset means any operator" would be an over-grant arriving by omission.
+  # There is no default price: an unpriced product refuses rather than guessing a rate.
+  intake:
+    enabled: ${LENDING_INTAKE_ENABLED:false}
+    caller-principal: ${LENDING_INTAKE_CALLER_PRINCIPAL:}
+    jurisdiction: ${LENDING_INTAKE_JURISDICTION:CZ}
+    product-type: ${LENDING_INTAKE_PRODUCT_TYPE:CONSUMER_CREDIT}
+    currency: ${LENDING_INTAKE_CURRENCY:CZK}
+    nominal-annual-rate: ${LENDING_INTAKE_NOMINAL_ANNUAL_RATE:}
+    min-amount: ${LENDING_INTAKE_MIN_AMOUNT:5000}
+    max-amount: ${LENDING_INTAKE_MAX_AMOUNT:1000000}
+    min-term-months: ${LENDING_INTAKE_MIN_TERM_MONTHS:6}
+    max-term-months: ${LENDING_INTAKE_MAX_TERM_MONTHS:120}
   origination:
     # Sandbox straight-through (ADR-0211 D5, ADR-0116 pattern): a submitted application is driven to
     # READY_TO_DISBURSE by the 'sandbox-auto-approval' actor so sandbox e2e runs without an operator.

--- a/openbank-lending-service/src/main/resources/openapi.yaml
+++ b/openbank-lending-service/src/main/resources/openapi.yaml
@@ -3,7 +3,7 @@
 openapi: 3.1.0
 info:
   title: Lending Service API
-  version: 1.10.0
+  version: 1.11.0
   description: >-
     Loan origination, servicing, collateral and IFRS 9 provisioning (ADR-0028). The loan book posts
     cash events to ledger-service and never owns balances. Credit decisions and collateral
@@ -52,6 +52,39 @@ paths:
           description: Applications for the party
         '403':
           $ref: '#/components/responses/Forbidden'
+  /api/v1/lending/intake/applications:
+    post:
+      tags: [Lending]
+      operationId: submitCustomerIntake
+      summary: Submit a loan application on behalf of an authenticated customer (customer-edge only)
+      description: >-
+        Customer self-service origination intake (ADR-0211). The party id is taken from the
+        X-Customer-Party-Id header set by customer-edge from the customer JWT — never from the body.
+        Price, jurisdiction and product type are lending-side configuration, so an applicant can
+        neither price their own loan nor choose which ADR-0212 compliance pack judges them. Only the
+        configured customer-edge service principal may call it; any other caller is refused 403.
+        This is the MAKER leg only — the application still needs a human four-eyes decision.
+      parameters:
+        - name: X-Customer-Party-Id
+          in: header
+          required: true
+          description: The applicant's party id, set by customer-edge from the customer JWT.
+          schema: { type: string, format: uuid }
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/CustomerIntakeRequest'
+      responses:
+        '201':
+          description: Application accepted into the origination graph
+        '400':
+          $ref: '#/components/responses/BadRequest'
+        '403':
+          $ref: '#/components/responses/Forbidden'
+        '422':
+          description: Refused by the origination guard (e.g. no active compliance pack)
   /api/v1/lending/applications/{id}:
     get:
       tags: [Lending]
@@ -641,6 +674,21 @@ components:
       properties:
         amount: { type: number }
         currency: { type: string, description: ISO-4217 currency code }
+    CustomerIntakeRequest:
+      type: object
+      required: [amount, termMonths]
+      description: >-
+        What a customer app may state. Note what is absent — partyId, nominalAnnualRate,
+        jurisdiction, productType. Those are the trusted header and server configuration
+        respectively; accepting any of them from the applicant would let them submit for another
+        party, price their own loan, or select the compliance pack that judges them.
+      properties:
+        amount:
+          type: number
+          description: Requested principal, in the configured self-service currency.
+        termMonths:
+          type: integer
+          description: Requested term. Bounds are server configuration; outside them is a 400.
     LoanApplicationRequest:
       type: object
       required: [partyId, requestedAmount, nominalAnnualRate, termPeriods, firstDueDate]

--- a/openbank-lending-service/src/test/kotlin/com/openbank/lending/infrastructure/rest/CustomerIntakeResourceTest.kt
+++ b/openbank-lending-service/src/test/kotlin/com/openbank/lending/infrastructure/rest/CustomerIntakeResourceTest.kt
@@ -1,0 +1,195 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright (c) OpenBank contributors. Licensed under the Apache License, Version 2.0.
+// See LICENSE in the repository root or https://www.apache.org/licenses/LICENSE-2.0 for details.
+
+package com.openbank.lending.infrastructure.rest
+
+import com.openbank.lending.application.port.`in`.ApplyForLoanUseCase
+import com.openbank.lending.domain.model.DecisionRequest
+import com.openbank.lending.domain.model.LoanApplication
+import com.openbank.lending.domain.model.LoanApplicationRequest
+import com.openbank.lending.infrastructure.intake.CustomerIntakeConfig
+import com.openbank.libs.domain.identifiers.LoanApplicationId
+import io.quarkus.security.identity.SecurityIdentity
+import io.quarkus.security.runtime.QuarkusSecurityIdentity
+import io.smallrye.mutiny.Uni
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.Test
+import java.math.BigDecimal
+import java.security.Principal
+import java.time.Clock
+import java.time.Instant
+import java.time.LocalDate
+import java.time.ZoneOffset
+import java.util.Optional
+import java.util.UUID
+
+/**
+ * The intake endpoint is a security boundary before it is a feature, so these tests are written
+ * against the ways it can WRONGLY admit a request, not the happy path alone:
+ *  - a real operator (not the edge) submitting in a customer's name,
+ *  - `caller-principal` left unset being read as "anyone may",
+ *  - the party id arriving in the body instead of the trusted header,
+ *  - the price arriving from the customer.
+ *
+ * Each is a case where the endpoint returning 201 would be a defect no downstream layer can catch:
+ * the application it creates is indistinguishable from a genuine one.
+ */
+class CustomerIntakeResourceTest {
+
+    private val clock = Clock.fixed(Instant.parse("2026-08-01T10:00:00Z"), ZoneOffset.UTC)
+    private val partyId = UUID.fromString("05a02ef1-381c-40e7-b73f-d6855eead42e")
+    private val edge = "service-account-openbank-edge"
+
+    private fun config(
+        enabled: Boolean = true,
+        caller: String? = "service-account-openbank-edge",
+        rate: BigDecimal? = BigDecimal("0.079"),
+    ) = CustomerIntakeConfig(
+        enabled = enabled,
+        callerPrincipal = Optional.ofNullable(caller),
+        nominalAnnualRate = Optional.ofNullable(rate),
+    )
+
+    private fun identity(name: String): SecurityIdentity =
+        QuarkusSecurityIdentity.builder().setPrincipal(Principal { name }).build()
+
+    private fun resource(
+        config: CustomerIntakeConfig = config(),
+        principal: String = edge,
+        apply: RecordingApply = RecordingApply(),
+    ) = CustomerIntakeResource(apply, config, identity(principal), clock) to apply
+
+    private fun request(amount: String = "250000", term: Int = 48) = CustomerIntakeRequest(BigDecimal(amount), term)
+
+    @Test
+    fun `accepts an application from the edge principal and records the customer as maker`() {
+        val (res, apply) = resource()
+
+        val response = res.submit(partyId.toString(), request()).await().indefinitely()
+
+        assertThat(response.status).isEqualTo(201)
+        assertThat(apply.lastRequest?.partyId).isEqualTo(partyId)
+        // The maker is namespaced. A customer maker must never be mistakable for a desk principal in
+        // the ADR-0214 evidence trail, nor satisfy the checker leg of the four-eyes decision.
+        assertThat(apply.lastActor).isEqualTo("customer:$partyId")
+    }
+
+    @Test
+    fun `refuses an ordinary operator who is not the edge principal`() {
+        val (res, apply) = resource(principal = "alice@openbank.local")
+
+        val response = res.submit(partyId.toString(), request()).await().indefinitely()
+
+        // @RolesAllowed(ROLE_OPERATOR) alone would have admitted this: the edge's M2M token carries
+        // ROLE_OPERATOR and nothing else, so the role cannot distinguish the edge from a person.
+        assertThat(response.status).isEqualTo(403)
+        assertThat(apply.lastRequest).isNull()
+    }
+
+    @Test
+    fun `an unset caller-principal refuses everything rather than admitting any operator`() {
+        val (res, apply) = resource(config = config(caller = null))
+
+        val response = res.submit(partyId.toString(), request()).await().indefinitely()
+
+        assertThat(response.status).isEqualTo(403)
+        assertThat(apply.lastRequest).isNull()
+    }
+
+    @Test
+    fun `refuses when the feature is off`() {
+        val (res, apply) = resource(config = config(enabled = false))
+
+        assertThat(res.submit(partyId.toString(), request()).await().indefinitely().status).isEqualTo(403)
+        assertThat(apply.lastRequest).isNull()
+    }
+
+    @Test
+    fun `refuses an unpriced product instead of guessing a rate`() {
+        val (res, apply) = resource(config = config(rate = null))
+
+        assertThat(res.submit(partyId.toString(), request()).await().indefinitely().status).isEqualTo(403)
+        assertThat(apply.lastRequest).isNull()
+    }
+
+    @Test
+    fun `refuses a missing or malformed party header`() {
+        val (res, apply) = resource()
+
+        assertThat(res.submit(null, request()).await().indefinitely().status).isEqualTo(400)
+        assertThat(res.submit("not-a-uuid", request()).await().indefinitely().status).isEqualTo(400)
+        // The nil UUID is a real value that parses; it is also what an unset header downstream looks
+        // like, so it must not become a party every customer shares.
+        assertThat(res.submit("00000000-0000-0000-0000-000000000000", request()).await().indefinitely().status)
+            .isEqualTo(400)
+        assertThat(apply.lastRequest).isNull()
+    }
+
+    @Test
+    fun `refuses amounts and terms outside the configured product bounds`() {
+        val (res, apply) = resource()
+
+        assertThat(res.submit(partyId.toString(), request(amount = "4999")).await().indefinitely().status)
+            .isEqualTo(400)
+        assertThat(res.submit(partyId.toString(), request(amount = "1000001")).await().indefinitely().status)
+            .isEqualTo(400)
+        assertThat(res.submit(partyId.toString(), request(term = 5)).await().indefinitely().status).isEqualTo(400)
+        assertThat(res.submit(partyId.toString(), request(term = 121)).await().indefinitely().status).isEqualTo(400)
+        assertThat(apply.lastRequest).isNull()
+    }
+
+    @Test
+    fun `an over-scaled amount is a 400, not the 500 that Money's init would raise`() {
+        val (res, apply) = resource()
+
+        val response = res.submit(partyId.toString(), CustomerIntakeRequest(BigDecimal("250000.123"), 48))
+            .await().indefinitely()
+
+        assertThat(response.status).isEqualTo(400)
+        assertThat(apply.lastRequest).isNull()
+    }
+
+    @Test
+    fun `price jurisdiction and product come from configuration, never from the caller`() {
+        val (res, apply) = resource()
+
+        res.submit(partyId.toString(), request()).await().indefinitely()
+
+        val submitted = requireNotNull(apply.lastRequest)
+        assertThat(submitted.nominalAnnualRate).isEqualByComparingTo(BigDecimal("0.079"))
+        // A customer-chosen jurisdiction would let the applicant pick which ADR-0212 compliance pack
+        // judges them — the pack is keyed on (jurisdiction, productType).
+        assertThat(submitted.jurisdiction).isEqualTo("CZ")
+        assertThat(submitted.productType).isEqualTo("CONSUMER_CREDIT")
+        assertThat(submitted.requestedAmount.currency.code).isEqualTo("CZK")
+        // A full month of runway before instalment one, derived from the clock and not the request.
+        assertThat(submitted.firstDueDate).isEqualTo(LocalDate.parse("2026-10-01"))
+    }
+
+    /** Records what the resource actually handed the use case — the assertions that matter are about
+     *  the request the DESK layer will see, not about the HTTP status alone. */
+    private class RecordingApply : ApplyForLoanUseCase {
+        var lastRequest: LoanApplicationRequest? = null
+        var lastActor: String? = null
+
+        override fun apply(request: LoanApplicationRequest, proposedBy: String): Uni<LoanApplication> {
+            lastRequest = request
+            lastActor = proposedBy
+            return Uni.createFrom().nullItem()
+        }
+
+        override fun decide(id: LoanApplicationId, decision: DecisionRequest, decidedBy: String) =
+            unsupported<LoanApplication>()
+        override fun getApplication(id: LoanApplicationId): Uni<LoanApplication?> = unsupported()
+        override fun listApplications(partyId: UUID) = unsupported<List<LoanApplication>>()
+        override fun advance(id: LoanApplicationId, actor: String) = unsupported<LoanApplication>()
+        override fun expireIfInState(id: LoanApplicationId, expectedState: String, actor: String) =
+            unsupported<LoanApplication>()
+        override fun advanceIfInState(id: LoanApplicationId, expectedState: String, actor: String) =
+            unsupported<LoanApplication>()
+        override fun listRecentApplications(status: String?, limit: Int) = unsupported<List<LoanApplication>>()
+
+        private fun <T> unsupported(): Uni<T> = throw UnsupportedOperationException("not used by intake")
+    }
+}


### PR DESCRIPTION
## What

The missing half of ADR-0211's origination path: a customer can now **apply** for a loan from the app.

- `POST /customer/v1/loan-applications` — customer-edge, `ROLE_CUSTOMER`. Party from the JWT,
  forwarded as `X-Customer-Party-Id`.
- `POST /api/v1/lending/intake/applications` — lending-service. Binds the party from that header;
  price, jurisdiction and product type come from configuration.

**Maker leg only.** The application enters the ordinary origination graph and still needs a human
checker (`lending.approve`, four-eyes) before anything is disbursed. This endpoint cannot move money.

## Why it did not exist

ADR-0211 names the customer edge as the intake channel ("Customer intake + signature | customer edge
(ADR-0065) + SCA (ADR-0021)"), but `LendingResource.applyForLoan` is a **desk** endpoint —
`ROLE_LENDING_OFFICER` / `ROLE_CREDIT_RISK` / `ROLE_COMPLIANCE` / `ROLE_ADMIN`. customer-edge already
proxied `/loans` and `/loans/{id}/schedule`, so the app could read a loan it had no way to ask for.

## The one design decision worth reviewing

**The caller check is in Kotlin, not in `@RolesAllowed` and not in rego.** customer-edge's M2M
identity carries `ROLE_OPERATOR` and nothing else, and `AuthorizeInterceptor` classifies a
client_credentials JWT as `HUMAN`. So:

- the JAX-RS role gate cannot distinguish the edge from a real person at a desk, and
- lending's existing `operator-lending-write` rego rule already admits **every** `lending.*` action
  for any `ROLE_OPERATOR` principal.

Gating this endpoint on `ROLE_OPERATOR` alone would therefore let any operator file an application
in a customer's name, with the party id supplied in a header. The handler compares
`SecurityIdentity.principal.name` against `lending.intake.caller-principal` and **refuses everything
while that is unset** — an "unset means any operator may" default would be precisely the over-grant
this endpoint exists to avoid, arriving by omission.

The `edge-customer-intake` rego rule added alongside identifies the caller by `principal.id` (never
`principal.type == "SERVICE"`, which can never fire — issue #266) and is documented in place as
stating intent, not enforcing it. It becomes load-bearing only if the blanket operator grant is
later narrowed.

## What the request body cannot say

`partyId`, `nominalAnnualRate`, `jurisdiction`, `productType`. A customer-supplied jurisdiction would
let the applicant choose which ADR-0212 compliance pack judges them — the pack is keyed on
(jurisdiction, productType). A customer-supplied rate would let them price their own loan. An
unpriced product refuses (403) rather than defaulting a rate.

## Safety of landing it

Default **OFF** (`lending.intake.enabled=false`) and refuses every call while
`lending.intake.caller-principal` is blank. Merging changes no existing request.

## Tests

Written against the ways the endpoint can wrongly **admit** a request, not the happy path — a 201 in
any of those cases creates an application indistinguishable from a genuine one:

- an ordinary operator who is not the edge principal → 403
- an unset `caller-principal` → 403 (not "anyone may")
- missing / malformed / nil-UUID party header → 400
- amount or term outside the configured bounds → 400
- an over-scaled amount → 400, not the 500 `Money`'s init would raise
- price / jurisdiction / product asserted to come from configuration
- maker recorded as `customer:<partyId>`, namespaced so it can never satisfy a checker leg

**Falsified:** replacing the named-principal check with a no-op turns 2 of the 9 red
(`tests="9" failures="2"`); restored, `failures="0"`.

## Verification

- `:openbank-lending-service:detekt ktlintCheck test` — green
- `:openbank-lending-service:quarkusBuild` — green (CDI wiring; unit tests alone don't validate it)
- `:openbank-customer-edge:detekt ktlintCheck test` — green
- `opa check` on the regenerated bundle — clean; `opa test` with the lending extension loaded — 101/101
- OPA bundle regenerated by its own generator (checksum `9449007dc499f6d0`), re-run idempotent.
  `rules.yaml` untouched, so no other service's bundle is restamped.
- `application.yaml` loaded with a duplicate-key-rejecting loader — clean
- API contract: lending `1.10.0 → 1.11.0`, customer-edge `1.24.0 → 1.25.0`, both re-checked against
  live `main` after the work (not against the branch base)

## Threat model

lending-service gains **§9** — this is the first entry point on a money-path service reachable from
outside the bank's staff, so §4's "an employee is behind every write" assumption needed replacing,
including the three residual gaps it does *not* close (no per-party intake rate limit, no SCA on
submission by ADR-0211's design, rego rule not enforcing). customer-edge's threat model gains a
change-log entry.

## Not in this PR

The customer app itself lives in the separate KMP repo — this is the backend it needs.

Refs #3168
