### PR TITLE
fix(ci): give every main commit its own concurrency lane

### DIFF
--- a/.github/workflows/0-wrapper-validation.yml
+++ b/.github/workflows/0-wrapper-validation.yml
@@ -40,8 +40,16 @@ permissions:
   contents: read
 
 concurrency:
-  group: wrapper-validation-${{ github.ref }}
-  cancel-in-progress: true
+  # On a push to main, github.ref is always refs/heads/main regardless of commit, so a
+  # ref-keyed group made every new commit cancel the previous commit's run. Bot commits
+  # (auto-deploy pin bumps, release-please) land every few minutes, so a main run rarely
+  # survived to completion — 9 of 11 CI runs and 9 of 11 Security runs were cancelled on
+  # 2026-08-02 (issue #3390). Give each main commit its own lane and never cancel it;
+  # PR pushes keep the superseding behaviour, which is what that setting is for.
+  # The key stays O(1) — a sha, never a list: interpolating a fleet-sized value here
+  # stops the job being created at all (#3082).
+  group: wrapper-validation-${{ github.ref }}-${{ github.event_name == 'push' && github.ref == 'refs/heads/main' && github.sha || 'ci' }}
+  cancel-in-progress: ${{ !(github.event_name == 'push' && github.ref == 'refs/heads/main') }}
 
 jobs:
   validate:

--- a/.github/workflows/adr-registry.yml
+++ b/.github/workflows/adr-registry.yml
@@ -41,8 +41,16 @@ permissions:
   contents: read
 
 concurrency:
-  group: adr-registry-${{ github.event.pull_request.number || github.ref }}
-  cancel-in-progress: true
+  # On a push to main, github.ref is always refs/heads/main regardless of commit, so a
+  # ref-keyed group made every new commit cancel the previous commit's run. Bot commits
+  # (auto-deploy pin bumps, release-please) land every few minutes, so a main run rarely
+  # survived to completion — 9 of 11 CI runs and 9 of 11 Security runs were cancelled on
+  # 2026-08-02 (issue #3390). Give each main commit its own lane and never cancel it;
+  # PR pushes keep the superseding behaviour, which is what that setting is for.
+  # The key stays O(1) — a sha, never a list: interpolating a fleet-sized value here
+  # stops the job being created at all (#3082).
+  group: adr-registry-${{ github.event.pull_request.number || github.ref }}-${{ github.event_name == 'push' && github.ref == 'refs/heads/main' && github.sha || 'ci' }}
+  cancel-in-progress: ${{ !(github.event_name == 'push' && github.ref == 'refs/heads/main') }}
 
 jobs:
   adr-registry:

--- a/.github/workflows/agent-charter-registry.yml
+++ b/.github/workflows/agent-charter-registry.yml
@@ -40,8 +40,16 @@ permissions:
   contents: read
 
 concurrency:
-  group: agent-charter-registry-${{ github.event.pull_request.number || github.ref }}
-  cancel-in-progress: true
+  # On a push to main, github.ref is always refs/heads/main regardless of commit, so a
+  # ref-keyed group made every new commit cancel the previous commit's run. Bot commits
+  # (auto-deploy pin bumps, release-please) land every few minutes, so a main run rarely
+  # survived to completion — 9 of 11 CI runs and 9 of 11 Security runs were cancelled on
+  # 2026-08-02 (issue #3390). Give each main commit its own lane and never cancel it;
+  # PR pushes keep the superseding behaviour, which is what that setting is for.
+  # The key stays O(1) — a sha, never a list: interpolating a fleet-sized value here
+  # stops the job being created at all (#3082).
+  group: agent-charter-registry-${{ github.event.pull_request.number || github.ref }}-${{ github.event_name == 'push' && github.ref == 'refs/heads/main' && github.sha || 'ci' }}
+  cancel-in-progress: ${{ !(github.event_name == 'push' && github.ref == 'refs/heads/main') }}
 
 jobs:
   agent-charter-registry:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -9,8 +9,16 @@ permissions:
   contents: read
 
 concurrency:
-  group: ci-${{ github.ref }}
-  cancel-in-progress: true
+  # On a push to main, github.ref is always refs/heads/main regardless of commit, so a
+  # ref-keyed group made every new commit cancel the previous commit's run. Bot commits
+  # (auto-deploy pin bumps, release-please) land every few minutes, so a main run rarely
+  # survived to completion — 9 of 11 CI runs and 9 of 11 Security runs were cancelled on
+  # 2026-08-02 (issue #3390). Give each main commit its own lane and never cancel it;
+  # PR pushes keep the superseding behaviour, which is what that setting is for.
+  # The key stays O(1) — a sha, never a list: interpolating a fleet-sized value here
+  # stops the job being created at all (#3082).
+  group: ci-${{ github.ref }}-${{ github.event_name == 'push' && github.ref == 'refs/heads/main' && github.sha || 'ci' }}
+  cancel-in-progress: ${{ !(github.event_name == 'push' && github.ref == 'refs/heads/main') }}
 
 jobs:
   # ---------------------------------------------------------------------------

--- a/.github/workflows/eu-ai-act-registry.yml
+++ b/.github/workflows/eu-ai-act-registry.yml
@@ -56,8 +56,16 @@ permissions:
   contents: read
 
 concurrency:
-  group: eu-ai-act-registry-${{ github.event.pull_request.number || github.ref }}
-  cancel-in-progress: true
+  # On a push to main, github.ref is always refs/heads/main regardless of commit, so a
+  # ref-keyed group made every new commit cancel the previous commit's run. Bot commits
+  # (auto-deploy pin bumps, release-please) land every few minutes, so a main run rarely
+  # survived to completion — 9 of 11 CI runs and 9 of 11 Security runs were cancelled on
+  # 2026-08-02 (issue #3390). Give each main commit its own lane and never cancel it;
+  # PR pushes keep the superseding behaviour, which is what that setting is for.
+  # The key stays O(1) — a sha, never a list: interpolating a fleet-sized value here
+  # stops the job being created at all (#3082).
+  group: eu-ai-act-registry-${{ github.event.pull_request.number || github.ref }}-${{ github.event_name == 'push' && github.ref == 'refs/heads/main' && github.sha || 'ci' }}
+  cancel-in-progress: ${{ !(github.event_name == 'push' && github.ref == 'refs/heads/main') }}
 
 jobs:
   eu-ai-act-registry:

--- a/.github/workflows/fleet-lint.yml
+++ b/.github/workflows/fleet-lint.yml
@@ -54,8 +54,16 @@ permissions:
 
 concurrency:
   # One fleet-lint per ref; a newer main push supersedes an in-flight one.
-  group: fleet-lint-${{ github.ref }}
-  cancel-in-progress: true
+  # On a push to main, github.ref is always refs/heads/main regardless of commit, so a
+  # ref-keyed group made every new commit cancel the previous commit's run. Bot commits
+  # (auto-deploy pin bumps, release-please) land every few minutes, so a main run rarely
+  # survived to completion — 9 of 11 CI runs and 9 of 11 Security runs were cancelled on
+  # 2026-08-02 (issue #3390). Give each main commit its own lane and never cancel it;
+  # PR pushes keep the superseding behaviour, which is what that setting is for.
+  # The key stays O(1) — a sha, never a list: interpolating a fleet-sized value here
+  # stops the job being created at all (#3082).
+  group: fleet-lint-${{ github.ref }}-${{ github.event_name == 'push' && github.ref == 'refs/heads/main' && github.sha || 'ci' }}
+  cancel-in-progress: ${{ !(github.event_name == 'push' && github.ref == 'refs/heads/main') }}
 
 jobs:
   fleet-lint:

--- a/.github/workflows/opa-policy.yml
+++ b/.github/workflows/opa-policy.yml
@@ -26,8 +26,16 @@ permissions:
   contents: read
 
 concurrency:
-  group: opa-policy-${{ github.ref }}
-  cancel-in-progress: true
+  # On a push to main, github.ref is always refs/heads/main regardless of commit, so a
+  # ref-keyed group made every new commit cancel the previous commit's run. Bot commits
+  # (auto-deploy pin bumps, release-please) land every few minutes, so a main run rarely
+  # survived to completion — 9 of 11 CI runs and 9 of 11 Security runs were cancelled on
+  # 2026-08-02 (issue #3390). Give each main commit its own lane and never cancel it;
+  # PR pushes keep the superseding behaviour, which is what that setting is for.
+  # The key stays O(1) — a sha, never a list: interpolating a fleet-sized value here
+  # stops the job being created at all (#3082).
+  group: opa-policy-${{ github.ref }}-${{ github.event_name == 'push' && github.ref == 'refs/heads/main' && github.sha || 'ci' }}
+  cancel-in-progress: ${{ !(github.event_name == 'push' && github.ref == 'refs/heads/main') }}
 
 jobs:
   changes:

--- a/.github/workflows/product-catalog-native-build.yml
+++ b/.github/workflows/product-catalog-native-build.yml
@@ -34,8 +34,16 @@ permissions:
   contents: read
 
 concurrency:
-  group: product-catalog-native-build-${{ github.ref }}
-  cancel-in-progress: true
+  # On a push to main, github.ref is always refs/heads/main regardless of commit, so a
+  # ref-keyed group made every new commit cancel the previous commit's run. Bot commits
+  # (auto-deploy pin bumps, release-please) land every few minutes, so a main run rarely
+  # survived to completion — 9 of 11 CI runs and 9 of 11 Security runs were cancelled on
+  # 2026-08-02 (issue #3390). Give each main commit its own lane and never cancel it;
+  # PR pushes keep the superseding behaviour, which is what that setting is for.
+  # The key stays O(1) — a sha, never a list: interpolating a fleet-sized value here
+  # stops the job being created at all (#3082).
+  group: product-catalog-native-build-${{ github.ref }}-${{ github.event_name == 'push' && github.ref == 'refs/heads/main' && github.sha || 'ci' }}
+  cancel-in-progress: ${{ !(github.event_name == 'push' && github.ref == 'refs/heads/main') }}
 
 jobs:
   native-build-smoke-test:

--- a/.github/workflows/scorecard.yml
+++ b/.github/workflows/scorecard.yml
@@ -46,8 +46,16 @@ on:
 permissions: read-all
 
 concurrency:
-  group: scorecard-${{ github.ref }}
-  cancel-in-progress: true
+  # On a push to main, github.ref is always refs/heads/main regardless of commit, so a
+  # ref-keyed group made every new commit cancel the previous commit's run. Bot commits
+  # (auto-deploy pin bumps, release-please) land every few minutes, so a main run rarely
+  # survived to completion — 9 of 11 CI runs and 9 of 11 Security runs were cancelled on
+  # 2026-08-02 (issue #3390). Give each main commit its own lane and never cancel it;
+  # PR pushes keep the superseding behaviour, which is what that setting is for.
+  # The key stays O(1) — a sha, never a list: interpolating a fleet-sized value here
+  # stops the job being created at all (#3082).
+  group: scorecard-${{ github.ref }}-${{ github.event_name == 'push' && github.ref == 'refs/heads/main' && github.sha || 'ci' }}
+  cancel-in-progress: ${{ !(github.event_name == 'push' && github.ref == 'refs/heads/main') }}
 
 jobs:
   analysis:

--- a/.github/workflows/secret-scan.yml
+++ b/.github/workflows/secret-scan.yml
@@ -14,8 +14,16 @@ permissions:
 # refs/heads/main, so without it a routine main push cancels the weekly
 # scheduled history scan (same fix as security.yml).
 concurrency:
-  group: secret-scan-${{ github.event_name }}-${{ github.ref }}
-  cancel-in-progress: true
+  # On a push to main, github.ref is always refs/heads/main regardless of commit, so a
+  # ref-keyed group made every new commit cancel the previous commit's run. Bot commits
+  # (auto-deploy pin bumps, release-please) land every few minutes, so a main run rarely
+  # survived to completion — 9 of 11 CI runs and 9 of 11 Security runs were cancelled on
+  # 2026-08-02 (issue #3390). Give each main commit its own lane and never cancel it;
+  # PR pushes keep the superseding behaviour, which is what that setting is for.
+  # The key stays O(1) — a sha, never a list: interpolating a fleet-sized value here
+  # stops the job being created at all (#3082).
+  group: secret-scan-${{ github.event_name }}-${{ github.ref }}-${{ github.event_name == 'push' && github.ref == 'refs/heads/main' && github.sha || 'ci' }}
+  cancel-in-progress: ${{ !(github.event_name == 'push' && github.ref == 'refs/heads/main') }}
 
 jobs:
   gitleaks:

--- a/.github/workflows/security.yml
+++ b/.github/workflows/security.yml
@@ -17,8 +17,16 @@ permissions:
 # refs/heads/main, so without it a routine Monday-morning push CANCELS the
 # weekly scheduled audit — the audit posture silently never runs that week.
 concurrency:
-  group: security-${{ github.event_name }}-${{ github.ref }}
-  cancel-in-progress: true
+  # On a push to main, github.ref is always refs/heads/main regardless of commit, so a
+  # ref-keyed group made every new commit cancel the previous commit's run. Bot commits
+  # (auto-deploy pin bumps, release-please) land every few minutes, so a main run rarely
+  # survived to completion — 9 of 11 CI runs and 9 of 11 Security runs were cancelled on
+  # 2026-08-02 (issue #3390). Give each main commit its own lane and never cancel it;
+  # PR pushes keep the superseding behaviour, which is what that setting is for.
+  # The key stays O(1) — a sha, never a list: interpolating a fleet-sized value here
+  # stops the job being created at all (#3082).
+  group: security-${{ github.event_name }}-${{ github.ref }}-${{ github.event_name == 'push' && github.ref == 'refs/heads/main' && github.sha || 'ci' }}
+  cancel-in-progress: ${{ !(github.event_name == 'push' && github.ref == 'refs/heads/main') }}
 
 jobs:
   # ---------------------------------------------------------------------------


### PR DESCRIPTION
Closes #3390.

## The change

Eleven workflows keyed their concurrency group on `github.ref` with `cancel-in-progress: true`. On a push to `main`, `github.ref` is always `refs/heads/main` regardless of commit, so every new commit cancelled the previous commit's run. Bot commits land every few minutes, so a main run rarely survived to completion.

`services-ci.yml` already carries the fix and states the reasoning in place. This applies the same shape to the other eleven:

```yaml
group: <existing>-${{ github.event_name == 'push' && github.ref == 'refs/heads/main' && github.sha || 'ci' }}
cancel-in-progress: ${{ !(github.event_name == 'push' && github.ref == 'refs/heads/main') }}
```

PR pushes keep the superseding behaviour — a new push to the same branch *should* cancel the old run. Only push-to-main gets a per-commit lane.

Worst affected is `ci.yml`, which hosts `Validate manifests` — a **required** check whose whole job is to be the fleet-wide gate. A cancelled run is not a red one, so nothing reports it, and the last verdict anyone sees belongs to whichever commit happened to finish uninterrupted.

## Left alone deliberately

`platform-tofu.yml`, `substrate-tofu.yml` and `release-please.yml` also key on `github.ref`, but already set `cancel-in-progress: false` — they serialize rather than cancel, which is the correct behaviour for a state-mutating apply and for the release cutter. Changing them would be churn, not a fix.

## The key stays O(1)

A sha, never a list. Interpolating a fleet-sized value into a `concurrency.group` stops the job being **created at all** — not skipped, absent, with no check-run on the commit — which is #3082 and strictly worse than the problem being fixed here. Longest resulting group name is ~90 chars.

## Validated against GitHub, not against a YAML parser

A parser cannot see what GitHub refuses, and this repo has already paid for trusting one (#3135/#3139). So the oracle was used, and validated in both directions first:

| throwaway branch | contents | runs produced |
|---|---|---|
| `tmp/wf-oracle-*` | one deliberately **invalid** workflow | **1** — titled after the file *path*, zero jobs, failed |
| `tmp/wf-real-*` | these **eleven** files | **0** |

Zero is the correct answer for a valid workflow filtered to `branches: [main]` pushed to a non-main branch; the oracle branch proves an invalid one would still have produced a run. Both probe branches have been deleted.

Also green locally: `run-gates.py --group lint` (4/4, including `yamllint` and `workflow-run-step-size` over the edited files).

## How to confirm it worked after merge

Watch a few consecutive main pushes: `gh run list --workflow=ci.yml --branch main` should stop showing `cancelled`. Today's baseline was 9 of 11.
