### PR TITLE
feat(campaign): reach and delivery for every campaign in one call

### DIFF
--- a/openbank-campaign-service/src/main/kotlin/com/openbank/campaign/application/port/out/Ports.kt
+++ b/openbank-campaign-service/src/main/kotlin/com/openbank/campaign/application/port/out/Ports.kt
@@ -20,12 +20,21 @@ interface CampaignRepository {
 interface EnrolmentRepository {
     suspend fun findByCampaignAndParty(campaignId: UUID, partyId: UUID): Enrolment?
     suspend fun listByCampaign(campaignId: UUID): List<Enrolment>
+
+    /** Enrolment counts for every campaign in one query (issue #3296). */
+    suspend fun countAllByCampaign(): List<CampaignEnrolmentCount>
     suspend fun listByParty(partyId: UUID): List<Enrolment>
     suspend fun save(enrolment: Enrolment): Enrolment
 }
 
 /** A single cell of the per-step funnel: how many sends of [outcome] step [stepOrder] produced. */
 data class StepOutcomeCount(val stepOrder: Int, val outcome: SendOutcome, val count: Long)
+
+/** One (campaign, outcome) cell of the fleet-wide send tally (issue #3296). */
+data class CampaignOutcomeCount(val campaignId: UUID, val outcome: SendOutcome, val count: Long)
+
+/** How many parties are enrolled in one campaign (issue #3296). */
+data class CampaignEnrolmentCount(val campaignId: UUID, val count: Long)
 
 interface SendLogRepository {
     suspend fun record(send: SendRecord)
@@ -51,6 +60,15 @@ interface SendLogRepository {
      * read as the whole picture by definition.
      */
     suspend fun countByStepAndOutcome(campaignId: UUID): List<StepOutcomeCount>
+
+    /**
+     * Sends tallied for EVERY campaign at once (issue #3296).
+     *
+     * One grouped query, deliberately. The per-campaign `summary()` runs one count per
+     * `SendOutcome` value; doing that across the estate would be campaigns × outcomes round trips
+     * against a service that is KEDA scale-to-zero — the N+1 the console refused to make.
+     */
+    suspend fun countAllByCampaignAndOutcome(): List<CampaignOutcomeCount>
 }
 
 /** ADR-0201 D1: segments are versioned artifacts loaded as code/data, never UI-typed SQL. */

--- a/openbank-campaign-service/src/main/kotlin/com/openbank/campaign/application/usecase/CampaignSummaryQuery.kt
+++ b/openbank-campaign-service/src/main/kotlin/com/openbank/campaign/application/usecase/CampaignSummaryQuery.kt
@@ -1,0 +1,79 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright (c) OpenBank contributors. Licensed under the Apache License, Version 2.0.
+// See LICENSE in the repository root or https://www.apache.org/licenses/LICENSE-2.0 for details.
+
+package com.openbank.campaign.application.usecase
+
+import com.openbank.campaign.application.port.out.CampaignRepository
+import com.openbank.campaign.application.port.out.EnrolmentRepository
+import com.openbank.campaign.application.port.out.SendLogRepository
+import com.openbank.campaign.domain.model.SendOutcome
+import jakarta.enterprise.context.ApplicationScoped
+import java.util.UUID
+
+/**
+ * Reach and delivery for EVERY campaign, in three queries total (issue #3296).
+ *
+ * WHY THIS EXISTS
+ * `GET /api/v1/campaigns` returns campaign records only, so the console could show what is running
+ * and what waits for an approver, and nothing about whether any of it reached anyone. The honest
+ * stop-gap was to say so on the screen. This is the endpoint that lets it stop saying so.
+ *
+ * WHY NOT LOOP THE EXISTING PER-CAMPAIGN SUMMARY
+ * `CampaignSendLogQuery.summary(id)` runs one count per `SendOutcome` value. Calling it per campaign
+ * would be campaigns × outcomes round trips against a service that is KEDA scale-to-zero — the
+ * exact N+1 the console refused to make. Both tallies here are single grouped queries.
+ *
+ * SUPPRESSIONS ARE NOT DROPPED IN THE AGGREGATE. "2 sent" and "2 sent, 40 suppressed for consent"
+ * are different campaigns, and only the second explains why reach was low. Every outcome that
+ * occurred is carried through with its own count; a marketer reading `sent` alone would conclude
+ * the audience was small when it was in fact refused.
+ */
+@ApplicationScoped
+class CampaignSummaryQuery(
+    private val campaigns: CampaignRepository,
+    private val enrolments: EnrolmentRepository,
+    private val sendLog: SendLogRepository,
+) {
+    suspend fun summaries(): List<CampaignSummary> {
+        val all = campaigns.list()
+        val enrolledByCampaign = enrolments.countAllByCampaign().associate { it.campaignId to it.count }
+        val outcomesByCampaign = sendLog.countAllByCampaignAndOutcome().groupBy { it.campaignId }
+
+        return all.map { c ->
+            val cells = outcomesByCampaign[c.id].orEmpty()
+            CampaignSummary(
+                campaignId = c.id,
+                state = c.state.name,
+                // A campaign with no enrolments yet is 0, never null: "not enrolled" and "unknown"
+                // read the same in a table and mean different things to whoever is deciding
+                // whether the campaign is working.
+                enrolled = enrolledByCampaign[c.id] ?: 0,
+                outcomes = cells
+                    .filter { it.count > 0 }
+                    .sortedBy { it.outcome.name }
+                    .map { OutcomeCount(it.outcome.name, it.count) },
+                sent = cells.firstOrNull { it.outcome == SendOutcome.SENT }?.count ?: 0,
+                suppressed = cells
+                    .filter { it.outcome in CampaignSendLogQuery.SUPPRESSION_REASONS }
+                    .sumOf { it.count },
+                failed = cells.firstOrNull { it.outcome == SendOutcome.FAILED }?.count ?: 0,
+            )
+        }
+    }
+}
+
+/** One campaign's reach, as a console can render it without a second request. */
+data class CampaignSummary(
+    val campaignId: UUID,
+    val state: String,
+    val enrolled: Long,
+    /** Every outcome that actually occurred, with its count — suppressions included. */
+    val outcomes: List<OutcomeCount>,
+    /** Convenience rollups over [outcomes]; the detail is kept so nothing is hidden by them. */
+    val sent: Long,
+    val suppressed: Long,
+    val failed: Long,
+)
+
+data class OutcomeCount(val outcome: String, val count: Long)

--- a/openbank-campaign-service/src/main/kotlin/com/openbank/campaign/infrastructure/persistence/Persistence.kt
+++ b/openbank-campaign-service/src/main/kotlin/com/openbank/campaign/infrastructure/persistence/Persistence.kt
@@ -6,12 +6,12 @@ package com.openbank.campaign.infrastructure.persistence
 
 import com.fasterxml.jackson.databind.ObjectMapper
 import com.fasterxml.jackson.module.kotlin.readValue
+import com.openbank.campaign.application.port.out.CampaignEnrolmentCount
+import com.openbank.campaign.application.port.out.CampaignOutcomeCount
 import com.openbank.campaign.application.port.out.CampaignRepository
 import com.openbank.campaign.application.port.out.EnrolmentRepository
 import com.openbank.campaign.application.port.out.SegmentRegistry
 import com.openbank.campaign.application.port.out.SendLogRepository
-import com.openbank.campaign.application.port.out.CampaignOutcomeCount
-import com.openbank.campaign.application.port.out.CampaignEnrolmentCount
 import com.openbank.campaign.application.port.out.StepOutcomeCount
 import com.openbank.campaign.domain.model.Campaign
 import com.openbank.campaign.domain.model.CampaignState

--- a/openbank-campaign-service/src/main/kotlin/com/openbank/campaign/infrastructure/persistence/Persistence.kt
+++ b/openbank-campaign-service/src/main/kotlin/com/openbank/campaign/infrastructure/persistence/Persistence.kt
@@ -10,6 +10,8 @@ import com.openbank.campaign.application.port.out.CampaignRepository
 import com.openbank.campaign.application.port.out.EnrolmentRepository
 import com.openbank.campaign.application.port.out.SegmentRegistry
 import com.openbank.campaign.application.port.out.SendLogRepository
+import com.openbank.campaign.application.port.out.CampaignOutcomeCount
+import com.openbank.campaign.application.port.out.CampaignEnrolmentCount
 import com.openbank.campaign.application.port.out.StepOutcomeCount
 import com.openbank.campaign.domain.model.Campaign
 import com.openbank.campaign.domain.model.CampaignState
@@ -203,6 +205,19 @@ class PanacheEnrolmentRepository :
         find("campaignId", campaignId).list<EnrolmentEntity>()
     }.awaitSuspending().map { it.toDomain() }
 
+    /** `GROUP BY campaignId` — enrolment counts for every campaign at once (issue #3296). */
+    override suspend fun countAllByCampaign(): List<CampaignEnrolmentCount> = Panache
+        .withSession {
+            Panache.getSession().flatMap { session ->
+                session.createQuery(
+                    "select e.campaignId, count(e) from EnrolmentEntity e group by e.campaignId",
+                    Array<Any>::class.java,
+                ).resultList
+            }
+        }
+        .awaitSuspending()
+        .map { row -> CampaignEnrolmentCount(campaignId = row[0] as UUID, count = row[1] as Long) }
+
     override suspend fun listByParty(partyId: UUID): List<Enrolment> =
         Panache.withSession { find("partyId", partyId).list<EnrolmentEntity>() }.awaitSuspending().map { it.toDomain() }
 
@@ -268,6 +283,26 @@ class PanacheSendLogRepository :
             occurredAt = it.occurredAt,
         )
     }
+
+    /** `GROUP BY campaignId, outcome` — the whole estate in one round trip (issue #3296). */
+    override suspend fun countAllByCampaignAndOutcome(): List<CampaignOutcomeCount> = Panache
+        .withSession {
+            Panache.getSession().flatMap { session ->
+                session.createQuery(
+                    "select s.campaignId, s.outcome, count(s) from SendLogEntity s " +
+                        "group by s.campaignId, s.outcome",
+                    Array<Any>::class.java,
+                ).resultList
+            }
+        }
+        .awaitSuspending()
+        .map { row ->
+            CampaignOutcomeCount(
+                campaignId = row[0] as UUID,
+                outcome = SendOutcome.valueOf(row[1] as String),
+                count = row[2] as Long,
+            )
+        }
 
     override suspend fun countByStepAndOutcome(campaignId: UUID): List<StepOutcomeCount> = Panache
         .withSession {

--- a/openbank-campaign-service/src/main/kotlin/com/openbank/campaign/infrastructure/rest/CampaignSendLogResource.kt
+++ b/openbank-campaign-service/src/main/kotlin/com/openbank/campaign/infrastructure/rest/CampaignSendLogResource.kt
@@ -23,10 +23,7 @@ import java.util.UUID
  */
 @Path("/api/v1/campaigns")
 @ApplicationScoped
-class CampaignSendLogResource(
-    private val query: CampaignSendLogQuery,
-    private val summaries: CampaignSummaryQuery,
-) {
+class CampaignSendLogResource(private val query: CampaignSendLogQuery, private val summaries: CampaignSummaryQuery) {
 
     /**
      * Reach and delivery for every campaign in one call (issue #3296).

--- a/openbank-campaign-service/src/main/kotlin/com/openbank/campaign/infrastructure/rest/CampaignSendLogResource.kt
+++ b/openbank-campaign-service/src/main/kotlin/com/openbank/campaign/infrastructure/rest/CampaignSendLogResource.kt
@@ -5,6 +5,7 @@
 package com.openbank.campaign.infrastructure.rest
 
 import com.openbank.campaign.application.usecase.CampaignSendLogQuery
+import com.openbank.campaign.application.usecase.CampaignSummaryQuery
 import com.openbank.campaign.domain.model.SendOutcome
 import com.openbank.libs.authz.Authorize
 import jakarta.enterprise.context.ApplicationScoped
@@ -22,7 +23,25 @@ import java.util.UUID
  */
 @Path("/api/v1/campaigns")
 @ApplicationScoped
-class CampaignSendLogResource(private val query: CampaignSendLogQuery) {
+class CampaignSendLogResource(
+    private val query: CampaignSendLogQuery,
+    private val summaries: CampaignSummaryQuery,
+) {
+
+    /**
+     * Reach and delivery for every campaign in one call (issue #3296).
+     *
+     * The campaign list returns records only, so a console had no way to show whether anything
+     * reached anyone without one request per campaign — an N+1 against a scale-to-zero service.
+     * Three grouped queries answer it instead.
+     *
+     * Suppressions are carried through rather than folded away: "2 sent" and "2 sent, 40 suppressed
+     * for consent" are different campaigns, and only the second says why reach was low.
+     */
+    @GET
+    @Path("/summary")
+    @Authorize(action = "campaign.read", resource = "")
+    suspend fun summary(): Response = Response.ok(summaries.summaries()).build()
 
     /**
      * What happened per party per step, newest first.

--- a/openbank-campaign-service/src/main/resources/openapi.yaml
+++ b/openbank-campaign-service/src/main/resources/openapi.yaml
@@ -4,7 +4,7 @@ openapi: 3.1.0
 info:
   title: Campaign Service API
   # major == openbank.api.version == URL /api/v1 (ADR-0048).
-  version: 1.6.0
+  version: 1.7.0
   description: >-
     Campaign management first slice (ADR-0200 / ADR-0209 D3): deterministic, versioned segments;
     per-enrolment Temporal journeys; consent-gated delivery through notification-service.
@@ -51,6 +51,26 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/Campaign'
+  /api/v1/campaigns/summary:
+    get:
+      tags: [Campaigns]
+      operationId: campaignSummary
+      summary: Reach and delivery for every campaign
+      description: >-
+        The campaign list returns records only, so a console had no way to show whether anything
+        reached anyone without one request per campaign — an N+1 against a scale-to-zero service
+        (issue #3296). Answered here in three grouped queries. Suppression counts are carried
+        through rather than folded away: "2 sent" and "2 sent, 40 suppressed for consent" are
+        different campaigns, and only the second explains why reach was low.
+        NOTE the literal path segment: it must keep matching ahead of /api/v1/campaigns/{id}.
+      responses:
+        '200':
+          description: One entry per campaign
+          content:
+            application/json:
+              schema:
+                type: array
+                items: { $ref: '#/components/schemas/CampaignSummary' }
   /api/v1/campaigns/{id}:
     get:
       tags: [Campaigns]
@@ -340,6 +360,34 @@ components:
         type: string
         format: uuid
   schemas:
+    OutcomeCount:
+      type: object
+      required: [outcome, count]
+      properties:
+        outcome: { type: string, description: A SendOutcome value. }
+        count: { type: integer, format: int64 }
+    CampaignSummary:
+      type: object
+      required: [campaignId, state, enrolled, outcomes, sent, suppressed, failed]
+      properties:
+        campaignId: { type: string, format: uuid }
+        state: { type: string }
+        enrolled:
+          type: integer
+          format: int64
+          description: >-
+            0 when nobody is enrolled yet — never null. "not enrolled" and "unknown" render the
+            same in a table and mean different things to whoever is judging the campaign.
+        outcomes:
+          type: array
+          description: Every outcome that actually occurred, suppressions included.
+          items: { $ref: '#/components/schemas/OutcomeCount' }
+        sent: { type: integer, format: int64 }
+        suppressed:
+          type: integer
+          format: int64
+          description: Sum of the ADR-0200 D6 suppression outcomes (cap, quiet hours, consent).
+        failed: { type: integer, format: int64 }
     Campaign:
       type: object
       properties:

--- a/openbank-campaign-service/src/test/kotlin/com/openbank/campaign/application/CampaignEnrolmentFailureTest.kt
+++ b/openbank-campaign-service/src/test/kotlin/com/openbank/campaign/application/CampaignEnrolmentFailureTest.kt
@@ -4,8 +4,8 @@
 
 package com.openbank.campaign.application
 
-import com.openbank.campaign.application.port.out.CampaignRepository
 import com.openbank.campaign.application.port.out.CampaignEnrolmentCount
+import com.openbank.campaign.application.port.out.CampaignRepository
 import com.openbank.campaign.application.port.out.EnrolmentRepository
 import com.openbank.campaign.application.port.out.JourneySignaller
 import com.openbank.campaign.application.port.out.SegmentEvaluationPort

--- a/openbank-campaign-service/src/test/kotlin/com/openbank/campaign/application/CampaignEnrolmentFailureTest.kt
+++ b/openbank-campaign-service/src/test/kotlin/com/openbank/campaign/application/CampaignEnrolmentFailureTest.kt
@@ -5,6 +5,7 @@
 package com.openbank.campaign.application
 
 import com.openbank.campaign.application.port.out.CampaignRepository
+import com.openbank.campaign.application.port.out.CampaignEnrolmentCount
 import com.openbank.campaign.application.port.out.EnrolmentRepository
 import com.openbank.campaign.application.port.out.JourneySignaller
 import com.openbank.campaign.application.port.out.SegmentEvaluationPort
@@ -76,6 +77,7 @@ class CampaignEnrolmentFailureTest {
         override suspend fun listByCampaign(campaignId: UUID): List<Enrolment> =
             saved.filter { it.campaignId == campaignId }
         override suspend fun listByParty(partyId: UUID): List<Enrolment> = saved.filter { it.partyId == partyId }
+        override suspend fun countAllByCampaign() = emptyList<CampaignEnrolmentCount>()
         override suspend fun save(enrolment: Enrolment): Enrolment = enrolment.also { saved += it }
     }
 

--- a/openbank-campaign-service/src/test/kotlin/com/openbank/campaign/application/CampaignSendLogTest.kt
+++ b/openbank-campaign-service/src/test/kotlin/com/openbank/campaign/application/CampaignSendLogTest.kt
@@ -57,10 +57,10 @@ class CampaignSendLogTest {
                 records.count { outcome == null || it.outcome == outcome }.toLong()
 
             override suspend fun countByStepAndOutcome(campaignId: UUID) =
-
-            override suspend fun countAllByCampaignAndOutcome() = emptyList<CampaignOutcomeCount>()
                 records.groupBy { it.stepOrder to it.outcome }
                     .map { (k, v) -> StepOutcomeCount(k.first, k.second, v.size.toLong()) }
+
+            override suspend fun countAllByCampaignAndOutcome() = emptyList<CampaignOutcomeCount>()
         },
     )
 

--- a/openbank-campaign-service/src/test/kotlin/com/openbank/campaign/application/CampaignSendLogTest.kt
+++ b/openbank-campaign-service/src/test/kotlin/com/openbank/campaign/application/CampaignSendLogTest.kt
@@ -4,6 +4,7 @@
 
 package com.openbank.campaign.application
 
+import com.openbank.campaign.application.port.out.CampaignOutcomeCount
 import com.openbank.campaign.application.port.out.SendLogRepository
 import com.openbank.campaign.application.port.out.StepOutcomeCount
 import com.openbank.campaign.application.usecase.CampaignSendLogQuery
@@ -56,6 +57,8 @@ class CampaignSendLogTest {
                 records.count { outcome == null || it.outcome == outcome }.toLong()
 
             override suspend fun countByStepAndOutcome(campaignId: UUID) =
+
+            override suspend fun countAllByCampaignAndOutcome() = emptyList<CampaignOutcomeCount>()
                 records.groupBy { it.stepOrder to it.outcome }
                     .map { (k, v) -> StepOutcomeCount(k.first, k.second, v.size.toLong()) }
         },

--- a/openbank-campaign-service/src/test/kotlin/com/openbank/campaign/application/usecase/CampaignSummaryQueryTest.kt
+++ b/openbank-campaign-service/src/test/kotlin/com/openbank/campaign/application/usecase/CampaignSummaryQueryTest.kt
@@ -50,10 +50,7 @@ class CampaignSummaryQueryTest {
         createdAt = Instant.EPOCH,
     )
 
-    private class Sends(
-        private val cells: List<CampaignOutcomeCount>,
-        var calls: Int = 0,
-    ) : SendLogRepository {
+    private class Sends(private val cells: List<CampaignOutcomeCount>, var calls: Int = 0) : SendLogRepository {
         override suspend fun record(send: SendRecord) = Unit
         override suspend fun countRecentForParty(partyId: UUID, sinceEpochSeconds: Long) = 0
         override suspend fun listByCampaign(campaignId: UUID, outcome: SendOutcome?, page: Int, size: Int) =

--- a/openbank-campaign-service/src/test/kotlin/com/openbank/campaign/application/usecase/CampaignSummaryQueryTest.kt
+++ b/openbank-campaign-service/src/test/kotlin/com/openbank/campaign/application/usecase/CampaignSummaryQueryTest.kt
@@ -89,7 +89,11 @@ class CampaignSummaryQueryTest {
                 CampaignOutcomeCount(c1, SendOutcome.SUPPRESSED_QUIET_HOURS, 3),
             ),
         )
-        val q = CampaignSummaryQuery(Campaigns(listOf(campaign(c1, CampaignState.ACTIVE))), Enrolments(emptyList()), sends)
+        val q = CampaignSummaryQuery(
+            Campaigns(listOf(campaign(c1, CampaignState.ACTIVE))),
+            Enrolments(emptyList()),
+            sends,
+        )
 
         val out = q.summaries().single()
 
@@ -137,7 +141,11 @@ class CampaignSummaryQueryTest {
                 CampaignOutcomeCount(c1, SendOutcome.FAILED, 0),
             ),
         )
-        val q = CampaignSummaryQuery(Campaigns(listOf(campaign(c1, CampaignState.ACTIVE))), Enrolments(emptyList()), sends)
+        val q = CampaignSummaryQuery(
+            Campaigns(listOf(campaign(c1, CampaignState.ACTIVE))),
+            Enrolments(emptyList()),
+            sends,
+        )
 
         assertThat(q.summaries().single().outcomes.map { it.outcome }).containsExactly("SENT")
     }

--- a/openbank-campaign-service/src/test/kotlin/com/openbank/campaign/application/usecase/CampaignSummaryQueryTest.kt
+++ b/openbank-campaign-service/src/test/kotlin/com/openbank/campaign/application/usecase/CampaignSummaryQueryTest.kt
@@ -81,7 +81,7 @@ class CampaignSummaryQueryTest {
     }
 
     @Test
-    fun `carries suppressions instead of reporting sends alone`() = runBlocking {
+    fun `carries suppressions instead of reporting sends alone`(): Unit = runBlocking {
         val sends = Sends(
             listOf(
                 CampaignOutcomeCount(c1, SendOutcome.SENT, 2),
@@ -101,7 +101,7 @@ class CampaignSummaryQueryTest {
     }
 
     @Test
-    fun `a campaign nobody is enrolled in reports zero, never null`() = runBlocking {
+    fun `a campaign nobody is enrolled in reports zero, never null`(): Unit = runBlocking {
         val q = CampaignSummaryQuery(
             Campaigns(listOf(campaign(c1, CampaignState.DRAFT))),
             Enrolments(emptyList()),
@@ -111,7 +111,7 @@ class CampaignSummaryQueryTest {
     }
 
     @Test
-    fun `asks the send log ONCE regardless of how many campaigns there are`() = runBlocking {
+    fun `asks the send log ONCE regardless of how many campaigns there are`(): Unit = runBlocking {
         val sends = Sends(listOf(CampaignOutcomeCount(c1, SendOutcome.SENT, 1)))
         val q = CampaignSummaryQuery(
             Campaigns(listOf(campaign(c1, CampaignState.ACTIVE), campaign(c2, CampaignState.PAUSED))),
@@ -130,7 +130,7 @@ class CampaignSummaryQueryTest {
     }
 
     @Test
-    fun `drops zero-count cells so the outcome list is what actually happened`() = runBlocking {
+    fun `drops zero-count cells so the outcome list is what actually happened`(): Unit = runBlocking {
         val sends = Sends(
             listOf(
                 CampaignOutcomeCount(c1, SendOutcome.SENT, 5),

--- a/openbank-campaign-service/src/test/kotlin/com/openbank/campaign/application/usecase/CampaignSummaryQueryTest.kt
+++ b/openbank-campaign-service/src/test/kotlin/com/openbank/campaign/application/usecase/CampaignSummaryQueryTest.kt
@@ -1,0 +1,144 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright (c) OpenBank contributors. Licensed under the Apache License, Version 2.0.
+// See LICENSE in the repository root or https://www.apache.org/licenses/LICENSE-2.0 for details.
+
+package com.openbank.campaign.application.usecase
+
+import com.openbank.campaign.application.port.out.CampaignEnrolmentCount
+import com.openbank.campaign.application.port.out.CampaignOutcomeCount
+import com.openbank.campaign.application.port.out.CampaignRepository
+import com.openbank.campaign.application.port.out.EnrolmentRepository
+import com.openbank.campaign.application.port.out.SendLogRepository
+import com.openbank.campaign.application.port.out.StepOutcomeCount
+import com.openbank.campaign.domain.model.Campaign
+import com.openbank.campaign.domain.model.CampaignState
+import com.openbank.campaign.domain.model.CampaignStep
+import com.openbank.campaign.domain.model.Channel
+import com.openbank.campaign.domain.model.Enrolment
+import com.openbank.campaign.domain.model.SegmentRef
+import com.openbank.campaign.domain.model.SendOutcome
+import com.openbank.campaign.domain.model.SendRecord
+import kotlinx.coroutines.runBlocking
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.Test
+import java.time.Instant
+import java.util.UUID
+
+/**
+ * The fold behind /api/v1/campaigns/summary (issue #3296).
+ *
+ * The assertions are about the ways an aggregate can mislead a marketer:
+ *  - reporting `sent` while dropping the suppressions that explain a low reach,
+ *  - returning null for a campaign nobody has enrolled in yet ("unknown" and "nobody" read the
+ *    same in a table and mean opposite things),
+ *  - asking the database once per campaign, which is the N+1 this endpoint exists to remove.
+ */
+class CampaignSummaryQueryTest {
+
+    private val c1 = UUID.randomUUID()
+    private val c2 = UUID.randomUUID()
+
+    private fun campaign(id: UUID, state: CampaignState) = Campaign(
+        id = id,
+        name = "c-$id",
+        goal = "goal",
+        segmentRef = SegmentRef("actives", 1),
+        steps = listOf(CampaignStep(0, "TPL", Channel.EMAIL, emptyMap(), 0)),
+        state = state,
+        createdBy = "maker",
+        approvedBy = null,
+        createdAt = Instant.EPOCH,
+    )
+
+    private class Sends(
+        private val cells: List<CampaignOutcomeCount>,
+        var calls: Int = 0,
+    ) : SendLogRepository {
+        override suspend fun record(send: SendRecord) = Unit
+        override suspend fun countRecentForParty(partyId: UUID, sinceEpochSeconds: Long) = 0
+        override suspend fun listByCampaign(campaignId: UUID, outcome: SendOutcome?, page: Int, size: Int) =
+            emptyList<SendRecord>()
+        override suspend fun countByCampaign(campaignId: UUID, outcome: SendOutcome?) = 0L
+        override suspend fun countByStepAndOutcome(campaignId: UUID) = emptyList<StepOutcomeCount>()
+        override suspend fun countAllByCampaignAndOutcome(): List<CampaignOutcomeCount> {
+            calls += 1
+            return cells
+        }
+    }
+
+    private class Enrolments(private val counts: List<CampaignEnrolmentCount>) : EnrolmentRepository {
+        override suspend fun findByCampaignAndParty(campaignId: UUID, partyId: UUID): Enrolment? = null
+        override suspend fun listByCampaign(campaignId: UUID) = emptyList<Enrolment>()
+        override suspend fun listByParty(partyId: UUID) = emptyList<Enrolment>()
+        override suspend fun save(enrolment: Enrolment) = enrolment
+        override suspend fun countAllByCampaign() = counts
+    }
+
+    private inner class Campaigns(private val items: List<Campaign>) : CampaignRepository {
+        override suspend fun findById(id: UUID) = items.firstOrNull { it.id == id }
+        override suspend fun list() = items
+        override suspend fun save(campaign: Campaign) = campaign
+    }
+
+    @Test
+    fun `carries suppressions instead of reporting sends alone`() = runBlocking {
+        val sends = Sends(
+            listOf(
+                CampaignOutcomeCount(c1, SendOutcome.SENT, 2),
+                CampaignOutcomeCount(c1, SendOutcome.SUPPRESSED_CONSENT, 40),
+                CampaignOutcomeCount(c1, SendOutcome.SUPPRESSED_QUIET_HOURS, 3),
+            ),
+        )
+        val q = CampaignSummaryQuery(Campaigns(listOf(campaign(c1, CampaignState.ACTIVE))), Enrolments(emptyList()), sends)
+
+        val out = q.summaries().single()
+
+        assertThat(out.sent).isEqualTo(2)
+        // 2 sent out of 45 attempted is a campaign that was refused, not a campaign nobody wanted.
+        assertThat(out.suppressed).isEqualTo(43)
+        assertThat(out.outcomes.map { it.outcome })
+            .containsExactly("SENT", "SUPPRESSED_CONSENT", "SUPPRESSED_QUIET_HOURS")
+    }
+
+    @Test
+    fun `a campaign nobody is enrolled in reports zero, never null`() = runBlocking {
+        val q = CampaignSummaryQuery(
+            Campaigns(listOf(campaign(c1, CampaignState.DRAFT))),
+            Enrolments(emptyList()),
+            Sends(emptyList()),
+        )
+        assertThat(q.summaries().single().enrolled).isEqualTo(0L)
+    }
+
+    @Test
+    fun `asks the send log ONCE regardless of how many campaigns there are`() = runBlocking {
+        val sends = Sends(listOf(CampaignOutcomeCount(c1, SendOutcome.SENT, 1)))
+        val q = CampaignSummaryQuery(
+            Campaigns(listOf(campaign(c1, CampaignState.ACTIVE), campaign(c2, CampaignState.PAUSED))),
+            Enrolments(listOf(CampaignEnrolmentCount(c1, 10), CampaignEnrolmentCount(c2, 5))),
+            sends,
+        )
+
+        val out = q.summaries()
+
+        assertThat(out).hasSize(2)
+        // The whole reason this endpoint exists: one grouped query, not one per campaign. A loop
+        // over the existing per-campaign summary would be campaigns × outcomes round trips.
+        assertThat(sends.calls).isEqualTo(1)
+        assertThat(out.first { it.campaignId == c2 }.enrolled).isEqualTo(5L)
+        assertThat(out.first { it.campaignId == c2 }.sent).isEqualTo(0L)
+    }
+
+    @Test
+    fun `drops zero-count cells so the outcome list is what actually happened`() = runBlocking {
+        val sends = Sends(
+            listOf(
+                CampaignOutcomeCount(c1, SendOutcome.SENT, 5),
+                CampaignOutcomeCount(c1, SendOutcome.FAILED, 0),
+            ),
+        )
+        val q = CampaignSummaryQuery(Campaigns(listOf(campaign(c1, CampaignState.ACTIVE))), Enrolments(emptyList()), sends)
+
+        assertThat(q.summaries().single().outcomes.map { it.outcome }).containsExactly("SENT")
+    }
+}

--- a/openbank-campaign-service/src/test/kotlin/com/openbank/campaign/application/usecase/CampaignSummaryQueryTest.kt
+++ b/openbank-campaign-service/src/test/kotlin/com/openbank/campaign/application/usecase/CampaignSummaryQueryTest.kt
@@ -48,6 +48,7 @@ class CampaignSummaryQueryTest {
         createdBy = "maker",
         approvedBy = null,
         createdAt = Instant.EPOCH,
+        updatedAt = Instant.EPOCH,
     )
 
     private class Sends(private val cells: List<CampaignOutcomeCount>, var calls: Int = 0) : SendLogRepository {

--- a/openbank-campaign-service/src/test/kotlin/com/openbank/campaign/application/usecase/CampaignSummaryQueryTest.kt
+++ b/openbank-campaign-service/src/test/kotlin/com/openbank/campaign/application/usecase/CampaignSummaryQueryTest.kt
@@ -43,7 +43,7 @@ class CampaignSummaryQueryTest {
         name = "c-$id",
         goal = "goal",
         segmentRef = SegmentRef("actives", 1),
-        steps = listOf(CampaignStep(0, "TPL", Channel.EMAIL, emptyMap(), 0)),
+        steps = listOf(CampaignStep(0, "MARKETING_PRODUCT_OFFER", Channel.EMAIL, emptyMap(), 0)),
         state = state,
         createdBy = "maker",
         approvedBy = null,


### PR DESCRIPTION
## What

```
GET /api/v1/campaigns/summary   enrolled, sent, suppressed, failed — per campaign
```

## Why

`GET /api/v1/campaigns` returns campaign records only, so the console could show what is running and
what waits for an approver — and nothing about whether any of it reached anyone. #3287 states that
gap on the board itself as the honest stop-gap. This is the endpoint that lets it stop.

## Why not loop the existing per-campaign summary

`CampaignSendLogQuery.summary(id)` runs **one count per `SendOutcome` value**. Calling it per
campaign would be campaigns × outcomes round trips against a service that is KEDA scale-to-zero —
the exact N+1 the console refused to make.

Both tallies here are single grouped queries (`GROUP BY campaignId, outcome` and
`GROUP BY campaignId`), so the whole estate costs **three queries** regardless of how many campaigns
exist. A test asserts the send log is asked **exactly once** for two campaigns, so a later refactor
cannot quietly reintroduce the loop.

## Suppressions survive the aggregate

> "2 sent" and "2 sent, 40 suppressed for consent" are different campaigns, and only the second
> explains why reach was low.

Every outcome that occurred is carried with its own count alongside the rollups, and zero-count cells
are dropped so the list is what actually happened.

`enrolled` is `0` for a campaign nobody has joined, never `null` — "nobody" and "unknown" render
identically in a table and mean opposite things to whoever is judging whether a campaign works.

## One routing trap, called out on purpose

The literal `/summary` segment must keep matching ahead of `/api/v1/campaigns/{id}`. JAX-RS prefers a
literal over a template, so it does today — and the OpenAPI description says so out loud, because a
future rename would silently turn this into a malformed-UUID lookup rather than a 404 anyone notices.

## Verification — read this before merging

**Not verified locally.** The host is at load ~130 with 25 Gradle daemons belonging to the
`JiRaska/openbank-app` self-hosted runner; the build never got past `Starting a Gradle Daemon`.
open-bank-oss builds on the cluster ARC pool, which is unaffected, so **CI is the first real check on
this branch**.

API contract 1.6.0 → 1.7.0 (new endpoint, existing ones unchanged).

Closes #3296
