### PR TITLE
fix(ci): classify a can-i-deploy REFUSE as NOT_ASKED, not UNKNOWN

### DIFF
--- a/.github/scripts/classify-can-i-deploy-block.sh
+++ b/.github/scripts/classify-can-i-deploy-block.sh
@@ -37,7 +37,12 @@
 # its own, so test-classify-can-i-deploy-block.sh can drive every branch.
 #
 # Usage:
-#   PACT_VERSION_PRESENT=yes|no|absent|unknown classify-can-i-deploy-block.sh <service> < cli-output
+#   PACT_VERSION_PRESENT=yes|no|absent|unknown [EVENT_NAME=<github.event_name>] \
+#     classify-can-i-deploy-block.sh <service> < cli-output
+#
+#   EVENT_NAME — the triggering event, same vocabulary and same default (push) as
+#     resolve-can-i-deploy-selector.sh. Only (no + workflow_dispatch) is treated specially;
+#     see the NOT_ASKED note below.
 #
 #   PACT_VERSION_PRESENT — the caller's probe of
 #     GET <broker>/pacticipants/<svc>/versions/<sha>:
@@ -51,22 +56,78 @@
 #   UNVERIFIED    — a version exists but no verification result yet. Usually the
 #                   counterpart provider lagging by minutes; treated as transient, but
 #                   named separately so it is not mistaken for a passed verification.
+#   NOT_ASKED     — the gate was never asked (#3454). resolve-can-i-deploy-selector.sh
+#                   REFUSEd to pick a selector, so no can-i-deploy verdict exists at all.
+#                   See the NOT_ASKED note below for why this is not PENDING_BUILD.
 #   UNKNOWN       — could not tell. Deliberately distinct from the three above: an
 #                   unclassifiable block must not borrow PENDING_BUILD's "it'll fix
 #                   itself" reassurance.
+#
+# WHY NOT_ASKED IS A CLASS AND NOT `PENDING_BUILD` (issue #3454)
+# The REFUSE branch in auto-deploy.yml recorded a blocked service with NO class, so every
+# refusal printed downstream as "[UNKNOWN] — no classification recorded for this service".
+# Measured on run 30765380309, a fleet workflow_dispatch of e4821ef6: all 54 services
+# refused, all 54 reported UNKNOWN, deployable=[].
+#
+# The tempting fix is to tag it PENDING_BUILD — the observable condition is byte-identical
+# (no published pact version for this sha). It is the wrong label, because PENDING_BUILD
+# does not only describe a state, it PROMISES one: "the 3-hourly reconcile re-drives it
+# automatically". That promise holds on a push, where the sha IS main's head and its
+# services-ci build is genuinely in flight. It does not hold for a dispatch, because
+# services-ci is PATH-SCOPED: on any given commit it builds only the services that commit
+# touched, so for the other ~53 no pact version for that sha will ever exist, no matter how
+# many reconcile ticks pass. Tagging those PENDING_BUILD asserts a self-clearing property
+# that is false — a confident label on a guess, which is the failure this file's header
+# already warns against.
+#
+# It is equally not UNKNOWN. UNKNOWN means "could not tell"; here we can tell exactly, and
+# the remedy is specific and different from every other class: nothing about the CONTRACTS
+# is wrong, the REQUEST is unanswerable. Deploy the sha services-ci actually built for this
+# service (let the push/reconcile lane carry it), or publish a pact version for this sha.
+#
+# WHY ONE CLASS AND NOT TWO. Two sub-cases hide behind one refusal — "dispatched sha is
+# main's head with a build in flight" (will gain a version) and "dispatched sha can never
+# gain one". Splitting them needs evidence this script does not have and cannot get without
+# a network call, and the two sub-cases have the SAME consequences everywhere the class is
+# consumed: neither is co-deploy evidence, neither may be silenced as transient, and
+# re-running the same dispatch fixes neither. A distinction with no distinct consequence,
+# bought with a guess, is exactly what the header forbids.
+#
+# WHY THE EVENT IS AN INPUT HERE TOO. NOT_ASKED must fire on precisely the inputs on which
+# resolve-can-i-deploy-selector.sh emits REFUSE, and nothing structural forces that: they
+# are two files. So both derive their answer from the SAME pair (PACT_VERSION_PRESENT,
+# EVENT_NAME) rather than the workflow hardcoding a class string next to the REFUSE branch,
+# and test-classify-can-i-deploy-block.sh asserts the equivalence over the whole input
+# cross-product. A future edit to either file's condition reddens that test.
+#
 # Always exits 0 — this is a labeller, not a gate.
 set -uo pipefail
 
 SVC="${1:-}"
 if [ -z "$SVC" ]; then
-  echo "usage: PACT_VERSION_PRESENT=yes|no|absent|unknown $0 <service> < cli-output" >&2
+  echo "usage: PACT_VERSION_PRESENT=yes|no|absent|unknown [EVENT_NAME=<event>] $0 <service> < cli-output" >&2
   exit 2
 fi
 
 PRESENT="${PACT_VERSION_PRESENT:-unknown}"
+# Same default as resolve-can-i-deploy-selector.sh: an absent EVENT_NAME behaves as a push,
+# so a caller that forgets to pass it keeps today's labelling instead of inventing NOT_ASKED.
+EVENT="${EVENT_NAME:-push}"
 OUT="$(cat)"
 
 emit() { printf '%s\t%s\n' "$1" "$2"; }
+
+# 0. NOT_ASKED is tested before EVERYTHING, including the regression check, and that is
+#    deliberate. On exactly these inputs resolve-can-i-deploy-selector.sh emits REFUSE, so
+#    can-i-deploy is never invoked and there is no verdict — whatever arrives on stdin (the
+#    caller sends nothing) is not one. Reporting REGRESSION from it would name a
+#    verification failure the gate never observed. Keeping this first also makes the
+#    NOT_ASKED ⇔ REFUSE equivalence hold for ANY stdin, which is what the cross-product
+#    test in test-classify-can-i-deploy-block.sh asserts.
+if [ "$PRESENT" = "no" ] && [ "$EVENT" = "workflow_dispatch" ]; then
+  emit NOT_ASKED "the contract gate was never asked about this commit — a manual dispatch of a sha with no published pact version for ${SVC}, so the selector REFUSEd rather than answer about a different commit (#3318). This is NOT self-clearing: services-ci is path-scoped, so a sha that did not touch ${SVC} never gains a version, and re-running the same dispatch cannot change that. Deploy the sha services-ci built for ${SVC} (the push/reconcile lane), or publish a pact version for this one"
+  exit 0
+fi
 
 # 1. A genuine verification failure is the only class that never self-clears, so it is
 #    tested FIRST — even when the broker probe says "no version for this sha". Those two

--- a/.github/scripts/derive-codeploy-set.py
+++ b/.github/scripts/derive-codeploy-set.py
@@ -62,6 +62,7 @@ Usage:
 Prints, one finding per line, TAB-separated. Two record types:
     CODEPLOY\t<svc> <svc> ...        a mutually-blocking set that must deploy together
     PENDING\t<svc> <svc> ...         blocked only because their builds have not finished
+    UNGATED\t<svc> <svc> ...         no can-i-deploy verdict exists for them at all (#3454)
     EXTERNAL\t<svc>\t<counterpart>   blocked on a service this run cannot move
 
 Always exits 0 — this is a reporter, not a gate.
@@ -105,6 +106,16 @@ PAIR_LINE = ("There is no verified pact", "The verification for the pact between
 # set. Records with no class at all keep today's behaviour, so older captures still parse.
 CODEPLOY_CLASSES = ("UNVERIFIED", "REGRESSION")
 TRANSIENT_CLASSES = ("PENDING_BUILD",)
+
+# NOT_ASKED (#3454) is ineligible for a set by construction — CODEPLOY_CLASSES is an
+# allow-list — but it must not be silently dropped either, and it is NOT transient, so it
+# cannot ride on the PENDING report ("waiting on their own builds, no action") without
+# repeating the false self-clearing promise the class exists to avoid. It gets its own
+# finding: these services have no can-i-deploy verdict at all, so a co-deploy over them
+# would not be a weaker check, it would be NO check. On a fleet dispatch this is the whole
+# run — 54 of 54 services on run 30765380309 — which is exactly the population a
+# CO-DEPLOY recommendation must never be printed for.
+UNGATED_CLASSES = ("NOT_ASKED",)
 
 
 def derive(changed: set[str], stream) -> list[str]:
@@ -173,6 +184,10 @@ def derive(changed: set[str], stream) -> list[str]:
     pending = sorted(s for s in blocked if cls_of.get(s) in TRANSIENT_CLASSES)
     if pending:
         findings.append("PENDING\t" + " ".join(pending))
+
+    ungated = sorted(s for s in blocked if cls_of.get(s) in UNGATED_CLASSES)
+    if ungated:
+        findings.append("UNGATED\t" + " ".join(ungated))
 
     for svc_name, counterpart in sorted(external):
         findings.append(f"EXTERNAL\t{svc_name}\t{counterpart}")

--- a/.github/scripts/test-classify-can-i-deploy-block.sh
+++ b/.github/scripts/test-classify-can-i-deploy-block.sh
@@ -11,16 +11,23 @@
 # case 5 returns PENDING_BUILD and this test goes red. That ordering is precisely the bug
 # that would silence a real contract regression as "still building", so the test that
 # catches it is the point of the file.
+#
+# Cases 8-13 (#3454) are the second load-bearing group. Case 13 is a DRIFT test rather than
+# a classification one: it drives resolve-can-i-deploy-selector.sh over the same input
+# cross-product and asserts NOT_ASKED fires on exactly the inputs where that script REFUSEs.
+# Nothing else forces the two files to agree, and a REFUSE with no matching class is how
+# every refusal came to print as "[UNKNOWN] — no classification recorded".
 set -uo pipefail
 
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 CLASSIFY="${SCRIPT_DIR}/classify-can-i-deploy-block.sh"
+RESOLVE="${SCRIPT_DIR}/resolve-can-i-deploy-selector.sh"
 
 fails=0
 check() {
-  local name="$1" want="$2" present="$3" out="$4"
+  local name="$1" want="$2" present="$3" out="$4" event="${5:-}"
   local got
-  got="$(PACT_VERSION_PRESENT="$present" bash "$CLASSIFY" openbank-demo-service <<< "$out" | cut -f1)"
+  got="$(PACT_VERSION_PRESENT="$present" EVENT_NAME="$event" bash "$CLASSIFY" openbank-demo-service <<< "$out" | cut -f1)"
   if [ "$got" = "$want" ]; then
     echo "  ok   ${name} → ${got}"
   else
@@ -67,6 +74,65 @@ check "version present + unrecognised output" UNKNOWN yes "Computer says no ¯\\
 # Different remedy — a contract, not a retry — so it needs its own label, and UNKNOWN's text
 # ("could not probe the broker") would describe an outage that never happened.
 check "pacticipant absent" NO_CONTRACTS absent "no versions for openbank-demo-service"
+
+# ── issue #3454: the REFUSE record carried no class, so every refusal read as UNKNOWN ────
+# 8. THE POINT OF THIS ADDITION. On (no version + workflow_dispatch) the selector REFUSEs,
+#    so can-i-deploy never runs and there is no verdict. Measured on run 30765380309, a
+#    fleet dispatch of e4821ef6: 54 of 54 services refused and all 54 printed
+#    "[UNKNOWN] — no classification recorded for this service (issue #1420)".
+check "dispatch + no version → NOT_ASKED" NOT_ASKED no "" workflow_dispatch
+
+# 9. THE LABEL THIS MUST NOT BE. PENDING_BUILD promises "the 3-hourly reconcile re-drives it
+#    automatically". services-ci is path-scoped, so a dispatched sha that did not touch this
+#    service NEVER gains a pact version and that promise is false. If someone "simplifies"
+#    NOT_ASKED away into PENDING_BUILD, this is what goes red.
+if [ "$(PACT_VERSION_PRESENT=no EVENT_NAME=workflow_dispatch bash "$CLASSIFY" openbank-demo-service </dev/null | cut -f1)" = "PENDING_BUILD" ]; then
+  echo "  FAIL dispatch must not borrow PENDING_BUILD's self-clearing promise"
+  fails=$((fails + 1))
+else
+  echo "  ok   dispatch is not labelled PENDING_BUILD"
+fi
+
+# 10. REGRESSION GUARD, the direction that would break the fleet. The push path is where
+#     "no version for this commit" really does mean "the build has not finished", and that
+#     is most services on most commits. Widening NOT_ASKED to all events relabels every
+#     ordinary push block and silences the reconcile story. This is case 1 with the event
+#     made explicit.
+check "push + no version → still PENDING_BUILD" PENDING_BUILD no "$NO_VERIFIED_PACT" push
+check "no EVENT_NAME + no version → still PENDING_BUILD" PENDING_BUILD no "$NO_VERIFIED_PACT"
+
+# 11. NOT_ASKED is narrow. A dispatch is only "never asked" when the version is genuinely
+#     missing AND the pacticipant is known; every other probe result keeps its own class, or
+#     the label would spread over blocks the gate DID answer.
+check "dispatch + version present + unverified → UNVERIFIED" UNVERIFIED yes "$NO_VERIFIED_PACT" workflow_dispatch
+check "dispatch + probe inconclusive → UNKNOWN" UNKNOWN unknown "$NO_VERIFIED_PACT" workflow_dispatch
+check "dispatch + pacticipant absent → NO_CONTRACTS" NO_CONTRACTS absent "" workflow_dispatch
+
+# 12. Ordering: NOT_ASKED is checked BEFORE the regression rule, unlike every other class.
+#     On these inputs can-i-deploy was never invoked, so text on stdin is not a verdict and
+#     reporting REGRESSION from it would name a verification failure the gate never observed.
+#     This also makes the equivalence in case 13 hold for ANY stdin, not just empty stdin.
+check "dispatch + no version + regression-looking stdin → still NOT_ASKED" NOT_ASKED no "$VERIFICATION_FAILED" workflow_dispatch
+
+# 13. THE DRIFT TEST. NOT_ASKED must fire on exactly the inputs where the selector REFUSEs —
+#     nothing structural forces that, they are two files. Assert the equivalence over the
+#     whole (probe × event) cross-product, so changing either condition alone goes red.
+SHA_FIXTURE="0e32873f8c52d37e1b6530e5bd5e94275e5cefae"
+for p in yes no absent unknown; do
+  for e in push workflow_dispatch schedule; do
+    sel="$(PACT_VERSION_PRESENT="$p" EVENT_NAME="$e" bash "$RESOLVE" openbank-demo-service "$SHA_FIXTURE" | cut -f1)"
+    cls="$(PACT_VERSION_PRESENT="$p" EVENT_NAME="$e" bash "$CLASSIFY" openbank-demo-service </dev/null | cut -f1)"
+    if [ "$sel" = "REFUSE" ] && [ "$cls" != "NOT_ASKED" ]; then
+      echo "  FAIL (${p},${e}): selector REFUSEd but classifier said ${cls}, not NOT_ASKED"
+      fails=$((fails + 1))
+    elif [ "$sel" != "REFUSE" ] && [ "$cls" = "NOT_ASKED" ]; then
+      echo "  FAIL (${p},${e}): classifier said NOT_ASKED but the selector chose '${sel}' — the gate WAS asked"
+      fails=$((fails + 1))
+    else
+      echo "  ok   (${p},${e}) selector/classifier agree"
+    fi
+  done
+done
 
 # 7. Missing argument is a usage error, not a silent classification.
 if PACT_VERSION_PRESENT=no bash "$CLASSIFY" </dev/null >/dev/null 2>&1; then

--- a/.github/scripts/test-derive-codeploy-set.sh
+++ b/.github/scripts/test-derive-codeploy-set.sh
@@ -154,6 +154,44 @@ There is no verified pact between version abc123 of openbank-fraud-service and t
 ===SERVICE openbank-transaction-service${TAB}PENDING_BUILD
 There is no verified pact between version def456 of openbank-transaction-service and the version of openbank-fraud-service currently deployed to sandbox"
 
+# ── issue #3454: NOT_ASKED, the class where no verdict exists at all ─────────────────────
+# 12. A NOT_ASKED pair references each other exactly like a deadlocked one, and on a fleet
+#     dispatch this is EVERY blocked service (54 of 54 on run 30765380309). Recommending a
+#     co-deploy there would not be a weaker check, it would be no check: can-i-deploy was
+#     never asked about any of them. The set must not be named.
+check "NOT_ASKED pair is not a co-deploy set" \
+  "UNGATED${TAB}openbank-fraud-service openbank-transaction-service" \
+  "openbank-fraud-service openbank-transaction-service" \
+"===SERVICE openbank-fraud-service${TAB}NOT_ASKED
+There is no verified pact between version abc123 of openbank-fraud-service and the version of openbank-transaction-service currently deployed to sandbox
+===SERVICE openbank-transaction-service${TAB}NOT_ASKED
+There is no verified pact between version def456 of openbank-transaction-service and the version of openbank-fraud-service currently deployed to sandbox"
+
+# 13. NOT_ASKED must not ride on the PENDING report either. PENDING prints "waiting on their
+#     own builds, not deadlocked; no action" — the self-clearing promise NOT_ASKED exists to
+#     avoid. If someone folds NOT_ASKED into TRANSIENT_CLASSES, this goes red.
+check "NOT_ASKED reports separately from PENDING_BUILD" \
+  "PENDING${TAB}openbank-fraud-service
+UNGATED${TAB}openbank-transaction-service" \
+  "openbank-fraud-service openbank-transaction-service" \
+"===SERVICE openbank-fraud-service${TAB}PENDING_BUILD
+Computer says no
+===SERVICE openbank-transaction-service${TAB}NOT_ASKED
+Computer says no"
+
+# 14. A durable pair stays a set even when a NOT_ASKED service names one of them — the
+#     addition must not silence the case the script exists for.
+check "NOT_ASKED alongside a durable pair does not suppress the set" \
+  "CODEPLOY${TAB}openbank-fraud-service openbank-transaction-service
+UNGATED${TAB}openbank-swift-service" \
+  "openbank-fraud-service openbank-transaction-service openbank-swift-service" \
+"===SERVICE openbank-fraud-service${TAB}UNVERIFIED
+There is no verified pact between version a of openbank-fraud-service and the version of openbank-transaction-service currently deployed to sandbox
+===SERVICE openbank-transaction-service${TAB}UNVERIFIED
+There is no verified pact between version b of openbank-transaction-service and the version of openbank-fraud-service currently deployed to sandbox
+===SERVICE openbank-swift-service${TAB}NOT_ASKED
+There is no verified pact between version c of openbank-swift-service and the version of openbank-fraud-service currently deployed to sandbox"
+
 if [ "$fails" -gt 0 ]; then
   echo "derive-codeploy-set.py: ${fails} case(s) FAILED"
   exit 1

--- a/.github/workflows/auto-deploy.yml
+++ b/.github/workflows/auto-deploy.yml
@@ -841,13 +841,10 @@ jobs:
           BLOCKS_FILE="$(mktemp)"
 
           # ── #1985: co-deploy mode ───────────────────────────────────────────────────────
-          # A set of services that block EACH OTHER cannot converge one deploy at a time:
-          # each is blocked by the other's not-yet-deployed version. `--to-environment
-          # sandbox` has no answer for that, so the set was being hand-driven past the gate
-          # (#1979, #2057, #2059 — all money-path, one week). This asks the broker the
-          # question the humans were asking by hand: are THESE versions mutually compatible.
-          # It is a gate, not a bypass — a red verdict deploys nothing — but it is a
-          # DIFFERENT question from the per-service one, so it is opt-in on workflow_dispatch
+          # Services that block EACH OTHER cannot converge one deploy at a time; this asks
+          # the broker whether THOSE versions are mutually compatible. Full reasoning in
+          # derive-codeploy-set.py's header. It is a gate, not a bypass — a red verdict
+          # deploys nothing — but a DIFFERENT question, so it is opt-in on workflow_dispatch
           # and never reachable from a push or a scheduled tick.
           if [ "${{ github.event_name }}" = "workflow_dispatch" ] \
              && [ "${{ github.event.inputs.codeploy }}" = "true" ]; then
@@ -904,8 +901,14 @@ jobs:
             # service — aborting the batch is the #846 shape (#3445).
             if [ "${CID_SELECTOR[0]}" = "REFUSE" ]; then
               refuse_why="$(printf '%s' "$sel_line" | cut -f2)"
-              echo "::error::can-i-deploy: ${refuse_why}"
-              printf '===SERVICE %s\n%s\n' "$svc" "$refuse_why" >> "$BLOCKS_FILE"
+              # #3454: classify it too, from the SAME inputs the selector refused on — a
+              # class-less record reads downstream as [UNKNOWN]. Empty stdin: no verdict exists.
+              r_line="$(PACT_VERSION_PRESENT="$vpresent" EVENT_NAME="$GITHUB_EVENT_NAME" \
+                bash .github/scripts/classify-can-i-deploy-block.sh "$svc" </dev/null)"
+              cls="$(cut -f1 <<< "$r_line")"
+              block_class["$svc"]="$cls"; block_reason["$svc"]="$(cut -f2- <<< "$r_line")"
+              echo "::error::can-i-deploy: [${cls}] ${refuse_why}"
+              printf '===SERVICE %s\t%s\n%s\n' "$svc" "$cls" "$refuse_why" >> "$BLOCKS_FILE"
               rc=1  # keep the job red (ADR-0092); only the batch survives
               continue
             fi
@@ -944,15 +947,11 @@ jobs:
                 echo "::warning::can-i-deploy: ${svc} has counterpart(s) not yet recorded in sandbox — treating as deployable (ADR-0092)"
                 deployable_list+=("$svc")
               else
-                # Why is it blocked? "the build has not published its pacts yet" and "a
-                # contract regressed" produce the SAME verdict, and reading them as one is
-                # how a 29-module sweep left 51 of 55 workloads behind with nothing to
-                # distinguish a queue delay from a regression (issue #2549). Probe the
-                # broker for a version of THIS commit, then classify (the classifier is
-                # unit-tested — .github/scripts/test-classify-can-i-deploy-block.sh).
-                # Reuse the probe taken above: a second call could disagree if the version
-                # landed in between, and the label would then explain a block decided on
-                # other evidence.
+                # Why is it blocked? A queue delay and a real regression give the SAME
+                # verdict (#2549) — classify-can-i-deploy-block.sh's header has the full
+                # reasoning and the unit test drives every branch. Reuse the probe taken
+                # above: a second call could disagree and explain a block decided on other
+                # evidence. Keep this comment SHORT (check-workflow-run-step-size.py).
                 cls_line="$(PACT_VERSION_PRESENT="$vpresent" \
                   bash .github/scripts/classify-can-i-deploy-block.sh "$svc" <<< "$cid_out")"
                 cls="$(cut -f1 <<< "$cls_line")"
@@ -1015,11 +1014,9 @@ jobs:
               fi
             done
             # ── #1985: name the SET, not just the members ────────────────────────────────
-            # #1420 names who is blocked and #2549 names what kind of block it is; neither
-            # answers "can this be deployed at all, one at a time?". When two blocked
-            # services name each other, the answer is no — and until now that was worked out
-            # by hand from the broker matrix and then hand-dispatched past the gate. Derive
-            # it instead, and print the exact supported command (unit-tested, no network:
+            # #1420 names who is blocked and #2549 names what kind; neither answers "can
+            # this deploy at all, one at a time?". Derive it instead of working it out by
+            # hand from the broker matrix (unit-tested, no network:
             # .github/scripts/test-derive-codeploy-set.sh).
             mapfile -t CHANGED_LIST < <(echo "$SERVICES" | jq -r '.[]')
             CODEPLOY_OUT="$(python3 .github/scripts/derive-codeploy-set.py "${CHANGED_LIST[@]}" < "$BLOCKS_FILE" || true)"
@@ -1042,6 +1039,10 @@ jobs:
                     echo "::notice::[${a}] waiting on their own main-push build (PENDING_BUILD) — self-clearing, not a deadlock. Do NOT co-deploy (#1985)"
                     echo "- \`${a}\` — waiting on their own builds, not deadlocked; no action" >> "$GITHUB_STEP_SUMMARY"
                     ;;
+                  UNGATED)
+                    echo "::error::[${a}] have NO can-i-deploy verdict at all [NOT_ASKED] — the gate was refused, not answered; a co-deploy over them would be no check, and re-running the same dispatch cannot help (#3454)"
+                    echo "- \`${a}\` — \`NOT_ASKED\`: no verdict exists; deploy the sha services-ci built for them, or publish a pact version for this one" >> "$GITHUB_STEP_SUMMARY"
+                    ;;
                   EXTERNAL)
                     echo "::warning::[${a}] is blocked on ${b}, which is NOT part of this run — a co-deploy cannot help; ${b} has to deploy first (issue #1985)"
                     echo "- \`${a}\` waits on \`${b}\`, outside this run — co-deploy does not apply" >> "$GITHUB_STEP_SUMMARY"
@@ -1054,7 +1055,8 @@ jobs:
               echo "\`PENDING_BUILD\`/\`UNVERIFIED\` clear themselves — the every-3h reconcile tick"
               echo "re-drives them (auto-deploy-reconcile-lag.sh, #2020). \`REGRESSION\` does not:"
               echo "it needs a contract fix, and is reported as an error on every run including"
-              echo "scheduled ticks. \`UNKNOWN\` means the classifier could not tell — read the log."
+              echo "scheduled ticks, and neither does \`NOT_ASKED\` (#3454), which means the gate was"
+              echo "never asked at all. \`UNKNOWN\` means the classifier could not tell — read the log."
             } >> "$GITHUB_STEP_SUMMARY"
             [ "$mp_blocked" = "1" ] && echo "::error::can-i-deploy left one or more MONEY-PATH services behind this run — see the job summary (issue #1420)"
             [ "$regression_blocked" = "1" ] && echo "::error::can-i-deploy: at least one block is a CONTRACT REGRESSION, which no reconcile tick can clear — see the job summary (issue #2549)"


### PR DESCRIPTION
## The defect

`auto-deploy.yml`'s `can-i-deploy` job has **two writers for `BLOCKS_FILE` and they disagree**:

| writer | record |
| --- | --- |
| REFUSE branch (#3318) | `===SERVICE <svc>` — no class |
| normal block branch (#2549) | `===SERVICE <svc>\t<class>` |

So every REFUSE fell through the summary's `${block_class[$svc]:-UNKNOWN}` default and printed
`[UNKNOWN] — no classification recorded for this service (issue #1420)`.

Measured on run **30765380309** (fleet `workflow_dispatch` of `e4821ef6`): **54 of 54** services
refused, all 54 reported UNKNOWN, `deployable=[]`.

## The class design, and why not `PENDING_BUILD`

I chose **(c): one new class, `NOT_ASKED`**, derived from the same inputs the selector refuses on.

`PENDING_BUILD` is the tempting answer because the observable condition is byte-identical — no
published pact version for this sha. It is the wrong label because `PENDING_BUILD` does not only
describe a state, it **promises** one: *"the 3-hourly reconcile re-drives it automatically."* That
holds on a push, where the sha is `main`'s head and its `services-ci` build really is in flight. It
does not hold for a dispatch, because `services-ci` is **path-scoped**: on any commit it builds only
the services that commit touched, so for the other ~53 no version for that sha will ever exist. That
is a self-clearing property asserted on no evidence — a confident label on a guess, which
`classify-can-i-deploy-block.sh`'s own header forbids.

It is equally not `UNKNOWN`. UNKNOWN means "could not tell"; here we can tell exactly, and the
remedy is specific and unlike every other class: nothing is wrong with the **contracts**, the
**request** is unanswerable.

**Why one class and not two (option b).** Two sub-cases hide behind one refusal — "dispatched sha is
main's head with a build in flight" and "dispatched sha can never gain a version". Telling them apart
needs evidence the classifier does not have and cannot get without a network call, and they have the
same consequence everywhere the class is consumed: neither is co-deploy evidence, neither may be
silenced as transient, and re-running the same dispatch fixes neither. A distinction with no distinct
consequence, bought with a guess, is the thing this file exists to avoid.

**Why the classifier and not a hardcoded string in the workflow.** `NOT_ASKED` must fire on exactly
the inputs where `resolve-can-i-deploy-selector.sh` emits `REFUSE`, and nothing structural forces
that — they are two files. Both now answer from the same `(PACT_VERSION_PRESENT, EVENT_NAME)` pair,
and case 13 asserts the equivalence over the whole cross-product, so moving either condition alone
goes red. A hardcoded class next to the REFUSE branch would also be unreachable by any test.

## Diff summary

- `classify-can-i-deploy-block.sh` — new `NOT_ASKED` class on `(no + workflow_dispatch)`, checked
  **before** the regression rule (on those inputs `can-i-deploy` never ran, so stdin is not a
  verdict); `EVENT_NAME` input with the selector's `push` default; header records the reasoning.
- `auto-deploy.yml` — REFUSE branch classifies and records `\t<class>`, populating
  `block_class`/`block_reason`; new `UNGATED` summary case; legend names `NOT_ASKED`. Three prose
  comments condensed into pointers to the script headers that already carry them, to stay under the
  `workflow-run-step-size` limit (18580 → **18872**, limit 19000).
- `derive-codeploy-set.py` — `UNGATED_CLASSES`; NOT_ASKED reported as its own `UNGATED` finding.
- both test harnesses extended.

## Downstream consistency

- `CODEPLOY_CLASSES` is an allow-list, so `NOT_ASKED` is co-deploy-ineligible by construction —
  but it is deliberately **not** added to `TRANSIENT_CLASSES` either: the PENDING report says
  *"waiting on their own builds, no action"*, which is the false promise all over again. Hence a
  separate `UNGATED` finding, so it is neither silently dropped nor mislabelled.
- Verified against `origin/main` that today's REFUSE records produce **no** co-deploy advice (the
  refuse text contains no `PAIR_LINE` marker, so no edges) — the pre-existing silence was accidental,
  not principled. `UNGATED` makes it explicit.
- The `schedule` silencing rule needs no change: REFUSE is reachable only on `workflow_dispatch`.
- `.github/gates/gates.yaml` needs no change — all three unit tests are already registered,
  `mode: enforced`, and run unconditionally.

## Test evidence — what I made fail on purpose

Every new assertion was driven against the exact input it must reject, on a copy of the tree:

| mutation | expected red | observed |
| --- | --- | --- |
| M1 `NOT_ASKED` branch deleted (the "just tag it PENDING_BUILD" simplification) | cases 8, 9, 12, drift | **4 FAIL** |
| M2 `NOT_ASKED` widened to every event | cases 1, 5, 10, drift(no,push)/(no,schedule) | **6 FAIL** |
| M3 `NOT_ASKED` ordered after the regression check | case 12 | **1 FAIL** |
| M4 selector stops emitting `REFUSE` (other direction of the drift test) | case 13 | **1 FAIL** |
| M5 `NOT_ASKED` added to `CODEPLOY_CLASSES` | derive 12, 14 | **2 FAIL** |
| M6 `NOT_ASKED` folded into `TRANSIENT_CLASSES` | derive 12, 13, 14 | **3 FAIL** |
| M7 `UNGATED` finding removed (silent drop) | derive 12, 13, 14 | **3 FAIL** |

Unmutated tree: all three harnesses green.

**End-to-end replay of the real run-30765380309 shape** — the REFUSE block was *extracted from the
workflow YAML by parsing it*, not retyped, and sourced with the real scripts:

```
::error::can-i-deploy: [NOT_ASKED] workflow_dispatch of e4821ef6... which has no published pact version for openbank-sepa-payment ...
UNGATED	openbank-sepa-payment openbank-transaction-service
rc=1
```

**Lint probe validated against a known-positive.** `actionlint`'s shellcheck finding set on the
branch is identical to `origin/main` (1× `SC2086:info`, pre-existing). To prove that probe actually
inspects the step I edited rather than reporting a comfortable nothing, I injected an unquoted
`echo $refuse_why $cls` into a copy: the count went 1 → 3.

---

# Critical self-assessment

### The strongest argument AGAINST `NOT_ASKED`

**It adds a sixth class to a vocabulary whose value is that a human can hold it in their head, and it
does so for a condition that is arguably not a *block* at all.** Every other class answers "why did
`can-i-deploy` say no?". `NOT_ASKED` answers a different question — "why is there no answer?" — and
smuggling it into the same enum means every consumer must now handle a value that is not a verdict.
`derive-codeploy-set.py` already shows the cost: it needed a third bucket. A defensible alternative
is that a refusal is not a classification problem at all and should never have entered `BLOCKS_FILE`,
with the workflow reporting refusals as their own list. I rejected that because it *duplicates* the
left-behind reporting path (#1420) rather than reusing it, and two reporting paths drift — but it is
a real trade, and I bought vocabulary growth to avoid it.

Second, weaker but honest: `NOT_ASKED` **conflates the two sub-cases on purpose**. If someone
dispatches `main`'s head 20 seconds after a merge, the label tells them "not self-clearing, deploy a
different sha", which is *pessimistic* — that one would have cleared. I accept that because the
optimistic error (PENDING_BUILD) is silent and the pessimistic one is not.

### Behaviour by event

- **`push`** — completely unchanged. The selector never emits `REFUSE` on a push, `EVENT_NAME=push`
  never reaches the new branch, and `PENDING_BUILD` still fires for a 404 version. Cases 10 and the
  drift test are the guards. This is the path that matters most: refusing here would block most of
  the fleet on most commits.
- **`schedule`** (the 3-hourly reconcile) — also unchanged, and structurally so: `REFUSE` is gated on
  `workflow_dispatch`, so `NOT_ASKED` cannot occur. The scheduled-tick silencing rule (fail only on
  money-path or REGRESSION) is untouched and does not need a `NOT_ASKED` arm.
- **`workflow_dispatch`** — the only path that changes. `rc`, `deployable`, `blocked` and the exit
  are all identical; the run stays red exactly as before. What changes is the label, the summary
  line, and one new `UNGATED` annotation.

### Does this make any money-path service easier to deploy?

**No — and specifically it makes one thing harder in the direction that matters.** Nothing in the
diff moves a service from `blocked` to `deployable`, and `rc` is set in the same places. The one
directional change is *away* from permissiveness: `NOT_ASKED` is excluded from `CODEPLOY_CLASSES`, so
a fleet dispatch can no longer contribute members to a co-deploy set. On main those 54 records
happened to produce no set anyway (no `PAIR_LINE` in the refuse text) — so the practical delta is
zero, but the *guarantee* is new: the accidental silence is now an explicit exclusion that a test
holds in place (M5). Given a co-deploy is a weaker check and 7 of the 8 services in the #3501
incident were money-path, converting an accident into an invariant is the point.

### What I did NOT verify

- **Nothing ran in CI or against a real broker.** All evidence is local, from unit tests and an
  extracted-fragment replay. The `curl`/`pact-broker` CLI paths are untouched by this diff, but I did
  not observe a live `workflow_dispatch` produce a `NOT_ASKED` annotation.
- **bash 5 semantics of the two map assignments.** macOS ships bash 3.2 (no `declare -A`), so the
  replay degraded `block_class["$svc"]` to index 0. I verified the strings, the tab-separated record
  and the derive output, not the map itself. Mitigation: the line is character-identical in form to
  the existing normal-block branch that already works in CI.
- **The claim that `services-ci` never builds an untouched service for a given sha.** I took this
  from `resolve-can-i-deploy-selector.sh`'s header (#3318/#3306) and the observed 54/54 refusal
  rather than re-deriving it from the path filters. It is the load-bearing premise for rejecting
  `PENDING_BUILD`; if it were false, `PENDING_BUILD` would be the right label.
- **`yamllint` was set-diffed** (base 584 `line-length` → branch 578, all other rule counts
  identical), but I did not validate that probe against a known-positive the way I did the
  `actionlint` one, so "no new findings" there rests on an unexercised checker.

Refs #3454, #3501
