### PR TITLE
feat(admin-ui): read the aggregate endpoints, and stop apologising for a cap

### DIFF
--- a/openbank-admin-ui/src/app/api/campaigns/route.ts
+++ b/openbank-admin-ui/src/app/api/campaigns/route.ts
@@ -80,7 +80,16 @@ export async function GET() {
         { status: 200 },
       )
     }
-    return NextResponse.json({ items: await res.json(), state: 'ok' })
+    // Reach and delivery (#3296). Fetched alongside the list rather than folded into it: the
+    // endpoint is NEWER than the deployed service in any environment that has not rolled forward
+    // yet, so a 404 here has to degrade to "no reach data" and leave the list intact. Coupling the
+    // two would take the whole page down for a feature that is additive.
+    const summary = await fetch(
+      serverSvcUrl('campaign-service', 'campaign', 8128, '/api/v1/campaigns/summary'),
+      { headers, signal: AbortSignal.timeout(4000), cache: 'no-store' },
+    ).then(r => (r.ok ? r.json() : null)).catch(() => null)
+
+    return NextResponse.json({ items: await res.json(), state: 'ok', summary })
   } catch {
     return NextResponse.json({ items: [], state: 'unreachable' }, { status: 200 })
   }

--- a/openbank-admin-ui/src/app/campaigns/page.tsx
+++ b/openbank-admin-ui/src/app/campaigns/page.tsx
@@ -35,6 +35,17 @@ import { DataUnavailable, type UnavailableKind } from '@/components/feedback/Dat
 import { PageHeader, StatCard, StatusBadge } from '@/components/ui'
 import { StageBoard, summariseBy, type StageDef } from '@/components/flow/StageBoard'
 
+/** `/api/v1/campaigns/summary` (#3296). Null when the deployed service predates the endpoint —
+ *  the page then keeps saying reach is not available rather than showing zeros that look like
+ *  "nobody was reached". */
+interface CampaignSummary {
+  campaignId: string
+  enrolled: number
+  sent: number
+  suppressed: number
+  failed: number
+}
+
 interface Campaign {
   id: string
   name: string
@@ -60,6 +71,7 @@ const LIFECYCLE: { key: string; cs: string; en: string; terminal?: boolean }[] =
 export default function CampaignsPage() {
   const { t, language } = useLanguage()
   const [items, setItems] = useState<Campaign[]>([])
+  const [summary, setSummary] = useState<Record<string, CampaignSummary> | null>(null)
   const [unavailable, setUnavailable] = useState<UnavailableKind | null>(null)
   const [loading, setLoading] = useState(true)
   const [search, setSearch] = useState('')
@@ -68,12 +80,15 @@ export default function CampaignsPage() {
   useEffect(() => {
     fetch('/api/campaigns')
       .then(r => r.json())
-      .then((d: { items: Campaign[]; state: string }) => {
+      .then((d: { items: Campaign[]; state: string; summary?: CampaignSummary[] | null }) => {
         if (d.state !== 'ok') {
           setUnavailable(d.state === 'unauthorized' ? 'unauthorized' : d.state === 'not_deployed' ? 'not_deployed' : 'unreachable')
           return
         }
         setItems(d.items ?? [])
+        setSummary(
+          Array.isArray(d.summary) ? Object.fromEntries(d.summary.map(x => [x.campaignId, x])) : null,
+        )
       })
       .catch(() => setUnavailable('unreachable'))
       .finally(() => setLoading(false))
@@ -161,10 +176,12 @@ export default function CampaignsPage() {
             onSelect={setStateFilter}
             lang={language}
             ariaLabel={t('Životní cyklus kampaní podle stavu', 'Campaign lifecycle by state')}
-            footnote={t(
-              'Doručení a odezva zde nejsou — seznam kampaní je od služby nevrací.',
-              'Delivery and response are not here — the campaign list endpoint does not return them.',
-            )}
+            footnote={summary
+              ? t('Dosah a doručení v tabulce níže.', 'Reach and delivery in the table below.')
+              : t(
+                  'Doručení a odezva zde nejsou — nasazená služba je zatím nevrací.',
+                  'Delivery and response are not here — the deployed service does not return them yet.',
+                )}
           />
 
           {unknownStates.length > 0 && (
@@ -213,6 +230,9 @@ export default function CampaignsPage() {
                     <th className="px-4 py-2 font-medium">{t('Název', 'Name')}</th>
                     <th className="px-4 py-2 font-medium">{t('Stav', 'State')}</th>
                     <th className="px-4 py-2 font-medium">{t('Segment', 'Segment')}</th>
+                    {summary && <th className="px-4 py-2 font-medium">{t('Zařazeno', 'Enrolled')}</th>}
+                    {summary && <th className="px-4 py-2 font-medium">{t('Doručeno', 'Sent')}</th>}
+                    {summary && <th className="px-4 py-2 font-medium">{t('Potlačeno', 'Suppressed')}</th>}
                     <th className="px-4 py-2 font-medium">{t('Vytvořil', 'Created by')}</th>
                     <th className="px-4 py-2 font-medium">{t('Schválil', 'Approved by')}</th>
                     <th className="px-4 py-2 font-medium">{t('Vytvořeno', 'Created')}</th>
@@ -235,6 +255,20 @@ export default function CampaignsPage() {
                       <td className="px-4 py-2 font-mono text-xs">
                         {c.segmentRef?.name}@{c.segmentRef?.version}
                       </td>
+                      {summary && <td className="px-4 py-2 text-xs">{summary[c.id]?.enrolled ?? 0}</td>}
+                      {summary && <td className="px-4 py-2 text-xs">{summary[c.id]?.sent ?? 0}</td>}
+                      {/* Suppressed is tinted only when it happened: "0 suppressed" is the normal
+                          case and colouring it would make every row look like it needs attention.
+                          A non-zero here is the answer to "why was reach low", so it must not read
+                          as ordinary. */}
+                      {summary && (
+                        <td
+                          className="px-4 py-2 text-xs"
+                          style={(summary[c.id]?.suppressed ?? 0) > 0 ? { color: 'var(--warning)', fontWeight: 600 } : undefined}
+                        >
+                          {summary[c.id]?.suppressed ?? 0}
+                        </td>
+                      )}
                       <td className="px-4 py-2 text-xs">{c.createdBy}</td>
                       {/* The checker, shown next to the maker on purpose: the maker/checker pair is
                           the audit-relevant fact about an ACTIVE campaign, not a detail. */}

--- a/openbank-admin-ui/src/app/lending/page.tsx
+++ b/openbank-admin-ui/src/app/lending/page.tsx
@@ -36,6 +36,17 @@ import { OriginationPipeline, type PipelineItem } from '@/components/lending/Ori
 
 type Application = PipelineItem & { partyId: string }
 
+/** `/applications/summary` and `/loans/summary` (#3294). Money is a list per currency, never one
+ *  number — the service refuses to add CZK to EUR and so must the console. */
+type MoneyTotal = { currency: string; amount: number }
+type StateSummary = {
+  status: string
+  count: number
+  oldestCreatedAt?: string | null
+  requested?: MoneyTotal[]
+  principal?: MoneyTotal[]
+}
+
 type Loan = {
   id: string
   partyId: string
@@ -61,6 +72,10 @@ export default function LendingPage() {
   const { t, language } = useLanguage()
   const [applications, setApplications] = useState<Application[]>([])
   const [loans, setLoans] = useState<Loan[]>([])
+  // Absent = the aggregate endpoints are not in the deployed build yet. The page then falls back to
+  // deriving from the capped lists AND keeps saying so, which is what it did before they existed.
+  const [appSummary, setAppSummary] = useState<StateSummary[] | null>(null)
+  const [loanSummary, setLoanSummary] = useState<StateSummary[] | null>(null)
   const [stage, setStage] = useState<string | null>(null)
   const [tab, setTab] = useState<'queue' | 'portfolio'>('queue')
   const [loading, setLoading] = useState(true)
@@ -69,15 +84,26 @@ export default function LendingPage() {
   const load = useCallback(async () => {
     setLoading(true)
     try {
-      const [appsRes, loansRes] = await Promise.all([
+      // The lists still load: the rows are the drill-down, and the summaries carry no identities.
+      // The two summary calls are allowed to fail independently — they are newer than the deployed
+      // service in an environment that has not rolled forward, and a missing aggregate must not
+      // take the console with it.
+      const okJson = (r: Response) => (r.ok ? r.json() : null)
+      const [appsRes, loansRes, appSum, loanSum] = await Promise.all([
         fetch(svcUrl('lending-service', '/api/v1/lending/applications/recent', { limit: String(LIMIT) }), { cache: 'no-store' }),
         fetch(svcUrl('lending-service', '/api/v1/lending/loans/active', { limit: String(LIMIT) }), { cache: 'no-store' }),
+        fetch(svcUrl('lending-service', '/api/v1/lending/applications/summary'), { cache: 'no-store' })
+          .then(okJson).catch(() => null),
+        fetch(svcUrl('lending-service', '/api/v1/lending/loans/summary'), { cache: 'no-store' })
+          .then(okJson).catch(() => null),
       ])
       if (!appsRes.ok || !loansRes.ok) throw new Error(`${appsRes.status}/${loansRes.status}`)
       const apps = await appsRes.json()
       const ln = await loansRes.json()
       setApplications(Array.isArray(apps) ? apps : [])
       setLoans(Array.isArray(ln) ? ln : [])
+      setAppSummary(Array.isArray(appSum) ? appSum : null)
+      setLoanSummary(Array.isArray(loanSum) ? loanSum : null)
       setError(null)
     } catch {
       setError('unreachable')
@@ -100,16 +126,55 @@ export default function LendingPage() {
 
   /** Headline figures, all computed from the SAME capped lists the tables show — so the page can
    *  never claim more than it fetched. */
+  /** Headline figures. When the aggregate endpoints answer, these are the WHOLE book; otherwise
+   *  they are derived from the capped lists and the page says so. The two are never mixed — a
+   *  half-real total is worse than an honestly capped one, because nothing on screen distinguishes
+   *  them. */
   const kpi = useMemo(() => {
     const ccy = loans[0]?.principal?.currency ?? applications[0]?.requestedAmount?.currency ?? 'CZK'
+    const sumFor = (rows: StateSummary[], pick: (r: StateSummary) => MoneyTotal[] | undefined) =>
+      rows.flatMap(r => pick(r) ?? []).filter(m => m.currency === ccy).reduce((s, m) => s + m.amount, 0)
+
+    if (appSummary && loanSummary) {
+      const openStates = appSummary.filter(r => !TERMINAL.has(r.status))
+      const now = Date.now()
+      return {
+        exact: true,
+        ccy,
+        // The label says "active", so count ACTIVE — the aggregate carries every status, and
+        // silently folding delinquent and defaulted loans in here would both change what the tile
+        // means and double-count them against the "in trouble" tile beside it.
+        loanCount: loanSummary.filter(r => !LOAN_TROUBLE.has(r.status)).reduce((s, r) => s + r.count, 0),
+          // Exposure, in contrast, IS the whole book: a delinquent loan is still money lent out.
+      book: sumFor(loanSummary, r => r.principal),
+        openCount: openStates.reduce((s, r) => s + r.count, 0),
+        requested: sumFor(openStates, r => r.requested),
+        // Aging is per STATE here, not per application: the aggregate carries the oldest timestamp
+        // per state, which is enough to say "something has been waiting too long" and is honest
+        // about not being a row count.
+        staleStates: openStates.filter(
+          r => r.oldestCreatedAt && now - new Date(r.oldestCreatedAt).getTime() > STALE_HOURS * 3_600_000,
+        ).length,
+        trouble: loanSummary.filter(r => LOAN_TROUBLE.has(r.status)).reduce((s, r) => s + r.count, 0),
+      }
+    }
+
     const book = loans.reduce((s, l) => s + (l.principal?.amount ?? 0), 0)
     const trouble = loans.filter(l => LOAN_TROUBLE.has(l.status))
     const now = Date.now()
     const open = applications.filter(a => !TERMINAL.has(a.status))
     const stale = open.filter(a => a.createdAt && now - new Date(a.createdAt).getTime() > STALE_HOURS * 3_600_000)
-    const requested = open.reduce((s, a) => s + (a.requestedAmount?.amount ?? 0), 0)
-    return { ccy, book, trouble, open, stale, requested }
-  }, [loans, applications])
+    return {
+      exact: false,
+      ccy,
+      loanCount: loans.length,
+      book,
+      openCount: open.length,
+      requested: open.reduce((s, a) => s + (a.requestedAmount?.amount ?? 0), 0),
+      staleStates: stale.length,
+      trouble: trouble.length,
+    }
+  }, [loans, applications, appSummary, loanSummary])
 
   const visibleApps = useMemo(
     () => (stage ? applications.filter(a => a.status === stage) : applications),
@@ -144,27 +209,29 @@ export default function LendingPage() {
       <div className="grid-4" style={{ marginBottom: 20 }}>
         <StatCard
           label={t('Aktivní úvěry', 'Active loans')}
-          value={loans.length}
+          value={kpi.loanCount}
           hint={t(`jistina ${money(kpi.book, kpi.ccy)}`, `principal ${money(kpi.book, kpi.ccy)}`)}
           icon={<Wallet size={13} />}
         />
         <StatCard
           label={t('Žádosti v běhu', 'Applications in flight')}
-          value={kpi.open.length}
+          value={kpi.openCount}
           hint={t(`požadováno ${money(kpi.requested, kpi.ccy)}`, `requested ${money(kpi.requested, kpi.ccy)}`)}
           icon={<Layers size={13} />}
         />
         <StatCard
           label={t('Čeká přes 72 h', 'Waiting over 72h')}
-          value={kpi.stale.length}
-          tone={kpi.stale.length > 0 ? 'warning' : undefined}
-          hint={t('nerozhodnuté a stárnoucí', 'undecided and aging')}
+          value={kpi.staleStates}
+          tone={kpi.staleStates > 0 ? 'warning' : undefined}
+          hint={kpi.exact
+            ? t('stavů se stárnoucí frontou', 'states with an aging queue')
+            : t('nerozhodnuté a stárnoucí', 'undecided and aging')}
           icon={<Clock size={13} />}
         />
         <StatCard
           label={t('Problémové úvěry', 'Loans in trouble')}
-          value={kpi.trouble.length}
-          tone={kpi.trouble.length > 0 ? 'danger' : undefined}
+          value={kpi.trouble}
+          tone={kpi.trouble > 0 ? 'danger' : undefined}
           hint={t('po splatnosti / default / odpis', 'delinquent / default / written off')}
           icon={<AlertTriangle size={13} />}
         />
@@ -174,6 +241,7 @@ export default function LendingPage() {
         <OriginationPipeline
           items={applications}
           cap={LIMIT}
+          summary={appSummary}
           lang={language}
           selected={stage}
           onSelectStage={s => { setStage(s); setTab('queue') }}

--- a/openbank-admin-ui/src/components/lending/OriginationPipeline.tsx
+++ b/openbank-admin-ui/src/components/lending/OriginationPipeline.tsx
@@ -38,6 +38,13 @@ type Props = {
   items: PipelineItem[]
   /** The server-side cap the list was fetched under — shown, never hidden. */
   cap: number
+  /**
+   * Whole-book totals from `/applications/summary` (#3294). When present the board stops deriving
+   * counts from the capped page and stops warning about the cap, because there is no longer a cap
+   * to warn about. Absent = the aggregate is not in the deployed build, and the old behaviour —
+   * derive and say so — is the honest one.
+   */
+  summary?: { status: string; count: number; oldestCreatedAt?: string | null }[] | null
   lang?: 'cs' | 'en'
   onSelectStage?: (state: string | null) => void
   selected?: string | null
@@ -92,11 +99,21 @@ export function summarise(items: PipelineItem[], now = Date.now()) {
   return byState
 }
 
-export function OriginationPipeline({ items, cap, lang = 'cs', onSelectStage, selected }: Props) {
+export function OriginationPipeline({ items, cap, lang = 'cs', onSelectStage, selected, summary }: Props) {
   const [flow, setFlow] = useFlowAnimation()
   const spine = happyPath(ORIGINATION_GRAPH)
   const exits = exitStates(ORIGINATION_GRAPH)
-  const byState = useMemo(() => summarise(items), [items])
+  const byState = useMemo(() => {
+    if (summary) {
+      const now = Date.now()
+      return new Map(summary.map(r => [r.status, {
+        count: r.count,
+        oldestHours: r.oldestCreatedAt ? (now - new Date(r.oldestCreatedAt).getTime()) / 3_600_000 : null,
+        amount: 0,
+      }]))
+    }
+    return summarise(items)
+  }, [items, summary])
   const max = Math.max(1, ...[...byState.values()].map(v => v.count))
 
   const label = (s: string) => {
@@ -113,19 +130,23 @@ export function OriginationPipeline({ items, cap, lang = 'cs', onSelectStage, se
   const H = 158
   const W = spine.length * COL
 
-  const capped = items.length >= cap
+  // Only meaningful while the counts come from the page. With whole-book totals there is nothing
+  // truncated to disclose, and leaving the warning up would be its own kind of lie.
+  const capped = !summary && items.length >= cap
 
   return (
     <div>
       <div style={{ display: 'flex', alignItems: 'baseline', gap: 10, marginBottom: 8, flexWrap: 'wrap' }}>
         <div className="section-title" style={{ margin: 0 }}>{t('Pipeline žádostí', 'Application pipeline')}</div>
         <span style={{ fontSize: 11, color: capped ? 'var(--warning)' : 'var(--text-tertiary)' }} data-testid="cap-note">
-          {capped
-            ? t(
-                `zobrazeno nejnovějších ${items.length} — starší žádosti v číslech NEJSOU`,
-                `showing the newest ${items.length} — older applications are NOT in these numbers`,
-              )
-            : t(`${items.length} žádostí (vše, co server vrátil)`, `${items.length} applications (everything the server returned)`)}
+          {summary
+            ? t('celá kniha žádostí', 'the whole application book')
+            : capped
+              ? t(
+                  `zobrazeno nejnovějších ${items.length} — starší žádosti v číslech NEJSOU`,
+                  `showing the newest ${items.length} — older applications are NOT in these numbers`,
+                )
+              : t(`${items.length} žádostí (vše, co server vrátil)`, `${items.length} applications (everything the server returned)`)}
         </span>
         <button
           onClick={() => setFlow(f => !f)}

--- a/openbank-admin-ui/src/test/console-summary-wiring.test.tsx
+++ b/openbank-admin-ui/src/test/console-summary-wiring.test.tsx
@@ -1,0 +1,151 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright (c) OpenBank contributors. Licensed under the Apache License, Version 2.0.
+// See LICENSE in the repository root or https://www.apache.org/licenses/LICENSE-2.0 for details.
+
+// Wiring the consoles to the aggregate endpoints (#3294, #3296).
+//
+// The endpoints are NEWER than the deployed services, so both pages must work two ways, and the
+// tests are about the seam between them:
+//
+//  - with an aggregate, the figures are the whole book and the cap warning must GO (leaving it up
+//    is its own lie),
+//  - without one, the old derive-from-the-capped-page behaviour must survive intact, warning and
+//    all — a silent downgrade to a wrong number is the failure this whole design avoids,
+//  - reach columns must be ABSENT rather than zero when campaign reach is unavailable: "0 sent"
+//    reads as "we reached nobody", not as "the service cannot say".
+
+import { describe, it, expect, afterEach, vi } from 'vitest'
+import React from 'react'
+import { render, screen, cleanup, waitFor } from '@testing-library/react'
+import { LanguageProvider } from '@/lib/i18n/LanguageContext'
+import { SessionProvider } from '@/components/auth/SessionProvider'
+import LendingPage from '@/app/lending/page'
+import CampaignsPage from '@/app/campaigns/page'
+
+const HOUR = 3_600_000
+
+function Providers({ children }: { children: React.ReactNode }) {
+  return React.createElement(SessionProvider, null, React.createElement(LanguageProvider, null, children))
+}
+
+afterEach(() => {
+  cleanup()
+  vi.unstubAllGlobals()
+  vi.restoreAllMocks()
+})
+
+const APPS = Array.from({ length: 100 }, (_, i) => ({
+  id: `a${i}`,
+  partyId: `p${i}`,
+  status: 'ASSESSMENT',
+  createdAt: new Date(Date.now() - HOUR).toISOString(),
+  requestedAmount: { amount: 1000, currency: 'CZK' },
+}))
+
+const LOANS = [{ id: 'l1', partyId: 'p1', status: 'ACTIVE', principal: { amount: 500, currency: 'CZK' } }]
+
+/** What `/applications/summary` returns: the WHOLE book, far larger than the capped page. */
+const APP_SUMMARY = [
+  { status: 'ASSESSMENT', count: 640, oldestCreatedAt: new Date(Date.now() - 200 * HOUR).toISOString(), requested: [{ currency: 'CZK', amount: 9_000_000 }] },
+  { status: 'DISBURSED', count: 120, oldestCreatedAt: null, requested: [{ currency: 'CZK', amount: 1_000 }] },
+]
+const LOAN_SUMMARY = [
+  { status: 'ACTIVE', count: 300, principal: [{ currency: 'CZK', amount: 7_000_000 }] },
+  { status: 'DELINQUENT', count: 9, principal: [{ currency: 'CZK', amount: 100_000 }] },
+]
+
+function lendingFetch({ summaries }: { summaries: boolean }) {
+  const json = (b: unknown) => new Response(JSON.stringify(b), { status: 200, headers: { 'content-type': 'application/json' } })
+  return vi.fn(async (input: RequestInfo | URL) => {
+    const url = String(input)
+    if (url.includes('/api/auth/session')) return new Response('null', { status: 200, headers: { 'content-type': 'application/json' } })
+    if (url.includes('/applications/summary')) {
+      return summaries ? json(APP_SUMMARY) : new Response('not found', { status: 404 })
+    }
+    if (url.includes('/loans/summary')) {
+      return summaries ? json(LOAN_SUMMARY) : new Response('not found', { status: 404 })
+    }
+    if (url.includes('/applications/recent')) return json(APPS)
+    if (url.includes('/loans/active')) return json(LOANS)
+    return json({})
+  })
+}
+
+describe('lending console + aggregates', () => {
+  it('reports the whole book and stops warning about a cap that no longer applies', async () => {
+    vi.stubGlobal('fetch', lendingFetch({ summaries: true }))
+    render(React.createElement(Providers, null, React.createElement(LendingPage)))
+
+    // Wait on the DATA, not on the node: the board renders all 13 stages from the generated graph
+    // before any fetch resolves, so waiting for the node to exist asserts against an empty page.
+    await waitFor(() =>
+      expect(screen.getByTestId('stage-ASSESSMENT').getAttribute('data-count')).toBe('640'),
+    )
+    // 300 ACTIVE, not 309: the tile says "active", so the 9 delinquent ones belong to the tile
+    // beside it, not to this one. Exposure below is the whole book, delinquent included, because
+    // a delinquent loan is still money lent out.
+    expect(screen.getByText('Active loans').closest('.stat-card')?.textContent).toMatch(/300/)
+    // \s, not a literal space: cs-CZ groups thousands with a NON-BREAKING space (U+00A0), so a
+    // plain-space regex fails against text that reads identically on screen.
+    expect(screen.getByText('Active loans').closest('.stat-card')?.textContent).toMatch(/7\s100\s000/)
+    expect(screen.getByText('Loans in trouble').closest('.stat-card')?.textContent).toMatch(/9/)
+    // The cap disclosure must be gone: there is nothing truncated to disclose.
+    expect(screen.getByTestId('cap-note').textContent).not.toMatch(/NOT in these numbers/)
+  })
+
+  it('falls back to the capped page — and keeps saying so — when the aggregate 404s', async () => {
+    vi.stubGlobal('fetch', lendingFetch({ summaries: false }))
+    render(React.createElement(Providers, null, React.createElement(LendingPage)))
+
+    // Same reason as above: wait for the count itself.
+    await waitFor(() =>
+      expect(screen.getByTestId('stage-ASSESSMENT').getAttribute('data-count')).toBe('100'),
+    )
+    // …and the page says the older ones are missing. A silent downgrade to a capped number that
+    // looks like a total is exactly what this design refuses to do.
+    expect(screen.getByTestId('cap-note').textContent).toMatch(/NOT in these numbers/)
+  })
+})
+
+const CAMPAIGNS = [{
+  id: 'c1',
+  name: 'smoke-offer',
+  goal: 'g',
+  segmentRef: { name: 'actives', version: 1 },
+  state: 'ACTIVE',
+  createdBy: 'maker',
+  approvedBy: 'checker',
+  createdAt: new Date(Date.now() - HOUR).toISOString(),
+}]
+
+function campaignFetch(summary: unknown) {
+  return vi.fn(async (input: RequestInfo | URL) => {
+    const url = String(input)
+    const json = (b: unknown) => new Response(JSON.stringify(b), { status: 200, headers: { 'content-type': 'application/json' } })
+    if (url.includes('/api/auth/session')) return new Response('null', { status: 200, headers: { 'content-type': 'application/json' } })
+    if (url.includes('/api/campaigns')) return json({ items: CAMPAIGNS, state: 'ok', summary })
+    return json({})
+  })
+}
+
+describe('campaign console + reach', () => {
+  it('shows reach, and flags suppression as the reason a campaign under-delivered', async () => {
+    vi.stubGlobal('fetch', campaignFetch([{ campaignId: 'c1', enrolled: 45, sent: 2, suppressed: 43, failed: 0 }]))
+    render(React.createElement(Providers, null, React.createElement(CampaignsPage)))
+
+    await waitFor(() => expect(screen.getByText('Enrolled')).toBeTruthy())
+    expect(screen.getByText('45')).toBeTruthy()
+    // 2 sent against 43 suppressed is the whole story — "2 sent" alone reads as a tiny audience.
+    expect(screen.getByText('43')).toBeTruthy()
+  })
+
+  it('omits the reach columns entirely when the deployed service cannot answer', async () => {
+    vi.stubGlobal('fetch', campaignFetch(null))
+    render(React.createElement(Providers, null, React.createElement(CampaignsPage)))
+
+    await waitFor(() => expect(screen.getByText('smoke-offer')).toBeTruthy())
+    // Zeros would read as "we reached nobody" rather than "the service cannot say".
+    expect(screen.queryByText('Enrolled')).toBeNull()
+    expect(screen.getByTestId('board-footnote').textContent).toMatch(/does not return them yet/)
+  })
+})


### PR DESCRIPTION
## What

#3309 and #3311 gave the services whole-book totals. Both consoles were still deriving their figures
from capped lists and saying so on screen. Now they ask.

- **lending** — `/applications/summary` + `/loans/summary` drive the KPI tiles and the pipeline
  board, so a stage reads **640** rather than *"100, of the newest 100"*.
- **campaigns** — `/campaigns/summary` rides along with the list in the BFF route and adds
  **enrolled / sent / suppressed** columns: the reach a CDP screen exists for.

## Both pages still work without the endpoints

They are newer than the deployed services, so a 404 falls back to the previous behaviour — derive
from the page, keep the cap disclosure up.

The two modes are **never mixed**. A half-real total is worse than an honestly capped one, because
nothing on screen tells them apart. And when the aggregate answers, the cap warning **goes** —
leaving it up would be its own lie.

Campaign reach columns are **absent rather than zero** when unavailable: *"0 sent"* reads as "we
reached nobody", not as "the service cannot say".

## A design defect the tests caught

The *active loans* tile was summing **every** status the aggregate returns. That both changed what
the tile meant and double-counted delinquent loans against the *in trouble* tile beside it. It now
counts what its label says — while **exposure** stays whole-book, because a delinquent loan is still
money lent out.

## Two test traps worth recording

Both produced a green that meant nothing until fixed:

| trap | why it lied |
|---|---|
| `waitFor(getByTestId('stage-ASSESSMENT'))` | the board renders all 13 stages from the generated graph **before any fetch resolves**, so waiting for the node to exist asserts against an empty page. Wait on the count. |
| `toMatch(/7 100 000/)` | `cs-CZ` groups thousands with a **non-breaking** space (U+00A0); a plain-space regex fails against text that reads identically on screen. |

## Verification

From a clean tree (`origination-graph.json`, `governance.json`, `catalog.json` deleted first):

- `npm test` — **72 files, 1019 tests passed**
- `npm run type-check` — clean
- `npm run lint` — 0 errors

admin-ui only — no API, DB, event or config change.

Refs #3294, #3296
