### PR TITLE
fix(observability): SbomDriftScannerFailing could never clear — it fired on Job history, not the latest run

### DIFF
--- a/openbank-infra/gitops/components/sbom-drift-scanner/prometheus-rules.yaml
+++ b/openbank-infra/gitops/components/sbom-drift-scanner/prometheus-rules.yaml
@@ -31,8 +31,30 @@ spec:
         # Fires when the scanner found real drift (running image != declared image) or a
         # money-path service with no running pod at all.
         - alert: SbomDriftScannerFailing
-          expr: kube_job_failed{namespace="admin-ui", job_name=~"sbom-drift-scanner-.*"} > 0
-          for: 5m
+          # Keyed on the LATEST scheduled run, not on "a failed Job exists somewhere in
+          # history". The previous expression was
+          #   kube_job_failed{namespace="admin-ui", job_name=~"sbom-drift-scanner-.*"} > 0
+          # which cannot self-clear: a Job object stays in `failedJobsHistoryLimit` after its
+          # pods are garbage-collected, so the series persists and the alert fires forever.
+          #
+          # Measured 2026-08-02: this had been firing `critical` for 27.8h off
+          # sbom-drift-scanner-29757790 (failed 07-31 03:10), while the two runs SINCE then
+          # both completed and the scanner reported `"ok": true, "driftedServices": []`. The
+          # failed Job's pods were already gone, so the alert pointed at an incident nobody
+          # could investigate any more, and no operator action could clear it short of
+          # deleting the object by hand.
+          #
+          # `last_schedule_time > last_successful_time` means the most recent scheduled run has
+          # not succeeded — it goes quiet the moment one does. `for: 15m` comfortably exceeds
+          # the observed run time (10-20s), so a run merely in flight does not trip it. The
+          # sibling SbomDriftScannerStale below already used this metric family; only this
+          # alert was left on the sticky one.
+          expr: >-
+            kube_cronjob_status_last_schedule_time{namespace="admin-ui",
+            cronjob="sbom-drift-scanner"}
+            > kube_cronjob_status_last_successful_time{namespace="admin-ui",
+            cronjob="sbom-drift-scanner"}
+          for: 15m
           labels:
             severity: critical
             component: supply-chain


### PR DESCRIPTION
Refs #3071

## The alert could never clear

```
expr: kube_job_failed{namespace="admin-ui", job_name=~"sbom-drift-scanner-.*"} > 0
```

A Job object survives in `failedJobsHistoryLimit` long after its pods are garbage-collected, so the series persists and the alert fires until someone deletes the object by hand.

Measured today: firing **critical for 27.8h** off `sbom-drift-scanner-29757790` (failed 2026-07-31 03:10) — while the two runs since then both completed and the scanner reported:

```json
{"ok": true, "driftedServices": [], "noPodServices": []}
```

Its pods were already gone, so the alert pointed at an incident **nobody could investigate any more**, and no operator action could clear it.

That is the worst shape an alert can have: permanently lit, not actionable, and `severity: critical` — so it feeds the "critical is the resting state" problem that makes the alerts which *do* matter get ignored. This one was 3 of the 18 firing criticals.

## The fix

```
last_schedule_time > last_successful_time
```

The most recent scheduled run has not succeeded — and it goes quiet the moment one does. `for: 15m` comfortably exceeds the observed run time (10–20s), so a run merely in flight does not trip it.

**Validated against live metrics before writing it**, not after:

```
sched: 2026-08-02T03:10  (11.6h ago)
succ : 2026-08-02T03:10  (11.6h ago)
proposed expr (sched > succ) = False  → quiet
```

Correct, because the scanner *did* succeed — while the old expression is firing on that same data.

## Note

The sibling `SbomDriftScannerStale` in the same file already used this metric family for exactly this reason ("a scanner that silently stops running is indistinguishable from a clean fleet"). Only `SbomDriftScannerFailing` was left on the sticky one — the right pattern was already in the file, one alert below.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
