### PR TITLE
ci(gates): elect one Gradle cache writer and gate the writer budget

### DIFF
--- a/.github/gates/gates.yaml
+++ b/.github/gates/gates.yaml
@@ -536,6 +536,23 @@ gates:
     run: |
       python3 .github/scripts/check-workflow-run-step-size.py
 
+  # Gradle Actions-cache writer budget (issue #3299). The pool has been over its 10 GB
+  # ceiling continuously (11.7 GB / 92 entries on 2026-08-02), so GitHub evicts LRU and the
+  # only symptom is somebody's job re-resolving dependencies — never a red check. What
+  # fills it is the number of jobs WRITING: each writing run stores a ~200 MB build-cache
+  # entry and, on any shift in the resolved set, a whole new ~700-850 MB dependencies entry.
+  # Nothing counted the writers, so a workflow adding `setup-gradle` with no cache inputs
+  # silently became one (the default writes on main). This declares every usage's mode and
+  # fails on drift in EITHER direction — new, changed, or removed.
+  - id: gradle-cache-writer-budget
+    name: "Gradle Actions-cache writer budget (issue #3299, enforced)"
+    group: lint
+    mode: enforced
+    selftest: |
+      python3 .github/scripts/check-gradle-cache-writers.py --self-test
+    run: |
+      python3 .github/scripts/check-gradle-cache-writers.py --enforce
+
   # co-deploy set derivation unit test (issue #1985). The classifier above says WHAT KIND
   # of block a service has; this one says whether the block can be resolved by deploying
   # that service at all. Two services that name each other never converge one at a time,

--- a/.github/scripts/check-gradle-cache-writers.py
+++ b/.github/scripts/check-gradle-cache-writers.py
@@ -1,0 +1,416 @@
+#!/usr/bin/env python3
+# SPDX-License-Identifier: Apache-2.0
+# Copyright (c) OpenBank contributors. Licensed under the Apache License, Version 2.0.
+# See LICENSE in the repository root or https://www.apache.org/licenses/LICENSE-2.0 for details.
+"""Every Gradle-cache consumer in CI declares, here, whether it may WRITE the cache.
+
+Background (#3299). The repo's GitHub Actions cache sits permanently over its 10 GB
+ceiling — measured 2026-08-02 at 11.7 GB across 92 entries — so GitHub evicts
+least-recently-used entries continuously. Nothing goes red: eviction shows up as a job
+re-downloading dependencies, never as a failed check.
+
+What actually fills it is the WRITE rate, not stale junk. Every entry in the pool had
+been accessed within the preceding ~30 minutes, which means the pool is already nothing
+but live entries and a janitor would have nothing to delete. Each cache-writing job-run
+stores a fresh `gradle-build-cache-v1` entry (~200 MB) and, whenever the fleet's resolved
+dependency set shifts by even one artifact, an entire new `gradle-dependencies-v1` entry
+of ~700-850 MB — the entry is content-addressed over the whole `modules-2` tree, so two
+jobs resolving almost-the-same set still store it twice. That is how 9 near-identical
+dependency entries came to hold 6.1 GB, 60% of the pool.
+
+So the lever is the number of jobs writing, and `setup-gradle`'s own documentation
+prescribes the shape ("Select which jobs should write to the cache"): elect ONE writer
+per OS+architecture and make every other job a consumer. `gradle-home-cache-strict-match`
+defaults to false, so consumers still restore across job boundaries.
+
+WHY A GATE AND NOT A COMMENT
+    The budget is only stable while something notices a new entrant. A workflow that adds
+    `setup-gradle` with no cache inputs writes by default, silently, and the only symptom
+    is somebody else's job getting slower days later. #3131's nightly sweep was written
+    without `cache: gradle` deliberately, and nothing in the tree recorded that intent.
+
+    So this is a DRIFT check in both directions, not an allowlist. Every usage is declared
+    below with the mode its YAML must produce. A new usage fails as undeclared; a declared
+    usage whose YAML changes mode fails as drift; a declared usage that disappears fails as
+    stale. None of the three can be resolved by editing this file alone without saying what
+    changed.
+
+    It does NOT check `runs-on`. Whether the runner is self-hosted is a property of the
+    expression, not of the step, and the ARC lane's NAT-egress reason for disabling the
+    cache entirely is documented at its own call site.
+
+Usage:
+    check-gradle-cache-writers.py             # warn
+    check-gradle-cache-writers.py --enforce   # fail
+    check-gradle-cache-writers.py --self-test # prove it can fail
+    check-gradle-cache-writers.py --list      # print the derived modes (to update DECLARED)
+"""
+
+from __future__ import annotations
+
+import argparse
+import pathlib
+import sys
+import tempfile
+
+import yaml
+
+WORKFLOW_DIR = pathlib.Path(".github/workflows")
+
+SETUP_GRADLE = "gradle/actions/setup-gradle"
+SETUP_JAVA = "actions/setup-java"
+
+# ---------------------------------------------------------------------------
+# THE DECLARED BUDGET
+#
+# key   "<workflow file>::<job id>"
+# mode  what the step's cache inputs must resolve to. One of:
+#         writes-on-main — no explicit input. NOT "always writes": `cache-read-only`
+#                          defaults to `${{ github.ref_name != default_branch }}`, so
+#                          silence already means "write on main, restore elsewhere".
+#         writes-always  — `cache-read-only: false` LITERALLY, which overrides that
+#                          default and writes on feature branches too.
+#         read-only      — restores, never writes (`cache-read-only: true` literally)
+#         disabled       — does not touch the Actions cache at all
+#         conditional    — an expression decides; may or may not write
+#         setup-java     — actions/setup-java `cache: gradle`
+# why   the justification. Required, and required to be non-empty, for every entry —
+#       this is the "any new workflow adding entries justifies them" half of #3299.
+#
+# The invariant this budget encodes: at most ONE `writer`/`conditional` entry per
+# OS+architecture on Linux-X64, which today is fleet-lint. Everything else restores.
+# ---------------------------------------------------------------------------
+DECLARED: dict[str, tuple[str, str]] = {
+    "fleet-lint.yml::fleet-lint": (
+        "conditional",
+        "THE designated Linux-X64 writer. Runs `testClasses detekt ktlintCheck` fleet-wide "
+        "on every push to main, so its Gradle home is a near-superset of what every other "
+        "fleet job needs. Writes on main only (`cache-read-only` is true off main).",
+    ),
+    "dependency-submission.yml::submit": (
+        "read-only",
+        "Demoted from writer in #3299. The only fleet-wide Gradle job nobody waits on: not "
+        "a required check, push/schedule-triggered, 4.8-8.5 min against a 30 min timeout. "
+        "Restores fleet-lint's home and re-downloads only the runtime-only artifacts "
+        "`assemble` needs beyond it.",
+    ),
+    "security.yml::codeql": (
+        "writes-on-main",
+        "Left as-is deliberately. Its java-kotlin leg documents a 25-30 min cold penalty and "
+        "is the most preemption-exposed job in the fleet, so demoting it would trade a felt "
+        "regression for headroom already obtained more cheaply elsewhere. Revisit only with "
+        "a measurement showing fleet-lint's entry covers `testClasses` for it.",
+    ),
+    "auto-deploy.yml::build-push": (
+        "writes-always",
+        "Runs on ubuntu-24.04-arm — a Linux-ARM64 cache scope with NO other writer, so "
+        "demoting it would leave the arm64 lane permanently cold rather than sharing an "
+        "entry. Its entries are also the smallest in the pool (~7 MB across 3). NOTE the "
+        "mode: its explicit `cache-read-only: false` writes on feature branches too, which "
+        "the action's default would not. Left unchanged in #3299 because the arm64 pool is "
+        "~0.06% of the total, but it is the first thing to revisit if arm64 entries grow.",
+    ),
+    "ghcr-publish.yml::publish": (
+        "writes-on-main",
+        "Same Linux-ARM64 scope and the same reasoning as auto-deploy's build-push.",
+    ),
+    "_service-ci.yml::build": (
+        "conditional",
+        "Provably never writes, by two complementary expressions: `cache-disabled` on "
+        "self-hosted (ARC NAT egress, ~$200/mo) and `cache-read-only` on GitHub-hosted. "
+        "Declared so that changing EITHER expression alone — which would silently re-arm "
+        "26 per-service writers — shows up here.",
+    ),
+    "api-fuzz.yml::fuzz": ("read-only", "Consumer; restores fleet-lint's home."),
+    "api-fuzz-authenticated.yml::fuzz-authenticated": (
+        "read-only",
+        "Consumer; restores fleet-lint's home.",
+    ),
+    "swift-boot-it-probe.yml::probe": (
+        "disabled",
+        "Boot probe; builds one service and needs no cross-run Gradle state.",
+    ),
+    "pitest.yml::pitest": (
+        "setup-java",
+        "Weekly mutation-testing sweep on a schedule. `actions/setup-java` keys its Gradle "
+        "cache on the build files, so it re-uses one entry across runs rather than storing a "
+        "new one per run; it is not part of the per-run churn this budget limits.",
+    ),
+    "pact-drift-check.yml::drift-check": (
+        "setup-java",
+        "Same setup-java keying as pitest; regenerates consumer pacts and diffs them.",
+    ),
+    "services-ci.yml::verification-metadata": (
+        "setup-java",
+        "Same setup-java keying as pitest.",
+    ),
+    "dependabot-verification-metadata.yml::refresh-metadata": (
+        "setup-java",
+        "Same setup-java keying as pitest.",
+    ),
+}
+
+
+# Modes that can put a new entry into the pool on at least one ref.
+WRITE_CAPABLE = ("writes-on-main", "writes-always", "conditional")
+
+# A ratchet, not a law: it equals today's count, so ADDING a write-capable job fails
+# until someone raises it on purpose. #3299's whole finding is that the pool is filled
+# by the number of writers, and nothing previously counted them.
+WRITER_BUDGET = 5
+
+
+def write_capable(found: dict[str, str]) -> list[str]:
+    return sorted(k for k, m in found.items() if m in WRITE_CAPABLE)
+
+
+def _is_true(value: object) -> bool:
+    """A LITERAL yes. A ${{ }} expression is never treated as a decided value."""
+    if isinstance(value, bool):
+        return value
+    return str(value).strip().lower() == "true"
+
+
+def _is_expression(value: object) -> bool:
+    return "${{" in str(value)
+
+
+def classify(step: dict) -> str | None:
+    """Derive the cache mode a single workflow step resolves to, or None if it has none."""
+    uses = str(step.get("uses", ""))
+    with_ = step.get("with") or {}
+    if not isinstance(with_, dict):
+        with_ = {}
+
+    if uses.startswith(SETUP_JAVA):
+        cache = with_.get("cache")
+        return "setup-java" if str(cache).strip() == "gradle" else None
+
+    if not uses.startswith(SETUP_GRADLE):
+        return None
+
+    disabled = with_.get("cache-disabled")
+    read_only = with_.get("cache-read-only")
+
+    # A decided "never touches the cache" beats everything else.
+    if disabled is not None and _is_true(disabled):
+        return "disabled"
+    if read_only is not None and _is_true(read_only):
+        return "read-only"
+    # Anything expression-shaped resolves per ref or per runner. Do not guess which —
+    # `_service-ci` is never a writer only because TWO complementary expressions cover
+    # each other, which no per-step rule can see.
+    if _is_expression(disabled) or _is_expression(read_only):
+        return "conditional"
+    # A LITERAL false overrides the action's safe default and writes on every ref,
+    # feature branches included. That is strictly worse than saying nothing.
+    if read_only is not None and str(read_only).strip().lower() == "false":
+        return "writes-always"
+    # Nothing said. `cache-read-only` DEFAULTS to
+    # `${{ github.ref_name != default_branch }}`, so silence means "writes on main".
+    return "writes-on-main"
+
+
+def scan(workflow_dir: pathlib.Path) -> dict[str, str]:
+    """Map "<file>::<job>" -> derived mode for every Gradle-cache usage found."""
+    found: dict[str, str] = {}
+    for path in sorted(workflow_dir.glob("*.yml")) + sorted(workflow_dir.glob("*.yaml")):
+        try:
+            doc = yaml.safe_load(path.read_text(encoding="utf-8"))
+        except yaml.YAMLError:
+            continue
+        if not isinstance(doc, dict):
+            continue
+        for job_id, job in (doc.get("jobs") or {}).items():
+            if not isinstance(job, dict):
+                continue
+            for step in job.get("steps") or []:
+                if not isinstance(step, dict):
+                    continue
+                mode = classify(step)
+                if mode is None:
+                    continue
+                key = f"{path.name}::{job_id}"
+                # setup-gradle is the meaningful signal when a job has both.
+                if key not in found or found[key] == "setup-java":
+                    found[key] = mode
+    return found
+
+
+def evaluate(found: dict[str, str], declared: dict[str, tuple[str, str]]) -> list[str]:
+    """Return one problem line per disagreement between YAML and the declared budget."""
+    problems: list[str] = []
+
+    for key, mode in sorted(found.items()):
+        if key not in declared:
+            problems.append(
+                f"UNDECLARED  {key} uses the Gradle cache (mode `{mode}`) but is not in "
+                f"DECLARED. Add it with a reason — a new writer costs every other job "
+                f"cache headroom (#3299)."
+            )
+            continue
+        want, why = declared[key]
+        if not why.strip():
+            problems.append(f"NO-REASON   {key} is declared with an empty justification.")
+        if mode != want:
+            problems.append(
+                f"DRIFT       {key} is declared `{want}` but its YAML now resolves to "
+                f"`{mode}`."
+            )
+
+    for key in sorted(declared):
+        if key not in found:
+            problems.append(
+                f"STALE       {key} is declared but no longer uses the Gradle cache. "
+                f"Remove the declaration."
+            )
+
+    # The point of the budget: one writer per cache scope. Anything that can write on
+    # Linux-X64 beyond the elected one is what put the pool over its ceiling.
+    writers = write_capable(found)
+    if len(writers) > WRITER_BUDGET:
+        problems.append(
+            f"BUDGET      {len(writers)} jobs can write the Gradle cache "
+            f"({', '.join(writers)}), over the budget of {WRITER_BUDGET}. Raising the "
+            f"budget is a deliberate act — say why in the PR (#3299)."
+        )
+    return problems
+
+
+# ---------------------------------------------------------------------------
+# Self-test: prove the RED is reachable, and prove the green is not vacuous.
+# ---------------------------------------------------------------------------
+_STEP = "      - uses: {uses}\n        with:\n{inputs}"
+
+
+def _wf(uses: str, inputs: str) -> str:
+    body = "".join(f"          {line}\n" for line in inputs.splitlines() if line)
+    return "on: push\njobs:\n  j:\n    steps:\n" + _STEP.format(uses=uses, inputs=body)
+
+
+def self_test() -> int:
+    cases = [
+        # (name, workflow yaml, declared budget, must_flag)
+        (
+            "undeclared writer (no cache inputs at all) is flagged",
+            _wf(SETUP_GRADLE + "@v6", "dependency-graph: generate"),
+            {},
+            True,
+        ),
+        (
+            "declared read-only is NOT flagged",
+            _wf(SETUP_GRADLE + "@v6", "cache-read-only: true"),
+            {"w.yml::j": ("read-only", "consumer")},
+            False,
+        ),
+        (
+            "declared read-only that silently became a writer is flagged",
+            _wf(SETUP_GRADLE + "@v6", "dependency-graph: generate"),
+            {"w.yml::j": ("read-only", "consumer")},
+            True,
+        ),
+        (
+            "an expression is `conditional`, never mistaken for read-only",
+            _wf(SETUP_GRADLE + "@v6", "cache-read-only: ${{ github.ref != 'refs/heads/main' }}"),
+            {"w.yml::j": ("read-only", "consumer")},
+            True,
+        ),
+        (
+            "a declaration with no reason is flagged",
+            _wf(SETUP_GRADLE + "@v6", "cache-read-only: true"),
+            {"w.yml::j": ("read-only", "   ")},
+            True,
+        ),
+        (
+            "a stale declaration (usage removed) is flagged",
+            "on: push\njobs:\n  j:\n    steps:\n      - run: echo hi\n",
+            {"w.yml::j": ("read-only", "consumer")},
+            True,
+        ),
+        (
+            "an explicit `cache-read-only: false` is `writes-always`, not `writes-on-main` "
+            "(it overrides the action's write-on-main-only default)",
+            _wf(SETUP_GRADLE + "@v6", "cache-read-only: false"),
+            {"w.yml::j": ("writes-on-main", "writer")},
+            True,
+        ),
+        (
+            "silence is `writes-on-main`, not `writes-always`",
+            _wf(SETUP_GRADLE + "@v6", "dependency-graph: generate"),
+            {"w.yml::j": ("writes-always", "writer")},
+            True,
+        ),
+        (
+            "setup-java without `cache: gradle` is not a Gradle-cache usage",
+            _wf(SETUP_JAVA + "@v5", "distribution: temurin"),
+            {},
+            False,
+        ),
+        (
+            "setup-java WITH `cache: gradle` must be declared",
+            _wf(SETUP_JAVA + "@v5", "cache: gradle"),
+            {},
+            True,
+        ),
+    ]
+
+    failures = 0
+    for name, wf_text, declared, must_flag in cases:
+        with tempfile.TemporaryDirectory() as tmp:
+            d = pathlib.Path(tmp)
+            (d / "w.yml").write_text(wf_text, encoding="utf-8")
+            problems = evaluate(scan(d), declared)
+        flagged = bool(problems)
+        ok = flagged == must_flag
+        failures += 0 if ok else 1
+        verdict = "ok" if ok else "WRONG"
+        want = "flag" if must_flag else "pass"
+        print(f"  [{verdict:5s}] must {want:4s}: {name}")
+        if not ok:
+            print(f"           got: {problems or 'no findings'}")
+
+    if failures:
+        print(
+            f"\nself-test: {failures} case(s) wrong — the check does not measure what it claims."
+        )
+        return 1
+    print("\nself-test: OK — flags a new writer, drift, a stale entry and a missing reason; "
+          "leaves a correctly declared consumer alone.")
+    return 0
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--enforce", action="store_true")
+    parser.add_argument("--self-test", action="store_true")
+    parser.add_argument("--list", action="store_true")
+    args = parser.parse_args()
+
+    if args.self_test:
+        return self_test()
+
+    found = scan(WORKFLOW_DIR)
+
+    if args.list:
+        for key, mode in sorted(found.items()):
+            print(f"{mode:12s} {key}")
+        return 0
+
+    problems = evaluate(found, DECLARED)
+    if not problems:
+        writers = write_capable(found)
+        print(
+            f"Gradle cache budget OK — {len(found)} declared usages, "
+            f"{len(writers)}/{WRITER_BUDGET} write-capable: {', '.join(writers)}"
+        )
+        return 0
+
+    for problem in problems:
+        level = "error" if args.enforce else "warning"
+        print(f"::{level}::{problem}")
+    print(f"\n{len(problems)} problem(s). See #3299 and this script's header.")
+    return 1 if args.enforce else 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/.github/workflows/dependency-submission.yml
+++ b/.github/workflows/dependency-submission.yml
@@ -125,7 +125,42 @@ jobs:
 
       - uses: gradle/actions/setup-gradle@3f131e8634966bd73d06cc69884922b02e6faf92 # v6.2.0
         with:
-          cache-read-only: ${{ github.ref != 'refs/heads/main' }}
+          # NEVER write the Actions cache from this job — restore only, on every ref
+          # including main (#3299).
+          #
+          # The repo's Actions cache runs permanently over its 10 GB ceiling (measured
+          # 2026-08-02: 11.7 GB / 92 entries), so GitHub evicts LRU continuously. Measured
+          # over 16 cache-writing job-runs, exactly two jobs write on main — `fleet-lint`
+          # and this one, 8 runs each — and each writing run pushes a fresh
+          # `gradle-build-cache-v1` entry (~200 MB) plus, whenever the fleet's dependency
+          # set shifts by even one artifact, a whole new ~700-850 MB
+          # `gradle-dependencies-v1` entry. That is why 9 near-identical dependency entries
+          # (6.1 GB, 60% of the pool) coexist: the entry is content-addressed over the
+          # entire `modules-2` tree, so two jobs resolving almost-the-same set still store
+          # it twice.
+          #
+          # This is the fix `setup-gradle`'s own docs prescribe for exactly this shape
+          # ("Select which jobs should write to the cache"): elect ONE writer per
+          # OS+architecture and make every other job a consumer. `fleet-lint` is that writer
+          # on Linux-X64 — it runs `testClasses detekt ktlintCheck` fleet-wide on every main
+          # push, so its Gradle home is a near-superset of what this job needs, and
+          # `gradle-home-cache-strict-match` defaults to false, so this job still RESTORES
+          # from it across job boundaries.
+          #
+          # Why THIS job is the right one to demote rather than fleet-lint or CodeQL:
+          # it is the only fleet-wide Gradle job nobody waits on. It is not a required
+          # check, it is push/schedule-triggered, and it currently runs 4.8-8.5 min against
+          # a 30 min timeout. The cost of a colder cache here is re-downloading the
+          # runtime-only artifacts `assemble` pulls beyond fleet-lint's `testClasses` set —
+          # minutes, inside that headroom. fleet-lint is a required check, and CodeQL's
+          # java-kotlin leg documents a 25-30 min cold penalty and is the most
+          # preemption-exposed job in the fleet; demoting either would trade a real, felt
+          # regression for the same headroom.
+          #
+          # Read-only does NOT affect the submitted graph: `generate-and-submit` resolves
+          # the fleet regardless of cache state, so the #1449 stale-graph alarm below is
+          # unaffected.
+          cache-read-only: true
           dependency-graph: generate-and-submit
           # Keep detached and buildscript configurations OUT of the submitted graph (#2833).
           #


### PR DESCRIPTION
## Summary

The Actions cache pool has been over its 10 GB ceiling continuously, so GitHub evicts LRU
without anything going red. This measures the hit rate first (as #3299 asks), then elects a
single Gradle cache writer per OS+architecture and adds a gate so the writer set cannot grow
back silently.

## Type of change

- [x] chore (build / tooling)

## Linked issues

Refs #3299

## The measurement (acceptance criterion 1)

Not assumed — parsed `setup-gradle`'s own restore/save lines out of the **raw logs of 40
recent runs** (`/actions/runs/<id>/logs`), across Fleet lint, Dependency submission, Security
scan, Services CI and CI.

| entry | hit | miss | hit % | saved |
|---|---|---|---|---|
| Gradle User Home | 16 | 0 | 100% | 16 |
| `gradle-dependencies-v1` | 15 | 1 | **93.8%** | 1 |
| `gradle-build-cache-v1` | 16 | 0 | 100% | **16** |
| `gradle-transforms-v1` | 16 | 0 | 100% | 2 |
| wrapper-zips / kotlin-dsl / groovy-dsl / instrumented-jars / generated-gradle-jars | 16 each | 0 | 100% | 0 |

**127 of 128 extracted-entry restore attempts hit — 99.2%.** The single miss was a ~850 MB
`dependencies` entry.

Two notes on how this number was reached, because both nearly produced a wrong answer:

- **My first probe could not express a miss.** It grepped for `not found` / `empty home`
  wording that `setup-gradle` never prints, so it reported a clean 100%. The real vocabulary
  is `Cache hit for: <key>` and `Did not restore <name> with key ...`. The 1 miss only
  appeared after re-running with the action's actual strings.
- **The raw counts double-count by exactly 2×.** A run's log zip contains both a job-level and
  a step-level copy of every line, differing only in the sub-millisecond timestamp. The table
  above is deduped; the ratios were unaffected.

## What this means

The cache is *working* — this is not a "cache is broken" fix. The cost is what #3299 says it
is: eviction as the steady state makes wall-clock depend on what else ran that day.

**A janitor would not have helped.** Every entry in the pool had been accessed within the
preceding ~30 minutes, i.e. the pool already holds nothing but live entries — GitHub's own LRU
has already deleted everything deletable. The filler is the **write rate**:

- each writing job-run stores a fresh ~200 MB `gradle-build-cache-v1` entry, **every run**
  (16/16 in the sample);
- plus an entire new ~700–850 MB `gradle-dependencies-v1` entry whenever the resolved set
  shifts by even one artifact — the entry is content-addressed over the whole `modules-2`
  tree, so two jobs resolving almost-the-same set still store it twice.

That is how **9 near-identical dependency entries came to hold 6.1 GB — 60% of the pool**.

## Changes

- **`dependency-submission.yml`: `cache-read-only: true`** (was `${{ ref != main }}`, i.e. a
  writer on main). Exactly two jobs write on main — `fleet-lint` and this one, 8 sampled runs
  each. This is `setup-gradle`'s own prescription for this shape ("Select which jobs should
  write to the cache"): elect one writer per OS+arch, make the rest consumers.
  `gradle-home-cache-strict-match` defaults to false, so it still **restores** fleet-lint's
  home across the job boundary.
- **New `.github/scripts/check-gradle-cache-writers.py`** + registration in
  `.github/gates/gates.yaml` (`lint` group, `enforced`, with a self-test).
- No `rules.yaml` / `.rego` edit, so **no OPA bundle restamp** — this PR is 3 files and will
  not conflict with a governance PR.

### Why `dependency-submission` is the right job to demote

It is the only fleet-wide Gradle job **nobody waits on**: not a required check,
push/schedule-triggered, and measured at **4.8–8.5 min against a 30 min timeout**. The cost of
a colder cache is re-downloading the runtime-only artifacts `assemble` pulls beyond
fleet-lint's `testClasses` set — minutes, inside that headroom. `generate-and-submit` resolves
the fleet regardless of cache state, so the #1449 stale-graph alarm is unaffected.

Deliberately **not** touched:

- **CodeQL** — its java-kotlin leg documents a 25–30 min cold penalty and is the most
  preemption-exposed job in the fleet.
- **`auto-deploy` / `ghcr-publish`** — `ubuntu-24.04-arm`, a **Linux-ARM64 cache scope with no
  other writer**, so demoting them means permanently cold, not shared. Their entries are also
  the smallest in the pool (~7 MB across 3).
- **`_service-ci.yml`** — untouched on purpose; its `cache-disabled` on ARC is the ~$200/mo NAT
  egress fix and must not be re-armed.

### The gate, and why it isn't just a comment

`cache-read-only` **defaults to `${{ github.ref_name != default_branch }}`** — so a workflow
that adds `setup-gradle` with *no* cache inputs silently becomes a writer on main. Nothing
counted them. The gate declares all 13 usages with a mode and a required justification, and
fails on drift in **either** direction: undeclared, changed, or stale. A `WRITER_BUDGET`
ratchet set to today's count (5) means growing the writer set is a deliberate act. This is
acceptance criterion 3.

It classifies honestly rather than conveniently — `writes-on-main` (silence, the default),
`writes-always` (a literal `cache-read-only: false`, which *overrides* that default and writes
on feature branches too — `auto-deploy` is the one instance), `read-only`, `disabled`,
`conditional` (an expression decides; `_service-ci` never writes only because two
complementary expressions cover each other, which no per-step rule can see).

## Exercising the failure path

Per this repo's hardest-won CI rule, the gate was run against cases it **must** flag, not just
until it went green:

| case | verdict |
|---|---|
| **revert this PR's own fix** in the real tree | `DRIFT` + `BUDGET`, exit 1 |
| add a new workflow with bare `setup-gradle` | `UNDECLARED` + `BUDGET`, exit 1 |
| declared `read-only` that silently became a writer | flagged |
| an expression mistaken for `read-only` | flagged |
| a declaration with an empty reason | flagged |
| a stale declaration (usage removed) | flagged |
| `cache-read-only: false` vs silence (the subtle distinction) | both flagged when mis-declared |
| a correctly declared consumer / `setup-java` without `cache: gradle` | **not** flagged |
| advisory mode (no `--enforce`) on a failing tree | exit **0**, as the repo's advisory convention requires |

The 10-case `--self-test` runs immediately before the gate via the runner, so the gate is
skipped entirely if its own red becomes unreachable.

## Definition of Done

- [x] `python3 .github/scripts/run-gates.py --group lint` — 5/5 PASS
- [x] `license-header-consistency` and `advisory-gate-registration` gates PASS
- [x] No Gradle build needed or run (CI-config-only change)
- [ ] Unit tests — N/A (the gate's `--self-test` is the test)

## Security checklist

- [x] No secrets, tokens, passwords, or PII.
- [x] No new `@Suppress`.
- [x] No new third-party dependency (stdlib + PyYAML, already used by sibling gates).

## Compliance impact

- [x] None

## Rollout / Rollback

- Deployment strategy: N/A (CI configuration).
- Rollback plan: revert the commit. The gate then flags its own revert as `DRIFT`, so the
  revert must also drop the declaration — deliberate, and the point of the two-way check.
- Data migration reversible: N/A

## Reviewer notes

**The projected saving is a projection, and I want to say so plainly.** Removing
`dependency-submission`'s writes should remove roughly half the `build-cache` churn (~2 GB) and
some of the 9 dependency entries (~2–3 GB), landing the pool around 7 GB. I could not verify
that from a PR branch — the effect is only observable after several days of main-branch runs,
because branch caches live in a separate scope. **Re-check with
`gh api /repos/JiRaska/open-bank-oss/actions/cache/usage` in ~3 days**; if it has not dropped
below ~9 GB, the next lever is `gradle-home-cache-excludes: caches/build-cache-1` on
`fleet-lint`, which is a straight ~2 GB for a real recompile cost.

Two other honest limits:

- The 16-job sample is a **few hours** of a very busy repo, all on `main`. It does not cover
  the arm64 lanes or a quiet period, and a 1-in-16 miss has a wide confidence interval.
- I did **not** delete any existing cache entries. The pool will drain on its own via the 7-day
  retention; a one-off purge would have been undone by the next hour of CI and would have
  obscured whether the structural change worked.
