### PR TITLE
test(admin-ui): await the act scope when rendering a use()-suspending page

### DIFF
--- a/openbank-admin-ui/src/test/origination-flow.test.tsx
+++ b/openbank-admin-ui/src/test/origination-flow.test.tsx
@@ -13,7 +13,7 @@
 
 import { describe, it, expect, afterEach, vi } from 'vitest'
 import React, { Suspense } from 'react'
-import { render, screen, cleanup, waitFor } from '@testing-library/react'
+import { render, screen, cleanup, waitFor, act } from '@testing-library/react'
 import { LanguageProvider } from '@/lib/i18n/LanguageContext'
 import { SessionProvider } from '@/components/auth/SessionProvider'
 import {
@@ -151,7 +151,7 @@ describe('application flow page', () => {
 
   it('draws the real path and the actors behind each step', async () => {
     vi.stubGlobal('fetch', mockFetch({ status: 200, body: APPLICATION }, { status: 200, body: EVIDENCE }))
-    render(React.createElement(Providers, null, React.createElement(ApplicationFlowPage, { params })))
+    await act(async () => { render(React.createElement(Providers, null, React.createElement(ApplicationFlowPage, { params }))) })
 
     await waitFor(() => expect(screen.getByTestId('origination-flow')).toBeTruthy())
     expect(screen.getByTestId('node-KYC_PENDING').getAttribute('data-tone')).toBe('done')
@@ -165,7 +165,7 @@ describe('application flow page', () => {
       { status: 200, body: APPLICATION },
       { status: 403, body: { error: 'forbidden' } },
     ))
-    render(React.createElement(Providers, null, React.createElement(ApplicationFlowPage, { params })))
+    await act(async () => { render(React.createElement(Providers, null, React.createElement(ApplicationFlowPage, { params }))) })
 
     await waitFor(() => expect(screen.getByTestId('evidence-restricted')).toBeTruthy())
     expect(screen.queryByTestId('evidence-empty')).toBeNull()
@@ -174,7 +174,7 @@ describe('application flow page', () => {
 
   it('shows decision and disbursement as disabled with the reason, not hidden', async () => {
     vi.stubGlobal('fetch', mockFetch({ status: 200, body: APPLICATION }, { status: 200, body: EVIDENCE }))
-    render(React.createElement(Providers, null, React.createElement(ApplicationFlowPage, { params })))
+    await act(async () => { render(React.createElement(Providers, null, React.createElement(ApplicationFlowPage, { params }))) })
 
     await waitFor(() => expect(screen.getByTestId('decide-disabled')).toBeTruthy())
     // Hiding them would teach an operator the platform cannot do it; disabling with a reason


### PR DESCRIPTION
## The defect

`src/app/lending/applications/[id]/page.tsx` reads its route params with `use(params)`. When RTL's
`render()` mounts that page, the tree suspends **inside the synchronous `act()` scope `render()`
opens**. The retry is queued against an act queue that is torn down before the ping arrives, and
`waitFor` then runs with `IS_REACT_ACT_ENVIRONMENT=false`, so nothing ever flushes it. The Suspense
boundary stays on its fallback permanently.

The promise is fulfilled one microtask later; the component simply never re-renders:

```
after render      {"status":"pending","renders":1}
after microtask   {"status":"fulfilled","value":{"id":"x"},"renders":1}
after 350ms       {"status":"fulfilled",...,"renders":1}   <div><div>loading</div></div>
```

React was printing `A component suspended inside an act scope, but the act call was not awaited` on
every run — including the passing ones. Vitest intercepts console, so nobody read it.

## This is not flakiness, and not order

Three tests share one `const params = Promise.resolve({ id: APP_ID })` at describe scope. React's
`trackUsedThenable` stamps `status: 'fulfilled'` onto that object even during the render that hangs,
so the *next* `use()` of it returns synchronously. **Two of the three tests were being rescued by the
first one failing.** Run individually, all three fail.

Measured on the unchanged tree, **default order, no shuffle**: 4 failures in 11 runs. Shuffling did
not cause this — it raised the hit rate by removing the accidental rescue. The suite has been passing
on a coin flip.

I previously concluded from three identical shuffled runs that the failure was deterministic per
seed. With a ~35% per-run failure rate, three matching outcomes was not evidence of determinism, and
that conclusion was wrong.

## The fix, and what it does not do

```diff
-    render(React.createElement(Providers, null, React.createElement(ApplicationFlowPage, { params })))
+    await act(async () => { render(React.createElement(Providers, null, React.createElement(ApplicationFlowPage, { params }))) })
```

Wrapping the render in an awaited async `act` gives the suspended tree a live act queue to resume
into. It is not a timeout increase and not a retry — the failing branch was a permanent hang, so no
timeout could ever have masked it. **Raising `asyncUtilTimeout` was tried and rejected**: it fixes
nothing here and would delay every genuinely-broken async test's failure by seconds elsewhere.

It fixes three call sites, not the class. Any future test that renders a `use()`-suspending component
with a bare `render()` reintroduces it and will pass most of the time locally. `use(params)` appears
in exactly one page today, which bounds the blast radius by accident rather than by design — filed
separately.

Do not delete the `waitFor` that follows: `await act` usually settles the fetch too, which makes the
wait look redundant, but it is what keeps the assertion honest if the page gains a second async
stage.

## Verification

Falsifiability first, on the isolated test that had never once been run alone:

```
control (fix reverted), 5 runs:  Tests 1 failed | 8 skipped   ×5
with the fix,           5 runs:  Tests 1 passed | 8 skipped   ×5
whole file,             3 runs:  Tests 9 passed (9)           ×3
```

A green whole-file run proves little here — it was green 7 times in 11 while broken. The isolated
run is the discriminator.

Diagnosis by a delegated investigation; the control/fixed measurements above were re-run
independently before this PR.


## Linked issues

Refs #3550 — the class this does not gate, and the second unexplained failure.
