### PR TITLE
fix(sanctions): merge on the review path, so a screening hit can actually be dispositioned

### DIFF
--- a/docs/threat-models/openbank-sanctions-service.md
+++ b/docs/threat-models/openbank-sanctions-service.md
@@ -8,12 +8,14 @@ STRIDE/DFD threat model for the sanctions/PEP screening bounded context, per ADR
 Money-path service — `SANCTIONS_SCREENING` in the KYC check set (ADR-0116) delegates here, and
 ADR-0032 documents the synchronous AML/sanctions screening gate. Reviewed in PR.
 
-- **Status:** Draft (first pass, written alongside the real-feed-registration wiring)
-- **Last reviewed:** 2026-07-07
+- **Status:** Draft (first pass, written alongside the real-feed-registration wiring; §6 added
+  with the review-path persistence fix)
+- **Last reviewed:** 2026-08-02
 - **Owner:** sanctions/AML CODEOWNERS
 - **Related ADRs:** ADR-0002 (hexagonal), ADR-0032 (synchronous AML/sanctions screening gate),
   ADR-0100 (injected Clock, Layer 1 determinism), ADR-0116 (KYC engine — `SANCTIONS_SCREENING`
-  check delegates to this service), ADR-0030 (money-path threat models)
+  check delegates to this service), ADR-0030 (money-path threat models),
+  ADR-0126 (assigned-id persistence), ADR-0155 (four-eyes gate)
 
 ## 1. Scope & assets
 
@@ -115,7 +117,45 @@ TLS. Domain layer (`SanctionsEntry`, `SanctionsList` models) has zero framework 
   §"External watchlist... Planned"). This threat model and PR close the **sanctions-screening feed
   registration/wiring** half of ADR-0116's screening surface, not the KYC-side vendor integration.
 
-## 6. Change log
+## 6. Manual review of a screening hit (`sanctions.clear`)
+
+Sections 1-5 model the **import** side only — feeds, `source_url` integrity, parser resource use.
+They omit the disposition side entirely, which is the higher-consequence half:
+`rules.yaml: money_path_services` justifies this service's entry on precisely that action, since
+"a wrongly-cleared true positive is a real sanctions violation". This section closes that gap.
+
+**Asset.** The disposition decision itself — the transition of a `HIT` / `POTENTIAL_HIT` to
+`CLEAR` / `WHITELISTED` / `ESCALATED`, together with `reviewed_by` and `review_note`. A wrongly
+recorded `CLEAR` releases a payment that a real match should have stopped; a lost or unattributable
+decision destroys the audit trail that a screening call was ever adjudicated by a human.
+
+**Entry point.** `POST /api/v1/sanctions/review` — `@RolesAllowed("ROLE_OPERATOR", "ROLE_ADMIN")`,
+`@Authorize(action = "sanctions.clear")`, deliberately no `ROLE_API`; there is no M2M caller (all
+six `SanctionsServiceClient` interfaces declare only `/screen`). Externally routable via the
+`sanctions-api` Ingress (`api.open-bank.tech`, prefix `/api/v1/sanctions`).
+
+| # | Threat | Mitigation | Residual risk |
+|---|---|---|---|
+| C1 | **Elevation / segregation of duties** — one operator both raises and clears a hit | Four-eyes on `sanctions.clear` (ADR-0155): `AuthorizeInterceptor` pauses the maker's call with 202 + a `PendingApproval` id; a DIFFERENT principal decides it via `PATCH /api/v1/sanctions/approvals/{id}`; the maker retries with `X-Approval-Id`. Enforced centrally in `RedisApprovalStore.decide`, not per-service, so a service's REST layer cannot forget it | **The guard compares principal-id strings.** One human or agent holding two identities satisfies it — #3190 is the measured lending instance. Mechanism-level limit, not an implementation defect; mitigating it needs identity-level controls, not more code here. **Separately, the guard is unfalsified (#3349):** no test anywhere feeds it a maker approving themselves — `AuthorizeInterceptorTest`'s fake re-implements the check, so deleting the production line stays green |
+| C2 | **Over-broad approval grant** — a checker approves one specific decision, the maker applies it elsewhere | `AuthorizeInterceptor.satisfies()` binds an approval to (action, resourceId, maker), and `markExecuted` makes it one-time — an EXECUTED approval can never be replayed | `@Authorize(action = "sanctions.clear", resource = "")` carries an **empty resource**, so a granted approval authorises *any* review by that maker, not the check the checker actually looked at. Narrowing it to `resource = "#cmd.checkId"` is the fix; deferred because no UI drives this flow yet (#3334) |
+| C3 | **Repudiation** — a cleared hit with no attributable decider | `reviewed_by` / `review_note` / `reviewed_at` persisted on the check; a `SanctionChecked` outbox event is emitted in the **same transaction** as the update, so audit/AML consumers cannot miss a decision that was durably recorded | Outbox delivery is at-least-once, not exactly-once; consumers must dedupe. `OutboxMessage.createdAt` defaults to `Instant.EPOCH` fleet-wide (#3272), which inverts FIFO claim order |
+| C4 | **Tampering via lost update** — a review silently overwrites a concurrent one | Single-statement `merge` inside one transaction | **No optimistic locking**: the entity has no `@Version`, so two concurrent reviewers last-write-wins with no conflict surfaced. Low likelihood while the queue is worked by hand; revisit if #3334 makes review routine |
+| C5 | **Denial of the control itself** — the review path does not work at all | Covered by `SanctionsReviewUpdateIT` against a real Postgres | Was live until this change: `review()` called the insert path on an application-assigned `@Id`, so **every** review died at flush on `sanctions_checks_pkey` (ADR-0126 D3). Nothing alerted — see below |
+
+**Invariant (must never regress).** The review path performs an **UPDATE**. The insert path
+(`saveWithEvent`) and the update path (`updateWithEvent`) stay separate: `merge` cannot raise a
+primary-key violation, and the insert path deliberately lets that violation escape (#3264), because
+there it signals a real defect rather than an idempotent replay. Collapsing the two into an
+unconditional upsert would delete that guard and render `SanctionsIdempotentReplayIT`'s
+primary-key case structurally unable to fail.
+
+**Detection gap worth naming.** C5 was invisible to every layer: the service's unit test stubbed the
+repository port, so it asserted a call that in production always threw; no UI exercised the endpoint
+(#3334); no M2M caller existed; and a failed review is a 500 on a rarely-used path, which no alert
+distinguishes from noise. The only signal available anywhere was `listPending()` never shrinking —
+and nothing alerts on a queue that fails to drain (the same class as #3273).
+
+## 7. Change log
 
 - **2026-07-07** — Verified the sanctions/PEP feed registry (`sanctions_lists`, Flyway V3/V7/V8) was
   already populated with real, live source URLs (OFAC Treasury `sdn.xml`; EU/UN/HM Treasury via

--- a/openbank-sanctions-service/src/main/kotlin/com/openbank/sanctions/application/port/out/SanctionsPorts.kt
+++ b/openbank-sanctions-service/src/main/kotlin/com/openbank/sanctions/application/port/out/SanctionsPorts.kt
@@ -14,8 +14,23 @@ interface SanctionsRepository {
     /** Persist check only (no outbox event). */
     suspend fun save(check: SanctionsCheck): SanctionsCheck
 
-    /** Persist check + outbox event atomically in one transaction. */
+    /**
+     * INSERT a NEW check + its outbox event atomically in one transaction.
+     *
+     * Insert-only by design. The aggregate's `@Id` is application-assigned, so this cannot be
+     * reused to update an existing check — see [updateWithEvent], and the split's rationale in
+     * `SanctionsRepositoryImpl`.
+     */
     suspend fun saveWithEvent(check: SanctionsCheck, eventType: String): SanctionsCheck
+
+    /**
+     * UPDATE an existing check + emit its outbox event atomically in one transaction.
+     *
+     * Separate from [saveWithEvent] because the two lifecycles need different Hibernate
+     * operations on an application-assigned `@Id`, and because they must fail differently on a
+     * primary-key collision — the insert path treats one as a real defect worth propagating.
+     */
+    suspend fun updateWithEvent(check: SanctionsCheck, eventType: String): SanctionsCheck
 
     suspend fun findById(id: UUID): SanctionsCheck?
 

--- a/openbank-sanctions-service/src/main/kotlin/com/openbank/sanctions/application/usecase/SanctionsService.kt
+++ b/openbank-sanctions-service/src/main/kotlin/com/openbank/sanctions/application/usecase/SanctionsService.kt
@@ -107,7 +107,10 @@ class SanctionsService(
             reviewNote = cmd.note,
             reviewedAt = Instant.now(clock),
         )
-        return repo.saveWithEvent(updated, "SanctionChecked")
+        // updateWithEvent, not saveWithEvent: this check already exists, and the aggregate's id is
+        // application-assigned, so the insert path would schedule an INSERT and collide with its
+        // own primary key (ADR-0126 D3).
+        return repo.updateWithEvent(updated, "SanctionChecked")
     }
 
     override suspend fun getById(id: UUID) = repo.findById(id)

--- a/openbank-sanctions-service/src/main/kotlin/com/openbank/sanctions/infrastructure/persistence/repository/SanctionsRepositoryImpl.kt
+++ b/openbank-sanctions-service/src/main/kotlin/com/openbank/sanctions/infrastructure/persistence/repository/SanctionsRepositoryImpl.kt
@@ -66,6 +66,42 @@ class SanctionsRepositoryImpl(private val outboxRepo: SanctionsOutboxRepository)
     }
 
     /**
+     * Update an existing check and emit its outbox event in one transaction (`SanctionsService.review`).
+     *
+     * `merge`, not `persist`, and that is not interchangeable here: `SanctionsCheckEntity.id` is
+     * application-assigned (no `@GeneratedValue`), so a non-null id cannot tell Hibernate whether
+     * the instance is transient or detached. `persist` resolves that ambiguity by always
+     * scheduling an INSERT, so every review died at flush on `sanctions_checks_pkey` — the manual
+     * disposition of a screening hit, which `rules.yaml` calls the highest-risk action in this
+     * service, had never once worked. ADR-0126 D3; the same defect 500'd every consent-service
+     * transition (#1521/#1553) and broke standing-order cancel (#2079). `SddMandateRepositoryImpl`
+     * documents the pattern.
+     *
+     * Kept as a SEPARATE method rather than making [saveWithEvent] an unconditional upsert. A
+     * `merge` cannot raise a primary-key violation, and the insert path deliberately lets that
+     * violation escape (see [isIdempotencyKeyViolation]) because there it signals a real defect
+     * rather than a replay. Merging the two paths would therefore delete a live guard and render
+     * `SanctionsIdempotentReplayIT`'s primary-key case structurally unable to fail.
+     *
+     * `call` rather than `chain`: the merged instance is the return value, and it is NOT the same
+     * object as `e` — Hibernate returns a managed copy, so reading state back off `e` would give
+     * the detached input, not what was written.
+     */
+    override suspend fun updateWithEvent(check: SanctionsCheck, eventType: String): SanctionsCheck {
+        val e = check.toEntity()
+        val event = OutboxMessage(
+            aggregateId = check.id,
+            eventType = eventType,
+            payload = mapper.writeValueAsString(check),
+        )
+        return Panache.withTransaction {
+            Panache.getSession()
+                .flatMap { session -> session.merge(e) }
+                .call { _ -> outboxRepo.persistInTransaction(event) }
+        }.awaitSuspending().toDomain()
+    }
+
+    /**
      * True when this violation is the unique index on `sanctions_checks.idempotency_key`.
      *
      * Identified by constraint, never by SQLSTATE alone: a primary-key collision is also 23505,

--- a/openbank-sanctions-service/src/test/kotlin/com/openbank/sanctions/application/usecase/SanctionsServiceTest.kt
+++ b/openbank-sanctions-service/src/test/kotlin/com/openbank/sanctions/application/usecase/SanctionsServiceTest.kt
@@ -161,7 +161,7 @@ class SanctionsServiceTest {
         val id = UUID.randomUUID()
         val existing = sampleCheck(id = id, status = SanctionsCheckStatus.HIT)
         coEvery { repo.findById(id) } returns existing
-        coEvery { repo.saveWithEvent(any(), any()) } answers { firstArg() }
+        coEvery { repo.updateWithEvent(any(), any()) } answers { firstArg() }
 
         val result = service.review(
             ReviewCommand(
@@ -176,12 +176,18 @@ class SanctionsServiceTest {
         assertThat(result.reviewedBy).isEqualTo("analyst-1")
         assertThat(result.reviewNote).isEqualTo("cleared after manual review")
         assertThat(result.reviewedAt).isNotNull
+        // The UPDATE path specifically. Asserting only "some save was called" is what let this
+        // test pass for the whole life of the service while every real review 500'd on
+        // `sanctions_checks_pkey` — a mock cannot see Hibernate's INSERT-vs-UPDATE decision, so
+        // pinning WHICH port method is called is the only thing this layer can contribute.
+        // SanctionsReviewUpdateIT owns the behaviour itself, against a real database.
         coVerify {
-            repo.saveWithEvent(
+            repo.updateWithEvent(
                 match { it.status == SanctionsCheckStatus.CLEAR && it.reviewedBy == "analyst-1" },
                 eq("SanctionChecked"),
             )
         }
+        coVerify(exactly = 0) { repo.saveWithEvent(any(), any()) }
     }
 
     @Test

--- a/openbank-sanctions-service/src/test/kotlin/com/openbank/sanctions/it/SanctionsReviewUpdateIT.kt
+++ b/openbank-sanctions-service/src/test/kotlin/com/openbank/sanctions/it/SanctionsReviewUpdateIT.kt
@@ -1,0 +1,185 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright (c) OpenBank contributors. Licensed under the Apache License, Version 2.0.
+// See LICENSE in the repository root or https://www.apache.org/licenses/LICENSE-2.0 for details.
+
+package com.openbank.sanctions.it
+
+import com.openbank.sanctions.application.port.`in`.ReviewCommand
+import com.openbank.sanctions.application.port.`in`.SanctionsUseCase
+import com.openbank.sanctions.domain.model.EntityType
+import com.openbank.sanctions.domain.model.SanctionsCheck
+import com.openbank.sanctions.domain.model.SanctionsCheckStatus
+import com.openbank.sanctions.domain.model.SanctionsListType
+import com.openbank.sanctions.infrastructure.persistence.repository.SanctionsRepositoryImpl
+import io.quarkus.test.common.QuarkusTestResource
+import io.quarkus.test.junit.QuarkusTest
+import io.quarkus.vertx.VertxContextSupport
+import io.smallrye.mutiny.coroutines.awaitSuspending
+import io.smallrye.mutiny.coroutines.uni
+import io.vertx.mutiny.pgclient.PgPool
+import io.vertx.mutiny.sqlclient.Tuple
+import jakarta.inject.Inject
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.Dispatchers
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Test
+import java.time.Instant
+import java.util.UUID
+
+/**
+ * Real-Postgres verification that a manual review UPDATES the stored check.
+ *
+ * `SanctionsService.review` loads a check, copies it with the review fields set, and hands the
+ * result back to the repository. The aggregate's `@Id` is application-assigned
+ * (`SanctionsCheckEntity.id`, no `@GeneratedValue`), so a repository `save` that calls `persist`
+ * schedules an INSERT and never an UPDATE — Hibernate cannot tell a transient instance from a
+ * detached one when the id is already non-null. Every review therefore died at flush with
+ * `duplicate key value violates unique constraint "sanctions_checks_pkey"` (ADR-0126 D3; the same
+ * defect made every consent-service transition 500 in #1521/#1553 and broke standing-order cancel
+ * in #2079).
+ *
+ * This must run against a real database. A mocked repository cannot express it: the failure is
+ * Hibernate's INSERT-vs-UPDATE decision at flush time, not anything visible in the port's
+ * signature — which is exactly why the service's unit tests passed throughout.
+ *
+ * The test drives the real `SanctionsUseCase` bean rather than the repository directly, so it also
+ * covers the wiring: `review` must reach the update path, and `screen` must keep reaching the
+ * insert path (`SanctionsIdempotentReplayIT` owns the latter).
+ */
+@QuarkusTest
+@QuarkusTestResource(PostgresTestResource::class)
+class SanctionsReviewUpdateIT {
+
+    @Inject
+    lateinit var useCase: SanctionsUseCase
+
+    @Inject
+    lateinit var repository: SanctionsRepositoryImpl
+
+    @Inject
+    lateinit var pool: PgPool
+
+    private fun <T> onEventLoop(block: suspend () -> T): T =
+        VertxContextSupport.subscribeAndAwait { uni(CoroutineScope(Dispatchers.Unconfined)) { block() } }
+
+    @BeforeEach
+    fun clearTables() {
+        onEventLoop {
+            pool.query("DELETE FROM sanctions_checks").execute().awaitSuspending()
+            pool.query("DELETE FROM sanctions_outbox").execute().awaitSuspending()
+        }
+    }
+
+    private fun hit(key: String, id: UUID = UUID.randomUUID()) = SanctionsCheck(
+        id = id,
+        idempotencyKey = key,
+        entityType = EntityType.INDIVIDUAL,
+        name = "Screened Subject",
+        aliases = emptyList(),
+        dateOfBirth = null,
+        nationality = null,
+        identifiers = emptyMap(),
+        status = SanctionsCheckStatus.POTENTIAL_HIT,
+        matches = emptyList(),
+        overallScore = 0.7,
+        checkedLists = listOf(SanctionsListType.OFAC_SDN),
+        reviewedBy = null,
+        reviewNote = null,
+        checkedAt = Instant.parse("2026-08-02T10:58:10Z"),
+        reviewedAt = null,
+    )
+
+    private fun rowCount(): Long = onEventLoop {
+        pool.query("SELECT count(*) AS c FROM sanctions_checks").execute().awaitSuspending()
+            .iterator().next().getLong("c")
+    }
+
+    private fun outboxCount(): Long = onEventLoop {
+        pool.query("SELECT count(*) AS c FROM sanctions_outbox").execute().awaitSuspending()
+            .iterator().next().getLong("c")
+    }
+
+    private fun storedStatus(id: UUID): String = onEventLoop {
+        pool.preparedQuery("SELECT status FROM sanctions_checks WHERE id = $1")
+            .execute(Tuple.of(id)).awaitSuspending()
+            .iterator().next().getString("status")
+    }
+
+    @Test
+    fun `reviewing a potential hit updates the stored row instead of colliding with its own primary key`() {
+        val stored = onEventLoop { repository.saveWithEvent(hit("review-key-1"), "SanctionChecked") }
+
+        val reviewed = onEventLoop {
+            useCase.review(
+                ReviewCommand(
+                    checkId = stored.id,
+                    reviewedBy = "operator-1",
+                    note = "false positive — different date of birth",
+                    newStatus = SanctionsCheckStatus.CLEAR,
+                ),
+            )
+        }
+
+        assertThat(reviewed.id).isEqualTo(stored.id)
+        assertThat(reviewed.status).isEqualTo(SanctionsCheckStatus.CLEAR)
+        assertThat(reviewed.reviewedBy).isEqualTo("operator-1")
+        assertThat(reviewed.reviewNote).isEqualTo("false positive — different date of birth")
+        assertThat(reviewed.reviewedAt).isNotNull()
+
+        assertThat(rowCount())
+            .describedAs("a review must UPDATE the check, never insert a second copy of it")
+            .isEqualTo(1)
+        assertThat(storedStatus(stored.id))
+            .describedAs("the transition must be durable, not just present on the returned object")
+            .isEqualTo("CLEAR")
+    }
+
+    @Test
+    fun `a review emits its own outbox event in the same transaction as the update`() {
+        val stored = onEventLoop { repository.saveWithEvent(hit("review-key-2"), "SanctionChecked") }
+        assertThat(outboxCount()).isEqualTo(1)
+
+        onEventLoop {
+            useCase.review(
+                ReviewCommand(
+                    checkId = stored.id,
+                    reviewedBy = "operator-2",
+                    note = "confirmed match, escalating",
+                    newStatus = SanctionsCheckStatus.ESCALATED,
+                ),
+            )
+        }
+
+        assertThat(outboxCount())
+            .describedAs("the review decision is an event downstream AML/audit consumers must see")
+            .isEqualTo(2)
+        assertThat(storedStatus(stored.id)).isEqualTo("ESCALATED")
+    }
+
+    /**
+     * Two reviews in a row: the second must update the row the first left behind. A fix that
+     * merely made the first review work — for example by deleting and re-inserting — would pass
+     * the first test and fail this one.
+     */
+    @Test
+    fun `a second review updates the row the first one left, and never accumulates rows`() {
+        val stored = onEventLoop { repository.saveWithEvent(hit("review-key-3"), "SanctionChecked") }
+
+        onEventLoop {
+            useCase.review(
+                ReviewCommand(stored.id, "operator-1", "cleared in error", SanctionsCheckStatus.CLEAR),
+            )
+        }
+        val second = onEventLoop {
+            useCase.review(
+                ReviewCommand(stored.id, "operator-2", "re-opened, it is a real match", SanctionsCheckStatus.HIT),
+            )
+        }
+
+        assertThat(second.status).isEqualTo(SanctionsCheckStatus.HIT)
+        assertThat(second.reviewedBy).isEqualTo("operator-2")
+        assertThat(rowCount()).isEqualTo(1)
+        assertThat(storedStatus(stored.id)).isEqualTo("HIT")
+    }
+}


### PR DESCRIPTION
## Summary

`SanctionsService.review()` called the INSERT path on an application-assigned `@Id`, so every manual
review of a screening hit died at flush on `sanctions_checks_pkey` — the action `rules.yaml` uses to
justify this service's money-path entry has never once worked. Fixed by splitting the insert and
update lifecycles, with the update path using `merge`.

## Type of change

- [ ] feat (new functionality)
- [x] fix (bug fix)
- [ ] refactor (no behavior change)
- [ ] perf (performance)
- [ ] docs
- [ ] chore (build / tooling)
- [ ] security (private until disclosed)
- [ ] breaking change

## Linked issues

Closes #3375
Refs #3334, #3264, #3349

## Changes

- `SanctionsRepository` (port): `saveWithEvent` documented as INSERT-only; new `updateWithEvent`.
- `SanctionsRepositoryImpl.updateWithEvent`: `Panache.getSession().flatMap { it.merge(e) }` with the
  outbox event in the same transaction — the pattern `SddMandateRepositoryImpl` documents. Uses
  `call` rather than `chain` because `merge` returns a **managed copy**, not the input instance, so
  reading state back off `e` would return the detached object rather than what was written.
- `SanctionsService.review()` now calls `updateWithEvent`; `screen()` is untouched.
- New `SanctionsReviewUpdateIT` (real Postgres, testcontainers).
- `SanctionsServiceTest`: the review case stubbed `saveWithEvent`, so it asserted a call that always
  threw in production. It now pins `updateWithEvent` and asserts the insert path is never touched.
- `docs/threat-models/openbank-sanctions-service.md`: new §6 for the review path.

## Why a split rather than an upsert

This is the part worth reviewing carefully. Making `saveWithEvent` an unconditional upsert looks
simpler and is wrong here: a `merge` cannot raise a primary-key violation, and the insert path
deliberately lets that violation escape. #3264's replay guard (merged yesterday in #3340) catches
**only** `sanctions_checks_idempotency_key_key`, and its KDoc states the reason — a pkey collision
means the persist-vs-merge defect and "swallowing that as an idempotent replay would hide a real
defect behind a successful-looking response". An upsert would delete that guard and render
`SanctionsIdempotentReplayIT`'s primary-key case structurally unable to fail.

## Verification

Confirmed RED before the fix, against a real Postgres — all three new cases failed with:

```
org.hibernate.exception.ConstraintViolationException: error executing SQL statement
[ERROR: duplicate key value violates unique constraint "sanctions_checks_pkey" (23505)]
[insert into sanctions_checks (aliases,checked_a…
```

The `insert into` in the failing statement is the point: this is the ADR-0126 D3 mechanism, not
merely a matching symptom.

After the fix, read from the JUnit XML rather than the console: **84 tests, 0 failures, 0 errors.**
Both integration classes actually executed (verified per-class, so neither was silently filtered
out): `SanctionsReviewUpdateIT` 3/3 and `SanctionsIdempotentReplayIT` 3/3 — the latter including its
primary-key case, i.e. #3264's guard survives the split.

`./gradlew :openbank-sanctions-service:detekt ktlintCheck koverVerify build` — BUILD SUCCESSFUL,
including `quarkusBuildAppModel` so the new port's CDI wiring is exercised.

The third new test (two consecutive reviews) exists to reject a delete-and-reinsert "fix" that would
pass the first case.

## Definition of Done

- [x] Hexagonal layering preserved (domain has zero framework imports).
- [x] Unit tests added/updated.
- [x] Integration tests added/updated (if service boundary involved).
- [ ] Contract tests updated (if public API changed) — N/A, no API change.
- [x] `./gradlew detekt ktlintCheck koverVerify build` passes.
- [x] No new lint warnings.
- [ ] OpenAPI spec regenerated (if REST API changed) — N/A, the REST contract is unchanged; this is
      a persistence defect behind an already-specified endpoint.
- [ ] Flyway migration added + rollback note (if DB changed) — N/A, no schema change.
- [ ] Avro schema versioned backward-compatibly (if event changed) — N/A, `SanctionChecked` payload
      unchanged.
- [x] Docs updated (README, ADR if architectural).

## Security checklist

- [x] No secrets, tokens, passwords, or PII in code, config, tests, logs.
- [x] No new `@SuppressWarnings`, `as Any`, `@Suppress("...")`.
- [x] No new third-party dependency.
- [ ] Auth / crypto / payment code changed? — no. The four-eyes gate on `sanctions.clear` is
      unchanged by this PR; §6 of the threat model documents it, and #3349 tracks the fact that its
      self-approval guard is unfalsified.
- [ ] PII path changed? — no.
- [ ] Cardholder data path changed? — no.

## Compliance impact

- [x] AML / 5AMLD

5AMLD Art. 13 manual review of a screening match was impossible through the product. This restores
the persistence half; #3334 tracks the fact that nothing currently calls the endpoint, so an
operator still has no UI path. No compensating control is being removed.

## Rollout / Rollback

- Deployment strategy: rolling
- Rollback plan: revert this commit. The pre-change behaviour is a 500 on every review, so a revert
  restores a broken path rather than risking a working one — no data written by this change needs
  unwinding.
- Data migration reversible: N/A — no schema change.

## Reviewer notes

- The load-bearing question is the split-vs-upsert argument above. If you disagree, the thing to
  check is `SanctionsIdempotentReplayIT."a primary-key collision still propagates and is not
  mistaken for a replay"` — an upsert makes that test unfalsifiable.
- `updateWithEvent` uses `call`, not `chain`, deliberately: `merge` returns a managed copy and the
  return value must be it, not the detached input.
- Two residual risks are recorded in the threat model rather than fixed here, both out of scope:
  `@Authorize(action = "sanctions.clear", resource = "")` has an empty resource, so an approval
  authorises any review by that maker rather than the specific check; and the entity has no
  `@Version`, so concurrent reviewers are last-write-wins. Neither is introduced by this PR, and
  both become materially more likely once #3334 gives the flow a UI.
