### PR TITLE
fix(delegation): put the validity window and the ceiling on the events that grant authority

### DIFF
--- a/openbank-contracts/openbank-delegation-service/asyncapi.yaml
+++ b/openbank-contracts/openbank-delegation-service/asyncapi.yaml
@@ -208,6 +208,45 @@ components:
           items:
             $ref: '#/components/schemas/capability'
 
+    # The enforceable window and the ceiling. Present on the events that make a grant enforceable
+    # — Offered, Activated, Reinstated — and on no other, because nothing else changes them.
+    #
+    # These were ADDED in #3410. Before that the aggregate carried all three and no event did, so
+    # both projections read fields the producer never sent and defaulted them: `validFrom ?: now`
+    # made a future-dated grant enforceable immediately, `validTo = null` meant it never expired
+    # locally, and no consumer could apply a per-transaction ceiling at all.
+    enforcement:
+      type: object
+      required: [validFrom]
+      properties:
+        validFrom:
+          type: string
+          format: date-time
+          description: >-
+            When the grant becomes enforceable. Consumers MUST NOT treat an absent value as "now" —
+            that is the defect this field closes.
+        validTo:
+          type: string
+          format: date-time
+          nullable: true
+          description: >-
+            End of the window, or null for open-ended. A consumer still receives DelegationExpired
+            from the producer's sweep; this field lets it stop authorising WITHOUT waiting for it.
+        perTransactionLimit:
+          type: object
+          nullable: true
+          required: [amount, currency]
+          properties:
+            amount: { type: string, format: decimal }
+            currency:
+              type: string
+              minLength: 3
+              maxLength: 3
+              description: >-
+                ISO 4217, flat — NOT the domain `CurrencyCode`, which Jackson renders as
+                `{"code":"CZK"}` while every consumer reads this as text. Matches the fleet's
+                event convention (AccountEvents, LedgerEvents).
+
   messages:
     DelegationOffered:
       name: DelegationOffered
@@ -225,6 +264,7 @@ components:
           - $ref: '#/components/schemas/parties'
           - $ref: '#/components/schemas/resource'
           - $ref: '#/components/schemas/capabilities'
+          - $ref: '#/components/schemas/enforcement'
 
     DelegationActivated:
       name: DelegationActivated
@@ -241,6 +281,7 @@ components:
           - $ref: '#/components/schemas/parties'
           - $ref: '#/components/schemas/resource'
           - $ref: '#/components/schemas/capabilities'
+          - $ref: '#/components/schemas/enforcement'
 
     DelegationDeclined:
       name: DelegationDeclined
@@ -310,6 +351,7 @@ components:
           - $ref: '#/components/schemas/parties'
           - $ref: '#/components/schemas/resource'
           - $ref: '#/components/schemas/capabilities'
+          - $ref: '#/components/schemas/enforcement'
 
     DelegationRenounced:
       name: DelegationRenounced

--- a/openbank-delegation-service/src/main/kotlin/com/openbank/delegation/application/usecase/DelegationService.kt
+++ b/openbank-delegation-service/src/main/kotlin/com/openbank/delegation/application/usecase/DelegationService.kt
@@ -27,6 +27,7 @@ import com.openbank.delegation.domain.event.DelegationReinstated
 import com.openbank.delegation.domain.event.DelegationRenounced
 import com.openbank.delegation.domain.event.DelegationRevoked
 import com.openbank.delegation.domain.event.DelegationSuspended
+import com.openbank.delegation.domain.event.EventMoney
 import com.openbank.delegation.domain.model.DelegationCheckResult
 import com.openbank.delegation.domain.model.DelegationGrant
 import jakarta.enterprise.context.ApplicationScoped
@@ -120,6 +121,9 @@ class DelegationService(
                 resourceType = grant.resourceType,
                 resourceId = grant.resourceId,
                 capabilities = grant.capabilities,
+                validFrom = grant.validFrom,
+                validTo = grant.validTo,
+                perTransactionLimit = EventMoney.from(grant.perTransactionLimit),
                 occurredAt = clock.instant(),
             ),
         )
@@ -149,6 +153,9 @@ class DelegationService(
                 resourceType = accepted.resourceType,
                 resourceId = accepted.resourceId,
                 capabilities = accepted.capabilities,
+                validFrom = accepted.validFrom,
+                validTo = accepted.validTo,
+                perTransactionLimit = EventMoney.from(accepted.perTransactionLimit),
                 occurredAt = clock.instant(),
             ),
         )
@@ -257,6 +264,9 @@ class DelegationService(
                 resourceType = reinstated.resourceType,
                 resourceId = reinstated.resourceId,
                 capabilities = reinstated.capabilities,
+                validFrom = reinstated.validFrom,
+                validTo = reinstated.validTo,
+                perTransactionLimit = EventMoney.from(reinstated.perTransactionLimit),
                 occurredAt = clock.instant(),
             ),
         )

--- a/openbank-delegation-service/src/main/kotlin/com/openbank/delegation/domain/event/DelegationEvents.kt
+++ b/openbank-delegation-service/src/main/kotlin/com/openbank/delegation/domain/event/DelegationEvents.kt
@@ -7,7 +7,10 @@ package com.openbank.delegation.domain.event
 import com.openbank.delegation.domain.model.DelegationCapability
 import com.openbank.delegation.domain.model.DelegationResourceType
 import com.openbank.libs.domain.event.DomainEvent
+import com.openbank.libs.domain.money.Money
+import java.math.BigDecimal
 import java.time.Instant
+import java.time.OffsetDateTime
 import java.util.UUID
 
 /**
@@ -16,6 +19,21 @@ import java.util.UUID
  * from the event stream alone, never by calling back — the same reason ConsentRevoked
  * mirrors ConsentGranted's scopes.
  */
+/**
+ * The wire shape of a money amount on a delegation event.
+ *
+ * NOT [com.openbank.libs.domain.money.Money]: `CurrencyCode` is a data class with no `@JsonValue`,
+ * so Jackson renders it as `{"code":"CZK"}` while both consumers read
+ * `perTransactionLimit.currency` as TEXT — the amount would arrive and the currency would silently
+ * be null. A flat `currency: String` matches the consumers and the fleet's own event convention
+ * (AccountEvents, LedgerEvents both carry `currency: String`).
+ */
+data class EventMoney(val amount: BigDecimal, val currency: String) {
+    companion object {
+        fun from(money: Money?): EventMoney? = money?.let { EventMoney(it.amount, it.currency.code) }
+    }
+}
+
 data class DelegationOffered(
     override val aggregateId: UUID,
     val grantorPartyId: UUID,
@@ -23,6 +41,9 @@ data class DelegationOffered(
     val resourceType: DelegationResourceType,
     val resourceId: UUID,
     val capabilities: Set<DelegationCapability>,
+    val validFrom: OffsetDateTime,
+    val validTo: OffsetDateTime? = null,
+    val perTransactionLimit: EventMoney? = null,
     override val occurredAt: Instant,
 ) : DomainEvent(occurredAt) {
     override val aggregateType = "DelegationGrant"
@@ -37,6 +58,9 @@ data class DelegationActivated(
     val resourceType: DelegationResourceType,
     val resourceId: UUID,
     val capabilities: Set<DelegationCapability>,
+    val validFrom: OffsetDateTime,
+    val validTo: OffsetDateTime? = null,
+    val perTransactionLimit: EventMoney? = null,
     override val occurredAt: Instant,
 ) : DomainEvent(occurredAt) {
     override val aggregateType = "DelegationGrant"
@@ -92,6 +116,9 @@ data class DelegationReinstated(
     val resourceType: DelegationResourceType,
     val resourceId: UUID,
     val capabilities: Set<DelegationCapability>,
+    val validFrom: OffsetDateTime,
+    val validTo: OffsetDateTime? = null,
+    val perTransactionLimit: EventMoney? = null,
     override val occurredAt: Instant,
 ) : DomainEvent(occurredAt) {
     override val aggregateType = "DelegationGrant"

--- a/openbank-delegation-service/src/test/kotlin/com/openbank/delegation/application/usecase/DelegationServiceTest.kt
+++ b/openbank-delegation-service/src/test/kotlin/com/openbank/delegation/application/usecase/DelegationServiceTest.kt
@@ -28,17 +28,17 @@ import io.mockk.coEvery
 import io.mockk.coVerify
 import io.mockk.mockk
 import io.mockk.slot
+import kotlinx.coroutines.runBlocking
+import org.assertj.core.api.Assertions.assertThat
+import org.assertj.core.api.Assertions.assertThatThrownBy
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Test
 import java.math.BigDecimal
 import java.time.Clock
 import java.time.Instant
 import java.time.OffsetDateTime
 import java.time.ZoneOffset
 import java.util.UUID
-import kotlinx.coroutines.runBlocking
-import org.assertj.core.api.Assertions.assertThat
-import org.assertj.core.api.Assertions.assertThatThrownBy
-import org.junit.jupiter.api.BeforeEach
-import org.junit.jupiter.api.Test
 
 class DelegationServiceTest {
 

--- a/openbank-delegation-service/src/test/kotlin/com/openbank/delegation/application/usecase/DelegationServiceTest.kt
+++ b/openbank-delegation-service/src/test/kotlin/com/openbank/delegation/application/usecase/DelegationServiceTest.kt
@@ -14,24 +14,31 @@ import com.openbank.delegation.application.port.out.PartyEligibilityClient
 import com.openbank.delegation.application.port.out.ResourceOwnershipClient
 import com.openbank.delegation.application.port.out.ScaChallengeClient
 import com.openbank.delegation.application.port.out.ScaChallengeSnapshot
+import com.openbank.delegation.domain.event.DelegationOffered
+import com.openbank.delegation.domain.event.EventMoney
 import com.openbank.delegation.domain.model.DelegationCapability
 import com.openbank.delegation.domain.model.DelegationCheckResult
 import com.openbank.delegation.domain.model.DelegationGrant
 import com.openbank.delegation.domain.model.DelegationResourceType
 import com.openbank.delegation.domain.model.DelegationStatus
+import com.openbank.libs.domain.event.DomainEvent
+import com.openbank.libs.domain.money.CurrencyCode
+import com.openbank.libs.domain.money.Money
 import io.mockk.coEvery
 import io.mockk.coVerify
 import io.mockk.mockk
-import kotlinx.coroutines.runBlocking
-import org.assertj.core.api.Assertions.assertThat
-import org.assertj.core.api.Assertions.assertThatThrownBy
-import org.junit.jupiter.api.BeforeEach
-import org.junit.jupiter.api.Test
+import io.mockk.slot
+import java.math.BigDecimal
 import java.time.Clock
 import java.time.Instant
 import java.time.OffsetDateTime
 import java.time.ZoneOffset
 import java.util.UUID
+import kotlinx.coroutines.runBlocking
+import org.assertj.core.api.Assertions.assertThat
+import org.assertj.core.api.Assertions.assertThatThrownBy
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Test
 
 class DelegationServiceTest {
 
@@ -83,6 +90,45 @@ class DelegationServiceTest {
         validTo = now.plusDays(30),
         grantScaSessionId = UUID.randomUUID(),
     )
+
+    /**
+     * #3410: the aggregate carried `validFrom`, `validTo` and `perTransactionLimit` and no event
+     * did, so both enforcement projections read fields the producer never sent and defaulted them
+     * — `validFrom ?: now` made a future-dated grant enforceable at once, `validTo = null` meant it
+     * never expired locally, and no consumer could apply a per-transaction ceiling at all.
+     *
+     * Asserting on the EMITTED EVENT, not on the returned aggregate: the aggregate always had these
+     * values, which is exactly why the gap was invisible from the producer's side.
+     */
+    @Test
+    fun `the offered event carries the window and the ceiling, not just the aggregate`(): Unit = runBlocking {
+        scaOk(grantor, "DELEGATION_GRANT")
+        eligibilityOk()
+        val event = slot<DomainEvent>()
+        coEvery { repository.save(any<DelegationGrant>(), capture(event)) } answers { firstArg() }
+
+        service.offer(offerCommand())
+
+        val offered = event.captured as DelegationOffered
+        assertThat(offered.validFrom).isEqualTo(now)
+        assertThat(offered.validTo).isEqualTo(now.plusDays(30))
+    }
+
+    /**
+     * The currency must be a FLAT string. `Money` holds a `CurrencyCode`, a data class with no
+     * `@JsonValue`, so serializing it directly renders `{"code":"CZK"}` while both consumers read
+     * `perTransactionLimit.currency` as text — the amount would arrive and the currency would
+     * silently be null.
+     */
+    @Test
+    fun `the event money carries a flat ISO currency, never the CurrencyCode object`() {
+        val wire = EventMoney.from(Money(BigDecimal("5000.00"), CurrencyCode("CZK")))
+
+        assertThat(wire).isNotNull
+        assertThat(wire!!.currency).isEqualTo("CZK")
+        assertThat(wire.amount).isEqualByComparingTo(BigDecimal("5000.00"))
+        assertThat(EventMoney.from(null)).isNull()
+    }
 
     @Test
     fun `offer persists OFFERED grant and emits DelegationOffered`(): Unit = runBlocking {


### PR DESCRIPTION
Closes #3410.

## The gap

The aggregate carried `validFrom`, `validTo` and `perTransactionLimit`; no event did. The outbox
payload is the serialized event (`DelegationRepositoryImpl:48`), so none of the three reached the
wire — while **both** enforcement projections read them:

```
validFrom / validTo / perTransactionLimit in the event classes …  0
read by account-service DelegationEventConsumer …………………………………… 10
read by card-issuance CardDelegationEventConsumer ………………………………  6
```

Each side looks correct alone. The producer emits its own event faithfully; the consumers read with
sensible fallbacks. Only the pair is wrong — which is the class ADR-0006 contracts exist to expose,
and the contract itself did not mention any of the three.

| field | what the projection did without it |
|---|---|
| `validFrom` | `?: now` — a grant dated to start next month was enforceable immediately. **No backstop.** |
| `validTo` | `null` = "no end". Expiry left to delegation-service's sweep: late rather than never, and only since #3164 made that sweep a `suspend fun` that runs at all. |
| `perTransactionLimit` | absent — a capability granted "up to 5 000 CZK" enforced as unbounded. |

## The part that made it more than a three-line change

`Money` holds a `CurrencyCode`, a data class with **no `@JsonValue`**, so Jackson renders it
`{"code":"CZK"}`. Both consumers read `perTransactionLimit.currency` as **text**. Adding `Money`
directly would have delivered the amount and silently nulled the currency — a fix that looks done
and half works.

So the events carry `EventMoney(amount, currency: String)`: flat, matching what the consumers parse
and the fleet's own event convention (`AccountEvents`, `LedgerEvents` both use `currency: String`).

## Scope

Added to the three events that make a grant enforceable — `DelegationOffered`,
`DelegationActivated`, `DelegationReinstated` — and no others, because nothing else changes them.
Additive and BACKWARD-compatible: the consumers already parse these fields, so nothing lands in
lockstep.

## What I deliberately did NOT do

#3410 also suggested dropping the consumers' `?: now` fallback so a missing window fails loudly.
Not here: the topic has `retention.ms: 604800000`, so events already on it lack these fields for
another seven days, and a consumer that hard-failed would break replaying its own backlog. That
change is safe once retention has rolled past this commit and deserves its own PR with the date
named.

## Tests

Assert on the **emitted event**, not the returned aggregate — the aggregate always had these
values, which is exactly why the gap was invisible from the producer's side. Plus a test pinning
the flat-currency shape, since that is the failure mode that would otherwise ship quietly.
