### PR TITLE
fix(admin-ui): relay the operator bearer on the sanctions and security BFF routes

### DIFF
--- a/openbank-admin-ui/src/app/api/sanctions/checks/route.ts
+++ b/openbank-admin-ui/src/app/api/sanctions/checks/route.ts
@@ -2,23 +2,10 @@
 // Copyright (c) OpenBank contributors. Licensed under the Apache License, Version 2.0.
 // See LICENSE in the repository root or https://www.apache.org/licenses/LICENSE-2.0 for details.
 
-import { NextRequest, NextResponse } from 'next/server'
-
-const BASE = process.env.SANCTIONS_SERVICE_URL ?? 'http://openbank-sanctions-service:8123'
+import { forwardToSanctionsService } from '@/lib/sanctions/upstream'
 
 export const dynamic = 'force-dynamic'
 
-export async function GET(_req: NextRequest) {
-  try {
-    const res = await fetch(`${BASE}/api/v1/sanctions`, {
-      headers: { 'Content-Type': 'application/json', Accept: 'application/json' },
-      cache: 'no-store',
-      signal: AbortSignal.timeout(10_000),
-    })
-    const data = await res.json().catch(() => ({ error: 'Invalid JSON' }))
-    if (!res.ok) return NextResponse.json(data, { status: res.status })
-    return NextResponse.json(data, { headers: { 'Cache-Control': 'no-store' } })
-  } catch (error) {
-    return NextResponse.json({ error: error instanceof Error ? error.message : 'Checks request failed' }, { status: 502 })
-  }
+export async function GET() {
+  return forwardToSanctionsService('/api/v1/sanctions')
 }

--- a/openbank-admin-ui/src/app/api/sanctions/lists/route.ts
+++ b/openbank-admin-ui/src/app/api/sanctions/lists/route.ts
@@ -2,38 +2,15 @@
 // Copyright (c) OpenBank contributors. Licensed under the Apache License, Version 2.0.
 // See LICENSE in the repository root or https://www.apache.org/licenses/LICENSE-2.0 for details.
 
-import { NextRequest, NextResponse } from 'next/server'
-
-const BASE = process.env.SANCTIONS_SERVICE_URL ?? 'http://openbank-sanctions-service:8123'
+import { forwardToSanctionsService } from '@/lib/sanctions/upstream'
 
 export const dynamic = 'force-dynamic'
 
 export async function GET() {
-  try {
-    const res = await fetch(`${BASE}/api/v1/sanctions/lists`, {
-      headers: { Accept: 'application/json' },
-      cache: 'no-store',
-      signal: AbortSignal.timeout(10_000),
-    })
-    const data = await res.json().catch(() => ({ error: 'Invalid JSON' }))
-    if (!res.ok) return NextResponse.json(data, { status: res.status })
-    return NextResponse.json(data, { headers: { 'Cache-Control': 'no-store' } })
-  } catch (error) {
-    return NextResponse.json({ error: error instanceof Error ? error.message : 'Lists request failed' }, { status: 502 })
-  }
+  return forwardToSanctionsService('/api/v1/sanctions/lists')
 }
 
-export async function POST(_req: NextRequest) {
-  try {
-    const res = await fetch(`${BASE}/api/v1/sanctions/lists/refresh-all`, {
-      method: 'POST',
-      headers: { Accept: 'application/json' },
-      cache: 'no-store',
-      signal: AbortSignal.timeout(20_000),
-    })
-    const data = await res.json().catch(() => ({}))
-    return NextResponse.json(data, { status: res.status })
-  } catch (error) {
-    return NextResponse.json({ error: error instanceof Error ? error.message : 'Refresh failed' }, { status: 502 })
-  }
+export async function POST() {
+  // Refreshing every enabled list re-downloads and re-indexes the upstream feeds.
+  return forwardToSanctionsService('/api/v1/sanctions/lists/refresh-all', 'POST', {}, 20_000)
 }

--- a/openbank-admin-ui/src/app/api/sanctions/screen/route.ts
+++ b/openbank-admin-ui/src/app/api/sanctions/screen/route.ts
@@ -2,25 +2,14 @@
 // Copyright (c) OpenBank contributors. Licensed under the Apache License, Version 2.0.
 // See LICENSE in the repository root or https://www.apache.org/licenses/LICENSE-2.0 for details.
 
-import { NextRequest, NextResponse } from 'next/server'
-
-const BASE = process.env.SANCTIONS_SERVICE_URL ?? 'http://openbank-sanctions-service:8123'
+import { NextRequest } from 'next/server'
+import { forwardToSanctionsService } from '@/lib/sanctions/upstream'
 
 export const dynamic = 'force-dynamic'
 
 export async function POST(req: NextRequest) {
-  try {
-    const body = await req.json()
-    const res = await fetch(`${BASE}/api/v1/sanctions/screen`, {
-      method: 'POST',
-      headers: { 'Content-Type': 'application/json', Accept: 'application/json' },
-      body: JSON.stringify(body),
-      cache: 'no-store',
-      signal: AbortSignal.timeout(15_000),
-    })
-    const data = await res.json().catch(() => ({ error: 'Invalid JSON' }))
-    return NextResponse.json(data, { status: res.status, headers: { 'Cache-Control': 'no-store' } })
-  } catch (error) {
-    return NextResponse.json({ error: error instanceof Error ? error.message : 'Screening failed' }, { status: 502 })
-  }
+  const body = await req.json()
+  // A screening run matches the name against every enabled list — give it more headroom
+  // than a plain read.
+  return forwardToSanctionsService('/api/v1/sanctions/screen', 'POST', body, 15_000)
 }

--- a/openbank-admin-ui/src/app/api/security/route.ts
+++ b/openbank-admin-ui/src/app/api/security/route.ts
@@ -5,6 +5,7 @@
 import { NextResponse } from 'next/server'
 import { promises as fs } from 'fs'
 import path from 'path'
+import { auth } from '@/auth'
 import { resolveInClusterBaseUrl } from '@/lib/discovery'
 
 // ── Security posture: READ-ONLY consumer of CI-produced results ──────────────
@@ -30,7 +31,11 @@ import { resolveInClusterBaseUrl } from '@/lib/discovery'
 export const dynamic = 'force-dynamic'
 export const revalidate = 0
 
-type Unavailable = { available: false; reason: 'not_deployed' | 'unreachable' | 'error'; detail?: string }
+type Unavailable = {
+  available: false
+  reason: 'not_deployed' | 'unreachable' | 'error' | 'unauthorized'
+  detail?: string
+}
 
 // Resolve the security-scanner base URL:
 //   1. In-cluster: Kubernetes Service DNS via discovery (authoritative, same pattern
@@ -63,9 +68,18 @@ async function fromBundle(): Promise<NextResponse | null> {
 async function fromScanner(): Promise<NextResponse | null> {
   const base = await scannerBase()
   if (!base) return null
+  // security-scanner is OIDC-gated (quarkus.oidc + @RolesAllowed on its resources), so the
+  // read needs the operator's Keycloak bearer relayed server-side — exactly like the generic
+  // /api/svc proxy does. Without it the scanner answered 401 and this route surfaced
+  // "scanner HTTP 401" on a healthy, deployed service.
+  const accessToken = (await auth())?.user?.accessToken
+  if (!accessToken) {
+    const payload: Unavailable = { available: false, reason: 'unauthorized' }
+    return NextResponse.json(payload, { status: 200 })
+  }
   try {
     const res = await fetch(`${base}/api/v1/security/report`, {
-      headers: { Accept: 'application/json' },
+      headers: { Authorization: `Bearer ${accessToken}`, Accept: 'application/json' },
       cache: 'no-store',
       signal: AbortSignal.timeout(10_000),
     })
@@ -74,10 +88,16 @@ async function fromScanner(): Promise<NextResponse | null> {
       // is empty after pod restart; scheduler runs on 30-min cadence + 2-min initial
       // delay). Report as 'unreachable' so the page shows a neutral state rather
       // than the misleading "not deployed" message.
-      const reason: Unavailable['reason'] = res.status === 404 ? 'unreachable' : 'error'
+      // 401/403 = the relayed operator token was rejected (expired, or the role is missing).
+      // That is a session state, not a scanner fault, so say so rather than printing a status.
+      const reason: Unavailable['reason'] =
+        res.status === 404 ? 'unreachable'
+          : res.status === 401 || res.status === 403 ? 'unauthorized'
+            : 'error'
       const detail = res.status === 404
         ? 'No scan completed yet — first scan runs 2 minutes after startup, then every 30 minutes'
-        : `scanner HTTP ${res.status}`
+        : reason === 'unauthorized' ? undefined
+          : `scanner HTTP ${res.status}`
       const payload: Unavailable = { available: false, reason, detail }
       return NextResponse.json(payload, { status: 200 })
     }

--- a/openbank-admin-ui/src/app/security/page.tsx
+++ b/openbank-admin-ui/src/app/security/page.tsx
@@ -15,7 +15,7 @@ import { summarizeReachable, serviceVerdict } from '@/lib/security/summary'
 // maps straight onto <DataUnavailable kind=...>.
 type SecurityEnvelope =
   | { available: true; report: PlatformReport }
-  | { available: false; reason: 'not_deployed' | 'unreachable' | 'error'; detail?: string }
+  | { available: false; reason: 'not_deployed' | 'unreachable' | 'error' | 'unauthorized'; detail?: string }
 
 interface ScanResult {
   serviceName: string; serviceUrl: string

--- a/openbank-admin-ui/src/lib/sanctions/upstream.ts
+++ b/openbank-admin-ui/src/lib/sanctions/upstream.ts
@@ -1,0 +1,79 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright (c) OpenBank contributors. Licensed under the Apache License, Version 2.0.
+// See LICENSE in the repository root or https://www.apache.org/licenses/LICENSE-2.0 for details.
+
+// Server-side helper for the sanctions BFF (/api/sanctions/**, ADR-0056 / ADR-0080 P1).
+//
+// Why this file exists: the three sanctions routes each hand-rolled their own fetch and
+// every one of them omitted the Authorization header. sanctions-service is OIDC-gated
+// (@RolesAllowed on SanctionsResource), so every call answered 401, the page classified
+// that as `unauthorized` and told a signed-in operator their session had expired — while
+// the service was healthy and holding real OFAC/EU/UN list data. A signed-in operator saw
+// "Vypršela relace" on a working screen, and the list tab rendered "Invalid JSON" because
+// the 401 body is not the JSON the route expected.
+//
+// The bearer is the OPERATOR's Keycloak token relayed server-side (the same BFF token
+// relay the generic /api/svc proxy documents) — never a service-account secret, and never
+// anything the browser can see or set. Routing every sanctions call through one helper is
+// the point: a per-route fetch is a per-route opportunity to forget the header again.
+//
+// Error contract mirrors the generic /api/svc proxy so the client can keep using
+// classifyBffFailure(): 401 {error:"unauthorized"} without a session,
+// 502 {error:"upstream_unreachable"} when the pod doesn't answer. Upstream non-2xx bodies
+// are replaced by a generic {error:"upstream_error"} — details stay in the server log.
+
+import { NextResponse } from 'next/server'
+import { auth } from '@/auth'
+
+// Deployed, SANCTIONS_SERVICE_URL is the in-cluster ClusterIP DNS name. The fallback is the
+// docker-compose service name, which is what local dev resolves.
+const BASE = process.env.SANCTIONS_SERVICE_URL ?? 'http://openbank-sanctions-service:8123'
+
+/**
+ * Session-gate the call, then forward `method <BASE><path>` with the operator's bearer.
+ *
+ * `body` is sent as JSON when present. `timeoutMs` defaults to a read-shaped 10s; the
+ * screening and refresh calls do real work upstream and pass a longer budget.
+ */
+export async function forwardToSanctionsService(
+  path: string,
+  method: 'GET' | 'POST' = 'GET',
+  body?: unknown,
+  timeoutMs = 10_000,
+): Promise<NextResponse> {
+  const accessToken = (await auth())?.user?.accessToken
+  if (!accessToken) {
+    return NextResponse.json({ error: 'unauthorized' }, { status: 401 })
+  }
+
+  try {
+    const res = await fetch(`${BASE}${path}`, {
+      method,
+      headers: {
+        Authorization: `Bearer ${accessToken}`,
+        Accept: 'application/json',
+        ...(body === undefined ? {} : { 'Content-Type': 'application/json' }),
+      },
+      ...(body === undefined ? {} : { body: JSON.stringify(body) }),
+      cache: 'no-store',
+      signal: AbortSignal.timeout(timeoutMs),
+    })
+
+    if (!res.ok) {
+      // Generic to the client; the real body stays server-side (ADR-0080 P1).
+      const detail = await res.text().catch(() => '')
+      console.error(`sanctions BFF: upstream ${method} ${path} -> ${res.status} ${detail.slice(0, 500)}`)
+      return NextResponse.json({ error: 'upstream_error' }, { status: res.status })
+    }
+    return new NextResponse(await res.arrayBuffer(), {
+      status: res.status,
+      headers: {
+        'Content-Type': res.headers.get('Content-Type') ?? 'application/json',
+        'Cache-Control': 'no-store',
+      },
+    })
+  } catch (err) {
+    console.error(`sanctions BFF: upstream ${method} ${path} unreachable:`, err)
+    return NextResponse.json({ error: 'upstream_unreachable' }, { status: 502 })
+  }
+}

--- a/openbank-admin-ui/src/test/sanctions-routes.test.ts
+++ b/openbank-admin-ui/src/test/sanctions-routes.test.ts
@@ -2,24 +2,45 @@
 // Copyright (c) OpenBank contributors. Licensed under the Apache License, Version 2.0.
 // See LICENSE in the repository root or https://www.apache.org/licenses/LICENSE-2.0 for details.
 
-import { afterEach, describe, expect, it, vi } from 'vitest'
+// These routes must never invent data: whatever sanctions-service answers is what the
+// operator sees, and a backend failure stays a failure rather than degrading into a
+// synthetic "clear" result. That is what this file has always defended.
+//
+// They are now session-gated and relay the operator's bearer (see
+// sanctions-security-bff-auth.test.ts for why), so each case supplies a session. The
+// upstream *status* still passes through; the upstream error *body* is deliberately
+// replaced by a generic envelope (ADR-0080 P1 — upstream detail stays in the server log,
+// never in the browser), which is the same contract the closings BFF helper documents.
+
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+
+vi.mock('@/auth', () => ({ auth: vi.fn() }))
+
+import { auth } from '@/auth'
+
+const SESSION = { user: { accessToken: 'operator-token', roles: ['ROLE_OPERATOR'] } }
 
 describe('sanctions api routes', () => {
+  beforeEach(() => {
+    vi.resetModules()
+    vi.mocked(auth).mockResolvedValue(SESSION as never)
+  })
   afterEach(() => {
     vi.restoreAllMocks()
   })
 
-  it('checks route forwards backend errors instead of returning empty fallback', async () => {
+  it('checks route forwards the backend failure status instead of an empty fallback', async () => {
     vi.stubGlobal('fetch', vi.fn().mockResolvedValue(new Response(JSON.stringify({ error: 'backend down' }), {
       status: 503,
       headers: { 'Content-Type': 'application/json' },
     })))
 
     const { GET } = await import('../app/api/sanctions/checks/route')
-    const response = await GET(new Request('http://localhost/api/sanctions/checks') as any)
+    const response = await GET()
 
     expect(response.status).toBe(503)
-    await expect(response.json()).resolves.toEqual({ error: 'backend down' })
+    // Generic envelope, not the upstream text — and emphatically not an empty list.
+    await expect(response.json()).resolves.toEqual({ error: 'upstream_error' })
   })
 
   it('screen route returns backend payload and never local fallback mock', async () => {
@@ -34,7 +55,7 @@ describe('sanctions api routes', () => {
       method: 'POST',
       headers: { 'Content-Type': 'application/json' },
       body: JSON.stringify({ name: 'Alice Example', entityType: 'INDIVIDUAL', idempotencyKey: 'manual-1' }),
-    }) as any)
+    }) as never)
 
     expect(response.status).toBe(201)
     await expect(response.json()).resolves.toEqual(payload)

--- a/openbank-admin-ui/src/test/sanctions-security-bff-auth.test.ts
+++ b/openbank-admin-ui/src/test/sanctions-security-bff-auth.test.ts
@@ -1,0 +1,142 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright (c) OpenBank contributors. Licensed under the Apache License, Version 2.0.
+// See LICENSE in the repository root or https://www.apache.org/licenses/LICENSE-2.0 for details.
+
+// Regression tests: the sanctions and security BFF routes must relay the operator's bearer.
+//
+// Both surfaces shipped without an Authorization header against OIDC-gated backends, so a
+// signed-in operator got 401s from healthy services — rendered as "session expired" on the
+// sanctions screen, "Invalid JSON" on its list tab and "scanner HTTP 401" on the security
+// screen. Each assertion below fails against that code.
+
+import { NextRequest } from 'next/server'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+
+vi.mock('@/auth', () => ({ auth: vi.fn() }))
+// The security route resolves the scanner through k8s discovery; pin it so the test never
+// touches the API server.
+vi.mock('@/lib/discovery', () => ({ resolveInClusterBaseUrl: vi.fn().mockResolvedValue('http://scanner:8120') }))
+
+import { auth } from '@/auth'
+
+const SESSION = { user: { accessToken: 'operator-token', roles: ['ROLE_OPERATOR'] } }
+
+function lastFetchCall() {
+  const mock = vi.mocked(global.fetch)
+  return mock.mock.calls[mock.mock.calls.length - 1] as [string, RequestInit]
+}
+
+function jsonOk(body: unknown) {
+  return vi.fn().mockResolvedValue(
+    new Response(JSON.stringify(body), { status: 200, headers: { 'Content-Type': 'application/json' } }),
+  )
+}
+
+describe('sanctions BFF relays the operator bearer', () => {
+  beforeEach(() => {
+    vi.resetModules()
+    vi.mocked(auth).mockResolvedValue(SESSION as never)
+  })
+  afterEach(() => { vi.restoreAllMocks() })
+
+  it('GET /api/sanctions/lists sends Authorization and returns the upstream body', async () => {
+    const lists = [{ id: 'l1', listType: 'OFAC_SDN', enabled: true }]
+    vi.stubGlobal('fetch', jsonOk(lists))
+
+    const { GET } = await import('@/app/api/sanctions/lists/route')
+    const res = await GET()
+
+    expect(res.status).toBe(200)
+    await expect(res.json()).resolves.toEqual(lists)
+    const [url, init] = lastFetchCall()
+    expect(String(url)).toContain('/api/v1/sanctions/lists')
+    expect(new Headers(init.headers).get('Authorization')).toBe('Bearer operator-token')
+  })
+
+  it('GET /api/sanctions/checks sends Authorization', async () => {
+    vi.stubGlobal('fetch', jsonOk([]))
+
+    const { GET } = await import('@/app/api/sanctions/checks/route')
+    await GET()
+
+    const [url, init] = lastFetchCall()
+    expect(String(url)).toContain('/api/v1/sanctions')
+    expect(new Headers(init.headers).get('Authorization')).toBe('Bearer operator-token')
+  })
+
+  it('POST /api/sanctions/screen sends Authorization and forwards the body', async () => {
+    vi.stubGlobal('fetch', jsonOk({ status: 'CLEAR' }))
+
+    const { POST } = await import('@/app/api/sanctions/screen/route')
+    await POST(new NextRequest('http://localhost/api/sanctions/screen', {
+      method: 'POST',
+      body: JSON.stringify({ name: 'Jan Novak' }),
+      headers: { 'Content-Type': 'application/json' },
+    }))
+
+    const [url, init] = lastFetchCall()
+    expect(String(url)).toContain('/api/v1/sanctions/screen')
+    expect(new Headers(init.headers).get('Authorization')).toBe('Bearer operator-token')
+    expect(JSON.parse(String(init.body))).toEqual({ name: 'Jan Novak' })
+  })
+
+  it('refuses without a session instead of calling the backend anonymously', async () => {
+    vi.mocked(auth).mockResolvedValue(null as never)
+    const fetchMock = jsonOk([])
+    vi.stubGlobal('fetch', fetchMock)
+
+    const { GET } = await import('@/app/api/sanctions/lists/route')
+    const res = await GET()
+
+    expect(res.status).toBe(401)
+    await expect(res.json()).resolves.toEqual({ error: 'unauthorized' })
+    expect(fetchMock).not.toHaveBeenCalled()
+  })
+
+  it('does not leak an upstream error body to the browser', async () => {
+    vi.stubGlobal('fetch', vi.fn().mockResolvedValue(
+      new Response('database "openbank_sanctions" is on fire', { status: 500 }),
+    ))
+
+    const { GET } = await import('@/app/api/sanctions/lists/route')
+    const res = await GET()
+
+    expect(res.status).toBe(500)
+    await expect(res.json()).resolves.toEqual({ error: 'upstream_error' })
+  })
+})
+
+describe('security BFF relays the operator bearer', () => {
+  beforeEach(() => {
+    vi.resetModules()
+    vi.mocked(auth).mockResolvedValue(SESSION as never)
+    // Force the live-scanner path: with a bundled report present the route never calls out.
+    process.env.OPENBANK_SECURITY_REPORT = '/nonexistent/security-report.json'
+  })
+  afterEach(() => {
+    vi.restoreAllMocks()
+    delete process.env.OPENBANK_SECURITY_REPORT
+  })
+
+  it('GET /api/security sends Authorization to the scanner', async () => {
+    vi.stubGlobal('fetch', jsonOk({ services: [], averageScore: 91 }))
+
+    const { GET } = await import('@/app/api/security/route')
+    const res = await GET()
+
+    expect(res.status).toBe(200)
+    await expect(res.json()).resolves.toMatchObject({ available: true })
+    const [url, init] = lastFetchCall()
+    expect(String(url)).toContain('/api/v1/security/report')
+    expect(new Headers(init.headers).get('Authorization')).toBe('Bearer operator-token')
+  })
+
+  it('reports a rejected token as unauthorized, not as a raw scanner status', async () => {
+    vi.stubGlobal('fetch', vi.fn().mockResolvedValue(new Response('', { status: 401 })))
+
+    const { GET } = await import('@/app/api/security/route')
+    const body = await (await GET()).json()
+
+    expect(body).toEqual({ available: false, reason: 'unauthorized' })
+  })
+})


### PR DESCRIPTION
## What

The three `/api/sanctions/*` BFF routes and the live-scanner leg of `/api/security` called OIDC-gated backends **with no `Authorization` header**. They relay the operator's Keycloak bearer now, via one shared helper for sanctions.

## Why

Both backends are healthy and holding real data; the console said otherwise, in three different misleading ways:

| Screen | What the operator saw | What was true |
|---|---|---|
| Sanctions | "Session expired" | 401 from `sanctions-service`, because no bearer was sent |
| Sanctions - list tab | "Invalid JSON" | the 401 body is not the JSON the route parsed |
| Security | "scanner HTTP 401" | 401 from `security-scanner-service`, same cause |

Measured from the `admin-ui` pod against the deployed services:

```
anonymous  -> sanctions-service /api/v1/sanctions/lists        401
anonymous  -> security-scanner-service /api/v1/security/report 401
+ bearer   -> sanctions-service /api/v1/sanctions/lists        200, real OFAC/EU/UN rows
```

## How

- New `src/lib/sanctions/upstream.ts`, mirroring the closings BFF helper: `auth()` server-side, operator bearer upstream, 401 before touching a backend when there is no session. All three sanctions routes go through it — a per-route `fetch` is a per-route opportunity to forget the header again, which is how all three came to be wrong.
- `/api/security` attaches the bearer on the scanner leg and maps a scanner 401/403 to `reason: 'unauthorized'` instead of printing `scanner HTTP 401`.
- Upstream error bodies no longer reach the browser (generic `upstream_error` envelope, detail logged server-side — ADR-0080 P1).

## Verification

- New `src/test/sanctions-security-bff-auth.test.ts` was **falsified against the pre-fix routes**: all 7 cases fail there, including one that reproduces the exact `{error:"Invalid JSON"}` the list tab rendered. All 7 pass after.
- `sanctions-routes.test.ts` keeps its original intent (no synthetic fallback data, upstream status forwarded) with the session supplied.
- `npm run type-check`, `npx eslint`, `npm test` — **1006 passed / 70 files**. (The suite needs `--maxWorkers=2` on this laptop; at full parallelism several heavy render suites time out. They pass in isolation and are untouched by this change.)

## Not in scope

Three sibling defects found in the same walk, each getting its own PR: `security-scanner` never runs Flyway (its schema is empty, so `/report` 500s even authenticated), `agent-service`'s `/mcp` is unregistered, and `fraud-service`'s ONNX initializer 500s the whole resource.

## Linked issues

N/A — defect found by walking the deployed console; no issue filed.
