### PR TITLE
fix(ci): resolve the prod runtime classpath when refreshing verification metadata

### DIFF
--- a/.github/workflows/dependabot-verification-metadata.yml
+++ b/.github/workflows/dependabot-verification-metadata.yml
@@ -74,7 +74,13 @@ jobs:
         if: steps.tok.outputs.have == 'true'
         run: |
           set -euo pipefail
-          ./gradlew --write-verification-metadata sha256 testClasses --no-daemon -q
+          # testClasses alone resolves only the TEST graph. The prod runtime classpath and
+          # its platform BOMs (quarkusProdRuntimeClasspathConfigurationPlatform) are never
+          # touched by it, so artifacts that exist only there were never hashed — measured
+          # as 38 missing for one service (#3028). quarkusDependenciesBuild resolves the
+          # Quarkus application model without running a full quarkusBuild.
+          ./gradlew --write-verification-metadata sha256 \
+            testClasses quarkusDependenciesBuild --no-daemon -q
         env:
           GRADLE_OPTS: "-Dorg.gradle.daemon=false"
 


### PR DESCRIPTION
## What

One-line change to the metadata producer:

```diff
-./gradlew --write-verification-metadata sha256 testClasses --no-daemon -q
+./gradlew --write-verification-metadata sha256 \
+  testClasses quarkusDependenciesBuild --no-daemon -q
```

## Why — this is the root cause of #3017, not a Dependabot oversight

`testClasses` resolves only the **test** graph. Artifacts reachable solely from the production
runtime classpath and its platform BOMs (`quarkusProdRuntimeClasspathConfigurationPlatform`) are
never touched by it, so they were never hashed — however often the refresh ran.

That is exactly where the 38 entries missing for `openbank-campaign-service` lived (#3028). The
producer was working as written; what it was written to resolve was narrower than what production
builds resolve.

Without this, the gap reopens with every new production-only dependency, no matter how many times
the file is patched by hand.

## Verification — with a control positive, because the obvious test lies here

Deleted a known entry (`hibernate-platform-7.4.5.Final.pom`) and checked which task restores it,
each against its **own empty** `GRADLE_USER_HOME`:

| task | result | entry restored |
|---|---|---|
| `quarkusBuild` | `BUILD SUCCESSFUL in 11m35s` | yes — **control positive** |
| `quarkusDependenciesBuild` | `BUILD SUCCESSFUL in 8m39s` | yes |

**The control positive is the point.** An earlier round of this same test ran against a warm cache
and reported that *none* of the three candidate tasks restored anything — including `quarkusBuild`,
which demonstrably does. A warm cache does not re-resolve metadata artifacts, so it cannot answer
this question; without the control the conclusion would have been confidently backwards.

The working tree was restored from git afterwards; `git diff` clean.

## Cost

Measured cold, all 60 modules:

- `testClasses` alone — 16m45s
- `testClasses quarkusDependenciesBuild` — 20m10s

CI runs with a warm Gradle cache, so the real delta is smaller than that ~3.5 min. `quarkusBuild`
was rejected as the alternative: over 60 modules it is a full fleet build, and it died with
`Java heap space` after **3h40m** at `-Xmx6g` on a 32 GB machine.

## What this does NOT do

- **No backfill.** Existing gaps in other services stay; only `openbank-campaign-service` has been
  measured and fixed (#3028). Fleet measurement is still open in #3131.
- **No coverage for human PRs.** This workflow is gated on
  `if: github.actor == 'dependabot[bot]'`, so a production-only dependency added by a person is
  never seen by it. That is arguably the larger remaining hole and is tracked in #3131 — the
  periodic cold-cache job proposed there is what would close it.

Worth stating plainly: fleet-wide, a cold `testClasses` regeneration across all 60 modules adds
**zero** entries today. The test graph is complete. Everything missing is on the prod side, which
is what this PR starts resolving.

## Linked issues

Refs #3131

🤖 Generated with [Claude Code](https://claude.com/claude-code)
