### PR TITLE
fix(ci): forward the Pact Broker properties into the test JVM for the last three providers

### DIFF
--- a/openbank-clearing-simulator/build.gradle.kts
+++ b/openbank-clearing-simulator/build.gradle.kts
@@ -58,3 +58,25 @@ kover {
         }
     }
 }
+
+// Pact Broker verification (ADR-0092): forward the broker config CI passes with `-D` into the
+// (forked) test JVM. Without this the properties reach the Gradle daemon and stop there, so the
+// @PactBroker provider test is @EnabledIfSystemProperty(pactbroker.url)-skipped and pact-jvm
+// logs "Skipping publishing of verification results ... not 'true'" — even on a main push where
+// the workflow set PUBLISH_RESULTS=true. That is exactly how this module ended up with a Pact
+// Broker version carrying no branch and no verification result, leaving its consumers
+// permanently UNVERIFIED and undeployable (issue #3285). 14 of 17 providers already had this
+// block; the correlation with the three that did not was exact.
+tasks.withType<Test> {
+    listOf(
+        "pactbroker.url",
+        "pactbroker.auth.username",
+        "pactbroker.auth.password",
+        "pactbroker.enablePending",
+        "pactbroker.providerBranch",
+        "pact.verifier.publishResults",
+        "pact.provider.version",
+        "pact.provider.branch",
+        "pact.provider.tag",
+    ).forEach { key -> System.getProperty(key)?.let { systemProperty(key, it) } }
+}

--- a/openbank-product-catalog/build.gradle.kts
+++ b/openbank-product-catalog/build.gradle.kts
@@ -59,6 +59,25 @@ dependencies {
 // Set on the test JVM fork, not the Gradle daemon — System.setProperty would not propagate.
 tasks.withType<Test> {
     systemProperty("pact.rootDir", "${rootProject.projectDir}/pacts")
+
+    // Pact Broker verification (ADR-0092): forward the broker config CI passes with `-D`.
+    // Without this the properties reach the Gradle daemon and stop there, so the @PactBroker
+    // provider test is @EnabledIfSystemProperty(pactbroker.url)-skipped and pact-jvm logs
+    // "Skipping publishing of verification results ... not 'true'" — even on a main push where
+    // the workflow set PUBLISH_RESULTS=true. That is exactly how this module ended up with a
+    // broker version carrying no branch and no verification result, leaving its consumers
+    // permanently UNVERIFIED and undeployable (issue #3285).
+    listOf(
+        "pactbroker.url",
+        "pactbroker.auth.username",
+        "pactbroker.auth.password",
+        "pactbroker.enablePending",
+        "pactbroker.providerBranch",
+        "pact.verifier.publishResults",
+        "pact.provider.version",
+        "pact.provider.branch",
+        "pact.provider.tag",
+    ).forEach { key -> System.getProperty(key)?.let { systemProperty(key, it) } }
 }
 
 // Coverage floor (ADR-0020, ratchet-only — sweep #466: this module previously had NO

--- a/openbank-tpp-registry-service/build.gradle.kts
+++ b/openbank-tpp-registry-service/build.gradle.kts
@@ -66,3 +66,25 @@ kover {
         }
     }
 }
+
+// Pact Broker verification (ADR-0092): forward the broker config CI passes with `-D` into the
+// (forked) test JVM. Without this the properties reach the Gradle daemon and stop there, so the
+// @PactBroker provider test is @EnabledIfSystemProperty(pactbroker.url)-skipped and pact-jvm
+// logs "Skipping publishing of verification results ... not 'true'" — even on a main push where
+// the workflow set PUBLISH_RESULTS=true. That is exactly how this module ended up with a Pact
+// Broker version carrying no branch and no verification result, leaving its consumers
+// permanently UNVERIFIED and undeployable (issue #3285). 14 of 17 providers already had this
+// block; the correlation with the three that did not was exact.
+tasks.withType<Test> {
+    listOf(
+        "pactbroker.url",
+        "pactbroker.auth.username",
+        "pactbroker.auth.password",
+        "pactbroker.enablePending",
+        "pactbroker.providerBranch",
+        "pact.verifier.publishResults",
+        "pact.provider.version",
+        "pact.provider.branch",
+        "pact.provider.tag",
+    ).forEach { key -> System.getProperty(key)?.let { systemProperty(key, it) } }
+}


### PR DESCRIPTION

The Pact Broker config CI passes with `-D` reaches the Gradle DAEMON, not the forked
test JVM. Each service's build.gradle.kts has to forward it explicitly. Fourteen of
seventeen providers did. These three did not:

  openbank-clearing-simulator     forwarded nothing
  openbank-product-catalog        forwarded only pact.rootDir
  openbank-tpp-registry-service   forwarded nothing

The correlation with the three providers that have no main-branch version in the
broker (#3285) is exact — those are the same three.

WHAT IT CAUSED
  pactbroker.url never reaches the test JVM, so the @PactBroker provider test is
  skipped by its own @EnabledIfSystemProperty gate, and pact.verifier.publishResults
  never arrives either, so pact-jvm logs

    Skipping publishing of verification results as it has been disabled
    (pact.verifier.publishResults is not 'true')

  on a run where the workflow had set PUBLISH_RESULTS=true. The service then owns a
  broker version with no branch and no verification result, and every consumer of it
  reads UNVERIFIED forever: swift-service, card-issuance-service and psd2-service are
  blocked by exactly this.

HOW IT WAS FOUND, AND WHAT MISLED ME TWICE
  Both wrong turns came from grepping a job log for `pactbroker.url=`. The step's
  `run:` block is echoed into the log, so that pattern matches the SCRIPT TEXT
  -Dpactbroker.url="${PACT_BROKER_URL:-}" and returns an empty-looking value on a run
  where the variable was set. It reads exactly like proof that the workflow forgot to
  set it. The env GitHub prints per step settles it instead — PACT_BROKER_URL was
  https://pact.open-bank.tech and PUBLISH_RESULTS was true all along, so the loss had
  to be downstream of the workflow, at the Gradle-to-test-JVM boundary.

  The second wrong turn: _service-ci.yml's own comment says a second gradle invocation
  runs with these properties unset, which made the "Skipping publishing" lines look
  expected. It does not — #1009 made both invocations pass them verbatim precisely so
  `test` stays cache-consistent. The comment describes the bug that fix removed.

Compiles clean (exit 0 read directly, not through a pipe).

Refs #3285, #3232, #3178