### PR TITLE
fix(observability): the platform had no logs for seven days — Loki's disk was full and Alloy was OOMKilled

### DIFF
--- a/openbank-infra/gitops/apps/alloy.yaml
+++ b/openbank-infra/gitops/apps/alloy.yaml
@@ -83,13 +83,28 @@ spec:
           # DaemonSet overhead by ~180Mi — a key ingredient of the 4Gi-node memory
           # exhaustion / reclaim-livelock hangs. The request must reflect reality
           # for Karpenter's bin-packing to be honest.
+          # 512Mi → 768Mi (2026-08-02). Measured with Loki HEALTHY, so this is the
+          # steady state and not a backlog artefact: across the 20 pods that were
+          # still alive, median 415Mi / p90 452Mi / max 458Mi against a 512Mi cap —
+          # 14 of 20 over 400Mi. Six more had already been OOMKilled, so the true
+          # requirement is above 458Mi; those are survivors.
+          #
+          # The OOMs were NOT a consequence of Loki being full, which is what I
+          # first assumed: all six died 3-4 minutes AFTER Loki was ready and
+          # draining. 512Mi is simply undersized for the log volume on the busiest
+          # nodes.
+          #
+          # FinOps: only the LIMIT moves; the 320Mi request is unchanged, so
+          # Karpenter's bin-packing and node count are unaffected. The cost is
+          # headroom the pods may use, not capacity reserved up front — and the
+          # alternative is a DaemonSet that crashloops and drops the fleet's logs.
           resources:
             requests:
               cpu: 50m
               memory: 320Mi
             limits:
               cpu: 300m
-              memory: 512Mi
+              memory: 768Mi
           configMap:
             content: |-
               // ---- discover every pod on this node ----

--- a/openbank-infra/gitops/apps/loki.yaml
+++ b/openbank-infra/gitops/apps/loki.yaml
@@ -145,7 +145,27 @@ spec:
               effect: NoSchedule
           persistence:
             enabled: true
-            size: 10Gi
+            # 10Gi → 30Gi (2026-08-02). The PVC hit 100% (9.73/9.75 GiB) and Loki
+            # entered a self-sustaining crashloop: no space to replay the WAL → it
+            # never started → nothing drained to S3 → the disk stayed full. 339
+            # restarts, and the platform had NO logs for seven days (last S3 index
+            # was index_20660 = 26 Jul; the whole bucket held 119 MB).
+            #
+            # This disk is not where chunks live — those go to S3 (storage.type
+            # above). It holds the WAL and the TSDB index scratch, and 10Gi was too
+            # little for that at 7d retention across ~120 pods.
+            #
+            # DEPLOY NOTE: volumeClaimTemplates is IMMUTABLE on a StatefulSet, so
+            # this change alone cannot resize the existing PVC and a plain sync is
+            # rejected. The live PVC was expanded in place first (gp3 has
+            # allowVolumeExpansion: true, online, no data loss); this commit makes
+            # it the declared state. To apply on a fresh cluster nothing special is
+            # needed; to reconcile THIS cluster the StatefulSet must be recreated
+            # with `kubectl delete sts loki --cascade=orphan` so pods and PVCs
+            # survive and ArgoCD rebuilds it from the new template.
+            #
+            # FinOps: +20Gi gp3 ≈ +$1.60/month.
+            size: 30Gi
             storageClass: gp3
           # 768Mi OOMKilled the SingleBinary loki (exit 137, crashloop) — TSDB +
           # ingester + querier + distributor in one process need real headroom, and


### PR DESCRIPTION
Refs #3071

Found by reading `KubePodCrashLooping` — which was firing **27 times**, unread.

## The platform had no logs for seven days

**Loki** was in a self-sustaining crashloop. The PVC was at 100% (9.73 / 9.75 GiB), so there was no space to replay the WAL → the process never started → nothing drained to S3 → the disk stayed full. **339 restarts.**

The evidence that this was not merely slow but stopped:

```
last S3 index prefix : index_20660  = 26 July   (today is 2 August)
whole bucket         : 2451 objects / 119.7 MB
```

The disk is **not** where chunks live — those go to S3 (`storage.type: s3`). It holds the WAL and the TSDB index scratch, and 10Gi was too little at 7d retention across ~120 pods. Raised to **30Gi** — gp3 at ~$0.08/GB-month, so **+$1.60/month**.

After expanding the live PVC in place (gp3 has `allowVolumeExpansion`, online, no data loss):

| | before | after |
|---|---|---|
| `loki-0` | crashloop, 339 restarts | **ready, 0 restarts** |
| `no space left` in log | the crash cause | **0 occurrences** |
| S3 objects | 2 451 / 119.7 MB | **30 398 / 243.7 MB** |
| S3 index | stuck at 26 Jul | **index_20665 / 20666 / 20667** (through today) |

The index lagged the chunks by ~10 minutes. I deliberately did not call the fix complete until it moved — chunks without an index are stored but **not queryable**, which would have looked fixed and not been.

## Alloy — and an assumption of mine that was wrong

512Mi was undersized. Measured with **Loki healthy**, so this is steady state rather than a backlog artefact:

```
20 surviving pods: median 415Mi · p90 452Mi · max 458Mi   (limit 512Mi)
14 of 20 over 400Mi
```

Six more had already been OOMKilled, so the real requirement is above 458Mi — the sample is survivors.

**I had assumed the OOMs were a consequence of Loki being full**, and deliberately held off raising the limit so as not to add memory fleet-wide for nothing. That assumption was wrong: all six died **3–4 minutes after** Loki was ready and draining. Raised to **768Mi**.

Only the **limit** moves. The 320Mi request is unchanged, so Karpenter's bin-packing and the node count are unaffected — the cost is headroom the pods may use, not capacity reserved up front. `KarpenterNodePoolNearLimit` is currently firing, which is why that distinction mattered enough to check.

## Deploy note — this one will not sync on its own

`volumeClaimTemplates` is **immutable** on a StatefulSet, so this commit cannot resize the existing PVC and a plain sync of it is rejected. The live PVC was already expanded by hand; this commit makes that the declared state.

To reconcile **this** cluster:

```
kubectl delete sts loki --cascade=orphan
```

Pods and PVCs survive; ArgoCD rebuilds the StatefulSet from the new template. A fresh cluster needs nothing special. This is written into the manifest too, not just here.

## Scope

This is point 1 of the ten-point programme. It is the unblocker: every other observability improvement was being built on a stack that had not stored a log since 26 July.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
