### PR TITLE
fix(gitops): a service the gate cannot evaluate must drop out of the batch, not take it down

### DIFF
--- a/.github/workflows/auto-deploy.yml
+++ b/.github/workflows/auto-deploy.yml
@@ -906,12 +906,14 @@ jobs:
             sel_line="$(PACT_VERSION_PRESENT="$vpresent" EVENT_NAME="$GITHUB_EVENT_NAME" \
               bash .github/scripts/resolve-can-i-deploy-selector.sh "$svc" "$GITHUB_SHA")"
             read -ra CID_SELECTOR <<< "$(printf '%s' "$sel_line" | cut -f1)"
-            # REFUSE (#3318): a manual dispatch of a sha with no pact version. Stop rather
-            # than gate it on a different commit — see the selector script's header.
+            # REFUSE (#3318): a manual dispatch of a sha with no pact version. Skip THIS
+            # service — aborting the batch is the #846 shape (#3445).
             if [ "${CID_SELECTOR[0]}" = "REFUSE" ]; then
-              echo "::error::can-i-deploy: $(printf '%s' "$sel_line" | cut -f2)"
-              echo "deployable=[]" >> "$GITHUB_OUTPUT"
-              exit 1
+              refuse_why="$(printf '%s' "$sel_line" | cut -f2)"
+              echo "::error::can-i-deploy: ${refuse_why}"
+              printf '===SERVICE %s\n%s\n' "$svc" "$refuse_why" >> "$BLOCKS_FILE"
+              rc=1  # keep the job red (ADR-0092); only the batch survives
+              continue
             fi
             echo "==> can-i-deploy ${svc} (${CID_SELECTOR[*]}) → environment sandbox"
             echo "    $(printf '%s' "$sel_line" | cut -f2)"


### PR DESCRIPTION
## What

REFUSE (#3318) correctly declines to gate a service on a commit it has no pact version for.
It then set deployable=[] and exit 1 from inside the per-service loop, discarding the
verdicts already computed for every other service. A whole-fleet dispatch carries ~54, and
openbank-delegation-service -- in ALL_SERVICES, no pacts yet (#2991) -- made every
workflow_dispatch and schedule run since 18:42 UTC deploy nothing.

That is the shape this file already documents twenty lines above the code that reintroduced
it: "ONE blocked service in a fleet-wide batch permanently starved the broker's
deployed-version matrix for every service in that batch, including the healthy ones" (#846).
The deployable/blocked split exists so a partial failure still deploys the passing subset.

Drop the service and continue, recording it in BLOCKS_FILE so the summary and the classifier
name it. #3318's intent is untouched: it is still not gated against the wrong commit, and it
still does not deploy.

rc=1 in that branch is load-bearing and was added only because the harness caught its
absence. rc is set to 1 at the failure path AFTER the CLI call, which `continue` skips -- so
without it a run whose only block was a refusal exited 0, turning a red gate green for a
money-path service. Both versions now exit 1; only the batch survives.

Verified by extracting the step's run: block from the workflow (not a retyped copy) and
running it against stubs, each validated against a known-positive first:

  ORIGINAL  exit=1  deployable=[]
  FIXED     exit=1  deployable=["openbank-aaa","openbank-zzz"]
                    blocked=["openbank-delegation-service"]

Under bash 5, deliberately: on macOS bash 3.2 the script dies earlier at
${block_class[$svc]} because 3.2 has no associative arrays, and exits 0 while doing it --
which reads exactly like "the fix made the job green" and is a property of the harness, not
the code.

actionlint and yamllint finding SETS are identical to origin/main (diffed, not eyeballed --
both files carry pre-existing SC2086, runner-label and line-length findings). The
can-i-deploy run: block is 18207 chars against the 19000 limit, so the reasoning above lives
here rather than in the workflow (#3135).

Closes #3445
Refs #3318, #3306, #2991

Co-Authored-By: Claude Opus 5 <noreply@anthropic.com>
