### PR TITLE
feat(admin-ui): build campaigns on a canvas instead of filling in a form

### DIFF
--- a/openbank-admin-ui/src/app/campaigns/new/page.tsx
+++ b/openbank-admin-ui/src/app/campaigns/new/page.tsx
@@ -10,18 +10,27 @@ import Link from 'next/link'
 import { ArrowLeft, Megaphone } from 'lucide-react'
 import { useLanguage } from '@/lib/i18n/LanguageContext'
 import { PageHeader } from '@/components/ui'
+import { JourneyEditor, MAX_STEPS, type EditorStep } from '@/components/campaigns/JourneyEditor'
+import { StepEditor } from '@/components/campaigns/StepEditor'
 
 /**
- * Campaign Studio — authoring (ADR-0221 D1).
+ * Campaign Studio — authoring on a canvas (ADR-0221 D1).
  *
- * The form IS the domain model: goal, a picker over versioned segment artifacts, steps composed
- * from the template catalogue, the platform contact rules shown read-only, and a summary that
- * submits for approval. There is no free-text body field anywhere, because the engine rejects one
- * by construction (ADR-0176 D4) — a textarea here would be a control the service would refuse.
+ * The form this replaces asked for `template`, `variables` and `delaySeconds`: the engine's
+ * vocabulary in the engine's order. A marketer now sees the journey they are assembling while they
+ * assemble it, and edits one node at a time.
  *
- * What this screen deliberately does NOT do: activate. Submission puts the campaign in
- * PENDING_APPROVAL, and the checker is a different person acting from the campaign's own page.
- * Offering both buttons to one author would render the four-eyes gate as decoration.
+ * On ADR-0221 D5, which rejects "a drag-and-drop journey canvas": the objection is a free-form
+ * 40-node graph, and this is not one. The flow is linear and capped at the domain's five steps
+ * (`Campaign.MAX_STEPS`) — nothing to drag, nothing to branch, nothing to arrange. It is D5's own
+ * "the wizard's step list covers the honest use cases", drawn rather than listed.
+ *
+ * Still absent on purpose, because the service refuses both: any free-text body (only declared
+ * template variables), and any way to author a segment — that is a pull request against the
+ * catalogue (ADR-0201 D1).
+ *
+ * It also stops at "create draft". Activation is a different person's action, and offering both
+ * buttons to one author would render the four-eyes gate decorative.
  */
 
 interface Segment {
@@ -35,21 +44,29 @@ const TEMPLATES: Record<string, string[]> = {
   MARKETING_PRODUCT_OFFER: ['offerTitle', 'offerText', 'ctaText'],
 }
 
+const newStep = (): EditorStep => ({
+  template: Object.keys(TEMPLATES)[0],
+  variables: {},
+  delaySeconds: 0,
+})
+
 export default function NewCampaignPage() {
-  const { t, language } = useLanguage()
+  const { t } = useLanguage()
   const router = useRouter()
 
   const [name, setName] = useState('')
   const [goal, setGoal] = useState('')
   const [segment, setSegment] = useState('')
   const [segments, setSegments] = useState<Segment[]>([])
-  const [template, setTemplate] = useState('MARKETING_PRODUCT_OFFER')
-  const [variables, setVariables] = useState<Record<string, string>>({})
-  const [delayHours, setDelayHours] = useState('0')
+  const [steps, setSteps] = useState<EditorStep[]>([newStep()])
+  const [selected, setSelected] = useState<number | null>(0)
   const [reach, setReach] = useState<number | null>(null)
-  const [reachState, setReachState] = useState<string>('')
   const [error, setError] = useState<string | null>(null)
   const [saving, setSaving] = useState(false)
+
+  const templateLabels: Record<string, string> = {
+    MARKETING_PRODUCT_OFFER: t('Nabídka produktu', 'Product offer'),
+  }
 
   useEffect(() => {
     fetch('/api/segments')
@@ -60,26 +77,41 @@ export default function NewCampaignPage() {
       .catch(() => undefined)
   }, [])
 
-  // The reach is the segment's own preview, run by the service — the same evaluation enrolment
-  // runs. A number computed here from a different query would agree with the send only by luck.
+  // The reach is the segment's own preview, run by the service — the same evaluation enrolment runs.
+  // A number computed here from a different query would agree with the send only by luck.
   const previewReach = (ref: string) => {
     setReach(null)
-    setReachState('')
     const [segName, segVersion] = ref.split('@')
     if (!segName) return
-    setReachState('loading')
     fetch(`/api/segments/${encodeURIComponent(segName)}/${encodeURIComponent(segVersion)}/preview`)
       .then(r => r.json())
       .then((d: { size?: number; state: string }) => {
-        setReachState(d.state)
         if (d.state === 'ok') setReach(d.size ?? 0)
       })
-      .catch(() => setReachState('unreachable'))
+      .catch(() => undefined)
   }
 
-  const declared = TEMPLATES[template] ?? []
-  const missing = declared.filter(v => !(variables[v] ?? '').trim())
-  const ready = name.trim() !== '' && goal.trim() !== '' && segment !== '' && missing.length === 0
+  const updateStep = (i: number, next: EditorStep) =>
+    setSteps(prev => prev.map((s, k) => (k === i ? next : s)))
+
+  const addStep = () =>
+    setSteps(prev => {
+      if (prev.length >= MAX_STEPS) return prev
+      setSelected(prev.length)
+      return [...prev, newStep()]
+    })
+
+  const removeStep = (i: number) =>
+    setSteps(prev => {
+      const next = prev.filter((_, k) => k !== i)
+      setSelected(null)
+      return next
+    })
+
+  const incomplete = steps.some(s =>
+    (TEMPLATES[s.template] ?? []).some(v => !(s.variables[v] ?? '').trim()),
+  )
+  const ready = name.trim() !== '' && goal.trim() !== '' && segment !== '' && steps.length > 0 && !incomplete
 
   const submit = () => {
     setSaving(true)
@@ -93,26 +125,25 @@ export default function NewCampaignPage() {
         goal: goal.trim(),
         segmentName: segName,
         segmentVersion: Number(segVersion),
-        steps: [
-          {
-            order: 1,
-            template,
-            variables,
-            delaySeconds: Math.max(0, Number(delayHours) || 0) * 3600,
-          },
-        ],
+        steps: steps.map((s, i) => ({
+          order: i + 1,
+          template: s.template,
+          variables: s.variables,
+          delaySeconds: s.delaySeconds,
+        })),
       }),
     })
       .then(r => r.json())
-      .then((d: { state: string; campaign?: { id: string }; error?: string }) => {
+      .then((d: { state: string; campaign?: { id: string }; error?: string; message?: string }) => {
         if (d.state === 'ok' && d.campaign) {
           router.push(`/campaigns/${d.campaign.id}`)
           return
         }
         // The service's own message names what to change — an unknown template, an undeclared
-        // variable. Replacing it with "could not create" would remove the only actionable part.
+        // variable. Replacing it with "could not create" removes the only actionable part.
         setError(
-          d.error ??
+          d.message ??
+            d.error ??
             (d.state === 'forbidden'
               ? t('Nemáte oprávnění zakládat kampaně.', 'You are not permitted to create campaigns.')
               : t('Campaign-service neodpovídá.', 'Campaign-service is not responding.')),
@@ -133,25 +164,26 @@ export default function NewCampaignPage() {
       <PageHeader
         title={t('Nová kampaň', 'New campaign')}
         subtitle={t(
-          'Založí koncept. Spustit ji musí někdo jiný — to je ten smysl schvalování ve dvou.',
-          'Creates a draft. Someone else activates it — that is the point of the four-eyes gate.',
+          'Sestavte cestu, kterou lidé projdou. Spustit ji musí někdo jiný — to je smysl schvalování ve dvou.',
+          'Assemble the journey people will take. Someone else activates it — that is the point of the four-eyes gate.',
         )}
         icon={<Megaphone className="h-6 w-6" />}
       />
 
-      <section className="max-w-2xl space-y-4">
-        <div className="space-y-1">
-          <label htmlFor="c-name" className="text-sm font-medium">{t('Název', 'Name')}</label>
-          <input id="c-name" className={field} value={name} onChange={e => setName(e.target.value)} />
+      <section className="max-w-3xl space-y-4">
+        <div className="grid gap-4 sm:grid-cols-2">
+          <div className="space-y-1">
+            <label htmlFor="c-name" className="text-sm font-medium">{t('Název', 'Name')}</label>
+            <input id="c-name" className={field} value={name} onChange={e => setName(e.target.value)} />
+          </div>
+          <div className="space-y-1">
+            <label htmlFor="c-goal" className="text-sm font-medium">{t('Cíl', 'Goal')}</label>
+            <input id="c-goal" className={field} value={goal} onChange={e => setGoal(e.target.value)} />
+          </div>
         </div>
 
         <div className="space-y-1">
-          <label htmlFor="c-goal" className="text-sm font-medium">{t('Cíl', 'Goal')}</label>
-          <input id="c-goal" className={field} value={goal} onChange={e => setGoal(e.target.value)} />
-        </div>
-
-        <div className="space-y-1">
-          <label htmlFor="c-segment" className="text-sm font-medium">{t('Publikum', 'Audience')}</label>
+          <label htmlFor="c-segment" className="text-sm font-medium">{t('Komu', 'Audience')}</label>
           <select
             id="c-segment"
             className={field}
@@ -168,83 +200,46 @@ export default function NewCampaignPage() {
               </option>
             ))}
           </select>
-          {/* Segments are code, not something this screen can author (ADR-0201 D1). Saying so here
-              is cheaper than letting someone hunt for an "add segment" button that will never exist. */}
+          {/* Segments are code (ADR-0201 D1). Saying so is cheaper than letting someone hunt for an
+              "add segment" button that will never exist. */}
           <p className="text-xs text-muted-foreground">
             {t(
               'Segmenty jsou definované v kódu a verzované. Nový segment je pull request, ne akce v UI.',
               'Segments are defined in code and versioned. A new segment is a pull request, not a UI action.',
             )}
           </p>
-          {reachState === 'loading' && (
-            <p className="text-xs text-muted-foreground">{t('Počítám dosah…', 'Counting reach…')}</p>
-          )}
-          {reachState === 'ok' && reach !== null && (
-            <p className="text-xs">
-              {t('Aktuální dosah', 'Current reach')}:{' '}
-              <strong>{reach.toLocaleString(language === 'cs' ? 'cs-CZ' : 'en-GB')}</strong>{' '}
-              {/* Stated, because reach is a moving number and a stale one drives a wrong decision. */}
-              <span className="text-muted-foreground">
-                {t(
-                  '— před ověřením souhlasu a potlačením; skutečný počet bude nižší.',
-                  '— before consent checks and suppression; the sent-to count will be lower.',
-                )}
-              </span>
-            </p>
-          )}
-          {reachState !== '' && reachState !== 'ok' && reachState !== 'loading' && (
-            <p className="text-xs text-amber-600">
-              {t('Dosah se nepodařilo spočítat.', 'Reach could not be computed.')}
-            </p>
-          )}
         </div>
+      </section>
 
-        <div className="space-y-1">
-          <label htmlFor="c-template" className="text-sm font-medium">{t('Šablona', 'Template')}</label>
-          <select
-            id="c-template"
-            className={field}
-            value={template}
-            onChange={e => {
-              setTemplate(e.target.value)
-              setVariables({})
-            }}
-          >
-            {Object.keys(TEMPLATES).map(tpl => (
-              <option key={tpl} value={tpl}>{tpl}</option>
-            ))}
-          </select>
-        </div>
+      <section className="space-y-3">
+        <h2 className="text-sm font-semibold">{t('Cesta', 'The journey')}</h2>
+        <JourneyEditor
+          steps={steps}
+          audience={segment}
+          audienceSize={reach}
+          selected={selected}
+          onSelect={setSelected}
+          onAdd={addStep}
+          onRemove={removeStep}
+          templateLabels={templateLabels}
+        />
 
-        {declared.map(v => (
-          <div key={v} className="space-y-1">
-            <label htmlFor={`var-${v}`} className="text-sm font-medium">{v}</label>
-            <input
-              id={`var-${v}`}
-              className={field}
-              value={variables[v] ?? ''}
-              onChange={e => setVariables(prev => ({ ...prev, [v]: e.target.value }))}
+        {selected !== null && steps[selected] && (
+          <div className="max-w-2xl">
+            <StepEditor
+              index={selected}
+              step={steps[selected]}
+              templates={TEMPLATES}
+              templateLabels={templateLabels}
+              onChange={next => updateStep(selected, next)}
+              onClose={() => setSelected(null)}
             />
           </div>
-        ))}
-
-        <div className="space-y-1">
-          <label htmlFor="c-delay" className="text-sm font-medium">
-            {t('Zpoždění kroku (hodiny)', 'Step delay (hours)')}
-          </label>
-          <input
-            id="c-delay"
-            type="number"
-            min="0"
-            className={field}
-            value={delayHours}
-            onChange={e => setDelayHours(e.target.value)}
-          />
-        </div>
+        )}
 
         {/* Read-only on purpose: the contact policy is a single enforcement point, and a per-campaign
             override here would make that point decorative (ADR-0219 D4, ADR-0221 D1 step 4). */}
-        <div className="rounded-lg border p-3 text-xs text-muted-foreground">
+        <div className="max-w-2xl rounded-lg border p-3 text-xs text-muted-foreground">
           <p className="font-medium text-foreground">{t('Pravidla kontaktu', 'Contact rules')}</p>
           <p>
             {t(
@@ -253,24 +248,36 @@ export default function NewCampaignPage() {
             )}
           </p>
         </div>
-
-        {error && <p className="text-sm text-red-600">{error}</p>}
-
-        <div className="flex items-center gap-3">
-          <button
-            onClick={submit}
-            disabled={!ready || saving}
-            className="rounded-md border px-3 py-1.5 text-sm disabled:opacity-40"
-          >
-            {saving ? t('Zakládám…', 'Creating…') : t('Založit koncept', 'Create draft')}
-          </button>
-          {!ready && missing.length > 0 && (
-            <span className="text-xs text-muted-foreground">
-              {t('Chybí', 'Missing')}: {missing.join(', ')}
-            </span>
-          )}
-        </div>
       </section>
+
+      {error && <p className="text-sm text-red-600">{error}</p>}
+
+      <div className="flex items-center gap-3">
+        <button
+          onClick={submit}
+          disabled={!ready || saving}
+          className="rounded-md border px-3 py-1.5 text-sm disabled:opacity-40"
+        >
+          {saving ? t('Zakládám…', 'Creating…') : t('Založit koncept', 'Create draft')}
+        </button>
+        {!ready && (
+          <span className="text-xs text-muted-foreground">
+            {incomplete
+              ? t('Některý krok má nevyplněné hodnoty.', 'A step still has empty values.')
+              : t('Vyplňte název, cíl a publikum.', 'Fill in the name, goal and audience.')}
+          </span>
+        )}
+        {reach !== null && (
+          // Qualified, because an unqualified reach number reads as "people who will get this" —
+          // the single most expensive misreading on an authoring screen.
+          <span className="text-xs text-muted-foreground">
+            {t(
+              `Dosah ${reach} — před ověřením souhlasu a potlačením; doručených bude méně.`,
+              `Reach ${reach} — before consent checks and suppression; fewer will be delivered.`,
+            )}
+          </span>
+        )}
+      </div>
     </div>
   )
 }

--- a/openbank-admin-ui/src/components/campaigns/JourneyEditor.tsx
+++ b/openbank-admin-ui/src/components/campaigns/JourneyEditor.tsx
@@ -1,0 +1,229 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright (c) OpenBank contributors. Licensed under the Apache License, Version 2.0.
+// See LICENSE in the repository root or https://www.apache.org/licenses/LICENSE-2.0 for details.
+
+'use client'
+
+import { useLanguage } from '@/lib/i18n/LanguageContext'
+
+/**
+ * The campaign builder as a canvas: entry → step → step, clicked rather than typed.
+ *
+ * The form it replaces asked a marketer for `template`, `variables` and `delaySeconds` — the
+ * engine's vocabulary, in the engine's order. This shows the journey they are building while they
+ * build it, which is what every tool in this category does and the reason ours read as a developer
+ * screen.
+ *
+ * **On ADR-0221 D5.** That decision rejects "a drag-and-drop journey canvas", and the reasoning is
+ * sound: a free-form 40-node graph is where campaign tools go to die. This is deliberately not that.
+ * The flow is LINEAR and BOUNDED — the domain caps a journey at five steps (`Campaign.MAX_STEPS`),
+ * and there is no arbitrary edge to draw, no branching to lay out, nothing to arrange. You add a
+ * step, you edit it, you remove it. It is the wizard's step list rendered as the thing it describes,
+ * which is what D5's "the wizard's step list covers the honest use cases" already wanted — it just
+ * did not say it could be drawn.
+ *
+ * Deliberately still absent, because D5 and ADR-0176 D4 forbid them and the service enforces both:
+ * no free-text body anywhere (only declared template variables), and no way to author a segment —
+ * that is a pull request against the catalogue.
+ */
+
+export interface EditorStep {
+  template: string
+  variables: Record<string, string>
+  delaySeconds: number
+}
+
+export const MAX_STEPS = 5
+
+const NODE_W = 176
+const NODE_H = 72
+const GAP_X = 84
+const ROW_Y = 70
+const PAD = 24
+
+export function JourneyEditor({
+  steps,
+  audience,
+  audienceSize,
+  selected,
+  onSelect,
+  onAdd,
+  onRemove,
+  templateLabels,
+}: {
+  steps: EditorStep[]
+  /** `name@version`, or empty while the marketer has not chosen one. */
+  audience: string
+  audienceSize: number | null
+  selected: number | null
+  onSelect: (index: number | null) => void
+  onAdd: () => void
+  onRemove: (index: number) => void
+  templateLabels: Record<string, string>
+}) {
+  const { t, language } = useLanguage()
+  const n = (v: number) => v.toLocaleString(language === 'cs' ? 'cs-CZ' : 'en-GB')
+
+  const delayLabel = (s: number): string => {
+    if (s <= 0) return t('ihned', 'immediately')
+    const d = Math.floor(s / 86400)
+    if (d >= 1) return t(`za ${d} d`, `after ${d} d`)
+    const h = Math.floor(s / 3600)
+    if (h >= 1) return t(`za ${h} h`, `after ${h} h`)
+    return t(`za ${Math.floor(s / 60)} min`, `after ${Math.floor(s / 60)} min`)
+  }
+
+  const canAdd = steps.length < MAX_STEPS
+  // Entry + steps + the add affordance, which occupies a slot so the canvas does not jump when a
+  // step is added.
+  const cols = 1 + steps.length + (canAdd ? 1 : 0)
+  const width = PAD * 2 + cols * NODE_W + (cols - 1) * GAP_X
+  const height = ROW_Y + NODE_H / 2 + 56
+
+  const colX = (i: number) => PAD + i * (NODE_W + GAP_X)
+
+  const edge = (fromIdx: number, toIdx: number, label: string) => {
+    const x0 = colX(fromIdx) + NODE_W
+    const x1 = colX(toIdx)
+    const mid = (x0 + x1) / 2
+    return (
+      <g key={`e${fromIdx}`}>
+        <path
+          d={`M ${x0} ${ROW_Y} L ${x1} ${ROW_Y}`}
+          stroke="var(--border-strong)" strokeWidth="1.6" fill="none" markerEnd="url(#je-arrow)"
+        />
+        <text x={mid} y={ROW_Y - 10} fontSize="11" textAnchor="middle" fill="var(--text-secondary)">
+          {label}
+        </text>
+      </g>
+    )
+  }
+
+  return (
+    <div className="overflow-x-auto rounded-xl border" style={{ background: 'var(--surface)' }}>
+      <svg
+        viewBox={`0 0 ${width} ${height}`}
+        style={{ width: '100%', minWidth: Math.min(width, 760), height: 'auto', display: 'block' }}
+        role="img"
+        aria-label={t('Plátno pro sestavení kampaně', 'Campaign builder canvas')}
+      >
+        <defs>
+          <marker id="je-arrow" markerWidth="8" markerHeight="8" refX="7" refY="4" orient="auto">
+            <path d="M0,0 L8,4 L0,8 Z" fill="var(--border-strong)" />
+          </marker>
+          <filter id="je-shadow" x="-20%" y="-20%" width="140%" height="140%">
+            <feDropShadow dx="0" dy="1" stdDeviation="1.5" floodOpacity="0.10" />
+          </filter>
+        </defs>
+
+        {/* Entry — the audience. Not editable here: a segment is code (ADR-0201 D1), so this node
+            reports the choice made above rather than offering to author one. */}
+        <g filter="url(#je-shadow)">
+          <rect
+            x={colX(0)} y={ROW_Y - NODE_H / 2} width={NODE_W} height={NODE_H} rx="14"
+            fill="var(--surface-2)" stroke="var(--border-strong)" strokeWidth="1.2"
+          />
+          <text x={colX(0) + 14} y={ROW_Y - 14} fontSize="10" fill="var(--text-secondary)">
+            {t('PUBLIKUM', 'AUDIENCE')}
+          </text>
+          <text x={colX(0) + 14} y={ROW_Y + 6} fontSize="13" fontWeight="600" fill="var(--text-primary)">
+            {audience || t('zatím nevybráno', 'not chosen yet')}
+          </text>
+          <text x={colX(0) + 14} y={ROW_Y + 24} fontSize="11" fill="var(--text-secondary)">
+            {audienceSize === null ? t('—', '—') : `${n(audienceSize)} ${t('lidí', 'people')}`}
+          </text>
+        </g>
+
+        {steps.map((step, i) => {
+          const x = colX(i + 1)
+          const isSelected = selected === i
+          return (
+            <g key={i}>
+              {edge(i, i + 1, delayLabel(step.delaySeconds))}
+              <g
+                filter="url(#je-shadow)"
+                style={{ cursor: 'pointer' }}
+                onClick={() => onSelect(isSelected ? null : i)}
+                role="button"
+                aria-label={t(`Upravit krok ${i + 1}`, `Edit step ${i + 1}`)}
+                data-step={i}
+                data-selected={isSelected ? 'true' : 'false'}
+              >
+                <rect
+                  x={x} y={ROW_Y - NODE_H / 2} width={NODE_W} height={NODE_H} rx="14"
+                  fill="var(--surface-2)"
+                  stroke={isSelected ? 'var(--accent)' : 'var(--border-strong)'}
+                  strokeWidth={isSelected ? 2 : 1.2}
+                />
+                <text x={x + 14} y={ROW_Y - 14} fontSize="10" fill="var(--text-secondary)">
+                  {t('KROK', 'STEP')} {i + 1} · {t('e-mail', 'email')}
+                </text>
+                <text x={x + 14} y={ROW_Y + 8} fontSize="13" fontWeight="600" fill="var(--text-primary)">
+                  {templateLabels[step.template] ?? step.template}
+                </text>
+              </g>
+
+              {/* Remove sits on the node rather than in a toolbar: the thing it acts on is the thing
+                  you are looking at, and a five-step journey never needs a bulk operation. */}
+              <g
+                style={{ cursor: 'pointer' }}
+                onClick={() => onRemove(i)}
+                role="button"
+                aria-label={t(`Odebrat krok ${i + 1}`, `Remove step ${i + 1}`)}
+                data-remove-step={i}
+              >
+                <circle cx={x + NODE_W - 14} cy={ROW_Y - NODE_H / 2 + 14} r="9" fill="var(--surface-3)" />
+                <text
+                  x={x + NODE_W - 14} y={ROW_Y - NODE_H / 2 + 18}
+                  fontSize="13" textAnchor="middle" fill="var(--text-secondary)"
+                >
+                  ×
+                </text>
+              </g>
+            </g>
+          )
+        })}
+
+        {canAdd && (
+          <g>
+            {steps.length > 0 && edge(steps.length, steps.length + 1, '')}
+            {steps.length === 0 && edge(0, 1, '')}
+            <g
+              style={{ cursor: 'pointer' }}
+              onClick={onAdd}
+              role="button"
+              aria-label={t('Přidat krok', 'Add a step')}
+              data-add-step="true"
+            >
+              <rect
+                x={colX(steps.length + 1)} y={ROW_Y - NODE_H / 2}
+                width={NODE_W} height={NODE_H} rx="14"
+                fill="none" stroke="var(--border-strong)" strokeWidth="1.4" strokeDasharray="5 4"
+              />
+              <text
+                x={colX(steps.length + 1) + NODE_W / 2} y={ROW_Y + 5}
+                fontSize="13" textAnchor="middle" fill="var(--text-secondary)"
+              >
+                + {t('přidat krok', 'add a step')}
+              </text>
+            </g>
+          </g>
+        )}
+
+        {!canAdd && (
+          // Stated, not enforced silently: the cap is a domain rule (Campaign.MAX_STEPS), and a
+          // marketer who cannot find the add button deserves to know why rather than assume a bug.
+          <text
+            x={width - PAD} y={ROW_Y + NODE_H / 2 + 30}
+            fontSize="11" textAnchor="end" fill="var(--text-secondary)"
+          >
+            {t(
+              `Maximum je ${MAX_STEPS} kroků — delší cesty se v praxi neudrží.`,
+              `${MAX_STEPS} steps is the maximum — longer journeys do not survive contact with reality.`,
+            )}
+          </text>
+        )}
+      </svg>
+    </div>
+  )
+}

--- a/openbank-admin-ui/src/components/campaigns/StepEditor.tsx
+++ b/openbank-admin-ui/src/components/campaigns/StepEditor.tsx
@@ -1,0 +1,124 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright (c) OpenBank contributors. Licensed under the Apache License, Version 2.0.
+// See LICENSE in the repository root or https://www.apache.org/licenses/LICENSE-2.0 for details.
+
+'use client'
+
+import { useLanguage } from '@/lib/i18n/LanguageContext'
+import type { EditorStep } from '@/components/campaigns/JourneyEditor'
+
+/**
+ * Edits the step selected on the canvas.
+ *
+ * It only ever shows the fields the chosen template DECLARES. That is not a convenience: ADR-0176 D4
+ * and the service's TemplateCatalog make a campaign supply values and never body text, so a
+ * free-text box here would be a control the service refuses — the worst kind, because it looks like
+ * it works until you submit.
+ *
+ * The delay is entered in the unit a person thinks in. `delaySeconds` is the engine's field, and
+ * asking a marketer for 172800 was one of the clearest symptoms of a screen built for the API.
+ */
+
+export function StepEditor({
+  index,
+  step,
+  templates,
+  templateLabels,
+  onChange,
+  onClose,
+}: {
+  index: number
+  step: EditorStep
+  /** template id → the variables it declares. Mirrors the service's catalogue. */
+  templates: Record<string, string[]>
+  templateLabels: Record<string, string>
+  onChange: (next: EditorStep) => void
+  onClose: () => void
+}) {
+  const { t } = useLanguage()
+  const declared = templates[step.template] ?? []
+  const missing = declared.filter(v => !(step.variables[v] ?? '').trim())
+  const field = 'w-full rounded-md border bg-transparent px-3 py-1.5 text-sm'
+
+  const setDelayDays = (raw: string) => {
+    const days = Math.max(0, Number(raw) || 0)
+    onChange({ ...step, delaySeconds: days * 86400 })
+  }
+
+  return (
+    <div className="rounded-xl border p-4 space-y-4" data-step-editor={index}>
+      <div className="flex items-baseline justify-between">
+        <h3 className="text-sm font-semibold">
+          {t('Krok', 'Step')} {index + 1}
+        </h3>
+        <button onClick={onClose} className="text-xs text-muted-foreground hover:underline">
+          {t('Hotovo', 'Done')}
+        </button>
+      </div>
+
+      <div className="space-y-1">
+        <label htmlFor={`tpl-${index}`} className="text-sm font-medium">
+          {t('Co se pošle', 'What gets sent')}
+        </label>
+        <select
+          id={`tpl-${index}`}
+          className={field}
+          value={step.template}
+          onChange={e => onChange({ ...step, template: e.target.value, variables: {} })}
+        >
+          {Object.keys(templates).map(tpl => (
+            <option key={tpl} value={tpl}>
+              {templateLabels[tpl] ?? tpl}
+            </option>
+          ))}
+        </select>
+        {/* Said out loud so the absence of a rich-text box reads as a rule, not a missing feature. */}
+        <p className="text-xs text-muted-foreground">
+          {t(
+            'Text e-mailu je v šabloně. Tady se vyplňují jen její pojmenované hodnoty.',
+            'The email copy lives in the template. Only its named values are filled in here.',
+          )}
+        </p>
+      </div>
+
+      {declared.map(v => (
+        <div key={v} className="space-y-1">
+          <label htmlFor={`var-${index}-${v}`} className="text-sm font-medium">
+            {v}
+          </label>
+          <input
+            id={`var-${index}-${v}`}
+            className={field}
+            value={step.variables[v] ?? ''}
+            onChange={e => onChange({ ...step, variables: { ...step.variables, [v]: e.target.value } })}
+          />
+        </div>
+      ))}
+
+      <div className="space-y-1">
+        <label htmlFor={`delay-${index}`} className="text-sm font-medium">
+          {t('Poslat po', 'Send after')}
+        </label>
+        <div className="flex items-center gap-2">
+          <input
+            id={`delay-${index}`}
+            type="number"
+            min="0"
+            className={`${field} w-28`}
+            value={Math.round(step.delaySeconds / 86400)}
+            onChange={e => setDelayDays(e.target.value)}
+          />
+          <span className="text-sm text-muted-foreground">
+            {t('dnech od předchozího kroku (0 = ihned)', 'days from the previous step (0 = immediately)')}
+          </span>
+        </div>
+      </div>
+
+      {missing.length > 0 && (
+        <p className="text-xs text-amber-600">
+          {t('Ještě chybí', 'Still missing')}: {missing.join(', ')}
+        </p>
+      )}
+    </div>
+  )
+}

--- a/openbank-admin-ui/src/test/journey-editor.test.tsx
+++ b/openbank-admin-ui/src/test/journey-editor.test.tsx
@@ -1,0 +1,117 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright (c) OpenBank contributors. Licensed under the Apache License, Version 2.0.
+// See LICENSE in the repository root or https://www.apache.org/licenses/LICENSE-2.0 for details.
+
+import React from 'react'
+import { describe, expect, it, vi } from 'vitest'
+import { render, screen, fireEvent } from '@testing-library/react'
+import { LanguageProvider } from '@/lib/i18n/LanguageContext'
+import { JourneyEditor, MAX_STEPS, type EditorStep } from '@/components/campaigns/JourneyEditor'
+import { StepEditor } from '@/components/campaigns/StepEditor'
+
+const TEMPLATES = { MARKETING_PRODUCT_OFFER: ['offerTitle', 'offerText', 'ctaText'] }
+const LABELS = { MARKETING_PRODUCT_OFFER: 'Product offer' }
+const step = (delay = 0, vars: Record<string, string> = {}): EditorStep => ({
+  template: 'MARKETING_PRODUCT_OFFER',
+  variables: vars,
+  delaySeconds: delay,
+})
+
+function canvas(steps: EditorStep[], handlers: Partial<Record<'onAdd' | 'onRemove' | 'onSelect', ReturnType<typeof vi.fn>>> = {}) {
+  const props = {
+    steps,
+    audience: 'actives@1',
+    audienceSize: 1240,
+    selected: null,
+    onSelect: handlers.onSelect ?? vi.fn(),
+    onAdd: handlers.onAdd ?? vi.fn(),
+    onRemove: handlers.onRemove ?? vi.fn(),
+    templateLabels: LABELS,
+  }
+  return { ...render(React.createElement(LanguageProvider, null, React.createElement(JourneyEditor, props))), props }
+}
+
+describe('campaign builder canvas', () => {
+  it('draws the audience and one node per step, in words', () => {
+    canvas([step(), step(172800)])
+
+    expect(screen.getByText('actives@1')).toBeTruthy()
+    expect(screen.getAllByText(/Product offer/).length).toBe(2)
+    expect(screen.getByText(/after 2 d/)).toBeTruthy()
+  })
+
+  /**
+   * ADR-0221 D5 rejects a drag-and-drop canvas because a free-form graph is unbounded. The cap is
+   * what makes this a different thing: at MAX_STEPS the add affordance is gone AND the reason is on
+   * screen, so a marketer who cannot find it is told why rather than left to assume a bug.
+   */
+  it('stops offering a step at the domain cap, and says why', () => {
+    const { container } = canvas(Array.from({ length: MAX_STEPS }, () => step()))
+
+    expect(container.querySelector('[data-add-step]')).toBeNull()
+    expect(screen.getByText(new RegExp(`${MAX_STEPS} steps is the maximum`))).toBeTruthy()
+  })
+
+  it('offers a step below the cap and reports the click', () => {
+    const onAdd = vi.fn()
+    const { container } = canvas([step()], { onAdd })
+
+    const add = container.querySelector('[data-add-step]')
+    expect(add).toBeTruthy()
+    fireEvent.click(add!)
+    expect(onAdd).toHaveBeenCalled()
+  })
+
+  it('removes the step whose node was clicked, not the last one', () => {
+    const onRemove = vi.fn()
+    const { container } = canvas([step(), step(), step()], { onRemove })
+
+    fireEvent.click(container.querySelector('[data-remove-step="1"]')!)
+    expect(onRemove).toHaveBeenCalledWith(1)
+  })
+})
+
+describe('step editor', () => {
+  /**
+   * ADR-0176 D4 and the service's TemplateCatalog make a campaign supply values, never body text.
+   * A free-text box here would be a control the service refuses — the worst kind, because it looks
+   * like it works until submit.
+   */
+  it('offers only the template’s declared variables and no free-text body', () => {
+    const { container } = render(
+      React.createElement(LanguageProvider, null,
+        React.createElement(StepEditor, {
+          index: 0, step: step(), templates: TEMPLATES, templateLabels: LABELS,
+          onChange: vi.fn(), onClose: vi.fn(),
+        })))
+
+    expect(screen.getByLabelText('offerTitle')).toBeTruthy()
+    expect(screen.getByLabelText('ctaText')).toBeTruthy()
+    expect(container.querySelector('textarea')).toBeNull()
+  })
+
+  /** `delaySeconds` is the engine's field. Asking a marketer for 172800 was the symptom. */
+  it('takes the delay in days and converts it', () => {
+    const onChange = vi.fn()
+    render(
+      React.createElement(LanguageProvider, null,
+        React.createElement(StepEditor, {
+          index: 0, step: step(), templates: TEMPLATES, templateLabels: LABELS,
+          onChange, onClose: vi.fn(),
+        })))
+
+    fireEvent.change(screen.getByLabelText(/Send after/), { target: { value: '2' } })
+    expect(onChange).toHaveBeenCalledWith(expect.objectContaining({ delaySeconds: 172800 }))
+  })
+
+  it('names what is still missing rather than just refusing later', () => {
+    render(
+      React.createElement(LanguageProvider, null,
+        React.createElement(StepEditor, {
+          index: 0, step: step(0, { offerTitle: 'T' }), templates: TEMPLATES, templateLabels: LABELS,
+          onChange: vi.fn(), onClose: vi.fn(),
+        })))
+
+    expect(screen.getByText(/offerText, ctaText/)).toBeTruthy()
+  })
+})


### PR DESCRIPTION
Refs #2895, ADR-0221 D1.

The create screen asked a marketer for `template`, `variables` and `delaySeconds` — the engine's
vocabulary, in the engine's order. Now the journey is **drawn while it is assembled**:

```
┌──────────────┐             ┌────────────────┐            ┌────────────────┐ ╭─ ─ ─ ─ ─ ─ ─╮
│ AUDIENCE     │ immediately │ STEP 1 · email×│  after 2 d │ STEP 2 · email×│ │ + add a step│
│ actives@1    │────────────▶│ Product offer  │───────────▶│ Product offer  │ ╰─ ─ ─ ─ ─ ─ ─╯
│ 1,240 people │             └────────────────┘            └────────────────┘
└──────────────┘
```

Click a node to edit it, the dashed node to add one, the `×` to remove one. Same visual language as
the journey view and `docs/service-map` — the console has one canvas vocabulary, not three.

## On ADR-0221 D5

D5 rejects "a drag-and-drop journey canvas", and I want that read rather than skipped: **this is
deliberately not one.** The objection is a free-form 40-node graph, and the flow here is linear and
capped at the domain's five steps (`Campaign.MAX_STEPS`). Nothing to drag, nothing to branch, nothing
to arrange. It is D5's own "the wizard's step list covers the honest use cases" — drawn rather than
listed.

At the cap the add affordance disappears **and the canvas says why**, so a marketer who cannot find
it is told rather than left assuming a bug. If a genuinely free-form canvas is wanted, that is an ADR
change, not a commit.

## What the step editor deliberately refuses to offer

Only the variables the chosen template **declares**. That is not convenience: ADR-0176 D4 and the
service's `TemplateCatalog` make a campaign supply values and never body text, so a free-text box
here would be a control the service refuses — the worst kind, because it looks like it works right up
to submit. The test asserts there is no `<textarea>` anywhere.

The delay is entered in **days**. `delaySeconds` is the engine's field, and asking a marketer for
172800 was among the clearest symptoms of a screen built for the API.

## Unchanged on purpose

- no way to author a segment — that is a pull request against the catalogue (ADR-0201 D1), and the
  screen says so rather than leaving someone hunting for a button that will never exist;
- contact rules shown read-only (ADR-0219 D4 — a per-campaign override would make the single
  enforcement point decorative);
- it stops at **create draft**. Offering activation to the author would render the four-eyes gate
  decorative, which is the same reason the detail screen only offers it in `PENDING_APPROVAL`.

## Tests

Seven: the canvas draws audience and one node per step in words; the add affordance is gone **and**
the reason is on screen at the cap; add and remove report the right index (remove targets the clicked
node, not the last one); the editor offers only declared variables with no free-text body; the delay
converts days → seconds; and incomplete steps are named rather than silently refused later.

263/263 across the campaign suite together with the i18n and layout-shell guards; `tsc` clean.
