### PR TITLE
feat(keycloak): add a second ROLE_COMPLIANCE principal so four-eyes is completable

### DIFF
--- a/openbank-infra/gitops/components/keycloak/realm-template.json
+++ b/openbank-infra/gitops/components/keycloak/realm-template.json
@@ -413,6 +413,25 @@
       ]
     },
     {
+      "username": "compliance2@openbank.local",
+      "email": "compliance2@openbank.local",
+      "firstName": "Compliance Two",
+      "lastName": "OpenBank",
+      "enabled": true,
+      "emailVerified": true,
+      "credentials": [
+        {
+          "type": "password",
+          "value": "__COMPLIANCE2_USER_PASSWORD__",
+          "temporary": false
+        }
+      ],
+      "realmRoles": [
+        "ROLE_COMPLIANCE",
+        "ROLE_VIEWER"
+      ]
+    },
+    {
       "username": "service-account-openbank-edge",
       "enabled": true,
       "serviceAccountClientId": "openbank-edge",


### PR DESCRIPTION
## The realm had exactly one ROLE_COMPLIANCE account

The OPA rule that permits pack activation (`compliance-lending-desk`) requires `ROLE_COMPLIANCE` for **both** legs, and `CompliancePackActivationService` raises `MakerCheckerViolation` when the maker and checker JWT subjects match. With a single such account the two conditions cannot both be satisfied: **ADR-0212 D4 activation is uncompletable by anyone, in any environment.**

That is the third independent blocker on the same control, after the OPA denial (#3402) and the persistence defects (#3448). Each one looked like the whole problem while it was merely the one in front.

## Naming carries no ordering

Either account may propose and either may decide. The service requires only that the two subjects **differ**, which is the property four-eyes actually needs. Binding "maker" and "checker" to fixed identities would make the control *weaker*, not stronger — it would tell an attacker which single account to take over.

## Credentials

Follows the existing pattern: a `__COMPLIANCE2_USER_PASSWORD__` placeholder here, the value only ever in the secret store. Nothing about it is in this repository.

## Deploying this

**Realm import runs on cold start only**, so merging this does not create the account in a running Keycloak. The live sandbox account was created through the admin API separately; this file is what makes it survive a rebuild.

Verified live, including the negative:

```
compliance@openbank.local     enabled=True  roles=[ROLE_COMPLIANCE, ROLE_VIEWER]
compliance2@openbank.local    enabled=True  roles=[ROLE_COMPLIANCE, ROLE_VIEWER]
distinct subjects: True          <- what MakerCheckerViolation compares
login with the stored password:  OK
login with a wrong password:     400
```

Refs ADR-0212 D4, #3402, #3448
