### PR TITLE
fix(admin-ui): the campaign detail bundle handed journey the summary result

### DIFF
--- a/openbank-admin-ui/app-status.json
+++ b/openbank-admin-ui/app-status.json
@@ -12,7 +12,7 @@
   "asOf": "2026-07-29",
   "appRepo": "JiRaska/openbank-app",
   "derived": {
-    "version": "0.11.0",
+    "version": "0.12.0",
     "useFakeData": false,
     "edgeBaseUrl": "https://customer.open-bank.tech",
     "keycloakIssuer": "https://kc.open-bank.tech/realms/openbank-customers",

--- a/openbank-admin-ui/src/app/api/campaigns/[id]/route.ts
+++ b/openbank-admin-ui/src/app/api/campaigns/[id]/route.ts
@@ -88,13 +88,19 @@ export async function GET(_req: Request, ctx: { params: Promise<{ id: string }> 
     // First page only. Paging and filtering go through /api/campaigns/[id]/sends so turning a
     // page does not re-read the campaign and its enrolments.
     readSends(headers, id),
-    // The journey funnel: per-step SQL aggregates. Bundled with the first paint because the flow is
-    // the first thing on the screen, not something you scroll to.
-    read(headers, `/api/v1/campaigns/${encodeURIComponent(id)}/journey`, []),
     // Counts come from the service, not from the page above: a suppressed-total derived from the
     // rows on screen understates every campaign larger than one page, and that total is the number
     // an operator acts on.
     read(headers, `/api/v1/campaigns/${encodeURIComponent(id)}/sends/summary`, {}),
+    // The journey funnel: per-step SQL aggregates. Bundled with the first paint because the flow is
+    // the first thing on the screen, not something you scroll to.
+    //
+    // ORDER IS THE CONTRACT. This array is positional and the destructuring above names the
+    // positions; adding a read in the middle silently hands every later name someone else's result.
+    // That is how the journey slot came to hold the summary object: `funnel` was no longer an array,
+    // and the screen died on `.map` with the 404 on /journey never surfacing, because its state had
+    // landed under `sendSummary`.
+    read(headers, `/api/v1/campaigns/${encodeURIComponent(id)}/journey`, []),
   ])
 
   return NextResponse.json({

--- a/openbank-admin-ui/src/app/campaigns/[id]/page.tsx
+++ b/openbank-admin-ui/src/app/campaigns/[id]/page.tsx
@@ -11,6 +11,7 @@ import { useLanguage } from '@/lib/i18n/LanguageContext'
 import { DataUnavailable, type UnavailableKind } from '@/components/feedback/DataUnavailable'
 import { PageHeader, StatCard, StatusBadge, type Tone } from '@/components/ui'
 import { JourneyFlow, type StepFunnel } from '@/components/campaigns/JourneyFlow'
+import { SectionBoundary } from '@/components/feedback/SectionBoundary'
 
 interface Campaign {
   id: string
@@ -321,19 +322,21 @@ export default function CampaignDetailPage({ params }: { params: Promise<{ id: s
                 showed the campaign's DEFINITION; a marketer needs its RESULT — who it reached and
                 where the rest went — and had to correlate it against the send log by eye to get
                 there. The definition is still visible, just drawn as the flow it describes. */}
-            {detail?.sources.journey !== 'ok' ? (
+            {detail?.sources?.journey !== 'ok' ? (
               <DataUnavailable
-                kind={detail?.sources.journey === 'unauthorized' ? 'unauthorized' : 'unreachable'}
+                kind={detail?.sources?.journey === 'unauthorized' ? 'unauthorized' : 'unreachable'}
                 service="Campaign-service"
                 feature={t('Průchod kampaní', 'Journey')}
                 dense
               />
             ) : (
-              <JourneyFlow
-                steps={c.steps ?? []}
-                funnel={detail?.journey ?? []}
-                audienceSize={(detail?.enrolments?.length ?? 0) > 0 ? (detail?.enrolments?.length ?? 0) : null}
-              />
+              <SectionBoundary name="Journey">
+                <JourneyFlow
+                  steps={c.steps ?? []}
+                  funnel={detail?.journey ?? []}
+                  audienceSize={(detail?.enrolments?.length ?? 0) > 0 ? (detail?.enrolments?.length ?? 0) : null}
+                />
+              </SectionBoundary>
             )}
           </section>
 
@@ -347,9 +350,9 @@ export default function CampaignDetailPage({ params }: { params: Promise<{ id: s
 
           <section className="space-y-2">
             <h2 className="text-sm font-semibold">{t('Zařazení', 'Enrolments')}</h2>
-            {detail?.sources.enrolments !== 'ok' ? (
+            {detail?.sources?.enrolments !== 'ok' ? (
               <DataUnavailable
-                kind={detail?.sources.enrolments === 'unauthorized' ? 'unauthorized' : detail?.sources.enrolments === 'not_deployed' ? 'not_deployed' : 'unreachable'}
+                kind={detail?.sources?.enrolments === 'unauthorized' ? 'unauthorized' : detail?.sources?.enrolments === 'not_deployed' ? 'not_deployed' : 'unreachable'}
                 service="Campaign-service"
                 feature={t('Zařazení', 'Enrolments')}
                 dense
@@ -445,12 +448,12 @@ export default function CampaignDetailPage({ params }: { params: Promise<{ id: s
               {sendsLoading && <span className="text-xs text-muted-foreground">{t('Načítám…', 'Loading…')}</span>}
             </div>
 
-            {detail?.sources.sends !== 'ok' || sendState !== 'ok' ? (
+            {detail?.sources?.sends !== 'ok' || sendState !== 'ok' ? (
               <DataUnavailable
                 kind={
-                  detail?.sources.sends === 'unauthorized' || sendState === 'unauthorized'
+                  detail?.sources?.sends === 'unauthorized' || sendState === 'unauthorized'
                     ? 'unauthorized'
-                    : detail?.sources.sends === 'not_deployed'
+                    : detail?.sources?.sends === 'not_deployed'
                       ? 'not_deployed'
                       : 'unreachable'
                 }

--- a/openbank-admin-ui/src/components/campaigns/JourneyFlow.tsx
+++ b/openbank-admin-ui/src/components/campaigns/JourneyFlow.tsx
@@ -96,11 +96,16 @@ export function JourneyFlow({
       MARKETING_PRODUCT_OFFER: t('Nabídka produktu', 'Product offer'),
     })[template] ?? template
 
-  const byStep = new Map(funnel.map(f => [f.stepOrder, f]))
-  const ordered = [...steps].sort((a, b) => a.order - b.order)
+  // Defensive despite the BFF contract: this component died on `.map` in front of a user when the
+  // journey slot briefly held an object, and a funnel that renders empty is a far cheaper failure
+  // than one that takes the whole screen with it. The route test asserts the contract; this makes
+  // breaking it survivable.
+  const rows = Array.isArray(funnel) ? funnel : []
+  const byStep = new Map(rows.map(f => [f.stepOrder, f]))
+  const ordered = Array.isArray(steps) ? [...steps].sort((a, b) => a.order - b.order) : []
 
   // Nothing has run yet: say so, rather than drawing an empty funnel that reads as "nobody matched".
-  const anyActivity = funnel.some(f => f.reached > 0)
+  const anyActivity = rows.some(f => f.reached > 0)
 
   return (
     <div className="space-y-4">

--- a/openbank-admin-ui/src/components/feedback/SectionBoundary.tsx
+++ b/openbank-admin-ui/src/components/feedback/SectionBoundary.tsx
@@ -1,0 +1,80 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright (c) OpenBank contributors. Licensed under the Apache License, Version 2.0.
+// See LICENSE in the repository root or https://www.apache.org/licenses/LICENSE-2.0 for details.
+
+'use client'
+
+import React from 'react'
+import { useLanguage } from '@/lib/i18n/LanguageContext'
+
+/**
+ * Contains a render error to one section of a screen.
+ *
+ * `app/error.tsx` catches per ROUTE, so any throw anywhere on a page replaces the whole thing with
+ * "this screen could not be displayed" — a campaign's state, its approvals, its send log and its
+ * journey all disappear because one of them broke. That is the failure the graceful-state rule
+ * (CLAUDE.md #1) exists to prevent, and the route boundary is too coarse to deliver it.
+ *
+ * It also makes the error legible. A route-level boundary tells an operator only that "something"
+ * failed; this names the section, which is the first thing anyone reporting it would be asked.
+ *
+ * Deliberately NOT a replacement for handling failure properly: a section that can fail for a known
+ * reason should say so via `DataUnavailable`. This is for the throw nobody predicted — and it prints
+ * the message, because a boundary that swallows what it caught turns a five-minute diagnosis into an
+ * afternoon of guessing at reproductions.
+ */
+interface BoundaryProps {
+  name: string
+  children: React.ReactNode
+  /**
+   * Copy is passed in rather than translated here: an error boundary must be a class (React exposes
+   * `getDerivedStateFromError` nowhere else) and a class cannot call `useLanguage`. The hook runs in
+   * the wrapper below — outside the subtree that throws, so a broken child cannot break the
+   * translation of its own failure message.
+   */
+  title: string
+  footer: string
+}
+
+class Boundary extends React.Component<BoundaryProps, { error: Error | null }> {
+  constructor(props: BoundaryProps) {
+    super(props)
+    this.state = { error: null }
+  }
+
+  static getDerivedStateFromError(error: Error) {
+    return { error }
+  }
+
+  componentDidCatch(error: Error, info: React.ErrorInfo) {
+    // The browser console is the only place this is currently readable — admin-ui ships no Sentry
+    // DSN, so `Sentry.captureException` in the route boundary reports to nothing.
+    console.error(`[admin-ui] section "${this.props.name}" failed to render:`, error, info)
+  }
+
+  render() {
+    if (!this.state.error) return this.props.children
+    return (
+      <div className="rounded-lg border border-dashed p-4 text-sm">
+        <p className="font-medium">{this.props.title}</p>
+        <p className="mt-1 text-xs text-muted-foreground">
+          {this.props.name} — {this.state.error.message}
+        </p>
+        <p className="mt-1 text-xs text-muted-foreground">{this.props.footer}</p>
+      </div>
+    )
+  }
+}
+
+export function SectionBoundary({ name, children }: { name: string; children: React.ReactNode }) {
+  const { t } = useLanguage()
+  return (
+    <Boundary
+      name={name}
+      title={t('Tuto část se nepodařilo zobrazit', 'This section could not be rendered')}
+      footer={t('Zbytek obrazovky funguje dál.', 'The rest of the screen still works.')}
+    >
+      {children}
+    </Boundary>
+  )
+}

--- a/openbank-admin-ui/src/test/campaign-detail-bff.test.ts
+++ b/openbank-admin-ui/src/test/campaign-detail-bff.test.ts
@@ -1,0 +1,75 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright (c) OpenBank contributors. Licensed under the Apache License, Version 2.0.
+// See LICENSE in the repository root or https://www.apache.org/licenses/LICENSE-2.0 for details.
+
+import { describe, expect, it, vi, beforeEach } from 'vitest'
+
+vi.mock('@/auth', () => ({ auth: async () => ({ user: { accessToken: 'tok' } }) }))
+
+/**
+ * The campaign-detail bundle fans out with `Promise.all` and names the results by POSITION. That is
+ * a contract nothing enforces: inserting a read in the middle hands every later name someone else's
+ * result, and the types still check because each slot has the same `{data, state}` shape.
+ *
+ * It shipped exactly that way. `journey` ended up holding the summary object, so the page passed a
+ * non-array to the funnel and the whole screen died on `TypeError: s.map is not a function` — while
+ * the real 404 on /journey never surfaced, because its state had landed under `sendSummary`.
+ *
+ * So this asserts what each key actually came from, by giving every upstream a distinguishable body.
+ */
+describe('campaign detail bundle', () => {
+  beforeEach(() => vi.resetModules())
+
+  it('maps every key to the upstream it names', async () => {
+    vi.stubGlobal(
+      'fetch',
+      vi.fn(async (url: string) => {
+        const u = String(url)
+        const body = u.endsWith('/enrolments')
+          ? [{ from: 'enrolments' }]
+          : u.includes('/sends/summary')
+            ? { from: 'summary' }
+            : u.includes('/journey')
+              ? [{ from: 'journey' }]
+              : u.includes('/sends')
+                ? [{ from: 'sends' }]
+                : { from: 'campaign' }
+        return { ok: true, status: 200, json: async () => body, headers: new Headers({ 'x-total-count': '7', 'x-page': '0', 'x-page-size': '50' }) }
+      }),
+    )
+
+    const { GET } = await import('@/app/api/campaigns/[id]/route')
+    const res = await GET(new Request('http://x/api/campaigns/abc'), { params: Promise.resolve({ id: 'abc' }) })
+    const d = await res.json()
+
+    expect(d.campaign).toEqual({ from: 'campaign' })
+    expect(d.enrolments).toEqual([{ from: 'enrolments' }])
+    expect(d.sends.items).toEqual([{ from: 'sends' }])
+    expect(d.sendSummary).toEqual({ from: 'summary' })
+    expect(d.journey).toEqual([{ from: 'journey' }])
+  })
+
+  /**
+   * The consequence that actually reached a user: whenever the journey slot is reported as usable,
+   * it must be something the funnel can iterate. A shape check here is worth more than the mapping
+   * assertion alone, because it fails for ANY future way of getting a non-array into that slot.
+   */
+  it('never reports the journey as ok while holding a non-array', async () => {
+    vi.stubGlobal(
+      'fetch',
+      vi.fn(async (url: string) => {
+        const u = String(url)
+        // /journey is missing upstream — the state the sandbox was actually in.
+        if (u.includes('/journey')) return { ok: false, status: 404, json: async () => ({ code: 'NOT_FOUND' }) }
+        return { ok: true, status: 200, json: async () => ({}), headers: new Headers() }
+      }),
+    )
+
+    const { GET } = await import('@/app/api/campaigns/[id]/route')
+    const res = await GET(new Request('http://x/api/campaigns/abc'), { params: Promise.resolve({ id: 'abc' }) })
+    const d = await res.json()
+
+    expect(d.sources.journey).toBe('not_deployed')
+    expect(Array.isArray(d.journey)).toBe(true)
+  })
+})

--- a/openbank-admin-ui/src/test/section-boundary.test.tsx
+++ b/openbank-admin-ui/src/test/section-boundary.test.tsx
@@ -1,0 +1,46 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright (c) OpenBank contributors. Licensed under the Apache License, Version 2.0.
+// See LICENSE in the repository root or https://www.apache.org/licenses/LICENSE-2.0 for details.
+
+import React from 'react'
+import { describe, expect, it, vi } from 'vitest'
+import { render, screen } from '@testing-library/react'
+import { LanguageProvider } from '@/lib/i18n/LanguageContext'
+import { SectionBoundary } from '@/components/feedback/SectionBoundary'
+
+function Boom(): React.ReactElement {
+  throw new Error('journey blew up')
+}
+
+describe('section boundary', () => {
+  /**
+   * The point: `app/error.tsx` catches per ROUTE, so one bad section takes the whole screen — a
+   * campaign's state, approvals and send log all disappear because the journey threw. That is the
+   * blank error page a user reported, and the reason it says nothing about which part failed.
+   */
+  it('contains the failure and keeps its siblings on screen', () => {
+    const spy = vi.spyOn(console, 'error').mockImplementation(() => {})
+
+    render(
+      React.createElement(LanguageProvider, null,
+        React.createElement('div', null,
+          React.createElement(SectionBoundary, { name: 'Journey' }, React.createElement(Boom)),
+          React.createElement('p', null, 'send log still here'))),
+    )
+
+    expect(screen.getByText('send log still here')).toBeTruthy()
+    // The section is named, because "which part failed" is the first question anyone is asked…
+    expect(screen.getByText(/Journey/)).toBeTruthy()
+    // …and the message is printed, because a boundary that swallows what it caught turns a
+    // five-minute diagnosis into an afternoon of guessing at reproductions.
+    expect(screen.getByText(/journey blew up/)).toBeTruthy()
+    expect(spy).toHaveBeenCalled()
+    spy.mockRestore()
+  })
+
+  it('renders children untouched when nothing throws', () => {
+    render(React.createElement(LanguageProvider, null,
+      React.createElement(SectionBoundary, { name: 'Journey' }, React.createElement('p', null, 'fine'))))
+    expect(screen.getByText('fine')).toBeTruthy()
+  })
+})


### PR DESCRIPTION
A user opening a campaign detail got the route error screen — state, approvals, send log and journey
all gone because one part threw.

## Root cause — mine, from #3191

The bundle fans out with `Promise.all` and names the results by **position**:

```js
const [campaign, enrolments, sends, sendSummary, journey] = await Promise.all([
  …campaign…, …enrolments…, readSends(…),
  …/journey…,         // ← 4th element
  …/sends/summary…,   // ← 5th element
])
```

I inserted the journey read in the middle and appended `journey` to the end of the destructuring, so
the two lists disagree from the fourth position on. Every later name holds someone else's result —
and the types still check, because each slot has the same `{data, state}` shape.

So `journey` held the summary **object** with `state: 'ok'`, the page passed a non-array to the
funnel, and the screen died on `TypeError: s.map is not a function`. The real 404 on `/journey`
(campaign-service has not shipped the endpoint yet) never surfaced, because its state had landed
under `sendSummary`.

That is also why an hour of reproduction attempts failed: I was feeding fixtures the shape the code
was *supposed* to produce, not the shape it did. The browser console line identified it in one read —
and nothing else could have, because admin-ui ships no Sentry DSN and the error reached no log
(#3214).

## The test that catches this class

A positional mismatch is invisible to review — reading the code is exactly what missed it — and
invisible to TypeScript. So the route test gives every upstream a **distinguishable body** and
asserts which key each one landed in, plus a shape check that the journey slot is never reported
`ok` while holding a non-array.

Falsified before committing: both cases fail with the ordering put back, and pass with it fixed.

`JourneyFlow` also now treats a non-array as empty — the route test asserts the contract, this makes
breaking it survivable rather than fatal.

## Containment

`app/error.tsx` catches per **route**. One bad section therefore replaces an entire screen, which is
the opposite of the graceful-state rule it exists to serve — and it names nothing, so neither the
operator reporting it nor I could say which part failed.

`SectionBoundary` contains the throw to one section, names it, and **prints the message**. A boundary
that swallows what it caught turns a five-minute diagnosis into an afternoon of guessing at
reproductions — which is literally what this issue cost. The journey section (the newest code on that
page, and the most likely suspect) is wrapped.

It is deliberately not a substitute for handling failure properly: a section that can fail for a known
reason still says so via `DataUnavailable`. This is for the throw nobody predicted.

Note the shape it had to take: an error boundary must be a class (`getDerivedStateFromError` exists
nowhere else) and a class cannot call `useLanguage`. The hook runs in a function wrapper, outside the
subtree that throws — so a broken child cannot break the translation of its own failure message. The
i18n guard caught the first version, correctly.

## Hardening

`detail?.sources.X` → `detail?.sources?.X`, 7 sites. A bundle response missing `sources` throws on
property access rather than degrading, and the page already treats every source as possibly-absent
everywhere else.

## Found while investigating, filed separately

**admin-ui ships no Sentry DSN.** `app/error.tsx` calls `Sentry.captureException`, GlitchTip is
deployed in `observability`, and no service in the fleet sets a DSN — so every caught render error
reports to nothing. Had that been wired, this would have been one lookup instead of an hour of failed
reproductions.

Suites green: 955/955 admin-ui, `tsc --noEmit` clean.
