### PR TITLE
DO NOT MERGE: prove the verification-metadata gate detects an unpinned dependency

### DIFF
--- a/openbank-campaign-service/build.gradle.kts
+++ b/openbank-campaign-service/build.gradle.kts
@@ -8,6 +8,10 @@ plugins {
 }
 
 dependencies {
+    // DELIBERATELY UNPINNED — this dependency is absent from
+    // gradle/verification-metadata.xml on purpose. Do not "fix" it: the point of
+    // this branch is to prove the #3233 gate goes red. Never merge.
+    implementation("org.jsoup:jsoup:1.18.3")
     implementation(enforcedPlatform(libs.quarkus.bom))
     implementation(libs.quarkus.kotlin)
     implementation(libs.quarkus.resteasy.reactive)


### PR DESCRIPTION
## ⚠️ DO NOT MERGE — this branch exists to make a check go red

Adds `org.jsoup:jsoup:1.18.3` to `openbank-campaign-service` and **deliberately does not**
regenerate `gradle/verification-metadata.xml`. jsoup appears nowhere in that file today.

## Why

#3233 added a gate that fails a PR whose dependency changes are not pinned. It merged with only its
**no-op path** exercised in CI: that PR changed nothing under `openbank-*/build.gradle.kts`, so the
gate correctly skipped, and green meant "did not block" — not "can detect".

Detection was verified only on my machine. The part it hinges on, `--refresh-dependencies`, is
precisely the piece whose behaviour differs between a local cache and CI's, and without it the check
reports "no gaps" even with an entry demonstrably deleted. So the one thing that makes the gate real
is the one thing CI has never exercised.

## Expected result

`verification-metadata` **fails**, naming the missing jsoup artifacts.

| outcome | meaning |
|---|---|
| ❌ red, names jsoup | gate works — close #3218, then close this PR unmerged |
| ✅ green | gate is a no-op in CI; #3218 is **not** resolved and #3233 needs rework |

A green result here is the valuable one to discover now rather than on 2026-09-30, when
`org.gradle.dependency.verification` graduates to `strict` (#1915) and this failure mode turns from
a silent warning into every cold-cache build breaking at once.

## Disposal

Close unmerged once the check reports. Nothing here is intended for `main`.

Refs #3218, #3233
