### PR TITLE
fix(gitops): stop auto-deploy detection failing on an empty libs fan-out

### DIFF
--- a/.github/scripts/libs-change-dependents.sh
+++ b/.github/scripts/libs-change-dependents.sh
@@ -91,7 +91,22 @@ selftest() {
     echo "selftest FAIL: a governance catalog matched the global paths — that is data, not a compile input" >&2
     fail=1
   fi
-  [ "$fail" -eq 0 ] && echo "selftest OK: declaration matcher and both path matchers verified in both directions."
+  # Exit status, asserted in both directions. The caller reads this script inside a command
+  # substitution under `set -e`, so a non-zero status is fatal REGARDLESS of the output — and the
+  # matcher assertions above cannot see that, which is how a script that could never succeed on a
+  # push kept a green self-test.
+  local me="${BASH_SOURCE[0]}"
+  local svcs="openbank-fx-service openbank-account-service"
+  if ! printf 'openbank-admin-ui/src/x.tsx\n' | bash "$me" "$svcs" >/dev/null 2>&1; then
+    echo "selftest FAIL: a change touching no libs module must exit 0, not report failure" >&2
+    fail=1
+  fi
+  if ! printf 'openbank-libs-domain/src/main/kotlin/X.kt\n' | bash "$me" "$svcs" >/dev/null 2>&1; then
+    echo "selftest FAIL: a real libs change must exit 0 — it printed consumers and still failed" >&2
+    fail=1
+  fi
+
+  [ "$fail" -eq 0 ] && echo "selftest OK: matchers verified in both directions, and the exit status on both an empty and a non-empty result."
   return "$fail"
 }
 
@@ -122,8 +137,14 @@ done
 
 # Intersect with ALL_SERVICES: a consumer that this pipeline cannot build (a different pipeline
 # owns it, or it has no gitops manifest) must never enter the build set.
-printf '%s\n' $DEPENDENTS | command grep -v '^$' | sort -u | while read -r svc; do
-  for known in $ALL_SERVICES; do
-    [ "$svc" = "$known" ] && echo "$svc" && break
-  done
-done
+#
+# The `|| true` is load-bearing, not defensive noise. An empty result is the COMMON case — most
+# pushes touch no libs module — and `grep` reports "nothing matched" as exit 1. Under the
+# `set -euo pipefail` at the top, and again in the caller's `SERVICES_JSON="$(...)"`, that status
+# killed the whole auto-deploy detect step with no message at all, so every push-triggered run
+# after this script landed detected nothing and deployed nothing. It failed even on the path that
+# WORKS: a libs change printed the right consumers and still exited 1, because a `while` loop's
+# status is the last thing it ran — here a non-matching `[` test.
+printf '%s\n' $DEPENDENTS \
+  | sort -u \
+  | command grep -Fxf <(printf '%s\n' $ALL_SERVICES) || true


### PR DESCRIPTION
## The symptom

Every push-triggered `auto-deploy.yml` run since #3256 merged (2026-08-02 12:56Z) failed in
`Detect changed services`, which skips `Build + push`, `can-i-deploy`, `Gitops PR` and
`Deploy signal`. Nothing merged to `main` in that window deployed. The one green run in the range
is a `workflow_dispatch`, which takes the first branch of the step and never reaches this script —
so the estate looked like it had a working deploy path and did not.

## The cause

`libs-change-dependents.sh` ends in a pipeline whose last stages are
`grep -v '^$' | sort -u | while read …`. Two independent ways to exit 1:

- **the empty case, which is the common one** — most pushes touch no libs module, `grep` reports
  "nothing matched" as exit 1, and `pipefail` promotes that to the script's status;
- **the non-empty case** — the `while` loop's status is the last command it ran, a non-matching
  `[ "$svc" = "$known" ]` test. So a libs change printed the correct consumers *and still exited 1*.

The caller reads it as `LIBS_DEPENDENTS="$(… | bash …)"` under `set -euo pipefail`, where a non-zero
status is fatal regardless of the output. Nothing is printed, so the job log shows the step's own
script listing and then `Process completed with exit code 1` — no error line anywhere.

Measured, both directions:

| stdin | before | after |
|---|---|---|
| `openbank-admin-ui/src/x.tsx` | rc=1, no output | rc=0, no output |
| `openbank-libs-domain/src/main/kotlin/X.kt` | **rc=1**, correct output | rc=0, same output |
| `build-logic/src/main/kotlin/X.kt` | rc=0 | rc=0 |

The third was already green because that path `exit 0`s early — it was the only path that could
succeed.

## Why the gate did not catch it

The script's `--selftest` asserts the declaration matcher and both path matchers. It never runs the
script. A gate that exercises a script's *internals* cannot see a defect in the contract its caller
depends on, and this one stayed green over a script that could not succeed on a push.

The self-test now invokes the script end-to-end on an empty and a non-empty result and asserts the
exit status. Falsifiability checked rather than assumed: reverting just the `|| true` makes it print
`selftest FAIL: a change touching no libs module must exit 0, not report failure` and return 1.

Refs #3256
