### PR TITLE
feat(devops,finops): run the daily analysis sweep on a schedule, not only when asked

### DIFF
--- a/openbank-devops-agent/src/main/kotlin/com/openbank/devops/application/port/incoming/DevOpsUseCases.kt
+++ b/openbank-devops-agent/src/main/kotlin/com/openbank/devops/application/port/incoming/DevOpsUseCases.kt
@@ -10,7 +10,23 @@ import com.openbank.devops.domain.model.DevOpsRunReport
 import com.openbank.devops.domain.model.RunTrigger
 
 interface RunDevOpsAnalysisUseCase {
+    /** Runs an analysis and WAITS for the report — the operator trigger, where a human is holding
+     *  an HTTP connection open and wants the outcome. */
     suspend fun run(trigger: RunTrigger): DevOpsRunReport
+
+    /**
+     * Starts an analysis and returns its workflow id WITHOUT waiting.
+     *
+     * What the schedule uses. A sweep runs several collect activities, threshold detectors and an
+     * LLM diagnosis per finding, so it can take many minutes; waiting inline would pin a scheduler
+     * thread for the whole run and make a slow analysis indistinguishable from a hung one. Temporal
+     * owns the execution and its history is the durable record.
+     *
+     * Idempotent: the workflow id is derived from the trigger and the UTC day, so a pod restart or
+     * a second replica is REJECTED by Temporal rather than starting a duplicate sweep that would
+     * spend the agent's daily LLM budget twice.
+     */
+    suspend fun startDetached(trigger: RunTrigger): String
 }
 
 interface GetFindingsUseCase {

--- a/openbank-devops-agent/src/main/kotlin/com/openbank/devops/application/usecase/DevOpsService.kt
+++ b/openbank-devops-agent/src/main/kotlin/com/openbank/devops/application/usecase/DevOpsService.kt
@@ -16,15 +16,21 @@ import com.openbank.devops.domain.model.FindingStatus
 import com.openbank.devops.domain.model.RunTrigger
 import com.openbank.libs.temporal.TemporalConfig
 import io.temporal.client.WorkflowClient
+import io.temporal.client.WorkflowExecutionAlreadyStarted
 import io.temporal.client.WorkflowOptions
 import jakarta.enterprise.context.ApplicationScoped
 import org.jboss.logging.Logger
+import java.time.Clock
+import java.time.Instant
+import java.time.ZoneOffset
+import java.time.format.DateTimeFormatter
 
 @ApplicationScoped
 class DevOpsService(
     private val workflowClient: WorkflowClient,
     private val temporalConfig: TemporalConfig,
     private val findingRepository: FindingRepository,
+    private val clock: Clock,
 ) : RunDevOpsAnalysisUseCase,
     GetFindingsUseCase,
     DecideFindingUseCase {
@@ -45,6 +51,24 @@ class DevOpsService(
         return workflow.runAnalysis(trigger)
     }
 
+    override suspend fun startDetached(trigger: RunTrigger): String {
+        val workflowId = scheduledWorkflowId(trigger, Instant.now(clock))
+        val options = WorkflowOptions.newBuilder()
+            .setTaskQueue(temporalConfig.taskQueue())
+            .setWorkflowId(workflowId)
+            .build()
+        val stub = workflowClient.newWorkflowStub(DevOpsAnalysisWorkflow::class.java, options)
+        try {
+            WorkflowClient.start({ stub.runAnalysis(trigger) })
+            log.infof("Started DevOps analysis workflow %s (trigger=%s)", workflowId, trigger)
+        } catch (duplicate: WorkflowExecutionAlreadyStarted) {
+            // Not an error — the dedupe working. Two pods, or one restarted after the cron fired,
+            // compute the same id and Temporal admits only the first.
+            log.infof("Analysis workflow %s already running, not starting a second: %s", workflowId, duplicate.message)
+        }
+        return workflowId
+    }
+
     override suspend fun getActive(): List<DevOpsFinding> = findingRepository.findActive()
 
     override suspend fun getById(id: String): DevOpsFinding? = findingRepository.findById(id)
@@ -57,5 +81,19 @@ class DevOpsService(
         val finding = findingRepository.findById(id) ?: return null
         log.infof("HITL %s on finding %s by operator", status, id.sanitizeForLog())
         return findingRepository.update(finding.copy(status = status))
+    }
+
+    companion object {
+        private val DAY: DateTimeFormatter = DateTimeFormatter.ofPattern("yyyy-MM-dd").withZone(ZoneOffset.UTC)
+
+        /**
+         * The id that makes a detached start idempotent for the day.
+         *
+         * Deliberately NOT `System.currentTimeMillis()`, which the operator path uses: an id that
+         * can never collide can never dedupe either. The trigger is part of the id so an operator
+         * can still force a run on a day the schedule has already used.
+         */
+        fun scheduledWorkflowId(trigger: RunTrigger, at: Instant): String =
+            "devops-analysis-${trigger.name.lowercase()}-${DAY.format(at)}"
     }
 }

--- a/openbank-devops-agent/src/main/kotlin/com/openbank/devops/infrastructure/config/DevOpsConfig.kt
+++ b/openbank-devops-agent/src/main/kotlin/com/openbank/devops/infrastructure/config/DevOpsConfig.kt
@@ -13,6 +13,17 @@ import jakarta.enterprise.context.ApplicationScoped
 @ApplicationScoped
 @Suppress("TooManyFunctions") // flat config mapping: one accessor per tunable (model, GitHub, detector thresholds)
 interface DevOpsConfig {
+    /**
+     * Cron for the daily analysis sweep (ADR-0119).
+     *
+     * Declared here because it lives under this mapping's prefix: SmallRye validates a
+     * `@ConfigMapping` prefix as a CLOSED set, so a key added to `application.yaml` with no
+     * matching accessor fails the whole application at boot with `ConfigValidationException` —
+     * not a warning about one property, a dead service.
+     */
+    @WithDefault("0 30 3 * * ?")
+    fun analysisCron(): String
+
     @WithDefault("http://prometheus-operated.observability:9090")
     fun prometheusUrl(): String
 

--- a/openbank-devops-agent/src/main/kotlin/com/openbank/devops/infrastructure/schedule/DevOpsAnalysisScheduler.kt
+++ b/openbank-devops-agent/src/main/kotlin/com/openbank/devops/infrastructure/schedule/DevOpsAnalysisScheduler.kt
@@ -1,0 +1,69 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+// Copyright (c) OpenBank contributors. Licensed under the GNU Affero General Public License v3.0 only.
+// A commercial licence is available from the maintainers as an alternative to the AGPL-3.0.
+// See LICENSES/AGPL-3.0-only.txt or https://www.gnu.org/licenses/agpl-3.0.html for details.
+
+package com.openbank.devops.infrastructure.schedule
+
+import com.openbank.devops.application.port.incoming.RunDevOpsAnalysisUseCase
+import com.openbank.devops.domain.model.RunTrigger
+import com.openbank.libs.temporal.TemporalConfig
+import io.quarkus.scheduler.Scheduled
+import jakarta.enterprise.context.ApplicationScoped
+import jakarta.inject.Inject
+import org.jboss.logging.Logger
+import java.util.concurrent.atomic.AtomicLong
+
+/**
+ * The daily analysis sweep ADR-0119 decided and nothing ever built.
+ *
+ * ADR-0119 shows a "schedule: durable analysis sweep" lane in the agent's own diagram, and `RunTrigger.SCHEDULED` has existed in the domain model since the service was
+ * written — but nothing ever emitted it. The agent was trigger-only
+ * (`POST /api/v1/devops/analysis/trigger`), so it had analysed **nothing**: measured
+ * 2026-08-02, the `openbank-devops` Temporal namespace held 0 schedules and 0 workflow
+ * executions, and `findings` was empty.
+ *
+ * The empty table is the trap. It renders as "nothing to act on" — the healthiest-looking possible
+ * answer — when it actually means nothing has ever looked. An agent that has never run and an agent
+ * that runs and finds nothing are indistinguishable from the outside.
+ *
+ * A `suspend fun` on purpose: a plain `@Scheduled` method carries no Vert.x context, so a body of
+ * `runBlocking { … }` around a reactive call throws `HR000068` and the job aborts silently —
+ * five schedulers in this fleet had never run for exactly that reason (#2148, #2187), and it is now
+ * a hard rule (`rules.yaml: scheduled_methods`).
+ */
+@ApplicationScoped
+class DevOpsAnalysisScheduler {
+
+    @Inject
+    lateinit var runAnalysis: RunDevOpsAnalysisUseCase
+
+    @Inject
+    lateinit var temporalConfig: TemporalConfig
+
+    private val log = Logger.getLogger(DevOpsAnalysisScheduler::class.java)
+    private val fires = AtomicLong(0)
+
+    /**
+     * How many times the cron has actually fired in this pod.
+     *
+     * Exists so a test can assert the SCHEDULE rather than the work: a test that calls the method
+     * directly cannot see whether the cron was ever wired, and would pass against a service with no
+     * schedule at all — which is the bug being fixed here.
+     */
+    val fireCount: Long get() = fires.get()
+
+    @Scheduled(
+        cron = "{openbank.devops.analysis-cron}",
+        concurrentExecution = Scheduled.ConcurrentExecution.SKIP,
+    )
+    suspend fun runScheduledAnalysis() {
+        fires.incrementAndGet()
+        if (!temporalConfig.enabled()) {
+            log.info("Temporal disabled; skipping the scheduled DevOps analysis")
+            return
+        }
+        val workflowId = runAnalysis.startDetached(RunTrigger.SCHEDULED)
+        log.infof("Scheduled DevOps analysis dispatched as workflow %s", workflowId)
+    }
+}

--- a/openbank-devops-agent/src/main/resources/application.yaml
+++ b/openbank-devops-agent/src/main/resources/application.yaml
@@ -77,6 +77,20 @@ quarkus:
       enabled: false
     management:
       enabled: false
+    http:
+      # Ephemeral: this module now has more than one @QuarkusTest profile, so there is more than
+      # one application boot per run, and on the fixed default the second dies with
+      # QuarkusBindException whenever anything else on the machine holds the port.
+      test-port: 0
+
+  openbank:
+    devops:
+      # A cron that never fires (the 31st of February), NOT `quarkus.scheduler.enabled: false`.
+      # Disabling the scheduler makes the class structurally invisible to every test — which is how
+      # five schedulers in this fleet reached production having never run (#2148, #2187). With a
+      # real-but-unreachable expression the wiring is still built and validated at boot, and a test
+      # profile can override this key with a fast cron to drive the REAL schedule.
+      analysis-cron: "0 0 5 31 2 ?"
 
 openbank:
   temporal:
@@ -90,6 +104,12 @@ openbank:
     # divergence is preserved as config rather than flattened. Flip to true to adopt the fleet norm.
     metrics-enabled: false
   devops:
+    # Daily analysis sweep (ADR-0119). 03:30 UTC — the three AI agents are offset from each
+    # other by 15 minutes because they share ONE LiteLLM gateway and one Prometheus, and each now
+    # carries its own daily token budget: finops-agent (03:00) and the control-liveness sentinel (03:15).
+    # Collisions with unrelated per-service batch jobs are not a consideration — different pods,
+    # different databases. Quarkus cron is SIX fields (second minute hour day month weekday).
+    analysis-cron: ${DEVOPS_ANALYSIS_CRON:0 30 3 * * ?}
     prometheus-url: ${PROMETHEUS_URL:http://prometheus-operated.observability:9090}
     alertmanager-url: ${ALERTMANAGER_URL:http://alertmanager-operated.observability:9093}
     # OpenAI-compatible model backend — DeepInfra + DeepSeek, same provider+model as the copilot

--- a/openbank-devops-agent/src/test/kotlin/com/openbank/devops/application/usecase/ScheduledWorkflowIdTest.kt
+++ b/openbank-devops-agent/src/test/kotlin/com/openbank/devops/application/usecase/ScheduledWorkflowIdTest.kt
@@ -1,0 +1,55 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+// Copyright (c) OpenBank contributors. Licensed under the GNU Affero General Public License v3.0 only.
+// A commercial licence is available from the maintainers as an alternative to the AGPL-3.0.
+// See LICENSES/AGPL-3.0-only.txt or https://www.gnu.org/licenses/agpl-3.0.html for details.
+
+package com.openbank.devops.application.usecase
+
+import com.openbank.devops.domain.model.RunTrigger
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Assertions.assertNotEquals
+import org.junit.jupiter.api.Test
+import java.time.Instant
+
+/**
+ * The workflow id IS the deduplication. Temporal rejects a second start under an id already
+ * running, so these equalities are what stop a pod restart or a second replica from launching a
+ * duplicate sweep — which would spend the agent's daily LLM budget twice.
+ */
+class ScheduledWorkflowIdTest {
+
+    private fun id(trigger: RunTrigger, iso: String) = DevOpsService.scheduledWorkflowId(trigger, Instant.parse(iso))
+
+    @Test
+    fun `two fires on the same UTC day produce the same id`() {
+        assertEquals(
+            id(RunTrigger.SCHEDULED, "2026-08-02T03:00:00Z"),
+            id(RunTrigger.SCHEDULED, "2026-08-02T21:40:11Z"),
+        )
+    }
+
+    @Test
+    fun `consecutive days produce different ids`() {
+        assertNotEquals(
+            id(RunTrigger.SCHEDULED, "2026-08-02T03:00:00Z"),
+            id(RunTrigger.SCHEDULED, "2026-08-03T03:00:00Z"),
+        )
+    }
+
+    @Test
+    fun `the day boundary is UTC, not the JVM default zone`() {
+        // 23:30 Prague on the 2nd is 21:30 UTC the same day; 00:30 Prague on the 3rd is 22:30 UTC
+        // on the 2nd. A local-zone truncation would split the first pair and merge the second, so
+        // the schedule would double-run on some days and skip others depending on where the pod runs.
+        assertEquals("devops-analysis-scheduled-2026-08-02", id(RunTrigger.SCHEDULED, "2026-08-02T23:59:59Z"))
+        assertEquals("devops-analysis-scheduled-2026-08-03", id(RunTrigger.SCHEDULED, "2026-08-03T00:00:00Z"))
+    }
+
+    @Test
+    fun `an operator run is never blocked by the day's scheduled run`() {
+        assertNotEquals(
+            id(RunTrigger.SCHEDULED, "2026-08-02T03:00:00Z"),
+            id(RunTrigger.OPERATOR_MANUAL, "2026-08-02T03:00:00Z"),
+        )
+    }
+}

--- a/openbank-devops-agent/src/test/kotlin/com/openbank/devops/infrastructure/schedule/DevOpsSchedulerCronIT.kt
+++ b/openbank-devops-agent/src/test/kotlin/com/openbank/devops/infrastructure/schedule/DevOpsSchedulerCronIT.kt
@@ -1,0 +1,73 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+// Copyright (c) OpenBank contributors. Licensed under the GNU Affero General Public License v3.0 only.
+// A commercial licence is available from the maintainers as an alternative to the AGPL-3.0.
+// See LICENSES/AGPL-3.0-only.txt or https://www.gnu.org/licenses/agpl-3.0.html for details.
+
+package com.openbank.devops.infrastructure.schedule
+
+import com.openbank.devops.PostgresTestResource
+import io.quarkus.test.common.QuarkusTestResource
+import io.quarkus.test.junit.QuarkusTest
+import io.quarkus.test.junit.QuarkusTestProfile
+import io.quarkus.test.junit.TestProfile
+import jakarta.inject.Inject
+import org.junit.jupiter.api.Assertions.assertTrue
+import org.junit.jupiter.api.Test
+import java.time.Duration
+import java.time.Instant
+
+/**
+ * Proves the agent has a WORKING SCHEDULE, by letting the real cron fire.
+ *
+ * Deliberately not a direct call to [DevOpsAnalysisScheduler.runScheduledAnalysis]. A direct call
+ * proves the method body works and says nothing about whether anything ever invokes it — it passes
+ * identically against the service as it shipped, which had no schedule at all and had therefore
+ * analysed nothing since it was deployed. The bug lives entirely in the wiring, so the wiring is
+ * what has to be exercised.
+ *
+ * The profile shrinks the cron to every second and leaves Temporal disabled: the assertion is that
+ * the SCHEDULER fires, not that a workflow starts.
+ *
+ * Note the literal cron string. A `QuarkusTestProfile` loads in a DIFFERENT classloader from the
+ * test class, so anything computed in `getConfigOverrides()` initialises twice and the scheduler
+ * and the assertion can end up holding different values.
+ */
+@QuarkusTest
+@QuarkusTestResource(PostgresTestResource::class)
+@TestProfile(DevOpsSchedulerCronIT.EverySecondProfile::class)
+class DevOpsSchedulerCronIT {
+
+    class EverySecondProfile : QuarkusTestProfile {
+        override fun getConfigOverrides(): Map<String, String> = mapOf(
+            // Literals only — see the class KDoc.
+            "openbank.devops.analysis-cron" to "*/1 * * * * ?",
+            "openbank.temporal.enabled" to "false",
+        )
+    }
+
+    @Inject
+    lateinit var scheduler: DevOpsAnalysisScheduler
+
+    @Test
+    fun `the real cron fires the scheduled analysis`() {
+        val before = scheduler.fireCount
+        val deadline = Instant.now().plus(Duration.ofSeconds(TIMEOUT_SECONDS))
+
+        while (Instant.now().isBefore(deadline) && scheduler.fireCount == before) {
+            Thread.sleep(POLL_MILLIS)
+        }
+
+        assertTrue(
+            scheduler.fireCount > before,
+            "The scheduled DevOps analysis never fired within $TIMEOUT_SECONDS s. The cron " +
+                "expression is not wired to the scheduler, which is the defect this test exists " +
+                "for: the agent then analyses nothing while its empty result table reads as " +
+                "'nothing to act on'.",
+        )
+    }
+
+    private companion object {
+        const val TIMEOUT_SECONDS = 30L
+        const val POLL_MILLIS = 200L
+    }
+}

--- a/openbank-finops-agent/src/main/kotlin/com/openbank/finops/application/port/incoming/FinOpsUseCases.kt
+++ b/openbank-finops-agent/src/main/kotlin/com/openbank/finops/application/port/incoming/FinOpsUseCases.kt
@@ -10,7 +10,23 @@ import com.openbank.finops.domain.model.FinOpsRunReport
 import com.openbank.finops.domain.model.RunTrigger
 
 interface RunFinOpsAnalysisUseCase {
+    /** Runs an analysis and WAITS for the report — the operator trigger, where a human is holding
+     *  an HTTP connection open and wants the outcome. */
     suspend fun run(trigger: RunTrigger): FinOpsRunReport
+
+    /**
+     * Starts an analysis and returns its workflow id WITHOUT waiting.
+     *
+     * What the schedule uses. A sweep runs several collect activities, threshold detectors and an
+     * LLM diagnosis per finding, so it can take many minutes; waiting inline would pin a scheduler
+     * thread for the whole run and make a slow analysis indistinguishable from a hung one. Temporal
+     * owns the execution and its history is the durable record.
+     *
+     * Idempotent: the workflow id is derived from the trigger and the UTC day, so a pod restart or
+     * a second replica is REJECTED by Temporal rather than starting a duplicate sweep that would
+     * spend the agent's daily LLM budget twice.
+     */
+    suspend fun startDetached(trigger: RunTrigger): String
 }
 
 interface GetAnomaliesUseCase {

--- a/openbank-finops-agent/src/main/kotlin/com/openbank/finops/application/usecase/FinOpsService.kt
+++ b/openbank-finops-agent/src/main/kotlin/com/openbank/finops/application/usecase/FinOpsService.kt
@@ -14,15 +14,21 @@ import com.openbank.finops.domain.model.FinOpsRunReport
 import com.openbank.finops.domain.model.RunTrigger
 import com.openbank.libs.temporal.TemporalConfig
 import io.temporal.client.WorkflowClient
+import io.temporal.client.WorkflowExecutionAlreadyStarted
 import io.temporal.client.WorkflowOptions
 import jakarta.enterprise.context.ApplicationScoped
 import org.jboss.logging.Logger
+import java.time.Clock
+import java.time.Instant
+import java.time.ZoneOffset
+import java.time.format.DateTimeFormatter
 
 @ApplicationScoped
 class FinOpsService(
     private val workflowClient: WorkflowClient,
     private val temporalConfig: TemporalConfig,
     private val anomalyRepository: AnomalyRepository,
+    private val clock: Clock,
 ) : RunFinOpsAnalysisUseCase,
     GetAnomaliesUseCase {
 
@@ -38,7 +44,39 @@ class FinOpsService(
         return workflow.runAnalysis(trigger)
     }
 
+    override suspend fun startDetached(trigger: RunTrigger): String {
+        val workflowId = scheduledWorkflowId(trigger, Instant.now(clock))
+        val options = WorkflowOptions.newBuilder()
+            .setTaskQueue(temporalConfig.taskQueue())
+            .setWorkflowId(workflowId)
+            .build()
+        val stub = workflowClient.newWorkflowStub(FinOpsAnalysisWorkflow::class.java, options)
+        try {
+            WorkflowClient.start({ stub.runAnalysis(trigger) })
+            log.infof("Started FinOps analysis workflow %s (trigger=%s)", workflowId, trigger)
+        } catch (duplicate: WorkflowExecutionAlreadyStarted) {
+            // Not an error — the dedupe working. Two pods, or one restarted after the cron fired,
+            // compute the same id and Temporal admits only the first.
+            log.infof("Analysis workflow %s already running, not starting a second: %s", workflowId, duplicate.message)
+        }
+        return workflowId
+    }
+
     override suspend fun getActive(): List<CostAnomaly> = anomalyRepository.findActive()
 
     override suspend fun getById(id: String): CostAnomaly? = anomalyRepository.findById(id)
+
+    companion object {
+        private val DAY: DateTimeFormatter = DateTimeFormatter.ofPattern("yyyy-MM-dd").withZone(ZoneOffset.UTC)
+
+        /**
+         * The id that makes a detached start idempotent for the day.
+         *
+         * Deliberately NOT `System.currentTimeMillis()`, which the operator path uses: an id that
+         * can never collide can never dedupe either. The trigger is part of the id so an operator
+         * can still force a run on a day the schedule has already used.
+         */
+        fun scheduledWorkflowId(trigger: RunTrigger, at: Instant): String =
+            "finops-analysis-${trigger.name.lowercase()}-${DAY.format(at)}"
+    }
 }

--- a/openbank-finops-agent/src/main/kotlin/com/openbank/finops/infrastructure/config/FinOpsConfig.kt
+++ b/openbank-finops-agent/src/main/kotlin/com/openbank/finops/infrastructure/config/FinOpsConfig.kt
@@ -12,6 +12,17 @@ import jakarta.enterprise.context.ApplicationScoped
 @ConfigMapping(prefix = "openbank.finops")
 @ApplicationScoped
 interface FinOpsConfig {
+    /**
+     * Cron for the daily analysis sweep (ADR-0112).
+     *
+     * Declared here because it lives under this mapping's prefix: SmallRye validates a
+     * `@ConfigMapping` prefix as a CLOSED set, so a key added to `application.yaml` with no
+     * matching accessor fails the whole application at boot with `ConfigValidationException` —
+     * not a warning about one property, a dead service.
+     */
+    @WithDefault("0 0 3 * * ?")
+    fun analysisCron(): String
+
     @WithDefault("http://prometheus-operated.observability:9090")
     fun prometheusUrl(): String
 

--- a/openbank-finops-agent/src/main/kotlin/com/openbank/finops/infrastructure/schedule/FinOpsAnalysisScheduler.kt
+++ b/openbank-finops-agent/src/main/kotlin/com/openbank/finops/infrastructure/schedule/FinOpsAnalysisScheduler.kt
@@ -1,0 +1,69 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+// Copyright (c) OpenBank contributors. Licensed under the GNU Affero General Public License v3.0 only.
+// A commercial licence is available from the maintainers as an alternative to the AGPL-3.0.
+// See LICENSES/AGPL-3.0-only.txt or https://www.gnu.org/licenses/agpl-3.0.html for details.
+
+package com.openbank.finops.infrastructure.schedule
+
+import com.openbank.finops.application.port.incoming.RunFinOpsAnalysisUseCase
+import com.openbank.finops.domain.model.RunTrigger
+import com.openbank.libs.temporal.TemporalConfig
+import io.quarkus.scheduler.Scheduled
+import jakarta.enterprise.context.ApplicationScoped
+import jakarta.inject.Inject
+import org.jboss.logging.Logger
+import java.util.concurrent.atomic.AtomicLong
+
+/**
+ * The daily analysis sweep ADR-0112 decided and nothing ever built.
+ *
+ * ADR-0112 states "schedule: daily 03:00 UTC" outright, and `RunTrigger.SCHEDULED` has existed in the domain model since the service was
+ * written — but nothing ever emitted it. The agent was trigger-only
+ * (`POST /api/v1/finops/analysis/trigger`), so it had analysed **nothing**: measured
+ * 2026-08-02, the `openbank-finops` Temporal namespace held 0 schedules and 0 workflow
+ * executions, and `anomalies` was empty.
+ *
+ * The empty table is the trap. It renders as "nothing to act on" — the healthiest-looking possible
+ * answer — when it actually means nothing has ever looked. An agent that has never run and an agent
+ * that runs and finds nothing are indistinguishable from the outside.
+ *
+ * A `suspend fun` on purpose: a plain `@Scheduled` method carries no Vert.x context, so a body of
+ * `runBlocking { … }` around a reactive call throws `HR000068` and the job aborts silently —
+ * five schedulers in this fleet had never run for exactly that reason (#2148, #2187), and it is now
+ * a hard rule (`rules.yaml: scheduled_methods`).
+ */
+@ApplicationScoped
+class FinOpsAnalysisScheduler {
+
+    @Inject
+    lateinit var runAnalysis: RunFinOpsAnalysisUseCase
+
+    @Inject
+    lateinit var temporalConfig: TemporalConfig
+
+    private val log = Logger.getLogger(FinOpsAnalysisScheduler::class.java)
+    private val fires = AtomicLong(0)
+
+    /**
+     * How many times the cron has actually fired in this pod.
+     *
+     * Exists so a test can assert the SCHEDULE rather than the work: a test that calls the method
+     * directly cannot see whether the cron was ever wired, and would pass against a service with no
+     * schedule at all — which is the bug being fixed here.
+     */
+    val fireCount: Long get() = fires.get()
+
+    @Scheduled(
+        cron = "{openbank.finops.analysis-cron}",
+        concurrentExecution = Scheduled.ConcurrentExecution.SKIP,
+    )
+    suspend fun runScheduledAnalysis() {
+        fires.incrementAndGet()
+        if (!temporalConfig.enabled()) {
+            log.info("Temporal disabled; skipping the scheduled FinOps analysis")
+            return
+        }
+        val workflowId = runAnalysis.startDetached(RunTrigger.SCHEDULED)
+        log.infof("Scheduled FinOps analysis dispatched as workflow %s", workflowId)
+    }
+}

--- a/openbank-finops-agent/src/main/resources/application.yaml
+++ b/openbank-finops-agent/src/main/resources/application.yaml
@@ -77,6 +77,20 @@ quarkus:
       enabled: false
     management:
       enabled: false
+    http:
+      # Ephemeral: this module now has more than one @QuarkusTest profile, so there is more than
+      # one application boot per run, and on the fixed default the second dies with
+      # QuarkusBindException whenever anything else on the machine holds the port.
+      test-port: 0
+
+  openbank:
+    finops:
+      # A cron that never fires (the 31st of February), NOT `quarkus.scheduler.enabled: false`.
+      # Disabling the scheduler makes the class structurally invisible to every test — which is how
+      # five schedulers in this fleet reached production having never run (#2148, #2187). With a
+      # real-but-unreachable expression the wiring is still built and validated at boot, and a test
+      # profile can override this key with a fast cron to drive the REAL schedule.
+      analysis-cron: "0 0 5 31 2 ?"
 
 openbank:
   temporal:
@@ -85,6 +99,12 @@ openbank:
     namespace: ${TEMPORAL_NAMESPACE:openbank}
     task-queue: finops-agent
   finops:
+    # Daily analysis sweep (ADR-0112). 03:00 UTC — the three AI agents are offset from each
+    # other by 15 minutes because they share ONE LiteLLM gateway and one Prometheus, and each now
+    # carries its own daily token budget: the control-liveness sentinel (03:15) and devops-agent (03:30).
+    # Collisions with unrelated per-service batch jobs are not a consideration — different pods,
+    # different databases. Quarkus cron is SIX fields (second minute hour day month weekday).
+    analysis-cron: ${FINOPS_ANALYSIS_CRON:0 0 3 * * ?}
     prometheus-url: ${PROMETHEUS_URL:http://prometheus-operated.observability:9090}
     alertmanager-url: ${ALERTMANAGER_URL:http://alertmanager-operated.observability:9093}
     llm-gateway-url: ${LLM_GATEWAY_URL:http://litellm.ai-platform:4000}

--- a/openbank-finops-agent/src/test/kotlin/com/openbank/finops/application/usecase/ScheduledWorkflowIdTest.kt
+++ b/openbank-finops-agent/src/test/kotlin/com/openbank/finops/application/usecase/ScheduledWorkflowIdTest.kt
@@ -1,0 +1,55 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+// Copyright (c) OpenBank contributors. Licensed under the GNU Affero General Public License v3.0 only.
+// A commercial licence is available from the maintainers as an alternative to the AGPL-3.0.
+// See LICENSES/AGPL-3.0-only.txt or https://www.gnu.org/licenses/agpl-3.0.html for details.
+
+package com.openbank.finops.application.usecase
+
+import com.openbank.finops.domain.model.RunTrigger
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Assertions.assertNotEquals
+import org.junit.jupiter.api.Test
+import java.time.Instant
+
+/**
+ * The workflow id IS the deduplication. Temporal rejects a second start under an id already
+ * running, so these equalities are what stop a pod restart or a second replica from launching a
+ * duplicate sweep — which would spend the agent's daily LLM budget twice.
+ */
+class ScheduledWorkflowIdTest {
+
+    private fun id(trigger: RunTrigger, iso: String) = FinOpsService.scheduledWorkflowId(trigger, Instant.parse(iso))
+
+    @Test
+    fun `two fires on the same UTC day produce the same id`() {
+        assertEquals(
+            id(RunTrigger.SCHEDULED, "2026-08-02T03:00:00Z"),
+            id(RunTrigger.SCHEDULED, "2026-08-02T21:40:11Z"),
+        )
+    }
+
+    @Test
+    fun `consecutive days produce different ids`() {
+        assertNotEquals(
+            id(RunTrigger.SCHEDULED, "2026-08-02T03:00:00Z"),
+            id(RunTrigger.SCHEDULED, "2026-08-03T03:00:00Z"),
+        )
+    }
+
+    @Test
+    fun `the day boundary is UTC, not the JVM default zone`() {
+        // 23:30 Prague on the 2nd is 21:30 UTC the same day; 00:30 Prague on the 3rd is 22:30 UTC
+        // on the 2nd. A local-zone truncation would split the first pair and merge the second, so
+        // the schedule would double-run on some days and skip others depending on where the pod runs.
+        assertEquals("finops-analysis-scheduled-2026-08-02", id(RunTrigger.SCHEDULED, "2026-08-02T23:59:59Z"))
+        assertEquals("finops-analysis-scheduled-2026-08-03", id(RunTrigger.SCHEDULED, "2026-08-03T00:00:00Z"))
+    }
+
+    @Test
+    fun `an operator run is never blocked by the day's scheduled run`() {
+        assertNotEquals(
+            id(RunTrigger.SCHEDULED, "2026-08-02T03:00:00Z"),
+            id(RunTrigger.OPERATOR_MANUAL, "2026-08-02T03:00:00Z"),
+        )
+    }
+}

--- a/openbank-finops-agent/src/test/kotlin/com/openbank/finops/infrastructure/schedule/FinOpsSchedulerCronIT.kt
+++ b/openbank-finops-agent/src/test/kotlin/com/openbank/finops/infrastructure/schedule/FinOpsSchedulerCronIT.kt
@@ -1,0 +1,73 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+// Copyright (c) OpenBank contributors. Licensed under the GNU Affero General Public License v3.0 only.
+// A commercial licence is available from the maintainers as an alternative to the AGPL-3.0.
+// See LICENSES/AGPL-3.0-only.txt or https://www.gnu.org/licenses/agpl-3.0.html for details.
+
+package com.openbank.finops.infrastructure.schedule
+
+import com.openbank.finops.PostgresTestResource
+import io.quarkus.test.common.QuarkusTestResource
+import io.quarkus.test.junit.QuarkusTest
+import io.quarkus.test.junit.QuarkusTestProfile
+import io.quarkus.test.junit.TestProfile
+import jakarta.inject.Inject
+import org.junit.jupiter.api.Assertions.assertTrue
+import org.junit.jupiter.api.Test
+import java.time.Duration
+import java.time.Instant
+
+/**
+ * Proves the agent has a WORKING SCHEDULE, by letting the real cron fire.
+ *
+ * Deliberately not a direct call to [FinOpsAnalysisScheduler.runScheduledAnalysis]. A direct call
+ * proves the method body works and says nothing about whether anything ever invokes it — it passes
+ * identically against the service as it shipped, which had no schedule at all and had therefore
+ * analysed nothing since it was deployed. The bug lives entirely in the wiring, so the wiring is
+ * what has to be exercised.
+ *
+ * The profile shrinks the cron to every second and leaves Temporal disabled: the assertion is that
+ * the SCHEDULER fires, not that a workflow starts.
+ *
+ * Note the literal cron string. A `QuarkusTestProfile` loads in a DIFFERENT classloader from the
+ * test class, so anything computed in `getConfigOverrides()` initialises twice and the scheduler
+ * and the assertion can end up holding different values.
+ */
+@QuarkusTest
+@QuarkusTestResource(PostgresTestResource::class)
+@TestProfile(FinOpsSchedulerCronIT.EverySecondProfile::class)
+class FinOpsSchedulerCronIT {
+
+    class EverySecondProfile : QuarkusTestProfile {
+        override fun getConfigOverrides(): Map<String, String> = mapOf(
+            // Literals only — see the class KDoc.
+            "openbank.finops.analysis-cron" to "*/1 * * * * ?",
+            "openbank.temporal.enabled" to "false",
+        )
+    }
+
+    @Inject
+    lateinit var scheduler: FinOpsAnalysisScheduler
+
+    @Test
+    fun `the real cron fires the scheduled analysis`() {
+        val before = scheduler.fireCount
+        val deadline = Instant.now().plus(Duration.ofSeconds(TIMEOUT_SECONDS))
+
+        while (Instant.now().isBefore(deadline) && scheduler.fireCount == before) {
+            Thread.sleep(POLL_MILLIS)
+        }
+
+        assertTrue(
+            scheduler.fireCount > before,
+            "The scheduled FinOps analysis never fired within $TIMEOUT_SECONDS s. The cron " +
+                "expression is not wired to the scheduler, which is the defect this test exists " +
+                "for: the agent then analyses nothing while its empty result table reads as " +
+                "'nothing to act on'.",
+        )
+    }
+
+    private companion object {
+        const val TIMEOUT_SECONDS = 30L
+        const val POLL_MILLIS = 200L
+    }
+}

--- a/openbank-infra/gitops/components/devops-agent/devops-agent.yaml
+++ b/openbank-infra/gitops/components/devops-agent/devops-agent.yaml
@@ -49,17 +49,18 @@ spec:
             - name: TEMPORAL_HOST
               value: temporal-frontend.temporal.svc:7233
             - name: TEMPORAL_ENABLED
+              value: "true"
             # The daily analysis sweep. Set EXPLICITLY here rather than left to the
-            # application.yaml default, because this is the only place an operator looks to answer
-            # "when does this agent run" — and until now the answer was "it doesn't". The agent was
-            # trigger-only: measured 2026-08-02, the openbank-devops Temporal namespace held 0
-            # schedules and 0 workflow executions, and its result table was empty — which renders
-            # as "nothing to act on" rather than "nothing has ever looked".
-            # 03:30 UTC, offset 15 minutes from finops-agent (03:00) and the control-liveness sentinel (03:15): the three share one LiteLLM gateway and
-            # one Prometheus. Six fields (second minute hour day month weekday), Quarkus not crontab.
+            # application.yaml default, because this is the only place an operator looks to
+            # answer "when does this agent run" — and until now the answer was "it doesn't".
+            # The agent was trigger-only: measured 2026-08-02, the openbank-devops Temporal
+            # namespace held 0 schedules and 0 workflow executions, and its result table was
+            # empty — which renders as "nothing to act on" rather than "nothing has looked".
+            # 03:30 UTC, offset 15 minutes from finops-agent (03:00) and the control-liveness sentinel (03:15):
+            # the three share one LiteLLM gateway and one Prometheus.
+            # Six fields (second minute hour day month weekday) — Quarkus, not crontab.
             - name: DEVOPS_ANALYSIS_CRON
               value: "0 30 3 * * ?"
-              value: "true"
             - name: PROMETHEUS_URL
               value: http://prometheus-operated.observability.svc:9090
             - name: ALERTMANAGER_URL

--- a/openbank-infra/gitops/components/devops-agent/devops-agent.yaml
+++ b/openbank-infra/gitops/components/devops-agent/devops-agent.yaml
@@ -49,6 +49,16 @@ spec:
             - name: TEMPORAL_HOST
               value: temporal-frontend.temporal.svc:7233
             - name: TEMPORAL_ENABLED
+            # The daily analysis sweep. Set EXPLICITLY here rather than left to the
+            # application.yaml default, because this is the only place an operator looks to answer
+            # "when does this agent run" — and until now the answer was "it doesn't". The agent was
+            # trigger-only: measured 2026-08-02, the openbank-devops Temporal namespace held 0
+            # schedules and 0 workflow executions, and its result table was empty — which renders
+            # as "nothing to act on" rather than "nothing has ever looked".
+            # 03:30 UTC, offset 15 minutes from finops-agent (03:00) and the control-liveness sentinel (03:15): the three share one LiteLLM gateway and
+            # one Prometheus. Six fields (second minute hour day month weekday), Quarkus not crontab.
+            - name: DEVOPS_ANALYSIS_CRON
+              value: "0 30 3 * * ?"
               value: "true"
             - name: PROMETHEUS_URL
               value: http://prometheus-operated.observability.svc:9090

--- a/openbank-infra/gitops/components/finops-agent/finops-agent.yaml
+++ b/openbank-infra/gitops/components/finops-agent/finops-agent.yaml
@@ -65,17 +65,18 @@ spec:
             - name: TEMPORAL_HOST
               value: temporal-frontend.temporal.svc:7233
             - name: TEMPORAL_ENABLED
+              value: "true"
             # The daily analysis sweep. Set EXPLICITLY here rather than left to the
-            # application.yaml default, because this is the only place an operator looks to answer
-            # "when does this agent run" — and until now the answer was "it doesn't". The agent was
-            # trigger-only: measured 2026-08-02, the openbank-finops Temporal namespace held 0
-            # schedules and 0 workflow executions, and its result table was empty — which renders
-            # as "nothing to act on" rather than "nothing has ever looked".
-            # 03:00 UTC, offset 15 minutes from the control-liveness sentinel (03:15) and devops-agent (03:30): the three share one LiteLLM gateway and
-            # one Prometheus. Six fields (second minute hour day month weekday), Quarkus not crontab.
+            # application.yaml default, because this is the only place an operator looks to
+            # answer "when does this agent run" — and until now the answer was "it doesn't".
+            # The agent was trigger-only: measured 2026-08-02, the openbank-finops Temporal
+            # namespace held 0 schedules and 0 workflow executions, and its result table was
+            # empty — which renders as "nothing to act on" rather than "nothing has looked".
+            # 03:00 UTC, offset 15 minutes from the control-liveness sentinel (03:15) and devops-agent (03:30):
+            # the three share one LiteLLM gateway and one Prometheus.
+            # Six fields (second minute hour day month weekday) — Quarkus, not crontab.
             - name: FINOPS_ANALYSIS_CRON
               value: "0 0 3 * * ?"
-              value: "true"
             - name: PROMETHEUS_URL
               value: http://prometheus-operated.observability.svc:9090
             - name: ALERTMANAGER_URL

--- a/openbank-infra/gitops/components/finops-agent/finops-agent.yaml
+++ b/openbank-infra/gitops/components/finops-agent/finops-agent.yaml
@@ -65,6 +65,16 @@ spec:
             - name: TEMPORAL_HOST
               value: temporal-frontend.temporal.svc:7233
             - name: TEMPORAL_ENABLED
+            # The daily analysis sweep. Set EXPLICITLY here rather than left to the
+            # application.yaml default, because this is the only place an operator looks to answer
+            # "when does this agent run" — and until now the answer was "it doesn't". The agent was
+            # trigger-only: measured 2026-08-02, the openbank-finops Temporal namespace held 0
+            # schedules and 0 workflow executions, and its result table was empty — which renders
+            # as "nothing to act on" rather than "nothing has ever looked".
+            # 03:00 UTC, offset 15 minutes from the control-liveness sentinel (03:15) and devops-agent (03:30): the three share one LiteLLM gateway and
+            # one Prometheus. Six fields (second minute hour day month weekday), Quarkus not crontab.
+            - name: FINOPS_ANALYSIS_CRON
+              value: "0 0 3 * * ?"
               value: "true"
             - name: PROMETHEUS_URL
               value: http://prometheus-operated.observability.svc:9090


### PR DESCRIPTION
## What

Gives `devops-agent` and `finops-agent` the daily analysis sweep their own ADRs decided and nothing ever built. Same defect and same fix as the control-liveness sentinel in #3339.

## The state this fixes

ADR-0112 states *"schedule: daily 03:00 UTC"* for finops-agent outright; ADR-0119 draws a *"schedule: durable analysis sweep"* lane for devops-agent. `RunTrigger.SCHEDULED` has been in both domain models since the services were written — nothing ever emitted it. Both were trigger-only (`POST /api/v1/<agent>/analysis/trigger`).

Measured against the live sandbox on 2026-08-02:

| namespace | Temporal schedules | workflow executions | stored results |
|---|---|---|---|
| `openbank-devops` | **0** | **0** | `findings` = 0 |
| `openbank-finops` | **0** | **0** | `anomalies` = 0 |

Probe validated against a known-positive first — `openbank-payments` and `openbank-campaign` each return 3 workflows — and the row counts came back as real zeroes from real tables, not errors.

## How this was nearly missed

`git grep -c "@Scheduled"` reports **1** for the sentinel on `main`, where the true count is **0**. The match is a *comment* explaining ADR-0160 mechanism 3. Matching `^\s*@Scheduled` separates the annotation from the prose about the annotation, and only then does the fleet read 0/0/0 — the same "a grep matches the text explaining the thing" trap this repo has been bitten by before.

## Why it survives review

An empty `findings` / `anomalies` table renders as **"nothing to act on"** — the healthiest-looking possible answer to a question nothing has ever asked. An agent that has never run is indistinguishable from one that runs and finds nothing.

## Design — deliberately identical to #3339 so the three cannot drift

- **`suspend fun`**, never a plain `@Scheduled` with `runBlocking`: that carries no Vert.x context, throws `HR000068` and aborts silently (`rules.yaml: scheduled_methods`, #2148/#2187).
- **Starts the workflow, does not wait.** A sweep runs several collect activities, threshold detectors and an LLM diagnosis *per finding*; waiting inline would pin a scheduler thread and make a slow analysis indistinguishable from a hung one.
- **The workflow id is the dedupe:** `<prefix>-scheduled-<yyyy-MM-dd>` in UTC, so a restart or a second replica gets `WorkflowExecutionAlreadyStarted` rather than a duplicate sweep spending the daily LLM budget twice. The operator path keeps `currentTimeMillis` — an id that cannot collide cannot dedupe. The trigger is part of the id so the schedule can never block a human.

## Times

```
finops-agent  03:00   (ADR-0112)
sentinel      03:15   (#3339)
devops-agent  03:30
```

The 15-minute offset is between the three **agents** specifically: they share one LiteLLM gateway and one Prometheus, and each now carries its own daily token budget. Collisions with unrelated per-service batch jobs are explicitly *not* avoided — different pods, different databases.

## Tests

Each cron IT drives the **real cron** from a `@TestProfile` shrunk to every second, rather than calling the method. A direct call passes identically against the service as it shipped, which is the entire bug. Literal strings in the profile, because a `QuarkusTestProfile` loads in a different classloader and computed overrides initialise twice.

Both modules switch `%test` to an ephemeral HTTP port, now that each has more than one `@QuarkusTest` profile and therefore more than one boot per run.

## One trap worth recording

`analysis-cron` is declared in both `@ConfigMapping` interfaces as well as the YAML. SmallRye validates a mapping prefix as a **closed set**, so a key with no matching accessor does not warn about one property — it fails the whole application at boot with `ConfigValidationException`.

Refs #2239

🤖 Generated with [Claude Code](https://claude.com/claude-code)
