### PR TITLE
docs(threat-models): record the delegation ingress edge and the AML party lookup

### DIFF
--- a/docs/threat-models/openbank-account-service.md
+++ b/docs/threat-models/openbank-account-service.md
@@ -293,3 +293,17 @@ not change any existing request's outcome until explicitly flipped.
   cross-purpose challenge fails). Residual: the Redis PendingApproval TTL (24h) is
   the proposal's effective expiry — a decided-late approval still fails at the store
   (PENDING-only decide). Rollback: revert; V18 is a droppable table.
+
+- **2026-08-02** — **New inbound trust edge: the `delegation` namespace.** `#3414` added
+  `delegation` as an allowed ingress peer in this component's `network-policies.yaml`, so
+  `delegation-service` can now reach this service's API from inside the cluster. A NetworkPolicy is
+  coarse — it decides *reach*, not *permission* — so the actual authorization is unchanged and still
+  rests on OIDC (`@RolesAllowed`) plus the OPA sidecar (ADR-0034); this edge widens who may attempt a
+  call, not who may succeed. Risk class = **elevation of privilege** if a policy gap exists on an
+  endpoint that previously had no in-cluster caller: network reach was an implicit second control for
+  such endpoints and is now gone for this peer. Per ADR-0232 delegation-service holds
+  `DelegationGrant` and enforcement stays with the product services, which build their own local
+  projection — so a compromised or buggy delegation-service should not be able to grant access it
+  never had, and that property is the mitigation this edge depends on. Rollback: drop the
+  `namespaceSelector` entry for `delegation`. Recorded here because #3431's measurement showed this
+  change landed with no threat-model update.

--- a/docs/threat-models/openbank-domestic-payment.md
+++ b/docs/threat-models/openbank-domestic-payment.md
@@ -177,3 +177,31 @@ not change any existing request's outcome until explicitly flipped.
   separately-reviewed flip, not bundled with this change. No DB schema change (the AML case store's
   `alertCode` column already accepts arbitrary values); rollback = flip the flag back to `false` or
   revert the commit.
+
+- **2026-08-02** — **New inbound trust edge: the `delegation` namespace.** `#3414` added
+  `delegation` as an allowed ingress peer in this component's `network-policies.yaml`, so
+  `delegation-service` can now reach this service's API from inside the cluster. A NetworkPolicy is
+  coarse — it decides *reach*, not *permission* — so the actual authorization is unchanged and still
+  rests on OIDC (`@RolesAllowed`) plus the OPA sidecar (ADR-0034); this edge widens who may attempt a
+  call, not who may succeed. Risk class = **elevation of privilege** if a policy gap exists on an
+  endpoint that previously had no in-cluster caller: network reach was an implicit second control for
+  such endpoints and is now gone for this peer. Per ADR-0232 delegation-service holds
+  `DelegationGrant` and enforcement stays with the product services, which build their own local
+  projection — so a compromised or buggy delegation-service should not be able to grant access it
+  never had, and that property is the mitigation this edge depends on. Rollback: drop the
+  `namespaceSelector` entry for `delegation`. Recorded here because #3431's measurement showed this
+  change landed with no threat-model update.
+
+- **2026-08-02** — **New outbound trust edge: `account-service` party lookup.** `d949ce9ef` added
+  `AccountServiceClient.getById` (`GET /api/v1/accounts/{accountId}`) and wired `AmlCaseAdapter` to
+  call it with an OIDC client-credentials token, so an AML case carries the debtor's *party* id
+  rather than an account id (ADR-0032 follow-up, #3274). Risk class = **information disclosure**
+  (account→party linkage now crosses a service boundary) and **availability** (a second synchronous
+  dependency on the AML-case path). Mitigations already in the code: the call is bearer-authenticated
+  per request; every failure path is caught and returns `null`, so a lookup outage degrades the case
+  record rather than blocking the payment; and a 404 is deliberately not logged as a warning, so a
+  missing account is not treated as an error. Residual: `null` is indistinguishable between "no such
+  account" and "lookup failed", so a sustained outage silently reintroduces cases without a party id
+  — the exact condition #3274 exists to fix. Rollback: revert; the adapter's previous behaviour was
+  to store the account id in `partyId`. Recorded here because #3431's measurement showed this change
+  landed with no threat-model update.

--- a/docs/threat-models/openbank-sca-service.md
+++ b/docs/threat-models/openbank-sca-service.md
@@ -81,3 +81,17 @@ is the **authentication assurance gate** for payments and consent — defeating 
 - **2026-05-30** — Added `sca_outbox_seq` (Hibernate fix). Additive DDL only — no new flow/surface/
   boundary, no change to challenge/verify logic. Risk class = **availability**, mitigated by
   `HibernateSequenceGuardTest`. Rollback: `DROP SEQUENCE`.
+
+- **2026-08-02** — **New inbound trust edge: the `delegation` namespace.** `#3414` added
+  `delegation` as an allowed ingress peer in this component's `network-policies.yaml`, so
+  `delegation-service` can now reach this service's API from inside the cluster. A NetworkPolicy is
+  coarse — it decides *reach*, not *permission* — so the actual authorization is unchanged and still
+  rests on OIDC (`@RolesAllowed`) plus the OPA sidecar (ADR-0034); this edge widens who may attempt a
+  call, not who may succeed. Risk class = **elevation of privilege** if a policy gap exists on an
+  endpoint that previously had no in-cluster caller: network reach was an implicit second control for
+  such endpoints and is now gone for this peer. Per ADR-0232 delegation-service holds
+  `DelegationGrant` and enforcement stays with the product services, which build their own local
+  projection — so a compromised or buggy delegation-service should not be able to grant access it
+  never had, and that property is the mitigation this edge depends on. Rollback: drop the
+  `namespaceSelector` entry for `delegation`. Recorded here because #3431's measurement showed this
+  change landed with no threat-model update.

--- a/docs/threat-models/openbank-sepa-payment.md
+++ b/docs/threat-models/openbank-sepa-payment.md
@@ -168,3 +168,17 @@ from clearing-simulator (cluster-internal, `ROLE_SERVICE`). New trust boundary:
   existing request in this PR; flipping it is a tracked follow-up. No DB schema change (Redis,
   TTL-bounded); rollback = revert the commit (or leave `authz.four-eyes.enforce=false`, its
   default).
+
+- **2026-08-02** — **New inbound trust edge: the `delegation` namespace.** `#3414` added
+  `delegation` as an allowed ingress peer in this component's `network-policies.yaml`, so
+  `delegation-service` can now reach this service's API from inside the cluster. A NetworkPolicy is
+  coarse — it decides *reach*, not *permission* — so the actual authorization is unchanged and still
+  rests on OIDC (`@RolesAllowed`) plus the OPA sidecar (ADR-0034); this edge widens who may attempt a
+  call, not who may succeed. Risk class = **elevation of privilege** if a policy gap exists on an
+  endpoint that previously had no in-cluster caller: network reach was an implicit second control for
+  such endpoints and is now gone for this peer. Per ADR-0232 delegation-service holds
+  `DelegationGrant` and enforcement stays with the product services, which build their own local
+  projection — so a compromised or buggy delegation-service should not be able to grant access it
+  never had, and that property is the mitigation this edge depends on. Rollback: drop the
+  `namespaceSelector` entry for `delegation`. Recorded here because #3431's measurement showed this
+  change landed with no threat-model update.


### PR DESCRIPTION
## Summary

Two trust-boundary changes landed on `main` with no threat-model update; #3431's measurement found
them. This records both, with their residual risks. Documentation only — no code, no manifest, no
policy change.

## Type of change

- [ ] feat (new functionality)
- [ ] fix (bug fix)
- [ ] refactor (no behavior change)
- [ ] perf (performance)
- [x] docs
- [ ] chore (build / tooling)
- [ ] security (private until disclosed)
- [ ] breaking change

## Linked issues

Refs #3431, #3414, #3274

## What is recorded

**`8992de535` (#3414) — new inbound edge, the `delegation` namespace.** Added as an allowed ingress
peer in the accounts, payments and sca `network-policies.yaml`, so `delegation-service` can now
reach those APIs in-cluster. Recorded in `openbank-account-service.md`, `openbank-sepa-payment.md`,
`openbank-domestic-payment.md` and `openbank-sca-service.md`.

The framing matters more than the fact: a NetworkPolicy decides **reach, not permission**.
Authorization is unchanged and still rests on OIDC `@RolesAllowed` plus the OPA sidecar (ADR-0034).
What actually changed is that network reach was an implicit *second* control for any endpoint that
previously had no in-cluster caller, and for this peer it is gone — so the risk class is elevation
of privilege *iff* a policy gap exists on such an endpoint. ADR-0232 keeps enforcement with the
product services, which build their own local projection of `DelegationGrant`; a compromised
delegation-service should therefore not be able to grant access it never had, and that property is
what this edge leans on.

**`d949ce9ef` — new outbound edge, `account-service` party lookup.** `AccountServiceClient.getById`
plus `AmlCaseAdapter` resolving the debtor's party with an OIDC client-credentials token, so an AML
case carries a party id rather than an account id (#3274). Recorded in
`openbank-domestic-payment.md` with the mitigations already present in the code (per-request bearer,
every failure path caught, a 404 deliberately not logged as a warning) and the residual worth
naming: `null` is indistinguishable between "no such account" and "lookup failed", so a sustained
outage silently reintroduces cases with no party id — the exact condition #3274 exists to fix.

## Verification

- `check-threat-models.py` (coverage, enforced): OK.
- `check-threat-model-diff.py` on this branch: clean — this PR changes no trust boundary.

## A correction to what I wrote on #3431

I claimed the gate could not be graduated until these models were updated, because "both surviving
findings are already on `main`" and enforcement "would fail the next PR that happens to touch those
services". **That was wrong, and this PR is not a prerequisite for enforcing the gate.**

The gate is diff-scoped: it flags service S only when the PR's *own* diff contains a
boundary-changing file for S. A later PR touching the same service without moving a boundary is not
affected. Measured with the fixed gate from #3438 on three recent commits that touch money-path
services but no boundary file — `0be78ce4b`, `866612c7a`, `f7fc3651b` — all three are CLEAN. The
58-of-60 clean rate in #3438's measurement says the same thing.

Two things that misled me, both worth stating because they are repeatable:

1. My "re-run the measurement, it should reach 0 of 60" step is unachievable by construction.
   Replaying a historical commit will always flag, because the model update is not in *that*
   commit's diff. The measurement is a property of the past, not a target to drive to zero.
2. My first attempt to prove the diff-scoping reported the opposite — all three commits FLAG — 
   because this worktree branches from `origin/main`, where #3438 is not merged, so I was measuring
   with the *old* gate. Caught by checking whether `hunk_moves_boundary` existed in the file at all
   (0 occurrences here, 4 in the #3438 worktree).

So this PR is worth having on its own terms — two real edges are now documented instead of
undocumented — but #3431's graduation step does not depend on it.

## Definition of Done

- [ ] Unit/integration/contract tests — N/A, documentation only.
- [x] `check-threat-models.py` and `check-threat-model-diff.py` pass.
- [ ] OpenAPI / Flyway / Avro — N/A.
- [x] Docs updated — that is the whole change.

## Reviewer notes

- The delegation entry is deliberately identical across the four models; the edge is the same fact
  seen from four services, and paraphrasing it per file would let the four copies drift.
- Neither entry claims the change was wrong. Both were reasonable; they were simply undocumented,
  which is what a threat model is for.
