### PR TITLE
fix(agent): @Path bound to a top-level function, so /mcp was never registered

### DIFF
--- a/openbank-agent-service/src/main/kotlin/com/openbank/agent/infrastructure/mcp/McpEndpoint.kt
+++ b/openbank-agent-service/src/main/kotlin/com/openbank/agent/infrastructure/mcp/McpEndpoint.kt
@@ -43,6 +43,20 @@ import org.eclipse.microprofile.config.inject.ConfigProperty
 import org.jboss.logging.Logger
 import java.time.Clock
 
+// CodeQL java/log-injection: reason/attemptedAgent/method below trace back to the request
+// (an identity claim asserted by the caller). Strip CR/LF so an attacker can't forge
+// additional log lines (log forging, CWE-117). Top-level, not a class member, so it doesn't
+// count against McpEndpoint's detekt TooManyFunctions budget.
+//
+// It lives ABOVE McpEndpoint's KDoc on purpose. A Kotlin annotation binds to the next
+// declaration, so while this function sat between `@Path("/mcp")` and `class McpEndpoint`,
+// the @Path bound to *it*: the class carried no @Path, RESTEasy never registered the
+// resource, and every POST /mcp answered 404 on a running pod while /agent/chat and
+// /api/v1/proposals were served normally. Nothing else changed shape — the class was still
+// a CDI bean, still compiled, still passed every unit test. McpEndpointRoutingIT is what
+// notices now. Never move a top-level declaration in between an annotation and its target.
+private fun String?.sanitizeForLog(): String = (this ?: "-").replace('\n', '_').replace('\r', '_')
+
 /**
  * ADR-0031 D3: the MCP surface now requires an authenticated operator (Keycloak bearer from the
  * admin-ui BFF). The bearer proves WHO is calling (a logged-in operator with an agent-capable
@@ -52,12 +66,6 @@ import java.time.Clock
  * %dev/%test profile (no inbound auth there), so the unit/contract tests are unaffected.
  */
 @Path("/mcp")
-// CodeQL java/log-injection: reason/attemptedAgent/method below trace back to the request
-// (an identity claim asserted by the caller). Strip CR/LF so an attacker can't forge
-// additional log lines (log forging, CWE-117). Top-level, not a class member, so it doesn't
-// count against McpEndpoint's detekt TooManyFunctions budget.
-private fun String?.sanitizeForLog(): String = (this ?: "-").replace('\n', '_').replace('\r', '_')
-
 @Produces(MediaType.APPLICATION_JSON)
 @Consumes(MediaType.APPLICATION_JSON)
 @RolesAllowed("ROLE_OPERATOR", "ROLE_ADMIN", "ROLE_COMPLIANCE")

--- a/openbank-agent-service/src/test/kotlin/com/openbank/agent/integration/McpEndpointRoutingIT.kt
+++ b/openbank-agent-service/src/test/kotlin/com/openbank/agent/integration/McpEndpointRoutingIT.kt
@@ -1,0 +1,66 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+// Copyright (c) OpenBank contributors. Licensed under the GNU Affero General Public License v3.0 only.
+// A commercial licence is available from the maintainers as an alternative to the AGPL-3.0.
+// See LICENSES/AGPL-3.0-only.txt or https://www.gnu.org/licenses/agpl-3.0.html for details.
+
+package com.openbank.agent.integration
+
+import com.openbank.agent.it.PostgresTestResource
+import io.quarkus.test.common.QuarkusTestResource
+import io.quarkus.test.junit.QuarkusTest
+import io.quarkus.test.security.TestSecurity
+import io.restassured.RestAssured.given
+import io.restassured.http.ContentType
+import jakarta.ws.rs.Path
+import org.hamcrest.Matchers.equalTo
+import org.hamcrest.Matchers.not
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Assertions.assertNotNull
+import org.junit.jupiter.api.Test
+
+/**
+ * The MCP surface is only real if RESTEasy actually registered it. `McpEndpointIdentityTest`
+ * calls the class directly and therefore cannot tell a served route from an unserved one — it
+ * passed for the entire time POST /mcp answered **404** on the deployed pod, because
+ * `@Path("/mcp")` had bound to a top-level function that sat between the annotation and the
+ * class. Everything else about the class was intact: it compiled, it was a CDI bean, its unit
+ * tests were green, and its siblings (`/agent/chat`, `/api/v1/proposals`) served normally, so
+ * the admin-ui MCP screen rendered "agent-service is not deployed" against a healthy service.
+ *
+ * These two cases are the missing layer: one asserts the annotation is on the class, the other
+ * drives the route over HTTP through the booted app. Both fail against the pre-fix source.
+ */
+@QuarkusTest
+@QuarkusTestResource(PostgresTestResource::class, restrictToAnnotatedClass = true)
+class McpEndpointRoutingIT {
+
+    @Test
+    fun `McpEndpoint carries the JAX-RS Path annotation on the class itself`() {
+        val path = com.openbank.agent.infrastructure.mcp.McpEndpoint::class.java.getAnnotation(Path::class.java)
+        assertNotNull(path, "@Path is missing from McpEndpoint — the resource will not be registered")
+        assertEquals("/mcp", path.value)
+    }
+
+    @Test
+    @TestSecurity(user = "operator", roles = ["ROLE_OPERATOR"])
+    fun `POST mcp initialize is served, not 404`() {
+        given()
+            .contentType(ContentType.JSON)
+            .header("X-Agent-Id", "ui-assistant")
+            .header("X-Agent-Plane", "control")
+            .body(
+                """
+                {"jsonrpc":"2.0","id":1,"method":"initialize",
+                 "params":{"protocolVersion":"2024-11-05",
+                           "clientInfo":{"name":"routing-it","version":"1.0.0"},
+                           "capabilities":{}}}
+                """.trimIndent(),
+            )
+            .`when`().post("/mcp")
+            .then()
+            // The assertion that matters is "the route exists". A policy or charter decision may
+            // legitimately shape the body, but an unregistered resource can only ever be 404.
+            .statusCode(not(equalTo(404)))
+            .body("jsonrpc", equalTo("2.0"))
+    }
+}


### PR DESCRIPTION
## What

`agent-service` has never served `POST /mcp`. `@Path("/mcp")` was bound to a top-level function instead of the class.

## Why

A Kotlin annotation binds to the **next declaration**. A top-level `sanitizeForLog()` sat between `@Path("/mcp")` and `class McpEndpoint`, so the `@Path` bound to the function; the class carried none, RESTEasy never registered the resource, and every request answered **404**.

Proof from the running pod (`agent-service-...`, image `sandbox-b52f989b`, i.e. today's `main`), asking the app about itself:

```
$ wget -O- http://127.0.0.1:8085/q/openapi | grep '^  /'
  /agent/chat:
  /agent/models:
  /agent/oversight/run:
  /api/v1/admin/agents/halt:
  ...
  /api/v1/proposals:
```

`/mcp` is absent. And the discriminator that rules out "wrong method" or "auth":

```
/agent/models -> 401   (registered, needs a token)
/agent/chat   -> 405   (registered, wrong method)
/mcp          -> 404   (POST or GET — not registered)
```

Nothing about this was visible from the outside. The class still compiled, was still a CDI bean, and `McpEndpointIdentityTest` still passed — it calls the class directly, so it cannot tell a served route from an unserved one. The admin-ui MCP screen maps *any* error to "not deployed", so a healthy service with a 404 route rendered as **"Agent-service (MCP) is not deployed in this environment"**.

## How

Move the top-level function above the class's KDoc, so `@Path` sits directly on `class McpEndpoint`. No behaviour change beyond the route existing. The comment on that function now says why it must stay there.

## Verification

New `McpEndpointRoutingIT` — the layer that was missing — with both halves falsified against the pre-fix source (read from the JUnit XML, not the console):

```
McpEndpoint carries the JAX-RS Path annotation on the class itself  FAIL
  → @Path is missing from McpEndpoint — the resource will not be registered ==> expected: not <null>
POST mcp initialize is served, not 404                             FAIL
  → Expected status code not <404> but was <404>
```

After the fix: `tests=2 failures=0 errors=0`. The HTTP case asserts only "not 404" — a policy or charter decision may legitimately shape the body, but an unregistered resource can only ever be 404.

Full local gate: `detekt`, `ktlintCheck`, `test`, `quarkusBuild`.

## Not in scope

Three sibling defects found in the same walk, each with its own PR: the admin-ui BFF sends no bearer to sanctions/security ([#3336](https://github.com/JiRaska/open-bank-oss/pull/3336)), `security-scanner` never runs Flyway ([#3350](https://github.com/JiRaska/open-bank-oss/pull/3350)), and `fraud-service`'s ONNX initializer 500s its read endpoints.

## Linked issues

N/A — defect found by walking the deployed console; no issue filed.
