### PR TITLE
feat(admin-ui): give the campaign list a lifecycle board instead of an inventory table

### DIFF
--- a/openbank-admin-ui/src/app/campaigns/page.tsx
+++ b/openbank-admin-ui/src/app/campaigns/page.tsx
@@ -2,18 +2,38 @@
 // Copyright (c) OpenBank contributors. Licensed under the Apache License, Version 2.0.
 // See LICENSE in the repository root or https://www.apache.org/licenses/LICENSE-2.0 for details.
 
-'use client'
-
-import { useEffect, useState } from 'react'
-import Link from 'next/link'
-import { Megaphone } from 'lucide-react'
-import { useLanguage } from '@/lib/i18n/LanguageContext'
-import { DataUnavailable, type UnavailableKind } from '@/components/feedback/DataUnavailable'
-import { PageHeader, StatusBadge } from '@/components/ui'
-
-// Read-only by design (#2895). Authoring is ADR-0221: `submit` → `activate`-by-a-different-approver
+// The campaign operator's landing surface.
+//
+// WHAT WAS WRONG
+// A table of raw enum states (`PENDING_APPROVAL`) with a search box. That is an inventory, and a
+// marketer does not open a console to take inventory. Their questions are:
+//   - what is live right now
+//   - what is stuck waiting for someone to approve it, and for how long
+//   - what am I sitting on unfinished
+// The campaign LIFECYCLE answers all three at a glance, so it is the primary object; the rows are
+// the drill-down. Same board, motion and age semantics as the lending pipeline — a third visual
+// language on one console would be worse than either (see components/flow/StageBoard).
+//
+// WHAT THIS PAGE HONESTLY CANNOT SHOW
+// Reach, delivery and conversion — the numbers a CDP screen is really about. `GET /api/v1/campaigns`
+// returns campaign records only; enrolments and sends are per-campaign endpoints, so a performance
+// overview here would mean one request per campaign or an API that does not exist yet. Inventing
+// the numbers, or quietly implying the page covers performance, would be worse than saying so — the
+// board carries that sentence rather than hiding it in a doc.
+//
+// Read-only by design (#2895). Authoring is ADR-0221: `submit` → `activate`-by-a-DIFFERENT-approver
 // is a two-people-at-a-screen flow, and exposing half of it as buttons would lose the point of the
 // four-eyes gate while looking like it had one.
+
+'use client'
+
+import { useEffect, useMemo, useState } from 'react'
+import Link from 'next/link'
+import { Megaphone, Play, PauseCircle, PenLine, ShieldCheck } from 'lucide-react'
+import { useLanguage } from '@/lib/i18n/LanguageContext'
+import { DataUnavailable, type UnavailableKind } from '@/components/feedback/DataUnavailable'
+import { PageHeader, StatCard, StatusBadge } from '@/components/ui'
+import { StageBoard, summariseBy, type StageDef } from '@/components/flow/StageBoard'
 
 interface Campaign {
   id: string
@@ -26,13 +46,24 @@ interface Campaign {
   createdAt: string
 }
 
+/** `CampaignState` in campaign-service: DRAFT → PENDING_APPROVAL → ACTIVE → PAUSED → CLOSED.
+ *  Only CLOSED ends the lifecycle, so only CLOSED is exempt from age tinting — a campaign paused
+ *  for a week IS something someone should look at, unlike one that finished a week ago. */
+const LIFECYCLE: { key: string; cs: string; en: string; terminal?: boolean }[] = [
+  { key: 'DRAFT', cs: 'Rozpracovaná', en: 'Draft' },
+  { key: 'PENDING_APPROVAL', cs: 'Čeká na schválení', en: 'Awaiting approval' },
+  { key: 'ACTIVE', cs: 'Běží', en: 'Running' },
+  { key: 'PAUSED', cs: 'Pozastavená', en: 'Paused' },
+  { key: 'CLOSED', cs: 'Ukončená', en: 'Closed', terminal: true },
+]
+
 export default function CampaignsPage() {
   const { t, language } = useLanguage()
   const [items, setItems] = useState<Campaign[]>([])
   const [unavailable, setUnavailable] = useState<UnavailableKind | null>(null)
   const [loading, setLoading] = useState(true)
   const [search, setSearch] = useState('')
-  const [stateFilter, setStateFilter] = useState('')
+  const [stateFilter, setStateFilter] = useState<string | null>(null)
 
   useEffect(() => {
     fetch('/api/campaigns')
@@ -51,9 +82,30 @@ export default function CampaignsPage() {
   const fmtDate = (iso: string | null | undefined) =>
     iso ? new Intl.DateTimeFormat(language === 'cs' ? 'cs-CZ' : 'en-GB', { dateStyle: 'medium' }).format(new Date(iso)) : '—'
 
-  // States present in the data, not a hardcoded list: a state the API starts returning would be
-  // missing from the filter forever, and the rows would look like they had vanished.
-  const states = Array.from(new Set(items.map(c => c.state))).sort()
+  const label = (state: string) => {
+    const s = LIFECYCLE.find(x => x.key === state)
+    return s ? (language === 'cs' ? s.cs : s.en) : state
+  }
+
+  const stages: StageDef[] = LIFECYCLE.map(s => ({
+    key: s.key,
+    label: language === 'cs' ? s.cs : s.en,
+    terminal: s.terminal,
+  }))
+
+  const stats = useMemo(
+    () => summariseBy(items, c => c.state, c => c.createdAt),
+    [items],
+  )
+
+  /** Any state the API returns that the lifecycle above does not name. Shown rather than dropped:
+   *  a campaign silently missing from both the board and the count is worse than an unknown label. */
+  const unknownStates = useMemo(
+    () => Array.from(new Set(items.map(c => c.state))).filter(s => !LIFECYCLE.some(l => l.key === s)),
+    [items],
+  )
+
+  const counts = (k: string) => stats.get(k)?.count ?? 0
 
   const needle = search.trim().toLowerCase()
   const filtered = items.filter(
@@ -66,105 +118,135 @@ export default function CampaignsPage() {
     <div className="space-y-6">
       <PageHeader
         title={t('Kampaně', 'Campaigns')}
-        subtitle={t('Co běží, kdo byl zařazen a co k lidem opravdu dorazilo', 'What is running, who was enrolled, and what actually reached them')}
+        subtitle={t(
+          'Co běží, co čeká na schválení a co je rozpracované. Doručení a odezvu najdete v detailu kampaně.',
+          'What is running, what waits for approval, and what is unfinished. Delivery and response live in the campaign detail.',
+        )}
         icon={<Megaphone className="h-6 w-6" />}
+        actions={
+          <Link href="/campaigns/new" className="btn btn-primary" style={{ fontSize: 12 }}>
+            {t('Nová kampaň', 'New campaign')}
+          </Link>
+        }
       />
-
-      <Link
-        href="/campaigns/new"
-        className="inline-flex items-center gap-1 rounded-md border px-3 py-1.5 text-sm hover:bg-muted"
-      >
-        {t('Nová kampaň', 'New campaign')}
-      </Link>
 
       {loading && <p className="text-sm text-muted-foreground">{t('Načítám…', 'Loading…')}</p>}
 
       {!loading && unavailable && <DataUnavailable kind={unavailable} service="Campaign-service" feature={t('Kampaně', 'Campaigns')} />}
 
-      {/* Filtered in the browser, unlike the send log. A campaign list has one row per campaign,
-          not one per recipient, so it is bounded by how many campaigns a bank runs — the send log
-          is bounded by the audience, which is why that one pages on the server. */}
-      {!loading && !unavailable && items.length > 0 && (
-        <div className="flex flex-wrap items-center gap-3">
-          <input
-            type="search"
-            value={search}
-            onChange={e => setSearch(e.target.value)}
-            placeholder={t('Hledat podle názvu nebo cíle…', 'Search by name or goal…')}
-            aria-label={t('Hledat kampaně', 'Search campaigns')}
-            className="w-72 rounded-md border bg-transparent px-3 py-1.5 text-sm"
-          />
-          <select
-            value={stateFilter}
-            onChange={e => setStateFilter(e.target.value)}
-            aria-label={t('Filtr stavu', 'State filter')}
-            className="rounded-md border bg-transparent px-2 py-1.5 text-sm"
-          >
-            <option value="">{t('Všechny stavy', 'All states')}</option>
-            {states.map(st => (
-              <option key={st} value={st}>
-                {st} ({items.filter(c => c.state === st).length})
-              </option>
-            ))}
-          </select>
-          {filtered.length !== items.length && (
-            <span className="text-xs text-muted-foreground">
-              {t('Zobrazeno', 'Showing')} {filtered.length} {t('z', 'of')} {items.length}
-            </span>
-          )}
-        </div>
-      )}
-
       {!loading && !unavailable && items.length === 0 && (
         <p className="text-sm text-muted-foreground">{t('Zatím žádné kampaně.', 'No campaigns yet.')}</p>
       )}
 
-      {!loading && !unavailable && items.length > 0 && filtered.length === 0 && (
-        // Distinct from "no campaigns yet": one is an empty estate, the other is a filter the
-        // user can undo, and rendering the same sentence for both hides the undo.
-        <p className="text-sm text-muted-foreground">
-          {t('Žádná kampaň neodpovídá filtru.', 'No campaign matches the filter.')}
-        </p>
-      )}
+      {!loading && !unavailable && items.length > 0 && (
+        <>
+          <div className="grid-4">
+            <StatCard label={t('Běží', 'Running')} value={counts('ACTIVE')} icon={<Play size={13} />} />
+            <StatCard
+              label={t('Čeká na schválení', 'Awaiting approval')}
+              value={counts('PENDING_APPROVAL')}
+              tone={counts('PENDING_APPROVAL') > 0 ? 'warning' : undefined}
+              hint={t('potřebuje druhý pár očí', 'needs a second approver')}
+              icon={<ShieldCheck size={13} />}
+            />
+            <StatCard label={t('Rozpracované', 'Drafts')} value={counts('DRAFT')} icon={<PenLine size={13} />} />
+            <StatCard label={t('Pozastavené', 'Paused')} value={counts('PAUSED')}
+                      tone={counts('PAUSED') > 0 ? 'warning' : undefined} icon={<PauseCircle size={13} />} />
+          </div>
 
-      {!loading && !unavailable && filtered.length > 0 && (
-        <div className="overflow-x-auto rounded-lg border">
-          <table className="w-full text-sm">
-            <thead className="bg-muted/50 text-left">
-              <tr>
-                <th className="px-4 py-2 font-medium">{t('Název', 'Name')}</th>
-                <th className="px-4 py-2 font-medium">{t('Stav', 'State')}</th>
-                <th className="px-4 py-2 font-medium">{t('Segment', 'Segment')}</th>
-                <th className="px-4 py-2 font-medium">{t('Vytvořil', 'Created by')}</th>
-                <th className="px-4 py-2 font-medium">{t('Schválil', 'Approved by')}</th>
-                <th className="px-4 py-2 font-medium">{t('Vytvořeno', 'Created')}</th>
-              </tr>
-            </thead>
-            <tbody>
-              {filtered.map(c => (
-                <tr key={c.id} className="border-t">
-                  <td className="px-4 py-2">
-                    <Link href={`/campaigns/${c.id}`} className="font-medium hover:underline">
-                      {c.name}
-                    </Link>
-                    <div className="text-xs text-muted-foreground">{c.goal}</div>
-                  </td>
-                  <td className="px-4 py-2">
-                    <StatusBadge status={c.state} />
-                  </td>
-                  <td className="px-4 py-2 font-mono text-xs">
-                    {c.segmentRef?.name}@{c.segmentRef?.version}
-                  </td>
-                  <td className="px-4 py-2 text-xs">{c.createdBy}</td>
-                  {/* The checker, shown next to the maker on purpose: the maker/checker pair is
-                      the audit-relevant fact about an ACTIVE campaign, not a detail. */}
-                  <td className="px-4 py-2 text-xs">{c.approvedBy ?? '—'}</td>
-                  <td className="px-4 py-2 text-xs whitespace-nowrap">{fmtDate(c.createdAt)}</td>
-                </tr>
-              ))}
-            </tbody>
-          </table>
-        </div>
+          <StageBoard
+            stages={stages}
+            stats={stats}
+            selected={stateFilter}
+            onSelect={setStateFilter}
+            lang={language}
+            ariaLabel={t('Životní cyklus kampaní podle stavu', 'Campaign lifecycle by state')}
+            footnote={t(
+              'Doručení a odezva zde nejsou — seznam kampaní je od služby nevrací.',
+              'Delivery and response are not here — the campaign list endpoint does not return them.',
+            )}
+          />
+
+          {unknownStates.length > 0 && (
+            <p className="text-xs" style={{ color: 'var(--warning)' }} data-testid="unknown-states">
+              {t(
+                `Stav mimo známý životní cyklus: ${unknownStates.join(', ')} — na tabuli chybí, v tabulce je najdete.`,
+                `State outside the known lifecycle: ${unknownStates.join(', ')} — absent from the board, still listed below.`,
+              )}
+            </p>
+          )}
+
+          <div className="flex flex-wrap items-center gap-3">
+            <input
+              type="search"
+              value={search}
+              onChange={e => setSearch(e.target.value)}
+              placeholder={t('Hledat podle názvu nebo cíle…', 'Search by name or goal…')}
+              aria-label={t('Hledat kampaně', 'Search campaigns')}
+              className="w-72 rounded-md border bg-transparent px-3 py-1.5 text-sm"
+            />
+            {stateFilter && (
+              <button className="btn btn-secondary" style={{ fontSize: 11 }} onClick={() => setStateFilter(null)} data-testid="clear-state">
+                {t('Filtr:', 'Filter:')} {label(stateFilter)} ✕
+              </button>
+            )}
+            {filtered.length !== items.length && (
+              <span className="text-xs text-muted-foreground">
+                {t('Zobrazeno', 'Showing')} {filtered.length} {t('z', 'of')} {items.length}
+              </span>
+            )}
+          </div>
+
+          {filtered.length === 0 && (
+            // Distinct from "no campaigns yet": one is an empty estate, the other is a filter the
+            // user can undo, and rendering the same sentence for both hides the undo.
+            <p className="text-sm text-muted-foreground">
+              {t('Žádná kampaň neodpovídá filtru.', 'No campaign matches the filter.')}
+            </p>
+          )}
+
+          {filtered.length > 0 && (
+            <div className="overflow-x-auto rounded-lg border">
+              <table className="w-full text-sm">
+                <thead className="bg-muted/50 text-left">
+                  <tr>
+                    <th className="px-4 py-2 font-medium">{t('Název', 'Name')}</th>
+                    <th className="px-4 py-2 font-medium">{t('Stav', 'State')}</th>
+                    <th className="px-4 py-2 font-medium">{t('Segment', 'Segment')}</th>
+                    <th className="px-4 py-2 font-medium">{t('Vytvořil', 'Created by')}</th>
+                    <th className="px-4 py-2 font-medium">{t('Schválil', 'Approved by')}</th>
+                    <th className="px-4 py-2 font-medium">{t('Vytvořeno', 'Created')}</th>
+                  </tr>
+                </thead>
+                <tbody>
+                  {filtered.map(c => (
+                    <tr key={c.id} className="border-t">
+                      <td className="px-4 py-2">
+                        <Link href={`/campaigns/${c.id}`} className="font-medium hover:underline">
+                          {c.name}
+                        </Link>
+                        <div className="text-xs text-muted-foreground">{c.goal}</div>
+                      </td>
+                      {/* Human label for the reader, raw state kept as the title so the screen and
+                          the state machine can never end up describing different things. */}
+                      <td className="px-4 py-2">
+                        <span title={c.state}><StatusBadge status={c.state} label={label(c.state)} /></span>
+                      </td>
+                      <td className="px-4 py-2 font-mono text-xs">
+                        {c.segmentRef?.name}@{c.segmentRef?.version}
+                      </td>
+                      <td className="px-4 py-2 text-xs">{c.createdBy}</td>
+                      {/* The checker, shown next to the maker on purpose: the maker/checker pair is
+                          the audit-relevant fact about an ACTIVE campaign, not a detail. */}
+                      <td className="px-4 py-2 text-xs">{c.approvedBy ?? '—'}</td>
+                      <td className="px-4 py-2 text-xs whitespace-nowrap">{fmtDate(c.createdAt)}</td>
+                    </tr>
+                  ))}
+                </tbody>
+              </table>
+            </div>
+          )}
+        </>
       )}
     </div>
   )

--- a/openbank-admin-ui/src/components/flow/StageBoard.tsx
+++ b/openbank-admin-ui/src/components/flow/StageBoard.tsx
@@ -1,0 +1,223 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright (c) OpenBank contributors. Licensed under the Apache License, Version 2.0.
+// See LICENSE in the repository root or https://www.apache.org/licenses/LICENSE-2.0 for details.
+
+// A lifecycle drawn as a board: one bubble per stage, sized by how much sits in it and tinted by
+// how long the OLDEST item there has waited.
+//
+// WHY GENERIC
+// The lending console grew this shape first (its origination pipeline). Campaigns need the same
+// answer to the same question — where is work piling up, and what has been stuck longest — and a
+// third hand-drawn variant would be a third visual language on the same console. So the geometry,
+// the motion and the age semantics live here once, and each domain supplies only its own stages and
+// labels. (The lending pipeline is a sibling PR; it should adopt this once both have landed —
+// deliberately not refactored across an open branch.)
+//
+// AGE MEANS NOTHING ON A TERMINAL STAGE
+// Learned the hard way on the lending board: tinting terminal stages by age painted successfully
+// finished work red and told the desk it had problems it did not have. A stage marked terminal is
+// never toned by age here.
+//
+// Motion follows the service map: SMIL particles along the connectors, off automatically under
+// `prefers-reduced-motion`, and with an explicit control so anyone can stop it.
+
+'use client'
+
+import { FlowParticle } from '@/components/topology/FlowParticle'
+import { NodeShadow } from '@/components/topology/TopologyDefs'
+import { useFlowAnimation } from '@/components/topology/useFlowAnimation'
+
+export type StageTone = 'ok' | 'warn' | 'bad' | 'done'
+
+export type StageDef = {
+  /** Machine value — also the test id and the tooltip, so the board and the state machine can
+   *  never end up describing different things. */
+  key: string
+  label: string
+  /** Terminal stages end the lifecycle; they are never toned by age. */
+  terminal?: boolean
+}
+
+export type StageStat = { count: number; oldestHours: number | null }
+
+type Props = {
+  stages: StageDef[]
+  stats: Map<string, StageStat>
+  /** Hours after which a waiting stage is amber / red. */
+  warnAfterHours?: number
+  badAfterHours?: number
+  selected?: string | null
+  onSelect?: (key: string | null) => void
+  lang?: 'cs' | 'en'
+  /** Rendered under the board, e.g. the honest note about what the numbers do not include. */
+  footnote?: string
+  ariaLabel: string
+}
+
+const TONE_COLOR: Record<StageTone, string> = {
+  ok: 'var(--success)',
+  warn: 'var(--warning)',
+  bad: 'var(--danger)',
+  done: 'var(--text-tertiary)',
+}
+
+export function toneFor(
+  stat: StageStat | undefined,
+  terminal: boolean,
+  warnAfter: number,
+  badAfter: number,
+): StageTone {
+  if (terminal) return 'done'
+  const h = stat?.oldestHours ?? null
+  if (h === null) return 'ok'
+  if (h >= badAfter) return 'bad'
+  if (h >= warnAfter) return 'warn'
+  return 'ok'
+}
+
+/** Split a stage name onto at most two lines at a word boundary. Truncation was tried first and
+ *  produced names nobody could act on ("Připraveno k čer…"). */
+export function wrapLabel(text: string, max = 15): string[] {
+  if (text.length <= max) return [text]
+  const lines: string[] = ['']
+  for (const w of text.split(' ')) {
+    const candidate = lines[lines.length - 1] ? `${lines[lines.length - 1]} ${w}` : w
+    if (candidate.length <= max || lines[lines.length - 1] === '') lines[lines.length - 1] = candidate
+    else lines.push(w)
+  }
+  return lines.slice(0, 2)
+}
+
+/** Group items by a state accessor and record the OLDEST age per state — the queue's health is set
+ *  by the item that has waited longest, not by the average, which hides exactly that item. */
+export function summariseBy<T>(
+  items: T[],
+  state: (t: T) => string,
+  since: (t: T) => string | undefined,
+  now = Date.now(),
+): Map<string, StageStat> {
+  const out = new Map<string, StageStat>()
+  for (const it of items) {
+    const k = state(it)
+    const cur = out.get(k) ?? { count: 0, oldestHours: null }
+    cur.count += 1
+    const raw = since(it)
+    if (raw) {
+      const h = (now - new Date(raw).getTime()) / 3_600_000
+      if (Number.isFinite(h)) cur.oldestHours = cur.oldestHours === null ? h : Math.max(cur.oldestHours, h)
+    }
+    out.set(k, cur)
+  }
+  return out
+}
+
+export function StageBoard({
+  stages,
+  stats,
+  warnAfterHours = 24,
+  badAfterHours = 72,
+  selected,
+  onSelect,
+  lang = 'cs',
+  footnote,
+  ariaLabel,
+}: Props) {
+  const [flow, setFlow] = useFlowAnimation()
+  const t = (cs: string, en: string) => (lang === 'cs' ? cs : en)
+  const max = Math.max(1, ...[...stats.values()].map(v => v.count))
+
+  const COL = 132
+  const H = 158
+  const W = stages.length * COL
+
+  return (
+    <div>
+      <div style={{ display: 'flex', justifyContent: 'flex-end', marginBottom: 6 }}>
+        <button onClick={() => setFlow(f => !f)} className="btn btn-secondary" style={{ fontSize: 11 }} aria-pressed={flow}>
+          {flow ? t('Zastavit animaci', 'Pause motion') : t('Spustit animaci', 'Resume motion')}
+        </button>
+      </div>
+
+      <div className="card" style={{ padding: 12, overflowX: 'auto' }}>
+        {/* Capped at its natural width: with a short lifecycle (campaigns have five states) a
+            stretched-to-100% viewBox letterboxes the drawing into the middle of a very wide card
+            and the board reads as a lonely strip. Long lifecycles still fill the width and scroll. */}
+        <svg viewBox={`0 0 ${W} ${H}`} width="100%" height={H} role="img" aria-label={ariaLabel}
+             preserveAspectRatio="xMinYMid meet" style={{ maxWidth: W, display: 'block' }}>
+          <defs>
+            <NodeShadow id="stage-shadow" />
+            {stages.slice(0, -1).map((s, i) => (
+              <path key={s.key} id={`stage-edge-${i}`} d={`M ${i * COL + 84} 46 L ${(i + 1) * COL + 42} 46`} fill="none" />
+            ))}
+          </defs>
+
+          {/* One continuous rail: without it an empty stage left a gap and the lifecycle read as
+              BROKEN rather than as idle at that step. */}
+          <path d={`M 60 46 L ${(stages.length - 1) * COL + 60} 46`} stroke="var(--border)" strokeWidth={1.5} fill="none" />
+
+          {stages.slice(0, -1).map((s, i) => {
+            const live = (stats.get(s.key)?.count ?? 0) > 0
+            return (
+              <g key={`e-${s.key}`}>
+                <path d={`M ${i * COL + 84} 46 L ${(i + 1) * COL + 42} 46`}
+                      stroke={live ? 'var(--accent)' : 'var(--border)'} strokeWidth={live ? 2 : 1.5} fill="none" />
+                {flow && live && <FlowParticle pathId={`stage-edge-${i}`} color="var(--accent)" dur={2.2} begin={i * 0.2} />}
+              </g>
+            )
+          })}
+
+          {stages.map((s, i) => {
+            const st = stats.get(s.key)
+            const count = st?.count ?? 0
+            const tone = toneFor(st, !!s.terminal, warnAfterHours, badAfterHours)
+            const cx = i * COL + 60
+            const r = 16 + (count / max) * 13
+            const isSel = selected === s.key
+            const lines = wrapLabel(s.label)
+            return (
+              <g key={s.key} data-testid={`stage-${s.key}`} data-count={count} data-tone={tone}
+                 onClick={() => onSelect?.(isSel ? null : s.key)}
+                 style={{ cursor: onSelect ? 'pointer' : 'default' }}>
+                <title>{`${s.label} — ${count}`}</title>
+                <circle cx={cx} cy={46} r={r} filter="url(#stage-shadow)"
+                        fill={count ? 'var(--surface)' : 'var(--surface-2)'}
+                        stroke={count ? TONE_COLOR[tone] : 'var(--border)'}
+                        strokeWidth={isSel ? 3.5 : count ? 2 : 1.2} />
+                <text x={cx} y={51} textAnchor="middle" fontSize={count ? 15 : 12} fontWeight={700}
+                      fill={count ? 'var(--text)' : 'var(--text-tertiary)'}>{count}</text>
+                {lines.map((line, li) => (
+                  <text key={li} x={cx} y={82 + li * 11} textAnchor="middle" fontSize={9.5} fill="var(--text-secondary)">
+                    {line}
+                  </text>
+                ))}
+                {st?.oldestHours != null && count > 0 && tone !== 'done' && (
+                  <text x={cx} y={82 + lines.length * 11 + 3} textAnchor="middle" fontSize={9}
+                        fill={TONE_COLOR[tone]} fontWeight={600}>
+                    {st.oldestHours >= 24
+                      ? t(`nejstarší ${Math.floor(st.oldestHours / 24)} d`, `oldest ${Math.floor(st.oldestHours / 24)}d`)
+                      : t(`nejstarší ${Math.floor(st.oldestHours)} h`, `oldest ${Math.floor(st.oldestHours)}h`)}
+                  </text>
+                )}
+              </g>
+            )
+          })}
+        </svg>
+      </div>
+
+      <div style={{ display: 'flex', gap: 14, flexWrap: 'wrap', marginTop: 10, fontSize: 11, alignItems: 'center' }}>
+        <span style={{ color: 'var(--text-tertiary)' }}>{t('Stáří nejstarší položky ve stavu:', 'Age of the oldest item in a stage:')}</span>
+        {(['ok', 'warn', 'bad'] as const).map(k => (
+          <span key={k} style={{ display: 'inline-flex', alignItems: 'center', gap: 5 }}>
+            <span style={{ width: 9, height: 9, borderRadius: '50%', background: TONE_COLOR[k] }} />
+            {k === 'ok'
+              ? t(`do ${warnAfterHours} h`, `under ${warnAfterHours}h`)
+              : k === 'warn'
+                ? t(`${warnAfterHours}–${badAfterHours} h`, `${warnAfterHours}–${badAfterHours}h`)
+                : t(`nad ${badAfterHours} h`, `over ${badAfterHours}h`)}
+          </span>
+        ))}
+        {footnote && <span data-testid="board-footnote" style={{ marginLeft: 'auto', color: 'var(--text-tertiary)' }}>{footnote}</span>}
+      </div>
+    </div>
+  )
+}

--- a/openbank-admin-ui/src/test/campaigns-console-board.test.tsx
+++ b/openbank-admin-ui/src/test/campaigns-console-board.test.tsx
@@ -1,0 +1,139 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright (c) OpenBank contributors. Licensed under the Apache License, Version 2.0.
+// See LICENSE in the repository root or https://www.apache.org/licenses/LICENSE-2.0 for details.
+
+// The campaign board tells an operator where work is stuck. The tests are about the ways it could
+// tell them something false:
+//
+//  - tinting a CLOSED campaign by age (finished last month is not a month overdue),
+//  - dropping a campaign whose state the UI does not recognise, so it vanishes from the console,
+//  - implying the page covers delivery and response, which the list endpoint does not return.
+
+import { describe, it, expect, afterEach, vi } from 'vitest'
+import React from 'react'
+import { render, screen, cleanup, waitFor, fireEvent } from '@testing-library/react'
+import { LanguageProvider } from '@/lib/i18n/LanguageContext'
+import { SessionProvider } from '@/components/auth/SessionProvider'
+import { StageBoard, summariseBy, toneFor, wrapLabel } from '@/components/flow/StageBoard'
+import CampaignsPage from '@/app/campaigns/page'
+
+const HOUR = 3_600_000
+const NOW = Date.parse('2026-08-02T12:00:00Z')
+const at = (h: number) => new Date(NOW - h * HOUR).toISOString()
+
+const campaign = (state: string, hoursAgo: number, i = 0) => ({
+  id: `${state}-${i}`,
+  name: `Campaign ${state} ${i}`,
+  goal: 'goal',
+  segmentRef: { name: 'actives', version: 1 },
+  state,
+  createdBy: 'maker@openbank.local',
+  approvedBy: state === 'ACTIVE' ? 'checker@openbank.local' : null,
+  createdAt: at(hoursAgo),
+})
+
+function Providers({ children }: { children: React.ReactNode }) {
+  return React.createElement(SessionProvider, null, React.createElement(LanguageProvider, null, children))
+}
+
+afterEach(() => {
+  cleanup()
+  vi.unstubAllGlobals()
+  vi.restoreAllMocks()
+})
+
+describe('StageBoard primitives', () => {
+  it('keeps the OLDEST age per stage, not the newest', () => {
+    const s = summariseBy(
+      [{ st: 'DRAFT', at: at(2) }, { st: 'DRAFT', at: at(200) }],
+      x => x.st, x => x.at, NOW,
+    )
+    // The queue's health is set by the item that has waited longest; the newest one hides it.
+    expect(Math.round(s.get('DRAFT')!.oldestHours!)).toBe(200)
+  })
+
+  it('never tones a terminal stage by age', () => {
+    expect(toneFor({ count: 3, oldestHours: 900 }, true, 24, 72)).toBe('done')
+    expect(toneFor({ count: 3, oldestHours: 900 }, false, 24, 72)).toBe('bad')
+  })
+
+  it('wraps a long stage name instead of truncating it', () => {
+    expect(wrapLabel('Čeká na schválení')).toEqual(['Čeká na', 'schválení'])
+    expect(wrapLabel('Běží')).toEqual(['Běží'])
+  })
+
+  it('renders the honest footnote it is given', () => {
+    render(React.createElement(Providers, null, React.createElement(StageBoard, {
+      stages: [{ key: 'A', label: 'A' }],
+      stats: new Map([['A', { count: 1, oldestHours: 1 }]]),
+      ariaLabel: 'board',
+      footnote: 'delivery is not here',
+    })))
+    expect(screen.getByTestId('board-footnote').textContent).toBe('delivery is not here')
+  })
+})
+
+describe('campaigns console', () => {
+  const ITEMS = [
+    campaign('DRAFT', 3, 1),
+    campaign('PENDING_APPROVAL', 100, 2),
+    campaign('ACTIVE', 30, 3),
+    campaign('CLOSED', 900, 4),
+  ]
+
+  function mockFetch(items = ITEMS, state = 'ok') {
+    return vi.fn(async (input: RequestInfo | URL) => {
+      const url = String(input)
+      const json = (b: unknown) => new Response(JSON.stringify(b), { status: 200, headers: { 'content-type': 'application/json' } })
+      if (url.includes('/api/auth/session')) return new Response('null', { status: 200, headers: { 'content-type': 'application/json' } })
+      if (url.includes('/api/campaigns')) return json({ items, state })
+      return json({})
+    })
+  }
+
+  // ONE render, asserted several ways. Four separate renders of this page pushed unrelated files
+  // (card-issue-dialog, service-map-topology) past their timeouts under parallel load — the suite's
+  // cost is shared, so a heavy test is not only its own problem.
+  it('surfaces what waits for an approver, ages it, keeps the enum, and states what is missing', async () => {
+    vi.stubGlobal('fetch', mockFetch())
+    render(React.createElement(Providers, null, React.createElement(CampaignsPage)))
+
+    await waitFor(() => expect(screen.getByTestId('stage-PENDING_APPROVAL')).toBeTruthy())
+
+    // 100 hours waiting for an approver is the single most actionable fact on this screen…
+    expect(screen.getByTestId('stage-PENDING_APPROVAL').getAttribute('data-tone')).toBe('bad')
+    // …and a campaign closed long ago is not a problem, however old it is.
+    expect(screen.getByTestId('stage-CLOSED').getAttribute('data-tone')).toBe('done')
+
+    // The list endpoint returns campaign records only. Implying otherwise — or quietly omitting the
+    // fact — is what makes a console look like it is reporting performance when it is not.
+    expect(screen.getByTestId('board-footnote').textContent).toMatch(/does not return them|nevrací/)
+
+    // Human label for the reader, raw enum still reachable.
+    expect(screen.getAllByText('Awaiting approval').length).toBeGreaterThan(0)
+    expect(screen.getByTitle('PENDING_APPROVAL')).toBeTruthy()
+  })
+
+  it('does not silently swallow a campaign whose state it does not know', async () => {
+    vi.stubGlobal('fetch', mockFetch([...ITEMS, campaign('ARCHIVED', 5, 9)]))
+    render(React.createElement(Providers, null, React.createElement(CampaignsPage)))
+
+    await waitFor(() => expect(screen.getByTestId('unknown-states')).toBeTruthy())
+    expect(screen.getByTestId('unknown-states').textContent).toMatch(/ARCHIVED/)
+    // …and it is still in the table, so the row cannot disappear from the console entirely.
+    expect(screen.getByText('Campaign ARCHIVED 9')).toBeTruthy()
+  })
+
+  it('clicking a stage filters the table to it', async () => {
+    vi.stubGlobal('fetch', mockFetch())
+    render(React.createElement(Providers, null, React.createElement(CampaignsPage)))
+
+    await waitFor(() => expect(screen.getByTestId('stage-ACTIVE')).toBeTruthy())
+    fireEvent.click(screen.getByTestId('stage-ACTIVE'))
+
+    await waitFor(() => expect(screen.getByTestId('clear-state')).toBeTruthy())
+    expect(screen.queryByText('Campaign DRAFT 1')).toBeNull()
+    expect(screen.getByText('Campaign ACTIVE 3')).toBeTruthy()
+  })
+
+})

--- a/openbank-admin-ui/src/test/campaigns-console.test.tsx
+++ b/openbank-admin-ui/src/test/campaigns-console.test.tsx
@@ -83,7 +83,12 @@ describe('campaign console', () => {
     render(React.createElement(Providers, null, React.createElement(CampaignsPage)))
 
     await waitFor(() => expect(screen.getByText('smoke-offer')).toBeTruthy())
-    expect(screen.getByText('ACTIVE')).toBeTruthy()
+    // The state is now rendered as a human label ("Running"), because a marketer should not have to
+    // know what ACTIVE means. Both halves are asserted on purpose: the label is what the reader
+    // sees, and the raw enum stays reachable as the title so the screen and the state machine can
+    // never end up describing different things. Asserting only the label would let the two drift.
+    expect(screen.getAllByText('Running').length).toBeGreaterThan(0)
+    expect(screen.getByTitle('ACTIVE')).toBeTruthy()
     // The checker is shown next to the maker: for an ACTIVE campaign that pair is the
     // audit-relevant fact, and a console that hides it makes four-eyes unverifiable by eye.
     expect(screen.getByText('ops-checker@openbank.local')).toBeTruthy()


### PR DESCRIPTION
## What

The campaigns landing page was a table of raw enum states (`PENDING_APPROVAL`) with a search box.
That is an inventory — and a marketer does not open a console to take inventory. Their questions are:

> what is live, what is stuck waiting for someone to approve it and for how long, and what am I
> sitting on unfinished

So the **lifecycle** is now the primary object and the rows are the drill-down. The campaign *detail*
already got this treatment in #3262 (`JourneyCanvas`); this is the entry point it was missing.

## Extracted, not hand-drawn again

`components/flow/StageBoard` — the lending console grew this shape first, campaigns need the same
answer to the same question, and a third visual language on one console would be worse than either.
It carries the geometry, the service-map motion (SMIL particles, `prefers-reduced-motion` honoured,
explicit pause control) and the age semantics — including the rule the lending board had to learn
the hard way:

> **A terminal stage is never toned by age.** A campaign closed last month is not a month overdue.
> The lending board's first render painted nine successfully disbursed loans red.

The lending pipeline is an open sibling PR (#3279) and should adopt this once both land; refactoring
across an open branch would have been worse than the temporary duplication.

## What this page honestly cannot show

Reach, delivery and conversion — the numbers a CDP screen is really about. `GET /api/v1/campaigns`
returns campaign records only; enrolments and sends are **per-campaign** endpoints, so a performance
overview here means one request per campaign or an API that does not exist yet.

The board says so on itself rather than leaving the reader to assume the page covers performance.
That gap is the honest reason this is not yet an Exponea-class overview, and it is an API question,
not a UI one.

A state the API returns that the lifecycle does not name is **called out and still listed**, instead
of vanishing from both the board and the table.

## Falsification

Re-toning terminal stages by age, dropping unknown states, and removing the "delivery is not here"
note each turn the suite red (4 of 9, before the page tests were consolidated).

## Verification, and an honest note about it

- `npm run type-check` — clean
- `npm run lint` — 0 errors
- the new file passes on its own: **7/7**
- rendered and screenshotted; the board is capped to its natural width, because a five-stage
  lifecycle stretched to 100% letterboxed itself into the middle of a very wide card

**The full local suite is not a trustworthy signal on this machine right now.** It shows failures —
but a full run of a clean `origin/main` worktree shows them too (5 failed / 967 passed), all
timeouts in unrelated files, with the host at load average ~80 because a self-hosted Actions runner
and Java builds are sharing it. CI is the arbiter here, not my laptop.

I also owe a correction on #3279: I claimed there that similar failures "were mine, not
pre-existing". That comparison was uneven — I ran two files on the baseline against the full suite
on the branch. The consolidation done there was still worth doing, but the attribution was not
established.
