### PR TITLE
perf(sanctions): let the screening search reach the trigram index it already has

### DIFF
--- a/openbank-sanctions-service/src/main/kotlin/com/openbank/sanctions/infrastructure/persistence/repository/SanctionsEntryRepositoryImpl.kt
+++ b/openbank-sanctions-service/src/main/kotlin/com/openbank/sanctions/infrastructure/persistence/repository/SanctionsEntryRepositoryImpl.kt
@@ -17,6 +17,7 @@ import io.vertx.mutiny.sqlclient.Tuple
 import jakarta.enterprise.context.ApplicationScoped
 import java.time.Clock
 import java.time.Instant
+import java.util.Locale
 import java.util.UUID
 import io.vertx.sqlclient.Tuple as CoreTuple
 
@@ -47,15 +48,32 @@ class SanctionsEntryRepositoryImpl(private val pool: PgPool, private val clock: 
             FROM sanctions_entries
             WHERE list_type IN ($inClause)
               AND active = true
+              AND $1 <% search_text
               AND word_similarity($1, search_text) >= $2
             ORDER BY match_score DESC
             LIMIT $3
         """.trimIndent()
 
-        val rows = pool
-            .preparedQuery(sql)
-            .execute(Tuple.of(normalizedQuery, threshold.toFloat(), limit))
-            .awaitSuspending()
+        // `<%` is what makes idx_entries_search_trgm usable; the word_similarity() call above it is
+        // NOT an indexable predicate, so without the operator this is a parallel sequential scan of
+        // every active row — measured at 4002 ms over 814,705 rows against 134 ms with the index,
+        // on every screen, twice per payment (#3265).
+        //
+        // `<%` takes its cutoff from the session GUC pg_trgm.word_similarity_threshold, never from a
+        // bind parameter, and the default (0.6) is NOT the caller's [threshold]. Leaving it inherited
+        // would make a sanctions screen's matching depend on ambient session state: raised above the
+        // caller's value it silently DROPS true matches, which is the one failure mode here that must
+        // not be possible. So the GUC is set per call, from the same [threshold] the exact filter
+        // uses, inside a transaction so `SET LOCAL` cannot leak to the next borrower of the pooled
+        // connection. The word_similarity() predicate is kept as well: it is the authoritative filter,
+        // and it makes the result set identical whatever the operator admits.
+        val rows = pool.withTransaction { conn ->
+            conn.query("SET LOCAL pg_trgm.word_similarity_threshold = ${threshold.toGucLiteral()}")
+                .execute()
+                .flatMap {
+                    conn.preparedQuery(sql).execute(Tuple.of(normalizedQuery, threshold.toFloat(), limit))
+                }
+        }.awaitSuspending()
 
         return rows.map { row ->
             val score = row.getDouble("match_score") ?: 0.0
@@ -234,4 +252,20 @@ class SanctionsEntryRepositoryImpl(private val pool: PgPool, private val clock: 
             updatedAt = updatedAt,
         )
     }
+
+    /**
+     * Render [this] as a literal for `SET LOCAL pg_trgm.word_similarity_threshold`.
+     *
+     * `SET` does not accept bind parameters, so the value has to be interpolated. It is made safe by
+     * construction rather than by trusting the caller: the receiver is a [Double], it is clamped
+     * into `0.0..1.0` (the operator's own domain), and it is formatted with an explicit `Locale.ROOT`
+     * pattern. A `Double` cannot carry SQL, and the clamp means a nonsensical threshold cannot widen
+     * the match set either.
+     *
+     * `Locale.ROOT` is load-bearing, not decoration: under a comma-decimal default locale
+     * `"%.4f".format(0.85)` yields `0,8500`, which Postgres reads as the integer list `0,8500` and
+     * the statement fails at runtime — in a service that runs with `-Duser.language=en` in CI and
+     * whatever the pod carries in production.
+     */
+    private fun Double.toGucLiteral(): String = String.format(Locale.ROOT, "%.4f", coerceIn(0.0, 1.0))
 }

--- a/openbank-sanctions-service/src/test/kotlin/com/openbank/sanctions/it/SanctionsSearchIndexEquivalenceIT.kt
+++ b/openbank-sanctions-service/src/test/kotlin/com/openbank/sanctions/it/SanctionsSearchIndexEquivalenceIT.kt
@@ -1,0 +1,172 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright (c) OpenBank contributors. Licensed under the Apache License, Version 2.0.
+// See LICENSE in the repository root or https://www.apache.org/licenses/LICENSE-2.0 for details.
+
+package com.openbank.sanctions.it
+
+import com.openbank.sanctions.domain.model.EntityType
+import com.openbank.sanctions.domain.model.SanctionsEntry
+import com.openbank.sanctions.domain.model.SanctionsListType
+import com.openbank.sanctions.infrastructure.persistence.repository.SanctionsEntryRepositoryImpl
+import io.quarkus.test.common.QuarkusTestResource
+import io.quarkus.test.junit.QuarkusTest
+import io.quarkus.vertx.VertxContextSupport
+import io.smallrye.mutiny.coroutines.awaitSuspending
+import io.smallrye.mutiny.coroutines.uni
+import io.vertx.mutiny.pgclient.PgPool
+import io.vertx.mutiny.sqlclient.Tuple
+import jakarta.inject.Inject
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.Dispatchers
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Test
+
+/**
+ * Real-Postgres cover for #3265: adding the `<%` trigram operator to the screening search must make
+ * the query use `idx_entries_search_trgm` **without changing which entries it matches**.
+ *
+ * Why equivalence is the assertion and speed is not. `word_similarity(q, search_text) >= t` written
+ * as a function is not an indexable predicate, so the search was a parallel sequential scan of every
+ * active row — 4002 ms over 814,705 rows in sandbox, against 134 ms once the index is reachable, paid
+ * on every screen and twice per payment. But this is the sanctions gate on the money path: a rewrite
+ * that is faster and matches a *smaller* set would let a listed subject through, and it would do so
+ * silently, because a screen that returns no match is indistinguishable from a clean one.
+ *
+ * `<%` also takes its cutoff from the session GUC `pg_trgm.word_similarity_threshold`, never from a
+ * bind parameter — so the equivalence being asserted here is a property of the implementation
+ * pinning that GUC per call, not of the operator alone. If the pinning is dropped and the GUC falls
+ * back to its 0.6 default while a caller asks for 0.85, these tests are what notices.
+ */
+@QuarkusTest
+@QuarkusTestResource(PostgresTestResource::class)
+class SanctionsSearchIndexEquivalenceIT {
+
+    @Inject
+    lateinit var repository: SanctionsEntryRepositoryImpl
+
+    @Inject
+    lateinit var pool: PgPool
+
+    private fun <T> onEventLoop(block: suspend () -> T): T =
+        VertxContextSupport.subscribeAndAwait { uni(CoroutineScope(Dispatchers.Unconfined)) { block() } }
+
+    private val lists = listOf(SanctionsListType.OFAC_SDN, SanctionsListType.PEP_GLOBAL)
+
+    @BeforeEach
+    fun seed() {
+        onEventLoop {
+            pool.query("DELETE FROM sanctions_entries").execute().awaitSuspending()
+            repository.upsertAll(
+                listOf(
+                    entry("e-1", "Oldrich Vanek"),
+                    entry("e-2", "Oldrich Vanicek"),
+                    entry("e-3", "Vanek Oldrich"),
+                    entry("e-4", "Jan Novak"),
+                    entry("e-5", "Vladimir Petrov", SanctionsListType.PEP_GLOBAL),
+                    entry("e-6", "Oldriska Vankova"),
+                ),
+            )
+        }
+    }
+
+    private fun entry(
+        externalId: String,
+        primaryName: String,
+        listType: SanctionsListType = SanctionsListType.OFAC_SDN,
+    ) = SanctionsEntry(
+        listType = listType,
+        externalId = externalId,
+        entityType = EntityType.INDIVIDUAL,
+        primaryName = primaryName,
+        aliases = emptyList(),
+        searchText = primaryName.lowercase(),
+    )
+
+    /** The pre-#3265 predicate: the exact filter, with no operator and therefore no index. */
+    private fun legacyMatches(query: String, threshold: Double): List<Pair<String, Double>> = onEventLoop {
+        val inClause = lists.joinToString(",") { "'${it.name}'" }
+        pool.preparedQuery(
+            """
+            SELECT external_id, word_similarity($1, search_text) AS s
+            FROM sanctions_entries
+            WHERE list_type IN ($inClause) AND active = true
+              AND word_similarity($1, search_text) >= $2
+            ORDER BY s DESC, external_id
+            """.trimIndent(),
+        ).execute(Tuple.of(query, threshold.toFloat())).awaitSuspending()
+            .map { it.getString("external_id") to (it.getDouble("s") ?: 0.0) }
+    }
+
+    private fun currentMatches(query: String, threshold: Double): List<Pair<String, Double>> =
+        onEventLoop { repository.search(query, lists, threshold, limit = 100) }
+            .map { it.entry.externalId!! to it.score }
+            .sortedWith(compareByDescending<Pair<String, Double>> { it.second }.thenBy { it.first })
+
+    /**
+     * The load-bearing test. Several thresholds, including ones on either side of the `<%` GUC
+     * default of 0.6 — a threshold below the default is exactly where an unpinned GUC would
+     * over-narrow and drop true matches.
+     */
+    @Test
+    fun `the indexed predicate matches exactly what the unindexed one matched`() {
+        val queries = listOf("oldrich vanek", "vanek", "oldrich", "jan novak", "petrov", "zzz nomatch")
+        val thresholds = listOf(0.3, 0.5, 0.65, 0.85, 0.95)
+
+        for (q in queries) {
+            for (t in thresholds) {
+                assertThat(currentMatches(q, t))
+                    .describedAs("query='%s' threshold=%s — a smaller set here is a missed sanctions hit", q, t)
+                    .isEqualTo(legacyMatches(q, t))
+            }
+        }
+    }
+
+    /**
+     * Equivalence alone would still hold if the operator were quietly a no-op, so pin the reason the
+     * change exists — but pin the claim that is actually testable here.
+     *
+     * The claim is **not** "the planner picks the trigram index". At any row count a test can
+     * reasonably seed, a sequential scan really is cheaper and Postgres is right to choose it; an
+     * assertion that only becomes true at 814,705 rows does not become true by being written down.
+     * The defect was narrower and sharper: `word_similarity(q, search_text) >= t` as a function is
+     * not an indexable predicate, so the index was not merely unchosen, it was **unreachable**.
+     *
+     * `enable_seqscan = off` isolates exactly that. It makes a sequential scan maximally expensive
+     * and asks the planner to use an index if one is applicable. The test asserts both directions,
+     * so it cannot pass vacuously: the old function-only predicate must still fail to reach
+     * `idx_entries_search_trgm`, and the new one with `<%` must reach it.
+     */
+    @Test
+    fun `the operator makes the trigram index reachable and the old predicate did not`() {
+        // The probe deliberately carries ONLY the similarity predicate. With `list_type`/`active`
+        // in the WHERE the planner satisfies `enable_seqscan = off` using idx_entries_list_active
+        // and never has to consider the trigram index at all — the plan then says nothing about
+        // whether the predicate is indexable, which is the entire question.
+        fun planFor(predicate: String): String = onEventLoop {
+            pool.query("SET enable_seqscan = off").execute().awaitSuspending()
+            pool.query("SET pg_trgm.word_similarity_threshold = 0.85").execute().awaitSuspending()
+            pool.query(
+                """
+                EXPLAIN SELECT external_id FROM sanctions_entries WHERE $predicate
+                """.trimIndent(),
+            ).execute().awaitSuspending().joinToString("\n") { it.getString(0) }
+        }
+
+        val legacyPlan = planFor("word_similarity('oldrich vanek', search_text) >= 0.85")
+        val currentPlan = planFor(
+            "'oldrich vanek' <% search_text AND word_similarity('oldrich vanek', search_text) >= 0.85",
+        )
+
+        assertThat(legacyPlan)
+            .describedAs(
+                "known-negative: without the operator the index must be unreachable, or this test " +
+                    "proves nothing about the fix. Plan was:\n%s",
+                legacyPlan,
+            )
+            .doesNotContain("idx_entries_search_trgm")
+        assertThat(currentPlan)
+            .describedAs("plan was:\n%s", currentPlan)
+            .contains("idx_entries_search_trgm")
+    }
+}


### PR DESCRIPTION
## What

Make the sanctions screening search reach the trigram index it already has, without changing which
entries it matches.

## The issue asked the wrong question, and measuring settled it

#3265 was filed as "the caller's `@Timeout(5_000)` is below the dependency's real latency" and asked
whether to raise the timeout or fix the latency. Measured first:

`POST /api/v1/sanctions/screen`, span metrics over 7 days, 18 calls (cumulative, `le` in seconds):

| ≤0.1s | ≤2s | ≤5s | total |
|---|---|---|---|
| 2 | 2 | 13 | 18 |

Mean **3.34 s**; **5 of 18 calls already exceed 5 s**. Not a cold-start outlier — the steady state.

A warning for anyone re-deriving this: aggregating `traces_spanmetrics_*` across all of
sanctions-service gives mean 10 ms / p99 99 ms, which reads as "the dependency is fast, the issue is
wrong". That figure is dominated by 16,697 outbox DB spans; screening is 18 calls out of ~18,000. I
reached the wrong conclusion once that way before filtering on `span_name`.

## Root cause

`SanctionsEntryRepositoryImpl.search` filtered with `word_similarity($1, search_text) >= $2`. As a
**function call** that is not an indexable predicate, so `idx_entries_search_trgm`
(`gin (search_text gin_trgm_ops)`) — which the table already carries — was never consulted.
`EXPLAIN ANALYZE` against sandbox, 814,705 active rows:

```
Limit  (actual time=4002.418..4037.827 rows=0)
  ->  Parallel Seq Scan on sanctions_entries  (actual time=3997.490 rows=0 loops=3)
        Filter: (active AND (word_similarity('oldrich vanek', search_text) >= '0.85') AND list_type = ANY (...))
        Rows Removed by Filter: 279640
```

**4002 ms**, every screen, twice per payment. With the `<%` operator: **134 ms**, `Bitmap Index Scan
on idx_entries_search_trgm`.

So the timeout is not a wrong budget for a 134 ms call — it is a generous one. `@Timeout(5_000)` is
left alone; the query is fixed.

## The part that needed care

`<%` takes its cutoff from the session GUC `pg_trgm.word_similarity_threshold` (default 0.6), never
from a bind parameter — while `search()` is called with `threshold = 0.85`. Swapping the predicate
naively would make a sanctions screen's matching depend on ambient session state, and in the
direction that matters: a GUC raised above the caller's threshold makes `<%` **drop true matches**,
silently, because a screen returning nothing is indistinguishable from a clean one.

So the GUC is set per call from the same threshold the exact filter uses, inside a transaction so
`SET LOCAL` cannot leak to the next borrower of the pooled connection, and the `word_similarity()`
predicate is **kept** as the authoritative filter. The operator only narrows via the index.

`SET` takes no bind parameters, so the value is interpolated — made safe by construction: a `Double`,
clamped to `0.0..1.0`, formatted with `Locale.ROOT`. The locale is not decoration: under a
comma-decimal default, `"%.4f".format(0.85)` yields `0,8500`, which Postgres parses as an integer
list and the statement fails at runtime.

## Verification

`SanctionsSearchIndexEquivalenceIT`, real Postgres.

**Equivalence is the load-bearing assertion, not speed.** This is the sanctions gate on the money
path: a rewrite that is faster and matches a *smaller* set lets a listed subject through, invisibly.
The test compares the new predicate against the old one over 6 queries × 5 thresholds (0.3, 0.5,
0.65, 0.85, 0.95 — deliberately spanning the 0.6 GUC default, which is exactly where an unpinned
threshold would over-narrow) and asserts the result sets are identical, ids and scores.

**The reachability test took four attempts, and what it asserts changed as a result.** It does not
claim "the planner picks the trigram index" — at any row count a test can seed, a sequential scan
genuinely is cheaper and Postgres is right to choose it. Seeding 6 rows picked
`idx_entries_list_active`; 20,000 rows still picked `Seq Scan`; `enable_seqscan = off` picked
`idx_entries_list_active` again. An assertion that only becomes true at 814,705 rows does not become
true by being written down.

The testable claim is narrower and is the actual defect: the old predicate could not reach the index
**at all**. So the test runs both predicates under `enable_seqscan = off`, with a probe carrying only
the similarity condition (with `list_type`/`active` present the planner satisfies the setting using
the other index and the plan says nothing), and asserts **both directions** — the old form must fail
to reach `idx_entries_search_trgm`, the new form must reach it. Without the negative half it would
pass against an operator that was a no-op.

Closes #3265
Refs #3264
