### PR TITLE
fix(observability): KarpenterNodePoolAtLimit paged for 19h on a pool whose resting state is "at limit"

### DIFF
--- a/openbank-infra/gitops/components/observability/prometheus-rules-capacity.yaml
+++ b/openbank-infra/gitops/components/observability/prometheus-rules-capacity.yaml
@@ -61,15 +61,35 @@ spec:
         # The cap is binding NOW: usage has reached the declared limit. The next
         # scale-up or node-drain stalls. Critical — this is the #809 state.
         - alert: KarpenterNodePoolAtLimit
+          # EXCLUDES runners-warm. `karpenter_nodepools_usage` measures the capacity
+          # Karpenter has PROVISIONED, not the demand placed on it — so "usage == limit"
+          # means "the pool is provisioned up to its cap", which for a fixed-size pool is
+          # the resting state, not an incident.
+          #
+          # runners-warm is exactly that: 2 on-demand nodes with `expireAfter: Never`
+          # (arc-runners.tf) against a limit of 8 CPU, so usage is pinned at 8/8 forever.
+          # Measured 2026-08-02 while it had been paging `critical` for 19h: the two nodes
+          # carried 2 runner pods and 2 node-exporters — essentially idle. Nothing was
+          # constrained; the alert was reporting the pool's own shape back at us.
+          #
+          # Do NOT read the nodepool status as occupancy either: its `pods: 116` is the
+          # max-pods capacity of the two nodes, not pods running (12 were). Same trap as
+          # the cpu figure — both are capacity, and both look like utilisation.
+          #
+          # `default` is deliberately still covered: there the same expression fires on a
+          # pool that genuinely could not place work, evidenced the same day by 8
+          # `FailedScheduling ... exceed limits for nodepool` events for ledger/payments.
+          # The distinction this exclusion draws is fixed-size pool vs elastic pool, not
+          # "noisy alert vs quiet one".
           expr: |
             (
-              karpenter_nodepools_usage{resource_type="cpu"}
+              karpenter_nodepools_usage{resource_type="cpu", nodepool!="runners-warm"}
               >= on(nodepool) group_left()
               karpenter_nodepools_limit{resource_type="cpu"}
             )
             or
             (
-              karpenter_nodepools_usage{resource_type="memory"}
+              karpenter_nodepools_usage{resource_type="memory", nodepool!="runners-warm"}
               >= on(nodepool) group_left()
               karpenter_nodepools_limit{resource_type="memory"}
             )


### PR DESCRIPTION
Refs #3071

## The alert was reporting the pool's own shape back at us

`karpenter_nodepools_usage` measures the capacity Karpenter has **provisioned**, not the demand placed on it. So `usage >= limit` means *"this pool is provisioned up to its cap"* — which for a **fixed-size** pool is the resting state, not an incident.

`runners-warm` is exactly that: 2 on-demand nodes with `expireAfter: Never` (`arc-runners.tf`) against a limit of 8 CPU. Usage sits at 8/8 permanently.

Measured today, after it had been paging **`critical` for 19h**:

```
nodes: 2   cpu 8/8 (100%)
actually running: 2 runner pods + 2 node-exporters
```

Essentially idle. Nothing was constrained.

## Two metrics here read as utilisation and are not

I got this wrong on the way, and it is worth writing down:

- the NodePool status `pods: 116` is the **max-pods capacity** of the two nodes — 12 were actually running. I briefly concluded the pool was full of real work on the strength of that number.
- `cpu: 8` is likewise allocated node capacity, not consumption.

A cross-check against the actual pod list is what corrected it.

## `default` stays covered, deliberately

The same expression fires there on a pool that genuinely could not place work — evidenced the same day by 8 `FailedScheduling ... exceed limits for nodepool` events for `ledger` and `payments` during a canary wave.

The distinction this exclusion draws is **fixed-size pool vs elastic pool**, not "noisy alert vs quiet one". A pool that can grow and has stopped growing is a real signal; a pool that was built to sit at its cap is not.

## Validated against live Prometheus, before and after

```
old expr -> ['runners-warm']
new expr -> []
```

`runners-warm` was the only series holding the alert up, and `default` is below its cap (44/48), so this goes quiet **without hiding anything currently true**.

## Left alone

`KarpenterNodePoolNearLimit` (warning) has the same construction, but it does not page, and narrowing both in one change would make the diff harder to argue about than it is worth. Noted in the issue instead.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
