### PR TITLE
fix(delegation): runtime-only Dockerfile, matching the #3392 convention

### DIFF
--- a/openbank-delegation-service/Dockerfile
+++ b/openbank-delegation-service/Dockerfile
@@ -1,42 +1,34 @@
-FROM eclipse-temurin:25-jdk@sha256:dfc0093e3dbf43dae57827111c6e374f5b44fac19a9451584b2b336b81474d64 AS build
-WORKDIR /build
-
-# The root settings.gradle.kts is the entry point for every openbank-* module and it
-# `includeBuild("build-logic")` for the `openbank.quarkus-service` convention plugin,
-# so the wrapper, the root build files and build-logic all have to be in the context —
-# not just the service directory. gradle.properties matters too: it carries
-# org.gradle.dependency.verification=lenient, so omitting it silently builds the
-# image under Gradle's default STRICT verification - different rules than the repo.
-COPY gradle /build/gradle
-COPY gradlew gradle.properties build.gradle.kts settings.gradle.kts /build/
-COPY build-logic /build/build-logic
-# ADR-0122 split the shared code into sibling top-level modules; `COPY openbank-libs`
-# alone leaves `project(":openbank-libs-domain")` etc. unresolvable at configuration time.
-COPY openbank-libs /build/openbank-libs
-COPY openbank-libs-domain /build/openbank-libs-domain
-COPY openbank-libs-runtime /build/openbank-libs-runtime
-COPY openbank-libs-temporal /build/openbank-libs-temporal
-COPY openbank-libs-testing /build/openbank-libs-testing
-COPY openbank-delegation-service /build/openbank-delegation-service
-
-RUN chmod +x gradlew && \
-    ./gradlew :openbank-delegation-service:quarkusBuild \
-      -Dquarkus.package.jar.type=fast-jar \
-      --no-daemon \
-      --console=plain
+# NOT a build recipe — and it never was one.
+#
+# The image is built by .github/workflows/Dockerfile.deploy from a quarkus-app/
+# produced host-side (auto-deploy.yml, ghcr-publish.yml,
+# openbank-infra/scripts/build-push-service.sh). Those three read exactly ONE thing
+# from this file: the EXPOSE line, used to set the container port (falling back to
+# 8080 when absent).
+#
+# This file was born with a Gradle build stage, and unlike the 51 #3016 measured it
+# would have worked — it did COPY build-logic, gradle.properties and the ADR-0122 libs
+# siblings, which is exactly what made the others unbuildable. That made it worse, not
+# better: a second and genuinely buildable definition of how the image is made, free to
+# drift from the one that actually runs. It now mirrors Dockerfile.deploy, so what it
+# says is what actually happens.
+#
+# Adding a build stage back here is enforced against by
+# .github/scripts/check-dockerfile-no-build-stage.py (#3392).
 
 FROM eclipse-temurin:25-jre-alpine@sha256:28db6fdf60e38945e43d840c0333aeaec66c15943070104f7586fd3c9d1665b0
 WORKDIR /app
 RUN addgroup -S openbank && adduser -S openbank -G openbank
 USER openbank
+COPY quarkus-app/lib/ /app/lib/
+COPY quarkus-app/*.jar /app/
+COPY quarkus-app/app/ /app/app/
+COPY quarkus-app/quarkus/ /app/quarkus/
 
-# fast-jar layout: build/quarkus-app/{lib,app,quarkus,quarkus-run.jar}. There is no
-# top-level <service>-<version>-runner.jar — that is the uber-jar output. Naming it
-# here also hardcoded a version that does not track version.txt.
-COPY --from=build /build/openbank-delegation-service/build/quarkus-app/lib/ /app/lib/
-COPY --from=build /build/openbank-delegation-service/build/quarkus-app/*.jar /app/
-COPY --from=build /build/openbank-delegation-service/build/quarkus-app/app/ /app/app/
-COPY --from=build /build/openbank-delegation-service/build/quarkus-app/quarkus/ /app/quarkus/
+# CycloneDX SBOM baked in by the deploy pipeline when the service produces one;
+# served live at /q/openbank/sbom (admin-ui Tech Inventory reads it).
+COPY sbom/bom.json /app/sbom/bom.json
+ENV OPENBANK_SBOM_PATH=/app/sbom/bom.json
 
 EXPOSE 8126
-ENTRYPOINT ["java", "-XX:+UseZGC", "-Djava.util.logging.manager=org.jboss.logmanager.LogManager", "-jar", "/app/quarkus-run.jar"]
+ENTRYPOINT ["java","-XX:+UseZGC","-Djava.util.logging.manager=org.jboss.logmanager.LogManager","-jar","/app/quarkus-run.jar"]


### PR DESCRIPTION
delegation-service arrived on `main` in #3414 with a Gradle build-stage Dockerfile, while #3392 was rewriting the other 52 to runtime-only and adding a gate that rejects that shape. #3414 merged first, so `main` now carries the 53rd file — and it is the one #3392's gate will flag.

## Measured, not assumed

I ran #3392's gate against `main` before and after this change:

```
main today          52 findings across 53 Dockerfiles   (delegation among them)
this branch         51 findings across 53 Dockerfiles   (delegation not among them)
```

The remaining 51 are #3392's to land; this removes exactly the one it does not cover.

## The result mirrors what actually builds

Diffed against `.github/workflows/Dockerfile.deploy`, ignoring comments and `EXPOSE`:

```
> COPY sbom/bom.json /app/sbom/bom.json
> ENV OPENBANK_SBOM_PATH=/app/sbom/bom.json
```

Those two lines are the whole difference, and they are correct: `build-push-service.sh:79-80`, `auto-deploy.yml:489` and `ghcr-publish.yml:141` each append them to the generated context at build time. So this file describes the **effective** image, which is the property #3392 is after. Against #3392's own `openbank-ledger-service/Dockerfile` the only difference is `EXPOSE 8126` vs `8101`.

## Why the build stage was worse than the ones it resembled

The 51 files #3016 measured were unbuildable — no `COPY build-logic`, no `gradle.properties`, no ADR-0122 libs siblings. This one had all three, so it would genuinely have built. That is not an improvement: an unbuildable recipe is obviously dead text, while a buildable one is a second, credible definition of how the image is made, free to drift from `Dockerfile.deploy` with nothing to notice. Of the 28 lines it added, `EXPOSE 8126` was the only one anything read.

## Ordering

Independent of #3392 — it merges cleanly before or after, and the gate is satisfied either way once both land. If #3392 merges first this is what turns its run green; if this merges first it simply arrives early.

Refs #3392, #3414, #3016
