### PR TITLE
fix(gitops): point security-scanner and analytics-sink at the real OIDC issuer

### DIFF
--- a/openbank-infra/gitops/components/analytics/analytics-sink.yaml
+++ b/openbank-infra/gitops/components/analytics/analytics-sink.yaml
@@ -69,8 +69,14 @@ spec:
           env:
             - name: QUARKUS_HTTP_PORT
               value: "8134"
-            - name: QUARKUS_OIDC_ENABLED
-              value: "false"
+            # Same defect as security-scanner (#3433). `QUARKUS_OIDC_ENABLED=false` is inert —
+            # quarkus.oidc.enabled is a BUILD-TIME property — so OIDC ran here regardless, against
+            # the application.yaml default `http://localhost:8080/realms/openbank` inside this
+            # pod. Verified in the sandbox: `GET /api/v1/info` answers 200 anonymously and 500
+            # with a bearer, and the pod logs `OIDC server is not available at the
+            # 'http://localhost:8080/realms/openbank' URL`.
+            - name: QUARKUS_OIDC_AUTH_SERVER_URL
+              value: http://keycloak.iam.svc:8080/realms/openbank
             - name: QUARKUS_OTEL_SDK_DISABLED
               value: "true"
             - name: ANALYTICS_SINK_TYPE

--- a/openbank-infra/gitops/components/keycloak/network-policies.yaml
+++ b/openbank-infra/gitops/components/keycloak/network-policies.yaml
@@ -53,6 +53,9 @@ spec:
               kubernetes.io/metadata.name: anacredit
         - namespaceSelector:
             matchLabels:
+              kubernetes.io/metadata.name: analytics
+        - namespaceSelector:
+            matchLabels:
               kubernetes.io/metadata.name: audit
         - namespaceSelector:
             matchLabels:
@@ -153,6 +156,9 @@ spec:
         - namespaceSelector:
             matchLabels:
               kubernetes.io/metadata.name: sdd
+        - namespaceSelector:
+            matchLabels:
+              kubernetes.io/metadata.name: security-scanner
         - namespaceSelector:
             matchLabels:
               kubernetes.io/metadata.name: statements

--- a/openbank-infra/gitops/components/security-scanner/security-scanner-service.yaml
+++ b/openbank-infra/gitops/components/security-scanner/security-scanner-service.yaml
@@ -66,8 +66,17 @@ spec:
                   key: password
             - name: KAFKA_BOOTSTRAP_SERVERS
               value: openbank-cluster-kafka-bootstrap.messaging.svc:9092
-            - name: QUARKUS_OIDC_ENABLED
-              value: "false"
+            # `QUARKUS_OIDC_ENABLED=false` used to sit here and did NOTHING: quarkus.oidc.enabled
+            # is a BUILD-TIME property, so setting it through the environment cannot switch OIDC
+            # off in an already-built image. It read as "auth is off for this service" while the
+            # pod validated every bearer it was given — against the application.yaml default
+            # `http://localhost:8080/realms/openbank`, i.e. inside its own pod, where nothing
+            # listens. Result: anonymous requests answered 200/401 normally and every request
+            # WITH a token answered 500 (`OIDCException: OIDC Server is not available`), which is
+            # what the admin-ui Security screen was hitting. Point it at the real issuer instead,
+            # exactly as fraud/sanctions/campaign do.
+            - name: QUARKUS_OIDC_AUTH_SERVER_URL
+              value: http://keycloak.iam.svc:8080/realms/openbank
             - name: QUARKUS_OTEL_EXPORTER_OTLP_ENDPOINT
               value: "http://tempo.observability.svc:4317"
             - name: OTEL_TRACES_SAMPLER_ARG


### PR DESCRIPTION
## What

`security-scanner` and `analytics-sink` answer **500 to every request carrying a bearer token**. Both are pointed at the real Keycloak; the inert `QUARKUS_OIDC_ENABLED=false` is removed.

## Why

`quarkus.oidc.enabled` is a **build-time** property. Setting it through the environment cannot switch OIDC off in an already-built image — so it read as *"auth is off for this service"* while the pod validated every bearer it was handed, against the `application.yaml` default `http://localhost:8080/realms/openbank`, i.e. **inside its own pod**. Both pods say so at startup:

```
WARN  OIDC server is not available at the 'http://localhost:8080/realms/openbank' URL
ERROR Failed to create OidcProviderClientImpl
      io.quarkus.oidc.OIDCException: OIDC Server is not available
```

Measured in the sandbox — same fingerprint on both:

| request | security-scanner | analytics-sink |
|---|---|---|
| `GET /api/v1/info` anonymous | 200 | 200 |
| `GET /api/v1/info` **+ bearer** | **500** | **500** |

The discriminator is the **presence of a token**, not the endpoint or its data. That is exactly what the admin-ui Security screen sends after [#3336](https://github.com/JiRaska/open-bank-oss/pull/3336), so that screen cannot render until this lands.

## Verified fix

`security-scanner` booted locally against a reachable Keycloak, **with its hardcoded YAML untouched**, real Postgres, migrations applied:

```
/api/v1/info               anon=200  bearer=200
/api/v1/security/report    anon=401  bearer=404   {"message":"No scan completed yet…"}
/api/v1/security/services  anon=401  bearer=200
```

No 500 anywhere; `/report`'s 404 is its documented empty state, which the console renders as a calm "no scan yet" panel.

## Two things I got wrong on the way, corrected here

- **Not a `${ENV:…}` placeholder problem.** I first claimed the working services differ by using a placeholder. They do not: `fraud-service` and `sanctions-service` hardcode the *identical* localhost URL in their own `application.yaml` and work fine, because their deployments set `QUARKUS_OIDC_AUTH_SERVER_URL`. An env var outranks `application.yaml` in SmallRye Config regardless. Hence **no `application.yaml` change in this PR**.
- **Not the missing database schema.** The scanner's 500 is unrelated to [#3350](https://github.com/JiRaska/open-bank-oss/pull/3350): the request path never touches the outbox — measured 72 dispatcher `SELECT`s and **zero** `INSERT`s across ten authenticated requests. Both fixes are needed; neither substitutes for the other.

## NetworkPolicy

Generated, not hand-written. `gen-network-policies.py` derives the keycloak ingress edge from these env declarations, so both namespaces gain one — without it the connection would be blocked even with the URL correct. `run-gates.py --group gitops` passes (the two unrelated reds — `loki-rule-load-test` unfalsified — reproduce on a clean `origin/main` here).

## Scope of the sweep

Seven workloads lack `QUARKUS_OIDC_AUTH_SERVER_URL`; five were checked and ruled out rather than assumed: `admin-ui` and `iam/keycloak` (not OIDC resource servers), `developer-portal` and `document-renderer` (**no quarkus-oidc dependency at all**), `campaign-service` (sets `KEYCLOAK_URL`). `notification-service` carries an equally inert `QUARKUS_OIDC_ENABLED=true` that happens to agree with its build — harmless today, noted in the issue.

## Linked issues

Closes #3433
