### PR TITLE
fix(ci): refuse a dispatched deploy of a sha with no pact version

### DIFF
--- a/.github/scripts/resolve-can-i-deploy-selector.sh
+++ b/.github/scripts/resolve-can-i-deploy-selector.sh
@@ -43,8 +43,21 @@
 # that can silently start asking about the wrong thing. Here it is a pure function of
 # (probe result, sha) with no network of its own, so the unit test can drive every branch.
 #
+# WHY A workflow_dispatch WITH NO VERSION IS REFUSED (issue #3318)
+# The `no` fallback is right for a PUSH: path-scoped CI skips most services on most commits,
+# so most of the fleet legitimately has no version for that sha. It is NOT right for a manual
+# dispatch. auto-deploy builds `sandbox-${GITHUB_SHA::8}` from the CURRENT main tip, a commit
+# services-ci never built for that service — so a version for it cannot exist, and falling
+# back means the gate answers about a DIFFERENT commit than the one being pinned into gitops.
+# Both outcomes are wrong and the quiet one ships: see the "WHY NOT JUST ALWAYS PASS" note
+# above. Measured on openbank-fx-service 2026-08-02 — five manual dispatches, five verdicts
+# about consumer version 8d321a8, a commit unrelated to the change being deployed (#3306).
+# So on (no + workflow_dispatch) this emits the REFUSE sentinel and the caller stops. Push
+# behaviour is untouched.
+#
 # Usage:
-#   PACT_VERSION_PRESENT=yes|no|unknown resolve-can-i-deploy-selector.sh <service> <sha>
+#   PACT_VERSION_PRESENT=yes|no|unknown [EVENT_NAME=<github.event_name>] \
+#     resolve-can-i-deploy-selector.sh <service> <sha>
 #
 #   PACT_VERSION_PRESENT — the caller's probe of
 #     GET <broker>/pacticipants/<svc>/versions/<sha>, same vocabulary the classifier uses:
@@ -68,6 +81,9 @@ if [ -z "$SVC" ] || [ -z "$SHA" ]; then
 fi
 
 PRESENT="${PACT_VERSION_PRESENT:-unknown}"
+# Absent EVENT_NAME behaves as a push: the refusal is opt-in on the event that needs it, so a
+# caller that forgets to pass it keeps today's behaviour rather than blocking the fleet.
+EVENT="${EVENT_NAME:-push}"
 
 emit() { printf '%s\t%s\n' "$1" "$2"; }
 
@@ -80,12 +96,21 @@ case "$PRESENT" in
       "this commit's pact version is in the broker — asking about it exactly, so the verdict cannot be inherited from an earlier build"
     ;;
   no)
-    # Today's behaviour, deliberately unchanged. `--version` would error "No pacts or
-    # verifications" for a service path-scoped CI skipped on this commit, which is most of
-    # the fleet on most commits. The block classifier downstream then labels this
-    # PENDING_BUILD from the same probe result, and the reconcile tick re-drives it.
-    emit "--latest main" \
-      "no pact version for this commit — falling back to latest/main (ADR-0092); the block classifier will label this PENDING_BUILD"
+    if [ "$EVENT" = "workflow_dispatch" ]; then
+      # A manual deploy of a sha nobody has built cannot be gated on itself, and gating it on
+      # another commit is what #3318 exists to stop. Refuse instead of answering the wrong
+      # question — a manual dispatch is a human act, so a loud stop is actionable where a
+      # misdirected verdict is not.
+      emit "REFUSE" \
+        "workflow_dispatch of ${SHA} which has no published pact version for ${SVC} — the gate cannot ask about the sha being deployed, and asking about a different commit is not a gate (#3318)"
+    else
+      # Today's behaviour on a push, deliberately unchanged. `--version` would error "No pacts
+      # or verifications" for a service path-scoped CI skipped on this commit, which is most
+      # of the fleet on most commits. The block classifier downstream then labels this
+      # PENDING_BUILD from the same probe result, and the reconcile tick re-drives it.
+      emit "--latest main" \
+        "no pact version for this commit — falling back to latest/main (ADR-0092); the block classifier will label this PENDING_BUILD"
+    fi
     ;;
   *)
     # Probe failed. Fall back rather than invent precision: an unreachable broker must not

--- a/.github/scripts/test-resolve-can-i-deploy-selector.sh
+++ b/.github/scripts/test-resolve-can-i-deploy-selector.sh
@@ -20,9 +20,9 @@ SHA="0e32873f8c52d37e1b6530e5bd5e94275e5cefae"
 
 fails=0
 check() {
-  local name="$1" want="$2" present="$3"
+  local name="$1" want="$2" present="$3" event="${4:-}"
   local got
-  got="$(PACT_VERSION_PRESENT="$present" bash "$RESOLVE" openbank-demo-service "$SHA" | cut -f1)"
+  got="$(PACT_VERSION_PRESENT="$present" EVENT_NAME="$event" bash "$RESOLVE" openbank-demo-service "$SHA" | cut -f1)"
   if [ "$got" = "$want" ]; then
     echo "  ok   ${name} → ${got}"
   else
@@ -88,6 +88,33 @@ if bash "$RESOLVE" openbank-demo-service >/dev/null 2>&1; then
 else
   echo "  ok   missing-sha-arg → non-zero exit"
 fi
+
+
+# ── issue #3318: a manual dispatch of a sha with no pact version ────────────────────────
+# 5. THE POINT OF THIS ADDITION. auto-deploy builds sandbox-${GITHUB_SHA::8} from the CURRENT
+#    main tip on a dispatch, a commit services-ci never built for this service — so no version
+#    can exist for it. Falling back to `--latest main` answers about a DIFFERENT commit than
+#    the image being pinned. Measured on openbank-fx-service: five dispatches, five verdicts
+#    about an unrelated commit (#3306). Refuse instead.
+check "dispatch + no version → REFUSE" "REFUSE" no workflow_dispatch
+
+# 6. REGRESSION GUARD. The push path must be untouched: most of the fleet legitimately has no
+#    version on most commits, and refusing there would block every deploy. If someone widens
+#    the refusal to all events, this is what goes red.
+check "push + no version → still latest/main (unchanged)" "--latest main" no push
+
+# 7. Same guard for the implicit case: no EVENT_NAME exported behaves as a push, so a caller
+#    that forgets to pass it keeps today's behaviour rather than blocking the fleet.
+check "no EVENT_NAME + no version → latest/main" "--latest main" no
+
+# 8. A dispatch is only refused when the version is genuinely absent. With the version present
+#    the precise question is still the right one, dispatch or not.
+check "dispatch + version present → ask about THIS commit" "--version ${SHA}" yes workflow_dispatch
+
+# 9. A dispatch with an inconclusive probe must NOT be refused: an unreachable broker is not
+#    evidence that the version is missing, and turning a probe outage into a hard stop would
+#    make the gate fail closed on infrastructure rather than on contracts.
+check "dispatch + probe inconclusive → latest/main, not REFUSE" "--latest main" unknown workflow_dispatch
 
 if [ "$fails" -ne 0 ]; then
   echo "FAILED: ${fails} case(s)"

--- a/.github/workflows/auto-deploy.yml
+++ b/.github/workflows/auto-deploy.yml
@@ -897,9 +897,16 @@ jobs:
             # and both scripts' headers. Keep this comment SHORT: an oversized `run:` makes the
             # whole workflow unparseable (check-workflow-run-step-size.py).
             vpresent="$(bash .github/scripts/probe-pact-version.sh "$svc" "$GITHUB_SHA")"
-            sel_line="$(PACT_VERSION_PRESENT="$vpresent" \
+            sel_line="$(PACT_VERSION_PRESENT="$vpresent" EVENT_NAME="$GITHUB_EVENT_NAME" \
               bash .github/scripts/resolve-can-i-deploy-selector.sh "$svc" "$GITHUB_SHA")"
             read -ra CID_SELECTOR <<< "$(printf '%s' "$sel_line" | cut -f1)"
+            # REFUSE (#3318): a manual dispatch of a sha with no pact version. Stop rather
+            # than gate it on a different commit — see the selector script's header.
+            if [ "${CID_SELECTOR[0]}" = "REFUSE" ]; then
+              echo "::error::can-i-deploy: $(printf '%s' "$sel_line" | cut -f2)"
+              echo "deployable=[]" >> "$GITHUB_OUTPUT"
+              exit 1
+            fi
             echo "==> can-i-deploy ${svc} (${CID_SELECTOR[*]}) → environment sandbox"
             echo "    $(printf '%s' "$sel_line" | cut -f2)"
             cid_out=$("$CLI" can-i-deploy \


### PR DESCRIPTION
Closes #3318.

## The change

`resolve-can-i-deploy-selector.sh` gains one branch: on `(no pact version + workflow_dispatch)` it emits a `REFUSE` sentinel instead of falling back to `--latest main`, and `can-i-deploy` stops with the reason.

**Push behaviour is byte-for-byte unchanged**, with a regression test that says so.

## Why the fallback is right for a push and wrong for a dispatch

Path-scoped CI skips most services on most commits, so on a push most of the fleet legitimately has no version for that sha — `--version` would error, and `--latest main` is the sane fallback.

A manual dispatch is different in kind: `auto-deploy` builds `sandbox-${GITHUB_SHA::8}` from the **current main tip**, a commit `services-ci` never built for that service. A version for it *cannot* exist, so the fallback guarantees the gate answers about a different commit than the one being pinned into gitops.

The script's own header already spells out both outcomes, and the quiet one is the one that ships:

> * the older version was NOT verified → red, labelled PENDING_BUILD. Noisy, honest, self-clearing.
> * the older version WAS verified → **GREEN, and auto-deploy ships an image built from `$GITHUB_SHA` whose contracts were never verified at all.** Nothing anywhere says so. A contract gate that answers about the wrong version is not a gate.

`openbank-fx-service` hit the first outcome **five times** on 2026-08-02: five dispatches, five verdicts about consumer version `8d321a8` — a commit unrelated to the change being deployed (#3306).

## Design notes

- **A sentinel, not `exit 1` inside the script.** Its contract is *"always exits 0 — this chooses a question, it does not answer one."* Keeping it a pure function of `(probe, sha, event)` is what makes every branch unit-testable without a network, which its header gives as the reason it is a separate file at all.
- **Absent `EVENT_NAME` behaves as `push`.** The refusal is opt-in on the event that needs it, so a caller that forgets to pass it keeps today's behaviour instead of blocking the fleet.
- **An inconclusive probe on a dispatch is NOT refused.** An unreachable broker is not evidence that a version is missing; turning a probe outage into a hard stop would fail the gate closed on infrastructure rather than on contracts.

## Tests

Five new cases in `test-resolve-can-i-deploy-selector.sh`:

| case | expectation |
|---|---|
| dispatch + no version | `REFUSE` |
| **push + no version** | `--latest main` — the regression guard |
| no `EVENT_NAME` + no version | `--latest main` |
| dispatch + version present | `--version <sha>` |
| dispatch + inconclusive probe | `--latest main`, not `REFUSE` |

I first appended these **after** the file's verdict block, where a failure could never have affected the exit code — a test that cannot fail. Moved above it and proved it by inverting one expectation on purpose (exit 1) and restoring it (exit 0).

Also verified: `check-workflow-run-step-size.py` passes (18099 / 19000 — the step comment is deliberately short for this reason), and `actionlint` finding sets are identical to `origin/main`'s, so nothing new was introduced.

## What this does not fix

Manual deploys of an unbuilt sha now fail. That is the intent — today they either block confusingly or ship unverified.

The convergence problem underneath — a dispatch minting a sha nobody has built, so retries move the goalposts instead of closing in — is untouched and stays #3306. `openbank-fx-service` remains undeployable until that lands.
