### PR TITLE
fix(infra): give delegation-db its backup credentials, and enforce the gate that said so

### DIFF
--- a/.github/gates/gates.yaml
+++ b/.github/gates/gates.yaml
@@ -341,13 +341,30 @@ gates:
   # in exactly that state (issue #1444); sdd-db had been failing every WAL archive for three
   # days. NOT diff-scoped: it runs against whole repo state, because the gap is a MISSING
   # pair, and a PR that adds only the gitops half would not touch the .tf side at all.
-  # ADVISORY for now — add --enforce to flip.
+  #
+  # ENFORCED since 2026-08-02, and the reason is that advisory demonstrably did not work: on
+  # that day delegation-db shipped in exactly this state, the gate printed the warning naming
+  # the cluster and the one-line fix, and the change merged anyway. That is the fourth
+  # occurrence of a defect this gate was built to end.
+  #
+  # An advisory verdict is right where a human still has judgement to exercise. Here there is
+  # none left: "this database declares a backup and cannot possibly authenticate to perform
+  # it" is not a style opinion, it is a database with no recovery point, and the failure is
+  # invisible until someone needs a restore. Advisory only made it mergeable.
+  #
+  # Scope note — `mode: enforced` ALONE is vacuous for this checker (the repo has paid for
+  # that once already): it prints ::warning and exits 0 unless passed --enforce, so both
+  # halves are needed and both are set below. Verified falsifiable against the real defect,
+  # not a fixture: --enforce exits 1 on the unfixed tree and 0 with delegation added. The
+  # goalert-db finding stays a ::warning under --enforce by design — a cluster backing up to
+  # a bucket outside Terraform is a governance question with a real choice in it, which is
+  # exactly where advisory belongs.
   - id: db-backup-association-gate
-    name: "db-backup association gate — every backed-up CNPG cluster has pod identity (advisory)"
+    name: "db-backup association gate — every backed-up CNPG cluster has pod identity (enforced)"
     group: gitops
-    mode: advisory
+    mode: enforced
     run: |
-      python3 openbank-infra/scripts/check-db-backup-associations.py
+      python3 openbank-infra/scripts/check-db-backup-associations.py --enforce
 
   # A probed or scraped port must be a port the service opens (issue #2872, item 1).
   #

--- a/openbank-infra/aws/envs/sandbox-platform/db-backups.tf
+++ b/openbank-infra/aws/envs/sandbox-platform/db-backups.tf
@@ -212,6 +212,25 @@ locals {
     liveness         = { namespace = "control-liveness-sentinel", sa = "liveness-db" }
     product-catalog  = { namespace = "accounts", sa = "product-catalog-db" }
     releasesteward   = { namespace = "release-steward", sa = "releasesteward-db" }
+    # delegation-db is the FOURTH time this list has been the thing that lagged a new cluster,
+    # and the first one where the gate built to prevent it had already said so. It shipped
+    # 2026-08-02 with a barmanObjectStore, a ScheduledBackup, and no association, so every WAL
+    # archive failed from the first minute:
+    #
+    #   Barman cloud WAL archive check exception: Unable to locate credentials
+    #
+    # Confirmed the same way campaign was, rather than assumed: the pod carries no
+    # AWS_CONTAINER_CREDENTIALS_FULL_URI at all (accounts-db-1 does), so this is a missing
+    # association and not the #1759 admission-injection race a restart fixes. IMDS is
+    # unreachable from pods, so there is no fallback credential path — the archive can only
+    # ever fail.
+    #
+    # check-db-backup-associations.py flagged it correctly and the change merged anyway,
+    # because the gate was advisory. That is the actual defect this entry pays for, and it is
+    # fixed alongside: a check that can only ever be right about "this database has no
+    # backups" has no judgement left to exercise, so advisory just made it mergeable. The gate
+    # is now enforced.
+    delegation = { namespace = "delegation", sa = "delegation-db" }
   }
 }
 


### PR DESCRIPTION
## Linked issues

Closes #3489

## What

`delegation-db` shipped today with a `barmanObjectStore`, a `ScheduledBackup`, and **no EKS Pod Identity association**. Every WAL archive has failed since the first minute:

```
Barman cloud WAL archive check exception: Unable to locate credentials
```

The database has **no recovery point at all**.

## Diagnosed, not assumed

Confirmed the same way `campaign` was:

```
accounts-db-1    env | grep AWS_  -> AWS_CONTAINER_CREDENTIALS_FULL_URI, AWS_CONTAINER_AUTHORIZATION_TOKEN_FILE
delegation-db-1  env | grep AWS_  -> (nothing)
```

A missing association — **not** the #1759 admission-injection race that a pod restart fixes. IMDS is unreachable from pods (verified on both), so there is no fallback credential path; the archive could only ever fail.

## The half that matters more

`check-db-backup-associations.py` exists precisely to prevent this. It **flagged `delegation-db` correctly** and printed the exact one-line fix. The change merged anyway — the gate was advisory.

Fourth occurrence of the defect that gate was built to end:

| when | clusters | outcome |
|---|---|---|
| #1444 | `sdd-db`, `tpp-registry-db`, `vop-db` | every WAL archive failed; sdd-db for three days |
| after | `campaign-db` | ~48h of `PostgresWALArchiveFailing` |
| today | `delegation-db` | no backups, **and the gate had already said so** |

An advisory verdict is right where a human still has judgement to exercise. Here there is none left: *"this database declares a backup and cannot possibly authenticate to perform it"* is not a style opinion — it is a database with no recovery point, and there is no failure until someone needs a restore. Advisory only made it mergeable.

## Enforcement details

`mode: enforced` **alone would have been vacuous** for this checker — it prints `::warning` and exits 0 unless passed `--enforce`. The repo has paid for that distinction once already, so both halves are set.

Verified falsifiable against the **real** defect, not a fixture:

```
--enforce, unfixed tree      -> exit 1
--enforce, delegation added  -> exit 0
```

`goalert-db` stays a `::warning` under `--enforce` by design: a cluster backing up to a bucket outside Terraform is a governance question with a real choice in it, which is exactly where advisory belongs.

## Apply note

`sandbox-platform` has no CI apply pipeline. The association is applied out-of-band; merging this PR is the mandatory bookkeeping that keeps `main` aware of infra that is already live.
