### PR TITLE
fix(infra): OPA bundles exceed the client-side apply ceiling, freezing policy in-cluster on 5 services

### DIFF
--- a/.github/gates/gates.yaml
+++ b/.github/gates/gates.yaml
@@ -1423,3 +1423,17 @@ gates:
     mode: enforced
     run: |
       python3 .github/scripts/check-roles-allowed-realm.py
+  - id: opa-bundle-apply-size
+    name: OPA bundle must be installable (client-side apply annotation ceiling)
+    group: gitops
+    mode: enforced
+    selftest: python3 .github/scripts/check-opa-bundle-apply-size.py --self-test
+    selftest_expect: pass
+    run: |
+      # A bundle over ~256 KB cannot be installed by client-side apply: the whole
+      # object goes into last-applied-configuration and the API server rejects it
+      # with "metadata.annotations: Too long". Argo then retries forever while the
+      # cluster keeps serving the PREVIOUS policy, and the Application reads as
+      # OutOfSync/Progressing rather than failed. Five services, four money-path,
+      # were drifted this way before the check existed.
+      python3 .github/scripts/check-opa-bundle-apply-size.py

--- a/.github/scripts/check-opa-bundle-apply-size.py
+++ b/.github/scripts/check-opa-bundle-apply-size.py
@@ -1,0 +1,242 @@
+#!/usr/bin/env python3
+# SPDX-License-Identifier: Apache-2.0
+# Copyright (c) OpenBank contributors. Licensed under the Apache License, Version 2.0.
+"""Refuse an OPA bundle that client-side apply cannot install.
+
+THE FAILURE THIS EXISTS TO PREVENT
+
+Kubernetes caps `metadata.annotations` at 262144 bytes for all annotations combined.
+Client-side apply writes the ENTIRE applied object into
+`kubectl.kubernetes.io/last-applied-configuration`, so a ConfigMap larger than roughly
+that ceiling can never be applied that way: the API server rejects it with
+
+    ConfigMap "<name>" is invalid: metadata.annotations: Too long
+
+and Argo CD retries the sync forever. Nothing goes red in a way anyone reads. The
+Application sits `OutOfSync`/`Progressing`, which is indistinguishable from a rollout
+still in progress, and the POLICY IN THE CLUSTER SILENTLY FREEZES at the last version
+that happened to fit while git moves on. Measured 2026-08-02: five Applications —
+ledger, psd2, balances, consent, lending, four of them money-path — were serving OPA
+policy that did not match `main`, and had been for as long as their bundle was oversized.
+
+Server-side apply tracks ownership in `metadata.managedFields` and writes no such
+annotation, so it has no ceiling of this kind. The fix is therefore not "shrink the
+bundle" but "apply it server-side", and this check enforces exactly that pairing:
+
+    a bundle over the ceiling is fine  IF AND ONLY IF  its Application uses
+    ServerSideApply=true.
+
+WHY THE SIZE ALONE IS NOT THE RULE. Every bundle embeds `rules.yaml` verbatim, so they
+all sit within a few kilobytes of each other and of the ceiling. A pure size limit would
+either fire on the whole fleet or be set so high it never fires. What actually matters is
+whether the apply mechanism can carry the object, and that is a property of the pair.
+
+DELIBERATELY NOT CHECKED: whether the live cluster matches. This runs on a PR, where
+there is no cluster to ask, and a gate that quietly degrades to "could not check" is
+worse than one with a stated scope.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import pathlib
+import sys
+
+import yaml
+
+# metadata.annotations ceiling, in bytes, for all annotations combined.
+# k8s.io/apimachinery: TotalAnnotationSizeLimitB = 256 * 1024
+ANNOTATION_LIMIT = 262144
+
+# last-applied-configuration is the object's JSON, but the apply also carries the other
+# annotations (tracking-id, checksum) and the key names themselves. Reserve for those so
+# the check fires slightly BEFORE the API server does rather than slightly after — an
+# off-by-a-few-hundred-bytes gate that lets the breaking change through is no gate.
+ANNOTATION_OVERHEAD = 2048
+
+REPO = pathlib.Path(__file__).resolve().parents[2]
+
+
+def applied_size(doc: dict) -> int:
+    """Bytes client-side apply would write into last-applied-configuration.
+
+    kubectl serialises the object it was given, minus the annotation it is about to add.
+    Compact separators match kubectl's encoder.
+    """
+    obj = {
+        "apiVersion": doc.get("apiVersion"),
+        "kind": doc.get("kind"),
+        "metadata": doc.get("metadata", {}),
+        "data": doc.get("data", {}),
+    }
+    return len(json.dumps(obj, separators=(",", ":")))
+
+
+def load_applications(apps_dir: pathlib.Path) -> dict[str, dict]:
+    """Map component-directory name -> Application spec that deploys it."""
+    by_path: dict[str, dict] = {}
+    for f in sorted(apps_dir.glob("*.yaml")):
+        try:
+            docs = [d for d in yaml.safe_load_all(f.read_text()) if d]
+        except yaml.YAMLError:
+            continue
+        for d in docs:
+            if not isinstance(d, dict) or d.get("kind") != "Application":
+                continue
+            path = ((d.get("spec") or {}).get("source") or {}).get("path") or ""
+            if not path:
+                continue
+            by_path[pathlib.PurePosixPath(path).name] = {
+                "file": f.name,
+                "name": (d.get("metadata") or {}).get("name"),
+                "options": (((d.get("spec") or {}).get("syncPolicy") or {}).get("syncOptions") or []),
+            }
+    return by_path
+
+
+def check(root: pathlib.Path) -> list[str]:
+    components = root / "openbank-infra/gitops/components"
+    apps = load_applications(root / "openbank-infra/gitops/apps")
+    problems: list[str] = []
+
+    for bundle in sorted(components.glob("*/*opa-bundle*.yaml")):
+        try:
+            docs = [d for d in yaml.safe_load_all(bundle.read_text()) if d]
+        except yaml.YAMLError as exc:
+            problems.append(f"{bundle.relative_to(root)}: unparseable ({exc})")
+            continue
+        for doc in docs:
+            if not isinstance(doc, dict) or doc.get("kind") != "ConfigMap":
+                continue
+            size = applied_size(doc)
+            if size + ANNOTATION_OVERHEAD <= ANNOTATION_LIMIT:
+                continue
+
+            component = bundle.parent.name
+            app = apps.get(component)
+            if app is None:
+                problems.append(
+                    f"{bundle.relative_to(root)}: {size} bytes exceeds the client-side apply "
+                    f"ceiling and no Application under gitops/apps deploys "
+                    f"components/{component}, so nothing can be verified to install it."
+                )
+                continue
+            if "ServerSideApply=true" not in app["options"]:
+                over = size + ANNOTATION_OVERHEAD - ANNOTATION_LIMIT
+                problems.append(
+                    f"{bundle.relative_to(root)}: {size} bytes, {over} over what client-side "
+                    f"apply can carry, but Application '{app['name']}' "
+                    f"(gitops/apps/{app['file']}) does not set ServerSideApply=true. "
+                    f"The API server will reject this ConfigMap with "
+                    f"'metadata.annotations: Too long' and Argo will retry forever while the "
+                    f"cluster keeps serving the previous policy. Add "
+                    f"'- ServerSideApply=true' to spec.syncPolicy.syncOptions."
+                )
+    return problems
+
+
+def self_test() -> int:
+    """Feed the checker the two inputs it must separate. A gate that has only ever seen
+    the correct tree is unfalsified — this proves it fires AND that it does not misfire."""
+    import tempfile
+
+    failures = 0
+    big = "x" * (ANNOTATION_LIMIT + 10_000)
+
+    for label, options, expect_problem in (
+        ("oversized bundle, no ServerSideApply", ["CreateNamespace=false"], True),
+        ("oversized bundle, ServerSideApply set", ["CreateNamespace=false", "ServerSideApply=true"], False),
+    ):
+        with tempfile.TemporaryDirectory() as tmp:
+            root = pathlib.Path(tmp)
+            comp = root / "openbank-infra/gitops/components/demo"
+            appdir = root / "openbank-infra/gitops/apps"
+            comp.mkdir(parents=True)
+            appdir.mkdir(parents=True)
+            (comp / "demo-opa-bundle.yaml").write_text(
+                yaml.safe_dump(
+                    {
+                        "apiVersion": "v1",
+                        "kind": "ConfigMap",
+                        "metadata": {"name": "demo-opa-bundle", "namespace": "demo"},
+                        "data": {"rest.rego": big},
+                    }
+                )
+            )
+            (appdir / "demo.yaml").write_text(
+                yaml.safe_dump(
+                    {
+                        "apiVersion": "argoproj.io/v1alpha1",
+                        "kind": "Application",
+                        "metadata": {"name": "demo"},
+                        "spec": {
+                            "source": {"path": "openbank-infra/gitops/components/demo"},
+                            "syncPolicy": {"syncOptions": options},
+                        },
+                    }
+                )
+            )
+            got = bool(check(root))
+            ok = got == expect_problem
+            failures += 0 if ok else 1
+            print(f"  [{'ok' if ok else 'FAIL'}] {label}: flagged={got} expected={expect_problem}")
+
+    # A small bundle must never be flagged, whatever the sync options.
+    with tempfile.TemporaryDirectory() as tmp:
+        root = pathlib.Path(tmp)
+        comp = root / "openbank-infra/gitops/components/demo"
+        appdir = root / "openbank-infra/gitops/apps"
+        comp.mkdir(parents=True)
+        appdir.mkdir(parents=True)
+        (comp / "demo-opa-bundle.yaml").write_text(
+            yaml.safe_dump(
+                {
+                    "apiVersion": "v1",
+                    "kind": "ConfigMap",
+                    "metadata": {"name": "demo-opa-bundle"},
+                    "data": {"rest.rego": "package x"},
+                }
+            )
+        )
+        (appdir / "demo.yaml").write_text(
+            yaml.safe_dump(
+                {
+                    "apiVersion": "argoproj.io/v1alpha1",
+                    "kind": "Application",
+                    "metadata": {"name": "demo"},
+                    "spec": {
+                        "source": {"path": "openbank-infra/gitops/components/demo"},
+                        "syncPolicy": {"syncOptions": []},
+                    },
+                }
+            )
+        )
+        got = bool(check(root))
+        failures += 0 if not got else 1
+        print(f"  [{'ok' if not got else 'FAIL'}] small bundle, no options: flagged={got} expected=False")
+
+    print("self-test:", "PASS" if failures == 0 else f"{failures} FAILED")
+    return 1 if failures else 0
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--self-test", action="store_true")
+    args = parser.parse_args()
+
+    if args.self_test:
+        return self_test()
+
+    problems = check(REPO)
+    if problems:
+        print("OPA bundles that cannot be installed by client-side apply:\n")
+        for p in problems:
+            print(f"::error::{p}")
+        return 1
+    print("OPA bundle apply-size check: OK")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/openbank-infra/gitops/apps/accounts.yaml
+++ b/openbank-infra/gitops/apps/accounts.yaml
@@ -38,8 +38,16 @@ spec:
         duration: 15s
         factor: 2
         maxDuration: 5m
+      # ServerSideApply: the OPA bundle ConfigMap is ~260 KB, and client-side apply
+      # stores the whole object in kubectl.kubernetes.io/last-applied-configuration,
+      # which Kubernetes caps at 262144 bytes for all annotations combined. Past that
+      # the ConfigMap is REJECTED and Argo retries forever ("Too long"), so the policy
+      # in the cluster silently freezes at the last version that fitted while git moves
+      # on. Server-side apply tracks ownership in metadata.managedFields instead and
+      # writes no such annotation, so it has no size ceiling of this kind.
     syncOptions:
       - CreateNamespace=false
+      - ServerSideApply=true
   # Argo Rollouts (ADR-0098) sets spec.selector.rollouts-pod-template-hash on the
   # stable and canary Services at runtime; git holds only the base selector, so
   # without this every Rollout-backed Service reads as permanently OutOfSync.

--- a/openbank-infra/gitops/apps/aml.yaml
+++ b/openbank-infra/gitops/apps/aml.yaml
@@ -25,5 +25,13 @@ spec:
         duration: 15s
         factor: 2
         maxDuration: 5m
+      # ServerSideApply: the OPA bundle ConfigMap is ~260 KB, and client-side apply
+      # stores the whole object in kubectl.kubernetes.io/last-applied-configuration,
+      # which Kubernetes caps at 262144 bytes for all annotations combined. Past that
+      # the ConfigMap is REJECTED and Argo retries forever ("Too long"), so the policy
+      # in the cluster silently freezes at the last version that fitted while git moves
+      # on. Server-side apply tracks ownership in metadata.managedFields instead and
+      # writes no such annotation, so it has no size ceiling of this kind.
     syncOptions:
       - CreateNamespace=false
+      - ServerSideApply=true

--- a/openbank-infra/gitops/apps/anacredit.yaml
+++ b/openbank-infra/gitops/apps/anacredit.yaml
@@ -26,5 +26,13 @@ spec:
         duration: 15s
         factor: 2
         maxDuration: 5m
+      # ServerSideApply: the OPA bundle ConfigMap is ~260 KB, and client-side apply
+      # stores the whole object in kubectl.kubernetes.io/last-applied-configuration,
+      # which Kubernetes caps at 262144 bytes for all annotations combined. Past that
+      # the ConfigMap is REJECTED and Argo retries forever ("Too long"), so the policy
+      # in the cluster silently freezes at the last version that fitted while git moves
+      # on. Server-side apply tracks ownership in metadata.managedFields instead and
+      # writes no such annotation, so it has no size ceiling of this kind.
     syncOptions:
       - CreateNamespace=false
+      - ServerSideApply=true

--- a/openbank-infra/gitops/apps/balances.yaml
+++ b/openbank-infra/gitops/apps/balances.yaml
@@ -33,8 +33,16 @@ spec:
         duration: 15s
         factor: 2
         maxDuration: 5m
+      # ServerSideApply: the OPA bundle ConfigMap is ~260 KB, and client-side apply
+      # stores the whole object in kubectl.kubernetes.io/last-applied-configuration,
+      # which Kubernetes caps at 262144 bytes for all annotations combined. Past that
+      # the ConfigMap is REJECTED and Argo retries forever ("Too long"), so the policy
+      # in the cluster silently freezes at the last version that fitted while git moves
+      # on. Server-side apply tracks ownership in metadata.managedFields instead and
+      # writes no such annotation, so it has no size ceiling of this kind.
     syncOptions:
       - CreateNamespace=false
+      - ServerSideApply=true
   # Argo Rollouts (ADR-0098) sets spec.selector.rollouts-pod-template-hash on the
   # stable and canary Services at runtime; git holds only the base selector, so
   # without this every Rollout-backed Service reads as permanently OutOfSync.

--- a/openbank-infra/gitops/apps/billing.yaml
+++ b/openbank-infra/gitops/apps/billing.yaml
@@ -22,6 +22,15 @@ spec:
     server: https://kubernetes.default.svc
     namespace: billing
   syncPolicy:
+    # ServerSideApply: the OPA bundle ConfigMap is ~260 KB, and client-side apply
+    # stores the whole object in kubectl.kubernetes.io/last-applied-configuration,
+    # which Kubernetes caps at 262144 bytes for all annotations combined. Past that
+    # the ConfigMap is REJECTED and Argo retries forever ("Too long"), so the policy
+    # in the cluster silently freezes at the last version that fitted while git moves
+    # on. Server-side apply tracks ownership in metadata.managedFields instead and
+    # writes no such annotation, so it has no size ceiling of this kind.
+    syncOptions:
+      - ServerSideApply=true
     automated:
       prune: true
       selfHeal: true

--- a/openbank-infra/gitops/apps/campaign.yaml
+++ b/openbank-infra/gitops/apps/campaign.yaml
@@ -28,5 +28,13 @@ spec:
         duration: 15s
         factor: 2
         maxDuration: 5m
+      # ServerSideApply: the OPA bundle ConfigMap is ~260 KB, and client-side apply
+      # stores the whole object in kubectl.kubernetes.io/last-applied-configuration,
+      # which Kubernetes caps at 262144 bytes for all annotations combined. Past that
+      # the ConfigMap is REJECTED and Argo retries forever ("Too long"), so the policy
+      # in the cluster silently freezes at the last version that fitted while git moves
+      # on. Server-side apply tracks ownership in metadata.managedFields instead and
+      # writes no such annotation, so it has no size ceiling of this kind.
     syncOptions:
       - CreateNamespace=false
+      - ServerSideApply=true

--- a/openbank-infra/gitops/apps/consent.yaml
+++ b/openbank-infra/gitops/apps/consent.yaml
@@ -22,8 +22,16 @@ spec:
     automated:
       prune: true
       selfHeal: true
+      # ServerSideApply: the OPA bundle ConfigMap is ~260 KB, and client-side apply
+      # stores the whole object in kubectl.kubernetes.io/last-applied-configuration,
+      # which Kubernetes caps at 262144 bytes for all annotations combined. Past that
+      # the ConfigMap is REJECTED and Argo retries forever ("Too long"), so the policy
+      # in the cluster silently freezes at the last version that fitted while git moves
+      # on. Server-side apply tracks ownership in metadata.managedFields instead and
+      # writes no such annotation, so it has no size ceiling of this kind.
     syncOptions:
       - CreateNamespace=true
+      - ServerSideApply=true
   # Argo Rollouts (ADR-0098) sets spec.selector.rollouts-pod-template-hash on the
   # stable and canary Services at runtime; git holds only the base selector, so
   # without this every Rollout-backed Service reads as permanently OutOfSync.

--- a/openbank-infra/gitops/apps/copilot.yaml
+++ b/openbank-infra/gitops/apps/copilot.yaml
@@ -30,5 +30,13 @@ spec:
         duration: 15s
         factor: 2
         maxDuration: 5m
+      # ServerSideApply: the OPA bundle ConfigMap is ~260 KB, and client-side apply
+      # stores the whole object in kubectl.kubernetes.io/last-applied-configuration,
+      # which Kubernetes caps at 262144 bytes for all annotations combined. Past that
+      # the ConfigMap is REJECTED and Argo retries forever ("Too long"), so the policy
+      # in the cluster silently freezes at the last version that fitted while git moves
+      # on. Server-side apply tracks ownership in metadata.managedFields instead and
+      # writes no such annotation, so it has no size ceiling of this kind.
     syncOptions:
       - CreateNamespace=false
+      - ServerSideApply=true

--- a/openbank-infra/gitops/apps/document-service.yaml
+++ b/openbank-infra/gitops/apps/document-service.yaml
@@ -29,6 +29,15 @@ spec:
     server: https://kubernetes.default.svc
     namespace: documents
   syncPolicy:
+    # ServerSideApply: the OPA bundle ConfigMap is ~260 KB, and client-side apply
+    # stores the whole object in kubectl.kubernetes.io/last-applied-configuration,
+    # which Kubernetes caps at 262144 bytes for all annotations combined. Past that
+    # the ConfigMap is REJECTED and Argo retries forever ("Too long"), so the policy
+    # in the cluster silently freezes at the last version that fitted while git moves
+    # on. Server-side apply tracks ownership in metadata.managedFields instead and
+    # writes no such annotation, so it has no size ceiling of this kind.
+    syncOptions:
+      - ServerSideApply=true
     automated:
       prune: true
       selfHeal: true

--- a/openbank-infra/gitops/apps/fraud.yaml
+++ b/openbank-infra/gitops/apps/fraud.yaml
@@ -22,6 +22,15 @@ spec:
     server: https://kubernetes.default.svc
     namespace: fraud
   syncPolicy:
+    # ServerSideApply: the OPA bundle ConfigMap is ~260 KB, and client-side apply
+    # stores the whole object in kubectl.kubernetes.io/last-applied-configuration,
+    # which Kubernetes caps at 262144 bytes for all annotations combined. Past that
+    # the ConfigMap is REJECTED and Argo retries forever ("Too long"), so the policy
+    # in the cluster silently freezes at the last version that fitted while git moves
+    # on. Server-side apply tracks ownership in metadata.managedFields instead and
+    # writes no such annotation, so it has no size ceiling of this kind.
+    syncOptions:
+      - ServerSideApply=true
     automated:
       prune: true
       selfHeal: true

--- a/openbank-infra/gitops/apps/fx.yaml
+++ b/openbank-infra/gitops/apps/fx.yaml
@@ -20,6 +20,15 @@ spec:
     server: https://kubernetes.default.svc
     namespace: fx
   syncPolicy:
+    # ServerSideApply: the OPA bundle ConfigMap is ~260 KB, and client-side apply
+    # stores the whole object in kubectl.kubernetes.io/last-applied-configuration,
+    # which Kubernetes caps at 262144 bytes for all annotations combined. Past that
+    # the ConfigMap is REJECTED and Argo retries forever ("Too long"), so the policy
+    # in the cluster silently freezes at the last version that fitted while git moves
+    # on. Server-side apply tracks ownership in metadata.managedFields instead and
+    # writes no such annotation, so it has no size ceiling of this kind.
+    syncOptions:
+      - ServerSideApply=true
     automated:
       prune: true
       selfHeal: true

--- a/openbank-infra/gitops/apps/kyc.yaml
+++ b/openbank-infra/gitops/apps/kyc.yaml
@@ -29,8 +29,16 @@ spec:
         duration: 15s
         factor: 2
         maxDuration: 5m
+      # ServerSideApply: the OPA bundle ConfigMap is ~260 KB, and client-side apply
+      # stores the whole object in kubectl.kubernetes.io/last-applied-configuration,
+      # which Kubernetes caps at 262144 bytes for all annotations combined. Past that
+      # the ConfigMap is REJECTED and Argo retries forever ("Too long"), so the policy
+      # in the cluster silently freezes at the last version that fitted while git moves
+      # on. Server-side apply tracks ownership in metadata.managedFields instead and
+      # writes no such annotation, so it has no size ceiling of this kind.
     syncOptions:
       - CreateNamespace=false
+      - ServerSideApply=true
   # Argo Rollouts (ADR-0098) sets spec.selector.rollouts-pod-template-hash on the
   # stable and canary Services at runtime; git holds only the base selector, so
   # without this every Rollout-backed Service reads as permanently OutOfSync.

--- a/openbank-infra/gitops/apps/ledger.yaml
+++ b/openbank-infra/gitops/apps/ledger.yaml
@@ -29,8 +29,16 @@ spec:
         duration: 15s
         factor: 2
         maxDuration: 5m
+      # ServerSideApply: the OPA bundle ConfigMap is ~260 KB, and client-side apply
+      # stores the whole object in kubectl.kubernetes.io/last-applied-configuration,
+      # which Kubernetes caps at 262144 bytes for all annotations combined. Past that
+      # the ConfigMap is REJECTED and Argo retries forever ("Too long"), so the policy
+      # in the cluster silently freezes at the last version that fitted while git moves
+      # on. Server-side apply tracks ownership in metadata.managedFields instead and
+      # writes no such annotation, so it has no size ceiling of this kind.
     syncOptions:
       - CreateNamespace=false
+      - ServerSideApply=true
   # Argo Rollouts (ADR-0098) sets spec.selector.rollouts-pod-template-hash on the
   # stable and canary Services at runtime; git holds only the base selector, so
   # without this every Rollout-backed Service reads as permanently OutOfSync.

--- a/openbank-infra/gitops/apps/lending.yaml
+++ b/openbank-infra/gitops/apps/lending.yaml
@@ -38,8 +38,16 @@ spec:
         duration: 15s
         factor: 2
         maxDuration: 5m
+      # ServerSideApply: the OPA bundle ConfigMap is ~260 KB, and client-side apply
+      # stores the whole object in kubectl.kubernetes.io/last-applied-configuration,
+      # which Kubernetes caps at 262144 bytes for all annotations combined. Past that
+      # the ConfigMap is REJECTED and Argo retries forever ("Too long"), so the policy
+      # in the cluster silently freezes at the last version that fitted while git moves
+      # on. Server-side apply tracks ownership in metadata.managedFields instead and
+      # writes no such annotation, so it has no size ceiling of this kind.
     syncOptions:
       - CreateNamespace=false
+      - ServerSideApply=true
   # Argo Rollouts sets spec.selector.rollouts-pod-template-hash on Services at
   # runtime; ignore that one controller-managed key so the Application stays Synced.
   ignoreDifferences:

--- a/openbank-infra/gitops/apps/notifications.yaml
+++ b/openbank-infra/gitops/apps/notifications.yaml
@@ -30,5 +30,13 @@ spec:
         duration: 15s
         factor: 2
         maxDuration: 5m
+      # ServerSideApply: the OPA bundle ConfigMap is ~260 KB, and client-side apply
+      # stores the whole object in kubectl.kubernetes.io/last-applied-configuration,
+      # which Kubernetes caps at 262144 bytes for all annotations combined. Past that
+      # the ConfigMap is REJECTED and Argo retries forever ("Too long"), so the policy
+      # in the cluster silently freezes at the last version that fitted while git moves
+      # on. Server-side apply tracks ownership in metadata.managedFields instead and
+      # writes no such annotation, so it has no size ceiling of this kind.
     syncOptions:
       - CreateNamespace=false
+      - ServerSideApply=true

--- a/openbank-infra/gitops/apps/party.yaml
+++ b/openbank-infra/gitops/apps/party.yaml
@@ -26,8 +26,16 @@ spec:
         duration: 15s
         factor: 2
         maxDuration: 5m
+      # ServerSideApply: the OPA bundle ConfigMap is ~260 KB, and client-side apply
+      # stores the whole object in kubectl.kubernetes.io/last-applied-configuration,
+      # which Kubernetes caps at 262144 bytes for all annotations combined. Past that
+      # the ConfigMap is REJECTED and Argo retries forever ("Too long"), so the policy
+      # in the cluster silently freezes at the last version that fitted while git moves
+      # on. Server-side apply tracks ownership in metadata.managedFields instead and
+      # writes no such annotation, so it has no size ceiling of this kind.
     syncOptions:
       - CreateNamespace=false
+      - ServerSideApply=true
   # Argo Rollouts (ADR-0098) sets spec.selector.rollouts-pod-template-hash on the
   # stable and canary Services at runtime; git holds only the base selector, so
   # without this every Rollout-backed Service reads as permanently OutOfSync.

--- a/openbank-infra/gitops/apps/payments.yaml
+++ b/openbank-infra/gitops/apps/payments.yaml
@@ -18,8 +18,16 @@ spec:
     automated:
       prune: true
       selfHeal: true
+      # ServerSideApply: the OPA bundle ConfigMap is ~260 KB, and client-side apply
+      # stores the whole object in kubectl.kubernetes.io/last-applied-configuration,
+      # which Kubernetes caps at 262144 bytes for all annotations combined. Past that
+      # the ConfigMap is REJECTED and Argo retries forever ("Too long"), so the policy
+      # in the cluster silently freezes at the last version that fitted while git moves
+      # on. Server-side apply tracks ownership in metadata.managedFields instead and
+      # writes no such annotation, so it has no size ceiling of this kind.
     syncOptions:
       - CreateNamespace=true
+      - ServerSideApply=true
   # Argo Rollouts (ADR-0098) sets spec.selector.rollouts-pod-template-hash on the
   # stable and canary Services at runtime; git holds only the base selector, so
   # without this every Rollout-backed Service reads as permanently OutOfSync.

--- a/openbank-infra/gitops/apps/pid.yaml
+++ b/openbank-infra/gitops/apps/pid.yaml
@@ -26,5 +26,13 @@ spec:
         duration: 15s
         factor: 2
         maxDuration: 5m
+      # ServerSideApply: the OPA bundle ConfigMap is ~260 KB, and client-side apply
+      # stores the whole object in kubectl.kubernetes.io/last-applied-configuration,
+      # which Kubernetes caps at 262144 bytes for all annotations combined. Past that
+      # the ConfigMap is REJECTED and Argo retries forever ("Too long"), so the policy
+      # in the cluster silently freezes at the last version that fitted while git moves
+      # on. Server-side apply tracks ownership in metadata.managedFields instead and
+      # writes no such annotation, so it has no size ceiling of this kind.
     syncOptions:
       - CreateNamespace=false
+      - ServerSideApply=true

--- a/openbank-infra/gitops/apps/psd2.yaml
+++ b/openbank-infra/gitops/apps/psd2.yaml
@@ -21,6 +21,15 @@ spec:
     server: https://kubernetes.default.svc
     namespace: psd2
   syncPolicy:
+    # ServerSideApply: the OPA bundle ConfigMap is ~260 KB, and client-side apply
+    # stores the whole object in kubectl.kubernetes.io/last-applied-configuration,
+    # which Kubernetes caps at 262144 bytes for all annotations combined. Past that
+    # the ConfigMap is REJECTED and Argo retries forever ("Too long"), so the policy
+    # in the cluster silently freezes at the last version that fitted while git moves
+    # on. Server-side apply tracks ownership in metadata.managedFields instead and
+    # writes no such annotation, so it has no size ceiling of this kind.
+    syncOptions:
+      - ServerSideApply=true
     automated:
       prune: true
       selfHeal: true

--- a/openbank-infra/gitops/apps/sanctions.yaml
+++ b/openbank-infra/gitops/apps/sanctions.yaml
@@ -27,8 +27,16 @@ spec:
         duration: 15s
         factor: 2
         maxDuration: 5m
+      # ServerSideApply: the OPA bundle ConfigMap is ~260 KB, and client-side apply
+      # stores the whole object in kubectl.kubernetes.io/last-applied-configuration,
+      # which Kubernetes caps at 262144 bytes for all annotations combined. Past that
+      # the ConfigMap is REJECTED and Argo retries forever ("Too long"), so the policy
+      # in the cluster silently freezes at the last version that fitted while git moves
+      # on. Server-side apply tracks ownership in metadata.managedFields instead and
+      # writes no such annotation, so it has no size ceiling of this kind.
     syncOptions:
       - CreateNamespace=false
+      - ServerSideApply=true
   # Argo Rollouts (ADR-0098) sets spec.selector.rollouts-pod-template-hash on the
   # stable and canary Services at runtime; git holds only the base selector, so
   # without this every Rollout-backed Service reads as permanently OutOfSync.

--- a/openbank-infra/gitops/apps/sca.yaml
+++ b/openbank-infra/gitops/apps/sca.yaml
@@ -18,8 +18,16 @@ spec:
     automated:
       prune: true
       selfHeal: true
+      # ServerSideApply: the OPA bundle ConfigMap is ~260 KB, and client-side apply
+      # stores the whole object in kubectl.kubernetes.io/last-applied-configuration,
+      # which Kubernetes caps at 262144 bytes for all annotations combined. Past that
+      # the ConfigMap is REJECTED and Argo retries forever ("Too long"), so the policy
+      # in the cluster silently freezes at the last version that fitted while git moves
+      # on. Server-side apply tracks ownership in metadata.managedFields instead and
+      # writes no such annotation, so it has no size ceiling of this kind.
     syncOptions:
       - CreateNamespace=true
+      - ServerSideApply=true
   # Argo Rollouts (ADR-0098) sets spec.selector.rollouts-pod-template-hash on the
   # stable and canary Services at runtime; git holds only the base selector, so
   # without this every Rollout-backed Service reads as permanently OutOfSync.

--- a/openbank-infra/gitops/apps/statements.yaml
+++ b/openbank-infra/gitops/apps/statements.yaml
@@ -28,5 +28,13 @@ spec:
         duration: 15s
         factor: 2
         maxDuration: 5m
+      # ServerSideApply: the OPA bundle ConfigMap is ~260 KB, and client-side apply
+      # stores the whole object in kubectl.kubernetes.io/last-applied-configuration,
+      # which Kubernetes caps at 262144 bytes for all annotations combined. Past that
+      # the ConfigMap is REJECTED and Argo retries forever ("Too long"), so the policy
+      # in the cluster silently freezes at the last version that fitted while git moves
+      # on. Server-side apply tracks ownership in metadata.managedFields instead and
+      # writes no such annotation, so it has no size ceiling of this kind.
     syncOptions:
       - CreateNamespace=false
+      - ServerSideApply=true

--- a/openbank-infra/gitops/apps/tpp-registry.yaml
+++ b/openbank-infra/gitops/apps/tpp-registry.yaml
@@ -26,5 +26,13 @@ spec:
         duration: 15s
         factor: 2
         maxDuration: 5m
+      # ServerSideApply: the OPA bundle ConfigMap is ~260 KB, and client-side apply
+      # stores the whole object in kubectl.kubernetes.io/last-applied-configuration,
+      # which Kubernetes caps at 262144 bytes for all annotations combined. Past that
+      # the ConfigMap is REJECTED and Argo retries forever ("Too long"), so the policy
+      # in the cluster silently freezes at the last version that fitted while git moves
+      # on. Server-side apply tracks ownership in metadata.managedFields instead and
+      # writes no such annotation, so it has no size ceiling of this kind.
     syncOptions:
       - CreateNamespace=false
+      - ServerSideApply=true

--- a/openbank-infra/gitops/components/lending/gen-lending-opa-bundle.sh
+++ b/openbank-infra/gitops/components/lending/gen-lending-opa-bundle.sh
@@ -19,6 +19,9 @@ LENDING_REST_EXT=$(cat << 'REGO'
 #   lending.create              — submit a loan application (maker)
 #   lending.approve             — approve/reject an application (checker; four-eyes in the handler)
 #   lending.intake              — customer self-service application via customer-edge (ADR-0211)
+#   lending.compliance.propose  — propose a jurisdictional compliance pack (maker, ADR-0212 D4)
+#   lending.compliance.decide   — approve/reject a pack activation (checker, must differ from maker)
+#   lending.compliance.read     — list pending proposals / active packs
 #   lending.read                — get application/loan/schedule/collateral/IFRS-9 snapshot (#id)
 #   lending.list                — list a party's applications/loans
 #   lending.disburse            — disburse an approved application (books the loan)
@@ -106,6 +109,20 @@ allowed_reasons contains "compliance-lending-desk" if {
 		"lending.repay",
 		"lending.writeoff",
 		"lending.collateralRegister",
+		# ADR-0212 D4 pack activation. Missing until now, and the omission made the control
+		# UNREACHABLE rather than merely awkward: the endpoints exist, @RolesAllowed admits
+		# ROLE_COMPLIANCE, and OPA denied every attempt with "policy denied" — so no pack had
+		# ever been activated in any environment with AUTHZ_ENFORCE=true, and none could be.
+		# Only the READ half worked, because base rest.rego's compliance-read-any grants `*.read`
+		# and `lending.compliance.read` happens to end in it. That partial grant is what made the
+		# gap invisible: /active answered 200 with `[]`, which reads as "no packs activated yet"
+		# rather than "you cannot activate one".
+		#
+		# maker != checker is NOT enforced here — CompliancePackActivationService raises
+		# MakerCheckerViolation from the JWT subject, the same stance as lending.approve.
+		"lending.compliance.propose",
+		"lending.compliance.decide",
+		"lending.compliance.read",
 	}
 }
 

--- a/openbank-infra/gitops/components/lending/lending-opa-bundle.yaml
+++ b/openbank-infra/gitops/components/lending/lending-opa-bundle.yaml
@@ -9,7 +9,7 @@ metadata:
     app.kubernetes.io/name: lending-service
     app.kubernetes.io/part-of: lending
   annotations:
-    openbank.tech/policy-checksum: "c78b4688a45adf09"
+    openbank.tech/policy-checksum: "9bb871bcdf9c3f8c"
 data:
   rest.rego: |
     # SPDX-License-Identifier: Apache-2.0
@@ -513,6 +513,9 @@ data:
     #   lending.create              — submit a loan application (maker)
     #   lending.approve             — approve/reject an application (checker; four-eyes in the handler)
     #   lending.intake              — customer self-service application via customer-edge (ADR-0211)
+    #   lending.compliance.propose  — propose a jurisdictional compliance pack (maker, ADR-0212 D4)
+    #   lending.compliance.decide   — approve/reject a pack activation (checker, must differ from maker)
+    #   lending.compliance.read     — list pending proposals / active packs
     #   lending.read                — get application/loan/schedule/collateral/IFRS-9 snapshot (#id)
     #   lending.list                — list a party's applications/loans
     #   lending.disburse            — disburse an approved application (books the loan)
@@ -600,6 +603,20 @@ data:
     		"lending.repay",
     		"lending.writeoff",
     		"lending.collateralRegister",
+    		# ADR-0212 D4 pack activation. Missing until now, and the omission made the control
+    		# UNREACHABLE rather than merely awkward: the endpoints exist, @RolesAllowed admits
+    		# ROLE_COMPLIANCE, and OPA denied every attempt with "policy denied" — so no pack had
+    		# ever been activated in any environment with AUTHZ_ENFORCE=true, and none could be.
+    		# Only the READ half worked, because base rest.rego's compliance-read-any grants `*.read`
+    		# and `lending.compliance.read` happens to end in it. That partial grant is what made the
+    		# gap invisible: /active answered 200 with `[]`, which reads as "no packs activated yet"
+    		# rather than "you cannot activate one".
+    		#
+    		# maker != checker is NOT enforced here — CompliancePackActivationService raises
+    		# MakerCheckerViolation from the JWT subject, the same stance as lending.approve.
+    		"lending.compliance.propose",
+    		"lending.compliance.decide",
+    		"lending.compliance.read",
     	}
     }
 

--- a/openbank-infra/gitops/components/lending/lending-service.yaml
+++ b/openbank-infra/gitops/components/lending/lending-service.yaml
@@ -34,7 +34,7 @@ spec:
       annotations:
         # Rolls the pods when the OPA bundle changes — subPath mounts do NOT hot-reload.
         # Kept in sync by gen-lending-opa-bundle.sh (do not hand-edit).
-        openbank.tech/policy-checksum: "c78b4688a45adf09"
+        openbank.tech/policy-checksum: "9bb871bcdf9c3f8c"
     spec:
       securityContext:
         runAsNonRoot: true


### PR DESCRIPTION
## Five Applications are serving OPA policy that does not match `main`

Measured against the live sandbox:

| app | sync | live checksum | git checksum | sync error |
|---|---|---|---|---|
| ledger | OutOfSync | `ea6e7952f166e3bc` | `8f455914ec6024b2` | Too long |
| psd2 | OutOfSync | `30a4784ea24dabe8` | `bdfcb407bfb50106` | Too long |
| balances | OutOfSync | *(absent)* | *(absent)* | Too long |
| consent | OutOfSync | `3267ec2b5ff04bea` | `87c6711fc8d91ecf` | Too long |
| lending | OutOfSync | `c78b4688a45adf09` | `9bb871bcdf9c3f8c` | Too long |
| **dispute** | **Synced** | `80a8d49133468957` | `80a8d49133468957` | — |

Four of the five are money-path.

## Cause

Kubernetes caps `metadata.annotations` at 262144 bytes for all annotations combined. Client-side apply writes the **entire object** into `kubectl.kubernetes.io/last-applied-configuration`, so once a bundle passes that ceiling the API server rejects it outright:

```
ConfigMap "lending-opa-bundle" is invalid: metadata.annotations:
Too long: may not be more than 262144 bytes
```

Argo retries on its 5m backoff, forever. **Six bundles are already over on `main`** and **25 of 40 sit within 5 KB of the ceiling**, because every bundle embeds `rules.yaml` verbatim — this was going to reach the whole fleet, not just these five. Live headroom on lending before this was **1518 bytes**.

## Why nobody noticed

The Application reads `OutOfSync`/`Progressing` — which is also what a rollout still in progress reads. Nothing compares the live bundle to git, the error is one line inside `operationState.message`, and OPA keeps answering: **with the previous policy**. A frozen authorization policy has no symptom until someone needs a rule added after the freeze — which is exactly how #3402 was found.

## dispute is the control

`dispute` identifies the mechanism rather than the size. Its bundle is the **largest of the fleet**, 5459 bytes *over* the ceiling, and it is `Synced` with matching checksums — because its Application already sets `ServerSideApply=true`. Server-side apply tracks ownership in `managedFields` and writes no such annotation.

## Fix

`ServerSideApply=true` on the 23 Applications that deploy an OPA bundle without it. Ten already had it, and `aws/envs/sandbox-platform/main.tf` already describes SSA as *"our default sync"* — the fleet was simply split.

Confirmed by server dry-run against the live cluster, both directions:

```
kubectl apply --dry-run=server                 ->  "Too long"          (today)
kubectl apply --server-side --force-conflicts  ->  serverside-applied  (after)
```

## New gate `opa-bundle-apply-size` (enforced, group `gitops`)

Refuses a bundle over the ceiling unless its Application uses server-side apply. **The rule is the pair, not the size** — every bundle is near the ceiling, so a size limit alone would either fire on the whole fleet or be set so high it never fires.

Falsified, not assumed: self-test 3/3 (fires when oversized without SSA, silent when oversized with SSA, silent when small), and run against **`main`** it names balances, consent, ledger, psd2 and lending — the exact five measured above.

## Deliberately not included

The one-time **field-ownership migration**. Resources already applied client-side conflict on their first server-side apply (`conflicts with "argocd-controller"`), which needs a deliberate per-service step — and for the four money-path services it converges live authorization onto policy nobody has re-reviewed since it was blocked. That belongs in a separate change with a human in front of it.

Refs #3402
