### PR TITLE
fix(gitops): derive the libs fan-out from the build files, so a shared-library change reaches its consumers

### DIFF
--- a/.github/gates/gates.yaml
+++ b/.github/gates/gates.yaml
@@ -1036,6 +1036,19 @@ gates:
     run: |
       python3 .github/scripts/check-object-store-blobs-migration.py --enforce
 
+  # auto-deploy derives its libs fan-out from the `project(":openbank-libs-*")` declarations
+  # (#2983). A hardcoded path regex missed the ADR-0122 siblings entirely, so a libs-temporal fix
+  # rebuilt zero consumers and left services running pre-fix images while their pods read green.
+  # The self-test pins the declaration matcher and both path matchers in both directions.
+  - id: libs-change-dependents
+    name: "libs change fan-out is derived (issue #2983, enforced)"
+    group: gitops
+    mode: enforced
+    selftest: |
+      bash .github/scripts/libs-change-dependents.sh --selftest
+    run: |
+      bash .github/scripts/libs-change-dependents.sh --selftest
+
   - id: kafka-acl-coverage
     name: "Kafka ACL coverage (issue #2598, enforced)"
     group: data

--- a/.github/scripts/libs-change-dependents.sh
+++ b/.github/scripts/libs-change-dependents.sh
@@ -1,0 +1,129 @@
+#!/usr/bin/env bash
+# SPDX-License-Identifier: Apache-2.0
+#
+# Which services must be rebuilt because a shared library changed (issue #2983).
+#
+# THE DEFECT THIS CLOSES
+# `Auto deploy` derived its build set from changed SERVICE directories, plus a hardcoded
+# "shared paths" regex that named only `openbank-libs`, `openbank-libs-domain` and
+# `openbank-libs-runtime`. The ADR-0122 split created two more siblings, and a change under
+# `openbank-libs-temporal/src/main` therefore matched nothing at all:
+#
+#     Detect changed services: success
+#     Build + push: skipped
+#
+# #2949 fixed the Temporal payload converter and rebuilt no consumer. campaign-service only got it
+# because someone re-dispatched by hand; fx-service and statement-service were still running images
+# built before the fix. Their pods were green, which says nothing about the change — they were not
+# running it.
+#
+# The second-order cost is worse than a delayed fix: a REGRESSION in a shared library then reaches
+# consumers one at a time, weeks apart, each carried in by an unrelated PR — and by the time it
+# surfaces, the correlation with the library change is gone and the innocent PR gets the blame.
+#
+# WHY DERIVED, NOT LISTED
+# The dependency is already declared in each consumer's build.gradle.kts. A hand-kept libs→services
+# mapping would rot exactly like the ESO cert-reader allow-list did (#2851). This greps the
+# declarations, so the mapping cannot drift from the build files it describes.
+#
+# It is also narrower than "rebuild everything on any libs change": libs-temporal has 16 consumers,
+# not 53. Measured today — domain 45, runtime 43, temporal 16.
+#
+# openbank-libs-testing is DELIBERATELY not a trigger: it is declared `testImplementation` by all
+# five of its consumers, so it is absent from the runtime image and rebuilding for it would burn
+# fleet CI to ship a byte-identical artifact.
+#
+# TRULY GLOBAL paths (build-logic, gradle wrapper, settings.gradle.kts, openbank-libs itself) still
+# mean everything: they change how every module is built, and no per-module declaration expresses
+# that.
+#
+# Usage:
+#   libs-change-dependents.sh <all-services>            # changed files on stdin, one per line
+#   libs-change-dependents.sh --selftest
+# Prints the services to rebuild, one per line (possibly none). Prints ALL_SERVICES for a global
+# path. Never prints a service outside the ALL_SERVICES it was given.
+set -euo pipefail
+
+# Runtime-affecting shared modules → their declaration token in a consumer's build file.
+LIBS_MODULES=(openbank-libs-domain openbank-libs-runtime openbank-libs-temporal)
+# Paths that change how EVERYTHING is built; no declaration can express these.
+GLOBAL_RE='^(build-logic/|gradle/|gradlew|settings\.gradle\.kts|build\.gradle\.kts|openbank-libs/(src/main|build\.gradle\.kts|gradle/))'
+# A libs module matters when its compiled sources or its own build file move. Its docs do not
+# (issue #375: a bare prefix match rebuilt 37 services on a doc-only change).
+libs_re() { printf '^%s/(src/main|build\\.gradle\\.kts)' "$1"; }
+
+dependents_of() {
+  local module="$1"
+  # `project(":<module>")` under implementation/api — testImplementation consumers are excluded by
+  # LIBS_MODULES not containing openbank-libs-testing, and are additionally skipped here so a
+  # future testImplementation of a runtime module does not trigger a pointless rebuild.
+  command grep -lE "^[[:space:]]*(implementation|api)\(project\(\":${module}\"\)\)" \
+    openbank-*/build.gradle.kts 2>/dev/null | cut -d/ -f1 || true
+}
+
+selftest() {
+  local fail=0
+  # The declaration matcher must see a real consumer and must not see a test-only one.
+  if ! dependents_of openbank-libs-temporal | command grep -qx openbank-fx-service; then
+    echo "selftest FAIL: fx-service is not detected as a libs-temporal consumer" >&2
+    fail=1
+  fi
+  if dependents_of openbank-libs-temporal | command grep -qx openbank-libs-temporal; then
+    echo "selftest FAIL: a module reported as its own consumer" >&2
+    fail=1
+  fi
+  # testImplementation must not count as a runtime dependency.
+  if dependents_of openbank-libs-testing | command grep -q .; then
+    echo "selftest FAIL: testImplementation consumers of libs-testing were counted as runtime" >&2
+    fail=1
+  fi
+  # The path matchers, both directions — a doc-only change must NOT trigger a module.
+  local re; re="$(libs_re openbank-libs-temporal)"
+  command grep -qE "$re" <<< "openbank-libs-temporal/src/main/kotlin/X.kt" || {
+    echo "selftest FAIL: a real source change did not match its module" >&2; fail=1; }
+  if command grep -qE "$re" <<< "openbank-libs-temporal/docs/README.md"; then
+    echo "selftest FAIL: a docs-only change matched its module (issue #375)" >&2
+    fail=1
+  fi
+  command grep -qE "$GLOBAL_RE" <<< "build-logic/src/main/kotlin/X.kt" || {
+    echo "selftest FAIL: build-logic did not match the global paths" >&2; fail=1; }
+  if command grep -qE "$GLOBAL_RE" <<< "openbank-libs/governance/rules.yaml"; then
+    echo "selftest FAIL: a governance catalog matched the global paths — that is data, not a compile input" >&2
+    fail=1
+  fi
+  [ "$fail" -eq 0 ] && echo "selftest OK: declaration matcher and both path matchers verified in both directions."
+  return "$fail"
+}
+
+if [ "${1:-}" = "--selftest" ]; then
+  selftest
+  exit $?
+fi
+
+ALL_SERVICES="${1:?usage: libs-change-dependents.sh <all-services>   # changed files on stdin}"
+CHANGED="$(cat)"
+
+if command grep -qE "$GLOBAL_RE" <<< "$CHANGED"; then
+  echo "global build input changed → every service" >&2
+  printf '%s\n' $ALL_SERVICES
+  exit 0
+fi
+
+DEPENDENTS=""
+for module in "${LIBS_MODULES[@]}"; do
+  if command grep -qE "$(libs_re "$module")" <<< "$CHANGED"; then
+    found="$(dependents_of "$module")"
+    count="$(printf '%s' "$found" | command grep -c . || true)"
+    echo "${module} changed → ${count} consumer(s)" >&2
+    DEPENDENTS="${DEPENDENTS}
+${found}"
+  fi
+done
+
+# Intersect with ALL_SERVICES: a consumer that this pipeline cannot build (a different pipeline
+# owns it, or it has no gitops manifest) must never enter the build set.
+printf '%s\n' $DEPENDENTS | command grep -v '^$' | sort -u | while read -r svc; do
+  for known in $ALL_SERVICES; do
+    [ "$svc" = "$known" ] && echo "$svc" && break
+  done
+done

--- a/.github/workflows/auto-deploy.yml
+++ b/.github/workflows/auto-deploy.yml
@@ -233,38 +233,45 @@ jobs:
           # exit SIGPIPEs the echo and the match is racily mis-read as false
           # (same footgun documented in services-ci.yml).
           CODE_FILES="$(grep -vE '^openbank-libs/governance/' <<< "$CHANGED_FILES" || true)"
-          SHARED_CHANGED=0
-          # Precise per-module match (src/main + build file), not a bare "openbank-libs"
-          # prefix — that also matched openbank-libs/docs/** (non-compiled) and silently
-          # triggered a 37-service rebuild on doc-only changes (issue #375).
-          grep -qE '^(openbank-libs/(src/main|build\.gradle\.kts|gradle/)|openbank-libs-domain/(src/main|build\.gradle\.kts)|openbank-libs-runtime/(src/main|build\.gradle\.kts)|build-logic|gradle/|settings\.gradle\.kts)' <<< "$CODE_FILES" && SHARED_CHANGED=1 || true
+          # Services to rebuild because a SHARED library changed, derived from the
+          # `project(":openbank-libs-*")` declarations in each consumer's build.gradle.kts
+          # (issue #2983). The old shape was a hardcoded path regex naming only openbank-libs,
+          # -domain and -runtime, so the ADR-0122 siblings matched NOTHING: #2949 fixed the
+          # Temporal payload converter and rebuilt zero consumers, leaving fx-service and
+          # statement-service running pre-fix images while their pods read green.
+          #
+          # Deriving it also narrows the blast radius rather than widening it: a libs-temporal
+          # change rebuilds its 16 consumers, not the whole fleet, and libs-testing
+          # (testImplementation everywhere) rebuilds nobody.
+          LIBS_DEPENDENTS="$(printf '%s\n' "$CODE_FILES" \
+            | bash .github/scripts/libs-change-dependents.sh "$ALL_SERVICES")"
 
-          if [ "$SHARED_CHANGED" = "1" ]; then
-            echo "Shared dependency changed → rebuilding all services."
-            SERVICES_JSON="$(echo "$ALL_SERVICES" | tr ' ' '\n' | jq -R . | jq -sc .)"
-          else
-            # Pick only services whose src/main or build file changed.
-            SERVICES=()
-            for svc in $ALL_SERVICES; do
-              if grep -qE "^${svc}/(src/main|build\.gradle\.kts)" <<< "$CHANGED_FILES"; then
-                # Only deploy services that have a gitops manifest (not lending, pid, etc.).
-                if grep -rlq "${svc}:sandbox-" openbank-infra/gitops/components 2>/dev/null; then
-                  SERVICES+=("$svc")
-                else
-                  echo "  skip ${svc} — no gitops manifest found"
-                fi
-              fi
-            done
-
-            if [ "${#SERVICES[@]}" -eq 0 ]; then
-              echo "No deployable services changed."
-              echo "services=[]" >> "$GITHUB_OUTPUT"
-              echo "any=false" >> "$GITHUB_OUTPUT"
-              exit 0
+          # Services changed directly in this push.
+          SERVICES=()
+          for svc in $ALL_SERVICES; do
+            if grep -qE "^${svc}/(src/main|build\.gradle\.kts)" <<< "$CHANGED_FILES"; then
+              SERVICES+=("$svc")
             fi
+          done
+          # ...unioned with the libs consumers, then filtered ONCE on the gitops manifest, so a
+          # library fan-out cannot try to deploy a service this pipeline has no manifest for.
+          DEPLOYABLE=()
+          for svc in $(printf '%s\n' "${SERVICES[@]+"${SERVICES[@]}"}" $LIBS_DEPENDENTS | grep -v '^$' | sort -u); do
+            if grep -rlq "${svc}:sandbox-" openbank-infra/gitops/components 2>/dev/null; then
+              DEPLOYABLE+=("$svc")
+            else
+              echo "  skip ${svc} — no gitops manifest found"
+            fi
+          done
 
-            SERVICES_JSON="$(printf '%s\n' "${SERVICES[@]}" | jq -R . | jq -sc .)"
+          if [ "${#DEPLOYABLE[@]}" -eq 0 ]; then
+            echo "No deployable services changed."
+            echo "services=[]" >> "$GITHUB_OUTPUT"
+            echo "any=false" >> "$GITHUB_OUTPUT"
+            exit 0
           fi
+
+          SERVICES_JSON="$(printf '%s\n' "${DEPLOYABLE[@]}" | jq -R . | jq -sc .)"
 
           echo "Services to deploy: $SERVICES_JSON"
           echo "services=$SERVICES_JSON" >> "$GITHUB_OUTPUT"


### PR DESCRIPTION
Closes #2983 · Refs #2949, #2749, #375

## The defect, precisely

The shared-path regex named only `openbank-libs`, `openbank-libs-domain` and `openbank-libs-runtime`. ADR-0122 created two more siblings, so a change under `openbank-libs-temporal/src/main` matched **nothing**:

```
Detect changed services: success
Build + push: skipped
```

#2949 fixed the Temporal payload converter and rebuilt zero consumers. `fx-service` and `statement-service` kept running pre-fix images with green pods — and green says nothing about a change a service is not running.

The reverse case is the dangerous one, as the issue argues: a **regression** in a shared library reaches consumers one at a time, weeks apart, each carried in by an unrelated PR. By the time it surfaces the correlation with the library change is gone, and the innocent PR gets the blame.

## Option 1, and it makes the fan-out *narrower*

Derived from the `project(":openbank-libs-*")` declarations already in each consumer's `build.gradle.kts` — not a second list, which would rot the way the ESO cert-reader allow-list did (#2851).

| changed | rebuilds — before → after |
|---|---|
| `openbank-libs-temporal` | **0** → 16 consumers |
| `openbank-libs-domain` | all 53 → 41 deployable consumers |
| `openbank-libs-runtime` | all 53 → its consumers |
| `openbank-libs-testing` | 0 → **0**, deliberately |
| `build-logic`, gradle wrapper, `settings.gradle.kts`, `openbank-libs` | all → all |

`libs-testing` stays a non-trigger on purpose: all five consumers declare it `testImplementation`, so it is absent from the runtime image and rebuilding for it would burn fleet CI to ship a byte-identical artifact. The truly global paths still mean everything — they change *how* every module is built, and no per-module declaration expresses that.

Net FinOps effect is a reduction on the common case (domain/runtime, 53 → ~41) and a real new cost on libs-temporal (0 → 16), which is the entire point of the issue.

## Verified by running the extracted step, not a retyped copy

The step body was parsed out of the workflow YAML and executed against stubbed change sets — a transcription is a different program, and the repo has been bitten by that before:

| changed files | result |
|---|---|
| `openbank-libs-temporal/src/main/kotlin/X.kt` | 16, including `fx-service` and `statement-service` — the two the issue names as stale |
| `openbank-ledger-service/src/main/kotlin/Y.kt` | 1 |
| `openbank-libs/governance/rules.yaml` | 0 (data, not a compile input) |
| `openbank-libs-temporal/docs/x.md` | 0 — #375's docs-only regression stays fixed |

`--selftest` is registered as gate `libs-change-dependents` and pins the declaration matcher (a real consumer is found; a module is not its own consumer; `testImplementation` does not count) and both path matchers in both directions. `shellcheck -S warning` clean.

## One structural change worth noticing in review

The gitops-manifest filter now runs **once over the union** of directly-changed services and libs consumers, rather than only over the directly-changed ones. Without that, a library fan-out could put a service with no manifest into the build set — which the old code could never do simply because it never fanned out.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
