### PR TITLE
fix(lending): OPA never permitted compliance-pack activation, so ADR-0212 D4 was unreachable

### DIFF
--- a/openbank-infra/gitops/components/lending/gen-lending-opa-bundle.sh
+++ b/openbank-infra/gitops/components/lending/gen-lending-opa-bundle.sh
@@ -19,6 +19,9 @@ LENDING_REST_EXT=$(cat << 'REGO'
 #   lending.create              — submit a loan application (maker)
 #   lending.approve             — approve/reject an application (checker; four-eyes in the handler)
 #   lending.intake              — customer self-service application via customer-edge (ADR-0211)
+#   lending.compliance.propose  — propose a jurisdictional compliance pack (maker, ADR-0212 D4)
+#   lending.compliance.decide   — approve/reject a pack activation (checker, must differ from maker)
+#   lending.compliance.read     — list pending proposals / active packs
 #   lending.read                — get application/loan/schedule/collateral/IFRS-9 snapshot (#id)
 #   lending.list                — list a party's applications/loans
 #   lending.disburse            — disburse an approved application (books the loan)
@@ -106,6 +109,20 @@ allowed_reasons contains "compliance-lending-desk" if {
 		"lending.repay",
 		"lending.writeoff",
 		"lending.collateralRegister",
+		# ADR-0212 D4 pack activation. Missing until now, and the omission made the control
+		# UNREACHABLE rather than merely awkward: the endpoints exist, @RolesAllowed admits
+		# ROLE_COMPLIANCE, and OPA denied every attempt with "policy denied" — so no pack had
+		# ever been activated in any environment with AUTHZ_ENFORCE=true, and none could be.
+		# Only the READ half worked, because base rest.rego's compliance-read-any grants `*.read`
+		# and `lending.compliance.read` happens to end in it. That partial grant is what made the
+		# gap invisible: /active answered 200 with `[]`, which reads as "no packs activated yet"
+		# rather than "you cannot activate one".
+		#
+		# maker != checker is NOT enforced here — CompliancePackActivationService raises
+		# MakerCheckerViolation from the JWT subject, the same stance as lending.approve.
+		"lending.compliance.propose",
+		"lending.compliance.decide",
+		"lending.compliance.read",
 	}
 }
 

--- a/openbank-infra/gitops/components/lending/lending-opa-bundle.yaml
+++ b/openbank-infra/gitops/components/lending/lending-opa-bundle.yaml
@@ -9,7 +9,7 @@ metadata:
     app.kubernetes.io/name: lending-service
     app.kubernetes.io/part-of: lending
   annotations:
-    openbank.tech/policy-checksum: "c78b4688a45adf09"
+    openbank.tech/policy-checksum: "9bb871bcdf9c3f8c"
 data:
   rest.rego: |
     # SPDX-License-Identifier: Apache-2.0
@@ -513,6 +513,9 @@ data:
     #   lending.create              — submit a loan application (maker)
     #   lending.approve             — approve/reject an application (checker; four-eyes in the handler)
     #   lending.intake              — customer self-service application via customer-edge (ADR-0211)
+    #   lending.compliance.propose  — propose a jurisdictional compliance pack (maker, ADR-0212 D4)
+    #   lending.compliance.decide   — approve/reject a pack activation (checker, must differ from maker)
+    #   lending.compliance.read     — list pending proposals / active packs
     #   lending.read                — get application/loan/schedule/collateral/IFRS-9 snapshot (#id)
     #   lending.list                — list a party's applications/loans
     #   lending.disburse            — disburse an approved application (books the loan)
@@ -600,6 +603,20 @@ data:
     		"lending.repay",
     		"lending.writeoff",
     		"lending.collateralRegister",
+    		# ADR-0212 D4 pack activation. Missing until now, and the omission made the control
+    		# UNREACHABLE rather than merely awkward: the endpoints exist, @RolesAllowed admits
+    		# ROLE_COMPLIANCE, and OPA denied every attempt with "policy denied" — so no pack had
+    		# ever been activated in any environment with AUTHZ_ENFORCE=true, and none could be.
+    		# Only the READ half worked, because base rest.rego's compliance-read-any grants `*.read`
+    		# and `lending.compliance.read` happens to end in it. That partial grant is what made the
+    		# gap invisible: /active answered 200 with `[]`, which reads as "no packs activated yet"
+    		# rather than "you cannot activate one".
+    		#
+    		# maker != checker is NOT enforced here — CompliancePackActivationService raises
+    		# MakerCheckerViolation from the JWT subject, the same stance as lending.approve.
+    		"lending.compliance.propose",
+    		"lending.compliance.decide",
+    		"lending.compliance.read",
     	}
     }
 

--- a/openbank-infra/gitops/components/lending/lending-service.yaml
+++ b/openbank-infra/gitops/components/lending/lending-service.yaml
@@ -34,7 +34,7 @@ spec:
       annotations:
         # Rolls the pods when the OPA bundle changes — subPath mounts do NOT hot-reload.
         # Kept in sync by gen-lending-opa-bundle.sh (do not hand-edit).
-        openbank.tech/policy-checksum: "c78b4688a45adf09"
+        openbank.tech/policy-checksum: "9bb871bcdf9c3f8c"
     spec:
       securityContext:
         runAsNonRoot: true


### PR DESCRIPTION
## What

Adds `lending.compliance.propose` / `.decide` / `.read` to the `compliance-lending-desk` rule in the lending OPA bundle.

## Why — this was not a rough edge, the control was unreachable

Found by trying to activate the CZ reference pack against the running sandbox service. Read worked; the proposal did not:

```
HTTP 403 {"status":403,"code":"FORBIDDEN","message":"policy denied"}
```

That message is OPA, not RBAC. The live `lending-opa-bundle` ConfigMap contains **zero** occurrences of any of the three actions — `compliance-lending-desk` lists six (`lending.create`, `.read`, `.list`, `.repay`, `.writeoff`, `.collateralRegister`) and none is the pack workflow.

`AUTHZ_ENFORCE=true` is set on lending. So **no principal could activate a compliance pack in any environment, and none ever had.** The endpoints, `@RolesAllowed`, the maker-checker service logic, the ADR-0212 D4 four-eyes invariant and the console are all correct and all shipped; the one line that makes them reachable was missing.

## Why nobody noticed

Only the READ half worked, and by accident: base `rest.rego`'s `compliance-read-any` grants `*.read`, and `lending.compliance.read` happens to end in it. So `/compliance-packs/active` answers `200 []`, which reads as *"no packs activated yet"* — the expected state of a new install — rather than *"you cannot activate one"*. The console renders that same empty list and inherited the same false impression.

Generalises: a partial grant is worse than no grant. A fully-denied control announces itself the first time someone tries; one whose read path succeeds looks like an idle feature.

## Evidence — falsified, not assumed

`opa eval` for a `HUMAN` with `ROLE_COMPLIANCE` asking `lending.compliance.propose`:

| bundle | result |
|---|---|
| the one currently in the cluster | `allow = false` |
| after this change | `allow = true`, reason `compliance-lending-desk` |

`opa check` clean · `opa test` **104/104**.

Bundle + pod-roll annotation regenerated with the committed generator **after** the final rego edit, per the ordering rule in `CLAUDE.md`.

## Not in scope

`maker != checker` is deliberately not enforced in rego — `CompliancePackActivationService` raises `MakerCheckerViolation` from the JWT subject, the same stance as `lending.approve`. Rego decides *whether the desk may act*; the service decides *whether this particular person may act twice*.

Refs ADR-0212 D4
