### PR TITLE
fix(infra): stop bin-packing the fleet onto 4 GiB nodes that cannot hold it

### DIFF
--- a/openbank-infra/aws/envs/sandbox-platform/main.tf
+++ b/openbank-infra/aws/envs/sandbox-platform/main.tf
@@ -188,14 +188,54 @@ resource "kubectl_manifest" "nodepool_default" {
             { key = "kubernetes.io/arch", operator = "In", values = ["arm64"] },
             { key = "kubernetes.io/os", operator = "In", values = ["linux"] },
             { key = "karpenter.sh/capacity-type", operator = "In", values = ["spot", "on-demand"] },
-            { key = "karpenter.k8s.aws/instance-category", operator = "In", values = ["c", "m", "r"] },
+            # `c` dropped (2026-08-02): c-family is 2 GiB/vCPU, which after the
+            # fixed per-node tax below leaves ~1.2 GiB of usable memory per vCPU
+            # — less than this fleet's own request ratio (55.3 GiB of memory
+            # requests against 25.0 vCPU ≈ 2.2 GiB/vCPU). A c-family node is
+            # therefore memory-exhausted while still half-idle on CPU, which is
+            # exactly the state the evictions came from. m (4 GiB/vCPU) and r
+            # (8 GiB/vCPU) both clear the ratio; Karpenter still price-sorts
+            # within them.
+            { key = "karpenter.k8s.aws/instance-category", operator = "In", values = ["m", "r"] },
             { key = "karpenter.k8s.aws/instance-generation", operator = "Gt", values = ["5"] },
-            # Cap at 4xlarge: DaemonSet overhead (Alloy + Falco + node-exporter +
-            # kube-proxy + aws-node ≈ 350m CPU / 400Mi RAM) justifies large minimum.
-            # Without an upper bound Karpenter picked c6g.12xlarge (48 vCPU spot) for
-            # ~20 pods — grossly over-provisioned and expensive even at spot pricing.
-            # large–4xlarge gives good bin-packing while keeping per-node cost sane.
-            { key = "karpenter.k8s.aws/instance-size", operator = "In", values = ["large", "xlarge", "2xlarge", "4xlarge"] }
+            # xlarge–2xlarge (2026-08-02). `large` removed; `4xlarge` removed.
+            #
+            # WHY `large` HAD TO GO. The previous comment justified a `large`
+            # MINIMUM with "DaemonSet overhead ≈ 350m CPU / 400Mi RAM". That
+            # figure is stale by ~2.4x. Measured on the live `default` pool
+            # (21 nodes, Prometheus `container_memory_working_set_bytes`,
+            # max_over_time[12h], 2026-08-02):
+            #
+            #   alloy 636Mi | aws-node 167Mi | falco 77Mi | kube-proxy 32Mi
+            #   ebs-csi-node 28Mi | node-exporter 13Mi | pod-identity-agent 9Mi
+            #   -> 962Mi and 0.26 vCPU of DaemonSet, on EVERY node.
+            #
+            # Stack that on a 4 GiB `large`: capacity 4.00 GiB, allocatable
+            # 2.87 GiB (kubelet/system reserved eats 1.13 GiB), minus 962Mi of
+            # DaemonSet = ~1.93 GiB actually available to workloads. ~52% of the
+            # machine is overhead, and the EC2NodeClass evicts at
+            # memory.available < 500Mi soft / 300Mi hard — thresholds that sit
+            # inside the noise band of what is left. Measured peak headroom on
+            # the 17 `large` nodes ran 19Mi–1165Mi; the node at 19Mi is where
+            # kyc-service and sdd-service were evicted.
+            #
+            # The same 962Mi on an xlarge (16 GiB, m-family) is ~7% of the node,
+            # and usable memory per node goes 1.93 GiB -> ~12.8 GiB. This is a
+            # pure win, not a trade: price per USABLE vCPU is a wash
+            # (c8g.large $0.0159/hr vs m7g.xlarge $0.0156/hr, eu-north-1 spot,
+            # 2026-08-02) because the tax is per node, not per vCPU.
+            #
+            # WHY `4xlarge` ALSO WENT. r8g.4xlarge is 128 GiB — a single node
+            # would consume the entire `limits.memory` below, so one greedy
+            # provisioning decision could wedge the pool at 1 node. 2xlarge caps
+            # a single node at 8 vCPU / 64 GiB, which is still 2x the largest
+            # bin-packing group this pool has ever needed. The original hazard
+            # the upper bound was written for (Karpenter reaching for
+            # c6g.12xlarge) is unchanged and still guarded.
+            #
+            # Spot diversity is not a casualty: m/r, gen>5, xlarge–2xlarge is
+            # 22 instance types x 3 AZs = 66 spot pools.
+            { key = "karpenter.k8s.aws/instance-size", operator = "In", values = ["xlarge", "2xlarge"] }
           ]
           nodeClassRef = {
             group = "karpenter.k8s.aws"
@@ -255,9 +295,27 @@ resource "kubectl_manifest" "nodepool_default" {
       # leaving the deploy backbone Pending and stalling the drift roll. 48
       # gives the roll surge + honest requests room while still capping
       # runaway cost.
+      #
+      # 128Gi → 192Gi memory (2026-08-02), cpu unchanged at 48. The memory cap
+      # was calibrated to `large` nodes at ~2.7 GiB of capacity per vCPU. With
+      # the xlarge/2xlarge m|r floor above, 48 vCPU of m-family is 192 GiB of
+      # CAPACITY — so leaving the cap at 128Gi would make memory bind at 32
+      # vCPU and re-create the #809 stall (pool pinned, "all available instance
+      # types exceed limits for nodepool", pods Pending) with no CPU pressure
+      # anywhere. Setting memory to 4x the CPU cap makes CPU the single binding
+      # guardrail, which is what this block was always meant to be.
+      #
+      # This raises the CEILING, not the spend. Ceiling: 48 vCPU as m7g.xlarge
+      # spot = 12 x $0.0568/hr = $497/mo, against $455/mo for 48 vCPU of
+      # c8g.large — +$42/mo on a ceiling that is not approached. ACTUAL
+      # `default`-pool instance spend is ~$61/mo (Cost Explorer, 7d annualised,
+      # 2026-08-02) out of an $853/mo account total, and the shape change is
+      # expected to move it by less than $10/mo in either direction because
+      # price per usable vCPU is unchanged. For scale: cross-AZ data transfer
+      # (EUN1-DataTransfer-Regional-Bytes) is ~$809/mo on the same bill.
       limits = {
         cpu    = "48"
-        memory = "128Gi"
+        memory = "192Gi"
       }
     }
   })

--- a/openbank-infra/gitops/apps/alloy.yaml
+++ b/openbank-infra/gitops/apps/alloy.yaml
@@ -98,10 +98,30 @@ spec:
           # Karpenter's bin-packing and node count are unaffected. The cost is
           # headroom the pods may use, not capacity reserved up front — and the
           # alternative is a DaemonSet that crashloops and drops the fleet's logs.
+          #
+          # Request 320Mi → 640Mi (2026-08-02). Leaving the request alone was the
+          # right call for the limit-only change above, but it is what makes the
+          # bin-packing dishonest: Karpenter reserves 320Mi per node for a
+          # DaemonSet that actually holds ~2x that, so every node it sizes is
+          # short by the difference before a single workload pod lands.
+          # Prometheus, `container_memory_working_set_bytes`, 12h window over the
+          # 21 nodes of the `default` pool: p95 630Mi, max 654Mi. 640Mi ≈ p95 and
+          # still leaves 128Mi of burst under the 768Mi limit, so nothing about
+          # the OOM headroom above changes.
+          #
+          # Working set, not RSS, is the quantity chosen deliberately: it is what
+          # the kubelet compares against its eviction thresholds, so it is the
+          # only number that predicts an eviction.
+          #
+          # This is the larger half of a pair — see the `default` NodePool in
+          # openbank-infra/aws/envs/sandbox-platform/main.tf, which stops that
+          # per-node tax landing on 4 GiB nodes at all. Raising this request
+          # WITHOUT that change would push the pool into more small nodes and
+          # make things worse; the two must ship together.
           resources:
             requests:
               cpu: 50m
-              memory: 320Mi
+              memory: 640Mi
             limits:
               cpu: 300m
               memory: 768Mi


### PR DESCRIPTION
## Summary

`kyc/kyc-service` and `sdd/sdd-service` were evicted for node memory pressure. The obvious reading is "requests are too low" — and 20+ pods do run above their request. Measurement says that is the symptom. The cause is that 17 of the 21 nodes in the `default` Karpenter NodePool are 4 GiB `*.large` machines carrying ~2.09 GiB of fixed per-node overhead, leaving ~1.93 GiB for actual workloads with a 500Mi soft / 300Mi hard eviction threshold sitting inside the noise band.

This PR fixes the node shape and the one request that is genuinely, systematically dishonest (alloy). It deliberately does **not** ship the broader right-sizing table — see "What I did not do, and why".

## Type of change

- [x] fix (bug fix)

## Linked issues

Refs #809

## Measurement method

Source: Prometheus (`svc/kube-prometheus-stack-prometheus`, ns `observability`), metric `container_memory_working_set_bytes`.

**Working set, not RSS** — it is the quantity the kubelet compares against its eviction thresholds, so it is the only one that predicts an eviction.

**Window: 12h. Quantile: `max_over_time`, with `quantile_over_time(0.95, ...)` alongside.** The task asked for 7d. 7d does not exist: this Prometheus runs `retention: 12h`, `scrapeInterval: 30s`, one replica, a 5Gi PVC, **no** `remoteWrite`, and there is no Thanos/Mimir/Cortex/Victoria in the cluster. A `[7d]` range query returns the same 12h of samples with a longer selector. That limitation shapes the whole proposal and is the first entry in the self-critique below.

`max_over_time` was chosen for the *sizing* numbers because eviction is a peak event, not an average one; p95 is reported next to it so a reader can see when a number is one spike (alloy: p95 630Mi vs max 654Mi — not a spike).

Denominators come from the live API server (`kubectl get pods -A -o json`, `kubectl get nodes -o json`) rather than `kube_pod_container_resource_requests`, so historical churn (1135 ephemeral runner pods in 12h) cannot inflate the totals. An earlier pass that keyed on the metric series did exactly that and reported an 8.3 TiB fleet.

### Numbers — `default` NodePool, 21 nodes, 2026-08-02

| | value |
|---|---|
| Non-DaemonSet memory **requests** | 55.3 GiB |
| Non-DaemonSet **12h peak** | 40.3 GiB |
| Usable memory the pool actually offers | ~85 GiB |
| CPU requests / allocatable | 30.4 / 44 |

**The pool is over-requested in aggregate, and has 30 GiB of slack.** It is not short of memory; it is short of memory *in the right places*.

Fixed per-node overhead, every node:

| component | 12h max |
|---|---|
| alloy | 636Mi |
| aws-node | 167Mi |
| falco | 77Mi |
| kube-proxy | 32Mi |
| ebs-csi-node | 28Mi |
| node-exporter | 13Mi |
| eks-pod-identity-agent | 9Mi |
| **DaemonSet total** | **962Mi** (0.26 vCPU) |
| kubelet/system reserved (4 GiB node) | 1.13 GiB |
| **overhead on a 4 GiB node** | **~2.09 GiB (52%)** |

The `main.tf` comment this PR replaces justified a `large` *minimum* with "DaemonSet overhead ≈ 350m CPU / 400Mi RAM". That figure is stale by ~2.4x, and the conclusion inverts once it is corrected.

Peak headroom per node (allocatable − 12h peak usage):

- the 17 `large` (4 GiB) nodes: **19Mi to 1165Mi**. Nine of them below 600Mi, i.e. inside the 500Mi soft-eviction threshold. `ip-10-80-109-193` sat at **19Mi**.
- the 4 nodes with ≥ 8 GiB: **4.1 GiB to 11.7 GiB**. None evicted.

That correlation is the whole finding.

## Changes

- **`default` NodePool `instance-category`: `[c, m, r]` → `[m, r]`.** c-family is 2 GiB/vCPU; after the per-node tax that is ~1.2 GiB usable per vCPU, below this fleet's own request ratio (55.3 GiB / 25.0 vCPU ≈ 2.2 GiB/vCPU). A c node is memory-exhausted while still half-idle on CPU — exactly the observed state.
- **`instance-size`: `[large, xlarge, 2xlarge, 4xlarge]` → `[xlarge, 2xlarge]`.** Usable memory per node 1.93 GiB → ~12.8 GiB. `4xlarge` removed as well: `r8g.4xlarge` is 128 GiB and one such node would consume the entire pool memory limit.
- **`limits.memory`: `128Gi` → `192Gi`** (cpu unchanged at 48). The old cap was calibrated to `large` at ~2.7 GiB capacity/vCPU. Against an xlarge m|r floor it binds at 32 of the 48 permitted vCPU and re-creates the #809 stall — pool pinned, `all available instance types exceed limits for nodepool`, pods Pending, with no CPU pressure anywhere. 4x the CPU cap makes CPU the single binding guardrail, which is what that block was always meant to be.
- **alloy memory request: `320Mi` → `640Mi`.** #3487 raised alloy's *limit* to 768Mi and explicitly left the request at 320Mi so bin-packing would not move. That was right for a limit-only change and is the remaining half of the defect: Karpenter reserves 320Mi per node for a DaemonSet holding p95 630Mi / max 654Mi, so every node it sizes is ~330Mi short before a workload pod lands. 640Mi ≈ p95, leaving 128Mi of burst under the unchanged 768Mi limit.

These two must ship together. Raising alloy's request while `large` is still permitted would push the pool into *more* small nodes and make things worse.

## FinOps — delta and denominator

**This is the $0 option, and that is the reason it was chosen.** It converts existing per-node waste into usable capacity instead of buying capacity.

| | $/mo | % of bill |
|---|---|---|
| Total AWS account (Cost Explorer, 30d) | **853.45** | 100% |
| — all EC2 instance usage, whole cluster (7d annualised) | 116 | 13.6% |
| — `default` pool's share of that | **~61** | **7.1%** |
| — cross-AZ data transfer (`EUN1-DataTransfer-Regional-Bytes`) | **~809** | 95% of the EC2 line |

Price per **usable** vCPU is a wash: `c8g.large` $0.0260/hr for 1.64 usable vCPU = **$0.0159**; `m7g.xlarge` $0.0568/hr for 3.64 usable vCPU = **$0.0156** (eu-north-1 spot, measured 2026-08-02). The tax is per *node*, not per vCPU, so consolidating 21 two-vCPU nodes into ~7–8 four-vCPU nodes buys ~11 GiB of usable memory per node for nothing. **Expected delta: under $10/mo in either direction — under 1.2% of the bill.**

The raised cap is a **ceiling, not spend**: 48 vCPU as `m7g.xlarge` spot = $497/mo vs $455/mo as `c8g.large`, +$42/mo on a ceiling currently sitting at $61/mo actual.

**The alternative was priced and rejected.** Keeping `large` and raising requests to match reality needs ~13 GiB more of declared requests ⇒ ~7 more 4 GiB nodes ⇒ +~$15/mo, *and* breaches the existing 128Gi cap on the way, stranding pods Pending. It costs more and does not work.

**Separately, and much larger than anything in this PR:** cross-AZ data transfer stepped from ~$3/day to ~$33/day on 2026-07-27 and has held there for six days — a ~$809/mo run rate that is now the single largest EC2 cost in the account and ~11x what `openbank-infra/CLAUDE.md` records ("~$70/mo", measured 2026-07-16). That is out of scope here and filed separately; it is flagged because it is the number that matters, and because node consolidation nudges it in the right direction (more same-node locality) without being a fix for it.

## Self-critique — what would make this wrong

Written before implementing, and it changed the plan (see the last item).

1. **The 12h window is the biggest weakness.** A nightly batch, a weekly close, or a monthly FINREP render peaking outside it is invisible to every number above. Mitigation is structural rather than evidential: **every `limits` value in this PR is unchanged**, so an unmeasured spike has exactly the headroom it has today, and the node-shape change *adds* ~11 GiB of per-node headroom — an unmeasured spike is strictly better off after this than before. Falsify by: re-running the queries after a nightly window, or by raising retention (see below).
2. **`max_over_time` can be set by one transient.** Per-node DS overhead at p95 is ~800Mi rather than 962Mi. Both numbers are 2–2.4x the 400Mi the code claimed, so the conclusion does not depend on the quantile. Only the alloy request would move (p95 630 vs max 654), and it is set from p95.
3. **Spot pool diversity.** Dropping `c` and `large` cuts the eligible set. Counted, not assumed: m/r, gen>5, xlarge–2xlarge is 22 instance types × 3 AZs = 66 spot pools, well above the flexibility AWS recommends. **Not verified: the resulting interruption rate.** Residual risk accepted; the pool permits `on-demand` fallback.
4. **Bigger nodes mean a bigger spot-interruption blast radius** — ~4x the pods per node. Not modelled. Partially offset by the fact that a `large` node loss today already takes ~15 pods, and that the only PDB in the cluster with zero allowed disruptions (`vault/openbao`) is a singleton that a node loss already reschedules.
5. **Raising the cap raises the worst case.** If the shape reasoning is wrong and Karpenter provisions greedily, the bill can rise toward $497/mo. Falsify by watching `kubectl get nodepool default -o jsonpath='{.status.resources}'` after apply; the CPU cap of 48 is unchanged and still binds first.
6. **I did not verify the eviction events myself** — the kyc/sdd eviction reasons came from the task, not from my own `kubectl describe`. The 19Mi-headroom node is independent evidence and stands on its own.
7. **I did not verify that anything lints the Terraform.** There is no `terraform fmt`/`validate`/`tflint` gate anywhere in `.github/`. HCL brace/bracket balance was checked by hand; the `tofu plan` job on this PR is the real check, and it must be read before merging.

**What the self-review changed:** the original plan also cut ~30 workloads' requests (postgres sidecars at 3–4x their peak, `document-renderer` 512Mi→64Mi, several temporal components 512Mi→96Mi) and cut `falco` 256Mi→128Mi. Item 1 rules those out: a 12h window cannot license a request *cut*, that is the one direction that bites, and it would free ~4 GiB on a pool that already has 30 GiB of slack — near-zero upside against a real downside. Dropped. Everything remaining moves the safe way.

## How to falsify these numbers

```
kubectl -n observability port-forward svc/kube-prometheus-stack-prometheus 19090:9090
# per-container 12h peak working set
curl -s --data-urlencode 'query=max by (namespace,pod,container) (max_over_time(container_memory_working_set_bytes{container!=""}[12h]))' localhost:19090/api/v1/query
# retention (expect 12h — this is the constraint)
kubectl -n observability get prometheus -o jsonpath='{.items[*].spec.retention}'
# per-node allocatable vs the DaemonSet sum
kubectl get nodes -l karpenter.sh/nodepool=default -o custom-columns='N:.metadata.name,T:.metadata.labels.node\.kubernetes\.io/instance-type,ALLOC:.status.allocatable.memory'
# pool state
kubectl get nodepool default -o jsonpath='{.status.resources}'
```

## Deploying this

`openbank-infra/aws/envs/sandbox-platform/main.tf` is **not** applied by merging. `platform-tofu.yml` runs `tofu plan` on this PR (read it) and applies only on manual `workflow_dispatch` against `main`. The alloy half is ArgoCD-synced and lands on merge.

Order matters: **apply the Terraform first, or at the same time.** The alloy request rise on its own increases declared demand against the old `large`-permitting pool and the old 128Gi cap, which is the wrong direction.

Expect Karpenter to roll all 17 `large` nodes; the existing disruption budget allows 50% outside 20:00–07:00 UTC and 0% inside it, so a merge shortly before 20:00 UTC will half-finish and resume in the morning.

## Definition of Done

- [x] Docs updated — both changed blocks carry the measurement and the reasoning in place; the stale "≈ 350m CPU / 400Mi RAM" claim is corrected rather than deleted.
- [x] No new lint warnings (`yamllint` with the `gates.yaml` config: clean).
- [ ] N/A: hexagonal layering, unit/integration/contract tests, Gradle gate, OpenAPI, Flyway, Avro — infrastructure-only change, no service code.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
