### PR TITLE
feat(ci): give the eight @PactFolder-only providers the @PactBroker half so their verifications reach the broker

### DIFF
--- a/.github/scripts/pact-reconcile-verifications.py
+++ b/.github/scripts/pact-reconcile-verifications.py
@@ -343,22 +343,44 @@ def self_test() -> int:
     if not edges:
         bad.append("edge list empty")
 
-    # can_publish_verification against the REAL repo, in both directions. A version that
-    # answered True for everything would have dispatched the folder-only providers
-    # forever; one that answered False for everything would dispatch nobody and look
-    # exactly like a healthy fleet.
+    # can_publish_verification in BOTH directions, against SYNTHETIC fixtures.
+    #
+    # This used to assert on the fleet's own population — that some provider could publish
+    # and some could not. That caught what it was built to catch and then went red for the
+    # right reason: #3232 added the @PactBroker half to all eight folder-only providers, so
+    # the "some cannot" half became false by being FIXED. An assertion whose truth depends
+    # on the fleet still having the defect is an assertion that must be edited every time
+    # someone improves things, and editing it under time pressure is how it ends up deleted.
+    # Fixtures do not have that problem: they test the function, not the estate.
+    import tempfile
+    with tempfile.TemporaryDirectory() as tmp:
+        tmpp = pathlib.Path(tmp)
+        for name, ann in (("prov-broker", "@PactBroker"), ("prov-folder", '@PactFolder("../pacts")')):
+            d = tmpp / name / "src" / "test" / "kotlin"
+            d.mkdir(parents=True)
+            (d / "T.kt").write_text(f'@Provider("x")\n{ann}\nclass T\n')
+        (tmpp / "prov-none" / "src" / "test").mkdir(parents=True)
+        checks = [
+            ("prov-broker", True, "@PactBroker provider is publishable"),
+            ("prov-folder", False, "@PactFolder-only provider is NOT publishable"),
+            ("prov-none", False, "provider with no test at all is NOT publishable"),
+            ("prov-missing", False, "provider directory that does not exist"),
+        ]
+        for name, want, why in checks:
+            got = can_publish_verification(tmpp, name)
+            mark = "ok " if got == want else "BAD"
+            print(f"  {mark} {why:48s} -> {got}")
+            if got != want:
+                bad.append(why)
+
+    # And a light fleet sanity check: if NOTHING in the real repo can publish, the function
+    # is answering False for everything and no verification would ever be dispatched — which
+    # looks exactly like a healthy fleet.
     providers = sorted({p for _, p in edges})
     pub = [p for p in providers if can_publish_verification(root, p)]
-    folder = [p for p in providers if not can_publish_verification(root, p)]
-    print(f"  {'ok ' if pub else 'BAD'} providers that CAN publish: {len(pub)}")
-    print(f"  {'ok ' if folder else 'BAD'} providers that CANNOT (folder-only): {len(folder)}")
+    print(f"  {'ok ' if pub else 'BAD'} providers in this repo that can publish: {len(pub)}/{len(providers)}")
     if not pub:
-        bad.append("no provider can publish — the check is answering False for everything")
-    if not folder:
-        bad.append(
-            "every provider can publish — either the fleet changed, or the check is "
-            "answering True for everything; verify before removing this assertion"
-        )
+        bad.append("no provider in the repo can publish — the check answers False for everything")
 
     if bad:
         print("\n::error::self-test FAILED: " + "; ".join(bad))

--- a/openbank-clearing-simulator/src/test/kotlin/com/openbank/clearingsimulator/contract/ClearingSimulatorPactBrokerProviderVerificationTest.kt
+++ b/openbank-clearing-simulator/src/test/kotlin/com/openbank/clearingsimulator/contract/ClearingSimulatorPactBrokerProviderVerificationTest.kt
@@ -1,0 +1,72 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright (c) OpenBank contributors. Licensed under the Apache License, Version 2.0.
+// See LICENSE in the repository root or https://www.apache.org/licenses/LICENSE-2.0 for details.
+
+package com.openbank.clearingsimulator.contract
+
+import au.com.dius.pact.provider.junit5.HttpTestTarget
+import au.com.dius.pact.provider.junit5.PactVerificationContext
+import au.com.dius.pact.provider.junit5.PactVerificationInvocationContextProvider
+import au.com.dius.pact.provider.junitsupport.IgnoreNoPactsToVerify
+import au.com.dius.pact.provider.junitsupport.Provider
+import au.com.dius.pact.provider.junitsupport.State
+import au.com.dius.pact.provider.junitsupport.loader.PactBroker
+import io.quarkus.test.junit.QuarkusTest
+import io.quarkus.test.security.TestSecurity
+import org.eclipse.microprofile.config.inject.ConfigProperty
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.TestTemplate
+import org.junit.jupiter.api.condition.EnabledIfSystemProperty
+import org.junit.jupiter.api.extension.ExtendWith
+
+/**
+ * Broker-side provider verification for openbank-clearing-simulator, the published-result counterpart to
+ * [ClearingSimulatorPactProviderVerificationTest].
+ *
+ * WHY BOTH EXIST. A `@PactFolder` test replays the COMMITTED pact from disk: it proves this
+ * provider still honours the contract, on every PR, with no infrastructure. It never contacts
+ * the broker, so it publishes nothing — and `can-i-deploy` reads published verification
+ * results, not green test runs. Without this class the broker never learned that
+ * openbank-clearing-simulator verifies anything, so its consumers (openbank-swift-service) stayed
+ * permanently UNVERIFIED and could not be deployed (issue #3232).
+ *
+ * A second `@Provider("openbank-clearing-simulator")` class is safe here for the reason
+ * CLAUDE.md gives for ledger-service's identical pair: the collision it warns about is HTTP vs
+ * MESSAGE target dispatch fighting over the same `@BeforeEach`, and both classes here use the
+ * same target type, so verifying the same interactions from two pact sources is at worst
+ * redundant, never colliding.
+ *
+ * Gated on `pactbroker.url`: skipped locally and on the PR lane, which have no broker
+ * configured. It runs on the main push, where `_service-ci.yml` sets `PUBLISH_RESULTS=true`
+ * — that is the run whose result `can-i-deploy` gates the deploy on. The `@PactFolder` class
+ * keeps running unconditionally, so PR-time contract coverage is unchanged by this addition.
+ */
+@QuarkusTest
+@TestSecurity(user = "rail", roles = ["ROLE_API"])
+@Provider("openbank-clearing-simulator")
+@PactBroker
+@IgnoreNoPactsToVerify(ignoreIoErrors = "true")
+@EnabledIfSystemProperty(named = "pactbroker.url", matches = ".+")
+class ClearingSimulatorPactBrokerProviderVerificationTest {
+
+    @ConfigProperty(name = "quarkus.http.test-port", defaultValue = "8081")
+    lateinit var testPort: String
+
+    @BeforeEach
+    fun configureTarget(context: PactVerificationContext?) {
+        context?.target = HttpTestTarget("localhost", testPort.toInt())
+        context?.addStateChangeHandlers(this)
+    }
+
+    @TestTemplate
+    @ExtendWith(PactVerificationInvocationContextProvider::class)
+    fun verifyPacts(context: PactVerificationContext?) {
+        context?.verifyInteraction()
+    }
+
+    @State("the clearing simulator is available")
+    fun stateSimulatorAvailable() {
+        // Stateless, deterministic counterparty (no DB) — no setup needed. A well-formed transfer
+        // always settles (ACSC) unless its amount triggers a deterministic reject.
+    }
+}

--- a/openbank-consent-service/src/test/kotlin/com/openbank/consent/contract/ConsentPactBrokerProviderVerificationTest.kt
+++ b/openbank-consent-service/src/test/kotlin/com/openbank/consent/contract/ConsentPactBrokerProviderVerificationTest.kt
@@ -1,0 +1,160 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright (c) OpenBank contributors. Licensed under the Apache License, Version 2.0.
+// See LICENSE in the repository root or https://www.apache.org/licenses/LICENSE-2.0 for details.
+
+package com.openbank.consent.contract
+
+import au.com.dius.pact.provider.junit5.HttpTestTarget
+import au.com.dius.pact.provider.junit5.PactVerificationContext
+import au.com.dius.pact.provider.junit5.PactVerificationInvocationContextProvider
+import au.com.dius.pact.provider.junitsupport.IgnoreNoPactsToVerify
+import au.com.dius.pact.provider.junitsupport.Provider
+import au.com.dius.pact.provider.junitsupport.State
+import au.com.dius.pact.provider.junitsupport.loader.PactBroker
+import com.openbank.consent.it.ConsentPostgresRedisTestResource
+import io.quarkus.test.common.QuarkusTestResource
+import io.quarkus.test.common.QuarkusTestResourceLifecycleManager
+import io.quarkus.test.junit.QuarkusTest
+import io.quarkus.test.security.TestSecurity
+import io.smallrye.reactive.messaging.memory.InMemoryConnector
+import jakarta.inject.Inject
+import org.eclipse.microprofile.config.inject.ConfigProperty
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.TestTemplate
+import org.junit.jupiter.api.condition.EnabledIfSystemProperty
+import org.junit.jupiter.api.extension.ExtendWith
+import java.sql.Connection
+import javax.sql.DataSource
+
+/**
+ * Broker-side provider verification for openbank-consent-service, the published-result counterpart to
+ * [ConsentPactProviderVerificationTest].
+ *
+ * WHY BOTH EXIST. A `@PactFolder` test replays the COMMITTED pact from disk: it proves this
+ * provider still honours the contract, on every PR, with no infrastructure. It never contacts
+ * the broker, so it publishes nothing — and `can-i-deploy` reads published verification
+ * results, not green test runs. Without this class the broker never learned that
+ * openbank-consent-service verifies anything, so its consumers (openbank-mcp-service) stayed
+ * permanently UNVERIFIED and could not be deployed (issue #3232).
+ *
+ * A second `@Provider("openbank-consent-service")` class is safe here for the reason
+ * CLAUDE.md gives for ledger-service's identical pair: the collision it warns about is HTTP vs
+ * MESSAGE target dispatch fighting over the same `@BeforeEach`, and both classes here use the
+ * same target type, so verifying the same interactions from two pact sources is at worst
+ * redundant, never colliding.
+ *
+ * Gated on `pactbroker.url`: skipped locally and on the PR lane, which have no broker
+ * configured. It runs on the main push, where `_service-ci.yml` sets `PUBLISH_RESULTS=true`
+ * — that is the run whose result `can-i-deploy` gates the deploy on. The `@PactFolder` class
+ * keeps running unconditionally, so PR-time contract coverage is unchanged by this addition.
+ */
+@QuarkusTest
+@QuarkusTestResource(ConsentPactBrokerProviderVerificationTest.InMemoryKafkaResource::class)
+@QuarkusTestResource(ConsentPostgresRedisTestResource::class)
+@TestSecurity(user = "pact-verifier", roles = ["ROLE_API", "ROLE_OPERATOR"])
+@Provider("openbank-consent-service")
+@PactBroker
+@IgnoreNoPactsToVerify(ignoreIoErrors = "true")
+@EnabledIfSystemProperty(named = "pactbroker.url", matches = ".+")
+class ConsentPactBrokerProviderVerificationTest {
+
+    class InMemoryKafkaResource : QuarkusTestResourceLifecycleManager {
+        override fun start(): Map<String, String> {
+            val props = InMemoryConnector.switchOutgoingChannelsToInMemory("consent-events-out").toMutableMap()
+            props["openbank.outbox.dispatch-enabled"] = "false"
+            return props
+        }
+
+        override fun stop() = InMemoryConnector.clear()
+    }
+
+    @ConfigProperty(name = "quarkus.http.test-port", defaultValue = "8081")
+    lateinit var testPort: String
+
+    @Inject
+    lateinit var dataSource: DataSource
+
+    @BeforeEach
+    fun configureTarget(context: PactVerificationContext?) {
+        if (context == null) return
+        context.target = HttpTestTarget("localhost", testPort.toInt())
+        context.addStateChangeHandlers(this)
+    }
+
+    @TestTemplate
+    @ExtendWith(PactVerificationInvocationContextProvider::class)
+    fun verifyPacts(context: PactVerificationContext?) {
+        // context is null on the @IgnoreNoPactsToVerify dummy invocation — skip gracefully.
+        context?.verifyInteraction()
+    }
+
+    /**
+     * State for mcp-service's `ConsentValidatePactConsumerTest` (ADR-0195): the live-validate call
+     * every MCP banking tool fails closed on. Seeds an ACTIVE AISP consent whose grantee, scope and
+     * covered IBAN all match the request, so `POST /{id}/validate` answers `valid: true` with the
+     * `scopes` / `grantedAccounts` / `frequencyPerDay` projection the consumer reads.
+     *
+     * `frequency_per_day` is stored but NOT what the response reports — `Consent.frequencyPerDay()`
+     * derives 4 from the AISP scope set (PSD2 RTS Art. 10(2)(b)), so the pinned 4 is deterministic
+     * regardless of the column. The column is still written because a CHECK constrains it to 1..4.
+     */
+    @State("an ACTIVE AISP consent covers the pact account for the pact grantee")
+    fun activeAispConsentExists() {
+        dataSource.connection.use { c ->
+            c.autoCommit = false
+            // Idempotent: pact-jvm 4.7.3 invokes each @State setup callback twice per interaction,
+            // and this inserts with a fixed id.
+            if (!consentExists(c)) {
+                insertActiveConsent(c)
+                insertRow(c, "INSERT INTO consent_scopes (consent_id, scope) VALUES (?::uuid, ?)", "ACCOUNTS_READ")
+                insertRow(c, "INSERT INTO consent_accounts (consent_id, iban) VALUES (?::uuid, ?)", PACT_ACCOUNT_IBAN)
+                c.commit()
+            }
+        }
+    }
+
+    private fun consentExists(c: Connection): Boolean =
+        c.prepareStatement("SELECT 1 FROM consents WHERE id = ?::uuid").use { ps ->
+            ps.setString(1, PACT_CONSENT_ID)
+            ps.executeQuery().use { rs -> rs.next() }
+        }
+
+    private fun insertActiveConsent(c: Connection) = c.prepareStatement(INSERT_CONSENT_SQL).use { ps ->
+        ps.setString(1, PACT_CONSENT_ID)
+        ps.setString(2, PACT_PARTY_ID)
+        ps.setString(3, PACT_GRANTEE_ID)
+        ps.executeUpdate()
+    }
+
+    /** Child-table insert: both `consent_scopes` and `consent_accounts` are (consent_id, value). */
+    private fun insertRow(c: Connection, sql: String, value: String) = c.prepareStatement(sql).use { ps ->
+        ps.setString(1, PACT_CONSENT_ID)
+        ps.setString(2, value)
+        ps.executeUpdate()
+    }
+
+    @State("no consent exists with the pact unknown-consent id")
+    fun unknownConsentDoesNotExist() {
+        // No setup: a fresh Testcontainer DB satisfies this by construction, and nothing in this
+        // class inserts that id. Declared so the state is an explicit part of the contract rather
+        // than an unhandled name pact-jvm would pass over silently.
+    }
+
+    private companion object {
+        private val INSERT_CONSENT_SQL = """
+            INSERT INTO consents (
+                id, party_id, grantee_id, grantee_type, grantee_name, status,
+                valid_from, valid_to, frequency_per_day, created_at, updated_at
+            ) VALUES (
+                ?::uuid, ?::uuid, ?, 'CUSTOMER_AGENT', 'Pact Verify MCP Agent', 'ACTIVE',
+                NOW() - INTERVAL '1 day', NOW() + INTERVAL '30 days', 4, NOW(), NOW()
+            )
+        """.trimIndent()
+
+        /** Must equal `ConsentValidatePactConsumerTest.PACT_CONSENT_ID` (openbank-mcp-service). */
+        const val PACT_CONSENT_ID = "c1c1c1c1-d2d2-4e4e-8f8f-a9a9a9a9a9a9"
+        const val PACT_PARTY_ID = "c2c2c2c2-d3d3-4e4e-8f8f-a8a8a8a8a8a8"
+        const val PACT_GRANTEE_ID = "agent:pact-verify-mcp"
+        const val PACT_ACCOUNT_IBAN = "CZ6508000000192000145399"
+    }
+}

--- a/openbank-customer-edge/src/test/kotlin/com/openbank/customeredge/contract/CustomerEdgeContractBrokerProviderVerificationTest.kt
+++ b/openbank-customer-edge/src/test/kotlin/com/openbank/customeredge/contract/CustomerEdgeContractBrokerProviderVerificationTest.kt
@@ -1,0 +1,177 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright (c) OpenBank contributors. Licensed under the Apache License, Version 2.0.
+// See LICENSE in the repository root or https://www.apache.org/licenses/LICENSE-2.0 for details.
+package com.openbank.customeredge.contract
+
+import au.com.dius.pact.provider.junit5.HttpTestTarget
+import au.com.dius.pact.provider.junit5.PactVerificationContext
+import au.com.dius.pact.provider.junit5.PactVerificationInvocationContextProvider
+import au.com.dius.pact.provider.junitsupport.IgnoreNoPactsToVerify
+import au.com.dius.pact.provider.junitsupport.Provider
+import au.com.dius.pact.provider.junitsupport.State
+import au.com.dius.pact.provider.junitsupport.loader.PactBroker
+import io.quarkus.test.common.QuarkusTestResource
+import io.quarkus.test.junit.QuarkusTest
+import io.quarkus.test.security.TestSecurity
+import io.quarkus.test.security.oidc.Claim
+import io.quarkus.test.security.oidc.OidcSecurity
+import org.eclipse.microprofile.config.inject.ConfigProperty
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.TestTemplate
+import org.junit.jupiter.api.condition.EnabledIfSystemProperty
+import org.junit.jupiter.api.extension.ExtendWith
+
+/**
+ * Broker-side provider verification for openbank-customer-edge, the published-result counterpart to
+ * [CustomerEdgeContractProviderVerificationTest].
+ *
+ * WHY BOTH EXIST. A `@PactFolder` test replays the COMMITTED pact from disk: it proves this
+ * provider still honours the contract, on every PR, with no infrastructure. It never contacts
+ * the broker, so it publishes nothing — and `can-i-deploy` reads published verification
+ * results, not green test runs. Without this class the broker never learned that
+ * openbank-customer-edge verifies anything, so its consumers (openbank-copilot-service) stayed
+ * permanently UNVERIFIED and could not be deployed (issue #3232).
+ *
+ * A second `@Provider("openbank-customer-edge")` class is safe here for the reason
+ * CLAUDE.md gives for ledger-service's identical pair: the collision it warns about is HTTP vs
+ * MESSAGE target dispatch fighting over the same `@BeforeEach`, and both classes here use the
+ * same target type, so verifying the same interactions from two pact sources is at worst
+ * redundant, never colliding.
+ *
+ * Gated on `pactbroker.url`: skipped locally and on the PR lane, which have no broker
+ * configured. It runs on the main push, where `_service-ci.yml` sets `PUBLISH_RESULTS=true`
+ * — that is the run whose result `can-i-deploy` gates the deploy on. The `@PactFolder` class
+ * keeps running unconditionally, so PR-time contract coverage is unchanged by this addition.
+ */
+@QuarkusTest
+@QuarkusTestResource(StubUpstreamResource::class)
+@TestSecurity(user = "customer:$PARTY_ID", roles = ["ROLE_CUSTOMER"])
+@OidcSecurity(claims = [Claim(key = "party_id", value = PARTY_ID)])
+@Provider("openbank-customer-edge")
+@PactBroker
+@IgnoreNoPactsToVerify(ignoreIoErrors = "true")
+@EnabledIfSystemProperty(named = "pactbroker.url", matches = ".+")
+class CustomerEdgeContractBrokerProviderVerificationTest {
+    // NOTE: the fixture ids (PARTY_ID, ACCOUNT_ID, ...) are file-level `internal const val`s
+    // declared in CustomerEdgeContractProviderVerificationTest.kt, in this same package.
+    // They are deliberately NOT redeclared here — a copy would be a second top-level
+    // declaration of the same name in the same package, which is an overload-resolution
+    // ambiguity on every use (that is exactly how the first draft of this file failed to
+    // compile). One definition, two tests.
+
+    @ConfigProperty(name = "quarkus.http.test-port", defaultValue = "8081")
+    lateinit var testPort: String
+
+    @BeforeEach
+    fun configureTarget(context: PactVerificationContext?) {
+        StubUpstreamResource.reset()
+        if (context == null) return
+        context.target = HttpTestTarget("localhost", testPort.toInt())
+        context.addStateChangeHandlers(this)
+    }
+
+    @TestTemplate
+    @ExtendWith(PactVerificationInvocationContextProvider::class)
+    fun verifyPacts(context: PactVerificationContext?) {
+        // context is null on the @IgnoreNoPactsToVerify dummy invocation — skip gracefully.
+        context?.verifyInteraction()
+    }
+
+    /** account-service's ownership-check response every ownership-gated read needs first. */
+    private fun ownedAccountFixture(): String = """
+        {"id":"$ACCOUNT_ID","accountNumber":"123456789/0800","accountType":"CURRENT",
+         "partyId":"$PARTY_ID","productId":"current-standard","currencyCode":"CZK"}
+    """.trimIndent()
+
+    @State("the customer has one account")
+    fun customerHasOneAccount() {
+        StubUpstreamResource.stub(
+            "/api/v1/accounts",
+            body = """{"data":[$FULL_ACCOUNT_JSON]}""",
+        )
+    }
+
+    @State("the customer owns an account with a balance")
+    fun customerOwnsAnAccountWithABalance() {
+        StubUpstreamResource.stub("/api/v1/accounts/$ACCOUNT_ID", body = ownedAccountFixture())
+        StubUpstreamResource.stub(
+            "/api/v1/balances/$ACCOUNT_ID",
+            // Bare JSON array — balance-service's real shape (issue #2322 / #2458). NOT wrapped.
+            body = """[{"currency":"CZK","bookedAmount":1000.00,"availableAmount":950.00}]""",
+        )
+    }
+
+    @State("the customer owns an account with transactions")
+    fun customerOwnsAnAccountWithTransactions() {
+        StubUpstreamResource.stub("/api/v1/accounts/$ACCOUNT_ID", body = ownedAccountFixture())
+        StubUpstreamResource.stub(
+            "/api/v1/transactions",
+            body = """
+                {"data":[{"amount":250.00,"currencyCode":"CZK","type":"PAYMENT","status":"BOOKED",
+                          "bookingDate":"2026-07-01","description":"Rent"}],
+                 "pagination":{"limit":10,"hasNextPage":false}}
+            """.trimIndent(),
+        )
+    }
+
+    @State("fx rates are available")
+    fun fxRatesAreAvailable() {
+        StubUpstreamResource.stub(
+            "/api/v1/fx/rates",
+            // Raw fx-service shape (mapFxRateRow reads baseCurrency/quoteCurrency/bidRate/askRate);
+            // source != "CNB" so it lands in the bank-rate list the edge projects, not the CNB
+            // reference map.
+            body = """
+                [{"baseCurrency":"EUR","quoteCurrency":"CZK","bidRate":"24.90","askRate":"25.10",
+                  "source":"INTERNAL","validFrom":"2026-07-25T08:00:00Z"}]
+            """.trimIndent(),
+        )
+    }
+
+    @State("the customer has a card")
+    fun customerHasACard() {
+        StubUpstreamResource.stub(
+            "/api/v1/cards/party/$PARTY_ID",
+            body = """
+                [{"id":"$CARD_ID","maskedPan":"**** **** **** 1234","cardType":"DEBIT",
+                  "network":"VISA","status":"ACTIVE","expiryDate":"2029-12-31","currency":"CZK"}]
+            """.trimIndent(),
+        )
+    }
+
+    @State("the customer owns an account with statements")
+    fun customerOwnsAnAccountWithStatements() {
+        StubUpstreamResource.stub("/api/v1/accounts/$ACCOUNT_ID", body = ownedAccountFixture())
+        StubUpstreamResource.stub(
+            "/api/v1/statements/$ACCOUNT_ID",
+            body = """
+                [{"id":"$STATEMENT_ID","pocketCurrency":"CZK","periodFrom":"2026-06-01",
+                  "periodTo":"2026-06-30","legalSequenceNumber":7,"openingBalance":900.00,
+                  "closingBalance":1000.00,"entryCount":12,"status":"ISSUED"}]
+            """.trimIndent(),
+        )
+    }
+
+    @State("the customer has a standing order")
+    fun customerHasAStandingOrder() {
+        StubUpstreamResource.stub(
+            "/api/v1/standing-orders/party/$PARTY_ID",
+            body = """
+                [{"id":"$STANDING_ORDER_ID","creditorIban":"CZ6508000000192000145399",
+                  "creditorName":"Elektrárna a.s.","status":"ACTIVE","frequency":"MONTHLY",
+                  "amount":1500.0,"currency":"CZK","nextExecutionDate":"2026-08-01",
+                  "remittanceInfo":"Elektřina"}]
+            """.trimIndent(),
+        )
+    }
+
+    companion object {
+        private const val FULL_ACCOUNT_JSON = """
+            {"id":"$ACCOUNT_ID","accountNumber":"123456789/0800","accountType":"CURRENT",
+             "partyId":"$PARTY_ID","productId":"current-standard","currencyCode":"CZK",
+             "status":"ACTIVE"}
+        """
+    }
+}
+
+// Compile-time constants for @OidcSecurity(claims = [...]) — must live outside the class body.

--- a/openbank-kyc-service/src/test/kotlin/com/openbank/kyc/contract/KycEventPactBrokerProviderVerificationTest.kt
+++ b/openbank-kyc-service/src/test/kotlin/com/openbank/kyc/contract/KycEventPactBrokerProviderVerificationTest.kt
@@ -1,0 +1,111 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright (c) OpenBank contributors. Licensed under the Apache License, Version 2.0.
+// See LICENSE in the repository root or https://www.apache.org/licenses/LICENSE-2.0 for details.
+
+package com.openbank.kyc.contract
+
+import au.com.dius.pact.provider.PactVerifyProvider
+import au.com.dius.pact.provider.junit5.MessageTestTarget
+import au.com.dius.pact.provider.junit5.PactVerificationContext
+import au.com.dius.pact.provider.junit5.PactVerificationInvocationContextProvider
+import au.com.dius.pact.provider.junitsupport.IgnoreNoPactsToVerify
+import au.com.dius.pact.provider.junitsupport.Provider
+import au.com.dius.pact.provider.junitsupport.State
+import au.com.dius.pact.provider.junitsupport.loader.PactBroker
+import com.fasterxml.jackson.datatype.jsr310.JavaTimeModule
+import com.fasterxml.jackson.module.kotlin.jacksonObjectMapper
+import com.openbank.kyc.domain.model.KycCaseStatus
+import com.openbank.kyc.domain.model.RiskLevel
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.TestTemplate
+import org.junit.jupiter.api.condition.EnabledIfSystemProperty
+import org.junit.jupiter.api.extension.ExtendWith
+import java.time.Instant
+import java.util.UUID
+
+/**
+ * Broker-side provider verification for openbank-kyc-service, the published-result counterpart to
+ * [KycEventPactProviderVerificationTest].
+ *
+ * WHY BOTH EXIST. A `@PactFolder` test replays the COMMITTED pact from disk: it proves this
+ * provider still honours the contract, on every PR, with no infrastructure. It never contacts
+ * the broker, so it publishes nothing — and `can-i-deploy` reads published verification
+ * results, not green test runs. Without this class the broker never learned that
+ * openbank-kyc-service verifies anything, so its consumers (openbank-onboarding-service) stayed
+ * permanently UNVERIFIED and could not be deployed (issue #3232).
+ *
+ * A second `@Provider("openbank-kyc-service")` class is safe here for the reason
+ * CLAUDE.md gives for ledger-service's identical pair: the collision it warns about is HTTP vs
+ * MESSAGE target dispatch fighting over the same `@BeforeEach`, and both classes here use the
+ * same target type, so verifying the same interactions from two pact sources is at worst
+ * redundant, never colliding.
+ *
+ * Gated on `pactbroker.url`: skipped locally and on the PR lane, which have no broker
+ * configured. It runs on the main push, where `_service-ci.yml` sets `PUBLISH_RESULTS=true`
+ * — that is the run whose result `can-i-deploy` gates the deploy on. The `@PactFolder` class
+ * keeps running unconditionally, so PR-time contract coverage is unchanged by this addition.
+ */
+@Provider("openbank-kyc-service")
+@PactBroker
+@IgnoreNoPactsToVerify(ignoreIoErrors = "true")
+@EnabledIfSystemProperty(named = "pactbroker.url", matches = ".+")
+class KycEventPactBrokerProviderVerificationTest {
+
+    private val objectMapper = jacksonObjectMapper().registerModule(JavaTimeModule())
+
+    @BeforeEach
+    fun setTarget(context: PactVerificationContext?) {
+        context?.let { it.target = MessageTestTarget(listOf("com.openbank.kyc.contract")) }
+    }
+
+    @TestTemplate
+    @ExtendWith(PactVerificationInvocationContextProvider::class)
+    fun verifyPacts(context: PactVerificationContext?) {
+        context?.verifyInteraction()
+    }
+
+    private fun event(eventType: String, status: KycCaseStatus): String {
+        // Mirrors KycEventPublisher.publish: the flat envelope, enums serialized to their names.
+        val payload = linkedMapOf(
+            "eventType" to eventType,
+            "kycCaseId" to UUID.randomUUID(),
+            "partyId" to UUID.randomUUID(),
+            "status" to status,
+            "riskLevel" to RiskLevel.MEDIUM,
+            "occurredAt" to Instant.now(),
+        )
+        return objectMapper.writeValueAsString(payload)
+    }
+
+    @State("a KYC case has been opened")
+    fun kycCaseHasBeenOpened() {
+        // No setup: produced deterministically by the @PactVerifyProvider method below.
+    }
+
+    @PactVerifyProvider("a KYC_CASE_OPENED event")
+    fun produceKycCaseOpenedEvent(): String = event("KYC_CASE_OPENED", KycCaseStatus.OPEN)
+
+    @State("a KYC case status has changed")
+    fun kycCaseStatusHasChanged() {
+        // No setup: produced deterministically by the @PactVerifyProvider method below.
+    }
+
+    @PactVerifyProvider("a KYC_CASE_STATUS_CHANGED event")
+    fun produceKycCaseStatusChangedEvent(): String = event("KYC_CASE_STATUS_CHANGED", KycCaseStatus.UNDER_REVIEW)
+
+    @State("a KYC case has been approved")
+    fun kycCaseHasBeenApproved() {
+        // No setup: produced deterministically by the @PactVerifyProvider method below.
+    }
+
+    @PactVerifyProvider("a KYC_CASE_APPROVED event")
+    fun produceKycCaseApprovedEvent(): String = event("KYC_CASE_APPROVED", KycCaseStatus.APPROVED)
+
+    @State("a KYC case has been rejected")
+    fun kycCaseHasBeenRejected() {
+        // No setup: produced deterministically by the @PactVerifyProvider method below.
+    }
+
+    @PactVerifyProvider("a KYC_CASE_REJECTED event")
+    fun produceKycCaseRejectedEvent(): String = event("KYC_CASE_REJECTED", KycCaseStatus.REJECTED)
+}

--- a/openbank-product-catalog/src/test/kotlin/com/openbank/productcatalog/contract/ProductCatalogPactBrokerProviderVerificationTest.kt
+++ b/openbank-product-catalog/src/test/kotlin/com/openbank/productcatalog/contract/ProductCatalogPactBrokerProviderVerificationTest.kt
@@ -1,0 +1,94 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright (c) OpenBank contributors. Licensed under the Apache License, Version 2.0.
+// See LICENSE in the repository root or https://www.apache.org/licenses/LICENSE-2.0 for details.
+
+package com.openbank.productcatalog.contract
+
+import au.com.dius.pact.provider.junit5.HttpTestTarget
+import au.com.dius.pact.provider.junit5.PactVerificationContext
+import au.com.dius.pact.provider.junit5.PactVerificationInvocationContextProvider
+import au.com.dius.pact.provider.junitsupport.IgnoreNoPactsToVerify
+import au.com.dius.pact.provider.junitsupport.Provider
+import au.com.dius.pact.provider.junitsupport.State
+import au.com.dius.pact.provider.junitsupport.loader.PactBroker
+import com.openbank.libs.testing.containers.PostgresTestResource
+import io.quarkus.test.common.QuarkusTestResource
+import io.quarkus.test.common.ResourceArg
+import io.quarkus.test.junit.QuarkusTest
+import io.quarkus.test.security.TestSecurity
+import org.eclipse.microprofile.config.inject.ConfigProperty
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.TestTemplate
+import org.junit.jupiter.api.condition.EnabledIfSystemProperty
+import org.junit.jupiter.api.extension.ExtendWith
+
+/**
+ * Broker-side provider verification for openbank-product-catalog, the published-result counterpart to
+ * [ProductCatalogPactProviderVerificationTest].
+ *
+ * WHY BOTH EXIST. A `@PactFolder` test replays the COMMITTED pact from disk: it proves this
+ * provider still honours the contract, on every PR, with no infrastructure. It never contacts
+ * the broker, so it publishes nothing — and `can-i-deploy` reads published verification
+ * results, not green test runs. Without this class the broker never learned that
+ * openbank-product-catalog verifies anything, so its consumers (openbank-card-issuance-service) stayed
+ * permanently UNVERIFIED and could not be deployed (issue #3232).
+ *
+ * A second `@Provider("openbank-product-catalog")` class is safe here for the reason
+ * CLAUDE.md gives for ledger-service's identical pair: the collision it warns about is HTTP vs
+ * MESSAGE target dispatch fighting over the same `@BeforeEach`, and both classes here use the
+ * same target type, so verifying the same interactions from two pact sources is at worst
+ * redundant, never colliding.
+ *
+ * Gated on `pactbroker.url`: skipped locally and on the PR lane, which have no broker
+ * configured. It runs on the main push, where `_service-ci.yml` sets `PUBLISH_RESULTS=true`
+ * — that is the run whose result `can-i-deploy` gates the deploy on. The `@PactFolder` class
+ * keeps running unconditionally, so PR-time contract coverage is unchanged by this addition.
+ */
+@QuarkusTest
+@QuarkusTestResource(
+    value = PostgresTestResource::class,
+    initArgs = [ResourceArg(name = "db", value = "openbank_products")],
+)
+@TestSecurity(user = "pact-verifier", roles = ["ROLE_OPERATOR"])
+@Provider("openbank-product-catalog")
+@PactBroker
+@IgnoreNoPactsToVerify(ignoreIoErrors = "true")
+@EnabledIfSystemProperty(named = "pactbroker.url", matches = ".+")
+class ProductCatalogPactBrokerProviderVerificationTest {
+
+    @ConfigProperty(name = "quarkus.http.test-port", defaultValue = "8081")
+    lateinit var testPort: String
+
+    @BeforeEach
+    fun configureTarget(context: PactVerificationContext?) {
+        context?.target = HttpTestTarget("localhost", testPort.toInt())
+    }
+
+    @TestTemplate
+    @ExtendWith(PactVerificationInvocationContextProvider::class)
+    fun verifyPacts(context: PactVerificationContext?) {
+        context?.verifyInteraction()
+    }
+
+    /**
+     * No seeding: `ProductCatalogSeeder` persists the whole canonical catalogue from `ProductSeed`
+     * on first boot, and `CURRENT_PERSONAL` (prod-003) is one of the card-enabled entries. Seeding
+     * it again here would either lose the UNIQUE(code) race or fork a second source of truth for a
+     * product the service already owns. If this state ever starts failing, the cause is a
+     * `ProductSeed` edit that dropped `CURRENT_PERSONAL`'s `cardConfig` — which is exactly the
+     * regression card issuance needs to hear about, so let it fail rather than seeding around it.
+     */
+    @State("a product with card configuration exists for code CURRENT_PERSONAL")
+    fun cardEnabledProductIsSeeded() {
+        // Intentionally empty — see the KDoc above.
+    }
+
+    /**
+     * No seeding: `NO_SUCH_CARD_PRODUCT` is deliberately absent from `ProductSeed`, so the seeded
+     * catalogue already satisfies "no product exists with this code".
+     */
+    @State("no product exists with code NO_SUCH_CARD_PRODUCT")
+    fun unknownProductCodeIsAbsent() {
+        // Intentionally empty — see the KDoc above.
+    }
+}

--- a/openbank-tpp-registry-service/src/test/kotlin/com/openbank/tppregistry/contract/TppRegistryPactBrokerProviderVerificationTest.kt
+++ b/openbank-tpp-registry-service/src/test/kotlin/com/openbank/tppregistry/contract/TppRegistryPactBrokerProviderVerificationTest.kt
@@ -1,0 +1,93 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright (c) OpenBank contributors. Licensed under the Apache License, Version 2.0.
+// See LICENSE in the repository root or https://www.apache.org/licenses/LICENSE-2.0 for details.
+
+package com.openbank.tppregistry.contract
+
+import au.com.dius.pact.provider.junit5.HttpTestTarget
+import au.com.dius.pact.provider.junit5.PactVerificationContext
+import au.com.dius.pact.provider.junit5.PactVerificationInvocationContextProvider
+import au.com.dius.pact.provider.junitsupport.IgnoreNoPactsToVerify
+import au.com.dius.pact.provider.junitsupport.Provider
+import au.com.dius.pact.provider.junitsupport.State
+import au.com.dius.pact.provider.junitsupport.loader.PactBroker
+import io.quarkus.test.common.QuarkusTestResource
+import io.quarkus.test.common.QuarkusTestResourceLifecycleManager
+import io.quarkus.test.junit.QuarkusTest
+import io.quarkus.test.security.TestSecurity
+import io.smallrye.reactive.messaging.memory.InMemoryConnector
+import org.eclipse.microprofile.config.inject.ConfigProperty
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.TestTemplate
+import org.junit.jupiter.api.condition.EnabledIfSystemProperty
+import org.junit.jupiter.api.extension.ExtendWith
+
+/**
+ * Broker-side provider verification for openbank-tpp-registry-service, the published-result counterpart to
+ * [TppRegistryPactProviderVerificationTest].
+ *
+ * WHY BOTH EXIST. A `@PactFolder` test replays the COMMITTED pact from disk: it proves this
+ * provider still honours the contract, on every PR, with no infrastructure. It never contacts
+ * the broker, so it publishes nothing — and `can-i-deploy` reads published verification
+ * results, not green test runs. Without this class the broker never learned that
+ * openbank-tpp-registry-service verifies anything, so its consumers (openbank-psd2-service) stayed
+ * permanently UNVERIFIED and could not be deployed (issue #3232).
+ *
+ * A second `@Provider("openbank-tpp-registry-service")` class is safe here for the reason
+ * CLAUDE.md gives for ledger-service's identical pair: the collision it warns about is HTTP vs
+ * MESSAGE target dispatch fighting over the same `@BeforeEach`, and both classes here use the
+ * same target type, so verifying the same interactions from two pact sources is at worst
+ * redundant, never colliding.
+ *
+ * Gated on `pactbroker.url`: skipped locally and on the PR lane, which have no broker
+ * configured. It runs on the main push, where `_service-ci.yml` sets `PUBLISH_RESULTS=true`
+ * — that is the run whose result `can-i-deploy` gates the deploy on. The `@PactFolder` class
+ * keeps running unconditionally, so PR-time contract coverage is unchanged by this addition.
+ */
+@QuarkusTest
+@QuarkusTestResource(TppRegistryPactBrokerProviderVerificationTest.InMemoryKafkaResource::class)
+@QuarkusTestResource(com.openbank.tppregistry.it.PostgresRedisTestResource::class)
+@TestSecurity(user = "pact-verifier", roles = ["ROLE_API", "ROLE_OPERATOR"])
+@Provider("openbank-tpp-registry-service")
+@PactBroker
+@IgnoreNoPactsToVerify(ignoreIoErrors = "true")
+@EnabledIfSystemProperty(named = "pactbroker.url", matches = ".+")
+class TppRegistryPactBrokerProviderVerificationTest {
+
+    class InMemoryKafkaResource : QuarkusTestResourceLifecycleManager {
+        override fun start(): Map<String, String> = InMemoryConnector.switchOutgoingChannelsToInMemory("tpp-events-out")
+
+        override fun stop() = InMemoryConnector.clear()
+    }
+
+    @ConfigProperty(name = "quarkus.http.test-port", defaultValue = "8081")
+    lateinit var testPort: String
+
+    @BeforeEach
+    fun configureTarget(context: PactVerificationContext?) {
+        if (context == null) return
+        context.target = HttpTestTarget("localhost", testPort.toInt())
+        context.addStateChangeHandlers(this)
+    }
+
+    @TestTemplate
+    @ExtendWith(PactVerificationInvocationContextProvider::class)
+    fun verifyPacts(context: PactVerificationContext?) {
+        // context is null on the @IgnoreNoPactsToVerify dummy invocation — skip gracefully.
+        context?.verifyInteraction()
+    }
+
+    @State("no registry entry exists for the pact unknown-TPP id")
+    fun unknownTppIsNotRegistered() {
+        // No setup: nothing registers CZ-CNB-PACT-UNREGISTERED. Declared so the state is an
+        // explicit part of the contract rather than a name pact-jvm passes over silently — an
+        // unhandled state is not an error, which is how #468's missing states stayed invisible.
+    }
+
+    @State("the TPP registry has an ACTIVE AISP with an unexpired QWAC")
+    fun activeAispWithValidQwacIsSeeded() {
+        // No setup: V1__init.sql already seeds CZ-CNB-TEST-AISP as ACTIVE/AISP with a NULL
+        // qwac_expires_at, which TppRegistryService.checkAuthorization treats as never-expired.
+        // Declared for the same reason as the state above — an explicit, visible no-op.
+    }
+}


### PR DESCRIPTION

A `@PactFolder` test replays the COMMITTED pact from disk: it proves the provider
still honours the contract, on every PR, with no infrastructure. It never contacts
the broker, so it publishes nothing — and `can-i-deploy` reads published
verification results, not green test runs.

Eight of seventeen providers had only that half, so the broker never learned they
verify anything and their consumers stayed permanently UNVERIFIED, unable to
deploy. Nothing caught it: check-pact-provider-replay.py (#2338) enforces the
FOLDER half and is satisfied; nothing enforced the broker half, so it quietly
never got added.

  openbank-aml-service            openbank-kyc-service
  openbank-clearing-simulator     openbank-product-catalog
  openbank-consent-service        openbank-sanctions-service
  openbank-customer-edge          openbank-tpp-registry-service

Each gets a sibling class derived MECHANICALLY from its own @PactFolder class —
same Quarkus resources, same @TestSecurity, same target, same @State methods —
with @PactFolder -> @PactBroker and an @EnabledIfSystemProperty(pactbroker.url)
gate, matching the pair openbank-ledger-service already carries. The folder class
keeps running unconditionally, so PR-time coverage is unchanged; the broker class
runs on the main push, where _service-ci.yml sets PUBLISH_RESULTS=true.

Two things the compiler found that reading would not have:

  * customer-edge declares its fixture ids as FILE-LEVEL `internal const val`s.
    Copying the file redeclared every one in the same package — an
    overload-resolution ambiguity on every use. The sibling now references the
    originals and says why, so the next person does not "helpfully" re-add them.
  * All eight compile (`compileTestKotlin`, exit 0, zero errors), ktlint and
    detekt clean. Worth stating that the exit code was read directly and not
    through a pipe — `./gradlew | tail` reports tail's status, which is how a
    failing build reads as green.

Also updates the reconciler's self-test. It asserted on the FLEET's population —
that some provider could publish and some could not — and this change made the
second half false by fixing it. That assertion did its job and then became a
maintenance trap, so it now tests can_publish_verification against synthetic
fixtures (@PactBroker, @PactFolder-only, no test, missing directory) plus a light
"something in this repo can publish" sanity check. It tests the function, not the
estate.

Verified: the reconciler now sees 17/17 providers as able to publish, so
openbank-kyc-service — the one genuine strand it found and could not act on —
becomes dispatchable.

Closes #3232
Refs #3178