### PR TITLE
fix(gitops): a co-deploy set must not be derived from builds that merely haven't finished

### DIFF
--- a/.github/scripts/derive-codeploy-set.py
+++ b/.github/scripts/derive-codeploy-set.py
@@ -49,14 +49,19 @@ Usage:
   derive-codeploy-set.py <changed-services-space-separated> < blocks
 
   stdin is a stream of records, one per blocked service:
-      ===SERVICE <name>
+      ===SERVICE <name>[\t<block-class>]
       <that service's verbatim can-i-deploy CLI output>
+
+  The block class is what classify-can-i-deploy-block.sh decided. It is OPTIONAL: without
+  it every blocked service is eligible for a set (the original behaviour). With it, only a
+  DURABLE block counts — see CODEPLOY_CLASSES.
 
   <changed-services> is every service in THIS run (deployable or not), so a counterpart
   can be told apart from one outside the run.
 
 Prints, one finding per line, TAB-separated. Two record types:
     CODEPLOY\t<svc> <svc> ...        a mutually-blocking set that must deploy together
+    PENDING\t<svc> <svc> ...         blocked only because their builds have not finished
     EXTERNAL\t<svc>\t<counterpart>   blocked on a service this run cannot move
 
 Always exits 0 — this is a reporter, not a gate.
@@ -80,17 +85,46 @@ SERVICE_TOKEN = re.compile(r"openbank-[a-z0-9][a-z0-9-]*")
 # co-deploy set no dispatch can satisfy. Read the prose lines only.
 PAIR_LINE = ("There is no verified pact", "The verification for the pact between")
 
+# A co-deploy is a WEAKER check over (usually) money-path services, so recommending one needs
+# positive evidence of a block that will not clear on its own. Only these two qualify.
+#
+# PENDING_BUILD emphatically does not. It means "no pact version published for this commit yet
+# — the main-push build has not finished"; probe-pact-version.sh's own header calls that class
+# self-clearing and expects the 3-hourly reconcile to absorb it. But this script never saw the
+# class, so a set of services that were merely WAITING TO BE BUILT looked exactly like a set
+# that mutually deadlocks — and the run then printed, with full authority, the command to
+# co-deploy them. Observed on run 30761740836 (2026-08-02 18:42Z): eight services blocked, all
+# eight PENDING_BUILD, and the output was
+#   CO-DEPLOY SET — [account domestic-payment fraud sepa-instant sepa-payment swift
+#   transaction] block each other; no per-service deploy order converges.
+# Seven of those are money-path. The hand-driven bypass this script exists to REPLACE is
+# exactly what that advice invites, on evidence that means only "CI is behind".
+#
+# UNKNOWN is excluded for the same reason from the other direction: an unclassified block is
+# not positive evidence of anything, and the safe default is to say so rather than to name a
+# set. Records with no class at all keep today's behaviour, so older captures still parse.
+CODEPLOY_CLASSES = ("UNVERIFIED", "REGRESSION")
+TRANSIENT_CLASSES = ("PENDING_BUILD",)
+
 
 def derive(changed: set[str], stream) -> list[str]:
     blocked: list[str] = []
     edges: dict[str, set[str]] = {}
     external: set[tuple[str, str]] = set()
+    cls_of: dict[str, str] = {}
 
     svc: str | None = None
     for raw in stream:
         line = raw.rstrip("\n")
         if line.startswith("===SERVICE "):
-            svc = line[len("===SERVICE "):].strip()
+            # "===SERVICE <name>" or "===SERVICE <name>\t<block-class>"; the class is optional
+            # so a capture taken before auto-deploy.yml recorded it still reads correctly.
+            header = line[len("===SERVICE "):].strip()
+            svc, _, cls = header.partition("\t")
+            svc = svc.strip()
+            cls = cls.strip()
+            if cls:
+                cls_of[svc] = cls
             if svc not in blocked:
                 blocked.append(svc)
                 edges.setdefault(svc, set())
@@ -106,10 +140,16 @@ def derive(changed: set[str], stream) -> list[str]:
             else:
                 external.add((svc, token))
 
+    # Eligible for a co-deploy set: blocked, and blocked for a reason that will not clear by
+    # itself. A record carrying no class is eligible (older captures), one carrying a class
+    # must carry a durable one.
+    def eligible(name: str) -> bool:
+        return name not in cls_of or cls_of[name] in CODEPLOY_CLASSES
+
     findings: list[str] = []
     seen: set[str] = set()
     for root in blocked:
-        if root in seen:
+        if root in seen or not eligible(root):
             continue
         component = [root]
         seen.add(root)
@@ -119,12 +159,20 @@ def derive(changed: set[str], stream) -> list[str]:
             i += 1
             for peer in sorted(edges.get(node, ())):
                 # Only BLOCKED services can be part of a co-deploy set: a counterpart that
-                # is in this run and already deployable needs nothing done to it.
-                if peer in blocked and peer not in seen:
+                # is in this run and already deployable needs nothing done to it — and one
+                # whose block is transient needs only time, not a weaker gate.
+                if peer in blocked and eligible(peer) and peer not in seen:
                     seen.add(peer)
                     component.append(peer)
         if len(component) > 1:
             findings.append("CODEPLOY\t" + " ".join(sorted(component)))
+
+    # Say what was set aside, so a transient block is never silently dropped: an operator
+    # reading "no co-deploy set" must be able to tell "nothing is deadlocked" apart from
+    # "the answer is not knowable yet".
+    pending = sorted(s for s in blocked if cls_of.get(s) in TRANSIENT_CLASSES)
+    if pending:
+        findings.append("PENDING\t" + " ".join(pending))
 
     for svc_name, counterpart in sorted(external):
         findings.append(f"EXTERNAL\t{svc_name}\t{counterpart}")

--- a/.github/scripts/test-derive-codeploy-set.sh
+++ b/.github/scripts/test-derive-codeploy-set.sh
@@ -122,6 +122,38 @@ The verification for the pact between openbank-transaction-service and openbank-
 #    a co-deploy hint in every green log.
 check "no blocked services => no output" "" "openbank-fraud-service" ""
 
+# 9. THE REGRESSION THIS FIXES (#1985, observed on run 30761740836). Two services blocked
+#    with PENDING_BUILD reference each other exactly like a deadlocked pair — but that class
+#    means only "their main-push build has not finished", which self-clears. Recommending a
+#    co-deploy (a weaker check, and these two are money-path) on that evidence is wrong, so
+#    the set must NOT be named; the pending services are reported instead.
+check "PENDING_BUILD pair is not a co-deploy set" \
+  "PENDING${TAB}openbank-fraud-service openbank-transaction-service" \
+  "openbank-fraud-service openbank-transaction-service" \
+"===SERVICE openbank-fraud-service${TAB}PENDING_BUILD
+There is no verified pact between version abc123 of openbank-fraud-service and the version of openbank-transaction-service currently deployed to sandbox
+===SERVICE openbank-transaction-service${TAB}PENDING_BUILD
+There is no verified pact between version def456 of openbank-transaction-service and the version of openbank-fraud-service currently deployed to sandbox"
+
+# 10. A DURABLE pair still is one — the fix must not silence the case the script exists for.
+check "UNVERIFIED pair is still a co-deploy set" \
+  "CODEPLOY${TAB}openbank-fraud-service openbank-transaction-service" \
+  "openbank-fraud-service openbank-transaction-service" \
+"===SERVICE openbank-fraud-service${TAB}UNVERIFIED
+There is no verified pact between version abc123 of openbank-fraud-service and the version of openbank-transaction-service currently deployed to sandbox
+===SERVICE openbank-transaction-service${TAB}UNVERIFIED
+There is no verified pact between version def456 of openbank-transaction-service and the version of openbank-fraud-service currently deployed to sandbox"
+
+# 11. Mixed: a durable block paired with a transient one cannot be called a deadlock yet —
+#     half the evidence is "CI is behind". Report the pending one, name no set.
+check "mixed durable+transient pair names no set" \
+  "PENDING${TAB}openbank-transaction-service" \
+  "openbank-fraud-service openbank-transaction-service" \
+"===SERVICE openbank-fraud-service${TAB}UNVERIFIED
+There is no verified pact between version abc123 of openbank-fraud-service and the version of openbank-transaction-service currently deployed to sandbox
+===SERVICE openbank-transaction-service${TAB}PENDING_BUILD
+There is no verified pact between version def456 of openbank-transaction-service and the version of openbank-fraud-service currently deployed to sandbox"
+
 if [ "$fails" -gt 0 ]; then
   echo "derive-codeploy-set.py: ${fails} case(s) FAILED"
   exit 1

--- a/.github/workflows/auto-deploy.yml
+++ b/.github/workflows/auto-deploy.yml
@@ -960,7 +960,8 @@ jobs:
                 block_class["$svc"]="$cls"
                 block_reason["$svc"]="$cls_why"
                 echo "::error::can-i-deploy: ${svc} NOT deployable [${cls}] — ${cls_why} (ADR-0092, #2549)"
-                printf '===SERVICE %s\n%s\n' "$svc" "$cid_out" >> "$BLOCKS_FILE"
+                # Class too: derive-codeploy-set.py rejects transient blocks (#1985).
+                printf '===SERVICE %s\t%s\n%s\n' "$svc" "$cls" "$cid_out" >> "$BLOCKS_FILE"
                 rc=1
               fi
             fi
@@ -1036,6 +1037,10 @@ jobs:
                       echo "gh workflow run auto-deploy.yml -f services='${a}' -f codeploy=true"
                       echo "\`\`\`"
                     } >> "$GITHUB_STEP_SUMMARY"
+                    ;;
+                  PENDING)
+                    echo "::notice::[${a}] waiting on their own main-push build (PENDING_BUILD) — self-clearing, not a deadlock. Do NOT co-deploy (#1985)"
+                    echo "- \`${a}\` — waiting on their own builds, not deadlocked; no action" >> "$GITHUB_STEP_SUMMARY"
                     ;;
                   EXTERNAL)
                     echo "::warning::[${a}] is blocked on ${b}, which is NOT part of this run — a co-deploy cannot help; ${b} has to deploy first (issue #1985)"


### PR DESCRIPTION
## What

`derive-codeploy-set.py` names the services that must deploy **together**, and the run then prints the command to co-deploy them. It never saw the block **class**, so services that were only *waiting to be built* looked exactly like services that mutually deadlock.

## The observation

Run [30761740836](https://github.com/JiRaska/open-bank-oss/actions/runs/30761740836) (2026-08-02 18:42Z, the scheduled reconcile):

```
[openbank-account-service]       MONEY-PATH blocked by can-i-deploy [PENDING_BUILD]
[openbank-domestic-payment]      MONEY-PATH blocked by can-i-deploy [PENDING_BUILD]
[openbank-fraud-service]         MONEY-PATH blocked by can-i-deploy [PENDING_BUILD]
[openbank-sepa-instant]          MONEY-PATH blocked by can-i-deploy [PENDING_BUILD]
[openbank-sepa-payment]          MONEY-PATH blocked by can-i-deploy [PENDING_BUILD]
[openbank-swift-service]         MONEY-PATH blocked by can-i-deploy [PENDING_BUILD]
[openbank-transaction-service]   MONEY-PATH blocked by can-i-deploy [PENDING_BUILD]
[openbank-card-issuance-service]            blocked by can-i-deploy [PENDING_BUILD]

::error::CO-DEPLOY SET — [account domestic-payment fraud sepa-instant sepa-payment swift
transaction] block each other; no per-service deploy order converges.
Re-run: gh workflow run auto-deploy.yml -f services='…' -f codeploy=true
```

**All eight were `PENDING_BUILD`** — not one `UNVERIFIED`, not one `REGRESSION`. That class means *"no pact version published for this commit yet, the main-push build has not finished"*, and `probe-pact-version.sh`'s own header calls it self-clearing, absorbed by the 3-hourly reconcile.

So the pipeline instructed an operator, with full authority, to run a **weaker check over seven money-path services** because CI was behind.

That inverts the script's stated purpose. Its header says the recurring hand-driven co-deploy bypass **is the risk it exists to replace** — manufacturing the recommendation from transient state is the same bypass with the pipeline's name on it.

## The fix

- `auto-deploy.yml` records the class it *already computed*: `===SERVICE <name>\t<class>`.
- `derive-codeploy-set.py` admits a service to a component only when its block is **durable** (`UNVERIFIED`, `REGRESSION`). A record with no class keeps today's behaviour, so older captures still parse. `UNKNOWN` is excluded from the other direction: an unclassified block is not positive evidence, and a weaker gate needs positive evidence.
- A transient block is **reported, never silently dropped** — a new `PENDING` finding printed as a notice. "No co-deploy set" must not be ambiguous between *nothing is deadlocked* and *the answer is not knowable yet*.

## Verification, and what it does not prove

Three unit cases added to the existing harness (11 total, all pass):

| case | expectation |
|---|---|
| `PENDING_BUILD` pair | **not** a co-deploy set → `PENDING` |
| `UNVERIFIED` pair | still a co-deploy set |
| mixed durable + transient | names no set — half the evidence is "CI is behind" |

All three fail against `origin/main`. **Being precise about why:** the old script cannot parse the class-bearing header at all, so it produces empty output for all three — that is format incompatibility, not by itself proof of the behavioural change. The claim these cases actually pin is the new one: *with the class present*, a transient pair is not named while a durable pair still is. The old behaviour is preserved for class-less input, which case 7 (unchanged) still covers.

`run-gates.py --only co-deploy-set-derivation-unit-test` → PASS.

## A guard caught me mid-change

Adding this pushed the `can-i-deploy` step's `run:` script to **19006** chars and `check-workflow-run-step-size.py` failed the build at its 19000 limit — the #3135 shape, where an oversized script makes the *whole* workflow unparseable with no error. The rationale moved into the script header where it costs nothing; the step is back to **18580**.

## Why this matters tonight

`fraud-service` (#3376) is undeployed and was named in that co-deploy set. Its block is `PENDING_BUILD` — it needs its build to finish, **not** a seven-service money-path co-deploy. This change stops the pipeline recommending the latter.

## Linked issues

Refs #1985, Refs #2549
