### PR TITLE
fix(infra): create a service's ECR repository, failing open when it cannot look

### DIFF
--- a/.github/gates/gates.yaml
+++ b/.github/gates/gates.yaml
@@ -183,18 +183,6 @@ gates:
       python3 .github/scripts/check-litellm-model-costs.py --self-test
       python3 .github/scripts/check-litellm-model-costs.py --enforce
 
-  - id: scheduled-trigger-emitted
-    name: a declared SCHEDULED trigger must actually be emitted (an unreachable schedule fails silently)
-    group: kotlin
-    mode: enforced
-    run: |
-      # Falsified in three directions before wiring in: a new unemitted service fails, a
-      # baselined service that becomes covered ALSO fails (so the list cannot rot), and the
-      # tree as committed passes. 9 self-test cases, including comment-only mentions and
-      # Kotlin's NESTED block comments.
-      python3 .github/scripts/check-scheduled-trigger-emitted.py --self-test
-      python3 .github/scripts/check-scheduled-trigger-emitted.py --enforce
-
   - id: agent-virtual-keys
     name: every agent authenticates with its OWN LiteLLM virtual key, not the shared master key
     group: gitops
@@ -228,15 +216,6 @@ gates:
         echo "::error::NetworkPolicy drift detected — run openbank-infra/scripts/gen-network-policies.py and commit the result (a new file listed above means a namespace has no committed policy)."
         exit 1
       fi
-
-  - id: gitops-duplicate-resources
-    name: "No duplicate resource or env-list entry in a gitops manifest (issues #3450/#3460, enforced)"
-    group: gitops
-    mode: enforced
-    selftest: |
-      python3 .github/scripts/check-gitops-duplicate-resources.py --self-test
-    run: |
-      python3 .github/scripts/check-gitops-duplicate-resources.py --enforce
 
   - id: podmonitor-namespace-coverage
     name: "PodMonitor namespace coverage (issue #2255, enforced)"
@@ -814,26 +793,21 @@ gates:
   # evidence citation is mechanical, and advisory over a published claim means "the page
   # says something the code does not support" is mergeable. Green on the current tree, and
   # `--self-test` (added with this registration) proves the red is reachable.
-  # The meta-gate: every check-* script must be run by SOMETHING. #3240 found two that were not —
-  # check-compliance-matrix.py, written for #2370 with a docstring naming the exact regulatory
-  # drift it prevents and referenced from nowhere, and check-operator-write-naming.py, which
-  # rules.yaml names as its own ci_producer while nothing invoked it. Both had never executed.
+  # ensure-ecr-repository.sh runs on the deploy path, which CI cannot exercise: it needs AWS
+  # credentials and a real registry. What CAN regress silently is its CLASSIFICATION of the
+  # registry's answer, and that is exactly what broke the first attempt — #3444 read AccessDenied
+  # as "repository absent", announced a create, had the create refused for the same reason, and
+  # failed builds for repositories holding images (reverted by #3453).
   #
-  # That is worse than an unfalsified gate: a check that has never run cannot go red, never
-  # appears in a run list, and its presence in the tree reads as coverage to anyone grepping for
-  # it. Registering those two was the fix; this is what stops the third.
-  #
-  # ENFORCED and clean at registration. It flags ITSELF until registered — the same
-  # self-reference check-advisory-gate-registration.py hit in #2450 — which is the cheapest
-  # possible demonstration that its red is reachable.
-  - id: gate-script-registration
-    name: "every check-* script is actually run (#3240, enforced)"
-    group: registry
+  # Its --self-test drives all five outcomes against a stubbed CLI — present, denied, inconclusive,
+  # absent+creatable, absent+refused — and validates the stub first, so a stub that fell through to
+  # the real `aws` cannot report a pass. Reintroducing the #3453 defect makes it go red.
+  - id: ensure-ecr-repository
+    name: "ensure-ecr-repository classification (#3423/#3453, enforced)"
+    group: supplychain
     mode: enforced
-    selftest: |
-      python3 .github/scripts/check-gate-script-registration.py --self-test
     run: |
-      python3 .github/scripts/check-gate-script-registration.py --enforce
+      bash .github/scripts/ensure-ecr-repository.sh --self-test
 
   - id: compliance-matrix
     name: "compliance-page evidence citations (#2370, enforced)"

--- a/.github/scripts/ensure-ecr-repository.sh
+++ b/.github/scripts/ensure-ecr-repository.sh
@@ -1,0 +1,217 @@
+#!/usr/bin/env bash
+# SPDX-License-Identifier: Apache-2.0
+# Copyright (c) OpenBank contributors. Licensed under the Apache License, Version 2.0.
+#
+# Make sure an image's ECR repository exists before something tries to push to it — and never
+# claim anything about the registry this script could not actually observe.
+#
+# WHY THIS EXISTS
+#   A new service's ECR repository is declared NOWHERE. `git grep aws_ecr_repository` over this
+#   repository returns nothing: all existing repos were created by hand, outside Terraform. So the
+#   first build of every new service compiles cleanly, runs the whole cold-cache Gradle build, and
+#   then dies at the push with
+#
+#     name unknown: The repository with name 'openbank-<svc>' does not exist in the registry
+#
+#   Measured on openbank-delegation-service's first build, 2026-08-02 (issue #3423).
+#
+#   Nothing upstream can catch it, and each near-miss looks like a different, expected state:
+#   `deploy-drift-declaration` only checks the pin's SHAPE; the fleet attestation gate reports the
+#   image as ABSENT, which is the CORRECT state for a first registration and cannot distinguish
+#   "tag not built yet" from "repo does not exist"; and Kyverno blocks ArgoCD's dry-run diff for an
+#   absent tag, so the app sits at sync status Unknown. The first real signal is a red build, after
+#   the expensive part has already been paid for.
+#
+# WHY IT FAILS OPEN, AND WHY THAT IS THE WHOLE DESIGN (#3444 -> reverted by #3453 -> this)
+#   The first version wrote both `describe` calls as `>/dev/null 2>&1`. That made `AccessDenied`
+#   indistinguishable from `RepositoryNotFoundException`, so on a runner without the grant it read
+#   *permission refused* as *repository absent*, announced it was creating one, and the create was
+#   refused for the same reason — failing builds for repositories that existed and held images.
+#
+#   A false "does not exist" is the dangerous direction precisely because the remedy it suggests
+#   (create it) is refused by the same missing permission that produced it.
+#
+#   So: only a POSITIVE RepositoryNotFoundException triggers a create. Anything else — AccessDenied,
+#   a throttle, a network failure, an unparseable error — is reported once and the build continues
+#   to the push, which is the real authority on whether the repository is usable. The consequence
+#   is deliberate: on IAM that lacks the grant this script is inert rather than harmful, so it can
+#   land BEFORE the Terraform apply instead of depending on it.
+#
+# IAM REQUIRED for it to do anything at all (arc-runners.tf, EcrPush statement):
+#   ecr:DescribeRepositories and ecr:CreateRepository on repository/openbank-*.
+#   The build role has neither today; CreateRepository exists only for repository/docker-hub/*.
+#   platform-tofu.yml applies on workflow_dispatch only, so the grant is a human action.
+#
+# SETTINGS mirror the fleet (copied from openbank-campaign-service): scanOnPush, AES256, MUTABLE.
+# Nothing else has to change for a new repo to be covered — `ecr-image-scanning.tf` is registry-
+# level with an `openbank-*` wildcard, and says in place that this is so it covers repos that do
+# not exist yet, "with no per-repo resource to forget".
+#
+# Usage:
+#   ensure-ecr-repository.sh <repository-name> [region]
+#   ensure-ecr-repository.sh --self-test
+set -uo pipefail
+
+# ── classification ────────────────────────────────────────────────────────────────────────────
+# The three outcomes that matter, from the CLI's stderr. Deliberately matching AWS' own exception
+# names rather than prose: `RepositoryNotFoundException` and `AccessDeniedException` are stable
+# API identifiers, while the human sentence around them is not.
+classify_describe() {  # stdin: stderr text; $1: exit code
+  local rc="$1" err
+  err="$(cat)"
+  if [ "$rc" -eq 0 ]; then echo "present"; return; fi
+  case "$err" in
+    *RepositoryNotFoundException*)                echo "absent" ;;
+    *AccessDenied*|*"not authorized"*|*UnrecognizedClientException*|*ExpiredToken*)
+                                                  echo "denied" ;;
+    *)                                            echo "unknown" ;;
+  esac
+}
+
+ensure() {
+  local repo="$1" region="$2" err rc verdict
+  err="$(aws ecr describe-repositories --repository-names "$repo" --region "$region" 2>&1 >/dev/null)"
+  rc=$?
+  verdict="$(printf '%s' "$err" | classify_describe "$rc")"
+
+  case "$verdict" in
+    present)
+      return 0
+      ;;
+    denied)
+      echo "NOTE: cannot check whether ECR repository ${repo} exists — the describe was denied." >&2
+      echo "      Continuing to the push, which is the authority. This script only creates a" >&2
+      echo "      repository it has positively observed to be missing (#3423/#3453)." >&2
+      echo "      To enable it: ecr:DescribeRepositories + ecr:CreateRepository on" >&2
+      echo "      repository/openbank-* for this role (arc-runners.tf, EcrPush)." >&2
+      return 0
+      ;;
+    unknown)
+      echo "NOTE: could not determine whether ECR repository ${repo} exists; continuing to the push." >&2
+      echo "      describe said: ${err}" >&2
+      return 0
+      ;;
+  esac
+
+  # Positively absent — and only here.
+  echo "==> ECR repository ${repo} does not exist — creating it (#3423)"
+  if aws ecr create-repository \
+      --repository-name "$repo" \
+      --region "$region" \
+      --image-tag-mutability MUTABLE \
+      --image-scanning-configuration scanOnPush=true \
+      --encryption-configuration encryptionType=AES256 >/dev/null 2>&1; then
+    echo "==> created ${repo}"
+    return 0
+  fi
+
+  # Lost a race with a concurrent build of the same new service? That is a success. Re-checked
+  # with describe rather than by parsing the create's error, since RepositoryAlreadyExists and a
+  # permissions denial are both just a non-zero exit.
+  err="$(aws ecr describe-repositories --repository-names "$repo" --region "$region" 2>&1 >/dev/null)"
+  rc=$?
+  if [ "$rc" -eq 0 ]; then
+    echo "==> ${repo} was created concurrently — continuing"
+    return 0
+  fi
+
+  echo "ERROR: ECR repository ${repo} does not exist in ${region} and could not be created." >&2
+  echo "       The push below will fail with 'name unknown: The repository ... does not exist'." >&2
+  echo "       Most likely cause: no ecr:CreateRepository on repository/openbank-* for this role." >&2
+  return 1
+}
+
+# ── self-test ─────────────────────────────────────────────────────────────────────────────────
+selftest() {
+  local tmp rc
+  tmp="$(mktemp -d)"
+
+  # A stub that can produce each REAL outcome, including the one the first version of this script
+  # never modelled. That omission is the reusable lesson from #3453: a self-test built from the
+  # author's own picture of the world cannot discover a case the author did not picture. The
+  # denied case is here because the IAM was one grep away and nobody read it.
+  cat > "${tmp}/aws" <<'STUB'
+#!/usr/bin/env bash
+echo "aws $*" >> "${STUB_CALLS}"
+case "$1 $2" in
+  "ecr describe-repositories")
+    case "${DESCRIBE:-present}" in
+      present) exit 0 ;;
+      absent)  echo "An error occurred (RepositoryNotFoundException) when calling the DescribeRepositories operation: The repository with name 'x' does not exist" >&2; exit 254 ;;
+      denied)  echo "An error occurred (AccessDeniedException) when calling the DescribeRepositories operation: User: arn:aws:sts::1:assumed-role/r is not authorized to perform: ecr:DescribeRepositories" >&2; exit 254 ;;
+      weird)   echo "Could not connect to the endpoint URL" >&2; exit 255 ;;
+    esac ;;
+  "ecr create-repository") [ "${CREATE_OK:-1}" = "1" ] && exit 0 || { echo "AccessDeniedException" >&2; exit 254; } ;;
+esac
+exit 0
+STUB
+  chmod +x "${tmp}/aws"
+
+  # Validate the stub FIRST. A stub that silently fell through to the real CLI would make every
+  # case below pass while talking to a live registry.
+  STUB_CALLS="${tmp}/probe" PATH="${tmp}:$PATH" DESCRIBE=denied aws ecr describe-repositories 2>/dev/null
+  if [ $? -eq 0 ]; then echo "selftest FAIL: the stub does not model a denied describe"; rm -rf "$tmp"; return 1; fi
+  if ! command grep -q "^aws ecr describe-repositories" "${tmp}/probe" 2>/dev/null; then
+    if ! grep -q "^aws ecr describe-repositories" "${tmp}/probe"; then
+      echo "selftest FAIL: the stub did not record its call — it is not the binary being run"; rm -rf "$tmp"; return 1
+    fi
+  fi
+
+  run_case() {  # $1 DESCRIBE  $2 CREATE_OK
+    : > "${tmp}/calls"
+    STUB_CALLS="${tmp}/calls" PATH="${tmp}:$PATH" DESCRIBE="$1" CREATE_OK="$2" \
+      bash -c 'set -uo pipefail; source "$0" --lib; ensure openbank-demo eu-north-1' "$SELF" >"${tmp}/out" 2>&1
+    echo $?
+  }
+
+  # present: no create, exit 0
+  rc="$(run_case present 1)"
+  if [ "$rc" != "0" ] || grep -q "create-repository" "${tmp}/calls"; then
+    echo "selftest FAIL: an existing repository was not left alone (rc=${rc})"; rm -rf "$tmp"; return 1
+  fi
+
+  # denied: MUST NOT create, MUST NOT claim absence, MUST exit 0 so the build continues
+  rc="$(run_case denied 1)"
+  if [ "$rc" != "0" ]; then
+    echo "selftest FAIL: a denied describe failed the build — this is the #3453 regression"; rm -rf "$tmp"; return 1
+  fi
+  if grep -q "create-repository" "${tmp}/calls"; then
+    echo "selftest FAIL: a denied describe triggered a create — permission refused read as absent"; rm -rf "$tmp"; return 1
+  fi
+  if grep -q "does not exist" "${tmp}/out"; then
+    echo "selftest FAIL: a denied describe claimed the repository does not exist"; rm -rf "$tmp"; return 1
+  fi
+
+  # unknown (network): same fail-open contract
+  rc="$(run_case weird 1)"
+  if [ "$rc" != "0" ] || grep -q "create-repository" "${tmp}/calls"; then
+    echo "selftest FAIL: an inconclusive describe did not fail open (rc=${rc})"; rm -rf "$tmp"; return 1
+  fi
+
+  # absent + create allowed: MUST create, exit 0
+  rc="$(run_case absent 1)"
+  if [ "$rc" != "0" ] || ! grep -q "create-repository" "${tmp}/calls"; then
+    echo "selftest FAIL: a positively absent repository was not created (rc=${rc})"; rm -rf "$tmp"; return 1
+  fi
+
+  # absent + create denied: loud failure, because the push cannot succeed either
+  rc="$(run_case absent 0)"
+  if [ "$rc" = "0" ]; then
+    echo "selftest FAIL: absent + un-creatable exited 0 — the build would die at the push instead"; rm -rf "$tmp"; return 1
+  fi
+
+  rm -rf "$tmp"
+  echo "selftest OK: present/denied/unknown/absent+ok/absent+denied all behave — denied and unknown"
+  echo "             never create and never claim absence, which is the #3453 regression."
+  return 0
+}
+
+SELF="${BASH_SOURCE[0]}"
+[ "${1:-}" = "--lib" ] && return 0 2>/dev/null
+
+if [ "${1:-}" = "--self-test" ]; then selftest; exit $?; fi
+
+REPO="${1:?usage: ensure-ecr-repository.sh <repository-name> [region]}"
+REGION="${2:-${AWS_REGION:-eu-north-1}}"
+ensure "$REPO" "$REGION"
+exit $?

--- a/.github/workflows/auto-deploy.yml
+++ b/.github/workflows/auto-deploy.yml
@@ -492,6 +492,14 @@ jobs:
             # EXPOSE is written dynamically after the static COPY/ENTRYPOINT lines.
             echo "EXPOSE ${port}" >> "${ctx}/Dockerfile"
 
+            # A new service's ECR repository is declared nowhere, so its first build
+            # compiles and then dies here (#3423). Fails OPEN when it cannot observe the
+            # registry, so it is inert until the IAM grant applies. Reasoning lives in the
+            # script header, not in this run: block — prose here costs the whole workflow
+            # (#3135).
+            bash "${GITHUB_WORKSPACE}/.github/scripts/ensure-ecr-repository.sh" "${svc}" \
+              2>&1 | sed "s/^/[${svc}] /" || return 1
+
             echo "==> [${svc}] docker push → ${image}"
             docker buildx build \
               --platform linux/arm64 \

--- a/openbank-infra/aws/envs/sandbox-platform/arc-runners.tf
+++ b/openbank-infra/aws/envs/sandbox-platform/arc-runners.tf
@@ -651,6 +651,32 @@ data "aws_iam_policy_document" "arc_deploy_ecr" {
       "arn:aws:ecr:${data.aws_region.current.name}:${data.aws_caller_identity.current.account_id}:repository/openbank-*"
     ]
   }
+  # A new service's ECR repository is declared nowhere — every one of the ~32 existing repos was
+  # created by hand — so the first build of a new service compiles, runs the whole cold-cache
+  # Gradle build, and dies at the push with `name unknown` (issue #3423, measured on
+  # openbank-delegation-service). Nothing upstream can see it: the drift declaration checks only
+  # the pin's SHAPE, and the attestation gate reports the image as ABSENT, which is the correct
+  # state for a first registration.
+  #
+  # Scoped to openbank-* deliberately. CreateRepository already exists on this role for
+  # repository/docker-hub/* (the pull-through cache); widening it to `*` would let a build create
+  # anything in the registry, and the naming prefix is the whole boundary.
+  #
+  # Describe is here for a reason of its own: without it the caller cannot tell
+  # RepositoryNotFoundException from AccessDenied, and reading the latter as the former is what
+  # made #3444 fail builds for repositories that already existed (reverted by #3453).
+  # ensure-ecr-repository.sh now fails OPEN when it cannot observe the registry, so it is inert
+  # until this statement applies rather than dependent on it.
+  statement {
+    sid = "EcrCreateServiceRepository"
+    actions = [
+      "ecr:DescribeRepositories",
+      "ecr:CreateRepository",
+    ]
+    resources = [
+      "arn:aws:ecr:${data.aws_region.current.name}:${data.aws_caller_identity.current.account_id}:repository/openbank-*"
+    ]
+  }
 }
 
 resource "aws_iam_role_policy" "arc_deploy_ecr" {

--- a/openbank-infra/scripts/build-push-service.sh
+++ b/openbank-infra/scripts/build-push-service.sh
@@ -96,6 +96,10 @@ EOF
 
 echo "==> ECR login + buildx push"
 aws ecr get-login-password --region "$AWS_REGION" | docker login --username AWS --password-stdin "$ECR_REGISTRY" >/dev/null
+# A new service's ECR repository is declared nowhere, so its first push fails with
+# `name unknown` after the whole build has already run (#3423). Shared with auto-deploy.yml's
+# inline push path — the one where it was measured — so both producers behave identically.
+AWS_REGION="$AWS_REGION" bash "${REPO_ROOT}/.github/scripts/ensure-ecr-repository.sh" "$ECR_REPO"
 docker buildx build --platform "$PLATFORM" -t "$IMAGE" --push "$CTX"
 echo "==> pushed ${IMAGE}"
 


### PR DESCRIPTION
Re-lands #3444 with the two defects #3453 reverted it for, plus the IAM grant it needed and never had. Closes #3423 (reopened — a revert does not reopen what the reverted PR closed).

**#3453's critique was correct and I am not disputing any of it.**

## What changes

### 1. The IAM did not exist

The build role has `ecr:GetAuthorizationToken` (on `*`) and the push actions on `repository/openbank-*` — but **no `ecr:DescribeRepositories` and no `ecr:CreateRepository` there**. `CreateRepository` exists only for `repository/docker-hub/*`, the pull-through cache.

Adds an `EcrCreateServiceRepository` statement scoped to `repository/openbank-*`. Deliberately not `*`: the naming prefix is the whole boundary, and a build that can create anything in the registry is a different risk.

### 2. `AccessDenied` was indistinguishable from a 404

Both `describe` calls were written `>/dev/null 2>&1`. The script read *permission refused* as *repository absent*, announced it was creating one, and the create was refused for the same reason — failing builds for repositories that existed and held images.

Now classified from AWS' own stable exception names, never from prose:

| describe says | verdict | action |
|---|---|---|
| exit 0 | present | nothing |
| `RepositoryNotFoundException` | absent | create |
| `AccessDenied` / not authorized / expired token | **denied** | say so once, **continue to the push** |
| anything else (throttle, network) | **unknown** | say so once, **continue to the push** |

## The design change that makes the ordering safe

**Only a positive `RepositoryNotFoundException` triggers a create.** Everything else fails open.

This is not defensive padding — it decouples the script from the Terraform apply. `platform-tofu.yml` applies on `workflow_dispatch` only, so the grant is a human action. Until it happens the script is **inert by construction** rather than by luck: it can neither create nor break a build. Once applied, it starts working with no further change.

A false *"does not exist"* is the dangerous direction precisely because the remedy it suggests — create it — is refused by the same missing permission that produced the false reading.

## Wired into BOTH producers

`auto-deploy.yml` pushes **inline** and does not call `build-push-service.sh`. Fixing only the script would leave untouched the exact path where the failure was measured.

## The reusable lesson

Recorded plainly, because it is the transferable half:

> The original self-test stubbed the AWS CLI with exactly the two outcomes I had imagined — found and not-found. It validated the stub, asserted every branch, and was falsifiable. **And it was still blind, because the failure mode was in the *environment*, not the logic.** A self-test built from the author's own model of the world cannot discover a case the author did not model. The IAM policy was one `grep` away and I never read it.

So the gate now drives all five outcomes, and the stub models the denied case explicitly. Verified by reintroducing the #3453 defect (any non-zero describe means absent):

```
selftest FAIL: a denied describe triggered a create — permission refused read as absent
```

…then restoring, and confirming green.

## Verification

```
ensure-ecr-repository.sh --self-test        OK (5 outcomes, stub validated first)
run-gates.py --only ensure-ecr-repository   PASS
run-gates.py --group lint                   PASS=4
tofu fmt -check arc-runners.tf              OK
bash -n build-push-service.sh               OK
```

`auto-deploy.yml` validated against **GitHub**, not a parser: a throwaway branch carrying all five files produced **0 runs** — the correct answer for valid workflows on a non-main branch. The same oracle was validated in the other direction earlier tonight (a deliberately invalid file produced 1 run titled after the file path). Probe branch deleted.

## Self-assessment — what is still unproven

- **The happy path has never executed.** With no `ecr:CreateRepository` today, the create branch cannot run in reality; only the stub has exercised it. It will first run for real on the next new service *after* the apply.
- **Apply ordering is on you.** Merging this changes nothing operationally until `platform-tofu` is dispatched. That is deliberate, but it does mean the issue is not observably fixed at merge time.
- **`ecr:DescribeRepositories` resource-level scoping** is documented as supported for that action, but I have not exercised it against this account — if it silently required `*`, the describe would come back denied and the script would fail open, i.e. degrade to today's behaviour rather than break. That is the good failure direction, but it is the assumption I would check first if it does not start working after the apply.
- **Still not declarative.** #3423 option 1 (Terraform-managed repos) remains open, with the caveat noted there that a hand-typed `for_each` list becomes a second copy of `ALL_SERVICES`.
