### PR TITLE
feat(lending): per-state and per-status totals for the whole book

### DIFF
--- a/openbank-lending-service/src/main/kotlin/com/openbank/lending/application/port/in/LendingUseCases.kt
+++ b/openbank-lending-service/src/main/kotlin/com/openbank/lending/application/port/in/LendingUseCases.kt
@@ -5,13 +5,13 @@
 package com.openbank.lending.application.port.`in`
 
 import com.openbank.lending.domain.model.AccrualOutcome
+import com.openbank.lending.domain.model.ApplicationStateSummary
 import com.openbank.lending.domain.model.Collateral
 import com.openbank.lending.domain.model.CollateralDecisionRequest
 import com.openbank.lending.domain.model.CollateralRequest
 import com.openbank.lending.domain.model.DecisionRequest
 import com.openbank.lending.domain.model.Loan
 import com.openbank.lending.domain.model.LoanApplication
-import com.openbank.lending.domain.model.ApplicationStateSummary
 import com.openbank.lending.domain.model.LoanApplicationRequest
 import com.openbank.lending.domain.model.LoanInstallment
 import com.openbank.lending.domain.model.LoanStateSummary

--- a/openbank-lending-service/src/main/kotlin/com/openbank/lending/application/port/in/LendingUseCases.kt
+++ b/openbank-lending-service/src/main/kotlin/com/openbank/lending/application/port/in/LendingUseCases.kt
@@ -11,8 +11,10 @@ import com.openbank.lending.domain.model.CollateralRequest
 import com.openbank.lending.domain.model.DecisionRequest
 import com.openbank.lending.domain.model.Loan
 import com.openbank.lending.domain.model.LoanApplication
+import com.openbank.lending.domain.model.ApplicationStateSummary
 import com.openbank.lending.domain.model.LoanApplicationRequest
 import com.openbank.lending.domain.model.LoanInstallment
+import com.openbank.lending.domain.model.LoanStateSummary
 import com.openbank.lending.domain.model.ProvisioningRunOutcome
 import com.openbank.lending.domain.model.ProvisioningSnapshot
 import com.openbank.lending.domain.model.RescheduleRequest
@@ -51,6 +53,9 @@ interface ApplyForLoanUseCase {
 
     /** Backoffice queue (ADR-0230 D1): newest applications fleet-wide, optionally one status. */
     fun listRecentApplications(status: String?, limit: Int): Uni<List<LoanApplication>>
+
+    /** Per-state totals over the WHOLE book (issue #3294) — what the capped queue above cannot say. */
+    fun summariseApplications(): Uni<List<ApplicationStateSummary>>
 }
 
 /**
@@ -70,6 +75,9 @@ interface ServicingUseCase {
 
     /** Backoffice portfolio view (ADR-0230 D1): active loans fleet-wide. */
     fun listActiveLoans(limit: Int): Uni<List<Loan>>
+
+    /** Per-status totals over the WHOLE loan book (issue #3294). */
+    fun summariseLoans(): Uni<List<LoanStateSummary>>
     fun recordRepayment(loanId: LoanId, installmentId: UUID): Uni<LoanInstallment>
 }
 

--- a/openbank-lending-service/src/main/kotlin/com/openbank/lending/application/port/out/LendingRepositories.kt
+++ b/openbank-lending-service/src/main/kotlin/com/openbank/lending/application/port/out/LendingRepositories.kt
@@ -4,11 +4,13 @@
 
 package com.openbank.lending.application.port.out
 
+import com.openbank.lending.domain.model.ApplicationStateSummary
 import com.openbank.lending.domain.model.Collateral
 import com.openbank.lending.domain.model.Loan
 import com.openbank.lending.domain.model.LoanApplication
 import com.openbank.lending.domain.model.LoanInstallment
 import com.openbank.lending.domain.model.LoanProvisioningRecord
+import com.openbank.lending.domain.model.LoanStateSummary
 import com.openbank.libs.domain.identifiers.CollateralId
 import com.openbank.libs.domain.identifiers.LoanApplicationId
 import com.openbank.libs.domain.identifiers.LoanId
@@ -22,6 +24,13 @@ interface LoanApplicationRepository {
 
     /** Backoffice queue (ADR-0230 D1): newest applications fleet-wide, optionally one status. */
     fun findRecent(status: String?, limit: Int): Uni<List<LoanApplication>>
+
+    /**
+     * Per-state totals for the whole book (issue #3294) — the answer [findRecent] cannot give,
+     * because it is capped and a capped count is not a count. Aggregated in the database; walking
+     * pages to add up rows would be the same wrong answer, slower.
+     */
+    fun summariseByState(): Uni<List<ApplicationStateSummary>>
     fun update(application: LoanApplication): Uni<LoanApplication>
 }
 
@@ -33,6 +42,10 @@ interface LoanRepository {
 
     /** ACTIVE loans still on the books, ordered deterministically — drives the provisioning cycle scan. */
     fun findActive(limit: Int): Uni<List<Loan>>
+
+    /** Per-status totals across the whole loan book (issue #3294). See the note on
+     *  [LoanApplicationRepository.summariseByState]. */
+    fun summariseByState(): Uni<List<LoanStateSummary>>
 }
 
 interface InstallmentRepository {

--- a/openbank-lending-service/src/main/kotlin/com/openbank/lending/application/usecase/LendingService.kt
+++ b/openbank-lending-service/src/main/kotlin/com/openbank/lending/application/usecase/LendingService.kt
@@ -26,6 +26,7 @@ import com.openbank.lending.application.port.out.PostingKind
 import com.openbank.lending.application.port.out.ProvisioningRepository
 import com.openbank.lending.application.port.out.RiskParameterSource
 import com.openbank.lending.domain.model.AccrualOutcome
+import com.openbank.lending.domain.model.ApplicationStateSummary
 import com.openbank.lending.domain.model.Collateral
 import com.openbank.lending.domain.model.CollateralDecisionRequest
 import com.openbank.lending.domain.model.CollateralRequest
@@ -33,11 +34,10 @@ import com.openbank.lending.domain.model.CollateralStatus
 import com.openbank.lending.domain.model.DecisionRequest
 import com.openbank.lending.domain.model.Loan
 import com.openbank.lending.domain.model.LoanApplication
-import com.openbank.lending.domain.model.ApplicationStateSummary
 import com.openbank.lending.domain.model.LoanApplicationRequest
 import com.openbank.lending.domain.model.LoanInstallment
-import com.openbank.lending.domain.model.LoanStateSummary
 import com.openbank.lending.domain.model.LoanProvisioningRecord
+import com.openbank.lending.domain.model.LoanStateSummary
 import com.openbank.lending.domain.model.LoanStatus
 import com.openbank.lending.domain.model.ProvisioningRunOutcome
 import com.openbank.lending.domain.model.ProvisioningSnapshot

--- a/openbank-lending-service/src/main/kotlin/com/openbank/lending/application/usecase/LendingService.kt
+++ b/openbank-lending-service/src/main/kotlin/com/openbank/lending/application/usecase/LendingService.kt
@@ -33,8 +33,10 @@ import com.openbank.lending.domain.model.CollateralStatus
 import com.openbank.lending.domain.model.DecisionRequest
 import com.openbank.lending.domain.model.Loan
 import com.openbank.lending.domain.model.LoanApplication
+import com.openbank.lending.domain.model.ApplicationStateSummary
 import com.openbank.lending.domain.model.LoanApplicationRequest
 import com.openbank.lending.domain.model.LoanInstallment
+import com.openbank.lending.domain.model.LoanStateSummary
 import com.openbank.lending.domain.model.LoanProvisioningRecord
 import com.openbank.lending.domain.model.LoanStatus
 import com.openbank.lending.domain.model.ProvisioningRunOutcome
@@ -387,6 +389,12 @@ class LendingService(
 
     override fun listRecentApplications(status: String?, limit: Int): Uni<List<LoanApplication>> =
         applications.findRecent(status, limit.coerceIn(1, MAX_LIST_LIMIT))
+
+    // Deliberately UNCAPPED: the point of a summary is that it is not a page. The result set is
+    // bounded by the number of (state, currency) pairs, not by the size of the book.
+    override fun summariseApplications(): Uni<List<ApplicationStateSummary>> = applications.summariseByState()
+
+    override fun summariseLoans(): Uni<List<LoanStateSummary>> = loans.summariseByState()
 
     // --- Disbursement (origination → servicing) -----------------------------------------------------
 

--- a/openbank-lending-service/src/main/kotlin/com/openbank/lending/domain/model/LendingSummaries.kt
+++ b/openbank-lending-service/src/main/kotlin/com/openbank/lending/domain/model/LendingSummaries.kt
@@ -35,8 +35,4 @@ data class ApplicationStateSummary(
 )
 
 /** One loan status: how many, and the principal behind them. */
-data class LoanStateSummary(
-    val status: String,
-    val count: Long,
-    val principal: List<MoneyTotal>,
-)
+data class LoanStateSummary(val status: String, val count: Long, val principal: List<MoneyTotal>)

--- a/openbank-lending-service/src/main/kotlin/com/openbank/lending/domain/model/LendingSummaries.kt
+++ b/openbank-lending-service/src/main/kotlin/com/openbank/lending/domain/model/LendingSummaries.kt
@@ -1,0 +1,42 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright (c) OpenBank contributors. Licensed under the Apache License, Version 2.0.
+// See LICENSE in the repository root or https://www.apache.org/licenses/LICENSE-2.0 for details.
+
+package com.openbank.lending.domain.model
+
+import java.math.BigDecimal
+import java.time.OffsetDateTime
+
+/**
+ * Backoffice aggregates (issue #3294).
+ *
+ * WHY THESE EXIST
+ * `findRecent` / `findActive` are capped lists (server clamps to 1..100), so the console could only
+ * ever report "of the newest 100" — and every figure a credit desk manages by is a total: how many
+ * applications wait in four-eyes, how much exposure is requested, how big the book is. Rendering a
+ * capped count as a total is a staffing decision made on a wrong number, so the console printed the
+ * cap instead. These types are what let it stop doing that.
+ *
+ * MONEY IS PER CURRENCY, NEVER ONE NUMBER
+ * `loan_application.currency` and `loan.currency` are per row. A single `sumRequestedAmount` would
+ * be CZK added to EUR — a figure that looks authoritative and means nothing. Totals are therefore a
+ * LIST keyed by currency, and a caller that wants one number has to say which currency it means.
+ */
+data class MoneyTotal(val currency: String, val amount: BigDecimal)
+
+/** One origination state: how many sit there, how long the oldest has, and the exposure behind it. */
+data class ApplicationStateSummary(
+    val status: String,
+    val count: Long,
+    /** Oldest `createdAt` in this state — the item the desk should act on first. Null only when the
+     *  state is empty, which the count already says. */
+    val oldestCreatedAt: OffsetDateTime?,
+    val requested: List<MoneyTotal>,
+)
+
+/** One loan status: how many, and the principal behind them. */
+data class LoanStateSummary(
+    val status: String,
+    val count: Long,
+    val principal: List<MoneyTotal>,
+)

--- a/openbank-lending-service/src/main/kotlin/com/openbank/lending/infrastructure/persistence/repository/LendingRepositories.kt
+++ b/openbank-lending-service/src/main/kotlin/com/openbank/lending/infrastructure/persistence/repository/LendingRepositories.kt
@@ -302,6 +302,16 @@ class ProvisioningRepositoryImpl @Inject constructor(
     }
 }
 
+// Column positions of the aggregate SELECTs. Named because the query and the fold that reads it sit
+// far apart in this file: `row[4]` says nothing at the point of use, and a column added to the
+// SELECT silently shifts every later index.
+private const val COL_STATUS = 0
+private const val COL_CURRENCY = 1
+private const val COL_COUNT = 2
+private const val COL_APP_OLDEST = 3
+private const val COL_APP_SUM = 4
+private const val COL_LOAN_SUM = 3
+
 /**
  * Fold `(status, currency, count, oldest, sum)` tuples into one entry per status.
  *
@@ -311,14 +321,19 @@ class ProvisioningRepositoryImpl @Inject constructor(
  */
 internal fun foldApplicationSummaries(rows: List<Array<Any?>>): List<ApplicationStateSummary> {
     val byStatus = LinkedHashMap<String, MutableList<Array<Any?>>>()
-    for (r in rows) byStatus.getOrPut(r[0].toString()) { mutableListOf() }.add(r)
+    for (r in rows) byStatus.getOrPut(r[COL_STATUS].toString()) { mutableListOf() }.add(r)
     return byStatus.map { (status, group) ->
         ApplicationStateSummary(
             status = status,
-            count = group.sumOf { (it[2] as Number).toLong() },
-            oldestCreatedAt = group.mapNotNull { it[3] as? java.time.OffsetDateTime }.minOrNull(),
+            count = group.sumOf { (it[COL_COUNT] as Number).toLong() },
+            oldestCreatedAt = group.mapNotNull { it[COL_APP_OLDEST] as? java.time.OffsetDateTime }.minOrNull(),
             requested = group
-                .map { MoneyTotal(it[1].toString().trim(), (it[4] as? BigDecimal) ?: BigDecimal.ZERO) }
+                .map {
+                    MoneyTotal(
+                        it[COL_CURRENCY].toString().trim(),
+                        (it[COL_APP_SUM] as? BigDecimal) ?: BigDecimal.ZERO,
+                    )
+                }
                 .sortedBy { it.currency },
         )
     }.sortedBy { it.status }
@@ -327,13 +342,18 @@ internal fun foldApplicationSummaries(rows: List<Array<Any?>>): List<Application
 /** As [foldApplicationSummaries], for `(status, currency, count, sum)` loan tuples. */
 internal fun foldLoanSummaries(rows: List<Array<Any?>>): List<LoanStateSummary> {
     val byStatus = LinkedHashMap<String, MutableList<Array<Any?>>>()
-    for (r in rows) byStatus.getOrPut(r[0].toString()) { mutableListOf() }.add(r)
+    for (r in rows) byStatus.getOrPut(r[COL_STATUS].toString()) { mutableListOf() }.add(r)
     return byStatus.map { (status, group) ->
         LoanStateSummary(
             status = status,
-            count = group.sumOf { (it[2] as Number).toLong() },
+            count = group.sumOf { (it[COL_COUNT] as Number).toLong() },
             principal = group
-                .map { MoneyTotal(it[1].toString().trim(), (it[3] as? BigDecimal) ?: BigDecimal.ZERO) }
+                .map {
+                    MoneyTotal(
+                        it[COL_CURRENCY].toString().trim(),
+                        (it[COL_LOAN_SUM] as? BigDecimal) ?: BigDecimal.ZERO,
+                    )
+                }
                 .sortedBy { it.currency },
         )
     }.sortedBy { it.status }

--- a/openbank-lending-service/src/main/kotlin/com/openbank/lending/infrastructure/persistence/repository/LendingRepositories.kt
+++ b/openbank-lending-service/src/main/kotlin/com/openbank/lending/infrastructure/persistence/repository/LendingRepositories.kt
@@ -25,6 +25,10 @@ import com.openbank.libs.domain.identifiers.LoanApplicationId
 import com.openbank.libs.domain.identifiers.LoanId
 import com.openbank.libs.lending.origination.LegacyOriginationMigration
 import com.openbank.libs.lending.origination.OriginationState
+import com.openbank.lending.domain.model.ApplicationStateSummary
+import com.openbank.lending.domain.model.LoanStateSummary
+import com.openbank.lending.domain.model.MoneyTotal
+import java.math.BigDecimal
 import io.quarkus.hibernate.reactive.panache.common.WithSession
 import io.quarkus.hibernate.reactive.panache.common.WithTransaction
 import io.smallrye.mutiny.Uni
@@ -54,6 +58,27 @@ class LoanApplicationRepositoryImpl @Inject constructor(
         )
             .setParameter("p", partyId).resultList
     }.map { it.map(mapper::toDomain) }
+
+    /**
+     * `GROUP BY status, currency` — one round trip for the whole book (issue #3294).
+     *
+     * Grouped by CURRENCY as well as status because `loan_application.currency` is per row: a single
+     * summed amount would be CZK added to EUR, which looks authoritative and means nothing. The rows
+     * are folded into one entry per status carrying a total per currency.
+     *
+     * `min(createdAt)` is the oldest item in that state — what the desk should act on first.
+     */
+    @WithSession
+    override fun summariseByState(): Uni<List<ApplicationStateSummary>> = sf.withSession { s ->
+        s.createQuery(
+            """
+            SELECT a.status, a.currency, count(a), min(a.createdAt), sum(a.requestedAmount)
+            FROM LoanApplicationEntity a
+            GROUP BY a.status, a.currency
+            """.trimIndent(),
+            Array<Any?>::class.java,
+        ).resultList
+    }.map { rows -> foldApplicationSummaries(rows) }
 
     private fun mapStatusFilter(status: String): OriginationState =
         OriginationState.entries.firstOrNull { it.name == status }
@@ -110,6 +135,20 @@ class LoanRepositoryImpl @Inject constructor(private val sf: Mutiny.SessionFacto
             s.persist(e).map { mapper.toDomain(e) }
         }
     }
+
+    /** `GROUP BY status, currency` over the loan book (issue #3294); see the application
+     *  repository's note on why currency is part of the grouping. */
+    @WithSession
+    override fun summariseByState(): Uni<List<LoanStateSummary>> = sf.withSession { s ->
+        s.createQuery(
+            """
+            SELECT l.status, l.currency, count(l), sum(l.principal)
+            FROM LoanEntity l
+            GROUP BY l.status, l.currency
+            """.trimIndent(),
+            Array<Any?>::class.java,
+        ).resultList
+    }.map { rows -> foldLoanSummaries(rows) }
 
     @WithSession override fun findActive(limit: Int): Uni<List<Loan>> = sf.withSession { s ->
         s.createQuery(
@@ -261,4 +300,41 @@ class ProvisioningRepositoryImpl @Inject constructor(
         val e = mapper.toEntity(record)
         return sf.withTransaction { s -> s.persist(e).map { mapper.toDomain(e) } }
     }
+}
+
+/**
+ * Fold `(status, currency, count, oldest, sum)` tuples into one entry per status.
+ *
+ * Pure and file-private on purpose: the SQL is only half the answer, and the half that turns rows
+ * into a per-currency total is the half that can silently add CZK to EUR. Unit-tested directly
+ * (`LendingSummaryFoldTest`) rather than only through a container.
+ */
+internal fun foldApplicationSummaries(rows: List<Array<Any?>>): List<ApplicationStateSummary> {
+    val byStatus = LinkedHashMap<String, MutableList<Array<Any?>>>()
+    for (r in rows) byStatus.getOrPut(r[0].toString()) { mutableListOf() }.add(r)
+    return byStatus.map { (status, group) ->
+        ApplicationStateSummary(
+            status = status,
+            count = group.sumOf { (it[2] as Number).toLong() },
+            oldestCreatedAt = group.mapNotNull { it[3] as? java.time.OffsetDateTime }.minOrNull(),
+            requested = group
+                .map { MoneyTotal(it[1].toString().trim(), (it[4] as? BigDecimal) ?: BigDecimal.ZERO) }
+                .sortedBy { it.currency },
+        )
+    }.sortedBy { it.status }
+}
+
+/** As [foldApplicationSummaries], for `(status, currency, count, sum)` loan tuples. */
+internal fun foldLoanSummaries(rows: List<Array<Any?>>): List<LoanStateSummary> {
+    val byStatus = LinkedHashMap<String, MutableList<Array<Any?>>>()
+    for (r in rows) byStatus.getOrPut(r[0].toString()) { mutableListOf() }.add(r)
+    return byStatus.map { (status, group) ->
+        LoanStateSummary(
+            status = status,
+            count = group.sumOf { (it[2] as Number).toLong() },
+            principal = group
+                .map { MoneyTotal(it[1].toString().trim(), (it[3] as? BigDecimal) ?: BigDecimal.ZERO) }
+                .sortedBy { it.currency },
+        )
+    }.sortedBy { it.status }
 }

--- a/openbank-lending-service/src/main/kotlin/com/openbank/lending/infrastructure/persistence/repository/LendingRepositories.kt
+++ b/openbank-lending-service/src/main/kotlin/com/openbank/lending/infrastructure/persistence/repository/LendingRepositories.kt
@@ -9,11 +9,14 @@ import com.openbank.lending.application.port.out.InstallmentRepository
 import com.openbank.lending.application.port.out.LoanApplicationRepository
 import com.openbank.lending.application.port.out.LoanRepository
 import com.openbank.lending.application.port.out.ProvisioningRepository
+import com.openbank.lending.domain.model.ApplicationStateSummary
 import com.openbank.lending.domain.model.Collateral
 import com.openbank.lending.domain.model.Loan
 import com.openbank.lending.domain.model.LoanApplication
 import com.openbank.lending.domain.model.LoanInstallment
 import com.openbank.lending.domain.model.LoanProvisioningRecord
+import com.openbank.lending.domain.model.LoanStateSummary
+import com.openbank.lending.domain.model.MoneyTotal
 import com.openbank.lending.infrastructure.persistence.entity.CollateralEntity
 import com.openbank.lending.infrastructure.persistence.entity.InstallmentEntity
 import com.openbank.lending.infrastructure.persistence.entity.LoanApplicationEntity
@@ -25,16 +28,13 @@ import com.openbank.libs.domain.identifiers.LoanApplicationId
 import com.openbank.libs.domain.identifiers.LoanId
 import com.openbank.libs.lending.origination.LegacyOriginationMigration
 import com.openbank.libs.lending.origination.OriginationState
-import com.openbank.lending.domain.model.ApplicationStateSummary
-import com.openbank.lending.domain.model.LoanStateSummary
-import com.openbank.lending.domain.model.MoneyTotal
-import java.math.BigDecimal
 import io.quarkus.hibernate.reactive.panache.common.WithSession
 import io.quarkus.hibernate.reactive.panache.common.WithTransaction
 import io.smallrye.mutiny.Uni
 import jakarta.enterprise.context.ApplicationScoped
 import jakarta.inject.Inject
 import org.hibernate.reactive.mutiny.Mutiny
+import java.math.BigDecimal
 import java.time.OffsetDateTime
 import java.util.UUID
 

--- a/openbank-lending-service/src/main/kotlin/com/openbank/lending/infrastructure/rest/LendingResource.kt
+++ b/openbank-lending-service/src/main/kotlin/com/openbank/lending/infrastructure/rest/LendingResource.kt
@@ -11,10 +11,12 @@ import com.openbank.lending.application.port.`in`.ProvisioningUseCase
 import com.openbank.lending.application.port.`in`.RescheduleLoanUseCase
 import com.openbank.lending.application.port.`in`.ServicingUseCase
 import com.openbank.lending.application.port.`in`.WriteOffLoanUseCase
+import com.openbank.lending.domain.model.ApplicationStateSummary
 import com.openbank.lending.domain.model.CollateralDecisionRequest
 import com.openbank.lending.domain.model.CollateralRequest
 import com.openbank.lending.domain.model.DecisionRequest
 import com.openbank.lending.domain.model.LoanApplicationRequest
+import com.openbank.lending.domain.model.LoanStateSummary
 import com.openbank.lending.domain.model.RescheduleRequest
 import com.openbank.lending.domain.model.WriteOffRequest
 import com.openbank.libs.authz.Authorize
@@ -269,8 +271,7 @@ class LendingResource(
     )
     @RolesAllowed("ROLE_OPERATOR", "ROLE_ADMIN", "ROLE_LENDING_OFFICER", "ROLE_CREDIT_RISK")
     @Authorize(action = "lending.list", resource = "")
-    fun summariseApplications(): Uni<List<com.openbank.lending.domain.model.ApplicationStateSummary>> =
-        apply.summariseApplications()
+    fun summariseApplications(): Uni<List<ApplicationStateSummary>> = apply.summariseApplications()
 
     @GET
     @Path("/loans/summary")
@@ -287,8 +288,7 @@ class LendingResource(
         "ROLE_ADMIN",
     )
     @Authorize(action = "lending.list", resource = "")
-    fun summariseLoans(): Uni<List<com.openbank.lending.domain.model.LoanStateSummary>> =
-        servicing.summariseLoans()
+    fun summariseLoans(): Uni<List<LoanStateSummary>> = servicing.summariseLoans()
 
     @POST
     @Path("/applications/{id}/disburse")

--- a/openbank-lending-service/src/main/kotlin/com/openbank/lending/infrastructure/rest/LendingResource.kt
+++ b/openbank-lending-service/src/main/kotlin/com/openbank/lending/infrastructure/rest/LendingResource.kt
@@ -258,6 +258,38 @@ class LendingResource(
         @QueryParam("limit") @DefaultValue("50") limit: Int,
     ) = apply.listRecentApplications(status, limit)
 
+    @GET
+    @Path("/applications/summary")
+    @Operation(
+        summary = "Per-state application totals across the whole book (issue #3294)",
+        description = "The answer /applications/recent cannot give: that endpoint is a capped list " +
+            "(1..100), so a count taken from it is 'of the newest N', never the book. Aggregated in " +
+            "the database. Money totals are per CURRENCY — loan_application.currency is per row, so " +
+            "one summed number would be CZK added to EUR.",
+    )
+    @RolesAllowed("ROLE_OPERATOR", "ROLE_ADMIN", "ROLE_LENDING_OFFICER", "ROLE_CREDIT_RISK")
+    @Authorize(action = "lending.list", resource = "")
+    fun summariseApplications(): Uni<List<com.openbank.lending.domain.model.ApplicationStateSummary>> =
+        apply.summariseApplications()
+
+    @GET
+    @Path("/loans/summary")
+    @Operation(
+        summary = "Per-status loan-book totals (issue #3294)",
+        description = "Companion to /applications/summary for the loan book. Totals are per currency.",
+    )
+    @RolesAllowed(
+        "ROLE_VIEWER",
+        "ROLE_OPERATOR",
+        "ROLE_LENDING_OFFICER",
+        "ROLE_CREDIT_RISK",
+        "ROLE_COMPLIANCE",
+        "ROLE_ADMIN",
+    )
+    @Authorize(action = "lending.list", resource = "")
+    fun summariseLoans(): Uni<List<com.openbank.lending.domain.model.LoanStateSummary>> =
+        servicing.summariseLoans()
+
     @POST
     @Path("/applications/{id}/disburse")
     @Operation(summary = "Disburse an approved application, booking the loan and its schedule")

--- a/openbank-lending-service/src/main/resources/openapi.yaml
+++ b/openbank-lending-service/src/main/resources/openapi.yaml
@@ -3,7 +3,7 @@
 openapi: 3.1.0
 info:
   title: Lending Service API
-  version: 1.11.0
+  version: 1.12.0
   description: >-
     Loan origination, servicing, collateral and IFRS 9 provisioning (ADR-0028). The loan book posts
     cash events to ledger-service and never owns balances. Credit decisions and collateral
@@ -97,6 +97,45 @@ paths:
         '403':
           $ref: '#/components/responses/Forbidden'
         '404': { description: Not found }
+  /api/v1/lending/applications/summary:
+    get:
+      tags: [Lending]
+      operationId: summariseApplications
+      summary: Per-state application totals across the whole book
+      description: >-
+        The answer /applications/recent cannot give. That endpoint is a capped list (the server
+        clamps limit to 1..100), so any count taken from it is "of the newest N", never the book —
+        and a console rendering a capped count as a total turns a staffing decision into a guess
+        (issue #3294). Aggregated in the database, one round trip, bounded by the number of
+        (state, currency) pairs rather than by the size of the book.
+      responses:
+        '200':
+          description: One entry per origination state
+          content:
+            application/json:
+              schema:
+                type: array
+                items: { $ref: '#/components/schemas/ApplicationStateSummary' }
+        '403':
+          $ref: '#/components/responses/Forbidden'
+  /api/v1/lending/loans/summary:
+    get:
+      tags: [Lending]
+      operationId: summariseLoans
+      summary: Per-status loan-book totals
+      description: >-
+        Companion to /applications/summary for the loan book (issue #3294), so "book size" and
+        "loans in trouble" stop being "of the newest 100".
+      responses:
+        '200':
+          description: One entry per loan status
+          content:
+            application/json:
+              schema:
+                type: array
+                items: { $ref: '#/components/schemas/LoanStateSummary' }
+        '403':
+          $ref: '#/components/responses/Forbidden'
   /api/v1/lending/applications/recent:
     get:
       tags: [Lending]
@@ -674,6 +713,43 @@ components:
       properties:
         amount: { type: number }
         currency: { type: string, description: ISO-4217 currency code }
+    MoneyTotal:
+      type: object
+      required: [currency, amount]
+      description: >-
+        A total for ONE currency. Money is never returned as a single summed number here: the
+        currency column is per row, so one figure would be CZK added to EUR — authoritative-looking
+        and meaningless. A caller wanting one number must say which currency it means.
+      properties:
+        currency: { type: string, minLength: 3, maxLength: 3 }
+        amount: { type: number }
+    ApplicationStateSummary:
+      type: object
+      required: [status, count, requested]
+      properties:
+        status:
+          type: string
+          description: An OriginationState value.
+        count: { type: integer, format: int64 }
+        oldestCreatedAt:
+          type: string
+          format: date-time
+          nullable: true
+          description: >-
+            Oldest application in this state — the one a desk should act on first. Null only when
+            the state is empty, which `count` already says.
+        requested:
+          type: array
+          items: { $ref: '#/components/schemas/MoneyTotal' }
+    LoanStateSummary:
+      type: object
+      required: [status, count, principal]
+      properties:
+        status: { type: string }
+        count: { type: integer, format: int64 }
+        principal:
+          type: array
+          items: { $ref: '#/components/schemas/MoneyTotal' }
     CustomerIntakeRequest:
       type: object
       required: [amount, termMonths]

--- a/openbank-lending-service/src/test/kotlin/com/openbank/lending/infrastructure/persistence/repository/LendingSummaryFoldTest.kt
+++ b/openbank-lending-service/src/test/kotlin/com/openbank/lending/infrastructure/persistence/repository/LendingSummaryFoldTest.kt
@@ -1,0 +1,88 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright (c) OpenBank contributors. Licensed under the Apache License, Version 2.0.
+// See LICENSE in the repository root or https://www.apache.org/licenses/LICENSE-2.0 for details.
+
+package com.openbank.lending.infrastructure.persistence.repository
+
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.Test
+import java.math.BigDecimal
+import java.time.OffsetDateTime
+import java.time.ZoneOffset
+
+/**
+ * The SQL is only half the answer (issue #3294). This is the other half: the fold that turns
+ * `(status, currency, count, …)` tuples into one entry per status.
+ *
+ * It is tested directly rather than only through the container IT because the failure mode it
+ * guards is silent and arithmetic — adding CZK to EUR produces a number that looks authoritative,
+ * passes every type check, and is wrong. A container test would happily agree with it as long as
+ * the fixture used one currency, which is exactly what a sandbox fixture tends to do.
+ */
+class LendingSummaryFoldTest {
+
+    private fun ts(day: Int) = OffsetDateTime.of(2026, 8, day, 12, 0, 0, 0, ZoneOffset.UTC)
+
+    @Test
+    fun `keeps money separate per currency instead of summing across them`() {
+        val rows: List<Array<Any?>> = listOf(
+            arrayOf("ASSESSMENT", "CZK", 2L, ts(1), BigDecimal("500000.00")),
+            arrayOf("ASSESSMENT", "EUR", 1L, ts(2), BigDecimal("20000.00")),
+        )
+
+        val out = foldApplicationSummaries(rows)
+
+        assertThat(out).hasSize(1)
+        assertThat(out[0].status).isEqualTo("ASSESSMENT")
+        assertThat(out[0].count).isEqualTo(3L)
+        // Two totals, not 520000 of nothing.
+        assertThat(out[0].requested.map { it.currency }).containsExactly("CZK", "EUR")
+        assertThat(out[0].requested.first { it.currency == "CZK" }.amount).isEqualByComparingTo("500000.00")
+        assertThat(out[0].requested.first { it.currency == "EUR" }.amount).isEqualByComparingTo("20000.00")
+    }
+
+    @Test
+    fun `takes the OLDEST timestamp across a state's currency groups`() {
+        val rows: List<Array<Any?>> = listOf(
+            arrayOf("FOUR_EYES", "CZK", 1L, ts(9), BigDecimal.ONE),
+            arrayOf("FOUR_EYES", "EUR", 1L, ts(3), BigDecimal.ONE),
+        )
+
+        // The desk acts on the item that has waited longest. Taking the first group's timestamp —
+        // or the newest — would hide it behind whichever currency happened to sort first.
+        assertThat(foldApplicationSummaries(rows)[0].oldestCreatedAt).isEqualTo(ts(3))
+    }
+
+    @Test
+    fun `a CHAR(3) currency column is trimmed, so CZK and 'CZK ' are one bucket`() {
+        // loan_application.currency is CHAR(3): the driver can hand back a space-padded value, and
+        // an untrimmed key would split one currency into two totals that each look too small.
+        val rows: List<Array<Any?>> = listOf(
+            arrayOf("SUBMITTED", "CZK", 1L, ts(1), BigDecimal("10.00")),
+            arrayOf("SUBMITTED", "CZK ", 1L, ts(1), BigDecimal("5.00")),
+        )
+
+        val requested = foldApplicationSummaries(rows)[0].requested
+        assertThat(requested.map { it.currency }.distinct()).containsExactly("CZK")
+    }
+
+    @Test
+    fun `an empty result is an empty summary, not a fabricated zero row`() {
+        assertThat(foldApplicationSummaries(emptyList())).isEmpty()
+        assertThat(foldLoanSummaries(emptyList())).isEmpty()
+    }
+
+    @Test
+    fun `folds loan rows the same way`() {
+        val rows: List<Array<Any?>> = listOf(
+            arrayOf("ACTIVE", "CZK", 4L, BigDecimal("1000000.00")),
+            arrayOf("DELINQUENT", "CZK", 1L, BigDecimal("250000.00")),
+        )
+
+        val out = foldLoanSummaries(rows)
+
+        assertThat(out.map { it.status }).containsExactly("ACTIVE", "DELINQUENT")
+        assertThat(out.first { it.status == "DELINQUENT" }.count).isEqualTo(1L)
+        assertThat(out.first { it.status == "ACTIVE" }.principal[0].amount).isEqualByComparingTo("1000000.00")
+    }
+}

--- a/openbank-lending-service/src/test/kotlin/com/openbank/lending/infrastructure/rest/CustomerIntakeResourceTest.kt
+++ b/openbank-lending-service/src/test/kotlin/com/openbank/lending/infrastructure/rest/CustomerIntakeResourceTest.kt
@@ -5,6 +5,7 @@
 package com.openbank.lending.infrastructure.rest
 
 import com.openbank.lending.application.port.`in`.ApplyForLoanUseCase
+import com.openbank.lending.domain.model.ApplicationStateSummary
 import com.openbank.lending.domain.model.DecisionRequest
 import com.openbank.lending.domain.model.LoanApplication
 import com.openbank.lending.domain.model.LoanApplicationRequest
@@ -189,6 +190,7 @@ class CustomerIntakeResourceTest {
         override fun advanceIfInState(id: LoanApplicationId, expectedState: String, actor: String) =
             unsupported<LoanApplication>()
         override fun listRecentApplications(status: String?, limit: Int) = unsupported<List<LoanApplication>>()
+        override fun summariseApplications() = unsupported<List<ApplicationStateSummary>>()
 
         private fun <T> unsupported(): Uni<T> = throw UnsupportedOperationException("not used by intake")
     }

--- a/openbank-lending-service/src/test/kotlin/com/openbank/lending/integration/LendingSummaryIT.kt
+++ b/openbank-lending-service/src/test/kotlin/com/openbank/lending/integration/LendingSummaryIT.kt
@@ -1,0 +1,147 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright (c) OpenBank contributors. Licensed under the Apache License, Version 2.0.
+// See LICENSE in the repository root or https://www.apache.org/licenses/LICENSE-2.0 for details.
+
+package com.openbank.lending.integration
+
+import com.openbank.lending.it.PostgresRedisTestResource
+import io.quarkus.test.common.QuarkusTestResource
+import io.quarkus.test.common.QuarkusTestResourceLifecycleManager
+import io.quarkus.test.junit.QuarkusTest
+import io.quarkus.test.security.TestSecurity
+import io.restassured.module.kotlin.extensions.Extract
+import io.restassured.module.kotlin.extensions.Given
+import io.restassured.module.kotlin.extensions.Then
+import io.restassured.module.kotlin.extensions.When
+import io.smallrye.reactive.messaging.memory.InMemoryConnector
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.MethodOrderer
+import org.junit.jupiter.api.Order
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.TestInstance
+import org.junit.jupiter.api.TestMethodOrder
+import java.time.LocalDate
+import java.util.UUID
+
+/**
+ * The aggregate endpoints (issue #3294) against a real Postgres.
+ *
+ * WHY A CONTAINER AND NOT A MOCK
+ * The value of these endpoints is a `GROUP BY` that runs. `LendingSummaryFoldTest` covers the
+ * arithmetic on rows; nothing but a real database proves the HQL parses, that `min(createdAt)` and
+ * `sum(requestedAmount)` come back in the types the fold expects, and that the enum-typed `status`
+ * column groups at all. A repository mock would agree with any query string, including one that
+ * does not compile — which is precisely the class of defect that only shows up in production.
+ *
+ * Driven through the REST endpoints on purpose: a direct CDI call into a `@WithSession` reactive
+ * repository from the bare test thread fails with "No current Vertx context found" — only a real
+ * HTTP request carries one. Same reasoning as `LendingOutboxWriteIT`.
+ *
+ * TWO CURRENCIES ON PURPOSE. A fixture with one currency would pass against an implementation that
+ * sums CZK and EUR into a single meaningless figure, which is the whole reason money is returned
+ * per currency.
+ */
+@QuarkusTest
+@TestInstance(TestInstance.Lifecycle.PER_CLASS)
+@TestMethodOrder(MethodOrderer.OrderAnnotation::class)
+@QuarkusTestResource(LendingSummaryIT.InMemoryKafkaResource::class)
+@QuarkusTestResource(PostgresRedisTestResource::class)
+class LendingSummaryIT {
+
+    class InMemoryKafkaResource : QuarkusTestResourceLifecycleManager {
+        override fun start(): Map<String, String> {
+            val props = InMemoryConnector.switchOutgoingChannelsToInMemory("lending-events-out").toMutableMap()
+            props["quarkus.kafka.devservices.enabled"] = "false"
+            props["openbank.outbox.dispatch-enabled"] = "false"
+            return props
+        }
+
+        override fun stop() = InMemoryConnector.clear()
+    }
+
+    private fun applyFor(amount: String, currency: String) {
+        val body = """
+            {"partyId":"${UUID.randomUUID()}","requestedAmount":{"amount":"$amount","currency":{"code":"$currency"}},
+            "nominalAnnualRate":0.05,"termPeriods":12,"firstDueDate":"${LocalDate.now().plusMonths(1)}"}
+        """.trimIndent()
+        Given {
+            contentType("application/json")
+            body(body)
+        } When {
+            post("/api/v1/lending/applications")
+        } Then {
+            statusCode(201)
+        }
+    }
+
+    @Test
+    @Order(1)
+    @TestSecurity(user = "summary-it-proposer", roles = ["ROLE_LENDING_OFFICER"])
+    fun `1 - seed applications in two currencies`() {
+        applyFor("10000.00", "EUR")
+        applyFor("20000.00", "EUR")
+        applyFor("500000.00", "CZK")
+    }
+
+    @Test
+    @Order(2)
+    @TestSecurity(user = "summary-it-reader", roles = ["ROLE_CREDIT_RISK"])
+    fun `2 - the summary counts the whole book and keeps currencies apart`() {
+        val response = Given {
+            contentType("application/json")
+        } When {
+            get("/api/v1/lending/applications/summary")
+        } Then {
+            statusCode(200)
+        } Extract {
+            this
+        }
+
+        val states = response.jsonPath().getList<String>("status")
+        assertThat(states).contains("SUBMITTED")
+
+        val i = states.indexOf("SUBMITTED")
+        assertThat(response.jsonPath().getLong("count[$i]")).isEqualTo(3L)
+
+        // The whole point: two entries, not one summed figure.
+        val currencies = response.jsonPath().getList<String>("requested[$i].currency")
+        assertThat(currencies).containsExactlyInAnyOrder("CZK", "EUR")
+
+        val eur = response.jsonPath().getList<Map<String, Any>>("requested[$i]")
+            .first { it["currency"] == "EUR" }["amount"].toString().toBigDecimal()
+        assertThat(eur).isEqualByComparingTo("30000.00")
+
+        // An aggregate must not inherit the list cap; `oldestCreatedAt` is what a desk sorts by.
+        assertThat(response.jsonPath().getString("oldestCreatedAt[$i]")).isNotBlank()
+    }
+
+    @Test
+    @Order(3)
+    @TestSecurity(user = "summary-it-reader", roles = ["ROLE_VIEWER"])
+    fun `3 - the loan summary answers even with an empty book`() {
+        // An empty book is a legitimate answer (200 + []), not an error and not a fabricated zero
+        // row — the console distinguishes "nothing here" from "could not read".
+        Given {
+            contentType("application/json")
+        } When {
+            get("/api/v1/lending/loans/summary")
+        } Then {
+            statusCode(200)
+        }
+    }
+
+    @Test
+    @Order(4)
+    @TestSecurity(user = "summary-it-outsider", roles = ["ROLE_CUSTOMER"])
+    fun `4 - a role outside the backoffice matrix is refused`() {
+        // The aggregate exposes book-wide exposure, so it must not be reachable by anyone the list
+        // endpoints would refuse.
+        Given {
+            contentType("application/json")
+        } When {
+            get("/api/v1/lending/applications/summary")
+        } Then {
+            statusCode(403)
+        }
+    }
+}


### PR DESCRIPTION
## What

```
GET /api/v1/lending/applications/summary   count, oldest, exposure per origination state
GET /api/v1/lending/loans/summary          count and principal per loan status
```

## Why

`/applications/recent` and `/loans/active` are capped lists — the server clamps `limit` to 1..100 —
so every figure the console could show was *"of the newest N"*, never the book. That is not a
cosmetic limit: each number a credit desk manages by is a total, and

> "12 waiting" when 300 wait is a staffing decision made on a wrong number.

#3279 prints the cap next to every count precisely because it cannot do better. These endpoints are
what let it stop.

Aggregated in the database (`GROUP BY status, currency`), one round trip, and deliberately
**uncapped** — the result is bounded by the number of (state, currency) pairs, not by the size of the
book. Paging to add rows up client-side would be the same wrong answer, slower.

## Money is per currency, never one number

`loan_application.currency` and `loan.currency` are per row. A single summed amount would be CZK
added to EUR — a figure that looks authoritative and means nothing. Totals are a list keyed by
currency; a caller wanting one number has to say which currency it means.

## Tests, in two halves because they fail differently

- **`LendingSummaryFoldTest`** — the arithmetic directly, including a `CHAR(3)` column handing back
  a space-padded `"CZK "`, which an untrimmed key would split into two totals that each look too
  small.
- **`LendingSummaryIT`** — the real HQL against a Testcontainers Postgres, through the REST layer
  (a direct CDI call into a `@WithSession` reactive repo from the bare test thread fails with
  "No current Vertx context found"). The fixture uses **two currencies on purpose**: a
  single-currency fixture would pass against an implementation that sums across them, which is the
  defect the design exists to prevent. It also asserts a role outside the backoffice matrix gets
  403, since the aggregate exposes book-wide exposure.

## Verification — read this before merging

**Not verified locally.** The host is at load ~130 with 25 Gradle daemons belonging to the
`JiRaska/openbank-app` self-hosted runner; my build sat at `Starting a Gradle Daemon` for 20 minutes
with zero build output. open-bank-oss builds on the cluster ARC pool, which is unaffected, so **CI is
the first real check on this branch** — please don't read a green local claim into it, there isn't
one.

API contract 1.11.0 → 1.12.0 (new endpoints, existing ones unchanged).

Closes #3294
