### PR TITLE
docs: a clean merge can silently delete a list entry

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -323,6 +323,22 @@ fire from *outside* it, so they stay here:
   Note the file list `gh pr view --json files` shows is computed against the MERGE-BASE, so after
   a competing PR squash-merges it still lists the overlap as a diff even when the content already
   agrees. Read the content, not the diff.
+- **A merge git calls CLEAN can still DELETE content — it reports no conflict when two sides add
+  neighbouring entries to the same list, and keeps only one.** Not a conflict resolved badly:
+  nothing to resolve, nothing printed, exit 0. Twice on 2026-08-02, both while merging `main` into
+  a branch. `.release-please-manifest.json` went **56 entries -> 55** because #3007 added
+  `openbank-tax-reporting-service` next to the branch's `openbank-delegation-service` and git kept
+  one; that would have put a service with a `version.txt` on `main` that release-please does not
+  know, breaking its first release. Caught only by the `release-registration consistency` gate
+  (rule 3, ADR-0029: `version.txt`, `release-please-config.json` and the manifest must stay in
+  lockstep) — no test and no review would have seen a line quietly not being there. The same day
+  #3241's two files differed by 77 and 81 lines yet were **identical once comments were stripped**
+  (40/40 and 44/44 code lines), the harmless end of the same phenomenon. **After any merge, diff the
+  RESULT against what you merged into and check the scope is what you expected** —
+  `git diff --name-only origin/main` and, for a structured file, count the entries before and
+  after. One command; it is knowing to run it that costs. Most exposed: JSON/YAML maps every
+  service registers itself in — the release manifest, `gates.yaml`, `rules.yaml` lists,
+  `event-contract-baseline.txt`.
 - **A finding from a CI run goes stale in MINUTES while a parallel agent is active — re-check
   before acting on it.** Three times in one session a ktlint/test failure was already fixed by the
   time the fix was written: the branch had moved (`db25c9ac8` -> `629aff176`,


### PR DESCRIPTION
## What it records

Git reports **no conflict** when two sides add neighbouring entries to the same map, and keeps only one. There is nothing to resolve, nothing printed, and exit 0 — so every habit built around "check the conflicts" misses it entirely.

## The instance that mattered

Merging `main` into `feat/delegation-service` while preparing #2971:

```
.release-please-manifest.json
  before the merge (2027b5a02)   56 entries   openbank-delegation-service 0.1.0
  after            (2512b4f22)   55 entries   absent
  restored         (main today)  56 entries
```

#3007 had added `openbank-tax-reporting-service` in the same alphabetical neighbourhood. Git merged the two additions and kept one.

Left in, this ships a service with a `version.txt` and a `release-please-config.json` entry that the manifest does not know — its first release breaks. Nothing in the change is visibly wrong; a line is quietly not there, which no test and no reviewer reads for.

**Only the `release-registration consistency` gate caught it** (rule 3, ADR-0029 — `version.txt`, the config and the manifest must stay in lockstep). That gate exists for exactly the invariant a silent drop violates, and it is the only reason this is a note rather than a broken release.

## The same phenomenon, harmless end

#3241's `aml`/`sanctions` broker-verification files differed from `main` by 77 and 81 lines and were **identical once comments were stripped** — 40/40 and 44/44 code lines. There the collision cost nothing. The two outcomes look the same from the diff; only comparing content tells them apart.

## The probe

After any merge, diff the **result** against what you merged into and check the scope is what you expected:

```bash
git diff --name-only origin/main
```

For a structured file, count entries before and after. It is one command — knowing to run it is the whole cost. Most exposed are the JSON/YAML maps every service registers itself in: the release manifest, `gates.yaml`, `rules.yaml` lists, `event-contract-baseline.txt`.

I ran exactly this on the next merge I did (#3337) and it reported one file and one line, as expected — which is what the check is for.

## Verification

Every figure re-read from the repo before committing: 56 → 55 → 56 across the three commits, the gate's presence, and #3241's 40 code lines. Fences balanced (4, even), +16/-0.

## Release impact

None — `docs` is a hidden type and `CLAUDE.md` is under no released package path.

Refs #2971, #3241
