### PR TITLE
chore(agent): record the OIDC issuer-override contract, and re-drive two stranded deploys

### DIFF
--- a/openbank-agent-service/src/main/resources/application.yaml
+++ b/openbank-agent-service/src/main/resources/application.yaml
@@ -27,6 +27,14 @@ quarkus:
         value: "max-age=31536000; includeSubDomains"
 
   oidc:
+    # LOCAL DEFAULT ONLY. Every deployed environment overrides this with
+    # QUARKUS_OIDC_AUTH_SERVER_URL (an env var outranks application.yaml in SmallRye Config),
+    # and a deployment that forgets to is not obviously broken: anonymous requests still answer
+    # 200/401 normally and only requests carrying a bearer fail — with 500, because token
+    # validation cannot reach an issuer at localhost inside the pod. security-scanner and
+    # analytics-sink shipped exactly that (#3433). Note also that QUARKUS_OIDC_ENABLED cannot
+    # switch OIDC off from the environment: quarkus.oidc.enabled is a BUILD-TIME property, so
+    # setting it in a manifest reads as "auth is off here" while the pod keeps validating.
     auth-server-url: http://localhost:8080/realms/openbank
     client-id: openbank-services
     credentials:

--- a/openbank-security-scanner/src/main/resources/application.yaml
+++ b/openbank-security-scanner/src/main/resources/application.yaml
@@ -78,6 +78,14 @@ quarkus:
   # was reachable with no authentication at all (issue found alongside the AmlCaseResource /
   # StandingOrderResource / TppRegistryResource unauthenticated-endpoint sweep).
   oidc:
+    # LOCAL DEFAULT ONLY — and this service is the reason the warning is worth writing down.
+    # Its deployment carried `QUARKUS_OIDC_ENABLED=false` and no issuer URL, which reads as
+    # "auth is off here" and is not: quarkus.oidc.enabled is a BUILD-TIME property, so an env
+    # var cannot switch OIDC off in a built image. The pod therefore validated every bearer
+    # against this localhost default, inside its own pod, where nothing listens. Anonymous
+    # requests answered 200/401 normally; every request WITH a token answered 500, which is
+    # what the admin-ui Security screen hit. Fixed by setting QUARKUS_OIDC_AUTH_SERVER_URL in
+    # the gitops manifest (#3443, #3433) — an env var outranks this value in SmallRye Config.
     auth-server-url: http://localhost:8080/realms/openbank
     client-id: openbank-services
     credentials:


### PR DESCRIPTION
## What

Comment-only change to two `application.yaml` files. Effective config is byte-identical — verified by parsing each YAML and printing `quarkus.oidc.auth-server-url` before and after.

It has two purposes, and the second one is stated openly rather than disguised.

## 1. The comment is worth having on its own

The localhost issuer in these files is a **local default**; every deployed environment overrides it with `QUARKUS_OIDC_AUTH_SERVER_URL`. A deployment that forgets to is **not obviously broken**:

- anonymous requests answer 200/401 normally,
- only requests carrying a **bearer** fail — with **500**, because validation cannot reach an issuer at `localhost` inside the pod.

`security-scanner` and `analytics-sink` shipped exactly that, and it went unnoticed for as long as nothing sent them a token ([#3433](https://github.com/JiRaska/open-bank-oss/issues/3433), fixed in [#3443](https://github.com/JiRaska/open-bank-oss/pull/3443)). The note also records that `QUARKUS_OIDC_ENABLED` **cannot** switch OIDC off from a manifest — `quarkus.oidc.enabled` is a *build-time* property, so setting it reads as "auth is off here" while the pod keeps validating.

## 2. It re-drives two stranded deploys

[#3371](https://github.com/JiRaska/open-bank-oss/pull/3371) (agent-service: `@Path` bound to a top-level function, `POST /mcp` answered 404) and [#3350](https://github.com/JiRaska/open-bank-oss/pull/3350) (security-scanner: Flyway never ran, database held zero tables) are both on `main` and **neither reached the cluster**. Their auto-deploy runs died in the `Detect changed services` breakage that [#3406](https://github.com/JiRaska/open-bank-oss/pull/3406) later fixed.

The 3-hourly reconcile cannot recover them. It is capped at `RECONCILE_MAX=12`, oldest-pin-first, and the whole #1985 co-deploy set occupies those 12 permanently because their pins never advance. Measured across the **last five scheduled ticks** — 12 services each, and neither of these two in any of them:

```
run 30761740836: [12 služeb]   run 30755027716: [12]   run 30748396593: [12]
run 30743028217: [12]          run 30737463468: [12]
```

That is starvation, not lag. Waiting is not a slower path to the same place.

## Nothing is bypassed

This is the ordinary push path. Both services are exempt from `can-i-deploy` under ADR-0092 for a **checkable** reason — they hold no contracts in either direction. Verified two independent ways:

- against the 34 committed pacts: neither service appears in any;
- against the source: no `@Provider` and no `@Pact` test in either module.

If either acquires a contract before this merges, the exemption stops applying and the run goes red rather than deploying — which is the correct failure direction.

## fraud-service is deliberately not here

It has real pacts (provider to sepa-payment, consumer of transaction) and sits inside the seven-way money-path deadlock of #1985. The only lever is `-f codeploy=true` over all seven, and that branch **skips `resolve-can-i-deploy-selector.sh`** — it asks `--latest main` while deploying `sandbox-<dispatch sha>` images, the exact sha-divergence [#3327](https://github.com/JiRaska/open-bank-oss/pull/3327) closed for the per-service path. Seven money-path services in one atomic move, on a weaker check, carrying other people's merges: that needs a human.

## Linked issues

Refs #3371, Refs #3350, Refs #1985
