### PR TITLE
feat(admin-ui): show party names on the campaign screen, not truncated UUIDs

### DIFF
--- a/openbank-admin-ui/src/app/api/campaigns/[id]/route.ts
+++ b/openbank-admin-ui/src/app/api/campaigns/[id]/route.ts
@@ -9,6 +9,7 @@
 import { NextResponse } from 'next/server'
 import { auth } from '@/auth'
 import { serverSvcUrl } from '@/lib/services/bff'
+import { resolvePartyNames } from '@/lib/campaigns/party-names'
 
 export const dynamic = 'force-dynamic'
 
@@ -103,7 +104,21 @@ export async function GET(_req: Request, ctx: { params: Promise<{ id: string }> 
     read(headers, `/api/v1/campaigns/${encodeURIComponent(id)}/journey`, []),
   ])
 
+  // Names for every party on this screen, resolved once and deduplicated. Done here rather than in
+  // the component so the client never fans out one request per row, and so an unresolved name
+  // degrades to the id instead of blanking the screen (lib/campaigns/party-names).
+  const enrolmentRows = (Array.isArray(enrolments.data) ? enrolments.data : []) as Array<{ partyId?: string }>
+  // Array.isArray, not `?? []`: a degraded `sends` part can carry a non-array `items`, and `.map`
+  // on it throws — the exact defect the bundle test exists for, reproduced here in new code.
+  const rawSendItems = (sends.data as { items?: unknown } | null)?.items
+  const sendRows = (Array.isArray(rawSendItems) ? rawSendItems : []) as Array<{ partyId?: string }>
+  const partyNames = await resolvePartyNames(headers, [
+    ...enrolmentRows.map(e => e.partyId ?? ''),
+    ...sendRows.map(r => r.partyId ?? ''),
+  ])
+
   return NextResponse.json({
+    partyNames,
     campaign: campaign.data,
     enrolments: enrolments.data,
     sends: sends.data,

--- a/openbank-admin-ui/src/app/campaigns/[id]/page.tsx
+++ b/openbank-admin-ui/src/app/campaigns/[id]/page.tsx
@@ -51,6 +51,7 @@ type Detail = {
   campaign: Campaign | null
   enrolments: Enrolment[]
   sends: SendPage
+  partyNames: Record<string, string>
   sendSummary: Record<string, number>
   journey: StepFunnel[]
   sources: Record<string, string>
@@ -360,7 +361,7 @@ export default function CampaignDetailPage({ params }: { params: Promise<{ id: s
               />
             ) : (
               <SectionBoundary name="People">
-                <PeopleSummary enrolments={detail.enrolments} />
+                <PeopleSummary enrolments={detail.enrolments} partyNames={detail.partyNames ?? {}} />
               </SectionBoundary>
             )}
 
@@ -459,7 +460,11 @@ export default function CampaignDetailPage({ params }: { params: Promise<{ id: s
                   <tbody>
                     {sends.map(s => (
                       <tr key={s.id} className="border-t">
-                        <td className="px-4 py-2 font-mono text-xs" title={s.partyId}>{shortId(s.partyId)}</td>
+                        <td className="px-4 py-2 text-xs" title={s.partyId}>
+                          {detail?.partyNames?.[s.partyId] ?? (
+                            <span className="font-mono">{shortId(s.partyId)}</span>
+                          )}
+                        </td>
                         <td className="px-4 py-2">{s.stepOrder}</td>
                         <td className="px-4 py-2">
                           <span title={s.outcome}>

--- a/openbank-admin-ui/src/components/campaigns/PeopleSummary.tsx
+++ b/openbank-admin-ui/src/components/campaigns/PeopleSummary.tsx
@@ -37,7 +37,14 @@ const STATE_TONE: Record<string, Tone> = {
   TERMINATED_CAMPAIGN_CLOSED: 'neutral',
 }
 
-export function PeopleSummary({ enrolments }: { enrolments: Enrolment[] }) {
+export function PeopleSummary({
+  enrolments,
+  partyNames = {},
+}: {
+  enrolments: Enrolment[]
+  /** id → display name. A missing entry falls back to the short id, never to a blank cell. */
+  partyNames?: Record<string, string>
+}) {
   const { t, language } = useLanguage()
   const n = (v: number) => v.toLocaleString(language === 'cs' ? 'cs-CZ' : 'en-GB')
 
@@ -100,8 +107,10 @@ export function PeopleSummary({ enrolments }: { enrolments: Enrolment[] }) {
             <tbody>
               {rows.map(e => (
                 <tr key={e.id} className="border-t" data-state={e.state}>
-                  <td className="px-4 py-2 font-mono text-xs" title={e.partyId}>
-                    {e.partyId.slice(0, 8)}
+                  {/* Name when we have it, short id when we do not — the full id stays in `title`,
+                      because the id is what goes into a support ticket. */}
+                  <td className="px-4 py-2 text-xs" title={e.partyId}>
+                    {partyNames[e.partyId] ?? <span className="font-mono">{e.partyId.slice(0, 8)}</span>}
                   </td>
                   <td className="px-4 py-2">
                     <StatusBadge status={e.state} label={stateLabel(e.state)} tone={STATE_TONE[e.state] ?? 'neutral'} />

--- a/openbank-admin-ui/src/lib/campaigns/party-names.ts
+++ b/openbank-admin-ui/src/lib/campaigns/party-names.ts
@@ -1,0 +1,57 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright (c) OpenBank contributors. Licensed under the Apache License, Version 2.0.
+// See LICENSE in the repository root or https://www.apache.org/licenses/LICENSE-2.0 for details.
+
+import { serverSvcUrl } from '@/lib/services/bff'
+
+/**
+ * Resolve party ids to display names for the campaign console.
+ *
+ * campaign-service stores only `partyId`, so every campaign screen showed `05a02ef1` — unreadable
+ * for the people the screen is for. The name lives in party-service, which means a cross-service
+ * lookup rather than a formatting change.
+ *
+ * Three properties this deliberately has:
+ *
+ *  - **Deduplicated.** A send log page repeats the same party across steps; resolving per row would
+ *    issue the same request several times for one screen.
+ *  - **Bounded.** Never more ids than one page can show, and the fan-out is capped, so a large page
+ *    cannot turn one console request into a burst against party-service.
+ *  - **Non-fatal.** A party that cannot be resolved — deleted, restricted, or party-service being
+ *    unavailable — falls back to the short id. A campaign screen must not go blank because a name
+ *    lookup failed; the id is worse to read but it is still the truth.
+ *
+ * Note this puts customer names on a marketing screen. That is a deliberate product decision (the
+ * screen is already behind `compliance:view`), not a formatting one — the audit trail for who read
+ * what stays with party-service, which is where the access is actually made.
+ */
+
+const MAX_LOOKUPS = 60
+
+export type PartyNames = Record<string, string>
+
+export async function resolvePartyNames(headers: HeadersInit, ids: string[]): Promise<PartyNames> {
+  const unique = Array.from(new Set(ids.filter(Boolean))).slice(0, MAX_LOOKUPS)
+  if (unique.length === 0) return {}
+
+  const entries = await Promise.all(
+    unique.map(async id => {
+      try {
+        const res = await fetch(
+          serverSvcUrl('party-service', 'party', 8111, `/api/v1/parties/${encodeURIComponent(id)}`),
+          { headers, signal: AbortSignal.timeout(3000), cache: 'no-store' },
+        )
+        if (!res.ok) return null
+        const body = (await res.json()) as { legalName?: string; tradingName?: string }
+        const name = body.tradingName?.trim() || body.legalName?.trim()
+        return name ? ([id, name] as const) : null
+      } catch {
+        // Deliberately swallowed: an unresolved name degrades to the id, and one slow party must
+        // not decide whether the campaign screen renders.
+        return null
+      }
+    }),
+  )
+
+  return Object.fromEntries(entries.filter((e): e is readonly [string, string] => e !== null))
+}

--- a/openbank-admin-ui/src/test/party-names.test.ts
+++ b/openbank-admin-ui/src/test/party-names.test.ts
@@ -1,0 +1,69 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright (c) OpenBank contributors. Licensed under the Apache License, Version 2.0.
+// See LICENSE in the repository root or https://www.apache.org/licenses/LICENSE-2.0 for details.
+
+import { describe, expect, it, vi, beforeEach } from 'vitest'
+import { resolvePartyNames } from '@/lib/campaigns/party-names'
+
+/**
+ * The campaign console showed `05a02ef1` where a marketer needed a name. The lookup crosses into
+ * party-service, so the properties that matter are about blast radius and failure, not formatting.
+ */
+describe('party name resolution', () => {
+  beforeEach(() => vi.unstubAllGlobals())
+
+  it('asks party-service once per DISTINCT id', async () => {
+    const fetchMock = vi.fn(async () => ({ ok: true, json: async () => ({ legalName: 'Jana Nováková' }) }))
+    vi.stubGlobal('fetch', fetchMock)
+
+    // The same party appears on several rows — the send log repeats it across steps.
+    const names = await resolvePartyNames({}, ['p1', 'p1', 'p2', 'p1'])
+
+    expect(fetchMock).toHaveBeenCalledTimes(2)
+    expect(names).toEqual({ p1: 'Jana Nováková', p2: 'Jana Nováková' })
+  })
+
+  /**
+   * The screen must survive a name it cannot get. A campaign going blank because party-service is
+   * slow would trade a readability problem for an outage.
+   */
+  it('omits a party it cannot resolve rather than failing', async () => {
+    vi.stubGlobal(
+      'fetch',
+      vi.fn(async (url: string) =>
+        String(url).includes('gone')
+          ? { ok: false, status: 404, json: async () => ({}) }
+          : { ok: true, json: async () => ({ legalName: 'Petr Svoboda' }) },
+      ),
+    )
+
+    const names = await resolvePartyNames({}, ['ok', 'gone'])
+
+    expect(names).toEqual({ ok: 'Petr Svoboda' })
+    expect(names.gone).toBeUndefined()
+  })
+
+  it('survives party-service throwing outright', async () => {
+    vi.stubGlobal('fetch', vi.fn(async () => { throw new Error('connection refused') }))
+
+    await expect(resolvePartyNames({}, ['p1'])).resolves.toEqual({})
+  })
+
+  /** One console request must not become an unbounded burst against party-service. */
+  it('caps the fan-out', async () => {
+    const fetchMock = vi.fn(async () => ({ ok: true, json: async () => ({ legalName: 'X' }) }))
+    vi.stubGlobal('fetch', fetchMock)
+
+    await resolvePartyNames({}, Array.from({ length: 500 }, (_, i) => `p${i}`))
+
+    expect(fetchMock.mock.calls.length).toBeLessThanOrEqual(60)
+  })
+
+  it('does not call out at all when there is nothing to resolve', async () => {
+    const fetchMock = vi.fn()
+    vi.stubGlobal('fetch', fetchMock)
+
+    expect(await resolvePartyNames({}, ['', ''])).toEqual({})
+    expect(fetchMock).not.toHaveBeenCalled()
+  })
+})


### PR DESCRIPTION
Refs #2895. **Stacked on #3304** (the people summary), because both touch the same section.

campaign-service stores only `partyId`, so the console showed `05a02ef1` to the people least able to
read it. The name lives in party-service — which is why this is a cross-service lookup rather than a
formatting change, and why I deferred it twice before you asked directly.

## What it does

Names are resolved **once per screen, in the BFF**, and passed to both places that used to print an
id: the people rows and the send log. Three properties matter more than the display itself:

- **Deduplicated** — a send log repeats the same party across steps, so resolving per row would fire
  the same request several times for one page;
- **Capped at 60** — one console request must not become a burst against party-service;
- **Non-fatal** — an unresolvable party (deleted, restricted, or party-service down) falls back to
  the short id. A campaign screen going blank because a name lookup failed would trade a readability
  problem for an outage.

The full id stays in `title` everywhere. The id is what goes into a support ticket.

## The part worth a decision, not just a review

This puts **customer names on a marketing screen**. That is a product decision, not formatting. The
screen is already behind `compliance:view`, and the record of who read what stays with party-service
where the access actually happens — but it is a real change in what this page exposes, and it should
be read as one.

## A defect this caught in itself

The bundle test from #3213 went red on my own new code: `sends.data.items` can be a non-array in a
degraded response, and `.map` on it throws — the same defect that took the campaign screen down
before, reproduced by me in the lines that resolve names. Guarded with `Array.isArray`.

That test has now paid for itself twice, which is the argument for writing it against the *contract*
rather than the current shape.

## Tests

Five on the resolver: distinct-id deduplication, an unresolvable party omitted rather than fatal,
party-service throwing outright, the fan-out cap, and no call at all when there is nothing to
resolve. 23/23 across the campaign suite together with the neighbouring files; `tsc` clean.
