### PR TITLE
fix(admin-ui): convert the enrolment table to the house style too

### DIFF
--- a/openbank-admin-ui/src/components/campaigns/PeopleSummary.tsx
+++ b/openbank-admin-ui/src/components/campaigns/PeopleSummary.tsx
@@ -96,26 +96,26 @@ export function PeopleSummary({
           {t('Jednotliví lidé (pro ladění)', 'Individual people (for debugging)')} — {n(rows.length)}
         </summary>
         <div className="overflow-x-auto border-t">
-          <table className="w-full text-sm">
-            <thead className="bg-muted/50 text-left">
+          <table className="data-table">
+            <thead>
               <tr>
-                <th className="px-4 py-2 font-medium">{t('Party', 'Party')}</th>
-                <th className="px-4 py-2 font-medium">{t('Stav', 'State')}</th>
-                <th className="px-4 py-2 font-medium">{t('Krok', 'Step')}</th>
+                <th>{t('Party', 'Party')}</th>
+                <th>{t('Stav', 'State')}</th>
+                <th>{t('Krok', 'Step')}</th>
               </tr>
             </thead>
             <tbody>
               {rows.map(e => (
-                <tr key={e.id} className="border-t" data-state={e.state}>
+                <tr key={e.id} data-state={e.state}>
                   {/* Name when we have it, short id when we do not — the full id stays in `title`,
                       because the id is what goes into a support ticket. */}
-                  <td className="px-4 py-2 text-xs" title={e.partyId}>
+                  <td className="text-xs" title={e.partyId}>
                     {partyNames[e.partyId] ?? <span className="font-mono">{e.partyId.slice(0, 8)}</span>}
                   </td>
-                  <td className="px-4 py-2">
+                  <td>
                     <StatusBadge status={e.state} label={stateLabel(e.state)} tone={STATE_TONE[e.state] ?? 'neutral'} />
                   </td>
-                  <td className="px-4 py-2">{e.currentStep}</td>
+                  <td>{e.currentStep}</td>
                 </tr>
               ))}
             </tbody>


### PR DESCRIPTION
## What

`PeopleSummary` — the enrolment table on the campaign detail screen — still hand-rolls
`w-full text-sm` + `bg-muted/50` + per-cell padding. #3480 converted the three campaign *pages* and
missed it, because it is a component.

## How the miss was caught

Not by review. The post-deploy probe for #3480 asserted the new class was present **and the old
strings were gone**:

```
data-table         36
w-full text-sm     2     ← expected 0
bg-muted/50        2     ← expected 0
```

The negative half is what found this; the positive half was already satisfied. A probe that only
confirms what you hoped for cannot tell "converted" from "partly converted".

## A correction to #3480's claim

That PR said the hand-rolled style was confined to exactly three pages, on the strength of

```
git grep -l 'table className="w-full text-sm"' -- src/app
```

That search was narrower than the claim: it only covered `src/app`, so components were invisible to
it. A survey of every `<table>` in `src` shows the estate is mixed — `.data-table` (15), inline
`style={{ borderCollapse … }}` (aml, approvals, cards, clearing, day-end ×3), and a `.table` class
(consents, customer-360). The campaign family is now uniformly `.data-table`; the rest is a
pre-existing inconsistency this PR does not touch, and no longer something #3480 should be read as
having ruled out.

## Verification

`npm test -- src/test/campaign src/test/segments` — 22 passed. `tsc --noEmit` clean. The remaining
`px-4 py-2` in the file is on the `<summary>` element, not a table cell.

Refs #3480
