### PR TITLE
fix(admin-ui): discover the delegation namespace

### DIFF
--- a/openbank-infra/gitops/components/admin-ui/admin-ui.yaml
+++ b/openbank-infra/gitops/components/admin-ui/admin-ui.yaml
@@ -75,7 +75,7 @@ spec:
             #   3. Add a RoleBinding for admin-ui-discovery below.
             # Adding a service *inside* an existing namespace is fully automatic.
             - name: OPENBANK_NAMESPACES
-              value: accounts,payments,compliance,identity,open-banking,platform,ledger,balances,audit,sanctions,security-scanner,onboarding,party,sca,statements,customer-edge,kyc,notifications,aml,consent,dispute,fraud,fx,interest,pid,psd2,documents,campaign,anacredit,billing,finrep,lending,sdd,tpp-registry
+              value: accounts,payments,compliance,identity,open-banking,platform,ledger,balances,audit,sanctions,security-scanner,onboarding,party,sca,statements,customer-edge,kyc,notifications,aml,consent,dispute,fraud,fx,interest,pid,psd2,documents,campaign,anacredit,billing,finrep,lending,sdd,tpp-registry,delegation
             # agent-service (MCP) is NOT reached via the discovery proxy: the
             # /api/agent/mcp and /api/agent/chat routes resolve it from this env
             # directly. Unset, they fall back to localhost:8109 (the admin-ui pod
@@ -847,6 +847,22 @@ kind: RoleBinding
 metadata:
   name: admin-ui-discovery
   namespace: tpp-registry
+  labels:
+    app.kubernetes.io/name: admin-ui
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: admin-ui-discovery
+subjects:
+  - kind: ServiceAccount
+    name: admin-ui
+    namespace: admin-ui
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: admin-ui-discovery
+  namespace: delegation
   labels:
     app.kubernetes.io/name: admin-ui
 roleRef:


### PR DESCRIPTION
`service-registry.guard.test.ts` has been red on `main` since #3414 landed delegation-service's gitops component:

```
AssertionError: namespaces running an openbank service that admin-ui discovery cannot see.
+ [ "delegation (not in OPENBANK_NAMESPACES) (no RoleBinding)" ]
```

The consequence is the one the assertion message states: the console renders **"not responding" for delegation-service against healthy pods**.

## The fix is the one the file prescribes

`admin-ui.yaml` says it in place:

> Adding a domain namespace is therefore a reviewed two-line change: a new RoleBinding here **AND** a bump to `OPENBANK_NAMESPACES` above.

```
OPENBANK_NAMESPACES   34 → 35 entries
RoleBindings          34 → 35
```

Both are required and they do different jobs — RBAC is the authoritative boundary so a compromised admin-ui SA cannot enumerate outside its domain, while `OPENBANK_NAMESPACES` is the app-level filter. Adding one without the other leaves the namespace undiscoverable either way, which is exactly the state #3414 left.

## Verified by running the guard's own computation

Rather than trusting that I hit both places, I re-ran what the test does — walk every `Deployment`/`Rollout` under `openbank-infra/gitops`, collect namespaces of workloads named `openbank-*` or `*-service`, and diff against both lists:

```
gitops workload namespaces   31
in OPENBANK_NAMESPACES       35
with a RoleBinding           35
missing                      []   → the assertion passes
```

And validated against a known positive — the same computation on the pre-fix file:

```
missing                      ['delegation']
```

So the probe distinguishes the two states rather than reporting clean by construction.

`admin-ui.yaml` parses as 40 documents, 35 of them `RoleBinding`.

Refs #3414
