### PR TITLE
feat(infra): detect Keycloak role ASSIGNMENT drift, and give four-eyes a second principal

### DIFF
--- a/.github/scripts/check-realm-user-role-parity.py
+++ b/.github/scripts/check-realm-user-role-parity.py
@@ -1,0 +1,348 @@
+#!/usr/bin/env python3
+# SPDX-License-Identifier: Apache-2.0
+# Copyright (c) OpenBank contributors. Licensed under the Apache License, Version 2.0.
+#
+# Detector: do the users in the LIVE Keycloak realm hold the roles the realm template
+# assigns them — and only those? (issue #2540 follow-up)
+#
+# WHY THIS EXISTS
+#   check-realm-role-parity.py compares role EXISTENCE, template vs live, and says so itself:
+#   its published report carries
+#       "doesNotVerify": "role ASSIGNMENTS to users/service accounts (#2540 follow-up)"
+#   That is this script. The gap matters because the two drifts fail in opposite directions and
+#   only one of them is visible:
+#
+#     - a MISSING role is loud downstream. Nothing can mint it, so a caller is denied and someone
+#       eventually notices.
+#     - a MISPLACED role is silent by construction. Every role involved exists in both the
+#       template and the live realm, so the existence check is green; what changed is only WHO
+#       holds it. Nothing 403s. The account simply does more than the repo says it may.
+#
+#   The second direction is the dangerous one, and its worst case is specific: an account whose
+#   credentials are deliberately published (a demo or guided-tour login) accumulating roles the
+#   template never granted it. That is not a hypothetical shape — every realm here ships such an
+#   account on purpose, and `--import-realm` runs on COLD START ONLY, so any grant made after the
+#   realm first came up lives outside git forever with ArgoCD reporting Synced/Healthy throughout.
+#
+#   It also breaks separation of duties without touching a single role definition. A four-eyes
+#   control needs two DIFFERENT principals; if one identity quietly accumulates both halves'
+#   roles, the control still exists, still passes every gate, and can be satisfied by one person.
+#
+# WHY IT IS NOT A PR-TIME GATE
+#   Same reason as its sibling: the live realm is unreachable from a PR runner (admin API blocked
+#   at the edge, no workflow holds cluster access, the credential is out-of-band). So this is a
+#   pure function over two snapshots — the templates in the repo, and user role mappings captured
+#   in-cluster by the keycloak-realm-drift CronJob — which keeps the COMPARISON as ordinary,
+#   reviewable, self-tested repo code.
+#
+# WHAT IT REPORTS — three kinds, because they are different defects:
+#   over-granted    live holds a role the template does not assign that user. The silent
+#                   direction above. Severity is raised for accounts flagged `published` (see
+#                   PUBLISHED_CREDENTIAL_USERS): those credentials are handed out on purpose, so
+#                   an extra role there is an extra role for everybody.
+#   under-granted   the template assigns a role the live user does not hold. The grant never
+#                   applied; anything relying on it degrades to whatever else the caller has.
+#   undeclared-user a live user no template describes. It works today and a cold-started realm
+#                   loses it — the same disaster-recovery landmine the sibling names.
+#
+# Keycloak's own built-ins are excluded by name; they are server-managed, appear in no template,
+# and a detector that always fires is a detector nobody reads.
+#
+# Run:
+#   python3 .github/scripts/check-realm-user-role-parity.py \
+#       --live openbank=/tmp/openbank-user-roles.json
+#   where the file is {"user@example": ["ROLE_A", ...]} or [{"username": ..., "realmRoles": [...]}]
+#
+#   python3 .github/scripts/check-realm-user-role-parity.py --self-test
+#
+# A realm with no --live snapshot is reported as unchecked, never as clean.
+
+import argparse
+import json
+import pathlib
+import sys
+
+REALM_GLOB = "openbank-infra/gitops/components/keycloak/*realm-template*.json"
+
+# Accounts whose credentials are published on purpose. An extra role on one of these is an extra
+# role for anyone who reads the docs, so it is reported at higher severity than ordinary drift.
+# Matched on the username as the template spells it.
+PUBLISHED_CREDENTIAL_USERS = {"demo@openbank.local"}
+
+# Keycloak returns service-account principals from /clients/<id>/service-account-user,
+# never from /users — so a snapshot that did not ask for them simply has none.
+SERVICE_ACCOUNT_PREFIX = "service-account-"
+
+
+def keycloak_builtins(realm: str) -> set:
+    """Roles the server assigns itself. Never in a template; excluded from both sides."""
+    return {
+        "offline_access",
+        "uma_authorization",
+        "uma_protection",
+        f"default-roles-{realm.lower()}",
+    }
+
+
+def template_users(root: pathlib.Path) -> tuple:
+    """({realm: {username: {roles}}}, {realms that allow self-registration}).
+
+    The registration flag matters: in a realm where anyone may sign up, a live user the template
+    does not name is the PRODUCT WORKING, not drift. Reporting each retail customer would bury the
+    one finding that matters under dozens that never will — the failure the sibling script calls
+    out as "a detector that always fires is a detector nobody reads".
+    """
+    out, open_registration = {}, set()
+    for p in sorted(root.glob(REALM_GLOB)):
+        doc = json.loads(p.read_text())
+        realm = doc.get("realm")
+        if not realm:
+            raise SystemExit(f"{p}: no `realm` key — cannot tell which realm it describes")
+        if doc.get("registrationAllowed"):
+            open_registration.add(realm)
+        users = {}
+        for u in doc.get("users", []) or []:
+            name = u.get("username")
+            if not name:
+                raise SystemExit(f"{p}: a user entry has no `username`")
+            roles = set(u.get("realmRoles") or [])
+            for client_roles in (u.get("clientRoles", {}) or {}).values():
+                roles |= set(client_roles or [])
+            users[name] = roles
+        out.setdefault(realm, {}).update(users)
+    return out, open_registration
+
+
+def load_live(spec: str) -> tuple:
+    """Parse a `realm=path` snapshot of user role mappings."""
+    if "=" not in spec:
+        raise SystemExit(f"--live expects realm=path, got {spec!r}")
+    realm, _, path = spec.partition("=")
+    raw = sys.stdin.read() if path == "-" else pathlib.Path(path).read_text()
+    doc = json.loads(raw)
+    users = {}
+    if isinstance(doc, dict):
+        for name, roles in doc.items():
+            users[name] = {r if isinstance(r, str) else r.get("name") for r in roles or []}
+    elif isinstance(doc, list):
+        for entry in doc:
+            if not isinstance(entry, dict) or not entry.get("username"):
+                raise SystemExit(f"{path}: unrecognised user entry {entry!r}")
+            roles = entry.get("realmRoles") or entry.get("roles") or []
+            users[entry["username"]] = {r if isinstance(r, str) else r.get("name") for r in roles}
+    else:
+        raise SystemExit(f"{path}: expected an object or a list, got {type(doc).__name__}")
+    if not users:
+        # An empty snapshot is a capture failure (bad credential, wrong realm), not a realm with
+        # no users — every realm here ships at least an admin. Refusing to treat it as data is
+        # what stops this printing "everything is missing" on an auth error.
+        raise SystemExit(f"{path}: no users parsed — treating as a failed capture, not an empty realm")
+    users = {k: {r for r in v if r} for k, v in users.items()}
+    return realm, users
+
+
+def compare(realm: str, declared: dict, live: dict, open_registration: bool = False) -> tuple:
+    """Return (findings, report-fragment) for one realm. Pure — the whole point of the split."""
+    builtins = keycloak_builtins(realm)
+    findings, over, under, undeclared, unchecked = [], {}, {}, [], []
+    # Does this snapshot cover service accounts at all? Derived from the snapshot itself rather
+    # than assumed, so an older capture degrades to "unchecked" instead of to a false finding.
+    saw_service_accounts = any(u.startswith(SERVICE_ACCOUNT_PREFIX) for u in live)
+
+    for user in sorted(set(declared) | set(live)):
+        want = (declared.get(user) or set()) - builtins
+        have = live.get(user)
+        if have is None:
+            # Declared but absent live. The sibling reports missing ROLES; a missing USER is the
+            # same class and equally invisible until someone tries to log in as them.
+            #
+            # EXCEPT for service accounts: Keycloak does not return them from /users, so their
+            # absence from a snapshot means the CAPTURE did not look, not that the principal is
+            # gone. Reporting it anyway would be a detector inventing a defect out of its own
+            # blind spot — worse than silence, because it trains the reader to skip the output.
+            if user.startswith(SERVICE_ACCOUNT_PREFIX) and not saw_service_accounts:
+                unchecked.append(user)
+                continue
+            findings.append(
+                f"::warning::[{realm}] user `{user}` is declared in the realm template but does "
+                f"not exist in the live realm — its grants {sorted(want)} never applied",
+            )
+            under[user] = sorted(want)
+            continue
+        have = have - builtins
+        if user not in declared:
+            undeclared.append(user)
+            # In a self-registration realm this is the product working. Still counted in the
+            # report (so the number is visible) but not raised as a finding.
+            if not open_registration and not user.startswith(SERVICE_ACCOUNT_PREFIX):
+                findings.append(
+                    f"::warning::[{realm}] user `{user}` exists live but no realm template "
+                    f"declares it — a cold-started realm loses it, and its roles {sorted(have)} "
+                    f"are outside git",
+                )
+            continue
+        extra, missing = sorted(have - want), sorted(want - have)
+        if extra:
+            over[user] = extra
+            if user in PUBLISHED_CREDENTIAL_USERS:
+                findings.append(
+                    f"::error::[{realm}] user `{user}` has PUBLISHED credentials and holds "
+                    f"{extra} which the realm template does not grant it — anyone holding those "
+                    f"credentials holds those roles. Template grants: {sorted(want)}",
+                )
+            else:
+                findings.append(
+                    f"::warning::[{realm}] user `{user}` holds {extra} which the realm template "
+                    f"does not grant it (template: {sorted(want)})",
+                )
+        if missing:
+            under[user] = missing
+            findings.append(
+                f"::warning::[{realm}] user `{user}` is missing {missing} which the realm "
+                f"template grants it — that grant never applied",
+            )
+
+    return findings, {
+        "status": "checked",
+        "overGranted": over,
+        "underGranted": under,
+        "undeclaredUsers": sorted(undeclared),
+        "undeclaredUsersReported": not open_registration,
+        "uncheckedPrincipals": sorted(unchecked),
+    }
+
+
+def self_test() -> int:
+    """Feed the comparison inputs it MUST flag, and one it must NOT.
+
+    A detector that has only ever seen agreeing snapshots is unfalsified, and this one's whole
+    value is a red on the silent direction — so the over-grant case, the published-credential
+    escalation, and the clean case are all exercised here rather than assumed.
+    """
+    failures = []
+
+    def check(name, cond):
+        if not cond:
+            failures.append(name)
+
+    # 1. identical sets are clean, and built-ins on the live side are not a finding
+    f, r = compare(
+        "openbank",
+        {"admin@x": {"ROLE_ADMIN"}},
+        {"admin@x": {"ROLE_ADMIN", "offline_access", "default-roles-openbank"}},
+    )
+    check("identical sets must be clean", f == [] and r["overGranted"] == {})
+
+    # 2. an extra live role is an over-grant
+    f, r = compare("openbank", {"ops@x": {"ROLE_VIEWER"}}, {"ops@x": {"ROLE_VIEWER", "ROLE_ADMIN"}})
+    check("extra live role must be reported", r["overGranted"] == {"ops@x": ["ROLE_ADMIN"]})
+    check("ordinary over-grant is a warning", any("::warning::" in x for x in f))
+
+    # 3. the same drift on a published-credential account escalates to error
+    f, r = compare(
+        "openbank",
+        {"demo@openbank.local": {"ROLE_VIEWER"}},
+        {"demo@openbank.local": {"ROLE_VIEWER", "ROLE_ADMIN"}},
+    )
+    check("published-credential over-grant must be an error", any("::error::" in x for x in f))
+    check("published-credential error names the role", any("ROLE_ADMIN" in x for x in f))
+
+    # 4. a declared grant that never applied
+    f, r = compare("openbank", {"a@x": {"ROLE_KYC"}}, {"a@x": set()})
+    check("missing live role must be reported", r["underGranted"] == {"a@x": ["ROLE_KYC"]})
+
+    # 5. a live user nothing declares
+    f, r = compare("openbank", {}, {"ghost@x": {"ROLE_ADMIN"}})
+    check("undeclared live user must be reported", r["undeclaredUsers"] == ["ghost@x"])
+    check("undeclared live user is a finding in a closed realm", any("ghost@x" in x for x in f))
+
+    # 5b. the same user in a SELF-REGISTRATION realm is the product working, not drift
+    f, r = compare("openbank-customers", {}, {"someone@x": {"ROLE_CUSTOMER"}}, open_registration=True)
+    check("self-registered user must not be a finding", f == [])
+    check("…but is still counted", r["undeclaredUsers"] == ["someone@x"])
+
+    # 5c. a declared service account missing from a snapshot that never captured any is UNCHECKED,
+    #     not a defect — a detector must not invent findings out of its own blind spot
+    f, r = compare(
+        "openbank",
+        {"service-account-x": {"ROLE_API"}, "admin@x": {"ROLE_ADMIN"}},
+        {"admin@x": {"ROLE_ADMIN"}},
+    )
+    check("absent service account is unchecked, not a finding",
+          f == [] and r["uncheckedPrincipals"] == ["service-account-x"])
+
+    # 6. an empty capture is a failure, never a clean realm — the difference between "this realm
+    #    has no users" and "the credential was wrong" is the difference between silence and alarm
+    import tempfile
+
+    with tempfile.NamedTemporaryFile("w", suffix=".json", delete=False) as fh:
+        fh.write("{}")
+        empty_snapshot = fh.name
+    try:
+        load_live(f"openbank={empty_snapshot}")
+        check("empty snapshot must raise", False)
+    except SystemExit:
+        pass
+
+    for name in failures:
+        sys.stderr.write(f"::error::self-test FAILED: {name}\n")
+    if failures:
+        return 1
+    print(f"self-test OK ({10 - len(failures)}/10 cases)")
+    return 0
+
+
+def main() -> int:
+    ap = argparse.ArgumentParser()
+    ap.add_argument("--root", default=".")
+    ap.add_argument(
+        "--live",
+        action="append",
+        default=[],
+        metavar="REALM=PATH",
+        help="live user role-mapping snapshot; PATH may be - for stdin. Repeatable.",
+    )
+    ap.add_argument("--self-test", action="store_true", help="run the falsifiability harness")
+    ap.add_argument(
+        "--enforce",
+        action="store_true",
+        help="exit non-zero on any finding (default: report and exit 0, like its sibling's intro)",
+    )
+    args = ap.parse_args()
+
+    if args.self_test:
+        return self_test()
+
+    root = pathlib.Path(args.root).resolve()
+    declared, open_registration = template_users(root)
+    if not declared:
+        sys.stderr.write(f"::error::no realm template found under {REALM_GLOB} — cannot run blind\n")
+        return 1
+
+    live = dict(load_live(s) for s in args.live)
+    findings, report = [], {"realms": {}}
+
+    for realm in sorted(set(declared) | set(live)):
+        if realm not in live:
+            findings.append(
+                f"::warning::realm `{realm}` has a template in git but no live user snapshot was "
+                f"supplied — UNCHECKED, not clean.",
+            )
+            report["realms"][realm] = {"status": "unchecked"}
+            continue
+        f, r = compare(realm, declared.get(realm, {}), live[realm], realm in open_registration)
+        findings += f
+        report["realms"][realm] = r
+
+    for line in findings:
+        sys.stderr.write(line + "\n")
+    print(json.dumps(report, indent=2, sort_keys=True))
+
+    hard = [f for f in findings if f.startswith("::error::")]
+    if args.enforce and findings:
+        return 1
+    return 1 if hard else 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/openbank-infra/gitops/components/keycloak-realm-drift/keycloak-realm-drift.yaml
+++ b/openbank-infra/gitops/components/keycloak-realm-drift/keycloak-realm-drift.yaml
@@ -232,6 +232,39 @@ spec:
                     # enables authorization services — so the checker's builtins filter
                     # carries it; see keycloak_builtins() in the script.
                     python3 -c "import glob,json;r=json.load(open('/work/${REALM}-realm-roles.json'));[r.extend(json.load(open(f))) for f in sorted(glob.glob('/work/${REALM}-cr/*.json'))];json.dump(r,open('/work/${REALM}-roles.json','w'));print('  %d role(s) (realm + client)' % len(r))"
+
+                    # WHO holds those roles (#2540 follow-up). Role EXISTENCE and role
+                    # ASSIGNMENT drift independently, and only the first is loud: a misplaced
+                    # role leaves every gate green because both sides still define it.
+                    # Service accounts are fetched separately on purpose — Keycloak never
+                    # returns them from /users, so a capture that only walks /users leaves the
+                    # checker unable to tell "absent" from "not looked at". It reports them as
+                    # unchecked rather than as missing; that distinction is why they are here.
+                    curl -sS --fail-with-body \
+                      -H "Authorization: Bearer ${TOKEN}" \
+                      "${KC_URL}/admin/realms/${REALM}/users?briefRepresentation=true&first=0&max=5000" \
+                      > "/work/${REALM}-users.json"
+                    REALM="${REALM}" TOKEN="${TOKEN}" KC_URL="${KC_URL}" python3 - <<'CAPTURE' > "/work/${REALM}-user-roles.json"
+                    import json, os, urllib.request
+                    realm, tok, url = os.environ["REALM"], os.environ["TOKEN"], os.environ["KC_URL"]
+                    def get(path):
+                        req = urllib.request.Request(f"{url}{path}", headers={"Authorization": f"Bearer {tok}"})
+                        return json.load(urllib.request.urlopen(req))
+                    out = {}
+                    for u in json.load(open(f"/work/{realm}-users.json")):
+                        out[u["username"]] = sorted(r["name"] for r in get(f"/admin/realms/{realm}/users/{u['id']}/role-mappings/realm"))
+                    builtin = {"account", "account-console", "admin-cli", "broker", "realm-management", "security-admin-console"}
+                    for c in json.load(open(f"/work/{realm}-clients.json")):
+                        if c.get("clientId") in builtin or not c.get("serviceAccountsEnabled"):
+                            continue
+                        try:
+                            sa = get(f"/admin/realms/{realm}/clients/{c['id']}/service-account-user")
+                        except Exception:
+                            continue
+                        out[sa["username"]] = sorted(r["name"] for r in get(f"/admin/realms/{realm}/users/{sa['id']}/role-mappings/realm"))
+                    json.dump(out, __import__("sys").stdout, indent=1, sort_keys=True)
+                    CAPTURE
+                    python3 -c "import json;print('  %d principal(s) with role mappings' % len(json.load(open('/work/${REALM}-user-roles.json'))))"
                   done
 
                   # --skip-annotations is NOT passed: the clone is a full checkout, so the
@@ -245,6 +278,17 @@ spec:
                     > /work/final.json 2> /work/findings.txt \
                     || echo "findings" > /work/findings
                   cat /work/findings.txt
+
+                  # Kept as a SECOND invocation rather than folded into the first: the two
+                  # answer different questions and fail independently, and a combined exit code
+                  # would make "which one went red" a log-reading exercise.
+                  python3 .github/scripts/check-realm-user-role-parity.py \
+                    --root /tmp/repo \
+                    --live "openbank=/work/openbank-user-roles.json" \
+                    --live "openbank-customers=/work/openbank-customers-user-roles.json" \
+                    > /work/final-users.json 2> /work/findings-users.txt \
+                    || echo "findings" > /work/findings
+                  cat /work/findings-users.txt
               volumeMounts:
                 - name: work
                   mountPath: /work
@@ -274,10 +318,15 @@ spec:
                   report = json.loads(raw) if raw else {"realms": {}, "captureFailed": True}
                   report["scannedAt"] = datetime.datetime.now(datetime.timezone.utc).strftime(
                       "%Y-%m-%dT%H:%M:%SZ")
-                  report["checkScope"] = "keycloak realm ROLE EXISTENCE, template vs live"
-                  report["doesNotVerify"] = "role ASSIGNMENTS to users/service accounts (#2540 follow-up)"
+                  report["checkScope"] = "keycloak realm ROLE EXISTENCE + ROLE ASSIGNMENTS, template vs live"
+                  report["doesNotVerify"] = "client-role assignments; group membership"
                   findings = pathlib.Path("/work/findings.txt")
                   report["findings"] = findings.read_text().splitlines() if findings.is_file() else []
+                  users_raw = pathlib.Path("/work/final-users.json")
+                  raw_u = users_raw.read_text().strip() if users_raw.is_file() else ""
+                  report["userRoleParity"] = json.loads(raw_u) if raw_u else {"captureFailed": True}
+                  uf = pathlib.Path("/work/findings-users.txt")
+                  report["userRoleFindings"] = uf.read_text().splitlines() if uf.is_file() else []
                   print(json.dumps(report, indent=2, sort_keys=True))
                   PY
 

--- a/openbank-infra/gitops/components/keycloak/realm-template.json
+++ b/openbank-infra/gitops/components/keycloak/realm-template.json
@@ -394,6 +394,25 @@
       ]
     },
     {
+      "username": "compliance@openbank.local",
+      "email": "compliance@openbank.local",
+      "firstName": "Compliance",
+      "lastName": "OpenBank",
+      "enabled": true,
+      "emailVerified": true,
+      "credentials": [
+        {
+          "type": "password",
+          "value": "__COMPLIANCE_USER_PASSWORD__",
+          "temporary": false
+        }
+      ],
+      "realmRoles": [
+        "ROLE_COMPLIANCE",
+        "ROLE_VIEWER"
+      ]
+    },
+    {
       "username": "service-account-openbank-edge",
       "enabled": true,
       "serviceAccountClientId": "openbank-edge",


### PR DESCRIPTION
## What

Builds the follow-up `keycloak-realm-drift` names in its own published report every run:

```
"doesNotVerify": "role ASSIGNMENTS to users/service accounts (#2540 follow-up)"
```

- `.github/scripts/check-realm-user-role-parity.py` — compares the realm templates' user→role
  assignments against a live capture.
- the drift CronJob now captures user role mappings (including service accounts) and runs it.
- `compliance@openbank.local` (`ROLE_COMPLIANCE`, `ROLE_VIEWER`) added to the realm template.

## Why the existing check cannot see this

Role **existence** and role **assignment** drift independently, and only one is loud:

| drift | what happens |
|---|---|
| a role goes missing | nothing can mint it → a caller is denied → someone notices |
| a role moves to another principal | **silent** — both sides still define it, the existence check is green, nothing 403s |

The second is the dangerous one. `--import-realm` runs on **cold start only**, so any grant made
after the realm first came up lives outside git forever, with ArgoCD reporting Synced/Healthy
throughout — the drift is a layer below anything ArgoCD or a PR-time gate can see.

It also breaks separation of duties without touching a single role definition: a four-eyes control
needs two **different** principals, and one identity quietly accumulating both halves' roles
satisfies it alone while every gate stays green.

## Two things that stop it being noise

Both were found by running it against a real capture, not by reasoning about it — the first run
produced 36 findings, of which 1 was real:

- **A self-registration realm's live users are the product working, not drift.** The customers realm
  returned 33 self-registered users. They are counted in the report and not raised. (Its sibling
  warns: "a detector that always fires is a detector nobody reads".)
- **Keycloak never returns service accounts from `/users`.** A capture that only walks `/users`
  cannot distinguish *absent* from *not looked at* — the first run reported both service accounts as
  missing grants, which is the detector inventing a defect out of its own blind spot. The capture now
  fetches them via `service-account-user`, and the checker derives from the snapshot itself whether
  service accounts were covered, reporting them as `unchecked` when they were not.

Severity is raised to `::error::` for over-grants on accounts whose credentials are published on
purpose — an extra role there is an extra role for everyone who reads the docs.

## The realm-template change

ADR-0212 D4 activation needs a maker and a **different** checker. The realm declared no compliance
principal at all, so the control was unreachable as declared — not "hard to use", unreachable.

**Operator note:** `__COMPLIANCE_USER_PASSWORD__` is a new placeholder. The substituted realm JSON is
an out-of-band secret, so a value must be supplied there **before the next cold start**, or the
literal placeholder becomes the password.

## Verification

Realm-template changes are verified against a real Keycloak before the PR, because import runs on
cold start only and a broken template ships silently:

```
docker run -v /tmp/realm-test.json:/opt/keycloak/data/import/realm.json \
  quay.io/keycloak/keycloak:26.6.3 start-dev --import-realm
```

- realm imports cleanly; `compliance@openbank.local` lands with `['ROLE_COMPLIANCE', 'ROLE_VIEWER']`
- **effective** role mappings give exactly **2** principals able to reach `CompliancePackResource`
  (`admin@`, `compliance@`) — so maker ≠ checker is satisfiable
- the published-credential account is **not** among them
- checker `--self-test`: **10/10**, including the over-grant, the published-credential escalation,
  the self-registration carve-out, the service-account blind spot, and an empty capture being treated
  as a failure rather than a clean realm
- the CronJob YAML parses (4 documents)

The end-to-end token claim was **not** exercised: `admin-cli` is the only direct-grant client in the
realm and it maps no realm roles into the token, so the check above is the admin API's effective
mapping — which is what Keycloak resolves the token from — rather than a minted JWT.

Refs #2540
