### PR TITLE
fix(mcp): key an agent session by the token's sub, not by a name an admin can change

### DIFF
--- a/openbank-mcp-service/src/main/kotlin/com/openbank/mcp/infrastructure/mcp/CallerContextResolver.kt
+++ b/openbank-mcp-service/src/main/kotlin/com/openbank/mcp/infrastructure/mcp/CallerContextResolver.kt
@@ -86,13 +86,23 @@ class CallerContextResolver @Inject constructor(
         // ADR-0224 D2: the token's `jti` must be bound to a live session of THIS subject (never
         // the SSO `sid` — an exchange mints a fresh one, which is exactly why jti is the binding),
         // and the effective roles are bounded by BOTH the token and the session ceiling. A missing
-        // store row or a mismatch is anonymous — revocation takes effect immediately. The session
-        // row's subject is the REST-layer principal name (Quarkus resolves preferred_username
-        // before sub), while Keycloak's `sub` is the stable UUID — match the name the store wrote,
-        // not the claim (E2E #2750: a UUID-vs-email mismatch here denied every bound call).
+        // store row or a mismatch is anonymous — revocation takes effect immediately.
+        //
+        // Matched on `sub`, which is what McpSessionResource now writes. It used to be the
+        // REST-layer principal name (Quarkus resolves preferred_username before sub) on BOTH
+        // sides — correct as a pair, but keyed on a claim a Keycloak admin can change. After a
+        // rename no token could match the live row again: null here, anonymous downstream, and
+        // under `mcp.obo.enabled` a fail-closed "Authorization unavailable" while the row still
+        // reads live (#3182). `sub` is the identifier Keycloak guarantees is immutable.
+        //
+        // Both sides move together or the pair breaks in the other direction — that is what
+        // #2955 did (reader only) and why E2E #2750 pins a real exchanged token end to end.
         val session = sessions?.findActiveByJti(jti, Instant.now(clock)) ?: return null
+        if (session.subject != subject) return null
+        // preferred_username stays the HUMAN-READABLE label on the audit trail — `sub` is a UUID
+        // and reads as nothing in a log. It is deliberately not what the line above matches on:
+        // display may drift with a rename, identity may not.
         val principalName = jwt.getClaim<String?>(CLAIM_PREFERRED_USERNAME)?.takeIf { it.isNotBlank() } ?: subject
-        if (session.subject != principalName) return null
         val ceiling = parseCeiling(session.roleCeiling)
         val bounded = roles.filter { it in ceiling }
         if (bounded.isEmpty()) return null

--- a/openbank-mcp-service/src/main/kotlin/com/openbank/mcp/infrastructure/rest/McpSessionResource.kt
+++ b/openbank-mcp-service/src/main/kotlin/com/openbank/mcp/infrastructure/rest/McpSessionResource.kt
@@ -22,6 +22,7 @@ import jakarta.ws.rs.Produces
 import jakarta.ws.rs.core.MediaType
 import jakarta.ws.rs.core.Response
 import org.eclipse.microprofile.config.inject.ConfigProperty
+import org.eclipse.microprofile.jwt.JsonWebToken
 import org.eclipse.microprofile.openapi.annotations.Operation
 import org.eclipse.microprofile.openapi.annotations.tags.Tag
 import org.jboss.logging.Logger
@@ -48,6 +49,22 @@ class McpSessionResource(
     @Inject
     lateinit var identity: SecurityIdentity
 
+    @Inject
+    lateinit var jwt: JsonWebToken
+
+    /**
+     * The key a session is stored and matched under: Keycloak's `sub`, the one identifier it
+     * guarantees is immutable.
+     *
+     * NOT `identity.principal.name` — Quarkus resolves that to `preferred_username`, which an
+     * admin can change. A rename then made the live session unmatchable: `resolveOboHuman`
+     * returned null, the call fell through to anonymous, and under `mcp.obo.enabled` that fails
+     * closed with "Authorization unavailable" while the row still reads as live in the store
+     * (#3182). Writer, reader ([owns]) and CallerContextResolver must agree on this — moving one
+     * alone breaks the pair in the other direction, which is what #2955 did.
+     */
+    private fun callerKey(): String = jwt.subject ?: identity.principal.name
+
     private val log = Logger.getLogger(McpSessionResource::class.java)
 
     @POST
@@ -67,7 +84,7 @@ class McpSessionResource(
         val now = Instant.now(clock)
         val session = AgentSessionEntity().also {
             it.id = Ids.newId()
-            it.subject = identity.principal.name
+            it.subject = callerKey()
             it.roleCeiling = ceiling.joinToString(",", prefix = "[", postfix = "]") { r -> "\"$r\"" }
             it.clientId = request.clientId
             it.purpose = request.purpose
@@ -137,7 +154,7 @@ class McpSessionResource(
     // Broken-access-control guard: the role grant admits every operator, but a session row is
     // its owner's alone — reading or revoking another operator's session needs ROLE_ADMIN.
     private fun owns(session: AgentSessionEntity): Boolean =
-        identity.roles.contains("ROLE_ADMIN") || session.subject == identity.principal.name
+        identity.roles.contains("ROLE_ADMIN") || session.subject == callerKey()
 
     private fun forbidden(): Response =
         Response.status(Response.Status.FORBIDDEN).entity(mapOf("error" to "not your session")).build()

--- a/openbank-mcp-service/src/test/kotlin/com/openbank/mcp/McpEndpointTest.kt
+++ b/openbank-mcp-service/src/test/kotlin/com/openbank/mcp/McpEndpointTest.kt
@@ -172,13 +172,14 @@ class McpEndpointTest {
     }
 
     @Test
-    fun `a staff token matches its session by preferred_username when sub is a uuid (E2E #2750)`() {
+    fun `a Keycloak-shaped staff token matches its session by sub, and is still LABELLED by name (E2E #2750, #3182)`() {
+        // #2750's defect was writer and reader disagreeing — the session row held one identifier
+        // and the resolver compared another, so every bound call was denied. That is what this
+        // pins, now on `sub`: a real Keycloak token has a UUID `sub` and a human
+        // `preferred_username`, and the pair must still meet. The username survives as the audit
+        // LABEL only (#3182) — matching on it made a rename strand the session.
         val pdp = RecordingPdp()
-        val kcShaped = staffClaims + mapOf(
-            "sub" to "ff90e87e-e7fc-4768-9e41-8b0474deb78d",
-            "preferred_username" to "jane.operator",
-        )
-        endpoint(pdp, jwt = TestJsonWebToken(kcShaped), oboEnabled = true).handle(
+        endpoint(pdp, jwt = staffOboJwt(), oboEnabled = true).handle(
             rpc("tools/call", mapOf("name" to "list_accounts", "arguments" to emptyMap<String, Any>())),
         )
         val principal = pdp.queries.single().principal
@@ -187,9 +188,26 @@ class McpEndpointTest {
     }
 
     @Test
-    fun `a staff token whose preferred_username owns no session is anonymous`() {
+    fun `a renamed operator still matches the session they created (#3182)`() {
+        // Same human, same `sub`, new preferred_username after an admin rename. Keyed on the
+        // display name this resolved to null and the call fell through to a fail-closed
+        // "Authorization unavailable" against a row that still reads live.
+        val pdp = RecordingPdp()
+        val renamed = staffClaims + mapOf("preferred_username" to "jane.smith")
+        endpoint(pdp, jwt = TestJsonWebToken(renamed), oboEnabled = true).handle(
+            rpc("tools/call", mapOf("name" to "list_accounts", "arguments" to emptyMap<String, Any>())),
+        )
+        val principal = pdp.queries.single().principal
+        assertThat(principal.type).isEqualTo("HUMAN")
+        assertThat(principal.id).isEqualTo("jane.smith")
+    }
+
+    @Test
+    fun `a staff token whose sub owns no session is anonymous`() {
+        // Another human reusing the same jti gets nothing: the session is bound to a `sub`, and
+        // a matching display name would not help them either.
         val kcShaped = staffClaims + mapOf(
-            "sub" to "ff90e87e-e7fc-4768-9e41-8b0474deb78d",
+            "sub" to "00000000-0000-0000-0000-0000deadbeef",
             "preferred_username" to "mallory.operator",
         )
         val resp = body(
@@ -223,8 +241,12 @@ class McpEndpointTest {
 
     private val staffSessionId = "3f2a9c41-7b5e-4c8d-9e0f-1a2b3c4d5e6f"
 
+    /** Keycloak's `sub`: an immutable UUID, and what a session is keyed on (#3182). */
+    private val staffSubject = "ff90e87e-e7fc-4768-9e41-8b0474deb78d"
+
     private val staffClaims = mapOf(
-        "sub" to "jane.operator",
+        "sub" to staffSubject,
+        "preferred_username" to "jane.operator",
         "azp" to "openbank-admin-ui",
         "jti" to staffSessionId,
         "aud" to "openbank-mcp-service",
@@ -234,10 +256,10 @@ class McpEndpointTest {
     private fun staffOboJwt() = TestJsonWebToken(staffClaims)
 
     // ADR-0224 D2 live check: a fake session store holding one ACTIVE session bound to the token's jti.
-    private fun fakeSessionRepo() = object : AgentSessionRepository() {
+    private fun fakeSessionRepo(subject: String = staffSubject) = object : AgentSessionRepository() {
         override suspend fun findActiveByJti(jti: String, asOf: java.time.Instant) = if (jti == staffSessionId) {
             AgentSessionEntity().also {
-                it.subject = "jane.operator"
+                it.subject = subject
                 it.roleCeiling = "[\"ROLE_OPERATOR\"]"
                 it.clientId = "admin-ui"
                 it.jti = staffSessionId

--- a/openbank-mcp-service/src/test/kotlin/com/openbank/mcp/McpSessionResourceTest.kt
+++ b/openbank-mcp-service/src/test/kotlin/com/openbank/mcp/McpSessionResourceTest.kt
@@ -34,11 +34,21 @@ class McpSessionResourceTest {
 
     private val clock = Clock.fixed(Instant.parse("2026-07-31T10:00:00Z"), ZoneOffset.UTC)
 
-    private fun resource(operator: String, roles: Set<String>) = McpSessionResource(repo, clock, 15).apply {
+    /**
+     * [operator] is the display name (`preferred_username`); [sub] is what the session is keyed
+     * on. They are separate parameters on purpose — keying on the display name is #3182.
+     */
+    private fun resource(
+        operator: String,
+        roles: Set<String>,
+        sub: String = "11111111-1111-1111-1111-111111111111",
+        repository: AgentSessionRepository = repo,
+    ) = McpSessionResource(repository, clock, 15).apply {
         identity = QuarkusSecurityIdentity.builder()
             .setPrincipal { operator }
             .apply { roles.forEach { addRole(it) } }
             .build() as SecurityIdentity
+        jwt = TestJsonWebToken(mapOf("sub" to sub, "preferred_username" to operator))
     }
 
     @Test
@@ -47,7 +57,7 @@ class McpSessionResourceTest {
             .create(CreateSessionRequest(roleCeiling = listOf("ROLE_OPERATOR", "ROLE_ADMIN")))
         assertThat(res.status).isEqualTo(201)
         assertThat(saved.single().roleCeiling).isEqualTo("[\"ROLE_OPERATOR\"]")
-        assertThat(saved.single().subject).isEqualTo("jane.operator")
+        assertThat(saved.single().subject).isEqualTo("11111111-1111-1111-1111-111111111111")
     }
 
     @Test
@@ -71,12 +81,7 @@ class McpSessionResourceTest {
         val repoWithForeign = object : AgentSessionRepository() {
             override suspend fun findById(id: java.util.UUID) = if (id == foreign.id) foreign else null
         }
-        val outsider = McpSessionResource(repoWithForeign, clock, 15).apply {
-            identity = QuarkusSecurityIdentity.builder()
-                .setPrincipal { "jane.operator" }
-                .addRole("ROLE_OPERATOR")
-                .build() as SecurityIdentity
-        }
+        val outsider = resource("jane.operator", setOf("ROLE_OPERATOR"), repository = repoWithForeign)
         assertThat(outsider.status(foreign.id).status).isEqualTo(403)
         assertThat(outsider.revoke(foreign.id).status).isEqualTo(403)
     }
@@ -103,5 +108,52 @@ class McpSessionResourceTest {
         }
         assertThat(admin.status(foreign.id).status).isEqualTo(200)
         assertThat(admin.revoke(foreign.id).status).isEqualTo(204)
+    }
+
+    @Test
+    fun `a Keycloak rename does not strand the caller's own session`(): Unit = runBlocking {
+        // The session is issued before the rename...
+        assertThat(
+            resource("jane.operator", setOf("ROLE_OPERATOR")).create(
+                CreateSessionRequest(roleCeiling = listOf("ROLE_OPERATOR")),
+            ).status,
+        ).isEqualTo(201)
+        val session = saved.single()
+
+        // ...and the admin then changes preferred_username. `sub` is unchanged, because Keycloak
+        // guarantees it is. Keyed on the display name, `owns()` would now say "not your session"
+        // and the OBO resolver would fall through to anonymous — a fail-closed
+        // "Authorization unavailable" against a row that still reads live (#3182).
+        val repoWithSession = object : AgentSessionRepository() {
+            override suspend fun findById(id: java.util.UUID) = if (id == session.id) session else null
+        }
+        val renamed = resource("jane.smith", setOf("ROLE_OPERATOR"), repository = repoWithSession)
+
+        assertThat(renamed.status(session.id).status)
+            .describedAs("the same human, one Keycloak rename later, must still own their session")
+            .isEqualTo(200)
+    }
+
+    @Test
+    fun `a different human with the same display name does not own the session`(): Unit = runBlocking {
+        // The converse, which is what keying on an immutable id actually buys: display names are
+        // not unique over time, so matching on one could hand a session to the wrong person.
+        assertThat(
+            resource("jane.operator", setOf("ROLE_OPERATOR")).create(
+                CreateSessionRequest(roleCeiling = listOf("ROLE_OPERATOR")),
+            ).status,
+        ).isEqualTo(201)
+        val session = saved.single()
+        val repoWithSession = object : AgentSessionRepository() {
+            override suspend fun findById(id: java.util.UUID) = if (id == session.id) session else null
+        }
+        val impostor = resource(
+            "jane.operator",
+            setOf("ROLE_OPERATOR"),
+            sub = "22222222-2222-2222-2222-222222222222",
+            repository = repoWithSession,
+        )
+
+        assertThat(impostor.status(session.id).status).isEqualTo(403)
     }
 }


### PR DESCRIPTION
Closes #3182 · Refs #2946, #2955, #2938, ADR-0224

## The defect

A session was stored and matched under `preferred_username`, which a Keycloak admin can change. After a rename no token could match the live row again — `resolveOboHuman` returns null, the call falls through to anonymous, and under `mcp.obo.enabled` that is a fail-closed `Authorization unavailable` **against a row that still reads as live in the store**. No error names the cause.

## All three sides move together

That is the difficulty the issue calls out, and why #2955 was closed rather than merged — it moved the reader alone, which breaks the pair in the other direction (#2938).

| site | before | after |
|---|---|---|
| `McpSessionResource.create` | `identity.principal.name` | `callerKey()` → `jwt.subject` |
| `McpSessionResource.owns()` | `identity.principal.name` | `callerKey()` |
| `CallerContextResolver` | `preferred_username ?: sub` | `sub` |

`preferred_username` survives as the audit **label** — `sub` is a UUID and reads as nothing in a log. Display may drift with a rename; identity may not.

## The E2E #2750 test is retargeted, not deleted

It failed on this change, and that is the interesting part: it explicitly pinned *"a staff token matches its session by preferred_username when sub is a uuid"*. Its **intent** — writer and reader must agree, against a realistically-shaped Keycloak token — is exactly what still needs pinning; only the identifier they agree ON has moved. So it is rewritten to assert the same anti-regression on `sub`, and keeps asserting that the audit principal is still the human-readable `jane.operator`.

Deleting it would have removed the guard that #2946's incident bought.

## New coverage, verified fail-first

Reverting `callerKey()` to the display name reddens all three:

- `a Keycloak rename does not strand the caller's own session` — same `sub`, new `preferred_username`, `status()` must still be 200;
- `a different human with the same display name does not own the session` — the converse an immutable key buys, since display names are not unique over time;
- `a renamed operator still matches the session they created` — the same thing end to end through the endpoint.

The existing `issuance bounds the ceiling to the caller's own roles` also goes red, because it now asserts the stored subject is the `sub`.

## The issue's open question, answered

It asks whether a *stranded* session should be distinguishable from a *revoked* one. With an immutable key there is no stranded state left: a rename cannot orphan a session, so "anonymous" now means revoked or expired and nothing else. No new state or error is needed.

## Verification

`ktlintCheck`, `detekt`, `test`, `koverVerify`, `quarkusBuild` green.

One local snag worth naming: `McpAuditEventIT` failed with `Port already bound: 8081` until I moved the test port — a `kubectl` port-forward on this machine (pid 97610, not mine) holds 8081. Re-run with `-Dquarkus.http.test-port=8099` and the whole suite is green; CI runners have no such forward.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
