### PR TITLE
feat(gitops): enable ADR-0211 customer intake in the sandbox

### DIFF
--- a/openbank-infra/gitops/components/lending/lending-service.yaml
+++ b/openbank-infra/gitops/components/lending/lending-service.yaml
@@ -131,6 +131,32 @@ spec:
             # Flipping early refuses every origination with no pack present.
             - name: LENDING_ENFORCE_PACK
               value: "false"
+            # ADR-0211 customer intake (#3197). The applicant's own channel into
+            # origination: customer-edge posts here with the party id it derived from the
+            # customer JWT. Three values, each a refusal boundary rather than a preference:
+            #
+            #   caller-principal  the ONLY identity permitted to submit on a customer's
+            #                     behalf. Left blank the service refuses every call, which
+            #                     is deliberate — edge's M2M token carries ROLE_OPERATOR and
+            #                     nothing else, and AuthorizeInterceptor classifies a
+            #                     client_credentials JWT as HUMAN, so neither @RolesAllowed
+            #                     nor rego can tell the edge from a person at a desk. The
+            #                     name match is the actual control.
+            #   nominal-annual-rate  no default in the service: an unpriced product refuses
+            #                     rather than guessing. The value below is a PLACEHOLDER for
+            #                     the sandbox, in the same spirit as the uncalibrated PD/LGD
+            #                     constants — it is not a rate anyone priced.
+            #   enabled           the feature switch. Restart-required.
+            #
+            # This is the MAKER leg only: an application lands in the ordinary origination
+            # graph and still needs a human four-eyes decision before any disbursement, so
+            # turning it on cannot move money.
+            - name: LENDING_INTAKE_ENABLED
+              value: "true"
+            - name: LENDING_INTAKE_CALLER_PRINCIPAL
+              value: service-account-openbank-edge
+            - name: LENDING_INTAKE_NOMINAL_ANNUAL_RATE
+              value: "0.079"
             # OTel traces → Tempo.
             - name: QUARKUS_OTEL_EXPORTER_OTLP_ENDPOINT
               value: "http://tempo.observability.svc:4317"


### PR DESCRIPTION
## What

Enables ADR-0211 customer intake (#3197) in the sandbox by setting the three values on
`lending-service`:

| variable | value | why it exists |
|---|---|---|
| `LENDING_INTAKE_ENABLED` | `true` | the feature switch, restart-required |
| `LENDING_INTAKE_CALLER_PRINCIPAL` | `service-account-openbank-edge` | the **only** identity permitted to submit on a customer's behalf |
| `LENDING_INTAKE_NOMINAL_ANNUAL_RATE` | `0.079` | **placeholder** — see below |

## The caller-principal is the control, not the role gate

customer-edge's M2M token carries `ROLE_OPERATOR` and nothing else, and
`AuthorizeInterceptor` classifies a client_credentials JWT as `HUMAN`. So neither `@RolesAllowed`
nor lending's rego (whose `operator-lending-write` rule admits any `lending.*` for that role) can
distinguish the edge from a real person at a desk. Left blank, the service refuses **every** call —
that is deliberate, and it is why this variable is not optional in practice.

## The rate is a placeholder, not a price

The service has no default for it: an unpriced product refuses rather than guessing. `0.079` is a
sandbox placeholder in the same spirit as the uncalibrated PD/LGD constants — **nobody priced it**,
and it should not be read as a product decision. Change it before it means anything.

## Declared in gitops, not patched live

A `kubectl set env` would put this config outside git — the exact drift class #3244 exists to detect
and #3246 measures. Same reason the CZ pack activation is not being scripted around.

## This cannot move money

Maker leg only. An application lands in the ordinary origination graph and still needs a human
four-eyes decision before any disbursement.

## It takes effect on the image, not on this merge

Verified against the running pod before committing:

```
/api/v1/lending/intake/applications   HTTP/1.1 404 Not Found
/api/v1/lending/applications          HTTP/1.1 401 Unauthorized
```

The 404 is the point — the endpoint does not exist in the deployed build (`sandbox-0fbd7459`,
0.20.2), which predates #3197. This config precedes the image that implements it; nothing changes
until that image deploys.

Refs #3197
