### PR TITLE
feat(domestic-payment): alert on payments that stop progressing, not just on the service being down

### DIFF
--- a/openbank-domestic-payment/src/main/kotlin/com/openbank/domestic/application/port/out/DomesticPaymentPorts.kt
+++ b/openbank-domestic-payment/src/main/kotlin/com/openbank/domestic/application/port/out/DomesticPaymentPorts.kt
@@ -8,6 +8,7 @@ import com.openbank.domestic.domain.model.DomesticPayment
 import com.openbank.domestic.domain.model.DomesticPaymentStatus
 import com.openbank.libs.persistence.outbox.OutboxMessage
 import com.openbank.libs.persistence.outbox.OutboxRepository
+import java.time.Instant
 import java.util.UUID
 
 /**
@@ -35,6 +36,18 @@ interface DomesticPaymentRepository {
 
     /** Update a payment and enqueue a domain-event outbox message, atomically. */
     suspend fun update(payment: DomesticPayment, outboxMessage: OutboxMessage): DomesticPayment
+
+    /** How many payments currently sit in [status]. */
+    suspend fun countByStatus(status: DomesticPaymentStatus): Long
+
+    /**
+     * When the oldest payment still in [status] was created, or `null` if none is.
+     *
+     * Feeds the stranded-payment age gauge (#3273): a payment held in a non-terminal state is a
+     * successful-looking 2xx that never progressed, so no error-rate or latency signal can see it —
+     * only its age can.
+     */
+    suspend fun oldestCreatedAt(status: DomesticPaymentStatus): Instant?
 }
 
 /** Outbound port for draining the transactional outbox (read pending, mark sent/failed). */

--- a/openbank-domestic-payment/src/main/kotlin/com/openbank/domestic/infrastructure/observability/DomesticPaymentStrandedGauge.kt
+++ b/openbank-domestic-payment/src/main/kotlin/com/openbank/domestic/infrastructure/observability/DomesticPaymentStrandedGauge.kt
@@ -1,0 +1,134 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright (c) OpenBank contributors. Licensed under the Apache License, Version 2.0.
+// See LICENSE in the repository root or https://www.apache.org/licenses/LICENSE-2.0 for details.
+package com.openbank.domestic.infrastructure.observability
+
+import com.openbank.domestic.application.port.out.DomesticPaymentRepository
+import com.openbank.domestic.domain.model.DomesticPaymentStatus
+import io.micrometer.core.instrument.Gauge
+import io.micrometer.core.instrument.MeterRegistry
+import io.quarkus.runtime.Startup
+import io.quarkus.scheduler.Scheduled
+import jakarta.annotation.PostConstruct
+import jakarta.enterprise.context.ApplicationScoped
+import jakarta.enterprise.inject.Instance
+import jakarta.inject.Inject
+import java.time.Clock
+import java.time.Duration
+import java.time.Instant
+import java.util.concurrent.atomic.AtomicLong
+
+/**
+ * Publishes how long payments have been sitting in a **non-terminal** state (#3273).
+ *
+ *  - `openbank_domestic_payments_non_terminal{service="domestic",status="..."}` — how many
+ *    payments are in that state right now.
+ *  - `openbank_domestic_payments_non_terminal_oldest_age_seconds{service="domestic",status="..."}`
+ *    — age of the oldest one, or `0` when there are none.
+ *
+ * ### Why an age gauge and not another error signal
+ *
+ * domestic-payment was already covered by `PaymentServiceDown`, `HighErrorRate`, `HighLatencyP99`
+ * and both `PaymentSLO*Burn` rules in `prometheus-rules-tier1.yaml`, and all of them were green
+ * while seven payments sat in `RECEIVED` — the oldest for six weeks. They were green *correctly*: a
+ * payment held fail-closed answered **2xx**, emitted no error span, took normal latency, and its pod
+ * was healthy. Every existing rule measures whether the service **answers**; none measures whether
+ * the work it accepted **progresses**. Nothing else in this service can express that, because a
+ * stranded payment is indistinguishable from a healthy one at every layer except its age.
+ *
+ * Terminal states ([DomesticPaymentStatus.SETTLED], `REJECTED`, `CANCELLED`, `RETURNED`) are not
+ * published: their age only grows and would alert forever.
+ *
+ * Per-status series rather than one aggregate, because the thresholds genuinely differ —
+ * `SENT_TO_CLEARING` legitimately waits for a clearing cycle, while `RECEIVED` should never be more
+ * than minutes old. One number for both could only be set to the loosest of them, which is the same
+ * as not alerting on `RECEIVED` at all.
+ *
+ * Mirrors [com.openbank.domestic.infrastructure.outbox.DomesticPaymentOutboxBacklogGauge]:
+ * Micrometer samples a gauge supplier synchronously on the Prometheus scrape (worker) thread, but
+ * these come from reactive queries — so a scheduled `suspend` tick refreshes cached [AtomicLong]s on
+ * the right context and the suppliers read those caches cheaply and lock-free.
+ *
+ * Service-local `MeterRegistry` (null-safe via [Instance], exactly like `ComplaintDeadlineGauge`):
+ * this is a domestic-payment concern, so putting it in the shared libs `DomainMetrics` facade would
+ * force a fleet-wide rebuild for one service's signal.
+ */
+@Startup
+@ApplicationScoped
+class DomesticPaymentStrandedGauge(
+    private val paymentRepository: DomesticPaymentRepository,
+    private val registry: MeterRegistry?,
+    private val clock: Clock,
+) {
+    // CDI constructor: MeterRegistry is optional (absent when no Prometheus registry is on the
+    // classpath, e.g. in slim test slices). Without an explicit @Inject constructor, ArC sees two
+    // constructors, registers no bean, and the @Startup hook silently never runs.
+    @Inject
+    constructor(
+        paymentRepository: DomesticPaymentRepository,
+        registryInstance: Instance<MeterRegistry>,
+        clock: Clock,
+    ) : this(
+        paymentRepository,
+        if (registryInstance.isResolvable) registryInstance.get() else null,
+        clock,
+    )
+
+    private val counts: Map<DomesticPaymentStatus, AtomicLong> =
+        NON_TERMINAL.associateWith { AtomicLong(0) }
+    private val oldestAgeSeconds: Map<DomesticPaymentStatus, AtomicLong> =
+        NON_TERMINAL.associateWith { AtomicLong(0) }
+
+    @PostConstruct
+    fun register() {
+        val r = registry ?: return
+        NON_TERMINAL.forEach { status ->
+            gauge(r, "openbank.domestic.payments.non_terminal", status, counts.getValue(status))
+            gauge(
+                r,
+                "openbank.domestic.payments.non_terminal.oldest.age.seconds",
+                status,
+                oldestAgeSeconds.getValue(status),
+            )
+        }
+    }
+
+    private fun gauge(r: MeterRegistry, name: String, status: DomesticPaymentStatus, holder: AtomicLong) {
+        Gauge.builder(name, holder) { it.get().toDouble() }
+            .tag("service", SERVICE)
+            .tag("status", status.name)
+            .strongReference(true)
+            .register(r)
+    }
+
+    @Scheduled(
+        every = "30s",
+        delayed = "15s",
+        concurrentExecution = Scheduled.ConcurrentExecution.SKIP,
+    )
+    suspend fun refresh() {
+        val now = Instant.now(clock)
+        NON_TERMINAL.forEach { status ->
+            counts.getValue(status).set(paymentRepository.countByStatus(status))
+            // Absent oldest row means the state is empty — report 0, not a stale previous age.
+            val oldest = paymentRepository.oldestCreatedAt(status)
+            oldestAgeSeconds.getValue(status).set(
+                oldest?.let { maxOf(0L, Duration.between(it, now).seconds) } ?: 0L,
+            )
+        }
+    }
+
+    companion object {
+        private const val SERVICE = "domestic"
+
+        /**
+         * States a payment must move out of. A payment in any of these has been accepted and is
+         * still owed an outcome, so age is meaningful; in a terminal state it is not.
+         */
+        val NON_TERMINAL: List<DomesticPaymentStatus> = listOf(
+            DomesticPaymentStatus.RECEIVED,
+            DomesticPaymentStatus.VALIDATED,
+            DomesticPaymentStatus.SENT_TO_CLEARING,
+        )
+    }
+}

--- a/openbank-domestic-payment/src/main/kotlin/com/openbank/domestic/infrastructure/persistence/repository/DomesticPaymentRepositoryImpl.kt
+++ b/openbank-domestic-payment/src/main/kotlin/com/openbank/domestic/infrastructure/persistence/repository/DomesticPaymentRepositoryImpl.kt
@@ -15,6 +15,7 @@ import io.quarkus.hibernate.reactive.panache.Panache
 import io.quarkus.hibernate.reactive.panache.kotlin.PanacheRepository
 import io.smallrye.mutiny.coroutines.awaitSuspending
 import jakarta.enterprise.context.ApplicationScoped
+import java.time.Instant
 import java.util.UUID
 
 @ApplicationScoped
@@ -33,6 +34,13 @@ class DomesticPaymentRepositoryImpl(private val outboxRepository: DomesticPaymen
 
     override suspend fun findByIdempotencyKey(idempotencyKey: String): DomesticPayment? =
         Panache.withSession { find("idempotencyKey", idempotencyKey).firstResult() }.awaitSuspending()?.toDomain()
+
+    override suspend fun countByStatus(status: DomesticPaymentStatus): Long =
+        Panache.withSession { count("status", status.name) }.awaitSuspending()
+
+    override suspend fun oldestCreatedAt(status: DomesticPaymentStatus): Instant? = Panache.withSession {
+        find("status = ?1 order by createdAt asc", status.name).firstResult()
+    }.awaitSuspending()?.createdAt
 
     override suspend fun list(
         status: DomesticPaymentStatus?,

--- a/openbank-domestic-payment/src/test/kotlin/com/openbank/domestic/infrastructure/observability/DomesticPaymentStrandedGaugeTest.kt
+++ b/openbank-domestic-payment/src/test/kotlin/com/openbank/domestic/infrastructure/observability/DomesticPaymentStrandedGaugeTest.kt
@@ -1,0 +1,138 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright (c) OpenBank contributors. Licensed under the Apache License, Version 2.0.
+// See LICENSE in the repository root or https://www.apache.org/licenses/LICENSE-2.0 for details.
+package com.openbank.domestic.infrastructure.observability
+
+import com.openbank.domestic.application.port.out.DomesticPaymentRepository
+import com.openbank.domestic.domain.model.DomesticPayment
+import com.openbank.domestic.domain.model.DomesticPaymentStatus
+import com.openbank.libs.persistence.outbox.OutboxMessage
+import io.micrometer.core.instrument.simple.SimpleMeterRegistry
+import kotlinx.coroutines.runBlocking
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.Test
+import java.time.Clock
+import java.time.Duration
+import java.time.Instant
+import java.time.ZoneOffset
+import java.util.UUID
+
+/**
+ * Unit cover for the #3273 stranded-payment gauges.
+ *
+ * The point of the metric is that a stranded payment is invisible to every other signal — it
+ * answered 2xx, emitted no error, and its pod is healthy — so the ONLY thing that can distinguish
+ * it from a healthy payment is age. These assertions are therefore on the age arithmetic and on the
+ * empty-state behaviour, not on "a gauge was registered".
+ */
+class DomesticPaymentStrandedGaugeTest {
+
+    private val now: Instant = Instant.parse("2026-08-02T12:00:00Z")
+    private val clock: Clock = Clock.fixed(now, ZoneOffset.UTC)
+
+    /** Repository stub: only the two methods the gauge uses are meaningful. */
+    private class StubRepository(
+        private val counts: Map<DomesticPaymentStatus, Long>,
+        private val oldest: Map<DomesticPaymentStatus, Instant>,
+    ) : DomesticPaymentRepository {
+        override suspend fun countByStatus(status: DomesticPaymentStatus): Long = counts[status] ?: 0L
+        override suspend fun oldestCreatedAt(status: DomesticPaymentStatus): Instant? = oldest[status]
+
+        override suspend fun save(payment: DomesticPayment, outboxMessage: OutboxMessage) = error("unused")
+        override suspend fun findById(paymentId: UUID) = error("unused")
+        override suspend fun findByIdempotencyKey(idempotencyKey: String) = error("unused")
+        override suspend fun list(status: DomesticPaymentStatus?, debtorAccountId: UUID?, limit: Int, offset: Int) =
+            error("unused")
+        override suspend fun update(payment: DomesticPayment, outboxMessage: OutboxMessage) = error("unused")
+    }
+
+    private fun gaugeValue(registry: SimpleMeterRegistry, name: String, status: DomesticPaymentStatus): Double =
+        registry.get(name).tag("service", "domestic").tag("status", status.name).gauge().value()
+
+    @Test
+    fun `publishes the age of the oldest payment in each non-terminal state`(): Unit = runBlocking {
+        val registry = SimpleMeterRegistry()
+        val repo = StubRepository(
+            counts = mapOf(DomesticPaymentStatus.RECEIVED to 7L, DomesticPaymentStatus.VALIDATED to 3L),
+            oldest = mapOf(
+                // Six weeks, the real age of the oldest stranded payment that prompted #3273.
+                DomesticPaymentStatus.RECEIVED to now.minus(Duration.ofDays(42)),
+                DomesticPaymentStatus.VALIDATED to now.minus(Duration.ofMinutes(5)),
+            ),
+        )
+        val gauge = DomesticPaymentStrandedGauge(repo, registry, clock)
+        gauge.register()
+
+        gauge.refresh()
+
+        assertThat(gaugeValue(registry, "openbank.domestic.payments.non_terminal", DomesticPaymentStatus.RECEIVED))
+            .isEqualTo(7.0)
+        assertThat(
+            gaugeValue(
+                registry,
+                "openbank.domestic.payments.non_terminal.oldest.age.seconds",
+                DomesticPaymentStatus.RECEIVED,
+            ),
+        ).describedAs("42 days must cross the 3600s alert threshold, not merely be non-zero")
+            .isEqualTo(Duration.ofDays(42).seconds.toDouble())
+        assertThat(
+            gaugeValue(
+                registry,
+                "openbank.domestic.payments.non_terminal.oldest.age.seconds",
+                DomesticPaymentStatus.VALIDATED,
+            ),
+        ).isEqualTo(300.0)
+    }
+
+    /**
+     * An emptied state must report 0, not the last age it saw. Holding the previous value would
+     * keep the alert firing after the payments were cleared — which is how an alert earns being
+     * ignored, and this whole issue exists because a signal nobody trusts is the same as no signal.
+     */
+    @Test
+    fun `an emptied state reports zero rather than a stale age`(): Unit = runBlocking {
+        val registry = SimpleMeterRegistry()
+        var oldest = mapOf(DomesticPaymentStatus.RECEIVED to now.minus(Duration.ofHours(9)))
+        val repo = object : DomesticPaymentRepository by StubRepository(emptyMap(), emptyMap()) {
+            override suspend fun countByStatus(status: DomesticPaymentStatus) =
+                if (oldest.containsKey(status)) 1L else 0L
+            override suspend fun oldestCreatedAt(status: DomesticPaymentStatus) = oldest[status]
+        }
+        val gauge = DomesticPaymentStrandedGauge(repo, registry, clock)
+        gauge.register()
+
+        gauge.refresh()
+        val name = "openbank.domestic.payments.non_terminal.oldest.age.seconds"
+        assertThat(gaugeValue(registry, name, DomesticPaymentStatus.RECEIVED)).isEqualTo(32400.0)
+
+        oldest = emptyMap()
+        gauge.refresh()
+
+        assertThat(gaugeValue(registry, name, DomesticPaymentStatus.RECEIVED)).isZero()
+        assertThat(gaugeValue(registry, "openbank.domestic.payments.non_terminal", DomesticPaymentStatus.RECEIVED))
+            .isZero()
+    }
+
+    /** Terminal states must not be published — their age only grows and would alert forever. */
+    @Test
+    fun `terminal states are not published`() {
+        val registry = SimpleMeterRegistry()
+        DomesticPaymentStrandedGauge(StubRepository(emptyMap(), emptyMap()), registry, clock).register()
+
+        val published = registry.meters
+            .filter { it.id.name == "openbank.domestic.payments.non_terminal" }
+            .mapNotNull { it.id.getTag("status") }
+            .toSet()
+
+        assertThat(published).containsExactlyInAnyOrder("RECEIVED", "VALIDATED", "SENT_TO_CLEARING")
+        assertThat(published).doesNotContain("SETTLED", "REJECTED", "CANCELLED", "RETURNED")
+    }
+
+    /** A missing Prometheus registry must not break startup — the gauge is optional telemetry. */
+    @Test
+    fun `registers nothing and does not throw when no registry is present`(): Unit = runBlocking {
+        val gauge = DomesticPaymentStrandedGauge(StubRepository(emptyMap(), emptyMap()), null, clock)
+        gauge.register()
+        gauge.refresh()
+    }
+}

--- a/openbank-infra/gitops/components/payments/prometheus-rules.yaml
+++ b/openbank-infra/gitops/components/payments/prometheus-rules.yaml
@@ -129,3 +129,73 @@ spec:
           annotations:
             summary: "No SWIFT messages processed in 1h (business hours)"
             description: "swift-service has not processed any MT/MX messages in 1h during business hours."
+---
+apiVersion: monitoring.coreos.com/v1
+kind: PrometheusRule
+metadata:
+  name: openbank-domestic-payment-alerts
+  namespace: payments
+  labels:
+    app.kubernetes.io/part-of: openbank
+    app.kubernetes.io/name: domestic-payment
+spec:
+  groups:
+    # domestic-payment had NO rule in this file until #3273, despite the header above listing it.
+    # It was not uncovered though: prometheus-rules-tier1.yaml already carries PaymentServiceDown,
+    # HighErrorRate, HighLatencyP99 and both PaymentSLO*Burn for it. All of them were green while
+    # seven payments sat in RECEIVED, the oldest for six weeks — green *correctly*, because a
+    # fail-closed hold answers 2xx, emits no error span, has normal latency and a healthy pod.
+    # Every rule that existed measured whether the service ANSWERS. None measured whether the work
+    # it accepted PROGRESSES. These rules are that second question.
+    - name: openbank.domestic-payment.progress
+      rules:
+        - alert: DomesticPaymentStrandedBeforeClearing
+          # RECEIVED and VALIDATED are hand-off states: the Temporal workflow drives a payment
+          # through both within seconds. An hour there means the workflow completed without
+          # advancing it (a fail-closed screening hold) or never ran at all — neither of which any
+          # error-rate or latency signal can see.
+          expr: |
+            max by (status) (
+              openbank_domestic_payments_non_terminal_oldest_age_seconds{
+                service="domestic", status=~"RECEIVED|VALIDATED"
+              }
+            ) > 3600
+          for: 10m
+          labels:
+            severity: critical
+            service: domestic-payment
+          annotations:
+            summary: "Domestic payment stranded in {{ $labels.status }} for over an hour"
+            description: >-
+              The oldest domestic payment in {{ $labels.status }} is {{ $value | humanizeDuration }} old.
+              Customer funds are neither moved nor returned and nothing else alerts on this state.
+              Check for an open AML case (alert_code SCREENING_UNAVAILABLE) and whether the Temporal
+              workflow for that payment completed without advancing it.
+        - alert: DomesticPaymentStuckInClearing
+          # SENT_TO_CLEARING legitimately waits for a clearing cycle, so this threshold is a day
+          # rather than an hour — it catches a missed cycle, not a slow one.
+          expr: |
+            openbank_domestic_payments_non_terminal_oldest_age_seconds{
+              service="domestic", status="SENT_TO_CLEARING"
+            } > 86400
+          for: 30m
+          labels:
+            severity: warning
+            service: domestic-payment
+          annotations:
+            summary: "Domestic payment awaiting clearing for over a day"
+            description: >-
+              The oldest domestic payment in SENT_TO_CLEARING is {{ $value | humanizeDuration }} old —
+              at least one clearing cycle has been missed, or settlement is failing silently.
+        - alert: DomesticPaymentOutboxBacklogStuck
+          # The gauge has been published by DomesticPaymentOutboxBacklogGauge all along; nothing
+          # read it. That is why 13 events reaching DEAD on a missing Kafka ACL (#3271) went
+          # unnoticed until a customer asked where their payment was.
+          expr: openbank_outbox_backlog{service="domestic"} > 100
+          for: 15m
+          labels:
+            severity: critical
+            service: domestic-payment
+          annotations:
+            summary: "domestic-payment outbox backlog stuck"
+            description: "domestic-payment outbox has >100 unrelayed rows for >15m — payment events are not being dispatched."


### PR DESCRIPTION
## What

Publish how long domestic payments have been sitting in a non-terminal state, and alert on it.

- `openbank_domestic_payments_non_terminal{service="domestic",status="..."}` — how many are there now
- `openbank_domestic_payments_non_terminal_oldest_age_seconds{service="domestic",status="..."}` — age of the oldest

plus three `PrometheusRule` alerts in the payments namespace.

## Why the existing alerts could not have caught this

domestic-payment was **not** uncovered — `prometheus-rules-tier1.yaml` already carries
`PaymentServiceDown`, `HighErrorRate`, `HighLatencyP99` and both `PaymentSLO*Burn` for it. All of
them were green while seven payments sat in `RECEIVED`, the oldest for six weeks.

They were green *correctly*:

| what the rule measures | what a stranded payment does |
|---|---|
| `up == 0` | pod healthy |
| error rate on spans | the API returned **2xx** — `RECEIVED` is a success |
| p99 latency | normal |
| SLO burn from `STATUS_CODE_ERROR` | no error span is ever emitted |

The payment was held *by design* (fail-closed screening), so nothing about it is an error. Every
existing rule asks whether the service **answers**. None asks whether the work it accepted
**progresses**, and a stranded payment is indistinguishable from a healthy one at every layer except
its age. That is the gap, not missing coverage — which is why this adds a metric rather than another
rule over existing signals.

## Design notes

**Per-status series, not one aggregate.** The thresholds genuinely differ: `SENT_TO_CLEARING`
legitimately waits for a clearing cycle, `RECEIVED` should never be more than minutes old. A single
number could only be set to the loosest of them, which is the same as not alerting on `RECEIVED`.

**Terminal states are not published** (`SETTLED`, `REJECTED`, `CANCELLED`, `RETURNED`) — their age
only grows and would alert forever.

**Service-local `MeterRegistry`, not shared `DomainMetrics`** — mirrors `ComplaintDeadlineGauge`;
adding a one-service signal to the shared facade would force a fleet-wide rebuild.

**`DomesticPaymentOutboxBacklogStuck` closes a second hole.** `DomesticPaymentOutboxBacklogGauge` has
been publishing `openbank.outbox.backlog{service="domestic"}` all along and nothing read it —
transaction, clearing and swift each had a rule, domestic did not. That is why 13 events reaching
`DEAD` on the missing Kafka ACL (#3271) went unnoticed until a customer asked where their payment was.

Three local conventions the gauge has to honour, each of which fails silently if missed: `@Startup`
(an `@ApplicationScoped` bean is lazy, so `@PostConstruct` would never run), `suspend fun` on
`@Scheduled` (a plain method carries no Vert.x context — HR000068), and an explicit `@Inject`
constructor (with two constructors ArC registers no bean at all and `@Startup` silently never fires).

## Verification

**Unit tests, falsified before being trusted.** Four tests pass. With the empty-state reset
deliberately broken — so the gauge keeps a stale age after the payments clear — exactly the test
written for that fails:

```
an emptied state reports zero rather than a stale age  FAILED
```

Restored, all four pass again. The assertions are on the age arithmetic and the empty-state
behaviour, not on "a gauge was registered", because the latter would pass against a gauge that never
updates.

**PromQL validated against the real Prometheus.** Nothing in CI validates `PrometheusRule`
expressions and `promtool` is not available here, so these would otherwise ship unverified. All three
expressions were run against the in-cluster Prometheus query API and parse. The probe itself was
validated both ways first: a deliberately malformed query returns `error`, an existing metric returns
`success` — otherwise "no error" would just mean the probe was broken.

## Before merging: these alerts will be red on arrival

There are currently **3 payments in `VALIDATED` and 11 in `SENT_TO_CLEARING`**, the oldest from June.
`DomesticPaymentStrandedBeforeClearing` will fire immediately on the `VALIDATED` ones, and
`DomesticPaymentStuckInClearing` on the rest.

The alerts are right — those payments are genuinely stranded. But an alert that is red from its first
minute is how an alert earns being ignored, and this repository already has a documented problem with
`critical` being the resting state. **Recommend triaging those 14 payments first**, so the rule
arrives green and its first red means something. I have not touched them here: deciding whether they
settle, reject or cancel is not a call this PR should make silently.

Closes #3273
Refs #3271
