### PR TITLE
fix(ci): register two check-* scripts that had never run

### DIFF
--- a/.github/gates/gates.yaml
+++ b/.github/gates/gates.yaml
@@ -764,6 +764,46 @@ gates:
     run: |
       python3 .github/scripts/check-ai-act-high-risk-inventory.py
 
+  # The admin-ui compliance page renders 47 regulatory-conformance claims from a hardcoded
+  # literal. #2370 found it wrong in BOTH directions — GDPR rows marked `ok` citing columns
+  # that exist only in a Flyway migration, with nothing reading them — and #2667 corrected
+  # those rows BY HAND. The checker that stops them rotting again was written at the same
+  # time and then referenced from nowhere: no workflow, no manifest entry, and nothing in
+  # this repo iterates `.github/scripts/check-*` (this runner reads the manifest, not the
+  # directory). So it had never run once (#3240).
+  #
+  # ENFORCED, same reasoning as the two gates above: the claim is published to users, the
+  # evidence citation is mechanical, and advisory over a published claim means "the page
+  # says something the code does not support" is mergeable. Green on the current tree, and
+  # `--self-test` (added with this registration) proves the red is reachable.
+  - id: compliance-matrix
+    name: "compliance-page evidence citations (#2370, enforced)"
+    group: registry
+    mode: enforced
+    selftest: |
+      python3 .github/scripts/check-compliance-matrix.py --self-test
+    run: |
+      python3 .github/scripts/check-compliance-matrix.py --enforce
+
+  # rules.yaml' shared_m2m_write_prohibition names this script as its own `ci_producer`, and
+  # nothing invoked it — so reading rules.yaml gave every impression the rule was enforced
+  # while the check had never executed (#3240). The surrounding rule is not a small one: it
+  # says in place that registering an operator write without it "is a money-path outage, not
+  # a test failure".
+  #
+  # ADVISORY, deliberately and temporarily. The script has no --enforce flag and exits 1 on
+  # the current tree with one real finding (`operator-mcp-session` in the shared rest.rego
+  # grants on ROLE_OPERATOR/ROLE_ADMIN without pinning input.principal.id). Registering it
+  # enforced would break main on a defect this PR is not fixing; registering it advisory is
+  # what makes that defect visible at all. Graduate to enforced once the finding is closed —
+  # tracked on #3240.
+  - id: operator-write-naming
+    name: "operator-write naming vs. shared-M2M prohibition (GHSA-58jq-9hq3-66jr, advisory)"
+    group: registry
+    mode: advisory
+    run: |
+      python3 .github/scripts/check-operator-write-naming.py
+
   # ==== kotlin ================================================================
 
   # ADR-0160 mechanism 1 / rules.yaml: change_requirements.event_consumer_liveness.

--- a/.github/scripts/check-compliance-matrix.py
+++ b/.github/scripts/check-compliance-matrix.py
@@ -28,8 +28,14 @@ references, the part that can be made honest by construction.
 
 stdlib-only; reads the working tree so it runs identically in CI and locally.
 
+Registered in `.github/gates/gates.yaml` as `compliance-matrix`. It was written for #2370 and
+then referenced from nowhere — no workflow, no manifest entry, and nothing in this repo
+iterates `.github/scripts/check-*` (`run-gates.py` reads the manifest, not the directory). So
+for its whole life the drift it exists to stop was unstopped (#3240). `--self-test` exists for
+the same reason the registration does: a gate that has only ever passed is unfalsified.
+
 Usage:
-    check-compliance-matrix.py [--enforce]
+    check-compliance-matrix.py [--enforce] [--self-test]
 """
 from __future__ import annotations
 
@@ -98,39 +104,150 @@ def service_exists(name: str) -> bool:
     return False
 
 
+def analyse() -> tuple[list[str], list[str], int, int]:
+    """Return (findings, notices, row_count, checked_column_count).
+
+    `findings` are the direction that must be able to fail the build: a row claiming `ok` on
+    evidence nothing reads. `notices` are the opposite direction — a `warn` row whose cited
+    column IS live — which the docstring has always promised to report and which the first
+    implementation silently omitted. It is reported and never fails: over-caution rots the
+    signal, but it does not publish a false green, and a gate that goes red on someone being
+    too careful teaches people to mark rows `ok`.
+    """
+    text = PAGE.read_text(encoding="utf-8")
+    items = iter_items(text)
+    if not items:
+        return (
+            ["no COMPLIANCE_AREAS items parsed — the page shape changed and the gate sees nothing"],
+            [],
+            0,
+            0,
+        )
+
+    findings: list[str] = []
+    notices: list[str] = []
+    reader_cache: dict[str, bool] = {}
+    checked_columns = 0
+    for status, req, note in items:
+        for column in sorted(set(COLUMN_RE.findall(note)) - NOT_COLUMNS - ENFORCEMENT_DDL):
+            checked_columns += 1
+            live = column_has_reader(column, reader_cache)
+            if not live and status == "ok":
+                findings.append(
+                    f"row marked ok but cites a column no code reads: '{column}' "
+                    f"(req: {req[:60]}…)"
+                )
+            elif live and status == "warn":
+                notices.append(
+                    f"row marked warn but its cited column '{column}' has a live reader — "
+                    f"check whether the row can be promoted (req: {req[:60]}…)"
+                )
+        for svc in sorted(set(SERVICE_RE.findall(note))):
+            if not service_exists(svc):
+                findings.append(f"cited service does not exist as a module: '{svc}'")
+
+    return findings, notices, len(items), checked_columns
+
+
+def _fixture(tmp: pathlib.Path, rows: str, kotlin: str = "", services: tuple[str, ...] = ()) -> None:
+    """Build a throwaway repo the real code paths can run against unchanged.
+
+    Deliberately a real directory tree rather than a stubbed reader: `column_has_reader` and
+    `service_exists` walk the filesystem, and a test that replaced them would be asserting
+    against its own re-implementation rather than against the gate (the failure #3349 is open
+    about elsewhere in this repo).
+    """
+    page = tmp / "openbank-admin-ui/src/app/docs/compliance/page.tsx"
+    page.parent.mkdir(parents=True, exist_ok=True)
+    page.write_text(f"const COMPLIANCE_AREAS = [\n{rows}\n]\n", encoding="utf-8")
+    src = tmp / "openbank-demo-service/src/main/kotlin"
+    src.mkdir(parents=True, exist_ok=True)
+    (src / "Demo.kt").write_text(kotlin or "class Demo\n", encoding="utf-8")
+    for svc in services:
+        (tmp / svc / "src/main").mkdir(parents=True, exist_ok=True)
+
+
+def _run_against(tmp: pathlib.Path) -> tuple[list[str], list[str]]:
+    """Point the module at `tmp` and analyse it, restoring the real paths afterwards."""
+    global REPO, PAGE
+    real_repo, real_page = REPO, PAGE
+    REPO, PAGE = tmp, tmp / "openbank-admin-ui/src/app/docs/compliance/page.tsx"
+    try:
+        findings, notices, _, _ = analyse()
+        return findings, notices
+    finally:
+        REPO, PAGE = real_repo, real_page
+
+
+def selftest() -> int:
+    """Feed each rule an input it MUST flag and one it must NOT."""
+    import tempfile
+
+    ok_dead = "  { req: ['R'], status: 'ok', note: ['stores ghost_column'] },"
+    ok_live = "  { req: ['R'], status: 'ok', note: ['stores ghost_column'] },"
+    warn_live = "  { req: ['R'], status: 'warn', note: ['stores ghost_column'] },"
+    warn_dead = "  { req: ['R'], status: 'warn', note: ['stores ghost_column'] },"
+    bad_svc = "  { req: ['R'], status: 'warn', note: ['implemented by unicorn-service'] },"
+    real_svc = "  { req: ['R'], status: 'warn', note: ['implemented by demo-service'] },"
+    reader = 'val x = row["ghost_column"]\n'
+
+    cases = [
+        # (label, rows, kotlin, services, expect_findings, expect_notices)
+        ("ok row citing a column nothing reads", ok_dead, "", (), 1, 0),
+        ("ok row whose column has a reader", ok_live, reader, (), 0, 0),
+        ("warn row whose column has a reader", warn_live, reader, (), 0, 1),
+        ("warn row citing a dead column", warn_dead, "", (), 0, 0),
+        ("a cited service that is not a module", bad_svc, "", (), 1, 0),
+        ("a cited service that exists", real_svc, "", ("openbank-demo-service",), 0, 0),
+    ]
+    for label, rows, kotlin, services, want_f, want_n in cases:
+        with tempfile.TemporaryDirectory() as d:
+            tmp = pathlib.Path(d)
+            _fixture(tmp, rows, kotlin, services)
+            findings, notices = _run_against(tmp)
+        if len(findings) != want_f or len(notices) != want_n:
+            print(
+                f"selftest FAIL: {label} — expected {want_f} finding(s)/{want_n} notice(s), "
+                f"got {len(findings)}/{len(notices)}: {findings or notices}"
+            )
+            return 1
+
+    # A page the parser cannot read must be a finding, never a silent pass. This is the
+    # failure mode that would make every other case above vacuous: a shape change to the
+    # page turns "0 rows parsed" into "0 findings", which reads exactly like a clean run.
+    with tempfile.TemporaryDirectory() as d:
+        tmp = pathlib.Path(d)
+        _fixture(tmp, "  // the literal was refactored away")
+        findings, _ = _run_against(tmp)
+    if not findings:
+        print("selftest FAIL: an unparseable page produced no finding — the gate would go green on nothing")
+        return 1
+
+    print(f"selftest OK: {len(cases)} fixture(s) both ways, plus the unparseable-page case.")
+    return 0
+
+
 def main() -> int:
     ap = argparse.ArgumentParser()
     ap.add_argument("--enforce", action="store_true")
+    ap.add_argument("--self-test", action="store_true", dest="self_test",
+                    help="prove the gate can fail, against fixtures it must and must not flag")
     args = ap.parse_args()
+
+    if args.self_test:
+        return selftest()
 
     if not PAGE.is_file():
         print(f"::error::compliance page not found at {PAGE}")
         return 1
 
-    text = PAGE.read_text(encoding="utf-8")
-    items = iter_items(text)
-    if not items:
-        print("::error::no COMPLIANCE_AREAS items parsed — the page shape changed and the gate sees nothing")
-        return 1
+    findings, notices, rows, checked_columns = analyse()
 
-    findings = []
-    reader_cache: dict[str, bool] = {}
-    checked_columns = 0
-    for status, req, note in items:
-        for column in set(COLUMN_RE.findall(note)) - NOT_COLUMNS - ENFORCEMENT_DDL:
-            checked_columns += 1
-            if not column_has_reader(column, reader_cache) and status == "ok":
-                findings.append(
-                    f"row marked ok but cites a column no code reads: '{column}' "
-                    f"(req: {req[:60]}…)"
-                )
-        for svc in set(SERVICE_RE.findall(note)):
-            if not service_exists(svc):
-                findings.append(f"cited service does not exist as a module: '{svc}'")
-
-    print(f"compliance-matrix: {len(items)} rows, {checked_columns} column citations checked")
+    print(f"compliance-matrix: {rows} rows, {checked_columns} column citations checked")
     for f in findings:
         print(("::error::" if args.enforce else "::warning::") + f)
+    for n in notices:
+        print("::warning::" + n)
     if findings and args.enforce:
         print(f"compliance-matrix: {len(findings)} finding(s) — fix the row or the evidence, not the gate (#2370)")
         return 1


### PR DESCRIPTION
Closes the first two items of #3240. The third turns out not to be a registration at all — see below.

## 1. `check-compliance-matrix.py` — written, then never run

141 lines written for #2370, referenced from **nowhere**: no workflow, no manifest entry, and nothing in this repo iterates `.github/scripts/check-*` (`run-gates.py` reads the manifest, not the directory). So the drift it exists to stop was unstopped for its entire life, and the compliance page's 47 published regulatory-conformance claims were only as good as #2667's hand-corrections — which is exactly the state #2370 was opened about.

Registered **enforced**, on the same reasoning as its two neighbours in the `registry` group: the claim is published to users, the evidence citation is mechanical, and advisory over a published claim makes "the page says something the code does not support" mergeable. It is green on the current tree.

## 2. `check-operator-write-naming.py` — a `ci_producer` CI never invoked

`rules.yaml`' `shared_m2m_write_prohibition` names this script as its own `ci_producer`. Nothing ran it, so reading `rules.yaml` gave every impression the rule was enforced.

Registered **advisory, deliberately**, because it exits 1 on `origin/main` today with a real finding:

```
openbank-libs/governance/policies/rest.rego: rule 'operator-mcp-session' grants on
ROLE_OPERATOR/ROLE_ADMIN without pinning input.principal.id, and is not named
'operator-*-write' — the shared openbank-services service-account, which carries
ROLE_OPERATOR, reaches this action and nothing will ever propose closing it.
(GHSA-58jq-9hq3-66jr)
```

Enforcing it here would break `main` on a defect this PR does not fix. Advisory is what makes the defect visible at all — it has been invisible since the rule was written. Graduating it to enforced once `operator-mcp-session` is resolved is left on #3240.

## 3. `check-verification-metadata-complete.py` — not a bookkeeping gap

#3240 calls this an undeclared-but-enforced gate that should be registered. It cannot be, and should not be: it takes `--modules` and is invoked per-service from `services-ci.yml`, so it has no repo-wide invocation for the manifest to hold. `run-gates.py` entries are unparameterised commands. It is genuinely enforced today (`--enforce`, and `all-green` has it in `needs:`), so nothing is unguarded.

## Falsifiability

`check-compliance-matrix.py` gains `--self-test`, wired as the gate's `selftest` (expect `pass`). It builds real fixture trees in a temp dir rather than stubbing `column_has_reader`/`service_exists` — a test that replaced those would assert against its own re-implementation instead of against the gate, which is the defect #3349 is open about elsewhere in this repo.

Six fixtures, each rule both ways, plus the case that would make all of them vacuous: an unparseable page must be a **finding**, not a silent zero-row pass — otherwise a refactor of the page literal turns the gate green forever.

Verified the self-test can fail rather than assuming it: broke rule 1 in place (`if False and not live …`), watched it go red with the right message, restored from a `cp` backup, watched it go green.

```
selftest FAIL: ok row citing a column nothing reads — expected 1 finding(s)/0 notice(s), got 0/0: []
```

## One behaviour change

Rule 2's docstring has always promised both directions — *"a `warn` row with live evidence is reported too (over-caution rots the signal the other way)"* — and the code only ever implemented the `ok`-with-dead-evidence half. Now implemented; **one** occurrence on the current tree (`audit_entries`).

It is reported and never fails the build. Over-caution does not publish a false green, and a gate that goes red on someone being careful teaches people to mark rows `ok` — which is the direction that actually hurts.

## Verification

```
run-gates.py --only compliance-matrix     PASS  (self-test + gate)
run-gates.py --only operator-write-naming WARN=1, rc=0  (advisory, finding shown)
run-gates.py --only gate-runner-self-test PASS
run-gates.py --only advisory-gate-registration PASS
run-gates.py --group lint                 PASS=4  (yamllint over the edited manifest)
```
