### PR TITLE
fix(analytics-sink): point the schema registry at the Service that exists

### DIFF
--- a/.github/asvs-l3-baseline.txt
+++ b/.github/asvs-l3-baseline.txt
@@ -206,6 +206,13 @@ V9.1 openbank-infra/gitops/components/billing/billing-service.yaml:78: plaintext
 V9.1 openbank-infra/gitops/components/billing/billing-service.yaml:97: plaintext http:// env value http://tempo.observability.svc:4317
 V9.1 openbank-infra/gitops/components/onboarding/onboarding-service.yaml:134: plaintext http:// env value http://tempo.observability.svc:4317
 V9.1 openbank-infra/gitops/components/analytics/analytics-sink.yaml:79: plaintext http:// env value http://clickhouse.analytics.svc:8123
+# analytics-sink -> Apicurio schema registry (issue #1916). Same declared debt as every other
+# in-cluster edge here: the Service exposes exactly one port, named `http`, on 8080
+# (gitops/components/apicurio/registry.yaml) — there is no TLS listener to point at, so https
+# is not an available alternative rather than an unchosen one. kafka-ui already carries the
+# identical URL in this baseline (see the kafka-ui.yaml:45 line above). Paid off by the
+# Layer 1 mTLS-everywhere work, with the rest of the V9.1 block, not before.
+V9.1 openbank-infra/gitops/components/analytics/analytics-sink.yaml:131: plaintext http:// env value http://apicurio-registry.messaging.svc:8080
 V13.1 openbank-analytics-sink: serves REST resources but publishes no openapi.yaml
 V13.1 openbank-authz-policy-auditor: serves REST resources but publishes no openapi.yaml
 V13.1 openbank-control-liveness-sentinel: serves REST resources but publishes no openapi.yaml

--- a/.github/gates/gates.yaml
+++ b/.github/gates/gates.yaml
@@ -344,6 +344,26 @@ gates:
     run: |
       python3 .github/scripts/check-gitops-secret-refs.py
 
+  # The in-cluster twin of external-feed-declaration-drift: a hostname naming another Service in
+  # this cluster is stubbed by the unit test, overridden to localhost by the IT and never sent by
+  # a consumer pact, so it is wrong only once a pod dials it. openbank-analytics-sink pointed at
+  # "schema-registry:8081" for the life of the service; the Service is apicurio-registry:8080 in
+  # `messaging` (issue #1916). Needs no network: the resolvable set is fully declared in gitops.
+  #
+  # ADVISORY (rules.yaml: incluster_hostnames, target_enforce_date 2026-10-31) — 6 pre-existing
+  # findings, all bare `openbank-<svc>` rest-client defaults on services whose pods override them
+  # by env. Four of the owners are money-path, so that cleanup takes the two-approval path rather
+  # than riding along with the guard that found it.
+  - id: incluster-hostname-resolution
+    name: "in-cluster hostnames resolve to a declared Service (issue #1916, advisory)"
+    group: gitops
+    mode: advisory
+    selftest: |
+      python3 .github/scripts/check-incluster-hostnames.py --self-test
+    selftest_expect: pass
+    run: |
+      python3 .github/scripts/check-incluster-hostnames.py --enforce
+
   # rules.yaml event_change / ADR-0006: schema-compat gate. The fleet's event
   # A CNPG cluster gets its S3 backup credentials from an EKS Pod Identity association in
   # db-backups.tf, granted per (namespace, serviceAccount). That list is maintained by hand

--- a/.github/scripts/check-incluster-hostnames.py
+++ b/.github/scripts/check-incluster-hostnames.py
@@ -1,0 +1,434 @@
+#!/usr/bin/env python3
+# SPDX-License-Identifier: Apache-2.0
+# Copyright (c) OpenBank contributors. Licensed under the Apache License, Version 2.0.
+# See LICENSE in the repository root or https://www.apache.org/licenses/LICENSE-2.0 for details.
+#
+# ---------------------------------------------------------------------------------------
+# Guard: every in-cluster hostname a service's application.yaml names must resolve to a
+# Kubernetes Service that gitops actually declares.
+#
+# THE FAILURE THIS CATCHES, AND WHY NOTHING ELSE DOES
+# A hostname in application.yaml is unfalsifiable by every test layer this repo has:
+#   * a unit test stubs the client, so the host is never resolved;
+#   * an @QuarkusTest / IT serves a local fixture on localhost, so the host is overridden;
+#   * a consumer pact answers whatever the client asks for, so the host is never sent;
+#   * yamllint checks the file is YAML, not that the YAML means anything.
+# So a wrong host is green everywhere until a pod tries to dial it in the cluster, where
+# the symptom is a hung call or a connect timeout in one log line nobody reads.
+#
+# That is exactly how openbank-fx-service's CNB fixing URL was a 404 for the whole life of
+# the service (root CLAUDE.md, "CI gates — exercise the failure path before trusting the
+# green"). check-external-feeds.py closed that hole for THIRD-PARTY URLs by fetching them.
+# An in-cluster host cannot be fetched from CI — there is no cluster — but it does not need
+# to be: the set of hostnames that can possibly resolve is fully declared in
+# openbank-infra/gitops/, so the claim is checkable statically.
+#
+# The case that forced it (issue #1916): openbank-analytics-sink's application.yaml
+# documented the Apicurio schema registry as "service schema-registry:8081" and defaulted
+# ANALYTICS_SCHEMA_APICURIO_URL to it. The real Service is apicurio-registry:8080 in
+# namespace `messaging`. Both the host and the port were wrong, in a comment AND in a
+# value, and nothing anywhere could say so.
+#
+# TWO RULES THIS GUARD OBEYS, BOTH LEARNED THE HARD WAY IN THIS REPO
+#
+# 1. IT KEEPS NO COPY OF ANY HOSTNAME. Both sides are read out of committed files: the
+#    claim from the service's application.yaml, the truth from gitops. A guard holding its
+#    own copy of the hostname moves with the config and keeps passing (the "second copy IS
+#    the drift" rule). Consequently there is no list in this file to update when a service
+#    is added, renamed, or moved to another namespace.
+#
+# 2. IT ASSERTS AGAINST THE PARSED YAML VALUE, NEVER THE FILE TEXT. A whole-file grep
+#    cannot distinguish config from the prose ABOUT config, and this repo has been burnt in
+#    both directions: a guard that flags the comment explaining the bug it exists to catch
+#    (#2450), and a test that matched the five-line comment above the very line it was
+#    asserting on, so deleting the line left it green (#3072). PyYAML drops comments during
+#    parsing, so working from `yaml.safe_load_all` output is immune to both by construction
+#    rather than by a strip-the-comments pass that can be got wrong. The self-test pins
+#    this: a fixture whose ONLY occurrence of a bogus host is in a `#` comment must not be
+#    flagged.
+#
+# WHAT COUNTS AS AN IN-CLUSTER HOSTNAME (deliberately conservative — see the honest limits
+# at the bottom of this header)
+#   a) `<name>.<ns>.svc` / `<name>.<ns>.svc.cluster.local`  — unambiguous, always checked
+#   b) `<name>.<ns>` where <ns> is a namespace gitops declares — the short in-cluster form
+#   c) a single-label host inside a `scheme://` URL (e.g. `http://openbank-product-catalog:8080`)
+#      — a bare Service name, resolved by the caller's own namespace search domain
+#   Forms (a) and (b) are also accepted as a bare `host:port` token (no scheme), because
+#   Temporal and Kafka client config is written that way. Form (c) is NOT: a single-label
+#   `host:port` with no scheme is how docker-compose and Quarkus dev-services defaults are
+#   written (`kafka:9092`), and flagging those would be wrong.
+#
+# NEVER FLAGGED: localhost, 127.0.0.1, 0.0.0.0, ::1, host.docker.internal, any IP literal,
+# and any multi-label host whose second label is not a known namespace (api.github.com,
+# www.cnb.cz, kc.open-bank.tech, s3.eu-central-1.amazonaws.com, ...) — those are external
+# and are check-external-feeds.py's job, not this one's.
+#
+# WHAT COUNTS AS A DECLARATION (all DERIVED from the gitops tree; nothing hand-kept)
+#   kind: Service                 -> (namespace, metadata.name)
+#   kind: Cluster (postgresql.cnpg.io)
+#                                 -> <name>-rw, <name>-ro, <name>-r   (CNPG derives these;
+#                                    none appears as a literal Service, exactly as
+#                                    check-gitops-secret-refs.py models <name>-app)
+#   kind: Kafka (strimzi)         -> <name>-kafka-bootstrap, <name>-kafka-brokers
+#   a host already declared in a gitops workload's env / args
+#                                 -> corroborated (see below)
+#
+# THE CORROBORATION TIER, AND WHY IT IS WEAKER ON PURPOSE
+# Several real Services are created by a Helm chart that gitops references as an ArgoCD
+# Application rather than templating into this tree: temporal-frontend (temporal chart),
+# prometheus-operated / alertmanager-operated (prometheus-operator). They exist, they are
+# dialled daily, and no `kind: Service` in this repo names them. The alternative to
+# modelling them would be a hand-written exception list — the single most reliably rotting
+# construct in this repo (a gate whose SCOPE is a hand-kept list reads as PASSING when the
+# list is short, never as UNCHECKED). So instead the known set is widened with every host
+# a gitops Deployment/Rollout/StatefulSet env or ConfigMap value already names: if the
+# deployment manifest dials it, the platform believes it exists.
+#
+# This is genuinely weaker evidence than a `kind: Service`, and it is reported separately
+# in the output so the distinction is never lost. It also means the guard cannot catch a
+# host that is wrong in application.yaml AND wrong the same way in the gitops env. That is
+# a real hole; it is stated here rather than papered over.
+#
+# Usage:
+#   check-incluster-hostnames.py                 # gate
+#   check-incluster-hostnames.py --enforce       # exit 1 on findings (advisory otherwise)
+#   check-incluster-hostnames.py --self-test     # prove the gate can fail
+# ---------------------------------------------------------------------------------------
+from __future__ import annotations
+
+import argparse
+import ipaddress
+import re
+import sys
+from pathlib import Path
+
+try:
+    import yaml
+except ImportError:  # pragma: no cover - CI always has PyYAML
+    sys.stderr.write("PyYAML required: pip install pyyaml\n")
+    sys.exit(2)
+
+REPO = Path(__file__).resolve().parents[2]
+GITOPS = REPO / "openbank-infra" / "gitops"
+
+WORKLOAD_KINDS = {"Deployment", "Rollout", "StatefulSet", "DaemonSet", "Job", "CronJob"}
+
+# Kinds this guard reads anything from. Used twice: to decide what to extract, and as a
+# cheap TEXT pre-filter that decides whether a file is worth handing to PyYAML at all.
+#
+# The pre-filter is not an optimisation for its own sake. gitops is ~13 MB of YAML, and
+# ~12 MB of that is the 26 generated `*-opa-bundle.yaml` ConfigMaps, which embed rego and
+# rules.yaml verbatim. Parsing the whole tree with pure-Python PyYAML costs ~90 s (measured
+# on this tree; libyaml's CSafeLoader is not available on every runner, so it cannot be
+# relied on). Skipping files that declare none of these kinds takes that to ~7 s and cannot
+# change the result: a file with no such object contributes nothing to the known set.
+READ_KINDS = WORKLOAD_KINDS | {"Service", "Cluster", "Kafka", "Namespace"}
+KIND_LINE = re.compile(
+    r"^kind:\s*(" + "|".join(sorted(READ_KINDS)) + r")\s*$", re.MULTILINE
+)
+
+# A host in one of these forms is a local/dev target, never an in-cluster Service.
+LOOPBACK = {"localhost", "0.0.0.0", "::1", "host.docker.internal", "docker.host.internal"}
+
+# `scheme://HOST` for any scheme (http, https, jdbc:postgresql, grpc, ...). The host stops
+# at the first `/`, `:`, `?` or `@`.
+#
+# The lookbehind must NOT exclude `:`. The overwhelmingly common shape in this fleet is a
+# SmallRye default, `${SCHEMA_URL:http://host:8080}`, where the scheme is preceded by the
+# `:` that separates the variable from its default. An earlier version of this regex
+# required whitespace or a quote there and silently matched nothing in exactly the
+# position that matters most — caught only because the self-test drives that shape
+# explicitly. Excluding scheme-name characters is enough to stop a partial match inside a
+# longer token.
+SCHEME_HOST = re.compile(r"(?<![A-Za-z0-9+.\-/])([a-z][a-z0-9+.\-]*)://([A-Za-z0-9_.\-]+)")
+
+# A bare `host:port` token. Anchored so it cannot match the tail of a URL already handled
+# above, nor a `${VAR:default}` boundary.
+BARE_HOST_PORT = re.compile(r"(?<![A-Za-z0-9_.:/\-])([a-z][a-z0-9\-]*(?:\.[a-z0-9\-]+)+):(\d{2,5})(?![0-9])")
+
+
+# Config keys whose value is NOT a host this process ever dials, so "does it resolve?" is the
+# wrong question to ask of it. `quarkus.http.cors.origins` is a list of browser Origin header
+# values compared as STRINGS against an incoming request — no DNS lookup happens, and the
+# comparand is whatever hostname the user's browser was pointed at, never a Service name. Three
+# services list `http://openbank-admin-ui:3000` there; that entry is dead config, but it is dead
+# in a different way from a rest-client URL and reporting the two together is a category error.
+# A guard that mislabels a third of its findings is a guard people learn to skim.
+#
+# This is matched on the PARSED key path, so it exempts the value, not the file.
+NON_DIALLED_KEY_SUFFIXES = ("cors.origins",)
+
+
+def is_dialled(ypath: str) -> bool:
+    p = ypath.lstrip(".")
+    return not any(p == s or p.endswith("." + s) for s in NON_DIALLED_KEY_SUFFIXES)
+
+
+def is_ip(host: str) -> bool:
+    try:
+        ipaddress.ip_address(host)
+        return True
+    except ValueError:
+        return False
+
+
+def normalise(host: str):
+    """Reduce an in-cluster hostname to (name, namespace); namespace None means bare.
+
+    Returns None when the host is not an in-cluster candidate at all.
+    `bare_ok` is decided by the caller (only URL positions accept a bare name).
+    """
+    h = host.rstrip(".").lower()
+    if not h or h in LOOPBACK or is_ip(h):
+        return None
+    if h.endswith(".svc.cluster.local"):
+        h = h[: -len(".svc.cluster.local")]
+    elif h.endswith(".svc"):
+        h = h[: -len(".svc")]
+    else:
+        # not an explicit cluster form; the caller decides using the namespace set
+        parts = h.split(".")
+        if len(parts) == 1:
+            return (h, None)
+        if len(parts) == 2:
+            return (parts[0], parts[1])
+        return None
+    parts = h.split(".")
+    if len(parts) == 2:
+        return (parts[0], parts[1])
+    if len(parts) == 1:
+        # `<name>.svc` — malformed but unambiguously meant as in-cluster
+        return (parts[0], None)
+    return None
+
+
+def scalars(node, path=""):
+    """Yield (dotted-path, string) for every string scalar in a parsed YAML doc."""
+    if isinstance(node, dict):
+        for k, v in node.items():
+            yield from scalars(v, f"{path}.{k}")
+    elif isinstance(node, list):
+        for i, v in enumerate(node):
+            yield from scalars(v, f"{path}[{i}]")
+    elif isinstance(node, str):
+        yield path, node
+
+
+def hosts_in(text: str):
+    """Yield (host, from_url) for every hostname-looking token in one scalar value."""
+    for _scheme, host in SCHEME_HOST.findall(text):
+        yield host, True
+    for host, _port in BARE_HOST_PORT.findall(text):
+        yield host, False
+
+
+def gitops_facts(gitops: Path):
+    """-> (services, namespaces, corroborated) — all derived, nothing hand-written."""
+    services, namespaces, corroborated = set(), set(), set()
+    if not gitops.is_dir():
+        return services, namespaces, corroborated
+
+    for path in sorted(gitops.rglob("*.yaml")):
+        text = path.read_text(encoding="utf-8", errors="ignore")
+        if not KIND_LINE.search(text):
+            continue  # declares nothing this guard reads — see READ_KINDS
+        try:
+            docs = [d for d in yaml.safe_load_all(text) if isinstance(d, dict)]
+        except yaml.YAMLError:
+            continue  # unparseable YAML is yamllint's problem, not this gate's
+        for doc in docs:
+            kind = doc.get("kind")
+            meta = doc.get("metadata") or {}
+            name, ns = meta.get("name"), meta.get("namespace")
+            if ns:
+                namespaces.add(ns)
+            if kind == "Namespace" and name:
+                namespaces.add(name)
+            if not name:
+                continue
+            if kind == "Service":
+                services.add((name, ns))
+            elif kind == "Cluster" and "cnpg" in str(doc.get("apiVersion", "")):
+                # CloudNativePG synthesises the read/write endpoints from the Cluster name.
+                for suffix in ("rw", "ro", "r"):
+                    services.add((f"{name}-{suffix}", ns))
+            elif kind == "Kafka" and "strimzi" in str(doc.get("apiVersion", "")):
+                for suffix in ("kafka-bootstrap", "kafka-brokers"):
+                    services.add((f"{name}-{suffix}", ns))
+
+            # Corroboration tier: a host the deployment manifest itself dials.
+            blobs = []
+            if kind in WORKLOAD_KINDS:
+                spec = doc.get("spec") or {}
+                tmpl = ((spec.get("jobTemplate") or {}).get("spec", {}).get("template")
+                        if kind == "CronJob" else spec.get("template")) or {}
+                ps = tmpl.get("spec") or {}
+                for c in (ps.get("containers") or []) + (ps.get("initContainers") or []):
+                    for e in c.get("env") or []:
+                        if isinstance(e.get("value"), str):
+                            blobs.append(e["value"])
+                    blobs.extend(a for a in (c.get("args") or []) if isinstance(a, str))
+            for blob in blobs:
+                for host, _from_url in hosts_in(blob):
+                    got = normalise(host)
+                    if got and got[1]:
+                        corroborated.add(got)
+
+    return services, namespaces, corroborated
+
+
+def service_yamls(root: Path):
+    """Every Quarkus service's main application.yaml (never src/test)."""
+    return sorted(
+        p for p in root.glob("*/src/main/resources/application.yaml") if p.is_file()
+    )
+
+
+def scan(files, services, namespaces, corroborated):
+    """-> (findings, checked_count). A finding is (path, yaml_path, host, reason)."""
+    findings, checked = [], 0
+    known_bare = {n for n, _ns in services}
+    for path in files:
+        try:
+            docs = [d for d in yaml.safe_load_all(path.read_text(encoding="utf-8")) if isinstance(d, dict)]
+        except yaml.YAMLError as exc:
+            findings.append((path, "<file>", "-", f"unparseable YAML: {exc}"))
+            continue
+        for doc in docs:
+            for ypath, value in scalars(doc):
+                if not is_dialled(ypath):
+                    continue
+                for host, from_url in hosts_in(value):
+                    got = normalise(host)
+                    if got is None:
+                        continue
+                    name, ns = got
+                    if ns is None:
+                        # bare single-label name: only a URL position implies a Service
+                        if not from_url:
+                            continue
+                        checked += 1
+                        if name not in known_bare:
+                            findings.append((path, ypath, host,
+                                             "no Service of this name is declared in any namespace"))
+                        continue
+                    if ns not in namespaces:
+                        continue  # not a cluster namespace -> external host, not our business
+                    checked += 1
+                    if (name, ns) in services or (name, ns) in corroborated:
+                        continue
+                    findings.append((path, ypath, host,
+                                     f"namespace '{ns}' exists in gitops but declares no "
+                                     f"Service '{name}'"))
+    return findings, checked
+
+
+def run_gate(enforce: bool) -> int:
+    services, namespaces, corroborated = gitops_facts(GITOPS)
+    if not services:
+        print(f"::error::no Services found under {GITOPS} — run from the repo root.")
+        return 2
+    files = service_yamls(REPO)
+    findings, checked = scan(files, services, namespaces, corroborated)
+
+    print(f"check-incluster-hostnames: {len(files)} application.yaml files, "
+          f"{checked} in-cluster hostnames checked against {len(services)} declared "
+          f"Services (+{len(corroborated)} corroborated by a gitops workload env) "
+          f"across {len(namespaces)} namespaces")
+    if not findings:
+        print("OK: every in-cluster hostname resolves to a Service gitops declares.")
+        return 0
+
+    level = "error" if enforce else "warning"
+    for path, ypath, host, reason in findings:
+        rel = path.relative_to(REPO) if path.is_absolute() and REPO in path.parents else path
+        print(f"::{level} file={rel}::in-cluster host '{host}' at `{ypath.lstrip('.')}` "
+              f"does not resolve: {reason}. Nothing in this repo's test layers can catch "
+              f"this — a unit test stubs the client and an IT serves localhost — so fix the "
+              f"hostname, or declare the Service in openbank-infra/gitops/.")
+    print(f"\n{len(findings)} unresolvable in-cluster hostname(s).")
+    return 1 if enforce else 0
+
+
+# ── falsification ──────────────────────────────────────────────────────────────────────
+def self_test() -> int:
+    """A gate that has only ever passed is unfalsified. Drive BOTH verdicts."""
+    import tempfile
+
+    failures = []
+    services = {("apicurio-registry", "messaging"), ("keycloak", "iam"), ("admin-ui", "admin-ui")}
+    namespaces = {"messaging", "iam", "admin-ui", "analytics", "temporal"}
+    corroborated = {("temporal-frontend", "temporal")}
+
+    def check(label, body, must_flag):
+        with tempfile.TemporaryDirectory() as td:
+            f = Path(td) / "application.yaml"
+            f.write_text(body, encoding="utf-8")
+            found, _ = scan([f], services, namespaces, corroborated)
+        ok = bool(found) == must_flag
+        print(f"  {'ok  ' if ok else 'FAIL'} {label}"
+              + ("" if ok else f"  (findings={[x[2] for x in found]})"))
+        if not ok:
+            failures.append(label)
+
+    # ---- MUST FLAG -------------------------------------------------------------------
+    # The #1916 defect itself, as a value: right namespace, Service that does not exist.
+    check("a .svc host naming a Service that does not exist IS flagged",
+          "openbank:\n  schema:\n    url: http://schema-registry.messaging.svc:8081\n", True)
+    check("the .svc.cluster.local form is flagged too",
+          "a:\n  b: http://schema-registry.messaging.svc.cluster.local:8081\n", True)
+    check("the short <name>.<ns> form is flagged",
+          "a:\n  b: http://schema-registry.messaging:8081\n", True)
+    check("a bare host:port (no scheme) in <name>.<ns> form is flagged",
+          "a:\n  b: schema-registry.messaging:8081\n", True)
+    check("a bare single-label name in a URL position is flagged",
+          "a:\n  b: http://openbank-product-catalog:8080\n", True)
+    check("a host inside a ${VAR:default} default is flagged",
+          "a:\n  b: ${SCHEMA_URL:http://schema-registry.messaging.svc:8081}\n", True)
+
+    # ---- MUST NOT FLAG ---------------------------------------------------------------
+    # THE code-about-code case: the only occurrence of the bogus host is a comment.
+    # PyYAML drops it, so the parsed value is clean. This is the assertion that stops the
+    # guard flagging the prose that explains the config (#2450 / #3072).
+    check("a bogus host that appears ONLY in a comment is NOT flagged",
+          "# provisioned in openbank-infra as service schema-registry.messaging.svc:8081\n"
+          "a:\n  b: http://apicurio-registry.messaging.svc:8080\n", False)
+    check("a real Service resolves clean", "a:\n  b: http://apicurio-registry.messaging.svc:8080\n", False)
+    check("localhost is never flagged", "a:\n  b: http://localhost:8081\n", False)
+    check("127.0.0.1 is never flagged", "a:\n  b: http://127.0.0.1:8081\n", False)
+    check("an external public host is never flagged", "a:\n  b: https://api.github.com/repos\n", False)
+    check("an external host with a deep prefix is never flagged",
+          "a:\n  b: https://s3.eu-central-1.amazonaws.com/bucket\n", False)
+    check("a dev-services style bare host:port with no scheme is NOT flagged",
+          "a:\n  b: kafka:9092\n", False)
+    check("a Helm-chart Service corroborated by a gitops env is NOT flagged",
+          "a:\n  b: temporal-frontend.temporal.svc.cluster.local:7233\n", False)
+    check("a host in an unknown (non-cluster) namespace-looking domain is NOT flagged",
+          "a:\n  b: http://kc.open-bank.tech/realms/openbank\n", False)
+
+    # The guard must also survive shapes that are not hostnames at all.
+    check("a CORS origin is NOT treated as a dialled host",
+          "quarkus:\n  http:\n    cors:\n      origins: \"http://openbank-admin-ui:3000\"\n", False)
+    check("but the SAME host under a rest-client url IS flagged",
+          "quarkus:\n  rest-client:\n    x:\n      url: http://openbank-admin-ui:3000\n", True)
+    check("a plain word is not treated as a host", "a:\n  b: earliest\n", False)
+    check("a duration/number scalar is not treated as a host", "a:\n  b: PT24H\n", False)
+
+    if failures:
+        print(f"\n::error::self-test failed: {', '.join(failures)}")
+        return 1
+    print("\nself-test passed: the gate flags an unresolvable in-cluster host, ignores a "
+          "host that exists only in a comment, and leaves localhost/external hosts alone.")
+    return 0
+
+
+def main() -> int:
+    ap = argparse.ArgumentParser(description=__doc__)
+    ap.add_argument("--self-test", action="store_true", help="prove the gate can fail")
+    ap.add_argument("--enforce", action="store_true", help="exit 1 on findings")
+    args = ap.parse_args()
+    return self_test() if args.self_test else run_gate(args.enforce)
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/openbank-analytics-sink/src/main/resources/application.yaml
+++ b/openbank-analytics-sink/src/main/resources/application.yaml
@@ -190,9 +190,19 @@ openbank:
       # When true, an unknown/newer-than-known schema is quarantined to the DLQ instead of written.
       strict: ${ANALYTICS_SCHEMA_STRICT:false}
       # Apicurio registry coordinates (used only when schema.backend=apicurio). Provisioned in
-      # openbank-infra as service schema-registry:8081. group is the Apicurio artifact group.
+      # openbank-infra by the `apicurio` ArgoCD Application as Service `apicurio-registry` on port
+      # 8080 in namespace `messaging` (gitops/components/apicurio/registry.yaml). group is the
+      # Apicurio artifact group.
+      #
+      # This previously read "service schema-registry:8081" and defaulted to
+      # http://localhost:8081 — wrong host AND wrong port, in the prose and in the value. Nothing
+      # could have said so: a unit test stubs the catalogue source and the IT serves a local
+      # fixture, so an in-cluster hostname is unfalsifiable by every test layer here (the same
+      # shape as the fx-service CNB URL that was a 404 for the life of the service). The value is
+      # now checked by .github/scripts/check-incluster-hostnames.py, which resolves it against the
+      # Services gitops actually declares (issue #1916).
       apicurio:
-        url: ${ANALYTICS_SCHEMA_APICURIO_URL:http://localhost:8081}
+        url: ${ANALYTICS_SCHEMA_APICURIO_URL:http://apicurio-registry.messaging.svc:8080}
         group: ${ANALYTICS_SCHEMA_APICURIO_GROUP:default}
     erasure:
       # Selects the CryptoErasure backend at BUILD time. Default (unset) = NoOpCryptoErasure (logs).

--- a/openbank-infra/gitops/components/accounts/account-opa-bundle.yaml
+++ b/openbank-infra/gitops/components/accounts/account-opa-bundle.yaml
@@ -9,7 +9,7 @@ metadata:
     app.kubernetes.io/name: account-service
     app.kubernetes.io/part-of: accounts
   annotations:
-    openbank.tech/policy-checksum: "c63a450ecf29a6d6"
+    openbank.tech/policy-checksum: "bf58b5555e275cf4"
 data:
   rest.rego: |
     # SPDX-License-Identifier: Apache-2.0
@@ -3051,6 +3051,46 @@ data:
       # first, so the probe would keep passing against a URL the service does not use — the same
       # vacuous shape as deriving both halves of a pact from one annotation.
       ci_producer: .github/scripts/check-external-feeds.py
+
+    incluster_hostnames:
+      # The in-cluster half of external_feeds (above). Same unfalsifiability, different upstream: a
+      # hostname naming another SERVICE in this cluster is stubbed by the unit test, overridden to
+      # localhost by the IT, and never sent by a consumer pact — so it is wrong only at the moment a
+      # pod dials it, and the symptom is a connect timeout in one log line.
+      #
+      # Found live (issue #1916): openbank-analytics-sink's application.yaml documented the Apicurio
+      # schema registry as "provisioned in openbank-infra as service schema-registry:8081" and
+      # defaulted ANALYTICS_SCHEMA_APICURIO_URL to http://localhost:8081. The Service is
+      # `apicurio-registry` on 8080 in namespace `messaging`. Wrong host AND wrong port, stated twice
+      # (prose and value), with nothing in the repo able to contradict either.
+      #
+      # THE RULE: every in-cluster hostname in an openbank-*/src/main/resources/application.yaml must
+      # resolve to a Service that openbank-infra/gitops/ declares.
+      hostname_must_resolve_to_declared_service: true
+      #
+      # Unlike external_feeds this needs no network — the set of names that CAN resolve is fully
+      # declared in gitops, so the claim is decidable offline and deterministically.
+      known_set_is_derived_from_gitops: true
+      # kind: Service, plus the endpoints CNPG (<name>-rw/-ro/-r) and Strimzi
+      # (<name>-kafka-bootstrap/-brokers) synthesise from their CRs. There is NO hand-kept list of
+      # service names in the checker: a gate whose scope is maintained separately from the artifacts
+      # it covers reads as PASSING when the list is short, never as unchecked.
+      asserts_against_parsed_yaml_not_file_text: true
+      # A whole-file grep cannot tell config from the prose ABOUT config, and this repo has been burnt
+      # in both directions (#2450 flagged the comment explaining the bug; #3072 matched the comment
+      # above the line it was asserting on, so deleting the line stayed green). The checker reads
+      # yaml.safe_load_all output, which drops comments by construction, and --self-test pins it with
+      # a fixture whose only bogus host is in a comment.
+      #
+      # ADVISORY while the 6 pre-existing findings are triaged. All six are bare `openbank-<svc>` rest
+      # client defaults (account, card-issuance, onboarding, settlement) that name no Service in any
+      # namespace — the deployed pods override them by env, so they are dead defaults rather than a
+      # live outage, but each is a hostname nobody could dial. They are NOT fixed in the PR that
+      # introduced this gate: four of the owning services are money-path, so a default-URL change
+      # there needs the two-approval path rather than riding along with a CI guard.
+      enforced: advisory
+      target_enforce_date: "2026-10-31"   # ADR-0144
+      ci_producer: .github/scripts/check-incluster-hostnames.py
 
     kafka_dotted_keys:
       # SmallRye Config's YAML source quotes any leaf map key containing a literal dot, so

--- a/openbank-infra/gitops/components/accounts/account-service.yaml
+++ b/openbank-infra/gitops/components/accounts/account-service.yaml
@@ -37,7 +37,7 @@ spec:
       annotations:
         # Rolls the pod when the OPA bundle changes — subPath mounts do NOT hot-reload.
         # Kept in sync by gen-account-opa-bundle.sh (do not hand-edit).
-        openbank.tech/policy-checksum: "c63a450ecf29a6d6"
+        openbank.tech/policy-checksum: "bf58b5555e275cf4"
     spec:
       securityContext:
         runAsNonRoot: true

--- a/openbank-infra/gitops/components/aml/aml-opa-bundle.yaml
+++ b/openbank-infra/gitops/components/aml/aml-opa-bundle.yaml
@@ -9,7 +9,7 @@ metadata:
     app.kubernetes.io/name: aml-service
     app.kubernetes.io/part-of: aml
   annotations:
-    openbank.tech/policy-checksum: "7d02b972f29053f6"
+    openbank.tech/policy-checksum: "3336b99ffb05943b"
 data:
   rest.rego: |
     # SPDX-License-Identifier: Apache-2.0
@@ -3024,6 +3024,46 @@ data:
       # first, so the probe would keep passing against a URL the service does not use — the same
       # vacuous shape as deriving both halves of a pact from one annotation.
       ci_producer: .github/scripts/check-external-feeds.py
+
+    incluster_hostnames:
+      # The in-cluster half of external_feeds (above). Same unfalsifiability, different upstream: a
+      # hostname naming another SERVICE in this cluster is stubbed by the unit test, overridden to
+      # localhost by the IT, and never sent by a consumer pact — so it is wrong only at the moment a
+      # pod dials it, and the symptom is a connect timeout in one log line.
+      #
+      # Found live (issue #1916): openbank-analytics-sink's application.yaml documented the Apicurio
+      # schema registry as "provisioned in openbank-infra as service schema-registry:8081" and
+      # defaulted ANALYTICS_SCHEMA_APICURIO_URL to http://localhost:8081. The Service is
+      # `apicurio-registry` on 8080 in namespace `messaging`. Wrong host AND wrong port, stated twice
+      # (prose and value), with nothing in the repo able to contradict either.
+      #
+      # THE RULE: every in-cluster hostname in an openbank-*/src/main/resources/application.yaml must
+      # resolve to a Service that openbank-infra/gitops/ declares.
+      hostname_must_resolve_to_declared_service: true
+      #
+      # Unlike external_feeds this needs no network — the set of names that CAN resolve is fully
+      # declared in gitops, so the claim is decidable offline and deterministically.
+      known_set_is_derived_from_gitops: true
+      # kind: Service, plus the endpoints CNPG (<name>-rw/-ro/-r) and Strimzi
+      # (<name>-kafka-bootstrap/-brokers) synthesise from their CRs. There is NO hand-kept list of
+      # service names in the checker: a gate whose scope is maintained separately from the artifacts
+      # it covers reads as PASSING when the list is short, never as unchecked.
+      asserts_against_parsed_yaml_not_file_text: true
+      # A whole-file grep cannot tell config from the prose ABOUT config, and this repo has been burnt
+      # in both directions (#2450 flagged the comment explaining the bug; #3072 matched the comment
+      # above the line it was asserting on, so deleting the line stayed green). The checker reads
+      # yaml.safe_load_all output, which drops comments by construction, and --self-test pins it with
+      # a fixture whose only bogus host is in a comment.
+      #
+      # ADVISORY while the 6 pre-existing findings are triaged. All six are bare `openbank-<svc>` rest
+      # client defaults (account, card-issuance, onboarding, settlement) that name no Service in any
+      # namespace — the deployed pods override them by env, so they are dead defaults rather than a
+      # live outage, but each is a hostname nobody could dial. They are NOT fixed in the PR that
+      # introduced this gate: four of the owning services are money-path, so a default-URL change
+      # there needs the two-approval path rather than riding along with a CI guard.
+      enforced: advisory
+      target_enforce_date: "2026-10-31"   # ADR-0144
+      ci_producer: .github/scripts/check-incluster-hostnames.py
 
     kafka_dotted_keys:
       # SmallRye Config's YAML source quotes any leaf map key containing a literal dot, so

--- a/openbank-infra/gitops/components/aml/aml-service.yaml
+++ b/openbank-infra/gitops/components/aml/aml-service.yaml
@@ -22,7 +22,7 @@ spec:
       annotations:
         # Rolls the pod when the OPA bundle changes (subPath mounts do not hot-reload).
         # Kept in sync by gen-aml-opa-bundle.sh (do not hand-edit).
-        openbank.tech/policy-checksum: "7d02b972f29053f6"
+        openbank.tech/policy-checksum: "3336b99ffb05943b"
     spec:
       securityContext:
         runAsNonRoot: true

--- a/openbank-infra/gitops/components/anacredit/anacredit-opa-bundle.yaml
+++ b/openbank-infra/gitops/components/anacredit/anacredit-opa-bundle.yaml
@@ -9,7 +9,7 @@ metadata:
     app.kubernetes.io/name: anacredit-service
     app.kubernetes.io/part-of: anacredit
   annotations:
-    openbank.tech/policy-checksum: "e5cef8bfdd373955"
+    openbank.tech/policy-checksum: "f6fc187c939ffb78"
 data:
   rest.rego: |
     # SPDX-License-Identifier: Apache-2.0
@@ -2994,6 +2994,46 @@ data:
       # first, so the probe would keep passing against a URL the service does not use — the same
       # vacuous shape as deriving both halves of a pact from one annotation.
       ci_producer: .github/scripts/check-external-feeds.py
+
+    incluster_hostnames:
+      # The in-cluster half of external_feeds (above). Same unfalsifiability, different upstream: a
+      # hostname naming another SERVICE in this cluster is stubbed by the unit test, overridden to
+      # localhost by the IT, and never sent by a consumer pact — so it is wrong only at the moment a
+      # pod dials it, and the symptom is a connect timeout in one log line.
+      #
+      # Found live (issue #1916): openbank-analytics-sink's application.yaml documented the Apicurio
+      # schema registry as "provisioned in openbank-infra as service schema-registry:8081" and
+      # defaulted ANALYTICS_SCHEMA_APICURIO_URL to http://localhost:8081. The Service is
+      # `apicurio-registry` on 8080 in namespace `messaging`. Wrong host AND wrong port, stated twice
+      # (prose and value), with nothing in the repo able to contradict either.
+      #
+      # THE RULE: every in-cluster hostname in an openbank-*/src/main/resources/application.yaml must
+      # resolve to a Service that openbank-infra/gitops/ declares.
+      hostname_must_resolve_to_declared_service: true
+      #
+      # Unlike external_feeds this needs no network — the set of names that CAN resolve is fully
+      # declared in gitops, so the claim is decidable offline and deterministically.
+      known_set_is_derived_from_gitops: true
+      # kind: Service, plus the endpoints CNPG (<name>-rw/-ro/-r) and Strimzi
+      # (<name>-kafka-bootstrap/-brokers) synthesise from their CRs. There is NO hand-kept list of
+      # service names in the checker: a gate whose scope is maintained separately from the artifacts
+      # it covers reads as PASSING when the list is short, never as unchecked.
+      asserts_against_parsed_yaml_not_file_text: true
+      # A whole-file grep cannot tell config from the prose ABOUT config, and this repo has been burnt
+      # in both directions (#2450 flagged the comment explaining the bug; #3072 matched the comment
+      # above the line it was asserting on, so deleting the line stayed green). The checker reads
+      # yaml.safe_load_all output, which drops comments by construction, and --self-test pins it with
+      # a fixture whose only bogus host is in a comment.
+      #
+      # ADVISORY while the 6 pre-existing findings are triaged. All six are bare `openbank-<svc>` rest
+      # client defaults (account, card-issuance, onboarding, settlement) that name no Service in any
+      # namespace — the deployed pods override them by env, so they are dead defaults rather than a
+      # live outage, but each is a hostname nobody could dial. They are NOT fixed in the PR that
+      # introduced this gate: four of the owning services are money-path, so a default-URL change
+      # there needs the two-approval path rather than riding along with a CI guard.
+      enforced: advisory
+      target_enforce_date: "2026-10-31"   # ADR-0144
+      ci_producer: .github/scripts/check-incluster-hostnames.py
 
     kafka_dotted_keys:
       # SmallRye Config's YAML source quotes any leaf map key containing a literal dot, so

--- a/openbank-infra/gitops/components/anacredit/anacredit-service.yaml
+++ b/openbank-infra/gitops/components/anacredit/anacredit-service.yaml
@@ -32,7 +32,7 @@ spec:
       annotations:
         # Rolls the pods when the OPA bundle changes — subPath mounts do NOT hot-reload.
         # Kept in sync by gen-anacredit-opa-bundle.sh (do not hand-edit).
-        openbank.tech/policy-checksum: "e5cef8bfdd373955"
+        openbank.tech/policy-checksum: "f6fc187c939ffb78"
     spec:
       securityContext:
         runAsNonRoot: true

--- a/openbank-infra/gitops/components/analytics/analytics-sink.yaml
+++ b/openbank-infra/gitops/components/analytics/analytics-sink.yaml
@@ -105,6 +105,30 @@ spec:
                 secretKeyRef:
                   name: kafka-cluster-ca-truststore
                   key: ca.password
+            # Apicurio schema registry (ADR-0023 F7 / issue #1916). Declared here even though
+            # ANALYTICS_SCHEMA_BACKEND is deliberately NOT set yet, for two reasons:
+            #
+            #  1. gen-network-policies.py derives every cross-namespace ingress edge from
+            #     Deployment env URLs and NOTHING else. A URL that lives only in the service's
+            #     application.yaml produces no edge at all, so `analytics` would be absent from
+            #     apicurio-registry's allow-list and the VPC CNI agent (standard mode, ADR-0060)
+            #     would DROP the call the moment the backend was flipped — no manifest error, no
+            #     policy diff, just a hung request. Declaring the URL here is what puts the
+            #     namespace in the derived allow-list; re-run the generator after editing this.
+            #  2. It pins the coordinates in the manifest that actually deploys, so the
+            #     application.yaml default and the deployed value cannot drift apart silently.
+            #
+            # The `.svc` suffix is load-bearing for the generator: its URL_RE requires a literal
+            # `.svc`, so the short `apicurio-registry.messaging:8080` form would match nothing and
+            # the generator would exit 0 having changed nothing — a silent no-op indistinguishable
+            # from "already in sync".
+            #
+            # Flipping ANALYTICS_SCHEMA_BACKEND to "apicurio" is a separate rollout decision and
+            # is NOT done here: no producer registers an Avro artifact yet (issue #1916), so the
+            # catalogue would come back empty and, with ANALYTICS_SCHEMA_STRICT unset, the F7 gate
+            # would accept everything while reporting it had a registry behind it.
+            - name: ANALYTICS_SCHEMA_APICURIO_URL
+              value: http://apicurio-registry.messaging.svc:8080
             - name: QUARKUS_CONFIG_LOCATIONS
               value: /mnt/msg-config/override.properties
           startupProbe:

--- a/openbank-infra/gitops/components/ap2/ap2-opa-bundle.yaml
+++ b/openbank-infra/gitops/components/ap2/ap2-opa-bundle.yaml
@@ -9,7 +9,7 @@ metadata:
     app.kubernetes.io/name: mcp-service
     app.kubernetes.io/part-of: platform
   annotations:
-    openbank.tech/policy-checksum: "83d0f65258683b24"
+    openbank.tech/policy-checksum: "9e16ec3241c00c6f"
 data:
   rest.rego: |
     # SPDX-License-Identifier: Apache-2.0
@@ -2962,6 +2962,46 @@ data:
       # first, so the probe would keep passing against a URL the service does not use — the same
       # vacuous shape as deriving both halves of a pact from one annotation.
       ci_producer: .github/scripts/check-external-feeds.py
+
+    incluster_hostnames:
+      # The in-cluster half of external_feeds (above). Same unfalsifiability, different upstream: a
+      # hostname naming another SERVICE in this cluster is stubbed by the unit test, overridden to
+      # localhost by the IT, and never sent by a consumer pact — so it is wrong only at the moment a
+      # pod dials it, and the symptom is a connect timeout in one log line.
+      #
+      # Found live (issue #1916): openbank-analytics-sink's application.yaml documented the Apicurio
+      # schema registry as "provisioned in openbank-infra as service schema-registry:8081" and
+      # defaulted ANALYTICS_SCHEMA_APICURIO_URL to http://localhost:8081. The Service is
+      # `apicurio-registry` on 8080 in namespace `messaging`. Wrong host AND wrong port, stated twice
+      # (prose and value), with nothing in the repo able to contradict either.
+      #
+      # THE RULE: every in-cluster hostname in an openbank-*/src/main/resources/application.yaml must
+      # resolve to a Service that openbank-infra/gitops/ declares.
+      hostname_must_resolve_to_declared_service: true
+      #
+      # Unlike external_feeds this needs no network — the set of names that CAN resolve is fully
+      # declared in gitops, so the claim is decidable offline and deterministically.
+      known_set_is_derived_from_gitops: true
+      # kind: Service, plus the endpoints CNPG (<name>-rw/-ro/-r) and Strimzi
+      # (<name>-kafka-bootstrap/-brokers) synthesise from their CRs. There is NO hand-kept list of
+      # service names in the checker: a gate whose scope is maintained separately from the artifacts
+      # it covers reads as PASSING when the list is short, never as unchecked.
+      asserts_against_parsed_yaml_not_file_text: true
+      # A whole-file grep cannot tell config from the prose ABOUT config, and this repo has been burnt
+      # in both directions (#2450 flagged the comment explaining the bug; #3072 matched the comment
+      # above the line it was asserting on, so deleting the line stayed green). The checker reads
+      # yaml.safe_load_all output, which drops comments by construction, and --self-test pins it with
+      # a fixture whose only bogus host is in a comment.
+      #
+      # ADVISORY while the 6 pre-existing findings are triaged. All six are bare `openbank-<svc>` rest
+      # client defaults (account, card-issuance, onboarding, settlement) that name no Service in any
+      # namespace — the deployed pods override them by env, so they are dead defaults rather than a
+      # live outage, but each is a hostname nobody could dial. They are NOT fixed in the PR that
+      # introduced this gate: four of the owning services are money-path, so a default-URL change
+      # there needs the two-approval path rather than riding along with a CI guard.
+      enforced: advisory
+      target_enforce_date: "2026-10-31"   # ADR-0144
+      ci_producer: .github/scripts/check-incluster-hostnames.py
 
     kafka_dotted_keys:
       # SmallRye Config's YAML source quotes any leaf map key containing a literal dot, so

--- a/openbank-infra/gitops/components/ap2/ap2-service.yaml
+++ b/openbank-infra/gitops/components/ap2/ap2-service.yaml
@@ -30,7 +30,7 @@ spec:
       annotations:
         # Roll the pod when the OPA policy bundle changes (subPath mounts don't hot-reload).
         # Kept in sync by gen-ap2-opa-bundle.sh (do not hand-edit).
-        openbank.tech/policy-checksum: "83d0f65258683b24"
+        openbank.tech/policy-checksum: "9e16ec3241c00c6f"
     spec:
       securityContext:
         runAsNonRoot: true

--- a/openbank-infra/gitops/components/apicurio/network-policies.yaml
+++ b/openbank-infra/gitops/components/apicurio/network-policies.yaml
@@ -44,6 +44,9 @@ spec:
     - from:
         - namespaceSelector:
             matchLabels:
+              kubernetes.io/metadata.name: analytics
+        - namespaceSelector:
+            matchLabels:
               kubernetes.io/metadata.name: admin-ui
       ports:
         - protocol: TCP

--- a/openbank-infra/gitops/components/audit/audit-opa-bundle.yaml
+++ b/openbank-infra/gitops/components/audit/audit-opa-bundle.yaml
@@ -9,7 +9,7 @@ metadata:
     app.kubernetes.io/name: audit-service
     app.kubernetes.io/part-of: audit
   annotations:
-    openbank.tech/policy-checksum: "1e42f829d18f0d57"
+    openbank.tech/policy-checksum: "d799e92a7f0cf6c6"
 data:
   rest.rego: |
     # SPDX-License-Identifier: Apache-2.0
@@ -3006,6 +3006,46 @@ data:
       # first, so the probe would keep passing against a URL the service does not use — the same
       # vacuous shape as deriving both halves of a pact from one annotation.
       ci_producer: .github/scripts/check-external-feeds.py
+
+    incluster_hostnames:
+      # The in-cluster half of external_feeds (above). Same unfalsifiability, different upstream: a
+      # hostname naming another SERVICE in this cluster is stubbed by the unit test, overridden to
+      # localhost by the IT, and never sent by a consumer pact — so it is wrong only at the moment a
+      # pod dials it, and the symptom is a connect timeout in one log line.
+      #
+      # Found live (issue #1916): openbank-analytics-sink's application.yaml documented the Apicurio
+      # schema registry as "provisioned in openbank-infra as service schema-registry:8081" and
+      # defaulted ANALYTICS_SCHEMA_APICURIO_URL to http://localhost:8081. The Service is
+      # `apicurio-registry` on 8080 in namespace `messaging`. Wrong host AND wrong port, stated twice
+      # (prose and value), with nothing in the repo able to contradict either.
+      #
+      # THE RULE: every in-cluster hostname in an openbank-*/src/main/resources/application.yaml must
+      # resolve to a Service that openbank-infra/gitops/ declares.
+      hostname_must_resolve_to_declared_service: true
+      #
+      # Unlike external_feeds this needs no network — the set of names that CAN resolve is fully
+      # declared in gitops, so the claim is decidable offline and deterministically.
+      known_set_is_derived_from_gitops: true
+      # kind: Service, plus the endpoints CNPG (<name>-rw/-ro/-r) and Strimzi
+      # (<name>-kafka-bootstrap/-brokers) synthesise from their CRs. There is NO hand-kept list of
+      # service names in the checker: a gate whose scope is maintained separately from the artifacts
+      # it covers reads as PASSING when the list is short, never as unchecked.
+      asserts_against_parsed_yaml_not_file_text: true
+      # A whole-file grep cannot tell config from the prose ABOUT config, and this repo has been burnt
+      # in both directions (#2450 flagged the comment explaining the bug; #3072 matched the comment
+      # above the line it was asserting on, so deleting the line stayed green). The checker reads
+      # yaml.safe_load_all output, which drops comments by construction, and --self-test pins it with
+      # a fixture whose only bogus host is in a comment.
+      #
+      # ADVISORY while the 6 pre-existing findings are triaged. All six are bare `openbank-<svc>` rest
+      # client defaults (account, card-issuance, onboarding, settlement) that name no Service in any
+      # namespace — the deployed pods override them by env, so they are dead defaults rather than a
+      # live outage, but each is a hostname nobody could dial. They are NOT fixed in the PR that
+      # introduced this gate: four of the owning services are money-path, so a default-URL change
+      # there needs the two-approval path rather than riding along with a CI guard.
+      enforced: advisory
+      target_enforce_date: "2026-10-31"   # ADR-0144
+      ci_producer: .github/scripts/check-incluster-hostnames.py
 
     kafka_dotted_keys:
       # SmallRye Config's YAML source quotes any leaf map key containing a literal dot, so

--- a/openbank-infra/gitops/components/audit/audit-service.yaml
+++ b/openbank-infra/gitops/components/audit/audit-service.yaml
@@ -22,7 +22,7 @@ spec:
       annotations:
         # Rolls the pod when the OPA bundle changes (subPath mounts do not hot-reload).
         # Kept in sync by gen-audit-opa-bundle.sh (do not hand-edit).
-        openbank.tech/policy-checksum: "1e42f829d18f0d57"
+        openbank.tech/policy-checksum: "d799e92a7f0cf6c6"
     spec:
       securityContext:
         runAsNonRoot: true

--- a/openbank-infra/gitops/components/balances/balance-opa-bundle.yaml
+++ b/openbank-infra/gitops/components/balances/balance-opa-bundle.yaml
@@ -9,7 +9,7 @@ metadata:
     app.kubernetes.io/name: balance-service
     app.kubernetes.io/part-of: balances
   annotations:
-    openbank.tech/policy-checksum: "a3a651f853299ef1"
+    openbank.tech/policy-checksum: "a01e01fea97a82c5"
 data:
   rest.rego: |
     # SPDX-License-Identifier: Apache-2.0
@@ -3095,6 +3095,46 @@ data:
       # first, so the probe would keep passing against a URL the service does not use — the same
       # vacuous shape as deriving both halves of a pact from one annotation.
       ci_producer: .github/scripts/check-external-feeds.py
+
+    incluster_hostnames:
+      # The in-cluster half of external_feeds (above). Same unfalsifiability, different upstream: a
+      # hostname naming another SERVICE in this cluster is stubbed by the unit test, overridden to
+      # localhost by the IT, and never sent by a consumer pact — so it is wrong only at the moment a
+      # pod dials it, and the symptom is a connect timeout in one log line.
+      #
+      # Found live (issue #1916): openbank-analytics-sink's application.yaml documented the Apicurio
+      # schema registry as "provisioned in openbank-infra as service schema-registry:8081" and
+      # defaulted ANALYTICS_SCHEMA_APICURIO_URL to http://localhost:8081. The Service is
+      # `apicurio-registry` on 8080 in namespace `messaging`. Wrong host AND wrong port, stated twice
+      # (prose and value), with nothing in the repo able to contradict either.
+      #
+      # THE RULE: every in-cluster hostname in an openbank-*/src/main/resources/application.yaml must
+      # resolve to a Service that openbank-infra/gitops/ declares.
+      hostname_must_resolve_to_declared_service: true
+      #
+      # Unlike external_feeds this needs no network — the set of names that CAN resolve is fully
+      # declared in gitops, so the claim is decidable offline and deterministically.
+      known_set_is_derived_from_gitops: true
+      # kind: Service, plus the endpoints CNPG (<name>-rw/-ro/-r) and Strimzi
+      # (<name>-kafka-bootstrap/-brokers) synthesise from their CRs. There is NO hand-kept list of
+      # service names in the checker: a gate whose scope is maintained separately from the artifacts
+      # it covers reads as PASSING when the list is short, never as unchecked.
+      asserts_against_parsed_yaml_not_file_text: true
+      # A whole-file grep cannot tell config from the prose ABOUT config, and this repo has been burnt
+      # in both directions (#2450 flagged the comment explaining the bug; #3072 matched the comment
+      # above the line it was asserting on, so deleting the line stayed green). The checker reads
+      # yaml.safe_load_all output, which drops comments by construction, and --self-test pins it with
+      # a fixture whose only bogus host is in a comment.
+      #
+      # ADVISORY while the 6 pre-existing findings are triaged. All six are bare `openbank-<svc>` rest
+      # client defaults (account, card-issuance, onboarding, settlement) that name no Service in any
+      # namespace — the deployed pods override them by env, so they are dead defaults rather than a
+      # live outage, but each is a hostname nobody could dial. They are NOT fixed in the PR that
+      # introduced this gate: four of the owning services are money-path, so a default-URL change
+      # there needs the two-approval path rather than riding along with a CI guard.
+      enforced: advisory
+      target_enforce_date: "2026-10-31"   # ADR-0144
+      ci_producer: .github/scripts/check-incluster-hostnames.py
 
     kafka_dotted_keys:
       # SmallRye Config's YAML source quotes any leaf map key containing a literal dot, so

--- a/openbank-infra/gitops/components/balances/balance-service.yaml
+++ b/openbank-infra/gitops/components/balances/balance-service.yaml
@@ -34,7 +34,7 @@ spec:
       annotations:
         # Rolls the pods when the OPA bundle changes — subPath mounts do NOT hot-reload.
         # Kept in sync by gen-balance-opa-bundle.sh (do not hand-edit).
-        openbank.tech/policy-checksum: "a3a651f853299ef1"
+        openbank.tech/policy-checksum: "a01e01fea97a82c5"
     spec:
       securityContext:
         runAsNonRoot: true

--- a/openbank-infra/gitops/components/billing/billing-opa-bundle.yaml
+++ b/openbank-infra/gitops/components/billing/billing-opa-bundle.yaml
@@ -9,7 +9,7 @@ metadata:
     app.kubernetes.io/name: billing-service
     app.kubernetes.io/part-of: billing
   annotations:
-    openbank.tech/policy-checksum: "961555b750e6ccbd"
+    openbank.tech/policy-checksum: "7cb483fb1503fd02"
 data:
   rest.rego: |
     # SPDX-License-Identifier: Apache-2.0
@@ -3000,6 +3000,46 @@ data:
       # first, so the probe would keep passing against a URL the service does not use — the same
       # vacuous shape as deriving both halves of a pact from one annotation.
       ci_producer: .github/scripts/check-external-feeds.py
+
+    incluster_hostnames:
+      # The in-cluster half of external_feeds (above). Same unfalsifiability, different upstream: a
+      # hostname naming another SERVICE in this cluster is stubbed by the unit test, overridden to
+      # localhost by the IT, and never sent by a consumer pact — so it is wrong only at the moment a
+      # pod dials it, and the symptom is a connect timeout in one log line.
+      #
+      # Found live (issue #1916): openbank-analytics-sink's application.yaml documented the Apicurio
+      # schema registry as "provisioned in openbank-infra as service schema-registry:8081" and
+      # defaulted ANALYTICS_SCHEMA_APICURIO_URL to http://localhost:8081. The Service is
+      # `apicurio-registry` on 8080 in namespace `messaging`. Wrong host AND wrong port, stated twice
+      # (prose and value), with nothing in the repo able to contradict either.
+      #
+      # THE RULE: every in-cluster hostname in an openbank-*/src/main/resources/application.yaml must
+      # resolve to a Service that openbank-infra/gitops/ declares.
+      hostname_must_resolve_to_declared_service: true
+      #
+      # Unlike external_feeds this needs no network — the set of names that CAN resolve is fully
+      # declared in gitops, so the claim is decidable offline and deterministically.
+      known_set_is_derived_from_gitops: true
+      # kind: Service, plus the endpoints CNPG (<name>-rw/-ro/-r) and Strimzi
+      # (<name>-kafka-bootstrap/-brokers) synthesise from their CRs. There is NO hand-kept list of
+      # service names in the checker: a gate whose scope is maintained separately from the artifacts
+      # it covers reads as PASSING when the list is short, never as unchecked.
+      asserts_against_parsed_yaml_not_file_text: true
+      # A whole-file grep cannot tell config from the prose ABOUT config, and this repo has been burnt
+      # in both directions (#2450 flagged the comment explaining the bug; #3072 matched the comment
+      # above the line it was asserting on, so deleting the line stayed green). The checker reads
+      # yaml.safe_load_all output, which drops comments by construction, and --self-test pins it with
+      # a fixture whose only bogus host is in a comment.
+      #
+      # ADVISORY while the 6 pre-existing findings are triaged. All six are bare `openbank-<svc>` rest
+      # client defaults (account, card-issuance, onboarding, settlement) that name no Service in any
+      # namespace — the deployed pods override them by env, so they are dead defaults rather than a
+      # live outage, but each is a hostname nobody could dial. They are NOT fixed in the PR that
+      # introduced this gate: four of the owning services are money-path, so a default-URL change
+      # there needs the two-approval path rather than riding along with a CI guard.
+      enforced: advisory
+      target_enforce_date: "2026-10-31"   # ADR-0144
+      ci_producer: .github/scripts/check-incluster-hostnames.py
 
     kafka_dotted_keys:
       # SmallRye Config's YAML source quotes any leaf map key containing a literal dot, so

--- a/openbank-infra/gitops/components/billing/billing-service.yaml
+++ b/openbank-infra/gitops/components/billing/billing-service.yaml
@@ -27,7 +27,7 @@ spec:
       annotations:
         # Rolls the pods when the OPA bundle changes — subPath mounts do NOT hot-reload.
         # Kept in sync by gen-billing-opa-bundle.sh (do not hand-edit).
-        openbank.tech/policy-checksum: "961555b750e6ccbd"
+        openbank.tech/policy-checksum: "7cb483fb1503fd02"
     spec:
       securityContext:
         runAsNonRoot: true

--- a/openbank-infra/gitops/components/campaign/campaign-opa-bundle.yaml
+++ b/openbank-infra/gitops/components/campaign/campaign-opa-bundle.yaml
@@ -9,7 +9,7 @@ metadata:
     app.kubernetes.io/name: campaign-service
     app.kubernetes.io/part-of: campaign
   annotations:
-    openbank.tech/policy-checksum: "11b89dc13c0cac3b"
+    openbank.tech/policy-checksum: "8b8fdfff0d05b738"
 data:
   rest.rego: |
     # SPDX-License-Identifier: Apache-2.0
@@ -3021,6 +3021,46 @@ data:
       # first, so the probe would keep passing against a URL the service does not use — the same
       # vacuous shape as deriving both halves of a pact from one annotation.
       ci_producer: .github/scripts/check-external-feeds.py
+
+    incluster_hostnames:
+      # The in-cluster half of external_feeds (above). Same unfalsifiability, different upstream: a
+      # hostname naming another SERVICE in this cluster is stubbed by the unit test, overridden to
+      # localhost by the IT, and never sent by a consumer pact — so it is wrong only at the moment a
+      # pod dials it, and the symptom is a connect timeout in one log line.
+      #
+      # Found live (issue #1916): openbank-analytics-sink's application.yaml documented the Apicurio
+      # schema registry as "provisioned in openbank-infra as service schema-registry:8081" and
+      # defaulted ANALYTICS_SCHEMA_APICURIO_URL to http://localhost:8081. The Service is
+      # `apicurio-registry` on 8080 in namespace `messaging`. Wrong host AND wrong port, stated twice
+      # (prose and value), with nothing in the repo able to contradict either.
+      #
+      # THE RULE: every in-cluster hostname in an openbank-*/src/main/resources/application.yaml must
+      # resolve to a Service that openbank-infra/gitops/ declares.
+      hostname_must_resolve_to_declared_service: true
+      #
+      # Unlike external_feeds this needs no network — the set of names that CAN resolve is fully
+      # declared in gitops, so the claim is decidable offline and deterministically.
+      known_set_is_derived_from_gitops: true
+      # kind: Service, plus the endpoints CNPG (<name>-rw/-ro/-r) and Strimzi
+      # (<name>-kafka-bootstrap/-brokers) synthesise from their CRs. There is NO hand-kept list of
+      # service names in the checker: a gate whose scope is maintained separately from the artifacts
+      # it covers reads as PASSING when the list is short, never as unchecked.
+      asserts_against_parsed_yaml_not_file_text: true
+      # A whole-file grep cannot tell config from the prose ABOUT config, and this repo has been burnt
+      # in both directions (#2450 flagged the comment explaining the bug; #3072 matched the comment
+      # above the line it was asserting on, so deleting the line stayed green). The checker reads
+      # yaml.safe_load_all output, which drops comments by construction, and --self-test pins it with
+      # a fixture whose only bogus host is in a comment.
+      #
+      # ADVISORY while the 6 pre-existing findings are triaged. All six are bare `openbank-<svc>` rest
+      # client defaults (account, card-issuance, onboarding, settlement) that name no Service in any
+      # namespace — the deployed pods override them by env, so they are dead defaults rather than a
+      # live outage, but each is a hostname nobody could dial. They are NOT fixed in the PR that
+      # introduced this gate: four of the owning services are money-path, so a default-URL change
+      # there needs the two-approval path rather than riding along with a CI guard.
+      enforced: advisory
+      target_enforce_date: "2026-10-31"   # ADR-0144
+      ci_producer: .github/scripts/check-incluster-hostnames.py
 
     kafka_dotted_keys:
       # SmallRye Config's YAML source quotes any leaf map key containing a literal dot, so

--- a/openbank-infra/gitops/components/campaign/campaign-service.yaml
+++ b/openbank-infra/gitops/components/campaign/campaign-service.yaml
@@ -25,7 +25,7 @@ spec:
       annotations:
         # Rolls the pod when the OPA bundle changes — subPath mounts do NOT hot-reload.
         # Kept in sync by gen-campaign-opa-bundle.sh (do not hand-edit).
-        openbank.tech/policy-checksum: "11b89dc13c0cac3b"
+        openbank.tech/policy-checksum: "8b8fdfff0d05b738"
       labels:
         app.kubernetes.io/name: campaign-service
         app.kubernetes.io/part-of: campaign

--- a/openbank-infra/gitops/components/consent/consent-opa-bundle.yaml
+++ b/openbank-infra/gitops/components/consent/consent-opa-bundle.yaml
@@ -9,7 +9,7 @@ metadata:
     app.kubernetes.io/name: consent-service
     app.kubernetes.io/part-of: consent
   annotations:
-    openbank.tech/policy-checksum: "810a31ed0f1aa444"
+    openbank.tech/policy-checksum: "9ba7a068470a2b9e"
 data:
   rest.rego: |
     # SPDX-License-Identifier: Apache-2.0
@@ -3070,6 +3070,46 @@ data:
       # first, so the probe would keep passing against a URL the service does not use — the same
       # vacuous shape as deriving both halves of a pact from one annotation.
       ci_producer: .github/scripts/check-external-feeds.py
+
+    incluster_hostnames:
+      # The in-cluster half of external_feeds (above). Same unfalsifiability, different upstream: a
+      # hostname naming another SERVICE in this cluster is stubbed by the unit test, overridden to
+      # localhost by the IT, and never sent by a consumer pact — so it is wrong only at the moment a
+      # pod dials it, and the symptom is a connect timeout in one log line.
+      #
+      # Found live (issue #1916): openbank-analytics-sink's application.yaml documented the Apicurio
+      # schema registry as "provisioned in openbank-infra as service schema-registry:8081" and
+      # defaulted ANALYTICS_SCHEMA_APICURIO_URL to http://localhost:8081. The Service is
+      # `apicurio-registry` on 8080 in namespace `messaging`. Wrong host AND wrong port, stated twice
+      # (prose and value), with nothing in the repo able to contradict either.
+      #
+      # THE RULE: every in-cluster hostname in an openbank-*/src/main/resources/application.yaml must
+      # resolve to a Service that openbank-infra/gitops/ declares.
+      hostname_must_resolve_to_declared_service: true
+      #
+      # Unlike external_feeds this needs no network — the set of names that CAN resolve is fully
+      # declared in gitops, so the claim is decidable offline and deterministically.
+      known_set_is_derived_from_gitops: true
+      # kind: Service, plus the endpoints CNPG (<name>-rw/-ro/-r) and Strimzi
+      # (<name>-kafka-bootstrap/-brokers) synthesise from their CRs. There is NO hand-kept list of
+      # service names in the checker: a gate whose scope is maintained separately from the artifacts
+      # it covers reads as PASSING when the list is short, never as unchecked.
+      asserts_against_parsed_yaml_not_file_text: true
+      # A whole-file grep cannot tell config from the prose ABOUT config, and this repo has been burnt
+      # in both directions (#2450 flagged the comment explaining the bug; #3072 matched the comment
+      # above the line it was asserting on, so deleting the line stayed green). The checker reads
+      # yaml.safe_load_all output, which drops comments by construction, and --self-test pins it with
+      # a fixture whose only bogus host is in a comment.
+      #
+      # ADVISORY while the 6 pre-existing findings are triaged. All six are bare `openbank-<svc>` rest
+      # client defaults (account, card-issuance, onboarding, settlement) that name no Service in any
+      # namespace — the deployed pods override them by env, so they are dead defaults rather than a
+      # live outage, but each is a hostname nobody could dial. They are NOT fixed in the PR that
+      # introduced this gate: four of the owning services are money-path, so a default-URL change
+      # there needs the two-approval path rather than riding along with a CI guard.
+      enforced: advisory
+      target_enforce_date: "2026-10-31"   # ADR-0144
+      ci_producer: .github/scripts/check-incluster-hostnames.py
 
     kafka_dotted_keys:
       # SmallRye Config's YAML source quotes any leaf map key containing a literal dot, so

--- a/openbank-infra/gitops/components/consent/consent-service.yaml
+++ b/openbank-infra/gitops/components/consent/consent-service.yaml
@@ -28,7 +28,7 @@ spec:
       annotations:
         # Rolls the pods when the OPA bundle changes — subPath mounts do NOT hot-reload.
         # Kept in sync by gen-consent-opa-bundle.sh (do not hand-edit).
-        openbank.tech/policy-checksum: "810a31ed0f1aa444"
+        openbank.tech/policy-checksum: "9ba7a068470a2b9e"
     spec:
       securityContext:
         runAsNonRoot: true

--- a/openbank-infra/gitops/components/copilot/copilot-opa-bundle.yaml
+++ b/openbank-infra/gitops/components/copilot/copilot-opa-bundle.yaml
@@ -9,7 +9,7 @@ metadata:
     app.kubernetes.io/name: copilot-service
     app.kubernetes.io/part-of: platform
   annotations:
-    openbank.tech/policy-checksum: "ce32408507eababf"
+    openbank.tech/policy-checksum: "7cb082886b665194"
 data:
   rest.rego: |
     # SPDX-License-Identifier: Apache-2.0
@@ -3086,6 +3086,46 @@ data:
       # first, so the probe would keep passing against a URL the service does not use — the same
       # vacuous shape as deriving both halves of a pact from one annotation.
       ci_producer: .github/scripts/check-external-feeds.py
+
+    incluster_hostnames:
+      # The in-cluster half of external_feeds (above). Same unfalsifiability, different upstream: a
+      # hostname naming another SERVICE in this cluster is stubbed by the unit test, overridden to
+      # localhost by the IT, and never sent by a consumer pact — so it is wrong only at the moment a
+      # pod dials it, and the symptom is a connect timeout in one log line.
+      #
+      # Found live (issue #1916): openbank-analytics-sink's application.yaml documented the Apicurio
+      # schema registry as "provisioned in openbank-infra as service schema-registry:8081" and
+      # defaulted ANALYTICS_SCHEMA_APICURIO_URL to http://localhost:8081. The Service is
+      # `apicurio-registry` on 8080 in namespace `messaging`. Wrong host AND wrong port, stated twice
+      # (prose and value), with nothing in the repo able to contradict either.
+      #
+      # THE RULE: every in-cluster hostname in an openbank-*/src/main/resources/application.yaml must
+      # resolve to a Service that openbank-infra/gitops/ declares.
+      hostname_must_resolve_to_declared_service: true
+      #
+      # Unlike external_feeds this needs no network — the set of names that CAN resolve is fully
+      # declared in gitops, so the claim is decidable offline and deterministically.
+      known_set_is_derived_from_gitops: true
+      # kind: Service, plus the endpoints CNPG (<name>-rw/-ro/-r) and Strimzi
+      # (<name>-kafka-bootstrap/-brokers) synthesise from their CRs. There is NO hand-kept list of
+      # service names in the checker: a gate whose scope is maintained separately from the artifacts
+      # it covers reads as PASSING when the list is short, never as unchecked.
+      asserts_against_parsed_yaml_not_file_text: true
+      # A whole-file grep cannot tell config from the prose ABOUT config, and this repo has been burnt
+      # in both directions (#2450 flagged the comment explaining the bug; #3072 matched the comment
+      # above the line it was asserting on, so deleting the line stayed green). The checker reads
+      # yaml.safe_load_all output, which drops comments by construction, and --self-test pins it with
+      # a fixture whose only bogus host is in a comment.
+      #
+      # ADVISORY while the 6 pre-existing findings are triaged. All six are bare `openbank-<svc>` rest
+      # client defaults (account, card-issuance, onboarding, settlement) that name no Service in any
+      # namespace — the deployed pods override them by env, so they are dead defaults rather than a
+      # live outage, but each is a hostname nobody could dial. They are NOT fixed in the PR that
+      # introduced this gate: four of the owning services are money-path, so a default-URL change
+      # there needs the two-approval path rather than riding along with a CI guard.
+      enforced: advisory
+      target_enforce_date: "2026-10-31"   # ADR-0144
+      ci_producer: .github/scripts/check-incluster-hostnames.py
 
     kafka_dotted_keys:
       # SmallRye Config's YAML source quotes any leaf map key containing a literal dot, so

--- a/openbank-infra/gitops/components/copilot/copilot-service.yaml
+++ b/openbank-infra/gitops/components/copilot/copilot-service.yaml
@@ -29,7 +29,7 @@ spec:
       annotations:
         # Rolls the pod when the OPA bundle changes — subPath mounts do NOT hot-reload.
         # Kept in sync by gen-copilot-opa-bundle.sh (do not hand-edit).
-        openbank.tech/policy-checksum: "ce32408507eababf"
+        openbank.tech/policy-checksum: "7cb082886b665194"
     spec:
       securityContext:
         runAsNonRoot: true

--- a/openbank-infra/gitops/components/customer-edge/customer-edge-opa-bundle.yaml
+++ b/openbank-infra/gitops/components/customer-edge/customer-edge-opa-bundle.yaml
@@ -10,7 +10,7 @@ metadata:
     app.kubernetes.io/name: customer-edge
     app.kubernetes.io/part-of: customer-edge
   annotations:
-    openbank.tech/policy-checksum: "24d54ba3a8be1db9"
+    openbank.tech/policy-checksum: "8761810ddcae0ff8"
 data:
   rest.rego: |
     # SPDX-License-Identifier: Apache-2.0
@@ -2185,6 +2185,46 @@ data:
       # first, so the probe would keep passing against a URL the service does not use — the same
       # vacuous shape as deriving both halves of a pact from one annotation.
       ci_producer: .github/scripts/check-external-feeds.py
+
+    incluster_hostnames:
+      # The in-cluster half of external_feeds (above). Same unfalsifiability, different upstream: a
+      # hostname naming another SERVICE in this cluster is stubbed by the unit test, overridden to
+      # localhost by the IT, and never sent by a consumer pact — so it is wrong only at the moment a
+      # pod dials it, and the symptom is a connect timeout in one log line.
+      #
+      # Found live (issue #1916): openbank-analytics-sink's application.yaml documented the Apicurio
+      # schema registry as "provisioned in openbank-infra as service schema-registry:8081" and
+      # defaulted ANALYTICS_SCHEMA_APICURIO_URL to http://localhost:8081. The Service is
+      # `apicurio-registry` on 8080 in namespace `messaging`. Wrong host AND wrong port, stated twice
+      # (prose and value), with nothing in the repo able to contradict either.
+      #
+      # THE RULE: every in-cluster hostname in an openbank-*/src/main/resources/application.yaml must
+      # resolve to a Service that openbank-infra/gitops/ declares.
+      hostname_must_resolve_to_declared_service: true
+      #
+      # Unlike external_feeds this needs no network — the set of names that CAN resolve is fully
+      # declared in gitops, so the claim is decidable offline and deterministically.
+      known_set_is_derived_from_gitops: true
+      # kind: Service, plus the endpoints CNPG (<name>-rw/-ro/-r) and Strimzi
+      # (<name>-kafka-bootstrap/-brokers) synthesise from their CRs. There is NO hand-kept list of
+      # service names in the checker: a gate whose scope is maintained separately from the artifacts
+      # it covers reads as PASSING when the list is short, never as unchecked.
+      asserts_against_parsed_yaml_not_file_text: true
+      # A whole-file grep cannot tell config from the prose ABOUT config, and this repo has been burnt
+      # in both directions (#2450 flagged the comment explaining the bug; #3072 matched the comment
+      # above the line it was asserting on, so deleting the line stayed green). The checker reads
+      # yaml.safe_load_all output, which drops comments by construction, and --self-test pins it with
+      # a fixture whose only bogus host is in a comment.
+      #
+      # ADVISORY while the 6 pre-existing findings are triaged. All six are bare `openbank-<svc>` rest
+      # client defaults (account, card-issuance, onboarding, settlement) that name no Service in any
+      # namespace — the deployed pods override them by env, so they are dead defaults rather than a
+      # live outage, but each is a hostname nobody could dial. They are NOT fixed in the PR that
+      # introduced this gate: four of the owning services are money-path, so a default-URL change
+      # there needs the two-approval path rather than riding along with a CI guard.
+      enforced: advisory
+      target_enforce_date: "2026-10-31"   # ADR-0144
+      ci_producer: .github/scripts/check-incluster-hostnames.py
 
     kafka_dotted_keys:
       # SmallRye Config's YAML source quotes any leaf map key containing a literal dot, so

--- a/openbank-infra/gitops/components/customer-edge/customer-edge.yaml
+++ b/openbank-infra/gitops/components/customer-edge/customer-edge.yaml
@@ -65,7 +65,7 @@ spec:
       annotations:
         # Rolls the pod when the OPA bundle changes — subPath mounts do NOT hot-reload.
         # Kept in sync by gen-customer-edge-opa-bundle.sh (do not hand-edit).
-        openbank.tech/policy-checksum: "24d54ba3a8be1db9"
+        openbank.tech/policy-checksum: "8761810ddcae0ff8"
     spec:
       # Dedicated SA so EKS Pod Identity can hand the edge (and ONLY the edge) the
       # feedback-screenshots S3 role — ADR-0192, openbank-infra/aws/envs/sandbox-platform/

--- a/openbank-infra/gitops/components/delegation/delegation-opa-bundle.yaml
+++ b/openbank-infra/gitops/components/delegation/delegation-opa-bundle.yaml
@@ -9,7 +9,7 @@ metadata:
     app.kubernetes.io/name: delegation-service
     app.kubernetes.io/part-of: delegation
   annotations:
-    openbank.tech/policy-checksum: "64e3b8c2000f9ace"
+    openbank.tech/policy-checksum: "f7cb29b59f8673f2"
 data:
   rest.rego: |
     # SPDX-License-Identifier: Apache-2.0
@@ -3041,6 +3041,46 @@ data:
       # first, so the probe would keep passing against a URL the service does not use — the same
       # vacuous shape as deriving both halves of a pact from one annotation.
       ci_producer: .github/scripts/check-external-feeds.py
+
+    incluster_hostnames:
+      # The in-cluster half of external_feeds (above). Same unfalsifiability, different upstream: a
+      # hostname naming another SERVICE in this cluster is stubbed by the unit test, overridden to
+      # localhost by the IT, and never sent by a consumer pact — so it is wrong only at the moment a
+      # pod dials it, and the symptom is a connect timeout in one log line.
+      #
+      # Found live (issue #1916): openbank-analytics-sink's application.yaml documented the Apicurio
+      # schema registry as "provisioned in openbank-infra as service schema-registry:8081" and
+      # defaulted ANALYTICS_SCHEMA_APICURIO_URL to http://localhost:8081. The Service is
+      # `apicurio-registry` on 8080 in namespace `messaging`. Wrong host AND wrong port, stated twice
+      # (prose and value), with nothing in the repo able to contradict either.
+      #
+      # THE RULE: every in-cluster hostname in an openbank-*/src/main/resources/application.yaml must
+      # resolve to a Service that openbank-infra/gitops/ declares.
+      hostname_must_resolve_to_declared_service: true
+      #
+      # Unlike external_feeds this needs no network — the set of names that CAN resolve is fully
+      # declared in gitops, so the claim is decidable offline and deterministically.
+      known_set_is_derived_from_gitops: true
+      # kind: Service, plus the endpoints CNPG (<name>-rw/-ro/-r) and Strimzi
+      # (<name>-kafka-bootstrap/-brokers) synthesise from their CRs. There is NO hand-kept list of
+      # service names in the checker: a gate whose scope is maintained separately from the artifacts
+      # it covers reads as PASSING when the list is short, never as unchecked.
+      asserts_against_parsed_yaml_not_file_text: true
+      # A whole-file grep cannot tell config from the prose ABOUT config, and this repo has been burnt
+      # in both directions (#2450 flagged the comment explaining the bug; #3072 matched the comment
+      # above the line it was asserting on, so deleting the line stayed green). The checker reads
+      # yaml.safe_load_all output, which drops comments by construction, and --self-test pins it with
+      # a fixture whose only bogus host is in a comment.
+      #
+      # ADVISORY while the 6 pre-existing findings are triaged. All six are bare `openbank-<svc>` rest
+      # client defaults (account, card-issuance, onboarding, settlement) that name no Service in any
+      # namespace — the deployed pods override them by env, so they are dead defaults rather than a
+      # live outage, but each is a hostname nobody could dial. They are NOT fixed in the PR that
+      # introduced this gate: four of the owning services are money-path, so a default-URL change
+      # there needs the two-approval path rather than riding along with a CI guard.
+      enforced: advisory
+      target_enforce_date: "2026-10-31"   # ADR-0144
+      ci_producer: .github/scripts/check-incluster-hostnames.py
 
     kafka_dotted_keys:
       # SmallRye Config's YAML source quotes any leaf map key containing a literal dot, so

--- a/openbank-infra/gitops/components/delegation/delegation-service.yaml
+++ b/openbank-infra/gitops/components/delegation/delegation-service.yaml
@@ -25,7 +25,7 @@ spec:
       annotations:
         # Rolls the pod when the OPA bundle changes — subPath mounts do NOT hot-reload.
         # Kept in sync by gen-delegation-opa-bundle.sh (do not hand-edit).
-        openbank.tech/policy-checksum: "64e3b8c2000f9ace"
+        openbank.tech/policy-checksum: "f7cb29b59f8673f2"
       labels:
         app.kubernetes.io/name: delegation-service
         app.kubernetes.io/part-of: delegation

--- a/openbank-infra/gitops/components/dispute-service/dispute-opa-bundle.yaml
+++ b/openbank-infra/gitops/components/dispute-service/dispute-opa-bundle.yaml
@@ -9,7 +9,7 @@ metadata:
     app.kubernetes.io/name: dispute-service
     app.kubernetes.io/part-of: dispute
   annotations:
-    openbank.tech/policy-checksum: "9906004dbac55714"
+    openbank.tech/policy-checksum: "e635515cae0e0d5f"
 data:
   rest.rego: |
     # SPDX-License-Identifier: Apache-2.0
@@ -3136,6 +3136,46 @@ data:
       # first, so the probe would keep passing against a URL the service does not use — the same
       # vacuous shape as deriving both halves of a pact from one annotation.
       ci_producer: .github/scripts/check-external-feeds.py
+
+    incluster_hostnames:
+      # The in-cluster half of external_feeds (above). Same unfalsifiability, different upstream: a
+      # hostname naming another SERVICE in this cluster is stubbed by the unit test, overridden to
+      # localhost by the IT, and never sent by a consumer pact — so it is wrong only at the moment a
+      # pod dials it, and the symptom is a connect timeout in one log line.
+      #
+      # Found live (issue #1916): openbank-analytics-sink's application.yaml documented the Apicurio
+      # schema registry as "provisioned in openbank-infra as service schema-registry:8081" and
+      # defaulted ANALYTICS_SCHEMA_APICURIO_URL to http://localhost:8081. The Service is
+      # `apicurio-registry` on 8080 in namespace `messaging`. Wrong host AND wrong port, stated twice
+      # (prose and value), with nothing in the repo able to contradict either.
+      #
+      # THE RULE: every in-cluster hostname in an openbank-*/src/main/resources/application.yaml must
+      # resolve to a Service that openbank-infra/gitops/ declares.
+      hostname_must_resolve_to_declared_service: true
+      #
+      # Unlike external_feeds this needs no network — the set of names that CAN resolve is fully
+      # declared in gitops, so the claim is decidable offline and deterministically.
+      known_set_is_derived_from_gitops: true
+      # kind: Service, plus the endpoints CNPG (<name>-rw/-ro/-r) and Strimzi
+      # (<name>-kafka-bootstrap/-brokers) synthesise from their CRs. There is NO hand-kept list of
+      # service names in the checker: a gate whose scope is maintained separately from the artifacts
+      # it covers reads as PASSING when the list is short, never as unchecked.
+      asserts_against_parsed_yaml_not_file_text: true
+      # A whole-file grep cannot tell config from the prose ABOUT config, and this repo has been burnt
+      # in both directions (#2450 flagged the comment explaining the bug; #3072 matched the comment
+      # above the line it was asserting on, so deleting the line stayed green). The checker reads
+      # yaml.safe_load_all output, which drops comments by construction, and --self-test pins it with
+      # a fixture whose only bogus host is in a comment.
+      #
+      # ADVISORY while the 6 pre-existing findings are triaged. All six are bare `openbank-<svc>` rest
+      # client defaults (account, card-issuance, onboarding, settlement) that name no Service in any
+      # namespace — the deployed pods override them by env, so they are dead defaults rather than a
+      # live outage, but each is a hostname nobody could dial. They are NOT fixed in the PR that
+      # introduced this gate: four of the owning services are money-path, so a default-URL change
+      # there needs the two-approval path rather than riding along with a CI guard.
+      enforced: advisory
+      target_enforce_date: "2026-10-31"   # ADR-0144
+      ci_producer: .github/scripts/check-incluster-hostnames.py
 
     kafka_dotted_keys:
       # SmallRye Config's YAML source quotes any leaf map key containing a literal dot, so

--- a/openbank-infra/gitops/components/dispute-service/dispute-service.yaml
+++ b/openbank-infra/gitops/components/dispute-service/dispute-service.yaml
@@ -15,7 +15,7 @@ spec:
       annotations:
         # Rolls the pod when the OPA bundle changes — subPath mounts do NOT hot-reload.
         # Kept in sync by gen-dispute-opa-bundle.sh (do not hand-edit).
-        openbank.tech/policy-checksum: "9906004dbac55714"
+        openbank.tech/policy-checksum: "e635515cae0e0d5f"
       labels: {app.kubernetes.io/name: dispute-service, app.kubernetes.io/part-of: dispute}
     spec:
       securityContext:

--- a/openbank-infra/gitops/components/document-service/document-service-opa-bundle.yaml
+++ b/openbank-infra/gitops/components/document-service/document-service-opa-bundle.yaml
@@ -10,7 +10,7 @@ metadata:
     app.kubernetes.io/name: document-service
     app.kubernetes.io/part-of: documents
   annotations:
-    openbank.tech/policy-checksum: "24d54ba3a8be1db9"
+    openbank.tech/policy-checksum: "8761810ddcae0ff8"
 data:
   rest.rego: |
     # SPDX-License-Identifier: Apache-2.0
@@ -2185,6 +2185,46 @@ data:
       # first, so the probe would keep passing against a URL the service does not use — the same
       # vacuous shape as deriving both halves of a pact from one annotation.
       ci_producer: .github/scripts/check-external-feeds.py
+
+    incluster_hostnames:
+      # The in-cluster half of external_feeds (above). Same unfalsifiability, different upstream: a
+      # hostname naming another SERVICE in this cluster is stubbed by the unit test, overridden to
+      # localhost by the IT, and never sent by a consumer pact — so it is wrong only at the moment a
+      # pod dials it, and the symptom is a connect timeout in one log line.
+      #
+      # Found live (issue #1916): openbank-analytics-sink's application.yaml documented the Apicurio
+      # schema registry as "provisioned in openbank-infra as service schema-registry:8081" and
+      # defaulted ANALYTICS_SCHEMA_APICURIO_URL to http://localhost:8081. The Service is
+      # `apicurio-registry` on 8080 in namespace `messaging`. Wrong host AND wrong port, stated twice
+      # (prose and value), with nothing in the repo able to contradict either.
+      #
+      # THE RULE: every in-cluster hostname in an openbank-*/src/main/resources/application.yaml must
+      # resolve to a Service that openbank-infra/gitops/ declares.
+      hostname_must_resolve_to_declared_service: true
+      #
+      # Unlike external_feeds this needs no network — the set of names that CAN resolve is fully
+      # declared in gitops, so the claim is decidable offline and deterministically.
+      known_set_is_derived_from_gitops: true
+      # kind: Service, plus the endpoints CNPG (<name>-rw/-ro/-r) and Strimzi
+      # (<name>-kafka-bootstrap/-brokers) synthesise from their CRs. There is NO hand-kept list of
+      # service names in the checker: a gate whose scope is maintained separately from the artifacts
+      # it covers reads as PASSING when the list is short, never as unchecked.
+      asserts_against_parsed_yaml_not_file_text: true
+      # A whole-file grep cannot tell config from the prose ABOUT config, and this repo has been burnt
+      # in both directions (#2450 flagged the comment explaining the bug; #3072 matched the comment
+      # above the line it was asserting on, so deleting the line stayed green). The checker reads
+      # yaml.safe_load_all output, which drops comments by construction, and --self-test pins it with
+      # a fixture whose only bogus host is in a comment.
+      #
+      # ADVISORY while the 6 pre-existing findings are triaged. All six are bare `openbank-<svc>` rest
+      # client defaults (account, card-issuance, onboarding, settlement) that name no Service in any
+      # namespace — the deployed pods override them by env, so they are dead defaults rather than a
+      # live outage, but each is a hostname nobody could dial. They are NOT fixed in the PR that
+      # introduced this gate: four of the owning services are money-path, so a default-URL change
+      # there needs the two-approval path rather than riding along with a CI guard.
+      enforced: advisory
+      target_enforce_date: "2026-10-31"   # ADR-0144
+      ci_producer: .github/scripts/check-incluster-hostnames.py
 
     kafka_dotted_keys:
       # SmallRye Config's YAML source quotes any leaf map key containing a literal dot, so

--- a/openbank-infra/gitops/components/document-service/document-service-service.yaml
+++ b/openbank-infra/gitops/components/document-service/document-service-service.yaml
@@ -43,7 +43,7 @@ spec:
       annotations:
         # Rolls the pods when the OPA bundle changes — subPath mounts do NOT hot-reload.
         # Kept in sync by gen-document-service-opa-bundle.sh (do not hand-edit).
-        openbank.tech/policy-checksum: "24d54ba3a8be1db9"
+        openbank.tech/policy-checksum: "8761810ddcae0ff8"
     spec:
       # ADR-0162 D4 (continued): a dedicated SA (not `default`) is what OpenBao's Kubernetes-auth
       # role `document-service-signing` is bound to — least-privilege, one identity per consumer.

--- a/openbank-infra/gitops/components/fraud-service/fraud-opa-bundle.yaml
+++ b/openbank-infra/gitops/components/fraud-service/fraud-opa-bundle.yaml
@@ -9,7 +9,7 @@ metadata:
     app.kubernetes.io/name: fraud-service
     app.kubernetes.io/part-of: fraud
   annotations:
-    openbank.tech/policy-checksum: "f8c2b2734bd885ae"
+    openbank.tech/policy-checksum: "7a51b41c5015da72"
 data:
   rest.rego: |
     # SPDX-License-Identifier: Apache-2.0
@@ -3011,6 +3011,46 @@ data:
       # first, so the probe would keep passing against a URL the service does not use — the same
       # vacuous shape as deriving both halves of a pact from one annotation.
       ci_producer: .github/scripts/check-external-feeds.py
+
+    incluster_hostnames:
+      # The in-cluster half of external_feeds (above). Same unfalsifiability, different upstream: a
+      # hostname naming another SERVICE in this cluster is stubbed by the unit test, overridden to
+      # localhost by the IT, and never sent by a consumer pact — so it is wrong only at the moment a
+      # pod dials it, and the symptom is a connect timeout in one log line.
+      #
+      # Found live (issue #1916): openbank-analytics-sink's application.yaml documented the Apicurio
+      # schema registry as "provisioned in openbank-infra as service schema-registry:8081" and
+      # defaulted ANALYTICS_SCHEMA_APICURIO_URL to http://localhost:8081. The Service is
+      # `apicurio-registry` on 8080 in namespace `messaging`. Wrong host AND wrong port, stated twice
+      # (prose and value), with nothing in the repo able to contradict either.
+      #
+      # THE RULE: every in-cluster hostname in an openbank-*/src/main/resources/application.yaml must
+      # resolve to a Service that openbank-infra/gitops/ declares.
+      hostname_must_resolve_to_declared_service: true
+      #
+      # Unlike external_feeds this needs no network — the set of names that CAN resolve is fully
+      # declared in gitops, so the claim is decidable offline and deterministically.
+      known_set_is_derived_from_gitops: true
+      # kind: Service, plus the endpoints CNPG (<name>-rw/-ro/-r) and Strimzi
+      # (<name>-kafka-bootstrap/-brokers) synthesise from their CRs. There is NO hand-kept list of
+      # service names in the checker: a gate whose scope is maintained separately from the artifacts
+      # it covers reads as PASSING when the list is short, never as unchecked.
+      asserts_against_parsed_yaml_not_file_text: true
+      # A whole-file grep cannot tell config from the prose ABOUT config, and this repo has been burnt
+      # in both directions (#2450 flagged the comment explaining the bug; #3072 matched the comment
+      # above the line it was asserting on, so deleting the line stayed green). The checker reads
+      # yaml.safe_load_all output, which drops comments by construction, and --self-test pins it with
+      # a fixture whose only bogus host is in a comment.
+      #
+      # ADVISORY while the 6 pre-existing findings are triaged. All six are bare `openbank-<svc>` rest
+      # client defaults (account, card-issuance, onboarding, settlement) that name no Service in any
+      # namespace — the deployed pods override them by env, so they are dead defaults rather than a
+      # live outage, but each is a hostname nobody could dial. They are NOT fixed in the PR that
+      # introduced this gate: four of the owning services are money-path, so a default-URL change
+      # there needs the two-approval path rather than riding along with a CI guard.
+      enforced: advisory
+      target_enforce_date: "2026-10-31"   # ADR-0144
+      ci_producer: .github/scripts/check-incluster-hostnames.py
 
     kafka_dotted_keys:
       # SmallRye Config's YAML source quotes any leaf map key containing a literal dot, so

--- a/openbank-infra/gitops/components/fraud-service/fraud-service.yaml
+++ b/openbank-infra/gitops/components/fraud-service/fraud-service.yaml
@@ -23,7 +23,7 @@ spec:
       annotations:
         # Rolls the pods when the OPA bundle changes — subPath mounts do NOT hot-reload.
         # Kept in sync by gen-fraud-opa-bundle.sh (do not hand-edit).
-        openbank.tech/policy-checksum: "f8c2b2734bd885ae"
+        openbank.tech/policy-checksum: "7a51b41c5015da72"
     spec:
       securityContext:
         runAsNonRoot: true

--- a/openbank-infra/gitops/components/fx-service/fx-opa-bundle.yaml
+++ b/openbank-infra/gitops/components/fx-service/fx-opa-bundle.yaml
@@ -9,7 +9,7 @@ metadata:
     app.kubernetes.io/name: fx-service
     app.kubernetes.io/part-of: fx
   annotations:
-    openbank.tech/policy-checksum: "337f1a800b836d55"
+    openbank.tech/policy-checksum: "8618a96b1cd942fd"
 data:
   rest.rego: |
     # SPDX-License-Identifier: Apache-2.0
@@ -3062,6 +3062,46 @@ data:
       # first, so the probe would keep passing against a URL the service does not use — the same
       # vacuous shape as deriving both halves of a pact from one annotation.
       ci_producer: .github/scripts/check-external-feeds.py
+
+    incluster_hostnames:
+      # The in-cluster half of external_feeds (above). Same unfalsifiability, different upstream: a
+      # hostname naming another SERVICE in this cluster is stubbed by the unit test, overridden to
+      # localhost by the IT, and never sent by a consumer pact — so it is wrong only at the moment a
+      # pod dials it, and the symptom is a connect timeout in one log line.
+      #
+      # Found live (issue #1916): openbank-analytics-sink's application.yaml documented the Apicurio
+      # schema registry as "provisioned in openbank-infra as service schema-registry:8081" and
+      # defaulted ANALYTICS_SCHEMA_APICURIO_URL to http://localhost:8081. The Service is
+      # `apicurio-registry` on 8080 in namespace `messaging`. Wrong host AND wrong port, stated twice
+      # (prose and value), with nothing in the repo able to contradict either.
+      #
+      # THE RULE: every in-cluster hostname in an openbank-*/src/main/resources/application.yaml must
+      # resolve to a Service that openbank-infra/gitops/ declares.
+      hostname_must_resolve_to_declared_service: true
+      #
+      # Unlike external_feeds this needs no network — the set of names that CAN resolve is fully
+      # declared in gitops, so the claim is decidable offline and deterministically.
+      known_set_is_derived_from_gitops: true
+      # kind: Service, plus the endpoints CNPG (<name>-rw/-ro/-r) and Strimzi
+      # (<name>-kafka-bootstrap/-brokers) synthesise from their CRs. There is NO hand-kept list of
+      # service names in the checker: a gate whose scope is maintained separately from the artifacts
+      # it covers reads as PASSING when the list is short, never as unchecked.
+      asserts_against_parsed_yaml_not_file_text: true
+      # A whole-file grep cannot tell config from the prose ABOUT config, and this repo has been burnt
+      # in both directions (#2450 flagged the comment explaining the bug; #3072 matched the comment
+      # above the line it was asserting on, so deleting the line stayed green). The checker reads
+      # yaml.safe_load_all output, which drops comments by construction, and --self-test pins it with
+      # a fixture whose only bogus host is in a comment.
+      #
+      # ADVISORY while the 6 pre-existing findings are triaged. All six are bare `openbank-<svc>` rest
+      # client defaults (account, card-issuance, onboarding, settlement) that name no Service in any
+      # namespace — the deployed pods override them by env, so they are dead defaults rather than a
+      # live outage, but each is a hostname nobody could dial. They are NOT fixed in the PR that
+      # introduced this gate: four of the owning services are money-path, so a default-URL change
+      # there needs the two-approval path rather than riding along with a CI guard.
+      enforced: advisory
+      target_enforce_date: "2026-10-31"   # ADR-0144
+      ci_producer: .github/scripts/check-incluster-hostnames.py
 
     kafka_dotted_keys:
       # SmallRye Config's YAML source quotes any leaf map key containing a literal dot, so

--- a/openbank-infra/gitops/components/fx-service/fx-service.yaml
+++ b/openbank-infra/gitops/components/fx-service/fx-service.yaml
@@ -22,7 +22,7 @@ spec:
       annotations:
         # Rolls the pods when the OPA bundle changes — subPath mounts do NOT hot-reload.
         # Kept in sync by gen-fx-opa-bundle.sh (do not hand-edit).
-        openbank.tech/policy-checksum: "337f1a800b836d55"
+        openbank.tech/policy-checksum: "8618a96b1cd942fd"
     spec:
       securityContext:
         runAsNonRoot: true

--- a/openbank-infra/gitops/components/interest-service/interest-opa-bundle.yaml
+++ b/openbank-infra/gitops/components/interest-service/interest-opa-bundle.yaml
@@ -9,7 +9,7 @@ metadata:
     app.kubernetes.io/name: interest-service
     app.kubernetes.io/part-of: interest
   annotations:
-    openbank.tech/policy-checksum: "4fe15a43154b952c"
+    openbank.tech/policy-checksum: "d1aad7334435a6d7"
 data:
   rest.rego: |
     # SPDX-License-Identifier: Apache-2.0
@@ -2996,6 +2996,46 @@ data:
       # first, so the probe would keep passing against a URL the service does not use — the same
       # vacuous shape as deriving both halves of a pact from one annotation.
       ci_producer: .github/scripts/check-external-feeds.py
+
+    incluster_hostnames:
+      # The in-cluster half of external_feeds (above). Same unfalsifiability, different upstream: a
+      # hostname naming another SERVICE in this cluster is stubbed by the unit test, overridden to
+      # localhost by the IT, and never sent by a consumer pact — so it is wrong only at the moment a
+      # pod dials it, and the symptom is a connect timeout in one log line.
+      #
+      # Found live (issue #1916): openbank-analytics-sink's application.yaml documented the Apicurio
+      # schema registry as "provisioned in openbank-infra as service schema-registry:8081" and
+      # defaulted ANALYTICS_SCHEMA_APICURIO_URL to http://localhost:8081. The Service is
+      # `apicurio-registry` on 8080 in namespace `messaging`. Wrong host AND wrong port, stated twice
+      # (prose and value), with nothing in the repo able to contradict either.
+      #
+      # THE RULE: every in-cluster hostname in an openbank-*/src/main/resources/application.yaml must
+      # resolve to a Service that openbank-infra/gitops/ declares.
+      hostname_must_resolve_to_declared_service: true
+      #
+      # Unlike external_feeds this needs no network — the set of names that CAN resolve is fully
+      # declared in gitops, so the claim is decidable offline and deterministically.
+      known_set_is_derived_from_gitops: true
+      # kind: Service, plus the endpoints CNPG (<name>-rw/-ro/-r) and Strimzi
+      # (<name>-kafka-bootstrap/-brokers) synthesise from their CRs. There is NO hand-kept list of
+      # service names in the checker: a gate whose scope is maintained separately from the artifacts
+      # it covers reads as PASSING when the list is short, never as unchecked.
+      asserts_against_parsed_yaml_not_file_text: true
+      # A whole-file grep cannot tell config from the prose ABOUT config, and this repo has been burnt
+      # in both directions (#2450 flagged the comment explaining the bug; #3072 matched the comment
+      # above the line it was asserting on, so deleting the line stayed green). The checker reads
+      # yaml.safe_load_all output, which drops comments by construction, and --self-test pins it with
+      # a fixture whose only bogus host is in a comment.
+      #
+      # ADVISORY while the 6 pre-existing findings are triaged. All six are bare `openbank-<svc>` rest
+      # client defaults (account, card-issuance, onboarding, settlement) that name no Service in any
+      # namespace — the deployed pods override them by env, so they are dead defaults rather than a
+      # live outage, but each is a hostname nobody could dial. They are NOT fixed in the PR that
+      # introduced this gate: four of the owning services are money-path, so a default-URL change
+      # there needs the two-approval path rather than riding along with a CI guard.
+      enforced: advisory
+      target_enforce_date: "2026-10-31"   # ADR-0144
+      ci_producer: .github/scripts/check-incluster-hostnames.py
 
     kafka_dotted_keys:
       # SmallRye Config's YAML source quotes any leaf map key containing a literal dot, so

--- a/openbank-infra/gitops/components/interest-service/interest-service.yaml
+++ b/openbank-infra/gitops/components/interest-service/interest-service.yaml
@@ -16,7 +16,7 @@ spec:
       annotations:
         # Rolls the pods when the OPA bundle changes — subPath mounts do NOT hot-reload.
         # Kept in sync by gen-interest-opa-bundle.sh (do not hand-edit).
-        openbank.tech/policy-checksum: "4fe15a43154b952c"
+        openbank.tech/policy-checksum: "d1aad7334435a6d7"
     spec:
       securityContext:
         runAsNonRoot: true

--- a/openbank-infra/gitops/components/kyc/kyc-opa-bundle.yaml
+++ b/openbank-infra/gitops/components/kyc/kyc-opa-bundle.yaml
@@ -9,7 +9,7 @@ metadata:
     app.kubernetes.io/name: kyc-service
     app.kubernetes.io/part-of: kyc
   annotations:
-    openbank.tech/policy-checksum: "3f4f27a48b6b9ad3"
+    openbank.tech/policy-checksum: "78d771a3fa6a2464"
 data:
   rest.rego: |
     # SPDX-License-Identifier: Apache-2.0
@@ -3024,6 +3024,46 @@ data:
       # first, so the probe would keep passing against a URL the service does not use — the same
       # vacuous shape as deriving both halves of a pact from one annotation.
       ci_producer: .github/scripts/check-external-feeds.py
+
+    incluster_hostnames:
+      # The in-cluster half of external_feeds (above). Same unfalsifiability, different upstream: a
+      # hostname naming another SERVICE in this cluster is stubbed by the unit test, overridden to
+      # localhost by the IT, and never sent by a consumer pact — so it is wrong only at the moment a
+      # pod dials it, and the symptom is a connect timeout in one log line.
+      #
+      # Found live (issue #1916): openbank-analytics-sink's application.yaml documented the Apicurio
+      # schema registry as "provisioned in openbank-infra as service schema-registry:8081" and
+      # defaulted ANALYTICS_SCHEMA_APICURIO_URL to http://localhost:8081. The Service is
+      # `apicurio-registry` on 8080 in namespace `messaging`. Wrong host AND wrong port, stated twice
+      # (prose and value), with nothing in the repo able to contradict either.
+      #
+      # THE RULE: every in-cluster hostname in an openbank-*/src/main/resources/application.yaml must
+      # resolve to a Service that openbank-infra/gitops/ declares.
+      hostname_must_resolve_to_declared_service: true
+      #
+      # Unlike external_feeds this needs no network — the set of names that CAN resolve is fully
+      # declared in gitops, so the claim is decidable offline and deterministically.
+      known_set_is_derived_from_gitops: true
+      # kind: Service, plus the endpoints CNPG (<name>-rw/-ro/-r) and Strimzi
+      # (<name>-kafka-bootstrap/-brokers) synthesise from their CRs. There is NO hand-kept list of
+      # service names in the checker: a gate whose scope is maintained separately from the artifacts
+      # it covers reads as PASSING when the list is short, never as unchecked.
+      asserts_against_parsed_yaml_not_file_text: true
+      # A whole-file grep cannot tell config from the prose ABOUT config, and this repo has been burnt
+      # in both directions (#2450 flagged the comment explaining the bug; #3072 matched the comment
+      # above the line it was asserting on, so deleting the line stayed green). The checker reads
+      # yaml.safe_load_all output, which drops comments by construction, and --self-test pins it with
+      # a fixture whose only bogus host is in a comment.
+      #
+      # ADVISORY while the 6 pre-existing findings are triaged. All six are bare `openbank-<svc>` rest
+      # client defaults (account, card-issuance, onboarding, settlement) that name no Service in any
+      # namespace — the deployed pods override them by env, so they are dead defaults rather than a
+      # live outage, but each is a hostname nobody could dial. They are NOT fixed in the PR that
+      # introduced this gate: four of the owning services are money-path, so a default-URL change
+      # there needs the two-approval path rather than riding along with a CI guard.
+      enforced: advisory
+      target_enforce_date: "2026-10-31"   # ADR-0144
+      ci_producer: .github/scripts/check-incluster-hostnames.py
 
     kafka_dotted_keys:
       # SmallRye Config's YAML source quotes any leaf map key containing a literal dot, so

--- a/openbank-infra/gitops/components/kyc/kyc-service.yaml
+++ b/openbank-infra/gitops/components/kyc/kyc-service.yaml
@@ -48,7 +48,7 @@ spec:
       annotations:
         # Rolls the pod when the OPA bundle changes (subPath mounts do not hot-reload).
         # Kept in sync by gen-kyc-opa-bundle.sh (do not hand-edit).
-        openbank.tech/policy-checksum: "3f4f27a48b6b9ad3"
+        openbank.tech/policy-checksum: "78d771a3fa6a2464"
     spec:
       securityContext:
         runAsNonRoot: true

--- a/openbank-infra/gitops/components/ledger/ledger-opa-bundle.yaml
+++ b/openbank-infra/gitops/components/ledger/ledger-opa-bundle.yaml
@@ -9,7 +9,7 @@ metadata:
     app.kubernetes.io/name: ledger-service
     app.kubernetes.io/part-of: ledger
   annotations:
-    openbank.tech/policy-checksum: "6ef160b0682ff4d9"
+    openbank.tech/policy-checksum: "59ca9e1a455033fc"
 data:
   rest.rego: |
     # SPDX-License-Identifier: Apache-2.0
@@ -3109,6 +3109,46 @@ data:
       # first, so the probe would keep passing against a URL the service does not use — the same
       # vacuous shape as deriving both halves of a pact from one annotation.
       ci_producer: .github/scripts/check-external-feeds.py
+
+    incluster_hostnames:
+      # The in-cluster half of external_feeds (above). Same unfalsifiability, different upstream: a
+      # hostname naming another SERVICE in this cluster is stubbed by the unit test, overridden to
+      # localhost by the IT, and never sent by a consumer pact — so it is wrong only at the moment a
+      # pod dials it, and the symptom is a connect timeout in one log line.
+      #
+      # Found live (issue #1916): openbank-analytics-sink's application.yaml documented the Apicurio
+      # schema registry as "provisioned in openbank-infra as service schema-registry:8081" and
+      # defaulted ANALYTICS_SCHEMA_APICURIO_URL to http://localhost:8081. The Service is
+      # `apicurio-registry` on 8080 in namespace `messaging`. Wrong host AND wrong port, stated twice
+      # (prose and value), with nothing in the repo able to contradict either.
+      #
+      # THE RULE: every in-cluster hostname in an openbank-*/src/main/resources/application.yaml must
+      # resolve to a Service that openbank-infra/gitops/ declares.
+      hostname_must_resolve_to_declared_service: true
+      #
+      # Unlike external_feeds this needs no network — the set of names that CAN resolve is fully
+      # declared in gitops, so the claim is decidable offline and deterministically.
+      known_set_is_derived_from_gitops: true
+      # kind: Service, plus the endpoints CNPG (<name>-rw/-ro/-r) and Strimzi
+      # (<name>-kafka-bootstrap/-brokers) synthesise from their CRs. There is NO hand-kept list of
+      # service names in the checker: a gate whose scope is maintained separately from the artifacts
+      # it covers reads as PASSING when the list is short, never as unchecked.
+      asserts_against_parsed_yaml_not_file_text: true
+      # A whole-file grep cannot tell config from the prose ABOUT config, and this repo has been burnt
+      # in both directions (#2450 flagged the comment explaining the bug; #3072 matched the comment
+      # above the line it was asserting on, so deleting the line stayed green). The checker reads
+      # yaml.safe_load_all output, which drops comments by construction, and --self-test pins it with
+      # a fixture whose only bogus host is in a comment.
+      #
+      # ADVISORY while the 6 pre-existing findings are triaged. All six are bare `openbank-<svc>` rest
+      # client defaults (account, card-issuance, onboarding, settlement) that name no Service in any
+      # namespace — the deployed pods override them by env, so they are dead defaults rather than a
+      # live outage, but each is a hostname nobody could dial. They are NOT fixed in the PR that
+      # introduced this gate: four of the owning services are money-path, so a default-URL change
+      # there needs the two-approval path rather than riding along with a CI guard.
+      enforced: advisory
+      target_enforce_date: "2026-10-31"   # ADR-0144
+      ci_producer: .github/scripts/check-incluster-hostnames.py
 
     kafka_dotted_keys:
       # SmallRye Config's YAML source quotes any leaf map key containing a literal dot, so

--- a/openbank-infra/gitops/components/ledger/ledger-service.yaml
+++ b/openbank-infra/gitops/components/ledger/ledger-service.yaml
@@ -38,7 +38,7 @@ spec:
       annotations:
         # Rolls the pods when the OPA bundle changes — subPath mounts do NOT hot-reload.
         # Kept in sync by gen-ledger-opa-bundle.sh (do not hand-edit).
-        openbank.tech/policy-checksum: "6ef160b0682ff4d9"
+        openbank.tech/policy-checksum: "59ca9e1a455033fc"
     spec:
       securityContext:
         runAsNonRoot: true

--- a/openbank-infra/gitops/components/lending/lending-opa-bundle.yaml
+++ b/openbank-infra/gitops/components/lending/lending-opa-bundle.yaml
@@ -9,7 +9,7 @@ metadata:
     app.kubernetes.io/name: lending-service
     app.kubernetes.io/part-of: lending
   annotations:
-    openbank.tech/policy-checksum: "363a70307c0bef34"
+    openbank.tech/policy-checksum: "e4a98cff615b2d48"
 data:
   rest.rego: |
     # SPDX-License-Identifier: Apache-2.0
@@ -3104,6 +3104,46 @@ data:
       # first, so the probe would keep passing against a URL the service does not use — the same
       # vacuous shape as deriving both halves of a pact from one annotation.
       ci_producer: .github/scripts/check-external-feeds.py
+
+    incluster_hostnames:
+      # The in-cluster half of external_feeds (above). Same unfalsifiability, different upstream: a
+      # hostname naming another SERVICE in this cluster is stubbed by the unit test, overridden to
+      # localhost by the IT, and never sent by a consumer pact — so it is wrong only at the moment a
+      # pod dials it, and the symptom is a connect timeout in one log line.
+      #
+      # Found live (issue #1916): openbank-analytics-sink's application.yaml documented the Apicurio
+      # schema registry as "provisioned in openbank-infra as service schema-registry:8081" and
+      # defaulted ANALYTICS_SCHEMA_APICURIO_URL to http://localhost:8081. The Service is
+      # `apicurio-registry` on 8080 in namespace `messaging`. Wrong host AND wrong port, stated twice
+      # (prose and value), with nothing in the repo able to contradict either.
+      #
+      # THE RULE: every in-cluster hostname in an openbank-*/src/main/resources/application.yaml must
+      # resolve to a Service that openbank-infra/gitops/ declares.
+      hostname_must_resolve_to_declared_service: true
+      #
+      # Unlike external_feeds this needs no network — the set of names that CAN resolve is fully
+      # declared in gitops, so the claim is decidable offline and deterministically.
+      known_set_is_derived_from_gitops: true
+      # kind: Service, plus the endpoints CNPG (<name>-rw/-ro/-r) and Strimzi
+      # (<name>-kafka-bootstrap/-brokers) synthesise from their CRs. There is NO hand-kept list of
+      # service names in the checker: a gate whose scope is maintained separately from the artifacts
+      # it covers reads as PASSING when the list is short, never as unchecked.
+      asserts_against_parsed_yaml_not_file_text: true
+      # A whole-file grep cannot tell config from the prose ABOUT config, and this repo has been burnt
+      # in both directions (#2450 flagged the comment explaining the bug; #3072 matched the comment
+      # above the line it was asserting on, so deleting the line stayed green). The checker reads
+      # yaml.safe_load_all output, which drops comments by construction, and --self-test pins it with
+      # a fixture whose only bogus host is in a comment.
+      #
+      # ADVISORY while the 6 pre-existing findings are triaged. All six are bare `openbank-<svc>` rest
+      # client defaults (account, card-issuance, onboarding, settlement) that name no Service in any
+      # namespace — the deployed pods override them by env, so they are dead defaults rather than a
+      # live outage, but each is a hostname nobody could dial. They are NOT fixed in the PR that
+      # introduced this gate: four of the owning services are money-path, so a default-URL change
+      # there needs the two-approval path rather than riding along with a CI guard.
+      enforced: advisory
+      target_enforce_date: "2026-10-31"   # ADR-0144
+      ci_producer: .github/scripts/check-incluster-hostnames.py
 
     kafka_dotted_keys:
       # SmallRye Config's YAML source quotes any leaf map key containing a literal dot, so

--- a/openbank-infra/gitops/components/lending/lending-service.yaml
+++ b/openbank-infra/gitops/components/lending/lending-service.yaml
@@ -34,7 +34,7 @@ spec:
       annotations:
         # Rolls the pods when the OPA bundle changes — subPath mounts do NOT hot-reload.
         # Kept in sync by gen-lending-opa-bundle.sh (do not hand-edit).
-        openbank.tech/policy-checksum: "363a70307c0bef34"
+        openbank.tech/policy-checksum: "e4a98cff615b2d48"
     spec:
       securityContext:
         runAsNonRoot: true

--- a/openbank-infra/gitops/components/mcp/mcp-opa-bundle.yaml
+++ b/openbank-infra/gitops/components/mcp/mcp-opa-bundle.yaml
@@ -9,7 +9,7 @@ metadata:
     app.kubernetes.io/name: mcp-service
     app.kubernetes.io/part-of: platform
   annotations:
-    openbank.tech/policy-checksum: "83d0f65258683b24"
+    openbank.tech/policy-checksum: "9e16ec3241c00c6f"
 data:
   rest.rego: |
     # SPDX-License-Identifier: Apache-2.0
@@ -2962,6 +2962,46 @@ data:
       # first, so the probe would keep passing against a URL the service does not use — the same
       # vacuous shape as deriving both halves of a pact from one annotation.
       ci_producer: .github/scripts/check-external-feeds.py
+
+    incluster_hostnames:
+      # The in-cluster half of external_feeds (above). Same unfalsifiability, different upstream: a
+      # hostname naming another SERVICE in this cluster is stubbed by the unit test, overridden to
+      # localhost by the IT, and never sent by a consumer pact — so it is wrong only at the moment a
+      # pod dials it, and the symptom is a connect timeout in one log line.
+      #
+      # Found live (issue #1916): openbank-analytics-sink's application.yaml documented the Apicurio
+      # schema registry as "provisioned in openbank-infra as service schema-registry:8081" and
+      # defaulted ANALYTICS_SCHEMA_APICURIO_URL to http://localhost:8081. The Service is
+      # `apicurio-registry` on 8080 in namespace `messaging`. Wrong host AND wrong port, stated twice
+      # (prose and value), with nothing in the repo able to contradict either.
+      #
+      # THE RULE: every in-cluster hostname in an openbank-*/src/main/resources/application.yaml must
+      # resolve to a Service that openbank-infra/gitops/ declares.
+      hostname_must_resolve_to_declared_service: true
+      #
+      # Unlike external_feeds this needs no network — the set of names that CAN resolve is fully
+      # declared in gitops, so the claim is decidable offline and deterministically.
+      known_set_is_derived_from_gitops: true
+      # kind: Service, plus the endpoints CNPG (<name>-rw/-ro/-r) and Strimzi
+      # (<name>-kafka-bootstrap/-brokers) synthesise from their CRs. There is NO hand-kept list of
+      # service names in the checker: a gate whose scope is maintained separately from the artifacts
+      # it covers reads as PASSING when the list is short, never as unchecked.
+      asserts_against_parsed_yaml_not_file_text: true
+      # A whole-file grep cannot tell config from the prose ABOUT config, and this repo has been burnt
+      # in both directions (#2450 flagged the comment explaining the bug; #3072 matched the comment
+      # above the line it was asserting on, so deleting the line stayed green). The checker reads
+      # yaml.safe_load_all output, which drops comments by construction, and --self-test pins it with
+      # a fixture whose only bogus host is in a comment.
+      #
+      # ADVISORY while the 6 pre-existing findings are triaged. All six are bare `openbank-<svc>` rest
+      # client defaults (account, card-issuance, onboarding, settlement) that name no Service in any
+      # namespace — the deployed pods override them by env, so they are dead defaults rather than a
+      # live outage, but each is a hostname nobody could dial. They are NOT fixed in the PR that
+      # introduced this gate: four of the owning services are money-path, so a default-URL change
+      # there needs the two-approval path rather than riding along with a CI guard.
+      enforced: advisory
+      target_enforce_date: "2026-10-31"   # ADR-0144
+      ci_producer: .github/scripts/check-incluster-hostnames.py
 
     kafka_dotted_keys:
       # SmallRye Config's YAML source quotes any leaf map key containing a literal dot, so

--- a/openbank-infra/gitops/components/mcp/mcp-service.yaml
+++ b/openbank-infra/gitops/components/mcp/mcp-service.yaml
@@ -29,7 +29,7 @@ spec:
       annotations:
         # Rolls the pod when the OPA bundle changes — subPath mounts do NOT hot-reload.
         # Kept in sync by gen-mcp-opa-bundle.sh (do not hand-edit).
-        openbank.tech/policy-checksum: "83d0f65258683b24"
+        openbank.tech/policy-checksum: "9e16ec3241c00c6f"
     spec:
       securityContext:
         runAsNonRoot: true

--- a/openbank-infra/gitops/components/notifications/notification-service-opa-bundle.yaml
+++ b/openbank-infra/gitops/components/notifications/notification-service-opa-bundle.yaml
@@ -10,7 +10,7 @@ metadata:
     app.kubernetes.io/name: notification-service
     app.kubernetes.io/part-of: notifications
   annotations:
-    openbank.tech/policy-checksum: "24d54ba3a8be1db9"
+    openbank.tech/policy-checksum: "8761810ddcae0ff8"
 data:
   rest.rego: |
     # SPDX-License-Identifier: Apache-2.0
@@ -2185,6 +2185,46 @@ data:
       # first, so the probe would keep passing against a URL the service does not use — the same
       # vacuous shape as deriving both halves of a pact from one annotation.
       ci_producer: .github/scripts/check-external-feeds.py
+
+    incluster_hostnames:
+      # The in-cluster half of external_feeds (above). Same unfalsifiability, different upstream: a
+      # hostname naming another SERVICE in this cluster is stubbed by the unit test, overridden to
+      # localhost by the IT, and never sent by a consumer pact — so it is wrong only at the moment a
+      # pod dials it, and the symptom is a connect timeout in one log line.
+      #
+      # Found live (issue #1916): openbank-analytics-sink's application.yaml documented the Apicurio
+      # schema registry as "provisioned in openbank-infra as service schema-registry:8081" and
+      # defaulted ANALYTICS_SCHEMA_APICURIO_URL to http://localhost:8081. The Service is
+      # `apicurio-registry` on 8080 in namespace `messaging`. Wrong host AND wrong port, stated twice
+      # (prose and value), with nothing in the repo able to contradict either.
+      #
+      # THE RULE: every in-cluster hostname in an openbank-*/src/main/resources/application.yaml must
+      # resolve to a Service that openbank-infra/gitops/ declares.
+      hostname_must_resolve_to_declared_service: true
+      #
+      # Unlike external_feeds this needs no network — the set of names that CAN resolve is fully
+      # declared in gitops, so the claim is decidable offline and deterministically.
+      known_set_is_derived_from_gitops: true
+      # kind: Service, plus the endpoints CNPG (<name>-rw/-ro/-r) and Strimzi
+      # (<name>-kafka-bootstrap/-brokers) synthesise from their CRs. There is NO hand-kept list of
+      # service names in the checker: a gate whose scope is maintained separately from the artifacts
+      # it covers reads as PASSING when the list is short, never as unchecked.
+      asserts_against_parsed_yaml_not_file_text: true
+      # A whole-file grep cannot tell config from the prose ABOUT config, and this repo has been burnt
+      # in both directions (#2450 flagged the comment explaining the bug; #3072 matched the comment
+      # above the line it was asserting on, so deleting the line stayed green). The checker reads
+      # yaml.safe_load_all output, which drops comments by construction, and --self-test pins it with
+      # a fixture whose only bogus host is in a comment.
+      #
+      # ADVISORY while the 6 pre-existing findings are triaged. All six are bare `openbank-<svc>` rest
+      # client defaults (account, card-issuance, onboarding, settlement) that name no Service in any
+      # namespace — the deployed pods override them by env, so they are dead defaults rather than a
+      # live outage, but each is a hostname nobody could dial. They are NOT fixed in the PR that
+      # introduced this gate: four of the owning services are money-path, so a default-URL change
+      # there needs the two-approval path rather than riding along with a CI guard.
+      enforced: advisory
+      target_enforce_date: "2026-10-31"   # ADR-0144
+      ci_producer: .github/scripts/check-incluster-hostnames.py
 
     kafka_dotted_keys:
       # SmallRye Config's YAML source quotes any leaf map key containing a literal dot, so

--- a/openbank-infra/gitops/components/notifications/notification-service.yaml
+++ b/openbank-infra/gitops/components/notifications/notification-service.yaml
@@ -39,7 +39,7 @@ spec:
       annotations:
         # Rolls the Deployment when the OPA policy bundle changes (subPath mounts don't
         # hot-reload). Kept in sync by gen-notification-opa-bundle.sh.
-        openbank.tech/policy-checksum: "24d54ba3a8be1db9"
+        openbank.tech/policy-checksum: "8761810ddcae0ff8"
       labels:
         app.kubernetes.io/name: notification-service
         app.kubernetes.io/part-of: notifications

--- a/openbank-infra/gitops/components/party/party-opa-bundle.yaml
+++ b/openbank-infra/gitops/components/party/party-opa-bundle.yaml
@@ -9,7 +9,7 @@ metadata:
     app.kubernetes.io/name: party-service
     app.kubernetes.io/part-of: party
   annotations:
-    openbank.tech/policy-checksum: "911f670c22a3ff57"
+    openbank.tech/policy-checksum: "663dea6c20f619cd"
 data:
   rest.rego: |
     # SPDX-License-Identifier: Apache-2.0
@@ -3033,6 +3033,46 @@ data:
       # first, so the probe would keep passing against a URL the service does not use — the same
       # vacuous shape as deriving both halves of a pact from one annotation.
       ci_producer: .github/scripts/check-external-feeds.py
+
+    incluster_hostnames:
+      # The in-cluster half of external_feeds (above). Same unfalsifiability, different upstream: a
+      # hostname naming another SERVICE in this cluster is stubbed by the unit test, overridden to
+      # localhost by the IT, and never sent by a consumer pact — so it is wrong only at the moment a
+      # pod dials it, and the symptom is a connect timeout in one log line.
+      #
+      # Found live (issue #1916): openbank-analytics-sink's application.yaml documented the Apicurio
+      # schema registry as "provisioned in openbank-infra as service schema-registry:8081" and
+      # defaulted ANALYTICS_SCHEMA_APICURIO_URL to http://localhost:8081. The Service is
+      # `apicurio-registry` on 8080 in namespace `messaging`. Wrong host AND wrong port, stated twice
+      # (prose and value), with nothing in the repo able to contradict either.
+      #
+      # THE RULE: every in-cluster hostname in an openbank-*/src/main/resources/application.yaml must
+      # resolve to a Service that openbank-infra/gitops/ declares.
+      hostname_must_resolve_to_declared_service: true
+      #
+      # Unlike external_feeds this needs no network — the set of names that CAN resolve is fully
+      # declared in gitops, so the claim is decidable offline and deterministically.
+      known_set_is_derived_from_gitops: true
+      # kind: Service, plus the endpoints CNPG (<name>-rw/-ro/-r) and Strimzi
+      # (<name>-kafka-bootstrap/-brokers) synthesise from their CRs. There is NO hand-kept list of
+      # service names in the checker: a gate whose scope is maintained separately from the artifacts
+      # it covers reads as PASSING when the list is short, never as unchecked.
+      asserts_against_parsed_yaml_not_file_text: true
+      # A whole-file grep cannot tell config from the prose ABOUT config, and this repo has been burnt
+      # in both directions (#2450 flagged the comment explaining the bug; #3072 matched the comment
+      # above the line it was asserting on, so deleting the line stayed green). The checker reads
+      # yaml.safe_load_all output, which drops comments by construction, and --self-test pins it with
+      # a fixture whose only bogus host is in a comment.
+      #
+      # ADVISORY while the 6 pre-existing findings are triaged. All six are bare `openbank-<svc>` rest
+      # client defaults (account, card-issuance, onboarding, settlement) that name no Service in any
+      # namespace — the deployed pods override them by env, so they are dead defaults rather than a
+      # live outage, but each is a hostname nobody could dial. They are NOT fixed in the PR that
+      # introduced this gate: four of the owning services are money-path, so a default-URL change
+      # there needs the two-approval path rather than riding along with a CI guard.
+      enforced: advisory
+      target_enforce_date: "2026-10-31"   # ADR-0144
+      ci_producer: .github/scripts/check-incluster-hostnames.py
 
     kafka_dotted_keys:
       # SmallRye Config's YAML source quotes any leaf map key containing a literal dot, so

--- a/openbank-infra/gitops/components/party/party-service.yaml
+++ b/openbank-infra/gitops/components/party/party-service.yaml
@@ -22,7 +22,7 @@ spec:
       annotations:
         # Rolls the pod when the OPA bundle changes — subPath mounts do NOT hot-reload.
         # Kept in sync by gen-party-opa-bundle.sh (do not hand-edit).
-        openbank.tech/policy-checksum: "911f670c22a3ff57"
+        openbank.tech/policy-checksum: "663dea6c20f619cd"
       labels:
         app.kubernetes.io/name: party-service
         app.kubernetes.io/part-of: party

--- a/openbank-infra/gitops/components/payments/card-issuance-opa-bundle.yaml
+++ b/openbank-infra/gitops/components/payments/card-issuance-opa-bundle.yaml
@@ -9,7 +9,7 @@ metadata:
     app.kubernetes.io/name: card-issuance-service
     app.kubernetes.io/part-of: payments
   annotations:
-    openbank.tech/policy-checksum: "0b2053c65885e3a7"
+    openbank.tech/policy-checksum: "afc59a9ee8a66e15"
 data:
   rest.rego: |
     # SPDX-License-Identifier: Apache-2.0
@@ -3017,6 +3017,46 @@ data:
       # first, so the probe would keep passing against a URL the service does not use — the same
       # vacuous shape as deriving both halves of a pact from one annotation.
       ci_producer: .github/scripts/check-external-feeds.py
+
+    incluster_hostnames:
+      # The in-cluster half of external_feeds (above). Same unfalsifiability, different upstream: a
+      # hostname naming another SERVICE in this cluster is stubbed by the unit test, overridden to
+      # localhost by the IT, and never sent by a consumer pact — so it is wrong only at the moment a
+      # pod dials it, and the symptom is a connect timeout in one log line.
+      #
+      # Found live (issue #1916): openbank-analytics-sink's application.yaml documented the Apicurio
+      # schema registry as "provisioned in openbank-infra as service schema-registry:8081" and
+      # defaulted ANALYTICS_SCHEMA_APICURIO_URL to http://localhost:8081. The Service is
+      # `apicurio-registry` on 8080 in namespace `messaging`. Wrong host AND wrong port, stated twice
+      # (prose and value), with nothing in the repo able to contradict either.
+      #
+      # THE RULE: every in-cluster hostname in an openbank-*/src/main/resources/application.yaml must
+      # resolve to a Service that openbank-infra/gitops/ declares.
+      hostname_must_resolve_to_declared_service: true
+      #
+      # Unlike external_feeds this needs no network — the set of names that CAN resolve is fully
+      # declared in gitops, so the claim is decidable offline and deterministically.
+      known_set_is_derived_from_gitops: true
+      # kind: Service, plus the endpoints CNPG (<name>-rw/-ro/-r) and Strimzi
+      # (<name>-kafka-bootstrap/-brokers) synthesise from their CRs. There is NO hand-kept list of
+      # service names in the checker: a gate whose scope is maintained separately from the artifacts
+      # it covers reads as PASSING when the list is short, never as unchecked.
+      asserts_against_parsed_yaml_not_file_text: true
+      # A whole-file grep cannot tell config from the prose ABOUT config, and this repo has been burnt
+      # in both directions (#2450 flagged the comment explaining the bug; #3072 matched the comment
+      # above the line it was asserting on, so deleting the line stayed green). The checker reads
+      # yaml.safe_load_all output, which drops comments by construction, and --self-test pins it with
+      # a fixture whose only bogus host is in a comment.
+      #
+      # ADVISORY while the 6 pre-existing findings are triaged. All six are bare `openbank-<svc>` rest
+      # client defaults (account, card-issuance, onboarding, settlement) that name no Service in any
+      # namespace — the deployed pods override them by env, so they are dead defaults rather than a
+      # live outage, but each is a hostname nobody could dial. They are NOT fixed in the PR that
+      # introduced this gate: four of the owning services are money-path, so a default-URL change
+      # there needs the two-approval path rather than riding along with a CI guard.
+      enforced: advisory
+      target_enforce_date: "2026-10-31"   # ADR-0144
+      ci_producer: .github/scripts/check-incluster-hostnames.py
 
     kafka_dotted_keys:
       # SmallRye Config's YAML source quotes any leaf map key containing a literal dot, so

--- a/openbank-infra/gitops/components/payments/clearing-opa-bundle.yaml
+++ b/openbank-infra/gitops/components/payments/clearing-opa-bundle.yaml
@@ -9,7 +9,7 @@ metadata:
     app.kubernetes.io/name: clearing-service
     app.kubernetes.io/part-of: payments
   annotations:
-    openbank.tech/policy-checksum: "3b8e9991ba2c9c37"
+    openbank.tech/policy-checksum: "c840c58a03a8a0f0"
 data:
   rest.rego: |
     # SPDX-License-Identifier: Apache-2.0
@@ -3054,6 +3054,46 @@ data:
       # first, so the probe would keep passing against a URL the service does not use — the same
       # vacuous shape as deriving both halves of a pact from one annotation.
       ci_producer: .github/scripts/check-external-feeds.py
+
+    incluster_hostnames:
+      # The in-cluster half of external_feeds (above). Same unfalsifiability, different upstream: a
+      # hostname naming another SERVICE in this cluster is stubbed by the unit test, overridden to
+      # localhost by the IT, and never sent by a consumer pact — so it is wrong only at the moment a
+      # pod dials it, and the symptom is a connect timeout in one log line.
+      #
+      # Found live (issue #1916): openbank-analytics-sink's application.yaml documented the Apicurio
+      # schema registry as "provisioned in openbank-infra as service schema-registry:8081" and
+      # defaulted ANALYTICS_SCHEMA_APICURIO_URL to http://localhost:8081. The Service is
+      # `apicurio-registry` on 8080 in namespace `messaging`. Wrong host AND wrong port, stated twice
+      # (prose and value), with nothing in the repo able to contradict either.
+      #
+      # THE RULE: every in-cluster hostname in an openbank-*/src/main/resources/application.yaml must
+      # resolve to a Service that openbank-infra/gitops/ declares.
+      hostname_must_resolve_to_declared_service: true
+      #
+      # Unlike external_feeds this needs no network — the set of names that CAN resolve is fully
+      # declared in gitops, so the claim is decidable offline and deterministically.
+      known_set_is_derived_from_gitops: true
+      # kind: Service, plus the endpoints CNPG (<name>-rw/-ro/-r) and Strimzi
+      # (<name>-kafka-bootstrap/-brokers) synthesise from their CRs. There is NO hand-kept list of
+      # service names in the checker: a gate whose scope is maintained separately from the artifacts
+      # it covers reads as PASSING when the list is short, never as unchecked.
+      asserts_against_parsed_yaml_not_file_text: true
+      # A whole-file grep cannot tell config from the prose ABOUT config, and this repo has been burnt
+      # in both directions (#2450 flagged the comment explaining the bug; #3072 matched the comment
+      # above the line it was asserting on, so deleting the line stayed green). The checker reads
+      # yaml.safe_load_all output, which drops comments by construction, and --self-test pins it with
+      # a fixture whose only bogus host is in a comment.
+      #
+      # ADVISORY while the 6 pre-existing findings are triaged. All six are bare `openbank-<svc>` rest
+      # client defaults (account, card-issuance, onboarding, settlement) that name no Service in any
+      # namespace — the deployed pods override them by env, so they are dead defaults rather than a
+      # live outage, but each is a hostname nobody could dial. They are NOT fixed in the PR that
+      # introduced this gate: four of the owning services are money-path, so a default-URL change
+      # there needs the two-approval path rather than riding along with a CI guard.
+      enforced: advisory
+      target_enforce_date: "2026-10-31"   # ADR-0144
+      ci_producer: .github/scripts/check-incluster-hostnames.py
 
     kafka_dotted_keys:
       # SmallRye Config's YAML source quotes any leaf map key containing a literal dot, so

--- a/openbank-infra/gitops/components/payments/domestic-payment-opa-bundle.yaml
+++ b/openbank-infra/gitops/components/payments/domestic-payment-opa-bundle.yaml
@@ -9,7 +9,7 @@ metadata:
     app.kubernetes.io/name: domestic-payment
     app.kubernetes.io/part-of: payments
   annotations:
-    openbank.tech/policy-checksum: "f729eca6da010c69"
+    openbank.tech/policy-checksum: "0327e637e9b08756"
 data:
   rest.rego: |
     # SPDX-License-Identifier: Apache-2.0
@@ -3039,6 +3039,46 @@ data:
       # first, so the probe would keep passing against a URL the service does not use — the same
       # vacuous shape as deriving both halves of a pact from one annotation.
       ci_producer: .github/scripts/check-external-feeds.py
+
+    incluster_hostnames:
+      # The in-cluster half of external_feeds (above). Same unfalsifiability, different upstream: a
+      # hostname naming another SERVICE in this cluster is stubbed by the unit test, overridden to
+      # localhost by the IT, and never sent by a consumer pact — so it is wrong only at the moment a
+      # pod dials it, and the symptom is a connect timeout in one log line.
+      #
+      # Found live (issue #1916): openbank-analytics-sink's application.yaml documented the Apicurio
+      # schema registry as "provisioned in openbank-infra as service schema-registry:8081" and
+      # defaulted ANALYTICS_SCHEMA_APICURIO_URL to http://localhost:8081. The Service is
+      # `apicurio-registry` on 8080 in namespace `messaging`. Wrong host AND wrong port, stated twice
+      # (prose and value), with nothing in the repo able to contradict either.
+      #
+      # THE RULE: every in-cluster hostname in an openbank-*/src/main/resources/application.yaml must
+      # resolve to a Service that openbank-infra/gitops/ declares.
+      hostname_must_resolve_to_declared_service: true
+      #
+      # Unlike external_feeds this needs no network — the set of names that CAN resolve is fully
+      # declared in gitops, so the claim is decidable offline and deterministically.
+      known_set_is_derived_from_gitops: true
+      # kind: Service, plus the endpoints CNPG (<name>-rw/-ro/-r) and Strimzi
+      # (<name>-kafka-bootstrap/-brokers) synthesise from their CRs. There is NO hand-kept list of
+      # service names in the checker: a gate whose scope is maintained separately from the artifacts
+      # it covers reads as PASSING when the list is short, never as unchecked.
+      asserts_against_parsed_yaml_not_file_text: true
+      # A whole-file grep cannot tell config from the prose ABOUT config, and this repo has been burnt
+      # in both directions (#2450 flagged the comment explaining the bug; #3072 matched the comment
+      # above the line it was asserting on, so deleting the line stayed green). The checker reads
+      # yaml.safe_load_all output, which drops comments by construction, and --self-test pins it with
+      # a fixture whose only bogus host is in a comment.
+      #
+      # ADVISORY while the 6 pre-existing findings are triaged. All six are bare `openbank-<svc>` rest
+      # client defaults (account, card-issuance, onboarding, settlement) that name no Service in any
+      # namespace — the deployed pods override them by env, so they are dead defaults rather than a
+      # live outage, but each is a hostname nobody could dial. They are NOT fixed in the PR that
+      # introduced this gate: four of the owning services are money-path, so a default-URL change
+      # there needs the two-approval path rather than riding along with a CI guard.
+      enforced: advisory
+      target_enforce_date: "2026-10-31"   # ADR-0144
+      ci_producer: .github/scripts/check-incluster-hostnames.py
 
     kafka_dotted_keys:
       # SmallRye Config's YAML source quotes any leaf map key containing a literal dot, so

--- a/openbank-infra/gitops/components/payments/payments-services.yaml
+++ b/openbank-infra/gitops/components/payments/payments-services.yaml
@@ -42,7 +42,7 @@ spec:
         # Rolls the pods when the OPA bundle changes — subPath mounts do NOT hot-reload.
         # Kept in sync by gen-transaction-opa-bundle.sh via the trailing marker comment
         # (do not hand-edit, do not drop the marker).
-        openbank.tech/policy-checksum: "2db22cf699739cb6" # transaction-opa-bundle
+        openbank.tech/policy-checksum: "241c9765b63d615d" # transaction-opa-bundle
     spec:
       securityContext:
         runAsNonRoot: true
@@ -375,7 +375,7 @@ spec:
       annotations:
         # Rolls the pods when the OPA bundle changes — subPath mounts do NOT hot-reload.
         # Kept in sync by gen-sepa-payment-opa-bundle.sh (do not hand-edit).
-        openbank.tech/policy-checksum: "897cd9c18eb2b02d"
+        openbank.tech/policy-checksum: "296c35de5bccae1b"
     spec:
       securityContext:
         runAsNonRoot: true
@@ -729,7 +729,7 @@ spec:
         # Rolls the pods when the OPA bundle changes — subPath mounts do NOT hot-reload.
         # Kept in sync by gen-domestic-payment-opa-bundle.sh via the trailing marker
         # comment (do not hand-edit, do not drop the marker).
-        openbank.tech/policy-checksum: "f729eca6da010c69" # domestic-payment-opa-bundle
+        openbank.tech/policy-checksum: "0327e637e9b08756" # domestic-payment-opa-bundle
     spec:
       securityContext:
         runAsNonRoot: true
@@ -1053,7 +1053,7 @@ spec:
       annotations:
         # Rolls the pods when the OPA bundle changes — subPath mounts do NOT hot-reload.
         # Kept in sync by gen-sepa-instant-opa-bundle.sh (do not hand-edit).
-        openbank.tech/policy-checksum: "0d7342f561d98473"
+        openbank.tech/policy-checksum: "4452c461ff24d382"
     spec:
       securityContext:
         runAsNonRoot: true
@@ -1369,7 +1369,7 @@ spec:
         # Rolls the pods when the OPA bundle changes — subPath mounts do NOT hot-reload.
         # Kept in sync by gen-clearing-opa-bundle.sh via the trailing marker comment
         # (do not hand-edit, do not drop the marker).
-        openbank.tech/policy-checksum: "3b8e9991ba2c9c37" # clearing-opa-bundle
+        openbank.tech/policy-checksum: "c840c58a03a8a0f0" # clearing-opa-bundle
     spec:
       securityContext:
         runAsNonRoot: true
@@ -1658,7 +1658,7 @@ spec:
       annotations:
         # Rolls the pod when the OPA bundle changes (ADR-0034). Value is stamped by
         # gen-standing-order-opa-bundle.sh — do not hand-edit.
-        openbank.tech/policy-checksum: "423c4c8865264ab6" # standing-order-opa-bundle
+        openbank.tech/policy-checksum: "21c7390d835a134f" # standing-order-opa-bundle
     spec:
       securityContext:
         runAsNonRoot: true
@@ -1911,7 +1911,7 @@ spec:
       annotations:
         # Rolls the pods when the OPA bundle changes — subPath mounts do NOT hot-reload.
         # Kept in sync by gen-card-issuance-opa-bundle.sh (do not hand-edit).
-        openbank.tech/policy-checksum: "0b2053c65885e3a7"
+        openbank.tech/policy-checksum: "afc59a9ee8a66e15"
     spec:
       securityContext:
         runAsNonRoot: true
@@ -2181,7 +2181,7 @@ spec:
         # Rolls the pods when the OPA bundle changes — subPath mounts do NOT hot-reload.
         # Kept in sync by gen-settlement-opa-bundle.sh via the trailing marker comment
         # (do not hand-edit, do not drop the marker).
-        openbank.tech/policy-checksum: "15f5d3bb09150383" # settlement-opa-bundle
+        openbank.tech/policy-checksum: "30af11a823e18676" # settlement-opa-bundle
     spec:
       securityContext:
         runAsNonRoot: true
@@ -2582,7 +2582,7 @@ spec:
       annotations:
         # Rolls the pods when the OPA bundle changes — subPath mounts do NOT hot-reload.
         # Kept in sync by gen-swift-opa-bundle.sh (do not hand-edit).
-        openbank.tech/policy-checksum: "062ab5f32de2d9e2"
+        openbank.tech/policy-checksum: "88147fb4a2fd7390"
     spec:
       securityContext:
         runAsNonRoot: true
@@ -2896,7 +2896,7 @@ spec:
       annotations:
         # Rolls the pods when the OPA bundle changes — subPath mounts do NOT hot-reload.
         # Kept in sync by gen-vop-opa-bundle.sh (do not hand-edit).
-        openbank.tech/policy-checksum: "b7dc55ceb3bffc70"
+        openbank.tech/policy-checksum: "c44b4ab60c5e9876"
     spec:
       securityContext:
         runAsNonRoot: true

--- a/openbank-infra/gitops/components/payments/sepa-instant-opa-bundle.yaml
+++ b/openbank-infra/gitops/components/payments/sepa-instant-opa-bundle.yaml
@@ -9,7 +9,7 @@ metadata:
     app.kubernetes.io/name: sepa-instant
     app.kubernetes.io/part-of: payments
   annotations:
-    openbank.tech/policy-checksum: "0d7342f561d98473"
+    openbank.tech/policy-checksum: "4452c461ff24d382"
 data:
   rest.rego: |
     # SPDX-License-Identifier: Apache-2.0
@@ -3012,6 +3012,46 @@ data:
       # first, so the probe would keep passing against a URL the service does not use — the same
       # vacuous shape as deriving both halves of a pact from one annotation.
       ci_producer: .github/scripts/check-external-feeds.py
+
+    incluster_hostnames:
+      # The in-cluster half of external_feeds (above). Same unfalsifiability, different upstream: a
+      # hostname naming another SERVICE in this cluster is stubbed by the unit test, overridden to
+      # localhost by the IT, and never sent by a consumer pact — so it is wrong only at the moment a
+      # pod dials it, and the symptom is a connect timeout in one log line.
+      #
+      # Found live (issue #1916): openbank-analytics-sink's application.yaml documented the Apicurio
+      # schema registry as "provisioned in openbank-infra as service schema-registry:8081" and
+      # defaulted ANALYTICS_SCHEMA_APICURIO_URL to http://localhost:8081. The Service is
+      # `apicurio-registry` on 8080 in namespace `messaging`. Wrong host AND wrong port, stated twice
+      # (prose and value), with nothing in the repo able to contradict either.
+      #
+      # THE RULE: every in-cluster hostname in an openbank-*/src/main/resources/application.yaml must
+      # resolve to a Service that openbank-infra/gitops/ declares.
+      hostname_must_resolve_to_declared_service: true
+      #
+      # Unlike external_feeds this needs no network — the set of names that CAN resolve is fully
+      # declared in gitops, so the claim is decidable offline and deterministically.
+      known_set_is_derived_from_gitops: true
+      # kind: Service, plus the endpoints CNPG (<name>-rw/-ro/-r) and Strimzi
+      # (<name>-kafka-bootstrap/-brokers) synthesise from their CRs. There is NO hand-kept list of
+      # service names in the checker: a gate whose scope is maintained separately from the artifacts
+      # it covers reads as PASSING when the list is short, never as unchecked.
+      asserts_against_parsed_yaml_not_file_text: true
+      # A whole-file grep cannot tell config from the prose ABOUT config, and this repo has been burnt
+      # in both directions (#2450 flagged the comment explaining the bug; #3072 matched the comment
+      # above the line it was asserting on, so deleting the line stayed green). The checker reads
+      # yaml.safe_load_all output, which drops comments by construction, and --self-test pins it with
+      # a fixture whose only bogus host is in a comment.
+      #
+      # ADVISORY while the 6 pre-existing findings are triaged. All six are bare `openbank-<svc>` rest
+      # client defaults (account, card-issuance, onboarding, settlement) that name no Service in any
+      # namespace — the deployed pods override them by env, so they are dead defaults rather than a
+      # live outage, but each is a hostname nobody could dial. They are NOT fixed in the PR that
+      # introduced this gate: four of the owning services are money-path, so a default-URL change
+      # there needs the two-approval path rather than riding along with a CI guard.
+      enforced: advisory
+      target_enforce_date: "2026-10-31"   # ADR-0144
+      ci_producer: .github/scripts/check-incluster-hostnames.py
 
     kafka_dotted_keys:
       # SmallRye Config's YAML source quotes any leaf map key containing a literal dot, so

--- a/openbank-infra/gitops/components/payments/sepa-payment-opa-bundle.yaml
+++ b/openbank-infra/gitops/components/payments/sepa-payment-opa-bundle.yaml
@@ -9,7 +9,7 @@ metadata:
     app.kubernetes.io/name: sepa-payment
     app.kubernetes.io/part-of: payments
   annotations:
-    openbank.tech/policy-checksum: "897cd9c18eb2b02d"
+    openbank.tech/policy-checksum: "296c35de5bccae1b"
 data:
   rest.rego: |
     # SPDX-License-Identifier: Apache-2.0
@@ -3033,6 +3033,46 @@ data:
       # first, so the probe would keep passing against a URL the service does not use — the same
       # vacuous shape as deriving both halves of a pact from one annotation.
       ci_producer: .github/scripts/check-external-feeds.py
+
+    incluster_hostnames:
+      # The in-cluster half of external_feeds (above). Same unfalsifiability, different upstream: a
+      # hostname naming another SERVICE in this cluster is stubbed by the unit test, overridden to
+      # localhost by the IT, and never sent by a consumer pact — so it is wrong only at the moment a
+      # pod dials it, and the symptom is a connect timeout in one log line.
+      #
+      # Found live (issue #1916): openbank-analytics-sink's application.yaml documented the Apicurio
+      # schema registry as "provisioned in openbank-infra as service schema-registry:8081" and
+      # defaulted ANALYTICS_SCHEMA_APICURIO_URL to http://localhost:8081. The Service is
+      # `apicurio-registry` on 8080 in namespace `messaging`. Wrong host AND wrong port, stated twice
+      # (prose and value), with nothing in the repo able to contradict either.
+      #
+      # THE RULE: every in-cluster hostname in an openbank-*/src/main/resources/application.yaml must
+      # resolve to a Service that openbank-infra/gitops/ declares.
+      hostname_must_resolve_to_declared_service: true
+      #
+      # Unlike external_feeds this needs no network — the set of names that CAN resolve is fully
+      # declared in gitops, so the claim is decidable offline and deterministically.
+      known_set_is_derived_from_gitops: true
+      # kind: Service, plus the endpoints CNPG (<name>-rw/-ro/-r) and Strimzi
+      # (<name>-kafka-bootstrap/-brokers) synthesise from their CRs. There is NO hand-kept list of
+      # service names in the checker: a gate whose scope is maintained separately from the artifacts
+      # it covers reads as PASSING when the list is short, never as unchecked.
+      asserts_against_parsed_yaml_not_file_text: true
+      # A whole-file grep cannot tell config from the prose ABOUT config, and this repo has been burnt
+      # in both directions (#2450 flagged the comment explaining the bug; #3072 matched the comment
+      # above the line it was asserting on, so deleting the line stayed green). The checker reads
+      # yaml.safe_load_all output, which drops comments by construction, and --self-test pins it with
+      # a fixture whose only bogus host is in a comment.
+      #
+      # ADVISORY while the 6 pre-existing findings are triaged. All six are bare `openbank-<svc>` rest
+      # client defaults (account, card-issuance, onboarding, settlement) that name no Service in any
+      # namespace — the deployed pods override them by env, so they are dead defaults rather than a
+      # live outage, but each is a hostname nobody could dial. They are NOT fixed in the PR that
+      # introduced this gate: four of the owning services are money-path, so a default-URL change
+      # there needs the two-approval path rather than riding along with a CI guard.
+      enforced: advisory
+      target_enforce_date: "2026-10-31"   # ADR-0144
+      ci_producer: .github/scripts/check-incluster-hostnames.py
 
     kafka_dotted_keys:
       # SmallRye Config's YAML source quotes any leaf map key containing a literal dot, so

--- a/openbank-infra/gitops/components/payments/settlement-opa-bundle.yaml
+++ b/openbank-infra/gitops/components/payments/settlement-opa-bundle.yaml
@@ -9,7 +9,7 @@ metadata:
     app.kubernetes.io/name: settlement-service
     app.kubernetes.io/part-of: payments
   annotations:
-    openbank.tech/policy-checksum: "15f5d3bb09150383"
+    openbank.tech/policy-checksum: "30af11a823e18676"
 data:
   rest.rego: |
     # SPDX-License-Identifier: Apache-2.0
@@ -3013,6 +3013,46 @@ data:
       # first, so the probe would keep passing against a URL the service does not use — the same
       # vacuous shape as deriving both halves of a pact from one annotation.
       ci_producer: .github/scripts/check-external-feeds.py
+
+    incluster_hostnames:
+      # The in-cluster half of external_feeds (above). Same unfalsifiability, different upstream: a
+      # hostname naming another SERVICE in this cluster is stubbed by the unit test, overridden to
+      # localhost by the IT, and never sent by a consumer pact — so it is wrong only at the moment a
+      # pod dials it, and the symptom is a connect timeout in one log line.
+      #
+      # Found live (issue #1916): openbank-analytics-sink's application.yaml documented the Apicurio
+      # schema registry as "provisioned in openbank-infra as service schema-registry:8081" and
+      # defaulted ANALYTICS_SCHEMA_APICURIO_URL to http://localhost:8081. The Service is
+      # `apicurio-registry` on 8080 in namespace `messaging`. Wrong host AND wrong port, stated twice
+      # (prose and value), with nothing in the repo able to contradict either.
+      #
+      # THE RULE: every in-cluster hostname in an openbank-*/src/main/resources/application.yaml must
+      # resolve to a Service that openbank-infra/gitops/ declares.
+      hostname_must_resolve_to_declared_service: true
+      #
+      # Unlike external_feeds this needs no network — the set of names that CAN resolve is fully
+      # declared in gitops, so the claim is decidable offline and deterministically.
+      known_set_is_derived_from_gitops: true
+      # kind: Service, plus the endpoints CNPG (<name>-rw/-ro/-r) and Strimzi
+      # (<name>-kafka-bootstrap/-brokers) synthesise from their CRs. There is NO hand-kept list of
+      # service names in the checker: a gate whose scope is maintained separately from the artifacts
+      # it covers reads as PASSING when the list is short, never as unchecked.
+      asserts_against_parsed_yaml_not_file_text: true
+      # A whole-file grep cannot tell config from the prose ABOUT config, and this repo has been burnt
+      # in both directions (#2450 flagged the comment explaining the bug; #3072 matched the comment
+      # above the line it was asserting on, so deleting the line stayed green). The checker reads
+      # yaml.safe_load_all output, which drops comments by construction, and --self-test pins it with
+      # a fixture whose only bogus host is in a comment.
+      #
+      # ADVISORY while the 6 pre-existing findings are triaged. All six are bare `openbank-<svc>` rest
+      # client defaults (account, card-issuance, onboarding, settlement) that name no Service in any
+      # namespace — the deployed pods override them by env, so they are dead defaults rather than a
+      # live outage, but each is a hostname nobody could dial. They are NOT fixed in the PR that
+      # introduced this gate: four of the owning services are money-path, so a default-URL change
+      # there needs the two-approval path rather than riding along with a CI guard.
+      enforced: advisory
+      target_enforce_date: "2026-10-31"   # ADR-0144
+      ci_producer: .github/scripts/check-incluster-hostnames.py
 
     kafka_dotted_keys:
       # SmallRye Config's YAML source quotes any leaf map key containing a literal dot, so

--- a/openbank-infra/gitops/components/payments/standing-order-opa-bundle.yaml
+++ b/openbank-infra/gitops/components/payments/standing-order-opa-bundle.yaml
@@ -9,7 +9,7 @@ metadata:
     app.kubernetes.io/name: standing-order-service
     app.kubernetes.io/part-of: payments
   annotations:
-    openbank.tech/policy-checksum: "423c4c8865264ab6"
+    openbank.tech/policy-checksum: "21c7390d835a134f"
 data:
   rest.rego: |
     # SPDX-License-Identifier: Apache-2.0
@@ -2998,6 +2998,46 @@ data:
       # first, so the probe would keep passing against a URL the service does not use — the same
       # vacuous shape as deriving both halves of a pact from one annotation.
       ci_producer: .github/scripts/check-external-feeds.py
+
+    incluster_hostnames:
+      # The in-cluster half of external_feeds (above). Same unfalsifiability, different upstream: a
+      # hostname naming another SERVICE in this cluster is stubbed by the unit test, overridden to
+      # localhost by the IT, and never sent by a consumer pact — so it is wrong only at the moment a
+      # pod dials it, and the symptom is a connect timeout in one log line.
+      #
+      # Found live (issue #1916): openbank-analytics-sink's application.yaml documented the Apicurio
+      # schema registry as "provisioned in openbank-infra as service schema-registry:8081" and
+      # defaulted ANALYTICS_SCHEMA_APICURIO_URL to http://localhost:8081. The Service is
+      # `apicurio-registry` on 8080 in namespace `messaging`. Wrong host AND wrong port, stated twice
+      # (prose and value), with nothing in the repo able to contradict either.
+      #
+      # THE RULE: every in-cluster hostname in an openbank-*/src/main/resources/application.yaml must
+      # resolve to a Service that openbank-infra/gitops/ declares.
+      hostname_must_resolve_to_declared_service: true
+      #
+      # Unlike external_feeds this needs no network — the set of names that CAN resolve is fully
+      # declared in gitops, so the claim is decidable offline and deterministically.
+      known_set_is_derived_from_gitops: true
+      # kind: Service, plus the endpoints CNPG (<name>-rw/-ro/-r) and Strimzi
+      # (<name>-kafka-bootstrap/-brokers) synthesise from their CRs. There is NO hand-kept list of
+      # service names in the checker: a gate whose scope is maintained separately from the artifacts
+      # it covers reads as PASSING when the list is short, never as unchecked.
+      asserts_against_parsed_yaml_not_file_text: true
+      # A whole-file grep cannot tell config from the prose ABOUT config, and this repo has been burnt
+      # in both directions (#2450 flagged the comment explaining the bug; #3072 matched the comment
+      # above the line it was asserting on, so deleting the line stayed green). The checker reads
+      # yaml.safe_load_all output, which drops comments by construction, and --self-test pins it with
+      # a fixture whose only bogus host is in a comment.
+      #
+      # ADVISORY while the 6 pre-existing findings are triaged. All six are bare `openbank-<svc>` rest
+      # client defaults (account, card-issuance, onboarding, settlement) that name no Service in any
+      # namespace — the deployed pods override them by env, so they are dead defaults rather than a
+      # live outage, but each is a hostname nobody could dial. They are NOT fixed in the PR that
+      # introduced this gate: four of the owning services are money-path, so a default-URL change
+      # there needs the two-approval path rather than riding along with a CI guard.
+      enforced: advisory
+      target_enforce_date: "2026-10-31"   # ADR-0144
+      ci_producer: .github/scripts/check-incluster-hostnames.py
 
     kafka_dotted_keys:
       # SmallRye Config's YAML source quotes any leaf map key containing a literal dot, so

--- a/openbank-infra/gitops/components/payments/swift-opa-bundle.yaml
+++ b/openbank-infra/gitops/components/payments/swift-opa-bundle.yaml
@@ -9,7 +9,7 @@ metadata:
     app.kubernetes.io/name: swift-service
     app.kubernetes.io/part-of: payments
   annotations:
-    openbank.tech/policy-checksum: "062ab5f32de2d9e2"
+    openbank.tech/policy-checksum: "88147fb4a2fd7390"
 data:
   rest.rego: |
     # SPDX-License-Identifier: Apache-2.0
@@ -3016,6 +3016,46 @@ data:
       # first, so the probe would keep passing against a URL the service does not use — the same
       # vacuous shape as deriving both halves of a pact from one annotation.
       ci_producer: .github/scripts/check-external-feeds.py
+
+    incluster_hostnames:
+      # The in-cluster half of external_feeds (above). Same unfalsifiability, different upstream: a
+      # hostname naming another SERVICE in this cluster is stubbed by the unit test, overridden to
+      # localhost by the IT, and never sent by a consumer pact — so it is wrong only at the moment a
+      # pod dials it, and the symptom is a connect timeout in one log line.
+      #
+      # Found live (issue #1916): openbank-analytics-sink's application.yaml documented the Apicurio
+      # schema registry as "provisioned in openbank-infra as service schema-registry:8081" and
+      # defaulted ANALYTICS_SCHEMA_APICURIO_URL to http://localhost:8081. The Service is
+      # `apicurio-registry` on 8080 in namespace `messaging`. Wrong host AND wrong port, stated twice
+      # (prose and value), with nothing in the repo able to contradict either.
+      #
+      # THE RULE: every in-cluster hostname in an openbank-*/src/main/resources/application.yaml must
+      # resolve to a Service that openbank-infra/gitops/ declares.
+      hostname_must_resolve_to_declared_service: true
+      #
+      # Unlike external_feeds this needs no network — the set of names that CAN resolve is fully
+      # declared in gitops, so the claim is decidable offline and deterministically.
+      known_set_is_derived_from_gitops: true
+      # kind: Service, plus the endpoints CNPG (<name>-rw/-ro/-r) and Strimzi
+      # (<name>-kafka-bootstrap/-brokers) synthesise from their CRs. There is NO hand-kept list of
+      # service names in the checker: a gate whose scope is maintained separately from the artifacts
+      # it covers reads as PASSING when the list is short, never as unchecked.
+      asserts_against_parsed_yaml_not_file_text: true
+      # A whole-file grep cannot tell config from the prose ABOUT config, and this repo has been burnt
+      # in both directions (#2450 flagged the comment explaining the bug; #3072 matched the comment
+      # above the line it was asserting on, so deleting the line stayed green). The checker reads
+      # yaml.safe_load_all output, which drops comments by construction, and --self-test pins it with
+      # a fixture whose only bogus host is in a comment.
+      #
+      # ADVISORY while the 6 pre-existing findings are triaged. All six are bare `openbank-<svc>` rest
+      # client defaults (account, card-issuance, onboarding, settlement) that name no Service in any
+      # namespace — the deployed pods override them by env, so they are dead defaults rather than a
+      # live outage, but each is a hostname nobody could dial. They are NOT fixed in the PR that
+      # introduced this gate: four of the owning services are money-path, so a default-URL change
+      # there needs the two-approval path rather than riding along with a CI guard.
+      enforced: advisory
+      target_enforce_date: "2026-10-31"   # ADR-0144
+      ci_producer: .github/scripts/check-incluster-hostnames.py
 
     kafka_dotted_keys:
       # SmallRye Config's YAML source quotes any leaf map key containing a literal dot, so

--- a/openbank-infra/gitops/components/payments/transaction-opa-bundle.yaml
+++ b/openbank-infra/gitops/components/payments/transaction-opa-bundle.yaml
@@ -9,7 +9,7 @@ metadata:
     app.kubernetes.io/name: transaction-service
     app.kubernetes.io/part-of: payments
   annotations:
-    openbank.tech/policy-checksum: "2db22cf699739cb6"
+    openbank.tech/policy-checksum: "241c9765b63d615d"
 data:
   rest.rego: |
     # SPDX-License-Identifier: Apache-2.0
@@ -3069,6 +3069,46 @@ data:
       # first, so the probe would keep passing against a URL the service does not use — the same
       # vacuous shape as deriving both halves of a pact from one annotation.
       ci_producer: .github/scripts/check-external-feeds.py
+
+    incluster_hostnames:
+      # The in-cluster half of external_feeds (above). Same unfalsifiability, different upstream: a
+      # hostname naming another SERVICE in this cluster is stubbed by the unit test, overridden to
+      # localhost by the IT, and never sent by a consumer pact — so it is wrong only at the moment a
+      # pod dials it, and the symptom is a connect timeout in one log line.
+      #
+      # Found live (issue #1916): openbank-analytics-sink's application.yaml documented the Apicurio
+      # schema registry as "provisioned in openbank-infra as service schema-registry:8081" and
+      # defaulted ANALYTICS_SCHEMA_APICURIO_URL to http://localhost:8081. The Service is
+      # `apicurio-registry` on 8080 in namespace `messaging`. Wrong host AND wrong port, stated twice
+      # (prose and value), with nothing in the repo able to contradict either.
+      #
+      # THE RULE: every in-cluster hostname in an openbank-*/src/main/resources/application.yaml must
+      # resolve to a Service that openbank-infra/gitops/ declares.
+      hostname_must_resolve_to_declared_service: true
+      #
+      # Unlike external_feeds this needs no network — the set of names that CAN resolve is fully
+      # declared in gitops, so the claim is decidable offline and deterministically.
+      known_set_is_derived_from_gitops: true
+      # kind: Service, plus the endpoints CNPG (<name>-rw/-ro/-r) and Strimzi
+      # (<name>-kafka-bootstrap/-brokers) synthesise from their CRs. There is NO hand-kept list of
+      # service names in the checker: a gate whose scope is maintained separately from the artifacts
+      # it covers reads as PASSING when the list is short, never as unchecked.
+      asserts_against_parsed_yaml_not_file_text: true
+      # A whole-file grep cannot tell config from the prose ABOUT config, and this repo has been burnt
+      # in both directions (#2450 flagged the comment explaining the bug; #3072 matched the comment
+      # above the line it was asserting on, so deleting the line stayed green). The checker reads
+      # yaml.safe_load_all output, which drops comments by construction, and --self-test pins it with
+      # a fixture whose only bogus host is in a comment.
+      #
+      # ADVISORY while the 6 pre-existing findings are triaged. All six are bare `openbank-<svc>` rest
+      # client defaults (account, card-issuance, onboarding, settlement) that name no Service in any
+      # namespace — the deployed pods override them by env, so they are dead defaults rather than a
+      # live outage, but each is a hostname nobody could dial. They are NOT fixed in the PR that
+      # introduced this gate: four of the owning services are money-path, so a default-URL change
+      # there needs the two-approval path rather than riding along with a CI guard.
+      enforced: advisory
+      target_enforce_date: "2026-10-31"   # ADR-0144
+      ci_producer: .github/scripts/check-incluster-hostnames.py
 
     kafka_dotted_keys:
       # SmallRye Config's YAML source quotes any leaf map key containing a literal dot, so

--- a/openbank-infra/gitops/components/payments/vop-opa-bundle.yaml
+++ b/openbank-infra/gitops/components/payments/vop-opa-bundle.yaml
@@ -9,7 +9,7 @@ metadata:
     app.kubernetes.io/name: vop-service
     app.kubernetes.io/part-of: payments
   annotations:
-    openbank.tech/policy-checksum: "b7dc55ceb3bffc70"
+    openbank.tech/policy-checksum: "c44b4ab60c5e9876"
 data:
   rest.rego: |
     # SPDX-License-Identifier: Apache-2.0
@@ -3020,6 +3020,46 @@ data:
       # first, so the probe would keep passing against a URL the service does not use — the same
       # vacuous shape as deriving both halves of a pact from one annotation.
       ci_producer: .github/scripts/check-external-feeds.py
+
+    incluster_hostnames:
+      # The in-cluster half of external_feeds (above). Same unfalsifiability, different upstream: a
+      # hostname naming another SERVICE in this cluster is stubbed by the unit test, overridden to
+      # localhost by the IT, and never sent by a consumer pact — so it is wrong only at the moment a
+      # pod dials it, and the symptom is a connect timeout in one log line.
+      #
+      # Found live (issue #1916): openbank-analytics-sink's application.yaml documented the Apicurio
+      # schema registry as "provisioned in openbank-infra as service schema-registry:8081" and
+      # defaulted ANALYTICS_SCHEMA_APICURIO_URL to http://localhost:8081. The Service is
+      # `apicurio-registry` on 8080 in namespace `messaging`. Wrong host AND wrong port, stated twice
+      # (prose and value), with nothing in the repo able to contradict either.
+      #
+      # THE RULE: every in-cluster hostname in an openbank-*/src/main/resources/application.yaml must
+      # resolve to a Service that openbank-infra/gitops/ declares.
+      hostname_must_resolve_to_declared_service: true
+      #
+      # Unlike external_feeds this needs no network — the set of names that CAN resolve is fully
+      # declared in gitops, so the claim is decidable offline and deterministically.
+      known_set_is_derived_from_gitops: true
+      # kind: Service, plus the endpoints CNPG (<name>-rw/-ro/-r) and Strimzi
+      # (<name>-kafka-bootstrap/-brokers) synthesise from their CRs. There is NO hand-kept list of
+      # service names in the checker: a gate whose scope is maintained separately from the artifacts
+      # it covers reads as PASSING when the list is short, never as unchecked.
+      asserts_against_parsed_yaml_not_file_text: true
+      # A whole-file grep cannot tell config from the prose ABOUT config, and this repo has been burnt
+      # in both directions (#2450 flagged the comment explaining the bug; #3072 matched the comment
+      # above the line it was asserting on, so deleting the line stayed green). The checker reads
+      # yaml.safe_load_all output, which drops comments by construction, and --self-test pins it with
+      # a fixture whose only bogus host is in a comment.
+      #
+      # ADVISORY while the 6 pre-existing findings are triaged. All six are bare `openbank-<svc>` rest
+      # client defaults (account, card-issuance, onboarding, settlement) that name no Service in any
+      # namespace — the deployed pods override them by env, so they are dead defaults rather than a
+      # live outage, but each is a hostname nobody could dial. They are NOT fixed in the PR that
+      # introduced this gate: four of the owning services are money-path, so a default-URL change
+      # there needs the two-approval path rather than riding along with a CI guard.
+      enforced: advisory
+      target_enforce_date: "2026-10-31"   # ADR-0144
+      ci_producer: .github/scripts/check-incluster-hostnames.py
 
     kafka_dotted_keys:
       # SmallRye Config's YAML source quotes any leaf map key containing a literal dot, so

--- a/openbank-infra/gitops/components/pid/pid-opa-bundle.yaml
+++ b/openbank-infra/gitops/components/pid/pid-opa-bundle.yaml
@@ -9,7 +9,7 @@ metadata:
     app.kubernetes.io/name: pid-service
     app.kubernetes.io/part-of: pid
   annotations:
-    openbank.tech/policy-checksum: "cff2f5cc24dcd034"
+    openbank.tech/policy-checksum: "9a3e8079f2851ee1"
 data:
   rest.rego: |
     # SPDX-License-Identifier: Apache-2.0
@@ -3022,6 +3022,46 @@ data:
       # first, so the probe would keep passing against a URL the service does not use — the same
       # vacuous shape as deriving both halves of a pact from one annotation.
       ci_producer: .github/scripts/check-external-feeds.py
+
+    incluster_hostnames:
+      # The in-cluster half of external_feeds (above). Same unfalsifiability, different upstream: a
+      # hostname naming another SERVICE in this cluster is stubbed by the unit test, overridden to
+      # localhost by the IT, and never sent by a consumer pact — so it is wrong only at the moment a
+      # pod dials it, and the symptom is a connect timeout in one log line.
+      #
+      # Found live (issue #1916): openbank-analytics-sink's application.yaml documented the Apicurio
+      # schema registry as "provisioned in openbank-infra as service schema-registry:8081" and
+      # defaulted ANALYTICS_SCHEMA_APICURIO_URL to http://localhost:8081. The Service is
+      # `apicurio-registry` on 8080 in namespace `messaging`. Wrong host AND wrong port, stated twice
+      # (prose and value), with nothing in the repo able to contradict either.
+      #
+      # THE RULE: every in-cluster hostname in an openbank-*/src/main/resources/application.yaml must
+      # resolve to a Service that openbank-infra/gitops/ declares.
+      hostname_must_resolve_to_declared_service: true
+      #
+      # Unlike external_feeds this needs no network — the set of names that CAN resolve is fully
+      # declared in gitops, so the claim is decidable offline and deterministically.
+      known_set_is_derived_from_gitops: true
+      # kind: Service, plus the endpoints CNPG (<name>-rw/-ro/-r) and Strimzi
+      # (<name>-kafka-bootstrap/-brokers) synthesise from their CRs. There is NO hand-kept list of
+      # service names in the checker: a gate whose scope is maintained separately from the artifacts
+      # it covers reads as PASSING when the list is short, never as unchecked.
+      asserts_against_parsed_yaml_not_file_text: true
+      # A whole-file grep cannot tell config from the prose ABOUT config, and this repo has been burnt
+      # in both directions (#2450 flagged the comment explaining the bug; #3072 matched the comment
+      # above the line it was asserting on, so deleting the line stayed green). The checker reads
+      # yaml.safe_load_all output, which drops comments by construction, and --self-test pins it with
+      # a fixture whose only bogus host is in a comment.
+      #
+      # ADVISORY while the 6 pre-existing findings are triaged. All six are bare `openbank-<svc>` rest
+      # client defaults (account, card-issuance, onboarding, settlement) that name no Service in any
+      # namespace — the deployed pods override them by env, so they are dead defaults rather than a
+      # live outage, but each is a hostname nobody could dial. They are NOT fixed in the PR that
+      # introduced this gate: four of the owning services are money-path, so a default-URL change
+      # there needs the two-approval path rather than riding along with a CI guard.
+      enforced: advisory
+      target_enforce_date: "2026-10-31"   # ADR-0144
+      ci_producer: .github/scripts/check-incluster-hostnames.py
 
     kafka_dotted_keys:
       # SmallRye Config's YAML source quotes any leaf map key containing a literal dot, so

--- a/openbank-infra/gitops/components/pid/pid-service.yaml
+++ b/openbank-infra/gitops/components/pid/pid-service.yaml
@@ -22,7 +22,7 @@ spec:
       annotations:
         # Rolls the pod when the OPA bundle changes — subPath mounts do NOT hot-reload.
         # Kept in sync by gen-pid-opa-bundle.sh (do not hand-edit).
-        openbank.tech/policy-checksum: "cff2f5cc24dcd034"
+        openbank.tech/policy-checksum: "9a3e8079f2851ee1"
     spec:
       securityContext:
         runAsNonRoot: true

--- a/openbank-infra/gitops/components/psd2-service/psd2-opa-bundle.yaml
+++ b/openbank-infra/gitops/components/psd2-service/psd2-opa-bundle.yaml
@@ -9,7 +9,7 @@ metadata:
     app.kubernetes.io/name: psd2-service
     app.kubernetes.io/part-of: psd2
   annotations:
-    openbank.tech/policy-checksum: "90c8518b17c818ed"
+    openbank.tech/policy-checksum: "331c991afa5eb6d0"
 data:
   rest.rego: |
     # SPDX-License-Identifier: Apache-2.0
@@ -3095,6 +3095,46 @@ data:
       # first, so the probe would keep passing against a URL the service does not use — the same
       # vacuous shape as deriving both halves of a pact from one annotation.
       ci_producer: .github/scripts/check-external-feeds.py
+
+    incluster_hostnames:
+      # The in-cluster half of external_feeds (above). Same unfalsifiability, different upstream: a
+      # hostname naming another SERVICE in this cluster is stubbed by the unit test, overridden to
+      # localhost by the IT, and never sent by a consumer pact — so it is wrong only at the moment a
+      # pod dials it, and the symptom is a connect timeout in one log line.
+      #
+      # Found live (issue #1916): openbank-analytics-sink's application.yaml documented the Apicurio
+      # schema registry as "provisioned in openbank-infra as service schema-registry:8081" and
+      # defaulted ANALYTICS_SCHEMA_APICURIO_URL to http://localhost:8081. The Service is
+      # `apicurio-registry` on 8080 in namespace `messaging`. Wrong host AND wrong port, stated twice
+      # (prose and value), with nothing in the repo able to contradict either.
+      #
+      # THE RULE: every in-cluster hostname in an openbank-*/src/main/resources/application.yaml must
+      # resolve to a Service that openbank-infra/gitops/ declares.
+      hostname_must_resolve_to_declared_service: true
+      #
+      # Unlike external_feeds this needs no network — the set of names that CAN resolve is fully
+      # declared in gitops, so the claim is decidable offline and deterministically.
+      known_set_is_derived_from_gitops: true
+      # kind: Service, plus the endpoints CNPG (<name>-rw/-ro/-r) and Strimzi
+      # (<name>-kafka-bootstrap/-brokers) synthesise from their CRs. There is NO hand-kept list of
+      # service names in the checker: a gate whose scope is maintained separately from the artifacts
+      # it covers reads as PASSING when the list is short, never as unchecked.
+      asserts_against_parsed_yaml_not_file_text: true
+      # A whole-file grep cannot tell config from the prose ABOUT config, and this repo has been burnt
+      # in both directions (#2450 flagged the comment explaining the bug; #3072 matched the comment
+      # above the line it was asserting on, so deleting the line stayed green). The checker reads
+      # yaml.safe_load_all output, which drops comments by construction, and --self-test pins it with
+      # a fixture whose only bogus host is in a comment.
+      #
+      # ADVISORY while the 6 pre-existing findings are triaged. All six are bare `openbank-<svc>` rest
+      # client defaults (account, card-issuance, onboarding, settlement) that name no Service in any
+      # namespace — the deployed pods override them by env, so they are dead defaults rather than a
+      # live outage, but each is a hostname nobody could dial. They are NOT fixed in the PR that
+      # introduced this gate: four of the owning services are money-path, so a default-URL change
+      # there needs the two-approval path rather than riding along with a CI guard.
+      enforced: advisory
+      target_enforce_date: "2026-10-31"   # ADR-0144
+      ci_producer: .github/scripts/check-incluster-hostnames.py
 
     kafka_dotted_keys:
       # SmallRye Config's YAML source quotes any leaf map key containing a literal dot, so

--- a/openbank-infra/gitops/components/psd2-service/psd2-service.yaml
+++ b/openbank-infra/gitops/components/psd2-service/psd2-service.yaml
@@ -18,7 +18,7 @@ spec:
       annotations:
         # Rolls the pod when the OPA bundle changes — subPath mounts do NOT hot-reload.
         # Kept in sync by gen-psd2-opa-bundle.sh (do not hand-edit).
-        openbank.tech/policy-checksum: "90c8518b17c818ed"
+        openbank.tech/policy-checksum: "331c991afa5eb6d0"
       labels: {app.kubernetes.io/name: psd2-service, app.kubernetes.io/part-of: psd2}
     spec:
       securityContext:

--- a/openbank-infra/gitops/components/sanctions-service/sanctions-opa-bundle.yaml
+++ b/openbank-infra/gitops/components/sanctions-service/sanctions-opa-bundle.yaml
@@ -9,7 +9,7 @@ metadata:
     app.kubernetes.io/name: sanctions-service
     app.kubernetes.io/part-of: sanctions
   annotations:
-    openbank.tech/policy-checksum: "774844eb3903bd47"
+    openbank.tech/policy-checksum: "8c99c62a079ab219"
 data:
   rest.rego: |
     # SPDX-License-Identifier: Apache-2.0
@@ -3000,6 +3000,46 @@ data:
       # first, so the probe would keep passing against a URL the service does not use — the same
       # vacuous shape as deriving both halves of a pact from one annotation.
       ci_producer: .github/scripts/check-external-feeds.py
+
+    incluster_hostnames:
+      # The in-cluster half of external_feeds (above). Same unfalsifiability, different upstream: a
+      # hostname naming another SERVICE in this cluster is stubbed by the unit test, overridden to
+      # localhost by the IT, and never sent by a consumer pact — so it is wrong only at the moment a
+      # pod dials it, and the symptom is a connect timeout in one log line.
+      #
+      # Found live (issue #1916): openbank-analytics-sink's application.yaml documented the Apicurio
+      # schema registry as "provisioned in openbank-infra as service schema-registry:8081" and
+      # defaulted ANALYTICS_SCHEMA_APICURIO_URL to http://localhost:8081. The Service is
+      # `apicurio-registry` on 8080 in namespace `messaging`. Wrong host AND wrong port, stated twice
+      # (prose and value), with nothing in the repo able to contradict either.
+      #
+      # THE RULE: every in-cluster hostname in an openbank-*/src/main/resources/application.yaml must
+      # resolve to a Service that openbank-infra/gitops/ declares.
+      hostname_must_resolve_to_declared_service: true
+      #
+      # Unlike external_feeds this needs no network — the set of names that CAN resolve is fully
+      # declared in gitops, so the claim is decidable offline and deterministically.
+      known_set_is_derived_from_gitops: true
+      # kind: Service, plus the endpoints CNPG (<name>-rw/-ro/-r) and Strimzi
+      # (<name>-kafka-bootstrap/-brokers) synthesise from their CRs. There is NO hand-kept list of
+      # service names in the checker: a gate whose scope is maintained separately from the artifacts
+      # it covers reads as PASSING when the list is short, never as unchecked.
+      asserts_against_parsed_yaml_not_file_text: true
+      # A whole-file grep cannot tell config from the prose ABOUT config, and this repo has been burnt
+      # in both directions (#2450 flagged the comment explaining the bug; #3072 matched the comment
+      # above the line it was asserting on, so deleting the line stayed green). The checker reads
+      # yaml.safe_load_all output, which drops comments by construction, and --self-test pins it with
+      # a fixture whose only bogus host is in a comment.
+      #
+      # ADVISORY while the 6 pre-existing findings are triaged. All six are bare `openbank-<svc>` rest
+      # client defaults (account, card-issuance, onboarding, settlement) that name no Service in any
+      # namespace — the deployed pods override them by env, so they are dead defaults rather than a
+      # live outage, but each is a hostname nobody could dial. They are NOT fixed in the PR that
+      # introduced this gate: four of the owning services are money-path, so a default-URL change
+      # there needs the two-approval path rather than riding along with a CI guard.
+      enforced: advisory
+      target_enforce_date: "2026-10-31"   # ADR-0144
+      ci_producer: .github/scripts/check-incluster-hostnames.py
 
     kafka_dotted_keys:
       # SmallRye Config's YAML source quotes any leaf map key containing a literal dot, so

--- a/openbank-infra/gitops/components/sanctions-service/sanctions-service.yaml
+++ b/openbank-infra/gitops/components/sanctions-service/sanctions-service.yaml
@@ -49,7 +49,7 @@ spec:
       annotations:
         # Rolls the pods when the OPA bundle changes — subPath mounts do NOT hot-reload.
         # Kept in sync by gen-sanctions-opa-bundle.sh (do not hand-edit).
-        openbank.tech/policy-checksum: "774844eb3903bd47"
+        openbank.tech/policy-checksum: "8c99c62a079ab219"
     spec:
       securityContext:
         runAsNonRoot: true

--- a/openbank-infra/gitops/components/sca/sca-opa-bundle.yaml
+++ b/openbank-infra/gitops/components/sca/sca-opa-bundle.yaml
@@ -9,7 +9,7 @@ metadata:
     app.kubernetes.io/name: sca-service
     app.kubernetes.io/part-of: sca
   annotations:
-    openbank.tech/policy-checksum: "61a90b8663b4a4eb"
+    openbank.tech/policy-checksum: "2753f7ef3059f5a6"
 data:
   rest.rego: |
     # SPDX-License-Identifier: Apache-2.0
@@ -3036,6 +3036,46 @@ data:
       # first, so the probe would keep passing against a URL the service does not use — the same
       # vacuous shape as deriving both halves of a pact from one annotation.
       ci_producer: .github/scripts/check-external-feeds.py
+
+    incluster_hostnames:
+      # The in-cluster half of external_feeds (above). Same unfalsifiability, different upstream: a
+      # hostname naming another SERVICE in this cluster is stubbed by the unit test, overridden to
+      # localhost by the IT, and never sent by a consumer pact — so it is wrong only at the moment a
+      # pod dials it, and the symptom is a connect timeout in one log line.
+      #
+      # Found live (issue #1916): openbank-analytics-sink's application.yaml documented the Apicurio
+      # schema registry as "provisioned in openbank-infra as service schema-registry:8081" and
+      # defaulted ANALYTICS_SCHEMA_APICURIO_URL to http://localhost:8081. The Service is
+      # `apicurio-registry` on 8080 in namespace `messaging`. Wrong host AND wrong port, stated twice
+      # (prose and value), with nothing in the repo able to contradict either.
+      #
+      # THE RULE: every in-cluster hostname in an openbank-*/src/main/resources/application.yaml must
+      # resolve to a Service that openbank-infra/gitops/ declares.
+      hostname_must_resolve_to_declared_service: true
+      #
+      # Unlike external_feeds this needs no network — the set of names that CAN resolve is fully
+      # declared in gitops, so the claim is decidable offline and deterministically.
+      known_set_is_derived_from_gitops: true
+      # kind: Service, plus the endpoints CNPG (<name>-rw/-ro/-r) and Strimzi
+      # (<name>-kafka-bootstrap/-brokers) synthesise from their CRs. There is NO hand-kept list of
+      # service names in the checker: a gate whose scope is maintained separately from the artifacts
+      # it covers reads as PASSING when the list is short, never as unchecked.
+      asserts_against_parsed_yaml_not_file_text: true
+      # A whole-file grep cannot tell config from the prose ABOUT config, and this repo has been burnt
+      # in both directions (#2450 flagged the comment explaining the bug; #3072 matched the comment
+      # above the line it was asserting on, so deleting the line stayed green). The checker reads
+      # yaml.safe_load_all output, which drops comments by construction, and --self-test pins it with
+      # a fixture whose only bogus host is in a comment.
+      #
+      # ADVISORY while the 6 pre-existing findings are triaged. All six are bare `openbank-<svc>` rest
+      # client defaults (account, card-issuance, onboarding, settlement) that name no Service in any
+      # namespace — the deployed pods override them by env, so they are dead defaults rather than a
+      # live outage, but each is a hostname nobody could dial. They are NOT fixed in the PR that
+      # introduced this gate: four of the owning services are money-path, so a default-URL change
+      # there needs the two-approval path rather than riding along with a CI guard.
+      enforced: advisory
+      target_enforce_date: "2026-10-31"   # ADR-0144
+      ci_producer: .github/scripts/check-incluster-hostnames.py
 
     kafka_dotted_keys:
       # SmallRye Config's YAML source quotes any leaf map key containing a literal dot, so

--- a/openbank-infra/gitops/components/sca/sca-service.yaml
+++ b/openbank-infra/gitops/components/sca/sca-service.yaml
@@ -28,7 +28,7 @@ spec:
       annotations:
         # Rolls the pods when the OPA bundle changes — subPath mounts do NOT hot-reload.
         # Kept in sync by gen-sca-opa-bundle.sh (do not hand-edit).
-        openbank.tech/policy-checksum: "61a90b8663b4a4eb"
+        openbank.tech/policy-checksum: "2753f7ef3059f5a6"
     spec:
       securityContext:
         runAsNonRoot: true

--- a/openbank-infra/gitops/components/statements/statement-opa-bundle.yaml
+++ b/openbank-infra/gitops/components/statements/statement-opa-bundle.yaml
@@ -9,7 +9,7 @@ metadata:
     app.kubernetes.io/name: statement-service
     app.kubernetes.io/part-of: statements
   annotations:
-    openbank.tech/policy-checksum: "98b6312a9edaf9a7"
+    openbank.tech/policy-checksum: "db5e7eb174694e81"
 data:
   rest.rego: |
     # SPDX-License-Identifier: Apache-2.0
@@ -3066,6 +3066,46 @@ data:
       # first, so the probe would keep passing against a URL the service does not use — the same
       # vacuous shape as deriving both halves of a pact from one annotation.
       ci_producer: .github/scripts/check-external-feeds.py
+
+    incluster_hostnames:
+      # The in-cluster half of external_feeds (above). Same unfalsifiability, different upstream: a
+      # hostname naming another SERVICE in this cluster is stubbed by the unit test, overridden to
+      # localhost by the IT, and never sent by a consumer pact — so it is wrong only at the moment a
+      # pod dials it, and the symptom is a connect timeout in one log line.
+      #
+      # Found live (issue #1916): openbank-analytics-sink's application.yaml documented the Apicurio
+      # schema registry as "provisioned in openbank-infra as service schema-registry:8081" and
+      # defaulted ANALYTICS_SCHEMA_APICURIO_URL to http://localhost:8081. The Service is
+      # `apicurio-registry` on 8080 in namespace `messaging`. Wrong host AND wrong port, stated twice
+      # (prose and value), with nothing in the repo able to contradict either.
+      #
+      # THE RULE: every in-cluster hostname in an openbank-*/src/main/resources/application.yaml must
+      # resolve to a Service that openbank-infra/gitops/ declares.
+      hostname_must_resolve_to_declared_service: true
+      #
+      # Unlike external_feeds this needs no network — the set of names that CAN resolve is fully
+      # declared in gitops, so the claim is decidable offline and deterministically.
+      known_set_is_derived_from_gitops: true
+      # kind: Service, plus the endpoints CNPG (<name>-rw/-ro/-r) and Strimzi
+      # (<name>-kafka-bootstrap/-brokers) synthesise from their CRs. There is NO hand-kept list of
+      # service names in the checker: a gate whose scope is maintained separately from the artifacts
+      # it covers reads as PASSING when the list is short, never as unchecked.
+      asserts_against_parsed_yaml_not_file_text: true
+      # A whole-file grep cannot tell config from the prose ABOUT config, and this repo has been burnt
+      # in both directions (#2450 flagged the comment explaining the bug; #3072 matched the comment
+      # above the line it was asserting on, so deleting the line stayed green). The checker reads
+      # yaml.safe_load_all output, which drops comments by construction, and --self-test pins it with
+      # a fixture whose only bogus host is in a comment.
+      #
+      # ADVISORY while the 6 pre-existing findings are triaged. All six are bare `openbank-<svc>` rest
+      # client defaults (account, card-issuance, onboarding, settlement) that name no Service in any
+      # namespace — the deployed pods override them by env, so they are dead defaults rather than a
+      # live outage, but each is a hostname nobody could dial. They are NOT fixed in the PR that
+      # introduced this gate: four of the owning services are money-path, so a default-URL change
+      # there needs the two-approval path rather than riding along with a CI guard.
+      enforced: advisory
+      target_enforce_date: "2026-10-31"   # ADR-0144
+      ci_producer: .github/scripts/check-incluster-hostnames.py
 
     kafka_dotted_keys:
       # SmallRye Config's YAML source quotes any leaf map key containing a literal dot, so

--- a/openbank-infra/gitops/components/statements/statement-service.yaml
+++ b/openbank-infra/gitops/components/statements/statement-service.yaml
@@ -26,7 +26,7 @@ spec:
       annotations:
         # Rolls the pod when the OPA bundle changes — subPath mounts do NOT hot-reload.
         # Kept in sync by gen-statement-opa-bundle.sh (do not hand-edit).
-        openbank.tech/policy-checksum: "98b6312a9edaf9a7"
+        openbank.tech/policy-checksum: "db5e7eb174694e81"
       labels:
         app.kubernetes.io/name: statement-service
         app.kubernetes.io/part-of: statements

--- a/openbank-infra/gitops/components/tpp-registry/tpp-registry-opa-bundle.yaml
+++ b/openbank-infra/gitops/components/tpp-registry/tpp-registry-opa-bundle.yaml
@@ -9,7 +9,7 @@ metadata:
     app.kubernetes.io/name: tpp-registry-service
     app.kubernetes.io/part-of: tpp-registry
   annotations:
-    openbank.tech/policy-checksum: "cd31ba8b31fc1caa"
+    openbank.tech/policy-checksum: "b48f942b3ffbc890"
 data:
   rest.rego: |
     # SPDX-License-Identifier: Apache-2.0
@@ -3003,6 +3003,46 @@ data:
       # first, so the probe would keep passing against a URL the service does not use — the same
       # vacuous shape as deriving both halves of a pact from one annotation.
       ci_producer: .github/scripts/check-external-feeds.py
+
+    incluster_hostnames:
+      # The in-cluster half of external_feeds (above). Same unfalsifiability, different upstream: a
+      # hostname naming another SERVICE in this cluster is stubbed by the unit test, overridden to
+      # localhost by the IT, and never sent by a consumer pact — so it is wrong only at the moment a
+      # pod dials it, and the symptom is a connect timeout in one log line.
+      #
+      # Found live (issue #1916): openbank-analytics-sink's application.yaml documented the Apicurio
+      # schema registry as "provisioned in openbank-infra as service schema-registry:8081" and
+      # defaulted ANALYTICS_SCHEMA_APICURIO_URL to http://localhost:8081. The Service is
+      # `apicurio-registry` on 8080 in namespace `messaging`. Wrong host AND wrong port, stated twice
+      # (prose and value), with nothing in the repo able to contradict either.
+      #
+      # THE RULE: every in-cluster hostname in an openbank-*/src/main/resources/application.yaml must
+      # resolve to a Service that openbank-infra/gitops/ declares.
+      hostname_must_resolve_to_declared_service: true
+      #
+      # Unlike external_feeds this needs no network — the set of names that CAN resolve is fully
+      # declared in gitops, so the claim is decidable offline and deterministically.
+      known_set_is_derived_from_gitops: true
+      # kind: Service, plus the endpoints CNPG (<name>-rw/-ro/-r) and Strimzi
+      # (<name>-kafka-bootstrap/-brokers) synthesise from their CRs. There is NO hand-kept list of
+      # service names in the checker: a gate whose scope is maintained separately from the artifacts
+      # it covers reads as PASSING when the list is short, never as unchecked.
+      asserts_against_parsed_yaml_not_file_text: true
+      # A whole-file grep cannot tell config from the prose ABOUT config, and this repo has been burnt
+      # in both directions (#2450 flagged the comment explaining the bug; #3072 matched the comment
+      # above the line it was asserting on, so deleting the line stayed green). The checker reads
+      # yaml.safe_load_all output, which drops comments by construction, and --self-test pins it with
+      # a fixture whose only bogus host is in a comment.
+      #
+      # ADVISORY while the 6 pre-existing findings are triaged. All six are bare `openbank-<svc>` rest
+      # client defaults (account, card-issuance, onboarding, settlement) that name no Service in any
+      # namespace — the deployed pods override them by env, so they are dead defaults rather than a
+      # live outage, but each is a hostname nobody could dial. They are NOT fixed in the PR that
+      # introduced this gate: four of the owning services are money-path, so a default-URL change
+      # there needs the two-approval path rather than riding along with a CI guard.
+      enforced: advisory
+      target_enforce_date: "2026-10-31"   # ADR-0144
+      ci_producer: .github/scripts/check-incluster-hostnames.py
 
     kafka_dotted_keys:
       # SmallRye Config's YAML source quotes any leaf map key containing a literal dot, so

--- a/openbank-infra/gitops/components/tpp-registry/tpp-registry-service.yaml
+++ b/openbank-infra/gitops/components/tpp-registry/tpp-registry-service.yaml
@@ -23,7 +23,7 @@ spec:
       annotations:
         # Rolls the pod when the OPA bundle changes (subPath mounts do not hot-reload).
         # Kept in sync by gen-tpp-registry-opa-bundle.sh (do not hand-edit).
-        openbank.tech/policy-checksum: "cd31ba8b31fc1caa"
+        openbank.tech/policy-checksum: "b48f942b3ffbc890"
     spec:
       securityContext:
         runAsNonRoot: true

--- a/openbank-libs/governance/rules.yaml
+++ b/openbank-libs/governance/rules.yaml
@@ -1500,6 +1500,46 @@ external_feeds:
   # vacuous shape as deriving both halves of a pact from one annotation.
   ci_producer: .github/scripts/check-external-feeds.py
 
+incluster_hostnames:
+  # The in-cluster half of external_feeds (above). Same unfalsifiability, different upstream: a
+  # hostname naming another SERVICE in this cluster is stubbed by the unit test, overridden to
+  # localhost by the IT, and never sent by a consumer pact — so it is wrong only at the moment a
+  # pod dials it, and the symptom is a connect timeout in one log line.
+  #
+  # Found live (issue #1916): openbank-analytics-sink's application.yaml documented the Apicurio
+  # schema registry as "provisioned in openbank-infra as service schema-registry:8081" and
+  # defaulted ANALYTICS_SCHEMA_APICURIO_URL to http://localhost:8081. The Service is
+  # `apicurio-registry` on 8080 in namespace `messaging`. Wrong host AND wrong port, stated twice
+  # (prose and value), with nothing in the repo able to contradict either.
+  #
+  # THE RULE: every in-cluster hostname in an openbank-*/src/main/resources/application.yaml must
+  # resolve to a Service that openbank-infra/gitops/ declares.
+  hostname_must_resolve_to_declared_service: true
+  #
+  # Unlike external_feeds this needs no network — the set of names that CAN resolve is fully
+  # declared in gitops, so the claim is decidable offline and deterministically.
+  known_set_is_derived_from_gitops: true
+  # kind: Service, plus the endpoints CNPG (<name>-rw/-ro/-r) and Strimzi
+  # (<name>-kafka-bootstrap/-brokers) synthesise from their CRs. There is NO hand-kept list of
+  # service names in the checker: a gate whose scope is maintained separately from the artifacts
+  # it covers reads as PASSING when the list is short, never as unchecked.
+  asserts_against_parsed_yaml_not_file_text: true
+  # A whole-file grep cannot tell config from the prose ABOUT config, and this repo has been burnt
+  # in both directions (#2450 flagged the comment explaining the bug; #3072 matched the comment
+  # above the line it was asserting on, so deleting the line stayed green). The checker reads
+  # yaml.safe_load_all output, which drops comments by construction, and --self-test pins it with
+  # a fixture whose only bogus host is in a comment.
+  #
+  # ADVISORY while the 6 pre-existing findings are triaged. All six are bare `openbank-<svc>` rest
+  # client defaults (account, card-issuance, onboarding, settlement) that name no Service in any
+  # namespace — the deployed pods override them by env, so they are dead defaults rather than a
+  # live outage, but each is a hostname nobody could dial. They are NOT fixed in the PR that
+  # introduced this gate: four of the owning services are money-path, so a default-URL change
+  # there needs the two-approval path rather than riding along with a CI guard.
+  enforced: advisory
+  target_enforce_date: "2026-10-31"   # ADR-0144
+  ci_producer: .github/scripts/check-incluster-hostnames.py
+
 kafka_dotted_keys:
   # SmallRye Config's YAML source quotes any leaf map key containing a literal dot, so
   # `group.id: foo` under `mp.messaging.incoming.<channel>:` registers as the property


### PR DESCRIPTION
## What and why

Two of the three blockers on the `openbank-analytics-sink` schema-registry path (#1916). The third — no producer registers an Avro artifact — is out of scope and keeps the issue open.

### 1. The coordinates were wrong in the prose *and* in the value

`openbank-analytics-sink/src/main/resources/application.yaml` said the registry was *"provisioned in openbank-infra as service schema-registry:8081"* and defaulted `ANALYTICS_SCHEMA_APICURIO_URL` to `http://localhost:8081`.

The registry is Service `apicurio-registry` on port **8080** in namespace **messaging**, deployed by the `apicurio` ArgoCD Application (`gitops/components/apicurio/registry.yaml`). Wrong host and wrong port, stated twice.

Now `http://apicurio-registry.messaging.svc:8080`, with the comment describing the real Service. The `${ENV:default}` override shape is unchanged.

I used the `.svc` form rather than `.svc.cluster.local` — the same Service either way, but it is the dominant form in this fleet and `gen-network-policies.py`'s `URL_RE` only captures the **port** from the `.svc:<port>` shape.

### 2. The NetworkPolicy would have dropped the call — fixed via the generator, not the artifact

`components/apicurio/network-policies.yaml` is derived (`openbank.io/derived: gen-network-policies`), so I edited the **generator input**: the analytics-sink Deployment now declares `ANALYTICS_SCHEMA_APICURIO_URL` in its `env`.

That is load-bearing, not cosmetic. `gen-network-policies.py` derives cross-namespace edges from Deployment env URLs **and nothing else** — a URL living only in `application.yaml` produces no edge at all, so `analytics` would have been absent from the allow-list and the VPC CNI agent (standard mode, ADR-0060) would have dropped the call with no manifest error and no policy diff.

Re-running the generator produced exactly one derived change: `analytics` added to the `:8080` rule.

### Not done on purpose

`ANALYTICS_SCHEMA_BACKEND` is **not** flipped. That is a rollout decision. No producer registers an artifact yet, so the catalogue would come back empty and — with `ANALYTICS_SCHEMA_STRICT` unset — the F7 gate would accept everything while appearing to have a registry behind it.

## The conceptual half: a new gate

An in-cluster hostname in `application.yaml` is unfalsifiable by every test layer this repo has. The unit test stubs the client, the IT serves localhost, a consumer pact never sends the host. That is the same shape as the fx-service CNB URL that was a 404 for the life of the service.

`check-incluster-hostnames.py` (gate `incluster-hostname-resolution`, group `gitops`) resolves every in-cluster hostname in a service `application.yaml` against the Services gitops declares. It needs no cluster: the set of names that *can* resolve is fully declared in `openbank-infra/gitops/`.

Design points it holds to:

- **No second copy of any hostname.** Both sides are read from committed files. There is no list in the script to update when a service is renamed or moved.
- **The known set is derived**, not hand-written: `kind: Service`, plus the endpoints CNPG (`<name>-rw/-ro/-r`) and Strimzi (`<name>-kafka-bootstrap/-brokers`) synthesise from their CRs.
- **Asserts against the parsed YAML value, never file text.** PyYAML drops comments, so the code-about-code collision is handled by construction rather than by a strip-pass that can be got wrong. A self-test case pins it: a fixture whose only bogus host is in a `#` comment must not be flagged.
- **Conservative matching.** `*.svc`, `*.svc.cluster.local`, `<name>.<ns>` where the namespace is one gitops declares, and bare single-label names *in a `scheme://` URL position*. Never `localhost`, `127.0.0.1`, IP literals, or external hosts.

### Falsification

`--self-test` drives 19 cases in both directions. I did not stop at "it passes":

- The self-test **caught a real bug in my own regex** before this was ever committed. My first `SCHEME_HOST` lookbehind excluded `:`, so it silently matched nothing inside `${VAR:http://host:8080}` — the single most common shape in this fleet. It reported clean while checking almost nothing.
- I then broke the gate in place twice, from a `cp` backup (never `reset --hard`), and confirmed the self-test goes **red** each time:
  - making the resolution check vacuous, 5 assertions fail;
  - reading raw file text instead of the parsed value, the comment case and the CORS case fail, i.e. it flags a host that exists only in a comment.
- Known-positive on the **real** file: injecting a one-word typo into the line this PR fixes (`messaging` to `analytics`) makes the gate report it. So the corrected hostname is now falsifiable, which it was not before.

### Findings: 6 — hence `mode: advisory`

Registered in `rules.yaml: incluster_hostnames` with `target_enforce_date: 2026-10-31`, as the gates.yaml contract requires.

All six are bare `openbank-<svc>` rest-client defaults naming no Service in any namespace:

| Service | Key | Host |
|---|---|---|
| account-service | `quarkus.rest-client.sanctions-service.url` | `openbank-sanctions-service` |
| account-service | `quarkus.rest-client.product-catalog-api.url` | `openbank-product-catalog` |
| card-issuance-service | `quarkus.rest-client.product-catalog-api.url` | `openbank-product-catalog` |
| onboarding-service | `quarkus.rest-client.party-service.url` | `openbank-party-service` |
| settlement-service | `quarkus.rest-client.balance-api.url` | `openbank-balance-service` |
| settlement-service | `quarkus.rest-client.ledger-api.url` | `openbank-ledger-service` |

The deployed pods override these by env, so they are dead defaults rather than a live outage — but each is a hostname nobody could dial. **Not fixed here:** four of the owning services are money-path, so that needs the two-approval path rather than riding along with the guard that found it.

## Honest self-assessment — what this gate does NOT catch

Written down rather than claimed complete.

1. **It would not have caught the original #1916 defect.** The pre-fix default was `http://localhost:8081`, and localhost is explicitly never flagged. What the gate protects is the *corrected* value going forward. The wrong-host-in-a-comment half is invisible to it by design — that is the deliberate trade for not flagging prose. I consider this the most important limitation here.
2. **The corroboration tier is a real hole.** Helm-chart Services (`temporal-frontend`, `prometheus-operated`, `alertmanager-operated`) exist but have no `kind: Service` in this repo, so the known set is widened with hosts already named in a gitops workload env. That means **a host wrong in `application.yaml` and wrong the same way in the gitops env is a false green.** I chose this over a hand-written exception list, which this repo has repeatedly found rots into a gate that reads as passing when the list is short.
3. **Bare names are resolved namespace-insensitively.** `http://foo:8080` passes if a Service named `foo` exists in *any* namespace. A cross-namespace bare name that cannot actually resolve from the caller's namespace is a false green. Tightening this needs a module-to-namespace mapping that is not textually derivable today.
4. **Ports are not checked at all.** Only the hostname. `apicurio-registry.messaging.svc:9999` passes. Half the #1916 defect *was* the port, so this is a genuine gap and the obvious next increment.
5. **Single-label `host:port` with no scheme is skipped**, so `kafka:9092` in a `bootstrap.servers` list is not examined. Needed to avoid flagging docker-compose/dev-services defaults; the cost is a blind spot in Kafka client config.
6. **`quarkus.http.cors.origins` is exempt.** A CORS origin is a browser `Origin` string comparison, not a host the process dials. Three services list `http://openbank-admin-ui:3000` there, which is dead config of a *different* kind — reporting it alongside rest-client URLs would be a category error. Worth its own follow-up.
7. **Scope is `*/src/main/resources/application.yaml` only.** Profile-specific files, Kotlin `@ConfigProperty` defaults, and gitops env values themselves are not scanned.

## Other

- Editing `rules.yaml` restamped all 40 OPA bundle generators (70 files). Regenerated as the **last** step before pushing, after the rebase onto current `main` — verified the embedded `rules-data.yaml` parses equal to the real `rules.yaml`, rather than trusting the generators' exit code.
- Stale comment spotted but **not** touched (different concern, #686): `analytics-sink`'s `application.yaml` says *"This service has NO gitops manifest yet (never deployed)"*, while `gitops/components/analytics/analytics-sink.yaml` is a live Deployment with the `group.id` override ConfigMap that comment asks someone to create.

## Linked issues

Refs #1916
