### PR TITLE
feat(control-liveness-sentinel): run the daily check on a schedule, not only when asked

### DIFF
--- a/openbank-control-liveness-sentinel/src/main/kotlin/com/openbank/liveness/application/port/incoming/LivenessUseCases.kt
+++ b/openbank-control-liveness-sentinel/src/main/kotlin/com/openbank/liveness/application/port/incoming/LivenessUseCases.kt
@@ -10,7 +10,26 @@ import com.openbank.liveness.domain.model.LivenessRunReport
 import com.openbank.liveness.domain.model.RunTrigger
 
 interface RunLivenessCheckUseCase {
+    /**
+     * Runs a check and WAITS for the report. Used by the operator trigger, where the caller is a
+     * human holding an HTTP connection open and wants the outcome.
+     */
     suspend fun run(trigger: RunTrigger): LivenessRunReport
+
+    /**
+     * Starts a check and returns its workflow id WITHOUT waiting for the report.
+     *
+     * This is what the schedule uses. A full run can legitimately take tens of minutes -- the
+     * detect activities allow 5 minutes each and the diagnose/propose activity 10, per finding --
+     * so waiting inline would hold a scheduler thread for the whole run and make a slow check
+     * indistinguishable from a hung one. Temporal already owns the execution and its history is
+     * the durable record; the report is persisted by the workflow itself.
+     *
+     * Idempotent by construction: the workflow id is derived from the trigger and the day, so a
+     * pod restart, a second replica, or a manual re-fire on the same day is REJECTED by Temporal
+     * rather than starting a duplicate run that would burn the agent's LLM budget twice.
+     */
+    suspend fun startDetached(trigger: RunTrigger): String
 }
 
 interface GetFindingsUseCase {

--- a/openbank-control-liveness-sentinel/src/main/kotlin/com/openbank/liveness/application/usecase/LivenessSentinelService.kt
+++ b/openbank-control-liveness-sentinel/src/main/kotlin/com/openbank/liveness/application/usecase/LivenessSentinelService.kt
@@ -14,15 +14,21 @@ import com.openbank.liveness.domain.model.LivenessFinding
 import com.openbank.liveness.domain.model.LivenessRunReport
 import com.openbank.liveness.domain.model.RunTrigger
 import io.temporal.client.WorkflowClient
+import io.temporal.client.WorkflowExecutionAlreadyStarted
 import io.temporal.client.WorkflowOptions
 import jakarta.enterprise.context.ApplicationScoped
 import org.jboss.logging.Logger
+import java.time.Clock
+import java.time.Instant
+import java.time.ZoneOffset
+import java.time.format.DateTimeFormatter
 
 @ApplicationScoped
 class LivenessSentinelService(
     private val workflowClient: WorkflowClient,
     private val temporalConfig: TemporalConfig,
     private val findingRepository: FindingRepository,
+    private val clock: Clock,
 ) : RunLivenessCheckUseCase,
     GetFindingsUseCase {
 
@@ -38,7 +44,40 @@ class LivenessSentinelService(
         return workflow.runCheck(trigger)
     }
 
+    override suspend fun startDetached(trigger: RunTrigger): String {
+        val workflowId = scheduledWorkflowId(trigger, Instant.now(clock))
+        val options = WorkflowOptions.newBuilder()
+            .setTaskQueue(temporalConfig.taskQueue())
+            .setWorkflowId(workflowId)
+            .build()
+        val stub = workflowClient.newWorkflowStub(LivenessCheckWorkflow::class.java, options)
+        try {
+            WorkflowClient.start({ stub.runCheck(trigger) })
+            log.infof("Started control-liveness-sentinel check workflow %s (trigger=%s)", workflowId, trigger)
+        } catch (duplicate: WorkflowExecutionAlreadyStarted) {
+            // Not an error: this is the dedupe working. Two pods, or one pod restarted after the
+            // cron fired, both compute the same id and Temporal admits only the first.
+            log.infof("Check workflow %s already running, not starting a second: %s", workflowId, duplicate.message)
+        }
+        return workflowId
+    }
+
     override suspend fun getActive(): List<LivenessFinding> = findingRepository.findActive()
 
     override suspend fun getById(id: String): LivenessFinding? = findingRepository.findById(id)
+
+    companion object {
+        private val DAY: DateTimeFormatter = DateTimeFormatter.ofPattern("yyyy-MM-dd").withZone(ZoneOffset.UTC)
+
+        /**
+         * The id that makes a detached start idempotent for the day.
+         *
+         * Deliberately NOT `System.currentTimeMillis()`, which the operator-triggered path uses:
+         * a millisecond-unique id can never collide, so it can never dedupe either. The trigger is
+         * part of the id so an operator can still force a run on a day the schedule has already
+         * used -- the schedule must not be able to block a human.
+         */
+        fun scheduledWorkflowId(trigger: RunTrigger, at: Instant): String =
+            "liveness-check-${trigger.name.lowercase()}-${DAY.format(at)}"
+    }
 }

--- a/openbank-control-liveness-sentinel/src/main/kotlin/com/openbank/liveness/infrastructure/ClockProducer.kt
+++ b/openbank-control-liveness-sentinel/src/main/kotlin/com/openbank/liveness/infrastructure/ClockProducer.kt
@@ -1,0 +1,18 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+// Copyright (c) OpenBank contributors. Licensed under the GNU Affero General Public License v3.0 only.
+// A commercial licence is available from the maintainers as an alternative to the AGPL-3.0.
+// See LICENSES/AGPL-3.0-only.txt or https://www.gnu.org/licenses/agpl-3.0.html for details.
+
+package com.openbank.liveness.infrastructure
+
+import jakarta.enterprise.context.ApplicationScoped
+import jakarta.enterprise.context.Dependent
+import jakarta.enterprise.inject.Produces
+import java.time.Clock
+
+@ApplicationScoped
+class ClockProducer {
+    @Produces
+    @Dependent
+    fun clock(): Clock = Clock.systemUTC()
+}

--- a/openbank-control-liveness-sentinel/src/main/kotlin/com/openbank/liveness/infrastructure/config/LivenessSentinelConfig.kt
+++ b/openbank-control-liveness-sentinel/src/main/kotlin/com/openbank/liveness/infrastructure/config/LivenessSentinelConfig.kt
@@ -13,6 +13,17 @@ import jakarta.enterprise.context.ApplicationScoped
 @ApplicationScoped
 @Suppress("TooManyFunctions") // flat config mapping: one accessor per tunable (model, GitHub, thresholds)
 interface LivenessSentinelConfig {
+    /**
+     * Cron for the daily fleet-wide check (ADR-0163: "runs daily ... plus reactively").
+     *
+     * Declared here because it lives under this mapping's prefix: SmallRye validates a
+     * `@ConfigMapping` prefix as a CLOSED set, so a key added to `application.yaml` without a
+     * matching accessor fails the whole application with `ConfigValidationException` at boot --
+     * not a warning about one property, a dead service.
+     */
+    @WithDefault("0 15 3 * * ?")
+    fun checkCron(): String
+
     @WithDefault("http://prometheus-operated.observability:9090")
     fun prometheusUrl(): String
 

--- a/openbank-control-liveness-sentinel/src/main/kotlin/com/openbank/liveness/infrastructure/schedule/LivenessCheckScheduler.kt
+++ b/openbank-control-liveness-sentinel/src/main/kotlin/com/openbank/liveness/infrastructure/schedule/LivenessCheckScheduler.kt
@@ -1,0 +1,72 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+// Copyright (c) OpenBank contributors. Licensed under the GNU Affero General Public License v3.0 only.
+// A commercial licence is available from the maintainers as an alternative to the AGPL-3.0.
+// See LICENSES/AGPL-3.0-only.txt or https://www.gnu.org/licenses/agpl-3.0.html for details.
+
+package com.openbank.liveness.infrastructure.schedule
+
+import com.openbank.libs.temporal.TemporalConfig
+import com.openbank.liveness.application.port.incoming.RunLivenessCheckUseCase
+import com.openbank.liveness.domain.model.RunTrigger
+import io.quarkus.scheduler.Scheduled
+import jakarta.enterprise.context.ApplicationScoped
+import jakarta.inject.Inject
+import org.jboss.logging.Logger
+import java.util.concurrent.atomic.AtomicLong
+
+/**
+ * The daily schedule ADR-0163 decided and nothing ever built.
+ *
+ * ADR-0163 says the sentinel "runs daily (03:00 UTC, offset from finops-agent/devops-agent) plus
+ * reactively", and `RunTrigger.SCHEDULED` has existed in the domain model since the service was
+ * written -- but nothing ever emitted it. The service was trigger-only
+ * (`POST /api/v1/liveness-sentinel/check/trigger`), so ADR-0160 mechanism 3 had evaluated
+ * **nothing**: measured 2026-08-02, the `openbank-liveness` Temporal namespace held 0 schedules and
+ * 0 workflow executions, and the `findings` table was empty.
+ *
+ * An empty findings table is the problem. It renders in the admin UI and reads as "no stale
+ * controls" -- the healthiest possible answer -- when it actually means "nothing has ever looked".
+ * A control that has never run and a control that runs and finds nothing are indistinguishable
+ * from the outside, which is precisely the failure class this agent exists to detect in OTHER
+ * services.
+ *
+ * Written as a `suspend fun` on purpose. A plain `@Scheduled` method carries no Vert.x context, so
+ * a body of `runBlocking { ... }` around a reactive call throws `HR000068` and the job aborts
+ * having done nothing, silently -- five schedulers in this fleet had never run for exactly that
+ * reason (#2148, #2187), and it is now a hard rule (`rules.yaml: scheduled_methods`).
+ */
+@ApplicationScoped
+class LivenessCheckScheduler {
+
+    @Inject
+    lateinit var runCheck: RunLivenessCheckUseCase
+
+    @Inject
+    lateinit var temporalConfig: TemporalConfig
+
+    private val log = Logger.getLogger(LivenessCheckScheduler::class.java)
+    private val fires = AtomicLong(0)
+
+    /**
+     * How many times the cron has actually fired in this pod.
+     *
+     * Exists so a test can assert the SCHEDULE, not the work: a test that calls the method
+     * directly cannot see whether the cron was ever wired, and would pass against a service with
+     * no schedule at all -- which is the exact bug being fixed here.
+     */
+    val fireCount: Long get() = fires.get()
+
+    @Scheduled(
+        cron = "{openbank.liveness-sentinel.check-cron}",
+        concurrentExecution = Scheduled.ConcurrentExecution.SKIP,
+    )
+    suspend fun runScheduledCheck() {
+        fires.incrementAndGet()
+        if (!temporalConfig.enabled()) {
+            log.info("Temporal disabled; skipping the scheduled control-liveness check")
+            return
+        }
+        val workflowId = runCheck.startDetached(RunTrigger.SCHEDULED)
+        log.infof("Scheduled control-liveness check dispatched as workflow %s", workflowId)
+    }
+}

--- a/openbank-control-liveness-sentinel/src/main/resources/application.yaml
+++ b/openbank-control-liveness-sentinel/src/main/resources/application.yaml
@@ -77,6 +77,23 @@ quarkus:
       enabled: false
     management:
       enabled: false
+    http:
+      # An ephemeral port, because this module now has TWO @QuarkusTest classes with different
+      # profiles and therefore two application boots per run. On the fixed default test port the
+      # second boot dies with `QuarkusBindException` whenever anything else on the machine holds
+      # it — observed here on a workstation that also hosts self-hosted CI runners. RestAssured
+      # reads the actual port from the test context, so nothing needs to know the number.
+      test-port: 0
+
+  openbank:
+    liveness-sentinel:
+      # A cron that never fires (the 31st of February), NOT `quarkus.scheduler.enabled: false`.
+      # Disabling the scheduler makes the class structurally invisible to every test -- which is
+      # how five schedulers in this fleet reached production having never run (#2148, #2187). With
+      # a real-but-unreachable expression the wiring is still constructed and validated at boot,
+      # and a test profile can override this key with a fast cron to drive the REAL schedule
+      # (LivenessSchedulerCronIT does exactly that).
+      check-cron: "0 0 5 31 2 ?"
 
 openbank:
   temporal:
@@ -85,6 +102,15 @@ openbank:
     namespace: ${TEMPORAL_NAMESPACE:openbank}
     task-queue: control-liveness-sentinel
   liveness-sentinel:
+    # ADR-0163: "runs daily (03:00 UTC, offset from finops-agent/devops-agent) plus reactively".
+    # 03:15 implements that offset: finops-agent runs 03:00 (ADR-0112) and devops-agent 03:30.
+    # The offset is between the three AI AGENTS specifically, because they share one LiteLLM
+    # gateway and one Prometheus, and each now carries its own daily token budget — firing them
+    # together contends on all three. Collisions with unrelated per-service batch jobs are NOT a
+    # consideration and are not avoided here: sdd-service's expiry sweep also runs at 03:15, on a
+    # different pod against a different database, and that costs nothing.
+    # Quarkus cron is SIX fields (second minute hour day month weekday).
+    check-cron: ${LIVENESS_CHECK_CRON:0 15 3 * * ?}
     prometheus-url: ${PROMETHEUS_URL:http://prometheus-operated.observability:9090}
     alertmanager-url: ${ALERTMANAGER_URL:http://alertmanager-operated.observability:9093}
     # OpenAI-compatible model backend — DeepInfra, the same provider devops-agent (ADR-0119) and

--- a/openbank-control-liveness-sentinel/src/test/kotlin/com/openbank/liveness/application/usecase/ScheduledWorkflowIdTest.kt
+++ b/openbank-control-liveness-sentinel/src/test/kotlin/com/openbank/liveness/application/usecase/ScheduledWorkflowIdTest.kt
@@ -1,0 +1,62 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+// Copyright (c) OpenBank contributors. Licensed under the GNU Affero General Public License v3.0 only.
+// A commercial licence is available from the maintainers as an alternative to the AGPL-3.0.
+// See LICENSES/AGPL-3.0-only.txt or https://www.gnu.org/licenses/agpl-3.0.html for details.
+
+package com.openbank.liveness.application.usecase
+
+import com.openbank.liveness.domain.model.RunTrigger
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Assertions.assertNotEquals
+import org.junit.jupiter.api.Test
+import java.time.Instant
+
+/**
+ * The workflow id IS the deduplication. Temporal rejects a second start under an id already
+ * running, so these equalities are what stop a pod restart or a second replica from launching a
+ * duplicate fleet-wide sweep -- which would burn the sentinel's daily LLM budget twice and write
+ * the same findings again.
+ */
+class ScheduledWorkflowIdTest {
+
+    private fun id(trigger: RunTrigger, iso: String) =
+        LivenessSentinelService.scheduledWorkflowId(trigger, Instant.parse(iso))
+
+    @Test
+    fun `two fires on the same UTC day produce the same id`() {
+        assertEquals(
+            id(RunTrigger.SCHEDULED, "2026-08-02T03:15:00Z"),
+            id(RunTrigger.SCHEDULED, "2026-08-02T21:40:11Z"),
+        )
+    }
+
+    @Test
+    fun `consecutive days produce different ids`() {
+        assertNotEquals(
+            id(RunTrigger.SCHEDULED, "2026-08-02T03:15:00Z"),
+            id(RunTrigger.SCHEDULED, "2026-08-03T03:15:00Z"),
+        )
+    }
+
+    @Test
+    fun `the day boundary is UTC, not the JVM default zone`() {
+        // 23:30 in Prague on 2026-08-02 is 21:30 UTC the same day; 00:30 Prague on the 3rd is
+        // 22:30 UTC on the 2nd. A local-zone truncation would split the first pair and merge the
+        // second, so the schedule would double-run on some days and skip others depending on
+        // where the pod happens to run.
+        assertEquals(
+            id(RunTrigger.SCHEDULED, "2026-08-02T21:30:00Z"),
+            id(RunTrigger.SCHEDULED, "2026-08-02T22:30:00Z"),
+        )
+        assertEquals("liveness-check-scheduled-2026-08-02", id(RunTrigger.SCHEDULED, "2026-08-02T23:59:59Z"))
+        assertEquals("liveness-check-scheduled-2026-08-03", id(RunTrigger.SCHEDULED, "2026-08-03T00:00:00Z"))
+    }
+
+    @Test
+    fun `an operator run is never blocked by the day's scheduled run`() {
+        assertNotEquals(
+            id(RunTrigger.SCHEDULED, "2026-08-02T03:15:00Z"),
+            id(RunTrigger.OPERATOR_MANUAL, "2026-08-02T03:15:00Z"),
+        )
+    }
+}

--- a/openbank-control-liveness-sentinel/src/test/kotlin/com/openbank/liveness/infrastructure/schedule/LivenessSchedulerCronIT.kt
+++ b/openbank-control-liveness-sentinel/src/test/kotlin/com/openbank/liveness/infrastructure/schedule/LivenessSchedulerCronIT.kt
@@ -1,0 +1,75 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+// Copyright (c) OpenBank contributors. Licensed under the GNU Affero General Public License v3.0 only.
+// A commercial licence is available from the maintainers as an alternative to the AGPL-3.0.
+// See LICENSES/AGPL-3.0-only.txt or https://www.gnu.org/licenses/agpl-3.0.html for details.
+
+package com.openbank.liveness.infrastructure.schedule
+
+import com.openbank.liveness.PostgresTestResource
+import io.quarkus.test.common.QuarkusTestResource
+import io.quarkus.test.junit.QuarkusTest
+import io.quarkus.test.junit.QuarkusTestProfile
+import io.quarkus.test.junit.TestProfile
+import jakarta.inject.Inject
+import org.junit.jupiter.api.Assertions.assertTrue
+import org.junit.jupiter.api.Test
+import java.time.Duration
+import java.time.Instant
+
+/**
+ * Proves the sentinel has a WORKING SCHEDULE, by letting the real cron fire.
+ *
+ * This is deliberately not a test that calls [LivenessCheckScheduler.runScheduledCheck] directly.
+ * A direct call proves the method body works and says nothing about whether anything ever invokes
+ * it -- it passes identically against the service as it shipped, which had no schedule at all and
+ * had therefore evaluated nothing since it was deployed. The bug being fixed lives entirely in the
+ * wiring, so the wiring is what has to be exercised.
+ *
+ * The profile shrinks the cron to every second and leaves Temporal disabled: the assertion is that
+ * the SCHEDULER fires, not that a workflow starts. Driving a real workflow would need a Temporal
+ * server and would test the workflow, which [DetectFindingsActivityImplTest] already covers.
+ *
+ * Note the literal cron string below. A `QuarkusTestProfile` is loaded in a DIFFERENT classloader
+ * from the test class, so anything computed in `getConfigOverrides()` -- a randomised value, a
+ * shared constant read from a companion object -- is initialised twice and the scheduler and the
+ * assertion can end up holding different values.
+ */
+@QuarkusTest
+@QuarkusTestResource(PostgresTestResource::class)
+@TestProfile(LivenessSchedulerCronIT.EverySecondProfile::class)
+class LivenessSchedulerCronIT {
+
+    class EverySecondProfile : QuarkusTestProfile {
+        override fun getConfigOverrides(): Map<String, String> = mapOf(
+            // Literals only — see the class KDoc.
+            "openbank.liveness-sentinel.check-cron" to "*/1 * * * * ?",
+            "openbank.temporal.enabled" to "false",
+        )
+    }
+
+    @Inject
+    lateinit var scheduler: LivenessCheckScheduler
+
+    @Test
+    fun `the real cron fires the scheduled check`() {
+        val before = scheduler.fireCount
+        val deadline = Instant.now().plus(Duration.ofSeconds(TIMEOUT_SECONDS))
+
+        while (Instant.now().isBefore(deadline) && scheduler.fireCount == before) {
+            Thread.sleep(POLL_MILLIS)
+        }
+
+        assertTrue(
+            scheduler.fireCount > before,
+            "The scheduled liveness check never fired within $TIMEOUT_SECONDS s. The cron " +
+                "expression is not wired to the scheduler, which is the defect this test exists " +
+                "for: the sentinel then evaluates nothing while its empty findings table reads " +
+                "as 'no stale controls'.",
+        )
+    }
+
+    private companion object {
+        const val TIMEOUT_SECONDS = 30L
+        const val POLL_MILLIS = 200L
+    }
+}

--- a/openbank-infra/gitops/components/control-liveness-sentinel/control-liveness-sentinel.yaml
+++ b/openbank-infra/gitops/components/control-liveness-sentinel/control-liveness-sentinel.yaml
@@ -56,6 +56,18 @@ spec:
               value: http://alertmanager-operated.observability.svc:9093
             - name: TEMPORAL_NAMESPACE
               value: openbank-liveness
+            # The daily fleet-wide check (ADR-0163). Set EXPLICITLY here rather than left to the
+            # application.yaml default, because this is the only place an operator looks to answer
+            # "when does the sentinel run" — and until #3305 the answer was "it doesn't". The
+            # service was trigger-only: measured 2026-08-02, the openbank-liveness Temporal
+            # namespace held 0 schedules and 0 workflow executions, and `findings` was empty. An
+            # empty findings table renders as "no stale controls", which is the healthiest-looking
+            # possible answer to a question nothing had ever asked.
+            # 03:15 is the ADR-0163 offset from finops-agent (03:00) and devops-agent (03:30):
+            # the three agents share one LiteLLM gateway and one Prometheus.
+            # Six fields (second minute hour day month weekday) — Quarkus cron, not crontab.
+            - name: LIVENESS_CHECK_CRON
+              value: "0 15 3 * * ?"
             # LLM backend — routed through the in-cluster LiteLLM gateway (ADR-0174/0175), which now
             # IS deployed (openbank-infra/gitops/components/ai-platform). The gateway holds the
             # provider key and is the only pod allowed to egress to the US provider; this agent


### PR DESCRIPTION
## What

Gives the control-liveness sentinel the daily schedule ADR-0163 decided and nothing ever built.

## The state this fixes

ADR-0163 says the sentinel *"runs daily (03:00 UTC, offset from finops-agent/devops-agent) plus reactively"*, and `RunTrigger.SCHEDULED` has been in the domain model since the service was written. Nothing ever emitted it. The service was trigger-only (`POST /api/v1/liveness-sentinel/check/trigger`), so ADR-0160 mechanism 3 had evaluated **nothing**.

Measured against the live sandbox on 2026-08-02:

| | |
|---|---|
| Temporal schedules in `openbank-liveness` | **0** |
| workflow executions in that namespace | **0** |
| rows in `findings` | **0** |
| CronJob or any other external trigger | none |

The probe was validated against a known-positive first — `openbank-payments` and `openbank-campaign` return 3 workflows each, so it can find executions where they exist; and the `findings` count came back as a real `0` from a real table, not an error.

## Why nobody noticed

An empty `findings` table renders as **"no stale controls"** — the healthiest-looking possible answer to a question nothing had ever asked. A control that has never run is indistinguishable from a control that runs and finds nothing, which is exactly the failure class this agent exists to detect *in other services*.

## Design

**`suspend fun`, not a plain method.** A plain `@Scheduled` method carries no Vert.x context, so a body of `runBlocking { … }` throws `HR000068` and the job aborts silently — five schedulers in this fleet had never run for that reason (#2148, #2187), and it is now a hard rule (`rules.yaml: scheduled_methods`).

**Starts the workflow, does not wait for it.** The detect activities allow 5 minutes each and diagnose/propose 10, *per finding*, so a full run can legitimately take tens of minutes. Waiting inline would pin a scheduler thread for the whole run and make a slow check indistinguishable from a hung one. Temporal already owns the execution and its history is the durable record.

**The workflow id is the deduplication.** `liveness-check-<trigger>-<yyyy-MM-dd>` (UTC), so a pod restart or a second replica gets `WorkflowExecutionAlreadyStarted` from Temporal instead of launching a duplicate fleet-wide sweep that would burn the agent's daily LLM budget twice. The existing operator path uses `System.currentTimeMillis()`, which cannot collide and therefore cannot dedupe either. The trigger is part of the id on purpose: the schedule must never be able to block a human from forcing a run the same day.

**03:15 is the ADR-0163 offset.** finops-agent runs 03:00 (ADR-0112), devops-agent 03:30. The offset is between the three AI **agents** specifically: they share one LiteLLM gateway and one Prometheus, and each now carries its own daily token budget, so firing them together contends on all three. Collisions with unrelated per-service batch jobs are explicitly *not* avoided — sdd-service's expiry sweep also runs 03:15, on a different pod against a different database, and that costs nothing. Quarkus cron is six fields.

## Tests

`LivenessSchedulerCronIT` drives the **real cron** from a `@TestProfile` that shrinks it to every second. Deliberately not a direct call to `runScheduledCheck()`: a direct call proves the method body works and says nothing about whether anything invokes it — it would pass identically against the service as it shipped, which is the entire bug. Falsified by removing `@Scheduled` and re-running: the test goes red, and green again when restored.

The profile uses **literal** strings, because a `QuarkusTestProfile` loads in a different classloader from the test class and anything computed in `getConfigOverrides()` initialises twice.

`ScheduledWorkflowIdTest` covers the idempotency property directly, including the UTC day boundary — a local-zone truncation would double-run on some days and skip others depending on where the pod happens to run.

`%test` also switches to an ephemeral HTTP port: this module has two `@QuarkusTest` classes with different profiles for the first time, so there are two application boots per run, and on the fixed default the second died with `QuarkusBindException` whenever anything else on the machine held the port.

In `%test` the scheduler is given a cron that never fires (the 31st of February) rather than `quarkus.scheduler.enabled: false`. Disabling the scheduler makes the class structurally invisible to every test, which is how the five schedulers above reached production having never run.

## One thing worth flagging

`check-cron` had to be declared in `LivenessSentinelConfig` as well as `application.yaml`. SmallRye validates a `@ConfigMapping` prefix as a **closed set**, so a key added to the YAML without a matching accessor does not warn about one property — it fails the whole application at boot with `ConfigValidationException`. Both integration tests caught it; compilation did not.

## Not in this PR

`openbank-devops-agent` and `openbank-finops-agent` have **no scheduling either** — no `@Scheduled`, no CronJob — even though ADR-0163 positions the sentinel's time slot as an offset from theirs. Same shape, separate change.

Refs #2239

🤖 Generated with [Claude Code](https://claude.com/claude-code)
