### PR TITLE
feat(admin-ui): read-only backoffice delegation console (ADR-0230/0232)

### DIFF
--- a/openbank-admin-ui/e2e/delegations-console.spec.ts
+++ b/openbank-admin-ui/e2e/delegations-console.spec.ts
@@ -1,0 +1,221 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright (c) OpenBank contributors. Licensed under the Apache License, Version 2.0.
+// See LICENSE in the repository root or https://www.apache.org/licenses/LICENSE-2.0 for details.
+
+// ADR-0076 Layer 2 — the delegation console end-to-end (ADR-0230 / ADR-0232).
+//
+// Three properties are worth an e2e rather than a route test:
+//   1. the grant list renders from a REAL BFF response (the page, its own route handler and the
+//      upstream shape agreeing — a route test proves only the middle one),
+//   2. party lookup goes through the ADR-0228 entity-resolution facade, never a UUID field,
+//   3. there is NO direct mutation path — asserted by watching the wire, not by reading source.
+//
+// Only the CLUSTER hop is stubbed (page.route intercepts the browser's call to admin-ui's own
+// BFF); the BFF handlers themselves are the real ones running in `next dev`.
+
+import { test, expect, type Page } from '@playwright/test'
+import { signInAsOperator } from './helpers/auth'
+
+const PARTY = '018f4a3c-1b2d-7e00-9a11-000000000001'
+const GRANTEE = '018f4a3c-1b2d-7e00-9a11-0000000000ff'
+const GRANT = '018f4a3c-1b2d-7e00-9a11-000000000002'
+const RESOURCE = '018f4a3c-1b2d-7e00-9a11-000000000003'
+
+const GRANT_ROW = {
+  id: GRANT,
+  grantorPartyId: PARTY,
+  granteePartyId: GRANTEE,
+  resourceType: 'ACCOUNT',
+  resourceId: RESOURCE,
+  capabilities: ['ACCOUNT_READ_BALANCES', 'ACCOUNT_INITIATE_PAYMENT'],
+  approvalPolicy: 'SOLO',
+  perTransactionLimit: { amount: 5000, currency: 'CZK' },
+  validFrom: '2026-01-01T00:00:00Z',
+  validTo: null,
+  status: 'ACTIVE',
+  createdAt: '2026-01-01T00:00:00Z',
+  updatedAt: '2026-01-01T00:00:00Z',
+}
+
+/** Stubs admin-ui's own BFF surface. Returns every request path the page actually issued. */
+async function stubBff(page: Page): Promise<string[]> {
+  const seen: string[] = []
+
+  await page.route('**/api/entities/resolve**', route => {
+    seen.push(route.request().url())
+    return route.fulfill({
+      status: 200,
+      contentType: 'application/json',
+      body: JSON.stringify({
+        results: [{ type: 'party', id: PARTY, label: 'Jan Novák', sublabel: 'NATURAL · ACTIVE', route: `/parties/${PARTY}` }],
+      }),
+    })
+  })
+
+  await page.route('**/api/delegations/**', route => {
+    const req = route.request()
+    seen.push(`${req.method()} ${new URL(req.url()).pathname}`)
+    const path = new URL(req.url()).pathname
+
+    if (path.endsWith('/projection-health')) {
+      return route.fulfill({
+        status: 200,
+        contentType: 'application/json',
+        body: JSON.stringify({
+          topic: 'openbank.delegation.events',
+          state: 'ok',
+          consumers: [{ groupId: 'account-service-delegation', state: 'STABLE', lag: 0, members: 1 }],
+        }),
+      })
+    }
+    if (path.includes('/party/')) {
+      return route.fulfill({
+        status: 200,
+        contentType: 'application/json',
+        body: JSON.stringify({
+          partyId: PARTY,
+          granted: [GRANT_ROW],
+          received: [],
+          sources: { granted: 'ok', received: 'ok' },
+        }),
+      })
+    }
+    // grant detail
+    return route.fulfill({ status: 200, contentType: 'application/json', body: JSON.stringify(GRANT_ROW) })
+  })
+
+  // party-service label resolution behind EntityChip (via the /api/svc proxy).
+  await page.route('**/api/svc/party-service/**', route =>
+    route.fulfill({ status: 200, contentType: 'application/json', body: JSON.stringify({ legalName: 'Petr Delegát' }) }),
+  )
+
+  return seen
+}
+
+test.beforeEach(async ({ context, baseURL }) => {
+  await signInAsOperator(context, baseURL!)
+})
+
+test('finds a party through entity resolution and renders its grants', async ({ page }) => {
+  const seen = await stubBff(page)
+  await page.goto('/delegations')
+
+  // ADR-0231: the operator types a NAME. There is no UUID field on this screen.
+  await page.getByRole('textbox', { name: /Hledat stranu|Search party/ }).fill('Novák')
+  await page.getByRole('button', { name: /Vyhledat|Search/ }).click()
+
+  await page.getByRole('button', { name: /Jan Novák/ }).click()
+
+  const main = page.locator('main')
+  await expect(main.getByText('ACCOUNT_READ_BALANCES, ACCOUNT_INITIATE_PAYMENT')).toBeVisible()
+  await expect(main.getByText('5 000 CZK')).toBeVisible()
+  await expect(main.getByText('ACTIVE').first()).toBeVisible()
+
+  // The grant list came through the console's own BFF route, and party lookup through the
+  // shared ADR-0228 facade — not a bespoke search endpoint.
+  expect(seen.some(s => s.includes('/api/entities/resolve'))).toBe(true)
+  expect(seen.some(s => s === `GET /api/delegations/party/${PARTY}`)).toBe(true)
+})
+
+test('a refused direction never renders as "no delegations"', async ({ page }) => {
+  await stubBff(page)
+  await page.unroute('**/api/delegations/**')
+  await page.route('**/api/delegations/**', route => {
+    const path = new URL(route.request().url()).pathname
+    if (path.endsWith('/projection-health')) {
+      return route.fulfill({ status: 200, contentType: 'application/json', body: JSON.stringify({ consumers: [], state: 'unavailable' }) })
+    }
+    return route.fulfill({
+      status: 200,
+      contentType: 'application/json',
+      body: JSON.stringify({ partyId: PARTY, granted: [], received: [], sources: { granted: 'forbidden', received: 'ok' } }),
+    })
+  })
+
+  await page.goto('/delegations')
+  await page.getByRole('textbox', { name: /Hledat stranu|Search party/ }).fill('Novák')
+  await page.getByRole('button', { name: /Vyhledat|Search/ }).click()
+  await page.getByRole('button', { name: /Jan Novák/ }).click()
+
+  const main = page.locator('main')
+  await expect(main.getByText(/nebyl povolen|was refused for your role/)).toBeVisible()
+  // The dangerous wrong answer must NOT be on screen for the refused direction.
+  await expect(main.getByText(/Žádné delegace\.|No delegations\./)).toHaveCount(1)
+})
+
+test('the grant detail offers NO mutation — suspend, reinstate and revoke are absent from the wire', async ({ page }) => {
+  const seen = await stubBff(page)
+
+  // Watch the DELEGATION surface specifically, not every /api/** call. A blanket watch also
+  // catches the app's own error-reporting beacon (`POST /api/2/envelope/`, Sentry/GlitchTip),
+  // which has nothing to do with delegated access — and a test that fails on unrelated
+  // telemetry would get "fixed" by loosening the assertion until it no longer tests anything.
+  // The invariant is: nothing this console does may mutate a delegation.
+  const mutations: string[] = []
+  await page.route('**/api/**', async route => {
+    const req = route.request()
+    const path = new URL(req.url()).pathname
+    const isDelegationSurface = path.includes('/api/delegations') || path.includes('delegation-service')
+    if (isDelegationSurface && ['POST', 'PUT', 'PATCH', 'DELETE'].includes(req.method())) {
+      mutations.push(`${req.method()} ${path}`)
+    }
+    await route.fallback()
+  })
+
+  await page.goto(`/delegations/${GRANT}`)
+
+  const main = page.locator('main')
+  await expect(main.getByText(/Zásahy banky|Bank-side actions/)).toBeVisible()
+  await expect(main.getByText(/nejdou|not available from this console/)).toBeVisible()
+
+  // No control anywhere on the page offers the bank-side mutations.
+  await expect(page.getByRole('button', { name: /Pozastavit|Suspend/ })).toHaveCount(0)
+  await expect(page.getByRole('button', { name: /Obnovit platnost|Reinstate/ })).toHaveCount(0)
+  await expect(page.getByRole('button', { name: /Odvolat|Revoke/ })).toHaveCount(0)
+
+  // And nothing was written on load. The ONLY non-GET this console may ever issue is the
+  // side-effect-free coverage probe, which needs an explicit click.
+  expect(mutations).toEqual([])
+  expect(seen.some(s => s.includes('/suspend') || s.includes('/reinstate'))).toBe(false)
+
+  // Known-positive: prove the watcher above can actually SEE a delegation mutation. Without
+  // this, narrowing its filter to the delegation surface could have made it match nothing, and
+  // an empty `mutations` array would mean "the probe is broken", not "the console is clean" —
+  // indistinguishable from the assertion passing for the right reason.
+  await page.evaluate(() =>
+    fetch('/api/delegations/00000000-0000-0000-0000-000000000000/suspend', { method: 'POST' }).catch(() => {}),
+  )
+  await expect.poll(() => mutations).toEqual([
+    'POST /api/delegations/00000000-0000-0000-0000-000000000000/suspend',
+  ])
+})
+
+test('the coverage probe asks the authority and shows its reason code', async ({ page }) => {
+  await stubBff(page)
+  await page.unroute('**/api/delegations/**')
+
+  const posted: string[] = []
+  await page.route('**/api/delegations/**', route => {
+    const req = route.request()
+    const path = new URL(req.url()).pathname
+    if (req.method() === 'POST' && path.endsWith('/check')) {
+      posted.push(String(req.postData()))
+      return route.fulfill({
+        status: 200,
+        contentType: 'application/json',
+        body: JSON.stringify({ granted: false, reason: 'per-transaction ceiling exceeded', code: 'CEILING_EXCEEDED' }),
+      })
+    }
+    return route.fulfill({ status: 200, contentType: 'application/json', body: JSON.stringify(GRANT_ROW) })
+  })
+
+  await page.goto(`/delegations/${GRANT}`)
+  await page.getByRole('textbox', { name: /Částka k ověření|Amount to probe/ }).fill('9000')
+  await page.getByRole('button', { name: /^(Ověřit|Probe)$/ }).click()
+
+  const main = page.locator('main')
+  await expect(main.getByText(/Zamítnuto|Denied/)).toBeVisible()
+  await expect(main.getByText('CEILING_EXCEEDED')).toBeVisible()
+  expect(posted).toHaveLength(1)
+  expect(JSON.parse(posted[0]).amount).toEqual({ amount: 9000, currency: 'CZK' })
+})

--- a/openbank-admin-ui/src/app/api/delegations/[id]/route.ts
+++ b/openbank-admin-ui/src/app/api/delegations/[id]/route.ts
@@ -1,0 +1,58 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright (c) OpenBank contributors. Licensed under the Apache License, Version 2.0.
+// See LICENSE in the repository root or https://www.apache.org/licenses/LICENSE-2.0 for details.
+
+// ADR-0230 + ADR-0232: single-grant detail read for the console's grant page.
+//
+// GET only. delegation-service exposes DELETE /{id} (revoke) on this same path, and this route
+// deliberately does not implement it — see src/test/delegations-no-mutation.guard.test.ts for
+// the enforced invariant and the PR body for why the mutation half is not shippable yet.
+//
+// See ../party/[partyId]/route.ts for why X-Customer-Party-Id is not sent.
+
+import { NextResponse } from 'next/server'
+import { auth } from '@/auth'
+import { serverSvcUrl } from '@/lib/services/bff'
+
+export const dynamic = 'force-dynamic'
+
+const UUID_RE = /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i
+const TIMEOUT_MS = 4000
+
+export async function GET(
+  _req: Request,
+  { params }: { params: Promise<{ id: string }> },
+) {
+  const session = await auth()
+  if (!session?.user?.accessToken) {
+    return NextResponse.json({ error: 'unauthenticated' }, { status: 401 })
+  }
+
+  const { id } = await params
+  if (!UUID_RE.test(id)) {
+    return NextResponse.json({ error: 'invalid_delegation_id' }, { status: 400 })
+  }
+
+  try {
+    const res = await fetch(
+      serverSvcUrl('delegation-service', 'delegation', 8126, `/api/v1/delegations/${id}`),
+      {
+        headers: { authorization: `Bearer ${session.user.accessToken}` },
+        signal: AbortSignal.timeout(TIMEOUT_MS),
+        cache: 'no-store',
+      },
+    )
+    if (res.status === 404) {
+      return NextResponse.json({ error: 'not_found' }, { status: 404 })
+    }
+    if (!res.ok) {
+      // Never relay the upstream body — it may carry internal detail, and the console only
+      // needs to tell "refused" apart from "broken" to pick its empty state.
+      const status = res.status === 401 || res.status === 403 ? 403 : 502
+      return NextResponse.json({ error: status === 403 ? 'forbidden' : 'upstream_error' }, { status })
+    }
+    return NextResponse.json(await res.json())
+  } catch {
+    return NextResponse.json({ error: 'upstream_unreachable' }, { status: 502 })
+  }
+}

--- a/openbank-admin-ui/src/app/api/delegations/check/route.ts
+++ b/openbank-admin-ui/src/app/api/delegations/check/route.ts
@@ -1,0 +1,88 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright (c) OpenBank contributors. Licensed under the Apache License, Version 2.0.
+// See LICENSE in the repository root or https://www.apache.org/licenses/LICENSE-2.0 for details.
+
+// ADR-0230 + ADR-0232: the coverage probe. "Does any live grant let party X do capability C on
+// resource R (optionally for amount A)?" — the same question account-service and card-issuance
+// ask before honouring a delegated action, asked from the operator console.
+//
+// This is a POST that CHANGES NOTHING: delegation-service's /check is a pure evaluation over
+// existing grants (DelegationCheckResult -> {granted, reason, code}), POST only because the
+// query is a structured body. It is therefore not a mutation path, and the no-mutation guard
+// (src/test/delegations-no-mutation.guard.test.ts) knows it by upstream path, not by HTTP verb.
+//
+// Why it earns its place on a read-only console: a grant list shows what EXISTS, not what the
+// enforcement point CONCLUDES. Ceilings, expiry, status and capability interact, so an operator
+// answering "could this delegate really have made that payment?" from the list is guessing.
+// This asks the authority directly and shows its own reason code.
+
+import { NextResponse } from 'next/server'
+import { auth } from '@/auth'
+import { serverSvcUrl } from '@/lib/services/bff'
+
+export const dynamic = 'force-dynamic'
+
+const UUID_RE = /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i
+const TIMEOUT_MS = 4000
+
+type CheckBody = {
+  granteePartyId?: unknown
+  resourceType?: unknown
+  resourceId?: unknown
+  capability?: unknown
+  amount?: { amount?: unknown; currency?: unknown } | null
+}
+
+export async function POST(req: Request) {
+  const session = await auth()
+  if (!session?.user?.accessToken) {
+    return NextResponse.json({ error: 'unauthenticated' }, { status: 401 })
+  }
+
+  let body: CheckBody
+  try {
+    body = (await req.json()) as CheckBody
+  } catch {
+    return NextResponse.json({ error: 'invalid_body' }, { status: 400 })
+  }
+
+  const { granteePartyId, resourceType, resourceId, capability, amount } = body
+  if (
+    typeof granteePartyId !== 'string' || !UUID_RE.test(granteePartyId) ||
+    typeof resourceId !== 'string' || !UUID_RE.test(resourceId) ||
+    typeof resourceType !== 'string' || !resourceType ||
+    typeof capability !== 'string' || !capability
+  ) {
+    return NextResponse.json({ error: 'invalid_body' }, { status: 400 })
+  }
+
+  // Forward a re-built body, never the caller's object: an unvalidated passthrough would let a
+  // console user smuggle extra fields straight into the authority's request DTO.
+  const upstream: Record<string, unknown> = { granteePartyId, resourceType, resourceId, capability }
+  if (amount && typeof amount.amount === 'number' && typeof amount.currency === 'string') {
+    upstream.amount = { amount: amount.amount, currency: amount.currency }
+  }
+
+  try {
+    const res = await fetch(
+      serverSvcUrl('delegation-service', 'delegation', 8126, '/api/v1/delegations/check'),
+      {
+        method: 'POST',
+        headers: {
+          authorization: `Bearer ${session.user.accessToken}`,
+          'content-type': 'application/json',
+        },
+        body: JSON.stringify(upstream),
+        signal: AbortSignal.timeout(TIMEOUT_MS),
+        cache: 'no-store',
+      },
+    )
+    if (!res.ok) {
+      const status = res.status === 401 || res.status === 403 ? 403 : 502
+      return NextResponse.json({ error: status === 403 ? 'forbidden' : 'upstream_error' }, { status })
+    }
+    return NextResponse.json(await res.json())
+  } catch {
+    return NextResponse.json({ error: 'upstream_unreachable' }, { status: 502 })
+  }
+}

--- a/openbank-admin-ui/src/app/api/delegations/party/[partyId]/route.ts
+++ b/openbank-admin-ui/src/app/api/delegations/party/[partyId]/route.ts
@@ -1,0 +1,80 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright (c) OpenBank contributors. Licensed under the Apache License, Version 2.0.
+// See LICENSE in the repository root or https://www.apache.org/licenses/LICENSE-2.0 for details.
+
+// ADR-0230 (hybrid consoles) + ADR-0232 (delegated access): the read half of the backoffice
+// delegation console. One BFF call answers "what has this party shared, and what has been
+// shared with them" by fanning out to delegation-service's two list endpoints.
+//
+// The two directions are reported SEPARATELY (`sources`), never merged into one silent list:
+// "this party has no grants" and "the grantor read was refused" look identical in a flat array,
+// and on a rights-management screen the wrong one of those is the dangerous one — an operator
+// investigating a fraud report would conclude nobody holds rights over the account.
+//
+// X-Customer-Party-Id is deliberately NOT sent. That header is customer-edge's IDOR guard for
+// customer-scoped calls; delegation-service refuses any operation whose claimed party differs
+// from it. An operator console is gated by role + OPA instead (the header's own contract says
+// "absent on an operator/back-office call"), so stamping it here would scope every backoffice
+// read to whichever party we guessed and break the console's entire purpose.
+
+import { NextResponse } from 'next/server'
+import { auth } from '@/auth'
+import { serverSvcUrl } from '@/lib/services/bff'
+
+export const dynamic = 'force-dynamic'
+
+const UUID_RE = /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i
+const TIMEOUT_MS = 4000
+
+export type DirectionState = 'ok' | 'forbidden' | 'unavailable'
+
+type DirectionResult = { grants: unknown[]; state: DirectionState }
+
+function stateFor(status: number): DirectionState {
+  return status === 401 || status === 403 ? 'forbidden' : 'unavailable'
+}
+
+async function listGrants(
+  direction: 'grantor' | 'grantee',
+  partyId: string,
+  headers: HeadersInit,
+): Promise<DirectionResult> {
+  const res = await fetch(
+    serverSvcUrl('delegation-service', 'delegation', 8126, `/api/v1/delegations/${direction}/${partyId}`),
+    { headers, signal: AbortSignal.timeout(TIMEOUT_MS), cache: 'no-store' },
+  )
+  if (!res.ok) return { grants: [], state: stateFor(res.status) }
+  const body = await res.json()
+  return { grants: Array.isArray(body) ? body : [], state: 'ok' }
+}
+
+export async function GET(
+  _req: Request,
+  { params }: { params: Promise<{ partyId: string }> },
+) {
+  const session = await auth()
+  if (!session?.user?.accessToken) {
+    return NextResponse.json({ error: 'unauthenticated' }, { status: 401 })
+  }
+
+  // Validate before any upstream call: a malformed id would otherwise be relayed to
+  // delegation-service, whose 404 the console cannot distinguish from "no such grant".
+  const { partyId } = await params
+  if (!UUID_RE.test(partyId)) {
+    return NextResponse.json({ error: 'invalid_party_id' }, { status: 400 })
+  }
+
+  const headers = { authorization: `Bearer ${session.user.accessToken}` }
+  const unavailable: DirectionResult = { grants: [], state: 'unavailable' }
+  const [granted, received] = await Promise.all([
+    listGrants('grantor', partyId, headers).catch(() => unavailable),
+    listGrants('grantee', partyId, headers).catch(() => unavailable),
+  ])
+
+  return NextResponse.json({
+    partyId,
+    granted: granted.grants,
+    received: received.grants,
+    sources: { granted: granted.state, received: received.state },
+  })
+}

--- a/openbank-admin-ui/src/app/api/delegations/projection-health/route.ts
+++ b/openbank-admin-ui/src/app/api/delegations/projection-health/route.ts
@@ -1,0 +1,97 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright (c) OpenBank contributors. Licensed under the Apache License, Version 2.0.
+// See LICENSE in the repository root or https://www.apache.org/licenses/LICENSE-2.0 for details.
+
+// ADR-0230 + ADR-0232: projection health for the delegation console.
+//
+// A grant is minted in delegation-service but ENFORCED by each product service's local
+// projection, fed from openbank.delegation.events. So the console's grant list can say ACTIVE
+// while account-service still refuses the delegate, or — the direction that matters — say
+// REVOKED while a lagging consumer still honours the revoked rights. Consumer-group lag on that
+// topic is the only in-repo signal for that window, so it belongs next to the grants, not on a
+// separate infra page an operator investigating a grant would never open.
+//
+// The consumer set is DERIVED from the topic (Kafka UI's topic-scoped consumer-groups endpoint),
+// never a hand-kept list of service names: a projection added later must show up here without
+// anyone remembering to register it, and a list maintained beside the thing it describes reads
+// as "healthy" exactly when it is incomplete.
+
+import { NextResponse } from 'next/server'
+import { auth } from '@/auth'
+import { inCluster } from '@/lib/discovery'
+
+export const dynamic = 'force-dynamic'
+export const revalidate = 0
+
+export const DELEGATION_TOPIC = 'openbank.delegation.events'
+const TIMEOUT_MS = 4000
+
+function kafkaUiBaseUrl(): string {
+  if (inCluster()) {
+    return process.env.KAFKA_UI_URL ?? 'http://kafka-ui.messaging.svc:8080'
+  }
+  const host = process.env.SERVICES_HOST === 'container' ? 'openbank-kafka-ui' : 'localhost'
+  return `http://${host}:8090`
+}
+
+type KafkaUiCluster = { name: string }
+
+type KafkaUiConsumerGroup = {
+  groupId?: string
+  state?: string
+  consumerLag?: number | null
+  members?: number
+}
+
+export type ProjectionConsumer = {
+  groupId: string
+  state: string | null
+  lag: number | null
+  members: number | null
+}
+
+async function fetchJson<T>(url: string): Promise<T | null> {
+  const res = await fetch(url, { signal: AbortSignal.timeout(TIMEOUT_MS), cache: 'no-store' })
+  if (!res.ok) return null
+  return (await res.json()) as T
+}
+
+export async function GET() {
+  const session = await auth()
+  if (!session?.user?.accessToken) {
+    return NextResponse.json({ error: 'unauthenticated' }, { status: 401 })
+  }
+
+  const base = kafkaUiBaseUrl()
+  try {
+    const clusters = await fetchJson<KafkaUiCluster[]>(`${base}/api/clusters`)
+    if (!clusters?.length) {
+      return NextResponse.json({ topic: DELEGATION_TOPIC, consumers: [], state: 'unavailable' })
+    }
+    const cluster = encodeURIComponent(clusters[0].name)
+
+    const raw = await fetchJson<KafkaUiConsumerGroup[] | { consumerGroups?: KafkaUiConsumerGroup[] }>(
+      `${base}/api/clusters/${cluster}/topics/${encodeURIComponent(DELEGATION_TOPIC)}/consumer-groups`,
+    )
+    if (raw === null) {
+      // Topic absent, or this Kafka UI build does not serve the topic-scoped view. Either way we
+      // do not know the lag — say so rather than rendering an empty, healthy-looking table.
+      return NextResponse.json({ topic: DELEGATION_TOPIC, consumers: [], state: 'unavailable' })
+    }
+
+    const groups = Array.isArray(raw) ? raw : (raw.consumerGroups ?? [])
+    const consumers: ProjectionConsumer[] = groups
+      .filter(g => typeof g.groupId === 'string' && g.groupId.length > 0)
+      .map(g => ({
+        groupId: g.groupId as string,
+        state: g.state ?? null,
+        lag: typeof g.consumerLag === 'number' ? g.consumerLag : null,
+        members: typeof g.members === 'number' ? g.members : null,
+      }))
+      .sort((a, b) => a.groupId.localeCompare(b.groupId))
+
+    return NextResponse.json({ topic: DELEGATION_TOPIC, consumers, state: 'ok' })
+  } catch {
+    return NextResponse.json({ topic: DELEGATION_TOPIC, consumers: [], state: 'unavailable' })
+  }
+}

--- a/openbank-admin-ui/src/app/delegations/[id]/page.tsx
+++ b/openbank-admin-ui/src/app/delegations/[id]/page.tsx
@@ -1,0 +1,244 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright (c) OpenBank contributors. Licensed under the Apache License, Version 2.0.
+// See LICENSE in the repository root or https://www.apache.org/licenses/LICENSE-2.0 for details.
+
+// ADR-0230 + ADR-0232: single-grant detail — capabilities, ceilings, status timeline, and the
+// coverage probe.
+//
+// The bank-side actions (suspend / reinstate / revoke) are stated as UNAVAILABLE in place rather
+// than rendered as disabled buttons. A greyed-out button says "you lack the right"; the true
+// reason is that the platform has nowhere to put the proposal — rules.yaml's own four-eyes
+// assessment for this service records that delegation.suspend "lands via the fraud pipeline, not
+// an operator console, so there is no maker/checker pair to gate yet", and ADR-0230 forbids the
+// direct write that would be the only alternative. Saying that plainly is the honest UI.
+
+'use client'
+
+import { useCallback, useEffect, useState } from 'react'
+import { useParams } from 'next/navigation'
+import Link from 'next/link'
+import { ArrowLeft, ShieldQuestion, Lock } from 'lucide-react'
+import { useLanguage } from '@/lib/i18n/LanguageContext'
+import { classifyBffFailure } from '@/lib/services/bff'
+import { DataUnavailable, type UnavailableKind } from '@/components/feedback/DataUnavailable'
+import { EntityChip } from '@/components/entities/EntityChip'
+import {
+  DelegationStatusBadge,
+  capabilityLabels,
+  formatCeiling,
+  type Grant,
+} from '@/components/delegations/GrantView'
+
+type CheckOutcome = { granted: boolean; reason?: string | null; code?: string | null }
+
+export default function DelegationDetailPage() {
+  const { t, language } = useLanguage()
+  const params = useParams<{ id: string }>()
+  const id = params?.id
+
+  const [grant, setGrant] = useState<Grant | null>(null)
+  const [unavail, setUnavail] = useState<UnavailableKind | null>(null)
+
+  const load = useCallback(async () => {
+    if (!id) return
+    setUnavail(null)
+    try {
+      const res = await fetch(`/api/delegations/${id}`, { cache: 'no-store', signal: AbortSignal.timeout(8000) })
+      if (!res.ok) { setUnavail(await classifyBffFailure(res)); setGrant(null); return }
+      setGrant((await res.json()) as Grant)
+    } catch {
+      setUnavail('unreachable')
+      setGrant(null)
+    }
+  }, [id])
+
+  useEffect(() => { load() }, [load])
+
+  return (
+    <div>
+      <Link href="/delegations" className="btn btn-secondary" style={{ marginBottom: '16px', fontSize: '12px' }}>
+        <ArrowLeft size={14} />
+        {t('Zpět na delegace', 'Back to delegations')}
+      </Link>
+
+      <h1 className="page-title">{t('Detail delegace', 'Delegation detail')}</h1>
+      <p className="page-subtitle">
+        {t(
+          'Udělená práva, stropy a časová osa stavu (ADR-0232).',
+          'Granted rights, ceilings and status timeline (ADR-0232).',
+        )}
+      </p>
+
+      {unavail && (
+        <DataUnavailable
+          kind={unavail}
+          service="delegation-service"
+          feature={t('detail delegace', 'delegation detail')}
+          lang={language}
+        />
+      )}
+
+      {!unavail && grant && (
+        <>
+          <div className="card" style={{ padding: '16px', marginTop: '16px' }}>
+            <dl style={{ display: 'grid', gridTemplateColumns: 'minmax(160px, 240px) 1fr', gap: '10px 16px', fontSize: '13px' }}>
+              <dt style={{ color: 'var(--text-tertiary)' }}>{t('Stav', 'Status')}</dt>
+              <dd><DelegationStatusBadge status={grant.status} /></dd>
+
+              <dt style={{ color: 'var(--text-tertiary)' }}>{t('Udělil', 'Grantor')}</dt>
+              <dd><EntityChip type="party" id={grant.grantorPartyId} /></dd>
+
+              <dt style={{ color: 'var(--text-tertiary)' }}>{t('Obdržel', 'Grantee')}</dt>
+              <dd><EntityChip type="party" id={grant.granteePartyId} /></dd>
+
+              <dt style={{ color: 'var(--text-tertiary)' }}>{t('Typ zdroje', 'Resource type')}</dt>
+              <dd>{grant.resourceType}</dd>
+
+              <dt style={{ color: 'var(--text-tertiary)' }}>{t('Oprávnění', 'Capabilities')}</dt>
+              <dd>{capabilityLabels(grant.capabilities)}</dd>
+
+              <dt style={{ color: 'var(--text-tertiary)' }}>{t('Režim schvalování', 'Approval policy')}</dt>
+              <dd>{grant.approvalPolicy ?? '—'}</dd>
+
+              <dt style={{ color: 'var(--text-tertiary)' }}>{t('Strop na transakci', 'Per-transaction cap')}</dt>
+              <dd>{formatCeiling(grant.perTransactionLimit)}</dd>
+
+              <dt style={{ color: 'var(--text-tertiary)' }}>{t('Denní strop', 'Daily cap')}</dt>
+              <dd>{formatCeiling(grant.dailyLimit)}</dd>
+
+              <dt style={{ color: 'var(--text-tertiary)' }}>{t('Měsíční strop', 'Monthly cap')}</dt>
+              <dd>{formatCeiling(grant.monthlyLimit)}</dd>
+
+              <dt style={{ color: 'var(--text-tertiary)' }}>{t('Platnost od', 'Valid from')}</dt>
+              <dd>{grant.validFrom ?? '—'}</dd>
+
+              <dt style={{ color: 'var(--text-tertiary)' }}>{t('Platnost do', 'Valid until')}</dt>
+              <dd>{grant.validTo ?? t('bez omezení', 'no expiry')}</dd>
+
+              <dt style={{ color: 'var(--text-tertiary)' }}>{t('Vytvořeno', 'Created')}</dt>
+              <dd>{grant.createdAt ?? '—'}</dd>
+
+              <dt style={{ color: 'var(--text-tertiary)' }}>{t('Naposledy změněno', 'Last changed')}</dt>
+              <dd>{grant.updatedAt ?? '—'}</dd>
+
+              <dt style={{ color: 'var(--text-tertiary)' }}>{t('Ukončeno', 'Closed')}</dt>
+              <dd>{grant.closedAt ? `${grant.closedAt} — ${grant.closedReason ?? ''}` : '—'}</dd>
+            </dl>
+          </div>
+
+          <CoverageProbe grant={grant} />
+          <BankSideActions />
+        </>
+      )}
+    </div>
+  )
+}
+
+/**
+ * Asks delegation-service the same question its enforcement points ask. A grant row shows what
+ * exists; only the authority knows how status, ceilings, expiry and capability combine, so an
+ * operator answering "could this delegate really have done that?" from the table is guessing.
+ */
+function CoverageProbe({ grant }: { grant: Grant }) {
+  const { t } = useLanguage()
+  const [capability, setCapability] = useState(grant.capabilities?.[0] ?? '')
+  const [amount, setAmount] = useState('')
+  const [outcome, setOutcome] = useState<CheckOutcome | null>(null)
+  const [failed, setFailed] = useState(false)
+
+  const run = useCallback(async () => {
+    setFailed(false)
+    setOutcome(null)
+    const body: Record<string, unknown> = {
+      granteePartyId: grant.granteePartyId,
+      resourceType: grant.resourceType,
+      resourceId: grant.resourceId,
+      capability,
+    }
+    const parsed = Number(amount)
+    if (amount.trim() !== '' && Number.isFinite(parsed)) {
+      body.amount = { amount: parsed, currency: grant.perTransactionLimit?.currency ?? 'CZK' }
+    }
+    try {
+      const res = await fetch('/api/delegations/check', {
+        method: 'POST',
+        headers: { 'content-type': 'application/json' },
+        body: JSON.stringify(body),
+        signal: AbortSignal.timeout(8000),
+      })
+      if (!res.ok) { setFailed(true); return }
+      setOutcome((await res.json()) as CheckOutcome)
+    } catch {
+      setFailed(true)
+    }
+  }, [grant, capability, amount])
+
+  return (
+    <div className="card" style={{ padding: '16px', marginTop: '16px' }}>
+      <h2 style={{ fontSize: '15px', fontWeight: 700, marginBottom: '2px' }}>
+        <ShieldQuestion size={15} color="var(--accent)" style={{ verticalAlign: 'middle', marginRight: '6px' }} />
+        {t('Ověření pokrytí', 'Coverage probe')}
+      </h2>
+      <p style={{ fontSize: '12px', color: 'var(--text-tertiary)', marginBottom: '12px' }}>
+        {t(
+          'Zeptá se delegační služby na stejnou otázku, jakou klade vynucovací bod. Nic nemění.',
+          'Asks delegation-service the same question the enforcement point asks. Changes nothing.',
+        )}
+      </p>
+
+      <div style={{ display: 'flex', gap: '8px', flexWrap: 'wrap', alignItems: 'center' }}>
+        <select
+          className="input"
+          value={capability}
+          onChange={e => setCapability(e.target.value)}
+          aria-label={t('Oprávnění k ověření', 'Capability to probe')}
+        >
+          {(grant.capabilities ?? []).map(c => <option key={c} value={c}>{c}</option>)}
+        </select>
+        <input
+          className="input"
+          value={amount}
+          onChange={e => setAmount(e.target.value)}
+          placeholder={t('Částka (nepovinné)', 'Amount (optional)')}
+          aria-label={t('Částka k ověření', 'Amount to probe')}
+          style={{ maxWidth: '200px' }}
+        />
+        <button className="btn btn-primary" onClick={run} disabled={!capability}>
+          {t('Ověřit', 'Probe')}
+        </button>
+      </div>
+
+      {failed && (
+        <p style={{ marginTop: '10px', fontSize: '13px', color: 'var(--text-tertiary)' }}>
+          {t('Ověření se teď nepodařilo provést.', 'The probe could not be run right now.')}
+        </p>
+      )}
+
+      {outcome && (
+        <div style={{ marginTop: '12px', fontSize: '13px' }}>
+          <strong>{outcome.granted ? t('Povoleno', 'Allowed') : t('Zamítnuto', 'Denied')}</strong>
+          {outcome.code && <span style={{ marginLeft: '8px', color: 'var(--text-tertiary)' }}>{outcome.code}</span>}
+          {outcome.reason && <div style={{ color: 'var(--text-tertiary)', marginTop: '4px' }}>{outcome.reason}</div>}
+        </div>
+      )}
+    </div>
+  )
+}
+
+function BankSideActions() {
+  const { t } = useLanguage()
+  return (
+    <div className="card" style={{ padding: '16px', marginTop: '16px' }}>
+      <h2 style={{ fontSize: '15px', fontWeight: 700, marginBottom: '2px' }}>
+        <Lock size={15} color="var(--text-tertiary)" style={{ verticalAlign: 'middle', marginRight: '6px' }} />
+        {t('Zásahy banky', 'Bank-side actions')}
+      </h2>
+      <p style={{ fontSize: '13px', color: 'var(--text-tertiary)' }}>
+        {t(
+          'Pozastavení, obnovení a odvolání z této konzole zatím nejdou. Delegační služba pro ně nemá frontu schvalování dvěma osobami a přímý zápis z konzole ADR-0230 zakazuje. Dnes je provádí fraud pipeline; operátorská cesta je samostatný krok.',
+          'Suspend, reinstate and revoke are not available from this console yet. delegation-service has no four-eyes queue for them, and ADR-0230 forbids the direct write that would be the only alternative. The fraud pipeline performs them today; the operator path is a separate piece of work.',
+        )}
+      </p>
+    </div>
+  )
+}

--- a/openbank-admin-ui/src/app/delegations/layout.tsx
+++ b/openbank-admin-ui/src/app/delegations/layout.tsx
@@ -1,0 +1,20 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright (c) OpenBank contributors. Licensed under the Apache License, Version 2.0.
+// See LICENSE in the repository root or https://www.apache.org/licenses/LICENSE-2.0 for details.
+
+import { Sidebar } from "@/components/layout/Sidebar"
+import { Header } from "@/components/layout/Header"
+
+export default function DelegationsLayout({ children }: { children: React.ReactNode }) {
+  return (
+    <div style={{ display: "flex", height: "100vh", overflow: "hidden" }}>
+      <Sidebar />
+      <div style={{ flex: 1, display: "flex", flexDirection: "column", overflow: "hidden" }}>
+        <Header />
+        <main style={{ flex: 1, overflowY: "auto", padding: "24px", background: "var(--bg)" }}>
+          {children}
+        </main>
+      </div>
+    </div>
+  )
+}

--- a/openbank-admin-ui/src/app/delegations/page.tsx
+++ b/openbank-admin-ui/src/app/delegations/page.tsx
@@ -1,0 +1,348 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright (c) OpenBank contributors. Licensed under the Apache License, Version 2.0.
+// See LICENSE in the repository root or https://www.apache.org/licenses/LICENSE-2.0 for details.
+
+// ADR-0230 (hybrid console) + ADR-0232 (delegated access): "grants by party".
+//
+// Party lookup reuses the ADR-0228 entity-resolution facade (/api/entities/resolve) rather than
+// asking the operator for a UUID — ADR-0231 D3 bans raw-UUID navigation, and the facade already
+// resolves parties by business key through party-service's /api/v1/parties/search. This screen
+// therefore never needs its own search endpoint; it consumes the shared one and renders results
+// as entity chips, so a party found here deep-links to the same /parties/{id} page as everywhere
+// else.
+//
+// Read-only by construction. delegation-service's bank-side mutations (suspend / reinstate /
+// revoke) are NOT reachable from this console — there is no maker-checker store for them to land
+// in, and ADR-0230 forbids a direct write. The grant detail page states that in place rather
+// than rendering a button that cannot work.
+
+'use client'
+
+import { useCallback, useState } from 'react'
+import Link from 'next/link'
+import { Search, Share2, RefreshCw, Activity } from 'lucide-react'
+import { useLanguage } from '@/lib/i18n/LanguageContext'
+import { classifyBffFailure, type BffFailure } from '@/lib/services/bff'
+import { DataUnavailable, type UnavailableKind } from '@/components/feedback/DataUnavailable'
+import { EntityChip } from '@/components/entities/EntityChip'
+import {
+  DelegationStatusBadge,
+  capabilityLabels,
+  formatCeiling,
+  type Grant,
+} from '@/components/delegations/GrantView'
+
+type EntityRef = { type: string; id: string; label: string; sublabel?: string }
+
+type DirectionState = 'ok' | 'forbidden' | 'unavailable'
+
+type GrantsPayload = {
+  granted: Grant[]
+  received: Grant[]
+  sources: { granted: DirectionState; received: DirectionState }
+}
+
+type ProjectionConsumer = { groupId: string; state: string | null; lag: number | null; members: number | null }
+
+const SEARCH_MIN = 2
+
+export default function DelegationsPage() {
+  const { t, language } = useLanguage()
+
+  const [term, setTerm] = useState('')
+  const [results, setResults] = useState<EntityRef[]>([])
+  const [searched, setSearched] = useState(false)
+  const [searchFailed, setSearchFailed] = useState(false)
+
+  const [party, setParty] = useState<EntityRef | null>(null)
+  const [grants, setGrants] = useState<GrantsPayload | null>(null)
+  const [grantsUnavail, setGrantsUnavail] = useState<UnavailableKind | null>(null)
+  const [loading, setLoading] = useState(false)
+
+  const [consumers, setConsumers] = useState<ProjectionConsumer[] | null>(null)
+  const [projectionKnown, setProjectionKnown] = useState(true)
+
+  const search = useCallback(async () => {
+    const q = term.trim()
+    if (q.length < SEARCH_MIN) return
+    setSearchFailed(false)
+    setSearched(true)
+    try {
+      const res = await fetch(`/api/entities/resolve?q=${encodeURIComponent(q)}`, {
+        cache: 'no-store',
+        signal: AbortSignal.timeout(6000),
+      })
+      if (!res.ok) { setSearchFailed(true); setResults([]); return }
+      const body = (await res.json()) as { results?: EntityRef[] }
+      setResults((body.results ?? []).filter(r => r.type === 'party'))
+    } catch {
+      setSearchFailed(true)
+      setResults([])
+    }
+  }, [term])
+
+  const loadGrants = useCallback(async (target: EntityRef) => {
+    setParty(target)
+    setLoading(true)
+    setGrantsUnavail(null)
+    setGrants(null)
+    try {
+      const res = await fetch(`/api/delegations/party/${target.id}`, {
+        cache: 'no-store',
+        signal: AbortSignal.timeout(8000),
+      })
+      if (!res.ok) {
+        setGrantsUnavail((await classifyBffFailure(res)) as BffFailure)
+        return
+      }
+      setGrants((await res.json()) as GrantsPayload)
+    } catch {
+      setGrantsUnavail('unreachable')
+    } finally {
+      setLoading(false)
+    }
+
+    try {
+      const res = await fetch('/api/delegations/projection-health', {
+        cache: 'no-store',
+        signal: AbortSignal.timeout(6000),
+      })
+      if (!res.ok) { setProjectionKnown(false); setConsumers(null); return }
+      const body = (await res.json()) as { consumers?: ProjectionConsumer[]; state?: string }
+      setProjectionKnown(body.state === 'ok')
+      setConsumers(body.consumers ?? [])
+    } catch {
+      setProjectionKnown(false)
+      setConsumers(null)
+    }
+  }, [])
+
+  return (
+    <div>
+      <div style={{ display: 'flex', justifyContent: 'space-between', alignItems: 'flex-start', marginBottom: '20px' }}>
+        <div>
+          <h1 className="page-title">
+            <Share2 size={18} color="var(--accent)" />
+            {t('Delegovaný přístup', 'Delegated Access')}
+          </h1>
+          <p className="page-subtitle">
+            {t(
+              'Kdo komu udělil práva k účtu, kartě nebo spoření (ADR-0232). Konzole je pouze pro čtení.',
+              'Who granted whom rights over an account, card or savings goal (ADR-0232). This console is read-only.',
+            )}
+          </p>
+        </div>
+        {party && (
+          <button className="btn btn-secondary" onClick={() => loadGrants(party)} disabled={loading}>
+            <RefreshCw size={14} />
+            {t('Obnovit', 'Refresh')}
+          </button>
+        )}
+      </div>
+
+      {/* ---- party lookup (ADR-0228 facade, never a raw UUID field) ---- */}
+      <div className="card" style={{ padding: '16px', marginBottom: '20px' }}>
+        <label htmlFor="party-search" style={{ display: 'block', fontSize: '13px', fontWeight: 600, marginBottom: '8px' }}>
+          {t('Najít stranu podle jména nebo obchodního klíče', 'Find a party by name or business key')}
+        </label>
+        <div style={{ display: 'flex', gap: '8px' }}>
+          <input
+            id="party-search"
+            className="input"
+            style={{ flex: 1 }}
+            value={term}
+            onChange={e => setTerm(e.target.value)}
+            onKeyDown={e => { if (e.key === 'Enter') search() }}
+            placeholder={t('Jméno strany…', 'Party name…')}
+            aria-label={t('Hledat stranu', 'Search party')}
+          />
+          <button className="btn btn-primary" onClick={search} disabled={term.trim().length < SEARCH_MIN}>
+            <Search size={14} />
+            {t('Vyhledat', 'Search')}
+          </button>
+        </div>
+
+        {searchFailed && (
+          <p style={{ marginTop: '10px', fontSize: '13px', color: 'var(--text-tertiary)' }}>
+            {t(
+              'Vyhledávání stran teď neodpovídá. Zkuste to prosím za chvíli.',
+              'Party search is not responding right now. Please try again shortly.',
+            )}
+          </p>
+        )}
+
+        {searched && !searchFailed && results.length === 0 && (
+          <p style={{ marginTop: '10px', fontSize: '13px', color: 'var(--text-tertiary)' }}>
+            {t('Žádná strana neodpovídá dotazu.', 'No party matches that query.')}
+          </p>
+        )}
+
+        {results.length > 0 && (
+          <div style={{ marginTop: '12px', display: 'flex', flexWrap: 'wrap', gap: '8px' }}>
+            {results.map(r => (
+              <button
+                key={r.id}
+                className="btn btn-secondary"
+                onClick={() => loadGrants(r)}
+                style={{ fontWeight: party?.id === r.id ? 700 : 500 }}
+              >
+                {r.label}
+                {r.sublabel && (
+                  <span style={{ color: 'var(--text-tertiary)', fontWeight: 400, marginLeft: '6px' }}>{r.sublabel}</span>
+                )}
+              </button>
+            ))}
+          </div>
+        )}
+      </div>
+
+      {!party && (
+        <div className="card" style={{ padding: '40px', textAlign: 'center', color: 'var(--text-tertiary)' }}>
+          {t('Vyberte stranu a zobrazte její delegace.', 'Pick a party to see its delegations.')}
+        </div>
+      )}
+
+      {party && grantsUnavail && (
+        <DataUnavailable
+          kind={grantsUnavail}
+          service="delegation-service"
+          feature={t('delegovaný přístup', 'delegated access')}
+          lang={language}
+        />
+      )}
+
+      {party && !grantsUnavail && grants && (
+        <>
+          <GrantTable
+            title={t('Sdíleno touto stranou', 'Shared by this party')}
+            subtitle={t('Práva, která tato strana udělila jiným.', 'Rights this party has granted to others.')}
+            grants={grants.granted}
+            state={grants.sources.granted}
+          />
+          <GrantTable
+            title={t('Sdíleno s touto stranou', 'Shared with this party')}
+            subtitle={t('Práva, která tato strana drží nad cizími zdroji.', 'Rights this party holds over other people’s resources.')}
+            grants={grants.received}
+            state={grants.sources.received}
+          />
+          <ProjectionHealth consumers={consumers} known={projectionKnown} />
+        </>
+      )}
+    </div>
+  )
+}
+
+function GrantTable({
+  title, subtitle, grants, state,
+}: { title: string; subtitle: string; grants: Grant[]; state: DirectionState }) {
+  const { t } = useLanguage()
+
+  return (
+    <div className="card" style={{ padding: '16px', marginBottom: '20px' }}>
+      <h2 style={{ fontSize: '15px', fontWeight: 700, marginBottom: '2px' }}>{title}</h2>
+      <p style={{ fontSize: '12px', color: 'var(--text-tertiary)', marginBottom: '12px' }}>{subtitle}</p>
+
+      {state !== 'ok' ? (
+        <div style={{ padding: '16px', borderRadius: '8px', background: 'var(--surface-3)', fontSize: '13px' }}>
+          {state === 'forbidden'
+            ? t(
+                'Tento pohled vám nebyl povolen — nezaměňujte za „žádné delegace“.',
+                'This view was refused for your role — do not read it as “no delegations”.',
+              )
+            : t(
+                'Tento pohled se teď nepodařilo načíst — nezaměňujte za „žádné delegace“.',
+                'This view could not be loaded right now — do not read it as “no delegations”.',
+              )}
+        </div>
+      ) : grants.length === 0 ? (
+        <div style={{ padding: '16px', color: 'var(--text-tertiary)', fontSize: '13px' }}>
+          {t('Žádné delegace.', 'No delegations.')}
+        </div>
+      ) : (
+        <div style={{ overflowX: 'auto' }}>
+          <table className="table" style={{ width: '100%' }}>
+            <thead>
+              <tr>
+                <th>{t('Stav', 'Status')}</th>
+                <th>{t('Protistrana', 'Counterparty')}</th>
+                <th>{t('Zdroj', 'Resource')}</th>
+                <th>{t('Oprávnění', 'Capabilities')}</th>
+                <th>{t('Strop na transakci', 'Per-transaction cap')}</th>
+                <th>{t('Platnost do', 'Valid until')}</th>
+                <th />
+              </tr>
+            </thead>
+            <tbody>
+              {grants.map(g => (
+                <tr key={g.id}>
+                  <td><DelegationStatusBadge status={g.status} /></td>
+                  <td><EntityChip type="party" id={g.granteePartyId} /></td>
+                  <td style={{ fontSize: '12px' }}>{g.resourceType}</td>
+                  <td style={{ fontSize: '12px' }}>{capabilityLabels(g.capabilities)}</td>
+                  <td style={{ fontSize: '12px' }}>{formatCeiling(g.perTransactionLimit)}</td>
+                  <td style={{ fontSize: '12px' }}>{g.validTo ? g.validTo.slice(0, 10) : '—'}</td>
+                  <td>
+                    <Link href={`/delegations/${g.id}`} className="btn btn-secondary" style={{ fontSize: '12px' }}>
+                      {t('Detail', 'Detail')}
+                    </Link>
+                  </td>
+                </tr>
+              ))}
+            </tbody>
+          </table>
+        </div>
+      )}
+    </div>
+  )
+}
+
+function ProjectionHealth({ consumers, known }: { consumers: ProjectionConsumer[] | null; known: boolean }) {
+  const { t } = useLanguage()
+
+  return (
+    <div className="card" style={{ padding: '16px' }}>
+      <h2 style={{ fontSize: '15px', fontWeight: 700, marginBottom: '2px' }}>
+        <Activity size={15} color="var(--accent)" style={{ verticalAlign: 'middle', marginRight: '6px' }} />
+        {t('Zdraví projekcí', 'Projection health')}
+      </h2>
+      <p style={{ fontSize: '12px', color: 'var(--text-tertiary)', marginBottom: '12px' }}>
+        {t(
+          'Práva vynucují produktové služby z vlastní projekce. Zpoždění konzumenta znamená, že odvolané právo může být ještě chvíli platné.',
+          'Rights are enforced by each product service from its own projection. Consumer lag means a revoked right may still be honoured for a while.',
+        )}
+      </p>
+
+      {!known || consumers === null ? (
+        <div style={{ padding: '12px', fontSize: '13px', color: 'var(--text-tertiary)' }}>
+          {t(
+            'Zpoždění konzumentů teď není známé — nepovažujte to za nulové zpoždění.',
+            'Consumer lag is not known right now — do not read that as zero lag.',
+          )}
+        </div>
+      ) : consumers.length === 0 ? (
+        <div style={{ padding: '12px', fontSize: '13px', color: 'var(--text-tertiary)' }}>
+          {t('Toto téma zatím nemá žádnou konzumentskou skupinu.', 'This topic has no consumer group yet.')}
+        </div>
+      ) : (
+        <table className="table" style={{ width: '100%' }}>
+          <thead>
+            <tr>
+              <th>{t('Skupina', 'Group')}</th>
+              <th>{t('Stav', 'State')}</th>
+              <th>{t('Zpoždění', 'Lag')}</th>
+            </tr>
+          </thead>
+          <tbody>
+            {consumers.map(c => (
+              <tr key={c.groupId}>
+                <td style={{ fontSize: '12px' }}>{c.groupId}</td>
+                <td style={{ fontSize: '12px' }}>{c.state ?? '—'}</td>
+                <td style={{ fontSize: '12px' }}>{c.lag === null ? '—' : c.lag}</td>
+              </tr>
+            ))}
+          </tbody>
+        </table>
+      )}
+    </div>
+  )
+}

--- a/openbank-admin-ui/src/components/delegations/GrantView.tsx
+++ b/openbank-admin-ui/src/components/delegations/GrantView.tsx
@@ -1,0 +1,64 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright (c) OpenBank contributors. Licensed under the Apache License, Version 2.0.
+// See LICENSE in the repository root or https://www.apache.org/licenses/LICENSE-2.0 for details.
+
+// ADR-0232 presentation helpers shared by the delegation list and detail screens. Kept in
+// src/components (not beside the pages) so the i18n and graceful-state guard tests, which scan
+// src/components/**, actually cover this file — a helper parked in src/app/ next to its page is
+// invisible to both.
+
+'use client'
+
+import { StatusBadge } from '@/components/ui'
+
+/** Mirrors delegation-service's DelegationResponse (rest/dto/DelegationDtos.kt). */
+export type Money = { amount: number; currency: string }
+
+export type Grant = {
+  id: string
+  grantorPartyId: string
+  granteePartyId: string
+  resourceType: string
+  resourceId: string
+  capabilities: string[]
+  approvalPolicy?: string | null
+  requiredApprovals?: number | null
+  perTransactionLimit?: Money | null
+  dailyLimit?: Money | null
+  monthlyLimit?: Money | null
+  validFrom?: string | null
+  validTo?: string | null
+  status: string
+  note?: string | null
+  createdAt?: string | null
+  updatedAt?: string | null
+  closedAt?: string | null
+  closedReason?: string | null
+}
+
+/**
+ * OFFERED is the one delegation status the shared tone map cannot get right by default: it is
+ * in-flight (awaiting the grantee's SCA-bound acceptance), not terminal, so it renders as a
+ * warning here per that map's own "pass an explicit tone" instruction. Every other status takes
+ * the shared default deliberately — ACTIVE success, SUSPENDED danger, and REVOKED / EXPIRED /
+ * DECLINED / RENOUNCED neutral, because a customer withdrawing rights is not an incident.
+ */
+export function DelegationStatusBadge({ status }: { status: string }) {
+  return <StatusBadge status={status} tone={status === 'OFFERED' ? 'warning' : undefined} />
+}
+
+/**
+ * Capability enums are rendered verbatim, not prettified into prose. They are the contract
+ * vocabulary shared with the OPA policy and the product-service projections, so an operator
+ * comparing this screen against a policy decision or a log line must see the same token.
+ */
+export function capabilityLabels(capabilities: string[] | undefined): string {
+  if (!capabilities?.length) return '—'
+  return capabilities.join(', ')
+}
+
+/** A ceiling of `null` means UNCAPPED for that window — never render it as zero. */
+export function formatCeiling(limit: Money | null | undefined): string {
+  if (!limit || typeof limit.amount !== 'number') return '—'
+  return `${limit.amount.toLocaleString('cs-CZ')} ${limit.currency}`
+}

--- a/openbank-admin-ui/src/components/layout/Sidebar.tsx
+++ b/openbank-admin-ui/src/components/layout/Sidebar.tsx
@@ -18,6 +18,7 @@ import {
   ClipboardCheck, Activity, Boxes, Bluetooth, Fingerprint, FileSignature, Network, Waypoints, Workflow,
   Megaphone,
   Target,
+  Share2,
 } from 'lucide-react'
 import { hasPermission, Permission } from '@/lib/auth/roles'
 import { personaForRoles, personaLabel, workspaceFor } from '@/lib/auth/persona'
@@ -54,6 +55,7 @@ const customerNav: NavItem[] = [
   { nameCs: 'KYC',         nameEn: 'KYC',         href: '/kyc',        icon: ShieldCheck,    permission: 'kyc:view' },
   { nameCs: 'Onboarding',  nameEn: 'Onboarding',  href: '/onboarding', icon: ClipboardList,  permission: 'onboarding:view' },
   { nameCs: 'Ověření identity', nameEn: 'Identity Cases', href: '/identity-cases', icon: Fingerprint, permission: 'onboarding:view' },
+  { nameCs: 'Delegovaný přístup', nameEn: 'Delegated Access', href: '/delegations', icon: Share2, permission: 'delegations:view' },
 ]
 
 const paymentsNav: NavItem[] = [

--- a/openbank-admin-ui/src/lib/auth/roles.ts
+++ b/openbank-admin-ui/src/lib/auth/roles.ts
@@ -50,6 +50,19 @@ export const PERMISSIONS = {
   "kyc:view":             [ROLES.ADMIN, ROLES.OPERATOR, ROLES.COMPLIANCE, ROLES.KYC, ROLES.KYC_OPENER, ROLES.KYC_REVIEWER],
   "kyc:approve":          [ROLES.ADMIN, ROLES.COMPLIANCE, ROLES.KYC_REVIEWER],
   "onboarding:view":      [ROLES.ADMIN, ROLES.OPERATOR, ROLES.COMPLIANCE, ROLES.KYC, ROLES.KYC_OPENER, ROLES.KYC_REVIEWER],
+  // Delegated access (ADR-0232 / ADR-0230). Mirrors delegation-service's own class-level
+  // @RolesAllowed(ROLE_API, ROLE_OPERATOR, ROLE_ADMIN) minus ROLE_API, which is the M2M
+  // identity and never a console session — listing it here would render a section for a
+  // principal that cannot hold a browser session anyway. Nav/route gating only, not a
+  // security control: the BFF relays the operator's own bearer and delegation-service +
+  // OPA (delegation.list / delegation.read) decide the real answer.
+  //
+  // There is deliberately NO "delegations:propose" yet. The bank-side mutations
+  // (suspend/reinstate/revoke) have no maker-checker store to land in, so this console
+  // ships read-only and there is no action for such a permission to gate — see
+  // src/test/delegations-no-mutation.guard.test.ts. Adding the permission before the
+  // action exists would be a role matrix that lies about what the UI can do.
+  "delegations:view":     [ROLES.ADMIN, ROLES.OPERATOR],
   // Audit
   "audit:view":           [ROLES.ADMIN, ROLES.AUDITOR, ROLES.COMPLIANCE, ROLES.SUPERVISOR],
   // Compliance / Regulatory

--- a/openbank-admin-ui/src/test/delegations-no-mutation.guard.test.ts
+++ b/openbank-admin-ui/src/test/delegations-no-mutation.guard.test.ts
@@ -1,0 +1,196 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright (c) OpenBank contributors. Licensed under the Apache License, Version 2.0.
+// See LICENSE in the repository root or https://www.apache.org/licenses/LICENSE-2.0 for details.
+
+// ADR-0230: "mutations only as approval proposals, never direct writes."
+//
+// delegation-service exposes three bank-side mutations — POST /{id}/suspend, POST
+// /{id}/reinstate, DELETE /{id} — and admin-ui has nowhere legitimate to route them: there is no
+// four-eyes / maker-checker store for delegation actions anywhere in the fleet (the shared
+// libs/foureyes contract has no adopters, lending's ApprovalResource is lending-private and
+// exposes list+decide only, and agent-service's /api/v1/proposals has no create endpoint). The
+// unified inbox (ADR-0227) can therefore only READ a proposal someone else persisted.
+//
+// So the console ships read-only, and this guard is what makes that a checked invariant instead
+// of a claim in a PR body: the day someone adds the "obvious" direct suspend route, this test
+// goes red and points at ADR-0230 rather than the change shipping quietly.
+//
+// It scans the WHOLE BFF tree, not just src/app/api/delegations/**, because the thing being
+// prevented is a mutation reaching delegation-service from anywhere in admin-ui.
+
+import { describe, expect, it } from 'vitest'
+import { readFileSync, readdirSync, statSync } from 'fs'
+import { join, sep } from 'path'
+
+const API_ROOT = join(process.cwd(), 'src/app/api')
+const UPSTREAM = 'delegation-service'
+
+/** The single non-GET upstream call this console is allowed to make. */
+const READ_ONLY_PROBE = '/api/v1/delegations/check'
+
+/** Bank-side mutations on delegation-service that must never be reachable from admin-ui. */
+const FORBIDDEN_PATH_FRAGMENTS = ['/suspend', '/reinstate']
+
+/**
+ * Strip comments before matching. Without this the guard matches the prose that EXPLAINS the
+ * rule — every one of these route files names `/suspend` in a WHY comment saying it is
+ * deliberately absent, so an uncommented scan reports the compliant tree as broken. Only
+ * line-start `//` is stripped, never mid-line, so a `http://…` inside a template literal
+ * survives intact (projection-health/route.ts has one).
+ */
+export function stripComments(src: string): string {
+  return src
+    .replace(/\/\*[\s\S]*?\*\//g, ' ')
+    .split('\n')
+    .filter(line => !/^\s*\/\//.test(line))
+    .join('\n')
+}
+
+export type Finding = { file: string; problem: string }
+
+/**
+ * The detector, exported so the falsifiability test below can run it against a known-positive.
+ * Returns one finding per violation; an empty array means the tree is clean.
+ */
+export function findDelegationMutations(files: { file: string; source: string }[]): Finding[] {
+  const findings: Finding[] = []
+
+  for (const { file, source } of files) {
+    const code = stripComments(source)
+    if (!code.includes(UPSTREAM)) continue
+
+    const upstreamPaths = [...code.matchAll(/\/api\/v1\/delegations[^'"`\s)]*/g)].map(m => m[0])
+    const methods = [...code.matchAll(/method:\s*['"]([A-Z]+)['"]/g)].map(m => m[1])
+
+    for (const path of upstreamPaths) {
+      for (const bad of FORBIDDEN_PATH_FRAGMENTS) {
+        if (path.includes(bad)) {
+          findings.push({ file, problem: `forwards to the bank-side mutation ${path}` })
+        }
+      }
+    }
+
+    for (const method of methods) {
+      if (method === 'GET') continue
+      if (method === 'POST' && upstreamPaths.some(p => p.startsWith(READ_ONLY_PROBE))) continue
+      findings.push({ file, problem: `issues ${method} against ${UPSTREAM}` })
+    }
+  }
+
+  return findings
+}
+
+function walk(dir: string, acc: string[] = []): string[] {
+  for (const entry of readdirSync(dir)) {
+    const full = join(dir, entry)
+    if (statSync(full).isDirectory()) walk(full, acc)
+    else if (entry === 'route.ts') acc.push(full)
+  }
+  return acc
+}
+
+function loadApiRoutes(): { file: string; source: string }[] {
+  return walk(API_ROOT).map(abs => ({
+    // POSIX-style repo-relative path so assertions read the same on any platform.
+    file: `src/app/api/${abs.slice(API_ROOT.length + 1).split(sep).join('/')}`,
+    source: readFileSync(abs, 'utf8'),
+  }))
+}
+
+describe('delegation console is read-only (ADR-0230)', () => {
+  it('no BFF route forwards a delegation mutation', () => {
+    const findings = findDelegationMutations(loadApiRoutes())
+    expect(findings, findings.map(f => `${f.file}: ${f.problem}`).join('\n')).toEqual([])
+  })
+
+  it('actually reaches the delegation routes it claims to scan', () => {
+    // A guard whose glob silently matches nothing passes forever. Anchor it: the read routes
+    // this PR ships must be in the scanned set and must mention the upstream.
+    const scanned = loadApiRoutes()
+    const delegationRoutes = scanned.filter(f => f.source.includes(UPSTREAM)).map(f => f.file)
+
+    expect(delegationRoutes).toContain('src/app/api/delegations/[id]/route.ts')
+    expect(delegationRoutes).toContain('src/app/api/delegations/party/[partyId]/route.ts')
+    expect(delegationRoutes).toContain('src/app/api/delegations/check/route.ts')
+  })
+
+  it('the delegation read routes export no mutating HTTP handler', () => {
+    const routes = loadApiRoutes().filter(f => f.file.startsWith('src/app/api/delegations/'))
+    expect(routes.length).toBeGreaterThan(0)
+
+    for (const { file, source } of routes) {
+      const handlers = [...stripComments(source).matchAll(/export async function ([A-Z]+)\s*\(/g)].map(m => m[1])
+      for (const h of handlers) {
+        // POST is allowed only on the side-effect-free coverage probe.
+        const allowed = h === 'GET' || (h === 'POST' && file === 'src/app/api/delegations/check/route.ts')
+        expect(allowed, `${file} exports a ${h} handler`).toBe(true)
+      }
+    }
+  })
+})
+
+describe('the guard itself fires (falsifiability)', () => {
+  // Every bullet in this repo's CI-gate lore says the same thing: a check that has only ever
+  // passed is unfalsified. These feed the detector the exact shapes it exists to reject.
+
+  it('flags a direct suspend forward', () => {
+    const findings = findDelegationMutations([{
+      file: 'fake/suspend/route.ts',
+      source: `
+        const url = serverSvcUrl('delegation-service', 'delegation', 8126, \`/api/v1/delegations/\${id}/suspend\`)
+        await fetch(url, { method: 'POST', body })
+      `,
+    }])
+    // Two independent detectors fire here — the forbidden path AND the non-probe POST — and
+    // that redundancy is deliberate: dropping either one still leaves the route flagged.
+    expect(findings.length).toBeGreaterThanOrEqual(1)
+    expect(findings.some(f => f.problem.includes('/suspend'))).toBe(true)
+    expect(findings.some(f => f.problem.includes('POST'))).toBe(true)
+  })
+
+  it('flags a DELETE revoke even though its path looks like the detail read', () => {
+    const findings = findDelegationMutations([{
+      file: 'fake/revoke/route.ts',
+      source: `
+        const url = serverSvcUrl('delegation-service', 'delegation', 8126, \`/api/v1/delegations/\${id}\`)
+        await fetch(url, { method: 'DELETE' })
+      `,
+    }])
+    expect(findings).toHaveLength(1)
+    expect(findings[0].problem).toContain('DELETE')
+  })
+
+  it('flags a reinstate forward', () => {
+    const findings = findDelegationMutations([{
+      file: 'fake/reinstate/route.ts',
+      source: `
+        await fetch(serverSvcUrl('delegation-service', 'delegation', 8126, '/api/v1/delegations/x/reinstate'), { method: 'POST' })
+      `,
+    }])
+    expect(findings.length).toBeGreaterThanOrEqual(1)
+  })
+
+  it('does NOT flag the coverage probe — a POST that changes nothing', () => {
+    const findings = findDelegationMutations([{
+      file: 'fake/check/route.ts',
+      source: `
+        await fetch(serverSvcUrl('delegation-service', 'delegation', 8126, '/api/v1/delegations/check'), { method: 'POST' })
+      `,
+    }])
+    expect(findings).toEqual([])
+  })
+
+  it('does NOT flag prose that merely names the forbidden routes', () => {
+    // The precedence decision this repo insists on making explicitly: code-about-code.
+    const findings = findDelegationMutations([{
+      file: 'fake/commented/route.ts',
+      source: `
+        // We deliberately do not implement /api/v1/delegations/{id}/suspend or /reinstate here,
+        // and never method: 'DELETE' against delegation-service — see ADR-0230.
+        /* Nor /api/v1/delegations/x/suspend in a block comment. */
+        await fetch(serverSvcUrl('delegation-service', 'delegation', 8126, '/api/v1/delegations/check'), { method: 'POST' })
+      `,
+    }])
+    expect(findings).toEqual([])
+  })
+})

--- a/openbank-admin-ui/src/test/delegations-routes.test.ts
+++ b/openbank-admin-ui/src/test/delegations-routes.test.ts
@@ -1,0 +1,276 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright (c) OpenBank contributors. Licensed under the Apache License, Version 2.0.
+// See LICENSE in the repository root or https://www.apache.org/licenses/LICENSE-2.0 for details.
+
+// ADR-0076 Layer 1 — BFF route integration tests for the delegation console (ADR-0230/0232),
+// mocked upstream + session.
+
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+
+vi.mock('@/auth', () => ({ auth: vi.fn() }))
+import { auth } from '@/auth'
+
+const SESSION = { user: { accessToken: 'operator-token', roles: ['ROLE_OPERATOR'] } }
+const PARTY = '018f4a3c-1b2d-7e00-9a11-000000000001'
+const GRANT = '018f4a3c-1b2d-7e00-9a11-000000000002'
+const RESOURCE = '018f4a3c-1b2d-7e00-9a11-000000000003'
+
+function grant(id: string, status = 'ACTIVE') {
+  return {
+    id,
+    grantorPartyId: PARTY,
+    granteePartyId: '018f4a3c-1b2d-7e00-9a11-0000000000ff',
+    resourceType: 'ACCOUNT',
+    resourceId: RESOURCE,
+    capabilities: ['ACCOUNT_READ_BALANCES'],
+    status,
+  }
+}
+
+function fetchCalls() {
+  return vi.mocked(global.fetch).mock.calls as unknown as [string, RequestInit][]
+}
+
+beforeEach(() => {
+  vi.resetModules()
+  vi.mocked(auth).mockResolvedValue(SESSION as never)
+})
+afterEach(() => {
+  vi.restoreAllMocks()
+})
+
+describe('GET /api/delegations/party/[partyId]', () => {
+  async function call(partyId: string) {
+    const { GET } = await import('@/app/api/delegations/party/[partyId]/route')
+    return GET({} as never, { params: Promise.resolve({ partyId }) })
+  }
+
+  it('401s without a session and never calls upstream', async () => {
+    vi.mocked(auth).mockResolvedValue(null as never)
+    const spy = vi.fn()
+    vi.stubGlobal('fetch', spy)
+    const res = await call(PARTY)
+    expect(res.status).toBe(401)
+    expect(spy).not.toHaveBeenCalled()
+  })
+
+  it('rejects a non-UUID party id before any upstream call', async () => {
+    const spy = vi.fn()
+    vi.stubGlobal('fetch', spy)
+    const res = await call('not-a-uuid')
+    expect(res.status).toBe(400)
+    expect(spy).not.toHaveBeenCalled()
+  })
+
+  it('fans out to both directions, relays the operator bearer, and omits the customer IDOR header', async () => {
+    vi.stubGlobal('fetch', vi.fn().mockImplementation((url: string) =>
+      Promise.resolve(new Response(JSON.stringify([grant(url.includes('grantor') ? 'g1' : 'r1')]), { status: 200 })),
+    ))
+
+    const res = await call(PARTY)
+    const body = await res.json()
+
+    expect(res.status).toBe(200)
+    expect(body.granted[0].id).toBe('g1')
+    expect(body.received[0].id).toBe('r1')
+    expect(body.sources).toEqual({ granted: 'ok', received: 'ok' })
+
+    const urls = fetchCalls().map(([u]) => String(u))
+    expect(urls.some(u => u.includes(`/api/v1/delegations/grantor/${PARTY}`))).toBe(true)
+    expect(urls.some(u => u.includes(`/api/v1/delegations/grantee/${PARTY}`))).toBe(true)
+
+    for (const [, init] of fetchCalls()) {
+      const h = new Headers(init.headers)
+      expect(h.get('authorization')).toBe('Bearer operator-token')
+      // Operator calls must NOT carry customer-edge's party-scoping header — it would make
+      // delegation-service refuse every party except the one we stamped.
+      expect(h.get('X-Customer-Party-Id')).toBeNull()
+    }
+  })
+
+  it('reports a refused direction as forbidden rather than an empty list', async () => {
+    vi.stubGlobal('fetch', vi.fn().mockImplementation((url: string) =>
+      Promise.resolve(
+        String(url).includes('grantor')
+          ? new Response('{}', { status: 403 })
+          : new Response(JSON.stringify([grant('r1')]), { status: 200 }),
+      ),
+    ))
+
+    const body = await (await call(PARTY)).json()
+    expect(body.granted).toEqual([])
+    expect(body.sources.granted).toBe('forbidden')
+    expect(body.sources.received).toBe('ok')
+  })
+
+  it('marks an unreachable direction unavailable, distinct from refused', async () => {
+    vi.stubGlobal('fetch', vi.fn().mockImplementation((url: string) =>
+      String(url).includes('grantor')
+        ? Promise.reject(new Error('ECONNREFUSED'))
+        : Promise.resolve(new Response('{}', { status: 500 })),
+    ))
+
+    const body = await (await call(PARTY)).json()
+    expect(body.sources).toEqual({ granted: 'unavailable', received: 'unavailable' })
+  })
+
+  it('survives a non-array upstream body instead of leaking it to the table', async () => {
+    vi.stubGlobal('fetch', vi.fn().mockResolvedValue(new Response(JSON.stringify({ oops: true }), { status: 200 })))
+    const body = await (await call(PARTY)).json()
+    expect(body.granted).toEqual([])
+    expect(body.received).toEqual([])
+  })
+})
+
+describe('GET /api/delegations/[id]', () => {
+  async function call(id: string) {
+    const { GET } = await import('@/app/api/delegations/[id]/route')
+    return GET({} as never, { params: Promise.resolve({ id }) })
+  }
+
+  it('401s without a session', async () => {
+    vi.mocked(auth).mockResolvedValue(null as never)
+    vi.stubGlobal('fetch', vi.fn())
+    expect((await call(GRANT)).status).toBe(401)
+  })
+
+  it('rejects a non-UUID id before any upstream call', async () => {
+    const spy = vi.fn()
+    vi.stubGlobal('fetch', spy)
+    expect((await call('../../etc/passwd')).status).toBe(400)
+    expect(spy).not.toHaveBeenCalled()
+  })
+
+  it('returns the grant and relays the bearer', async () => {
+    vi.stubGlobal('fetch', vi.fn().mockResolvedValue(new Response(JSON.stringify(grant(GRANT)), { status: 200 })))
+    const res = await call(GRANT)
+    expect(res.status).toBe(200)
+    expect((await res.json()).id).toBe(GRANT)
+    const [url, init] = fetchCalls()[0]
+    expect(String(url)).toContain(`/api/v1/delegations/${GRANT}`)
+    expect(new Headers(init.headers).get('authorization')).toBe('Bearer operator-token')
+  })
+
+  it('passes a 404 through as not_found', async () => {
+    vi.stubGlobal('fetch', vi.fn().mockResolvedValue(new Response('{}', { status: 404 })))
+    const res = await call(GRANT)
+    expect(res.status).toBe(404)
+    expect((await res.json()).error).toBe('not_found')
+  })
+
+  it('never leaks an upstream error body', async () => {
+    vi.stubGlobal('fetch', vi.fn().mockResolvedValue(
+      new Response(JSON.stringify({ stack: 'internal detail', sql: 'select *' }), { status: 500 }),
+    ))
+    const res = await call(GRANT)
+    const body = await res.json()
+    expect(res.status).toBe(502)
+    expect(body).toEqual({ error: 'upstream_error' })
+  })
+})
+
+describe('POST /api/delegations/check', () => {
+  async function call(body: unknown) {
+    const { POST } = await import('@/app/api/delegations/check/route')
+    return POST(new Request('http://localhost/api/delegations/check', {
+      method: 'POST',
+      body: JSON.stringify(body),
+    }))
+  }
+
+  const valid = {
+    granteePartyId: PARTY,
+    resourceType: 'ACCOUNT',
+    resourceId: RESOURCE,
+    capability: 'ACCOUNT_INITIATE_PAYMENT',
+  }
+
+  it('401s without a session', async () => {
+    vi.mocked(auth).mockResolvedValue(null as never)
+    vi.stubGlobal('fetch', vi.fn())
+    expect((await call(valid)).status).toBe(401)
+  })
+
+  it('rejects a malformed body before any upstream call', async () => {
+    const spy = vi.fn()
+    vi.stubGlobal('fetch', spy)
+    expect((await call({ ...valid, granteePartyId: 'nope' })).status).toBe(400)
+    expect((await call({ resourceType: 'ACCOUNT' })).status).toBe(400)
+    expect(spy).not.toHaveBeenCalled()
+  })
+
+  it('forwards a re-built body, dropping fields the caller smuggled in', async () => {
+    vi.stubGlobal('fetch', vi.fn().mockResolvedValue(
+      new Response(JSON.stringify({ granted: false, code: 'CEILING_EXCEEDED' }), { status: 200 }),
+    ))
+
+    const res = await call({ ...valid, amount: { amount: 500, currency: 'CZK' }, grantorPartyId: 'attacker-controlled' })
+    expect(res.status).toBe(200)
+    expect((await res.json()).code).toBe('CEILING_EXCEEDED')
+
+    const [url, init] = fetchCalls()[0]
+    expect(String(url)).toContain('/api/v1/delegations/check')
+    expect(init.method).toBe('POST')
+    const sent = JSON.parse(String(init.body))
+    expect(sent).toEqual({ ...valid, amount: { amount: 500, currency: 'CZK' } })
+    expect(sent.grantorPartyId).toBeUndefined()
+  })
+
+  it('drops a malformed amount rather than forwarding it', async () => {
+    vi.stubGlobal('fetch', vi.fn().mockResolvedValue(new Response(JSON.stringify({ granted: true }), { status: 200 })))
+    await call({ ...valid, amount: { amount: 'lots', currency: 'CZK' } })
+    expect(JSON.parse(String(fetchCalls()[0][1].body)).amount).toBeUndefined()
+  })
+})
+
+describe('GET /api/delegations/projection-health', () => {
+  async function call() {
+    const { GET } = await import('@/app/api/delegations/projection-health/route')
+    return GET()
+  }
+
+  it('401s without a session', async () => {
+    vi.mocked(auth).mockResolvedValue(null as never)
+    vi.stubGlobal('fetch', vi.fn())
+    expect((await call()).status).toBe(401)
+  })
+
+  it('derives the consumer set from the topic, never a hardcoded service list', async () => {
+    vi.stubGlobal('fetch', vi.fn().mockImplementation((url: string) => {
+      if (String(url).endsWith('/api/clusters')) {
+        return Promise.resolve(new Response(JSON.stringify([{ name: 'openbank' }]), { status: 200 }))
+      }
+      return Promise.resolve(new Response(JSON.stringify([
+        { groupId: 'card-issuance-delegation', state: 'STABLE', consumerLag: 7, members: 1 },
+        { groupId: 'account-service-delegation', state: 'STABLE', consumerLag: 0, members: 2 },
+      ]), { status: 200 }))
+    }))
+
+    const body = await (await call()).json()
+    expect(body.state).toBe('ok')
+    expect(body.consumers.map((c: { groupId: string }) => c.groupId))
+      .toEqual(['account-service-delegation', 'card-issuance-delegation'])
+    expect(body.consumers[1].lag).toBe(7)
+
+    const urls = fetchCalls().map(([u]) => String(u))
+    expect(urls.some(u => u.includes('openbank.delegation.events') && u.includes('consumer-groups'))).toBe(true)
+  })
+
+  it('says "unknown", never an empty healthy-looking table, when Kafka UI cannot answer', async () => {
+    vi.stubGlobal('fetch', vi.fn().mockImplementation((url: string) =>
+      String(url).endsWith('/api/clusters')
+        ? Promise.resolve(new Response(JSON.stringify([{ name: 'openbank' }]), { status: 200 }))
+        : Promise.resolve(new Response('{}', { status: 404 })),
+    ))
+
+    const body = await (await call()).json()
+    expect(body.state).toBe('unavailable')
+    expect(body.consumers).toEqual([])
+  })
+
+  it('degrades to unavailable when Kafka UI is unreachable', async () => {
+    vi.stubGlobal('fetch', vi.fn().mockRejectedValue(new Error('ECONNREFUSED')))
+    const body = await (await call()).json()
+    expect(body.state).toBe('unavailable')
+  })
+})


### PR DESCRIPTION
## What

The backoffice delegation console for ADR-0232 delegated access (S6 of the delegation program, `Refs #2990`).

An operator can find any party by name, see **what it has shared** and **what has been shared with it**, open a grant's capabilities / ceilings / status timeline, ask delegation-service the same coverage question its enforcement points ask, and see consumer-group lag on `openbank.delegation.events` — because a grant is minted centrally but *enforced* from each product service's local projection.

| Area | Files |
|---|---|
| BFF (ADR-0056) | `api/delegations/party/[partyId]`, `api/delegations/[id]`, `api/delegations/check`, `api/delegations/projection-health` |
| Screens | `app/delegations/{layout,page}.tsx`, `app/delegations/[id]/page.tsx`, `components/delegations/GrantView.tsx` |
| Role wiring | `lib/auth/roles.ts` (`delegations:view`), `components/layout/Sidebar.tsx` |
| Tests | `delegations-routes.test.ts`, `delegations-no-mutation.guard.test.ts`, `e2e/delegations-console.spec.ts` |

Local gate: `npm run type-check` clean, `npm test` **1077 passed / 77 files**, `npm run lint` 0 errors and 0 warnings in the new files.

## Party lookup without a UUID field

**Decision: reuse the existing ADR-0228 entity-resolution facade (`GET /api/entities/resolve`), filtered to `type === 'party'`.**

The brief for this work said ADR-0228 "does NOT exist" and told me to invent something. That premise is **false on `main`** — `src/app/api/entities/resolve/route.ts` shipped as ADR-0228 phase 1, and its provider is real: party-service's `GET /api/v1/parties/search` exists in `PartyResource.kt` and in that service's `openapi.yaml`. `EntityChip` (ADR-0231 D3) exists too. So this console needed **no new search endpoint and no UUID field** — the operator types a name, and results render as the same chips that deep-link to `/parties/{id}` everywhere else.

What that costs, honestly:
- **Only what ADR-0228 phase 1 resolves.** Parties by business key, accounts by IBAN. There is no chained resolution — you cannot search by *account* and pivot to the parties holding rights over it, which is the query a fraud analyst most plausibly wants. The ADR names chained resolution as a follow-up.
- **No ⌘K deep-link into this console** (ADR-0228 D3 palette), so the entry point is the sidebar.
- **No search-audit event** (ADR-0226 `channel=ui`) — a phase-1 gap I inherited, not one I introduced. Backoffice party searches on this screen are unlogged.

## Why there is no suspend/revoke button

The spec asked for mutations routed into the ADR-0227 inbox as proposals. **I could not do that honestly, so I shipped none.** There is nowhere for a delegation proposal to land:

- the shared `libs/foureyes` `ApprovalEntry` contract has **zero adopters** outside libs itself;
- lending's `ApprovalResource` is lending-private and exposes **list + decide only** — no create;
- agent-service's `/api/v1/proposals` is likewise **list + decide**; proposals are minted internally by `ProposalDetector`;
- so `/api/approvals/pending` (ADR-0227 phase 1) can only **read** a proposal something else persisted.

`rules.yaml` already reached this conclusion and anticipated this PR, verbatim:

> `delegation.offer/revoke/suspend are self-service or fraud-signal actions with SCA-bound ceremonies on both ends; the bank-side suspend lands via the fraud pipeline, not an operator console, so there is no maker/checker pair to gate yet. Revisit when the operator backoffice surface ships.`

The two available moves were a direct write (forbidden by ADR-0230) or a fake proposal with no durable store. I took the third: **ship read-only and make the absence a checked invariant.** `delegations-no-mutation.guard.test.ts` scans the whole BFF tree and fails if any route ever forwards `/suspend`, `/reinstate`, or a non-GET to delegation-service other than the side-effect-free `/check`. The day someone adds the obvious direct route, it goes red and cites ADR-0230.

Per the repo's own lore that an only-ever-passing gate is unfalsified, the guard is fed the four shapes it must reject — direct suspend, `DELETE` revoke (whose path is *identical* to the detail read, so only the method distinguishes it), reinstate, and the **code-about-code** case where the file's own explanatory comment names `/suspend` three times. It flagged the compliant tree until comments were stripped, which is the bug that case exists to prevent.

## Critical self-assessment

**Most likely to be wrong — the projection-health route.** It calls Kafka UI's topic-scoped `GET /api/clusters/{c}/topics/{t}/consumer-groups`. **I did not verify that endpoint against the running Kafka UI**; I inferred it from the existing `infra/kafka-topics` route's use of the same API. If that path is wrong, the panel degrades to "lag is not known" and *stays* there — silently, forever, exactly the failure class this repo caught with the ČNB feed. It fails safe (never renders "0 lag" when it does not know), but a safe failure that nobody notices is still a dead panel. **Wants a real-environment check before anyone trusts it.**

**What I traded away.**
- **The delegate activity feed is absent, not deferred quietly.** The spec asks for it "from the audit `onBehalfOf` projection". `onBehalfOf` appears in **zero** Kotlin files on `main` — S3 has not shipped. I could have keyed a feed off `audit-service`'s real `/entries/by-actor/{actorId}`, but that returns *everything the party did*, delegated or not. Labelling that "delegate activity" would be a screen that misrepresents its own data — ADR-0231's mock-data ban in spirit. Building it needs S3 first.
- **`rules.yaml` is untouched, against the brief's instruction.** The brief said delegation permissions go there and are "generated into the UI". **There is no such generator** — `roles.ts` is a hand-maintained file with prose comments, and ADR-0229 is `proposed/planned`. Editing `rules.yaml` would have restamped ~65 OPA bundles across every service for **zero** UI effect. So the permission lives in `roles.ts`, and **ADR-0229's single-source claim remains unimplemented** — that is the real gap, and it is bigger than this PR.
- **`delegations:view` is nav/route gating, not a security control**, like every other entry in that matrix: the BFF relays the operator's own bearer, and delegation-service + OPA decide the real answer. Worth stating because a role matrix reads like enforcement.

**Unverified.** Nothing here ran against the deployed sandbox service — every test mocks the upstream. The route tests prove *my* handler's behaviour; they cannot prove the path exists, which is precisely the defect that shipped finrep's non-existent `/ledger/trial-balance`. The delegation BFF paths are taken from `DelegationResource.kt` on `main` and match its `openapi.yaml`, but **no consumer pact or provider replay backstops admin-ui**, and admin-ui is not in the Pact estate at all. ~~The Playwright spec is also advisory in CI (`continue-on-error`), so its "no mutation on the wire" assertion does not block a merge — only the vitest guard does.~~ **Corrected:** that was wrong. The Playwright step in `Admin UI build` is NOT `continue-on-error` — it blocked, and the first push went red on this very spec. I had asserted it from a survey instead of checking the workflow.

**What I would do differently.** Split S6 in two and land the backend half first: a delegation proposal store (adopting `libs/foureyes` — it would become its **first** adopter, which is itself a signal the shared contract may not be fit) plus a create endpoint, then wire the console's mutations through it. Building the read console first was the right call for delivering value now, but it means the console's most operationally valuable action — *freeze this grant, I think it is being abused* — is still not available to the operator it was built for, and the fraud pipeline remains the only path.

**Not a money-path PR:** admin-ui is not in `money_path_services`, and this changes no money-path service code.



---

### Correction log (first push → CI red)

I did not run Playwright locally before the first push — vitest and `type-check` were green and I
took the e2e on faith. CI caught two real defects in it, and both are worth naming because they are
the same class of mistake this repo keeps writing bullets about:

1. **The no-mutation watcher was scoped to `**/api/**`,** so it recorded the app's own
   error-reporting beacon (`POST /api/2/envelope/`, Sentry/GlitchTip) and failed on traffic that has
   nothing to do with delegated access. The tempting fix — loosen the assertion until it goes green
   — would have quietly destroyed the only thing the test was for. It is now scoped to the
   delegation surface.
2. **Narrowing the filter could have made it match nothing,** in which case an empty `mutations`
   array means "the probe is broken", not "the console is clean" — indistinguishable from a real
   pass. So the test now fires a synthetic `POST /api/delegations/{id}/suspend` at the end and
   asserts the watcher *caught* it. The assertion is falsified in the same test that relies on it.

Both now verified locally (`4 passed`) rather than assumed. My original "unverified" caveat was
right about the risk and wrong about which artifact carried it.
