### PR TITLE
test(gitops): assert the third exit route of the libs fan-out script

### DIFF
--- a/.github/scripts/libs-change-dependents.sh
+++ b/.github/scripts/libs-change-dependents.sh
@@ -105,8 +105,17 @@ selftest() {
     echo "selftest FAIL: a real libs change must exit 0 — it printed consumers and still failed" >&2
     fail=1
   fi
+  # A libs module changed, but none of its consumers is in ALL_SERVICES — a third route to a
+  # non-zero status, distinct from the two above: the fan-out is non-empty and the intersection is
+  # empty. Found by #3407, which fixed the same defect independently and asserted this case; the
+  # merged fix already handles it, and an untested route is one refactor away from returning.
+  if ! printf 'openbank-libs-domain/src/main/kotlin/X.kt\n' \
+    | bash "$me" "openbank-not-a-real-service" >/dev/null 2>&1; then
+    echo "selftest FAIL: a fan-out with no consumer inside ALL_SERVICES must exit 0" >&2
+    fail=1
+  fi
 
-  [ "$fail" -eq 0 ] && echo "selftest OK: matchers verified in both directions, and the exit status on both an empty and a non-empty result."
+  [ "$fail" -eq 0 ] && echo "selftest OK: matchers verified in both directions, and the exit status on all three routes — empty fan-out, non-empty fan-out, and a fan-out that intersects nothing."
   return "$fail"
 }
 


### PR DESCRIPTION
## What

#3406 fixed the auto-deploy detect step, which had two silent routes to exit 1. There is a **third**,
and the self-test does not assert it: a libs module changed, the fan-out is non-empty, and none of
its consumers is in `ALL_SERVICES` — so the intersection is empty while the fan-out is not.

The merged fix already handles it (`grep -Fxf … || true` returns 0 on no match; measured `rc=0`).
This adds the assertion, so the route is covered rather than incidentally correct.

## Credit

Found by #3407, which fixed the same defect independently, was closed as a duplicate of #3406, and
asserted this case where mine did not. Comparing the two branches' *content* rather than their merge
state is what surfaced it — the closed PR carried a test the merged one lacked.

## Verification

Falsifiability checked rather than assumed. Reverting only the `|| true` in the merged fix makes the
self-test print both failures and return 1:

```
selftest FAIL: a change touching no libs module must exit 0, not report failure
selftest FAIL: a fan-out with no consumer inside ALL_SERVICES must exit 0
```

Refs #3406, #3407
