### PR TITLE
ci(gates): enforce the threat-model-diff gate (#3431)

### DIFF
--- a/.github/gates/gates.yaml
+++ b/.github/gates/gates.yaml
@@ -1347,21 +1347,29 @@ gates:
   # ADR-0144) — findings are ::warning annotations; add --enforce to flip.
   # PR-only: the gate diffs against the resolved PR diff base (see above).
   - id: threat-model-updated-on-trust-boundary-change
-    name: "threat-model updated on trust-boundary change (ADR-0030 D2, advisory)"
+    name: "threat-model updated on trust-boundary change (ADR-0030 D2, enforced)"
     group: security
-    mode: advisory
+    mode: enforced
     when: pull_request
     needs_base: required
     selftest: python3 openbank-infra/scripts/check-threat-model-diff.py --self-test
     selftest_expect: pass
     run: |
-      # Advisory by ADR-0144 graduation, NOT because the finding is optional: a
-      # threat model that no longer describes the service is how #3378 shipped —
-      # openbank-sanctions-service satisfied the enforced coverage gate for nine
-      # months while omitting sanctions.clear entirely. Graduating this to
-      # `enforced` is tracked in #3431; the blocker was a 7-of-60 false-positive
-      # rate on generated manifest churn, fixed here (now 2 of 60, both real).
-      python3 openbank-infra/scripts/check-threat-model-diff.py --base "${PR_DIFF_BASE}"
+      # BOTH the mode above and --enforce below are required, and neither alone does
+      # anything (#2392): the script prints ::warning and exits 0 unless passed
+      # --enforce, so `mode: enforced` on its own leaves the runner seeing rc=0 and
+      # reporting a permanently green gate that blocks nothing. Measured on #3431:
+      # `--base d949ce9ef^ --head d949ce9ef` exits 0 without the flag and 1 with it.
+      #
+      # Graduated from advisory in #3431 after the scope fix in #3438 took the
+      # false-positive rate from 7-of-60 to 2-of-60 (both survivors real). What this
+      # now blocks: a PR that moves a money-path service's trust boundary — an
+      # inbound REST surface, an outbound client edge, authn/listener keys in
+      # application.yaml, a NetworkPolicy, or a Deployment hunk touching ports,
+      # identity or privilege — without updating that service's threat model in the
+      # same diff. Generated churn (policy-checksum restamps, image tags) does not
+      # count; see hunk_moves_boundary and the gate's --self-test.
+      python3 openbank-infra/scripts/check-threat-model-diff.py --base "${PR_DIFF_BASE}" --enforce
 
   - id: compliance-page-evidence
     name: "Compliance-page evidence (issue #2370, enforced)"


### PR DESCRIPTION
## Summary

Graduates `threat-model-updated-on-trust-boundary-change` from advisory to enforced, the remaining
step of #3431. One gate entry changes; no script logic changes.

**This blocks other people's PRs from the moment it merges** — see "What this blocks" below before
approving.

## Type of change

- [ ] feat (new functionality)
- [ ] fix (bug fix)
- [ ] refactor (no behavior change)
- [ ] perf (performance)
- [ ] docs
- [x] chore (build / tooling)
- [ ] security (private until disclosed)
- [ ] breaking change

## Linked issues

Closes #3431

## Two changes, and neither alone does anything

This is the #2392 trap, and it is the reason this PR is not a one-word diff:

```
mode: advisory  ->  mode: enforced
python3 …/check-threat-model-diff.py --base "${PR_DIFF_BASE}"
  ->  python3 …/check-threat-model-diff.py --base "${PR_DIFF_BASE}" --enforce
```

The script prints `::warning` and **exits 0** unless passed `--enforce`. `run-gates.py` maps
`rc == 0` to `ok` regardless of mode. So flipping only `mode:` produces a gate that is *declared*
enforced, reports green forever, and blocks nothing — the vacuous-green class this repo works hard
to avoid. Measured:

```
--base d949ce9ef^ --head d949ce9ef            -> exit 0   (the command gates.yaml runs today)
--base d949ce9ef^ --head d949ce9ef --enforce  -> exit 1
```

## Falsified both ways, through the runner

Not just the script — the runner's status mapping is the thing that actually decides a PR's fate:

```
PR_DIFF_BASE=d949ce9ef^  run-gates.py --only <id>  ->  1 gates  FAIL=1
    ::error title=…::gate failed: threat-model updated on trust-boundary change (…, enforced)

PR_DIFF_BASE=origin/main run-gates.py --only <id>  ->  1 gates  PASS=1
```

The known-positive is a real commit: `d949ce9ef` added an outbound `infrastructure/client` edge to
domestic-payment with no threat-model update in the same diff. The known-negative is this PR, which
moves no boundary.

The gate's own `--self-test` (added in #3438, seven cases) runs on every invocation and still
passes.

## What this blocks

A PR that moves a money-path service's trust boundary without updating that service's threat model
**in the same diff**:

- an inbound REST surface (`infrastructure/rest/**`)
- an outbound client edge (`infrastructure/client/**`, or an adapter that speaks HTTP/gRPC)
- authn / listener / transport keys in `application.yaml` (matched on the diff hunks)
- a `network-policies.yaml` change — any change; a NetworkPolicy is reach by construction
- a Deployment/Rollout **hunk** touching ports, identity, privilege or auth-shaped env

Explicitly not blocked: generated churn. A `policy-checksum` restamp (which one `rules.yaml` edit
applies to ~29 manifests at once) and an auto-deploy image tag are filtered by
`hunk_moves_boundary`, which is what took the rate from 7-of-60 to 2-of-60 in #3438.

## Why the historical flags do not matter

`8992de535`, `d949ce9ef` and `c7a78ff10` still flag when replayed. That is inherent to a diff-scoped
gate — the model update lives in a later commit (#3447), not in theirs — and it has no effect on any
future PR, because the gate only inspects the diff in front of it. Verified: `0be78ce4b`,
`866612c7a`, `f7fc3651b` all touch money-path services and are CLEAN.

I got this wrong first time round on #3431 and corrected it there; repeating the correction here so
a reviewer does not re-derive the same wrong conclusion from the replay numbers.

## Definition of Done

- [ ] Unit tests — N/A; the gate's `--self-test` is its test and is unchanged.
- [x] Falsified: known-positive FAILs, known-negative PASSes, through `run-gates.py`.
- [x] `gates.yaml` parses; `check-advisory-gate-registration.py`'s declared-mode contract is
      satisfied (name and `mode:` both say enforced).
- [ ] OpenAPI / Flyway / Avro — N/A.

## Reviewer notes

- The one judgement call: an author who legitimately changes a boundary must now edit a threat model
  in the same PR. That is the intent of ADR-0030 D2, but it is friction, and it lands on whoever
  opens the next such PR rather than on us. If you would rather stage it, the alternative is to
  merge this when the next boundary-changing PR is already expecting it.
- Rollback is one line each way, and the gate keeps working advisory-style if only `--enforce` is
  dropped.
