### PR TITLE
fix(gitops): read delegation's OIDC secret from the shared client's KV entry

### DIFF
--- a/openbank-infra/gitops/components/delegation/external-secret-oidc.yaml
+++ b/openbank-infra/gitops/components/delegation/external-secret-oidc.yaml
@@ -1,8 +1,26 @@
 # delegation-service OIDC client secret from Vault -> delegation-service-oidc Secret
 # (key OIDC_CLIENT_SECRET), shared openbank-services realm client. creationPolicy
 # Owner: ESO creates/owns and re-creates the Secret (mirrors every other service).
-# Prerequisite: the Vault KV must hold `delegation-service` with OIDC_CLIENT_SECRET set
-# to the openbank-services client secret (seed step in the rollout runbook).
+#
+# The remoteRef key is `account-service` and NOT `delegation-service`, which is what this
+# file asked for until it was corrected. That was self-contradictory in place: the comment
+# said "shared openbank-services realm client" and "mirrors every other service", while the
+# key named a per-service KV entry that nobody had ever written. delegation-service's
+# application.yaml sets `quarkus.oidc.client-id: openbank-services` — the same shared realm
+# client 28 other ExternalSecrets read out of the shared `account-service` KV entry — so
+# there was never a distinct secret for a `delegation-service` entry to hold.
+#
+# The cost of the mismatch, measured 2026-08-02: ESO answered `Secret does not exist`, the
+# Secret was never created, and the pod sat in CreateContainerConfigError for its whole life
+# (the env ref is not `optional: true`, deliberately — see openbank-infra/CLAUDE.md on that
+# trade). Roughly a dozen alerts traced back to this ONE missing key: SLOMetricAbsent x3,
+# TargetDown, DeploymentNoAvailableReplicas, KubePodNotReady, KubeContainerWaiting,
+# KubeDeploymentReplicasMismatch/RolloutStuck, ArgoCDAppDegraded, PostgresWALArchiveFailing
+# and both Kyverno criticals.
+#
+# Deleting the "Prerequisite: seed the KV" line is part of the fix, not tidying: the seed
+# step existed only to satisfy the wrong key, so keeping it would preserve a manual rollout
+# action that has no purpose and that nobody performed anyway.
 apiVersion: external-secrets.io/v1beta1
 kind: ExternalSecret
 metadata:
@@ -24,5 +42,5 @@ spec:
   data:
     - secretKey: OIDC_CLIENT_SECRET
       remoteRef:
-        key: delegation-service
+        key: account-service
         property: OIDC_CLIENT_SECRET


### PR DESCRIPTION
## Linked issues

Closes #3479

## What

`delegation-service` has never started. Its ExternalSecret asked Vault for the KV entry `delegation-service`, which has never existed:

```
error retrieving secret at .data[0], key: delegation-service, err: Secret does not exist
Error: secret "delegation-service-oidc" not found
```

The pod sat in `CreateContainerConfigError` for the entire life of the namespace.

## The manifest contradicted itself

Its own header said *"shared openbank-services realm client"* and *"mirrors every other service"* — while the `remoteRef` named a **per-service** entry, which only makes sense for a dedicated client.

`delegation-service` sets `quarkus.oidc.client-id: openbank-services`. That is the same shared realm client **28 other ExternalSecrets** read out of the shared `account-service` KV entry. There was never a distinct secret for a `delegation-service` entry to hold.

Fleet histogram of `remoteRef.key` across every `*-oidc` ExternalSecret:

```
account-service: 28   <- the shared openbank-services client
delegation-service: 1 <- the only one in SecretSyncedError
```

## Blast radius — a dozen alerts, one wrong string

Every one of these was a *true* report of a workload that could not start, all from the same key:

`SLOMetricAbsent` ×3 · `TargetDown` · `DeploymentNoAvailableReplicas` · `KubePodNotReady` · `KubeContainerWaiting` · `KubeDeploymentReplicasMismatch` · `KubeDeploymentRolloutStuck` · `ArgoCDAppDegraded` · `PostgresWALArchiveFailing` · `KyvernoAdmissionDenied` · `KyvernoEnforcePolicyBlocking`

## Why the "Prerequisite: seed the KV" line is deleted, not kept

That rollout step existed **only** to satisfy the wrong key. Keeping it would preserve a manual action with no purpose — one nobody had performed anyway, which is how this shipped.

## Verified live, not reasoned about

Patching the running ExternalSecret to `account-service`:

```
status.conditions[0].reason -> SecretSynced        (within seconds)
secret/delegation-service-oidc -> created
delegation-service-774ddbbff9-ps4xf -> 2/2 Running
```

ArgoCD will reconcile the same value once this merges.

