### PR TITLE
fix(fraud): an ONNX native-load Error 500'd the whole resource, not just scoring

### DIFF
--- a/openbank-fraud-service/src/main/kotlin/com/openbank/fraud/infrastructure/ml/OnnxFraudModel.kt
+++ b/openbank-fraud-service/src/main/kotlin/com/openbank/fraud/infrastructure/ml/OnnxFraudModel.kt
@@ -36,6 +36,11 @@ import java.security.MessageDigest
  * Session load happens once at construction; a load or verification failure leaves [session] `null`,
  * so every [scoreShadow] call returns `null` immediately — the ADR-0139 fail-closed floor applies to
  * model *loading* (and now verification), not just per-call inference failures.
+ *
+ * "Failure" includes the native library not loading at all, which is an `Error` and not an
+ * `Exception` — see [loadEnvironment]. Construction of this bean must never throw: it is injected
+ * into the same graph as read-only endpoints that do not use a model, and a bean that fails to
+ * construct takes all of them down with it.
  */
 @ApplicationScoped
 class OnnxFraudModel(
@@ -43,17 +48,18 @@ class OnnxFraudModel(
     private val requireSignature: Boolean = false,
 ) : MlModelPort {
 
-    private val environment: OrtEnvironment = OrtEnvironment.getEnvironment()
+    private val environment: OrtEnvironment? = loadEnvironment()
     private val session: OrtSession? =
-        loadSession(environment, MODEL_RESOURCE_PATH, MODEL_CARD_PATH, requireSignature)
+        environment?.let { loadSession(it, MODEL_RESOURCE_PATH, MODEL_CARD_PATH, requireSignature) }
 
     @Suppress("TooGenericExceptionCaught") // OrtException + tensor lifecycle errors have no common base
     override fun scoreShadow(features: Map<String, Double>): Double? {
+        val env = environment ?: return null
         val activeSession = session ?: return null
         val h1 = (features[VELOCITY_TXN_COUNT_H1.name] ?: 0.0).toFloat()
         val h24 = (features[VELOCITY_TXN_COUNT_H24.name] ?: 0.0).toFloat()
         return try {
-            OnnxTensor.createTensor(environment, FloatBuffer.wrap(floatArrayOf(h1, h24)), INPUT_SHAPE).use { input ->
+            OnnxTensor.createTensor(env, FloatBuffer.wrap(floatArrayOf(h1, h24)), INPUT_SHAPE).use { input ->
                 activeSession.run(mapOf(INPUT_NAME to input)).use { result ->
                     @Suppress("UNCHECKED_CAST")
                     (result[0].value as Array<FloatArray>)[0][0].toDouble()
@@ -86,9 +92,49 @@ class OnnxFraudModel(
         // credit-decisioning model, ADR-0142) must not be served here even if its bytes verify.
         private val ALLOWED_SCOPES = setOf("fraud-shadow")
 
+        /**
+         * Acquire the ONNX Runtime environment, or `null` when the native library will not load.
+         *
+         * This MUST catch [Throwable], not [Exception]. `OrtEnvironment.getEnvironment()` unpacks
+         * and `System.load`s a bundled `.so`, and a platform mismatch surfaces as
+         * `ExceptionInInitializerError` wrapping an `UnsatisfiedLinkError` — both `Error`s, so the
+         * `catch (ex: Exception)` in [loadSession] below never saw them and the class documented a
+         * degradation it could not perform.
+         *
+         * What that cost: the deploy image is `eclipse-temurin:25-jre-alpine` (musl, no libstdc++),
+         * onnxruntime's `libonnxruntime.so` is built against glibc, so `getEnvironment()` threw in
+         * a FIELD INITIALIZER — construction of the bean failed, and CDI then failed every
+         * injection point of it. `FraudResource.reviewQueue` is a read-only analyst query that
+         * never touches the model, and it answered 500 on every call because this bean sits in the
+         * same graph. A missing native library disabled a listing endpoint.
+         *
+         * Measured against the three candidate bases (arm64, onnxruntime 1.22.0):
+         *   eclipse-temurin:25-jre-alpine                -> UnsatisfiedLinkError: libstdc++.so.6
+         *   eclipse-temurin:25-jre-alpine + apk libstdc++ -> UnsatisfiedLinkError: ld-linux-aarch64.so.1
+         *   eclipse-temurin:25-jre (glibc)               -> loads
+         * So the runtime image is the fix for *shadow scoring*; this is the fix for *the blast
+         * radius*, and it is worth having either way — a corrupt library or an OOM at load time
+         * must never be able to take a read endpoint down with it.
+         */
+        @Suppress("TooGenericExceptionCaught") // an Error is exactly what we must survive here
+        internal fun loadEnvironment(): OrtEnvironment? = try {
+            OrtEnvironment.getEnvironment()
+        } catch (t: Throwable) {
+            log.errorf(
+                t,
+                "ONNX Runtime native library unavailable — shadow scoring disabled, rules-only " +
+                    "verdicts stand. This does NOT change any fraud verdict (ADR-0139 phase-1b " +
+                    "scores in shadow); it only removes the shadow signal.",
+            )
+            null
+        }
+
         // internal (not private): OnnxFraudModelTest exercises the load-failure branch directly.
         // requireSignature defaults to false so the existing 2-/3-arg test calls keep the advisory
         // (log + proceed) behaviour without a card assertion.
+        //
+        // Catches Throwable for the same reason as loadEnvironment: createSession also crosses into
+        // native code, so a linkage failure here is an Error, not an Exception.
         @Suppress("TooGenericExceptionCaught") // OrtException + IO errors have no common base worth splitting
         internal fun loadSession(
             environment: OrtEnvironment,
@@ -103,7 +149,7 @@ class OnnxFraudModel(
                 return null // fail-closed: card mismatch under require-signature
             }
             environment.createSession(modelBytes, OrtSession.SessionOptions())
-        } catch (ex: Exception) {
+        } catch (ex: Throwable) {
             log.errorf(ex, "failed to load ONNX baseline fraud model (%s) — shadow scoring disabled", resourcePath)
             null
         }

--- a/openbank-fraud-service/src/test/kotlin/com/openbank/fraud/infrastructure/ml/OnnxFraudModelTest.kt
+++ b/openbank-fraud-service/src/test/kotlin/com/openbank/fraud/infrastructure/ml/OnnxFraudModelTest.kt
@@ -5,8 +5,13 @@
 package com.openbank.fraud.infrastructure.ml
 
 import ai.onnxruntime.OrtEnvironment
+import ai.onnxruntime.OrtSession
 import com.openbank.libs.domain.feature.VELOCITY_TXN_COUNT_H1
 import com.openbank.libs.domain.feature.VELOCITY_TXN_COUNT_H24
+import io.mockk.every
+import io.mockk.mockk
+import io.mockk.mockkStatic
+import io.mockk.unmockkStatic
 import org.assertj.core.api.Assertions.assertThat
 import org.junit.jupiter.api.AfterEach
 import org.junit.jupiter.api.Test
@@ -82,5 +87,52 @@ class OnnxFraudModelTest {
         val anyBytes = byteArrayOf(9)
         assertThat(OnnxFraudModel.verifyCard(anyBytes, "ml/no-such.card.json", requireSignature = true))
             .isFalse()
+    }
+
+    // --- the native library not loading at all ---
+    //
+    // The cases above cover a missing *resource*, which is an Exception. A platform mismatch is an
+    // Error: OrtEnvironment.getEnvironment() System.load()s a bundled .so and throws
+    // ExceptionInInitializerError wrapping UnsatisfiedLinkError. That escaped the field initializer,
+    // so constructing this bean threw, so CDI failed every injection point of it — and
+    // FraudResource.reviewQueue, a read-only analyst query that never touches a model, answered 500
+    // on every call in the deployed environment. These two cases fail against that code.
+
+    @Test
+    fun `a native library Error leaves the environment null instead of propagating`() {
+        mockkStatic(OrtEnvironment::class)
+        try {
+            every { OrtEnvironment.getEnvironment() } throws
+                ExceptionInInitializerError(UnsatisfiedLinkError("libstdc++.so.6: No such file or directory"))
+
+            assertThat(OnnxFraudModel.loadEnvironment()).isNull()
+        } finally {
+            unmockkStatic(OrtEnvironment::class)
+        }
+    }
+
+    @Test
+    fun `construction survives a native library Error and degrades to null scores`() {
+        mockkStatic(OrtEnvironment::class)
+        try {
+            every { OrtEnvironment.getEnvironment() } throws
+                ExceptionInInitializerError(UnsatisfiedLinkError("libstdc++.so.6: No such file or directory"))
+
+            // The constructor must not throw — anything sharing this bean's CDI graph depends on it.
+            val degraded = OnnxFraudModel()
+            assertThat(degraded.scoreShadow(mapOf(VELOCITY_TXN_COUNT_H1.name to 5.0))).isNull()
+            degraded.close()
+        } finally {
+            unmockkStatic(OrtEnvironment::class)
+        }
+    }
+
+    @Test
+    fun `a linkage Error while creating the session degrades instead of propagating`() {
+        val hostile = mockk<OrtEnvironment>()
+        every { hostile.createSession(any<ByteArray>(), any<OrtSession.SessionOptions>()) } throws
+            UnsatisfiedLinkError("native session creation failed")
+
+        assertThat(OnnxFraudModel.loadSession(hostile, "ml/baseline-fraud-v1.onnx")).isNull()
     }
 }


### PR DESCRIPTION
## What

An `Error` from ONNX Runtime's native loader escaped a **field initializer** in `OnnxFraudModel`, so the bean failed to construct — and took every endpoint sharing its CDI graph down with it, including `GET /api/v1/fraud/review-queue`, a read-only analyst query that never touches a model.

## Why

The class already documents the behaviour it was supposed to have:

> *Session load happens once at construction; a load or verification failure leaves `session` null, so every `scoreShadow` call returns null immediately.*

It could not do that. `loadSession` catches `Exception`, but the failure is `ExceptionInInitializerError` wrapping `UnsatisfiedLinkError` — both `Error`s — and it is thrown one line earlier, by `OrtEnvironment.getEnvironment()` in a field initializer outside any `try`.

From the deployed pod:

```
Caused by: java.lang.ExceptionInInitializerError: Exception java.lang.UnsatisfiedLinkError:
  /tmp/onnxruntime-java.../libonnxruntime.so: Error loading shared library libstdc++.so.6:
  No such file or directory (needed by /tmp/onnxruntime-java.../libonnxruntime.so)
        at com.openbank.fraud.infrastructure.rest.FraudResource.reviewQueue(FraudResource.kt:57)
```

`reviewQueue` is in that stack because the bean is in its graph, not because it uses the model. In the console this rendered as **"fraud-service is unavailable"** on the fraud review queue, against a healthy, running service.

## How

- `loadEnvironment()` catches `Throwable` — the whole point is surviving an `Error` — and returns null. `environment` becomes nullable, `session` follows, and `scoreShadow` already returns null when either is missing.
- `loadSession` widens to `Throwable` for the same reason: `createSession` also crosses into native code.

Construction can no longer throw. Shadow scoring degrades to rules-only, which is what the KDoc always claimed and what ADR-0139 phase-1b's fail-closed floor intends.

**No fraud verdict changes.** `scoreShadow` is shadow-only, and the bundled model encodes the same deterministic logistic the previous pure-Kotlin `BaselineFraudModel` computed. What is lost is only the shadow signal — which was already absent, since the library never loaded.

## Verification

Three new cases in `OnnxFraudModelTest`, each failing against the pre-fix code (the existing "load failure degrades" case only covered a missing *resource*, i.e. an `Exception`):

- `OrtEnvironment.getEnvironment()` mocked to throw `ExceptionInInitializerError(UnsatisfiedLinkError)` → `loadEnvironment()` returns null rather than propagating.
- Same mock → **constructing** `OnnxFraudModel` does not throw, and `scoreShadow` returns null.
- An `OrtEnvironment` whose `createSession` throws `UnsatisfiedLinkError` → `loadSession` returns null.

## Why the runtime image is not changed here

Measured on `linux/arm64`, onnxruntime 1.22.0:

| Base | Result |
|---|---|
| `eclipse-temurin:25-jre-alpine` (today's `Dockerfile.deploy`) | `UnsatisfiedLinkError: libstdc++.so.6` |
| `eclipse-temurin:25-jre-alpine` + `apk add libstdc++` | `UnsatisfiedLinkError: ld-linux-aarch64.so.1` |
| `eclipse-temurin:25-jre` (glibc) | **loads** |

The obvious cheap fix does not work — adding `libstdc++` just moves the failure to the glibc loader — so making ONNX actually load needs a glibc base, which is a fleet-wide image decision with its own risk and its own verification. That is [#3354](https://github.com/JiRaska/open-bank-oss/issues/3354), with the measurements and a cost breakdown.

This PR is worth having independently of that one: a corrupt library or an OOM at load time must never be able to take a read endpoint down with it.

## Local gate

`detekt`, `ktlintCheck`, `test`, `quarkusBuild`. `OnnxFraudModelTest` is **10/10**. One unrelated flake appeared in the full run — `FraudPactFolderProviderVerificationTest` failed to boot with `QuarkusBindException` (port already bound, from another Gradle build running concurrently on this machine); re-run in isolation it passes, `tests=1 failures=0`.

## Linked issues

Refs #3354 — the runtime-image half of the same defect.
