### PR TITLE
fix(admin-ui): stage the origination Kotlin so the image build can derive its graph

### DIFF
--- a/openbank-admin-ui/Dockerfile
+++ b/openbank-admin-ui/Dockerfile
@@ -160,6 +160,28 @@ RUN set -e; \
 # node_modules contains only JS/JSON — no arch-specific binaries — so it
 # is safe to copy into the arm64 runtime stage unchanged.
 # ──────────────────────────────────────────────────────────────────────
+# ──────────────────────────────────────────────────────────────────────
+# Stage 1g: Stage the ADR-0211 origination Kotlin so `prebuild` can derive the state graph.
+#
+# `generate-origination-graph.mjs` reads openbank-libs-domain/.../origination/*.kt — deliberately,
+# because a console that carried its own copy of the state machine would drift from the code that
+# runs it. But the build stage copies ONLY `openbank-admin-ui/`, so inside the image that path does
+# not exist: the script exited 1 and every admin-ui image build failed for six runs while local
+# builds and `npm test` stayed green, because they run with the repo root present (#3283).
+#
+# Staged as its own collector rather than widening the build COPY: the image context stays the
+# admin-ui directory plus explicitly named bundles, which is what every other input here does.
+# ──────────────────────────────────────────────────────────────────────
+FROM alpine:3.24@sha256:28bd5fe8b56d1bd048e5babf5b10710ebe0bae67db86916198a6eec434943f8b AS origination-collector
+WORKDIR /collect
+COPY . /repo
+RUN set -e; \
+    mkdir -p /origination-src/openbank-libs-domain/src/main/kotlin/com/openbank/libs/lending/origination; \
+    cp /repo/openbank-libs-domain/src/main/kotlin/com/openbank/libs/lending/origination/*.kt \
+       /origination-src/openbank-libs-domain/src/main/kotlin/com/openbank/libs/lending/origination/ 2>/dev/null || true; \
+    echo "── origination sources: $(ls /origination-src/openbank-libs-domain/src/main/kotlin/com/openbank/libs/lending/origination | wc -l) file(s) ──"; \
+    ls /origination-src/openbank-libs-domain/src/main/kotlin/com/openbank/libs/lending/origination
+
 FROM --platform=$BUILDPLATFORM node:26-alpine@sha256:725aeba2364a9b16beae49e180d83bd597dbd0b15c47f1f28875c290bfd255b9 AS deps
 WORKDIR /app
 COPY openbank-admin-ui/package.json openbank-admin-ui/package-lock.json* ./
@@ -201,6 +223,9 @@ ENV NEXT_PUBLIC_BUILD_VERSION=$BUILD_VERSION \
 
 COPY --from=deps /app/node_modules ./node_modules
 COPY openbank-admin-ui/ ./
+# The origination Kotlin, at the repo-relative path the generator expects (#3283). It resolves
+# against --repo, which defaults to the parent of the admin-ui directory — here, /.
+COPY --from=origination-collector /origination-src/openbank-libs-domain /openbank-libs-domain
 ENV NEXT_TELEMETRY_DISABLED=1
 ENV NEXT_STANDALONE=true
 # Source-map upload to GlitchTip (#3235). The token arrives as a BuildKit SECRET, not a build arg:


### PR DESCRIPTION
Closes #3283.

**Every admin-ui image build has failed since 12:24** — six consecutive runs — so nothing merged this
afternoon has reached the cluster, including the campaign journey canvas (#3262). The pod still
serves `sandbox-8d321a80` from 05:50.

## Cause

#3236 added `generate-origination-graph.mjs` to admin-ui's `prebuild`. It reads the ADR-0211 state
machine from `openbank-libs-domain` on purpose — a console carrying its own copy of the state machine
would drift from the code that runs it. But the build stage copies only `openbank-admin-ui/`:

```dockerfile
COPY openbank-admin-ui/ ./
```

so inside the image that path does not exist:

```
[generate-origination-graph] cannot read
openbank-libs-domain/src/main/kotlin/com/openbank/libs/lending/origination/OriginationState.kt
 — the ADR-0211 source of truth moved
```

**The file had not moved.** It is on `main` at exactly that path. The Docker build context simply does
not contain it — which is why `npm run build` and `npm test` stayed green on every developer machine
while the only build that ships failed.

## Fix

A collector stage, matching how docs, SBOMs, openapi and governance bundles already enter this image.
The build context stays "the admin-ui directory plus explicitly named inputs" rather than widening
the COPY to the repo root.

## Verification

Not "the Dockerfile parses". I replicated the container's layout — script at `/app/scripts`, sources
at `/openbank-libs-domain`, which is what the generator's `--repo` default (`__dirname/../..`)
resolves to inside the image — and ran the generator both ways:

```
without the staged sources : exit 1, and the exact error CI printed
with them                  : exit 0, 16 states (4 terminal), 41 edges
```

The first run also caught a probe bug of my own worth noting: I read `$?` after a pipe and got `0`
from `tail`, not from the script. The exit codes above are measured without the pipe.

## Why this was expensive to find

The failure is loud in the run list and invisible everywhere anyone looks: the PR is green and merges
normally (the image build happens **after** the merge), the deploy produces no GitOps PR so nothing
appears to be waiting, and the service keeps serving the previous image — which is indistinguishable
from a healthy deploy. I misdiagnosed it once as "the deploy never fired" before checking the runs.

The generalisable gap, noted in #3283 and not fixed here: nothing asserts that `npm run build` works
**in the container** before a merge. The PR lane builds with the repo root present; the deploy lane
builds from a directory subset. They are different builds, and only the second one ships.
