### PR TITLE
chore(fraud): record that ONNX shadow scoring has never loaded, and re-drive the deploy

### DIFF
--- a/openbank-fraud-service/src/main/resources/application.yaml
+++ b/openbank-fraud-service/src/main/resources/application.yaml
@@ -140,6 +140,16 @@ mp:
           connector: smallrye-kafka
           enabled: false
 openbank:
+  # ML / shadow scoring (ADR-0139 phase-1b) — READ THIS BEFORE TRUSTING A "shadow score" NUMBER.
+  # The in-process ONNX adapter has NEVER loaded in a deployed environment: the fleet runtime
+  # image is eclipse-temurin:*-jre-alpine (musl) and onnxruntime's libonnxruntime.so is linked
+  # against glibc, so OrtEnvironment.getEnvironment() throws UnsatisfiedLinkError at startup and
+  # scoreShadow() returns null for every request. Verdicts are therefore rules-only, and always
+  # have been — measured on arm64: alpine fails on libstdc++.so.6, alpine + `apk add libstdc++`
+  # then fails on ld-linux-aarch64.so.1, and only a glibc base loads it (#3354). No verdict has
+  # ever differed because of this — the bundled model reproduces the previous pure-Kotlin
+  # logistic exactly — but any claim that the ONNX serving path "works" is unverified.
+  # openbank.ml.require-signature (ADR-0141 model-card pinning) only takes effect once it does.
   rate-limit:
     enabled: true
     max-concurrent-requests: 100


### PR DESCRIPTION
## What

Comment-only change to `openbank-fraud-service/src/main/resources/application.yaml`. Effective config is byte-identical (parsed and compared). Two purposes, both stated openly.

## 1. It records something a reader needs

The in-process ONNX adapter (ADR-0139 phase-1b) **has never loaded in a deployed environment**. The fleet runtime image is `eclipse-temurin:*-jre-alpine` (musl); `onnxruntime`'s `libonnxruntime.so` is linked against glibc, so `OrtEnvironment.getEnvironment()` throws `UnsatisfiedLinkError` at startup and `scoreShadow()` returns `null` for every request. Measured on arm64:

| base | result |
|---|---|
| `eclipse-temurin:25-jre-alpine` | `UnsatisfiedLinkError: libstdc++.so.6` |
| `+ apk add libstdc++` | `UnsatisfiedLinkError: ld-linux-aarch64.so.1` |
| `eclipse-temurin:25-jre` (glibc) | loads |

Tracked in [#3354](https://github.com/JiRaska/open-bank-oss/issues/3354). **No verdict has ever differed because of it** — the bundled model reproduces the previous pure-Kotlin logistic exactly and scoring is shadow-only. What is false is any claim that the ONNX serving path works, and anyone reading `openbank.ml.require-signature` (the ADR-0141 model-card pin) deserves to know it gates a path that does not execute.

## 2. It re-drives the deploy of #3376

[#3376](https://github.com/JiRaska/open-bank-oss/pull/3376) fixed an ONNX native-load `Error` that escaped a **field initializer**, failed bean construction, and made CDI answer **500** on `GET /api/v1/fraud/review-queue` — a read-only analyst query that never touches a model. It is on `main` and has **not** reached the cluster; its auto-deploy run died in the `Detect changed services` breakage later fixed by [#3406](https://github.com/JiRaska/open-bank-oss/pull/3406).

Nothing else recovers it. A pact version is published for the sha where a service actually **builds**; auto-deploy deploys the current main **tip**, and main advances on inert commits that build nothing. `fraud-service` has a published version at `330707ce7` (its own merge — `build (openbank-fraud-service): success`) but **not** at the tip, so every later reconcile reports `PENDING_BUILD`. A push touching this service is what makes the two shas agree.

## This is deliberately not a co-deploy

The 18:42 reconcile named fraud in a seven-service money-path `CO-DEPLOY SET`. All eight blocked services were classified `PENDING_BUILD` — the **transient** class — so that advice was derived from *"CI is behind"*, not from a deadlock. [#3501](https://github.com/JiRaska/open-bank-oss/pull/3501) stops the pipeline giving it.

**If the gate returns `UNVERIFIED` for fraud after this build, that is a real deadlock** and it needs a human, not a night-shift dispatch. I will report that outcome rather than route around it.

## Money-path disclosure

`openbank-fraud-service` is on `rules.yaml: money_path_services`, which asks for **2 approvals and a threat model**. This change is comment-only and the deploy it re-drives is a defect fix already merged, but the approval count is **0** and the ruleset does not enforce it (#2183). Saying so here rather than leaving it to be noticed.

## Linked issues

Refs #3376, Refs #3354, Refs #1985
