### PR TITLE
feat(customer-edge): customer routes for delegated access (ADR-0232 D6)

### DIFF
--- a/openbank-customer-edge/src/main/kotlin/com/openbank/customeredge/infrastructure/rest/CustomerDelegationResource.kt
+++ b/openbank-customer-edge/src/main/kotlin/com/openbank/customeredge/infrastructure/rest/CustomerDelegationResource.kt
@@ -1,0 +1,190 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright (c) OpenBank contributors. Licensed under the Apache License, Version 2.0.
+// See LICENSE in the repository root or https://www.apache.org/licenses/LICENSE-2.0 for details.
+
+package com.openbank.customeredge.infrastructure.rest
+
+import com.fasterxml.jackson.databind.ObjectMapper
+import com.fasterxml.jackson.databind.node.ObjectNode
+import io.smallrye.common.annotation.Blocking
+import jakarta.annotation.security.RolesAllowed
+import jakarta.inject.Inject
+import jakarta.ws.rs.Consumes
+import jakarta.ws.rs.DELETE
+import jakarta.ws.rs.ForbiddenException
+import jakarta.ws.rs.GET
+import jakarta.ws.rs.POST
+import jakarta.ws.rs.Path
+import jakarta.ws.rs.PathParam
+import jakarta.ws.rs.Produces
+import jakarta.ws.rs.QueryParam
+import jakarta.ws.rs.core.MediaType
+import jakarta.ws.rs.core.Response
+import org.eclipse.microprofile.config.inject.ConfigProperty
+import org.eclipse.microprofile.jwt.JsonWebToken
+import java.util.UUID
+
+/**
+ * Customer-facing delegated-access routes (ADR-0232 D6), proxying `openbank-delegation-service`
+ * with the edge M2M token. Without this class the service is merged but unreachable: the app
+ * authenticates against the `openbank-customers` realm, which upstream services do not accept.
+ *
+ * **The party identity is taken from the token on EVERY route and never from the client.** That is
+ * the whole security property of this file, and it is why the routes do not simply mirror the
+ * upstream paths: upstream exposes `/grantor/{partyId}` and takes `granteePartyId` as a query
+ * parameter, both of which a customer client must not be able to choose. Here the caller says
+ * *which side of the relationship they are asking about* ("shared by me" / "shared with me") and
+ * the edge supplies *who they are*.
+ *
+ * delegation-service independently re-checks the same thing via `X-Customer-Party-Id`
+ * (`requireCallerIs`, added in #3164) — this is the outer half of that pair, not a replacement for
+ * it. The upstream check is what makes a direct call safe; this one is what makes the customer
+ * realm work at all.
+ *
+ * A separate resource from [CustomerEdgeResource] to keep that (already `@Suppress("LargeClass")`)
+ * class from growing further, matching [CustomerDocumentResource]; party resolution reuses its
+ * `resolvePartyIdClaim` companion helper.
+ */
+@Path("/customer/v1/delegations")
+@Produces(MediaType.APPLICATION_JSON)
+@Consumes(MediaType.APPLICATION_JSON)
+@RolesAllowed("ROLE_CUSTOMER")
+class CustomerDelegationResource(private val upstream: UpstreamClient) {
+
+    @Inject
+    lateinit var jwt: JsonWebToken
+
+    @ConfigProperty(
+        name = "openbank.edge.delegation-service-url",
+        defaultValue = "http://delegation-service.delegation.svc:8126",
+    )
+    lateinit var delegationServiceUrl: String
+
+    private val json = ObjectMapper()
+
+    /**
+     * Grants the caller has ISSUED ("Sdílím"). The upstream path is party-scoped and the party comes
+     * from the token, so this can only ever list the caller's own grants.
+     */
+    @GET
+    @Path("/shared-by-me")
+    @Blocking
+    fun sharedByMe(): Response {
+        val partyId = partyId()
+        return upstream.get("$delegationServiceUrl$UPSTREAM/grantor/$partyId", partyId)
+    }
+
+    /** Grants the caller has RECEIVED ("Sdíleno se mnou"), including offers awaiting a response. */
+    @GET
+    @Path("/shared-with-me")
+    @Blocking
+    fun sharedWithMe(): Response {
+        val partyId = partyId()
+        return upstream.get("$delegationServiceUrl$UPSTREAM/grantee/$partyId", partyId)
+    }
+
+    /**
+     * One grant the caller is a party to. Upstream answers 404 when the caller is neither grantor
+     * nor grantee, so a guessed id yields no existence oracle and the edge adds no check of its own.
+     */
+    @GET
+    @Path("/{id}")
+    @Blocking
+    fun getById(@PathParam("id") id: UUID): Response {
+        val partyId = partyId()
+        return upstream.get("$delegationServiceUrl$UPSTREAM/$id", partyId)
+    }
+
+    /**
+     * Offer a grant over one of the caller's own resources (SCA-bound, purpose `DELEGATION_GRANT`).
+     *
+     * `grantorPartyId` is FORCED to the token's party. A body naming a different grantor is
+     * rejected with 403 rather than silently rewritten: a client that sends the wrong id has a bug,
+     * and quietly issuing a grant the user did not ask for is the worse of the two outcomes. An
+     * absent field is filled in, since the app has no reason to send it at all.
+     *
+     * Everything else — grantee, resource, capabilities, limits, SCA session — is passed through
+     * untouched; delegation-service owns that validation and verifies resource ownership itself.
+     */
+    @POST
+    @Blocking
+    fun offer(body: String?): Response {
+        val partyId = partyId()
+        val node = runCatching { json.readTree(body ?: "{}") as? ObjectNode }.getOrNull()
+            ?: return refuse(Response.Status.BAD_REQUEST, "Body must be a JSON object")
+        val declared = node.get(FIELD_GRANTOR)?.asText()?.takeIf { it.isNotBlank() }
+        if (declared != null && declared != partyId) {
+            return refuse(Response.Status.FORBIDDEN, "grantorPartyId must be the authenticated party")
+        }
+        node.put(FIELD_GRANTOR, partyId)
+        return upstream.post("$delegationServiceUrl$UPSTREAM", partyId, json.writeValueAsString(node))
+    }
+
+    /**
+     * Accept an offered grant. `granteePartyId` is the token's party, so the caller can only ever
+     * accept an offer addressed to themselves; `scaSessionId` is the grantee's OWN challenge
+     * (purpose `DELEGATION_ACCEPT`) and is the one thing the client supplies.
+     */
+    @POST
+    @Path("/{id}/accept")
+    @Blocking
+    fun accept(@PathParam("id") id: UUID, @QueryParam("scaSessionId") scaSessionId: UUID?): Response {
+        val partyId = partyId()
+        if (scaSessionId == null) return refuse(Response.Status.BAD_REQUEST, "scaSessionId is required")
+        return upstream.post(
+            "$delegationServiceUrl$UPSTREAM/$id/accept?granteePartyId=$partyId&scaSessionId=$scaSessionId",
+            partyId,
+            "",
+        )
+    }
+
+    /** Decline an offered grant. No SCA: refusing access never needs a step-up. */
+    @POST
+    @Path("/{id}/decline")
+    @Blocking
+    fun decline(@PathParam("id") id: UUID): Response {
+        val partyId = partyId()
+        return upstream.post("$delegationServiceUrl$UPSTREAM/$id/decline?granteePartyId=$partyId", partyId, "")
+    }
+
+    /** Give back an active grant the caller holds. Same reasoning as decline — no SCA to drop access. */
+    @POST
+    @Path("/{id}/renounce")
+    @Blocking
+    fun renounce(@PathParam("id") id: UUID): Response {
+        val partyId = partyId()
+        return upstream.post("$delegationServiceUrl$UPSTREAM/$id/renounce?granteePartyId=$partyId", partyId, "")
+    }
+
+    /**
+     * Revoke a grant the caller issued — unilateral and instant, which is the property the UI
+     * promises. `revokedBy` is NOT sent: upstream derives the actor from `X-Customer-Party-Id` for
+     * customer-scoped calls, and the query parameter it still accepts is the bank-initiated path,
+     * role-gated and narrowed by `delegation_rest_ext.rego`. Passing it from here would re-open the
+     * hole #3164 closed, where the actor was caller-supplied.
+     */
+    @DELETE
+    @Path("/{id}")
+    @Blocking
+    fun revoke(@PathParam("id") id: UUID, @QueryParam("reason") reason: String?): Response {
+        val partyId = partyId()
+        val body = json.writeValueAsString(mapOf("reason" to (reason?.takeIf { it.isNotBlank() } ?: DEFAULT_REASON)))
+        return upstream.delete("$delegationServiceUrl$UPSTREAM/$id", partyId, body)
+    }
+
+    private fun partyId(): String = CustomerEdgeResource.resolvePartyIdClaim(
+        partyIdClaim = jwt.getClaim<String>("party_id"),
+        sub = jwt.subject,
+    ) ?: throw ForbiddenException("Missing party_id/sub claim in customer token")
+
+    // One helper rather than a forbidden()/badRequest() pair: detekt's TooManyFunctions fires AT
+    // the threshold (11), not above it, and a second one-line wrapper is the cheapest thing to give up.
+    private fun refuse(status: Response.Status, message: String): Response =
+        Response.status(status).entity(mapOf("error" to message)).build()
+
+    private companion object {
+        const val UPSTREAM = "/api/v1/delegations"
+        const val FIELD_GRANTOR = "grantorPartyId"
+        const val DEFAULT_REASON = "Revoked by grantor"
+    }
+}

--- a/openbank-customer-edge/src/main/resources/application.yaml
+++ b/openbank-customer-edge/src/main/resources/application.yaml
@@ -118,6 +118,7 @@ openbank:
     vop-service-url: ${VOP_SERVICE_URL:http://vop-service.payments.svc:8149}
     sdd-service-url: ${SDD_SERVICE_URL:http://sdd-service.sdd.svc:8129}
     consent-service-url: ${CONSENT_SERVICE_URL:http://consent-service.consent.svc:8106}
+    delegation-service-url: ${DELEGATION_SERVICE_URL:http://delegation-service.delegation.svc:8126}
     bank-bic: ${OPENBANK_BANK_BIC:OPENCZPPXXX}
     sca-service-url:     ${SCA_SERVICE_URL:http://sca-service.sca.svc:8110}
     party-service-url:   ${PARTY_SERVICE_URL:http://party-service.party.svc:8111}

--- a/openbank-customer-edge/src/main/resources/openapi.yaml
+++ b/openbank-customer-edge/src/main/resources/openapi.yaml
@@ -3,7 +3,7 @@
 openapi: 3.1.0
 info:
   title: Customer Edge API
-  version: 1.25.0
+  version: 1.26.0
   description: >-
     Customer-facing edge proxy (ADR-0065). Single internet-facing entry point for the
     retail customer app. Validates JWTs from the openbank-customers Keycloak realm,
@@ -34,6 +34,7 @@ tags:
   - name: Feedback
   - name: Cards
   - name: Lending
+  - name: Delegation
 
 paths:
   /feedback:
@@ -1407,6 +1408,126 @@ paths:
               schema:
                 $ref: '#/components/schemas/CardError'
         '403': {description: Card does not belong to caller}
+
+
+  /delegations:
+    post:
+      tags: [Delegation]
+      summary: Offer a delegated-access grant over one of the caller's own resources
+      description: >-
+        ADR-0232 D6. SCA-bound (purpose DELEGATION_GRANT, single-use challenge). grantorPartyId is
+        FORCED to the authenticated party: a body naming a different grantor is rejected with 403
+        rather than rewritten, because silently issuing a grant the user did not ask for is worse
+        than failing a client bug loudly. Everything else is passed through — delegation-service
+        owns capability validation and verifies that the grantor actually owns the resource.
+      operationId: offerDelegation
+      security:
+        - customerOidc: [delegations:write]
+      responses:
+        '201': {description: Grant offered}
+        '400': {description: Body is not a JSON object, or upstream validation failed}
+        '403': {description: grantorPartyId is not the authenticated party, or resource not owned}
+
+  /delegations/shared-by-me:
+    get:
+      tags: [Delegation]
+      summary: Grants the caller has issued
+      description: >-
+        Party-scoped server-side from the token; the caller cannot ask about another party. Includes
+        every lifecycle state, so the UI can show pending offers alongside active grants.
+      operationId: listDelegationsSharedByMe
+      security:
+        - customerOidc: [delegations:read]
+      responses:
+        '200': {description: Grants issued by the caller}
+
+  /delegations/shared-with-me:
+    get:
+      tags: [Delegation]
+      summary: Grants the caller has received, including offers awaiting a response
+      operationId: listDelegationsSharedWithMe
+      security:
+        - customerOidc: [delegations:read]
+      responses:
+        '200': {description: Grants received by the caller}
+
+  /delegations/{id}:
+    get:
+      tags: [Delegation]
+      summary: One grant the caller is a party to
+      description: >-
+        404 when the caller is neither grantor nor grantee — deliberately not 403, so a guessed id
+        is not an existence oracle.
+      operationId: getDelegation
+      security:
+        - customerOidc: [delegations:read]
+      parameters:
+        - {name: id, in: path, required: true, schema: {type: string, format: uuid}}
+      responses:
+        '200': {description: Grant detail}
+        '404': {description: No such grant, or the caller is not a party to it}
+    delete:
+      tags: [Delegation]
+      summary: Revoke a grant the caller issued — unilateral and instant
+      description: >-
+        The actor is DERIVED from the authenticated party, never sent by the client: the upstream
+        query parameter that still exists is the bank-initiated path and is role-gated. No SCA —
+        withdrawing access must never be harder than granting it.
+      operationId: revokeDelegation
+      security:
+        - customerOidc: [delegations:write]
+      parameters:
+        - {name: id, in: path, required: true, schema: {type: string, format: uuid}}
+        - {name: reason, in: query, required: false, schema: {type: string}}
+      responses:
+        '200': {description: Grant revoked}
+        '403': {description: Caller is not the grantor}
+
+  /delegations/{id}/accept:
+    post:
+      tags: [Delegation]
+      summary: Accept an offered grant (grantee's own SCA)
+      description: >-
+        granteePartyId is the authenticated party, so a caller can only accept an offer addressed to
+        themselves. scaSessionId is the grantee's OWN challenge (purpose DELEGATION_ACCEPT) — the
+        grantor's ceremony does not carry over.
+      operationId: acceptDelegation
+      security:
+        - customerOidc: [delegations:write]
+      parameters:
+        - {name: id, in: path, required: true, schema: {type: string, format: uuid}}
+        - {name: scaSessionId, in: query, required: true, schema: {type: string, format: uuid}}
+      responses:
+        '200': {description: Grant accepted and now ACTIVE}
+        '400': {description: scaSessionId missing}
+        '403': {description: Offer is not addressed to the caller, or SCA invalid}
+
+  /delegations/{id}/decline:
+    post:
+      tags: [Delegation]
+      summary: Decline an offered grant
+      description: No SCA — refusing access never needs a step-up.
+      operationId: declineDelegation
+      security:
+        - customerOidc: [delegations:write]
+      parameters:
+        - {name: id, in: path, required: true, schema: {type: string, format: uuid}}
+      responses:
+        '200': {description: Offer declined}
+        '403': {description: Offer is not addressed to the caller}
+
+  /delegations/{id}/renounce:
+    post:
+      tags: [Delegation]
+      summary: Give back an active grant the caller holds
+      operationId: renounceDelegation
+      security:
+        - customerOidc: [delegations:write]
+      parameters:
+        - {name: id, in: path, required: true, schema: {type: string, format: uuid}}
+      responses:
+        '200': {description: Grant renounced}
+        '403': {description: Caller is not the grantee}
 
 components:
   securitySchemes:

--- a/openbank-customer-edge/src/test/kotlin/com/openbank/customeredge/CustomerDelegationResourceTest.kt
+++ b/openbank-customer-edge/src/test/kotlin/com/openbank/customeredge/CustomerDelegationResourceTest.kt
@@ -1,0 +1,190 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright (c) OpenBank contributors. Licensed under the Apache License, Version 2.0.
+// See LICENSE in the repository root or https://www.apache.org/licenses/LICENSE-2.0 for details.
+
+package com.openbank.customeredge
+
+import com.openbank.customeredge.infrastructure.rest.CustomerDelegationResource
+import com.openbank.customeredge.infrastructure.rest.UpstreamClient
+import io.mockk.every
+import io.mockk.mockk
+import io.mockk.slot
+import io.mockk.verify
+import jakarta.ws.rs.core.Response
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.Test
+import java.util.UUID
+
+/**
+ * The single property these routes exist to hold: **the party identity comes from the token, never
+ * from the client** (ADR-0232 D6, ADR-0065). delegation-service re-checks it via
+ * `X-Customer-Party-Id`, so these are the outer half of a pair — but the outer half is the one the
+ * app actually goes through, and a mistake here hands a customer another party's grants.
+ *
+ * Every assertion below therefore names a party the caller is NOT and proves it does not reach
+ * upstream. A test that only checked "the URL contains a UUID" would pass against exactly the bug
+ * worth catching.
+ */
+class CustomerDelegationResourceTest {
+
+    private val caller: UUID = UUID.randomUUID()
+    private val stranger: UUID = UUID.randomUUID()
+    private val svc = "http://delegation-service.delegation.svc:8126"
+
+    private fun resource(upstream: UpstreamClient): CustomerDelegationResource =
+        CustomerDelegationResource(upstream).apply {
+            jwt = mockk {
+                every { getClaim<String>("party_id") } returns caller.toString()
+                every { subject } returns caller.toString()
+            }
+            delegationServiceUrl = svc
+        }
+
+    @Test
+    fun `sharedByMe scopes the upstream path to the token party`() {
+        val upstream = mockk<UpstreamClient>()
+        val url = slot<String>()
+        every { upstream.get(capture(url), any()) } returns Response.ok("[]").build()
+
+        resource(upstream).sharedByMe()
+
+        assertThat(url.captured).isEqualTo("$svc/api/v1/delegations/grantor/$caller")
+    }
+
+    @Test
+    fun `sharedWithMe scopes the upstream path to the token party`() {
+        val upstream = mockk<UpstreamClient>()
+        val url = slot<String>()
+        every { upstream.get(capture(url), any()) } returns Response.ok("[]").build()
+
+        resource(upstream).sharedWithMe()
+
+        assertThat(url.captured).isEqualTo("$svc/api/v1/delegations/grantee/$caller")
+    }
+
+    @Test
+    fun `every read forwards the token party as the upstream party header`() {
+        val upstream = mockk<UpstreamClient>()
+        val party = slot<String>()
+        every { upstream.get(any(), capture(party)) } returns Response.ok("[]").build()
+
+        resource(upstream).getById(UUID.randomUUID())
+
+        assertThat(party.captured).isEqualTo(caller.toString())
+    }
+
+    @Test
+    fun `offer fills in the grantor when the client omits it`() {
+        val upstream = mockk<UpstreamClient>()
+        val body = slot<String>()
+        every { upstream.post(any(), any(), capture(body), any()) } returns Response.status(201).build()
+
+        val response = resource(upstream).offer("""{"granteePartyId":"$stranger","resourceType":"ACCOUNT"}""")
+
+        assertThat(response.status).isEqualTo(201)
+        assertThat(body.captured).contains("\"grantorPartyId\":\"$caller\"")
+        // The rest of the body is delegation-service's business and must survive untouched.
+        assertThat(body.captured).contains("\"granteePartyId\":\"$stranger\"")
+        assertThat(body.captured).contains("\"resourceType\":\"ACCOUNT\"")
+    }
+
+    @Test
+    fun `offer REJECTS a body naming someone else as grantor instead of rewriting it`() {
+        val upstream = mockk<UpstreamClient>()
+
+        val response = resource(upstream).offer("""{"grantorPartyId":"$stranger","granteePartyId":"$caller"}""")
+
+        assertThat(response.status).isEqualTo(403)
+        // Silently rewriting would issue a grant the user never asked for — nothing may reach upstream.
+        verify(exactly = 0) { upstream.post(any(), any(), any(), any()) }
+    }
+
+    @Test
+    fun `offer accepts a body that names the caller as grantor`() {
+        val upstream = mockk<UpstreamClient>()
+        every { upstream.post(any(), any(), any(), any()) } returns Response.status(201).build()
+
+        val response = resource(upstream).offer("""{"grantorPartyId":"$caller","granteePartyId":"$stranger"}""")
+
+        assertThat(response.status).isEqualTo(201)
+    }
+
+    @Test
+    fun `offer rejects a body that is not a JSON object`() {
+        val upstream = mockk<UpstreamClient>()
+
+        assertThat(resource(upstream).offer("[]").status).isEqualTo(400)
+        assertThat(resource(upstream).offer("not json").status).isEqualTo(400)
+        verify(exactly = 0) { upstream.post(any(), any(), any(), any()) }
+    }
+
+    @Test
+    fun `accept sends the token party as grantee and the client's SCA session`() {
+        val upstream = mockk<UpstreamClient>()
+        val url = slot<String>()
+        every { upstream.post(capture(url), any(), any(), any()) } returns Response.ok().build()
+        val sca = UUID.randomUUID()
+
+        resource(upstream).accept(GRANT_ID, sca)
+
+        assertThat(url.captured)
+            .isEqualTo("$svc/api/v1/delegations/$GRANT_ID/accept?granteePartyId=$caller&scaSessionId=$sca")
+        assertThat(url.captured).doesNotContain(stranger.toString())
+    }
+
+    @Test
+    fun `accept without an SCA session is rejected at the edge`() {
+        val upstream = mockk<UpstreamClient>()
+
+        val response = resource(upstream).accept(GRANT_ID, null)
+
+        assertThat(response.status).isEqualTo(400)
+        verify(exactly = 0) { upstream.post(any(), any(), any(), any()) }
+    }
+
+    @Test
+    fun `decline and renounce identify the grantee from the token`() {
+        val upstream = mockk<UpstreamClient>()
+        val urls = mutableListOf<String>()
+        every { upstream.post(capture(urls), any(), any(), any()) } returns Response.ok().build()
+
+        resource(upstream).decline(GRANT_ID)
+        resource(upstream).renounce(GRANT_ID)
+
+        assertThat(urls).containsExactly(
+            "$svc/api/v1/delegations/$GRANT_ID/decline?granteePartyId=$caller",
+            "$svc/api/v1/delegations/$GRANT_ID/renounce?granteePartyId=$caller",
+        )
+    }
+
+    @Test
+    fun `revoke never sends revokedBy, so the actor stays derived upstream`() {
+        val upstream = mockk<UpstreamClient>()
+        val url = slot<String>()
+        val body = slot<String>()
+        every { upstream.delete(capture(url), any(), capture(body)) } returns Response.ok().build()
+
+        resource(upstream).revoke(GRANT_ID, "no longer needed")
+
+        assertThat(url.captured).isEqualTo("$svc/api/v1/delegations/$GRANT_ID")
+        // #3164: a caller-supplied actor let anyone revoke anyone's grant and sign it as someone else.
+        assertThat(url.captured).doesNotContain("revokedBy")
+        assertThat(body.captured).contains("no longer needed")
+    }
+
+    @Test
+    fun `revoke supplies a default reason when the client sends none`() {
+        val upstream = mockk<UpstreamClient>()
+        val body = slot<String>()
+        every { upstream.delete(any(), any(), capture(body)) } returns Response.ok().build()
+
+        resource(upstream).revoke(GRANT_ID, null)
+
+        assertThat(body.captured).contains("reason")
+        assertThat(body.captured).doesNotContain("null")
+    }
+
+    private companion object {
+        val GRANT_ID: UUID = UUID.fromString("11111111-2222-3333-4444-555555555555")
+    }
+}


### PR DESCRIPTION
## Why

`openbank-delegation-service` is on `main` (#2971 + the enforcement projections #3058/#3105/#3143)
and the app still cannot use any of it. The app authenticates against the `openbank-customers`
Keycloak realm, which upstream services do not accept — everything reaches them through
customer-edge — and `git grep -l delegation openbank-customer-edge/src/main` returned **nothing**.

This is one of three independent blockers between "merged" and "usable". The other two are
#2992 (no gitops workload manifest) and #3382 (not in `auto-deploy.yml`'s `ALL_SERVICES`); both
are separate PRs. **This PR alone does not make the feature work** — it makes the edge able to
proxy a service that does not yet run anywhere.

## What

Eight routes under `/customer/v1/delegations` in a new `CustomerDelegationResource`, kept out of
`CustomerEdgeResource` (already `@Suppress("LargeClass")`), matching `CustomerDocumentResource`.

| | |
|---|---|
| `POST /delegations` | offer a grant (SCA-bound) |
| `GET /delegations/shared-by-me` | grants the caller issued |
| `GET /delegations/shared-with-me` | grants received, incl. pending offers |
| `GET /delegations/{id}` | detail |
| `POST /delegations/{id}/accept` | accept, grantee's own SCA |
| `POST /delegations/{id}/decline` | decline |
| `POST /delegations/{id}/renounce` | give an active grant back |
| `DELETE /delegations/{id}` | revoke |

## The shape of the routes is the security property

They deliberately do **not** mirror upstream. delegation-service exposes `/grantor/{partyId}` and
takes `granteePartyId` as a query parameter — both things a customer client must not choose. Here
the caller says *which side of the relationship* they are asking about and the edge supplies *who
they are*, from the JWT, on every route.

Two decisions worth arguing with if you disagree:

- **`offer()` rejects rather than rewrites.** A body naming a different `grantorPartyId` gets 403;
  it is not silently replaced with the caller's. A client sending the wrong id has a bug, and
  quietly issuing a grant the user never asked for is the worse of the two failures. An absent
  field is filled in, since the app has no reason to send it at all.
- **`revoke()` never sends `revokedBy`.** Upstream derives the actor from `X-Customer-Party-Id` for
  customer-scoped calls; the query parameter it still accepts is the bank-initiated, role-gated
  path. Passing it from the edge would re-open exactly what #3164 closed, where the actor was
  caller-supplied and anyone could revoke anyone's grant signed as someone else.

delegation-service re-checks the caller itself (`requireCallerIs`). This is the outer half of that
pair, not a replacement for it — but it is the half the app actually goes through.

## Verification

- 12 unit tests, all naming a party the caller is **not** and proving it never reaches upstream.
  A test asserting only "the URL contains a UUID" would pass against the bug worth catching.
- `detekt` + `ktlintCheck` + `test` green, exit code read directly from Gradle.
- `openapi.yaml` 1.25.0 → 1.26.0 (new endpoints, backward compatible; ADR-0048 classifies from the
  `oasdiff`, this is the expected minor).
- `application.yaml` gains `delegation-service-url`, checked with a duplicate-key-rejecting YAML
  loader — SmallRye silently keeps the last of a repeated mapping key.

**The route-conformance gate was verified falsifiable rather than trusted.** It reports 77 findings
on this branch and 77 on `main`, which on its own proves nothing — the checker might simply not see
the new resource. Removing the delegation paths from `openapi.yaml` takes it to **85**, exactly the
8 route+verb pairs added, and restoring them returns it to 77.

## Not covered here

No Pact contract for the edge→delegation pair (#2991 — delegation-service has zero pacts today, so
there is nothing to replay against yet). No notification on lifecycle transitions, no `onBehalfOf`
audit threading, no object-level disclosure — all unbuilt upstream, and the UI must not promise
them. Cumulative daily/monthly ceilings are carried by the API but enforced nowhere, so a
"5 000 Kč/day" chip in the app would be a claim the platform cannot keep.

Refs #2992, #2991
