### PR TITLE
fix(ci): stop the reconciler cancelling its own queued verifications

### DIFF
--- a/.github/workflows/verify-provider.yml
+++ b/.github/workflows/verify-provider.yml
@@ -21,23 +21,34 @@ permissions:
   contents: read
   id-token: write
 
-# Collapse duplicate dispatches for the SAME provider. The Pact Broker webhook
-# (.github/workflows/pact-verification-reconcile.yml) dispatches once per provider
-# requiring verification, so a fleet-wide libs change that makes twenty consumers
-# republish would dispatch twenty runs — at most a handful of which are distinct
-# work — onto a six-runner ARC pool that already wedges for hours (#2039). Without
-# this, the fix for the unverified-pact strand would deepen the queue starvation
-# that strands things in the first place.
+# Collapse duplicate dispatches for the SAME provider. The reconciler
+# (.github/workflows/pact-verification-reconcile.yml) dispatches once per provider that
+# owes a verification, so a fleet-wide libs change that makes many consumers republish
+# would otherwise queue one run per tick per provider onto a six-runner ARC pool that
+# already wedges for hours (#2039).
 #
-# cancel-in-progress is TRUE, and that is safe here specifically because a provider
-# verification is not incremental: the run verifies EVERY consumer pact currently
-# required of that provider, so the newest run is a strict superset of the work any
-# run it cancels was doing. Cancelling the older one loses nothing. (That reasoning
-# does NOT transfer to the publish side, where each run carries its own SHA's
-# result — do not copy this block to a workflow that publishes pacts.)
+# cancel-in-progress is FALSE, and the reasoning behind the original `true` is worth
+# keeping because it was wrong in an instructive way. The argument was: a provider
+# verification is not incremental — it verifies every consumer pact currently required of
+# that provider — so the newest run is a strict superset of any run it cancels, and
+# cancelling the older one loses nothing. That is true about the WORK. It silently assumed
+# the runs get to RUN.
+#
+# They did not. With the pool saturated, a dispatched verification sits queued for longer
+# than the reconciler's 30-minute interval, so every tick cancelled the still-queued
+# predecessor and dispatched a fresh one that queued behind the same wall. Observed on
+# openbank-kyc-service: runs at 12:25 and 12:31 both cancelled, a third queued at 12:49 —
+# the verification never executed, the strand never cleared, and the reconciler kept
+# reporting a successful dispatch every time. A livelock that looks like it is working.
+#
+# With `false`, GitHub holds the newer run as pending and cancels older PENDING runs
+# instead, so duplicates are still collapsed to one — but a run that is already underway
+# is never killed, which is the only property that actually mattered. The exact wrong
+# assumption to avoid re-making: "superseding is free" is only true when the thing being
+# superseded was making progress.
 concurrency:
   group: verify-provider-${{ inputs.service }}
-  cancel-in-progress: true
+  cancel-in-progress: false
 
 jobs:
   verify:


### PR DESCRIPTION

`verify-provider.yml` had `cancel-in-progress: true`, which I justified in #3209
like this: a provider verification is not incremental — it verifies every consumer
pact currently required of that provider — so the newest run is a strict superset
of any run it cancels, and cancelling the older one loses nothing.

That is true about the WORK. It silently assumed the runs get to RUN.

They did not. The `openbank-build` pool is capped at 6 and routinely saturated
(#2039), so a dispatched verification sits QUEUED for longer than the reconciler's
30-minute interval. Every tick then cancelled the still-queued predecessor and
dispatched a fresh one that queued behind the same wall:

  12:25:28  verify openbank-kyc-service  -> cancelled
  12:31:52  verify openbank-kyc-service  -> cancelled
  12:49:30  verify openbank-kyc-service  -> queued

The verification never executed, the strand never cleared, and the reconciler
reported a successful dispatch (HTTP 204) every single time. A livelock that looks
exactly like the feature working — which is the failure mode this repo keeps
recording, arriving this time through something I added to prevent a different one.

With `cancel-in-progress: false`, GitHub holds the newer run as pending and cancels
older PENDING runs instead. Duplicates are still collapsed to one, which was the
actual requirement; a run that is already underway is never killed.

The transferable half: "superseding is free" is only true when the thing being
superseded was making progress. Under queue starvation, cancel-in-progress turns a
backlog into a treadmill.

Refs #3178