### PR TITLE
fix(infra): grant the twelve Kafka ACLs that were baselined, and correct the premise that hid them

### DIFF
--- a/.github/scripts/check-kafka-acl-coverage.py
+++ b/.github/scripts/check-kafka-acl-coverage.py
@@ -60,37 +60,22 @@ GITOPS = REPO / "openbank-infra" / "gitops"
 # principal a new topic permission is a live-broker change whose blast radius wants its own
 # review, and several of them may instead mean the service publishes over a different principal.
 # Tracked in #2598's follow-up.
-KNOWN_GAPS: dict[str, str] = {
-    "openbank-audit-service#openbank.cards.events#Read":
-        "audit subscribes to six payment/card/lending topics its KafkaUser predates; needs a "
-        "broker-side grant reviewed as one change (#2598 follow-up).",
-    "openbank-audit-service#openbank.domestic.payment.events#Read":
-        "same audit grant batch (#2598 follow-up).",
-    "openbank-audit-service#openbank.lending.events#Read":
-        "same audit grant batch (#2598 follow-up).",
-    "openbank-audit-service#openbank.payments.swift.event#Read":
-        "same audit grant batch (#2598 follow-up).",
-    "openbank-audit-service#openbank.sepa.instant.events#Read":
-        "same audit grant batch (#2598 follow-up).",
-    "openbank-audit-service#openbank.sepa.payment.events#Read":
-        "same audit grant batch (#2598 follow-up).",
-    "openbank-card-issuance-service#openbank.cards.events#Write":
-        "producer grant missing; card-issuance's KafkaUser carries only the party.events Read it "
-        "was created for (#2598 follow-up).",
-    "openbank-domestic-payment#openbank.domestic.payment.events#Write":
-        "producer grant missing; the KafkaUser carries only payment.scheme-accepted (#2598 "
-        "follow-up).",
-    "openbank-sepa-payment#openbank.sepa.payment.events#Write":
-        "producer grant missing; the KafkaUser carries only payment.scheme-accepted (#2598 "
-        "follow-up).",
-    "openbank-transaction-service#openbank.transactions.transaction.initiated#Write":
-        "producer grant missing; the KafkaUser carries only payment.scheme-accepted (#2598 "
-        "follow-up).",
-    "openbank-interest-service#openbank.interest.accrual.event#Read":
-        "self-consumed topic with no KafkaUser grant (#2598 follow-up).",
-    "openbank-sdd-service#openbank.sdd.event#Read":
-        "self-consumed topic with no KafkaUser grant (#2598 follow-up).",
-}
+KNOWN_GAPS: dict[str, str] = {}
+# EMPTY, and that is the point. All twelve original entries were granted in #3271's follow-up.
+#
+# They were baselined rather than fixed because a grant is a live-broker change and it was not
+# settled from the repo alone whether a service publishes under a different principal. Both halves
+# have since been answered with evidence: every workload mounts `<service>-kafka-keystore`, whose
+# ExternalSecret extracts the KafkaUser of the same name, so the name-based match this check makes
+# is exact; and `components/kafka/kafka.yaml:118` sets
+# `allow.everyone.if.no.acl.found: "false"`, so a topic with no ACL is denied, not open.
+#
+# What that baseline cost: domestic-payment's own event topic had no Write grant and 13 outbox
+# rows went DEAD before anyone looked (#3271). "Declared debt" and "measured incident" were the
+# same fact the whole time — the entry just made it easy not to check.
+#
+# An entry added here needs a reason, and the check fails on a stale declaration in BOTH
+# directions, so a new gap cannot quietly become permanent.
 
 
 def _walk(node: object, path: list[str], out: list[tuple[list[str], object]]) -> None:

--- a/openbank-infra/gitops/components/audit/kafka-audit-mtls.yaml
+++ b/openbank-infra/gitops/components/audit/kafka-audit-mtls.yaml
@@ -128,6 +128,47 @@ spec:
           patternType: literal
         operations: [Read, Describe]
         host: "*"
+      # Six topics audit-service subscribes to whose grants its KafkaUser predates (#2598 → #3271).
+      # The cluster is deny-by-default (allow.everyone.if.no.acl.found=false,
+      # components/kafka/kafka.yaml:118), so each of these subscriptions was silently receiving
+      # nothing — and an audit trail missing payment, card and lending events reads exactly like a
+      # quiet period.
+      - resource:
+          type: topic
+          name: openbank.cards.events
+          patternType: literal
+        operations: [Read, Describe]
+        host: "*"
+      - resource:
+          type: topic
+          name: openbank.domestic.payment.events
+          patternType: literal
+        operations: [Read, Describe]
+        host: "*"
+      - resource:
+          type: topic
+          name: openbank.lending.events
+          patternType: literal
+        operations: [Read, Describe]
+        host: "*"
+      - resource:
+          type: topic
+          name: openbank.payments.swift.event
+          patternType: literal
+        operations: [Read, Describe]
+        host: "*"
+      - resource:
+          type: topic
+          name: openbank.sepa.instant.events
+          patternType: literal
+        operations: [Read, Describe]
+        host: "*"
+      - resource:
+          type: topic
+          name: openbank.sepa.payment.events
+          patternType: literal
+        operations: [Read, Describe]
+        host: "*"
       - resource:
           type: group
           name: audit-service

--- a/openbank-infra/gitops/components/interest-service/kafka-interest-mtls.yaml
+++ b/openbank-infra/gitops/components/interest-service/kafka-interest-mtls.yaml
@@ -32,6 +32,22 @@ spec:
   authorization:
     type: simple
     acls:
+      # It CONSUMES this topic too and had no Read grant (#2598 → #3271). The effective consumer
+      # group is `openbank-interest-service`: application.yaml deliberately omits `group.id` as a YAML key
+      # (SmallRye's dotted-key footgun, #686/#703), so the fallback — quarkus.application.name —
+      # is what Kafka sees. Granting any other name here would deny just as silently.
+      - resource:
+          type: topic
+          name: openbank.interest.accrual.event
+          patternType: literal
+        operations: [Read, Describe]
+        host: "*"
+      - resource:
+          type: group
+          name: openbank-interest-service
+          patternType: literal
+        operations: [Read]
+        host: "*"
       - resource:
           type: topic
           name: openbank.interest.accrual.event

--- a/openbank-infra/gitops/components/payments/kafka-scheme-accepted-acl.yaml
+++ b/openbank-infra/gitops/components/payments/kafka-scheme-accepted-acl.yaml
@@ -15,8 +15,14 @@
 # named after the service, not after a per-topic role. A KafkaUser's ACLs list
 # everything that service may do on the ACL'd resources; resources without ACLs
 # stay open under allow.everyone.if.no.acl.found=true (see kafka.yaml), so each
-# service only needs ACLs for the locked-down scheme-accepted topics — its own
-# domain-event topics need none.
+# service needs an ACL for EVERY topic it touches. This comment used to say the
+# opposite — that resources without ACLs "stay open under
+# allow.everyone.if.no.acl.found=true", so a service's own domain-event topics
+# needed none. That was true until #2794 flipped the cluster to
+# `allow.everyone.if.no.acl.found: "false"` (components/kafka/kafka.yaml:118) and
+# was never corrected here. The stale prose is what made the missing producer
+# grants below read as deliberate: domestic-payment's own event topic had no
+# Write grant and 13 outbox rows went DEAD (#3271).
 #
 # These live in `messaging` (where the Strimzi User Operator watches); the User
 # Operator mints a per-user Secret of the same name there (user.crt/key/p12 +
@@ -46,6 +52,11 @@ spec:
   authorization:
     type: simple
     acls:
+      # Its own domain-event topic. Missing until #3271: with the cluster
+      # deny-by-default, the outbox dispatcher could not publish at all.
+      - resource: { type: topic, name: openbank.sepa.payment.events, patternType: literal }
+        operations: [Write, Describe]
+        host: "*"
       - resource:
           type: topic
           name: payment.scheme-accepted
@@ -106,6 +117,11 @@ spec:
   authorization:
     type: simple
     acls:
+      # Its own domain-event topic. Missing until #3271, which measured the cost:
+      # 13 outbox rows DEAD because every publish was denied.
+      - resource: { type: topic, name: openbank.domestic.payment.events, patternType: literal }
+        operations: [Write, Describe]
+        host: "*"
       - resource:
           type: topic
           name: payment.scheme-accepted
@@ -172,6 +188,10 @@ spec:
   authorization:
     type: simple
     acls:
+      # Its own domain-event topic — consumed by audit-service and analytics-sink.
+      - resource: { type: topic, name: openbank.transactions.transaction.initiated, patternType: literal }
+        operations: [Write, Describe]
+        host: "*"
       - resource:
           type: topic
           name: payment.scheme-accepted
@@ -244,6 +264,10 @@ spec:
   authorization:
     type: simple
     acls:
+      # Its own domain-event topic.
+      - resource: { type: topic, name: openbank.cards.events, patternType: literal }
+        operations: [Write, Describe]
+        host: "*"
       - resource:
           type: topic
           name: openbank.party.events

--- a/openbank-infra/gitops/components/sdd/kafka-sdd-mtls.yaml
+++ b/openbank-infra/gitops/components/sdd/kafka-sdd-mtls.yaml
@@ -26,6 +26,22 @@ spec:
   authorization:
     type: simple
     acls:
+      # It CONSUMES this topic too and had no Read grant (#2598 → #3271). The effective consumer
+      # group is `openbank-sdd-service`: application.yaml deliberately omits `group.id` as a YAML key
+      # (SmallRye's dotted-key footgun, #686/#703), so the fallback — quarkus.application.name —
+      # is what Kafka sees. Granting any other name here would deny just as silently.
+      - resource:
+          type: topic
+          name: openbank.sdd.event
+          patternType: literal
+        operations: [Read, Describe]
+        host: "*"
+      - resource:
+          type: group
+          name: openbank-sdd-service
+          patternType: literal
+        operations: [Read]
+        host: "*"
       - resource:
           type: topic
           name: openbank.sdd.event


### PR DESCRIPTION
Closes #3271 · Refs #2598, #2979, #2794, #686

## Why these were baselined, and why that no longer holds

#2979's gate derived every service's required Kafka ACLs from its own `mp.messaging` config and found twelve missing. I baselined them rather than fixing them, because a grant is a live-broker change and it was not settled **from the repo alone** whether a service publishes under a different principal.

Both halves are now answered with evidence:

| question | answer, measured |
|---|---|
| does each service authenticate as the KafkaUser of its own name? | **yes** — every workload mounts `<service>-kafka-keystore`, whose ExternalSecret extracts the KafkaUser of the same name. Checked for all seven affected services. |
| is a topic with no ACL open or denied? | **denied** — `components/kafka/kafka.yaml:118` sets `allow.everyone.if.no.acl.found: "false"` |

The second is what the baseline was quietly betting against, and #3271 shows the bet was already lost: domestic-payment's own event topic had no Write grant and **13 outbox rows went DEAD**.

## What is granted

- **sepa-payment, domestic-payment, transaction-service, card-issuance-service** — `Write` on their own domain-event topic.
- **audit-service** — `Read` on the six payment/card/lending topics it subscribes to. Worth stating the consequence: an audit trail missing those events reads exactly like a quiet period.
- **interest-service, sdd-service** — `Read` on the topic they consume, plus the consumer group.

The group name for those two is the **fallback** (`quarkus.application.name`), not anything written in the YAML: both deliberately omit `group.id` as a YAML key because of SmallRye's dotted-key footgun (#686/#703). Granting the name a reader would take from the config would have denied just as silently as no grant at all.

## The stale comment that made this look deliberate

`kafka-scheme-accepted-acl.yaml`'s header still claimed resources without ACLs *"stay open under `allow.everyone.if.no.acl.found=true`"* and that a service's own domain-event topics *"need none"*. True until #2794 flipped the cluster; never corrected. That is precisely what #3271 means by "the manifest comment asserts the opposite of the live cluster", and it is why the missing producer grants read as intentional for as long as they did. Corrected in place, with the reason.

## Verification

`KNOWN_GAPS` is now **empty**, and that is how this was checked rather than an afterthought: the gate fails on a stale entry in **both** directions, so it went red on all twelve the moment they were covered —

```
::error::stale KNOWN_GAPS entry openbank-sepa-payment#openbank.sepa.payment.events#Write — that
topic/operation is now covered (or no longer referenced). Remove it, so the list can only shrink.
```

— and clean once the list was emptied. Falsified again afterwards by removing one grant (sdd-service): the gate names it and exits 1; restored, clean. `yamllint` clean, all four manifests parse.

## Note for review

This grants broker permissions, so it is worth a look even though every grant is additive and derived from what the service already declares it does. Nothing is widened beyond a service's own declared topics.

The remaining `::notice` is `openbank-security-scanner`, which references two topics and has no KafkaUser at all — deliberately not invented here, since "this service does not use the mTLS listener" is a legitimate state the check cannot tell apart from a missing user.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
