### PR TITLE
fix(ci): a service the broker has never heard of is not the #3318 refusal case

### DIFF
--- a/.github/scripts/classify-can-i-deploy-block.sh
+++ b/.github/scripts/classify-can-i-deploy-block.sh
@@ -37,7 +37,7 @@
 # its own, so test-classify-can-i-deploy-block.sh can drive every branch.
 #
 # Usage:
-#   PACT_VERSION_PRESENT=yes|no|unknown classify-can-i-deploy-block.sh <service> < cli-output
+#   PACT_VERSION_PRESENT=yes|no|absent|unknown classify-can-i-deploy-block.sh <service> < cli-output
 #
 #   PACT_VERSION_PRESENT — the caller's probe of
 #     GET <broker>/pacticipants/<svc>/versions/<sha>:
@@ -59,7 +59,7 @@ set -uo pipefail
 
 SVC="${1:-}"
 if [ -z "$SVC" ]; then
-  echo "usage: PACT_VERSION_PRESENT=yes|no|unknown $0 <service> < cli-output" >&2
+  echo "usage: PACT_VERSION_PRESENT=yes|no|absent|unknown $0 <service> < cli-output" >&2
   exit 2
 fi
 
@@ -90,6 +90,14 @@ case "$PRESENT" in
       exit 0
     fi
     emit UNKNOWN "blocked with a version present and no recognised reason in the CLI output — read the job log for ${SVC}"
+    exit 0
+    ;;
+  absent)
+    # The probe SUCCEEDED and the answer was "no such pacticipant". Distinct from the `*` branch
+    # below, which means the probe itself failed — labelling this one "could not probe" would
+    # describe an outage that did not happen, and hide the real state: a service with no
+    # contracts at all. No reconcile tick can change this; publishing a pact can.
+    emit NO_CONTRACTS "the broker does not know ${SVC} — it publishes no consumer pact and verifies no provider pact, so no reconcile tick will clear this; the fix is a contract (#2991), not a retry"
     exit 0
     ;;
   *)

--- a/.github/scripts/probe-pact-version.sh
+++ b/.github/scripts/probe-pact-version.sh
@@ -74,7 +74,23 @@ probe() {
     "${PACT_BROKER_URL:-}/pacticipants/${SVC}/versions/${SHA}" 2>/dev/null || echo 000)"
   case "$code" in
     200) echo yes ;;
-    404) echo no ;;
+    # A 404 here is AMBIGUOUS: the broker answers it both when this sha has no version and
+    # when it has never heard of the pacticipant at all. Collapsing the two is what blocked
+    # openbank-delegation-service's first deploy (#3423-adjacent): the REFUSE branch fired on
+    # a service that has no pacts to publish, where there is nothing for can-i-deploy to
+    # verify. Ask the second question before answering.
+    404)
+      pcode="$(curl -s -o /dev/null -w '%{http_code}' \
+        -u "$auth" \
+        "${PACT_BROKER_URL:-}/pacticipants/${SVC}" 2>/dev/null || echo 000)"
+      case "$pcode" in
+        404) echo absent ;;
+        200) echo no ;;
+        # Second probe inconclusive — do NOT upgrade to `absent`, which would wave a service
+        # through. Fall back to the pre-existing meaning.
+        *)   echo no ;;
+      esac
+      ;;
     # Anything else — 5xx, a proxy error, no network — is deliberately NOT "no". Reporting a
     # broker outage as "this commit has published nothing" would send the caller down the
     # PENDING_BUILD path and quietly relabel an infrastructure failure as a build queue.

--- a/.github/scripts/resolve-can-i-deploy-selector.sh
+++ b/.github/scripts/resolve-can-i-deploy-selector.sh
@@ -62,7 +62,8 @@
 #   PACT_VERSION_PRESENT — the caller's probe of
 #     GET <broker>/pacticipants/<svc>/versions/<sha>, same vocabulary the classifier uses:
 #       yes     → 200, a version exists for THIS commit
-#       no      → 404, this commit's build has published nothing yet
+#       no      → 404 on the version, but the pacticipant EXISTS: this commit has published nothing yet
+#       absent  → the broker does not know the pacticipant AT ALL (no contracts either way)
 #       unknown → the probe itself failed (broker unreachable / non-2xx-non-404)
 #
 # Prints one TAB-separated line: <selector args>\t<human reason>
@@ -111,6 +112,18 @@ case "$PRESENT" in
       emit "--latest main" \
         "no pact version for this commit — falling back to latest/main (ADR-0092); the block classifier will label this PENDING_BUILD"
     fi
+    ;;
+  absent)
+    # The broker has never heard of this pacticipant: the service publishes no consumer pact
+    # and verifies no provider pact, so there is no contract for can-i-deploy to check. This is
+    # NOT the #3318 case — that one is a service WITH contracts whose sha has no version, where
+    # answering about a different commit would be a false verdict. Here there is no question to
+    # answer at all, and REFUSE would make a service undeployable for as long as it has no
+    # pacts, which is every service's first deploy (it blocked openbank-delegation-service's).
+    # `--latest main` on an unknown pacticipant is the pre-#3318 behaviour and can-i-deploy
+    # answers it the same way it answers a 404 pacticipant today.
+    emit "--latest main" \
+      "broker does not know ${SVC} — no published contracts either way, so there is nothing to verify (not the #3318 case: that is a service WITH contracts and no version for this sha)"
     ;;
   *)
     # Probe failed. Fall back rather than invent precision: an unreachable broker must not

--- a/.github/scripts/test-classify-can-i-deploy-block.sh
+++ b/.github/scripts/test-classify-can-i-deploy-block.sh
@@ -63,6 +63,11 @@ check "404 on the sha BUT latest-main verification failed" REGRESSION no "$VERIF
 # 6. Version present, blocked, but no recognised explanation — must not be guessed at.
 check "version present + unrecognised output" UNKNOWN yes "Computer says no ¯\\_(ツ)_/¯"
 
+# `absent` must NOT read as a probe failure: the probe worked, the pacticipant does not exist.
+# Different remedy — a contract, not a retry — so it needs its own label, and UNKNOWN's text
+# ("could not probe the broker") would describe an outage that never happened.
+check "pacticipant absent" NO_CONTRACTS absent "no versions for openbank-demo-service"
+
 # 7. Missing argument is a usage error, not a silent classification.
 if PACT_VERSION_PRESENT=no bash "$CLASSIFY" </dev/null >/dev/null 2>&1; then
   echo "  FAIL missing-service-arg: expected non-zero exit"

--- a/.github/scripts/test-resolve-can-i-deploy-selector.sh
+++ b/.github/scripts/test-resolve-can-i-deploy-selector.sh
@@ -116,6 +116,14 @@ check "dispatch + version present → ask about THIS commit" "--version ${SHA}" 
 #    make the gate fail closed on infrastructure rather than on contracts.
 check "dispatch + probe inconclusive → latest/main, not REFUSE" "--latest main" unknown workflow_dispatch
 
+# The distinction the REFUSE branch got wrong: a service the broker has never heard of has no
+# contracts to verify, so refusing makes its FIRST deploy impossible. Measured on
+# openbank-delegation-service, whose first dispatch was blocked by exactly this.
+check "dispatch + pacticipant absent → latest/main, NOT REFUSE" "--latest main" absent workflow_dispatch
+check "push + pacticipant absent → latest/main" "--latest main" absent push
+# And the #3318 case must still refuse — 'absent' must not have widened it.
+check "dispatch + version missing but pacticipant KNOWN → still REFUSE" "REFUSE" no workflow_dispatch
+
 if [ "$fails" -ne 0 ]; then
   echo "FAILED: ${fails} case(s)"
   exit 1


### PR DESCRIPTION
## What went wrong

#3327 taught `can-i-deploy` to REFUSE when a `workflow_dispatch` names a sha with no published
pact version, so the gate would stop rather than silently answer about a *different* commit
(#3318). Sound for the case it was written for.

It fired today on `openbank-delegation-service`'s **first deploy** — a service that publishes no
consumer pact and verifies no provider pact. There is no contract for `can-i-deploy` to check, so
there is no wrong question to avoid asking. As written, the guard makes a service undeployable
until it has pacts, and its first deploy is precisely when it has none.

```
::error::can-i-deploy: workflow_dispatch of 8403bec2... which has no published pact version
for openbank-delegation-service — the gate cannot ask about the sha being deployed
```

The deploy was correctly withheld — the gitops pin on `main` stayed at the placeholder, nothing
half-shipped — so this is a false stop, not a broken gate.

## Root cause: an ambiguous 404

`GET /pacticipants/<svc>/versions/<sha>` answers 404 **both** when the version does not exist and
when the pacticipant is unknown. `probe-pact-version.sh` mapped both to `no`, and the REFUSE branch
read `no` as "this build has not published yet".

The probe now asks the second question — `GET /pacticipants/<svc>` — and reports a new state
`absent` only when the broker confirms it does not know the service. **A non-2xx on that second
probe stays `no`**, deliberately: an inconclusive answer must never be upgraded to "nothing to
verify", which would wave a service through.

## Behaviour

| probe | dispatch | push |
|---|---|---|
| `yes` — version exists | `--version <sha>` | `--version <sha>` |
| `no` — pacticipant known, sha not published | **REFUSE** (#3318, unchanged) | `--latest main` |
| `absent` — broker does not know the service | `--latest main` | `--latest main` |
| `unknown` — probe failed | `--latest main` | `--latest main` |

The classifier gains `NO_CONTRACTS` for `absent`. Previously it fell into `UNKNOWN`, whose text
reads "could not probe the broker" — describing an outage that did not happen and hiding the actual
state. `NO_CONTRACTS` also says the remedy is a contract (#2991), not a retry, because no reconcile
tick can ever clear it.

## Verification

Both new test sets were **falsified before being trusted** — a test that has only ever passed says
nothing about whether it can fail:

- selector: breaking the `absent` branch → suite exits 1; restoring → exits 0. The new cases sit
  **above** the verdict block, so they can actually fail the run (appending them below it, as I did
  once before, makes them decorative).
- classifier: same, `NO_CONTRACTS` → `UNKNOWN` turns it red.

A test asserts the #3318 case **still refuses**: widening the guard's exit must not narrow its
purpose.

## Scope

This does not give delegation-service contracts — #2991 is still open and still the right work.
It stops the absence of contracts from being an unbreakable deploy block.

Refs #3318, #2991
