### PR TITLE
fix(admin-ui): make the campaign builder legible to a marketer

### DIFF
--- a/openbank-admin-ui/src/app/campaigns/new/page.tsx
+++ b/openbank-admin-ui/src/app/campaigns/new/page.tsx
@@ -68,6 +68,23 @@ export default function NewCampaignPage() {
     MARKETING_PRODUCT_OFFER: t('Nabídka produktu', 'Product offer'),
   }
 
+  // The template declares `offerTitle`; a marketer writes a headline. Same field, and only one of
+  // those two words belongs on a screen someone uses to write an email.
+  const variableLabels: Record<string, { label: string; example: string }> = {
+    offerTitle: {
+      label: t('Titulek', 'Headline'),
+      example: t('Spoření s úrokem 4 %', 'Savings at 4% interest'),
+    },
+    offerText: {
+      label: t('Text nabídky', 'Offer text'),
+      example: t('Jedna věta, proč to stojí za to.', 'One sentence on why it is worth it.'),
+    },
+    ctaText: {
+      label: t('Text tlačítka', 'Button text'),
+      example: t('Chci spořit', 'Start saving'),
+    },
+  }
+
   useEffect(() => {
     fetch('/api/segments')
       .then(r => r.json())
@@ -153,8 +170,6 @@ export default function NewCampaignPage() {
       .finally(() => setSaving(false))
   }
 
-  const field = 'w-full rounded-md border bg-transparent px-3 py-1.5 text-sm'
-
   return (
     <div className="space-y-6">
       <Link href="/campaigns" className="inline-flex items-center gap-1 text-sm hover:underline">
@@ -170,39 +185,77 @@ export default function NewCampaignPage() {
         icon={<Megaphone className="h-6 w-6" />}
       />
 
-      <section className="max-w-3xl space-y-4">
-        <div className="grid gap-4 sm:grid-cols-2">
-          <div className="space-y-1">
-            <label htmlFor="c-name" className="text-sm font-medium">{t('Název', 'Name')}</label>
-            <input id="c-name" className={field} value={name} onChange={e => setName(e.target.value)} />
-          </div>
-          <div className="space-y-1">
-            <label htmlFor="c-goal" className="text-sm font-medium">{t('Cíl', 'Goal')}</label>
-            <input id="c-goal" className={field} value={goal} onChange={e => setGoal(e.target.value)} />
-          </div>
+      {/* A marketer names a campaign and picks who gets it. Both were `<label>` + bare box, which is
+          how a database table looks, not how a campaign brief does. The name behaves like a document
+          title; the audience is a set of tiles carrying its plain-language rule and its reach, which
+          is the choice being made — a dropdown hides exactly the number the choice turns on. */}
+      <section className="max-w-3xl space-y-8">
+        <div>
+          <input
+            id="c-name"
+            className="input w-full"
+            style={{ fontSize: '1.5rem', fontWeight: 600, padding: '0.7rem 0.9rem' }}
+            placeholder={t('Pojmenujte kampaň', 'Name this campaign')}
+            value={name}
+            onChange={e => setName(e.target.value)}
+          />
+          <input
+            id="c-goal"
+            className="input w-full"
+            style={{ marginTop: '0.75rem' }}
+            placeholder={t(
+              'Čeho má dosáhnout? Třeba „víc lidí si založí spoření"',
+              'What should it achieve? e.g. "more people open a savings account"',
+            )}
+            value={goal}
+            onChange={e => setGoal(e.target.value)}
+          />
         </div>
 
-        <div className="space-y-1">
-          <label htmlFor="c-segment" className="text-sm font-medium">{t('Komu', 'Audience')}</label>
-          <select
-            id="c-segment"
-            className={field}
-            value={segment}
-            onChange={e => {
-              setSegment(e.target.value)
-              previewReach(e.target.value)
-            }}
-          >
-            <option value="">{t('Vyberte segment…', 'Choose a segment…')}</option>
-            {segments.map(s => (
-              <option key={`${s.name}@${s.version}`} value={`${s.name}@${s.version}`}>
-                {s.name} v{s.version} — {s.rules.join('; ')}
-              </option>
-            ))}
-          </select>
+        <div>
+          <h2 className="text-sm font-semibold" style={{ marginBottom: '0.75rem' }}>
+            {t('Komu to půjde', 'Who gets it')}
+          </h2>
+          <div className="grid gap-3 sm:grid-cols-2">
+            {segments.map(s => {
+              const ref = `${s.name}@${s.version}`
+              const active = segment === ref
+              return (
+                <button
+                  key={ref}
+                  type="button"
+                  data-segment={ref}
+                  data-selected={active ? 'true' : 'false'}
+                  onClick={() => {
+                    setSegment(ref)
+                    previewReach(ref)
+                  }}
+                  className="rounded-xl border text-left"
+                  style={{
+                    padding: '0.9rem 1rem',
+                    background: 'var(--surface)',
+                    borderColor: active ? 'var(--accent)' : 'var(--border)',
+                    boxShadow: active ? '0 0 0 1px var(--accent)' : undefined,
+                  }}
+                >
+                  <p className="text-sm font-semibold">{s.name}</p>
+                  <p className="text-xs text-muted-foreground" style={{ marginTop: '0.25rem' }}>
+                    {s.rules.join('; ')}
+                  </p>
+                  {/* The reach lands on the tile that was chosen, next to the rule that produced it —
+                      the two facts a marketer weighs together. */}
+                  <p className="text-xs text-muted-foreground" style={{ marginTop: '0.5rem' }}>
+                    {active && reach !== null
+                      ? t(`≈ ${reach} lidí`, `≈ ${reach} people`)
+                      : t(`verze ${s.version}`, `version ${s.version}`)}
+                  </p>
+                </button>
+              )
+            })}
+          </div>
           {/* Segments are code (ADR-0201 D1). Saying so is cheaper than letting someone hunt for an
               "add segment" button that will never exist. */}
-          <p className="text-xs text-muted-foreground">
+          <p className="text-xs text-muted-foreground" style={{ marginTop: '0.75rem' }}>
             {t(
               'Segmenty jsou definované v kódu a verzované. Nový segment je pull request, ne akce v UI.',
               'Segments are defined in code and versioned. A new segment is a pull request, not a UI action.',
@@ -213,9 +266,14 @@ export default function NewCampaignPage() {
 
       <section className="space-y-3">
         <h2 className="text-sm font-semibold">{t('Cesta', 'The journey')}</h2>
+        {/* space-y-0 around the canvas+panel pair: any gap between them undoes the join. */}
+        <div className="space-y-0">
         <JourneyEditor
+          attachedBelow={selected !== null && steps[selected] !== undefined}
           steps={steps}
-          audience={segment}
+          // `savers@2` is how the API refers to a segment. The node says who they are; the tile above
+          // already carries the version, which is the only place it is a decision.
+          audience={segment ? segment.split('@')[0] : ''}
           audienceSize={reach}
           selected={selected}
           onSelect={setSelected}
@@ -224,18 +282,22 @@ export default function NewCampaignPage() {
           templateLabels={templateLabels}
         />
 
+        {/* No gap and no separate card: the panel is the selected node opened, so it continues the
+            canvas surface rather than sitting under it as an unrelated block. */}
         {selected !== null && steps[selected] && (
-          <div className="max-w-2xl">
-            <StepEditor
-              index={selected}
-              step={steps[selected]}
-              templates={TEMPLATES}
-              templateLabels={templateLabels}
-              onChange={next => updateStep(selected, next)}
-              onClose={() => setSelected(null)}
-            />
-          </div>
+          <StepEditor
+            attached
+            index={selected}
+            step={steps[selected]}
+            templates={TEMPLATES}
+            templateLabels={templateLabels}
+            variableLabels={variableLabels}
+            onChange={next => updateStep(selected, next)}
+            onClose={() => setSelected(null)}
+          />
         )}
+
+        </div>
 
         {/* Read-only on purpose: the contact policy is a single enforcement point, and a per-campaign
             override here would make that point decorative (ADR-0219 D4, ADR-0221 D1 step 4). */}
@@ -256,7 +318,7 @@ export default function NewCampaignPage() {
         <button
           onClick={submit}
           disabled={!ready || saving}
-          className="rounded-md border px-3 py-1.5 text-sm disabled:opacity-40"
+          className="btn btn-primary disabled:opacity-40"
         >
           {saving ? t('Zakládám…', 'Creating…') : t('Založit koncept', 'Create draft')}
         </button>

--- a/openbank-admin-ui/src/components/campaigns/JourneyEditor.tsx
+++ b/openbank-admin-ui/src/components/campaigns/JourneyEditor.tsx
@@ -50,6 +50,7 @@ export function JourneyEditor({
   onAdd,
   onRemove,
   templateLabels,
+  attachedBelow = false,
 }: {
   steps: EditorStep[]
   /** `name@version`, or empty while the marketer has not chosen one. */
@@ -60,6 +61,8 @@ export function JourneyEditor({
   onAdd: () => void
   onRemove: (index: number) => void
   templateLabels: Record<string, string>
+  /** True when the step editor renders directly beneath, so the two read as one surface. */
+  attachedBelow?: boolean
 }) {
   const { t, language } = useLanguage()
   const n = (v: number) => v.toLocaleString(language === 'cs' ? 'cs-CZ' : 'en-GB')
@@ -100,7 +103,14 @@ export function JourneyEditor({
   }
 
   return (
-    <div className="overflow-x-auto rounded-xl border" style={{ background: 'var(--surface)' }}>
+    <div
+      className={
+        attachedBelow
+          ? 'overflow-x-auto rounded-t-xl border-x border-t'
+          : 'overflow-x-auto rounded-xl border'
+      }
+      style={{ background: 'var(--surface)' }}
+    >
       <svg
         viewBox={`0 0 ${width} ${height}`}
         style={{ width: '100%', minWidth: Math.min(width, 760), height: 'auto', display: 'block' }}

--- a/openbank-admin-ui/src/components/campaigns/StepEditor.tsx
+++ b/openbank-admin-ui/src/components/campaigns/StepEditor.tsx
@@ -24,21 +24,42 @@ export function StepEditor({
   step,
   templates,
   templateLabels,
+  variableLabels,
   onChange,
   onClose,
+  attached = false,
 }: {
   index: number
   step: EditorStep
   /** template id → the variables it declares. Mirrors the service's catalogue. */
   templates: Record<string, string[]>
   templateLabels: Record<string, string>
+  /**
+   * variable id → what to call it, and what a filled-in one looks like.
+   *
+   * `offerTitle` is the engine's name for the field. Printing it as the label made a marketer read
+   * an API contract; the example matters as much as the name, because "what goes in here" is the
+   * actual question and a bare box does not answer it.
+   */
+  variableLabels: Record<string, { label: string; example: string }>
   onChange: (next: EditorStep) => void
   onClose: () => void
+  /**
+   * Rendered as a continuation of the canvas rather than a card of its own.
+   *
+   * Separated, it read as a block that had fallen off the page: a narrower box under a full-width
+   * canvas, with nothing tying it to the node it edits. The relationship is structural — this panel
+   * IS the selected node, opened — so it is expressed with layout rather than with a caption saying
+   * so.
+   */
+  attached?: boolean
 }) {
   const { t } = useLanguage()
   const declared = templates[step.template] ?? []
   const missing = declared.filter(v => !(step.variables[v] ?? '').trim())
-  const field = 'w-full rounded-md border bg-transparent px-3 py-1.5 text-sm'
+  // `.input` is the console's own field style — hover, focus ring, sizing — and I had hand-rolled a
+  // worse copy of it. Reinventing a house primitive is the same failure ADR-0208 D2 names for colour.
+  const field = 'input w-full'
 
   const setDelayDays = (raw: string) => {
     const days = Math.max(0, Number(raw) || 0)
@@ -46,7 +67,14 @@ export function StepEditor({
   }
 
   return (
-    <div className="rounded-xl border p-4 space-y-4" data-step-editor={index}>
+    <div
+      className={
+        attached
+          ? 'border-x border-b rounded-b-xl p-5 space-y-5'
+          : 'rounded-xl border p-4 space-y-4'
+      }
+      data-step-editor={index}
+    >
       <div className="flex items-baseline justify-between">
         <h3 className="text-sm font-semibold">
           {t('Krok', 'Step')} {index + 1}
@@ -56,7 +84,7 @@ export function StepEditor({
         </button>
       </div>
 
-      <div className="space-y-1">
+      <div className="space-y-1.5">
         <label htmlFor={`tpl-${index}`} className="text-sm font-medium">
           {t('Co se pošle', 'What gets sent')}
         </label>
@@ -82,20 +110,21 @@ export function StepEditor({
       </div>
 
       {declared.map(v => (
-        <div key={v} className="space-y-1">
+        <div key={v} className="space-y-1.5">
           <label htmlFor={`var-${index}-${v}`} className="text-sm font-medium">
-            {v}
+            {variableLabels[v]?.label ?? v}
           </label>
           <input
             id={`var-${index}-${v}`}
             className={field}
+            placeholder={variableLabels[v]?.example ?? ''}
             value={step.variables[v] ?? ''}
             onChange={e => onChange({ ...step, variables: { ...step.variables, [v]: e.target.value } })}
           />
         </div>
       ))}
 
-      <div className="space-y-1">
+      <div className="space-y-1.5">
         <label htmlFor={`delay-${index}`} className="text-sm font-medium">
           {t('Poslat po', 'Send after')}
         </label>
@@ -104,7 +133,8 @@ export function StepEditor({
             id={`delay-${index}`}
             type="number"
             min="0"
-            className={`${field} w-28`}
+            className={field}
+            style={{ width: '5.5rem' }}
             value={Math.round(step.delaySeconds / 86400)}
             onChange={e => setDelayDays(e.target.value)}
           />
@@ -116,7 +146,8 @@ export function StepEditor({
 
       {missing.length > 0 && (
         <p className="text-xs text-amber-600">
-          {t('Ještě chybí', 'Still missing')}: {missing.join(', ')}
+          {t('Ještě chybí', 'Still missing')}:{' '}
+          {missing.map(v => variableLabels[v]?.label ?? v).join(', ')}
         </p>
       )}
     </div>

--- a/openbank-admin-ui/src/test/campaign-studio.test.tsx
+++ b/openbank-admin-ui/src/test/campaign-studio.test.tsx
@@ -72,8 +72,15 @@ describe('campaign studio', () => {
     vi.stubGlobal('fetch', mockFetch({ '/api/segments': SEGMENTS }))
     render(React.createElement(Providers, null, React.createElement(NewCampaignPage)))
 
-    await waitFor(() => expect(screen.getByLabelText('Audience')).toBeTruthy(), { timeout: 8000 })
-    expect((screen.getByLabelText('Audience') as HTMLSelectElement).tagName).toBe('SELECT')
+    await waitFor(
+      () => expect(document.querySelector('[data-segment]')).toBeTruthy(),
+      { timeout: 8000 },
+    )
+    // Tiles, not a text box: the catalogue is the only source of an audience, so the control offers
+    // the choices rather than accepting a name that may not exist (ADR-0201 D1).
+    for (const tile of Array.from(document.querySelectorAll('[data-segment]'))) {
+      expect(tile.tagName).toBe('BUTTON')
+    }
     expect(screen.getByText(/a pull request, not a UI action/)).toBeTruthy()
   }, 15000)
 
@@ -86,10 +93,17 @@ describe('campaign studio', () => {
     vi.stubGlobal('fetch', mockFetch({ '/api/segments': SEGMENTS }))
     render(React.createElement(Providers, null, React.createElement(NewCampaignPage)))
 
-    await waitFor(() => expect(screen.getByLabelText('offerTitle')).toBeTruthy(), { timeout: 8000 })
-    expect(screen.getByLabelText('offerText')).toBeTruthy()
-    expect(screen.getByLabelText('ctaText')).toBeTruthy()
+    // The labels are the marketer's words, but the FIELD SET is still exactly the template's
+    // declared variables — asserted by id, which carries the variable name the service knows.
+    await waitFor(() => expect(document.getElementById('var-0-offerTitle')).toBeTruthy(), {
+      timeout: 8000,
+    })
+    expect(document.getElementById('var-0-offerText')).toBeTruthy()
+    expect(document.getElementById('var-0-ctaText')).toBeTruthy()
+    expect(screen.getByLabelText('Headline')).toBeTruthy()
     expect(document.querySelector('textarea')).toBeNull()
+    // No field beyond the declared three, which is what "never a free-text body" means in practice.
+    expect(document.querySelectorAll('[id^="var-0-"]').length).toBe(3)
   }, 15000)
 
   it('a draft can be submitted but not activated from the same screen', async () => {

--- a/openbank-admin-ui/src/test/journey-editor.test.tsx
+++ b/openbank-admin-ui/src/test/journey-editor.test.tsx
@@ -10,6 +10,14 @@ import { JourneyEditor, MAX_STEPS, type EditorStep } from '@/components/campaign
 import { StepEditor } from '@/components/campaigns/StepEditor'
 
 const TEMPLATES = { MARKETING_PRODUCT_OFFER: ['offerTitle', 'offerText', 'ctaText'] }
+
+// The editor labels a variable in the marketer's words. The mapping is data, so the test carries its
+// own copy — asserting the rendered label against the same map the component reads would be vacuous.
+const VAR_LABELS = {
+  offerTitle: { label: 'Headline', example: 'Savings at 4% interest' },
+  offerText: { label: 'Offer text', example: 'One sentence.' },
+  ctaText: { label: 'Button text', example: 'Start saving' },
+}
 const LABELS = { MARKETING_PRODUCT_OFFER: 'Product offer' }
 const step = (delay = 0, vars: Record<string, string> = {}): EditorStep => ({
   template: 'MARKETING_PRODUCT_OFFER',
@@ -81,12 +89,15 @@ describe('step editor', () => {
     const { container } = render(
       React.createElement(LanguageProvider, null,
         React.createElement(StepEditor, {
-          index: 0, step: step(), templates: TEMPLATES, templateLabels: LABELS,
+          index: 0, step: step(), templates: TEMPLATES, templateLabels: LABELS, variableLabels: VAR_LABELS,
           onChange: vi.fn(), onClose: vi.fn(),
         })))
 
-    expect(screen.getByLabelText('offerTitle')).toBeTruthy()
-    expect(screen.getByLabelText('ctaText')).toBeTruthy()
+    // Asserted by id, not by label: the id carries the variable name the SERVICE knows, so a
+    // renamed label can never quietly change which field is submitted.
+    expect(document.getElementById('var-0-offerTitle')).toBeTruthy()
+    expect(document.getElementById('var-0-ctaText')).toBeTruthy()
+    expect(screen.getByLabelText('Headline')).toBeTruthy()
     expect(container.querySelector('textarea')).toBeNull()
   })
 
@@ -96,7 +107,7 @@ describe('step editor', () => {
     render(
       React.createElement(LanguageProvider, null,
         React.createElement(StepEditor, {
-          index: 0, step: step(), templates: TEMPLATES, templateLabels: LABELS,
+          index: 0, step: step(), templates: TEMPLATES, templateLabels: LABELS, variableLabels: VAR_LABELS,
           onChange, onClose: vi.fn(),
         })))
 
@@ -108,10 +119,12 @@ describe('step editor', () => {
     render(
       React.createElement(LanguageProvider, null,
         React.createElement(StepEditor, {
-          index: 0, step: step(0, { offerTitle: 'T' }), templates: TEMPLATES, templateLabels: LABELS,
+          index: 0, step: step(0, { offerTitle: 'T' }), templates: TEMPLATES, templateLabels: LABELS, variableLabels: VAR_LABELS,
           onChange: vi.fn(), onClose: vi.fn(),
         })))
 
-    expect(screen.getByText(/offerText, ctaText/)).toBeTruthy()
+    // Named the way the fields above are named. Listing `offerText` under a field labelled
+    // "Offer text" would send someone hunting for a control that is not on the screen.
+    expect(screen.getByText(/Offer text, Button text/)).toBeTruthy()
   })
 })


### PR DESCRIPTION
## What

The campaign builder's authoring screen, made usable by the person who actually writes campaigns.
Two defects I introduced in #3323, plus the form that was still an API contract with labels on it.

### The panel and canvas were two unrelated boxes

The step editor is the selected node, opened — but it rendered as a narrower card floating under a
full-width canvas, with nothing tying it to the node it edits. `attachedBelow` / `attached` join the
two into one surface (`rounded-t` above, `rounded-b` below, no gap).

### The form read as a database table

`<label>` + bare box × 3, and an audience `<select>` whose options said `actives v1 — party status is
ACTIVE`. Now:

- the name is a document title, and the goal asks for it in a marketer's words
  (*"more people open a savings account"*), placeholder rather than label;
- the audience is a set of tiles carrying the plain-language rule and, once chosen, **the reach**.
  A dropdown hid the one number the choice turns on;
- the step's fields are `Headline` / `Offer text` / `Button text` with worked examples, not
  `offerTitle` / `offerText` / `ctaText`. Those are the engine's names for the fields, and an empty
  box does not answer "what goes in here" — the example does.

Hand-rolled field styling replaced with the console's own `.input` and `.btn` classes. Reinventing a
house primitive is the failure ADR-0208 D2 names for colour, applied to form controls.

## Constraints kept

Nothing here loosens what the service enforces. The field set is still exactly the template's
declared variables (ADR-0176 D4) — asserted by element id, so the friendlier labels cannot hide a
drift; there is still no free-text body and no way to author a segment (ADR-0201 D1); the canvas is
still linear and capped at `Campaign.MAX_STEPS`, which is why it is not the free-form graph ADR-0221
D5 rejects.

## Verification

- `npm test -- src/test/campaign` — 19 passed. The two tests that asserted the old `<select>` and the
  raw variable labels now assert the constructs (`[data-segment]` is a `BUTTON`; `var-0-*` ids exist
  and number exactly three).
- Rendered against the **freshly compiled** stylesheet and read the screenshot. The first attempt
  used a stale `.next` CSS that contained none of the new utilities, so it rendered as an unstyled
  stack — a render is only evidence if the stylesheet is the one the build produced.

Refs #3323
