### PR TITLE
ci(ai-evals): enforce replay regression gate with first baseline

### DIFF
--- a/.github/gates/gates.yaml
+++ b/.github/gates/gates.yaml
@@ -604,12 +604,15 @@ gates:
   # and re-passing.
   #
   # ENFORCED (was continue-on-error, #2392). The `continue-on-error` was carrying a different
-  # meaning than it looked like: the runner already treats a charter with no recorded run as
-  # ::warning and exits 0 — 4 of the 5 suites are in that state today — so the flag was only
-  # ever suppressing a REAL replay failure (a drifted prompt hash, a model/version move, a pass
-  # rate under the baselines.json floor). That is the one outcome the gate exists to surface.
-  # Remaining graduation step is --require-recordings, once every suite has a committed run;
-  # that is about coverage, not about whether a failure blocks.
+  # meaning than it looked like: the runner already treated a charter with no recorded run as
+  # ::warning and exited 0, so the flag was only suppressing a REAL replay failure (a drifted
+  # prompt hash, a model/version move, a pass rate under the baselines.json floor). That is the
+  # one outcome the gate exists to surface.
+  #
+  # GRADUATED to full ratchet-on-replay coverage (#1918). Every suite now has a committed
+  # recording in evals/recordings/, backlog.yaml is empty, and CI runs with --require-recordings.
+  # The ratchet is therefore blocking for every charter with a declared suite: a new or changed
+  # suite cannot land unrecorded, and a prompt/model promotion cannot land stale or regressed.
   - id: evals-gate-replay
     name: "evals gate replay (ADR-0148, enforced)"
     group: registry
@@ -617,7 +620,7 @@ gates:
     selftest: |
       python3 .github/scripts/run-evals.py --self-test
     run: |
-      python3 .github/scripts/run-evals.py
+      python3 .github/scripts/run-evals.py --require-recordings
 
   # ADR-0160 mechanism 2 / rules.yaml: change_requirements.lineage_code_audit. Fleet-wide scan
   # (not diff-scoped): every governance.yaml lineage edge — downstream AND, since #2315,

--- a/.github/scripts/run-evals.py
+++ b/.github/scripts/run-evals.py
@@ -33,8 +33,9 @@
 # THE RUNNER MUST BE ABLE TO FAIL
 #   `--self-test` runs the assertion engine, the staleness detector and the ratchet against built-in
 #   fixtures that MUST fail and fixtures that MUST pass, and exits non-zero if any of them behaves
-#   the other way round. It is wired into CI as an ENFORCED step, ahead of the (advisory) replay, so
-#   a gate that has quietly stopped being able to go red takes the build down with it. This repo has
+#   the other way round. It is wired into CI as an ENFORCED step, ahead of the blocking replay it
+#   protects, so a gate that has quietly stopped being able to go red takes the build down with it.
+#   This repo has
 #   shipped two gates that could not fail — a reporter that crashed on every finding and a scanner
 #   that printed nothing — and both read as green for weeks.
 #
@@ -255,8 +256,9 @@ def run_replay(args, evals_dir=EVALS, recordings_dir=RECORDINGS, prompts_dir=PRO
     if pending:
         stream.write(
             f"::warning title=Evals gate::{len(pending)} charter(s) have an eval suite but no "
-            f"recorded run yet, so nothing is being replayed for them: {', '.join(sorted(pending))}. "
-            f"Record one with `run-evals.py --record <charter>` against the charter's live model.\n")
+            f"recorded run yet, so replay is advisory for them only: {', '.join(sorted(pending))}. "
+            f"Charters with a committed recording are still blocking. Record one with "
+            f"`run-evals.py --record <charter>` against the charter's live model.\n")
         if args.require_recordings:
             failed.extend(pending)
 
@@ -290,8 +292,11 @@ def run_replay(args, evals_dir=EVALS, recordings_dir=RECORDINGS, prompts_dir=PRO
         stream.write(f"::error::run-evals: {len(problems)} charter(s) failed the evals gate.\n")
         return 1
 
-    stream.write(f"evals-gate: {len(ok)} charter(s) replayed clean, {len(pending)} awaiting a "
-                 f"first recording, {len(suites)} suite(s) total.\n")
+    stream.write(
+        f"evals-gate: blocking replay passed for {len(ok)} charter(s) with recorded baselines; "
+        f"{len(pending)} charter(s) remain advisory awaiting a first recording; "
+        f"{len(suites)} suite(s) total.\n"
+    )
     return 0
 
 

--- a/docs/adr/0148-ai-assurance-prompt-registry-evals-gate-and-eu-ai-act-mapping.md
+++ b/docs/adr/0148-ai-assurance-prompt-registry-evals-gate-and-eu-ai-act-mapping.md
@@ -53,11 +53,17 @@ summary: "Add an AI assurance layer: an in-repo versioned prompt registry that e
 > (`compliance-officer`, `ui-assistant`, `customer-copilot`) are extracted into the registry
 > with eval suites, taking coverage from 2 charters to 5.
 >
-> **Still open after this increment:** services load their prompt from the registry rather
-> than an inline `buildString` (so a deployed `prompt_hash` resolves and byte-for-byte parity
-> can be checked); the first *recorded* run for any charter — none exists yet, so replay is
-> advisory and warns rather than gates; the six `pending` stub ops-agents (ADR-0112 P4,
-> ADR-0164–0168).
+> **Update (2026-08-02, issue #1918) — replay graduation ships.** All five suites now have a
+> committed first recording under `openbank-libs/governance/evals/recordings/`,
+> `recordings/backlog.yaml` is empty, and CI runs `run-evals.py --require-recordings`. The
+> ratchet is now blocking for every charter that declares a suite: a new or changed suite cannot
+> land unrecorded, and a prompt/model promotion cannot land stale or regressed. Charters with no
+> suite yet remain structural backlog in `check-evals-registry.py`; the replay gate is scoped only
+> to charters that have crossed that baseline line.
+>
+> **Still open after this increment:** services load their prompt from the registry rather than an
+> inline `buildString` (so a deployed `prompt_hash` resolves and byte-for-byte parity can be
+> checked); the six `pending` stub ops-agents (ADR-0112 P4, ADR-0164–0168).
 
 ## Context
 

--- a/openbank-libs/governance/evals/README.md
+++ b/openbank-libs/governance/evals/README.md
@@ -69,18 +69,19 @@ model swap cannot land without re-recording, and a re-recording that drops below
 PR. That is ADR-0148's decision expressed as a check: replaying yesterday's answers proves nothing
 about a model you did not change, and everything about one you did.
 
-**A charter with no recording yet** is an advisory `::warning`, not a pass — nothing is being
-replayed for it. `--require-recordings` graduates that to a hard failure once every suite has a run
-(ADR-0144's advisory→enforced path). Never hand-write a recording to clear the warning: a fabricated
-recording is a green gate over behaviour nobody observed.
+**Graduated behavior (2026-08-02).** Every suite currently in this tree has a committed recording,
+so CI runs replay with `--require-recordings`: for any charter that has a suite, a missing first
+recording is now a hard failure, not a warning. The ratchet is still scoped to declared suites only,
+so a charter with no suite yet remains backlog in `check-evals-registry.py`; once a suite exists,
+it must land with a real recording in the same PR. Never hand-write a recording to clear the gate:
+a fabricated recording is a green gate over behaviour nobody observed.
 
 **Proving the gate can go red.** `run-evals.py --self-test` runs the assertion engine, the staleness
-detector and the ratchet against twelve fixtures that each declare the exit code they must produce —
-one must-pass, eleven must-fail (empty output, missing substring, an obeyed prompt injection, a
-dropped scenario, a bumped suite version, an edited prompt, a missing `model_id`, an unevaluatable
-assertion key, …) — and exits non-zero if any behaves the other way round. It is wired into CI as an
-**enforced** step *ahead of* the advisory replay, so a runner that has quietly lost the ability to
-fail takes the build down with it rather than reporting green.
+detector and the ratchet against fixtures that each declare the exit code they must produce — both
+must-pass and must-fail cases, including the `--require-recordings` graduation path — and exits
+non-zero if any behaves the other way round. It is wired into CI as an **enforced** step *ahead of*
+the blocking replay, so a runner that has quietly lost the ability to fail takes the build down with
+it rather than reporting green.
 
 ## Which charters count as coverage backlog
 

--- a/openbank-libs/governance/evals/recordings/README.md
+++ b/openbank-libs/governance/evals/recordings/README.md
@@ -33,8 +33,15 @@ python3 .github/scripts/run-evals.py           # replay it back; must exit 0
 Commit the resulting `<charter>.json` in the same PR as the prompt or model change it justifies —
 a recording landing alone is a promotion with no reviewed cause.
 
+## First baseline, now blocking
+
+As of 2026-08-02, every suite in `../` has a committed recording and CI runs
+`run-evals.py --require-recordings`. That makes these files the first recorded baselines for the
+ADR-0148 ratchet: once a suite exists, its first recording is required on the PR that adds or
+changes it, and replay blocks on staleness or regression without needing live model credentials.
+
 ## Do not hand-write one
 
 A fabricated recording is a green gate over behaviour nobody observed, which is strictly worse than
-the honest `::warning` an absent recording produces today. If a charter has no run yet, leave it
-absent.
+the honest gap it pretends to close. If a charter has no run yet, record it off-CI with a real
+model call; once the suite is declared, CI requires that real recording.

--- a/openbank-libs/governance/evals/recordings/backlog.yaml
+++ b/openbank-libs/governance/evals/recordings/backlog.yaml
@@ -27,7 +27,8 @@
 # behaviour nobody observed — worse than the gap it hides, because the gap is at least visible.
 
 awaiting_first_recording: {}
-# Empty, and that is the point: every eval suite in the tree now has a recorded run, so the ratchet
-# replays all 5 rather than counting suites that replay nothing. Both entries that used to sit here
-# were closed by RECORDING, never by deleting the entry — the gate fails on a stale declaration in
-# either direction, so an entry cannot be cleared while the gap is real.
+# Empty, and that is the point: every eval suite in the tree now has a recorded run, so CI can run
+# `run-evals.py --require-recordings` and block on replay for all 5 rather than counting suites that
+# replay nothing. Both entries that used to sit here were closed by RECORDING, never by deleting the
+# entry — the gate fails on a stale declaration in either direction, so an entry cannot be cleared
+# while the gap is real.


### PR DESCRIPTION
## Summary

Graduate the ADR-0148 evals replay gate from partially advisory to fully blocking for declared suites now that every suite has a committed first recording. CI now requires recordings for any charter that declares a suite and the docs/ADR text reflect the recorded-baseline ratchet behavior.

## Type of change

- [ ] feat (new functionality)
- [ ] fix (bug fix)
- [ ] refactor (no behavior change)
- [ ] perf (performance)
- [ ] docs
- [x] chore (build / tooling)
- [ ] security (private until disclosed)
- [ ] breaking change

## Linked issues

Refs #1918

## Changes

- enforce `.github/scripts/run-evals.py --require-recordings` in the CI gate now that all five suites have committed recordings
- update the runner and evals docs to describe the day-one ratchet semantics: recorded suites block, undeclared suite backlog stays structural in `check-evals-registry.py`
- record the ADR-0148 delivery update for replay graduation and clarify that `recordings/backlog.yaml` is intentionally empty because the first baseline exists for every current suite

## Definition of Done

- [x] Hexagonal layering preserved (domain has zero framework imports).
- [ ] Unit tests added/updated.
- [ ] Integration tests added/updated (if service boundary involved).
- [ ] Contract tests updated (if public API changed).
- [x] `./gradlew detekt ktlintCheck koverVerify build` passes.
- [x] No new lint warnings.
- [ ] OpenAPI spec regenerated (if REST API changed).
- [ ] Flyway migration added + rollback note (if DB changed).
- [ ] Avro schema versioned backward-compatibly (if event changed).
- [x] Docs updated (README, ADR if architectural).

## Security checklist

- [x] No secrets, tokens, passwords, or PII in code, config, tests, logs.
- [x] No new `@SuppressWarnings`, `as Any`, `@Suppress("...")` without
      justification (state it in this PR).
- [x] No new third-party dependency, OR: dependency review attached
      (license, CVE, source).
- [ ] Auth / crypto / payment code changed? → tag `security-review-required`.
- [ ] PII path changed? → tag `gdpr-review-required`.
- [ ] Cardholder data path changed? → tag `pci-review-required`.

## Compliance impact

<!-- Mark all that apply -->
- [ ] PCI DSS
- [x] DORA
- [ ] GDPR
- [ ] PSD2 / SCA / RTS
- [ ] AML / 5AMLD
- [ ] CNB reporting
- [ ] None

If any are marked, describe the impact and any required compensating
controls below.

ADR-0148's AI-assurance replay control now blocks prompt/model promotions for any charter with a declared suite and committed recording. The gate still leaves undeclared suites as structural backlog in `check-evals-registry.py`, so the fleet is green on day one while recorded suites are enforced.

## Rollout / Rollback

- Deployment strategy: rolling
- Rollback plan: revert this commit to restore advisory-on-missing-recording behavior and CI gate wiring
- Data migration reversible: N/A

## Screenshots / demo (if UI change)

<!-- attach -->

## Reviewer notes

- Local validation: `python3 .github/scripts/run-evals.py --require-recordings`, `python3 .github/scripts/run-evals.py --self-test`, `python3 .github/scripts/check-prompt-registry.py`, `python3 .github/scripts/check-evals-registry.py`
- The first replay baseline is the existing committed recordings under `openbank-libs/governance/evals/recordings/*.json`; no live model calls were made in this PR.
