### PR TITLE
fix(infra): keep one failed Job per CronJob, not three — KubeJobFailed fires per surviving object

### DIFF
--- a/openbank-infra/aws/envs/sandbox-platform/arc-runner-reaper.tf
+++ b/openbank-infra/aws/envs/sandbox-platform/arc-runner-reaper.tf
@@ -227,7 +227,12 @@ resource "kubernetes_cron_job_v1" "arc_reaper" {
     concurrency_policy            = "Forbid"
     starting_deadline_seconds     = 200
     successful_jobs_history_limit = 3
-    failed_jobs_history_limit     = 3
+    # 3 -> 1: KubeJobFailed fires per surviving failed Job OBJECT, so keeping three
+    # turns one recurring failure into three permanent alerts, and the pods are
+    # garbage-collected long before the objects are — the extra tombstones carry the
+    # alert and none of the evidence. Measured 2026-08-02: this reaper alone accounted
+    # for 3 of the 11 firing KubeJobFailed, its oldest from 07-28 with pods=0.
+    failed_jobs_history_limit = 1
 
     job_template {
       metadata {}

--- a/openbank-infra/gitops/components/admin-ui/cost-collector.yaml
+++ b/openbank-infra/gitops/components/admin-ui/cost-collector.yaml
@@ -77,7 +77,15 @@ spec:
   timeZone: "Europe/Prague"
   concurrencyPolicy: Forbid
   successfulJobsHistoryLimit: 3
-  failedJobsHistoryLimit: 3
+  # failedJobsHistoryLimit: 1 — keep the LATEST failure for triage, not an archive.
+  # kube-prometheus-stack's KubeJobFailed fires per surviving failed Job OBJECT, so a
+  # limit of 3 turns one recurring failure into three permanent alerts. Worse, the pods
+  # are garbage-collected long before the Job object is, so the extra tombstones carry
+  # no diagnostic value at all — only the alert. Measured 2026-08-02: KubeJobFailed was
+  # 11 of the 37 firing alerts, 8 of them with pods=0 and the oldest dating to 07-12.
+  # One failure per CronJob still alerts (a job that keeps failing should), the
+  # duplicates stop.
+  failedJobsHistoryLimit: 1
   startingDeadlineSeconds: 600
   jobTemplate:
     spec:

--- a/openbank-infra/gitops/components/admin-ui/tier-classifier.yaml
+++ b/openbank-infra/gitops/components/admin-ui/tier-classifier.yaml
@@ -72,7 +72,15 @@ spec:
   timeZone: "UTC"
   concurrencyPolicy: Forbid
   successfulJobsHistoryLimit: 3
-  failedJobsHistoryLimit: 3
+  # failedJobsHistoryLimit: 1 — keep the LATEST failure for triage, not an archive.
+  # kube-prometheus-stack's KubeJobFailed fires per surviving failed Job OBJECT, so a
+  # limit of 3 turns one recurring failure into three permanent alerts. Worse, the pods
+  # are garbage-collected long before the Job object is, so the extra tombstones carry
+  # no diagnostic value at all — only the alert. Measured 2026-08-02: KubeJobFailed was
+  # 11 of the 37 firing alerts, 8 of them with pods=0 and the oldest dating to 07-12.
+  # One failure per CronJob still alerts (a job that keeps failing should), the
+  # duplicates stop.
+  failedJobsHistoryLimit: 1
   startingDeadlineSeconds: 600
   jobTemplate:
     spec:

--- a/openbank-infra/gitops/components/finops-scaledown/cronjob-scale-down.yaml
+++ b/openbank-infra/gitops/components/finops-scaledown/cronjob-scale-down.yaml
@@ -38,7 +38,15 @@ spec:
   concurrencyPolicy: Forbid
   startingDeadlineSeconds: 900
   successfulJobsHistoryLimit: 5
-  failedJobsHistoryLimit: 5
+  # failedJobsHistoryLimit: 1 — keep the LATEST failure for triage, not an archive.
+  # kube-prometheus-stack's KubeJobFailed fires per surviving failed Job OBJECT, so a
+  # limit of 3 turns one recurring failure into three permanent alerts. Worse, the pods
+  # are garbage-collected long before the Job object is, so the extra tombstones carry
+  # no diagnostic value at all — only the alert. Measured 2026-08-02: KubeJobFailed was
+  # 11 of the 37 firing alerts, 8 of them with pods=0 and the oldest dating to 07-12.
+  # One failure per CronJob still alerts (a job that keeps failing should), the
+  # duplicates stop.
+  failedJobsHistoryLimit: 1
   jobTemplate:
     spec:
       activeDeadlineSeconds: 600

--- a/openbank-infra/gitops/components/finops-scaledown/cronjob-scale-up.yaml
+++ b/openbank-infra/gitops/components/finops-scaledown/cronjob-scale-up.yaml
@@ -33,7 +33,15 @@ spec:
   concurrencyPolicy: Forbid
   startingDeadlineSeconds: 900
   successfulJobsHistoryLimit: 5
-  failedJobsHistoryLimit: 5
+  # failedJobsHistoryLimit: 1 — keep the LATEST failure for triage, not an archive.
+  # kube-prometheus-stack's KubeJobFailed fires per surviving failed Job OBJECT, so a
+  # limit of 3 turns one recurring failure into three permanent alerts. Worse, the pods
+  # are garbage-collected long before the Job object is, so the extra tombstones carry
+  # no diagnostic value at all — only the alert. Measured 2026-08-02: KubeJobFailed was
+  # 11 of the 37 firing alerts, 8 of them with pods=0 and the oldest dating to 07-12.
+  # One failure per CronJob still alerts (a job that keeps failing should), the
+  # duplicates stop.
+  failedJobsHistoryLimit: 1
   jobTemplate:
     spec:
       activeDeadlineSeconds: 600

--- a/openbank-infra/gitops/components/infra-vuln-scanner/infra-vuln-scanner.yaml
+++ b/openbank-infra/gitops/components/infra-vuln-scanner/infra-vuln-scanner.yaml
@@ -229,7 +229,15 @@ spec:
   timeZone: "UTC"
   concurrencyPolicy: Forbid
   successfulJobsHistoryLimit: 3
-  failedJobsHistoryLimit: 3
+  # failedJobsHistoryLimit: 1 — keep the LATEST failure for triage, not an archive.
+  # kube-prometheus-stack's KubeJobFailed fires per surviving failed Job OBJECT, so a
+  # limit of 3 turns one recurring failure into three permanent alerts. Worse, the pods
+  # are garbage-collected long before the Job object is, so the extra tombstones carry
+  # no diagnostic value at all — only the alert. Measured 2026-08-02: KubeJobFailed was
+  # 11 of the 37 firing alerts, 8 of them with pods=0 and the oldest dating to 07-12.
+  # One failure per CronJob still alerts (a job that keeps failing should), the
+  # duplicates stop.
+  failedJobsHistoryLimit: 1
   startingDeadlineSeconds: 600
   jobTemplate:
     spec:

--- a/openbank-infra/gitops/components/keycloak-realm-drift/keycloak-realm-drift.yaml
+++ b/openbank-infra/gitops/components/keycloak-realm-drift/keycloak-realm-drift.yaml
@@ -119,7 +119,15 @@ spec:
   timeZone: "UTC"
   concurrencyPolicy: Forbid
   successfulJobsHistoryLimit: 3
-  failedJobsHistoryLimit: 3
+  # failedJobsHistoryLimit: 1 — keep the LATEST failure for triage, not an archive.
+  # kube-prometheus-stack's KubeJobFailed fires per surviving failed Job OBJECT, so a
+  # limit of 3 turns one recurring failure into three permanent alerts. Worse, the pods
+  # are garbage-collected long before the Job object is, so the extra tombstones carry
+  # no diagnostic value at all — only the alert. Measured 2026-08-02: KubeJobFailed was
+  # 11 of the 37 firing alerts, 8 of them with pods=0 and the oldest dating to 07-12.
+  # One failure per CronJob still alerts (a job that keeps failing should), the
+  # duplicates stop.
+  failedJobsHistoryLimit: 1
   startingDeadlineSeconds: 600
   jobTemplate:
     spec:

--- a/openbank-infra/gitops/components/observability/cronjob-rum-attribute-audit.yaml
+++ b/openbank-infra/gitops/components/observability/cronjob-rum-attribute-audit.yaml
@@ -27,7 +27,15 @@ spec:
   schedule: "0 2 * * 0"
   concurrencyPolicy: Forbid
   successfulJobsHistoryLimit: 4
-  failedJobsHistoryLimit: 2
+  # failedJobsHistoryLimit: 1 — keep the LATEST failure for triage, not an archive.
+  # kube-prometheus-stack's KubeJobFailed fires per surviving failed Job OBJECT, so a
+  # limit of 3 turns one recurring failure into three permanent alerts. Worse, the pods
+  # are garbage-collected long before the Job object is, so the extra tombstones carry
+  # no diagnostic value at all — only the alert. Measured 2026-08-02: KubeJobFailed was
+  # 11 of the 37 firing alerts, 8 of them with pods=0 and the oldest dating to 07-12.
+  # One failure per CronJob still alerts (a job that keeps failing should), the
+  # duplicates stop.
+  failedJobsHistoryLimit: 1
   jobTemplate:
     spec:
       activeDeadlineSeconds: 600

--- a/openbank-infra/gitops/components/sbom-drift-scanner/sbom-drift-scanner.yaml
+++ b/openbank-infra/gitops/components/sbom-drift-scanner/sbom-drift-scanner.yaml
@@ -382,7 +382,15 @@ spec:
   timeZone: "UTC"
   concurrencyPolicy: Forbid
   successfulJobsHistoryLimit: 3
-  failedJobsHistoryLimit: 3
+  # failedJobsHistoryLimit: 1 — keep the LATEST failure for triage, not an archive.
+  # kube-prometheus-stack's KubeJobFailed fires per surviving failed Job OBJECT, so a
+  # limit of 3 turns one recurring failure into three permanent alerts. Worse, the pods
+  # are garbage-collected long before the Job object is, so the extra tombstones carry
+  # no diagnostic value at all — only the alert. Measured 2026-08-02: KubeJobFailed was
+  # 11 of the 37 firing alerts, 8 of them with pods=0 and the oldest dating to 07-12.
+  # One failure per CronJob still alerts (a job that keeps failing should), the
+  # duplicates stop.
+  failedJobsHistoryLimit: 1
   startingDeadlineSeconds: 600
   jobTemplate:
     spec:


### PR DESCRIPTION
Refs #3071

## The alert counts objects, not failures

kube-prometheus-stack's `KubeJobFailed` fires **per surviving failed Job object**. So `failedJobsHistoryLimit: 3` turns one recurring failure into three permanent alerts.

Worse: the **pods are garbage-collected long before the Job objects are**, so the extra tombstones carry the alert and none of the evidence. The result is an alert pointing at an incident nobody can investigate, that no operator action can clear.

Measured today — `KubeJobFailed` was **11 of the 37 firing alerts**, and 8 of the 11 had `pods=0`:

```
arc-stuck-runner-reaper   3 alerts   oldest 07-28   pods=0
sbom-drift-scanner        3 alerts   oldest 07-30   pods=0
keycloak-realm-drift      2 alerts   08-01 / 08-02  (fixed earlier today)
secret-rotator            1 alert    08-02
openbao-document-signing  1 alert    07-26          pods=0
rum-attribute-audit       1 alert    07-12          pods=0
```

Three weeks, in the oldest case, of a lit alert whose diagnosis was already gone.

## The change

`failedJobsHistoryLimit: 1` — keep the **latest** failure for triage, drop the archive. A CronJob that keeps failing still alerts, which is correct; the duplicates stop.

Scope: the eight gitops CronJobs above 1 (two at 5, five at 3, one at 2) plus the arc reaper's Terraform. The four openbao CronJobs were already at 1 and are untouched.

## Expected effect — corrected

**11 → at most 6, i.e. −5.**

I earlier told the reviewer this would remove 8 alerts. That was wrong: it counted every alert rather than every CronJob, and limit 1 deliberately keeps one per job. Two of the remaining six (`sbom-drift-scanner`, `keycloak-realm-drift`) should clear on their own next run since both were fixed earlier today; the rest are genuine "this job's latest run failed" signals and should stay lit.

## What this does not do

It does not fix the upstream rule, which cannot distinguish *"failed once, long ago, evidence gone"* from *"failing now"* — that expression belongs to kube-prometheus-stack, not to us. This removes the input that made it noisy.

Our own equivalent, `SbomDriftScannerFailing`, was rewritten to key on the latest run instead (#3316); the upstream one we can only feed better data.

## Verification

All eight manifests pass `kubectl apply --dry-run=server`; yamllint clean over the whole gitops tree; `tofu fmt` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
