### PR TITLE
ci(build): nightly verification-metadata sweep + fix the gate on non-Quarkus modules

### DIFF
--- a/.github/scripts/check-verification-metadata-complete.py
+++ b/.github/scripts/check-verification-metadata-complete.py
@@ -51,6 +51,22 @@ ARTIFACT_RE = re.compile(r'<artifact name="([^"]*)"')
 # without the cost of a full quarkusBuild — see #3199.
 TASKS = ("testClasses", "quarkusDependenciesBuild")
 
+# `quarkusDependenciesBuild` only exists on modules applying the `openbank.quarkus-service`
+# convention plugin. Three do not — openbank-libs-{domain,runtime,temporal} — and naming
+# the task for them fails the WHOLE invocation with "Cannot locate tasks that match", so a
+# PR touching one of those build files would take the check down with it. They still get
+# `testClasses`, which is the only graph they have.
+QUARKUS_MARKER = "openbank.quarkus-service"
+
+
+def tasks_for(module: str) -> tuple[str, ...]:
+    build_file = pathlib.Path(module) / "build.gradle.kts"
+    try:
+        is_quarkus = QUARKUS_MARKER in build_file.read_text(encoding="utf-8")
+    except OSError:
+        is_quarkus = False
+    return TASKS if is_quarkus else ("testClasses",)
+
 
 def artifact_set(path: pathlib.Path) -> set[str]:
     """Every (component, artifact) pair in the file, as flat 'g:n:v|artifact' keys."""
@@ -79,7 +95,7 @@ def regenerate(modules: list[str]) -> None:
     same outcome as "a gap was found": a crashed build proves nothing either way,
     and reporting it as a gap would send the author chasing entries that are fine.
     """
-    targets = [f":{module}:{task}" for module in modules for task in TASKS]
+    targets = [f":{module}:{task}" for module in modules for task in tasks_for(module)]
     result = subprocess.run(
         ["./gradlew", "--write-verification-metadata", "sha256",
          # Without this the check is vacuous on CI. A warm Gradle cache does not
@@ -107,9 +123,23 @@ def main() -> int:
                         help="comma-separated Gradle module dirs; empty means nothing to do")
     parser.add_argument("--enforce", action="store_true",
                         help="exit non-zero on a gap (default: warn only)")
+    parser.add_argument("--shard", type=str, default=None, metavar="I/N",
+                        help="with --modules all: take shard I of N (1-based), for the "
+                             "periodic guard — a single fleet run needs ~12g of heap, "
+                             "more than a 16 GB runner can safely give it")
     args = parser.parse_args()
 
-    modules = [m.strip() for m in args.modules.split(",") if m.strip()]
+    if args.modules.strip() == "all":
+        every = sorted(d.name for d in pathlib.Path(".").iterdir()
+                       if d.is_dir() and d.name.startswith("openbank-")
+                       and (d / "build.gradle.kts").is_file())
+        if args.shard:
+            index, total = (int(x) for x in args.shard.split("/"))
+            every = every[index - 1::total]
+            print(f"check-verification-metadata: shard {index}/{total}")
+        modules = every
+    else:
+        modules = [m.strip() for m in args.modules.split(",") if m.strip()]
     if not modules:
         print("check-verification-metadata: no Gradle modules changed — nothing to check")
         return 0
@@ -157,7 +187,7 @@ def main() -> int:
           f"modules resolves artifacts that gradle/verification-metadata.xml does not pin. "
           f"Regenerate locally and commit the additions: "
           f"./gradlew --write-verification-metadata sha256 "
-          f"{' '.join(f':{m}:{t}' for m in modules for t in TASKS)} "
+          f"{' '.join(f':{m}:{t}' for m in modules for t in tasks_for(m))} "
           f"-Dorg.gradle.jvmargs=-Xmx6g")
     for key in missing:
         component, artifact = key.split("|", 1)

--- a/.github/workflows/verification-metadata-drift.yml
+++ b/.github/workflows/verification-metadata-drift.yml
@@ -1,0 +1,127 @@
+# SPDX-License-Identifier: Apache-2.0
+# Copyright (c) OpenBank contributors. Licensed under the Apache License, Version 2.0.
+#
+# Periodic regression guard for gradle/verification-metadata.xml (#3131).
+#
+# The PR gate (#3233) only sees modules whose build.gradle.kts changed, and the
+# producer (#3199) only runs on Dependabot PRs. Neither notices a gap that arrives
+# some other way — a transitive dependency shifting under an unchanged version
+# range, a platform BOM bump pulling a new artifact, or a merge that raced both.
+# This sweeps the whole fleet on a schedule so such a gap has a ceiling on how long
+# it can sit undetected.
+#
+# Why it matters more each week: org.gradle.dependency.verification is `lenient`
+# today, so a missing entry is a warning. At the ADR-0144 graduation (2026-09-30,
+# #1915) it becomes a failing build on every cold cache at once — a fresh runner,
+# a recreated ARC volume, CodeQL's tracing build, a new clone.
+#
+# Sharded on purpose: one fleet-wide regeneration needs ~12g of heap (measured;
+# 6g died with `Java heap space` after 3h40m on the quarkusBuild variant), which is
+# more than a 16 GB runner can safely hand a single JVM. Eight shards of ~7 modules
+# each keep every job well inside that budget and run concurrently.
+#
+# Eight rather than four costs nothing: this repo is public, so ubuntu-latest minutes
+# are free and unmetered, and GitHub-hosted runners are outside our VPC so no NAT
+# egress is billed. The one resource that IS scarce is the Actions cache (~9 GB of a
+# 10 GB ceiling) — which is exactly why this workflow does not populate it.
+name: Verification metadata drift
+
+on:
+  schedule:
+    - cron: "20 4 * * *" # 04:20 UTC daily, after the nightly service builds
+  workflow_dispatch: {}
+
+permissions:
+  contents: read
+
+concurrency:
+  group: verification-metadata-drift
+  cancel-in-progress: false
+
+jobs:
+  sweep:
+    name: sweep ${{ matrix.shard }}/8
+    runs-on: ubuntu-latest
+    timeout-minutes: 45
+    strategy:
+      fail-fast: false # one shard's gap must not hide another's
+      matrix:
+        shard: [1, 2, 3, 4, 5, 6, 7, 8]
+    steps:
+      - uses: actions/checkout@v4
+
+      # No `cache: gradle` on purpose. Two reasons, one FinOps and one correctness:
+      # the repo's Actions cache sits at ~9 GB of its 10 GB ceiling across 61 entries, so
+      # eight more entries per night would evict caches that PR builds depend on — slowing
+      # everyone else down to speed up a nightly job that has no deadline. And the sweep
+      # passes --refresh-dependencies anyway, so a warm cache buys it nothing.
+      - uses: actions/setup-java@v4
+        with:
+          distribution: temurin
+          java-version: "25"
+
+      # The script passes --refresh-dependencies, which is what makes this real: on a
+      # warm cache Gradle does not re-resolve metadata artifacts, so a regeneration
+      # check reports "no gaps" even with an entry demonstrably deleted. CI caches are
+      # always warm. Do not "optimise" that flag away.
+      - name: Sweep shard for unpinned artifacts
+        run: |
+          python3 .github/scripts/check-verification-metadata-complete.py \
+            --modules all --shard "${{ matrix.shard }}/8" --enforce
+
+  # A red schedule is addressed to nobody. Turn a real gap into an owned ticket —
+  # the same reason fleet-attestation.yml and dependency-submission.yml do this.
+  raise-issue:
+    name: Raise issue on drift
+    needs: sweep
+    if: ${{ failure() && github.event_name == 'schedule' }}
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    permissions:
+      contents: read
+      issues: write
+    steps:
+      - uses: actions/checkout@v4
+      - name: Open or refresh the tracking issue
+        env:
+          GH_TOKEN: ${{ github.token }}
+          RUN_URL: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
+        run: |
+          set -euo pipefail
+          TITLE="verification-metadata drift: unpinned artifacts on main"
+          # Flush-left heredoc: `run: |` strips only the common YAML indent, so an
+          # indented body would carry leading spaces into the issue markdown.
+          BODY=$(cat <<EOF
+          The daily verification-metadata sweep FAILED: at least one Gradle module on
+          \`main\` resolves an artifact that \`gradle/verification-metadata.xml\` does not pin.
+
+          Run: ${RUN_URL} — each failing shard's log names the exact artifacts.
+
+          **Latent today, breaking on 2026-09-30.** \`org.gradle.dependency.verification\`
+          is \`lenient\`, so this is currently a warning. At the ADR-0144 graduation (#1915)
+          it becomes a failing build on every cold cache — a fresh runner, a recreated ARC
+          cache volume, CodeQL's tracing build, a new contributor clone.
+
+          To fix, regenerate for the affected modules and commit **only the additions**
+          (a full rewrite reindents ~18.5k lines and has previously deleted valid entries):
+
+          \`\`\`
+          ./gradlew --write-verification-metadata sha256 --refresh-dependencies \\
+            :<module>:testClasses :<module>:quarkusDependenciesBuild \\
+            -Dorg.gradle.jvmargs=-Xmx6g
+          \`\`\`
+
+          Cross-check each new sha256 against Maven Central's published \`.sha1\` before
+          committing it — this file is a security control, and "add the hash the build
+          showed you" is the failure mode it exists to prevent.
+
+          Context: #3131.
+          EOF
+          )
+          existing=$(gh issue list --state open --search "$TITLE in:title" --json number --jq '.[0].number' || true)
+          if [ -n "$existing" ]; then
+            gh issue comment "$existing" --body "$BODY"
+          else
+            gh issue create --title "$TITLE" --body "$BODY" \
+              --label fleet-health-build --label dependencies --label "severity:medium"
+          fi


### PR DESCRIPTION
## Two changes — the bug fix matters more than the feature

### 1. Bug fix for #3233, which is already on `main`

`quarkusDependenciesBuild` only exists on modules applying the `openbank.quarkus-service`
convention plugin. Three modules do not — `openbank-libs-{domain,runtime,temporal}` — and naming
the task for them fails the **entire** Gradle invocation:

```
Cannot locate tasks that match ':openbank-libs-domain:quarkusDependenciesBuild'
as task 'quarkusDependenciesBuild' not found in project
```

So today, any PR touching one of those three build files takes the gate down with it, surfacing as
`verification-metadata check could not run`. Tasks are now selected per module: 57 Quarkus services
get both tasks, the 3 library modules get `testClasses` only — the sole graph they have.

**This was my bug, introduced in #3233.** It survived because #3233 was only ever exercised against
`openbank-campaign-service`, a Quarkus service. The sharded sweep below was the first run that put a
library module into the same invocation, which is how it surfaced.

### 2. The periodic guard (#3131)

The PR gate sees only modules whose `build.gradle.kts` changed; the producer (#3199) runs only on
Dependabot PRs. Neither notices a gap arriving another way — a transitive dependency moving under an
unchanged version range, a platform BOM bump pulling a new artifact, a merge that raced both. This
sweeps the fleet nightly, so such a gap has a ceiling on how long it can sit undetected.

It **files an issue** rather than just going red: an unread red schedule is addressed to nobody,
the same reason `fleet-attestation.yml` escalates.

## Sizing and cost

**8 shards of ~7 modules.** One fleet-wide regeneration needs ~12g of heap (measured: 6g died with
`Java heap space` after 3h40m on the `quarkusBuild` variant), more than a 16 GB runner can safely
hand a single JVM.

Eight rather than four is **free**: the repo is public, so `ubuntu-latest` minutes are unmetered,
and GitHub-hosted runners sit outside our VPC, so no NAT egress is billed.

**No `cache: gradle`, deliberately.** The Actions cache is at **10.36 GB against a 10 GB ceiling
across 67 entries** (#3299) — already evicting. Eight nightly entries would push out caches that PR
builds depend on: slowing everyone else to speed up a job with no deadline. The sweep passes
`--refresh-dependencies` anyway, so a warm cache buys it nothing.

## What is verified

- `actionlint` clean on the new workflow
- 8 shards cover all 60 modules, no overlap, no gaps
- per-module task selection returns `(testClasses, quarkusDependenciesBuild)` for
  `openbank-campaign-service` and `(testClasses,)` for `openbank-libs-{domain,runtime}`
- the underlying script's detection was proven in CI on #3238: it went red naming the unpinned
  `jsoup-1.18.3.jar` / `.pom`

## What is NOT yet verified — stated plainly

The end-to-end run of the **fixed** script across a module set containing a library module has not
completed. Two attempts were killed by the OOM killer on my machine (`exit 143`), which is under
load from parallel agents — that says nothing about a clean runner, but it means I do not have the
local proof in hand yet.

I will post the result as a comment either way. **If it does not detect the deleted entry, this PR
should not merge as-is** and I will say so.

Also unproven: whether a 7-module shard fits a 16 GB runner. `timeout-minutes: 45` and
`fail-fast: false` are set; the first scheduled run is what will tell us. If shards OOM, raising the
shard count further is the cheap lever — it costs nothing on free runners.

## Linked issues

Refs #3131, #3233, #3299

🤖 Generated with [Claude Code](https://claude.com/claude-code)
