### PR TITLE
fix(ci): scope the threat-model-diff gate to hunks, not manifest filenames

### DIFF
--- a/.github/gates/gates.yaml
+++ b/.github/gates/gates.yaml
@@ -1299,7 +1299,15 @@ gates:
     mode: advisory
     when: pull_request
     needs_base: required
+    selftest: python3 openbank-infra/scripts/check-threat-model-diff.py --self-test
+    selftest_expect: pass
     run: |
+      # Advisory by ADR-0144 graduation, NOT because the finding is optional: a
+      # threat model that no longer describes the service is how #3378 shipped —
+      # openbank-sanctions-service satisfied the enforced coverage gate for nine
+      # months while omitting sanctions.clear entirely. Graduating this to
+      # `enforced` is tracked in #3431; the blocker was a 7-of-60 false-positive
+      # rate on generated manifest churn, fixed here (now 2 of 60, both real).
       python3 openbank-infra/scripts/check-threat-model-diff.py --base "${PR_DIFF_BASE}"
 
   - id: compliance-page-evidence

--- a/openbank-infra/scripts/check-threat-model-diff.py
+++ b/openbank-infra/scripts/check-threat-model-diff.py
@@ -10,8 +10,11 @@ trust-boundary change for service S is any changed file matching:
   - S/src/main/**/adapter{,s}/**.kt|.java with an HTTP/gRPC client hint in the file
   - S/src/main/resources/application.yaml with (oidc|auth|authz|opa|http|kafka|
     security) keys in the diff hunks                 (listeners / authn / transport)
-  - openbank-infra/gitops/components/**: S's network-policies.yaml or its
-    Deployment/Rollout manifest                      (new ingress/egress)
+  - openbank-infra/gitops/components/**: S's network-policies.yaml (any change —
+    a NetworkPolicy is reach by construction), or its Deployment/Rollout manifest
+    when the DIFF HUNKS touch a boundary key (ports, serviceAccountName,
+    securityContext, auth-shaped env) rather than generated churn — a
+    policy-checksum restamp or an image tag is not a boundary change (#3431)
 
 When any of those change for a money-path service (rules.yaml:
 money_path_services, parsed by check-threat-models.py's parser) and
@@ -26,7 +29,11 @@ Usage:
                             <ref>...HEAD` (3-dot = the actual squash delta).
                             Default: origin/main.
     --changed-files <path>  newline-separated changed-file list — bypasses git
-                            entirely (testable with a synthetic diff).
+                            entirely. Hunks cannot be inspected this way, so the
+                            manifest rule stays conservative and flags on the path.
+    --head <ref>            head ref/sha (default HEAD); lets a measurement replay a
+                            past commit with `--base <sha>^ --head <sha>`.
+    --self-test             run the classifier against known-positive/negative diffs.
 
 Modes (ADR-0144 gate graduation):
     default    advisory — findings are ::warning annotations, exit 0
@@ -60,6 +67,29 @@ SECURITY_KEY = re.compile(r"\b(oidc|authz?|opa|http|kafka|security)[\w.-]*\s*:",
 # Only these manifest kinds define ingress/egress or the runtime env of a service.
 GITOPS_KIND = re.compile(r"^kind:\s*(NetworkPolicy|Deployment|Rollout)\s*$", re.MULTILINE)
 
+# Generated lines in a Deployment/Rollout that are never a trust-boundary change:
+# the OPA pod-roll annotation (restamped fleet-wide by any rules.yaml edit) and the
+# image reference (rewritten by auto-deploy on every push). Matched BEFORE the
+# boundary keys below, since an image line contains ':' and digests look like config.
+MANIFEST_GENERATED = re.compile(
+    r"^(openbank\.tech/policy-checksum|image|imagePullPolicy)\s*:",
+    re.IGNORECASE,
+)
+
+# Keys in a Deployment/Rollout/NetworkPolicy hunk that CAN move a trust boundary:
+# who can reach the pod, what identity it runs as, what it may talk to.
+MANIFEST_BOUNDARY_KEY = re.compile(
+    r"\b("
+    r"ports?|containerPort|hostPort|nodePort|targetPort|"          # listeners
+    r"ingress|egress|policyTypes|podSelector|namespaceSelector|"    # NetworkPolicy reach
+    r"serviceAccountName|automountServiceAccountToken|"            # workload identity
+    r"securityContext|runAsUser|runAsNonRoot|privileged|"          # privilege
+    r"capabilities|hostNetwork|hostPID|hostIPC|"
+    r"[A-Z_]*(OIDC|AUTHZ?|OPA|TLS|MTLS|ISSUER|TOKEN|SECRET|KEYCLOAK)[A-Z_]*"  # env names
+    r")\b",
+    re.IGNORECASE,
+)
+
 
 def load_money_path_services() -> list[str]:
     """Reuse check-threat-models.py's rules.yaml parser — one parser, one truth."""
@@ -70,9 +100,9 @@ def load_money_path_services() -> list[str]:
     return mod.money_path_services()
 
 
-def changed_files(base: str) -> list[str]:
+def changed_files(base: str, head: str = "HEAD") -> list[str]:
     res = subprocess.run(
-        ["git", "diff", "--name-only", f"{base}...HEAD"],  # 3-dot: the squash delta
+        ["git", "diff", "--name-only", f"{base}...{head}"],  # 3-dot: the squash delta
         capture_output=True, text=True, cwd=REPO,
     )
     if res.returncode != 0 and "no merge base" in res.stderr:
@@ -81,7 +111,7 @@ def changed_files(base: str) -> list[str]:
         # 2-dot diff against the base sha IS the squash delta there (same reason
         # check-api-contract.py diffs 2-dot) — fall back to it.
         res = subprocess.run(
-            ["git", "diff", "--name-only", base, "HEAD"],
+            ["git", "diff", "--name-only", base, head],
             capture_output=True, text=True, cwd=REPO,
         )
     if res.returncode != 0:
@@ -110,27 +140,63 @@ def token_in(tokens: set[str], text: str) -> bool:
     )
 
 
-def yaml_security_keys_changed(base: str | None, rel: str) -> bool:
+def changed_body_lines(diff_text: str) -> list[str]:
+    """The added/removed content lines of a unified diff, comments and headers dropped."""
+    out: list[str] = []
+    for line in diff_text.splitlines():
+        if line.startswith(("+++", "---")) or line[:1] not in "+-":
+            continue
+        body = line[1:].strip()
+        if body and not body.startswith("#"):
+            out.append(body)
+    return out
+
+
+def hunk_moves_boundary(diff_text: str) -> bool:
+    """True if a Deployment/Rollout diff changes something that can move a trust boundary.
+
+    The manifest FILENAME is not evidence. A single `rules.yaml` edit restamps the
+    `openbank.tech/policy-checksum` pod-roll annotation on ~29 service manifests at once, and
+    auto-deploy rewrites an image tag on every push — neither opens a port, grants an identity
+    or changes who may reach the pod. Treating those as boundary changes lit up the whole
+    money-path fleet on 7 of 60 commits (issue #3431) and is exactly the generated churn that
+    teaches people to ignore a gate.
+
+    So: drop the known-generated lines first, then require a key that actually describes the
+    boundary. Mirrors what this script already does for application.yaml — the gitops rule was
+    the one place trusting the path instead of the hunk.
+    """
+    for body in changed_body_lines(diff_text):
+        if MANIFEST_GENERATED.search(body):
+            continue
+        if MANIFEST_BOUNDARY_KEY.search(body):
+            return True
+    return False
+
+
+def file_diff(base: str | None, head: str, rel: str) -> str | None:
+    """Unified diff of one path, or None when it cannot be inspected."""
+    if base is None:
+        return None
+    res = subprocess.run(
+        ["git", "diff", f"{base}...{head}", "--", rel],
+        capture_output=True, text=True, cwd=REPO,
+    )
+    if res.returncode != 0 or not res.stdout:
+        return None
+    return res.stdout
+
+
+def yaml_security_keys_changed(base: str | None, head: str, rel: str) -> bool:
     """True if the application.yaml diff touches a trust-boundary key.
 
     Without git (--changed-files synthetic list) the hunks cannot be inspected —
     be conservative and treat the touch as boundary-relevant (advisory gate).
     """
-    if base is None:
-        return True
-    res = subprocess.run(
-        ["git", "diff", f"{base}...HEAD", "--", rel],
-        capture_output=True, text=True, cwd=REPO,
-    )
-    if res.returncode != 0 or not res.stdout:
+    diff_text = file_diff(base, head, rel)
+    if diff_text is None:
         return True  # can't inspect — stay conservative
-    for line in res.stdout.splitlines():
-        if line.startswith(("+++", "---")) or line[:1] not in "+-":
-            continue
-        body = line[1:].strip()
-        if not body.startswith("#") and SECURITY_KEY.search(body):
-            return True
-    return False
+    return any(SECURITY_KEY.search(b) for b in changed_body_lines(diff_text))
 
 
 def adapter_is_client(rel: str) -> bool:
@@ -143,8 +209,14 @@ def adapter_is_client(rel: str) -> bool:
         return False
 
 
-def gitops_hit(service: str, comp: str, fname: str) -> str | None:
-    """Reason string if this gitops file is S's NetworkPolicy or Deployment/Rollout."""
+def gitops_hit(
+    service: str, comp: str, fname: str, base: str | None = None, head: str = "HEAD",
+) -> str | None:
+    """Reason string if this gitops file is S's NetworkPolicy or Deployment/Rollout.
+
+    A NetworkPolicy is a boundary by construction — its entire content is reach — so any
+    change to one counts. A Deployment/Rollout is not: see hunk_moves_boundary.
+    """
     tokens = gitops_tokens(service)
     if not (token_in(tokens, comp) or token_in(tokens, fname)):
         return None
@@ -158,11 +230,18 @@ def gitops_hit(service: str, comp: str, fname: str) -> str | None:
         except OSError:
             return None
         if GITOPS_KIND.search(text) and token_in(tokens, text):
+            diff_text = file_diff(base, head, rel)
+            if diff_text is None:
+                # Cannot inspect hunks (synthetic --changed-files list): stay conservative,
+                # same contract as yaml_security_keys_changed.
+                return f"{rel} (Deployment/Rollout)"
+            if not hunk_moves_boundary(diff_text):
+                return None
             return f"{rel} (Deployment/Rollout)"
     return None
 
 
-def boundary_reasons(service: str, changed: list[str], base: str | None) -> list[str]:
+def boundary_reasons(service: str, changed: list[str], base: str | None, head: str = "HEAD") -> list[str]:
     reasons: list[str] = []
     for rel in changed:
         m = REST_RE.match(rel)
@@ -178,23 +257,89 @@ def boundary_reasons(service: str, changed: list[str], base: str | None) -> list
             reasons.append(f"{rel} (HTTP/gRPC adapter)")
             continue
         m = APP_YAML_RE.match(rel)
-        if m and m.group(1) == service and yaml_security_keys_changed(base, rel):
+        if m and m.group(1) == service and yaml_security_keys_changed(base, head, rel):
             reasons.append(f"{rel} (authn/listener/transport keys)")
             continue
         m = GITOPS_RE.match(rel)
         if m:
-            hit = gitops_hit(service, m.group(1), m.group(2))
+            hit = gitops_hit(service, m.group(1), m.group(2), base, head)
             if hit:
                 reasons.append(hit)
     return reasons
 
 
+SELF_TEST_CASES: list[tuple[str, str, bool]] = [
+    (
+        "pod-roll annotation restamp only (a rules.yaml edit does this fleet-wide)",
+        "@@\n-        openbank.tech/policy-checksum: \"8f455914ec6024b2\"\n"
+        "+        openbank.tech/policy-checksum: \"6ef160b0682ff4d9\"\n",
+        False,
+    ),
+    (
+        "image tag bump only (auto-deploy rewrites this on every push)",
+        "@@\n-        image: ghcr.io/jiraska/openbank-ledger-service:sandbox-8992de5\n"
+        "+        image: ghcr.io/jiraska/openbank-ledger-service:sandbox-2b8a7cf\n",
+        False,
+    ),
+    (
+        "a new container port IS a boundary change",
+        "@@\n         ports:\n+          - containerPort: 9443\n",
+        True,
+    ),
+    (
+        "a changed service account IS a boundary change",
+        "@@\n-      serviceAccountName: ledger\n+      serviceAccountName: ledger-privileged\n",
+        True,
+    ),
+    (
+        "a new OIDC issuer env var IS a boundary change",
+        "@@\n+            - name: QUARKUS_OIDC_AUTH_SERVER_URL\n"
+        "+              value: https://keycloak.example/realms/openbank\n",
+        True,
+    ),
+    (
+        "a replica count is not a boundary change",
+        "@@\n-  replicas: 2\n+  replicas: 3\n",
+        False,
+    ),
+    (
+        "an annotation restamp AND a port change still flags",
+        "@@\n-        openbank.tech/policy-checksum: \"aaaa\"\n"
+        "+        openbank.tech/policy-checksum: \"bbbb\"\n+          - containerPort: 8443\n",
+        True,
+    ),
+]
+
+
+def self_test() -> int:
+    """Feed the classifier diffs it MUST flag and diffs it MUST NOT.
+
+    This gate shipped advisory with no self-test, so its failure path had never run —
+    the 7-of-60 false-positive rate in #3431 was found by hand, not by CI. A gate whose
+    only demonstrated behaviour is passing cannot be graduated to enforced.
+    """
+    ok = True
+    for name, diff_text, expected in SELF_TEST_CASES:
+        got = hunk_moves_boundary(diff_text)
+        mark = "ok" if got == expected else "FAIL"
+        if got != expected:
+            ok = False
+        print(f"  [{mark}] {name}: flagged={got} expected={expected}")
+    print(f"self-test: {'PASS' if ok else 'FAIL'}")
+    return 0 if ok else 1
+
+
 def main() -> int:
     ap = argparse.ArgumentParser()
     ap.add_argument("--base", default="origin/main", help="PR base ref/sha (3-dot diff)")
+    ap.add_argument("--head", default="HEAD", help="head ref/sha; lets a measurement replay a past commit")
     ap.add_argument("--changed-files", help="file with a newline-separated changed-file list (skips git)")
     ap.add_argument("--enforce", action="store_true")
+    ap.add_argument("--self-test", action="store_true", help="run the classifier's known-positive/negative cases")
     args = ap.parse_args()
+
+    if args.self_test:
+        return self_test()
 
     if args.changed_files:
         changed = [
@@ -204,7 +349,7 @@ def main() -> int:
         ]
         base = None
     else:
-        changed = changed_files(args.base)
+        changed = changed_files(args.base, args.head)
         base = args.base
 
     level = "error" if args.enforce else "warning"
@@ -213,7 +358,7 @@ def main() -> int:
     findings: list[tuple[str, list[str]]] = []
 
     for service in services:
-        reasons = boundary_reasons(service, changed, base)
+        reasons = boundary_reasons(service, changed, base, args.head)
         if not reasons:
             continue
         tm_rel = f"docs/threat-models/{service}.md"


### PR DESCRIPTION
## Summary

The threat-model-diff gate flagged a money-path service whenever *any* line of its
Deployment/Rollout manifest changed. Two generated edits therefore lit up the whole fleet. This
scopes the manifest rule to the diff hunks, and adds the self-test the gate never had.

Measured on the last 60 commits of `main`: **would-block 7 -> 2**, and both survivors are real
findings.

## Type of change

- [ ] feat (new functionality)
- [x] fix (bug fix)
- [ ] refactor (no behavior change)
- [ ] perf (performance)
- [ ] docs
- [ ] chore (build / tooling)
- [ ] security (private until disclosed)
- [ ] breaking change

## Linked issues

Refs #3431, #3378

## The defect

`gitops_hit()` returned a finding for a Deployment/Rollout based on the **filename**. But:

- a `rules.yaml` edit restamps `openbank.tech/policy-checksum` on ~29 service manifests at once —
  so one governance PR flagged every money-path service simultaneously (this is exactly what
  happened to #3420, whose only manifest change was that annotation);
- auto-deploy rewrites an `image:` tag on every push.

Neither opens a port, grants an identity, or changes who can reach the pod. A gate that fires on
generated churn is a gate people learn to ignore — and this one is the *only* check that a threat
model is current rather than merely present.

The script already did the right thing one rule over: `application.yaml` is matched on its diff
hunks (`SECURITY_KEY`), not its path. The gitops rule was the outlier.

## The fix

- `hunk_moves_boundary()` drops known-generated lines (`policy-checksum`, `image`,
  `imagePullPolicy`) and then requires a key that actually describes a boundary: listeners
  (`ports`, `containerPort`, `nodePort`…), reach (`ingress`, `egress`, `podSelector`…), identity
  (`serviceAccountName`, `automountServiceAccountToken`), privilege (`securityContext`,
  `privileged`, `capabilities`, `hostNetwork`…), and auth-shaped env names
  (`*OIDC*`, `*AUTHZ*`, `*TLS*`, `*ISSUER*`, `*TOKEN*`, `*SECRET*`, `*KEYCLOAK*`).
- **NetworkPolicy files still count on any change** — a NetworkPolicy is reach by construction, so
  there is no such thing as a cosmetic edit to one.
- When hunks cannot be inspected (`--changed-files` synthetic list, no git), the manifest rule
  stays conservative and flags on the path — same contract `yaml_security_keys_changed()` already
  had.

## Measurement

| | would-block, of last 60 commits |
|---|---|
| before | 7 |
| after | 2 |

Dropped (all generated churn): `2b8a7cfcb` (OPA restamp), `8403bec20` + `122c5e4f7` (auto-deploy
image bumps), `5ce707b1c`, `90f077e7c`.

Kept, and correct to keep:

- `8992de535` — new `network-policies.yaml` for accounts, payments and sca plus a whole new
  service; genuinely new ingress/egress, no threat-model update.
- `d949ce9ef` — a changed `infrastructure/client` file, i.e. an outbound trust edge.

Reproduce either direction with the new `--head`:

```bash
python3 openbank-infra/scripts/check-threat-model-diff.py --base 2b8a7cfcb^ --head 2b8a7cfcb --enforce
```

## Falsifiability

The gate shipped advisory with **no self-test**, so its failure path had never run — the 7-of-60
false-positive rate was found by hand, not by CI. Added `--self-test` with seven cases and
registered it in `gates.yaml` (`selftest_expect: pass`), so the runner exercises it on every run:

```
[ok] pod-roll annotation restamp only: flagged=False expected=False
[ok] image tag bump only:              flagged=False expected=False
[ok] a new container port:             flagged=True  expected=True
[ok] a changed service account:        flagged=True  expected=True
[ok] a new OIDC issuer env var:        flagged=True  expected=True
[ok] a replica count:                  flagged=False expected=False
[ok] restamp AND a port change:        flagged=True  expected=True
```

The last case is the one that matters: a real boundary change buried in a diff that also contains
generated churn must still flag, or the fix would have traded false positives for false negatives.

## Still advisory

`mode` is unchanged. Graduating to `enforced` is #3431's remaining step and should be a
maintainer's decision with the new numbers in hand, not a drive-by flip in the PR that fixed the
scoping — especially since the two true positives above are both on `main` already, so enforcement
would need those threat models updated first.

## Definition of Done

- [x] Unit tests added/updated — `--self-test`, seven cases, wired into the gate runner.
- [ ] Integration tests — N/A, stdlib script with no service boundary.
- [x] No new lint warnings; `gates.yaml` parses and `run-gates.py --only …` passes.
- [ ] OpenAPI / Flyway / Avro — N/A.
- [x] Docs updated — module docstring states the new hunk rule and the `#3431` rationale.

## Reviewer notes

- The interesting question is whether `MANIFEST_BOUNDARY_KEY` is too narrow. It errs toward
  flagging: any key containing `OIDC|AUTHZ|OPA|TLS|ISSUER|TOKEN|SECRET|KEYCLOAK` matches, which
  covers env-var renames as well as additions.
- `--head` was added for the measurement, not for CI; CI still passes only `--base`.
