### PR TITLE
fix(keycloak): the realm-drift detector compared realm roles against realm+client declarations

### DIFF
--- a/.github/scripts/check-realm-role-parity.py
+++ b/.github/scripts/check-realm-role-parity.py
@@ -72,8 +72,23 @@ SIBLING_GATE = ".github/scripts/check-roles-allowed-realm.py"
 
 
 def keycloak_builtins(realm: str) -> set:
-    """Roles the Keycloak server creates itself; never declared in a template."""
-    return {"offline_access", "uma_authorization", f"default-roles-{realm.lower()}"}
+    """Roles the Keycloak server creates itself; never declared in a template.
+
+    `uma_protection` is CLIENT-scoped, unlike the other three: Keycloak adds it to any
+    client that enables authorization services, including our own. It only became
+    reachable here once the capture started including client roles (the realm-roles-only
+    capture reported every client role as declared-not-live — that is what kept
+    `mcp-caller` red). Keycloak's own clients — realm-management, account,
+    account-console, broker — are excluded at capture time by clientId instead of by
+    role name, so that a role we define that happens to share a built-in's name is still
+    compared rather than silently skipped.
+    """
+    return {
+        "offline_access",
+        "uma_authorization",
+        "uma_protection",
+        f"default-roles-{realm.lower()}",
+    }
 
 
 def template_roles(root: pathlib.Path) -> dict:

--- a/openbank-infra/gitops/components/keycloak-realm-drift/keycloak-realm-drift.yaml
+++ b/openbank-infra/gitops/components/keycloak-realm-drift/keycloak-realm-drift.yaml
@@ -194,8 +194,44 @@ spec:
                     curl -sS --fail-with-body \
                       -H "Authorization: Bearer ${TOKEN}" \
                       "${KC_URL}/admin/realms/${REALM}/roles?briefRepresentation=true&first=0&max=2000" \
-                      > "/work/${REALM}-roles.json"
-                    echo "  $(python3 -c "import json;print(len(json.load(open('/work/${REALM}-roles.json'))))") role(s)"
+                      > "/work/${REALM}-realm-roles.json"
+
+                    # CLIENT roles too. check-realm-role-parity.py's template_roles()
+                    # flattens `roles.realm` AND `roles.client[*]` into ONE name set, so a
+                    # capture of realm roles alone reports every client role as
+                    # declared-not-live — permanently, and by construction rather than
+                    # because anything drifted. `mcp-caller` (a client role on
+                    # openbank-mcp-service, ADR-0224) sat that way: present in the live
+                    # realm the whole time, reported missing on every run, and the
+                    # CronJob failing on its own false positive took the ArgoCD app to
+                    # Degraded for a day. The two sides of a comparison have to agree on
+                    # scope; that is what actually broke here, not the realm.
+                    #
+                    # SKIP KEYCLOAK'S OWN CLIENTS. Measured on the sandbox 2026-08-02:
+                    # the realm has 29 client roles and exactly ONE (`mcp-caller`) is ours
+                    # — the other 28 come from realm-management, account, account-console
+                    # and broker. Capturing them unfiltered trades one false
+                    # declared-not-live for 28 false live-not-declared, which is worse.
+                    # Filter by CLIENT IDENTITY rather than by role name, so a role we
+                    # later define that happens to be called `view-users` is still checked
+                    # instead of silently matching a built-in's name.
+                    curl -sS --fail-with-body \
+                      -H "Authorization: Bearer ${TOKEN}" \
+                      "${KC_URL}/admin/realms/${REALM}/clients?briefRepresentation=true&first=0&max=2000" \
+                      > "/work/${REALM}-clients.json"
+                    rm -rf "/work/${REALM}-cr" && mkdir -p "/work/${REALM}-cr"
+                    for CID in $(python3 -c "import json;B={'account','account-console','admin-cli','broker','realm-management','security-admin-console'};print(' '.join(c['id'] for c in json.load(open('/work/${REALM}-clients.json')) if c.get('clientId') not in B))"); do
+                      curl -sS --fail-with-body \
+                        -H "Authorization: Bearer ${TOKEN}" \
+                        "${KC_URL}/admin/realms/${REALM}/clients/${CID}/roles?briefRepresentation=true&first=0&max=2000" \
+                        > "/work/${REALM}-cr/${CID}.json"
+                    done
+
+                    # Merge into the single array load_live() expects. `uma_protection` is
+                    # still expected here — Keycloak creates it on any of OUR clients that
+                    # enables authorization services — so the checker's builtins filter
+                    # carries it; see keycloak_builtins() in the script.
+                    python3 -c "import glob,json;r=json.load(open('/work/${REALM}-realm-roles.json'));[r.extend(json.load(open(f))) for f in sorted(glob.glob('/work/${REALM}-cr/*.json'))];json.dump(r,open('/work/${REALM}-roles.json','w'));print('  %d role(s) (realm + client)' % len(r))"
                   done
 
                   # --skip-annotations is NOT passed: the clone is a full checkout, so the

--- a/openbank-infra/scripts/check_realm_role_parity_test.py
+++ b/openbank-infra/scripts/check_realm_role_parity_test.py
@@ -73,6 +73,30 @@ class RealmRoleParityTest(unittest.TestCase):
         self.assertNotIn("offline_access", r.stderr)
         self.assertNotIn("default-roles-openbank", r.stderr)
 
+    def test_uma_protection_is_a_builtin_not_a_finding(self):
+        """CLIENT-scoped built-in. Keycloak adds uma_protection to any of OUR clients that turns
+        on authorization services, so it appears in the live capture and in no template. It only
+        became reachable once the capture started including client roles (2026-08-02); before
+        that the realm-roles-only capture reported every client role as declared-not-live, which
+        is what kept `mcp-caller` permanently red and the CronJob failing on its own output."""
+        r = run(declared_roles() + BUILTINS + ["uma_protection"])
+        self.assertEqual(0, r.returncode, r.stderr)
+        self.assertNotIn("uma_protection", r.stderr)
+
+    def test_client_scoped_declared_role_is_matched_by_the_live_capture(self):
+        """`mcp-caller` is declared under roles.client, not roles.realm. template_roles() flattens
+        both into one name set, so a live snapshot that carries it must read as in-sync — and one
+        that omits it must flag it. Asserting only the first half would pass against a capture
+        that never looked at client roles at all, which was the actual defect."""
+        self.assertIn("mcp-caller", declared_roles())
+        r = run(declared_roles() + BUILTINS)
+        self.assertNotIn("mcp-caller", r.stderr)
+
+        without = [n for n in declared_roles() if n != "mcp-caller"] + BUILTINS
+        r2 = run(without)
+        self.assertNotEqual(0, r2.returncode)
+        self.assertIn("mcp-caller", r2.stderr)
+
     # --- direction 1: declared in the template, absent from the live realm ---------------------
     def test_role_missing_from_live_realm_is_flagged(self):
         """The real #2540 defect: ROLE_KYC_REVIEWER declared, never created live."""


### PR DESCRIPTION
Refs #3071

Found by chasing a firing `ArgoCDAppDegraded` — the second of the two apps that had been Degraded and unread.

## The role was never missing

`mcp-caller` has been reported as declared-not-live since it was added (ADR-0224), and the CronJob exits non-zero on a finding, so ArgoCD showed `keycloak-realm-drift` Degraded for a day. Checked against the running realm:

```
client openbank-mcp-service id=f3438a37-…
--- its client roles ---
mcp-caller uma_protection
```

It was live the whole time. **The two sides of the comparison disagreed about scope.**

`template_roles()` flattens `roles.realm` **and** `roles.client[*]` into one name set:

```python
names = {r["name"] for r in (roles.get("realm") or [])}
for client_roles in (roles.get("client", {}) or {}).values():
    names |= {r["name"] for r in client_roles or []}
```

while the capture step fetched only `/admin/realms/{realm}/roles`, which returns realm roles. Every client role was therefore guaranteed to read as missing — by construction, not because anything drifted. The script's own header warns that "a detector's worst failure mode is inventing findings"; this was that.

## Why the obvious fix would have been worse

Capturing client roles unfiltered trades one false `declared-not-live` for **28 false `live-not-declared`**. Measured, not guessed — the realm has 29 client roles and exactly one is ours:

```
create-client delete-account impersonation manage-account manage-account-links
manage-authorization manage-clients manage-consent manage-events … mcp-caller …
uma_protection view-applications view-authorization … view-users
```

The rest come from `realm-management`, `account`, `account-console` and `broker`.

So the capture skips **Keycloak's own clients, by clientId** — not by role name. Filtering on names would silently skip a role we later define that happens to be called `view-users`. The filter keeps 10 of 16 clients, all ours.

`uma_protection` is the one name-level exemption left: Keycloak creates it on any of *our* clients that enables authorization services, so it is genuinely live-only. It joins `keycloak_builtins()`, which until now held only realm-scoped built-ins — because client roles were never reachable before this change.

## Verification, against the live realm

| capture | result |
|---|---|
| realm roles only (today's behaviour) | `declaredNotLive: ['mcp-caller']`, `inSync: False` |
| realm + our client roles (this PR) | `declaredNotLive: []`, `liveNotDeclared: []`, `inSync: True` |

Both shell one-liners were run against real captured data before shipping, not just read.

Two tests added, both falsified:

- removing `uma_protection` from the builtins reddens the first;
- the second asserts **both** that a client-scoped declared role matches a capture containing it **and** that it is flagged when absent. Asserting only the former would pass against a capture that never looked at client roles at all — which is precisely the defect being fixed.

Suite 8 → 10, all green. yamllint clean; `kubectl apply --dry-run=server` accepts the CronJob.

## Note

This does not change what the realm contains — no roles are added or removed anywhere. It changes what the detector compares, so that its next finding is a real one.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
