### PR TITLE
fix(admin-ui): de-duplicate the delegation discovery entry

### DIFF
--- a/openbank-infra/gitops/components/admin-ui/admin-ui.yaml
+++ b/openbank-infra/gitops/components/admin-ui/admin-ui.yaml
@@ -75,7 +75,7 @@ spec:
             #   3. Add a RoleBinding for admin-ui-discovery below.
             # Adding a service *inside* an existing namespace is fully automatic.
             - name: OPENBANK_NAMESPACES
-              value: accounts,payments,compliance,identity,open-banking,platform,ledger,balances,audit,sanctions,security-scanner,onboarding,party,sca,statements,customer-edge,kyc,notifications,aml,consent,dispute,fraud,fx,interest,pid,psd2,documents,campaign,anacredit,billing,finrep,lending,sdd,tpp-registry,delegation,delegation
+              value: accounts,payments,compliance,identity,open-banking,platform,ledger,balances,audit,sanctions,security-scanner,onboarding,party,sca,statements,customer-edge,kyc,notifications,aml,consent,dispute,fraud,fx,interest,pid,psd2,documents,campaign,anacredit,billing,finrep,lending,sdd,tpp-registry,delegation
             # agent-service (MCP) is NOT reached via the discovery proxy: the
             # /api/agent/mcp and /api/agent/chat routes resolve it from this env
             # directly. Unset, they fall back to localhost:8109 (the admin-ui pod
@@ -847,22 +847,6 @@ kind: RoleBinding
 metadata:
   name: admin-ui-discovery
   namespace: tpp-registry
-  labels:
-    app.kubernetes.io/name: admin-ui
-roleRef:
-  apiGroup: rbac.authorization.k8s.io
-  kind: ClusterRole
-  name: admin-ui-discovery
-subjects:
-  - kind: ServiceAccount
-    name: admin-ui
-    namespace: admin-ui
----
-apiVersion: rbac.authorization.k8s.io/v1
-kind: RoleBinding
-metadata:
-  name: admin-ui-discovery
-  namespace: delegation
   labels:
     app.kubernetes.io/name: admin-ui
 roleRef:


### PR DESCRIPTION
#3450 and #3460 fixed the same defect independently and both merged, ~17 minutes apart. `delegation` is now in the file twice.

**#3450 is mine.** I found the red guard test, wrote the fix, and never asked whether anyone else was already on it — the exact check I added to `CLAUDE.md` this morning after three collisions in one day.

## ArgoCD noticed

```
RepeatedResourceWarning
Resource rbac.authorization.k8s.io/RoleBinding/delegation/admin-ui-discovery
appeared 2 times among application resources.
```

Not an outage: the two blocks are byte-identical, the cluster holds one RoleBinding, and `admin-ui` is `Synced / Healthy` at revision `7065f5834`. But the warning is real, and a file that states a thing twice is one edit away from stating it two different ways.

```
                        before   after
OPENBANK_NAMESPACES        36      35
RoleBindings               36      35
delegation appears          2×      1×
```

## Still satisfies the guard

Re-ran the computation `service-registry.guard.test.ts` performs — every `Deployment`/`Rollout` namespace under `openbank-infra/gitops` for workloads named `openbank-*` or `*-service`, diffed against both lists:

```
missing namespaces: []
```

So this removes the duplication without reopening what the two PRs were fixing.

## Note on the class

Worth recording where this fits: `gh pr view --json files` could not have shown it, because at the time each PR was written the other had not merged. What would have shown it is asking "is anyone else already fixing this red test" before starting — one `gh pr list --search` against the failing test name. Cheap, and I skipped it.

Refs #3450, #3460
