### PR TITLE
fix(ci): detect Quarkus modules by declaration, not by substring

### DIFF
--- a/.github/scripts/check-verification-metadata-complete.py
+++ b/.github/scripts/check-verification-metadata-complete.py
@@ -56,16 +56,32 @@ TASKS = ("testClasses", "quarkusDependenciesBuild")
 # the task for them fails the WHOLE invocation with "Cannot locate tasks that match", so a
 # PR touching one of those build files would take the check down with it. They still get
 # `testClasses`, which is the only graph they have.
-QUARKUS_MARKER = "openbank.quarkus-service"
+# Whether a module owns `quarkusDependenciesBuild` is decided by how it applies the
+# Quarkus plugin, and there are TWO ways in this repo:
+#   id("openbank.quarkus-service")   the convention plugin (55 services)
+#   alias(libs.plugins.quarkus)      the plugin directly (openbank-analytics-sink)
+# Naming the task for a module that has neither fails the WHOLE Gradle invocation
+# with "Cannot locate tasks that match", so this must be exact in both directions.
+#
+# Comments are stripped first, and that is not defensive coding. A plain substring
+# search misfires on prose: openbank-libs-testing says "This module isn't a Quarkus
+# service (no openbank.quarkus-service ...)", and that sentence alone classified it AS
+# one. openbank-libs carries a comment with the same effect. Both were caught by the
+# nightly sweep on its first real run; the over-correction that followed — matching only
+# the convention plugin — then misclassified analytics-sink the other way, which would
+# have silently stopped checking its prod graph rather than failing loudly.
+QUARKUS_PLUGIN_RE = re.compile(
+    r'^\s*(?:id\("openbank\.quarkus-service"\)|alias\(libs\.plugins\.quarkus\))', re.M)
 
 
 def tasks_for(module: str) -> tuple[str, ...]:
     build_file = pathlib.Path(module) / "build.gradle.kts"
     try:
-        is_quarkus = QUARKUS_MARKER in build_file.read_text(encoding="utf-8")
+        text = build_file.read_text(encoding="utf-8")
     except OSError:
-        is_quarkus = False
-    return TASKS if is_quarkus else ("testClasses",)
+        return ("testClasses",)
+    code = "\n".join(l for l in text.split("\n") if not l.lstrip().startswith("//"))
+    return TASKS if QUARKUS_PLUGIN_RE.search(code) else ("testClasses",)
 
 
 def artifact_set(path: pathlib.Path) -> set[str]:


### PR DESCRIPTION
## The nightly sweep found a bug on its first real run — and the bug was mine

Manually dispatched #3302's sweep to verify shard sizing. Six shards passed; **3/8 and 7/8 failed**:

```
Cannot locate tasks that match ':openbank-libs:quarkusDependenciesBuild'
Cannot locate tasks that match ':openbank-libs-testing:quarkusDependenciesBuild'
```

Not a sizing problem. `tasks_for()` searched for the string `openbank.quarkus-service` **anywhere**
in `build.gradle.kts`, and both modules mention it in a comment. `openbank-libs-testing`'s reads:

```kotlin
// This module isn't a Quarkus service (no openbank.quarkus-service ...)
```

The sentence declaring it is *not* a Quarkus service is what classified it **as** one. That is the
text-matching-guard trap `CLAUDE.md` documents — the Dockerfile guard strips comments for exactly
this reason, and this script did not.

## The first correction was wrong too, in the worse direction

Matching only `id("openbank.quarkus-service")` fixed both failures and introduced a quieter defect:
`openbank-analytics-sink` applies the plugin as `alias(libs.plugins.quarkus)`, so it got
reclassified as non-Quarkus.

That would **not** have failed. It would have silently dropped `quarkusDependenciesBuild` for that
service — leaving its prod-runtime graph unchecked, which is the precise gap this entire line of
work (#3017 → #3199 → #3233 → #3302) exists to close. A loud failure replaced by a silent one.

Caught only by cross-checking the classification against a direct grep instead of trusting that the
failures had stopped.

## The fix

Strip comments, then match **either** declaration form:

```python
id("openbank.quarkus-service")   # convention plugin — 55 services
alias(libs.plugins.quarkus)      # plugin directly — openbank-analytics-sink
```

Verified against every module: **56 Quarkus, 6 non-Quarkus, 0 mismatches** versus a direct grep of
the declarations.

| module | tasks |
|---|---|
| 56 services incl. `analytics-sink` | `testClasses`, `quarkusDependenciesBuild` |
| `libs`, `libs-{domain,runtime,temporal,testing}`, `simulation` | `testClasses` |

## Why this is worth reading twice

The guard worked. It ran, it failed, and it named the reason precisely enough to fix in one pass —
on a bug that neither the local tests nor the CI run on #3302 could reach, because both only ever
exercised a Quarkus service and a single library module.

It also shows the value of the "could not run" vs "found a gap" distinction built into the script:
these were reported as invocation failures, never as metadata gaps, so no one was sent chasing
entries that were fine.

Refs #3131, #3233

🤖 Generated with [Claude Code](https://claude.com/claude-code)
