### PR TITLE
fix(domestic): resolve the debtor's party for an AML case instead of sending the account id

### DIFF
--- a/openbank-domestic-payment/src/main/kotlin/com/openbank/domestic/application/port/out/AccountLookupPort.kt
+++ b/openbank-domestic-payment/src/main/kotlin/com/openbank/domestic/application/port/out/AccountLookupPort.kt
@@ -10,6 +10,17 @@ interface AccountLookupPort {
     /** Returns the partyId that owns [iban], or null if not an internal account. */
     suspend fun findPartyByIban(iban: String): UUID?
 
+    /**
+     * Returns the partyId that OWNS [accountId], or null when it cannot be resolved.
+     *
+     * ADR-0032's documented follow-up. A payment carries only `debtorAccountId`, and the AML
+     * adapter filled the case's required `partyId` with it — so every case opened from the payment
+     * path pointed at a party that does not exist, and no join from `aml_cases.party_id` to the
+     * party register resolved. `party_id` is `not null`, so the column looked populated and
+     * healthy the whole time (#3274).
+     */
+    suspend fun findPartyByAccountId(accountId: UUID): UUID?
+
     /** Returns the accountId for [iban] (the internal creditor account to credit), or null if it
      *  is not an internal account / cannot be resolved. */
     suspend fun findAccountIdByIban(iban: String): UUID?

--- a/openbank-domestic-payment/src/main/kotlin/com/openbank/domestic/infrastructure/client/AccountServiceClient.kt
+++ b/openbank-domestic-payment/src/main/kotlin/com/openbank/domestic/infrastructure/client/AccountServiceClient.kt
@@ -28,6 +28,13 @@ interface AccountServiceRestClient {
         @HeaderParam("Authorization") authorization: String,
         @PathParam("iban") iban: String,
     ): io.smallrye.mutiny.Uni<AccountDto>
+
+    @GET
+    @Path("/{accountId}")
+    fun getById(
+        @HeaderParam("Authorization") authorization: String,
+        @PathParam("accountId") accountId: String,
+    ): io.smallrye.mutiny.Uni<AccountDto>
 }
 
 data class AccountDto(val id: String, val partyId: String)
@@ -71,6 +78,21 @@ class AccountServiceClient(
         }
     } catch (ex: Exception) {
         log.warnf(ex, "Account lookup for IBAN %s failed — treating as external", iban)
+        null
+    }
+
+    @Suppress("TooGenericExceptionCaught")
+    override suspend fun findPartyByAccountId(accountId: UUID): UUID? = try {
+        val token = oidcClient.get().tokens.awaitSuspending().accessToken
+        val dto = httpClient.getById("Bearer $token", accountId.toString()).awaitSuspending()
+        UUID.fromString(dto.partyId)
+    } catch (ex: jakarta.ws.rs.WebApplicationException) {
+        if (ex.response.status != HTTP_NOT_FOUND) {
+            log.warnf(ex, "Party lookup for account %s failed with HTTP %d", accountId, ex.response.status)
+        }
+        null
+    } catch (ex: Exception) {
+        log.warnf(ex, "Party lookup for account %s failed", accountId)
         null
     }
 

--- a/openbank-domestic-payment/src/main/kotlin/com/openbank/domestic/infrastructure/client/AmlCaseAdapter.kt
+++ b/openbank-domestic-payment/src/main/kotlin/com/openbank/domestic/infrastructure/client/AmlCaseAdapter.kt
@@ -4,6 +4,7 @@
 
 package com.openbank.domestic.infrastructure.client
 
+import com.openbank.domestic.application.port.out.AccountLookupPort
 import com.openbank.domestic.application.port.out.AmlCasePort
 import com.openbank.domestic.application.port.out.OpenAmlCaseCommand
 import io.smallrye.mutiny.coroutines.awaitSuspending
@@ -12,6 +13,7 @@ import jakarta.inject.Inject
 import org.eclipse.microprofile.faulttolerance.Retry
 import org.eclipse.microprofile.faulttolerance.Timeout
 import org.eclipse.microprofile.rest.client.inject.RestClient
+import org.jboss.logging.Logger
 
 /**
  * Adapter over [AmlServiceClient]. Maps the payment-boundary [OpenAmlCaseCommand] onto the aml-service
@@ -25,6 +27,11 @@ class AmlCaseAdapter(@RestClient private val client: AmlServiceClient) : AmlCase
     @Inject
     lateinit var self: AmlCaseAdapter
 
+    @Inject
+    lateinit var accounts: AccountLookupPort
+
+    private val log = Logger.getLogger(AmlCaseAdapter::class.java)
+
     override suspend fun openCase(command: OpenAmlCaseCommand) {
         self.openCaseWithResilience(command)
     }
@@ -32,10 +39,28 @@ class AmlCaseAdapter(@RestClient private val client: AmlServiceClient) : AmlCase
     @Retry(maxRetries = 2, delay = 300, jitter = 150, retryOn = [Exception::class])
     @Timeout(5_000)
     open suspend fun openCaseWithResilience(command: OpenAmlCaseCommand) {
+        // ADR-0032's documented follow-up (#3274). The command carries only `debtorAccountId`, and
+        // this used to fill the case's required `partyId` with it — so every case pointed at a
+        // party that does not exist and no join to the party register resolved. `party_id` is
+        // `not null`, so the column read as populated and healthy, and nothing detected that the
+        // UUID came from the wrong table.
+        //
+        // On a failed lookup the account id is still sent, because the alternative is losing an
+        // AML case over a resolution outage — but it is now LOUD instead of silent, so the rows
+        // that carry the old shape are identifiable rather than indistinguishable.
+        val partyId = accounts.findPartyByAccountId(command.debtorAccountId)
+        if (partyId == null) {
+            log.warnf(
+                "aml.case.party_unresolved payment_id=%s debtor_account_id=%s — opening the case with the " +
+                    "ACCOUNT id in party_id; a join to the party register will not resolve it (#3274)",
+                command.paymentId,
+                command.debtorAccountId,
+            )
+        }
         client.createCase(
             command.idempotencyKey,
             CreateAmlCaseRequest(
-                partyId = command.debtorAccountId,
+                partyId = partyId ?: command.debtorAccountId,
                 accountId = command.debtorAccountId,
                 transactionId = command.paymentId,
                 customerReference = command.customerReference,

--- a/openbank-domestic-payment/src/test/kotlin/com/openbank/domestic/infrastructure/client/AmlCaseAdapterTest.kt
+++ b/openbank-domestic-payment/src/test/kotlin/com/openbank/domestic/infrastructure/client/AmlCaseAdapterTest.kt
@@ -4,6 +4,7 @@
 
 package com.openbank.domestic.infrastructure.client
 
+import com.openbank.domestic.application.port.out.AccountLookupPort
 import com.openbank.domestic.application.port.out.AmlCaseRiskLevel
 import com.openbank.domestic.application.port.out.OpenAmlCaseCommand
 import io.mockk.every
@@ -21,7 +22,20 @@ class AmlCaseAdapterTest {
 
     private val client: AmlServiceClient = mockk()
 
-    private fun adapter(): AmlCaseAdapter = AmlCaseAdapter(client).also { it.self = it }
+    /** The party that actually owns the debtor account — a DIFFERENT id, which is the whole point. */
+    private val resolvedParty: UUID = UUID.randomUUID()
+
+    private fun adapter(party: UUID? = resolvedParty): AmlCaseAdapter {
+        val accounts = object : AccountLookupPort {
+            override suspend fun findPartyByIban(iban: String): UUID? = null
+            override suspend fun findPartyByAccountId(accountId: UUID): UUID? = party
+            override suspend fun findAccountIdByIban(iban: String): UUID? = null
+        }
+        return AmlCaseAdapter(client).also {
+            it.self = it
+            it.accounts = accounts
+        }
+    }
 
     private fun command(matchedEntity: String? = "Sanctioned Co") = OpenAmlCaseCommand(
         idempotencyKey = "aml-key-1",
@@ -48,7 +62,12 @@ class AmlCaseAdapterTest {
         verify(exactly = 1) { client.createCase(any(), any()) }
         assertThat(keySlot.captured).isEqualTo("aml-key-1")
         val body = bodySlot.captured
-        assertThat(body.partyId).isEqualTo(cmd.debtorAccountId)
+        // This used to assert `partyId == cmd.debtorAccountId`, i.e. it PINNED the defect: an
+        // account id in party_id, which no join to the party register can resolve (#3274).
+        assertThat(body.partyId)
+            .describedAs("the case must carry the party that owns the debtor account, not the account")
+            .isEqualTo(resolvedParty)
+            .isNotEqualTo(cmd.debtorAccountId)
         assertThat(body.accountId).isEqualTo(cmd.debtorAccountId)
         assertThat(body.transactionId).isEqualTo(cmd.paymentId)
         assertThat(body.customerReference).isEqualTo("Payer / 1000/0800")
@@ -68,5 +87,21 @@ class AmlCaseAdapterTest {
         adapter().openCase(command(matchedEntity = null))
 
         assertThat(bodySlot.captured.matchedEntity).isNull()
+    }
+
+    @Test
+    fun `an unresolvable party still opens the case, with the account id and a loud warning`(): Unit = runBlocking {
+        // Losing an AML case over an account-service outage would be worse than an imprecise one,
+        // so the fallback stays — but it is logged, so those rows are identifiable rather than
+        // indistinguishable from correctly-resolved ones (#3274).
+        val cmd = command()
+        val bodySlot = slot<CreateAmlCaseRequest>()
+        every { client.createCase(any(), capture(bodySlot)) } returns
+            Uni.createFrom().item(mockk<Response>())
+
+        adapter(party = null).openCase(cmd)
+
+        assertThat(bodySlot.captured.partyId).isEqualTo(cmd.debtorAccountId)
+        assertThat(bodySlot.captured.accountId).isEqualTo(cmd.debtorAccountId)
     }
 }


### PR DESCRIPTION
Closes #3274 · Refs ADR-0032

## The defect

A payment carries only `debtorAccountId`, and the adapter filled the AML case's required `partyId` with it:

```kotlin
partyId   = command.debtorAccountId,
accountId = command.debtorAccountId,
```

So every case opened from the payment path pointed at a party that does not exist. `party_id` is `not null`, so the column read as populated and healthy, and nothing detected that the UUID came from the wrong table. ADR-0032 documented the account→party resolution as a follow-up; it never landed.

## The fix

`AccountLookupPort.findPartyByAccountId` over the account-service client this service **already has** (`GET /api/v1/accounts/{accountId}`) — no new dependency, config, or network edge.

On a failed lookup the account id is still sent. Losing an AML case over an account-service outage would be worse than an imprecise one — but it is now logged at WARN with the payment and account ids, so those rows are **identifiable** rather than indistinguishable from correctly-resolved ones.

## The test pinned the defect

This is why the issue's "nothing here is caught by a test" was true — it was worse than absence:

```kotlin
assertThat(body.partyId).isEqualTo(cmd.debtorAccountId)   // asserted the wrong behaviour
```

Now it asserts the case carries the **resolved** party *and* that it differs from the account id, so the old shape cannot come back silently. A second case pins the unresolved fallback.

## Two other rails have the identical shape — deliberately not in this PR

The issue says to check before closing. Measured:

| rail | same two lines? | has an account-service client? |
|---|---|---|
| `openbank-domestic-payment` | yes | **yes** — fixed here |
| `openbank-sepa-payment` | yes | no |
| `openbank-sepa-instant` | yes | no |

Neither of the other two can reach account-service at all today, so each needs a new rest-client, its config and the network edge that goes with it. That is a separate change per rail — not three money-path services in one PR. Worth deciding whether to fix them or to have aml-service reject a `partyId` that is not in the party register, which would close the class rather than the instances.

## Verification

`ktlintCheck`, `detekt`, `test`, `quarkusBuild` green for `openbank-domestic-payment`. `quarkusBuild` matters here specifically — the adapter gained an `@Inject` field, and CDI wiring is not validated by ktlint or unit tests.

Money-path service, so two approvals per `rules.yaml` / ADR-0030.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
