### PR TITLE
fix(payments): deploy the card-issuance image that owns the delegation channel its config already declares

### DIFF
--- a/openbank-infra/gitops/components/payments/payments-services.yaml
+++ b/openbank-infra/gitops/components/payments/payments-services.yaml
@@ -1922,7 +1922,7 @@ spec:
           type: RuntimeDefault
       containers:
         - name: card-issuance-service
-          image: 265175468565.dkr.ecr.eu-north-1.amazonaws.com/openbank-card-issuance-service:sandbox-bc21905c
+          image: 265175468565.dkr.ecr.eu-north-1.amazonaws.com/openbank-card-issuance-service:sandbox-9ef6c0ab
           imagePullPolicy: IfNotPresent
           ports:
             - name: http


### PR DESCRIPTION

card-issuance-service is in CrashLoopBackOff and has been since 22:46, money-path,
16 restarts:

  SRMSG00071: Invalid channel configuration - the `connector` attribute must be set
  for channel `delegation-events-in`

The two halves of one change went out of step. The gitops ConfigMap
`card-issuance-service-msg-override` carries, at config_ordinal=500:

  mp.messaging.incoming.delegation-events-in.group.id=cardissuance-delegation
  mp.messaging.incoming.delegation-events-in.auto.offset.reset=earliest

which is enough to make SmallRye consider the channel DECLARED. The running image is
sandbox-bc21905c, built 2026-07-25, which has neither the `connector: smallrye-kafka`
line for that channel nor CardDelegationEventConsumer. A declared channel with no
connector is a hard boot failure, so the pod cannot start at all.

Config reached the cluster through gitops; the image did not, because auto-deploy's
can-i-deploy gate was blocked for most of the day (#3178). The manifest still pointed
at a 25-July image while ECR already had sandbox-9ef6c0ab from 20:52 today, which
carries both the connector config and the consumer class — verified in that commit
before pointing at it.

This only moves the image tag to the one the committed config has always described.

Refs #3178