### PR TITLE
fix(agent-service): route model calls only through LiteLLM gateway

### DIFF
--- a/openbank-infra/gitops/components/agent/agent-service.yaml
+++ b/openbank-infra/gitops/components/agent/agent-service.yaml
@@ -59,7 +59,8 @@ spec:
               value: http://keycloak.iam.svc:8080/realms/openbank
             # openbank-services client secret — lets the agent mint a client-credentials
             # token (ROLE_OPERATOR) so its read tools reach the banking services as a
-            # least-privilege service principal. Same Secret as the Groq key.
+            # least-privilege service principal. Projected by the same ExternalSecret as the
+            # LiteLLM virtual key, but sourced from the agent-service OpenBao path.
             - name: OIDC_CLIENT_SECRET
               valueFrom:
                 secretKeyRef:
@@ -96,17 +97,6 @@ spec:
                 secretKeyRef:
                   name: agent-service-secrets
                   key: AGENT_MODEL_API_KEY
-                  optional: true
-            # ROLLOUT WINDOW ONLY — remove with the es-agent-service.yaml entry once the repointed
-            # image is live. The image deployed at merge time predates the AGENT_MODEL_* seam and
-            # still resolves `agent.model.openai.api-key` from GROQ_API_KEY against api.groq.com;
-            # dropping it here in the same commit would break the assistant until the deploy lands.
-            # Its removal is the precondition for the agent-pod egress lock (ADR-0175 §4).
-            - name: GROQ_API_KEY
-              valueFrom:
-                secretKeyRef:
-                  name: agent-service-secrets
-                  key: GROQ_API_KEY
                   optional: true
             # MCP tool backends — in-cluster ClusterIPs. get_account hits account-service
             # (accounts ns, live); balance via balance-service (balances ns, live).

--- a/openbank-infra/gitops/components/agent/networkpolicy-agent-egress.yaml
+++ b/openbank-infra/gitops/components/agent/networkpolicy-agent-egress.yaml
@@ -12,13 +12,6 @@
 # Ingress for this pod stays generator-owned; this file is egress-only. NetworkPolicies are additive,
 # so adding `Egress` here does not weaken the generated ingress allow-list.
 #
-# PRECONDITION — do not merge before both hold:
-#   1. The agent-service image running in the sandbox honours AGENT_MODEL_ENDPOINT (i.e. the #1919
-#      routing change is deployed, not merely merged). An older image resolves the backend endpoint
-#      from the baked-in https://api.groq.com/openai/v1, which this policy denies.
-#   2. `GROQ_API_KEY` has been dropped from agent-service.yaml and es-agent-service.yaml — its
-#      presence is the marker that the direct-to-provider path is still in use.
-#
 # THE ALLOW-LIST IS EXHAUSTIVE — every rule below is a destination agent-service actually has,
 # derived from its Deployment env, its application.yaml rest-clients, and its source. A destination
 # that is missing here is DROPPED by the VPC CNI network-policy agent (standard mode, ADR-0060) with

--- a/openbank-infra/gitops/components/copilot/networkpolicy-copilot-egress.yaml
+++ b/openbank-infra/gitops/components/copilot/networkpolicy-copilot-egress.yaml
@@ -1,0 +1,75 @@
+# Egress lockdown for copilot-service (ADR-0175 §4).
+#
+# The platform namespace now contains two LiteLLM callers: agent-service and copilot-service. The
+# gateway in ai-platform is the ONLY workload permitted to leave the cluster to a hosted LLM
+# provider, so the caller pod itself must be default-deny for internet egress and may reach only the
+# gateway plus its in-cluster dependencies.
+#
+# Hand-written and DELIBERATELY named networkpolicy-*.yaml (not network-policies.yaml) so
+# gen-network-policies.py — which owns/overwrites network-policies.yaml and emits INGRESS only —
+# never clobbers it (ADR-0081). Ingress for this pod stays generator-owned; this file is egress-only.
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: copilot-service-egress-allow-list
+  namespace: platform
+  labels:
+    app.kubernetes.io/name: copilot-service
+    app.kubernetes.io/part-of: platform
+spec:
+  podSelector:
+    matchLabels:
+      app.kubernetes.io/name: copilot-service
+  policyTypes:
+    - Egress
+  egress:
+    # DNS resolution.
+    - to:
+        - namespaceSelector:
+            matchLabels:
+              kubernetes.io/metadata.name: kube-system
+      ports:
+        - protocol: UDP
+          port: 53
+        - protocol: TCP
+          port: 53
+    # Hosted-model leg — always through the in-cluster LiteLLM gateway, never directly to the provider.
+    - to:
+        - namespaceSelector:
+            matchLabels:
+              kubernetes.io/metadata.name: ai-platform
+      ports:
+        - protocol: TCP
+          port: 4000
+    # Same-namespace dependency: redis session/token store.
+    - to:
+        - podSelector:
+            matchLabels:
+              app.kubernetes.io/name: copilot-redis
+      ports:
+        - protocol: TCP
+          port: 6379
+    # Customer JWT verification (Keycloak JWKS / metadata).
+    - to:
+        - namespaceSelector:
+            matchLabels:
+              kubernetes.io/metadata.name: iam
+      ports:
+        - protocol: TCP
+          port: 8080
+    # Customer data reads go through the BFF, not directly to banking services.
+    - to:
+        - namespaceSelector:
+            matchLabels:
+              kubernetes.io/metadata.name: customer-edge
+      ports:
+        - protocol: TCP
+          port: 8128
+    # OTLP traces to Tempo.
+    - to:
+        - namespaceSelector:
+            matchLabels:
+              kubernetes.io/metadata.name: observability
+      ports:
+        - protocol: TCP
+          port: 4317

--- a/openbank-infra/gitops/components/external-secrets/es-agent-service.yaml
+++ b/openbank-infra/gitops/components/external-secrets/es-agent-service.yaml
@@ -5,11 +5,6 @@
 # source and same shape as copilot's COPILOT_MODEL_API_KEY (es-copilot-service.yaml), each on its
 # own budgeted virtual key rather than the shared master key.
 #
-# GROQ_API_KEY is retained ONLY for the rollout window: the currently-deployed image predates the
-# AGENT_MODEL_* config seam and still reads GROQ_API_KEY against api.groq.com directly. Drop it (and
-# the matching env in agent-service.yaml) once the repointed image is live — that removal is the
-# precondition for turning on the agent-pod egress lock.
-#
 # OIDC_CLIENT_SECRET (openbank-services realm client) is unchanged.
 apiVersion: external-secrets.io/v1beta1
 kind: ExternalSecret
@@ -42,10 +37,6 @@ spec:
       remoteRef:
         key: litellm
         property: KEY_AGENT_SERVICE
-    - secretKey: GROQ_API_KEY
-      remoteRef:
-        key: agent-service
-        property: GROQ_API_KEY
     - secretKey: OIDC_CLIENT_SECRET
       remoteRef:
         key: agent-service


### PR DESCRIPTION
## Summary

Close the ADR-0031 D6/D7 GitOps gaps for platform namespace agent workloads by removing the last direct-provider fallback from `agent-service` manifests and adding an explicit egress allow-list for `copilot-service` so platform LLM callers can reach only the in-cluster LiteLLM gateway and required in-cluster dependencies.

## Type of change

- [x] fix (bug fix)
- [ ] feat (new functionality)
- [ ] refactor (no behavior change)
- [ ] perf (performance)
- [ ] docs
- [ ] chore (build / tooling)
- [ ] security (private until disclosed)
- [ ] breaking change

## Linked issues

N/A — ADR-0031 D6/D7 gap closure (gateway routing + egress lock)

## Changes

- Remove the `GROQ_API_KEY` rollout fallback from `agent-service` GitOps so the workload authenticates to LiteLLM only with its per-agent virtual key.
- Drop the now-stale precondition commentary from the existing `agent-service` egress allow-list to match the routed deployment state.
- Add a new `copilot-service` egress NetworkPolicy that allows only DNS, LiteLLM, Keycloak, customer-edge, Tempo, and Redis.

## Definition of Done

- [x] Hexagonal layering preserved (domain has zero framework imports).
- [ ] Unit tests added/updated.
- [ ] Integration tests added/updated (if service boundary involved).
- [ ] Contract tests updated (if public API changed).
- [ ] `./gradlew detekt ktlintCheck koverVerify build` passes.
- [x] No new lint warnings.
- [ ] OpenAPI spec regenerated (if REST API changed).
- [ ] Flyway migration added + rollback note (if DB changed).
- [ ] Avro schema versioned backward-compatibly (if event changed).
- [ ] Docs updated (README, ADR if architectural).

## Security checklist

- [x] No secrets, tokens, passwords, or PII in code, config, tests, logs.
- [x] No new `@SuppressWarnings`, `as Any`, `@Suppress("...")` without
      justification (state it in this PR).
- [x] No new third-party dependency, OR: dependency review attached
      (license, CVE, source).
- [x] Auth / crypto / payment code changed? → tag `security-review-required`.
- [ ] PII path changed? → tag `gdpr-review-required`.
- [ ] Cardholder data path changed? → tag `pci-review-required`.

## Compliance impact

- [x] DORA
- [ ] PCI DSS
- [ ] GDPR
- [ ] PSD2 / SCA / RTS
- [ ] AML / 5AMLD
- [ ] CNB reporting
- [ ] None

If any are marked, describe the impact and any required compensating
controls below.

Locks operator-side AI workloads to the declared in-cluster LiteLLM choke point so hosted-model egress stays centralized and reviewable.

## Rollout / Rollback

- Deployment strategy: rolling
- Rollback plan: revert this PR to restore the direct-provider fallback secret/env and remove the copilot egress allow-list if an undeclared dependency is discovered.
- Data migration reversible: N/A

## Screenshots / demo (if UI change)

<!-- attach -->

## Reviewer notes

- Validation run: changed YAML files parse cleanly via `yaml.safe_load_all`; LSP diagnostics are clean on every changed manifest.
- `python3 openbank-infra/scripts/gen-network-policies.py` was run to confirm the generated ingress baselines stay stable; no generated files changed.
- Offline Gradle verification is currently blocked in this isolated worktree because settings plugin resolution needs `org.gradle.toolchains.foojay-resolver-convention:1.0.0`, which is unavailable in the empty offline cache.
