### PR TITLE
feat(admin-ui): make the lending console a credit desk, not a table dump

### DIFF
--- a/openbank-admin-ui/src/app/lending/page.tsx
+++ b/openbank-admin-ui/src/app/lending/page.tsx
@@ -2,27 +2,39 @@
 // Copyright (c) OpenBank contributors. Licensed under the Apache License, Version 2.0.
 // See LICENSE in the repository root or https://www.apache.org/licenses/LICENSE-2.0 for details.
 
-// ADR-0230 D1: the lending console, read views first — the origination queue (recent
-// applications fleet-wide) and the active-loan portfolio. Mutations deliberately absent:
-// credit decisions, disbursements and write-offs live in the approval inbox (ADR-0227),
-// never as direct writes from this page.
+// The credit desk's working surface (ADR-0230 D1).
+//
+// WHAT WAS WRONG WITH THE OLD SCREEN
+// Two flat tables of raw enum strings. That answers "which applications exist" — a question a
+// database answers. It does not answer the questions an underwriter, a credit-risk analyst or a
+// lending officer actually open a console with:
+//   - what is waiting on a decision, and how long has it waited
+//   - where is the pipeline JAMMED
+//   - how big is the book and what is going wrong in it
+// So the primary object is now the STAGE, not the row, and every number is either actionable or
+// labelled as not-a-total. Rows stay, one level down, filtered by clicking a stage.
+//
+// HONESTY ABOUT THE NUMBERS
+// `/applications/recent` and `/loans/active` are capped lists (the server clamps limit to 1..100).
+// Nothing here may present a capped count as a book total: "12 waiting" when 300 wait is a staffing
+// decision made on a wrong number. The cap travels with the figure, and a full page is called out.
+//
+// Mutations stay absent, as before: decisions, disbursements and write-offs live in the approval
+// inbox (ADR-0227 D4), and the per-application screen links there.
 
 'use client'
 
-import { useCallback, useEffect, useState } from 'react'
+import { useCallback, useEffect, useMemo, useState } from 'react'
 import Link from 'next/link'
-import { RefreshCw, TrendingUp } from 'lucide-react'
+import { RefreshCw, TrendingUp, Layers, Wallet, AlertTriangle, Clock } from 'lucide-react'
 import { useLanguage } from '@/lib/i18n/LanguageContext'
 import { svcUrl } from '@/lib/services/bff'
 import { EntityChip } from '@/components/entities/EntityChip'
+import { PageHeader, StatCard, StatusBadge } from '@/components/ui'
+import { STATE_LABELS } from '@/components/lending/OriginationFlow'
+import { OriginationPipeline, type PipelineItem } from '@/components/lending/OriginationPipeline'
 
-type Application = {
-  id: string
-  partyId: string
-  status: string
-  requestedAmount?: { amount: number; currency: string }
-  createdAt?: string
-}
+type Application = PipelineItem & { partyId: string }
 
 type Loan = {
   id: string
@@ -32,14 +44,25 @@ type Loan = {
   disbursedAt?: string
 }
 
-const STATUSES = ['', 'PENDING_REVIEW', 'APPROVED', 'REJECTED'] as const
+/** The server clamps to 100; ask for it explicitly so the cap is a known number rather than a
+ *  silent default we would then have to guess at when labelling the figures. */
+const LIMIT = 100
+
+/** Terminal origination states — an application here is not waiting on anybody. */
+const TERMINAL = new Set(['DISBURSED', 'WITHDRAWN', 'DECLINED', 'EXPIRED'])
+
+/** Loan states that are a problem rather than a stage. Kept small on purpose — a console that
+ *  tints everything tints nothing. */
+const LOAN_TROUBLE = new Set(['DELINQUENT', 'DEFAULTED', 'WRITTEN_OFF'])
+
+const STALE_HOURS = 72
 
 export default function LendingPage() {
-  const { t } = useLanguage()
-  const [tab, setTab] = useState<'queue' | 'portfolio'>('queue')
-  const [status, setStatus] = useState<string>('')
+  const { t, language } = useLanguage()
   const [applications, setApplications] = useState<Application[]>([])
   const [loans, setLoans] = useState<Loan[]>([])
+  const [stage, setStage] = useState<string | null>(null)
+  const [tab, setTab] = useState<'queue' | 'portfolio'>('queue')
   const [loading, setLoading] = useState(true)
   const [error, setError] = useState<string | null>(null)
 
@@ -47,50 +70,70 @@ export default function LendingPage() {
     setLoading(true)
     try {
       const [appsRes, loansRes] = await Promise.all([
-        fetch(svcUrl('lending-service', '/api/v1/lending/applications/recent', {
-          limit: '50', ...(status ? { status } : {}),
-        }), { cache: 'no-store' }),
-        fetch(svcUrl('lending-service', '/api/v1/lending/loans/active', { limit: '50' }), { cache: 'no-store' }),
+        fetch(svcUrl('lending-service', '/api/v1/lending/applications/recent', { limit: String(LIMIT) }), { cache: 'no-store' }),
+        fetch(svcUrl('lending-service', '/api/v1/lending/loans/active', { limit: String(LIMIT) }), { cache: 'no-store' }),
       ])
       if (!appsRes.ok || !loansRes.ok) throw new Error(`${appsRes.status}/${loansRes.status}`)
-      setApplications(await appsRes.json())
-      setLoans(await loansRes.json())
+      const apps = await appsRes.json()
+      const ln = await loansRes.json()
+      setApplications(Array.isArray(apps) ? apps : [])
+      setLoans(Array.isArray(ln) ? ln : [])
       setError(null)
     } catch {
       setError('unreachable')
     } finally {
       setLoading(false)
     }
-  }, [status])
+  }, [])
 
   useEffect(() => { void load() }, [load])
+
+  const label = (s: string) => {
+    const l = STATE_LABELS[s]
+    return l ? (language === 'cs' ? l.cs : l.en) : s
+  }
 
   const fmt = (m?: { amount: number; currency: string }) =>
     m ? `${m.amount.toLocaleString('cs-CZ')} ${m.currency}` : '—'
 
+  const money = (n: number, ccy: string) => `${Math.round(n).toLocaleString('cs-CZ')} ${ccy}`
+
+  /** Headline figures, all computed from the SAME capped lists the tables show — so the page can
+   *  never claim more than it fetched. */
+  const kpi = useMemo(() => {
+    const ccy = loans[0]?.principal?.currency ?? applications[0]?.requestedAmount?.currency ?? 'CZK'
+    const book = loans.reduce((s, l) => s + (l.principal?.amount ?? 0), 0)
+    const trouble = loans.filter(l => LOAN_TROUBLE.has(l.status))
+    const now = Date.now()
+    const open = applications.filter(a => !TERMINAL.has(a.status))
+    const stale = open.filter(a => a.createdAt && now - new Date(a.createdAt).getTime() > STALE_HOURS * 3_600_000)
+    const requested = open.reduce((s, a) => s + (a.requestedAmount?.amount ?? 0), 0)
+    return { ccy, book, trouble, open, stale, requested }
+  }, [loans, applications])
+
+  const visibleApps = useMemo(
+    () => (stage ? applications.filter(a => a.status === stage) : applications),
+    [applications, stage],
+  )
+
+  const th = { padding: '10px 14px', fontSize: 11, color: 'var(--text-tertiary)' } as const
+  const td = { padding: '10px 14px' } as const
+
   return (
     <div>
-      <div className="page-header">
-        <div>
-          <div className="breadcrumb">
-            <span>OpenBank</span><span className="breadcrumb-sep">/</span>
-            <span className="breadcrumb-current">{t('Úvěry', 'Lending')}</span>
-          </div>
-          <h1 className="page-title" style={{ display: 'flex', alignItems: 'center', gap: 8 }}>
-            <TrendingUp size={18} style={{ color: 'var(--accent)' }} />
-            {t('Úvěrová konzole', 'Lending console')}
-          </h1>
-          <p className="page-subtitle">
-            {t(
-              'Čtecí přehled (ADR-0230). Rozhodnutí, čerpání a odpisy se řeší výhradně přes frontu schvalování (maker-checker).',
-              'Read views (ADR-0230). Decisions, disbursements and write-offs are handled exclusively via the approval inbox (maker-checker).',
-            )}
-          </p>
-        </div>
-        <button onClick={load} disabled={loading} className="btn btn-secondary" style={{ display: 'flex', alignItems: 'center', gap: 6, fontSize: 12 }}>
-          <RefreshCw size={14} className={loading ? 'animate-spin' : ''} /> {t('Obnovit', 'Refresh')}
-        </button>
-      </div>
+      <PageHeader
+        title={t('Úvěrová konzole', 'Lending console')}
+        subtitle={t(
+          'Kde stojí pipeline, co čeká na rozhodnutí a jak je na tom portfolio. Rozhodnutí, čerpání a odpisy se schvalují ve frontě schvalování (ADR-0227).',
+          'Where the pipeline stands, what waits on a decision, and how the book is doing. Decisions, disbursements and write-offs are approved in the approval inbox (ADR-0227).',
+        )}
+        icon={<TrendingUp size={18} style={{ color: 'var(--accent)' }} />}
+        actions={
+          <button onClick={load} disabled={loading} className="btn btn-secondary" style={{ display: 'flex', alignItems: 'center', gap: 6, fontSize: 12 }}>
+            <RefreshCw size={14} className={loading ? 'animate-spin' : ''} /> {t('Obnovit', 'Refresh')}
+          </button>
+        }
+      />
 
       {error && (
         <div className="card" style={{ padding: 12, marginBottom: 16, borderLeft: '3px solid var(--danger)', color: 'var(--danger)', fontSize: 13 }}>
@@ -98,7 +141,46 @@ export default function LendingPage() {
         </div>
       )}
 
-      <div style={{ display: 'flex', gap: 4, marginBottom: 14 }}>
+      <div className="grid-4" style={{ marginBottom: 20 }}>
+        <StatCard
+          label={t('Aktivní úvěry', 'Active loans')}
+          value={loans.length}
+          hint={t(`jistina ${money(kpi.book, kpi.ccy)}`, `principal ${money(kpi.book, kpi.ccy)}`)}
+          icon={<Wallet size={13} />}
+        />
+        <StatCard
+          label={t('Žádosti v běhu', 'Applications in flight')}
+          value={kpi.open.length}
+          hint={t(`požadováno ${money(kpi.requested, kpi.ccy)}`, `requested ${money(kpi.requested, kpi.ccy)}`)}
+          icon={<Layers size={13} />}
+        />
+        <StatCard
+          label={t('Čeká přes 72 h', 'Waiting over 72h')}
+          value={kpi.stale.length}
+          tone={kpi.stale.length > 0 ? 'warning' : undefined}
+          hint={t('nerozhodnuté a stárnoucí', 'undecided and aging')}
+          icon={<Clock size={13} />}
+        />
+        <StatCard
+          label={t('Problémové úvěry', 'Loans in trouble')}
+          value={kpi.trouble.length}
+          tone={kpi.trouble.length > 0 ? 'danger' : undefined}
+          hint={t('po splatnosti / default / odpis', 'delinquent / default / written off')}
+          icon={<AlertTriangle size={13} />}
+        />
+      </div>
+
+      <div style={{ marginBottom: 20 }}>
+        <OriginationPipeline
+          items={applications}
+          cap={LIMIT}
+          lang={language}
+          selected={stage}
+          onSelectStage={s => { setStage(s); setTab('queue') }}
+        />
+      </div>
+
+      <div style={{ display: 'flex', gap: 4, marginBottom: 12, alignItems: 'center', flexWrap: 'wrap' }}>
         {(['queue', 'portfolio'] as const).map(id => (
           <button
             key={id}
@@ -109,18 +191,13 @@ export default function LendingPage() {
               color: tab === id ? '#fff' : 'var(--text-secondary)',
             }}
           >
-            {id === 'queue' ? t('Fronta žádostí', 'Applications queue') : t('Aktivní úvěry', 'Active loans')}
+            {id === 'queue' ? t('Fronta žádostí', 'Applications queue') : t('Portfolio', 'Portfolio')}
           </button>
         ))}
-        {tab === 'queue' && (
-          <select
-            value={status}
-            onChange={e => setStatus(e.target.value)}
-            style={{ marginLeft: 'auto', fontSize: 12, padding: '4px 8px', borderRadius: 6, border: '1px solid var(--border)', background: 'var(--surface)' }}
-            aria-label={t('Filtr stavu', 'Status filter')}
-          >
-            {STATUSES.map(s => <option key={s} value={s}>{s === '' ? t('Všechny stavy', 'All statuses') : s}</option>)}
-          </select>
+        {stage && tab === 'queue' && (
+          <button onClick={() => setStage(null)} className="btn btn-secondary" style={{ fontSize: 11 }} data-testid="clear-stage">
+            {t('Filtr:', 'Filter:')} {label(stage)} ✕
+          </button>
         )}
       </div>
 
@@ -128,29 +205,27 @@ export default function LendingPage() {
         <table style={{ width: '100%', borderCollapse: 'collapse', fontSize: 13 }}>
           <thead>
             <tr style={{ background: 'var(--surface-2)', textAlign: 'left' }}>
-              <th style={{ padding: '10px 14px', fontSize: 11, color: 'var(--text-tertiary)' }}>{t('Klient', 'Party')}</th>
-              <th style={{ padding: '10px 14px', fontSize: 11, color: 'var(--text-tertiary)' }}>{t('Částka', 'Amount')}</th>
-              <th style={{ padding: '10px 14px', fontSize: 11, color: 'var(--text-tertiary)' }}>{t('Stav', 'Status')}</th>
-              <th style={{ padding: '10px 14px', fontSize: 11, color: 'var(--text-tertiary)' }}>
-                {tab === 'queue' ? t('Podáno', 'Submitted') : t('Čerpáno', 'Disbursed')}
-              </th>
-              {tab === 'queue' && (
-                <th style={{ padding: '10px 14px', fontSize: 11, color: 'var(--text-tertiary)' }} />
-              )}
+              <th style={th}>{t('Klient', 'Party')}</th>
+              <th style={th}>{t('Částka', 'Amount')}</th>
+              <th style={th}>{t('Stav', 'Status')}</th>
+              <th style={th}>{tab === 'queue' ? t('Podáno', 'Submitted') : t('Čerpáno', 'Disbursed')}</th>
+              {tab === 'queue' && <th style={th} />}
             </tr>
           </thead>
           <tbody>
-            {tab === 'queue' && applications.map(a => (
+            {tab === 'queue' && visibleApps.map(a => (
               <tr key={a.id} style={{ borderTop: '1px solid var(--border)' }}>
-                <td style={{ padding: '10px 14px' }}><EntityChip type="party" id={a.partyId} /></td>
-                <td style={{ padding: '10px 14px', fontWeight: 600 }}>{fmt(a.requestedAmount)}</td>
-                <td style={{ padding: '10px 14px' }}><span className="pill">{a.status}</span></td>
-                <td style={{ padding: '10px 14px', color: 'var(--text-tertiary)', fontSize: 12 }}>
+                <td style={td}><EntityChip type="party" id={a.partyId} /></td>
+                <td style={{ ...td, fontWeight: 600 }}>{fmt(a.requestedAmount)}</td>
+                {/* The human label is what a credit officer reads; the raw state stays as the title
+                    so the screen and the machine can never be describing different things. */}
+                <td style={td}>
+                  <span title={a.status}><StatusBadge status={a.status} label={label(a.status)} /></span>
+                </td>
+                <td style={{ ...td, color: 'var(--text-tertiary)', fontSize: 12 }}>
                   {a.createdAt ? new Date(a.createdAt).toLocaleString() : '—'}
                 </td>
-                {/* The row answers "which applications exist"; the desk's next question is always
-                    "where is this one and what is it waiting for" — that lives on the flow page. */}
-                <td style={{ padding: '10px 14px' }}>
+                <td style={td}>
                   <Link href={`/lending/applications/${a.id}`} style={{ color: 'var(--accent)', fontSize: 12 }}>
                     {t('Průběh', 'Progress')} ›
                   </Link>
@@ -159,17 +234,21 @@ export default function LendingPage() {
             ))}
             {tab === 'portfolio' && loans.map(l => (
               <tr key={l.id} style={{ borderTop: '1px solid var(--border)' }}>
-                <td style={{ padding: '10px 14px' }}><EntityChip type="party" id={l.partyId} /></td>
-                <td style={{ padding: '10px 14px', fontWeight: 600 }}>{fmt(l.principal)}</td>
-                <td style={{ padding: '10px 14px' }}><span className="pill">{l.status}</span></td>
-                <td style={{ padding: '10px 14px', color: 'var(--text-tertiary)', fontSize: 12 }}>
+                <td style={td}><EntityChip type="party" id={l.partyId} /></td>
+                <td style={{ ...td, fontWeight: 600 }}>{fmt(l.principal)}</td>
+                <td style={td}>
+                  <StatusBadge status={l.status} tone={LOAN_TROUBLE.has(l.status) ? 'danger' : undefined} />
+                </td>
+                <td style={{ ...td, color: 'var(--text-tertiary)', fontSize: 12 }}>
                   {l.disbursedAt ? new Date(l.disbursedAt).toLocaleString() : '—'}
                 </td>
               </tr>
             ))}
-            {!loading && ((tab === 'queue' && applications.length === 0) || (tab === 'portfolio' && loans.length === 0)) && (
+            {!loading && ((tab === 'queue' && visibleApps.length === 0) || (tab === 'portfolio' && loans.length === 0)) && (
               <tr><td colSpan={tab === 'queue' ? 5 : 4} style={{ padding: 20, textAlign: 'center', color: 'var(--text-tertiary)', fontSize: 13 }}>
-                {t('Žádné záznamy', 'No records')}
+                {stage && tab === 'queue'
+                  ? t(`Ve stavu „${label(stage)}“ nic není.`, `Nothing in “${label(stage)}”.`)
+                  : t('Žádné záznamy', 'No records')}
               </td></tr>
             )}
           </tbody>

--- a/openbank-admin-ui/src/components/lending/OriginationPipeline.tsx
+++ b/openbank-admin-ui/src/components/lending/OriginationPipeline.tsx
@@ -1,0 +1,220 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright (c) OpenBank contributors. Licensed under the Apache License, Version 2.0.
+// See LICENSE in the repository root or https://www.apache.org/licenses/LICENSE-2.0 for details.
+
+// The origination pipeline as a credit desk reads it: where the book is, where it is STUCK, and
+// what is aging. Same animated engine as the service map (FlowParticle / NodeShadow / reduced-motion
+// respected) — that page is the house benchmark for "a diagram that teaches", and the lending
+// console had none of it.
+//
+// WHAT THE DESIGN IS FOR
+// A flat table answers "which applications exist". An underwriter's first question is never that —
+// it is "what is waiting on me, and how long has it waited". So the primary object here is a STAGE,
+// sized by how much sits in it and tinted by how long the oldest item has been there. The
+// application rows stay, one level down.
+//
+// THE CAP IS PART OF THE PICTURE, NOT A FOOTNOTE
+// `/applications/recent` is a capped list (server clamps limit to 1..100). Counts here are therefore
+// "of the newest N", never the book. Rendering them as totals would be worse than useless to a
+// credit officer: "12 waiting" when 300 wait is a staffing decision made on a wrong number. The cap
+// is shown next to the count and the component refuses to imply otherwise.
+
+'use client'
+
+import { useMemo } from 'react'
+import { FlowParticle } from '@/components/topology/FlowParticle'
+import { NodeShadow } from '@/components/topology/TopologyDefs'
+import { useFlowAnimation } from '@/components/topology/useFlowAnimation'
+import { ORIGINATION_GRAPH, STATE_LABELS, happyPath, exitStates } from './OriginationFlow'
+
+export type PipelineItem = {
+  id: string
+  status: string
+  createdAt?: string
+  requestedAmount?: { amount: number; currency: string }
+}
+
+type Props = {
+  items: PipelineItem[]
+  /** The server-side cap the list was fetched under — shown, never hidden. */
+  cap: number
+  lang?: 'cs' | 'en'
+  onSelectStage?: (state: string | null) => void
+  selected?: string | null
+}
+
+/** Hours the oldest item in a stage has waited → a tone. Thresholds are DELIBERATELY coarse: an
+ *  underwriter needs "fine / slipping / stuck", not a gradient nobody can act on.
+ *
+ *  TERMINAL STATES ARE NEVER TONED BY AGE. A loan that was disbursed four days ago is not a
+ *  four-day-old problem — it is a finished one, and painting it red tells a credit officer there
+ *  are nine problems where there are none. Age only means something while something is WAITING. */
+function ageTone(hours: number | null, terminal: boolean): 'ok' | 'warn' | 'bad' | 'done' {
+  if (terminal) return 'done'
+  if (hours === null) return 'ok'
+  if (hours >= 72) return 'bad'
+  if (hours >= 24) return 'warn'
+  return 'ok'
+}
+
+const TONE_COLOR: Record<'ok' | 'warn' | 'bad' | 'done', string> = {
+  ok: 'var(--success)',
+  warn: 'var(--warning)',
+  bad: 'var(--danger)',
+  done: 'var(--text-tertiary)',
+}
+
+/** Split a stage name onto at most two lines at a word boundary. */
+export function wrap(text: string, max = 15): string[] {
+  if (text.length <= max) return [text]
+  const words = text.split(' ')
+  const lines: string[] = ['']
+  for (const w of words) {
+    const candidate = lines[lines.length - 1] ? `${lines[lines.length - 1]} ${w}` : w
+    if (candidate.length <= max || lines[lines.length - 1] === '') lines[lines.length - 1] = candidate
+    else lines.push(w)
+  }
+  return lines.slice(0, 2)
+}
+
+export function summarise(items: PipelineItem[], now = Date.now()) {
+  const byState = new Map<string, { count: number; oldestHours: number | null; amount: number }>()
+  for (const it of items) {
+    const cur = byState.get(it.status) ?? { count: 0, oldestHours: null, amount: 0 }
+    cur.count += 1
+    cur.amount += it.requestedAmount?.amount ?? 0
+    if (it.createdAt) {
+      const h = (now - new Date(it.createdAt).getTime()) / 3_600_000
+      if (Number.isFinite(h)) cur.oldestHours = cur.oldestHours === null ? h : Math.max(cur.oldestHours, h)
+    }
+    byState.set(it.status, cur)
+  }
+  return byState
+}
+
+export function OriginationPipeline({ items, cap, lang = 'cs', onSelectStage, selected }: Props) {
+  const [flow, setFlow] = useFlowAnimation()
+  const spine = happyPath(ORIGINATION_GRAPH)
+  const exits = exitStates(ORIGINATION_GRAPH)
+  const byState = useMemo(() => summarise(items), [items])
+  const max = Math.max(1, ...[...byState.values()].map(v => v.count))
+
+  const label = (s: string) => {
+    const l = STATE_LABELS[s]
+    return l ? (lang === 'cs' ? l.cs : l.en) : s
+  }
+  const t = (cs: string, en: string) => (lang === 'cs' ? cs : en)
+
+  // Geometry: one column per stage, laid out in an SVG so the connectors can carry motion the way
+  // the topology pages do. Width is driven by the stage count, and the viewBox scales it down —
+  // 13 stages will not fit at a readable fixed width, and a horizontally scrolled pipeline hides
+  // exactly the jam the operator opened the page to find.
+  const COL = 118
+  const H = 158
+  const W = spine.length * COL
+
+  const capped = items.length >= cap
+
+  return (
+    <div>
+      <div style={{ display: 'flex', alignItems: 'baseline', gap: 10, marginBottom: 8, flexWrap: 'wrap' }}>
+        <div className="section-title" style={{ margin: 0 }}>{t('Pipeline žádostí', 'Application pipeline')}</div>
+        <span style={{ fontSize: 11, color: capped ? 'var(--warning)' : 'var(--text-tertiary)' }} data-testid="cap-note">
+          {capped
+            ? t(
+                `zobrazeno nejnovějších ${items.length} — starší žádosti v číslech NEJSOU`,
+                `showing the newest ${items.length} — older applications are NOT in these numbers`,
+              )
+            : t(`${items.length} žádostí (vše, co server vrátil)`, `${items.length} applications (everything the server returned)`)}
+        </span>
+        <button
+          onClick={() => setFlow(f => !f)}
+          className="btn btn-secondary"
+          style={{ marginLeft: 'auto', fontSize: 11 }}
+          aria-pressed={flow}
+        >
+          {flow ? t('Zastavit animaci', 'Pause motion') : t('Spustit animaci', 'Resume motion')}
+        </button>
+      </div>
+
+      <div className="card" style={{ padding: 12, overflowX: 'auto' }}>
+        <svg viewBox={`0 0 ${W} ${H}`} width="100%" height={H} role="img"
+             aria-label={t('Pipeline úvěrových žádostí po stavech', 'Loan application pipeline by stage')}>
+          <defs>
+            <NodeShadow id="pipe-shadow" />
+            {spine.slice(0, -1).map((s, i) => (
+              <path key={s} id={`pipe-edge-${i}`} d={`M ${i * COL + 78} 46 L ${(i + 1) * COL + 30} 46`} fill="none" />
+            ))}
+          </defs>
+
+          {/* One continuous rail under the whole pipeline. Without it an empty stage left a visible
+              gap and the pipeline read as BROKEN rather than as idle at that step. */}
+          <path d={`M 54 46 L ${(spine.length - 1) * COL + 54} 46`} stroke="var(--border)" strokeWidth={1.5} fill="none" />
+          {spine.slice(0, -1).map((s, i) => {
+            const live = (byState.get(s)?.count ?? 0) > 0
+            return (
+              <g key={`e-${s}`}>
+                <path d={`M ${i * COL + 78} 46 L ${(i + 1) * COL + 30} 46`}
+                      stroke={live ? 'var(--accent)' : 'var(--border)'} strokeWidth={live ? 2 : 1.5} fill="none" />
+                {flow && live && (
+                  <FlowParticle pathId={`pipe-edge-${i}`} color="var(--accent)" dur={2.2} begin={i * 0.18} />
+                )}
+              </g>
+            )
+          })}
+
+          {spine.map((s, i) => {
+            const st = byState.get(s)
+            const count = st?.count ?? 0
+            const tone = ageTone(st?.oldestHours ?? null, ORIGINATION_GRAPH.terminal.includes(s))
+            const cx = i * COL + 54
+            const r = 15 + (count / max) * 13
+            const isSel = selected === s
+            const lines = wrap(label(s))
+            return (
+              <g key={s} data-testid={`stage-${s}`} data-count={count} data-tone={tone}
+                 onClick={() => onSelectStage?.(isSel ? null : s)}
+                 style={{ cursor: onSelectStage ? 'pointer' : 'default' }}>
+                <title>{`${label(s)} — ${count}`}</title>
+                <circle cx={cx} cy={46} r={r} filter="url(#pipe-shadow)"
+                        fill={count ? 'var(--surface)' : 'var(--surface-2)'}
+                        stroke={count ? TONE_COLOR[tone] : 'var(--border)'}
+                        strokeWidth={isSel ? 3.5 : count ? 2 : 1.2} />
+                <text x={cx} y={51} textAnchor="middle" fontSize={count ? 15 : 12} fontWeight={700}
+                      fill={count ? 'var(--text)' : 'var(--text-tertiary)'}>{count}</text>
+                {/* Two lines rather than an ellipsis: "Čeká na rozhodnu…" and "Připraveno k čer…"
+                    are not names anybody can act on, and the stage name is the whole label. */}
+                {lines.map((line, li) => (
+                  <text key={li} x={cx} y={82 + li * 11} textAnchor="middle" fontSize={9.5} fill="var(--text-secondary)">
+                    {line}
+                  </text>
+                ))}
+                {st?.oldestHours != null && count > 0 && tone !== 'done' && (
+                  <text x={cx} y={82 + lines.length * 11 + 3} textAnchor="middle" fontSize={9} fill={TONE_COLOR[tone]} fontWeight={600}>
+                    {st.oldestHours >= 24
+                      ? t(`nejstarší ${Math.floor(st.oldestHours / 24)} d`, `oldest ${Math.floor(st.oldestHours / 24)}d`)
+                      : t(`nejstarší ${Math.floor(st.oldestHours)} h`, `oldest ${Math.floor(st.oldestHours)}h`)}
+                  </text>
+                )}
+              </g>
+            )
+          })}
+        </svg>
+      </div>
+
+      <div style={{ display: 'flex', gap: 14, flexWrap: 'wrap', marginTop: 10, fontSize: 11, alignItems: 'center' }}>
+        <span style={{ color: 'var(--text-tertiary)' }}>{t('Stáří nejstarší žádosti ve stavu:', 'Age of the oldest application in a stage:')}</span>
+        {(['ok', 'warn', 'bad'] as const).map(k => (
+          <span key={k} style={{ display: 'inline-flex', alignItems: 'center', gap: 5 }}>
+            <span style={{ width: 9, height: 9, borderRadius: '50%', background: TONE_COLOR[k] }} />
+            {k === 'ok' ? t('do 24 h', 'under 24h') : k === 'warn' ? t('24–72 h', '24–72h') : t('nad 72 h', 'over 72h')}
+          </span>
+        ))}
+        <span style={{ marginLeft: 'auto', color: 'var(--text-tertiary)' }}>
+          {t('Ukončené: ', 'Ended: ')}
+          {exits.map(s => `${label(s)} ${byState.get(s)?.count ?? 0}`).join(' · ')}
+        </span>
+      </div>
+    </div>
+  )
+}

--- a/openbank-admin-ui/src/test/origination-pipeline.test.tsx
+++ b/openbank-admin-ui/src/test/origination-pipeline.test.tsx
@@ -1,0 +1,156 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright (c) OpenBank contributors. Licensed under the Apache License, Version 2.0.
+// See LICENSE in the repository root or https://www.apache.org/licenses/LICENSE-2.0 for details.
+
+// The pipeline exists to tell a credit officer where work is STUCK. So the tests are about the ways
+// it could tell them something false:
+//
+//  - tinting a terminal stage by age (a loan disbursed four days ago is not a four-day-old problem;
+//    the first render did exactly this and showed nine successful disbursements in red),
+//  - presenting a CAPPED list as if it were the book, which turns a staffing decision into a guess,
+//  - counting finished applications as "in flight".
+
+import { describe, it, expect, afterEach, vi } from 'vitest'
+import React from 'react'
+import { render, screen, cleanup, waitFor, fireEvent } from '@testing-library/react'
+import { LanguageProvider } from '@/lib/i18n/LanguageContext'
+import { SessionProvider } from '@/components/auth/SessionProvider'
+import { OriginationPipeline, summarise, wrap, type PipelineItem } from '@/components/lending/OriginationPipeline'
+import LendingPage from '@/app/lending/page'
+
+const HOUR = 3_600_000
+const NOW = Date.parse('2026-08-02T12:00:00Z')
+
+const at = (hoursAgo: number) => new Date(NOW - hoursAgo * HOUR).toISOString()
+
+const item = (status: string, hoursAgo: number, amount = 100_000, i = 0): PipelineItem => ({
+  id: `${status}-${i}`,
+  status,
+  createdAt: at(hoursAgo),
+  requestedAmount: { amount, currency: 'CZK' },
+})
+
+function Providers({ children }: { children: React.ReactNode }) {
+  return React.createElement(SessionProvider, null, React.createElement(LanguageProvider, null, children))
+}
+
+afterEach(() => {
+  cleanup()
+  vi.unstubAllGlobals()
+  vi.restoreAllMocks()
+})
+
+describe('summarise', () => {
+  it('counts per state and keeps the OLDEST age, not the newest', () => {
+    const s = summarise([item('ASSESSMENT', 2, 1, 1), item('ASSESSMENT', 90, 1, 2)], NOW)
+    expect(s.get('ASSESSMENT')?.count).toBe(2)
+    // The queue's health is set by the item that has waited longest; averaging or taking the newest
+    // would hide the one the desk needs to act on.
+    expect(Math.round(s.get('ASSESSMENT')!.oldestHours!)).toBe(90)
+  })
+
+  it('survives an item with no timestamp instead of producing NaN', () => {
+    const s = summarise([{ id: 'x', status: 'SUBMITTED' }], NOW)
+    expect(s.get('SUBMITTED')?.count).toBe(1)
+    expect(s.get('SUBMITTED')?.oldestHours).toBeNull()
+  })
+})
+
+describe('wrap', () => {
+  it('breaks a long stage name onto two lines rather than truncating it', () => {
+    expect(wrap('Připraveno k čerpání')).toEqual(['Připraveno k', 'čerpání'])
+    expect(wrap('Podáno')).toEqual(['Podáno'])
+  })
+})
+
+describe('OriginationPipeline', () => {
+  it('tints a waiting stage by how long the oldest item has waited', () => {
+    render(React.createElement(Providers, null, React.createElement(OriginationPipeline, {
+      items: [item('ASSESSMENT', 1), item('FOUR_EYES', 100, 1, 2), item('KYC_PENDING', 30, 1, 3)],
+      cap: 100, lang: 'en',
+    })))
+    expect(screen.getByTestId('stage-ASSESSMENT').getAttribute('data-tone')).toBe('ok')
+    expect(screen.getByTestId('stage-KYC_PENDING').getAttribute('data-tone')).toBe('warn')
+    expect(screen.getByTestId('stage-FOUR_EYES').getAttribute('data-tone')).toBe('bad')
+  })
+
+  it('never tints a TERMINAL stage by age', () => {
+    render(React.createElement(Providers, null, React.createElement(OriginationPipeline, {
+      items: [item('DISBURSED', 400), item('DECLINED', 400, 1, 2)],
+      cap: 100, lang: 'en',
+    })))
+    // Disbursed 400 hours ago is finished, not 400 hours late. The first render painted these red
+    // and told the desk it had problems it did not have.
+    expect(screen.getByTestId('stage-DISBURSED').getAttribute('data-tone')).toBe('done')
+  })
+
+  it('says so when the list is capped, instead of presenting it as the whole book', () => {
+    const items = Array.from({ length: 20 }, (_, i) => item('ASSESSMENT', 1, 1, i))
+    render(React.createElement(Providers, null, React.createElement(OriginationPipeline, {
+      items, cap: 20, lang: 'en',
+    })))
+    expect(screen.getByTestId('cap-note').textContent).toMatch(/are NOT in these numbers/)
+  })
+
+  it('does not cry "capped" when the server returned everything', () => {
+    render(React.createElement(Providers, null, React.createElement(OriginationPipeline, {
+      items: [item('ASSESSMENT', 1)], cap: 100, lang: 'en',
+    })))
+    expect(screen.getByTestId('cap-note').textContent).not.toMatch(/NOT in these numbers/)
+  })
+})
+
+describe('lending console', () => {
+  const APPS = [
+    { ...item('ASSESSMENT', 1, 250_000, 1), partyId: 'p1' },
+    { ...item('FOUR_EYES', 100, 400_000, 2), partyId: 'p2' },
+    { ...item('DISBURSED', 500, 900_000, 3), partyId: 'p3' },
+  ]
+  const LOANS = [
+    { id: 'l1', partyId: 'p9', status: 'ACTIVE', principal: { amount: 1_000_000, currency: 'CZK' } },
+    { id: 'l2', partyId: 'p8', status: 'DELINQUENT', principal: { amount: 500_000, currency: 'CZK' } },
+  ]
+
+  function mockFetch() {
+    const json = (b: unknown) => new Response(JSON.stringify(b), { status: 200, headers: { 'content-type': 'application/json' } })
+    return vi.fn(async (input: RequestInfo | URL) => {
+      const url = String(input)
+      if (url.includes('/api/auth/session')) return new Response('null', { status: 200, headers: { 'content-type': 'application/json' } })
+      if (url.includes('/loans/active')) return json(LOANS)
+      if (url.includes('/applications/recent')) return json(APPS)
+      return json({})
+    })
+  }
+
+  // ONE render for the whole console, asserted several ways. Four separate renders of this page
+  // pushed unrelated test files past their timeouts under parallel load — the suite's cost is
+  // shared, so a heavy test is not only its own problem.
+  it('summarises the desk: in-flight excludes finished work, trouble is flagged, stages are human', async () => {
+    vi.stubGlobal('fetch', mockFetch())
+    render(React.createElement(Providers, null, React.createElement(LendingPage)))
+
+    await waitFor(() => expect(screen.getByText('Applications in flight')).toBeTruthy())
+
+    // 3 applications, one DISBURSED — "in flight" is 2, not 3. Counting the finished one would
+    // inflate the desk's own workload figure.
+    expect(screen.getByText('Applications in flight').closest('.stat-card')?.textContent).toMatch(/2/)
+    expect(screen.getByText('Loans in trouble').closest('.stat-card')?.textContent).toMatch(/1/)
+
+    // A credit officer reads "Four-eyes review"; the enum stays as the title so the screen and the
+    // machine can never be describing different things.
+    expect(screen.getAllByText('Four-eyes review').length).toBeGreaterThan(0)
+    expect(screen.getByTitle('FOUR_EYES')).toBeTruthy()
+  })
+
+  it('clicking a stage filters the queue to it', async () => {
+    vi.stubGlobal('fetch', mockFetch())
+    render(React.createElement(Providers, null, React.createElement(LendingPage)))
+
+    await waitFor(() => expect(screen.getByTestId('stage-FOUR_EYES')).toBeTruthy())
+    fireEvent.click(screen.getByTestId('stage-FOUR_EYES'))
+
+    await waitFor(() => expect(screen.getByTestId('clear-stage')).toBeTruthy())
+    // A filter that leaves everything visible is a filter that lied about being applied.
+    expect(screen.queryByText('250,000 CZK')).toBeNull()
+  })
+})


### PR DESCRIPTION
## What

The lending console was two flat tables of raw enum strings (`PENDING_REVIEW`, `FOUR_EYES`). That
answers *which applications exist* — a question a database answers. It does not answer what an
underwriter, a credit-risk analyst or a lending officer opens a console to find out:

> what is waiting on a decision, how long has it waited, where is the pipeline jammed, and what is
> going wrong in the book

So the primary object is now the **stage**, not the row.

- The ADR-0211 lifecycle drawn as a pipeline: a bubble per stage, **sized** by how much sits in it,
  **tinted** by how long the *oldest* item there has waited (under 24h / 24–72h / over 72h).
- Same animated engine as the service map — `FlowParticle`, `NodeShadow`, `useFlowAnimation` — so
  `prefers-reduced-motion` is honoured and the motion has an explicit pause control.
- Clicking a stage filters the rows beneath it.
- Four headline tiles: book size, applications in flight, anything aging past 72h, loans in trouble.

Stage names come from the generated origination graph, so the picture cannot drift from the machine.
Rows show the human label with the raw state kept as the `title` — the screen and the state machine
can never end up describing different things.

## Two things the first render got wrong

Found by **looking at it**, not by reasoning about it:

| defect | why it mattered |
|---|---|
| terminal stages tinted by age | nine successfully disbursed loans rendered **red**. A loan disbursed four days ago is finished, not four days late — that is a desk being told it has problems it does not have |
| labels truncated, then colliding | `Připraveno k čerpání` → `Připraveno k čer…` is not a name anybody can act on; the two-line fix then overlapped the age line until the age was placed beneath the label block |

## Honesty about the numbers

`/applications/recent` and `/loans/active` are **capped** lists — the server clamps `limit` to
1..100. No figure here may read as a book total: *"12 waiting" when 300 wait is a staffing decision
made on a wrong number.* The cap travels with the count, and a full page says so outright rather
than in a footnote.

Mutations stay absent — decisions, disbursements and write-offs remain in the approval inbox
(ADR-0227 D4).

## Falsification

Each of these turns the suite red (3 of 9):

- re-tinting terminal stages by age
- hiding the cap notice
- counting finished applications as in-flight

## A note on suite cost

Four separate renders of the console pushed **unrelated** files (`card-issue-dialog`,
`service-map-topology`) past their timeouts under parallel load. I checked rather than assumed: they
pass alone on this branch and pass on a clean `origin/main` worktree, so the failures were mine.
Consolidated to two page renders — the suite's cost is shared, so a heavy test is not only its own
problem.

## Verification

From a clean tree (`origination-graph.json`, `governance.json`, `catalog.json` all deleted first):

- `npm test` — **67 files, 983 tests passed**
- `npm run type-check` — clean
- `npm run lint` — 0 errors
- rendered and screenshotted at each iteration

admin-ui only — no API, DB, event or config change.

Refs #3168
