### PR TITLE
fix(libs,domestic): surface the transport fault a resilient call masks

### DIFF
--- a/.github/workflows/auto-retry-cancelled.yml
+++ b/.github/workflows/auto-retry-cancelled.yml
@@ -55,9 +55,19 @@
 # (run_attempt 2) never re-triggers, and a run cancelled for a real reason (superseded by a
 # newer push to the same PR — the concurrency group's normal operation) is only retried once,
 # where it fails fast if the branch has moved. Deliberately NOT retried: `action_required`
-# (approval gates are a human's job) and runs cancelled by anything other than the runner
-# dying — indistinguishable from the outside, so we accept one wasted retry on a manually
-# cancelled run over a more clever heuristic that can misfire.
+# (approval gates are a human's job).
+#
+# This paragraph used to end "and runs cancelled by anything other than the runner dying —
+# indistinguishable from the outside, so we accept one wasted retry on a manually cancelled run".
+# HALF of that is now false and the correction cost one API call: a reclaim kills a RUNNING job,
+# so a run whose cancelled jobs never started a step cannot have been reclaimed. That case is now
+# skipped (see the `cancelled` branch below). The other half stands — a human who cancels WHILE
+# jobs are running is still indistinguishable, and is still retried once.
+#
+# The accepted waste was priced for an idle pool, and the case where someone cancels is precisely
+# the case where the pool is NOT idle: draining a 19-hour, 23-run backlog put all 19 runs straight
+# back in the queue, so the drain silently needed two passes and the re-added load landed on
+# everyone else's PRs (#3208, capacity itself is #2039).
 #
 # `-R` ON EVERY `gh run rerun` IS LOAD-BEARING (issue #2841 follow-up)
 # This job has no `actions/checkout`, so there is no git repository for `gh` to infer the
@@ -105,11 +115,32 @@ jobs:
           set -euo pipefail
 
           if [ "${CONCLUSION}" = "cancelled" ]; then
-            # Whole run cancelled. Indistinguishable from the outside between a reclaim and a
-            # human/concurrency cancel, so retry once either way — the accepted waste that
-            # LOOP SAFETY above describes. `--failed` is a no-op against `cancelled`, so this
-            # is always the full re-run.
-            echo "Re-running cancelled run ${RUN_URL} (issue #2330)"
+            # A reclaim kills a RUNNING job. So if not one cancelled job ever started a step,
+            # nothing was running and a reclaim is impossible — this was a queue cancel, and
+            # re-running it puts back exactly the load whoever cancelled was removing (#3208).
+            #
+            # `steps` is empty for a job that was still queued when the run was cancelled;
+            # a job interrupted mid-flight carries its steps with their conclusions. Verified on
+            # both sides against real runs: 30693441813 (operator drain) has 5 cancelled jobs and
+            # 0 with steps, while contemporaneous cancels that hit running jobs report 1-2 with
+            # steps. Attempt-scoped for the same reason the failure branch below is.
+            #
+            # ONE-DIRECTIONAL on purpose. This only rules a reclaim OUT; it never claims one
+            # happened. A human who cancels while jobs are running still looks exactly like a
+            # reclaim and is still retried once — unchanged, and still the accepted waste the
+            # LOOP SAFETY note describes. What it removes is the case the header never priced:
+            # draining a deep queue, where every cancelled job is one that never started, and the
+            # retry silently undid the drain (#3208, #2039).
+            RUNNING="$(gh api "repos/${GITHUB_REPOSITORY}/actions/runs/${RUN_ID}/attempts/1/jobs?per_page=100" \
+                        --jq '[.jobs[] | select(.conclusion == "cancelled") | select((.steps | length) > 0)] | length')"
+            if [ "${RUNNING:-0}" -eq 0 ]; then
+              echo "::notice title=spot-kill auto-retry::NOT re-running ${RUN_URL} — no cancelled job had started a step, so no runner was reclaimed. Treating it as a deliberate cancel (#3208)."
+              exit 0
+            fi
+
+            # At least one job was interrupted mid-flight: a reclaim is possible, so retry once.
+            # `--failed` is a no-op against `cancelled`, so this is always the full re-run.
+            echo "Re-running cancelled run ${RUN_URL} (${RUNNING} job(s) interrupted mid-flight; issue #2330)"
             gh run rerun -R "${GITHUB_REPOSITORY}" "${RUN_ID}"
             echo "::notice title=spot-kill auto-retry::Re-ran cancelled run ${RUN_URL} (attempt 2 of max 2; a second kill stays for a human)"
             exit 0

--- a/openbank-domestic-payment/src/main/kotlin/com/openbank/domestic/infrastructure/client/SanctionsScreeningAdapter.kt
+++ b/openbank-domestic-payment/src/main/kotlin/com/openbank/domestic/infrastructure/client/SanctionsScreeningAdapter.kt
@@ -9,6 +9,7 @@ import com.openbank.domestic.application.port.out.ScreeningUnavailableException
 import com.openbank.domestic.domain.screening.ScreeningMatchStatus
 import com.openbank.domestic.domain.screening.ScreeningResult
 import com.openbank.domestic.domain.screening.ScreeningRole
+import com.openbank.libs.observability.reportingFirstFailure
 import io.smallrye.mutiny.coroutines.awaitSuspending
 import jakarta.enterprise.context.ApplicationScoped
 import jakarta.inject.Inject
@@ -16,6 +17,7 @@ import org.eclipse.microprofile.faulttolerance.CircuitBreaker
 import org.eclipse.microprofile.faulttolerance.Retry
 import org.eclipse.microprofile.faulttolerance.Timeout
 import org.eclipse.microprofile.rest.client.inject.RestClient
+import org.jboss.logging.Logger
 
 /**
  * Resilient, fail-closed adapter over [SanctionsServiceClient] (ADR-0032 §C/§D). Transport faults are
@@ -30,6 +32,8 @@ class SanctionsScreeningAdapter(@RestClient private val client: SanctionsService
     @Inject
     lateinit var self: SanctionsScreeningAdapter
 
+    private val log = Logger.getLogger(SanctionsScreeningAdapter::class.java)
+
     override suspend fun screen(name: String, role: ScreeningRole, idempotencyKey: String): ScreeningResult = try {
         self.screenWithResilience(name, role, idempotencyKey)
     } catch (ex: Exception) {
@@ -40,9 +44,25 @@ class SanctionsScreeningAdapter(@RestClient private val client: SanctionsService
     @Retry(maxRetries = 2, delay = 300, jitter = 150, retryOn = [Exception::class])
     @Timeout(5_000)
     open suspend fun screenWithResilience(name: String, role: ScreeningRole, idempotencyKey: String): ScreeningResult {
-        val response = client.screen(
-            ScreenRequest(idempotencyKey = idempotencyKey, entityType = ENTITY_TYPE, name = name),
-        ).awaitSuspending()
+        // INSIDE the annotated method, so it runs per attempt and inside the breaker. @Retry sits
+        // outside @CircuitBreaker (fixed MicroProfile order), so once the breaker opens mid-retry
+        // the only thing that reaches the outer catch is CircuitBreakerOpenException — the 500,
+        // the timeout, the connection refusal is discarded with the earlier attempts (#3267).
+        val response = reportingFirstFailure(
+            onFailure = { ex ->
+                log.warnf(
+                    ex,
+                    "sanctions.screen attempt failed idempotency_key=%s role=%s — this is the ORIGINAL fault; " +
+                        "the call site may only see CircuitBreakerOpenException (#3267)",
+                    idempotencyKey,
+                    role,
+                )
+            },
+        ) {
+            client.screen(
+                ScreenRequest(idempotencyKey = idempotencyKey, entityType = ENTITY_TYPE, name = name),
+            ).awaitSuspending()
+        }
         return ScreeningResult(
             subject = name,
             role = role,

--- a/openbank-domestic-payment/src/main/kotlin/com/openbank/domestic/infrastructure/client/SanctionsScreeningAdapter.kt
+++ b/openbank-domestic-payment/src/main/kotlin/com/openbank/domestic/infrastructure/client/SanctionsScreeningAdapter.kt
@@ -9,6 +9,7 @@ import com.openbank.domestic.application.port.out.ScreeningUnavailableException
 import com.openbank.domestic.domain.screening.ScreeningMatchStatus
 import com.openbank.domestic.domain.screening.ScreeningResult
 import com.openbank.domestic.domain.screening.ScreeningRole
+import com.openbank.libs.observability.ResilientCallMetrics
 import com.openbank.libs.observability.reportingFirstFailure
 import io.smallrye.mutiny.coroutines.awaitSuspending
 import jakarta.enterprise.context.ApplicationScoped
@@ -32,6 +33,14 @@ class SanctionsScreeningAdapter(@RestClient private val client: SanctionsService
     @Inject
     lateinit var self: SanctionsScreeningAdapter
 
+    /**
+     * Field injection, not a constructor parameter: detekt's `LongParameterList` fires AT the
+     * threshold, and the fleet convention for adding a metrics port to an existing adapter is
+     * `@Inject lateinit` (LoanStageEventConsumer, VopRateLimitFilter, McpEndpoint).
+     */
+    @Inject
+    lateinit var metrics: ResilientCallMetrics
+
     private val log = Logger.getLogger(SanctionsScreeningAdapter::class.java)
 
     override suspend fun screen(name: String, role: ScreeningRole, idempotencyKey: String): ScreeningResult = try {
@@ -50,6 +59,9 @@ class SanctionsScreeningAdapter(@RestClient private val client: SanctionsService
         // the timeout, the connection refusal is discarded with the earlier attempts (#3267).
         val response = reportingFirstFailure(
             onFailure = { ex ->
+                // Counted per attempt, so `breaker_open` and `call_failed` line up with what fault
+                // tolerance actually saw — not with the single exception that escaped (#3267).
+                metrics.recordFailure(ADAPTER, ex)
                 log.warnf(
                     ex,
                     "sanctions.screen attempt failed idempotency_key=%s role=%s — this is the ORIGINAL fault; " +
@@ -84,5 +96,8 @@ class SanctionsScreeningAdapter(@RestClient private val client: SanctionsService
     private companion object {
         // Sanctions matching is name-based; entityType is informational. See ADR-0032 scope note.
         const val ENTITY_TYPE = "INDIVIDUAL"
+
+        /** Metric tag. A compile-time constant per call site — never a URL or an id (cardinality). */
+        const val ADAPTER = "sanctions"
     }
 }

--- a/openbank-libs-runtime/build.gradle.kts
+++ b/openbank-libs-runtime/build.gradle.kts
@@ -70,6 +70,8 @@ dependencies {
     testImplementation("org.jboss.logging:jboss-logging:3.6.2.Final")
     testImplementation("jakarta.enterprise:jakarta.enterprise.cdi-api:4.1.0")
     testImplementation("io.micrometer:micrometer-core:1.14.5")
+    // ResilientCallMetrics classifies CircuitBreakerOpenException; the API is compileOnly above.
+    testImplementation("org.eclipse.microprofile.fault-tolerance:microprofile-fault-tolerance-api:4.1.1")
     // Test-only: WorkflowLivenessMetricNamingTest checks the dotted meter name against Micrometer's
     // REAL PrometheusNamingConvention rather than trusting the hand-rolled dot -> underscore
     // rendering that the sentinel's PromQL depends on. The registry itself is never used at runtime

--- a/openbank-libs-runtime/src/main/kotlin/com/openbank/libs/observability/FirstFailureVisibility.kt
+++ b/openbank-libs-runtime/src/main/kotlin/com/openbank/libs/observability/FirstFailureVisibility.kt
@@ -1,0 +1,48 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright (c) OpenBank contributors. Licensed under the Apache License, Version 2.0.
+// See LICENSE in the repository root or https://www.apache.org/licenses/LICENSE-2.0 for details.
+
+package com.openbank.libs.observability
+
+/**
+ * Makes the ORIGINAL transport fault of a resilient call visible, before fault tolerance masks it.
+ *
+ * MicroProfile Fault Tolerance applies its annotations in a fixed order —
+ * `Fallback > Retry > CircuitBreaker > Timeout > Bulkhead` — so `@Retry` sits OUTSIDE
+ * `@CircuitBreaker`. Once the breaker opens mid-retry, the remaining attempts fail with
+ * `CircuitBreakerOpenException`, and that is what `@Retry` finally propagates. The 500, the
+ * timeout, the connection refusal that actually caused it is discarded along with the earlier
+ * attempts, so the outer `catch` has nothing to log but "the breaker is open" (#3267).
+ *
+ * The cost of that is not abstract: a domestic payment was held on 2026-08-02 and six hours of the
+ * owning service's logs contained exactly one line about sanctions, naming nothing. The real cause
+ * (`duplicate key value violates unique constraint "sanctions_checks_idempotency_key_key"`) was
+ * only findable in a DIFFERENT service's log. On a rail where a screening failure holds customer
+ * money, that is the wrong place for the evidence to live.
+ *
+ * Wrapping the call body — INSIDE the annotated method, so it runs per attempt and inside the
+ * breaker — means every attempt reports its own fault as it happens.
+ *
+ * The failure handler is a parameter rather than a logger on purpose. It keeps this module free of
+ * a logging opinion, and it makes the behaviour assertable in a plain unit test: a test can pin
+ * "the underlying throwable was surfaced" without capturing log output, which is what #3267 asks
+ * for ("the assertion has to be on what was logged, or the change is unverified").
+ *
+ * Applied to `openbank-domestic-payment`'s `SanctionsScreeningAdapter` first. The pattern is
+ * fleet-wide — 57 files stack `@Retry` over `@CircuitBreaker` and only 7 mention a warn/error log
+ * at all — so the remaining adapters are a follow-up sweep, not a blind 57-file refactor.
+ */
+// TooGenericExceptionCaught: catching narrowly is precisely the defect. A Timeout surfaces as an
+// InterruptedException on some paths, a breaker rejection is an unchecked RuntimeException, and the
+// transport faults this exists to reveal are whatever the rest-client threw. Nothing is swallowed —
+// every throwable is rethrown unchanged, so fault tolerance still counts it.
+@Suppress("TooGenericExceptionCaught")
+suspend fun <T> reportingFirstFailure(onFailure: (Throwable) -> Unit, block: suspend () -> T): T = try {
+    block()
+} catch (ex: Throwable) {
+    // Throwable, not Exception: a Timeout surfaces as an InterruptedException on some paths and a
+    // breaker rejection is an unchecked RuntimeException — narrowing here would silently re-create
+    // the blind spot for exactly the faults this exists to show.
+    onFailure(ex)
+    throw ex
+}

--- a/openbank-libs-runtime/src/main/kotlin/com/openbank/libs/observability/ResilientCallMetrics.kt
+++ b/openbank-libs-runtime/src/main/kotlin/com/openbank/libs/observability/ResilientCallMetrics.kt
@@ -1,0 +1,66 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright (c) OpenBank contributors. Licensed under the Apache License, Version 2.0.
+// See LICENSE in the repository root or https://www.apache.org/licenses/LICENSE-2.0 for details.
+
+package com.openbank.libs.observability
+
+import io.micrometer.core.instrument.MeterRegistry
+import jakarta.enterprise.context.ApplicationScoped
+import jakarta.enterprise.inject.Instance
+import jakarta.inject.Inject
+import org.eclipse.microprofile.faulttolerance.exceptions.CircuitBreakerOpenException
+
+/**
+ * Separates *the breaker is open* from *the call failed* on a resilient inter-service adapter.
+ *
+ * #3267's third ask. Without it the two are indistinguishable outside the logs, and they mean
+ * opposite things operationally: `call_failed` is the dependency misbehaving and is what you page
+ * on; `breaker_open` is this service protecting itself and is a CONSEQUENCE of an earlier burst of
+ * `call_failed`. A dashboard that sums them reports a long flat plateau of "sanctions failing"
+ * while the dependency may already have recovered — the breaker is simply still open.
+ *
+ * Same CDI shape as [LlmCallMetrics] and DomainMetrics, deliberately: `@ApplicationScoped` with an
+ * `Instance<MeterRegistry>` rather than a direct injection, so this bean loads harmlessly in a
+ * service with no `quarkus-micrometer-*` on its classpath and every method becomes a silent no-op.
+ * A plain bean, **not** a `@Produces` — a producer would drag Micrometer into the Arc type closure
+ * of every consumer of openbank-libs-runtime, including the ones that make no resilient call.
+ *
+ * One series, tagged only with closed low-cardinality sets:
+ * `openbank.resilient.call.failures{adapter,outcome}` where `outcome` is exactly `breaker_open`
+ * or `call_failed`. The adapter name is a compile-time constant per call site, never a URL or an
+ * id — an unbounded tag here would be a cardinality incident on the money path.
+ */
+@ApplicationScoped
+class ResilientCallMetrics {
+
+    @Inject
+    lateinit var registryInstance: Instance<MeterRegistry>
+
+    private fun reg(): MeterRegistry? = if (registryInstance.isResolvable) registryInstance.get() else null
+
+    /**
+     * Count one failed attempt of [adapter], classifying [error] by whether the breaker rejected
+     * it or the call itself failed.
+     *
+     * Called per ATTEMPT, from inside the `@CircuitBreaker`-annotated method, so the counts line up
+     * with what fault tolerance actually saw rather than with the single exception that escaped.
+     */
+    fun recordFailure(adapter: String, error: Throwable) {
+        val registry = reg() ?: return
+        registry.counter(
+            "openbank.resilient.call.failures",
+            "adapter",
+            adapter,
+            "outcome",
+            outcomeOf(error),
+        ).increment()
+    }
+
+    private fun outcomeOf(error: Throwable): String =
+        if (error is CircuitBreakerOpenException) OUTCOME_BREAKER_OPEN else OUTCOME_CALL_FAILED
+
+    companion object {
+        const val OUTCOME_BREAKER_OPEN = "breaker_open"
+        const val OUTCOME_CALL_FAILED = "call_failed"
+    }
+}

--- a/openbank-libs-runtime/src/test/kotlin/com/openbank/libs/observability/FirstFailureVisibilityTest.kt
+++ b/openbank-libs-runtime/src/test/kotlin/com/openbank/libs/observability/FirstFailureVisibilityTest.kt
@@ -1,0 +1,72 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright (c) OpenBank contributors. Licensed under the Apache License, Version 2.0.
+// See LICENSE in the repository root or https://www.apache.org/licenses/LICENSE-2.0 for details.
+
+package com.openbank.libs.observability
+
+import kotlinx.coroutines.runBlocking
+import org.assertj.core.api.Assertions.assertThat
+import org.assertj.core.api.Assertions.assertThatThrownBy
+import org.junit.jupiter.api.Test
+
+/**
+ * #3267: the original transport fault of a resilient call must be surfaced before fault tolerance
+ * masks it.
+ *
+ * The issue is explicit that the obvious test does not work — "a test asserting the adapter throws
+ * `ScreeningUnavailableException` passes today and would still pass after the fix". The assertion
+ * has to be on what the caller was TOLD about the underlying fault. That is why the failure handler
+ * is a parameter: these pin it directly, with no log capture and no fault-tolerance runtime.
+ */
+class FirstFailureVisibilityTest {
+
+    @Test
+    fun `the original throwable is reported, not a masked one`(): Unit = runBlocking {
+        val seen = mutableListOf<Throwable>()
+        val transportFault = IllegalStateException(
+            """duplicate key value violates unique constraint "sanctions_checks_idempotency_key_key"""",
+        )
+
+        assertThatThrownBy {
+            runBlocking {
+                reportingFirstFailure<Unit>(onFailure = { seen += it }) { throw transportFault }
+            }
+        }.isSameAs(transportFault)
+
+        // The point of #3267: without this, the only thing anyone ever saw was
+        // CircuitBreakerOpenException, which names nothing about what actually failed.
+        assertThat(seen).containsExactly(transportFault)
+        assertThat(seen.single().message).contains("sanctions_checks_idempotency_key_key")
+    }
+
+    @Test
+    fun `the exception is rethrown unchanged, so fault tolerance still sees it`(): Unit = runBlocking {
+        // Swallowing here would turn a held payment into a released one — the helper must observe,
+        // never intercept. @Retry/@CircuitBreaker only count a failure they actually receive.
+        val fault = RuntimeException("boom")
+        assertThatThrownBy {
+            runBlocking { reportingFirstFailure<Unit>(onFailure = { }) { throw fault } }
+        }.isSameAs(fault)
+    }
+
+    @Test
+    fun `a successful call reports nothing and returns its value`(): Unit = runBlocking {
+        val seen = mutableListOf<Throwable>()
+        val result = reportingFirstFailure(onFailure = { seen += it }) { "CLEAR" }
+        assertThat(result).isEqualTo("CLEAR")
+        assertThat(seen).isEmpty()
+    }
+
+    @Test
+    fun `an Error is reported too`(): Unit = runBlocking {
+        // Throwable, not Exception, on purpose: a Timeout surfaces as an InterruptedException on
+        // some paths and a breaker rejection is unchecked. Narrowing the catch would re-create the
+        // blind spot for exactly the faults this exists to show.
+        val seen = mutableListOf<Throwable>()
+        val err = StackOverflowError("deep")
+        assertThatThrownBy {
+            runBlocking { reportingFirstFailure<Unit>(onFailure = { seen += it }) { throw err } }
+        }.isSameAs(err)
+        assertThat(seen).containsExactly(err)
+    }
+}

--- a/openbank-libs-runtime/src/test/kotlin/com/openbank/libs/observability/ResilientCallMetricsTest.kt
+++ b/openbank-libs-runtime/src/test/kotlin/com/openbank/libs/observability/ResilientCallMetricsTest.kt
@@ -1,0 +1,53 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright (c) OpenBank contributors. Licensed under the Apache License, Version 2.0.
+// See LICENSE in the repository root or https://www.apache.org/licenses/LICENSE-2.0 for details.
+
+package com.openbank.libs.observability
+
+import io.micrometer.core.instrument.simple.SimpleMeterRegistry
+import io.mockk.every
+import io.mockk.mockk
+import jakarta.enterprise.inject.Instance
+import org.assertj.core.api.Assertions.assertThat
+import org.eclipse.microprofile.faulttolerance.exceptions.CircuitBreakerOpenException
+import org.junit.jupiter.api.Test
+
+/**
+ * #3267's third ask: *breaker open* and *call failed* must be separable without log spelunking.
+ * They mean opposite things — one is the dependency misbehaving, the other is this service
+ * protecting itself — so a dashboard that cannot tell them apart reports a flat plateau of
+ * "sanctions failing" while the dependency may already have recovered.
+ */
+class ResilientCallMetricsTest {
+
+    private fun metrics(registry: SimpleMeterRegistry?): ResilientCallMetrics {
+        val instance = mockk<Instance<io.micrometer.core.instrument.MeterRegistry>>()
+        every { instance.isResolvable } returns (registry != null)
+        if (registry != null) every { instance.get() } returns registry
+        return ResilientCallMetrics().also { it.registryInstance = instance }
+    }
+
+    @Test
+    fun `a breaker rejection and a transport fault are counted separately`() {
+        val registry = SimpleMeterRegistry()
+        val m = metrics(registry)
+
+        m.recordFailure("sanctions", IllegalStateException("connection refused"))
+        m.recordFailure("sanctions", IllegalStateException("500"))
+        m.recordFailure("sanctions", CircuitBreakerOpenException("open"))
+
+        fun count(outcome: String) = registry
+            .counter("openbank.resilient.call.failures", "adapter", "sanctions", "outcome", outcome)
+            .count()
+
+        assertThat(count(ResilientCallMetrics.OUTCOME_CALL_FAILED)).isEqualTo(2.0)
+        assertThat(count(ResilientCallMetrics.OUTCOME_BREAKER_OPEN)).isEqualTo(1.0)
+    }
+
+    @Test
+    fun `it is a silent no-op when the service has no meter registry`() {
+        // libs-runtime is consumed by services with no quarkus-micrometer on the classpath; the
+        // bean must load and do nothing rather than fail their boot.
+        metrics(null).recordFailure("sanctions", RuntimeException("boom"))
+    }
+}


### PR DESCRIPTION
Closes #3267 · Refs #3264, #3266

## The masking

`@Retry` sits **outside** `@CircuitBreaker` (fixed MicroProfile order: `Fallback > Retry > CircuitBreaker > Timeout > Bulkhead`). Once the breaker opens mid-retry, the remaining attempts fail with `CircuitBreakerOpenException` — and that is what `@Retry` finally propagates. The 500, the timeout, the connection refusal is discarded with the earlier attempts.

The cost, from the issue: a domestic payment held on 2026-08-02, **six hours of the owning service's logs containing exactly one line about sanctions**, naming nothing. The real cause (`duplicate key value violates unique constraint "sanctions_checks_idempotency_key_key"`) was only findable in a *different* service's log. On a rail where a screening failure holds customer money, that is the wrong place for the evidence to live.

## The fix, and where it goes

`reportingFirstFailure` wraps the call body **inside** the annotated method, so it runs per attempt and inside the breaker. Every attempt reports its own fault as it happens, and the throwable is rethrown unchanged so fault tolerance still counts it — swallowing here would turn a held payment into a released one.

The issue asks whether this belongs in a shared helper. Measured, and it does:

| | count |
|---|---|
| files stacking `@Retry` over `@CircuitBreaker` | **57** |
| of those, mentioning a warn/error log at all | **7** |

So it lives in `openbank-libs-runtime`. `SanctionsScreeningAdapter` — the adapter the issue names — is the first consumer and the proof. The other 56 are a follow-up sweep, deliberately **not** a blind 57-file refactor landed inside a money-path PR.

## Why the handler is a parameter, not a logger

This is the part the issue is sharpest about:

> Falsifiability: a test asserting "the adapter throws `ScreeningUnavailableException`" passes today and would still pass after the fix. The assertion has to be on **what was logged** — that the underlying cause appears — or the change is unverified.

Passing the handler in makes that contract assertable directly, with no log capture and no fault-tolerance runtime. `FirstFailureVisibilityTest` pins:

- the **original** throwable reaches the handler (asserted on the `sanctions_checks_idempotency_key_key` message, i.e. the exact fault that was invisible);
- it is rethrown **unchanged** (`isSameAs`) — otherwise `@Retry`/`@CircuitBreaker` would stop counting the failure;
- a success reports nothing;
- an `Error` is reported too.

## `Throwable`, not `Exception`

Deliberate, and the reason is in the code: a `@Timeout` surfaces as an `InterruptedException` on some paths and a breaker rejection is an unchecked `RuntimeException`. Narrowing the catch would silently re-create the blind spot for exactly the faults this exists to reveal. That is also why detekt's `TooGenericExceptionCaught` is suppressed here with a written reason rather than worked around.

## The metric — all three asks are now covered

`ResilientCallMetrics` emits `openbank.resilient.call.failures{adapter,outcome}`, counted **per attempt** from inside the `@CircuitBreaker`-annotated method, so the numbers line up with what fault tolerance actually saw rather than with the single exception that escaped.

Why the two outcomes must be separable, beyond "the issue asked": they mean opposite things. `call_failed` is the dependency misbehaving and is what you page on; `breaker_open` is this service protecting itself, and is a *consequence* of an earlier burst of `call_failed`. A dashboard summing them shows a flat plateau of "sanctions failing" while the dependency may already have recovered — the breaker is simply still open.

Shape follows `LlmCallMetrics`/`DomainMetrics`: `Instance<MeterRegistry>` rather than direct injection, so the bean loads harmlessly in a service with no `quarkus-micrometer` on its classpath and every method is a silent no-op — pinned by a test. A plain bean, **not** a `@Produces`, which would drag Micrometer into the Arc type closure of every consumer of `openbank-libs-runtime` including those that make no resilient call.

Both tags are closed low-cardinality sets: `outcome` is exactly `breaker_open` or `call_failed`, and `adapter` is a compile-time constant per call site — never a URL or an id, which on the money path would be a cardinality incident.

Injected as a **field**, not a constructor parameter: detekt's `LongParameterList` fires AT the threshold, and `@Inject lateinit` is the fleet convention for adding a metrics port to an existing adapter (`LoanStageEventConsumer`, `VopRateLimitFilter`, `McpEndpoint`).

## What this does not do

- **No change to the sibling adapters.** Named above with the measured count so the follow-up is scoped rather than guessed.

## Note for review

This touches `openbank-domestic-payment`, so it is money-path and wants the two approvals per `rules.yaml` / ADR-0030. The behavioural surface is one added WARN per failed attempt; the screening semantics, the fail-closed mapping to `ScreeningUnavailableException`, and the annotation stack are untouched.

`ktlintCheck`, `detekt`, `test` green for `openbank-libs-runtime` and `openbank-domestic-payment`, plus `quarkusBuild` on domestic-payment — CDI wiring is not validated by ktlint or unit tests, and a new `@Inject` field is exactly what that build catches.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

