### PR TITLE
fix(delegation): allow ESO to read the delegation-service Kafka cert

### DIFF
--- a/openbank-infra/gitops/components/payments/kafka-scheme-accepted-acl.yaml
+++ b/openbank-infra/gitops/components/payments/kafka-scheme-accepted-acl.yaml
@@ -426,6 +426,7 @@ rules:
       - customer-edge                   # ADR-0086 audit trail + ADR-0072 resume, ns customer-edge (first ESO Kafka client there); missed by the #2665 sweep
       - analytics-sink                  # ADR-0022/0069: analytics bronze consumer (party/kyc/consent/sca/documents/onboarding-funnel), ns analytics (first ESO client there)
       - campaign-service                # ADR-0200: campaign journey delivery requests, ns campaign (first ESO client there); missing entry blocked the whole sandbox rollout at sync-wave -1 (#2749)
+      - delegation-service              # ADR-0232: grant lifecycle producer, ns delegation (first ESO client there); same #2749 failure, observed again — the keystore ExternalSecret sat at SecretSyncedError and ArgoCD never advanced past sync-wave -1, so all 11 wave-0 resources stayed OutOfSync and no pod was ever created
       - openbank-cluster-cluster-ca-cert
 ---
 apiVersion: rbac.authorization.k8s.io/v1


### PR DESCRIPTION
## Symptom

`delegation` ArgoCD app: `OutOfSync / Degraded`, **11 resources OutOfSync**, no pod ever created —
including the Deployment, the CNPG Cluster, the OIDC ExternalSecret and the NetworkPolicies. The app
condition says only "one or more synchronization tasks completed unsuccessfully. Retrying attempt #10".

## Cause

One resource fails:

```
delegation-service-kafka-keystore   SecretSyncedError   could not get secret data from provider
```

The `eso-kafka-cert-reader` Role in `messaging` is `resourceNames`-scoped — an explicit 37-entry
allow-list — and `delegation-service` was not on it. Everything upstream was healthy and therefore
misleading: the KafkaUser is `Ready`, and the source secret `delegation-service` exists in
`messaging` with all 5 keys.

**The blast radius is the whole component, not that one secret.** The Kafka ExternalSecrets carry
`argocd.argoproj.io/sync-wave: "-1"`; ArgoCD blocks the wave until they are healthy, so it never
advanced to wave 0 where the rest of the component lives. One missing line in an RBAC allow-list
presents as "the entire service failed to deploy, cause unclear".

## Fix

Add `delegation-service` to the allow-list (now 38).

## This is the second time

The entry immediately above carries the same story:

```yaml
- campaign-service   # ... missing entry blocked the whole sandbox rollout at sync-wave -1 (#2749)
```

A hand-kept allow-list sitting beside the thing it authorises fails this way every time, and it
**reads as complete because it is long**. Same shape as the pact-drift scope (#2284) and
`ALL_SERVICES` (#3382), both of which were fixed by deriving the set instead of typing it.

Worth a follow-up, not folded in here: derive the allow-list from the KafkaUsers that actually
exist, or add a check that every `ExternalSecret` sourcing `kafka-messaging-certs` names a secret
the Role permits. Either turns this from "discovered by a failed rollout" into "fails at PR time".

Refs #2749, #2992
