### PR TITLE
fix(finops-agent): wire the datasource — the pod has been CrashLoopBackOff on localhost since it was deployed

### DIFF
--- a/openbank-infra/gitops/components/finops-agent/finops-agent.yaml
+++ b/openbank-infra/gitops/components/finops-agent/finops-agent.yaml
@@ -34,6 +34,32 @@ spec:
             - name: management
               containerPort: 8085
           env:
+            # Datasource. Without these the pod CrashLoopBackOffs: application.yaml
+            # defaults every URL to localhost:5432, so Flyway's migrate-at-start
+            # fails with `Connection refused` before the app ever serves. It sat
+            # that way while postgres.yaml provisioned a healthy CNPG cluster for a
+            # client that could not dial it — the file's own comment says the
+            # Deployment uses finops-db-rw, and it did not.
+            #
+            # NOTE THE VARIABLE NAMES. This service reads JDBC_URL / REACTIVE_URL /
+            # POSTGRES_USER / POSTGRES_PASSWORD (see its application.yaml), NOT the
+            # QUARKUS_DATASOURCE_* names most siblings use. Copying the campaign
+            # block verbatim would set variables nothing reads, leave the localhost
+            # defaults in place, and look like a fix while changing nothing.
+            #
+            # Reactive is the app's own client (Panache); the JDBC leg exists only
+            # for Flyway. Both point at the CNPG primary.
+            - name: JDBC_URL
+              value: jdbc:postgresql://finops-db-rw.finops-agent.svc:5432/openbank_finops
+            - name: REACTIVE_URL
+              value: postgresql://finops-db-rw.finops-agent.svc:5432/openbank_finops
+            - name: POSTGRES_USER
+              value: openbank
+            - name: POSTGRES_PASSWORD
+              valueFrom:
+                secretKeyRef:
+                  name: finops-db-app
+                  key: password
             - name: QUARKUS_OIDC_AUTH_SERVER_URL
               value: http://keycloak.iam.svc:8080/realms/openbank
             - name: TEMPORAL_HOST


### PR DESCRIPTION
Refs #3071

Found by reading a firing alert nobody had read. `ArgoCDAppDegraded` has been up for `finops-agent`, and the app was `Synced/Degraded` — gitops applied the manifests and the workload they describe was broken.

## What was wrong

The Deployment carried **no datasource configuration at all** — no `JDBC_URL`, no `REACTIVE_URL`, no credentials, no `envFrom`. So `application.yaml`'s defaults applied, every URL pointed at `localhost:5432`, and Flyway's `migrate-at-start` died before the app could serve:

```
org.flywaydb.core.internal.jdbc.JdbcUtils.openConnection
Caused by: java.net.ConnectException: Connection refused
```

117 restarts over 8h across two ReplicaSets.

**`Connection refused` rather than a timeout was the tell.** A NetworkPolicy drop hangs; a refusal means it reached something that actively said no — its own loopback. That ruled out the network before any time was spent there.

Everything downstream was healthy the entire time, which is why nothing else complained:

```
CNPG cluster:  Cluster in healthy state, 1/1 ready, primary finops-db-1
finops-db-1:   ready=true restarts=0
finops-db-rw:  endpoint 10.80.143.77:5432 (9 days)
finops-db-app: secret present (9 days), keys include `password`
```

`postgres.yaml` even describes the secret and Service as *"the finops-db-rw Service the Deployment uses"*. The Deployment did not use it. A database had been provisioned and maintained for nine days for a client that could not dial it.

## The trap this fix is written around

This service reads **`JDBC_URL` / `REACTIVE_URL` / `POSTGRES_USER` / `POSTGRES_PASSWORD`** (its own `application.yaml`), *not* the `QUARKUS_DATASOURCE_*` names that campaign, ledger and payments use.

Copying a sibling's env block verbatim — the obvious move — would set variables nothing reads, leave the localhost defaults in place, and **present as a fix while changing nothing**: same CrashLoopBackOff, now with plausible-looking config above it. The manifest comment says so explicitly so the next person does not make that trade.

Reactive is the app's Panache client; the JDBC leg exists only for Flyway. Both point at the CNPG primary; the password comes from the operator-generated secret, key confirmed against the live object rather than assumed.

## Verification

`kubectl apply --dry-run=server` accepts it against the live API; yamllint clean with the CI config; `gen-network-policies.py` emits no change (the DB is same-namespace and CNPG pods are not selected by the generator).

**Not verified live, and cannot be before merge** — the root app-of-apps syncs `gitops/apps` and `components/` with prune+selfHeal, so a hand-applied unmerged change is reverted within seconds (#3165). After merge the check is: pod `Ready`, restart count stops climbing, and `ArgoCDAppDegraded{name="finops-agent"}` clears. I will confirm those rather than assume the manifest change was sufficient — Flyway may surface a second problem once it can actually connect.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
