### PR TITLE
fix(ci): catch unpinned dependencies on human PRs, not just Dependabot's

### DIFF
--- a/.github/scripts/check-verification-metadata-complete.py
+++ b/.github/scripts/check-verification-metadata-complete.py
@@ -1,0 +1,170 @@
+#!/usr/bin/env python3
+# SPDX-License-Identifier: Apache-2.0
+# Copyright (c) OpenBank contributors. Licensed under the Apache License, Version 2.0.
+# See LICENSE in the repository root or https://www.apache.org/licenses/LICENSE-2.0 for details.
+"""Fail when gradle/verification-metadata.xml is missing entries a build would need.
+
+Why this exists (#3218): the only thing that refreshes the file is
+`dependabot-verification-metadata.yml`, and it is gated on
+`github.actor == 'dependabot[bot]'`. A human PR that adds or bumps a dependency
+therefore ships it unpinned. Today that is a warning
+(`org.gradle.dependency.verification=lenient`); at the ADR-0144 graduation
+(2026-09-30, #1915) it becomes a failing build on any cold cache.
+
+This checks rather than writes: regeneration happens against a throwaway copy and
+the committed file is restored, so nothing is pushed back to a contributor's
+branch and the trust boundary that motivates the actor gate is untouched.
+
+Two things this deliberately does NOT do:
+
+  * It does not diff the file as text. `--write-verification-metadata` reindents
+    the whole document (~18.5k lines), so `git diff --exit-code` would be red on
+    every run regardless of content. The comparison is over the SET of
+    (component, artifact) pairs.
+  * It does not report removals. Regeneration only observes what the selected
+    tasks resolve, so an entry absent from this run is not evidence it is unused
+    — a narrower task list would "remove" half the file. Only additions mean a
+    real gap.
+
+Usage:
+    check-verification-metadata-complete.py --modules openbank-a,openbank-b
+    check-verification-metadata-complete.py --modules "" --enforce   # no-op, exits 0
+"""
+
+from __future__ import annotations
+
+import argparse
+import pathlib
+import re
+import shutil
+import subprocess
+import sys
+import tempfile
+
+METADATA = pathlib.Path("gradle/verification-metadata.xml")
+COMPONENT_RE = re.compile(r'<component group="([^"]*)" name="([^"]*)" version="([^"]*)"')
+ARTIFACT_RE = re.compile(r'<artifact name="([^"]*)"')
+
+# Both graphs matter. `testClasses` alone resolves only the test classpath, which
+# is exactly how the prod-side gap in #3017 stayed invisible; quarkusDependenciesBuild
+# resolves the Quarkus application model (prod runtime classpath + platform BOMs)
+# without the cost of a full quarkusBuild — see #3199.
+TASKS = ("testClasses", "quarkusDependenciesBuild")
+
+
+def artifact_set(path: pathlib.Path) -> set[str]:
+    """Every (component, artifact) pair in the file, as flat 'g:n:v|artifact' keys."""
+    found: set[str] = set()
+    component = None
+    for line in path.read_text(encoding="utf-8").splitlines():
+        match = COMPONENT_RE.search(line)
+        if match:
+            component = "%s:%s:%s" % match.groups()
+            continue
+        match = ARTIFACT_RE.search(line)
+        if match and component:
+            found.add(f"{component}|{match.group(1)}")
+    return found
+
+
+# `--write-verification-metadata` OOMs at Gradle's default heap: measured, it dies
+# with `Java heap space` even on a single module. This is not optional tuning.
+GRADLE_HEAP = "-Dorg.gradle.jvmargs=-Xmx6g"
+
+
+def regenerate(modules: list[str]) -> None:
+    """Run the metadata writer for the given modules, in place.
+
+    Raises RegenerationFailed if Gradle itself failed. That is deliberately NOT the
+    same outcome as "a gap was found": a crashed build proves nothing either way,
+    and reporting it as a gap would send the author chasing entries that are fine.
+    """
+    targets = [f":{module}:{task}" for module in modules for task in TASKS]
+    result = subprocess.run(
+        ["./gradlew", "--write-verification-metadata", "sha256",
+         # Without this the check is vacuous on CI. A warm Gradle cache does not
+         # re-resolve metadata artifacts, so nothing gets re-hashed and the run
+         # reports "no gaps" even when an entry is demonstrably missing — measured:
+         # delete a known entry, run without --refresh-dependencies, and it passes.
+         # CI always has a warm cache (`actions/setup-java` with `cache: gradle`).
+         "--refresh-dependencies",
+         *targets, GRADLE_HEAP, "--no-daemon", "--console=plain", "-q"],
+        check=False,
+    )
+    if result.returncode != 0:
+        raise RegenerationFailed(result.returncode)
+
+
+class RegenerationFailed(RuntimeError):
+    def __init__(self, code: int) -> None:
+        super().__init__(f"gradle exited {code}")
+        self.code = code
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--modules", required=True,
+                        help="comma-separated Gradle module dirs; empty means nothing to do")
+    parser.add_argument("--enforce", action="store_true",
+                        help="exit non-zero on a gap (default: warn only)")
+    args = parser.parse_args()
+
+    modules = [m.strip() for m in args.modules.split(",") if m.strip()]
+    if not modules:
+        print("check-verification-metadata: no Gradle modules changed — nothing to check")
+        return 0
+
+    if not METADATA.is_file():
+        print(f"::error::{METADATA} not found")
+        return 1
+
+    print(f"check-verification-metadata: regenerating for {len(modules)} module(s): "
+          f"{', '.join(modules)}")
+
+    before = artifact_set(METADATA)
+    with tempfile.NamedTemporaryFile(suffix=".xml", delete=False) as backup_handle:
+        backup = pathlib.Path(backup_handle.name)
+    shutil.copy2(METADATA, backup)
+    failed = None
+    try:
+        regenerate(modules)
+        after = artifact_set(METADATA)
+    except RegenerationFailed as exc:
+        failed = exc
+        after = before
+    finally:
+        # Restore unconditionally: a failed Gradle run can still have rewritten the file.
+        shutil.copy2(backup, METADATA)
+        backup.unlink(missing_ok=True)
+
+    if failed is not None:
+        # Infrastructure failure, not a verdict about the metadata. Say so out loud
+        # rather than letting a crash read as either a pass or a gap.
+        print(f"::error title=verification-metadata check could not run::Gradle failed "
+              f"({failed}); this says nothing about whether the metadata is complete. "
+              f"Re-run, and if it persists treat it as a build problem, not a metadata gap.")
+        return 1
+
+    missing = sorted(after - before)
+    if not missing:
+        print(f"check-verification-metadata: OK — {len(before)} artifacts, no gaps "
+              f"for the changed modules")
+        return 0
+
+    level = "error" if args.enforce else "warning"
+    print(f"::{level} title=verification-metadata is missing {len(missing)} entr"
+          f"{'y' if len(missing) == 1 else 'ies'}::A cold-cache build of the changed "
+          f"modules resolves artifacts that gradle/verification-metadata.xml does not pin. "
+          f"Regenerate locally and commit the additions: "
+          f"./gradlew --write-verification-metadata sha256 "
+          f"{' '.join(f':{m}:{t}' for m in modules for t in TASKS)} "
+          f"-Dorg.gradle.jvmargs=-Xmx6g")
+    for key in missing:
+        component, artifact = key.split("|", 1)
+        print(f"  missing: {artifact}  ({component})")
+
+    return 1 if args.enforce else 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/.github/workflows/services-ci.yml
+++ b/.github/workflows/services-ci.yml
@@ -337,9 +337,59 @@ jobs:
 
   # Single required status check that aggregates the matrix, so branch protection
   # can require "Services CI / all-green" without enumerating every service.
+  # Human PRs never get their verification metadata refreshed: the producer
+  # (dependabot-verification-metadata.yml) is gated on
+  # `github.actor == 'dependabot[bot]'`, deliberately, because it pushes a commit
+  # back to the PR branch. So this VERIFIES instead of writing — regeneration runs
+  # against a throwaway copy and the committed file is restored, which keeps that
+  # trust boundary intact while still catching an unpinned artifact. See #3218.
+  #
+  # Scoped to the modules whose build files changed, not the fleet: a full-fleet
+  # regeneration is ~20 min and a `quarkusBuild` variant OOM'd after 3h40m.
+  verification-metadata:
+    name: verification-metadata
+    needs: [changes]
+    if: always()
+    runs-on: ubuntu-latest
+    timeout-minutes: 30
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Derive changed Gradle modules
+        id: mods
+        run: |
+          set -euo pipefail
+          base="${{ github.event.pull_request.base.sha || github.event.before }}"
+          if [ -z "$base" ] || ! git cat-file -e "$base^{commit}" 2>/dev/null; then
+            echo "modules=" >> "$GITHUB_OUTPUT"
+            echo "No usable base sha — skipping."; exit 0
+          fi
+          # Only module-level build files matter; a root or build-logic change is
+          # out of scope here and would fan out to the whole fleet.
+          mods="$(git diff --name-only "$base"...HEAD \
+                    | grep -E '^openbank-[^/]+/build\.gradle\.kts$' \
+                    | cut -d/ -f1 | sort -u | paste -sd, -)"
+          echo "modules=${mods}" >> "$GITHUB_OUTPUT"
+          echo "changed modules: ${mods:-<none>}"
+
+      - uses: actions/setup-java@v4
+        if: steps.mods.outputs.modules != ''
+        with:
+          distribution: temurin
+          java-version: "25"
+          cache: gradle
+
+      - name: Check verification metadata covers the changed modules
+        if: steps.mods.outputs.modules != ''
+        run: |
+          python3 .github/scripts/check-verification-metadata-complete.py \
+            --modules "${{ steps.mods.outputs.modules }}" --enforce
+
   all-green:
     name: all-green
-    needs: [changes, build]
+    needs: [changes, build, verification-metadata]
     if: always()
     runs-on: ubuntu-latest
     timeout-minutes: 2
@@ -348,6 +398,9 @@ jobs:
         run: |
           if [ "${{ needs.build.result }}" = "failure" ] || [ "${{ needs.build.result }}" = "cancelled" ]; then
             echo "One or more service builds failed."; exit 1
+          fi
+          if [ "${{ needs.verification-metadata.result }}" = "failure" ]; then
+            echo "verification-metadata check failed (#3218)."; exit 1
           fi
           echo "All changed services built green (or nothing to build)."
 

--- a/.github/workflows/services-ci.yml
+++ b/.github/workflows/services-ci.yml
@@ -368,8 +368,12 @@ jobs:
           fi
           # Only module-level build files matter; a root or build-logic change is
           # out of scope here and would fan out to the whole fleet.
+          # `|| true` on the grep is required, not defensive: under `set -o pipefail`
+          # a grep that matches nothing exits 1 and kills the step — which is the
+          # common case here, since most PRs touch no module build file. Measured on
+          # this very PR (#3233), whose own gate went red for exactly this reason.
           mods="$(git diff --name-only "$base"...HEAD \
-                    | grep -E '^openbank-[^/]+/build\.gradle\.kts$' \
+                    | { grep -E '^openbank-[^/]+/build\.gradle\.kts$' || true; } \
                     | cut -d/ -f1 | sort -u | paste -sd, -)"
           echo "modules=${mods}" >> "$GITHUB_OUTPUT"
           echo "changed modules: ${mods:-<none>}"


### PR DESCRIPTION
## What

A CI gate that fails a PR whose dependency changes are not pinned in
`gradle/verification-metadata.xml` — regardless of who opened it.

New script `.github/scripts/check-verification-metadata-complete.py`, plus a
`verification-metadata` job in `services-ci.yml` wired into `all-green`.

## Why

The file is only ever refreshed by `dependabot-verification-metadata.yml`, which is gated on
`github.actor == 'dependabot[bot]'`. A human PR that adds or bumps a dependency ships it unpinned.

Today `org.gradle.dependency.verification=lenient` makes that a warning. At the ADR-0144 graduation
(2026-09-30, #1915) it becomes a failing build on any cold cache — a fresh runner, a recreated ARC
volume, CodeQL's tracing build, a new clone.

**It verifies instead of writing.** Regeneration runs against a throwaway copy and the committed
file is restored, so nothing is pushed to a contributor's branch. The actor gate on the producer is
not a bug — it exists because that job pushes a commit back — so relaxing it was the wrong fix.

## `--refresh-dependencies` is load-bearing, not tuning

Without it this check is **vacuous on CI**. A warm Gradle cache does not re-resolve metadata
artifacts, so nothing is re-hashed and the run reports "no gaps" even with an entry demonstrably
deleted. CI always has a warm cache (`actions/setup-java`, `cache: gradle`).

Measured, not assumed — same deleted entry, same warm cache:

| | verdict |
|---|---|
| without `--refresh-dependencies` | `OK — no gaps` ❌ wrong |
| with it | `exit 1`, names the missing artifact ✅ |

The first version of this PR had it green and passing, and it was checking nothing. The comment in
the code says so, so nobody removes the flag as redundant later.

## Gate exercised against a case it must flag

| scenario | result |
|---|---|
| known entry deleted | `exit 1` — `missing: hibernate-platform-7.4.5.Final.pom (org.hibernate.orm:hibernate-platform:7.4.5.Final)` |
| file untouched | `exit 0` — 5168 artifacts, no gaps |
| no Gradle modules changed | `exit 0`, no work done |

## Two other things learned the hard way, both encoded

**Set comparison, not text diff.** `--write-verification-metadata` reindents the whole document
(~18.5k lines), so `git diff --exit-code` would be red on every run regardless of content. The
comparison is over `(component, artifact)` pairs. Removals are ignored on purpose: regeneration only
observes what the selected tasks resolve, so a narrower task list would "remove" half the file.

**A Gradle crash reports "could not run", never a gap.** The first version used `check=True`, so an
OOM surfaced as `exit 1` — indistinguishable from a real finding, and it would have sent the author
hunting entries that are fine. `-Xmx6g` is required; the writer OOMs at the default heap even for a
single module.

## Cost

Scoped to modules whose `build.gradle.kts` changed, not the fleet — a fleet-wide regeneration is
~20 min and the `quarkusBuild` variant OOM'd after 3h40m. PRs touching no module build file skip the
work entirely.

Tasks match the producer fixed in #3199 (`testClasses` + `quarkusDependenciesBuild`). Checking only
`testClasses` would reproduce the exact blind spot behind #3017.

## Scope

Catches gaps going forward. Does **not** backfill existing ones — fleet prod-graph measurement
remains open in #3131.

`actionlint` finding sets diffed against `origin/main`: 2 before, 2 after, no new findings (both
pre-existing, unrelated lines).

## Linked issues

Refs #3218, #1915

🤖 Generated with [Claude Code](https://claude.com/claude-code)
