### PR TITLE
feat(aml,sanctions): publish provider verifications so consumers can deploy

### DIFF
--- a/openbank-aml-service/src/test/kotlin/com/openbank/aml/contract/AmlPactBrokerProviderVerificationTest.kt
+++ b/openbank-aml-service/src/test/kotlin/com/openbank/aml/contract/AmlPactBrokerProviderVerificationTest.kt
@@ -1,0 +1,102 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright (c) OpenBank contributors. Licensed under the Apache License, Version 2.0.
+// See LICENSE in the repository root or https://www.apache.org/licenses/LICENSE-2.0 for details.
+
+package com.openbank.aml.contract
+
+import au.com.dius.pact.provider.junit5.HttpTestTarget
+import au.com.dius.pact.provider.junit5.PactVerificationContext
+import au.com.dius.pact.provider.junit5.PactVerificationInvocationContextProvider
+import au.com.dius.pact.provider.junitsupport.IgnoreNoPactsToVerify
+import au.com.dius.pact.provider.junitsupport.Provider
+import au.com.dius.pact.provider.junitsupport.State
+import au.com.dius.pact.provider.junitsupport.loader.PactBroker
+import io.quarkus.test.common.QuarkusTestResource
+import io.quarkus.test.junit.QuarkusTest
+import io.quarkus.test.security.TestSecurity
+import org.eclipse.microprofile.config.inject.ConfigProperty
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.TestTemplate
+import org.junit.jupiter.api.condition.EnabledIfSystemProperty
+import org.junit.jupiter.api.extension.ExtendWith
+
+/**
+ * Broker-side provider verification for aml-service, published-result counterpart to
+ * [AmlPactProviderVerificationTest].
+ *
+ * **Why this exists.** aml-service had only a `@PactFolder` class, which replays the committed
+ * pact from disk and never contacts the broker — so aml-service has **never published a version
+ * on main**. `pact-verification-reconcile.yml` says so in as many words on every run:
+ *
+ * ```
+ * NO main VERSION, not dispatching: openbank-aml-service has never published a version on
+ * main, so its consumers (openbank-fx-service) read as unverified
+ * ```
+ *
+ * and then finishes with "every provider has verified its consumers' latest pacts — nothing to
+ * do". The consequence is not a delay that clears itself: `can-i-deploy` sees no verified pact
+ * between fx-service and the aml-service running in the environment, and **blocks every
+ * fx-service deploy, permanently**. Measured on 2026-08-02: the fx inverse-pair fix (#3189)
+ * merged green and could not reach the sandbox at all, on two separate auto-deploy runs.
+ *
+ * A `@PactFolder` replay is the right PR-lane gate (ADR-0063: zero infra, always runs) but it
+ * cannot publish a result, and `can-i-deploy` only reads published results. The two classes
+ * answer different questions and the service needs both.
+ *
+ * **Why a second `@Provider("openbank-aml-service")` class is safe here.** The footgun
+ * `rules.yaml`/ADR-0029 D3 warns about is two BROKER-sourced classes both pulling every pact for
+ * one provider, or HTTP and MESSAGE targets fighting over the same `@BeforeEach`. This is the
+ * sanctioned pair CLAUDE.md documents — a `@PactFolder` class plus a `@PactBroker` class gated on
+ * `pactbroker.url` — exactly as openbank-ledger-service already carries. aml-service has no
+ * message-consumer contracts and both classes use [HttpTestTarget] exclusively, so verifying the
+ * same interaction from two sources is at worst redundant, never colliding.
+ *
+ * Gated on `pactbroker.url`: skipped locally and on the PR lane, where `_service-ci.yml` blanks
+ * `PACT_BROKER_URL` (the broker has no public ingress, ADR-0056). It runs on main-push, where
+ * `PUBLISH_RESULTS=true`, which is the whole point — that run is what creates the main version
+ * the reconciler is looking for.
+ *
+ * **Every state its git-pact counterpart handles must be handled here too.** The broker serves
+ * EVERY consumer's pact for this provider, not just the one in `pacts/`; a missing state fails
+ * with MissingStateChangeMethod, publishes as a FAILURE, and then blocks deploys on a pair that
+ * is otherwise healthy — turning this fix into the very problem it removes.
+ */
+@QuarkusTest
+@QuarkusTestResource(com.openbank.aml.it.PostgresRedisTestResource::class)
+@TestSecurity(user = "pact-verifier", roles = ["ROLE_OPERATOR", "ROLE_COMPLIANCE"])
+@Provider("openbank-aml-service")
+@PactBroker
+@IgnoreNoPactsToVerify(ignoreIoErrors = "true")
+@EnabledIfSystemProperty(named = "pactbroker.url", matches = ".+")
+class AmlPactBrokerProviderVerificationTest {
+
+    @ConfigProperty(name = "quarkus.http.test-port", defaultValue = "8081")
+    lateinit var testPort: String
+
+    @BeforeEach
+    fun configureTarget(context: PactVerificationContext?) {
+        context?.target = HttpTestTarget("localhost", testPort.toInt())
+        context?.addStateChangeHandlers(this)
+    }
+
+    @TestTemplate
+    @ExtendWith(PactVerificationInvocationContextProvider::class)
+    fun verifyPacts(context: PactVerificationContext?) {
+        context?.verifyInteraction()
+    }
+
+    /**
+     * Mirrors [AmlPactProviderVerificationTest.stateNoExistingCaseForIdempotencyKey] verbatim, and
+     * is intentionally a no-op for the same reason: a fresh Testcontainer Postgres + Valkey carry
+     * neither the case row nor the Redis idempotency entry, so `AmlCaseService.createCase` takes
+     * the create branch and answers 201.
+     *
+     * Seeding the other direction from here is not merely unnecessary but unsafe — both stores are
+     * reached through `suspend` reactive APIs that cannot be driven from a plain JUnit state-change
+     * callback without a Vert.x context (the HR000068 trap).
+     */
+    @State("no AML case exists for the FX conversion idempotency key")
+    fun stateNoExistingCaseForIdempotencyKey() {
+        // Intentionally empty — see the KDoc above.
+    }
+}

--- a/openbank-aml-service/src/test/kotlin/com/openbank/aml/contract/AmlPactProviderVerificationTest.kt
+++ b/openbank-aml-service/src/test/kotlin/com/openbank/aml/contract/AmlPactProviderVerificationTest.kt
@@ -37,10 +37,19 @@ import org.junit.jupiter.api.extension.ExtendWith
  * `pacts/openbank-fx-service-openbank-aml-service.json` in the same PR, or this test verifies a
  * stale contract.
  *
- * **This must remain the ONLY `@Provider("openbank-aml-service")` class in the repo.** Two classes
- * sharing a provider name both pull every pact for that provider and collide (`rules.yaml:`
- * ADR-0029 D3 note); a second interaction type belongs in `@BeforeEach` target selection here, not
- * in a new class.
+ * **This is the git-pact half of the sanctioned pair.** Its counterpart is
+ * [AmlPactBrokerProviderVerificationTest], a `@PactBroker` class gated on `pactbroker.url` that
+ * runs only on main-push and PUBLISHES its result — which is what `can-i-deploy` reads, and what
+ * this class structurally cannot do. Before that class existed, aml-service had never published a
+ * version on main and every fx-service deploy was blocked on the missing verification.
+ *
+ * That is the only permitted second `@Provider("openbank-aml-service")` class. The collision
+ * ADR-0029 D3 warns about is two BROKER-sourced classes both pulling every pact, or HTTP and
+ * MESSAGE targets fighting over the same `@BeforeEach`; both classes here use `HttpTestTarget`
+ * exclusively and read from different sources. A further interaction TYPE still belongs in
+ * `@BeforeEach` target selection here, not in a third class — and any `@State` added here must be
+ * added to the broker class too, or the broker replay fails with MissingStateChangeMethod and
+ * publishes a failure.
  *
  * `@IgnoreNoPactsToVerify(ignoreIoErrors)` makes a missing/unreadable pact file a skip rather than
  * a failure — relevant if the folder is ever emptied ahead of a broker migration.

--- a/openbank-sanctions-service/src/test/kotlin/com/openbank/sanctions/contract/SanctionsPactBrokerProviderVerificationTest.kt
+++ b/openbank-sanctions-service/src/test/kotlin/com/openbank/sanctions/contract/SanctionsPactBrokerProviderVerificationTest.kt
@@ -1,0 +1,96 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright (c) OpenBank contributors. Licensed under the Apache License, Version 2.0.
+// See LICENSE in the repository root or https://www.apache.org/licenses/LICENSE-2.0 for details.
+
+package com.openbank.sanctions.contract
+
+import au.com.dius.pact.provider.junit5.HttpTestTarget
+import au.com.dius.pact.provider.junit5.PactVerificationContext
+import au.com.dius.pact.provider.junit5.PactVerificationInvocationContextProvider
+import au.com.dius.pact.provider.junitsupport.IgnoreNoPactsToVerify
+import au.com.dius.pact.provider.junitsupport.Provider
+import au.com.dius.pact.provider.junitsupport.State
+import au.com.dius.pact.provider.junitsupport.loader.PactBroker
+import com.openbank.sanctions.it.PostgresTestResource
+import io.quarkus.test.common.QuarkusTestResource
+import io.quarkus.test.junit.QuarkusTest
+import io.quarkus.test.security.TestSecurity
+import org.eclipse.microprofile.config.inject.ConfigProperty
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.TestTemplate
+import org.junit.jupiter.api.condition.EnabledIfSystemProperty
+import org.junit.jupiter.api.extension.ExtendWith
+
+/**
+ * Broker-side provider verification for sanctions-service, published-result counterpart to
+ * [SanctionsPactProviderVerificationTest].
+ *
+ * **Why this exists.** sanctions-service had only a `@PactFolder` class, which replays the
+ * committed pact from disk and never contacts the broker — so it has **never published a version
+ * on main**. `pact-verification-reconcile.yml` reports it on every run:
+ *
+ * ```
+ * NO main VERSION, not dispatching: openbank-sanctions-service has never published a version
+ * on main, so its consumers (openbank-fx-service) read as unverified
+ * ```
+ *
+ * and then finishes with "every provider has verified its consumers' latest pacts — nothing to
+ * do", which reads as an all-clear over a list of things that are not clear. The consequence:
+ * `can-i-deploy` sees no verified pact between fx-service and the sanctions-service running in
+ * the environment and blocks every fx-service deploy, permanently. Measured 2026-08-02 on the
+ * fx inverse-pair fix (#3189) — merged green, blocked twice, never reached the sandbox.
+ *
+ * A `@PactFolder` replay is the right PR-lane gate (ADR-0063: zero infra, always runs) but it
+ * cannot publish a result, and `can-i-deploy` only reads published results.
+ *
+ * **Why a second `@Provider("openbank-sanctions-service")` class is safe here.** The collision
+ * ADR-0029 D3 warns about is two BROKER-sourced classes both pulling every pact for one provider,
+ * or HTTP and MESSAGE targets fighting over the same `@BeforeEach`. This is the sanctioned pair
+ * CLAUDE.md documents — `@PactFolder` plus `@PactBroker` gated on `pactbroker.url` — as
+ * openbank-ledger-service already carries. sanctions-service has no message-consumer contracts
+ * and both classes use [HttpTestTarget] exclusively.
+ *
+ * Gated on `pactbroker.url`: skipped locally and on the PR lane (`_service-ci.yml` blanks
+ * `PACT_BROKER_URL`; the broker has no public ingress, ADR-0056). It runs on main-push with
+ * `PUBLISH_RESULTS=true` — that run is what creates the main version the reconciler looks for.
+ *
+ * **Both of the counterpart's states are handled here**, because the broker serves every
+ * consumer's pact for this provider: a missing state fails with MissingStateChangeMethod and
+ * publishes a FAILURE, which blocks deploys on a healthy pair.
+ */
+@QuarkusTest
+@QuarkusTestResource(PostgresTestResource::class)
+@TestSecurity(user = "pact-verifier", roles = ["ROLE_OPERATOR"])
+@Provider("openbank-sanctions-service")
+@PactBroker
+@IgnoreNoPactsToVerify(ignoreIoErrors = "true")
+@EnabledIfSystemProperty(named = "pactbroker.url", matches = ".+")
+class SanctionsPactBrokerProviderVerificationTest {
+
+    @ConfigProperty(name = "quarkus.http.test-port", defaultValue = "8081")
+    lateinit var testPort: String
+
+    @BeforeEach
+    fun configureTarget(context: PactVerificationContext?) {
+        context?.target = HttpTestTarget("localhost", testPort.toInt())
+        context?.addStateChangeHandlers(this)
+    }
+
+    @TestTemplate
+    @ExtendWith(PactVerificationInvocationContextProvider::class)
+    fun verifyPacts(context: PactVerificationContext?) {
+        context?.verifyInteraction()
+    }
+
+    /** Mirrors [SanctionsPactProviderVerificationTest] — no-op by design, see that class's KDoc. */
+    @State("the sanctions lists are seeded and carry no entry for the screened name")
+    fun stateNoSeededEntryMatchesTheName() {
+        // Intentionally empty — see the KDoc above.
+    }
+
+    /** Mirrors [SanctionsPactProviderVerificationTest] — the boot-time seed provides the entries. */
+    @State("the sanctions lists are seeded with the boot-time OFAC/EU/UN/PEP entries")
+    fun stateSeededSanctionsEntriesExist() {
+        // Intentionally empty — see the KDoc above.
+    }
+}

--- a/openbank-sanctions-service/src/test/kotlin/com/openbank/sanctions/contract/SanctionsPactProviderVerificationTest.kt
+++ b/openbank-sanctions-service/src/test/kotlin/com/openbank/sanctions/contract/SanctionsPactProviderVerificationTest.kt
@@ -40,10 +40,17 @@ import org.junit.jupiter.api.extension.ExtendWith
  * `pacts/openbank-fx-service-openbank-sanctions-service.json` in the same PR, or this test verifies
  * a stale contract.
  *
- * **This must remain the ONLY `@Provider("openbank-sanctions-service")` class in the repo.** Two
- * classes sharing a provider name both pull every pact for that provider and collide (ADR-0029 D3);
- * a further interaction type belongs in the `@BeforeEach` target selection here, or in a new
- * `@State` handler, not in a new class.
+ * **This is the git-pact half of the sanctioned pair.** Its counterpart is
+ * [SanctionsPactBrokerProviderVerificationTest], a `@PactBroker` class gated on `pactbroker.url`
+ * that runs only on main-push and PUBLISHES its result — which is what `can-i-deploy` reads, and
+ * what this class structurally cannot do. Before it existed, sanctions-service had never published
+ * a version on main and every fx-service deploy was blocked on the missing verification.
+ *
+ * That is the only permitted second `@Provider("openbank-sanctions-service")` class: the ADR-0029
+ * D3 collision is two BROKER-sourced classes, or HTTP vs MESSAGE targets sharing a `@BeforeEach`.
+ * A further interaction type still belongs in the `@BeforeEach` target selection here, not in a
+ * third class — and any `@State` added here must be added to the broker class too, or its replay
+ * fails with MissingStateChangeMethod and publishes a failure.
  *
  * `@IgnoreNoPactsToVerify(ignoreIoErrors)` makes a missing/unreadable pact file a skip rather than a
  * failure — relevant if the folder is ever emptied ahead of a broker migration.


### PR DESCRIPTION
## What this unblocks

`openbank-fx-service` is **permanently undeployable**, and so are four other consumers. Not a flake, not a lag — a structural gap that cannot clear itself.

`pact-verification-reconcile.yml` reports it on every 30-minute run, and then contradicts itself in the last line:

```
NO main VERSION, not dispatching: openbank-aml-service has never published a version on
main, so its consumers (openbank-fx-service) read as unverified
NO main VERSION, not dispatching: openbank-sanctions-service has never published a version
on main, so its consumers (openbank-fx-service) read as unverified
...
every provider has verified its consumers' latest pacts — nothing to do
```

**Measured, not inferred.** The FX inverse-pair fix ([#3189](https://github.com/JiRaska/open-bank-oss/pull/3189)) merged green on 2026-08-02, its image built and pushed, and `can-i-deploy` blocked it on **two** separate auto-deploy runs. It has never reached the sandbox. The customer-visible symptom — currency exchange failing — is still live because of this gate, not because of the code.

## Root cause

Both services had **only** a `@PactFolder` provider test. That replays the committed pact from disk and never contacts the broker, so neither service has ever published a version on main — and `can-i-deploy` reads *published verification results*, nothing else.

A `@PactFolder` class structurally cannot publish. It is the right PR-lane gate (ADR-0063: zero infra, always runs) and it is not the thing `can-i-deploy` consults. The two classes answer different questions.

**A misleading label cost the first diagnosis.** `can-i-deploy` classified the block as `PENDING_BUILD — the main-push build has not finished`. The build *had* finished and fx's pact *was* published; what was missing was the provider's side. Worth a separate look at that classifier.

## The fix

The pair `openbank-ledger-service` already carries and CLAUDE.md documents:

| class | source | runs | publishes |
|---|---|---|---|
| `*PactProviderVerificationTest` (existing) | `@PactFolder` | always, incl. PR lane | no |
| `*PactBrokerProviderVerificationTest` (new) | `@PactBroker`, gated on `pactbroker.url` | main-push | **yes** |

The main-push run is what creates the main version the reconciler looks for.

**Why a second `@Provider(...)` class is safe.** The ADR-0029 D3 collision is two *broker-sourced* classes both pulling every pact, or HTTP and MESSAGE targets fighting over one `@BeforeEach`. Neither service has a message-consumer contract and both classes use `HttpTestTarget` exclusively.

**Every `@State` is mirrored.** The broker serves *every* consumer's pact for a provider, not just the one in `pacts/` — a missing state fails with `MissingStateChangeMethod`, publishes a FAILURE, and blocks deploys on a healthy pair. That would make this change the problem it removes.

## Corrected documentation

Both existing classes' KDoc asserted *"this must remain the ONLY `@Provider(...)` class in the repo"*. That was already false against the ledger precedent — and worse, it argued the next reader out of the single fix that clears this. Rewritten in place to distinguish a real collision from the sanctioned pair, and to record that a new `@State` must be added to both classes.

## Still stranded, same cause

The same reconciler output names four more, not fixed here:

- `openbank-swift-service` → `openbank-clearing-simulator`
- `openbank-copilot-service` → `openbank-customer-edge`
- `openbank-card-issuance-service` → `openbank-product-catalog`
- `openbank-psd2-service` → `openbank-tpp-registry-service`

## Verification

`:openbank-aml-service:compileTestKotlin :openbank-sanctions-service:compileTestKotlin` + `detekt` + `ktlintCheck` on both → **BUILD SUCCESSFUL**, no findings.

The new classes are gated on `pactbroker.url`, so they skip locally and on the PR lane by design — the proof that they work is the main-push run publishing a version, and the reconciler's `NO main VERSION` lines disappearing for these two.

Refs #1985, #3221
