### PR TITLE
fix(observability): stop the audit-chain alerts paging on the boot-time zero gauge

### DIFF
--- a/openbank-infra/gitops/components/observability/prometheus-rules-audit-chain.yaml
+++ b/openbank-infra/gitops/components/observability/prometheus-rules-audit-chain.yaml
@@ -25,8 +25,30 @@ spec:
       interval: 5m
       rules:
         # 1. The chain is broken. This is the incident.
+        #
+        # The `> 0` guard is what makes `intact == 0` mean "verified and broken" rather than
+        # "not verified yet". AuditChainIntegrityGauge registers all four gauges from
+        # AtomicLong(0) at boot and only sets them when the hourly cron first completes, so
+        # between pod start and the next :00 the series EXISTS and reads 0 — a fourth state the
+        # original three rules did not separate. Rule 2's absent() is false (the series is
+        # there), rule 3 computes time() - 0 and reports ~56 years, and this rule paged
+        # `severity: critical` with "AUDIT HASH CHAIN BROKEN — potential integrity incident".
+        # Measured in the sandbox 2026-08-02: both gauges read 0 against a 29-minute-old pod,
+        # and the critical was firing purely as a boot artifact. The window is up to an hour
+        # wide on every restart, because the cron is `0 0 * * * ?`.
+        #
+        # The rule being enforced here is one AuditChainIntegrityGauge's own KDoc already
+        # states about its DB-error path — "no failure to RUN may ever be reported as
+        # tampering" — and which the BOOT path quietly violated, because the gauge's initial
+        # AtomicLong(0) is indistinguishable from a computed 0 at the query layer. Fixing it in
+        # the rules rather than by verifying eagerly in @PostConstruct is deliberate: an eager
+        # reactive Panache call from a construction callback carries no Vert.x context and is
+        # the HR000068 shape this repo has already paid for five times over. Rule 2 covers the
+        # unverified state, so nothing is left uncovered by keeping the fix declarative.
         - alert: AuditChainBroken
-          expr: openbank_audit_chain_intact == 0
+          expr: |
+            openbank_audit_chain_intact == 0
+              and openbank_audit_chain_last_verified_timestamp_seconds > 0
           for: 0m
           labels:
             severity: critical
@@ -46,9 +68,17 @@ spec:
           # keeps its previous value when the verification cannot RUN (a DB blip must not page as
           # tampering).
 
-        # 2. The chain has never been verified. Invisible to rule 1 — an absent series is not 0.
+        # 2. The chain has never been verified. Invisible to rule 1 — an absent series is not 0,
+        # and now also not a zero-valued one: with rule 1 guarded on `> 0`, a verification that
+        # never completes would otherwise be covered by NOTHING. The `== 0` arm is what keeps
+        # that guard from turning a silent control into a silent-and-unalerted one. `for: 2h`
+        # is unchanged and still the right grace: a healthy pod leaves the zero state at the
+        # next :00, so it absorbs a redeploy plus the hourly cadence, and 2h of it means the
+        # scheduler genuinely is not completing.
         - alert: AuditChainNeverVerified
-          expr: absent(openbank_audit_chain_last_verified_timestamp_seconds)
+          expr: |
+            absent(openbank_audit_chain_last_verified_timestamp_seconds)
+              or openbank_audit_chain_last_verified_timestamp_seconds == 0
           for: 2h
           labels:
             severity: warning
@@ -64,8 +94,14 @@ spec:
         # 3. It ran once and stopped. Invisible to BOTH rules above: the gauge still publishes its
         # last value for the life of the pod, so `intact` reads 1 and `absent()` is false while the
         # verdict quietly ages.
+        # The `> 0` guard again: against the boot-time zero this expression is time() - 0, which
+        # rendered as "Audit chain last verified 20667d 20h ago" — a 56-year figure that reads as
+        # a corrupt metric rather than an actionable staleness, and which fired on every restart.
+        # A genuinely never-completing verification is rule 2's job, not this one's.
         - alert: AuditChainVerificationStale
-          expr: (time() - openbank_audit_chain_last_verified_timestamp_seconds) > 10800
+          expr: |
+            (time() - openbank_audit_chain_last_verified_timestamp_seconds) > 10800
+              and openbank_audit_chain_last_verified_timestamp_seconds > 0
           for: 15m
           labels:
             severity: warning


### PR DESCRIPTION
## Linked issues

Closes #3478

## What

Two audit-chain alerts — one of them `severity: critical` — fire on **every audit-service restart**, about a chain that has not been checked at all.

## Root cause

`AuditChainIntegrityGauge` registers all four gauges from `AtomicLong(0)` and only sets them when the hourly cron (`0 0 * * * ?`) first completes. Between pod start and the next `:00`, the series **exists and reads 0**. At the query layer an initial `0` is indistinguishable from a computed one — a fourth state the three rules did not separate.

In that window:

| rule | what it did | what it should do |
|---|---|---|
| `AuditChainBroken` | paged **critical**, "AUDIT HASH CHAIN BROKEN — potential integrity incident" | stay silent — nothing was verified |
| `AuditChainVerificationStale` | `time() - 0` → *"last verified 20667d 20h ago"* (~56 years) | stay silent |
| `AuditChainNeverVerified` | **silent** — `absent()` is false for a series that is present | fire; this is exactly its condition |

Measured in the sandbox 2026-08-02: both gauges read `0` against a 29-minute-old pod, and both alerts were firing as pure boot artifacts.

## Fix

Guard rules 1 and 3 on `last_verified_timestamp_seconds > 0`; extend rule 2 to `absent(...) or ... == 0`. The unverified state is then covered by exactly one rule — the one named for it — and no state is left uncovered.

`for: 2h` on rule 2 is unchanged and still right: a healthy pod leaves the zero state at the next `:00`, so the grace absorbs a redeploy plus the hourly cadence; 2h of it means the scheduler genuinely is not completing.

## Why not fix it in the service instead

Verifying eagerly in `@PostConstruct` would shrink the window to seconds, but an eager reactive Panache call from a construction callback carries no Vert.x context — the `HR000068` shape this repo has already paid for five times (#2148, #2187, #2913). Staying declarative leaves nothing uncovered, so it is the cheaper correct fix.

## Verification — against live Prometheus, both directions

```
rule 1 (guarded)  -> silent    # was firing critical
rule 2 (extended) -> fires     # correct: never verified
rule 3 (guarded)  -> silent    # was firing with the 56-year value
```

The invariant restored is one `AuditChainIntegrityGauge`'s own KDoc already states about its DB-error path: **no failure to RUN may ever be reported as tampering.** The boot path quietly violated it.

