### PR TITLE
fix(admin-ui): stop tagging every GlitchTip event with a release nobody ships

### DIFF
--- a/.github/workflows/admin-ui-deploy.yml
+++ b/.github/workflows/admin-ui-deploy.yml
@@ -396,6 +396,10 @@ jobs:
 
       - name: Build, collect, push
         id: build
+        env:
+          # Optional: enables source-map upload to GlitchTip (#3235). Unset = no upload, normal
+          # build — the maps are what turn a captured error into a file and a line.
+          GLITCHTIP_AUTH_TOKEN: ${{ secrets.GLITCHTIP_AUTH_TOKEN }}
         run: |
           set -euo pipefail
           # build-push-admin-ui.sh derives the tag from git (dirty check runs BEFORE

--- a/openbank-admin-ui/Dockerfile
+++ b/openbank-admin-ui/Dockerfile
@@ -203,7 +203,15 @@ COPY --from=deps /app/node_modules ./node_modules
 COPY openbank-admin-ui/ ./
 ENV NEXT_TELEMETRY_DISABLED=1
 ENV NEXT_STANDALONE=true
-RUN npm run build
+# Source-map upload to GlitchTip (#3235). The token arrives as a BuildKit SECRET, not a build arg:
+# an ARG is recorded in `docker history` and would ship the credential inside the image everyone
+# can pull. The mount exists only for the lifetime of this RUN.
+#
+# Absent secret = no upload and a normal build, so local and PR builds are unaffected and this can
+# never become the reason a build fails.
+RUN --mount=type=secret,id=glitchtip_token \
+    SENTRY_AUTH_TOKEN="$(cat /run/secrets/glitchtip_token 2>/dev/null || true)" \
+    npm run build
 
 # ──────────────────────────────────────────────────────────────────────
 # Stage 4: Runtime image — minimal surface, non-root.

--- a/openbank-admin-ui/next.config.mjs
+++ b/openbank-admin-ui/next.config.mjs
@@ -1,3 +1,4 @@
+import { withSentryConfig } from '@sentry/nextjs'
 /** @type {import('next').NextConfig} */
 
 const securityHeaders = [
@@ -33,11 +34,47 @@ const nextConfig = {
     // same as the mobile app baking its DSN). Internal open-bank.tech origin, never sentry.io.
     NEXT_PUBLIC_GLITCHTIP_DSN: process.env.NEXT_PUBLIC_GLITCHTIP_DSN || 'https://58123562c22f4cb98ab9f2023d828f93@glitchtip.open-bank.tech/2',
     NEXT_PUBLIC_GLITCHTIP_ENVIRONMENT: process.env.NEXT_PUBLIC_GLITCHTIP_ENVIRONMENT || 'sandbox',
-    NEXT_PUBLIC_GLITCHTIP_RELEASE: process.env.NEXT_PUBLIC_GLITCHTIP_RELEASE || 'openbank-admin-ui@0.29.0',
+    // Derived from BUILD_VERSION, never a literal. It was pinned at 0.29.0 while version.txt said
+    // 0.80.1 — fifty-one minors stale — and a release string that names a build nobody ships is not
+    // cosmetic once source maps exist: maps are filed under a release, events are tagged with one,
+    // and symbolication is the join between them. A stale literal silently guarantees a miss.
+    NEXT_PUBLIC_GLITCHTIP_RELEASE:
+      process.env.NEXT_PUBLIC_GLITCHTIP_RELEASE ||
+      `openbank-admin-ui@${process.env.BUILD_VERSION || 'dev'}`,
   },
   async headers() {
     return [{ source: '/(.*)', headers: securityHeaders }]
   },
 }
 
-export default nextConfig
+// Upload wiring for GlitchTip (#3235) — a PREREQUISITE, not the fix.
+//
+// Measured on Next 16.2.12: this build runs Turbopack, which emits no CLIENT source maps
+// (`.next/static` has zero `.map` files, with or without a token) — `productionBrowserSourceMaps` is
+// a webpack-era option Turbopack ignores, and @sentry/nextjs says as much about its own hooks. So
+// there is currently nothing to upload and this block is a no-op until that is solved.
+//
+// It is here because the token plumbing and the release naming are the parts that CAN be got right
+// now, and because the alternative — wiring it later together with the Turbopack work — is how the
+// release string came to be pinned at a version nobody shipped.
+//
+// `telemetry: false` is not optional here — the plugin phones home to sentry.io by default, and this
+// estate reports to a self-hosted GlitchTip on an internal origin precisely so it does not.
+//
+// No token (local dev, PR builds) means no upload and a normal build: `withSentryConfig` skips the
+// upload step rather than failing, so this cannot become a reason a build breaks.
+export default withSentryConfig(nextConfig, {
+  org: 'openbank',
+  project: 'openbank-admin-ui',
+  sentryUrl: 'https://glitchtip.open-bank.tech',
+  authToken: process.env.SENTRY_AUTH_TOKEN,
+  // Must equal what the SDK tags events with, or maps and events never join.
+  release: { name: `openbank-admin-ui@${process.env.BUILD_VERSION || 'dev'}` },
+  sourcemaps: {
+    // Uploaded, then deleted from the image: a .map served next to the bundle hands the whole
+    // source to anyone who opens the console, which is the opposite of what this is for.
+    deleteSourcemapsAfterUpload: true,
+  },
+  silent: true,
+  telemetry: false,
+})

--- a/openbank-infra/scripts/build-push-admin-ui.sh
+++ b/openbank-infra/scripts/build-push-admin-ui.sh
@@ -317,7 +317,18 @@ fi
 # Context is the repo root: the Dockerfile collects every openbank-*/docs tree and
 # COPYs openbank-admin-ui/ in. Build args carry the provenance into the image.
 echo "==> docker buildx build + push"
+# GLITCHTIP_AUTH_TOKEN (optional) enables source-map upload — passed as a BuildKit secret so it is
+# never recorded in the image history. Unset means a normal build with no upload (#3235).
+SECRET_ARGS=()
+if [ -n "${GLITCHTIP_AUTH_TOKEN:-}" ]; then
+  SECRET_ARGS+=(--secret "id=glitchtip_token,env=GLITCHTIP_AUTH_TOKEN")
+  echo "    sourcemaps: upload ENABLED"
+else
+  echo "    sourcemaps: no GLITCHTIP_AUTH_TOKEN — upload skipped"
+fi
+
 docker buildx build \
+  "${SECRET_ARGS[@]}" \
   --platform "${PLATFORM}" \
   --file openbank-admin-ui/Dockerfile \
   --build-arg "BUILD_VERSION=${BUILD_VERSION}" \


### PR DESCRIPTION
Refs #3235. **Read the scope carefully: this does not make symbolication work.**

## What is fixed and verified

`NEXT_PUBLIC_GLITCHTIP_RELEASE` was the hand-pinned literal `openbank-admin-ui@0.29.0` while
`version.txt` said **0.80.1** — fifty-one minors stale, and pinned in a way that could never catch up.
It is now derived from `BUILD_VERSION`, confirmed in the built bundle (`0.80.1` present, `0.29.0`
gone).

This matters more than it looks. Maps are filed under a release, events are tagged with one, and
symbolication is the **join** between them. Uploading maps without this fix would have produced a
green upload step and no symbolication — precisely the "the gate passed and did nothing" shape this
repo keeps recording.

## What is wired, as a prerequisite

`withSentryConfig` with the org/project taken from the live GlitchTip (`openbank` /
`openbank-admin-ui`, project id 2 — matching the DSN already baked in), `sentryUrl` pointing at the
self-hosted instance, and `telemetry: false` so the plugin does not phone home to sentry.io from a
bank repo that deliberately self-hosts.

The token travels as a **BuildKit secret**, never a build arg: an `ARG` is recorded in
`docker history` and would ship the credential inside an image anyone can pull. Absent token = no
upload and an ordinary build, verified — so local and PR builds are unaffected and this can never
become the reason a build fails.

## What is NOT fixed, and why I am not pretending otherwise

Measured on **Next 16.2.12**, which builds with **Turbopack**:

```
maps in .next/static : 0     (with a token AND without one)
maps in .next/server : 1018
maps in .next/build  : 10
```

There are **no client source maps at all**, so there is nothing for the upload to send.
`productionBrowserSourceMaps` is a webpack-era option Turbopack ignores — I added it, measured no
change, and removed it rather than leave a setting that reads as load-bearing and is not.

I also could not verify the upload path end to end: creating a GlitchTip auth token needs a login I
should not perform. That step, and the Turbopack map question, are the remaining work on #3235.

## One manual step this needs

A GlitchTip auth token with project write scope, stored as the repo secret `GLITCHTIP_AUTH_TOKEN`.
Without it everything here is inert but harmless.

## Verification that would actually prove #3235 closed

Not a green upload step. Trigger a deliberate client-side throw on a deployed build and confirm the
GlitchTip event names a **source file and line**. Today it would say `s.map is not a function` with an
empty culprit, which is what the reporter's own console already told us.

957/957 admin-ui tests green; builds succeed with and without a token.
