### PR TITLE
feat(infra): give every agent its own budgeted LiteLLM key instead of the shared master key

### DIFF
--- a/.github/gates/gates.yaml
+++ b/.github/gates/gates.yaml
@@ -159,6 +159,17 @@ gates:
   # PyYAML is not stdlib: try multiple install paths for portability across
   # macOS (system python3 without pip, Homebrew pip3) and Linux ARC runners
   # (pip/pip3 not in PATH). Fall back to checking if pyyaml is already present.
+  - id: agent-virtual-keys
+    name: every agent authenticates with its OWN LiteLLM virtual key, not the shared master key
+    group: gitops
+    mode: enforced
+    run: |
+      # Falsified in both directions before it was wired in: 4 findings against the
+      # pre-fix tree, 0 after, plus 7 self-test cases covering the exemption and the
+      # near-misses. A gate that has only ever passed is unfalsified.
+      python3 .github/scripts/check-agent-virtual-keys.py --self-test
+      python3 .github/scripts/check-agent-virtual-keys.py --enforce
+
   - id: gen-network-policies-drift-gate
     name: "gen-network-policies drift gate (ADR-0081, issue #854)"
     group: gitops

--- a/.github/scripts/check-agent-virtual-keys.py
+++ b/.github/scripts/check-agent-virtual-keys.py
@@ -1,0 +1,133 @@
+#!/usr/bin/env python3
+"""Every agent must authenticate to the LiteLLM gateway with its OWN virtual key.
+
+WHY THIS IS A GATE AND NOT A COMMENT. The master key and a virtual key are the same shape
+(`sk-...`) and both authenticate successfully, so an agent wired to the master key works
+perfectly -- it just has no budget, no attribution, and cannot be revoked without revoking the
+whole fleet. There is no failing request, no red dashboard, and no log line to notice: the only
+symptom is that a control the platform claims to enforce quietly enforces nothing. That is
+precisely the class of regression a text guard can catch and a human review cannot.
+
+THE RULE. In `openbank-infra/gitops/components/`, an ExternalSecret entry whose `remoteRef.key`
+is `litellm` may reference `property: LITELLM_MASTER_KEY` ONLY inside `components/ai-platform/`
+-- the gateway's own namespace, where that key is the proxy's admin credential and is supposed
+to live. Anywhere else it means an agent is on the shared key.
+
+Run standalone:  .github/scripts/check-agent-virtual-keys.py [--enforce]
+Self-test:       .github/scripts/check-agent-virtual-keys.py --self-test
+"""
+
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+import yaml
+
+REPO = Path(__file__).resolve().parents[2]
+COMPONENTS = REPO / "openbank-infra" / "gitops" / "components"
+MASTER = "LITELLM_MASTER_KEY"
+# The gateway's own namespace: this is where the master key legitimately lives.
+ALLOWED_PREFIX = "ai-platform"
+
+
+def offenders_in(doc: dict, rel: str) -> list[str]:
+    """Return one message per entry that sources the master key from outside ai-platform."""
+    if not isinstance(doc, dict) or doc.get("kind") != "ExternalSecret":
+        return []
+    if rel.split("/")[0] == ALLOWED_PREFIX:
+        return []
+    out = []
+    for entry in (doc.get("spec") or {}).get("data") or []:
+        if not isinstance(entry, dict):
+            continue
+        ref = entry.get("remoteRef") or {}
+        if ref.get("key") == "litellm" and ref.get("property") == MASTER:
+            out.append(
+                f"{rel}: secretKey {entry.get('secretKey')} sources the SHARED master key "
+                f"(remoteRef.property: {MASTER}). Use this agent's own virtual key "
+                f"(property: KEY_<AGENT_ID>), seeded by "
+                f"openbank-infra/scripts/seed-litellm-virtual-keys.sh."
+            )
+    return out
+
+
+def audit() -> list[str]:
+    findings: list[str] = []
+    for path in sorted(COMPONENTS.rglob("*.yaml")):
+        rel_to_components = path.relative_to(COMPONENTS).as_posix()
+        try:
+            docs = list(yaml.safe_load_all(path.read_text()))
+        except yaml.YAMLError:
+            # Not this gate's job: `Validate manifests` already fails on unparseable YAML, and
+            # swallowing it here would be a second opinion nobody reads.
+            continue
+        for doc in docs:
+            findings += offenders_in(doc, rel_to_components)
+    return findings
+
+
+def self_test() -> int:
+    """Feed it inputs it MUST flag and inputs it MUST NOT. A gate that has only ever passed is
+    unfalsified -- both directions are asserted, so neither a dead check nor a false positive
+    can hide."""
+    agent = {
+        "kind": "ExternalSecret",
+        "spec": {
+            "data": [
+                {"secretKey": "X_MODEL_API_KEY",
+                 "remoteRef": {"key": "litellm", "property": MASTER}}
+            ]
+        },
+    }
+    cases = [
+        ("agent on the master key is flagged",
+         agent, "devops-agent/model-externalsecret.yaml", 1),
+        ("the gateway's own namespace is exempt",
+         agent, "ai-platform/model-externalsecret.yaml", 0),
+        ("an agent on its own virtual key passes",
+         {"kind": "ExternalSecret", "spec": {"data": [
+             {"secretKey": "X", "remoteRef": {"key": "litellm",
+                                              "property": "KEY_DEVOPS_AGENT"}}]}},
+         "devops-agent/model-externalsecret.yaml", 0),
+        ("a different KV path with the same property name is not our business",
+         {"kind": "ExternalSecret", "spec": {"data": [
+             {"secretKey": "X", "remoteRef": {"key": "somewhere-else",
+                                              "property": MASTER}}]}},
+         "devops-agent/model-externalsecret.yaml", 0),
+        ("a non-ExternalSecret document mentioning the key is not flagged",
+         {"kind": "Deployment", "spec": {"data": [
+             {"secretKey": "X", "remoteRef": {"key": "litellm", "property": MASTER}}]}},
+         "devops-agent/deploy.yaml", 0),
+        ("an ExternalSecret with no data entries is fine",
+         {"kind": "ExternalSecret", "spec": {}}, "devops-agent/es.yaml", 0),
+        ("a null document does not crash the walk",
+         None, "devops-agent/es.yaml", 0),
+    ]
+    failed = 0
+    for name, doc, rel, expected in cases:
+        got = len(offenders_in(doc, rel))
+        ok = got == expected
+        failed += not ok
+        print(f"  {'PASS' if ok else 'FAIL'}  {name} (expected {expected}, got {got})")
+    print(f"self-test: {len(cases) - failed}/{len(cases)} passed")
+    return 1 if failed else 0
+
+
+def main() -> int:
+    if "--self-test" in sys.argv:
+        return self_test()
+    enforce = "--enforce" in sys.argv
+    findings = audit()
+    if not findings:
+        print("check-agent-virtual-keys: OK — no agent sources the shared LiteLLM master key.")
+        return 0
+    for f in findings:
+        print(f"{'::error::' if enforce else '::warning::'}{f}")
+    print(f"\n{len(findings)} agent secret(s) on the shared master key. "
+          f"Each is a caller with no budget, no spend attribution, and no independent revocation.")
+    return 1 if enforce else 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/openbank-infra/gitops/components/agent/agent-service.yaml
+++ b/openbank-infra/gitops/components/agent/agent-service.yaml
@@ -89,7 +89,7 @@ spec:
               value: llama-3.3-70b-versatile
             - name: AGENT_MODEL_ENDPOINT
               value: http://litellm.ai-platform.svc:4000/v1
-            # LiteLLM virtual key (OpenBao litellm/LITELLM_MASTER_KEY via ESO), not a provider key.
+            # LiteLLM virtual key (OpenBao litellm/KEY_AGENT_SERVICE via ESO), not a provider key.
             # Optional so an un-seeded key degrades the chat call instead of CrashLooping the pod.
             - name: AGENT_MODEL_API_KEY
               valueFrom:

--- a/openbank-infra/gitops/components/control-liveness-sentinel/model-externalsecret.yaml
+++ b/openbank-infra/gitops/components/control-liveness-sentinel/model-externalsecret.yaml
@@ -20,10 +20,18 @@ spec:
   data:
     # LiteLLM virtual key (ADR-0174): auth to the in-cluster gateway, not the DeepInfra key —
     # the provider key now lives only in ai-platform (ADR-0175).
+      # Per-agent LiteLLM virtual key, NOT the shared master key. The master key is the proxy's
+      # admin credential: it can mint and revoke keys, it is exempt from every budget, and it is
+      # the same string in every agent namespace — so with it "which agent burned the budget" is
+      # unanswerable and "stop THAT agent" revokes the whole fleet. This key carries its own daily
+      # budget, which LiteLLM REFUSES to exceed (a preventive control, where AiFleetDailySpendHigh
+      # is only detective), and its spend attributes to this alias in /spend/logs.
+      # Seeded by openbank-infra/scripts/seed-litellm-virtual-keys.sh; the property name is the
+      # agent's charter id, so a spend row joins onto agents.yaml with no mapping table.
     - secretKey: LIVENESS_MODEL_API_KEY
       remoteRef:
         key: litellm
-        property: LITELLM_MASTER_KEY
+        property: KEY_CONTROL_LIVENESS_SENTINEL
     - secretKey: LIVENESS_GITHUB_TOKEN
       remoteRef:
         key: control-liveness-sentinel

--- a/openbank-infra/gitops/components/copilot/copilot-service.yaml
+++ b/openbank-infra/gitops/components/copilot/copilot-service.yaml
@@ -75,7 +75,7 @@ spec:
               value: deepseek-ai/DeepSeek-V3.2
             - name: COPILOT_MODEL_ID
               value: deepseek-ai/DeepSeek-V3.2
-            # LiteLLM virtual key, projected from OpenBao (litellm/LITELLM_MASTER_KEY) by ESO — the
+            # LiteLLM virtual key, projected from OpenBao (litellm/KEY_COPILOT_SERVICE) by ESO — the
             # provider key now lives only in ai-platform (ADR-0175). Optional so an un-seeded key does
             # not CrashLoop the pod — until it is set the model call degrades.
             - name: COPILOT_MODEL_API_KEY

--- a/openbank-infra/gitops/components/devops-agent/model-externalsecret.yaml
+++ b/openbank-infra/gitops/components/devops-agent/model-externalsecret.yaml
@@ -1,9 +1,9 @@
-# DeepInfra API key for the devops-agent LLM diagnosis backend (ADR-0119).
-# Projects OpenBao kv openbank/devops-agent:MODEL_API_KEY into a k8s Secret in the
-# devops-agent namespace, mounted as DEVOPS_MODEL_API_KEY (optional in the Deployment,
-# so an un-seeded key degrades diagnosis instead of CrashLooping).
-# Seed once: bao kv patch openbank/devops-agent MODEL_API_KEY=<deepinfra-key>
-# Shares the same DeepInfra/DeepSeek backend the copilot uses (ADR-0089).
+# Secrets for the devops-agent LLM diagnosis backend (ADR-0119).
+# DEVOPS_MODEL_API_KEY is the agent's own LiteLLM virtual key (OpenBao openbank/litellm,
+# property KEY_DEVOPS_AGENT), NOT a provider key — the DeepInfra key lives only in ai-platform
+# since ADR-0175. It stays optional in the Deployment, so an un-seeded key degrades diagnosis
+# instead of CrashLooping.
+# Seed: openbank-infra/scripts/seed-litellm-virtual-keys.sh
 apiVersion: external-secrets.io/v1beta1
 kind: ExternalSecret
 metadata:
@@ -26,10 +26,18 @@ spec:
   data:
     # The LiteLLM virtual key (ADR-0174): the agent authenticates to the in-cluster gateway with
     # this, not with the DeepInfra key — the provider key now lives only in ai-platform (ADR-0175).
+      # Per-agent LiteLLM virtual key, NOT the shared master key. The master key is the proxy's
+      # admin credential: it can mint and revoke keys, it is exempt from every budget, and it is
+      # the same string in every agent namespace — so with it "which agent burned the budget" is
+      # unanswerable and "stop THAT agent" revokes the whole fleet. This key carries its own daily
+      # budget, which LiteLLM REFUSES to exceed (a preventive control, where AiFleetDailySpendHigh
+      # is only detective), and its spend attributes to this alias in /spend/logs.
+      # Seeded by openbank-infra/scripts/seed-litellm-virtual-keys.sh; the property name is the
+      # agent's charter id, so a spend row joins onto agents.yaml with no mapping table.
     - secretKey: DEVOPS_MODEL_API_KEY
       remoteRef:
         key: litellm
-        property: LITELLM_MASTER_KEY
+        property: KEY_DEVOPS_AGENT
     # Fine-grained GitHub token for opening remediation-proposal PRs (contents:write +
     # pull_requests:write on the repo). Seed: bao kv patch openbank/devops-agent GITHUB_TOKEN=<pat>
     - secretKey: DEVOPS_GITHUB_TOKEN

--- a/openbank-infra/gitops/components/external-secrets/es-agent-service.yaml
+++ b/openbank-infra/gitops/components/external-secrets/es-agent-service.yaml
@@ -2,7 +2,8 @@
 #
 # AGENT_MODEL_API_KEY = the LiteLLM virtual key (ADR-0174/0175, #1919): agent-service authenticates
 # to the in-cluster gateway, NOT to the provider — the Groq key now lives only in ai-platform. Same
-# source and same shape as copilot's COPILOT_MODEL_API_KEY (es-copilot-service.yaml).
+# source and same shape as copilot's COPILOT_MODEL_API_KEY (es-copilot-service.yaml), each on its
+# own budgeted virtual key rather than the shared master key.
 #
 # GROQ_API_KEY is retained ONLY for the rollout window: the currently-deployed image predates the
 # AGENT_MODEL_* config seam and still reads GROQ_API_KEY against api.groq.com directly. Drop it (and
@@ -29,10 +30,18 @@ spec:
         annotations:
           argocd.argoproj.io/compare-options: IgnoreExtraneous
   data:
+      # Per-agent LiteLLM virtual key, NOT the shared master key. The master key is the proxy's
+      # admin credential: it can mint and revoke keys, it is exempt from every budget, and it is
+      # the same string in every agent namespace — so with it "which agent burned the budget" is
+      # unanswerable and "stop THAT agent" revokes the whole fleet. This key carries its own daily
+      # budget, which LiteLLM REFUSES to exceed (a preventive control, where AiFleetDailySpendHigh
+      # is only detective), and its spend attributes to this alias in /spend/logs.
+      # Seeded by openbank-infra/scripts/seed-litellm-virtual-keys.sh; the property name is the
+      # agent's charter id, so a spend row joins onto agents.yaml with no mapping table.
     - secretKey: AGENT_MODEL_API_KEY
       remoteRef:
         key: litellm
-        property: LITELLM_MASTER_KEY
+        property: KEY_AGENT_SERVICE
     - secretKey: GROQ_API_KEY
       remoteRef:
         key: agent-service

--- a/openbank-infra/gitops/components/external-secrets/es-copilot-service.yaml
+++ b/openbank-infra/gitops/components/external-secrets/es-copilot-service.yaml
@@ -1,8 +1,8 @@
 # copilot-service secret from OpenBao → copilot-service-secrets Secret.
 # COPILOT_MODEL_API_KEY = the LiteLLM virtual key (ADR-0174/0175): copilot authenticates to the
 # in-cluster gateway, NOT to the provider — the DeepInfra key now lives only in ai-platform (#1919).
-# Sourced from OpenBao KV path `openbank/litellm`, property `LITELLM_MASTER_KEY` (the same key the
-# gateway checks and the ops agents already present).
+# Sourced from OpenBao KV path `openbank/litellm`, property `KEY_COPILOT_SERVICE` — copilot's OWN
+# virtual key with its own daily budget, not the shared master key (see the data entry below).
 # (No OIDC secret: copilot validates the customer JWT bearer-only via JWKS — no client secret.)
 apiVersion: external-secrets.io/v1beta1
 kind: ExternalSecret
@@ -23,7 +23,15 @@ spec:
         annotations:
           argocd.argoproj.io/compare-options: IgnoreExtraneous
   data:
+      # Per-agent LiteLLM virtual key, NOT the shared master key. The master key is the proxy's
+      # admin credential: it can mint and revoke keys, it is exempt from every budget, and it is
+      # the same string in every agent namespace — so with it "which agent burned the budget" is
+      # unanswerable and "stop THAT agent" revokes the whole fleet. This key carries its own daily
+      # budget, which LiteLLM REFUSES to exceed (a preventive control, where AiFleetDailySpendHigh
+      # is only detective), and its spend attributes to this alias in /spend/logs.
+      # Seeded by openbank-infra/scripts/seed-litellm-virtual-keys.sh; the property name is the
+      # agent's charter id, so a spend row joins onto agents.yaml with no mapping table.
     - secretKey: COPILOT_MODEL_API_KEY
       remoteRef:
         key: litellm
-        property: LITELLM_MASTER_KEY
+        property: KEY_COPILOT_SERVICE

--- a/openbank-infra/scripts/seed-litellm-virtual-keys.sh
+++ b/openbank-infra/scripts/seed-litellm-virtual-keys.sh
@@ -80,17 +80,40 @@ if ! curl -sf --max-time 10 http://127.0.0.1:14001/key/list \
   exit 1
 fi
 
-EXISTING="$(curl -s --max-time 10 http://127.0.0.1:14001/key/list \
-  -H "Authorization: Bearer $MASTER_KEY" | jq -r '[.keys[]?.key_alias // empty] | join(" ")')"
+# `?return_full_object=true` is REQUIRED: without it LiteLLM answers with a bare array of key
+# STRINGS, and `.keys[].key_alias` then aborts jq with
+#   jq: error (at <stdin>:0): Cannot index string with string ("key_alias")
+# That failure could not happen on the run that created the keys — an empty `.keys[]` yields
+# nothing and exits 0 — so the idempotency branch this feeds was only ever exercised in the one
+# state where it had nothing to do. The `if type=="object"` arm keeps it working against both
+# shapes rather than pinning the script to today's response format.
+EXISTING="$(curl -s --max-time 10 "http://127.0.0.1:14001/key/list?return_full_object=true" \
+  -H "Authorization: Bearer $MASTER_KEY" \
+  | jq -r '[.keys[]? | if type=="object" then (.key_alias // empty) else empty end] | join(" ")')"
 
 echo "[4/4] Seeding per-agent keys ..."
 for entry in "${AGENT_BUDGETS[@]}"; do
   alias="${entry%%:*}"
   budget="${entry##*:}"
 
-  if [[ " $EXISTING " == *" $alias "* && "$ROTATE" -eq 0 ]]; then
-    echo "      = $alias already has a key (budget unchanged) — skipping. Use --rotate to replace."
-    continue
+  if [[ " $EXISTING " == *" $alias "* ]]; then
+    if [[ "$ROTATE" -eq 0 ]]; then
+      echo "      = $alias already has a key (budget unchanged) — skipping. Use --rotate to replace."
+      continue
+    fi
+    # /key/generate REFUSES a duplicate alias outright:
+    #   "Key with alias '<alias>' already exists. Unique key aliases across all keys are required."
+    # so --rotate cannot mean "generate over the top" — the old key has to go first. Like the
+    # listing bug above, this path was unreachable until a key existed, so --rotate had never once
+    # run against the state it exists for.
+    echo "      - $alias: deleting the existing key before re-issuing (--rotate) ..."
+    del="$(curl -s --max-time 20 -X POST http://127.0.0.1:14001/key/delete \
+      -H "Authorization: Bearer $MASTER_KEY" -H 'Content-Type: application/json' \
+      -d "{\"key_aliases\":[\"$alias\"]}")"
+    echo "$del" | jq -e --arg a "$alias" '.deleted_keys | index($a)' >/dev/null 2>&1 || {
+      echo "ERROR: could not delete the existing key for $alias. Response: $del" >&2
+      exit 1
+    }
   fi
 
   resp="$(curl -s --max-time 20 -X POST http://127.0.0.1:14001/key/generate \


### PR DESCRIPTION
## What

Every agent now authenticates to the LiteLLM gateway with **its own budgeted virtual key** instead of the shared master key.

Builds directly on #3276, which restored the database that makes virtual keys possible at all.

## The problem this closes

All four agents used the same credential — and not just any credential. `LITELLM_MASTER_KEY` is the proxy's **admin** key: it mints and revokes keys, it is exempt from every budget, and it was being projected verbatim into four namespaces by ESO.

| question | before | after |
|---|---|---|
| which agent burned the budget? | unanswerable — one key, one spend row | `/spend/logs` splits by `key_alias` |
| stop *that* agent | only lever revokes the whole fleet | revoke one key |
| what enforces a per-caller ceiling? | nothing — only per-**model** ceilings, which cannot tell a runaway scheduler from ordinary interactive use of the same model | LiteLLM refuses the call once the key's daily budget is spent |

None of this produced a failing request, a red dashboard, or a log line. The platform claimed a control it did not have.

## Budgets

Seeded from `openbank-infra/scripts/seed-litellm-virtual-keys.sh`, deliberately layered:

```
devops-agent 3  +  control-liveness-sentinel 3  +  copilot-service 8  +  agent-service 5
  <  per-model ceilings (20 ops / 5 interactive)  <  AiFleetDailySpendHigh (25 USD/day)
```

Each layer bites before the one outside it, so the alert is the last line rather than the first. Budget enforcement is **preventive**; `AiFleetDailySpendHigh` was only ever detective.

## Verified against the running gateway, not asserted

```
devops-agent                 http=200 reply=ok    budget=3.0/1d
control-liveness-sentinel    http=200 reply=ok    budget=3.0/1d
copilot-service              http=200 reply=ok    budget=8.0/1d
agent-service                http=200 reply=ok    budget=5.0/1d
bogus-key                    http=401                          <- negative control
```

The negative control matters: without it a `200` proves only that *something* authenticated, not that the key did. Keys are in OpenBao under `openbank/litellm`; the local capture file was overwritten and removed.

## Two bugs in the seeding script, both found by running it a *second* time

- `/key/list` returns an array of key **strings**, so `.keys[].key_alias` aborted with `Cannot index string with string ("key_alias")`. This could not happen on the run that *created* the keys — an empty `.keys[]` yields nothing and exits 0. The idempotency branch had only ever executed in the one state where it had nothing to do.
- `--rotate` could never work: `/key/generate` refuses a duplicate alias outright (`Unique key aliases across all keys are required`), so rotation must delete first. Same shape — unreachable until a key existed.

Both now exercised against the real gateway in the state they exist for.

## New enforced gate: `agent-virtual-keys`

A master key and a virtual key are the same shape and both authenticate. An agent wired back to the master key therefore *works perfectly* while silently losing its budget, its attribution and its independent revocation — there is nothing for a reviewer to see. That is a gate's job, not a comment's.

Falsified in both directions before wiring in:

- **4** findings against the pre-fix tree, **0** after
- 7 self-test cases: the `ai-platform` exemption (where the master key legitimately lives), a different KV path with the same property name, a non-ExternalSecret document, an empty `data`, a null document
- the runner's **real exit code checked without a pipe** — `1` on a violating tree, `0` on a clean one — so it blocks rather than merely printing `::error::`

## Also

Corrects prose in five manifests that still named `LITELLM_MASTER_KEY`. Stale prose naming a dead identifier is invisible to a text guard forever, so it gets swept with the vocabulary rather than after it.

Refs #3276

🤖 Generated with [Claude Code](https://claude.com/claude-code)
