### PR TITLE
docs: four defects that a green build cannot see, from one walk of the console

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -67,6 +67,13 @@ Labels are code (`.github/labels.yml`, applied by the Label-sync workflow) — d
 ```
 CI is path-scoped (only changed services build). The domain layer has **zero** framework imports.
 
+**Gradle stops at the first failing task, so a green-looking task list is not a list that ran.** In
+that one-liner `test` precedes `ktlintCheck`; a failing `test` means ktlint never executes, and a
+`test` failure can be environmental (a second Gradle build on the same machine takes the port, and
+the run dies with `QuarkusBindException`) — so a genuine lint violation reaches CI while the local
+gate looked like it had merely flaked. Read which tasks actually appear in the output, and re-run
+the cheap checks (`ktlintCheck detekt`, seconds) on their own after fixing a test failure.
+
 ## Skills
 
 - `/ship-check` — authoritative pre-merge preflight; mirrors the CI gates.
@@ -104,6 +111,29 @@ These are real, repeatable gotchas — worth knowing before they cost you a debu
   (RestAssured + `@TestSecurity`) and assert the row with a plain JDBC read. This is also the only
   way to prove transactional-outbox atomicity (status change + outbox row commit together) — a mocked
   repo can't. Pattern: `LendingOutboxWriteIT`, `ConsentRevocationOutboxIT`.
+- **A Kotlin annotation binds to the NEXT declaration — a top-level function between `@Path` and its
+  class silently steals it.** `McpEndpoint` had `@Path("/mcp")`, then a top-level
+  `private fun String?.sanitizeForLog()`, then `class McpEndpoint`. The `@Path` bound to the
+  *function*; the class carried none, RESTEasy never registered the resource, and **every POST /mcp
+  answered 404 on a running pod** for the whole life of the endpoint. Nothing else changed shape: it
+  compiled, it was still a CDI bean, `McpEndpointIdentityTest` (which calls the class directly) stayed
+  green, and its siblings `/agent/chat` and `/api/v1/proposals` served normally. Downstream, admin-ui
+  maps any error to "not deployed", so a healthy service rendered as *"Agent-service (MCP) is not
+  deployed in this environment"*. **Ask the running app what it serves** — `/q/openapi` on the
+  management port lists the registered paths, and 404-vs-405-vs-401 discriminates "unregistered" from
+  "wrong method" / "needs a token". A unit test that calls a resource class cannot tell a served route
+  from an unserved one; only a `@QuarkusTest` driving real HTTP can (`McpEndpointRoutingIT`, #3371).
+- **An `Error` thrown in a FIELD INITIALIZER fails bean construction, and CDI then fails every
+  injection point of that bean — including endpoints that never use it.** `OnnxFraudModel` documented
+  "a load failure leaves `session` null, so `scoreShadow` returns null", and could not do it: the
+  native library surfaces as `ExceptionInInitializerError` wrapping `UnsatisfiedLinkError` — both
+  `Error`s, not `Exception` — thrown by `OrtEnvironment.getEnvironment()` in a field initializer,
+  outside the `try` that catches `Exception`. So `GET /api/v1/fraud/review-queue`, a read-only analyst
+  query that never touches a model, answered **500 on every call** because the bean is in its graph
+  (#3376). Two rules: anything crossing into native code (`System.load`, JNI, `OrtEnvironment`) must be
+  caught as `Throwable`, and a bean whose construction can fail belongs behind a nullable field, never
+  a direct initializer. Grep for the shape: `private val x: T = SomethingNative...()` in an
+  `@ApplicationScoped` class.
 - **`@ApplicationScoped` is LAZY — an `init {}` guard or warning does not run at boot.** Quarkus
   creates the bean via a client proxy on first use, so a constructor that logs "this config is
   DEV-ONLY" or `check()`s a go-live flag stays silent until the first request that touches it — which
@@ -171,6 +201,18 @@ These are real, repeatable gotchas — worth knowing before they cost you a debu
 ### Flyway
 - **Never change a migration after it has been applied to a live DB** — Flyway checksums the whole
   file (comments included), so any edit triggers a `checksum mismatch` startup failure.
+- **Committing migrations does not run them: `migrate-at-start` defaults to FALSE.**
+  security-scanner shipped `db/migration/V2`+`V3` with `quarkus-flyway` on the classpath and the
+  switch set nowhere — not in `application.yaml`, not in its gitops env — so the deployed database
+  held **zero tables and no `flyway_schema_history` at all**, and every write answered
+  `relation "security_outbox" does not exist (42P01)` as a 500. Invisible from every angle you would
+  normally check: the pod is Ready (health probes never touch the schema) and the migrations *are*
+  present in the repo (#3350). `check-flyway-default-datasource.py` now enforces both directions —
+  migrations ⇒ something runs them (the config key, or `QUARKUS_FLYWAY_MIGRATE_AT_START` in that
+  service's own gitops manifest, which is psd2's deliberate shape), and `migrate-at-start` ⇒ a
+  literal `quarkus.datasource.jdbc.url` in the file, since Flyway migrates the DEFAULT (Agroal/JDBC)
+  datasource and a service that only boots because the env supplied one cannot start from this repo
+  alone (#3080).
 
 ### Contract tests (Pact)
 - **One BROKER-sourced `@Provider` test per provider.** Two verification classes with the same

--- a/openbank-admin-ui/CLAUDE.md
+++ b/openbank-admin-ui/CLAUDE.md
@@ -136,6 +136,36 @@ always mounted, never conditionally hidden.
 a page hand-rolls an agent-finding renderer (the HITL lifecycle `proposed/approved/rejected` status-map
 signature) instead of importing `AgentInsightsPanel`. New agent surfaces must comply from day one.
 
+### 7. Bearer-relay rule — a BFF route calls an OIDC-gated backend with the operator's token, or not at all
+
+Every `openbank-*` service is OIDC-gated (`quarkus.oidc` + `@RolesAllowed`). The browser holds a NextAuth
+**session cookie**, not a bearer, so a server-side route that just `fetch`es a backend sends **no
+credential** and gets a 401 — from a perfectly healthy service. The page then blames the operator: the
+sanctions screen rendered *"Vypršela relace"* (session expired) at a freshly signed-in operator, its list
+tab rendered *"Invalid JSON"* (a 401 body is not the JSON the route parsed), and the security screen
+printed *"scanner HTTP 401"*. Three routes, all wrong the same way, because each hand-rolled its own
+`fetch` (#3336).
+
+**The rule:** a route that reaches a cluster service goes through a shared upstream helper —
+`src/lib/sanctions/upstream.ts` and `src/lib/closings/upstream.ts` are the pattern, and the generic
+`/api/svc` proxy documents the reasoning. The helper `auth()`s server-side, sends
+`Authorization: Bearer <session.user.accessToken>`, and **returns 401 before touching a backend** when
+there is no session (ADR-0056: the BFF must never be an unauthenticated relay into the cluster). A
+per-route `fetch` is a per-route opportunity to omit the header again.
+
+Two corollaries, both learned the same day:
+- **Never pass an upstream error body to the browser.** Replace it with a generic envelope
+  (`{error:"upstream_error"}`) and log the detail server-side (ADR-0080 P1). Forwarding it is how
+  `{error:"Invalid JSON"}` became operator-facing copy.
+- **Map a backend 401/403 to `kind: 'unauthorized'`, never to a status string.** `classifyBffFailure`
+  already does this for the `/api/svc` proxy; a route with its own envelope (like `/api/security`) must
+  carry the same case, or it prints `scanner HTTP 401` at someone whose session is fine.
+
+**Verifying it:** mock `@/auth`, assert `new Headers(init.headers).get('Authorization')` on the outgoing
+`fetch`, and assert that a session-less call never calls `fetch` at all — see
+`src/test/sanctions-security-bff-auth.test.ts`. Run the assertions against the *unfixed* route first; a
+bearer test that has only ever seen the fixed code proves nothing.
+
 ## Versioning
 
 **Do not hand-edit `version.txt` or `package.json` `version` — a feature PR touches neither.**


### PR DESCRIPTION
## What

The transferable half of four defects found in one walk of the deployed console. The fixes are [#3336](https://github.com/JiRaska/open-bank-oss/pull/3336), [#3350](https://github.com/JiRaska/open-bank-oss/pull/3350), [#3371](https://github.com/JiRaska/open-bank-oss/pull/3371), [#3376](https://github.com/JiRaska/open-bank-oss/pull/3376); this puts the lessons where contributors read them, per `rules.yaml: knowledge_capture`.

## Why these four

Four screens, four different error messages, and **all four backing services were running**. Every message was a lie, and not one of the failures was visible to a test, a gate, or a health probe:

| Screen said | Actually |
|---|---|
| "fraud-service is unavailable" | an `Error` in a field initializer failed the bean, so an unrelated read endpoint 500'd |
| "Session expired" / "Invalid JSON" | the BFF sent no bearer to an OIDC-gated backend |
| "scanner HTTP 401" | same, plus a database with **zero tables** behind it |
| "Agent-service (MCP) is not deployed" | `@Path` bound to a top-level function, so the route 404'd |

Each one is a class, not an incident — which is what makes them worth a bullet rather than a PR description.

## Routing

Per the private guidance that root keeps only what fires fleet-wide:

- **Root `CLAUDE.md` → Kotlin/Quarkus** — the annotation-binding trap and the `Error`-in-a-field-initializer trap. Both are language/CDI behaviour, reachable from any service.
- **Root `CLAUDE.md` → Flyway** — committed migrations are not run migrations; `migrate-at-start` defaults to false and a pod with an empty schema still reports Ready.
- **Root `CLAUDE.md` → Build** — Gradle stops at the first failing task, so `test` before `ktlintCheck` in the documented one-liner means a test failure hides lint completely. I hit this in the same session: an environmental `QuarkusBindException` (a second Gradle build took the port) meant ktlint never ran locally and a real violation reached CI.
- **`openbank-admin-ui/CLAUDE.md` → new rule 7** — the bearer-relay rule, with its two corollaries (never forward an upstream error body; map 401/403 to `kind: 'unauthorized'`, not a status string). Admin-ui-specific, so it goes in the admin-ui tree.

Net: +42 lines in root, +30 in admin-ui, no lesson stored twice.

## Merge order

**Merge after the four fix PRs.** The text cites artifacts those PRs introduce — `McpEndpointRoutingIT`, `src/lib/sanctions/upstream.ts`, `src/test/sanctions-security-bff-auth.test.ts`, and the third rule in `check-flyway-default-datasource.py`. Nothing here gates on their existence (no link checker runs over `CLAUDE.md`), so merging early would not break CI — it would just describe things that are not there yet.

## Verification

No code changes; `docs:` also means release-please cuts nothing. Every claim is measured evidence from the four PRs — cluster probes, `/q/openapi` output, and assertions falsified against the pre-fix source — not recollection.

## Linked issues

N/A — documentation of defects fixed in #3336/#3350/#3371/#3376.
