### PR TITLE
fix(infra): create a service's ECR repository instead of failing the push

### DIFF
--- a/.github/gates/gates.yaml
+++ b/.github/gates/gates.yaml
@@ -797,6 +797,19 @@ gates:
   # enforced would break main on a defect this PR is not fixing; registering it advisory is
   # what makes that defect visible at all. Graduate to enforced once the finding is closed —
   # tracked on #3240.
+  # ensure-ecr-repository.sh runs on the deploy path, where CI cannot exercise it — it needs AWS
+  # credentials and a real registry. So the only thing that can be checked here is that it still
+  # behaves correctly against a stubbed CLI, which is exactly the part that regresses silently:
+  # the script's whole value is "make no mutating call when the repo exists, create it when it
+  # does not, and fail loudly when it cannot". Its own --self-test asserts all three and validates
+  # the stub first, so a stub that fell through to the real `aws` cannot report a pass (#3423).
+  - id: ensure-ecr-repository
+    name: "ensure-ecr-repository behaviour (#3423, enforced)"
+    group: supplychain
+    mode: enforced
+    run: |
+      bash .github/scripts/ensure-ecr-repository.sh --self-test
+
   - id: operator-write-naming
     name: "operator-write naming vs. shared-M2M prohibition (GHSA-58jq-9hq3-66jr, advisory)"
     group: registry

--- a/.github/scripts/ensure-ecr-repository.sh
+++ b/.github/scripts/ensure-ecr-repository.sh
@@ -1,0 +1,127 @@
+#!/usr/bin/env bash
+# SPDX-License-Identifier: Apache-2.0
+# Copyright (c) OpenBank contributors. Licensed under the Apache License, Version 2.0.
+#
+# Make sure an image's ECR repository exists before something tries to push to it.
+#
+# WHY THIS EXISTS
+#   A new service's ECR repository is declared NOWHERE. `git grep aws_ecr_repository` over this
+#   repository returns nothing: all existing repos were created by hand, outside Terraform. So the
+#   first build of every new service compiles cleanly, runs the whole cold-cache Gradle build, and
+#   then dies at the push with
+#
+#     name unknown: The repository with name 'openbank-<svc>' does not exist in the registry
+#
+#   Measured on openbank-delegation-service's first build, 2026-08-02 (issue #3423).
+#
+#   Nothing upstream can catch it, and each near-miss looks like a different, expected state:
+#     - `deploy-drift-declaration` only checks the pin's SHAPE (`sandbox-<hex>`).
+#     - the fleet attestation gate reports the image as ABSENT — which is the CORRECT state for a
+#       first registration, and cannot distinguish "tag not built yet" from "repo does not exist".
+#     - Kyverno blocks ArgoCD's dry-run diff for an absent tag, so the app sits at sync status
+#       Unknown — again indistinguishable.
+#   The first real signal is a red build, after the expensive part has already been paid for.
+#
+# WHY CREATE RATHER THAN GATE
+#   #3423 proposes a PR-time gate asserting every gitops image pin has a repository. That gate
+#   would need AWS credentials on the PR lane, which runs on ubuntu-latest with none, to answer a
+#   question the push job is *already* authenticated for. Creating it at the point of use costs no
+#   new credential and removes the failure outright rather than moving it earlier.
+#
+#   This does not make the registry declarative; declaring the repos in Terraform (#3423 option 1)
+#   is still worth doing and composes with this. Note the trap called out there: a hand-typed
+#   `for_each` service list becomes a second copy of ALL_SERVICES that can drift from it — derive
+#   it from one source or do not add it.
+#
+# IDEMPOTENT BY CONSTRUCTION
+#   describe-repositories runs first, so the common case (every existing repo, every build) makes
+#   no mutating call at all. A create that loses a race against a concurrent build of the same new
+#   service is a SUCCESS, not a failure — re-checked with describe rather than by parsing the
+#   error string, since RepositoryAlreadyExistsException and a permissions denial are both just a
+#   non-zero exit here.
+#
+# SETTINGS mirror the fleet (copied from openbank-campaign-service): scanOnPush, AES256, MUTABLE.
+# Nothing else has to change for a new repo to be covered — `ecr-image-scanning.tf` is deliberately
+# registry-level with an `openbank-*` wildcard, and says in place that this is so it covers repos
+# that do not exist yet, "with no per-repo resource to forget".
+#
+# Usage:
+#   ensure-ecr-repository.sh <repository-name> [region]
+#   ensure-ecr-repository.sh --self-test
+set -euo pipefail
+
+selftest() {
+  # The gate this script IS: prove it does not call create when the repo exists, does call it when
+  # it does not, and fails loudly when creation is impossible. Runs against a stub `aws` on PATH —
+  # and the stub is validated first, because a silent passthrough would run the real AWS CLI.
+  local tmp rc out
+  tmp="$(mktemp -d)"; trap 'rm -rf "$tmp"' RETURN
+  cat > "${tmp}/aws" <<'STUB'
+#!/usr/bin/env bash
+echo "aws $*" >> "${STUB_CALLS}"
+case "$1 $2" in
+  "ecr describe-repositories") [ "${REPO_EXISTS:-0}" = "1" ] && exit 0 || exit 254 ;;
+  "ecr create-repository")     [ "${CREATE_OK:-1}" = "1" ] && exit 0 || exit 254 ;;
+esac
+exit 0
+STUB
+  chmod +x "${tmp}/aws"
+
+  # Validate the stub before trusting anything it reports: a stub that fell through to the real
+  # binary would make every case below pass while doing something else entirely.
+  STUB_CALLS="${tmp}/calls" PATH="${tmp}:$PATH" REPO_EXISTS=1 aws ecr describe-repositories >/dev/null 2>&1 \
+    || { echo "selftest FAIL: the stub does not answer describe-repositories"; return 1; }
+  grep -q "^aws ecr describe-repositories" "${tmp}/calls" \
+    || { echo "selftest FAIL: the stub did not record its call — it is not the binary being run"; return 1; }
+
+  : > "${tmp}/calls"
+  STUB_CALLS="${tmp}/calls" PATH="${tmp}:$PATH" REPO_EXISTS=1 "$0" openbank-demo >/dev/null 2>&1
+  if grep -q "create-repository" "${tmp}/calls"; then
+    echo "selftest FAIL: created a repository that already exists"; return 1
+  fi
+
+  : > "${tmp}/calls"
+  STUB_CALLS="${tmp}/calls" PATH="${tmp}:$PATH" REPO_EXISTS=0 CREATE_OK=1 "$0" openbank-demo >/dev/null 2>&1
+  if ! grep -q "create-repository" "${tmp}/calls"; then
+    echo "selftest FAIL: a missing repository was not created — the push would still fail"; return 1
+  fi
+
+  : > "${tmp}/calls"
+  set +e
+  STUB_CALLS="${tmp}/calls" PATH="${tmp}:$PATH" REPO_EXISTS=0 CREATE_OK=0 "$0" openbank-demo >/dev/null 2>&1
+  rc=$?
+  set -e
+  if [ "$rc" -eq 0 ]; then
+    echo "selftest FAIL: creation failed and the script exited 0 — the build would die at the push instead"
+    return 1
+  fi
+
+  echo "selftest OK: existing repo makes no mutating call, missing repo is created, unrecoverable failure exits ${rc}."
+  return 0
+}
+
+if [ "${1:-}" = "--self-test" ]; then selftest; exit $?; fi
+
+REPO="${1:?usage: ensure-ecr-repository.sh <repository-name> [region]}"
+REGION="${2:-${AWS_REGION:-eu-north-1}}"
+
+if aws ecr describe-repositories --repository-names "$REPO" --region "$REGION" >/dev/null 2>&1; then
+  exit 0
+fi
+
+echo "==> ECR repository ${REPO} does not exist — creating it (#3423)"
+if ! aws ecr create-repository \
+  --repository-name "$REPO" \
+  --region "$REGION" \
+  --image-tag-mutability MUTABLE \
+  --image-scanning-configuration scanOnPush=true \
+  --encryption-configuration encryptionType=AES256 >/dev/null 2>&1; then
+  # Lost a race with a concurrent build of the same new service? That is a success.
+  if ! aws ecr describe-repositories --repository-names "$REPO" --region "$REGION" >/dev/null 2>&1; then
+    echo "ERROR: could not create ECR repository ${REPO} in ${REGION}." >&2
+    echo "       Without it the push fails with 'name unknown: The repository ... does not exist'," >&2
+    echo "       after the whole build has already run. Check ecr:CreateRepository on this role." >&2
+    exit 1
+  fi
+fi
+echo "==> created ${REPO}"

--- a/.github/workflows/auto-deploy.yml
+++ b/.github/workflows/auto-deploy.yml
@@ -492,6 +492,12 @@ jobs:
             # EXPOSE is written dynamically after the static COPY/ENTRYPOINT lines.
             echo "EXPOSE ${port}" >> "${ctx}/Dockerfile"
 
+            # A new service's ECR repository is declared nowhere, so its first build compiles
+            # and then dies here (#3423). Reasoning lives in the script header, not in this
+            # run: block — prose here costs the whole workflow (#3135).
+            bash "${GITHUB_WORKSPACE}/.github/scripts/ensure-ecr-repository.sh" "${svc}" \
+              2>&1 | sed "s/^/[${svc}] /" || return 1
+
             echo "==> [${svc}] docker push → ${image}"
             docker buildx build \
               --platform linux/arm64 \

--- a/openbank-infra/scripts/build-push-service.sh
+++ b/openbank-infra/scripts/build-push-service.sh
@@ -96,6 +96,10 @@ EOF
 
 echo "==> ECR login + buildx push"
 aws ecr get-login-password --region "$AWS_REGION" | docker login --username AWS --password-stdin "$ECR_REGISTRY" >/dev/null
+# A new service's ECR repository is declared nowhere, so its first push fails with
+# `name unknown` after the whole build has already run (#3423). Shared with auto-deploy.yml's
+# inline push path — the one where it was actually measured — so both producers behave the same.
+AWS_REGION="$AWS_REGION" bash "${REPO_ROOT}/.github/scripts/ensure-ecr-repository.sh" "$ECR_REPO"
 docker buildx build --platform "$PLATFORM" -t "$IMAGE" --push "$CTX"
 echo "==> pushed ${IMAGE}"
 


### PR DESCRIPTION
Closes #3423.

## The failure

A new service's ECR repository is declared **nowhere** — `git grep aws_ecr_repository` over this repository returns nothing, and all existing repos were created by hand. So the first build of every new service compiles cleanly, runs the whole cold-cache Gradle build, and then dies at the push:

```
name unknown: The repository with name 'openbank-delegation-service' does not exist in the registry
```

Nothing upstream catches it, and each near-miss looks like a different, *expected* state: `deploy-drift-declaration` checks only the pin's shape, the fleet attestation gate reports the image as ABSENT (which is correct for a first registration and indistinguishable from a missing repo), and Kyverno blocks ArgoCD's dry-run diff for an absent tag so the app sits at sync status Unknown.

## Create at the point of use, not a PR-time gate

#3423 proposes a gate asserting every gitops image pin has a repository. That gate needs AWS credentials on the PR lane — which runs on `ubuntu-latest` with none — to answer a question the push job is *already* authenticated for. Creating the repository where it is needed costs no new credential and removes the failure rather than moving it earlier.

## Wired into BOTH producers — this was the trap

`auto-deploy.yml` pushes **inline** at line ~496 and does not call `build-push-service.sh`. My first pass patched only the script, which would have left untouched the exact path where the failure was measured (run 30762211614). Both now call the same shared helper.

## Idempotent by construction

`describe-repositories` runs first, so every existing repo makes no mutating call at all. A `create` that loses a race with a concurrent build of the same new service is re-checked with `describe` rather than by parsing the error string — `RepositoryAlreadyExistsException` and a permissions denial are both just a non-zero exit, and only one of them is a success.

Settings mirror the fleet (`scanOnPush`, `AES256`, `MUTABLE`), copied from `openbank-campaign-service`. Nothing else changes for a new repo to be covered: `ecr-image-scanning.tf` is registry-level with an `openbank-*` wildcard, and says in place that this is so it covers repos that do not exist yet.

## Falsifiability

The deploy path cannot be exercised in CI — it needs AWS credentials and a real registry. What *can* regress silently is the script's behaviour, so that is what the gate checks: `--self-test` asserts all three outcomes against a stubbed `aws`, and **validates the stub first**, because a stub that fell through to the real CLI would report a pass while doing something else entirely.

Verified the self-test can fail rather than assuming it — disabled the create branch in place and watched it go red with the right message, then restored:

```
selftest FAIL: a missing repository was not created — the push would still fail
```

## Validated against GitHub, not a YAML parser

`auto-deploy.yml` is edited here, and an oversized or unparseable workflow is silent locally (#3135). Throwaway branch carrying these four files produced **0 runs** — the correct answer for valid workflows on a non-main branch. The same oracle was validated in both directions earlier today on #3441, where a deliberately invalid file produced 1 run titled after the file path. Probe branch deleted.

Also green: `run-gates.py --group lint` (4/4), `--only ensure-ecr-repository`, `--only gate-runner-self-test`, `--only advisory-gate-registration`, `bash -n` on the edited shell script.

## Not claimed

This does not make the registry declarative. #3423 option 1 (Terraform) still stands and composes with this — with the caveat noted there that a hand-typed `for_each` list becomes a second copy of `ALL_SERVICES` that can drift from it.
