### PR TITLE
feat(admin-ui): lead the campaign people section with counts, not a list of UUIDs

### DIFF
--- a/openbank-admin-ui/src/app/campaigns/[id]/page.tsx
+++ b/openbank-admin-ui/src/app/campaigns/[id]/page.tsx
@@ -12,6 +12,7 @@ import { DataUnavailable, type UnavailableKind } from '@/components/feedback/Dat
 import { PageHeader, StatCard, StatusBadge, type Tone } from '@/components/ui'
 import { JourneyCanvas, type StepFunnel } from '@/components/campaigns/JourneyCanvas'
 import { SectionBoundary } from '@/components/feedback/SectionBoundary'
+import { PeopleSummary } from '@/components/campaigns/PeopleSummary'
 
 interface Campaign {
   id: string
@@ -358,28 +359,9 @@ export default function CampaignDetailPage({ params }: { params: Promise<{ id: s
                 dense
               />
             ) : (
-              <div className="overflow-x-auto rounded-lg border">
-                <table className="w-full text-sm">
-                  <thead className="bg-muted/50 text-left">
-                    <tr>
-                      <th className="px-4 py-2 font-medium">{t('Party', 'Party')}</th>
-                      <th className="px-4 py-2 font-medium">{t('Stav', 'State')}</th>
-                      <th className="px-4 py-2 font-medium">{t('Krok', 'Step')}</th>
-                    </tr>
-                  </thead>
-                  <tbody>
-                    {detail.enrolments.map(e => (
-                      <tr key={e.id} className="border-t">
-                        <td className="px-4 py-2 font-mono text-xs" title={e.partyId}>{shortId(e.partyId)}</td>
-                        <td className="px-4 py-2">
-                          <span title={e.state}><StatusBadge status={e.state} label={stateLabel(e.state)} /></span>
-                        </td>
-                        <td className="px-4 py-2">{e.currentStep}</td>
-                      </tr>
-                    ))}
-                  </tbody>
-                </table>
-              </div>
+              <SectionBoundary name="People">
+                <PeopleSummary enrolments={detail.enrolments} />
+              </SectionBoundary>
             )}
 
             {sends.length > 0 && (

--- a/openbank-admin-ui/src/app/globals.css
+++ b/openbank-admin-ui/src/app/globals.css
@@ -193,21 +193,6 @@ main {
 .badge-neutral { background: var(--surface-3);  color: var(--text-secondary); border: 1px solid var(--border-strong); }
 .badge-accent  { background: var(--ob-accent-light); color: var(--ob-accent-text); border: 1px solid var(--ob-accent-border); }
 
-/* ── Funnel bar (ADR-0208 D2 vocabulary, solid variant) ──
-   A proportion bar is not a chip. The `.badge-*` rules are pale backgrounds tuned so DARK TEXT sits
-   on them legibly, which makes them the wrong fill for a 14px bar carrying no text: at that size the
-   success and info pastels are barely distinguishable, and each segment's 1px border reads as noise
-   rather than structure. These use the SAME semantic variables at full saturation, so the meaning
-   stays in one place and only the presentation differs. Colour still never leaves this file. */
-.funnel-bar { display: flex; height: 14px; width: 100%; overflow: hidden; border-radius: 999px;
-              background: var(--surface-3); }
-.funnel-seg { height: 100%; border: 0; transition: width 240ms ease; }
-.funnel-seg-success { background: var(--success); }
-.funnel-seg-info    { background: var(--info); }
-.funnel-seg-warning { background: var(--warning); }
-.funnel-seg-danger  { background: var(--danger); }
-/* Neutral must stay visible against the track it sits on, so it is a mid grey, not the track grey. */
-.funnel-seg-neutral { background: var(--text-secondary); opacity: 0.45; }
 
 /* ── Button ── */
 @layer components {

--- a/openbank-admin-ui/src/components/campaigns/PeopleSummary.tsx
+++ b/openbank-admin-ui/src/components/campaigns/PeopleSummary.tsx
@@ -1,0 +1,118 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright (c) OpenBank contributors. Licensed under the Apache License, Version 2.0.
+// See LICENSE in the repository root or https://www.apache.org/licenses/LICENSE-2.0 for details.
+
+'use client'
+
+import { useLanguage } from '@/lib/i18n/LanguageContext'
+import { StatusBadge, type Tone } from '@/components/ui'
+
+/**
+ * Where the people in a campaign currently are, counted by state.
+ *
+ * This replaces a per-person table of party UUIDs as the default view. The table was not badly
+ * formatted — it answered a question a campaign person does not have. "What happened to
+ * `05a02ef1`" is a lookup you perform when someone complains; "how many are still running and how
+ * many stopped, and why" is what you open the screen for. Showing the lookup by default made the
+ * screen read as a database dump.
+ *
+ * The per-person rows are still one click away, and deliberately labelled as the debugging view.
+ * They are the only place an individual case can be traced, so hiding them entirely would trade one
+ * unusable screen for another.
+ */
+
+export interface Enrolment {
+  id: string
+  partyId: string
+  state: string
+  currentStep: number
+}
+
+/** Colour by meaning: still running, finished normally, or stopped by a rule. */
+const STATE_TONE: Record<string, Tone> = {
+  ACTIVE: 'success',
+  COMPLETED: 'info',
+  TERMINATED_CONSENT_REVOKED: 'warning',
+  TERMINATED_SUPPRESSED: 'neutral',
+  TERMINATED_CAMPAIGN_CLOSED: 'neutral',
+}
+
+export function PeopleSummary({ enrolments }: { enrolments: Enrolment[] }) {
+  const { t, language } = useLanguage()
+  const n = (v: number) => v.toLocaleString(language === 'cs' ? 'cs-CZ' : 'en-GB')
+
+  /** Plain language. The enum stays on the row's `data-state`, never in the visible text. */
+  const stateLabel = (s: string): string =>
+    ({
+      ACTIVE: t('Prochází kampaní', 'Still in the journey'),
+      COMPLETED: t('Dokončili cestu', 'Finished the journey'),
+      TERMINATED_CONSENT_REVOKED: t('Odvolali souhlas', 'Withdrew consent'),
+      TERMINATED_SUPPRESSED: t('Zastaveni pravidlem', 'Stopped by a rule'),
+      TERMINATED_CAMPAIGN_CLOSED: t('Kampaň byla uzavřena', 'Campaign was closed'),
+    })[s] ?? s
+
+  const rows = Array.isArray(enrolments) ? enrolments : []
+  const counts = rows.reduce<Record<string, number>>((acc, e) => {
+    acc[e.state] = (acc[e.state] ?? 0) + 1
+    return acc
+  }, {})
+  const ordered = Object.entries(counts).sort((a, b) => b[1] - a[1])
+
+  if (rows.length === 0) {
+    return (
+      <p className="text-sm text-muted-foreground">
+        {t('Zatím nikdo nebyl zařazen.', 'Nobody has been enrolled yet.')}
+      </p>
+    )
+  }
+
+  return (
+    <div className="space-y-3">
+      <div className="flex flex-wrap gap-2">
+        {ordered.map(([state, count]) => (
+          <div
+            key={state}
+            data-state={state}
+            className="rounded-lg border px-4 py-3"
+            style={{ minWidth: 168 }}
+          >
+            <div className="text-2xl font-semibold tabular-nums">{n(count)}</div>
+            <div className="mt-0.5 text-xs text-muted-foreground">{stateLabel(state)}</div>
+          </div>
+        ))}
+      </div>
+
+      {/* Collapsed by default and named for what it is. An operator tracing one complaint needs
+          this; nobody deciding whether the campaign works does. */}
+      <details className="rounded-lg border">
+        <summary className="cursor-pointer px-4 py-2 text-sm text-muted-foreground">
+          {t('Jednotliví lidé (pro ladění)', 'Individual people (for debugging)')} — {n(rows.length)}
+        </summary>
+        <div className="overflow-x-auto border-t">
+          <table className="w-full text-sm">
+            <thead className="bg-muted/50 text-left">
+              <tr>
+                <th className="px-4 py-2 font-medium">{t('Party', 'Party')}</th>
+                <th className="px-4 py-2 font-medium">{t('Stav', 'State')}</th>
+                <th className="px-4 py-2 font-medium">{t('Krok', 'Step')}</th>
+              </tr>
+            </thead>
+            <tbody>
+              {rows.map(e => (
+                <tr key={e.id} className="border-t" data-state={e.state}>
+                  <td className="px-4 py-2 font-mono text-xs" title={e.partyId}>
+                    {e.partyId.slice(0, 8)}
+                  </td>
+                  <td className="px-4 py-2">
+                    <StatusBadge status={e.state} label={stateLabel(e.state)} tone={STATE_TONE[e.state] ?? 'neutral'} />
+                  </td>
+                  <td className="px-4 py-2">{e.currentStep}</td>
+                </tr>
+              ))}
+            </tbody>
+          </table>
+        </div>
+      </details>
+    </div>
+  )
+}

--- a/openbank-admin-ui/src/test/campaigns-console.test.tsx
+++ b/openbank-admin-ui/src/test/campaigns-console.test.tsx
@@ -116,12 +116,16 @@ describe('campaign console', () => {
     // Human phrasing is what a marketer reads…
     await waitFor(() => expect(screen.getByText('Consent withdrawn')).toBeTruthy(), { timeout: 8000 })
     expect(screen.getByText('Sent')).toBeTruthy()
-    expect(screen.getByText('Ended — consent withdrawn')).toBeTruthy()
+    // The enrolment table became a counts-by-state summary (PeopleSummary); the label moved
+    // with it. Assert the summary's wording, not the old row badge.
+    expect(screen.getAllByText(/Withdrew consent/).length).toBeGreaterThan(0)
 
     // …and the raw enum stays reachable, so the screen and the API never describe different things.
     // Without this, relabelling could quietly drift from the values the service actually emits.
     expect(screen.getByTitle('SUPPRESSED_CONSENT')).toBeTruthy()
-    expect(screen.getByTitle('TERMINATED_CONSENT_REVOKED')).toBeTruthy()
+    // The enrolment state moved from a `title` on a table row to `data-state` on the summary
+    // tile — same rule as the journey canvas: the enum stays queryable, never visible text.
+    expect(document.querySelector('[data-state="TERMINATED_CONSENT_REVOKED"]')).toBeTruthy()
 
     // Surfaced as a headline number, not buried in the table.
     expect(screen.getByText('Suppressed sends')).toBeTruthy()

--- a/openbank-admin-ui/src/test/people-summary.test.tsx
+++ b/openbank-admin-ui/src/test/people-summary.test.tsx
@@ -1,0 +1,75 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright (c) OpenBank contributors. Licensed under the Apache License, Version 2.0.
+// See LICENSE in the repository root or https://www.apache.org/licenses/LICENSE-2.0 for details.
+
+import React from 'react'
+import { describe, expect, it } from 'vitest'
+import { render, screen } from '@testing-library/react'
+import { LanguageProvider } from '@/lib/i18n/LanguageContext'
+import { PeopleSummary } from '@/components/campaigns/PeopleSummary'
+
+const ENROLMENTS = [
+  { id: 'a', partyId: '05a02ef1-381c-40e7-b73f-d6855eead42e', state: 'TERMINATED_SUPPRESSED', currentStep: 0 },
+  { id: 'b', partyId: '026289e3-0b80-452a-be01-e69034838549', state: 'TERMINATED_SUPPRESSED', currentStep: 0 },
+  { id: 'c', partyId: '5e3d6411-cb5b-4e94-83f8-de95495ef5dd', state: 'TERMINATED_CONSENT_REVOKED', currentStep: 1 },
+  { id: 'd', partyId: '7a1b2c3d-0000-0000-0000-000000000000', state: 'ACTIVE', currentStep: 1 },
+]
+
+const show = (rows = ENROLMENTS) =>
+  render(React.createElement(LanguageProvider, null, React.createElement(PeopleSummary, { enrolments: rows })))
+
+describe('people summary', () => {
+  /**
+   * The reason this component exists. A per-person table of party UUIDs answers "what happened to
+   * 05a02ef1" — a lookup you do when someone complains. The screen is opened to answer "how many
+   * are still running, how many stopped, and why", and showing the lookup by default made the page
+   * read as a database dump.
+   */
+  it('leads with counts by state, in words', () => {
+    show()
+
+    // The label appears twice on purpose — once on the count tile, once on the row badge in the
+    // collapsed detail — so assert the TILE, which is what leads the section.
+    expect(screen.getByText('2')).toBeTruthy()
+    expect(screen.getAllByText(/Stopped by a rule/).length).toBeGreaterThan(0)
+    expect(screen.getAllByText(/Withdrew consent/).length).toBeGreaterThan(0)
+    expect(screen.getAllByText(/Still in the journey/).length).toBeGreaterThan(0)
+  })
+
+  it('never shows a state enum as visible text', () => {
+    const { container } = show()
+
+    expect(container.textContent).not.toMatch(/TERMINATED_/)
+    expect(container.textContent).not.toMatch(/\bACTIVE\b/)
+  })
+
+  /**
+   * …but the enum stays queryable, so the screen and the API cannot drift apart unnoticed — the
+   * same rule the journey canvas follows with `data-outcome`.
+   */
+  it('keeps the raw state reachable for whoever is debugging', () => {
+    const { container } = show()
+
+    expect(container.querySelector('[data-state="TERMINATED_CONSENT_REVOKED"]')).toBeTruthy()
+    expect(container.querySelector('[data-state="ACTIVE"]')).toBeTruthy()
+  })
+
+  /**
+   * The per-person rows are the only place an individual case can be traced, so they are one click
+   * away rather than gone — and named for what they are, so nobody mistakes them for the overview.
+   */
+  it('keeps the per-person rows behind a disclosure, labelled as debugging', () => {
+    const { container } = show()
+
+    const details = container.querySelector('details')
+    expect(details).toBeTruthy()
+    expect(details?.hasAttribute('open')).toBe(false)
+    expect(screen.getByText(/for debugging/)).toBeTruthy()
+  })
+
+  it('says nobody is enrolled rather than rendering an empty table', () => {
+    show([])
+
+    expect(screen.getByText(/Nobody has been enrolled yet/)).toBeTruthy()
+  })
+})


### PR DESCRIPTION
Refs #2895.

## The enrolment table answered the wrong question

It was not badly formatted. "What happened to `05a02ef1`" is a **lookup** you perform when someone
complains; the screen is opened to answer "how many are still running, how many stopped, and why".
Showing the lookup by default made the page read as a database dump — which is the feedback.

Now the section leads with count tiles in plain language: **Stopped by a rule**, **Withdrew
consent**, **Still in the journey**. The per-person rows are one click away behind a disclosure
labelled "Individual people (for debugging)" — they are the only place an individual case can be
traced, so removing them would trade one unusable screen for another.

The state enum moved to `data-state` and is never visible text, the same rule the journey canvas
follows with `data-outcome`: the raw value stays queryable so the screen and the API cannot drift
apart without a test noticing.

Also removes `.funnel-bar` / `.funnel-seg-*` from `globals.css` — the component that used them was
replaced by the SVG canvas and the CSS outlived it (1 154 bytes of dead rules).

## Something worth knowing about this suite

While checking my work I nearly attributed pre-existing flakiness to this change. Three unrelated
files failed alongside mine; run on their own against a clean tree they passed, which looked
damning. Running the **full** suite against a clean tree produces **15** failures — more than the 6
I saw with my change.

So `npm test` is order-dependent and unstable on `main` today, independently of this PR. I have not
chased it here, but it is worth knowing before anyone reads a red run as a regression: mine and the
baseline's failure sets differ, and neither is empty.

My own files pass: `people-summary`, `campaigns-console` and `journey-flow` — 16/16 together, `tsc`
clean.

## Not in this PR

Two things the same feedback asked for, both larger than a table swap:

- **Party names instead of IDs.** The send log and the debugging rows still show a truncated party
  UUID. campaign-service stores only the id; showing a name means a party-service lookup per row,
  and putting customer names on a marketing screen is a privacy decision, not a formatting one.
- **Visual campaign authoring.** The create form is still a form. A simplified BPMN-style canvas is
  the right shape and is ADR-0221's D1 wizard done properly — a piece of work in its own right,
  not a follow-up commit.
