### PR TITLE
feat(delegation): announce the authorization mode at boot

### DIFF
--- a/openbank-delegation-service/src/main/kotlin/com/openbank/delegation/infrastructure/authz/AuthzModeAnnouncer.kt
+++ b/openbank-delegation-service/src/main/kotlin/com/openbank/delegation/infrastructure/authz/AuthzModeAnnouncer.kt
@@ -1,0 +1,65 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright (c) OpenBank contributors. Licensed under the Apache License, Version 2.0.
+// See LICENSE in the repository root or https://www.apache.org/licenses/LICENSE-2.0 for details.
+
+package com.openbank.delegation.infrastructure.authz
+
+import io.quarkus.runtime.Startup
+import jakarta.annotation.PostConstruct
+import jakarta.enterprise.context.ApplicationScoped
+import org.eclipse.microprofile.config.inject.ConfigProperty
+import org.jboss.logging.Logger
+
+/**
+ * Announce the effective authorization mode once, at boot.
+ *
+ * `AuthorizeInterceptor` reads `authz.enforce` with `defaultValue = "true"`, and this service ships
+ * its first rollout with `AUTHZ_ENFORCE=false` (ADR-0034 D5 phased rollout): every `@Authorize`
+ * decision is evaluated and recorded, and none of them block. That is a deliberate window, and it
+ * ends when the `outcome=deny, enforced=false` population is confirmed empty — but **nothing said
+ * which mode a running pod was in**. You had to read the GitOps manifest and trust it matched the
+ * pod, which is exactly the kind of claim that drifts silently.
+ *
+ * `@Startup` is load-bearing, not decoration. `@ApplicationScoped` is LAZY: Quarkus creates the
+ * bean through a client proxy on first use, so a `@PostConstruct` that exists to state a boot-time
+ * fact never runs until something else touches the bean — and for a bean nothing injects, that is
+ * never. `PdfBoxPadesSealAdapter` warned that every PAdES seal was "worthless as evidence" without
+ * a real keystore, and that warning had never once appeared in a pod log (#1299). `@Startup` forces
+ * instantiation at boot, which is the only thing that makes this line appear at all.
+ *
+ * Deliberately logged at WARN while advisory: an authorization layer that is evaluating but not
+ * blocking is a temporary state someone has to come back to, and INFO is where such things go to
+ * die in a log aggregator.
+ *
+ * Belongs in `openbank-libs-runtime` next to the interceptor so the whole fleet gets it — every
+ * service carries the same advisory window and the same blind spot. Kept here for now because a
+ * libs change rebuilds every consumer; see the follow-up note in the PR.
+ */
+@Startup
+@ApplicationScoped
+class AuthzModeAnnouncer {
+
+    @ConfigProperty(name = "authz.enforce", defaultValue = "true")
+    var enforce: Boolean = true
+
+    @ConfigProperty(name = "authz.four-eyes.enforce", defaultValue = "false")
+    var fourEyesEnforce: Boolean = false
+
+    @PostConstruct
+    fun announce() {
+        if (enforce) {
+            log.info("authz: ENFORCING — a policy deny returns 403 (four-eyes enforce=$fourEyesEnforce)")
+        } else {
+            log.warn(
+                "authz: ADVISORY (authz.enforce=false) — every @Authorize decision is evaluated and " +
+                    "recorded but NONE of them block. Deliberate for the phased rollout (ADR-0034 D5); " +
+                    "flip to enforce once openbank.authz.decisions{outcome=\"deny\",enforced=\"false\"} " +
+                    "is confirmed empty (four-eyes enforce=$fourEyesEnforce)",
+            )
+        }
+    }
+
+    private companion object {
+        val log: Logger = Logger.getLogger(AuthzModeAnnouncer::class.java)
+    }
+}

--- a/openbank-delegation-service/src/test/kotlin/com/openbank/delegation/infrastructure/authz/AuthzModeAnnouncerTest.kt
+++ b/openbank-delegation-service/src/test/kotlin/com/openbank/delegation/infrastructure/authz/AuthzModeAnnouncerTest.kt
@@ -1,0 +1,48 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright (c) OpenBank contributors. Licensed under the Apache License, Version 2.0.
+// See LICENSE in the repository root or https://www.apache.org/licenses/LICENSE-2.0 for details.
+
+package com.openbank.delegation.infrastructure.authz
+
+import io.quarkus.runtime.Startup
+import jakarta.annotation.PostConstruct
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.Test
+
+/**
+ * The thing worth protecting here is not the log text — it is `@Startup`.
+ *
+ * Without it the bean is lazy, nothing injects it, and the announcement never runs: the class would
+ * look completely correct and produce nothing, forever (#1299). A test that only called `announce()`
+ * directly would pass against exactly that bug, because the direct call supplies the instantiation
+ * the container would not. So assert the annotation itself.
+ */
+class AuthzModeAnnouncerTest {
+
+    @Test
+    fun `carries @Startup, without which the announcement never runs`() {
+        assertThat(AuthzModeAnnouncer::class.java.isAnnotationPresent(Startup::class.java))
+            .`as`("@ApplicationScoped is lazy — @Startup is what makes a boot-time statement happen at boot")
+            .isTrue()
+    }
+
+    @Test
+    fun `the announcement is a @PostConstruct callback, so the container invokes it`() {
+        val method = AuthzModeAnnouncer::class.java.declaredMethods.single { it.name == "announce" }
+        assertThat(method.isAnnotationPresent(PostConstruct::class.java)).isTrue()
+    }
+
+    @Test
+    fun `defaults to enforcing when nothing sets the property`() {
+        // Mirrors AuthorizeInterceptor's own defaultValue = "true": an unset flag must never read
+        // as advisory, or a misconfigured service would quietly stop blocking.
+        assertThat(AuthzModeAnnouncer().enforce).isTrue()
+        assertThat(AuthzModeAnnouncer().fourEyesEnforce).isFalse()
+    }
+
+    @Test
+    fun `announce runs in both modes without throwing`() {
+        AuthzModeAnnouncer().apply { enforce = true }.announce()
+        AuthzModeAnnouncer().apply { enforce = false }.announce()
+    }
+}


### PR DESCRIPTION
## Why this exists

delegation-service ships its first rollout with `AUTHZ_ENFORCE=false` (ADR-0034 D5 phased
rollout): every `@Authorize` decision is evaluated and recorded, and none of them block. That is
deliberate, and it ends when the `outcome=deny, enforced=false` population is confirmed empty.

**Nothing said which mode a running pod was in.** You had to read the GitOps manifest and trust it
matched the pod. An authorization layer that is silently not blocking is not a state to infer from
a second artefact.

## `@Startup` is the whole point

`@ApplicationScoped` is lazy — Quarkus creates the bean through a client proxy on first use, so a
`@PostConstruct` that exists to state a boot-time fact never runs until something touches the bean.
Nothing injects this one, so without `@Startup` that is *never*: a class that looks completely
correct and produces nothing, forever.

That is not hypothetical here. `PdfBoxPadesSealAdapter` warns that every PAdES seal is "worthless
as evidence" without a real keystore, and that warning had never once appeared in a pod log
(#1299).

WARN while advisory, INFO while enforcing: a layer that evaluates but does not block is a temporary
state someone has to come back to, and INFO is where such things go to die in a log aggregator.

## The test asserts the annotation, not the log text

Calling `announce()` directly would pass against exactly the bug worth catching — the direct call
supplies the instantiation the container would not. So the test asserts `@Startup` and
`@PostConstruct` are present, plus that an unset flag defaults to *enforcing* (mirroring
`AuthorizeInterceptor`'s own `defaultValue = "true"`, so a misconfigured service never quietly
stops blocking).

Falsified rather than assumed: removing `@Startup` turns the suite red (exit 1), restoring it turns
it green (exit 0). 4 tests, `detekt` + `ktlintCheck` + `test` green with the exit code read directly
from Gradle.

## Follow-up, stated rather than done silently

This belongs in `openbank-libs-runtime` next to `AuthorizeInterceptor` — every service carries the
same advisory window and the same blind spot, and 12 of them are on `AUTHZ_ENFORCE=false` today. It
is kept service-local here because a libs change rebuilds every consumer, which is not something to
bundle into a rollout unblock.

## Deploy note

This is a real `src/main` change, so it also takes delegation-service through the **push** deploy
path rather than a manual dispatch. That matters: `#3327`'s guard deliberately refuses a
`workflow_dispatch` of a sha with no published pact version, and a service with no contracts trips
it on every first deploy (see #3427, whose `absent` branch does not fire here because the broker
does know the pacticipant — a deployment was recorded against the placeholder pin). The push path
uses the `--latest main` fallback the fleet already relies on.

Refs #1299, #3327
