### PR TITLE
fix(admin-ui): render the campaign tables in the console's own style

### DIFF
--- a/openbank-admin-ui/src/app/campaigns/[id]/page.tsx
+++ b/openbank-admin-ui/src/app/campaigns/[id]/page.tsx
@@ -448,30 +448,30 @@ export default function CampaignDetailPage({ params }: { params: Promise<{ id: s
               <p className="text-sm text-muted-foreground">{t('Zatím nic odesláno ani pokusem.', 'Nothing sent or attempted yet.')}</p>
             ) : (
               <div className="overflow-x-auto rounded-lg border">
-                <table className="w-full text-sm">
-                  <thead className="bg-muted/50 text-left">
+                <table className="data-table">
+                  <thead>
                     <tr>
-                      <th className="px-4 py-2 font-medium">{t('Party', 'Party')}</th>
-                      <th className="px-4 py-2 font-medium">{t('Krok', 'Step')}</th>
-                      <th className="px-4 py-2 font-medium">{t('Výsledek', 'Outcome')}</th>
-                      <th className="px-4 py-2 font-medium">{t('Kdy', 'When')}</th>
+                      <th>{t('Party', 'Party')}</th>
+                      <th>{t('Krok', 'Step')}</th>
+                      <th>{t('Výsledek', 'Outcome')}</th>
+                      <th>{t('Kdy', 'When')}</th>
                     </tr>
                   </thead>
                   <tbody>
                     {sends.map(s => (
-                      <tr key={s.id} className="border-t">
-                        <td className="px-4 py-2 text-xs" title={s.partyId}>
+                      <tr key={s.id}>
+                        <td className="text-xs" title={s.partyId}>
                           {detail?.partyNames?.[s.partyId] ?? (
                             <span className="font-mono">{shortId(s.partyId)}</span>
                           )}
                         </td>
-                        <td className="px-4 py-2">{s.stepOrder}</td>
-                        <td className="px-4 py-2">
+                        <td>{s.stepOrder}</td>
+                        <td>
                           <span title={s.outcome}>
                             <StatusBadge status={s.outcome} tone={outcomeTone(s.outcome)} label={outcomeLabel(s.outcome)} />
                           </span>
                         </td>
-                        <td className="px-4 py-2 text-xs whitespace-nowrap">{fmtDateTime(s.occurredAt)}</td>
+                        <td className="text-xs whitespace-nowrap">{fmtDateTime(s.occurredAt)}</td>
                       </tr>
                     ))}
                   </tbody>

--- a/openbank-admin-ui/src/app/campaigns/page.tsx
+++ b/openbank-admin-ui/src/app/campaigns/page.tsx
@@ -224,24 +224,24 @@ export default function CampaignsPage() {
 
           {filtered.length > 0 && (
             <div className="overflow-x-auto rounded-lg border">
-              <table className="w-full text-sm">
-                <thead className="bg-muted/50 text-left">
+              <table className="data-table">
+                <thead>
                   <tr>
-                    <th className="px-4 py-2 font-medium">{t('Název', 'Name')}</th>
-                    <th className="px-4 py-2 font-medium">{t('Stav', 'State')}</th>
-                    <th className="px-4 py-2 font-medium">{t('Segment', 'Segment')}</th>
-                    {summary && <th className="px-4 py-2 font-medium">{t('Zařazeno', 'Enrolled')}</th>}
-                    {summary && <th className="px-4 py-2 font-medium">{t('Doručeno', 'Sent')}</th>}
-                    {summary && <th className="px-4 py-2 font-medium">{t('Potlačeno', 'Suppressed')}</th>}
-                    <th className="px-4 py-2 font-medium">{t('Vytvořil', 'Created by')}</th>
-                    <th className="px-4 py-2 font-medium">{t('Schválil', 'Approved by')}</th>
-                    <th className="px-4 py-2 font-medium">{t('Vytvořeno', 'Created')}</th>
+                    <th>{t('Název', 'Name')}</th>
+                    <th>{t('Stav', 'State')}</th>
+                    <th>{t('Segment', 'Segment')}</th>
+                    {summary && <th>{t('Zařazeno', 'Enrolled')}</th>}
+                    {summary && <th>{t('Doručeno', 'Sent')}</th>}
+                    {summary && <th>{t('Potlačeno', 'Suppressed')}</th>}
+                    <th>{t('Vytvořil', 'Created by')}</th>
+                    <th>{t('Schválil', 'Approved by')}</th>
+                    <th>{t('Vytvořeno', 'Created')}</th>
                   </tr>
                 </thead>
                 <tbody>
                   {filtered.map(c => (
-                    <tr key={c.id} className="border-t">
-                      <td className="px-4 py-2">
+                    <tr key={c.id}>
+                      <td>
                         <Link href={`/campaigns/${c.id}`} className="font-medium hover:underline">
                           {c.name}
                         </Link>
@@ -249,31 +249,31 @@ export default function CampaignsPage() {
                       </td>
                       {/* Human label for the reader, raw state kept as the title so the screen and
                           the state machine can never end up describing different things. */}
-                      <td className="px-4 py-2">
+                      <td>
                         <span title={c.state}><StatusBadge status={c.state} label={label(c.state)} /></span>
                       </td>
-                      <td className="px-4 py-2 font-mono text-xs">
+                      <td className="font-mono text-xs">
                         {c.segmentRef?.name}@{c.segmentRef?.version}
                       </td>
-                      {summary && <td className="px-4 py-2 text-xs">{summary[c.id]?.enrolled ?? 0}</td>}
-                      {summary && <td className="px-4 py-2 text-xs">{summary[c.id]?.sent ?? 0}</td>}
+                      {summary && <td className="text-xs">{summary[c.id]?.enrolled ?? 0}</td>}
+                      {summary && <td className="text-xs">{summary[c.id]?.sent ?? 0}</td>}
                       {/* Suppressed is tinted only when it happened: "0 suppressed" is the normal
                           case and colouring it would make every row look like it needs attention.
                           A non-zero here is the answer to "why was reach low", so it must not read
                           as ordinary. */}
                       {summary && (
                         <td
-                          className="px-4 py-2 text-xs"
+                          className="text-xs"
                           style={(summary[c.id]?.suppressed ?? 0) > 0 ? { color: 'var(--warning)', fontWeight: 600 } : undefined}
                         >
                           {summary[c.id]?.suppressed ?? 0}
                         </td>
                       )}
-                      <td className="px-4 py-2 text-xs">{c.createdBy}</td>
+                      <td className="text-xs">{c.createdBy}</td>
                       {/* The checker, shown next to the maker on purpose: the maker/checker pair is
                           the audit-relevant fact about an ACTIVE campaign, not a detail. */}
-                      <td className="px-4 py-2 text-xs">{c.approvedBy ?? '—'}</td>
-                      <td className="px-4 py-2 text-xs whitespace-nowrap">{fmtDate(c.createdAt)}</td>
+                      <td className="text-xs">{c.approvedBy ?? '—'}</td>
+                      <td className="text-xs whitespace-nowrap">{fmtDate(c.createdAt)}</td>
                     </tr>
                   ))}
                 </tbody>

--- a/openbank-admin-ui/src/app/segments/page.tsx
+++ b/openbank-admin-ui/src/app/segments/page.tsx
@@ -130,28 +130,28 @@ export default function SegmentsPage() {
 
       {!loading && !unavailable && items.length > 0 && (
         <div className="overflow-x-auto rounded-lg border">
-          <table className="w-full text-sm">
-            <thead className="bg-muted/50 text-left">
+          <table className="data-table">
+            <thead>
               <tr>
-                <th className="px-4 py-2 font-medium">{t('Segment', 'Segment')}</th>
-                <th className="px-4 py-2 font-medium">{t('Verze', 'Version')}</th>
-                <th className="px-4 py-2 font-medium">{t('Koho zahrnuje', 'Who it selects')}</th>
-                <th className="px-4 py-2 font-medium">{t('Velikost', 'Size')}</th>
+                <th>{t('Segment', 'Segment')}</th>
+                <th>{t('Verze', 'Version')}</th>
+                <th>{t('Koho zahrnuje', 'Who it selects')}</th>
+                <th>{t('Velikost', 'Size')}</th>
               </tr>
             </thead>
             <tbody>
               {items.map(s => (
-                <tr key={key(s)} className="border-t">
-                  <td className="px-4 py-2 font-medium">{s.name}</td>
-                  <td className="px-4 py-2 tabular-nums text-muted-foreground">v{s.version}</td>
-                  <td className="px-4 py-2">
+                <tr key={key(s)}>
+                  <td className="font-medium">{s.name}</td>
+                  <td className="tabular-nums text-muted-foreground">v{s.version}</td>
+                  <td>
                     <ul className="list-inside list-disc text-muted-foreground">
                       {s.rules.map(r => (
                         <li key={r}>{r}</li>
                       ))}
                     </ul>
                   </td>
-                  <td className="px-4 py-2">{renderPreview(s)}</td>
+                  <td>{renderPreview(s)}</td>
                 </tr>
               ))}
             </tbody>


### PR DESCRIPTION
## What

`/segments`, `/campaigns` and `/campaigns/[id]` render their tables with a hand-rolled
`w-full text-sm` + `bg-muted/50` + `px-4 py-2`-per-cell instead of the console's own `.data-table`.
The result does not look like the rest of the console: no uppercase column headers, no row hover, no
house padding or borders — a marketer moving between screens meets a different table on this one.

Measured, not impressionistic: **exactly three pages** hand-roll it, and they are exactly the
campaign family. The other 15 table pages in `src/app` use `.data-table`.

```
$ git grep -l 'table className="w-full text-sm"' -- src/app
campaigns/[id]  campaigns  segments
$ git grep -l 'table className="data-table"' -- src/app | wc -l
15
```

`.data-table` (globals.css:443) already supplies width, collapse, the 11px uppercase header, cell
padding, the row separators and the hover tint — so the per-cell classes are not just inconsistent,
they are duplicated worse.

## Why it keeps happening

This is the same failure as reinventing `.input` two PRs ago: the house primitive exists and
something was built next to it. Worth naming, because a third instance is cheaper to prevent than to
find.

## Verification

`npm test -- src/test/campaign src/test/segments` — 22 passed. `tsc --noEmit` clean. No
`px-4 py-2`, `bg-muted/50` or `w-full text-sm` remains in the three files.

Refs #3373
