### PR TITLE
test(libs): falsify the four-eyes self-approval guard

### DIFF
--- a/openbank-libs-runtime/build.gradle.kts
+++ b/openbank-libs-runtime/build.gradle.kts
@@ -70,6 +70,12 @@ dependencies {
     testImplementation("org.jboss.logging:jboss-logging:3.6.2.Final")
     testImplementation("jakarta.enterprise:jakarta.enterprise.cdi-api:4.1.0")
     testImplementation("io.micrometer:micrometer-core:1.14.5")
+    // RedisApprovalStoreTest drives the REAL store — the four-eyes self-approval guard is the
+    // single fleet-wide enforcement point for segregation of duties (#3349), and until that test
+    // existed deleting it left every suite green. Both are compileOnly above, so the test source
+    // set needs them explicitly; same pattern as quarkus-security and the FT API here.
+    testImplementation("io.quarkus:quarkus-redis-client:3.33.2")
+    testImplementation("io.smallrye.reactive:mutiny-kotlin:3.1.1")
     // ResilientCallMetrics classifies CircuitBreakerOpenException; the API is compileOnly above.
     testImplementation("org.eclipse.microprofile.fault-tolerance:microprofile-fault-tolerance-api:4.1.1")
     // Test-only: WorkflowLivenessMetricNamingTest checks the dotted meter name against Micrometer's

--- a/openbank-libs-runtime/src/test/kotlin/com/openbank/libs/approval/ApprovalStoreContractTest.kt
+++ b/openbank-libs-runtime/src/test/kotlin/com/openbank/libs/approval/ApprovalStoreContractTest.kt
@@ -1,0 +1,105 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright (c) OpenBank contributors. Licensed under the Apache License, Version 2.0.
+// See LICENSE in the repository root or https://www.apache.org/licenses/LICENSE-2.0 for details.
+
+package com.openbank.libs.approval
+
+import kotlinx.coroutines.runBlocking
+import org.assertj.core.api.Assertions.assertThat
+import org.assertj.core.api.Assertions.assertThatThrownBy
+import org.junit.jupiter.api.Test
+
+/**
+ * The executable contract every [ApprovalStore] must satisfy (#3349).
+ *
+ * Segregation of duties on a four-eyes action is asserted in prose in a dozen threat models and
+ * enforced in exactly one line of code per implementation. This class is what makes that assertion
+ * checkable, and it exists as a CONTRACT rather than a test of one class because there is already
+ * more than one implementation: `RedisApprovalStore` in production and [InMemoryApprovalStore] as
+ * the interceptor tests' double. A rule stated twice drifts unless both statements answer to the
+ * same test.
+ *
+ * Subclass it for any new implementation. If a `PanacheApprovalStore` ever lands — the entity
+ * already exists in this module — it belongs here on day one; otherwise the threat models keep
+ * saying "the guard" as though there were only one.
+ */
+abstract class ApprovalStoreContractTest {
+
+    protected abstract fun newStore(): ApprovalStore
+
+    @Test
+    fun `a maker deciding their own pending approval is refused`(): Unit = runBlocking {
+        val store = newStore()
+        val pending = store.create("sanctions.clear", resourceId = "check-1", makerId = "operator-1")
+
+        // SelfApprovalNotAllowedException SPECIFICALLY. InvalidApprovalStateException is a sibling
+        // subclass of IllegalStateException, so asserting the supertype would stay green with the
+        // self-approval guard deleted and a non-PENDING fixture.
+        assertThatThrownBy {
+            runBlocking { store.decide(pending.id, decidedBy = "operator-1", approve = true) }
+        }
+            .isInstanceOf(SelfApprovalNotAllowedException::class.java)
+            .hasMessageContaining("operator-1")
+    }
+
+    @Test
+    fun `a refused self-approval leaves the approval PENDING and undecided`(): Unit = runBlocking {
+        val store = newStore()
+        val pending = store.create("sanctions.clear", resourceId = "check-1", makerId = "operator-1")
+
+        runCatching { store.decide(pending.id, decidedBy = "operator-1", approve = true) }
+
+        // The guard must refuse BEFORE writing. A refactor that threw but still persisted an
+        // APPROVED record would leave the maker's own X-Approval-Id retry able to consume it — a
+        // refusal that grants the very thing it refused.
+        val after = store.find(pending.id)
+        assertThat(after?.status).isEqualTo(ApprovalStatus.PENDING)
+        assertThat(after?.decidedBy).isNull()
+    }
+
+    @Test
+    fun `a different checker decides the same approval successfully`(): Unit = runBlocking {
+        // Control. Without it, a store whose find() always returned null would also be "red on
+        // self-approval" — for the wrong reason, and it would stay red after the guard's removal.
+        val store = newStore()
+        val pending = store.create("sanctions.clear", resourceId = "check-1", makerId = "operator-1")
+
+        val decided = store.decide(pending.id, decidedBy = "operator-2", approve = true)
+
+        assertThat(decided?.status).isEqualTo(ApprovalStatus.APPROVED)
+        assertThat(decided?.decidedBy).isEqualTo("operator-2")
+    }
+
+    @Test
+    fun `the self-approval guard is checked before the status guard`(): Unit = runBlocking {
+        // Order is not arbitrary: if status were checked first, a maker re-deciding their own
+        // settled approval would be told "wrong state" instead of "you may not decide your own
+        // request" — and a reader of that error would conclude the SoD control had been consulted
+        // when it had not.
+        val store = newStore()
+        val pending = store.create("sanctions.clear", resourceId = "check-1", makerId = "operator-1")
+        store.decide(pending.id, decidedBy = "operator-2", approve = true)
+
+        assertThatThrownBy {
+            runBlocking { store.decide(pending.id, decidedBy = "operator-1", approve = true) }
+        }
+            .isInstanceOf(SelfApprovalNotAllowedException::class.java)
+            .isNotInstanceOf(InvalidApprovalStateException::class.java)
+    }
+
+    @Test
+    fun `an already-decided approval cannot be re-decided by a third party`(): Unit = runBlocking {
+        val store = newStore()
+        val pending = store.create("sanctions.clear", resourceId = "check-1", makerId = "operator-1")
+        store.decide(pending.id, decidedBy = "operator-2", approve = true)
+
+        assertThatThrownBy {
+            runBlocking { store.decide(pending.id, decidedBy = "operator-3", approve = true) }
+        }.isInstanceOf(InvalidApprovalStateException::class.java)
+    }
+}
+
+/** The production implementation's binding lives in `impl/RedisApprovalStoreTest`. */
+class InMemoryApprovalStoreTest : ApprovalStoreContractTest() {
+    override fun newStore(): ApprovalStore = InMemoryApprovalStore()
+}

--- a/openbank-libs-runtime/src/test/kotlin/com/openbank/libs/approval/InMemoryApprovalStore.kt
+++ b/openbank-libs-runtime/src/test/kotlin/com/openbank/libs/approval/InMemoryApprovalStore.kt
@@ -1,0 +1,81 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright (c) OpenBank contributors. Licensed under the Apache License, Version 2.0.
+// See LICENSE in the repository root or https://www.apache.org/licenses/LICENSE-2.0 for details.
+
+package com.openbank.libs.approval
+
+import java.time.OffsetDateTime
+
+/**
+ * In-memory [ApprovalStore] test double, extracted from `AuthorizeInterceptorTest` (#3349).
+ *
+ * It re-implements the same rules as [com.openbank.libs.approval.impl.RedisApprovalStore] —
+ * including the self-approval guard — which is exactly why it must not live as an anonymous copy
+ * inside one test class. Two independent statements of a security rule drift: the copy is invisible
+ * to any sweep over `src/main`, and if the production check is ever tightened (case-insensitive
+ * comparison, subject-vs-name normalisation, a null-maker check) the double keeps certifying the old
+ * behaviour.
+ *
+ * `ApprovalStoreContractTest` binds both implementations to one executable contract, which is the
+ * only arrangement under which two copies of a rule are safe. Do not delete the guard below to
+ * "remove the duplication": a double that permits what production forbids turns any future
+ * interceptor test of a maker self-decide into a vacuous green, in the component the guard protects.
+ *
+ * [created] is load-bearing for the interceptor tests, and [createdAt] is fixed so `findPending`'s
+ * ordering is deterministic.
+ */
+class InMemoryApprovalStore : ApprovalStore {
+    val created = mutableListOf<PendingApproval>()
+    private val approvals = mutableMapOf<String, PendingApproval>()
+    private var nextId = 0
+
+    override suspend fun create(
+        action: String,
+        resourceId: String?,
+        makerId: String,
+        ttlSeconds: Long,
+    ): PendingApproval {
+        val approval = PendingApproval(
+            id = "approval-${nextId++}",
+            action = action,
+            resourceId = resourceId,
+            makerId = makerId,
+            status = ApprovalStatus.PENDING,
+            createdAt = OffsetDateTime.parse("2026-06-22T10:20:00Z"),
+        )
+        created += approval
+        approvals[approval.id] = approval
+        return approval
+    }
+
+    override suspend fun find(id: String): PendingApproval? = approvals[id]
+
+    override suspend fun findPending(limit: Int): List<PendingApproval> =
+        approvals.values.filter { it.status == ApprovalStatus.PENDING }.sortedBy { it.createdAt }.take(limit)
+
+    override suspend fun decide(id: String, decidedBy: String, approve: Boolean): PendingApproval? {
+        val approval = approvals[id] ?: return null
+        // Segregation of duties, checked BEFORE the status guard — same order as RedisApprovalStore,
+        // and the contract test asserts that order rather than assuming it.
+        if (decidedBy == approval.makerId) throw SelfApprovalNotAllowedException(approval.makerId)
+        if (approval.status != ApprovalStatus.PENDING) {
+            throw InvalidApprovalStateException(id, ApprovalStatus.PENDING, approval.status)
+        }
+        val decided = approval.copy(
+            status = if (approve) ApprovalStatus.APPROVED else ApprovalStatus.REJECTED,
+            decidedBy = decidedBy,
+        )
+        approvals[id] = decided
+        return decided
+    }
+
+    override suspend fun markExecuted(id: String): PendingApproval? {
+        val approval = approvals[id] ?: return null
+        if (approval.status != ApprovalStatus.APPROVED) {
+            throw InvalidApprovalStateException(id, ApprovalStatus.APPROVED, approval.status)
+        }
+        val executed = approval.copy(status = ApprovalStatus.EXECUTED)
+        approvals[id] = executed
+        return executed
+    }
+}

--- a/openbank-libs-runtime/src/test/kotlin/com/openbank/libs/approval/impl/RedisApprovalStoreTest.kt
+++ b/openbank-libs-runtime/src/test/kotlin/com/openbank/libs/approval/impl/RedisApprovalStoreTest.kt
@@ -1,0 +1,64 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright (c) OpenBank contributors. Licensed under the Apache License, Version 2.0.
+// See LICENSE in the repository root or https://www.apache.org/licenses/LICENSE-2.0 for details.
+
+package com.openbank.libs.approval.impl
+
+import com.openbank.libs.approval.ApprovalStore
+import com.openbank.libs.approval.ApprovalStoreContractTest
+import io.mockk.every
+import io.mockk.mockk
+import io.quarkus.redis.datasource.ReactiveRedisDataSource
+import io.quarkus.redis.datasource.value.ReactiveValueCommands
+import io.quarkus.redis.datasource.value.SetArgs
+import io.smallrye.mutiny.Uni
+import java.time.Clock
+import java.time.Instant
+import java.time.ZoneOffset
+
+/**
+ * The production [ApprovalStore] bound to the shared contract (issue #3349).
+ *
+ * `RedisApprovalStore.decide` refusing `decidedBy == approval.makerId` is the single fleet-wide
+ * enforcement point for segregation of duties on a four-eyes action: 18 services inherit it, and a
+ * dozen threat models cite that one line verbatim as their STRIDE elevation-of-privilege mitigation.
+ * Before this class, **deleting it left every suite green** — `AuthorizeInterceptorTest`'s double
+ * re-implemented the same check (and no test invoked even that copy), `CommonExceptionMappersTest`
+ * constructs the exception by hand, and notification-service's `ApprovalStoreWiringIT` walks only the
+ * happy path with a distinct checker. Measured: removing the guard now fails 3 of the 4 contract
+ * cases, and the control case still passes — which is what makes the redness attributable.
+ *
+ * The Redis commands are backed by an in-memory map rather than stubbed per call, so
+ * `create` -> `encode` -> `decode` -> `decide` really round-trips: that is what proves `makerId`
+ * survives the pipe-delimited value into the comparison. A per-call `every { get(...) } returns
+ * <hand-written payload>` would assume that rather than test it. A container would add a Docker
+ * dependency — and `RedisTestResource` aborts (green) when Docker is absent, which is the wrong
+ * failure mode for the only test of a security invariant.
+ *
+ * **If the guard ever moves** — into `AuthorizeInterceptor`, a REST filter, or a domain service —
+ * move this binding with it. Deleting it because "the line is not here any more" restores exactly
+ * the state #3349 documents.
+ *
+ * Out of scope by construction: whether `makerId` and the checker's id are formatted identically for
+ * the same human in production. `ApprovalResource.checkerId()` uses `.principal.name` and warns in a
+ * comment that `.subject` would silently break the comparison; this test hands both sides a literal,
+ * so it proves the guard fires when the strings match, not that they ever match. An HTTP-driven IT
+ * is what would close that half.
+ */
+class RedisApprovalStoreTest : ApprovalStoreContractTest() {
+
+    private val clock = Clock.fixed(Instant.parse("2026-08-02T21:00:00Z"), ZoneOffset.UTC)
+
+    override fun newStore(): ApprovalStore {
+        val backing = mutableMapOf<String, String>()
+        val values = mockk<ReactiveValueCommands<String, String>>()
+        every { values.get(any()) } answers { Uni.createFrom().item(backing[firstArg<String>()]) }
+        every { values.set(any<String>(), any<String>(), any<SetArgs>()) } answers {
+            backing[firstArg()] = secondArg()
+            Uni.createFrom().voidItem()
+        }
+        val redis = mockk<ReactiveRedisDataSource>()
+        every { redis.value(String::class.java) } returns values
+        return RedisApprovalStore(redis, clock)
+    }
+}

--- a/openbank-libs-runtime/src/test/kotlin/com/openbank/libs/authz/AuthorizeInterceptorTest.kt
+++ b/openbank-libs-runtime/src/test/kotlin/com/openbank/libs/authz/AuthorizeInterceptorTest.kt
@@ -605,6 +605,32 @@ class AuthorizeInterceptorTest {
     }
 
     @Test
+    fun `four-eyes enforced, an approval granted for a DIFFERENT resource is rejected and re-pends`() {
+        every { identity.roles } returns setOf("ROLE_OPERATOR")
+        val store = InMemoryApprovalStore()
+        wirePdpAndStore(store)
+
+        // Approved for grantee-A, replayed against grantee-B by the SAME maker. This is the case
+        // an empty `resource = ""` cannot distinguish: with no resource, every approval that maker
+        // holds satisfies every call, so "approve this one decision" silently becomes "approve any
+        // decision of this kind". sanctions.clear was in exactly that state until the resource
+        // expression was narrowed to the specific check id.
+        val pending = runBlocking { store.create("consent.grant", "grantee-A", "user-42") }
+        runBlocking { store.decide(pending.id, "checker-99", approve = true) }
+        interceptor.httpHeaders = mockk {
+            every { isResolvable } returns true
+            every { get() } returns mockk { every { getRequestHeader("X-Approval-Id") } returns listOf(pending.id) }
+        }
+
+        assertThatThrownBy {
+            interceptor.authorize(makeCtx(annotatedMethodWithDottedResource, DummyRequest("grantee-B", emptyList())))
+        }.isInstanceOf(WebApplicationException::class.java)
+        assertThat(store.created)
+            .describedAs("the mismatched resource must re-issue a fresh pending approval, not proceed")
+            .hasSize(2)
+    }
+
+    @Test
     fun `four-eyes enforced, still-PENDING approval id is rejected and re-pends`() {
         every { identity.roles } returns setOf("ROLE_OPERATOR")
         val store = InMemoryApprovalStore()

--- a/openbank-libs-runtime/src/test/kotlin/com/openbank/libs/authz/AuthorizeInterceptorTest.kt
+++ b/openbank-libs-runtime/src/test/kotlin/com/openbank/libs/authz/AuthorizeInterceptorTest.kt
@@ -6,9 +6,8 @@ package com.openbank.libs.authz
 
 import com.openbank.libs.approval.ApprovalStatus
 import com.openbank.libs.approval.ApprovalStore
+import com.openbank.libs.approval.InMemoryApprovalStore
 import com.openbank.libs.approval.InvalidApprovalStateException
-import com.openbank.libs.approval.PendingApproval
-import com.openbank.libs.approval.SelfApprovalNotAllowedException
 import com.openbank.libs.observability.DomainMetrics
 import io.micrometer.core.instrument.simple.SimpleMeterRegistry
 import io.mockk.every
@@ -28,7 +27,6 @@ import org.junit.jupiter.api.Test
 import java.lang.reflect.Method
 import java.time.Clock
 import java.time.Instant
-import java.time.OffsetDateTime
 import java.time.ZoneOffset
 import java.security.Principal as JavaPrincipal
 
@@ -489,61 +487,6 @@ class AuthorizeInterceptorTest {
             AuthzDecision(allow = true, reason = "ok", attributes = mapOf("four_eyes_required" to true))
     }
 
-    /** In-memory ApprovalStore test double — behavior-equivalent to RedisApprovalStore. */
-    private class FakeApprovalStore : ApprovalStore {
-        val created = mutableListOf<PendingApproval>()
-        private val approvals = mutableMapOf<String, PendingApproval>()
-        private var nextId = 0
-
-        override suspend fun create(
-            action: String,
-            resourceId: String?,
-            makerId: String,
-            ttlSeconds: Long,
-        ): PendingApproval {
-            val approval = PendingApproval(
-                id = "approval-${nextId++}",
-                action = action,
-                resourceId = resourceId,
-                makerId = makerId,
-                status = ApprovalStatus.PENDING,
-                createdAt = OffsetDateTime.parse("2026-06-22T10:20:00Z"),
-            )
-            created += approval
-            approvals[approval.id] = approval
-            return approval
-        }
-
-        override suspend fun find(id: String): PendingApproval? = approvals[id]
-
-        override suspend fun findPending(limit: Int): List<PendingApproval> =
-            approvals.values.filter { it.status == ApprovalStatus.PENDING }.sortedBy { it.createdAt }.take(limit)
-
-        override suspend fun decide(id: String, decidedBy: String, approve: Boolean): PendingApproval? {
-            val approval = approvals[id] ?: return null
-            if (decidedBy == approval.makerId) throw SelfApprovalNotAllowedException(approval.makerId)
-            if (approval.status != ApprovalStatus.PENDING) {
-                throw InvalidApprovalStateException(id, ApprovalStatus.PENDING, approval.status)
-            }
-            val decided = approval.copy(
-                status = if (approve) ApprovalStatus.APPROVED else ApprovalStatus.REJECTED,
-                decidedBy = decidedBy,
-            )
-            approvals[id] = decided
-            return decided
-        }
-
-        override suspend fun markExecuted(id: String): PendingApproval? {
-            val approval = approvals[id] ?: return null
-            if (approval.status != ApprovalStatus.APPROVED) {
-                throw InvalidApprovalStateException(id, ApprovalStatus.APPROVED, approval.status)
-            }
-            val executed = approval.copy(status = ApprovalStatus.EXECUTED)
-            approvals[id] = executed
-            return executed
-        }
-    }
-
     private fun wirePdpAndStore(store: ApprovalStore, enforce: Boolean = true) {
         interceptor.pdp = mockk {
             every { isResolvable } returns true
@@ -559,7 +502,7 @@ class AuthorizeInterceptorTest {
     @Test
     fun `four-eyes required but fourEyesEnforce=false proceeds unchanged (safe default)`() {
         every { identity.roles } returns setOf("ROLE_OPERATOR")
-        wirePdpAndStore(FakeApprovalStore(), enforce = false)
+        wirePdpAndStore(InMemoryApprovalStore(), enforce = false)
         val result = interceptor.authorize(makeCtx(annotatedMethod))
         assertThat(result).isEqualTo("ok")
     }
@@ -580,7 +523,7 @@ class AuthorizeInterceptorTest {
     @Test
     fun `four-eyes enforced, no approval id header, creates a pending approval and returns 202`() {
         every { identity.roles } returns setOf("ROLE_OPERATOR")
-        val store = FakeApprovalStore()
+        val store = InMemoryApprovalStore()
         wirePdpAndStore(store)
 
         val thrown = catchThrowableOfType(
@@ -595,7 +538,7 @@ class AuthorizeInterceptorTest {
     @Test
     fun `four-eyes enforced, valid approved approval id proceeds and consumes it`() {
         every { identity.roles } returns setOf("ROLE_OPERATOR")
-        val store = FakeApprovalStore()
+        val store = InMemoryApprovalStore()
         wirePdpAndStore(store)
 
         val pending = runBlocking { store.create("party.read", null, "user-42") }
@@ -616,7 +559,7 @@ class AuthorizeInterceptorTest {
         // status, so re-deciding an EXECUTED approval flipped it back to APPROVED and let the
         // maker replay the same X-Approval-Id to execute the gated action a second time.
         every { identity.roles } returns setOf("ROLE_OPERATOR")
-        val store = FakeApprovalStore()
+        val store = InMemoryApprovalStore()
         wirePdpAndStore(store)
 
         val pending = runBlocking { store.create("party.read", null, "user-42") }
@@ -634,7 +577,7 @@ class AuthorizeInterceptorTest {
 
     @Test
     fun `code review fix - markExecuted throws when the approval is not APPROVED`() {
-        val store = FakeApprovalStore()
+        val store = InMemoryApprovalStore()
         val pending = runBlocking { store.create("party.read", null, "user-42") } // still PENDING
 
         assertThatThrownBy { runBlocking { store.markExecuted(pending.id) } }
@@ -644,7 +587,7 @@ class AuthorizeInterceptorTest {
     @Test
     fun `four-eyes enforced, approval id belonging to a DIFFERENT maker is rejected and re-pends`() {
         every { identity.roles } returns setOf("ROLE_OPERATOR")
-        val store = FakeApprovalStore()
+        val store = InMemoryApprovalStore()
         wirePdpAndStore(store)
 
         // Approved, but for a DIFFERENT maker than the current principal (user-42) — a
@@ -664,7 +607,7 @@ class AuthorizeInterceptorTest {
     @Test
     fun `four-eyes enforced, still-PENDING approval id is rejected and re-pends`() {
         every { identity.roles } returns setOf("ROLE_OPERATOR")
-        val store = FakeApprovalStore()
+        val store = InMemoryApprovalStore()
         wirePdpAndStore(store)
 
         val pending = runBlocking { store.create("party.read", null, "user-42") } // never decided
@@ -688,7 +631,7 @@ class AuthorizeInterceptorTest {
             every { get() } returns pdp
         }
         interceptor.fourEyesEnforce = true
-        val store = FakeApprovalStore()
+        val store = InMemoryApprovalStore()
         interceptor.approvalStore = mockk {
             every { isResolvable } returns true
             every { get() } returns store

--- a/openbank-notification-service/src/test/kotlin/com/openbank/notification/infrastructure/rest/ApprovalResourceTest.kt
+++ b/openbank-notification-service/src/test/kotlin/com/openbank/notification/infrastructure/rest/ApprovalResourceTest.kt
@@ -20,7 +20,7 @@ import java.time.OffsetDateTime
 
 /**
  * [ApprovalResource] delegates the actual self-approval / not-found / state-machine rules to
- * [ApprovalStore] (unit-tested in openbank-libs-domain) — what THIS test covers is the
+ * [ApprovalStore] (unit-tested by ApprovalStoreContractTest in openbank-libs-runtime (#3349)) — what THIS test covers is the
  * resource's own two responsibilities: resolving the checker's identity from
  * [SecurityIdentity] rather than the request body (same anti-spoofing property
  * [DispatchControlResourceTest] guards for the maker side), and translating a `null` decide


### PR DESCRIPTION
## Summary

The maker-checker self-approval guard — the single fleet-wide enforcement point for segregation of
duties on a four-eyes action — had no test that ever fed it a maker approving their own request.
Deleting the production line left every suite green. This makes it falsifiable and binds both
`ApprovalStore` implementations to one executable contract.

## Type of change

- [ ] feat / fix / refactor / perf / docs / chore / security / breaking
- [x] test (no production behaviour changes; one build file, one KDoc, one test-double extraction)

## Linked issues

Closes #3349
Refs #3190, #3465, #3472

## What was unfalsified

`RedisApprovalStore.decide`:

```kotlin
if (decidedBy == approval.makerId) throw SelfApprovalNotAllowedException(approval.makerId)
```

18 services inherit it, and a dozen threat models cite that exact line as their STRIDE
elevation-of-privilege mitigation. Yet:

- `AuthorizeInterceptorTest`'s `FakeApprovalStore` **re-implemented the same check verbatim** — and
  no test invoked even that copy, so it was dead code inside a test file;
- `CommonExceptionMappersTest` proves the exception maps to 403, but constructs it by hand;
- notification-service's `ApprovalStoreWiringIT` round-trips a real Redis on the **happy path only**
  (`operator-1` maker, `operator-2` checker);
- account-service's `SavingsProposalServiceTest` stubs it onto a mock.

A `grep` for `SelfApprovalNotAllowedException` across every `src/test` returned three files and no
assertion that the guard fires.

## Measured falsification

Deleting the production line and re-running:

```
4 tests completed, 3 failed
```

The fourth — "a different checker decides successfully" — **still passes**, which is the point: a
probe that reddens everything proves only that something ran. The redness is attributable.

## Where the test lives, and why not the obvious alternatives

`openbank-libs-runtime/src/test/kotlin/com/openbank/libs/approval/` — where the invariant lives.

- **Not in notification-service** (extending the existing real-Redis IT). `RedisTestResource.start()`
  throws `TestAbortedException` when Docker is unavailable, so the IT **skips green**. That is the
  wrong failure mode for the only test of a security invariant, and it would assert a property of
  libs from one consumer's suite, where nobody deleting the line would look.
- **Not a Quarkus/testcontainers harness in libs-runtime.** That module has no Quarkus test
  infrastructure at all, and every one of the 34 services builds it — a container start to test a
  two-operand string comparison is the wrong cost by an order of magnitude.
- **Redis commands backed by an in-memory map, not stubbed per call.** `create` -> `encode` ->
  `decode` -> `decide` really round-trips, which is what proves `makerId` survives the pipe-delimited
  value into the comparison. A hand-written payload returned from `every { get(...) }` would assume
  that rather than test it.

## The contract, and why the duplicate guard was not simply deleted

`ApprovalStoreContractTest` is abstract; `RedisApprovalStoreTest` and `InMemoryApprovalStoreTest`
bind to it. Five cases: the refusal, that the refusal writes nothing, the distinct-checker control,
that the self-approval guard is checked **before** the status guard, and that a settled approval
cannot be re-decided by a third party.

The `FakeApprovalStore` guard was **extracted, not deleted**. Deleting it is behaviour-neutral today
and harmful tomorrow: `AuthorizeInterceptor` is exactly the component that will grow four-eyes tests,
and one exercising a maker self-decide would then pass against a double that permits what production
forbids. Two statements of a security rule are only safe when both answer to the same test — which
is what the contract class is for.

## Also fixed: a false claim that hid this gap

`openbank-notification-service/.../ApprovalResourceTest.kt` stated the store's rules were
"unit-tested in openbank-libs-domain". They were not — libs-domain has only `ApprovalEntryTest`, for
the unrelated `foureyes` package. Stale prose naming a test that does not exist is invisible to every
gate in this repo, and is plausibly why nobody noticed. Repointed at the new contract test.

## What this still does not cover

Whether `makerId` and the checker's id are formatted identically for the same human in production.
`ApprovalResource.checkerId()` uses `.principal.name` and carries a comment warning that `.subject`
would silently break the comparison — the guard would then compare unequal and pass. This test hands
both sides a literal, so it proves the guard fires when the strings match, never that they ever
match. An HTTP-driven IT would close that half; recorded in the KDoc rather than left implicit.

Also unchanged: the guard compares strings, so one human with two identities still satisfies it
(#3190). That is a mechanism-level limit, not an implementation defect.

## Definition of Done

- [x] Unit tests added — 5 contract cases × 2 implementations.
- [x] Falsified by mutation: production line deleted -> 3 of 4 red, control still green.
- [ ] Integration tests — N/A by design (see above).
- [x] `detekt ktlintCheck test` on `openbank-libs-runtime`.
- [ ] OpenAPI / Flyway / Avro — N/A.

## Reviewer notes

- Two test-scope dependencies added (`quarkus-redis-client`, `mutiny-kotlin`), both already
  `compileOnly` in this module and both already pinned in `verification-metadata.xml` — the same
  pattern as `quarkus-security` and the fault-tolerance API here.
- If you would rather this ran against a container, the objection to answer first is the silent
  `TestAbortedException` skip, not the fidelity of the fake.
- The strongest argument against this shape: it tests a comparison that has nothing to do with Redis,
  in a class whose only reason to be integration-tested is Redis. I think that argues for the
  contract class — which is why there is one — rather than against testing the guard where it
  currently lives.
