### PR TITLE
fix(gitops): serve /api/v1/balances from the balances namespace

### DIFF
--- a/docs/threat-models/openbank-balance-service.md
+++ b/docs/threat-models/openbank-balance-service.md
@@ -173,6 +173,32 @@ also be deleted (nothing else in balance-service depends on it).
 
 ## 7. Change log
 
+- **2026-08-02** — **balance-service is now genuinely reachable from the public edge**, and the
+  honest framing is that the *intent* did not change while the *reality* did. `accounts/accounts-api`
+  had declared `api.open-bank.tech/api/v1/balances` since the Ingress was written, so the exposure was
+  always designed and threat-modelled as public — but an Ingress backend resolves only inside its own
+  namespace, and it named `balance-service` in `accounts`, where no such Service exists. The path
+  returned **503 for ~60 days** and nginx logged `no object matching key "accounts/balance-service"`
+  ~1,700×/hour. The route now lives in `components/balances/ingress.yaml` beside the Service it
+  targets (the shape `payments-api`/`sanctions-api` already use on this host).
+  **Trust-boundary delta:** `balance-service-ingress-allow-list` gains one derived rule,
+  `TCP:8103 FROM ingress-nginx` — the first non-`openbank-*` namespace admitted to the service port.
+  Without it the fix would have swapped the 503 for a hang, so it is load-bearing, not incidental;
+  it was produced by `gen-network-policies.py` (which derives ingress-nginx edges from Ingress
+  backends) rather than hand-written, and no other component's policies moved.
+  **Why the residual risk does not move:** every §4 mitigation on S1/I1/E1 is authn/authz at the
+  application layer — OIDC bearer JWT, role-gated mutations, OPA enforced on every endpoint, and the
+  A1 `X-Customer-Party-Id` ownership scoping — none of which depended on the caller being in-cluster.
+  This is the same posture `account-service` already carries on the same host and the same Ingress
+  class. D1 (DoS) is the one row that changes in practice rather than in principle: the new Ingress
+  carries the same `limit-rps: 20` / `limit-burst-multiplier: 3` / `limit-connections: 10`
+  annotations as its three siblings, deliberately identical so one host does not present four
+  different limits depending on which path a client happens to hit. The pre-existing
+  "Gateway rate-limit — infra scope" residual is now actually exercised instead of theoretical.
+  **What this does NOT change:** no application code, no schema, no role, no OPA policy, no
+  in-cluster caller. Rollback is deleting `components/balances/ingress.yaml` and re-running the
+  NetworkPolicy generator; the path returns to 503, which is where it has been all along.
+
 - **2026-07-12** — Wired the four-eyes (maker-checker) enforcement *mechanism* (ADR-0155) onto
   `balance.credit`/`balance.debit`, mirroring the account-service rollout (issue #413). New
   `ApprovalConfig` (`RedisApprovalStore` producer) and `PATCH /api/v1/balances/approvals/{id}`

--- a/openbank-infra/gitops/components/accounts/ingress.yaml
+++ b/openbank-infra/gitops/components/accounts/ingress.yaml
@@ -32,10 +32,10 @@ spec:
                 name: account-service
                 port:
                   number: 8100
-          - path: /api/v1/balances
-            pathType: Prefix
-            backend:
-              service:
-                name: balance-service
-                port:
-                  number: 8103
+          # /api/v1/balances is NOT served from here. An Ingress backend resolves only within
+          # the Ingress's own namespace, and balance-service lives in `balances`, so this rule
+          # named a Service that has never existed: nginx logged `no object matching key
+          # "accounts/balance-service"` ~1,700 times an hour and the public path answered 503
+          # for ~60 days. It now lives in components/balances/ingress.yaml, beside the Service
+          # it routes to -- the same one-Ingress-per-owning-namespace shape payments-api and
+          # sanctions-api use on this host.

--- a/openbank-infra/gitops/components/balances/ingress.yaml
+++ b/openbank-infra/gitops/components/balances/ingress.yaml
@@ -1,0 +1,56 @@
+# Public API Ingress for balance-service.
+#
+# WHY THIS LIVES HERE AND NOT IN components/accounts/: an Ingress backend resolves only within
+# the Ingress's OWN namespace. `accounts/accounts-api` routed /api/v1/balances to a Service
+# literally named `balance-service` in namespace `accounts` -- and balance-service has always
+# lived in `balances`. So the rule pointed at nothing:
+#
+#   Error obtaining Endpoints for Service "accounts/balance-service":
+#     no object matching key "accounts/balance-service" in local store
+#
+# nginx logged that ~1,700 times an hour for the life of the route, and
+# https://api.open-bank.tech/api/v1/balances answered **503** for ~60 days while
+# /api/v1/accounts on the same host answered 401 (auth-gated, i.e. working). Nothing else
+# noticed: balance-service itself was healthy, its in-cluster callers use
+# `http://balance-service.balances.svc:8103` and were unaffected, and no probe covered the
+# public path -- the Ingress object was `Synced/Healthy` throughout, because a backend that
+# does not resolve is not a manifest error.
+#
+# The cross-namespace fix is NOT an ExternalName Service in `accounts`: `tools-gate.test.ts`
+# asserts the ADR-0234 grafana-tools Service stays the only `type: ExternalName` in gitops
+# (it carries the repo-wide AVD-KSV-0108 trivy baseline, which a second one would silently
+# inherit). Instead this follows the pattern payments-api and sanctions-api already use --
+# one Ingress per owning namespace, all sharing the api.open-bank.tech host, which nginx
+# merges into a single server block. Each declares its own TLS secret so cert-manager issues
+# per-Ingress, exactly as the two siblings do.
+apiVersion: networking.k8s.io/v1
+kind: Ingress
+metadata:
+  name: balances-api
+  namespace: balances
+  annotations:
+    cert-manager.io/cluster-issuer: letsencrypt-prod
+    nginx.ingress.kubernetes.io/ssl-redirect: "true"
+    # Per-client rate limiting for the public sandbox API (auth-gated, but bound flood/cost).
+    # Kept identical to accounts-api/payments-api/sanctions-api so one host does not present
+    # four different limits depending on which path a client happens to hit.
+    nginx.ingress.kubernetes.io/limit-rps: "20"
+    nginx.ingress.kubernetes.io/limit-burst-multiplier: "3"
+    nginx.ingress.kubernetes.io/limit-connections: "10"
+spec:
+  ingressClassName: nginx
+  tls:
+    - hosts:
+        - api.open-bank.tech
+      secretName: balances-api-tls
+  rules:
+    - host: api.open-bank.tech
+      http:
+        paths:
+          - path: /api/v1/balances
+            pathType: Prefix
+            backend:
+              service:
+                name: balance-service
+                port:
+                  name: http

--- a/openbank-infra/gitops/components/balances/network-policies.yaml
+++ b/openbank-infra/gitops/components/balances/network-policies.yaml
@@ -83,6 +83,13 @@ spec:
       ports:
         - protocol: TCP
           port: 8085
+    - from:
+        - namespaceSelector:
+            matchLabels:
+              kubernetes.io/metadata.name: ingress-nginx
+      ports:
+        - protocol: TCP
+          port: 8103
 ---
 apiVersion: networking.k8s.io/v1
 kind: NetworkPolicy


### PR DESCRIPTION
## Linked issues

Closes #3476

## What

`https://api.open-bank.tech/api/v1/balances` has answered **503 for ~60 days**. Measured today:

```
/api/v1/balances  -> 503
/api/v1/accounts  -> 401   # same host, auth-gated, i.e. working
```

## Root cause

An Ingress backend resolves only within the Ingress's **own namespace**. `accounts/accounts-api` routed `/api/v1/balances` to a Service literally named `balance-service` in namespace `accounts` — and balance-service has always lived in `balances`. The rule named a Service that has never existed:

```
Error obtaining Endpoints for Service "accounts/balance-service":
  no object matching key "accounts/balance-service" in local store
```

nginx logged that **~1,700 times an hour**, making `ingress-nginx` the fourth-largest error-log producer in the sandbox.

## Why nothing caught it

- balance-service itself was healthy — the fault is in the route, not the service;
- its in-cluster callers use `http://balance-service.balances.svc:8103` and were unaffected, so every integration path stayed green;
- no probe covers the public path;
- the Ingress object was `Synced/Healthy` throughout, because **a backend that does not resolve is not a manifest error**.

## The fix

One Ingress per owning namespace, sharing the `api.open-bank.tech` host — the shape `payments-api` and `sanctions-api` already use. nginx merges them into a single server block; each declares its own TLS secret, as the two siblings do.

Deliberately **not** an ExternalName Service in `accounts`: `tools-gate.test.ts` asserts the ADR-0234 `grafana-tools` Service stays the only `type: ExternalName` in gitops, because it carries the repo-wide `AVD-KSV-0108` trivy baseline — a second one would silently inherit that exemption.

## The NetworkPolicy half — easy to miss, and it decides whether this works

`balances` had **no** `ingress-nginx` rule. `gen-network-policies.py` derives one only where an Ingress backend declares it, and the declaration was in the wrong namespace, so it was never generated. Without it this change would have swapped the 503 for a hang.

Regenerated with the generator rather than hand-edited (never edit a derived file). The only derived change is exactly the expected one:

```diff
+    - from:
+        - namespaceSelector:
+            matchLabels:
+              kubernetes.io/metadata.name: ingress-nginx
+      ports:
+        - protocol: TCP
+          port: 8103
```

No other component's policies moved, which also confirms the broken backend never produced a rule on the `accounts` side.

