### PR TITLE
feat(admin-ui): let an operator dispose of a sanctions hit

### DIFF
--- a/openbank-admin-ui/src/app/api/sanctions/approvals/[id]/route.ts
+++ b/openbank-admin-ui/src/app/api/sanctions/approvals/[id]/route.ts
@@ -1,0 +1,30 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright (c) OpenBank contributors. Licensed under the Apache License, Version 2.0.
+// See LICENSE in the repository root or https://www.apache.org/licenses/LICENSE-2.0 for details.
+
+import { NextRequest } from 'next/server'
+import { forwardToSanctionsService } from '@/lib/sanctions/upstream'
+
+export const dynamic = 'force-dynamic'
+
+/**
+ * Checker half of the four-eyes gate on `sanctions.clear` (ADR-0155, issue #3334).
+ *
+ * Without this route the ceremony is half-built: the maker could submit a review from the UI and
+ * then wait on a checker who has no way to decide except curl. `ApprovalResource.decide` is a
+ * PATCH, and the self-approval guard lives in `RedisApprovalStore.decide` — a DIFFERENT principal
+ * must decide, enforced server-side, so this route deliberately adds no check of its own (see
+ * #3349 for the fact that guard has no test feeding it a maker approving themselves).
+ *
+ * A maker deciding their own request gets 403 from the shared `SelfApprovalNotAllowedMapper`,
+ * which the helper surfaces as `upstream_error` with the status preserved.
+ */
+export async function PATCH(req: NextRequest, { params }: { params: Promise<{ id: string }> }) {
+  const { id } = await params
+  const body = await req.json()
+  return forwardToSanctionsService(
+    `/api/v1/sanctions/approvals/${encodeURIComponent(id)}`,
+    'PATCH',
+    body,
+  )
+}

--- a/openbank-admin-ui/src/app/api/sanctions/lists/[id]/refresh/route.ts
+++ b/openbank-admin-ui/src/app/api/sanctions/lists/[id]/refresh/route.ts
@@ -2,25 +2,24 @@
 // Copyright (c) OpenBank contributors. Licensed under the Apache License, Version 2.0.
 // See LICENSE in the repository root or https://www.apache.org/licenses/LICENSE-2.0 for details.
 
-import { NextRequest, NextResponse } from 'next/server'
-
-const BASE = process.env.SANCTIONS_SERVICE_URL ?? 'http://openbank-sanctions-service:8123'
+import { NextRequest } from 'next/server'
+import { forwardToSanctionsService } from '@/lib/sanctions/upstream'
 
 export const dynamic = 'force-dynamic'
 
+/**
+ * Trigger a refresh of one sanctions list. `id` here is the listType (e.g. OFAC_SDN), not a uuid.
+ *
+ * Moved onto the shared helper in #3334, same reason as the sibling PUT: it hand-rolled its fetch
+ * and sent no `Authorization`, so an operator's manual refresh 401'd against a healthy service.
+ * Keeps the longer 15s budget — a refresh fetches and parses a real upstream feed.
+ */
 export async function POST(_req: NextRequest, { params }: { params: Promise<{ id: string }> }) {
-  try {
-    // id here is the listType (e.g. OFAC_SDN)
-    const { id } = await params
-    const res = await fetch(`${BASE}/api/v1/sanctions/lists/${id}/refresh`, {
-      method: 'POST',
-      headers: { Accept: 'application/json' },
-      cache: 'no-store',
-      signal: AbortSignal.timeout(15_000),
-    })
-    const data = await res.json().catch(() => ({}))
-    return NextResponse.json(data, { status: res.status })
-  } catch (error) {
-    return NextResponse.json({ error: error instanceof Error ? error.message : 'Refresh failed' }, { status: 502 })
-  }
+  const { id } = await params
+  return forwardToSanctionsService(
+    `/api/v1/sanctions/lists/${encodeURIComponent(id)}/refresh`,
+    'POST',
+    undefined,
+    15_000,
+  )
 }

--- a/openbank-admin-ui/src/app/api/sanctions/lists/[id]/route.ts
+++ b/openbank-admin-ui/src/app/api/sanctions/lists/[id]/route.ts
@@ -2,26 +2,22 @@
 // Copyright (c) OpenBank contributors. Licensed under the Apache License, Version 2.0.
 // See LICENSE in the repository root or https://www.apache.org/licenses/LICENSE-2.0 for details.
 
-import { NextRequest, NextResponse } from 'next/server'
-
-const BASE = process.env.SANCTIONS_SERVICE_URL ?? 'http://openbank-sanctions-service:8123'
+import { NextRequest } from 'next/server'
+import { forwardToSanctionsService } from '@/lib/sanctions/upstream'
 
 export const dynamic = 'force-dynamic'
 
+/**
+ * Enable/disable a sanctions list, or patch its cron/source URL. Operator-mutating against an
+ * OIDC-gated upstream.
+ *
+ * Moved onto the shared helper in #3334. #3336 fixed `checks`, `lists` and `screen`, but this
+ * route and `lists/[id]/refresh` kept their own fetch and their own missing `Authorization`
+ * header — the same defect, on the same screen, still live. The old `catch` also returned the
+ * upstream error message verbatim, which #3336 removed everywhere else (ADR-0080 P1).
+ */
 export async function PUT(req: NextRequest, { params }: { params: Promise<{ id: string }> }) {
-  try {
-    const { id } = await params
-    const body = await req.json()
-    const res = await fetch(`${BASE}/api/v1/sanctions/lists/${id}`, {
-      method: 'PUT',
-      headers: { 'Content-Type': 'application/json', Accept: 'application/json' },
-      body: JSON.stringify(body),
-      cache: 'no-store',
-      signal: AbortSignal.timeout(10_000),
-    })
-    const data = await res.json().catch(() => ({ error: 'Invalid JSON' }))
-    return NextResponse.json(data, { status: res.status })
-  } catch (error) {
-    return NextResponse.json({ error: error instanceof Error ? error.message : 'Update failed' }, { status: 502 })
-  }
+  const { id } = await params
+  const body = await req.json()
+  return forwardToSanctionsService(`/api/v1/sanctions/lists/${encodeURIComponent(id)}`, 'PUT', body)
 }

--- a/openbank-admin-ui/src/app/api/sanctions/review/route.ts
+++ b/openbank-admin-ui/src/app/api/sanctions/review/route.ts
@@ -1,0 +1,36 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright (c) OpenBank contributors. Licensed under the Apache License, Version 2.0.
+// See LICENSE in the repository root or https://www.apache.org/licenses/LICENSE-2.0 for details.
+
+import { NextRequest } from 'next/server'
+import { forwardToSanctionsService } from '@/lib/sanctions/upstream'
+
+export const dynamic = 'force-dynamic'
+
+/**
+ * Manual disposition of a screening hit (issue #3334).
+ *
+ * `POST /api/v1/sanctions/review` had no caller anywhere in the product: no route here, no UI
+ * control, and no M2M client (all six SanctionsServiceClient interfaces declare only /screen).
+ * So a HIT/POTENTIAL_HIT could not be cleared, whitelisted or escalated without hand-crafting a
+ * request against api.open-bank.tech, while the screen rendered a "Pending Review" queue with no
+ * way to work it. 5AMLD Art. 13 manual review, and per rules.yaml the highest-risk action in that
+ * service.
+ *
+ * Four-eyes (ADR-0155): the upstream answers 202 + {status, approvalId} when OPA flags
+ * `sanctions.clear` as four_eyes_required. That is a normal outcome, not a failure — 202 is
+ * `res.ok`, so the helper forwards the body untouched and the client can show the approval id.
+ * The maker then retries this route with `X-Approval-Id`, which MUST reach the upstream: the
+ * interceptor reads it off the request, and without it every retry mints a fresh approval and
+ * answers 202 again — an infinite loop in which each individual call looks healthy.
+ */
+export async function POST(req: NextRequest) {
+  const body = await req.json()
+
+  // Allow-list, not a pass-through of req.headers: forwarding the browser's header set to an
+  // OIDC-gated backend is how a BFF leaks cookies or lets a caller override Authorization.
+  const approvalId = req.headers.get('x-approval-id')
+  const extraHeaders = approvalId ? { 'X-Approval-Id': approvalId } : undefined
+
+  return forwardToSanctionsService('/api/v1/sanctions/review', 'POST', body, 10_000, extraHeaders)
+}

--- a/openbank-admin-ui/src/app/sanctions/page.tsx
+++ b/openbank-admin-ui/src/app/sanctions/page.tsx
@@ -3,7 +3,7 @@
 // See LICENSE in the repository root or https://www.apache.org/licenses/LICENSE-2.0 for details.
 
 'use client'
-import { useState, useEffect, useCallback } from 'react'
+import { useState, useEffect, useCallback, Fragment } from 'react'
 import {
   ShieldAlert, Search, CheckCircle2, Clock, RefreshCw,
   AlertTriangle, User, Play, List, ChevronDown, ChevronUp,
@@ -32,6 +32,18 @@ interface SanctionsList {
 
 interface ApiError {
   error?: string
+}
+
+// The upstream enum (openapi.yaml ReviewCommand.newStatus). POTENTIAL_HIT is deliberately absent
+// from the picker: a review that leaves the check pending is a no-op that still consumes a
+// four-eyes approval.
+type ReviewStatus = 'CLEAR' | 'HIT' | 'WHITELISTED' | 'ESCALATED'
+
+// 202 + this body is the four-eyes pause, not an error (ADR-0155). `res.ok` covers 202, so the
+// BFF forwards it untouched.
+interface PendingApprovalResponse {
+  status?: string
+  approvalId?: string
 }
 
 const DAYS = ['MON','TUE','WED','THU','FRI','SAT','SUN']
@@ -180,6 +192,21 @@ export default function SanctionsPage() {
   const [selectedListTypes, setSelectedListTypes] = useState<string[]>([])
   const [listScopeInitialised, setListScopeInitialised] = useState(false)
 
+  // Manual disposition of a hit (issue #3334). POST /api/v1/sanctions/review existed, was
+  // publicly routed and had no caller anywhere in the product — so this queue could only grow.
+  const [reviewFor, setReviewFor] = useState<string | null>(null)
+  const [reviewStatus, setReviewStatus] = useState<ReviewStatus>('CLEAR')
+  const [reviewNote, setReviewNote] = useState('')
+  const [reviewBusy, setReviewBusy] = useState(false)
+  const [reviewError, setReviewError] = useState('')
+  // Four-eyes (ADR-0155): a 202 parks the maker's decision until a DIFFERENT operator decides it.
+  // The id has to survive in the UI — it is the only way back to this exact decision, and the
+  // retry must carry it as X-Approval-Id or the interceptor mints a fresh one and 202s forever.
+  const [pendingApproval, setPendingApproval] = useState<{ id: string; checkId: string } | null>(null)
+  const [decideId, setDecideId] = useState('')
+  const [decideBusy, setDecideBusy] = useState(false)
+  const [decideMsg, setDecideMsg] = useState('')
+
   const loadChecks = useCallback(async () => {
     setLoading(true)
     try {
@@ -307,6 +334,98 @@ export default function SanctionsPage() {
     setRefreshingAll(false)
   }
 
+  const openReview = (c: SanctionCheck) => {
+    setReviewFor(c.id)
+    // Pre-select the safer direction: ESCALATED for a confirmed HIT, CLEAR for a potential one.
+    // Never pre-select CLEAR on a HIT — a wrongly-cleared true positive is a real sanctions
+    // violation (rules.yaml), and a default is a decision most people accept.
+    setReviewStatus(c.status === 'HIT' ? 'ESCALATED' : 'CLEAR')
+    setReviewNote('')
+    setReviewError('')
+    setPendingApproval(null)
+  }
+
+  /** Submit a disposition. `approvalId` is set only on the post-approval retry. */
+  const submitReview = async (checkId: string, approvalId?: string) => {
+    if (!reviewNote.trim()) {
+      setReviewError(t('Poznámka je povinná — je to auditní stopa rozhodnutí.', 'A note is required — it is the audit trail for this decision.'))
+      return
+    }
+    setReviewBusy(true)
+    setReviewError('')
+    try {
+      const res = await fetch('/api/sanctions/review', {
+        method: 'POST',
+        headers: {
+          'Content-Type': 'application/json',
+          ...(approvalId ? { 'X-Approval-Id': approvalId } : {}),
+        },
+        body: JSON.stringify({ checkId, note: reviewNote.trim(), newStatus: reviewStatus }),
+      })
+
+      if (res.status === 202) {
+        const parked = await res.json().catch(() => ({})) as PendingApprovalResponse
+        if (parked.approvalId) {
+          setPendingApproval({ id: parked.approvalId, checkId })
+          setReviewError('')
+        } else {
+          // 202 without an id would leave the decision unreachable — say so rather than
+          // rendering a success that never completes.
+          setReviewError(t('Služba vrátila 202 bez approvalId — rozhodnutí nelze dokončit.', 'The service returned 202 with no approvalId — this decision cannot be completed.'))
+        }
+        return
+      }
+
+      if (!res.ok) {
+        const payload = await res.json().catch(() => ({})) as ApiError
+        setReviewError(payload.error === 'unauthorized'
+          ? t('Nemáte oprávnění k tomuto rozhodnutí.', 'You are not authorised to make this decision.')
+          : t(`Rozhodnutí se nepodařilo uložit (HTTP ${res.status}).`, `Could not record the decision (HTTP ${res.status}).`))
+        return
+      }
+
+      setReviewFor(null)
+      setPendingApproval(null)
+      setReviewNote('')
+      await loadChecks()
+    } catch {
+      setReviewError(t('Služba je nedostupná.', 'The service is unreachable.'))
+    } finally {
+      setReviewBusy(false)
+    }
+  }
+
+  /** Checker half of the four-eyes gate. A maker deciding their own request gets 403 upstream. */
+  const decideApproval = async (approve: boolean) => {
+    const id = decideId.trim()
+    if (!id) return
+    setDecideBusy(true)
+    setDecideMsg('')
+    try {
+      const res = await fetch(`/api/sanctions/approvals/${encodeURIComponent(id)}`, {
+        method: 'PATCH',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ approve }),
+      })
+      if (res.status === 403) {
+        setDecideMsg(t('Zamítnuto: vlastní žádost nelze schválit (oddělení pravomocí).', 'Refused: you cannot decide your own request (segregation of duties).'))
+        return
+      }
+      if (!res.ok) {
+        setDecideMsg(t(`Rozhodnutí selhalo (HTTP ${res.status}).`, `Decision failed (HTTP ${res.status}).`))
+        return
+      }
+      setDecideMsg(approve
+        ? t('Schváleno. Maker nyní může akci zopakovat.', 'Approved. The maker can now retry the action.')
+        : t('Zamítnuto.', 'Rejected.'))
+      setDecideId('')
+    } catch {
+      setDecideMsg(t('Služba je nedostupná.', 'The service is unreachable.'))
+    } finally {
+      setDecideBusy(false)
+    }
+  }
+
   const filtered = checks.filter(c =>
     c.name?.toLowerCase().includes(search.toLowerCase()) ||
     c.status?.toLowerCase().includes(search.toLowerCase()) ||
@@ -412,7 +531,7 @@ export default function SanctionsPage() {
               ) : (
                 <table style={{ width: '100%', borderCollapse: 'collapse' }}>
                   <thead><tr style={{ borderBottom: '1px solid var(--border)' }}>
-                    {[t('Entita', 'Entity'), t('Typ', 'Type'), t('Seznamy', 'Lists'), t('Skóre', 'Score'), t('Výsledek', 'Result'), t('Zkontrolováno', 'Checked At')].map(h => (
+                    {[t('Entita', 'Entity'), t('Typ', 'Type'), t('Seznamy', 'Lists'), t('Skóre', 'Score'), t('Výsledek', 'Result'), t('Zkontrolováno', 'Checked At'), t('Rozhodnutí', 'Disposition')].map(h => (
                       <th key={h} style={{ padding: '10px 16px', textAlign: 'left', fontSize: '11px', fontWeight: 700, color: 'var(--text-tertiary)', textTransform: 'uppercase', letterSpacing: '0.05em' }}>{h}</th>
                     ))}
                   </tr></thead>
@@ -420,7 +539,8 @@ export default function SanctionsPage() {
                     const isHit = c.status === 'HIT'
                     const isPending = c.status === 'POTENTIAL_HIT'
                     return (
-                      <tr key={c.id} style={{ borderBottom: '1px solid var(--border)', background: isHit ? 'rgba(239,68,68,0.03)' : '' }}
+                      <Fragment key={c.id}>
+                      <tr style={{ borderBottom: '1px solid var(--border)', background: isHit ? 'rgba(239,68,68,0.03)' : '' }}
                         onMouseEnter={e => (e.currentTarget.style.background = isHit ? 'rgba(239,68,68,0.06)' : 'var(--surface-2)')}
                         onMouseLeave={e => (e.currentTarget.style.background = isHit ? 'rgba(239,68,68,0.03)' : '')}>
                         <td style={{ padding: '12px 16px', fontSize: '13px', fontWeight: 500, color: 'var(--text-primary)' }}>
@@ -454,11 +574,132 @@ export default function SanctionsPage() {
                         <td style={{ padding: '12px 16px', fontSize: '12px', color: 'var(--text-tertiary)' }}>
                           {c.checkedAt ? new Date(c.checkedAt).toLocaleString('cs-CZ') : '—'}
                         </td>
+                        <td style={{ padding: '12px 16px', fontSize: '12px' }}>
+                          {c.reviewedBy ? (
+                            <span title={c.reviewNote ?? ''} style={{ color: 'var(--text-tertiary)' }}>
+                              {t('Rozhodl', 'By')} {c.reviewedBy}
+                            </span>
+                          ) : (isHit || isPending) ? (
+                            <button onClick={() => openReview(c)} disabled={reviewFor === c.id}
+                              style={{ padding: '4px 10px', borderRadius: '6px', border: '1px solid var(--border)', background: 'var(--surface-2)',
+                                color: 'var(--text-primary)', fontSize: '11px', fontWeight: 600, cursor: reviewFor === c.id ? 'default' : 'pointer' }}>
+                              {t('Posoudit', 'Review')}
+                            </button>
+                          ) : <span style={{ color: 'var(--text-tertiary)' }}>—</span>}
+                        </td>
                       </tr>
+                      {reviewFor === c.id && (
+                        <tr style={{ borderBottom: '1px solid var(--border)', background: 'var(--surface-2)' }}>
+                          <td colSpan={7} style={{ padding: '16px' }}>
+                            <div style={{ display: 'flex', flexDirection: 'column', gap: '10px', maxWidth: '640px' }}>
+                              <div style={{ fontSize: '13px', fontWeight: 700, color: 'var(--text-primary)' }}>
+                                {t('Manuální rozhodnutí', 'Manual disposition')} — {c.name}
+                              </div>
+
+                              {pendingApproval?.checkId === c.id ? (
+                                <div style={{ display: 'flex', flexDirection: 'column', gap: '8px', padding: '12px', borderRadius: '8px',
+                                  background: 'var(--warning-bg)', border: '1px solid var(--warning-border)' }}>
+                                  <div style={{ fontSize: '12px', fontWeight: 600, color: 'var(--warning-text)' }}>
+                                    {t('Čeká na druhého schvalovatele (čtyři oči, ADR-0155)', 'Awaiting a second approver (four-eyes, ADR-0155)')}
+                                  </div>
+                                  <div style={{ fontSize: '12px', color: 'var(--text-secondary)' }}>
+                                    {t('Předejte toto ID jinému operátorovi. Rozhodnutí schválí níže v poli „Schválit žádost“ — vlastní žádost schválit nelze.',
+                                       'Hand this id to another operator. They decide it in the "Decide an approval" box below — nobody can approve their own request.')}
+                                  </div>
+                                  <code style={{ fontSize: '12px', fontFamily: 'var(--font-mono)', color: 'var(--text-primary)', wordBreak: 'break-all' }}>
+                                    {pendingApproval.id}
+                                  </code>
+                                  <div style={{ display: 'flex', gap: '8px' }}>
+                                    <button onClick={() => submitReview(c.id, pendingApproval.id)} disabled={reviewBusy}
+                                      style={{ padding: '6px 12px', borderRadius: '6px', border: 'none', background: 'var(--accent)', color: '#fff', fontSize: '12px', fontWeight: 600, cursor: 'pointer' }}>
+                                      {reviewBusy ? <Loader2 size={12} className="spin" /> : t('Zopakovat po schválení', 'Retry once approved')}
+                                    </button>
+                                    <button onClick={() => { setReviewFor(null); setPendingApproval(null) }}
+                                      style={{ padding: '6px 12px', borderRadius: '6px', border: '1px solid var(--border)', background: 'transparent', color: 'var(--text-secondary)', fontSize: '12px', cursor: 'pointer' }}>
+                                      {t('Zavřít', 'Close')}
+                                    </button>
+                                  </div>
+                                </div>
+                              ) : (
+                                <>
+                                  <div style={{ display: 'flex', gap: '12px', flexWrap: 'wrap' }}>
+                                    <div style={{ display: 'flex', flexDirection: 'column', gap: '4px' }}>
+                                      <label style={{ fontSize: '11px', fontWeight: 600, color: 'var(--text-tertiary)', textTransform: 'uppercase', letterSpacing: '0.05em' }}>
+                                        {t('Nový stav', 'New status')}
+                                      </label>
+                                      <select value={reviewStatus} onChange={e => setReviewStatus(e.target.value as ReviewStatus)}
+                                        style={{ padding: '8px 12px', borderRadius: '6px', border: '1px solid var(--border)', fontSize: '13px', background: 'var(--surface-2)', color: 'var(--text-primary)' }}>
+                                        <option value="CLEAR">{t('CLEAR — falešná shoda', 'CLEAR — false positive')}</option>
+                                        <option value="WHITELISTED">{t('WHITELISTED — trvale povoleno', 'WHITELISTED — permanently allowed')}</option>
+                                        <option value="ESCALATED">{t('ESCALATED — předat compliance', 'ESCALATED — hand to compliance')}</option>
+                                        <option value="HIT">{t('HIT — potvrzená shoda', 'HIT — confirmed match')}</option>
+                                      </select>
+                                    </div>
+                                  </div>
+                                  <div style={{ display: 'flex', flexDirection: 'column', gap: '4px' }}>
+                                    <label style={{ fontSize: '11px', fontWeight: 600, color: 'var(--text-tertiary)', textTransform: 'uppercase', letterSpacing: '0.05em' }}>
+                                      {t('Odůvodnění *', 'Rationale *')}
+                                    </label>
+                                    <textarea value={reviewNote} onChange={e => setReviewNote(e.target.value)} rows={2}
+                                      placeholder={t('Proč je toto rozhodnutí správné — jde o auditní stopu.', 'Why this decision is correct — this is the audit trail.')}
+                                      style={{ padding: '8px 12px', borderRadius: '6px', border: '1px solid var(--border)', fontSize: '13px', background: 'var(--surface-2)', color: 'var(--text-primary)', resize: 'vertical' }} />
+                                  </div>
+                                  {reviewError && (
+                                    <div style={{ fontSize: '12px', color: 'var(--danger-text)' }}>{reviewError}</div>
+                                  )}
+                                  <div style={{ display: 'flex', gap: '8px' }}>
+                                    <button onClick={() => submitReview(c.id)} disabled={reviewBusy}
+                                      style={{ padding: '6px 14px', borderRadius: '6px', border: 'none', background: 'var(--accent)', color: '#fff', fontSize: '12px', fontWeight: 600, cursor: reviewBusy ? 'default' : 'pointer' }}>
+                                      {reviewBusy ? <Loader2 size={12} className="spin" /> : t('Odeslat rozhodnutí', 'Submit decision')}
+                                    </button>
+                                    <button onClick={() => setReviewFor(null)}
+                                      style={{ padding: '6px 14px', borderRadius: '6px', border: '1px solid var(--border)', background: 'transparent', color: 'var(--text-secondary)', fontSize: '12px', cursor: 'pointer' }}>
+                                      {t('Zrušit', 'Cancel')}
+                                    </button>
+                                  </div>
+                                </>
+                              )}
+                            </div>
+                          </td>
+                        </tr>
+                      )}
+                      </Fragment>
                     )
                   })}</tbody>
                 </table>
               )}
+
+              {/* Checker half of the four-eyes gate. It is an id field rather than a queue because
+                  sanctions-service exposes no pending-approvals list endpoint — ApprovalResource
+                  serves only PATCH /{id}, so the id has to be handed over out of band. The
+                  ADR-0227 inbox federates lending and agent only, and is read-only by design. */}
+              <div style={{ padding: '16px', borderTop: '1px solid var(--border)' }}>
+                <div style={{ maxWidth: '560px', display: 'flex', flexDirection: 'column', gap: '8px' }}>
+                  <div style={{ fontSize: '12px', fontWeight: 700, color: 'var(--text-primary)' }}>
+                    {t('Schválit žádost (druhý pár očí)', 'Decide an approval (second pair of eyes)')}
+                  </div>
+                  <div style={{ fontSize: '11px', color: 'var(--text-tertiary)' }}>
+                    {t('Vložte ID žádosti, které vám předal jiný operátor. Vlastní žádost schválit nelze — službu to odmítne.',
+                       'Paste the approval id another operator handed you. You cannot decide your own request — the service refuses it.')}
+                  </div>
+                  <div style={{ display: 'flex', gap: '8px' }}>
+                    <input value={decideId} onChange={e => setDecideId(e.target.value)} placeholder={t('ID žádosti', 'Approval id')}
+                      style={{ flex: 1, padding: '8px 12px', borderRadius: '6px', border: '1px solid var(--border)', fontSize: '12px',
+                        fontFamily: 'var(--font-mono)', background: 'var(--surface-2)', color: 'var(--text-primary)', outline: 'none' }} />
+                    <button onClick={() => decideApproval(true)} disabled={decideBusy || !decideId.trim()}
+                      style={{ padding: '8px 14px', borderRadius: '6px', border: 'none', background: 'var(--success)', color: '#fff', fontSize: '12px', fontWeight: 600,
+                        cursor: decideBusy || !decideId.trim() ? 'default' : 'pointer', opacity: decideBusy || !decideId.trim() ? 0.6 : 1 }}>
+                      {t('Schválit', 'Approve')}
+                    </button>
+                    <button onClick={() => decideApproval(false)} disabled={decideBusy || !decideId.trim()}
+                      style={{ padding: '8px 14px', borderRadius: '6px', border: '1px solid var(--border)', background: 'transparent', color: 'var(--text-secondary)', fontSize: '12px',
+                        cursor: decideBusy || !decideId.trim() ? 'default' : 'pointer', opacity: decideBusy || !decideId.trim() ? 0.6 : 1 }}>
+                      {t('Zamítnout', 'Reject')}
+                    </button>
+                  </div>
+                  {decideMsg && <div style={{ fontSize: '12px', color: 'var(--text-secondary)' }}>{decideMsg}</div>}
+                </div>
+              </div>
             </>
           )}
 

--- a/openbank-admin-ui/src/lib/sanctions/upstream.ts
+++ b/openbank-admin-ui/src/lib/sanctions/upstream.ts
@@ -34,12 +34,21 @@ const BASE = process.env.SANCTIONS_SERVICE_URL ?? 'http://openbank-sanctions-ser
  *
  * `body` is sent as JSON when present. `timeoutMs` defaults to a read-shaped 10s; the
  * screening and refresh calls do real work upstream and pass a longer budget.
+ *
+ * `extraHeaders` exists for the four-eyes retry and is not optional decoration: the maker's
+ * second call must carry `X-Approval-Id`, which `AuthorizeInterceptor.resolveApprovalIdHeader`
+ * reads off the REQUEST. Dropping it does not error — the interceptor simply mints a fresh
+ * PendingApproval and answers 202 again, so the operator loops forever with every individual
+ * call looking healthy. Never let a caller reach the upstream except through this function;
+ * a per-route fetch is a per-route opportunity to forget a header (that is how all three
+ * original routes lost the bearer).
  */
 export async function forwardToSanctionsService(
   path: string,
-  method: 'GET' | 'POST' = 'GET',
+  method: 'GET' | 'PATCH' | 'POST' | 'PUT' = 'GET',
   body?: unknown,
   timeoutMs = 10_000,
+  extraHeaders?: Record<string, string>,
 ): Promise<NextResponse> {
   const accessToken = (await auth())?.user?.accessToken
   if (!accessToken) {
@@ -53,6 +62,10 @@ export async function forwardToSanctionsService(
         Authorization: `Bearer ${accessToken}`,
         Accept: 'application/json',
         ...(body === undefined ? {} : { 'Content-Type': 'application/json' }),
+        // Last, but Authorization is not overridable in practice: the only caller-supplied
+        // header today is X-Approval-Id, and the review route allow-lists what it forwards
+        // rather than passing the browser's headers through.
+        ...(extraHeaders ?? {}),
       },
       ...(body === undefined ? {} : { body: JSON.stringify(body) }),
       cache: 'no-store',

--- a/openbank-admin-ui/src/test/sanctions-review-bff.test.ts
+++ b/openbank-admin-ui/src/test/sanctions-review-bff.test.ts
@@ -1,0 +1,188 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright (c) OpenBank contributors. Licensed under the Apache License, Version 2.0.
+// See LICENSE in the repository root or https://www.apache.org/licenses/LICENSE-2.0 for details.
+
+// Issue #3334: POST /api/v1/sanctions/review had no caller in the product, so a HIT could never
+// be dispositioned. These cover the BFF half — the review route, the four-eyes retry header, the
+// checker's decide route, and the two list routes that #3336 left hand-rolled without a bearer.
+//
+// The load-bearing case is "X-Approval-Id reaches the upstream". Without it the four-eyes retry
+// silently loops: AuthorizeInterceptor reads the id off the REQUEST, so a dropped header makes it
+// mint a fresh PendingApproval and answer 202 again — every individual call looking healthy.
+
+import { NextRequest } from 'next/server'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+
+vi.mock('@/auth', () => ({ auth: vi.fn() }))
+
+import { auth } from '@/auth'
+
+const SESSION = { user: { accessToken: 'operator-token', roles: ['ROLE_OPERATOR'] } }
+
+function lastFetchCall() {
+  const mock = vi.mocked(global.fetch)
+  return mock.mock.calls[mock.mock.calls.length - 1] as [string, RequestInit]
+}
+
+function headersOf(init: RequestInit): Record<string, string> {
+  return (init.headers ?? {}) as Record<string, string>
+}
+
+function respond(body: unknown, status = 200) {
+  return vi.fn().mockResolvedValue(
+    new Response(JSON.stringify(body), { status, headers: { 'Content-Type': 'application/json' } }),
+  )
+}
+
+describe('sanctions review BFF', () => {
+  beforeEach(() => {
+    vi.resetModules()
+    vi.mocked(auth).mockResolvedValue(SESSION as never)
+  })
+  afterEach(() => { vi.restoreAllMocks() })
+
+  it('relays the operator bearer and posts to the review endpoint', async () => {
+    global.fetch = respond({ id: 'check-1', status: 'CLEAR' })
+    const { POST } = await import('../app/api/sanctions/review/route')
+
+    const res = await POST(new NextRequest('http://localhost/api/sanctions/review', {
+      method: 'POST',
+      body: JSON.stringify({ checkId: 'check-1', note: 'false positive', newStatus: 'CLEAR' }),
+    }))
+
+    expect(res.status).toBe(200)
+    const [url, init] = lastFetchCall()
+    expect(url).toBe('http://openbank-sanctions-service:8123/api/v1/sanctions/review')
+    expect(headersOf(init).Authorization).toBe('Bearer operator-token')
+  })
+
+  it('forwards X-Approval-Id to the upstream when the client supplies it', async () => {
+    global.fetch = respond({ id: 'check-1', status: 'CLEAR' })
+    const { POST } = await import('../app/api/sanctions/review/route')
+
+    await POST(new NextRequest('http://localhost/api/sanctions/review', {
+      method: 'POST',
+      headers: { 'X-Approval-Id': 'approval-42' },
+      body: JSON.stringify({ checkId: 'check-1', note: 'approved by a checker', newStatus: 'CLEAR' }),
+    }))
+
+    // The whole point of the header parameter on forwardToSanctionsService.
+    expect(headersOf(lastFetchCall()[1])['X-Approval-Id']).toBe('approval-42')
+  })
+
+  it('omits X-Approval-Id entirely on a first submission', async () => {
+    global.fetch = respond({ id: 'check-1', status: 'CLEAR' })
+    const { POST } = await import('../app/api/sanctions/review/route')
+
+    await POST(new NextRequest('http://localhost/api/sanctions/review', {
+      method: 'POST',
+      body: JSON.stringify({ checkId: 'check-1', note: 'first try', newStatus: 'CLEAR' }),
+    }))
+
+    expect(headersOf(lastFetchCall()[1])).not.toHaveProperty('X-Approval-Id')
+  })
+
+  it('passes a 202 four-eyes pause through with its body intact', async () => {
+    // 202 is res.ok, so it must NOT be flattened into the generic upstream_error envelope —
+    // the approvalId in this body is the only way back to that pending decision.
+    global.fetch = respond({ status: 'PENDING_APPROVAL', approvalId: 'approval-42' }, 202)
+    const { POST } = await import('../app/api/sanctions/review/route')
+
+    const res = await POST(new NextRequest('http://localhost/api/sanctions/review', {
+      method: 'POST',
+      body: JSON.stringify({ checkId: 'check-1', note: 'needs a checker', newStatus: 'CLEAR' }),
+    }))
+
+    expect(res.status).toBe(202)
+    await expect(res.json()).resolves.toEqual({ status: 'PENDING_APPROVAL', approvalId: 'approval-42' })
+  })
+
+  it('refuses without a session before touching the backend', async () => {
+    vi.mocked(auth).mockResolvedValue(null as never)
+    global.fetch = respond({})
+    const { POST } = await import('../app/api/sanctions/review/route')
+
+    const res = await POST(new NextRequest('http://localhost/api/sanctions/review', {
+      method: 'POST',
+      body: JSON.stringify({ checkId: 'check-1', note: 'x', newStatus: 'CLEAR' }),
+    }))
+
+    expect(res.status).toBe(401)
+    expect(global.fetch).not.toHaveBeenCalled()
+  })
+})
+
+describe('sanctions approvals decide BFF (checker half)', () => {
+  beforeEach(() => {
+    vi.resetModules()
+    vi.mocked(auth).mockResolvedValue(SESSION as never)
+  })
+  afterEach(() => { vi.restoreAllMocks() })
+
+  it('PATCHes the approval with the operator bearer', async () => {
+    global.fetch = respond({ id: 'approval-42', status: 'APPROVED' })
+    const { PATCH } = await import('../app/api/sanctions/approvals/[id]/route')
+
+    const res = await PATCH(
+      new NextRequest('http://localhost/api/sanctions/approvals/approval-42', {
+        method: 'PATCH', body: JSON.stringify({ approve: true }),
+      }),
+      { params: Promise.resolve({ id: 'approval-42' }) },
+    )
+
+    expect(res.status).toBe(200)
+    const [url, init] = lastFetchCall()
+    expect(url).toBe('http://openbank-sanctions-service:8123/api/v1/sanctions/approvals/approval-42')
+    expect(init.method).toBe('PATCH')
+    expect(headersOf(init).Authorization).toBe('Bearer operator-token')
+  })
+
+  it('preserves a 403 self-approval refusal rather than masking it as a generic failure', async () => {
+    global.fetch = respond({ code: 'FORBIDDEN' }, 403)
+    const { PATCH } = await import('../app/api/sanctions/approvals/[id]/route')
+
+    const res = await PATCH(
+      new NextRequest('http://localhost/api/sanctions/approvals/approval-42', {
+        method: 'PATCH', body: JSON.stringify({ approve: true }),
+      }),
+      { params: Promise.resolve({ id: 'approval-42' }) },
+    )
+
+    // The status is what the UI keys its "you cannot decide your own request" message off.
+    expect(res.status).toBe(403)
+  })
+})
+
+describe('sanctions list routes relay the bearer too (#3336 leftovers)', () => {
+  beforeEach(() => {
+    vi.resetModules()
+    vi.mocked(auth).mockResolvedValue(SESSION as never)
+  })
+  afterEach(() => { vi.restoreAllMocks() })
+
+  it('PUT /lists/[id] sends Authorization', async () => {
+    global.fetch = respond({ id: 'OFAC_SDN', enabled: false })
+    const { PUT } = await import('../app/api/sanctions/lists/[id]/route')
+
+    await PUT(
+      new NextRequest('http://localhost/api/sanctions/lists/OFAC_SDN', {
+        method: 'PUT', body: JSON.stringify({ enabled: false }),
+      }),
+      { params: Promise.resolve({ id: 'OFAC_SDN' }) },
+    )
+
+    expect(headersOf(lastFetchCall()[1]).Authorization).toBe('Bearer operator-token')
+  })
+
+  it('POST /lists/[id]/refresh sends Authorization', async () => {
+    global.fetch = respond({ imported: 12 })
+    const { POST } = await import('../app/api/sanctions/lists/[id]/refresh/route')
+
+    await POST(
+      new NextRequest('http://localhost/api/sanctions/lists/OFAC_SDN/refresh', { method: 'POST' }),
+      { params: Promise.resolve({ id: 'OFAC_SDN' }) },
+    )
+
+    expect(headersOf(lastFetchCall()[1]).Authorization).toBe('Bearer operator-token')
+  })
+})


### PR DESCRIPTION
## Summary

`POST /api/v1/sanctions/review` is deployed, publicly routed, four-eyes gated — and had **no caller
anywhere in the product**. This gives it one: a maker flow on the sanctions screen, a checker flow
for the four-eyes decision, and the BFF routes behind both.

## Type of change

- [x] feat (new functionality)
- [ ] fix (bug fix)
- [ ] refactor / perf / docs / chore / security / breaking

## Linked issues

Closes #3334
Refs #3336, #3349

## What was broken

No BFF route, no UI control, and no M2M client — all six `SanctionsServiceClient` interfaces declare
only `/screen`. So a `HIT` or `POTENTIAL_HIT` could not be moved to `CLEAR`, `WHITELISTED` or
`ESCALATED` without hand-crafting a request against `api.open-bank.tech`, while the screen rendered
a "Pending Review" tile over a queue that had no drain and fields (`reviewedBy`, `reviewNote`) that
could only ever be null.

That is 5AMLD Art. 13 manual review, and per `rules.yaml` the highest-risk action in the service —
"a wrongly-cleared true positive is a real sanctions violation".

## Maker flow

A **Review** button on `HIT` / `POTENTIAL_HIT` rows opens an inline form: new status, mandatory
rationale.

Two deliberate choices:

- **`POTENTIAL_HIT` is absent from the picker.** A review that leaves the check pending is a no-op
  that still consumes a four-eyes approval.
- **A confirmed `HIT` pre-selects `ESCALATED`, not `CLEAR`.** A default is a decision most people
  accept, so the safer direction is the one that should be free.

## Four-eyes, and the trap this PR exists to avoid

A 202 parks the decision (ADR-0155). That is a normal outcome, not a failure — `202` is `res.ok`, so
the helper forwards the body untouched — and the UI surfaces the `approvalId` as first-class state
with a retry action.

**The retry must carry `X-Approval-Id`.** `AuthorizeInterceptor.resolveApprovalIdHeader` reads it off
the *request*; drop it and the interceptor mints a fresh `PendingApproval` and answers 202 again —
an infinite loop in which every individual call looks perfectly healthy. `forwardToSanctionsService`
gained an `extraHeaders` parameter for exactly this, and the route **allow-lists that one header**
rather than passing the browser's header set through to an OIDC-gated backend.

## Checker flow

`PATCH /api/v1/sanctions/approvals/{id}`, exposed as an id field rather than a queue — because
sanctions-service has no pending-approvals list endpoint (`ApprovalResource` serves only `PATCH`),
and the ADR-0227 inbox federates lending and agent only, read-only by design. The id therefore has
to be handed over out of band; the UI says so plainly instead of implying a queue exists.

The self-approval guard stays server-side in `RedisApprovalStore.decide`; this route adds no check of
its own. Worth knowing while reviewing: #3349 records that the guard has no test that ever feeds it a
maker approving themselves.

## Included beyond the issue: two more routes that never got a bearer

`lists/[id]` (PUT) and `lists/[id]/refresh` (POST) still hand-rolled their own `fetch` with no
`Authorization` header. #3336 fixed `checks`, `lists` and `screen` — the route set is five. Same
defect, same screen, still live: an operator's list toggle and manual refresh 401'd against a healthy
service. Folded in because they are two small files on the surface this PR is already making work;
say the word and I will split them out.

## Verification

- **9 new BFF tests, falsified.** Dropping the `X-Approval-Id` forwarding reddens **exactly one** of
  them and leaves the other eight green — a probe that reddens everything proves only "something
  runs".
- Full suite via `npm test` (so `pretest` bakes the governance/catalog artifacts): **74 files / 1035
  tests**, all green.
- `npm run type-check` clean.
- `eslint` on the changed files: 4 warnings, versus **5 on `origin/main` for the same files** — none
  new, one fewer.

**Not verified in a browser.** The screen is auth-gated and needs a live sanctions-service; a local
dev server renders the login redirect, so a screenshot would show nothing about this change. The BFF
contract is covered by the tests above; the rendering is not.

## Definition of Done

- [x] Unit tests added — 9, covering both new routes and the two converted ones.
- [ ] Integration tests — N/A, BFF routes over a mocked upstream.
- [ ] Contract tests — N/A, no API change; the upstream contract is unchanged.
- [x] `type-check`, `eslint`, `npm test` pass.
- [ ] OpenAPI / Flyway / Avro — N/A.

## Reviewer notes

- The `extraHeaders` parameter is the load-bearing piece. If you dislike the allow-list shape, the
  alternative is a header pass-through, which I avoided on purpose: forwarding the browser's headers
  to an OIDC-gated backend is how a BFF leaks cookies or lets a caller override `Authorization`.
- Follow-up worth filing, not done here: sanctions-service could expose its pending-approvals queue
  (`ApprovalStore.findPending` already exists, and ADR-0227 D2 anticipates each service serving one),
  which would let the checker see a real queue and the inbox federate sanctions.
