### PR TITLE
fix(libs): outbox timestamps default to now, not 1970 — and make the conformance suite able to see it

### DIFF
--- a/openbank-libs-domain/src/main/kotlin/com/openbank/libs/persistence/outbox/OutboxPorts.kt
+++ b/openbank-libs-domain/src/main/kotlin/com/openbank/libs/persistence/outbox/OutboxPorts.kt
@@ -46,14 +46,25 @@ interface OutboxRepository {
      */
     suspend fun countProcessable(): Long = listProcessable(Int.MAX_VALUE).size.toLong()
 
-    suspend fun markSent(eventId: UUID, sentAt: Instant = Instant.EPOCH)
+    /**
+     * `Instant.now()` and NOT `Instant.EPOCH` — the shared [OutboxDispatch] calls this with no
+     * timestamp, so the default is what every dispatched row in the fleet actually got. Repository
+     * implementations assign it to BOTH `sent_at` and `updated_at`, so an epoch default stamped
+     * both 1970 (#3272, same family as the `createdAt` default).
+     */
+    suspend fun markSent(eventId: UUID, sentAt: Instant = Instant.now())
 
     /**
      * Record a failed publish: increment the attempt counter, store the (truncated) error,
      * and apply [OutboxFailurePolicy] so an exhausted row transitions to terminal
      * [OutboxStatus.DEAD] instead of being retried forever (ADR-0050 N5).
+     *
+     * `failedAt` defaults to `Instant.now()` for the same reason as [markSent]: [OutboxDispatch]
+     * passes none, and it lands in `updated_at` — which the dead-letter janitor prunes on
+     * (`status = DEAD and updatedAt < threshold`). At 1970 every DEAD row is instantly older than
+     * any retention window (#3272).
      */
-    suspend fun markFailed(eventId: UUID, error: String, failedAt: Instant = Instant.EPOCH)
+    suspend fun markFailed(eventId: UUID, error: String, failedAt: Instant = Instant.now())
 }
 
 interface OutboxEventPublisher {

--- a/openbank-libs-domain/src/main/kotlin/com/openbank/libs/persistence/outbox/OutboxStatus.kt
+++ b/openbank-libs-domain/src/main/kotlin/com/openbank/libs/persistence/outbox/OutboxStatus.kt
@@ -30,7 +30,19 @@ data class OutboxMessage(
     val aggregateId: UUID,
     val eventType: String,
     val payload: String,
-    val createdAt: Instant = Instant.EPOCH,
+    /**
+     * When the row was created. `Instant.now()` and NOT `Instant.EPOCH`: every service's
+     * `toEntity()` assigns this over the column's `DEFAULT now()`, so an omitted value used to
+     * stamp the row 1970 with nothing raising an error — 388 of ledger's 553 outbox rows (#3272).
+     *
+     * That is not cosmetic. The dispatcher claims work with
+     * `ORDER BY created_at ASC ... FOR UPDATE SKIP LOCKED`, so an epoch row sorts ahead of every
+     * correctly-stamped one permanently and starves real traffic behind a 1970 backlog, while the
+     * `openbank.outbox.backlog` age signal reads a fresh row as 56 years old.
+     *
+     * A caller that needs a fixed clock (tests, replay) still passes it explicitly.
+     */
+    val createdAt: Instant = Instant.now(),
 )
 
 data class OutboxEntry(

--- a/openbank-libs-testing/src/main/kotlin/com/openbank/libs/testing/outbox/OutboxDispatchConformanceIT.kt
+++ b/openbank-libs-testing/src/main/kotlin/com/openbank/libs/testing/outbox/OutboxDispatchConformanceIT.kt
@@ -104,7 +104,8 @@ abstract class OutboxDispatchConformanceIT {
             aggregateId = aggregateId,
             eventType = "test.event.posted",
             payload = """{"seq":1}""",
-            createdAt = Instant.now(),
+            // createdAt DELIBERATELY omitted: the default is what ~48 fleet call sites use, and
+            // passing it here is what made this suite blind to the epoch default (#3272).
         )
         val second = first.copy(eventId = Ids.newId(), payload = """{"seq":2}""")
         onEventLoop { seed(first) }
@@ -136,9 +137,18 @@ abstract class OutboxDispatchConformanceIT {
             val row = onEventLoop { findEntry(msg.eventId) }
             assertThat(row).describedAs("row for event ${msg.eventId}").isNotNull
             assertThat(row!!.status).isEqualTo(OutboxStatus.SENT)
-            assertThat(row.sentAt).isNotNull
             assertThat(row.attemptCount).isGreaterThanOrEqualTo(1)
             assertThat(row.lastError).isNull()
+            // `isNotNull` is what this used to assert, and Instant.EPOCH satisfies it. The claim
+            // query orders on created_at and the janitor prunes on updated_at, so a 1970 stamp is
+            // a live defect, not a cosmetic one (#3272).
+            assertThat(row.sentAt)
+                .describedAs("sentAt must be a real time — markSent's default reaches every row in the fleet")
+                .isNotNull
+                .isAfter(EPOCH_SANITY_FLOOR)
+            assertThat(row.createdAt)
+                .describedAs("createdAt must be a real time when the caller omits it")
+                .isAfter(EPOCH_SANITY_FLOOR)
         }
     }
 
@@ -165,5 +175,13 @@ abstract class OutboxDispatchConformanceIT {
             headerValue(it, OutboxKafkaHeaders.HEADER_EVENT_ID) == message.eventId.toString()
         }
         assertThat(secondPassCount).describedAs("SENT row must not be re-published on replay").isEqualTo(1)
+    }
+    private companion object {
+        /**
+         * Any real stamp is after this; `Instant.EPOCH` is not. Deliberately a floor rather than
+         * "within N seconds of now" — the point is to catch a 1970 default, not to police clock
+         * skew on a slow runner (#3272).
+         */
+        val EPOCH_SANITY_FLOOR: Instant = Instant.parse("2020-01-01T00:00:00Z")
     }
 }


### PR DESCRIPTION
Closes #3272

## Three EPOCH defaults, not one

The issue names `OutboxMessage.createdAt`. Verifying it turned up two more in the same file pair, and they are **worse**, because no call site avoids them:

| default | who hits it | consequence |
|---|---|---|
| `OutboxMessage.createdAt` | ~48 call sites that omit it | 1970 rows sort ahead of every real one in `ORDER BY created_at ASC ... FOR UPDATE SKIP LOCKED`, permanently. 388/553 ledger rows. |
| `markSent(sentAt)` | **the shared `OutboxDispatch`**, which passes none | repository impls assign it to `sent_at` **and** `updated_at` → every dispatched row in the fleet carries 1970 in both |
| `markFailed(failedAt)` | same dispatcher, same omission | lands in `updated_at`, which the dead-letter janitor prunes on (`status = DEAD and updatedAt < threshold`) — at 1970 every DEAD row is older than any retention window |

Measured: **0** call sites pass a timestamp to either mark method.

All three now default to `Instant.now()`. A caller that needs a fixed clock — tests, replay — still passes one explicitly.

## The conformance suite is why this ran fleet-wide

The issue calls this out and it is the more important half. `OutboxDispatchConformanceIT` passed `createdAt = Instant.now()` explicitly, so the shared suite exercised the *correct* path and could never see the default. And its persistence assertion was:

```kotlin
assertThat(row.sentAt).isNotNull      // Instant.EPOCH satisfies this
```

Now it omits `createdAt` — the shape the ~48 fleet call sites actually use — and asserts both stamps are after a sanity floor:

```kotlin
assertThat(row.sentAt).isNotNull.isAfter(EPOCH_SANITY_FLOOR)
assertThat(row.createdAt).isAfter(EPOCH_SANITY_FLOOR)
```

A **floor** (2020-01-01) rather than "within N seconds of now" on purpose: the thing being caught is a 1970 default, not clock skew on a slow CI runner. A tight window would turn a real guard into a flake.

## Verified fail-first

| build | `LedgerOutboxDispatchIT` |
|---|---|
| `createdAt` default restored to `Instant.EPOCH` | **FAILED** |
| with the fix | passes |

`ktlintCheck` and `detekt` green for `openbank-libs-domain` and `openbank-libs-testing`.

## Two things this PR does NOT do

- **No backfill of the existing 1970 rows.** They stay ahead in the claim order until dispatched or pruned. A per-service Flyway migration could correct them, but that is ~20 migrations against live money-path tables and deserves its own change and its own review.
- **No `Clock` injection.** `Instant.now()` matches what the surrounding repository code already does (`applyFailure(..., at: Instant = Instant.now(clock))` is the only clock-aware path, and it keeps its clock). Threading a `Clock` into a domain data class is a larger design change than this defect warrants.

## Note on blast radius

This is `openbank-libs-domain`, so it fans out to 41 services — which, as of #3256, auto-deploy now actually rebuilds rather than silently skipping.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
