### PR TITLE
feat(gitops): the ESO cert-reader grant is now derived-checked, not hand-kept

### DIFF
--- a/.github/gates/gates.yaml
+++ b/.github/gates/gates.yaml
@@ -971,6 +971,28 @@ gates:
     run: |
       python3 .github/scripts/check-opa-sidecar-bundle-shape.py --enforce
 
+  # campaign-service's rollout died on `secrets "campaign-service" is forbidden` (#2872/#2851):
+  # the ESO cert-reader Role grants by resourceNames, a HAND-KEPT list, and adding a service to
+  # the fleet means editing it while nothing says so. Four of that rollout's five boot failures
+  # were pure repo-internal contradictions — two artifacts in this tree disagreeing, with nothing
+  # comparing them.
+  #
+  # Derived, not declared: the required set comes from the ExternalSecrets that actually read the
+  # kafka cert store, which is why it needs NO exception list — openbank-cluster-cluster-ca-cert
+  # is read by 30 of them and is not a KafkaUser, so a KafkaUser-based rule would have needed an
+  # allowlist entry, the very construct this retires.
+  #
+  # ENFORCED: 38 read, 38 granted, zero drift in either direction at registration. Proven against
+  # the real tree by deleting one entry and watching it reproduce the exact production message.
+  - id: kafka-cert-reader-grant
+    name: "ESO cert-reader grant covers what ExternalSecrets read (#2872, enforced)"
+    group: gitops
+    mode: enforced
+    selftest: |
+      python3 .github/scripts/check-kafka-cert-reader-grant.py --self-test
+    run: |
+      python3 .github/scripts/check-kafka-cert-reader-grant.py --enforce
+
   - id: compliance-matrix
     name: "compliance-page evidence citations (#2370, enforced)"
     group: registry

--- a/.github/scripts/check-kafka-cert-reader-grant.py
+++ b/.github/scripts/check-kafka-cert-reader-grant.py
@@ -1,0 +1,217 @@
+#!/usr/bin/env python3
+# SPDX-License-Identifier: Apache-2.0
+"""The ESO cert-reader grant must cover exactly the secrets ExternalSecrets actually read.
+
+WHY THIS EXISTS
+---------------
+Rolling campaign-service into the sandbox hit five independent boot failures, all on `main` with
+every required check green (#2872). The first was:
+
+    secrets "campaign-service" is forbidden
+
+The component declared a `KafkaUser` and an `ExternalSecret` reading its cert, and the Role that
+lets External Secrets Operator read those secrets — `eso-kafka-cert-reader` in namespace
+`messaging` — grants by `resourceNames`, a HAND-KEPT list. Adding a service to the fleet means
+editing that list, and nothing said so. The pod could not start; nothing in the repo disagreed with
+itself in a way any gate could see, because no gate read the two artifacts together.
+
+That is the recurring shape in this codebase: a gate whose SCOPE is a hand-kept list of the thing it
+covers reads as *passing* when the list is short, never as *unchecked* — the same defect as the pact
+drift scope (#2284) and the Kafka ACL baseline (#2945).
+
+WHAT IT CHECKS — and why it derives rather than declares
+--------------------------------------------------------
+Both directions, against a set DERIVED from the ExternalSecrets themselves:
+
+  required = every `remoteRef.key` (and `dataFrom[].extract.key`) used by an ExternalSecret whose
+             `spec.secretStoreRef.name` is the kafka cert store
+  granted  = the Role's `resourceNames`
+
+  1. required - granted  ⇒ ERROR. This IS the #2851 failure: the workload cannot start.
+  2. granted  - required ⇒ ERROR. A standing grant nobody uses is privilege with no purpose, and a
+     stale entry is how a list stops describing reality.
+
+Deriving from the ExternalSecrets rather than from `KafkaUser` objects is deliberate and is what
+removes the need for an exception list. `openbank-cluster-cluster-ca-cert` is read by 30
+ExternalSecrets and is not a KafkaUser — a KafkaUser-based rule would flag it forever and someone
+would add an allowlist entry, which is the very construct this gate exists to retire. Measured on
+`origin/main` at the time of writing: 38 required, 38 granted, zero drift in either direction, with
+no declared exceptions at all. A rule that needs no exceptions on a real tree is usually the right
+rule.
+
+WHAT IT DOES NOT CHECK
+----------------------
+That the secret exists in the source store, that the ServiceAccount ESO runs as is the one this Role
+is bound to, or that the RoleBinding exists. Those are one layer further out and would need cluster
+state; this compares two artifacts in the tree.
+
+Usage:  check-kafka-cert-reader-grant.py [--enforce] [--self-test]
+"""
+
+from __future__ import annotations
+
+import argparse
+import pathlib
+import sys
+
+import yaml
+
+REPO = pathlib.Path(__file__).resolve().parents[2]
+GITOPS = REPO / "openbank-infra/gitops"
+ROLE_NAME = "eso-kafka-cert-reader"
+STORE_NAME = "kafka-messaging-certs"
+
+
+def documents(root: pathlib.Path):
+    for path in sorted(root.rglob("*.yaml")):
+        try:
+            docs = list(yaml.safe_load_all(path.read_text(encoding="utf-8")))
+        except (yaml.YAMLError, OSError, UnicodeDecodeError):
+            # A manifest this script cannot parse is not this script's finding — `yamllint` and
+            # `Validate manifests` own that. Skipping keeps one broken file from masking the
+            # comparison for every other one.
+            continue
+        for doc in docs:
+            if isinstance(doc, dict):
+                yield path, doc
+
+
+def analyse(root: pathlib.Path) -> tuple[dict[str, str], set[str], bool]:
+    """Return ({required key: the file that reads it}, granted keys, role_found)."""
+    required: dict[str, str] = {}
+    granted: set[str] = set()
+    role_found = False
+
+    for path, doc in documents(root):
+        meta = doc.get("metadata") or {}
+        kind = doc.get("kind")
+
+        if kind == "ExternalSecret":
+            spec = doc.get("spec") or {}
+            if ((spec.get("secretStoreRef") or {}).get("name")) != STORE_NAME:
+                continue
+            rel = str(path.relative_to(REPO)) if path.is_relative_to(REPO) else str(path)
+            for item in spec.get("data") or []:
+                key = (item.get("remoteRef") or {}).get("key")
+                if key:
+                    required.setdefault(key, rel)
+            for item in spec.get("dataFrom") or []:
+                key = (item.get("extract") or {}).get("key")
+                if key:
+                    required.setdefault(key, rel)
+
+        elif kind == "Role" and meta.get("name") == ROLE_NAME:
+            role_found = True
+            for rule in doc.get("rules") or []:
+                if "secrets" in (rule.get("resources") or []) and rule.get("resourceNames"):
+                    granted |= set(rule["resourceNames"])
+
+    return required, granted, role_found
+
+
+def findings(root: pathlib.Path = GITOPS) -> list[str]:
+    required, granted, role_found = analyse(root)
+
+    if not role_found:
+        # Never silently pass on a missing Role: an absent grant list and an empty one look the
+        # same from a set difference, and "0 findings" would be the most dangerous possible answer.
+        return [f"the Role {ROLE_NAME} was not found under {root} — this gate cannot compare "
+                f"anything, and its silence would mean nothing. Did it move or get renamed?"]
+    if not required:
+        return [f"no ExternalSecret referencing secretStoreRef {STORE_NAME} was found — either the "
+                f"store was renamed or the scan is broken. Not reporting a clean run on that."]
+
+    out = []
+    for key in sorted(set(required) - granted):
+        out.append(
+            f"{key} is read by an ExternalSecret ({required[key]}) but is NOT in "
+            f"{ROLE_NAME}'s resourceNames. External Secrets Operator will be refused with "
+            f"'secrets \"{key}\" is forbidden' and the workload will not start (#2872/#2851)."
+        )
+    for key in sorted(granted - set(required)):
+        out.append(
+            f"{key} is granted by {ROLE_NAME} but no ExternalSecret reads it. Either the "
+            f"ExternalSecret was removed and the grant was not, or the name drifted — a standing "
+            f"grant nobody uses is privilege with no purpose."
+        )
+    return out
+
+
+def selftest() -> int:
+    """Build fixture trees the rules MUST flag and MUST NOT, and run the real analysis on them."""
+    import tempfile
+
+    def tree(dirpath: pathlib.Path, reads: list[str], grants: list[str], role: bool = True) -> None:
+        dirpath.mkdir(parents=True, exist_ok=True)
+        for i, key in enumerate(reads):
+            (dirpath / f"es-{i}.yaml").write_text(yaml.safe_dump({
+                "apiVersion": "external-secrets.io/v1", "kind": "ExternalSecret",
+                "metadata": {"name": f"es-{i}", "namespace": "messaging"},
+                "spec": {"secretStoreRef": {"name": STORE_NAME},
+                         "data": [{"remoteRef": {"key": key}}]},
+            }), encoding="utf-8")
+        if role:
+            (dirpath / "role.yaml").write_text(yaml.safe_dump({
+                "apiVersion": "rbac.authorization.k8s.io/v1", "kind": "Role",
+                "metadata": {"name": ROLE_NAME, "namespace": "messaging"},
+                "rules": [{"apiGroups": [""], "resources": ["secrets"],
+                           "verbs": ["get"], "resourceNames": grants}],
+            }), encoding="utf-8")
+
+    cases = [
+        # (label, reads, grants, role present, expected finding count)
+        ("a read with no grant — the #2851 failure", ["a", "b"], ["a"], True, 1),
+        ("a grant nothing reads", ["a"], ["a", "b"], True, 1),
+        ("both drifts at once", ["a", "c"], ["a", "b"], True, 2),
+        ("exact agreement", ["a", "b"], ["a", "b"], True, 0),
+        # The CA cert is not a KafkaUser. A KafkaUser-derived rule would flag it forever; deriving
+        # from the ExternalSecrets means it needs no exception. Pinned so nobody "simplifies" the
+        # derivation back to KafkaUser objects.
+        ("a non-KafkaUser secret both read and granted",
+         ["openbank-cluster-cluster-ca-cert"], ["openbank-cluster-cluster-ca-cert"], True, 0),
+        # An absent Role must be loud. A set difference against an empty grant list would otherwise
+        # report every read as missing, or — if the reads were also empty — report a clean run.
+        ("the Role is missing entirely", ["a"], [], False, 1),
+    ]
+
+    for label, reads, grants, role, want in cases:
+        with tempfile.TemporaryDirectory() as d:
+            root = pathlib.Path(d)
+            tree(root / "components" / "x", reads, grants, role)
+            got = findings(root)
+        if len(got) != want:
+            print(f"selftest FAIL: {label} — expected {want} finding(s), got {len(got)}: {got}")
+            return 1
+
+    # An empty tree must NOT read as clean — that is the shape in which this gate would be green
+    # about a renamed store or a broken scan.
+    with tempfile.TemporaryDirectory() as d:
+        if not findings(pathlib.Path(d)):
+            print("selftest FAIL: an empty tree produced no finding — the gate would pass on nothing.")
+            return 1
+
+    print(f"selftest OK: {len(cases)} fixture(s) covering both drift directions, a non-KafkaUser "
+          f"secret, a missing Role and an empty tree.")
+    return 0
+
+
+def main() -> int:
+    ap = argparse.ArgumentParser()
+    ap.add_argument("--enforce", action="store_true")
+    ap.add_argument("--self-test", action="store_true", dest="self_test")
+    args = ap.parse_args()
+    if args.self_test:
+        return selftest()
+
+    found = findings()
+    for line in found:
+        print(("::error::" if args.enforce else "::warning::") + line)
+    required, granted, _ = analyse(GITOPS)
+    print(f"check-kafka-cert-reader-grant: {len(required)} secret(s) read from {STORE_NAME}, "
+          f"{len(granted)} granted by {ROLE_NAME} — "
+          f"{'clean.' if not found else f'{len(found)} finding(s) above.'}")
+    return 1 if found and args.enforce else 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/openbank-infra/gitops/components/payments/kafka-scheme-accepted-acl.yaml
+++ b/openbank-infra/gitops/components/payments/kafka-scheme-accepted-acl.yaml
@@ -385,6 +385,11 @@ rules:
   - apiGroups: [""]
     resources: [secrets]
     verbs: [get]
+    # DERIVED-CHECKED, not trusted: check-kafka-cert-reader-grant.py (gate
+    # kafka-cert-reader-grant, enforced) compares this list BOTH ways against every
+    # ExternalSecret that reads the kafka cert store. Adding a service without adding it
+    # here is now a build failure rather than a pod that will not start (#2872/#2851);
+    # a grant nothing reads fails too.
     resourceNames:
       - transaction-service
       - sepa-payment


### PR DESCRIPTION
Closes the first of the five boot failures in #2872, and the one whose shape recurs most in this repo.

## What broke

campaign-service's rollout died on:

```
secrets "campaign-service" is forbidden
```

The Role that lets External Secrets Operator read Kafka cert secrets — `eso-kafka-cert-reader` in namespace `messaging` — grants by `resourceNames`, a **hand-kept list**. Adding a service to the fleet means editing it, and nothing said so. The pod could not start; no gate disagreed, because nothing read the two artifacts together.

#2872's own framing: four of the five failures were *pure repo-internal contradictions — two artifacts in this tree disagree, and nothing compares them.*

## Both directions

| drift | consequence |
|---|---|
| read but not granted | the workload does not start — this IS #2851 |
| granted but not read | a standing grant nobody uses is privilege with no purpose, and a stale entry is how a list stops describing reality |

## Derived, not declared — and that is what removes the exception list

The required set comes from the **ExternalSecrets that actually read the kafka cert store**, not from `KafkaUser` objects.

That distinction is the whole design. `openbank-cluster-cluster-ca-cert` is read by 30 ExternalSecrets and is **not** a KafkaUser. A KafkaUser-derived rule would flag it forever, someone would add an allowlist entry — and an allowlist inside a gate whose purpose is to retire a hand-kept list is the failure repeating itself one level up. Pinned as a self-test case so nobody "simplifies" the derivation back.

**38 read, 38 granted, zero drift in either direction, zero declared exceptions.** A rule that needs no exceptions on a real tree is usually the right rule — that agreement is the main evidence the derivation is correct, not my say-so.

Registered `enforced`.

## Proven against the real tree, not only fixtures

Deleting `campaign-service` from the list reproduces the production message verbatim:

```
::error::campaign-service is read by an ExternalSecret
(openbank-infra/gitops/components/campaign/kafka-mtls-externalsecrets.yaml) but is NOT in
eso-kafka-cert-reader's resourceNames. External Secrets Operator will be refused with
'secrets "campaign-service" is forbidden' and the workload will not start (#2872/#2851).
```

Restored from a `cp` backup (never `git reset --hard`), confirmed green again, working tree clean.

The self-test additionally pins the two shapes in which this gate would be **green about nothing** — the failure mode that matters more than any true positive:

- **the Role is missing** — a set difference against an absent grant list looks identical to agreement;
- **an empty tree** — a renamed store or a broken scan would otherwise report a clean run.

Both are findings, not passes.

## The list now says it is checked

Five lines above `resourceNames`, so the next person editing it learns that from the file rather than from an outage. That header was already wrong once tonight in a way that cost production: the same file claimed the broker ran `allow.everyone.if.no.acl.found=true` when it runs `false`, and that false claim is why 13 outbox rows went DEAD.

## Self-assessment — what this does NOT cover

- **One Role, one store.** It is specific to `eso-kafka-cert-reader` / `kafka-messaging-certs`. A second cert-reader Role elsewhere would be invisible. I chose the specific rule over a general "every Role with resourceNames" one because the general version has no derivable required-set and would need exactly the exception list this retires — but that is a trade, not a free win.
- **It stops at the tree.** It does not check that the secret exists in the source store, that the ServiceAccount ESO runs as is the one this Role is bound to, or that the RoleBinding exists. Those need cluster state.
- **The remaining four #2872 defects are untouched** — OPA sidecar shape, missing Redis config, unwired ClickHouse credentials. Item 1 of that issue (probe/scrape port has a listener) is already an enforced gate. I am leaving #2872 open for the rest.
- **A `dataFrom` shape other than `extract.key`** (e.g. `find`) would not be collected. None exists today; if one is added, the failure direction is a false *pass*, which is the bad direction. Worth revisiting if `find` ever appears.

## Verification

```
check-kafka-cert-reader-grant.py --self-test   OK (6 fixtures, both directions + missing Role + empty tree)
check-kafka-cert-reader-grant.py --enforce     clean (38/38)
run-gates.py --only kafka-cert-reader-grant    PASS
run-gates.py --only gate-script-registration   PASS
run-gates.py --group lint                      PASS=4
```
