### PR TITLE
fix(sanctions): replay the stored check when a concurrent writer wins the idempotency key

### DIFF
--- a/openbank-sanctions-service/src/main/kotlin/com/openbank/sanctions/infrastructure/persistence/repository/SanctionsRepositoryImpl.kt
+++ b/openbank-sanctions-service/src/main/kotlin/com/openbank/sanctions/infrastructure/persistence/repository/SanctionsRepositoryImpl.kt
@@ -15,6 +15,7 @@ import io.quarkus.hibernate.reactive.panache.Panache
 import io.quarkus.hibernate.reactive.panache.kotlin.PanacheRepository
 import io.smallrye.mutiny.coroutines.awaitSuspending
 import jakarta.enterprise.context.ApplicationScoped
+import org.hibernate.exception.ConstraintViolationException
 import java.util.UUID
 
 @ApplicationScoped
@@ -30,6 +31,21 @@ class SanctionsRepositoryImpl(private val outboxRepo: SanctionsOutboxRepository)
         return e.toDomain()
     }
 
+    /**
+     * Persist the check and its outbox event in one transaction, replaying idempotently when a
+     * concurrent caller won the race for the same `idempotencyKey` (#3264).
+     *
+     * `SanctionsService.screen` already looks the key up before screening, but that is a
+     * check-then-act: screening takes seconds, so a retry that arrives while the first call is
+     * still in flight finds nothing, screens too, and then loses the INSERT to the unique index on
+     * `idempotency_key`. Before this, that surfaced as an unhandled `ConstraintViolationException`
+     * -> 500, which the caller cannot distinguish from a transport fault. Measured cost: a
+     * domestic payment was held for hours on a check that had in fact completed and stored `CLEAR`.
+     *
+     * On that specific violation the loser's transaction is already rolled back — so it emitted no
+     * duplicate outbox event — and the winner's row is the one true result for the key, so we
+     * return it. Any other failure, including a primary-key violation, is rethrown untouched.
+     */
     override suspend fun saveWithEvent(check: SanctionsCheck, eventType: String): SanctionsCheck {
         val e = check.toEntity()
         val event = OutboxMessage(
@@ -37,8 +53,39 @@ class SanctionsRepositoryImpl(private val outboxRepo: SanctionsOutboxRepository)
             eventType = eventType,
             payload = mapper.writeValueAsString(check),
         )
-        Panache.withTransaction { persist(e).chain { _ -> outboxRepo.persistInTransaction(event) } }.awaitSuspending()
-        return e.toDomain()
+        return try {
+            Panache.withTransaction {
+                persist(e).chain { _ -> outboxRepo.persistInTransaction(event) }
+            }.awaitSuspending()
+            e.toDomain()
+        } catch (ex: ConstraintViolationException) {
+            if (!ex.isIdempotencyKeyViolation()) throw ex
+            // The winner committed between our lookup and our INSERT; return its row.
+            findByIdempotencyKey(check.idempotencyKey) ?: throw ex
+        }
+    }
+
+    /**
+     * True when this violation is the unique index on `sanctions_checks.idempotency_key`.
+     *
+     * Identified by constraint, never by SQLSTATE alone: a primary-key collision is also 23505,
+     * and it means something entirely different — the persist-vs-merge failure mode on an
+     * application-assigned `@Id` (ADR-0126 D3). Swallowing that as "an idempotent replay" would
+     * hide a real defect behind a successful-looking response, so it must keep propagating.
+     *
+     * `constraintName` is authoritative when Hibernate populates it; the message scan is the
+     * fallback for drivers that leave it null. The name comes from the `UNIQUE` column in
+     * `V1__create_sanctions.sql` (Postgres derives it), so it is not independently maintained —
+     * and `SanctionsIdempotentReplayIT` drives a real duplicate through Postgres, so a rename
+     * fails that test instead of quietly turning this branch into dead code.
+     */
+    private fun ConstraintViolationException.isIdempotencyKeyViolation(): Boolean =
+        constraintName == IDEMPOTENCY_KEY_CONSTRAINT ||
+            generateSequence(this as Throwable) { t -> t.cause.takeIf { it !== t } }
+                .any { it.message?.contains(IDEMPOTENCY_KEY_CONSTRAINT) == true }
+
+    private companion object {
+        const val IDEMPOTENCY_KEY_CONSTRAINT = "sanctions_checks_idempotency_key_key"
     }
 
     override suspend fun findById(id: UUID) =

--- a/openbank-sanctions-service/src/test/kotlin/com/openbank/sanctions/it/SanctionsIdempotentReplayIT.kt
+++ b/openbank-sanctions-service/src/test/kotlin/com/openbank/sanctions/it/SanctionsIdempotentReplayIT.kt
@@ -1,0 +1,149 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright (c) OpenBank contributors. Licensed under the Apache License, Version 2.0.
+// See LICENSE in the repository root or https://www.apache.org/licenses/LICENSE-2.0 for details.
+
+package com.openbank.sanctions.it
+
+import com.openbank.sanctions.domain.model.EntityType
+import com.openbank.sanctions.domain.model.SanctionsCheck
+import com.openbank.sanctions.domain.model.SanctionsCheckStatus
+import com.openbank.sanctions.domain.model.SanctionsListType
+import com.openbank.sanctions.infrastructure.persistence.repository.SanctionsRepositoryImpl
+import io.quarkus.test.common.QuarkusTestResource
+import io.quarkus.test.junit.QuarkusTest
+import io.quarkus.vertx.VertxContextSupport
+import io.smallrye.mutiny.coroutines.awaitSuspending
+import io.smallrye.mutiny.coroutines.uni
+import io.vertx.mutiny.pgclient.PgPool
+import io.vertx.mutiny.sqlclient.Tuple
+import jakarta.inject.Inject
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.Dispatchers
+import org.assertj.core.api.Assertions.assertThat
+import org.assertj.core.api.Assertions.assertThatThrownBy
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Test
+import java.time.Instant
+import java.util.UUID
+
+/**
+ * Real-Postgres verification for #3264: a losing concurrent write on the same `idempotency_key`
+ * must replay the stored check, not surface a 500.
+ *
+ * `SanctionsService.screen` looks the key up before screening, but that is a check-then-act —
+ * screening takes seconds, so a client retry that arrives while the first call is still in flight
+ * finds nothing, screens too, and loses the INSERT to `sanctions_checks_idempotency_key_key`.
+ * Before the fix that escaped as an unhandled `ConstraintViolationException` -> 500, which a
+ * caller cannot tell apart from a transport fault; a domestic payment was held for hours on a
+ * check that had actually completed and stored `CLEAR`.
+ *
+ * This has to run against a real database. The defect IS the unique index, so a mocked or
+ * in-memory repository cannot express it — the constraint is the thing under test. The test also
+ * pins the constraint NAME: the fix matches on it to stay narrow, so a rename must fail here
+ * rather than quietly turning the replay branch into dead code.
+ */
+@QuarkusTest
+@QuarkusTestResource(PostgresTestResource::class)
+class SanctionsIdempotentReplayIT {
+
+    @Inject
+    lateinit var repository: SanctionsRepositoryImpl
+
+    @Inject
+    lateinit var pool: PgPool
+
+    private fun <T> onEventLoop(block: suspend () -> T): T =
+        VertxContextSupport.subscribeAndAwait { uni(CoroutineScope(Dispatchers.Unconfined)) { block() } }
+
+    @BeforeEach
+    fun clearTables() {
+        onEventLoop {
+            pool.query("DELETE FROM sanctions_checks").execute().awaitSuspending()
+            pool.query("DELETE FROM sanctions_outbox").execute().awaitSuspending()
+        }
+    }
+
+    private fun check(key: String, id: UUID = UUID.randomUUID(), name: String = "Screened Subject") = SanctionsCheck(
+        id = id,
+        idempotencyKey = key,
+        entityType = EntityType.INDIVIDUAL,
+        name = name,
+        aliases = emptyList(),
+        dateOfBirth = null,
+        nationality = null,
+        identifiers = emptyMap(),
+        status = SanctionsCheckStatus.CLEAR,
+        matches = emptyList(),
+        overallScore = 0.0,
+        checkedLists = listOf(SanctionsListType.OFAC_SDN),
+        reviewedBy = null,
+        reviewNote = null,
+        checkedAt = Instant.parse("2026-08-02T10:58:10Z"),
+        reviewedAt = null,
+    )
+
+    private fun rowCount(key: String): Long = onEventLoop {
+        pool.preparedQuery("SELECT count(*) AS c FROM sanctions_checks WHERE idempotency_key = $1")
+            .execute(Tuple.of(key)).awaitSuspending()
+            .iterator().next().getLong("c")
+    }
+
+    private fun outboxCount(): Long = onEventLoop {
+        pool.query("SELECT count(*) AS c FROM sanctions_outbox").execute().awaitSuspending()
+            .iterator().next().getLong("c")
+    }
+
+    @Test
+    fun `a losing writer on the same idempotency key gets the stored check back, not an exception`() {
+        val key = "c05853f8-4259-4c97-b648-9c8a84082789:debtor"
+        val winner = check(key, name = "Winner")
+
+        val stored = onEventLoop { repository.saveWithEvent(winner, "SanctionChecked") }
+        assertThat(stored.id).isEqualTo(winner.id)
+
+        // The loser screened the same subject concurrently and generated its own id, exactly as
+        // `SanctionsService.screen` does after its lookup came back empty.
+        val loser = check(key, name = "Loser")
+        val replayed = onEventLoop { repository.saveWithEvent(loser, "SanctionChecked") }
+
+        assertThat(replayed.id)
+            .describedAs("replay must return the winner's stored row, not the loser's discarded one")
+            .isEqualTo(winner.id)
+        assertThat(replayed.name).isEqualTo("Winner")
+    }
+
+    @Test
+    fun `a replay writes neither a second row nor a duplicate outbox event`() {
+        val key = "payment-1:creditor"
+
+        onEventLoop { repository.saveWithEvent(check(key), "SanctionChecked") }
+        assertThat(outboxCount()).isEqualTo(1)
+
+        onEventLoop { repository.saveWithEvent(check(key), "SanctionChecked") }
+
+        assertThat(rowCount(key)).describedAs("one key, one stored check").isEqualTo(1)
+        assertThat(outboxCount())
+            .describedAs("the loser's transaction rolled back, so it must not emit a second event")
+            .isEqualTo(1)
+    }
+
+    /**
+     * The guard must be narrow. A primary-key collision is a DIFFERENT failure — the
+     * persist-vs-merge trap on an application-assigned `@Id` (ADR-0126 D3) — and swallowing it as
+     * "an idempotent replay" would hide a real bug behind a successful-looking response. Without
+     * this case the fix could be written as a blanket `catch (ex: Exception)` and still pass every
+     * other assertion in this class.
+     */
+    @Test
+    fun `a primary-key collision still propagates and is not mistaken for a replay`() {
+        val sharedId = UUID.randomUUID()
+        onEventLoop { repository.saveWithEvent(check("key-a", id = sharedId), "SanctionChecked") }
+
+        assertThatThrownBy {
+            onEventLoop { repository.saveWithEvent(check("key-b", id = sharedId), "SanctionChecked") }
+        }.describedAs("same id, different key — a pkey violation, not an idempotent replay")
+            .isInstanceOf(Exception::class.java)
+
+        assertThat(rowCount("key-b")).isEqualTo(0)
+    }
+}


### PR DESCRIPTION
## What

Make `SanctionsRepositoryImpl.saveWithEvent` replay idempotently when a concurrent caller has
already stored a check for the same `idempotency_key`, instead of surfacing the unique-constraint
violation as an unhandled 500.

## Why the issue's diagnosis needed correcting

#3264 says the service has "no idempotent-replay path". That is wrong, and I'd rather say so than
have someone add a lookup that already exists — `SanctionsService.screen:81` does
`repo.findByIdempotencyKey(cmd.idempotencyKey)?.let { return it }`.

The real defect is that this is a **check-then-act race**. Screening takes seconds. A client retry
that arrives while the first call is still in flight finds nothing at the lookup, screens the same
subject too, and then loses the INSERT to `sanctions_checks_idempotency_key_key`. The timeline
measured on the payment that prompted the issue:

| time | event |
|---|---|
| 10:58:02 | attempt 1 begins screening |
| ~10:58:07 | caller's 5s timeout fires, retry dispatched (#3265) |
| 10:58:07 | attempt 2's lookup finds nothing — attempt 1 has not committed |
| 10:58:10 | attempt 1 commits `status = CLEAR` |
| 10:58:15 | attempt 2's INSERT → `23505` → `GenericExceptionMapper` → 500 |

The caller cannot tell that 500 apart from a transport fault, so it opened its circuit breaker and
held a payment for hours on a check that had in fact completed and cleared.

## How

On `ConstraintViolationException` for that specific constraint, re-read by idempotency key and
return the winner's stored row. The loser's transaction has already rolled back, so it emits no
duplicate outbox event.

Two deliberate choices:

- **Narrow, not blanket.** A primary-key collision is also `23505` and means something completely
  different — the persist-vs-merge trap on an application-assigned `@Id` (ADR-0126 D3). Catching
  broadly would hide that behind a successful-looking response. The guard matches on
  `constraintName` (falling back to a message scan where the driver leaves it null) and rethrows
  everything else.
- **Fixed in the adapter, not the use case.** `ConstraintViolationException` is a Hibernate type;
  letting it reach `SanctionsService` would put a persistence detail in the application layer.

No API change: same request, same 200 response shape. `openapi.yaml` and its contract version are
untouched, since a 500 was never part of the contract.

## Verification

`SanctionsIdempotentReplayIT` — real Postgres via `PostgresTestResource`, because the defect *is*
the unique index and a mocked repository cannot express it.

**Falsified before it was trusted.** Reverted the fix, ran the test against unmodified `main`:

```
a losing writer on the same idempotency key gets the stored check back  FAILED
  org.hibernate.exception.ConstraintViolationException: ...
a replay writes neither a second row nor a duplicate outbox event       FAILED
  org.hibernate.exception.ConstraintViolationException: ...
a primary-key collision still propagates                                passed
```

2 of 3 fail on exactly the defect; the pkey case passes either way, which is the point of including
it — without that case the fix could have been written as `catch (ex: Exception)` and still passed
everything else. With the fix restored, all three pass.

The test also pins the constraint name, so renaming it fails the test rather than quietly turning
the replay branch into dead code.

## Noticed while in here, not fixed

`SanctionsService.review()` goes through the same `saveWithEvent` with an existing id, and
`SanctionsCheckEntity` has an application-assigned `@Id` with no `@GeneratedValue` — so `persist`
schedules an INSERT and review should fail with a duplicate pkey, the same trap that broke
consent-service (#1521) and standing-order cancel (#2079). The new pkey test demonstrates that
shape throws. Left out of this PR because the fix (`merge` vs `persist`) interacts with the replay
guard added here and deserves its own change with its own test.

Closes #3264
Refs #3265, #3267
