### PR TITLE
fix(infra): price the gateway models — an unpriced model costs $0 and voids every budget

### DIFF
--- a/.github/gates/gates.yaml
+++ b/.github/gates/gates.yaml
@@ -159,6 +159,16 @@ gates:
   # PyYAML is not stdlib: try multiple install paths for portability across
   # macOS (system python3 without pip, Homebrew pip3) and Linux ARC runners
   # (pip/pip3 not in PATH). Fall back to checking if pyyaml is already present.
+  - id: litellm-model-costs
+    name: every gateway model declares a per-token price (an unpriced model costs $0 and voids every budget)
+    group: gitops
+    mode: enforced
+    run: |
+      # Falsified both ways before wiring in: 4 findings against the unpriced tree, 0 after,
+      # 9 self-test cases including an explicit zero (which must NOT be treated as a price).
+      python3 .github/scripts/check-litellm-model-costs.py --self-test
+      python3 .github/scripts/check-litellm-model-costs.py --enforce
+
   - id: agent-virtual-keys
     name: every agent authenticates with its OWN LiteLLM virtual key, not the shared master key
     group: gitops

--- a/.github/scripts/check-litellm-model-costs.py
+++ b/.github/scripts/check-litellm-model-costs.py
@@ -1,0 +1,131 @@
+#!/usr/bin/env python3
+"""Every model routed through the LiteLLM gateway must declare its own per-token price.
+
+WHY THIS EXISTS. LiteLLM costs a request using a built-in model-cost table shipped inside the
+pinned dependency. When that table has no entry for a model, the request is costed at **$0** --
+it does not error, does not warn, and returns a perfectly normal 200. Every dollar-denominated
+control downstream then measures a meter that never moves:
+
+  - the per-key virtual-key budgets (the only per-CALLER ceiling),
+  - `max_budget` on the model itself, the one that lives in git,
+  - and the fleet-wide AiFleetDailySpendHigh alert.
+
+All three read as healthy while enforcing nothing. Measured on 2026-08-02: `deepseek-ai/
+DeepSeek-V3.2` -- the ops model behind devops-agent, the liveness sentinel and copilot -- had
+`in=0 out=0` in `/model/info`, and every `/spend/logs` row read `spend=0.0` after a real 200
+response of 13 tokens.
+
+A model whose price the table DOES know is not safe either: that is a value inside a dependency,
+so a version bump can drop or rename the entry and silently restore the $0 behaviour. Declaring
+the price in git makes it auditable and makes this gate possible.
+
+Run standalone:  .github/scripts/check-litellm-model-costs.py [--enforce]
+Self-test:       .github/scripts/check-litellm-model-costs.py --self-test
+"""
+
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+import yaml
+
+REPO = Path(__file__).resolve().parents[2]
+CONFIG = REPO / "openbank-infra" / "gitops" / "components" / "ai-platform" / "litellm-config.yaml"
+REQUIRED = ("input_cost_per_token", "output_cost_per_token")
+
+
+def offenders_in(model_list: list, where: str) -> list[str]:
+    """One message per model that cannot be costed. Both a MISSING key and an explicit zero are
+    violations: a zero price is indistinguishable at runtime from an absent one, so allowing it
+    would let the exact failure this gate exists for be re-introduced deliberately."""
+    out = []
+    for entry in model_list or []:
+        if not isinstance(entry, dict):
+            continue
+        name = entry.get("model_name", "<unnamed>")
+        params = entry.get("litellm_params") or {}
+        for key in REQUIRED:
+            value = params.get(key)
+            if value is None:
+                out.append(
+                    f"{where}: model '{name}' does not declare {key}. Without it LiteLLM falls "
+                    f"back to its built-in cost table, which costs an unknown model at $0 and "
+                    f"makes every budget and spend alert downstream measure nothing."
+                )
+            elif not isinstance(value, (int, float)) or value <= 0:
+                out.append(
+                    f"{where}: model '{name}' declares {key}={value!r}, which cannot cost a "
+                    f"request. A zero or non-numeric price is indistinguishable from having no "
+                    f"price at all."
+                )
+    return out
+
+
+def audit() -> list[str]:
+    if not CONFIG.exists():
+        return [f"{CONFIG.relative_to(REPO)}: not found — the gateway config moved, so this "
+                f"gate is checking nothing. Repoint it or remove it deliberately."]
+    doc = yaml.safe_load(CONFIG.read_text())
+    # The file is a ConfigMap; the proxy config is a string under data['config.yaml'].
+    raw = ((doc or {}).get("data") or {}).get("config.yaml")
+    if raw is None:
+        return [f"{CONFIG.relative_to(REPO)}: no data['config.yaml'] key — the ConfigMap shape "
+                f"changed and the model list can no longer be read."]
+    cfg = yaml.safe_load(raw) or {}
+    models = cfg.get("model_list")
+    if not models:
+        return [f"{CONFIG.relative_to(REPO)}: model_list is empty or absent. An empty list would "
+                f"otherwise make this gate pass while checking nothing."]
+    return offenders_in(models, CONFIG.relative_to(REPO).as_posix())
+
+
+def self_test() -> int:
+    priced = {"model_name": "m", "litellm_params": {"input_cost_per_token": 2.6e-07,
+                                                    "output_cost_per_token": 3.8e-07}}
+    cases = [
+        ("a fully priced model passes", [priced], 0),
+        ("a model with no cost keys is flagged twice (input and output)",
+         [{"model_name": "m", "litellm_params": {"max_budget": 20}}], 2),
+        ("a model missing only the output price is flagged once",
+         [{"model_name": "m", "litellm_params": {"input_cost_per_token": 1e-07}}], 1),
+        ("an explicit zero is a violation, not a price",
+         [{"model_name": "m", "litellm_params": {"input_cost_per_token": 0,
+                                                 "output_cost_per_token": 0}}], 2),
+        ("a string price cannot cost a request",
+         [{"model_name": "m", "litellm_params": {"input_cost_per_token": "0.1",
+                                                 "output_cost_per_token": 1e-07}}], 1),
+        ("a negative price is a violation",
+         [{"model_name": "m", "litellm_params": {"input_cost_per_token": -1e-07,
+                                                 "output_cost_per_token": 1e-07}}], 1),
+        ("no litellm_params at all is flagged", [{"model_name": "m"}], 2),
+        ("two priced models pass", [priced, priced], 0),
+        ("a non-dict entry does not crash the walk", ["nonsense"], 0),
+    ]
+    failed = 0
+    for name, models, expected in cases:
+        got = len(offenders_in(models, "test"))
+        ok = got == expected
+        failed += not ok
+        print(f"  {'PASS' if ok else 'FAIL'}  {name} (expected {expected}, got {got})")
+    print(f"self-test: {len(cases) - failed}/{len(cases)} passed")
+    return 1 if failed else 0
+
+
+def main() -> int:
+    if "--self-test" in sys.argv:
+        return self_test()
+    enforce = "--enforce" in sys.argv
+    findings = audit()
+    if not findings:
+        print("check-litellm-model-costs: OK — every gateway model declares a usable price.")
+        return 0
+    for f in findings:
+        print(f"{'::error::' if enforce else '::warning::'}{f}")
+    print(f"\n{len(findings)} problem(s). Until each model has a price, the per-key budgets, the "
+          f"per-model max_budget and AiFleetDailySpendHigh all measure a meter that never moves.")
+    return 1 if enforce else 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/openbank-infra/gitops/components/ai-platform/litellm-config.yaml
+++ b/openbank-infra/gitops/components/ai-platform/litellm-config.yaml
@@ -22,6 +22,18 @@ data:
           # only after the money is gone is a receipt, not a guardrail.
           max_budget: 20
           budget_duration: 1d
+          # Price DECLARED here, not inherited from LiteLLM's built-in model-cost map. That map
+          # had no entry for this model, so every call was costed at $0 — and a budget measured
+          # in dollars cannot bite when the meter never moves. Measured, not assumed: /model/info
+          # reported `in=0 out=0` while a real call returned 200 and 13 tokens, and every
+          # /spend/logs row read `spend=0.0`. That made THREE nested controls decorative at once —
+          # the per-key budgets, the max_budget directly above, and the 25 USD/day
+          # AiFleetDailySpendHigh alert — with nothing anywhere going red about it.
+          # Values are DeepInfra's own published price for this model
+          # (api.deepinfra.com/models/deepseek-ai/DeepSeek-V3.2: cents_per_input_token 2.6e-05,
+          # cents_per_output_token 3.8e-05), converted from cents to USD per token.
+          input_cost_per_token: 0.00000026
+          output_cost_per_token: 0.00000038
       # agent-service's admin-UI assistant model (#1919). It sends `model-gateway.models[].id`
       # verbatim, so the model_name MUST stay `llama-3.3-70b-versatile` — that is what repointing
       # agent-service at this gateway costs: an endpoint + key change, nothing else. The Groq key
@@ -36,6 +48,14 @@ data:
           # would let a runaway ops loop starve the interactive one, or vice versa.
           max_budget: 5
           budget_duration: 1d
+          # Declared for the same reason, even though LiteLLM's built-in map DOES currently price
+          # this model correctly (it reported 5.9e-07 / 7.9e-07, matching Groq's published
+          # $0.59 / $0.79 per million tokens). Relying on that is relying on a table inside a
+          # pinned dependency: a version bump that drops or renames the entry silently returns to
+          # costing every call $0 — the same failure as above, and equally silent. In git the
+          # number is auditable and a gate can check it.
+          input_cost_per_token: 0.00000059
+          output_cost_per_token: 0.00000079
     general_settings:
       # Virtual keys and every budget below persist here. Injected from the CNPG litellm-db-app
       # secret (components/ai-platform/postgres.yaml) — see the DATABASE_URL note in litellm.yaml

--- a/openbank-infra/gitops/components/ai-platform/litellm.yaml
+++ b/openbank-infra/gitops/components/ai-platform/litellm.yaml
@@ -26,7 +26,7 @@ spec:
         # would leave agent-service's repointed call failing "model not found" with a green,
         # in-sync ArgoCD — the same silent-degradation shape as an `optional: true` secret ref.
         # BUMP THIS whenever litellm-config.yaml changes; that is what rolls the pod.
-        openbank.tech/litellm-config-revision: "5"
+        openbank.tech/litellm-config-revision: "6"
     spec:
       securityContext:
         runAsNonRoot: true


### PR DESCRIPTION
## What

Both gateway models now declare their own per-token price. Without it LiteLLM was costing every call to the ops model at **$0**.

## How this surfaced

Checking whether spend attribution had started after #3284. Attribution *was* working — `/spend/logs` split rows correctly by `key_alias` — but every row read `spend=0.0` after a real 200 response of 13 tokens:

```
/model/info:  deepseek-ai/DeepSeek-V3.2   in=0        out=0
              llama-3.3-70b-versatile     in=5.9e-07  out=7.9e-07
```

LiteLLM prices a request from a built-in model-cost table inside the pinned dependency. That table has no entry for `deepseek-ai/DeepSeek-V3.2`, and an unknown model is costed at zero — no error, no warning, a perfectly normal 200. **Charging zero is not an error condition**, so there was nothing red anywhere to notice.

## What was actually broken

`deepseek-ai/DeepSeek-V3.2` is the ops model behind devops-agent, the liveness sentinel and copilot. Three nested dollar-denominated controls were all measuring a meter that never moves, and all three read as healthy:

| control | where | status before this PR |
|---|---|---|
| per-key virtual-key budgets (#3284) | database | measures $0 forever |
| `max_budget: 20` on the model | git — its own comment calls it *"the preventive control [that] bites BEFORE the detective one pages"* | measures $0 forever |
| `AiFleetDailySpendHigh` 25 USD/day | PrometheusRule | measures $0 forever |

This also corrects the claim I made in #3284, that the per-agent budgets were a working preventive control. They were correctly *configured* and correctly *attributed*, and they could not have fired.

## The prices

Providers' own published numbers, not estimates:

- **DeepSeek-V3.2** — DeepInfra's model API reports `cents_per_input_token: 2.6e-05`, `cents_per_output_token: 3.8e-05` → `0.00000026` / `0.00000038` USD per token.
- **llama-3.3-70b-versatile** — Groq's $0.59 / $0.79 per million → `0.00000059` / `0.00000079`, which matches what LiteLLM's table already returned.

llama is declared **even though the table currently prices it right**. That value lives inside a pinned dependency, so a version bump that drops or renames the entry silently restores the $0 behaviour — same failure, equally silent. In git it is auditable and a gate can check it.

## New enforced gate: `litellm-model-costs`

An explicit `0` counts as a violation, not as a price: at runtime a zero is indistinguishable from an absent entry, so accepting it would let exactly this failure be re-introduced deliberately.

Falsified both ways before wiring in:

- **4** findings against the unpriced tree, **0** after
- 9 self-test cases — explicit zero, negative, string-typed price, missing only the output price, absent `litellm_params`, non-dict entry
- runner's **real exit code checked without a pipe**: `1` unpriced, `0` priced — it blocks rather than only printing `::error::`
- an empty or unreadable `model_list` is a finding too, so the gate cannot pass by checking nothing

Refs #3284

🤖 Generated with [Claude Code](https://claude.com/claude-code)
