### PR TITLE
fix(lending): compliance-pack activation never worked — three defects behind one 403

### DIFF
--- a/openbank-lending-service/src/main/kotlin/com/openbank/lending/application/port/out/CompliancePackActivationRepository.kt
+++ b/openbank-lending-service/src/main/kotlin/com/openbank/lending/application/port/out/CompliancePackActivationRepository.kt
@@ -6,7 +6,10 @@ package com.openbank.lending.application.port.out
 
 import com.openbank.lending.infrastructure.persistence.entity.CompliancePackActivationEntity
 import com.openbank.libs.governance.ProposalState
+import io.quarkus.hibernate.reactive.panache.Panache
 import io.quarkus.hibernate.reactive.panache.PanacheRepositoryBase
+import io.quarkus.hibernate.reactive.panache.common.WithSession
+import io.quarkus.hibernate.reactive.panache.common.WithTransaction
 import io.smallrye.mutiny.Uni
 import jakarta.enterprise.context.ApplicationScoped
 import java.util.UUID
@@ -24,14 +27,29 @@ class JpaCompliancePackActivationRepository :
     CompliancePackActivationRepository,
     PanacheRepositoryBase<CompliancePackActivationEntity, UUID> {
 
+    /**
+     * `merge`, not `persist`. [CompliancePackActivationEntity.id] is assigned by the application
+     * (`Ids.newId()`), not by `@GeneratedValue`, so a non-null id cannot tell Hibernate a transient
+     * entity from a detached one: `persist`/`persistAndFlush` schedules an INSERT for BOTH, and the
+     * checker leg — which loads a PROPOSED row, flips its state and saves it — then dies at flush
+     * with `duplicate key value violates ... _pkey`. `merge` upserts and handles both.
+     *
+     * The same defect shipped in consent-service (#1521) and standing-order (#2079). It is invisible
+     * to any test that mocks this repository, which is why the coverage for it is a REST-driven
+     * integration test against a real database, not a unit test.
+     */
+    @WithTransaction
     override fun save(entity: CompliancePackActivationEntity): Uni<CompliancePackActivationEntity> =
-        persistAndFlush(entity).replaceWith(entity)
+        Panache.getSession().flatMap { it.merge(entity) }
 
+    @WithSession
     override fun findById(id: UUID): Uni<CompliancePackActivationEntity?> = find("id", id).firstResult()
 
+    @WithSession
     override fun findByState(state: ProposalState): Uni<List<CompliancePackActivationEntity>> =
         list("state = ?1 order by proposed_at", state)
 
+    @WithSession
     override fun findActivated(): Uni<List<CompliancePackActivationEntity>> = list(
         "state in ?1 order by jurisdiction, productType, packVersion",
         listOf(ProposalState.APPROVED, ProposalState.EXECUTED),

--- a/openbank-lending-service/src/main/kotlin/com/openbank/lending/application/usecase/CompliancePackActivationService.kt
+++ b/openbank-lending-service/src/main/kotlin/com/openbank/lending/application/usecase/CompliancePackActivationService.kt
@@ -78,14 +78,30 @@ class CompliancePackActivationService(
             } else {
                 proposal.reject(checker, now(), reason)
             }
-            if (approve) registry.activate(decided)
             entity.state = decided.state
             entity.decidedBy = decided.decidedBy
             entity.decidedAt = decided.decidedAt?.let { OffsetDateTime.ofInstant(it, clock.zone) }
             entity.decisionReason = decided.decisionReason
             entity.updatedAt = OffsetDateTime.now(clock)
-            entity
-        }.flatMap { activations.save(it) }.map { it.toView() }
+            entity to decided
+        }.flatMap { (entity, decided) ->
+            // Persist FIRST, activate only once the row is committed.
+            //
+            // The previous order activated the in-memory registry inside the map above, before the
+            // save. When the save failed, the caller got a 500 and reasonably concluded that nothing
+            // had happened — while THIS pod was already enforcing the pack, with no row to show for
+            // it. That state is invisible and does not survive: a restart loses it (boot rehydrates
+            // from the table), and sibling replicas never had it, so the same application would be
+            // judged against different rules depending on which pod answered.
+            //
+            // Measured, not theorised: with the persist-vs-merge defect still in place, the decide
+            // call returned 500 and `GET /compliance-packs/active` nonetheless listed the pack
+            // (CompliancePackActivationIT step 3 failing while step 4 passed).
+            activations.save(entity).map { saved ->
+                if (approve) registry.activate(decided)
+                saved.toView()
+            }
+        }
 
     fun listPending(): Uni<List<PackActivationView>> =
         activations.findByState(ProposalState.PROPOSED).map { rows -> rows.map { it.toView() } }

--- a/openbank-lending-service/src/test/kotlin/com/openbank/lending/integration/CompliancePackActivationIT.kt
+++ b/openbank-lending-service/src/test/kotlin/com/openbank/lending/integration/CompliancePackActivationIT.kt
@@ -1,0 +1,205 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright (c) OpenBank contributors. Licensed under the Apache License, Version 2.0.
+// See LICENSE in the repository root or https://www.apache.org/licenses/LICENSE-2.0 for details.
+
+package com.openbank.lending.integration
+
+import com.openbank.lending.it.PostgresRedisTestResource
+import io.quarkus.test.common.QuarkusTestResource
+import io.quarkus.test.junit.QuarkusTest
+import io.quarkus.test.security.TestSecurity
+import io.restassured.module.kotlin.extensions.Extract
+import io.restassured.module.kotlin.extensions.Given
+import io.restassured.module.kotlin.extensions.Then
+import io.restassured.module.kotlin.extensions.When
+import jakarta.inject.Inject
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.MethodOrderer
+import org.junit.jupiter.api.Order
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.TestInstance
+import org.junit.jupiter.api.TestMethodOrder
+import javax.sql.DataSource
+
+/**
+ * The ADR-0212 D4 four-eyes pack activation, driven end-to-end against a real database.
+ *
+ * WHY THIS TEST HAD TO EXIST BEFORE THE FEATURE COULD BE BELIEVED
+ *
+ * The whole workflow shipped — endpoints, `@RolesAllowed`, the maker-checker invariant, the console —
+ * and had never once been executed. OPA denied `lending.compliance.propose` outright (#3402), so the
+ * first request to reach the service body did so on 2026-08-02, and it found TWO defects stacked
+ * behind that 403:
+ *
+ *  1. `No current Mutiny.Session found` — the repository carried neither `@WithTransaction` nor
+ *     `@WithSession`, so every call failed before touching a row.
+ *  2. `persistAndFlush` on an application-assigned `@Id`. Hibernate cannot distinguish transient from
+ *     detached when the id is non-null either way, so it schedules an INSERT for both and the CHECKER
+ *     leg — which loads a PROPOSED row, flips its state and saves — dies at flush with
+ *     `duplicate key value violates ... _pkey`. Same defect as consent-service (#1521) and
+ *     standing-order (#2079).
+ *
+ * Neither is visible to a test that mocks `CompliancePackActivationRepository`, and defect 2 is not
+ * visible even to a real-DB test that only proposes: the INSERT is correct on the maker leg. It takes
+ * the SECOND write to the SAME row, which is why maker and checker are separate ordered tests here
+ * rather than one helper that asserts a happy path.
+ *
+ * A direct CDI call into a `@WithTransaction` repository from the bare test thread fails with
+ * "No current Vertx context found" — only a real HTTP request carries a Vert.x context — so the flow
+ * goes through the REST endpoints and the assertions read the table over plain JDBC.
+ */
+@QuarkusTest
+@TestInstance(TestInstance.Lifecycle.PER_CLASS)
+@TestMethodOrder(MethodOrderer.OrderAnnotation::class)
+@QuarkusTestResource(PostgresRedisTestResource::class)
+class CompliancePackActivationIT {
+
+    @Inject
+    lateinit var dataSource: DataSource
+
+    private lateinit var proposalId: String
+
+    /**
+     * The REAL shipped pack, with only its version changed. An invented payload would be rejected by
+     * `CompliancePackParser`/`CompliancePackCompiler` and the maker leg would fail for a reason that
+     * has nothing to do with what this test is about; version 999 keeps it from colliding with a
+     * genuinely activated `cz-consumer-credit-v1` in the same database.
+     */
+    private val pack: String by lazy {
+        val raw = checkNotNull(javaClass.getResourceAsStream("/compliance-packs/cz-consumer-credit-v1.json")) {
+            "the shipped CZ pack must be on the test classpath"
+        }.bufferedReader().readText()
+        raw.replace(Regex("\"version\"\\s*:\\s*1"), "\"version\": $PACK_VERSION")
+    }
+
+    private companion object {
+        const val PACK_VERSION = 999
+    }
+
+    @Test
+    @Order(1)
+    @TestSecurity(user = "pack-it-maker", roles = ["ROLE_COMPLIANCE"])
+    fun `1 - maker proposes a pack`() {
+        val response = Given {
+            contentType("application/json")
+            body(pack)
+        } When {
+            post("/api/v1/lending/compliance-packs/proposals")
+        } Then {
+            // 422 here is the "No current Mutiny.Session found" regression: the endpoint maps every
+            // business-rule failure to 422, so a missing @WithTransaction reads as a domain rejection.
+            statusCode(201)
+        } Extract {
+            this
+        }
+        proposalId = response.jsonPath().getString("id")
+        assertThat(proposalId).isNotBlank()
+
+        dataSource.connection.use { conn ->
+            conn.prepareStatement(
+                "SELECT state, proposed_by, decided_by FROM compliance_pack_activation WHERE id = ?::uuid",
+            ).use { st ->
+                st.setString(1, proposalId)
+                st.executeQuery().use { rs ->
+                    assertThat(rs.next()).describedAs("a compliance_pack_activation row for $proposalId").isTrue()
+                    assertThat(rs.getString("state")).isEqualTo("PROPOSED")
+                    assertThat(rs.getString("proposed_by")).isEqualTo("pack-it-maker")
+                    // Nobody has decided yet. A checker stamped at proposal time would mean the
+                    // four-eyes record is written by whoever proposes, which is the thing it prevents.
+                    assertThat(rs.getString("decided_by")).isNull()
+                }
+            }
+        }
+    }
+
+    @Test
+    @Order(2)
+    @TestSecurity(user = "pack-it-maker", roles = ["ROLE_COMPLIANCE"])
+    fun `2 - the maker cannot also be the checker`() {
+        Given {
+            contentType("application/json")
+            body("""{"approve":true,"reason":"same person"}""")
+        } When {
+            post("/api/v1/lending/compliance-packs/proposals/$proposalId/decide")
+        } Then {
+            // MakerCheckerViolation. This is the invariant the whole control exists for, so it is
+            // asserted before the happy path — a green happy path over a broken invariant is worse
+            // than no test, because it reads as the control working.
+            statusCode(422)
+        }
+
+        dataSource.connection.use { conn ->
+            conn.prepareStatement("SELECT state FROM compliance_pack_activation WHERE id = ?::uuid").use { st ->
+                st.setString(1, proposalId)
+                st.executeQuery().use { rs ->
+                    assertThat(rs.next()).isTrue()
+                    assertThat(
+                        rs.getString("state"),
+                    ).describedAs("a refused decision must not move the row").isEqualTo("PROPOSED")
+                }
+            }
+        }
+    }
+
+    @Test
+    @Order(3)
+    @TestSecurity(user = "pack-it-checker", roles = ["ROLE_COMPLIANCE"])
+    fun `3 - a different checker approves, and the row is UPDATED not re-inserted`() {
+        Given {
+            contentType("application/json")
+            body("""{"approve":true,"reason":"reviewed against ADR-0212"}""")
+        } When {
+            post("/api/v1/lending/compliance-packs/proposals/$proposalId/decide")
+        } Then {
+            // 500 here is the persist-vs-merge defect: this is the second write to the same primary
+            // key, so `persistAndFlush` fails with `duplicate key value violates ... _pkey`.
+            statusCode(200)
+        }
+
+        dataSource.connection.use { conn ->
+            conn.prepareStatement(
+                "SELECT state, proposed_by, decided_by FROM compliance_pack_activation WHERE id = ?::uuid",
+            ).use { st ->
+                st.setString(1, proposalId)
+                st.executeQuery().use { rs ->
+                    assertThat(rs.next()).isTrue()
+                    assertThat(rs.getString("state")).isIn("APPROVED", "EXECUTED")
+                    assertThat(rs.getString("proposed_by")).isEqualTo("pack-it-maker")
+                    assertThat(rs.getString("decided_by")).isEqualTo("pack-it-checker")
+                }
+            }
+
+            // Exactly one row. A merge that behaved like a persist would leave the original PROPOSED
+            // row and add a second one — the count is what distinguishes an UPDATE from an INSERT,
+            // and reading the row by id alone cannot.
+            conn.prepareStatement(
+                "SELECT count(*) FROM compliance_pack_activation WHERE pack_version = $PACK_VERSION",
+            ).use { st ->
+                st.executeQuery().use { rs ->
+                    rs.next()
+                    assertThat(
+                        rs.getInt(1),
+                    ).describedAs("the decision must UPDATE the proposal, not insert a second row").isEqualTo(1)
+                }
+            }
+        }
+    }
+
+    @Test
+    @Order(4)
+    @TestSecurity(user = "pack-it-reader", roles = ["ROLE_COMPLIANCE"])
+    fun `4 - the approved pack shows up as active`() {
+        val body = Given {
+            contentType("application/json")
+        } When {
+            get("/api/v1/lending/compliance-packs/active")
+        } Then {
+            statusCode(200)
+        } Extract {
+            asString()
+        }
+        // An empty list here is indistinguishable from "nothing activated yet" in the console, which
+        // is precisely how the OPA denial stayed invisible for the life of the feature (#3402).
+        assertThat(body).contains("\"packVersion\":$PACK_VERSION")
+    }
+}


### PR DESCRIPTION
The ADR-0212 D4 workflow shipped complete — endpoints, `@RolesAllowed`, the maker-checker invariant, persistence, the console — and had **never once been executed**. OPA denied `lending.compliance.propose` outright (#3402), so the first request ever to reach the service body did so on 2026-08-02, against the sandbox. It found three defects stacked behind that denial.

## 1. No session

`JpaCompliancePackActivationRepository` carried neither `@WithTransaction` nor `@WithSession`:

```
HTTP 422  No current Mutiny.Session found
```

The endpoint maps business-rule failures to 422, so a missing annotation reads as a *domain rejection* rather than a wiring fault.

## 2. Persist, not merge

`save()` called `persistAndFlush` on an entity whose `@Id` is assigned by the application (`Ids.newId()`), not `@GeneratedValue`. A non-null id cannot tell Hibernate transient from detached, so it schedules an INSERT for both — and the **checker** leg, which loads a PROPOSED row, flips its state and saves, dies at flush with `duplicate key value violates ... _pkey`. Same defect as consent-service (#1521) and standing-order (#2079).

## 3. Activate-before-persist

`decide()` called `registry.activate(decided)` **inside the map, before `activations.save()`**. When the save failed, the caller got a 500 and reasonably concluded that nothing had happened — while that pod was already enforcing the pack, with no row to show for it. A restart loses it (boot rehydrates from the table) and sibling replicas never had it, so **the same loan application is judged against different rules depending on which pod answers**.

This one was not looked for. It fell out of a **contradiction between two tests** in a run meant to prove something else: with defect 2 still in place, step 3 failed with 500 while step 4 still found the pack active. A green run of the fixed code would have left it in.

## Coverage

`CompliancePackActivationIT` drives maker and checker through the real REST endpoints against a Testcontainers Postgres and asserts over plain JDBC.

It has to be an integration test. A mocked repository cannot see any of this, and a real-DB test that only *proposes* cannot see defect 2 either — the INSERT is correct on the maker leg; it takes a **second write to the same row**. Maker and checker are therefore separate ordered tests rather than one happy-path helper.

It also asserts what must **not** happen: the maker cannot decide (422, and the row must not move), and the decision must UPDATE rather than insert a second row — which only `count(*)` can distinguish, never a read by id.

## Falsified three ways, not assumed

| run | result |
|---|---|
| fix applied | **4/4 pass** (+ 7/7 existing unit tests still green) |
| `origin/main`, unfixed | **4/4 fail** |
| annotations fixed, `persistAndFlush` kept | **step 3 alone fails, HTTP 500** |

The middle run alone would have been misread: steps 2 and 3 failed only by cascading on an uninitialised `proposalId`, so defect 2 was **hidden behind defect 1, not demonstrated**. The third run is what measures it.

## What this says about the 403

The OPA denial did not act as a gate, it acted as a **cover**. It kept three defects out of sight in code that every test layer called finished, and the feature read as shipped for its whole life. Worth remembering the next time an authorization fix "just" unblocks something.

Refs #3402, ADR-0212 D4
