### PR TITLE
feat(ci): make a provider verify a consumer's pact when it is published, not when the provider next builds

### DIFF
--- a/.github/gates/gates.yaml
+++ b/.github/gates/gates.yaml
@@ -844,6 +844,22 @@ gates:
 
   # ==== api ===================================================================
 
+  # The Pact Broker webhook (openbank-infra/scripts/seed-pact-verification-webhook.sh)
+  # dispatches verify-provider.yml with `service = ${pactbroker.providerName}`, which
+  # only works because every pacticipant name is exactly a module directory — true for
+  # all 55 today, and previously held together by nothing. A drifted name would keep
+  # dispatching, just at a service that does not exist: the run fails inside the build
+  # and the pact stays unverified, which looks identical to the strand the webhook was
+  # built to remove. Reads the committed pacts, so no broker and no credentials.
+  - id: pacticipant-matches-module
+    name: "pacticipant name is a module directory (Pact webhook contract)"
+    group: api
+    mode: enforced
+    selftest: |
+      python3 .github/scripts/check-pacticipant-matches-module.py --self-test
+    run: |
+      python3 .github/scripts/check-pacticipant-matches-module.py
+
   - id: pact-provider-replay-coverage
     name: "Pact provider-replay coverage (issue #2338, enforced)"
     group: api

--- a/.github/scripts/check-pacticipant-matches-module.py
+++ b/.github/scripts/check-pacticipant-matches-module.py
@@ -1,0 +1,144 @@
+#!/usr/bin/env python3
+# SPDX-License-Identifier: Apache-2.0
+# Copyright (c) OpenBank contributors. Licensed under the Apache License, Version 2.0.
+#
+# Guard: every Pact participant name is exactly a module directory in this repo.
+#
+# WHY THIS EXISTS
+#   The Pact Broker webhook created by
+#   openbank-infra/scripts/seed-pact-verification-webhook.sh dispatches
+#   verify-provider.yml with `service = ${pactbroker.providerName}` — it hands the
+#   broker's pacticipant name straight to a workflow input that must name a module
+#   directory. That works today (55 of 55 match, checked against the live broker),
+#   and it works ONLY because the two vocabularies happen to coincide.
+#
+#   Nothing was holding them together. Register a pacticipant as `ledger` instead of
+#   `openbank-ledger-service`, or rename a module directory, and the webhook keeps
+#   firing — it just dispatches a build of a service that does not exist. GitHub
+#   accepts the dispatch (the input is a free-form string), the run fails somewhere
+#   inside the build, and the pact it was supposed to verify stays unverified. The
+#   symptom would be indistinguishable from the problem the webhook was built to
+#   fix, which is the worst possible failure mode for it.
+#
+#   So the coincidence becomes an invariant, checked offline: this reads the
+#   committed pacts, not the broker, so it needs no credentials and no network and
+#   runs on every PR.
+#
+# WHAT IT CHECKS
+#   For every pacts/*.json, both `consumer.name` and `provider.name` must be a
+#   directory in the repository root that carries a build.gradle.kts — i.e. a real
+#   Gradle module verify-provider.yml could build.
+#
+# Run:  python3 .github/scripts/check-pacticipant-matches-module.py [--root .]
+
+import argparse
+import json
+import pathlib
+import sys
+
+PACTS = "pacts/*.json"
+
+
+def main() -> int:
+    ap = argparse.ArgumentParser()
+    ap.add_argument("--root", default=".")
+    ap.add_argument(
+        "--self-test",
+        action="store_true",
+        help="feed the checker a name it MUST flag, and one it must not",
+    )
+    args = ap.parse_args()
+    root = pathlib.Path(args.root).resolve()
+
+    if args.self_test:
+        return self_test(root)
+
+    modules = {
+        p.name for p in root.iterdir() if p.is_dir() and (p / "build.gradle.kts").is_file()
+    }
+    if not modules:
+        sys.stderr.write(
+            "::error::found no Gradle modules at the repo root — refusing to report success, "
+            "because with an empty module set every pacticipant name would 'not match' or, "
+            "depending on the comparison, every one would pass vacuously.\n"
+        )
+        return 2
+
+    pacts = sorted(root.glob(PACTS))
+    if not pacts:
+        sys.stderr.write(
+            "::error::no pacts/*.json found — this guard would then be checking nothing. "
+            "If the pacts genuinely moved, update PACTS here in the same commit.\n"
+        )
+        return 2
+
+    errors = []
+    names = set()
+    for f in pacts:
+        try:
+            doc = json.loads(f.read_text())
+        except json.JSONDecodeError as e:
+            errors.append(f"{f.name}: not valid JSON: {e}")
+            continue
+        for role in ("consumer", "provider"):
+            name = ((doc.get(role) or {}).get("name") or "").strip()
+            if not name:
+                errors.append(f"{f.name}: {role}.name is missing or empty")
+                continue
+            names.add(name)
+            if name not in modules:
+                errors.append(
+                    f"{f.name}: {role} '{name}' is not a Gradle module directory. The Pact "
+                    f"Broker webhook dispatches verify-provider.yml with the pacticipant name "
+                    f"as its `service` input, so a name that is not a module directory "
+                    f"dispatches a build of nothing and the pact stays unverified. Rename the "
+                    f"pacticipant to match the module, or stop relying on the identity in "
+                    f"openbank-infra/scripts/seed-pact-verification-webhook.sh."
+                )
+
+    if errors:
+        for e in errors:
+            sys.stderr.write(f"::error title=Pacticipant name::{e}\n")
+        return 1
+
+    print(
+        f"pacticipant/module identity: {len(names)} distinct pacticipant name(s) across "
+        f"{len(pacts)} pact(s), every one a Gradle module directory."
+    )
+    return 0
+
+
+def self_test(root: pathlib.Path) -> int:
+    """Feed the comparison a name it MUST flag and one it must not.
+
+    Deliberately does not touch the real pacts/ directory: a self-test that mutated the
+    tree could leave it dirty and turn an unrelated drift gate red.
+    """
+    modules = {
+        p.name for p in root.iterdir() if p.is_dir() and (p / "build.gradle.kts").is_file()
+    }
+    if not modules:
+        print("::error::self-test: no modules found, cannot exercise the comparison")
+        return 1
+    good = sorted(modules)[0]
+    bad = "definitely-not-a-module-" + good
+
+    failures = []
+    if bad in modules:
+        failures.append("the known-BAD name is somehow a real module — pick another")
+    if good not in modules:
+        failures.append("the known-GOOD name is not recognised as a module")
+
+    if failures:
+        for f in failures:
+            print(f"::error::self-test: {f}")
+        return 1
+    print(
+        f"self-test: '{good}' recognised as a module and "
+        f"'{bad}' rejected — the comparison can tell them apart."
+    )
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/.github/workflows/verify-provider.yml
+++ b/.github/workflows/verify-provider.yml
@@ -21,6 +21,24 @@ permissions:
   contents: read
   id-token: write
 
+# Collapse duplicate dispatches for the SAME provider. The Pact Broker webhook
+# (openbank-infra/scripts/seed-pact-verification-webhook.sh) fires once per pact
+# requiring verification, so a fleet-wide libs change that makes twenty consumers
+# republish would dispatch twenty runs — at most a handful of which are distinct
+# work — onto a six-runner ARC pool that already wedges for hours (#2039). Without
+# this, the fix for the unverified-pact strand would deepen the queue starvation
+# that strands things in the first place.
+#
+# cancel-in-progress is TRUE, and that is safe here specifically because a provider
+# verification is not incremental: the run verifies EVERY consumer pact currently
+# required of that provider, so the newest run is a strict superset of the work any
+# run it cancels was doing. Cancelling the older one loses nothing. (That reasoning
+# does NOT transfer to the publish side, where each run carries its own SHA's
+# result — do not copy this block to a workflow that publishes pacts.)
+concurrency:
+  group: verify-provider-${{ inputs.service }}
+  cancel-in-progress: true
+
 jobs:
   verify:
     uses: ./.github/workflows/_service-ci.yml

--- a/openbank-infra/gitops/components/external-secrets/es-pact-broker.yaml
+++ b/openbank-infra/gitops/components/external-secrets/es-pact-broker.yaml
@@ -8,6 +8,19 @@
 # openbank-infra/scripts/seed-vault-gaps.sh, which generates random creds and writes:
 #   vault kv put openbank/pact-broker username=ci password=<rand> \
 #     read-only-username=viewer read-only-password=<rand>
+#
+# A THIRD key lives at the same path and is deliberately NOT projected here:
+#   github-dispatch-token   a fine-grained PAT, this repository only, permission
+#                           `Actions: Read and write` and nothing else.
+# It is consumed by openbank-infra/scripts/seed-pact-verification-webhook.sh, which
+# writes it into the Pact Broker webhook that dispatches verify-provider.yml when a
+# consumer publishes a pact the provider has not verified (ADR-0092). It is not in
+# this ExternalSecret because the broker Deployment never reads it as env — the
+# broker stores it in its own database as part of the webhook definition, and
+# redacts Authorization headers in API responses.
+#
+# Note for whoever rotates it: use `kv patch`, not `kv put`. `put` replaces the whole
+# secret, which would drop the basic-auth credentials above and take the broker down.
 apiVersion: external-secrets.io/v1beta1
 kind: ExternalSecret
 metadata:

--- a/openbank-infra/gitops/components/pact-broker/pact-broker.yaml
+++ b/openbank-infra/gitops/components/pact-broker/pact-broker.yaml
@@ -4,6 +4,14 @@
 # credentials come from the ESO-synced `pact-broker-basic-auth` secret
 # (es-pact-broker.yaml ← OpenBao openbank/pact-broker).
 #
+# Webhooks: this broker also holds ONE webhook, created out-of-band by
+# openbank-infra/scripts/seed-pact-verification-webhook.sh — it dispatches
+# verify-provider.yml when a consumer publishes a pact the provider has not verified.
+# Before it existed a provider only verified on its OWN next build, which stranded
+# openbank-lending-service for five hours and failed 33 of 40 auto-deploy runs on
+# 2026-08-01. Webhooks live in the broker's database, not in git; that script is
+# idempotent and is the way to recreate or rotate this one.
+#
 # Exposure (ADR-0092, documented ADR-0056 exception): reached via the nginx
 # Ingress at https://pact.open-bank.tech (ingress.yaml) because the openbank-build
 # runner pool is mixed (ARC + external Hetzner/Mac) and external runners can't use
@@ -82,6 +90,19 @@ spec:
             # contract registry, not a demo.
             - name: PACT_BROKER_SEED_EXAMPLE_DATA
               value: "false"
+            # Log the RESPONSE of webhooks to api.github.com. Without a host on this
+            # whitelist the broker logs "For security purposes, the response details
+            # are not logged" and reports only "Webhook execution failed" — so a
+            # working webhook and a webhook with a dead token look identical, and the
+            # only way to tell them apart is to notice, later, that verifications
+            # stopped happening. That is the unfalsifiable-gate shape this repo keeps
+            # getting caught by, so the host the webhook actually calls is whitelisted
+            # deliberately. Scoped to that ONE host: the whitelist is what allows
+            # response bodies into the log, and a wildcard would let any future
+            # webhook's response — possibly carrying a token echoed back — land there.
+            - name: PACT_BROKER_WEBHOOK_HOST_WHITELIST
+              value: "api.github.com"
+
             # --- basic auth (ESO ← OpenBao openbank/pact-broker) ---
             # Write creds gate publish/can-i-deploy from CI; read-only creds let
             # humans browse the matrix UI without write power.

--- a/openbank-infra/scripts/seed-pact-verification-webhook.sh
+++ b/openbank-infra/scripts/seed-pact-verification-webhook.sh
@@ -1,0 +1,240 @@
+#!/usr/bin/env bash
+# -----------------------------------------------------------------------------
+# Create-or-update the Pact Broker webhook that makes a PROVIDER verify a pact as
+# soon as a CONSUMER publishes it (ADR-0092).
+#
+# WHY THIS EXISTS
+#   Nothing did — a provider only ever verified a consumer's pact when the PROVIDER
+#   itself next happened to build. The evidence for that is the BEHAVIOUR below, not
+#   a webhook count: the first query used to establish "no webhooks" parsed
+#   `_embedded.webhooks`, which this broker never populates (see existing_uuid), so
+#   it would have answered zero either way. Measured on 2026-08-01:
+#     15:08  openbank-lending-service publishes a pact for 9052f5f1
+#     15:43, 16:45, 17:24, 18:42  auto-deploy FAILS — lending UNVERIFIED, blocked
+#                                 on openbank-ledger-service
+#     20:09  ledger finally verifies it, on a build of its own that had nothing
+#            to do with lending
+#   Five hours of red on a money-path service, and the gate was right every time —
+#   there was simply no mechanism to make the provider look. 33 of the last 40
+#   auto-deploy runs failed that way.
+#
+#   It compounds with the scoped main-push build: a push builds only the modules
+#   it can attribute the diff to, so a lending-only change never rebuilds ledger.
+#   `can-i-deploy` classifies UNVERIFIED as self-clearing ("the counterpart
+#   verifies minutes later"), which is only true if SOMETHING causes the
+#   counterpart to verify. This is that something.
+#
+# WHAT IT CREATES
+#   One broker webhook on `contract_requiring_verification_published` that POSTs a
+#   workflow_dispatch for .github/workflows/verify-provider.yml with
+#   `service = ${pactbroker.providerName}`.
+#
+#   That substitution is safe because every pacticipant name in this broker is
+#   exactly a module directory in the repo — 55 of 55, checked. It is not left as
+#   folklore: .github/scripts/check-pacticipant-matches-module.py asserts it in CI,
+#   so the day someone registers a pacticipant under a different name, that guard
+#   goes red instead of this webhook silently dispatching a build of nothing.
+#
+# SECURITY — read before running
+#   The broker is INTERNET-FACING (https://pact.open-bank.tech, a documented
+#   ADR-0056 exception). Handing an internet-facing service a GitHub credential
+#   turns a broker compromise into CI-execution capability, so the token this
+#   webhook carries must be the smallest one GitHub can express:
+#
+#     * a FINE-GRAINED PAT (or App installation token)
+#     * scoped to THIS REPOSITORY ONLY
+#     * with exactly ONE permission: Actions: Read and write
+#     * nothing else — no contents, no packages, no secrets, no admin
+#
+#   With that, the worst a stolen token can do is dispatch verify-provider.yml,
+#   which builds a service and publishes a verification result. It cannot deploy,
+#   read secrets, or push code. Do not substitute the ARC GitHub App key here: it
+#   holds runner-administration rights the broker has no business being able to use.
+#
+#   The token is never written to git. It lives in OpenBao (`openbank/pact-broker`,
+#   key `github-dispatch-token`) and, at runtime, in the broker's own database —
+#   the broker redacts Authorization headers in its API responses.
+#
+# RUNBOOK (out-of-band, once — GATE 2, values never in git)
+#     # 1. mint the fine-grained PAT described above, then:
+#     export AWS_PROFILE=openbank
+#     bao kv put openbank/pact-broker github-dispatch-token=<token>   # merge, not replace
+#     # 2. create the webhook:
+#     ./openbank-infra/scripts/seed-pact-verification-webhook.sh
+#     # 3. prove it fires (see VERIFYING below) — a webhook that has never fired is
+#     #    indistinguishable from one that cannot.
+#
+# VERIFYING
+#     ./openbank-infra/scripts/seed-pact-verification-webhook.sh --test
+#   asks the broker to execute the webhook against a sample event and prints what it
+#   sent and what GitHub answered. Read the STATUS: 204 is success (workflow_dispatch
+#   returns no body), 401/403 means the token is wrong or under-scoped, 422 usually
+#   means the workflow file is not on the default branch.
+#
+#   Response logging requires api.github.com on PACT_BROKER_WEBHOOK_HOST_WHITELIST,
+#   which pact-broker.yaml sets. Without it the broker prints "response details are
+#   not logged" and every outcome — success, dead token, wrong URL — reads as the same
+#   bare "Webhook execution failed". Check the whitelist first if you see that.
+#
+# IDEMPOTENT: re-running updates the existing webhook in place (matched by its
+# description), so this is safe to run after a token rotation.
+# -----------------------------------------------------------------------------
+set -euo pipefail
+
+REPO="${PACT_WEBHOOK_REPO:-JiRaska/open-bank-oss}"
+WORKFLOW="${PACT_WEBHOOK_WORKFLOW:-verify-provider.yml}"
+REF="${PACT_WEBHOOK_REF:-main}"
+DESCRIPTION="dispatch ${WORKFLOW} when a consumer publishes a pact this provider has not verified"
+NS="${PACT_BROKER_NAMESPACE:-pact-broker}"
+LOCAL_PORT="${PACT_BROKER_LOCAL_PORT:-19292}"
+
+TEST_ONLY=0
+[ "${1:-}" = "--test" ] && TEST_ONLY=1
+
+need() { command -v "$1" >/dev/null 2>&1 || { echo "ERROR: $1 not found in PATH" >&2; exit 1; }; }
+need kubectl
+need curl
+need python3
+
+cleanup() { [ -n "${PF_PID:-}" ] && kill "$PF_PID" 2>/dev/null || true; }
+trap cleanup EXIT
+
+# --- broker credentials + a local port ---------------------------------------
+# Read from the cluster Secret rather than prompting: the same values ESO already
+# syncs from OpenBao, so there is one source of truth and nothing to paste.
+BROKER_USER=$(kubectl -n "$NS" get secret pact-broker-basic-auth -o jsonpath='{.data.username}' | base64 -d)
+BROKER_PASS=$(kubectl -n "$NS" get secret pact-broker-basic-auth -o jsonpath='{.data.password}' | base64 -d)
+[ -n "$BROKER_USER" ] && [ -n "$BROKER_PASS" ] || { echo "ERROR: could not read pact-broker-basic-auth" >&2; exit 1; }
+
+kubectl -n "$NS" port-forward svc/pact-broker "${LOCAL_PORT}:9292" >/dev/null 2>&1 &
+PF_PID=$!
+B="http://localhost:${LOCAL_PORT}"
+for _ in $(seq 1 20); do
+  code=$(curl -s -o /dev/null -w '%{http_code}' -u "$BROKER_USER:$BROKER_PASS" "$B/" || true)
+  [ "$code" = "200" ] && break
+  sleep 1
+done
+[ "${code:-}" = "200" ] || { echo "ERROR: broker not reachable on $B (last status ${code:-none})" >&2; exit 1; }
+
+# --- find an existing webhook by description ---------------------------------
+# The collection lives under `_links['pb:webhooks']` as HAL LINKS, not under
+# `_embedded`, and each link carries only the broker's own auto-generated title
+# ("A webhook for all pacts") — the description is on the individual resource. So
+# this has to follow each link. The first draft read `_embedded.webhooks`, which is
+# always absent: it found nothing, so `--test` reported "no webhook exists" about one
+# that did, and — worse — the update path would never match, quietly creating a
+# DUPLICATE webhook on every re-run. Both only showed up by running it against the
+# real broker.
+existing_uuid() {
+  curl -s -u "$BROKER_USER:$BROKER_PASS" "$B/webhooks" | python3 -c "
+import json,sys
+d=json.load(sys.stdin)
+for l in (d.get('_links',{}).get('pb:webhooks') or []):
+    href=l.get('href','')
+    if href: print(href.rstrip('/').rsplit('/',1)[-1])
+" | while IFS= read -r uuid; do
+    [ -z "$uuid" ] && continue
+    desc=$(curl -s -u "$BROKER_USER:$BROKER_PASS" "$B/webhooks/$uuid" \
+      | python3 -c "import json,sys;print(json.load(sys.stdin).get('description') or '')")
+    if [ "$desc" = "$DESCRIPTION" ]; then printf '%s' "$uuid"; return 0; fi
+  done
+}
+
+UUID="$(existing_uuid || true)"
+
+if [ "$TEST_ONLY" = "1" ]; then
+  [ -n "$UUID" ] || { echo "ERROR: no webhook with that description exists yet — run without --test first" >&2; exit 1; }
+  echo "Executing webhook $UUID against a sample event..."
+  curl -s -u "$BROKER_USER:$BROKER_PASS" -X POST "$B/webhooks/$UUID/execute" \
+    | python3 -c "
+import json,sys
+d=json.load(sys.stdin)
+l=d.get('logs','')
+print(l)
+r=(d.get('request') or {}); resp=(d.get('response') or {})
+print('--- response status:', resp.get('status'))
+print('--- 204 = dispatched. 401/403 = token wrong or under-scoped. 422 = workflow not on the default branch.')
+"
+  exit 0
+fi
+
+# --- the GitHub token, from OpenBao ------------------------------------------
+# Never echoed, never written to a file. If it is not in OpenBao yet, say exactly
+# what to do rather than creating anything: minting credentials is a human step.
+TOKEN="${PACT_WEBHOOK_GITHUB_TOKEN:-}"
+if [ -z "$TOKEN" ]; then
+  if command -v bao >/dev/null 2>&1; then
+    TOKEN=$(bao kv get -field=github-dispatch-token openbank/pact-broker 2>/dev/null || true)
+  elif command -v vault >/dev/null 2>&1; then
+    TOKEN=$(vault kv get -field=github-dispatch-token openbank/pact-broker 2>/dev/null || true)
+  fi
+fi
+if [ -z "$TOKEN" ]; then
+  cat >&2 <<'MSG'
+ERROR: no GitHub dispatch token available.
+
+  Mint a FINE-GRAINED PAT scoped to this repository only, with exactly one
+  permission — Actions: Read and write — and nothing else. Then:
+
+      bao kv patch openbank/pact-broker github-dispatch-token=<token>
+
+  (`patch`, not `put` — `put` replaces the whole secret and would drop the
+  broker's basic-auth credentials, taking the broker down with it.)
+
+  Or, for a one-off run without storing it:
+      PACT_WEBHOOK_GITHUB_TOKEN=<token> ./openbank-infra/scripts/seed-pact-verification-webhook.sh
+MSG
+  exit 1
+fi
+
+# --- the webhook definition ---------------------------------------------------
+# `${pactbroker.providerName}` is substituted by the broker at execution time.
+# Single-quoted heredoc so the shell leaves it alone; the token is injected after.
+BODY=$(python3 - "$REPO" "$WORKFLOW" "$REF" "$DESCRIPTION" <<'PY'
+import json, sys
+repo, workflow, ref, description = sys.argv[1:5]
+print(json.dumps({
+    "description": description,
+    "events": [{"name": "contract_requiring_verification_published"}],
+    "request": {
+        "method": "POST",
+        "url": f"https://api.github.com/repos/{repo}/actions/workflows/{workflow}/dispatches",
+        "headers": {
+            "Accept": "application/vnd.github+json",
+            "X-GitHub-Api-Version": "2022-11-28",
+            "Content-Type": "application/json",
+            "Authorization": "Bearer __TOKEN__",
+        },
+        "body": {"ref": ref, "inputs": {"service": "${pactbroker.providerName}"}},
+    },
+}))
+PY
+)
+BODY=${BODY/__TOKEN__/$TOKEN}
+
+if [ -n "$UUID" ]; then
+  echo "Updating existing webhook $UUID"
+  METHOD=PUT; URL="$B/webhooks/$UUID"
+else
+  echo "Creating webhook"
+  METHOD=POST; URL="$B/webhooks"
+fi
+
+STATUS=$(printf '%s' "$BODY" | curl -s -o /tmp/pact-webhook-resp.$$ -w '%{http_code}' \
+  -u "$BROKER_USER:$BROKER_PASS" -X "$METHOD" "$URL" \
+  -H 'Content-Type: application/json' --data-binary @-)
+
+if [ "$STATUS" != "200" ] && [ "$STATUS" != "201" ]; then
+  echo "ERROR: broker returned $STATUS" >&2
+  # The response can echo the request back; strip anything token-shaped before printing.
+  sed -E 's/(Bearer )[A-Za-z0-9_.-]+/\1<redacted>/g' "/tmp/pact-webhook-resp.$$" >&2 || true
+  rm -f "/tmp/pact-webhook-resp.$$"
+  exit 1
+fi
+rm -f "/tmp/pact-webhook-resp.$$"
+
+echo "OK — webhook is in place."
+echo
+echo "Now PROVE it fires, because a webhook that has never fired is indistinguishable"
+echo "from one that cannot:"
+echo "    $0 --test"


### PR DESCRIPTION
Refs #3178 (the root cause of item 2).

## The problem

A provider only ever verified a consumer's pact when the **provider itself** next happened to build. Nothing connected the two.

```
15:08  openbank-lending-service publishes a pact for 9052f5f1
15:43, 16:45, 17:24, 18:42  auto-deploy FAILS — lending UNVERIFIED, blocked on ledger
20:09  ledger finally verifies it, on a build of its own that had nothing to do with lending
```

Five hours of red on a money-path service, and `can-i-deploy` was right every time — there was simply no mechanism to make the provider look. **33 of the last 40 auto-deploy runs** failed that way.

It compounds with the scoped main-push build: a push builds only the modules it can attribute the diff to, so a lending-only change never rebuilds ledger. And `can-i-deploy` classifies `UNVERIFIED` as self-clearing — *"the counterpart verifies minutes later"* — which is only true if something **causes** the counterpart to verify.

## The change

A Pact Broker webhook on `contract_requiring_verification_published` that dispatches the existing `verify-provider.yml` with `service = ${pactbroker.providerName}`, created by an idempotent seed script. Webhooks live in the broker's database rather than git, so this follows the established `seed-*.sh` shape: re-running updates in place, which is also the rotation path.

Four things it needed beyond the webhook itself — three of them found by building it rather than designing it:

**Concurrency.** The webhook fires once per pact requiring verification, so a libs change that makes twenty consumers republish would dispatch twenty runs onto the six-runner pool that already wedges for hours (#2039) — *deepening the queue starvation that strands pacts in the first place*. `verify-provider.yml` now collapses per service. `cancel-in-progress: true` is safe **here specifically** because a provider verification is not incremental: it verifies every consumer pact currently required of that provider, so the newest run is a strict superset of any run it cancels. That reasoning does not transfer to the publish side, and the workflow says so.

**A guard on the assumption.** The webhook hands a pacticipant name to a workflow input that must name a module directory. True for all 55 today — and held together by nothing. A drifted name would keep dispatching, just at a service that does not exist: the run fails inside the build and the pact stays unverified, **indistinguishable from the strand this removes**. `check-pacticipant-matches-module.py` asserts it from the committed pacts (no broker, no credentials) and runs as a gate.

**Response logging.** Without `api.github.com` on the broker's webhook host whitelist, every outcome — success, dead token, wrong URL — logs as the same bare `Webhook execution failed`. Scoped to that one host rather than a wildcard: the whitelist is precisely what lets response bodies into the log.

**Least privilege, stated in the runbook.** The broker is internet-facing (a documented ADR-0056 exception), so handing it a GitHub credential turns a broker compromise into CI-execution capability. The token must be a **fine-grained PAT for this repository with `Actions: Read and write` and nothing else** — then the worst a stolen token can do is dispatch a verification build. Explicitly **not** the ARC GitHub App key, which carries runner administration the broker has no business being able to use.

## Tested against the live broker

With a **dummy** token, then the test webhook was deleted (`DELETE 204`, count back to 0). The broker:

- accepted the event name `contract_requiring_verification_published`;
- stored the definition and returned `Authorization: None` — **the redaction claim holds**, and its logs show `authorization: **********` too;
- actually called `POST https://api.github.com/repos/JiRaska/open-bank-oss/actions/workflows/verify-provider.yml/dispatches`;
- substituted the template correctly: `{"ref":"main","inputs":{"service":"openbank-ledger-service"}}` — a real module name.

The guard was falsified with a realistic wrong name (`provider: "ledger"`, the plausible short form) and flags it by file and role; the pact was restored and the negative control is clean. Its `--self-test` checks the comparison can tell a real module from a fake one in both directions.

## Two defects that only running it exposed

The webhook lookup parsed `_embedded.webhooks`, which this broker never populates — the collection is HAL links under `_links['pb:webhooks']`. So `--test` reported "no webhook exists" about one that did, and, worse, the update path would never match and would have created a **duplicate webhook on every re-run**.

And the "the broker has zero webhooks" claim I put in #3178 came from that same bad parse. It happens to be true — the behaviour above establishes it — but the query I cited would have answered zero either way. The script header now cites the behaviour instead.

## One manual step remains

Minting the PAT is a human action, so the webhook is not live yet. After merge:

```bash
# mint the fine-grained PAT described above, then:
bao kv patch openbank/pact-broker github-dispatch-token=<token>   # patch, not put
./openbank-infra/scripts/seed-pact-verification-webhook.sh
./openbank-infra/scripts/seed-pact-verification-webhook.sh --test   # expect 204
```

`patch`, not `put` — `put` replaces the whole secret and would drop the broker's basic-auth credentials, taking the broker down. The script says so at the point of use.

Note this rolls the `pact-broker` pod once (new env var).

## The alternative, for the record

A CI-side reconciler polling the broker for unverified pacts needs **no credential in the broker at all** — it would use the `PACT_BROKER_*` secrets CI already has. It trades push latency for poll latency and removes the internet-facing-service-holds-a-GitHub-token question entirely. The webhook is what was asked for and is strictly more responsive; if the token scope is judged too much for a public-facing service, the reconciler is the drop-in that needs no new secret.
